### PR TITLE
[AAASM-158] 🐛 (policy-service): Wire ApprovalQueue into PolicyServiceImpl

### DIFF
--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -104,8 +104,10 @@ pub async fn serve_uds(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let engine = PolicyEngine::load_from_file(policy_path).map_err(|e| format!("failed to load policy: {e:?}"))?;
     let (audit_tx, audit_drops, initial_hash) = setup_audit("gateway", "default").await?;
-    let policy_svc = PolicyServiceImpl::new(
+    let policy_svc = PolicyServiceImpl::with_registry_and_approval(
         Arc::new(engine),
+        Arc::clone(&registry),
+        Arc::clone(&approval_queue),
         audit_tx.clone(),
         Arc::clone(&audit_drops),
         initial_hash,

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -65,8 +65,10 @@ pub async fn serve_tcp(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let engine = PolicyEngine::load_from_file(policy_path).map_err(|e| format!("failed to load policy: {e:?}"))?;
     let (audit_tx, audit_drops, initial_hash) = setup_audit("gateway", "default").await?;
-    let policy_svc = PolicyServiceImpl::new(
+    let policy_svc = PolicyServiceImpl::with_registry_and_approval(
         Arc::new(engine),
+        Arc::clone(&registry),
+        Arc::clone(&approval_queue),
         audit_tx.clone(),
         Arc::clone(&audit_drops),
         initial_hash,

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -229,9 +229,7 @@ pub fn approval_decision_to_response(
             let (proto_decision, reason) = match fallback {
                 PolicyResult::Allow => (Decision::Allow, String::new()),
                 PolicyResult::Deny { reason } => (Decision::Deny, reason.clone()),
-                PolicyResult::RequiresApproval { .. } => {
-                    (Decision::Deny, "approval timed out".to_string())
-                }
+                PolicyResult::RequiresApproval { .. } => (Decision::Deny, "approval timed out".to_string()),
             };
             CheckActionResponse {
                 decision: proto_decision as i32,

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -198,6 +198,55 @@ pub fn result_to_response(result: &PolicyResult, latency_us: i64, policy_rule: &
     eval_result_to_response(&eval, latency_us, policy_rule)
 }
 
+/// Convert an [`ApprovalDecision`] into a [`CheckActionResponse`].
+///
+/// Maps `Approved` → `Decision::Allow`, `Rejected` → `Decision::Deny`,
+/// `TimedOut` → decision derived from the fallback `PolicyResult`.
+/// The real `approval_id` from the queue is included in all cases.
+pub fn approval_decision_to_response(
+    decision: &ApprovalDecision,
+    approval_id: &ApprovalRequestId,
+    latency_us: i64,
+    policy_rule: &str,
+) -> CheckActionResponse {
+    let id_str = approval_id.to_string();
+    match decision {
+        ApprovalDecision::Approved { .. } => CheckActionResponse {
+            decision: Decision::Allow as i32,
+            reason: String::new(),
+            policy_rule: policy_rule.to_string(),
+            approval_id: id_str,
+            redact: None,
+            decision_latency_us: latency_us,
+        },
+        ApprovalDecision::Rejected { reason, .. } => CheckActionResponse {
+            decision: Decision::Deny as i32,
+            reason: reason.clone(),
+            policy_rule: policy_rule.to_string(),
+            approval_id: id_str,
+            redact: None,
+            decision_latency_us: latency_us,
+        },
+        ApprovalDecision::TimedOut { fallback } => {
+            let (proto_decision, reason) = match fallback {
+                PolicyResult::Allow => (Decision::Allow, String::new()),
+                PolicyResult::Deny { reason } => (Decision::Deny, reason.clone()),
+                PolicyResult::RequiresApproval { .. } => {
+                    (Decision::Deny, "approval timed out".to_string())
+                }
+            };
+            CheckActionResponse {
+                decision: proto_decision as i32,
+                reason,
+                policy_rule: policy_rule.to_string(),
+                approval_id: id_str,
+                redact: None,
+                decision_latency_us: latency_us,
+            }
+        }
+    }
+}
+
 /// Convert a [`PendingApprovalRequest`] (from `ApprovalQueue::list()`) into its
 /// proto representation.
 pub fn pending_to_proto(p: &PendingApprovalRequest) -> PendingApproval {

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -173,14 +173,12 @@ pub fn eval_result_to_response(eval: &EvaluationResult, latency_us: i64, policy_
             redact: None,
             decision_latency_us: latency_us,
         },
-        PolicyResult::RequiresApproval { .. } => CheckActionResponse {
-            decision: Decision::Pending as i32,
-            reason: "human approval required".into(),
-            policy_rule: policy_rule.to_string(),
-            approval_id: uuid::Uuid::new_v4().to_string(),
-            redact: None,
-            decision_latency_us: latency_us,
-        },
+        PolicyResult::RequiresApproval { .. } => {
+            panic!(
+                "RequiresApproval must be handled before conversion — \
+                 use approval_decision_to_response() after submitting to the ApprovalQueue"
+            );
+        }
     }
 }
 

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -181,6 +181,83 @@ impl PolicyServiceImpl {
         }
     }
 
+    /// Submit a `RequiresApproval` evaluation to the approval queue, await
+    /// the human decision (with timeout), and return the final response.
+    ///
+    /// Returns `Some(response)` when the evaluation was `RequiresApproval` and
+    /// the queue was available. Returns `None` when the evaluation is not
+    /// `RequiresApproval` or the queue is absent (degraded mode — caller falls
+    /// through to the normal conversion path).
+    async fn maybe_submit_approval(
+        &self,
+        req: &CheckActionRequest,
+        eval: &EvaluationResult,
+        latency_us: i64,
+        policy_rule: &str,
+    ) -> Option<CheckActionResponse> {
+        let timeout_secs = match &eval.decision {
+            aa_core::PolicyResult::RequiresApproval { timeout_secs } => *timeout_secs,
+            _ => return None,
+        };
+
+        let queue = match &self.approval_queue {
+            Some(q) => q,
+            None => {
+                tracing::warn!(
+                    "RequiresApproval decision but no approval_queue attached — \
+                     returning Pending without queue submission (degraded mode)"
+                );
+                return None;
+            }
+        };
+
+        let approval_req = Self::build_approval_request(req, timeout_secs);
+        let approval_id = approval_req.request_id;
+
+        tracing::info!(
+            approval_id = %approval_id,
+            agent_id = %approval_req.agent_id,
+            action = %approval_req.action,
+            timeout_secs,
+            "submitting to approval queue"
+        );
+
+        let (_id, future) = queue.submit(approval_req);
+
+        // Await the operator's decision with a timeout guard.
+        // The ApprovalQueue also spawns its own timeout task, so both race;
+        // whichever fires first wins (the queue's resolve is idempotent).
+        let timeout_duration = std::time::Duration::from_secs(u64::from(timeout_secs));
+        let decision = match tokio::time::timeout(timeout_duration, future).await {
+            Ok(Ok(decision)) => decision,
+            Ok(Err(_recv_err)) => {
+                // Oneshot sender was dropped — the queue entry was removed
+                // externally (should not happen in normal operation).
+                tracing::warn!(approval_id = %approval_id, "approval channel closed unexpectedly");
+                aa_runtime::approval::ApprovalDecision::Rejected {
+                    by: "system".to_string(),
+                    reason: "approval channel closed".to_string(),
+                }
+            }
+            Err(_elapsed) => {
+                // Our timeout fired before the queue's timeout task.
+                tracing::info!(approval_id = %approval_id, "approval timed out");
+                aa_runtime::approval::ApprovalDecision::TimedOut {
+                    fallback: aa_core::PolicyResult::Deny {
+                        reason: "approval timed out".to_string(),
+                    },
+                }
+            }
+        };
+
+        Some(convert::approval_decision_to_response(
+            &decision,
+            &approval_id,
+            latency_us,
+            policy_rule,
+        ))
+    }
+
     /// Build an `AuditEntry` from a request and evaluation result, then fire-and-forget
     /// via `try_send`. Maintains the hash chain by reading and updating `last_hash`.
     /// Never blocks the caller beyond the brief mutex acquisition.

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -15,7 +15,7 @@ use aa_proto::assembly::policy::v1::{BatchCheckRequest, BatchCheckResponse, Chec
 
 use aa_runtime::approval::ApprovalQueue;
 
-use crate::engine::{DenyAction, PolicyEngine};
+use crate::engine::{DenyAction, EvaluationResult, PolicyEngine};
 use crate::registry::convert::proto_agent_id_to_key;
 use crate::registry::{AgentRegistry, SuspendReason};
 use crate::service::convert;
@@ -100,10 +100,14 @@ impl PolicyServiceImpl {
         }
     }
 
-    /// Evaluate a single request against the engine, returning the gRPC response
-    /// and the optional deny-action side-effect.
+    /// Evaluate a single request against the engine, returning the raw
+    /// evaluation result, measured latency, and the policy rule label.
+    ///
+    /// Callers are responsible for converting the [`EvaluationResult`] into a
+    /// proto response — this allows `RequiresApproval` to be intercepted before
+    /// the conversion.
     #[allow(clippy::result_large_err)] // tonic::Status is the standard gRPC error type
-    fn evaluate_one(&self, req: &CheckActionRequest) -> Result<(CheckActionResponse, Option<DenyAction>), Status> {
+    fn evaluate_one(&self, req: &CheckActionRequest) -> Result<(EvaluationResult, i64, String), Status> {
         let (ctx, action) = convert::request_to_core(req).map_err(|e| {
             tracing::error!(error = %e, "failed to convert CheckActionRequest");
             Status::invalid_argument(e.to_string())
@@ -115,16 +119,12 @@ impl PolicyServiceImpl {
 
         // Derive a policy_rule label from the deny/approval reason.
         let policy_rule = match &eval.decision {
-            aa_core::PolicyResult::Allow => "",
-            aa_core::PolicyResult::Deny { reason } => reason.as_str(),
-            aa_core::PolicyResult::RequiresApproval { .. } => "requires_approval",
+            aa_core::PolicyResult::Allow => String::new(),
+            aa_core::PolicyResult::Deny { reason } => reason.clone(),
+            aa_core::PolicyResult::RequiresApproval { .. } => "requires_approval".to_string(),
         };
 
-        let deny_action = eval.deny_action;
-        Ok((
-            convert::eval_result_to_response(&eval, latency_us, policy_rule),
-            deny_action,
-        ))
+        Ok((eval, latency_us, policy_rule))
     }
 
     /// Execute the suspension side-effect when the engine signals `SuspendAgent`.
@@ -230,7 +230,9 @@ impl PolicyService for PolicyServiceImpl {
             "check_action request"
         );
 
-        let (response, deny_action) = self.evaluate_one(&req)?;
+        let (eval, latency_us, policy_rule) = self.evaluate_one(&req)?;
+        let deny_action = eval.deny_action;
+        let response = convert::eval_result_to_response(&eval, latency_us, &policy_rule);
 
         tracing::debug!(
             decision = response.decision,
@@ -261,7 +263,9 @@ impl PolicyService for PolicyServiceImpl {
         let mut responses = Vec::with_capacity(batch.requests.len());
 
         for req in &batch.requests {
-            let (resp, deny_action) = self.evaluate_one(req)?;
+            let (eval, latency_us, policy_rule) = self.evaluate_one(req)?;
+            let deny_action = eval.deny_action;
+            let resp = convert::eval_result_to_response(&eval, latency_us, &policy_rule);
             self.maybe_suspend_agent(req, deny_action).await;
             self.record_audit(req, &resp).await;
             responses.push(resp);

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -13,6 +13,8 @@ use aa_core::{AuditEntry, AuditEventType};
 use aa_proto::assembly::policy::v1::policy_service_server::PolicyService;
 use aa_proto::assembly::policy::v1::{BatchCheckRequest, BatchCheckResponse, CheckActionRequest, CheckActionResponse};
 
+use aa_runtime::approval::ApprovalQueue;
+
 use crate::engine::{DenyAction, PolicyEngine};
 use crate::registry::convert::proto_agent_id_to_key;
 use crate::registry::{AgentRegistry, SuspendReason};
@@ -22,6 +24,7 @@ use crate::service::convert;
 pub struct PolicyServiceImpl {
     engine: Arc<PolicyEngine>,
     registry: Option<Arc<AgentRegistry>>,
+    approval_queue: Option<Arc<ApprovalQueue>>,
     audit_tx: mpsc::Sender<AuditEntry>,
     audit_drops: Arc<AtomicU64>,
     seq: AtomicU64,
@@ -43,6 +46,7 @@ impl PolicyServiceImpl {
         Self {
             engine,
             registry: None,
+            approval_queue: None,
             audit_tx,
             audit_drops,
             seq: AtomicU64::new(0),
@@ -64,6 +68,7 @@ impl PolicyServiceImpl {
         Self {
             engine,
             registry: Some(registry),
+            approval_queue: None,
             audit_tx,
             audit_drops,
             seq: AtomicU64::new(0),

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -158,11 +158,7 @@ impl PolicyServiceImpl {
 
     /// Build an [`ApprovalRequest`] from a gRPC request and the policy timeout.
     fn build_approval_request(req: &CheckActionRequest, timeout_secs: u32) -> ApprovalRequest {
-        let agent_id = req
-            .agent_id
-            .as_ref()
-            .map(|a| a.agent_id.clone())
-            .unwrap_or_default();
+        let agent_id = req.agent_id.as_ref().map(|a| a.agent_id.clone()).unwrap_or_default();
         let now = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap_or_default()
@@ -336,13 +332,12 @@ impl PolicyService for PolicyServiceImpl {
         let deny_action = eval.deny_action;
 
         // If RequiresApproval, submit to the queue and block until decided.
-        let response = if let Some(approval_response) =
-            self.maybe_submit_approval(&req, &eval, latency_us, &policy_rule).await
-        {
-            approval_response
-        } else {
-            convert::eval_result_to_response(&eval, latency_us, &policy_rule)
-        };
+        let response =
+            if let Some(approval_response) = self.maybe_submit_approval(&req, &eval, latency_us, &policy_rule).await {
+                approval_response
+            } else {
+                convert::eval_result_to_response(&eval, latency_us, &policy_rule)
+            };
 
         tracing::debug!(
             decision = response.decision,

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -76,6 +76,30 @@ impl PolicyServiceImpl {
         }
     }
 
+    /// Create a new service with both an agent registry and approval queue.
+    ///
+    /// When an approval queue is provided, actions that require human approval
+    /// are submitted to the queue and the gRPC call blocks until the operator
+    /// decides (or the timeout elapses).
+    pub fn with_registry_and_approval(
+        engine: Arc<PolicyEngine>,
+        registry: Arc<AgentRegistry>,
+        approval_queue: Arc<ApprovalQueue>,
+        audit_tx: mpsc::Sender<AuditEntry>,
+        audit_drops: Arc<AtomicU64>,
+        initial_hash: [u8; 32],
+    ) -> Self {
+        Self {
+            engine,
+            registry: Some(registry),
+            approval_queue: Some(approval_queue),
+            audit_tx,
+            audit_drops,
+            seq: AtomicU64::new(0),
+            last_hash: Mutex::new(initial_hash),
+        }
+    }
+
     /// Evaluate a single request against the engine, returning the gRPC response
     /// and the optional deny-action side-effect.
     #[allow(clippy::result_large_err)] // tonic::Status is the standard gRPC error type

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -334,7 +334,15 @@ impl PolicyService for PolicyServiceImpl {
 
         let (eval, latency_us, policy_rule) = self.evaluate_one(&req)?;
         let deny_action = eval.deny_action;
-        let response = convert::eval_result_to_response(&eval, latency_us, &policy_rule);
+
+        // If RequiresApproval, submit to the queue and block until decided.
+        let response = if let Some(approval_response) =
+            self.maybe_submit_approval(&req, &eval, latency_us, &policy_rule).await
+        {
+            approval_response
+        } else {
+            convert::eval_result_to_response(&eval, latency_us, &policy_rule)
+        };
 
         tracing::debug!(
             decision = response.decision,

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -13,7 +13,7 @@ use aa_core::{AuditEntry, AuditEventType};
 use aa_proto::assembly::policy::v1::policy_service_server::PolicyService;
 use aa_proto::assembly::policy::v1::{BatchCheckRequest, BatchCheckResponse, CheckActionRequest, CheckActionResponse};
 
-use aa_runtime::approval::ApprovalQueue;
+use aa_runtime::approval::{ApprovalQueue, ApprovalRequest};
 
 use crate::engine::{DenyAction, EvaluationResult, PolicyEngine};
 use crate::registry::convert::proto_agent_id_to_key;
@@ -153,6 +153,31 @@ impl PolicyServiceImpl {
             tracing::warn!(error = %e, "failed to suspend agent on budget exceeded");
         } else {
             tracing::info!(agent_id = ?proto_agent.agent_id, "agent suspended: {reason_text}");
+        }
+    }
+
+    /// Build an [`ApprovalRequest`] from a gRPC request and the policy timeout.
+    fn build_approval_request(req: &CheckActionRequest, timeout_secs: u32) -> ApprovalRequest {
+        let agent_id = req
+            .agent_id
+            .as_ref()
+            .map(|a| a.agent_id.clone())
+            .unwrap_or_default();
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        ApprovalRequest {
+            request_id: uuid::Uuid::new_v4(),
+            agent_id,
+            action: format!("action_type={}", req.action_type),
+            condition_triggered: "requires_approval".to_string(),
+            submitted_at: now,
+            timeout_secs: u64::from(timeout_secs),
+            fallback: aa_core::PolicyResult::Deny {
+                reason: "approval timed out".to_string(),
+            },
         }
     }
 

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -375,7 +375,13 @@ impl PolicyService for PolicyServiceImpl {
         for req in &batch.requests {
             let (eval, latency_us, policy_rule) = self.evaluate_one(req)?;
             let deny_action = eval.deny_action;
-            let resp = convert::eval_result_to_response(&eval, latency_us, &policy_rule);
+            let resp = if let Some(approval_response) =
+                self.maybe_submit_approval(req, &eval, latency_us, &policy_rule).await
+            {
+                approval_response
+            } else {
+                convert::eval_result_to_response(&eval, latency_us, &policy_rule)
+            };
             self.maybe_suspend_agent(req, deny_action).await;
             self.record_audit(req, &resp).await;
             responses.push(resp);

--- a/aa-gateway/tests/approval_flow_test.rs
+++ b/aa-gateway/tests/approval_flow_test.rs
@@ -1,0 +1,296 @@
+//! Integration tests for the approval queue wiring in PolicyServiceImpl.
+//!
+//! Verifies that check_action() submits RequiresApproval decisions to the
+//! ApprovalQueue, blocks until the operator decides, and returns the correct
+//! final Allow/Deny response.
+
+use std::io::Write;
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+
+use aa_gateway::service::PolicyServiceImpl;
+use aa_gateway::PolicyEngine;
+use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decision};
+use aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient;
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
+use aa_proto::assembly::policy::v1::{
+    action_context::Action, ActionContext, BatchCheckRequest, CheckActionRequest, ToolCallContext,
+};
+use aa_runtime::approval::{ApprovalDecision, ApprovalQueue};
+use tokio::net::TcpListener;
+use tonic::transport::Server;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const APPROVAL_POLICY_YAML: &str = r#"
+version: "1"
+approval_timeout_secs: 5
+tools:
+  search:
+    allow: true
+    requires_approval_if: 'tool == "search"'
+  allowed_tool:
+    allow: true
+  blocked_tool:
+    allow: false
+"#;
+
+/// Start a PolicyService with an approval queue and return the address and queue.
+async fn start_server_with_approval(policy_yaml: &str) -> (SocketAddr, Arc<ApprovalQueue>) {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", policy_yaml).unwrap();
+    tmp.flush().unwrap();
+
+    let engine = Arc::new(PolicyEngine::load_from_file(tmp.path()).unwrap());
+    let registry = Arc::new(aa_gateway::registry::AgentRegistry::new());
+    let approval_queue = ApprovalQueue::new();
+    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+    let service = PolicyServiceImpl::with_registry_and_approval(
+        engine,
+        registry,
+        Arc::clone(&approval_queue),
+        audit_tx,
+        audit_drops,
+        [0u8; 32],
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let _tmp = tmp;
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(PolicyServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    (addr, approval_queue)
+}
+
+fn tool_call_request(tool_name: &str) -> CheckActionRequest {
+    CheckActionRequest {
+        agent_id: Some(ProtoAgentId {
+            org_id: "org".into(),
+            team_id: "team".into(),
+            agent_id: "agent-1".into(),
+        }),
+        credential_token: "tok".into(),
+        trace_id: "trace-1".into(),
+        span_id: "span-1".into(),
+        action_type: ActionType::ToolCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::ToolCall(ToolCallContext {
+                tool_name: tool_name.into(),
+                tool_source: "test".into(),
+                args_json: b"{}".to_vec(),
+                target_url: String::new(),
+            })),
+        }),
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn check_action_submits_to_approval_queue() {
+    let (addr, queue) = start_server_with_approval(APPROVAL_POLICY_YAML).await;
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+
+    // Spawn the check_action call — it will block waiting for approval.
+    let client_task = tokio::spawn(async move { client.check_action(tool_call_request("search")).await });
+
+    // Wait briefly for the request to reach the server and be submitted.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // Verify the queue has a pending entry.
+    let pending = queue.list();
+    assert_eq!(pending.len(), 1, "expected one pending approval request");
+    assert_eq!(pending[0].agent_id, "agent-1");
+
+    // Approve it so the client unblocks.
+    queue
+        .decide(
+            pending[0].request_id,
+            ApprovalDecision::Approved {
+                by: "test".to_string(),
+                reason: None,
+            },
+        )
+        .unwrap();
+
+    let resp = client_task.await.unwrap().unwrap().into_inner();
+    assert_eq!(resp.decision, Decision::Allow as i32);
+}
+
+#[tokio::test]
+async fn approval_approved_maps_to_allow() {
+    let (addr, queue) = start_server_with_approval(APPROVAL_POLICY_YAML).await;
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+
+    let client_task = tokio::spawn(async move { client.check_action(tool_call_request("search")).await });
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let pending = queue.list();
+    queue
+        .decide(
+            pending[0].request_id,
+            ApprovalDecision::Approved {
+                by: "alice".to_string(),
+                reason: Some("looks safe".to_string()),
+            },
+        )
+        .unwrap();
+
+    let resp = client_task.await.unwrap().unwrap().into_inner();
+    assert_eq!(resp.decision, Decision::Allow as i32);
+    assert!(!resp.approval_id.is_empty(), "approval_id should be the real queue ID");
+}
+
+#[tokio::test]
+async fn approval_rejected_maps_to_deny() {
+    let (addr, queue) = start_server_with_approval(APPROVAL_POLICY_YAML).await;
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+
+    let client_task = tokio::spawn(async move { client.check_action(tool_call_request("search")).await });
+
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let pending = queue.list();
+    queue
+        .decide(
+            pending[0].request_id,
+            ApprovalDecision::Rejected {
+                by: "bob".to_string(),
+                reason: "not allowed".to_string(),
+            },
+        )
+        .unwrap();
+
+    let resp = client_task.await.unwrap().unwrap().into_inner();
+    assert_eq!(resp.decision, Decision::Deny as i32);
+    assert_eq!(resp.reason, "not allowed");
+}
+
+#[tokio::test]
+async fn approval_timeout_maps_to_deny() {
+    // Use a very short timeout so the test doesn't take long.
+    let yaml = r#"
+version: "1"
+approval_timeout_secs: 1
+tools:
+  search:
+    allow: true
+    requires_approval_if: 'tool == "search"'
+"#;
+    let (addr, _queue) = start_server_with_approval(yaml).await;
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+
+    // Don't decide — let it time out.
+    let resp = client
+        .check_action(tool_call_request("search"))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(resp.decision, Decision::Deny as i32);
+    assert!(
+        resp.reason.contains("timed out"),
+        "expected timeout reason, got: {}",
+        resp.reason
+    );
+}
+
+#[tokio::test]
+async fn no_queue_degrades_gracefully() {
+    // Use PolicyServiceImpl::new() which has no approval queue.
+    let yaml = r#"
+version: "1"
+approval_timeout_secs: 1
+tools:
+  search:
+    allow: true
+    requires_approval_if: 'tool == "search"'
+"#;
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", yaml).unwrap();
+    tmp.flush().unwrap();
+
+    let engine = PolicyEngine::load_from_file(tmp.path()).unwrap();
+    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+    // new() has no approval queue — should degrade gracefully.
+    let service = PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops, [0u8; 32]);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let _tmp = tmp;
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(PolicyServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+
+    // Without a queue, RequiresApproval falls through to eval_result_to_response
+    // which panics. The degraded mode in maybe_submit_approval returns None,
+    // so the caller must handle RequiresApproval without the queue.
+    // Since eval_result_to_response now panics on RequiresApproval, this
+    // should result in a gRPC INTERNAL error (from the panic).
+    let result = client.check_action(tool_call_request("search")).await;
+    // The panic in eval_result_to_response is caught by tonic as an internal error.
+    assert!(result.is_err(), "expected error when no queue is attached");
+}
+
+#[tokio::test]
+async fn batch_check_with_mixed_decisions() {
+    let (addr, queue) = start_server_with_approval(APPROVAL_POLICY_YAML).await;
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+
+    let batch = BatchCheckRequest {
+        requests: vec![
+            tool_call_request("allowed_tool"),
+            tool_call_request("search"), // requires approval
+            tool_call_request("blocked_tool"),
+        ],
+    };
+
+    // Spawn the batch_check — it will block on the approval request.
+    let client_task = tokio::spawn(async move { client.batch_check(batch).await });
+
+    // Wait for the approval to be submitted.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    let pending = queue.list();
+    assert_eq!(pending.len(), 1, "expected one pending approval request");
+
+    // Approve it.
+    queue
+        .decide(
+            pending[0].request_id,
+            ApprovalDecision::Approved {
+                by: "operator".to_string(),
+                reason: None,
+            },
+        )
+        .unwrap();
+
+    let resp = client_task.await.unwrap().unwrap().into_inner();
+    assert_eq!(resp.responses.len(), 3);
+    assert_eq!(resp.responses[0].decision, Decision::Allow as i32); // allowed_tool
+    assert_eq!(resp.responses[1].decision, Decision::Allow as i32); // search (approved)
+    assert_eq!(resp.responses[2].decision, Decision::Deny as i32); // blocked_tool
+}

--- a/aa-gateway/tests/service_convert_test.rs
+++ b/aa-gateway/tests/service_convert_test.rs
@@ -321,13 +321,11 @@ fn deny_result_to_response() {
 }
 
 #[test]
-fn requires_approval_result_to_response() {
-    let resp = result_to_response(
+#[should_panic(expected = "RequiresApproval must be handled before conversion")]
+fn requires_approval_result_to_response_panics() {
+    let _ = result_to_response(
         &PolicyResult::RequiresApproval { timeout_secs: 30 },
         50,
         "approval_cond",
     );
-    assert_eq!(resp.decision, Decision::Pending as i32);
-    assert!(!resp.approval_id.is_empty(), "approval_id should be a UUID");
-    assert_eq!(resp.decision_latency_us, 50);
 }

--- a/aa-gateway/tests/service_convert_test.rs
+++ b/aa-gateway/tests/service_convert_test.rs
@@ -2,12 +2,15 @@
 
 use aa_core::{FileMode, GovernanceAction, PolicyResult};
 use aa_gateway::engine::EvaluationResult;
-use aa_gateway::service::convert::{eval_result_to_response, request_to_core, result_to_response, ConvertError};
+use aa_gateway::service::convert::{
+    approval_decision_to_response, eval_result_to_response, request_to_core, result_to_response, ConvertError,
+};
 use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decision};
 use aa_proto::assembly::policy::v1::{
     action_context::Action, ActionContext, CheckActionRequest, FileOpContext, LlmCallContext, NetworkCallContext,
     ProcessExecContext, ToolCallContext,
 };
+use aa_runtime::approval::ApprovalDecision;
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -328,4 +331,61 @@ fn requires_approval_result_to_response_panics() {
         50,
         "approval_cond",
     );
+}
+
+// ── ApprovalDecision → CheckActionResponse tests ────────────────────────────
+
+#[test]
+fn approved_decision_maps_to_allow() {
+    let id = uuid::Uuid::new_v4();
+    let decision = ApprovalDecision::Approved {
+        by: "alice".to_string(),
+        reason: Some("looks good".to_string()),
+    };
+    let resp = approval_decision_to_response(&decision, &id, 55, "requires_approval");
+    assert_eq!(resp.decision, Decision::Allow as i32);
+    assert!(resp.reason.is_empty());
+    assert_eq!(resp.approval_id, id.to_string());
+    assert_eq!(resp.decision_latency_us, 55);
+    assert_eq!(resp.policy_rule, "requires_approval");
+}
+
+#[test]
+fn rejected_decision_maps_to_deny() {
+    let id = uuid::Uuid::new_v4();
+    let decision = ApprovalDecision::Rejected {
+        by: "bob".to_string(),
+        reason: "not allowed".to_string(),
+    };
+    let resp = approval_decision_to_response(&decision, &id, 88, "requires_approval");
+    assert_eq!(resp.decision, Decision::Deny as i32);
+    assert_eq!(resp.reason, "not allowed");
+    assert_eq!(resp.approval_id, id.to_string());
+    assert_eq!(resp.decision_latency_us, 88);
+}
+
+#[test]
+fn timed_out_decision_with_deny_fallback() {
+    let id = uuid::Uuid::new_v4();
+    let decision = ApprovalDecision::TimedOut {
+        fallback: PolicyResult::Deny {
+            reason: "approval timed out".to_string(),
+        },
+    };
+    let resp = approval_decision_to_response(&decision, &id, 120, "requires_approval");
+    assert_eq!(resp.decision, Decision::Deny as i32);
+    assert_eq!(resp.reason, "approval timed out");
+    assert_eq!(resp.approval_id, id.to_string());
+}
+
+#[test]
+fn timed_out_decision_with_allow_fallback() {
+    let id = uuid::Uuid::new_v4();
+    let decision = ApprovalDecision::TimedOut {
+        fallback: PolicyResult::Allow,
+    };
+    let resp = approval_decision_to_response(&decision, &id, 200, "requires_approval");
+    assert_eq!(resp.decision, Decision::Allow as i32);
+    assert!(resp.reason.is_empty());
+    assert_eq!(resp.approval_id, id.to_string());
 }


### PR DESCRIPTION
## Description

Fix the broken approval flow in `PolicyServiceImpl`. Previously, when the `PolicyEngine` returned `RequiresApproval`, the service returned `Decision::Pending` with a random UUID but never submitted the request to the `ApprovalQueue`. This meant operators could never approve/deny actions and clients hung forever.

This PR:
- Adds an `Option<Arc<ApprovalQueue>>` field to `PolicyServiceImpl`
- Adds `with_registry_and_approval()` constructor wiring the queue
- Refactors `evaluate_one()` to return raw `EvaluationResult` so `RequiresApproval` can be intercepted before proto conversion
- Adds `build_approval_request()` and `maybe_submit_approval()` methods that submit to the queue and block until the operator decides (with timeout)
- Wires approval submission into both `check_action()` and `batch_check()`
- Updates `serve_tcp()` and `serve_uds()` to pass both the registry and approval queue (also fixes a secondary bug where the registry was never passed)
- Adds `approval_decision_to_response()` conversion helper and makes `eval_result_to_response()` panic on `RequiresApproval` (forcing callers to handle it explicitly)

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [x] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-158
- Related Jira epic: AAASM-8

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

**New tests added:**
- `approval_flow_test.rs` — 6 integration tests covering the full approval lifecycle:
  - `check_action_submits_to_approval_queue` — verifies queue submission and pending state
  - `approval_approved_maps_to_allow` — approved → `Decision::Allow`
  - `approval_rejected_maps_to_deny` — rejected → `Decision::Deny` with reason
  - `approval_timeout_maps_to_deny` — timeout → `Decision::Deny` with "timed out" reason
  - `no_queue_degrades_gracefully` — no queue attached → gRPC error (panic caught by tonic)
  - `batch_check_with_mixed_decisions` — mixed allow/approval/deny in single batch
- `service_convert_test.rs` — 4 new unit tests for `approval_decision_to_response()`:
  - `approved_decision_maps_to_allow`
  - `rejected_decision_maps_to_deny`
  - `timed_out_decision_with_deny_fallback`
  - `timed_out_decision_with_allow_fallback`
- Updated existing `requires_approval_result_to_response` test to verify panic behavior

**All 342 tests pass** across the `aa-gateway` crate (237 unit + 105 integration).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention