### PR TITLE
[AAASM-145] 🐛 (tracepoint): Implement TracepointManager attach/detach lifecycle

### DIFF
--- a/aa-ebpf/src/lib.rs
+++ b/aa-ebpf/src/lib.rs
@@ -34,10 +34,12 @@
 //!
 //! ## Platform support
 //!
-//! eBPF is Linux-only. On macOS, this crate compiles but all aya-dependent
-//! modules (`uprobe`, `kprobe`, `tracepoint`, `ringbuf`) are gated with
-//! `#[cfg(target_os = "linux")]`.  Cross-platform modules (`events`, `lineage`,
-//! `alert`, `error`, `loader`, `maps`, `syscall`) are available on all platforms.
+//! eBPF is Linux-only. On macOS, this crate compiles but most aya-dependent
+//! modules (`uprobe`, `kprobe`, `ringbuf`) are gated with
+//! `#[cfg(target_os = "linux")]`.  The `tracepoint` module is cross-platform
+//! (aya-dependent code is gated internally; non-Linux stubs are provided).
+//! Cross-platform modules (`events`, `lineage`, `alert`, `error`, `loader`,
+//! `maps`, `syscall`) are available on all platforms.
 
 // Cross-platform modules (no aya dependency).
 pub mod alert;
@@ -55,7 +57,8 @@ pub mod syscall;
 pub mod kprobe;
 #[cfg(target_os = "linux")]
 pub mod ringbuf;
-#[cfg(target_os = "linux")]
+// tracepoint is cross-platform: aya-dependent code is gated internally,
+// and non-Linux stubs provide a consistent API surface.
 pub mod tracepoint;
 #[cfg(target_os = "linux")]
 pub mod uprobe;

--- a/aa-ebpf/src/tracepoint.rs
+++ b/aa-ebpf/src/tracepoint.rs
@@ -14,6 +14,12 @@ use crate::error::EbpfError;
 /// Create via [`TracepointManager::attach`]. The tracepoints stay active
 /// until the `TracepointManager` is dropped.
 pub struct TracepointManager {
+    /// Live tracepoint link handles. Stored as type-erased `Box<dyn Any>`
+    /// to avoid depending on aya's internal link-id type name. Dropping
+    /// them detaches the tracepoints from the kernel.
+    #[cfg(target_os = "linux")]
+    _links: Vec<Box<dyn std::any::Any>>,
+    #[cfg(not(target_os = "linux"))]
     _private: (),
 }
 
@@ -59,7 +65,7 @@ impl TracepointManager {
             tracing::info!(program = prog_name, tracepoint = %format!("{category}/{tp_name}"), "tracepoint attached");
         }
 
-        Ok(Self { _private: () })
+        Ok(Self { _links: Vec::new() })
     }
 
     /// Attach tracepoints — non-Linux stub.

--- a/aa-ebpf/src/tracepoint.rs
+++ b/aa-ebpf/src/tracepoint.rs
@@ -99,3 +99,15 @@ impl TracepointManager {
         ))
     }
 }
+
+impl Drop for TracepointManager {
+    fn drop(&mut self) {
+        #[cfg(target_os = "linux")]
+        if !self._links.is_empty() {
+            tracing::debug!(
+                count = self._links.len(),
+                "TracepointManager dropping, detaching tracepoints"
+            );
+        }
+    }
+}

--- a/aa-ebpf/src/tracepoint.rs
+++ b/aa-ebpf/src/tracepoint.rs
@@ -71,6 +71,24 @@ impl TracepointManager {
         Ok(Self { _links: links })
     }
 
+    /// Explicitly detach all tracepoints.
+    ///
+    /// Dropping the link handles causes aya to detach the probes from the
+    /// kernel. After this call the `TracepointManager` is inert — calling
+    /// `detach` again is a no-op.
+    #[cfg(target_os = "linux")]
+    pub fn detach(&mut self) {
+        let count = self._links.len();
+        self._links.clear();
+        if count > 0 {
+            tracing::info!(count, "tracepoints explicitly detached");
+        }
+    }
+
+    /// Explicit detach — non-Linux stub (no-op).
+    #[cfg(not(target_os = "linux"))]
+    pub fn detach(&mut self) {}
+
     /// Attach tracepoints — non-Linux stub.
     ///
     /// Returns an error immediately since eBPF is not supported on this platform.

--- a/aa-ebpf/src/tracepoint.rs
+++ b/aa-ebpf/src/tracepoint.rs
@@ -93,7 +93,7 @@ impl TracepointManager {
     ///
     /// Returns an error immediately since eBPF is not supported on this platform.
     #[cfg(not(target_os = "linux"))]
-    pub fn attach_stub() -> Result<Self, EbpfError> {
+    pub fn attach(_bpf: &mut ()) -> Result<Self, EbpfError> {
         Err(EbpfError::ProgramLoad(
             "eBPF tracepoints are only supported on Linux".into(),
         ))

--- a/aa-ebpf/src/tracepoint.rs
+++ b/aa-ebpf/src/tracepoint.rs
@@ -100,6 +100,23 @@ impl TracepointManager {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn attach_returns_error_on_non_linux() {
+        let result = TracepointManager::attach(&mut ());
+        assert!(result.is_err());
+        let err = result.err().unwrap();
+        assert!(
+            err.to_string().contains("only supported on Linux"),
+            "expected 'only supported on Linux', got: {err}"
+        );
+    }
+}
+
 impl Drop for TracepointManager {
     fn drop(&mut self) {
         #[cfg(target_os = "linux")]

--- a/aa-ebpf/src/tracepoint.rs
+++ b/aa-ebpf/src/tracepoint.rs
@@ -48,6 +48,8 @@ impl TracepointManager {
             ("handle_sched_process_exit", "sched", "sched_process_exit"),
         ];
 
+        let mut links: Vec<Box<dyn std::any::Any>> = Vec::with_capacity(tracepoints.len());
+
         for (prog_name, category, tp_name) in tracepoints {
             let program: &mut TracePoint = bpf
                 .program_mut(prog_name)
@@ -58,14 +60,15 @@ impl TracepointManager {
             program
                 .load()
                 .map_err(|e| EbpfError::ProbeAttach(format!("{prog_name} load failed: {e}")))?;
-            program.attach(category, tp_name).map_err(|e| {
+            let link = program.attach(category, tp_name).map_err(|e| {
                 EbpfError::ProbeAttach(format!("{prog_name} attach to {category}/{tp_name} failed: {e}"))
             })?;
+            links.push(Box::new(link));
 
             tracing::info!(program = prog_name, tracepoint = %format!("{category}/{tp_name}"), "tracepoint attached");
         }
 
-        Ok(Self { _links: Vec::new() })
+        Ok(Self { _links: links })
     }
 
     /// Attach tracepoints — non-Linux stub.

--- a/aa-ebpf/src/tracepoint.rs
+++ b/aa-ebpf/src/tracepoint.rs
@@ -115,6 +115,16 @@ mod tests {
             "expected 'only supported on Linux', got: {err}"
         );
     }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn detach_is_idempotent_no_op_on_non_linux() {
+        // On non-Linux, we cannot construct a TracepointManager via attach(),
+        // but we can verify detach() exists and is callable on the type.
+        // This test documents the API contract: detach is a no-op stub.
+        // Full lifecycle testing happens in the integration test on Linux.
+        let _: fn(&mut TracepointManager) = TracepointManager::detach;
+    }
 }
 
 impl Drop for TracepointManager {

--- a/aa-ebpf/tests/exec_tracepoint.rs
+++ b/aa-ebpf/tests/exec_tracepoint.rs
@@ -8,52 +8,39 @@
 //   sudo env "PATH=$PATH" cargo test -p aa-ebpf --features integration-test --test exec_tracepoint -- --nocapture
 #![cfg(all(target_os = "linux", feature = "integration-test"))]
 
-use aa_ebpf::AA_EXEC_BPF;
-use aya::{programs::TracePoint, Ebpf};
+use aa_ebpf::{tracepoint::TracepointManager, AA_EXEC_BPF};
+use aya::Ebpf;
 
-/// Verify the full "compile → embed → load → attach" pipeline for exec tracepoints.
+/// Verify the full "compile → embed → load → attach" pipeline for exec tracepoints
+/// using the `TracepointManager` API.
 ///
 /// 1. `Ebpf::load` parses and JIT-compiles the embedded BPF bytecode.
-/// 2. `TracePoint::load` submits the program to the kernel verifier.
-/// 3. `TracePoint::attach` hooks onto `sched/sched_process_exec`.
-///
-/// The link guard returned by `attach` detaches the probe on drop, so the
-/// kernel is left clean after the test regardless of pass/fail.
+/// 2. `TracepointManager::attach` loads and attaches both tracepoints.
+/// 3. Dropping the `TracepointManager` detaches the probes from the kernel.
 #[test]
 fn aa_exec_probes_loads_and_attaches() {
     let mut bpf = Ebpf::load(AA_EXEC_BPF)
         .expect("failed to load aa-exec-probes BPF program — ensure the test is running as root");
 
-    // Attach sched_process_exec tracepoint.
-    let exec_program: &mut TracePoint = bpf
-        .program_mut("handle_sched_process_exec")
-        .expect("handle_sched_process_exec program not found in BPF object")
-        .try_into()
-        .expect("handle_sched_process_exec is not a TracePoint program");
-
-    exec_program
-        .load()
-        .expect("kernel verifier rejected handle_sched_process_exec");
-
-    let _exec_link = exec_program
-        .attach("sched", "sched_process_exec")
-        .expect("failed to attach handle_sched_process_exec to sched/sched_process_exec");
-
-    // Attach sched_process_exit tracepoint.
-    let exit_program: &mut TracePoint = bpf
-        .program_mut("handle_sched_process_exit")
-        .expect("handle_sched_process_exit program not found in BPF object")
-        .try_into()
-        .expect("handle_sched_process_exit is not a TracePoint program");
-
-    exit_program
-        .load()
-        .expect("kernel verifier rejected handle_sched_process_exit");
-
-    let _exit_link = exit_program
-        .attach("sched", "sched_process_exit")
-        .expect("failed to attach handle_sched_process_exit to sched/sched_process_exit");
+    let _manager = TracepointManager::attach(&mut bpf)
+        .expect("TracepointManager::attach failed");
 
     // Reaching this line confirms the full pipeline works.
-    // Links are dropped here, which detaches the probes from the kernel.
+    // TracepointManager is dropped here, which detaches the probes from the kernel.
+}
+
+/// Verify that `detach()` can be called explicitly without panic.
+#[test]
+fn tracepoint_manager_explicit_detach() {
+    let mut bpf = Ebpf::load(AA_EXEC_BPF)
+        .expect("failed to load aa-exec-probes BPF program — ensure the test is running as root");
+
+    let mut manager = TracepointManager::attach(&mut bpf)
+        .expect("TracepointManager::attach failed");
+
+    // Explicit detach should succeed.
+    manager.detach();
+
+    // Calling detach again should be a no-op (not panic).
+    manager.detach();
 }

--- a/aa-ebpf/tests/exec_tracepoint.rs
+++ b/aa-ebpf/tests/exec_tracepoint.rs
@@ -22,8 +22,7 @@ fn aa_exec_probes_loads_and_attaches() {
     let mut bpf = Ebpf::load(AA_EXEC_BPF)
         .expect("failed to load aa-exec-probes BPF program — ensure the test is running as root");
 
-    let _manager = TracepointManager::attach(&mut bpf)
-        .expect("TracepointManager::attach failed");
+    let _manager = TracepointManager::attach(&mut bpf).expect("TracepointManager::attach failed");
 
     // Reaching this line confirms the full pipeline works.
     // TracepointManager is dropped here, which detaches the probes from the kernel.
@@ -35,8 +34,7 @@ fn tracepoint_manager_explicit_detach() {
     let mut bpf = Ebpf::load(AA_EXEC_BPF)
         .expect("failed to load aa-exec-probes BPF program — ensure the test is running as root");
 
-    let mut manager = TracepointManager::attach(&mut bpf)
-        .expect("TracepointManager::attach failed");
+    let mut manager = TracepointManager::attach(&mut bpf).expect("TracepointManager::attach failed");
 
     // Explicit detach should succeed.
     manager.detach();


### PR DESCRIPTION
## Description

Implement the missing `TracepointManager` attach/detach lifecycle in `aa-ebpf/src/tracepoint.rs`. The struct previously held `_private: ()` instead of storing tracepoint link handles, causing tracepoints to be immediately detached when the temporary link values went out of scope inside `attach()`.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [x] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [ ] Yes (describe below)
- [x] No

## Related Issues

- Related Jira ticket: AAASM-145
- Related Jira epic: AAASM-4

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

### Changes summary

1. **Store link handles** — Replace `_private: ()` with `_links: Vec<Box<dyn Any>>` (matching `UprobeManager` pattern). Capture `TracePointLink` returned by `program.attach()` so tracepoints stay active for the lifetime of the manager.
2. **Add `detach()` method** — Explicit detach by clearing the links vector. Idempotent (no-op on second call).
3. **Add `Drop` impl** — Logs tracepoint count being detached on drop for observability.
4. **Align non-Linux stub** — Rename `attach_stub()` to `attach(&mut ())` matching `UprobeManager`'s pattern.
5. **Make module cross-platform** — Remove `#[cfg(target_os = "linux")]` gate from `lib.rs` since the module has proper internal cfg gates already.
6. **Refactor integration test** — Use `TracepointManager::attach()` instead of raw aya API.
7. **Add unit tests** — Non-Linux attach error test, detach method signature test.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention