### PR TITLE
[AAASM-73] ✨ (simulation): Scaffold policy simulation module and CLI subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
 ]
 

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -11,8 +11,11 @@ name = "aasm"
 path = "src/main.rs"
 
 [dependencies]
-aa-core = { path = "../aa-core" }
-clap = { version = "4", features = ["derive"] }
+aa-core    = { path = "../aa-core" }
+aa-gateway = { path = "../aa-gateway" }
+clap       = { version = "4", features = ["derive"] }
+serde_json = "1"
+tokio      = { version = "1", features = ["full"] }
 
 [lints]
 workspace = true

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -1,0 +1,19 @@
+//! Top-level CLI subcommand definitions and dispatch.
+
+use clap::Subcommand;
+
+pub mod policy;
+
+/// Top-level subcommands for the `aasm` CLI.
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Manage governance policies.
+    Policy(policy::PolicyArgs),
+}
+
+/// Dispatch the parsed CLI command to the appropriate handler.
+pub fn dispatch(cmd: Commands) {
+    match cmd {
+        Commands::Policy(args) => policy::dispatch(args),
+    }
+}

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -1,5 +1,7 @@
 //! Top-level CLI subcommand definitions and dispatch.
 
+use std::process::ExitCode;
+
 use clap::Subcommand;
 
 pub mod policy;
@@ -12,7 +14,7 @@ pub enum Commands {
 }
 
 /// Dispatch the parsed CLI command to the appropriate handler.
-pub fn dispatch(cmd: Commands) {
+pub fn dispatch(cmd: Commands) -> ExitCode {
     match cmd {
         Commands::Policy(args) => policy::dispatch(args),
     }

--- a/aa-cli/src/commands/policy/mod.rs
+++ b/aa-cli/src/commands/policy/mod.rs
@@ -1,0 +1,26 @@
+//! Policy management subcommands (`aasm policy ...`).
+
+use clap::{Args, Subcommand};
+
+pub mod simulate;
+
+/// Arguments for the `aasm policy` subcommand group.
+#[derive(Args)]
+pub struct PolicyArgs {
+    #[command(subcommand)]
+    pub command: PolicyCommands,
+}
+
+/// Available policy subcommands.
+#[derive(Subcommand)]
+pub enum PolicyCommands {
+    /// Simulate a policy against historical events or live traffic (dry-run).
+    Simulate(simulate::SimulateArgs),
+}
+
+/// Dispatch a policy subcommand.
+pub fn dispatch(args: PolicyArgs) {
+    match args.command {
+        PolicyCommands::Simulate(sim_args) => simulate::run(sim_args),
+    }
+}

--- a/aa-cli/src/commands/policy/mod.rs
+++ b/aa-cli/src/commands/policy/mod.rs
@@ -1,5 +1,7 @@
 //! Policy management subcommands (`aasm policy ...`).
 
+use std::process::ExitCode;
+
 use clap::{Args, Subcommand};
 
 pub mod simulate;
@@ -19,7 +21,7 @@ pub enum PolicyCommands {
 }
 
 /// Dispatch a policy subcommand.
-pub fn dispatch(args: PolicyArgs) {
+pub fn dispatch(args: PolicyArgs) -> ExitCode {
     match args.command {
         PolicyCommands::Simulate(sim_args) => simulate::run(sim_args),
     }

--- a/aa-cli/src/commands/policy/simulate.rs
+++ b/aa-cli/src/commands/policy/simulate.rs
@@ -1,6 +1,7 @@
 //! `aasm policy simulate` — dry-run policy evaluation.
 
 use std::path::PathBuf;
+use std::process::ExitCode;
 
 use clap::Args;
 
@@ -33,6 +34,10 @@ pub struct SimulateArgs {
 }
 
 /// Execute the simulate command.
-pub fn run(_args: SimulateArgs) {
+///
+/// Returns [`ExitCode::SUCCESS`] if no violations were found,
+/// or [`ExitCode::FAILURE`] if the simulation detected policy violations.
+/// This allows CI pipelines to gate on `aasm policy simulate` exit status.
+pub fn run(_args: SimulateArgs) -> ExitCode {
     todo!("AAASM-73: implement policy simulation CLI handler")
 }

--- a/aa-cli/src/commands/policy/simulate.rs
+++ b/aa-cli/src/commands/policy/simulate.rs
@@ -1,0 +1,34 @@
+//! `aasm policy simulate` — dry-run policy evaluation.
+
+use std::path::PathBuf;
+
+use clap::Args;
+
+/// Arguments for `aasm policy simulate`.
+#[derive(Args)]
+pub struct SimulateArgs {
+    /// Path to the policy YAML file to simulate.
+    #[arg(long)]
+    pub policy: PathBuf,
+
+    /// Path to an audit log JSONL file to replay against the policy.
+    #[arg(long)]
+    pub against: Option<PathBuf>,
+
+    /// Observe live agent traffic instead of replaying a file.
+    #[arg(long, default_value_t = false)]
+    pub live: bool,
+
+    /// Duration for live simulation (e.g. "60s", "5m").
+    #[arg(long)]
+    pub duration: Option<String>,
+
+    /// Path to write the simulation report JSON.
+    #[arg(long)]
+    pub output: Option<PathBuf>,
+}
+
+/// Execute the simulate command.
+pub fn run(_args: SimulateArgs) {
+    todo!("AAASM-73: implement policy simulation CLI handler")
+}

--- a/aa-cli/src/commands/policy/simulate.rs
+++ b/aa-cli/src/commands/policy/simulate.rs
@@ -4,6 +4,10 @@ use std::path::PathBuf;
 
 use clap::Args;
 
+// Gateway types will be used when simulation logic is implemented.
+#[allow(unused_imports)]
+use aa_gateway::simulation::{SimulationEngine, SimulationReport};
+
 /// Arguments for `aasm policy simulate`.
 #[derive(Args)]
 pub struct SimulateArgs {

--- a/aa-cli/src/main.rs
+++ b/aa-cli/src/main.rs
@@ -3,6 +3,19 @@
 //! Provides commands for managing agents, policies, and the governance
 //! gateway from the terminal.
 
+use clap::Parser;
+
+mod commands;
+
+/// Agent Assembly CLI — governance gateway management tool.
+#[derive(Parser)]
+#[command(name = "aasm", version, about)]
+struct Cli {
+    #[command(subcommand)]
+    command: commands::Commands,
+}
+
 fn main() {
-    println!("aasm — Agent Assembly CLI (v{})", env!("CARGO_PKG_VERSION"));
+    let cli = Cli::parse();
+    commands::dispatch(cli.command);
 }

--- a/aa-cli/src/main.rs
+++ b/aa-cli/src/main.rs
@@ -3,6 +3,8 @@
 //! Provides commands for managing agents, policies, and the governance
 //! gateway from the terminal.
 
+use std::process::ExitCode;
+
 use clap::Parser;
 
 mod commands;
@@ -15,7 +17,7 @@ struct Cli {
     command: commands::Commands,
 }
 
-fn main() {
+fn main() -> ExitCode {
     let cli = Cli::parse();
-    commands::dispatch(cli.command);
+    commands::dispatch(cli.command)
 }

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -21,6 +21,7 @@ notify       = { version = "6", features = [] }
 chrono       = { version = "0.4", features = ["clock", "serde"] }
 chrono-tz    = "0.9"
 rust_decimal = { version = "1", features = ["serde-str"] }
+thiserror    = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -7,5 +7,6 @@
 pub mod budget;
 pub mod engine;
 pub mod policy;
+pub mod simulation;
 
 pub use engine::{PolicyEngine, PolicyLoadError};

--- a/aa-gateway/src/simulation/engine.rs
+++ b/aa-gateway/src/simulation/engine.rs
@@ -28,7 +28,7 @@ impl SimulationEngine {
     /// Evaluate a single event against the loaded policy in dry-run mode.
     ///
     /// Returns the outcome without writing to the audit log or triggering alerts.
-    pub fn simulate_event(&self, index: usize, _event: &SimulationEvent) -> EventOutcome {
+    pub fn simulate_event(&self, _index: usize, _event: &SimulationEvent) -> EventOutcome {
         todo!("AAASM-73: evaluate event against policy sections")
     }
 

--- a/aa-gateway/src/simulation/engine.rs
+++ b/aa-gateway/src/simulation/engine.rs
@@ -3,7 +3,7 @@
 use crate::policy::document::PolicyDocument;
 
 use super::replay::SimulationEvent;
-use super::report::EventOutcome;
+use super::report::{EventOutcome, SimulationReport};
 
 /// A simulation engine that evaluates events against a policy without enforcing decisions.
 ///
@@ -30,5 +30,10 @@ impl SimulationEngine {
     /// Returns the outcome without writing to the audit log or triggering alerts.
     pub fn simulate_event(&self, index: usize, _event: &SimulationEvent) -> EventOutcome {
         todo!("AAASM-73: evaluate event against policy sections")
+    }
+
+    /// Run the simulation against a sequence of events, producing an aggregate report.
+    pub fn run(&self, _events: &[SimulationEvent]) -> SimulationReport {
+        todo!("AAASM-73: iterate events and collect into SimulationReport")
     }
 }

--- a/aa-gateway/src/simulation/engine.rs
+++ b/aa-gateway/src/simulation/engine.rs
@@ -2,6 +2,9 @@
 
 use crate::policy::document::PolicyDocument;
 
+use super::replay::SimulationEvent;
+use super::report::EventOutcome;
+
 /// A simulation engine that evaluates events against a policy without enforcing decisions.
 ///
 /// Created by cloning a `PolicyDocument` with `dry_run: true` semantics —
@@ -20,5 +23,12 @@ impl SimulationEngine {
     /// Returns a reference to the loaded policy document.
     pub fn policy(&self) -> &PolicyDocument {
         &self.policy
+    }
+
+    /// Evaluate a single event against the loaded policy in dry-run mode.
+    ///
+    /// Returns the outcome without writing to the audit log or triggering alerts.
+    pub fn simulate_event(&self, index: usize, _event: &SimulationEvent) -> EventOutcome {
+        todo!("AAASM-73: evaluate event against policy sections")
     }
 }

--- a/aa-gateway/src/simulation/engine.rs
+++ b/aa-gateway/src/simulation/engine.rs
@@ -1,0 +1,24 @@
+//! Dry-run policy evaluation engine.
+
+use crate::policy::document::PolicyDocument;
+
+/// A simulation engine that evaluates events against a policy without enforcing decisions.
+///
+/// Created by cloning a `PolicyDocument` with `dry_run: true` semantics —
+/// no audit log writes, no alert triggers, no approval queue entries.
+pub struct SimulationEngine {
+    /// The policy document to evaluate against.
+    policy: PolicyDocument,
+}
+
+impl SimulationEngine {
+    /// Create a new simulation engine for the given policy.
+    pub fn new(policy: PolicyDocument) -> Self {
+        Self { policy }
+    }
+
+    /// Returns a reference to the loaded policy document.
+    pub fn policy(&self) -> &PolicyDocument {
+        &self.policy
+    }
+}

--- a/aa-gateway/src/simulation/engine.rs
+++ b/aa-gateway/src/simulation/engine.rs
@@ -1,35 +1,42 @@
 //! Dry-run policy evaluation engine.
 
-use crate::policy::document::PolicyDocument;
+use std::sync::Arc;
+
+use crate::PolicyEngine;
 
 use super::replay::SimulationEvent;
 use super::report::{EventOutcome, SimulationReport};
 
 /// A simulation engine that evaluates events against a policy without enforcing decisions.
 ///
-/// Created by cloning a `PolicyDocument` with `dry_run: true` semantics —
-/// no audit log writes, no alert triggers, no approval queue entries.
+/// Wraps a [`PolicyEngine`] in dry-run mode — reuses the full 7-step evaluation
+/// pipeline (schedule, network, tool allow/deny, rate limit, approval condition,
+/// data pattern scan, budget) but suppresses all side effects: no audit log writes,
+/// no alert triggers, no approval queue entries.
 pub struct SimulationEngine {
-    /// The policy document to evaluate against.
-    policy: PolicyDocument,
+    /// The real policy engine whose evaluate() pipeline is reused in dry-run mode.
+    engine: Arc<PolicyEngine>,
 }
 
 impl SimulationEngine {
-    /// Create a new simulation engine for the given policy.
-    pub fn new(policy: PolicyDocument) -> Self {
-        Self { policy }
+    /// Create a new simulation engine wrapping the given policy engine.
+    ///
+    /// The engine is shared via `Arc` so callers can retain a reference to the
+    /// same engine used by the live enforcement path.
+    pub fn new(engine: Arc<PolicyEngine>) -> Self {
+        Self { engine }
     }
 
-    /// Returns a reference to the loaded policy document.
-    pub fn policy(&self) -> &PolicyDocument {
-        &self.policy
+    /// Returns a reference to the underlying policy engine.
+    pub fn engine(&self) -> &PolicyEngine {
+        &self.engine
     }
 
     /// Evaluate a single event against the loaded policy in dry-run mode.
     ///
     /// Returns the outcome without writing to the audit log or triggering alerts.
     pub fn simulate_event(&self, _index: usize, _event: &SimulationEvent) -> EventOutcome {
-        todo!("AAASM-73: evaluate event against policy sections")
+        todo!("AAASM-73: evaluate event against policy engine pipeline")
     }
 
     /// Run the simulation against a sequence of events, producing an aggregate report.

--- a/aa-gateway/src/simulation/error.rs
+++ b/aa-gateway/src/simulation/error.rs
@@ -1,0 +1,20 @@
+//! Error types for the policy simulation module.
+
+use std::fmt;
+
+/// Errors that can occur during policy simulation.
+#[derive(Debug)]
+pub enum SimulationError {
+    /// The policy file could not be loaded or parsed.
+    PolicyLoad(String),
+}
+
+impl fmt::Display for SimulationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::PolicyLoad(msg) => write!(f, "policy load error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for SimulationError {}

--- a/aa-gateway/src/simulation/error.rs
+++ b/aa-gateway/src/simulation/error.rs
@@ -9,6 +9,8 @@ pub enum SimulationError {
     PolicyLoad(String),
     /// The audit log file could not be parsed.
     AuditParse(String),
+    /// An I/O error occurred reading a file.
+    IoError(std::io::Error),
 }
 
 impl fmt::Display for SimulationError {
@@ -16,8 +18,15 @@ impl fmt::Display for SimulationError {
         match self {
             Self::PolicyLoad(msg) => write!(f, "policy load error: {msg}"),
             Self::AuditParse(msg) => write!(f, "audit log parse error: {msg}"),
+            Self::IoError(err) => write!(f, "I/O error: {err}"),
         }
     }
 }
 
 impl std::error::Error for SimulationError {}
+
+impl From<std::io::Error> for SimulationError {
+    fn from(err: std::io::Error) -> Self {
+        Self::IoError(err)
+    }
+}

--- a/aa-gateway/src/simulation/error.rs
+++ b/aa-gateway/src/simulation/error.rs
@@ -11,6 +11,8 @@ pub enum SimulationError {
     AuditParse(String),
     /// An I/O error occurred reading a file.
     IoError(std::io::Error),
+    /// The duration string could not be parsed (e.g. `--duration 60s`).
+    InvalidDuration(String),
 }
 
 impl fmt::Display for SimulationError {
@@ -19,6 +21,7 @@ impl fmt::Display for SimulationError {
             Self::PolicyLoad(msg) => write!(f, "policy load error: {msg}"),
             Self::AuditParse(msg) => write!(f, "audit log parse error: {msg}"),
             Self::IoError(err) => write!(f, "I/O error: {err}"),
+            Self::InvalidDuration(msg) => write!(f, "invalid duration: {msg}"),
         }
     }
 }

--- a/aa-gateway/src/simulation/error.rs
+++ b/aa-gateway/src/simulation/error.rs
@@ -7,12 +7,15 @@ use std::fmt;
 pub enum SimulationError {
     /// The policy file could not be loaded or parsed.
     PolicyLoad(String),
+    /// The audit log file could not be parsed.
+    AuditParse(String),
 }
 
 impl fmt::Display for SimulationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::PolicyLoad(msg) => write!(f, "policy load error: {msg}"),
+            Self::AuditParse(msg) => write!(f, "audit log parse error: {msg}"),
         }
     }
 }

--- a/aa-gateway/src/simulation/live.rs
+++ b/aa-gateway/src/simulation/live.rs
@@ -1,0 +1,48 @@
+//! Live traffic simulation — observe real agent events in dry-run mode.
+//!
+//! Subscribes to the event stream with a read-only view, evaluates each
+//! event against a policy without enforcing decisions or producing side effects.
+
+use std::time::Duration;
+
+use super::engine::SimulationEngine;
+use super::error::SimulationError;
+use super::report::SimulationReport;
+
+/// Observes live agent traffic and evaluates events against a policy in dry-run mode.
+///
+/// Unlike [`super::replay::HistoricalReplay`], which reads from a static JSONL file,
+/// `LiveSimulation` subscribes to the real-time event stream and runs for a
+/// configurable duration before producing a report.
+pub struct LiveSimulation {
+    /// The simulation engine used to evaluate each observed event.
+    engine: SimulationEngine,
+    /// How long to observe before stopping and producing the report.
+    duration: Duration,
+}
+
+impl LiveSimulation {
+    /// Create a new live simulation with the given engine and observation duration.
+    pub fn new(engine: SimulationEngine, duration: Duration) -> Self {
+        Self { engine, duration }
+    }
+
+    /// Returns the configured observation duration.
+    pub fn duration(&self) -> Duration {
+        self.duration
+    }
+
+    /// Returns a reference to the underlying simulation engine.
+    pub fn engine(&self) -> &SimulationEngine {
+        &self.engine
+    }
+
+    /// Run the live simulation, observing events for the configured duration.
+    ///
+    /// Subscribes to the event stream, evaluates each event against the loaded
+    /// policy, and collects results into a [`SimulationReport`]. Does not enforce
+    /// any decisions or produce side effects.
+    pub async fn run(&self) -> Result<SimulationReport, SimulationError> {
+        todo!("AAASM-73: subscribe to event stream and evaluate for configured duration")
+    }
+}

--- a/aa-gateway/src/simulation/mod.rs
+++ b/aa-gateway/src/simulation/mod.rs
@@ -1,0 +1,14 @@
+//! Policy simulation engine for dry-run evaluation.
+//!
+//! Allows testing a new policy against historical audit logs or live traffic
+//! without enforcing any decisions. Entry point: [`engine::SimulationEngine`].
+
+pub mod engine;
+pub mod error;
+pub mod replay;
+pub mod report;
+
+pub use engine::SimulationEngine;
+pub use error::SimulationError;
+pub use replay::{HistoricalReplay, SimulationEvent};
+pub use report::{EventOutcome, SimulationReport};

--- a/aa-gateway/src/simulation/mod.rs
+++ b/aa-gateway/src/simulation/mod.rs
@@ -5,10 +5,12 @@
 
 pub mod engine;
 pub mod error;
+pub mod live;
 pub mod replay;
 pub mod report;
 
 pub use engine::SimulationEngine;
 pub use error::SimulationError;
+pub use live::LiveSimulation;
 pub use replay::{HistoricalReplay, SimulationEvent};
 pub use report::{EventOutcome, SimulationReport};

--- a/aa-gateway/src/simulation/replay.rs
+++ b/aa-gateway/src/simulation/replay.rs
@@ -34,4 +34,9 @@ impl HistoricalReplay {
     pub fn from_file(_path: &Path) -> Result<Self, SimulationError> {
         todo!("AAASM-73: read JSONL file and deserialize lines into SimulationEvent")
     }
+
+    /// Returns a slice of all parsed simulation events.
+    pub fn events(&self) -> &[SimulationEvent] {
+        &self.events
+    }
 }

--- a/aa-gateway/src/simulation/replay.rs
+++ b/aa-gateway/src/simulation/replay.rs
@@ -1,6 +1,10 @@
 //! Historical audit log replay for dry-run policy simulation.
 
+use std::path::Path;
+
 use serde::Deserialize;
+
+use super::error::SimulationError;
 
 /// A single event extracted from an audit log for simulation replay.
 ///
@@ -20,4 +24,14 @@ pub struct SimulationEvent {
 pub struct HistoricalReplay {
     /// Parsed events from the audit log file.
     events: Vec<SimulationEvent>,
+}
+
+impl HistoricalReplay {
+    /// Parse an audit log JSONL file into a replay sequence.
+    ///
+    /// Each line of the file is expected to be a JSON object matching
+    /// the `SimulationEvent` schema.
+    pub fn from_file(_path: &Path) -> Result<Self, SimulationError> {
+        todo!("AAASM-73: read JSONL file and deserialize lines into SimulationEvent")
+    }
 }

--- a/aa-gateway/src/simulation/replay.rs
+++ b/aa-gateway/src/simulation/replay.rs
@@ -15,3 +15,9 @@ pub struct SimulationEvent {
     /// Pre-serialized JSON payload from the original audit entry.
     pub payload: String,
 }
+
+/// Reads an audit log JSONL file and produces a sequence of `SimulationEvent`s.
+pub struct HistoricalReplay {
+    /// Parsed events from the audit log file.
+    events: Vec<SimulationEvent>,
+}

--- a/aa-gateway/src/simulation/replay.rs
+++ b/aa-gateway/src/simulation/replay.rs
@@ -1,0 +1,17 @@
+//! Historical audit log replay for dry-run policy simulation.
+
+use serde::Deserialize;
+
+/// A single event extracted from an audit log for simulation replay.
+///
+/// This is a deserialized subset of `aa_core::AuditEntry` — only the fields
+/// needed for policy re-evaluation.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SimulationEvent {
+    /// The audit event type (e.g. "ToolCallIntercepted", "PolicyViolation").
+    pub event_type: String,
+    /// The agent identifier that produced this event.
+    pub agent_id: String,
+    /// Pre-serialized JSON payload from the original audit entry.
+    pub payload: String,
+}

--- a/aa-gateway/src/simulation/report.rs
+++ b/aa-gateway/src/simulation/report.rs
@@ -14,3 +14,20 @@ pub struct EventOutcome {
     /// Explanation of why this decision was reached.
     pub reason: String,
 }
+
+/// Aggregate report produced by a simulation run.
+#[derive(Debug, Clone, Serialize)]
+pub struct SimulationReport {
+    /// Total number of events evaluated.
+    pub total_events: usize,
+    /// Number of events that would have been denied.
+    pub denied: usize,
+    /// Number of events that would have been allowed.
+    pub allowed: usize,
+    /// Number of events that would have required human approval.
+    pub approval_required: usize,
+    /// Estimated budget impact in USD (if budget policy is present).
+    pub budget_impact_usd: Option<f64>,
+    /// Per-event outcomes for events that were not simply allowed.
+    pub flagged_outcomes: Vec<EventOutcome>,
+}

--- a/aa-gateway/src/simulation/report.rs
+++ b/aa-gateway/src/simulation/report.rs
@@ -1,0 +1,16 @@
+//! Output types for policy simulation results.
+
+use serde::Serialize;
+
+/// The outcome of evaluating a single event against a policy in dry-run mode.
+#[derive(Debug, Clone, Serialize)]
+pub struct EventOutcome {
+    /// Zero-based index of the event in the input sequence.
+    pub event_index: usize,
+    /// Human-readable description of the action that was evaluated.
+    pub action: String,
+    /// The policy decision: "allow", "deny", or "requires_approval".
+    pub decision: String,
+    /// Explanation of why this decision was reached.
+    pub reason: String,
+}

--- a/schemas/simulation/v1/simulation-report.schema.json
+++ b/schemas/simulation/v1/simulation-report.schema.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://agent-assembly.github.io/schemas/simulation/v1/simulation-report.schema.json",
+  "title": "SimulationReport",
+  "description": "Schema for the output of `aasm policy simulate`. Contains aggregate statistics and per-event outcomes from a dry-run policy evaluation.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "total_events",
+    "denied",
+    "allowed",
+    "approval_required",
+    "flagged_outcomes"
+  ],
+  "properties": {
+    "total_events": {
+      "description": "Total number of events evaluated during the simulation.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "denied": {
+      "description": "Number of events that would have been denied by the policy.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "allowed": {
+      "description": "Number of events that would have been allowed by the policy.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "approval_required": {
+      "description": "Number of events that would have required human approval.",
+      "type": "integer",
+      "minimum": 0
+    },
+    "budget_impact_usd": {
+      "description": "Estimated budget impact in USD, if a budget policy section is present. Null when no budget policy is configured.",
+      "type": ["number", "null"]
+    },
+    "flagged_outcomes": {
+      "description": "Per-event outcomes for events that were not simply allowed (denied or approval-required).",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/EventOutcome"
+      }
+    }
+  },
+  "$defs": {
+    "EventOutcome": {
+      "description": "The outcome of evaluating a single event against a policy in dry-run mode.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event_index",
+        "action",
+        "decision",
+        "reason"
+      ],
+      "properties": {
+        "event_index": {
+          "description": "Zero-based index of the event in the input sequence.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "action": {
+          "description": "Human-readable description of the action that was evaluated.",
+          "type": "string"
+        },
+        "decision": {
+          "description": "The policy decision for this event.",
+          "type": "string",
+          "enum": ["allow", "deny", "requires_approval"]
+        },
+        "reason": {
+          "description": "Explanation of why this decision was reached.",
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Scaffold the project architecture for AAASM-73 (F38: Policy Simulation Mode / dry-run). This sets up the module structure, types, and interfaces in `aa-gateway` and `aa-cli` so the codebase is ready for feature implementation.

**No implementation logic** — all method bodies are `todo!()` stubs. This PR establishes:

- `aa-gateway/src/simulation/` module with:
  - `error.rs` — `SimulationError` enum (PolicyLoad, AuditParse, IoError, InvalidDuration)
  - `report.rs` — `EventOutcome` and `SimulationReport` output types
  - `engine.rs` — `SimulationEngine` struct with `simulate_event()` and `run()` method signatures
  - `replay.rs` — `SimulationEvent` and `HistoricalReplay` for audit log replay
  - `mod.rs` — module root with re-exports

- `aa-cli/src/commands/` restructure with:
  - Clap derive-based CLI skeleton (`Cli` struct with subcommands)
  - `aasm policy simulate` subcommand with all CLI args (`--policy`, `--against`, `--live`, `--duration`, `--output`)
  - Gateway simulation type imports wired through

## Type of Change

- [x] ✨ New feature
- [x] ♻️ Refactoring

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-73
- Parent Epic: AAASM-8 (Governance Gateway & Policy Engine)

## Testing

- [x] No tests required (explain why)

Architecture scaffolding only — all methods are `todo!()` stubs. Tests will be added when implementation logic is written in the follow-up feature PR.

Verified: `cargo check -p aa-gateway -p aa-cli` and `cargo clippy -p aa-gateway -p aa-cli` both pass with zero errors.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention