### PR TITLE
[AAASM-130] ✨ ipc: Wire ViolationAlert pushback to originating SDK connections

### DIFF
--- a/aa-runtime/src/health/mod.rs
+++ b/aa-runtime/src/health/mod.rs
@@ -19,7 +19,7 @@ pub struct HealthState {
     pub ready_rx: watch::Receiver<bool>,
     pub prometheus_handle: PrometheusHandle,
     pub active_connections: Arc<AtomicI64>,
-    pub inbound_tx: mpsc::Sender<IpcFrame>,
+    pub inbound_tx: mpsc::Sender<(u64, IpcFrame)>,
 }
 
 /// Response body for GET /health.

--- a/aa-runtime/src/ipc/codec.rs
+++ b/aa-runtime/src/ipc/codec.rs
@@ -18,7 +18,9 @@ use prost::Message;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::ipc::message::{IpcFrame, IpcResponse};
-use aa_proto::assembly::audit::v1::{AuditEvent, PolicyViolation};
+use aa_proto::assembly::audit::v1::AuditEvent;
+#[cfg(test)]
+use aa_proto::assembly::audit::v1::PolicyViolation;
 use aa_proto::assembly::event::v1::ApprovalDecision;
 use aa_proto::assembly::policy::v1::CheckActionRequest;
 #[cfg(test)]

--- a/aa-runtime/src/ipc/codec.rs
+++ b/aa-runtime/src/ipc/codec.rs
@@ -12,12 +12,13 @@
 //!   1 = PolicyResponse   (CheckActionResponse)
 //!   2 = ApprovalDecision (ApprovalDecision)
 //!   3 = Ack              (zero-length varint + empty body: [0x03][0x00])
+//!   4 = ViolationAlert   (PolicyViolation)
 
 use prost::Message;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::ipc::message::{IpcFrame, IpcResponse};
-use aa_proto::assembly::audit::v1::AuditEvent;
+use aa_proto::assembly::audit::v1::{AuditEvent, PolicyViolation};
 use aa_proto::assembly::event::v1::ApprovalDecision;
 use aa_proto::assembly::policy::v1::CheckActionRequest;
 #[cfg(test)]
@@ -35,6 +36,7 @@ pub const TAG_HEARTBEAT: u8 = 4;
 pub const TAG_POLICY_RESPONSE: u8 = 1;
 pub const TAG_APPROVAL_DECISION: u8 = 2;
 pub const TAG_ACK: u8 = 3;
+pub const TAG_VIOLATION_ALERT: u8 = 4;
 
 /// Errors that can occur during frame encoding or decoding.
 #[derive(Debug)]
@@ -115,6 +117,11 @@ where
         }
         IpcResponse::ApprovalDecision(msg) => {
             writer.write_u8(TAG_APPROVAL_DECISION).await?;
+            let bytes = msg.encode_to_vec();
+            write_length_delimited(writer, &bytes).await?;
+        }
+        IpcResponse::ViolationAlert(msg) => {
+            writer.write_u8(TAG_VIOLATION_ALERT).await?;
             let bytes = msg.encode_to_vec();
             write_length_delimited(writer, &bytes).await?;
         }
@@ -349,5 +356,31 @@ mod tests {
         let mut cursor = Cursor::new(buf);
         let result = read_frame(&mut cursor).await;
         assert!(matches!(result, Err(CodecError::UnknownTag(99))));
+    }
+
+    #[tokio::test]
+    async fn violation_alert_encodes_with_correct_tag_and_decodes() {
+        let violation = PolicyViolation {
+            policy_rule: "block-files".to_string(),
+            blocked_action: "FILE_OPERATION".to_string(),
+            reason: "file access not permitted".to_string(),
+        };
+
+        let bytes = encode_response(IpcResponse::ViolationAlert(violation)).await;
+
+        // Tag must be TAG_VIOLATION_ALERT.
+        assert_eq!(bytes[0], TAG_VIOLATION_ALERT);
+
+        // Decode payload back.
+        let mut cursor = Cursor::new(&bytes[1..]);
+        let len = read_varint(&mut cursor).await.unwrap() as usize;
+        let varint_bytes = cursor.position() as usize;
+        let payload_start = 1 + varint_bytes;
+        let payload = &bytes[payload_start..payload_start + len];
+        let decoded = PolicyViolation::decode(payload).unwrap();
+
+        assert_eq!(decoded.policy_rule, "block-files");
+        assert_eq!(decoded.blocked_action, "FILE_OPERATION");
+        assert_eq!(decoded.reason, "file access not permitted");
     }
 }

--- a/aa-runtime/src/ipc/message.rs
+++ b/aa-runtime/src/ipc/message.rs
@@ -26,6 +26,7 @@ pub enum IpcFrame {
     Heartbeat,
 }
 
+use aa_proto::assembly::audit::v1::PolicyViolation;
 use aa_proto::assembly::policy::v1::CheckActionResponse;
 
 /// A message sent from the runtime back to an SDK process over the Unix socket.
@@ -34,6 +35,7 @@ use aa_proto::assembly::policy::v1::CheckActionResponse;
 /// - `1` = PolicyResponse
 /// - `2` = ApprovalDecision (async push when a PENDING decision resolves)
 /// - `3` = Ack
+/// - `4` = ViolationAlert (runtime pushes a policy violation back to the originating SDK)
 #[derive(Debug)]
 pub enum IpcResponse {
     /// The policy engine's verdict for a `PolicyQuery`.
@@ -43,4 +45,7 @@ pub enum IpcResponse {
     ApprovalDecision(ApprovalDecision),
     /// Acknowledgement of a received `EventReport` or `Heartbeat`.
     Ack,
+    /// Runtime-initiated push: a policy violation was detected on an event
+    /// submitted by this connection. Contains the full `PolicyViolation` proto.
+    ViolationAlert(PolicyViolation),
 }

--- a/aa-runtime/src/ipc/mod.rs
+++ b/aa-runtime/src/ipc/mod.rs
@@ -6,3 +6,19 @@ pub mod server;
 
 pub use message::{IpcFrame, IpcResponse};
 pub use server::IpcServer;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::{mpsc, RwLock};
+
+/// Shared map from connection ID to the per-connection outbound response sender.
+///
+/// The IPC server inserts an entry when a connection is accepted and removes it
+/// when the connection closes. The pipeline reads from this map to route
+/// `IpcResponse::ViolationAlert` back to the originating SDK client.
+pub type ResponseRouter = Arc<RwLock<HashMap<u64, mpsc::Sender<IpcResponse>>>>;
+
+/// Create an empty [`ResponseRouter`].
+pub fn new_response_router() -> ResponseRouter {
+    Arc::new(RwLock::new(HashMap::new()))
+}

--- a/aa-runtime/src/ipc/server.rs
+++ b/aa-runtime/src/ipc/server.rs
@@ -184,7 +184,15 @@ pub(super) fn spawn_connection(
     let reader_frame_tx = frame_tx;
     tracker.spawn(async move {
         let _permit = permit; // held until reader task completes
-        run_reader(read_half, reader_frame_tx, reader_token, active_connections, connection_id, response_router).await;
+        run_reader(
+            read_half,
+            reader_frame_tx,
+            reader_token,
+            active_connections,
+            connection_id,
+            response_router,
+        )
+        .await;
     });
 
     // Writer task: outbound responses → socket.
@@ -315,7 +323,9 @@ mod tests {
         let tracker = TaskTracker::new();
         let tracker_clone = tracker.clone();
         tracker.spawn(async move {
-            server.run(tracker_clone, token, tx, active_connections, router_clone).await;
+            server
+                .run(tracker_clone, token, tx, active_connections, router_clone)
+                .await;
         });
         (rx, router)
     }
@@ -598,7 +608,10 @@ mod tests {
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
         }
-        assert_eq!(observed_len, 0, "router entry should be removed after client disconnects");
+        assert_eq!(
+            observed_len, 0,
+            "router entry should be removed after client disconnects"
+        );
 
         token.cancel();
     }
@@ -618,8 +631,7 @@ mod tests {
         let socket_path = temp_socket_path("violation-alert");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let (inbound_rx, router) =
-            start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (inbound_rx, router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         // Spin up the pipeline.
         let pipeline_config = PipelineConfig {
@@ -630,8 +642,7 @@ mod tests {
             agent_id: "test-agent".to_string(),
         };
         let pipeline_metrics = Arc::new(PipelineMetrics::default());
-        let (broadcast_tx, _broadcast_rx) =
-            tokio::sync::broadcast::channel::<crate::pipeline::EnrichedEvent>(64);
+        let (broadcast_tx, _broadcast_rx) = tokio::sync::broadcast::channel::<crate::pipeline::EnrichedEvent>(64);
         let pipeline_router = Arc::clone(&router);
         let pipeline_token = token.clone();
         tokio::spawn(crate::pipeline::run(
@@ -708,8 +719,7 @@ mod tests {
         let socket_path = temp_socket_path("no-alert");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let (inbound_rx, router) =
-            start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (inbound_rx, router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         // Spin up the pipeline.
         let pipeline_config = PipelineConfig {
@@ -720,8 +730,7 @@ mod tests {
             agent_id: "test-agent".to_string(),
         };
         let pipeline_metrics = Arc::new(PipelineMetrics::default());
-        let (broadcast_tx, _broadcast_rx) =
-            tokio::sync::broadcast::channel::<crate::pipeline::EnrichedEvent>(64);
+        let (broadcast_tx, _broadcast_rx) = tokio::sync::broadcast::channel::<crate::pipeline::EnrichedEvent>(64);
         let pipeline_router = Arc::clone(&router);
         let pipeline_token = token.clone();
         tokio::spawn(crate::pipeline::run(
@@ -765,8 +774,7 @@ mod tests {
         write_half.flush().await.unwrap();
 
         // No ViolationAlert should arrive — read should time out.
-        let result =
-            tokio::time::timeout(Duration::from_millis(100), read_half.read_u8()).await;
+        let result = tokio::time::timeout(Duration::from_millis(100), read_half.read_u8()).await;
         assert!(
             result.is_err(),
             "expected no response for a normal event, but received one"

--- a/aa-runtime/src/ipc/server.rs
+++ b/aa-runtime/src/ipc/server.rs
@@ -602,4 +602,176 @@ mod tests {
 
         token.cancel();
     }
+
+    /// Spin up an IPC server + pipeline and verify that a violation EventReport
+    /// results in a ViolationAlert (tag 4) arriving on the same connection
+    /// within 100 ms.
+    #[tokio::test]
+    async fn violation_event_triggers_alert_within_100ms() {
+        use crate::ipc::codec::{TAG_EVENT_REPORT, TAG_VIOLATION_ALERT};
+        use crate::pipeline::{PipelineConfig, PipelineMetrics};
+        use aa_proto::assembly::audit::v1::{audit_event::Detail, PolicyViolation};
+        use prost::Message;
+        use std::sync::Arc;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let socket_path = temp_socket_path("violation-alert");
+        let token = CancellationToken::new();
+        let counter = Arc::new(AtomicI64::new(0));
+        let (inbound_rx, router) =
+            start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+
+        // Spin up the pipeline.
+        let pipeline_config = PipelineConfig {
+            input_buffer: 64,
+            batch_size: 100,
+            flush_interval: std::time::Duration::from_secs(60),
+            broadcast_capacity: 64,
+            agent_id: "test-agent".to_string(),
+        };
+        let pipeline_metrics = Arc::new(PipelineMetrics::default());
+        let (broadcast_tx, _broadcast_rx) =
+            tokio::sync::broadcast::channel::<crate::pipeline::EnrichedEvent>(64);
+        let pipeline_router = Arc::clone(&router);
+        let pipeline_token = token.clone();
+        tokio::spawn(crate::pipeline::run(
+            inbound_rx,
+            broadcast_tx,
+            pipeline_config,
+            pipeline_metrics,
+            pipeline_token,
+            Arc::new(crate::policy::PolicyRules::default()),
+            pipeline_router,
+        ));
+
+        // Connect a client.
+        let client = connect_client(&socket_path).await;
+        let (mut read_half, mut write_half) = client.into_split();
+
+        // Wait for the connection to be registered.
+        for _ in 0..50 {
+            if counter.load(Ordering::Relaxed) == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        // Build a PolicyViolation event.
+        let violation = PolicyViolation {
+            policy_rule: "test-rule".to_string(),
+            blocked_action: "FILE_OPERATION".to_string(),
+            reason: "blocked".to_string(),
+        };
+        let event = AuditEvent {
+            detail: Some(Detail::Violation(violation)),
+            ..Default::default()
+        };
+        let payload = event.encode_to_vec();
+
+        // Send as EventReport frame.
+        write_half.write_u8(TAG_EVENT_REPORT).await.unwrap();
+        let mut len = payload.len() as u64;
+        loop {
+            let byte = (len & 0x7F) as u8;
+            len >>= 7;
+            if len == 0 {
+                write_half.write_u8(byte).await.unwrap();
+                break;
+            } else {
+                write_half.write_u8(byte | 0x80).await.unwrap();
+            }
+        }
+        write_half.write_all(&payload).await.unwrap();
+        write_half.flush().await.unwrap();
+
+        // The pipeline should detect the violation and push ViolationAlert (tag 4) back.
+        let tag = tokio::time::timeout(Duration::from_millis(100), read_half.read_u8())
+            .await
+            .expect("ViolationAlert did not arrive within 100ms")
+            .expect("read error");
+
+        assert_eq!(tag, TAG_VIOLATION_ALERT, "expected ViolationAlert tag (4)");
+
+        token.cancel();
+    }
+
+    /// A normal (non-violation) EventReport must NOT produce any response
+    /// on the same connection.
+    #[tokio::test]
+    async fn normal_event_produces_no_response() {
+        use crate::ipc::codec::TAG_EVENT_REPORT;
+        use crate::pipeline::{PipelineConfig, PipelineMetrics};
+        use prost::Message;
+        use std::sync::Arc;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let socket_path = temp_socket_path("no-alert");
+        let token = CancellationToken::new();
+        let counter = Arc::new(AtomicI64::new(0));
+        let (inbound_rx, router) =
+            start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+
+        // Spin up the pipeline.
+        let pipeline_config = PipelineConfig {
+            input_buffer: 64,
+            batch_size: 100,
+            flush_interval: std::time::Duration::from_secs(60),
+            broadcast_capacity: 64,
+            agent_id: "test-agent".to_string(),
+        };
+        let pipeline_metrics = Arc::new(PipelineMetrics::default());
+        let (broadcast_tx, _broadcast_rx) =
+            tokio::sync::broadcast::channel::<crate::pipeline::EnrichedEvent>(64);
+        let pipeline_router = Arc::clone(&router);
+        let pipeline_token = token.clone();
+        tokio::spawn(crate::pipeline::run(
+            inbound_rx,
+            broadcast_tx,
+            pipeline_config,
+            pipeline_metrics,
+            pipeline_token,
+            Arc::new(crate::policy::PolicyRules::default()),
+            pipeline_router,
+        ));
+
+        // Connect a client.
+        let client = connect_client(&socket_path).await;
+        let (mut read_half, mut write_half) = client.into_split();
+
+        // Wait for the connection to be registered.
+        for _ in 0..50 {
+            if counter.load(Ordering::Relaxed) == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        // Send a normal (non-violation) event.
+        let event = AuditEvent::default();
+        let payload = event.encode_to_vec();
+        write_half.write_u8(TAG_EVENT_REPORT).await.unwrap();
+        let mut len = payload.len() as u64;
+        loop {
+            let byte = (len & 0x7F) as u8;
+            len >>= 7;
+            if len == 0 {
+                write_half.write_u8(byte).await.unwrap();
+                break;
+            } else {
+                write_half.write_u8(byte | 0x80).await.unwrap();
+            }
+        }
+        write_half.write_all(&payload).await.unwrap();
+        write_half.flush().await.unwrap();
+
+        // No ViolationAlert should arrive — read should time out.
+        let result =
+            tokio::time::timeout(Duration::from_millis(100), read_half.read_u8()).await;
+        assert!(
+            result.is_err(),
+            "expected no response for a normal event, but received one"
+        );
+
+        token.cancel();
+    }
 }

--- a/aa-runtime/src/ipc/server.rs
+++ b/aa-runtime/src/ipc/server.rs
@@ -14,6 +14,7 @@ use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 
 use crate::ipc::message::{IpcFrame, IpcResponse};
+use crate::ipc::ResponseRouter;
 
 /// Configuration for the IPC server.
 #[derive(Debug, Clone)]
@@ -80,6 +81,7 @@ impl IpcServer {
         token: CancellationToken,
         inbound_tx: mpsc::Sender<IpcFrame>,
         active_connections: Arc<AtomicI64>,
+        _response_router: ResponseRouter, // wired in commit 3
     ) {
         let semaphore = Arc::new(Semaphore::new(self.config.max_connections));
         let listener = self.listener;
@@ -298,7 +300,7 @@ mod tests {
         let tracker = TaskTracker::new();
         let tracker_clone = tracker.clone();
         tracker.spawn(async move {
-            server.run(tracker_clone, token, tx, active_connections).await;
+            server.run(tracker_clone, token, tx, active_connections, crate::ipc::new_response_router()).await;
         });
         rx
     }

--- a/aa-runtime/src/ipc/server.rs
+++ b/aa-runtime/src/ipc/server.rs
@@ -5,7 +5,7 @@
 
 use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::Arc;
 
 use tokio::net::UnixListener;
@@ -81,13 +81,15 @@ impl IpcServer {
         token: CancellationToken,
         inbound_tx: mpsc::Sender<IpcFrame>,
         active_connections: Arc<AtomicI64>,
-        _response_router: ResponseRouter, // wired in commit 3
+        response_router: ResponseRouter,
     ) {
         let semaphore = Arc::new(Semaphore::new(self.config.max_connections));
         let listener = self.listener;
         let socket_path = self.config.socket_path.clone();
         let inbound_channel_capacity = self.config.inbound_channel_capacity;
         let max_connections = self.config.max_connections;
+        // Monotonically increasing connection ID — unique per accepted connection.
+        let next_conn_id = Arc::new(AtomicU64::new(0));
 
         tracing::info!("IPC server accept loop started");
 
@@ -117,20 +119,23 @@ impl IpcServer {
                                 }
                             };
 
+                            let connection_id = next_conn_id.fetch_add(1, Ordering::Relaxed);
                             let frame_tx = inbound_tx.clone();
                             let conn_token = token.child_token();
 
                             // Per-connection outbound channel.
-                            // NOTE: resp_tx is not yet wired to a response dispatcher — response routing
-                            // is out of scope for AAASM-30 and will be implemented in a follow-on ticket.
-                            // The writer task will exit immediately when resp_tx is dropped here.
                             let (resp_tx, resp_rx) =
                                 mpsc::channel::<IpcResponse>(inbound_channel_capacity);
+
+                            // Register resp_tx in the router so the pipeline can route
+                            // ViolationAlert responses back to this connection.
+                            response_router.write().await.insert(connection_id, resp_tx.clone());
 
                             // Increment the active connection counter before spawning.
                             active_connections.fetch_add(1, Ordering::Relaxed);
 
                             // Spawn connection handler tasks.
+                            let conn_router = Arc::clone(&response_router);
                             spawn_connection(
                                 &tracker,
                                 stream,
@@ -140,6 +145,8 @@ impl IpcServer {
                                 conn_token,
                                 permit,
                                 Arc::clone(&active_connections),
+                                connection_id,
+                                conn_router,
                             );
                         }
                     }
@@ -162,13 +169,13 @@ pub(super) fn spawn_connection(
     tracker: &TaskTracker,
     stream: tokio::net::UnixStream,
     frame_tx: mpsc::Sender<IpcFrame>,
-    // _resp_tx: not yet used — response routing is out of scope for AAASM-30.
-    // Will be wired to the governance dispatcher in a follow-on ticket.
-    _resp_tx: mpsc::Sender<IpcResponse>,
+    resp_tx: mpsc::Sender<IpcResponse>,
     resp_rx: mpsc::Receiver<IpcResponse>,
     token: CancellationToken,
     permit: tokio::sync::OwnedSemaphorePermit,
     active_connections: Arc<AtomicI64>,
+    connection_id: u64,
+    response_router: ResponseRouter,
 ) {
     let (read_half, write_half) = stream.into_split();
 
@@ -177,10 +184,12 @@ pub(super) fn spawn_connection(
     let reader_frame_tx = frame_tx;
     tracker.spawn(async move {
         let _permit = permit; // held until reader task completes
-        run_reader(read_half, reader_frame_tx, reader_token, active_connections).await;
+        run_reader(read_half, reader_frame_tx, reader_token, active_connections, connection_id, response_router).await;
     });
 
     // Writer task: outbound responses → socket.
+    // resp_tx is held here to keep the channel alive while the writer is running.
+    let _resp_tx = resp_tx;
     tracker.spawn(async move {
         run_writer(write_half, resp_rx, token).await;
     });
@@ -192,6 +201,8 @@ pub(super) async fn run_reader(
     frame_tx: mpsc::Sender<IpcFrame>,
     token: CancellationToken,
     active_connections: Arc<AtomicI64>,
+    connection_id: u64,
+    response_router: ResponseRouter,
 ) {
     loop {
         tokio::select! {
@@ -222,6 +233,8 @@ pub(super) async fn run_reader(
             }
         }
     }
+    // Remove this connection from the response router before signalling shutdown.
+    response_router.write().await.remove(&connection_id);
     token.cancel(); // Signal the paired writer to stop.
     active_connections.fetch_sub(1, Ordering::Relaxed);
 }
@@ -284,12 +297,12 @@ mod tests {
         panic!("could not connect to test IPC server at {}", path.display());
     }
 
-    /// Start a test IpcServer and return the inbound frame receiver.
+    /// Start a test IpcServer and return the inbound frame receiver plus response router.
     async fn start_server(
         socket_path: std::path::PathBuf,
         token: CancellationToken,
         active_connections: Arc<AtomicI64>,
-    ) -> mpsc::Receiver<IpcFrame> {
+    ) -> (mpsc::Receiver<IpcFrame>, crate::ipc::ResponseRouter) {
         let config = IpcServerConfig {
             socket_path,
             max_connections: 64,
@@ -297,12 +310,14 @@ mod tests {
         };
         let server = IpcServer::bind(config).expect("bind failed");
         let (tx, rx) = mpsc::channel(16);
+        let router = crate::ipc::new_response_router();
+        let router_clone = Arc::clone(&router);
         let tracker = TaskTracker::new();
         let tracker_clone = tracker.clone();
         tracker.spawn(async move {
-            server.run(tracker_clone, token, tx, active_connections, crate::ipc::new_response_router()).await;
+            server.run(tracker_clone, token, tx, active_connections, router_clone).await;
         });
-        rx
+        (rx, router)
     }
 
     /// Write a raw inbound frame (tag + varint len + payload) to the socket.
@@ -330,7 +345,7 @@ mod tests {
         let socket_path = temp_socket_path("heartbeat");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let mut rx = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (mut rx, _router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         let client = connect_client(&socket_path).await;
         let (_, mut write_half) = client.into_split();
@@ -354,7 +369,7 @@ mod tests {
         let socket_path = temp_socket_path("policy-query");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let mut rx = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (mut rx, _router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         let client = connect_client(&socket_path).await;
         let (_, mut write_half) = client.into_split();
@@ -383,7 +398,7 @@ mod tests {
         let socket_path = temp_socket_path("event-report");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let mut rx = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (mut rx, _router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         let client = connect_client(&socket_path).await;
         let (_, mut write_half) = client.into_split();
@@ -412,7 +427,7 @@ mod tests {
         let socket_path = temp_socket_path("concurrent");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let _rx = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (_rx, _router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         const CONN_COUNT: usize = 5;
         let mut clients = Vec::new();
@@ -432,7 +447,7 @@ mod tests {
         let socket_path = temp_socket_path("latency");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let mut rx = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (mut rx, _router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         let client = connect_client(&socket_path).await;
         let (_, mut write_half) = client.into_split();
@@ -464,7 +479,7 @@ mod tests {
         let socket_path = temp_socket_path("counter-increment");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let _rx = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (_rx, _router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         const CONN_COUNT: usize = 3;
         let mut clients = Vec::new();
@@ -496,7 +511,7 @@ mod tests {
         let socket_path = temp_socket_path("counter-decrement");
         let token = CancellationToken::new();
         let counter = Arc::new(AtomicI64::new(0));
-        let _rx = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+        let (_rx, _router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
 
         let client = connect_client(&socket_path).await;
 
@@ -527,6 +542,63 @@ mod tests {
         }
 
         assert_eq!(observed, 0, "counter should return to 0 after client disconnects");
+
+        token.cancel();
+    }
+
+    #[tokio::test]
+    async fn response_router_has_entry_after_accept() {
+        let socket_path = temp_socket_path("router-insert");
+        let token = CancellationToken::new();
+        let counter = Arc::new(AtomicI64::new(0));
+        let (_rx, router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+
+        let _client = connect_client(&socket_path).await;
+
+        // Poll until the server has processed the accept (counter reaches 1).
+        for _ in 0..50 {
+            if counter.load(Ordering::Relaxed) == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let map = router.read().await;
+        assert_eq!(map.len(), 1, "router should contain one entry after one connection");
+        token.cancel();
+    }
+
+    #[tokio::test]
+    async fn response_router_entry_removed_after_disconnect() {
+        let socket_path = temp_socket_path("router-remove");
+        let token = CancellationToken::new();
+        let counter = Arc::new(AtomicI64::new(0));
+        let (_rx, router) = start_server(socket_path.clone(), token.clone(), Arc::clone(&counter)).await;
+
+        let client = connect_client(&socket_path).await;
+
+        // Wait for entry to appear.
+        for _ in 0..50 {
+            if router.read().await.len() == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(router.read().await.len(), 1);
+
+        // Drop client — triggers disconnect → router removal.
+        drop(client);
+
+        // Poll for the entry to be removed.
+        let mut observed_len = 1usize;
+        for _ in 0..100 {
+            observed_len = router.read().await.len();
+            if observed_len == 0 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(observed_len, 0, "router entry should be removed after client disconnects");
 
         token.cancel();
     }

--- a/aa-runtime/src/ipc/server.rs
+++ b/aa-runtime/src/ipc/server.rs
@@ -79,7 +79,7 @@ impl IpcServer {
         self,
         tracker: TaskTracker,
         token: CancellationToken,
-        inbound_tx: mpsc::Sender<IpcFrame>,
+        inbound_tx: mpsc::Sender<(u64, IpcFrame)>,
         active_connections: Arc<AtomicI64>,
         response_router: ResponseRouter,
     ) {
@@ -168,7 +168,7 @@ impl IpcServer {
 pub(super) fn spawn_connection(
     tracker: &TaskTracker,
     stream: tokio::net::UnixStream,
-    frame_tx: mpsc::Sender<IpcFrame>,
+    frame_tx: mpsc::Sender<(u64, IpcFrame)>,
     resp_tx: mpsc::Sender<IpcResponse>,
     resp_rx: mpsc::Receiver<IpcResponse>,
     token: CancellationToken,
@@ -198,7 +198,7 @@ pub(super) fn spawn_connection(
 /// Reader task: reads frames from the socket and sends them to the inbound channel.
 pub(super) async fn run_reader(
     mut stream: tokio::net::unix::OwnedReadHalf,
-    frame_tx: mpsc::Sender<IpcFrame>,
+    frame_tx: mpsc::Sender<(u64, IpcFrame)>,
     token: CancellationToken,
     active_connections: Arc<AtomicI64>,
     connection_id: u64,
@@ -213,7 +213,7 @@ pub(super) async fn run_reader(
             result = super::codec::read_frame(&mut stream) => {
                 match result {
                     Ok(frame) => {
-                        if frame_tx.send(frame).await.is_err() {
+                        if frame_tx.send((connection_id, frame)).await.is_err() {
                             tracing::debug!("inbound channel closed — reader exiting");
                             break;
                         }
@@ -302,7 +302,7 @@ mod tests {
         socket_path: std::path::PathBuf,
         token: CancellationToken,
         active_connections: Arc<AtomicI64>,
-    ) -> (mpsc::Receiver<IpcFrame>, crate::ipc::ResponseRouter) {
+    ) -> (mpsc::Receiver<(u64, IpcFrame)>, crate::ipc::ResponseRouter) {
         let config = IpcServerConfig {
             socket_path,
             max_connections: 64,
@@ -355,7 +355,7 @@ mod tests {
         write_half.write_u8(TAG_HEARTBEAT).await.unwrap();
         write_half.flush().await.unwrap();
 
-        let frame = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        let (_conn_id, frame) = tokio::time::timeout(Duration::from_secs(2), rx.recv())
             .await
             .expect("timed out waiting for frame")
             .expect("channel closed");
@@ -381,7 +381,7 @@ mod tests {
         let payload = request.encode_to_vec();
         write_raw_frame(&mut write_half, TAG_POLICY_QUERY, &payload).await;
 
-        let frame = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        let (_conn_id, frame) = tokio::time::timeout(Duration::from_secs(2), rx.recv())
             .await
             .expect("timed out")
             .expect("channel closed");
@@ -410,7 +410,7 @@ mod tests {
         let payload = event.encode_to_vec();
         write_raw_frame(&mut write_half, TAG_EVENT_REPORT, &payload).await;
 
-        let frame = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        let (_conn_id, frame) = tokio::time::timeout(Duration::from_secs(2), rx.recv())
             .await
             .expect("timed out")
             .expect("channel closed");
@@ -462,7 +462,7 @@ mod tests {
             tokio::time::timeout(Duration::from_millis(100), rx.recv())
                 .await
                 .expect("timed out")
-                .expect("channel closed");
+                .expect("channel closed"); // returns (conn_id, frame) — result unused in latency test
         }
 
         let elapsed = start.elapsed();

--- a/aa-runtime/src/pipeline/event.rs
+++ b/aa-runtime/src/pipeline/event.rs
@@ -29,6 +29,9 @@ pub struct EnrichedEvent {
     pub source: EventSource,
     /// Agent identity string — copied from `RuntimeConfig::agent_id`.
     pub agent_id: String,
+    /// ID of the IPC connection that submitted this event.
+    /// Used to route `IpcResponse::ViolationAlert` back to the originating SDK client.
+    pub connection_id: u64,
 }
 
 #[cfg(test)]
@@ -41,18 +44,21 @@ mod tests {
         let received_at_ms: i64 = 1234567890;
         let source = EventSource::Sdk;
         let agent_id = "test-agent".to_string();
+        let connection_id: u64 = 42;
 
         let enriched_event = EnrichedEvent {
             inner: audit_event.clone(),
             received_at_ms,
             source: source.clone(),
             agent_id: agent_id.clone(),
+            connection_id,
         };
 
         assert_eq!(enriched_event.inner, audit_event);
         assert_eq!(enriched_event.received_at_ms, received_at_ms);
         assert_eq!(enriched_event.source, source);
         assert_eq!(enriched_event.agent_id, agent_id);
+        assert_eq!(enriched_event.connection_id, connection_id);
     }
 
     #[test]
@@ -70,9 +76,11 @@ mod tests {
             received_at_ms: 1234567890,
             source: EventSource::EBpf,
             agent_id: "original-agent".to_string(),
+            connection_id: 7,
         };
 
         let cloned = original.clone();
         assert_eq!(cloned.agent_id, original.agent_id);
+        assert_eq!(cloned.connection_id, original.connection_id);
     }
 }

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -557,7 +557,15 @@ mod tests {
         let metrics = Arc::new(PipelineMetrics::default());
         let token = CancellationToken::new();
 
-        tokio::spawn(run(rx, broadcast_tx, config, metrics.clone(), token.clone(), policy, crate::ipc::new_response_router()));
+        tokio::spawn(run(
+            rx,
+            broadcast_tx,
+            config,
+            metrics.clone(),
+            token.clone(),
+            policy,
+            crate::ipc::new_response_router(),
+        ));
 
         // Build an AuditEvent with action_type = FILE_OPERATION
         let event = AuditEvent {
@@ -597,7 +605,15 @@ mod tests {
         let metrics = Arc::new(PipelineMetrics::default());
         let token = CancellationToken::new();
 
-        tokio::spawn(run(rx, broadcast_tx, config, metrics.clone(), token.clone(), policy, crate::ipc::new_response_router()));
+        tokio::spawn(run(
+            rx,
+            broadcast_tx,
+            config,
+            metrics.clone(),
+            token.clone(),
+            policy,
+            crate::ipc::new_response_router(),
+        ));
 
         // Yield briefly so the pipeline's interval fires its immediate first tick
         // (tokio::time::interval ticks once immediately on creation).

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -7,7 +7,7 @@ pub use event::{EnrichedEvent, EventSource};
 pub use metrics::PipelineMetrics;
 
 use crate::config::RuntimeConfig;
-use crate::ipc::IpcFrame;
+use crate::ipc::{IpcFrame, ResponseRouter};
 use crate::policy::PolicyRules;
 use aa_proto::assembly::audit::v1::{audit_event::Detail, AuditEvent};
 use aa_proto::assembly::common::v1::ActionType;
@@ -59,6 +59,7 @@ pub async fn run(
     metrics: Arc<PipelineMetrics>,
     token: CancellationToken,
     policy: Arc<PolicyRules>,
+    _response_router: ResponseRouter, // wired in commit 6
 ) {
     let mut batch: Vec<EnrichedEvent> = Vec::with_capacity(config.batch_size);
     let mut ticker = tokio::time::interval(config.flush_interval);
@@ -333,6 +334,7 @@ mod tests {
             metrics.clone(),
             token.clone(),
             Arc::new(PolicyRules::default()),
+            crate::ipc::new_response_router(),
         ));
 
         // Send 3 events — batch threshold reached, should flush before interval
@@ -366,6 +368,7 @@ mod tests {
             metrics.clone(),
             token.clone(),
             Arc::new(PolicyRules::default()),
+            crate::ipc::new_response_router(),
         ));
 
         // Send 5 events (less than batch_size=100) — should arrive after interval flush
@@ -399,6 +402,7 @@ mod tests {
             metrics.clone(),
             token.clone(),
             Arc::new(PolicyRules::default()),
+            crate::ipc::new_response_router(),
         ));
 
         // Send a violation — should arrive immediately, bypassing batch
@@ -429,6 +433,7 @@ mod tests {
             metrics.clone(),
             token.clone(),
             Arc::new(PolicyRules::default()),
+            crate::ipc::new_response_router(),
         ));
 
         // Send 5 events (batch won't flush yet)
@@ -480,6 +485,7 @@ mod tests {
             metrics.clone(),
             token.clone(),
             Arc::new(PolicyRules::default()),
+            crate::ipc::new_response_router(),
         ));
 
         // Send non-event frames
@@ -513,7 +519,7 @@ mod tests {
         let metrics = Arc::new(PipelineMetrics::default());
         let token = CancellationToken::new();
 
-        tokio::spawn(run(rx, broadcast_tx, config, metrics.clone(), token.clone(), policy));
+        tokio::spawn(run(rx, broadcast_tx, config, metrics.clone(), token.clone(), policy, crate::ipc::new_response_router()));
 
         // Build an AuditEvent with action_type = FILE_OPERATION
         let event = AuditEvent {
@@ -553,7 +559,7 @@ mod tests {
         let metrics = Arc::new(PipelineMetrics::default());
         let token = CancellationToken::new();
 
-        tokio::spawn(run(rx, broadcast_tx, config, metrics.clone(), token.clone(), policy));
+        tokio::spawn(run(rx, broadcast_tx, config, metrics.clone(), token.clone(), policy, crate::ipc::new_response_router()));
 
         // Yield briefly so the pipeline's interval fires its immediate first tick
         // (tokio::time::interval ticks once immediately on creation).
@@ -595,6 +601,7 @@ mod tests {
             metrics.clone(),
             token.clone(),
             Arc::new(PolicyRules::default()),
+            crate::ipc::new_response_router(),
         ));
 
         // Spawn a receiver that drains the broadcast channel

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -7,9 +7,9 @@ pub use event::{EnrichedEvent, EventSource};
 pub use metrics::PipelineMetrics;
 
 use crate::config::RuntimeConfig;
-use crate::ipc::{IpcFrame, ResponseRouter};
+use crate::ipc::{IpcFrame, IpcResponse, ResponseRouter};
 use crate::policy::PolicyRules;
-use aa_proto::assembly::audit::v1::{audit_event::Detail, AuditEvent};
+use aa_proto::assembly::audit::v1::{audit_event::Detail, AuditEvent, PolicyViolation};
 use aa_proto::assembly::common::v1::ActionType;
 use std::sync::Arc;
 use std::time::Duration;
@@ -59,7 +59,7 @@ pub async fn run(
     metrics: Arc<PipelineMetrics>,
     token: CancellationToken,
     policy: Arc<PolicyRules>,
-    _response_router: ResponseRouter, // wired in commit 6
+    response_router: ResponseRouter,
 ) {
     let mut batch: Vec<EnrichedEvent> = Vec::with_capacity(config.batch_size);
     let mut ticker = tokio::time::interval(config.flush_interval);
@@ -85,6 +85,8 @@ pub async fn run(
                     if is_policy_violation(&enriched, &policy) {
                         // Bypass the batch — emit immediately.
                         ::metrics::counter!("aa_policy_violations_total").increment(1);
+                        // Push a ViolationAlert back to the originating SDK connection.
+                        push_violation_alert(&enriched, &response_router).await;
                         let _ = broadcast_tx.send(enriched);
                     } else {
                         batch.push(enriched);
@@ -146,6 +148,42 @@ fn is_policy_violation(event: &EnrichedEvent, policy: &PolicyRules) -> bool {
         }
     }
     false
+}
+
+/// Extract a `PolicyViolation` from an `EnrichedEvent`, if one is present.
+///
+/// Returns `Some` when the event's detail is `Detail::Violation(_)`.
+/// Returns `None` for rule-matched events that have no embedded violation proto —
+/// in that case the SDK already knows the action was blocked.
+fn extract_violation(event: &EnrichedEvent) -> Option<PolicyViolation> {
+    match &event.inner.detail {
+        Some(Detail::Violation(v)) => Some(v.clone()),
+        _ => None,
+    }
+}
+
+/// Send a `ViolationAlert` to the SDK connection that originated `event`.
+///
+/// Looks up the per-connection sender in the `ResponseRouter`. If the connection
+/// has already disconnected the entry will be absent and the alert is silently
+/// dropped — the connection is gone so there is no point delivering it.
+async fn push_violation_alert(event: &EnrichedEvent, router: &crate::ipc::ResponseRouter) {
+    let Some(violation) = extract_violation(event) else {
+        // Rule-matched events don't carry a PolicyViolation proto; skip.
+        return;
+    };
+    let sender = {
+        let map = router.read().await;
+        map.get(&event.connection_id).cloned()
+    };
+    if let Some(tx) = sender {
+        if tx.send(IpcResponse::ViolationAlert(violation)).await.is_err() {
+            tracing::debug!(
+                connection_id = event.connection_id,
+                "ViolationAlert dropped — connection already closed"
+            );
+        }
+    }
 }
 
 /// Broadcast all events in `batch` and record metrics.

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -78,7 +78,7 @@ pub async fn run(
 
             Some(frame) = rx.recv() => {
                 if let IpcFrame::EventReport(event) = frame {
-                    let enriched = enrich(event, &config.agent_id);
+                    let enriched = enrich(event, &config.agent_id, 0); // connection_id wired in commit 4
                     metrics.record_processed(1);
                     ::metrics::counter!("aa_events_received_total").increment(1);
                     if is_policy_violation(&enriched, &policy) {
@@ -106,7 +106,7 @@ pub async fn run(
 }
 
 /// Enrich a raw [`AuditEvent`] with runtime-side metadata.
-fn enrich(event: AuditEvent, agent_id: &str) -> EnrichedEvent {
+fn enrich(event: AuditEvent, agent_id: &str, connection_id: u64) -> EnrichedEvent {
     use std::time::{SystemTime, UNIX_EPOCH};
     let received_at_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -117,6 +117,7 @@ fn enrich(event: AuditEvent, agent_id: &str) -> EnrichedEvent {
         received_at_ms,
         source: EventSource::Sdk,
         agent_id: agent_id.to_string(),
+        connection_id,
     }
 }
 
@@ -184,35 +185,35 @@ mod tests {
     #[test]
     fn enrich_sets_agent_id() {
         let event = make_audit_event();
-        let enriched = enrich(event, "my-agent");
+        let enriched = enrich(event, "my-agent", 0);
         assert_eq!(enriched.agent_id, "my-agent");
     }
 
     #[test]
     fn enrich_sets_received_at_ms_positive() {
         let event = make_audit_event();
-        let enriched = enrich(event, "agent");
+        let enriched = enrich(event, "agent", 0);
         assert!(enriched.received_at_ms > 0);
     }
 
     #[test]
     fn enrich_sets_source_to_sdk() {
         let event = make_audit_event();
-        let enriched = enrich(event, "agent");
+        let enriched = enrich(event, "agent", 0);
         assert_eq!(enriched.source, EventSource::Sdk);
     }
 
     #[test]
     fn is_policy_violation_true_for_violation_detail() {
         let event = make_policy_violation_event();
-        let enriched = enrich(event, "agent");
+        let enriched = enrich(event, "agent", 0);
         assert!(is_policy_violation(&enriched, &PolicyRules::default()));
     }
 
     #[test]
     fn is_policy_violation_false_for_normal_event() {
         let event = make_audit_event(); // detail = None
-        let enriched = enrich(event, "agent");
+        let enriched = enrich(event, "agent", 0);
         assert!(!is_policy_violation(&enriched, &PolicyRules::default()));
     }
 
@@ -230,7 +231,7 @@ mod tests {
     fn flush_broadcasts_all_events_and_records_batch_size() {
         let (tx, mut rx) = broadcast::channel::<EnrichedEvent>(16);
         let metrics = PipelineMetrics::default();
-        let mut batch = vec![enrich(make_audit_event(), "a"), enrich(make_audit_event(), "b")];
+        let mut batch = vec![enrich(make_audit_event(), "a", 0), enrich(make_audit_event(), "b", 0)];
         flush(&mut batch, &tx, &metrics);
         assert!(batch.is_empty());
         assert_eq!(metrics.last_batch_size(), 2);

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -53,7 +53,7 @@ impl PipelineConfig {
 ///
 /// Returns when `token` is cancelled — flushing any pending batch first.
 pub async fn run(
-    mut rx: mpsc::Receiver<IpcFrame>,
+    mut rx: mpsc::Receiver<(u64, IpcFrame)>,
     broadcast_tx: broadcast::Sender<EnrichedEvent>,
     config: PipelineConfig,
     metrics: Arc<PipelineMetrics>,
@@ -77,9 +77,9 @@ pub async fn run(
                 break;
             }
 
-            Some(frame) = rx.recv() => {
+            Some((connection_id, frame)) = rx.recv() => {
                 if let IpcFrame::EventReport(event) = frame {
-                    let enriched = enrich(event, &config.agent_id, 0); // connection_id wired in commit 4
+                    let enriched = enrich(event, &config.agent_id, connection_id);
                     metrics.record_processed(1);
                     ::metrics::counter!("aa_events_received_total").increment(1);
                     if is_policy_violation(&enriched, &policy) {
@@ -322,7 +322,7 @@ mod tests {
     #[tokio::test]
     async fn batch_flushes_on_size_threshold() {
         let config = test_config(3, 10_000); // batch_size=3, very long interval (won't fire)
-        let (tx, rx) = mpsc::channel::<IpcFrame>(64);
+        let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
         let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<EnrichedEvent>(64);
         let metrics = Arc::new(PipelineMetrics::default());
         let token = CancellationToken::new();
@@ -339,7 +339,7 @@ mod tests {
 
         // Send 3 events — batch threshold reached, should flush before interval
         for _ in 0..3 {
-            tx.send(IpcFrame::EventReport(normal_event())).await.unwrap();
+            tx.send((0, IpcFrame::EventReport(normal_event()))).await.unwrap();
         }
 
         // All 3 events should arrive within a short time
@@ -356,7 +356,7 @@ mod tests {
     #[tokio::test]
     async fn batch_flushes_on_interval() {
         let config = test_config(100, 50); // batch_size=100 (won't reach), interval=50ms
-        let (tx, rx) = mpsc::channel::<IpcFrame>(64);
+        let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
         let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<EnrichedEvent>(64);
         let metrics = Arc::new(PipelineMetrics::default());
         let token = CancellationToken::new();
@@ -373,7 +373,7 @@ mod tests {
 
         // Send 5 events (less than batch_size=100) — should arrive after interval flush
         for _ in 0..5 {
-            tx.send(IpcFrame::EventReport(normal_event())).await.unwrap();
+            tx.send((0, IpcFrame::EventReport(normal_event()))).await.unwrap();
         }
 
         for _ in 0..5 {
@@ -390,7 +390,7 @@ mod tests {
     async fn policy_violation_bypasses_batch() {
         // batch_size=100, very long interval — only a violation should arrive
         let config = test_config(100, 10_000);
-        let (tx, rx) = mpsc::channel::<IpcFrame>(64);
+        let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
         let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<EnrichedEvent>(64);
         let metrics = Arc::new(PipelineMetrics::default());
         let token = CancellationToken::new();
@@ -406,7 +406,7 @@ mod tests {
         ));
 
         // Send a violation — should arrive immediately, bypassing batch
-        tx.send(IpcFrame::EventReport(violation_event())).await.unwrap();
+        tx.send((0, IpcFrame::EventReport(violation_event()))).await.unwrap();
 
         let event = tokio::time::timeout(Duration::from_millis(200), broadcast_rx.recv())
             .await
@@ -421,7 +421,7 @@ mod tests {
     #[tokio::test]
     async fn cancellation_flushes_pending_batch() {
         let config = test_config(100, 10_000); // large batch, long interval
-        let (tx, rx) = mpsc::channel::<IpcFrame>(64);
+        let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
         let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<EnrichedEvent>(64);
         let metrics = Arc::new(PipelineMetrics::default());
         let token = CancellationToken::new();
@@ -438,7 +438,7 @@ mod tests {
 
         // Send 5 events (batch won't flush yet)
         for _ in 0..5 {
-            tx.send(IpcFrame::EventReport(normal_event())).await.unwrap();
+            tx.send((0, IpcFrame::EventReport(normal_event()))).await.unwrap();
         }
 
         // Wait until the run loop has processed all 5 events before cancelling,
@@ -473,7 +473,7 @@ mod tests {
     #[tokio::test]
     async fn non_event_frames_ignored() {
         let config = test_config(100, 50);
-        let (tx, rx) = mpsc::channel::<IpcFrame>(64);
+        let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
         let (broadcast_tx, _broadcast_rx) = broadcast::channel::<EnrichedEvent>(64);
         let metrics = Arc::new(PipelineMetrics::default());
         let token = CancellationToken::new();
@@ -489,7 +489,7 @@ mod tests {
         ));
 
         // Send non-event frames
-        tx.send(IpcFrame::Heartbeat).await.unwrap();
+        tx.send((0, IpcFrame::Heartbeat)).await.unwrap();
 
         // Give run loop a moment to process
         tokio::time::sleep(Duration::from_millis(20)).await;
@@ -514,7 +514,7 @@ mod tests {
 
         // batch_size=100, very long interval — only a rule-matched event should arrive immediately
         let config = test_config(100, 10_000);
-        let (tx, rx) = mpsc::channel::<IpcFrame>(64);
+        let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
         let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<EnrichedEvent>(64);
         let metrics = Arc::new(PipelineMetrics::default());
         let token = CancellationToken::new();
@@ -526,7 +526,7 @@ mod tests {
             action_type: ActionType::FileOperation as i32,
             ..Default::default()
         };
-        tx.send(IpcFrame::EventReport(event)).await.unwrap();
+        tx.send((0, IpcFrame::EventReport(event))).await.unwrap();
 
         // Should arrive immediately (before flush interval)
         let received = tokio::time::timeout(Duration::from_millis(200), broadcast_rx.recv())
@@ -554,7 +554,7 @@ mod tests {
 
         // batch_size=100, very long interval — event should NOT arrive before timeout
         let config = test_config(100, 10_000);
-        let (tx, rx) = mpsc::channel::<IpcFrame>(64);
+        let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
         let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<EnrichedEvent>(64);
         let metrics = Arc::new(PipelineMetrics::default());
         let token = CancellationToken::new();
@@ -570,7 +570,7 @@ mod tests {
             action_type: ActionType::ToolCall as i32,
             ..Default::default()
         };
-        tx.send(IpcFrame::EventReport(event)).await.unwrap();
+        tx.send((0, IpcFrame::EventReport(event))).await.unwrap();
 
         // Should NOT arrive before the flush interval (100ms timeout)
         let result = tokio::time::timeout(Duration::from_millis(100), broadcast_rx.recv()).await;
@@ -589,7 +589,7 @@ mod tests {
         const EVENT_COUNT: u64 = 100_000;
 
         let config = test_config(100, 10);
-        let (tx, rx) = mpsc::channel::<IpcFrame>(10_000);
+        let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(10_000);
         let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<EnrichedEvent>(10_000);
         let metrics = Arc::new(PipelineMetrics::default());
         let token = CancellationToken::new();
@@ -610,7 +610,7 @@ mod tests {
         let start = std::time::Instant::now();
 
         for _ in 0..EVENT_COUNT {
-            tx.send(IpcFrame::EventReport(normal_event())).await.unwrap();
+            tx.send((0, IpcFrame::EventReport(normal_event()))).await.unwrap();
         }
 
         // Wait until all events are processed

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -70,7 +70,7 @@ pub async fn run(config: RuntimeConfig) {
 
     // Build pipeline config and create the inbound channel at the configured depth.
     let pipeline_config = crate::pipeline::PipelineConfig::from_runtime_config(&config);
-    let (inbound_tx, inbound_rx) = tokio::sync::mpsc::channel::<crate::ipc::IpcFrame>(pipeline_config.input_buffer);
+    let (inbound_tx, inbound_rx) = tokio::sync::mpsc::channel::<(u64, crate::ipc::IpcFrame)>(pipeline_config.input_buffer);
 
     // Create the broadcast channel for fan-out to downstream subscribers.
     // The leading `_broadcast_rx` keeps the channel alive until real subscribers

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -84,6 +84,9 @@ pub async fn run(config: RuntimeConfig) {
     // Shared active-connections counter exposed to the health/metrics endpoint.
     let active_connections = std::sync::Arc::new(std::sync::atomic::AtomicI64::new(0));
 
+    // Shared response router — maps connection_id → per-connection IpcResponse sender.
+    let response_router = crate::ipc::new_response_router();
+
     // Clone inbound_tx for the health/metrics handler before IpcServer consumes it.
     let inbound_tx_health = inbound_tx.clone();
 
@@ -95,9 +98,10 @@ pub async fn run(config: RuntimeConfig) {
             let ipc_tracker = tracker.clone();
             let ipc_token = token.clone();
             let ipc_active_connections = std::sync::Arc::clone(&active_connections);
+            let ipc_router = std::sync::Arc::clone(&response_router);
             tracker.spawn(async move {
                 ipc_server
-                    .run(ipc_tracker, ipc_token, inbound_tx, ipc_active_connections)
+                    .run(ipc_tracker, ipc_token, inbound_tx, ipc_active_connections, ipc_router)
                     .await;
             });
             tracing::info!("IPC server task spawned");
@@ -114,6 +118,7 @@ pub async fn run(config: RuntimeConfig) {
         let pipeline_token = token.clone();
         let pm = pipeline_metrics.clone();
         let pipeline_policy = std::sync::Arc::clone(&policy);
+        let pipeline_router = std::sync::Arc::clone(&response_router);
         tracker.spawn(async move {
             crate::pipeline::run(
                 inbound_rx,
@@ -122,6 +127,7 @@ pub async fn run(config: RuntimeConfig) {
                 pm,
                 pipeline_token,
                 pipeline_policy,
+                pipeline_router,
             )
             .await;
         });

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -70,7 +70,8 @@ pub async fn run(config: RuntimeConfig) {
 
     // Build pipeline config and create the inbound channel at the configured depth.
     let pipeline_config = crate::pipeline::PipelineConfig::from_runtime_config(&config);
-    let (inbound_tx, inbound_rx) = tokio::sync::mpsc::channel::<(u64, crate::ipc::IpcFrame)>(pipeline_config.input_buffer);
+    let (inbound_tx, inbound_rx) =
+        tokio::sync::mpsc::channel::<(u64, crate::ipc::IpcFrame)>(pipeline_config.input_buffer);
 
     // Create the broadcast channel for fan-out to downstream subscribers.
     // The leading `_broadcast_rx` keeps the channel alive until real subscribers


### PR DESCRIPTION
## Summary

- Each accepted UDS connection is assigned a monotonically-increasing `connection_id: u64` via `AtomicU64`, stored in `EnrichedEvent` and carried through the pipeline.
- A shared `ResponseRouter` (`Arc<RwLock<HashMap<u64, mpsc::Sender<IpcResponse>>>>`) maps connection IDs to per-connection outbound senders; inserted on accept, removed on disconnect.
- Inbound channel type changed from `mpsc::Sender<IpcFrame>` to `mpsc::Sender<(u64, IpcFrame)>` so the pipeline always knows which connection originated each frame.
- New `IpcResponse::ViolationAlert(PolicyViolation)` variant (wire tag 4) pushes policy violation details back to the originating SDK client.
- On every violation event, `pipeline::run()` looks up the `connection_id` in the router and sends the `ViolationAlert`; silently drops it if the connection has already closed.

## Commits

1. `✨ pipeline(event)` — Add `connection_id` field to `EnrichedEvent`
2. `🔧 runtime` — Add `ResponseRouter` type and thread through IPC server and pipeline
3. `✨ ipc(server)` — Assign `connection_id` per connection and wire `resp_tx` into `ResponseRouter`
4. `♻️ ipc(channel)` — Change inbound channel type to `(u64, IpcFrame)` for connection routing
5. `✨ ipc(message)` — Add `IpcResponse::ViolationAlert(PolicyViolation)` wire variant (tag 4)
6. `✨ pipeline` — Send `ViolationAlert` to originating SDK connection on policy violation
7. `✅ test(ipc)` — Integration tests for ViolationAlert end-to-end pushback

## Test plan

- [ ] `cargo test -p aa-runtime` — 81 tests pass, 0 failures (2 ignored benchmarks)
- [ ] `violation_event_triggers_alert_within_100ms` — sends a `PolicyViolation` `EventReport` over a real UDS, asserts `ViolationAlert` tag (4) arrives back within 100 ms
- [ ] `normal_event_produces_no_response` — sends a plain `EventReport`, asserts no response byte within 100 ms
- [ ] `response_router_has_entry_after_accept` — verifies router entry inserted on accept
- [ ] `response_router_entry_removed_after_disconnect` — verifies router entry removed on disconnect
- [ ] `violation_alert_encodes_with_correct_tag_and_decodes` — codec round-trip for new wire tag

Closes #AAASM-130