### PR TITLE
[AAASM-22] ✨ (aa-core): Add AgentContext struct with identity newtypes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,11 @@ dependencies = [
 [[package]]
 name = "aa-core"
 version = "0.0.1"
+dependencies = [
+ "cfg-if",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "aa-ebpf"

--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -12,7 +12,7 @@ serde  = { version = "1", default-features = false, features = ["derive", "alloc
 
 [features]
 default = ["std"]
-std     = []
+std     = ["alloc"]
 alloc   = []
 serde   = ["dep:serde"]
 

--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -8,7 +8,7 @@ description = "Pure domain logic for Agent Assembly — no_std compatible"
 
 [dependencies]
 cfg-if = "1"
-serde  = { version = "1", default-features = false, features = ["derive"], optional = true }
+serde  = { version = "1", default-features = false, features = ["derive", "alloc"], optional = true }
 
 [features]
 default = ["std"]

--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -16,5 +16,8 @@ std     = []
 alloc   = []
 serde   = ["dep:serde"]
 
+[dev-dependencies]
+serde_json = "1"
+
 [lints]
 workspace = true

--- a/aa-core/src/agent.rs
+++ b/aa-core/src/agent.rs
@@ -1,0 +1,30 @@
+#[cfg(feature = "alloc")]
+use alloc::{collections::BTreeMap, string::String};
+
+use crate::{
+    identity::{AgentId, SessionId},
+    time::Timestamp,
+};
+
+/// Identity carrier for an agent execution.
+///
+/// `AgentContext` flows through every governance event in the system.
+/// It captures the stable agent identity, per-session identity, process ID,
+/// start time, and any additional runtime metadata.
+///
+/// Requires the `alloc` feature.
+#[cfg(feature = "alloc")]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AgentContext {
+    /// Stable identifier for the agent (UUID v4 bytes).
+    pub agent_id: AgentId,
+    /// Per-execution session identifier (UUID v4 bytes).
+    pub session_id: SessionId,
+    /// OS process ID of the agent process.
+    pub pid: u32,
+    /// Nanoseconds since the Unix epoch when this context was created.
+    pub started_at: Timestamp,
+    /// Extensible key-value metadata attached to this execution context.
+    pub metadata: BTreeMap<&'static str, String>,
+}

--- a/aa-core/src/agent.rs
+++ b/aa-core/src/agent.rs
@@ -26,7 +26,10 @@ pub struct AgentContext {
     /// Nanoseconds since the Unix epoch when this context was created.
     pub started_at: Timestamp,
     /// Extensible key-value metadata attached to this execution context.
-    pub metadata: BTreeMap<&'static str, String>,
+    ///
+    /// Keys are owned `String` so the map is serde-compatible and accepts
+    /// both string-literal keys and computed keys at runtime.
+    pub metadata: BTreeMap<String, String>,
 }
 
 #[cfg(all(feature = "alloc", feature = "std"))]

--- a/aa-core/src/agent.rs
+++ b/aa-core/src/agent.rs
@@ -44,3 +44,64 @@ impl AgentContext {
         }
     }
 }
+
+#[cfg(all(test, feature = "alloc"))]
+mod tests {
+    use super::*;
+
+    const AGENT_BYTES: [u8; 16] = [1; 16];
+    const SESSION_BYTES: [u8; 16] = [2; 16];
+
+    fn make_context() -> AgentContext {
+        AgentContext {
+            agent_id: AgentId::from_bytes(AGENT_BYTES),
+            session_id: SessionId::from_bytes(SESSION_BYTES),
+            pid: 42,
+            started_at: Timestamp::from_nanos(1_000_000),
+            metadata: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn field_access() {
+        let ctx = make_context();
+        assert_eq!(ctx.agent_id.as_bytes(), &AGENT_BYTES);
+        assert_eq!(ctx.session_id.as_bytes(), &SESSION_BYTES);
+        assert_eq!(ctx.pid, 42);
+        assert_eq!(ctx.started_at.as_nanos(), 1_000_000);
+        assert!(ctx.metadata.is_empty());
+    }
+
+    #[test]
+    fn clone_equals_original() {
+        let ctx = make_context();
+        assert_eq!(ctx.clone(), ctx);
+    }
+
+    #[test]
+    fn equality() {
+        let a = make_context();
+        let b = make_context();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn inequality_on_different_pid() {
+        let a = make_context();
+        let mut b = make_context();
+        b.pid = 99;
+        assert_ne!(a, b);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn now_constructor_sets_nonzero_timestamp() {
+        let ctx = AgentContext::now(
+            AgentId::from_bytes(AGENT_BYTES),
+            SessionId::from_bytes(SESSION_BYTES),
+            std::process::id(),
+        );
+        assert!(ctx.started_at.as_nanos() > 0);
+        assert!(ctx.metadata.is_empty());
+    }
+}

--- a/aa-core/src/agent.rs
+++ b/aa-core/src/agent.rs
@@ -28,3 +28,19 @@ pub struct AgentContext {
     /// Extensible key-value metadata attached to this execution context.
     pub metadata: BTreeMap<&'static str, String>,
 }
+
+#[cfg(all(feature = "alloc", feature = "std"))]
+impl AgentContext {
+    /// Construct an [`AgentContext`] stamped at the current wall-clock time.
+    ///
+    /// `metadata` is initialised empty; insert entries after construction.
+    pub fn now(agent_id: AgentId, session_id: SessionId, pid: u32) -> Self {
+        Self {
+            started_at: Timestamp::from(std::time::SystemTime::now()),
+            agent_id,
+            session_id,
+            pid,
+            metadata: BTreeMap::new(),
+        }
+    }
+}

--- a/aa-core/src/agent.rs
+++ b/aa-core/src/agent.rs
@@ -104,4 +104,13 @@ mod tests {
         assert!(ctx.started_at.as_nanos() > 0);
         assert!(ctx.metadata.is_empty());
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_round_trip() {
+        let original = make_context();
+        let json = serde_json::to_string(&original).expect("serialize");
+        let restored: AgentContext = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(original, restored);
+    }
 }

--- a/aa-core/src/agent.rs
+++ b/aa-core/src/agent.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "alloc")]
 use alloc::{collections::BTreeMap, string::String};
 
+#[cfg(feature = "alloc")]
 use crate::{
     identity::{AgentId, SessionId},
     time::Timestamp,

--- a/aa-core/src/identity.rs
+++ b/aa-core/src/identity.rs
@@ -18,3 +18,27 @@ impl AgentId {
         &self.0
     }
 }
+
+/// Per-execution session identifier — UUID v4 encoded as raw bytes.
+///
+/// A new [`SessionId`] is generated for each agent execution. It ties together
+/// all governance events within a single run.
+///
+/// The inner `[u8; 16]` is private. Use [`SessionId::from_bytes`] to construct
+/// and [`SessionId::as_bytes`] to inspect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SessionId([u8; 16]);
+
+impl SessionId {
+    /// Construct a [`SessionId`] from raw UUID bytes.
+    #[inline]
+    pub const fn from_bytes(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+
+    /// Return the raw UUID bytes.
+    #[inline]
+    pub const fn as_bytes(&self) -> &[u8; 16] {
+        &self.0
+    }
+}

--- a/aa-core/src/identity.rs
+++ b/aa-core/src/identity.rs
@@ -3,6 +3,7 @@
 /// The inner `[u8; 16]` is private. Use [`AgentId::from_bytes`] to construct
 /// and [`AgentId::as_bytes`] to inspect.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct AgentId([u8; 16]);
 
 impl AgentId {
@@ -27,6 +28,7 @@ impl AgentId {
 /// The inner `[u8; 16]` is private. Use [`SessionId::from_bytes`] to construct
 /// and [`SessionId::as_bytes`] to inspect.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SessionId([u8; 16]);
 
 impl SessionId {

--- a/aa-core/src/identity.rs
+++ b/aa-core/src/identity.rs
@@ -44,3 +44,58 @@ impl SessionId {
         &self.0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BYTES: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+
+    #[test]
+    fn agent_id_round_trip() {
+        let id = AgentId::from_bytes(BYTES);
+        assert_eq!(id.as_bytes(), &BYTES);
+    }
+
+    #[test]
+    fn session_id_round_trip() {
+        let id = SessionId::from_bytes(BYTES);
+        assert_eq!(id.as_bytes(), &BYTES);
+    }
+
+    #[test]
+    fn agent_id_equality() {
+        let a = AgentId::from_bytes(BYTES);
+        let b = AgentId::from_bytes(BYTES);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn session_id_equality() {
+        let a = SessionId::from_bytes(BYTES);
+        let b = SessionId::from_bytes(BYTES);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn agent_id_copy_semantics() {
+        let a = AgentId::from_bytes(BYTES);
+        let b = a; // Copy, not move
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn session_id_copy_semantics() {
+        let a = SessionId::from_bytes(BYTES);
+        let b = a; // Copy, not move
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn agent_id_and_session_id_are_distinct_types() {
+        // Compile-time check: AgentId and SessionId are different types.
+        // If they were the same type, the following would be ambiguous or fail.
+        let _agent: AgentId = AgentId::from_bytes(BYTES);
+        let _session: SessionId = SessionId::from_bytes(BYTES);
+    }
+}

--- a/aa-core/src/identity.rs
+++ b/aa-core/src/identity.rs
@@ -1,0 +1,20 @@
+/// Stable identifier for an agent — UUID v4 encoded as raw bytes.
+///
+/// The inner `[u8; 16]` is private. Use [`AgentId::from_bytes`] to construct
+/// and [`AgentId::as_bytes`] to inspect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AgentId([u8; 16]);
+
+impl AgentId {
+    /// Construct an [`AgentId`] from raw UUID bytes.
+    #[inline]
+    pub const fn from_bytes(bytes: [u8; 16]) -> Self {
+        Self(bytes)
+    }
+
+    /// Return the raw UUID bytes.
+    #[inline]
+    pub const fn as_bytes(&self) -> &[u8; 16] {
+        &self.0
+    }
+}

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -19,3 +19,6 @@ cfg_if::cfg_if! {
 }
 
 pub mod time;
+pub mod identity;
+
+pub use identity::{AgentId, SessionId};

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -18,9 +18,9 @@ cfg_if::cfg_if! {
     }
 }
 
-pub mod time;
-pub mod identity;
 pub mod agent;
+pub mod identity;
+pub mod time;
 
 pub use identity::{AgentId, SessionId};
 

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -20,5 +20,9 @@ cfg_if::cfg_if! {
 
 pub mod time;
 pub mod identity;
+pub mod agent;
 
 pub use identity::{AgentId, SessionId};
+
+#[cfg(feature = "alloc")]
+pub use agent::AgentContext;

--- a/docs/superpowers/specs/2026-04-27-aaasm-22-agent-context-struct-design.md
+++ b/docs/superpowers/specs/2026-04-27-aaasm-22-agent-context-struct-design.md
@@ -1,0 +1,200 @@
+# AAASM-22: `AgentContext` Struct — Design Spec
+
+**Date:** 2026-04-27
+**Ticket:** [AAASM-22](https://lightning-dust-mite.atlassian.net/browse/AAASM-22)
+**Epic:** [AAASM-2](https://lightning-dust-mite.atlassian.net/browse/AAASM-2) — Runtime Core Foundations
+**Sprint:** AAA Sprint 1 (ends 2026-04-30)
+**Branch:** `v0.0.1/AAASM-22/feat/agent_context_struct`
+
+---
+
+## Purpose
+
+Implement `AgentContext` — the core identity carrier that flows through every governance event
+in the agent-assembly system. Alongside it, define the `AgentId` and `SessionId` newtype
+wrappers that will be referenced by all future domain types (AuditEntry, PolicyEvaluator, etc.).
+
+---
+
+## Scope
+
+### In scope
+- `aa-core/Cargo.toml` — add `serde_json` dev-dependency
+- `aa-core/src/identity.rs` — new file: `AgentId` and `SessionId` newtypes
+- `aa-core/src/agent.rs` — new file: `AgentContext` struct
+- `aa-core/src/lib.rs` — module declarations and re-exports
+
+### Out of scope
+- No changes to CI, other workspace crates, or tooling
+- No `Timestamp::now()` method — `AgentContext::now()` uses `Timestamp::from(SystemTime::now())`
+
+---
+
+## Design Decisions
+
+### Module structure: split identity primitives from context (Approach B)
+
+Two options were evaluated:
+
+| Option | Description | Decision |
+|--------|-------------|----------|
+| **A — Single `src/agent.rs`** | All three types co-located in one file | Rejected |
+| **B — `src/identity.rs` + `src/agent.rs`** | Identity newtypes separate from context struct | **Selected** |
+
+**Rationale:** `AgentId` and `SessionId` are stack-only `[u8; 16]` newtypes with no `alloc`
+requirement. They will be referenced by every future domain type (AuditEntry, PolicyEvaluator,
+etc.). Separating them ensures those future types can import identifiers without pulling in
+`AgentContext`'s `alloc` dependency. Import paths are semantically honest:
+`use crate::identity::AgentId` does not imply "I need agent context."
+
+### `started_at` type: `crate::time::Timestamp`
+
+The `started_at` field uses `crate::time::Timestamp` (established in AAASM-26), not raw `u64`.
+Rationale: type safety (prevents silent unit mismatches), design validation of AAASM-26's
+abstraction, and consistency across all future time fields in the codebase. Zero runtime cost —
+`Timestamp` is a `#[repr(transparent)]`-equivalent newtype over `u64`.
+
+### `AgentContext` alloc gating: entire struct gated on `#[cfg(feature = "alloc")]`
+
+`AgentContext` requires `alloc` for `BTreeMap<&'static str, String>` (metadata). The correct
+approach is to gate the entire type, not just the metadata field, because:
+- There is no real consumer of `AgentContext` on a heap-free target
+- Pure `no_std` without `alloc` still gets `Timestamp`, error enums, and other heap-free primitives
+- The `no_std` CI target (`thumbv7em`) verifies build hygiene, not MCU deployability
+
+---
+
+## File Changes
+
+### `aa-core/Cargo.toml`
+
+```toml
+[dev-dependencies]
+serde_json = "1"
+```
+
+### `aa-core/src/identity.rs` (new file)
+
+```rust
+/// Stable identifier for an agent — UUID v4 as raw bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AgentId([u8; 16]);
+
+/// Per-execution session identifier — UUID v4 as raw bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct SessionId([u8; 16]);
+
+impl AgentId {
+    pub const fn from_bytes(bytes: [u8; 16]) -> Self { Self(bytes) }
+    pub const fn as_bytes(&self) -> &[u8; 16] { &self.0 }
+}
+
+impl SessionId {
+    pub const fn from_bytes(bytes: [u8; 16]) -> Self { Self(bytes) }
+    pub const fn as_bytes(&self) -> &[u8; 16] { &self.0 }
+}
+```
+
+- Both types are stack-only — no `alloc` gate needed
+- `Copy` is correct: `[u8; 16]` is small and cheaply duplicable
+- Inner field is private — `from_bytes`/`as_bytes` are the stable API surface
+
+### `aa-core/src/agent.rs` (new file)
+
+```rust
+#[cfg(feature = "alloc")]
+use alloc::{collections::BTreeMap, string::String};
+use crate::{identity::{AgentId, SessionId}, time::Timestamp};
+
+#[cfg(feature = "alloc")]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AgentContext {
+    /// Stable identifier for the agent (UUID v4 bytes).
+    pub agent_id:   AgentId,
+    /// Per-execution session identifier (UUID v4 bytes).
+    pub session_id: SessionId,
+    /// OS process ID of the agent process.
+    pub pid:        u32,
+    /// Nanoseconds since Unix epoch when this context was created.
+    pub started_at: Timestamp,
+    /// Extensible key-value metadata.
+    pub metadata:   BTreeMap<&'static str, String>,
+}
+
+#[cfg(all(feature = "alloc", feature = "std"))]
+impl AgentContext {
+    /// Construct a new `AgentContext` stamped at the current wall-clock time.
+    pub fn now(agent_id: AgentId, session_id: SessionId, pid: u32) -> Self {
+        Self {
+            started_at: Timestamp::from(std::time::SystemTime::now()),
+            agent_id,
+            session_id,
+            pid,
+            metadata: BTreeMap::new(),
+        }
+    }
+}
+```
+
+### `aa-core/src/lib.rs` additions
+
+```rust
+pub mod identity;
+pub mod agent;
+
+pub use identity::{AgentId, SessionId};
+
+#[cfg(feature = "alloc")]
+pub use agent::AgentContext;
+```
+
+---
+
+## Commit Plan (11 commits)
+
+| # | Message | Key change |
+|---|---------|------------|
+| 1 | `🔧 (aa-core): Add serde_json dev-dependency` | `serde_json = "1"` in `[dev-dependencies]` |
+| 2 | `✨ (aa-core/identity): Add AgentId newtype over [u8; 16]` | New `src/identity.rs` with `AgentId` |
+| 3 | `✨ (aa-core/identity): Add SessionId newtype over [u8; 16]` | `SessionId` added to `identity.rs` |
+| 4 | `✨ (aa-core/identity): Add serde derives to AgentId and SessionId` | `cfg_attr` serde derives on both |
+| 5 | `✅ (aa-core/identity): Add unit tests for AgentId and SessionId` | Round-trip, equality, `Copy` tests |
+| 6 | `✨ (aa-core): Declare identity module and re-export AgentId, SessionId` | `pub mod identity` + `pub use` in `lib.rs` |
+| 7 | `✨ (aa-core/agent): Add AgentContext struct gated on alloc` | New `src/agent.rs` with full struct |
+| 8 | `✨ (aa-core/agent): Add AgentContext::now() constructor under std feature` | `#[cfg(all(alloc, std))] impl` block |
+| 9 | `✅ (aa-core/agent): Add field access, clone, and equality tests` | Tests gated on `alloc` |
+| 10 | `✅ (aa-core/agent): Add serde round-trip test` | Test gated on `alloc + serde`, uses `serde_json` |
+| 11 | `✨ (aa-core): Declare agent module and re-export AgentContext under alloc` | `pub mod agent` + conditional `pub use` in `lib.rs` |
+
+---
+
+## Acceptance Criteria (from ticket)
+
+- [ ] `AgentContext` struct defined with all required fields
+- [ ] Newtype wrappers `AgentId` and `SessionId` implemented
+- [ ] `no_std` compilation passes
+- [ ] Unit tests verify field access, clone, and equality
+- [ ] Serialization round-trip test passes (serde_json)
+
+---
+
+## Pattern for AAASM-23–25
+
+Identity types (`AgentId`, `SessionId`) and `Timestamp` are now available in `aa-core`.
+Future domain type tickets follow this template:
+
+```rust
+#[cfg(feature = "alloc")]
+use alloc::{ /* heap types needed */ };
+use crate::{identity::{AgentId, SessionId}, time::Timestamp};
+
+#[cfg(feature = "alloc")]   // or just #[cfg] if heap-free
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct MyDomainType { ... }
+```
+
+No future ticket needs to add new `Cargo.toml` entries — all feature wiring is already done.

--- a/docs/superpowers/specs/2026-04-27-aaasm-42-ca-provisioning-design.md
+++ b/docs/superpowers/specs/2026-04-27-aaasm-42-ca-provisioning-design.md
@@ -1,0 +1,149 @@
+# AAASM-42: CA Certificate Provisioning Design
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the CA certificate provisioning flow in `aa-proxy` — generating and persisting a local EC P-256 CA key pair on first run, signing per-domain leaf certs, and managing the CA's trust status in the macOS System Keychain.
+
+**Architecture:** `ca.rs` is platform-agnostic and owns key generation, disk persistence, and cert signing. A new `keychain.rs` is macOS-only (`#[cfg(target_os = "macos")]`) and owns all `security` CLI invocations. `CaStore` delegates trust store operations to `keychain.rs` through three methods: `install`, `uninstall`, `is_installed`. `CertCache::get_or_insert` ties the cache to `CaStore::sign_cert` for on-demand per-domain cert generation.
+
+**Tech Stack:** `rcgen 0.13` (key + cert generation), `std::process::Command` (macOS `security` CLI), `std::fs` (file I/O + permissions), `lru 0.16` (cert cache).
+
+---
+
+## Component Responsibilities
+
+### `aa-proxy/src/error.rs`
+
+Add a `Keychain(String)` variant to `ProxyError` for failures from the `security` CLI (non-zero exit, unexpected output). Keeps keychain errors distinct from I/O and cert-gen errors.
+
+### `aa-proxy/src/tls/keychain.rs` (new, macOS-only)
+
+Three package-private functions, all gated with `#[cfg(target_os = "macos")]`:
+
+| Function | CLI invoked | Purpose |
+|---|---|---|
+| `add_trusted_cert(cert_path: &Path)` | `security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain <cert>` | Install CA cert into System Keychain with full trust |
+| `remove_trusted_cert(cert_path: &Path)` | `security remove-trusted-cert -d <cert>` | Remove CA cert from System Keychain |
+| `is_cert_trusted(subject: &str)` | `security find-certificate -c <subject> -a /Library/Keychains/System.keychain` | Return `true` if a cert with the given CN is found |
+
+All three check the exit code and map failures to `ProxyError::Keychain`. The `security` CLI triggers macOS's native privilege prompt automatically when the System Keychain requires elevation — no explicit `osascript` needed.
+
+### `aa-proxy/src/tls/ca.rs`
+
+`CaStore` gains a `ca_dir: PathBuf` field and the following concrete implementations:
+
+**`load_or_create(ca_dir: &Path) -> Result<Self, ProxyError>`**
+
+1. If `ca_dir/ca-cert.pem` and `ca_dir/ca-key.pem` both exist → read and return.
+2. Otherwise: generate EC P-256 (`PKCS_ECDSA_P256_SHA256`) CA key pair with `rcgen`, set validity to 10 years, set `is_ca = IsCa::Ca(BasicConstraints::Unconstrained)`, set `key_usages = [KeyCertSign, CrlSign]`, self-sign.
+3. Create `ca_dir` with `fs::create_dir_all`.
+4. Write `ca-cert.pem` (world-readable) and `ca-key.pem` (`chmod 600`, owner-only).
+5. Return the loaded `CaStore`.
+
+After `load_or_create` returns, `aa_proxy::run()` calls `is_installed()` and, if `false`, calls `install()`. This keeps `load_or_create` focused on disk state and `install` focused on OS trust state — two distinct concerns with a clear call sequence in `run()`.
+
+**`sign_cert(&self, domain: &str) -> Result<CertifiedKey, ProxyError>`**
+
+Generate a fresh EC P-256 leaf cert for `domain`: SAN = `[domain]`, validity = 1 year, signed by the CA key. Return DER-encoded cert + key as `CertifiedKey`.
+
+**`install(&self) -> Result<(), ProxyError>`**
+
+Call `keychain::add_trusted_cert(&self.ca_dir.join("ca-cert.pem"))`.
+
+**`uninstall(&self) -> Result<(), ProxyError>`**
+
+Call `keychain::remove_trusted_cert(&self.ca_dir.join("ca-cert.pem"))`. Then `fs::remove_dir_all(&self.ca_dir)`.
+
+**`is_installed(&self) -> Result<bool, ProxyError>`**
+
+Call `keychain::is_cert_trusted("Agent Assembly CA")`.
+
+### `aa-proxy/src/tls/cert.rs`
+
+**`get_or_insert(&self, domain: &str, ca: &CaStore) -> Result<Arc<CertifiedKey>, ProxyError>`**
+
+Lock the `Mutex`, look up `domain` in the `LruCache`. On hit: clone and return the `Arc`. On miss: call `ca.sign_cert(domain)`, wrap in `Arc`, insert into the cache, return.
+
+---
+
+## Data Flow
+
+### First proxy start (cold)
+
+```
+aa_proxy::run(config)
+  → CaStore::load_or_create(&config.ca_dir)
+      → ca-cert.pem missing → generate EC P-256 CA
+      → write ca-cert.pem + ca-key.pem (chmod 600)
+      → return CaStore
+  → CaStore::is_installed()
+      → security find-certificate → not found
+  → CaStore::install()
+      → security add-trusted-cert → macOS prompts for auth
+  → ProxyServer::new(config, ca) → ready
+```
+
+### Per-domain TLS interception (cache miss)
+
+```
+client CONNECT api.openai.com:443
+  → CertCache::get_or_insert("api.openai.com", &ca)
+      → LRU miss
+      → ca.sign_cert("api.openai.com")
+          → rcgen generates EC P-256 leaf cert, 1-year, signed by CA
+      → Arc<CertifiedKey> inserted into LRU, returned
+  → TLS handshake with dynamic cert proceeds
+```
+
+### Subsequent connections (cache hit)
+
+```
+client CONNECT api.openai.com:443
+  → CertCache::get_or_insert("api.openai.com", &ca)
+      → LRU hit → return Arc clone (zero signing cost)
+```
+
+---
+
+## Error Handling
+
+| Scenario | Error |
+|---|---|
+| `ca_dir` not writable | `ProxyError::Io` (from `fs::create_dir_all`) |
+| `rcgen` key/cert generation fails | `ProxyError::CertGen(e.to_string())` |
+| `chmod 600` fails | `ProxyError::Io` |
+| `security` CLI not found (non-macOS / CI) | `ProxyError::Keychain("security CLI not found")` |
+| `security` exits non-zero | `ProxyError::Keychain(stderr)` |
+| CA already installed (is_installed = true) | `install()` is a no-op — skip CLI call |
+
+`load_or_create` is called at startup; any error is fatal and propagated via `anyhow::Result` in `main.rs`. Keychain failures are non-fatal if CA was previously installed and `is_installed()` returns true.
+
+---
+
+## Testing Strategy
+
+### Unit tests (no macOS required, no sudo)
+
+- **`ca.rs`**: `load_or_create` with a `tempdir` — verify files are created, key file has mode `0o600`, reloading same dir returns without regenerating, cert CN is "Agent Assembly CA".
+- **`cert.rs`**: `get_or_insert` with a real `CaStore` from `tempdir` — verify first call for a domain signs a cert, second call for the same domain returns the same `Arc` pointer (cache hit).
+
+### Integration tests (`#[cfg(target_os = "macos")]` + `#[ignore]`)
+
+- `install()` → `is_installed()` returns `true`.
+- `uninstall()` → `is_installed()` returns `false` → `ca_dir` no longer exists.
+- Python `requests` GET to a test HTTPS server using the dynamic cert succeeds after installation.
+
+Integration tests are marked `#[ignore]` (require sudo and a real macOS keychain) and run only in the CI job that has keychain access, or manually with `cargo test -- --ignored`.
+
+---
+
+## Files Changed
+
+| File | Action |
+|---|---|
+| `aa-proxy/src/error.rs` | Modify — add `Keychain(String)` variant |
+| `aa-proxy/src/tls/keychain.rs` | Create — macOS `security` CLI wrappers |
+| `aa-proxy/src/tls/ca.rs` | Modify — implement all methods, add `ca_dir` field |
+| `aa-proxy/src/tls/cert.rs` | Modify — implement `get_or_insert` |
+| `aa-proxy/src/tls/mod.rs` | Modify — add `mod keychain` |
+| `aa-proxy/Cargo.toml` | No change — `rcgen 0.13` already present |


### PR DESCRIPTION
## Description

Implements `AgentContext` — the core identity carrier for the agent-assembly governance system — along with `AgentId` and `SessionId` newtype wrappers. These types establish the identity layer that all future domain types (AuditEntry, PolicyEvaluator, etc.) will reference.

Key design decisions:
- `AgentId([u8; 16])` and `SessionId([u8; 16])` live in `src/identity.rs` — stack-only, no `alloc` gate, importable by any future type without pulling in heap dependencies
- `AgentContext` lives in `src/agent.rs`, gated on `#[cfg(feature = "alloc")]` — requires heap for `BTreeMap<String, String>` metadata
- `started_at: Timestamp` uses the `crate::time::Timestamp` newtype from AAASM-26 (not raw `u64`)
- `AgentContext::now()` constructor available under `std` feature via `Timestamp::from(SystemTime::now())`
- Fixed `metadata` key type from `&'static str` to `String` — serde cannot deserialize `&'static str` map keys

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-22
- Epic: AAASM-2 (Runtime Core Foundations)

## Testing

- [x] Unit tests added / updated
  - 7 identity tests: round-trip, equality, Copy semantics for `AgentId` and `SessionId`
  - 5 AgentContext tests: field access, clone, equality, inequality, `now()` constructor
  - 1 serde round-trip test via `serde_json` (gated on `alloc + serde` features)
  - All 15 tests pass (`cargo test -p aa-core --all-features --lib`)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention