### PR TITLE
[AAASM-42] ✨ tls: Implement CA certificate provisioning for macOS proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,9 @@ dependencies = [
  "lru",
  "rcgen",
  "rustls",
+ "tempfile",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -199,6 +201,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -507,6 +548,26 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "der-parser"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -1232,6 +1293,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1316,6 +1383,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1325,10 +1402,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_enum"
@@ -1350,6 +1455,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -1751,6 +1865,7 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "time",
+ "x509-parser",
  "yasna",
 ]
 
@@ -1885,6 +2000,15 @@ name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "rustix"
@@ -2244,10 +2368,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -2255,6 +2381,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -3108,6 +3244,24 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x509-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 1.0.69",
+ "time",
+]
 
 [[package]]
 name = "yasna"

--- a/aa-proxy/Cargo.toml
+++ b/aa-proxy/Cargo.toml
@@ -21,7 +21,7 @@ hyper      = { version = "1", features = ["server", "http1"] }
 hyper-util   = { version = "0.1", features = ["tokio", "server"] }
 rustls       = { version = "0.23", features = ["ring"] }
 tokio-rustls = "0.26"
-rcgen        = "0.13"
+rcgen        = { version = "0.13", features = ["x509-parser"] }
 time         = "0.3"
 lru          = "0.16"
 anyhow       = "1"

--- a/aa-proxy/Cargo.toml
+++ b/aa-proxy/Cargo.toml
@@ -31,3 +31,6 @@ tracing-subscriber  = { version = "0.3", features = ["env-filter"] }
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/aa-proxy/Cargo.toml
+++ b/aa-proxy/Cargo.toml
@@ -22,6 +22,7 @@ hyper-util   = { version = "0.1", features = ["tokio", "server"] }
 rustls       = { version = "0.23", features = ["ring"] }
 tokio-rustls = "0.26"
 rcgen        = "0.13"
+time         = "0.3"
 lru          = "0.16"
 anyhow       = "1"
 thiserror    = "2"

--- a/aa-proxy/src/error.rs
+++ b/aa-proxy/src/error.rs
@@ -20,4 +20,8 @@ pub enum ProxyError {
     /// A configuration error (missing or invalid env var).
     #[error("Configuration error: {0}")]
     Config(String),
+
+    /// A macOS Keychain operation failed (security CLI returned non-zero).
+    #[error("Keychain error: {0}")]
+    Keychain(String),
 }

--- a/aa-proxy/src/lib.rs
+++ b/aa-proxy/src/lib.rs
@@ -28,10 +28,19 @@ pub use error::ProxyError;
 
 /// Start the proxy with the given configuration.
 ///
-/// Loads or creates the CA from `config.ca_dir`, constructs a [`proxy::ProxyServer`],
+/// Loads or creates the CA from `config.ca_dir`, installs it into the macOS
+/// System Keychain if not already trusted, constructs a [`proxy::ProxyServer`],
 /// and enters the TCP accept loop. Returns only on unrecoverable error.
 pub async fn run(config: ProxyConfig) -> anyhow::Result<()> {
     let ca = tls::CaStore::load_or_create(&config.ca_dir).await?;
+
+    #[cfg(target_os = "macos")]
+    if !ca.is_installed()? {
+        tracing::info!("CA not yet trusted — installing into macOS System Keychain");
+        ca.install()?;
+        tracing::info!("CA installed successfully");
+    }
+
     let server = proxy::ProxyServer::new(config, ca);
     server.run().await?;
     Ok(())

--- a/aa-proxy/src/tls/ca.rs
+++ b/aa-proxy/src/tls/ca.rs
@@ -42,11 +42,18 @@ impl CaStore {
         let cert_path = ca_dir.join("ca-cert.pem");
         let key_path  = ca_dir.join("ca-key.pem");
 
-        // Load existing CA if both files are present.
-        if cert_path.exists() && key_path.exists() {
-            let ca_cert_pem = tokio::fs::read_to_string(&cert_path).await?;
-            let ca_key_pem  = tokio::fs::read_to_string(&key_path).await?;
-            return Ok(Self { ca_dir: ca_dir.to_path_buf(), ca_cert_pem, ca_key_pem });
+        // Attempt to load existing CA; fall through to generation only on NotFound.
+        match (
+            tokio::fs::read_to_string(&cert_path).await,
+            tokio::fs::read_to_string(&key_path).await,
+        ) {
+            (Ok(ca_cert_pem), Ok(ca_key_pem)) => {
+                return Ok(Self { ca_dir: ca_dir.to_path_buf(), ca_cert_pem, ca_key_pem });
+            }
+            (Err(e), _) | (_, Err(e)) if e.kind() == std::io::ErrorKind::NotFound => {
+                // fall through to generate
+            }
+            (Err(e), _) | (_, Err(e)) => return Err(ProxyError::Io(e)),
         }
 
         // Generate a new EC P-256 CA key pair.
@@ -58,9 +65,9 @@ impl CaStore {
         ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
         ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
         ca_params.distinguished_name.push(DnType::CommonName, "Agent Assembly CA");
-        ca_params.not_before = OffsetDateTime::now_utc();
-        ca_params.not_after  = OffsetDateTime::now_utc()
-            .checked_add(Duration::days(365 * 10))
+        let now = OffsetDateTime::now_utc();
+        ca_params.not_before = now;
+        ca_params.not_after  = now.checked_add(Duration::days(365 * 10))
             .expect("date arithmetic cannot overflow for 10-year span");
 
         let ca_cert     = ca_params.self_signed(&ca_key)
@@ -70,14 +77,31 @@ impl CaStore {
 
         // Persist to disk.
         tokio::fs::create_dir_all(ca_dir).await?;
-        tokio::fs::write(&cert_path, &ca_cert_pem).await?;
-        tokio::fs::write(&key_path,  &ca_key_pem).await?;
 
-        // Restrict key file to owner read/write only.
+        // Write the cert file (world-readable is fine for public cert).
+        tokio::fs::write(&cert_path, &ca_cert_pem).await?;
+
+        // Write the key file with restricted permissions from the start (mode 0o600).
         #[cfg(unix)]
         {
-            use std::os::unix::fs::PermissionsExt;
-            tokio::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600)).await?;
+            use std::os::unix::fs::OpenOptionsExt;
+            use std::io::Write;
+            let key_path_clone = key_path.clone();
+            let key_pem_bytes = ca_key_pem.as_bytes().to_vec();
+            tokio::task::spawn_blocking(move || {
+                let mut f = std::fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .mode(0o600)
+                    .open(&key_path_clone)?;
+                f.write_all(&key_pem_bytes)
+            })
+            .await
+            .map_err(|e| ProxyError::Io(std::io::Error::new(std::io::ErrorKind::Other, e)))??;
+        }
+        #[cfg(not(unix))]
+        {
+            tokio::fs::write(&key_path, &ca_key_pem).await?;
         }
 
         Ok(Self { ca_dir: ca_dir.to_path_buf(), ca_cert_pem, ca_key_pem })

--- a/aa-proxy/src/tls/ca.rs
+++ b/aa-proxy/src/tls/ca.rs
@@ -5,8 +5,8 @@
 
 use std::path::{Path, PathBuf};
 
-use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, KeyPair, KeyUsagePurpose};
 use rcgen::PKCS_ECDSA_P256_SHA256;
+use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, KeyPair, KeyUsagePurpose};
 use time::{Duration, OffsetDateTime};
 
 use crate::error::ProxyError;
@@ -40,7 +40,7 @@ impl CaStore {
     /// and persist it before returning.
     pub async fn load_or_create(ca_dir: &Path) -> Result<Self, ProxyError> {
         let cert_path = ca_dir.join("ca-cert.pem");
-        let key_path  = ca_dir.join("ca-key.pem");
+        let key_path = ca_dir.join("ca-key.pem");
 
         // Attempt to load existing CA; fall through to generation only on NotFound.
         match (
@@ -48,7 +48,11 @@ impl CaStore {
             tokio::fs::read_to_string(&key_path).await,
         ) {
             (Ok(ca_cert_pem), Ok(ca_key_pem)) => {
-                return Ok(Self { ca_dir: ca_dir.to_path_buf(), ca_cert_pem, ca_key_pem });
+                return Ok(Self {
+                    ca_dir: ca_dir.to_path_buf(),
+                    ca_cert_pem,
+                    ca_key_pem,
+                });
             }
             (Err(e), _) | (_, Err(e)) if e.kind() == std::io::ErrorKind::NotFound => {
                 // fall through to generate
@@ -57,23 +61,25 @@ impl CaStore {
         }
 
         // Generate a new EC P-256 CA key pair.
-        let ca_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)
-            .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+        let ca_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).map_err(|e| ProxyError::CertGen(e.to_string()))?;
 
-        let mut ca_params = CertificateParams::new(vec![])
-            .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+        let mut ca_params = CertificateParams::new(vec![]).map_err(|e| ProxyError::CertGen(e.to_string()))?;
         ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
         ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
-        ca_params.distinguished_name.push(DnType::CommonName, "Agent Assembly CA");
+        ca_params
+            .distinguished_name
+            .push(DnType::CommonName, "Agent Assembly CA");
         let now = OffsetDateTime::now_utc();
         ca_params.not_before = now;
-        ca_params.not_after  = now.checked_add(Duration::days(365 * 10))
+        ca_params.not_after = now
+            .checked_add(Duration::days(365 * 10))
             .expect("date arithmetic cannot overflow for 10-year span");
 
-        let ca_cert     = ca_params.self_signed(&ca_key)
+        let ca_cert = ca_params
+            .self_signed(&ca_key)
             .map_err(|e| ProxyError::CertGen(e.to_string()))?;
         let ca_cert_pem = ca_cert.pem();
-        let ca_key_pem  = ca_key.serialize_pem();
+        let ca_key_pem = ca_key.serialize_pem();
 
         // Persist to disk.
         tokio::fs::create_dir_all(ca_dir).await?;
@@ -84,8 +90,8 @@ impl CaStore {
         // Write the key file with restricted permissions from the start (mode 0o600).
         #[cfg(unix)]
         {
-            use std::os::unix::fs::OpenOptionsExt;
             use std::io::Write;
+            use std::os::unix::fs::OpenOptionsExt;
             let key_path_clone = key_path.clone();
             let key_pem_bytes = ca_key_pem.as_bytes().to_vec();
             tokio::task::spawn_blocking(move || {
@@ -104,7 +110,11 @@ impl CaStore {
             tokio::fs::write(&key_path, &ca_key_pem).await?;
         }
 
-        Ok(Self { ca_dir: ca_dir.to_path_buf(), ca_cert_pem, ca_key_pem })
+        Ok(Self {
+            ca_dir: ca_dir.to_path_buf(),
+            ca_cert_pem,
+            ca_key_pem,
+        })
     }
 
     /// Generate a DER-encoded leaf certificate for `domain`, signed by this CA.
@@ -112,21 +122,21 @@ impl CaStore {
         // Load the CA key and reconstruct the CA cert from the persisted PEM.
         // Using from_ca_cert_pem ensures the issued leaf cert's AKID matches
         // the SKID of the actual trusted CA cert in the system keychain.
-        let ca_key = KeyPair::from_pem(&self.ca_key_pem)
-            .map_err(|e| ProxyError::CertGen(e.to_string()))?;
-        let ca_params = CertificateParams::from_ca_cert_pem(&self.ca_cert_pem)
-            .map_err(|e| ProxyError::CertGen(e.to_string()))?;
-        let ca_cert = ca_params.self_signed(&ca_key)
+        let ca_key = KeyPair::from_pem(&self.ca_key_pem).map_err(|e| ProxyError::CertGen(e.to_string()))?;
+        let ca_params =
+            CertificateParams::from_ca_cert_pem(&self.ca_cert_pem).map_err(|e| ProxyError::CertGen(e.to_string()))?;
+        let ca_cert = ca_params
+            .self_signed(&ca_key)
             .map_err(|e| ProxyError::CertGen(e.to_string()))?;
 
         // Generate a fresh EC P-256 leaf key and cert for `domain`.
-        let leaf_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)
-            .map_err(|e| ProxyError::CertGen(e.to_string()))?;
-        let mut leaf_params = CertificateParams::new(vec![domain.to_string()])
-            .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+        let leaf_key =
+            KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).map_err(|e| ProxyError::CertGen(e.to_string()))?;
+        let mut leaf_params =
+            CertificateParams::new(vec![domain.to_string()]).map_err(|e| ProxyError::CertGen(e.to_string()))?;
         let now = OffsetDateTime::now_utc();
         leaf_params.not_before = now;
-        leaf_params.not_after  = now
+        leaf_params.not_after = now
             .checked_add(Duration::days(365))
             .expect("date arithmetic cannot overflow for 1-year span");
 
@@ -136,7 +146,7 @@ impl CaStore {
 
         Ok(CertifiedKey {
             cert_der: leaf_cert.der().to_vec(),
-            key_der:  leaf_key.serialize_der(),
+            key_der: leaf_key.serialize_der(),
         })
     }
 
@@ -192,9 +202,7 @@ mod tests {
         use std::os::unix::fs::PermissionsExt;
         let dir = TempDir::new().unwrap();
         CaStore::load_or_create(dir.path()).await.unwrap();
-        let perms = std::fs::metadata(dir.path().join("ca-key.pem"))
-            .unwrap()
-            .permissions();
+        let perms = std::fs::metadata(dir.path().join("ca-key.pem")).unwrap().permissions();
         assert_eq!(perms.mode() & 0o777, 0o600, "ca-key.pem must be owner-read-write only");
     }
 
@@ -221,7 +229,10 @@ mod tests {
         let ca = CaStore::load_or_create(dir.path()).await.unwrap();
         let ck1 = ca.sign_cert("api.openai.com").unwrap();
         let ck2 = ca.sign_cert("api.anthropic.com").unwrap();
-        assert_ne!(ck1.cert_der, ck2.cert_der, "different domains must produce different certs");
+        assert_ne!(
+            ck1.cert_der, ck2.cert_der,
+            "different domains must produce different certs"
+        );
     }
 
     #[tokio::test]

--- a/aa-proxy/src/tls/ca.rs
+++ b/aa-proxy/src/tls/ca.rs
@@ -97,7 +97,7 @@ impl CaStore {
                 f.write_all(&key_pem_bytes)
             })
             .await
-            .map_err(|e| ProxyError::Io(std::io::Error::new(std::io::ErrorKind::Other, e)))??;
+            .map_err(|e| ProxyError::Io(std::io::Error::other(e)))??;
         }
         #[cfg(not(unix))]
         {

--- a/aa-proxy/src/tls/ca.rs
+++ b/aa-proxy/src/tls/ca.rs
@@ -3,7 +3,11 @@
 //! The CA is generated once on first startup and persisted to `~/.aa/ca/`.
 //! All subsequent per-domain certificates are signed by this CA.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+
+use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, KeyPair, KeyUsagePurpose};
+use rcgen::PKCS_ECDSA_P256_SHA256;
+use time::{Duration, OffsetDateTime};
 
 use crate::error::ProxyError;
 
@@ -20,26 +24,128 @@ pub struct CertifiedKey {
 /// Holds the local CA certificate and key pair used to sign per-domain certs.
 ///
 /// The CA files on disk are:
-/// - `<ca_dir>/ca.crt` — PEM-encoded CA certificate
-/// - `<ca_dir>/ca.key` — PEM-encoded CA private key
-// Fields are read by sign_cert() once implemented; silence dead_code until then.
-#[allow(dead_code)]
+/// - `<ca_dir>/ca-cert.pem` — PEM-encoded CA certificate
+/// - `<ca_dir>/ca-key.pem`  — PEM-encoded CA private key (chmod 600)
 pub struct CaStore {
-    /// PEM bytes of the CA certificate.
-    ca_cert_pem: Vec<u8>,
-    /// PEM bytes of the CA private key.
-    ca_key_pem: Vec<u8>,
+    /// Directory where CA files are persisted.
+    pub(crate) ca_dir: PathBuf,
+    /// PEM-encoded CA certificate (used for signing and keychain install).
+    pub(crate) ca_cert_pem: String,
+    /// PEM-encoded CA private key (used for signing leaf certs).
+    pub(crate) ca_key_pem: String,
 }
 
 impl CaStore {
     /// Load the CA from `ca_dir` if it exists, or generate a new self-signed CA
     /// and persist it before returning.
-    pub async fn load_or_create(_ca_dir: &Path) -> Result<Self, ProxyError> {
-        todo!()
+    pub async fn load_or_create(ca_dir: &Path) -> Result<Self, ProxyError> {
+        let cert_path = ca_dir.join("ca-cert.pem");
+        let key_path  = ca_dir.join("ca-key.pem");
+
+        // Load existing CA if both files are present.
+        if cert_path.exists() && key_path.exists() {
+            let ca_cert_pem = tokio::fs::read_to_string(&cert_path).await?;
+            let ca_key_pem  = tokio::fs::read_to_string(&key_path).await?;
+            return Ok(Self { ca_dir: ca_dir.to_path_buf(), ca_cert_pem, ca_key_pem });
+        }
+
+        // Generate a new EC P-256 CA key pair.
+        let ca_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)
+            .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+
+        let mut ca_params = CertificateParams::new(vec![])
+            .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        ca_params.distinguished_name.push(DnType::CommonName, "Agent Assembly CA");
+        ca_params.not_before = OffsetDateTime::now_utc();
+        ca_params.not_after  = OffsetDateTime::now_utc()
+            .checked_add(Duration::days(365 * 10))
+            .expect("date arithmetic cannot overflow for 10-year span");
+
+        let ca_cert     = ca_params.self_signed(&ca_key)
+            .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+        let ca_cert_pem = ca_cert.pem();
+        let ca_key_pem  = ca_key.serialize_pem();
+
+        // Persist to disk.
+        tokio::fs::create_dir_all(ca_dir).await?;
+        tokio::fs::write(&cert_path, &ca_cert_pem).await?;
+        tokio::fs::write(&key_path,  &ca_key_pem).await?;
+
+        // Restrict key file to owner read/write only.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            tokio::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600)).await?;
+        }
+
+        Ok(Self { ca_dir: ca_dir.to_path_buf(), ca_cert_pem, ca_key_pem })
     }
 
     /// Generate a DER-encoded leaf certificate for `domain`, signed by this CA.
     pub fn sign_cert(&self, _domain: &str) -> Result<CertifiedKey, ProxyError> {
         todo!()
+    }
+
+    /// Install the CA certificate into the macOS System Keychain as a trusted root.
+    /// No-op if already installed.
+    #[cfg(target_os = "macos")]
+    pub fn install(&self) -> Result<(), ProxyError> {
+        todo!()
+    }
+
+    /// Return `true` if this CA is currently trusted by the macOS System Keychain.
+    #[cfg(target_os = "macos")]
+    pub fn is_installed(&self) -> Result<bool, ProxyError> {
+        todo!()
+    }
+
+    /// Remove this CA from the macOS System Keychain and delete `ca_dir` from disk.
+    #[cfg(target_os = "macos")]
+    pub fn uninstall(&self) -> Result<(), ProxyError> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn load_or_create_generates_pem_files() {
+        let dir = TempDir::new().unwrap();
+        CaStore::load_or_create(dir.path()).await.unwrap();
+        assert!(dir.path().join("ca-cert.pem").exists(), "ca-cert.pem missing");
+        assert!(dir.path().join("ca-key.pem").exists(), "ca-key.pem missing");
+    }
+
+    #[tokio::test]
+    async fn load_or_create_returns_valid_pem() {
+        let dir = TempDir::new().unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+        assert!(ca.ca_cert_pem.contains("-----BEGIN CERTIFICATE-----"));
+        assert!(ca.ca_key_pem.contains("-----BEGIN PRIVATE KEY-----"));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn load_or_create_key_file_is_chmod_600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        CaStore::load_or_create(dir.path()).await.unwrap();
+        let perms = std::fs::metadata(dir.path().join("ca-key.pem"))
+            .unwrap()
+            .permissions();
+        assert_eq!(perms.mode() & 0o777, 0o600, "ca-key.pem must be owner-read-write only");
+    }
+
+    #[tokio::test]
+    async fn load_or_create_reload_returns_same_cert() {
+        let dir = TempDir::new().unwrap();
+        let ca1 = CaStore::load_or_create(dir.path()).await.unwrap();
+        let ca2 = CaStore::load_or_create(dir.path()).await.unwrap();
+        assert_eq!(ca1.ca_cert_pem, ca2.ca_cert_pem, "reload must return identical cert");
     }
 }

--- a/aa-proxy/src/tls/ca.rs
+++ b/aa-proxy/src/tls/ca.rs
@@ -28,6 +28,8 @@ pub struct CertifiedKey {
 /// - `<ca_dir>/ca-key.pem`  — PEM-encoded CA private key (chmod 600)
 pub struct CaStore {
     /// Directory where CA files are persisted.
+    // Only read by macOS keychain methods; allow dead_code on other platforms.
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
     pub(crate) ca_dir: PathBuf,
     /// PEM-encoded CA certificate (used for signing and keychain install).
     pub(crate) ca_cert_pem: String,

--- a/aa-proxy/src/tls/ca.rs
+++ b/aa-proxy/src/tls/ca.rs
@@ -144,19 +144,24 @@ impl CaStore {
     /// No-op if already installed.
     #[cfg(target_os = "macos")]
     pub fn install(&self) -> Result<(), ProxyError> {
-        todo!()
+        if self.is_installed()? {
+            return Ok(()); // Already trusted — no-op.
+        }
+        super::keychain::add_trusted_cert(&self.ca_dir.join("ca-cert.pem"))
     }
 
     /// Return `true` if this CA is currently trusted by the macOS System Keychain.
     #[cfg(target_os = "macos")]
     pub fn is_installed(&self) -> Result<bool, ProxyError> {
-        todo!()
+        super::keychain::is_cert_trusted("Agent Assembly CA")
     }
 
     /// Remove this CA from the macOS System Keychain and delete `ca_dir` from disk.
     #[cfg(target_os = "macos")]
     pub fn uninstall(&self) -> Result<(), ProxyError> {
-        todo!()
+        super::keychain::remove_trusted_cert(&self.ca_dir.join("ca-cert.pem"))?;
+        std::fs::remove_dir_all(&self.ca_dir)?;
+        Ok(())
     }
 }
 
@@ -227,5 +232,58 @@ mod tests {
         let ck2 = ca.sign_cert("api.openai.com").unwrap();
         // sign_cert generates a fresh key each call; keys must differ
         assert_ne!(ck1.key_der, ck2.key_der, "each call generates a fresh key pair");
+    }
+}
+
+/// Integration tests for macOS Keychain operations.
+///
+/// These tests require:
+/// - macOS (System Keychain)
+/// - Admin privileges (macOS will prompt via GUI)
+///
+/// Run with: `cargo test -p aa-proxy -- --ignored keychain`
+#[cfg(all(test, target_os = "macos"))]
+mod keychain_tests {
+    use super::super::keychain;
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    #[ignore = "requires macOS System Keychain write access (admin auth prompt)"]
+    async fn install_makes_ca_trusted() {
+        let dir = TempDir::new().unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+        ca.install().unwrap();
+        assert!(ca.is_installed().unwrap(), "CA must be trusted after install");
+        // Cleanup: remove from keychain so test is idempotent.
+        keychain::remove_trusted_cert(&dir.path().join("ca-cert.pem")).unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore = "requires macOS System Keychain write access (admin auth prompt)"]
+    async fn uninstall_removes_ca_and_deletes_dir() {
+        let dir = TempDir::new().unwrap();
+        let dir_path = dir.path().to_path_buf();
+        let ca = CaStore::load_or_create(&dir_path).await.unwrap();
+        ca.install().unwrap();
+        assert!(ca.is_installed().unwrap());
+
+        ca.uninstall().unwrap();
+        assert!(!ca.is_installed().unwrap(), "CA must not be trusted after uninstall");
+        assert!(!dir_path.exists(), "ca_dir must be deleted after uninstall");
+        // TempDir will try to clean up, but the dir is already gone — that's fine.
+        std::mem::forget(dir);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires macOS System Keychain write access (admin auth prompt)"]
+    async fn install_is_idempotent() {
+        let dir = TempDir::new().unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+        ca.install().unwrap();
+        ca.install().unwrap(); // Second call must not fail.
+        assert!(ca.is_installed().unwrap());
+        // Cleanup.
+        keychain::remove_trusted_cert(&dir.path().join("ca-cert.pem")).unwrap();
     }
 }

--- a/aa-proxy/src/tls/ca.rs
+++ b/aa-proxy/src/tls/ca.rs
@@ -109,18 +109,13 @@ impl CaStore {
 
     /// Generate a DER-encoded leaf certificate for `domain`, signed by this CA.
     pub fn sign_cert(&self, domain: &str) -> Result<CertifiedKey, ProxyError> {
-        // Reconstruct the CA signing key from stored PEM.
+        // Load the CA key and reconstruct the CA cert from the persisted PEM.
+        // Using from_ca_cert_pem ensures the issued leaf cert's AKID matches
+        // the SKID of the actual trusted CA cert in the system keychain.
         let ca_key = KeyPair::from_pem(&self.ca_key_pem)
             .map_err(|e| ProxyError::CertGen(e.to_string()))?;
-
-        // Rebuild CA params from the same settings used in load_or_create so we
-        // can produce a signing-capable Certificate (rcgen 0.13 requires self_signed
-        // to obtain an issuer Certificate; from_ca_cert_pem requires x509-parser feature).
-        let mut ca_params = CertificateParams::new(vec![])
+        let ca_params = CertificateParams::from_ca_cert_pem(&self.ca_cert_pem)
             .map_err(|e| ProxyError::CertGen(e.to_string()))?;
-        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
-        ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
-        ca_params.distinguished_name.push(DnType::CommonName, "Agent Assembly CA");
         let ca_cert = ca_params.self_signed(&ca_key)
             .map_err(|e| ProxyError::CertGen(e.to_string()))?;
 

--- a/aa-proxy/src/tls/ca.rs
+++ b/aa-proxy/src/tls/ca.rs
@@ -108,8 +108,41 @@ impl CaStore {
     }
 
     /// Generate a DER-encoded leaf certificate for `domain`, signed by this CA.
-    pub fn sign_cert(&self, _domain: &str) -> Result<CertifiedKey, ProxyError> {
-        todo!()
+    pub fn sign_cert(&self, domain: &str) -> Result<CertifiedKey, ProxyError> {
+        // Reconstruct the CA signing key from stored PEM.
+        let ca_key = KeyPair::from_pem(&self.ca_key_pem)
+            .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+
+        // Rebuild CA params from the same settings used in load_or_create so we
+        // can produce a signing-capable Certificate (rcgen 0.13 requires self_signed
+        // to obtain an issuer Certificate; from_ca_cert_pem requires x509-parser feature).
+        let mut ca_params = CertificateParams::new(vec![])
+            .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+        ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+        ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+        ca_params.distinguished_name.push(DnType::CommonName, "Agent Assembly CA");
+        let ca_cert = ca_params.self_signed(&ca_key)
+            .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+
+        // Generate a fresh EC P-256 leaf key and cert for `domain`.
+        let leaf_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)
+            .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+        let mut leaf_params = CertificateParams::new(vec![domain.to_string()])
+            .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+        let now = OffsetDateTime::now_utc();
+        leaf_params.not_before = now;
+        leaf_params.not_after  = now
+            .checked_add(Duration::days(365))
+            .expect("date arithmetic cannot overflow for 1-year span");
+
+        let leaf_cert = leaf_params
+            .signed_by(&leaf_key, &ca_cert, &ca_key)
+            .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+
+        Ok(CertifiedKey {
+            cert_der: leaf_cert.der().to_vec(),
+            key_der:  leaf_key.serialize_der(),
+        })
     }
 
     /// Install the CA certificate into the macOS System Keychain as a trusted root.
@@ -171,5 +204,33 @@ mod tests {
         let ca1 = CaStore::load_or_create(dir.path()).await.unwrap();
         let ca2 = CaStore::load_or_create(dir.path()).await.unwrap();
         assert_eq!(ca1.ca_cert_pem, ca2.ca_cert_pem, "reload must return identical cert");
+    }
+
+    #[tokio::test]
+    async fn sign_cert_returns_non_empty_der() {
+        let dir = TempDir::new().unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+        let ck = ca.sign_cert("api.openai.com").unwrap();
+        assert!(!ck.cert_der.is_empty(), "cert DER must not be empty");
+        assert!(!ck.key_der.is_empty(), "key DER must not be empty");
+    }
+
+    #[tokio::test]
+    async fn sign_cert_different_domains_produce_different_certs() {
+        let dir = TempDir::new().unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+        let ck1 = ca.sign_cert("api.openai.com").unwrap();
+        let ck2 = ca.sign_cert("api.anthropic.com").unwrap();
+        assert_ne!(ck1.cert_der, ck2.cert_der, "different domains must produce different certs");
+    }
+
+    #[tokio::test]
+    async fn sign_cert_same_domain_produces_fresh_cert_each_call() {
+        let dir = TempDir::new().unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+        let ck1 = ca.sign_cert("api.openai.com").unwrap();
+        let ck2 = ca.sign_cert("api.openai.com").unwrap();
+        // sign_cert generates a fresh key each call; keys must differ
+        assert_ne!(ck1.key_der, ck2.key_der, "each call generates a fresh key pair");
     }
 }

--- a/aa-proxy/src/tls/cert.rs
+++ b/aa-proxy/src/tls/cert.rs
@@ -1,6 +1,6 @@
 //! LRU cache for dynamically generated per-domain TLS certificates.
 //!
-//! Generating a certificate with rcgen takes ~1–2 ms. This cache avoids
+//! Generating a certificate with rcgen takes ~0.1 ms. This cache avoids
 //! regenerating a cert for every connection to the same domain.
 
 use std::num::NonZeroUsize;
@@ -12,8 +12,6 @@ use crate::error::ProxyError;
 use crate::tls::ca::{CaStore, CertifiedKey};
 
 /// Thread-safe LRU cache mapping domain names to their signed [`CertifiedKey`].
-// Field is read by get_or_insert() once implemented; silence dead_code until then.
-#[allow(dead_code)]
 pub struct CertCache {
     inner: Mutex<LruCache<String, Arc<CertifiedKey>>>,
 }
@@ -34,7 +32,50 @@ impl CertCache {
 
     /// Return the cached [`CertifiedKey`] for `domain`, generating and inserting
     /// a new one (via `ca.sign_cert()`) if the domain is not in the cache.
-    pub fn get_or_insert(&self, _domain: &str, _ca: &CaStore) -> Result<Arc<CertifiedKey>, ProxyError> {
-        todo!()
+    pub fn get_or_insert(&self, domain: &str, ca: &CaStore) -> Result<Arc<CertifiedKey>, ProxyError> {
+        let mut cache = self.inner.lock().expect("cert cache lock poisoned");
+        if let Some(ck) = cache.get(domain) {
+            return Ok(Arc::clone(ck));
+        }
+        let ck = Arc::new(ca.sign_cert(domain)?);
+        cache.put(domain.to_string(), Arc::clone(&ck));
+        Ok(ck)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn get_or_insert_returns_cert_on_cache_miss() {
+        let dir = TempDir::new().unwrap();
+        let ca    = CaStore::load_or_create(dir.path()).await.unwrap();
+        let cache = CertCache::new(10);
+        let ck = cache.get_or_insert("api.openai.com", &ca).unwrap();
+        assert!(!ck.cert_der.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_or_insert_returns_same_arc_on_cache_hit() {
+        let dir = TempDir::new().unwrap();
+        let ca    = CaStore::load_or_create(dir.path()).await.unwrap();
+        let cache = CertCache::new(10);
+        let ck1 = cache.get_or_insert("api.openai.com", &ca).unwrap();
+        let ck2 = cache.get_or_insert("api.openai.com", &ca).unwrap();
+        // Identical Arc pointer proves cache hit — no re-signing occurred.
+        assert!(Arc::ptr_eq(&ck1, &ck2), "second call must return the cached Arc");
+    }
+
+    #[tokio::test]
+    async fn get_or_insert_different_domains_get_different_certs() {
+        let dir = TempDir::new().unwrap();
+        let ca    = CaStore::load_or_create(dir.path()).await.unwrap();
+        let cache = CertCache::new(10);
+        let ck1 = cache.get_or_insert("api.openai.com", &ca).unwrap();
+        let ck2 = cache.get_or_insert("api.anthropic.com", &ca).unwrap();
+        assert!(!Arc::ptr_eq(&ck1, &ck2));
+        assert_ne!(ck1.cert_der, ck2.cert_der);
     }
 }

--- a/aa-proxy/src/tls/cert.rs
+++ b/aa-proxy/src/tls/cert.rs
@@ -51,7 +51,7 @@ mod tests {
     #[tokio::test]
     async fn get_or_insert_returns_cert_on_cache_miss() {
         let dir = TempDir::new().unwrap();
-        let ca    = CaStore::load_or_create(dir.path()).await.unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
         let cache = CertCache::new(10);
         let ck = cache.get_or_insert("api.openai.com", &ca).unwrap();
         assert!(!ck.cert_der.is_empty());
@@ -60,7 +60,7 @@ mod tests {
     #[tokio::test]
     async fn get_or_insert_returns_same_arc_on_cache_hit() {
         let dir = TempDir::new().unwrap();
-        let ca    = CaStore::load_or_create(dir.path()).await.unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
         let cache = CertCache::new(10);
         let ck1 = cache.get_or_insert("api.openai.com", &ca).unwrap();
         let ck2 = cache.get_or_insert("api.openai.com", &ca).unwrap();
@@ -71,7 +71,7 @@ mod tests {
     #[tokio::test]
     async fn get_or_insert_different_domains_get_different_certs() {
         let dir = TempDir::new().unwrap();
-        let ca    = CaStore::load_or_create(dir.path()).await.unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
         let cache = CertCache::new(10);
         let ck1 = cache.get_or_insert("api.openai.com", &ca).unwrap();
         let ck2 = cache.get_or_insert("api.anthropic.com", &ca).unwrap();

--- a/aa-proxy/src/tls/keychain.rs
+++ b/aa-proxy/src/tls/keychain.rs
@@ -1,0 +1,38 @@
+//! macOS System Keychain operations for CA certificate trust management.
+//!
+//! All functions invoke the `security` CLI via `std::process::Command`.
+//! This entire module is macOS-only.
+
+use std::path::Path;
+
+use crate::error::ProxyError;
+
+/// Install the certificate at `cert_path` into the macOS System Keychain
+/// as a trusted root CA.
+///
+/// Invokes: `security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain <cert>`
+///
+/// Requires admin privileges — macOS prompts for authentication automatically.
+#[cfg(target_os = "macos")]
+pub(super) fn add_trusted_cert(_cert_path: &Path) -> Result<(), ProxyError> {
+    todo!()
+}
+
+/// Remove the certificate at `cert_path` from the macOS System Keychain trust.
+///
+/// Invokes: `security remove-trusted-cert -d <cert>`
+///
+/// Requires admin privileges — macOS prompts for authentication automatically.
+#[cfg(target_os = "macos")]
+pub(super) fn remove_trusted_cert(_cert_path: &Path) -> Result<(), ProxyError> {
+    todo!()
+}
+
+/// Return `true` if a certificate with common name `subject` exists in the
+/// macOS System Keychain.
+///
+/// Invokes: `security find-certificate -c <subject> -a /Library/Keychains/System.keychain`
+#[cfg(target_os = "macos")]
+pub(super) fn is_cert_trusted(_subject: &str) -> Result<bool, ProxyError> {
+    todo!()
+}

--- a/aa-proxy/src/tls/keychain.rs
+++ b/aa-proxy/src/tls/keychain.rs
@@ -24,8 +24,10 @@ pub(super) fn add_trusted_cert(cert_path: &Path) -> Result<(), ProxyError> {
         .args([
             "add-trusted-cert",
             "-d",
-            "-r", "trustRoot",
-            "-k", "/Library/Keychains/System.keychain",
+            "-r",
+            "trustRoot",
+            "-k",
+            "/Library/Keychains/System.keychain",
             cert_str,
         ])
         .output()
@@ -74,7 +76,8 @@ pub(super) fn is_cert_trusted(subject: &str) -> Result<bool, ProxyError> {
     let output = Command::new("security")
         .args([
             "find-certificate",
-            "-c", subject,
+            "-c",
+            subject,
             "-a",
             "/Library/Keychains/System.keychain",
         ])

--- a/aa-proxy/src/tls/keychain.rs
+++ b/aa-proxy/src/tls/keychain.rs
@@ -4,6 +4,7 @@
 //! This entire module is macOS-only.
 
 use std::path::Path;
+use std::process::Command;
 
 use crate::error::ProxyError;
 
@@ -14,8 +15,29 @@ use crate::error::ProxyError;
 ///
 /// Requires admin privileges — macOS prompts for authentication automatically.
 #[cfg(target_os = "macos")]
-pub(super) fn add_trusted_cert(_cert_path: &Path) -> Result<(), ProxyError> {
-    todo!()
+pub(super) fn add_trusted_cert(cert_path: &Path) -> Result<(), ProxyError> {
+    let cert_str = cert_path
+        .to_str()
+        .ok_or_else(|| ProxyError::Keychain("cert path is not valid UTF-8".into()))?;
+
+    let output = Command::new("security")
+        .args([
+            "add-trusted-cert",
+            "-d",
+            "-r", "trustRoot",
+            "-k", "/Library/Keychains/System.keychain",
+            cert_str,
+        ])
+        .output()
+        .map_err(|e| ProxyError::Keychain(format!("failed to run security CLI: {e}")))?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(ProxyError::Keychain(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ))
+    }
 }
 
 /// Remove the certificate at `cert_path` from the macOS System Keychain trust.
@@ -24,8 +46,23 @@ pub(super) fn add_trusted_cert(_cert_path: &Path) -> Result<(), ProxyError> {
 ///
 /// Requires admin privileges — macOS prompts for authentication automatically.
 #[cfg(target_os = "macos")]
-pub(super) fn remove_trusted_cert(_cert_path: &Path) -> Result<(), ProxyError> {
-    todo!()
+pub(super) fn remove_trusted_cert(cert_path: &Path) -> Result<(), ProxyError> {
+    let cert_str = cert_path
+        .to_str()
+        .ok_or_else(|| ProxyError::Keychain("cert path is not valid UTF-8".into()))?;
+
+    let output = Command::new("security")
+        .args(["remove-trusted-cert", "-d", cert_str])
+        .output()
+        .map_err(|e| ProxyError::Keychain(format!("failed to run security CLI: {e}")))?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(ProxyError::Keychain(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ))
+    }
 }
 
 /// Return `true` if a certificate with common name `subject` exists in the
@@ -33,6 +70,16 @@ pub(super) fn remove_trusted_cert(_cert_path: &Path) -> Result<(), ProxyError> {
 ///
 /// Invokes: `security find-certificate -c <subject> -a /Library/Keychains/System.keychain`
 #[cfg(target_os = "macos")]
-pub(super) fn is_cert_trusted(_subject: &str) -> Result<bool, ProxyError> {
-    todo!()
+pub(super) fn is_cert_trusted(subject: &str) -> Result<bool, ProxyError> {
+    let output = Command::new("security")
+        .args([
+            "find-certificate",
+            "-c", subject,
+            "-a",
+            "/Library/Keychains/System.keychain",
+        ])
+        .output()
+        .map_err(|e| ProxyError::Keychain(format!("failed to run security CLI: {e}")))?;
+
+    Ok(output.status.success())
 }

--- a/aa-proxy/src/tls/mod.rs
+++ b/aa-proxy/src/tls/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod ca;
 pub mod cert;
+#[cfg(target_os = "macos")]
 mod keychain;
 
 pub use ca::{CaStore, CertifiedKey};

--- a/aa-proxy/src/tls/mod.rs
+++ b/aa-proxy/src/tls/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod ca;
 pub mod cert;
+mod keychain;
 
 pub use ca::{CaStore, CertifiedKey};
 pub use cert::CertCache;

--- a/aa-runtime/src/config.rs
+++ b/aa-runtime/src/config.rs
@@ -49,10 +49,17 @@ impl RuntimeConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Env vars are process-global; this mutex serializes all tests that
+    // read or write them so they cannot race under multi-threaded test runners
+    // (e.g. `cargo llvm-cov` which uses `cargo test` with parallel threads).
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn defaults_when_env_vars_absent() {
-        // Ensure neither var is set for this test.
+        let _guard = ENV_LOCK.lock().unwrap();
+
         std::env::remove_var("AA_RUNTIME_WORKER_THREADS");
         std::env::remove_var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS");
 
@@ -64,6 +71,8 @@ mod tests {
 
     #[test]
     fn reads_worker_threads_from_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+
         std::env::set_var("AA_RUNTIME_WORKER_THREADS", "4");
         std::env::remove_var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS");
 
@@ -77,6 +86,8 @@ mod tests {
 
     #[test]
     fn reads_shutdown_timeout_from_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+
         std::env::remove_var("AA_RUNTIME_WORKER_THREADS");
         std::env::set_var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS", "60");
 
@@ -90,6 +101,8 @@ mod tests {
 
     #[test]
     fn falls_back_to_default_on_invalid_value() {
+        let _guard = ENV_LOCK.lock().unwrap();
+
         std::env::set_var("AA_RUNTIME_WORKER_THREADS", "not-a-number");
         std::env::set_var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS", "abc");
 

--- a/docs/superpowers/plans/2026-04-27-aaasm-42-ca-provisioning.md
+++ b/docs/superpowers/plans/2026-04-27-aaasm-42-ca-provisioning.md
@@ -1,0 +1,877 @@
+# AAASM-42: CA Certificate Provisioning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement EC P-256 CA key generation, disk persistence, per-domain leaf cert signing, LRU cert caching, and macOS System Keychain trust management in `aa-proxy`.
+
+**Architecture:** `ca.rs` is platform-agnostic (key generation, file I/O, signing). New `keychain.rs` is macOS-only (`#[cfg(target_os = "macos")]`) and owns all `security` CLI calls. `cert.rs` implements the LRU cache wrapper. All three are wired together in `lib.rs::run()`.
+
+**Tech Stack:** `rcgen 0.13` (EC P-256 key/cert generation), `time 0.3` (cert validity dates), `lru 0.16` (cert cache), `tokio::fs` (async file I/O), `std::process::Command` (macOS `security` CLI), `tempfile 3` (test temp dirs).
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `aa-proxy/Cargo.toml` | Modify | Add `tempfile` dev dep |
+| `aa-proxy/src/error.rs` | Modify | Add `Keychain(String)` variant |
+| `aa-proxy/src/tls/keychain.rs` | Create | macOS `security` CLI wrappers |
+| `aa-proxy/src/tls/mod.rs` | Modify | Add `mod keychain` |
+| `aa-proxy/src/tls/ca.rs` | Modify | Implement all `CaStore` methods |
+| `aa-proxy/src/tls/cert.rs` | Modify | Implement `CertCache::get_or_insert` |
+| `aa-proxy/src/lib.rs` | Modify | Wire `is_installed` + `install` into `run()` |
+
+---
+
+### Task 1: Add dev dependency and Keychain error variant
+
+**Files:**
+- Modify: `aa-proxy/Cargo.toml`
+- Modify: `aa-proxy/src/error.rs`
+
+- [ ] **Step 1: Add `tempfile` to dev-dependencies**
+
+Open `aa-proxy/Cargo.toml` and add after `[lints]`:
+
+```toml
+[dev-dependencies]
+tempfile = "3"
+```
+
+- [ ] **Step 2: Add `Keychain` variant to `ProxyError`**
+
+Replace the full contents of `aa-proxy/src/error.rs`:
+
+```rust
+//! Error types for the `aa-proxy` crate.
+
+use thiserror::Error;
+
+/// All errors that can arise within `aa-proxy`.
+#[derive(Debug, Error)]
+pub enum ProxyError {
+    /// An underlying I/O error (bind failure, connection reset, etc.).
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// A TLS handshake or configuration error.
+    #[error("TLS error: {0}")]
+    Tls(String),
+
+    /// A certificate generation error (rcgen failure).
+    #[error("Certificate generation error: {0}")]
+    CertGen(String),
+
+    /// A configuration error (missing or invalid env var).
+    #[error("Configuration error: {0}")]
+    Config(String),
+
+    /// A macOS Keychain operation failed (security CLI returned non-zero).
+    #[error("Keychain error: {0}")]
+    Keychain(String),
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+```bash
+cargo check -p aa-proxy
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add aa-proxy/Cargo.toml aa-proxy/src/error.rs
+git commit -m "✨ (error): Add Keychain variant to ProxyError"
+```
+
+---
+
+### Task 2: Scaffold `keychain.rs` with function stubs
+
+**Files:**
+- Create: `aa-proxy/src/tls/keychain.rs`
+- Modify: `aa-proxy/src/tls/mod.rs`
+
+- [ ] **Step 1: Create `aa-proxy/src/tls/keychain.rs`**
+
+```rust
+//! macOS System Keychain operations for CA certificate trust management.
+//!
+//! All functions invoke the `security` CLI via `std::process::Command`.
+//! This entire module is macOS-only.
+
+use std::path::Path;
+
+use crate::error::ProxyError;
+
+/// Install the certificate at `cert_path` into the macOS System Keychain
+/// as a trusted root CA.
+///
+/// Invokes: `security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain <cert>`
+///
+/// Requires admin privileges — macOS prompts for authentication automatically.
+#[cfg(target_os = "macos")]
+pub(super) fn add_trusted_cert(_cert_path: &Path) -> Result<(), ProxyError> {
+    todo!()
+}
+
+/// Remove the certificate at `cert_path` from the macOS System Keychain trust.
+///
+/// Invokes: `security remove-trusted-cert -d <cert>`
+///
+/// Requires admin privileges — macOS prompts for authentication automatically.
+#[cfg(target_os = "macos")]
+pub(super) fn remove_trusted_cert(_cert_path: &Path) -> Result<(), ProxyError> {
+    todo!()
+}
+
+/// Return `true` if a certificate with common name `subject` exists in the
+/// macOS System Keychain.
+///
+/// Invokes: `security find-certificate -c <subject> -a /Library/Keychains/System.keychain`
+#[cfg(target_os = "macos")]
+pub(super) fn is_cert_trusted(_subject: &str) -> Result<bool, ProxyError> {
+    todo!()
+}
+```
+
+- [ ] **Step 2: Add `mod keychain` to `aa-proxy/src/tls/mod.rs`**
+
+Replace the full contents of `aa-proxy/src/tls/mod.rs`:
+
+```rust
+//! TLS subsystem: CA management and per-domain certificate caching.
+
+pub mod ca;
+pub mod cert;
+mod keychain;
+
+pub use ca::{CaStore, CertifiedKey};
+pub use cert::CertCache;
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+```bash
+cargo check -p aa-proxy
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add aa-proxy/src/tls/keychain.rs aa-proxy/src/tls/mod.rs
+git commit -m "✨ (tls): Scaffold keychain.rs with security CLI stubs"
+```
+
+---
+
+### Task 3: Implement and test `CaStore::load_or_create`
+
+**Files:**
+- Modify: `aa-proxy/src/tls/ca.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the full contents of `aa-proxy/src/tls/ca.rs`:
+
+```rust
+//! CA certificate and key management for the MitM proxy.
+//!
+//! The CA is generated once on first startup and persisted to `~/.aa/ca/`.
+//! All subsequent per-domain certificates are signed by this CA.
+
+use std::path::{Path, PathBuf};
+
+use rcgen::{BasicConstraints, CertificateParams, DnType, IsCa, KeyPair, KeyUsagePurpose};
+use rcgen::PKCS_ECDSA_P256_SHA256;
+use time::{Duration, OffsetDateTime};
+
+use crate::error::ProxyError;
+
+/// A signed TLS certificate and its corresponding private key in DER encoding.
+///
+/// Used as the value stored in [`super::cert::CertCache`].
+pub struct CertifiedKey {
+    /// DER-encoded certificate chain (leaf cert only for dynamically generated certs).
+    pub cert_der: Vec<u8>,
+    /// DER-encoded PKCS#8 private key.
+    pub key_der: Vec<u8>,
+}
+
+/// Holds the local CA certificate and key pair used to sign per-domain certs.
+///
+/// The CA files on disk are:
+/// - `<ca_dir>/ca-cert.pem` — PEM-encoded CA certificate
+/// - `<ca_dir>/ca-key.pem`  — PEM-encoded CA private key (chmod 600)
+pub struct CaStore {
+    /// Directory where CA files are persisted.
+    pub(crate) ca_dir: PathBuf,
+    /// PEM-encoded CA certificate (used for signing and keychain install).
+    pub(crate) ca_cert_pem: String,
+    /// PEM-encoded CA private key (used for signing leaf certs).
+    pub(crate) ca_key_pem: String,
+}
+
+impl CaStore {
+    /// Load the CA from `ca_dir` if it exists, or generate a new self-signed CA
+    /// and persist it before returning.
+    pub async fn load_or_create(_ca_dir: &Path) -> Result<Self, ProxyError> {
+        todo!()
+    }
+
+    /// Generate a DER-encoded leaf certificate for `domain`, signed by this CA.
+    pub fn sign_cert(&self, _domain: &str) -> Result<CertifiedKey, ProxyError> {
+        todo!()
+    }
+
+    /// Install the CA certificate into the macOS System Keychain as a trusted root.
+    /// No-op if already installed.
+    #[cfg(target_os = "macos")]
+    pub fn install(&self) -> Result<(), ProxyError> {
+        todo!()
+    }
+
+    /// Return `true` if this CA is currently trusted by the macOS System Keychain.
+    #[cfg(target_os = "macos")]
+    pub fn is_installed(&self) -> Result<bool, ProxyError> {
+        todo!()
+    }
+
+    /// Remove this CA from the macOS System Keychain and delete `ca_dir` from disk.
+    #[cfg(target_os = "macos")]
+    pub fn uninstall(&self) -> Result<(), ProxyError> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn load_or_create_generates_pem_files() {
+        let dir = TempDir::new().unwrap();
+        CaStore::load_or_create(dir.path()).await.unwrap();
+        assert!(dir.path().join("ca-cert.pem").exists(), "ca-cert.pem missing");
+        assert!(dir.path().join("ca-key.pem").exists(), "ca-key.pem missing");
+    }
+
+    #[tokio::test]
+    async fn load_or_create_returns_valid_pem() {
+        let dir = TempDir::new().unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+        assert!(ca.ca_cert_pem.contains("-----BEGIN CERTIFICATE-----"));
+        assert!(ca.ca_key_pem.contains("-----BEGIN PRIVATE KEY-----"));
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn load_or_create_key_file_is_chmod_600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = TempDir::new().unwrap();
+        CaStore::load_or_create(dir.path()).await.unwrap();
+        let perms = std::fs::metadata(dir.path().join("ca-key.pem"))
+            .unwrap()
+            .permissions();
+        assert_eq!(perms.mode() & 0o777, 0o600, "ca-key.pem must be owner-read-write only");
+    }
+
+    #[tokio::test]
+    async fn load_or_create_reload_returns_same_cert() {
+        let dir = TempDir::new().unwrap();
+        let ca1 = CaStore::load_or_create(dir.path()).await.unwrap();
+        let ca2 = CaStore::load_or_create(dir.path()).await.unwrap();
+        assert_eq!(ca1.ca_cert_pem, ca2.ca_cert_pem, "reload must return identical cert");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — verify they fail on `todo!()`**
+
+```bash
+cargo test -p aa-proxy load_or_create 2>&1 | tail -20
+```
+
+Expected: tests fail with `not yet implemented` panic.
+
+- [ ] **Step 3: Implement `load_or_create`**
+
+Replace only the `load_or_create` method body in `aa-proxy/src/tls/ca.rs`:
+
+```rust
+pub async fn load_or_create(ca_dir: &Path) -> Result<Self, ProxyError> {
+    let cert_path = ca_dir.join("ca-cert.pem");
+    let key_path  = ca_dir.join("ca-key.pem");
+
+    // Load existing CA if both files are present.
+    if cert_path.exists() && key_path.exists() {
+        let ca_cert_pem = tokio::fs::read_to_string(&cert_path).await?;
+        let ca_key_pem  = tokio::fs::read_to_string(&key_path).await?;
+        return Ok(Self { ca_dir: ca_dir.to_path_buf(), ca_cert_pem, ca_key_pem });
+    }
+
+    // Generate a new EC P-256 CA key pair.
+    let ca_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)
+        .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+
+    let mut ca_params = CertificateParams::new(vec![])
+        .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    ca_params.key_usages = vec![KeyUsagePurpose::KeyCertSign, KeyUsagePurpose::CrlSign];
+    ca_params.distinguished_name.push(DnType::CommonName, "Agent Assembly CA");
+    ca_params.not_before = OffsetDateTime::now_utc();
+    ca_params.not_after  = OffsetDateTime::now_utc()
+        .checked_add(Duration::days(365 * 10))
+        .expect("date arithmetic cannot overflow for 10-year span");
+
+    let ca_cert     = ca_params.self_signed(&ca_key)
+        .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+    let ca_cert_pem = ca_cert.pem();
+    let ca_key_pem  = ca_key.serialize_pem();
+
+    // Persist to disk.
+    tokio::fs::create_dir_all(ca_dir).await?;
+    tokio::fs::write(&cert_path, &ca_cert_pem).await?;
+    tokio::fs::write(&key_path,  &ca_key_pem).await?;
+
+    // Restrict key file to owner read/write only.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        tokio::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600)).await?;
+    }
+
+    Ok(Self { ca_dir: ca_dir.to_path_buf(), ca_cert_pem, ca_key_pem })
+}
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+```bash
+cargo test -p aa-proxy load_or_create 2>&1 | tail -20
+```
+
+Expected: all `load_or_create_*` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aa-proxy/src/tls/ca.rs
+git commit -m "✨ (tls/ca): Implement load_or_create — generate and persist EC P-256 CA"
+```
+
+---
+
+### Task 4: Implement and test `CaStore::sign_cert`
+
+**Files:**
+- Modify: `aa-proxy/src/tls/ca.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add the following tests to the `#[cfg(test)] mod tests` block at the bottom of `aa-proxy/src/tls/ca.rs` (inside the existing `tests` module, after the `load_or_create_reload_returns_same_cert` test):
+
+```rust
+    #[tokio::test]
+    async fn sign_cert_returns_non_empty_der() {
+        let dir = TempDir::new().unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+        let ck = ca.sign_cert("api.openai.com").unwrap();
+        assert!(!ck.cert_der.is_empty(), "cert DER must not be empty");
+        assert!(!ck.key_der.is_empty(), "key DER must not be empty");
+    }
+
+    #[tokio::test]
+    async fn sign_cert_different_domains_produce_different_certs() {
+        let dir = TempDir::new().unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+        let ck1 = ca.sign_cert("api.openai.com").unwrap();
+        let ck2 = ca.sign_cert("api.anthropic.com").unwrap();
+        assert_ne!(ck1.cert_der, ck2.cert_der, "different domains must produce different certs");
+    }
+
+    #[tokio::test]
+    async fn sign_cert_same_domain_produces_fresh_cert_each_call() {
+        let dir = TempDir::new().unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+        let ck1 = ca.sign_cert("api.openai.com").unwrap();
+        let ck2 = ca.sign_cert("api.openai.com").unwrap();
+        // sign_cert generates a fresh key each call; keys must differ
+        assert_ne!(ck1.key_der, ck2.key_der, "each call generates a fresh key pair");
+    }
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+cargo test -p aa-proxy sign_cert 2>&1 | tail -10
+```
+
+Expected: fail with `not yet implemented`.
+
+- [ ] **Step 3: Implement `sign_cert`**
+
+Replace only the `sign_cert` method body in `aa-proxy/src/tls/ca.rs`:
+
+```rust
+pub fn sign_cert(&self, domain: &str) -> Result<CertifiedKey, ProxyError> {
+    // Reconstruct the CA key and cert from stored PEM.
+    let ca_key = KeyPair::from_pem(&self.ca_key_pem)
+        .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+    let ca_params = CertificateParams::from_ca_cert_pem(&self.ca_cert_pem)
+        .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+    let ca_cert = ca_params.self_signed(&ca_key)
+        .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+
+    // Generate a fresh EC P-256 leaf key and cert for `domain`.
+    let leaf_key = KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256)
+        .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+    let mut leaf_params = CertificateParams::new(vec![domain.to_string()])
+        .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+    leaf_params.not_before = OffsetDateTime::now_utc();
+    leaf_params.not_after  = OffsetDateTime::now_utc()
+        .checked_add(Duration::days(365))
+        .expect("date arithmetic cannot overflow for 1-year span");
+
+    let leaf_cert = leaf_params
+        .signed_by(&leaf_key, &ca_cert, &ca_key)
+        .map_err(|e| ProxyError::CertGen(e.to_string()))?;
+
+    Ok(CertifiedKey {
+        cert_der: leaf_cert.der().to_vec(),
+        key_der:  leaf_key.serialize_der(),
+    })
+}
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+```bash
+cargo test -p aa-proxy sign_cert 2>&1 | tail -10
+```
+
+Expected: all three `sign_cert_*` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aa-proxy/src/tls/ca.rs
+git commit -m "✨ (tls/ca): Implement sign_cert — per-domain leaf cert signed by CA"
+```
+
+---
+
+### Task 5: Implement and test `CertCache::get_or_insert`
+
+**Files:**
+- Modify: `aa-proxy/src/tls/cert.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace the full contents of `aa-proxy/src/tls/cert.rs`:
+
+```rust
+//! LRU cache for dynamically generated per-domain TLS certificates.
+//!
+//! Generating a certificate with rcgen takes ~0.1 ms. This cache avoids
+//! regenerating a cert for every connection to the same domain.
+
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+
+use lru::LruCache;
+
+use crate::error::ProxyError;
+use crate::tls::ca::{CaStore, CertifiedKey};
+
+/// Thread-safe LRU cache mapping domain names to their signed [`CertifiedKey`].
+pub struct CertCache {
+    inner: Mutex<LruCache<String, Arc<CertifiedKey>>>,
+}
+
+impl CertCache {
+    /// Create a new cache with the given `capacity` (maximum number of entries).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `capacity` is zero.
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            inner: Mutex::new(LruCache::new(
+                NonZeroUsize::new(capacity).expect("cert cache capacity must be non-zero"),
+            )),
+        }
+    }
+
+    /// Return the cached [`CertifiedKey`] for `domain`, generating and inserting
+    /// a new one (via `ca.sign_cert()`) if the domain is not in the cache.
+    pub fn get_or_insert(&self, _domain: &str, _ca: &CaStore) -> Result<Arc<CertifiedKey>, ProxyError> {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn get_or_insert_returns_cert_on_cache_miss() {
+        let dir = TempDir::new().unwrap();
+        let ca    = CaStore::load_or_create(dir.path()).await.unwrap();
+        let cache = CertCache::new(10);
+        let ck = cache.get_or_insert("api.openai.com", &ca).unwrap();
+        assert!(!ck.cert_der.is_empty());
+    }
+
+    #[tokio::test]
+    async fn get_or_insert_returns_same_arc_on_cache_hit() {
+        let dir = TempDir::new().unwrap();
+        let ca    = CaStore::load_or_create(dir.path()).await.unwrap();
+        let cache = CertCache::new(10);
+        let ck1 = cache.get_or_insert("api.openai.com", &ca).unwrap();
+        let ck2 = cache.get_or_insert("api.openai.com", &ca).unwrap();
+        // Identical Arc pointer proves cache hit — no re-signing occurred.
+        assert!(Arc::ptr_eq(&ck1, &ck2), "second call must return the cached Arc");
+    }
+
+    #[tokio::test]
+    async fn get_or_insert_different_domains_get_different_certs() {
+        let dir = TempDir::new().unwrap();
+        let ca    = CaStore::load_or_create(dir.path()).await.unwrap();
+        let cache = CertCache::new(10);
+        let ck1 = cache.get_or_insert("api.openai.com", &ca).unwrap();
+        let ck2 = cache.get_or_insert("api.anthropic.com", &ca).unwrap();
+        assert!(!Arc::ptr_eq(&ck1, &ck2));
+        assert_ne!(ck1.cert_der, ck2.cert_der);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+cargo test -p aa-proxy get_or_insert 2>&1 | tail -10
+```
+
+Expected: fail with `not yet implemented`.
+
+- [ ] **Step 3: Implement `get_or_insert`**
+
+Replace only the `get_or_insert` method body:
+
+```rust
+pub fn get_or_insert(&self, domain: &str, ca: &CaStore) -> Result<Arc<CertifiedKey>, ProxyError> {
+    let mut cache = self.inner.lock().expect("cert cache lock poisoned");
+    if let Some(ck) = cache.get(domain) {
+        return Ok(Arc::clone(ck));
+    }
+    let ck = Arc::new(ca.sign_cert(domain)?);
+    cache.put(domain.to_string(), Arc::clone(&ck));
+    Ok(ck)
+}
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+```bash
+cargo test -p aa-proxy get_or_insert 2>&1 | tail -10
+```
+
+Expected: all three `get_or_insert_*` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aa-proxy/src/tls/cert.rs
+git commit -m "✨ (tls/cert): Implement get_or_insert — LRU cache with sign_cert on miss"
+```
+
+---
+
+### Task 6: Implement `keychain.rs` functions
+
+**Files:**
+- Modify: `aa-proxy/src/tls/keychain.rs`
+
+- [ ] **Step 1: Implement all three functions**
+
+Replace the full contents of `aa-proxy/src/tls/keychain.rs`:
+
+```rust
+//! macOS System Keychain operations for CA certificate trust management.
+//!
+//! All functions invoke the `security` CLI via `std::process::Command`.
+//! This entire module is macOS-only.
+
+use std::path::Path;
+use std::process::Command;
+
+use crate::error::ProxyError;
+
+/// Install the certificate at `cert_path` into the macOS System Keychain
+/// as a trusted root CA.
+///
+/// Invokes: `security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain <cert>`
+///
+/// Requires admin privileges — macOS prompts for authentication automatically.
+#[cfg(target_os = "macos")]
+pub(super) fn add_trusted_cert(cert_path: &Path) -> Result<(), ProxyError> {
+    let cert_str = cert_path
+        .to_str()
+        .ok_or_else(|| ProxyError::Keychain("cert path is not valid UTF-8".into()))?;
+
+    let output = Command::new("security")
+        .args([
+            "add-trusted-cert",
+            "-d",
+            "-r", "trustRoot",
+            "-k", "/Library/Keychains/System.keychain",
+            cert_str,
+        ])
+        .output()
+        .map_err(|e| ProxyError::Keychain(format!("failed to run security CLI: {e}")))?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(ProxyError::Keychain(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ))
+    }
+}
+
+/// Remove the certificate at `cert_path` from the macOS System Keychain trust.
+///
+/// Invokes: `security remove-trusted-cert -d <cert>`
+///
+/// Requires admin privileges — macOS prompts for authentication automatically.
+#[cfg(target_os = "macos")]
+pub(super) fn remove_trusted_cert(cert_path: &Path) -> Result<(), ProxyError> {
+    let cert_str = cert_path
+        .to_str()
+        .ok_or_else(|| ProxyError::Keychain("cert path is not valid UTF-8".into()))?;
+
+    let output = Command::new("security")
+        .args(["remove-trusted-cert", "-d", cert_str])
+        .output()
+        .map_err(|e| ProxyError::Keychain(format!("failed to run security CLI: {e}")))?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(ProxyError::Keychain(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ))
+    }
+}
+
+/// Return `true` if a certificate with common name `subject` exists in the
+/// macOS System Keychain.
+///
+/// Invokes: `security find-certificate -c <subject> -a /Library/Keychains/System.keychain`
+#[cfg(target_os = "macos")]
+pub(super) fn is_cert_trusted(subject: &str) -> Result<bool, ProxyError> {
+    let output = Command::new("security")
+        .args([
+            "find-certificate",
+            "-c", subject,
+            "-a",
+            "/Library/Keychains/System.keychain",
+        ])
+        .output()
+        .map_err(|e| ProxyError::Keychain(format!("failed to run security CLI: {e}")))?;
+
+    Ok(output.status.success())
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cargo check -p aa-proxy
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-proxy/src/tls/keychain.rs
+git commit -m "✨ (tls/keychain): Implement security CLI operations"
+```
+
+---
+
+### Task 7: Implement and test `CaStore::install`, `is_installed`, `uninstall`
+
+**Files:**
+- Modify: `aa-proxy/src/tls/ca.rs`
+
+- [ ] **Step 1: Implement the three methods**
+
+Replace the three `todo!()` method bodies in `aa-proxy/src/tls/ca.rs`:
+
+```rust
+#[cfg(target_os = "macos")]
+pub fn install(&self) -> Result<(), ProxyError> {
+    if self.is_installed()? {
+        return Ok(()); // Already trusted — no-op.
+    }
+    super::keychain::add_trusted_cert(&self.ca_dir.join("ca-cert.pem"))
+}
+
+#[cfg(target_os = "macos")]
+pub fn is_installed(&self) -> Result<bool, ProxyError> {
+    super::keychain::is_cert_trusted("Agent Assembly CA")
+}
+
+#[cfg(target_os = "macos")]
+pub fn uninstall(&self) -> Result<(), ProxyError> {
+    super::keychain::remove_trusted_cert(&self.ca_dir.join("ca-cert.pem"))?;
+    std::fs::remove_dir_all(&self.ca_dir)?;
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cargo check -p aa-proxy
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Add keychain integration tests (macOS only, `#[ignore]`)**
+
+Add the following module at the very bottom of `aa-proxy/src/tls/ca.rs`, after the existing `tests` module:
+
+```rust
+/// Integration tests for macOS Keychain operations.
+///
+/// These tests require:
+/// - macOS (System Keychain)
+/// - Admin privileges (macOS will prompt via GUI)
+///
+/// Run with: `cargo test -p aa-proxy -- --ignored keychain`
+#[cfg(all(test, target_os = "macos"))]
+mod keychain_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    #[ignore = "requires macOS System Keychain write access (admin auth prompt)"]
+    async fn install_makes_ca_trusted() {
+        let dir = TempDir::new().unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+        ca.install().unwrap();
+        assert!(ca.is_installed().unwrap(), "CA must be trusted after install");
+        // Cleanup: remove from keychain so test is idempotent.
+        super::keychain::remove_trusted_cert(&dir.path().join("ca-cert.pem")).unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore = "requires macOS System Keychain write access (admin auth prompt)"]
+    async fn uninstall_removes_ca_and_deletes_dir() {
+        let dir = TempDir::new().unwrap();
+        let dir_path = dir.path().to_path_buf();
+        let ca = CaStore::load_or_create(&dir_path).await.unwrap();
+        ca.install().unwrap();
+        assert!(ca.is_installed().unwrap());
+
+        ca.uninstall().unwrap();
+        assert!(!ca.is_installed().unwrap(), "CA must not be trusted after uninstall");
+        assert!(!dir_path.exists(), "ca_dir must be deleted after uninstall");
+        // TempDir will try to clean up, but the dir is already gone — that's fine.
+        std::mem::forget(dir);
+    }
+
+    #[tokio::test]
+    #[ignore = "requires macOS System Keychain write access (admin auth prompt)"]
+    async fn install_is_idempotent() {
+        let dir = TempDir::new().unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+        ca.install().unwrap();
+        ca.install().unwrap(); // Second call must not fail.
+        assert!(ca.is_installed().unwrap());
+        // Cleanup.
+        super::keychain::remove_trusted_cert(&dir.path().join("ca-cert.pem")).unwrap();
+    }
+}
+```
+
+- [ ] **Step 4: Run unit tests (non-ignored) to confirm nothing regressed**
+
+```bash
+cargo test -p aa-proxy 2>&1 | tail -20
+```
+
+Expected: all non-`#[ignore]` tests pass, ignored tests listed but skipped.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add aa-proxy/src/tls/ca.rs
+git commit -m "✨ (tls/ca): Add install, is_installed, uninstall to CaStore"
+```
+
+---
+
+### Task 8: Wire `is_installed` + `install` into `run()` and run full suite
+
+**Files:**
+- Modify: `aa-proxy/src/lib.rs`
+
+- [ ] **Step 1: Update `run()` to install CA trust if needed**
+
+Replace the `run` function in `aa-proxy/src/lib.rs`:
+
+```rust
+/// Start the proxy with the given configuration.
+///
+/// Loads or creates the CA from `config.ca_dir`, installs it into the macOS
+/// System Keychain if not already trusted, constructs a [`proxy::ProxyServer`],
+/// and enters the TCP accept loop. Returns only on unrecoverable error.
+pub async fn run(config: ProxyConfig) -> anyhow::Result<()> {
+    let ca = tls::CaStore::load_or_create(&config.ca_dir).await?;
+
+    #[cfg(target_os = "macos")]
+    if !ca.is_installed()? {
+        tracing::info!("CA not yet trusted — installing into macOS System Keychain");
+        ca.install()?;
+        tracing::info!("CA installed successfully");
+    }
+
+    let server = proxy::ProxyServer::new(config, ca);
+    server.run().await?;
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+```bash
+cargo test -p aa-proxy 2>&1
+```
+
+Expected: all non-`#[ignore]` tests pass. `clippy` must also be clean:
+
+```bash
+cargo clippy -p aa-proxy -- -D warnings 2>&1 | tail -20
+```
+
+Expected: no warnings or errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-proxy/src/lib.rs
+git commit -m "✨ (lib): Wire CA is_installed + install into run() on macOS"
+```


### PR DESCRIPTION
## Summary

- Add `CaStore` with EC P-256 CA key generation, disk persistence (`ca-cert.pem` + `ca-key.pem` at mode 0o600), and on-demand per-domain leaf cert signing via `rcgen 0.13` with `x509-parser` feature for correct AKID linkage
- Add `keychain.rs` (macOS-only) with `security` CLI wrappers to install/remove/check the CA in the macOS System Keychain; wire into `CaStore::install`, `is_installed`, and `uninstall`
- Add `CertCache::get_or_insert` backed by an LRU cache (`lru 0.16`) — returns a cached `Arc<CertifiedKey>` on hit, signs a fresh leaf cert on miss
- Wire `CaStore::load_or_create` + conditional `install()` into `run()` on macOS startup

## Test Plan

- [ ] `cargo test -p aa-proxy` — 10 unit tests pass, 3 keychain integration tests are `#[ignore]` (require admin auth)
- [ ] `cargo clippy -p aa-proxy -- -D warnings` — clean
- [ ] Manual: run `aa-proxy` on macOS, confirm CA cert is generated in `~/.aa/ca/`, macOS auth prompt appears, cert is trusted in System Keychain, leaf certs are issued for each intercepted domain
- [ ] Manual: run `cargo test -p aa-proxy -- --ignored` on macOS with admin privileges to exercise keychain integration tests

Closes AAASM-42