### PR TITLE
[AAASM-127] 🔧 aa-core: Enforce missing_docs lint + rustdoc all public items

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,18 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
+  docs:
+    name: Rustdoc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Check rustdoc (no undocumented public items)
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --no-deps --all-features -p aa-core
+
   test:
     name: Test
     runs-on: ubuntu-latest

--- a/aa-core/src/agent.rs
+++ b/aa-core/src/agent.rs
@@ -1,3 +1,8 @@
+//! Agent execution context carrying identity, PID, and metadata.
+//!
+//! The primary type is [`AgentContext`], which flows through every governance
+//! event in the system. Requires the `alloc` feature.
+
 #[cfg(feature = "alloc")]
 use alloc::{collections::BTreeMap, string::String};
 

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -23,13 +23,21 @@ use crate::{AgentId, SessionId};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum AuditEventType {
+    /// A tool call was intercepted by the governance layer before execution.
     ToolCallIntercepted = 0,
+    /// An evaluated action violated an active policy rule.
     PolicyViolation = 1,
+    /// A credential or secret present in tool arguments was blocked.
     CredentialLeakBlocked = 2,
+    /// Human approval was requested before the action could proceed.
     ApprovalRequested = 3,
+    /// A pending human approval request was granted.
     ApprovalGranted = 4,
+    /// A pending human approval request was denied.
     ApprovalDenied = 5,
+    /// The session budget is approaching its configured limit.
     BudgetLimitApproached = 6,
+    /// The session budget has been exhausted; further actions are blocked.
     BudgetLimitExceeded = 7,
 }
 

--- a/aa-core/src/evaluators.rs
+++ b/aa-core/src/evaluators.rs
@@ -1,3 +1,9 @@
+//! Test-only [`PolicyEvaluator`](crate::policy::PolicyEvaluator) implementations.
+//!
+//! [`DenyAllEvaluator`] and [`PermitAllEvaluator`] let downstream crates
+//! write unit tests without building a real policy document or parser.
+//! Gated on the `test-utils` feature.
+
 /// Test-only policy evaluator that denies every action unconditionally.
 ///
 /// Use `DenyAllEvaluator` in unit tests that need to assert denial paths

--- a/aa-core/src/identity.rs
+++ b/aa-core/src/identity.rs
@@ -1,3 +1,9 @@
+//! Stable identity types for agents and execution sessions.
+//!
+//! [`AgentId`] identifies a long-lived agent across sessions.
+//! [`SessionId`] identifies a single execution run within that agent.
+//! Both are 16-byte opaque wrappers over UUID v4 raw bytes.
+
 /// Stable identifier for an agent — UUID v4 encoded as raw bytes.
 ///
 /// The inner `[u8; 16]` is private. Use [`AgentId::from_bytes`] to construct

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -14,6 +14,7 @@
 //! - `alloc` (also default via std): enables `AuditEntry`, `AuditEventType`, and all audit types
 
 #![cfg_attr(not(feature = "std"), no_std)]
+#![warn(missing_docs)]
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "alloc")] {

--- a/aa-core/src/policy.rs
+++ b/aa-core/src/policy.rs
@@ -18,9 +18,13 @@ pub type ArgsJson = alloc::string::String;
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FileMode {
+    /// Open the file for reading only.
     Read,
+    /// Open the file for writing, truncating any existing content.
     Write,
+    /// Open the file for writing, appending to existing content.
     Append,
+    /// Delete the file from the filesystem.
     Delete,
 }
 
@@ -42,8 +46,11 @@ pub enum PolicyError {
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum PolicyDecision {
+    /// The action is permitted without restriction.
     Allow,
+    /// The action is prohibited.
     Deny,
+    /// The action may proceed only after explicit human approval.
     RequireApproval,
 }
 
@@ -88,9 +95,15 @@ pub enum PolicyResult {
     /// The action is permitted.
     Allow,
     /// The action is denied; `reason` explains why.
-    Deny { reason: alloc::string::String },
+    Deny {
+        /// Human-readable description of why the action was denied.
+        reason: alloc::string::String,
+    },
     /// Human approval is required within the given timeout.
-    RequiresApproval { timeout_secs: u32 },
+    RequiresApproval {
+        /// Maximum seconds to wait for human approval before the request expires.
+        timeout_secs: u32,
+    },
 }
 
 /// An agent action subject to governance evaluation.
@@ -102,21 +115,30 @@ pub enum PolicyResult {
 pub enum GovernanceAction {
     /// Invocation of a named tool with pre-serialized JSON arguments.
     ToolCall {
+        /// Registered name of the tool being invoked.
         name: alloc::string::String,
+        /// Pre-serialized JSON arguments passed to the tool.
         args: ArgsJson,
     },
     /// Read or write access to a file path.
     FileAccess {
+        /// Absolute or relative path of the file being accessed.
         path: alloc::string::String,
+        /// Access mode (read, write, append, or delete).
         mode: FileMode,
     },
     /// Outbound network request.
     NetworkRequest {
+        /// Target URL of the outbound request.
         url: alloc::string::String,
+        /// HTTP method (e.g., `"GET"`, `"POST"`).
         method: alloc::string::String,
     },
     /// Spawning an external process.
-    ProcessExec { command: alloc::string::String },
+    ProcessExec {
+        /// Full shell command string to be executed.
+        command: alloc::string::String,
+    },
 }
 
 /// Pluggable policy evaluation backend.

--- a/aa-core/src/policy.rs
+++ b/aa-core/src/policy.rs
@@ -1,3 +1,11 @@
+//! Policy types and the [`PolicyEvaluator`] trait for governance decisions.
+//!
+//! A [`GovernanceAction`] describes what an agent wants to do.
+//! A [`PolicyEvaluator`] decides whether that action is permitted,
+//! denied, or requires human approval, and returns a [`PolicyResult`].
+//! Policy rules are expressed as [`PolicyDocument`] objects containing
+//! ordered [`PolicyRule`] entries.
+
 /// Pre-serialized JSON string passed at policy trait boundaries.
 ///
 /// Callers serialize arguments before handing them to an evaluator;

--- a/aa-core/src/scanner.rs
+++ b/aa-core/src/scanner.rs
@@ -63,33 +63,55 @@ const AC_KINDS: &[CredentialKind] = &[
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum CredentialKind {
     // API keys
+    /// Anthropic API key (prefix `sk-ant-`).
     AnthropicKey,
+    /// AWS access key ID (prefix `AKIA`).
     AwsAccessKey,
+    /// GCP service account JSON credential (contains `"type": "service_account"`).
     GcpServiceAccount,
+    /// OpenAI API key (prefix `sk-`).
     OpenAiKey,
     // Cloud credentials
+    /// Azure Storage connection string (prefix `DefaultEndpointsProtocol=`).
     AzureConnectionString,
     // Auth tokens
+    /// GitHub App installation token (prefix `ghs_`).
     GitHubAppToken,
+    /// GitHub personal access token (prefix `ghp_`).
     GitHubPat,
+    /// Slack bot token (prefix `xoxb-`).
     SlackBotToken,
+    /// Slack OAuth token (prefix `xoxa-`).
     SlackOAuthToken,
+    /// Slack user token (prefix `xoxp-`).
     SlackUserToken,
     // Database URLs
+    /// MongoDB connection URI (prefix `mongodb://`).
     MongodbUrl,
+    /// MySQL connection URI (prefix `mysql://`).
     MysqlUrl,
+    /// PostgreSQL connection URI (prefix `postgres://`).
     PostgresUrl,
     // Private keys
+    /// PEM-encoded EC private key (`-----BEGIN EC PRIVATE KEY-----`).
     EcPrivateKey,
+    /// PEM-encoded OpenSSH private key (`-----BEGIN OPENSSH PRIVATE KEY-----`).
     OpensshPrivateKey,
+    /// PEM-encoded PGP private key block (`-----BEGIN PGP PRIVATE KEY BLOCK-----`).
     PgpPrivateKey,
+    /// PEM-encoded PKCS#8 private key (`-----BEGIN PRIVATE KEY-----`).
     PrivateKey,
+    /// PEM-encoded RSA private key (`-----BEGIN RSA PRIVATE KEY-----`).
     RsaPrivateKey,
     // PII
+    /// Credit card number validated by the Luhn algorithm (13–19 digits).
     CreditCardLuhn,
+    /// Email address containing `@` and a dot-separated domain.
     EmailAddress,
+    /// US Social Security Number in `DDD-DD-DDDD` format.
     SsnPattern,
     // Generic
+    /// High-entropy token (Shannon entropy > 4.5 bits/char, length 20–64 bytes).
     GenericHighEntropy,
 }
 
@@ -134,8 +156,11 @@ impl CredentialKind {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CredentialFinding {
+    /// Category of the detected credential.
     pub kind: CredentialKind,
+    /// Byte offset in the original text where the pattern begins.
     pub offset: usize,
+    /// Redacted label replacing the secret, e.g. `[REDACTED:AwsAccessKey]`.
     pub matched: String,
     #[cfg_attr(feature = "serde", serde(skip))]
     end: usize,
@@ -157,6 +182,7 @@ impl CredentialFinding {
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScanResult {
+    /// All credential findings detected in the scanned text, sorted by byte offset.
     pub findings: Vec<CredentialFinding>,
 }
 


### PR DESCRIPTION
## Summary

- Adds `#![warn(missing_docs)]` to `aa-core/lib.rs` — any new undocumented public item is a compile warning (hard error in CI)
- Documents all previously undocumented public items across 5 source files: module-level `//!` docs for `agent`, `identity`, `policy`, `evaluators`; `///` variant docs for `AuditEventType` (8), `FileMode` (4), `PolicyDecision` (3), `CredentialKind` (22); field docs for `PolicyResult`, `GovernanceAction`, `CredentialFinding`, `ScanResult`
- Adds a `docs` CI job: `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features -p aa-core` — blocks undocumented public APIs from landing on master going forward

## Commits

| # | Change |
|---|---|
| 1 | 🔧 `aa-core/lib.rs`: Add `#![warn(missing_docs)]` lint gate |
| 2 | 📝 `aa-core/agent`: Add `//!` module-level rustdoc |
| 3 | 📝 `aa-core/identity`: Add `//!` module-level rustdoc |
| 4 | 📝 `aa-core/policy,evaluators`: Add `//!` module-level rustdoc |
| 5 | 📝 `aa-core/audit`: Add `///` docs to all `AuditEventType` variants |
| 6 | 📝 `aa-core/policy`: Add `///` docs to variants and variant fields |
| 7 | 📝 `aa-core/scanner`: Add `///` docs to `CredentialKind` variants and public fields |
| 8 | 🔧 `ci`: Add Rustdoc job |

## Acceptance Criteria

- [x] `#![warn(missing_docs)]` is active in `aa-core/lib.rs`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features -p aa-core` exits 0 locally
- [x] All 92 existing tests pass (`cargo test --all-features -p aa-core`)
- [x] Clippy and fmt are clean
- [x] CI `docs` job added to `.github/workflows/ci.yml`

Closes AAASM-127