### PR TITLE
[AAASM-40] ✨ (correlation): Scaffold causal correlation engine module in aa-runtime

### DIFF
--- a/aa-runtime/src/correlation/config.rs
+++ b/aa-runtime/src/correlation/config.rs
@@ -1,0 +1,1 @@
+//! Configuration for the causal correlation engine.

--- a/aa-runtime/src/correlation/config.rs
+++ b/aa-runtime/src/correlation/config.rs
@@ -25,3 +25,23 @@ impl Default for CorrelationConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_has_expected_values() {
+        let config = CorrelationConfig::default();
+        assert_eq!(config.window_ms, 5_000);
+        assert_eq!(config.max_window_size, 10_000);
+        assert_eq!(config.eviction_interval_ms, 1_000);
+    }
+
+    #[test]
+    fn config_is_clone() {
+        let config = CorrelationConfig::default();
+        let cloned = config.clone();
+        assert_eq!(cloned.window_ms, config.window_ms);
+    }
+}

--- a/aa-runtime/src/correlation/config.rs
+++ b/aa-runtime/src/correlation/config.rs
@@ -1,1 +1,27 @@
 //! Configuration for the causal correlation engine.
+
+/// Configuration parameters for the [`super::CorrelationEngine`].
+#[derive(Debug, Clone)]
+pub struct CorrelationConfig {
+    /// Maximum time window (in milliseconds) within which an intent and an
+    /// action must occur to be considered causally correlated.
+    ///
+    /// Default: 5000 ms.
+    pub window_ms: u64,
+    /// Maximum number of events held in the sliding window before the oldest
+    /// events are force-evicted regardless of age.
+    pub max_window_size: usize,
+    /// How often (in milliseconds) the engine runs TTL eviction on the sliding
+    /// window to discard events older than `window_ms`.
+    pub eviction_interval_ms: u64,
+}
+
+impl Default for CorrelationConfig {
+    fn default() -> Self {
+        Self {
+            window_ms: 5_000,
+            max_window_size: 10_000,
+            eviction_interval_ms: 1_000,
+        }
+    }
+}

--- a/aa-runtime/src/correlation/engine.rs
+++ b/aa-runtime/src/correlation/engine.rs
@@ -1,0 +1,1 @@
+//! Orchestrator that ties together sliding window, PID lineage, and config.

--- a/aa-runtime/src/correlation/engine.rs
+++ b/aa-runtime/src/correlation/engine.rs
@@ -67,3 +67,45 @@ impl CorrelationEngine {
         &self.config
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::correlation::event::IntentEvent;
+    use uuid::Uuid;
+
+    #[test]
+    fn engine_constructs_with_default_config() {
+        let engine = CorrelationEngine::new(CorrelationConfig::default());
+        assert_eq!(engine.config().window_ms, 5_000);
+    }
+
+    #[test]
+    fn ingest_adds_event_to_window() {
+        let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+        let event = CorrelationEvent::Intent(IntentEvent {
+            event_id: Uuid::new_v4(),
+            timestamp_ms: 1000,
+            pid: 1,
+            intent_text: "test".to_string(),
+            action_keyword: "test".to_string(),
+        });
+        engine.ingest(event);
+        // Window is not directly accessible, but we can verify no panic occurred
+        // and eviction works after ingest.
+        engine.evict(2000);
+    }
+
+    #[test]
+    fn register_pid_does_not_panic() {
+        let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+        engine.register_pid(100, 1);
+        engine.register_pid(200, 100);
+    }
+
+    #[test]
+    fn evict_on_empty_engine_does_not_panic() {
+        let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+        engine.evict(10_000);
+    }
+}

--- a/aa-runtime/src/correlation/engine.rs
+++ b/aa-runtime/src/correlation/engine.rs
@@ -1,1 +1,69 @@
 //! Orchestrator that ties together sliding window, PID lineage, and config.
+//!
+//! The [`CorrelationEngine`] is the main entry point for the causal correlation
+//! subsystem. It is intentionally synchronous — the caller (the Tokio event
+//! loop in aa-runtime) handles channel I/O; the engine handles pure logic.
+
+use super::config::CorrelationConfig;
+use super::event::CorrelationEvent;
+use super::outcome::CorrelationOutcome;
+use super::pid::PidLineage;
+use super::window::SlidingWindow;
+
+/// The causal correlation engine.
+///
+/// Ingests intent events (from LLM responses) and action events (from eBPF
+/// kernel probes), stores them in a sliding time window, and produces
+/// [`CorrelationOutcome`] results by matching intents to actions using PID
+/// lineage and configurable time windows.
+#[derive(Debug)]
+pub struct CorrelationEngine {
+    config: CorrelationConfig,
+    window: SlidingWindow,
+    lineage: PidLineage,
+}
+
+impl CorrelationEngine {
+    /// Create a new correlation engine with the given configuration.
+    pub fn new(config: CorrelationConfig) -> Self {
+        let window = SlidingWindow::new(config.window_ms, config.max_window_size);
+        Self {
+            config,
+            window,
+            lineage: PidLineage::new(),
+        }
+    }
+
+    /// Ingest a correlation event into the sliding window.
+    ///
+    /// This is a synchronous operation — no I/O, just an insertion into the
+    /// in-memory window.
+    pub fn ingest(&mut self, event: CorrelationEvent) {
+        self.window.insert(event);
+    }
+
+    /// Run the correlation algorithm over the current window contents.
+    ///
+    /// Returns all correlation outcomes (matched, unexpected, intent-without-action)
+    /// found in the current window state.
+    pub fn correlate(&self) -> Vec<CorrelationOutcome> {
+        todo!("implement PID lineage + keyword matching correlation algorithm")
+    }
+
+    /// Evict events older than the configured time window.
+    ///
+    /// Should be called periodically by the runtime at `config.eviction_interval_ms`.
+    pub fn evict(&mut self, now_ms: u64) {
+        self.window.evict(now_ms);
+    }
+
+    /// Register a PID parent-child relationship for lineage tracking.
+    pub fn register_pid(&mut self, child_pid: u32, parent_pid: u32) {
+        self.lineage.register(child_pid, parent_pid);
+    }
+
+    /// Returns a reference to the current configuration.
+    pub fn config(&self) -> &CorrelationConfig {
+        &self.config
+    }
+}

--- a/aa-runtime/src/correlation/event.rs
+++ b/aa-runtime/src/correlation/event.rs
@@ -42,3 +42,32 @@ pub struct ActionEvent {
     /// (e.g., the file path for unlink, the address for connect).
     pub details: String,
 }
+
+/// A correlation event — either an intent from the LLM or an action from the kernel.
+///
+/// This is the unified input type ingested by the [`super::SlidingWindow`].
+#[derive(Debug, Clone)]
+pub enum CorrelationEvent {
+    /// An LLM response intent.
+    Intent(IntentEvent),
+    /// A kernel-level syscall action.
+    Action(ActionEvent),
+}
+
+impl CorrelationEvent {
+    /// Returns the timestamp (in milliseconds) of the underlying event.
+    pub fn timestamp_ms(&self) -> u64 {
+        match self {
+            Self::Intent(e) => e.timestamp_ms,
+            Self::Action(e) => e.timestamp_ms,
+        }
+    }
+
+    /// Returns the PID of the process that produced the event.
+    pub fn pid(&self) -> u32 {
+        match self {
+            Self::Intent(e) => e.pid,
+            Self::Action(e) => e.pid,
+        }
+    }
+}

--- a/aa-runtime/src/correlation/event.rs
+++ b/aa-runtime/src/correlation/event.rs
@@ -1,1 +1,24 @@
 //! Event types for the causal correlation engine.
+
+use uuid::Uuid;
+
+/// An LLM response intent captured via the SDK hook or proxy.
+///
+/// Represents what the LLM instructed the agent to do — e.g., "delete file X",
+/// "make HTTP request to Y". The correlation engine matches these intents
+/// against observed kernel-level actions.
+#[derive(Debug, Clone)]
+pub struct IntentEvent {
+    /// Unique identifier for this intent event.
+    pub event_id: Uuid,
+    /// Unix timestamp in milliseconds when the intent was captured.
+    pub timestamp_ms: u64,
+    /// PID of the process that received the LLM response.
+    pub pid: u32,
+    /// The raw text or structured description of the intended action
+    /// extracted from the LLM response.
+    pub intent_text: String,
+    /// The action type keyword derived from the intent text
+    /// (e.g., "file_delete", "network_connect", "process_exec").
+    pub action_keyword: String,
+}

--- a/aa-runtime/src/correlation/event.rs
+++ b/aa-runtime/src/correlation/event.rs
@@ -22,3 +22,23 @@ pub struct IntentEvent {
     /// (e.g., "file_delete", "network_connect", "process_exec").
     pub action_keyword: String,
 }
+
+/// A kernel-level action captured via eBPF probes.
+///
+/// Represents an observed syscall — e.g., `unlink("/tmp/foo")`,
+/// `connect(1.2.3.4:443)`, `execve("/bin/sh")`. The correlation engine
+/// matches these actions against preceding LLM intents.
+#[derive(Debug, Clone)]
+pub struct ActionEvent {
+    /// Unique identifier for this action event.
+    pub event_id: Uuid,
+    /// Unix timestamp in milliseconds when the syscall was observed.
+    pub timestamp_ms: u64,
+    /// PID of the process that performed the syscall.
+    pub pid: u32,
+    /// The syscall name (e.g., "unlink", "connect", "execve", "openat").
+    pub syscall: String,
+    /// Human-readable summary of the syscall arguments
+    /// (e.g., the file path for unlink, the address for connect).
+    pub details: String,
+}

--- a/aa-runtime/src/correlation/event.rs
+++ b/aa-runtime/src/correlation/event.rs
@@ -71,3 +71,58 @@ impl CorrelationEvent {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_intent(ts: u64, pid: u32) -> IntentEvent {
+        IntentEvent {
+            event_id: Uuid::new_v4(),
+            timestamp_ms: ts,
+            pid,
+            intent_text: "delete file".to_string(),
+            action_keyword: "file_delete".to_string(),
+        }
+    }
+
+    fn make_action(ts: u64, pid: u32) -> ActionEvent {
+        ActionEvent {
+            event_id: Uuid::new_v4(),
+            timestamp_ms: ts,
+            pid,
+            syscall: "unlink".to_string(),
+            details: "/tmp/foo".to_string(),
+        }
+    }
+
+    #[test]
+    fn intent_event_fields_accessible() {
+        let intent = make_intent(1000, 42);
+        assert_eq!(intent.timestamp_ms, 1000);
+        assert_eq!(intent.pid, 42);
+    }
+
+    #[test]
+    fn action_event_fields_accessible() {
+        let action = make_action(2000, 99);
+        assert_eq!(action.timestamp_ms, 2000);
+        assert_eq!(action.pid, 99);
+    }
+
+    #[test]
+    fn correlation_event_timestamp_delegates_to_inner() {
+        let intent = CorrelationEvent::Intent(make_intent(1000, 1));
+        let action = CorrelationEvent::Action(make_action(2000, 2));
+        assert_eq!(intent.timestamp_ms(), 1000);
+        assert_eq!(action.timestamp_ms(), 2000);
+    }
+
+    #[test]
+    fn correlation_event_pid_delegates_to_inner() {
+        let intent = CorrelationEvent::Intent(make_intent(1000, 10));
+        let action = CorrelationEvent::Action(make_action(2000, 20));
+        assert_eq!(intent.pid(), 10);
+        assert_eq!(action.pid(), 20);
+    }
+}

--- a/aa-runtime/src/correlation/event.rs
+++ b/aa-runtime/src/correlation/event.rs
@@ -1,0 +1,1 @@
+//! Event types for the causal correlation engine.

--- a/aa-runtime/src/correlation/mod.rs
+++ b/aa-runtime/src/correlation/mod.rs
@@ -13,3 +13,9 @@ pub mod outcome;
 pub mod pid;
 pub mod window;
 
+pub use config::CorrelationConfig;
+pub use engine::CorrelationEngine;
+pub use event::{ActionEvent, CorrelationEvent, IntentEvent};
+pub use outcome::{CausalCorrelation, CorrelationOutcome};
+pub use pid::PidLineage;
+pub use window::SlidingWindow;

--- a/aa-runtime/src/correlation/mod.rs
+++ b/aa-runtime/src/correlation/mod.rs
@@ -1,0 +1,15 @@
+//! Intent-Action Causal Correlation engine.
+//!
+//! Matches LLM response intents (captured via SDK or proxy) to kernel-level
+//! actions (captured via eBPF) using PID lineage and a configurable time
+//! window. Detects intent→action divergence and unauthorized escalation.
+//!
+//! Inspired by the AgentSight paper.
+
+pub mod config;
+pub mod engine;
+pub mod event;
+pub mod outcome;
+pub mod pid;
+pub mod window;
+

--- a/aa-runtime/src/correlation/outcome.rs
+++ b/aa-runtime/src/correlation/outcome.rs
@@ -1,1 +1,22 @@
 //! Correlation outcome types produced by the engine.
+
+use uuid::Uuid;
+
+/// A positive causal correlation between an intent event and an action event.
+///
+/// Produced when the engine matches an LLM response intent to a kernel-level
+/// action within the configured time window and PID lineage.
+#[derive(Debug, Clone)]
+pub struct CausalCorrelation {
+    /// ID of the intent event (LLM response) that initiated the action.
+    pub intent_event_id: Uuid,
+    /// ID of the action event (kernel syscall) that was correlated.
+    pub action_event_id: Uuid,
+    /// Strength of the correlation (0.0–1.0).
+    ///
+    /// Determined by the matching algorithm based on keyword overlap,
+    /// PID proximity, and time delta.
+    pub correlation_strength: f64,
+    /// Time elapsed (in milliseconds) between the intent and the action.
+    pub time_delta_ms: u64,
+}

--- a/aa-runtime/src/correlation/outcome.rs
+++ b/aa-runtime/src/correlation/outcome.rs
@@ -43,3 +43,48 @@ pub enum CorrelationOutcome {
         intent_event_id: Uuid,
     },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn causal_correlation_fields_accessible() {
+        let corr = CausalCorrelation {
+            intent_event_id: Uuid::new_v4(),
+            action_event_id: Uuid::new_v4(),
+            correlation_strength: 0.85,
+            time_delta_ms: 120,
+        };
+        assert!(corr.correlation_strength > 0.0);
+        assert_eq!(corr.time_delta_ms, 120);
+    }
+
+    #[test]
+    fn outcome_matched_variant() {
+        let corr = CausalCorrelation {
+            intent_event_id: Uuid::new_v4(),
+            action_event_id: Uuid::new_v4(),
+            correlation_strength: 1.0,
+            time_delta_ms: 50,
+        };
+        let outcome = CorrelationOutcome::Matched(corr);
+        assert!(matches!(outcome, CorrelationOutcome::Matched(_)));
+    }
+
+    #[test]
+    fn outcome_unexpected_action_variant() {
+        let outcome = CorrelationOutcome::UnexpectedAction {
+            action_event_id: Uuid::new_v4(),
+        };
+        assert!(matches!(outcome, CorrelationOutcome::UnexpectedAction { .. }));
+    }
+
+    #[test]
+    fn outcome_intent_without_action_variant() {
+        let outcome = CorrelationOutcome::IntentWithoutAction {
+            intent_event_id: Uuid::new_v4(),
+        };
+        assert!(matches!(outcome, CorrelationOutcome::IntentWithoutAction { .. }));
+    }
+}

--- a/aa-runtime/src/correlation/outcome.rs
+++ b/aa-runtime/src/correlation/outcome.rs
@@ -1,0 +1,1 @@
+//! Correlation outcome types produced by the engine.

--- a/aa-runtime/src/correlation/outcome.rs
+++ b/aa-runtime/src/correlation/outcome.rs
@@ -20,3 +20,26 @@ pub struct CausalCorrelation {
     /// Time elapsed (in milliseconds) between the intent and the action.
     pub time_delta_ms: u64,
 }
+
+/// The result of a correlation check — one of three possible outcomes.
+#[derive(Debug, Clone)]
+pub enum CorrelationOutcome {
+    /// An intent was matched to a kernel action within the time window.
+    Matched(CausalCorrelation),
+    /// A kernel action was observed with no preceding LLM intent in the window.
+    ///
+    /// This indicates the agent performed an action that was not instructed —
+    /// potential unauthorized escalation.
+    UnexpectedAction {
+        /// ID of the unmatched action event.
+        action_event_id: Uuid,
+    },
+    /// An LLM intent was observed but no corresponding kernel action followed
+    /// within the time window.
+    ///
+    /// This may indicate the agent bypassed the normal execution path.
+    IntentWithoutAction {
+        /// ID of the unmatched intent event.
+        intent_event_id: Uuid,
+    },
+}

--- a/aa-runtime/src/correlation/pid.rs
+++ b/aa-runtime/src/correlation/pid.rs
@@ -63,6 +63,6 @@ mod tests {
         let mut lineage = PidLineage::new();
         lineage.register(100, 1);
         lineage.remove(100);
-        assert!(lineage.parent_map.get(&100).is_none());
+        assert!(!lineage.parent_map.contains_key(&100));
     }
 }

--- a/aa-runtime/src/correlation/pid.rs
+++ b/aa-runtime/src/correlation/pid.rs
@@ -40,3 +40,29 @@ impl PidLineage {
         self.parent_map.remove(&pid);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_lineage_is_empty() {
+        let lineage = PidLineage::new();
+        assert!(lineage.parent_map.is_empty());
+    }
+
+    #[test]
+    fn register_adds_entry() {
+        let mut lineage = PidLineage::new();
+        lineage.register(100, 1);
+        assert_eq!(lineage.parent_map.get(&100), Some(&1));
+    }
+
+    #[test]
+    fn remove_deletes_entry() {
+        let mut lineage = PidLineage::new();
+        lineage.register(100, 1);
+        lineage.remove(100);
+        assert!(lineage.parent_map.get(&100).is_none());
+    }
+}

--- a/aa-runtime/src/correlation/pid.rs
+++ b/aa-runtime/src/correlation/pid.rs
@@ -1,1 +1,42 @@
 //! PID lineage tracker for causal group membership.
+//!
+//! Maintains a mapping of child PID → parent PID so the correlation engine
+//! can determine whether two processes belong to the same causal group
+//! (i.e., the SDK process and all of its descendants).
+
+use std::collections::HashMap;
+
+/// Tracks PID-to-parent relationships for causal group membership.
+///
+/// The SDK process and all its descendant PIDs form a single causal group.
+/// When the correlation engine sees an intent from PID A and an action from
+/// PID B, it uses this tracker to determine whether B is a descendant of A
+/// (or vice versa).
+#[derive(Debug, Default)]
+pub struct PidLineage {
+    /// Maps child PID → parent PID.
+    parent_map: HashMap<u32, u32>,
+}
+
+impl PidLineage {
+    /// Create a new empty lineage tracker.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a parent-child PID relationship.
+    pub fn register(&mut self, child_pid: u32, parent_pid: u32) {
+        self.parent_map.insert(child_pid, parent_pid);
+    }
+
+    /// Returns `true` if `pid_a` and `pid_b` belong to the same causal group
+    /// (i.e., one is an ancestor of the other, or they share a common ancestor).
+    pub fn is_same_family(&self, _pid_a: u32, _pid_b: u32) -> bool {
+        todo!("implement ancestor walk using parent_map")
+    }
+
+    /// Remove a PID from the lineage tracker (e.g., after process exit).
+    pub fn remove(&mut self, pid: u32) {
+        self.parent_map.remove(&pid);
+    }
+}

--- a/aa-runtime/src/correlation/pid.rs
+++ b/aa-runtime/src/correlation/pid.rs
@@ -1,0 +1,1 @@
+//! PID lineage tracker for causal group membership.

--- a/aa-runtime/src/correlation/window.rs
+++ b/aa-runtime/src/correlation/window.rs
@@ -62,3 +62,72 @@ impl SlidingWindow {
         self.max_size
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::correlation::event::{ActionEvent, IntentEvent};
+    use uuid::Uuid;
+
+    fn make_intent_event(ts: u64) -> CorrelationEvent {
+        CorrelationEvent::Intent(IntentEvent {
+            event_id: Uuid::new_v4(),
+            timestamp_ms: ts,
+            pid: 1,
+            intent_text: "test".to_string(),
+            action_keyword: "test".to_string(),
+        })
+    }
+
+    fn make_action_event(ts: u64) -> CorrelationEvent {
+        CorrelationEvent::Action(ActionEvent {
+            event_id: Uuid::new_v4(),
+            timestamp_ms: ts,
+            pid: 1,
+            syscall: "unlink".to_string(),
+            details: "/tmp/foo".to_string(),
+        })
+    }
+
+    #[test]
+    fn new_window_is_empty() {
+        let w = SlidingWindow::new(5000, 100);
+        assert!(w.is_empty());
+        assert_eq!(w.len(), 0);
+    }
+
+    #[test]
+    fn insert_increases_len() {
+        let mut w = SlidingWindow::new(5000, 100);
+        w.insert(make_intent_event(1000));
+        assert_eq!(w.len(), 1);
+        w.insert(make_action_event(1000));
+        assert_eq!(w.len(), 2);
+    }
+
+    #[test]
+    fn evict_removes_old_events() {
+        let mut w = SlidingWindow::new(5000, 100);
+        w.insert(make_intent_event(1000));
+        w.insert(make_action_event(7000));
+        // now_ms=7000, window=5000 → cutoff=2000 → event at 1000 evicted
+        w.evict(7000);
+        assert_eq!(w.len(), 1);
+    }
+
+    #[test]
+    fn evict_keeps_events_within_window() {
+        let mut w = SlidingWindow::new(5000, 100);
+        w.insert(make_intent_event(3000));
+        w.insert(make_action_event(4000));
+        // now_ms=7000, window=5000 → cutoff=2000 → both kept
+        w.evict(7000);
+        assert_eq!(w.len(), 2);
+    }
+
+    #[test]
+    fn max_size_returns_configured_value() {
+        let w = SlidingWindow::new(5000, 42);
+        assert_eq!(w.max_size(), 42);
+    }
+}

--- a/aa-runtime/src/correlation/window.rs
+++ b/aa-runtime/src/correlation/window.rs
@@ -1,1 +1,64 @@
 //! In-memory sliding time window for correlation events.
+//!
+//! Events are stored in a `BTreeMap<u64, Vec<CorrelationEvent>>` keyed by
+//! timestamp (milliseconds). TTL eviction removes events older than the
+//! configured window duration.
+
+use std::collections::BTreeMap;
+
+use super::event::CorrelationEvent;
+
+/// A time-ordered sliding window of correlation events.
+///
+/// Events are indexed by their timestamp in milliseconds. The window supports
+/// insertion, TTL-based eviction, and range queries for the correlation
+/// algorithm.
+#[derive(Debug)]
+pub struct SlidingWindow {
+    /// Events indexed by timestamp. Multiple events can share the same
+    /// millisecond timestamp.
+    events: BTreeMap<u64, Vec<CorrelationEvent>>,
+    /// Maximum age (in milliseconds) before an event is evicted.
+    window_ms: u64,
+    /// Maximum total events before force-eviction of the oldest entries.
+    max_size: usize,
+}
+
+impl SlidingWindow {
+    /// Create a new sliding window with the given time window and capacity.
+    pub fn new(window_ms: u64, max_size: usize) -> Self {
+        Self {
+            events: BTreeMap::new(),
+            window_ms,
+            max_size,
+        }
+    }
+
+    /// Insert an event into the window.
+    pub fn insert(&mut self, event: CorrelationEvent) {
+        let ts = event.timestamp_ms();
+        self.events.entry(ts).or_default().push(event);
+    }
+
+    /// Evict all events older than `now_ms - window_ms`.
+    pub fn evict(&mut self, now_ms: u64) {
+        let cutoff = now_ms.saturating_sub(self.window_ms);
+        // `split_off` returns everything >= cutoff; we keep that and drop the rest.
+        self.events = self.events.split_off(&cutoff);
+    }
+
+    /// Returns the total number of events currently in the window.
+    pub fn len(&self) -> usize {
+        self.events.values().map(|v| v.len()).sum()
+    }
+
+    /// Returns `true` if the window contains no events.
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    /// Returns the configured maximum capacity.
+    pub fn max_size(&self) -> usize {
+        self.max_size
+    }
+}

--- a/aa-runtime/src/correlation/window.rs
+++ b/aa-runtime/src/correlation/window.rs
@@ -1,0 +1,1 @@
+//! In-memory sliding time window for correlation events.

--- a/aa-runtime/src/lib.rs
+++ b/aa-runtime/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod approval;
 pub mod config;
+pub mod correlation;
 pub mod health;
 pub mod ipc;
 pub mod lifecycle;


### PR DESCRIPTION
## Description

Scaffold the `correlation` module inside `aa-runtime` with type stubs, module structure, and compilation tests — preparing the crate for implementation of the Intent-Action Causal Correlation engine (PID lineage + time window matching).

This is the architecture setup phase for AAASM-40 (F14). The engine will match LLM response intents to kernel-level actions using PID lineage and a configurable time window, detecting intent→action divergence and unauthorized escalation (inspired by the AgentSight paper).

### Module structure

```
aa-runtime/src/correlation/
  mod.rs       — submodule declarations + pub use re-exports
  config.rs    — CorrelationConfig (window_ms, max_size, eviction_interval)
  event.rs     — IntentEvent, ActionEvent, CorrelationEvent enum
  outcome.rs   — CausalCorrelation, CorrelationOutcome enum
  pid.rs       — PidLineage tracker stub
  window.rs    — SlidingWindow stub (BTreeMap<u64, Vec<CorrelationEvent>>)
  engine.rs    — CorrelationEngine stub, sync ingest() + correlate()
```

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-40
- Parent Epic: AAASM-4 (Three-Layer Agent Interception)

## Testing

- [x] Unit tests added / updated
- 22 compilation and construction tests covering all scaffolded types
- `cargo clippy -p aa-runtime` passes with zero warnings
- `cargo test -p aa-runtime -- correlation` — 22/22 pass

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention