### PR TITLE
[AAASM-78] ✨ (aa-api): Initialize Axum REST API crate with router and middleware stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,7 @@ dependencies = [
  "aa-runtime",
  "axum 0.7.9",
  "axum-test",
+ "chrono-tz",
  "http 1.4.0",
  "hyper",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,10 +8,22 @@ version = "0.0.1"
 dependencies = [
  "aa-core",
  "aa-gateway",
+ "aa-runtime",
  "axum 0.7.9",
+ "axum-test",
+ "http 1.4.0",
+ "hyper",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
  "tokio",
+ "tower 0.5.3",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
  "utoipa",
  "utoipa-swagger-ui",
+ "uuid",
 ]
 
 [[package]]
@@ -73,6 +85,7 @@ version = "0.0.1"
 dependencies = [
  "aa-core",
  "aa-proto",
+ "criterion",
  "prost",
  "pyo3",
  "tokio",
@@ -134,6 +147,7 @@ dependencies = [
  "aa-runtime",
  "anyhow",
  "bytes",
+ "criterion",
  "dirs",
  "hyper",
  "hyper-util",
@@ -356,10 +370,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "assert_matches"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "async-stream"
@@ -401,6 +437,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-future"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1e7e457ea78e524f48639f551fd79703ac3f2237f5ecccdf4708f8a75ad373"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,7 +480,7 @@ dependencies = [
  "axum-core 0.4.5",
  "bytes",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -471,7 +513,7 @@ dependencies = [
  "axum-core 0.5.6",
  "bytes",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "itoa",
@@ -496,7 +538,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "mime",
@@ -516,7 +558,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "mime",
@@ -524,6 +566,36 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-test"
+version = "16.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e3a443d2608936a02a222da7b746eb412fede7225b3030b64fe9be99eab8dc"
+dependencies = [
+ "anyhow",
+ "assert-json-diff",
+ "auto-future",
+ "axum 0.7.9",
+ "bytes",
+ "bytesize",
+ "cookie",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "mime",
+ "pretty_assertions",
+ "reserve-port",
+ "rust-multipart-rfc7578_2",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "tokio",
+ "tower 0.5.3",
+ "url",
 ]
 
 [[package]]
@@ -685,6 +757,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bytesize"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,6 +912,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
+
+[[package]]
 name = "conformance"
 version = "0.0.1"
 dependencies = [
@@ -857,6 +952,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "time",
+ "version_check",
 ]
 
 [[package]]
@@ -1090,6 +1195,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -1420,7 +1531,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1502,6 +1613,17 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -1517,7 +1639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1528,7 +1650,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
+ "http 1.4.0",
  "http-body",
  "pin-project-lite",
 ]
@@ -1556,7 +1678,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2",
- "http",
+ "http 1.4.0",
  "http-body",
  "httparse",
  "httpdate",
@@ -1573,7 +1695,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
+ "http 1.4.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -1607,7 +1729,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "hyper",
  "ipnet",
@@ -2518,6 +2640,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2999,7 +3131,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -3026,6 +3158,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
+]
+
+[[package]]
+name = "reserve-port"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94070964579245eb2f76e62a7668fe87bd9969ed6c41256f3bf614e3323dd3cc"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3103,6 +3244,22 @@ checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "sha2",
  "walkdir",
+]
+
+[[package]]
+name = "rust-multipart-rfc7578_2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b748410c0afdef2ebbe3685a6a862e2ee937127cdaae623336a459451c8d57"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "mime",
+ "mime_guess",
+ "rand 0.8.6",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3830,7 +3987,7 @@ dependencies = [
  "base64",
  "bytes",
  "h2",
- "http",
+ "http 1.4.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -3902,16 +4059,22 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.1",
  "bytes",
+ "futures-core",
  "futures-util",
- "http",
+ "http 1.4.0",
  "http-body",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -4781,6 +4944,12 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yasna"

--- a/aa-api/Cargo.toml
+++ b/aa-api/Cargo.toml
@@ -27,6 +27,8 @@ uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 axum-test = "16"
+chrono-tz = "0.9"
+serde_json = "1"
 tower = { version = "0.5", features = ["util"] }
 
 [lints]

--- a/aa-api/Cargo.toml
+++ b/aa-api/Cargo.toml
@@ -9,10 +9,25 @@ description = "HTTP presentation layer with OpenAPI spec generation for Agent As
 [dependencies]
 aa-core = { path = "../aa-core" }
 aa-gateway = { path = "../aa-gateway" }
+aa-runtime = { path = "../aa-runtime" }
 axum = "0.7"
+http = "1"
+hyper = { version = "1", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
 tokio = { version = "1", features = ["full"] }
+tower = { version = "0.5", features = ["util"] }
+tower-http = { version = "0.6", features = ["trace", "cors", "compression-gzip", "request-id", "util", "set-header"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 utoipa = { version = "4", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "7", features = ["axum"] }
+uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+axum-test = "16"
+tower = { version = "0.5", features = ["util"] }
 
 [lints]
 workspace = true

--- a/aa-api/src/config.rs
+++ b/aa-api/src/config.rs
@@ -1,0 +1,40 @@
+//! API server configuration.
+
+use std::net::SocketAddr;
+
+/// Default bind address for the API server.
+const DEFAULT_ADDR: &str = "127.0.0.1:7700";
+
+/// Configuration for the `aa-api` HTTP server.
+#[derive(Debug, Clone)]
+pub struct ApiConfig {
+    /// Socket address to bind the server to.
+    pub bind_addr: SocketAddr,
+}
+
+impl ApiConfig {
+    /// Build configuration from environment variables.
+    ///
+    /// Reads `AA_API_ADDR` (e.g. `"0.0.0.0:7700"`). Falls back to
+    /// `127.0.0.1:7700` when the variable is unset.
+    pub fn from_env() -> Self {
+        let addr = std::env::var("AA_API_ADDR").unwrap_or_else(|_| DEFAULT_ADDR.to_string());
+        let bind_addr = addr.parse().unwrap_or_else(|e| {
+            tracing::warn!(
+                addr = %addr,
+                error = %e,
+                "invalid AA_API_ADDR, falling back to default"
+            );
+            DEFAULT_ADDR.parse().expect("default address is valid")
+        });
+        Self { bind_addr }
+    }
+}
+
+impl Default for ApiConfig {
+    fn default() -> Self {
+        Self {
+            bind_addr: DEFAULT_ADDR.parse().expect("default address is valid"),
+        }
+    }
+}

--- a/aa-api/src/error.rs
+++ b/aa-api/src/error.rs
@@ -1,0 +1,73 @@
+//! RFC 7807 Problem Details error responses.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+
+/// RFC 7807 Problem Details JSON body.
+#[derive(Debug, Clone, Serialize)]
+pub struct ProblemDetail {
+    /// URI reference identifying the problem type.
+    #[serde(rename = "type")]
+    pub type_uri: String,
+    /// Short human-readable summary.
+    pub title: String,
+    /// HTTP status code.
+    pub status: u16,
+    /// Human-readable explanation specific to this occurrence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    /// URI reference identifying the specific occurrence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instance: Option<String>,
+}
+
+impl ProblemDetail {
+    /// Create a `ProblemDetail` from an HTTP status code.
+    pub fn from_status(status: StatusCode) -> Self {
+        Self {
+            type_uri: "about:blank".to_string(),
+            title: status
+                .canonical_reason()
+                .unwrap_or("Unknown Error")
+                .to_string(),
+            status: status.as_u16(),
+            detail: None,
+            instance: None,
+        }
+    }
+
+    /// Attach a human-readable detail message.
+    #[must_use]
+    pub fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+
+    /// Attach the request URI as the instance identifier.
+    #[must_use]
+    pub fn with_instance(mut self, instance: impl Into<String>) -> Self {
+        self.instance = Some(instance.into());
+        self
+    }
+}
+
+impl IntoResponse for ProblemDetail {
+    fn into_response(self) -> Response {
+        let status =
+            StatusCode::from_u16(self.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+        let body = serde_json::to_string(&self).unwrap_or_else(|_| {
+            r#"{"type":"about:blank","title":"Internal Server Error","status":500}"#.to_string()
+        });
+
+        (
+            status,
+            [(
+                axum::http::header::CONTENT_TYPE,
+                "application/problem+json",
+            )],
+            body,
+        )
+            .into_response()
+    }
+}

--- a/aa-api/src/error.rs
+++ b/aa-api/src/error.rs
@@ -27,10 +27,7 @@ impl ProblemDetail {
     pub fn from_status(status: StatusCode) -> Self {
         Self {
             type_uri: "about:blank".to_string(),
-            title: status
-                .canonical_reason()
-                .unwrap_or("Unknown Error")
-                .to_string(),
+            title: status.canonical_reason().unwrap_or("Unknown Error").to_string(),
             status: status.as_u16(),
             detail: None,
             instance: None,
@@ -54,18 +51,13 @@ impl ProblemDetail {
 
 impl IntoResponse for ProblemDetail {
     fn into_response(self) -> Response {
-        let status =
-            StatusCode::from_u16(self.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-        let body = serde_json::to_string(&self).unwrap_or_else(|_| {
-            r#"{"type":"about:blank","title":"Internal Server Error","status":500}"#.to_string()
-        });
+        let status = StatusCode::from_u16(self.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+        let body = serde_json::to_string(&self)
+            .unwrap_or_else(|_| r#"{"type":"about:blank","title":"Internal Server Error","status":500}"#.to_string());
 
         (
             status,
-            [(
-                axum::http::header::CONTENT_TYPE,
-                "application/problem+json",
-            )],
+            [(axum::http::header::CONTENT_TYPE, "application/problem+json")],
             body,
         )
             .into_response()

--- a/aa-api/src/events.rs
+++ b/aa-api/src/events.rs
@@ -1,0 +1,74 @@
+//! Unified event broadcast bus for the API layer.
+//!
+//! Aggregates the individual `tokio::sync::broadcast` channels from the
+//! runtime, gateway, and proxy crates into a single struct that the API
+//! layer (and downstream WebSocket streaming) can subscribe to.
+
+use aa_gateway::budget::types::BudgetAlert;
+use aa_runtime::approval::ApprovalRequest;
+use aa_runtime::pipeline::event::PipelineEvent;
+use tokio::sync::broadcast;
+
+/// Default channel capacity for each event broadcast.
+const DEFAULT_CHANNEL_CAPACITY: usize = 256;
+
+/// Unified event broadcast bus.
+///
+/// Holds one `broadcast::Sender` per event domain so that API consumers
+/// (e.g. the WebSocket streaming endpoint) can subscribe to any
+/// combination without reaching into individual subsystem internals.
+pub struct EventBroadcast {
+    pipeline_tx: broadcast::Sender<PipelineEvent>,
+    approval_tx: broadcast::Sender<ApprovalRequest>,
+    budget_tx: broadcast::Sender<BudgetAlert>,
+}
+
+impl EventBroadcast {
+    /// Create a new `EventBroadcast` with the given per-channel capacity.
+    pub fn new(capacity: usize) -> Self {
+        let (pipeline_tx, _) = broadcast::channel(capacity);
+        let (approval_tx, _) = broadcast::channel(capacity);
+        let (budget_tx, _) = broadcast::channel(capacity);
+        Self {
+            pipeline_tx,
+            approval_tx,
+            budget_tx,
+        }
+    }
+
+    /// Subscribe to pipeline audit events.
+    pub fn subscribe_pipeline(&self) -> broadcast::Receiver<PipelineEvent> {
+        self.pipeline_tx.subscribe()
+    }
+
+    /// Subscribe to human-approval request events.
+    pub fn subscribe_approvals(&self) -> broadcast::Receiver<ApprovalRequest> {
+        self.approval_tx.subscribe()
+    }
+
+    /// Subscribe to budget threshold alerts.
+    pub fn subscribe_budget(&self) -> broadcast::Receiver<BudgetAlert> {
+        self.budget_tx.subscribe()
+    }
+
+    /// Get a clone of the pipeline event sender.
+    pub fn pipeline_sender(&self) -> broadcast::Sender<PipelineEvent> {
+        self.pipeline_tx.clone()
+    }
+
+    /// Get a clone of the approval event sender.
+    pub fn approval_sender(&self) -> broadcast::Sender<ApprovalRequest> {
+        self.approval_tx.clone()
+    }
+
+    /// Get a clone of the budget alert sender.
+    pub fn budget_sender(&self) -> broadcast::Sender<BudgetAlert> {
+        self.budget_tx.clone()
+    }
+}
+
+impl Default for EventBroadcast {
+    fn default() -> Self {
+        Self::new(DEFAULT_CHANNEL_CAPACITY)
+    }
+}

--- a/aa-api/src/lib.rs
+++ b/aa-api/src/lib.rs
@@ -4,3 +4,5 @@
 //! OpenAPI documentation is generated at build time from route annotations
 //! via `utoipa`. CI validates that `openapi/v1.yaml` stays in sync with
 //! the generated spec — a drift failure blocks merge.
+
+pub mod error;

--- a/aa-api/src/lib.rs
+++ b/aa-api/src/lib.rs
@@ -8,4 +8,5 @@
 pub mod config;
 pub mod error;
 pub mod events;
+pub mod middleware;
 pub mod state;

--- a/aa-api/src/lib.rs
+++ b/aa-api/src/lib.rs
@@ -9,4 +9,5 @@ pub mod config;
 pub mod error;
 pub mod events;
 pub mod middleware;
+pub mod routes;
 pub mod state;

--- a/aa-api/src/lib.rs
+++ b/aa-api/src/lib.rs
@@ -10,5 +10,6 @@ pub mod error;
 pub mod events;
 pub mod middleware;
 pub mod routes;
+pub mod server;
 pub mod shutdown;
 pub mod state;

--- a/aa-api/src/lib.rs
+++ b/aa-api/src/lib.rs
@@ -7,3 +7,4 @@
 
 pub mod error;
 pub mod events;
+pub mod state;

--- a/aa-api/src/lib.rs
+++ b/aa-api/src/lib.rs
@@ -6,3 +6,4 @@
 //! the generated spec — a drift failure blocks merge.
 
 pub mod error;
+pub mod events;

--- a/aa-api/src/lib.rs
+++ b/aa-api/src/lib.rs
@@ -13,3 +13,9 @@ pub mod routes;
 pub mod server;
 pub mod shutdown;
 pub mod state;
+
+pub use config::ApiConfig;
+pub use error::ProblemDetail;
+pub use events::EventBroadcast;
+pub use server::{build_app, run_server};
+pub use state::AppState;

--- a/aa-api/src/lib.rs
+++ b/aa-api/src/lib.rs
@@ -10,4 +10,5 @@ pub mod error;
 pub mod events;
 pub mod middleware;
 pub mod routes;
+pub mod shutdown;
 pub mod state;

--- a/aa-api/src/lib.rs
+++ b/aa-api/src/lib.rs
@@ -5,6 +5,7 @@
 //! via `utoipa`. CI validates that `openapi/v1.yaml` stays in sync with
 //! the generated spec — a drift failure blocks merge.
 
+pub mod config;
 pub mod error;
 pub mod events;
 pub mod state;

--- a/aa-api/src/middleware/compression.rs
+++ b/aa-api/src/middleware/compression.rs
@@ -1,0 +1,10 @@
+//! Response compression middleware.
+//!
+//! Applies gzip compression to HTTP response bodies.
+
+use tower_http::compression::CompressionLayer;
+
+/// Build a [`CompressionLayer`] with gzip encoding.
+pub fn compression_layer() -> CompressionLayer {
+    CompressionLayer::new().gzip(true)
+}

--- a/aa-api/src/middleware/cors.rs
+++ b/aa-api/src/middleware/cors.rs
@@ -9,9 +9,9 @@ use tower_http::cors::{AllowOrigin, CorsLayer};
 /// Build a [`CorsLayer`] configured for dashboard access.
 pub fn cors_layer() -> CorsLayer {
     CorsLayer::new()
-        .allow_origin(AllowOrigin::list([
-            "http://localhost:3000".parse().expect("valid origin"),
-        ]))
+        .allow_origin(AllowOrigin::list(["http://localhost:3000"
+            .parse()
+            .expect("valid origin")]))
         .allow_methods([
             Method::GET,
             Method::POST,
@@ -20,10 +20,6 @@ pub fn cors_layer() -> CorsLayer {
             Method::DELETE,
             Method::OPTIONS,
         ])
-        .allow_headers([
-            header::CONTENT_TYPE,
-            header::AUTHORIZATION,
-            header::ACCEPT,
-        ])
+        .allow_headers([header::CONTENT_TYPE, header::AUTHORIZATION, header::ACCEPT])
         .allow_credentials(true)
 }

--- a/aa-api/src/middleware/cors.rs
+++ b/aa-api/src/middleware/cors.rs
@@ -1,0 +1,29 @@
+//! CORS middleware configuration.
+//!
+//! Allows the dashboard origin (`http://localhost:3000` in dev) to make
+//! cross-origin requests to the API.
+
+use axum::http::{header, Method};
+use tower_http::cors::{AllowOrigin, CorsLayer};
+
+/// Build a [`CorsLayer`] configured for dashboard access.
+pub fn cors_layer() -> CorsLayer {
+    CorsLayer::new()
+        .allow_origin(AllowOrigin::list([
+            "http://localhost:3000".parse().expect("valid origin"),
+        ]))
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PUT,
+            Method::PATCH,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
+        .allow_headers([
+            header::CONTENT_TYPE,
+            header::AUTHORIZATION,
+            header::ACCEPT,
+        ])
+        .allow_credentials(true)
+}

--- a/aa-api/src/middleware/mod.rs
+++ b/aa-api/src/middleware/mod.rs
@@ -1,0 +1,29 @@
+//! Tower middleware stack for the API server.
+//!
+//! Middleware is applied in this order (outermost first):
+//! 1. Request ID injection (`x-request-id`)
+//! 2. Structured tracing (logs method, path, status, duration, request_id)
+//! 3. CORS (allow dashboard origin)
+//! 4. Response compression (gzip)
+//!
+//! Authentication middleware will be added by AAASM-82.
+
+pub mod compression;
+pub mod cors;
+pub mod request_id;
+pub mod tracing;
+
+use axum::Router;
+use tower_http::request_id::{PropagateRequestIdLayer, SetRequestIdLayer};
+
+use self::request_id::UuidRequestId;
+
+/// Apply the full middleware stack to the given router.
+pub fn apply_middleware(router: Router) -> Router {
+    router
+        .layer(self::compression::compression_layer())
+        .layer(self::cors::cors_layer())
+        .layer(self::tracing::trace_layer())
+        .layer(PropagateRequestIdLayer::x_request_id())
+        .layer(SetRequestIdLayer::x_request_id(UuidRequestId))
+}

--- a/aa-api/src/middleware/request_id.rs
+++ b/aa-api/src/middleware/request_id.rs
@@ -1,0 +1,19 @@
+//! Request ID injection middleware.
+//!
+//! Assigns a UUID v4 to every incoming request via the `x-request-id` header
+//! and propagates it on the response.
+
+use http::HeaderValue;
+use tower_http::request_id::{MakeRequestId, RequestId};
+use uuid::Uuid;
+
+/// Generates UUID v4 request identifiers.
+#[derive(Clone, Copy)]
+pub struct UuidRequestId;
+
+impl MakeRequestId for UuidRequestId {
+    fn make_request_id<B>(&mut self, _request: &http::Request<B>) -> Option<RequestId> {
+        let id = Uuid::new_v4().to_string();
+        HeaderValue::from_str(&id).ok().map(RequestId::new)
+    }
+}

--- a/aa-api/src/middleware/tracing.rs
+++ b/aa-api/src/middleware/tracing.rs
@@ -1,0 +1,37 @@
+//! Structured request/response tracing middleware.
+//!
+//! Logs method, path, status, duration_ms, and request_id for every
+//! request using `tower-http::trace`.
+
+use axum::http::Request;
+use tower_http::trace::{DefaultOnResponse, TraceLayer};
+use tracing::{Level, Span};
+
+/// Build a [`TraceLayer`] that logs request and response metadata.
+pub fn trace_layer() -> TraceLayer<
+    tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>,
+    impl Fn(&Request<axum::body::Body>) -> Span + Clone,
+    (),
+    DefaultOnResponse,
+> {
+    TraceLayer::new_for_http()
+        .make_span_with(|request: &Request<axum::body::Body>| {
+            let request_id = request
+                .headers()
+                .get("x-request-id")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or("-");
+            tracing::info_span!(
+                "http_request",
+                method = %request.method(),
+                path = %request.uri().path(),
+                request_id = %request_id,
+            )
+        })
+        .on_request(())
+        .on_response(
+            DefaultOnResponse::new()
+                .level(Level::INFO)
+                .include_headers(false),
+        )
+}

--- a/aa-api/src/middleware/tracing.rs
+++ b/aa-api/src/middleware/tracing.rs
@@ -29,9 +29,5 @@ pub fn trace_layer() -> TraceLayer<
             )
         })
         .on_request(())
-        .on_response(
-            DefaultOnResponse::new()
-                .level(Level::INFO)
-                .include_headers(false),
-        )
+        .on_response(DefaultOnResponse::new().level(Level::INFO).include_headers(false))
 }

--- a/aa-api/src/routes/health.rs
+++ b/aa-api/src/routes/health.rs
@@ -1,0 +1,22 @@
+//! Health check endpoint.
+
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::Serialize;
+
+/// Response body for the health endpoint.
+#[derive(Serialize)]
+pub struct HealthResponse {
+    pub status: String,
+}
+
+/// `GET /api/v1/health` — liveness probe.
+pub async fn health() -> impl IntoResponse {
+    (
+        StatusCode::OK,
+        Json(HealthResponse {
+            status: "ok".to_string(),
+        }),
+    )
+}

--- a/aa-api/src/routes/mod.rs
+++ b/aa-api/src/routes/mod.rs
@@ -1,0 +1,22 @@
+//! Route definitions for the REST API.
+//!
+//! All endpoints are nested under `/api/v1/`.
+
+pub mod health;
+
+use axum::routing::get;
+use axum::Router;
+
+use crate::error::ProblemDetail;
+
+/// Build the v1 API router with all registered routes.
+pub fn v1_router() -> Router {
+    Router::new().route("/health", get(health::health))
+}
+
+/// Fallback handler returning a 404 RFC 7807 response.
+pub async fn fallback_404(uri: axum::http::Uri) -> ProblemDetail {
+    ProblemDetail::from_status(axum::http::StatusCode::NOT_FOUND)
+        .with_detail(format!("No route matched: {uri}"))
+        .with_instance(uri.to_string())
+}

--- a/aa-api/src/server.rs
+++ b/aa-api/src/server.rs
@@ -1,0 +1,41 @@
+//! Server builder wiring router, middleware, state, and graceful shutdown.
+
+use axum::Router;
+use tokio::net::TcpListener;
+
+use crate::config::ApiConfig;
+use crate::middleware::apply_middleware;
+use crate::routes;
+use crate::state::AppState;
+
+/// Build the full Axum application with middleware and state.
+pub fn build_app(state: AppState) -> Router {
+    let api = routes::v1_router();
+
+    let app = Router::new()
+        .nest("/api/v1", api)
+        .fallback(routes::fallback_404)
+        .with_state(());
+
+    let app = app.layer(axum::Extension(state));
+
+    apply_middleware(app)
+}
+
+/// Start the HTTP server and block until shutdown.
+pub async fn run_server(
+    config: ApiConfig,
+    state: AppState,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let app = build_app(state);
+
+    let listener = TcpListener::bind(config.bind_addr).await?;
+    tracing::info!(addr = %config.bind_addr, "aa-api server listening");
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(crate::shutdown::shutdown_signal())
+        .await?;
+
+    tracing::info!("aa-api server shut down");
+    Ok(())
+}

--- a/aa-api/src/server.rs
+++ b/aa-api/src/server.rs
@@ -23,16 +23,34 @@ pub fn build_app(state: AppState) -> Router {
 }
 
 /// Start the HTTP server and block until shutdown.
+///
+/// After receiving a shutdown signal the server drains in-flight requests.
+/// If draining does not complete within [`DRAIN_TIMEOUT`] the server exits
+/// anyway so the process is not stuck indefinitely.
+///
+/// [`DRAIN_TIMEOUT`]: crate::shutdown::DRAIN_TIMEOUT
 pub async fn run_server(config: ApiConfig, state: AppState) -> Result<(), Box<dyn std::error::Error>> {
     let app = build_app(state);
 
     let listener = TcpListener::bind(config.bind_addr).await?;
     tracing::info!(addr = %config.bind_addr, "aa-api server listening");
 
-    axum::serve(listener, app)
-        .with_graceful_shutdown(crate::shutdown::shutdown_signal())
-        .await?;
+    let serve = axum::serve(listener, app).with_graceful_shutdown(crate::shutdown::shutdown_signal());
 
-    tracing::info!("aa-api server shut down");
+    match tokio::time::timeout(crate::shutdown::DRAIN_TIMEOUT, serve).await {
+        Ok(Ok(())) => {
+            tracing::info!("aa-api server shut down gracefully");
+        }
+        Ok(Err(e)) => {
+            return Err(e.into());
+        }
+        Err(_elapsed) => {
+            tracing::warn!(
+                timeout_secs = crate::shutdown::DRAIN_TIMEOUT.as_secs(),
+                "drain timeout exceeded, forcing shutdown"
+            );
+        }
+    }
+
     Ok(())
 }

--- a/aa-api/src/server.rs
+++ b/aa-api/src/server.rs
@@ -23,10 +23,7 @@ pub fn build_app(state: AppState) -> Router {
 }
 
 /// Start the HTTP server and block until shutdown.
-pub async fn run_server(
-    config: ApiConfig,
-    state: AppState,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn run_server(config: ApiConfig, state: AppState) -> Result<(), Box<dyn std::error::Error>> {
     let app = build_app(state);
 
     let listener = TcpListener::bind(config.bind_addr).await?;

--- a/aa-api/src/shutdown.rs
+++ b/aa-api/src/shutdown.rs
@@ -1,0 +1,38 @@
+//! Graceful shutdown signal handler.
+//!
+//! Listens for `SIGTERM` (and `Ctrl-C` for dev convenience) and returns
+//! a future that completes when the signal is received. The server uses
+//! this to drain in-flight requests within a configurable timeout.
+
+use std::time::Duration;
+
+/// Default drain timeout after receiving a shutdown signal.
+pub const DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Returns a future that completes when a shutdown signal is received.
+///
+/// On Unix, listens for both `SIGTERM` and `SIGINT` (Ctrl-C).
+pub async fn shutdown_signal() {
+    let ctrl_c = tokio::signal::ctrl_c();
+
+    #[cfg(unix)]
+    {
+        let mut sigterm =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+                .expect("failed to register SIGTERM handler");
+        tokio::select! {
+            _ = ctrl_c => {
+                tracing::info!("received SIGINT, starting graceful shutdown");
+            }
+            _ = sigterm.recv() => {
+                tracing::info!("received SIGTERM, starting graceful shutdown");
+            }
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        ctrl_c.await.expect("failed to listen for Ctrl-C");
+        tracing::info!("received Ctrl-C, starting graceful shutdown");
+    }
+}

--- a/aa-api/src/shutdown.rs
+++ b/aa-api/src/shutdown.rs
@@ -17,9 +17,8 @@ pub async fn shutdown_signal() {
 
     #[cfg(unix)]
     {
-        let mut sigterm =
-            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-                .expect("failed to register SIGTERM handler");
+        let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to register SIGTERM handler");
         tokio::select! {
             _ = ctrl_c => {
                 tracing::info!("received SIGINT, starting graceful shutdown");

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -1,0 +1,22 @@
+//! Shared application state for the Axum server.
+
+use std::sync::Arc;
+
+use aa_gateway::budget::tracker::BudgetTracker;
+use aa_gateway::engine::PolicyEngine;
+use aa_runtime::approval::ApprovalQueue;
+
+use crate::events::EventBroadcast;
+
+/// Shared state available to all Axum handlers via `Extension<AppState>`.
+#[derive(Clone)]
+pub struct AppState {
+    /// Policy engine for governance decisions.
+    pub policy_engine: Arc<PolicyEngine>,
+    /// Cost tracking and budget enforcement.
+    pub budget_tracker: Arc<BudgetTracker>,
+    /// Human-in-the-loop approval request queue.
+    pub approval_queue: Arc<ApprovalQueue>,
+    /// Unified event broadcast bus for streaming to clients.
+    pub events: Arc<EventBroadcast>,
+}

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -1,0 +1,57 @@
+//! Shared test utilities for aa-api integration tests.
+
+use std::sync::Arc;
+
+use aa_api::events::EventBroadcast;
+use aa_api::server::build_app;
+use aa_api::state::AppState;
+use aa_gateway::budget::pricing::PricingTable;
+use aa_gateway::budget::tracker::BudgetTracker;
+use aa_gateway::engine::PolicyEngine;
+use aa_runtime::approval::ApprovalQueue;
+use axum::Router;
+
+/// Build a test `AppState` with minimal real dependencies.
+pub fn test_state() -> AppState {
+    // PolicyEngine requires a policy file; use a minimal valid policy.
+    let policy_dir = std::env::temp_dir().join("aa-api-test-policy");
+    std::fs::create_dir_all(&policy_dir).unwrap();
+    let policy_path = policy_dir.join("test-policy.yaml");
+    std::fs::write(
+        &policy_path,
+        r#"
+apiVersion: agent-assembly.dev/v1alpha1
+kind: GovernancePolicy
+metadata:
+  name: test-policy
+  version: "0.1.0"
+spec:
+  rules: []
+"#,
+    )
+    .unwrap();
+
+    let events = Arc::new(EventBroadcast::default());
+    let budget_alert_tx = events.budget_sender();
+    let policy_engine =
+        Arc::new(PolicyEngine::load_from_file(&policy_path, budget_alert_tx).unwrap());
+    let budget_tracker = Arc::new(BudgetTracker::new(
+        PricingTable::default_table(),
+        None,
+        None,
+        chrono_tz::UTC,
+    ));
+    let approval_queue = ApprovalQueue::new();
+
+    AppState {
+        policy_engine,
+        budget_tracker,
+        approval_queue,
+        events,
+    }
+}
+
+/// Build the full app for testing (router + middleware + state).
+pub fn test_app() -> Router {
+    build_app(test_state())
+}

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -33,8 +33,7 @@ spec:
 
     let events = Arc::new(EventBroadcast::default());
     let budget_alert_tx = events.budget_sender();
-    let policy_engine =
-        Arc::new(PolicyEngine::load_from_file(&policy_path, budget_alert_tx).unwrap());
+    let policy_engine = Arc::new(PolicyEngine::load_from_file(&policy_path, budget_alert_tx).unwrap());
     let budget_tracker = Arc::new(BudgetTracker::new(
         PricingTable::default_table(),
         None,

--- a/aa-api/tests/error_response.rs
+++ b/aa-api/tests/error_response.rs
@@ -1,0 +1,42 @@
+//! Integration test for RFC 7807 error responses.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn unmatched_route_returns_rfc7807_404() {
+    let app = common::test_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/nonexistent")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    assert_eq!(content_type, "application/problem+json");
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["type"], "about:blank");
+    assert_eq!(json["title"], "Not Found");
+    assert_eq!(json["status"], 404);
+    assert!(json["detail"].as_str().unwrap().contains("nonexistent"));
+    assert_eq!(json["instance"], "/api/v1/nonexistent");
+}

--- a/aa-api/tests/error_response.rs
+++ b/aa-api/tests/error_response.rs
@@ -29,9 +29,7 @@ async fn unmatched_route_returns_rfc7807_404() {
         .unwrap_or("");
     assert_eq!(content_type, "application/problem+json");
 
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-        .await
-        .unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
     assert_eq!(json["type"], "about:blank");

--- a/aa-api/tests/event_broadcast.rs
+++ b/aa-api/tests/event_broadcast.rs
@@ -1,0 +1,63 @@
+//! Tests for the EventBroadcast unified event bus.
+
+use aa_api::events::EventBroadcast;
+use aa_gateway::budget::types::BudgetAlert;
+use aa_runtime::pipeline::event::{LayerDegradationInfo, PipelineEvent};
+
+#[tokio::test]
+async fn subscribe_pipeline_receives_published_event() {
+    let bus = EventBroadcast::new(16);
+    let mut rx = bus.subscribe_pipeline();
+    let tx = bus.pipeline_sender();
+
+    let event = PipelineEvent::LayerDegradation(LayerDegradationInfo {
+        layer: "test".to_string(),
+        reason: "unit test".to_string(),
+        remaining_layers: vec![],
+    });
+
+    tx.send(event).unwrap();
+    let received = rx.recv().await.unwrap();
+    assert!(matches!(received, PipelineEvent::LayerDegradation(_)));
+}
+
+#[tokio::test]
+async fn subscribe_approvals_receives_published_event() {
+    let bus = EventBroadcast::new(16);
+    let mut rx = bus.subscribe_approvals();
+    let tx = bus.approval_sender();
+
+    let request = aa_runtime::approval::ApprovalRequest {
+        request_id: uuid::Uuid::new_v4(),
+        agent_id: "test-agent".to_string(),
+        action: "test action".to_string(),
+        condition_triggered: "test condition".to_string(),
+        submitted_at: 0,
+        timeout_secs: 60,
+        fallback: aa_core::PolicyResult::Deny {
+            reason: "test".to_string(),
+        },
+    };
+
+    tx.send(request).unwrap();
+    let received = rx.recv().await.unwrap();
+    assert_eq!(received.agent_id, "test-agent");
+}
+
+#[tokio::test]
+async fn subscribe_budget_receives_published_alert() {
+    let bus = EventBroadcast::new(16);
+    let mut rx = bus.subscribe_budget();
+    let tx = bus.budget_sender();
+
+    let alert = BudgetAlert {
+        agent_id: aa_core::AgentId::from_bytes([1; 16]),
+        threshold_pct: 80,
+        spent_usd: 8.0,
+        limit_usd: 10.0,
+    };
+
+    tx.send(alert).unwrap();
+    let received = rx.recv().await.unwrap();
+    assert_eq!(received.threshold_pct, 80);
+}

--- a/aa-api/tests/health.rs
+++ b/aa-api/tests/health.rs
@@ -1,0 +1,30 @@
+//! Integration test for the health endpoint.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn health_returns_200_with_ok_status() {
+    let app = common::test_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["status"], "ok");
+}

--- a/aa-api/tests/health.rs
+++ b/aa-api/tests/health.rs
@@ -11,20 +11,13 @@ async fn health_returns_200_with_ok_status() {
     let app = common::test_app();
 
     let response = app
-        .oneshot(
-            Request::builder()
-                .uri("/api/v1/health")
-                .body(Body::empty())
-                .unwrap(),
-        )
+        .oneshot(Request::builder().uri("/api/v1/health").body(Body::empty()).unwrap())
         .await
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-        .await
-        .unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["status"], "ok");
 }


### PR DESCRIPTION
## Description

Initialize the `aa-api` crate for REST API development. This sets up the complete Axum server skeleton with middleware stack, shared application state, RFC 7807 error handling, a unified event broadcast bus, health endpoint, and graceful shutdown — ready for endpoint implementation in subsequent tickets (AAASM-79–83).

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-78 (task), AAASM-9 (epic)
- Related GitHub issues: N/A

## What's Included

- **Dependencies**: tower-http (trace, cors, compression, request-id), serde, thiserror, uuid, tracing
- **Error handling**: RFC 7807 ProblemDetail with `application/problem+json` content type
- **EventBroadcast**: Unified event bus aggregating PipelineEvent, ApprovalRequest, and BudgetAlert broadcast channels
- **AppState**: Shared state holding Arc references to PolicyEngine, BudgetTracker, ApprovalQueue, EventBroadcast
- **Config**: ApiConfig reading `AA_API_ADDR` env var (default `127.0.0.1:7700`)
- **Middleware stack**: Request ID (UUID v4) → Structured tracing → CORS (localhost:3000) → Gzip compression
- **Routes**: `/api/v1/health` endpoint + 404 fallback with RFC 7807 format
- **Graceful shutdown**: SIGTERM/SIGINT handler with 30s drain timeout
- **Server builder**: `build_app()` and `run_server()` wiring everything together

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

**Tests added:**
- Health endpoint integration test (200 OK with `{"status": "ok"}`)
- RFC 7807 error response integration test (404 with correct content type and fields)
- EventBroadcast unit tests (subscribe/publish round-trip for all 3 event channels)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention