### PR TITLE
[AAASM-71] ✨ approval: Add human approval request queue (ApprovalQueue)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,11 +40,13 @@ version = "0.0.1"
 dependencies = [
  "aa-core",
  "aa-ebpf-common",
+ "anyhow",
  "aya",
  "aya-log",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -126,16 +128,20 @@ dependencies = [
  "aa-core",
  "aa-proto",
  "axum 0.7.9",
+ "dashmap",
  "metrics",
  "metrics-exporter-prometheus",
  "prost",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-util",
+ "toml",
  "tower 0.4.13",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -2244,7 +2250,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -2915,6 +2921,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3282,6 +3297,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3292,14 +3328,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -3308,8 +3358,14 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.2",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
@@ -3612,6 +3668,17 @@ dependencies = [
  "url",
  "utoipa",
  "zip",
+]
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4098,6 +4165,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -39,6 +39,8 @@ pub enum AuditEventType {
     BudgetLimitApproached = 6,
     /// The session budget has been exhausted; further actions are blocked.
     BudgetLimitExceeded = 7,
+    /// A pending human approval request expired before a decision was made.
+    ApprovalTimedOut = 8,
 }
 
 impl AuditEventType {
@@ -55,6 +57,7 @@ impl AuditEventType {
             Self::ApprovalDenied => "ApprovalDenied",
             Self::BudgetLimitApproached => "BudgetLimitApproached",
             Self::BudgetLimitExceeded => "BudgetLimitExceeded",
+            Self::ApprovalTimedOut => "ApprovalTimedOut",
         }
     }
 }
@@ -504,10 +507,11 @@ mod tests {
         assert_eq!(AuditEventType::ApprovalDenied.as_str(), "ApprovalDenied");
         assert_eq!(AuditEventType::BudgetLimitApproached.as_str(), "BudgetLimitApproached");
         assert_eq!(AuditEventType::BudgetLimitExceeded.as_str(), "BudgetLimitExceeded");
+        assert_eq!(AuditEventType::ApprovalTimedOut.as_str(), "ApprovalTimedOut");
     }
 
     #[test]
-    fn event_type_discriminants_are_0_through_7() {
+    fn event_type_discriminants_are_0_through_8() {
         assert_eq!(AuditEventType::ToolCallIntercepted as u32, 0);
         assert_eq!(AuditEventType::PolicyViolation as u32, 1);
         assert_eq!(AuditEventType::CredentialLeakBlocked as u32, 2);
@@ -516,6 +520,7 @@ mod tests {
         assert_eq!(AuditEventType::ApprovalDenied as u32, 5);
         assert_eq!(AuditEventType::BudgetLimitApproached as u32, 6);
         assert_eq!(AuditEventType::BudgetLimitExceeded as u32, 7);
+        assert_eq!(AuditEventType::ApprovalTimedOut as u32, 8);
     }
 
     #[test]
@@ -529,6 +534,7 @@ mod tests {
             AuditEventType::ApprovalDenied,
             AuditEventType::BudgetLimitApproached,
             AuditEventType::BudgetLimitExceeded,
+            AuditEventType::ApprovalTimedOut,
         ];
         for i in 0..variants.len() {
             for j in (i + 1)..variants.len() {

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -10,6 +10,8 @@ description = "Tokio async runtime wrapper and lifecycle management for Agent As
 aa-core                     = { path = "../aa-core" }
 aa-proto                    = { path = "../aa-proto" }
 axum                        = "0.7"
+dashmap                     = "6"
+uuid                        = { version = "1", features = ["v4"] }
 metrics                     = "0.24"
 metrics-exporter-prometheus = "0.16"
 prost                       = "0.13"

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -25,6 +25,7 @@ tracing-subscriber          = { version = "0.3", features = ["json", "env-filter
 
 [dev-dependencies]
 tempfile = "3"
+tokio = { version = "1", features = ["test-util"] }
 tower = { version = "0.4", features = ["util"] }
 
 [lints]

--- a/aa-runtime/src/approval.rs
+++ b/aa-runtime/src/approval.rs
@@ -441,4 +441,58 @@ mod tests {
         let decision = fut.await.expect("future should resolve after timeout");
         assert!(matches!(decision, ApprovalDecision::TimedOut { .. }));
     }
+
+    #[tokio::test]
+    async fn list_reflects_pending_and_clears_after_decide() {
+        let q = ApprovalQueue::new();
+        let req = make_request(60);
+        let id = req.request_id;
+        let (_rid, _fut) = q.submit(req);
+
+        let pending = q.list();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].request_id, id);
+
+        q.decide(
+            id,
+            ApprovalDecision::Approved { by: "alice".to_string(), reason: None },
+        )
+        .expect("decide should succeed");
+
+        assert!(q.list().is_empty());
+    }
+
+    #[tokio::test]
+    async fn submit_100_concurrent_requests_all_resolve() {
+        use std::collections::HashMap;
+
+        let q = ApprovalQueue::new();
+        let n = 100_usize;
+
+        let mut futures_map = HashMap::new();
+        for _ in 0..n {
+            let req = make_request(60);
+            let id = req.request_id;
+            let (_rid, fut) = q.submit(req);
+            futures_map.insert(id, fut);
+        }
+
+        assert_eq!(q.list().len(), n);
+
+        let ids: Vec<_> = futures_map.keys().copied().collect();
+        for id in &ids {
+            q.decide(
+                *id,
+                ApprovalDecision::Approved { by: "operator".to_string(), reason: None },
+            )
+            .expect("decide should succeed for each request");
+        }
+
+        for (_id, fut) in futures_map {
+            let decision = fut.await.expect("future should resolve");
+            assert!(matches!(decision, ApprovalDecision::Approved { .. }));
+        }
+
+        assert!(q.list().is_empty());
+    }
 }

--- a/aa-runtime/src/approval.rs
+++ b/aa-runtime/src/approval.rs
@@ -1,0 +1,149 @@
+//! Human-approval request queue for Agent Assembly governance.
+//!
+//! When the policy engine returns [`aa_core::PolicyResult::RequiresApproval`],
+//! the runtime submits an [`ApprovalRequest`] here. The request stays pending
+//! until a human operator calls [`ApprovalQueue::decide`], or the per-request
+//! timeout elapses and the queue auto-resolves it as [`ApprovalDecision::TimedOut`].
+
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Public type aliases
+// ---------------------------------------------------------------------------
+
+/// Opaque identifier for a single pending approval request.
+pub type ApprovalRequestId = Uuid;
+
+/// A one-shot receiver that resolves to the [`ApprovalDecision`] once a human
+/// (or the timeout task) settles the request.
+pub type ApprovalFuture = tokio::sync::oneshot::Receiver<ApprovalDecision>;
+
+// ---------------------------------------------------------------------------
+// ApprovalRequest
+// ---------------------------------------------------------------------------
+
+/// All data needed to present a pending action to a human operator.
+#[derive(Debug, Clone)]
+pub struct ApprovalRequest {
+    /// Unique ID for this request (UUID v4).
+    pub request_id: ApprovalRequestId,
+    /// The agent that triggered the approval requirement.
+    pub agent_id: String,
+    /// Human-readable description of the action awaiting approval.
+    pub action: String,
+    /// Name or description of the policy condition that triggered this request.
+    pub condition_triggered: String,
+    /// Unix epoch timestamp (seconds) when the request was submitted.
+    pub submitted_at: u64,
+    /// Seconds before the queue auto-resolves the request as timed-out.
+    pub timeout_secs: u64,
+    /// Policy decision to apply if the request times out without a human decision.
+    pub fallback: aa_core::PolicyResult,
+}
+
+// ---------------------------------------------------------------------------
+// PendingApprovalRequest  (safe, outward-facing view — no channel or fallback)
+// ---------------------------------------------------------------------------
+
+/// A redacted, outward-facing snapshot of a pending request.
+///
+/// Returned by [`ApprovalQueue::list`] so callers cannot access the internal
+/// one-shot sender or fallback policy.
+#[derive(Debug, Clone)]
+pub struct PendingApprovalRequest {
+    /// Unique ID for this request.
+    pub request_id: ApprovalRequestId,
+    /// The agent that triggered the approval requirement.
+    pub agent_id: String,
+    /// Human-readable description of the action awaiting approval.
+    pub action: String,
+    /// Name or description of the policy condition that triggered this request.
+    pub condition_triggered: String,
+    /// Unix epoch timestamp (seconds) when the request was submitted.
+    pub submitted_at: u64,
+    /// Seconds before the request times out.
+    pub timeout_secs: u64,
+}
+
+// ---------------------------------------------------------------------------
+// ApprovalDecision  (placeholder — full definition added in next commit)
+// ---------------------------------------------------------------------------
+
+/// The outcome of a pending [`ApprovalRequest`].
+#[derive(Debug, Clone)]
+pub enum ApprovalDecision {
+    /// A human operator approved the action.
+    Approved {
+        /// Identifier of the operator who approved.
+        by: String,
+        /// Optional free-text rationale.
+        reason: Option<String>,
+    },
+    /// A human operator rejected the action.
+    Rejected {
+        /// Identifier of the operator who rejected.
+        by: String,
+        /// Mandatory explanation for the rejection.
+        reason: String,
+    },
+    /// The timeout elapsed before a human decided; the fallback policy applies.
+    TimedOut {
+        /// The fallback [`aa_core::PolicyResult`] originally attached to the request.
+        fallback: aa_core::PolicyResult,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- type aliases ---
+
+    #[test]
+    fn approval_request_id_is_uuid() {
+        let id: ApprovalRequestId = Uuid::new_v4();
+        assert!(!id.is_nil());
+    }
+
+    // --- ApprovalRequest fields ---
+
+    #[test]
+    fn approval_request_fields_are_accessible() {
+        let req = ApprovalRequest {
+            request_id: Uuid::new_v4(),
+            agent_id: "agent-1".to_string(),
+            action: "read_file /etc/passwd".to_string(),
+            condition_triggered: "sensitive-file-access".to_string(),
+            submitted_at: 1_700_000_000,
+            timeout_secs: 30,
+            fallback: aa_core::PolicyResult::Deny {
+                reason: "timed out".to_string(),
+            },
+        };
+        assert_eq!(req.agent_id, "agent-1");
+        assert_eq!(req.timeout_secs, 30);
+        assert!(!req.request_id.is_nil());
+    }
+
+    // --- PendingApprovalRequest ---
+
+    #[test]
+    fn pending_approval_request_fields_match_source() {
+        let id = Uuid::new_v4();
+        let pending = PendingApprovalRequest {
+            request_id: id,
+            agent_id: "agent-1".to_string(),
+            action: "read_file /etc/passwd".to_string(),
+            condition_triggered: "sensitive-file-access".to_string(),
+            submitted_at: 1_700_000_000,
+            timeout_secs: 60,
+        };
+        assert_eq!(pending.request_id, id);
+        assert_eq!(pending.agent_id, "agent-1");
+        assert_eq!(pending.timeout_secs, 60);
+    }
+}

--- a/aa-runtime/src/approval.rs
+++ b/aa-runtime/src/approval.rs
@@ -191,6 +191,37 @@ impl ApprovalQueue {
             false
         }
     }
+
+    /// Submit a new approval request and start its timeout task.
+    ///
+    /// Returns the request's [`ApprovalRequestId`] and an [`ApprovalFuture`]
+    /// that resolves when the request is settled (approved, rejected, or timed
+    /// out).
+    ///
+    /// # Timeout behaviour
+    ///
+    /// A `tokio::spawn`ed task sleeps for `request.timeout_secs` seconds, then
+    /// calls `resolve(TimedOut)`. Because [`resolve`] is idempotent, a human
+    /// decision that arrives before the timeout simply wins the race; the
+    /// timeout task's subsequent `resolve` call becomes a no-op.
+    pub fn submit(self: &Arc<Self>, request: ApprovalRequest) -> (ApprovalRequestId, ApprovalFuture) {
+        let id = request.request_id;
+        let timeout_secs = request.timeout_secs;
+        let fallback = request.fallback.clone();
+
+        let (tx, rx) = oneshot::channel();
+        self.pending.insert(id, (request, tx));
+
+        // Spawn the timeout enforcer.  The Arc clone keeps the queue alive
+        // for the duration of the sleep even if all other holders drop.
+        let queue = Arc::clone(self);
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_secs(timeout_secs)).await;
+            queue.resolve(id, ApprovalDecision::TimedOut { fallback });
+        });
+
+        (id, rx)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -324,5 +355,90 @@ mod tests {
             },
         );
         assert_eq!(result, Err(ApprovalError::NotFound));
+    }
+
+    fn make_request(timeout_secs: u64) -> ApprovalRequest {
+        ApprovalRequest {
+            request_id: Uuid::new_v4(),
+            agent_id: "agent-1".to_string(),
+            action: "read_file /etc/passwd".to_string(),
+            condition_triggered: "sensitive-file-access".to_string(),
+            submitted_at: 1_700_000_000,
+            timeout_secs,
+            fallback: aa_core::PolicyResult::Deny {
+                reason: "timed out".to_string(),
+            },
+        }
+    }
+
+    // --- ApprovalQueue::submit ---
+
+    #[tokio::test]
+    async fn submit_then_approve_resolves_future() {
+        let q = ApprovalQueue::new();
+        let req = make_request(60);
+        let id = req.request_id;
+        let (_rid, fut) = q.submit(req);
+
+        q.decide(
+            id,
+            ApprovalDecision::Approved { by: "alice".to_string(), reason: None },
+        )
+        .expect("decide should succeed");
+
+        let decision = fut.await.expect("future should resolve");
+        assert!(matches!(decision, ApprovalDecision::Approved { .. }));
+    }
+
+    #[tokio::test]
+    async fn submit_then_reject_resolves_future() {
+        let q = ApprovalQueue::new();
+        let req = make_request(60);
+        let id = req.request_id;
+        let (_rid, fut) = q.submit(req);
+
+        q.decide(
+            id,
+            ApprovalDecision::Rejected {
+                by: "bob".to_string(),
+                reason: "not allowed".to_string(),
+            },
+        )
+        .expect("decide should succeed");
+
+        let decision = fut.await.expect("future should resolve");
+        assert!(matches!(decision, ApprovalDecision::Rejected { .. }));
+    }
+
+    #[tokio::test]
+    async fn decide_after_resolve_returns_not_found() {
+        let q = ApprovalQueue::new();
+        let req = make_request(60);
+        let id = req.request_id;
+        let (_rid, _fut) = q.submit(req);
+
+        q.decide(
+            id,
+            ApprovalDecision::Approved { by: "alice".to_string(), reason: None },
+        )
+        .expect("first decide should succeed");
+
+        let result = q.decide(
+            id,
+            ApprovalDecision::Rejected { by: "eve".to_string(), reason: "too late".to_string() },
+        );
+        assert_eq!(result, Err(ApprovalError::NotFound));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn submit_times_out_after_timeout_secs() {
+        let q = ApprovalQueue::new();
+        let req = make_request(5);
+        let (_rid, fut) = q.submit(req);
+
+        tokio::time::advance(std::time::Duration::from_secs(6)).await;
+
+        let decision = fut.await.expect("future should resolve after timeout");
+        assert!(matches!(decision, ApprovalDecision::TimedOut { .. }));
     }
 }

--- a/aa-runtime/src/approval.rs
+++ b/aa-runtime/src/approval.rs
@@ -178,7 +178,20 @@ impl ApprovalQueue {
     /// if the entry was already gone (idempotent — a second call for the same
     /// `id` is a safe no-op).
     fn resolve(&self, id: ApprovalRequestId, decision: ApprovalDecision) -> bool {
-        if let Some((_key, (_req, tx))) = self.pending.remove(&id) {
+        if let Some((_key, (req, tx))) = self.pending.remove(&id) {
+            let (event_type, decided_by) = match &decision {
+                ApprovalDecision::Approved { by, .. } => ("ApprovalGranted", by.clone()),
+                ApprovalDecision::Rejected { by, .. } => ("ApprovalDenied", by.clone()),
+                ApprovalDecision::TimedOut { .. } => ("ApprovalTimedOut", "timeout".to_string()),
+            };
+            tracing::info!(
+                event_type,
+                request_id = %req.request_id,
+                agent_id = %req.agent_id,
+                action = %req.action,
+                decided_by = %decided_by,
+                "approval decision recorded"
+            );
             // Ignore send errors: the receiver may have been dropped (caller
             // gave up waiting), which is not a failure on our side.
             let _ = tx.send(decision);
@@ -204,6 +217,16 @@ impl ApprovalQueue {
         let id = request.request_id;
         let timeout_secs = request.timeout_secs;
         let fallback = request.fallback.clone();
+
+        tracing::info!(
+            event_type = "ApprovalRequested",
+            request_id = %id,
+            agent_id = %request.agent_id,
+            action = %request.action,
+            condition_triggered = %request.condition_triggered,
+            timeout_secs,
+            "approval requested"
+        );
 
         let (tx, rx) = oneshot::channel();
         self.pending.insert(id, (request, tx));

--- a/aa-runtime/src/approval.rs
+++ b/aa-runtime/src/approval.rs
@@ -159,6 +159,38 @@ impl ApprovalQueue {
             })
             .collect()
     }
+
+    /// Apply an [`ApprovalDecision`] to the request identified by `id`.
+    ///
+    /// Returns `Err(ApprovalError::NotFound)` if no pending request exists for
+    /// `id` (already resolved, timed out, or never submitted).
+    pub fn decide(
+        &self,
+        id: ApprovalRequestId,
+        decision: ApprovalDecision,
+    ) -> Result<(), ApprovalError> {
+        if self.resolve(id, decision) {
+            Ok(())
+        } else {
+            Err(ApprovalError::NotFound)
+        }
+    }
+
+    /// Remove and settle the request identified by `id`.
+    ///
+    /// Returns `true` if the entry existed and the sender was consumed, `false`
+    /// if the entry was already gone (idempotent — a second call for the same
+    /// `id` is a safe no-op).
+    fn resolve(&self, id: ApprovalRequestId, decision: ApprovalDecision) -> bool {
+        if let Some((_key, (_req, tx))) = self.pending.remove(&id) {
+            // Ignore send errors: the receiver may have been dropped (caller
+            // gave up waiting), which is not a failure on our side.
+            let _ = tx.send(decision);
+            true
+        } else {
+            false
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -277,5 +309,20 @@ mod tests {
     fn new_queue_list_is_empty() {
         let q = ApprovalQueue::new();
         assert!(q.list().is_empty());
+    }
+
+    // --- ApprovalQueue::decide (no pending entry) ---
+
+    #[test]
+    fn decide_unknown_id_returns_not_found() {
+        let q = ApprovalQueue::new();
+        let result = q.decide(
+            Uuid::new_v4(),
+            ApprovalDecision::Approved {
+                by: "alice".to_string(),
+                reason: None,
+            },
+        );
+        assert_eq!(result, Err(ApprovalError::NotFound));
     }
 }

--- a/aa-runtime/src/approval.rs
+++ b/aa-runtime/src/approval.rs
@@ -164,11 +164,7 @@ impl ApprovalQueue {
     ///
     /// Returns `Err(ApprovalError::NotFound)` if no pending request exists for
     /// `id` (already resolved, timed out, or never submitted).
-    pub fn decide(
-        &self,
-        id: ApprovalRequestId,
-        decision: ApprovalDecision,
-    ) -> Result<(), ApprovalError> {
+    pub fn decide(&self, id: ApprovalRequestId, decision: ApprovalDecision) -> Result<(), ApprovalError> {
         if self.resolve(id, decision) {
             Ok(())
         } else {
@@ -295,7 +291,9 @@ mod tests {
         let fallback = aa_core::PolicyResult::Deny {
             reason: "expired".to_string(),
         };
-        let d = ApprovalDecision::TimedOut { fallback: fallback.clone() };
+        let d = ApprovalDecision::TimedOut {
+            fallback: fallback.clone(),
+        };
         if let ApprovalDecision::TimedOut { fallback: f } = d {
             assert_eq!(f, fallback);
         } else {
@@ -382,7 +380,10 @@ mod tests {
 
         q.decide(
             id,
-            ApprovalDecision::Approved { by: "alice".to_string(), reason: None },
+            ApprovalDecision::Approved {
+                by: "alice".to_string(),
+                reason: None,
+            },
         )
         .expect("decide should succeed");
 
@@ -419,13 +420,19 @@ mod tests {
 
         q.decide(
             id,
-            ApprovalDecision::Approved { by: "alice".to_string(), reason: None },
+            ApprovalDecision::Approved {
+                by: "alice".to_string(),
+                reason: None,
+            },
         )
         .expect("first decide should succeed");
 
         let result = q.decide(
             id,
-            ApprovalDecision::Rejected { by: "eve".to_string(), reason: "too late".to_string() },
+            ApprovalDecision::Rejected {
+                by: "eve".to_string(),
+                reason: "too late".to_string(),
+            },
         );
         assert_eq!(result, Err(ApprovalError::NotFound));
     }
@@ -455,7 +462,10 @@ mod tests {
 
         q.decide(
             id,
-            ApprovalDecision::Approved { by: "alice".to_string(), reason: None },
+            ApprovalDecision::Approved {
+                by: "alice".to_string(),
+                reason: None,
+            },
         )
         .expect("decide should succeed");
 
@@ -483,7 +493,10 @@ mod tests {
         for id in &ids {
             q.decide(
                 *id,
-                ApprovalDecision::Approved { by: "operator".to_string(), reason: None },
+                ApprovalDecision::Approved {
+                    by: "operator".to_string(),
+                    reason: None,
+                },
             )
             .expect("decide should succeed for each request");
         }

--- a/aa-runtime/src/approval.rs
+++ b/aa-runtime/src/approval.rs
@@ -5,6 +5,10 @@
 //! until a human operator calls [`ApprovalQueue::decide`], or the per-request
 //! timeout elapses and the queue auto-resolves it as [`ApprovalDecision::TimedOut`].
 
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use tokio::sync::oneshot;
 use uuid::Uuid;
 
 // ---------------------------------------------------------------------------
@@ -115,6 +119,49 @@ impl std::fmt::Display for ApprovalError {
 impl std::error::Error for ApprovalError {}
 
 // ---------------------------------------------------------------------------
+// ApprovalQueue
+// ---------------------------------------------------------------------------
+
+/// Concurrent, in-memory store of pending approval requests.
+///
+/// Constructed via [`ApprovalQueue::new`], which returns an [`Arc`] so the
+/// queue can be cloned cheaply across tasks (e.g., the timeout spawner holds
+/// a back-reference).
+pub struct ApprovalQueue {
+    pending: DashMap<ApprovalRequestId, (ApprovalRequest, oneshot::Sender<ApprovalDecision>)>,
+}
+
+impl ApprovalQueue {
+    /// Creates a new, empty queue wrapped in an [`Arc`].
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            pending: DashMap::new(),
+        })
+    }
+
+    /// Returns a snapshot of all currently pending requests.
+    ///
+    /// The snapshot is consistent at the moment of the call; entries submitted
+    /// or resolved concurrently may not appear.
+    pub fn list(&self) -> Vec<PendingApprovalRequest> {
+        self.pending
+            .iter()
+            .map(|entry| {
+                let req = &entry.value().0;
+                PendingApprovalRequest {
+                    request_id: req.request_id,
+                    agent_id: req.agent_id.clone(),
+                    action: req.action.clone(),
+                    condition_triggered: req.condition_triggered.clone(),
+                    submitted_at: req.submitted_at,
+                    timeout_secs: req.timeout_secs,
+                }
+            })
+            .collect()
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -222,5 +269,13 @@ mod tests {
         assert_eq!(pending.request_id, id);
         assert_eq!(pending.agent_id, "agent-1");
         assert_eq!(pending.timeout_secs, 60);
+    }
+
+    // --- ApprovalQueue::new and list ---
+
+    #[test]
+    fn new_queue_list_is_empty() {
+        let q = ApprovalQueue::new();
+        assert!(q.list().is_empty());
     }
 }

--- a/aa-runtime/src/approval.rs
+++ b/aa-runtime/src/approval.rs
@@ -94,6 +94,27 @@ pub enum ApprovalDecision {
 }
 
 // ---------------------------------------------------------------------------
+// ApprovalError
+// ---------------------------------------------------------------------------
+
+/// Errors returned by [`ApprovalQueue::decide`].
+#[derive(Debug, PartialEq, Eq)]
+pub enum ApprovalError {
+    /// No pending request exists for the given ID (already resolved or never submitted).
+    NotFound,
+}
+
+impl std::fmt::Display for ApprovalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "approval request not found"),
+        }
+    }
+}
+
+impl std::error::Error for ApprovalError {}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -127,6 +148,62 @@ mod tests {
         assert_eq!(req.agent_id, "agent-1");
         assert_eq!(req.timeout_secs, 30);
         assert!(!req.request_id.is_nil());
+    }
+
+    // --- ApprovalDecision ---
+
+    #[test]
+    fn approval_decision_approved_fields() {
+        let d = ApprovalDecision::Approved {
+            by: "alice".to_string(),
+            reason: Some("looks safe".to_string()),
+        };
+        if let ApprovalDecision::Approved { by, reason } = d {
+            assert_eq!(by, "alice");
+            assert_eq!(reason, Some("looks safe".to_string()));
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    #[test]
+    fn approval_decision_rejected_fields() {
+        let d = ApprovalDecision::Rejected {
+            by: "bob".to_string(),
+            reason: "policy violation".to_string(),
+        };
+        if let ApprovalDecision::Rejected { by, reason } = d {
+            assert_eq!(by, "bob");
+            assert_eq!(reason, "policy violation");
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    #[test]
+    fn approval_decision_timed_out_carries_fallback() {
+        let fallback = aa_core::PolicyResult::Deny {
+            reason: "expired".to_string(),
+        };
+        let d = ApprovalDecision::TimedOut { fallback: fallback.clone() };
+        if let ApprovalDecision::TimedOut { fallback: f } = d {
+            assert_eq!(f, fallback);
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    // --- ApprovalError ---
+
+    #[test]
+    fn approval_error_not_found_display() {
+        let e = ApprovalError::NotFound;
+        assert_eq!(e.to_string(), "approval request not found");
+    }
+
+    #[test]
+    fn approval_error_not_found_eq() {
+        assert_eq!(ApprovalError::NotFound, ApprovalError::NotFound);
     }
 
     // --- PendingApprovalRequest ---

--- a/aa-runtime/src/ipc/server.rs
+++ b/aa-runtime/src/ipc/server.rs
@@ -653,6 +653,7 @@ mod tests {
             pipeline_token,
             Arc::new(crate::policy::PolicyRules::default()),
             pipeline_router,
+            crate::approval::ApprovalQueue::new(),
         ));
 
         // Connect a client.
@@ -741,6 +742,7 @@ mod tests {
             pipeline_token,
             Arc::new(crate::policy::PolicyRules::default()),
             pipeline_router,
+            crate::approval::ApprovalQueue::new(),
         ));
 
         // Connect a client.

--- a/aa-runtime/src/lib.rs
+++ b/aa-runtime/src/lib.rs
@@ -4,6 +4,7 @@
 //! for Agent Assembly components. It handles runtime initialization, shutdown
 //! coordination, and lifecycle hooks.
 
+pub mod approval;
 pub mod config;
 pub mod health;
 pub mod ipc;

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -6,16 +6,20 @@ pub mod metrics;
 pub use event::{EnrichedEvent, EventSource};
 pub use metrics::PipelineMetrics;
 
+use crate::approval::{ApprovalDecision as RuntimeApprovalDecision, ApprovalQueue, ApprovalRequest};
 use crate::config::RuntimeConfig;
 use crate::ipc::{IpcFrame, IpcResponse, ResponseRouter};
 use crate::policy::PolicyRules;
 use aa_proto::assembly::audit::v1::{audit_event::Detail, AuditEvent, PolicyViolation};
-use aa_proto::assembly::common::v1::ActionType;
+use aa_proto::assembly::common::v1::{ActionType, Decision};
+use aa_proto::assembly::event::v1::ApprovalDecision as ProtoApprovalDecision;
+use aa_proto::assembly::policy::v1::CheckActionResponse;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tokio::sync::{broadcast, mpsc};
 use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
 
 /// Configuration for the event aggregation pipeline.
 ///
@@ -61,6 +65,7 @@ pub async fn run(
     token: CancellationToken,
     policy: Arc<PolicyRules>,
     response_router: ResponseRouter,
+    approval_queue: Arc<ApprovalQueue>,
 ) {
     let seq = AtomicU64::new(0);
     let mut batch: Vec<EnrichedEvent> = Vec::with_capacity(config.batch_size);
@@ -80,25 +85,38 @@ pub async fn run(
             }
 
             Some((connection_id, frame)) = rx.recv() => {
-                if let IpcFrame::EventReport(event) = frame {
-                    let enriched = enrich(event, &config.agent_id, connection_id, &seq);
-                    tracing::debug!(sequence_number = enriched.sequence_number, connection_id, "event enriched");
-                    metrics.record_processed(1);
-                    ::metrics::counter!("aa_events_received_total").increment(1);
-                    if is_policy_violation(&enriched, &policy) {
-                        // Bypass the batch — emit immediately.
-                        ::metrics::counter!("aa_policy_violations_total").increment(1);
-                        // Push a ViolationAlert back to the originating SDK connection.
-                        push_violation_alert(&enriched, &response_router).await;
-                        let _ = broadcast_tx.send(enriched);
-                    } else {
-                        batch.push(enriched);
-                        if batch.len() >= config.batch_size {
-                            flush(&mut batch, &broadcast_tx, &metrics);
+                match frame {
+                    IpcFrame::EventReport(event) => {
+                        let enriched = enrich(event, &config.agent_id, connection_id, &seq);
+                        tracing::debug!(sequence_number = enriched.sequence_number, connection_id, "event enriched");
+                        metrics.record_processed(1);
+                        ::metrics::counter!("aa_events_received_total").increment(1);
+                        if is_policy_violation(&enriched, &policy) {
+                            // Bypass the batch — emit immediately.
+                            ::metrics::counter!("aa_policy_violations_total").increment(1);
+                            // Push a ViolationAlert back to the originating SDK connection.
+                            push_violation_alert(&enriched, &response_router).await;
+                            let _ = broadcast_tx.send(enriched);
+                        } else {
+                            batch.push(enriched);
+                            if batch.len() >= config.batch_size {
+                                flush(&mut batch, &broadcast_tx, &metrics);
+                            }
                         }
                     }
+                    IpcFrame::PolicyQuery(req) => {
+                        handle_policy_query(
+                            connection_id,
+                            req,
+                            &policy,
+                            &approval_queue,
+                            &response_router,
+                        )
+                        .await;
+                    }
+                    // ApprovalResponse, Heartbeat: not pipeline events, ignored.
+                    _ => {}
                 }
-                // PolicyQuery, ApprovalResponse, Heartbeat: not pipeline events, ignored.
             }
 
             _ = ticker.tick() => {
@@ -189,6 +207,137 @@ async fn push_violation_alert(event: &EnrichedEvent, router: &crate::ipc::Respon
             );
         }
     }
+}
+
+/// Send an [`IpcResponse`] to the SDK connection identified by `connection_id`.
+///
+/// If the connection has already disconnected the message is silently dropped.
+async fn send_ipc_response(connection_id: u64, response: IpcResponse, router: &ResponseRouter) {
+    let sender = {
+        let map = router.read().await;
+        map.get(&connection_id).cloned()
+    };
+    if let Some(tx) = sender {
+        if tx.send(response).await.is_err() {
+            tracing::debug!(connection_id, "IpcResponse dropped — connection already closed");
+        }
+    }
+}
+
+/// Evaluate a [`IpcFrame::PolicyQuery`] against the loaded policy and respond.
+///
+/// Decision priority (first match wins):
+/// 1. `requires_approval_actions` → `PENDING` + submit to [`ApprovalQueue`]; spawn a task to
+///    push an [`IpcResponse::ApprovalDecision`] back once the request is resolved.
+/// 2. `blocked_actions` → `DENY`.
+/// 3. No match → `ALLOW`.
+async fn handle_policy_query(
+    connection_id: u64,
+    req: aa_proto::assembly::policy::v1::CheckActionRequest,
+    policy: &PolicyRules,
+    approval_queue: &Arc<ApprovalQueue>,
+    response_router: &ResponseRouter,
+) {
+    let action_str = ActionType::try_from(req.action_type)
+        .map(|a| a.as_str_name())
+        .unwrap_or("");
+    let agent_id_str = req
+        .agent_id
+        .as_ref()
+        .map(|a| a.agent_id.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    // 1. Check requires_approval_actions.
+    for rule in &policy.rules {
+        if rule.requires_approval_actions.iter().any(|a| a == action_str) {
+            let request_id = Uuid::new_v4();
+            let submitted_at = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or(Duration::ZERO)
+                .as_secs();
+            let approval_req = ApprovalRequest {
+                request_id,
+                agent_id: agent_id_str.clone(),
+                action: action_str.to_string(),
+                condition_triggered: rule.name.clone(),
+                submitted_at,
+                timeout_secs: rule.approval_timeout_secs as u64,
+                fallback: aa_core::PolicyResult::Deny {
+                    reason: "approval timed out".to_string(),
+                },
+            };
+            let (rid, fut) = approval_queue.submit(approval_req);
+
+            send_ipc_response(
+                connection_id,
+                IpcResponse::PolicyResponse(CheckActionResponse {
+                    decision: Decision::Pending as i32,
+                    approval_id: rid.to_string(),
+                    policy_rule: rule.name.clone(),
+                    ..Default::default()
+                }),
+                response_router,
+            )
+            .await;
+
+            // Spawn a task that awaits resolution and pushes the decision back.
+            let router = Arc::clone(response_router);
+            tokio::spawn(async move {
+                if let Ok(decision) = fut.await {
+                    let (approved, decided_by, reason) = match decision {
+                        RuntimeApprovalDecision::Approved { by, reason } => (true, by, reason.unwrap_or_default()),
+                        RuntimeApprovalDecision::Rejected { by, reason } => (false, by, reason),
+                        RuntimeApprovalDecision::TimedOut { .. } => {
+                            (false, "timeout".to_string(), "approval timed out".to_string())
+                        }
+                    };
+                    let decided_at_unix_ms = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap_or(Duration::ZERO)
+                        .as_millis() as i64;
+                    let proto = ProtoApprovalDecision {
+                        approval_id: rid.to_string(),
+                        approved,
+                        decided_by,
+                        reason,
+                        decided_at_unix_ms,
+                    };
+                    send_ipc_response(connection_id, IpcResponse::ApprovalDecision(proto), &router).await;
+                }
+            });
+            return;
+        }
+    }
+
+    // 2. Check blocked_actions.
+    for rule in &policy.rules {
+        if rule.blocked_actions.iter().any(|ba| ba == action_str) {
+            send_ipc_response(
+                connection_id,
+                IpcResponse::PolicyResponse(CheckActionResponse {
+                    decision: Decision::Deny as i32,
+                    reason: format!("blocked by rule: {}", rule.name),
+                    policy_rule: rule.name.clone(),
+                    ..Default::default()
+                }),
+                response_router,
+            )
+            .await;
+            return;
+        }
+    }
+
+    // 3. Default: allow.
+    send_ipc_response(
+        connection_id,
+        IpcResponse::PolicyResponse(CheckActionResponse {
+            decision: Decision::Allow as i32,
+            ..Default::default()
+        }),
+        response_router,
+    )
+    .await;
 }
 
 /// Broadcast all events in `batch` and record metrics.
@@ -387,6 +536,7 @@ mod tests {
             token.clone(),
             Arc::new(PolicyRules::default()),
             crate::ipc::new_response_router(),
+            crate::approval::ApprovalQueue::new(),
         ));
 
         // Send 3 events — batch threshold reached, should flush before interval
@@ -421,6 +571,7 @@ mod tests {
             token.clone(),
             Arc::new(PolicyRules::default()),
             crate::ipc::new_response_router(),
+            crate::approval::ApprovalQueue::new(),
         ));
 
         // Send 5 events (less than batch_size=100) — should arrive after interval flush
@@ -455,6 +606,7 @@ mod tests {
             token.clone(),
             Arc::new(PolicyRules::default()),
             crate::ipc::new_response_router(),
+            crate::approval::ApprovalQueue::new(),
         ));
 
         // Send a violation — should arrive immediately, bypassing batch
@@ -486,6 +638,7 @@ mod tests {
             token.clone(),
             Arc::new(PolicyRules::default()),
             crate::ipc::new_response_router(),
+            crate::approval::ApprovalQueue::new(),
         ));
 
         // Send 5 events (batch won't flush yet)
@@ -538,6 +691,7 @@ mod tests {
             token.clone(),
             Arc::new(PolicyRules::default()),
             crate::ipc::new_response_router(),
+            crate::approval::ApprovalQueue::new(),
         ));
 
         // Send non-event frames
@@ -561,6 +715,7 @@ mod tests {
             rules: vec![PolicyRule {
                 name: "block-files".to_string(),
                 blocked_actions: vec![ActionType::FileOperation.as_str_name().to_string()],
+                ..Default::default()
             }],
         });
 
@@ -579,6 +734,7 @@ mod tests {
             token.clone(),
             policy,
             crate::ipc::new_response_router(),
+            crate::approval::ApprovalQueue::new(),
         ));
 
         // Build an AuditEvent with action_type = FILE_OPERATION
@@ -609,6 +765,7 @@ mod tests {
             rules: vec![PolicyRule {
                 name: "block-files".to_string(),
                 blocked_actions: vec![ActionType::FileOperation.as_str_name().to_string()],
+                ..Default::default()
             }],
         });
 
@@ -627,6 +784,7 @@ mod tests {
             token.clone(),
             policy,
             crate::ipc::new_response_router(),
+            crate::approval::ApprovalQueue::new(),
         ));
 
         // Yield briefly so the pipeline's interval fires its immediate first tick
@@ -667,6 +825,7 @@ mod tests {
             token.clone(),
             Arc::new(PolicyRules::default()),
             crate::ipc::new_response_router(),
+            crate::approval::ApprovalQueue::new(),
         ));
 
         for _ in 0..3 {
@@ -708,6 +867,7 @@ mod tests {
             token.clone(),
             Arc::new(PolicyRules::default()),
             crate::ipc::new_response_router(),
+            crate::approval::ApprovalQueue::new(),
         ));
 
         // First batch of 2
@@ -771,6 +931,7 @@ mod tests {
             token.clone(),
             Arc::new(PolicyRules::default()),
             crate::ipc::new_response_router(),
+            crate::approval::ApprovalQueue::new(),
         ));
 
         // Spawn a receiver that drains the broadcast channel
@@ -807,6 +968,240 @@ mod tests {
         );
 
         assert!(elapsed.as_secs() < 5, "100k events took more than 5s: {:?}", elapsed);
+        token.cancel();
+    }
+
+    // -----------------------------------------------------------------------
+    // PolicyQuery handling tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: build a router with a live receiver for `connection_id = 0`.
+    fn make_router_with_receiver() -> (ResponseRouter, tokio::sync::mpsc::Receiver<IpcResponse>) {
+        let router = crate::ipc::new_response_router();
+        let (tx, rx) = tokio::sync::mpsc::channel::<IpcResponse>(16);
+        router.try_write().unwrap().insert(0, tx);
+        (router, rx)
+    }
+
+    fn policy_query_frame(action_type: aa_proto::assembly::common::v1::ActionType) -> IpcFrame {
+        IpcFrame::PolicyQuery(aa_proto::assembly::policy::v1::CheckActionRequest {
+            action_type: action_type as i32,
+            ..Default::default()
+        })
+    }
+
+    #[tokio::test]
+    async fn policy_query_no_rules_responds_allow() {
+        use aa_proto::assembly::common::v1::{ActionType, Decision};
+
+        let config = test_config(100, 10_000);
+        let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
+        let (broadcast_tx, _rx) = broadcast::channel::<EnrichedEvent>(64);
+        let metrics = Arc::new(PipelineMetrics::default());
+        let token = CancellationToken::new();
+        let (router, mut resp_rx) = make_router_with_receiver();
+        let approval_queue = crate::approval::ApprovalQueue::new();
+
+        tokio::spawn(run(
+            rx,
+            broadcast_tx,
+            config,
+            metrics,
+            token.clone(),
+            Arc::new(PolicyRules::default()),
+            router,
+            approval_queue,
+        ));
+
+        tx.send((0, policy_query_frame(ActionType::ToolCall))).await.unwrap();
+
+        let resp = tokio::time::timeout(Duration::from_millis(200), resp_rx.recv())
+            .await
+            .expect("response timed out")
+            .expect("channel closed");
+
+        if let IpcResponse::PolicyResponse(r) = resp {
+            assert_eq!(r.decision, Decision::Allow as i32);
+        } else {
+            panic!("expected PolicyResponse, got {resp:?}");
+        }
+        token.cancel();
+    }
+
+    #[tokio::test]
+    async fn policy_query_blocked_action_responds_deny() {
+        use crate::policy::{PolicyRule, PolicyRules};
+        use aa_proto::assembly::common::v1::{ActionType, Decision};
+
+        let policy = Arc::new(PolicyRules {
+            rules: vec![PolicyRule {
+                name: "block-tool".to_string(),
+                blocked_actions: vec![ActionType::ToolCall.as_str_name().to_string()],
+                ..Default::default()
+            }],
+        });
+
+        let config = test_config(100, 10_000);
+        let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
+        let (broadcast_tx, _rx) = broadcast::channel::<EnrichedEvent>(64);
+        let metrics = Arc::new(PipelineMetrics::default());
+        let token = CancellationToken::new();
+        let (router, mut resp_rx) = make_router_with_receiver();
+        let approval_queue = crate::approval::ApprovalQueue::new();
+
+        tokio::spawn(run(
+            rx,
+            broadcast_tx,
+            config,
+            metrics,
+            token.clone(),
+            policy,
+            router,
+            approval_queue,
+        ));
+
+        tx.send((0, policy_query_frame(ActionType::ToolCall))).await.unwrap();
+
+        let resp = tokio::time::timeout(Duration::from_millis(200), resp_rx.recv())
+            .await
+            .expect("response timed out")
+            .expect("channel closed");
+
+        if let IpcResponse::PolicyResponse(r) = resp {
+            assert_eq!(r.decision, Decision::Deny as i32);
+        } else {
+            panic!("expected PolicyResponse, got {resp:?}");
+        }
+        token.cancel();
+    }
+
+    #[tokio::test]
+    async fn policy_query_requires_approval_responds_pending_and_adds_to_queue() {
+        use crate::policy::{PolicyRule, PolicyRules};
+        use aa_proto::assembly::common::v1::{ActionType, Decision};
+
+        let policy = Arc::new(PolicyRules {
+            rules: vec![PolicyRule {
+                name: "approve-tool".to_string(),
+                requires_approval_actions: vec![ActionType::ToolCall.as_str_name().to_string()],
+                approval_timeout_secs: 60,
+                ..Default::default()
+            }],
+        });
+
+        let config = test_config(100, 10_000);
+        let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
+        let (broadcast_tx, _rx) = broadcast::channel::<EnrichedEvent>(64);
+        let metrics = Arc::new(PipelineMetrics::default());
+        let token = CancellationToken::new();
+        let (router, mut resp_rx) = make_router_with_receiver();
+        let approval_queue = crate::approval::ApprovalQueue::new();
+        let queue_ref = Arc::clone(&approval_queue);
+
+        tokio::spawn(run(
+            rx,
+            broadcast_tx,
+            config,
+            metrics,
+            token.clone(),
+            policy,
+            router,
+            approval_queue,
+        ));
+
+        tx.send((0, policy_query_frame(ActionType::ToolCall))).await.unwrap();
+
+        let resp = tokio::time::timeout(Duration::from_millis(200), resp_rx.recv())
+            .await
+            .expect("response timed out")
+            .expect("channel closed");
+
+        if let IpcResponse::PolicyResponse(r) = resp {
+            assert_eq!(r.decision, Decision::Pending as i32);
+            assert!(!r.approval_id.is_empty(), "approval_id should be set");
+        } else {
+            panic!("expected PolicyResponse(PENDING), got {resp:?}");
+        }
+
+        // One pending entry should now be in the queue.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        assert_eq!(queue_ref.list().len(), 1);
+
+        token.cancel();
+    }
+
+    #[tokio::test]
+    async fn policy_query_pending_resolution_pushes_approval_decision() {
+        use crate::approval::ApprovalDecision as RuntimeApprovalDecision;
+        use crate::policy::{PolicyRule, PolicyRules};
+        use aa_proto::assembly::common::v1::ActionType;
+
+        let policy = Arc::new(PolicyRules {
+            rules: vec![PolicyRule {
+                name: "approve-tool".to_string(),
+                requires_approval_actions: vec![ActionType::ToolCall.as_str_name().to_string()],
+                approval_timeout_secs: 60,
+                ..Default::default()
+            }],
+        });
+
+        let config = test_config(100, 10_000);
+        let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
+        let (broadcast_tx, _rx) = broadcast::channel::<EnrichedEvent>(64);
+        let metrics = Arc::new(PipelineMetrics::default());
+        let token = CancellationToken::new();
+        let (router, mut resp_rx) = make_router_with_receiver();
+        let approval_queue = crate::approval::ApprovalQueue::new();
+        let queue_ref = Arc::clone(&approval_queue);
+
+        tokio::spawn(run(
+            rx,
+            broadcast_tx,
+            config,
+            metrics,
+            token.clone(),
+            policy,
+            router,
+            approval_queue,
+        ));
+
+        // Send the query — get back PENDING with approval_id.
+        tx.send((0, policy_query_frame(ActionType::ToolCall))).await.unwrap();
+        let pending_resp = tokio::time::timeout(Duration::from_millis(200), resp_rx.recv())
+            .await
+            .expect("response timed out")
+            .expect("channel closed");
+        let approval_id = if let IpcResponse::PolicyResponse(r) = pending_resp {
+            uuid::Uuid::parse_str(&r.approval_id).expect("invalid UUID in approval_id")
+        } else {
+            panic!("expected PolicyResponse(PENDING), got {pending_resp:?}");
+        };
+
+        // Approve it via the queue.
+        queue_ref
+            .decide(
+                approval_id,
+                RuntimeApprovalDecision::Approved {
+                    by: "test-operator".to_string(),
+                    reason: Some("looks safe".to_string()),
+                },
+            )
+            .expect("decide should succeed");
+
+        // The spawned resolution task should push an ApprovalDecision response.
+        let decision_resp = tokio::time::timeout(Duration::from_millis(200), resp_rx.recv())
+            .await
+            .expect("ApprovalDecision push timed out")
+            .expect("channel closed");
+
+        if let IpcResponse::ApprovalDecision(proto) = decision_resp {
+            assert!(proto.approved);
+            assert_eq!(proto.decided_by, "test-operator");
+            assert_eq!(proto.approval_id, approval_id.to_string());
+        } else {
+            panic!("expected IpcResponse::ApprovalDecision, got {decision_resp:?}");
+        }
+
         token.cancel();
     }
 }

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -57,6 +57,7 @@ impl PipelineConfig {
 /// enriches and batches events, and fans them out via `broadcast_tx`.
 ///
 /// Returns when `token` is cancelled — flushing any pending batch first.
+#[allow(clippy::too_many_arguments)]
 pub async fn run(
     mut rx: mpsc::Receiver<(u64, IpcFrame)>,
     broadcast_tx: broadcast::Sender<EnrichedEvent>,

--- a/aa-runtime/src/policy.rs
+++ b/aa-runtime/src/policy.rs
@@ -2,14 +2,38 @@
 
 use serde::Deserialize;
 
-/// A single policy rule: a named set of action strings that are blocked.
+fn default_approval_timeout_secs() -> u32 {
+    300
+}
+
+/// A single policy rule: a named set of action strings that are blocked or require approval.
 #[derive(Debug, Clone, Deserialize)]
 pub struct PolicyRule {
     /// Human-readable rule name (used in violation log messages).
     pub name: String,
-    /// Action strings that this rule blocks.
-    /// Matched against `AuditEvent` action fields during pipeline evaluation.
+    /// Action strings that this rule blocks outright.
+    /// Matched against the action type string during pipeline evaluation.
     pub blocked_actions: Vec<String>,
+    /// Action strings that require human approval before proceeding.
+    /// When matched, the pipeline responds with `Decision::PENDING` and
+    /// submits the request to the [`crate::approval::ApprovalQueue`].
+    #[serde(default)]
+    pub requires_approval_actions: Vec<String>,
+    /// Seconds before an approval request times out and the fallback policy applies.
+    /// Defaults to 300 (5 minutes) when absent from the policy file.
+    #[serde(default = "default_approval_timeout_secs")]
+    pub approval_timeout_secs: u32,
+}
+
+impl Default for PolicyRule {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            blocked_actions: Vec::new(),
+            requires_approval_actions: Vec::new(),
+            approval_timeout_secs: 300,
+        }
+    }
 }
 
 /// The full set of policy rules loaded at runtime startup.
@@ -82,6 +106,7 @@ mod tests {
             rules: vec![PolicyRule {
                 name: "test-rule".to_string(),
                 blocked_actions: vec!["dangerous_action".to_string()],
+                ..Default::default()
             }],
         };
         assert!(!rules.is_empty());
@@ -92,9 +117,21 @@ mod tests {
         let rule = PolicyRule {
             name: "block-exfil".to_string(),
             blocked_actions: vec!["send_email".to_string(), "upload_file".to_string()],
+            ..Default::default()
         };
         assert_eq!(rule.name, "block-exfil");
         assert_eq!(rule.blocked_actions.len(), 2);
+    }
+
+    #[test]
+    fn policy_rule_requires_approval_defaults_empty() {
+        let rule = PolicyRule {
+            name: "approval-rule".to_string(),
+            requires_approval_actions: vec!["TOOL_CALL".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(rule.requires_approval_actions, vec!["TOOL_CALL"]);
+        assert_eq!(rule.approval_timeout_secs, 300);
     }
 
     #[test]
@@ -116,6 +153,8 @@ mod tests {
         assert_eq!(result.rules.len(), 1);
         assert_eq!(result.rules[0].name, "block-exfil");
         assert_eq!(result.rules[0].blocked_actions, vec!["send_email"]);
+        assert!(result.rules[0].requires_approval_actions.is_empty());
+        assert_eq!(result.rules[0].approval_timeout_secs, 300);
     }
 
     #[test]

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -88,6 +88,9 @@ pub async fn run(config: RuntimeConfig) {
     // Shared response router — maps connection_id → per-connection IpcResponse sender.
     let response_router = crate::ipc::new_response_router();
 
+    // Shared approval queue — holds pending human-approval requests.
+    let approval_queue = crate::approval::ApprovalQueue::new();
+
     // Clone inbound_tx for the health/metrics handler before IpcServer consumes it.
     let inbound_tx_health = inbound_tx.clone();
 
@@ -120,6 +123,7 @@ pub async fn run(config: RuntimeConfig) {
         let pm = pipeline_metrics.clone();
         let pipeline_policy = std::sync::Arc::clone(&policy);
         let pipeline_router = std::sync::Arc::clone(&response_router);
+        let pipeline_approval_queue = std::sync::Arc::clone(&approval_queue);
         tracker.spawn(async move {
             crate::pipeline::run(
                 inbound_rx,
@@ -129,6 +133,7 @@ pub async fn run(config: RuntimeConfig) {
                 pipeline_token,
                 pipeline_policy,
                 pipeline_router,
+                pipeline_approval_queue,
             )
             .await;
         });


### PR DESCRIPTION
## Summary

- Adds `ApprovalTimedOut = 8` discriminant to `AuditEventType` in `aa-core`
- Introduces `aa-runtime/src/approval.rs` with the full `ApprovalQueue` API:
  - `ApprovalRequest` / `PendingApprovalRequest` structs and type aliases
  - `ApprovalDecision` (Approved / Rejected / TimedOut) and `ApprovalError`
  - `ApprovalQueue::new()`, `list()`, `decide()`, `submit()` with per-request tokio timeout task
- Adds `dashmap = "6"` and `uuid = "1"` (v4) to `aa-runtime` dependencies

## Architecture

`submit()` returns a `(ApprovalRequestId, oneshot::Receiver<ApprovalDecision>)`. The internal `resolve()` method is the single idempotent exit point — `DashMap::remove` is atomic, so a human decision and the timeout task racing each other is safe: whichever fires first wins, the second becomes a no-op.

## Test plan

- [ ] `cargo test --workspace` — all tests pass (verified locally: 0 failures)
- [ ] `approval::tests::submit_times_out_after_timeout_secs` — uses `tokio::time::advance` with paused clock
- [ ] `approval::tests::submit_100_concurrent_requests_all_resolve` — 100 concurrent submits + decides, all futures resolve

Closes #AAASM-71

🤖 Generated with [Claude Code](https://claude.com/claude-code)