### PR TITLE
[AAASM-64] ✨ (ffi-go): Add Rust staticlib C-ABI runtime exports

### DIFF
--- a/.github/workflows/ffi-go-staticlib.yml
+++ b/.github/workflows/ffi-go-staticlib.yml
@@ -1,0 +1,67 @@
+name: FFI Go Staticlib
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "aa-ffi-go/**"
+      - ".github/workflows/ffi-go-staticlib.yml"
+  pull_request:
+    branches: [master]
+    paths:
+      - "aa-ffi-go/**"
+      - ".github/workflows/ffi-go-staticlib.yml"
+
+jobs:
+  build-aa-ffi-go:
+    name: Build aa-ffi-go (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          - os: macos-latest
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install zig (linux arm64 cross toolchain)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        uses: mlugg/setup-zig@v2
+
+      - name: Install cargo-zigbuild
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        uses: taiki-e/install-action@3f7f2bd74f95d407a45d96b106f26d4f6c238fab
+        with:
+          tool: cargo-zigbuild
+
+      - name: Build staticlib (native)
+        if: matrix.target != 'aarch64-unknown-linux-gnu'
+        run: cargo build --release -p aa-ffi-go --target ${{ matrix.target }}
+
+      - name: Build staticlib (linux arm64 cross)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: cargo zigbuild --release -p aa-ffi-go --target ${{ matrix.target }}
+
+      - name: Collect artifact
+        shell: bash
+        run: |
+          mkdir -p dist/${{ matrix.target }}
+          cp target/${{ matrix.target }}/release/libaa_ffi_go.a dist/${{ matrix.target }}/libaa_ffi_go.a
+
+      - name: Upload staticlib artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: aa-ffi-go-${{ matrix.target }}
+          path: dist/${{ matrix.target }}/libaa_ffi_go.a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "aa-runtime",
     "aa-ebpf",
     "aa-proxy",
+    "aa-ffi-go",
     "aa-ffi-python",
     "aa-ffi-node",
     "aa-wasm",

--- a/aa-ffi-go/Cargo.toml
+++ b/aa-ffi-go/Cargo.toml
@@ -4,6 +4,13 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
+description = "Go C-ABI static library bindings for Agent Assembly"
+
+[lib]
+crate-type = ["staticlib", "rlib"]
+
+[dependencies]
+serde_json = "1"
 
 [lints]
 workspace = true

--- a/aa-ffi-go/Cargo.toml
+++ b/aa-ffi-go/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "aa-ffi-go"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true

--- a/aa-ffi-go/include/aa_ffi_go.h
+++ b/aa-ffi-go/include/aa_ffi_go.h
@@ -29,6 +29,8 @@ typedef struct aa_string {
   char* ptr;
 } aa_string;
 
+aa_status aa_connect(const char* endpoint, aa_client_handle** out_client);
+
 #ifdef __cplusplus
 }
 #endif

--- a/aa-ffi-go/include/aa_ffi_go.h
+++ b/aa-ffi-go/include/aa_ffi_go.h
@@ -38,6 +38,7 @@ aa_status aa_query_policy(
 );
 aa_status aa_disconnect(aa_client_handle* client);
 void aa_free_string(char* value);
+void aa_free_bytes(uint8_t* bytes, size_t len);
 
 #ifdef __cplusplus
 }

--- a/aa-ffi-go/include/aa_ffi_go.h
+++ b/aa-ffi-go/include/aa_ffi_go.h
@@ -30,6 +30,7 @@ typedef struct aa_string {
 } aa_string;
 
 aa_status aa_connect(const char* endpoint, aa_client_handle** out_client);
+aa_status aa_send_event(aa_client_handle* client, const char* event_json);
 
 #ifdef __cplusplus
 }

--- a/aa-ffi-go/include/aa_ffi_go.h
+++ b/aa-ffi-go/include/aa_ffi_go.h
@@ -1,11 +1,33 @@
 #ifndef AA_FFI_GO_H
 #define AA_FFI_GO_H
 
+#include <stddef.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+typedef int32_t aa_status;
+
+enum {
+  AA_STATUS_OK = 0,
+  AA_STATUS_NULL_POINTER = 1,
+  AA_STATUS_INVALID_UTF8 = 2,
+  AA_STATUS_NOT_CONNECTED = 3,
+  AA_STATUS_MUTEX_POISONED = 4,
+};
+
 typedef struct aa_client_handle aa_client_handle;
+
+typedef struct aa_bytes {
+  uint8_t* ptr;
+  size_t len;
+} aa_bytes;
+
+typedef struct aa_string {
+  char* ptr;
+} aa_string;
 
 #ifdef __cplusplus
 }

--- a/aa-ffi-go/include/aa_ffi_go.h
+++ b/aa-ffi-go/include/aa_ffi_go.h
@@ -37,6 +37,7 @@ aa_status aa_query_policy(
     char** out_response
 );
 aa_status aa_disconnect(aa_client_handle* client);
+void aa_free_string(char* value);
 
 #ifdef __cplusplus
 }

--- a/aa-ffi-go/include/aa_ffi_go.h
+++ b/aa-ffi-go/include/aa_ffi_go.h
@@ -36,6 +36,7 @@ aa_status aa_query_policy(
     const char* query_json,
     char** out_response
 );
+aa_status aa_disconnect(aa_client_handle* client);
 
 #ifdef __cplusplus
 }

--- a/aa-ffi-go/include/aa_ffi_go.h
+++ b/aa-ffi-go/include/aa_ffi_go.h
@@ -31,6 +31,11 @@ typedef struct aa_string {
 
 aa_status aa_connect(const char* endpoint, aa_client_handle** out_client);
 aa_status aa_send_event(aa_client_handle* client, const char* event_json);
+aa_status aa_query_policy(
+    aa_client_handle* client,
+    const char* query_json,
+    char** out_response
+);
 
 #ifdef __cplusplus
 }

--- a/aa-ffi-go/include/aa_ffi_go.h
+++ b/aa-ffi-go/include/aa_ffi_go.h
@@ -1,0 +1,14 @@
+#ifndef AA_FFI_GO_H
+#define AA_FFI_GO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct aa_client_handle aa_client_handle;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // AA_FFI_GO_H

--- a/aa-ffi-go/src/lib.rs
+++ b/aa-ffi-go/src/lib.rs
@@ -1,6 +1,7 @@
 //! Go C-ABI static library bindings for Agent Assembly.
 
 use core::ffi::c_char;
+use std::ffi::CStr;
 use std::sync::Mutex;
 
 pub type AaStatus = i32;
@@ -32,4 +33,40 @@ struct ClientState {
     endpoint: String,
     connected: bool,
     events_sent: u64,
+}
+
+/// # Safety
+///
+/// `endpoint` and `out_client` must be valid pointers for reads/writes.
+#[no_mangle]
+pub unsafe extern "C" fn aa_connect(
+    endpoint: *const c_char,
+    out_client: *mut *mut aa_client_handle,
+) -> AaStatus {
+    if endpoint.is_null() || out_client.is_null() {
+        return AA_STATUS_NULL_POINTER;
+    }
+
+    // SAFETY: `endpoint` null-check above ensures pointer validity precondition.
+    let endpoint = match unsafe { CStr::from_ptr(endpoint) }.to_str() {
+        Ok(value) => value.to_owned(),
+        Err(_) => return AA_STATUS_INVALID_UTF8,
+    };
+
+    let handle = aa_client_handle {
+        state: Mutex::new(ClientState {
+            endpoint,
+            connected: true,
+            events_sent: 0,
+        }),
+    };
+
+    let raw_handle = Box::into_raw(Box::new(handle));
+
+    // SAFETY: `out_client` null-check above ensures pointer validity precondition.
+    unsafe {
+        *out_client = raw_handle;
+    }
+
+    AA_STATUS_OK
 }

--- a/aa-ffi-go/src/lib.rs
+++ b/aa-ffi-go/src/lib.rs
@@ -24,6 +24,7 @@ pub struct AaString {
 }
 
 #[repr(C)]
+#[allow(non_camel_case_types)]
 pub struct aa_client_handle {
     state: Mutex<ClientState>,
 }

--- a/aa-ffi-go/src/lib.rs
+++ b/aa-ffi-go/src/lib.rs
@@ -70,3 +70,35 @@ pub unsafe extern "C" fn aa_connect(
 
     AA_STATUS_OK
 }
+
+/// # Safety
+///
+/// `client` and `event_json` must be valid pointers for reads.
+#[no_mangle]
+pub unsafe extern "C" fn aa_send_event(
+    client: *mut aa_client_handle,
+    event_json: *const c_char,
+) -> AaStatus {
+    if client.is_null() || event_json.is_null() {
+        return AA_STATUS_NULL_POINTER;
+    }
+
+    // SAFETY: `event_json` null-check above ensures pointer validity precondition.
+    if unsafe { CStr::from_ptr(event_json) }.to_str().is_err() {
+        return AA_STATUS_INVALID_UTF8;
+    }
+
+    // SAFETY: `client` null-check above ensures pointer validity precondition.
+    let client_ref = unsafe { &*client };
+    let mut state = match client_ref.state.lock() {
+        Ok(guard) => guard,
+        Err(_) => return AA_STATUS_MUTEX_POISONED,
+    };
+
+    if !state.connected {
+        return AA_STATUS_NOT_CONNECTED;
+    }
+
+    state.events_sent = state.events_sent.saturating_add(1);
+    AA_STATUS_OK
+}

--- a/aa-ffi-go/src/lib.rs
+++ b/aa-ffi-go/src/lib.rs
@@ -1,1 +1,27 @@
-//! Go FFI bindings crate scaffold.
+//! Go C-ABI static library bindings for Agent Assembly.
+
+use core::ffi::c_char;
+
+pub type AaStatus = i32;
+
+pub const AA_STATUS_OK: AaStatus = 0;
+pub const AA_STATUS_NULL_POINTER: AaStatus = 1;
+pub const AA_STATUS_INVALID_UTF8: AaStatus = 2;
+pub const AA_STATUS_NOT_CONNECTED: AaStatus = 3;
+pub const AA_STATUS_MUTEX_POISONED: AaStatus = 4;
+
+#[repr(C)]
+pub struct AaBytes {
+    pub ptr: *mut u8,
+    pub len: usize,
+}
+
+#[repr(C)]
+pub struct AaString {
+    pub ptr: *mut c_char,
+}
+
+#[repr(C)]
+pub struct aa_client_handle {
+    _private: [u8; 0],
+}

--- a/aa-ffi-go/src/lib.rs
+++ b/aa-ffi-go/src/lib.rs
@@ -217,3 +217,68 @@ pub unsafe extern "C" fn aa_free_bytes(bytes: *mut u8, len: usize) {
         drop(Vec::from_raw_parts(bytes, len, len));
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ptr;
+
+    #[test]
+    fn status_mapping_connect_send_disconnect() {
+        let endpoint = CString::new("unix:///tmp/aa.sock").expect("valid endpoint");
+
+        let mut client: *mut aa_client_handle = ptr::null_mut();
+        // SAFETY: Passing valid pointers from controlled test context.
+        let connect = unsafe { aa_connect(endpoint.as_ptr(), &mut client) };
+        assert_eq!(connect, AA_STATUS_OK);
+        assert!(!client.is_null());
+
+        let event = CString::new(r#"{"type":"test"}"#).expect("valid event");
+        // SAFETY: Connected handle and valid C string.
+        let send = unsafe { aa_send_event(client, event.as_ptr()) };
+        assert_eq!(send, AA_STATUS_OK);
+
+        // SAFETY: Handle returned by `aa_connect`.
+        let disconnect = unsafe { aa_disconnect(client) };
+        assert_eq!(disconnect, AA_STATUS_OK);
+    }
+
+    #[test]
+    fn status_mapping_null_pointer() {
+        let endpoint = CString::new("unix:///tmp/aa.sock").expect("valid endpoint");
+
+        // SAFETY: Deliberate null pointer to validate status mapping.
+        let status = unsafe { aa_connect(endpoint.as_ptr(), ptr::null_mut()) };
+        assert_eq!(status, AA_STATUS_NULL_POINTER);
+    }
+
+    #[test]
+    fn status_mapping_invalid_utf8() {
+        let bytes = vec![0xFF, 0x00];
+        // SAFETY: Test-only pointer with invalid UTF-8 payload.
+        let invalid = bytes.as_ptr().cast::<c_char>();
+
+        let mut client: *mut aa_client_handle = ptr::null_mut();
+        // SAFETY: Deliberate invalid UTF-8 input for mapping validation.
+        let status = unsafe { aa_connect(invalid, &mut client) };
+        assert_eq!(status, AA_STATUS_INVALID_UTF8);
+        assert!(client.is_null());
+    }
+
+    #[test]
+    fn free_string_and_bytes_callbacks() {
+        let owned = CString::new("owned-string").expect("valid string");
+        let raw = owned.into_raw();
+
+        // SAFETY: Pointer came from CString::into_raw in this test.
+        unsafe { aa_free_string(raw) };
+
+        let mut bytes = vec![1_u8, 2, 3, 4];
+        let len = bytes.len();
+        let raw_bytes = bytes.as_mut_ptr();
+        std::mem::forget(bytes);
+
+        // SAFETY: Pointer and length came from Vec allocation above.
+        unsafe { aa_free_bytes(raw_bytes, len) };
+    }
+}

--- a/aa-ffi-go/src/lib.rs
+++ b/aa-ffi-go/src/lib.rs
@@ -187,3 +187,18 @@ pub unsafe extern "C" fn aa_disconnect(client: *mut aa_client_handle) -> AaStatu
 
     AA_STATUS_OK
 }
+
+/// # Safety
+///
+/// `value` must be a pointer previously returned by `aa_query_policy`.
+#[no_mangle]
+pub unsafe extern "C" fn aa_free_string(value: *mut c_char) {
+    if value.is_null() {
+        return;
+    }
+
+    // SAFETY: `value` originated from `CString::into_raw` in this crate.
+    unsafe {
+        drop(CString::from_raw(value));
+    }
+}

--- a/aa-ffi-go/src/lib.rs
+++ b/aa-ffi-go/src/lib.rs
@@ -202,3 +202,18 @@ pub unsafe extern "C" fn aa_free_string(value: *mut c_char) {
         drop(CString::from_raw(value));
     }
 }
+
+/// # Safety
+///
+/// `bytes` and `len` must come from an allocation owned by this crate.
+#[no_mangle]
+pub unsafe extern "C" fn aa_free_bytes(bytes: *mut u8, len: usize) {
+    if bytes.is_null() {
+        return;
+    }
+
+    // SAFETY: Caller guarantees pointer/length originate from this crate.
+    unsafe {
+        drop(Vec::from_raw_parts(bytes, len, len));
+    }
+}

--- a/aa-ffi-go/src/lib.rs
+++ b/aa-ffi-go/src/lib.rs
@@ -1,7 +1,7 @@
 //! Go C-ABI static library bindings for Agent Assembly.
 
 use core::ffi::c_char;
-use std::ffi::CStr;
+use std::ffi::{CStr, CString};
 use std::sync::Mutex;
 
 pub type AaStatus = i32;
@@ -100,5 +100,59 @@ pub unsafe extern "C" fn aa_send_event(
     }
 
     state.events_sent = state.events_sent.saturating_add(1);
+    AA_STATUS_OK
+}
+
+/// # Safety
+///
+/// `client`, `query_json`, and `out_response` must be valid pointers.
+#[no_mangle]
+pub unsafe extern "C" fn aa_query_policy(
+    client: *mut aa_client_handle,
+    query_json: *const c_char,
+    out_response: *mut *mut c_char,
+) -> AaStatus {
+    if client.is_null() || query_json.is_null() || out_response.is_null() {
+        return AA_STATUS_NULL_POINTER;
+    }
+
+    // SAFETY: `query_json` null-check above ensures pointer validity precondition.
+    let query = match unsafe { CStr::from_ptr(query_json) }.to_str() {
+        Ok(value) => value.to_owned(),
+        Err(_) => return AA_STATUS_INVALID_UTF8,
+    };
+
+    // SAFETY: `client` null-check above ensures pointer validity precondition.
+    let client_ref = unsafe { &*client };
+    let state = match client_ref.state.lock() {
+        Ok(guard) => guard,
+        Err(_) => return AA_STATUS_MUTEX_POISONED,
+    };
+
+    if !state.connected {
+        return AA_STATUS_NOT_CONNECTED;
+    }
+
+    let response_json = serde_json::json!({
+        "allow": true,
+        "reason": "stub-policy",
+        "endpoint": state.endpoint,
+        "events_sent": state.events_sent,
+        "query": query,
+    })
+    .to_string();
+
+    let response = match CString::new(response_json) {
+        Ok(value) => value,
+        Err(_) => return AA_STATUS_INVALID_UTF8,
+    };
+
+    let raw_response = response.into_raw();
+
+    // SAFETY: `out_response` null-check above ensures pointer validity precondition.
+    unsafe {
+        *out_response = raw_response;
+    }
+
     AA_STATUS_OK
 }

--- a/aa-ffi-go/src/lib.rs
+++ b/aa-ffi-go/src/lib.rs
@@ -1,6 +1,7 @@
 //! Go C-ABI static library bindings for Agent Assembly.
 
 use core::ffi::c_char;
+use std::sync::Mutex;
 
 pub type AaStatus = i32;
 
@@ -23,5 +24,12 @@ pub struct AaString {
 
 #[repr(C)]
 pub struct aa_client_handle {
-    _private: [u8; 0],
+    state: Mutex<ClientState>,
+}
+
+#[derive(Default)]
+struct ClientState {
+    endpoint: String,
+    connected: bool,
+    events_sent: u64,
 }

--- a/aa-ffi-go/src/lib.rs
+++ b/aa-ffi-go/src/lib.rs
@@ -156,3 +156,34 @@ pub unsafe extern "C" fn aa_query_policy(
 
     AA_STATUS_OK
 }
+
+/// # Safety
+///
+/// `client` must be a pointer previously returned by `aa_connect`.
+#[no_mangle]
+pub unsafe extern "C" fn aa_disconnect(client: *mut aa_client_handle) -> AaStatus {
+    if client.is_null() {
+        return AA_STATUS_NULL_POINTER;
+    }
+
+    // SAFETY: `client` null-check above ensures pointer validity precondition.
+    let client_ref = unsafe { &*client };
+    let mut state = match client_ref.state.lock() {
+        Ok(guard) => guard,
+        Err(_) => return AA_STATUS_MUTEX_POISONED,
+    };
+
+    if !state.connected {
+        return AA_STATUS_NOT_CONNECTED;
+    }
+
+    state.connected = false;
+    drop(state);
+
+    // SAFETY: `client` originated from `Box::into_raw` in `aa_connect`.
+    unsafe {
+        drop(Box::from_raw(client));
+    }
+
+    AA_STATUS_OK
+}

--- a/aa-ffi-go/src/lib.rs
+++ b/aa-ffi-go/src/lib.rs
@@ -1,0 +1,1 @@
+//! Go FFI bindings crate scaffold.


### PR DESCRIPTION
## Description

Add the AAASM-64 Rust `aa-ffi-go` staticlib project scaffolding and core C-ABI exports for runtime interactions, plus CI artifact workflow for multi-platform staticlib builds.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-64
- Related GitHub issues: N/A

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [x] No tests required (explain why)

Note: Local Rust toolchain is unavailable in this execution environment (`cargo`/`rustc` missing), so tests could not be executed locally here.

## Checklist

- [ ] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
