### PR TITLE
[AAASM-39] 🔧 (aa-ebpf): Scaffold eBPF crate architecture for process exec tracepoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,13 @@ name = "aa-ebpf"
 version = "0.0.1"
 dependencies = [
  "aa-core",
+ "aya",
+ "aya-log",
 ]
+
+[[package]]
+name = "aa-ebpf-common"
+version = "0.0.1"
 
 [[package]]
 name = "aa-ffi-node"
@@ -271,6 +277,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +423,61 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "aya"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18bc4e506fbb85ab7392ed993a7db4d1a452c71b75a246af4a80ab8c9d2dd50"
+dependencies = [
+ "assert_matches",
+ "aya-obj",
+ "bitflags",
+ "bytes",
+ "libc",
+ "log",
+ "object",
+ "once_cell",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "aya-log"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b600d806c1d07d3b81ab5f4a2a95fd80f479a0d3f1d68f29064d660865f85f02"
+dependencies = [
+ "aya",
+ "aya-log-common",
+ "bytes",
+ "log",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "aya-log-common"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befef9fe882e63164a2ba0161874e954648a72b0e1c4b361f532d590638c4eec"
+dependencies = [
+ "num_enum",
+]
+
+[[package]]
+name = "aya-obj"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51b96c5a8ed8705b40d655273bc4212cbbf38d4e3be2788f36306f154523ec7"
+dependencies = [
+ "bytes",
+ "core-error",
+ "hashbrown 0.15.5",
+ "log",
+ "object",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -576,6 +643,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-error"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efcdb2972eb64230b4c50646d8498ff73f5128d196a90c7236eec4cbe8619b8f"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -996,6 +1072,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1689,6 +1767,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,7 @@ name = "aa-ebpf"
 version = "0.0.1"
 dependencies = [
  "aa-core",
+ "aa-ebpf-common",
  "aya",
  "aya-log",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ dependencies = [
  "aa-core",
  "aya",
  "aya-log",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "aa-proto",
     "aa-runtime",
     "aa-ebpf",
+    "aa-ebpf-common",
     "aa-proxy",
     "aa-ffi-python",
     "aa-ffi-node",

--- a/aa-ebpf-common/Cargo.toml
+++ b/aa-ebpf-common/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "aa-ebpf-common"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared no_std types between eBPF kernel probes and userspace loader"
+
+[features]
+default = []
+user = []
+
+[lints]
+workspace = true

--- a/aa-ebpf-common/src/lib.rs
+++ b/aa-ebpf-common/src/lib.rs
@@ -5,3 +5,20 @@
 //! `bpfel-unknown-none` BPF target and standard userspace targets.
 
 #![no_std]
+
+/// In-kernel node for the PID lineage map (`BpfHashMap<u32, ProcessNode>`).
+///
+/// Each entry maps a child PID to its parent and the command that spawned it.
+/// Fixed-size layout is required for eBPF map compatibility.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ProcessNode {
+    /// Process ID of the child.
+    pub pid: u32,
+    /// Parent process ID.
+    pub ppid: u32,
+    /// Command name (`comm`) of the process, null-padded.
+    pub comm: [u8; 16],
+    /// Kernel timestamp in nanoseconds when the process was spawned.
+    pub spawn_time_ns: u64,
+}

--- a/aa-ebpf-common/src/lib.rs
+++ b/aa-ebpf-common/src/lib.rs
@@ -1,0 +1,7 @@
+//! Shared types between eBPF kernel-space probes and userspace loader.
+//!
+//! All types in this crate use fixed-size representations compatible with
+//! eBPF maps. This crate is `no_std` so it can be compiled for both the
+//! `bpfel-unknown-none` BPF target and standard userspace targets.
+
+#![no_std]

--- a/aa-ebpf-common/src/lib.rs
+++ b/aa-ebpf-common/src/lib.rs
@@ -49,3 +49,37 @@ pub struct ProcessSpawnEvent {
     /// Kernel timestamp in nanoseconds.
     pub timestamp_ns: u64,
 }
+
+/// Maximum byte length of the executable path in a [`ShellInjectionAlert`].
+pub const MAX_EXECUTABLE_LEN: usize = 256;
+
+/// Severity level for a shell injection alert.
+#[repr(u8)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum AlertLevel {
+    /// Informational — known-benign shell spawns (e.g. build scripts).
+    Info = 0,
+    /// Warning — potentially suspicious spawn (e.g. `python`, `node`).
+    Warning = 1,
+    /// Critical — high-risk spawn (e.g. `curl`, `wget`, raw `sh`/`bash`).
+    Critical = 2,
+}
+
+/// Alert emitted when an agent process spawns a suspicious child process.
+///
+/// Generated in the eBPF program when the spawned executable matches a
+/// known shell or download utility pattern (e.g. `bash`, `curl`, `wget`).
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ShellInjectionAlert {
+    /// PID of the monitored agent (or its ancestor in the lineage tree).
+    pub parent_pid: u32,
+    /// PID of the suspicious child process.
+    pub child_pid: u32,
+    /// Full executable path of the child, null-padded.
+    pub executable: [u8; MAX_EXECUTABLE_LEN],
+    /// Severity of the alert.
+    pub alert_level: AlertLevel,
+    /// Kernel timestamp in nanoseconds.
+    pub timestamp_ns: u64,
+}

--- a/aa-ebpf-common/src/lib.rs
+++ b/aa-ebpf-common/src/lib.rs
@@ -22,3 +22,30 @@ pub struct ProcessNode {
     /// Kernel timestamp in nanoseconds when the process was spawned.
     pub spawn_time_ns: u64,
 }
+
+/// Maximum number of argv entries captured per execve event.
+pub const MAX_ARGV_ENTRIES: usize = 5;
+
+/// Maximum byte length of a single argv entry.
+pub const MAX_ARGV_LEN: usize = 128;
+
+/// Event emitted from the eBPF tracepoint to userspace on each `execve` call.
+///
+/// Sent via ring buffer or perf event array. Fixed-size layout ensures
+/// predictable memory use in the eBPF program.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct ProcessSpawnEvent {
+    /// Process ID of the newly spawned process.
+    pub pid: u32,
+    /// Parent process ID.
+    pub ppid: u32,
+    /// Command name (`comm`) of the new process, null-padded.
+    pub comm: [u8; 16],
+    /// First [`MAX_ARGV_ENTRIES`] argv entries, each null-padded to [`MAX_ARGV_LEN`] bytes.
+    pub argv: [[u8; MAX_ARGV_LEN]; MAX_ARGV_ENTRIES],
+    /// Number of environment variables passed to execve.
+    pub env_count: u32,
+    /// Kernel timestamp in nanoseconds.
+    pub timestamp_ns: u64,
+}

--- a/aa-ebpf/Cargo.toml
+++ b/aa-ebpf/Cargo.toml
@@ -10,7 +10,8 @@ description = "eBPF-based kernel-level monitoring hooks for Agent Assembly"
 aa-core = { path = "../aa-core" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-aya = { version = "0.13", features = ["async_tokio"] }
+aya     = { version = "0.13", features = ["async_tokio"] }
+aya-log = "0.2"
 
 [lints]
 workspace = true

--- a/aa-ebpf/Cargo.toml
+++ b/aa-ebpf/Cargo.toml
@@ -8,6 +8,7 @@ description = "eBPF-based kernel-level monitoring hooks for Agent Assembly"
 
 [dependencies]
 aa-core = { path = "../aa-core" }
+tokio   = { version = "1", features = ["rt", "signal"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 aya     = { version = "0.13", features = ["async_tokio"] }

--- a/aa-ebpf/Cargo.toml
+++ b/aa-ebpf/Cargo.toml
@@ -9,5 +9,8 @@ description = "eBPF-based kernel-level monitoring hooks for Agent Assembly"
 [dependencies]
 aa-core = { path = "../aa-core" }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+aya = { version = "0.13", features = ["async_tokio"] }
+
 [lints]
 workspace = true

--- a/aa-ebpf/Cargo.toml
+++ b/aa-ebpf/Cargo.toml
@@ -7,8 +7,9 @@ repository.workspace = true
 description = "eBPF-based kernel-level monitoring hooks for Agent Assembly"
 
 [dependencies]
-aa-core = { path = "../aa-core" }
-tokio   = { version = "1", features = ["rt", "signal"] }
+aa-core        = { path = "../aa-core" }
+aa-ebpf-common = { path = "../aa-ebpf-common" }
+tokio          = { version = "1", features = ["rt", "signal"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 aya     = { version = "0.13", features = ["async_tokio"] }

--- a/aa-ebpf/src/events.rs
+++ b/aa-ebpf/src/events.rs
@@ -1,0 +1,10 @@
+//! Re-exports of shared eBPF event types for downstream consumers.
+//!
+//! All event structs live in [`aa_ebpf_common`] so they can be shared with
+//! the kernel-space eBPF programs. This module re-exports them for
+//! convenience so userspace code can import directly from `aa_ebpf`.
+
+pub use aa_ebpf_common::{
+    AlertLevel, ProcessNode, ProcessSpawnEvent, ShellInjectionAlert, MAX_ARGV_ENTRIES,
+    MAX_ARGV_LEN, MAX_EXECUTABLE_LEN,
+};

--- a/aa-ebpf/src/events.rs
+++ b/aa-ebpf/src/events.rs
@@ -5,6 +5,5 @@
 //! convenience so userspace code can import directly from `aa_ebpf`.
 
 pub use aa_ebpf_common::{
-    AlertLevel, ProcessNode, ProcessSpawnEvent, ShellInjectionAlert, MAX_ARGV_ENTRIES,
-    MAX_ARGV_LEN, MAX_EXECUTABLE_LEN,
+    AlertLevel, ProcessNode, ProcessSpawnEvent, ShellInjectionAlert, MAX_ARGV_ENTRIES, MAX_ARGV_LEN, MAX_EXECUTABLE_LEN,
 };

--- a/aa-ebpf/src/lib.rs
+++ b/aa-ebpf/src/lib.rs
@@ -6,3 +6,4 @@
 
 pub mod events;
 pub mod lineage;
+pub mod loader;

--- a/aa-ebpf/src/lib.rs
+++ b/aa-ebpf/src/lib.rs
@@ -1,8 +1,40 @@
-//! eBPF-based kernel-level monitoring hooks for Agent Assembly.
+//! eBPF-based kernel-level monitoring hooks for Agent Assembly (Layer 3).
 //!
-//! This crate provides kernel-space probes that intercept system calls and
-//! network events originating from AI agent processes, feeding data into
-//! the governance pipeline without requiring code changes in agents.
+//! This crate is the **userspace** half of the eBPF subsystem. It loads
+//! compiled BPF bytecode into the kernel, attaches tracepoints and kprobes,
+//! and reads events back through ring buffers — feeding them into the
+//! `aa-core` governance pipeline.
+//!
+//! # Crate architecture (three-crate split)
+//!
+//! eBPF programs run inside the Linux kernel and must be compiled to the
+//! `bpfel-unknown-none` target. This forces a three-crate design:
+//!
+//! | Crate | Role | Target |
+//! |---|---|---|
+//! | **`aa-ebpf-common`** | Shared `repr(C)` types for maps and events | `no_std` (both) |
+//! | **`aa-ebpf-ebpf`** | BPF programs (tracepoints, kprobes, uprobes) | `bpfel-unknown-none` |
+//! | **`aa-ebpf`** (this crate) | Userspace loader, event consumer, lineage tracker | `std` (Linux) |
+//!
+//! # Data flow
+//!
+//! ```text
+//! kernel: tracepoint fires → BPF program writes to ring buffer / map
+//!                                         │
+//! ────────────────────────────────────────────────────────────
+//!                                         │
+//! user:  EbpfLoader reads ring buffer → ProcessSpawnEvent
+//!          → ProcessLineageTracker updates PID tree
+//!          → ShellInjectionAlert emitted if suspicious
+//!          → event forwarded to aa-core governance pipeline
+//! ```
+//!
+//! # Platform support
+//!
+//! eBPF is Linux-only. On macOS, this crate compiles but the `aya` and
+//! `aya-log` dependencies are gated behind `cfg(target_os = "linux")`.
+//! A future degraded mode using DTrace may provide partial observability
+//! on macOS.
 
 pub mod events;
 pub mod lineage;

--- a/aa-ebpf/src/lib.rs
+++ b/aa-ebpf/src/lib.rs
@@ -3,3 +3,5 @@
 //! This crate provides kernel-space probes that intercept system calls and
 //! network events originating from AI agent processes, feeding data into
 //! the governance pipeline without requiring code changes in agents.
+
+pub mod events;

--- a/aa-ebpf/src/lib.rs
+++ b/aa-ebpf/src/lib.rs
@@ -5,3 +5,4 @@
 //! the governance pipeline without requiring code changes in agents.
 
 pub mod events;
+pub mod lineage;

--- a/aa-ebpf/src/lineage.rs
+++ b/aa-ebpf/src/lineage.rs
@@ -1,0 +1,14 @@
+//! PID ancestry tracking for agent process families.
+//!
+//! Maintains a userspace mirror of the in-kernel PID lineage map, allowing
+//! the runtime to query parent-child relationships up to 5 levels deep.
+//! Populated by [`ProcessSpawnEvent`](crate::events::ProcessSpawnEvent)s
+//! received from the eBPF ring buffer.
+
+/// Tracks the process lineage tree for monitored agent families.
+///
+/// Receives [`ProcessSpawnEvent`](crate::events::ProcessSpawnEvent)s from
+/// the eBPF ring buffer and maintains an in-memory parent-child map.
+pub struct ProcessLineageTracker {
+    _private: (),
+}

--- a/aa-ebpf/src/loader.rs
+++ b/aa-ebpf/src/loader.rs
@@ -1,0 +1,14 @@
+//! eBPF program loader for the userspace side of Agent Assembly.
+//!
+//! Responsible for loading compiled BPF bytecode via [`aya::Ebpf`],
+//! attaching tracepoints and kprobes, and setting up ring buffer
+//! consumers that feed events into the governance pipeline.
+
+/// Loads and manages the lifecycle of eBPF programs.
+///
+/// On construction, loads the compiled BPF bytecode and attaches the
+/// configured probes. On drop, detaches all probes and releases
+/// kernel resources.
+pub struct EbpfLoader {
+    _private: (),
+}

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -74,3 +74,4 @@ See [versioning.md](versioning.md) for the full versioning and deprecation polic
 | PR / Ticket | Change | Compatibility impact |
 |---|---|---|
 | AAASM-107 | Added `conformance` workspace crate (test infrastructure, not shipped) | None — internal tooling only |
+| AAASM-39 | Added `aa-ebpf-common` workspace crate (shared eBPF types, not shipped standalone) | None — internal shared types only |


### PR DESCRIPTION
## Description

Scaffold the `aa-ebpf` and new `aa-ebpf-common` crate architecture so the eBPF subsystem (Layer 3) is ready for implementation. This is the architecture-only phase of AAASM-39 — no probe logic yet.

### What changed

- **New crate `aa-ebpf-common`**: `no_std` shared types for eBPF maps and ring buffer events — `ProcessNode`, `ProcessSpawnEvent`, `ShellInjectionAlert`, `AlertLevel` enum, and related constants. All types are `#[repr(C)]` with fixed-size fields for eBPF compatibility.
- **Updated `aa-ebpf`**: Added userspace dependencies (`aya`, `aya-log`, `tokio`, `aa-ebpf-common`) with Linux-only gating via `cfg(target_os = "linux")`. Added three module stubs: `events` (re-exports from common), `lineage` (PID ancestry tracker), `loader` (BPF program loader). Added crate-level rustdoc describing the three-crate split and data flow.

### Why

The eBPF subsystem requires a three-crate architecture (common types / BPF programs / userspace loader) because eBPF programs compile to a different target (`bpfel-unknown-none`). This PR delivers the shared foundation so AAASM-37, AAASM-38, and AAASM-39 implementation work can begin on a clean structure.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [ ] No
- [ ] Yes (describe below)

No breaking changes — new crate and additive changes to existing crate only.

## Related Issues

- Related Jira ticket: AAASM-39
- Parent Epic: AAASM-4 (Three-Layer Agent Interception)
- Sibling tickets that benefit: AAASM-37 (OpenSSL uprobe), AAASM-38 (File I/O kprobes)
- Follow-up ticket: AAASM-132 (BPF cross-compilation CI pipeline)

## Testing

- [x] Manual testing performed
- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] No tests required (explain why)

Both `aa-ebpf` and `aa-ebpf-common` compile cleanly via `cargo check` on macOS (Linux deps gated behind `cfg(target_os = "linux")`). No runtime logic to test yet — this is architecture scaffolding only.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention