### PR TITLE
[AAASM-108] 📝 docs: Write CHANGELOG.md template and protocol migration guide for spec versioning

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/protocol-change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/protocol-change.md
@@ -1,0 +1,42 @@
+## Protocol change description
+
+Brief description of what changed in the protocol specification.
+
+## Change classification
+
+See [docs/versioning.md](../../docs/versioning.md) for the full classification rules.
+
+- [ ] **Non-breaking** — new optional field, new RPC, new enum value, documentation fix
+- [ ] **Breaking** — removed/renamed field, changed field number or type, removed RPC or enum value
+
+## Breaking change details *(skip if non-breaking)*
+
+**Deprecated since:** `protocol/v` *(leave blank if not previously deprecated)*
+
+Does this change follow the two-MAJOR-version deprecation window?
+
+- [ ] Yes — item was deprecated at least two major versions ago
+- [ ] No — this is an emergency break (explain below)
+- [ ] N/A — non-breaking change
+
+## Related issues
+
+- Jira ticket: AAASM-XX
+- GitHub issue: #XX
+
+## Checklist
+
+- [ ] `docs/protocol/CHANGELOG.md` updated under the correct section
+  (`Added` / `Changed` / `Deprecated` / `Removed` / `Fixed` / `Security`)
+- [ ] If breaking: migration guide added at `docs/migration/<vX.Y-to-vZ.0>.md`
+  (use [`docs/migration/template.md`](../../docs/migration/template.md) as starting point)
+- [ ] Proto lint passes (`buf lint` in `proto/`)
+- [ ] No unintended breaking changes (`buf breaking` against base branch)
+- [ ] Conformance vectors updated if wire format changed
+  (`conformance/vectors/<category>/` and `conformance/vectors/proto/*.bin` if applicable)
+- [ ] `docs/compatibility.md` updated if runtime/SDK version compatibility is affected
+
+---
+
+> **To use this template** when opening a PR, append `?template=protocol-change.md`
+> to the PR creation URL, or select it from the template picker on GitHub.

--- a/docs/migration/template.md
+++ b/docs/migration/template.md
@@ -1,0 +1,127 @@
+# Migration Guide — [FILL IN: brief title, e.g. "`AgentId.agent_id` renamed to `AgentId.id`"]
+
+> **Template instructions:** Copy this file to `docs/migration/<vX.Y-to-vZ.0>.md`,
+> fill in every `[FILL IN]` section, and delete these instruction lines.
+> See the completed worked example in [`docs/versioning.md`](../versioning.md)
+> for a reference of what a finished guide looks like.
+
+---
+
+**Breaking change introduced in:** `protocol/v[FILL IN]`
+**Deprecated since:** `protocol/v[FILL IN]` *(omit if not previously deprecated)*
+**Affected SDK versions:** [FILL IN: e.g. "All SDKs using `MessageName.field_name`"]
+**Estimated migration effort:** [FILL IN: Low / Medium / High]
+
+> **Low** — mechanical find-and-replace, no logic change.
+> **Medium** — logic changes in a small number of call sites.
+> **High** — widespread changes or dependent schema updates required.
+
+---
+
+## What changed
+
+[FILL IN: One or two paragraphs describing what was removed, renamed, or altered and why.
+Include the field number, message name, and proto file. Explain the motivation briefly —
+e.g. naming consistency, type safety, protocol simplification.]
+
+---
+
+## Before (`protocol/v[FILL IN].x`)
+
+**Proto encoding:**
+
+```protobuf
+[FILL IN: show the relevant message with the old field]
+MessageName {
+  field_name: "example-value"   // field N — old name/type
+}
+```
+
+**Python SDK:**
+
+```python
+[FILL IN: show the old API call]
+obj = MessageName(field_name="example-value")
+```
+
+**Node.js SDK:**
+
+```typescript
+[FILL IN: show the old API call]
+const obj = new MessageName({ fieldName: 'example-value' });
+```
+
+**Go SDK:**
+
+```go
+[FILL IN: show the old API call]
+obj := &pb.MessageName{FieldName: "example-value"}
+```
+
+---
+
+## After (`protocol/v[FILL IN].0+`)
+
+**Proto encoding:**
+
+```protobuf
+[FILL IN: show the relevant message with the new field]
+MessageName {
+  new_field_name: "example-value"   // field M — new name/type
+}
+```
+
+**Python SDK:**
+
+```python
+[FILL IN: show the new API call]
+obj = MessageName(new_field_name="example-value")
+```
+
+**Node.js SDK:**
+
+```typescript
+[FILL IN: show the new API call]
+const obj = new MessageName({ newFieldName: 'example-value' });
+```
+
+**Go SDK:**
+
+```go
+[FILL IN: show the new API call]
+obj := &pb.MessageName{NewFieldName: "example-value"}
+```
+
+---
+
+## Migration steps
+
+1. [FILL IN: First step — e.g. "Search your codebase for all usages of `MessageName.field_name`."]
+2. [FILL IN: Second step — e.g. "Replace each with `MessageName.new_field_name`."]
+3. [FILL IN: Third step — e.g. "Run the conformance test suite to verify."]
+4. [FILL IN: Deployment order step if relevant — e.g. "Deploy the updated SDK before
+   upgrading `aa-runtime` past vN.x (runtime vN.x still supports protocol/v(N-1))."]
+
+---
+
+## Verification
+
+Run the conformance suite against a runtime at `protocol/v[FILL IN]`:
+
+```bash
+[FILL IN: exact command, e.g.]
+cargo test -p conformance
+python conformance/runner/runner.py --verbose
+```
+
+Expected: all vectors pass with no failures referencing `[FILL IN: old field name]`.
+
+---
+
+## See also
+
+- [`docs/versioning.md`](../versioning.md) — change classification rules and deprecation
+  lifecycle
+- [`docs/protocol/CHANGELOG.md`](../protocol/CHANGELOG.md) — full protocol changelog
+- [`conformance/vectors/`](../../conformance/vectors/) — test vectors for the affected
+  message category

--- a/docs/protocol/CHANGELOG.md
+++ b/docs/protocol/CHANGELOG.md
@@ -1,0 +1,127 @@
+# Protocol Specification Changelog
+
+> **Scope:** This changelog covers the Agent Assembly **protocol specification only** —
+> proto message schemas, JSON schema, IPC framing contract, and SDK protocol conformance
+> requirements. For runtime/crate release notes, see the project CHANGELOG when it exists.
+
+All notable changes to the protocol specification are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Protocol versioning follows the policy in [docs/versioning.md](../versioning.md).
+
+---
+
+## [v0.0.1] — 2026-04-28
+
+Initial release of the Agent Assembly protocol specification.
+
+### Added
+
+#### Services
+
+- `AgentLifecycleService` (`proto/agent.proto`) — RPC surface for agent registration,
+  heartbeat, deregistration, and runtime control stream
+- `PolicyService` (`proto/policy.proto`) — synchronous policy check RPC for intercepting
+  agent actions before execution
+- `AuditService` (`proto/audit.proto`) — event reporting and streaming RPC for immutable
+  audit log ingestion
+
+#### Agent lifecycle messages (`proto/agent.proto`)
+
+- `RegisterRequest` — agent startup registration carrying identity, framework, tool list,
+  risk tier, public key, and arbitrary metadata
+- `RegisterResponse` — gateway issues credential token, assigns policy, sets heartbeat
+  interval
+- `HeartbeatRequest` — periodic liveness signal carrying active run count and cumulative
+  action count
+- `HeartbeatResponse` — gateway signals policy update and/or suspend request to agent
+- `DeregisterRequest` — clean or forced agent shutdown with optional reason string
+- `DeregisterResponse` — gateway confirms deregistration success and echoes agent identity
+- `ControlStreamRequest` — opens persistent server-streaming channel for runtime control
+- `ControlCommand` — oneof wrapper dispatching to one of four command variants:
+  - `SuspendCommand` — instructs agent to pause execution
+  - `ResumeCommand` — instructs agent to resume execution
+  - `PolicyUpdateCommand` — delivers updated policy document inline
+  - `KillCommand` — instructs agent to terminate with optional reason
+
+#### Policy messages (`proto/policy.proto`)
+
+- `CheckActionRequest` — policy check request carrying agent identity, credential token,
+  trace/span IDs, action type, and action-specific context
+- `CheckActionResponse` — policy decision carrying `Decision` enum, reason, policy rule
+  reference, optional approval ID, optional redact instructions, and decision latency
+- `ActionContext` — oneof wrapper for the five action context subtypes:
+  - `LLMCallContext` — model name, prompt token count, and sampled prompt prefix
+  - `ToolCallContext` — tool name, source (mcp/builtin), JSON args, and target URL
+  - `FileOpContext` — operation type, file path, and byte count
+  - `NetworkCallContext` — method, URL, and header names
+  - `ProcessExecContext` — executable path and argument list
+- `RedactInstructions` — container for one or more redaction rules
+- `RedactRule` — field path (JSONPath) and replacement string for a single redaction
+- `BatchCheckRequest` — wraps multiple `CheckActionRequest` items for bulk evaluation
+- `BatchCheckResponse` — wraps corresponding `CheckActionResponse` items
+
+#### Event messages (`proto/event.proto`)
+
+- `EnvelopedEvent` — typed event envelope with agent identity, timestamp, sequence number,
+  and oneof payload for the five event subtypes
+- `AlertTriggered` — credential or policy violation alert with severity and matched pattern
+- `ApprovalRequested` — human-in-the-loop approval request with timeout and context summary
+- `AgentStatusChanged` — agent lifecycle state transition notification
+- `BudgetThresholdHit` — token or cost budget threshold breach notification
+- `ApprovalDecision` — outcome of a previously requested approval
+
+#### Audit messages (`proto/audit.proto`)
+
+- `AuditEvent` — immutable audit record with agent identity, timestamp, sequence number,
+  SHA-256 hash chain field, and oneof payload for five detail subtypes:
+  - `LLMCallDetail` — model, token counts, finish reason
+  - `ToolCallDetail` — tool name, source, args hash, result hash
+  - `FileOpDetail` — operation, path, byte count, hash
+  - `NetworkCallDetail` — method, URL, status code, response byte count
+  - `ProcessExecDetail` — executable, args hash, exit code
+- `PolicyViolation` — policy rule reference, decision, and triggering action summary
+- `ApprovalEvent` — approval request and decision pair linked by approval ID
+- `ReportEventsRequest` / `ReportEventsResponse` — unary bulk event submission
+- `StreamEventsResponse` — server acknowledgement for the streaming submission RPC
+
+#### Common types (`proto/common.proto`)
+
+- `AgentId` — composite agent identity: `org_id`, `team_id`, `agent_id` (DID string)
+- `Timestamp` — millisecond-precision Unix timestamp (`unix_ms` int64)
+- `Decision` enum — `ALLOW`, `DENY`, `PENDING`, `REDACT`
+- `ActionType` enum — `LLM_CALL`, `TOOL_CALL`, `FILE_OPERATION`, `NETWORK_CALL`,
+  `PROCESS_EXEC`, `AGENT_SPAWN`
+- `RiskTier` enum — `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`
+
+#### JSON Schema
+
+- `schemas/policy/v1/policy-document.schema.json` — PolicyDocument JSON Schema v1,
+  defining the structure of policy rules evaluated by `PolicyService`
+- Example policy documents: `schemas/examples/strict.yaml`, `balanced.yaml`,
+  `audit-only.yaml`
+
+#### IPC framing contract
+
+- Transport: Unix domain socket (`/var/run/aa-runtime.sock` by default)
+- Framing: prost varint length-delimited encoding —
+  each frame is a varint-encoded byte length followed by the raw proto bytes
+- Reference: `prost::encode_length_delimited` / `prost::decode_length_delimited`
+- Conformance vectors: `conformance/vectors/ipc_framing/` (10 vectors)
+
+---
+
+## Tagging runbook
+
+Run the following commands **only when AAASM-12 (Protocol Specification epic) is fully
+closed** and all protocol tickets have been merged into `master`:
+
+```bash
+# Create annotated tag for the initial spec release
+git tag -a spec/v0.0.1 -m "Protocol Specification v0.0.1 — initial release"
+
+# Push the tag to the upstream remote
+git push origin spec/v0.0.1
+```
+
+Tag namespace convention: `spec/<version>` — coexists with future `runtime/<version>`,
+`sdk/<version>` tags in the same monorepo without ambiguity.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -157,3 +157,7 @@ agent_id = AgentId(org_id="acme", team_id="platform", id="did:key:z6Mk...")
 | protocol/v1 | protocol/v1 only (first version) |
 | protocol/v2 | protocol/v1, protocol/v2 |
 | protocol/v3 | protocol/v2, protocol/v3 (v1 support may be dropped) |
+
+---
+
+For the blank template to copy when writing a new migration guide, see [`docs/migration/template.md`](migration/template.md).


### PR DESCRIPTION
## What changed

Establishes the protocol specification changelog and migration guide
infrastructure required by AAASM-108:

- `docs/protocol/CHANGELOG.md` — protocol-spec-only changelog (Keep a
  Changelog format) with a complete v0.0.1 entry enumerating all 3
  services, 35+ messages, 4 enums, the PolicyDocument JSON Schema, and
  the IPC framing contract. Placed under `docs/protocol/` (not repo root)
  to avoid collision with future project-wide release tooling. Includes
  a tagging runbook for `spec/v0.0.1` to be run when AAASM-12 closes.
- `docs/migration/template.md` — blank skeleton with `[FILL IN]`
  placeholders and per-section instructions for Python, Node.js, and Go
  SDKs. Cross-references the completed worked example in `docs/versioning.md`.
- `docs/versioning.md` — one-line cross-reference appended after the
  existing migration example, pointing authors to the blank template.
- `.github/PULL_REQUEST_TEMPLATE/protocol-change.md` — dedicated PR
  template for protocol changes; coexists with the existing general
  template. Covers CHANGELOG update, migration guide, `buf lint/breaking`,
  and conformance vector checklist items.

## Why

The Protocol Specification epic (AAASM-12) needs a versioned changelog and
migration guide process before the initial spec can be tagged. The `spec/v0.0.1`
tag itself is deferred until AAASM-12 closes; this PR delivers all the
infrastructure and the tagging runbook.

## How to verify

- `docs/protocol/CHANGELOG.md` — review v0.0.1 entry covers all proto
  messages and schemas defined in `proto/` and `schemas/`
- `docs/migration/template.md` — open the file; confirm all sections have
  `[FILL IN]` placeholders and point to `docs/versioning.md` for reference
- `docs/versioning.md` — confirm the cross-reference line appears at the
  bottom of the file
- `.github/PULL_REQUEST_TEMPLATE/protocol-change.md` — confirm it is
  selectable via `?template=protocol-change.md` on a new PR URL

Closes #AAASM-108

🤖 Generated with [Claude Code](https://claude.ai/claude-code)