### PR TITLE
[AAASM-140] ✨ (gateway): Auto-suspend agents on budget exceeded

### DIFF
--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -779,6 +779,47 @@ mod tests {
     }
 
     #[test]
+    fn monthly_budget_exceed_with_suspend_returns_suspend_agent() {
+        let mut doc = empty_doc();
+        doc.budget = Some(BudgetPolicy {
+            daily_limit_usd: None,
+            monthly_limit_usd: Some(5.0),
+            timezone: None,
+            action_on_exceed: ActionOnExceed::Suspend,
+        });
+        let engine = make_engine(doc);
+        let ctx = make_ctx();
+        engine.record_spend(&ctx, 5.0);
+
+        let result = engine.evaluate(&ctx, &tool_call("any", ""));
+        assert_eq!(
+            result.decision,
+            PolicyResult::Deny {
+                reason: "monthly budget exceeded".into()
+            }
+        );
+        assert_eq!(result.deny_action, Some(DenyAction::SuspendAgent));
+    }
+
+    #[test]
+    fn action_deny_within_budget_allows_normally() {
+        let mut doc = empty_doc();
+        doc.budget = Some(BudgetPolicy {
+            daily_limit_usd: Some(10.0),
+            monthly_limit_usd: None,
+            timezone: None,
+            action_on_exceed: ActionOnExceed::Deny,
+        });
+        let engine = make_engine(doc);
+        let ctx = make_ctx();
+        engine.record_spend(&ctx, 1.0);
+
+        let result = engine.evaluate(&ctx, &tool_call("any", ""));
+        assert_eq!(result.decision, PolicyResult::Allow);
+        assert_eq!(result.deny_action, None);
+    }
+
+    #[test]
     fn short_circuit_stops_at_first_deny() {
         // Tool deny (Stage 3) fires before the credential scan (Stage 6).
         let mut doc = empty_doc();

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -13,6 +13,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use crate::policy::document::ActionOnExceed;
 use crate::policy::{PolicyDocument, PolicyValidator};
 
 /// Side-effect action the service layer should take when a request is denied.
@@ -292,6 +293,10 @@ impl PolicyEngine {
 
         // Stage 7 — Budget check (monthly first, then daily).
         if let Some(bp) = &policy.budget {
+            let deny_action = match bp.action_on_exceed {
+                ActionOnExceed::Suspend => Some(DenyAction::SuspendAgent),
+                ActionOnExceed::Deny => None,
+            };
             if let Some(limit) = bp.monthly_limit_usd {
                 if self.budget.is_monthly_exceeded(ctx.agent_id.as_bytes(), limit) {
                     return EvaluationResult {
@@ -300,7 +305,7 @@ impl PolicyEngine {
                         },
                         redacted_payload,
                         credential_findings,
-                        deny_action: None,
+                        deny_action,
                     };
                 }
             }
@@ -312,7 +317,7 @@ impl PolicyEngine {
                         },
                         redacted_payload,
                         credential_findings,
-                        deny_action: None,
+                        deny_action,
                     };
                 }
             }
@@ -701,6 +706,52 @@ mod tests {
                 reason: "monthly budget exceeded".into()
             }
         );
+    }
+
+    #[test]
+    fn budget_exceed_with_action_deny_returns_no_deny_action() {
+        let mut doc = empty_doc();
+        doc.budget = Some(BudgetPolicy {
+            daily_limit_usd: Some(1.0),
+            monthly_limit_usd: None,
+            timezone: None,
+            action_on_exceed: ActionOnExceed::Deny,
+        });
+        let engine = make_engine(doc);
+        let ctx = make_ctx();
+        engine.record_spend(&ctx, 1.0);
+
+        let result = engine.evaluate(&ctx, &tool_call("any", ""));
+        assert_eq!(
+            result.decision,
+            PolicyResult::Deny {
+                reason: "daily budget exceeded".into()
+            }
+        );
+        assert_eq!(result.deny_action, None);
+    }
+
+    #[test]
+    fn budget_exceed_with_action_suspend_returns_suspend_agent() {
+        let mut doc = empty_doc();
+        doc.budget = Some(BudgetPolicy {
+            daily_limit_usd: Some(1.0),
+            monthly_limit_usd: None,
+            timezone: None,
+            action_on_exceed: ActionOnExceed::Suspend,
+        });
+        let engine = make_engine(doc);
+        let ctx = make_ctx();
+        engine.record_spend(&ctx, 1.0);
+
+        let result = engine.evaluate(&ctx, &tool_call("any", ""));
+        assert_eq!(
+            result.decision,
+            PolicyResult::Deny {
+                reason: "daily budget exceeded".into()
+            }
+        );
+        assert_eq!(result.deny_action, Some(DenyAction::SuspendAgent));
     }
 
     #[test]

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -336,6 +336,30 @@ impl PolicyEngine {
         self.budget.record(ctx.agent_id.as_bytes(), amount_usd);
         self.budget.record_monthly(ctx.agent_id.as_bytes(), amount_usd);
     }
+
+    /// Check whether an agent is within both daily and monthly budget limits.
+    ///
+    /// Returns `true` if the agent has not exceeded any configured budget limit
+    /// (or if no budget limits are configured). Used by the heartbeat handler to
+    /// determine whether a budget-suspended agent can be auto-resumed.
+    pub fn is_within_budget(&self, agent_id_bytes: &[u8; 16]) -> bool {
+        let policy = self.policy.load();
+        let bp = match &policy.budget {
+            Some(bp) => bp,
+            None => return true,
+        };
+        if let Some(limit) = bp.daily_limit_usd {
+            if self.budget.is_exceeded(agent_id_bytes, limit) {
+                return false;
+            }
+        }
+        if let Some(limit) = bp.monthly_limit_usd {
+            if self.budget.is_monthly_exceeded(agent_id_bytes, limit) {
+                return false;
+            }
+        }
+        true
+    }
 }
 
 /// Implement the `aa_core::PolicyEvaluator` trait so `PolicyEngine` can be used

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -338,7 +338,8 @@ impl aa_core::PolicyEvaluator for PolicyEngine {
 mod tests {
     use super::*;
     use crate::policy::document::{
-        ActiveHours, BudgetPolicy, DataPolicy, NetworkPolicy, PolicyDocument, SchedulePolicy, ToolPolicy,
+        ActionOnExceed, ActiveHours, BudgetPolicy, DataPolicy, NetworkPolicy, PolicyDocument, SchedulePolicy,
+        ToolPolicy,
     };
     use aa_core::{
         identity::{AgentId, SessionId},
@@ -601,6 +602,7 @@ mod tests {
             daily_limit_usd: Some(1.0),
             monthly_limit_usd: None,
             timezone: None,
+            action_on_exceed: ActionOnExceed::default(),
         });
         let engine = make_engine(doc);
         let ctx = make_ctx();
@@ -623,6 +625,7 @@ mod tests {
             daily_limit_usd: None,
             monthly_limit_usd: Some(5.0),
             timezone: None,
+            action_on_exceed: ActionOnExceed::default(),
         });
         let engine = make_engine(doc);
         let ctx = make_ctx();
@@ -645,6 +648,7 @@ mod tests {
             daily_limit_usd: None,
             monthly_limit_usd: Some(10.0),
             timezone: None,
+            action_on_exceed: ActionOnExceed::default(),
         });
         let engine = make_engine(doc);
         let ctx = make_ctx();
@@ -662,6 +666,7 @@ mod tests {
             daily_limit_usd: Some(2.0),
             monthly_limit_usd: Some(5.0),
             timezone: None,
+            action_on_exceed: ActionOnExceed::default(),
         });
         let engine = make_engine(doc);
         let ctx = make_ctx();

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -15,6 +15,15 @@ use std::{
 
 use crate::policy::{PolicyDocument, PolicyValidator};
 
+/// Side-effect action the service layer should take when a request is denied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DenyAction {
+    /// Default: just deny this request, keep the agent active.
+    Block,
+    /// Deny this request and request that the caller suspend the agent.
+    SuspendAgent,
+}
+
 /// The outcome of a [`PolicyEngine::evaluate`] call.
 ///
 /// Carries the governance decision alongside any credential or PII findings
@@ -32,6 +41,9 @@ pub struct EvaluationResult {
     /// All credential and PII findings detected during the scanner pass.
     /// Empty when the payload was clean.
     pub credential_findings: Vec<aa_core::CredentialFinding>,
+    /// Optional side-effect action for the service layer when the decision is `Deny`.
+    /// `None` means no side-effect beyond denying the request.
+    pub deny_action: Option<DenyAction>,
 }
 
 /// Assembled policy engine that evaluates governance actions through a 7-step pipeline.
@@ -144,6 +156,7 @@ impl PolicyEngine {
                         },
                         redacted_payload: None,
                         credential_findings: vec![],
+                        deny_action: None,
                     };
                 }
             }
@@ -167,6 +180,7 @@ impl PolicyEngine {
                             },
                             redacted_payload: None,
                             credential_findings: vec![],
+                            deny_action: None,
                         };
                     }
                 }
@@ -183,6 +197,7 @@ impl PolicyEngine {
                         },
                         redacted_payload: None,
                         credential_findings: vec![],
+                        deny_action: None,
                     };
                 }
             }
@@ -204,6 +219,7 @@ impl PolicyEngine {
                             },
                             redacted_payload: None,
                             credential_findings: vec![],
+                            deny_action: None,
                         };
                     }
                 }
@@ -219,6 +235,7 @@ impl PolicyEngine {
                             decision: aa_core::PolicyResult::RequiresApproval { timeout_secs: 30 },
                             redacted_payload: None,
                             credential_findings: vec![],
+                            deny_action: None,
                         };
                     }
                 }
@@ -283,6 +300,7 @@ impl PolicyEngine {
                         },
                         redacted_payload,
                         credential_findings,
+                        deny_action: None,
                     };
                 }
             }
@@ -294,6 +312,7 @@ impl PolicyEngine {
                         },
                         redacted_payload,
                         credential_findings,
+                        deny_action: None,
                     };
                 }
             }
@@ -303,6 +322,7 @@ impl PolicyEngine {
             decision: aa_core::PolicyResult::Allow,
             redacted_payload,
             credential_findings,
+            deny_action: None,
         }
     }
 

--- a/aa-gateway/src/policy/document.rs
+++ b/aa-gateway/src/policy/document.rs
@@ -25,6 +25,16 @@ pub struct SchedulePolicy {
     pub active_hours: Option<ActiveHours>,
 }
 
+/// Action to take when budget limit is exceeded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ActionOnExceed {
+    /// Deny individual requests but keep the agent active (default).
+    #[default]
+    Deny,
+    /// Suspend the agent entirely until budget resets.
+    Suspend,
+}
+
 /// Validated spend budget policy.
 #[derive(Debug, Clone, PartialEq)]
 pub struct BudgetPolicy {
@@ -34,6 +44,8 @@ pub struct BudgetPolicy {
     pub monthly_limit_usd: Option<f64>,
     /// IANA timezone for daily/monthly reset boundary. `None` means UTC.
     pub timezone: Option<String>,
+    /// Action when budget is exceeded: deny individual requests or suspend agent.
+    pub action_on_exceed: ActionOnExceed,
 }
 
 /// Validated data / PII policy.

--- a/aa-gateway/src/policy/raw.rs
+++ b/aa-gateway/src/policy/raw.rs
@@ -47,6 +47,8 @@ pub struct RawBudgetPolicy {
     pub monthly_limit_usd: Option<f64>,
     /// Optional IANA timezone for daily/monthly reset boundary. Defaults to UTC if absent.
     pub timezone: Option<String>,
+    /// Action when budget is exceeded: `"deny"` (default) or `"suspend"`.
+    pub action_on_exceed: Option<String>,
     /// Unknown keys captured for warning emission.
     #[serde(flatten)]
     pub unknown: HashMap<String, serde_yaml::Value>,
@@ -191,6 +193,20 @@ mod tests {
         let yaml = "{}\n";
         let raw: RawBudgetPolicy = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(raw.daily_limit_usd, None);
+    }
+
+    #[test]
+    fn raw_budget_deserializes_action_on_exceed() {
+        let yaml = "daily_limit_usd: 50.0\naction_on_exceed: suspend\n";
+        let raw: RawBudgetPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(raw.action_on_exceed, Some("suspend".to_string()));
+    }
+
+    #[test]
+    fn raw_budget_absent_action_on_exceed_is_none() {
+        let yaml = "daily_limit_usd: 50.0\n";
+        let raw: RawBudgetPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(raw.action_on_exceed, None);
     }
 
     // ── RawDataPolicy ───────────────────────────────────────────────────────

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -3,7 +3,10 @@
 use std::collections::HashMap;
 
 use crate::policy::{
-    document::{ActiveHours, BudgetPolicy, DataPolicy, NetworkPolicy, PolicyDocument, SchedulePolicy, ToolPolicy},
+    document::{
+        ActionOnExceed, ActiveHours, BudgetPolicy, DataPolicy, NetworkPolicy, PolicyDocument, SchedulePolicy,
+        ToolPolicy,
+    },
     error::{ValidationError, ValidationWarning},
     raw::RawPolicyDocument,
 };
@@ -227,6 +230,7 @@ impl PolicyValidator {
             daily_limit_usd: raw.daily_limit_usd,
             monthly_limit_usd: raw.monthly_limit_usd,
             timezone: raw.timezone,
+            action_on_exceed: ActionOnExceed::default(),
         })
     }
 

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -226,11 +226,24 @@ impl PolicyValidator {
             }
         }
 
+        // Validate action_on_exceed if provided
+        let action_on_exceed = match raw.action_on_exceed.as_deref() {
+            Some("deny") | None => ActionOnExceed::Deny,
+            Some("suspend") => ActionOnExceed::Suspend,
+            Some(other) => {
+                errors.push(ValidationError::new(
+                    "budget.action_on_exceed",
+                    format!("must be 'deny' or 'suspend', got '{}'", other),
+                ));
+                ActionOnExceed::Deny
+            }
+        };
+
         Some(BudgetPolicy {
             daily_limit_usd: raw.daily_limit_usd,
             monthly_limit_usd: raw.monthly_limit_usd,
             timezone: raw.timezone,
-            action_on_exceed: ActionOnExceed::default(),
+            action_on_exceed,
         })
     }
 
@@ -499,6 +512,41 @@ mod tests {
         let bp = out.document.budget.unwrap();
         assert_eq!(bp.monthly_limit_usd, Some(1000.0));
         assert!(bp.daily_limit_usd.is_none());
+    }
+
+    // ── action_on_exceed validation ────────────────────────────────────────
+
+    #[test]
+    fn budget_action_on_exceed_deny_round_trips() {
+        let yaml = "budget:\n  daily_limit_usd: 50.0\n  action_on_exceed: deny\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        let bp = out.document.budget.unwrap();
+        assert_eq!(bp.action_on_exceed, ActionOnExceed::Deny);
+    }
+
+    #[test]
+    fn budget_action_on_exceed_suspend_round_trips() {
+        let yaml = "budget:\n  daily_limit_usd: 50.0\n  action_on_exceed: suspend\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        let bp = out.document.budget.unwrap();
+        assert_eq!(bp.action_on_exceed, ActionOnExceed::Suspend);
+    }
+
+    #[test]
+    fn budget_action_on_exceed_invalid_value_is_an_error() {
+        let yaml = "budget:\n  daily_limit_usd: 50.0\n  action_on_exceed: quarantine\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err());
+        let errs = result.unwrap_err();
+        assert!(errs.iter().any(|e| e.field == "budget.action_on_exceed"));
+    }
+
+    #[test]
+    fn budget_action_on_exceed_absent_defaults_to_deny() {
+        let yaml = "budget:\n  daily_limit_usd: 50.0\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        let bp = out.document.budget.unwrap();
+        assert_eq!(bp.action_on_exceed, ActionOnExceed::Deny);
     }
 
     // ── Schedule active_hours validation ───────────────────────────────────

--- a/aa-gateway/src/registry/mod.rs
+++ b/aa-gateway/src/registry/mod.rs
@@ -21,13 +21,22 @@ pub enum RegistryError {
     NotFound([u8; 16]),
 }
 
+/// Reason an agent was suspended — determines whether auto-resume is possible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SuspendReason {
+    /// Suspended because a budget limit was exceeded. Auto-resumable when budget resets.
+    BudgetExceeded,
+    /// Suspended by an operator or external system. Only manually resumable.
+    Manual,
+}
+
 /// Runtime status of a registered agent.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AgentStatus {
     /// Agent is actively running and sending heartbeats.
     Active,
-    /// Agent has been suspended by the gateway (e.g. budget exceeded, manual pause).
-    Suspended,
+    /// Agent has been suspended by the gateway. Contains the reason for suspension.
+    Suspended(SuspendReason),
     /// Agent has been removed from the registry (clean shutdown or forced removal).
     Deregistered,
 }

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -135,6 +135,38 @@ impl AgentRegistry {
     pub fn list(&self) -> Vec<AgentRecord> {
         self.agents.iter().map(|r| r.value().clone()).collect()
     }
+
+    /// Suspend an agent with the given reason.
+    pub fn suspend_agent(
+        &self,
+        agent_id: &[u8; 16],
+        reason: super::SuspendReason,
+    ) -> Result<(), RegistryError> {
+        let mut entry = self
+            .agents
+            .get_mut(agent_id)
+            .ok_or(RegistryError::NotFound(*agent_id))?;
+        entry.status = AgentStatus::Suspended(reason);
+        Ok(())
+    }
+
+    /// Resume a suspended agent back to Active status.
+    pub fn resume_agent(&self, agent_id: &[u8; 16]) -> Result<(), RegistryError> {
+        let mut entry = self
+            .agents
+            .get_mut(agent_id)
+            .ok_or(RegistryError::NotFound(*agent_id))?;
+        entry.status = AgentStatus::Active;
+        Ok(())
+    }
+
+    /// Query the current status of an agent.
+    pub fn agent_status(&self, agent_id: &[u8; 16]) -> Result<AgentStatus, RegistryError> {
+        self.agents
+            .get(agent_id)
+            .map(|r| r.status)
+            .ok_or(RegistryError::NotFound(*agent_id))
+    }
 }
 
 impl Default for AgentRegistry {

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -138,11 +138,7 @@ impl AgentRegistry {
     }
 
     /// Suspend an agent with the given reason.
-    pub fn suspend_agent(
-        &self,
-        agent_id: &[u8; 16],
-        reason: super::SuspendReason,
-    ) -> Result<(), RegistryError> {
+    pub fn suspend_agent(&self, agent_id: &[u8; 16], reason: super::SuspendReason) -> Result<(), RegistryError> {
         let mut entry = self
             .agents
             .get_mut(agent_id)

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -7,7 +7,8 @@ use dashmap::DashMap;
 use tokio::sync::mpsc;
 use tonic::Status;
 
-use aa_proto::assembly::agent::v1::ControlCommand;
+use aa_proto::assembly::agent::v1::control_command::Command;
+use aa_proto::assembly::agent::v1::{ControlCommand, SuspendCommand};
 
 use super::{AgentStatus, RegistryError};
 
@@ -147,6 +148,30 @@ impl AgentRegistry {
             .get_mut(agent_id)
             .ok_or(RegistryError::NotFound(*agent_id))?;
         entry.status = AgentStatus::Suspended(reason);
+        Ok(())
+    }
+
+    /// Suspend an agent and send a [`SuspendCommand`] via the control stream.
+    ///
+    /// Sets the agent status to `Suspended(reason)` and, if a control stream
+    /// is open, pushes a `SuspendCommand` with the given reason string.
+    /// The control stream send is best-effort: if the stream is closed or full,
+    /// the suspension still takes effect.
+    pub async fn suspend_and_notify(
+        &self,
+        agent_id: &[u8; 16],
+        reason: super::SuspendReason,
+        reason_text: &str,
+    ) -> Result<(), RegistryError> {
+        self.suspend_agent(agent_id, reason)?;
+
+        let cmd = ControlCommand {
+            command: Some(Command::Suspend(SuspendCommand {
+                reason: reason_text.to_string(),
+            })),
+        };
+        // Best-effort: ignore errors if the stream is not open.
+        let _ = self.send_command(agent_id, cmd).await;
         Ok(())
     }
 

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -34,7 +34,7 @@ pub enum ConvertError {
 /// Proto identity fields are variable-length strings; core identity types are
 /// fixed `[u8; 16]`. This deterministic mapping avoids collisions in practice
 /// while satisfying the type constraint.
-pub(crate) fn hash_to_16(s: &str) -> [u8; 16] {
+pub fn hash_to_16(s: &str) -> [u8; 16] {
     let digest = Sha256::digest(s.as_bytes());
     let mut out = [0u8; 16];
     out.copy_from_slice(&digest[..16]);

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -190,6 +190,7 @@ pub fn result_to_response(result: &PolicyResult, latency_us: i64, policy_rule: &
         decision: result.clone(),
         redacted_payload: None,
         credential_findings: Vec::new(),
+        deny_action: None,
     };
     eval_result_to_response(&eval, latency_us, policy_rule)
 }

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -13,10 +13,11 @@ use aa_proto::assembly::agent::v1::{
     RegisterRequest, RegisterResponse,
 };
 
+use crate::engine::PolicyEngine;
 use crate::registry::convert::{proto_agent_id_to_key, validate_proto_agent_id};
 use crate::registry::store::AgentRecord;
 use crate::registry::token::{generate_credential_token, validate_token};
-use crate::registry::{AgentRegistry, AgentStatus};
+use crate::registry::{AgentRegistry, AgentStatus, SuspendReason};
 
 /// Default heartbeat interval returned to agents at registration (seconds).
 const DEFAULT_HEARTBEAT_INTERVAL_SEC: i64 = 30;
@@ -25,12 +26,27 @@ const DEFAULT_HEARTBEAT_INTERVAL_SEC: i64 = 30;
 /// `ControlStream` to the in-memory [`AgentRegistry`].
 pub struct AgentLifecycleServiceImpl {
     registry: Arc<AgentRegistry>,
+    policy_engine: Option<Arc<PolicyEngine>>,
 }
 
 impl AgentLifecycleServiceImpl {
     /// Create a new service backed by the given agent registry.
     pub fn new(registry: Arc<AgentRegistry>) -> Self {
-        Self { registry }
+        Self {
+            registry,
+            policy_engine: None,
+        }
+    }
+
+    /// Create a new service with both an agent registry and a policy engine.
+    ///
+    /// When a policy engine is provided, the heartbeat handler can check budget
+    /// state and auto-resume agents that were suspended due to budget limits.
+    pub fn with_policy_engine(registry: Arc<AgentRegistry>, policy_engine: Arc<PolicyEngine>) -> Self {
+        Self {
+            registry,
+            policy_engine: Some(policy_engine),
+        }
     }
 }
 
@@ -110,11 +126,31 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
             .update_heartbeat(&agent_key)
             .map_err(|e| Status::not_found(e.to_string()))?;
 
-        let should_suspend = self
+        let status = self
             .registry
             .agent_status(&agent_key)
-            .map(|s| matches!(s, AgentStatus::Suspended(_)))
-            .unwrap_or(false);
+            .unwrap_or(AgentStatus::Active);
+
+        // Lazy auto-resume: if agent was suspended due to budget and budget has
+        // since reset (daily/monthly boundary crossed), resume the agent.
+        let should_suspend = match status {
+            AgentStatus::Suspended(SuspendReason::BudgetExceeded) => {
+                let within_budget = self
+                    .policy_engine
+                    .as_ref()
+                    .map(|pe| pe.is_within_budget(&agent_key))
+                    .unwrap_or(false);
+                if within_budget {
+                    let _ = self.registry.resume_agent(&agent_key);
+                    tracing::info!(agent_id = ?proto_id.agent_id, "auto-resumed: budget reset");
+                    false
+                } else {
+                    true
+                }
+            }
+            AgentStatus::Suspended(_) => true,
+            _ => false,
+        };
 
         tracing::debug!(agent_id = ?proto_id.agent_id, should_suspend, "heartbeat received");
 

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -110,11 +110,17 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
             .update_heartbeat(&agent_key)
             .map_err(|e| Status::not_found(e.to_string()))?;
 
-        tracing::debug!(agent_id = ?proto_id.agent_id, "heartbeat received");
+        let should_suspend = self
+            .registry
+            .agent_status(&agent_key)
+            .map(|s| matches!(s, AgentStatus::Suspended(_)))
+            .unwrap_or(false);
+
+        tracing::debug!(agent_id = ?proto_id.agent_id, should_suspend, "heartbeat received");
 
         Ok(Response::new(HeartbeatResponse {
             policy_updated: false,
-            should_suspend: false,
+            should_suspend,
         }))
     }
 

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -126,10 +126,7 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
             .update_heartbeat(&agent_key)
             .map_err(|e| Status::not_found(e.to_string()))?;
 
-        let status = self
-            .registry
-            .agent_status(&agent_key)
-            .unwrap_or(AgentStatus::Active);
+        let status = self.registry.agent_status(&agent_key).unwrap_or(AgentStatus::Active);
 
         // Lazy auto-resume: if agent was suspended due to budget and budget has
         // since reset (daily/monthly boundary crossed), resume the agent.

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -92,7 +92,10 @@ impl PolicyServiceImpl {
         };
 
         let deny_action = eval.deny_action;
-        Ok((convert::eval_result_to_response(&eval, latency_us, policy_rule), deny_action))
+        Ok((
+            convert::eval_result_to_response(&eval, latency_us, policy_rule),
+            deny_action,
+        ))
     }
 
     /// Execute the suspension side-effect when the engine signals `SuspendAgent`.

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -13,12 +13,15 @@ use aa_core::{AuditEntry, AuditEventType};
 use aa_proto::assembly::policy::v1::policy_service_server::PolicyService;
 use aa_proto::assembly::policy::v1::{BatchCheckRequest, BatchCheckResponse, CheckActionRequest, CheckActionResponse};
 
-use crate::engine::PolicyEngine;
+use crate::engine::{DenyAction, PolicyEngine};
+use crate::registry::convert::proto_agent_id_to_key;
+use crate::registry::{AgentRegistry, SuspendReason};
 use crate::service::convert;
 
 /// gRPC service implementation wiring `CheckAction` / `BatchCheck` to [`PolicyEngine`].
 pub struct PolicyServiceImpl {
     engine: Arc<PolicyEngine>,
+    registry: Option<Arc<AgentRegistry>>,
     audit_tx: mpsc::Sender<AuditEntry>,
     audit_drops: Arc<AtomicU64>,
     seq: AtomicU64,
@@ -39,6 +42,7 @@ impl PolicyServiceImpl {
     ) -> Self {
         Self {
             engine,
+            registry: None,
             audit_tx,
             audit_drops,
             seq: AtomicU64::new(0),
@@ -46,9 +50,31 @@ impl PolicyServiceImpl {
         }
     }
 
-    /// Evaluate a single request against the engine, returning the gRPC response.
+    /// Create a new service with an agent registry attached.
+    ///
+    /// When a registry is provided, the service can suspend agents when the
+    /// policy engine returns `DenyAction::SuspendAgent` on budget exceeded.
+    pub fn with_registry(
+        engine: Arc<PolicyEngine>,
+        registry: Arc<AgentRegistry>,
+        audit_tx: mpsc::Sender<AuditEntry>,
+        audit_drops: Arc<AtomicU64>,
+        initial_hash: [u8; 32],
+    ) -> Self {
+        Self {
+            engine,
+            registry: Some(registry),
+            audit_tx,
+            audit_drops,
+            seq: AtomicU64::new(0),
+            last_hash: Mutex::new(initial_hash),
+        }
+    }
+
+    /// Evaluate a single request against the engine, returning the gRPC response
+    /// and the optional deny-action side-effect.
     #[allow(clippy::result_large_err)] // tonic::Status is the standard gRPC error type
-    fn evaluate_one(&self, req: &CheckActionRequest) -> Result<CheckActionResponse, Status> {
+    fn evaluate_one(&self, req: &CheckActionRequest) -> Result<(CheckActionResponse, Option<DenyAction>), Status> {
         let (ctx, action) = convert::request_to_core(req).map_err(|e| {
             tracing::error!(error = %e, "failed to convert CheckActionRequest");
             Status::invalid_argument(e.to_string())
@@ -65,7 +91,37 @@ impl PolicyServiceImpl {
             aa_core::PolicyResult::RequiresApproval { .. } => "requires_approval",
         };
 
-        Ok(convert::eval_result_to_response(&eval, latency_us, policy_rule))
+        let deny_action = eval.deny_action;
+        Ok((convert::eval_result_to_response(&eval, latency_us, policy_rule), deny_action))
+    }
+
+    /// Execute the suspension side-effect when the engine signals `SuspendAgent`.
+    ///
+    /// Suspends the agent in the registry and sends a `SuspendCommand` via the
+    /// control stream. Best-effort: if the registry is not attached or the agent
+    /// is not found, the suspension is skipped (the deny response still applies).
+    async fn maybe_suspend_agent(&self, req: &CheckActionRequest, deny_action: Option<DenyAction>) {
+        if deny_action != Some(DenyAction::SuspendAgent) {
+            return;
+        }
+        let registry = match &self.registry {
+            Some(r) => r,
+            None => return,
+        };
+        let proto_agent = match req.agent_id.as_ref() {
+            Some(a) => a,
+            None => return,
+        };
+        let agent_key = proto_agent_id_to_key(proto_agent);
+        let reason_text = "budget limit exceeded";
+        if let Err(e) = registry
+            .suspend_and_notify(&agent_key, SuspendReason::BudgetExceeded, reason_text)
+            .await
+        {
+            tracing::warn!(error = %e, "failed to suspend agent on budget exceeded");
+        } else {
+            tracing::info!(agent_id = ?proto_agent.agent_id, "agent suspended: {reason_text}");
+        }
     }
 
     /// Build an `AuditEntry` from a request and evaluation result, then fire-and-forget
@@ -142,7 +198,7 @@ impl PolicyService for PolicyServiceImpl {
             "check_action request"
         );
 
-        let response = self.evaluate_one(&req)?;
+        let (response, deny_action) = self.evaluate_one(&req)?;
 
         tracing::debug!(
             decision = response.decision,
@@ -159,6 +215,9 @@ impl PolicyService for PolicyServiceImpl {
             );
         }
 
+        // Suspend the agent if the engine signaled SuspendAgent.
+        self.maybe_suspend_agent(&req, deny_action).await;
+
         // Fire-and-forget audit entry — never blocks the response.
         self.record_audit(&req, &response).await;
 
@@ -170,7 +229,8 @@ impl PolicyService for PolicyServiceImpl {
         let mut responses = Vec::with_capacity(batch.requests.len());
 
         for req in &batch.requests {
-            let resp = self.evaluate_one(req)?;
+            let (resp, deny_action) = self.evaluate_one(req)?;
+            self.maybe_suspend_agent(req, deny_action).await;
             self.record_audit(req, &resp).await;
             responses.push(resp);
         }

--- a/aa-gateway/tests/lifecycle_service_test.rs
+++ b/aa-gateway/tests/lifecycle_service_test.rs
@@ -55,6 +55,38 @@ async fn start_server() -> (SocketAddr, Arc<AgentRegistry>) {
     (addr, registry)
 }
 
+/// Start a server with a policy engine attached (for auto-resume tests).
+async fn start_server_with_engine(
+    policy_yaml: &str,
+) -> (SocketAddr, Arc<AgentRegistry>, Arc<aa_gateway::PolicyEngine>) {
+    use aa_gateway::PolicyEngine;
+
+    let registry = Arc::new(AgentRegistry::new());
+
+    // Write the policy YAML to a temp file and load it.
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    std::io::Write::write_all(&mut tmp, policy_yaml.as_bytes()).unwrap();
+    let engine = Arc::new(PolicyEngine::load_from_file(tmp.path()).unwrap());
+
+    let service =
+        AgentLifecycleServiceImpl::with_policy_engine(Arc::clone(&registry), Arc::clone(&engine));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(AgentLifecycleServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    (addr, registry, engine)
+}
+
 // ── Full lifecycle test ────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -323,4 +355,113 @@ async fn heartbeat_returns_should_suspend_false_for_active_agent() {
         .into_inner();
 
     assert!(!hb_resp.should_suspend);
+}
+
+// ── Heartbeat auto-resume ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn heartbeat_auto_resumes_budget_suspended_agent_when_budget_reset() {
+    use aa_gateway::registry::convert::proto_agent_id_to_key;
+    use aa_gateway::registry::{AgentStatus, SuspendReason};
+
+    let yaml = "budget:\n  daily_limit_usd: 10.0\n  action_on_exceed: suspend\n";
+    let (addr, registry, _engine) = start_server_with_engine(yaml).await;
+
+    let mut client = AgentLifecycleServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let agent_id = test_agent_id();
+    let reg_resp = client
+        .register(RegisterRequest {
+            agent_id: Some(agent_id.clone()),
+            name: "auto-resume-agent".into(),
+            framework: "custom".into(),
+            version: "1.0.0".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key: test_ed25519_public_key_hex(),
+            metadata: Default::default(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    let token = reg_resp.credential_token;
+
+    // Suspend the agent as if budget was exceeded
+    let agent_key = proto_agent_id_to_key(&agent_id);
+    registry
+        .suspend_agent(&agent_key, SuspendReason::BudgetExceeded)
+        .unwrap();
+
+    // Heartbeat: engine has no spend recorded → is_within_budget() = true → auto-resume
+    let hb_resp = client
+        .heartbeat(HeartbeatRequest {
+            agent_id: Some(agent_id.clone()),
+            credential_token: token.clone(),
+            active_runs: 0,
+            actions_count: 0,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(!hb_resp.should_suspend, "agent should have been auto-resumed");
+
+    // Verify the registry status was updated to Active
+    let status = registry.agent_status(&agent_key).unwrap();
+    assert_eq!(status, AgentStatus::Active);
+}
+
+#[tokio::test]
+async fn heartbeat_does_not_resume_manually_suspended_agent() {
+    use aa_gateway::registry::convert::proto_agent_id_to_key;
+    use aa_gateway::registry::{AgentStatus, SuspendReason};
+
+    let yaml = "budget:\n  daily_limit_usd: 10.0\n  action_on_exceed: suspend\n";
+    let (addr, registry, _engine) = start_server_with_engine(yaml).await;
+
+    let mut client = AgentLifecycleServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let agent_id = test_agent_id();
+    let reg_resp = client
+        .register(RegisterRequest {
+            agent_id: Some(agent_id.clone()),
+            name: "manual-suspend-agent".into(),
+            framework: "custom".into(),
+            version: "1.0.0".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key: test_ed25519_public_key_hex(),
+            metadata: Default::default(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    let token = reg_resp.credential_token;
+
+    // Manually suspend the agent
+    let agent_key = proto_agent_id_to_key(&agent_id);
+    registry
+        .suspend_agent(&agent_key, SuspendReason::Manual)
+        .unwrap();
+
+    // Heartbeat: manual suspension is not auto-resumable
+    let hb_resp = client
+        .heartbeat(HeartbeatRequest {
+            agent_id: Some(agent_id),
+            credential_token: token,
+            active_runs: 0,
+            actions_count: 0,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(hb_resp.should_suspend, "manually suspended agent must not auto-resume");
+
+    let status = registry.agent_status(&agent_key).unwrap();
+    assert_eq!(status, AgentStatus::Suspended(SuspendReason::Manual));
 }

--- a/aa-gateway/tests/lifecycle_service_test.rs
+++ b/aa-gateway/tests/lifecycle_service_test.rs
@@ -230,3 +230,97 @@ async fn duplicate_register_returns_already_exists() {
     let status = client.register(req).await.unwrap_err();
     assert_eq!(status.code(), tonic::Code::AlreadyExists);
 }
+
+// ── Heartbeat suspend signaling ──────────────────────────────────────────
+
+#[tokio::test]
+async fn heartbeat_returns_should_suspend_true_for_suspended_agent() {
+    use aa_gateway::registry::SuspendReason;
+
+    let (addr, registry) = start_server().await;
+    let mut client = AgentLifecycleServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let agent_id = test_agent_id();
+    let public_key = test_ed25519_public_key_hex();
+
+    let reg_resp = client
+        .register(RegisterRequest {
+            agent_id: Some(agent_id.clone()),
+            name: "suspend-test-agent".into(),
+            framework: "custom".into(),
+            version: "1.0.0".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key,
+            metadata: Default::default(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    let token = reg_resp.credential_token;
+
+    // Suspend the agent directly via the registry
+    use aa_gateway::registry::convert::proto_agent_id_to_key;
+    let agent_key = proto_agent_id_to_key(&agent_id);
+    registry
+        .suspend_agent(&agent_key, SuspendReason::BudgetExceeded)
+        .unwrap();
+
+    // Heartbeat should return should_suspend = true
+    let hb_resp = client
+        .heartbeat(HeartbeatRequest {
+            agent_id: Some(agent_id),
+            credential_token: token,
+            active_runs: 0,
+            actions_count: 0,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(hb_resp.should_suspend);
+}
+
+#[tokio::test]
+async fn heartbeat_returns_should_suspend_false_for_active_agent() {
+    let (addr, _registry) = start_server().await;
+    let mut client = AgentLifecycleServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let agent_id = test_agent_id();
+    let public_key = test_ed25519_public_key_hex();
+
+    let reg_resp = client
+        .register(RegisterRequest {
+            agent_id: Some(agent_id.clone()),
+            name: "active-test-agent".into(),
+            framework: "custom".into(),
+            version: "1.0.0".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key,
+            metadata: Default::default(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    let token = reg_resp.credential_token;
+
+    let hb_resp = client
+        .heartbeat(HeartbeatRequest {
+            agent_id: Some(agent_id),
+            credential_token: token,
+            active_runs: 0,
+            actions_count: 0,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(!hb_resp.should_suspend);
+}

--- a/aa-gateway/tests/lifecycle_service_test.rs
+++ b/aa-gateway/tests/lifecycle_service_test.rs
@@ -68,8 +68,7 @@ async fn start_server_with_engine(
     std::io::Write::write_all(&mut tmp, policy_yaml.as_bytes()).unwrap();
     let engine = Arc::new(PolicyEngine::load_from_file(tmp.path()).unwrap());
 
-    let service =
-        AgentLifecycleServiceImpl::with_policy_engine(Arc::clone(&registry), Arc::clone(&engine));
+    let service = AgentLifecycleServiceImpl::with_policy_engine(Arc::clone(&registry), Arc::clone(&engine));
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
@@ -444,9 +443,7 @@ async fn heartbeat_does_not_resume_manually_suspended_agent() {
 
     // Manually suspend the agent
     let agent_key = proto_agent_id_to_key(&agent_id);
-    registry
-        .suspend_agent(&agent_key, SuspendReason::Manual)
-        .unwrap();
+    registry.suspend_agent(&agent_key, SuspendReason::Manual).unwrap();
 
     // Heartbeat: manual suspension is not auto-resumable
     let hb_resp = client

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -190,6 +190,183 @@ tools:
     assert_eq!(resp.responses[2].decision, Decision::Allow as i32);
 }
 
+// ── Budget suspend integration test ────────────────────────────────────────
+
+/// Start a PolicyService with an attached AgentRegistry, returning the address,
+/// the engine (for recording spend), and the registry (for verifying suspension).
+async fn start_server_with_registry(
+    policy_yaml: &str,
+) -> (
+    SocketAddr,
+    Arc<aa_gateway::PolicyEngine>,
+    Arc<aa_gateway::registry::AgentRegistry>,
+) {
+    use aa_gateway::registry::AgentRegistry;
+
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", policy_yaml).unwrap();
+    tmp.flush().unwrap();
+
+    let engine = Arc::new(PolicyEngine::load_from_file(tmp.path()).unwrap());
+    let registry = Arc::new(AgentRegistry::new());
+    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+    let service = PolicyServiceImpl::with_registry(
+        Arc::clone(&engine),
+        Arc::clone(&registry),
+        audit_tx,
+        audit_drops,
+        [0u8; 32],
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let _tmp = tmp;
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(PolicyServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    (addr, engine, registry)
+}
+
+#[tokio::test]
+async fn check_action_suspends_agent_on_budget_exceeded_with_suspend_policy() {
+    use aa_gateway::registry::convert::proto_agent_id_to_key;
+    use aa_gateway::registry::store::AgentRecord;
+    use aa_gateway::registry::{AgentStatus, SuspendReason};
+
+    let yaml = r#"
+version: "1"
+budget:
+  daily_limit_usd: 1.0
+  action_on_exceed: suspend
+"#;
+    let (addr, engine, registry) = start_server_with_registry(yaml).await;
+
+    // Pre-register the agent in the registry so suspend_and_notify can find it.
+    let proto_id = ProtoAgentId {
+        org_id: "org".into(),
+        team_id: "team".into(),
+        agent_id: "agent-1".into(),
+    };
+    let agent_key = proto_agent_id_to_key(&proto_id);
+    let record = AgentRecord {
+        agent_id: agent_key,
+        name: "budget-test-agent".into(),
+        framework: "custom".into(),
+        version: "1.0.0".into(),
+        risk_tier: 0,
+        tool_names: vec![],
+        public_key: "pk_test".into(),
+        credential_token: "tok_test".into(),
+        metadata: std::collections::BTreeMap::new(),
+        registered_at: chrono::Utc::now(),
+        last_heartbeat: chrono::Utc::now(),
+        status: AgentStatus::Active,
+    };
+    registry.register(record).unwrap();
+
+    // Push budget over the limit using the engine's budget tracker.
+    // The engine uses hash_to_16("agent-1") as the budget key (from request_to_core).
+    let agent_ctx = aa_core::AgentContext {
+        agent_id: aa_core::identity::AgentId::from_bytes(aa_gateway::service::convert::hash_to_16("agent-1")),
+        session_id: aa_core::identity::SessionId::from_bytes([0u8; 16]),
+        pid: 0,
+        started_at: aa_core::time::Timestamp::from_nanos(0),
+        metadata: std::collections::BTreeMap::new(),
+    };
+    engine.record_spend(&agent_ctx, 2.0); // exceeds $1.0 daily limit
+
+    // Send a CheckAction — should get Deny and trigger suspension.
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let resp = client
+        .check_action(tool_call_request("any_tool"))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(resp.decision, Decision::Deny as i32);
+    assert!(resp.reason.contains("budget exceeded"));
+
+    // Verify the agent was suspended in the registry.
+    let status = registry.agent_status(&agent_key).unwrap();
+    assert_eq!(
+        status,
+        AgentStatus::Suspended(SuspendReason::BudgetExceeded),
+        "agent should be suspended after budget-exceeded with action_on_exceed=suspend"
+    );
+}
+
+#[tokio::test]
+async fn check_action_does_not_suspend_agent_on_budget_exceeded_with_deny_policy() {
+    use aa_gateway::registry::convert::proto_agent_id_to_key;
+    use aa_gateway::registry::store::AgentRecord;
+    use aa_gateway::registry::AgentStatus;
+
+    let yaml = r#"
+version: "1"
+budget:
+  daily_limit_usd: 1.0
+  action_on_exceed: deny
+"#;
+    let (addr, engine, registry) = start_server_with_registry(yaml).await;
+
+    let proto_id = ProtoAgentId {
+        org_id: "org".into(),
+        team_id: "team".into(),
+        agent_id: "agent-1".into(),
+    };
+    let agent_key = proto_agent_id_to_key(&proto_id);
+    let record = AgentRecord {
+        agent_id: agent_key,
+        name: "deny-test-agent".into(),
+        framework: "custom".into(),
+        version: "1.0.0".into(),
+        risk_tier: 0,
+        tool_names: vec![],
+        public_key: "pk_test".into(),
+        credential_token: "tok_test".into(),
+        metadata: std::collections::BTreeMap::new(),
+        registered_at: chrono::Utc::now(),
+        last_heartbeat: chrono::Utc::now(),
+        status: AgentStatus::Active,
+    };
+    registry.register(record).unwrap();
+
+    let agent_ctx = aa_core::AgentContext {
+        agent_id: aa_core::identity::AgentId::from_bytes(aa_gateway::service::convert::hash_to_16("agent-1")),
+        session_id: aa_core::identity::SessionId::from_bytes([0u8; 16]),
+        pid: 0,
+        started_at: aa_core::time::Timestamp::from_nanos(0),
+        metadata: std::collections::BTreeMap::new(),
+    };
+    engine.record_spend(&agent_ctx, 2.0);
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let resp = client
+        .check_action(tool_call_request("any_tool"))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(resp.decision, Decision::Deny as i32);
+
+    // Agent should still be Active — deny policy does not suspend.
+    let status = registry.agent_status(&agent_key).unwrap();
+    assert_eq!(
+        status,
+        AgentStatus::Active,
+        "agent should remain active with action_on_exceed=deny"
+    );
+}
+
 // ── GatewayClient integration test ──────────────────────────────────────────
 
 #[tokio::test]

--- a/aa-gateway/tests/registry_test.rs
+++ b/aa-gateway/tests/registry_test.rs
@@ -258,3 +258,28 @@ fn suspend_agent_not_found_returns_error() {
     let result = reg.suspend_agent(&key(99), SuspendReason::Manual);
     assert!(result.is_err());
 }
+
+#[tokio::test]
+async fn suspend_and_notify_sends_command_on_control_stream() {
+    use aa_gateway::registry::SuspendReason;
+    use aa_proto::assembly::agent::v1::control_command::Command;
+
+    let reg = AgentRegistry::new();
+    reg.register(make_record(key(1))).unwrap();
+    let mut rx = reg.open_control_stream(&key(1)).unwrap();
+
+    reg.suspend_and_notify(&key(1), SuspendReason::BudgetExceeded, "budget limit exceeded")
+        .await
+        .unwrap();
+
+    // Status should be Suspended
+    let status = reg.agent_status(&key(1)).unwrap();
+    assert_eq!(status, AgentStatus::Suspended(SuspendReason::BudgetExceeded));
+
+    // SuspendCommand should have been delivered
+    let received = rx.recv().await.unwrap().unwrap();
+    match received.command {
+        Some(Command::Suspend(s)) => assert_eq!(s.reason, "budget limit exceeded"),
+        other => panic!("expected Suspend command, got {other:?}"),
+    }
+}

--- a/aa-gateway/tests/registry_test.rs
+++ b/aa-gateway/tests/registry_test.rs
@@ -220,3 +220,41 @@ async fn concurrent_registration_of_100_agents() {
 
     assert_eq!(reg.list().len(), 100);
 }
+
+// ── Suspend / Resume / Status ─────────────���───────────────────────────────
+
+#[test]
+fn suspend_agent_sets_status_to_suspended() {
+    use aa_gateway::registry::SuspendReason;
+
+    let reg = AgentRegistry::new();
+    reg.register(make_record(key(1))).unwrap();
+
+    reg.suspend_agent(&key(1), SuspendReason::BudgetExceeded).unwrap();
+
+    let status = reg.agent_status(&key(1)).unwrap();
+    assert_eq!(status, AgentStatus::Suspended(SuspendReason::BudgetExceeded));
+}
+
+#[test]
+fn resume_agent_sets_status_to_active() {
+    use aa_gateway::registry::SuspendReason;
+
+    let reg = AgentRegistry::new();
+    reg.register(make_record(key(1))).unwrap();
+
+    reg.suspend_agent(&key(1), SuspendReason::BudgetExceeded).unwrap();
+    reg.resume_agent(&key(1)).unwrap();
+
+    let status = reg.agent_status(&key(1)).unwrap();
+    assert_eq!(status, AgentStatus::Active);
+}
+
+#[test]
+fn suspend_agent_not_found_returns_error() {
+    use aa_gateway::registry::SuspendReason;
+
+    let reg = AgentRegistry::new();
+    let result = reg.suspend_agent(&key(99), SuspendReason::Manual);
+    assert!(result.is_err());
+}

--- a/aa-gateway/tests/service_convert_test.rs
+++ b/aa-gateway/tests/service_convert_test.rs
@@ -284,6 +284,7 @@ fn eval_result_with_credential_findings_returns_redact() {
         decision: PolicyResult::Allow,
         redacted_payload: Some("redacted text".into()),
         credential_findings: vec![aa_core::CredentialFinding::from_regex_match(0, 10)],
+        deny_action: None,
     };
     let resp = eval_result_to_response(&eval, 77, "");
     assert_eq!(resp.decision, Decision::Redact as i32);


### PR DESCRIPTION
## Description

Implements auto-suspend on budget exceeded (AAASM-140). When a policy's action_on_exceed is set to suspend, agents that exceed their daily or monthly budget are suspended in the registry, notified via SuspendCommand on the ControlStream, and signaled via should_suspend: true in heartbeat responses. Budget-suspended agents are automatically resumed on the next heartbeat once the budget resets (daily/monthly boundary crossing).

**Key changes:**
- ActionOnExceed enum (Deny / Suspend) in policy schema with YAML action_on_exceed field
- DenyAction enum (Block / SuspendAgent) as side-effect signal in EvaluationResult
- SuspendReason enum (BudgetExceeded / Manual) carried by AgentStatus::Suspended
- Registry methods: suspend_agent, resume_agent, agent_status, suspend_and_notify
- Service-layer wiring: PolicyServiceImpl calls suspend_and_notify() when engine returns DenyAction::SuspendAgent
- Lazy auto-resume on heartbeat: only BudgetExceeded suspensions auto-resume; Manual suspensions require explicit intervention
- PolicyEngine::is_within_budget() for budget state queries

## Type of Change

- [x] New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-140
- Parent epic: AAASM-8

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

Test coverage (295 total: 226 unit + 69 integration):
- Policy: 2 serde tests + 4 validation tests for action_on_exceed
- Engine: 6 tests for deny/suspend paths, monthly suspend, within-budget allow
- Registry: 4 tests for suspend/resume/status/suspend_and_notify
- Lifecycle: 4 integration tests for heartbeat suspend signaling and auto-resume
- Policy service: 2 integration tests for suspend and deny budget paths (end-to-end through gRPC)

## Checklist

- [x] Code follows project style guidelines (cargo fmt, cargo clippy)
- [x] Self-review of the diff completed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Acceptance Criteria

| AC | Status |
|----|--------|
| action_on_exceed field in policy YAML (deny / suspend) | Done |
| When action_on_exceed: deny, behavior unchanged (per-request deny) | Done |
| When action_on_exceed: suspend, agent marked as Suspended in registry | Done |
| Suspended agent HeartbeatResponse has should_suspend: true | Done |
| SuspendCommand sent via ControlStream with reason budget limit exceeded | Done |
| Agent auto-resumes when budget resets (daily/monthly boundary) | Done |
| Unit tests for both deny and suspend paths | Done |