### PR TITLE
[AAASM-138] 🐛 audit: Wire AuditService gRPC and audit trail into gateway

### DIFF
--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "Control plane — policy enforcement engine and agent registry for Agent Assembly"
 
 [dependencies]
-aa-core      = { path = "../aa-core" }
+aa-core      = { path = "../aa-core", features = ["serde"] }
 aa-proto     = { path = "../aa-proto" }
 aa-runtime   = { path = "../aa-runtime" }
 tokio        = { version = "1", features = ["full"] }

--- a/aa-gateway/benches/policy_check.rs
+++ b/aa-gateway/benches/policy_check.rs
@@ -8,6 +8,7 @@
 
 use std::io::Write;
 use std::net::SocketAddr;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
@@ -123,7 +124,9 @@ async fn start_server() -> SocketAddr {
     tmp.flush().unwrap();
 
     let engine = PolicyEngine::load_from_file(tmp.path()).unwrap();
-    let service = PolicyServiceImpl::new(Arc::new(engine));
+    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+    let service = PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/aa-gateway/benches/policy_check.rs
+++ b/aa-gateway/benches/policy_check.rs
@@ -126,7 +126,7 @@ async fn start_server() -> SocketAddr {
     let engine = PolicyEngine::load_from_file(tmp.path()).unwrap();
     let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel(4096);
     let audit_drops = Arc::new(AtomicU64::new(0));
-    let service = PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops);
+    let service = PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops, [0u8; 32]);
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/aa-gateway/src/audit.rs
+++ b/aa-gateway/src/audit.rs
@@ -25,15 +25,28 @@ pub struct AuditWriter {
 
 impl AuditWriter {
     /// Create a new writer that appends to `<audit_dir>/<agent_id>-<session_id>.jsonl`.
+    ///
+    /// Creates the `audit_dir` if it does not exist. Opens the target file in
+    /// append mode so existing entries are preserved across restarts.
     pub async fn new(
-        _audit_dir: PathBuf,
-        _agent_id: &str,
-        _session_id: &str,
+        audit_dir: PathBuf,
+        agent_id: &str,
+        session_id: &str,
         receiver: mpsc::Receiver<AuditEntry>,
     ) -> io::Result<Self> {
-        // Skeleton — will be implemented in a subsequent commit.
-        let _ = receiver;
-        todo!("AuditWriter::new")
+        tokio::fs::create_dir_all(&audit_dir).await?;
+
+        let filename = format!("{agent_id}-{session_id}.jsonl");
+        let path = audit_dir.join(filename);
+
+        let file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .await?;
+        let file = tokio::io::BufWriter::new(file);
+
+        Ok(Self { receiver, file, path })
     }
 
     /// Background consumption loop — call via `tokio::spawn(writer.run())`.

--- a/aa-gateway/src/audit.rs
+++ b/aa-gateway/src/audit.rs
@@ -60,9 +60,25 @@ impl AuditWriter {
     }
 
     /// Background consumption loop — call via `tokio::spawn(writer.run())`.
-    pub async fn run(self) {
-        let _ = self;
-        todo!("AuditWriter::run")
+    ///
+    /// Drains the channel until the sender is dropped (server shutdown).
+    /// Individual write failures are logged but do not kill the pipeline.
+    pub async fn run(mut self) {
+        tracing::info!(path = %self.path.display(), "audit writer started");
+        while let Some(entry) = self.receiver.recv().await {
+            if let Err(e) = self.append(&entry).await {
+                tracing::error!(
+                    error = %e,
+                    seq = entry.seq(),
+                    "audit write failed"
+                );
+            }
+        }
+        // Channel closed — sender dropped during shutdown. Flush remaining data.
+        if let Err(e) = self.file.flush().await {
+            tracing::error!(error = %e, "audit writer final flush failed");
+        }
+        tracing::info!(path = %self.path.display(), "audit writer stopped");
     }
 
     /// Verify the hash chain of a JSONL audit file.

--- a/aa-gateway/src/audit.rs
+++ b/aa-gateway/src/audit.rs
@@ -82,8 +82,58 @@ impl AuditWriter {
     }
 
     /// Verify the hash chain of a JSONL audit file.
-    pub async fn verify_chain(_path: &Path) -> Result<VerifyResult, AuditError> {
-        todo!("AuditWriter::verify_chain")
+    ///
+    /// Reads every entry, checks each entry's internal hash integrity via
+    /// [`AuditEntry::verify_integrity`], and verifies the `previous_hash`
+    /// linkage between consecutive entries.
+    pub async fn verify_chain(path: &Path) -> Result<VerifyResult, AuditError> {
+        let file = tokio::fs::File::open(path).await?;
+        let reader = tokio::io::BufReader::new(file);
+        let mut lines = reader.lines();
+
+        let mut entries_checked: u64 = 0;
+        let mut previous_hash: Option<[u8; 32]> = None;
+
+        while let Some(line) = lines.next_line().await? {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let entry: AuditEntry =
+                serde_json::from_str(&line).map_err(|source| AuditError::Deserialize {
+                    line: entries_checked,
+                    source,
+                })?;
+
+            // Check internal hash integrity.
+            if !entry.verify_integrity() {
+                return Ok(VerifyResult {
+                    is_valid: false,
+                    entries_checked,
+                    first_invalid: Some(entries_checked),
+                });
+            }
+
+            // Check chain linkage: entry's previous_hash must match the prior
+            // entry's entry_hash (or [0u8; 32] for the genesis entry).
+            if let Some(expected) = previous_hash {
+                if *entry.previous_hash() != expected {
+                    return Ok(VerifyResult {
+                        is_valid: false,
+                        entries_checked,
+                        first_invalid: Some(entries_checked),
+                    });
+                }
+            }
+
+            previous_hash = Some(*entry.entry_hash());
+            entries_checked += 1;
+        }
+
+        Ok(VerifyResult {
+            is_valid: true,
+            entries_checked,
+            first_invalid: None,
+        })
     }
 
     /// Read the `entry_hash` of the last entry in a JSONL file.

--- a/aa-gateway/src/audit.rs
+++ b/aa-gateway/src/audit.rs
@@ -51,8 +51,7 @@ impl AuditWriter {
 
     /// Serialize one `AuditEntry` as a JSON line and append to the file.
     async fn append(&mut self, entry: &AuditEntry) -> io::Result<()> {
-        let json = serde_json::to_string(entry)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        let json = serde_json::to_string(entry).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         self.file.write_all(json.as_bytes()).await?;
         self.file.write_all(b"\n").await?;
         self.file.flush().await?;
@@ -98,11 +97,10 @@ impl AuditWriter {
             if line.trim().is_empty() {
                 continue;
             }
-            let entry: AuditEntry =
-                serde_json::from_str(&line).map_err(|source| AuditError::Deserialize {
-                    line: entries_checked,
-                    source,
-                })?;
+            let entry: AuditEntry = serde_json::from_str(&line).map_err(|source| AuditError::Deserialize {
+                line: entries_checked,
+                source,
+            })?;
 
             // Check internal hash integrity.
             if !entry.verify_integrity() {
@@ -183,8 +181,5 @@ pub enum AuditError {
     #[error("I/O error: {0}")]
     Io(#[from] io::Error),
     #[error("JSON deserialization error at line {line}: {source}")]
-    Deserialize {
-        line: u64,
-        source: serde_json::Error,
-    },
+    Deserialize { line: u64, source: serde_json::Error },
 }

--- a/aa-gateway/src/audit.rs
+++ b/aa-gateway/src/audit.rs
@@ -8,7 +8,7 @@
 use std::io;
 use std::path::{Path, PathBuf};
 
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt};
 use tokio::sync::mpsc;
 
 use aa_core::AuditEntry;
@@ -47,6 +47,16 @@ impl AuditWriter {
         let file = tokio::io::BufWriter::new(file);
 
         Ok(Self { receiver, file, path })
+    }
+
+    /// Serialize one `AuditEntry` as a JSON line and append to the file.
+    async fn append(&mut self, entry: &AuditEntry) -> io::Result<()> {
+        let json = serde_json::to_string(entry)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        self.file.write_all(json.as_bytes()).await?;
+        self.file.write_all(b"\n").await?;
+        self.file.flush().await?;
+        Ok(())
     }
 
     /// Background consumption loop — call via `tokio::spawn(writer.run())`.

--- a/aa-gateway/src/audit.rs
+++ b/aa-gateway/src/audit.rs
@@ -1,0 +1,79 @@
+//! Persistent, append-only audit writer for governance events.
+//!
+//! [`AuditWriter`] consumes [`AuditEntry`] values from an async mpsc channel
+//! and appends each one as a single JSON line to a per-session JSONL file.
+//! The hash chain in [`AuditEntry`] provides tamper-evidence; persistence
+//! provides durability across process restarts.
+
+use std::io;
+use std::path::{Path, PathBuf};
+
+use tokio::io::AsyncWriteExt;
+use tokio::sync::mpsc;
+
+use aa_core::AuditEntry;
+
+/// Append-only JSONL audit writer backed by an mpsc channel.
+///
+/// Created once at server startup, then moved into a background `tokio::spawn`
+/// task via [`AuditWriter::run`].
+pub struct AuditWriter {
+    receiver: mpsc::Receiver<AuditEntry>,
+    file: tokio::io::BufWriter<tokio::fs::File>,
+    path: PathBuf,
+}
+
+impl AuditWriter {
+    /// Create a new writer that appends to `<audit_dir>/<agent_id>-<session_id>.jsonl`.
+    pub async fn new(
+        _audit_dir: PathBuf,
+        _agent_id: &str,
+        _session_id: &str,
+        receiver: mpsc::Receiver<AuditEntry>,
+    ) -> io::Result<Self> {
+        // Skeleton — will be implemented in a subsequent commit.
+        let _ = receiver;
+        todo!("AuditWriter::new")
+    }
+
+    /// Background consumption loop — call via `tokio::spawn(writer.run())`.
+    pub async fn run(self) {
+        let _ = self;
+        todo!("AuditWriter::run")
+    }
+
+    /// Verify the hash chain of a JSONL audit file.
+    pub async fn verify_chain(_path: &Path) -> Result<VerifyResult, AuditError> {
+        todo!("AuditWriter::verify_chain")
+    }
+
+    /// Read the `entry_hash` of the last entry in a JSONL file.
+    ///
+    /// Returns `None` if the file does not exist or is empty.
+    pub async fn read_last_hash(_path: &Path) -> io::Result<Option<[u8; 32]>> {
+        todo!("AuditWriter::read_last_hash")
+    }
+}
+
+/// Result of a hash-chain verification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifyResult {
+    /// `true` if every entry's hash matches and the chain links correctly.
+    pub is_valid: bool,
+    /// Total number of entries checked.
+    pub entries_checked: u64,
+    /// Index of the first invalid entry, if any.
+    pub first_invalid: Option<u64>,
+}
+
+/// Errors that can occur during audit operations.
+#[derive(Debug, thiserror::Error)]
+pub enum AuditError {
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+    #[error("JSON deserialization error at line {line}: {source}")]
+    Deserialize {
+        line: u64,
+        source: serde_json::Error,
+    },
+}

--- a/aa-gateway/src/audit.rs
+++ b/aa-gateway/src/audit.rs
@@ -89,8 +89,30 @@ impl AuditWriter {
     /// Read the `entry_hash` of the last entry in a JSONL file.
     ///
     /// Returns `None` if the file does not exist or is empty.
-    pub async fn read_last_hash(_path: &Path) -> io::Result<Option<[u8; 32]>> {
-        todo!("AuditWriter::read_last_hash")
+    /// Skips blank or incomplete trailing lines (standard JSONL recovery).
+    pub async fn read_last_hash(path: &Path) -> io::Result<Option<[u8; 32]>> {
+        let file = match tokio::fs::File::open(path).await {
+            Ok(f) => f,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(e),
+        };
+        let reader = tokio::io::BufReader::new(file);
+        let mut lines = reader.lines();
+        let mut last_hash: Option<[u8; 32]> = None;
+
+        while let Some(line) = lines.next_line().await? {
+            if line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<AuditEntry>(&line) {
+                Ok(entry) => last_hash = Some(*entry.entry_hash()),
+                Err(_) => {
+                    // Incomplete trailing line from a crash — skip it.
+                    continue;
+                }
+            }
+        }
+        Ok(last_hash)
     }
 }
 

--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -5,6 +5,7 @@
 //! back to proxies and SDK shims, and writes the audit trail.
 
 pub mod anomaly;
+pub mod audit;
 pub mod budget;
 pub mod engine;
 pub mod policy;

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -1,17 +1,42 @@
 //! gRPC server startup — loads policy, builds service, serves over TCP or UDS.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use tonic::transport::Server;
 
 use aa_core::AuditEntry;
+use crate::audit::AuditWriter;
 use crate::engine::PolicyEngine;
 use crate::registry::AgentRegistry;
 use crate::service::{AgentLifecycleServiceImpl, PolicyServiceImpl};
 use aa_proto::assembly::agent::v1::agent_lifecycle_service_server::AgentLifecycleServiceServer;
 use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
+
+/// Default audit directory relative to the system data directory (`~/.aa/audit`).
+fn default_audit_dir() -> PathBuf {
+    dirs::data_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("aa")
+        .join("audit")
+}
+
+/// Create the audit channel, spawn the background `AuditWriter`, and return
+/// the sender + drop counter for injection into services.
+async fn setup_audit(
+    agent_id: &str,
+    session_id: &str,
+) -> Result<(tokio::sync::mpsc::Sender<AuditEntry>, Arc<AtomicU64>), Box<dyn std::error::Error>> {
+    let audit_dir = default_audit_dir();
+    let (audit_tx, audit_rx) = tokio::sync::mpsc::channel::<AuditEntry>(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+
+    let writer = AuditWriter::new(audit_dir, agent_id, session_id, audit_rx).await?;
+    tokio::spawn(writer.run());
+
+    Ok((audit_tx, audit_drops))
+}
 
 /// Start the gRPC server on a TCP address.
 ///
@@ -24,8 +49,7 @@ pub async fn serve_tcp(
     registry: Arc<AgentRegistry>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let engine = PolicyEngine::load_from_file(policy_path).map_err(|e| format!("failed to load policy: {e:?}"))?;
-    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel::<AuditEntry>(4096);
-    let audit_drops = Arc::new(AtomicU64::new(0));
+    let (audit_tx, audit_drops) = setup_audit("gateway", "default").await?;
     let policy_svc = PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops);
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);
 
@@ -52,8 +76,7 @@ pub async fn serve_uds(
     registry: Arc<AgentRegistry>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let engine = PolicyEngine::load_from_file(policy_path).map_err(|e| format!("failed to load policy: {e:?}"))?;
-    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel::<AuditEntry>(4096);
-    let audit_drops = Arc::new(AtomicU64::new(0));
+    let (audit_tx, audit_drops) = setup_audit("gateway", "default").await?;
     let policy_svc = PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops);
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);
 

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -6,11 +6,11 @@ use std::sync::Arc;
 
 use tonic::transport::Server;
 
-use aa_core::AuditEntry;
 use crate::audit::AuditWriter;
 use crate::engine::PolicyEngine;
 use crate::registry::AgentRegistry;
 use crate::service::{AgentLifecycleServiceImpl, AuditServiceImpl, PolicyServiceImpl};
+use aa_core::AuditEntry;
 use aa_proto::assembly::agent::v1::agent_lifecycle_service_server::AgentLifecycleServiceServer;
 use aa_proto::assembly::audit::v1::audit_service_server::AuditServiceServer;
 use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -23,20 +23,31 @@ fn default_audit_dir() -> PathBuf {
         .join("audit")
 }
 
+/// Resolve the JSONL path for the given agent/session pair.
+fn audit_file_path(audit_dir: &Path, agent_id: &str, session_id: &str) -> PathBuf {
+    audit_dir.join(format!("{agent_id}-{session_id}.jsonl"))
+}
+
 /// Create the audit channel, spawn the background `AuditWriter`, and return
-/// the sender + drop counter for injection into services.
+/// the sender, drop counter, and the last persisted hash (for chain continuity).
 async fn setup_audit(
     agent_id: &str,
     session_id: &str,
-) -> Result<(tokio::sync::mpsc::Sender<AuditEntry>, Arc<AtomicU64>), Box<dyn std::error::Error>> {
+) -> Result<(tokio::sync::mpsc::Sender<AuditEntry>, Arc<AtomicU64>, [u8; 32]), Box<dyn std::error::Error>> {
     let audit_dir = default_audit_dir();
+
+    // Read the last hash from the existing JSONL file (if any) so the hash
+    // chain is maintained across process restarts.
+    let audit_path = audit_file_path(&audit_dir, agent_id, session_id);
+    let initial_hash = AuditWriter::read_last_hash(&audit_path).await?.unwrap_or([0u8; 32]);
+
     let (audit_tx, audit_rx) = tokio::sync::mpsc::channel::<AuditEntry>(4096);
     let audit_drops = Arc::new(AtomicU64::new(0));
 
     let writer = AuditWriter::new(audit_dir, agent_id, session_id, audit_rx).await?;
     tokio::spawn(writer.run());
 
-    Ok((audit_tx, audit_drops))
+    Ok((audit_tx, audit_drops, initial_hash))
 }
 
 /// Start the gRPC server on a TCP address.
@@ -50,9 +61,14 @@ pub async fn serve_tcp(
     registry: Arc<AgentRegistry>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let engine = PolicyEngine::load_from_file(policy_path).map_err(|e| format!("failed to load policy: {e:?}"))?;
-    let (audit_tx, audit_drops) = setup_audit("gateway", "default").await?;
-    let policy_svc = PolicyServiceImpl::new(Arc::new(engine), audit_tx.clone(), Arc::clone(&audit_drops));
-    let audit_svc = AuditServiceImpl::new(audit_tx, audit_drops);
+    let (audit_tx, audit_drops, initial_hash) = setup_audit("gateway", "default").await?;
+    let policy_svc = PolicyServiceImpl::new(
+        Arc::new(engine),
+        audit_tx.clone(),
+        Arc::clone(&audit_drops),
+        initial_hash,
+    );
+    let audit_svc = AuditServiceImpl::new(audit_tx, audit_drops, initial_hash);
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);
 
     let addr = listen_addr.parse()?;
@@ -79,9 +95,14 @@ pub async fn serve_uds(
     registry: Arc<AgentRegistry>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let engine = PolicyEngine::load_from_file(policy_path).map_err(|e| format!("failed to load policy: {e:?}"))?;
-    let (audit_tx, audit_drops) = setup_audit("gateway", "default").await?;
-    let policy_svc = PolicyServiceImpl::new(Arc::new(engine), audit_tx.clone(), Arc::clone(&audit_drops));
-    let audit_svc = AuditServiceImpl::new(audit_tx, audit_drops);
+    let (audit_tx, audit_drops, initial_hash) = setup_audit("gateway", "default").await?;
+    let policy_svc = PolicyServiceImpl::new(
+        Arc::new(engine),
+        audit_tx.clone(),
+        Arc::clone(&audit_drops),
+        initial_hash,
+    );
+    let audit_svc = AuditServiceImpl::new(audit_tx, audit_drops, initial_hash);
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);
 
     tracing::info!(socket = %socket_path.display(), "starting gRPC server on UDS");

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -1,10 +1,12 @@
 //! gRPC server startup — loads policy, builds service, serves over TCP or UDS.
 
 use std::path::Path;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use tonic::transport::Server;
 
+use aa_core::AuditEntry;
 use crate::engine::PolicyEngine;
 use crate::registry::AgentRegistry;
 use crate::service::{AgentLifecycleServiceImpl, PolicyServiceImpl};
@@ -22,7 +24,9 @@ pub async fn serve_tcp(
     registry: Arc<AgentRegistry>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let engine = PolicyEngine::load_from_file(policy_path).map_err(|e| format!("failed to load policy: {e:?}"))?;
-    let policy_svc = PolicyServiceImpl::new(Arc::new(engine));
+    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel::<AuditEntry>(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+    let policy_svc = PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops);
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);
 
     let addr = listen_addr.parse()?;
@@ -48,7 +52,9 @@ pub async fn serve_uds(
     registry: Arc<AgentRegistry>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let engine = PolicyEngine::load_from_file(policy_path).map_err(|e| format!("failed to load policy: {e:?}"))?;
-    let policy_svc = PolicyServiceImpl::new(Arc::new(engine));
+    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel::<AuditEntry>(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+    let policy_svc = PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops);
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);
 
     tracing::info!(socket = %socket_path.display(), "starting gRPC server on UDS");

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -10,8 +10,9 @@ use aa_core::AuditEntry;
 use crate::audit::AuditWriter;
 use crate::engine::PolicyEngine;
 use crate::registry::AgentRegistry;
-use crate::service::{AgentLifecycleServiceImpl, PolicyServiceImpl};
+use crate::service::{AgentLifecycleServiceImpl, AuditServiceImpl, PolicyServiceImpl};
 use aa_proto::assembly::agent::v1::agent_lifecycle_service_server::AgentLifecycleServiceServer;
+use aa_proto::assembly::audit::v1::audit_service_server::AuditServiceServer;
 use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
 
 /// Default audit directory relative to the system data directory (`~/.aa/audit`).
@@ -50,7 +51,8 @@ pub async fn serve_tcp(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let engine = PolicyEngine::load_from_file(policy_path).map_err(|e| format!("failed to load policy: {e:?}"))?;
     let (audit_tx, audit_drops) = setup_audit("gateway", "default").await?;
-    let policy_svc = PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops);
+    let policy_svc = PolicyServiceImpl::new(Arc::new(engine), audit_tx.clone(), Arc::clone(&audit_drops));
+    let audit_svc = AuditServiceImpl::new(audit_tx, audit_drops);
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);
 
     let addr = listen_addr.parse()?;
@@ -58,6 +60,7 @@ pub async fn serve_tcp(
 
     Server::builder()
         .add_service(PolicyServiceServer::new(policy_svc))
+        .add_service(AuditServiceServer::new(audit_svc))
         .add_service(AgentLifecycleServiceServer::new(lifecycle_svc))
         .serve(addr)
         .await?;
@@ -77,7 +80,8 @@ pub async fn serve_uds(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let engine = PolicyEngine::load_from_file(policy_path).map_err(|e| format!("failed to load policy: {e:?}"))?;
     let (audit_tx, audit_drops) = setup_audit("gateway", "default").await?;
-    let policy_svc = PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops);
+    let policy_svc = PolicyServiceImpl::new(Arc::new(engine), audit_tx.clone(), Arc::clone(&audit_drops));
+    let audit_svc = AuditServiceImpl::new(audit_tx, audit_drops);
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);
 
     tracing::info!(socket = %socket_path.display(), "starting gRPC server on UDS");
@@ -91,6 +95,7 @@ pub async fn serve_uds(
 
     Server::builder()
         .add_service(PolicyServiceServer::new(policy_svc))
+        .add_service(AuditServiceServer::new(audit_svc))
         .add_service(AgentLifecycleServiceServer::new(lifecycle_svc))
         .serve_with_incoming(incoming)
         .await?;

--- a/aa-gateway/src/service/audit_service.rs
+++ b/aa-gateway/src/service/audit_service.rs
@@ -5,7 +5,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex};
 use tonic::{Request, Response, Status};
 
 use aa_core::identity::{AgentId, SessionId};
@@ -22,22 +22,28 @@ pub struct AuditServiceImpl {
     audit_tx: mpsc::Sender<AuditEntry>,
     audit_drops: Arc<AtomicU64>,
     seq: AtomicU64,
+    last_hash: Mutex<[u8; 32]>,
 }
 
 impl AuditServiceImpl {
     /// Create a new service backed by the given audit channel.
-    pub fn new(audit_tx: mpsc::Sender<AuditEntry>, audit_drops: Arc<AtomicU64>) -> Self {
+    ///
+    /// `initial_hash` seeds the hash chain — pass `[0u8; 32]` for a fresh chain,
+    /// or the last persisted hash to continue an existing chain.
+    pub fn new(audit_tx: mpsc::Sender<AuditEntry>, audit_drops: Arc<AtomicU64>, initial_hash: [u8; 32]) -> Self {
         Self {
             audit_tx,
             audit_drops,
             seq: AtomicU64::new(0),
+            last_hash: Mutex::new(initial_hash),
         }
     }
 
     /// Convert a proto `AuditEvent` into a core `AuditEntry` and send via try_send.
     ///
-    /// Returns the event_id on success, or an empty string if the entry was dropped.
-    fn ingest_event(&self, event: &AuditEvent, previous_hash: [u8; 32]) -> String {
+    /// Maintains the hash chain by reading and updating `last_hash`.
+    /// Returns the event_id on success, or the event_id even if the entry was dropped.
+    async fn ingest_event(&self, event: &AuditEvent) -> String {
         let event_id = event.event_id.clone();
         let seq = self.seq.fetch_add(1, Ordering::Relaxed);
 
@@ -69,15 +75,12 @@ impl AuditServiceImpl {
         })
         .to_string();
 
-        let entry = AuditEntry::new(
-            seq,
-            timestamp_ns,
-            event_type,
-            agent_id,
-            session_id,
-            payload,
-            previous_hash,
-        );
+        let mut last_hash = self.last_hash.lock().await;
+
+        let entry = AuditEntry::new(seq, timestamp_ns, event_type, agent_id, session_id, payload, *last_hash);
+
+        *last_hash = *entry.entry_hash();
+        drop(last_hash);
 
         if let Err(e) = self.audit_tx.try_send(entry) {
             match e {
@@ -116,7 +119,7 @@ impl AuditService for AuditServiceImpl {
         let mut event_ids = Vec::with_capacity(batch.events.len());
 
         for event in &batch.events {
-            let id = self.ingest_event(event, [0u8; 32]);
+            let id = self.ingest_event(event).await;
             event_ids.push(id);
         }
 
@@ -134,7 +137,7 @@ impl AuditService for AuditServiceImpl {
             tracing::error!(error = %e, "stream_events receive error");
             Status::internal(format!("stream receive error: {e}"))
         })? {
-            self.ingest_event(&event, [0u8; 32]);
+            self.ingest_event(&event).await;
             events_received += 1;
         }
 

--- a/aa-gateway/src/service/audit_service.rs
+++ b/aa-gateway/src/service/audit_service.rs
@@ -11,9 +11,7 @@ use tonic::{Request, Response, Status};
 use aa_core::identity::{AgentId, SessionId};
 use aa_core::{AuditEntry, AuditEventType};
 use aa_proto::assembly::audit::v1::audit_service_server::AuditService;
-use aa_proto::assembly::audit::v1::{
-    AuditEvent, ReportEventsRequest, ReportEventsResponse, StreamEventsResponse,
-};
+use aa_proto::assembly::audit::v1::{AuditEvent, ReportEventsRequest, ReportEventsResponse, StreamEventsResponse};
 use aa_proto::assembly::common::v1::Decision;
 
 use crate::service::convert;

--- a/aa-gateway/src/service/audit_service.rs
+++ b/aa-gateway/src/service/audit_service.rs
@@ -127,8 +127,19 @@ impl AuditService for AuditServiceImpl {
 
     async fn stream_events(
         &self,
-        _request: Request<tonic::Streaming<AuditEvent>>,
+        request: Request<tonic::Streaming<AuditEvent>>,
     ) -> Result<Response<StreamEventsResponse>, Status> {
-        Err(Status::unimplemented("StreamEvents not yet implemented"))
+        let mut stream = request.into_inner();
+        let mut events_received: i64 = 0;
+
+        while let Some(event) = stream.message().await.map_err(|e| {
+            tracing::error!(error = %e, "stream_events receive error");
+            Status::internal(format!("stream receive error: {e}"))
+        })? {
+            self.ingest_event(&event, [0u8; 32]);
+            events_received += 1;
+        }
+
+        Ok(Response::new(StreamEventsResponse { events_received }))
     }
 }

--- a/aa-gateway/src/service/audit_service.rs
+++ b/aa-gateway/src/service/audit_service.rs
@@ -1,0 +1,31 @@
+//! `AuditService` tonic trait implementation wiring gRPC RPCs to [`AuditWriter`].
+//!
+//! [`AuditWriter`]: crate::audit::AuditWriter
+
+use tonic::{Request, Response, Status};
+
+use aa_proto::assembly::audit::v1::audit_service_server::AuditService;
+use aa_proto::assembly::audit::v1::{
+    AuditEvent, ReportEventsRequest, ReportEventsResponse, StreamEventsResponse,
+};
+
+/// gRPC service implementation wiring `ReportEvents` / `StreamEvents` to the
+/// audit writer channel.
+pub struct AuditServiceImpl;
+
+#[tonic::async_trait]
+impl AuditService for AuditServiceImpl {
+    async fn report_events(
+        &self,
+        _request: Request<ReportEventsRequest>,
+    ) -> Result<Response<ReportEventsResponse>, Status> {
+        Err(Status::unimplemented("ReportEvents not yet implemented"))
+    }
+
+    async fn stream_events(
+        &self,
+        _request: Request<tonic::Streaming<AuditEvent>>,
+    ) -> Result<Response<StreamEventsResponse>, Status> {
+        Err(Status::unimplemented("StreamEvents not yet implemented"))
+    }
+}

--- a/aa-gateway/src/service/audit_service.rs
+++ b/aa-gateway/src/service/audit_service.rs
@@ -2,24 +2,127 @@
 //!
 //! [`AuditWriter`]: crate::audit::AuditWriter
 
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
 use tonic::{Request, Response, Status};
 
+use aa_core::identity::{AgentId, SessionId};
+use aa_core::{AuditEntry, AuditEventType};
 use aa_proto::assembly::audit::v1::audit_service_server::AuditService;
 use aa_proto::assembly::audit::v1::{
     AuditEvent, ReportEventsRequest, ReportEventsResponse, StreamEventsResponse,
 };
+use aa_proto::assembly::common::v1::Decision;
+
+use crate::service::convert;
 
 /// gRPC service implementation wiring `ReportEvents` / `StreamEvents` to the
 /// audit writer channel.
-pub struct AuditServiceImpl;
+pub struct AuditServiceImpl {
+    audit_tx: mpsc::Sender<AuditEntry>,
+    audit_drops: Arc<AtomicU64>,
+    seq: AtomicU64,
+}
+
+impl AuditServiceImpl {
+    /// Create a new service backed by the given audit channel.
+    pub fn new(audit_tx: mpsc::Sender<AuditEntry>, audit_drops: Arc<AtomicU64>) -> Self {
+        Self {
+            audit_tx,
+            audit_drops,
+            seq: AtomicU64::new(0),
+        }
+    }
+
+    /// Convert a proto `AuditEvent` into a core `AuditEntry` and send via try_send.
+    ///
+    /// Returns the event_id on success, or an empty string if the entry was dropped.
+    fn ingest_event(&self, event: &AuditEvent, previous_hash: [u8; 32]) -> String {
+        let event_id = event.event_id.clone();
+        let seq = self.seq.fetch_add(1, Ordering::Relaxed);
+
+        let agent_id = event
+            .agent_id
+            .as_ref()
+            .map(|a| AgentId::from_bytes(convert::hash_to_16(&a.agent_id)))
+            .unwrap_or_else(|| AgentId::from_bytes([0u8; 16]));
+
+        let session_id = if event.trace_id.is_empty() {
+            SessionId::from_bytes([0u8; 16])
+        } else {
+            SessionId::from_bytes(convert::hash_to_16(&event.trace_id))
+        };
+
+        let timestamp_ns = event
+            .occurred_at
+            .as_ref()
+            .map(|t| (t.unix_ms as u64).saturating_mul(1_000_000))
+            .unwrap_or(0);
+
+        let event_type = decision_to_audit_event_type(event.decision);
+
+        let payload = serde_json::json!({
+            "event_id": &event.event_id,
+            "action_type": event.action_type,
+            "span_id": &event.span_id,
+            "parent_span_id": &event.parent_span_id,
+        })
+        .to_string();
+
+        let entry = AuditEntry::new(
+            seq,
+            timestamp_ns,
+            event_type,
+            agent_id,
+            session_id,
+            payload,
+            previous_hash,
+        );
+
+        if let Err(e) = self.audit_tx.try_send(entry) {
+            match e {
+                mpsc::error::TrySendError::Full(_) => {
+                    tracing::warn!(seq, "audit channel full — event dropped");
+                    self.audit_drops.fetch_add(1, Ordering::Relaxed);
+                }
+                mpsc::error::TrySendError::Closed(_) => {
+                    tracing::error!("audit channel closed — AuditWriter task has exited");
+                }
+            }
+        }
+
+        event_id
+    }
+}
+
+/// Map a proto `Decision` i32 to `AuditEventType`.
+fn decision_to_audit_event_type(decision: i32) -> AuditEventType {
+    match Decision::try_from(decision) {
+        Ok(Decision::Allow) => AuditEventType::ToolCallIntercepted,
+        Ok(Decision::Deny) => AuditEventType::PolicyViolation,
+        Ok(Decision::Redact) => AuditEventType::CredentialLeakBlocked,
+        Ok(Decision::Pending) => AuditEventType::ApprovalRequested,
+        _ => AuditEventType::PolicyViolation,
+    }
+}
 
 #[tonic::async_trait]
 impl AuditService for AuditServiceImpl {
     async fn report_events(
         &self,
-        _request: Request<ReportEventsRequest>,
+        request: Request<ReportEventsRequest>,
     ) -> Result<Response<ReportEventsResponse>, Status> {
-        Err(Status::unimplemented("ReportEvents not yet implemented"))
+        let batch = request.into_inner();
+        let mut event_ids = Vec::with_capacity(batch.events.len());
+
+        for event in &batch.events {
+            let id = self.ingest_event(event, [0u8; 32]);
+            event_ids.push(id);
+        }
+
+        Ok(Response::new(ReportEventsResponse { event_ids }))
     }
 
     async fn stream_events(

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -34,7 +34,7 @@ pub enum ConvertError {
 /// Proto identity fields are variable-length strings; core identity types are
 /// fixed `[u8; 16]`. This deterministic mapping avoids collisions in practice
 /// while satisfying the type constraint.
-fn hash_to_16(s: &str) -> [u8; 16] {
+pub(crate) fn hash_to_16(s: &str) -> [u8; 16] {
     let digest = Sha256::digest(s.as_bytes());
     let mut out = [0u8; 16];
     out.copy_from_slice(&digest[..16]);

--- a/aa-gateway/src/service/mod.rs
+++ b/aa-gateway/src/service/mod.rs
@@ -1,8 +1,10 @@
 //! gRPC service layer — wires tonic-generated services to business logic.
 
+pub mod audit_service;
 pub mod convert;
 pub mod lifecycle_service;
 pub mod policy_service;
 
+pub use audit_service::AuditServiceImpl;
 pub use lifecycle_service::AgentLifecycleServiceImpl;
 pub use policy_service::PolicyServiceImpl;

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -2,12 +2,14 @@
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Instant, SystemTime};
 
 use tokio::sync::mpsc;
 use tonic::{Request, Response, Status};
 
-use aa_core::AuditEntry;
+use aa_core::identity::{AgentId, SessionId};
+use aa_core::time::Timestamp;
+use aa_core::{AuditEntry, AuditEventType};
 use aa_proto::assembly::policy::v1::policy_service_server::PolicyService;
 use aa_proto::assembly::policy::v1::{BatchCheckRequest, BatchCheckResponse, CheckActionRequest, CheckActionResponse};
 
@@ -52,6 +54,77 @@ impl PolicyServiceImpl {
 
         Ok(convert::eval_result_to_response(&eval, latency_us, policy_rule))
     }
+
+    /// Map a `PolicyResult` to the corresponding `AuditEventType`.
+    fn decision_to_event_type(decision: &aa_core::PolicyResult) -> AuditEventType {
+        match decision {
+            aa_core::PolicyResult::Allow => AuditEventType::ToolCallIntercepted,
+            aa_core::PolicyResult::Deny { .. } => AuditEventType::PolicyViolation,
+            aa_core::PolicyResult::RequiresApproval { .. } => AuditEventType::ApprovalRequested,
+        }
+    }
+
+    /// Build an `AuditEntry` from a request and evaluation result, then fire-and-forget
+    /// via `try_send`. Never blocks the caller.
+    fn record_audit(
+        &self,
+        req: &CheckActionRequest,
+        response: &CheckActionResponse,
+        seq: u64,
+        previous_hash: [u8; 32],
+    ) {
+        let proto_agent = match req.agent_id.as_ref() {
+            Some(a) => a,
+            None => return, // No agent identity — cannot construct entry.
+        };
+        let agent_id = AgentId::from_bytes(convert::hash_to_16(&proto_agent.agent_id));
+        let session_id = SessionId::from_bytes(convert::hash_to_16(&req.trace_id));
+        let event_type = Self::decision_to_event_type_from_response(response.decision);
+        let timestamp_ns = Timestamp::from(SystemTime::now()).as_nanos();
+
+        let payload = serde_json::json!({
+            "action_type": req.action_type,
+            "decision": response.decision,
+            "reason": &response.reason,
+            "policy_rule": &response.policy_rule,
+            "latency_us": response.decision_latency_us,
+        })
+        .to_string();
+
+        let entry = AuditEntry::new(
+            seq,
+            timestamp_ns,
+            event_type,
+            agent_id,
+            session_id,
+            payload,
+            previous_hash,
+        );
+
+        if let Err(e) = self.audit_tx.try_send(entry) {
+            match e {
+                mpsc::error::TrySendError::Full(_) => {
+                    tracing::warn!(seq, "audit channel full — entry dropped");
+                    self.audit_drops.fetch_add(1, Ordering::Relaxed);
+                }
+                mpsc::error::TrySendError::Closed(_) => {
+                    tracing::error!("audit channel closed — AuditWriter task has exited");
+                }
+            }
+        }
+    }
+
+    /// Map a proto `Decision` i32 to `AuditEventType`.
+    fn decision_to_event_type_from_response(decision: i32) -> AuditEventType {
+        use aa_proto::assembly::common::v1::Decision;
+        match Decision::try_from(decision) {
+            Ok(Decision::Allow) => AuditEventType::ToolCallIntercepted,
+            Ok(Decision::Deny) => AuditEventType::PolicyViolation,
+            Ok(Decision::Redact) => AuditEventType::CredentialLeakBlocked,
+            Ok(Decision::Pending) => AuditEventType::ApprovalRequested,
+            _ => AuditEventType::PolicyViolation, // fallback for unknown
+        }
+    }
 }
 
 #[tonic::async_trait]
@@ -86,6 +159,9 @@ impl PolicyService for PolicyServiceImpl {
             );
         }
 
+        // Fire-and-forget audit entry — never blocks the response.
+        self.record_audit(&req, &response, 0, [0u8; 32]);
+
         Ok(Response::new(response))
     }
 
@@ -93,8 +169,10 @@ impl PolicyService for PolicyServiceImpl {
         let batch = request.into_inner();
         let mut responses = Vec::with_capacity(batch.requests.len());
 
-        for req in &batch.requests {
-            responses.push(self.evaluate_one(req)?);
+        for (i, req) in batch.requests.iter().enumerate() {
+            let resp = self.evaluate_one(req)?;
+            self.record_audit(req, &resp, i as u64, [0u8; 32]);
+            responses.push(resp);
         }
 
         Ok(Response::new(BatchCheckResponse { responses }))

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -25,12 +25,12 @@ pub struct PolicyServiceImpl {
 
 impl PolicyServiceImpl {
     /// Create a new service backed by the given policy engine and audit channel.
-    pub fn new(
-        engine: Arc<PolicyEngine>,
-        audit_tx: mpsc::Sender<AuditEntry>,
-        audit_drops: Arc<AtomicU64>,
-    ) -> Self {
-        Self { engine, audit_tx, audit_drops }
+    pub fn new(engine: Arc<PolicyEngine>, audit_tx: mpsc::Sender<AuditEntry>, audit_drops: Arc<AtomicU64>) -> Self {
+        Self {
+            engine,
+            audit_tx,
+            audit_drops,
+        }
     }
 
     /// Evaluate a single request against the engine, returning the gRPC response.

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -1,10 +1,13 @@
 //! `PolicyService` tonic trait implementation wiring gRPC RPCs to `PolicyEngine`.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
+use tokio::sync::mpsc;
 use tonic::{Request, Response, Status};
 
+use aa_core::AuditEntry;
 use aa_proto::assembly::policy::v1::policy_service_server::PolicyService;
 use aa_proto::assembly::policy::v1::{BatchCheckRequest, BatchCheckResponse, CheckActionRequest, CheckActionResponse};
 
@@ -14,12 +17,18 @@ use crate::service::convert;
 /// gRPC service implementation wiring `CheckAction` / `BatchCheck` to [`PolicyEngine`].
 pub struct PolicyServiceImpl {
     engine: Arc<PolicyEngine>,
+    audit_tx: mpsc::Sender<AuditEntry>,
+    audit_drops: Arc<AtomicU64>,
 }
 
 impl PolicyServiceImpl {
-    /// Create a new service backed by the given policy engine.
-    pub fn new(engine: Arc<PolicyEngine>) -> Self {
-        Self { engine }
+    /// Create a new service backed by the given policy engine and audit channel.
+    pub fn new(
+        engine: Arc<PolicyEngine>,
+        audit_tx: mpsc::Sender<AuditEntry>,
+        audit_drops: Arc<AtomicU64>,
+    ) -> Self {
+        Self { engine, audit_tx, audit_drops }
     }
 
     /// Evaluate a single request against the engine, returning the gRPC response.

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -55,15 +55,6 @@ impl PolicyServiceImpl {
         Ok(convert::eval_result_to_response(&eval, latency_us, policy_rule))
     }
 
-    /// Map a `PolicyResult` to the corresponding `AuditEventType`.
-    fn decision_to_event_type(decision: &aa_core::PolicyResult) -> AuditEventType {
-        match decision {
-            aa_core::PolicyResult::Allow => AuditEventType::ToolCallIntercepted,
-            aa_core::PolicyResult::Deny { .. } => AuditEventType::PolicyViolation,
-            aa_core::PolicyResult::RequiresApproval { .. } => AuditEventType::ApprovalRequested,
-        }
-    }
-
     /// Build an `AuditEntry` from a request and evaluation result, then fire-and-forget
     /// via `try_send`. Never blocks the caller.
     fn record_audit(

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Instant, SystemTime};
 
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex};
 use tonic::{Request, Response, Status};
 
 use aa_core::identity::{AgentId, SessionId};
@@ -21,15 +21,28 @@ pub struct PolicyServiceImpl {
     engine: Arc<PolicyEngine>,
     audit_tx: mpsc::Sender<AuditEntry>,
     audit_drops: Arc<AtomicU64>,
+    seq: AtomicU64,
+    last_hash: Mutex<[u8; 32]>,
 }
 
 impl PolicyServiceImpl {
     /// Create a new service backed by the given policy engine and audit channel.
-    pub fn new(engine: Arc<PolicyEngine>, audit_tx: mpsc::Sender<AuditEntry>, audit_drops: Arc<AtomicU64>) -> Self {
+    ///
+    /// `initial_hash` should be the `entry_hash` of the last persisted audit entry
+    /// (obtained via [`AuditWriter::read_last_hash`]) so the hash chain is maintained
+    /// across process restarts. Pass `[0u8; 32]` for a fresh chain.
+    pub fn new(
+        engine: Arc<PolicyEngine>,
+        audit_tx: mpsc::Sender<AuditEntry>,
+        audit_drops: Arc<AtomicU64>,
+        initial_hash: [u8; 32],
+    ) -> Self {
         Self {
             engine,
             audit_tx,
             audit_drops,
+            seq: AtomicU64::new(0),
+            last_hash: Mutex::new(initial_hash),
         }
     }
 
@@ -56,14 +69,9 @@ impl PolicyServiceImpl {
     }
 
     /// Build an `AuditEntry` from a request and evaluation result, then fire-and-forget
-    /// via `try_send`. Never blocks the caller.
-    fn record_audit(
-        &self,
-        req: &CheckActionRequest,
-        response: &CheckActionResponse,
-        seq: u64,
-        previous_hash: [u8; 32],
-    ) {
+    /// via `try_send`. Maintains the hash chain by reading and updating `last_hash`.
+    /// Never blocks the caller beyond the brief mutex acquisition.
+    async fn record_audit(&self, req: &CheckActionRequest, response: &CheckActionResponse) {
         let proto_agent = match req.agent_id.as_ref() {
             Some(a) => a,
             None => return, // No agent identity — cannot construct entry.
@@ -72,6 +80,7 @@ impl PolicyServiceImpl {
         let session_id = SessionId::from_bytes(convert::hash_to_16(&req.trace_id));
         let event_type = Self::decision_to_event_type_from_response(response.decision);
         let timestamp_ns = Timestamp::from(SystemTime::now()).as_nanos();
+        let seq = self.seq.fetch_add(1, Ordering::Relaxed);
 
         let payload = serde_json::json!({
             "action_type": req.action_type,
@@ -82,15 +91,15 @@ impl PolicyServiceImpl {
         })
         .to_string();
 
-        let entry = AuditEntry::new(
-            seq,
-            timestamp_ns,
-            event_type,
-            agent_id,
-            session_id,
-            payload,
-            previous_hash,
-        );
+        let mut last_hash = self.last_hash.lock().await;
+
+        let entry = AuditEntry::new(seq, timestamp_ns, event_type, agent_id, session_id, payload, *last_hash);
+
+        // Update the chain head before sending — even if try_send fails (the entry
+        // is dropped), we advance the chain so subsequent entries don't duplicate
+        // the previous_hash and produce a misleading "valid" chain with a gap.
+        *last_hash = *entry.entry_hash();
+        drop(last_hash);
 
         if let Err(e) = self.audit_tx.try_send(entry) {
             match e {
@@ -151,7 +160,7 @@ impl PolicyService for PolicyServiceImpl {
         }
 
         // Fire-and-forget audit entry — never blocks the response.
-        self.record_audit(&req, &response, 0, [0u8; 32]);
+        self.record_audit(&req, &response).await;
 
         Ok(Response::new(response))
     }
@@ -160,9 +169,9 @@ impl PolicyService for PolicyServiceImpl {
         let batch = request.into_inner();
         let mut responses = Vec::with_capacity(batch.requests.len());
 
-        for (i, req) in batch.requests.iter().enumerate() {
+        for req in &batch.requests {
             let resp = self.evaluate_one(req)?;
-            self.record_audit(req, &resp, i as u64, [0u8; 32]);
+            self.record_audit(req, &resp).await;
             responses.push(resp);
         }
 

--- a/aa-gateway/tests/audit_channel_test.rs
+++ b/aa-gateway/tests/audit_channel_test.rs
@@ -32,7 +32,7 @@ async fn start_server_with_tiny_channel() -> (SocketAddr, Arc<AtomicU64>, tokio:
     // Channel capacity of 1 — will fill up quickly.
     let (audit_tx, audit_rx) = tokio::sync::mpsc::channel::<AuditEntry>(1);
     let audit_drops = Arc::new(AtomicU64::new(0));
-    let service = PolicyServiceImpl::new(Arc::new(engine), audit_tx, Arc::clone(&audit_drops));
+    let service = PolicyServiceImpl::new(Arc::new(engine), audit_tx, Arc::clone(&audit_drops), [0u8; 32]);
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/aa-gateway/tests/audit_channel_test.rs
+++ b/aa-gateway/tests/audit_channel_test.rs
@@ -1,0 +1,104 @@
+//! Test that policy evaluation succeeds even when the audit channel is full.
+
+use std::io::Write;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use aa_core::AuditEntry;
+use aa_gateway::service::PolicyServiceImpl;
+use aa_gateway::PolicyEngine;
+use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decision};
+use aa_proto::assembly::policy::v1::action_context::Action;
+use aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient;
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
+use aa_proto::assembly::policy::v1::{ActionContext, CheckActionRequest, ToolCallContext};
+use tokio::net::TcpListener;
+use tonic::transport::Server;
+
+const POLICY_YAML: &str = r#"
+version: "1"
+tools:
+  web_search:
+    allow: true
+"#;
+
+async fn start_server_with_tiny_channel() -> (
+    SocketAddr,
+    Arc<AtomicU64>,
+    tokio::sync::mpsc::Receiver<AuditEntry>,
+) {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", POLICY_YAML).unwrap();
+    tmp.flush().unwrap();
+
+    let engine = PolicyEngine::load_from_file(tmp.path()).unwrap();
+    // Channel capacity of 1 — will fill up quickly.
+    let (audit_tx, audit_rx) = tokio::sync::mpsc::channel::<AuditEntry>(1);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+    let service = PolicyServiceImpl::new(Arc::new(engine), audit_tx, Arc::clone(&audit_drops));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let drops = Arc::clone(&audit_drops);
+    tokio::spawn(async move {
+        let _tmp = tmp;
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(PolicyServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    // Wait for server to be ready.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    // Return the receiver so it stays alive — dropping it would close the channel
+    // and cause try_send to return Closed instead of Full.
+    (addr, drops, audit_rx)
+}
+
+fn make_request() -> CheckActionRequest {
+    CheckActionRequest {
+        agent_id: Some(ProtoAgentId {
+            org_id: "test-org".into(),
+            team_id: "test-team".into(),
+            agent_id: "test-agent".into(),
+        }),
+        action_type: ActionType::ToolCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::ToolCall(ToolCallContext {
+                tool_name: "web_search".into(),
+                tool_source: "mcp".into(),
+                args_json: "{}".into(),
+                target_url: String::new(),
+            })),
+        }),
+        trace_id: "trace-001".into(),
+        span_id: "span-001".into(),
+        credential_token: String::new(),
+    }
+}
+
+#[tokio::test]
+async fn policy_evaluation_succeeds_when_audit_channel_full() {
+    let (addr, audit_drops, _rx) = start_server_with_tiny_channel().await;
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    // Send multiple requests — the channel(1) will fill after the first.
+    // Note: the _audit_rx receiver is never consumed, so all sends after
+    // the first will hit try_send Full.
+    for _ in 0..5 {
+        let response = client.check_action(make_request()).await.unwrap();
+        let resp = response.into_inner();
+        assert_eq!(resp.decision, Decision::Allow as i32);
+    }
+
+    // Some audit entries should have been dropped (channel capacity = 1, no consumer).
+    let drops = audit_drops.load(Ordering::Relaxed);
+    assert!(drops > 0, "expected some audit drops, got {drops}");
+}

--- a/aa-gateway/tests/audit_channel_test.rs
+++ b/aa-gateway/tests/audit_channel_test.rs
@@ -23,11 +23,7 @@ tools:
     allow: true
 "#;
 
-async fn start_server_with_tiny_channel() -> (
-    SocketAddr,
-    Arc<AtomicU64>,
-    tokio::sync::mpsc::Receiver<AuditEntry>,
-) {
+async fn start_server_with_tiny_channel() -> (SocketAddr, Arc<AtomicU64>, tokio::sync::mpsc::Receiver<AuditEntry>) {
     let mut tmp = tempfile::NamedTempFile::new().unwrap();
     write!(tmp, "{}", POLICY_YAML).unwrap();
     tmp.flush().unwrap();
@@ -85,9 +81,7 @@ fn make_request() -> CheckActionRequest {
 #[tokio::test]
 async fn policy_evaluation_succeeds_when_audit_channel_full() {
     let (addr, audit_drops, _rx) = start_server_with_tiny_channel().await;
-    let mut client = PolicyServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     // Send multiple requests — the channel(1) will fill after the first.
     // Note: the _audit_rx receiver is never consumed, so all sends after

--- a/aa-gateway/tests/audit_integration_test.rs
+++ b/aa-gateway/tests/audit_integration_test.rs
@@ -10,13 +10,13 @@ use aa_core::{AuditEntry, AuditEventType};
 use aa_gateway::service::{AuditServiceImpl, PolicyServiceImpl};
 use aa_gateway::PolicyEngine;
 use aa_proto::assembly::audit::v1::audit_service_client::AuditServiceClient;
+use aa_proto::assembly::audit::v1::audit_service_server::AuditServiceServer;
 use aa_proto::assembly::audit::v1::{AuditEvent, ReportEventsRequest};
 use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decision, Timestamp};
 use aa_proto::assembly::policy::v1::action_context::Action;
 use aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient;
 use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
 use aa_proto::assembly::policy::v1::{ActionContext, CheckActionRequest, ToolCallContext};
-use aa_proto::assembly::audit::v1::audit_service_server::AuditServiceServer;
 use tokio::net::TcpListener;
 use tokio::sync::mpsc;
 use tonic::transport::Server;
@@ -32,11 +32,7 @@ tools:
 
 /// Start a server wired to an audit channel where the receiver is returned so
 /// the test can consume and inspect entries.
-async fn start_server_with_audit_rx() -> (
-    SocketAddr,
-    mpsc::Receiver<AuditEntry>,
-    Arc<AtomicU64>,
-) {
+async fn start_server_with_audit_rx() -> (SocketAddr, mpsc::Receiver<AuditEntry>, Arc<AtomicU64>) {
     let mut tmp = tempfile::NamedTempFile::new().unwrap();
     write!(tmp, "{}", POLICY_YAML).unwrap();
     tmp.flush().unwrap();
@@ -44,8 +40,7 @@ async fn start_server_with_audit_rx() -> (
     let engine = PolicyEngine::load_from_file(tmp.path()).unwrap();
     let (audit_tx, audit_rx) = mpsc::channel::<AuditEntry>(4096);
     let audit_drops = Arc::new(AtomicU64::new(0));
-    let policy_svc =
-        PolicyServiceImpl::new(Arc::new(engine), audit_tx.clone(), Arc::clone(&audit_drops));
+    let policy_svc = PolicyServiceImpl::new(Arc::new(engine), audit_tx.clone(), Arc::clone(&audit_drops));
     let audit_svc = AuditServiceImpl::new(audit_tx, Arc::clone(&audit_drops));
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -93,9 +88,7 @@ fn tool_call_request(tool_name: &str) -> CheckActionRequest {
 #[tokio::test]
 async fn check_action_allow_produces_audit_entry() {
     let (addr, mut audit_rx, _drops) = start_server_with_audit_rx().await;
-    let mut client = PolicyServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let resp = client
         .check_action(tool_call_request("web_search"))
@@ -122,9 +115,7 @@ async fn check_action_allow_produces_audit_entry() {
 #[tokio::test]
 async fn check_action_deny_produces_policy_violation_event() {
     let (addr, mut audit_rx, _drops) = start_server_with_audit_rx().await;
-    let mut client = PolicyServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let resp = client
         .check_action(tool_call_request("dangerous"))
@@ -146,9 +137,7 @@ async fn check_action_deny_produces_policy_violation_event() {
 #[tokio::test]
 async fn report_events_ingests_batch() {
     let (addr, mut audit_rx, _drops) = start_server_with_audit_rx().await;
-    let mut client = AuditServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = AuditServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let events = vec![
         AuditEvent {
@@ -160,7 +149,9 @@ async fn report_events_ingests_batch() {
             }),
             action_type: ActionType::ToolCall as i32,
             decision: Decision::Allow as i32,
-            occurred_at: Some(Timestamp { unix_ms: 1_700_000_000_000 }),
+            occurred_at: Some(Timestamp {
+                unix_ms: 1_700_000_000_000,
+            }),
             trace_id: "trace-r1".into(),
             span_id: "span-r1".into(),
             parent_span_id: String::new(),
@@ -176,7 +167,9 @@ async fn report_events_ingests_batch() {
             }),
             action_type: ActionType::ToolCall as i32,
             decision: Decision::Deny as i32,
-            occurred_at: Some(Timestamp { unix_ms: 1_700_000_001_000 }),
+            occurred_at: Some(Timestamp {
+                unix_ms: 1_700_000_001_000,
+            }),
             trace_id: "trace-r2".into(),
             span_id: "span-r2".into(),
             parent_span_id: String::new(),
@@ -214,9 +207,7 @@ async fn report_events_ingests_batch() {
 #[tokio::test]
 async fn stream_events_ingests_client_stream() {
     let (addr, mut audit_rx, _drops) = start_server_with_audit_rx().await;
-    let mut client = AuditServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = AuditServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let events = vec![
         AuditEvent {
@@ -228,7 +219,9 @@ async fn stream_events_ingests_client_stream() {
             }),
             action_type: ActionType::ToolCall as i32,
             decision: Decision::Allow as i32,
-            occurred_at: Some(Timestamp { unix_ms: 1_700_000_000_000 }),
+            occurred_at: Some(Timestamp {
+                unix_ms: 1_700_000_000_000,
+            }),
             trace_id: "trace-s1".into(),
             span_id: "span-s1".into(),
             parent_span_id: String::new(),
@@ -244,7 +237,9 @@ async fn stream_events_ingests_client_stream() {
             }),
             action_type: ActionType::FileOperation as i32,
             decision: Decision::Deny as i32,
-            occurred_at: Some(Timestamp { unix_ms: 1_700_000_002_000 }),
+            occurred_at: Some(Timestamp {
+                unix_ms: 1_700_000_002_000,
+            }),
             trace_id: "trace-s2".into(),
             span_id: "span-s2".into(),
             parent_span_id: String::new(),
@@ -260,7 +255,9 @@ async fn stream_events_ingests_client_stream() {
             }),
             action_type: ActionType::ToolCall as i32,
             decision: Decision::Pending as i32,
-            occurred_at: Some(Timestamp { unix_ms: 1_700_000_003_000 }),
+            occurred_at: Some(Timestamp {
+                unix_ms: 1_700_000_003_000,
+            }),
             trace_id: "trace-s3".into(),
             span_id: "span-s3".into(),
             parent_span_id: String::new(),
@@ -270,11 +267,7 @@ async fn stream_events_ingests_client_stream() {
     ];
 
     let stream = tokio_stream::iter(events);
-    let resp = client
-        .stream_events(stream)
-        .await
-        .unwrap()
-        .into_inner();
+    let resp = client.stream_events(stream).await.unwrap().into_inner();
 
     assert_eq!(resp.events_received, 3);
 

--- a/aa-gateway/tests/audit_integration_test.rs
+++ b/aa-gateway/tests/audit_integration_test.rs
@@ -40,8 +40,8 @@ async fn start_server_with_audit_rx() -> (SocketAddr, mpsc::Receiver<AuditEntry>
     let engine = PolicyEngine::load_from_file(tmp.path()).unwrap();
     let (audit_tx, audit_rx) = mpsc::channel::<AuditEntry>(4096);
     let audit_drops = Arc::new(AtomicU64::new(0));
-    let policy_svc = PolicyServiceImpl::new(Arc::new(engine), audit_tx.clone(), Arc::clone(&audit_drops));
-    let audit_svc = AuditServiceImpl::new(audit_tx, Arc::clone(&audit_drops));
+    let policy_svc = PolicyServiceImpl::new(Arc::new(engine), audit_tx.clone(), Arc::clone(&audit_drops), [0u8; 32]);
+    let audit_svc = AuditServiceImpl::new(audit_tx, Arc::clone(&audit_drops), [0u8; 32]);
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/aa-gateway/tests/audit_integration_test.rs
+++ b/aa-gateway/tests/audit_integration_test.rs
@@ -1,0 +1,298 @@
+//! Integration tests verifying that policy evaluation and audit RPCs produce
+//! correct `AuditEntry` values on the internal channel.
+
+use std::io::Write;
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+
+use aa_core::{AuditEntry, AuditEventType};
+use aa_gateway::service::{AuditServiceImpl, PolicyServiceImpl};
+use aa_gateway::PolicyEngine;
+use aa_proto::assembly::audit::v1::audit_service_client::AuditServiceClient;
+use aa_proto::assembly::audit::v1::{AuditEvent, ReportEventsRequest};
+use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decision, Timestamp};
+use aa_proto::assembly::policy::v1::action_context::Action;
+use aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient;
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
+use aa_proto::assembly::policy::v1::{ActionContext, CheckActionRequest, ToolCallContext};
+use aa_proto::assembly::audit::v1::audit_service_server::AuditServiceServer;
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+use tonic::transport::Server;
+
+const POLICY_YAML: &str = r#"
+version: "1"
+tools:
+  web_search:
+    allow: true
+  dangerous:
+    allow: false
+"#;
+
+/// Start a server wired to an audit channel where the receiver is returned so
+/// the test can consume and inspect entries.
+async fn start_server_with_audit_rx() -> (
+    SocketAddr,
+    mpsc::Receiver<AuditEntry>,
+    Arc<AtomicU64>,
+) {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", POLICY_YAML).unwrap();
+    tmp.flush().unwrap();
+
+    let engine = PolicyEngine::load_from_file(tmp.path()).unwrap();
+    let (audit_tx, audit_rx) = mpsc::channel::<AuditEntry>(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+    let policy_svc =
+        PolicyServiceImpl::new(Arc::new(engine), audit_tx.clone(), Arc::clone(&audit_drops));
+    let audit_svc = AuditServiceImpl::new(audit_tx, Arc::clone(&audit_drops));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let _tmp = tmp;
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(PolicyServiceServer::new(policy_svc))
+            .add_service(AuditServiceServer::new(audit_svc))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    (addr, audit_rx, audit_drops)
+}
+
+fn tool_call_request(tool_name: &str) -> CheckActionRequest {
+    CheckActionRequest {
+        agent_id: Some(ProtoAgentId {
+            org_id: "test-org".into(),
+            team_id: "test-team".into(),
+            agent_id: "test-agent".into(),
+        }),
+        action_type: ActionType::ToolCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::ToolCall(ToolCallContext {
+                tool_name: tool_name.into(),
+                tool_source: "mcp".into(),
+                args_json: b"{}".to_vec(),
+                target_url: String::new(),
+            })),
+        }),
+        trace_id: "trace-001".into(),
+        span_id: "span-001".into(),
+        credential_token: String::new(),
+    }
+}
+
+// ── Commit 18: check_action produces audit entry with correct fields ────────
+
+#[tokio::test]
+async fn check_action_allow_produces_audit_entry() {
+    let (addr, mut audit_rx, _drops) = start_server_with_audit_rx().await;
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let resp = client
+        .check_action(tool_call_request("web_search"))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(resp.decision, Decision::Allow as i32);
+
+    // The audit entry should arrive on the channel.
+    let entry = tokio::time::timeout(std::time::Duration::from_secs(2), audit_rx.recv())
+        .await
+        .expect("timed out waiting for audit entry")
+        .expect("channel closed without entry");
+
+    assert_eq!(entry.event_type(), AuditEventType::ToolCallIntercepted);
+    assert!(entry.timestamp_ns() > 0, "timestamp should be non-zero");
+
+    // Payload should contain the decision and action_type.
+    let payload: serde_json::Value = serde_json::from_str(entry.payload()).unwrap();
+    assert_eq!(payload["decision"], Decision::Allow as i32);
+    assert_eq!(payload["action_type"], ActionType::ToolCall as i32);
+}
+
+#[tokio::test]
+async fn check_action_deny_produces_policy_violation_event() {
+    let (addr, mut audit_rx, _drops) = start_server_with_audit_rx().await;
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let resp = client
+        .check_action(tool_call_request("dangerous"))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(resp.decision, Decision::Deny as i32);
+
+    let entry = tokio::time::timeout(std::time::Duration::from_secs(2), audit_rx.recv())
+        .await
+        .expect("timed out waiting for audit entry")
+        .expect("channel closed without entry");
+
+    assert_eq!(entry.event_type(), AuditEventType::PolicyViolation);
+}
+
+// ── Commit 19: ReportEvents RPC produces audit entries ──────────────────────
+
+#[tokio::test]
+async fn report_events_ingests_batch() {
+    let (addr, mut audit_rx, _drops) = start_server_with_audit_rx().await;
+    let mut client = AuditServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let events = vec![
+        AuditEvent {
+            event_id: "evt-1".into(),
+            agent_id: Some(ProtoAgentId {
+                org_id: "org".into(),
+                team_id: "team".into(),
+                agent_id: "agent-1".into(),
+            }),
+            action_type: ActionType::ToolCall as i32,
+            decision: Decision::Allow as i32,
+            occurred_at: Some(Timestamp { unix_ms: 1_700_000_000_000 }),
+            trace_id: "trace-r1".into(),
+            span_id: "span-r1".into(),
+            parent_span_id: String::new(),
+            detail: None,
+            labels: Default::default(),
+        },
+        AuditEvent {
+            event_id: "evt-2".into(),
+            agent_id: Some(ProtoAgentId {
+                org_id: "org".into(),
+                team_id: "team".into(),
+                agent_id: "agent-1".into(),
+            }),
+            action_type: ActionType::ToolCall as i32,
+            decision: Decision::Deny as i32,
+            occurred_at: Some(Timestamp { unix_ms: 1_700_000_001_000 }),
+            trace_id: "trace-r2".into(),
+            span_id: "span-r2".into(),
+            parent_span_id: String::new(),
+            detail: None,
+            labels: Default::default(),
+        },
+    ];
+
+    let resp = client
+        .report_events(ReportEventsRequest { events })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(resp.event_ids.len(), 2);
+    assert_eq!(resp.event_ids[0], "evt-1");
+    assert_eq!(resp.event_ids[1], "evt-2");
+
+    // Both entries should arrive on the channel.
+    let e1 = tokio::time::timeout(std::time::Duration::from_secs(2), audit_rx.recv())
+        .await
+        .expect("timed out")
+        .expect("channel closed");
+    let e2 = tokio::time::timeout(std::time::Duration::from_secs(2), audit_rx.recv())
+        .await
+        .expect("timed out")
+        .expect("channel closed");
+
+    assert_eq!(e1.event_type(), AuditEventType::ToolCallIntercepted);
+    assert_eq!(e2.event_type(), AuditEventType::PolicyViolation);
+}
+
+// ── Commit 20: StreamEvents RPC produces audit entries ──────────────────────
+
+#[tokio::test]
+async fn stream_events_ingests_client_stream() {
+    let (addr, mut audit_rx, _drops) = start_server_with_audit_rx().await;
+    let mut client = AuditServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let events = vec![
+        AuditEvent {
+            event_id: "stream-1".into(),
+            agent_id: Some(ProtoAgentId {
+                org_id: "org".into(),
+                team_id: "team".into(),
+                agent_id: "agent-s".into(),
+            }),
+            action_type: ActionType::ToolCall as i32,
+            decision: Decision::Allow as i32,
+            occurred_at: Some(Timestamp { unix_ms: 1_700_000_000_000 }),
+            trace_id: "trace-s1".into(),
+            span_id: "span-s1".into(),
+            parent_span_id: String::new(),
+            detail: None,
+            labels: Default::default(),
+        },
+        AuditEvent {
+            event_id: "stream-2".into(),
+            agent_id: Some(ProtoAgentId {
+                org_id: "org".into(),
+                team_id: "team".into(),
+                agent_id: "agent-s".into(),
+            }),
+            action_type: ActionType::FileOperation as i32,
+            decision: Decision::Deny as i32,
+            occurred_at: Some(Timestamp { unix_ms: 1_700_000_002_000 }),
+            trace_id: "trace-s2".into(),
+            span_id: "span-s2".into(),
+            parent_span_id: String::new(),
+            detail: None,
+            labels: Default::default(),
+        },
+        AuditEvent {
+            event_id: "stream-3".into(),
+            agent_id: Some(ProtoAgentId {
+                org_id: "org".into(),
+                team_id: "team".into(),
+                agent_id: "agent-s".into(),
+            }),
+            action_type: ActionType::ToolCall as i32,
+            decision: Decision::Pending as i32,
+            occurred_at: Some(Timestamp { unix_ms: 1_700_000_003_000 }),
+            trace_id: "trace-s3".into(),
+            span_id: "span-s3".into(),
+            parent_span_id: String::new(),
+            detail: None,
+            labels: Default::default(),
+        },
+    ];
+
+    let stream = tokio_stream::iter(events);
+    let resp = client
+        .stream_events(stream)
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(resp.events_received, 3);
+
+    // All three entries should arrive on the channel.
+    let e1 = tokio::time::timeout(std::time::Duration::from_secs(2), audit_rx.recv())
+        .await
+        .expect("timed out")
+        .expect("closed");
+    let e2 = tokio::time::timeout(std::time::Duration::from_secs(2), audit_rx.recv())
+        .await
+        .expect("timed out")
+        .expect("closed");
+    let e3 = tokio::time::timeout(std::time::Duration::from_secs(2), audit_rx.recv())
+        .await
+        .expect("timed out")
+        .expect("closed");
+
+    assert_eq!(e1.event_type(), AuditEventType::ToolCallIntercepted);
+    assert_eq!(e2.event_type(), AuditEventType::PolicyViolation);
+    assert_eq!(e3.event_type(), AuditEventType::ApprovalRequested);
+}

--- a/aa-gateway/tests/audit_test.rs
+++ b/aa-gateway/tests/audit_test.rs
@@ -1,0 +1,168 @@
+//! Unit tests for `AuditWriter` — append, verify_chain, read_last_hash.
+
+use aa_core::identity::{AgentId, SessionId};
+use aa_core::{AuditEntry, AuditEventType};
+use aa_gateway::audit::{AuditWriter, VerifyResult};
+use tokio::sync::mpsc;
+
+const AGENT: AgentId = AgentId::from_bytes([1u8; 16]);
+const SESSION: SessionId = SessionId::from_bytes([2u8; 16]);
+
+fn make_entry(seq: u64, previous_hash: [u8; 32]) -> AuditEntry {
+    AuditEntry::new(
+        seq,
+        1_700_000_000_000_000_000 + seq,
+        AuditEventType::ToolCallIntercepted,
+        AGENT,
+        SESSION,
+        format!("{{\"seq\":{seq}}}"),
+        previous_hash,
+    )
+}
+
+fn make_chain(count: u64) -> Vec<AuditEntry> {
+    let mut entries = Vec::new();
+    let mut prev_hash = [0u8; 32];
+    for seq in 0..count {
+        let entry = make_entry(seq, prev_hash);
+        prev_hash = *entry.entry_hash();
+        entries.push(entry);
+    }
+    entries
+}
+
+#[tokio::test]
+async fn append_writes_valid_jsonl() {
+    let dir = tempfile::tempdir().unwrap();
+    let (tx, rx) = mpsc::channel(64);
+    let writer = AuditWriter::new(dir.path().to_path_buf(), "agent-1", "sess-1", rx)
+        .await
+        .unwrap();
+
+    tokio::spawn(writer.run());
+
+    let entries = make_chain(3);
+    for entry in &entries {
+        tx.send(entry.clone()).await.unwrap();
+    }
+    drop(tx); // close channel, writer flushes and exits
+
+    // Give the writer task time to process.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let path = dir.path().join("agent-1-sess-1.jsonl");
+    assert!(path.exists(), "JSONL file should be created");
+
+    // Read back and verify line count.
+    let content = tokio::fs::read_to_string(&path).await.unwrap();
+    let lines: Vec<&str> = content.lines().collect();
+    assert_eq!(lines.len(), 3, "should have 3 JSON lines");
+
+    // Each line should deserialize to an AuditEntry.
+    for (i, line) in lines.iter().enumerate() {
+        let entry: AuditEntry = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("line {i} failed to parse: {e}"));
+        assert_eq!(entry.seq(), i as u64);
+    }
+}
+
+#[tokio::test]
+async fn verify_chain_valid() {
+    let dir = tempfile::tempdir().unwrap();
+    let (tx, rx) = mpsc::channel(64);
+    let writer = AuditWriter::new(dir.path().to_path_buf(), "agent-v", "sess-v", rx)
+        .await
+        .unwrap();
+
+    tokio::spawn(writer.run());
+
+    let entries = make_chain(5);
+    for entry in &entries {
+        tx.send(entry.clone()).await.unwrap();
+    }
+    drop(tx);
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let path = dir.path().join("agent-v-sess-v.jsonl");
+    let result = AuditWriter::verify_chain(&path).await.unwrap();
+    assert_eq!(
+        result,
+        VerifyResult {
+            is_valid: true,
+            entries_checked: 5,
+            first_invalid: None,
+        }
+    );
+}
+
+#[tokio::test]
+async fn verify_chain_detects_tampering() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("tampered.jsonl");
+
+    // Write a valid chain, then tamper with the second entry.
+    let entries = make_chain(3);
+    let mut lines: Vec<String> = entries
+        .iter()
+        .map(|e| serde_json::to_string(e).unwrap())
+        .collect();
+
+    // Tamper: replace the payload in line 1 (breaks its hash).
+    let _original: AuditEntry = serde_json::from_str(&lines[1]).unwrap();
+    // We can't mutate AuditEntry directly (fields are private), so we re-create
+    // with a different payload but the same previous_hash — this breaks the stored hash.
+    let bad_entry = AuditEntry::new(
+        1,
+        entries[1].timestamp_ns(),
+        entries[1].event_type(),
+        entries[1].agent_id(),
+        entries[1].session_id(),
+        "TAMPERED".to_string(),
+        *entries[1].previous_hash(),
+    );
+    // Write the original first entry + tampered second entry (different hash) + third entry
+    // The third entry's previous_hash will no longer match the tampered entry's hash.
+    lines[1] = serde_json::to_string(&bad_entry).unwrap();
+    // Note: line[1] itself is internally consistent (new hash matches its own fields),
+    // but line[2]'s previous_hash still points to the ORIGINAL line[1]'s hash.
+
+    let content = lines.join("\n") + "\n";
+    tokio::fs::write(&path, content).await.unwrap();
+
+    let result = AuditWriter::verify_chain(&path).await.unwrap();
+    assert!(!result.is_valid);
+    // The break is at entry 2 (index 2) because its previous_hash doesn't match
+    // the tampered entry 1's new hash.
+    assert_eq!(result.first_invalid, Some(2));
+}
+
+#[tokio::test]
+async fn read_last_hash_returns_correct_hash() {
+    let dir = tempfile::tempdir().unwrap();
+    let (tx, rx) = mpsc::channel(64);
+    let writer = AuditWriter::new(dir.path().to_path_buf(), "agent-h", "sess-h", rx)
+        .await
+        .unwrap();
+
+    tokio::spawn(writer.run());
+
+    let entries = make_chain(3);
+    let expected_hash = *entries.last().unwrap().entry_hash();
+    for entry in &entries {
+        tx.send(entry.clone()).await.unwrap();
+    }
+    drop(tx);
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let path = dir.path().join("agent-h-sess-h.jsonl");
+    let hash = AuditWriter::read_last_hash(&path).await.unwrap();
+    assert_eq!(hash, Some(expected_hash));
+}
+
+#[tokio::test]
+async fn read_last_hash_returns_none_for_missing_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("nonexistent.jsonl");
+    let hash = AuditWriter::read_last_hash(&path).await.unwrap();
+    assert_eq!(hash, None);
+}

--- a/aa-gateway/tests/audit_test.rs
+++ b/aa-gateway/tests/audit_test.rs
@@ -60,8 +60,7 @@ async fn append_writes_valid_jsonl() {
 
     // Each line should deserialize to an AuditEntry.
     for (i, line) in lines.iter().enumerate() {
-        let entry: AuditEntry = serde_json::from_str(line)
-            .unwrap_or_else(|e| panic!("line {i} failed to parse: {e}"));
+        let entry: AuditEntry = serde_json::from_str(line).unwrap_or_else(|e| panic!("line {i} failed to parse: {e}"));
         assert_eq!(entry.seq(), i as u64);
     }
 }
@@ -102,10 +101,7 @@ async fn verify_chain_detects_tampering() {
 
     // Write a valid chain, then tamper with the second entry.
     let entries = make_chain(3);
-    let mut lines: Vec<String> = entries
-        .iter()
-        .map(|e| serde_json::to_string(e).unwrap())
-        .collect();
+    let mut lines: Vec<String> = entries.iter().map(|e| serde_json::to_string(e).unwrap()).collect();
 
     // Tamper: replace the payload in line 1 (breaks its hash).
     let _original: AuditEntry = serde_json::from_str(&lines[1]).unwrap();

--- a/aa-gateway/tests/policy_latency_test.rs
+++ b/aa-gateway/tests/policy_latency_test.rs
@@ -7,6 +7,7 @@
 
 use std::io::Write;
 use std::net::SocketAddr;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -45,7 +46,9 @@ async fn start_server() -> SocketAddr {
     tmp.flush().unwrap();
 
     let engine = PolicyEngine::load_from_file(tmp.path()).unwrap();
-    let service = PolicyServiceImpl::new(Arc::new(engine));
+    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+    let service = PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops);
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/aa-gateway/tests/policy_latency_test.rs
+++ b/aa-gateway/tests/policy_latency_test.rs
@@ -48,7 +48,7 @@ async fn start_server() -> SocketAddr {
     let engine = PolicyEngine::load_from_file(tmp.path()).unwrap();
     let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel(4096);
     let audit_drops = Arc::new(AtomicU64::new(0));
-    let service = PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops);
+    let service = PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops, [0u8; 32]);
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -30,7 +30,7 @@ async fn start_server(policy_yaml: &str) -> SocketAddr {
     let engine = PolicyEngine::load_from_file(tmp.path()).unwrap();
     let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel(4096);
     let audit_drops = Arc::new(AtomicU64::new(0));
-    let service = PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops);
+    let service = PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops, [0u8; 32]);
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -5,6 +5,7 @@
 
 use std::io::Write;
 use std::net::SocketAddr;
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use aa_gateway::service::PolicyServiceImpl;
@@ -27,7 +28,9 @@ async fn start_server(policy_yaml: &str) -> SocketAddr {
     tmp.flush().unwrap();
 
     let engine = PolicyEngine::load_from_file(tmp.path()).unwrap();
-    let service = PolicyServiceImpl::new(Arc::new(engine));
+    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+    let service = PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops);
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -17,6 +17,7 @@ metrics                     = "0.24"
 metrics-exporter-prometheus = "0.16"
 prost                       = "0.13"
 serde                       = { version = "1", features = ["derive"] }
+sha2                        = "0.10"
 serde_json                  = "1"
 toml                        = "0.8"
 tokio                       = { version = "1", features = ["full"] }

--- a/aa-runtime/src/approval.rs
+++ b/aa-runtime/src/approval.rs
@@ -664,4 +664,138 @@ mod tests {
 
         assert!(q.list().is_empty());
     }
+
+    // --- Audit logging tests ---
+
+    #[tokio::test]
+    async fn submit_with_audit_emits_approval_requested_entry() {
+        let (tx, mut rx) = mpsc::channel::<AuditEntry>(64);
+        let q = ApprovalQueue::with_audit(tx, [0u8; 32]);
+
+        let req = make_request(60);
+        let _id = req.request_id;
+        let (_rid, _fut) = q.submit(req);
+
+        let entry = rx.try_recv().expect("should receive ApprovalRequested entry");
+        assert_eq!(entry.event_type(), AuditEventType::ApprovalRequested);
+        assert_eq!(entry.seq(), 0);
+    }
+
+    #[tokio::test]
+    async fn decide_approved_emits_approval_granted_entry() {
+        let (tx, mut rx) = mpsc::channel::<AuditEntry>(64);
+        let q = ApprovalQueue::with_audit(tx, [0u8; 32]);
+
+        let req = make_request(60);
+        let id = req.request_id;
+        let (_rid, _fut) = q.submit(req);
+
+        // Drain the ApprovalRequested entry from submit.
+        let _ = rx.try_recv().expect("submit entry");
+
+        q.decide(
+            id,
+            ApprovalDecision::Approved {
+                by: "alice".to_string(),
+                reason: None,
+            },
+        )
+        .expect("decide should succeed");
+
+        let entry = rx.try_recv().expect("should receive ApprovalGranted entry");
+        assert_eq!(entry.event_type(), AuditEventType::ApprovalGranted);
+        assert_eq!(entry.seq(), 1);
+    }
+
+    #[tokio::test]
+    async fn decide_rejected_emits_approval_denied_entry() {
+        let (tx, mut rx) = mpsc::channel::<AuditEntry>(64);
+        let q = ApprovalQueue::with_audit(tx, [0u8; 32]);
+
+        let req = make_request(60);
+        let id = req.request_id;
+        let (_rid, _fut) = q.submit(req);
+
+        let _ = rx.try_recv().expect("submit entry");
+
+        q.decide(
+            id,
+            ApprovalDecision::Rejected {
+                by: "bob".to_string(),
+                reason: "not allowed".to_string(),
+            },
+        )
+        .expect("decide should succeed");
+
+        let entry = rx.try_recv().expect("should receive ApprovalDenied entry");
+        assert_eq!(entry.event_type(), AuditEventType::ApprovalDenied);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn timeout_emits_approval_timed_out_entry() {
+        let (tx, mut rx) = mpsc::channel::<AuditEntry>(64);
+        let q = ApprovalQueue::with_audit(tx, [0u8; 32]);
+
+        let req = make_request(5);
+        let (_rid, _fut) = q.submit(req);
+
+        let _ = rx.try_recv().expect("submit entry");
+
+        tokio::time::advance(std::time::Duration::from_secs(6)).await;
+        // Yield to let the spawned timeout task run after time advances.
+        tokio::task::yield_now().await;
+
+        let entry = rx.recv().await.expect("should receive ApprovalTimedOut entry");
+        assert_eq!(entry.event_type(), AuditEventType::ApprovalTimedOut);
+    }
+
+    #[tokio::test]
+    async fn audit_entries_form_hash_chain() {
+        let (tx, mut rx) = mpsc::channel::<AuditEntry>(64);
+        let q = ApprovalQueue::with_audit(tx, [0u8; 32]);
+
+        let req = make_request(60);
+        let id = req.request_id;
+        let (_rid, _fut) = q.submit(req);
+
+        q.decide(
+            id,
+            ApprovalDecision::Approved {
+                by: "alice".to_string(),
+                reason: None,
+            },
+        )
+        .expect("decide should succeed");
+
+        let entry0 = rx.try_recv().expect("first entry");
+        let entry1 = rx.try_recv().expect("second entry");
+
+        // First entry's previous_hash should be the initial hash (all zeros).
+        assert_eq!(*entry0.previous_hash(), [0u8; 32]);
+        // Second entry's previous_hash should equal the first entry's entry_hash.
+        assert_eq!(entry1.previous_hash(), entry0.entry_hash());
+        // Hash chain entries should have distinct hashes.
+        assert_ne!(entry0.entry_hash(), entry1.entry_hash());
+    }
+
+    #[tokio::test]
+    async fn no_audit_without_audit_channel() {
+        // Using ApprovalQueue::new() (no audit channel) should not panic or fail.
+        let q = ApprovalQueue::new();
+        let req = make_request(60);
+        let id = req.request_id;
+        let (_rid, fut) = q.submit(req);
+
+        q.decide(
+            id,
+            ApprovalDecision::Approved {
+                by: "alice".to_string(),
+                reason: None,
+            },
+        )
+        .expect("decide should succeed");
+
+        let decision = fut.await.expect("future should resolve");
+        assert!(matches!(decision, ApprovalDecision::Approved { .. }));
+    }
 }

--- a/aa-runtime/src/approval.rs
+++ b/aa-runtime/src/approval.rs
@@ -5,11 +5,18 @@
 //! until a human operator calls [`ApprovalQueue::decide`], or the per-request
 //! timeout elapses and the queue auto-resolves it as [`ApprovalDecision::TimedOut`].
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use dashmap::DashMap;
-use tokio::sync::oneshot;
+use sha2::{Digest, Sha256};
+use tokio::sync::{mpsc, oneshot, Mutex};
 use uuid::Uuid;
+
+use aa_core::identity::{AgentId, SessionId};
+use aa_core::time::Timestamp;
+use aa_core::{AuditEntry, AuditEventType};
 
 // ---------------------------------------------------------------------------
 // Public type aliases
@@ -129,6 +136,17 @@ impl std::error::Error for ApprovalError {}
 /// a back-reference).
 pub struct ApprovalQueue {
     pending: DashMap<ApprovalRequestId, (ApprovalRequest, oneshot::Sender<ApprovalDecision>)>,
+    audit_tx: Option<mpsc::Sender<AuditEntry>>,
+    audit_seq: AtomicU64,
+    audit_last_hash: Mutex<[u8; 32]>,
+}
+
+/// Hash a string into a 16-byte identifier using SHA-256 truncation.
+fn hash_to_16(s: &str) -> [u8; 16] {
+    let digest = Sha256::digest(s.as_bytes());
+    let mut out = [0u8; 16];
+    out.copy_from_slice(&digest[..16]);
+    out
 }
 
 impl ApprovalQueue {
@@ -136,6 +154,22 @@ impl ApprovalQueue {
     pub fn new() -> Arc<Self> {
         Arc::new(Self {
             pending: DashMap::new(),
+            audit_tx: None,
+            audit_seq: AtomicU64::new(0),
+            audit_last_hash: Mutex::new([0u8; 32]),
+        })
+    }
+
+    /// Creates a new queue with audit logging enabled.
+    ///
+    /// Approval decisions (Approved, Rejected, TimedOut) will be recorded
+    /// as `AuditEntry` values on the given channel.
+    pub fn with_audit(audit_tx: mpsc::Sender<AuditEntry>, initial_hash: [u8; 32]) -> Arc<Self> {
+        Arc::new(Self {
+            pending: DashMap::new(),
+            audit_tx: Some(audit_tx),
+            audit_seq: AtomicU64::new(0),
+            audit_last_hash: Mutex::new(initial_hash),
         })
     }
 
@@ -179,19 +213,87 @@ impl ApprovalQueue {
     /// `id` is a safe no-op).
     fn resolve(&self, id: ApprovalRequestId, decision: ApprovalDecision) -> bool {
         if let Some((_key, (req, tx))) = self.pending.remove(&id) {
-            let (event_type, decided_by) = match &decision {
+            let (event_type_str, decided_by) = match &decision {
                 ApprovalDecision::Approved { by, .. } => ("ApprovalGranted", by.clone()),
                 ApprovalDecision::Rejected { by, .. } => ("ApprovalDenied", by.clone()),
                 ApprovalDecision::TimedOut { .. } => ("ApprovalTimedOut", "timeout".to_string()),
             };
             tracing::info!(
-                event_type,
+                event_type = event_type_str,
                 request_id = %req.request_id,
                 agent_id = %req.agent_id,
                 action = %req.action,
                 decided_by = %decided_by,
                 "approval decision recorded"
             );
+
+            // Record an audit entry for the approval decision.
+            if let Some(audit_tx) = &self.audit_tx {
+                let audit_event_type = match &decision {
+                    ApprovalDecision::Approved { .. } => AuditEventType::ApprovalGranted,
+                    ApprovalDecision::Rejected { .. } => AuditEventType::ApprovalDenied,
+                    ApprovalDecision::TimedOut { .. } => AuditEventType::ApprovalTimedOut,
+                };
+                let seq = self.audit_seq.fetch_add(1, Ordering::Relaxed);
+                let agent_id = AgentId::from_bytes(hash_to_16(&req.agent_id));
+                let session_id = SessionId::from_bytes(hash_to_16(&req.request_id.to_string()));
+                let timestamp_ns = Timestamp::from(SystemTime::now()).as_nanos();
+
+                let payload = serde_json::json!({
+                    "request_id": req.request_id.to_string(),
+                    "agent_id": &req.agent_id,
+                    "action": &req.action,
+                    "condition_triggered": &req.condition_triggered,
+                    "decided_by": &decided_by,
+                })
+                .to_string();
+
+                // Use try_lock to avoid blocking the resolve path; fall back to
+                // a broken chain link rather than deadlocking.
+                let (entry, hash_updated) = match self.audit_last_hash.try_lock() {
+                    Ok(mut guard) => {
+                        let entry = AuditEntry::new(
+                            seq,
+                            timestamp_ns,
+                            audit_event_type,
+                            agent_id,
+                            session_id,
+                            payload,
+                            *guard,
+                        );
+                        *guard = *entry.entry_hash();
+                        (entry, true)
+                    }
+                    Err(_) => {
+                        let entry = AuditEntry::new(
+                            seq,
+                            timestamp_ns,
+                            audit_event_type,
+                            agent_id,
+                            session_id,
+                            payload,
+                            [0u8; 32],
+                        );
+                        (entry, false)
+                    }
+                };
+
+                if !hash_updated {
+                    tracing::debug!(seq, "audit hash chain lock contended — entry uses zero previous_hash");
+                }
+
+                if let Err(e) = audit_tx.try_send(entry) {
+                    match e {
+                        mpsc::error::TrySendError::Full(_) => {
+                            tracing::warn!(seq, "audit channel full — approval event dropped");
+                        }
+                        mpsc::error::TrySendError::Closed(_) => {
+                            tracing::error!("audit channel closed — AuditWriter task has exited");
+                        }
+                    }
+                }
+            }
+
             // Ignore send errors: the receiver may have been dropped (caller
             // gave up waiting), which is not a failure on our side.
             let _ = tx.send(decision);
@@ -227,6 +329,37 @@ impl ApprovalQueue {
             timeout_secs,
             "approval requested"
         );
+
+        // Record the submission as an ApprovalRequested audit entry.
+        if let Some(audit_tx) = &self.audit_tx {
+            let seq = self.audit_seq.fetch_add(1, Ordering::Relaxed);
+            let agent_id = AgentId::from_bytes(hash_to_16(&request.agent_id));
+            let session_id = SessionId::from_bytes(hash_to_16(&id.to_string()));
+            let timestamp_ns = Timestamp::from(SystemTime::now()).as_nanos();
+
+            let payload = serde_json::json!({
+                "request_id": id.to_string(),
+                "agent_id": &request.agent_id,
+                "action": &request.action,
+                "condition_triggered": &request.condition_triggered,
+                "timeout_secs": request.timeout_secs,
+            })
+            .to_string();
+
+            if let Ok(mut guard) = self.audit_last_hash.try_lock() {
+                let entry = AuditEntry::new(
+                    seq,
+                    timestamp_ns,
+                    AuditEventType::ApprovalRequested,
+                    agent_id,
+                    session_id,
+                    payload,
+                    *guard,
+                );
+                *guard = *entry.entry_hash();
+                let _ = audit_tx.try_send(entry);
+            }
+        }
 
         let (tx, rx) = oneshot::channel();
         self.pending.insert(id, (request, tx));


### PR DESCRIPTION
## Summary

- **AuditWriter** — background tokio task consuming `mpsc::Receiver<AuditEntry>`, appending hash-chained JSONL to `~/.aa/audit/<agent>-<session>.jsonl`. Includes `verify_chain` (tamper detection) and `read_last_hash` (chain continuity).
- **PolicyService audit integration** — `PolicyServiceImpl` now accepts an `mpsc::Sender<AuditEntry>` and fires a `try_send` after every `check_action` / `batch_check` evaluation. Never blocks the hot path; drops are counted via `Arc<AtomicU64>`.
- **AuditService gRPC** — `AuditServiceImpl` implements `ReportEvents` (unary batch) and `StreamEvents` (client-streaming), converting proto `AuditEvent` to core `AuditEntry` and forwarding via the shared channel.
- **Server wiring** — `serve_tcp` and `serve_uds` now create the audit channel, spawn `AuditWriter`, and register both `PolicyServiceServer` and `AuditServiceServer`.

## Test plan

- [x] `audit_test.rs` — 5 unit tests: JSONL append, verify_chain valid/tampered, read_last_hash present/missing
- [x] `audit_channel_test.rs` — 1 unit test: policy evaluation succeeds when channel is full, drops counter incremented
- [x] `audit_integration_test.rs` — 4 integration tests: check_action Allow/Deny produce correct AuditEntry, ReportEvents batch ingestion, StreamEvents client-streaming ingestion
- [x] All existing 162 aa-gateway tests continue to pass
- [x] Full workspace test suite passes (0 failures)

Closes AAASM-138

🤖 Generated with [Claude Code](https://claude.com/claude-code)