### PR TITLE
[AAASM-163] 🐛 (intercept): Wire CredentialScanner into event pipelines

### DIFF
--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -48,4 +48,4 @@ pub use evaluators::{DenyAllEvaluator, PermitAllEvaluator};
 pub use audit::{AuditEntry, AuditEventType, AuditLog, AuditLogError};
 
 #[cfg(feature = "std")]
-pub use scanner::{CredentialFinding, CredentialKind, CredentialScanner, ScanResult};
+pub use scanner::{CredentialFinding, CredentialKind, CredentialScanner, ScanResult, ScannerConfig};

--- a/aa-core/src/scanner.rs
+++ b/aa-core/src/scanner.rs
@@ -222,13 +222,34 @@ impl ScanResult {
     }
 }
 
+/// Configuration for the credential scanner.
+///
+/// Controls whether scanning is enabled and allows adding custom literal
+/// patterns beyond the built-in set.
+#[derive(Debug, Clone, Default)]
+pub struct ScannerConfig {
+    /// When `true`, scanning is disabled and [`CredentialScanner::scan`] always
+    /// returns an empty [`ScanResult`].
+    pub disabled: bool,
+    /// Additional literal prefixes to detect as [`CredentialKind::Custom`].
+    /// Each string is compiled into the Aho-Corasick automaton alongside the
+    /// built-in patterns.
+    pub custom_patterns: Vec<String>,
+}
+
 /// Pre-compiled multi-pattern credential scanner.
 ///
-/// Construct once with [`CredentialScanner::new`] and call [`CredentialScanner::scan`]
-/// repeatedly. Pattern compilation happens at construction time; each scan call is
-/// O(n) in the length of the input text.
+/// Construct once with [`CredentialScanner::new`] (or [`CredentialScanner::with_config`])
+/// and call [`CredentialScanner::scan`] repeatedly. Pattern compilation happens at
+/// construction time; each scan call is O(n) in the length of the input text.
 pub struct CredentialScanner {
     patterns: AhoCorasick,
+    /// Maps each AC pattern index to its [`CredentialKind`]. Built-in patterns
+    /// use the static `AC_KINDS` entries; custom patterns are appended as
+    /// [`CredentialKind::Custom`].
+    kinds: Vec<CredentialKind>,
+    /// When `true`, [`scan`](Self::scan) short-circuits and returns an empty result.
+    disabled: bool,
 }
 
 impl Default for CredentialScanner {
@@ -238,18 +259,40 @@ impl Default for CredentialScanner {
 }
 
 impl CredentialScanner {
-    /// Build the scanner, compiling all patterns into an Aho-Corasick automaton.
+    /// Build the scanner with all built-in patterns and scanning enabled.
     ///
     /// # Panics
     ///
     /// Panics only if the hard-coded AC patterns are somehow invalid — this
     /// cannot happen in practice.
     pub fn new() -> Self {
+        Self::with_config(ScannerConfig::default())
+    }
+
+    /// Build the scanner from explicit configuration.
+    ///
+    /// Custom patterns are appended after the built-in set and are tagged as
+    /// [`CredentialKind::Custom`]. If `config.disabled` is true the scanner
+    /// is inert — [`scan`](Self::scan) always returns an empty result.
+    pub fn with_config(config: ScannerConfig) -> Self {
+        let mut all_patterns: Vec<&str> = AC_PATTERNS.to_vec();
+        // Collect custom pattern references — lifetime tied to `config`.
+        let custom_refs: Vec<&str> = config.custom_patterns.iter().map(|s| s.as_str()).collect();
+        all_patterns.extend_from_slice(&custom_refs);
+
+        let mut kinds: Vec<CredentialKind> = AC_KINDS.to_vec();
+        kinds.extend(std::iter::repeat_n(CredentialKind::Custom, config.custom_patterns.len()));
+
         let ac = AhoCorasick::builder()
             .match_kind(aho_corasick::MatchKind::LeftmostFirst)
-            .build(AC_PATTERNS)
-            .expect("static AC patterns are always valid");
-        Self { patterns: ac }
+            .build(&all_patterns)
+            .expect("AC patterns are always valid");
+
+        Self {
+            patterns: ac,
+            kinds,
+            disabled: config.disabled,
+        }
     }
 
     /// Scan `text` for credential patterns and return a [`ScanResult`].
@@ -261,12 +304,18 @@ impl CredentialScanner {
     /// 3. Email address scan.
     /// 4. High-entropy token scan (Shannon entropy > 4.5 bits/char, length 20–64).
     pub fn scan(&self, text: &str) -> ScanResult {
+        if self.disabled {
+            return ScanResult {
+                findings: Vec::new(),
+            };
+        }
+
         let mut findings = Vec::new();
 
         // Phase 1: AC literal prefix scan (API keys, auth tokens, cloud creds,
-        //          database URLs, PEM private key headers — 18 patterns)
+        //          database URLs, PEM private key headers — 18 patterns + custom)
         for mat in self.patterns.find_iter(text) {
-            let kind = AC_KINDS[mat.pattern()].clone();
+            let kind = self.kinds[mat.pattern()].clone();
             let offset = mat.start();
             let end = token_end(text, mat.end());
             findings.push(CredentialFinding::new(kind, offset, end));

--- a/aa-core/src/scanner.rs
+++ b/aa-core/src/scanner.rs
@@ -281,7 +281,10 @@ impl CredentialScanner {
         all_patterns.extend_from_slice(&custom_refs);
 
         let mut kinds: Vec<CredentialKind> = AC_KINDS.to_vec();
-        kinds.extend(std::iter::repeat_n(CredentialKind::Custom, config.custom_patterns.len()));
+        kinds.extend(std::iter::repeat_n(
+            CredentialKind::Custom,
+            config.custom_patterns.len(),
+        ));
 
         let ac = AhoCorasick::builder()
             .match_kind(aho_corasick::MatchKind::LeftmostFirst)
@@ -305,9 +308,7 @@ impl CredentialScanner {
     /// 4. High-entropy token scan (Shannon entropy > 4.5 bits/char, length 20–64).
     pub fn scan(&self, text: &str) -> ScanResult {
         if self.disabled {
-            return ScanResult {
-                findings: Vec::new(),
-            };
+            return ScanResult { findings: Vec::new() };
         }
 
         let mut findings = Vec::new();

--- a/aa-core/src/scanner.rs
+++ b/aa-core/src/scanner.rs
@@ -873,4 +873,62 @@ mod tests {
             assert!(hard.is_empty(), "false positive in: {:?} → {:?}", text, hard);
         }
     }
+
+    // --- ScannerConfig ---
+
+    #[test]
+    fn disabled_scanner_returns_empty_result() {
+        let config = ScannerConfig {
+            disabled: true,
+            ..Default::default()
+        };
+        let scanner = CredentialScanner::with_config(config);
+        let result = scanner.scan("sk-proj-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX ghp_XXXXXXXXX");
+        assert!(result.is_clean(), "disabled scanner must return no findings");
+    }
+
+    #[test]
+    fn custom_pattern_detected_as_custom_kind() {
+        let config = ScannerConfig {
+            custom_patterns: vec!["INTERNAL_SECRET_".into()],
+            ..Default::default()
+        };
+        let scanner = CredentialScanner::with_config(config);
+        let result = scanner.scan("token=INTERNAL_SECRET_hello");
+        let custom: Vec<_> = result
+            .findings
+            .iter()
+            .filter(|f| f.kind == CredentialKind::Custom)
+            .collect();
+        assert!(!custom.is_empty(), "custom pattern must produce a Custom finding");
+        assert!(custom[0].matched.contains("[REDACTED:Custom]"));
+    }
+
+    #[test]
+    fn custom_pattern_coexists_with_builtin() {
+        let config = ScannerConfig {
+            custom_patterns: vec!["MY_TOKEN_".into()],
+            ..Default::default()
+        };
+        let scanner = CredentialScanner::with_config(config);
+        let text = "a=ghp_XXXXXXXXX b=MY_TOKEN_secret123";
+        let result = scanner.scan(text);
+        let kinds: Vec<_> = result.findings.iter().map(|f| &f.kind).collect();
+        assert!(kinds.contains(&&CredentialKind::GitHubPat));
+        assert!(kinds.contains(&&CredentialKind::Custom));
+    }
+
+    #[test]
+    fn default_config_matches_new() {
+        let default_scanner = CredentialScanner::new();
+        let config_scanner = CredentialScanner::with_config(ScannerConfig::default());
+        let text = "key=ghp_XXXXXXXXX url=postgres://u:p@host/db";
+        let r1 = default_scanner.scan(text);
+        let r2 = config_scanner.scan(text);
+        assert_eq!(r1.findings.len(), r2.findings.len());
+        for (a, b) in r1.findings.iter().zip(r2.findings.iter()) {
+            assert_eq!(a.kind, b.kind);
+            assert_eq!(a.offset, b.offset);
+        }
+    }
 }

--- a/aa-core/src/scanner.rs
+++ b/aa-core/src/scanner.rs
@@ -281,9 +281,7 @@ impl CredentialScanner {
         all_patterns.extend_from_slice(&custom_refs);
 
         let mut kinds: Vec<CredentialKind> = AC_KINDS.to_vec();
-        kinds.extend(
-            std::iter::repeat(CredentialKind::Custom).take(config.custom_patterns.len()),
-        );
+        kinds.extend(std::iter::repeat(CredentialKind::Custom).take(config.custom_patterns.len()));
 
         let ac = AhoCorasick::builder()
             .match_kind(aho_corasick::MatchKind::LeftmostFirst)

--- a/aa-core/src/scanner.rs
+++ b/aa-core/src/scanner.rs
@@ -281,10 +281,9 @@ impl CredentialScanner {
         all_patterns.extend_from_slice(&custom_refs);
 
         let mut kinds: Vec<CredentialKind> = AC_KINDS.to_vec();
-        kinds.extend(std::iter::repeat_n(
-            CredentialKind::Custom,
-            config.custom_patterns.len(),
-        ));
+        kinds.extend(
+            std::iter::repeat(CredentialKind::Custom).take(config.custom_patterns.len()),
+        );
 
         let ac = AhoCorasick::builder()
             .match_kind(aho_corasick::MatchKind::LeftmostFirst)

--- a/aa-ffi-python/src/handle.rs
+++ b/aa-ffi-python/src/handle.rs
@@ -209,6 +209,18 @@ fn unique_event_id() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ipc::{IpcCommand, IpcHandle};
+    use tokio::sync::mpsc;
+
+    /// Create an `AssemblyHandle` backed by a test mpsc channel (no real socket).
+    fn make_test_handle() -> (AssemblyHandle, mpsc::Receiver<IpcCommand>) {
+        let (tx, rx) = mpsc::channel(16);
+        let ipc = IpcHandle {
+            cmd_tx: tx,
+            thread: None,
+        };
+        (AssemblyHandle::new(ipc, vec![]), rx)
+    }
 
     /// Create a test handle backed by a real mpsc channel (no socket).
     /// Returns `(handle, receiver)` so tests can inspect sent commands.
@@ -308,6 +320,48 @@ mod tests {
                 }
             }
             other => panic!("expected SendEvent, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn report_event_redacts_credentials_in_details() {
+        let (handle, mut rx) = make_test_handle();
+        let secret = "sk-proj-aBcDeFgHiJkLmNoPqRsT1234567890abcdef1234567890ab";
+        let details = format!("called openai with key {secret}");
+
+        handle.report_event("llm_call".into(), details).unwrap();
+
+        let cmd = rx.try_recv().expect("should receive command");
+        match cmd {
+            IpcCommand::SendEvent(event) => {
+                let labels_str = format!("{:?}", event.labels);
+                assert!(
+                    !labels_str.contains("sk-proj-"),
+                    "details label must not contain raw credential, got: {labels_str}"
+                );
+                assert!(
+                    labels_str.contains("[REDACTED:"),
+                    "details label should contain redaction marker"
+                );
+            }
+            other => panic!("expected SendEvent, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn report_event_passes_clean_details_unchanged() {
+        let (handle, mut rx) = make_test_handle();
+
+        handle
+            .report_event("tool_call".into(), "searched for cats".into())
+            .unwrap();
+
+        let cmd = rx.try_recv().expect("should receive command");
+        match cmd {
+            IpcCommand::SendEvent(event) => {
+                assert_eq!(event.labels.get("details").unwrap(), "searched for cats");
+            }
+            other => panic!("expected SendEvent, got {other:?}"),
         }
     }
 }

--- a/aa-ffi-python/src/handle.rs
+++ b/aa-ffi-python/src/handle.rs
@@ -392,9 +392,7 @@ mod tests {
         let secret = "sk-proj-aBcDeFgHiJkLmNoPqRsT1234567890abcdef1234567890ab";
         let details = format!("key is {secret}");
 
-        handle
-            .report_event("llm_call".into(), details.clone())
-            .unwrap();
+        handle.report_event("llm_call".into(), details.clone()).unwrap();
 
         let cmd = rx.try_recv().expect("should receive command");
         match cmd {

--- a/aa-ffi-python/src/handle.rs
+++ b/aa-ffi-python/src/handle.rs
@@ -26,16 +26,28 @@ use crate::ipc::{IpcCommand, IpcHandle};
 pub struct AssemblyHandle {
     inner: Mutex<Option<IpcHandle>>,
     detected_frameworks: Vec<String>,
-    scanner: CredentialScanner,
+    scanner: Option<CredentialScanner>,
 }
 
 impl AssemblyHandle {
-    /// Create a new handle wrapping an IPC connection.
+    /// Create a new handle with default credential scanning enabled.
     pub fn new(ipc_handle: IpcHandle, detected_frameworks: Vec<String>) -> Self {
+        Self::with_scanner(ipc_handle, detected_frameworks, Some(CredentialScanner::new()))
+    }
+
+    /// Create a new handle with an explicit scanner configuration.
+    ///
+    /// Pass `None` to disable credential scanning, or `Some(scanner)` to use
+    /// a custom-configured [`CredentialScanner`].
+    pub fn with_scanner(
+        ipc_handle: IpcHandle,
+        detected_frameworks: Vec<String>,
+        scanner: Option<CredentialScanner>,
+    ) -> Self {
         Self {
             inner: Mutex::new(Some(ipc_handle)),
             detected_frameworks,
-            scanner: CredentialScanner::new(),
+            scanner,
         }
     }
 }
@@ -59,15 +71,19 @@ impl AssemblyHandle {
 
         // Redact any credentials from user-supplied details before they enter
         // the audit pipeline.
-        let scan_result = self.scanner.scan(&details);
-        let safe_details = if scan_result.is_clean() {
-            details
+        let safe_details = if let Some(scanner) = &self.scanner {
+            let scan_result = scanner.scan(&details);
+            if scan_result.is_clean() {
+                details
+            } else {
+                tracing::warn!(
+                    findings = scan_result.findings.len(),
+                    "credentials detected in report_event details, redacting"
+                );
+                scan_result.redact(&details)
+            }
         } else {
-            tracing::warn!(
-                findings = scan_result.findings.len(),
-                "credentials detected in report_event details, redacting"
-            );
-            scan_result.redact(&details)
+            details
         };
 
         let mut labels = std::collections::HashMap::new();

--- a/aa-ffi-python/src/handle.rs
+++ b/aa-ffi-python/src/handle.rs
@@ -7,6 +7,8 @@ use std::sync::Mutex;
 
 use pyo3::prelude::*;
 
+use aa_core::CredentialScanner;
+
 use crate::ipc::{IpcCommand, IpcHandle};
 
 /// Handle to an active Agent Assembly session.
@@ -24,6 +26,7 @@ use crate::ipc::{IpcCommand, IpcHandle};
 pub struct AssemblyHandle {
     inner: Mutex<Option<IpcHandle>>,
     detected_frameworks: Vec<String>,
+    scanner: CredentialScanner,
 }
 
 impl AssemblyHandle {
@@ -32,6 +35,7 @@ impl AssemblyHandle {
         Self {
             inner: Mutex::new(Some(ipc_handle)),
             detected_frameworks,
+            scanner: CredentialScanner::new(),
         }
     }
 }
@@ -53,9 +57,22 @@ impl AssemblyHandle {
             pyo3::exceptions::PyRuntimeError::new_err("AssemblyHandle is shut down; cannot report events")
         })?;
 
+        // Redact any credentials from user-supplied details before they enter
+        // the audit pipeline.
+        let scan_result = self.scanner.scan(&details);
+        let safe_details = if scan_result.is_clean() {
+            details
+        } else {
+            tracing::warn!(
+                findings = scan_result.findings.len(),
+                "credentials detected in report_event details, redacting"
+            );
+            scan_result.redact(&details)
+        };
+
         let mut labels = std::collections::HashMap::new();
         labels.insert("event_type".to_string(), event_type);
-        labels.insert("details".to_string(), details);
+        labels.insert("details".to_string(), safe_details);
 
         let event = aa_proto::assembly::audit::v1::AuditEvent {
             event_id: unique_event_id(),

--- a/aa-ffi-python/src/handle.rs
+++ b/aa-ffi-python/src/handle.rs
@@ -380,4 +380,29 @@ mod tests {
             other => panic!("expected SendEvent, got {other:?}"),
         }
     }
+
+    #[test]
+    fn report_event_with_scanner_disabled_passes_details_through() {
+        let (tx, mut rx) = mpsc::channel(16);
+        let ipc = IpcHandle {
+            cmd_tx: tx,
+            thread: None,
+        };
+        let handle = AssemblyHandle::with_scanner(ipc, vec![], None);
+        let secret = "sk-proj-aBcDeFgHiJkLmNoPqRsT1234567890abcdef1234567890ab";
+        let details = format!("key is {secret}");
+
+        handle
+            .report_event("llm_call".into(), details.clone())
+            .unwrap();
+
+        let cmd = rx.try_recv().expect("should receive command");
+        match cmd {
+            IpcCommand::SendEvent(event) => {
+                // Scanner is disabled — raw credential passes through.
+                assert_eq!(event.labels.get("details").unwrap(), &details);
+            }
+            other => panic!("expected SendEvent, got {other:?}"),
+        }
+    }
 }

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -411,4 +411,20 @@ mod tests {
             "pipeline event must not contain raw credential"
         );
     }
+
+    #[tokio::test]
+    async fn intercept_with_scanner_disabled_skips_redaction() {
+        let (tx, _rx) = broadcast::channel(16);
+        let interceptor = Interceptor::with_scanner(tx, None);
+        let mut event = make_event(LlmApiPattern::OpenAi);
+        // Body contains a credential — but scanner is disabled.
+        event.response_body = Some(Bytes::from(
+            r#"{"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":8},"debug":"sk-proj-aBcDeFgHiJkLmNoPqRsT1234567890abcdef1234567890ab"}"#,
+        ));
+
+        let fields = interceptor.intercept(&event).await.unwrap().unwrap();
+        // Fields are still extracted — scanning is off, not extraction.
+        assert_eq!(fields.model, "gpt-4");
+        assert_eq!(fields.prompt_tokens, Some(5));
+    }
 }

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -52,9 +52,26 @@ impl Interceptor {
 
         // Pick the body to extract from: prefer response (has usage stats),
         // fall back to request.
-        let body = event.response_body.as_ref().or(event.request_body.as_ref());
+        let raw_body = event.response_body.as_ref().or(event.request_body.as_ref());
 
-        let fields = match body {
+        // Scan for credentials and redact before any further processing so
+        // that secrets never appear in audit events or log output.
+        let body: Option<bytes::Bytes> = raw_body.map(|b| {
+            let text = String::from_utf8_lossy(b);
+            let result = self.scanner.scan(&text);
+            if result.is_clean() {
+                b.clone()
+            } else {
+                tracing::warn!(
+                    findings = result.findings.len(),
+                    agent_id = event.agent_id.as_deref().unwrap_or("<unknown>"),
+                    "credentials detected in LLM body, redacting before audit"
+                );
+                bytes::Bytes::from(result.redact(&text))
+            }
+        });
+
+        let fields = match body.as_ref() {
             Some(bytes) => match Self::extract_for_pattern(&event.pattern, bytes) {
                 Ok(f) => Some(f),
                 Err(e) => {

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -42,10 +42,7 @@ impl Interceptor {
     ///
     /// Pass `None` to disable credential scanning entirely, or `Some(scanner)`
     /// to use a custom-configured [`CredentialScanner`].
-    pub fn with_scanner(
-        event_tx: broadcast::Sender<PipelineEvent>,
-        scanner: Option<CredentialScanner>,
-    ) -> Self {
+    pub fn with_scanner(event_tx: broadcast::Sender<PipelineEvent>, scanner: Option<CredentialScanner>) -> Self {
         Self { event_tx, scanner }
     }
 

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -357,4 +357,43 @@ mod tests {
             other => panic!("expected Audit event, got {other:?}"),
         }
     }
+
+    #[tokio::test]
+    async fn intercept_redacts_credentials_from_body() {
+        let interceptor = make_interceptor();
+        let mut event = make_event(LlmApiPattern::OpenAi);
+        // Embed a well-known OpenAI API key pattern in a message content field.
+        event.request_body = Some(Bytes::from(
+            r#"{"model":"gpt-4","messages":[{"role":"user","content":"my key is sk-proj-aBcDeFgHiJkLmNoPqRsT1234567890abcdef1234567890ab"}]}"#,
+        ));
+        event.response_body = None;
+
+        let fields = interceptor.intercept(&event).await.unwrap().unwrap();
+        // Extraction still succeeds — model and message count are preserved.
+        assert_eq!(fields.model, "gpt-4");
+        assert_eq!(fields.messages_count, 1);
+    }
+
+    #[tokio::test]
+    async fn intercept_credential_body_emits_redacted_event() {
+        let (tx, mut rx) = broadcast::channel(16);
+        let interceptor = Interceptor::new(tx);
+        let mut event = make_event(LlmApiPattern::OpenAi);
+        // Response body with a credential embedded in a field.
+        event.response_body = Some(Bytes::from(
+            r#"{"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":8},"debug":"sk-proj-aBcDeFgHiJkLmNoPqRsT1234567890abcdef1234567890ab"}"#,
+        ));
+
+        let fields = interceptor.intercept(&event).await.unwrap().unwrap();
+        assert_eq!(fields.model, "gpt-4");
+        assert_eq!(fields.prompt_tokens, Some(5));
+
+        // The pipeline event should not contain the raw credential.
+        let pipeline_event = rx.try_recv().expect("should receive pipeline event");
+        let event_str = format!("{pipeline_event:?}");
+        assert!(
+            !event_str.contains("sk-proj-"),
+            "pipeline event must not contain raw credential"
+        );
+    }
 }

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -13,6 +13,8 @@ use aa_proto::assembly::common::v1::ActionType;
 use aa_runtime::pipeline::event::{EnrichedEvent, EventSource};
 use aa_runtime::pipeline::PipelineEvent;
 
+use aa_core::CredentialScanner;
+
 use crate::error::ProxyError;
 use crate::intercept::detect::LlmApiPattern;
 use crate::intercept::extract::{extract_anthropic, extract_cohere, extract_openai, ExtractionError, LlmFields};
@@ -24,12 +26,16 @@ use crate::intercept::extract::{extract_anthropic, extract_cohere, extract_opena
 /// LLM calls into the runtime event pipeline.
 pub struct Interceptor {
     event_tx: broadcast::Sender<PipelineEvent>,
+    scanner: CredentialScanner,
 }
 
 impl Interceptor {
     /// Create a new `Interceptor` that emits events on the given broadcast channel.
     pub fn new(event_tx: broadcast::Sender<PipelineEvent>) -> Self {
-        Self { event_tx }
+        Self {
+            event_tx,
+            scanner: CredentialScanner::new(),
+        }
     }
 
     /// Inspect an intercepted exchange, extract LLM fields from the body,

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -26,16 +26,27 @@ use crate::intercept::extract::{extract_anthropic, extract_cohere, extract_opena
 /// LLM calls into the runtime event pipeline.
 pub struct Interceptor {
     event_tx: broadcast::Sender<PipelineEvent>,
-    scanner: CredentialScanner,
+    scanner: Option<CredentialScanner>,
 }
 
 impl Interceptor {
-    /// Create a new `Interceptor` that emits events on the given broadcast channel.
+    /// Create a new `Interceptor` with default credential scanning enabled.
     pub fn new(event_tx: broadcast::Sender<PipelineEvent>) -> Self {
         Self {
             event_tx,
-            scanner: CredentialScanner::new(),
+            scanner: Some(CredentialScanner::new()),
         }
+    }
+
+    /// Create a new `Interceptor` with an explicit scanner configuration.
+    ///
+    /// Pass `None` to disable credential scanning entirely, or `Some(scanner)`
+    /// to use a custom-configured [`CredentialScanner`].
+    pub fn with_scanner(
+        event_tx: broadcast::Sender<PipelineEvent>,
+        scanner: Option<CredentialScanner>,
+    ) -> Self {
+        Self { event_tx, scanner }
     }
 
     /// Inspect an intercepted exchange, extract LLM fields from the body,
@@ -57,17 +68,21 @@ impl Interceptor {
         // Scan for credentials and redact before any further processing so
         // that secrets never appear in audit events or log output.
         let body: Option<bytes::Bytes> = raw_body.map(|b| {
-            let text = String::from_utf8_lossy(b);
-            let result = self.scanner.scan(&text);
-            if result.is_clean() {
-                b.clone()
+            if let Some(scanner) = &self.scanner {
+                let text = String::from_utf8_lossy(b);
+                let result = scanner.scan(&text);
+                if result.is_clean() {
+                    b.clone()
+                } else {
+                    tracing::warn!(
+                        findings = result.findings.len(),
+                        agent_id = event.agent_id.as_deref().unwrap_or("<unknown>"),
+                        "credentials detected in LLM body, redacting before audit"
+                    );
+                    bytes::Bytes::from(result.redact(&text))
+                }
             } else {
-                tracing::warn!(
-                    findings = result.findings.len(),
-                    agent_id = event.agent_id.as_deref().unwrap_or("<unknown>"),
-                    "credentials detected in LLM body, redacting before audit"
-                );
-                bytes::Bytes::from(result.redact(&text))
+                b.clone()
             }
         });
 


### PR DESCRIPTION
## Description

Wire the existing `CredentialScanner` from `aa-core` into both event emission paths so that credentials leaked in LLM API bodies or Python FFI event details are redacted before reaching the audit pipeline. Add configurability (enable/disable, custom patterns) to satisfy AC #5.

### Credential redaction (AC #3, #4, #8)

**Proxy interceptor (`aa-proxy`):** Scan the LLM request/response body with `CredentialScanner` before extracting fields or emitting `PipelineEvent::Audit`. Secrets are replaced with `[REDACTED:<kind>]` markers.

**Python FFI (`aa-ffi-python`):** Scan the `details` string in `AssemblyHandle::report_event()` before inserting into audit event labels.

### Configurability (AC #5)

**`ScannerConfig`** (`aa-core`): New config struct with:
- `disabled: bool` — skip scanning entirely (`scan()` returns empty result)
- `custom_patterns: Vec<String>` — additional literal prefixes appended to the AC automaton as `CredentialKind::Custom`

**`Interceptor::with_scanner()`** (`aa-proxy`): Accept `Option<CredentialScanner>` — `None` disables scanning, `Some(scanner)` uses a custom-configured scanner.

**`AssemblyHandle::with_scanner()`** (`aa-ffi-python`): Same pattern — `None` disables, `Some(scanner)` uses custom config.

Both `new()` constructors retain the default always-on behavior (secure by default).

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-163
- Epic: AAASM-4 (Three-Layer Agent Interception)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

New tests verify:
- Credentials in intercepted LLM bodies are redacted before audit emission
- Extraction still succeeds after redaction (model, token counts preserved)
- Raw credentials never appear in emitted `PipelineEvent`
- Credentials in `report_event()` details are replaced with redaction markers
- Clean details pass through unchanged
- Disabled scanner returns empty result (ScannerConfig)
- Custom patterns detected as `CredentialKind::Custom`
- Custom patterns coexist with built-in patterns
- `ScannerConfig::default()` matches `CredentialScanner::new()` behavior
- Disabled scanner in Interceptor skips redaction
- Disabled scanner in AssemblyHandle passes details through

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention