### PR TITLE
[AAASM-72] ✨ (budget): Implement budget tracking engine with daily limit enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,9 @@ dependencies = [
  "dashmap",
  "notify",
  "regex",
+ "rust_decimal",
  "serde",
+ "serde_json",
  "serde_yaml",
  "tempfile",
  "tokio",
@@ -157,6 +159,17 @@ name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
 
 [[package]]
 name = "ahash"
@@ -273,6 +286,12 @@ checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asn1-rs"
@@ -536,6 +555,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,10 +576,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytes"
@@ -595,6 +672,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -1047,6 +1125,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1185,6 +1269,15 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -1478,9 +1571,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1596,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1750,7 +1843,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "portable-atomic",
 ]
 
@@ -2339,6 +2432,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "pyo3"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,11 +2606,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
@@ -2507,8 +2628,18 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2526,6 +2657,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -2636,6 +2770,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,6 +2833,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2721,6 +2893,23 @@ checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "sha2",
  "walkdir",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.6",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2836,6 +3025,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -2997,6 +3192,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3065,6 +3266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
+ "quote",
  "unicode-ident",
 ]
 
@@ -3098,6 +3300,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
@@ -3738,22 +3946,23 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3761,9 +3970,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3771,9 +3980,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3784,9 +3993,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -3827,9 +4036,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4283,6 +4492,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x509-parser"

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -7,18 +7,19 @@ repository.workspace = true
 description = "Control plane — policy enforcement engine and agent registry for Agent Assembly"
 
 [dependencies]
-aa-core    = { path = "../aa-core" }
-aa-proto   = { path = "../aa-proto" }
-aa-runtime = { path = "../aa-runtime" }
-tokio      = { version = "1", features = ["full"] }
-regex      = "1"
-serde      = { version = "1", features = ["derive"] }
-serde_yaml = "0.9"
-arc-swap   = "1"
-dashmap    = "6"
-notify     = { version = "6", features = [] }
-chrono     = { version = "0.4", features = ["clock"] }
-chrono-tz  = "0.9"
+aa-core      = { path = "../aa-core" }
+aa-proto     = { path = "../aa-proto" }
+aa-runtime   = { path = "../aa-runtime" }
+tokio        = { version = "1", features = ["full"] }
+regex        = "1"
+serde        = { version = "1", features = ["derive"] }
+serde_yaml   = "0.9"
+arc-swap     = "1"
+dashmap      = "6"
+notify       = { version = "6", features = [] }
+chrono       = { version = "0.4", features = ["clock"] }
+chrono-tz    = "0.9"
+rust_decimal = { version = "1", features = ["serde-str"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -18,7 +18,7 @@ serde_yaml   = "0.9"
 arc-swap     = "1"
 dashmap      = "6"
 notify       = { version = "6", features = [] }
-chrono       = { version = "0.4", features = ["clock"] }
+chrono       = { version = "0.4", features = ["clock", "serde"] }
 chrono-tz    = "0.9"
 rust_decimal = { version = "1", features = ["serde-str"] }
 

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -13,6 +13,7 @@ aa-runtime   = { path = "../aa-runtime" }
 tokio        = { version = "1", features = ["full"] }
 regex        = "1"
 serde        = { version = "1", features = ["derive"] }
+serde_json   = "1"
 serde_yaml   = "0.9"
 arc-swap     = "1"
 dashmap      = "6"

--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -10,7 +10,8 @@ pub use pricing::{PricingEntry, PricingLoadError, PricingTable};
 
 pub mod persistence;
 pub use persistence::{
-    default_budget_path, load_from_disk, save_to_disk_atomic, PersistedAgentEntry, PersistedBudget, PersistenceError,
+    default_budget_path, load_from_disk, save_to_disk_atomic, start_background_writer, PersistedAgentEntry,
+    PersistedBudget, PersistenceError,
 };
 
 pub mod tracker;

--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -9,6 +9,7 @@ pub mod pricing;
 pub use pricing::{PricingEntry, PricingLoadError, PricingTable};
 
 pub mod persistence;
+pub use persistence::PersistedAgentEntry;
 
 pub mod tracker;
 pub use tracker::BudgetTracker;

--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -3,4 +3,4 @@
 //! Entry point: [`tracker::BudgetTracker::record_usage`].
 
 pub mod types;
-pub use types::Provider;
+pub use types::{Model, Provider};

--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -7,3 +7,6 @@ pub use types::{BudgetAlert, BudgetState, BudgetStatus, Model, Provider};
 
 pub mod pricing;
 pub use pricing::{PricingEntry, PricingLoadError, PricingTable};
+
+pub mod tracker;
+pub use tracker::BudgetTracker;

--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -1,0 +1,3 @@
+//! Budget tracking engine for `aa-gateway`.
+//!
+//! Entry point: [`tracker::BudgetTracker::record_usage`].

--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -6,4 +6,4 @@ pub mod types;
 pub use types::{BudgetAlert, BudgetState, BudgetStatus, Model, Provider};
 
 pub mod pricing;
-pub use pricing::{PricingEntry, PricingLoadError};
+pub use pricing::{PricingEntry, PricingLoadError, PricingTable};

--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -6,4 +6,4 @@ pub mod types;
 pub use types::{BudgetAlert, BudgetState, BudgetStatus, Model, Provider};
 
 pub mod pricing;
-pub use pricing::PricingEntry;
+pub use pricing::{PricingEntry, PricingLoadError};

--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -9,7 +9,9 @@ pub mod pricing;
 pub use pricing::{PricingEntry, PricingLoadError, PricingTable};
 
 pub mod persistence;
-pub use persistence::{default_budget_path, load_from_disk, PersistedAgentEntry, PersistedBudget, PersistenceError};
+pub use persistence::{
+    default_budget_path, load_from_disk, save_to_disk_atomic, PersistedAgentEntry, PersistedBudget, PersistenceError,
+};
 
 pub mod tracker;
 pub use tracker::BudgetTracker;

--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -3,4 +3,4 @@
 //! Entry point: [`tracker::BudgetTracker::record_usage`].
 
 pub mod types;
-pub use types::{BudgetState, BudgetStatus, Model, Provider};
+pub use types::{BudgetAlert, BudgetState, BudgetStatus, Model, Provider};

--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -9,7 +9,7 @@ pub mod pricing;
 pub use pricing::{PricingEntry, PricingLoadError, PricingTable};
 
 pub mod persistence;
-pub use persistence::PersistedAgentEntry;
+pub use persistence::{PersistedAgentEntry, PersistedBudget};
 
 pub mod tracker;
 pub use tracker::BudgetTracker;

--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -9,7 +9,7 @@ pub mod pricing;
 pub use pricing::{PricingEntry, PricingLoadError, PricingTable};
 
 pub mod persistence;
-pub use persistence::{PersistedAgentEntry, PersistedBudget};
+pub use persistence::{PersistedAgentEntry, PersistedBudget, PersistenceError};
 
 pub mod tracker;
 pub use tracker::BudgetTracker;

--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -3,4 +3,4 @@
 //! Entry point: [`tracker::BudgetTracker::record_usage`].
 
 pub mod types;
-pub use types::{Model, Provider};
+pub use types::{BudgetStatus, Model, Provider};

--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -8,5 +8,7 @@ pub use types::{BudgetAlert, BudgetState, BudgetStatus, Model, Provider};
 pub mod pricing;
 pub use pricing::{PricingEntry, PricingLoadError, PricingTable};
 
+pub mod persistence;
+
 pub mod tracker;
 pub use tracker::BudgetTracker;

--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -1,3 +1,6 @@
 //! Budget tracking engine for `aa-gateway`.
 //!
 //! Entry point: [`tracker::BudgetTracker::record_usage`].
+
+pub mod types;
+pub use types::Provider;

--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -9,7 +9,7 @@ pub mod pricing;
 pub use pricing::{PricingEntry, PricingLoadError, PricingTable};
 
 pub mod persistence;
-pub use persistence::{default_budget_path, PersistedAgentEntry, PersistedBudget, PersistenceError};
+pub use persistence::{default_budget_path, load_from_disk, PersistedAgentEntry, PersistedBudget, PersistenceError};
 
 pub mod tracker;
 pub use tracker::BudgetTracker;

--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -9,7 +9,7 @@ pub mod pricing;
 pub use pricing::{PricingEntry, PricingLoadError, PricingTable};
 
 pub mod persistence;
-pub use persistence::{PersistedAgentEntry, PersistedBudget, PersistenceError};
+pub use persistence::{default_budget_path, PersistedAgentEntry, PersistedBudget, PersistenceError};
 
 pub mod tracker;
 pub use tracker::BudgetTracker;

--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -4,3 +4,6 @@
 
 pub mod types;
 pub use types::{BudgetAlert, BudgetState, BudgetStatus, Model, Provider};
+
+pub mod pricing;
+pub use pricing::PricingEntry;

--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -3,4 +3,4 @@
 //! Entry point: [`tracker::BudgetTracker::record_usage`].
 
 pub mod types;
-pub use types::{BudgetStatus, Model, Provider};
+pub use types::{BudgetState, BudgetStatus, Model, Provider};

--- a/aa-gateway/src/budget/persistence.rs
+++ b/aa-gateway/src/budget/persistence.rs
@@ -53,4 +53,13 @@ mod tests {
         };
         assert_eq!(entry.agent_id_hex, "aabbcc");
     }
+
+    #[test]
+    fn persisted_budget_holds_entries_and_global() {
+        let budget = PersistedBudget {
+            per_agent: vec![],
+            global: BudgetState::new_today(),
+        };
+        assert!(budget.per_agent.is_empty());
+    }
 }

--- a/aa-gateway/src/budget/persistence.rs
+++ b/aa-gateway/src/budget/persistence.rs
@@ -32,6 +32,12 @@ impl std::fmt::Display for PersistenceError {
 
 impl std::error::Error for PersistenceError {}
 
+/// Returns `~/.aa/budget.json` (uses `$HOME` env var; falls back to `.`).
+pub fn default_budget_path() -> std::path::PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+    std::path::PathBuf::from(home).join(".aa").join("budget.json")
+}
+
 pub fn agent_id_to_hex(id: &aa_core::AgentId) -> String {
     id.as_bytes().iter().map(|b| format!("{:02x}", b)).collect()
 }
@@ -70,6 +76,12 @@ mod tests {
             state: BudgetState::new_today(),
         };
         assert_eq!(entry.agent_id_hex, "aabbcc");
+    }
+
+    #[test]
+    fn default_budget_path_ends_with_budget_json() {
+        let p = default_budget_path();
+        assert!(p.to_string_lossy().ends_with("budget.json"));
     }
 
     #[test]

--- a/aa-gateway/src/budget/persistence.rs
+++ b/aa-gateway/src/budget/persistence.rs
@@ -1,4 +1,4 @@
-//! Budget persistence — STUB (will be fully implemented in Tasks 25–32).
+//! Atomic disk persistence for budget state.
 
 use crate::budget::types::BudgetState;
 
@@ -37,5 +37,20 @@ fn hex_nibble(b: u8) -> Result<u8, String> {
         b'a'..=b'f' => Ok(b - b'a' + 10),
         b'A'..=b'F' => Ok(b - b'A' + 10),
         _ => Err(format!("invalid hex byte: {b}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::budget::types::BudgetState;
+
+    #[test]
+    fn persisted_agent_entry_stores_hex_and_state() {
+        let entry = PersistedAgentEntry {
+            agent_id_hex: "aabbcc".to_string(),
+            state: BudgetState::new_today(),
+        };
+        assert_eq!(entry.agent_id_hex, "aabbcc");
     }
 }

--- a/aa-gateway/src/budget/persistence.rs
+++ b/aa-gateway/src/budget/persistence.rs
@@ -14,6 +14,24 @@ pub struct PersistedBudget {
     pub global: BudgetState,
 }
 
+/// Error type for persistence I/O operations.
+#[derive(Debug)]
+pub enum PersistenceError {
+    Io(std::io::Error),
+    Json(serde_json::Error),
+}
+
+impl std::fmt::Display for PersistenceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PersistenceError::Io(e) => write!(f, "budget I/O error: {e}"),
+            PersistenceError::Json(e) => write!(f, "budget JSON error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for PersistenceError {}
+
 pub fn agent_id_to_hex(id: &aa_core::AgentId) -> String {
     id.as_bytes().iter().map(|b| format!("{:02x}", b)).collect()
 }
@@ -52,6 +70,12 @@ mod tests {
             state: BudgetState::new_today(),
         };
         assert_eq!(entry.agent_id_hex, "aabbcc");
+    }
+
+    #[test]
+    fn persistence_error_io_displays_message() {
+        let e = PersistenceError::Io(std::io::Error::new(std::io::ErrorKind::Other, "disk full"));
+        assert!(e.to_string().contains("budget I/O error"));
     }
 
     #[test]

--- a/aa-gateway/src/budget/persistence.rs
+++ b/aa-gateway/src/budget/persistence.rs
@@ -50,6 +50,18 @@ pub fn load_from_disk(path: &std::path::Path) -> Result<PersistedBudget, Persist
     }
 }
 
+/// Write budget to path atomically: write to `<path>.json.tmp`, then rename.
+pub fn save_to_disk_atomic(path: &std::path::Path, budget: &PersistedBudget) -> Result<(), PersistenceError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(PersistenceError::Io)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    let json = serde_json::to_string_pretty(budget).map_err(PersistenceError::Json)?;
+    std::fs::write(&tmp, &json).map_err(PersistenceError::Io)?;
+    std::fs::rename(&tmp, path).map_err(PersistenceError::Io)?;
+    Ok(())
+}
+
 pub fn agent_id_to_hex(id: &aa_core::AgentId) -> String {
     id.as_bytes().iter().map(|b| format!("{:02x}", b)).collect()
 }
@@ -107,6 +119,40 @@ mod tests {
         let p = std::path::Path::new("/nonexistent/budget.json");
         let b = load_from_disk(p).unwrap();
         assert!(b.per_agent.is_empty());
+    }
+
+    #[test]
+    fn save_then_load_round_trips_decimal_precisely() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("budget.json");
+        let budget = PersistedBudget {
+            per_agent: vec![PersistedAgentEntry {
+                agent_id_hex: "0102030405060708090a0b0c0d0e0f10".to_string(),
+                state: crate::budget::types::BudgetState {
+                    spent_usd: "12.345".parse().unwrap(),
+                    date: chrono::Utc::now().date_naive(),
+                },
+            }],
+            global: crate::budget::types::BudgetState::new_today(),
+        };
+        save_to_disk_atomic(&path, &budget).unwrap();
+        let loaded = load_from_disk(&path).unwrap();
+        assert_eq!(loaded.per_agent[0].state.spent_usd, budget.per_agent[0].state.spent_usd);
+    }
+
+    #[test]
+    fn save_to_disk_creates_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("budget.json");
+        save_to_disk_atomic(
+            &path,
+            &PersistedBudget {
+                per_agent: vec![],
+                global: crate::budget::types::BudgetState::new_today(),
+            },
+        )
+        .unwrap();
+        assert!(path.exists());
     }
 
     #[test]

--- a/aa-gateway/src/budget/persistence.rs
+++ b/aa-gateway/src/budget/persistence.rs
@@ -1,0 +1,41 @@
+//! Budget persistence — STUB (will be fully implemented in Tasks 25–32).
+
+use crate::budget::types::BudgetState;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PersistedAgentEntry {
+    pub agent_id_hex: String,
+    pub state: BudgetState,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PersistedBudget {
+    pub per_agent: Vec<PersistedAgentEntry>,
+    pub global: BudgetState,
+}
+
+pub fn agent_id_to_hex(id: &aa_core::AgentId) -> String {
+    id.as_bytes().iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+pub fn hex_to_agent_id(hex: &str) -> Result<aa_core::AgentId, std::io::Error> {
+    if hex.len() != 32 {
+        return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "bad hex len"));
+    }
+    let mut bytes = [0u8; 16];
+    for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
+        let hi = hex_nibble(chunk[0]).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        let lo = hex_nibble(chunk[1]).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        bytes[i] = (hi << 4) | lo;
+    }
+    Ok(aa_core::AgentId::from_bytes(bytes))
+}
+
+fn hex_nibble(b: u8) -> Result<u8, String> {
+    match b {
+        b'0'..=b'9' => Ok(b - b'0'),
+        b'a'..=b'f' => Ok(b - b'a' + 10),
+        b'A'..=b'F' => Ok(b - b'A' + 10),
+        _ => Err(format!("invalid hex byte: {b}")),
+    }
+}

--- a/aa-gateway/src/budget/persistence.rs
+++ b/aa-gateway/src/budget/persistence.rs
@@ -135,7 +135,7 @@ mod tests {
 
     #[test]
     fn persistence_error_io_displays_message() {
-        let e = PersistenceError::Io(std::io::Error::new(std::io::ErrorKind::Other, "disk full"));
+        let e = PersistenceError::Io(std::io::Error::other("disk full"));
         assert!(e.to_string().contains("budget I/O error"));
     }
 

--- a/aa-gateway/src/budget/persistence.rs
+++ b/aa-gateway/src/budget/persistence.rs
@@ -38,6 +38,18 @@ pub fn default_budget_path() -> std::path::PathBuf {
     std::path::PathBuf::from(home).join(".aa").join("budget.json")
 }
 
+/// Load persisted budget from disk. Returns an empty budget on `NotFound`.
+pub fn load_from_disk(path: &std::path::Path) -> Result<PersistedBudget, PersistenceError> {
+    match std::fs::read_to_string(path) {
+        Ok(json) => serde_json::from_str(&json).map_err(PersistenceError::Json),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(PersistedBudget {
+            per_agent: vec![],
+            global: crate::budget::types::BudgetState::new_today(),
+        }),
+        Err(e) => Err(PersistenceError::Io(e)),
+    }
+}
+
 pub fn agent_id_to_hex(id: &aa_core::AgentId) -> String {
     id.as_bytes().iter().map(|b| format!("{:02x}", b)).collect()
 }
@@ -88,6 +100,13 @@ mod tests {
     fn persistence_error_io_displays_message() {
         let e = PersistenceError::Io(std::io::Error::new(std::io::ErrorKind::Other, "disk full"));
         assert!(e.to_string().contains("budget I/O error"));
+    }
+
+    #[test]
+    fn load_from_disk_returns_empty_on_missing_file() {
+        let p = std::path::Path::new("/nonexistent/budget.json");
+        let b = load_from_disk(p).unwrap();
+        assert!(b.per_agent.is_empty());
     }
 
     #[test]

--- a/aa-gateway/src/budget/persistence.rs
+++ b/aa-gateway/src/budget/persistence.rs
@@ -62,29 +62,37 @@ pub fn save_to_disk_atomic(path: &std::path::Path, budget: &PersistedBudget) -> 
     Ok(())
 }
 
+/// Encode an `AgentId` as a 32-char lowercase hex string.
 pub fn agent_id_to_hex(id: &aa_core::AgentId) -> String {
     id.as_bytes().iter().map(|b| format!("{:02x}", b)).collect()
 }
 
-pub fn hex_to_agent_id(hex: &str) -> Result<aa_core::AgentId, std::io::Error> {
+/// Decode a 32-char hex string back to an `AgentId`.
+pub fn hex_to_agent_id(hex: &str) -> Result<aa_core::AgentId, PersistenceError> {
     if hex.len() != 32 {
-        return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, "bad hex len"));
+        return Err(PersistenceError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("expected 32 hex chars, got {}", hex.len()),
+        )));
     }
     let mut bytes = [0u8; 16];
     for (i, chunk) in hex.as_bytes().chunks(2).enumerate() {
-        let hi = hex_nibble(chunk[0]).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        let lo = hex_nibble(chunk[1]).map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        let hi = hex_nibble(chunk[0])?;
+        let lo = hex_nibble(chunk[1])?;
         bytes[i] = (hi << 4) | lo;
     }
     Ok(aa_core::AgentId::from_bytes(bytes))
 }
 
-fn hex_nibble(b: u8) -> Result<u8, String> {
+fn hex_nibble(b: u8) -> Result<u8, PersistenceError> {
     match b {
         b'0'..=b'9' => Ok(b - b'0'),
         b'a'..=b'f' => Ok(b - b'a' + 10),
         b'A'..=b'F' => Ok(b - b'A' + 10),
-        _ => Err(format!("invalid hex byte: {b}")),
+        _ => Err(PersistenceError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("invalid hex byte: {b}"),
+        ))),
     }
 }
 
@@ -162,5 +170,15 @@ mod tests {
             global: BudgetState::new_today(),
         };
         assert!(budget.per_agent.is_empty());
+    }
+
+    #[test]
+    fn agent_id_hex_round_trip() {
+        use aa_core::AgentId;
+        let id = AgentId::from_bytes([0xABu8; 16]);
+        let hex = agent_id_to_hex(&id);
+        assert_eq!(hex.len(), 32);
+        let restored = hex_to_agent_id(&hex).unwrap();
+        assert_eq!(id, restored);
     }
 }

--- a/aa-gateway/src/budget/persistence.rs
+++ b/aa-gateway/src/budget/persistence.rs
@@ -62,6 +62,23 @@ pub fn save_to_disk_atomic(path: &std::path::Path, budget: &PersistedBudget) -> 
     Ok(())
 }
 
+/// Spawn a tokio task that saves tracker state every 60 seconds.
+pub fn start_background_writer(
+    tracker: std::sync::Arc<crate::budget::tracker::BudgetTracker>,
+    path: std::path::PathBuf,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+        loop {
+            interval.tick().await;
+            let snapshot = tracker.snapshot();
+            if let Err(e) = save_to_disk_atomic(&path, &snapshot) {
+                eprintln!("aa-gateway budget: persistence error: {e}");
+            }
+        }
+    })
+}
+
 /// Encode an `AgentId` as a 32-char lowercase hex string.
 pub fn agent_id_to_hex(id: &aa_core::AgentId) -> String {
     id.as_bytes().iter().map(|b| format!("{:02x}", b)).collect()
@@ -180,5 +197,19 @@ mod tests {
         assert_eq!(hex.len(), 32);
         let restored = hex_to_agent_id(&hex).unwrap();
         assert_eq!(id, restored);
+    }
+
+    #[test]
+    fn start_background_writer_returns_join_handle() {
+        use crate::budget::{pricing::PricingTable, tracker::BudgetTracker};
+        use std::sync::Arc;
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let tracker = Arc::new(BudgetTracker::new(PricingTable::default_table(), None));
+            let dir = tempfile::tempdir().unwrap();
+            let path = dir.path().join("budget.json");
+            let handle = start_background_writer(tracker, path);
+            handle.abort(); // immediately abort — just verifying it compiles and starts
+        });
     }
 }

--- a/aa-gateway/src/budget/pricing.rs
+++ b/aa-gateway/src/budget/pricing.rs
@@ -13,9 +13,32 @@ pub struct PricingEntry {
     pub output_per_1k_usd: Decimal,
 }
 
+/// Error loading the pricing JSON config.
+#[derive(Debug)]
+pub enum PricingLoadError {
+    Json(serde_json::Error),
+}
+
+impl std::fmt::Display for PricingLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PricingLoadError::Json(e) => write!(f, "pricing JSON error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for PricingLoadError {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pricing_load_error_displays_message() {
+        let raw = serde_json::from_str::<serde_json::Value>("not json").unwrap_err();
+        let err = PricingLoadError::Json(raw);
+        assert!(err.to_string().contains("pricing JSON error"));
+    }
 
     #[test]
     fn pricing_entry_stores_rates() {

--- a/aa-gateway/src/budget/pricing.rs
+++ b/aa-gateway/src/budget/pricing.rs
@@ -1,0 +1,32 @@
+//! LLM pricing table — per-model USD cost per 1,000 tokens.
+
+use rust_decimal::Decimal;
+
+/// USD cost per 1,000 tokens for one direction (input or output).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PricingEntry {
+    /// USD per 1,000 input tokens.
+    #[serde(with = "rust_decimal::serde::str")]
+    pub input_per_1k_usd: Decimal,
+    /// USD per 1,000 output tokens.
+    #[serde(with = "rust_decimal::serde::str")]
+    pub output_per_1k_usd: Decimal,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pricing_entry_stores_rates() {
+        fn d(s: &str) -> rust_decimal::Decimal {
+            s.parse().unwrap()
+        }
+        let entry = PricingEntry {
+            input_per_1k_usd: d("0.005"),
+            output_per_1k_usd: d("0.015"),
+        };
+        assert_eq!(entry.input_per_1k_usd, d("0.005"));
+        assert_eq!(entry.output_per_1k_usd, d("0.015"));
+    }
+}

--- a/aa-gateway/src/budget/pricing.rs
+++ b/aa-gateway/src/budget/pricing.rs
@@ -13,6 +13,69 @@ pub struct PricingEntry {
     pub output_per_1k_usd: Decimal,
 }
 
+/// Flat JSON record used only for deserialization.
+#[derive(serde::Deserialize)]
+#[allow(dead_code)] // used in load_from_json_str (added in next task)
+struct PricingJsonRow {
+    provider: crate::budget::types::Provider,
+    model: crate::budget::types::Model,
+    #[serde(with = "rust_decimal::serde::str")]
+    input_per_1k_usd: Decimal,
+    #[serde(with = "rust_decimal::serde::str")]
+    output_per_1k_usd: Decimal,
+}
+
+/// In-memory table mapping `(Provider, Model)` to pricing.
+#[derive(Debug, Clone)]
+pub struct PricingTable {
+    entries: std::collections::HashMap<(crate::budget::types::Provider, crate::budget::types::Model), PricingEntry>,
+}
+
+impl PricingTable {
+    /// Build the default embedded pricing table (2024 list prices).
+    pub fn default_table() -> Self {
+        use crate::budget::types::{Model, Provider};
+        fn d(s: &str) -> Decimal {
+            s.parse().expect("embedded literal")
+        }
+
+        let rows: &[(Provider, Model, &str, &str)] = &[
+            (Provider::OpenAi, Model::Gpt4o, "0.005", "0.015"),
+            (Provider::OpenAi, Model::Gpt4, "0.03", "0.06"),
+            (Provider::OpenAi, Model::Gpt35Turbo, "0.0005", "0.0015"),
+            (Provider::Anthropic, Model::Claude3Opus, "0.015", "0.075"),
+            (Provider::Anthropic, Model::Claude3Sonnet, "0.003", "0.015"),
+            (Provider::Anthropic, Model::Claude3Haiku, "0.00025", "0.00125"),
+            (Provider::Cohere, Model::CommandRPlus, "0.003", "0.015"),
+            (Provider::Cohere, Model::CommandR, "0.0005", "0.0015"),
+        ];
+
+        let entries = rows
+            .iter()
+            .map(|(prov, model, inp, out)| {
+                (
+                    (*prov, *model),
+                    PricingEntry {
+                        input_per_1k_usd: d(inp),
+                        output_per_1k_usd: d(out),
+                    },
+                )
+            })
+            .collect();
+
+        Self { entries }
+    }
+
+    /// Look up pricing for a `(provider, model)` pair.
+    pub fn entry(
+        &self,
+        provider: crate::budget::types::Provider,
+        model: crate::budget::types::Model,
+    ) -> Option<&PricingEntry> {
+        self.entries.get(&(provider, model))
+    }
+}
+
 /// Error loading the pricing JSON config.
 #[derive(Debug)]
 pub enum PricingLoadError {
@@ -32,6 +95,36 @@ impl std::error::Error for PricingLoadError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn default_table_contains_all_eight_models() {
+        use crate::budget::types::{Model, Provider};
+        let table = PricingTable::default_table();
+        for (prov, model) in [
+            (Provider::OpenAi, Model::Gpt4o),
+            (Provider::OpenAi, Model::Gpt4),
+            (Provider::OpenAi, Model::Gpt35Turbo),
+            (Provider::Anthropic, Model::Claude3Opus),
+            (Provider::Anthropic, Model::Claude3Sonnet),
+            (Provider::Anthropic, Model::Claude3Haiku),
+            (Provider::Cohere, Model::CommandRPlus),
+            (Provider::Cohere, Model::CommandR),
+        ] {
+            assert!(table.entry(prov, model).is_some(), "{prov:?}/{model:?} missing");
+        }
+    }
+
+    #[test]
+    fn default_table_gpt4o_has_correct_rates() {
+        use crate::budget::types::{Model, Provider};
+        fn d(s: &str) -> rust_decimal::Decimal {
+            s.parse().unwrap()
+        }
+        let table = PricingTable::default_table();
+        let entry = table.entry(Provider::OpenAi, Model::Gpt4o).unwrap();
+        assert_eq!(entry.input_per_1k_usd, d("0.005"));
+        assert_eq!(entry.output_per_1k_usd, d("0.015"));
+    }
 
     #[test]
     fn pricing_load_error_displays_message() {

--- a/aa-gateway/src/budget/pricing.rs
+++ b/aa-gateway/src/budget/pricing.rs
@@ -92,6 +92,24 @@ impl PricingTable {
         }
     }
 
+    /// Compute USD cost for a completed LLM call. Returns `Decimal::ZERO` for unknown pairs.
+    pub fn cost_usd(
+        &self,
+        provider: crate::budget::types::Provider,
+        model: crate::budget::types::Model,
+        input_tokens: u64,
+        output_tokens: u64,
+    ) -> Decimal {
+        match self.entries.get(&(provider, model)) {
+            Some(entry) => {
+                let input_cost = entry.input_per_1k_usd * Decimal::from(input_tokens) / Decimal::from(1_000u64);
+                let output_cost = entry.output_per_1k_usd * Decimal::from(output_tokens) / Decimal::from(1_000u64);
+                input_cost + output_cost
+            }
+            None => Decimal::ZERO,
+        }
+    }
+
     /// Look up pricing for a `(provider, model)` pair.
     pub fn entry(
         &self,
@@ -121,6 +139,42 @@ impl std::error::Error for PricingLoadError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cost_usd_gpt4o_input_only() {
+        use crate::budget::types::{Model, Provider};
+        fn d(s: &str) -> rust_decimal::Decimal {
+            s.parse().unwrap()
+        }
+        let table = PricingTable::default_table();
+        // 1,000 input tokens × $0.005/1k = $0.005
+        assert_eq!(table.cost_usd(Provider::OpenAi, Model::Gpt4o, 1_000, 0), d("0.005"));
+    }
+
+    #[test]
+    fn cost_usd_gpt4o_mixed_tokens() {
+        use crate::budget::types::{Model, Provider};
+        fn d(s: &str) -> rust_decimal::Decimal {
+            s.parse().unwrap()
+        }
+        let table = PricingTable::default_table();
+        // 100k input ($0.50) + 20k output ($0.30) = $0.80
+        assert_eq!(
+            table.cost_usd(Provider::OpenAi, Model::Gpt4o, 100_000, 20_000),
+            d("0.80")
+        );
+    }
+
+    #[test]
+    fn cost_usd_unknown_pair_returns_zero() {
+        use crate::budget::types::{Model, Provider};
+        let table = PricingTable::default_table();
+        // Anthropic + CommandR is not a valid pair
+        assert_eq!(
+            table.cost_usd(Provider::Anthropic, Model::CommandR, 1_000, 1_000),
+            rust_decimal::Decimal::ZERO,
+        );
+    }
 
     #[test]
     fn load_from_file_falls_back_to_defaults_on_missing_file() {

--- a/aa-gateway/src/budget/pricing.rs
+++ b/aa-gateway/src/budget/pricing.rs
@@ -15,7 +15,6 @@ pub struct PricingEntry {
 
 /// Flat JSON record used only for deserialization.
 #[derive(serde::Deserialize)]
-#[allow(dead_code)] // used in load_from_json_str (added in next task)
 struct PricingJsonRow {
     provider: crate::budget::types::Provider,
     model: crate::budget::types::Model,
@@ -66,6 +65,22 @@ impl PricingTable {
         Self { entries }
     }
 
+    /// Load pricing overrides from a JSON string, merging on top of the defaults.
+    pub fn load_from_json_str(json: &str) -> Result<Self, PricingLoadError> {
+        let rows: Vec<PricingJsonRow> = serde_json::from_str(json).map_err(PricingLoadError::Json)?;
+        let mut table = Self::default_table();
+        for row in rows {
+            table.entries.insert(
+                (row.provider, row.model),
+                PricingEntry {
+                    input_per_1k_usd: row.input_per_1k_usd,
+                    output_per_1k_usd: row.output_per_1k_usd,
+                },
+            );
+        }
+        Ok(table)
+    }
+
     /// Look up pricing for a `(provider, model)` pair.
     pub fn entry(
         &self,
@@ -95,6 +110,23 @@ impl std::error::Error for PricingLoadError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn load_from_json_str_overrides_gpt4o_input_price() {
+        use crate::budget::types::{Model, Provider};
+        fn d(s: &str) -> rust_decimal::Decimal {
+            s.parse().unwrap()
+        }
+        let json = r#"[
+          { "provider": "open_ai", "model": "gpt4o",
+            "input_per_1k_usd": "0.999", "output_per_1k_usd": "0.015" }
+        ]"#;
+        let table = PricingTable::load_from_json_str(json).unwrap();
+        let entry = table.entry(Provider::OpenAi, Model::Gpt4o).unwrap();
+        assert_eq!(entry.input_per_1k_usd, d("0.999"));
+        // Non-overridden models keep defaults
+        assert!(table.entry(Provider::Anthropic, Model::Claude3Opus).is_some());
+    }
 
     #[test]
     fn default_table_contains_all_eight_models() {

--- a/aa-gateway/src/budget/pricing.rs
+++ b/aa-gateway/src/budget/pricing.rs
@@ -81,6 +81,17 @@ impl PricingTable {
         Ok(table)
     }
 
+    /// Load from a file path. Returns `default_table()` silently on any I/O or parse error.
+    pub fn load_from_file(path: &std::path::Path) -> Self {
+        match std::fs::read_to_string(path) {
+            Ok(json) => Self::load_from_json_str(&json).unwrap_or_else(|e| {
+                eprintln!("aa-gateway: pricing.json parse error ({e}); using defaults");
+                Self::default_table()
+            }),
+            Err(_) => Self::default_table(),
+        }
+    }
+
     /// Look up pricing for a `(provider, model)` pair.
     pub fn entry(
         &self,
@@ -110,6 +121,14 @@ impl std::error::Error for PricingLoadError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn load_from_file_falls_back_to_defaults_on_missing_file() {
+        let path = std::path::Path::new("/nonexistent/path/pricing.json");
+        let table = PricingTable::load_from_file(path);
+        use crate::budget::types::{Model, Provider};
+        assert!(table.entry(Provider::OpenAi, Model::Gpt4o).is_some());
+    }
 
     #[test]
     fn load_from_json_str_overrides_gpt4o_input_price() {

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -146,6 +146,14 @@ impl BudgetTracker {
 
         status
     }
+
+    /// Return a snapshot of the current global (all-agents combined) budget state.
+    pub fn global_state(&self) -> BudgetState {
+        self.global
+            .lock()
+            .map(|g| g.clone())
+            .unwrap_or_else(|_| BudgetState::new_today())
+    }
 }
 
 #[cfg(test)]
@@ -276,5 +284,16 @@ mod tests {
         let t = BudgetTracker::with_state(PricingTable::default_table(), None, persisted);
         let entry = t.per_agent.get(&id).unwrap();
         assert_eq!(entry.spent_usd, state.spent_usd);
+    }
+
+    #[test]
+    fn global_state_accumulates_all_agents() {
+        use crate::budget::types::{Model, Provider};
+        let t = new_tracker();
+        t.record_usage(agent(5), Provider::OpenAi, Model::Gpt4o, 1_000, 0); // $0.005
+        t.record_usage(agent(6), Provider::OpenAi, Model::Gpt4o, 1_000, 0); // $0.005
+        let g = t.global_state();
+        let expected: Decimal = "0.010".parse().unwrap();
+        assert_eq!(g.spent_usd, expected);
     }
 }

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -1,0 +1,58 @@
+//! Per-agent and global LLM spend tracker.
+
+use std::sync::Mutex;
+
+use dashmap::DashMap;
+use rust_decimal::Decimal;
+use tokio::sync::broadcast;
+
+use aa_core::AgentId;
+
+use crate::budget::{
+    pricing::PricingTable,
+    types::{BudgetAlert, BudgetState},
+};
+
+const ALERT_CHANNEL_CAPACITY: usize = 64;
+
+/// Per-agent and global budget tracker. All methods take `&self` — safe to share via `Arc`.
+#[allow(dead_code)]
+pub struct BudgetTracker {
+    /// Per-agent daily spend. `pub(crate)` for test date manipulation.
+    pub(crate) per_agent: DashMap<AgentId, BudgetState>,
+    pub(crate) global: Mutex<BudgetState>,
+    pricing: PricingTable,
+    daily_limit_usd: Option<Decimal>,
+    alert_tx: broadcast::Sender<BudgetAlert>,
+}
+
+impl BudgetTracker {
+    /// Create a new tracker with no prior state.
+    pub fn new(pricing: PricingTable, daily_limit_usd: Option<Decimal>) -> Self {
+        let (alert_tx, _) = broadcast::channel(ALERT_CHANNEL_CAPACITY);
+        Self {
+            per_agent: DashMap::new(),
+            global: Mutex::new(BudgetState::new_today()),
+            pricing,
+            daily_limit_usd,
+            alert_tx,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::budget::pricing::PricingTable;
+    use rust_decimal::Decimal;
+
+    fn new_tracker() -> BudgetTracker {
+        BudgetTracker::new(PricingTable::default_table(), None)
+    }
+
+    #[test]
+    fn new_tracker_has_empty_per_agent_map() {
+        let t = new_tracker();
+        assert!(t.per_agent.is_empty());
+    }
+}

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -38,6 +38,31 @@ impl BudgetTracker {
             alert_tx,
         }
     }
+
+    /// Create a tracker pre-loaded with persisted state (call after `load_from_disk`).
+    pub fn with_state(
+        pricing: PricingTable,
+        daily_limit_usd: Option<Decimal>,
+        initial: crate::budget::persistence::PersistedBudget,
+    ) -> Self {
+        let (alert_tx, _) = broadcast::channel(ALERT_CHANNEL_CAPACITY);
+        let per_agent: DashMap<AgentId, BudgetState> = initial
+            .per_agent
+            .into_iter()
+            .filter_map(|e| {
+                crate::budget::persistence::hex_to_agent_id(&e.agent_id_hex)
+                    .ok()
+                    .map(|id| (id, e.state))
+            })
+            .collect();
+        Self {
+            per_agent,
+            global: Mutex::new(initial.global),
+            pricing,
+            daily_limit_usd,
+            alert_tx,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -54,5 +79,25 @@ mod tests {
     fn new_tracker_has_empty_per_agent_map() {
         let t = new_tracker();
         assert!(t.per_agent.is_empty());
+    }
+
+    #[test]
+    fn with_state_restores_per_agent_entries() {
+        use crate::budget::persistence::{agent_id_to_hex, PersistedAgentEntry, PersistedBudget};
+        let id = AgentId::from_bytes([42u8; 16]);
+        let state = BudgetState {
+            spent_usd: "5.00".parse::<Decimal>().unwrap(),
+            date: chrono::Utc::now().date_naive(),
+        };
+        let persisted = PersistedBudget {
+            per_agent: vec![PersistedAgentEntry {
+                agent_id_hex: agent_id_to_hex(&id),
+                state: state.clone(),
+            }],
+            global: BudgetState::new_today(),
+        };
+        let t = BudgetTracker::with_state(PricingTable::default_table(), None, persisted);
+        let entry = t.per_agent.get(&id).unwrap();
+        assert_eq!(entry.spent_usd, state.spent_usd);
     }
 }

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -19,7 +19,6 @@ const ALERT_CHANNEL_CAPACITY: usize = 64;
 const ALERT_PCT_HIGH: u8 = 95;
 const ALERT_PCT_LOW: u8 = 80;
 
-#[allow(dead_code)]
 fn compute_status(spent: Decimal, limit: Decimal) -> BudgetStatus {
     if spent >= limit {
         return BudgetStatus::LimitExceeded;
@@ -95,6 +94,58 @@ impl BudgetTracker {
     pub fn subscribe_alerts(&self) -> broadcast::Receiver<BudgetAlert> {
         self.alert_tx.subscribe()
     }
+
+    /// Record token usage and return the resulting [`BudgetStatus`].
+    pub fn record_usage(
+        &self,
+        agent_id: AgentId,
+        provider: crate::budget::types::Provider,
+        model: crate::budget::types::Model,
+        input_tokens: u64,
+        output_tokens: u64,
+    ) -> BudgetStatus {
+        let cost = self.pricing.cost_usd(provider, model, input_tokens, output_tokens);
+
+        self.per_agent
+            .entry(agent_id)
+            .and_modify(|s| {
+                s.maybe_reset();
+                s.spent_usd += cost;
+            })
+            .or_insert_with(|| {
+                let mut s = BudgetState::new_today();
+                s.spent_usd += cost;
+                s
+            });
+
+        let spent = self.per_agent.get(&agent_id).map(|s| s.spent_usd).unwrap_or(cost);
+
+        if let Ok(mut g) = self.global.lock() {
+            g.maybe_reset();
+            g.spent_usd += cost;
+        }
+
+        let status = match self.daily_limit_usd {
+            None => BudgetStatus::WithinBudget {
+                spent_usd: spent.to_f64().unwrap_or(0.0),
+                remaining_usd: f64::INFINITY,
+            },
+            Some(limit) => compute_status(spent, limit),
+        };
+
+        if let Some(limit) = self.daily_limit_usd {
+            if let BudgetStatus::ThresholdAlert { pct } = &status {
+                let _ = self.alert_tx.send(BudgetAlert {
+                    agent_id,
+                    threshold_pct: *pct,
+                    spent_usd: spent.to_f64().unwrap_or(0.0),
+                    limit_usd: limit.to_f64().unwrap_or(0.0),
+                });
+            }
+        }
+
+        status
+    }
 }
 
 #[cfg(test)]
@@ -105,6 +156,14 @@ mod tests {
 
     fn new_tracker() -> BudgetTracker {
         BudgetTracker::new(PricingTable::default_table(), None)
+    }
+
+    fn agent(b: u8) -> AgentId {
+        AgentId::from_bytes([b; 16])
+    }
+
+    fn tracker_with_limit(s: &str) -> BudgetTracker {
+        BudgetTracker::new(PricingTable::default_table(), Some(s.parse().unwrap()))
     }
 
     #[test]
@@ -151,6 +210,46 @@ mod tests {
         }
         assert_eq!(compute_status(d("10.00"), d("10.00")), BudgetStatus::LimitExceeded);
         assert_eq!(compute_status(d("11.00"), d("10.00")), BudgetStatus::LimitExceeded);
+    }
+
+    #[test]
+    fn record_usage_no_limit_returns_within_budget() {
+        use crate::budget::types::{BudgetStatus, Model, Provider};
+        let t = new_tracker();
+        let s = t.record_usage(agent(1), Provider::OpenAi, Model::Gpt4o, 100, 100);
+        assert!(matches!(s, BudgetStatus::WithinBudget { .. }));
+    }
+
+    #[test]
+    fn record_usage_over_limit_returns_limit_exceeded() {
+        use crate::budget::types::{BudgetStatus, Model, Provider};
+        // GPT-4o: 100k input=$0.50 + 40k output=$0.60 = $1.10 > $1.00 limit
+        let t = tracker_with_limit("1.00");
+        let s = t.record_usage(agent(2), Provider::OpenAi, Model::Gpt4o, 100_000, 40_000);
+        assert_eq!(s, BudgetStatus::LimitExceeded);
+    }
+
+    #[test]
+    fn record_usage_alert_at_80_pct() {
+        use crate::budget::types::{BudgetStatus, Model, Provider};
+        // 100k input=$0.50 + 20k output=$0.30 = $0.80 = 80% of $1.00
+        let t = tracker_with_limit("1.00");
+        let s = t.record_usage(agent(3), Provider::OpenAi, Model::Gpt4o, 100_000, 20_000);
+        assert_eq!(s, BudgetStatus::ThresholdAlert { pct: 80 });
+    }
+
+    #[test]
+    fn record_usage_resets_on_old_date() {
+        use crate::budget::types::{BudgetStatus, Model, Provider};
+        let t = tracker_with_limit("1.00");
+        let id = agent(4);
+        t.record_usage(id, Provider::OpenAi, Model::Gpt4o, 100_000, 30_000); // $0.95
+        t.per_agent.alter(&id, |_, mut s| {
+            s.date = chrono::Utc::now().date_naive() - chrono::Duration::days(1);
+            s
+        });
+        let s = t.record_usage(id, Provider::OpenAi, Model::Gpt4o, 100, 0);
+        assert!(matches!(s, BudgetStatus::WithinBudget { .. }));
     }
 
     #[test]

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -42,7 +42,6 @@ fn compute_status(spent: Decimal, limit: Decimal) -> BudgetStatus {
 }
 
 /// Per-agent and global budget tracker. All methods take `&self` — safe to share via `Arc`.
-#[allow(dead_code)]
 pub struct BudgetTracker {
     /// Per-agent daily spend. `pub(crate)` for test date manipulation.
     pub(crate) per_agent: DashMap<AgentId, BudgetState>,
@@ -153,6 +152,22 @@ impl BudgetTracker {
             .lock()
             .map(|g| g.clone())
             .unwrap_or_else(|_| BudgetState::new_today())
+    }
+
+    /// Snapshot the full tracker state for disk persistence.
+    pub fn snapshot(&self) -> crate::budget::persistence::PersistedBudget {
+        let per_agent = self
+            .per_agent
+            .iter()
+            .map(|entry| crate::budget::persistence::PersistedAgentEntry {
+                agent_id_hex: crate::budget::persistence::agent_id_to_hex(entry.key()),
+                state: entry.value().clone(),
+            })
+            .collect();
+        crate::budget::persistence::PersistedBudget {
+            per_agent,
+            global: self.global_state(),
+        }
     }
 }
 
@@ -284,6 +299,17 @@ mod tests {
         let t = BudgetTracker::with_state(PricingTable::default_table(), None, persisted);
         let entry = t.per_agent.get(&id).unwrap();
         assert_eq!(entry.spent_usd, state.spent_usd);
+    }
+
+    #[test]
+    fn snapshot_includes_per_agent_and_global() {
+        use crate::budget::types::{Model, Provider};
+        let t = new_tracker();
+        let id = agent(7);
+        t.record_usage(id, Provider::OpenAi, Model::Gpt4o, 1_000, 0);
+        let snap = t.snapshot();
+        assert_eq!(snap.per_agent.len(), 1);
+        assert_eq!(snap.global.spent_usd, snap.per_agent[0].state.spent_usd);
     }
 
     #[test]

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -63,6 +63,11 @@ impl BudgetTracker {
             alert_tx,
         }
     }
+
+    /// Subscribe to budget threshold alert events (80% and 95% crossings).
+    pub fn subscribe_alerts(&self) -> broadcast::Receiver<BudgetAlert> {
+        self.alert_tx.subscribe()
+    }
 }
 
 #[cfg(test)]
@@ -79,6 +84,12 @@ mod tests {
     fn new_tracker_has_empty_per_agent_map() {
         let t = new_tracker();
         assert!(t.per_agent.is_empty());
+    }
+
+    #[test]
+    fn subscribe_alerts_returns_receiver() {
+        let t = new_tracker();
+        let _rx = t.subscribe_alerts(); // compiles and doesn't panic
     }
 
     #[test]

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -8,12 +8,39 @@ use tokio::sync::broadcast;
 
 use aa_core::AgentId;
 
+use rust_decimal::prelude::ToPrimitive;
+
 use crate::budget::{
     pricing::PricingTable,
-    types::{BudgetAlert, BudgetState},
+    types::{BudgetAlert, BudgetState, BudgetStatus},
 };
 
 const ALERT_CHANNEL_CAPACITY: usize = 64;
+const ALERT_PCT_HIGH: u8 = 95;
+const ALERT_PCT_LOW: u8 = 80;
+
+#[allow(dead_code)]
+fn compute_status(spent: Decimal, limit: Decimal) -> BudgetStatus {
+    if spent >= limit {
+        return BudgetStatus::LimitExceeded;
+    }
+    let pct = (spent / limit * Decimal::ONE_HUNDRED)
+        .round_dp(0)
+        .to_u8()
+        .unwrap_or(100);
+    let spent_f = spent.to_f64().unwrap_or(0.0);
+    let limit_f = limit.to_f64().unwrap_or(0.0);
+    if pct >= ALERT_PCT_HIGH {
+        BudgetStatus::ThresholdAlert { pct: ALERT_PCT_HIGH }
+    } else if pct >= ALERT_PCT_LOW {
+        BudgetStatus::ThresholdAlert { pct: ALERT_PCT_LOW }
+    } else {
+        BudgetStatus::WithinBudget {
+            spent_usd: spent_f,
+            remaining_usd: limit_f - spent_f,
+        }
+    }
+}
 
 /// Per-agent and global budget tracker. All methods take `&self` — safe to share via `Arc`.
 #[allow(dead_code)]
@@ -84,6 +111,46 @@ mod tests {
     fn new_tracker_has_empty_per_agent_map() {
         let t = new_tracker();
         assert!(t.per_agent.is_empty());
+    }
+
+    #[test]
+    fn compute_status_returns_within_budget_below_80() {
+        use crate::budget::types::BudgetStatus;
+        fn d(s: &str) -> Decimal {
+            s.parse().unwrap()
+        }
+        let status = compute_status(d("7.00"), d("10.00")); // 70%
+        assert!(matches!(status, BudgetStatus::WithinBudget { .. }));
+    }
+
+    #[test]
+    fn compute_status_returns_alert_at_80() {
+        use crate::budget::types::BudgetStatus;
+        fn d(s: &str) -> Decimal {
+            s.parse().unwrap()
+        }
+        let status = compute_status(d("8.00"), d("10.00")); // exactly 80%
+        assert_eq!(status, BudgetStatus::ThresholdAlert { pct: 80 });
+    }
+
+    #[test]
+    fn compute_status_returns_alert_at_95() {
+        use crate::budget::types::BudgetStatus;
+        fn d(s: &str) -> Decimal {
+            s.parse().unwrap()
+        }
+        let status = compute_status(d("9.50"), d("10.00")); // exactly 95%
+        assert_eq!(status, BudgetStatus::ThresholdAlert { pct: 95 });
+    }
+
+    #[test]
+    fn compute_status_returns_limit_exceeded_at_100() {
+        use crate::budget::types::BudgetStatus;
+        fn d(s: &str) -> Decimal {
+            s.parse().unwrap()
+        }
+        assert_eq!(compute_status(d("10.00"), d("10.00")), BudgetStatus::LimitExceeded);
+        assert_eq!(compute_status(d("11.00"), d("10.00")), BudgetStatus::LimitExceeded);
     }
 
     #[test]

--- a/aa-gateway/src/budget/types.rs
+++ b/aa-gateway/src/budget/types.rs
@@ -1,0 +1,26 @@
+//! Core domain types for the budget tracking engine.
+
+/// LLM provider identifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Provider {
+    /// OpenAI (GPT-* models).
+    OpenAi,
+    /// Anthropic (Claude models).
+    Anthropic,
+    /// Cohere (Command models).
+    Cohere,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_variants_are_distinct() {
+        assert_eq!(Provider::OpenAi, Provider::OpenAi);
+        assert_ne!(Provider::OpenAi, Provider::Anthropic);
+        assert_ne!(Provider::OpenAi, Provider::Cohere);
+        assert_ne!(Provider::Anthropic, Provider::Cohere);
+    }
+}

--- a/aa-gateway/src/budget/types.rs
+++ b/aa-gateway/src/budget/types.rs
@@ -69,6 +69,19 @@ impl BudgetState {
     }
 }
 
+/// Alert emitted via broadcast when spend crosses 80% or 95% of the daily limit.
+#[derive(Debug, Clone)]
+pub struct BudgetAlert {
+    /// The agent whose spend triggered the alert.
+    pub agent_id: aa_core::AgentId,
+    /// Threshold percentage crossed: 80 or 95.
+    pub threshold_pct: u8,
+    /// Current total spend in USD.
+    pub spent_usd: f64,
+    /// Configured daily limit in USD.
+    pub limit_usd: f64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -147,5 +160,19 @@ mod tests {
         };
         state.maybe_reset();
         assert_eq!(state.spent_usd, amount);
+    }
+
+    #[test]
+    fn budget_alert_stores_fields() {
+        use aa_core::AgentId;
+        let id = AgentId::from_bytes([1u8; 16]);
+        let alert = BudgetAlert {
+            agent_id: id,
+            threshold_pct: 80,
+            spent_usd: 8.0,
+            limit_usd: 10.0,
+        };
+        assert_eq!(alert.threshold_pct, 80);
+        assert!((alert.spent_usd - 8.0).abs() < f64::EPSILON);
     }
 }

--- a/aa-gateway/src/budget/types.rs
+++ b/aa-gateway/src/budget/types.rs
@@ -29,6 +29,17 @@ pub enum Model {
     CommandR,
 }
 
+/// Result returned by [`super::tracker::BudgetTracker::record_usage`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum BudgetStatus {
+    /// Spend is below the 80% alert threshold.
+    WithinBudget { spent_usd: f64, remaining_usd: f64 },
+    /// Spend crossed 80% or 95% of the daily limit.
+    ThresholdAlert { pct: u8 },
+    /// Daily limit reached or exceeded — caller should block the LLM call.
+    LimitExceeded,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -47,5 +58,30 @@ mod tests {
         assert_ne!(Model::Gpt4o, Model::Gpt4);
         assert_ne!(Model::Claude3Opus, Model::Claude3Haiku);
         assert_ne!(Model::CommandRPlus, Model::CommandR);
+    }
+
+    #[test]
+    fn budget_status_within_budget_holds_values() {
+        let s = BudgetStatus::WithinBudget {
+            spent_usd: 5.0,
+            remaining_usd: 45.0,
+        };
+        match s {
+            BudgetStatus::WithinBudget {
+                spent_usd,
+                remaining_usd,
+            } => {
+                assert!((spent_usd - 5.0).abs() < f64::EPSILON);
+                assert!((remaining_usd - 45.0).abs() < f64::EPSILON);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn budget_status_threshold_alert_holds_pct() {
+        let s = BudgetStatus::ThresholdAlert { pct: 80 };
+        assert_eq!(s, BudgetStatus::ThresholdAlert { pct: 80 });
+        assert_ne!(s, BudgetStatus::ThresholdAlert { pct: 95 });
     }
 }

--- a/aa-gateway/src/budget/types.rs
+++ b/aa-gateway/src/budget/types.rs
@@ -40,6 +40,26 @@ pub enum BudgetStatus {
     LimitExceeded,
 }
 
+/// Per-agent accumulated spend for a single UTC calendar day.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct BudgetState {
+    /// Total USD spent today using exact decimal arithmetic.
+    #[serde(with = "rust_decimal::serde::str")]
+    pub spent_usd: rust_decimal::Decimal,
+    /// UTC calendar date this state is valid for.
+    pub date: chrono::NaiveDate,
+}
+
+impl BudgetState {
+    /// Create a fresh zero-spend state stamped with today's UTC date.
+    pub fn new_today() -> Self {
+        Self {
+            spent_usd: rust_decimal::Decimal::ZERO,
+            date: chrono::Utc::now().date_naive(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -83,5 +103,14 @@ mod tests {
         let s = BudgetStatus::ThresholdAlert { pct: 80 };
         assert_eq!(s, BudgetStatus::ThresholdAlert { pct: 80 });
         assert_ne!(s, BudgetStatus::ThresholdAlert { pct: 95 });
+    }
+
+    #[test]
+    fn budget_state_new_today_has_zero_spend() {
+        use chrono::Utc;
+        use rust_decimal::Decimal;
+        let state = BudgetState::new_today();
+        assert_eq!(state.spent_usd, Decimal::ZERO);
+        assert_eq!(state.date, Utc::now().date_naive());
     }
 }

--- a/aa-gateway/src/budget/types.rs
+++ b/aa-gateway/src/budget/types.rs
@@ -58,6 +58,15 @@ impl BudgetState {
             date: chrono::Utc::now().date_naive(),
         }
     }
+
+    /// Reset `spent_usd` to zero if `date` is before today UTC. No-op if same day.
+    pub fn maybe_reset(&mut self) {
+        let today = chrono::Utc::now().date_naive();
+        if self.date < today {
+            self.spent_usd = rust_decimal::Decimal::ZERO;
+            self.date = today;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -112,5 +121,31 @@ mod tests {
         let state = BudgetState::new_today();
         assert_eq!(state.spent_usd, Decimal::ZERO);
         assert_eq!(state.date, Utc::now().date_naive());
+    }
+
+    #[test]
+    fn budget_state_maybe_reset_clears_old_date() {
+        use chrono::Utc;
+        use rust_decimal::Decimal;
+        let mut state = BudgetState {
+            spent_usd: Decimal::new(500, 2), // 5.00
+            date: Utc::now().date_naive() - chrono::Duration::days(1),
+        };
+        state.maybe_reset();
+        assert_eq!(state.spent_usd, Decimal::ZERO);
+        assert_eq!(state.date, Utc::now().date_naive());
+    }
+
+    #[test]
+    fn budget_state_maybe_reset_same_day_is_noop() {
+        use chrono::Utc;
+        use rust_decimal::Decimal;
+        let amount = Decimal::new(500, 2); // 5.00
+        let mut state = BudgetState {
+            spent_usd: amount,
+            date: Utc::now().date_naive(),
+        };
+        state.maybe_reset();
+        assert_eq!(state.spent_usd, amount);
     }
 }

--- a/aa-gateway/src/budget/types.rs
+++ b/aa-gateway/src/budget/types.rs
@@ -12,6 +12,23 @@ pub enum Provider {
     Cohere,
 }
 
+/// LLM model identifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Model {
+    // OpenAI
+    Gpt4o,
+    Gpt4,
+    Gpt35Turbo,
+    // Anthropic
+    Claude3Opus,
+    Claude3Sonnet,
+    Claude3Haiku,
+    // Cohere
+    CommandRPlus,
+    CommandR,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -22,5 +39,13 @@ mod tests {
         assert_ne!(Provider::OpenAi, Provider::Anthropic);
         assert_ne!(Provider::OpenAi, Provider::Cohere);
         assert_ne!(Provider::Anthropic, Provider::Cohere);
+    }
+
+    #[test]
+    fn model_variants_are_distinct() {
+        assert_eq!(Model::Gpt4o, Model::Gpt4o);
+        assert_ne!(Model::Gpt4o, Model::Gpt4);
+        assert_ne!(Model::Claude3Opus, Model::Claude3Haiku);
+        assert_ne!(Model::CommandRPlus, Model::CommandR);
     }
 }

--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -4,8 +4,8 @@
 //! registry, evaluates governance policies, routes enforcement decisions
 //! back to proxies and SDK shims, and writes the audit trail.
 
+pub mod budget;
 pub mod engine;
 pub mod policy;
-pub mod budget;
 
 pub use engine::{PolicyEngine, PolicyLoadError};

--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -6,5 +6,6 @@
 
 pub mod engine;
 pub mod policy;
+pub mod budget;
 
 pub use engine::{PolicyEngine, PolicyLoadError};


### PR DESCRIPTION
## Description

Implements the `budget` module in `aa-gateway` — a complete budget tracking engine that accumulates per-agent and global LLM API costs from token usage, enforces daily limits with threshold alerts at 80%/95%, and persists state to `~/.aa/budget.json` every 60 seconds.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-72
- Epic: AAASM-8 (Governance Gateway & Policy Engine)

## Testing

- [x] Unit tests added / updated

116 tests pass (`cargo test -p aa-gateway --lib`). The `budget` module contributes 30 new tests across 4 files:

- `budget/types.rs` — 8 tests: `Provider`, `Model`, `BudgetStatus`, `BudgetState` (new_today, maybe_reset), `BudgetAlert`
- `budget/pricing.rs` — 9 tests: `PricingEntry`, `PricingLoadError`, `PricingTable` (default_table, load_from_json_str, load_from_file, cost_usd)
- `budget/tracker.rs` — 13 tests: `BudgetTracker::new`, `with_state`, `subscribe_alerts`, `compute_status`, `record_usage` (no limit, over limit, 80% alert, date reset), `global_state`, `snapshot`
- `budget/persistence.rs` — 9 tests: `PersistedAgentEntry`, `PersistedBudget`, `PersistenceError`, `default_budget_path`, `load_from_disk`, `save_to_disk_atomic` (round-trip + creates file), hex round-trip, `start_background_writer`

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

---

### Commit breakdown (32 atomic commits)

| # | Commit | Description |
|---|--------|-------------|
| 1–3 | ⬆️/🔧 deps | Add `rust_decimal` (serde-str), `serde_json`, chrono `serde` feature |
| 4–5 | ✨/🔌 scaffold | Create `budget/mod.rs` stub; expose `pub mod budget` from `lib.rs` |
| 6–11 | ✨ types | `Provider`, `Model`, `BudgetStatus`, `BudgetState` (+`new_today`, `maybe_reset`), `BudgetAlert` |
| 12–17 | ✨ pricing | `PricingEntry`, `PricingLoadError`, `PricingTable` (+`default_table`, `load_from_json_str`, `load_from_file`, `cost_usd`) |
| 18–24 | ✨ tracker | `BudgetTracker` (+`new`, `with_state`, `subscribe_alerts`), `compute_status`, `record_usage`, `global_state`, `snapshot` |
| 25–32 | ✨ persistence | `PersistedAgentEntry`, `PersistedBudget`, `PersistenceError`, `default_budget_path`, `load_from_disk`, `save_to_disk_atomic`, `agent_id_to_hex`/`hex_to_agent_id`, `start_background_writer` |