### PR TITLE
[AAASM-125] ✅ bench(aa-gateway): Benchmark CheckAction RPC p99 latency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,21 @@ jobs:
             "CARGO_HOME=${RUNNER_CARGO}" \
             cargo +nightly test -p aa-ebpf --features integration-test --test load_hello -- --nocapture
 
+  benchmark:
+    name: Benchmark
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install protobuf compiler
+        run: sudo apt-get install -y protobuf-compiler
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Run criterion benchmarks
+        run: cargo bench -p aa-gateway --bench policy_check
+      - name: Run latency SLA test (5s burst)
+        run: cargo test -p aa-gateway --test policy_latency_test -- --nocapture
+
   conformance:
     name: Rust conformance suite
     runs-on: ubuntu-latest

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -34,11 +34,17 @@ uuid         = { version = "1", features = ["v4"] }
 clap         = { version = "4", features = ["derive"] }
 
 [dev-dependencies]
+criterion    = { version = "0.5", features = ["async_tokio"] }
 tempfile     = "3"
+tokio-stream = "0.1"
 
 [[bin]]
 name = "aa-gateway"
 path = "src/main.rs"
+
+[[bench]]
+name    = "policy_check"
+harness = false
 
 [lints]
 workspace = true

--- a/aa-gateway/benches/policy_check.rs
+++ b/aa-gateway/benches/policy_check.rs
@@ -1,13 +1,178 @@
 //! Criterion benchmarks for PolicyService CheckAction RPC latency.
 //!
 //! Measures end-to-end gRPC round-trip (serialize → transport → evaluate → respond)
-//! across three representative payload variants.
+//! across three representative payload variants:
+//! - Minimal: LlmCallContext with no PII
+//! - Full: ToolCallContext with ~1KB args_json
+//! - Worst-case: NetworkCallContext with long target_url
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use std::io::Write;
+use std::net::SocketAddr;
+use std::sync::Arc;
 
-fn bench_placeholder(_c: &mut Criterion) {
-    // Will be replaced in the next commit with real benchmarks.
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use tokio::runtime::Runtime;
+
+use aa_gateway::service::PolicyServiceImpl;
+use aa_gateway::PolicyEngine;
+use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId};
+use aa_proto::assembly::policy::v1::action_context::Action;
+use aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient;
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
+use aa_proto::assembly::policy::v1::{
+    ActionContext, CheckActionRequest, LlmCallContext, NetworkCallContext, ToolCallContext,
+};
+
+const POLICY_YAML: &str = r#"
+version: "1"
+tools:
+  web_search:
+    allow: true
+  llm_call:
+    allow: true
+"#;
+
+fn agent_id() -> ProtoAgentId {
+    ProtoAgentId {
+        org_id: "bench-org".into(),
+        team_id: "bench-team".into(),
+        agent_id: "bench-agent".into(),
+    }
 }
 
-criterion_group!(benches, bench_placeholder);
+fn minimal_llm_call() -> CheckActionRequest {
+    CheckActionRequest {
+        agent_id: Some(agent_id()),
+        credential_token: "bench-token".into(),
+        trace_id: "trace-bench".into(),
+        span_id: "span-bench".into(),
+        action_type: ActionType::LlmCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::LlmCall(LlmCallContext {
+                model: "gpt-4o".into(),
+                prompt_tokens: 100,
+                contains_pii: false,
+            })),
+        }),
+    }
+}
+
+fn full_tool_call() -> CheckActionRequest {
+    // ~1KB args_json payload
+    let args = serde_json::json!({
+        "query": "a]".repeat(200),
+        "max_results": 10,
+        "filters": {
+            "date_range": "last_7_days",
+            "language": "en",
+            "region": "us-east-1",
+        },
+        "metadata": {
+            "session": "bench-session-id-12345",
+            "correlation": "corr-67890",
+        }
+    });
+    CheckActionRequest {
+        agent_id: Some(agent_id()),
+        credential_token: "bench-token".into(),
+        trace_id: "trace-bench".into(),
+        span_id: "span-bench".into(),
+        action_type: ActionType::ToolCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::ToolCall(ToolCallContext {
+                tool_name: "web_search".into(),
+                tool_source: "mcp".into(),
+                args_json: args.to_string().into_bytes(),
+                target_url: String::new(),
+            })),
+        }),
+    }
+}
+
+fn worst_case_network() -> CheckActionRequest {
+    // Long URL with many path segments and query parameters
+    let long_url = format!(
+        "https://api.example.com/v1/organizations/{}/projects/{}/resources/{}?token={}&session={}&trace={}",
+        "org-".to_owned() + &"x".repeat(50),
+        "proj-".to_owned() + &"y".repeat(50),
+        "res-".to_owned() + &"z".repeat(50),
+        "t".repeat(64),
+        "s".repeat(64),
+        "r".repeat(64),
+    );
+    CheckActionRequest {
+        agent_id: Some(agent_id()),
+        credential_token: "bench-token".into(),
+        trace_id: "trace-bench".into(),
+        span_id: "span-bench".into(),
+        action_type: ActionType::NetworkCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::NetworkCall(NetworkCallContext {
+                host: long_url,
+                port: 443,
+                protocol: "https".into(),
+                in_allowlist: false,
+            })),
+        }),
+    }
+}
+
+async fn start_server() -> SocketAddr {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", POLICY_YAML).unwrap();
+    tmp.flush().unwrap();
+
+    let engine = PolicyEngine::load_from_file(tmp.path()).unwrap();
+    let service = PolicyServiceImpl::new(Arc::new(engine));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let _tmp = tmp;
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        tonic::transport::Server::builder()
+            .add_service(PolicyServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    addr
+}
+
+fn bench_check_action(c: &mut Criterion) {
+    let rt = Runtime::new().unwrap();
+    let addr = rt.block_on(start_server());
+    let endpoint = format!("http://{addr}");
+
+    let cases: Vec<(&str, CheckActionRequest)> = vec![
+        ("minimal_llm_call", minimal_llm_call()),
+        ("full_tool_call_1kb", full_tool_call()),
+        ("worst_case_network", worst_case_network()),
+    ];
+
+    let mut reuse_group = c.benchmark_group("check_action_rpc");
+    let client = std::sync::Arc::new(tokio::sync::Mutex::new(
+        rt.block_on(PolicyServiceClient::connect(endpoint.clone())).unwrap(),
+    ));
+
+    for (name, req) in &cases {
+        reuse_group.bench_with_input(BenchmarkId::new("round_trip", name), req, |b, req| {
+            b.to_async(&rt).iter(|| {
+                let r = req.clone();
+                let c = client.clone();
+                async move {
+                    let resp = c.lock().await.check_action(r).await.unwrap();
+                    criterion::black_box(resp);
+                }
+            });
+        });
+    }
+
+    reuse_group.finish();
+}
+
+criterion_group!(benches, bench_check_action);
 criterion_main!(benches);

--- a/aa-gateway/benches/policy_check.rs
+++ b/aa-gateway/benches/policy_check.rs
@@ -1,0 +1,13 @@
+//! Criterion benchmarks for PolicyService CheckAction RPC latency.
+//!
+//! Measures end-to-end gRPC round-trip (serialize → transport → evaluate → respond)
+//! across three representative payload variants.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn bench_placeholder(_c: &mut Criterion) {
+    // Will be replaced in the next commit with real benchmarks.
+}
+
+criterion_group!(benches, bench_placeholder);
+criterion_main!(benches);

--- a/aa-gateway/tests/policy_latency_test.rs
+++ b/aa-gateway/tests/policy_latency_test.rs
@@ -1,0 +1,166 @@
+//! Sustained load test for PolicyService CheckAction RPC.
+//!
+//! Sends requests at 1,000 req/sec for a configurable duration (default 5s for
+//! CI, set `AA_BENCH_DURATION_SECS=60` for full local/nightly validation) and
+//! asserts that p99 latency stays below the 5ms SLA.
+
+use std::io::Write;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use aa_gateway::service::PolicyServiceImpl;
+use aa_gateway::PolicyEngine;
+use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId};
+use aa_proto::assembly::policy::v1::action_context::Action;
+use aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient;
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
+use aa_proto::assembly::policy::v1::{ActionContext, CheckActionRequest, ToolCallContext};
+use tokio::net::TcpListener;
+use tonic::transport::Server;
+
+const POLICY_YAML: &str = r#"
+version: "1"
+tools:
+  web_search:
+    allow: true
+"#;
+
+const TARGET_RPS: u64 = 1_000;
+const SLA_P99: Duration = Duration::from_millis(5);
+
+async fn start_server() -> SocketAddr {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", POLICY_YAML).unwrap();
+    tmp.flush().unwrap();
+
+    let engine = PolicyEngine::load_from_file(tmp.path()).unwrap();
+    let service = PolicyServiceImpl::new(Arc::new(engine));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let _tmp = tmp;
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(PolicyServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    addr
+}
+
+fn make_request() -> CheckActionRequest {
+    CheckActionRequest {
+        agent_id: Some(ProtoAgentId {
+            org_id: "load-org".into(),
+            team_id: "load-team".into(),
+            agent_id: "load-agent".into(),
+        }),
+        credential_token: "tok".into(),
+        trace_id: "trace-load".into(),
+        span_id: "span-load".into(),
+        action_type: ActionType::ToolCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::ToolCall(ToolCallContext {
+                tool_name: "web_search".into(),
+                tool_source: "mcp".into(),
+                args_json: b"{\"query\":\"benchmark test\"}".to_vec(),
+                target_url: String::new(),
+            })),
+        }),
+    }
+}
+
+fn percentile(sorted: &[Duration], pct: f64) -> Duration {
+    let idx = ((sorted.len() as f64) * pct / 100.0).ceil() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+#[tokio::test]
+async fn sustained_load_p99_under_5ms() {
+    let duration_secs: u64 = std::env::var("AA_BENCH_DURATION_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(5);
+
+    let addr = start_server().await;
+    let endpoint = format!("http://{addr}");
+
+    // Pre-create a pool of clients to avoid connection setup in the hot loop.
+    let concurrency = 10_u64;
+    let mut clients = Vec::with_capacity(concurrency as usize);
+    for _ in 0..concurrency {
+        clients.push(PolicyServiceClient::connect(endpoint.clone()).await.unwrap());
+    }
+    let clients: Vec<_> = clients
+        .into_iter()
+        .map(|c| Arc::new(tokio::sync::Mutex::new(c)))
+        .collect();
+
+    let total_requests = TARGET_RPS * duration_secs;
+    let interval = Duration::from_micros(1_000_000 / TARGET_RPS);
+    let latencies = Arc::new(tokio::sync::Mutex::new(Vec::with_capacity(total_requests as usize)));
+
+    let start = Instant::now();
+
+    let mut handles = Vec::with_capacity(total_requests as usize);
+    for i in 0..total_requests {
+        let target_time = start + interval * (i as u32);
+        let now = Instant::now();
+        if target_time > now {
+            tokio::time::sleep(target_time - now).await;
+        }
+
+        let client = clients[(i as usize) % clients.len()].clone();
+        let lats = latencies.clone();
+        let req = make_request();
+
+        handles.push(tokio::spawn(async move {
+            let t0 = Instant::now();
+            let _resp = client.lock().await.check_action(req).await.unwrap();
+            let elapsed = t0.elapsed();
+            lats.lock().await.push(elapsed);
+        }));
+    }
+
+    // Wait for all in-flight requests to complete.
+    for h in handles {
+        h.await.unwrap();
+    }
+
+    let wall_time = start.elapsed();
+    let mut lats = Arc::try_unwrap(latencies).unwrap().into_inner();
+    lats.sort();
+
+    let total = lats.len();
+    let p50 = percentile(&lats, 50.0);
+    let p95 = percentile(&lats, 95.0);
+    let p99 = percentile(&lats, 99.0);
+    let p999 = percentile(&lats, 99.9);
+    let max = lats[total - 1];
+
+    eprintln!();
+    eprintln!("=== PolicyService CheckAction Load Test ===");
+    eprintln!("  Duration:    {duration_secs}s ({wall_time:.2?} wall)");
+    eprintln!("  Target RPS:  {TARGET_RPS}");
+    eprintln!("  Total reqs:  {total}");
+    eprintln!("  Actual RPS:  {:.0}", total as f64 / wall_time.as_secs_f64());
+    eprintln!("  Concurrency: {concurrency} clients");
+    eprintln!();
+    eprintln!("  p50:  {p50:>10.3?}");
+    eprintln!("  p95:  {p95:>10.3?}");
+    eprintln!("  p99:  {p99:>10.3?}");
+    eprintln!("  p999: {p999:>10.3?}");
+    eprintln!("  max:  {max:>10.3?}");
+    eprintln!();
+
+    assert!(
+        p99 < SLA_P99,
+        "p99 latency {p99:?} exceeds 5ms SLA (target: {SLA_P99:?})"
+    );
+}

--- a/docs/benchmarks/policy-check-p99.md
+++ b/docs/benchmarks/policy-check-p99.md
@@ -1,0 +1,49 @@
+# PolicyService CheckAction RPC — Latency Benchmark Results
+
+## Environment
+
+| Parameter | Value |
+|-----------|-------|
+| CPU | Apple M3 Max |
+| Memory | 128 GB |
+| OS | macOS 26.2 (Darwin) |
+| Rust | 1.95.0 (2026-04-14) |
+| Tonic | 0.13.1 |
+| Transport | TCP loopback (127.0.0.1) |
+| Profile | `--release` (optimized) |
+
+## SLA Target
+
+**p99 < 5ms** end-to-end round-trip (serialize + transport + evaluate + respond).
+
+## Criterion Micro-Benchmarks
+
+Reused TCP connection, single client, 100 samples per variant.
+
+| Payload Variant | Description | Mean | Std Dev |
+|-----------------|-------------|------|---------|
+| `minimal_llm_call` | `LlmCallContext`, no PII | 77.9 us | ~1 us |
+| `full_tool_call_1kb` | `ToolCallContext`, ~1KB `args_json` | 82.2 us | ~1 us |
+| `worst_case_network` | `NetworkCallContext`, long URL (~400 bytes) | 81.9 us | ~1 us |
+
+## Sustained Load Test (60 seconds)
+
+1,000 req/sec sustained for 60 seconds, 10 concurrent clients, `ToolCallContext` payload.
+
+| Metric | Value | vs SLA |
+|--------|-------|--------|
+| Total requests | 60,000 | |
+| Actual RPS | 999 | |
+| **p50** | 144 us | 34x headroom |
+| **p95** | 357 us | 14x headroom |
+| **p99** | **803 us** | **6.2x headroom** |
+| **p999** | 2.65 ms | 1.9x headroom |
+| **max** | 10.89 ms | |
+
+## Verdict
+
+**PASS** — p99 latency of 803 us is well under the 5ms SLA target with 6.2x headroom.
+
+The max latency (10.89 ms) exceeds 5ms but this is expected for a single outlier in
+60,000 requests on a non-isolated workstation. The p999 (2.65 ms) confirms the tail
+is well-bounded for all practical purposes.


### PR DESCRIPTION
## Summary

- Add criterion benchmark harness measuring end-to-end CheckAction gRPC round-trip across 3 payload variants (minimal LlmCall, 1KB ToolCall, worst-case NetworkCall) — all ~80µs
- Add sustained load test (1k req/sec, configurable duration via `AA_BENCH_DURATION_SECS`, default 5s for CI) with hard `assert!(p99 < 5ms)` SLA gate
- Add `Benchmark` CI job that runs both criterion benchmarks and the latency SLA test on every PR
- Record full 60-second benchmark results in `docs/benchmarks/policy-check-p99.md` — **p99 = 803µs** (6.2x headroom vs 5ms SLA)

Closes AAASM-125

## Test plan

- [x] `cargo bench -p aa-gateway --bench policy_check` runs all 3 payload variants
- [x] `cargo test -p aa-gateway --test policy_latency_test -- --nocapture` passes with p99 < 5ms (5s default)
- [x] `AA_BENCH_DURATION_SECS=60 cargo test -p aa-gateway --test policy_latency_test --release -- --nocapture` passes full 60s run
- [x] Full workspace test suite passes (`cargo test --workspace --exclude aa-ebpf`)
- [x] Clippy and fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)