### PR TITLE
[AAASM-31] ✨ pipeline(runtime): Implement event aggregation pipeline with broadcast fan-out

### DIFF
--- a/aa-runtime/src/config.rs
+++ b/aa-runtime/src/config.rs
@@ -28,21 +28,25 @@ pub struct RuntimeConfig {
     pub ipc_max_connections: usize,
 
     /// Depth of the mpsc channel that feeds the event pipeline.
+    ///
     /// Read from `AA_PIPELINE_INPUT_BUFFER`. Defaults to `10_000`.
     /// Zero falls back to the default.
     pub pipeline_input_buffer: usize,
 
     /// Maximum events in a batch before an early flush is triggered.
+    ///
     /// Read from `AA_PIPELINE_BATCH_SIZE`. Defaults to `100`.
     /// Zero falls back to the default.
     pub pipeline_batch_size: usize,
 
     /// Interval in milliseconds between scheduled batch flushes.
+    ///
     /// Read from `AA_PIPELINE_FLUSH_INTERVAL_MS`. Defaults to `100`.
     /// Zero falls back to the default.
     pub pipeline_flush_interval_ms: u64,
 
     /// Capacity of the broadcast ring buffer for fan-out subscribers.
+    ///
     /// Read from `AA_PIPELINE_BROADCAST_CAPACITY`. Defaults to `1_024`.
     /// Zero falls back to the default.
     pub pipeline_broadcast_capacity: usize,
@@ -207,6 +211,10 @@ mod tests {
         assert_eq!(config.worker_threads, 0);
         assert_eq!(config.shutdown_timeout_secs, 30);
         assert_eq!(config.ipc_max_connections, 64);
+        assert_eq!(config.pipeline_input_buffer, 10_000);
+        assert_eq!(config.pipeline_batch_size, 100);
+        assert_eq!(config.pipeline_flush_interval_ms, 100);
+        assert_eq!(config.pipeline_broadcast_capacity, 1_024);
 
         std::env::remove_var("AA_AGENT_ID");
     }
@@ -259,6 +267,7 @@ mod tests {
 
     #[test]
     fn rejects_zero_ipc_max_connections() {
+        let _guard = ENV_LOCK.lock().unwrap();
         std::env::set_var("AA_AGENT_ID", "agent-zero");
         std::env::set_var("AA_IPC_MAX_CONNECTIONS", "0");
 
@@ -272,6 +281,7 @@ mod tests {
 
     #[test]
     fn rejects_agent_id_with_path_separator() {
+        let _guard = ENV_LOCK.lock().unwrap();
         std::env::set_var("AA_AGENT_ID", "../../etc/passwd");
 
         let result = RuntimeConfig::from_env();
@@ -306,7 +316,7 @@ mod tests {
     fn reads_pipeline_input_buffer_from_env() {
         let _guard = ENV_LOCK.lock().unwrap();
         std::env::set_var("AA_AGENT_ID", "agent-pib");
-        std::env::set_var("AA_PIPELINE_INPUT_BUFFER", "5000");
+        std::env::set_var("AA_PIPELINE_INPUT_BUFFER", "5000"); // arbitrary non-default, non-zero value
 
         let config = RuntimeConfig::from_env().unwrap();
 
@@ -320,7 +330,7 @@ mod tests {
     fn reads_pipeline_batch_size_from_env() {
         let _guard = ENV_LOCK.lock().unwrap();
         std::env::set_var("AA_AGENT_ID", "agent-pbs");
-        std::env::set_var("AA_PIPELINE_BATCH_SIZE", "50");
+        std::env::set_var("AA_PIPELINE_BATCH_SIZE", "50"); // arbitrary non-default, non-zero value
 
         let config = RuntimeConfig::from_env().unwrap();
 
@@ -334,7 +344,7 @@ mod tests {
     fn reads_pipeline_flush_interval_ms_from_env() {
         let _guard = ENV_LOCK.lock().unwrap();
         std::env::set_var("AA_AGENT_ID", "agent-pfi");
-        std::env::set_var("AA_PIPELINE_FLUSH_INTERVAL_MS", "200");
+        std::env::set_var("AA_PIPELINE_FLUSH_INTERVAL_MS", "200"); // arbitrary non-default, non-zero value
 
         let config = RuntimeConfig::from_env().unwrap();
 
@@ -348,7 +358,7 @@ mod tests {
     fn reads_pipeline_broadcast_capacity_from_env() {
         let _guard = ENV_LOCK.lock().unwrap();
         std::env::set_var("AA_AGENT_ID", "agent-pbc");
-        std::env::set_var("AA_PIPELINE_BROADCAST_CAPACITY", "2048");
+        std::env::set_var("AA_PIPELINE_BROADCAST_CAPACITY", "2048"); // arbitrary non-default, non-zero value
 
         let config = RuntimeConfig::from_env().unwrap();
 

--- a/aa-runtime/src/config.rs
+++ b/aa-runtime/src/config.rs
@@ -401,7 +401,10 @@ mod tests {
         assert_eq!(config.pipeline_input_buffer, 10_000, "0 should fall back to default");
         assert_eq!(config.pipeline_batch_size, 100, "0 should fall back to default");
         assert_eq!(config.pipeline_flush_interval_ms, 100, "0 should fall back to default");
-        assert_eq!(config.pipeline_broadcast_capacity, 1_024, "0 should fall back to default");
+        assert_eq!(
+            config.pipeline_broadcast_capacity, 1_024,
+            "0 should fall back to default"
+        );
 
         std::env::remove_var("AA_AGENT_ID");
         std::env::remove_var("AA_PIPELINE_INPUT_BUFFER");

--- a/aa-runtime/src/config.rs
+++ b/aa-runtime/src/config.rs
@@ -26,6 +26,26 @@ pub struct RuntimeConfig {
     ///
     /// Read from `AA_IPC_MAX_CONNECTIONS`. Defaults to `64`.
     pub ipc_max_connections: usize,
+
+    /// Depth of the mpsc channel that feeds the event pipeline.
+    /// Read from `AA_PIPELINE_INPUT_BUFFER`. Defaults to `10_000`.
+    /// Zero falls back to the default.
+    pub pipeline_input_buffer: usize,
+
+    /// Maximum events in a batch before an early flush is triggered.
+    /// Read from `AA_PIPELINE_BATCH_SIZE`. Defaults to `100`.
+    /// Zero falls back to the default.
+    pub pipeline_batch_size: usize,
+
+    /// Interval in milliseconds between scheduled batch flushes.
+    /// Read from `AA_PIPELINE_FLUSH_INTERVAL_MS`. Defaults to `100`.
+    /// Zero falls back to the default.
+    pub pipeline_flush_interval_ms: u64,
+
+    /// Capacity of the broadcast ring buffer for fan-out subscribers.
+    /// Read from `AA_PIPELINE_BROADCAST_CAPACITY`. Defaults to `1_024`.
+    /// Zero falls back to the default.
+    pub pipeline_broadcast_capacity: usize,
 }
 
 impl RuntimeConfig {
@@ -43,6 +63,10 @@ impl RuntimeConfig {
     /// | `AA_RUNTIME_WORKER_THREADS` | `usize` | `0` (Tokio picks per-CPU) |
     /// | `AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS` | `u64` | `30` |
     /// | `AA_IPC_MAX_CONNECTIONS` | `usize` | `64` |
+    /// | `AA_PIPELINE_INPUT_BUFFER` | `usize` | `10_000` |
+    /// | `AA_PIPELINE_BATCH_SIZE` | `usize` | `100` |
+    /// | `AA_PIPELINE_FLUSH_INTERVAL_MS` | `u64` | `100` |
+    /// | `AA_PIPELINE_BROADCAST_CAPACITY` | `usize` | `1_024` |
     pub fn from_env() -> Result<Self, String> {
         let agent_id = std::env::var("AA_AGENT_ID").map_err(|_| "AA_AGENT_ID is required but not set".to_string())?;
 
@@ -70,11 +94,39 @@ impl RuntimeConfig {
             .filter(|&n| n > 0)
             .unwrap_or(64);
 
+        let pipeline_input_buffer = std::env::var("AA_PIPELINE_INPUT_BUFFER")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(10_000);
+
+        let pipeline_batch_size = std::env::var("AA_PIPELINE_BATCH_SIZE")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(100);
+
+        let pipeline_flush_interval_ms = std::env::var("AA_PIPELINE_FLUSH_INTERVAL_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(100);
+
+        let pipeline_broadcast_capacity = std::env::var("AA_PIPELINE_BROADCAST_CAPACITY")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(1_024);
+
         Ok(Self {
             agent_id,
             worker_threads,
             shutdown_timeout_secs,
             ipc_max_connections,
+            pipeline_input_buffer,
+            pipeline_batch_size,
+            pipeline_flush_interval_ms,
+            pipeline_broadcast_capacity,
         })
     }
 }
@@ -145,6 +197,10 @@ mod tests {
         std::env::remove_var("AA_RUNTIME_WORKER_THREADS");
         std::env::remove_var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS");
         std::env::remove_var("AA_IPC_MAX_CONNECTIONS");
+        std::env::remove_var("AA_PIPELINE_INPUT_BUFFER");
+        std::env::remove_var("AA_PIPELINE_BATCH_SIZE");
+        std::env::remove_var("AA_PIPELINE_FLUSH_INTERVAL_MS");
+        std::env::remove_var("AA_PIPELINE_BROADCAST_CAPACITY");
 
         let config = RuntimeConfig::from_env().unwrap();
 
@@ -244,5 +300,103 @@ mod tests {
         std::env::remove_var("AA_RUNTIME_WORKER_THREADS");
         std::env::remove_var("AA_RUNTIME_SHUTDOWN_TIMEOUT_SECS");
         std::env::remove_var("AA_IPC_MAX_CONNECTIONS");
+    }
+
+    #[test]
+    fn reads_pipeline_input_buffer_from_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AA_AGENT_ID", "agent-pib");
+        std::env::set_var("AA_PIPELINE_INPUT_BUFFER", "5000");
+
+        let config = RuntimeConfig::from_env().unwrap();
+
+        assert_eq!(config.pipeline_input_buffer, 5000);
+
+        std::env::remove_var("AA_AGENT_ID");
+        std::env::remove_var("AA_PIPELINE_INPUT_BUFFER");
+    }
+
+    #[test]
+    fn reads_pipeline_batch_size_from_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AA_AGENT_ID", "agent-pbs");
+        std::env::set_var("AA_PIPELINE_BATCH_SIZE", "50");
+
+        let config = RuntimeConfig::from_env().unwrap();
+
+        assert_eq!(config.pipeline_batch_size, 50);
+
+        std::env::remove_var("AA_AGENT_ID");
+        std::env::remove_var("AA_PIPELINE_BATCH_SIZE");
+    }
+
+    #[test]
+    fn reads_pipeline_flush_interval_ms_from_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AA_AGENT_ID", "agent-pfi");
+        std::env::set_var("AA_PIPELINE_FLUSH_INTERVAL_MS", "200");
+
+        let config = RuntimeConfig::from_env().unwrap();
+
+        assert_eq!(config.pipeline_flush_interval_ms, 200);
+
+        std::env::remove_var("AA_AGENT_ID");
+        std::env::remove_var("AA_PIPELINE_FLUSH_INTERVAL_MS");
+    }
+
+    #[test]
+    fn reads_pipeline_broadcast_capacity_from_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AA_AGENT_ID", "agent-pbc");
+        std::env::set_var("AA_PIPELINE_BROADCAST_CAPACITY", "2048");
+
+        let config = RuntimeConfig::from_env().unwrap();
+
+        assert_eq!(config.pipeline_broadcast_capacity, 2048);
+
+        std::env::remove_var("AA_AGENT_ID");
+        std::env::remove_var("AA_PIPELINE_BROADCAST_CAPACITY");
+    }
+
+    #[test]
+    fn pipeline_defaults_when_env_vars_absent() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AA_AGENT_ID", "agent-pipe-defaults");
+        std::env::remove_var("AA_PIPELINE_INPUT_BUFFER");
+        std::env::remove_var("AA_PIPELINE_BATCH_SIZE");
+        std::env::remove_var("AA_PIPELINE_FLUSH_INTERVAL_MS");
+        std::env::remove_var("AA_PIPELINE_BROADCAST_CAPACITY");
+
+        let config = RuntimeConfig::from_env().unwrap();
+
+        assert_eq!(config.pipeline_input_buffer, 10_000);
+        assert_eq!(config.pipeline_batch_size, 100);
+        assert_eq!(config.pipeline_flush_interval_ms, 100);
+        assert_eq!(config.pipeline_broadcast_capacity, 1_024);
+
+        std::env::remove_var("AA_AGENT_ID");
+    }
+
+    #[test]
+    fn pipeline_rejects_zero_values() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AA_AGENT_ID", "agent-pipe-zero");
+        std::env::set_var("AA_PIPELINE_INPUT_BUFFER", "0");
+        std::env::set_var("AA_PIPELINE_BATCH_SIZE", "0");
+        std::env::set_var("AA_PIPELINE_FLUSH_INTERVAL_MS", "0");
+        std::env::set_var("AA_PIPELINE_BROADCAST_CAPACITY", "0");
+
+        let config = RuntimeConfig::from_env().unwrap();
+
+        assert_eq!(config.pipeline_input_buffer, 10_000, "0 should fall back to default");
+        assert_eq!(config.pipeline_batch_size, 100, "0 should fall back to default");
+        assert_eq!(config.pipeline_flush_interval_ms, 100, "0 should fall back to default");
+        assert_eq!(config.pipeline_broadcast_capacity, 1_024, "0 should fall back to default");
+
+        std::env::remove_var("AA_AGENT_ID");
+        std::env::remove_var("AA_PIPELINE_INPUT_BUFFER");
+        std::env::remove_var("AA_PIPELINE_BATCH_SIZE");
+        std::env::remove_var("AA_PIPELINE_FLUSH_INTERVAL_MS");
+        std::env::remove_var("AA_PIPELINE_BROADCAST_CAPACITY");
     }
 }

--- a/aa-runtime/src/pipeline/event.rs
+++ b/aa-runtime/src/pipeline/event.rs
@@ -1,0 +1,78 @@
+//! Enriched event type produced by the pipeline ingestion stage.
+
+use aa_proto::assembly::audit::v1::AuditEvent;
+
+/// The input source that delivered the raw event to the pipeline.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EventSource {
+    /// Delivered via the Unix domain socket IPC server (SDK process).
+    Sdk,
+    /// Delivered via eBPF kernel-level instrumentation.
+    EBpf,
+    /// Delivered via the aa-proxy sidecar.
+    Proxy,
+}
+
+/// A governance event enriched with runtime-side metadata.
+///
+/// Produced by the pipeline enrichment stage from a raw [`AuditEvent`].
+/// Cloneable so it can be broadcast to multiple subscribers via
+/// `tokio::sync::broadcast`.
+#[derive(Debug, Clone)]
+pub struct EnrichedEvent {
+    /// The original audit event from the SDK or other source.
+    pub inner: AuditEvent,
+    /// Unix milliseconds when this event was received by the pipeline
+    /// (wall-clock time on the runtime host, not the SDK's timestamp).
+    pub received_at_ms: i64,
+    /// The input source that delivered this event.
+    pub source: EventSource,
+    /// Agent identity string — copied from `RuntimeConfig::agent_id`.
+    pub agent_id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enriched_event_fields_are_accessible() {
+        let audit_event = AuditEvent::default();
+        let received_at_ms: i64 = 1234567890;
+        let source = EventSource::Sdk;
+        let agent_id = "test-agent".to_string();
+
+        let enriched_event = EnrichedEvent {
+            inner: audit_event.clone(),
+            received_at_ms,
+            source: source.clone(),
+            agent_id: agent_id.clone(),
+        };
+
+        assert_eq!(enriched_event.inner, audit_event);
+        assert_eq!(enriched_event.received_at_ms, received_at_ms);
+        assert_eq!(enriched_event.source, source);
+        assert_eq!(enriched_event.agent_id, agent_id);
+    }
+
+    #[test]
+    fn event_source_variants_are_distinct() {
+        assert_ne!(EventSource::Sdk, EventSource::EBpf);
+        assert_ne!(EventSource::EBpf, EventSource::Proxy);
+        assert_ne!(EventSource::Sdk, EventSource::Proxy);
+    }
+
+    #[test]
+    fn enriched_event_is_clone() {
+        let audit_event = AuditEvent::default();
+        let original = EnrichedEvent {
+            inner: audit_event,
+            received_at_ms: 1234567890,
+            source: EventSource::EBpf,
+            agent_id: "original-agent".to_string(),
+        };
+
+        let cloned = original.clone();
+        assert_eq!(cloned.agent_id, original.agent_id);
+    }
+}

--- a/aa-runtime/src/pipeline/metrics.rs
+++ b/aa-runtime/src/pipeline/metrics.rs
@@ -13,8 +13,8 @@ use std::sync::atomic::{AtomicU64, Ordering};
 #[derive(Debug, Default)]
 pub struct PipelineMetrics {
     events_processed_total: AtomicU64,
-    events_dropped_total:   AtomicU64,
-    last_batch_size:        AtomicU64,
+    events_dropped_total: AtomicU64,
+    last_batch_size: AtomicU64,
 }
 
 impl PipelineMetrics {

--- a/aa-runtime/src/pipeline/metrics.rs
+++ b/aa-runtime/src/pipeline/metrics.rs
@@ -1,0 +1,102 @@
+//! In-process pipeline metrics counters.
+//!
+//! Counters are stored as `AtomicU64` values so they can be updated from
+//! the pipeline task and read from health/metrics endpoints without locking.
+//! The HTTP exposure of these counters is handled by AAASM-32.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Shared metrics for the event aggregation pipeline.
+///
+/// Wrap in an `Arc` and pass clones to both the pipeline task and any
+/// downstream consumers that need to record dropped events.
+#[derive(Debug, Default)]
+pub struct PipelineMetrics {
+    events_processed_total: AtomicU64,
+    events_dropped_total:   AtomicU64,
+    last_batch_size:        AtomicU64,
+}
+
+impl PipelineMetrics {
+    /// Increment the processed-events counter by `n`.
+    pub fn record_processed(&self, n: u64) {
+        self.events_processed_total.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Increment the dropped-events counter by `n`.
+    ///
+    /// Called by broadcast subscribers when they receive
+    /// `RecvError::Lagged(n)`.
+    pub fn record_dropped(&self, n: u64) {
+        self.events_dropped_total.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Record the size of the most recently flushed batch.
+    ///
+    /// This is a last-value gauge, not a cumulative counter — each flush
+    /// overwrites the previous value.
+    pub fn record_batch_size(&self, n: u64) {
+        self.last_batch_size.store(n, Ordering::Relaxed);
+    }
+
+    /// Read the current total processed-events count.
+    pub fn processed(&self) -> u64 {
+        self.events_processed_total.load(Ordering::Relaxed)
+    }
+
+    /// Read the current total dropped-events count.
+    pub fn dropped(&self) -> u64 {
+        self.events_dropped_total.load(Ordering::Relaxed)
+    }
+
+    /// Read the size of the most recently flushed batch.
+    pub fn last_batch_size(&self) -> u64 {
+        self.last_batch_size.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_state_is_all_zeros() {
+        let metrics = PipelineMetrics::default();
+        assert_eq!(metrics.processed(), 0);
+        assert_eq!(metrics.dropped(), 0);
+        assert_eq!(metrics.last_batch_size(), 0);
+    }
+
+    #[test]
+    fn record_processed_accumulates() {
+        let metrics = PipelineMetrics::default();
+        metrics.record_processed(5);
+        metrics.record_processed(3);
+        assert_eq!(metrics.processed(), 8);
+    }
+
+    #[test]
+    fn record_dropped_accumulates() {
+        let metrics = PipelineMetrics::default();
+        metrics.record_dropped(10);
+        metrics.record_dropped(2);
+        assert_eq!(metrics.dropped(), 12);
+    }
+
+    #[test]
+    fn record_batch_size_is_last_value() {
+        let metrics = PipelineMetrics::default();
+        metrics.record_batch_size(100);
+        metrics.record_batch_size(42);
+        assert_eq!(metrics.last_batch_size(), 42);
+    }
+
+    #[test]
+    fn metrics_are_independent() {
+        let metrics = PipelineMetrics::default();
+        metrics.record_processed(7);
+        metrics.record_dropped(3);
+        assert_eq!(metrics.processed(), 7);
+        assert_eq!(metrics.dropped(), 3);
+    }
+}

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -7,7 +7,12 @@ pub use event::{EnrichedEvent, EventSource};
 pub use metrics::PipelineMetrics;
 
 use crate::config::RuntimeConfig;
+use crate::ipc::IpcFrame;
+use aa_proto::assembly::audit::v1::{audit_event::Detail, AuditEvent};
+use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::{broadcast, mpsc};
+use tokio_util::sync::CancellationToken;
 
 /// Configuration for the event aggregation pipeline.
 ///
@@ -39,9 +44,181 @@ impl PipelineConfig {
     }
 }
 
+/// Start the event aggregation pipeline.
+///
+/// Consumes `rx` (the inbound IpcFrame channel from the IPC server),
+/// enriches and batches events, and fans them out via `broadcast_tx`.
+///
+/// Returns when `token` is cancelled — flushing any pending batch first.
+pub async fn run(
+    mut rx:       mpsc::Receiver<IpcFrame>,
+    broadcast_tx: broadcast::Sender<EnrichedEvent>,
+    config:       PipelineConfig,
+    metrics:      Arc<PipelineMetrics>,
+    token:        CancellationToken,
+) {
+    let mut batch: Vec<EnrichedEvent> = Vec::with_capacity(config.batch_size);
+    let mut ticker = tokio::time::interval(config.flush_interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            biased;
+
+            _ = token.cancelled() => {
+                // Drain any remaining batch before exiting.
+                if !batch.is_empty() {
+                    flush(&mut batch, &broadcast_tx, &metrics);
+                }
+                break;
+            }
+
+            Some(frame) = rx.recv() => {
+                if let IpcFrame::EventReport(event) = frame {
+                    let enriched = enrich(event, &config.agent_id);
+                    metrics.record_processed(1);
+                    if is_policy_violation(&enriched) {
+                        // Bypass the batch — emit immediately.
+                        let _ = broadcast_tx.send(enriched);
+                    } else {
+                        batch.push(enriched);
+                        if batch.len() >= config.batch_size {
+                            flush(&mut batch, &broadcast_tx, &metrics);
+                        }
+                    }
+                }
+                // PolicyQuery, ApprovalResponse, Heartbeat: not pipeline events, ignored.
+            }
+
+            _ = ticker.tick() => {
+                if !batch.is_empty() {
+                    flush(&mut batch, &broadcast_tx, &metrics);
+                }
+            }
+        }
+    }
+    tracing::info!("pipeline task stopped");
+}
+
+/// Enrich a raw [`AuditEvent`] with runtime-side metadata.
+fn enrich(event: AuditEvent, agent_id: &str) -> EnrichedEvent {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let received_at_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or(Duration::ZERO)
+        .as_millis() as i64;
+    EnrichedEvent {
+        inner: event,
+        received_at_ms,
+        source: EventSource::Sdk,
+        agent_id: agent_id.to_string(),
+    }
+}
+
+/// Returns `true` if this event's detail is a `PolicyViolation`.
+///
+/// Policy violation events bypass batching and are emitted immediately.
+fn is_policy_violation(event: &EnrichedEvent) -> bool {
+    matches!(event.inner.detail, Some(Detail::Violation(_)))
+}
+
+/// Broadcast all events in `batch` and record metrics.
+///
+/// Clears `batch` after broadcasting. Errors from `broadcast_tx.send`
+/// (all receivers dropped) are silently ignored — the pipeline does not
+/// require any active subscribers to operate.
+fn flush(
+    batch:        &mut Vec<EnrichedEvent>,
+    broadcast_tx: &broadcast::Sender<EnrichedEvent>,
+    metrics:      &PipelineMetrics,
+) {
+    let n = batch.len() as u64;
+    for event in batch.drain(..) {
+        let _ = broadcast_tx.send(event);
+    }
+    metrics.record_batch_size(n);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aa_proto::assembly::audit::v1::{audit_event::Detail, AuditEvent, PolicyViolation};
+
+    fn make_audit_event() -> AuditEvent {
+        AuditEvent::default()
+    }
+
+    fn make_policy_violation_event() -> AuditEvent {
+        AuditEvent {
+            detail: Some(Detail::Violation(PolicyViolation {
+                policy_rule: "test-rule".to_string(),
+                blocked_action: "test-action".to_string(),
+                reason: "test-reason".to_string(),
+            })),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn enrich_sets_agent_id() {
+        let event = make_audit_event();
+        let enriched = enrich(event, "my-agent");
+        assert_eq!(enriched.agent_id, "my-agent");
+    }
+
+    #[test]
+    fn enrich_sets_received_at_ms_positive() {
+        let event = make_audit_event();
+        let enriched = enrich(event, "agent");
+        assert!(enriched.received_at_ms > 0);
+    }
+
+    #[test]
+    fn enrich_sets_source_to_sdk() {
+        let event = make_audit_event();
+        let enriched = enrich(event, "agent");
+        assert_eq!(enriched.source, EventSource::Sdk);
+    }
+
+    #[test]
+    fn is_policy_violation_true_for_violation_detail() {
+        let event = make_policy_violation_event();
+        let enriched = enrich(event, "agent");
+        assert!(is_policy_violation(&enriched));
+    }
+
+    #[test]
+    fn is_policy_violation_false_for_normal_event() {
+        let event = make_audit_event(); // detail = None
+        let enriched = enrich(event, "agent");
+        assert!(!is_policy_violation(&enriched));
+    }
+
+    #[test]
+    fn flush_empty_batch_does_nothing() {
+        let (tx, _rx) = broadcast::channel::<EnrichedEvent>(16);
+        let metrics = PipelineMetrics::default();
+        let mut batch: Vec<EnrichedEvent> = vec![];
+        flush(&mut batch, &tx, &metrics);
+        assert_eq!(metrics.last_batch_size(), 0);
+        assert_eq!(metrics.processed(), 0);
+    }
+
+    #[test]
+    fn flush_broadcasts_all_events_and_records_batch_size() {
+        let (tx, mut rx) = broadcast::channel::<EnrichedEvent>(16);
+        let metrics = PipelineMetrics::default();
+        let mut batch = vec![
+            enrich(make_audit_event(), "a"),
+            enrich(make_audit_event(), "b"),
+        ];
+        flush(&mut batch, &tx, &metrics);
+        assert!(batch.is_empty());
+        assert_eq!(metrics.last_batch_size(), 2);
+        // Both events were sent and are receivable.
+        assert!(rx.try_recv().is_ok());
+        assert!(rx.try_recv().is_ok());
+    }
 
     #[test]
     fn from_runtime_config_copies_all_fields() {

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -35,11 +35,11 @@ impl PipelineConfig {
     /// Build a [`PipelineConfig`] from a [`RuntimeConfig`].
     pub fn from_runtime_config(c: &RuntimeConfig) -> Self {
         Self {
-            input_buffer:       c.pipeline_input_buffer,
-            batch_size:         c.pipeline_batch_size,
-            flush_interval:     Duration::from_millis(c.pipeline_flush_interval_ms),
+            input_buffer: c.pipeline_input_buffer,
+            batch_size: c.pipeline_batch_size,
+            flush_interval: Duration::from_millis(c.pipeline_flush_interval_ms),
             broadcast_capacity: c.pipeline_broadcast_capacity,
-            agent_id:           c.agent_id.clone(),
+            agent_id: c.agent_id.clone(),
         }
     }
 }
@@ -51,11 +51,11 @@ impl PipelineConfig {
 ///
 /// Returns when `token` is cancelled — flushing any pending batch first.
 pub async fn run(
-    mut rx:       mpsc::Receiver<IpcFrame>,
+    mut rx: mpsc::Receiver<IpcFrame>,
     broadcast_tx: broadcast::Sender<EnrichedEvent>,
-    config:       PipelineConfig,
-    metrics:      Arc<PipelineMetrics>,
-    token:        CancellationToken,
+    config: PipelineConfig,
+    metrics: Arc<PipelineMetrics>,
+    token: CancellationToken,
 ) {
     let mut batch: Vec<EnrichedEvent> = Vec::with_capacity(config.batch_size);
     let mut ticker = tokio::time::interval(config.flush_interval);
@@ -127,11 +127,7 @@ fn is_policy_violation(event: &EnrichedEvent) -> bool {
 /// Clears `batch` after broadcasting. Errors from `broadcast_tx.send`
 /// (all receivers dropped) are silently ignored — the pipeline does not
 /// require any active subscribers to operate.
-fn flush(
-    batch:        &mut Vec<EnrichedEvent>,
-    broadcast_tx: &broadcast::Sender<EnrichedEvent>,
-    metrics:      &PipelineMetrics,
-) {
+fn flush(batch: &mut Vec<EnrichedEvent>, broadcast_tx: &broadcast::Sender<EnrichedEvent>, metrics: &PipelineMetrics) {
     let n = batch.len() as u64;
     for event in batch.drain(..) {
         let _ = broadcast_tx.send(event);
@@ -208,10 +204,7 @@ mod tests {
     fn flush_broadcasts_all_events_and_records_batch_size() {
         let (tx, mut rx) = broadcast::channel::<EnrichedEvent>(16);
         let metrics = PipelineMetrics::default();
-        let mut batch = vec![
-            enrich(make_audit_event(), "a"),
-            enrich(make_audit_event(), "b"),
-        ];
+        let mut batch = vec![enrich(make_audit_event(), "a"), enrich(make_audit_event(), "b")];
         flush(&mut batch, &tx, &metrics);
         assert!(batch.is_empty());
         assert_eq!(metrics.last_batch_size(), 2);
@@ -269,11 +262,11 @@ mod tests {
 
     fn test_config(batch_size: usize, flush_interval_ms: u64) -> PipelineConfig {
         PipelineConfig {
-            input_buffer:       1_024,
+            input_buffer: 1_024,
             batch_size,
-            flush_interval:     Duration::from_millis(flush_interval_ms),
+            flush_interval: Duration::from_millis(flush_interval_ms),
             broadcast_capacity: 1_024,
-            agent_id:           "test-agent".to_string(),
+            agent_id: "test-agent".to_string(),
         }
     }
 
@@ -451,9 +444,7 @@ mod tests {
         tokio::spawn(run(rx, broadcast_tx, config, metrics.clone(), token.clone()));
 
         // Spawn a receiver that drains the broadcast channel
-        tokio::spawn(async move {
-            while broadcast_rx.recv().await.is_ok() {}
-        });
+        tokio::spawn(async move { while broadcast_rx.recv().await.is_ok() {} });
 
         let start = std::time::Instant::now();
 
@@ -468,14 +459,22 @@ mod tests {
                 break;
             }
             if std::time::Instant::now() > deadline {
-                panic!("load benchmark timeout: only {} / {} events processed", metrics.processed(), EVENT_COUNT);
+                panic!(
+                    "load benchmark timeout: only {} / {} events processed",
+                    metrics.processed(),
+                    EVENT_COUNT
+                );
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
 
         let elapsed = start.elapsed();
-        println!("pipeline_load_benchmark: {} events in {:?} ({:.0} events/sec)",
-            EVENT_COUNT, elapsed, EVENT_COUNT as f64 / elapsed.as_secs_f64());
+        println!(
+            "pipeline_load_benchmark: {} events in {:?} ({:.0} events/sec)",
+            EVENT_COUNT,
+            elapsed,
+            EVENT_COUNT as f64 / elapsed.as_secs_f64()
+        );
 
         assert!(elapsed.as_secs() < 5, "100k events took more than 5s: {:?}", elapsed);
         token.cancel();

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -386,10 +386,19 @@ mod tests {
             tx.send(IpcFrame::EventReport(normal_event())).await.unwrap();
         }
 
-        // Give the run loop a moment to receive them
-        tokio::time::sleep(Duration::from_millis(20)).await;
-
-        // Cancel — should flush the pending 5 events
+        // Wait until the run loop has processed all 5 events before cancelling,
+        // so they are guaranteed to be in the pending batch when the flush fires.
+        let deadline = std::time::Instant::now() + Duration::from_millis(200);
+        loop {
+            if metrics.processed() == 5 {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "events were not processed within 200ms"
+            );
+            tokio::task::yield_now().await;
+        }
         token.cancel();
 
         // Wait for pipeline to stop

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -5,3 +5,84 @@ pub mod metrics;
 
 pub use event::{EnrichedEvent, EventSource};
 pub use metrics::PipelineMetrics;
+
+use crate::config::RuntimeConfig;
+use std::time::Duration;
+
+/// Configuration for the event aggregation pipeline.
+///
+/// Derived from [`RuntimeConfig`] via [`PipelineConfig::from_runtime_config`].
+#[derive(Debug, Clone)]
+pub struct PipelineConfig {
+    /// Depth of the mpsc inbound channel.
+    pub input_buffer: usize,
+    /// Maximum events in a batch before an early flush.
+    pub batch_size: usize,
+    /// Interval between scheduled batch flushes.
+    pub flush_interval: Duration,
+    /// Capacity of the broadcast ring buffer.
+    pub broadcast_capacity: usize,
+    /// Agent identity — copied from `RuntimeConfig::agent_id`.
+    pub agent_id: String,
+}
+
+impl PipelineConfig {
+    /// Build a [`PipelineConfig`] from a [`RuntimeConfig`].
+    pub fn from_runtime_config(c: &RuntimeConfig) -> Self {
+        Self {
+            input_buffer:       c.pipeline_input_buffer,
+            batch_size:         c.pipeline_batch_size,
+            flush_interval:     Duration::from_millis(c.pipeline_flush_interval_ms),
+            broadcast_capacity: c.pipeline_broadcast_capacity,
+            agent_id:           c.agent_id.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_runtime_config_copies_all_fields() {
+        let runtime_config = RuntimeConfig {
+            agent_id: "test-agent".to_string(),
+            worker_threads: 0,
+            shutdown_timeout_secs: 30,
+            ipc_max_connections: 64,
+            pipeline_input_buffer: 5_000,
+            pipeline_batch_size: 50,
+            pipeline_flush_interval_ms: 200,
+            pipeline_broadcast_capacity: 512,
+        };
+
+        let pipeline_config = PipelineConfig::from_runtime_config(&runtime_config);
+
+        assert_eq!(pipeline_config.input_buffer, runtime_config.pipeline_input_buffer);
+        assert_eq!(pipeline_config.batch_size, runtime_config.pipeline_batch_size);
+        assert_eq!(
+            pipeline_config.flush_interval,
+            Duration::from_millis(runtime_config.pipeline_flush_interval_ms)
+        );
+        assert_eq!(
+            pipeline_config.broadcast_capacity,
+            runtime_config.pipeline_broadcast_capacity
+        );
+        assert_eq!(pipeline_config.agent_id, runtime_config.agent_id);
+    }
+
+    #[test]
+    fn pipeline_config_is_clone() {
+        let pipeline_config = PipelineConfig {
+            input_buffer: 5_000,
+            batch_size: 50,
+            flush_interval: Duration::from_millis(200),
+            broadcast_capacity: 512,
+            agent_id: "test-agent".to_string(),
+        };
+
+        let cloned = pipeline_config.clone();
+
+        assert_eq!(cloned.agent_id, pipeline_config.agent_id);
+    }
+}

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -262,4 +262,213 @@ mod tests {
 
         assert_eq!(cloned.agent_id, pipeline_config.agent_id);
     }
+
+    // -----------------------------------------------------------------------
+    // Integration test helpers
+    // -----------------------------------------------------------------------
+
+    fn test_config(batch_size: usize, flush_interval_ms: u64) -> PipelineConfig {
+        PipelineConfig {
+            input_buffer:       1_024,
+            batch_size,
+            flush_interval:     Duration::from_millis(flush_interval_ms),
+            broadcast_capacity: 1_024,
+            agent_id:           "test-agent".to_string(),
+        }
+    }
+
+    fn normal_event() -> AuditEvent {
+        AuditEvent::default()
+    }
+
+    fn violation_event() -> AuditEvent {
+        AuditEvent {
+            detail: Some(Detail::Violation(PolicyViolation {
+                policy_rule: "rule".to_string(),
+                blocked_action: "action".to_string(),
+                reason: "reason".to_string(),
+            })),
+            ..Default::default()
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration tests — spin up a real run() task
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn batch_flushes_on_size_threshold() {
+        let config = test_config(3, 10_000); // batch_size=3, very long interval (won't fire)
+        let (tx, rx) = mpsc::channel::<IpcFrame>(64);
+        let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<EnrichedEvent>(64);
+        let metrics = Arc::new(PipelineMetrics::default());
+        let token = CancellationToken::new();
+
+        tokio::spawn(run(rx, broadcast_tx, config, metrics.clone(), token.clone()));
+
+        // Send 3 events — batch threshold reached, should flush before interval
+        for _ in 0..3 {
+            tx.send(IpcFrame::EventReport(normal_event())).await.unwrap();
+        }
+
+        // All 3 events should arrive within a short time
+        for _ in 0..3 {
+            tokio::time::timeout(Duration::from_millis(500), broadcast_rx.recv())
+                .await
+                .expect("timed out waiting for event")
+                .expect("broadcast error");
+        }
+        assert_eq!(metrics.processed(), 3);
+        token.cancel();
+    }
+
+    #[tokio::test]
+    async fn batch_flushes_on_interval() {
+        let config = test_config(100, 50); // batch_size=100 (won't reach), interval=50ms
+        let (tx, rx) = mpsc::channel::<IpcFrame>(64);
+        let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<EnrichedEvent>(64);
+        let metrics = Arc::new(PipelineMetrics::default());
+        let token = CancellationToken::new();
+
+        tokio::spawn(run(rx, broadcast_tx, config, metrics.clone(), token.clone()));
+
+        // Send 5 events (less than batch_size=100) — should arrive after interval flush
+        for _ in 0..5 {
+            tx.send(IpcFrame::EventReport(normal_event())).await.unwrap();
+        }
+
+        for _ in 0..5 {
+            tokio::time::timeout(Duration::from_millis(500), broadcast_rx.recv())
+                .await
+                .expect("timed out waiting for event from interval flush")
+                .expect("broadcast error");
+        }
+        assert_eq!(metrics.processed(), 5);
+        token.cancel();
+    }
+
+    #[tokio::test]
+    async fn policy_violation_bypasses_batch() {
+        // batch_size=100, very long interval — only a violation should arrive
+        let config = test_config(100, 10_000);
+        let (tx, rx) = mpsc::channel::<IpcFrame>(64);
+        let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<EnrichedEvent>(64);
+        let metrics = Arc::new(PipelineMetrics::default());
+        let token = CancellationToken::new();
+
+        tokio::spawn(run(rx, broadcast_tx, config, metrics.clone(), token.clone()));
+
+        // Send a violation — should arrive immediately, bypassing batch
+        tx.send(IpcFrame::EventReport(violation_event())).await.unwrap();
+
+        let event = tokio::time::timeout(Duration::from_millis(200), broadcast_rx.recv())
+            .await
+            .expect("violation event should arrive immediately, before any flush interval")
+            .expect("broadcast error");
+
+        assert!(matches!(event.inner.detail, Some(Detail::Violation(_))));
+        assert_eq!(metrics.processed(), 1);
+        token.cancel();
+    }
+
+    #[tokio::test]
+    async fn cancellation_flushes_pending_batch() {
+        let config = test_config(100, 10_000); // large batch, long interval
+        let (tx, rx) = mpsc::channel::<IpcFrame>(64);
+        let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<EnrichedEvent>(64);
+        let metrics = Arc::new(PipelineMetrics::default());
+        let token = CancellationToken::new();
+
+        let handle = tokio::spawn(run(rx, broadcast_tx, config, metrics.clone(), token.clone()));
+
+        // Send 5 events (batch won't flush yet)
+        for _ in 0..5 {
+            tx.send(IpcFrame::EventReport(normal_event())).await.unwrap();
+        }
+
+        // Give the run loop a moment to receive them
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // Cancel — should flush the pending 5 events
+        token.cancel();
+
+        // Wait for pipeline to stop
+        tokio::time::timeout(Duration::from_millis(500), handle)
+            .await
+            .expect("pipeline did not stop after cancellation")
+            .expect("pipeline task panicked");
+
+        // All 5 events should be in the broadcast channel
+        let mut received = 0;
+        while broadcast_rx.try_recv().is_ok() {
+            received += 1;
+        }
+        assert_eq!(received, 5, "expected 5 events flushed on cancellation");
+    }
+
+    #[tokio::test]
+    async fn non_event_frames_ignored() {
+        let config = test_config(100, 50);
+        let (tx, rx) = mpsc::channel::<IpcFrame>(64);
+        let (broadcast_tx, _broadcast_rx) = broadcast::channel::<EnrichedEvent>(64);
+        let metrics = Arc::new(PipelineMetrics::default());
+        let token = CancellationToken::new();
+
+        tokio::spawn(run(rx, broadcast_tx, config, metrics.clone(), token.clone()));
+
+        // Send non-event frames
+        tx.send(IpcFrame::Heartbeat).await.unwrap();
+
+        // Give run loop a moment to process
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // No events processed
+        assert_eq!(metrics.processed(), 0);
+        token.cancel();
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn pipeline_load_benchmark() {
+        // Run with: cargo test -p aa-runtime -- --ignored pipeline_load_benchmark --nocapture
+        const EVENT_COUNT: u64 = 100_000;
+
+        let config = test_config(100, 10);
+        let (tx, rx) = mpsc::channel::<IpcFrame>(10_000);
+        let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<EnrichedEvent>(10_000);
+        let metrics = Arc::new(PipelineMetrics::default());
+        let token = CancellationToken::new();
+
+        tokio::spawn(run(rx, broadcast_tx, config, metrics.clone(), token.clone()));
+
+        // Spawn a receiver that drains the broadcast channel
+        tokio::spawn(async move {
+            while broadcast_rx.recv().await.is_ok() {}
+        });
+
+        let start = std::time::Instant::now();
+
+        for _ in 0..EVENT_COUNT {
+            tx.send(IpcFrame::EventReport(normal_event())).await.unwrap();
+        }
+
+        // Wait until all events are processed
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            if metrics.processed() >= EVENT_COUNT {
+                break;
+            }
+            if std::time::Instant::now() > deadline {
+                panic!("load benchmark timeout: only {} / {} events processed", metrics.processed(), EVENT_COUNT);
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let elapsed = start.elapsed();
+        println!("pipeline_load_benchmark: {} events in {:?} ({:.0} events/sec)",
+            EVENT_COUNT, elapsed, EVENT_COUNT as f64 / elapsed.as_secs_f64());
+
+        assert!(elapsed.as_secs() < 5, "100k events took more than 5s: {:?}", elapsed);
+        token.cancel();
+    }
 }

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -1,5 +1,7 @@
 //! Event aggregation pipeline — receives IpcFrames, enriches, batches, and fans out.
 
 pub mod event;
+pub mod metrics;
 
 pub use event::{EnrichedEvent, EventSource};
+pub use metrics::PipelineMetrics;

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -1,1 +1,5 @@
-//! Event aggregation pipeline — implemented in AAASM-31.
+//! Event aggregation pipeline — receives IpcFrames, enriches, batches, and fans out.
+
+pub mod event;
+
+pub use event::{EnrichedEvent, EventSource};

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -23,16 +23,13 @@ pub async fn run(config: RuntimeConfig) {
 
     // Build pipeline config and create the inbound channel at the configured depth.
     let pipeline_config = crate::pipeline::PipelineConfig::from_runtime_config(&config);
-    let (inbound_tx, inbound_rx) =
-        tokio::sync::mpsc::channel::<crate::ipc::IpcFrame>(pipeline_config.input_buffer);
+    let (inbound_tx, inbound_rx) = tokio::sync::mpsc::channel::<crate::ipc::IpcFrame>(pipeline_config.input_buffer);
 
     // Create the broadcast channel for fan-out to downstream subscribers.
     // The leading `_broadcast_rx` keeps the channel alive until real subscribers
     // are wired in AAASM-32+.
     let (broadcast_tx, _broadcast_rx) =
-        tokio::sync::broadcast::channel::<crate::pipeline::EnrichedEvent>(
-            pipeline_config.broadcast_capacity,
-        );
+        tokio::sync::broadcast::channel::<crate::pipeline::EnrichedEvent>(pipeline_config.broadcast_capacity);
 
     // Shared metrics — future health/metrics endpoints will receive an Arc clone.
     let pipeline_metrics = std::sync::Arc::new(crate::pipeline::PipelineMetrics::default());

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -21,8 +21,23 @@ pub async fn run(config: RuntimeConfig) {
 
     tracing::info!("structured concurrency primitives initialised");
 
+    // Build pipeline config and create the inbound channel at the configured depth.
+    let pipeline_config = crate::pipeline::PipelineConfig::from_runtime_config(&config);
+    let (inbound_tx, inbound_rx) =
+        tokio::sync::mpsc::channel::<crate::ipc::IpcFrame>(pipeline_config.input_buffer);
+
+    // Create the broadcast channel for fan-out to downstream subscribers.
+    // The leading `_broadcast_rx` keeps the channel alive until real subscribers
+    // are wired in AAASM-32+.
+    let (broadcast_tx, _broadcast_rx) =
+        tokio::sync::broadcast::channel::<crate::pipeline::EnrichedEvent>(
+            pipeline_config.broadcast_capacity,
+        );
+
+    // Shared metrics — future health/metrics endpoints will receive an Arc clone.
+    let pipeline_metrics = std::sync::Arc::new(crate::pipeline::PipelineMetrics::default());
+
     // Spawn the IPC server task.
-    let (inbound_tx, _inbound_rx) = tokio::sync::mpsc::channel::<crate::ipc::IpcFrame>(256);
     let ipc_config = crate::ipc::server::IpcServerConfig::from_runtime_config(&config);
     match crate::ipc::server::IpcServer::bind(ipc_config) {
         Ok(ipc_server) => {
@@ -35,7 +50,19 @@ pub async fn run(config: RuntimeConfig) {
         }
         Err(e) => {
             tracing::error!(error = %e, "failed to bind IPC socket — continuing without IPC");
+            // Without an IPC server the inbound_tx is dropped here;
+            // the pipeline will see the channel closed and exit cleanly.
         }
+    }
+
+    // Spawn the event aggregation pipeline task.
+    {
+        let pipeline_token = token.clone();
+        let pm = pipeline_metrics.clone();
+        tracker.spawn(async move {
+            crate::pipeline::run(inbound_rx, broadcast_tx, pipeline_config, pm, pipeline_token).await;
+        });
+        tracing::info!("pipeline task spawned");
     }
 
     // Wait for an OS shutdown signal.


### PR DESCRIPTION
## Summary

- Implements the internal event aggregation pipeline in `aa-runtime` (AAASM-31), consuming `inbound_rx` left as a placeholder by AAASM-30
- Receive → Enrich → Classify → Batch/Immediate → `tokio::broadcast` fan-out with dual-trigger flush (100ms interval **or** 100-event threshold, whichever fires first)
- `PolicyViolation` events bypass the batch and are broadcast immediately; normal events are batched and flushed on either trigger
- In-process `PipelineMetrics` (`events_processed_total`, `events_dropped_total`, `last_batch_size`) via `AtomicU64` — HTTP exposure deferred to AAASM-32

## What changed

| File | Change |
|---|---|
| `aa-runtime/src/config.rs` | 4 new env-var fields: `AA_PIPELINE_INPUT_BUFFER` (10k), `AA_PIPELINE_BATCH_SIZE` (100), `AA_PIPELINE_FLUSH_INTERVAL_MS` (100), `AA_PIPELINE_BROADCAST_CAPACITY` (1024) |
| `aa-runtime/src/pipeline/event.rs` | New — `EnrichedEvent` (Clone) + `EventSource` enum |
| `aa-runtime/src/pipeline/metrics.rs` | New — `PipelineMetrics` with `AtomicU64` counters |
| `aa-runtime/src/pipeline/mod.rs` | Expanded — `PipelineConfig`, `run()`, `enrich()`, `is_policy_violation()`, `flush()`, 22 tests + `#[ignore]` load benchmark |
| `aa-runtime/src/runtime.rs` | Wired: `_inbound_rx` → pipeline task, broadcast channel created, `Arc<PipelineMetrics>` kept in scope for AAASM-32 |

## Test plan

- [ ] `cargo test -p aa-runtime -- --test-threads=1` — 52 passed, 0 failed, 2 ignored
- [ ] `cargo clippy -p aa-runtime -- -D warnings` — clean
- [ ] `cargo fmt -p aa-runtime --check` — clean
- [ ] Load benchmark (optional): `cargo test -p aa-runtime -- --ignored pipeline_load_benchmark --nocapture`

## Notes

- `events_dropped_total` is owned by `PipelineMetrics` but incremented by broadcast **subscribers** (not the pipeline itself) when they receive `RecvError::Lagged(n)`. Subscribers in AAASM-32+ will receive an `Arc<PipelineMetrics>` clone for this purpose.
- `_broadcast_rx` in `runtime.rs` keeps the broadcast channel alive until real subscribers are wired in AAASM-32+.

Closes #AAASM-31