### PR TITLE
[AAASM-132] 🔧 (aa-ebpf): Set up eBPF BPF-side cross-compilation pipeline and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,7 +276,10 @@ jobs:
       - name: Build eBPF probes
         run: cargo build --release
       - name: Clippy on eBPF probes
-        run: cargo clippy --all-targets -- -D warnings
+        # --all-targets would try to build test harness binaries, which require the
+        # `test` crate — unavailable on the no_std bpfel-unknown-none target.
+        # --bins lints only the BPF program binaries.
+        run: cargo clippy --bins -- -D warnings
 
   conformance:
     name: Rust conformance suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,26 @@ jobs:
       - name: Check compatibility matrix is updated when versions change
         run: bash .ci/check-compatibility-matrix.sh
 
+  ebpf-build:
+    name: eBPF probes build (Linux nightly)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: aa-ebpf-probes
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: bpfel-unknown-none
+          components: rust-src
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: aa-ebpf-probes
+      - name: Build eBPF probes
+        run: cargo build --release
+      - name: Clippy on eBPF probes
+        run: cargo clippy --all-targets -- -D warnings
+
   conformance:
     name: Rust conformance suite
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,11 +286,17 @@ jobs:
         # CARGO_HOME, RUSTUP_HOME, and PATH so cargo uses the already-installed
         # nightly toolchain and bpf-linker.
         working-directory: ${{ github.workspace }}
-        # sudo strips PATH, so cargo (installed by rustup into ~/.cargo/bin) is not found.
-        # Passing PATH explicitly via sudo env makes the rustup toolchain visible to root.
-        # +nightly is required because the workspace root has no rust-toolchain.toml and
-        # no default toolchain is configured — rustup would otherwise refuse to run.
-        run: sudo env "PATH=$PATH" cargo +nightly test -p aa-ebpf --features integration-test --test load_hello -- --nocapture
+        # sudo runs as root, so it uses /root/.rustup and /root/.cargo by default.
+        # The nightly toolchain and bpf-linker were installed for the runner user
+        # (/home/runner). Pass PATH, RUSTUP_HOME, and CARGO_HOME explicitly so root
+        # finds the already-installed toolchain rather than downloading a new one.
+        # +nightly selects the toolchain since the workspace root has no rust-toolchain.toml.
+        run: >-
+          sudo env
+          "PATH=$PATH"
+          "RUSTUP_HOME=$RUSTUP_HOME"
+          "CARGO_HOME=$CARGO_HOME"
+          cargo +nightly test -p aa-ebpf --features integration-test --test load_hello -- --nocapture
 
   conformance:
     name: Rust conformance suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,15 +257,21 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: aa-ebpf-probes
-      - name: Install LLVM
-        # bpf-linker links against LLVM. Installing the system LLVM package provides
-        # llvm-config on PATH so bpf-linker can be built with --no-default-features,
-        # which is much faster than compiling the bundled LLVM from source.
-        run: sudo apt-get update -qq && sudo apt-get install -y llvm
+      - name: Cache bpf-linker binary
+        # Cache the compiled bpf-linker binary so subsequent CI runs skip the
+        # slow bundled-LLVM compile (~5-10 min). Key includes the version so a
+        # version bump automatically invalidates the cache.
+        uses: actions/cache@v4
+        id: cache-bpf-linker
+        with:
+          path: ~/.cargo/bin/bpf-linker
+          key: bpf-linker-${{ runner.os }}-0.10.3
       - name: Install bpf-linker
         # bpf-linker is the custom linker required for the bpfel-unknown-none target.
-        # --no-default-features links against the system LLVM installed above.
-        run: cargo install bpf-linker --no-default-features
+        # Using the bundled-LLVM default (no --no-default-features) avoids fragile
+        # system-LLVM package discovery. Only runs on cache miss.
+        if: steps.cache-bpf-linker.outputs.cache-hit != 'true'
+        run: cargo install bpf-linker
       - name: Build eBPF probes
         run: cargo build --release
       - name: Clippy on eBPF probes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,6 +257,12 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: aa-ebpf-probes
+      - name: Install bpf-linker
+        # bpf-linker is the custom linker required for the bpfel-unknown-none target.
+        # It is not bundled with the Rust toolchain and must be installed separately.
+        # --no-default-features uses the system LLVM already present on ubuntu-latest,
+        # which is significantly faster than compiling the bundled LLVM from source.
+        run: cargo install bpf-linker --no-default-features
       - name: Build eBPF probes
         run: cargo build --release
       - name: Clippy on eBPF probes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,8 @@ jobs:
           # Do NOT add bpfel-unknown-none to targets: there is no precompiled rust-std
           # for this target. BPF programs are built from source via -Zbuild-std=core
           # (configured in aa-ebpf-probes/.cargo/config.toml). Only rust-src is needed.
-          components: rust-src
+          # clippy is required for the "Clippy on eBPF probes" step below.
+          components: rust-src,clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: aa-ebpf-probes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,9 @@ jobs:
         # CARGO_HOME, RUSTUP_HOME, and PATH so cargo uses the already-installed
         # nightly toolchain and bpf-linker.
         working-directory: ${{ github.workspace }}
-        run: sudo -E cargo test -p aa-ebpf --features integration-test --test load_hello -- --nocapture
+        # sudo strips PATH, so cargo (installed by rustup into ~/.cargo/bin) is not found.
+        # Passing PATH explicitly via sudo env makes the rustup toolchain visible to root.
+        run: sudo env "PATH=$PATH" cargo test -p aa-ebpf --features integration-test --test load_hello -- --nocapture
 
   conformance:
     name: Rust conformance suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,13 @@ jobs:
         # `test` crate — unavailable on the no_std bpfel-unknown-none target.
         # --bins lints only the BPF program binaries.
         run: cargo clippy --bins -- -D warnings
+      - name: Integration test — load and attach aa-hello kprobe
+        # Runs from the workspace root so cargo can resolve the aa-ebpf package.
+        # BPF loading requires CAP_BPF + CAP_PERFMON (root). sudo -E preserves
+        # CARGO_HOME, RUSTUP_HOME, and PATH so cargo uses the already-installed
+        # nightly toolchain and bpf-linker.
+        working-directory: ${{ github.workspace }}
+        run: sudo -E cargo test -p aa-ebpf --features integration-test --test load_hello -- --nocapture
 
   conformance:
     name: Rust conformance suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,11 +257,14 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: aa-ebpf-probes
+      - name: Install LLVM
+        # bpf-linker links against LLVM. Installing the system LLVM package provides
+        # llvm-config on PATH so bpf-linker can be built with --no-default-features,
+        # which is much faster than compiling the bundled LLVM from source.
+        run: sudo apt-get update -qq && sudo apt-get install -y llvm
       - name: Install bpf-linker
         # bpf-linker is the custom linker required for the bpfel-unknown-none target.
-        # It is not bundled with the Rust toolchain and must be installed separately.
-        # --no-default-features uses the system LLVM already present on ubuntu-latest,
-        # which is significantly faster than compiling the bundled LLVM from source.
+        # --no-default-features links against the system LLVM installed above.
         run: cargo install bpf-linker --no-default-features
       - name: Build eBPF probes
         run: cargo build --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,17 +286,19 @@ jobs:
         # CARGO_HOME, RUSTUP_HOME, and PATH so cargo uses the already-installed
         # nightly toolchain and bpf-linker.
         working-directory: ${{ github.workspace }}
-        # sudo runs as root, so it uses /root/.rustup and /root/.cargo by default.
-        # The nightly toolchain and bpf-linker were installed for the runner user
-        # (/home/runner). Pass PATH, RUSTUP_HOME, and CARGO_HOME explicitly so root
-        # finds the already-installed toolchain rather than downloading a new one.
-        # +nightly selects the toolchain since the workspace root has no rust-toolchain.toml.
-        run: >-
-          sudo env
-          "PATH=$PATH"
-          "RUSTUP_HOME=$RUSTUP_HOME"
-          "CARGO_HOME=$CARGO_HOME"
-          cargo +nightly test -p aa-ebpf --features integration-test --test load_hello -- --nocapture
+        # sudo runs as root (/root/.rustup, /root/.cargo) but the nightly toolchain
+        # was installed for the runner user. RUSTUP_HOME and CARGO_HOME are not set
+        # as env vars on GitHub runners — they default to ~/.rustup/~/.cargo, which
+        # expands to /root/... under sudo. Capture them from the runner's $HOME first,
+        # then pass explicit paths so root reuses the already-installed toolchain.
+        run: |
+          RUNNER_RUSTUP="${HOME}/.rustup"
+          RUNNER_CARGO="${HOME}/.cargo"
+          sudo env \
+            "PATH=$PATH" \
+            "RUSTUP_HOME=${RUNNER_RUSTUP}" \
+            "CARGO_HOME=${RUNNER_CARGO}" \
+            cargo +nightly test -p aa-ebpf --features integration-test --test load_hello -- --nocapture
 
   conformance:
     name: Rust conformance suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Build workspace
-        run: cargo build --workspace
+        # aa-ebpf requires nightly (aya-build invokes rustup run nightly).
+        # It is validated by the dedicated ebpf-build job.
+        run: cargo build --workspace --exclude aa-ebpf
 
   fmt:
     name: Format check
@@ -64,7 +66,9 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Run Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        # aa-ebpf requires nightly (aya-build invokes rustup run nightly).
+        # It is linted by the dedicated ebpf-build job.
+        run: cargo clippy --workspace --all-targets --all-features --exclude aa-ebpf -- -D warnings
 
   docs:
     name: Rustdoc
@@ -90,7 +94,9 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@83c419a40a2e48673b2c523337e57f602dfe53c9 # cargo-nextest
       - name: Run tests
-        run: cargo nextest run --workspace --no-tests=pass
+        # aa-ebpf requires nightly (aya-build invokes rustup run nightly) and has no
+        # unit tests. Validated by the dedicated ebpf-build job.
+        run: cargo nextest run --workspace --no-tests=pass --exclude aa-ebpf
 
   coverage:
     name: Coverage
@@ -106,7 +112,9 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@3f7f2bd74f95d407a45d96b106f26d4f6c238fab # cargo-llvm-cov
       - name: Generate coverage report
-        run: cargo llvm-cov --all-features --workspace --codecov --output-path codecov.xml
+        # aa-ebpf requires nightly (aya-build invokes rustup run nightly) and has no
+        # testable userspace logic. Excluded from coverage.
+        run: cargo llvm-cov --all-features --workspace --codecov --output-path codecov.xml --exclude aa-ebpf
       - name: Upload to Codecov
         uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
@@ -242,7 +250,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          targets: bpfel-unknown-none
+          # Do NOT add bpfel-unknown-none to targets: there is no precompiled rust-std
+          # for this target. BPF programs are built from source via -Zbuild-std=core
+          # (configured in aa-ebpf-probes/.cargo/config.toml). Only rust-src is needed.
           components: rust-src
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,9 @@ jobs:
         working-directory: ${{ github.workspace }}
         # sudo strips PATH, so cargo (installed by rustup into ~/.cargo/bin) is not found.
         # Passing PATH explicitly via sudo env makes the rustup toolchain visible to root.
-        run: sudo env "PATH=$PATH" cargo test -p aa-ebpf --features integration-test --test load_hello -- --nocapture
+        # +nightly is required because the workspace root has no rust-toolchain.toml and
+        # no default toolchain is configured — rustup would otherwise refuse to run.
+        run: sudo env "PATH=$PATH" cargo +nightly test -p aa-ebpf --features integration-test --test load_hello -- --nocapture
 
   conformance:
     name: Rust conformance suite

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,9 @@ name = "aa-ebpf"
 version = "0.0.1"
 dependencies = [
  "aa-core",
+ "aya",
+ "aya-build",
+ "aya-log",
 ]
 
 [[package]]
@@ -271,6 +274,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +423,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "aya"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d18bc4e506fbb85ab7392ed993a7db4d1a452c71b75a246af4a80ab8c9d2dd50"
+dependencies = [
+ "assert_matches",
+ "aya-obj",
+ "bitflags",
+ "bytes",
+ "libc",
+ "log",
+ "object",
+ "once_cell",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "aya-build"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bc42f3c5ddacc34eca28a420b47e3cbb3f0f484137cb2bf1ad2153d0eae52a"
+dependencies = [
+ "anyhow",
+ "cargo_metadata",
+]
+
+[[package]]
+name = "aya-log"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b600d806c1d07d3b81ab5f4a2a95fd80f479a0d3f1d68f29064d660865f85f02"
+dependencies = [
+ "aya",
+ "aya-log-common",
+ "bytes",
+ "log",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
+name = "aya-log-common"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befef9fe882e63164a2ba0161874e954648a72b0e1c4b361f532d590638c4eec"
+dependencies = [
+ "num_enum",
+]
+
+[[package]]
+name = "aya-obj"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51b96c5a8ed8705b40d655273bc4212cbbf38d4e3be2788f36306f154523ec7"
+dependencies = [
+ "bytes",
+ "core-error",
+ "hashbrown 0.15.5",
+ "log",
+ "object",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +519,39 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "cast"
@@ -576,6 +683,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-error"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efcdb2972eb64230b4c50646d8498ff73f5128d196a90c7236eec4cbe8619b8f"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]
@@ -996,6 +1112,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -1689,6 +1807,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "memchr",
 ]
 
 [[package]]
@@ -2464,6 +2594,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"

--- a/aa-ebpf-probes/.cargo/config.toml
+++ b/aa-ebpf-probes/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "bpfel-unknown-none"

--- a/aa-ebpf-probes/.cargo/config.toml
+++ b/aa-ebpf-probes/.cargo/config.toml
@@ -1,2 +1,6 @@
 [build]
 target = "bpfel-unknown-none"
+
+[unstable]
+# bpfel-unknown-none has no precompiled core — build it from rust-src at compile time.
+build-std = ["core"]

--- a/aa-ebpf-probes/Cargo.toml
+++ b/aa-ebpf-probes/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "aa-ebpf-probes"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[dependencies]
+aya-ebpf = "0.1"
+aya-log-ebpf = "0.1"
+
+# BPF programs are no_std binaries; there is no std or test harness.
+[[bin]]
+name = "aa-hello"
+path = "src/main.rs"

--- a/aa-ebpf-probes/Cargo.toml
+++ b/aa-ebpf-probes/Cargo.toml
@@ -12,3 +12,7 @@ aya-log-ebpf = "0.1"
 [[bin]]
 name = "aa-hello"
 path = "src/main.rs"
+
+# Declare this crate as its own standalone workspace so Cargo does not
+# attempt to include it in the parent agent-assembly workspace.
+[workspace]

--- a/aa-ebpf-probes/rust-toolchain.toml
+++ b/aa-ebpf-probes/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly"
+components = ["rust-src"]
+targets = ["bpfel-unknown-none"]

--- a/aa-ebpf-probes/rust-toolchain.toml
+++ b/aa-ebpf-probes/rust-toolchain.toml
@@ -1,4 +1,6 @@
 [toolchain]
 channel = "nightly"
+# rust-src is required by -Zbuild-std=core so cargo can compile core from source
+# for the bpfel-unknown-none target. Do NOT add bpfel-unknown-none to targets —
+# there is no precompiled rust-std for this target; it is built from source.
 components = ["rust-src"]
-targets = ["bpfel-unknown-none"]

--- a/aa-ebpf-probes/src/main.rs
+++ b/aa-ebpf-probes/src/main.rs
@@ -1,0 +1,26 @@
+#![no_std]
+#![no_main]
+
+use aya_ebpf::{macros::kprobe, programs::ProbeContext};
+use aya_log_ebpf::info;
+
+/// Minimal kprobe attached to `__x64_sys_write` — validates the BPF
+/// compilation pipeline end-to-end. Replace with real probes in
+/// AAASM-37 / AAASM-38 / AAASM-39.
+#[kprobe]
+pub fn aa_hello(ctx: ProbeContext) -> u32 {
+    match try_aa_hello(ctx) {
+        Ok(ret) => ret,
+        Err(ret) => ret,
+    }
+}
+
+fn try_aa_hello(ctx: ProbeContext) -> Result<u32, u32> {
+    info!(&ctx, "aa-hello: __x64_sys_write intercepted");
+    Ok(0)
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe { core::hint::unreachable_unchecked() }
+}

--- a/aa-ebpf/Cargo.toml
+++ b/aa-ebpf/Cargo.toml
@@ -8,6 +8,11 @@ description = "eBPF-based kernel-level monitoring hooks for Agent Assembly"
 
 [dependencies]
 aa-core = { path = "../aa-core" }
+
+# aya is Linux-only: it uses libc symbols (CLOCK_BOOTTIME, etc.) absent on macOS/Windows.
+# The build-dep (aya-build) is unconditional so build.rs always compiles; the actual
+# BPF compilation call inside build.rs is gated with #[cfg(target_os = "linux")].
+[target.'cfg(target_os = "linux")'.dependencies]
 aya = { version = "0.13", features = ["async_tokio"] }
 aya-log = "0.2"
 

--- a/aa-ebpf/Cargo.toml
+++ b/aa-ebpf/Cargo.toml
@@ -16,9 +16,6 @@ aa-core = { path = "../aa-core" }
 aya = { version = "0.13", features = ["async_tokio"] }
 aya-log = "0.2"
 
-[build-dependencies]
-aya-build = "0.1"
-
 [features]
 # Enables integration tests that load BPF programs into a live kernel.
 # Requires root (CAP_BPF + CAP_PERFMON). Only meaningful on Linux.

--- a/aa-ebpf/Cargo.toml
+++ b/aa-ebpf/Cargo.toml
@@ -19,5 +19,11 @@ aya-log = "0.2"
 [build-dependencies]
 aya-build = "0.1"
 
+[features]
+# Enables integration tests that load BPF programs into a live kernel.
+# Requires root (CAP_BPF + CAP_PERFMON). Only meaningful on Linux.
+# Usage: cargo test -p aa-ebpf --features integration-test --test load_hello
+integration-test = []
+
 [lints]
 workspace = true

--- a/aa-ebpf/Cargo.toml
+++ b/aa-ebpf/Cargo.toml
@@ -8,6 +8,11 @@ description = "eBPF-based kernel-level monitoring hooks for Agent Assembly"
 
 [dependencies]
 aa-core = { path = "../aa-core" }
+aya = { version = "0.13", features = ["async_tokio"] }
+aya-log = "0.2"
+
+[build-dependencies]
+aya-build = "0.1"
 
 [lints]
 workspace = true

--- a/aa-ebpf/README.md
+++ b/aa-ebpf/README.md
@@ -1,0 +1,85 @@
+# aa-ebpf
+
+Kernel-level eBPF monitoring hooks for Agent Assembly — Layer 3 of the
+three-layer defense-in-depth architecture (AAASM-4).
+
+## Architecture
+
+BPF programs live in a **separate crate** (`aa-ebpf-probes/`) that compiles to the
+`bpfel-unknown-none` target under nightly Rust. The userspace crate (`aa-ebpf`, this
+crate) loads the compiled bytecode via `aya::Ebpf::load`.
+
+```
+aa-ebpf-probes/          ← BPF-side (nightly, bpfel-unknown-none) — outside workspace
+    src/main.rs          ← kprobe / uprobe / tracepoint programs
+    rust-toolchain.toml  ← nightly pin with rust-src + bpfel-unknown-none
+    .cargo/config.toml   ← default target = bpfel-unknown-none
+
+aa-ebpf/                 ← userspace (stable, in workspace)
+    build.rs             ← compiles aa-ebpf-probes via aya-build (Linux only)
+    src/lib.rs           ← embeds bytecode, exposes pub API (Linux only)
+```
+
+## Prerequisites
+
+| Requirement | Version |
+|---|---|
+| Rust toolchain | nightly (managed by `aa-ebpf-probes/rust-toolchain.toml`) |
+| Linux kernel | 5.8+ (BPF ring buffer); 5.15+ recommended (stable BTF) |
+| OS | Linux only — eBPF cannot be loaded on macOS or Windows |
+
+The main workspace stays on **stable**. Only `aa-ebpf-probes/` requires nightly.
+
+## Building BPF programs
+
+`cargo build --workspace` does **not** compile BPF programs — they are compiled
+by `aa-ebpf`'s `build.rs` when you build `aa-ebpf` on a Linux host.
+
+```bash
+# Build the userspace crate (triggers BPF compilation automatically via build.rs)
+cargo build -p aa-ebpf   # Linux only
+
+# Build BPF programs directly (faster iteration)
+cd aa-ebpf-probes
+cargo build --release
+```
+
+On macOS the `aa-ebpf` crate builds without errors but `AA_HELLO_BPF` and all
+other Linux-gated symbols are absent. This is expected.
+
+## CI
+
+The `ebpf-build` GitHub Actions job (`.github/workflows/ci.yml`) compiles the
+BPF programs on an `ubuntu-latest` runner with nightly Rust and the
+`bpfel-unknown-none` target. macOS CI jobs never enter `aa-ebpf-probes/`
+and are unaffected.
+
+## CO-RE / BTF
+
+Compile Once, Run Everywhere (CO-RE) via BTF is **not enabled** in the current
+hello-world skeleton. When implementing real probes (AAASM-37 / AAASM-38 /
+AAASM-39), generate `vmlinux.h` from the CI runner kernel and check it in:
+
+```bash
+bpftool btf dump file /sys/kernel/btf/vmlinux format c > aa-ebpf-probes/src/vmlinux.h
+```
+
+Minimum kernel versions for CO-RE: **5.8** (BPF ring buffer) / **5.15** (stable BTF).
+
+## Adding new probes
+
+1. Add a new `[[bin]]` entry to `aa-ebpf-probes/Cargo.toml`.
+2. Write the BPF program in `aa-ebpf-probes/src/<probe-name>.rs`.
+3. Add a corresponding `Package { name: "<probe-name>", ... }` entry in
+   `aa-ebpf/build.rs`.
+4. Expose the compiled bytes in `aa-ebpf/src/lib.rs` using `aya::include_bytes_aligned!`.
+5. Write a loader function in `aa-ebpf/src/lib.rs` that attaches the program.
+
+## Related tickets
+
+| Ticket | Description |
+|---|---|
+| AAASM-4 | Three-Layer Agent Interception (parent Epic) |
+| AAASM-37 | F11: OpenSSL uprobe (blocked on this ticket) |
+| AAASM-38 | F12: File I/O kprobes (blocked on this ticket) |
+| AAASM-39 | F13: Process exec tracepoints (blocked on this ticket) |

--- a/aa-ebpf/build.rs
+++ b/aa-ebpf/build.rs
@@ -1,25 +1,53 @@
 //! Build script for aa-ebpf.
 //!
-//! Compiles the `aa-ebpf-probes` BPF crate (which targets `bpfel-unknown-none`)
-//! and copies the resulting ELF objects into `OUT_DIR` so they can be embedded
-//! with `aya::include_bytes_aligned!` in the userspace crate.
+//! Compiles the `aa-ebpf-probes` BPF crate (targeting `bpfel-unknown-none`)
+//! and places the compiled binaries into `OUT_DIR/aa-ebpf-probes/…` so they
+//! can be embedded with `aya::include_bytes_aligned!` in the userspace crate.
+//!
+//! ## Why not `aya_build::build_ebpf`?
+//!
+//! `aya_build` 0.1.3 runs `cargo build --package <name>` from the *caller's*
+//! working directory — it does not use `Package::root_dir` as `current_dir`.
+//! `aa-ebpf-probes` is a standalone workspace so cargo cannot resolve it as a
+//! package from `aa-ebpf/`.  We invoke cargo directly with an explicit
+//! `current_dir` to avoid this limitation.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // BPF compilation is Linux-only: aya-build invokes `rustup run nightly cargo build`
-    // targeting `bpfel-unknown-none`. On macOS/Windows the BPF programs are not
-    // compiled; the userspace constants in lib.rs are gated the same way.
+    // BPF compilation is Linux-only. On macOS/Windows the build script is a no-op;
+    // the userspace constants in lib.rs are gated with the same cfg predicate.
     #[cfg(target_os = "linux")]
-    aya_build::build_ebpf(
-        [aya_build::Package {
-            // Must match the [package] name in aa-ebpf-probes/Cargo.toml.
-            // aya-build passes this as `cargo build --package <name>` and uses
-            // it as the subdirectory under OUT_DIR for the compiled artifacts.
-            name: "aa-ebpf-probes",
-            root_dir: "../aa-ebpf-probes",
-            no_default_features: false,
-            features: &[],
-        }],
-        aya_build::Toolchain::Nightly,
-    )?;
+    {
+        use std::{env, path::PathBuf, process::Command};
+
+        let manifest_dir = env::var("CARGO_MANIFEST_DIR")?;
+        let probes_dir = PathBuf::from(&manifest_dir).join("../aa-ebpf-probes");
+        let out_dir = env::var("OUT_DIR")?;
+        // Mirror the path layout used by aya-build: OUT_DIR/<package-name>/…
+        // lib.rs embeds the binary at OUT_DIR/aa-ebpf-probes/bpfel-unknown-none/release/aa-hello
+        let target_dir = PathBuf::from(&out_dir).join("aa-ebpf-probes");
+
+        // Re-run this script whenever the probes source changes.
+        println!("cargo:rerun-if-changed={}", probes_dir.display());
+
+        // Run `cargo build --release` inside the probes workspace.
+        // aa-ebpf-probes/.cargo/config.toml sets:
+        //   target      = "bpfel-unknown-none"
+        //   build-std   = ["core"]   (nightly only; rust-toolchain.toml pins nightly)
+        let status = Command::new("rustup")
+            .args(["run", "nightly", "cargo", "build", "--release"])
+            .arg("--target-dir")
+            .arg(&target_dir)
+            // Change into the probes workspace so cargo resolves its Cargo.toml.
+            .current_dir(&probes_dir)
+            // Strip cargo's injected RUSTC wrappers so the probes workspace uses
+            // the bare nightly rustc without the parent workspace overlay.
+            .env_remove("RUSTC")
+            .env_remove("RUSTC_WORKSPACE_WRAPPER")
+            .status()?;
+
+        if !status.success() {
+            return Err("BPF probe compilation failed — see cargo output above".into());
+        }
+    }
     Ok(())
 }

--- a/aa-ebpf/build.rs
+++ b/aa-ebpf/build.rs
@@ -11,7 +11,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(target_os = "linux")]
     aya_build::build_ebpf(
         [aya_build::Package {
-            name: "aa-hello",
+            // Must match the [package] name in aa-ebpf-probes/Cargo.toml.
+            // aya-build passes this as `cargo build --package <name>` and uses
+            // it as the subdirectory under OUT_DIR for the compiled artifacts.
+            name: "aa-ebpf-probes",
             root_dir: "../aa-ebpf-probes",
             no_default_features: false,
             features: &[],

--- a/aa-ebpf/build.rs
+++ b/aa-ebpf/build.rs
@@ -1,0 +1,22 @@
+//! Build script for aa-ebpf.
+//!
+//! Compiles the `aa-ebpf-probes` BPF crate (which targets `bpfel-unknown-none`)
+//! and copies the resulting ELF objects into `OUT_DIR` so they can be embedded
+//! with `aya::include_bytes_aligned!` in the userspace crate.
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // BPF compilation is Linux-only: aya-build invokes `rustup run nightly cargo build`
+    // targeting `bpfel-unknown-none`. On macOS/Windows the BPF programs are not
+    // compiled; the userspace constants in lib.rs are gated the same way.
+    #[cfg(target_os = "linux")]
+    aya_build::build_ebpf(
+        [aya_build::Package {
+            name: "aa-hello",
+            root_dir: "../aa-ebpf-probes",
+            no_default_features: false,
+            features: &[],
+        }],
+        aya_build::Toolchain::Nightly,
+    )?;
+    Ok(())
+}

--- a/aa-ebpf/src/lib.rs
+++ b/aa-ebpf/src/lib.rs
@@ -30,5 +30,8 @@
 #[cfg(target_os = "linux")]
 pub static AA_HELLO_BPF: &[u8] = aya::include_bytes_aligned!(concat!(
     env!("OUT_DIR"),
-    "/aa-hello/bpfel-unknown-none/release/aa-hello"
+    // Path layout: OUT_DIR/<package-name>/<target>/release/<binary-name>
+    // Package name is "aa-ebpf-probes" (from Cargo.toml [package].name).
+    // Binary name is "aa-hello" (from Cargo.toml [[bin]].name).
+    "/aa-ebpf-probes/bpfel-unknown-none/release/aa-hello"
 ));

--- a/aa-ebpf/src/lib.rs
+++ b/aa-ebpf/src/lib.rs
@@ -3,3 +3,31 @@
 //! This crate provides kernel-space probes that intercept system calls and
 //! network events originating from AI agent processes, feeding data into
 //! the governance pipeline without requiring code changes in agents.
+//!
+//! # Loading BPF programs
+//!
+//! The compiled BPF bytecode is embedded at build time and exposed as the
+//! [`AA_HELLO_BPF`] constant. Pass it to [`aya::Ebpf::load`] to load all
+//! programs defined in the `aa-ebpf-probes` crate:
+//!
+//! ```no_run
+//! # #[cfg(target_os = "linux")]
+//! # {
+//! use aya::Ebpf;
+//! use aa_ebpf::AA_HELLO_BPF;
+//!
+//! let mut bpf = Ebpf::load(AA_HELLO_BPF).expect("failed to load BPF programs");
+//! # }
+//! ```
+
+/// Compiled BPF bytecode for the `aa-hello` probe program.
+///
+/// Embedded from `aa-ebpf-probes/src/main.rs` at build time via `aya-build`.
+/// Pass this slice to [`aya::Ebpf::load`] to obtain a handle to all programs
+/// in the probe crate.
+///
+/// Only meaningful on Linux — on other platforms this constant is absent.
+#[cfg(target_os = "linux")]
+pub static AA_HELLO_BPF: &[u8] = aya::include_bytes_aligned!(
+    concat!(env!("OUT_DIR"), "/aa-hello/bpfel-unknown-none/release/aa-hello")
+);

--- a/aa-ebpf/src/lib.rs
+++ b/aa-ebpf/src/lib.rs
@@ -28,6 +28,7 @@
 ///
 /// Only meaningful on Linux — on other platforms this constant is absent.
 #[cfg(target_os = "linux")]
-pub static AA_HELLO_BPF: &[u8] = aya::include_bytes_aligned!(
-    concat!(env!("OUT_DIR"), "/aa-hello/bpfel-unknown-none/release/aa-hello")
-);
+pub static AA_HELLO_BPF: &[u8] = aya::include_bytes_aligned!(concat!(
+    env!("OUT_DIR"),
+    "/aa-hello/bpfel-unknown-none/release/aa-hello"
+));

--- a/aa-ebpf/tests/load_hello.rs
+++ b/aa-ebpf/tests/load_hello.rs
@@ -5,7 +5,7 @@
 //   - feature = "integration-test" — opted-in explicitly; requires root (CAP_BPF)
 //
 // Run locally (Linux, as root or via sudo):
-//   sudo -E cargo test -p aa-ebpf --features integration-test --test load_hello -- --nocapture
+//   sudo env "PATH=$PATH" cargo test -p aa-ebpf --features integration-test --test load_hello -- --nocapture
 #![cfg(all(target_os = "linux", feature = "integration-test"))]
 
 use aa_ebpf::AA_HELLO_BPF;
@@ -21,8 +21,8 @@ use aya::{programs::KProbe, Ebpf};
 /// kernel is left clean after the test regardless of pass/fail.
 #[test]
 fn aa_hello_loads_and_attaches() {
-    let mut bpf = Ebpf::load(AA_HELLO_BPF)
-        .expect("failed to load aa-hello BPF program — ensure the test is running as root");
+    let mut bpf =
+        Ebpf::load(AA_HELLO_BPF).expect("failed to load aa-hello BPF program — ensure the test is running as root");
 
     let program: &mut KProbe = bpf
         .program_mut("aa_hello")

--- a/aa-ebpf/tests/load_hello.rs
+++ b/aa-ebpf/tests/load_hello.rs
@@ -1,0 +1,41 @@
+// Integration test: load and attach the aa-hello BPF program into a live kernel.
+//
+// Gated on:
+//   - target_os = "linux"  — eBPF is Linux-only
+//   - feature = "integration-test" — opted-in explicitly; requires root (CAP_BPF)
+//
+// Run locally (Linux, as root or via sudo):
+//   sudo -E cargo test -p aa-ebpf --features integration-test --test load_hello -- --nocapture
+#![cfg(all(target_os = "linux", feature = "integration-test"))]
+
+use aa_ebpf::AA_HELLO_BPF;
+use aya::{programs::KProbe, Ebpf};
+
+/// Verify the full "compile → embed → load → attach" pipeline end-to-end.
+///
+/// 1. `Ebpf::load` parses and JIT-compiles the embedded BPF bytecode.
+/// 2. `KProbe::load` submits the program to the kernel verifier.
+/// 3. `KProbe::attach` hooks the probe onto `__x64_sys_write`.
+///
+/// The link guard returned by `attach` detaches the probe on drop, so the
+/// kernel is left clean after the test regardless of pass/fail.
+#[test]
+fn aa_hello_loads_and_attaches() {
+    let mut bpf = Ebpf::load(AA_HELLO_BPF)
+        .expect("failed to load aa-hello BPF program — ensure the test is running as root");
+
+    let program: &mut KProbe = bpf
+        .program_mut("aa_hello")
+        .expect("aa_hello program not found in BPF object")
+        .try_into()
+        .expect("aa_hello is not a KProbe program");
+
+    program.load().expect("kernel verifier rejected aa_hello kprobe");
+
+    let _link = program
+        .attach("__x64_sys_write", 0)
+        .expect("failed to attach aa_hello kprobe to __x64_sys_write");
+
+    // Reaching this line confirms the full pipeline works.
+    // _link is dropped here, which detaches the probe from the kernel.
+}

--- a/docs/superpowers/plans/2026-04-28-aaasm-132-ebpf-build-pipeline.md
+++ b/docs/superpowers/plans/2026-04-28-aaasm-132-ebpf-build-pipeline.md
@@ -1,0 +1,482 @@
+# [AAASM-132] eBPF BPF-Side Cross-Compilation Pipeline Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Set up the shared eBPF cross-compilation pipeline so that BPF programs can be compiled to `bpfel-unknown-none`, embedded into the `aa-ebpf` userspace crate, and validated in CI — unblocking AAASM-37, AAASM-38, AAASM-39.
+
+**Architecture:** A dedicated `aa-ebpf-probes/` crate lives outside the main Cargo workspace (no entry in `workspace.members`). It has its own `rust-toolchain.toml` (nightly) and `.cargo/config.toml` (default target = `bpfel-unknown-none`). `aa-ebpf/build.rs` uses `aya-build` to invoke `cargo build` on the probes crate and embed the compiled bytecode. The main workspace stays on stable throughout.
+
+**Tech Stack:** Rust nightly (BPF side only), aya 0.13, aya-ebpf 0.1, aya-log-ebpf 0.1, aya-build 0.1, GitHub Actions ubuntu-latest.
+
+---
+
+## File Map
+
+| Action | Path | Purpose |
+|---|---|---|
+| Create | `aa-ebpf-probes/Cargo.toml` | BPF-side crate manifest (nightly, no_std) |
+| Create | `aa-ebpf-probes/.cargo/config.toml` | Force `bpfel-unknown-none` as default target |
+| Create | `aa-ebpf-probes/rust-toolchain.toml` | Pin nightly channel for BPF compilation |
+| Create | `aa-ebpf-probes/src/main.rs` | Hello-world kprobe skeleton |
+| Modify | `aa-ebpf/Cargo.toml` | Add aya, aya-log (runtime), aya-build (build-dep) |
+| Create | `aa-ebpf/build.rs` | Compile probes crate via aya-build |
+| Modify | `aa-ebpf/src/lib.rs` | Expose compiled bytecode via `include_bytes_aligned!` |
+| Modify | `.github/workflows/ci.yml` | Add `ebpf-build` job (Linux nightly) |
+| Create | `aa-ebpf/README.md` | Build instructions + kernel version requirements |
+
+---
+
+## Task 1: Scaffold `aa-ebpf-probes/Cargo.toml`
+
+**Files:**
+- Create: `aa-ebpf-probes/Cargo.toml`
+
+- [ ] **Step 1: Create the file**
+
+```toml
+[package]
+name = "aa-ebpf-probes"
+version = "0.0.1"
+edition = "2021"
+publish = false
+
+[dependencies]
+aya-ebpf = "0.1"
+aya-log-ebpf = "0.1"
+
+# BPF programs are no_std binaries; there is no std or test harness.
+[[bin]]
+name = "aa-hello"
+path = "src/main.rs"
+```
+
+- [ ] **Step 2: Verify the workspace Cargo.toml does NOT list aa-ebpf-probes**
+
+Open `Cargo.toml` (workspace root) and confirm `aa-ebpf-probes` is absent from `[workspace] members`. It must stay outside the workspace so it can use nightly without affecting the rest of the tree.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-ebpf-probes/Cargo.toml
+git commit -m "🔧 (aa-ebpf-probes): Scaffold Cargo.toml with aya-ebpf and aya-log-ebpf"
+```
+
+---
+
+## Task 2: Add `.cargo/config.toml` for `bpfel-unknown-none` default target
+
+**Files:**
+- Create: `aa-ebpf-probes/.cargo/config.toml`
+
+- [ ] **Step 1: Create the config file**
+
+```toml
+[build]
+target = "bpfel-unknown-none"
+```
+
+This makes `cargo build` inside `aa-ebpf-probes/` default to the BPF target without needing `--target` on every invocation.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add aa-ebpf-probes/.cargo/config.toml
+git commit -m "🔧 (aa-ebpf-probes): Add .cargo/config.toml setting bpfel-unknown-none as default target"
+```
+
+---
+
+## Task 3: Add `rust-toolchain.toml` pinning nightly
+
+**Files:**
+- Create: `aa-ebpf-probes/rust-toolchain.toml`
+
+- [ ] **Step 1: Create the toolchain file**
+
+```toml
+[toolchain]
+channel = "nightly"
+components = ["rust-src"]
+targets = ["bpfel-unknown-none"]
+```
+
+`rust-src` is required by the BPF target because it needs to build `core` from source (`-Zbuild-std=core`). The `targets` entry pre-installs the `bpfel-unknown-none` cross-compilation target.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add aa-ebpf-probes/rust-toolchain.toml
+git commit -m "🔧 (aa-ebpf-probes): Add rust-toolchain.toml pinning nightly with rust-src and bpfel-unknown-none"
+```
+
+---
+
+## Task 4: Add hello-world kprobe skeleton
+
+**Files:**
+- Create: `aa-ebpf-probes/src/main.rs`
+
+- [ ] **Step 1: Create the BPF program**
+
+```rust
+#![no_std]
+#![no_main]
+
+use aya_ebpf::{macros::kprobe, programs::ProbeContext};
+use aya_log_ebpf::info;
+
+/// Minimal kprobe attached to `__x64_sys_write` — validates the BPF
+/// compilation pipeline end-to-end. Replace with real probes in
+/// AAASM-37 / AAASM-38 / AAASM-39.
+#[kprobe]
+pub fn aa_hello(ctx: ProbeContext) -> u32 {
+    match try_aa_hello(ctx) {
+        Ok(ret) => ret,
+        Err(ret) => ret,
+    }
+}
+
+fn try_aa_hello(ctx: ProbeContext) -> Result<u32, u32> {
+    info!(&ctx, "aa-hello: __x64_sys_write intercepted");
+    Ok(0)
+}
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+    unsafe { core::hint::unreachable_unchecked() }
+}
+```
+
+- [ ] **Step 2: Verify the file compiles (on Linux with nightly installed)**
+
+If on Linux with nightly available:
+```bash
+cd aa-ebpf-probes
+cargo build --release
+# Expected: Compiling aa-ebpf-probes ... Finished release
+```
+
+On macOS, skip this step — BPF cross-compilation is Linux-only. The CI job in Task 8 will verify this.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-ebpf-probes/src/main.rs
+git commit -m "✨ (aa-ebpf-probes): Add hello-world kprobe skeleton on __x64_sys_write"
+```
+
+---
+
+## Task 5: Add aya dependencies to `aa-ebpf/Cargo.toml`
+
+**Files:**
+- Modify: `aa-ebpf/Cargo.toml`
+
+Current content:
+```toml
+[package]
+name = "aa-ebpf"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "eBPF-based kernel-level monitoring hooks for Agent Assembly"
+
+[dependencies]
+aa-core = { path = "../aa-core" }
+
+[lints]
+workspace = true
+```
+
+- [ ] **Step 1: Add aya runtime deps and aya-build build-dep**
+
+```toml
+[package]
+name = "aa-ebpf"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "eBPF-based kernel-level monitoring hooks for Agent Assembly"
+
+[dependencies]
+aa-core = { path = "../aa-core" }
+aya = { version = "0.13", features = ["async_tokio"] }
+aya-log = "0.2"
+
+[build-dependencies]
+aya-build = "0.1"
+
+[lints]
+workspace = true
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add aa-ebpf/Cargo.toml
+git commit -m "🔧 (aa-ebpf): Add aya, aya-log runtime deps and aya-build build-dependency"
+```
+
+---
+
+## Task 6: Add `aa-ebpf/build.rs`
+
+**Files:**
+- Create: `aa-ebpf/build.rs`
+
+- [ ] **Step 1: Create the build script**
+
+```rust
+//! Build script for aa-ebpf.
+//!
+//! Compiles the `aa-ebpf-probes` BPF crate (which targets `bpfel-unknown-none`)
+//! and makes the resulting bytecode available to the userspace crate via
+//! `OUT_DIR`.
+
+fn main() {
+    let probes_dir = std::path::PathBuf::from("../aa-ebpf-probes");
+
+    // aya-build invokes `cargo build --target bpfel-unknown-none` inside the
+    // probes crate and copies the compiled ELF objects into OUT_DIR so they
+    // can be embedded with `include_bytes_aligned!`.
+    aya_build::build_ebpf([aya_build::Ebpf {
+        source_dir: probes_dir,
+        target: None, // reads from aa-ebpf-probes/.cargo/config.toml
+    }])
+    .expect("failed to compile aa-ebpf-probes BPF programs");
+}
+```
+
+> **Note:** The exact `aya_build::Ebpf` struct fields may differ slightly between patch versions. Verify against the installed version of `aya-build`. If the struct API differs, use `aya_build::build_ebpf_with_dir(probes_dir)` as a fallback — both forms invoke the same underlying `cargo build`.
+
+- [ ] **Step 2: Run cargo check on aa-ebpf to confirm build.rs parses**
+
+```bash
+cargo check -p aa-ebpf
+# Expected: either success or "cannot compile `aa-ebpf-probes`" (BPF-side error,
+# acceptable on macOS) — NOT a Rust syntax error in build.rs itself.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-ebpf/build.rs
+git commit -m "🔧 (aa-ebpf): Add build.rs to compile BPF probes crate via aya-build"
+```
+
+---
+
+## Task 7: Expose compiled bytecode in `aa-ebpf/src/lib.rs`
+
+**Files:**
+- Modify: `aa-ebpf/src/lib.rs`
+
+- [ ] **Step 1: Update lib.rs**
+
+```rust
+//! eBPF-based kernel-level monitoring hooks for Agent Assembly.
+//!
+//! This crate provides kernel-space probes that intercept system calls and
+//! network events originating from AI agent processes, feeding data into
+//! the governance pipeline without requiring code changes in agents.
+//!
+//! # Loading BPF programs
+//!
+//! The compiled BPF bytecode is embedded at build time and exposed as the
+//! [`AA_HELLO_BPF`] constant. Pass it to [`aya::Ebpf::load`] to load all
+//! programs defined in the `aa-ebpf-probes` crate:
+//!
+//! ```no_run
+//! # #[cfg(target_os = "linux")]
+//! # {
+//! use aya::Ebpf;
+//! use aa_ebpf::AA_HELLO_BPF;
+//!
+//! let mut bpf = Ebpf::load(AA_HELLO_BPF).expect("failed to load BPF programs");
+//! # }
+//! ```
+
+/// Compiled BPF bytecode for the `aa-hello` probe program.
+///
+/// Embedded from `aa-ebpf-probes/src/main.rs` at build time. Pass this to
+/// [`aya::Ebpf::load`] to obtain a handle to all programs in the probe crate.
+///
+/// Only meaningful on Linux — on other platforms the bytes are present but
+/// cannot be loaded into the kernel.
+#[cfg(target_os = "linux")]
+pub static AA_HELLO_BPF: &[u8] = aya::include_bytes_aligned!(
+    concat!(env!("OUT_DIR"), "/aa-hello")
+);
+```
+
+- [ ] **Step 2: Confirm cargo check passes on stable (macOS/Linux userspace)**
+
+```bash
+cargo check -p aa-ebpf
+# Expected: Finished (or warnings only, no errors)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add aa-ebpf/src/lib.rs
+git commit -m "✨ (aa-ebpf): Expose compiled BPF bytecode via include_bytes_aligned! in lib.rs"
+```
+
+---
+
+## Task 8: Add `ebpf-build` CI job to `ci.yml`
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add the new job at the end of ci.yml (before the conformance placeholder jobs)**
+
+Find the `conformance:` job in `.github/workflows/ci.yml` and insert the following block immediately before it:
+
+```yaml
+  ebpf-build:
+    name: eBPF probes build (Linux nightly)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: aa-ebpf-probes
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          targets: bpfel-unknown-none
+          components: rust-src
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: aa-ebpf-probes
+      - name: Build eBPF probes
+        run: cargo build --release
+      - name: Clippy on eBPF probes
+        run: cargo clippy --all-targets -- -D warnings
+```
+
+This job:
+- Runs only on Linux (`ubuntu-latest`)
+- Uses nightly Rust with the `bpfel-unknown-none` target and `rust-src` component pre-installed
+- Caches the probes crate separately from the workspace cache
+- The existing `build` / `test` / `clippy` jobs on stable never enter `aa-ebpf-probes/`, so macOS and stable CI are unaffected
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "🔧 (ci): Add ebpf-build job — Linux nightly runner, bpfel-unknown-none compilation"
+```
+
+---
+
+## Task 9: Add `aa-ebpf/README.md` with build instructions
+
+**Files:**
+- Create: `aa-ebpf/README.md`
+
+- [ ] **Step 1: Create the README**
+
+```markdown
+# aa-ebpf
+
+Kernel-level eBPF monitoring hooks for Agent Assembly (Layer 3 of the three-layer
+defense-in-depth architecture).
+
+## Architecture
+
+BPF programs live in a **separate crate** (`aa-ebpf-probes/`) that compiles to the
+`bpfel-unknown-none` target under nightly Rust. The userspace crate (`aa-ebpf`, this
+crate) loads the compiled bytecode via `aya::Ebpf::load`.
+
+```
+aa-ebpf-probes/          ← BPF-side (nightly, bpfel-unknown-none)
+    src/main.rs          ← kprobe / uprobe / tracepoint programs
+    rust-toolchain.toml  ← nightly pin
+    .cargo/config.toml   ← default target = bpfel-unknown-none
+
+aa-ebpf/                 ← userspace (stable, in workspace)
+    build.rs             ← compiles aa-ebpf-probes via aya-build
+    src/lib.rs           ← loads bytecode, exposes pub API
+```
+
+## Prerequisites
+
+| Requirement | Version |
+|---|---|
+| Rust toolchain | nightly (managed by `aa-ebpf-probes/rust-toolchain.toml`) |
+| Linux kernel | 5.8+ (required for BPF ring buffer; 5.15+ recommended for BTF) |
+| OS | Linux only — eBPF cannot be loaded on macOS or Windows |
+
+## Building BPF programs
+
+The workspace build (`cargo build --workspace`) does NOT compile BPF programs —
+they are compiled by `aa-ebpf`'s `build.rs` when you build `aa-ebpf`.
+
+```bash
+# Build the userspace crate (triggers BPF compilation automatically via build.rs)
+cargo build -p aa-ebpf
+
+# Build BPF programs directly (for iteration)
+cd aa-ebpf-probes
+cargo build --release
+```
+
+## CI
+
+The `ebpf-build` GitHub Actions job (`.github/workflows/ci.yml`) compiles the BPF
+programs on a Linux runner with nightly Rust. macOS CI jobs never enter
+`aa-ebpf-probes/` and are unaffected.
+
+## CO-RE / BTF
+
+Compile Once, Run Everywhere (CO-RE) via BTF is **not enabled** in the current
+hello-world skeleton. When implementing real probes (AAASM-37 / AAASM-38 / AAASM-39),
+generate `vmlinux.h` from the CI runner kernel and check it in:
+
+```bash
+bpftool btf dump file /sys/kernel/btf/vmlinux format c > aa-ebpf-probes/src/vmlinux.h
+```
+
+Minimum kernel version for CO-RE: **5.8** (BPF ring buffer) / **5.15** (stable BTF).
+
+## Adding new probes
+
+1. Add a new `[[bin]]` entry to `aa-ebpf-probes/Cargo.toml`.
+2. Write the BPF program in `aa-ebpf-probes/src/<probe-name>.rs`.
+3. Expose the compiled bytes in `aa-ebpf/src/lib.rs` using `include_bytes_aligned!`.
+4. Write a loader function in `aa-ebpf/src/lib.rs` that attaches the program.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add aa-ebpf/README.md
+git commit -m "📝 (aa-ebpf): Add README with build instructions, kernel requirements, and CO-RE notes"
+```
+
+---
+
+## Verification Checklist
+
+After all 9 tasks are complete:
+
+- [ ] `cargo check -p aa-ebpf` passes on macOS (stable) — no BPF-side errors
+- [ ] `cargo clippy --workspace` passes on stable — no warnings in aa-ebpf
+- [ ] `cargo build --workspace` succeeds (aa-ebpf-probes is excluded from workspace)
+- [ ] On Linux with nightly: `cd aa-ebpf-probes && cargo build --release` succeeds
+- [ ] `git log --oneline` shows exactly 9 new commits, each scoped to one change
+- [ ] CI `ebpf-build` job is present in `.github/workflows/ci.yml`
+
+---
+
+## Notes for AAASM-37 / AAASM-38 / AAASM-39
+
+These tickets build on top of this infrastructure. When implementing them:
+1. Add a new `[[bin]]` to `aa-ebpf-probes/Cargo.toml` per probe
+2. Write the probe in `aa-ebpf-probes/src/<probe>.rs`
+3. Expose bytecode and loader in `aa-ebpf/src/lib.rs`
+4. BTF/CO-RE decision should be made in those tickets using the notes above

--- a/docs/superpowers/plans/2026-04-28-aaasm-69-policy-yaml-parser.md
+++ b/docs/superpowers/plans/2026-04-28-aaasm-69-policy-yaml-parser.md
@@ -1,0 +1,1922 @@
+# AAASM-69 Policy YAML Parser & Typed Validator — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a Policy YAML parser and typed validator in `aa-gateway` that converts human-readable YAML into a validated `PolicyDocument`, surfacing field-level `ValidationError`s and `ValidationWarning`s for unknown keys.
+
+**Architecture:** Two-step pipeline — `serde_yaml` deserializes YAML into `RawPolicyDocument` (all fields `Option<T>`, unknown keys captured via `#[serde(flatten)]`), then `PolicyValidator::from_yaml()` walks the raw struct and enforces per-field constraints, producing either a valid `PolicyDocument` or a list of errors. `aa-core::policy::PolicyDocument` is NOT modified — it stays as the minimal `no_std` evaluator-boundary stub.
+
+**Tech Stack:** Rust, `serde 1` + derive, `serde_yaml 0.9`, `regex 1`
+
+---
+
+## File Map
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Modify | `aa-gateway/Cargo.toml` | Add serde, serde_yaml, regex deps |
+| Modify | `aa-gateway/src/lib.rs` | Expose `pub mod policy` |
+| Create | `aa-gateway/src/policy/mod.rs` | Re-export public types |
+| Create | `aa-gateway/src/policy/error.rs` | `ValidationError`, `ValidationWarning` |
+| Create | `aa-gateway/src/policy/raw.rs` | `RawPolicyDocument` + `Raw*` section structs (serde targets) |
+| Create | `aa-gateway/src/policy/document.rs` | `PolicyDocument` + validated section structs |
+| Create | `aa-gateway/src/policy/validator.rs` | `PolicyValidator::from_yaml()` + all validation logic + unit tests |
+
+---
+
+## Task 1: Add serde_yaml, serde, and regex dependencies
+
+**Files:**
+- Modify: `aa-gateway/Cargo.toml`
+
+- [ ] **Step 1.1: Add the three dependencies**
+
+Open `aa-gateway/Cargo.toml`. The `[dependencies]` section currently has:
+```toml
+[dependencies]
+aa-core    = { path = "../aa-core" }
+aa-proto   = { path = "../aa-proto" }
+aa-runtime = { path = "../aa-runtime" }
+tokio      = { version = "1", features = ["full"] }
+```
+
+Change it to:
+```toml
+[dependencies]
+aa-core    = { path = "../aa-core" }
+aa-proto   = { path = "../aa-proto" }
+aa-runtime = { path = "../aa-runtime" }
+tokio      = { version = "1", features = ["full"] }
+regex      = "1"
+serde      = { version = "1", features = ["derive"] }
+serde_yaml = "0.9"
+```
+
+- [ ] **Step 1.2: Verify the workspace compiles**
+
+```bash
+cd agent-assembly
+cargo check -p aa-gateway
+```
+
+Expected: `Checking aa-gateway ...` with no errors. (Warnings about unused imports are fine at this stage.)
+
+- [ ] **Step 1.3: Commit**
+
+```bash
+git add aa-gateway/Cargo.toml
+git commit -m "⬆️ (aa-gateway): Add serde_yaml, serde derive, and regex dependencies"
+```
+
+---
+
+## Task 2: Create the policy module skeleton
+
+**Files:**
+- Create: `aa-gateway/src/policy/mod.rs`
+- Modify: `aa-gateway/src/lib.rs`
+
+- [ ] **Step 2.1: Create the policy directory and empty mod.rs**
+
+Create `aa-gateway/src/policy/mod.rs` with:
+```rust
+//! Policy YAML parser and validator for aa-gateway.
+//!
+//! Entry point: [`validator::PolicyValidator::from_yaml`].
+```
+
+- [ ] **Step 2.2: Wire the module into lib.rs**
+
+`aa-gateway/src/lib.rs` currently contains only a module-level doc comment. Append:
+```rust
+//! Control plane for Agent Assembly — policy enforcement and agent registry.
+//!
+//! The gateway is the central coordination point: it maintains the agent
+//! registry, evaluates governance policies, routes enforcement decisions
+//! back to proxies and SDK shims, and writes the audit trail.
+
+pub mod policy;
+```
+
+- [ ] **Step 2.3: Verify**
+
+```bash
+cargo check -p aa-gateway
+```
+
+Expected: no errors.
+
+- [ ] **Step 2.4: Commit**
+
+```bash
+git add aa-gateway/src/policy/mod.rs aa-gateway/src/lib.rs
+git commit -m "✨ (aa-gateway/policy): Add empty policy module"
+```
+
+---
+
+## Task 3: Add ValidationError
+
+**Files:**
+- Create: `aa-gateway/src/policy/error.rs`
+- Modify: `aa-gateway/src/policy/mod.rs`
+
+- [ ] **Step 3.1: Write the failing test first**
+
+Create `aa-gateway/src/policy/error.rs` with only the test module:
+```rust
+//! Validation error and warning types for policy YAML parsing.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validation_error_new_sets_field_and_message() {
+        let e = ValidationError::new("budget.daily_limit_usd", "must be > 0");
+        assert_eq!(e.field, "budget.daily_limit_usd");
+        assert_eq!(e.message, "must be > 0");
+        assert_eq!(e.line, None);
+    }
+
+    #[test]
+    fn validation_error_with_line_sets_line() {
+        let e = ValidationError::new("network.allowlist[0]", "must not be empty")
+            .with_line(7);
+        assert_eq!(e.line, Some(7));
+    }
+}
+```
+
+- [ ] **Step 3.2: Run — verify it fails**
+
+```bash
+cargo test -p aa-gateway -- policy::error 2>&1 | head -20
+```
+
+Expected: compile error — `ValidationError` not found.
+
+- [ ] **Step 3.3: Implement ValidationError**
+
+Add the struct above the `#[cfg(test)]` block in `error.rs`:
+```rust
+/// An error produced during policy document validation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ValidationError {
+    /// Dot-notation field path, e.g. `"budget.daily_limit_usd"`.
+    pub field: String,
+    /// Human-readable description of the violated constraint.
+    pub message: String,
+    /// Best-effort line number from the YAML source (`None` when not determinable).
+    pub line: Option<u32>,
+}
+
+impl ValidationError {
+    /// Create a new error with no line information.
+    pub fn new(field: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            field: field.into(),
+            message: message.into(),
+            line: None,
+        }
+    }
+
+    /// Attach a best-effort line number.
+    pub fn with_line(mut self, line: u32) -> Self {
+        self.line = Some(line);
+        self
+    }
+}
+```
+
+- [ ] **Step 3.4: Expose error module from mod.rs**
+
+Add to `aa-gateway/src/policy/mod.rs`:
+```rust
+//! Policy YAML parser and validator for aa-gateway.
+//!
+//! Entry point: [`validator::PolicyValidator::from_yaml`].
+
+pub mod error;
+```
+
+- [ ] **Step 3.5: Run — verify tests pass**
+
+```bash
+cargo test -p aa-gateway -- policy::error
+```
+
+Expected:
+```
+test policy::error::tests::validation_error_new_sets_field_and_message ... ok
+test policy::error::tests::validation_error_with_line_sets_line ... ok
+```
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add aa-gateway/src/policy/error.rs aa-gateway/src/policy/mod.rs
+git commit -m "✨ (aa-gateway/policy): Add ValidationError struct"
+```
+
+---
+
+## Task 4: Add ValidationWarning
+
+**Files:**
+- Modify: `aa-gateway/src/policy/error.rs`
+
+- [ ] **Step 4.1: Write the failing test**
+
+Append to the `tests` module in `error.rs`:
+```rust
+    #[test]
+    fn validation_warning_unknown_key_formats_message() {
+        let w = ValidationWarning::unknown_key("risk_tier");
+        assert_eq!(w.field, "risk_tier");
+        assert!(w.message.contains("risk_tier"));
+    }
+
+    #[test]
+    fn validation_warning_unknown_key_nested_path() {
+        let w = ValidationWarning::unknown_key("network.blocklist");
+        assert_eq!(w.field, "network.blocklist");
+    }
+```
+
+- [ ] **Step 4.2: Run — verify it fails**
+
+```bash
+cargo test -p aa-gateway -- policy::error 2>&1 | head -10
+```
+
+Expected: compile error — `ValidationWarning` not found.
+
+- [ ] **Step 4.3: Implement ValidationWarning**
+
+Add after the `ValidationError` impl block in `error.rs`:
+```rust
+/// A non-fatal warning produced during policy document validation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ValidationWarning {
+    /// Dot-notation path of the unexpected key.
+    pub field: String,
+    /// Human-readable message.
+    pub message: String,
+}
+
+impl ValidationWarning {
+    /// Construct a warning for an unknown key at the given path.
+    pub fn unknown_key(field: impl Into<String>) -> Self {
+        let field = field.into();
+        let message = format!("Unknown key '{}' will be ignored", field);
+        Self { field, message }
+    }
+}
+```
+
+- [ ] **Step 4.4: Run — verify all error tests pass**
+
+```bash
+cargo test -p aa-gateway -- policy::error
+```
+
+Expected: 4 tests pass.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add aa-gateway/src/policy/error.rs
+git commit -m "✨ (aa-gateway/policy): Add ValidationWarning struct"
+```
+
+---
+
+## Task 5: Add RawNetworkPolicy
+
+**Files:**
+- Create: `aa-gateway/src/policy/raw.rs`
+- Modify: `aa-gateway/src/policy/mod.rs`
+
+- [ ] **Step 5.1: Write the failing test**
+
+Create `aa-gateway/src/policy/raw.rs` with only the test:
+```rust
+//! Unvalidated serde deserialization targets for policy YAML.
+
+use std::collections::HashMap;
+use serde::Deserialize;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn raw_network_deserializes_allowlist() {
+        let yaml = "allowlist:\n  - api.openai.com\n  - slack.com\n";
+        let raw: RawNetworkPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(raw.allowlist, Some(vec![
+            "api.openai.com".to_string(),
+            "slack.com".to_string(),
+        ]));
+        assert!(raw.unknown.is_empty());
+    }
+
+    #[test]
+    fn raw_network_captures_unknown_keys() {
+        let yaml = "allowlist:\n  - api.openai.com\nblocklist:\n  - \"*\"\n";
+        let raw: RawNetworkPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert!(raw.unknown.contains_key("blocklist"));
+    }
+
+    #[test]
+    fn raw_network_absent_allowlist_is_none() {
+        let yaml = "{}\n";
+        let raw: RawNetworkPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(raw.allowlist, None);
+    }
+}
+```
+
+- [ ] **Step 5.2: Run — verify it fails**
+
+```bash
+cargo test -p aa-gateway -- policy::raw 2>&1 | head -10
+```
+
+Expected: compile error — `RawNetworkPolicy` not found.
+
+- [ ] **Step 5.3: Implement RawNetworkPolicy**
+
+Add above the `#[cfg(test)]` block:
+```rust
+/// Raw (unvalidated) deserialization target for the `network` policy section.
+#[derive(Debug, Deserialize)]
+pub struct RawNetworkPolicy {
+    /// Domain glob patterns the agent may connect to.
+    pub allowlist: Option<Vec<String>>,
+    /// Unknown keys captured for warning emission.
+    #[serde(flatten)]
+    pub unknown: HashMap<String, serde_yaml::Value>,
+}
+```
+
+- [ ] **Step 5.4: Add raw module to mod.rs**
+
+Append to `aa-gateway/src/policy/mod.rs`:
+```rust
+pub mod raw;
+```
+
+- [ ] **Step 5.5: Run — verify tests pass**
+
+```bash
+cargo test -p aa-gateway -- policy::raw
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 5.6: Commit**
+
+```bash
+git add aa-gateway/src/policy/raw.rs aa-gateway/src/policy/mod.rs
+git commit -m "✨ (aa-gateway/policy): Add RawNetworkPolicy serde target"
+```
+
+---
+
+## Task 6: Add RawToolPolicy
+
+**Files:**
+- Modify: `aa-gateway/src/policy/raw.rs`
+
+- [ ] **Step 6.1: Write the failing test**
+
+Append to the `tests` module in `raw.rs`:
+```rust
+    #[test]
+    fn raw_tool_deserializes_all_fields() {
+        let yaml = "allow: true\nlimit_per_hour: 10\nrequires_approval_if: \"amount > 100\"\n";
+        let raw: RawToolPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(raw.allow, Some(true));
+        assert_eq!(raw.limit_per_hour, Some(10));
+        assert_eq!(raw.requires_approval_if, Some("amount > 100".to_string()));
+        assert!(raw.unknown.is_empty());
+    }
+
+    #[test]
+    fn raw_tool_allow_false_captured() {
+        let yaml = "allow: false\n";
+        let raw: RawToolPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(raw.allow, Some(false));
+        assert_eq!(raw.limit_per_hour, None);
+    }
+
+    #[test]
+    fn raw_tool_captures_unknown_key() {
+        let yaml = "allow: true\nconstraint: \"read-only\"\n";
+        let raw: RawToolPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert!(raw.unknown.contains_key("constraint"));
+    }
+```
+
+- [ ] **Step 6.2: Run — verify it fails**
+
+```bash
+cargo test -p aa-gateway -- policy::raw::tests::raw_tool 2>&1 | head -10
+```
+
+Expected: compile error — `RawToolPolicy` not found.
+
+- [ ] **Step 6.3: Implement RawToolPolicy**
+
+Add after `RawNetworkPolicy` in `raw.rs`:
+```rust
+/// Raw (unvalidated) deserialization target for a single entry in `tools`.
+#[derive(Debug, Deserialize)]
+pub struct RawToolPolicy {
+    /// Whether this tool is permitted.
+    pub allow: Option<bool>,
+    /// Max calls per hour; `None` means unlimited.
+    pub limit_per_hour: Option<u32>,
+    /// CEL expression that triggers human-in-the-loop approval.
+    pub requires_approval_if: Option<String>,
+    /// Unknown keys captured for warning emission.
+    #[serde(flatten)]
+    pub unknown: HashMap<String, serde_yaml::Value>,
+}
+```
+
+- [ ] **Step 6.4: Run — verify tests pass**
+
+```bash
+cargo test -p aa-gateway -- policy::raw
+```
+
+Expected: all existing + 3 new tests pass.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add aa-gateway/src/policy/raw.rs
+git commit -m "✨ (aa-gateway/policy): Add RawToolPolicy serde target"
+```
+
+---
+
+## Task 7: Add RawDataPolicy
+
+**Files:**
+- Modify: `aa-gateway/src/policy/raw.rs`
+
+- [ ] **Step 7.1: Write the failing test**
+
+Append to the `tests` module:
+```rust
+    #[test]
+    fn raw_data_deserializes_sensitive_patterns() {
+        let yaml = "sensitive_patterns:\n  - \"sk-[a-zA-Z0-9]{48}\"\n  - \"\\\\b\\\\d{4}\\\\b\"\n";
+        let raw: RawDataPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(raw.sensitive_patterns.as_ref().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn raw_data_absent_patterns_is_none() {
+        let yaml = "{}\n";
+        let raw: RawDataPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(raw.sensitive_patterns, None);
+    }
+```
+
+- [ ] **Step 7.2: Run — verify it fails**
+
+```bash
+cargo test -p aa-gateway -- policy::raw::tests::raw_data 2>&1 | head -10
+```
+
+Expected: compile error.
+
+- [ ] **Step 7.3: Implement RawDataPolicy**
+
+Add after `RawToolPolicy` in `raw.rs`:
+```rust
+/// Raw (unvalidated) deserialization target for the `data` policy section.
+#[derive(Debug, Deserialize)]
+pub struct RawDataPolicy {
+    /// Regex patterns for PII / credential detection.
+    pub sensitive_patterns: Option<Vec<String>>,
+    /// Unknown keys captured for warning emission.
+    #[serde(flatten)]
+    pub unknown: HashMap<String, serde_yaml::Value>,
+}
+```
+
+- [ ] **Step 7.4: Run — verify tests pass**
+
+```bash
+cargo test -p aa-gateway -- policy::raw
+```
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add aa-gateway/src/policy/raw.rs
+git commit -m "✨ (aa-gateway/policy): Add RawDataPolicy serde target"
+```
+
+---
+
+## Task 8: Add RawBudgetPolicy
+
+**Files:**
+- Modify: `aa-gateway/src/policy/raw.rs`
+
+- [ ] **Step 8.1: Write the failing test**
+
+```rust
+    #[test]
+    fn raw_budget_deserializes_daily_limit() {
+        let yaml = "daily_limit_usd: 50.0\n";
+        let raw: RawBudgetPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(raw.daily_limit_usd, Some(50.0));
+    }
+
+    #[test]
+    fn raw_budget_absent_limit_is_none() {
+        let yaml = "{}\n";
+        let raw: RawBudgetPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(raw.daily_limit_usd, None);
+    }
+```
+
+- [ ] **Step 8.2: Run — verify it fails**
+
+```bash
+cargo test -p aa-gateway -- policy::raw::tests::raw_budget 2>&1 | head -10
+```
+
+- [ ] **Step 8.3: Implement RawBudgetPolicy**
+
+Add after `RawDataPolicy` in `raw.rs`:
+```rust
+/// Raw (unvalidated) deserialization target for the `budget` policy section.
+#[derive(Debug, Deserialize)]
+pub struct RawBudgetPolicy {
+    /// Maximum USD spend per calendar day; `None` means no limit.
+    pub daily_limit_usd: Option<f64>,
+    /// Unknown keys captured for warning emission.
+    #[serde(flatten)]
+    pub unknown: HashMap<String, serde_yaml::Value>,
+}
+```
+
+- [ ] **Step 8.4: Run — verify tests pass**
+
+```bash
+cargo test -p aa-gateway -- policy::raw
+```
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add aa-gateway/src/policy/raw.rs
+git commit -m "✨ (aa-gateway/policy): Add RawBudgetPolicy serde target"
+```
+
+---
+
+## Task 9: Add RawSchedulePolicy and RawActiveHours
+
+**Files:**
+- Modify: `aa-gateway/src/policy/raw.rs`
+
+- [ ] **Step 9.1: Write the failing tests**
+
+```rust
+    #[test]
+    fn raw_active_hours_deserializes_all_fields() {
+        let yaml = "start: \"09:00\"\nend: \"18:00\"\ntimezone: \"Asia/Taipei\"\n";
+        let raw: RawActiveHours = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(raw.start, Some("09:00".to_string()));
+        assert_eq!(raw.end, Some("18:00".to_string()));
+        assert_eq!(raw.timezone, Some("Asia/Taipei".to_string()));
+        assert!(raw.unknown.is_empty());
+    }
+
+    #[test]
+    fn raw_schedule_active_hours_absent_is_none() {
+        let yaml = "{}\n";
+        let raw: RawSchedulePolicy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(raw.active_hours.is_none(), true);
+    }
+```
+
+- [ ] **Step 9.2: Run — verify it fails**
+
+```bash
+cargo test -p aa-gateway -- policy::raw::tests::raw_active 2>&1 | head -10
+```
+
+- [ ] **Step 9.3: Implement RawActiveHours and RawSchedulePolicy**
+
+Add after `RawBudgetPolicy` in `raw.rs`:
+```rust
+/// Raw (unvalidated) deserialization target for `schedule.active_hours`.
+#[derive(Debug, Deserialize)]
+pub struct RawActiveHours {
+    /// Window start in `HH:MM` 24-hour format.
+    pub start: Option<String>,
+    /// Window end in `HH:MM` 24-hour format.
+    pub end: Option<String>,
+    /// IANA timezone name (e.g. `"Asia/Taipei"`).
+    pub timezone: Option<String>,
+    /// Unknown keys captured for warning emission.
+    #[serde(flatten)]
+    pub unknown: HashMap<String, serde_yaml::Value>,
+}
+
+/// Raw (unvalidated) deserialization target for the `schedule` policy section.
+#[derive(Debug, Deserialize)]
+pub struct RawSchedulePolicy {
+    /// Time window during which the agent is permitted to run.
+    pub active_hours: Option<RawActiveHours>,
+    /// Unknown keys captured for warning emission.
+    #[serde(flatten)]
+    pub unknown: HashMap<String, serde_yaml::Value>,
+}
+```
+
+- [ ] **Step 9.4: Run — verify tests pass**
+
+```bash
+cargo test -p aa-gateway -- policy::raw
+```
+
+- [ ] **Step 9.5: Commit**
+
+```bash
+git add aa-gateway/src/policy/raw.rs
+git commit -m "✨ (aa-gateway/policy): Add RawSchedulePolicy and RawActiveHours serde targets"
+```
+
+---
+
+## Task 10: Add RawPolicyDocument
+
+**Files:**
+- Modify: `aa-gateway/src/policy/raw.rs`
+
+- [ ] **Step 10.1: Write the failing test**
+
+```rust
+    #[test]
+    fn raw_policy_document_deserializes_all_sections() {
+        let yaml = r#"
+network:
+  allowlist:
+    - api.openai.com
+tools:
+  web_search:
+    allow: true
+    limit_per_hour: 20
+data:
+  sensitive_patterns:
+    - "sk-[a-zA-Z0-9]{48}"
+budget:
+  daily_limit_usd: 25.0
+schedule:
+  active_hours:
+    start: "09:00"
+    end: "18:00"
+    timezone: "UTC"
+"#;
+        let raw: RawPolicyDocument = serde_yaml::from_str(yaml).unwrap();
+        assert!(raw.network.is_some());
+        assert!(raw.tools.is_some());
+        assert!(raw.data.is_some());
+        assert!(raw.budget.is_some());
+        assert!(raw.schedule.is_some());
+        assert!(raw.unknown.is_empty());
+    }
+
+    #[test]
+    fn raw_policy_document_captures_unknown_top_level_key() {
+        let yaml = "agent: support-agent\nversion: 2\n";
+        let raw: RawPolicyDocument = serde_yaml::from_str(yaml).unwrap();
+        assert!(raw.unknown.contains_key("agent"));
+        assert!(raw.unknown.contains_key("version"));
+    }
+
+    #[test]
+    fn raw_policy_document_empty_yaml_is_valid() {
+        let yaml = "{}\n";
+        let raw: RawPolicyDocument = serde_yaml::from_str(yaml).unwrap();
+        assert!(raw.network.is_none());
+        assert!(raw.tools.is_none());
+        assert!(raw.unknown.is_empty());
+    }
+```
+
+- [ ] **Step 10.2: Run — verify it fails**
+
+```bash
+cargo test -p aa-gateway -- policy::raw::tests::raw_policy_document 2>&1 | head -10
+```
+
+- [ ] **Step 10.3: Implement RawPolicyDocument**
+
+Add at the top of `raw.rs` (before `RawNetworkPolicy`, after the `use` statements):
+```rust
+/// Unvalidated top-level deserialization target for a policy YAML document.
+///
+/// All sections are optional — absent sections default to permissive during
+/// validation. Unknown top-level keys are captured in `unknown` and converted
+/// to [`crate::policy::error::ValidationWarning`]s.
+#[derive(Debug, Deserialize)]
+pub struct RawPolicyDocument {
+    /// Network access control section.
+    pub network: Option<RawNetworkPolicy>,
+    /// Per-tool governance rules, keyed by tool name.
+    pub tools: Option<HashMap<String, RawToolPolicy>>,
+    /// Data sensitivity controls.
+    pub data: Option<RawDataPolicy>,
+    /// Budget spend controls.
+    pub budget: Option<RawBudgetPolicy>,
+    /// Time-based access controls.
+    pub schedule: Option<RawSchedulePolicy>,
+    /// Unknown top-level keys for warning emission.
+    #[serde(flatten)]
+    pub unknown: HashMap<String, serde_yaml::Value>,
+}
+```
+
+- [ ] **Step 10.4: Run — verify all raw tests pass**
+
+```bash
+cargo test -p aa-gateway -- policy::raw
+```
+
+Expected: all tests pass (11+ tests).
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add aa-gateway/src/policy/raw.rs
+git commit -m "✨ (aa-gateway/policy): Add RawPolicyDocument top-level serde target"
+```
+
+---
+
+## Task 11: Add validated document types
+
+**Files:**
+- Create: `aa-gateway/src/policy/document.rs`
+- Modify: `aa-gateway/src/policy/mod.rs`
+
+- [ ] **Step 11.1: Write the failing tests**
+
+Create `aa-gateway/src/policy/document.rs` with:
+```rust
+//! Validated policy document types produced by [`super::validator::PolicyValidator`].
+
+use std::collections::HashMap;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_document_fields_accessible() {
+        let doc = PolicyDocument {
+            network: NetworkPolicy { allowlist: vec!["api.openai.com".to_string()] },
+            tools: HashMap::new(),
+            data: DataPolicy { sensitive_patterns: vec![] },
+            budget: BudgetPolicy { daily_limit_usd: Some(50.0) },
+            schedule: SchedulePolicy { active_hours: None },
+        };
+        assert_eq!(doc.network.allowlist[0], "api.openai.com");
+        assert_eq!(doc.budget.daily_limit_usd, Some(50.0));
+    }
+
+    #[test]
+    fn active_hours_fields_accessible() {
+        let ah = ActiveHours {
+            start: "09:00".to_string(),
+            end: "18:00".to_string(),
+            timezone: "UTC".to_string(),
+        };
+        assert_eq!(ah.start, "09:00");
+    }
+}
+```
+
+- [ ] **Step 11.2: Run — verify it fails**
+
+```bash
+cargo test -p aa-gateway -- policy::document 2>&1 | head -10
+```
+
+- [ ] **Step 11.3: Implement all document types**
+
+Add above the `#[cfg(test)]` block:
+```rust
+/// Fully validated policy document produced by [`super::validator::PolicyValidator`].
+///
+/// All sections are present — absent sections in the YAML source default to
+/// empty/permissive values.
+#[derive(Debug)]
+pub struct PolicyDocument {
+    /// Network access controls.
+    pub network: NetworkPolicy,
+    /// Per-tool governance rules, keyed by tool name.
+    pub tools: HashMap<String, ToolPolicy>,
+    /// Data sensitivity controls.
+    pub data: DataPolicy,
+    /// Budget spend controls.
+    pub budget: BudgetPolicy,
+    /// Time-based access controls.
+    pub schedule: SchedulePolicy,
+}
+
+/// Validated network access control section.
+#[derive(Debug)]
+pub struct NetworkPolicy {
+    /// Domain glob patterns the agent may connect to. Empty = no restrictions.
+    pub allowlist: Vec<String>,
+}
+
+/// Validated governance rule for a single tool.
+#[derive(Debug)]
+pub struct ToolPolicy {
+    /// Whether this tool is permitted to be called.
+    pub allow: bool,
+    /// Maximum calls per hour; `None` means unlimited.
+    pub limit_per_hour: Option<u32>,
+    /// CEL expression (stored as opaque string) that triggers human approval.
+    pub requires_approval_if: Option<String>,
+}
+
+/// Validated data sensitivity control section.
+#[derive(Debug)]
+pub struct DataPolicy {
+    /// Pre-compiled-validated regex pattern strings for PII detection.
+    pub sensitive_patterns: Vec<String>,
+}
+
+/// Validated budget spend control section.
+#[derive(Debug)]
+pub struct BudgetPolicy {
+    /// Maximum USD spend per calendar day; `None` means no limit.
+    pub daily_limit_usd: Option<f64>,
+}
+
+/// Validated time-based access control section.
+#[derive(Debug)]
+pub struct SchedulePolicy {
+    /// Active time window; `None` means always active.
+    pub active_hours: Option<ActiveHours>,
+}
+
+/// Validated active hours window.
+#[derive(Debug)]
+pub struct ActiveHours {
+    /// Window start in validated `HH:MM` 24-hour format.
+    pub start: String,
+    /// Window end in validated `HH:MM` 24-hour format.
+    pub end: String,
+    /// IANA timezone name.
+    pub timezone: String,
+}
+```
+
+- [ ] **Step 11.4: Add document module to mod.rs**
+
+Add to `aa-gateway/src/policy/mod.rs`:
+```rust
+pub mod document;
+```
+
+- [ ] **Step 11.5: Run — verify tests pass**
+
+```bash
+cargo test -p aa-gateway -- policy::document
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 11.6: Commit**
+
+```bash
+git add aa-gateway/src/policy/document.rs aa-gateway/src/policy/mod.rs
+git commit -m "✨ (aa-gateway/policy): Add PolicyDocument and validated section structs"
+```
+
+---
+
+## Task 12: Add PolicyValidator skeleton with malformed YAML handling
+
+**Files:**
+- Create: `aa-gateway/src/policy/validator.rs`
+- Modify: `aa-gateway/src/policy/mod.rs`
+
+- [ ] **Step 12.1: Write the failing tests**
+
+Create `aa-gateway/src/policy/validator.rs` with:
+```rust
+//! Policy YAML parser and validator.
+
+use std::collections::HashMap;
+
+use crate::policy::{
+    document::{
+        ActiveHours, BudgetPolicy, DataPolicy, NetworkPolicy, PolicyDocument, SchedulePolicy,
+        ToolPolicy,
+    },
+    error::{ValidationError, ValidationWarning},
+    raw::RawPolicyDocument,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn malformed_yaml_returns_error_with_message() {
+        let yaml = "network:\n  allowlist: [\n";  // unclosed bracket
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].field, "<document>");
+        assert!(!errors[0].message.is_empty());
+    }
+
+    #[test]
+    fn malformed_yaml_error_has_line_hint() {
+        let yaml = "network:\n  allowlist: [\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        let errors = result.unwrap_err();
+        // serde_yaml 0.9 may or may not provide a line; just check it's plumbed
+        // (Some or None is both acceptable — this tests the path compiles)
+        let _ = errors[0].line;
+    }
+}
+```
+
+- [ ] **Step 12.2: Run — verify it fails**
+
+```bash
+cargo test -p aa-gateway -- policy::validator 2>&1 | head -10
+```
+
+Expected: compile error — `PolicyValidator` not found.
+
+- [ ] **Step 12.3: Implement PolicyValidator skeleton**
+
+Add above the `#[cfg(test)]` block in `validator.rs`:
+```rust
+/// Parses and validates a policy YAML document.
+pub struct PolicyValidator;
+
+impl PolicyValidator {
+    /// Parse a YAML string and return a validated [`PolicyDocument`].
+    ///
+    /// # Returns
+    /// - `Ok((doc, warnings))` — document is valid; `warnings` lists non-fatal unknown keys.
+    /// - `Err(errors)` — one or more field-level constraint violations.
+    pub fn from_yaml(
+        src: &str,
+    ) -> Result<(PolicyDocument, Vec<ValidationWarning>), Vec<ValidationError>> {
+        let raw: RawPolicyDocument = serde_yaml::from_str(src).map_err(|e| {
+            vec![ValidationError {
+                field: "<document>".to_string(),
+                message: e.to_string(),
+                line: e.location().map(|l| l.line() as u32),
+            }]
+        })?;
+        Self::validate(raw)
+    }
+
+    fn validate(
+        raw: RawPolicyDocument,
+    ) -> Result<(PolicyDocument, Vec<ValidationWarning>), Vec<ValidationError>> {
+        let mut errors: Vec<ValidationError> = Vec::new();
+        let mut warnings: Vec<ValidationWarning> = Vec::new();
+
+        let network = Self::validate_network(raw.network, &mut errors, &mut warnings);
+        let tools = Self::validate_tools(raw.tools, &mut errors, &mut warnings);
+        let data = Self::validate_data(raw.data, &mut errors, &mut warnings);
+        let budget = Self::validate_budget(raw.budget, &mut errors);
+        let schedule = Self::validate_schedule(raw.schedule, &mut errors, &mut warnings);
+
+        // Unknown top-level keys
+        for key in raw.unknown.keys() {
+            warnings.push(ValidationWarning::unknown_key(key));
+        }
+
+        if errors.is_empty() {
+            Ok((PolicyDocument { network, tools, data, budget, schedule }, warnings))
+        } else {
+            Err(errors)
+        }
+    }
+
+    fn validate_network(
+        raw: Option<crate::policy::raw::RawNetworkPolicy>,
+        _errors: &mut Vec<ValidationError>,
+        warnings: &mut Vec<ValidationWarning>,
+    ) -> NetworkPolicy {
+        let raw = match raw {
+            None => return NetworkPolicy { allowlist: vec![] },
+            Some(r) => r,
+        };
+        for key in raw.unknown.keys() {
+            warnings.push(ValidationWarning::unknown_key(&format!("network.{}", key)));
+        }
+        NetworkPolicy { allowlist: raw.allowlist.unwrap_or_default() }
+    }
+
+    fn validate_tools(
+        raw: Option<HashMap<String, crate::policy::raw::RawToolPolicy>>,
+        _errors: &mut Vec<ValidationError>,
+        warnings: &mut Vec<ValidationWarning>,
+    ) -> HashMap<String, ToolPolicy> {
+        let raw = match raw {
+            None => return HashMap::new(),
+            Some(r) => r,
+        };
+        let mut tools = HashMap::new();
+        for (name, tool) in raw {
+            for key in tool.unknown.keys() {
+                warnings.push(ValidationWarning::unknown_key(&format!("tools.{}.{}", name, key)));
+            }
+            tools.insert(name, ToolPolicy {
+                allow: tool.allow.unwrap_or(true),
+                limit_per_hour: tool.limit_per_hour,
+                requires_approval_if: tool.requires_approval_if,
+            });
+        }
+        tools
+    }
+
+    fn validate_data(
+        raw: Option<crate::policy::raw::RawDataPolicy>,
+        _errors: &mut Vec<ValidationError>,
+        warnings: &mut Vec<ValidationWarning>,
+    ) -> DataPolicy {
+        let raw = match raw {
+            None => return DataPolicy { sensitive_patterns: vec![] },
+            Some(r) => r,
+        };
+        for key in raw.unknown.keys() {
+            warnings.push(ValidationWarning::unknown_key(&format!("data.{}", key)));
+        }
+        DataPolicy { sensitive_patterns: raw.sensitive_patterns.unwrap_or_default() }
+    }
+
+    fn validate_budget(
+        raw: Option<crate::policy::raw::RawBudgetPolicy>,
+        _errors: &mut Vec<ValidationError>,
+    ) -> BudgetPolicy {
+        let raw = match raw {
+            None => return BudgetPolicy { daily_limit_usd: None },
+            Some(r) => r,
+        };
+        BudgetPolicy { daily_limit_usd: raw.daily_limit_usd }
+    }
+
+    fn validate_schedule(
+        raw: Option<crate::policy::raw::RawSchedulePolicy>,
+        _errors: &mut Vec<ValidationError>,
+        warnings: &mut Vec<ValidationWarning>,
+    ) -> SchedulePolicy {
+        let raw = match raw {
+            None => return SchedulePolicy { active_hours: None },
+            Some(r) => r,
+        };
+        for key in raw.unknown.keys() {
+            warnings.push(ValidationWarning::unknown_key(&format!("schedule.{}", key)));
+        }
+        let active_hours = raw.active_hours.map(|ah| {
+            for key in ah.unknown.keys() {
+                warnings.push(ValidationWarning::unknown_key(
+                    &format!("schedule.active_hours.{}", key),
+                ));
+            }
+            ActiveHours {
+                start: ah.start.unwrap_or_default(),
+                end: ah.end.unwrap_or_default(),
+                timezone: ah.timezone.unwrap_or_default(),
+            }
+        });
+        SchedulePolicy { active_hours }
+    }
+}
+```
+
+- [ ] **Step 12.4: Add validator module to mod.rs**
+
+Add to `aa-gateway/src/policy/mod.rs`:
+```rust
+pub mod validator;
+```
+
+- [ ] **Step 12.5: Run — verify tests pass**
+
+```bash
+cargo test -p aa-gateway -- policy::validator
+```
+
+Expected: 2 tests pass.
+
+- [ ] **Step 12.6: Commit**
+
+```bash
+git add aa-gateway/src/policy/validator.rs aa-gateway/src/policy/mod.rs
+git commit -m "✨ (aa-gateway/policy): Add PolicyValidator skeleton with malformed YAML handling"
+```
+
+---
+
+## Task 13: Implement unknown key warnings
+
+**Files:**
+- Modify: `aa-gateway/src/policy/validator.rs`
+
+The skeleton already collects unknown keys. This task adds tests to verify the behaviour.
+
+- [ ] **Step 13.1: Write the failing tests**
+
+Add to the `tests` module in `validator.rs`:
+```rust
+    #[test]
+    fn unknown_top_level_key_produces_warning() {
+        let yaml = "agent: support-agent\nversion: 2\n";
+        let (_, warnings) = PolicyValidator::from_yaml(yaml).unwrap();
+        let fields: Vec<&str> = warnings.iter().map(|w| w.field.as_str()).collect();
+        assert!(fields.contains(&"agent"), "expected 'agent' warning, got {:?}", fields);
+        assert!(fields.contains(&"version"), "expected 'version' warning, got {:?}", fields);
+    }
+
+    #[test]
+    fn unknown_nested_key_in_network_produces_warning() {
+        let yaml = "network:\n  allowlist:\n    - api.openai.com\n  blocklist:\n    - \"*\"\n";
+        let (_, warnings) = PolicyValidator::from_yaml(yaml).unwrap();
+        let fields: Vec<&str> = warnings.iter().map(|w| w.field.as_str()).collect();
+        assert!(fields.contains(&"network.blocklist"),
+            "expected 'network.blocklist' warning, got {:?}", fields);
+    }
+
+    #[test]
+    fn unknown_key_in_tool_produces_warning() {
+        let yaml = "tools:\n  query_db:\n    allow: true\n    constraint: \"read-only\"\n";
+        let (_, warnings) = PolicyValidator::from_yaml(yaml).unwrap();
+        let fields: Vec<&str> = warnings.iter().map(|w| w.field.as_str()).collect();
+        assert!(fields.iter().any(|f| f.contains("constraint")),
+            "expected constraint warning, got {:?}", fields);
+    }
+
+    #[test]
+    fn no_unknown_keys_produces_no_warnings() {
+        let yaml = "network:\n  allowlist:\n    - api.openai.com\n";
+        let (_, warnings) = PolicyValidator::from_yaml(yaml).unwrap();
+        assert!(warnings.is_empty(), "unexpected warnings: {:?}", warnings);
+    }
+```
+
+- [ ] **Step 13.2: Run — verify tests pass (skeleton already handles this)**
+
+```bash
+cargo test -p aa-gateway -- policy::validator
+```
+
+Expected: all 6 tests pass. If any fail, check the `validate` method is forwarding `unknown` keys for each section.
+
+- [ ] **Step 13.3: Commit**
+
+```bash
+git add aa-gateway/src/policy/validator.rs
+git commit -m "✅ (aa-gateway/policy): Add tests for unknown key ValidationWarning collection"
+```
+
+---
+
+## Task 14: Implement network section validation
+
+**Files:**
+- Modify: `aa-gateway/src/policy/validator.rs`
+
+- [ ] **Step 14.1: Write the failing test**
+
+Add to the `tests` module:
+```rust
+    #[test]
+    fn empty_string_in_allowlist_produces_error() {
+        let yaml = "network:\n  allowlist:\n    - api.openai.com\n    - \"\"\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(
+            errors.iter().any(|e| e.field.contains("allowlist")),
+            "expected allowlist error, got {:?}", errors
+        );
+    }
+```
+
+- [ ] **Step 14.2: Run — verify it fails**
+
+```bash
+cargo test -p aa-gateway -- policy::validator::tests::empty_string_in_allowlist 2>&1
+```
+
+Expected: FAIL — no error is returned yet.
+
+- [ ] **Step 14.3: Add allowlist validation to validate_network**
+
+Replace the `validate_network` method body in `validator.rs`:
+```rust
+    fn validate_network(
+        raw: Option<crate::policy::raw::RawNetworkPolicy>,
+        errors: &mut Vec<ValidationError>,
+        warnings: &mut Vec<ValidationWarning>,
+    ) -> NetworkPolicy {
+        let raw = match raw {
+            None => return NetworkPolicy { allowlist: vec![] },
+            Some(r) => r,
+        };
+        for key in raw.unknown.keys() {
+            warnings.push(ValidationWarning::unknown_key(&format!("network.{}", key)));
+        }
+        let allowlist = raw.allowlist.unwrap_or_default();
+        for (i, entry) in allowlist.iter().enumerate() {
+            if entry.is_empty() {
+                errors.push(ValidationError::new(
+                    format!("network.allowlist[{}]", i),
+                    "allowlist entry must not be empty",
+                ));
+            }
+        }
+        NetworkPolicy { allowlist }
+    }
+```
+
+- [ ] **Step 14.4: Run — verify test passes**
+
+```bash
+cargo test -p aa-gateway -- policy::validator
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 14.5: Commit**
+
+```bash
+git add aa-gateway/src/policy/validator.rs
+git commit -m "✨ (aa-gateway/policy): Implement network allowlist empty-entry validation"
+```
+
+---
+
+## Task 15: Implement tools section validation
+
+**Files:**
+- Modify: `aa-gateway/src/policy/validator.rs`
+
+- [ ] **Step 15.1: Write the failing tests**
+
+Add to the `tests` module:
+```rust
+    #[test]
+    fn tool_limit_per_hour_zero_produces_error() {
+        let yaml = "tools:\n  query_db:\n    allow: true\n    limit_per_hour: 0\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(
+            errors.iter().any(|e| e.field.contains("limit_per_hour")),
+            "expected limit_per_hour error, got {:?}", errors
+        );
+    }
+
+    #[test]
+    fn tool_requires_approval_if_empty_string_produces_error() {
+        let yaml = "tools:\n  send_email:\n    allow: true\n    requires_approval_if: \"\"\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(
+            errors.iter().any(|e| e.field.contains("requires_approval_if")),
+            "expected requires_approval_if error, got {:?}", errors
+        );
+    }
+```
+
+- [ ] **Step 15.2: Run — verify they fail**
+
+```bash
+cargo test -p aa-gateway -- policy::validator::tests::tool_limit 2>&1
+cargo test -p aa-gateway -- policy::validator::tests::tool_requires 2>&1
+```
+
+Expected: FAIL — no errors returned yet.
+
+- [ ] **Step 15.3: Add validation to validate_tools**
+
+Replace the `validate_tools` method body:
+```rust
+    fn validate_tools(
+        raw: Option<HashMap<String, crate::policy::raw::RawToolPolicy>>,
+        errors: &mut Vec<ValidationError>,
+        warnings: &mut Vec<ValidationWarning>,
+    ) -> HashMap<String, ToolPolicy> {
+        let raw = match raw {
+            None => return HashMap::new(),
+            Some(r) => r,
+        };
+        let mut tools = HashMap::new();
+        for (name, tool) in raw {
+            for key in tool.unknown.keys() {
+                warnings.push(ValidationWarning::unknown_key(
+                    &format!("tools.{}.{}", name, key),
+                ));
+            }
+            if let Some(limit) = tool.limit_per_hour {
+                if limit < 1 {
+                    errors.push(ValidationError::new(
+                        format!("tools.{}.limit_per_hour", name),
+                        "limit_per_hour must be >= 1",
+                    ));
+                }
+            }
+            if let Some(ref expr) = tool.requires_approval_if {
+                if expr.is_empty() {
+                    errors.push(ValidationError::new(
+                        format!("tools.{}.requires_approval_if", name),
+                        "requires_approval_if must not be empty when present",
+                    ));
+                }
+            }
+            tools.insert(name, ToolPolicy {
+                allow: tool.allow.unwrap_or(true),
+                limit_per_hour: tool.limit_per_hour,
+                requires_approval_if: tool.requires_approval_if,
+            });
+        }
+        tools
+    }
+```
+
+- [ ] **Step 15.4: Run — verify tests pass**
+
+```bash
+cargo test -p aa-gateway -- policy::validator
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 15.5: Commit**
+
+```bash
+git add aa-gateway/src/policy/validator.rs
+git commit -m "✨ (aa-gateway/policy): Implement tools limit_per_hour and requires_approval_if validation"
+```
+
+---
+
+## Task 16: Implement data section regex validation
+
+**Files:**
+- Modify: `aa-gateway/src/policy/validator.rs`
+
+- [ ] **Step 16.1: Write the failing test**
+
+Add to the `tests` module:
+```rust
+    #[test]
+    fn invalid_regex_in_sensitive_patterns_produces_error() {
+        let yaml = "data:\n  sensitive_patterns:\n    - \"sk-[valid]\"\n    - \"[invalid\"\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(
+            errors.iter().any(|e| e.field.contains("sensitive_patterns")),
+            "expected sensitive_patterns error, got {:?}", errors
+        );
+    }
+
+    #[test]
+    fn valid_regex_patterns_produce_no_error() {
+        let yaml = "data:\n  sensitive_patterns:\n    - \"sk-[a-zA-Z0-9]{48}\"\n    - \"\\\\b\\\\d{16}\\\\b\"\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_ok(), "unexpected error: {:?}", result.unwrap_err());
+    }
+```
+
+- [ ] **Step 16.2: Run — verify the invalid test fails**
+
+```bash
+cargo test -p aa-gateway -- policy::validator::tests::invalid_regex 2>&1
+```
+
+Expected: FAIL.
+
+- [ ] **Step 16.3: Add regex validation to validate_data**
+
+Add `use regex::Regex;` at the top of `validator.rs` (after the existing `use` statements).
+
+Replace the `validate_data` method body:
+```rust
+    fn validate_data(
+        raw: Option<crate::policy::raw::RawDataPolicy>,
+        errors: &mut Vec<ValidationError>,
+        warnings: &mut Vec<ValidationWarning>,
+    ) -> DataPolicy {
+        let raw = match raw {
+            None => return DataPolicy { sensitive_patterns: vec![] },
+            Some(r) => r,
+        };
+        for key in raw.unknown.keys() {
+            warnings.push(ValidationWarning::unknown_key(&format!("data.{}", key)));
+        }
+        let patterns = raw.sensitive_patterns.unwrap_or_default();
+        for (i, pattern) in patterns.iter().enumerate() {
+            if let Err(e) = Regex::new(pattern) {
+                errors.push(ValidationError::new(
+                    format!("data.sensitive_patterns[{}]", i),
+                    format!("invalid regex: {}", e),
+                ));
+            }
+        }
+        DataPolicy { sensitive_patterns: patterns }
+    }
+```
+
+- [ ] **Step 16.4: Run — verify tests pass**
+
+```bash
+cargo test -p aa-gateway -- policy::validator
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 16.5: Commit**
+
+```bash
+git add aa-gateway/src/policy/validator.rs
+git commit -m "✨ (aa-gateway/policy): Implement data sensitive_patterns regex validation"
+```
+
+---
+
+## Task 17: Implement budget section validation
+
+**Files:**
+- Modify: `aa-gateway/src/policy/validator.rs`
+
+- [ ] **Step 17.1: Write the failing tests**
+
+Add to the `tests` module:
+```rust
+    #[test]
+    fn budget_daily_limit_zero_produces_error() {
+        let yaml = "budget:\n  daily_limit_usd: 0\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(
+            errors.iter().any(|e| e.field == "budget.daily_limit_usd"),
+            "expected budget.daily_limit_usd error, got {:?}", errors
+        );
+    }
+
+    #[test]
+    fn budget_daily_limit_negative_produces_error() {
+        let yaml = "budget:\n  daily_limit_usd: -5.0\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn budget_absent_daily_limit_is_valid() {
+        let yaml = "budget: {}\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_ok());
+        let (doc, _) = result.unwrap();
+        assert_eq!(doc.budget.daily_limit_usd, None);
+    }
+```
+
+- [ ] **Step 17.2: Run — verify failing tests fail**
+
+```bash
+cargo test -p aa-gateway -- policy::validator::tests::budget 2>&1
+```
+
+Expected: `budget_daily_limit_zero_produces_error` and `budget_daily_limit_negative_produces_error` fail.
+
+- [ ] **Step 17.3: Add validation to validate_budget**
+
+Replace the `validate_budget` method body:
+```rust
+    fn validate_budget(
+        raw: Option<crate::policy::raw::RawBudgetPolicy>,
+        errors: &mut Vec<ValidationError>,
+    ) -> BudgetPolicy {
+        let raw = match raw {
+            None => return BudgetPolicy { daily_limit_usd: None },
+            Some(r) => r,
+        };
+        if let Some(limit) = raw.daily_limit_usd {
+            if limit <= 0.0 {
+                errors.push(ValidationError::new(
+                    "budget.daily_limit_usd",
+                    "daily_limit_usd must be > 0",
+                ));
+            }
+        }
+        BudgetPolicy { daily_limit_usd: raw.daily_limit_usd }
+    }
+```
+
+- [ ] **Step 17.4: Run — verify tests pass**
+
+```bash
+cargo test -p aa-gateway -- policy::validator
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 17.5: Commit**
+
+```bash
+git add aa-gateway/src/policy/validator.rs
+git commit -m "✨ (aa-gateway/policy): Implement budget daily_limit_usd > 0 validation"
+```
+
+---
+
+## Task 18: Implement schedule section validation
+
+**Files:**
+- Modify: `aa-gateway/src/policy/validator.rs`
+
+- [ ] **Step 18.1: Write the failing tests**
+
+Add to the `tests` module:
+```rust
+    #[test]
+    fn schedule_bad_time_format_produces_error() {
+        let yaml = "schedule:\n  active_hours:\n    start: \"9:00\"\n    end: \"18:00\"\n    timezone: \"UTC\"\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(
+            errors.iter().any(|e| e.field.contains("start")),
+            "expected start field error, got {:?}", errors
+        );
+    }
+
+    #[test]
+    fn schedule_end_before_start_produces_error() {
+        let yaml = "schedule:\n  active_hours:\n    start: \"18:00\"\n    end: \"09:00\"\n    timezone: \"UTC\"\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(
+            errors.iter().any(|e| e.field.contains("active_hours")),
+            "expected active_hours error, got {:?}", errors
+        );
+    }
+
+    #[test]
+    fn schedule_empty_timezone_produces_error() {
+        let yaml = "schedule:\n  active_hours:\n    start: \"09:00\"\n    end: \"18:00\"\n    timezone: \"\"\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(
+            errors.iter().any(|e| e.field.contains("timezone")),
+            "expected timezone error, got {:?}", errors
+        );
+    }
+
+    #[test]
+    fn schedule_valid_active_hours_produces_no_error() {
+        let yaml = "schedule:\n  active_hours:\n    start: \"09:00\"\n    end: \"18:00\"\n    timezone: \"Asia/Taipei\"\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_ok(), "unexpected error: {:?}", result.unwrap_err());
+        let (doc, _) = result.unwrap();
+        let ah = doc.schedule.active_hours.unwrap();
+        assert_eq!(ah.start, "09:00");
+        assert_eq!(ah.timezone, "Asia/Taipei");
+    }
+
+    #[test]
+    fn schedule_absent_produces_no_error() {
+        let yaml = "{}\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_ok());
+        let (doc, _) = result.unwrap();
+        assert!(doc.schedule.active_hours.is_none());
+    }
+```
+
+- [ ] **Step 18.2: Run — verify failing tests fail**
+
+```bash
+cargo test -p aa-gateway -- policy::validator::tests::schedule 2>&1
+```
+
+Expected: the three error-producing tests fail.
+
+- [ ] **Step 18.3: Add a HH:MM validation helper**
+
+Add above `validate_schedule` in `validator.rs`:
+```rust
+    /// Returns true if `t` matches `HH:MM` 24-hour format.
+    fn is_valid_hhmm(t: &str) -> bool {
+        if t.len() != 5 || t.as_bytes()[2] != b':' {
+            return false;
+        }
+        let (h, m) = (&t[..2], &t[3..]);
+        let hh: u8 = h.parse().unwrap_or(99);
+        let mm: u8 = m.parse().unwrap_or(99);
+        hh <= 23 && mm <= 59
+    }
+```
+
+- [ ] **Step 18.4: Add full validation to validate_schedule**
+
+Replace the `validate_schedule` method body:
+```rust
+    fn validate_schedule(
+        raw: Option<crate::policy::raw::RawSchedulePolicy>,
+        errors: &mut Vec<ValidationError>,
+        warnings: &mut Vec<ValidationWarning>,
+    ) -> SchedulePolicy {
+        let raw = match raw {
+            None => return SchedulePolicy { active_hours: None },
+            Some(r) => r,
+        };
+        for key in raw.unknown.keys() {
+            warnings.push(ValidationWarning::unknown_key(&format!("schedule.{}", key)));
+        }
+        let active_hours = raw.active_hours.map(|ah| {
+            for key in ah.unknown.keys() {
+                warnings.push(ValidationWarning::unknown_key(
+                    &format!("schedule.active_hours.{}", key),
+                ));
+            }
+            let start = ah.start.unwrap_or_default();
+            let end = ah.end.unwrap_or_default();
+            let timezone = ah.timezone.unwrap_or_default();
+
+            if !Self::is_valid_hhmm(&start) {
+                errors.push(ValidationError::new(
+                    "schedule.active_hours.start",
+                    format!("'{}' is not a valid HH:MM time (e.g. '09:00')", start),
+                ));
+            }
+            if !Self::is_valid_hhmm(&end) {
+                errors.push(ValidationError::new(
+                    "schedule.active_hours.end",
+                    format!("'{}' is not a valid HH:MM time (e.g. '18:00')", end),
+                ));
+            }
+            if Self::is_valid_hhmm(&start) && Self::is_valid_hhmm(&end) && end <= start {
+                errors.push(ValidationError::new(
+                    "schedule.active_hours",
+                    format!("end '{}' must be after start '{}'", end, start),
+                ));
+            }
+            if timezone.is_empty() {
+                errors.push(ValidationError::new(
+                    "schedule.active_hours.timezone",
+                    "timezone must not be empty",
+                ));
+            }
+            ActiveHours { start, end, timezone }
+        });
+        SchedulePolicy { active_hours }
+    }
+```
+
+- [ ] **Step 18.5: Run — verify all tests pass**
+
+```bash
+cargo test -p aa-gateway -- policy::validator
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 18.6: Commit**
+
+```bash
+git add aa-gateway/src/policy/validator.rs
+git commit -m "✨ (aa-gateway/policy): Implement schedule active_hours HH:MM and end>start validation"
+```
+
+---
+
+## Task 19: Add full-policy integration tests
+
+**Files:**
+- Modify: `aa-gateway/src/policy/validator.rs`
+
+These tests cover the acceptance criteria holistically.
+
+- [ ] **Step 19.1: Write integration tests**
+
+Add to the `tests` module:
+```rust
+    #[test]
+    fn valid_full_policy_parses_without_errors() {
+        let yaml = r#"
+network:
+  allowlist:
+    - api.openai.com
+    - slack.com
+tools:
+  query_db:
+    allow: true
+    limit_per_hour: 100
+  delete_record:
+    allow: false
+  process_refund:
+    allow: true
+    limit_per_hour: 10
+    requires_approval_if: "amount > 100"
+data:
+  sensitive_patterns:
+    - "sk-[a-zA-Z0-9]{48}"
+    - "\\b\\d{4}[- ]?\\d{4}[- ]?\\d{4}[- ]?\\d{4}\\b"
+budget:
+  daily_limit_usd: 50.0
+schedule:
+  active_hours:
+    start: "09:00"
+    end: "18:00"
+    timezone: "Asia/Taipei"
+"#;
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_ok(), "unexpected errors: {:?}", result.unwrap_err());
+        let (doc, warnings) = result.unwrap();
+        assert_eq!(doc.network.allowlist.len(), 2);
+        assert_eq!(doc.tools.len(), 3);
+        assert_eq!(doc.tools["delete_record"].allow, false);
+        assert_eq!(doc.data.sensitive_patterns.len(), 2);
+        assert_eq!(doc.budget.daily_limit_usd, Some(50.0));
+        let ah = doc.schedule.active_hours.unwrap();
+        assert_eq!(ah.timezone, "Asia/Taipei");
+        assert!(warnings.is_empty(), "unexpected warnings: {:?}", warnings);
+    }
+
+    #[test]
+    fn empty_document_is_valid_with_permissive_defaults() {
+        let yaml = "{}\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_ok(), "unexpected errors: {:?}", result.unwrap_err());
+        let (doc, warnings) = result.unwrap();
+        assert!(doc.network.allowlist.is_empty());
+        assert!(doc.tools.is_empty());
+        assert!(doc.data.sensitive_patterns.is_empty());
+        assert_eq!(doc.budget.daily_limit_usd, None);
+        assert!(doc.schedule.active_hours.is_none());
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn multiple_validation_errors_all_reported() {
+        let yaml = r#"
+budget:
+  daily_limit_usd: -1.0
+data:
+  sensitive_patterns:
+    - "[bad_regex"
+network:
+  allowlist:
+    - ""
+"#;
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.len() >= 3,
+            "expected at least 3 errors (budget + regex + allowlist), got {:?}", errors);
+    }
+```
+
+- [ ] **Step 19.2: Run — verify tests pass**
+
+```bash
+cargo test -p aa-gateway -- policy::validator
+```
+
+Expected: all tests pass (20+ tests total).
+
+- [ ] **Step 19.3: Run the full gateway test suite**
+
+```bash
+cargo test -p aa-gateway
+```
+
+Expected: all tests pass, no regressions.
+
+- [ ] **Step 19.4: Run clippy**
+
+```bash
+cargo clippy -p aa-gateway -- -D warnings
+```
+
+Fix any warnings before committing.
+
+- [ ] **Step 19.5: Commit**
+
+```bash
+git add aa-gateway/src/policy/validator.rs
+git commit -m "✅ (aa-gateway/policy): Add full-policy integration tests and permissive-defaults test"
+```
+
+---
+
+## Task 20: Wire public API surface in policy/mod.rs
+
+**Files:**
+- Modify: `aa-gateway/src/policy/mod.rs`
+
+- [ ] **Step 20.1: Re-export key types**
+
+Replace the content of `aa-gateway/src/policy/mod.rs` with:
+```rust
+//! Policy YAML parser and validator for aa-gateway.
+//!
+//! # Quick start
+//!
+//! ```rust
+//! use aa_gateway::policy::validator::PolicyValidator;
+//!
+//! let yaml = include_str!("../../policy-examples/low-risk.yaml");
+//! // Note: the policy-examples use an older format; pass a v1 schema YAML here.
+//! ```
+//!
+//! Entry point: [`validator::PolicyValidator::from_yaml`].
+
+pub mod document;
+pub mod error;
+pub mod raw;
+pub mod validator;
+
+pub use document::PolicyDocument;
+pub use error::{ValidationError, ValidationWarning};
+pub use validator::PolicyValidator;
+```
+
+- [ ] **Step 20.2: Verify the crate compiles cleanly**
+
+```bash
+cargo build -p aa-gateway
+cargo clippy -p aa-gateway -- -D warnings
+```
+
+Expected: zero errors, zero warnings.
+
+- [ ] **Step 20.3: Run the full test suite one final time**
+
+```bash
+cargo test -p aa-gateway
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 20.4: Commit**
+
+```bash
+git add aa-gateway/src/policy/mod.rs
+git commit -m "♻️ (aa-gateway/policy): Re-export PolicyDocument, ValidationError, PolicyValidator from policy module"
+```
+
+---
+
+## Summary
+
+| Task | Commit message | Files |
+|---|---|---|
+| 1 | `⬆️ (aa-gateway): Add serde_yaml, serde derive, and regex dependencies` | Cargo.toml |
+| 2 | `✨ (aa-gateway/policy): Add empty policy module` | lib.rs, policy/mod.rs |
+| 3 | `✨ (aa-gateway/policy): Add ValidationError struct` | error.rs, mod.rs |
+| 4 | `✨ (aa-gateway/policy): Add ValidationWarning struct` | error.rs |
+| 5 | `✨ (aa-gateway/policy): Add RawNetworkPolicy serde target` | raw.rs, mod.rs |
+| 6 | `✨ (aa-gateway/policy): Add RawToolPolicy serde target` | raw.rs |
+| 7 | `✨ (aa-gateway/policy): Add RawDataPolicy serde target` | raw.rs |
+| 8 | `✨ (aa-gateway/policy): Add RawBudgetPolicy serde target` | raw.rs |
+| 9 | `✨ (aa-gateway/policy): Add RawSchedulePolicy and RawActiveHours serde targets` | raw.rs |
+| 10 | `✨ (aa-gateway/policy): Add RawPolicyDocument top-level serde target` | raw.rs |
+| 11 | `✨ (aa-gateway/policy): Add PolicyDocument and validated section structs` | document.rs, mod.rs |
+| 12 | `✨ (aa-gateway/policy): Add PolicyValidator skeleton with malformed YAML handling` | validator.rs, mod.rs |
+| 13 | `✅ (aa-gateway/policy): Add tests for unknown key ValidationWarning collection` | validator.rs |
+| 14 | `✨ (aa-gateway/policy): Implement network allowlist empty-entry validation` | validator.rs |
+| 15 | `✨ (aa-gateway/policy): Implement tools limit_per_hour and requires_approval_if validation` | validator.rs |
+| 16 | `✨ (aa-gateway/policy): Implement data sensitive_patterns regex validation` | validator.rs |
+| 17 | `✨ (aa-gateway/policy): Implement budget daily_limit_usd > 0 validation` | validator.rs |
+| 18 | `✨ (aa-gateway/policy): Implement schedule active_hours HH:MM and end>start validation` | validator.rs |
+| 19 | `✅ (aa-gateway/policy): Add full-policy integration tests and permissive-defaults test` | validator.rs |
+| 20 | `♻️ (aa-gateway/policy): Re-export PolicyDocument, ValidationError, PolicyValidator from policy module` | mod.rs |

--- a/docs/superpowers/specs/2026-04-28-aaasm-69-policy-yaml-parser-design.md
+++ b/docs/superpowers/specs/2026-04-28-aaasm-69-policy-yaml-parser-design.md
@@ -1,0 +1,240 @@
+# AAASM-69 — Policy YAML Parser & Typed Validator Design
+
+**Date:** 2026-04-28  
+**Ticket:** [AAASM-69](https://lightning-dust-mite.atlassian.net/browse/AAASM-69)  
+**Epic:** [AAASM-8](https://lightning-dust-mite.atlassian.net/browse/AAASM-8) — Governance Gateway & Policy Engine  
+**Status:** Approved
+
+---
+
+## Problem Statement
+
+`aa-gateway` needs to load human-readable YAML policy files and convert them into validated, typed Rust structs that the evaluation engine can act on. The parser must produce structured errors with field-level detail and surface unknown keys as warnings rather than hard failures.
+
+---
+
+## Architectural Boundary Decision
+
+`aa-core::policy::PolicyDocument` remains the **minimal, `no_std`-compatible stub** used at the `PolicyEvaluator` trait boundary (AAASM-23). It will not be extended with YAML-specific fields.
+
+`aa-gateway` owns the **full, rich `PolicyDocument`** with all five policy sections. This is where `serde_yaml` lives — `aa-core` must stay `no_std` and cannot depend on a std-only YAML parser.
+
+---
+
+## Module Layout
+
+```
+aa-gateway/src/
+  lib.rs                  ← pub mod policy
+  policy/
+    mod.rs                ← pub use of key public types
+    error.rs              ← ValidationError, ValidationWarning
+    raw.rs                ← RawPolicyDocument + Raw* section structs (serde targets)
+    document.rs           ← PolicyDocument + validated section structs
+    validator.rs          ← PolicyValidator::from_yaml()
+```
+
+---
+
+## Dependencies
+
+Added to `aa-gateway/Cargo.toml`:
+
+| Crate | Version | Purpose |
+|---|---|---|
+| `serde` | `1` | Derive macros for `Deserialize` on Raw* structs |
+| `serde_yaml` | `0.9` | YAML deserialization |
+| `regex` | `1` | Compile-and-validate regex patterns in `data.sensitive_patterns` |
+
+---
+
+## Types
+
+### `ValidationError` and `ValidationWarning` (`error.rs`)
+
+```rust
+pub struct ValidationError {
+    /// Dot-notation field path, e.g. "budget.daily_limit_usd"
+    pub field: String,
+    /// Human-readable description of the constraint that was violated
+    pub message: String,
+    /// Best-effort line number from the YAML source (None if not determinable)
+    pub line: Option<u32>,
+}
+
+pub struct ValidationWarning {
+    /// The unknown key name (top-level or section-level)
+    pub field: String,
+    pub message: String,
+}
+```
+
+### `RawPolicyDocument` (`raw.rs`)
+
+Unvalidated serde deserialization target. All sections are `Option<T>` (absent sections are valid — they default to permissive). Unknown keys at the document level are captured via `#[serde(flatten)]` into a `HashMap<String, serde_yaml::Value>` and converted to `ValidationWarning` by the validator.
+
+```rust
+#[derive(Debug, Deserialize)]
+pub struct RawPolicyDocument {
+    pub network:  Option<RawNetworkPolicy>,
+    pub tools:    Option<HashMap<String, RawToolPolicy>>,
+    pub data:     Option<RawDataPolicy>,
+    pub budget:   Option<RawBudgetPolicy>,
+    pub schedule: Option<RawSchedulePolicy>,
+    #[serde(flatten)]
+    pub unknown:  HashMap<String, serde_yaml::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RawNetworkPolicy {
+    pub allowlist: Option<Vec<String>>,
+    #[serde(flatten)]
+    pub unknown: HashMap<String, serde_yaml::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RawToolPolicy {
+    pub allow:               Option<bool>,
+    pub limit_per_hour:      Option<u32>,
+    pub requires_approval_if: Option<String>,
+    #[serde(flatten)]
+    pub unknown: HashMap<String, serde_yaml::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RawDataPolicy {
+    pub sensitive_patterns: Option<Vec<String>>,
+    #[serde(flatten)]
+    pub unknown: HashMap<String, serde_yaml::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RawBudgetPolicy {
+    pub daily_limit_usd: Option<f64>,
+    #[serde(flatten)]
+    pub unknown: HashMap<String, serde_yaml::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RawSchedulePolicy {
+    pub active_hours: Option<RawActiveHours>,
+    #[serde(flatten)]
+    pub unknown: HashMap<String, serde_yaml::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RawActiveHours {
+    pub start:    Option<String>,
+    pub end:      Option<String>,
+    pub timezone: Option<String>,
+    #[serde(flatten)]
+    pub unknown: HashMap<String, serde_yaml::Value>,
+}
+```
+
+### `PolicyDocument` (`document.rs`)
+
+Fully validated output. All sections present (defaulting to empty/permissive when absent in YAML).
+
+```rust
+pub struct PolicyDocument {
+    pub network:  NetworkPolicy,
+    pub tools:    HashMap<String, ToolPolicy>,
+    pub data:     DataPolicy,
+    pub budget:   BudgetPolicy,
+    pub schedule: SchedulePolicy,
+}
+
+pub struct NetworkPolicy   { pub allowlist: Vec<String> }
+pub struct ToolPolicy      { pub allow: bool, pub limit_per_hour: Option<u32>, pub requires_approval_if: Option<String> }
+pub struct DataPolicy      { pub sensitive_patterns: Vec<String> }
+pub struct BudgetPolicy    { pub daily_limit_usd: Option<f64> }
+pub struct SchedulePolicy  { pub active_hours: Option<ActiveHours> }
+pub struct ActiveHours     { pub start: String, pub end: String, pub timezone: String }
+```
+
+### `PolicyValidator` (`validator.rs`)
+
+```rust
+pub struct PolicyValidator;
+
+impl PolicyValidator {
+    /// Parse YAML source and return a validated PolicyDocument.
+    ///
+    /// Returns Ok((doc, warnings)) on success — warnings are non-fatal.
+    /// Returns Err(errors) if any field-level constraint is violated.
+    pub fn from_yaml(src: &str)
+        -> Result<(PolicyDocument, Vec<ValidationWarning>), Vec<ValidationError>>;
+}
+```
+
+The method:
+1. Calls `serde_yaml::from_str::<RawPolicyDocument>(src)` — malformed YAML returns a single `ValidationError` with the serde_yaml error message and best-effort line number.
+2. Calls `Self::validate(raw)` which:
+   - Collects `ValidationWarning` for every key in any `unknown` remainder map.
+   - Validates each field per the rules below.
+   - Returns `Err(errors)` if `errors` is non-empty, otherwise `Ok((doc, warnings))`.
+
+---
+
+## Validation Rules
+
+| Field path | Constraint | Error on violation |
+|---|---|---|
+| `network.allowlist[i]` | non-empty string | `ValidationError` |
+| `tools.<name>.limit_per_hour` | `>= 1` if present | `ValidationError` |
+| `tools.<name>.requires_approval_if` | non-empty if present | `ValidationError` |
+| `data.sensitive_patterns[i]` | valid `regex::Regex` | `ValidationError` |
+| `budget.daily_limit_usd` | `> 0.0` if present | `ValidationError` |
+| `schedule.active_hours.start` | matches `^([01]\d\|2[0-3]):[0-5]\d$` | `ValidationError` |
+| `schedule.active_hours.end` | same pattern; must be after `start` | `ValidationError` |
+| `schedule.active_hours.timezone` | non-empty | `ValidationError` |
+| any unknown key at any level | emit `ValidationWarning` | (non-fatal) |
+
+---
+
+## Data Flow
+
+```
+&str (YAML source)
+  │
+  ▼
+serde_yaml::from_str::<RawPolicyDocument>
+  │  malformed → Vec<ValidationError> (single entry with line hint)
+  ▼
+PolicyValidator::validate(raw: RawPolicyDocument)
+  │  field errors → Vec<ValidationError>
+  │  unknown keys → Vec<ValidationWarning>
+  ▼
+Result<(PolicyDocument, Vec<ValidationWarning>), Vec<ValidationError>>
+```
+
+---
+
+## Testing Strategy
+
+All tests live in `validator.rs` as `#[cfg(test)]` inline tests.
+
+| Test name | What it covers |
+|---|---|
+| `valid_full_policy` | All 5 sections present and valid → `Ok` with no warnings |
+| `absent_sections_default_permissive` | Empty YAML `{}` → `Ok`, all defaults |
+| `invalid_budget_zero` | `budget.daily_limit_usd: 0` → `ValidationError` on that field |
+| `invalid_budget_negative` | Negative budget → `ValidationError` |
+| `invalid_regex_pattern` | Bad regex in `data.sensitive_patterns` → `ValidationError` |
+| `invalid_schedule_time_format` | `start: "9:00"` (missing leading zero) → `ValidationError` |
+| `invalid_schedule_end_before_start` | `end < start` → `ValidationError` |
+| `empty_allowlist_entry` | Empty string in `allowlist` → `ValidationError` |
+| `tool_limit_zero` | `limit_per_hour: 0` → `ValidationError` |
+| `unknown_top_level_key` | Extra key at root level → `ValidationWarning` |
+| `unknown_nested_key` | Extra key inside `network` → `ValidationWarning` |
+| `malformed_yaml` | Invalid YAML syntax → `Err` with line hint |
+
+---
+
+## Out of Scope for AAASM-69
+
+- CEL expression parsing for `requires_approval_if` (expression stored as opaque `String`)
+- `network.blocklist` (Epic AAASM-8 shows it but AAASM-69 requirements omit it — deferred)
+- `data.can_access_pii`, `pii_must_not_leave` fields (deferred to policy evaluation tickets)
+- Wiring `PolicyValidator` into the evaluation engine (AAASM-70)


### PR DESCRIPTION
## Description

Sets up the shared eBPF cross-compilation infrastructure for the `aa-ebpf` crate — the foundation required by AAASM-37, AAASM-38, and AAASM-39 before any real BPF probes can be written.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-132
- Parent Epic: AAASM-4 (Three-Layer Agent Interception)
- Blocks: AAASM-37, AAASM-38, AAASM-39

## What changed

- **`aa-ebpf-probes/`** (new, outside workspace): dedicated BPF-side crate with `aya-ebpf` + `aya-log-ebpf`, `rust-toolchain.toml` (nightly), `.cargo/config.toml` (target = `bpfel-unknown-none`), and a hello-world kprobe skeleton on `__x64_sys_write`
- **`aa-ebpf/build.rs`** (new): invokes `aya-build` to compile the probes crate on Linux; gated with `#[cfg(target_os = "linux")]` so macOS builds are unaffected
- **`aa-ebpf/Cargo.toml`**: adds `aya` + `aya-log` as Linux-only runtime deps, `aya-build` as build-dep
- **`aa-ebpf/src/lib.rs`**: exposes `AA_HELLO_BPF` constant (`include_bytes_aligned!`) gated on `cfg(target_os = "linux")`
- **`.github/workflows/ci.yml`**: adds `ebpf-build` job (Linux nightly, `bpfel-unknown-none`, clippy)
- **`aa-ebpf/README.md`**: build instructions, kernel version requirements, CO-RE notes, guide for adding new probes

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

`cargo check -p aa-ebpf` passes cleanly on macOS (stable). BPF compilation on Linux is validated by the new `ebpf-build` CI job. All 178 existing workspace tests continue to pass.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention