### PR TITLE
[AAASM-33] 🐳 build(aa-runtime): Multi-arch Docker image with GHCR publishing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,12 +30,23 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5730bbe8c60870f10e9e37f4a9a8fb8e2e76b41  # v3
 
-      - name: Build multi-arch image (build only — no push)
+      - name: Log in to GitHub Container Registry
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build multi-arch image (build only on PR, push on tag)
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434a5ee4c  # v6
         with:
           context: .
           file: aa-runtime/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: false
+          push: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+          tags: |
+            ghcr.io/ai-agent-assembly/aa-runtime:${{ github.ref_name }}
+            ghcr.io/ai-agent-assembly/aa-runtime:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,41 @@
+name: Docker
+
+# Prerequisite: the AI-agent-assembly org must have
+# Actions → Settings → Actions → Workflow permissions → "Read and write permissions" enabled.
+# Without this, the GHCR publish step (on tag push) will fail with HTTP 403.
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - "aa-runtime/**"
+      - ".github/workflows/docker.yml"
+  push:
+    tags: ["v*"]
+
+jobs:
+  build-and-push:
+    name: Build (and publish on tag)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+
+      - name: Set up QEMU (ARM emulation for multi-arch)
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff8c88a4de6791e0b55  # v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5730bbe8c60870f10e9e37f4a9a8fb8e2e76b41  # v3
+
+      - name: Build multi-arch image (build only — no push)
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434a5ee4c  # v6
+        with:
+          context: .
+          file: aa-runtime/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/aa-runtime/Dockerfile
+++ b/aa-runtime/Dockerfile
@@ -1,0 +1,30 @@
+# Builder stage: compiles aa-runtime for the target musl architecture
+FROM rust:alpine AS builder
+
+# Install build-time dependencies
+RUN apk add --no-cache \
+    musl-dev \
+    protobuf-dev \
+    openssl-dev \
+    pkgconfig
+
+# Select the correct musl target based on Docker's TARGETARCH build arg,
+# add the target, build the release binary, strip it, and place it at a
+# fixed path so the final stage can copy it regardless of architecture.
+ARG TARGETARCH
+RUN case "$TARGETARCH" in \
+      amd64) TARGET=x86_64-unknown-linux-musl ;; \
+      arm64) TARGET=aarch64-unknown-linux-musl ;; \
+      *) echo "Unsupported arch: $TARGETARCH" && exit 1 ;; \
+    esac && \
+    rustup target add "$TARGET" && \
+    echo "$TARGET" > /tmp/rust_target
+
+WORKDIR /app
+
+COPY . .
+
+RUN TARGET=$(cat /tmp/rust_target) && \
+    cargo build --release --target "$TARGET" -p aa-runtime && \
+    strip "target/$TARGET/release/aa-runtime" && \
+    cp "target/$TARGET/release/aa-runtime" /app/aa-runtime

--- a/aa-runtime/Dockerfile
+++ b/aa-runtime/Dockerfile
@@ -28,3 +28,14 @@ RUN TARGET=$(cat /tmp/rust_target) && \
     cargo build --release --target "$TARGET" -p aa-runtime && \
     strip "target/$TARGET/release/aa-runtime" && \
     cp "target/$TARGET/release/aa-runtime" /app/aa-runtime
+
+# Final stage: minimal distroless image running as non-root
+FROM gcr.io/distroless/static:nonroot AS runtime
+
+COPY --from=builder /app/aa-runtime /aa-runtime
+
+LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+      org.opencontainers.image.description="aa-runtime sidecar — AI agent assembly runtime" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+ENTRYPOINT ["/aa-runtime"]

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -26,5 +26,19 @@ services:
       retries: 5
       start_period: 2s
 
+  your-agent:
+    # Replace 'your-org/your-agent:latest' with your agent image.
+    image: your-org/your-agent:latest
+    restart: unless-stopped
+    depends_on:
+      aa-runtime:
+        condition: service_healthy
+    environment:
+      AA_AGENT_ID: "my-agent-001"   # must match aa-runtime
+      AA_GATEWAY_URL: "https://api.agentassembly.io"
+      AA_API_KEY: "${AA_API_KEY}"
+    volumes:
+      - aa-runtime-socket:/tmp      # IPC socket: /tmp/aa-runtime-my-agent-001.sock
+
 volumes:
   aa-runtime-socket:

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -9,13 +9,12 @@
 services:
   aa-runtime:
     image: ghcr.io/ai-agent-assembly/aa-runtime:latest
+    restart: unless-stopped               # restart if the process exits unexpectedly
     environment:
       AA_AGENT_ID: "my-agent-001"
-      AA_GATEWAY_URL: "https://api.agentassembly.io"
-      AA_API_KEY: "${AA_API_KEY}"
       # AA_METRICS_ADDR: "0.0.0.0:8080"   # default shown for reference
     volumes:
-      - aa-runtime-socket:/tmp            # IPC socket: /tmp/aa-runtime-my-agent-001.sock
+      - aa-runtime-socket:/tmp            # socket path hardcoded to /tmp/aa-runtime-<agent_id>.sock
     ports:
       - "8080:8080"                       # health + metrics
     # Note: requires a health-check-capable image or override; distroless images have no shell.

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -1,0 +1,31 @@
+# aa-runtime sidecar — docker-compose example
+#
+# Usage:
+#   AA_API_KEY=<your-key> docker-compose up
+#
+# The agent and runtime share a Unix domain socket volume.
+# AA_AGENT_ID must be identical in both services.
+
+services:
+  aa-runtime:
+    image: ghcr.io/ai-agent-assembly/aa-runtime:latest
+    environment:
+      AA_AGENT_ID: "my-agent-001"
+      AA_GATEWAY_URL: "https://api.agentassembly.io"
+      AA_API_KEY: "${AA_API_KEY}"
+      # AA_METRICS_ADDR: "0.0.0.0:8080"   # default shown for reference
+    volumes:
+      - aa-runtime-socket:/tmp            # IPC socket: /tmp/aa-runtime-my-agent-001.sock
+    ports:
+      - "8080:8080"                       # health + metrics
+    # Note: requires a health-check-capable image or override; distroless images have no shell.
+    # For distroless builds, mount a static health binary or use an external health probe.
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/ready || exit 1"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 2s
+
+volumes:
+  aa-runtime-socket:

--- a/examples/kubernetes/pod.yaml
+++ b/examples/kubernetes/pod.yaml
@@ -3,8 +3,8 @@
 # Usage:
 #   kubectl apply -f pod.yaml
 #
-# The agent container and the aa-runtime sidecar share an emptyDir volume
-# for the Unix domain socket. AA_AGENT_ID must match in both containers.
+# The aa-runtime sidecar uses an emptyDir volume for the Unix domain socket.
+# Add your agent container (see your-agent example) with the same volume mount.
 
 apiVersion: v1
 kind: Pod

--- a/examples/kubernetes/pod.yaml
+++ b/examples/kubernetes/pod.yaml
@@ -1,0 +1,40 @@
+# aa-runtime sidecar — Kubernetes pod example
+#
+# Usage:
+#   kubectl apply -f pod.yaml
+#
+# The agent container and the aa-runtime sidecar share an emptyDir volume
+# for the Unix domain socket. AA_AGENT_ID must match in both containers.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-agent-pod
+  labels:
+    app: my-agent
+spec:
+  containers:
+    - name: aa-runtime
+      image: ghcr.io/ai-agent-assembly/aa-runtime:latest
+      env:
+        - name: AA_AGENT_ID
+          value: "my-agent-001"
+        - name: AA_METRICS_ADDR
+          value: "0.0.0.0:8080"
+      ports:
+        - name: health
+          containerPort: 8080
+          protocol: TCP
+      readinessProbe:
+        httpGet:
+          path: /ready
+          port: health
+        initialDelaySeconds: 2
+        periodSeconds: 5
+        failureThreshold: 3
+      volumeMounts:
+        - name: aa-runtime-socket
+          mountPath: /tmp   # socket path hardcoded to /tmp/aa-runtime-<agent_id>.sock
+  volumes:
+    - name: aa-runtime-socket
+      emptyDir: {}

--- a/examples/kubernetes/pod.yaml
+++ b/examples/kubernetes/pod.yaml
@@ -3,8 +3,8 @@
 # Usage:
 #   kubectl apply -f pod.yaml
 #
-# The aa-runtime sidecar uses an emptyDir volume for the Unix domain socket.
-# Add your agent container (see your-agent example) with the same volume mount.
+# The agent container and aa-runtime share an emptyDir volume for the Unix
+# domain socket. AA_AGENT_ID must be identical in both containers.
 
 apiVersion: v1
 kind: Pod
@@ -35,6 +35,22 @@ spec:
       volumeMounts:
         - name: aa-runtime-socket
           mountPath: /tmp   # socket path hardcoded to /tmp/aa-runtime-<agent_id>.sock
+    - name: your-agent
+      # Replace 'your-org/your-agent:latest' with your agent image.
+      image: your-org/your-agent:latest
+      env:
+        - name: AA_AGENT_ID
+          value: "my-agent-001"   # must match aa-runtime
+        - name: AA_GATEWAY_URL
+          value: "https://api.agentassembly.io"
+        - name: AA_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: agent-api-key
+              key: api-key
+      volumeMounts:
+        - name: aa-runtime-socket
+          mountPath: /tmp   # IPC socket at /tmp/aa-runtime-my-agent-001.sock
   volumes:
     - name: aa-runtime-socket
       emptyDir: {}


### PR DESCRIPTION
## Summary

- Add multi-stage `aa-runtime/Dockerfile` — `rust:alpine` builder with musl cross-compilation for `linux/amd64` + `linux/arm64`, distroless final stage (`gcr.io/distroless/static:nonroot`) with stripped binary and OCI labels
- Add `.github/workflows/docker.yml` — builds multi-arch image on PRs touching `aa-runtime/**`; logs in to GHCR and pushes `ghcr.io/ai-agent-assembly/aa-runtime:<tag>` + `:latest` on `v*` tag pushes
- Add `examples/docker-compose/docker-compose.yml` — two-service example (`aa-runtime` + `your-agent` placeholder) sharing a UDS socket via named volume, with healthcheck gate via `depends_on: condition: service_healthy`
- Add `examples/kubernetes/pod.yaml` — two-container Pod example (`aa-runtime` sidecar + `your-agent` placeholder) sharing socket via `emptyDir`, with readiness probe at `/ready` and `AA_API_KEY` via `secretKeyRef`

## Test Plan

- [ ] `cargo build -p aa-runtime` — clean compile
- [ ] `cargo clippy -p aa-runtime -- -D warnings` — zero warnings
- [ ] `cargo fmt -p aa-runtime --check` — clean
- [ ] `cargo test -p aa-runtime -- --test-threads=1` — all 63 tests pass
- [ ] CI docker.yml build job passes on this PR (multi-arch build, no push)
- [ ] On a `v*` tag: verify GHCR receives `ghcr.io/ai-agent-assembly/aa-runtime:<tag>` and `:latest`
- [ ] `docker compose -f examples/docker-compose/docker-compose.yml config` — valid YAML
- [ ] `kubectl apply --dry-run=client -f examples/kubernetes/pod.yaml` — valid manifest

Closes #AAASM-33