### PR TITLE
[AAASM-26] 🔧 (aa-core): Set up no_std build config and feature flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,3 +135,26 @@ jobs:
         run: pnpm type-check
       - name: Lint
         run: pnpm lint
+
+  no-std:
+    name: no_std targets
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - target: wasm32-unknown-unknown
+          - target: thumbv7em-none-eabihf
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Build aa-core (no_std + alloc)
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          cargo build -p aa-core \
+            --target "$TARGET" \
+            --no-default-features \
+            --features alloc

--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -10,5 +10,11 @@ description = "Pure domain logic for Agent Assembly — no_std compatible"
 cfg-if = "1"
 serde  = { version = "1", default-features = false, features = ["derive"], optional = true }
 
+[features]
+default = ["std"]
+std     = []
+alloc   = []
+serde   = ["dep:serde"]
+
 [lints]
 workspace = true

--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 description = "Pure domain logic for Agent Assembly — no_std compatible"
 
 [dependencies]
+cfg-if = "1"
 
 [lints]
 workspace = true

--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -8,6 +8,7 @@ description = "Pure domain logic for Agent Assembly — no_std compatible"
 
 [dependencies]
 cfg-if = "1"
+serde  = { version = "1", default-features = false, features = ["derive"], optional = true }
 
 [lints]
 workspace = true

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -20,3 +20,5 @@ cfg_if::cfg_if! {
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
+pub mod time;

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -5,3 +5,9 @@
 //! It has no runtime or I/O dependencies.
 
 #![cfg_attr(not(feature = "std"), no_std)]
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "alloc")] {
+        extern crate alloc;
+    }
+}

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -3,6 +3,12 @@
 //! This crate is `no_std` compatible and contains the foundational types,
 //! traits, and pure logic shared across all other crates in the workspace.
 //! It has no runtime or I/O dependencies.
+//!
+//! # Feature Flags
+//!
+//! - `std` (default): enables `std`-dependent convenience impls (e.g. `From<SystemTime>`)
+//! - `alloc`: enables heap types (`String`, `Vec`, `BTreeMap`) in `no_std` environments
+//! - `serde`: enables `Serialize`/`Deserialize` derives on all core types (added in AAASM-22–25)
 
 #![cfg_attr(not(feature = "std"), no_std)]
 

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -3,3 +3,5 @@
 //! This crate is `no_std` compatible and contains the foundational types,
 //! traits, and pure logic shared across all other crates in the workspace.
 //! It has no runtime or I/O dependencies.
+
+#![cfg_attr(not(feature = "std"), no_std)]

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -18,7 +18,4 @@ cfg_if::cfg_if! {
     }
 }
 
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
 pub mod time;

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -11,3 +11,6 @@ cfg_if::cfg_if! {
         extern crate alloc;
     }
 }
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};

--- a/aa-core/src/time.rs
+++ b/aa-core/src/time.rs
@@ -25,3 +25,14 @@ impl Timestamp {
         self.0
     }
 }
+
+#[cfg(feature = "std")]
+impl From<std::time::SystemTime> for Timestamp {
+    fn from(t: std::time::SystemTime) -> Self {
+        let nanos = t
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time before Unix epoch")
+            .as_nanos() as u64;
+        Self(nanos)
+    }
+}

--- a/aa-core/src/time.rs
+++ b/aa-core/src/time.rs
@@ -1,0 +1,27 @@
+//! Timestamp abstraction compatible with `no_std` environments.
+//!
+//! In `no_std` mode the caller is responsible for supplying the nanosecond
+//! value. In `std` mode a [`From<SystemTime>`] convenience impl is available.
+
+/// Nanoseconds since the Unix epoch.
+///
+/// In `no_std` environments use [`Timestamp::from_nanos`] to construct a value
+/// directly. In `std` environments the [`From<std::time::SystemTime>`] impl
+/// can be used as a convenience.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Timestamp(u64);
+
+impl Timestamp {
+    /// Construct a [`Timestamp`] from raw nanoseconds since the Unix epoch.
+    #[inline]
+    pub const fn from_nanos(nanos: u64) -> Self {
+        Self(nanos)
+    }
+
+    /// Return the raw nanosecond value.
+    #[inline]
+    pub const fn as_nanos(&self) -> u64 {
+        self.0
+    }
+}

--- a/aa-core/src/time.rs
+++ b/aa-core/src/time.rs
@@ -36,3 +36,21 @@ impl From<std::time::SystemTime> for Timestamp {
         Self(nanos)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_nanos() {
+        let ts = Timestamp::from_nanos(1_000_000_000);
+        assert_eq!(ts.as_nanos(), 1_000_000_000);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn from_system_time_at_epoch_is_zero() {
+        let ts = Timestamp::from(std::time::SystemTime::UNIX_EPOCH);
+        assert_eq!(ts.as_nanos(), 0);
+    }
+}

--- a/docs/superpowers/specs/2026-04-27-aaasm-26-no-std-core-build-config-design.md
+++ b/docs/superpowers/specs/2026-04-27-aaasm-26-no-std-core-build-config-design.md
@@ -1,0 +1,191 @@
+# AAASM-26: `no_std` Core Build Config for `aa-core` — Design Spec
+
+**Date:** 2026-04-27
+**Ticket:** [AAASM-26](https://lightning-dust-mite.atlassian.net/browse/AAASM-26)
+**Epic:** [AAASM-2](https://lightning-dust-mite.atlassian.net/browse/AAASM-2) — Runtime Core Foundations
+**Sprint:** AAA Sprint 1 (ends 2026-04-30)
+**Branch:** `v0.0.1/AAASM-26/no_std_core_build_config`
+
+---
+
+## Purpose
+
+Establish the `no_std` build configuration, feature flags, and conditional compilation
+strategy for `aa-core` so all core data structures work in both `std` and `no_std` + `alloc`
+environments. This is the foundation that AAASM-22–25 build on.
+
+---
+
+## Scope
+
+### In scope
+- `aa-core/Cargo.toml` — feature flags + dependencies
+- `aa-core/src/lib.rs` — `no_std` gate, `cfg_if!` setup, conditional imports, module doc
+- `aa-core/src/time.rs` — new file: `Timestamp` type (the only concrete type in this ticket)
+- `.github/workflows/ci.yml` — new `no-std` matrix job
+
+### Out of scope
+- No domain types (AgentContext, PolicyEvaluator, AuditEntry — AAASM-22–25)
+- No changes to any other workspace crate
+- No `dashboard/` or tooling changes
+
+---
+
+## Design Decisions
+
+### Conditional compilation strategy: `cfg_if!` macro
+
+Three options were evaluated:
+
+| Option | Description | Decision |
+|--------|-------------|----------|
+| **A — `cfg_if!` macro** | Use `cfg_if` crate for all conditional blocks | **Selected** |
+| B — Raw `#[cfg(...)]` | Bare attribute syntax, no extra dep | Rejected — verbose for compound conditions, not ticket-specified |
+| C — `compat` re-export module | `src/compat.rs` re-exports the right types | Rejected — premature abstraction, no types exist yet |
+
+**Rationale:** `cfg_if!` is the most readable for feature-combo logic as the codebase grows.
+It is explicitly called for in the ticket spec. `cfg-if` has ~500M downloads and is a
+de-facto standard in the `no_std` ecosystem.
+
+### `serde` feature scope
+
+Only the `Cargo.toml` declaration is added here (Option A from ticket comment). No derives
+or prelude re-exports. This pins the version and establishes the feature name so AAASM-22–25
+never need to touch `Cargo.toml`. Individual type tickets add `#[cfg_attr(feature = "serde", ...)]`.
+
+---
+
+## File Changes
+
+### `aa-core/Cargo.toml`
+
+```toml
+[dependencies]
+cfg-if = "1"
+serde  = { version = "1", default-features = false, features = ["derive"], optional = true }
+
+[features]
+default = ["std"]
+std     = []
+alloc   = []
+serde   = ["dep:serde"]
+```
+
+- `default = ["std"]` — consumers get `std` unless they opt out
+- `std` and `alloc` are independent, non-exclusive flags
+- `serde = ["dep:serde"]` — Cargo's `dep:` syntax avoids feature/dependency name conflict
+
+### `aa-core/src/lib.rs`
+
+```rust
+//! Core domain logic for Agent Assembly.
+//!
+//! # Feature Flags
+//!
+//! - `std` (default): enables `std`-dependent convenience impls (e.g. `From<SystemTime>`)
+//! - `alloc`: enables heap types (`String`, `Vec`, `BTreeMap`) in `no_std` environments
+//! - `serde`: enables `Serialize`/`Deserialize` derives on all core types (added in AAASM-22–25)
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "alloc")] {
+        extern crate alloc;
+    }
+}
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+pub mod time;
+```
+
+- `#![cfg_attr(...)]` — crate stays `std` in default builds, silently goes `no_std` when `std` absent
+- `cfg_if!` block — establishes the pattern all future type modules follow
+
+### `aa-core/src/time.rs` (new file)
+
+```rust
+/// Nanoseconds since the Unix epoch.
+///
+/// - no_std: caller supplies the value via `Timestamp::from_nanos`
+/// - std: use the `From<SystemTime>` convenience impl
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Timestamp(u64);   // inner field private — API-stable
+
+impl Timestamp {
+    pub const fn from_nanos(nanos: u64) -> Self { ... }
+    pub const fn as_nanos(&self) -> u64 { ... }
+}
+
+#[cfg(feature = "std")]
+impl From<std::time::SystemTime> for Timestamp { ... }
+```
+
+- Inner `u64` is private — `from_nanos`/`as_nanos` are the stable API surface
+- `From<SystemTime>` is `#[cfg(feature = "std")]` — pattern for all std-only impls
+- `cfg_attr` uses fully-qualified `serde::Serialize` — no conditional `use` needed per module
+- Tests: one no_std-compatible (round-trip), one `#[cfg(feature = "std")]` (epoch = 0)
+
+### `.github/workflows/ci.yml`
+
+New `no-std` job with 2-target matrix:
+
+```yaml
+no-std:
+  strategy:
+    matrix:
+      include:
+        - target: wasm32-unknown-unknown
+        - target: thumbv7em-none-eabihf
+  # builds aa-core only with --no-default-features --features alloc
+```
+
+- Only `aa-core` built — no other crate is `no_std` compatible yet
+- No `protobuf-compiler` needed — `aa-core` has no proto dependency
+
+---
+
+## Commit Plan (11 commits)
+
+| # | Message | Key change |
+|---|---------|------------|
+| 1 | `🔧 (aa-core): Add cfg-if dependency` | Add `cfg-if = "1"` to `[dependencies]` |
+| 2 | `🔧 (aa-core): Add serde as optional dependency` | Add serde `optional = true, default-features = false` |
+| 3 | `🔧 (aa-core): Add std, alloc and serde feature flags` | Add full `[features]` section |
+| 4 | `✨ (aa-core): Add no_std conditional crate attribute` | `#![cfg_attr(not(feature = "std"), no_std)]` |
+| 5 | `✨ (aa-core): Add cfg_if block for conditional alloc extern` | `cfg_if!` block gating `extern crate alloc` |
+| 6 | `✨ (aa-core): Add conditional serde import` | `#[cfg(feature = "serde")] use serde::{...}` |
+| 7 | `📝 (aa-core): Document feature flags in crate-level doc comment` | `# Feature Flags` section in module doc |
+| 8 | `✨ (aa-core/time): Add Timestamp struct with constructor methods` | New `src/time.rs` + `pub mod time` in lib.rs |
+| 9 | `✨ (aa-core/time): Add From<SystemTime> impl under std feature` | `#[cfg(feature = "std")] impl From<SystemTime>` |
+| 10 | `✅ (aa-core/time): Add unit tests for Timestamp` | Round-trip test + std From test |
+| 11 | `🔧 (ci): Add no_std CI matrix job for wasm32 and thumbv7em` | New CI job, 2-target matrix |
+
+---
+
+## Acceptance Criteria (from ticket)
+
+- [ ] `cargo build --target wasm32-unknown-unknown --no-default-features --features alloc` succeeds
+- [ ] All core types available in `no_std` + `alloc` configuration
+- [ ] `std` feature adds convenience impls (`From<SystemTime>`) but is not required
+- [ ] CI matrix includes at least one `no_std` target
+- [ ] Zero use of `std::` outside `#[cfg(feature = "std")]` blocks
+
+---
+
+## Pattern for AAASM-22–25
+
+Each domain type ticket follows this template:
+
+```rust
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AgentContext { ... }
+
+#[cfg(feature = "std")]
+impl SomeStdTrait for AgentContext { ... }
+```
+
+No future domain ticket needs to touch `Cargo.toml` — all feature wiring is done here.


### PR DESCRIPTION
## Description

Establishes the `no_std` build configuration, feature flags, and conditional compilation strategy for `aa-core`. This is the foundational ticket (F5) of Epic AAASM-2 — all subsequent type tickets (AAASM-22–25) build on top of this.

**What changed:**
- `aa-core/Cargo.toml`: added `cfg-if` dependency, optional `serde` dependency, and `[features]` section (`default = ["std"]`, `std`, `alloc`, `serde`)
- `aa-core/src/lib.rs`: added `#![cfg_attr(not(feature = "std"), no_std)]`, `cfg_if!` block for conditional `alloc` extern, feature flag doc section
- `aa-core/src/time.rs` (new): `Timestamp(u64)` newtype with `from_nanos`/`as_nanos` const methods, `#[cfg(feature = "std")] From<SystemTime>` impl, and unit tests
- `.github/workflows/ci.yml`: new `no-std` matrix job building `aa-core` for `wasm32-unknown-unknown` and `thumbv7em-none-eabihf`

## Type of Change

- [x] ✨ New feature
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [ ] No
- [x] Yes (describe below)

N/A — `aa-core` had no public API before this PR.

## Related Issues

- Related Jira ticket: AAASM-26
- Parent Epic: AAASM-2

## Testing

- [x] Unit tests added: `time::tests::round_trips_nanos` (no_std-compatible), `time::tests::from_system_time_at_epoch_is_zero` (std-only)
- [x] Manual: `cargo build -p aa-core` (std), `cargo build -p aa-core --no-default-features --features alloc` (no_std+alloc)
- [x] `cargo clippy -p aa-core --all-features -- -D warnings` clean
- [x] `cargo fmt -p aa-core -- --check` clean

## Pattern established for AAASM-22–25

Future domain type tickets follow this template — no `Cargo.toml` changes needed:
```rust
#[derive(Debug, Clone, PartialEq)]
#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
pub struct AgentContext { ... }

#[cfg(feature = "std")]
impl SomeStdTrait for AgentContext { ... }
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated (crate-level `# Feature Flags` doc section)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention