### PR TITLE
[AAASM-160] 🐛 (budget): Wire budget persistence into server startup

### DIFF
--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -128,6 +128,39 @@ impl BudgetTracker {
         }
     }
 
+    /// Create a tracker pre-loaded with persisted state that sends alerts on an
+    /// externally-owned channel.
+    ///
+    /// Combines [`with_state`] (restoring prior spend) with [`new_with_alert_sender`]
+    /// (sharing a broadcast channel created upstream).
+    pub fn with_state_and_alert_sender(
+        pricing: PricingTable,
+        daily_limit_usd: Option<Decimal>,
+        monthly_limit_usd: Option<Decimal>,
+        initial: crate::budget::persistence::PersistedBudget,
+        alert_tx: broadcast::Sender<BudgetAlert>,
+    ) -> Self {
+        let timezone = initial.timezone;
+        let per_agent: DashMap<AgentId, BudgetState> = initial
+            .per_agent
+            .into_iter()
+            .filter_map(|e| {
+                crate::budget::persistence::hex_to_agent_id(&e.agent_id_hex)
+                    .ok()
+                    .map(|id| (id, e.state))
+            })
+            .collect();
+        Self {
+            per_agent,
+            global: Mutex::new(initial.global),
+            pricing,
+            daily_limit_usd,
+            monthly_limit_usd,
+            alert_tx,
+            timezone,
+        }
+    }
+
     /// Subscribe to budget threshold alert events (80% and 95% crossings).
     pub fn subscribe_alerts(&self) -> broadcast::Receiver<BudgetAlert> {
         self.alert_tx.subscribe()

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -402,6 +402,14 @@ impl PolicyEngine {
         }
         true
     }
+
+    /// Returns a clone of the `Arc<BudgetTracker>` for shared ownership.
+    ///
+    /// Used by the persistence layer to spawn the background writer and
+    /// to perform the final save on graceful shutdown.
+    pub fn budget_tracker(&self) -> Arc<BudgetTracker> {
+        Arc::clone(&self.budget)
+    }
 }
 
 /// Implement the `aa_core::PolicyEvaluator` trait so `PolicyEngine` can be used

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -12,6 +12,8 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use crate::budget::BudgetTracker;
+
 use crate::policy::document::ActionOnExceed;
 use crate::policy::{PolicyDocument, PolicyValidator};
 
@@ -61,7 +63,7 @@ pub struct PolicyEngine {
     // construction time and will not update when the watcher swaps in a new policy document.
     compiled_patterns: Vec<regex::Regex>,
     rate_state: DashMap<String, Mutex<crate::engine::rate_limit::TokenBucket>>,
-    budget: crate::budget::BudgetTracker,
+    budget: Arc<BudgetTracker>,
     _watcher: Option<notify::RecommendedWatcher>,
 }
 
@@ -118,13 +120,13 @@ impl PolicyEngine {
             .as_ref()
             .and_then(|bp| bp.monthly_limit_usd)
             .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
-        let budget = crate::budget::BudgetTracker::new_with_alert_sender(
+        let budget = Arc::new(BudgetTracker::new_with_alert_sender(
             crate::budget::PricingTable::default_table(),
             daily_limit,
             monthly_limit,
             budget_tz,
             budget_alert_tx,
-        );
+        ));
         let policy_arc = Arc::new(ArcSwap::new(Arc::new(output.document)));
         let watcher = crate::engine::watcher::start_watcher(path, policy_arc.clone()).ok();
         Ok(PolicyEngine {
@@ -487,12 +489,12 @@ mod tests {
             scanner: aa_core::CredentialScanner::new(),
             compiled_patterns,
             rate_state: DashMap::new(),
-            budget: crate::budget::BudgetTracker::new(
+            budget: Arc::new(BudgetTracker::new(
                 crate::budget::PricingTable::default_table(),
                 daily_limit,
                 monthly_limit,
                 chrono_tz::UTC,
-            ),
+            )),
             _watcher: None,
         }
     }
@@ -1156,13 +1158,13 @@ mod tests {
             scanner: aa_core::CredentialScanner::new(),
             compiled_patterns,
             rate_state: DashMap::new(),
-            budget: crate::budget::BudgetTracker::new_with_alert_sender(
+            budget: Arc::new(BudgetTracker::new_with_alert_sender(
                 crate::budget::PricingTable::default_table(),
                 daily_limit,
                 monthly_limit,
                 chrono_tz::UTC,
                 alert_tx,
-            ),
+            )),
             _watcher: None,
         }
     }

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -139,6 +139,36 @@ impl PolicyEngine {
         })
     }
 
+    /// Load a policy from a YAML file using a pre-built budget tracker.
+    ///
+    /// Use this when restoring budget state from disk — the caller constructs
+    /// the tracker via [`BudgetTracker::with_state`] and passes it in.
+    pub fn load_from_file_with_budget(path: &Path, budget: Arc<BudgetTracker>) -> Result<Self, PolicyLoadError> {
+        let yaml = std::fs::read_to_string(path).map_err(PolicyLoadError::Io)?;
+        let output = PolicyValidator::from_yaml(&yaml).map_err(PolicyLoadError::Validation)?;
+        let compiled_patterns = output
+            .document
+            .data
+            .as_ref()
+            .map(|dp| {
+                dp.sensitive_patterns
+                    .iter()
+                    .filter_map(|p| regex::Regex::new(p).ok())
+                    .collect()
+            })
+            .unwrap_or_default();
+        let policy_arc = Arc::new(ArcSwap::new(Arc::new(output.document)));
+        let watcher = crate::engine::watcher::start_watcher(path, policy_arc.clone()).ok();
+        Ok(PolicyEngine {
+            policy: policy_arc,
+            scanner: aa_core::CredentialScanner::new(),
+            compiled_patterns,
+            rate_state: DashMap::new(),
+            budget,
+            _watcher: watcher,
+        })
+    }
+
     /// Apply a raw YAML policy string: validate, swap into the live slot, and
     /// persist a versioned snapshot to the history store.
     ///

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -62,10 +62,7 @@ async fn setup_audit(
 /// return it wrapped in `Arc` alongside the budget file path.
 ///
 /// Falls back to an empty tracker if the file is missing or corrupt.
-fn setup_budget(
-    policy_path: &Path,
-    budget_alert_tx: broadcast::Sender<BudgetAlert>,
-) -> (Arc<BudgetTracker>, PathBuf) {
+fn setup_budget(policy_path: &Path, budget_alert_tx: broadcast::Sender<BudgetAlert>) -> (Arc<BudgetTracker>, PathBuf) {
     let budget_path = default_budget_path();
 
     let persisted = load_from_disk(&budget_path).unwrap_or_else(|e| {
@@ -79,24 +76,23 @@ fn setup_budget(
 
     // Extract limits from the policy YAML so the tracker enforces them.
     let yaml = std::fs::read_to_string(policy_path).unwrap_or_default();
-    let (daily_limit, monthly_limit) =
-        if let Ok(output) = crate::policy::PolicyValidator::from_yaml(&yaml) {
-            let daily = output
-                .document
-                .budget
-                .as_ref()
-                .and_then(|bp| bp.daily_limit_usd)
-                .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
-            let monthly = output
-                .document
-                .budget
-                .as_ref()
-                .and_then(|bp| bp.monthly_limit_usd)
-                .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
-            (daily, monthly)
-        } else {
-            (None, None)
-        };
+    let (daily_limit, monthly_limit) = if let Ok(output) = crate::policy::PolicyValidator::from_yaml(&yaml) {
+        let daily = output
+            .document
+            .budget
+            .as_ref()
+            .and_then(|bp| bp.daily_limit_usd)
+            .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
+        let monthly = output
+            .document
+            .budget
+            .as_ref()
+            .and_then(|bp| bp.monthly_limit_usd)
+            .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
+        (daily, monthly)
+    } else {
+        (None, None)
+    };
 
     let tracker = Arc::new(BudgetTracker::with_state_and_alert_sender(
         crate::budget::PricingTable::default_table(),
@@ -116,9 +112,8 @@ async fn shutdown_signal() {
     let ctrl_c = tokio::signal::ctrl_c();
     #[cfg(unix)]
     {
-        let mut sigterm =
-            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-                .expect("failed to register SIGTERM handler");
+        let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to register SIGTERM handler");
         tokio::select! {
             _ = ctrl_c => tracing::info!("received SIGINT, shutting down"),
             _ = sigterm.recv() => tracing::info!("received SIGTERM, shutting down"),

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -19,7 +19,7 @@ use tokio::sync::broadcast;
 
 use aa_runtime::approval::ApprovalQueue;
 
-use crate::budget::persistence::{default_budget_path, load_from_disk, start_background_writer};
+use crate::budget::persistence::{default_budget_path, load_from_disk, save_to_disk_atomic, start_background_writer};
 use crate::budget::{BudgetAlert, BudgetTracker};
 
 /// Default audit directory relative to the system data directory (`~/.aa/audit`).
@@ -111,6 +111,35 @@ fn setup_budget(
     (tracker, budget_path)
 }
 
+/// Wait for SIGINT or SIGTERM, then return so the server can shut down gracefully.
+async fn shutdown_signal() {
+    let ctrl_c = tokio::signal::ctrl_c();
+    #[cfg(unix)]
+    {
+        let mut sigterm =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                .expect("failed to register SIGTERM handler");
+        tokio::select! {
+            _ = ctrl_c => tracing::info!("received SIGINT, shutting down"),
+            _ = sigterm.recv() => tracing::info!("received SIGTERM, shutting down"),
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        ctrl_c.await.ok();
+        tracing::info!("received SIGINT, shutting down");
+    }
+}
+
+/// Persist the current budget snapshot to disk. Best-effort — logs on failure.
+fn final_budget_save(tracker: &BudgetTracker, budget_path: &Path) {
+    let snapshot = tracker.snapshot();
+    match save_to_disk_atomic(budget_path, &snapshot) {
+        Ok(()) => tracing::info!(path = %budget_path.display(), "budget state saved on shutdown"),
+        Err(e) => tracing::error!(error = %e, "failed to save budget state on shutdown"),
+    }
+}
+
 /// Start the gRPC server on a TCP address.
 ///
 /// Loads the policy from `policy_path`, wraps it in a `PolicyServiceImpl`, and
@@ -124,7 +153,7 @@ pub async fn serve_tcp(
     budget_alert_tx: broadcast::Sender<BudgetAlert>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (tracker, budget_path) = setup_budget(policy_path, budget_alert_tx);
-    let _budget_writer = start_background_writer(Arc::clone(&tracker), budget_path);
+    let _budget_writer = start_background_writer(Arc::clone(&tracker), budget_path.clone());
     let engine = PolicyEngine::load_from_file_with_budget(policy_path, Arc::clone(&tracker))
         .map_err(|e| format!("failed to load policy: {e:?}"))?;
     let (audit_tx, audit_drops, initial_hash) = setup_audit("gateway", "default").await?;
@@ -148,8 +177,11 @@ pub async fn serve_tcp(
         .add_service(AuditServiceServer::new(audit_svc))
         .add_service(AgentLifecycleServiceServer::new(lifecycle_svc))
         .add_service(ApprovalServiceServer::new(approval_svc))
-        .serve(addr)
+        .serve_with_shutdown(addr, shutdown_signal())
         .await?;
+
+    // Final flush so the last ≤60 s of spend is not lost.
+    final_budget_save(&tracker, &budget_path);
 
     Ok(())
 }
@@ -167,7 +199,7 @@ pub async fn serve_uds(
     budget_alert_tx: broadcast::Sender<BudgetAlert>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (tracker, budget_path) = setup_budget(policy_path, budget_alert_tx);
-    let _budget_writer = start_background_writer(Arc::clone(&tracker), budget_path);
+    let _budget_writer = start_background_writer(Arc::clone(&tracker), budget_path.clone());
     let engine = PolicyEngine::load_from_file_with_budget(policy_path, Arc::clone(&tracker))
         .map_err(|e| format!("failed to load policy: {e:?}"))?;
     let (audit_tx, audit_drops, initial_hash) = setup_audit("gateway", "default").await?;
@@ -197,8 +229,11 @@ pub async fn serve_uds(
         .add_service(AuditServiceServer::new(audit_svc))
         .add_service(AgentLifecycleServiceServer::new(lifecycle_svc))
         .add_service(ApprovalServiceServer::new(approval_svc))
-        .serve_with_incoming(incoming)
+        .serve_with_incoming_shutdown(incoming, shutdown_signal())
         .await?;
+
+    // Final flush so the last ≤60 s of spend is not lost.
+    final_budget_save(&tracker, &budget_path);
 
     Ok(())
 }

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -19,7 +19,8 @@ use tokio::sync::broadcast;
 
 use aa_runtime::approval::ApprovalQueue;
 
-use crate::budget::BudgetAlert;
+use crate::budget::persistence::{default_budget_path, load_from_disk};
+use crate::budget::{BudgetAlert, BudgetTracker};
 
 /// Default audit directory relative to the system data directory (`~/.aa/audit`).
 fn default_audit_dir() -> PathBuf {
@@ -56,6 +57,60 @@ async fn setup_audit(
     Ok((audit_tx, audit_drops, initial_hash))
 }
 
+/// Load persisted budget state from `~/.aa/budget.json`, construct a
+/// [`BudgetTracker`] pre-populated with the restored spend totals, and
+/// return it wrapped in `Arc` alongside the budget file path.
+///
+/// Falls back to an empty tracker if the file is missing or corrupt.
+fn setup_budget(
+    policy_path: &Path,
+    budget_alert_tx: broadcast::Sender<BudgetAlert>,
+) -> (Arc<BudgetTracker>, PathBuf) {
+    let budget_path = default_budget_path();
+
+    let persisted = load_from_disk(&budget_path).unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "failed to load budget state, starting fresh");
+        crate::budget::persistence::PersistedBudget {
+            per_agent: vec![],
+            global: crate::budget::types::BudgetState::new_today(),
+            timezone: chrono_tz::UTC,
+        }
+    });
+
+    // Extract limits from the policy YAML so the tracker enforces them.
+    let yaml = std::fs::read_to_string(policy_path).unwrap_or_default();
+    let (daily_limit, monthly_limit) =
+        if let Ok(output) = crate::policy::PolicyValidator::from_yaml(&yaml) {
+            let daily = output
+                .document
+                .budget
+                .as_ref()
+                .and_then(|bp| bp.daily_limit_usd)
+                .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
+            let monthly = output
+                .document
+                .budget
+                .as_ref()
+                .and_then(|bp| bp.monthly_limit_usd)
+                .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
+            (daily, monthly)
+        } else {
+            (None, None)
+        };
+
+    let tracker = Arc::new(BudgetTracker::with_state_and_alert_sender(
+        crate::budget::PricingTable::default_table(),
+        daily_limit,
+        monthly_limit,
+        persisted,
+        budget_alert_tx,
+    ));
+
+    tracing::info!(path = %budget_path.display(), "budget state loaded");
+
+    (tracker, budget_path)
+}
+
 /// Start the gRPC server on a TCP address.
 ///
 /// Loads the policy from `policy_path`, wraps it in a `PolicyServiceImpl`, and
@@ -68,7 +123,8 @@ pub async fn serve_tcp(
     approval_queue: Arc<ApprovalQueue>,
     budget_alert_tx: broadcast::Sender<BudgetAlert>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let engine = PolicyEngine::load_from_file(policy_path, budget_alert_tx)
+    let (tracker, _budget_path) = setup_budget(policy_path, budget_alert_tx);
+    let engine = PolicyEngine::load_from_file_with_budget(policy_path, Arc::clone(&tracker))
         .map_err(|e| format!("failed to load policy: {e:?}"))?;
     let (audit_tx, audit_drops, initial_hash) = setup_audit("gateway", "default").await?;
     let policy_svc = PolicyServiceImpl::with_registry_and_approval(
@@ -109,7 +165,8 @@ pub async fn serve_uds(
     approval_queue: Arc<ApprovalQueue>,
     budget_alert_tx: broadcast::Sender<BudgetAlert>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let engine = PolicyEngine::load_from_file(policy_path, budget_alert_tx)
+    let (tracker, _budget_path) = setup_budget(policy_path, budget_alert_tx);
+    let engine = PolicyEngine::load_from_file_with_budget(policy_path, Arc::clone(&tracker))
         .map_err(|e| format!("failed to load policy: {e:?}"))?;
     let (audit_tx, audit_drops, initial_hash) = setup_audit("gateway", "default").await?;
     let policy_svc = PolicyServiceImpl::with_registry_and_approval(

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -19,7 +19,7 @@ use tokio::sync::broadcast;
 
 use aa_runtime::approval::ApprovalQueue;
 
-use crate::budget::persistence::{default_budget_path, load_from_disk};
+use crate::budget::persistence::{default_budget_path, load_from_disk, start_background_writer};
 use crate::budget::{BudgetAlert, BudgetTracker};
 
 /// Default audit directory relative to the system data directory (`~/.aa/audit`).
@@ -123,7 +123,8 @@ pub async fn serve_tcp(
     approval_queue: Arc<ApprovalQueue>,
     budget_alert_tx: broadcast::Sender<BudgetAlert>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let (tracker, _budget_path) = setup_budget(policy_path, budget_alert_tx);
+    let (tracker, budget_path) = setup_budget(policy_path, budget_alert_tx);
+    let _budget_writer = start_background_writer(Arc::clone(&tracker), budget_path);
     let engine = PolicyEngine::load_from_file_with_budget(policy_path, Arc::clone(&tracker))
         .map_err(|e| format!("failed to load policy: {e:?}"))?;
     let (audit_tx, audit_drops, initial_hash) = setup_audit("gateway", "default").await?;
@@ -165,7 +166,8 @@ pub async fn serve_uds(
     approval_queue: Arc<ApprovalQueue>,
     budget_alert_tx: broadcast::Sender<BudgetAlert>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let (tracker, _budget_path) = setup_budget(policy_path, budget_alert_tx);
+    let (tracker, budget_path) = setup_budget(policy_path, budget_alert_tx);
+    let _budget_writer = start_background_writer(Arc::clone(&tracker), budget_path);
     let engine = PolicyEngine::load_from_file_with_budget(policy_path, Arc::clone(&tracker))
         .map_err(|e| format!("failed to load policy: {e:?}"))?;
     let (audit_tx, audit_drops, initial_hash) = setup_audit("gateway", "default").await?;

--- a/aa-gateway/tests/budget_persistence_test.rs
+++ b/aa-gateway/tests/budget_persistence_test.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use aa_core::AgentId;
-use aa_gateway::budget::persistence::{load_from_disk, save_to_disk_atomic};
+use aa_gateway::budget::persistence::{load_from_disk, save_to_disk_atomic, PersistedBudget};
 use aa_gateway::budget::pricing::PricingTable;
 use aa_gateway::budget::tracker::BudgetTracker;
 use aa_gateway::budget::types::BudgetAlert;
@@ -91,4 +91,42 @@ fn restored_tracker_accumulates_further_spend() {
     let final_snapshot = restored.snapshot();
     assert_eq!(final_snapshot.per_agent[0].state.spent_usd, Decimal::from_str("15.00").unwrap());
     assert_eq!(final_snapshot.global.spent_usd, Decimal::from_str("15.00").unwrap());
+}
+
+/// Corrupt JSON on disk returns an error from load_from_disk.
+#[test]
+fn corrupt_file_returns_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("budget.json");
+    std::fs::write(&path, b"NOT VALID JSON {{{").unwrap();
+    assert!(load_from_disk(&path).is_err());
+}
+
+/// Simulate the graceful fallback: when load fails, start fresh and continue.
+#[test]
+fn corrupt_file_fallback_produces_empty_tracker() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("budget.json");
+    std::fs::write(&path, b"NOT VALID JSON {{{").unwrap();
+
+    let (alert_tx, _rx) = tokio::sync::broadcast::channel::<BudgetAlert>(16);
+
+    // Mirror the fallback logic from server::setup_budget.
+    let persisted = load_from_disk(&path).unwrap_or_else(|_| PersistedBudget {
+        per_agent: vec![],
+        global: aa_gateway::budget::types::BudgetState::new_today(),
+        timezone: chrono_tz::UTC,
+    });
+
+    let tracker = BudgetTracker::with_state_and_alert_sender(
+        PricingTable::default_table(),
+        None,
+        None,
+        persisted,
+        alert_tx,
+    );
+
+    let snapshot = tracker.snapshot();
+    assert!(snapshot.per_agent.is_empty());
+    assert_eq!(snapshot.global.spent_usd, Decimal::ZERO);
 }

--- a/aa-gateway/tests/budget_persistence_test.rs
+++ b/aa-gateway/tests/budget_persistence_test.rs
@@ -1,0 +1,94 @@
+//! Integration tests for budget persistence round-trip:
+//! tracker → snapshot → save → load → restore → verify spend.
+
+use std::sync::Arc;
+
+use aa_core::AgentId;
+use aa_gateway::budget::persistence::{load_from_disk, save_to_disk_atomic};
+use aa_gateway::budget::pricing::PricingTable;
+use aa_gateway::budget::tracker::BudgetTracker;
+use aa_gateway::budget::types::BudgetAlert;
+use rust_decimal::Decimal;
+use std::str::FromStr;
+
+fn test_agent_id() -> AgentId {
+    AgentId::from_bytes([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
+}
+
+/// Record spend, save to disk, load back, and confirm the spend survived.
+#[test]
+fn round_trip_preserves_spend() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("budget.json");
+
+    let (alert_tx, _rx) = tokio::sync::broadcast::channel::<BudgetAlert>(16);
+
+    // 1. Fresh tracker — record some spend.
+    let tracker = BudgetTracker::new_with_alert_sender(
+        PricingTable::default_table(),
+        Some(Decimal::from_str("100.0").unwrap()),
+        None,
+        chrono_tz::UTC,
+        alert_tx.clone(),
+    );
+    let agent = test_agent_id();
+    tracker.record_raw_spend(agent, Decimal::from_str("42.50").unwrap());
+
+    // 2. Snapshot and persist.
+    let snapshot = tracker.snapshot();
+    save_to_disk_atomic(&path, &snapshot).unwrap();
+
+    // 3. Load from disk and restore into a new tracker.
+    let persisted = load_from_disk(&path).unwrap();
+    let restored = BudgetTracker::with_state_and_alert_sender(
+        PricingTable::default_table(),
+        Some(Decimal::from_str("100.0").unwrap()),
+        None,
+        persisted,
+        alert_tx,
+    );
+
+    // 4. Verify the restored tracker kept the spend.
+    let restored_snapshot = restored.snapshot();
+    assert_eq!(restored_snapshot.per_agent.len(), 1);
+    assert_eq!(restored_snapshot.per_agent[0].state.spent_usd, Decimal::from_str("42.50").unwrap());
+    assert_eq!(restored_snapshot.global.spent_usd, Decimal::from_str("42.50").unwrap());
+}
+
+/// After restoring, additional spend accumulates on top of the persisted total.
+#[test]
+fn restored_tracker_accumulates_further_spend() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("budget.json");
+
+    let (alert_tx, _rx) = tokio::sync::broadcast::channel::<BudgetAlert>(16);
+
+    let tracker = BudgetTracker::new_with_alert_sender(
+        PricingTable::default_table(),
+        Some(Decimal::from_str("100.0").unwrap()),
+        None,
+        chrono_tz::UTC,
+        alert_tx.clone(),
+    );
+    let agent = test_agent_id();
+    tracker.record_raw_spend(agent, Decimal::from_str("10.00").unwrap());
+
+    let snapshot = tracker.snapshot();
+    save_to_disk_atomic(&path, &snapshot).unwrap();
+
+    let persisted = load_from_disk(&path).unwrap();
+    let restored = Arc::new(BudgetTracker::with_state_and_alert_sender(
+        PricingTable::default_table(),
+        Some(Decimal::from_str("100.0").unwrap()),
+        None,
+        persisted,
+        alert_tx,
+    ));
+
+    // Record more spend on the restored tracker.
+    restored.record_raw_spend(agent, Decimal::from_str("5.00").unwrap());
+
+    let final_snapshot = restored.snapshot();
+    assert_eq!(final_snapshot.per_agent[0].state.spent_usd, Decimal::from_str("15.00").unwrap());
+    assert_eq!(final_snapshot.global.spent_usd, Decimal::from_str("15.00").unwrap());
+}

--- a/aa-gateway/tests/budget_persistence_test.rs
+++ b/aa-gateway/tests/budget_persistence_test.rs
@@ -51,7 +51,10 @@ fn round_trip_preserves_spend() {
     // 4. Verify the restored tracker kept the spend.
     let restored_snapshot = restored.snapshot();
     assert_eq!(restored_snapshot.per_agent.len(), 1);
-    assert_eq!(restored_snapshot.per_agent[0].state.spent_usd, Decimal::from_str("42.50").unwrap());
+    assert_eq!(
+        restored_snapshot.per_agent[0].state.spent_usd,
+        Decimal::from_str("42.50").unwrap()
+    );
     assert_eq!(restored_snapshot.global.spent_usd, Decimal::from_str("42.50").unwrap());
 }
 
@@ -89,7 +92,10 @@ fn restored_tracker_accumulates_further_spend() {
     restored.record_raw_spend(agent, Decimal::from_str("5.00").unwrap());
 
     let final_snapshot = restored.snapshot();
-    assert_eq!(final_snapshot.per_agent[0].state.spent_usd, Decimal::from_str("15.00").unwrap());
+    assert_eq!(
+        final_snapshot.per_agent[0].state.spent_usd,
+        Decimal::from_str("15.00").unwrap()
+    );
     assert_eq!(final_snapshot.global.spent_usd, Decimal::from_str("15.00").unwrap());
 }
 
@@ -118,13 +124,8 @@ fn corrupt_file_fallback_produces_empty_tracker() {
         timezone: chrono_tz::UTC,
     });
 
-    let tracker = BudgetTracker::with_state_and_alert_sender(
-        PricingTable::default_table(),
-        None,
-        None,
-        persisted,
-        alert_tx,
-    );
+    let tracker =
+        BudgetTracker::with_state_and_alert_sender(PricingTable::default_table(), None, None, persisted, alert_tx);
 
     let snapshot = tracker.snapshot();
     assert!(snapshot.per_agent.is_empty());


### PR DESCRIPTION
## Summary

- **Wrap `BudgetTracker` in `Arc`** inside `PolicyEngine` and expose a `budget_tracker()` accessor so the tracker can be shared with the persistence layer
- **Add `with_state_and_alert_sender` constructor** to `BudgetTracker` — combines restoring persisted spend state with an externally-owned broadcast channel
- **Add `setup_budget()` helper** in `server.rs` that loads `~/.aa/budget.json` via `load_from_disk`, extracts policy limits, and builds a pre-populated `Arc<BudgetTracker>`
- **Wire `load_from_file_with_budget()`** into both `serve_tcp` and `serve_uds` so the engine uses the restored tracker
- **Spawn `start_background_writer()`** on startup — persists budget state to disk every 60 seconds
- **Add graceful shutdown** via `serve_with_shutdown` / `serve_with_incoming_shutdown` — flushes budget state on SIGINT/SIGTERM so the last ≤60s of spend is not lost
- **4 integration tests**: round-trip save/load, accumulation on restored tracker, corrupt file error, and corrupt file graceful fallback

## What was broken

`load_from_disk`, `save_to_disk_atomic`, and `start_background_writer` were fully implemented in `persistence.rs` but never called — budget state was always lost on restart. The `PolicyEngine` owned the tracker by value, preventing shared access for the background writer.

## Key changes

| File | Change |
|---|---|
| `aa-gateway/src/budget/tracker.rs` | Add `with_state_and_alert_sender()` constructor |
| `aa-gateway/src/engine/mod.rs` | Wrap `budget` field in `Arc`, add `budget_tracker()` accessor, add `load_from_file_with_budget()` |
| `aa-gateway/src/server.rs` | Add `setup_budget()`, `shutdown_signal()`, `final_budget_save()`; update both serve functions |
| `aa-gateway/tests/budget_persistence_test.rs` | 4 integration tests |

## Test plan

- [x] `cargo test -p aa-gateway` — all 349 tests pass (243 unit + 106 integration)
- [x] `cargo clippy -p aa-gateway -- -D warnings` — clean
- [x] `cargo fmt -p aa-gateway -- --check` — clean
- [ ] Manual: start gateway, record spend, kill with SIGINT, restart — verify spend is preserved

Closes AAASM-160

🤖 Generated with [Claude Code](https://claude.com/claude-code)