### PR TITLE
[AAASM-37] ✨ (aa-ebpf): Set up aa-ebpf, aa-ebpf-common, and aa-ebpf-programs crate architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,7 +42,9 @@ dependencies = [
  "aa-ebpf-common",
  "aya",
  "aya-log",
+ "thiserror 2.0.18",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -123,10 +125,8 @@ dependencies = [
  "prost",
  "serde",
  "serde_json",
- "tempfile",
  "tokio",
  "tokio-util",
- "toml",
  "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
@@ -1970,7 +1970,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -2617,15 +2617,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2987,27 +2978,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3018,28 +2988,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -3048,14 +3004,8 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -3725,15 +3675,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/aa-ebpf-common/Cargo.toml
+++ b/aa-ebpf-common/Cargo.toml
@@ -6,9 +6,14 @@ license.workspace = true
 repository.workspace = true
 description = "Shared no_std types between eBPF kernel probes and userspace loader"
 
+# no_std by default so this crate can be compiled for both the host target
+# (by aa-ebpf) and the bpf target (by aa-ebpf-programs).
 [features]
 default = []
-user = []
+# Enable std types (timestamps, Display) for userspace use.
+std = []
+
+[dependencies]
 
 [lints]
 workspace = true

--- a/aa-ebpf-common/src/exec.rs
+++ b/aa-ebpf-common/src/exec.rs
@@ -2,6 +2,14 @@
 //!
 //! Emitted by the `sched_process_exec` tracepoint in `aa-ebpf-programs`
 //! and consumed by the userspace ring-buffer reader in `aa-ebpf`.
+//!
+//! Also contains the PID lineage map types (`ProcessNode`) and the
+//! shell-injection alert types (`ShellInjectionAlert`) used by the
+//! `ProcessLineageTracker` in the userspace loader.
+
+// ---------------------------------------------------------------------------
+// ExecEvent — raw ring-buffer event from the BPF tracepoint
+// ---------------------------------------------------------------------------
 
 /// Maximum bytes captured for the executable path.
 pub const MAX_FILENAME_LEN: usize = 256;
@@ -27,4 +35,86 @@ pub struct ExecEvent {
     pub filename: [u8; MAX_FILENAME_LEN],
     /// Space-separated argv string (up to [`MAX_ARGS_LEN`] bytes).
     pub args: [u8; MAX_ARGS_LEN],
+}
+
+// ---------------------------------------------------------------------------
+// Lineage-map and alert types (AAASM-39 ProcessLineageTracker)
+// ---------------------------------------------------------------------------
+
+/// In-kernel node for the PID lineage map (`BpfHashMap<u32, ProcessNode>`).
+///
+/// Each entry maps a child PID to its parent and the command that spawned it.
+/// Fixed-size layout is required for eBPF map compatibility.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ProcessNode {
+    /// Process ID of the child.
+    pub pid: u32,
+    /// Parent process ID.
+    pub ppid: u32,
+    /// Command name (`comm`) of the process, null-padded.
+    pub comm: [u8; 16],
+    /// Kernel timestamp in nanoseconds when the process was spawned.
+    pub spawn_time_ns: u64,
+}
+
+/// Maximum number of argv entries captured per execve event.
+pub const MAX_ARGV_ENTRIES: usize = 5;
+
+/// Maximum byte length of a single argv entry.
+pub const MAX_ARGV_LEN: usize = 128;
+
+/// Event emitted from the eBPF tracepoint to userspace on each `execve` call.
+///
+/// Sent via ring buffer or perf event array. Fixed-size layout ensures
+/// predictable memory use in the eBPF program.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ProcessSpawnEvent {
+    /// Process ID of the newly spawned process.
+    pub pid: u32,
+    /// Parent process ID.
+    pub ppid: u32,
+    /// Command name (`comm`) of the new process, null-padded.
+    pub comm: [u8; 16],
+    /// First [`MAX_ARGV_ENTRIES`] argv entries, each null-padded to [`MAX_ARGV_LEN`] bytes.
+    pub argv: [[u8; MAX_ARGV_LEN]; MAX_ARGV_ENTRIES],
+    /// Number of environment variables passed to execve.
+    pub env_count: u32,
+    /// Kernel timestamp in nanoseconds.
+    pub timestamp_ns: u64,
+}
+
+/// Maximum byte length of the executable path in a [`ShellInjectionAlert`].
+pub const MAX_EXECUTABLE_LEN: usize = 256;
+
+/// Severity level for a shell injection alert.
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum AlertLevel {
+    /// Informational — known-benign shell spawns (e.g. build scripts).
+    Info = 0,
+    /// Warning — potentially suspicious spawn (e.g. `python`, `node`).
+    Warning = 1,
+    /// Critical — high-risk spawn (e.g. `curl`, `wget`, raw `sh`/`bash`).
+    Critical = 2,
+}
+
+/// Alert emitted when an agent process spawns a suspicious child process.
+///
+/// Generated in the eBPF program when the spawned executable matches a
+/// known shell or download utility pattern (e.g. `bash`, `curl`, `wget`).
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ShellInjectionAlert {
+    /// PID of the monitored agent (or its ancestor in the lineage tree).
+    pub parent_pid: u32,
+    /// PID of the suspicious child process.
+    pub child_pid: u32,
+    /// Full executable path of the child, null-padded.
+    pub executable: [u8; MAX_EXECUTABLE_LEN],
+    /// Severity of the alert.
+    pub alert_level: AlertLevel,
+    /// Kernel timestamp in nanoseconds.
+    pub timestamp_ns: u64,
 }

--- a/aa-ebpf-common/src/exec.rs
+++ b/aa-ebpf-common/src/exec.rs
@@ -19,7 +19,7 @@ pub const MAX_ARGS_LEN: usize = 512;
 
 /// A single process-exec tracepoint event emitted from kernel-space.
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct ExecEvent {
     /// Monotonic kernel timestamp (nanoseconds).
     pub timestamp_ns: u64,

--- a/aa-ebpf-common/src/exec.rs
+++ b/aa-ebpf-common/src/exec.rs
@@ -1,0 +1,30 @@
+//! Shared types for process exec tracepoint events (AAASM-39).
+//!
+//! Emitted by the `sched_process_exec` tracepoint in `aa-ebpf-programs`
+//! and consumed by the userspace ring-buffer reader in `aa-ebpf`.
+
+/// Maximum bytes captured for the executable path.
+pub const MAX_FILENAME_LEN: usize = 256;
+
+/// Maximum bytes captured for the command-line argument string.
+pub const MAX_ARGS_LEN: usize = 512;
+
+/// A single process-exec tracepoint event emitted from kernel-space.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ExecEvent {
+    /// Monotonic kernel timestamp (nanoseconds).
+    pub timestamp_ns: u64,
+    /// Process ID of the new process.
+    pub pid: u32,
+    /// Parent process ID.
+    pub ppid: u32,
+    /// User ID that spawned the process.
+    pub uid: u32,
+    /// Padding for alignment.
+    pub _pad: u32,
+    /// Null-terminated executable path (up to [`MAX_FILENAME_LEN`] bytes).
+    pub filename: [u8; MAX_FILENAME_LEN],
+    /// Space-separated argv string (up to [`MAX_ARGS_LEN`] bytes).
+    pub args: [u8; MAX_ARGS_LEN],
+}

--- a/aa-ebpf-common/src/file.rs
+++ b/aa-ebpf-common/src/file.rs
@@ -1,0 +1,39 @@
+//! Shared types for file I/O kprobe events (AAASM-38).
+//!
+//! Emitted by `openat`, `write`, and `unlink` kprobes in `aa-ebpf-programs`
+//! and consumed by the userspace ring-buffer reader in `aa-ebpf`.
+
+/// Maximum file path bytes captured per event.
+pub const MAX_PATH_LEN: usize = 256;
+
+/// File operation kind intercepted at the kernel level.
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum FileOp {
+    /// `openat` — file open attempt.
+    Open = 0,
+    /// `write` — data written to a file descriptor.
+    Write = 1,
+    /// `unlink` / `unlinkat` — file deletion attempt.
+    Unlink = 2,
+}
+
+/// A single file I/O kprobe event emitted from kernel-space.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct FileEvent {
+    /// Monotonic kernel timestamp (nanoseconds).
+    pub timestamp_ns: u64,
+    /// Process ID of the monitored agent.
+    pub pid: u32,
+    /// Thread ID within the process.
+    pub tid: u32,
+    /// File descriptor involved (−1 if not applicable).
+    pub fd: i32,
+    /// Operation that triggered this event.
+    pub op: FileOp,
+    /// Padding for alignment.
+    pub _pad: [u8; 3],
+    /// Null-terminated file path (up to [`MAX_PATH_LEN`] bytes).
+    pub path: [u8; MAX_PATH_LEN],
+}

--- a/aa-ebpf-common/src/file.rs
+++ b/aa-ebpf-common/src/file.rs
@@ -8,7 +8,7 @@ pub const MAX_PATH_LEN: usize = 256;
 
 /// File operation kind intercepted at the kernel level.
 #[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FileOp {
     /// `openat` — file open attempt.
     Open = 0,
@@ -20,7 +20,7 @@ pub enum FileOp {
 
 /// A single file I/O kprobe event emitted from kernel-space.
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct FileEvent {
     /// Monotonic kernel timestamp (nanoseconds).
     pub timestamp_ns: u64,

--- a/aa-ebpf-common/src/lib.rs
+++ b/aa-ebpf-common/src/lib.rs
@@ -1,85 +1,22 @@
-//! Shared types between eBPF kernel-space probes and userspace loader.
+//! Shared no_std event types for the aa-ebpf kernel/userspace boundary.
 //!
-//! All types in this crate use fixed-size representations compatible with
-//! eBPF maps. This crate is `no_std` so it can be compiled for both the
-//! `bpfel-unknown-none` BPF target and standard userspace targets.
+//! This crate is compiled twice:
+//! - For the **host** target by `aa-ebpf` (userspace consumer).
+//! - For the **bpf** target by `aa-ebpf-programs` (kernel-space producer).
+//!
+//! All types are `#[repr(C)]` and `Copy` so they can be safely transferred
+//! through the BPF ring buffer without serialisation overhead.
+//!
+//! ## Modules
+//!
+//! | Module | Event type | Task |
+//! |--------|-----------|------|
+//! | [`tls`] | [`tls::TlsCaptureEvent`] | AAASM-37 — OpenSSL uprobe |
+//! | [`file`] | [`file::FileEvent`] | AAASM-38 — file I/O kprobes |
+//! | [`exec`] | [`exec::ProcessSpawnEvent`] | AAASM-39 — exec tracepoints |
 
 #![no_std]
 
-/// In-kernel node for the PID lineage map (`BpfHashMap<u32, ProcessNode>`).
-///
-/// Each entry maps a child PID to its parent and the command that spawned it.
-/// Fixed-size layout is required for eBPF map compatibility.
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct ProcessNode {
-    /// Process ID of the child.
-    pub pid: u32,
-    /// Parent process ID.
-    pub ppid: u32,
-    /// Command name (`comm`) of the process, null-padded.
-    pub comm: [u8; 16],
-    /// Kernel timestamp in nanoseconds when the process was spawned.
-    pub spawn_time_ns: u64,
-}
-
-/// Maximum number of argv entries captured per execve event.
-pub const MAX_ARGV_ENTRIES: usize = 5;
-
-/// Maximum byte length of a single argv entry.
-pub const MAX_ARGV_LEN: usize = 128;
-
-/// Event emitted from the eBPF tracepoint to userspace on each `execve` call.
-///
-/// Sent via ring buffer or perf event array. Fixed-size layout ensures
-/// predictable memory use in the eBPF program.
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct ProcessSpawnEvent {
-    /// Process ID of the newly spawned process.
-    pub pid: u32,
-    /// Parent process ID.
-    pub ppid: u32,
-    /// Command name (`comm`) of the new process, null-padded.
-    pub comm: [u8; 16],
-    /// First [`MAX_ARGV_ENTRIES`] argv entries, each null-padded to [`MAX_ARGV_LEN`] bytes.
-    pub argv: [[u8; MAX_ARGV_LEN]; MAX_ARGV_ENTRIES],
-    /// Number of environment variables passed to execve.
-    pub env_count: u32,
-    /// Kernel timestamp in nanoseconds.
-    pub timestamp_ns: u64,
-}
-
-/// Maximum byte length of the executable path in a [`ShellInjectionAlert`].
-pub const MAX_EXECUTABLE_LEN: usize = 256;
-
-/// Severity level for a shell injection alert.
-#[repr(u8)]
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub enum AlertLevel {
-    /// Informational — known-benign shell spawns (e.g. build scripts).
-    Info = 0,
-    /// Warning — potentially suspicious spawn (e.g. `python`, `node`).
-    Warning = 1,
-    /// Critical — high-risk spawn (e.g. `curl`, `wget`, raw `sh`/`bash`).
-    Critical = 2,
-}
-
-/// Alert emitted when an agent process spawns a suspicious child process.
-///
-/// Generated in the eBPF program when the spawned executable matches a
-/// known shell or download utility pattern (e.g. `bash`, `curl`, `wget`).
-#[repr(C)]
-#[derive(Clone, Copy)]
-pub struct ShellInjectionAlert {
-    /// PID of the monitored agent (or its ancestor in the lineage tree).
-    pub parent_pid: u32,
-    /// PID of the suspicious child process.
-    pub child_pid: u32,
-    /// Full executable path of the child, null-padded.
-    pub executable: [u8; MAX_EXECUTABLE_LEN],
-    /// Severity of the alert.
-    pub alert_level: AlertLevel,
-    /// Kernel timestamp in nanoseconds.
-    pub timestamp_ns: u64,
-}
+pub mod exec;
+pub mod file;
+pub mod tls;

--- a/aa-ebpf-common/src/tls.rs
+++ b/aa-ebpf-common/src/tls.rs
@@ -16,7 +16,7 @@ pub const MAX_PAYLOAD_LEN: usize = 4096;
 /// the eBPF program (compiled for the bpf target) and the userspace consumer
 /// (compiled for the host target).
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct TlsCaptureEvent {
     /// Monotonic kernel timestamp (nanoseconds).
     pub timestamp_ns: u64,

--- a/aa-ebpf-common/src/tls.rs
+++ b/aa-ebpf-common/src/tls.rs
@@ -1,0 +1,37 @@
+//! Shared types for TLS plaintext capture events (AAASM-37).
+//!
+//! Emitted by the `SSL_write` uprobe and `SSL_read` uretprobe in
+//! `aa-ebpf-programs` and consumed by the userspace ring-buffer reader in
+//! `aa-ebpf`.
+
+/// Maximum payload bytes captured per event.
+///
+/// Larger payloads are split across multiple events identified by the same
+/// `seq` counter.
+pub const MAX_PAYLOAD_LEN: usize = 4096;
+
+/// A single TLS plaintext capture event emitted from kernel-space.
+///
+/// The struct is `#[repr(C)]` so that the same memory layout is shared between
+/// the eBPF program (compiled for the bpf target) and the userspace consumer
+/// (compiled for the host target).
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct TlsCaptureEvent {
+    /// Monotonic kernel timestamp (nanoseconds).
+    pub timestamp_ns: u64,
+    /// Process ID of the monitored agent.
+    pub pid: u32,
+    /// Thread ID within the process.
+    pub tid: u32,
+    /// Total plaintext length before splitting (bytes).
+    pub data_len: u32,
+    /// Sequence number for reassembling split payloads (0-indexed).
+    pub seq: u32,
+    /// Direction: `0` = write (outbound), `1` = read (inbound).
+    pub direction: u8,
+    /// Padding for alignment.
+    pub _pad: [u8; 7],
+    /// Raw plaintext bytes (up to [`MAX_PAYLOAD_LEN`]).
+    pub payload: [u8; MAX_PAYLOAD_LEN],
+}

--- a/aa-ebpf-probes/src/ssl_probes.rs
+++ b/aa-ebpf-probes/src/ssl_probes.rs
@@ -89,35 +89,7 @@ fn try_ssl_write(ctx: ProbeContext) -> Result<u32, i64> {
         return Ok(0);
     }
 
-    let data_len = num as u32;
-    let capture_len = if data_len as usize > MAX_PAYLOAD_LEN {
-        MAX_PAYLOAD_LEN
-    } else {
-        data_len as usize
-    };
-
-    // Reserve ring buffer memory — avoids the 512-byte BPF stack limit.
-    let mut entry = EVENTS.reserve::<TlsCaptureEvent>(0).ok_or(-1i64)?;
-    let event_ptr = entry.as_mut_ptr();
-
-    unsafe {
-        (*event_ptr).timestamp_ns = bpf_ktime_get_ns();
-        (*event_ptr).pid = pid;
-        (*event_ptr).tid = pid_tgid as u32;
-        (*event_ptr).data_len = data_len;
-        (*event_ptr).seq = 0;
-        (*event_ptr).direction = 0; // outbound
-        (*event_ptr)._pad = [0u8; 7];
-
-        let dest = &mut (*event_ptr).payload[..capture_len];
-        if bpf_probe_read_user_buf(buf_ptr as *const u8, dest).is_err() {
-            entry.discard(0);
-            return Ok(0);
-        }
-    }
-
-    entry.submit(0);
-    Ok(0)
+    emit_tls_event(pid_tgid, pid, buf_ptr, num as u32, 0)
 }
 
 // ---------------------------------------------------------------------------
@@ -185,7 +157,23 @@ fn try_ssl_read_exit(ctx: RetProbeContext) -> Result<u32, i64> {
     };
     let _ = SSL_READ_ARGS.remove(&pid_tgid);
 
-    let data_len = num as u32;
+    emit_tls_event(pid_tgid, pid, buf_ptr, num as u32, 1)
+}
+
+// ---------------------------------------------------------------------------
+// Shared helper — write one TlsCaptureEvent into the ring buffer.
+// ---------------------------------------------------------------------------
+
+/// Emit a TLS plaintext capture event into the shared ring buffer.
+///
+/// Reserves ring-buffer memory (avoiding the 512-byte BPF stack limit),
+/// fills the [`TlsCaptureEvent`] fields in place, reads up to
+/// [`MAX_PAYLOAD_LEN`] bytes from `buf_ptr`, and submits.
+///
+/// Returns `Ok(0)` on success or if the userspace read fails (event discarded).
+/// Returns `Err(-1)` only if the ring buffer is full.
+#[inline(always)]
+fn emit_tls_event(pid_tgid: u64, pid: u32, buf_ptr: u64, data_len: u32, direction: u8) -> Result<u32, i64> {
     let capture_len = if data_len as usize > MAX_PAYLOAD_LEN {
         MAX_PAYLOAD_LEN
     } else {
@@ -201,7 +189,7 @@ fn try_ssl_read_exit(ctx: RetProbeContext) -> Result<u32, i64> {
         (*event_ptr).tid = pid_tgid as u32;
         (*event_ptr).data_len = data_len;
         (*event_ptr).seq = 0;
-        (*event_ptr).direction = 1; // inbound
+        (*event_ptr).direction = direction;
         (*event_ptr)._pad = [0u8; 7];
 
         let dest = &mut (*event_ptr).payload[..capture_len];

--- a/aa-ebpf-probes/src/ssl_probes.rs
+++ b/aa-ebpf-probes/src/ssl_probes.rs
@@ -167,7 +167,7 @@ fn try_ssl_read_exit(ctx: RetProbeContext) -> Result<u32, i64> {
 /// Emit a TLS plaintext capture event into the shared ring buffer.
 ///
 /// Reserves ring-buffer memory (avoiding the 512-byte BPF stack limit),
-/// fills the [`TlsCaptureEvent`] fields in place, reads up to
+/// fills the [`TlsCaptureEvent`] fields in-place, reads up to
 /// [`MAX_PAYLOAD_LEN`] bytes from `buf_ptr`, and submits.
 ///
 /// Returns `Ok(0)` on success or if the userspace read fails (event discarded).

--- a/aa-ebpf-probes/src/ssl_probes.rs
+++ b/aa-ebpf-probes/src/ssl_probes.rs
@@ -74,7 +74,7 @@ pub fn ssl_write(ctx: ProbeContext) -> u32 {
 }
 
 fn try_ssl_write(ctx: ProbeContext) -> Result<u32, i64> {
-    let pid_tgid = unsafe { bpf_get_current_pid_tgid() };
+    let pid_tgid = bpf_get_current_pid_tgid();
     let pid = (pid_tgid >> 32) as u32;
 
     if !pid_allowed(pid) {
@@ -82,8 +82,8 @@ fn try_ssl_write(ctx: ProbeContext) -> Result<u32, i64> {
     }
 
     // arg(1) = const void *buf, arg(2) = int num
-    let buf_ptr: u64 = unsafe { ctx.arg(1).ok_or(-1i64)? };
-    let num: i32 = unsafe { ctx.arg(2).ok_or(-1i64)? };
+    let buf_ptr: u64 = ctx.arg(1).ok_or(-1i64)?;
+    let num: i32 = ctx.arg(2).ok_or(-1i64)?;
 
     if num <= 0 {
         return Ok(0);
@@ -130,14 +130,14 @@ fn try_ssl_write(ctx: ProbeContext) -> Result<u32, i64> {
 /// [`ssl_read_exit`] can read it after the call returns.
 #[uprobe]
 pub fn ssl_read_entry(ctx: ProbeContext) -> u32 {
-    let pid_tgid = unsafe { bpf_get_current_pid_tgid() };
+    let pid_tgid = bpf_get_current_pid_tgid();
     let pid = (pid_tgid >> 32) as u32;
 
     if !pid_allowed(pid) {
         return 0;
     }
 
-    let buf_ptr: u64 = match unsafe { ctx.arg(1) } {
+    let buf_ptr: u64 = match ctx.arg(1) {
         Some(p) => p,
         None => return 0,
     };
@@ -165,7 +165,7 @@ pub fn ssl_read_exit(ctx: RetProbeContext) -> u32 {
 }
 
 fn try_ssl_read_exit(ctx: RetProbeContext) -> Result<u32, i64> {
-    let pid_tgid = unsafe { bpf_get_current_pid_tgid() };
+    let pid_tgid = bpf_get_current_pid_tgid();
     let pid = (pid_tgid >> 32) as u32;
 
     if !pid_allowed(pid) {

--- a/aa-ebpf-probes/src/ssl_probes.rs
+++ b/aa-ebpf-probes/src/ssl_probes.rs
@@ -216,7 +216,7 @@ fn try_ssl_read_exit(ctx: RetProbeContext) -> Result<u32, i64> {
 }
 
 // ---------------------------------------------------------------------------
-// Panic handler — required for no_std BPF binaries.
+// Panic handler (required for no_std binaries)
 // ---------------------------------------------------------------------------
 
 #[panic_handler]

--- a/aa-ebpf-probes/src/ssl_probes.rs
+++ b/aa-ebpf-probes/src/ssl_probes.rs
@@ -17,13 +17,13 @@
 #![no_std]
 #![no_main]
 
+use aa_ebpf_common::tls::{TlsCaptureEvent, MAX_PAYLOAD_LEN};
 use aya_ebpf::{
     helpers::{bpf_get_current_pid_tgid, bpf_ktime_get_ns, bpf_probe_read_user_buf},
     macros::{map, uprobe, uretprobe},
     maps::{Array, HashMap, RingBuf},
     programs::{ProbeContext, RetProbeContext},
 };
-use aa_ebpf_common::tls::{TlsCaptureEvent, MAX_PAYLOAD_LEN};
 
 // ---------------------------------------------------------------------------
 // BPF maps

--- a/aa-ebpf-probes/src/ssl_probes.rs
+++ b/aa-ebpf-probes/src/ssl_probes.rs
@@ -216,7 +216,7 @@ fn try_ssl_read_exit(ctx: RetProbeContext) -> Result<u32, i64> {
 }
 
 // ---------------------------------------------------------------------------
-// Panic handler (required for no_std binaries)
+// Panic handler — required for no_std BPF binaries.
 // ---------------------------------------------------------------------------
 
 #[panic_handler]

--- a/aa-ebpf-probes/src/ssl_probes.rs
+++ b/aa-ebpf-probes/src/ssl_probes.rs
@@ -1,0 +1,225 @@
+//! BPF TLS uprobe programs for AAASM-37.
+//!
+//! Three programs share a single ring buffer (`EVENTS`) and a per-thread
+//! argument-save map (`SSL_READ_ARGS`):
+//!
+//! - `ssl_write`      — uprobe on `SSL_write`; captures outbound plaintext.
+//! - `ssl_read_entry` — uprobe on `SSL_read`; saves the `buf` pointer so the
+//!                      uretprobe can read it after the call returns.
+//! - `ssl_read_exit`  — uretprobe on `SSL_read`; captures inbound plaintext.
+//!
+//! ## Stack-limit workaround
+//!
+//! [`TlsCaptureEvent`] is 4112 bytes — well above the BPF 512-byte stack
+//! limit.  We use [`RingBuf::reserve`] to allocate the event directly in ring
+//! buffer memory and fill it in place before submitting.
+
+#![no_std]
+#![no_main]
+
+use aya_ebpf::{
+    helpers::{bpf_get_current_pid_tgid, bpf_ktime_get_ns, bpf_probe_read_user_buf},
+    macros::{map, uprobe, uretprobe},
+    maps::{Array, HashMap, RingBuf},
+    programs::{ProbeContext, RetProbeContext},
+};
+use aa_ebpf_common::tls::{TlsCaptureEvent, MAX_PAYLOAD_LEN};
+
+// ---------------------------------------------------------------------------
+// BPF maps
+// ---------------------------------------------------------------------------
+
+/// Shared ring buffer for all eBPF events (EVENTS map, 256 KiB).
+#[map]
+static EVENTS: RingBuf = RingBuf::with_byte_size(262144, 0);
+
+/// Saves the `buf` pointer from an SSL_read entry so the uretprobe can
+/// read the data after the call returns.  Keyed by `pid_tgid` (u64).
+#[map]
+static SSL_READ_ARGS: HashMap<u64, u64> = HashMap::with_max_entries(1024, 0);
+
+/// Single-element array holding the target PID to monitor.
+/// Index 0 = target PID; value 0 means "monitor all processes".
+/// Written by userspace via [`crate::uprobe::UprobeManager::attach`].
+#[map]
+static TARGET_PID: Array<u32> = Array::with_max_entries(1, 0);
+
+// ---------------------------------------------------------------------------
+// PID filter helper
+// ---------------------------------------------------------------------------
+
+/// Returns `true` when `pid` should be traced (matches TARGET_PID or all).
+#[inline(always)]
+fn pid_allowed(pid: u32) -> bool {
+    match unsafe { TARGET_PID.get(0) } {
+        Some(target) => *target == 0 || *target == pid,
+        None => true,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ssl_write uprobe — outbound TLS plaintext
+// ---------------------------------------------------------------------------
+
+/// Uprobe attached to `SSL_write(ssl, buf, num)`.
+///
+/// Copies up to [`MAX_PAYLOAD_LEN`] bytes from userspace `buf` into the ring
+/// buffer and submits a [`TlsCaptureEvent`] with `direction = 0` (outbound).
+#[uprobe]
+pub fn ssl_write(ctx: ProbeContext) -> u32 {
+    match try_ssl_write(ctx) {
+        Ok(ret) => ret,
+        Err(_) => 0,
+    }
+}
+
+fn try_ssl_write(ctx: ProbeContext) -> Result<u32, i64> {
+    let pid_tgid = unsafe { bpf_get_current_pid_tgid() };
+    let pid = (pid_tgid >> 32) as u32;
+
+    if !pid_allowed(pid) {
+        return Ok(0);
+    }
+
+    // arg(1) = const void *buf, arg(2) = int num
+    let buf_ptr: u64 = unsafe { ctx.arg(1).ok_or(-1i64)? };
+    let num: i32 = unsafe { ctx.arg(2).ok_or(-1i64)? };
+
+    if num <= 0 {
+        return Ok(0);
+    }
+
+    let data_len = num as u32;
+    let capture_len = if data_len as usize > MAX_PAYLOAD_LEN {
+        MAX_PAYLOAD_LEN
+    } else {
+        data_len as usize
+    };
+
+    // Reserve ring buffer memory — avoids the 512-byte BPF stack limit.
+    let mut entry = EVENTS.reserve::<TlsCaptureEvent>(0).ok_or(-1i64)?;
+    let event_ptr = entry.as_mut_ptr();
+
+    unsafe {
+        (*event_ptr).timestamp_ns = bpf_ktime_get_ns();
+        (*event_ptr).pid = pid;
+        (*event_ptr).tid = pid_tgid as u32;
+        (*event_ptr).data_len = data_len;
+        (*event_ptr).seq = 0;
+        (*event_ptr).direction = 0; // outbound
+        (*event_ptr)._pad = [0u8; 7];
+
+        let dest = &mut (*event_ptr).payload[..capture_len];
+        if bpf_probe_read_user_buf(buf_ptr as *const u8, dest).is_err() {
+            entry.discard(0);
+            return Ok(0);
+        }
+    }
+
+    entry.submit(0);
+    Ok(0)
+}
+
+// ---------------------------------------------------------------------------
+// ssl_read_entry uprobe — save buf pointer for the uretprobe
+// ---------------------------------------------------------------------------
+
+/// Uprobe on `SSL_read(ssl, buf, num)` entry.
+///
+/// Saves the `buf` pointer in [`SSL_READ_ARGS`] keyed by `pid_tgid` so
+/// [`ssl_read_exit`] can read it after the call returns.
+#[uprobe]
+pub fn ssl_read_entry(ctx: ProbeContext) -> u32 {
+    let pid_tgid = unsafe { bpf_get_current_pid_tgid() };
+    let pid = (pid_tgid >> 32) as u32;
+
+    if !pid_allowed(pid) {
+        return 0;
+    }
+
+    let buf_ptr: u64 = match unsafe { ctx.arg(1) } {
+        Some(p) => p,
+        None => return 0,
+    };
+
+    // Ignore insert errors — if it fails we simply miss this read.
+    let _ = SSL_READ_ARGS.insert(&pid_tgid, &buf_ptr, 0);
+    0
+}
+
+// ---------------------------------------------------------------------------
+// ssl_read_exit uretprobe — inbound TLS plaintext
+// ---------------------------------------------------------------------------
+
+/// Uretprobe on `SSL_read` return.
+///
+/// Reads the saved `buf` pointer from [`SSL_READ_ARGS`], copies up to
+/// [`MAX_PAYLOAD_LEN`] bytes of inbound plaintext, and emits a
+/// [`TlsCaptureEvent`] with `direction = 1` (inbound).
+#[uretprobe]
+pub fn ssl_read_exit(ctx: RetProbeContext) -> u32 {
+    match try_ssl_read_exit(ctx) {
+        Ok(ret) => ret,
+        Err(_) => 0,
+    }
+}
+
+fn try_ssl_read_exit(ctx: RetProbeContext) -> Result<u32, i64> {
+    let pid_tgid = unsafe { bpf_get_current_pid_tgid() };
+    let pid = (pid_tgid >> 32) as u32;
+
+    if !pid_allowed(pid) {
+        return Ok(0);
+    }
+
+    let num: i32 = ctx.ret().ok_or(-1i64)?;
+    if num <= 0 {
+        // No data or error — clean up saved arg.
+        let _ = SSL_READ_ARGS.remove(&pid_tgid);
+        return Ok(0);
+    }
+
+    let buf_ptr: u64 = match unsafe { SSL_READ_ARGS.get(&pid_tgid) } {
+        Some(p) => *p,
+        None => return Ok(0),
+    };
+    let _ = SSL_READ_ARGS.remove(&pid_tgid);
+
+    let data_len = num as u32;
+    let capture_len = if data_len as usize > MAX_PAYLOAD_LEN {
+        MAX_PAYLOAD_LEN
+    } else {
+        data_len as usize
+    };
+
+    let mut entry = EVENTS.reserve::<TlsCaptureEvent>(0).ok_or(-1i64)?;
+    let event_ptr = entry.as_mut_ptr();
+
+    unsafe {
+        (*event_ptr).timestamp_ns = bpf_ktime_get_ns();
+        (*event_ptr).pid = pid;
+        (*event_ptr).tid = pid_tgid as u32;
+        (*event_ptr).data_len = data_len;
+        (*event_ptr).seq = 0;
+        (*event_ptr).direction = 1; // inbound
+        (*event_ptr)._pad = [0u8; 7];
+
+        let dest = &mut (*event_ptr).payload[..capture_len];
+        if bpf_probe_read_user_buf(buf_ptr as *const u8, dest).is_err() {
+            entry.discard(0);
+            return Ok(0);
+        }
+    }
+
+    entry.submit(0);
+    Ok(0)
+}
+
+// ---------------------------------------------------------------------------
+// Panic handler (required for no_std binaries)
+// ---------------------------------------------------------------------------
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe { core::hint::unreachable_unchecked() }
+}

--- a/aa-ebpf-programs/.cargo/config.toml
+++ b/aa-ebpf-programs/.cargo/config.toml
@@ -1,0 +1,12 @@
+# Cargo config for aa-ebpf-programs.
+#
+# This crate must be compiled for the eBPF virtual machine, not the host.
+# `bpfel-unknown-none` is the little-endian eBPF target used on x86-64 and
+# arm64 Linux hosts.  The `build-std` unstable feature is required because
+# the standard library is not pre-compiled for this target.
+
+[build]
+target = "bpfel-unknown-none"
+
+[unstable]
+build-std = ["core"]

--- a/aa-ebpf-programs/Cargo.toml
+++ b/aa-ebpf-programs/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "aa-ebpf-programs"
+version = "0.0.1"
+edition = "2021"
+license = "Apache-2.0"
+repository = "https://github.com/AI-agent-assembly/agent-assembly"
+description = "eBPF kernel-space programs for Agent Assembly — compiled for the bpf target"
+publish = false
+
+# This crate is NOT a member of the top-level Cargo workspace because it must
+# be compiled for the `bpfel-unknown-none` target.  It is built by the
+# `aa-ebpf/build.rs` script via `aya-build`.
+
+[dependencies]
+aa-ebpf-common = { path = "../aa-ebpf-common" }
+aya-ebpf       = "0.1"
+aya-log-ebpf   = "0.1"
+
+[[bin]]
+name = "aa-ebpf-programs"
+path = "src/main.rs"

--- a/aa-ebpf-programs/src/main.rs
+++ b/aa-ebpf-programs/src/main.rs
@@ -1,0 +1,91 @@
+//! eBPF kernel-space programs for Agent Assembly — Layer 3 interception.
+//!
+//! Each function in this file is an eBPF program compiled for the
+//! `bpfel-unknown-none` target and loaded into the Linux kernel by the
+//! userspace loader in `aa-ebpf`.
+//!
+//! ## Programs
+//!
+//! | Program | Probe type | Task |
+//! |---------|-----------|------|
+//! | [`ssl_write_uprobe`] | uprobe on `SSL_write` | AAASM-37 |
+//! | [`ssl_read_uretprobe`] | uretprobe on `SSL_read` | AAASM-37 |
+//! | [`openat_kprobe`] | kprobe on `do_sys_openat2` | AAASM-38 |
+//! | [`write_kprobe`] | kprobe on `ksys_write` | AAASM-38 |
+//! | [`unlink_kprobe`] | kprobe on `do_unlinkat` | AAASM-38 |
+//! | [`sched_process_exec`] | tracepoint on `sched/sched_process_exec` | AAASM-39 |
+
+#![no_std]
+#![no_main]
+
+use aya_ebpf::{macros::kprobe, macros::tracepoint, macros::uprobe, macros::uretprobe};
+use aya_ebpf::{programs::KProbeContext, programs::TracePointContext, programs::UProbeContext};
+
+// ---------------------------------------------------------------------------
+// AAASM-37 — OpenSSL TLS plaintext capture (uprobe / uretprobe)
+// ---------------------------------------------------------------------------
+
+/// Uprobe on `SSL_write`: captures plaintext before TLS encryption.
+///
+/// Target symbols: `SSL_write` (OpenSSL 1.1.x and 3.x).
+/// TODO(AAASM-37): read plaintext buffer, write TlsCaptureEvent to ring buffer.
+#[uprobe]
+pub fn ssl_write_uprobe(_ctx: UProbeContext) -> u32 {
+    0
+}
+
+/// Uretprobe on `SSL_read`: captures plaintext after TLS decryption.
+///
+/// Target symbols: `SSL_read` (OpenSSL 1.1.x and 3.x).
+/// TODO(AAASM-37): read return buffer, write TlsCaptureEvent to ring buffer.
+#[uretprobe]
+pub fn ssl_read_uretprobe(_ctx: UProbeContext) -> u32 {
+    0
+}
+
+// ---------------------------------------------------------------------------
+// AAASM-38 — File I/O kprobes
+// ---------------------------------------------------------------------------
+
+/// Kprobe on `do_sys_openat2`: intercepts file open attempts.
+///
+/// TODO(AAASM-38): extract dfd + filename, write FileEvent to ring buffer.
+#[kprobe]
+pub fn openat_kprobe(_ctx: KProbeContext) -> u32 {
+    0
+}
+
+/// Kprobe on `ksys_write`: intercepts data written to file descriptors.
+///
+/// TODO(AAASM-38): extract fd + count, write FileEvent to ring buffer.
+#[kprobe]
+pub fn write_kprobe(_ctx: KProbeContext) -> u32 {
+    0
+}
+
+/// Kprobe on `do_unlinkat`: intercepts file deletion attempts.
+///
+/// TODO(AAASM-38): extract pathname, write FileEvent to ring buffer.
+#[kprobe]
+pub fn unlink_kprobe(_ctx: KProbeContext) -> u32 {
+    0
+}
+
+// ---------------------------------------------------------------------------
+// AAASM-39 — Process exec tracepoints
+// ---------------------------------------------------------------------------
+
+/// Tracepoint on `sched/sched_process_exec`: fires on every execve call.
+///
+/// TODO(AAASM-39): extract pid, ppid, uid, filename, argv, write ExecEvent
+/// to ring buffer.
+#[tracepoint]
+pub fn sched_process_exec(_ctx: TracePointContext) -> u32 {
+    0
+}
+
+// Required by #![no_std] / #![no_main] for the BPF target.
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    loop {}
+}

--- a/aa-ebpf/Cargo.toml
+++ b/aa-ebpf/Cargo.toml
@@ -22,9 +22,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 aya     = { version = "0.13", features = ["async_tokio"] }
 aya-log = "0.2"
 
-[build-dependencies]
-aya-build = "0.1"
-
 [features]
 # Enables integration tests that load BPF programs into a live kernel.
 # Requires root (CAP_BPF + CAP_PERFMON). Only meaningful on Linux.

--- a/aa-ebpf/Cargo.toml
+++ b/aa-ebpf/Cargo.toml
@@ -8,8 +8,12 @@ description = "eBPF-based kernel-level monitoring hooks for Agent Assembly"
 
 [dependencies]
 aa-core        = { path = "../aa-core" }
-aa-ebpf-common = { path = "../aa-ebpf-common" }
-tokio          = { version = "1", features = ["rt", "signal"] }
+aa-ebpf-common = { path = "../aa-ebpf-common", features = ["std"] }
+anyhow         = "1"
+thiserror      = "2"
+tokio          = { version = "1", features = ["full"] }
+tracing        = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # aya is Linux-only: it uses libc symbols (CLOCK_BOOTTIME, etc.) absent on macOS/Windows.
 # The build-dep (aya-build) is unconditional so build.rs always compiles; the actual
@@ -17,6 +21,9 @@ tokio          = { version = "1", features = ["rt", "signal"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 aya     = { version = "0.13", features = ["async_tokio"] }
 aya-log = "0.2"
+
+[build-dependencies]
+aya-build = "0.1"
 
 [features]
 # Enables integration tests that load BPF programs into a live kernel.

--- a/aa-ebpf/build.rs
+++ b/aa-ebpf/build.rs
@@ -49,5 +49,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             return Err("BPF probe compilation failed — see cargo output above".into());
         }
     }
+
     Ok(())
 }

--- a/aa-ebpf/src/error.rs
+++ b/aa-ebpf/src/error.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 pub enum EbpfError {
     /// Failed to load the eBPF program ELF object.
     #[error("failed to load eBPF object: {0}")]
-    Load(#[from] aya::BpfError),
+    Load(#[from] aya::EbpfError),
 
     /// Failed to attach an uprobe or kprobe to a target symbol.
     #[error("failed to attach probe to `{symbol}`: {source}")]

--- a/aa-ebpf/src/error.rs
+++ b/aa-ebpf/src/error.rs
@@ -1,0 +1,37 @@
+//! Error types for the aa-ebpf userspace loader.
+
+use thiserror::Error;
+
+/// Errors that can occur while loading, attaching, or reading eBPF programs.
+#[derive(Debug, Error)]
+pub enum EbpfError {
+    /// Failed to load the eBPF program ELF object.
+    #[error("failed to load eBPF object: {0}")]
+    Load(#[from] aya::BpfError),
+
+    /// Failed to attach an uprobe or kprobe to a target symbol.
+    #[error("failed to attach probe to `{symbol}`: {source}")]
+    Attach {
+        /// Name of the target symbol (e.g. `SSL_write`).
+        symbol: String,
+        /// Underlying aya error.
+        #[source]
+        source: Box<dyn std::error::Error + Send + Sync + 'static>,
+    },
+
+    /// The ring buffer returned an unexpected event size.
+    #[error("ring buffer event size mismatch: expected {expected}, got {got}")]
+    EventSize {
+        /// Expected byte length.
+        expected: usize,
+        /// Actual byte length received.
+        got: usize,
+    },
+
+    /// A required eBPF map was not found in the loaded object.
+    #[error("eBPF map `{name}` not found in object")]
+    MapNotFound {
+        /// Name of the missing map.
+        name: String,
+    },
+}

--- a/aa-ebpf/src/error.rs
+++ b/aa-ebpf/src/error.rs
@@ -6,15 +6,26 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum EbpfError {
     /// Failed to load the eBPF program ELF object.
+    #[cfg(target_os = "linux")]
     #[error("failed to load eBPF object: {0}")]
     Load(#[from] aya::EbpfError),
+
+    /// An eBPF map operation failed (e.g. writing to a PID filter map).
+    #[cfg(target_os = "linux")]
+    #[error("eBPF map operation failed: {0}")]
+    Map(#[from] aya::maps::MapError),
+
+    /// An eBPF program operation failed (e.g. load or attach).
+    #[cfg(target_os = "linux")]
+    #[error("eBPF program operation failed: {0}")]
+    Program(#[from] aya::programs::ProgramError),
 
     /// Failed to attach an uprobe or kprobe to a target symbol.
     #[error("failed to attach probe to `{symbol}`: {source}")]
     Attach {
         /// Name of the target symbol (e.g. `SSL_write`).
         symbol: String,
-        /// Underlying aya error.
+        /// Underlying error.
         #[source]
         source: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
@@ -33,5 +44,12 @@ pub enum EbpfError {
     MapNotFound {
         /// Name of the missing map.
         name: String,
+    },
+
+    /// OpenSSL shared library could not be located for the target process.
+    #[error("could not find OpenSSL library for pid {pid:?}")]
+    OpenSslNotFound {
+        /// Target PID, or `None` for system-wide search.
+        pid: Option<i32>,
     },
 }

--- a/aa-ebpf/src/events.rs
+++ b/aa-ebpf/src/events.rs
@@ -5,6 +5,5 @@
 //! convenience so userspace code can import directly from `aa_ebpf`.
 
 pub use aa_ebpf_common::exec::{
-    AlertLevel, ProcessNode, ProcessSpawnEvent, ShellInjectionAlert, MAX_ARGV_ENTRIES,
-    MAX_ARGV_LEN, MAX_EXECUTABLE_LEN,
+    AlertLevel, ProcessNode, ProcessSpawnEvent, ShellInjectionAlert, MAX_ARGV_ENTRIES, MAX_ARGV_LEN, MAX_EXECUTABLE_LEN,
 };

--- a/aa-ebpf/src/events.rs
+++ b/aa-ebpf/src/events.rs
@@ -4,6 +4,7 @@
 //! the kernel-space eBPF programs. This module re-exports them for
 //! convenience so userspace code can import directly from `aa_ebpf`.
 
-pub use aa_ebpf_common::{
-    AlertLevel, ProcessNode, ProcessSpawnEvent, ShellInjectionAlert, MAX_ARGV_ENTRIES, MAX_ARGV_LEN, MAX_EXECUTABLE_LEN,
+pub use aa_ebpf_common::exec::{
+    AlertLevel, ProcessNode, ProcessSpawnEvent, ShellInjectionAlert, MAX_ARGV_ENTRIES,
+    MAX_ARGV_LEN, MAX_EXECUTABLE_LEN,
 };

--- a/aa-ebpf/src/kprobe.rs
+++ b/aa-ebpf/src/kprobe.rs
@@ -1,0 +1,39 @@
+//! Kprobe management for file I/O interception (AAASM-38).
+//!
+//! Attaches `openat_kprobe`, `write_kprobe`, and `unlink_kprobe` from
+//! `aa-ebpf-programs` to the corresponding kernel functions, filtered by
+//! the target PID stored in a BPF map.
+
+use aya::Bpf;
+
+use crate::error::EbpfError;
+
+/// Attaches and manages file I/O kprobe programs.
+///
+/// Create via [`KprobeManager::attach`]. The probes stay active until the
+/// `KprobeManager` is dropped.
+#[allow(dead_code)]
+pub struct KprobeManager {
+    /// Target PID to filter inside the eBPF program.
+    target_pid: Option<i32>,
+}
+
+impl KprobeManager {
+    /// Attach file I/O kprobes (`openat`, `write`, `unlink`) for the target PID.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EbpfError::Attach`] if a kernel symbol cannot be found
+    /// (e.g., the running kernel uses a different internal function name).
+    ///
+    /// # Arguments
+    ///
+    /// * `bpf` — live [`Bpf`] handle from [`crate::loader::EbpfLoader::load`].
+    /// * `target_pid` — PID to filter, or `None` for system-wide monitoring.
+    pub fn attach(bpf: &mut Bpf, target_pid: Option<i32>) -> Result<Self, EbpfError> {
+        // TODO(AAASM-38): attach openat_kprobe, write_kprobe, unlink_kprobe
+        // and write target_pid into the PID filter BPF map.
+        let _ = (bpf, target_pid);
+        todo!("attach file I/O kprobes")
+    }
+}

--- a/aa-ebpf/src/kprobe.rs
+++ b/aa-ebpf/src/kprobe.rs
@@ -4,6 +4,7 @@
 //! `aa-ebpf-programs` to the corresponding kernel functions, filtered by
 //! the target PID stored in a BPF map.
 
+#[cfg(target_os = "linux")]
 use aya::Ebpf;
 
 use crate::error::EbpfError;
@@ -30,6 +31,7 @@ impl KprobeManager {
     ///
     /// * `bpf` — live [`Ebpf`] handle from [`crate::loader::EbpfLoader::load`].
     /// * `target_pid` — PID to filter, or `None` for system-wide monitoring.
+    #[cfg(target_os = "linux")]
     pub fn attach(bpf: &mut Ebpf, target_pid: Option<i32>) -> Result<Self, EbpfError> {
         // TODO(AAASM-38): attach openat_kprobe, write_kprobe, unlink_kprobe
         // and write target_pid into the PID filter BPF map.

--- a/aa-ebpf/src/kprobe.rs
+++ b/aa-ebpf/src/kprobe.rs
@@ -4,7 +4,7 @@
 //! `aa-ebpf-programs` to the corresponding kernel functions, filtered by
 //! the target PID stored in a BPF map.
 
-use aya::Bpf;
+use aya::Ebpf;
 
 use crate::error::EbpfError;
 
@@ -28,9 +28,9 @@ impl KprobeManager {
     ///
     /// # Arguments
     ///
-    /// * `bpf` — live [`Bpf`] handle from [`crate::loader::EbpfLoader::load`].
+    /// * `bpf` — live [`Ebpf`] handle from [`crate::loader::EbpfLoader::load`].
     /// * `target_pid` — PID to filter, or `None` for system-wide monitoring.
-    pub fn attach(bpf: &mut Bpf, target_pid: Option<i32>) -> Result<Self, EbpfError> {
+    pub fn attach(bpf: &mut Ebpf, target_pid: Option<i32>) -> Result<Self, EbpfError> {
         // TODO(AAASM-38): attach openat_kprobe, write_kprobe, unlink_kprobe
         // and write target_pid into the PID filter BPF map.
         let _ = (bpf, target_pid);

--- a/aa-ebpf/src/lib.rs
+++ b/aa-ebpf/src/lib.rs
@@ -32,34 +32,34 @@
 //! [`aa_ebpf_common`].  They are `#[repr(C)]` and `no_std` so they compile
 //! for both targets without modification.
 //!
-//! ## Usage
+//! ## Platform support
 //!
-//! ```rust,ignore
-//! use aa_ebpf::{loader::EbpfLoader, ringbuf::RingBufReader};
-//! use aa_ebpf::{uprobe::UprobeManager, kprobe::KprobeManager};
-//! use aa_ebpf::tracepoint::TracepointManager;
-//!
-//! let mut bpf = EbpfLoader::load()?;
-//! let _uprobes  = UprobeManager::attach(&mut bpf, Some(target_pid))?;
-//! let _kprobes  = KprobeManager::attach(&mut bpf, Some(target_pid))?;
-//! let _tp       = TracepointManager::attach(&mut bpf)?;
-//! let mut reader = RingBufReader::new(bpf)?;
-//!
-//! while let Some(event) = reader.next().await? {
-//!     // forward event to aa-runtime governance pipeline
-//! }
-//! ```
+//! eBPF is Linux-only. On macOS, this crate compiles but all aya-dependent
+//! modules (`loader`, `uprobe`, `kprobe`, `tracepoint`, `ringbuf`) are gated
+//! with `#[cfg(target_os = "linux")]`.  The `events` and `lineage` modules
+//! are unconditional and available on all platforms.
 
-pub mod error;
+// Shared event type re-exports — unconditional (no aya dependency).
 pub mod events;
-pub mod kprobe;
 pub mod lineage;
+
+// aya-dependent modules — Linux only.
+#[cfg(target_os = "linux")]
+pub mod error;
+#[cfg(target_os = "linux")]
+pub mod kprobe;
+#[cfg(target_os = "linux")]
 pub mod loader;
+#[cfg(target_os = "linux")]
 pub mod ringbuf;
+#[cfg(target_os = "linux")]
 pub mod tracepoint;
+#[cfg(target_os = "linux")]
 pub mod uprobe;
 
+#[cfg(target_os = "linux")]
 pub use error::EbpfError;
+#[cfg(target_os = "linux")]
 pub use ringbuf::EbpfEvent;
 
 /// Compiled BPF bytecode for the `aa-hello` probe program.

--- a/aa-ebpf/src/lib.rs
+++ b/aa-ebpf/src/lib.rs
@@ -1,60 +1,66 @@
-//! eBPF-based kernel-level monitoring hooks for Agent Assembly (Layer 3).
+//! eBPF-based kernel-level monitoring hooks for Agent Assembly — Layer 3.
 //!
-//! This crate is the **userspace** half of the eBPF subsystem. It loads
-//! compiled BPF bytecode into the kernel, attaches tracepoints and kprobes,
-//! and reads events back through ring buffers — feeding them into the
-//! `aa-core` governance pipeline.
+//! This crate is the **userspace** half of the aa-ebpf subsystem.  It loads
+//! the compiled eBPF programs (from `aa-ebpf-probes`), attaches the probes
+//! to the kernel, and reads structured events from the shared BPF ring buffer.
 //!
-//! # Crate architecture (three-crate split)
-//!
-//! eBPF programs run inside the Linux kernel and must be compiled to the
-//! `bpfel-unknown-none` target. This forces a three-crate design:
-//!
-//! | Crate | Role | Target |
-//! |---|---|---|
-//! | **`aa-ebpf-common`** | Shared `repr(C)` types for maps and events | `no_std` (both) |
-//! | **`aa-ebpf-ebpf`** | BPF programs (tracepoints, kprobes, uprobes) | `bpfel-unknown-none` |
-//! | **`aa-ebpf`** (this crate) | Userspace loader, event consumer, lineage tracker | `std` (Linux) |
-//!
-//! # Data flow
+//! ## Architecture
 //!
 //! ```text
-//! kernel: tracepoint fires → BPF program writes to ring buffer / map
-//!                                         │
-//! ────────────────────────────────────────────────────────────
-//!                                         │
-//! user:  EbpfLoader reads ring buffer → ProcessSpawnEvent
-//!          → ProcessLineageTracker updates PID tree
-//!          → ShellInjectionAlert emitted if suspicious
-//!          → event forwarded to aa-core governance pipeline
+//! ┌─────────────────────────────────────────────┐
+//! │  aa-ebpf (userspace)                         │
+//! │                                              │
+//! │  EbpfLoader ──► UprobeManager  (AAASM-37)   │
+//! │             ──► KprobeManager  (AAASM-38)   │
+//! │             ──► TracepointManager (AAASM-39) │
+//! │                                              │
+//! │  RingBufReader ◄── BPF ring buffer           │
+//! └─────────────────────────────────────────────┘
+//!          │ kernel boundary │
+//! ┌─────────────────────────────────────────────┐
+//! │  aa-ebpf-probes (bpfel-unknown-none)         │
+//! │                                              │
+//! │  ssl_write_uprobe / ssl_read_uretprobe       │
+//! │  openat_kprobe / write_kprobe / unlink_kprobe│
+//! │  sched_process_exec (tracepoint)             │
+//! └─────────────────────────────────────────────┘
 //! ```
 //!
-//! # Loading BPF programs
+//! ## Shared types
 //!
-//! The compiled BPF bytecode is embedded at build time and exposed as the
-//! [`AA_HELLO_BPF`] constant. Pass it to [`aya::Ebpf::load`] to load all
-//! programs defined in the `aa-ebpf-probes` crate:
+//! Event structs shared between kernel-space and userspace live in
+//! [`aa_ebpf_common`].  They are `#[repr(C)]` and `no_std` so they compile
+//! for both targets without modification.
 //!
-//! ```no_run
-//! # #[cfg(target_os = "linux")]
-//! # {
-//! use aya::Ebpf;
-//! use aa_ebpf::AA_HELLO_BPF;
+//! ## Usage
 //!
-//! let mut bpf = Ebpf::load(AA_HELLO_BPF).expect("failed to load BPF programs");
-//! # }
+//! ```rust,ignore
+//! use aa_ebpf::{loader::EbpfLoader, ringbuf::RingBufReader};
+//! use aa_ebpf::{uprobe::UprobeManager, kprobe::KprobeManager};
+//! use aa_ebpf::tracepoint::TracepointManager;
+//!
+//! let mut bpf = EbpfLoader::load()?;
+//! let _uprobes  = UprobeManager::attach(&mut bpf, Some(target_pid))?;
+//! let _kprobes  = KprobeManager::attach(&mut bpf, Some(target_pid))?;
+//! let _tp       = TracepointManager::attach(&mut bpf)?;
+//! let mut reader = RingBufReader::new(bpf)?;
+//!
+//! while let Some(event) = reader.next().await? {
+//!     // forward event to aa-runtime governance pipeline
+//! }
 //! ```
-//!
-//! # Platform support
-//!
-//! eBPF is Linux-only. On macOS, this crate compiles but the `aya` and
-//! `aya-log` dependencies are gated behind `cfg(target_os = "linux")`.
-//! A future degraded mode using DTrace may provide partial observability
-//! on macOS.
 
+pub mod error;
 pub mod events;
+pub mod kprobe;
 pub mod lineage;
 pub mod loader;
+pub mod ringbuf;
+pub mod tracepoint;
+pub mod uprobe;
+
+pub use error::EbpfError;
+pub use ringbuf::EbpfEvent;
 
 /// Compiled BPF bytecode for the `aa-hello` probe program.
 ///

--- a/aa-ebpf/src/loader.rs
+++ b/aa-ebpf/src/loader.rs
@@ -1,6 +1,6 @@
 //! eBPF object loader: parses and loads the compiled eBPF ELF into the kernel.
 
-use aya::Bpf;
+use aya::Ebpf;
 
 use crate::error::EbpfError;
 
@@ -8,12 +8,12 @@ use crate::error::EbpfError;
 ///
 /// The object is embedded at build time by `build.rs` using `aya-build`.
 /// `EbpfLoader` is the entry point for all probe attachment in this crate:
-/// obtain a [`Bpf`] handle from [`EbpfLoader::load`] and pass it to the
+/// obtain an [`Ebpf`] handle from [`EbpfLoader::load`] and pass it to the
 /// individual managers ([`crate::uprobe::UprobeManager`], etc.).
 pub struct EbpfLoader;
 
 impl EbpfLoader {
-    /// Load the embedded eBPF ELF bytecode and return a live [`Bpf`] handle.
+    /// Load the embedded eBPF ELF bytecode and return a live [`Ebpf`] handle.
     ///
     /// # Errors
     ///
@@ -23,9 +23,9 @@ impl EbpfLoader {
     /// # Linux requirements
     ///
     /// Requires Linux 5.8+ with BTF enabled (`CONFIG_DEBUG_INFO_BTF=y`).
-    pub fn load() -> Result<Bpf, EbpfError> {
+    pub fn load() -> Result<Ebpf, EbpfError> {
         // TODO(AAASM-37): embed eBPF ELF via include_bytes_aligned! from
-        // OUT_DIR and call Bpf::load().
+        // OUT_DIR and call Ebpf::load().
         todo!("embed and load aa-ebpf-programs ELF")
     }
 }

--- a/aa-ebpf/src/loader.rs
+++ b/aa-ebpf/src/loader.rs
@@ -1,5 +1,6 @@
 //! eBPF object loader: parses and loads the compiled eBPF ELF into the kernel.
 
+#[cfg(target_os = "linux")]
 use aya::Ebpf;
 
 use crate::error::EbpfError;

--- a/aa-ebpf/src/loader.rs
+++ b/aa-ebpf/src/loader.rs
@@ -1,14 +1,31 @@
-//! eBPF program loader for the userspace side of Agent Assembly.
-//!
-//! Responsible for loading compiled BPF bytecode via [`aya::Ebpf`],
-//! attaching tracepoints and kprobes, and setting up ring buffer
-//! consumers that feed events into the governance pipeline.
+//! eBPF object loader: parses and loads the compiled eBPF ELF into the kernel.
 
-/// Loads and manages the lifecycle of eBPF programs.
+use aya::Bpf;
+
+use crate::error::EbpfError;
+
+/// Loads the compiled `aa-ebpf-programs` ELF object into the Linux kernel.
 ///
-/// On construction, loads the compiled BPF bytecode and attaches the
-/// configured probes. On drop, detaches all probes and releases
-/// kernel resources.
-pub struct EbpfLoader {
-    _private: (),
+/// The object is embedded at build time by `build.rs` using `aya-build`.
+/// `EbpfLoader` is the entry point for all probe attachment in this crate:
+/// obtain a [`Bpf`] handle from [`EbpfLoader::load`] and pass it to the
+/// individual managers ([`crate::uprobe::UprobeManager`], etc.).
+pub struct EbpfLoader;
+
+impl EbpfLoader {
+    /// Load the embedded eBPF ELF bytecode and return a live [`Bpf`] handle.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EbpfError::Load`] if the kernel rejects the object (e.g.
+    /// missing BTF, kernel too old).
+    ///
+    /// # Linux requirements
+    ///
+    /// Requires Linux 5.8+ with BTF enabled (`CONFIG_DEBUG_INFO_BTF=y`).
+    pub fn load() -> Result<Bpf, EbpfError> {
+        // TODO(AAASM-37): embed eBPF ELF via include_bytes_aligned! from
+        // OUT_DIR and call Bpf::load().
+        todo!("embed and load aa-ebpf-programs ELF")
+    }
 }

--- a/aa-ebpf/src/ringbuf.rs
+++ b/aa-ebpf/src/ringbuf.rs
@@ -4,6 +4,8 @@
 //! BPF ring buffer map.  `RingBufReader` multiplexes the three event types
 //! and dispatches them to registered callbacks.
 
+use std::mem;
+
 use aa_ebpf_common::{exec::ExecEvent, file::FileEvent, tls::TlsCaptureEvent};
 use aya::Ebpf;
 
@@ -54,5 +56,49 @@ impl RingBufReader {
         // TODO(AAASM-37/38/39): await next raw bytes, discriminate by size,
         // cast to the correct event type, and return.
         todo!("read next event from BPF ring buffer")
+    }
+}
+
+/// Discriminate a raw byte slice by size and copy it into an owned event.
+///
+/// Sizes (from `#[repr(C)]` layout):
+/// - [`TlsCaptureEvent`]: 4 + 8 + 4 + 4 + 4 + 4 + 1 + 7 + 4096 = 4112 bytes
+/// - [`FileEvent`]:  8 + 4 + 4 + 4 + 4 + 3 + 256 = 283... see struct for exact
+/// - [`ExecEvent`]:  8 + 4 + 4 + 4 + 4 + 256 + 512 = 792 bytes
+fn parse_event(bytes: &[u8]) -> Result<EbpfEvent, EbpfError> {
+    match bytes.len() {
+        n if n == mem::size_of::<TlsCaptureEvent>() => {
+            Ok(EbpfEvent::Tls(Box::new(bytes_to::<TlsCaptureEvent>(bytes))))
+        }
+        n if n == mem::size_of::<FileEvent>() => {
+            Ok(EbpfEvent::File(Box::new(bytes_to::<FileEvent>(bytes))))
+        }
+        n if n == mem::size_of::<ExecEvent>() => {
+            Ok(EbpfEvent::Exec(Box::new(bytes_to::<ExecEvent>(bytes))))
+        }
+        got => Err(EbpfError::EventSize {
+            expected: mem::size_of::<TlsCaptureEvent>(),
+            got,
+        }),
+    }
+}
+
+/// Copy `bytes` into a new instance of `T` via a raw pointer copy.
+///
+/// # Safety
+///
+/// `T` must be `#[repr(C)]` and `Copy`.  The caller must guarantee that
+/// `bytes.len() == size_of::<T>()` (enforced by [`parse_event`]).
+fn bytes_to<T: Copy>(bytes: &[u8]) -> T {
+    assert_eq!(bytes.len(), mem::size_of::<T>());
+    // SAFETY: T is #[repr(C)] and Copy; size equality is checked above.
+    let mut value = mem::MaybeUninit::<T>::uninit();
+    unsafe {
+        std::ptr::copy_nonoverlapping(
+            bytes.as_ptr(),
+            value.as_mut_ptr().cast::<u8>(),
+            bytes.len(),
+        );
+        value.assume_init()
     }
 }

--- a/aa-ebpf/src/ringbuf.rs
+++ b/aa-ebpf/src/ringbuf.rs
@@ -1,0 +1,58 @@
+//! BPF ring-buffer consumer: reads events from kernel-space to userspace.
+//!
+//! All three eBPF sub-tasks (AAASM-37, 38, 39) emit events through a shared
+//! BPF ring buffer map.  `RingBufReader` multiplexes the three event types
+//! and dispatches them to registered callbacks.
+
+use aya::Bpf;
+use aa_ebpf_common::{exec::ExecEvent, file::FileEvent, tls::TlsCaptureEvent};
+
+use crate::error::EbpfError;
+
+/// Dispatched event variants read from the shared BPF ring buffer.
+#[derive(Debug)]
+pub enum EbpfEvent {
+    /// TLS plaintext capture (AAASM-37).
+    Tls(TlsCaptureEvent),
+    /// File I/O operation (AAASM-38).
+    File(FileEvent),
+    /// Process exec (AAASM-39).
+    Exec(ExecEvent),
+}
+
+/// Async consumer that reads [`EbpfEvent`]s from the BPF ring buffer.
+///
+/// Create via [`RingBufReader::new`], then poll with [`RingBufReader::next`]
+/// inside a Tokio task.
+#[allow(dead_code)]
+pub struct RingBufReader {
+    bpf: Bpf,
+}
+
+impl RingBufReader {
+    /// Construct a `RingBufReader` from a loaded [`Bpf`] handle.
+    ///
+    /// Looks up the `EVENTS` ring buffer map in the loaded object.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EbpfError::MapNotFound`] if the `EVENTS` map is absent.
+    pub fn new(bpf: Bpf) -> Result<Self, EbpfError> {
+        // TODO(AAASM-37/38/39): obtain AsyncRingBuf handle from the EVENTS map.
+        Ok(Self { bpf })
+    }
+
+    /// Read the next event from the ring buffer (async).
+    ///
+    /// Returns `None` when the ring buffer has been closed (loader shut down).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EbpfError::EventSize`] if the raw bytes cannot be
+    /// interpreted as a known event type.
+    pub async fn next(&mut self) -> Result<Option<EbpfEvent>, EbpfError> {
+        // TODO(AAASM-37/38/39): await next raw bytes, discriminate by size,
+        // cast to the correct event type, and return.
+        todo!("read next event from BPF ring buffer")
+    }
+}

--- a/aa-ebpf/src/ringbuf.rs
+++ b/aa-ebpf/src/ringbuf.rs
@@ -4,8 +4,8 @@
 //! BPF ring buffer map.  `RingBufReader` multiplexes the three event types
 //! and dispatches them to registered callbacks.
 
-use aya::Bpf;
 use aa_ebpf_common::{exec::ExecEvent, file::FileEvent, tls::TlsCaptureEvent};
+use aya::Bpf;
 
 use crate::error::EbpfError;
 

--- a/aa-ebpf/src/ringbuf.rs
+++ b/aa-ebpf/src/ringbuf.rs
@@ -68,15 +68,9 @@ impl RingBufReader {
 /// - [`ExecEvent`]:  8 + 4 + 4 + 4 + 4 + 256 + 512 = 792 bytes
 fn parse_event(bytes: &[u8]) -> Result<EbpfEvent, EbpfError> {
     match bytes.len() {
-        n if n == mem::size_of::<TlsCaptureEvent>() => {
-            Ok(EbpfEvent::Tls(Box::new(bytes_to::<TlsCaptureEvent>(bytes))))
-        }
-        n if n == mem::size_of::<FileEvent>() => {
-            Ok(EbpfEvent::File(Box::new(bytes_to::<FileEvent>(bytes))))
-        }
-        n if n == mem::size_of::<ExecEvent>() => {
-            Ok(EbpfEvent::Exec(Box::new(bytes_to::<ExecEvent>(bytes))))
-        }
+        n if n == mem::size_of::<TlsCaptureEvent>() => Ok(EbpfEvent::Tls(Box::new(bytes_to::<TlsCaptureEvent>(bytes)))),
+        n if n == mem::size_of::<FileEvent>() => Ok(EbpfEvent::File(Box::new(bytes_to::<FileEvent>(bytes)))),
+        n if n == mem::size_of::<ExecEvent>() => Ok(EbpfEvent::Exec(Box::new(bytes_to::<ExecEvent>(bytes)))),
         got => Err(EbpfError::EventSize {
             expected: mem::size_of::<TlsCaptureEvent>(),
             got,
@@ -95,11 +89,7 @@ fn bytes_to<T: Copy>(bytes: &[u8]) -> T {
     // SAFETY: T is #[repr(C)] and Copy; size equality is checked above.
     let mut value = mem::MaybeUninit::<T>::uninit();
     unsafe {
-        std::ptr::copy_nonoverlapping(
-            bytes.as_ptr(),
-            value.as_mut_ptr().cast::<u8>(),
-            bytes.len(),
-        );
+        std::ptr::copy_nonoverlapping(bytes.as_ptr(), value.as_mut_ptr().cast::<u8>(), bytes.len());
         value.assume_init()
     }
 }

--- a/aa-ebpf/src/ringbuf.rs
+++ b/aa-ebpf/src/ringbuf.rs
@@ -7,6 +7,7 @@
 use std::mem;
 
 use aa_ebpf_common::{exec::ExecEvent, file::FileEvent, tls::TlsCaptureEvent};
+#[cfg(target_os = "linux")]
 use aya::Ebpf;
 
 use crate::error::EbpfError;

--- a/aa-ebpf/src/ringbuf.rs
+++ b/aa-ebpf/src/ringbuf.rs
@@ -15,9 +15,9 @@ pub enum EbpfEvent {
     /// TLS plaintext capture (AAASM-37).
     Tls(Box<TlsCaptureEvent>),
     /// File I/O operation (AAASM-38).
-    File(FileEvent),
+    File(Box<FileEvent>),
     /// Process exec (AAASM-39).
-    Exec(ExecEvent),
+    Exec(Box<ExecEvent>),
 }
 
 /// Async consumer that reads [`EbpfEvent`]s from the BPF ring buffer.

--- a/aa-ebpf/src/ringbuf.rs
+++ b/aa-ebpf/src/ringbuf.rs
@@ -5,7 +5,7 @@
 //! and dispatches them to registered callbacks.
 
 use aa_ebpf_common::{exec::ExecEvent, file::FileEvent, tls::TlsCaptureEvent};
-use aya::Bpf;
+use aya::Ebpf;
 
 use crate::error::EbpfError;
 
@@ -13,7 +13,7 @@ use crate::error::EbpfError;
 #[derive(Debug)]
 pub enum EbpfEvent {
     /// TLS plaintext capture (AAASM-37).
-    Tls(TlsCaptureEvent),
+    Tls(Box<TlsCaptureEvent>),
     /// File I/O operation (AAASM-38).
     File(FileEvent),
     /// Process exec (AAASM-39).
@@ -26,18 +26,18 @@ pub enum EbpfEvent {
 /// inside a Tokio task.
 #[allow(dead_code)]
 pub struct RingBufReader {
-    bpf: Bpf,
+    bpf: Ebpf,
 }
 
 impl RingBufReader {
-    /// Construct a `RingBufReader` from a loaded [`Bpf`] handle.
+    /// Construct a `RingBufReader` from a loaded [`Ebpf`] handle.
     ///
     /// Looks up the `EVENTS` ring buffer map in the loaded object.
     ///
     /// # Errors
     ///
     /// Returns [`EbpfError::MapNotFound`] if the `EVENTS` map is absent.
-    pub fn new(bpf: Bpf) -> Result<Self, EbpfError> {
+    pub fn new(bpf: Ebpf) -> Result<Self, EbpfError> {
         // TODO(AAASM-37/38/39): obtain AsyncRingBuf handle from the EVENTS map.
         Ok(Self { bpf })
     }

--- a/aa-ebpf/src/tracepoint.rs
+++ b/aa-ebpf/src/tracepoint.rs
@@ -1,0 +1,36 @@
+//! Tracepoint management for process exec monitoring (AAASM-39).
+//!
+//! Attaches the `sched_process_exec` tracepoint from `aa-ebpf-programs` to
+//! the Linux `sched/sched_process_exec` kernel tracepoint.
+
+use aya::Bpf;
+
+use crate::error::EbpfError;
+
+/// Attaches and manages the `sched_process_exec` tracepoint program.
+///
+/// Create via [`TracepointManager::attach`]. The tracepoint stays active
+/// until the `TracepointManager` is dropped.
+#[allow(dead_code)]
+pub struct TracepointManager;
+
+impl TracepointManager {
+    /// Attach the `sched/sched_process_exec` tracepoint program.
+    ///
+    /// This tracepoint fires for every `execve`/`execveat` syscall on the
+    /// system, regardless of whether the process imported the aa SDK.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EbpfError::Attach`] if the tracepoint category or name
+    /// is not available on the running kernel.
+    ///
+    /// # Arguments
+    ///
+    /// * `bpf` — live [`Bpf`] handle from [`crate::loader::EbpfLoader::load`].
+    pub fn attach(bpf: &mut Bpf) -> Result<Self, EbpfError> {
+        // TODO(AAASM-39): attach sched_process_exec tracepoint.
+        let _ = bpf;
+        todo!("attach sched_process_exec tracepoint")
+    }
+}

--- a/aa-ebpf/src/tracepoint.rs
+++ b/aa-ebpf/src/tracepoint.rs
@@ -3,7 +3,7 @@
 //! Attaches the `sched_process_exec` tracepoint from `aa-ebpf-programs` to
 //! the Linux `sched/sched_process_exec` kernel tracepoint.
 
-use aya::Bpf;
+use aya::Ebpf;
 
 use crate::error::EbpfError;
 
@@ -27,8 +27,8 @@ impl TracepointManager {
     ///
     /// # Arguments
     ///
-    /// * `bpf` — live [`Bpf`] handle from [`crate::loader::EbpfLoader::load`].
-    pub fn attach(bpf: &mut Bpf) -> Result<Self, EbpfError> {
+    /// * `bpf` — live [`Ebpf`] handle from [`crate::loader::EbpfLoader::load`].
+    pub fn attach(bpf: &mut Ebpf) -> Result<Self, EbpfError> {
         // TODO(AAASM-39): attach sched_process_exec tracepoint.
         let _ = bpf;
         todo!("attach sched_process_exec tracepoint")

--- a/aa-ebpf/src/tracepoint.rs
+++ b/aa-ebpf/src/tracepoint.rs
@@ -3,6 +3,7 @@
 //! Attaches the `sched_process_exec` tracepoint from `aa-ebpf-programs` to
 //! the Linux `sched/sched_process_exec` kernel tracepoint.
 
+#[cfg(target_os = "linux")]
 use aya::Ebpf;
 
 use crate::error::EbpfError;
@@ -28,6 +29,7 @@ impl TracepointManager {
     /// # Arguments
     ///
     /// * `bpf` — live [`Ebpf`] handle from [`crate::loader::EbpfLoader::load`].
+    #[cfg(target_os = "linux")]
     pub fn attach(bpf: &mut Ebpf) -> Result<Self, EbpfError> {
         // TODO(AAASM-39): attach sched_process_exec tracepoint.
         let _ = bpf;

--- a/aa-ebpf/src/uprobe.rs
+++ b/aa-ebpf/src/uprobe.rs
@@ -1,0 +1,42 @@
+//! Uprobe/uretprobe management for OpenSSL TLS plaintext capture (AAASM-37).
+//!
+//! Attaches `ssl_write_uprobe` and `ssl_read_uretprobe` from
+//! `aa-ebpf-programs` to the `SSL_write` and `SSL_read` symbols in every
+//! matching OpenSSL shared library loaded by the target process.
+
+use aya::Bpf;
+
+use crate::error::EbpfError;
+
+/// Attaches and manages OpenSSL uprobe/uretprobe programs.
+///
+/// Create via [`UprobeManager::attach`]. The probes stay active until the
+/// `UprobeManager` is dropped.
+#[allow(dead_code)]
+pub struct UprobeManager {
+    /// Target PID to monitor. `None` means monitor all processes.
+    target_pid: Option<i32>,
+}
+
+impl UprobeManager {
+    /// Attach `SSL_write` uprobe and `SSL_read` uretprobe to the target PID.
+    ///
+    /// Supports both OpenSSL 1.1.x (`SSL_write` symbol) and 3.x
+    /// (`SSL_write_ex` symbol) — both are attached when present.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EbpfError::Attach`] if the symbol cannot be resolved in any
+    /// loaded OpenSSL library for the given PID.
+    ///
+    /// # Arguments
+    ///
+    /// * `bpf` — live [`Bpf`] handle from [`crate::loader::EbpfLoader::load`].
+    /// * `target_pid` — PID to attach to, or `None` for system-wide.
+    pub fn attach(bpf: &mut Bpf, target_pid: Option<i32>) -> Result<Self, EbpfError> {
+        // TODO(AAASM-37): resolve OpenSSL library path for target_pid,
+        // attach ssl_write_uprobe and ssl_read_uretprobe.
+        let _ = (bpf, target_pid);
+        todo!("attach SSL_write uprobe and SSL_read uretprobe")
+    }
+}

--- a/aa-ebpf/src/uprobe.rs
+++ b/aa-ebpf/src/uprobe.rs
@@ -4,7 +4,11 @@
 //! `aa-ebpf-programs` to the `SSL_write` and `SSL_read` symbols in every
 //! matching OpenSSL shared library loaded by the target process.
 
-use aya::Ebpf;
+use aya::{
+    maps::Array,
+    programs::UProbe,
+    Ebpf,
+};
 
 use crate::error::EbpfError;
 
@@ -34,9 +38,65 @@ impl UprobeManager {
     /// * `bpf` — live [`Ebpf`] handle from [`crate::loader::EbpfLoader::load`].
     /// * `target_pid` — PID to attach to, or `None` for system-wide.
     pub fn attach(bpf: &mut Ebpf, target_pid: Option<i32>) -> Result<Self, EbpfError> {
-        // TODO(AAASM-37): resolve OpenSSL library path for target_pid,
-        // attach ssl_write_uprobe and ssl_read_uretprobe.
-        let _ = (bpf, target_pid);
-        todo!("attach SSL_write uprobe and SSL_read uretprobe")
+        // 1. Write the target PID into the BPF-side filter map.
+        {
+            let map = bpf.map_mut("TARGET_PID").ok_or_else(|| EbpfError::MapNotFound {
+                name: "TARGET_PID".into(),
+            })?;
+            let mut pid_map: Array<_, u32> = Array::try_from(map)?;
+            let pid_val: u32 = target_pid.map(|p| p as u32).unwrap_or(0);
+            pid_map.set(0, pid_val, 0)?;
+        }
+
+        // 2. Find the OpenSSL shared library for the target process.
+        let ssl_path = find_openssl_path(target_pid)?;
+
+        // 3. Attach ssl_write uprobe (captures outbound TLS plaintext).
+        {
+            let prog: &mut UProbe = bpf
+                .program_mut("ssl_write")
+                .ok_or_else(|| EbpfError::MapNotFound {
+                    name: "ssl_write".into(),
+                })?
+                .try_into()?;
+            prog.load()?;
+            prog.attach(Some("SSL_write"), 0, &ssl_path, target_pid)?;
+        }
+
+        // 4. Attach ssl_read_entry uprobe (saves SSL_read buf ptr for step 5).
+        {
+            let prog: &mut UProbe = bpf
+                .program_mut("ssl_read_entry")
+                .ok_or_else(|| EbpfError::MapNotFound {
+                    name: "ssl_read_entry".into(),
+                })?
+                .try_into()?;
+            prog.load()?;
+            prog.attach(Some("SSL_read"), 0, &ssl_path, target_pid)?;
+        }
+
+        // 5. Attach ssl_read_exit uretprobe (captures inbound TLS plaintext).
+        {
+            let prog: &mut UProbe = bpf
+                .program_mut("ssl_read_exit")
+                .ok_or_else(|| EbpfError::MapNotFound {
+                    name: "ssl_read_exit".into(),
+                })?
+                .try_into()?;
+            prog.load()?;
+            prog.attach(Some("SSL_read"), 0, &ssl_path, target_pid)?;
+        }
+
+        Ok(Self { target_pid })
     }
+}
+
+/// Find the path to the OpenSSL shared library for the given PID.
+///
+/// Scans `/proc/<pid>/maps` for a line containing `libssl.so` or
+/// `/proc/1/maps` (the init process) as a fallback for system-wide mode.
+fn find_openssl_path(target_pid: Option<i32>) -> Result<String, EbpfError> {
+    // TODO(AAASM-37): implement /proc/<pid>/maps parsing to find libssl path.
+    let _ = target_pid;
+    todo!("find OpenSSL library path for target PID")
 }

--- a/aa-ebpf/src/uprobe.rs
+++ b/aa-ebpf/src/uprobe.rs
@@ -53,7 +53,9 @@ impl UprobeManager {
         {
             let prog: &mut UProbe = bpf
                 .program_mut("ssl_write")
-                .ok_or_else(|| EbpfError::MapNotFound { name: "ssl_write".into() })?
+                .ok_or_else(|| EbpfError::MapNotFound {
+                    name: "ssl_write".into(),
+                })?
                 .try_into()?;
             prog.load()?;
             prog.attach(Some("SSL_write"), 0, &ssl_path, target_pid)?;
@@ -63,7 +65,9 @@ impl UprobeManager {
         {
             let prog: &mut UProbe = bpf
                 .program_mut("ssl_read_entry")
-                .ok_or_else(|| EbpfError::MapNotFound { name: "ssl_read_entry".into() })?
+                .ok_or_else(|| EbpfError::MapNotFound {
+                    name: "ssl_read_entry".into(),
+                })?
                 .try_into()?;
             prog.load()?;
             prog.attach(Some("SSL_read"), 0, &ssl_path, target_pid)?;
@@ -73,7 +77,9 @@ impl UprobeManager {
         {
             let prog: &mut UProbe = bpf
                 .program_mut("ssl_read_exit")
-                .ok_or_else(|| EbpfError::MapNotFound { name: "ssl_read_exit".into() })?
+                .ok_or_else(|| EbpfError::MapNotFound {
+                    name: "ssl_read_exit".into(),
+                })?
                 .try_into()?;
             prog.load()?;
             prog.attach(Some("SSL_read"), 0, &ssl_path, target_pid)?;

--- a/aa-ebpf/src/uprobe.rs
+++ b/aa-ebpf/src/uprobe.rs
@@ -4,7 +4,7 @@
 //! `aa-ebpf-programs` to the `SSL_write` and `SSL_read` symbols in every
 //! matching OpenSSL shared library loaded by the target process.
 
-use aya::Bpf;
+use aya::Ebpf;
 
 use crate::error::EbpfError;
 
@@ -31,9 +31,9 @@ impl UprobeManager {
     ///
     /// # Arguments
     ///
-    /// * `bpf` — live [`Bpf`] handle from [`crate::loader::EbpfLoader::load`].
+    /// * `bpf` — live [`Ebpf`] handle from [`crate::loader::EbpfLoader::load`].
     /// * `target_pid` — PID to attach to, or `None` for system-wide.
-    pub fn attach(bpf: &mut Bpf, target_pid: Option<i32>) -> Result<Self, EbpfError> {
+    pub fn attach(bpf: &mut Ebpf, target_pid: Option<i32>) -> Result<Self, EbpfError> {
         // TODO(AAASM-37): resolve OpenSSL library path for target_pid,
         // attach ssl_write_uprobe and ssl_read_uretprobe.
         let _ = (bpf, target_pid);

--- a/aa-ebpf/src/uprobe.rs
+++ b/aa-ebpf/src/uprobe.rs
@@ -1,14 +1,11 @@
 //! Uprobe/uretprobe management for OpenSSL TLS plaintext capture (AAASM-37).
 //!
 //! Attaches `ssl_write_uprobe` and `ssl_read_uretprobe` from
-//! `aa-ebpf-programs` to the `SSL_write` and `SSL_read` symbols in every
+//! `aa-ebpf-probes` to the `SSL_write` and `SSL_read` symbols in every
 //! matching OpenSSL shared library loaded by the target process.
 
-use aya::{
-    maps::Array,
-    programs::UProbe,
-    Ebpf,
-};
+#[cfg(target_os = "linux")]
+use aya::{maps::Array, programs::UProbe, Ebpf};
 
 use crate::error::EbpfError;
 
@@ -37,6 +34,7 @@ impl UprobeManager {
     ///
     /// * `bpf` — live [`Ebpf`] handle from [`crate::loader::EbpfLoader::load`].
     /// * `target_pid` — PID to attach to, or `None` for system-wide.
+    #[cfg(target_os = "linux")]
     pub fn attach(bpf: &mut Ebpf, target_pid: Option<i32>) -> Result<Self, EbpfError> {
         // 1. Write the target PID into the BPF-side filter map.
         {
@@ -55,9 +53,7 @@ impl UprobeManager {
         {
             let prog: &mut UProbe = bpf
                 .program_mut("ssl_write")
-                .ok_or_else(|| EbpfError::MapNotFound {
-                    name: "ssl_write".into(),
-                })?
+                .ok_or_else(|| EbpfError::MapNotFound { name: "ssl_write".into() })?
                 .try_into()?;
             prog.load()?;
             prog.attach(Some("SSL_write"), 0, &ssl_path, target_pid)?;
@@ -67,9 +63,7 @@ impl UprobeManager {
         {
             let prog: &mut UProbe = bpf
                 .program_mut("ssl_read_entry")
-                .ok_or_else(|| EbpfError::MapNotFound {
-                    name: "ssl_read_entry".into(),
-                })?
+                .ok_or_else(|| EbpfError::MapNotFound { name: "ssl_read_entry".into() })?
                 .try_into()?;
             prog.load()?;
             prog.attach(Some("SSL_read"), 0, &ssl_path, target_pid)?;
@@ -79,9 +73,7 @@ impl UprobeManager {
         {
             let prog: &mut UProbe = bpf
                 .program_mut("ssl_read_exit")
-                .ok_or_else(|| EbpfError::MapNotFound {
-                    name: "ssl_read_exit".into(),
-                })?
+                .ok_or_else(|| EbpfError::MapNotFound { name: "ssl_read_exit".into() })?
                 .try_into()?;
             prog.load()?;
             prog.attach(Some("SSL_read"), 0, &ssl_path, target_pid)?;
@@ -89,12 +81,20 @@ impl UprobeManager {
 
         Ok(Self { target_pid })
     }
+
+    /// Stub for non-Linux platforms — uprobe attachment requires Linux.
+    #[cfg(not(target_os = "linux"))]
+    pub fn attach(_bpf: &mut (), _target_pid: Option<i32>) -> Result<Self, EbpfError> {
+        Err(EbpfError::MapNotFound {
+            name: "uprobe attachment requires Linux".into(),
+        })
+    }
 }
 
 /// Find the path to the OpenSSL shared library for the given PID.
 ///
-/// Scans `/proc/<pid>/maps` for a line containing `libssl.so` or
-/// `/proc/1/maps` (the init process) as a fallback for system-wide mode.
+/// Scans `/proc/<pid>/maps` for a line containing `libssl.so`.
+#[cfg(target_os = "linux")]
 fn find_openssl_path(target_pid: Option<i32>) -> Result<String, EbpfError> {
     // TODO(AAASM-37): implement /proc/<pid>/maps parsing to find libssl path.
     let _ = target_pid;

--- a/aa-ebpf/tests/tls_uprobe.rs
+++ b/aa-ebpf/tests/tls_uprobe.rs
@@ -1,0 +1,56 @@
+// Integration test: load and attach the TLS uprobe BPF programs.
+//
+// Gated on:
+//   - target_os = "linux"  — eBPF is Linux-only
+//   - feature = "integration-test" — opted-in explicitly; requires root (CAP_BPF)
+//
+// Run locally (Linux, as root or via sudo):
+//   sudo env "PATH=$PATH" cargo test -p aa-ebpf --features integration-test --test tls_uprobe -- --nocapture
+#![cfg(all(target_os = "linux", feature = "integration-test"))]
+
+use aa_ebpf::AA_TLS_BPF;
+use aya::{programs::UProbe, Ebpf};
+
+/// Verify the TLS probe pipeline: compile → embed → load into kernel verifier.
+///
+/// Does *not* attach to a live process (that would require OpenSSL to be
+/// present at a known path).  Loading through the verifier is sufficient to
+/// confirm that:
+///
+/// 1. `Ebpf::load` successfully parses the embedded BPF ELF.
+/// 2. All three programs pass the kernel verifier (`prog.load()`).
+///
+/// This test requires `CAP_BPF` + `CAP_PERFMON` (Linux 5.8+).
+#[test]
+fn aa_tls_probes_load_through_verifier() {
+    let mut bpf =
+        Ebpf::load(AA_TLS_BPF).expect("failed to load aa-tls-probes BPF object — ensure the test is running as root");
+
+    // Verify ssl_write uprobe program loads.
+    let ssl_write: &mut UProbe = bpf
+        .program_mut("ssl_write")
+        .expect("ssl_write program not found in BPF object")
+        .try_into()
+        .expect("ssl_write is not a UProbe program");
+    ssl_write.load().expect("kernel verifier rejected ssl_write uprobe");
+
+    // Verify ssl_read_entry uprobe program loads.
+    let ssl_read_entry: &mut UProbe = bpf
+        .program_mut("ssl_read_entry")
+        .expect("ssl_read_entry program not found in BPF object")
+        .try_into()
+        .expect("ssl_read_entry is not a UProbe program");
+    ssl_read_entry
+        .load()
+        .expect("kernel verifier rejected ssl_read_entry uprobe");
+
+    // Verify ssl_read_exit uretprobe program loads.
+    let ssl_read_exit: &mut UProbe = bpf
+        .program_mut("ssl_read_exit")
+        .expect("ssl_read_exit program not found in BPF object")
+        .try_into()
+        .expect("ssl_read_exit is not a UProbe program");
+    ssl_read_exit
+        .load()
+        .expect("kernel verifier rejected ssl_read_exit uretprobe");
+}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -75,3 +75,4 @@ See [versioning.md](versioning.md) for the full versioning and deprecation polic
 |---|---|---|
 | AAASM-107 | Added `conformance` workspace crate (test infrastructure, not shipped) | None — internal tooling only |
 | AAASM-39 | Added `aa-ebpf-common` workspace crate (shared eBPF types, not shipped standalone) | None — internal shared types only |
+| AAASM-37  | Added `aa-ebpf-common` workspace crate (no_std shared eBPF event types, not shipped as a public API) | None — internal kernel/userspace bridge only |


### PR DESCRIPTION
## Description

Scaffolds the full `aa-ebpf` crate architecture — the shared foundation for AAASM-37 (TLS uprobe), AAASM-38 (file I/O kprobes), and AAASM-39 (exec tracepoints) — so that all three implementation tasks have a clean, isolated module to work in from the start.

Three crate-level changes:

**`aa-ebpf-common`** (new, in workspace, `no_std`)
Shared `#[repr(C)]` event types used by both the kernel-space eBPF programs and the userspace consumer without any serialisation overhead:
- `tls::TlsCaptureEvent` — for AAASM-37
- `file::FileEvent` + `FileOp` — for AAASM-38
- `exec::ExecEvent` — for AAASM-39

**`aa-ebpf-programs`** (new, *not* in workspace — compiled for `bpfel-unknown-none`)
Kernel-space eBPF programs with probe/tracepoint stubs ready for implementation:
- `ssl_write_uprobe` / `ssl_read_uretprobe` (AAASM-37)
- `openat_kprobe` / `write_kprobe` / `unlink_kprobe` (AAASM-38)
- `sched_process_exec` tracepoint (AAASM-39)
Cross-compilation configured via `.cargo/config.toml` (`target = bpfel-unknown-none`, `build-std = ["core"]`).

**`aa-ebpf`** (updated — userspace loader)
- Added `aya`, `aya-log`, `tokio`, `anyhow`, `thiserror` dependencies
- `build.rs` using `aya-build` to cross-compile `aa-ebpf-programs`
- New module skeletons: `error`, `loader`, `uprobe`, `kprobe`, `tracepoint`, `ringbuf`
- `lib.rs` updated with full architecture diagram and usage example

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-37
- Related GitHub issues: N/A

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [x] No tests required (explain why)

Architecture-only scaffold. All implementation functions contain `todo!()` stubs. Tests will be added in AAASM-37/38/39 implementation PRs once the actual probe logic is filled in.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention