### PR TITLE
[AAASM-40] ✨ (correlation): Implement causal correlation engine algorithm

### DIFF
--- a/aa-runtime/src/correlation/engine.rs
+++ b/aa-runtime/src/correlation/engine.rs
@@ -4,9 +4,13 @@
 //! subsystem. It is intentionally synchronous — the caller (the Tokio event
 //! loop in aa-runtime) handles channel I/O; the engine handles pure logic.
 
+use std::collections::HashSet;
+
+use uuid::Uuid;
+
 use super::config::CorrelationConfig;
 use super::event::CorrelationEvent;
-use super::outcome::CorrelationOutcome;
+use super::outcome::{CausalCorrelation, CorrelationOutcome};
 use super::pid::PidLineage;
 use super::window::SlidingWindow;
 
@@ -66,10 +70,92 @@ impl CorrelationEngine {
 
     /// Run the correlation algorithm over the current window contents.
     ///
-    /// Returns all correlation outcomes (matched, unexpected, intent-without-action)
-    /// found in the current window state.
+    /// For each action, finds the best matching intent by:
+    /// 1. Keyword match — the intent's `action_keyword` must equal the syscall's
+    ///    canonical keyword (via [`syscall_to_keyword`]).
+    /// 2. PID lineage — the intent PID and action PID must belong to the same
+    ///    causal group (via [`PidLineage::is_same_family`]).
+    /// 3. Temporal ordering — the intent must precede the action.
+    ///
+    /// Among matching intents, the closest in time is selected (smallest delta).
+    /// Correlation strength decays linearly from 1.0 at delta=0 to 0.0 at the
+    /// window boundary.
+    ///
+    /// Returns all correlation outcomes: matched pairs, unexpected actions
+    /// (no matching intent), and intents without a subsequent action.
     pub fn correlate(&self) -> Vec<CorrelationOutcome> {
-        todo!("implement PID lineage + keyword matching correlation algorithm")
+        let intents = self.window.intents();
+        let actions = self.window.actions();
+
+        let mut results = Vec::new();
+        let mut matched_intent_ids: HashSet<Uuid> = HashSet::new();
+        let mut matched_action_ids: HashSet<Uuid> = HashSet::new();
+
+        for action in &actions {
+            let action_keyword = match syscall_to_keyword(&action.syscall) {
+                Some(kw) => kw,
+                None => continue,
+            };
+
+            let mut best_intent: Option<(&super::event::IntentEvent, u64)> = None;
+
+            for intent in &intents {
+                // Keyword must match.
+                if intent.action_keyword != action_keyword {
+                    continue;
+                }
+                // Intent must precede the action.
+                if intent.timestamp_ms >= action.timestamp_ms {
+                    continue;
+                }
+                // PIDs must be in the same causal group.
+                if !self.lineage.is_same_family(intent.pid, action.pid) {
+                    continue;
+                }
+
+                let delta = action.timestamp_ms - intent.timestamp_ms;
+                match &best_intent {
+                    Some((_, best_delta)) if delta >= *best_delta => {}
+                    _ => best_intent = Some((intent, delta)),
+                }
+            }
+
+            if let Some((intent, delta)) = best_intent {
+                let strength = 1.0
+                    - (delta as f64 / self.config.window_ms as f64).min(1.0);
+                results.push(CorrelationOutcome::Matched(CausalCorrelation {
+                    intent_event_id: intent.event_id,
+                    action_event_id: action.event_id,
+                    correlation_strength: strength,
+                    time_delta_ms: delta,
+                }));
+                matched_intent_ids.insert(intent.event_id);
+                matched_action_ids.insert(action.event_id);
+            }
+        }
+
+        // Actions with no matching intent → UnexpectedAction.
+        for action in &actions {
+            if syscall_to_keyword(&action.syscall).is_none() {
+                continue;
+            }
+            if !matched_action_ids.contains(&action.event_id) {
+                results.push(CorrelationOutcome::UnexpectedAction {
+                    action_event_id: action.event_id,
+                });
+            }
+        }
+
+        // Intents with no matching action → IntentWithoutAction.
+        for intent in &intents {
+            if !matched_intent_ids.contains(&intent.event_id) {
+                results.push(CorrelationOutcome::IntentWithoutAction {
+                    intent_event_id: intent.event_id,
+                });
+            }
+        }
+
+        results
     }
 
     /// Evict events older than the configured time window.

--- a/aa-runtime/src/correlation/engine.rs
+++ b/aa-runtime/src/correlation/engine.rs
@@ -179,7 +179,7 @@ impl CorrelationEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::correlation::event::IntentEvent;
+    use crate::correlation::event::{ActionEvent, IntentEvent};
     use uuid::Uuid;
 
     #[test]
@@ -247,5 +247,142 @@ mod tests {
     #[test]
     fn syscall_to_keyword_returns_none_for_unknown() {
         assert_eq!(syscall_to_keyword("unknown_syscall"), None);
+    }
+
+    #[test]
+    fn correlate_matches_intent_to_action_same_pid() {
+        let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+        let intent_id = Uuid::new_v4();
+        let action_id = Uuid::new_v4();
+
+        engine.ingest(CorrelationEvent::Intent(IntentEvent {
+            event_id: intent_id,
+            timestamp_ms: 1000,
+            pid: 1,
+            intent_text: "delete /tmp/foo".to_string(),
+            action_keyword: "file_delete".to_string(),
+        }));
+        engine.ingest(CorrelationEvent::Action(ActionEvent {
+            event_id: action_id,
+            timestamp_ms: 1500,
+            pid: 1,
+            syscall: "unlink".to_string(),
+            details: "/tmp/foo".to_string(),
+        }));
+
+        let outcomes = engine.correlate();
+        assert_eq!(outcomes.len(), 1);
+        match &outcomes[0] {
+            CorrelationOutcome::Matched(c) => {
+                assert_eq!(c.intent_event_id, intent_id);
+                assert_eq!(c.action_event_id, action_id);
+                assert_eq!(c.time_delta_ms, 500);
+                assert!(c.correlation_strength > 0.0);
+                assert!(c.correlation_strength <= 1.0);
+            }
+            other => panic!("expected Matched, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn correlate_matches_intent_to_action_via_pid_lineage() {
+        let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+        // PID 100 is a child of PID 1.
+        engine.register_pid(100, 1);
+
+        let intent_id = Uuid::new_v4();
+        let action_id = Uuid::new_v4();
+
+        engine.ingest(CorrelationEvent::Intent(IntentEvent {
+            event_id: intent_id,
+            timestamp_ms: 1000,
+            pid: 1,
+            intent_text: "exec /bin/ls".to_string(),
+            action_keyword: "process_exec".to_string(),
+        }));
+        engine.ingest(CorrelationEvent::Action(ActionEvent {
+            event_id: action_id,
+            timestamp_ms: 1200,
+            pid: 100,
+            syscall: "execve".to_string(),
+            details: "/bin/ls".to_string(),
+        }));
+
+        let outcomes = engine.correlate();
+        assert_eq!(outcomes.len(), 1);
+        assert!(matches!(&outcomes[0], CorrelationOutcome::Matched(c) if c.intent_event_id == intent_id));
+    }
+
+    #[test]
+    fn correlate_picks_closest_intent() {
+        let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+        let far_intent_id = Uuid::new_v4();
+        let near_intent_id = Uuid::new_v4();
+        let action_id = Uuid::new_v4();
+
+        engine.ingest(CorrelationEvent::Intent(IntentEvent {
+            event_id: far_intent_id,
+            timestamp_ms: 1000,
+            pid: 1,
+            intent_text: "delete file".to_string(),
+            action_keyword: "file_delete".to_string(),
+        }));
+        engine.ingest(CorrelationEvent::Intent(IntentEvent {
+            event_id: near_intent_id,
+            timestamp_ms: 1800,
+            pid: 1,
+            intent_text: "delete file".to_string(),
+            action_keyword: "file_delete".to_string(),
+        }));
+        engine.ingest(CorrelationEvent::Action(ActionEvent {
+            event_id: action_id,
+            timestamp_ms: 2000,
+            pid: 1,
+            syscall: "unlink".to_string(),
+            details: "/tmp/foo".to_string(),
+        }));
+
+        let outcomes = engine.correlate();
+        // Should match the near intent (delta=200) not the far one (delta=1000).
+        let matched: Vec<_> = outcomes
+            .iter()
+            .filter(|o| matches!(o, CorrelationOutcome::Matched(_)))
+            .collect();
+        assert_eq!(matched.len(), 1);
+        match &matched[0] {
+            CorrelationOutcome::Matched(c) => {
+                assert_eq!(c.intent_event_id, near_intent_id);
+                assert_eq!(c.time_delta_ms, 200);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn correlate_strength_decays_with_time_delta() {
+        let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+
+        engine.ingest(CorrelationEvent::Intent(IntentEvent {
+            event_id: Uuid::new_v4(),
+            timestamp_ms: 1000,
+            pid: 1,
+            intent_text: "delete".to_string(),
+            action_keyword: "file_delete".to_string(),
+        }));
+        engine.ingest(CorrelationEvent::Action(ActionEvent {
+            event_id: Uuid::new_v4(),
+            timestamp_ms: 3500, // delta = 2500, window = 5000 → strength = 0.5
+            pid: 1,
+            syscall: "unlink".to_string(),
+            details: "/tmp/foo".to_string(),
+        }));
+
+        let outcomes = engine.correlate();
+        match &outcomes[0] {
+            CorrelationOutcome::Matched(c) => {
+                assert!((c.correlation_strength - 0.5).abs() < 0.01);
+            }
+            other => panic!("expected Matched, got {:?}", other),
+        }
     }
 }

--- a/aa-runtime/src/correlation/engine.rs
+++ b/aa-runtime/src/correlation/engine.rs
@@ -538,4 +538,46 @@ mod tests {
         let engine = CorrelationEngine::new(CorrelationConfig::default());
         assert!(engine.correlate().is_empty());
     }
+
+    #[test]
+    fn eviction_removes_intent_preventing_match() {
+        let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+
+        // Intent at t=1000.
+        engine.ingest(CorrelationEvent::Intent(IntentEvent {
+            event_id: Uuid::new_v4(),
+            timestamp_ms: 1000,
+            pid: 1,
+            intent_text: "delete file".to_string(),
+            action_keyword: "file_delete".to_string(),
+        }));
+
+        // Action at t=7000 (within window of 5000 from now=7000, but intent at
+        // t=1000 is outside the window).
+        let action_id = Uuid::new_v4();
+        engine.ingest(CorrelationEvent::Action(ActionEvent {
+            event_id: action_id,
+            timestamp_ms: 7000,
+            pid: 1,
+            syscall: "unlink".to_string(),
+            details: "/tmp/foo".to_string(),
+        }));
+
+        // Evict with now=7000 → cutoff=2000 → intent at 1000 is evicted.
+        engine.evict(7000);
+
+        let outcomes = engine.correlate();
+        // Intent was evicted, so action is unexpected.
+        let unexpected: Vec<_> = outcomes
+            .iter()
+            .filter(|o| matches!(o, CorrelationOutcome::UnexpectedAction { .. }))
+            .collect();
+        assert_eq!(unexpected.len(), 1);
+        // No matched outcomes.
+        let matched: Vec<_> = outcomes
+            .iter()
+            .filter(|o| matches!(o, CorrelationOutcome::Matched(_)))
+            .collect();
+        assert!(matched.is_empty());
+    }
 }

--- a/aa-runtime/src/correlation/engine.rs
+++ b/aa-runtime/src/correlation/engine.rs
@@ -121,8 +121,7 @@ impl CorrelationEngine {
             }
 
             if let Some((intent, delta)) = best_intent {
-                let strength = 1.0
-                    - (delta as f64 / self.config.window_ms as f64).min(1.0);
+                let strength = 1.0 - (delta as f64 / self.config.window_ms as f64).min(1.0);
                 results.push(CorrelationOutcome::Matched(CausalCorrelation {
                     intent_event_id: intent.event_id,
                     action_event_id: action.event_id,

--- a/aa-runtime/src/correlation/engine.rs
+++ b/aa-runtime/src/correlation/engine.rs
@@ -473,4 +473,69 @@ mod tests {
             .collect();
         assert_eq!(unexpected.len(), 1);
     }
+
+    #[test]
+    fn correlate_intent_without_action_when_no_action() {
+        let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+        let intent_id = Uuid::new_v4();
+
+        // Intent with no subsequent action.
+        engine.ingest(CorrelationEvent::Intent(IntentEvent {
+            event_id: intent_id,
+            timestamp_ms: 1000,
+            pid: 1,
+            intent_text: "delete file".to_string(),
+            action_keyword: "file_delete".to_string(),
+        }));
+
+        let outcomes = engine.correlate();
+        assert_eq!(outcomes.len(), 1);
+        match &outcomes[0] {
+            CorrelationOutcome::IntentWithoutAction { intent_event_id } => {
+                assert_eq!(*intent_event_id, intent_id);
+            }
+            other => panic!("expected IntentWithoutAction, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn correlate_intent_without_action_when_action_precedes_intent() {
+        let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+        let intent_id = Uuid::new_v4();
+
+        // Action at t=1000, intent at t=2000 — action happened before intent.
+        engine.ingest(CorrelationEvent::Action(ActionEvent {
+            event_id: Uuid::new_v4(),
+            timestamp_ms: 1000,
+            pid: 1,
+            syscall: "unlink".to_string(),
+            details: "/tmp/foo".to_string(),
+        }));
+        engine.ingest(CorrelationEvent::Intent(IntentEvent {
+            event_id: intent_id,
+            timestamp_ms: 2000,
+            pid: 1,
+            intent_text: "delete file".to_string(),
+            action_keyword: "file_delete".to_string(),
+        }));
+
+        let outcomes = engine.correlate();
+        let intent_without: Vec<_> = outcomes
+            .iter()
+            .filter(|o| matches!(o, CorrelationOutcome::IntentWithoutAction { .. }))
+            .collect();
+        assert_eq!(intent_without.len(), 1);
+        match &intent_without[0] {
+            CorrelationOutcome::IntentWithoutAction { intent_event_id } => {
+                assert_eq!(*intent_event_id, intent_id);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn correlate_empty_window_returns_empty() {
+        let engine = CorrelationEngine::new(CorrelationConfig::default());
+        assert!(engine.correlate().is_empty());
+    }
 }

--- a/aa-runtime/src/correlation/engine.rs
+++ b/aa-runtime/src/correlation/engine.rs
@@ -385,4 +385,92 @@ mod tests {
             other => panic!("expected Matched, got {:?}", other),
         }
     }
+
+    #[test]
+    fn correlate_unexpected_action_when_no_intent() {
+        let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+        let action_id = Uuid::new_v4();
+
+        // Action with no preceding intent.
+        engine.ingest(CorrelationEvent::Action(ActionEvent {
+            event_id: action_id,
+            timestamp_ms: 1000,
+            pid: 1,
+            syscall: "unlink".to_string(),
+            details: "/tmp/foo".to_string(),
+        }));
+
+        let outcomes = engine.correlate();
+        assert_eq!(outcomes.len(), 1);
+        match &outcomes[0] {
+            CorrelationOutcome::UnexpectedAction { action_event_id } => {
+                assert_eq!(*action_event_id, action_id);
+            }
+            other => panic!("expected UnexpectedAction, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn correlate_unexpected_action_when_keyword_mismatch() {
+        let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+        let action_id = Uuid::new_v4();
+
+        // Intent for file_delete, but action is process_exec.
+        engine.ingest(CorrelationEvent::Intent(IntentEvent {
+            event_id: Uuid::new_v4(),
+            timestamp_ms: 1000,
+            pid: 1,
+            intent_text: "delete file".to_string(),
+            action_keyword: "file_delete".to_string(),
+        }));
+        engine.ingest(CorrelationEvent::Action(ActionEvent {
+            event_id: action_id,
+            timestamp_ms: 1500,
+            pid: 1,
+            syscall: "execve".to_string(),
+            details: "/bin/sh".to_string(),
+        }));
+
+        let outcomes = engine.correlate();
+        let unexpected: Vec<_> = outcomes
+            .iter()
+            .filter(|o| matches!(o, CorrelationOutcome::UnexpectedAction { .. }))
+            .collect();
+        assert_eq!(unexpected.len(), 1);
+        match &unexpected[0] {
+            CorrelationOutcome::UnexpectedAction { action_event_id } => {
+                assert_eq!(*action_event_id, action_id);
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn correlate_unexpected_action_when_different_pid_family() {
+        let mut engine = CorrelationEngine::new(CorrelationConfig::default());
+        let action_id = Uuid::new_v4();
+
+        // Intent from PID 1, action from PID 2 (unrelated).
+        engine.ingest(CorrelationEvent::Intent(IntentEvent {
+            event_id: Uuid::new_v4(),
+            timestamp_ms: 1000,
+            pid: 1,
+            intent_text: "delete file".to_string(),
+            action_keyword: "file_delete".to_string(),
+        }));
+        engine.ingest(CorrelationEvent::Action(ActionEvent {
+            event_id: action_id,
+            timestamp_ms: 1500,
+            pid: 2,
+            syscall: "unlink".to_string(),
+            details: "/tmp/foo".to_string(),
+        }));
+
+        let outcomes = engine.correlate();
+        let unexpected: Vec<_> = outcomes
+            .iter()
+            .filter(|o| matches!(o, CorrelationOutcome::UnexpectedAction { .. }))
+            .collect();
+        assert_eq!(unexpected.len(), 1);
+    }
 }

--- a/aa-runtime/src/correlation/engine.rs
+++ b/aa-runtime/src/correlation/engine.rs
@@ -10,6 +10,28 @@ use super::outcome::CorrelationOutcome;
 use super::pid::PidLineage;
 use super::window::SlidingWindow;
 
+/// Maps a syscall name to an action keyword category.
+///
+/// Returns the canonical action keyword that corresponds to the given syscall,
+/// allowing the correlation algorithm to match an intent's `action_keyword`
+/// against an observed syscall. Returns `None` for unknown syscalls.
+fn syscall_to_keyword(syscall: &str) -> Option<&'static str> {
+    match syscall {
+        "unlink" | "unlinkat" | "rmdir" => Some("file_delete"),
+        "openat" | "open" | "creat" => Some("file_write"),
+        "read" | "readv" | "pread64" => Some("file_read"),
+        "rename" | "renameat" | "renameat2" => Some("file_rename"),
+        "connect" => Some("network_connect"),
+        "sendto" | "sendmsg" | "write" => Some("network_send"),
+        "execve" | "execveat" => Some("process_exec"),
+        "fork" | "clone" | "clone3" => Some("process_spawn"),
+        "kill" | "tkill" | "tgkill" => Some("process_signal"),
+        "chmod" | "fchmod" | "fchmodat" => Some("file_permission"),
+        "chown" | "fchown" | "fchownat" | "lchown" => Some("file_owner"),
+        _ => None,
+    }
+}
+
 /// The causal correlation engine.
 ///
 /// Ingests intent events (from LLM responses) and action events (from eBPF
@@ -107,5 +129,37 @@ mod tests {
     fn evict_on_empty_engine_does_not_panic() {
         let mut engine = CorrelationEngine::new(CorrelationConfig::default());
         engine.evict(10_000);
+    }
+
+    #[test]
+    fn syscall_to_keyword_maps_file_delete() {
+        assert_eq!(syscall_to_keyword("unlink"), Some("file_delete"));
+        assert_eq!(syscall_to_keyword("unlinkat"), Some("file_delete"));
+        assert_eq!(syscall_to_keyword("rmdir"), Some("file_delete"));
+    }
+
+    #[test]
+    fn syscall_to_keyword_maps_file_write() {
+        assert_eq!(syscall_to_keyword("openat"), Some("file_write"));
+        assert_eq!(syscall_to_keyword("open"), Some("file_write"));
+        assert_eq!(syscall_to_keyword("creat"), Some("file_write"));
+    }
+
+    #[test]
+    fn syscall_to_keyword_maps_network() {
+        assert_eq!(syscall_to_keyword("connect"), Some("network_connect"));
+        assert_eq!(syscall_to_keyword("sendto"), Some("network_send"));
+    }
+
+    #[test]
+    fn syscall_to_keyword_maps_process() {
+        assert_eq!(syscall_to_keyword("execve"), Some("process_exec"));
+        assert_eq!(syscall_to_keyword("fork"), Some("process_spawn"));
+        assert_eq!(syscall_to_keyword("kill"), Some("process_signal"));
+    }
+
+    #[test]
+    fn syscall_to_keyword_returns_none_for_unknown() {
+        assert_eq!(syscall_to_keyword("unknown_syscall"), None);
     }
 }

--- a/aa-runtime/src/correlation/pid.rs
+++ b/aa-runtime/src/correlation/pid.rs
@@ -4,7 +4,7 @@
 //! can determine whether two processes belong to the same causal group
 //! (i.e., the SDK process and all of its descendants).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Tracks PID-to-parent relationships for causal group membership.
 ///
@@ -31,8 +31,49 @@ impl PidLineage {
 
     /// Returns `true` if `pid_a` and `pid_b` belong to the same causal group
     /// (i.e., one is an ancestor of the other, or they share a common ancestor).
-    pub fn is_same_family(&self, _pid_a: u32, _pid_b: u32) -> bool {
-        todo!("implement ancestor walk using parent_map")
+    ///
+    /// Walks the ancestor chain of `pid_a` up to `max_depth` steps, collecting
+    /// all ancestors into a set, then walks `pid_b`'s chain checking for overlap.
+    /// A cycle guard (`max_depth`) prevents infinite loops in malformed data.
+    pub fn is_same_family(&self, pid_a: u32, pid_b: u32) -> bool {
+        if pid_a == pid_b {
+            return true;
+        }
+
+        const MAX_DEPTH: usize = 64;
+
+        // Collect all ancestors of pid_a (including pid_a itself).
+        let mut ancestors_a = HashSet::new();
+        ancestors_a.insert(pid_a);
+        let mut current = pid_a;
+        for _ in 0..MAX_DEPTH {
+            match self.parent_map.get(&current) {
+                Some(&parent) if !ancestors_a.contains(&parent) => {
+                    ancestors_a.insert(parent);
+                    current = parent;
+                }
+                _ => break,
+            }
+        }
+
+        // Walk pid_b's ancestor chain, checking for overlap with ancestors_a.
+        if ancestors_a.contains(&pid_b) {
+            return true;
+        }
+        current = pid_b;
+        for _ in 0..MAX_DEPTH {
+            match self.parent_map.get(&current) {
+                Some(&parent) => {
+                    if ancestors_a.contains(&parent) {
+                        return true;
+                    }
+                    current = parent;
+                }
+                None => break,
+            }
+        }
+
+        false
     }
 
     /// Remove a PID from the lineage tracker (e.g., after process exit).

--- a/aa-runtime/src/correlation/pid.rs
+++ b/aa-runtime/src/correlation/pid.rs
@@ -106,4 +106,54 @@ mod tests {
         lineage.remove(100);
         assert!(!lineage.parent_map.contains_key(&100));
     }
+
+    #[test]
+    fn same_pid_is_same_family() {
+        let lineage = PidLineage::new();
+        assert!(lineage.is_same_family(42, 42));
+    }
+
+    #[test]
+    fn parent_child_is_same_family() {
+        let mut lineage = PidLineage::new();
+        // 100 is child of 1
+        lineage.register(100, 1);
+        assert!(lineage.is_same_family(1, 100));
+        assert!(lineage.is_same_family(100, 1));
+    }
+
+    #[test]
+    fn grandparent_grandchild_is_same_family() {
+        let mut lineage = PidLineage::new();
+        // 1 → 100 → 200
+        lineage.register(100, 1);
+        lineage.register(200, 100);
+        assert!(lineage.is_same_family(1, 200));
+        assert!(lineage.is_same_family(200, 1));
+    }
+
+    #[test]
+    fn shared_ancestor_is_same_family() {
+        let mut lineage = PidLineage::new();
+        // 1 → 100, 1 → 200 (siblings)
+        lineage.register(100, 1);
+        lineage.register(200, 1);
+        assert!(lineage.is_same_family(100, 200));
+        assert!(lineage.is_same_family(200, 100));
+    }
+
+    #[test]
+    fn unrelated_pids_are_not_same_family() {
+        let mut lineage = PidLineage::new();
+        // Two separate trees: 1→100 and 2→200
+        lineage.register(100, 1);
+        lineage.register(200, 2);
+        assert!(!lineage.is_same_family(100, 200));
+    }
+
+    #[test]
+    fn unknown_pids_are_not_same_family() {
+        let lineage = PidLineage::new();
+        assert!(!lineage.is_same_family(1, 2));
+    }
 }

--- a/aa-runtime/src/correlation/window.rs
+++ b/aa-runtime/src/correlation/window.rs
@@ -6,7 +6,7 @@
 
 use std::collections::BTreeMap;
 
-use super::event::CorrelationEvent;
+use super::event::{ActionEvent, CorrelationEvent, IntentEvent};
 
 /// A time-ordered sliding window of correlation events.
 ///
@@ -60,6 +60,30 @@ impl SlidingWindow {
     /// Returns the configured maximum capacity.
     pub fn max_size(&self) -> usize {
         self.max_size
+    }
+
+    /// Returns all intent events in the window, ordered by timestamp.
+    pub fn intents(&self) -> Vec<&IntentEvent> {
+        self.events
+            .values()
+            .flat_map(|bucket| bucket.iter())
+            .filter_map(|e| match e {
+                CorrelationEvent::Intent(intent) => Some(intent),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// Returns all action events in the window, ordered by timestamp.
+    pub fn actions(&self) -> Vec<&ActionEvent> {
+        self.events
+            .values()
+            .flat_map(|bucket| bucket.iter())
+            .filter_map(|e| match e {
+                CorrelationEvent::Action(action) => Some(action),
+                _ => None,
+            })
+            .collect()
     }
 }
 
@@ -129,5 +153,43 @@ mod tests {
     fn max_size_returns_configured_value() {
         let w = SlidingWindow::new(5000, 42);
         assert_eq!(w.max_size(), 42);
+    }
+
+    #[test]
+    fn intents_returns_only_intent_events() {
+        let mut w = SlidingWindow::new(5000, 100);
+        w.insert(make_intent_event(1000));
+        w.insert(make_action_event(2000));
+        w.insert(make_intent_event(3000));
+        let intents = w.intents();
+        assert_eq!(intents.len(), 2);
+        assert_eq!(intents[0].timestamp_ms, 1000);
+        assert_eq!(intents[1].timestamp_ms, 3000);
+    }
+
+    #[test]
+    fn actions_returns_only_action_events() {
+        let mut w = SlidingWindow::new(5000, 100);
+        w.insert(make_intent_event(1000));
+        w.insert(make_action_event(2000));
+        w.insert(make_action_event(3000));
+        let actions = w.actions();
+        assert_eq!(actions.len(), 2);
+        assert_eq!(actions[0].timestamp_ms, 2000);
+        assert_eq!(actions[1].timestamp_ms, 3000);
+    }
+
+    #[test]
+    fn intents_empty_when_only_actions() {
+        let mut w = SlidingWindow::new(5000, 100);
+        w.insert(make_action_event(1000));
+        assert!(w.intents().is_empty());
+    }
+
+    #[test]
+    fn actions_empty_when_only_intents() {
+        let mut w = SlidingWindow::new(5000, 100);
+        w.insert(make_intent_event(1000));
+        assert!(w.actions().is_empty());
     }
 }


### PR DESCRIPTION
## Description

Implements the core causal correlation algorithm for the Intent-Action Correlation engine in `aa-runtime`. This builds on the scaffold from PR #77, adding the actual matching logic that correlates LLM response intents to kernel-level actions using PID lineage, keyword mapping, and temporal ordering.

### Key changes:
- **PidLineage::is_same_family** — ancestor walk algorithm to determine if two PIDs share a causal group (up to 64 depth, cycle-safe)
- **SlidingWindow::intents()/actions()** — filtered accessors for the correlation algorithm to iterate intent and action events separately
- **syscall_to_keyword()** — maps syscall names (unlink, execve, connect, etc.) to canonical action keywords (file_delete, process_exec, network_connect)
- **CorrelationEngine::correlate()** — the core algorithm that matches intents to actions by keyword + PID lineage + temporal ordering, selecting the closest-in-time intent with linear strength decay

### Correlation outcomes:
- `Matched` — intent successfully correlated to a kernel action
- `UnexpectedAction` — kernel action observed with no preceding LLM intent (potential unauthorized escalation)
- `IntentWithoutAction` — LLM intent with no corresponding kernel action (potential bypass)

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-40
- Related GitHub PR: #77 (scaffold, merged)

## Testing

- [x] Unit tests added / updated

### Test coverage (38 new correlation tests total across all modules):
- PidLineage: 9 tests (same-pid, parent-child, grandparent, siblings, unrelated, unknown)
- SlidingWindow: 9 tests (insert, evict, intents/actions accessors)
- CorrelationEngine: 20 tests (keyword mapping, matched outcomes, unexpected actions, intent-without-action, strength decay, closest-intent selection, eviction behavior)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] All CI checks passing (152 tests pass, clippy clean with `--all-features -D warnings`)
- [x] Commits are small and follow the Gitmoji convention (9 implementation commits)