### PR TITLE
[AAASM-155] ✨ gateway: Add gRPC ApprovalService with 3 RPCs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,7 @@ dependencies = [
  "aa-proto",
  "aa-runtime",
  "arc-swap",
+ "async-stream",
  "async-trait",
  "chrono",
  "chrono-tz",
@@ -358,6 +359,28 @@ name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "async-trait"

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -25,6 +25,7 @@ chrono-tz    = { version = "0.9", features = ["serde"] }
 rust_decimal = { version = "1", features = ["serde-str"] }
 thiserror    = "2"
 dirs         = "6"
+async-stream = "0.3"
 async-trait  = "0.1"
 sha2         = "0.10"
 similar      = "2"

--- a/aa-gateway/src/main.rs
+++ b/aa-gateway/src/main.rs
@@ -49,8 +49,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _webhook_handle = aa_gateway::events::startup::maybe_spawn_webhook(&approval_queue, budget_alert_rx);
 
     if let Some(socket_path) = &cli.socket {
-        aa_gateway::server::serve_uds(&cli.policy, socket_path, registry).await
+        aa_gateway::server::serve_uds(&cli.policy, socket_path, registry, approval_queue).await
     } else {
-        aa_gateway::server::serve_tcp(&cli.policy, &cli.listen, registry).await
+        aa_gateway::server::serve_tcp(&cli.policy, &cli.listen, registry, approval_queue).await
     }
 }

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -9,11 +9,13 @@ use tonic::transport::Server;
 use crate::audit::AuditWriter;
 use crate::engine::PolicyEngine;
 use crate::registry::AgentRegistry;
-use crate::service::{AgentLifecycleServiceImpl, AuditServiceImpl, PolicyServiceImpl};
+use crate::service::{AgentLifecycleServiceImpl, ApprovalServiceImpl, AuditServiceImpl, PolicyServiceImpl};
 use aa_core::AuditEntry;
 use aa_proto::assembly::agent::v1::agent_lifecycle_service_server::AgentLifecycleServiceServer;
+use aa_proto::assembly::approval::v1::approval_service_server::ApprovalServiceServer;
 use aa_proto::assembly::audit::v1::audit_service_server::AuditServiceServer;
 use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
+use aa_runtime::approval::ApprovalQueue;
 
 /// Default audit directory relative to the system data directory (`~/.aa/audit`).
 fn default_audit_dir() -> PathBuf {

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -61,6 +61,7 @@ pub async fn serve_tcp(
     policy_path: &Path,
     listen_addr: &str,
     registry: Arc<AgentRegistry>,
+    approval_queue: Arc<ApprovalQueue>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let engine = PolicyEngine::load_from_file(policy_path).map_err(|e| format!("failed to load policy: {e:?}"))?;
     let (audit_tx, audit_drops, initial_hash) = setup_audit("gateway", "default").await?;
@@ -72,6 +73,7 @@ pub async fn serve_tcp(
     );
     let audit_svc = AuditServiceImpl::new(audit_tx, audit_drops, initial_hash);
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);
+    let approval_svc = ApprovalServiceImpl::new(approval_queue);
 
     let addr = listen_addr.parse()?;
     tracing::info!(%addr, "starting gRPC server on TCP");
@@ -80,6 +82,7 @@ pub async fn serve_tcp(
         .add_service(PolicyServiceServer::new(policy_svc))
         .add_service(AuditServiceServer::new(audit_svc))
         .add_service(AgentLifecycleServiceServer::new(lifecycle_svc))
+        .add_service(ApprovalServiceServer::new(approval_svc))
         .serve(addr)
         .await?;
 

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -98,6 +98,7 @@ pub async fn serve_uds(
     policy_path: &Path,
     socket_path: &Path,
     registry: Arc<AgentRegistry>,
+    approval_queue: Arc<ApprovalQueue>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let engine = PolicyEngine::load_from_file(policy_path).map_err(|e| format!("failed to load policy: {e:?}"))?;
     let (audit_tx, audit_drops, initial_hash) = setup_audit("gateway", "default").await?;
@@ -109,6 +110,7 @@ pub async fn serve_uds(
     );
     let audit_svc = AuditServiceImpl::new(audit_tx, audit_drops, initial_hash);
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);
+    let approval_svc = ApprovalServiceImpl::new(approval_queue);
 
     tracing::info!(socket = %socket_path.display(), "starting gRPC server on UDS");
 
@@ -123,6 +125,7 @@ pub async fn serve_uds(
         .add_service(PolicyServiceServer::new(policy_svc))
         .add_service(AuditServiceServer::new(audit_svc))
         .add_service(AgentLifecycleServiceServer::new(lifecycle_svc))
+        .add_service(ApprovalServiceServer::new(approval_svc))
         .serve_with_incoming(incoming)
         .await?;
 

--- a/aa-gateway/src/service/approval_service.rs
+++ b/aa-gateway/src/service/approval_service.rs
@@ -67,6 +67,25 @@ impl ApprovalService for ApprovalServiceImpl {
         &self,
         _request: Request<WatchApprovalsRequest>,
     ) -> Result<Response<Self::WatchApprovalsStream>, Status> {
-        Err(Status::unimplemented("not yet implemented"))
+        let mut rx = self.queue.subscribe_events();
+
+        let stream = async_stream::stream! {
+            loop {
+                match rx.recv().await {
+                    Ok(approval_request) => {
+                        yield Ok(convert::approval_event_to_proto(&approval_request));
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!(skipped = n, "WatchApprovals subscriber lagged");
+                        continue;
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        break;
+                    }
+                }
+            }
+        };
+
+        Ok(Response::new(Box::pin(stream)))
     }
 }

--- a/aa-gateway/src/service/approval_service.rs
+++ b/aa-gateway/src/service/approval_service.rs
@@ -8,8 +8,7 @@ use tonic::{Request, Response, Status};
 
 use aa_proto::assembly::approval::v1::approval_service_server::ApprovalService;
 use aa_proto::assembly::approval::v1::{
-    ApprovalEvent, DecideRequest, DecideResponse, ListPendingRequest, ListPendingResponse,
-    WatchApprovalsRequest,
+    ApprovalEvent, DecideRequest, DecideResponse, ListPendingRequest, ListPendingResponse, WatchApprovalsRequest,
 };
 use aa_runtime::approval::ApprovalQueue;
 
@@ -29,8 +28,7 @@ impl ApprovalServiceImpl {
 
 #[tonic::async_trait]
 impl ApprovalService for ApprovalServiceImpl {
-    type WatchApprovalsStream =
-        Pin<Box<dyn Stream<Item = Result<ApprovalEvent, Status>> + Send + 'static>>;
+    type WatchApprovalsStream = Pin<Box<dyn Stream<Item = Result<ApprovalEvent, Status>> + Send + 'static>>;
 
     async fn list_pending(
         &self,
@@ -41,15 +39,11 @@ impl ApprovalService for ApprovalServiceImpl {
         Ok(Response::new(ListPendingResponse { requests }))
     }
 
-    async fn decide(
-        &self,
-        request: Request<DecideRequest>,
-    ) -> Result<Response<DecideResponse>, Status> {
+    async fn decide(&self, request: Request<DecideRequest>) -> Result<Response<DecideResponse>, Status> {
         let req = request.into_inner();
 
-        let (id, decision) = convert::decide_request_to_core(&req).map_err(|e| {
-            Status::invalid_argument(e.to_string())
-        })?;
+        let (id, decision) =
+            convert::decide_request_to_core(&req).map_err(|e| Status::invalid_argument(e.to_string()))?;
 
         match self.queue.decide(id, decision) {
             Ok(()) => Ok(Response::new(DecideResponse {

--- a/aa-gateway/src/service/approval_service.rs
+++ b/aa-gateway/src/service/approval_service.rs
@@ -1,0 +1,17 @@
+//! `ApprovalService` tonic trait implementation wiring gRPC RPCs to `ApprovalQueue`.
+
+use std::sync::Arc;
+
+use aa_runtime::approval::ApprovalQueue;
+
+/// gRPC service implementation wiring approval RPCs to [`ApprovalQueue`].
+pub struct ApprovalServiceImpl {
+    queue: Arc<ApprovalQueue>,
+}
+
+impl ApprovalServiceImpl {
+    /// Create a new service backed by the given approval queue.
+    pub fn new(queue: Arc<ApprovalQueue>) -> Self {
+        Self { queue }
+    }
+}

--- a/aa-gateway/src/service/approval_service.rs
+++ b/aa-gateway/src/service/approval_service.rs
@@ -43,9 +43,24 @@ impl ApprovalService for ApprovalServiceImpl {
 
     async fn decide(
         &self,
-        _request: Request<DecideRequest>,
+        request: Request<DecideRequest>,
     ) -> Result<Response<DecideResponse>, Status> {
-        Err(Status::unimplemented("not yet implemented"))
+        let req = request.into_inner();
+
+        let (id, decision) = convert::decide_request_to_core(&req).map_err(|e| {
+            Status::invalid_argument(e.to_string())
+        })?;
+
+        match self.queue.decide(id, decision) {
+            Ok(()) => Ok(Response::new(DecideResponse {
+                success: true,
+                error_message: String::new(),
+            })),
+            Err(e) => Ok(Response::new(DecideResponse {
+                success: false,
+                error_message: e.to_string(),
+            })),
+        }
     }
 
     async fn watch_approvals(

--- a/aa-gateway/src/service/approval_service.rs
+++ b/aa-gateway/src/service/approval_service.rs
@@ -1,8 +1,19 @@
 //! `ApprovalService` tonic trait implementation wiring gRPC RPCs to `ApprovalQueue`.
 
+use std::pin::Pin;
 use std::sync::Arc;
 
+use tokio_stream::Stream;
+use tonic::{Request, Response, Status};
+
+use aa_proto::assembly::approval::v1::approval_service_server::ApprovalService;
+use aa_proto::assembly::approval::v1::{
+    ApprovalEvent, DecideRequest, DecideResponse, ListPendingRequest, ListPendingResponse,
+    WatchApprovalsRequest,
+};
 use aa_runtime::approval::ApprovalQueue;
+
+use crate::service::convert;
 
 /// gRPC service implementation wiring approval RPCs to [`ApprovalQueue`].
 pub struct ApprovalServiceImpl {
@@ -13,5 +24,34 @@ impl ApprovalServiceImpl {
     /// Create a new service backed by the given approval queue.
     pub fn new(queue: Arc<ApprovalQueue>) -> Self {
         Self { queue }
+    }
+}
+
+#[tonic::async_trait]
+impl ApprovalService for ApprovalServiceImpl {
+    type WatchApprovalsStream =
+        Pin<Box<dyn Stream<Item = Result<ApprovalEvent, Status>> + Send + 'static>>;
+
+    async fn list_pending(
+        &self,
+        _request: Request<ListPendingRequest>,
+    ) -> Result<Response<ListPendingResponse>, Status> {
+        let pending = self.queue.list();
+        let requests = pending.iter().map(convert::pending_to_proto).collect();
+        Ok(Response::new(ListPendingResponse { requests }))
+    }
+
+    async fn decide(
+        &self,
+        _request: Request<DecideRequest>,
+    ) -> Result<Response<DecideResponse>, Status> {
+        Err(Status::unimplemented("not yet implemented"))
+    }
+
+    async fn watch_approvals(
+        &self,
+        _request: Request<WatchApprovalsRequest>,
+    ) -> Result<Response<Self::WatchApprovalsStream>, Status> {
+        Err(Status::unimplemented("not yet implemented"))
     }
 }

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -8,11 +8,11 @@ use aa_core::identity::{AgentId, SessionId};
 use aa_core::time::Timestamp;
 use aa_core::{AgentContext, FileMode, GovernanceAction, PolicyResult};
 use aa_proto::assembly::approval::v1::{ApprovalDecisionType, ApprovalEvent, DecideRequest, PendingApproval};
-use aa_runtime::approval::{ApprovalDecision, ApprovalRequest, ApprovalRequestId};
 use aa_proto::assembly::common::v1::Decision;
 use aa_proto::assembly::policy::v1::action_context::Action;
 use aa_proto::assembly::policy::v1::{CheckActionRequest, CheckActionResponse, RedactInstructions, RedactRule};
 use aa_runtime::approval::PendingApprovalRequest;
+use aa_runtime::approval::{ApprovalDecision, ApprovalRequest, ApprovalRequestId};
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 
@@ -245,8 +245,8 @@ pub fn decide_request_to_core(
 ) -> Result<(ApprovalRequestId, ApprovalDecision), ApprovalConvertError> {
     let id: ApprovalRequestId = req.request_id.parse()?;
 
-    let decision_type = ApprovalDecisionType::try_from(req.decision)
-        .unwrap_or(ApprovalDecisionType::DecisionUnspecified);
+    let decision_type =
+        ApprovalDecisionType::try_from(req.decision).unwrap_or(ApprovalDecisionType::DecisionUnspecified);
 
     let decision = match decision_type {
         ApprovalDecisionType::Approved => ApprovalDecision::Approved {

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -7,7 +7,8 @@
 use aa_core::identity::{AgentId, SessionId};
 use aa_core::time::Timestamp;
 use aa_core::{AgentContext, FileMode, GovernanceAction, PolicyResult};
-use aa_proto::assembly::approval::v1::PendingApproval;
+use aa_proto::assembly::approval::v1::{ApprovalEvent, PendingApproval};
+use aa_runtime::approval::ApprovalRequest;
 use aa_proto::assembly::common::v1::Decision;
 use aa_proto::assembly::policy::v1::action_context::Action;
 use aa_proto::assembly::policy::v1::{CheckActionRequest, CheckActionResponse, RedactInstructions, RedactRule};
@@ -207,5 +208,18 @@ pub fn pending_to_proto(p: &PendingApprovalRequest) -> PendingApproval {
         condition_triggered: p.condition_triggered.clone(),
         submitted_at: p.submitted_at,
         timeout_secs: p.timeout_secs,
+    }
+}
+
+/// Convert an [`ApprovalRequest`] (from the broadcast channel) into a proto
+/// [`ApprovalEvent`] for streaming to WatchApprovals subscribers.
+pub fn approval_event_to_proto(req: &ApprovalRequest) -> ApprovalEvent {
+    ApprovalEvent {
+        request_id: req.request_id.to_string(),
+        agent_id: req.agent_id.clone(),
+        action: req.action.clone(),
+        condition_triggered: req.condition_triggered.clone(),
+        submitted_at: req.submitted_at,
+        timeout_secs: req.timeout_secs,
     }
 }

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -7,8 +7,8 @@
 use aa_core::identity::{AgentId, SessionId};
 use aa_core::time::Timestamp;
 use aa_core::{AgentContext, FileMode, GovernanceAction, PolicyResult};
-use aa_proto::assembly::approval::v1::{ApprovalEvent, PendingApproval};
-use aa_runtime::approval::ApprovalRequest;
+use aa_proto::assembly::approval::v1::{ApprovalDecisionType, ApprovalEvent, DecideRequest, PendingApproval};
+use aa_runtime::approval::{ApprovalDecision, ApprovalRequest, ApprovalRequestId};
 use aa_proto::assembly::common::v1::Decision;
 use aa_proto::assembly::policy::v1::action_context::Action;
 use aa_proto::assembly::policy::v1::{CheckActionRequest, CheckActionResponse, RedactInstructions, RedactRule};
@@ -236,4 +236,40 @@ pub enum ApprovalConvertError {
     /// REJECTED decision requires a non-empty reason.
     #[error("rejection reason is required")]
     MissingRejectionReason,
+}
+
+/// Convert a proto [`DecideRequest`] into the core types needed to call
+/// [`ApprovalQueue::decide`].
+pub fn decide_request_to_core(
+    req: &DecideRequest,
+) -> Result<(ApprovalRequestId, ApprovalDecision), ApprovalConvertError> {
+    let id: ApprovalRequestId = req.request_id.parse()?;
+
+    let decision_type = ApprovalDecisionType::try_from(req.decision)
+        .unwrap_or(ApprovalDecisionType::DecisionUnspecified);
+
+    let decision = match decision_type {
+        ApprovalDecisionType::Approved => ApprovalDecision::Approved {
+            by: req.decided_by.clone(),
+            reason: if req.reason.is_empty() {
+                None
+            } else {
+                Some(req.reason.clone())
+            },
+        },
+        ApprovalDecisionType::Rejected => {
+            if req.reason.is_empty() {
+                return Err(ApprovalConvertError::MissingRejectionReason);
+            }
+            ApprovalDecision::Rejected {
+                by: req.decided_by.clone(),
+                reason: req.reason.clone(),
+            }
+        }
+        ApprovalDecisionType::DecisionUnspecified => {
+            return Err(ApprovalConvertError::UnspecifiedDecision);
+        }
+    };
+
+    Ok((id, decision))
 }

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -7,9 +7,11 @@
 use aa_core::identity::{AgentId, SessionId};
 use aa_core::time::Timestamp;
 use aa_core::{AgentContext, FileMode, GovernanceAction, PolicyResult};
+use aa_proto::assembly::approval::v1::PendingApproval;
 use aa_proto::assembly::common::v1::Decision;
 use aa_proto::assembly::policy::v1::action_context::Action;
 use aa_proto::assembly::policy::v1::{CheckActionRequest, CheckActionResponse, RedactInstructions, RedactRule};
+use aa_runtime::approval::PendingApprovalRequest;
 use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 
@@ -193,4 +195,17 @@ pub fn result_to_response(result: &PolicyResult, latency_us: i64, policy_rule: &
         deny_action: None,
     };
     eval_result_to_response(&eval, latency_us, policy_rule)
+}
+
+/// Convert a [`PendingApprovalRequest`] (from `ApprovalQueue::list()`) into its
+/// proto representation.
+pub fn pending_to_proto(p: &PendingApprovalRequest) -> PendingApproval {
+    PendingApproval {
+        request_id: p.request_id.to_string(),
+        agent_id: p.agent_id.clone(),
+        action: p.action.clone(),
+        condition_triggered: p.condition_triggered.clone(),
+        submitted_at: p.submitted_at,
+        timeout_secs: p.timeout_secs,
+    }
 }

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -223,3 +223,17 @@ pub fn approval_event_to_proto(req: &ApprovalRequest) -> ApprovalEvent {
         timeout_secs: req.timeout_secs,
     }
 }
+
+/// Errors specific to approval decision conversion.
+#[derive(Debug, thiserror::Error)]
+pub enum ApprovalConvertError {
+    /// The `request_id` field is not a valid UUID.
+    #[error("invalid request_id UUID: {0}")]
+    InvalidRequestId(#[from] uuid::Error),
+    /// The `decision` field is unspecified or unknown.
+    #[error("decision type is unspecified")]
+    UnspecifiedDecision,
+    /// REJECTED decision requires a non-empty reason.
+    #[error("rejection reason is required")]
+    MissingRejectionReason,
+}

--- a/aa-gateway/src/service/mod.rs
+++ b/aa-gateway/src/service/mod.rs
@@ -1,10 +1,12 @@
 //! gRPC service layer — wires tonic-generated services to business logic.
 
+pub mod approval_service;
 pub mod audit_service;
 pub mod convert;
 pub mod lifecycle_service;
 pub mod policy_service;
 
+pub use approval_service::ApprovalServiceImpl;
 pub use audit_service::AuditServiceImpl;
 pub use lifecycle_service::AgentLifecycleServiceImpl;
 pub use policy_service::PolicyServiceImpl;

--- a/aa-gateway/tests/approval_service_test.rs
+++ b/aa-gateway/tests/approval_service_test.rs
@@ -256,3 +256,44 @@ async fn watch_approvals_streams_new_request() {
     assert_eq!(event.agent_id, "agent-test");
     assert_eq!(event.action, "deploy to production");
 }
+
+#[tokio::test]
+async fn watch_approvals_streams_multiple_requests() {
+    let (addr, queue) = start_server().await;
+    let mut client = ApprovalServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let mut stream = client
+        .watch_approvals(WatchApprovalsRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let mut expected_ids = Vec::new();
+    for _ in 0..3 {
+        let req = make_test_request();
+        expected_ids.push(req.request_id.to_string());
+        let (_rid, _fut) = queue.submit(req);
+    }
+
+    let mut received_ids = Vec::new();
+    for _ in 0..3 {
+        let event = tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            stream.message(),
+        )
+        .await
+        .expect("should receive event within 3 seconds")
+        .expect("stream should not error")
+        .expect("stream should not end");
+
+        received_ids.push(event.request_id);
+    }
+
+    expected_ids.sort();
+    received_ids.sort();
+    assert_eq!(received_ids, expected_ids);
+}

--- a/aa-gateway/tests/approval_service_test.rs
+++ b/aa-gateway/tests/approval_service_test.rs
@@ -1,0 +1,53 @@
+//! Integration tests for the ApprovalService gRPC endpoint.
+//!
+//! Starts a tonic server on a random TCP port, connects a client,
+//! and exercises ListPending, Decide, and WatchApprovals RPCs.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use aa_proto::assembly::approval::v1::approval_service_client::ApprovalServiceClient;
+use aa_proto::assembly::approval::v1::approval_service_server::ApprovalServiceServer;
+use aa_proto::assembly::approval::v1::{
+    ApprovalDecisionType, DecideRequest, ListPendingRequest, WatchApprovalsRequest,
+};
+use aa_gateway::service::ApprovalServiceImpl;
+use aa_runtime::approval::{ApprovalQueue, ApprovalRequest};
+use tokio::net::TcpListener;
+use tonic::transport::Server;
+use uuid::Uuid;
+
+/// Start an ApprovalService gRPC server and return the address + queue handle.
+async fn start_server() -> (SocketAddr, Arc<ApprovalQueue>) {
+    let queue = ApprovalQueue::new();
+    let service = ApprovalServiceImpl::new(Arc::clone(&queue));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(ApprovalServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    (addr, queue)
+}
+
+fn make_test_request() -> ApprovalRequest {
+    ApprovalRequest {
+        request_id: Uuid::new_v4(),
+        agent_id: "agent-test".to_string(),
+        action: "deploy to production".to_string(),
+        condition_triggered: "requires-tech-lead-approval".to_string(),
+        submitted_at: 1_700_000_000,
+        timeout_secs: 300,
+        fallback: aa_core::PolicyResult::Deny {
+            reason: "timed out".to_string(),
+        },
+    }
+}

--- a/aa-gateway/tests/approval_service_test.rs
+++ b/aa-gateway/tests/approval_service_test.rs
@@ -155,3 +155,25 @@ async fn decide_reject_resolves_request() {
         .into_inner();
     assert!(list_resp.requests.is_empty());
 }
+
+#[tokio::test]
+async fn decide_unknown_id_returns_failure() {
+    let (addr, _queue) = start_server().await;
+    let mut client = ApprovalServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let resp = client
+        .decide(DecideRequest {
+            request_id: Uuid::new_v4().to_string(),
+            decision: ApprovalDecisionType::Approved as i32,
+            decided_by: "alice".to_string(),
+            reason: String::new(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(!resp.success);
+    assert!(!resp.error_message.is_empty());
+}

--- a/aa-gateway/tests/approval_service_test.rs
+++ b/aa-gateway/tests/approval_service_test.rs
@@ -90,3 +90,36 @@ async fn list_pending_returns_submitted_request() {
     assert_eq!(resp.requests[0].agent_id, "agent-test");
     assert_eq!(resp.requests[0].action, "deploy to production");
 }
+
+#[tokio::test]
+async fn decide_approve_resolves_request() {
+    let (addr, queue) = start_server().await;
+    let mut client = ApprovalServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let req = make_test_request();
+    let request_id = req.request_id.to_string();
+    let (_rid, _fut) = queue.submit(req);
+
+    let resp = client
+        .decide(DecideRequest {
+            request_id: request_id.clone(),
+            decision: ApprovalDecisionType::Approved as i32,
+            decided_by: "alice".to_string(),
+            reason: "looks safe".to_string(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(resp.success);
+    assert!(resp.error_message.is_empty());
+
+    let list_resp = client
+        .list_pending(ListPendingRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(list_resp.requests.is_empty());
+}

--- a/aa-gateway/tests/approval_service_test.rs
+++ b/aa-gateway/tests/approval_service_test.rs
@@ -51,3 +51,19 @@ fn make_test_request() -> ApprovalRequest {
         },
     }
 }
+
+#[tokio::test]
+async fn list_pending_returns_empty_initially() {
+    let (addr, _queue) = start_server().await;
+    let mut client = ApprovalServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let resp = client
+        .list_pending(ListPendingRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(resp.requests.is_empty());
+}

--- a/aa-gateway/tests/approval_service_test.rs
+++ b/aa-gateway/tests/approval_service_test.rs
@@ -177,3 +177,24 @@ async fn decide_unknown_id_returns_failure() {
     assert!(!resp.success);
     assert!(!resp.error_message.is_empty());
 }
+
+#[tokio::test]
+async fn decide_invalid_uuid_returns_error() {
+    let (addr, _queue) = start_server().await;
+    let mut client = ApprovalServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let result = client
+        .decide(DecideRequest {
+            request_id: "not-a-uuid".to_string(),
+            decision: ApprovalDecisionType::Approved as i32,
+            decided_by: "alice".to_string(),
+            reason: String::new(),
+        })
+        .await;
+
+    assert!(result.is_err());
+    let status = result.unwrap_err();
+    assert_eq!(status.code(), tonic::Code::InvalidArgument);
+}

--- a/aa-gateway/tests/approval_service_test.rs
+++ b/aa-gateway/tests/approval_service_test.rs
@@ -123,3 +123,35 @@ async fn decide_approve_resolves_request() {
         .into_inner();
     assert!(list_resp.requests.is_empty());
 }
+
+#[tokio::test]
+async fn decide_reject_resolves_request() {
+    let (addr, queue) = start_server().await;
+    let mut client = ApprovalServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let req = make_test_request();
+    let request_id = req.request_id.to_string();
+    let (_rid, _fut) = queue.submit(req);
+
+    let resp = client
+        .decide(DecideRequest {
+            request_id,
+            decision: ApprovalDecisionType::Rejected as i32,
+            decided_by: "bob".to_string(),
+            reason: "too risky".to_string(),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert!(resp.success);
+
+    let list_resp = client
+        .list_pending(ListPendingRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(list_resp.requests.is_empty());
+}

--- a/aa-gateway/tests/approval_service_test.rs
+++ b/aa-gateway/tests/approval_service_test.rs
@@ -223,3 +223,36 @@ async fn reject_without_reason_returns_error() {
     let status = result.unwrap_err();
     assert_eq!(status.code(), tonic::Code::InvalidArgument);
 }
+
+#[tokio::test]
+async fn watch_approvals_streams_new_request() {
+    let (addr, queue) = start_server().await;
+    let mut client = ApprovalServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let mut stream = client
+        .watch_approvals(WatchApprovalsRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let req = make_test_request();
+    let expected_id = req.request_id.to_string();
+    let (_rid, _fut) = queue.submit(req);
+
+    let event = tokio::time::timeout(
+        std::time::Duration::from_secs(3),
+        stream.message(),
+    )
+    .await
+    .expect("should receive event within 3 seconds")
+    .expect("stream should not error")
+    .expect("stream should not end");
+
+    assert_eq!(event.request_id, expected_id);
+    assert_eq!(event.agent_id, "agent-test");
+    assert_eq!(event.action, "deploy to production");
+}

--- a/aa-gateway/tests/approval_service_test.rs
+++ b/aa-gateway/tests/approval_service_test.rs
@@ -67,3 +67,26 @@ async fn list_pending_returns_empty_initially() {
 
     assert!(resp.requests.is_empty());
 }
+
+#[tokio::test]
+async fn list_pending_returns_submitted_request() {
+    let (addr, queue) = start_server().await;
+    let mut client = ApprovalServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let req = make_test_request();
+    let expected_id = req.request_id.to_string();
+    let (_rid, _fut) = queue.submit(req);
+
+    let resp = client
+        .list_pending(ListPendingRequest {})
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(resp.requests.len(), 1);
+    assert_eq!(resp.requests[0].request_id, expected_id);
+    assert_eq!(resp.requests[0].agent_id, "agent-test");
+    assert_eq!(resp.requests[0].action, "deploy to production");
+}

--- a/aa-gateway/tests/approval_service_test.rs
+++ b/aa-gateway/tests/approval_service_test.rs
@@ -198,3 +198,28 @@ async fn decide_invalid_uuid_returns_error() {
     let status = result.unwrap_err();
     assert_eq!(status.code(), tonic::Code::InvalidArgument);
 }
+
+#[tokio::test]
+async fn reject_without_reason_returns_error() {
+    let (addr, queue) = start_server().await;
+    let mut client = ApprovalServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let req = make_test_request();
+    let request_id = req.request_id.to_string();
+    let (_rid, _fut) = queue.submit(req);
+
+    let result = client
+        .decide(DecideRequest {
+            request_id,
+            decision: ApprovalDecisionType::Rejected as i32,
+            decided_by: "bob".to_string(),
+            reason: String::new(),
+        })
+        .await;
+
+    assert!(result.is_err());
+    let status = result.unwrap_err();
+    assert_eq!(status.code(), tonic::Code::InvalidArgument);
+}

--- a/aa-gateway/tests/approval_service_test.rs
+++ b/aa-gateway/tests/approval_service_test.rs
@@ -6,12 +6,12 @@
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use aa_gateway::service::ApprovalServiceImpl;
 use aa_proto::assembly::approval::v1::approval_service_client::ApprovalServiceClient;
 use aa_proto::assembly::approval::v1::approval_service_server::ApprovalServiceServer;
 use aa_proto::assembly::approval::v1::{
     ApprovalDecisionType, DecideRequest, ListPendingRequest, WatchApprovalsRequest,
 };
-use aa_gateway::service::ApprovalServiceImpl;
 use aa_runtime::approval::{ApprovalQueue, ApprovalRequest};
 use tokio::net::TcpListener;
 use tonic::transport::Server;
@@ -55,15 +55,9 @@ fn make_test_request() -> ApprovalRequest {
 #[tokio::test]
 async fn list_pending_returns_empty_initially() {
     let (addr, _queue) = start_server().await;
-    let mut client = ApprovalServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = ApprovalServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
-    let resp = client
-        .list_pending(ListPendingRequest {})
-        .await
-        .unwrap()
-        .into_inner();
+    let resp = client.list_pending(ListPendingRequest {}).await.unwrap().into_inner();
 
     assert!(resp.requests.is_empty());
 }
@@ -71,19 +65,13 @@ async fn list_pending_returns_empty_initially() {
 #[tokio::test]
 async fn list_pending_returns_submitted_request() {
     let (addr, queue) = start_server().await;
-    let mut client = ApprovalServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = ApprovalServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let req = make_test_request();
     let expected_id = req.request_id.to_string();
     let (_rid, _fut) = queue.submit(req);
 
-    let resp = client
-        .list_pending(ListPendingRequest {})
-        .await
-        .unwrap()
-        .into_inner();
+    let resp = client.list_pending(ListPendingRequest {}).await.unwrap().into_inner();
 
     assert_eq!(resp.requests.len(), 1);
     assert_eq!(resp.requests[0].request_id, expected_id);
@@ -94,9 +82,7 @@ async fn list_pending_returns_submitted_request() {
 #[tokio::test]
 async fn decide_approve_resolves_request() {
     let (addr, queue) = start_server().await;
-    let mut client = ApprovalServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = ApprovalServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let req = make_test_request();
     let request_id = req.request_id.to_string();
@@ -116,20 +102,14 @@ async fn decide_approve_resolves_request() {
     assert!(resp.success);
     assert!(resp.error_message.is_empty());
 
-    let list_resp = client
-        .list_pending(ListPendingRequest {})
-        .await
-        .unwrap()
-        .into_inner();
+    let list_resp = client.list_pending(ListPendingRequest {}).await.unwrap().into_inner();
     assert!(list_resp.requests.is_empty());
 }
 
 #[tokio::test]
 async fn decide_reject_resolves_request() {
     let (addr, queue) = start_server().await;
-    let mut client = ApprovalServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = ApprovalServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let req = make_test_request();
     let request_id = req.request_id.to_string();
@@ -148,20 +128,14 @@ async fn decide_reject_resolves_request() {
 
     assert!(resp.success);
 
-    let list_resp = client
-        .list_pending(ListPendingRequest {})
-        .await
-        .unwrap()
-        .into_inner();
+    let list_resp = client.list_pending(ListPendingRequest {}).await.unwrap().into_inner();
     assert!(list_resp.requests.is_empty());
 }
 
 #[tokio::test]
 async fn decide_unknown_id_returns_failure() {
     let (addr, _queue) = start_server().await;
-    let mut client = ApprovalServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = ApprovalServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let resp = client
         .decide(DecideRequest {
@@ -181,9 +155,7 @@ async fn decide_unknown_id_returns_failure() {
 #[tokio::test]
 async fn decide_invalid_uuid_returns_error() {
     let (addr, _queue) = start_server().await;
-    let mut client = ApprovalServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = ApprovalServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let result = client
         .decide(DecideRequest {
@@ -202,9 +174,7 @@ async fn decide_invalid_uuid_returns_error() {
 #[tokio::test]
 async fn reject_without_reason_returns_error() {
     let (addr, queue) = start_server().await;
-    let mut client = ApprovalServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = ApprovalServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let req = make_test_request();
     let request_id = req.request_id.to_string();
@@ -227,9 +197,7 @@ async fn reject_without_reason_returns_error() {
 #[tokio::test]
 async fn watch_approvals_streams_new_request() {
     let (addr, queue) = start_server().await;
-    let mut client = ApprovalServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = ApprovalServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let mut stream = client
         .watch_approvals(WatchApprovalsRequest {})
@@ -243,14 +211,11 @@ async fn watch_approvals_streams_new_request() {
     let expected_id = req.request_id.to_string();
     let (_rid, _fut) = queue.submit(req);
 
-    let event = tokio::time::timeout(
-        std::time::Duration::from_secs(3),
-        stream.message(),
-    )
-    .await
-    .expect("should receive event within 3 seconds")
-    .expect("stream should not error")
-    .expect("stream should not end");
+    let event = tokio::time::timeout(std::time::Duration::from_secs(3), stream.message())
+        .await
+        .expect("should receive event within 3 seconds")
+        .expect("stream should not error")
+        .expect("stream should not end");
 
     assert_eq!(event.request_id, expected_id);
     assert_eq!(event.agent_id, "agent-test");
@@ -260,9 +225,7 @@ async fn watch_approvals_streams_new_request() {
 #[tokio::test]
 async fn watch_approvals_streams_multiple_requests() {
     let (addr, queue) = start_server().await;
-    let mut client = ApprovalServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = ApprovalServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let mut stream = client
         .watch_approvals(WatchApprovalsRequest {})
@@ -281,14 +244,11 @@ async fn watch_approvals_streams_multiple_requests() {
 
     let mut received_ids = Vec::new();
     for _ in 0..3 {
-        let event = tokio::time::timeout(
-            std::time::Duration::from_secs(3),
-            stream.message(),
-        )
-        .await
-        .expect("should receive event within 3 seconds")
-        .expect("stream should not error")
-        .expect("stream should not end");
+        let event = tokio::time::timeout(std::time::Duration::from_secs(3), stream.message())
+            .await
+            .expect("should receive event within 3 seconds")
+            .expect("stream should not error")
+            .expect("stream should not end");
 
         received_ids.push(event.request_id);
     }

--- a/aa-proto/build.rs
+++ b/aa-proto/build.rs
@@ -16,6 +16,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         proto_root.join("policy.proto"),
         proto_root.join("audit.proto"),
         proto_root.join("event.proto"),
+        proto_root.join("approval.proto"),
     ];
 
     tonic_build::configure()

--- a/aa-proto/src/lib.rs
+++ b/aa-proto/src/lib.rs
@@ -14,6 +14,7 @@
 //! assembly::policy::v1   — policy check hot path (path ②)
 //! assembly::audit::v1    — async audit trail (path ③)
 //! assembly::event::v1    — internal event bus envelope (paths ⑤ ⑥)
+//! assembly::approval::v1 — human-in-the-loop approval queue
 //! ```
 
 pub mod assembly {
@@ -44,6 +45,12 @@ pub mod assembly {
     pub mod event {
         pub mod v1 {
             tonic::include_proto!("assembly.event.v1");
+        }
+    }
+
+    pub mod approval {
+        pub mod v1 {
+            tonic::include_proto!("assembly.approval.v1");
         }
     }
 }

--- a/proto/approval.proto
+++ b/proto/approval.proto
@@ -52,3 +52,17 @@ message DecideResponse {
   // Non-empty when success is false; describes why the decision was not applied.
   string error_message = 2;
 }
+
+// ── WatchApprovals ───────────────────────────────────────────────────────────
+
+message WatchApprovalsRequest {}
+
+// ApprovalEvent is streamed to WatchApprovals subscribers when a new request arrives.
+message ApprovalEvent {
+  string request_id          = 1;
+  string agent_id            = 2;
+  string action              = 3;
+  string condition_triggered = 4;
+  uint64 submitted_at        = 5;
+  uint64 timeout_secs        = 6;
+}

--- a/proto/approval.proto
+++ b/proto/approval.proto
@@ -2,6 +2,21 @@ syntax = "proto3";
 
 package assembly.approval.v1;
 
+// ApprovalService exposes the human-in-the-loop approval queue over gRPC.
+//
+// Consumed by: CLI (future), dashboard WebSocket handler (future), grpcurl (testing)
+// Backed by:   aa-runtime/src/approval.rs (ApprovalQueue)
+service ApprovalService {
+  // ListPending returns a snapshot of all currently pending approval requests.
+  rpc ListPending(ListPendingRequest) returns (ListPendingResponse);
+
+  // Decide settles a pending approval request (approve or reject).
+  rpc Decide(DecideRequest) returns (DecideResponse);
+
+  // WatchApprovals streams new approval requests as they arrive in real-time.
+  rpc WatchApprovals(WatchApprovalsRequest) returns (stream ApprovalEvent);
+}
+
 // PendingApproval is the outward-facing snapshot of one pending request.
 message PendingApproval {
   // UUID v4 string identifying the request.

--- a/proto/approval.proto
+++ b/proto/approval.proto
@@ -17,3 +17,11 @@ message PendingApproval {
   // Seconds before the request auto-resolves as timed out.
   uint64 timeout_secs        = 6;
 }
+
+// ── ListPending ──────────────────────────────────────────────────────────────
+
+message ListPendingRequest {}
+
+message ListPendingResponse {
+  repeated PendingApproval requests = 1;
+}

--- a/proto/approval.proto
+++ b/proto/approval.proto
@@ -25,3 +25,12 @@ message ListPendingRequest {}
 message ListPendingResponse {
   repeated PendingApproval requests = 1;
 }
+
+// ── Decide ───────────────────────────────────────────────────────────────────
+
+// ApprovalDecisionType is the human operator's verdict.
+enum ApprovalDecisionType {
+  DECISION_UNSPECIFIED = 0;
+  APPROVED             = 1;
+  REJECTED             = 2;
+}

--- a/proto/approval.proto
+++ b/proto/approval.proto
@@ -34,3 +34,21 @@ enum ApprovalDecisionType {
   APPROVED             = 1;
   REJECTED             = 2;
 }
+
+message DecideRequest {
+  // UUID of the pending request to settle.
+  string               request_id = 1;
+  // The decision: approve or reject.
+  ApprovalDecisionType decision   = 2;
+  // Identifier of the operator making the decision.
+  string               decided_by = 3;
+  // Free-text reason. Required for REJECTED; optional for APPROVED.
+  string               reason     = 4;
+}
+
+message DecideResponse {
+  // True if the decision was applied; false if the request was already settled.
+  bool   success       = 1;
+  // Non-empty when success is false; describes why the decision was not applied.
+  string error_message = 2;
+}

--- a/proto/approval.proto
+++ b/proto/approval.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package assembly.approval.v1;
+
+// PendingApproval is the outward-facing snapshot of one pending request.
+message PendingApproval {
+  // UUID v4 string identifying the request.
+  string request_id          = 1;
+  // Agent that triggered the approval requirement.
+  string agent_id            = 2;
+  // Human-readable description of the action awaiting approval.
+  string action              = 3;
+  // Policy condition name that triggered this request.
+  string condition_triggered = 4;
+  // Unix epoch seconds when the request was submitted.
+  uint64 submitted_at        = 5;
+  // Seconds before the request auto-resolves as timed out.
+  uint64 timeout_secs        = 6;
+}


### PR DESCRIPTION
## Description

Implements the gRPC `ApprovalService` that exposes the human-in-the-loop approval queue (`aa-runtime::ApprovalQueue`) as a first-class gRPC endpoint.

### What changed

- **Proto definition** (`proto/approval.proto`): new `ApprovalService` with three RPCs — `ListPending`, `Decide`, `WatchApprovals` (server-streaming)
- **Code generation** (`aa-proto`): registered `approval.proto` in build script and module tree
- **Converters** (`aa-gateway/src/service/convert.rs`): `pending_to_proto`, `approval_event_to_proto`, `decide_request_to_core`, and `ApprovalConvertError` enum
- **Service implementation** (`aa-gateway/src/service/approval_service.rs`): `ApprovalServiceImpl` implementing all 3 RPCs via `ApprovalQueue`
- **Server wiring** (`aa-gateway/src/server.rs`, `main.rs`): `ApprovalServiceServer` added to both TCP and UDS listeners
- **Integration tests** (9 tests): ListPending empty/populated, Decide approve/reject/unknown ID/invalid UUID/missing rejection reason, WatchApprovals single/multiple events

### Why

AAASM-155: The `ApprovalQueue` existed in `aa-runtime` but had no external interface — agents could submit approval requests, but no operator could list, approve, or reject them via gRPC. This PR closes that gap.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Breaking Changes

None. New service is additive — existing RPCs are unchanged.

## Related Issues

Closes AAASM-155
Epic: AAASM-8 (Governance Gateway & Policy Engine)

## Testing

- 9 integration tests exercise all 3 RPCs end-to-end (real tonic server on random port)
- `cargo test --workspace` passes with 0 failures
- `cargo clippy --workspace` clean
- `cargo fmt --all -- --check` clean

## Checklist

- [x] Code compiles without warnings (clippy clean)
- [x] Tests pass locally
- [x] Code formatted with `cargo fmt`
- [x] No new dependencies except `async-stream = "0.3"` (for streaming RPC)
- [x] Proto follows existing `assembly.<domain>.v1` package convention
- [x] Service implementation follows existing patterns in `aa-gateway/src/service/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)