### PR TITLE
[AAASM-146] 🐛 (uprobe): Fix UprobeManager::attach() error handling

### DIFF
--- a/aa-ebpf/src/error.rs
+++ b/aa-ebpf/src/error.rs
@@ -45,6 +45,13 @@ pub enum EbpfError {
         name: String,
     },
 
+    /// A required eBPF program was not found in the loaded object.
+    #[error("eBPF program `{name}` not found in object")]
+    ProgramNotFound {
+        /// Name of the missing program.
+        name: String,
+    },
+
     /// OpenSSL shared library could not be located for the target process.
     #[error("could not find OpenSSL library for pid {pid:?}")]
     OpenSslNotFound {

--- a/aa-ebpf/src/error.rs
+++ b/aa-ebpf/src/error.rs
@@ -52,6 +52,13 @@ pub enum EbpfError {
         name: String,
     },
 
+    /// Insufficient permissions to load or attach eBPF programs.
+    #[error("permission denied: {detail}")]
+    PermissionDenied {
+        /// Human-readable description of the required capability.
+        detail: String,
+    },
+
     /// OpenSSL shared library could not be located for the target process.
     #[error("could not find OpenSSL library for pid {pid:?}")]
     OpenSslNotFound {

--- a/aa-ebpf/src/error.rs
+++ b/aa-ebpf/src/error.rs
@@ -125,6 +125,34 @@ mod tests {
     }
 
     #[test]
+    fn display_program_not_found() {
+        let err = EbpfError::ProgramNotFound {
+            name: "ssl_write".into(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "eBPF program `ssl_write` not found in object"
+        );
+    }
+
+    #[test]
+    fn display_permission_denied() {
+        let err = EbpfError::PermissionDenied {
+            detail: "requires CAP_BPF".into(),
+        };
+        assert_eq!(err.to_string(), "permission denied: requires CAP_BPF");
+    }
+
+    #[test]
+    fn display_openssl_not_found() {
+        let err = EbpfError::OpenSslNotFound { pid: Some(1234) };
+        assert_eq!(
+            err.to_string(),
+            "could not find OpenSSL library for pid Some(1234)"
+        );
+    }
+
+    #[test]
     fn implements_std_error() {
         let err = EbpfError::ProgramLoad("test".into());
         let _: &dyn std::error::Error = &err;

--- a/aa-ebpf/src/error.rs
+++ b/aa-ebpf/src/error.rs
@@ -129,10 +129,7 @@ mod tests {
         let err = EbpfError::ProgramNotFound {
             name: "ssl_write".into(),
         };
-        assert_eq!(
-            err.to_string(),
-            "eBPF program `ssl_write` not found in object"
-        );
+        assert_eq!(err.to_string(), "eBPF program `ssl_write` not found in object");
     }
 
     #[test]
@@ -146,10 +143,7 @@ mod tests {
     #[test]
     fn display_openssl_not_found() {
         let err = EbpfError::OpenSslNotFound { pid: Some(1234) };
-        assert_eq!(
-            err.to_string(),
-            "could not find OpenSSL library for pid Some(1234)"
-        );
+        assert_eq!(err.to_string(), "could not find OpenSSL library for pid Some(1234)");
     }
 
     #[test]

--- a/aa-ebpf/src/uprobe.rs
+++ b/aa-ebpf/src/uprobe.rs
@@ -216,3 +216,38 @@ fn find_openssl_path(target_pid: Option<i32>) -> Result<String, EbpfError> {
 
     Err(EbpfError::OpenSslNotFound { pid: target_pid })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// On Linux: reading /proc/maps for a nonexistent PID returns an Io error.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn find_openssl_path_nonexistent_pid_returns_io_error() {
+        // PID 2^22 - 1 is extremely unlikely to exist.
+        let result = find_openssl_path(Some(4_194_303));
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, EbpfError::Io(_)),
+            "expected Io error, got: {err}",
+        );
+    }
+
+    /// On Linux: system-wide search with no libssl installed returns OpenSslNotFound.
+    /// This test only fails on systems that actually have libssl — which is
+    /// acceptable; it validates the error path on minimal CI containers.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn find_openssl_path_system_wide_falls_through_to_filesystem() {
+        // We cannot guarantee libssl is absent, so just verify the function
+        // returns Ok (found) or OpenSslNotFound (not found) — never panics.
+        let result = find_openssl_path(None);
+        match &result {
+            Ok(path) => assert!(path.contains("libssl.so"), "unexpected path: {path}"),
+            Err(EbpfError::OpenSslNotFound { .. }) => { /* expected on minimal systems */ }
+            Err(e) => panic!("unexpected error variant: {e}"),
+        }
+    }
+}

--- a/aa-ebpf/src/uprobe.rs
+++ b/aa-ebpf/src/uprobe.rs
@@ -60,7 +60,7 @@ impl UprobeManager {
         {
             let prog: &mut UProbe = bpf
                 .program_mut("ssl_write")
-                .ok_or_else(|| EbpfError::MapNotFound {
+                .ok_or_else(|| EbpfError::ProgramNotFound {
                     name: "ssl_write".into(),
                 })?
                 .try_into()?;
@@ -72,7 +72,7 @@ impl UprobeManager {
         {
             let prog: &mut UProbe = bpf
                 .program_mut("ssl_read_entry")
-                .ok_or_else(|| EbpfError::MapNotFound {
+                .ok_or_else(|| EbpfError::ProgramNotFound {
                     name: "ssl_read_entry".into(),
                 })?
                 .try_into()?;
@@ -84,7 +84,7 @@ impl UprobeManager {
         {
             let prog: &mut UProbe = bpf
                 .program_mut("ssl_read_exit")
-                .ok_or_else(|| EbpfError::MapNotFound {
+                .ok_or_else(|| EbpfError::ProgramNotFound {
                     name: "ssl_read_exit".into(),
                 })?
                 .try_into()?;

--- a/aa-ebpf/src/uprobe.rs
+++ b/aa-ebpf/src/uprobe.rs
@@ -134,9 +134,7 @@ fn load_program(prog: &mut UProbe, name: &str) -> Result<(), EbpfError> {
         let msg = e.to_string();
         if msg.contains("EPERM") || msg.contains("Operation not permitted") {
             EbpfError::PermissionDenied {
-                detail: format!(
-                    "loading program `{name}` requires CAP_BPF + CAP_PERFMON (or root)"
-                ),
+                detail: format!("loading program `{name}` requires CAP_BPF + CAP_PERFMON (or root)"),
             }
         } else {
             EbpfError::Program(e)
@@ -229,10 +227,7 @@ mod tests {
         let result = find_openssl_path(Some(4_194_303));
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(
-            matches!(err, EbpfError::Io(_)),
-            "expected Io error, got: {err}",
-        );
+        assert!(matches!(err, EbpfError::Io(_)), "expected Io error, got: {err}",);
     }
 
     /// On Linux: system-wide search with no libssl installed returns OpenSslNotFound.

--- a/aa-ebpf/src/uprobe.rs
+++ b/aa-ebpf/src/uprobe.rs
@@ -101,9 +101,24 @@ impl UprobeManager {
     /// Stub for non-Linux platforms — uprobe attachment requires Linux.
     #[cfg(not(target_os = "linux"))]
     pub fn attach(_bpf: &mut (), _target_pid: Option<i32>) -> Result<Self, EbpfError> {
-        Err(EbpfError::MapNotFound {
+        Err(EbpfError::ProgramNotFound {
             name: "uprobe attachment requires Linux".into(),
         })
+    }
+}
+
+impl Drop for UprobeManager {
+    fn drop(&mut self) {
+        #[cfg(target_os = "linux")]
+        let count = self._links.len();
+        #[cfg(not(target_os = "linux"))]
+        let count = 0_usize;
+
+        tracing::debug!(
+            target_pid = ?self.target_pid,
+            probe_count = count,
+            "detaching uprobe links",
+        );
     }
 }
 

--- a/aa-ebpf/src/uprobe.rs
+++ b/aa-ebpf/src/uprobe.rs
@@ -64,7 +64,7 @@ impl UprobeManager {
                     name: "ssl_write".into(),
                 })?
                 .try_into()?;
-            prog.load()?;
+            load_program(prog, "ssl_write")?;
             links.push(Box::new(prog.attach(Some("SSL_write"), 0, &ssl_path, target_pid)?));
         }
 
@@ -76,7 +76,7 @@ impl UprobeManager {
                     name: "ssl_read_entry".into(),
                 })?
                 .try_into()?;
-            prog.load()?;
+            load_program(prog, "ssl_read_entry")?;
             links.push(Box::new(prog.attach(Some("SSL_read"), 0, &ssl_path, target_pid)?));
         }
 
@@ -88,7 +88,7 @@ impl UprobeManager {
                     name: "ssl_read_exit".into(),
                 })?
                 .try_into()?;
-            prog.load()?;
+            load_program(prog, "ssl_read_exit")?;
             links.push(Box::new(prog.attach(Some("SSL_read"), 0, &ssl_path, target_pid)?));
         }
 
@@ -105,6 +105,28 @@ impl UprobeManager {
             name: "uprobe attachment requires Linux".into(),
         })
     }
+}
+
+/// Load a BPF program, converting EPERM to [`EbpfError::PermissionDenied`].
+///
+/// `prog.load()` returns `aya::programs::ProgramError` on failure.  When the
+/// kernel rejects the load with EPERM the error string contains "EPERM" or
+/// "Operation not permitted".  This wrapper detects that pattern and returns a
+/// more actionable [`EbpfError::PermissionDenied`] instead.
+#[cfg(target_os = "linux")]
+fn load_program(prog: &mut UProbe, name: &str) -> Result<(), EbpfError> {
+    prog.load().map_err(|e| {
+        let msg = e.to_string();
+        if msg.contains("EPERM") || msg.contains("Operation not permitted") {
+            EbpfError::PermissionDenied {
+                detail: format!(
+                    "loading program `{name}` requires CAP_BPF + CAP_PERFMON (or root)"
+                ),
+            }
+        } else {
+            EbpfError::Program(e)
+        }
+    })
 }
 
 /// Target well-known `libssl.so` filesystem paths tried when the library is


### PR DESCRIPTION
## Description

Fix incomplete error handling in `UprobeManager::attach()` (`aa-ebpf/src/uprobe.rs`). The method was misusing `EbpfError::MapNotFound` for program lookup failures and lacked permission-denied detection and detach observability.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [ ] No
- [x] Yes (describe below)

`EbpfError` enum has two new variants (`ProgramNotFound`, `PermissionDenied`). Code that exhaustively matches on `EbpfError` will need to add arms for these variants. The non-Linux `attach()` stub now returns `ProgramNotFound` instead of `MapNotFound`.

## Related Issues

- Related Jira ticket: AAASM-146
- Parent Epic: AAASM-4

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [x] No tests required (explain why)

New display tests for `ProgramNotFound`, `PermissionDenied`, and `OpenSslNotFound` variants. Linux-gated tests for `find_openssl_path` error paths. Integration tests require Linux kernel with eBPF support (not available on macOS CI).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Changes Summary

1. **New `ProgramNotFound` error variant** — separates program-not-found from map-not-found semantics
2. **New `PermissionDenied` error variant** — surfaces CAP_BPF/CAP_PERFMON requirement clearly
3. **Fixed `attach()`** — uses correct error variants for program lookup
4. **Permission detection** — `load_program()` helper detects EPERM and wraps it
5. **Drop observability** — explicit `Drop` impl logs probe detach via `tracing::debug!`
6. **Tests** — display tests for all new variants + Linux-gated `find_openssl_path` tests