### PR TITLE
[AAASM-29] ✨ (aa-runtime): Bootstrap Tokio runtime init with graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,9 @@ dependencies = [
  "aa-core",
  "aa-proto",
  "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -611,6 +614,12 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -653,6 +662,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -672,6 +692,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -711,9 +732,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -737,13 +771,22 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -960,6 +1003,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,6 +1114,12 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1652,6 +1707,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,7 +2182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2278,6 +2339,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -2449,6 +2511,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2458,12 +2530,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2495,6 +2570,12 @@ name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unindent"
@@ -2618,7 +2699,16 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -2674,6 +2764,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -2887,9 +3011,97 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -11,6 +11,7 @@ aa-core    = { path = "../aa-core" }
 aa-proto   = { path = "../aa-proto" }
 tokio      = { version = "1", features = ["full"] }
 tokio-util = { version = "0.7", features = ["rt"] }
+tracing    = "0.1"
 
 [lints]
 workspace = true

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -7,11 +7,12 @@ repository.workspace = true
 description = "Tokio async runtime wrapper and lifecycle management for Agent Assembly"
 
 [dependencies]
-aa-core    = { path = "../aa-core" }
-aa-proto   = { path = "../aa-proto" }
-tokio      = { version = "1", features = ["full"] }
-tokio-util = { version = "0.7", features = ["rt"] }
-tracing    = "0.1"
+aa-core              = { path = "../aa-core" }
+aa-proto             = { path = "../aa-proto" }
+tokio                = { version = "1", features = ["full"] }
+tokio-util           = { version = "0.7", features = ["rt"] }
+tracing              = "0.1"
+tracing-subscriber   = { version = "0.3", features = ["json", "env-filter"] }
 
 [lints]
 workspace = true

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -7,9 +7,10 @@ repository.workspace = true
 description = "Tokio async runtime wrapper and lifecycle management for Agent Assembly"
 
 [dependencies]
-aa-core  = { path = "../aa-core" }
-aa-proto = { path = "../aa-proto" }
-tokio    = { version = "1", features = ["full"] }
+aa-core    = { path = "../aa-core" }
+aa-proto   = { path = "../aa-proto" }
+tokio      = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 
 [lints]
 workspace = true

--- a/aa-runtime/src/config.rs
+++ b/aa-runtime/src/config.rs
@@ -1,1 +1,13 @@
 //! Runtime configuration loaded from environment variables.
+
+/// Configuration for the `aa-runtime` sidecar process.
+///
+/// All fields are populated by [`RuntimeConfig::from_env`].
+#[derive(Debug, Clone)]
+pub struct RuntimeConfig {
+    /// Number of Tokio worker threads.
+    ///
+    /// Read from `AA_RUNTIME_WORKER_THREADS`. Defaults to `0`, which tells
+    /// Tokio to use one thread per logical CPU.
+    pub worker_threads: usize,
+}

--- a/aa-runtime/src/config.rs
+++ b/aa-runtime/src/config.rs
@@ -16,3 +16,32 @@ pub struct RuntimeConfig {
     /// Read from `AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS`. Defaults to `30`.
     pub shutdown_timeout_secs: u64,
 }
+
+impl RuntimeConfig {
+    /// Build configuration from environment variables, falling back to defaults.
+    ///
+    /// # Env vars
+    ///
+    /// | Variable | Type | Default |
+    /// |---|---|---|
+    /// | `AA_RUNTIME_WORKER_THREADS` | `usize` | `0` (Tokio picks per-CPU) |
+    /// | `AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS` | `u64` | `30` |
+    ///
+    /// Invalid values are silently ignored and the default is used instead.
+    pub fn from_env() -> Self {
+        let worker_threads = std::env::var("AA_RUNTIME_WORKER_THREADS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+
+        let shutdown_timeout_secs = std::env::var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(30);
+
+        Self {
+            worker_threads,
+            shutdown_timeout_secs,
+        }
+    }
+}

--- a/aa-runtime/src/config.rs
+++ b/aa-runtime/src/config.rs
@@ -10,4 +10,9 @@ pub struct RuntimeConfig {
     /// Read from `AA_RUNTIME_WORKER_THREADS`. Defaults to `0`, which tells
     /// Tokio to use one thread per logical CPU.
     pub worker_threads: usize,
+
+    /// Maximum seconds to wait for in-flight tasks to complete during shutdown.
+    ///
+    /// Read from `AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS`. Defaults to `30`.
+    pub shutdown_timeout_secs: u64,
 }

--- a/aa-runtime/src/config.rs
+++ b/aa-runtime/src/config.rs
@@ -45,3 +45,60 @@ impl RuntimeConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_when_env_vars_absent() {
+        // Ensure neither var is set for this test.
+        std::env::remove_var("AA_RUNTIME_WORKER_THREADS");
+        std::env::remove_var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS");
+
+        let config = RuntimeConfig::from_env();
+
+        assert_eq!(config.worker_threads, 0);
+        assert_eq!(config.shutdown_timeout_secs, 30);
+    }
+
+    #[test]
+    fn reads_worker_threads_from_env() {
+        std::env::set_var("AA_RUNTIME_WORKER_THREADS", "4");
+        std::env::remove_var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS");
+
+        let config = RuntimeConfig::from_env();
+
+        assert_eq!(config.worker_threads, 4);
+        assert_eq!(config.shutdown_timeout_secs, 30);
+
+        std::env::remove_var("AA_RUNTIME_WORKER_THREADS");
+    }
+
+    #[test]
+    fn reads_shutdown_timeout_from_env() {
+        std::env::remove_var("AA_RUNTIME_WORKER_THREADS");
+        std::env::set_var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS", "60");
+
+        let config = RuntimeConfig::from_env();
+
+        assert_eq!(config.worker_threads, 0);
+        assert_eq!(config.shutdown_timeout_secs, 60);
+
+        std::env::remove_var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS");
+    }
+
+    #[test]
+    fn falls_back_to_default_on_invalid_value() {
+        std::env::set_var("AA_RUNTIME_WORKER_THREADS", "not-a-number");
+        std::env::set_var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS", "abc");
+
+        let config = RuntimeConfig::from_env();
+
+        assert_eq!(config.worker_threads, 0);
+        assert_eq!(config.shutdown_timeout_secs, 30);
+
+        std::env::remove_var("AA_RUNTIME_WORKER_THREADS");
+        std::env::remove_var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS");
+    }
+}

--- a/aa-runtime/src/config.rs
+++ b/aa-runtime/src/config.rs
@@ -1,0 +1,1 @@
+//! Runtime configuration loaded from environment variables.

--- a/aa-runtime/src/health.rs
+++ b/aa-runtime/src/health.rs
@@ -1,0 +1,1 @@
+//! HTTP health check and Prometheus metrics endpoint — implemented in AAASM-32.

--- a/aa-runtime/src/ipc/mod.rs
+++ b/aa-runtime/src/ipc/mod.rs
@@ -1,0 +1,1 @@
+//! Unix domain socket IPC server — implemented in AAASM-30.

--- a/aa-runtime/src/lib.rs
+++ b/aa-runtime/src/lib.rs
@@ -5,6 +5,7 @@
 //! coordination, and lifecycle hooks.
 
 pub mod config;
+pub mod health;
 pub mod ipc;
 pub mod lifecycle;
 pub mod pipeline;

--- a/aa-runtime/src/lib.rs
+++ b/aa-runtime/src/lib.rs
@@ -5,5 +5,6 @@
 //! coordination, and lifecycle hooks.
 
 pub mod config;
+pub mod ipc;
 pub mod lifecycle;
 pub mod runtime;

--- a/aa-runtime/src/lib.rs
+++ b/aa-runtime/src/lib.rs
@@ -10,3 +10,5 @@ pub mod ipc;
 pub mod lifecycle;
 pub mod pipeline;
 pub mod runtime;
+
+pub use runtime::run;

--- a/aa-runtime/src/lib.rs
+++ b/aa-runtime/src/lib.rs
@@ -5,4 +5,5 @@
 //! coordination, and lifecycle hooks.
 
 pub mod config;
+pub mod lifecycle;
 pub mod runtime;

--- a/aa-runtime/src/lib.rs
+++ b/aa-runtime/src/lib.rs
@@ -3,3 +3,5 @@
 //! This crate wraps `tokio` to provide a consistent async execution environment
 //! for Agent Assembly components. It handles runtime initialization, shutdown
 //! coordination, and lifecycle hooks.
+
+pub mod config;

--- a/aa-runtime/src/lib.rs
+++ b/aa-runtime/src/lib.rs
@@ -7,4 +7,5 @@
 pub mod config;
 pub mod ipc;
 pub mod lifecycle;
+pub mod pipeline;
 pub mod runtime;

--- a/aa-runtime/src/lib.rs
+++ b/aa-runtime/src/lib.rs
@@ -5,3 +5,4 @@
 //! coordination, and lifecycle hooks.
 
 pub mod config;
+pub mod runtime;

--- a/aa-runtime/src/lifecycle.rs
+++ b/aa-runtime/src/lifecycle.rs
@@ -28,8 +28,7 @@ async fn sigterm() {
     #[cfg(unix)]
     {
         use tokio::signal::unix::{signal, SignalKind};
-        let mut stream = signal(SignalKind::terminate())
-            .expect("failed to install SIGTERM handler");
+        let mut stream = signal(SignalKind::terminate()).expect("failed to install SIGTERM handler");
         stream.recv().await;
     }
     #[cfg(not(unix))]

--- a/aa-runtime/src/lifecycle.rs
+++ b/aa-runtime/src/lifecycle.rs
@@ -1,0 +1,1 @@
+//! Signal handling and graceful shutdown coordination.

--- a/aa-runtime/src/lifecycle.rs
+++ b/aa-runtime/src/lifecycle.rs
@@ -5,6 +5,28 @@
 /// Returns as soon as either signal fires. Callers should then trigger
 /// cooperative cancellation on all tracked tasks.
 pub async fn wait_for_shutdown_signal() {
-    // SIGTERM and SIGINT handlers added in subsequent steps.
-    std::future::pending::<()>().await
+    let sigterm = sigterm();
+
+    tokio::select! {
+        _ = sigterm => {
+            tracing::info!("received SIGTERM — initiating graceful shutdown");
+        }
+    }
+}
+
+/// Returns a future that resolves on the first SIGTERM.
+///
+/// On non-Unix platforms this future never resolves (SIGTERM is Unix-only).
+async fn sigterm() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut stream = signal(SignalKind::terminate())
+            .expect("failed to install SIGTERM handler");
+        stream.recv().await;
+    }
+    #[cfg(not(unix))]
+    {
+        std::future::pending::<()>().await
+    }
 }

--- a/aa-runtime/src/lifecycle.rs
+++ b/aa-runtime/src/lifecycle.rs
@@ -1,1 +1,10 @@
 //! Signal handling and graceful shutdown coordination.
+
+/// Waits until the process receives a shutdown signal (SIGTERM or SIGINT).
+///
+/// Returns as soon as either signal fires. Callers should then trigger
+/// cooperative cancellation on all tracked tasks.
+pub async fn wait_for_shutdown_signal() {
+    // SIGTERM and SIGINT handlers added in subsequent steps.
+    std::future::pending::<()>().await
+}

--- a/aa-runtime/src/lifecycle.rs
+++ b/aa-runtime/src/lifecycle.rs
@@ -6,10 +6,17 @@
 /// cooperative cancellation on all tracked tasks.
 pub async fn wait_for_shutdown_signal() {
     let sigterm = sigterm();
+    let sigint = tokio::signal::ctrl_c();
 
     tokio::select! {
         _ = sigterm => {
             tracing::info!("received SIGTERM — initiating graceful shutdown");
+        }
+        result = sigint => {
+            match result {
+                Ok(()) => tracing::info!("received SIGINT (Ctrl-C) — initiating graceful shutdown"),
+                Err(e) => tracing::error!("SIGINT handler error: {e}"),
+            }
         }
     }
 }

--- a/aa-runtime/src/main.rs
+++ b/aa-runtime/src/main.rs
@@ -1,0 +1,5 @@
+//! `aa-runtime` sidecar binary entry point.
+
+fn main() {
+    // Tracing and runtime wired in subsequent tasks.
+}

--- a/aa-runtime/src/main.rs
+++ b/aa-runtime/src/main.rs
@@ -1,10 +1,25 @@
 //! `aa-runtime` sidecar binary entry point.
 
+fn init_tracing() {
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+    tracing_subscriber::registry()
+        .with(EnvFilter::from_default_env())
+        .with(fmt::layer().json())
+        .init();
+}
+
 fn main() {
+    init_tracing();
+
     let config = aa_runtime::config::RuntimeConfig::from_env();
 
-    // Build the Tokio multi-thread runtime.
-    // When worker_threads == 0, Builder uses one thread per logical CPU (Tokio default).
+    tracing::info!(
+        worker_threads = config.worker_threads,
+        shutdown_timeout_secs = config.shutdown_timeout_secs,
+        "configuration loaded"
+    );
+
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.enable_all();
 

--- a/aa-runtime/src/main.rs
+++ b/aa-runtime/src/main.rs
@@ -1,5 +1,19 @@
 //! `aa-runtime` sidecar binary entry point.
 
 fn main() {
-    // Tracing and runtime wired in subsequent tasks.
+    let config = aa_runtime::config::RuntimeConfig::from_env();
+
+    // Build the Tokio multi-thread runtime.
+    // When worker_threads == 0, Builder uses one thread per logical CPU (Tokio default).
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.enable_all();
+
+    if config.worker_threads > 0 {
+        builder.worker_threads(config.worker_threads);
+    }
+
+    builder
+        .build()
+        .expect("failed to build Tokio runtime")
+        .block_on(aa_runtime::run(config));
 }

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -1,0 +1,1 @@
+//! Event aggregation pipeline — implemented in AAASM-31.

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -1,5 +1,8 @@
 //! Tokio runtime initialisation and structured task lifecycle management.
 
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+
 use crate::config::RuntimeConfig;
 
 /// Start the runtime and block until graceful shutdown completes.
@@ -9,5 +12,19 @@ use crate::config::RuntimeConfig;
 /// shutdown signal, then drains all tasks within the configured timeout.
 pub async fn run(_config: RuntimeConfig) {
     tracing::info!("aa-runtime starting");
+
+    let tracker = TaskTracker::new();
+    let token = CancellationToken::new();
+
+    tracing::info!(
+        tasks = tracker.len(),
+        "structured concurrency primitives initialised"
+    );
+
+    // Shutdown sequence added in the next task.
+    drop(token);
+    tracker.close();
+    tracker.wait().await;
+
     tracing::info!("aa-runtime stopped");
 }

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -47,3 +47,70 @@ pub async fn run(config: RuntimeConfig) {
 
     tracing::info!("aa-runtime stopped");
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio_util::sync::CancellationToken;
+    use tokio_util::task::TaskTracker;
+
+    /// Verifies the structured concurrency primitives drain cleanly under load.
+    ///
+    /// Spawns N tasks that loop until the cancellation token fires, then
+    /// cancels the token and asserts all tasks complete within the timeout.
+    #[tokio::test]
+    async fn graceful_shutdown_drains_all_tasks() {
+        const TASK_COUNT: usize = 10;
+        const TIMEOUT: Duration = Duration::from_secs(5);
+
+        let tracker = TaskTracker::new();
+        let token = CancellationToken::new();
+
+        // Spawn synthetic load tasks that honor the cancellation token.
+        for i in 0..TASK_COUNT {
+            let child_token = token.clone();
+            tracker.spawn(async move {
+                loop {
+                    tokio::select! {
+                        _ = child_token.cancelled() => {
+                            break;
+                        }
+                        _ = tokio::time::sleep(Duration::from_millis(10)) => {
+                            // Simulate work.
+                        }
+                    }
+                }
+                tracing::debug!(task = i, "task completed cleanly");
+            });
+        }
+
+        // Trigger shutdown.
+        token.cancel();
+        tracker.close();
+
+        // All tasks must complete within the timeout — no leaks.
+        tokio::time::timeout(TIMEOUT, tracker.wait())
+            .await
+            .expect("tasks did not complete within timeout");
+    }
+
+    /// Verifies that shutdown timeout enforcement works when tasks ignore cancellation.
+    #[tokio::test]
+    async fn shutdown_timeout_fires_when_tasks_hang() {
+        let tracker = TaskTracker::new();
+        let token = CancellationToken::new();
+
+        // Spawn a task that ignores cancellation and sleeps forever.
+        tracker.spawn(async move {
+            let _token = token; // hold token to prevent drop-based cancellation
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+        });
+
+        tracker.close();
+
+        // Drain with a very short timeout — must expire.
+        let result = tokio::time::timeout(Duration::from_millis(100), tracker.wait()).await;
+        assert!(result.is_err(), "expected timeout but tasks completed");
+    }
+}

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -1,1 +1,13 @@
 //! Tokio runtime initialisation and structured task lifecycle management.
+
+use crate::config::RuntimeConfig;
+
+/// Start the runtime and block until graceful shutdown completes.
+///
+/// This is the main async entry point called from `main()`. It creates the
+/// structured concurrency primitives, spawns subsystem tasks, waits for a
+/// shutdown signal, then drains all tasks within the configured timeout.
+pub async fn run(_config: RuntimeConfig) {
+    tracing::info!("aa-runtime starting");
+    tracing::info!("aa-runtime stopped");
+}

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -1,0 +1,1 @@
+//! Tokio runtime initialisation and structured task lifecycle management.

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -1,30 +1,49 @@
 //! Tokio runtime initialisation and structured task lifecycle management.
 
+use std::time::Duration;
+
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 
 use crate::config::RuntimeConfig;
+use crate::lifecycle::wait_for_shutdown_signal;
 
 /// Start the runtime and block until graceful shutdown completes.
 ///
 /// This is the main async entry point called from `main()`. It creates the
 /// structured concurrency primitives, spawns subsystem tasks, waits for a
 /// shutdown signal, then drains all tasks within the configured timeout.
-pub async fn run(_config: RuntimeConfig) {
+pub async fn run(config: RuntimeConfig) {
     tracing::info!("aa-runtime starting");
 
     let tracker = TaskTracker::new();
     let token = CancellationToken::new();
 
-    tracing::info!(
-        tasks = tracker.len(),
-        "structured concurrency primitives initialised"
-    );
+    tracing::info!("structured concurrency primitives initialised");
 
-    // Shutdown sequence added in the next task.
-    drop(token);
+    // Subsystem tasks (ipc, pipeline, health) are spawned here in later tickets.
+    // Each receives a cloned `token` and a `tracker.token()` guard.
+
+    // Wait for an OS shutdown signal.
+    wait_for_shutdown_signal().await;
+
+    // Signal all tasks to stop cooperatively.
+    token.cancel();
+    tracing::info!("cancellation token fired — draining tasks");
+
+    // Stop accepting new task registrations.
     tracker.close();
-    tracker.wait().await;
+
+    // Wait for all tasks to complete, with a hard timeout.
+    let timeout = Duration::from_secs(config.shutdown_timeout_secs);
+    if tokio::time::timeout(timeout, tracker.wait()).await.is_err() {
+        tracing::error!(
+            timeout_secs = config.shutdown_timeout_secs,
+            "shutdown timeout exceeded — forcing exit"
+        );
+    } else {
+        tracing::info!("all tasks completed cleanly");
+    }
 
     tracing::info!("aa-runtime stopped");
 }

--- a/docs/superpowers/plans/2026-04-27-aaasm-29-tokio-runtime-init.md
+++ b/docs/superpowers/plans/2026-04-27-aaasm-29-tokio-runtime-init.md
@@ -1,0 +1,1311 @@
+# AAASM-29: `aa-runtime` Bootstrap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bootstrap the `aa-runtime` crate with Tokio multi-thread runtime, structured concurrency via `TaskTracker` + `CancellationToken`, graceful SIGTERM/SIGINT shutdown, structured JSON logging, and the full epic module scaffolding.
+
+**Architecture:** `main.rs` initialises tracing then calls `runtime::run(config)`. The `run()` function creates a `TaskTracker` and `CancellationToken`, waits for a shutdown signal via `lifecycle::wait_for_shutdown_signal()`, cancels the token, drains all tracked tasks within a configurable timeout, then exits. Stub modules (`ipc`, `pipeline`, `health`) are declared in `lib.rs` but left empty for AAASM-30/31/32.
+
+**Tech Stack:** Rust 2021 edition, `tokio 1` (full features), `tokio-util 0.7` (TaskTracker + CancellationToken), `tracing 0.1`, `tracing-subscriber 0.3` (json + env-filter)
+
+**Worktree:** `/Users/bryant/Bryant-Developments/AI-agent-assembly/agent-assembly-v0.0.1-AAASM-29-tokio_runtime_init`
+**Branch:** `v0.0.1/AAASM-29/tokio_runtime_init`
+**All commands run from the worktree root unless stated otherwise.**
+
+---
+
+## Task 1: Add `tokio-util` dependency
+
+**Files:**
+- Modify: `aa-runtime/Cargo.toml`
+
+- [ ] **Step 1: Add `tokio-util` to `[dependencies]`**
+
+Open `aa-runtime/Cargo.toml`. The `[dependencies]` section currently reads:
+
+```toml
+[dependencies]
+aa-core  = { path = "../aa-core" }
+aa-proto = { path = "../aa-proto" }
+tokio    = { version = "1", features = ["full"] }
+```
+
+Add one line for `tokio-util`:
+
+```toml
+[dependencies]
+aa-core    = { path = "../aa-core" }
+aa-proto   = { path = "../aa-proto" }
+tokio      = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["rt"] }
+```
+
+- [ ] **Step 2: Verify workspace compiles**
+
+```bash
+cargo build -p aa-runtime
+```
+
+Expected: builds without errors (only the lib stub compiles).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-runtime/Cargo.toml
+git commit -m "🔧 (aa-runtime): Add tokio-util dependency with rt feature"
+```
+
+---
+
+## Task 2: Add `tracing` dependency
+
+**Files:**
+- Modify: `aa-runtime/Cargo.toml`
+
+- [ ] **Step 1: Add `tracing` to `[dependencies]`**
+
+```toml
+[dependencies]
+aa-core    = { path = "../aa-core" }
+aa-proto   = { path = "../aa-proto" }
+tokio      = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["rt"] }
+tracing    = "0.1"
+```
+
+- [ ] **Step 2: Verify workspace compiles**
+
+```bash
+cargo build -p aa-runtime
+```
+
+Expected: builds without errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-runtime/Cargo.toml
+git commit -m "🔧 (aa-runtime): Add tracing dependency"
+```
+
+---
+
+## Task 3: Add `tracing-subscriber` dependency
+
+**Files:**
+- Modify: `aa-runtime/Cargo.toml`
+
+- [ ] **Step 1: Add `tracing-subscriber` to `[dependencies]`**
+
+```toml
+[dependencies]
+aa-core              = { path = "../aa-core" }
+aa-proto             = { path = "../aa-proto" }
+tokio                = { version = "1", features = ["full"] }
+tokio-util           = { version = "0.7", features = ["rt"] }
+tracing              = "0.1"
+tracing-subscriber   = { version = "0.3", features = ["json", "env-filter"] }
+```
+
+- [ ] **Step 2: Verify workspace compiles**
+
+```bash
+cargo build -p aa-runtime
+```
+
+Expected: builds without errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-runtime/Cargo.toml
+git commit -m "🔧 (aa-runtime): Add tracing-subscriber with json and env-filter features"
+```
+
+---
+
+## Task 4: Add `config` module stub
+
+**Files:**
+- Create: `aa-runtime/src/config.rs`
+- Modify: `aa-runtime/src/lib.rs`
+
+- [ ] **Step 1: Create empty `config.rs`**
+
+Create `aa-runtime/src/config.rs` with only a module-level doc comment:
+
+```rust
+//! Runtime configuration loaded from environment variables.
+```
+
+- [ ] **Step 2: Declare `config` module in `lib.rs`**
+
+The current `lib.rs` is:
+
+```rust
+//! Tokio async runtime wrapper and agent lifecycle management.
+//!
+//! This crate wraps `tokio` to provide a consistent async execution environment
+//! for Agent Assembly components. It handles runtime initialization, shutdown
+//! coordination, and lifecycle hooks.
+```
+
+Replace the entire file with:
+
+```rust
+//! Tokio async runtime wrapper and agent lifecycle management.
+//!
+//! This crate wraps `tokio` to provide a consistent async execution environment
+//! for Agent Assembly components. It handles runtime initialization, shutdown
+//! coordination, and lifecycle hooks.
+
+pub mod config;
+```
+
+- [ ] **Step 3: Verify workspace compiles**
+
+```bash
+cargo build -p aa-runtime
+```
+
+Expected: builds without errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add aa-runtime/src/config.rs aa-runtime/src/lib.rs
+git commit -m "✨ (aa-runtime): Add config module declaration to lib.rs"
+```
+
+---
+
+## Task 5: Add `runtime` module stub
+
+**Files:**
+- Create: `aa-runtime/src/runtime.rs`
+- Modify: `aa-runtime/src/lib.rs`
+
+- [ ] **Step 1: Create empty `runtime.rs`**
+
+Create `aa-runtime/src/runtime.rs`:
+
+```rust
+//! Tokio runtime initialisation and structured task lifecycle management.
+```
+
+- [ ] **Step 2: Add `runtime` module to `lib.rs`**
+
+```rust
+//! Tokio async runtime wrapper and agent lifecycle management.
+//!
+//! This crate wraps `tokio` to provide a consistent async execution environment
+//! for Agent Assembly components. It handles runtime initialization, shutdown
+//! coordination, and lifecycle hooks.
+
+pub mod config;
+pub mod runtime;
+```
+
+- [ ] **Step 3: Verify workspace compiles**
+
+```bash
+cargo build -p aa-runtime
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add aa-runtime/src/runtime.rs aa-runtime/src/lib.rs
+git commit -m "✨ (aa-runtime): Add runtime module declaration to lib.rs"
+```
+
+---
+
+## Task 6: Add `lifecycle` module stub
+
+**Files:**
+- Create: `aa-runtime/src/lifecycle.rs`
+- Modify: `aa-runtime/src/lib.rs`
+
+- [ ] **Step 1: Create empty `lifecycle.rs`**
+
+Create `aa-runtime/src/lifecycle.rs`:
+
+```rust
+//! Signal handling and graceful shutdown coordination.
+```
+
+- [ ] **Step 2: Add `lifecycle` module to `lib.rs`**
+
+```rust
+//! Tokio async runtime wrapper and agent lifecycle management.
+//!
+//! This crate wraps `tokio` to provide a consistent async execution environment
+//! for Agent Assembly components. It handles runtime initialization, shutdown
+//! coordination, and lifecycle hooks.
+
+pub mod config;
+pub mod lifecycle;
+pub mod runtime;
+```
+
+- [ ] **Step 3: Verify workspace compiles**
+
+```bash
+cargo build -p aa-runtime
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add aa-runtime/src/lifecycle.rs aa-runtime/src/lib.rs
+git commit -m "✨ (aa-runtime): Add lifecycle module declaration to lib.rs"
+```
+
+---
+
+## Task 7: Add `ipc` stub module (for AAASM-30)
+
+**Files:**
+- Create: `aa-runtime/src/ipc/mod.rs`
+- Modify: `aa-runtime/src/lib.rs`
+
+- [ ] **Step 1: Create `ipc/mod.rs`**
+
+```bash
+mkdir -p aa-runtime/src/ipc
+```
+
+Create `aa-runtime/src/ipc/mod.rs`:
+
+```rust
+//! Unix domain socket IPC server — implemented in AAASM-30.
+```
+
+- [ ] **Step 2: Add `ipc` module to `lib.rs`**
+
+```rust
+//! Tokio async runtime wrapper and agent lifecycle management.
+//!
+//! This crate wraps `tokio` to provide a consistent async execution environment
+//! for Agent Assembly components. It handles runtime initialization, shutdown
+//! coordination, and lifecycle hooks.
+
+pub mod config;
+pub mod ipc;
+pub mod lifecycle;
+pub mod runtime;
+```
+
+- [ ] **Step 3: Verify workspace compiles**
+
+```bash
+cargo build -p aa-runtime
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add aa-runtime/src/ipc/mod.rs aa-runtime/src/lib.rs
+git commit -m "✨ (aa-runtime): Add ipc stub module for AAASM-30"
+```
+
+---
+
+## Task 8: Add `pipeline` stub module (for AAASM-31)
+
+**Files:**
+- Create: `aa-runtime/src/pipeline/mod.rs`
+- Modify: `aa-runtime/src/lib.rs`
+
+- [ ] **Step 1: Create `pipeline/mod.rs`**
+
+```bash
+mkdir -p aa-runtime/src/pipeline
+```
+
+Create `aa-runtime/src/pipeline/mod.rs`:
+
+```rust
+//! Event aggregation pipeline — implemented in AAASM-31.
+```
+
+- [ ] **Step 2: Add `pipeline` module to `lib.rs`**
+
+```rust
+//! Tokio async runtime wrapper and agent lifecycle management.
+//!
+//! This crate wraps `tokio` to provide a consistent async execution environment
+//! for Agent Assembly components. It handles runtime initialization, shutdown
+//! coordination, and lifecycle hooks.
+
+pub mod config;
+pub mod ipc;
+pub mod lifecycle;
+pub mod pipeline;
+pub mod runtime;
+```
+
+- [ ] **Step 3: Verify workspace compiles**
+
+```bash
+cargo build -p aa-runtime
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add aa-runtime/src/pipeline/mod.rs aa-runtime/src/lib.rs
+git commit -m "✨ (aa-runtime): Add pipeline stub module for AAASM-31"
+```
+
+---
+
+## Task 9: Add `health` stub module (for AAASM-32)
+
+**Files:**
+- Create: `aa-runtime/src/health.rs`
+- Modify: `aa-runtime/src/lib.rs`
+
+- [ ] **Step 1: Create `health.rs`**
+
+Create `aa-runtime/src/health.rs`:
+
+```rust
+//! HTTP health check and Prometheus metrics endpoint — implemented in AAASM-32.
+```
+
+- [ ] **Step 2: Add `health` module to `lib.rs`**
+
+```rust
+//! Tokio async runtime wrapper and agent lifecycle management.
+//!
+//! This crate wraps `tokio` to provide a consistent async execution environment
+//! for Agent Assembly components. It handles runtime initialization, shutdown
+//! coordination, and lifecycle hooks.
+
+pub mod config;
+pub mod health;
+pub mod ipc;
+pub mod lifecycle;
+pub mod pipeline;
+pub mod runtime;
+```
+
+- [ ] **Step 3: Verify workspace compiles**
+
+```bash
+cargo build -p aa-runtime
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add aa-runtime/src/health.rs aa-runtime/src/lib.rs
+git commit -m "✨ (aa-runtime): Add health stub module for AAASM-32"
+```
+
+---
+
+## Task 10: Add `main.rs` binary entry point stub
+
+**Files:**
+- Create: `aa-runtime/src/main.rs`
+
+- [ ] **Step 1: Create `main.rs` stub**
+
+Create `aa-runtime/src/main.rs`:
+
+```rust
+//! `aa-runtime` sidecar binary entry point.
+
+fn main() {
+    // Tracing and runtime wired in subsequent tasks.
+}
+```
+
+- [ ] **Step 2: Verify binary builds**
+
+```bash
+cargo build -p aa-runtime --bins
+```
+
+Expected: builds. A binary named `aa-runtime` should appear in `target/debug/`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-runtime/src/main.rs
+git commit -m "✨ (aa-runtime): Add main.rs binary entry point stub"
+```
+
+---
+
+## Task 11: Add `RuntimeConfig` struct with `worker_threads` field
+
+**Files:**
+- Modify: `aa-runtime/src/config.rs`
+
+- [ ] **Step 1: Add the struct**
+
+Replace the entire `config.rs` with:
+
+```rust
+//! Runtime configuration loaded from environment variables.
+
+/// Configuration for the `aa-runtime` sidecar process.
+///
+/// All fields are populated by [`RuntimeConfig::from_env`].
+#[derive(Debug, Clone)]
+pub struct RuntimeConfig {
+    /// Number of Tokio worker threads.
+    ///
+    /// Read from `AA_RUNTIME_WORKER_THREADS`. Defaults to `0`, which tells
+    /// Tokio to use one thread per logical CPU.
+    pub worker_threads: usize,
+}
+```
+
+- [ ] **Step 2: Verify workspace compiles**
+
+```bash
+cargo build -p aa-runtime
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-runtime/src/config.rs
+git commit -m "✨ (aa-runtime/config): Add RuntimeConfig struct with worker_threads field"
+```
+
+---
+
+## Task 12: Add `shutdown_timeout_secs` field to `RuntimeConfig`
+
+**Files:**
+- Modify: `aa-runtime/src/config.rs`
+
+- [ ] **Step 1: Add the field**
+
+```rust
+//! Runtime configuration loaded from environment variables.
+
+/// Configuration for the `aa-runtime` sidecar process.
+///
+/// All fields are populated by [`RuntimeConfig::from_env`].
+#[derive(Debug, Clone)]
+pub struct RuntimeConfig {
+    /// Number of Tokio worker threads.
+    ///
+    /// Read from `AA_RUNTIME_WORKER_THREADS`. Defaults to `0`, which tells
+    /// Tokio to use one thread per logical CPU.
+    pub worker_threads: usize,
+
+    /// Maximum seconds to wait for in-flight tasks to complete during shutdown.
+    ///
+    /// Read from `AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS`. Defaults to `30`.
+    pub shutdown_timeout_secs: u64,
+}
+```
+
+- [ ] **Step 2: Verify workspace compiles**
+
+```bash
+cargo build -p aa-runtime
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-runtime/src/config.rs
+git commit -m "✨ (aa-runtime/config): Add shutdown_timeout_secs field to RuntimeConfig"
+```
+
+---
+
+## Task 13: Add `RuntimeConfig::from_env()` constructor
+
+**Files:**
+- Modify: `aa-runtime/src/config.rs`
+
+- [ ] **Step 1: Implement `from_env()`**
+
+```rust
+//! Runtime configuration loaded from environment variables.
+
+/// Configuration for the `aa-runtime` sidecar process.
+///
+/// All fields are populated by [`RuntimeConfig::from_env`].
+#[derive(Debug, Clone)]
+pub struct RuntimeConfig {
+    /// Number of Tokio worker threads.
+    ///
+    /// Read from `AA_RUNTIME_WORKER_THREADS`. Defaults to `0`, which tells
+    /// Tokio to use one thread per logical CPU.
+    pub worker_threads: usize,
+
+    /// Maximum seconds to wait for in-flight tasks to complete during shutdown.
+    ///
+    /// Read from `AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS`. Defaults to `30`.
+    pub shutdown_timeout_secs: u64,
+}
+
+impl RuntimeConfig {
+    /// Build configuration from environment variables, falling back to defaults.
+    ///
+    /// # Env vars
+    ///
+    /// | Variable | Type | Default |
+    /// |---|---|---|
+    /// | `AA_RUNTIME_WORKER_THREADS` | `usize` | `0` (Tokio picks per-CPU) |
+    /// | `AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS` | `u64` | `30` |
+    ///
+    /// Invalid values are silently ignored and the default is used instead.
+    pub fn from_env() -> Self {
+        let worker_threads = std::env::var("AA_RUNTIME_WORKER_THREADS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+
+        let shutdown_timeout_secs = std::env::var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(30);
+
+        Self {
+            worker_threads,
+            shutdown_timeout_secs,
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify workspace compiles**
+
+```bash
+cargo build -p aa-runtime
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-runtime/src/config.rs
+git commit -m "✨ (aa-runtime/config): Add RuntimeConfig::from_env() constructor"
+```
+
+---
+
+## Task 14: Add `wait_for_shutdown_signal()` async function skeleton
+
+**Files:**
+- Modify: `aa-runtime/src/lifecycle.rs`
+
+- [ ] **Step 1: Add the function skeleton**
+
+```rust
+//! Signal handling and graceful shutdown coordination.
+
+/// Waits until the process receives a shutdown signal (SIGTERM or SIGINT).
+///
+/// Returns as soon as either signal fires. Callers should then trigger
+/// cooperative cancellation on all tracked tasks.
+pub async fn wait_for_shutdown_signal() {
+    // SIGTERM and SIGINT handlers added in subsequent steps.
+    std::future::pending::<()>().await
+}
+```
+
+- [ ] **Step 2: Verify workspace compiles**
+
+```bash
+cargo build -p aa-runtime
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-runtime/src/lifecycle.rs
+git commit -m "✨ (aa-runtime/lifecycle): Add wait_for_shutdown_signal() async function"
+```
+
+---
+
+## Task 15: Add SIGTERM handler to `wait_for_shutdown_signal()`
+
+**Files:**
+- Modify: `aa-runtime/src/lifecycle.rs`
+
+- [ ] **Step 1: Add SIGTERM branch**
+
+```rust
+//! Signal handling and graceful shutdown coordination.
+
+/// Waits until the process receives a shutdown signal (SIGTERM or SIGINT).
+///
+/// Returns as soon as either signal fires. Callers should then trigger
+/// cooperative cancellation on all tracked tasks.
+pub async fn wait_for_shutdown_signal() {
+    let sigterm = sigterm();
+
+    tokio::select! {
+        _ = sigterm => {
+            tracing::info!("received SIGTERM — initiating graceful shutdown");
+        }
+    }
+}
+
+/// Returns a future that resolves on the first SIGTERM.
+///
+/// On non-Unix platforms this future never resolves (SIGTERM is Unix-only).
+async fn sigterm() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut stream = signal(SignalKind::terminate())
+            .expect("failed to install SIGTERM handler");
+        stream.recv().await;
+    }
+    #[cfg(not(unix))]
+    {
+        std::future::pending::<()>().await
+    }
+}
+```
+
+- [ ] **Step 2: Verify workspace compiles**
+
+```bash
+cargo build -p aa-runtime
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-runtime/src/lifecycle.rs
+git commit -m "✨ (aa-runtime/lifecycle): Add SIGTERM handler inside shutdown signal listener"
+```
+
+---
+
+## Task 16: Add SIGINT handler to `wait_for_shutdown_signal()`
+
+**Files:**
+- Modify: `aa-runtime/src/lifecycle.rs`
+
+- [ ] **Step 1: Add SIGINT branch to the `select!`**
+
+```rust
+//! Signal handling and graceful shutdown coordination.
+
+/// Waits until the process receives a shutdown signal (SIGTERM or SIGINT).
+///
+/// Returns as soon as either signal fires. Callers should then trigger
+/// cooperative cancellation on all tracked tasks.
+pub async fn wait_for_shutdown_signal() {
+    let sigterm = sigterm();
+    let sigint = tokio::signal::ctrl_c();
+
+    tokio::select! {
+        _ = sigterm => {
+            tracing::info!("received SIGTERM — initiating graceful shutdown");
+        }
+        result = sigint => {
+            match result {
+                Ok(()) => tracing::info!("received SIGINT (Ctrl-C) — initiating graceful shutdown"),
+                Err(e) => tracing::error!("SIGINT handler error: {e}"),
+            }
+        }
+    }
+}
+
+/// Returns a future that resolves on the first SIGTERM.
+///
+/// On non-Unix platforms this future never resolves (SIGTERM is Unix-only).
+async fn sigterm() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let mut stream = signal(SignalKind::terminate())
+            .expect("failed to install SIGTERM handler");
+        stream.recv().await;
+    }
+    #[cfg(not(unix))]
+    {
+        std::future::pending::<()>().await
+    }
+}
+```
+
+- [ ] **Step 2: Verify workspace compiles**
+
+```bash
+cargo build -p aa-runtime
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-runtime/src/lifecycle.rs
+git commit -m "✨ (aa-runtime/lifecycle): Add SIGINT handler inside shutdown signal listener"
+```
+
+---
+
+## Task 17: Add `run()` async function skeleton in `runtime.rs`
+
+**Files:**
+- Modify: `aa-runtime/src/runtime.rs`
+
+- [ ] **Step 1: Add the skeleton**
+
+```rust
+//! Tokio runtime initialisation and structured task lifecycle management.
+
+use crate::config::RuntimeConfig;
+
+/// Start the runtime and block until graceful shutdown completes.
+///
+/// This is the main async entry point called from `main()`. It creates the
+/// structured concurrency primitives, spawns subsystem tasks, waits for a
+/// shutdown signal, then drains all tasks within the configured timeout.
+pub async fn run(_config: RuntimeConfig) {
+    tracing::info!("aa-runtime starting");
+    tracing::info!("aa-runtime stopped");
+}
+```
+
+- [ ] **Step 2: Re-export `run` from `lib.rs`**
+
+Add `pub use runtime::run;` to `lib.rs`:
+
+```rust
+//! Tokio async runtime wrapper and agent lifecycle management.
+//!
+//! This crate wraps `tokio` to provide a consistent async execution environment
+//! for Agent Assembly components. It handles runtime initialization, shutdown
+//! coordination, and lifecycle hooks.
+
+pub mod config;
+pub mod health;
+pub mod ipc;
+pub mod lifecycle;
+pub mod pipeline;
+pub mod runtime;
+
+pub use runtime::run;
+```
+
+- [ ] **Step 3: Verify workspace compiles**
+
+```bash
+cargo build -p aa-runtime
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add aa-runtime/src/runtime.rs aa-runtime/src/lib.rs
+git commit -m "✨ (aa-runtime/runtime): Add run() async function skeleton"
+```
+
+---
+
+## Task 18: Add `TaskTracker` and `CancellationToken` init in `run()`
+
+**Files:**
+- Modify: `aa-runtime/src/runtime.rs`
+
+- [ ] **Step 1: Wire in the structured concurrency primitives**
+
+```rust
+//! Tokio runtime initialisation and structured task lifecycle management.
+
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+
+use crate::config::RuntimeConfig;
+
+/// Start the runtime and block until graceful shutdown completes.
+///
+/// This is the main async entry point called from `main()`. It creates the
+/// structured concurrency primitives, spawns subsystem tasks, waits for a
+/// shutdown signal, then drains all tasks within the configured timeout.
+pub async fn run(_config: RuntimeConfig) {
+    tracing::info!("aa-runtime starting");
+
+    let tracker = TaskTracker::new();
+    let token = CancellationToken::new();
+
+    tracing::info!(
+        tasks = tracker.len(),
+        "structured concurrency primitives initialised"
+    );
+
+    // Shutdown sequence added in the next task.
+    drop(token);
+    tracker.close();
+    tracker.wait().await;
+
+    tracing::info!("aa-runtime stopped");
+}
+```
+
+- [ ] **Step 2: Verify workspace compiles**
+
+```bash
+cargo build -p aa-runtime
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-runtime/src/runtime.rs
+git commit -m "✨ (aa-runtime/runtime): Add TaskTracker and CancellationToken init in run()"
+```
+
+---
+
+## Task 19: Add graceful shutdown sequence with timeout in `run()`
+
+**Files:**
+- Modify: `aa-runtime/src/runtime.rs`
+
+- [ ] **Step 1: Implement the full shutdown sequence**
+
+```rust
+//! Tokio runtime initialisation and structured task lifecycle management.
+
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
+
+use crate::config::RuntimeConfig;
+use crate::lifecycle::wait_for_shutdown_signal;
+
+/// Start the runtime and block until graceful shutdown completes.
+///
+/// This is the main async entry point called from `main()`. It creates the
+/// structured concurrency primitives, spawns subsystem tasks, waits for a
+/// shutdown signal, then drains all tasks within the configured timeout.
+pub async fn run(config: RuntimeConfig) {
+    tracing::info!("aa-runtime starting");
+
+    let tracker = TaskTracker::new();
+    let token = CancellationToken::new();
+
+    tracing::info!("structured concurrency primitives initialised");
+
+    // Subsystem tasks (ipc, pipeline, health) are spawned here in later tickets.
+    // Each receives a cloned `token` and a `tracker.token()` guard.
+
+    // Wait for an OS shutdown signal.
+    wait_for_shutdown_signal().await;
+
+    // Signal all tasks to stop cooperatively.
+    token.cancel();
+    tracing::info!("cancellation token fired — draining tasks");
+
+    // Stop accepting new task registrations.
+    tracker.close();
+
+    // Wait for all tasks to complete, with a hard timeout.
+    let timeout = Duration::from_secs(config.shutdown_timeout_secs);
+    if tokio::time::timeout(timeout, tracker.wait()).await.is_err() {
+        tracing::error!(
+            timeout_secs = config.shutdown_timeout_secs,
+            "shutdown timeout exceeded — forcing exit"
+        );
+    } else {
+        tracing::info!("all tasks completed cleanly");
+    }
+
+    tracing::info!("aa-runtime stopped");
+}
+```
+
+- [ ] **Step 2: Verify workspace compiles**
+
+```bash
+cargo build -p aa-runtime
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-runtime/src/runtime.rs
+git commit -m "✨ (aa-runtime/runtime): Add graceful shutdown sequence with timeout in run()"
+```
+
+---
+
+## Task 20: Wire manual Tokio runtime entry with configurable `worker_threads`
+
+**Files:**
+- Modify: `aa-runtime/src/main.rs`
+
+- [ ] **Step 1: Replace the stub with a manual runtime builder**
+
+Using `#[tokio::main]` and then calling `Builder::new_multi_thread().build()` inside it would panic
+("Cannot start a runtime from within a runtime"). The correct approach is a plain sync `fn main()`
+that always builds the runtime manually:
+
+```rust
+//! `aa-runtime` sidecar binary entry point.
+
+fn main() {
+    let config = aa_runtime::config::RuntimeConfig::from_env();
+
+    // Build the Tokio multi-thread runtime.
+    // When worker_threads == 0, Builder uses one thread per logical CPU (Tokio default).
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.enable_all();
+
+    if config.worker_threads > 0 {
+        builder.worker_threads(config.worker_threads);
+    }
+
+    builder
+        .build()
+        .expect("failed to build Tokio runtime")
+        .block_on(aa_runtime::run(config));
+}
+```
+
+- [ ] **Step 2: Verify binary builds and runs**
+
+```bash
+cargo build -p aa-runtime --bins
+./target/debug/aa-runtime &
+sleep 1
+kill -TERM $!
+wait $!
+```
+
+Expected: process starts, logs startup, then logs graceful shutdown after SIGTERM.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-runtime/src/main.rs
+git commit -m "✨ (aa-runtime): Wire manual Tokio runtime entry with configurable worker_threads"
+```
+
+---
+
+## Task 21: Initialize tracing JSON subscriber in `main`
+
+**Files:**
+- Modify: `aa-runtime/src/main.rs`
+
+- [ ] **Step 1: Add `init_tracing()` and call it first in `main()`**
+
+Tracing must be initialised before any async work (and before the runtime is built), so it lives
+in the sync portion of `main()`:
+
+```rust
+//! `aa-runtime` sidecar binary entry point.
+
+fn init_tracing() {
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+    tracing_subscriber::registry()
+        .with(EnvFilter::from_default_env())
+        .with(fmt::layer().json())
+        .init();
+}
+
+fn main() {
+    init_tracing();
+
+    let config = aa_runtime::config::RuntimeConfig::from_env();
+
+    tracing::info!(
+        worker_threads = config.worker_threads,
+        shutdown_timeout_secs = config.shutdown_timeout_secs,
+        "configuration loaded"
+    );
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.enable_all();
+
+    if config.worker_threads > 0 {
+        builder.worker_threads(config.worker_threads);
+    }
+
+    builder
+        .build()
+        .expect("failed to build Tokio runtime")
+        .block_on(aa_runtime::run(config));
+}
+```
+
+- [ ] **Step 2: Verify binary builds and emits JSON logs**
+
+```bash
+cargo build -p aa-runtime --bins
+RUST_LOG=info ./target/debug/aa-runtime &
+PID=$!
+sleep 1
+kill -TERM $PID
+wait $PID
+```
+
+Expected: JSON log lines like `{"timestamp":"...","level":"INFO","message":"configuration loaded",...}` then shutdown logs, then process exits 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-runtime/src/main.rs
+git commit -m "✨ (aa-runtime): Initialize tracing JSON subscriber in main"
+```
+
+---
+
+## Task 22: Add unit tests for `RuntimeConfig::from_env()`
+
+**Files:**
+- Modify: `aa-runtime/src/config.rs`
+
+- [ ] **Step 1: Add tests module at the bottom of `config.rs`**
+
+Append to the end of `aa-runtime/src/config.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_when_env_vars_absent() {
+        // Ensure neither var is set for this test.
+        std::env::remove_var("AA_RUNTIME_WORKER_THREADS");
+        std::env::remove_var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS");
+
+        let config = RuntimeConfig::from_env();
+
+        assert_eq!(config.worker_threads, 0);
+        assert_eq!(config.shutdown_timeout_secs, 30);
+    }
+
+    #[test]
+    fn reads_worker_threads_from_env() {
+        std::env::set_var("AA_RUNTIME_WORKER_THREADS", "4");
+        std::env::remove_var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS");
+
+        let config = RuntimeConfig::from_env();
+
+        assert_eq!(config.worker_threads, 4);
+        assert_eq!(config.shutdown_timeout_secs, 30);
+
+        std::env::remove_var("AA_RUNTIME_WORKER_THREADS");
+    }
+
+    #[test]
+    fn reads_shutdown_timeout_from_env() {
+        std::env::remove_var("AA_RUNTIME_WORKER_THREADS");
+        std::env::set_var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS", "60");
+
+        let config = RuntimeConfig::from_env();
+
+        assert_eq!(config.worker_threads, 0);
+        assert_eq!(config.shutdown_timeout_secs, 60);
+
+        std::env::remove_var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS");
+    }
+
+    #[test]
+    fn falls_back_to_default_on_invalid_value() {
+        std::env::set_var("AA_RUNTIME_WORKER_THREADS", "not-a-number");
+        std::env::set_var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS", "abc");
+
+        let config = RuntimeConfig::from_env();
+
+        assert_eq!(config.worker_threads, 0);
+        assert_eq!(config.shutdown_timeout_secs, 30);
+
+        std::env::remove_var("AA_RUNTIME_WORKER_THREADS");
+        std::env::remove_var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cargo nextest run -p aa-runtime --test-threads=1
+```
+
+The `--test-threads=1` flag is important — these tests mutate environment variables and must not run concurrently.
+
+Expected: 4 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-runtime/src/config.rs
+git commit -m "✅ (aa-runtime/config): Add unit tests for RuntimeConfig::from_env()"
+```
+
+---
+
+## Task 23: Add integration test for graceful shutdown under synthetic load
+
+**Files:**
+- Modify: `aa-runtime/src/runtime.rs`
+
+- [ ] **Step 1: Add integration test module at the bottom of `runtime.rs`**
+
+Append to the end of `aa-runtime/src/runtime.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio_util::sync::CancellationToken;
+    use tokio_util::task::TaskTracker;
+
+    /// Verifies the structured concurrency primitives drain cleanly under load.
+    ///
+    /// Spawns N tasks that loop until the cancellation token fires, then
+    /// cancels the token and asserts all tasks complete within the timeout.
+    #[tokio::test]
+    async fn graceful_shutdown_drains_all_tasks() {
+        const TASK_COUNT: usize = 10;
+        const TIMEOUT: Duration = Duration::from_secs(5);
+
+        let tracker = TaskTracker::new();
+        let token = CancellationToken::new();
+
+        // Spawn synthetic load tasks that honor the cancellation token.
+        for i in 0..TASK_COUNT {
+            let child_token = token.clone();
+            tracker.spawn(async move {
+                loop {
+                    tokio::select! {
+                        _ = child_token.cancelled() => {
+                            break;
+                        }
+                        _ = tokio::time::sleep(Duration::from_millis(10)) => {
+                            // Simulate work.
+                        }
+                    }
+                }
+                tracing::debug!(task = i, "task completed cleanly");
+            });
+        }
+
+        // Trigger shutdown.
+        token.cancel();
+        tracker.close();
+
+        // All tasks must complete within the timeout — no leaks.
+        tokio::time::timeout(TIMEOUT, tracker.wait())
+            .await
+            .expect("tasks did not complete within timeout");
+    }
+
+    /// Verifies that shutdown timeout enforcement works when tasks ignore cancellation.
+    #[tokio::test]
+    async fn shutdown_timeout_fires_when_tasks_hang() {
+        let tracker = TaskTracker::new();
+        let token = CancellationToken::new();
+
+        // Spawn a task that ignores cancellation and sleeps forever.
+        tracker.spawn(async move {
+            let _token = token; // hold token to prevent drop-based cancellation
+            tokio::time::sleep(Duration::from_secs(3600)).await;
+        });
+
+        tracker.close();
+
+        // Drain with a very short timeout — must expire.
+        let result = tokio::time::timeout(Duration::from_millis(100), tracker.wait()).await;
+        assert!(result.is_err(), "expected timeout but tasks completed");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cargo nextest run -p aa-runtime
+```
+
+Expected: both tests pass. `graceful_shutdown_drains_all_tasks` completes well within 5 seconds. `shutdown_timeout_fires_when_tasks_hang` completes in ~100ms.
+
+- [ ] **Step 3: Run `cargo clippy` to catch any lint issues**
+
+```bash
+cargo clippy -p aa-runtime --all-targets -- -D warnings
+```
+
+Expected: no warnings.
+
+- [ ] **Step 4: Run `cargo fmt` to ensure formatting**
+
+```bash
+cargo fmt -p aa-runtime -- --check
+```
+
+Expected: no diff.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aa-runtime/src/runtime.rs
+git commit -m "✅ (aa-runtime/runtime): Add integration test for graceful shutdown under synthetic load"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Run the full workspace test suite**
+
+```bash
+cargo nextest run --workspace --test-threads=1
+```
+
+Expected: all tests pass across all workspace crates.
+
+- [ ] **Run full clippy**
+
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Expected: zero warnings.
+
+- [ ] **Run full fmt check**
+
+```bash
+cargo fmt --all -- --check
+```
+
+Expected: no diff.
+
+- [ ] **Smoke-test the binary with SIGINT**
+
+```bash
+RUST_LOG=info cargo run -p aa-runtime &
+PID=$!
+sleep 1
+kill -INT $PID
+wait $PID
+echo "Exit code: $?"
+```
+
+Expected: JSON log lines showing startup → SIGINT received → shutdown → `aa-runtime stopped`. Exit code `0`.
+
+---
+
+## PR
+
+Once all tasks are complete and CI is green:
+
+**Branch:** `v0.0.1/AAASM-29/tokio_runtime_init`
+**PR title:** `[AAASM-29] ✨ (aa-runtime): Bootstrap Tokio runtime init with graceful shutdown`
+**PR body:** follows `.github/PULL_REQUEST_TEMPLATE.md`

--- a/docs/superpowers/specs/2026-04-27-aaasm-29-tokio-runtime-init-design.md
+++ b/docs/superpowers/specs/2026-04-27-aaasm-29-tokio-runtime-init-design.md
@@ -1,0 +1,204 @@
+# AAASM-29: `aa-runtime` Bootstrap — Tokio Runtime Init & Graceful Shutdown Design Spec
+
+**Date:** 2026-04-27
+**Ticket:** [AAASM-29](https://lightning-dust-mite.atlassian.net/browse/AAASM-29)
+**Epic:** [AAASM-3](https://lightning-dust-mite.atlassian.net/browse/AAASM-3) — Async Sidecar Runtime
+**Branch:** `v0.0.1/AAASM-29/tokio_runtime_init`
+
+---
+
+## Purpose
+
+Bootstrap the `aa-runtime` crate as a Tokio-based binary with structured concurrency, configurable
+runtime parameters, and graceful shutdown handling. This is the foundation (F6) upon which the
+IPC server (AAASM-30), event pipeline (AAASM-31), health endpoint (AAASM-32), and Docker image
+(AAASM-33) are all built. It also establishes the full epic module layout as stubs so subsequent
+tickets slot in cleanly.
+
+---
+
+## Scope
+
+### In scope
+
+- `aa-runtime/Cargo.toml` — add `tokio-util`, `tracing`, `tracing-subscriber` dependencies
+- `aa-runtime/src/lib.rs` — module declarations + public re-export of `run()`
+- `aa-runtime/src/main.rs` — binary entry point: `#[tokio::main]`, tracing init, calls `run()`
+- `aa-runtime/src/config.rs` — `RuntimeConfig` struct, `from_env()` constructor
+- `aa-runtime/src/runtime.rs` — `async fn run()`: `TaskTracker` + `CancellationToken` lifecycle
+- `aa-runtime/src/lifecycle.rs` — `wait_for_shutdown_signal()`: SIGTERM + SIGINT via `tokio::signal`
+- `aa-runtime/src/ipc/mod.rs` — empty stub (for AAASM-30)
+- `aa-runtime/src/pipeline/mod.rs` — empty stub (for AAASM-31)
+- `aa-runtime/src/health.rs` — empty stub (for AAASM-32)
+
+### Out of scope
+
+- IPC server implementation (AAASM-30)
+- Event aggregation pipeline (AAASM-31)
+- Health check / metrics HTTP server (AAASM-32)
+- Docker image (AAASM-33)
+- Any changes outside `aa-runtime/`
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  main.rs                                                    │
+│  #[tokio::main(worker_threads = N)]                         │
+│  - init_tracing()                                           │
+│  - RuntimeConfig::from_env()                                │
+│  - aa_runtime::run(config).await                            │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────────────────┐
+│  runtime.rs  async fn run(config: RuntimeConfig)            │
+│  - TaskTracker::new()                                        │
+│  - CancellationToken::new()                                  │
+│  - (future: spawn ipc, pipeline, health via tracker)        │
+│  - lifecycle::wait_for_shutdown_signal().await               │
+│  - token.cancel()                                           │
+│  - tracker.close() + timeout wait                           │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+       ┌───────────────┼───────────────┐
+       ▼               ▼               ▼
+  lifecycle.rs      ipc/mod.rs    pipeline/mod.rs   health.rs
+  (SIGTERM/SIGINT)  (stub→AAASM-30) (stub→AAASM-31) (stub→AAASM-32)
+```
+
+---
+
+## Design Decisions
+
+### Structured concurrency via `TaskTracker` + `CancellationToken`
+
+Three options evaluated:
+
+| Option | Description | Decision |
+|--------|-------------|----------|
+| **A — `TaskTracker` + `CancellationToken`** | `tokio-util` tracker closes after all tasks complete; token propagates cancellation | **Selected** |
+| B — `JoinSet` | tokio built-in, no extra dep | Rejected — no cooperative cancellation; tasks must be aborted, not drained |
+| C — raw `Arc<AtomicBool>` shutdown flag | No extra dep, simple | Rejected — no structured tracking; fire-and-forget risk |
+
+**Rationale:** Ticket explicitly requires `TaskTracker` + `CancellationToken`. All spawned tasks receive a cloned token and must check `token.cancelled()` at yield points. This prevents premature process exit during in-flight event drain.
+
+### Signal handling via `tokio::signal`
+
+`tokio::signal` is already included via `features = ["full"]`. No new dependency needed.
+`wait_for_shutdown_signal()` races SIGTERM (`unix::signal`) and SIGINT (`ctrl_c`) using `tokio::select!`.
+On Windows, only `ctrl_c` is available — `#[cfg(unix)]` guards the SIGTERM branch.
+
+### `RuntimeConfig` loaded from environment
+
+`RuntimeConfig::from_env()` reads env vars with typed defaults:
+- `AA_RUNTIME_WORKER_THREADS` → `usize`, default: `num_cpus` (tokio default)
+- `AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS` → `u64`, default: `30`
+
+No CLI arg parser needed for this ticket. Config is a plain struct, fully testable without env side effects.
+
+### Tracing init in `main.rs`, not in `run()`
+
+`tracing-subscriber` global subscriber must be initialised exactly once, before any async work.
+Placing it in `main()` (sync) avoids races and keeps `run()` free of global state side effects.
+`RUST_LOG` env var is honoured by the `EnvFilter` layer.
+
+---
+
+## New Dependencies
+
+```toml
+# aa-runtime/Cargo.toml additions
+tokio-util         = { version = "0.7", features = ["rt"] }
+tracing            = "0.1"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
+```
+
+---
+
+## File Map
+
+| File | Status | Responsibility |
+|------|--------|----------------|
+| `aa-runtime/Cargo.toml` | Modify | Add 3 new dependencies |
+| `aa-runtime/src/lib.rs` | Modify | Module declarations + `pub use runtime::run` |
+| `aa-runtime/src/main.rs` | Create | Binary entry: tracing init + `run()` call |
+| `aa-runtime/src/config.rs` | Create | `RuntimeConfig` struct + `from_env()` |
+| `aa-runtime/src/runtime.rs` | Create | `async fn run()`: structured concurrency + shutdown |
+| `aa-runtime/src/lifecycle.rs` | Create | `wait_for_shutdown_signal()`: SIGTERM + SIGINT |
+| `aa-runtime/src/ipc/mod.rs` | Create | Empty stub for AAASM-30 |
+| `aa-runtime/src/pipeline/mod.rs` | Create | Empty stub for AAASM-31 |
+| `aa-runtime/src/health.rs` | Create | Empty stub for AAASM-32 |
+
+---
+
+## Commit Plan (23 atomic commits)
+
+### Phase 1 — Dependencies
+
+| # | Commit | File change |
+|---|--------|-------------|
+| 1 | `🔧 (aa-runtime): Add tokio-util dependency with rt feature` | `Cargo.toml` |
+| 2 | `🔧 (aa-runtime): Add tracing dependency` | `Cargo.toml` |
+| 3 | `🔧 (aa-runtime): Add tracing-subscriber with json and env-filter features` | `Cargo.toml` |
+
+### Phase 2 — Module scaffolding
+
+| # | Commit | File change |
+|---|--------|-------------|
+| 4 | `✨ (aa-runtime): Add config module declaration to lib.rs` | `lib.rs` + empty `config.rs` |
+| 5 | `✨ (aa-runtime): Add runtime module declaration to lib.rs` | `lib.rs` + empty `runtime.rs` |
+| 6 | `✨ (aa-runtime): Add lifecycle module declaration to lib.rs` | `lib.rs` + empty `lifecycle.rs` |
+| 7 | `✨ (aa-runtime): Add ipc stub module for AAASM-30` | `lib.rs` + `ipc/mod.rs` |
+| 8 | `✨ (aa-runtime): Add pipeline stub module for AAASM-31` | `lib.rs` + `pipeline/mod.rs` |
+| 9 | `✨ (aa-runtime): Add health stub module for AAASM-32` | `lib.rs` + `health.rs` |
+| 10 | `✨ (aa-runtime): Add main.rs binary entry point stub` | `main.rs` |
+
+### Phase 3 — `RuntimeConfig`
+
+| # | Commit | File change |
+|---|--------|-------------|
+| 11 | `✨ (aa-runtime/config): Add RuntimeConfig struct with worker_threads field` | `config.rs` |
+| 12 | `✨ (aa-runtime/config): Add shutdown_timeout_secs field to RuntimeConfig` | `config.rs` |
+| 13 | `✨ (aa-runtime/config): Add RuntimeConfig::from_env() constructor` | `config.rs` |
+
+### Phase 4 — `lifecycle.rs`
+
+| # | Commit | File change |
+|---|--------|-------------|
+| 14 | `✨ (aa-runtime/lifecycle): Add wait_for_shutdown_signal() async function` | `lifecycle.rs` |
+| 15 | `✨ (aa-runtime/lifecycle): Add SIGTERM handler inside shutdown signal listener` | `lifecycle.rs` |
+| 16 | `✨ (aa-runtime/lifecycle): Add SIGINT handler inside shutdown signal listener` | `lifecycle.rs` |
+
+### Phase 5 — `runtime.rs`
+
+| # | Commit | File change |
+|---|--------|-------------|
+| 17 | `✨ (aa-runtime/runtime): Add run() async function skeleton` | `runtime.rs` |
+| 18 | `✨ (aa-runtime/runtime): Add TaskTracker and CancellationToken init in run()` | `runtime.rs` |
+| 19 | `✨ (aa-runtime/runtime): Add graceful shutdown sequence with timeout in run()` | `runtime.rs` |
+
+### Phase 6 — `main.rs` wiring
+
+| # | Commit | File change |
+|---|--------|-------------|
+| 20 | `✨ (aa-runtime): Wire tokio::main entry with configurable worker_threads` | `main.rs` |
+| 21 | `✨ (aa-runtime): Initialize tracing JSON subscriber in main` | `main.rs` |
+
+### Phase 7 — Tests
+
+| # | Commit | File change |
+|---|--------|-------------|
+| 22 | `✅ (aa-runtime/config): Add unit tests for RuntimeConfig::from_env()` | `config.rs` |
+| 23 | `✅ (aa-runtime/runtime): Add integration test for graceful shutdown under synthetic load` | `runtime.rs` |
+
+---
+
+## Acceptance Criteria (from ticket)
+
+- [ ] Runtime starts and logs all component initialization
+- [ ] SIGTERM triggers graceful shutdown completing within timeout
+- [ ] All spawned tasks complete before process exits
+- [ ] Zero panics on normal and graceful shutdown paths
+- [ ] Integration test verifies graceful shutdown under synthetic load


### PR DESCRIPTION
## Description

Implements the Tokio async runtime foundation for the `aa-runtime` sidecar binary (AAASM-29). This PR scaffolds the full module structure for the `aa-runtime` crate and delivers the Tokio runtime initialization, structured concurrency primitives, graceful shutdown sequence, and environment-based configuration.

Key changes:
- `main.rs`: Plain `fn main()` with `Builder::new_multi_thread()` (avoids nested runtime panic), JSON tracing subscriber initialized via `EnvFilter::from_default_env()`
- `config.rs`: `RuntimeConfig` loaded from `AA_RUNTIME_WORKER_THREADS` and `AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS` env vars with safe defaults
- `lifecycle.rs`: `wait_for_shutdown_signal()` races SIGTERM (Unix only) and SIGINT (Ctrl-C) via `tokio::select!`
- `runtime.rs`: `run()` creates `TaskTracker` + `CancellationToken`, waits for signal, fires cancellation, drains tasks with configurable hard timeout
- Stub modules: `ipc/`, `pipeline/`, `health` (implemented in AAASM-30/31/32)

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-29 (child of AAASM-3)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

Tests added:
- `config::tests` (4 unit tests): defaults, worker threads from env, shutdown timeout from env, fallback on invalid value
- `runtime::tests::graceful_shutdown_drains_all_tasks`: spawns 10 synthetic tasks that honor cancellation, verifies all drain within 5s
- `runtime::tests::shutdown_timeout_fires_when_tasks_hang`: spawns a task that ignores cancellation, verifies 100ms timeout fires

All 6 tests pass: `cargo test -p aa-runtime -- --test-threads=1`

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention