### PR TITLE
[AAASM-144] 🐛 (kprobe): Implement KprobeManager::attach() replacing todo!() stub

### DIFF
--- a/aa-ebpf/src/kprobe.rs
+++ b/aa-ebpf/src/kprobe.rs
@@ -87,4 +87,14 @@ impl KprobeManager {
             _links: links,
         })
     }
+
+    /// Attach kprobes — non-Linux stub.
+    ///
+    /// Returns an error immediately since eBPF is not supported on this platform.
+    #[cfg(not(target_os = "linux"))]
+    pub fn attach(_bpf: &mut (), _target_pid: Option<i32>) -> Result<Self, EbpfError> {
+        Err(EbpfError::ProbeAttach(
+            "kprobe attachment requires Linux".into(),
+        ))
+    }
 }

--- a/aa-ebpf/src/kprobe.rs
+++ b/aa-ebpf/src/kprobe.rs
@@ -101,9 +101,7 @@ impl KprobeManager {
     /// Returns an error immediately since eBPF is not supported on this platform.
     #[cfg(not(target_os = "linux"))]
     pub fn attach(_bpf: &mut (), _target_pid: Option<i32>) -> Result<Self, EbpfError> {
-        Err(EbpfError::ProbeAttach(
-            "kprobe attachment requires Linux".into(),
-        ))
+        Err(EbpfError::ProbeAttach("kprobe attachment requires Linux".into()))
     }
 
     /// The complete list of (BPF program name, kernel function) pairs that

--- a/aa-ebpf/src/kprobe.rs
+++ b/aa-ebpf/src/kprobe.rs
@@ -11,8 +11,8 @@ use crate::error::EbpfError;
 
 /// Attaches and manages file I/O kprobe programs.
 ///
-/// Create via [`KprobeManager::attach`]. The probes stay active until the
-/// `KprobeManager` is dropped.
+/// Create via [`KprobeManager::attach`]. The probes stay active until
+/// [`KprobeManager::detach`] is called or the `KprobeManager` is dropped.
 pub struct KprobeManager {
     /// Target PID to filter inside the eBPF program.
     target_pid: Option<i32>,
@@ -20,7 +20,7 @@ pub struct KprobeManager {
     /// kernel. Stored as type-erased `Box<dyn Any>` to avoid coupling to
     /// aya's internal link-id type (matches `UprobeManager` convention).
     #[cfg(target_os = "linux")]
-    _links: Vec<Box<dyn std::any::Any>>,
+    links: Vec<Box<dyn std::any::Any>>,
 }
 
 impl std::fmt::Debug for KprobeManager {
@@ -90,10 +90,7 @@ impl KprobeManager {
             tracing::info!(program = prog_name, function = fn_name, "kprobe attached");
         }
 
-        Ok(Self {
-            target_pid,
-            _links: links,
-        })
+        Ok(Self { target_pid, links })
     }
 
     /// Attach kprobes — non-Linux stub.
@@ -102,6 +99,36 @@ impl KprobeManager {
     #[cfg(not(target_os = "linux"))]
     pub fn attach(_bpf: &mut (), _target_pid: Option<i32>) -> Result<Self, EbpfError> {
         Err(EbpfError::ProbeAttach("kprobe attachment requires Linux".into()))
+    }
+
+    /// Explicitly detach all kprobes from the kernel.
+    ///
+    /// After this call, [`is_attached`](Self::is_attached) returns `false`.
+    /// Calling `detach` on an already-detached manager is a no-op.
+    /// This is also called automatically when the `KprobeManager` is dropped.
+    #[cfg(target_os = "linux")]
+    pub fn detach(&mut self) {
+        let count = self.links.len();
+        self.links.clear();
+        if count > 0 {
+            tracing::info!(probes = count, "kprobes detached");
+        }
+    }
+
+    /// Explicitly detach — non-Linux stub (no-op).
+    #[cfg(not(target_os = "linux"))]
+    pub fn detach(&mut self) {}
+
+    /// Returns `true` if the kprobes are currently attached.
+    #[cfg(target_os = "linux")]
+    pub fn is_attached(&self) -> bool {
+        !self.links.is_empty()
+    }
+
+    /// Returns `false` — non-Linux stub (probes are never attached).
+    #[cfg(not(target_os = "linux"))]
+    pub fn is_attached(&self) -> bool {
+        false
     }
 
     /// The complete list of (BPF program name, kernel function) pairs that

--- a/aa-ebpf/src/kprobe.rs
+++ b/aa-ebpf/src/kprobe.rs
@@ -13,10 +13,14 @@ use crate::error::EbpfError;
 ///
 /// Create via [`KprobeManager::attach`]. The probes stay active until the
 /// `KprobeManager` is dropped.
-#[allow(dead_code)]
 pub struct KprobeManager {
     /// Target PID to filter inside the eBPF program.
     target_pid: Option<i32>,
+    /// Live kprobe link handles. Dropping them detaches the probes from the
+    /// kernel. Stored as type-erased `Box<dyn Any>` to avoid coupling to
+    /// aya's internal link-id type (matches `UprobeManager` convention).
+    #[cfg(target_os = "linux")]
+    _links: Vec<Box<dyn std::any::Any>>,
 }
 
 impl KprobeManager {

--- a/aa-ebpf/src/kprobe.rs
+++ b/aa-ebpf/src/kprobe.rs
@@ -37,9 +37,26 @@ impl KprobeManager {
     /// * `target_pid` — PID to filter, or `None` for system-wide monitoring.
     #[cfg(target_os = "linux")]
     pub fn attach(bpf: &mut Ebpf, target_pid: Option<i32>) -> Result<Self, EbpfError> {
-        // TODO(AAASM-38): attach openat_kprobe, write_kprobe, unlink_kprobe
-        // and write target_pid into the PID filter BPF map.
-        let _ = (bpf, target_pid);
-        todo!("attach file I/O kprobes")
+        // Write target PID into the BPF-side filter map so the kernel-space
+        // probes only emit events for the monitored process.
+        if let Some(pid) = target_pid {
+            let mut pid_filter: aya::maps::HashMap<_, u32, u8> = aya::maps::HashMap::try_from(
+                bpf.map_mut("PID_FILTER")
+                    .ok_or_else(|| EbpfError::ProbeAttach("PID_FILTER map not found".into()))?,
+            )
+            .map_err(|e| EbpfError::ProbeAttach(e.to_string()))?;
+
+            pid_filter
+                .insert(pid as u32, 1, 0)
+                .map_err(|e| EbpfError::ProbeAttach(e.to_string()))?;
+        }
+
+        // TODO(AAASM-144): attach kprobe programs (next commit).
+        let links: Vec<Box<dyn std::any::Any>> = Vec::new();
+
+        Ok(Self {
+            target_pid,
+            _links: links,
+        })
     }
 }

--- a/aa-ebpf/src/kprobe.rs
+++ b/aa-ebpf/src/kprobe.rs
@@ -51,8 +51,36 @@ impl KprobeManager {
                 .map_err(|e| EbpfError::ProbeAttach(e.to_string()))?;
         }
 
-        // TODO(AAASM-144): attach kprobe programs (next commit).
-        let links: Vec<Box<dyn std::any::Any>> = Vec::new();
+        // Attach all file I/O kprobe programs to their kernel functions.
+        let probes: &[(&str, &str)] = &[
+            ("aa_sys_openat", "__x64_sys_openat"),
+            ("aa_sys_openat_ret", "__x64_sys_openat"),
+            ("aa_sys_read", "__x64_sys_read"),
+            ("aa_sys_write", "__x64_sys_write"),
+            ("aa_sys_unlink", "__x64_sys_unlinkat"),
+            ("aa_sys_rename", "__x64_sys_renameat2"),
+        ];
+
+        let mut links: Vec<Box<dyn std::any::Any>> = Vec::with_capacity(probes.len());
+
+        for (prog_name, fn_name) in probes {
+            let program: &mut aya::programs::KProbe = bpf
+                .program_mut(prog_name)
+                .ok_or_else(|| EbpfError::ProbeAttach(format!("{prog_name} program not found")))?
+                .try_into()
+                .map_err(|e: aya::programs::ProgramError| EbpfError::ProbeAttach(e.to_string()))?;
+
+            program
+                .load()
+                .map_err(|e| EbpfError::ProbeAttach(format!("{prog_name} load failed: {e}")))?;
+
+            let link = program
+                .attach(fn_name, 0)
+                .map_err(|e| EbpfError::ProbeAttach(format!("{prog_name} attach to {fn_name} failed: {e}")))?;
+
+            links.push(Box::new(link));
+            tracing::info!(program = prog_name, function = fn_name, "kprobe attached");
+        }
 
         Ok(Self {
             target_pid,

--- a/aa-ebpf/src/kprobe.rs
+++ b/aa-ebpf/src/kprobe.rs
@@ -177,6 +177,16 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(target_os = "linux"))]
+    fn detach_is_noop_on_non_linux() {
+        // Construct directly — no links field on non-Linux.
+        let mut mgr = KprobeManager { target_pid: None };
+        assert!(!mgr.is_attached());
+        mgr.detach(); // should not panic
+        assert!(!mgr.is_attached());
+    }
+
+    #[test]
     fn kprobe_targets_kernel_functions_are_prefixed() {
         for (_, fn_name) in KprobeManager::KPROBE_TARGETS {
             assert!(

--- a/aa-ebpf/src/kprobe.rs
+++ b/aa-ebpf/src/kprobe.rs
@@ -23,6 +23,14 @@ pub struct KprobeManager {
     _links: Vec<Box<dyn std::any::Any>>,
 }
 
+impl std::fmt::Debug for KprobeManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KprobeManager")
+            .field("target_pid", &self.target_pid)
+            .finish()
+    }
+}
+
 impl KprobeManager {
     /// Attach file I/O kprobes (`openat`, `write`, `unlink`) for the target PID.
     ///
@@ -96,5 +104,60 @@ impl KprobeManager {
         Err(EbpfError::ProbeAttach(
             "kprobe attachment requires Linux".into(),
         ))
+    }
+
+    /// The complete list of (BPF program name, kernel function) pairs that
+    /// `attach()` will load. Exposed for testing and introspection.
+    pub const KPROBE_TARGETS: &[(&str, &str)] = &[
+        ("aa_sys_openat", "__x64_sys_openat"),
+        ("aa_sys_openat_ret", "__x64_sys_openat"),
+        ("aa_sys_read", "__x64_sys_read"),
+        ("aa_sys_write", "__x64_sys_write"),
+        ("aa_sys_unlink", "__x64_sys_unlinkat"),
+        ("aa_sys_rename", "__x64_sys_renameat2"),
+    ];
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[cfg(not(target_os = "linux"))]
+    fn attach_returns_error_on_non_linux() {
+        let err = KprobeManager::attach(&mut (), Some(1234)).unwrap_err();
+        assert!(matches!(err, EbpfError::ProbeAttach(_)));
+        assert!(err.to_string().contains("requires Linux"));
+    }
+
+    #[test]
+    #[cfg(not(target_os = "linux"))]
+    fn attach_returns_error_on_non_linux_system_wide() {
+        let err = KprobeManager::attach(&mut (), None).unwrap_err();
+        assert!(matches!(err, EbpfError::ProbeAttach(_)));
+    }
+
+    #[test]
+    fn kprobe_targets_covers_all_file_io_syscalls() {
+        let targets = KprobeManager::KPROBE_TARGETS;
+        assert_eq!(targets.len(), 6);
+
+        let prog_names: Vec<&str> = targets.iter().map(|(p, _)| *p).collect();
+        assert!(prog_names.contains(&"aa_sys_openat"));
+        assert!(prog_names.contains(&"aa_sys_openat_ret"));
+        assert!(prog_names.contains(&"aa_sys_read"));
+        assert!(prog_names.contains(&"aa_sys_write"));
+        assert!(prog_names.contains(&"aa_sys_unlink"));
+        assert!(prog_names.contains(&"aa_sys_rename"));
+    }
+
+    #[test]
+    fn kprobe_targets_kernel_functions_are_prefixed() {
+        for (_, fn_name) in KprobeManager::KPROBE_TARGETS {
+            assert!(
+                fn_name.starts_with("__x64_sys_"),
+                "kernel function {fn_name} should use __x64_sys_ prefix"
+            );
+        }
     }
 }

--- a/aa-ebpf/src/lib.rs
+++ b/aa-ebpf/src/lib.rs
@@ -50,8 +50,7 @@ pub mod maps;
 pub mod shell_detect;
 pub mod syscall;
 
-// aya-dependent modules — Linux only.
-#[cfg(target_os = "linux")]
+// aya-dependent modules — Linux only (except kprobe which has a non-Linux stub).
 pub mod kprobe;
 #[cfg(target_os = "linux")]
 pub mod ringbuf;

--- a/aa-ebpf/tests/kprobe_manager.rs
+++ b/aa-ebpf/tests/kprobe_manager.rs
@@ -1,0 +1,42 @@
+// Integration test: KprobeManager attach/detach lifecycle on a live kernel.
+//
+// Gated on:
+//   - target_os = "linux"  — eBPF is Linux-only
+//   - feature = "integration-test" — opted-in explicitly; requires root (CAP_BPF)
+//
+// Run locally (Linux, as root or via sudo):
+//   sudo env "PATH=$PATH" cargo test -p aa-ebpf --features integration-test --test kprobe_manager -- --nocapture
+#![cfg(all(target_os = "linux", feature = "integration-test"))]
+
+use aa_ebpf::{kprobe::KprobeManager, AA_FILE_IO_BPF};
+use aya::Ebpf;
+
+/// Verify that KprobeManager::attach() loads and attaches all 6 kprobes,
+/// is_attached() returns true, and detach() cleans up without error.
+#[test]
+fn kprobe_manager_attach_detach_lifecycle() {
+    let mut bpf =
+        Ebpf::load(AA_FILE_IO_BPF).expect("failed to load aa-file-io BPF program — ensure the test is running as root");
+
+    let mut mgr = KprobeManager::attach(&mut bpf, None).expect("KprobeManager::attach() failed");
+
+    assert!(mgr.is_attached(), "manager should be attached after attach()");
+
+    mgr.detach();
+
+    assert!(!mgr.is_attached(), "manager should not be attached after detach()");
+}
+
+/// Verify that KprobeManager::attach() works with a specific target PID
+/// (writes into the PID_FILTER map without error).
+#[test]
+fn kprobe_manager_attach_with_pid_filter() {
+    let mut bpf =
+        Ebpf::load(AA_FILE_IO_BPF).expect("failed to load aa-file-io BPF program — ensure the test is running as root");
+
+    let mgr = KprobeManager::attach(&mut bpf, Some(std::process::id() as i32))
+        .expect("KprobeManager::attach() with PID filter failed");
+
+    assert!(mgr.is_attached());
+    // mgr is dropped here — probes detach automatically.
+}


### PR DESCRIPTION
## Description

Implement `KprobeManager::attach()` in `aa-ebpf/src/kprobe.rs`, replacing the `todo!()` stub that panicked at runtime. The implementation uses aya's `KProbe` API to attach all 6 file I/O kprobe programs to their kernel functions, with proper link storage for detach-on-drop.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-144
- Parent Epic: AAASM-4 (Three-Layer Agent Interception)
- Related tasks: AAASM-38, AAASM-35

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [ ] Integration tests added / updated (requires CAP_BPF on Linux)
- [ ] Manual testing performed
- [ ] No tests required (explain why)

**Tests added:**
- `attach_returns_error_on_non_linux` — verifies non-Linux stub returns `EbpfError::ProbeAttach`
- `attach_returns_error_on_non_linux_system_wide` — verifies system-wide mode also errors on non-Linux
- `kprobe_targets_covers_all_file_io_syscalls` — verifies all 6 probe programs are listed
- `kprobe_targets_kernel_functions_are_prefixed` — verifies `__x64_sys_` convention

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention