### PR TITLE
[AAASM-135] ✨ gateway: Implement PolicyService gRPC server wiring RPCs to PolicyEngine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "chrono-tz",
+ "clap",
  "dashmap",
  "dirs",
  "notify",
@@ -99,7 +100,11 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-stream",
+ "tonic",
  "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -150,6 +155,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "toml",
+ "tonic",
  "tower 0.4.13",
  "tracing",
  "tracing-subscriber",

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -33,7 +33,8 @@ uuid         = { version = "1", features = ["v4"] }
 clap         = { version = "4", features = ["derive"] }
 
 [dev-dependencies]
-tempfile = "3"
+tempfile     = "3"
+tokio-stream = "0.1"
 
 [[bin]]
 name = "aa-gateway"

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -26,10 +26,18 @@ dirs         = "6"
 async-trait  = "0.1"
 sha2         = "0.10"
 similar      = "2"
+tonic        = { version = "0.13", features = ["transport"] }
 tracing      = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+uuid         = { version = "1", features = ["v4"] }
+clap         = { version = "4", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3"
+
+[[bin]]
+name = "aa-gateway"
+path = "src/main.rs"
 
 [lints]
 workspace = true

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -26,6 +26,7 @@ dirs         = "6"
 async-trait  = "0.1"
 sha2         = "0.10"
 similar      = "2"
+tokio-stream = "0.1"
 tonic        = { version = "0.13", features = ["transport"] }
 tracing      = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
@@ -34,7 +35,6 @@ clap         = { version = "4", features = ["derive"] }
 
 [dev-dependencies]
 tempfile     = "3"
-tokio-stream = "0.1"
 
 [[bin]]
 name = "aa-gateway"

--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod budget;
 pub mod engine;
 pub mod policy;
+pub mod server;
 pub mod service;
 pub mod simulation;
 

--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -7,6 +7,8 @@
 pub mod budget;
 pub mod engine;
 pub mod policy;
+pub mod service;
 pub mod simulation;
 
 pub use engine::{EvaluationResult, PolicyEngine, PolicyLoadError};
+pub use service::PolicyServiceImpl;

--- a/aa-gateway/src/main.rs
+++ b/aa-gateway/src/main.rs
@@ -1,5 +1,78 @@
 //! `aa-gateway` — Agent Assembly governance gateway gRPC server.
+//!
+//! Loads a policy YAML, starts the `PolicyEngine` with hot-reload, and serves
+//! `PolicyService` over TCP (default) or Unix domain socket.
 
-fn main() {
-    todo!("AAASM-135: implement gateway server CLI and bootstrap")
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use clap::Parser;
+use tonic::transport::Server;
+use tracing_subscriber::EnvFilter;
+
+use aa_gateway::engine::PolicyEngine;
+use aa_gateway::service::PolicyServiceImpl;
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
+
+/// Agent Assembly governance gateway — gRPC policy evaluation server.
+#[derive(Parser)]
+#[command(name = "aa-gateway", version, about)]
+struct Cli {
+    /// Path to the policy YAML file.
+    #[arg(long)]
+    policy: PathBuf,
+
+    /// TCP listen address (e.g. "127.0.0.1:50051").
+    #[arg(long, default_value = "127.0.0.1:50051")]
+    listen: String,
+
+    /// Unix domain socket path. When set, takes precedence over --listen.
+    #[arg(long)]
+    socket: Option<PathBuf>,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialise tracing (respects RUST_LOG env var, defaults to info).
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    let cli = Cli::parse();
+
+    tracing::info!(policy = %cli.policy.display(), "loading policy");
+    let engine = PolicyEngine::load_from_file(&cli.policy)
+        .map_err(|e| format!("failed to load policy: {e:?}"))?;
+    let service = PolicyServiceImpl::new(Arc::new(engine));
+
+    if let Some(socket_path) = &cli.socket {
+        // ── UDS transport ────────────────────────────────────────────────
+        tracing::info!(socket = %socket_path.display(), "starting gRPC server on UDS");
+
+        // Remove stale socket file if it exists.
+        if socket_path.exists() {
+            std::fs::remove_file(socket_path)?;
+        }
+
+        let uds = tokio::net::UnixListener::bind(socket_path)?;
+        let incoming = tokio_stream::wrappers::UnixListenerStream::new(uds);
+
+        Server::builder()
+            .add_service(PolicyServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await?;
+    } else {
+        // ── TCP transport ────────────────────────────────────────────────
+        let addr = cli.listen.parse()?;
+        tracing::info!(%addr, "starting gRPC server on TCP");
+
+        Server::builder()
+            .add_service(PolicyServiceServer::new(service))
+            .serve(addr)
+            .await?;
+    }
+
+    Ok(())
 }

--- a/aa-gateway/src/main.rs
+++ b/aa-gateway/src/main.rs
@@ -1,18 +1,9 @@
 //! `aa-gateway` — Agent Assembly governance gateway gRPC server.
-//!
-//! Loads a policy YAML, starts the `PolicyEngine` with hot-reload, and serves
-//! `PolicyService` over TCP (default) or Unix domain socket.
 
 use std::path::PathBuf;
-use std::sync::Arc;
 
 use clap::Parser;
-use tonic::transport::Server;
 use tracing_subscriber::EnvFilter;
-
-use aa_gateway::engine::PolicyEngine;
-use aa_gateway::service::PolicyServiceImpl;
-use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
 
 /// Agent Assembly governance gateway — gRPC policy evaluation server.
 #[derive(Parser)]
@@ -33,7 +24,6 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Initialise tracing (respects RUST_LOG env var, defaults to info).
     tracing_subscriber::fmt()
         .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
         .init();
@@ -41,35 +31,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
 
     tracing::info!(policy = %cli.policy.display(), "loading policy");
-    let engine = PolicyEngine::load_from_file(&cli.policy).map_err(|e| format!("failed to load policy: {e:?}"))?;
-    let service = PolicyServiceImpl::new(Arc::new(engine));
 
     if let Some(socket_path) = &cli.socket {
-        // ── UDS transport ────────────────────────────────────────────────
-        tracing::info!(socket = %socket_path.display(), "starting gRPC server on UDS");
-
-        // Remove stale socket file if it exists.
-        if socket_path.exists() {
-            std::fs::remove_file(socket_path)?;
-        }
-
-        let uds = tokio::net::UnixListener::bind(socket_path)?;
-        let incoming = tokio_stream::wrappers::UnixListenerStream::new(uds);
-
-        Server::builder()
-            .add_service(PolicyServiceServer::new(service))
-            .serve_with_incoming(incoming)
-            .await?;
+        aa_gateway::server::serve_uds(&cli.policy, socket_path).await
     } else {
-        // ── TCP transport ────────────────────────────────────────────────
-        let addr = cli.listen.parse()?;
-        tracing::info!(%addr, "starting gRPC server on TCP");
-
-        Server::builder()
-            .add_service(PolicyServiceServer::new(service))
-            .serve(addr)
-            .await?;
+        aa_gateway::server::serve_tcp(&cli.policy, &cli.listen).await
     }
-
-    Ok(())
 }

--- a/aa-gateway/src/main.rs
+++ b/aa-gateway/src/main.rs
@@ -35,16 +35,13 @@ struct Cli {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialise tracing (respects RUST_LOG env var, defaults to info).
     tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-        )
+        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
         .init();
 
     let cli = Cli::parse();
 
     tracing::info!(policy = %cli.policy.display(), "loading policy");
-    let engine = PolicyEngine::load_from_file(&cli.policy)
-        .map_err(|e| format!("failed to load policy: {e:?}"))?;
+    let engine = PolicyEngine::load_from_file(&cli.policy).map_err(|e| format!("failed to load policy: {e:?}"))?;
     let service = PolicyServiceImpl::new(Arc::new(engine));
 
     if let Some(socket_path) = &cli.socket {

--- a/aa-gateway/src/main.rs
+++ b/aa-gateway/src/main.rs
@@ -1,0 +1,5 @@
+//! `aa-gateway` — Agent Assembly governance gateway gRPC server.
+
+fn main() {
+    todo!("AAASM-135: implement gateway server CLI and bootstrap")
+}

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -1,0 +1,54 @@
+//! gRPC server startup — loads policy, builds service, serves over TCP or UDS.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use tonic::transport::Server;
+
+use crate::engine::PolicyEngine;
+use crate::service::PolicyServiceImpl;
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
+
+/// Start the gRPC server on a TCP address.
+///
+/// Loads the policy from `policy_path`, wraps it in a `PolicyServiceImpl`, and
+/// serves on `listen_addr` (e.g. `"127.0.0.1:50051"`).
+pub async fn serve_tcp(policy_path: &Path, listen_addr: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let engine = PolicyEngine::load_from_file(policy_path).map_err(|e| format!("failed to load policy: {e:?}"))?;
+    let service = PolicyServiceImpl::new(Arc::new(engine));
+
+    let addr = listen_addr.parse()?;
+    tracing::info!(%addr, "starting gRPC server on TCP");
+
+    Server::builder()
+        .add_service(PolicyServiceServer::new(service))
+        .serve(addr)
+        .await?;
+
+    Ok(())
+}
+
+/// Start the gRPC server on a Unix domain socket.
+///
+/// Loads the policy from `policy_path`, wraps it in a `PolicyServiceImpl`, and
+/// serves on the given `socket_path`. Removes any stale socket file first.
+pub async fn serve_uds(policy_path: &Path, socket_path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let engine = PolicyEngine::load_from_file(policy_path).map_err(|e| format!("failed to load policy: {e:?}"))?;
+    let service = PolicyServiceImpl::new(Arc::new(engine));
+
+    tracing::info!(socket = %socket_path.display(), "starting gRPC server on UDS");
+
+    if socket_path.exists() {
+        std::fs::remove_file(socket_path)?;
+    }
+
+    let uds = tokio::net::UnixListener::bind(socket_path)?;
+    let incoming = tokio_stream::wrappers::UnixListenerStream::new(uds);
+
+    Server::builder()
+        .add_service(PolicyServiceServer::new(service))
+        .serve_with_incoming(incoming)
+        .await?;
+
+    Ok(())
+}

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -1,0 +1,1 @@
+//! Proto ↔ core type conversions for the PolicyService gRPC layer.

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -9,9 +9,11 @@ use aa_core::time::Timestamp;
 use aa_core::{AgentContext, FileMode, GovernanceAction, PolicyResult};
 use aa_proto::assembly::common::v1::Decision;
 use aa_proto::assembly::policy::v1::action_context::Action;
-use aa_proto::assembly::policy::v1::{CheckActionRequest, CheckActionResponse};
+use aa_proto::assembly::policy::v1::{CheckActionRequest, CheckActionResponse, RedactInstructions, RedactRule};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
+
+use crate::engine::EvaluationResult;
 
 /// Errors arising from malformed or incomplete proto requests.
 #[derive(Debug, thiserror::Error)]
@@ -125,16 +127,39 @@ pub fn request_to_core(
     Ok((ctx, action))
 }
 
-/// Convert a [`PolicyResult`] into a [`CheckActionResponse`].
+/// Convert an [`EvaluationResult`] into a [`CheckActionResponse`].
 ///
 /// `latency_us` is the measured evaluation wall time in microseconds.
 /// `policy_rule` is the identifier of the rule that triggered (empty for Allow).
-pub fn result_to_response(
-    result: &PolicyResult,
+///
+/// When the engine detected credential/PII findings and produced a redacted payload,
+/// the response uses `Decision::Redact` with the redacted field paths.
+pub fn eval_result_to_response(
+    eval: &EvaluationResult,
     latency_us: i64,
     policy_rule: &str,
 ) -> CheckActionResponse {
-    match result {
+    // If the scanner produced redaction findings, return REDACT with instructions.
+    if !eval.credential_findings.is_empty() {
+        let rules: Vec<RedactRule> = eval
+            .credential_findings
+            .iter()
+            .map(|f| RedactRule {
+                field_path: format!("$.{:?}", f.kind),
+                replacement: "[REDACTED]".into(),
+            })
+            .collect();
+        return CheckActionResponse {
+            decision: Decision::Redact as i32,
+            reason: "sensitive data detected".into(),
+            policy_rule: "data_pattern_scan".into(),
+            approval_id: String::new(),
+            redact: Some(RedactInstructions { rules }),
+            decision_latency_us: latency_us,
+        };
+    }
+
+    match &eval.decision {
         PolicyResult::Allow => CheckActionResponse {
             decision: Decision::Allow as i32,
             reason: String::new(),
@@ -160,4 +185,21 @@ pub fn result_to_response(
             decision_latency_us: latency_us,
         },
     }
+}
+
+/// Convert a [`PolicyResult`] into a [`CheckActionResponse`].
+///
+/// Convenience wrapper for tests and callers that only have a `PolicyResult`
+/// (no redaction findings).
+pub fn result_to_response(
+    result: &PolicyResult,
+    latency_us: i64,
+    policy_rule: &str,
+) -> CheckActionResponse {
+    let eval = EvaluationResult {
+        decision: result.clone(),
+        redacted_payload: None,
+        credential_findings: Vec::new(),
+    };
+    eval_result_to_response(&eval, latency_us, policy_rule)
 }

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -43,9 +43,7 @@ fn hash_to_16(s: &str) -> [u8; 16] {
 
 /// Convert a [`CheckActionRequest`] into the core domain pair
 /// ([`AgentContext`], [`GovernanceAction`]).
-pub fn request_to_core(
-    req: &CheckActionRequest,
-) -> Result<(AgentContext, GovernanceAction), ConvertError> {
+pub fn request_to_core(req: &CheckActionRequest) -> Result<(AgentContext, GovernanceAction), ConvertError> {
     // --- Agent context ---
     let proto_agent = req.agent_id.as_ref().ok_or(ConvertError::MissingAgentId)?;
     let agent_id = AgentId::from_bytes(hash_to_16(&proto_agent.agent_id));
@@ -134,11 +132,7 @@ pub fn request_to_core(
 ///
 /// When the engine detected credential/PII findings and produced a redacted payload,
 /// the response uses `Decision::Redact` with the redacted field paths.
-pub fn eval_result_to_response(
-    eval: &EvaluationResult,
-    latency_us: i64,
-    policy_rule: &str,
-) -> CheckActionResponse {
+pub fn eval_result_to_response(eval: &EvaluationResult, latency_us: i64, policy_rule: &str) -> CheckActionResponse {
     // If the scanner produced redaction findings, return REDACT with instructions.
     if !eval.credential_findings.is_empty() {
         let rules: Vec<RedactRule> = eval
@@ -191,11 +185,7 @@ pub fn eval_result_to_response(
 ///
 /// Convenience wrapper for tests and callers that only have a `PolicyResult`
 /// (no redaction findings).
-pub fn result_to_response(
-    result: &PolicyResult,
-    latency_us: i64,
-    policy_rule: &str,
-) -> CheckActionResponse {
+pub fn result_to_response(result: &PolicyResult, latency_us: i64, policy_rule: &str) -> CheckActionResponse {
     let eval = EvaluationResult {
         decision: result.clone(),
         redacted_payload: None,

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -1,1 +1,163 @@
 //! Proto ↔ core type conversions for the PolicyService gRPC layer.
+//!
+//! Bridges the structural gap between protobuf message types
+//! (`CheckActionRequest`, `CheckActionResponse`) and the core domain types
+//! (`AgentContext`, `GovernanceAction`, `PolicyResult`).
+
+use aa_core::identity::{AgentId, SessionId};
+use aa_core::time::Timestamp;
+use aa_core::{AgentContext, FileMode, GovernanceAction, PolicyResult};
+use aa_proto::assembly::common::v1::Decision;
+use aa_proto::assembly::policy::v1::action_context::Action;
+use aa_proto::assembly::policy::v1::{CheckActionRequest, CheckActionResponse};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+
+/// Errors arising from malformed or incomplete proto requests.
+#[derive(Debug, thiserror::Error)]
+pub enum ConvertError {
+    /// The `agent_id` field is missing from the request.
+    #[error("missing agent_id")]
+    MissingAgentId,
+    /// The `context` oneof field is missing or empty.
+    #[error("missing action context")]
+    MissingContext,
+    /// The file operation string is not one of "read", "write", "append", "delete".
+    #[error("unknown file operation: {0}")]
+    UnknownFileOp(String),
+}
+
+/// Hash a string into a 16-byte identifier using SHA-256 truncation.
+///
+/// Proto identity fields are variable-length strings; core identity types are
+/// fixed `[u8; 16]`. This deterministic mapping avoids collisions in practice
+/// while satisfying the type constraint.
+fn hash_to_16(s: &str) -> [u8; 16] {
+    let digest = Sha256::digest(s.as_bytes());
+    let mut out = [0u8; 16];
+    out.copy_from_slice(&digest[..16]);
+    out
+}
+
+/// Convert a [`CheckActionRequest`] into the core domain pair
+/// ([`AgentContext`], [`GovernanceAction`]).
+pub fn request_to_core(
+    req: &CheckActionRequest,
+) -> Result<(AgentContext, GovernanceAction), ConvertError> {
+    // --- Agent context ---
+    let proto_agent = req.agent_id.as_ref().ok_or(ConvertError::MissingAgentId)?;
+    let agent_id = AgentId::from_bytes(hash_to_16(&proto_agent.agent_id));
+    let session_id = SessionId::from_bytes(hash_to_16(&req.trace_id));
+
+    let mut metadata = BTreeMap::new();
+    if !proto_agent.org_id.is_empty() {
+        metadata.insert("org_id".into(), proto_agent.org_id.clone());
+    }
+    if !proto_agent.team_id.is_empty() {
+        metadata.insert("team_id".into(), proto_agent.team_id.clone());
+    }
+    if !req.credential_token.is_empty() {
+        metadata.insert("credential_token".into(), req.credential_token.clone());
+    }
+    if !req.span_id.is_empty() {
+        metadata.insert("span_id".into(), req.span_id.clone());
+    }
+
+    let ctx = AgentContext {
+        agent_id,
+        session_id,
+        pid: 0, // not available in proto — set to 0
+        started_at: Timestamp::from_nanos(0),
+        metadata,
+    };
+
+    // --- Governance action ---
+    let context = req.context.as_ref().ok_or(ConvertError::MissingContext)?;
+    let action_oneof = context.action.as_ref().ok_or(ConvertError::MissingContext)?;
+
+    let action = match action_oneof {
+        Action::ToolCall(tc) => GovernanceAction::ToolCall {
+            name: tc.tool_name.clone(),
+            args: String::from_utf8_lossy(&tc.args_json).into_owned(),
+        },
+        Action::FileOp(fo) => {
+            let mode = match fo.operation.as_str() {
+                "read" => FileMode::Read,
+                "write" | "create" => FileMode::Write,
+                "append" => FileMode::Append,
+                "delete" => FileMode::Delete,
+                other => return Err(ConvertError::UnknownFileOp(other.to_string())),
+            };
+            GovernanceAction::FileAccess {
+                path: fo.path.clone(),
+                mode,
+            }
+        }
+        Action::NetworkCall(nc) => {
+            let url = format!("{}://{}:{}", nc.protocol, nc.host, nc.port);
+            GovernanceAction::NetworkRequest {
+                url,
+                method: "CONNECT".into(),
+            }
+        }
+        Action::ProcessExec(pe) => {
+            let command = if pe.args.is_empty() {
+                pe.command.clone()
+            } else {
+                format!("{} {}", pe.command, pe.args.join(" "))
+            };
+            GovernanceAction::ProcessExec { command }
+        }
+        Action::LlmCall(lc) => {
+            let args = serde_json::json!({
+                "model": lc.model,
+                "prompt_tokens": lc.prompt_tokens,
+                "contains_pii": lc.contains_pii,
+            })
+            .to_string();
+            GovernanceAction::ToolCall {
+                name: "llm_call".into(),
+                args,
+            }
+        }
+    };
+
+    Ok((ctx, action))
+}
+
+/// Convert a [`PolicyResult`] into a [`CheckActionResponse`].
+///
+/// `latency_us` is the measured evaluation wall time in microseconds.
+/// `policy_rule` is the identifier of the rule that triggered (empty for Allow).
+pub fn result_to_response(
+    result: &PolicyResult,
+    latency_us: i64,
+    policy_rule: &str,
+) -> CheckActionResponse {
+    match result {
+        PolicyResult::Allow => CheckActionResponse {
+            decision: Decision::Allow as i32,
+            reason: String::new(),
+            policy_rule: String::new(),
+            approval_id: String::new(),
+            redact: None,
+            decision_latency_us: latency_us,
+        },
+        PolicyResult::Deny { reason } => CheckActionResponse {
+            decision: Decision::Deny as i32,
+            reason: reason.clone(),
+            policy_rule: policy_rule.to_string(),
+            approval_id: String::new(),
+            redact: None,
+            decision_latency_us: latency_us,
+        },
+        PolicyResult::RequiresApproval { .. } => CheckActionResponse {
+            decision: Decision::Pending as i32,
+            reason: "human approval required".into(),
+            policy_rule: policy_rule.to_string(),
+            approval_id: uuid::Uuid::new_v4().to_string(),
+            redact: None,
+            decision_latency_us: latency_us,
+        },
+    }
+}

--- a/aa-gateway/src/service/mod.rs
+++ b/aa-gateway/src/service/mod.rs
@@ -1,0 +1,6 @@
+//! gRPC service layer — wires tonic-generated `PolicyService` to `PolicyEngine`.
+
+pub mod convert;
+pub mod policy_service;
+
+pub use policy_service::PolicyServiceImpl;

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -25,6 +25,7 @@ impl PolicyServiceImpl {
     }
 
     /// Evaluate a single request against the engine, returning the gRPC response.
+    #[allow(clippy::result_large_err)] // tonic::Status is the standard gRPC error type
     fn evaluate_one(&self, req: &CheckActionRequest) -> Result<CheckActionResponse, Status> {
         let (ctx, action) = convert::request_to_core(req).map_err(|e| {
             tracing::error!(error = %e, "failed to convert CheckActionRequest");

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -6,9 +6,7 @@ use std::time::Instant;
 use tonic::{Request, Response, Status};
 
 use aa_proto::assembly::policy::v1::policy_service_server::PolicyService;
-use aa_proto::assembly::policy::v1::{
-    BatchCheckRequest, BatchCheckResponse, CheckActionRequest, CheckActionResponse,
-};
+use aa_proto::assembly::policy::v1::{BatchCheckRequest, BatchCheckResponse, CheckActionRequest, CheckActionResponse};
 
 use crate::engine::PolicyEngine;
 use crate::service::convert;
@@ -82,10 +80,7 @@ impl PolicyService for PolicyServiceImpl {
         Ok(Response::new(response))
     }
 
-    async fn batch_check(
-        &self,
-        request: Request<BatchCheckRequest>,
-    ) -> Result<Response<BatchCheckResponse>, Status> {
+    async fn batch_check(&self, request: Request<BatchCheckRequest>) -> Result<Response<BatchCheckResponse>, Status> {
         let batch = request.into_inner();
         let mut responses = Vec::with_capacity(batch.requests.len());
 

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -1,0 +1,18 @@
+//! `PolicyService` tonic trait implementation wiring gRPC RPCs to `PolicyEngine`.
+
+use std::sync::Arc;
+
+use crate::PolicyEngine;
+
+/// gRPC service implementation wiring `CheckAction` / `BatchCheck` to [`PolicyEngine`].
+pub struct PolicyServiceImpl {
+    #[allow(dead_code)]
+    engine: Arc<PolicyEngine>,
+}
+
+impl PolicyServiceImpl {
+    /// Create a new service backed by the given policy engine.
+    pub fn new(engine: Arc<PolicyEngine>) -> Self {
+        Self { engine }
+    }
+}

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -1,12 +1,20 @@
 //! `PolicyService` tonic trait implementation wiring gRPC RPCs to `PolicyEngine`.
 
 use std::sync::Arc;
+use std::time::Instant;
 
-use crate::PolicyEngine;
+use tonic::{Request, Response, Status};
+
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyService;
+use aa_proto::assembly::policy::v1::{
+    BatchCheckRequest, BatchCheckResponse, CheckActionRequest, CheckActionResponse,
+};
+
+use crate::engine::PolicyEngine;
+use crate::service::convert;
 
 /// gRPC service implementation wiring `CheckAction` / `BatchCheck` to [`PolicyEngine`].
 pub struct PolicyServiceImpl {
-    #[allow(dead_code)]
     engine: Arc<PolicyEngine>,
 }
 
@@ -14,5 +22,76 @@ impl PolicyServiceImpl {
     /// Create a new service backed by the given policy engine.
     pub fn new(engine: Arc<PolicyEngine>) -> Self {
         Self { engine }
+    }
+
+    /// Evaluate a single request against the engine, returning the gRPC response.
+    fn evaluate_one(&self, req: &CheckActionRequest) -> Result<CheckActionResponse, Status> {
+        let (ctx, action) = convert::request_to_core(req).map_err(|e| {
+            tracing::error!(error = %e, "failed to convert CheckActionRequest");
+            Status::invalid_argument(e.to_string())
+        })?;
+
+        let start = Instant::now();
+        let eval = self.engine.evaluate(&ctx, &action);
+        let latency_us = start.elapsed().as_micros() as i64;
+
+        // Derive a policy_rule label from the deny/approval reason.
+        let policy_rule = match &eval.decision {
+            aa_core::PolicyResult::Allow => "",
+            aa_core::PolicyResult::Deny { reason } => reason.as_str(),
+            aa_core::PolicyResult::RequiresApproval { .. } => "requires_approval",
+        };
+
+        Ok(convert::eval_result_to_response(&eval, latency_us, policy_rule))
+    }
+}
+
+#[tonic::async_trait]
+impl PolicyService for PolicyServiceImpl {
+    async fn check_action(
+        &self,
+        request: Request<CheckActionRequest>,
+    ) -> Result<Response<CheckActionResponse>, Status> {
+        let req = request.into_inner();
+
+        tracing::debug!(
+            agent_id = ?req.agent_id.as_ref().map(|a| &a.agent_id),
+            action_type = req.action_type,
+            trace_id = %req.trace_id,
+            "check_action request"
+        );
+
+        let response = self.evaluate_one(&req)?;
+
+        tracing::debug!(
+            decision = response.decision,
+            latency_us = response.decision_latency_us,
+            "check_action response"
+        );
+
+        if response.decision != aa_proto::assembly::common::v1::Decision::Allow as i32 {
+            tracing::warn!(
+                decision = response.decision,
+                reason = %response.reason,
+                policy_rule = %response.policy_rule,
+                "non-allow decision"
+            );
+        }
+
+        Ok(Response::new(response))
+    }
+
+    async fn batch_check(
+        &self,
+        request: Request<BatchCheckRequest>,
+    ) -> Result<Response<BatchCheckResponse>, Status> {
+        let batch = request.into_inner();
+        let mut responses = Vec::with_capacity(batch.requests.len());
+
+        for req in &batch.requests {
+            responses.push(self.evaluate_one(req)?);
+        }
+
+        Ok(Response::new(BatchCheckResponse { responses }))
     }
 }

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -186,3 +186,33 @@ tools:
     assert_eq!(resp.responses[1].decision, Decision::Deny as i32);
     assert_eq!(resp.responses[2].decision, Decision::Allow as i32);
 }
+
+// ── GatewayClient integration test ──────────────────────────────────────────
+
+#[tokio::test]
+async fn gateway_client_check_action_round_trip() {
+    let addr = start_server(
+        r#"
+version: "1"
+tools:
+  web_search:
+    allow: true
+"#,
+    )
+    .await;
+
+    let mut client = aa_runtime::gateway_client::GatewayClient::connect(&format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let resp = client.check_action(tool_call_request("web_search")).await.unwrap();
+
+    assert_eq!(resp.decision, Decision::Allow as i32);
+}
+
+#[tokio::test]
+async fn gateway_client_connect_failure() {
+    // Attempt to connect to a port that is not listening.
+    let result = aa_runtime::gateway_client::GatewayClient::connect("http://127.0.0.1:1").await;
+    assert!(result.is_err(), "should fail to connect to closed port");
+}

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -1,0 +1,198 @@
+//! Integration tests for the PolicyService gRPC endpoint.
+//!
+//! Each test starts a tonic server on a random TCP port, connects a client,
+//! sends requests, and asserts on responses.
+
+use std::io::Write;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use aa_gateway::PolicyEngine;
+use aa_gateway::service::PolicyServiceImpl;
+use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decision};
+use aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient;
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
+use aa_proto::assembly::policy::v1::{
+    action_context::Action, ActionContext, BatchCheckRequest, CheckActionRequest, ToolCallContext,
+};
+use tokio::net::TcpListener;
+use tonic::transport::Server;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Start a PolicyService gRPC server on a random port and return the address.
+async fn start_server(policy_yaml: &str) -> SocketAddr {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", policy_yaml).unwrap();
+    tmp.flush().unwrap();
+
+    let engine = PolicyEngine::load_from_file(tmp.path()).unwrap();
+    let service = PolicyServiceImpl::new(Arc::new(engine));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    // Keep the tempfile alive for the duration of the server.
+    tokio::spawn(async move {
+        let _tmp = tmp; // prevent drop
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(PolicyServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    // Give the server a moment to start.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    addr
+}
+
+fn tool_call_request(tool_name: &str) -> CheckActionRequest {
+    CheckActionRequest {
+        agent_id: Some(ProtoAgentId {
+            org_id: "org".into(),
+            team_id: "team".into(),
+            agent_id: "agent-1".into(),
+        }),
+        credential_token: "tok".into(),
+        trace_id: "trace-1".into(),
+        span_id: "span-1".into(),
+        action_type: ActionType::ToolCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::ToolCall(ToolCallContext {
+                tool_name: tool_name.into(),
+                tool_source: "test".into(),
+                args_json: b"{}".to_vec(),
+                target_url: String::new(),
+            })),
+        }),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn check_action_allows_permitted_tool() {
+    let addr = start_server(
+        r#"
+version: "1"
+tools:
+  web_search:
+    allow: true
+"#,
+    )
+    .await;
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let resp = client
+        .check_action(tool_call_request("web_search"))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(resp.decision, Decision::Allow as i32);
+}
+
+#[tokio::test]
+async fn check_action_denies_blocked_tool() {
+    let addr = start_server(
+        r#"
+version: "1"
+tools:
+  dangerous:
+    allow: false
+"#,
+    )
+    .await;
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let resp = client
+        .check_action(tool_call_request("dangerous"))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(resp.decision, Decision::Deny as i32);
+    assert!(!resp.reason.is_empty());
+}
+
+#[tokio::test]
+async fn check_action_returns_invalid_argument_on_missing_context() {
+    let addr = start_server("version: \"1\"\n").await;
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let bad_req = CheckActionRequest {
+        agent_id: Some(ProtoAgentId {
+            agent_id: "a".into(),
+            ..Default::default()
+        }),
+        context: None,
+        ..Default::default()
+    };
+
+    let err = client.check_action(bad_req).await.unwrap_err();
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+}
+
+#[tokio::test]
+async fn check_action_populates_latency_us() {
+    let addr = start_server("version: \"1\"\n").await;
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let resp = client
+        .check_action(tool_call_request("any"))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(
+        resp.decision_latency_us >= 0,
+        "decision_latency_us should be non-negative"
+    );
+}
+
+#[tokio::test]
+async fn batch_check_returns_ordered_responses() {
+    let addr = start_server(
+        r#"
+version: "1"
+tools:
+  allowed_tool:
+    allow: true
+  blocked_tool:
+    allow: false
+"#,
+    )
+    .await;
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let batch = BatchCheckRequest {
+        requests: vec![
+            tool_call_request("allowed_tool"),
+            tool_call_request("blocked_tool"),
+            tool_call_request("allowed_tool"),
+        ],
+    };
+
+    let resp = client.batch_check(batch).await.unwrap().into_inner();
+    assert_eq!(resp.responses.len(), 3);
+    assert_eq!(resp.responses[0].decision, Decision::Allow as i32);
+    assert_eq!(resp.responses[1].decision, Decision::Deny as i32);
+    assert_eq!(resp.responses[2].decision, Decision::Allow as i32);
+}

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -7,8 +7,8 @@ use std::io::Write;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use aa_gateway::PolicyEngine;
 use aa_gateway::service::PolicyServiceImpl;
+use aa_gateway::PolicyEngine;
 use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decision};
 use aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient;
 use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
@@ -84,9 +84,7 @@ tools:
     )
     .await;
 
-    let mut client = PolicyServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let resp = client
         .check_action(tool_call_request("web_search"))
@@ -109,9 +107,7 @@ tools:
     )
     .await;
 
-    let mut client = PolicyServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let resp = client
         .check_action(tool_call_request("dangerous"))
@@ -127,9 +123,7 @@ tools:
 async fn check_action_returns_invalid_argument_on_missing_context() {
     let addr = start_server("version: \"1\"\n").await;
 
-    let mut client = PolicyServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let bad_req = CheckActionRequest {
         agent_id: Some(ProtoAgentId {
@@ -148,9 +142,7 @@ async fn check_action_returns_invalid_argument_on_missing_context() {
 async fn check_action_populates_latency_us() {
     let addr = start_server("version: \"1\"\n").await;
 
-    let mut client = PolicyServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let resp = client
         .check_action(tool_call_request("any"))
@@ -178,9 +170,7 @@ tools:
     )
     .await;
 
-    let mut client = PolicyServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let batch = BatchCheckRequest {
         requests: vec![

--- a/aa-gateway/tests/service_convert_test.rs
+++ b/aa-gateway/tests/service_convert_test.rs
@@ -1,7 +1,8 @@
 //! Unit tests for `aa_gateway::service::convert` — proto ↔ core type conversions.
 
 use aa_core::{FileMode, GovernanceAction, PolicyResult};
-use aa_gateway::service::convert::{request_to_core, result_to_response, ConvertError};
+use aa_gateway::engine::EvaluationResult;
+use aa_gateway::service::convert::{eval_result_to_response, request_to_core, result_to_response, ConvertError};
 use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decision};
 use aa_proto::assembly::policy::v1::{
     action_context::Action, ActionContext, CheckActionRequest, FileOpContext, LlmCallContext, NetworkCallContext,
@@ -171,7 +172,129 @@ fn missing_context_returns_error() {
     assert!(matches!(err, ConvertError::MissingContext));
 }
 
+// ── Additional inbound conversion tests ─────────────────────────────────────
+
+#[test]
+fn file_op_create_maps_to_write_mode() {
+    let req = base_request(Action::FileOp(FileOpContext {
+        operation: "create".into(),
+        path: "/tmp/new.txt".into(),
+        is_sensitive_path: false,
+    }));
+    let (_, action) = request_to_core(&req).unwrap();
+    match action {
+        GovernanceAction::FileAccess { mode, .. } => assert_eq!(mode, FileMode::Write),
+        other => panic!("expected FileAccess, got {:?}", other),
+    }
+}
+
+#[test]
+fn file_op_append_converts_to_append_mode() {
+    let req = base_request(Action::FileOp(FileOpContext {
+        operation: "append".into(),
+        path: "/var/log/app.log".into(),
+        is_sensitive_path: false,
+    }));
+    let (_, action) = request_to_core(&req).unwrap();
+    match action {
+        GovernanceAction::FileAccess { mode, .. } => assert_eq!(mode, FileMode::Append),
+        other => panic!("expected FileAccess, got {:?}", other),
+    }
+}
+
+#[test]
+fn unknown_file_op_returns_error() {
+    let req = base_request(Action::FileOp(FileOpContext {
+        operation: "chmod".into(),
+        path: "/tmp/f".into(),
+        is_sensitive_path: false,
+    }));
+    let err = request_to_core(&req).unwrap_err();
+    assert!(matches!(err, ConvertError::UnknownFileOp(ref s) if s == "chmod"));
+}
+
+#[test]
+fn process_exec_with_empty_args_uses_command_only() {
+    let req = base_request(Action::ProcessExec(ProcessExecContext {
+        command: "whoami".into(),
+        args: vec![],
+    }));
+    let (_, action) = request_to_core(&req).unwrap();
+    match action {
+        GovernanceAction::ProcessExec { command } => assert_eq!(command, "whoami"),
+        other => panic!("expected ProcessExec, got {:?}", other),
+    }
+}
+
+#[test]
+fn missing_action_oneof_returns_missing_context() {
+    let req = CheckActionRequest {
+        agent_id: Some(ProtoAgentId {
+            agent_id: "a".into(),
+            ..Default::default()
+        }),
+        context: Some(ActionContext { action: None }),
+        ..Default::default()
+    };
+    let err = request_to_core(&req).unwrap_err();
+    assert!(matches!(err, ConvertError::MissingContext));
+}
+
+#[test]
+fn metadata_populated_from_org_team_credential_span() {
+    let req = base_request(Action::ToolCall(ToolCallContext {
+        tool_name: "t".into(),
+        ..Default::default()
+    }));
+    let (ctx, _) = request_to_core(&req).unwrap();
+    assert_eq!(ctx.metadata.get("org_id").unwrap(), "org-1");
+    assert_eq!(ctx.metadata.get("team_id").unwrap(), "team-a");
+    assert_eq!(ctx.metadata.get("credential_token").unwrap(), "tok");
+    assert_eq!(ctx.metadata.get("span_id").unwrap(), "span-1");
+}
+
+#[test]
+fn empty_metadata_fields_are_omitted() {
+    let req = CheckActionRequest {
+        agent_id: Some(ProtoAgentId {
+            agent_id: "a".into(),
+            org_id: String::new(),
+            team_id: String::new(),
+        }),
+        credential_token: String::new(),
+        trace_id: "t".into(),
+        span_id: String::new(),
+        action_type: ActionType::ToolCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::ToolCall(ToolCallContext {
+                tool_name: "t".into(),
+                ..Default::default()
+            })),
+        }),
+    };
+    let (ctx, _) = request_to_core(&req).unwrap();
+    assert!(ctx.metadata.is_empty());
+}
+
 // ── Outbound conversion tests ────────────────────────────────────────────────
+
+#[test]
+fn eval_result_with_credential_findings_returns_redact() {
+    let eval = EvaluationResult {
+        decision: PolicyResult::Allow,
+        redacted_payload: Some("redacted text".into()),
+        credential_findings: vec![aa_core::CredentialFinding::from_regex_match(0, 10)],
+    };
+    let resp = eval_result_to_response(&eval, 77, "");
+    assert_eq!(resp.decision, Decision::Redact as i32);
+    assert_eq!(resp.reason, "sensitive data detected");
+    assert_eq!(resp.policy_rule, "data_pattern_scan");
+    assert!(resp.redact.is_some());
+    let redact = resp.redact.unwrap();
+    assert_eq!(redact.rules.len(), 1);
+    assert_eq!(redact.rules[0].replacement, "[REDACTED]");
+    assert_eq!(resp.decision_latency_us, 77);
+}
 
 #[test]
 fn allow_result_to_response() {

--- a/aa-gateway/tests/service_convert_test.rs
+++ b/aa-gateway/tests/service_convert_test.rs
@@ -4,8 +4,8 @@ use aa_core::{FileMode, GovernanceAction, PolicyResult};
 use aa_gateway::service::convert::{request_to_core, result_to_response, ConvertError};
 use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decision};
 use aa_proto::assembly::policy::v1::{
-    action_context::Action, ActionContext, CheckActionRequest, FileOpContext, LlmCallContext,
-    NetworkCallContext, ProcessExecContext, ToolCallContext,
+    action_context::Action, ActionContext, CheckActionRequest, FileOpContext, LlmCallContext, NetworkCallContext,
+    ProcessExecContext, ToolCallContext,
 };
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -21,9 +21,7 @@ fn base_request(action: Action) -> CheckActionRequest {
         trace_id: "trace-1".into(),
         span_id: "span-1".into(),
         action_type: ActionType::ToolCall as i32,
-        context: Some(ActionContext {
-            action: Some(action),
-        }),
+        context: Some(ActionContext { action: Some(action) }),
     }
 }
 

--- a/aa-gateway/tests/service_convert_test.rs
+++ b/aa-gateway/tests/service_convert_test.rs
@@ -1,0 +1,211 @@
+//! Unit tests for `aa_gateway::service::convert` — proto ↔ core type conversions.
+
+use aa_core::{FileMode, GovernanceAction, PolicyResult};
+use aa_gateway::service::convert::{request_to_core, result_to_response, ConvertError};
+use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decision};
+use aa_proto::assembly::policy::v1::{
+    action_context::Action, ActionContext, CheckActionRequest, FileOpContext, LlmCallContext,
+    NetworkCallContext, ProcessExecContext, ToolCallContext,
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn base_request(action: Action) -> CheckActionRequest {
+    CheckActionRequest {
+        agent_id: Some(ProtoAgentId {
+            org_id: "org-1".into(),
+            team_id: "team-a".into(),
+            agent_id: "agent-42".into(),
+        }),
+        credential_token: "tok".into(),
+        trace_id: "trace-1".into(),
+        span_id: "span-1".into(),
+        action_type: ActionType::ToolCall as i32,
+        context: Some(ActionContext {
+            action: Some(action),
+        }),
+    }
+}
+
+// ── Inbound conversion tests ─────────────────────────────────────────────────
+
+#[test]
+fn tool_call_context_converts_to_governance_action() {
+    let req = base_request(Action::ToolCall(ToolCallContext {
+        tool_name: "web_search".into(),
+        tool_source: "mcp".into(),
+        args_json: b"{\"q\":\"rust\"}".to_vec(),
+        target_url: String::new(),
+    }));
+    let (ctx, action) = request_to_core(&req).unwrap();
+    assert!(!ctx.metadata.is_empty());
+    match action {
+        GovernanceAction::ToolCall { name, args } => {
+            assert_eq!(name, "web_search");
+            assert!(args.contains("rust"));
+        }
+        other => panic!("expected ToolCall, got {:?}", other),
+    }
+}
+
+#[test]
+fn file_op_read_converts_to_file_access() {
+    let req = base_request(Action::FileOp(FileOpContext {
+        operation: "read".into(),
+        path: "/etc/passwd".into(),
+        is_sensitive_path: true,
+    }));
+    let (_, action) = request_to_core(&req).unwrap();
+    match action {
+        GovernanceAction::FileAccess { path, mode } => {
+            assert_eq!(path, "/etc/passwd");
+            assert_eq!(mode, FileMode::Read);
+        }
+        other => panic!("expected FileAccess, got {:?}", other),
+    }
+}
+
+#[test]
+fn file_op_write_converts_to_file_access() {
+    let req = base_request(Action::FileOp(FileOpContext {
+        operation: "write".into(),
+        path: "/tmp/out.txt".into(),
+        is_sensitive_path: false,
+    }));
+    let (_, action) = request_to_core(&req).unwrap();
+    match action {
+        GovernanceAction::FileAccess { mode, .. } => assert_eq!(mode, FileMode::Write),
+        other => panic!("expected FileAccess, got {:?}", other),
+    }
+}
+
+#[test]
+fn file_op_delete_converts_to_file_access() {
+    let req = base_request(Action::FileOp(FileOpContext {
+        operation: "delete".into(),
+        path: "/tmp/junk".into(),
+        is_sensitive_path: false,
+    }));
+    let (_, action) = request_to_core(&req).unwrap();
+    match action {
+        GovernanceAction::FileAccess { mode, .. } => assert_eq!(mode, FileMode::Delete),
+        other => panic!("expected FileAccess, got {:?}", other),
+    }
+}
+
+#[test]
+fn network_call_converts_to_network_request() {
+    let req = base_request(Action::NetworkCall(NetworkCallContext {
+        host: "api.openai.com".into(),
+        port: 443,
+        protocol: "https".into(),
+        in_allowlist: true,
+    }));
+    let (_, action) = request_to_core(&req).unwrap();
+    match action {
+        GovernanceAction::NetworkRequest { url, method } => {
+            assert_eq!(url, "https://api.openai.com:443");
+            assert_eq!(method, "CONNECT");
+        }
+        other => panic!("expected NetworkRequest, got {:?}", other),
+    }
+}
+
+#[test]
+fn process_exec_converts_to_process_exec() {
+    let req = base_request(Action::ProcessExec(ProcessExecContext {
+        command: "ls".into(),
+        args: vec!["-la".into(), "/tmp".into()],
+    }));
+    let (_, action) = request_to_core(&req).unwrap();
+    match action {
+        GovernanceAction::ProcessExec { command } => {
+            assert_eq!(command, "ls -la /tmp");
+        }
+        other => panic!("expected ProcessExec, got {:?}", other),
+    }
+}
+
+#[test]
+fn llm_call_converts_to_tool_call() {
+    let req = base_request(Action::LlmCall(LlmCallContext {
+        model: "gpt-4o".into(),
+        prompt_tokens: 500,
+        contains_pii: false,
+    }));
+    let (_, action) = request_to_core(&req).unwrap();
+    match action {
+        GovernanceAction::ToolCall { name, args } => {
+            assert_eq!(name, "llm_call");
+            assert!(args.contains("gpt-4o"));
+        }
+        other => panic!("expected ToolCall, got {:?}", other),
+    }
+}
+
+#[test]
+fn missing_agent_id_returns_error() {
+    let req = CheckActionRequest {
+        agent_id: None,
+        context: Some(ActionContext {
+            action: Some(Action::ToolCall(ToolCallContext {
+                tool_name: "t".into(),
+                ..Default::default()
+            })),
+        }),
+        ..Default::default()
+    };
+    let err = request_to_core(&req).unwrap_err();
+    assert!(matches!(err, ConvertError::MissingAgentId));
+}
+
+#[test]
+fn missing_context_returns_error() {
+    let req = CheckActionRequest {
+        agent_id: Some(ProtoAgentId {
+            agent_id: "a".into(),
+            ..Default::default()
+        }),
+        context: None,
+        ..Default::default()
+    };
+    let err = request_to_core(&req).unwrap_err();
+    assert!(matches!(err, ConvertError::MissingContext));
+}
+
+// ── Outbound conversion tests ────────────────────────────────────────────────
+
+#[test]
+fn allow_result_to_response() {
+    let resp = result_to_response(&PolicyResult::Allow, 42, "");
+    assert_eq!(resp.decision, Decision::Allow as i32);
+    assert!(resp.reason.is_empty());
+    assert_eq!(resp.decision_latency_us, 42);
+}
+
+#[test]
+fn deny_result_to_response() {
+    let resp = result_to_response(
+        &PolicyResult::Deny {
+            reason: "blocked".into(),
+        },
+        100,
+        "tool_deny",
+    );
+    assert_eq!(resp.decision, Decision::Deny as i32);
+    assert_eq!(resp.reason, "blocked");
+    assert_eq!(resp.policy_rule, "tool_deny");
+    assert_eq!(resp.decision_latency_us, 100);
+}
+
+#[test]
+fn requires_approval_result_to_response() {
+    let resp = result_to_response(
+        &PolicyResult::RequiresApproval { timeout_secs: 30 },
+        50,
+        "approval_cond",
+    );
+    assert_eq!(resp.decision, Decision::Pending as i32);
+    assert!(!resp.approval_id.is_empty(), "approval_id should be a UUID");
+    assert_eq!(resp.decision_latency_us, 50);
+}

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -20,6 +20,7 @@ serde_json                  = "1"
 toml                        = "0.8"
 tokio                       = { version = "1", features = ["full"] }
 tokio-util                  = { version = "0.7", features = ["rt"] }
+tonic                       = { version = "0.13", features = ["transport"] }
 tracing                     = "0.1"
 tracing-subscriber          = { version = "0.3", features = ["json", "env-filter"] }
 

--- a/aa-runtime/src/config.rs
+++ b/aa-runtime/src/config.rs
@@ -65,6 +65,17 @@ pub struct RuntimeConfig {
     /// - Non-empty string → `Some(<value>)`
     /// - Empty string → `None` (policy enforcement disabled)
     pub policy_path: Option<PathBuf>,
+
+    /// Optional gRPC endpoint for the governance gateway.
+    ///
+    /// Read from `AA_GATEWAY_ENDPOINT`.
+    /// - Not set or empty → `None` (local policy evaluation)
+    /// - Non-empty string → `Some(<value>)` (forward policy checks to gateway)
+    ///
+    /// When set, `handle_policy_query` forwards `CheckActionRequest` to the
+    /// gateway via [`crate::gateway_client::GatewayClient`] instead of
+    /// evaluating locally with [`crate::policy::PolicyRules`].
+    pub gateway_endpoint: Option<String>,
 }
 
 impl RuntimeConfig {
@@ -88,6 +99,7 @@ impl RuntimeConfig {
     /// | `AA_PIPELINE_BROADCAST_CAPACITY` | `usize` | `1_024` |
     /// | `AA_METRICS_ADDR` | `String` | `"0.0.0.0:8080"` |
     /// | `AA_POLICY_PATH` | `Option<PathBuf>` | `Some("/etc/aa/policy.toml")` |
+    /// | `AA_GATEWAY_ENDPOINT` | `Option<String>` | `None` |
     pub fn from_env() -> Result<Self, String> {
         let agent_id = std::env::var("AA_AGENT_ID").map_err(|_| "AA_AGENT_ID is required but not set".to_string())?;
 
@@ -147,6 +159,10 @@ impl RuntimeConfig {
             Ok(v) => Some(PathBuf::from(v)),
         };
 
+        let gateway_endpoint = std::env::var("AA_GATEWAY_ENDPOINT")
+            .ok()
+            .filter(|v| !v.is_empty());
+
         Ok(Self {
             agent_id,
             worker_threads,
@@ -158,6 +174,7 @@ impl RuntimeConfig {
             pipeline_broadcast_capacity,
             metrics_addr,
             policy_path,
+            gateway_endpoint,
         })
     }
 }
@@ -508,5 +525,49 @@ mod tests {
 
         std::env::remove_var("AA_AGENT_ID");
         std::env::remove_var("AA_POLICY_PATH");
+    }
+
+    #[test]
+    fn gateway_endpoint_none_when_unset() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AA_AGENT_ID", "agent-gw-default");
+        std::env::remove_var("AA_GATEWAY_ENDPOINT");
+
+        let config = RuntimeConfig::from_env().unwrap();
+
+        assert_eq!(config.gateway_endpoint, None);
+
+        std::env::remove_var("AA_AGENT_ID");
+    }
+
+    #[test]
+    fn gateway_endpoint_none_when_empty() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AA_AGENT_ID", "agent-gw-empty");
+        std::env::set_var("AA_GATEWAY_ENDPOINT", "");
+
+        let config = RuntimeConfig::from_env().unwrap();
+
+        assert_eq!(config.gateway_endpoint, None);
+
+        std::env::remove_var("AA_AGENT_ID");
+        std::env::remove_var("AA_GATEWAY_ENDPOINT");
+    }
+
+    #[test]
+    fn gateway_endpoint_reads_from_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AA_AGENT_ID", "agent-gw-custom");
+        std::env::set_var("AA_GATEWAY_ENDPOINT", "http://127.0.0.1:50051");
+
+        let config = RuntimeConfig::from_env().unwrap();
+
+        assert_eq!(
+            config.gateway_endpoint,
+            Some("http://127.0.0.1:50051".to_string())
+        );
+
+        std::env::remove_var("AA_AGENT_ID");
+        std::env::remove_var("AA_GATEWAY_ENDPOINT");
     }
 }

--- a/aa-runtime/src/config.rs
+++ b/aa-runtime/src/config.rs
@@ -159,9 +159,7 @@ impl RuntimeConfig {
             Ok(v) => Some(PathBuf::from(v)),
         };
 
-        let gateway_endpoint = std::env::var("AA_GATEWAY_ENDPOINT")
-            .ok()
-            .filter(|v| !v.is_empty());
+        let gateway_endpoint = std::env::var("AA_GATEWAY_ENDPOINT").ok().filter(|v| !v.is_empty());
 
         Ok(Self {
             agent_id,
@@ -562,10 +560,7 @@ mod tests {
 
         let config = RuntimeConfig::from_env().unwrap();
 
-        assert_eq!(
-            config.gateway_endpoint,
-            Some("http://127.0.0.1:50051".to_string())
-        );
+        assert_eq!(config.gateway_endpoint, Some("http://127.0.0.1:50051".to_string()));
 
         std::env::remove_var("AA_AGENT_ID");
         std::env::remove_var("AA_GATEWAY_ENDPOINT");

--- a/aa-runtime/src/gateway_client.rs
+++ b/aa-runtime/src/gateway_client.rs
@@ -1,0 +1,34 @@
+//! Optional gRPC client for forwarding policy checks to `aa-gateway`.
+//!
+//! When the runtime is configured with a `gateway_endpoint`, policy queries
+//! are forwarded over gRPC to the governance gateway instead of being
+//! evaluated locally. This enables the full 7-stage policy pipeline.
+
+use aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient;
+use aa_proto::assembly::policy::v1::{CheckActionRequest, CheckActionResponse};
+use tonic::transport::Channel;
+
+/// gRPC client wrapper for the governance gateway's `PolicyService`.
+pub struct GatewayClient {
+    client: PolicyServiceClient<Channel>,
+}
+
+impl GatewayClient {
+    /// Connect to the gateway at the given endpoint.
+    ///
+    /// `endpoint` should be a URI like `"http://127.0.0.1:50051"` (TCP) or
+    /// a UDS path handled by a custom connector.
+    pub async fn connect(endpoint: &str) -> Result<Self, tonic::transport::Error> {
+        let client = PolicyServiceClient::connect(endpoint.to_string()).await?;
+        Ok(Self { client })
+    }
+
+    /// Forward a `CheckActionRequest` to the gateway and return the response.
+    pub async fn check_action(
+        &mut self,
+        req: CheckActionRequest,
+    ) -> Result<CheckActionResponse, tonic::Status> {
+        let resp = self.client.check_action(req).await?;
+        Ok(resp.into_inner())
+    }
+}

--- a/aa-runtime/src/gateway_client.rs
+++ b/aa-runtime/src/gateway_client.rs
@@ -24,10 +24,7 @@ impl GatewayClient {
     }
 
     /// Forward a `CheckActionRequest` to the gateway and return the response.
-    pub async fn check_action(
-        &mut self,
-        req: CheckActionRequest,
-    ) -> Result<CheckActionResponse, tonic::Status> {
+    pub async fn check_action(&mut self, req: CheckActionRequest) -> Result<CheckActionResponse, tonic::Status> {
         let resp = self.client.check_action(req).await?;
         Ok(resp.into_inner())
     }

--- a/aa-runtime/src/ipc/server.rs
+++ b/aa-runtime/src/ipc/server.rs
@@ -654,6 +654,7 @@ mod tests {
             Arc::new(crate::policy::PolicyRules::default()),
             pipeline_router,
             crate::approval::ApprovalQueue::new(),
+            None,
         ));
 
         // Connect a client.
@@ -743,6 +744,7 @@ mod tests {
             Arc::new(crate::policy::PolicyRules::default()),
             pipeline_router,
             crate::approval::ApprovalQueue::new(),
+            None,
         ));
 
         // Connect a client.

--- a/aa-runtime/src/lib.rs
+++ b/aa-runtime/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod approval;
 pub mod config;
 pub mod correlation;
+pub mod gateway_client;
 pub mod health;
 pub mod ipc;
 pub mod lifecycle;

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -8,6 +8,7 @@ pub use metrics::PipelineMetrics;
 
 use crate::approval::{ApprovalDecision as RuntimeApprovalDecision, ApprovalQueue, ApprovalRequest};
 use crate::config::RuntimeConfig;
+use crate::gateway_client::GatewayClient;
 use crate::ipc::{IpcFrame, IpcResponse, ResponseRouter};
 use crate::policy::PolicyRules;
 use aa_proto::assembly::audit::v1::{audit_event::Detail, AuditEvent, PolicyViolation};
@@ -17,7 +18,7 @@ use aa_proto::assembly::policy::v1::CheckActionResponse;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::{broadcast, mpsc, Mutex};
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
@@ -67,6 +68,7 @@ pub async fn run(
     policy: Arc<PolicyRules>,
     response_router: ResponseRouter,
     approval_queue: Arc<ApprovalQueue>,
+    gateway_client: Option<Arc<Mutex<GatewayClient>>>,
 ) {
     let seq = AtomicU64::new(0);
     let mut batch: Vec<EnrichedEvent> = Vec::with_capacity(config.batch_size);
@@ -112,6 +114,7 @@ pub async fn run(
                             &policy,
                             &approval_queue,
                             &response_router,
+                            &gateway_client,
                         )
                         .await;
                     }
@@ -227,7 +230,11 @@ async fn send_ipc_response(connection_id: u64, response: IpcResponse, router: &R
 
 /// Evaluate a [`IpcFrame::PolicyQuery`] against the loaded policy and respond.
 ///
-/// Decision priority (first match wins):
+/// When `gateway_client` is `Some`, the request is forwarded to the governance
+/// gateway over gRPC. If the gateway call fails, the function falls back to
+/// local [`PolicyRules`] evaluation with a warning log.
+///
+/// Local decision priority (first match wins):
 /// 1. `requires_approval_actions` → `PENDING` + submit to [`ApprovalQueue`]; spawn a task to
 ///    push an [`IpcResponse::ApprovalDecision`] back once the request is resolved.
 /// 2. `blocked_actions` → `DENY`.
@@ -238,7 +245,34 @@ async fn handle_policy_query(
     policy: &PolicyRules,
     approval_queue: &Arc<ApprovalQueue>,
     response_router: &ResponseRouter,
+    gateway_client: &Option<Arc<Mutex<GatewayClient>>>,
 ) {
+    // ── Gateway forwarding path ─────────────────────────────────────────
+    if let Some(client) = gateway_client {
+        let mut guard = client.lock().await;
+        match guard.check_action(req.clone()).await {
+            Ok(resp) => {
+                tracing::debug!(connection_id, decision = resp.decision, "gateway responded");
+                send_ipc_response(
+                    connection_id,
+                    IpcResponse::PolicyResponse(resp),
+                    response_router,
+                )
+                .await;
+                return;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    connection_id,
+                    error = %e,
+                    "gateway call failed — falling back to local policy evaluation"
+                );
+                // Fall through to local evaluation below.
+            }
+        }
+    }
+
+    // ── Local evaluation path ───────────────────────────────────────────
     let action_str = ActionType::try_from(req.action_type)
         .map(|a| a.as_str_name())
         .unwrap_or("");
@@ -456,6 +490,7 @@ mod tests {
             pipeline_broadcast_capacity: 512,
             metrics_addr: "0.0.0.0:8080".to_string(),
             policy_path: None,
+            gateway_endpoint: None,
         };
 
         let pipeline_config = PipelineConfig::from_runtime_config(&runtime_config);
@@ -538,6 +573,7 @@ mod tests {
             Arc::new(PolicyRules::default()),
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
+            None,
         ));
 
         // Send 3 events — batch threshold reached, should flush before interval
@@ -573,6 +609,7 @@ mod tests {
             Arc::new(PolicyRules::default()),
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
+            None,
         ));
 
         // Send 5 events (less than batch_size=100) — should arrive after interval flush
@@ -608,6 +645,7 @@ mod tests {
             Arc::new(PolicyRules::default()),
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
+            None,
         ));
 
         // Send a violation — should arrive immediately, bypassing batch
@@ -640,6 +678,7 @@ mod tests {
             Arc::new(PolicyRules::default()),
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
+            None,
         ));
 
         // Send 5 events (batch won't flush yet)
@@ -693,6 +732,7 @@ mod tests {
             Arc::new(PolicyRules::default()),
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
+            None,
         ));
 
         // Send non-event frames
@@ -736,6 +776,7 @@ mod tests {
             policy,
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
+            None,
         ));
 
         // Build an AuditEvent with action_type = FILE_OPERATION
@@ -786,6 +827,7 @@ mod tests {
             policy,
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
+            None,
         ));
 
         // Yield briefly so the pipeline's interval fires its immediate first tick
@@ -827,6 +869,7 @@ mod tests {
             Arc::new(PolicyRules::default()),
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
+            None,
         ));
 
         for _ in 0..3 {
@@ -869,6 +912,7 @@ mod tests {
             Arc::new(PolicyRules::default()),
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
+            None,
         ));
 
         // First batch of 2
@@ -933,6 +977,7 @@ mod tests {
             Arc::new(PolicyRules::default()),
             crate::ipc::new_response_router(),
             crate::approval::ApprovalQueue::new(),
+            None,
         ));
 
         // Spawn a receiver that drains the broadcast channel
@@ -1012,6 +1057,7 @@ mod tests {
             Arc::new(PolicyRules::default()),
             router,
             approval_queue,
+            None,
         ));
 
         tx.send((0, policy_query_frame(ActionType::ToolCall))).await.unwrap();
@@ -1059,6 +1105,7 @@ mod tests {
             policy,
             router,
             approval_queue,
+            None,
         ));
 
         tx.send((0, policy_query_frame(ActionType::ToolCall))).await.unwrap();
@@ -1108,6 +1155,7 @@ mod tests {
             policy,
             router,
             approval_queue,
+            None,
         ));
 
         tx.send((0, policy_query_frame(ActionType::ToolCall))).await.unwrap();
@@ -1164,6 +1212,7 @@ mod tests {
             policy,
             router,
             approval_queue,
+            None,
         ));
 
         // Send the query — get back PENDING with approval_id.

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -253,12 +253,7 @@ async fn handle_policy_query(
         match guard.check_action(req.clone()).await {
             Ok(resp) => {
                 tracing::debug!(connection_id, decision = resp.decision, "gateway responded");
-                send_ipc_response(
-                    connection_id,
-                    IpcResponse::PolicyResponse(resp),
-                    response_router,
-                )
-                .await;
+                send_ipc_response(connection_id, IpcResponse::PolicyResponse(resp), response_router).await;
                 return;
             }
             Err(e) => {

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -134,6 +134,7 @@ pub async fn run(config: RuntimeConfig) {
                 pipeline_policy,
                 pipeline_router,
                 pipeline_approval_queue,
+                None,
             )
             .await;
         });


### PR DESCRIPTION
## Summary

- Implements the gRPC **PolicyService** server layer in `aa-gateway`, wiring `CheckAction` and `BatchCheck` RPCs to the existing `PolicyEngine`
- Adds **proto ↔ core type conversions** (5 `ActionContext` variants → 4 `GovernanceAction` variants, `EvaluationResult` → `CheckActionResponse` with `Decision::Redact` support)
- Creates the **`aa-gateway` binary** with clap CLI supporting TCP (`--listen`) and Unix domain socket (`--socket`) transports
- Adds **`GatewayClient`** to `aa-runtime` for optional gRPC forwarding, with graceful fallback to local `PolicyRules` evaluation
- Wires gateway forwarding into `handle_policy_query()` via `AA_GATEWAY_ENDPOINT` env var

## Key design decisions

- **SHA-256 truncation** bridges proto string-based agent/session IDs to core `[u8; 16]` identities
- **LlmCall** (proto-only action type) maps to `GovernanceAction::ToolCall { name: "llm_call", ... }`
- **Credential findings** from `EvaluationResult` populate `Decision::Redact` with `RedactInstructions`
- **Fallback on gateway failure** — if the gateway gRPC call fails, the runtime logs a warning and evaluates locally

## Test coverage

- 12 unit tests for proto ↔ core conversions (all 5 action types + error paths + outbound mapping)
- 5 integration tests for gRPC service (allow, deny, invalid argument, latency, batch ordering)
- 3 config tests for `AA_GATEWAY_ENDPOINT` (unset, empty, custom)
- All 107 `aa-runtime` tests pass; all `aa-gateway` tests pass

## Files changed

| Area | Files | Purpose |
|------|-------|---------|
| Service layer | `service/convert.rs`, `service/policy_service.rs`, `service/mod.rs` | Proto ↔ core conversion + gRPC trait impl |
| Binary | `main.rs` | CLI + TCP/UDS server startup |
| Tests | `tests/service_convert_test.rs`, `tests/policy_service_test.rs` | Unit + integration tests |
| Runtime | `gateway_client.rs`, `config.rs`, `pipeline/mod.rs` | Client, config field, forwarding logic |

Closes AAASM-135

## Test plan

- [x] `cargo test --workspace` — all tests pass
- [x] `cargo clippy -p aa-gateway -p aa-runtime -p aa-proto -- -D warnings` — clean
- [ ] Reviewer: verify proto ↔ core mapping covers all `ActionContext` variants
- [ ] Reviewer: verify fallback behavior when gateway is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)