### PR TITLE
[AAASM-148] ✨ (proxy): Implement per-provider LLM body extractors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,8 @@ dependencies = [
  "rcgen",
  "rustls",
  "rustls-native-certs",
+ "serde",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "time",
@@ -199,18 +201,6 @@ dependencies = [
  "getrandom 0.2.17",
  "once_cell",
  "version_check",
-]
-
-[[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
 ]
 
 [[package]]
@@ -1430,7 +1420,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.8",
+ "ahash",
 ]
 
 [[package]]
@@ -1998,12 +1988,12 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.3"
+version = "0.24.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+checksum = "b7cd3e9eb685089c784f5769b1197d348c7274bc20d4e1349650f63b91b6d0af"
 dependencies = [
- "ahash 0.8.12",
  "portable-atomic",
+ "rapidhash",
 ]
 
 [[package]]
@@ -2855,6 +2845,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3137,9 +3136,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/aa-proxy/Cargo.toml
+++ b/aa-proxy/Cargo.toml
@@ -25,6 +25,8 @@ rustls-native-certs = "0.8"
 rcgen        = { version = "0.13", features = ["x509-parser"] }
 time         = "0.3"
 lru          = "0.16"
+serde        = { version = "1", features = ["derive"] }
+serde_json   = "1"
 anyhow       = "1"
 thiserror    = "2"
 dirs                = "6"

--- a/aa-proxy/src/intercept/extract.rs
+++ b/aa-proxy/src/intercept/extract.rs
@@ -1,0 +1,30 @@
+//! Per-provider LLM request/response body extractors.
+//!
+//! Each extractor is a pure function that takes raw body bytes and returns
+//! [`LlmFields`] with the audit-relevant fields extracted from the JSON payload.
+
+use thiserror::Error;
+
+/// Audit-relevant fields extracted from an LLM API request or response body.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LlmFields {
+    /// Model identifier (e.g. `"gpt-4"`, `"claude-3-opus-20240229"`).
+    pub model: String,
+    /// Number of prompt/input tokens (from request estimate or response usage).
+    pub prompt_tokens: Option<u64>,
+    /// Number of completion/output tokens (from response usage only).
+    pub completion_tokens: Option<u64>,
+    /// Number of messages in the request conversation.
+    pub messages_count: u32,
+}
+
+/// Errors that can occur during body extraction.
+#[derive(Debug, Error)]
+pub enum ExtractionError {
+    /// The body is not valid JSON.
+    #[error("invalid JSON: {0}")]
+    InvalidJson(#[from] serde_json::Error),
+    /// The JSON is valid but does not match the expected provider schema.
+    #[error("unrecognized format: {reason}")]
+    UnrecognizedFormat { reason: String },
+}

--- a/aa-proxy/src/intercept/extract.rs
+++ b/aa-proxy/src/intercept/extract.rs
@@ -54,6 +54,99 @@ pub fn extract_openai(body: &[u8]) -> Result<LlmFields, ExtractionError> {
     })
 }
 
+// ── Anthropic ───────────────────────────────────────────────────────────
+
+/// Extract LLM fields from an Anthropic API request or response body.
+///
+/// Anthropic uses `input_tokens`/`output_tokens` in its `usage` block
+/// (unlike OpenAI's `prompt_tokens`/`completion_tokens`).
+pub fn extract_anthropic(body: &[u8]) -> Result<LlmFields, ExtractionError> {
+    #[derive(serde::Deserialize)]
+    struct AnthropicBody {
+        model: Option<String>,
+        messages: Option<Vec<serde_json::Value>>,
+        usage: Option<AnthropicUsage>,
+    }
+    #[derive(serde::Deserialize)]
+    struct AnthropicUsage {
+        input_tokens: Option<u64>,
+        output_tokens: Option<u64>,
+    }
+
+    let parsed: AnthropicBody = serde_json::from_slice(body)?;
+
+    let model = parsed.model.unwrap_or_default();
+    if model.is_empty() && parsed.messages.is_none() && parsed.usage.is_none() {
+        return Err(ExtractionError::UnrecognizedFormat {
+            reason: "no model, messages, or usage fields found".into(),
+        });
+    }
+
+    Ok(LlmFields {
+        model,
+        prompt_tokens: parsed.usage.as_ref().and_then(|u| u.input_tokens),
+        completion_tokens: parsed.usage.as_ref().and_then(|u| u.output_tokens),
+        messages_count: parsed.messages.map(|m| m.len() as u32).unwrap_or(0),
+    })
+}
+
+// ── Cohere ──────────────────────────────────────────────────────────────
+
+/// Extract LLM fields from a Cohere API request or response body.
+///
+/// Cohere's chat endpoint uses `message` (singular string) instead of
+/// `messages` (array), and reports tokens in `meta.tokens`.
+pub fn extract_cohere(body: &[u8]) -> Result<LlmFields, ExtractionError> {
+    #[derive(serde::Deserialize)]
+    struct CohereBody {
+        model: Option<String>,
+        message: Option<String>,
+        chat_history: Option<Vec<serde_json::Value>>,
+        meta: Option<CohereMeta>,
+    }
+    #[derive(serde::Deserialize)]
+    struct CohereMeta {
+        tokens: Option<CohereTokens>,
+    }
+    #[derive(serde::Deserialize)]
+    struct CohereTokens {
+        input_tokens: Option<u64>,
+        output_tokens: Option<u64>,
+    }
+
+    let parsed: CohereBody = serde_json::from_slice(body)?;
+
+    let model = parsed.model.unwrap_or_default();
+    if model.is_empty() && parsed.message.is_none() && parsed.meta.is_none() {
+        return Err(ExtractionError::UnrecognizedFormat {
+            reason: "no model, message, or meta fields found".into(),
+        });
+    }
+
+    // Count messages: 1 for the current message + chat_history length.
+    let history_count = parsed.chat_history.map(|h| h.len() as u32).unwrap_or(0);
+    let messages_count = if parsed.message.is_some() {
+        history_count + 1
+    } else {
+        history_count
+    };
+
+    Ok(LlmFields {
+        model,
+        prompt_tokens: parsed
+            .meta
+            .as_ref()
+            .and_then(|m| m.tokens.as_ref())
+            .and_then(|t| t.input_tokens),
+        completion_tokens: parsed
+            .meta
+            .as_ref()
+            .and_then(|m| m.tokens.as_ref())
+            .and_then(|t| t.output_tokens),
+        messages_count,
+    })
+}
+
 /// Errors that can occur during body extraction.
 #[derive(Debug, Error)]
 pub enum ExtractionError {

--- a/aa-proxy/src/intercept/extract.rs
+++ b/aa-proxy/src/intercept/extract.rs
@@ -18,6 +18,42 @@ pub struct LlmFields {
     pub messages_count: u32,
 }
 
+// ── OpenAI ──────────────────────────────────────────────────────────────
+
+/// Extract LLM fields from an OpenAI API request or response body.
+///
+/// Handles both request payloads (`{"model":"...","messages":[...]}`) and
+/// response payloads with usage stats (`{"usage":{"prompt_tokens":...}}`).
+pub fn extract_openai(body: &[u8]) -> Result<LlmFields, ExtractionError> {
+    #[derive(serde::Deserialize)]
+    struct OpenAiBody {
+        model: Option<String>,
+        messages: Option<Vec<serde_json::Value>>,
+        usage: Option<OpenAiUsage>,
+    }
+    #[derive(serde::Deserialize)]
+    struct OpenAiUsage {
+        prompt_tokens: Option<u64>,
+        completion_tokens: Option<u64>,
+    }
+
+    let parsed: OpenAiBody = serde_json::from_slice(body)?;
+
+    let model = parsed.model.unwrap_or_default();
+    if model.is_empty() && parsed.messages.is_none() && parsed.usage.is_none() {
+        return Err(ExtractionError::UnrecognizedFormat {
+            reason: "no model, messages, or usage fields found".into(),
+        });
+    }
+
+    Ok(LlmFields {
+        model,
+        prompt_tokens: parsed.usage.as_ref().and_then(|u| u.prompt_tokens),
+        completion_tokens: parsed.usage.as_ref().and_then(|u| u.completion_tokens),
+        messages_count: parsed.messages.map(|m| m.len() as u32).unwrap_or(0),
+    })
+}
+
 /// Errors that can occur during body extraction.
 #[derive(Debug, Error)]
 pub enum ExtractionError {

--- a/aa-proxy/src/intercept/extract.rs
+++ b/aa-proxy/src/intercept/extract.rs
@@ -157,3 +157,137 @@ pub enum ExtractionError {
     #[error("unrecognized format: {reason}")]
     UnrecognizedFormat { reason: String },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── OpenAI tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn openai_minimal_request() {
+        let body = br#"{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}"#;
+        let fields = extract_openai(body).unwrap();
+        assert_eq!(fields.model, "gpt-4");
+        assert_eq!(fields.messages_count, 1);
+        assert_eq!(fields.prompt_tokens, None);
+        assert_eq!(fields.completion_tokens, None);
+    }
+
+    #[test]
+    fn openai_response_with_usage() {
+        let body = br#"{
+            "model": "gpt-4",
+            "choices": [],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 20}
+        }"#;
+        let fields = extract_openai(body).unwrap();
+        assert_eq!(fields.model, "gpt-4");
+        assert_eq!(fields.prompt_tokens, Some(10));
+        assert_eq!(fields.completion_tokens, Some(20));
+    }
+
+    #[test]
+    fn openai_malformed_json_returns_error() {
+        let body = b"not json";
+        let err = extract_openai(body).unwrap_err();
+        assert!(matches!(err, ExtractionError::InvalidJson(_)));
+    }
+
+    #[test]
+    fn openai_empty_object_returns_unrecognized() {
+        let body = br#"{}"#;
+        let err = extract_openai(body).unwrap_err();
+        assert!(matches!(err, ExtractionError::UnrecognizedFormat { .. }));
+    }
+
+    // ── Anthropic tests ─────────────────────────────────────────────────
+
+    #[test]
+    fn anthropic_minimal_request() {
+        let body = br#"{"model":"claude-3-opus-20240229","messages":[{"role":"user","content":"hi"}]}"#;
+        let fields = extract_anthropic(body).unwrap();
+        assert_eq!(fields.model, "claude-3-opus-20240229");
+        assert_eq!(fields.messages_count, 1);
+        assert_eq!(fields.prompt_tokens, None);
+    }
+
+    #[test]
+    fn anthropic_response_with_usage() {
+        let body = br#"{
+            "model": "claude-3-opus-20240229",
+            "content": [],
+            "usage": {"input_tokens": 15, "output_tokens": 30}
+        }"#;
+        let fields = extract_anthropic(body).unwrap();
+        assert_eq!(fields.model, "claude-3-opus-20240229");
+        assert_eq!(fields.prompt_tokens, Some(15));
+        assert_eq!(fields.completion_tokens, Some(30));
+    }
+
+    #[test]
+    fn anthropic_malformed_json_returns_error() {
+        let body = b"{invalid";
+        let err = extract_anthropic(body).unwrap_err();
+        assert!(matches!(err, ExtractionError::InvalidJson(_)));
+    }
+
+    #[test]
+    fn anthropic_empty_object_returns_unrecognized() {
+        let body = br#"{}"#;
+        let err = extract_anthropic(body).unwrap_err();
+        assert!(matches!(err, ExtractionError::UnrecognizedFormat { .. }));
+    }
+
+    // ── Cohere tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn cohere_minimal_request() {
+        let body = br#"{"model":"command-r-plus","message":"hello"}"#;
+        let fields = extract_cohere(body).unwrap();
+        assert_eq!(fields.model, "command-r-plus");
+        assert_eq!(fields.messages_count, 1);
+        assert_eq!(fields.prompt_tokens, None);
+    }
+
+    #[test]
+    fn cohere_response_with_meta_tokens() {
+        let body = br#"{
+            "model": "command-r-plus",
+            "text": "response",
+            "meta": {"tokens": {"input_tokens": 5, "output_tokens": 12}}
+        }"#;
+        let fields = extract_cohere(body).unwrap();
+        assert_eq!(fields.model, "command-r-plus");
+        assert_eq!(fields.prompt_tokens, Some(5));
+        assert_eq!(fields.completion_tokens, Some(12));
+    }
+
+    #[test]
+    fn cohere_with_chat_history() {
+        let body = br#"{
+            "model": "command-r",
+            "message": "next question",
+            "chat_history": [
+                {"role": "USER", "message": "first"},
+                {"role": "CHATBOT", "message": "reply"}
+            ]
+        }"#;
+        let fields = extract_cohere(body).unwrap();
+        assert_eq!(fields.messages_count, 3); // 2 history + 1 current
+    }
+
+    #[test]
+    fn cohere_malformed_json_returns_error() {
+        let body = b"<<<";
+        let err = extract_cohere(body).unwrap_err();
+        assert!(matches!(err, ExtractionError::InvalidJson(_)));
+    }
+
+    #[test]
+    fn cohere_empty_object_returns_unrecognized() {
+        let body = br#"{}"#;
+        let err = extract_cohere(body).unwrap_err();
+        assert!(matches!(err, ExtractionError::UnrecognizedFormat { .. }));
+    }
+}

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -5,9 +5,11 @@ pub mod event;
 pub mod extract;
 
 use crate::error::ProxyError;
+use crate::intercept::detect::LlmApiPattern;
+use crate::intercept::extract::{extract_anthropic, extract_cohere, extract_openai, ExtractionError, LlmFields};
 
 /// Inspects a decrypted HTTP request/response pair, decides whether it is an
-/// LLM API call, and emits a [`event::ProxyEvent`] if so.
+/// LLM API call, and extracts audit-relevant fields from the body.
 pub struct Interceptor;
 
 impl Interceptor {
@@ -16,20 +18,61 @@ impl Interceptor {
         Self
     }
 
-    /// Inspect an intercepted exchange and, if it matches an LLM API pattern,
-    /// log and return the corresponding [`event::ProxyEvent`].
+    /// Inspect an intercepted exchange, extract LLM fields from the body
+    /// (if available), and log the result.
     ///
-    /// Full policy evaluation (forwarding to `aa-gateway`) will be added in a
-    /// future ticket. For now this captures and logs the event.
-    pub async fn intercept(&self, event: event::ProxyEvent) -> Result<(), ProxyError> {
+    /// Full policy evaluation (forwarding to `aa-gateway`) and pipeline
+    /// integration (`broadcast::Sender<PipelineEvent>`) will be added in a
+    /// future ticket. For now this extracts and logs.
+    pub async fn intercept(&self, event: &event::ProxyEvent) -> Result<Option<LlmFields>, ProxyError> {
+        // Non-LLM traffic is passed through without extraction.
+        if event.pattern == LlmApiPattern::Unknown {
+            tracing::debug!(method = %event.method, path = %event.path, "non-LLM traffic, skipping");
+            return Ok(None);
+        }
+
+        // Pick the body to extract from: prefer response (has usage stats),
+        // fall back to request.
+        let body = event.response_body.as_ref().or(event.request_body.as_ref());
+
+        let fields = match body {
+            Some(bytes) => match Self::extract_for_pattern(&event.pattern, bytes) {
+                Ok(f) => Some(f),
+                Err(e) => {
+                    tracing::warn!(
+                        pattern = ?event.pattern,
+                        error = %e,
+                        "failed to extract LLM fields from body"
+                    );
+                    None
+                }
+            },
+            None => None,
+        };
+
         tracing::info!(
             agent_id = event.agent_id.as_deref().unwrap_or("<unknown>"),
             pattern = ?event.pattern,
             method = %event.method,
             path = %event.path,
+            model = fields.as_ref().map(|f| f.model.as_str()).unwrap_or("<unknown>"),
+            messages = fields.as_ref().map(|f| f.messages_count).unwrap_or(0),
             "intercepted LLM API call"
         );
-        Ok(())
+
+        Ok(fields)
+    }
+
+    /// Select the correct extractor based on the detected API pattern.
+    fn extract_for_pattern(pattern: &LlmApiPattern, body: &[u8]) -> Result<LlmFields, ExtractionError> {
+        match pattern {
+            LlmApiPattern::OpenAi => extract_openai(body),
+            LlmApiPattern::Anthropic => extract_anthropic(body),
+            LlmApiPattern::Cohere => extract_cohere(body),
+            LlmApiPattern::Unknown => Err(ExtractionError::UnrecognizedFormat {
+                reason: "unknown provider".into(),
+            }),
+        }
     }
 }
 
@@ -62,22 +105,25 @@ mod tests {
     #[tokio::test]
     async fn intercept_openai_event_succeeds() {
         let interceptor = Interceptor::new();
-        let result = interceptor.intercept(make_event(LlmApiPattern::OpenAi)).await;
+        let result = interceptor.intercept(&make_event(LlmApiPattern::OpenAi)).await;
         assert!(result.is_ok());
     }
 
     #[tokio::test]
     async fn intercept_anthropic_event_succeeds() {
         let interceptor = Interceptor::new();
-        let result = interceptor.intercept(make_event(LlmApiPattern::Anthropic)).await;
+        let result = interceptor.intercept(&make_event(LlmApiPattern::Anthropic)).await;
         assert!(result.is_ok());
     }
 
     #[tokio::test]
-    async fn intercept_unknown_event_succeeds() {
+    async fn intercept_unknown_returns_none() {
         let interceptor = Interceptor::new();
-        let result = interceptor.intercept(make_event(LlmApiPattern::Unknown)).await;
-        assert!(result.is_ok());
+        let result = interceptor
+            .intercept(&make_event(LlmApiPattern::Unknown))
+            .await
+            .unwrap();
+        assert!(result.is_none(), "unknown pattern should skip extraction");
     }
 
     #[tokio::test]
@@ -85,6 +131,6 @@ mod tests {
         let interceptor = Interceptor::new();
         let mut event = make_event(LlmApiPattern::OpenAi);
         event.agent_id = None;
-        assert!(interceptor.intercept(event).await.is_ok());
+        assert!(interceptor.intercept(&event).await.is_ok());
     }
 }

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod detect;
 pub mod event;
+pub mod extract;
 
 use crate::error::ProxyError;
 

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -86,6 +86,8 @@ impl Default for Interceptor {
 mod tests {
     use std::time::SystemTime;
 
+    use bytes::Bytes;
+
     use super::*;
     use crate::intercept::detect::LlmApiPattern;
     use crate::intercept::event::ProxyEvent;
@@ -132,5 +134,95 @@ mod tests {
         let mut event = make_event(LlmApiPattern::OpenAi);
         event.agent_id = None;
         assert!(interceptor.intercept(&event).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn intercept_openai_with_body_extracts_fields() {
+        let interceptor = Interceptor::new();
+        let mut event = make_event(LlmApiPattern::OpenAi);
+        event.response_body = Some(Bytes::from(
+            r#"{"model":"gpt-4","usage":{"prompt_tokens":10,"completion_tokens":20}}"#,
+        ));
+        let fields = interceptor.intercept(&event).await.unwrap().unwrap();
+        assert_eq!(fields.model, "gpt-4");
+        assert_eq!(fields.prompt_tokens, Some(10));
+        assert_eq!(fields.completion_tokens, Some(20));
+    }
+
+    #[tokio::test]
+    async fn intercept_anthropic_with_body_extracts_fields() {
+        let interceptor = Interceptor::new();
+        let mut event = make_event(LlmApiPattern::Anthropic);
+        event.response_body = Some(Bytes::from(
+            r#"{"model":"claude-3-opus-20240229","usage":{"input_tokens":15,"output_tokens":30}}"#,
+        ));
+        let fields = interceptor.intercept(&event).await.unwrap().unwrap();
+        assert_eq!(fields.model, "claude-3-opus-20240229");
+        assert_eq!(fields.prompt_tokens, Some(15));
+        assert_eq!(fields.completion_tokens, Some(30));
+    }
+
+    #[tokio::test]
+    async fn intercept_cohere_with_body_extracts_fields() {
+        let interceptor = Interceptor::new();
+        let mut event = make_event(LlmApiPattern::Cohere);
+        event.response_body = Some(Bytes::from(
+            r#"{"model":"command-r-plus","message":"hello","meta":{"tokens":{"input_tokens":5,"output_tokens":12}}}"#,
+        ));
+        let fields = interceptor.intercept(&event).await.unwrap().unwrap();
+        assert_eq!(fields.model, "command-r-plus");
+        assert_eq!(fields.prompt_tokens, Some(5));
+        assert_eq!(fields.completion_tokens, Some(12));
+        assert_eq!(fields.messages_count, 1);
+    }
+
+    #[tokio::test]
+    async fn intercept_prefers_response_body_over_request() {
+        let interceptor = Interceptor::new();
+        let mut event = make_event(LlmApiPattern::OpenAi);
+        event.request_body = Some(Bytes::from(
+            r#"{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}"#,
+        ));
+        event.response_body = Some(Bytes::from(
+            r#"{"model":"gpt-4","usage":{"prompt_tokens":10,"completion_tokens":20}}"#,
+        ));
+        let fields = interceptor.intercept(&event).await.unwrap().unwrap();
+        // Response body was used — it has usage stats, not messages
+        assert_eq!(fields.prompt_tokens, Some(10));
+        assert_eq!(fields.completion_tokens, Some(20));
+        assert_eq!(fields.messages_count, 0);
+    }
+
+    #[tokio::test]
+    async fn intercept_falls_back_to_request_body() {
+        let interceptor = Interceptor::new();
+        let mut event = make_event(LlmApiPattern::OpenAi);
+        event.request_body = Some(Bytes::from(
+            r#"{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}"#,
+        ));
+        event.response_body = None;
+        let fields = interceptor.intercept(&event).await.unwrap().unwrap();
+        assert_eq!(fields.model, "gpt-4");
+        assert_eq!(fields.messages_count, 1);
+        assert_eq!(fields.prompt_tokens, None);
+    }
+
+    #[tokio::test]
+    async fn intercept_with_none_body_returns_none() {
+        let interceptor = Interceptor::new();
+        let event = make_event(LlmApiPattern::OpenAi);
+        // Both request_body and response_body are None
+        let result = interceptor.intercept(&event).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn intercept_with_malformed_body_returns_none() {
+        let interceptor = Interceptor::new();
+        let mut event = make_event(LlmApiPattern::OpenAi);
+        event.response_body = Some(Bytes::from("not json"));
+        // Malformed body logs a warning and returns None (not an error)
+        let result = interceptor.intercept(&event).await.unwrap();
+        assert!(result.is_none());
     }
 }

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -182,7 +182,7 @@ impl ProxyServer {
                     response_body: None,
                     timestamp: SystemTime::now(),
                 };
-                self.interceptor.intercept(event).await?;
+                self.interceptor.intercept(&event).await?;
             }
 
             // Bidirectional copy between client and upstream.


### PR DESCRIPTION
## Description

Implement per-provider LLM request/response body extractors for the `aa-proxy` interceptor. Adds `extract_openai()`, `extract_anthropic()`, and `extract_cohere()` functions that parse JSON payloads into a unified `LlmFields` struct containing model name, token usage, and message count. Wires extractors into `Interceptor::intercept()` with pattern-based dispatch, preferring response bodies (which contain usage stats) over request bodies.

This is Phase A of the interceptor extraction work. Phase B (pipeline integration via `broadcast::Sender<PipelineEvent>`) will follow in a separate ticket.

## Type of Change

- [x] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [ ] No
- [x] Yes (describe below)

`Interceptor::intercept()` signature changed:
- Parameter: `event: ProxyEvent` → `event: &ProxyEvent` (borrow instead of move)
- Return type: `Result<(), ProxyError>` → `Result<Option<LlmFields>, ProxyError>`

The single caller in `proxy/mod.rs` is updated in this PR.

## Related Issues

- Related Jira ticket: AAASM-148
- Parent epic: AAASM-4 (Three-Layer Agent Interception)

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

**21 new tests added:**
- 13 extractor unit tests (OpenAI/Anthropic/Cohere: minimal request, full usage, malformed JSON, empty object, plus Cohere chat history)
- 8 Interceptor-level tests (body extraction for each provider, response-over-request preference, request fallback, None body, malformed body graceful handling)

All 47 unit tests + 5 integration tests pass. `cargo fmt` and `cargo clippy` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention