### PR TITLE
[AAASM-150] 🐛 (runtime): Wire correlation engine into event loop

### DIFF
--- a/aa-runtime/src/config.rs
+++ b/aa-runtime/src/config.rs
@@ -76,6 +76,18 @@ pub struct RuntimeConfig {
     /// gateway via [`crate::gateway_client::GatewayClient`] instead of
     /// evaluating locally with [`crate::policy::PolicyRules`].
     pub gateway_endpoint: Option<String>,
+
+    /// Sliding window duration in milliseconds for the correlation engine.
+    ///
+    /// Read from `AA_CORRELATION_WINDOW_MS`. Defaults to `5_000`.
+    /// Zero falls back to the default.
+    pub correlation_window_ms: u64,
+
+    /// Interval in milliseconds between correlation and eviction runs.
+    ///
+    /// Read from `AA_CORRELATION_INTERVAL_MS`. Defaults to `1_000`.
+    /// Zero falls back to the default.
+    pub correlation_interval_ms: u64,
 }
 
 impl RuntimeConfig {
@@ -100,6 +112,8 @@ impl RuntimeConfig {
     /// | `AA_METRICS_ADDR` | `String` | `"0.0.0.0:8080"` |
     /// | `AA_POLICY_PATH` | `Option<PathBuf>` | `Some("/etc/aa/policy.toml")` |
     /// | `AA_GATEWAY_ENDPOINT` | `Option<String>` | `None` |
+    /// | `AA_CORRELATION_WINDOW_MS` | `u64` | `5_000` |
+    /// | `AA_CORRELATION_INTERVAL_MS` | `u64` | `1_000` |
     pub fn from_env() -> Result<Self, String> {
         let agent_id = std::env::var("AA_AGENT_ID").map_err(|_| "AA_AGENT_ID is required but not set".to_string())?;
 
@@ -161,6 +175,18 @@ impl RuntimeConfig {
 
         let gateway_endpoint = std::env::var("AA_GATEWAY_ENDPOINT").ok().filter(|v| !v.is_empty());
 
+        let correlation_window_ms = std::env::var("AA_CORRELATION_WINDOW_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(5_000);
+
+        let correlation_interval_ms = std::env::var("AA_CORRELATION_INTERVAL_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(1_000);
+
         Ok(Self {
             agent_id,
             worker_threads,
@@ -173,6 +199,8 @@ impl RuntimeConfig {
             metrics_addr,
             policy_path,
             gateway_endpoint,
+            correlation_window_ms,
+            correlation_interval_ms,
         })
     }
 }
@@ -564,5 +592,65 @@ mod tests {
 
         std::env::remove_var("AA_AGENT_ID");
         std::env::remove_var("AA_GATEWAY_ENDPOINT");
+    }
+
+    #[test]
+    fn correlation_defaults_when_env_vars_absent() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AA_AGENT_ID", "agent-corr-defaults");
+        std::env::remove_var("AA_CORRELATION_WINDOW_MS");
+        std::env::remove_var("AA_CORRELATION_INTERVAL_MS");
+
+        let config = RuntimeConfig::from_env().unwrap();
+
+        assert_eq!(config.correlation_window_ms, 5_000);
+        assert_eq!(config.correlation_interval_ms, 1_000);
+
+        std::env::remove_var("AA_AGENT_ID");
+    }
+
+    #[test]
+    fn reads_correlation_window_ms_from_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AA_AGENT_ID", "agent-corr-win");
+        std::env::set_var("AA_CORRELATION_WINDOW_MS", "10000");
+
+        let config = RuntimeConfig::from_env().unwrap();
+
+        assert_eq!(config.correlation_window_ms, 10_000);
+
+        std::env::remove_var("AA_AGENT_ID");
+        std::env::remove_var("AA_CORRELATION_WINDOW_MS");
+    }
+
+    #[test]
+    fn reads_correlation_interval_ms_from_env() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AA_AGENT_ID", "agent-corr-int");
+        std::env::set_var("AA_CORRELATION_INTERVAL_MS", "2000");
+
+        let config = RuntimeConfig::from_env().unwrap();
+
+        assert_eq!(config.correlation_interval_ms, 2_000);
+
+        std::env::remove_var("AA_AGENT_ID");
+        std::env::remove_var("AA_CORRELATION_INTERVAL_MS");
+    }
+
+    #[test]
+    fn correlation_rejects_zero_values() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AA_AGENT_ID", "agent-corr-zero");
+        std::env::set_var("AA_CORRELATION_WINDOW_MS", "0");
+        std::env::set_var("AA_CORRELATION_INTERVAL_MS", "0");
+
+        let config = RuntimeConfig::from_env().unwrap();
+
+        assert_eq!(config.correlation_window_ms, 5_000, "0 should fall back to default");
+        assert_eq!(config.correlation_interval_ms, 1_000, "0 should fall back to default");
+
+        std::env::remove_var("AA_AGENT_ID");
+        std::env::remove_var("AA_CORRELATION_WINDOW_MS");
+        std::env::remove_var("AA_CORRELATION_INTERVAL_MS");
     }
 }

--- a/aa-runtime/src/correlation/config.rs
+++ b/aa-runtime/src/correlation/config.rs
@@ -16,6 +16,22 @@ pub struct CorrelationConfig {
     pub eviction_interval_ms: u64,
 }
 
+impl CorrelationConfig {
+    /// Build a [`CorrelationConfig`] from the runtime-level configuration.
+    ///
+    /// Maps `RuntimeConfig::correlation_window_ms` → `window_ms` and
+    /// `RuntimeConfig::correlation_interval_ms` → `eviction_interval_ms`.
+    /// `max_window_size` keeps the compile-time default (`10_000`).
+    pub fn from_runtime_config(rc: &crate::config::RuntimeConfig) -> Self {
+        let defaults = Self::default();
+        Self {
+            window_ms: rc.correlation_window_ms,
+            max_window_size: defaults.max_window_size,
+            eviction_interval_ms: rc.correlation_interval_ms,
+        }
+    }
+}
+
 impl Default for CorrelationConfig {
     fn default() -> Self {
         Self {
@@ -43,5 +59,30 @@ mod tests {
         let config = CorrelationConfig::default();
         let cloned = config.clone();
         assert_eq!(cloned.window_ms, config.window_ms);
+    }
+
+    #[test]
+    fn from_runtime_config_maps_fields() {
+        let rc = crate::config::RuntimeConfig {
+            agent_id: "test".to_string(),
+            worker_threads: 0,
+            shutdown_timeout_secs: 30,
+            ipc_max_connections: 64,
+            pipeline_input_buffer: 10_000,
+            pipeline_batch_size: 100,
+            pipeline_flush_interval_ms: 100,
+            pipeline_broadcast_capacity: 1_024,
+            metrics_addr: "0.0.0.0:8080".to_string(),
+            policy_path: None,
+            gateway_endpoint: None,
+            correlation_window_ms: 8_000,
+            correlation_interval_ms: 2_000,
+        };
+
+        let config = CorrelationConfig::from_runtime_config(&rc);
+
+        assert_eq!(config.window_ms, 8_000);
+        assert_eq!(config.eviction_interval_ms, 2_000);
+        assert_eq!(config.max_window_size, 10_000, "max_window_size keeps default");
     }
 }

--- a/aa-runtime/src/correlation/mod.rs
+++ b/aa-runtime/src/correlation/mod.rs
@@ -101,8 +101,8 @@ fn extract_action_fields(detail: &Option<Detail>, action_type: ActionType) -> (S
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aa_proto::assembly::audit::v1::AuditEvent;
     use crate::pipeline::event::{EnrichedEvent, EventSource};
+    use aa_proto::assembly::audit::v1::AuditEvent;
 
     /// Helper to build an `EnrichedEvent` with the given source and action_type.
     fn make_enriched(source: EventSource, action_type: ActionType) -> EnrichedEvent {
@@ -186,10 +186,7 @@ mod tests {
         match result {
             CorrelationEvent::Intent(intent) => {
                 assert_eq!(intent.timestamp_ms, 1000);
-                assert_eq!(
-                    intent.event_id.to_string(),
-                    "550e8400-e29b-41d4-a716-446655440000"
-                );
+                assert_eq!(intent.event_id.to_string(), "550e8400-e29b-41d4-a716-446655440000");
             }
             _ => panic!("expected Intent"),
         }
@@ -202,10 +199,7 @@ mod tests {
         match result {
             CorrelationEvent::Action(action) => {
                 assert_eq!(action.timestamp_ms, 1000);
-                assert_eq!(
-                    action.event_id.to_string(),
-                    "550e8400-e29b-41d4-a716-446655440000"
-                );
+                assert_eq!(action.event_id.to_string(), "550e8400-e29b-41d4-a716-446655440000");
             }
             _ => panic!("expected Action"),
         }

--- a/aa-runtime/src/correlation/mod.rs
+++ b/aa-runtime/src/correlation/mod.rs
@@ -19,3 +19,81 @@ pub use event::{ActionEvent, CorrelationEvent, IntentEvent};
 pub use outcome::{CausalCorrelation, CorrelationOutcome};
 pub use pid::PidLineage;
 pub use window::SlidingWindow;
+
+use aa_proto::assembly::audit::v1::audit_event::Detail;
+use aa_proto::assembly::common::v1::ActionType;
+use uuid::Uuid;
+
+use crate::pipeline::event::{EnrichedEvent, EventSource};
+
+/// Convert an [`EnrichedEvent`] from the pipeline broadcast channel into a
+/// [`CorrelationEvent`] for ingestion by the correlation engine.
+///
+/// # Mapping rules
+///
+/// | Source   | ActionType                                    | Result          |
+/// |----------|-----------------------------------------------|-----------------|
+/// | SDK      | `LLM_CALL`, `TOOL_CALL`                       | `Intent`        |
+/// | eBPF     | `FILE_OPERATION`, `NETWORK_CALL`, `PROCESS_EXEC` | `Action`     |
+/// | *        | anything else                                 | `None`          |
+///
+/// Returns `None` for events that do not participate in causal correlation
+/// (e.g., policy violations, layer degradation, or proxy-sourced events that
+/// don't yet have a mapping).
+pub fn try_from_enriched(event: &EnrichedEvent) -> Option<CorrelationEvent> {
+    let action_type = ActionType::try_from(event.inner.action_type).ok()?;
+    let event_id = event.inner.event_id.parse::<Uuid>().unwrap_or_else(|_| Uuid::new_v4());
+    let timestamp_ms = event.received_at_ms as u64;
+    // TODO(AAASM-150): Proto does not carry PID — use 0 as placeholder until
+    // the AuditEvent schema is extended with a `pid` field.
+    let pid: u32 = 0;
+
+    match (&event.source, action_type) {
+        // SDK-sourced LLM and tool calls → intents
+        (EventSource::Sdk, ActionType::LlmCall) | (EventSource::Sdk, ActionType::ToolCall) => {
+            let (intent_text, action_keyword) = extract_intent_fields(&event.inner.detail, action_type);
+            Some(CorrelationEvent::Intent(IntentEvent {
+                event_id,
+                timestamp_ms,
+                pid,
+                intent_text,
+                action_keyword,
+            }))
+        }
+        // eBPF-sourced syscall actions → actions
+        (EventSource::EBpf, ActionType::FileOperation)
+        | (EventSource::EBpf, ActionType::NetworkCall)
+        | (EventSource::EBpf, ActionType::ProcessExec) => {
+            let (syscall, details) = extract_action_fields(&event.inner.detail, action_type);
+            Some(CorrelationEvent::Action(ActionEvent {
+                event_id,
+                timestamp_ms,
+                pid,
+                syscall,
+                details,
+            }))
+        }
+        _ => None,
+    }
+}
+
+/// Extract intent-side fields from the audit event detail payload.
+fn extract_intent_fields(detail: &Option<Detail>, action_type: ActionType) -> (String, String) {
+    let action_keyword = action_type.as_str_name().to_string();
+    let intent_text = match detail {
+        Some(Detail::LlmCall(d)) => format!("model={} provider={}", d.model, d.provider),
+        Some(Detail::ToolCall(d)) => format!("tool={} source={}", d.tool_name, d.tool_source),
+        _ => String::new(),
+    };
+    (intent_text, action_keyword)
+}
+
+/// Extract action-side fields from the audit event detail payload.
+fn extract_action_fields(detail: &Option<Detail>, action_type: ActionType) -> (String, String) {
+    match detail {
+        Some(Detail::FileOp(d)) => (d.operation.clone(), d.path.clone()),
+        Some(Detail::Network(d)) => (d.protocol.clone(), format!("{}:{}", d.host, d.port)),
+        Some(Detail::Process(d)) => (d.command.clone(), d.args.join(" ")),
+        _ => (action_type.as_str_name().to_string(), String::new()),
+    }
+}

--- a/aa-runtime/src/correlation/mod.rs
+++ b/aa-runtime/src/correlation/mod.rs
@@ -97,3 +97,117 @@ fn extract_action_fields(detail: &Option<Detail>, action_type: ActionType) -> (S
         _ => (action_type.as_str_name().to_string(), String::new()),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aa_proto::assembly::audit::v1::AuditEvent;
+    use crate::pipeline::event::{EnrichedEvent, EventSource};
+
+    /// Helper to build an `EnrichedEvent` with the given source and action_type.
+    fn make_enriched(source: EventSource, action_type: ActionType) -> EnrichedEvent {
+        EnrichedEvent {
+            inner: AuditEvent {
+                event_id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
+                action_type: action_type as i32,
+                ..AuditEvent::default()
+            },
+            received_at_ms: 1000,
+            source,
+            agent_id: "test-agent".to_string(),
+            connection_id: 1,
+            sequence_number: 0,
+        }
+    }
+
+    #[test]
+    fn sdk_tool_call_produces_intent() {
+        let event = make_enriched(EventSource::Sdk, ActionType::ToolCall);
+        let result = try_from_enriched(&event);
+        assert!(matches!(result, Some(CorrelationEvent::Intent(_))));
+    }
+
+    #[test]
+    fn sdk_llm_call_produces_intent() {
+        let event = make_enriched(EventSource::Sdk, ActionType::LlmCall);
+        let result = try_from_enriched(&event);
+        assert!(matches!(result, Some(CorrelationEvent::Intent(_))));
+    }
+
+    #[test]
+    fn ebpf_file_operation_produces_action() {
+        let event = make_enriched(EventSource::EBpf, ActionType::FileOperation);
+        let result = try_from_enriched(&event);
+        assert!(matches!(result, Some(CorrelationEvent::Action(_))));
+    }
+
+    #[test]
+    fn ebpf_network_call_produces_action() {
+        let event = make_enriched(EventSource::EBpf, ActionType::NetworkCall);
+        let result = try_from_enriched(&event);
+        assert!(matches!(result, Some(CorrelationEvent::Action(_))));
+    }
+
+    #[test]
+    fn ebpf_process_exec_produces_action() {
+        let event = make_enriched(EventSource::EBpf, ActionType::ProcessExec);
+        let result = try_from_enriched(&event);
+        assert!(matches!(result, Some(CorrelationEvent::Action(_))));
+    }
+
+    #[test]
+    fn sdk_file_operation_returns_none() {
+        let event = make_enriched(EventSource::Sdk, ActionType::FileOperation);
+        assert!(try_from_enriched(&event).is_none());
+    }
+
+    #[test]
+    fn ebpf_llm_call_returns_none() {
+        let event = make_enriched(EventSource::EBpf, ActionType::LlmCall);
+        assert!(try_from_enriched(&event).is_none());
+    }
+
+    #[test]
+    fn proxy_source_returns_none() {
+        let event = make_enriched(EventSource::Proxy, ActionType::ToolCall);
+        assert!(try_from_enriched(&event).is_none());
+    }
+
+    #[test]
+    fn unspecified_action_type_returns_none() {
+        let event = make_enriched(EventSource::Sdk, ActionType::ActionUnspecified);
+        assert!(try_from_enriched(&event).is_none());
+    }
+
+    #[test]
+    fn intent_preserves_timestamp_and_event_id() {
+        let event = make_enriched(EventSource::Sdk, ActionType::ToolCall);
+        let result = try_from_enriched(&event).unwrap();
+        match result {
+            CorrelationEvent::Intent(intent) => {
+                assert_eq!(intent.timestamp_ms, 1000);
+                assert_eq!(
+                    intent.event_id.to_string(),
+                    "550e8400-e29b-41d4-a716-446655440000"
+                );
+            }
+            _ => panic!("expected Intent"),
+        }
+    }
+
+    #[test]
+    fn action_preserves_timestamp_and_event_id() {
+        let event = make_enriched(EventSource::EBpf, ActionType::FileOperation);
+        let result = try_from_enriched(&event).unwrap();
+        match result {
+            CorrelationEvent::Action(action) => {
+                assert_eq!(action.timestamp_ms, 1000);
+                assert_eq!(
+                    action.event_id.to_string(),
+                    "550e8400-e29b-41d4-a716-446655440000"
+                );
+            }
+            _ => panic!("expected Action"),
+        }
+    }
+}

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -494,6 +494,8 @@ mod tests {
             metrics_addr: "0.0.0.0:8080".to_string(),
             policy_path: None,
             gateway_endpoint: None,
+            correlation_window_ms: 5_000,
+            correlation_interval_ms: 1_000,
         };
 
         let pipeline_config = PipelineConfig::from_runtime_config(&runtime_config);

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -381,10 +381,10 @@ mod tests {
     /// the correlation engine and verify that correlate() produces outcomes.
     #[tokio::test]
     async fn correlation_subscriber_ingests_and_correlates() {
-        use aa_proto::assembly::audit::v1::AuditEvent;
-        use aa_proto::assembly::common::v1::ActionType;
         use crate::correlation::{CorrelationConfig, CorrelationEngine};
         use crate::pipeline::event::{EnrichedEvent, EventSource};
+        use aa_proto::assembly::audit::v1::AuditEvent;
+        use aa_proto::assembly::common::v1::ActionType;
 
         // Short window and interval for fast test execution.
         let config = CorrelationConfig {
@@ -441,12 +441,11 @@ mod tests {
     /// convert it.
     #[tokio::test]
     async fn broadcast_channel_delivers_to_correlation() {
+        use crate::pipeline::event::{EnrichedEvent, EventSource, PipelineEvent};
         use aa_proto::assembly::audit::v1::AuditEvent;
         use aa_proto::assembly::common::v1::ActionType;
-        use crate::pipeline::event::{EnrichedEvent, EventSource, PipelineEvent};
 
-        let (tx, mut rx) =
-            tokio::sync::broadcast::channel::<PipelineEvent>(16);
+        let (tx, mut rx) = tokio::sync::broadcast::channel::<PipelineEvent>(16);
 
         let enriched = EnrichedEvent {
             inner: AuditEvent {

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -94,9 +94,7 @@ pub async fn run(config: RuntimeConfig) {
         tokio::sync::mpsc::channel::<(u64, crate::ipc::IpcFrame)>(pipeline_config.input_buffer);
 
     // Create the broadcast channel for fan-out to downstream subscribers.
-    // The leading `_broadcast_rx` keeps the channel alive until real subscribers
-    // are wired in AAASM-32+.
-    let (broadcast_tx, _broadcast_rx) =
+    let (broadcast_tx, correlation_rx) =
         tokio::sync::broadcast::channel::<crate::pipeline::PipelineEvent>(pipeline_config.broadcast_capacity);
 
     // Shared metrics — future health/metrics endpoints will receive an Arc clone.
@@ -159,6 +157,79 @@ pub async fn run(config: RuntimeConfig) {
             .await;
         });
         tracing::info!("pipeline task spawned");
+    }
+
+    // Spawn the correlation engine subscriber task.
+    {
+        let corr_config = crate::correlation::CorrelationConfig::from_runtime_config(&config);
+        let corr_interval = Duration::from_millis(corr_config.eviction_interval_ms);
+        let mut engine = crate::correlation::CorrelationEngine::new(corr_config);
+        let corr_token = token.clone();
+        let mut corr_rx = correlation_rx;
+        tracker.spawn(async move {
+            let mut ticker = tokio::time::interval(corr_interval);
+            loop {
+                tokio::select! {
+                    _ = corr_token.cancelled() => {
+                        tracing::info!("correlation subscriber shutting down");
+                        break;
+                    }
+                    _ = ticker.tick() => {
+                        let now_ms = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap_or_default()
+                            .as_millis() as u64;
+                        let outcomes = engine.correlate();
+                        for outcome in &outcomes {
+                            match outcome {
+                                crate::correlation::CorrelationOutcome::Matched(c) => {
+                                    tracing::info!(
+                                        intent = %c.intent_event_id,
+                                        action = %c.action_event_id,
+                                        strength = c.correlation_strength,
+                                        delta_ms = c.time_delta_ms,
+                                        "correlation matched"
+                                    );
+                                }
+                                crate::correlation::CorrelationOutcome::UnexpectedAction { action_event_id } => {
+                                    tracing::warn!(
+                                        action = %action_event_id,
+                                        "unexpected action — no matching intent"
+                                    );
+                                }
+                                crate::correlation::CorrelationOutcome::IntentWithoutAction { intent_event_id } => {
+                                    tracing::info!(
+                                        intent = %intent_event_id,
+                                        "intent without observed action"
+                                    );
+                                }
+                            }
+                        }
+                        engine.evict(now_ms);
+                    }
+                    result = corr_rx.recv() => {
+                        match result {
+                            Ok(crate::pipeline::PipelineEvent::Audit(enriched)) => {
+                                if let Some(corr_event) = crate::correlation::try_from_enriched(&enriched) {
+                                    engine.ingest(corr_event);
+                                }
+                            }
+                            Ok(crate::pipeline::PipelineEvent::LayerDegradation(_)) => {
+                                // Layer degradation events are not correlated.
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                                tracing::warn!(dropped = n, "correlation subscriber lagged — events lost");
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                                tracing::info!("broadcast channel closed — correlation subscriber exiting");
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        tracing::info!("correlation subscriber task spawned");
     }
 
     // Spawn the health/metrics HTTP server task.

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -376,4 +376,100 @@ mod tests {
         let result = tokio::time::timeout(Duration::from_millis(100), tracker.wait()).await;
         assert!(result.is_err(), "expected timeout but tasks completed");
     }
+
+    /// End-to-end integration test: feed events through a broadcast channel into
+    /// the correlation engine and verify that correlate() produces outcomes.
+    #[tokio::test]
+    async fn correlation_subscriber_ingests_and_correlates() {
+        use aa_proto::assembly::audit::v1::AuditEvent;
+        use aa_proto::assembly::common::v1::ActionType;
+        use crate::correlation::{CorrelationConfig, CorrelationEngine};
+        use crate::pipeline::event::{EnrichedEvent, EventSource};
+
+        // Short window and interval for fast test execution.
+        let config = CorrelationConfig {
+            window_ms: 500,
+            max_window_size: 100,
+            eviction_interval_ms: 50,
+        };
+        let mut engine = CorrelationEngine::new(config);
+
+        // Build an SDK/TOOL_CALL intent event.
+        let intent_enriched = EnrichedEvent {
+            inner: AuditEvent {
+                event_id: "550e8400-e29b-41d4-a716-446655440001".to_string(),
+                action_type: ActionType::ToolCall as i32,
+                ..AuditEvent::default()
+            },
+            received_at_ms: 1000,
+            source: EventSource::Sdk,
+            agent_id: "test".to_string(),
+            connection_id: 1,
+            sequence_number: 0,
+        };
+
+        // Build an eBPF/FILE_OPERATION action event.
+        let action_enriched = EnrichedEvent {
+            inner: AuditEvent {
+                event_id: "550e8400-e29b-41d4-a716-446655440002".to_string(),
+                action_type: ActionType::FileOperation as i32,
+                ..AuditEvent::default()
+            },
+            received_at_ms: 1050,
+            source: EventSource::EBpf,
+            agent_id: "test".to_string(),
+            connection_id: 1,
+            sequence_number: 1,
+        };
+
+        // Simulate the subscriber loop: convert and ingest.
+        let intent_event = crate::correlation::try_from_enriched(&intent_enriched);
+        assert!(intent_event.is_some(), "SDK/TOOL_CALL should produce Intent");
+        engine.ingest(intent_event.unwrap());
+
+        let action_event = crate::correlation::try_from_enriched(&action_enriched);
+        assert!(action_event.is_some(), "eBPF/FILE_OPERATION should produce Action");
+        engine.ingest(action_event.unwrap());
+
+        // Run correlation — should produce at least one outcome.
+        let outcomes = engine.correlate();
+        assert!(!outcomes.is_empty(), "expected at least one correlation outcome");
+    }
+
+    /// Verify the broadcast channel integration: send a PipelineEvent through
+    /// the channel and confirm the correlation subscriber can receive and
+    /// convert it.
+    #[tokio::test]
+    async fn broadcast_channel_delivers_to_correlation() {
+        use aa_proto::assembly::audit::v1::AuditEvent;
+        use aa_proto::assembly::common::v1::ActionType;
+        use crate::pipeline::event::{EnrichedEvent, EventSource, PipelineEvent};
+
+        let (tx, mut rx) =
+            tokio::sync::broadcast::channel::<PipelineEvent>(16);
+
+        let enriched = EnrichedEvent {
+            inner: AuditEvent {
+                event_id: "550e8400-e29b-41d4-a716-446655440003".to_string(),
+                action_type: ActionType::ToolCall as i32,
+                ..AuditEvent::default()
+            },
+            received_at_ms: 2000,
+            source: EventSource::Sdk,
+            agent_id: "test".to_string(),
+            connection_id: 1,
+            sequence_number: 0,
+        };
+
+        tx.send(PipelineEvent::Audit(Box::new(enriched))).unwrap();
+
+        let received = rx.recv().await.unwrap();
+        match received {
+            PipelineEvent::Audit(e) => {
+                let corr = crate::correlation::try_from_enriched(&e);
+                assert!(corr.is_some());
+            }
+            _ => panic!("expected Audit event"),
+        }
+    }
 }


### PR DESCRIPTION
## Description

Wires the existing `CorrelationEngine` (previously dead code) into the runtime event loop as a broadcast channel subscriber. The engine now receives enriched events, converts them to `CorrelationEvent` via `try_from_enriched`, runs periodic correlation and eviction, and logs outcomes.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-150
- Parent Epic: AAASM-4

## Changes

1. **RuntimeConfig** — Added `AA_CORRELATION_WINDOW_MS` (default 5000) and `AA_CORRELATION_INTERVAL_MS` (default 1000) env vars
2. **CorrelationConfig** — Added `from_runtime_config()` constructor mapping runtime env vars to correlation config
3. **try_from_enriched()** — New conversion function: SDK+LLM_CALL/TOOL_CALL → Intent, eBPF+FILE_OPERATION/NETWORK_CALL/PROCESS_EXEC → Action, else → None
4. **runtime::run()** — Spawns correlation subscriber task with `tokio::select!` (recv/tick/cancel arms), replaces `_broadcast_rx` keepalive
5. **Tests** — 11 unit tests for `try_from_enriched` mapping + 2 integration tests for end-to-end correlation flow

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

**Test results:** 205 passed, 0 failed, 2 ignored (pre-existing benchmarks)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention