### PR TITLE
[AAASM-129] 🐛 (examples): Replace unresolvable placeholder image with alpine stub

### DIFF
--- a/examples/docker-compose/README.md
+++ b/examples/docker-compose/README.md
@@ -1,0 +1,52 @@
+# aa-runtime docker-compose example
+
+Demonstrates running `aa-runtime` as a sidecar alongside an agent container,
+connected via a shared Unix domain socket.
+
+## Prerequisites
+
+- Docker and Docker Compose v2
+- An Agent Assembly API key (`AA_API_KEY`)
+
+## Running the example
+
+```bash
+AA_API_KEY=<your-key> docker compose up
+```
+
+`aa-runtime` will start, expose the IPC socket at `/tmp/aa-runtime-my-agent-001.sock`,
+and serve health/metrics at `http://localhost:8080`.
+
+## Agent placeholder
+
+> **Python SDK not yet available.** The `agent-stub` service is an `alpine` placeholder.
+> Replace it with your agent image once the Python SDK (`aa-sdk`) is published
+> (tracked in AAASM-55). The socket mount and `AA_AGENT_ID` env var must be
+> preserved in your replacement.
+
+To swap in your own agent:
+
+1. Replace the `agent-stub` service's `image:` with your agent image
+   (or use `build: ./your-agent` to build locally).
+2. Keep `AA_AGENT_ID` identical in both `aa-runtime` and your agent service.
+3. Keep the `aa-runtime-socket` volume mount at `/tmp` — the IPC socket lives at
+   `/tmp/aa-runtime-<AA_AGENT_ID>.sock`.
+
+## Policy enforcement (optional)
+
+Uncomment the policy volume mount in `docker-compose.yml` to load a policy file:
+
+```yaml
+volumes:
+  - ./policy.toml:/etc/aa/policy.toml:ro
+```
+
+See `../policy.toml` for an example policy.
+
+## Health check
+
+```bash
+curl http://localhost:8080/health
+curl http://localhost:8080/ready
+curl http://localhost:8080/metrics
+```

--- a/examples/docker-compose/docker-compose.yml
+++ b/examples/docker-compose/docker-compose.yml
@@ -28,9 +28,18 @@ services:
       retries: 5
       start_period: 2s
 
-  your-agent:
-    # Replace 'your-org/your-agent:latest' with your agent image.
-    image: your-org/your-agent:latest
+  agent-stub:
+    # Placeholder agent — demonstrates sidecar wiring without requiring a real agent image.
+    #
+    # The Python SDK (aa-sdk) is not yet published; a real LangChain example will be
+    # added once it ships (tracked in AAASM-55).
+    #
+    # To use your own agent:
+    #   1. Replace 'image: alpine:latest' with your agent image (or add a 'build:' key).
+    #   2. Keep the AA_AGENT_ID value identical to the aa-runtime service.
+    #   3. Keep the aa-runtime-socket volume mount at /tmp — the IPC socket lives there.
+    image: alpine:latest
+    command: ["sh", "-c", "echo 'agent-stub: replace this service with your agent (see README)' && sleep infinity"]
     restart: unless-stopped
     depends_on:
       aa-runtime:


### PR DESCRIPTION
## Summary

- Replaces `your-org/your-agent:latest` (unresolvable image) with `alpine:latest` + `sleep infinity` so `docker compose up` runs without errors out of the box.
- Renames the service from `your-agent` to `agent-stub` to make its placeholder role explicit.
- Adds inline comments explaining that the Python SDK (`aa-sdk`) is not yet published and pointing to AAASM-55, plus instructions for swapping in a real agent image.
- Adds `examples/docker-compose/README.md` with prerequisites, run instructions, and the SDK-not-yet-available notice.

## Why

`docker compose up` was failing immediately because `your-org/your-agent:latest` does not exist in any registry. This is the primary onboarding example; it must run. The real LangChain integration example is deferred to AAASM-55 (Python SDK).

## How to verify

```bash
cd examples/docker-compose
docker compose up
# aa-runtime starts and serves /health, /ready, /metrics on :8080
# agent-stub prints its message and idles (no image pull failure)
```

## Related

Closes AAASM-129 / parent story AAASM-27 (AC5)