### PR TITLE
[AAASM-25] ✨ (aa-core/audit): Implement immutable AuditEntry with SHA-256 hash chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "criterion",
  "serde",
  "serde_json",
+ "sha2",
 ]
 
 [[package]]

--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -10,11 +10,12 @@ description = "Pure domain logic for Agent Assembly — no_std compatible"
 aho-corasick = { version = "1", optional = true }
 cfg-if = "1"
 serde  = { version = "1", default-features = false, features = ["derive", "alloc"], optional = true }
+sha2   = { version = "0.10", default-features = false, optional = true }
 
 [features]
 default    = ["std"]
 std        = ["alloc", "dep:aho-corasick"]
-alloc      = []
+alloc      = ["dep:sha2"]
 serde      = ["dep:serde"]
 test-utils = []
 

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -202,6 +202,28 @@ impl AuditEntry {
     }
 
     // -----------------------------------------------------------------------
+    // Integrity
+    // -----------------------------------------------------------------------
+
+    /// Returns `true` if the stored `entry_hash` matches a fresh re-computation
+    /// over the stored fields.
+    ///
+    /// Returns `false` if any field has been altered after construction — including
+    /// via `unsafe` code.
+    pub fn verify_integrity(&self) -> bool {
+        let expected = Self::compute_hash(
+            self.seq,
+            self.timestamp_ns,
+            &self.event_type,
+            &self.agent_id,
+            &self.session_id,
+            &self.previous_hash,
+            &self.payload,
+        );
+        expected == self.entry_hash
+    }
+
+    // -----------------------------------------------------------------------
     // Private helpers
     // -----------------------------------------------------------------------
 

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -251,3 +251,27 @@ impl AuditEntry {
         hasher.finalize().into()
     }
 }
+
+// ---------------------------------------------------------------------------
+// Display
+// ---------------------------------------------------------------------------
+
+impl core::fmt::Display for AuditEntry {
+    /// Human-readable one-line representation suitable for log output.
+    ///
+    /// Format: `[seq=N ts=T agent=HEX session=HEX event=TypeName]`
+    ///
+    /// `payload` is omitted from `Display` — it may be arbitrarily large.
+    /// Use [`AuditEntry::payload`] to access the full payload string.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "[seq={} ts={} agent=", self.seq, self.timestamp_ns)?;
+        for b in self.agent_id.as_bytes() {
+            write!(f, "{:02x}", b)?;
+        }
+        write!(f, " session=")?;
+        for b in self.session_id.as_bytes() {
+            write!(f, "{:02x}", b)?;
+        }
+        write!(f, " event={}]", self.event_type.as_str())
+    }
+}

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -1,0 +1,47 @@
+//! Immutable, hash-chained audit entry for Agent Assembly governance events.
+//!
+//! Each [`AuditEntry`] commits to all tamper-meaningful fields via a SHA-256 hash
+//! that includes the hash of the preceding entry, forming a tamper-evident chain.
+//!
+//! Gated on the `alloc` feature because [`AuditEntry::payload`] is an
+//! [`alloc::string::String`].
+
+// ---------------------------------------------------------------------------
+// AuditEventType
+// ---------------------------------------------------------------------------
+
+/// Category of a governance event recorded in an [`AuditEntry`].
+///
+/// The `#[repr(u32)]` attribute makes `event_type as u32` the canonical
+/// 4-byte discriminant used in the SHA-256 hash input.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum AuditEventType {
+    ToolCallIntercepted = 0,
+    PolicyViolation = 1,
+    CredentialLeakBlocked = 2,
+    ApprovalRequested = 3,
+    ApprovalGranted = 4,
+    ApprovalDenied = 5,
+    BudgetLimitApproached = 6,
+    BudgetLimitExceeded = 7,
+}
+
+impl AuditEventType {
+    /// Returns the string label used in [`Display`] output and log messages.
+    ///
+    /// [`Display`]: core::fmt::Display
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ToolCallIntercepted => "ToolCallIntercepted",
+            Self::PolicyViolation => "PolicyViolation",
+            Self::CredentialLeakBlocked => "CredentialLeakBlocked",
+            Self::ApprovalRequested => "ApprovalRequested",
+            Self::ApprovalGranted => "ApprovalGranted",
+            Self::ApprovalDenied => "ApprovalDenied",
+            Self::BudgetLimitApproached => "BudgetLimitApproached",
+            Self::BudgetLimitExceeded => "BudgetLimitExceeded",
+        }
+    }
+}

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -275,3 +275,74 @@ impl core::fmt::Display for AuditEntry {
         write!(f, " event={}]", self.event_type.as_str())
     }
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Shared test fixtures
+    const AGENT_BYTES: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+    const SESSION_BYTES: [u8; 16] = [17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32];
+    const GENESIS_HASH: [u8; 32] = [0u8; 32];
+
+    fn make_entry(seq: u64) -> AuditEntry {
+        AuditEntry::new(
+            seq,
+            1_714_222_134_000_000_000,
+            AuditEventType::ToolCallIntercepted,
+            AgentId::from_bytes(AGENT_BYTES),
+            SessionId::from_bytes(SESSION_BYTES),
+            alloc::string::String::from("{\"tool\":\"bash\",\"args\":{\"cmd\":\"ls\"}}"),
+            GENESIS_HASH,
+        )
+    }
+
+    // --- AuditEventType ---
+
+    #[test]
+    fn event_type_as_str_all_variants() {
+        assert_eq!(AuditEventType::ToolCallIntercepted.as_str(), "ToolCallIntercepted");
+        assert_eq!(AuditEventType::PolicyViolation.as_str(), "PolicyViolation");
+        assert_eq!(AuditEventType::CredentialLeakBlocked.as_str(), "CredentialLeakBlocked");
+        assert_eq!(AuditEventType::ApprovalRequested.as_str(), "ApprovalRequested");
+        assert_eq!(AuditEventType::ApprovalGranted.as_str(), "ApprovalGranted");
+        assert_eq!(AuditEventType::ApprovalDenied.as_str(), "ApprovalDenied");
+        assert_eq!(AuditEventType::BudgetLimitApproached.as_str(), "BudgetLimitApproached");
+        assert_eq!(AuditEventType::BudgetLimitExceeded.as_str(), "BudgetLimitExceeded");
+    }
+
+    #[test]
+    fn event_type_discriminants_are_0_through_7() {
+        assert_eq!(AuditEventType::ToolCallIntercepted as u32, 0);
+        assert_eq!(AuditEventType::PolicyViolation as u32, 1);
+        assert_eq!(AuditEventType::CredentialLeakBlocked as u32, 2);
+        assert_eq!(AuditEventType::ApprovalRequested as u32, 3);
+        assert_eq!(AuditEventType::ApprovalGranted as u32, 4);
+        assert_eq!(AuditEventType::ApprovalDenied as u32, 5);
+        assert_eq!(AuditEventType::BudgetLimitApproached as u32, 6);
+        assert_eq!(AuditEventType::BudgetLimitExceeded as u32, 7);
+    }
+
+    #[test]
+    fn event_type_variants_are_all_distinct() {
+        let variants = [
+            AuditEventType::ToolCallIntercepted,
+            AuditEventType::PolicyViolation,
+            AuditEventType::CredentialLeakBlocked,
+            AuditEventType::ApprovalRequested,
+            AuditEventType::ApprovalGranted,
+            AuditEventType::ApprovalDenied,
+            AuditEventType::BudgetLimitApproached,
+            AuditEventType::BudgetLimitExceeded,
+        ];
+        for i in 0..variants.len() {
+            for j in (i + 1)..variants.len() {
+                assert_ne!(variants[i], variants[j]);
+            }
+        }
+    }
+}

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -6,6 +6,10 @@
 //! Gated on the `alloc` feature because [`AuditEntry::payload`] is an
 //! [`alloc::string::String`].
 
+use alloc::string::String;
+
+use crate::{AgentId, SessionId};
+
 // ---------------------------------------------------------------------------
 // AuditEventType
 // ---------------------------------------------------------------------------
@@ -43,5 +47,95 @@ impl AuditEventType {
             Self::BudgetLimitApproached => "BudgetLimitApproached",
             Self::BudgetLimitExceeded => "BudgetLimitExceeded",
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// AuditEntry
+// ---------------------------------------------------------------------------
+
+/// An immutable, hash-chained record of a single governance event.
+///
+/// ## Immutability
+///
+/// All fields are private. The only way to create an [`AuditEntry`] is via
+/// [`AuditEntry::new`]. There are no mutation methods.
+///
+/// ## Hash chain
+///
+/// `entry_hash` is a SHA-256 digest computed over all tamper-meaningful fields
+/// in a canonical byte order (see [`AuditEntry::new`] for the full sequence).
+/// Each entry commits to `previous_hash`, linking entries into a tamper-evident
+/// chain. The genesis entry uses `[0u8; 32]` as `previous_hash`.
+///
+/// ## Tamper detection
+///
+/// [`AuditEntry::verify_integrity`] re-computes the hash from the stored fields
+/// and compares it to the stored `entry_hash`. Any field alteration — including
+/// via `unsafe` code — will cause the re-computed hash to diverge.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct AuditEntry {
+    seq: u64,
+    timestamp_ns: u64,
+    event_type: AuditEventType,
+    agent_id: AgentId,
+    session_id: SessionId,
+    payload: String,
+    previous_hash: [u8; 32],
+    entry_hash: [u8; 32],
+}
+
+impl AuditEntry {
+    // -----------------------------------------------------------------------
+    // Getters
+    // -----------------------------------------------------------------------
+
+    /// Monotonic sequence counter within the session.
+    #[inline]
+    pub fn seq(&self) -> u64 {
+        self.seq
+    }
+
+    /// Nanoseconds since the Unix epoch at the time the entry was created.
+    #[inline]
+    pub fn timestamp_ns(&self) -> u64 {
+        self.timestamp_ns
+    }
+
+    /// Category of the governance event.
+    #[inline]
+    pub fn event_type(&self) -> AuditEventType {
+        self.event_type
+    }
+
+    /// Identifier of the agent that produced this entry.
+    #[inline]
+    pub fn agent_id(&self) -> AgentId {
+        self.agent_id
+    }
+
+    /// Identifier of the specific agent run (session) that produced this entry.
+    #[inline]
+    pub fn session_id(&self) -> SessionId {
+        self.session_id
+    }
+
+    /// Pre-serialized UTF-8 payload (JSON in practice).
+    #[inline]
+    pub fn payload(&self) -> &str {
+        &self.payload
+    }
+
+    /// SHA-256 hash of the preceding entry; `[0u8; 32]` for the genesis entry.
+    #[inline]
+    pub fn previous_hash(&self) -> &[u8; 32] {
+        &self.previous_hash
+    }
+
+    /// SHA-256 hash computed over all tamper-meaningful fields at construction.
+    #[inline]
+    pub fn entry_hash(&self) -> &[u8; 32] {
+        &self.entry_hash
     }
 }

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -89,6 +89,67 @@ pub struct AuditEntry {
 
 impl AuditEntry {
     // -----------------------------------------------------------------------
+    // Constructor
+    // -----------------------------------------------------------------------
+
+    /// Create a new [`AuditEntry`], computing `entry_hash` over all fields.
+    ///
+    /// ## Parameters
+    ///
+    /// - `seq` — monotonic counter within the session; genesis entry is `0`.
+    /// - `timestamp_ns` — nanoseconds since the Unix epoch (caller-supplied;
+    ///   use `Timestamp::from(SystemTime::now()).as_nanos()` in `std` environments).
+    /// - `event_type` — category of the governance event.
+    /// - `agent_id` — identifier of the agent that produced the event.
+    /// - `session_id` — identifier of the specific agent run.
+    /// - `payload` — pre-serialized UTF-8 string (JSON in practice).
+    /// - `previous_hash` — `entry_hash` of the preceding entry;
+    ///   `[0u8; 32]` for the genesis entry.
+    ///
+    /// ## Canonical hash input (84 fixed bytes + variable payload)
+    ///
+    /// ```text
+    /// SHA-256(
+    ///     seq.to_be_bytes()                  //  8 bytes
+    ///     || timestamp_ns.to_be_bytes()      //  8 bytes
+    ///     || (event_type as u32).to_be_bytes() // 4 bytes
+    ///     || agent_id.as_bytes()             // 16 bytes
+    ///     || session_id.as_bytes()           // 16 bytes
+    ///     || previous_hash                   // 32 bytes
+    ///     || payload.as_bytes()              // variable
+    /// )
+    /// ```
+    pub fn new(
+        seq: u64,
+        timestamp_ns: u64,
+        event_type: AuditEventType,
+        agent_id: AgentId,
+        session_id: SessionId,
+        payload: String,
+        previous_hash: [u8; 32],
+    ) -> Self {
+        let entry_hash = Self::compute_hash(
+            seq,
+            timestamp_ns,
+            &event_type,
+            &agent_id,
+            &session_id,
+            &previous_hash,
+            &payload,
+        );
+        Self {
+            seq,
+            timestamp_ns,
+            event_type,
+            agent_id,
+            session_id,
+            payload,
+            previous_hash,
+            entry_hash,
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // Getters
     // -----------------------------------------------------------------------
 

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -345,4 +345,39 @@ mod tests {
             }
         }
     }
+
+    // --- AuditEntry::new() and getters ---
+
+    #[test]
+    fn new_produces_nonzero_entry_hash() {
+        let entry = make_entry(0);
+        assert_ne!(entry.entry_hash(), &[0u8; 32]);
+    }
+
+    #[test]
+    fn getters_return_correct_values() {
+        let payload = alloc::string::String::from("{\"k\":\"v\"}");
+        let entry = AuditEntry::new(
+            42,
+            999_000_000,
+            AuditEventType::PolicyViolation,
+            AgentId::from_bytes(AGENT_BYTES),
+            SessionId::from_bytes(SESSION_BYTES),
+            payload.clone(),
+            GENESIS_HASH,
+        );
+        assert_eq!(entry.seq(), 42);
+        assert_eq!(entry.timestamp_ns(), 999_000_000);
+        assert_eq!(entry.event_type(), AuditEventType::PolicyViolation);
+        assert_eq!(entry.agent_id(), AgentId::from_bytes(AGENT_BYTES));
+        assert_eq!(entry.session_id(), SessionId::from_bytes(SESSION_BYTES));
+        assert_eq!(entry.payload(), "{\"k\":\"v\"}");
+        assert_eq!(entry.previous_hash(), &GENESIS_HASH);
+    }
+
+    #[test]
+    fn genesis_entry_uses_zero_previous_hash() {
+        let entry = make_entry(0);
+        assert_eq!(entry.previous_hash(), &[0u8; 32]);
+    }
 }

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -380,4 +380,57 @@ mod tests {
         let entry = make_entry(0);
         assert_eq!(entry.previous_hash(), &[0u8; 32]);
     }
+
+    // --- verify_integrity() ---
+
+    #[test]
+    fn verify_integrity_true_for_untampered_entry() {
+        assert!(make_entry(0).verify_integrity());
+    }
+
+    #[test]
+    fn verify_integrity_false_after_seq_tamper() {
+        let mut entry = make_entry(0);
+        // SAFETY: deliberate tampering to test integrity detection.
+        unsafe {
+            let ptr = &mut entry.seq as *mut u64;
+            *ptr = 999;
+        }
+        assert!(!entry.verify_integrity());
+    }
+
+    #[test]
+    fn verify_integrity_false_after_payload_tamper() {
+        let mut entry = make_entry(0);
+        // SAFETY: deliberate tampering to test integrity detection.
+        unsafe {
+            let ptr = entry.payload.as_mut_vec();
+            if let Some(b) = ptr.first_mut() {
+                *b = b'X';
+            }
+        }
+        assert!(!entry.verify_integrity());
+    }
+
+    #[test]
+    fn verify_integrity_false_after_event_type_tamper() {
+        let mut entry = make_entry(0);
+        // SAFETY: deliberate tampering to test integrity detection.
+        unsafe {
+            let ptr = &mut entry.event_type as *mut AuditEventType;
+            *ptr = AuditEventType::BudgetLimitExceeded;
+        }
+        assert!(!entry.verify_integrity());
+    }
+
+    #[test]
+    fn verify_integrity_false_after_previous_hash_tamper() {
+        let mut entry = make_entry(0);
+        // SAFETY: deliberate tampering to test integrity detection.
+        unsafe {
+            let ptr = &mut entry.previous_hash as *mut [u8; 32];
+            (*ptr)[0] = 0xFF;
+        }
+        assert!(!entry.verify_integrity());
+    }
 }

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -7,6 +7,7 @@
 //! [`alloc::string::String`].
 
 use alloc::string::String;
+use sha2::{Digest, Sha256};
 
 use crate::{AgentId, SessionId};
 
@@ -137,5 +138,33 @@ impl AuditEntry {
     #[inline]
     pub fn entry_hash(&self) -> &[u8; 32] {
         &self.entry_hash
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers
+    // -----------------------------------------------------------------------
+
+    /// Canonical SHA-256 computation over all tamper-meaningful fields.
+    ///
+    /// Field order and encoding are fixed — see [`AuditEntry::new`] for the
+    /// documented byte sequence.
+    fn compute_hash(
+        seq: u64,
+        timestamp_ns: u64,
+        event_type: &AuditEventType,
+        agent_id: &AgentId,
+        session_id: &SessionId,
+        previous_hash: &[u8; 32],
+        payload: &str,
+    ) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(seq.to_be_bytes());
+        hasher.update(timestamp_ns.to_be_bytes());
+        hasher.update((*event_type as u32).to_be_bytes());
+        hasher.update(agent_id.as_bytes());
+        hasher.update(session_id.as_bytes());
+        hasher.update(previous_hash);
+        hasher.update(payload.as_bytes());
+        hasher.finalize().into()
     }
 }

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -433,4 +433,87 @@ mod tests {
         }
         assert!(!entry.verify_integrity());
     }
+
+    // --- Hash chain linkage ---
+
+    #[test]
+    fn chained_entries_have_distinct_hashes() {
+        let first = make_entry(0);
+        let second = AuditEntry::new(
+            1,
+            1_714_222_134_000_000_001,
+            AuditEventType::PolicyViolation,
+            AgentId::from_bytes(AGENT_BYTES),
+            SessionId::from_bytes(SESSION_BYTES),
+            alloc::string::String::from("{\"rule\":\"deny\"}"),
+            *first.entry_hash(),
+        );
+        assert_ne!(first.entry_hash(), second.entry_hash());
+        assert_eq!(second.previous_hash(), first.entry_hash());
+        assert!(second.verify_integrity());
+    }
+
+    #[test]
+    fn different_seq_produces_different_hash() {
+        let a = make_entry(0);
+        let b = make_entry(1);
+        assert_ne!(a.entry_hash(), b.entry_hash());
+    }
+
+    #[test]
+    fn different_previous_hash_produces_different_entry_hash() {
+        let prev_a = [0u8; 32];
+        let mut prev_b = [0u8; 32];
+        prev_b[0] = 1;
+
+        let a = AuditEntry::new(
+            0,
+            0,
+            AuditEventType::ToolCallIntercepted,
+            AgentId::from_bytes(AGENT_BYTES),
+            SessionId::from_bytes(SESSION_BYTES),
+            alloc::string::String::from("{}"),
+            prev_a,
+        );
+        let b = AuditEntry::new(
+            0,
+            0,
+            AuditEventType::ToolCallIntercepted,
+            AgentId::from_bytes(AGENT_BYTES),
+            SessionId::from_bytes(SESSION_BYTES),
+            alloc::string::String::from("{}"),
+            prev_b,
+        );
+        assert_ne!(a.entry_hash(), b.entry_hash());
+    }
+
+    // --- Display ---
+
+    #[test]
+    fn display_contains_seq_ts_and_event_name() {
+        let entry = make_entry(7);
+        let s = alloc::format!("{}", entry);
+        assert!(s.starts_with('['));
+        assert!(s.ends_with(']'));
+        assert!(s.contains("seq=7"));
+        assert!(s.contains("ts=1714222134000000000"));
+        assert!(s.contains("event=ToolCallIntercepted"));
+    }
+
+    #[test]
+    fn display_contains_agent_and_session_hex() {
+        let entry = make_entry(0);
+        let s = alloc::format!("{}", entry);
+        // AGENT_BYTES starts with 01 02 03 04
+        assert!(s.contains("agent=01020304"));
+        // SESSION_BYTES starts with 11 12 13 14
+        assert!(s.contains("session=11121314"));
+    }
+
+    #[test]
+    fn display_does_not_contain_payload() {
+        let entry = make_entry(0);
+        let s = alloc::format!("{}", entry);
+        assert!(!s.contains("bash"));
+    }
 }

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -11,6 +11,7 @@
 //! - `serde`: enables `Serialize`/`Deserialize` derives on all core types (added in AAASM-22–25)
 //! - `test-utils`: exposes `PermitAllEvaluator` and `DenyAllEvaluator` for downstream test code
 //! - `std` (also default): enables `CredentialScanner` and all std-dependent types
+//! - `alloc` (also default via std): enables `AuditEntry`, `AuditEventType`, and all audit types
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
@@ -21,6 +22,8 @@ cfg_if::cfg_if! {
 }
 
 pub mod agent;
+#[cfg(feature = "alloc")]
+pub mod audit;
 pub mod evaluators;
 pub mod identity;
 pub mod policy;
@@ -39,6 +42,9 @@ pub use policy::{ArgsJson, GovernanceAction, PolicyDocument, PolicyEvaluator, Po
 
 #[cfg(all(feature = "alloc", feature = "test-utils"))]
 pub use evaluators::{DenyAllEvaluator, PermitAllEvaluator};
+
+#[cfg(feature = "alloc")]
+pub use audit::{AuditEntry, AuditEventType};
 
 #[cfg(feature = "std")]
 pub use scanner::{CredentialFinding, CredentialKind, CredentialScanner, ScanResult};

--- a/docs/superpowers/specs/2026-04-27-aaasm-25-audit-entry-design.md
+++ b/docs/superpowers/specs/2026-04-27-aaasm-25-audit-entry-design.md
@@ -1,0 +1,214 @@
+# AAASM-25 — Immutable `AuditEntry` with SHA-256 Hash Chain
+
+**Ticket:** [AAASM-25](https://lightning-dust-mite.atlassian.net/browse/AAASM-25)
+**Date:** 2026-04-27
+**Status:** Approved
+
+---
+
+## Overview
+
+Implement the `AuditEntry` type in `aa-core` — the foundational tamper-evident record for the
+Agent Assembly audit trail. Immutability is enforced through Rust's ownership system (no
+mutation methods). Each entry is content-addressed via a SHA-256 hash that covers all
+tamper-meaningful fields, forming a hash chain where each entry commits to the hash of its
+predecessor.
+
+---
+
+## Module Structure
+
+New file: `aa-core/src/audit.rs`, gated on `#[cfg(feature = "alloc")]`.
+Consistent with the existing `alloc`-tier types (`GovernanceAction`, `AgentContext`).
+
+**Changes:**
+
+| File | Change |
+|---|---|
+| `aa-core/src/audit.rs` | New module — all types live here |
+| `aa-core/src/lib.rs` | Add `pub mod audit;` + re-exports under `#[cfg(feature = "alloc")]` |
+| `aa-core/Cargo.toml` | Add `sha2` optional dep, activate under `alloc` feature |
+
+---
+
+## Types
+
+### `AuditEventType`
+
+```rust
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum AuditEventType {
+    ToolCallIntercepted   = 0,
+    PolicyViolation       = 1,
+    CredentialLeakBlocked = 2,
+    ApprovalRequested     = 3,
+    ApprovalGranted       = 4,
+    ApprovalDenied        = 5,
+    BudgetLimitApproached = 6,
+    BudgetLimitExceeded   = 7,
+}
+```
+
+`#[repr(u32)]` allows `event_type as u32` to produce the canonical 4-byte discriminant
+for the hash input. `as_str() -> &'static str` supports `Display` and logging.
+
+### `AuditEntry`
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct AuditEntry {
+    // All fields private — access via getters only.
+    seq:           u64,
+    timestamp_ns:  u64,
+    event_type:    AuditEventType,
+    agent_id:      AgentId,
+    session_id:    SessionId,
+    payload:       alloc::string::String,
+    previous_hash: [u8; 32],
+    entry_hash:    [u8; 32],
+}
+```
+
+---
+
+## Constructor
+
+```rust
+impl AuditEntry {
+    pub fn new(
+        seq:           u64,
+        timestamp_ns:  u64,
+        event_type:    AuditEventType,
+        agent_id:      AgentId,
+        session_id:    SessionId,
+        payload:       alloc::string::String,
+        previous_hash: [u8; 32],
+    ) -> Self
+}
+```
+
+`timestamp_ns` is **caller-supplied** (nanoseconds since Unix epoch). This keeps the
+constructor `no_std`-compatible — in `std` environments callers use
+`Timestamp::from(SystemTime::now()).as_nanos()`. `entry_hash` is computed internally by
+`compute_hash()` and is never a constructor parameter.
+
+Returns `Self` directly — SHA-256 computation via `sha2` is infallible. No `AuditError`
+type is needed for this ticket's scope.
+
+---
+
+## Canonical Hash Input
+
+`entry_hash = SHA-256(bytes)` where `bytes` is the concatenation of:
+
+```
+seq.to_be_bytes()                  //  8 bytes, big-endian u64
+timestamp_ns.to_be_bytes()         //  8 bytes, big-endian u64
+(event_type as u32).to_be_bytes()  //  4 bytes, big-endian u32 (repr discriminant)
+agent_id.as_bytes()                // 16 bytes ([u8; 16])
+session_id.as_bytes()              // 16 bytes ([u8; 16])
+previous_hash                      // 32 bytes ([u8; 32])
+payload.as_bytes()                 // variable — UTF-8 bytes of pre-serialized string
+```
+
+**Fixed-width prefix: 84 bytes.** Field order is canonical and documented here.
+Verifiers must use this exact order. `previous_hash = [0u8; 32]` for the genesis entry.
+
+---
+
+## `verify_integrity()`
+
+```rust
+pub fn verify_integrity(&self) -> bool {
+    let expected = Self::compute_hash(
+        self.seq, self.timestamp_ns, &self.event_type,
+        &self.agent_id, &self.session_id, &self.previous_hash, &self.payload,
+    );
+    expected == self.entry_hash
+}
+```
+
+Re-runs the same hash computation from stored fields. Returns `false` if any field has
+been altered (including via `unsafe` code). Used by the acceptance criterion test that
+simulates field tampering.
+
+---
+
+## `Display` Format
+
+```
+[seq=42 ts=1714222134000000000 agent=0102030405060708090a0b0c0d0e0f10 session=... event=ToolCallIntercepted]
+```
+
+`agent_id` and `session_id` are rendered as lowercase hex strings. `payload` is **not**
+included in `Display` output — it may be arbitrarily large and callers use `payload()`
+directly when they need it.
+
+---
+
+## `payload` Type
+
+`alloc::string::String` — pre-serialized UTF-8. JSON in practice
+(`serde_json::to_string(...)`). The `AuditEntry` does not inspect or validate the payload
+format. Deterministic hashing is guaranteed by UTF-8's well-defined byte encoding.
+
+---
+
+## Dependency
+
+```toml
+sha2 = { version = "0.10", default-features = false, features = ["alloc"], optional = true }
+```
+
+Activated under the `alloc` feature:
+
+```toml
+alloc = ["dep:sha2"]
+```
+
+`sha2 0.10` is pure Rust, `no_std` + `alloc` compatible, and widely used in the Rust
+ecosystem (same family as `sha2` used by `ring`, `rustls`, etc.).
+
+---
+
+## Feature Gating
+
+| Feature | Activates |
+|---|---|
+| `alloc` | `audit` module, `sha2` dep, `AuditEntry`, `AuditEventType` |
+| `serde` | Serialize/Deserialize derives on both types |
+
+The `audit` module does **not** require `std`. The existing `no_std` CI targets
+(`thumbv7em-none-eabihf`, `wasm32-unknown-unknown`) will verify this with `--features alloc`.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `AuditEntry` has no public mutation methods
+- [ ] `verify_integrity()` returns `false` if any field is altered via `unsafe` code
+- [ ] Constructor computes and stores SHA-256 hash over all 7 tamper-meaningful fields
+- [ ] `no_std` compilation passes (`--no-default-features --features alloc`)
+- [ ] Unit tests verify integrity check catches simulated tampering
+
+---
+
+## Commit Plan (12 commits)
+
+| # | Emoji | Scope | Key change |
+|---|---|---|---|
+| 1 | ⬆️ | `aa-core/Cargo.toml` | Add `sha2 0.10` optional dep; activate under `alloc` feature |
+| 2 | ✨ | `aa-core/audit` | Add `AuditEventType` — `#[repr(u32)]` enum, 8 variants, `as_str()`, serde derives |
+| 3 | ✨ | `aa-core/audit` | Add `AuditEntry` struct — 8 private fields, 8 getter methods, serde derives |
+| 4 | ✨ | `aa-core/audit` | Add private `compute_hash()` — 84-byte fixed prefix + payload into SHA-256 |
+| 5 | ✨ | `aa-core/audit` | Add `AuditEntry::new()` — 7 caller params, calls `compute_hash()`, returns `Self` |
+| 6 | ✨ | `aa-core/audit` | Add `verify_integrity() -> bool` — re-runs hash, compares to stored `entry_hash` |
+| 7 | ✨ | `aa-core/audit` | Implement `Display` for `AuditEntry` — `[seq=N ts=T agent=HEX session=HEX event=Name]` |
+| 8 | ✨ | `aa-core/lib.rs` | Wire `audit` module — `pub mod audit` + crate-root re-exports, both `alloc`-gated |
+| 9 | ✅ | `aa-core/audit` | Tests for `AuditEventType` — `as_str()` all 8 variants, discriminants 0–7, all distinct |
+| 10 | ✅ | `aa-core/audit` | Tests for `AuditEntry::new()` and getters — non-zero hash, all getters, genesis entry |
+| 11 | ✅ | `aa-core/audit` | Tests for `verify_integrity()` — true when clean; false after `unsafe` mutation of `seq`, `payload`, `event_type`, `previous_hash` |
+| 12 | ✅ | `aa-core/audit` | Tests for hash chain linkage and `Display` — chained entries, `seq` uniqueness, Display format |


### PR DESCRIPTION
## What changed

Adds the `AuditEntry` type and supporting `AuditEventType` enum to `aa-core`, implementing a tamper-evident, immutable audit record with a SHA-256 hash chain. Each entry commits to all tamper-meaningful fields and to the hash of its predecessor, forming a verifiable chain. The entire module is gated on the `alloc` feature for `no_std` compatibility.

## Why it changed

AAASM-25 — foundational audit trail primitive required by the Agent Assembly governance layer. Immutability is enforced through Rust's ownership model (private fields, no mutation methods). Tamper detection is provided by `verify_integrity()`, which re-runs the SHA-256 computation and compares it to the stored hash.

## Key implementation details

- **`AuditEventType`** — `#[repr(u32)]` enum (8 variants, discriminants 0–7); `as_str()` for Display/logging; serde derives behind `serde` feature
- **`AuditEntry`** — 8 private fields, 8 getter methods, no mutation methods
- **Canonical hash input** — 84-byte fixed prefix: `seq (8) ‖ timestamp_ns (8) ‖ event_type as u32 (4) ‖ agent_id (16) ‖ session_id (16) ‖ previous_hash (32)` + variable `payload.as_bytes()`
- **`new()`** — infallible, `timestamp_ns` is caller-supplied (keeps constructor `no_std`-compatible)
- **`verify_integrity()`** — re-runs `compute_hash()` from stored fields; returns `false` if any field altered
- **Display** — `[seq=N ts=T agent=HEX session=HEX event=TypeName]`; payload excluded (may be large)
- **`sha2 0.10`** — pure Rust, `no_std`-compatible, activated under `alloc` feature

## How to verify

All 17 new audit tests pass alongside the full suite (92 total):

```
cargo test --package aa-core --all-features
```

Tests cover: `as_str()` all 8 variants, discriminants 0–7, all distinct, `new()` produces non-zero hash, all getters, genesis entry (`previous_hash = [0u8;32]`), `verify_integrity()` true when clean and false after `unsafe` mutation of `seq` / `payload` / `event_type` / `previous_hash`, hash chain linkage, `seq` uniqueness, Display format.

## Closes

Closes [AAASM-25](https://lightning-dust-mite.atlassian.net/browse/AAASM-25)

[AAASM-25]: https://lightning-dust-mite.atlassian.net/browse/AAASM-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ