### PR TITLE
[AAASM-153] ✨ (proxy): Wire LLM extractors into runtime pipeline

### DIFF
--- a/aa-proxy/Cargo.toml
+++ b/aa-proxy/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 aa-core = { path = "../aa-core" }
+aa-proto   = { path = "../aa-proto" }
 aa-runtime = { path = "../aa-runtime" }
 tokio      = { version = "1", features = ["full"] }
 hyper      = { version = "1", features = ["server", "http1"] }

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -4,18 +4,27 @@ pub mod detect;
 pub mod event;
 pub mod extract;
 
+use tokio::sync::broadcast;
+
+use aa_runtime::pipeline::PipelineEvent;
+
 use crate::error::ProxyError;
 use crate::intercept::detect::LlmApiPattern;
 use crate::intercept::extract::{extract_anthropic, extract_cohere, extract_openai, ExtractionError, LlmFields};
 
 /// Inspects a decrypted HTTP request/response pair, decides whether it is an
 /// LLM API call, and extracts audit-relevant fields from the body.
-pub struct Interceptor;
+///
+/// Holds a [`broadcast::Sender`] to emit [`PipelineEvent`]s for intercepted
+/// LLM calls into the runtime event pipeline.
+pub struct Interceptor {
+    event_tx: broadcast::Sender<PipelineEvent>,
+}
 
 impl Interceptor {
-    /// Create a new `Interceptor`.
-    pub fn new() -> Self {
-        Self
+    /// Create a new `Interceptor` that emits events on the given broadcast channel.
+    pub fn new(event_tx: broadcast::Sender<PipelineEvent>) -> Self {
+        Self { event_tx }
     }
 
     /// Inspect an intercepted exchange, extract LLM fields from the body
@@ -76,12 +85,6 @@ impl Interceptor {
     }
 }
 
-impl Default for Interceptor {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::time::SystemTime;
@@ -91,6 +94,14 @@ mod tests {
     use super::*;
     use crate::intercept::detect::LlmApiPattern;
     use crate::intercept::event::ProxyEvent;
+
+    /// Create a dummy `Interceptor` with a broadcast sender whose receiver is
+    /// dropped — sends silently fail, which is correct for unit tests that
+    /// only verify extraction logic.
+    fn make_interceptor() -> Interceptor {
+        let (tx, _rx) = broadcast::channel(16);
+        Interceptor::new(tx)
+    }
 
     fn make_event(pattern: LlmApiPattern) -> ProxyEvent {
         ProxyEvent {
@@ -106,21 +117,21 @@ mod tests {
 
     #[tokio::test]
     async fn intercept_openai_event_succeeds() {
-        let interceptor = Interceptor::new();
+        let interceptor = make_interceptor();
         let result = interceptor.intercept(&make_event(LlmApiPattern::OpenAi)).await;
         assert!(result.is_ok());
     }
 
     #[tokio::test]
     async fn intercept_anthropic_event_succeeds() {
-        let interceptor = Interceptor::new();
+        let interceptor = make_interceptor();
         let result = interceptor.intercept(&make_event(LlmApiPattern::Anthropic)).await;
         assert!(result.is_ok());
     }
 
     #[tokio::test]
     async fn intercept_unknown_returns_none() {
-        let interceptor = Interceptor::new();
+        let interceptor = make_interceptor();
         let result = interceptor
             .intercept(&make_event(LlmApiPattern::Unknown))
             .await
@@ -130,7 +141,7 @@ mod tests {
 
     #[tokio::test]
     async fn intercept_with_no_agent_id_succeeds() {
-        let interceptor = Interceptor::new();
+        let interceptor = make_interceptor();
         let mut event = make_event(LlmApiPattern::OpenAi);
         event.agent_id = None;
         assert!(interceptor.intercept(&event).await.is_ok());
@@ -138,7 +149,7 @@ mod tests {
 
     #[tokio::test]
     async fn intercept_openai_with_body_extracts_fields() {
-        let interceptor = Interceptor::new();
+        let interceptor = make_interceptor();
         let mut event = make_event(LlmApiPattern::OpenAi);
         event.response_body = Some(Bytes::from(
             r#"{"model":"gpt-4","usage":{"prompt_tokens":10,"completion_tokens":20}}"#,
@@ -151,7 +162,7 @@ mod tests {
 
     #[tokio::test]
     async fn intercept_anthropic_with_body_extracts_fields() {
-        let interceptor = Interceptor::new();
+        let interceptor = make_interceptor();
         let mut event = make_event(LlmApiPattern::Anthropic);
         event.response_body = Some(Bytes::from(
             r#"{"model":"claude-3-opus-20240229","usage":{"input_tokens":15,"output_tokens":30}}"#,
@@ -164,7 +175,7 @@ mod tests {
 
     #[tokio::test]
     async fn intercept_cohere_with_body_extracts_fields() {
-        let interceptor = Interceptor::new();
+        let interceptor = make_interceptor();
         let mut event = make_event(LlmApiPattern::Cohere);
         event.response_body = Some(Bytes::from(
             r#"{"model":"command-r-plus","message":"hello","meta":{"tokens":{"input_tokens":5,"output_tokens":12}}}"#,
@@ -178,7 +189,7 @@ mod tests {
 
     #[tokio::test]
     async fn intercept_prefers_response_body_over_request() {
-        let interceptor = Interceptor::new();
+        let interceptor = make_interceptor();
         let mut event = make_event(LlmApiPattern::OpenAi);
         event.request_body = Some(Bytes::from(
             r#"{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}"#,
@@ -195,7 +206,7 @@ mod tests {
 
     #[tokio::test]
     async fn intercept_falls_back_to_request_body() {
-        let interceptor = Interceptor::new();
+        let interceptor = make_interceptor();
         let mut event = make_event(LlmApiPattern::OpenAi);
         event.request_body = Some(Bytes::from(
             r#"{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}"#,
@@ -209,7 +220,7 @@ mod tests {
 
     #[tokio::test]
     async fn intercept_with_none_body_returns_none() {
-        let interceptor = Interceptor::new();
+        let interceptor = make_interceptor();
         let event = make_event(LlmApiPattern::OpenAi);
         // Both request_body and response_body are None
         let result = interceptor.intercept(&event).await.unwrap();
@@ -218,7 +229,7 @@ mod tests {
 
     #[tokio::test]
     async fn intercept_with_malformed_body_returns_none() {
-        let interceptor = Interceptor::new();
+        let interceptor = make_interceptor();
         let mut event = make_event(LlmApiPattern::OpenAi);
         event.response_body = Some(Bytes::from("not json"));
         // Malformed body logs a warning and returns None (not an error)

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -293,4 +293,51 @@ mod tests {
         let result = interceptor.intercept(&event).await.unwrap();
         assert!(result.is_none());
     }
+
+    #[tokio::test]
+    async fn non_llm_traffic_emits_no_pipeline_event() {
+        let (tx, mut rx) = broadcast::channel(16);
+        let interceptor = Interceptor::new(tx);
+        let event = make_event(LlmApiPattern::Unknown);
+
+        interceptor.intercept(&event).await.unwrap();
+
+        // Channel should be empty — Unknown pattern skips emission.
+        assert!(
+            rx.try_recv().is_err(),
+            "non-LLM traffic must not emit a pipeline event"
+        );
+    }
+
+    #[tokio::test]
+    async fn llm_traffic_emits_pipeline_event_with_correct_fields() {
+        let (tx, mut rx) = broadcast::channel(16);
+        let interceptor = Interceptor::new(tx);
+        let mut event = make_event(LlmApiPattern::OpenAi);
+        event.response_body = Some(Bytes::from(
+            r#"{"model":"gpt-4","usage":{"prompt_tokens":10,"completion_tokens":20}}"#,
+        ));
+
+        interceptor.intercept(&event).await.unwrap();
+
+        let pipeline_event = rx.try_recv().expect("should have received a pipeline event");
+        match pipeline_event {
+            PipelineEvent::Audit(enriched) => {
+                assert_eq!(enriched.source, EventSource::Proxy);
+                assert_eq!(enriched.agent_id, "test-agent");
+                // Verify the LlmCallDetail inside the AuditEvent.
+                let detail = enriched.inner.detail.expect("detail must be set");
+                match detail {
+                    aa_proto::assembly::audit::v1::audit_event::Detail::LlmCall(llm) => {
+                        assert_eq!(llm.model, "gpt-4");
+                        assert_eq!(llm.prompt_tokens, 10);
+                        assert_eq!(llm.completion_tokens, 20);
+                        assert_eq!(llm.provider, "openai");
+                    }
+                    other => panic!("expected LlmCall detail, got {other:?}"),
+                }
+            }
+            other => panic!("expected Audit event, got {other:?}"),
+        }
+    }
 }

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -84,10 +84,7 @@ impl Interceptor {
     }
 
     /// Build a [`PipelineEvent::Audit`] from a proxy event and optional extracted fields.
-    fn build_pipeline_event(
-        event: &event::ProxyEvent,
-        fields: Option<&LlmFields>,
-    ) -> PipelineEvent {
+    fn build_pipeline_event(event: &event::ProxyEvent, fields: Option<&LlmFields>) -> PipelineEvent {
         let now_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
@@ -303,10 +300,7 @@ mod tests {
         interceptor.intercept(&event).await.unwrap();
 
         // Channel should be empty — Unknown pattern skips emission.
-        assert!(
-            rx.try_recv().is_err(),
-            "non-LLM traffic must not emit a pipeline event"
-        );
+        assert!(rx.try_recv().is_err(), "non-LLM traffic must not emit a pipeline event");
     }
 
     #[tokio::test]

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -4,8 +4,13 @@ pub mod detect;
 pub mod event;
 pub mod extract;
 
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use tokio::sync::broadcast;
 
+use aa_proto::assembly::audit::v1::{audit_event, AuditEvent, LlmCallDetail};
+use aa_proto::assembly::common::v1::ActionType;
+use aa_runtime::pipeline::event::{EnrichedEvent, EventSource};
 use aa_runtime::pipeline::PipelineEvent;
 
 use crate::error::ProxyError;
@@ -27,12 +32,11 @@ impl Interceptor {
         Self { event_tx }
     }
 
-    /// Inspect an intercepted exchange, extract LLM fields from the body
-    /// (if available), and log the result.
+    /// Inspect an intercepted exchange, extract LLM fields from the body,
+    /// and emit a [`PipelineEvent::Audit`] on the broadcast channel.
     ///
-    /// Full policy evaluation (forwarding to `aa-gateway`) and pipeline
-    /// integration (`broadcast::Sender<PipelineEvent>`) will be added in a
-    /// future ticket. For now this extracts and logs.
+    /// Returns the extracted [`LlmFields`] (or `None` for non-LLM traffic
+    /// and extraction failures).
     pub async fn intercept(&self, event: &event::ProxyEvent) -> Result<Option<LlmFields>, ProxyError> {
         // Non-LLM traffic is passed through without extraction.
         if event.pattern == LlmApiPattern::Unknown {
@@ -69,7 +73,60 @@ impl Interceptor {
             "intercepted LLM API call"
         );
 
+        // Emit a PipelineEvent for every detected LLM call (even when body
+        // extraction failed — the audit record still captures the call).
+        let pipeline_event = Self::build_pipeline_event(event, fields.as_ref());
+        // send() returns Err only when there are zero receivers — that is
+        // normal during standalone proxy operation (no runtime attached).
+        let _ = self.event_tx.send(pipeline_event);
+
         Ok(fields)
+    }
+
+    /// Build a [`PipelineEvent::Audit`] from a proxy event and optional extracted fields.
+    fn build_pipeline_event(
+        event: &event::ProxyEvent,
+        fields: Option<&LlmFields>,
+    ) -> PipelineEvent {
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+
+        let llm_detail = LlmCallDetail {
+            model: fields.map(|f| f.model.clone()).unwrap_or_default(),
+            prompt_tokens: fields.and_then(|f| f.prompt_tokens).unwrap_or(0) as i32,
+            completion_tokens: fields.and_then(|f| f.completion_tokens).unwrap_or(0) as i32,
+            provider: Self::provider_name(&event.pattern).into(),
+            ..Default::default()
+        };
+
+        let audit = AuditEvent {
+            action_type: ActionType::LlmCall.into(),
+            detail: Some(audit_event::Detail::LlmCall(llm_detail)),
+            ..Default::default()
+        };
+
+        let enriched = EnrichedEvent {
+            inner: audit,
+            received_at_ms: now_ms,
+            source: EventSource::Proxy,
+            agent_id: event.agent_id.clone().unwrap_or_default(),
+            connection_id: 0,
+            sequence_number: 0,
+        };
+
+        PipelineEvent::Audit(Box::new(enriched))
+    }
+
+    /// Map a detected API pattern to the provider name stored in the audit record.
+    fn provider_name(pattern: &LlmApiPattern) -> &'static str {
+        match pattern {
+            LlmApiPattern::OpenAi => "openai",
+            LlmApiPattern::Anthropic => "anthropic",
+            LlmApiPattern::Cohere => "cohere",
+            LlmApiPattern::Unknown => "unknown",
+        }
     }
 
     /// Select the correct extractor based on the detected API pattern.

--- a/aa-proxy/src/lib.rs
+++ b/aa-proxy/src/lib.rs
@@ -31,7 +31,10 @@ pub use error::ProxyError;
 /// Loads or creates the CA from `config.ca_dir`, installs it into the macOS
 /// System Keychain if not already trusted, constructs a [`proxy::ProxyServer`],
 /// and enters the TCP accept loop. Returns only on unrecoverable error.
-pub async fn run(config: ProxyConfig) -> anyhow::Result<()> {
+pub async fn run(
+    config: ProxyConfig,
+    event_tx: tokio::sync::broadcast::Sender<aa_runtime::pipeline::PipelineEvent>,
+) -> anyhow::Result<()> {
     let ca = tls::CaStore::load_or_create(&config.ca_dir).await?;
 
     #[cfg(target_os = "macos")]
@@ -41,7 +44,7 @@ pub async fn run(config: ProxyConfig) -> anyhow::Result<()> {
         tracing::info!("CA installed successfully");
     }
 
-    let server = proxy::ProxyServer::new(config, ca);
+    let server = proxy::ProxyServer::new(config, ca, event_tx);
     server.run().await?;
     Ok(())
 }

--- a/aa-proxy/src/main.rs
+++ b/aa-proxy/src/main.rs
@@ -10,5 +10,6 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let config = aa_proxy::ProxyConfig::from_env()?;
-    aa_proxy::run(config).await
+    let (event_tx, _rx) = tokio::sync::broadcast::channel(256);
+    aa_proxy::run(config, event_tx).await
 }

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -10,7 +10,10 @@ use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, Serve
 use rustls::ServerConfig;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::broadcast;
 use tokio_rustls::{TlsAcceptor, TlsConnector};
+
+use aa_runtime::pipeline::PipelineEvent;
 
 use crate::config::ProxyConfig;
 use crate::error::ProxyError;
@@ -32,14 +35,15 @@ pub struct ProxyServer {
 }
 
 impl ProxyServer {
-    /// Construct a `ProxyServer` from a validated config and an initialised CA.
-    pub fn new(config: ProxyConfig, ca: CaStore) -> Arc<Self> {
+    /// Construct a `ProxyServer` from a validated config, an initialised CA,
+    /// and a broadcast sender for emitting pipeline events.
+    pub fn new(config: ProxyConfig, ca: CaStore, event_tx: broadcast::Sender<PipelineEvent>) -> Arc<Self> {
         let certs = CertCache::new(config.cert_cache_capacity);
         Arc::new(Self {
             config,
             ca,
             certs,
-            interceptor: Interceptor::new(),
+            interceptor: Interceptor::new(event_tx),
         })
     }
 

--- a/aa-proxy/tests/pipeline_emission.rs
+++ b/aa-proxy/tests/pipeline_emission.rs
@@ -1,0 +1,140 @@
+//! Integration tests verifying that the Interceptor emits correct
+//! PipelineEvents for each supported LLM provider.
+
+use std::time::SystemTime;
+
+use bytes::Bytes;
+use tokio::sync::broadcast;
+
+use aa_proto::assembly::audit::v1::audit_event;
+use aa_runtime::pipeline::event::{EnrichedEvent, EventSource};
+use aa_runtime::pipeline::PipelineEvent;
+
+use aa_proxy::intercept::detect::LlmApiPattern;
+use aa_proxy::intercept::event::ProxyEvent;
+use aa_proxy::intercept::Interceptor;
+
+fn make_event(pattern: LlmApiPattern, response_body: &str) -> ProxyEvent {
+    ProxyEvent {
+        agent_id: Some("integration-agent".into()),
+        pattern,
+        method: "POST".into(),
+        path: "/v1/chat/completions".into(),
+        request_body: None,
+        response_body: Some(Bytes::from(response_body.to_string())),
+        timestamp: SystemTime::now(),
+    }
+}
+
+fn unwrap_llm_detail(event: PipelineEvent) -> (EnrichedEvent, audit_event::Detail) {
+    match event {
+        PipelineEvent::Audit(enriched) => {
+            let detail = enriched.inner.detail.clone().expect("detail must be set");
+            (*enriched, detail)
+        }
+        other => panic!("expected Audit event, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn openai_response_emits_audit_event_with_llm_detail() {
+    let (tx, mut rx) = broadcast::channel(16);
+    let interceptor = Interceptor::new(tx);
+
+    let event = make_event(
+        LlmApiPattern::OpenAi,
+        r#"{"model":"gpt-4o","usage":{"prompt_tokens":100,"completion_tokens":50}}"#,
+    );
+    interceptor.intercept(&event).await.unwrap();
+
+    let (enriched, detail) = unwrap_llm_detail(rx.try_recv().unwrap());
+    assert_eq!(enriched.source, EventSource::Proxy);
+    assert_eq!(enriched.agent_id, "integration-agent");
+    match detail {
+        audit_event::Detail::LlmCall(llm) => {
+            assert_eq!(llm.model, "gpt-4o");
+            assert_eq!(llm.prompt_tokens, 100);
+            assert_eq!(llm.completion_tokens, 50);
+            assert_eq!(llm.provider, "openai");
+        }
+        other => panic!("expected LlmCall, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn anthropic_response_emits_audit_event_with_llm_detail() {
+    let (tx, mut rx) = broadcast::channel(16);
+    let interceptor = Interceptor::new(tx);
+
+    let event = make_event(
+        LlmApiPattern::Anthropic,
+        r#"{"model":"claude-3-5-sonnet","usage":{"input_tokens":200,"output_tokens":80}}"#,
+    );
+    interceptor.intercept(&event).await.unwrap();
+
+    let (enriched, detail) = unwrap_llm_detail(rx.try_recv().unwrap());
+    assert_eq!(enriched.source, EventSource::Proxy);
+    match detail {
+        audit_event::Detail::LlmCall(llm) => {
+            assert_eq!(llm.model, "claude-3-5-sonnet");
+            assert_eq!(llm.prompt_tokens, 200);
+            assert_eq!(llm.completion_tokens, 80);
+            assert_eq!(llm.provider, "anthropic");
+        }
+        other => panic!("expected LlmCall, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn cohere_response_emits_audit_event_with_llm_detail() {
+    let (tx, mut rx) = broadcast::channel(16);
+    let interceptor = Interceptor::new(tx);
+
+    let event = make_event(
+        LlmApiPattern::Cohere,
+        r#"{"model":"command-r-plus","message":"hi","meta":{"tokens":{"input_tokens":30,"output_tokens":15}}}"#,
+    );
+    interceptor.intercept(&event).await.unwrap();
+
+    let (enriched, detail) = unwrap_llm_detail(rx.try_recv().unwrap());
+    assert_eq!(enriched.source, EventSource::Proxy);
+    match detail {
+        audit_event::Detail::LlmCall(llm) => {
+            assert_eq!(llm.model, "command-r-plus");
+            assert_eq!(llm.prompt_tokens, 30);
+            assert_eq!(llm.completion_tokens, 15);
+            assert_eq!(llm.provider, "cohere");
+        }
+        other => panic!("expected LlmCall, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn multiple_llm_calls_produce_separate_events() {
+    let (tx, mut rx) = broadcast::channel(16);
+    let interceptor = Interceptor::new(tx);
+
+    let event1 = make_event(
+        LlmApiPattern::OpenAi,
+        r#"{"model":"gpt-4","usage":{"prompt_tokens":10,"completion_tokens":5}}"#,
+    );
+    let event2 = make_event(
+        LlmApiPattern::Anthropic,
+        r#"{"model":"claude-3-opus","usage":{"input_tokens":20,"output_tokens":10}}"#,
+    );
+
+    interceptor.intercept(&event1).await.unwrap();
+    interceptor.intercept(&event2).await.unwrap();
+
+    let (_, detail1) = unwrap_llm_detail(rx.try_recv().unwrap());
+    let (_, detail2) = unwrap_llm_detail(rx.try_recv().unwrap());
+
+    match detail1 {
+        audit_event::Detail::LlmCall(llm) => assert_eq!(llm.provider, "openai"),
+        other => panic!("expected LlmCall, got {other:?}"),
+    }
+    match detail2 {
+        audit_event::Detail::LlmCall(llm) => assert_eq!(llm.provider, "anthropic"),
+        other => panic!("expected LlmCall, got {other:?}"),
+    }
+}

--- a/aa-proxy/tests/proxy_integration.rs
+++ b/aa-proxy/tests/proxy_integration.rs
@@ -5,8 +5,11 @@ use std::net::SocketAddr;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 
+use tokio::sync::broadcast;
+
 use aa_proxy::config::ProxyConfig;
 use aa_proxy::tls::CaStore;
+use aa_runtime::pipeline::PipelineEvent;
 
 /// Helper: build a `ProxyConfig` bound to an ephemeral port on localhost.
 fn test_config(ca_dir: &std::path::Path) -> ProxyConfig {
@@ -33,7 +36,8 @@ async fn start_proxy(config: ProxyConfig, ca: CaStore) -> (SocketAddr, tokio::ta
         ..config
     };
 
-    let server = aa_proxy::proxy::ProxyServer::new(cfg, ca);
+    let (tx, _rx) = broadcast::channel::<PipelineEvent>(16);
+    let server = aa_proxy::proxy::ProxyServer::new(cfg, ca, tx);
     let handle = tokio::spawn(async move {
         let _ = server.run().await;
     });


### PR DESCRIPTION
## Description

Wires the per-provider LLM body extractors (OpenAI, Anthropic, Cohere) from AAASM-148 into the runtime event pipeline. The `Interceptor` now holds a `broadcast::Sender<PipelineEvent>` and emits `PipelineEvent::Audit` events containing `LlmCallDetail` (model, token counts, provider) for every intercepted LLM API call. Non-LLM traffic is skipped without emission.

This is Phase B of the AAASM-148 epic — Phase A (extractors) was delivered in PR #93.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] Yes (describe below)

`Interceptor::new()` now requires a `broadcast::Sender<PipelineEvent>` argument. `ProxyServer::new()` and `aa_proxy::run()` also require the sender parameter. The `Default` impl for `Interceptor` has been removed.

## Related Issues

- Related Jira ticket: AAASM-153
- Parent epic: AAASM-4 (Three-Layer Agent Interception)
- Depends on: AAASM-148 (extractors, merged in PR #93)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

**Unit tests (2 new):**
- `non_llm_traffic_emits_no_pipeline_event` — verifies Unknown pattern produces no broadcast event
- `llm_traffic_emits_pipeline_event_with_correct_fields` — verifies OpenAI event produces correct `EventSource::Proxy`, agent_id, model, token counts, and provider

**Integration tests (4 new in `tests/pipeline_emission.rs`):**
- `openai_response_emits_audit_event_with_llm_detail`
- `anthropic_response_emits_audit_event_with_llm_detail`
- `cohere_response_emits_audit_event_with_llm_detail`
- `multiple_llm_calls_produce_separate_events`

All 58 aa-proxy tests pass. Full workspace suite green (0 failures).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention