### PR TITLE
[AAASM-82] ✨ (auth): Implement API key and JWT authentication for aa-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,13 +9,17 @@ dependencies = [
  "aa-core",
  "aa-gateway",
  "aa-runtime",
+ "argon2",
  "axum 0.7.9",
  "axum-test",
  "chrono",
  "chrono-tz",
+ "dashmap",
  "futures",
  "http 1.4.0",
  "hyper",
+ "jsonwebtoken",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -328,6 +332,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
 ]
 
 [[package]]
@@ -696,6 +712,15 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -1225,6 +1250,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -2024,6 +2050,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2501,6 +2542,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
 dependencies = [
  "regex",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -3626,6 +3678,18 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "siphasher"

--- a/aa-api/Cargo.toml
+++ b/aa-api/Cargo.toml
@@ -10,9 +10,13 @@ description = "HTTP presentation layer with OpenAPI spec generation for Agent As
 aa-core = { path = "../aa-core" }
 aa-gateway = { path = "../aa-gateway" }
 aa-runtime = { path = "../aa-runtime" }
+argon2 = "0.5"
 axum = { version = "0.7", features = ["ws"] }
+dashmap = "6"
 http = "1"
 hyper = { version = "1", features = ["full"] }
+jsonwebtoken = "9"
+rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/aa-api/src/auth/api_key.rs
+++ b/aa-api/src/auth/api_key.rs
@@ -26,9 +26,7 @@ impl ApiKey {
     ///
     /// Returns an error if the key doesn't match `aa_<32-hex-chars>`.
     pub fn parse(raw: &str) -> Result<Self, ApiKeyError> {
-        let hex_part = raw
-            .strip_prefix(API_KEY_PREFIX)
-            .ok_or(ApiKeyError::InvalidPrefix)?;
+        let hex_part = raw.strip_prefix(API_KEY_PREFIX).ok_or(ApiKeyError::InvalidPrefix)?;
 
         if hex_part.len() != API_KEY_HEX_LEN {
             return Err(ApiKeyError::InvalidLength {
@@ -75,9 +73,7 @@ impl ApiKey {
         let Ok(parsed) = PasswordHash::new(hash) else {
             return false;
         };
-        Argon2::default()
-            .verify_password(self.0.as_bytes(), &parsed)
-            .is_ok()
+        Argon2::default().verify_password(self.0.as_bytes(), &parsed).is_ok()
     }
 }
 
@@ -108,9 +104,7 @@ impl ApiKeyStore {
     /// Returns an empty store if the file does not exist.
     pub fn load(path: &Path) -> Result<Self, ApiKeyError> {
         if !path.exists() {
-            return Ok(Self {
-                entries: Vec::new(),
-            });
+            return Ok(Self { entries: Vec::new() });
         }
 
         let content = std::fs::read_to_string(path).map_err(|e| ApiKeyError::Io(e.to_string()))?;
@@ -196,7 +190,10 @@ mod tests {
         let result = ApiKey::parse("aa_0011");
         assert!(matches!(
             result,
-            Err(ApiKeyError::InvalidLength { expected: 32, actual: 4 })
+            Err(ApiKeyError::InvalidLength {
+                expected: 32,
+                actual: 4
+            })
         ));
     }
 
@@ -239,9 +236,7 @@ mod tests {
             created_at: 1700000000,
             label: Some("test key".to_string()),
         };
-        let store = ApiKeyStore {
-            entries: vec![entry],
-        };
+        let store = ApiKeyStore { entries: vec![entry] };
 
         let result = store.validate(key.as_str());
         assert!(result.is_some());
@@ -260,9 +255,7 @@ mod tests {
             created_at: 1700000000,
             label: None,
         };
-        let store = ApiKeyStore {
-            entries: vec![entry],
-        };
+        let store = ApiKeyStore { entries: vec![entry] };
 
         let result = store.validate(key2.as_str());
         assert!(result.is_none());

--- a/aa-api/src/auth/api_key.rs
+++ b/aa-api/src/auth/api_key.rs
@@ -1,0 +1,270 @@
+//! API key generation, validation, and storage.
+
+use std::path::Path;
+
+use argon2::password_hash::rand_core::OsRng;
+use argon2::password_hash::SaltString;
+use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier};
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::scope::Scope;
+
+/// Prefix for all Agent Assembly API keys.
+const API_KEY_PREFIX: &str = "aa_";
+
+/// Expected length of the hex portion of an API key.
+const API_KEY_HEX_LEN: usize = 32;
+
+/// An Agent Assembly API key in `aa_<32-hex-chars>` format.
+#[derive(Debug, Clone)]
+pub struct ApiKey(String);
+
+impl ApiKey {
+    /// Parse and validate a raw API key string.
+    ///
+    /// Returns an error if the key doesn't match `aa_<32-hex-chars>`.
+    pub fn parse(raw: &str) -> Result<Self, ApiKeyError> {
+        let hex_part = raw
+            .strip_prefix(API_KEY_PREFIX)
+            .ok_or(ApiKeyError::InvalidPrefix)?;
+
+        if hex_part.len() != API_KEY_HEX_LEN {
+            return Err(ApiKeyError::InvalidLength {
+                expected: API_KEY_HEX_LEN,
+                actual: hex_part.len(),
+            });
+        }
+
+        if !hex_part.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(ApiKeyError::InvalidHex);
+        }
+
+        Ok(Self(raw.to_string()))
+    }
+
+    /// Generate a new cryptographically random API key.
+    ///
+    /// Returns the `ApiKey` and the plaintext string (for display to the user).
+    pub fn generate() -> Self {
+        let mut rng = rand::thread_rng();
+        let mut hex_bytes = [0u8; API_KEY_HEX_LEN / 2];
+        rng.fill(&mut hex_bytes);
+        let hex = hex::encode(&hex_bytes);
+        Self(format!("{API_KEY_PREFIX}{hex}"))
+    }
+
+    /// Return the raw key string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Hash this key using argon2 for secure storage.
+    pub fn hash(&self) -> Result<String, ApiKeyError> {
+        let salt = SaltString::generate(&mut OsRng);
+        let argon2 = Argon2::default();
+        let hash = argon2
+            .hash_password(self.0.as_bytes(), &salt)
+            .map_err(|e| ApiKeyError::HashError(e.to_string()))?;
+        Ok(hash.to_string())
+    }
+
+    /// Verify this key against a stored argon2 hash.
+    pub fn verify(&self, hash: &str) -> bool {
+        let Ok(parsed) = PasswordHash::new(hash) else {
+            return false;
+        };
+        Argon2::default()
+            .verify_password(self.0.as_bytes(), &parsed)
+            .is_ok()
+    }
+}
+
+/// A stored API key entry with metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiKeyEntry {
+    /// Unique identifier for this key.
+    pub id: String,
+    /// Argon2 hash of the key (never store plaintext).
+    pub key_hash: String,
+    /// Scopes granted to this key.
+    pub scopes: Vec<Scope>,
+    /// Unix timestamp when the key was created.
+    pub created_at: u64,
+    /// Optional human-readable label.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
+/// In-memory store of API key entries loaded from a JSON file.
+pub struct ApiKeyStore {
+    entries: Vec<ApiKeyEntry>,
+}
+
+impl ApiKeyStore {
+    /// Load API key entries from a JSON file.
+    ///
+    /// Returns an empty store if the file does not exist.
+    pub fn load(path: &Path) -> Result<Self, ApiKeyError> {
+        if !path.exists() {
+            return Ok(Self {
+                entries: Vec::new(),
+            });
+        }
+
+        let content = std::fs::read_to_string(path).map_err(|e| ApiKeyError::Io(e.to_string()))?;
+        let entries: Vec<ApiKeyEntry> =
+            serde_json::from_str(&content).map_err(|e| ApiKeyError::ParseError(e.to_string()))?;
+        Ok(Self { entries })
+    }
+
+    /// Validate a raw API key string against stored entries.
+    ///
+    /// Returns the matching entry if the key is valid, or `None` if no match.
+    pub fn validate(&self, raw_key: &str) -> Option<&ApiKeyEntry> {
+        let key = ApiKey::parse(raw_key).ok()?;
+        self.entries.iter().find(|entry| key.verify(&entry.key_hash))
+    }
+
+    /// Return the number of stored entries.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Check if the store is empty.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+/// Errors related to API key operations.
+#[derive(Debug, Error)]
+pub enum ApiKeyError {
+    #[error("API key must start with '{API_KEY_PREFIX}'")]
+    InvalidPrefix,
+    #[error("API key hex portion must be {expected} characters (got {actual})")]
+    InvalidLength { expected: usize, actual: usize },
+    #[error("API key hex portion contains non-hex characters")]
+    InvalidHex,
+    #[error("failed to hash API key: {0}")]
+    HashError(String),
+    #[error("I/O error reading API keys file: {0}")]
+    Io(String),
+    #[error("failed to parse API keys file: {0}")]
+    ParseError(String),
+}
+
+/// Hex encoding helper (avoids adding `hex` crate dependency).
+mod hex {
+    pub fn encode(bytes: &[u8]) -> String {
+        bytes.iter().map(|b| format!("{b:02x}")).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_api_key_generate_format() {
+        let key = ApiKey::generate();
+        let raw = key.as_str();
+        assert!(raw.starts_with("aa_"), "key should start with aa_");
+        assert_eq!(raw.len(), 3 + API_KEY_HEX_LEN, "key should be aa_ + 32 hex chars");
+        assert!(
+            raw[3..].chars().all(|c| c.is_ascii_hexdigit()),
+            "hex portion should be valid hex"
+        );
+    }
+
+    #[test]
+    fn test_api_key_parse_valid() {
+        let key = ApiKey::generate();
+        let parsed = ApiKey::parse(key.as_str());
+        assert!(parsed.is_ok());
+    }
+
+    #[test]
+    fn test_api_key_parse_invalid_prefix() {
+        let result = ApiKey::parse("bb_00112233445566778899aabbccddeeff");
+        assert!(matches!(result, Err(ApiKeyError::InvalidPrefix)));
+    }
+
+    #[test]
+    fn test_api_key_parse_invalid_length() {
+        let result = ApiKey::parse("aa_0011");
+        assert!(matches!(
+            result,
+            Err(ApiKeyError::InvalidLength { expected: 32, actual: 4 })
+        ));
+    }
+
+    #[test]
+    fn test_api_key_parse_invalid_hex() {
+        let result = ApiKey::parse("aa_gggggggggggggggggggggggggggggggg");
+        assert!(matches!(result, Err(ApiKeyError::InvalidHex)));
+    }
+
+    #[test]
+    fn test_api_key_hash_verify_roundtrip() {
+        let key = ApiKey::generate();
+        let hash = key.hash().expect("hashing should succeed");
+        assert!(key.verify(&hash), "key should verify against its own hash");
+    }
+
+    #[test]
+    fn test_api_key_verify_wrong_key() {
+        let key1 = ApiKey::generate();
+        let key2 = ApiKey::generate();
+        let hash = key1.hash().expect("hashing should succeed");
+        assert!(!key2.verify(&hash), "different key should not verify");
+    }
+
+    #[test]
+    fn test_api_key_store_load_missing_file() {
+        let store = ApiKeyStore::load(Path::new("/nonexistent/path/keys.json"));
+        assert!(store.is_ok());
+        assert!(store.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_api_key_store_validate_roundtrip() {
+        let key = ApiKey::generate();
+        let hash = key.hash().expect("hashing should succeed");
+        let entry = ApiKeyEntry {
+            id: "test-key-1".to_string(),
+            key_hash: hash,
+            scopes: vec![Scope::Read, Scope::Write],
+            created_at: 1700000000,
+            label: Some("test key".to_string()),
+        };
+        let store = ApiKeyStore {
+            entries: vec![entry],
+        };
+
+        let result = store.validate(key.as_str());
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().id, "test-key-1");
+    }
+
+    #[test]
+    fn test_api_key_store_validate_wrong_key() {
+        let key1 = ApiKey::generate();
+        let key2 = ApiKey::generate();
+        let hash = key1.hash().expect("hashing should succeed");
+        let entry = ApiKeyEntry {
+            id: "test-key-1".to_string(),
+            key_hash: hash,
+            scopes: vec![Scope::Read],
+            created_at: 1700000000,
+            label: None,
+        };
+        let store = ApiKeyStore {
+            entries: vec![entry],
+        };
+
+        let result = store.validate(key2.as_str());
+        assert!(result.is_none());
+    }
+}

--- a/aa-api/src/auth/config.rs
+++ b/aa-api/src/auth/config.rs
@@ -1,0 +1,116 @@
+//! Authentication configuration from environment variables.
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+/// Default path for API keys storage.
+const DEFAULT_API_KEYS_PATH: &str = "~/.aa/api-keys.json";
+
+/// Default rate limit: requests per minute per API key.
+const DEFAULT_RATE_LIMIT_RPM: u32 = 1000;
+
+/// Minimum length for the JWT secret (256 bits).
+const MIN_JWT_SECRET_LEN: usize = 32;
+
+/// Authentication mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthMode {
+    /// Authentication is enabled (default).
+    On,
+    /// Authentication is disabled — all requests are treated as admin.
+    Off,
+}
+
+/// Authentication configuration for the API server.
+#[derive(Debug, Clone)]
+pub struct AuthConfig {
+    /// Whether auth is enabled or bypassed.
+    pub mode: AuthMode,
+    /// HMAC-SHA256 secret for JWT signing. `None` when `mode == Off`.
+    pub jwt_secret: Option<Vec<u8>>,
+    /// Path to the API keys JSON file.
+    pub api_keys_path: PathBuf,
+    /// Maximum requests per minute per API key.
+    pub rate_limit_rpm: u32,
+}
+
+/// Errors that can occur when loading auth configuration.
+#[derive(Debug, Error)]
+pub enum AuthConfigError {
+    #[error("AA_JWT_SECRET must be set when authentication is enabled")]
+    MissingJwtSecret,
+    #[error(
+        "AA_JWT_SECRET must be at least {MIN_JWT_SECRET_LEN} bytes (got {actual} bytes)"
+    )]
+    JwtSecretTooShort { actual: usize },
+    #[error("AA_RATE_LIMIT_RPM must be a positive integer: {0}")]
+    InvalidRateLimit(String),
+}
+
+impl AuthConfig {
+    /// Build auth configuration from environment variables.
+    ///
+    /// # Environment variables
+    ///
+    /// - `AA_AUTH`: `"on"` (default) or `"off"` (bypass mode)
+    /// - `AA_JWT_SECRET`: HMAC key for JWT, required when auth is enabled
+    /// - `AA_API_KEYS_PATH`: path to API keys file (default `~/.aa/api-keys.json`)
+    /// - `AA_RATE_LIMIT_RPM`: requests per minute per key (default 1000)
+    pub fn from_env() -> Result<Self, AuthConfigError> {
+        let mode = match std::env::var("AA_AUTH").as_deref() {
+            Ok("off") | Ok("OFF") => {
+                tracing::warn!("AA_AUTH=off: authentication is disabled — all requests treated as admin");
+                AuthMode::Off
+            }
+            _ => AuthMode::On,
+        };
+
+        let jwt_secret = if mode == AuthMode::On {
+            let secret = std::env::var("AA_JWT_SECRET")
+                .map_err(|_| AuthConfigError::MissingJwtSecret)?;
+            let bytes = secret.into_bytes();
+            if bytes.len() < MIN_JWT_SECRET_LEN {
+                return Err(AuthConfigError::JwtSecretTooShort {
+                    actual: bytes.len(),
+                });
+            }
+            Some(bytes)
+        } else {
+            None
+        };
+
+        let api_keys_path = std::env::var("AA_API_KEYS_PATH")
+            .unwrap_or_else(|_| DEFAULT_API_KEYS_PATH.to_string());
+        let api_keys_path = expand_tilde(&api_keys_path);
+
+        let rate_limit_rpm = match std::env::var("AA_RATE_LIMIT_RPM") {
+            Ok(val) => val
+                .parse::<u32>()
+                .map_err(|_| AuthConfigError::InvalidRateLimit(val))?,
+            Err(_) => DEFAULT_RATE_LIMIT_RPM,
+        };
+
+        Ok(Self {
+            mode,
+            jwt_secret,
+            api_keys_path,
+            rate_limit_rpm,
+        })
+    }
+}
+
+/// Expand `~` prefix to the user's home directory.
+fn expand_tilde(path: &str) -> PathBuf {
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = dirs_home() {
+            return home.join(rest);
+        }
+    }
+    PathBuf::from(path)
+}
+
+/// Get the user's home directory.
+fn dirs_home() -> Option<PathBuf> {
+    std::env::var("HOME").ok().map(PathBuf::from)
+}

--- a/aa-api/src/auth/config.rs
+++ b/aa-api/src/auth/config.rs
@@ -40,9 +40,7 @@ pub struct AuthConfig {
 pub enum AuthConfigError {
     #[error("AA_JWT_SECRET must be set when authentication is enabled")]
     MissingJwtSecret,
-    #[error(
-        "AA_JWT_SECRET must be at least {MIN_JWT_SECRET_LEN} bytes (got {actual} bytes)"
-    )]
+    #[error("AA_JWT_SECRET must be at least {MIN_JWT_SECRET_LEN} bytes (got {actual} bytes)")]
     JwtSecretTooShort { actual: usize },
     #[error("AA_RATE_LIMIT_RPM must be a positive integer: {0}")]
     InvalidRateLimit(String),
@@ -67,27 +65,21 @@ impl AuthConfig {
         };
 
         let jwt_secret = if mode == AuthMode::On {
-            let secret = std::env::var("AA_JWT_SECRET")
-                .map_err(|_| AuthConfigError::MissingJwtSecret)?;
+            let secret = std::env::var("AA_JWT_SECRET").map_err(|_| AuthConfigError::MissingJwtSecret)?;
             let bytes = secret.into_bytes();
             if bytes.len() < MIN_JWT_SECRET_LEN {
-                return Err(AuthConfigError::JwtSecretTooShort {
-                    actual: bytes.len(),
-                });
+                return Err(AuthConfigError::JwtSecretTooShort { actual: bytes.len() });
             }
             Some(bytes)
         } else {
             None
         };
 
-        let api_keys_path = std::env::var("AA_API_KEYS_PATH")
-            .unwrap_or_else(|_| DEFAULT_API_KEYS_PATH.to_string());
+        let api_keys_path = std::env::var("AA_API_KEYS_PATH").unwrap_or_else(|_| DEFAULT_API_KEYS_PATH.to_string());
         let api_keys_path = expand_tilde(&api_keys_path);
 
         let rate_limit_rpm = match std::env::var("AA_RATE_LIMIT_RPM") {
-            Ok(val) => val
-                .parse::<u32>()
-                .map_err(|_| AuthConfigError::InvalidRateLimit(val))?,
+            Ok(val) => val.parse::<u32>().map_err(|_| AuthConfigError::InvalidRateLimit(val))?,
             Err(_) => DEFAULT_RATE_LIMIT_RPM,
         };
 
@@ -161,10 +153,7 @@ mod tests {
 
         let result = AuthConfig::from_env();
         assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            AuthConfigError::JwtSecretTooShort { .. }
-        ));
+        assert!(matches!(result.unwrap_err(), AuthConfigError::JwtSecretTooShort { .. }));
     }
 
     #[test]

--- a/aa-api/src/auth/config.rs
+++ b/aa-api/src/auth/config.rs
@@ -114,3 +114,88 @@ fn expand_tilde(path: &str) -> PathBuf {
 fn dirs_home() -> Option<PathBuf> {
     std::env::var("HOME").ok().map(PathBuf::from)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Guard to serialize env-var-dependent tests.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Helper: clear all auth-related env vars before a test.
+    fn clear_auth_env() {
+        std::env::remove_var("AA_AUTH");
+        std::env::remove_var("AA_JWT_SECRET");
+        std::env::remove_var("AA_API_KEYS_PATH");
+        std::env::remove_var("AA_RATE_LIMIT_RPM");
+    }
+
+    #[test]
+    fn test_config_auth_off_no_secret_required() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_auth_env();
+        std::env::set_var("AA_AUTH", "off");
+
+        let config = AuthConfig::from_env().expect("auth=off should succeed without secret");
+        assert_eq!(config.mode, AuthMode::Off);
+        assert!(config.jwt_secret.is_none());
+    }
+
+    #[test]
+    fn test_config_auth_on_missing_secret_fails() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_auth_env();
+        // AA_AUTH defaults to On when unset.
+
+        let result = AuthConfig::from_env();
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), AuthConfigError::MissingJwtSecret));
+    }
+
+    #[test]
+    fn test_config_auth_on_short_secret_fails() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_auth_env();
+        std::env::set_var("AA_JWT_SECRET", "too-short");
+
+        let result = AuthConfig::from_env();
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            AuthConfigError::JwtSecretTooShort { .. }
+        ));
+    }
+
+    #[test]
+    fn test_config_auth_on_valid_secret_succeeds() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_auth_env();
+        std::env::set_var("AA_JWT_SECRET", "a]secret-that-is-at-least-32-bytes-long!!");
+
+        let config = AuthConfig::from_env().expect("valid secret should succeed");
+        assert_eq!(config.mode, AuthMode::On);
+        assert!(config.jwt_secret.is_some());
+    }
+
+    #[test]
+    fn test_config_default_rate_limit() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_auth_env();
+        std::env::set_var("AA_AUTH", "off");
+
+        let config = AuthConfig::from_env().unwrap();
+        assert_eq!(config.rate_limit_rpm, 1000);
+    }
+
+    #[test]
+    fn test_config_custom_rate_limit() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_auth_env();
+        std::env::set_var("AA_AUTH", "off");
+        std::env::set_var("AA_RATE_LIMIT_RPM", "500");
+
+        let config = AuthConfig::from_env().unwrap();
+        assert_eq!(config.rate_limit_rpm, 500);
+    }
+}

--- a/aa-api/src/auth/jwt.rs
+++ b/aa-api/src/auth/jwt.rs
@@ -51,12 +51,7 @@ impl JwtSigner {
 
     /// Sign a JWT with a custom expiry (for testing).
     #[cfg(test)]
-    fn sign_with_expiry(
-        &self,
-        key_id: &str,
-        scopes: &[Scope],
-        exp: u64,
-    ) -> Result<String, JwtError> {
+    fn sign_with_expiry(&self, key_id: &str, scopes: &[Scope], exp: u64) -> Result<String, JwtError> {
         let claims = Claims {
             sub: key_id.to_string(),
             iat: now_epoch_secs(),
@@ -88,8 +83,7 @@ impl JwtVerifier {
     ///
     /// Returns an error if the signature is invalid or the token has expired.
     pub fn verify(&self, token: &str) -> Result<Claims, JwtError> {
-        let data = decode::<Claims>(token, &self.decoding_key, &self.validation)
-            .map_err(JwtError::Decode)?;
+        let data = decode::<Claims>(token, &self.decoding_key, &self.validation).map_err(JwtError::Decode)?;
         Ok(data.claims)
     }
 }
@@ -152,9 +146,7 @@ mod tests {
         let signer = JwtSigner::new(TEST_SECRET);
         let verifier = JwtVerifier::new(b"different-secret-that-is-also-32-bytes-long!!");
 
-        let token = signer
-            .sign("key-123", &[Scope::Read])
-            .expect("signing should succeed");
+        let token = signer.sign("key-123", &[Scope::Read]).expect("signing should succeed");
 
         let result = verifier.verify(&token);
         assert!(result.is_err(), "token signed with different secret should be rejected");
@@ -166,9 +158,7 @@ mod tests {
         let verifier = JwtVerifier::new(TEST_SECRET);
 
         let scopes = vec![Scope::Read, Scope::Write, Scope::Admin];
-        let token = signer
-            .sign("key-456", &scopes)
-            .expect("signing should succeed");
+        let token = signer.sign("key-456", &scopes).expect("signing should succeed");
         let claims = verifier.verify(&token).expect("verification should succeed");
 
         assert_eq!(claims.scope, scopes);

--- a/aa-api/src/auth/jwt.rs
+++ b/aa-api/src/auth/jwt.rs
@@ -1,0 +1,176 @@
+//! JWT signing and verification using HMAC-SHA256.
+
+use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, Validation};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::scope::Scope;
+
+/// JWT token expiry duration: 24 hours in seconds.
+const TOKEN_EXPIRY_SECS: u64 = 24 * 60 * 60;
+
+/// JWT claims payload.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Claims {
+    /// Subject: the API key ID that this token was issued for.
+    pub sub: String,
+    /// Issued-at timestamp (Unix epoch seconds).
+    pub iat: u64,
+    /// Expiry timestamp (Unix epoch seconds).
+    pub exp: u64,
+    /// Scopes granted to this token.
+    pub scope: Vec<Scope>,
+}
+
+/// Signs JWTs using HMAC-SHA256.
+pub struct JwtSigner {
+    encoding_key: EncodingKey,
+}
+
+impl JwtSigner {
+    /// Create a new signer from a raw HMAC secret.
+    pub fn new(secret: &[u8]) -> Self {
+        Self {
+            encoding_key: EncodingKey::from_secret(secret),
+        }
+    }
+
+    /// Sign a new JWT for the given API key ID and scopes.
+    ///
+    /// The token expires after 24 hours.
+    pub fn sign(&self, key_id: &str, scopes: &[Scope]) -> Result<String, JwtError> {
+        let now = now_epoch_secs();
+        let claims = Claims {
+            sub: key_id.to_string(),
+            iat: now,
+            exp: now + TOKEN_EXPIRY_SECS,
+            scope: scopes.to_vec(),
+        };
+        encode(&Header::default(), &claims, &self.encoding_key).map_err(JwtError::Encode)
+    }
+
+    /// Sign a JWT with a custom expiry (for testing).
+    #[cfg(test)]
+    fn sign_with_expiry(
+        &self,
+        key_id: &str,
+        scopes: &[Scope],
+        exp: u64,
+    ) -> Result<String, JwtError> {
+        let claims = Claims {
+            sub: key_id.to_string(),
+            iat: now_epoch_secs(),
+            exp,
+            scope: scopes.to_vec(),
+        };
+        encode(&Header::default(), &claims, &self.encoding_key).map_err(JwtError::Encode)
+    }
+}
+
+/// Verifies JWT tokens using HMAC-SHA256.
+pub struct JwtVerifier {
+    decoding_key: DecodingKey,
+    validation: Validation,
+}
+
+impl JwtVerifier {
+    /// Create a new verifier from a raw HMAC secret.
+    pub fn new(secret: &[u8]) -> Self {
+        let mut validation = Validation::default();
+        validation.set_required_spec_claims(&["sub", "iat", "exp"]);
+        Self {
+            decoding_key: DecodingKey::from_secret(secret),
+            validation,
+        }
+    }
+
+    /// Verify a JWT token and return its claims.
+    ///
+    /// Returns an error if the signature is invalid or the token has expired.
+    pub fn verify(&self, token: &str) -> Result<Claims, JwtError> {
+        let data = decode::<Claims>(token, &self.decoding_key, &self.validation)
+            .map_err(JwtError::Decode)?;
+        Ok(data.claims)
+    }
+}
+
+/// Return the current Unix epoch timestamp in seconds.
+fn now_epoch_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before Unix epoch")
+        .as_secs()
+}
+
+/// Errors related to JWT operations.
+#[derive(Debug, Error)]
+pub enum JwtError {
+    #[error("failed to encode JWT: {0}")]
+    Encode(jsonwebtoken::errors::Error),
+    #[error("failed to decode JWT: {0}")]
+    Decode(jsonwebtoken::errors::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_SECRET: &[u8] = b"test-secret-key-that-is-at-least-32-bytes-long!!";
+
+    #[test]
+    fn test_jwt_sign_verify_roundtrip() {
+        let signer = JwtSigner::new(TEST_SECRET);
+        let verifier = JwtVerifier::new(TEST_SECRET);
+
+        let token = signer
+            .sign("key-123", &[Scope::Read, Scope::Write])
+            .expect("signing should succeed");
+        let claims = verifier.verify(&token).expect("verification should succeed");
+
+        assert_eq!(claims.sub, "key-123");
+        assert_eq!(claims.scope, vec![Scope::Read, Scope::Write]);
+        assert!(claims.exp > claims.iat);
+    }
+
+    #[test]
+    fn test_jwt_expired_token_rejected() {
+        let signer = JwtSigner::new(TEST_SECRET);
+        let verifier = JwtVerifier::new(TEST_SECRET);
+
+        // Create a token that expired 1 hour ago.
+        let expired = now_epoch_secs() - 3600;
+        let token = signer
+            .sign_with_expiry("key-123", &[Scope::Read], expired)
+            .expect("signing should succeed");
+
+        let result = verifier.verify(&token);
+        assert!(result.is_err(), "expired token should be rejected");
+    }
+
+    #[test]
+    fn test_jwt_wrong_secret_rejected() {
+        let signer = JwtSigner::new(TEST_SECRET);
+        let verifier = JwtVerifier::new(b"different-secret-that-is-also-32-bytes-long!!");
+
+        let token = signer
+            .sign("key-123", &[Scope::Read])
+            .expect("signing should succeed");
+
+        let result = verifier.verify(&token);
+        assert!(result.is_err(), "token signed with different secret should be rejected");
+    }
+
+    #[test]
+    fn test_jwt_scopes_preserved() {
+        let signer = JwtSigner::new(TEST_SECRET);
+        let verifier = JwtVerifier::new(TEST_SECRET);
+
+        let scopes = vec![Scope::Read, Scope::Write, Scope::Admin];
+        let token = signer
+            .sign("key-456", &scopes)
+            .expect("signing should succeed");
+        let claims = verifier.verify(&token).expect("verification should succeed");
+
+        assert_eq!(claims.scope, scopes);
+    }
+}

--- a/aa-api/src/auth/mod.rs
+++ b/aa-api/src/auth/mod.rs
@@ -18,12 +18,12 @@ use axum::http::request::Parts;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 
-use crate::error::ProblemDetail;
 use self::api_key::ApiKeyStore;
 use self::config::{AuthConfig, AuthMode};
 use self::jwt::JwtVerifier;
 use self::rate_limit::RateLimiter;
 use self::scope::Scope;
+use crate::error::ProblemDetail;
 
 /// Authentication / authorization errors returned by extractors.
 #[derive(Debug)]
@@ -53,11 +53,9 @@ impl IntoResponse for AuthError {
                 .with_detail("Missing Authorization header")
                 .into_response(),
 
-            AuthError::InvalidToken(reason) => {
-                ProblemDetail::from_status(StatusCode::UNAUTHORIZED)
-                    .with_detail(format!("Invalid token: {reason}"))
-                    .into_response()
-            }
+            AuthError::InvalidToken(reason) => ProblemDetail::from_status(StatusCode::UNAUTHORIZED)
+                .with_detail(format!("Invalid token: {reason}"))
+                .into_response(),
 
             AuthError::ExpiredToken => ProblemDetail::from_status(StatusCode::UNAUTHORIZED)
                 .with_detail("Token has expired")
@@ -65,9 +63,7 @@ impl IntoResponse for AuthError {
 
             AuthError::RateLimited { retry_after_secs } => {
                 let problem = ProblemDetail::from_status(StatusCode::TOO_MANY_REQUESTS)
-                    .with_detail(format!(
-                        "Rate limit exceeded. Retry after {retry_after_secs} seconds"
-                    ));
+                    .with_detail(format!("Rate limit exceeded. Retry after {retry_after_secs} seconds"));
                 let mut response = problem.into_response();
                 response.headers_mut().insert(
                     "retry-after",
@@ -79,11 +75,9 @@ impl IntoResponse for AuthError {
                 response
             }
 
-            AuthError::InsufficientScope { required } => {
-                ProblemDetail::from_status(StatusCode::FORBIDDEN)
-                    .with_detail(format!("Insufficient scope: requires '{required}'"))
-                    .into_response()
-            }
+            AuthError::InsufficientScope { required } => ProblemDetail::from_status(StatusCode::FORBIDDEN)
+                .with_detail(format!("Insufficient scope: requires '{required}'"))
+                .into_response(),
         }
     }
 }

--- a/aa-api/src/auth/mod.rs
+++ b/aa-api/src/auth/mod.rs
@@ -10,10 +10,19 @@ pub mod jwt;
 pub mod rate_limit;
 pub mod scope;
 
+use std::sync::Arc;
+
+use axum::async_trait;
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 
 use crate::error::ProblemDetail;
+use self::api_key::ApiKeyStore;
+use self::config::{AuthConfig, AuthMode};
+use self::jwt::JwtVerifier;
+use self::rate_limit::RateLimiter;
 use self::scope::Scope;
 
 /// Authentication / authorization errors returned by extractors.
@@ -89,4 +98,92 @@ pub struct AuthenticatedCaller {
     pub key_id: String,
     /// Scopes granted to this caller.
     pub scopes: Vec<Scope>,
+}
+
+/// Prefix used by API keys (`aa_`).
+const API_KEY_PREFIX: &str = "aa_";
+
+#[async_trait]
+impl<S> FromRequestParts<S> for AuthenticatedCaller
+where
+    S: Send + Sync,
+{
+    type Rejection = AuthError;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        // 1. Read auth config from extensions.
+        let auth_config = parts
+            .extensions
+            .get::<Arc<AuthConfig>>()
+            .expect("AuthConfig extension missing — did you forget to add it in build_app?");
+
+        // Bypass mode: return synthetic admin caller.
+        if auth_config.mode == AuthMode::Off {
+            return Ok(AuthenticatedCaller {
+                key_id: "__bypass__".to_string(),
+                scopes: vec![Scope::Read, Scope::Write, Scope::Admin],
+            });
+        }
+
+        // 2. Parse `Authorization: Bearer <token>` header.
+        let header_value = parts
+            .headers
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .ok_or(AuthError::MissingHeader)?;
+
+        let token = header_value
+            .strip_prefix("Bearer ")
+            .ok_or_else(|| AuthError::InvalidToken("expected 'Bearer <token>' format".into()))?;
+
+        // 3. Determine credential type and validate.
+        let caller = if token.starts_with(API_KEY_PREFIX) {
+            // API key path.
+            let key_store = parts
+                .extensions
+                .get::<Arc<ApiKeyStore>>()
+                .expect("ApiKeyStore extension missing");
+
+            let entry = key_store
+                .validate(token)
+                .ok_or_else(|| AuthError::InvalidToken("invalid API key".into()))?;
+
+            AuthenticatedCaller {
+                key_id: entry.id.clone(),
+                scopes: entry.scopes.clone(),
+            }
+        } else {
+            // JWT path.
+            let jwt_verifier = parts
+                .extensions
+                .get::<Arc<JwtVerifier>>()
+                .expect("JwtVerifier extension missing");
+
+            let claims = jwt_verifier.verify(token).map_err(|e| {
+                let msg = e.to_string();
+                if msg.contains("ExpiredSignature") {
+                    AuthError::ExpiredToken
+                } else {
+                    AuthError::InvalidToken(msg)
+                }
+            })?;
+
+            AuthenticatedCaller {
+                key_id: claims.sub,
+                scopes: claims.scope,
+            }
+        };
+
+        // 4. Check rate limit.
+        let rate_limiter = parts
+            .extensions
+            .get::<Arc<RateLimiter>>()
+            .expect("RateLimiter extension missing");
+
+        rate_limiter
+            .check(&caller.key_id)
+            .map_err(|retry_after_secs| AuthError::RateLimited { retry_after_secs })?;
+
+        Ok(caller)
+    }
 }

--- a/aa-api/src/auth/mod.rs
+++ b/aa-api/src/auth/mod.rs
@@ -1,7 +1,80 @@
 //! Authentication and authorization for the API server.
+//!
+//! Auth is handled via Axum `FromRequestParts` extractors, not middleware
+//! layers. The [`AuthenticatedCaller`] extractor validates API keys or JWTs
+//! and enforces per-key rate limits. [`RequireScope`] checks scope levels.
 
 pub mod api_key;
 pub mod config;
 pub mod jwt;
 pub mod rate_limit;
 pub mod scope;
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+
+use crate::error::ProblemDetail;
+use self::scope::Scope;
+
+/// Authentication / authorization errors returned by extractors.
+#[derive(Debug)]
+pub enum AuthError {
+    /// No `Authorization` header was present.
+    MissingHeader,
+    /// The token could not be validated (bad format, wrong signature, etc.).
+    InvalidToken(String),
+    /// The token signature was valid but the token has expired.
+    ExpiredToken,
+    /// The caller has exceeded the per-key rate limit.
+    RateLimited {
+        /// Seconds until the next request may be accepted.
+        retry_after_secs: u64,
+    },
+    /// The caller's scopes do not satisfy the required scope.
+    InsufficientScope {
+        /// The scope level that was required.
+        required: Scope,
+    },
+}
+
+impl IntoResponse for AuthError {
+    fn into_response(self) -> Response {
+        match self {
+            AuthError::MissingHeader => ProblemDetail::from_status(StatusCode::UNAUTHORIZED)
+                .with_detail("Missing Authorization header")
+                .into_response(),
+
+            AuthError::InvalidToken(reason) => {
+                ProblemDetail::from_status(StatusCode::UNAUTHORIZED)
+                    .with_detail(format!("Invalid token: {reason}"))
+                    .into_response()
+            }
+
+            AuthError::ExpiredToken => ProblemDetail::from_status(StatusCode::UNAUTHORIZED)
+                .with_detail("Token has expired")
+                .into_response(),
+
+            AuthError::RateLimited { retry_after_secs } => {
+                let problem = ProblemDetail::from_status(StatusCode::TOO_MANY_REQUESTS)
+                    .with_detail(format!(
+                        "Rate limit exceeded. Retry after {retry_after_secs} seconds"
+                    ));
+                let mut response = problem.into_response();
+                response.headers_mut().insert(
+                    "retry-after",
+                    retry_after_secs
+                        .to_string()
+                        .parse()
+                        .expect("integer is valid header value"),
+                );
+                response
+            }
+
+            AuthError::InsufficientScope { required } => {
+                ProblemDetail::from_status(StatusCode::FORBIDDEN)
+                    .with_detail(format!("Insufficient scope: requires '{required}'"))
+                    .into_response()
+            }
+        }
+    }
+}

--- a/aa-api/src/auth/mod.rs
+++ b/aa-api/src/auth/mod.rs
@@ -3,4 +3,5 @@
 pub mod api_key;
 pub mod config;
 pub mod jwt;
+pub mod rate_limit;
 pub mod scope;

--- a/aa-api/src/auth/mod.rs
+++ b/aa-api/src/auth/mod.rs
@@ -78,3 +78,15 @@ impl IntoResponse for AuthError {
         }
     }
 }
+
+/// The authenticated identity of a request caller.
+///
+/// Populated by the `FromRequestParts` implementation, which validates
+/// either an API key (`aa_…`) or a JWT bearer token.
+#[derive(Debug, Clone)]
+pub struct AuthenticatedCaller {
+    /// The API key ID or JWT subject that identifies this caller.
+    pub key_id: String,
+    /// Scopes granted to this caller.
+    pub scopes: Vec<Scope>,
+}

--- a/aa-api/src/auth/mod.rs
+++ b/aa-api/src/auth/mod.rs
@@ -1,0 +1,5 @@
+//! Authentication and authorization for the API server.
+
+pub mod api_key;
+pub mod config;
+pub mod scope;

--- a/aa-api/src/auth/mod.rs
+++ b/aa-api/src/auth/mod.rs
@@ -2,4 +2,5 @@
 
 pub mod api_key;
 pub mod config;
+pub mod jwt;
 pub mod scope;

--- a/aa-api/src/auth/rate_limit.rs
+++ b/aa-api/src/auth/rate_limit.rs
@@ -112,7 +112,7 @@ mod tests {
     #[test]
     fn test_token_bucket_refills_over_time() {
         let mut bucket = TokenBucket::new(60); // 1 token per second
-        // Exhaust all tokens.
+                                               // Exhaust all tokens.
         for _ in 0..60 {
             bucket.try_consume().unwrap();
         }

--- a/aa-api/src/auth/rate_limit.rs
+++ b/aa-api/src/auth/rate_limit.rs
@@ -1,0 +1,139 @@
+//! In-memory per-key rate limiter using token bucket algorithm.
+
+use std::time::Instant;
+
+use dashmap::DashMap;
+
+/// A token bucket that refills at a fixed rate.
+#[derive(Debug)]
+struct TokenBucket {
+    /// Current number of available tokens.
+    tokens: f64,
+    /// Maximum number of tokens (bucket capacity).
+    capacity: f64,
+    /// Tokens added per second.
+    refill_rate: f64,
+    /// Last time the bucket was refilled.
+    last_refill: Instant,
+}
+
+impl TokenBucket {
+    /// Create a new full bucket with the given capacity (requests per minute).
+    fn new(rpm: u32) -> Self {
+        let capacity = f64::from(rpm);
+        Self {
+            tokens: capacity,
+            capacity,
+            refill_rate: capacity / 60.0, // tokens per second
+            last_refill: Instant::now(),
+        }
+    }
+
+    /// Try to consume one token. Returns `Ok(())` if allowed, or
+    /// `Err(seconds)` with the number of seconds until the next token
+    /// is available.
+    fn try_consume(&mut self) -> Result<(), u64> {
+        self.refill();
+        if self.tokens >= 1.0 {
+            self.tokens -= 1.0;
+            Ok(())
+        } else {
+            // Calculate seconds until one token is available.
+            let deficit = 1.0 - self.tokens;
+            let wait_secs = (deficit / self.refill_rate).ceil() as u64;
+            Err(wait_secs.max(1))
+        }
+    }
+
+    /// Refill tokens based on elapsed time since last refill.
+    fn refill(&mut self) {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        self.tokens = (self.tokens + elapsed * self.refill_rate).min(self.capacity);
+        self.last_refill = now;
+    }
+}
+
+/// Concurrent per-key rate limiter.
+///
+/// Each API key ID gets its own [`TokenBucket`]. Buckets are created
+/// on first access and cleaned up when stale.
+pub struct RateLimiter {
+    buckets: DashMap<String, TokenBucket>,
+    rpm: u32,
+}
+
+impl RateLimiter {
+    /// Create a new rate limiter with the given per-key requests-per-minute limit.
+    pub fn new(rpm: u32) -> Self {
+        Self {
+            buckets: DashMap::new(),
+            rpm,
+        }
+    }
+
+    /// Check whether a request from the given key ID is allowed.
+    ///
+    /// Returns `Ok(())` if the request is within the rate limit, or
+    /// `Err(retry_after_secs)` if the rate limit is exceeded.
+    pub fn check(&self, key_id: &str) -> Result<(), u64> {
+        let mut bucket = self
+            .buckets
+            .entry(key_id.to_string())
+            .or_insert_with(|| TokenBucket::new(self.rpm));
+        bucket.try_consume()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_token_bucket_allows_within_limit() {
+        let mut bucket = TokenBucket::new(100);
+        for _ in 0..100 {
+            assert!(bucket.try_consume().is_ok());
+        }
+    }
+
+    #[test]
+    fn test_token_bucket_rejects_over_limit() {
+        let mut bucket = TokenBucket::new(10);
+        for _ in 0..10 {
+            bucket.try_consume().unwrap();
+        }
+        let result = bucket.try_consume();
+        assert!(result.is_err(), "should reject when tokens exhausted");
+        let retry_after = result.unwrap_err();
+        assert!(retry_after >= 1, "retry_after should be at least 1 second");
+    }
+
+    #[test]
+    fn test_token_bucket_refills_over_time() {
+        let mut bucket = TokenBucket::new(60); // 1 token per second
+        // Exhaust all tokens.
+        for _ in 0..60 {
+            bucket.try_consume().unwrap();
+        }
+        assert!(bucket.try_consume().is_err());
+
+        // Simulate time passing by adjusting last_refill.
+        bucket.last_refill = Instant::now() - std::time::Duration::from_secs(2);
+        assert!(bucket.try_consume().is_ok(), "should have tokens after refill");
+    }
+
+    #[test]
+    fn test_rate_limiter_per_key_isolation() {
+        let limiter = RateLimiter::new(5);
+
+        // Exhaust key-a.
+        for _ in 0..5 {
+            limiter.check("key-a").unwrap();
+        }
+        assert!(limiter.check("key-a").is_err(), "key-a should be exhausted");
+
+        // key-b should still have tokens.
+        assert!(limiter.check("key-b").is_ok(), "key-b should be independent");
+    }
+}

--- a/aa-api/src/auth/scope.rs
+++ b/aa-api/src/auth/scope.rs
@@ -1,6 +1,11 @@
 //! Authorization scope levels for API operations.
 
+use axum::async_trait;
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
 use serde::{Deserialize, Serialize};
+
+use super::{AuthError, AuthenticatedCaller};
 
 /// Authorization scope level for API operations.
 ///
@@ -34,5 +39,79 @@ impl std::fmt::Display for Scope {
             Scope::Write => write!(f, "write"),
             Scope::Admin => write!(f, "admin"),
         }
+    }
+}
+
+/// Axum extractor that enforces a minimum scope level.
+///
+/// Use as a handler parameter to gate access:
+///
+/// ```ignore
+/// async fn admin_only(_scope: RequireScope<{ Scope::Admin as u8 }>) { ... }
+/// ```
+///
+/// This extractor first resolves the [`AuthenticatedCaller`] and then
+/// checks that the caller's scopes satisfy the required level.
+pub struct RequireScope(pub AuthenticatedCaller);
+
+impl RequireScope {
+    /// Validate that the caller has at least the given scope.
+    fn check(caller: &AuthenticatedCaller, required: Scope) -> Result<(), AuthError> {
+        if required.is_satisfied_by(&caller.scopes) {
+            Ok(())
+        } else {
+            Err(AuthError::InsufficientScope { required })
+        }
+    }
+}
+
+/// Require `Scope::Read` — the caller must have at least read access.
+pub struct RequireRead(pub AuthenticatedCaller);
+
+#[async_trait]
+impl<S> FromRequestParts<S> for RequireRead
+where
+    S: Send + Sync,
+{
+    type Rejection = AuthError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let caller = AuthenticatedCaller::from_request_parts(parts, state).await?;
+        RequireScope::check(&caller, Scope::Read)?;
+        Ok(Self(caller))
+    }
+}
+
+/// Require `Scope::Write` — the caller must have at least write access.
+pub struct RequireWrite(pub AuthenticatedCaller);
+
+#[async_trait]
+impl<S> FromRequestParts<S> for RequireWrite
+where
+    S: Send + Sync,
+{
+    type Rejection = AuthError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let caller = AuthenticatedCaller::from_request_parts(parts, state).await?;
+        RequireScope::check(&caller, Scope::Write)?;
+        Ok(Self(caller))
+    }
+}
+
+/// Require `Scope::Admin` — the caller must have admin access.
+pub struct RequireAdmin(pub AuthenticatedCaller);
+
+#[async_trait]
+impl<S> FromRequestParts<S> for RequireAdmin
+where
+    S: Send + Sync,
+{
+    type Rejection = AuthError;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let caller = AuthenticatedCaller::from_request_parts(parts, state).await?;
+        RequireScope::check(&caller, Scope::Admin)?;
+        Ok(Self(caller))
     }
 }

--- a/aa-api/src/auth/scope.rs
+++ b/aa-api/src/auth/scope.rs
@@ -115,3 +115,54 @@ where
         Ok(Self(caller))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scope_ordering() {
+        assert!(Scope::Admin > Scope::Write);
+        assert!(Scope::Write > Scope::Read);
+        assert!(Scope::Admin > Scope::Read);
+    }
+
+    #[test]
+    fn test_scope_contains_same_level() {
+        assert!(Scope::Write.is_satisfied_by(&[Scope::Write]));
+        assert!(Scope::Read.is_satisfied_by(&[Scope::Read]));
+        assert!(Scope::Admin.is_satisfied_by(&[Scope::Admin]));
+    }
+
+    #[test]
+    fn test_scope_contains_higher_level() {
+        assert!(Scope::Write.is_satisfied_by(&[Scope::Admin]));
+        assert!(Scope::Read.is_satisfied_by(&[Scope::Admin]));
+        assert!(Scope::Read.is_satisfied_by(&[Scope::Write]));
+    }
+
+    #[test]
+    fn test_scope_rejects_lower_level() {
+        assert!(!Scope::Write.is_satisfied_by(&[Scope::Read]));
+        assert!(!Scope::Admin.is_satisfied_by(&[Scope::Write]));
+        assert!(!Scope::Admin.is_satisfied_by(&[Scope::Read]));
+    }
+
+    #[test]
+    fn test_scope_empty_grants_rejects_all() {
+        assert!(!Scope::Read.is_satisfied_by(&[]));
+        assert!(!Scope::Write.is_satisfied_by(&[]));
+        assert!(!Scope::Admin.is_satisfied_by(&[]));
+    }
+
+    #[test]
+    fn test_scope_check_with_caller() {
+        let caller = AuthenticatedCaller {
+            key_id: "test".to_string(),
+            scopes: vec![Scope::Read, Scope::Write],
+        };
+        assert!(RequireScope::check(&caller, Scope::Read).is_ok());
+        assert!(RequireScope::check(&caller, Scope::Write).is_ok());
+        assert!(RequireScope::check(&caller, Scope::Admin).is_err());
+    }
+}

--- a/aa-api/src/auth/scope.rs
+++ b/aa-api/src/auth/scope.rs
@@ -1,0 +1,38 @@
+//! Authorization scope levels for API operations.
+
+use serde::{Deserialize, Serialize};
+
+/// Authorization scope level for API operations.
+///
+/// Variants are ordered by privilege: `Read < Write < Admin`.
+/// A caller with `Admin` scope satisfies any scope requirement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Scope {
+    /// Read-only access to resources.
+    Read,
+    /// Read and write access (create, update, delete).
+    Write,
+    /// Full administrative access including agent kill.
+    Admin,
+}
+
+impl Scope {
+    /// Check whether the given set of scopes satisfies this required scope.
+    ///
+    /// Returns `true` if any scope in `granted` is >= `self` in the
+    /// privilege ordering.
+    pub fn is_satisfied_by(self, granted: &[Scope]) -> bool {
+        granted.iter().any(|s| *s >= self)
+    }
+}
+
+impl std::fmt::Display for Scope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Scope::Read => write!(f, "read"),
+            Scope::Write => write!(f, "write"),
+            Scope::Admin => write!(f, "admin"),
+        }
+    }
+}

--- a/aa-api/src/config.rs
+++ b/aa-api/src/config.rs
@@ -2,6 +2,8 @@
 
 use std::net::SocketAddr;
 
+use crate::auth::config::{AuthConfig, AuthConfigError};
+
 /// Default bind address for the API server.
 const DEFAULT_ADDR: &str = "127.0.0.1:7700";
 
@@ -10,6 +12,15 @@ const DEFAULT_ADDR: &str = "127.0.0.1:7700";
 pub struct ApiConfig {
     /// Socket address to bind the server to.
     pub bind_addr: SocketAddr,
+    /// Authentication configuration (fail-closed).
+    pub auth: AuthConfig,
+}
+
+/// Errors that can occur when building `ApiConfig`.
+#[derive(Debug, thiserror::Error)]
+pub enum ApiConfigError {
+    #[error("auth configuration error: {0}")]
+    Auth(#[from] AuthConfigError),
 }
 
 impl ApiConfig {
@@ -17,7 +28,11 @@ impl ApiConfig {
     ///
     /// Reads `AA_API_ADDR` (e.g. `"0.0.0.0:7700"`). Falls back to
     /// `127.0.0.1:7700` when the variable is unset.
-    pub fn from_env() -> Self {
+    ///
+    /// Also reads auth-related env vars via [`AuthConfig::from_env()`].
+    /// If auth is enabled and configuration is invalid, this returns an
+    /// error (fail-closed).
+    pub fn from_env() -> Result<Self, ApiConfigError> {
         let addr = std::env::var("AA_API_ADDR").unwrap_or_else(|_| DEFAULT_ADDR.to_string());
         let bind_addr = addr.parse().unwrap_or_else(|e| {
             tracing::warn!(
@@ -27,14 +42,7 @@ impl ApiConfig {
             );
             DEFAULT_ADDR.parse().expect("default address is valid")
         });
-        Self { bind_addr }
-    }
-}
-
-impl Default for ApiConfig {
-    fn default() -> Self {
-        Self {
-            bind_addr: DEFAULT_ADDR.parse().expect("default address is valid"),
-        }
+        let auth = AuthConfig::from_env()?;
+        Ok(Self { bind_addr, auth })
     }
 }

--- a/aa-api/src/lib.rs
+++ b/aa-api/src/lib.rs
@@ -5,6 +5,7 @@
 //! via `utoipa`. CI validates that `openapi/v1.yaml` stays in sync with
 //! the generated spec — a drift failure blocks merge.
 
+pub mod auth;
 pub mod config;
 pub mod error;
 pub mod events;

--- a/aa-api/src/middleware/mod.rs
+++ b/aa-api/src/middleware/mod.rs
@@ -6,7 +6,8 @@
 //! 3. CORS (allow dashboard origin)
 //! 4. Response compression (gzip)
 //!
-//! Authentication middleware will be added by AAASM-82.
+//! Authentication is handled by FromRequestParts extractors (see auth module),
+//! not middleware layers.
 
 pub mod compression;
 pub mod cors;

--- a/aa-api/src/routes/auth.rs
+++ b/aa-api/src/routes/auth.rs
@@ -1,0 +1,83 @@
+//! Authentication routes: JWT token issuance.
+
+use std::sync::Arc;
+
+use axum::Extension;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use crate::auth::jwt::JwtSigner;
+use crate::auth::scope::Scope;
+use crate::auth::AuthenticatedCaller;
+use crate::error::ProblemDetail;
+
+/// JWT token lifetime in seconds (must match [`crate::auth::jwt::TOKEN_EXPIRY_SECS`]).
+const TOKEN_EXPIRY_SECS: u64 = 24 * 60 * 60;
+
+/// Request body for `POST /auth/token`.
+#[derive(Debug, Deserialize)]
+pub struct TokenRequest {
+    /// Requested scopes for the issued JWT.
+    /// If omitted, the caller's full scopes are used.
+    #[serde(default)]
+    pub scopes: Option<Vec<Scope>>,
+}
+
+/// Response body for `POST /auth/token`.
+#[derive(Debug, Serialize)]
+pub struct TokenResponse {
+    /// The issued JWT token string.
+    pub token: String,
+    /// Unix timestamp when the token expires.
+    pub expires_at: u64,
+    /// Scopes granted in the token.
+    pub scopes: Vec<Scope>,
+}
+
+/// Issue a short-lived JWT token from an authenticated API key.
+///
+/// The caller must already be authenticated (via API key or existing JWT).
+/// If `scopes` is provided in the request body, it must be a subset of
+/// the caller's granted scopes.
+pub async fn issue_token(
+    caller: AuthenticatedCaller,
+    Extension(jwt_signer): Extension<Arc<JwtSigner>>,
+    Json(body): Json<TokenRequest>,
+) -> Result<Json<TokenResponse>, ProblemDetail> {
+    let token_scopes = match body.scopes {
+        Some(requested) => {
+            // Validate that each requested scope is satisfied by the caller's scopes.
+            for scope in &requested {
+                if !scope.is_satisfied_by(&caller.scopes) {
+                    return Err(
+                        ProblemDetail::from_status(axum::http::StatusCode::FORBIDDEN).with_detail(
+                            format!(
+                                "Requested scope '{scope}' exceeds caller's granted scopes"
+                            ),
+                        ),
+                    );
+                }
+            }
+            requested
+        }
+        None => caller.scopes.clone(),
+    };
+
+    let token = jwt_signer
+        .sign(&caller.key_id, &token_scopes)
+        .map_err(|e| {
+            ProblemDetail::from_status(axum::http::StatusCode::INTERNAL_SERVER_ERROR)
+                .with_detail(format!("Failed to sign token: {e}"))
+        })?;
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock before Unix epoch")
+        .as_secs();
+
+    Ok(Json(TokenResponse {
+        token,
+        expires_at: now + TOKEN_EXPIRY_SECS,
+        scopes: token_scopes,
+    }))
+}

--- a/aa-api/src/routes/auth.rs
+++ b/aa-api/src/routes/auth.rs
@@ -49,13 +49,8 @@ pub async fn issue_token(
             // Validate that each requested scope is satisfied by the caller's scopes.
             for scope in &requested {
                 if !scope.is_satisfied_by(&caller.scopes) {
-                    return Err(
-                        ProblemDetail::from_status(axum::http::StatusCode::FORBIDDEN).with_detail(
-                            format!(
-                                "Requested scope '{scope}' exceeds caller's granted scopes"
-                            ),
-                        ),
-                    );
+                    return Err(ProblemDetail::from_status(axum::http::StatusCode::FORBIDDEN)
+                        .with_detail(format!("Requested scope '{scope}' exceeds caller's granted scopes")));
                 }
             }
             requested
@@ -63,12 +58,10 @@ pub async fn issue_token(
         None => caller.scopes.clone(),
     };
 
-    let token = jwt_signer
-        .sign(&caller.key_id, &token_scopes)
-        .map_err(|e| {
-            ProblemDetail::from_status(axum::http::StatusCode::INTERNAL_SERVER_ERROR)
-                .with_detail(format!("Failed to sign token: {e}"))
-        })?;
+    let token = jwt_signer.sign(&caller.key_id, &token_scopes).map_err(|e| {
+        ProblemDetail::from_status(axum::http::StatusCode::INTERNAL_SERVER_ERROR)
+            .with_detail(format!("Failed to sign token: {e}"))
+    })?;
 
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/aa-api/src/routes/mod.rs
+++ b/aa-api/src/routes/mod.rs
@@ -2,9 +2,10 @@
 //!
 //! All endpoints are nested under `/api/v1/`.
 
+pub mod auth;
 pub mod health;
 
-use axum::routing::get;
+use axum::routing::{get, post};
 use axum::Router;
 
 use crate::error::ProblemDetail;
@@ -14,6 +15,7 @@ pub fn v1_router() -> Router {
     Router::new()
         .route("/health", get(health::health))
         .route("/ws/events", get(crate::ws::handler::ws_events_handler))
+        .route("/auth/token", post(auth::issue_token))
 }
 
 /// Fallback handler returning a 404 RFC 7807 response.

--- a/aa-api/src/server.rs
+++ b/aa-api/src/server.rs
@@ -9,6 +9,9 @@ use crate::routes;
 use crate::state::AppState;
 
 /// Build the full Axum application with middleware and state.
+///
+/// Auth components are injected as individual `Extension` layers so the
+/// `AuthenticatedCaller` extractor can resolve them from request parts.
 pub fn build_app(state: AppState) -> Router {
     let api = routes::v1_router();
 
@@ -16,6 +19,14 @@ pub fn build_app(state: AppState) -> Router {
         .nest("/api/v1", api)
         .fallback(routes::fallback_404)
         .with_state(());
+
+    // Auth extensions — read by FromRequestParts extractors.
+    let app = app
+        .layer(axum::Extension(state.auth_config.clone()))
+        .layer(axum::Extension(state.key_store.clone()))
+        .layer(axum::Extension(state.rate_limiter.clone()))
+        .layer(axum::Extension(state.jwt_signer.clone()))
+        .layer(axum::Extension(state.jwt_verifier.clone()));
 
     let app = app.layer(axum::Extension(state));
 

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -7,6 +7,10 @@ use aa_gateway::budget::tracker::BudgetTracker;
 use aa_gateway::engine::PolicyEngine;
 use aa_runtime::approval::ApprovalQueue;
 
+use crate::auth::api_key::ApiKeyStore;
+use crate::auth::config::AuthConfig;
+use crate::auth::jwt::{JwtSigner, JwtVerifier};
+use crate::auth::rate_limit::RateLimiter;
 use crate::events::EventBroadcast;
 use crate::replay::ReplayBuffer;
 
@@ -25,4 +29,14 @@ pub struct AppState {
     pub replay_buffer: ReplayBuffer,
     /// Monotonic counter for assigning GovernanceEvent ids.
     pub next_event_id: Arc<AtomicU64>,
+    /// Authentication configuration.
+    pub auth_config: Arc<AuthConfig>,
+    /// Loaded API key entries for validation.
+    pub key_store: Arc<ApiKeyStore>,
+    /// Per-key rate limiter.
+    pub rate_limiter: Arc<RateLimiter>,
+    /// JWT token signer.
+    pub jwt_signer: Arc<JwtSigner>,
+    /// JWT token verifier.
+    pub jwt_verifier: Arc<JwtVerifier>,
 }

--- a/aa-api/tests/auth_api_key.rs
+++ b/aa-api/tests/auth_api_key.rs
@@ -1,0 +1,98 @@
+//! Integration tests for API key authentication flow.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use aa_api::auth::scope::Scope;
+
+#[tokio::test]
+async fn test_valid_api_key_grants_access() {
+    let (plaintext, entry) = common::generate_test_api_key("key-1", vec![Scope::Read, Scope::Write]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/token")
+                .header("authorization", format!("Bearer {plaintext}"))
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_invalid_api_key_returns_401() {
+    let (_plaintext, entry) = common::generate_test_api_key("key-1", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/token")
+                .header("authorization", "Bearer aa_00000000000000000000000000000000")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["status"], 401);
+}
+
+#[tokio::test]
+async fn test_missing_auth_header_returns_401() {
+    let (_plaintext, entry) = common::generate_test_api_key("key-1", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/token")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_malformed_bearer_returns_401() {
+    let (_plaintext, entry) = common::generate_test_api_key("key-1", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/token")
+                .header("authorization", "Basic dXNlcjpwYXNz")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}

--- a/aa-api/tests/auth_api_key.rs
+++ b/aa-api/tests/auth_api_key.rs
@@ -49,9 +49,7 @@ async fn test_invalid_api_key_returns_401() {
 
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-        .await
-        .unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["status"], 401);
 }

--- a/aa-api/tests/auth_bypass.rs
+++ b/aa-api/tests/auth_bypass.rs
@@ -45,9 +45,7 @@ async fn test_bypass_mode_grants_admin_scope() {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-        .await
-        .unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     let scopes = json["scopes"].as_array().expect("scopes should be array");
     assert!(

--- a/aa-api/tests/auth_bypass.rs
+++ b/aa-api/tests/auth_bypass.rs
@@ -1,0 +1,57 @@
+//! Integration tests for AA_AUTH=off bypass mode.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn test_bypass_mode_allows_unauthenticated() {
+    let app = common::test_app_no_auth();
+
+    // No credentials at all — should still succeed in bypass mode.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/token")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_bypass_mode_grants_admin_scope() {
+    let app = common::test_app_no_auth();
+
+    // Request a token with admin scope — bypass caller has all scopes.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/token")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"scopes":["admin"]}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let scopes = json["scopes"].as_array().expect("scopes should be array");
+    assert!(
+        scopes.iter().any(|s| s.as_str() == Some("admin")),
+        "bypass caller should have admin scope"
+    );
+}

--- a/aa-api/tests/auth_jwt.rs
+++ b/aa-api/tests/auth_jwt.rs
@@ -1,0 +1,138 @@
+//! Integration tests for JWT authentication flow.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use aa_api::auth::scope::Scope;
+
+#[tokio::test]
+async fn test_valid_jwt_grants_access() {
+    let (_plaintext, entry) = common::generate_test_api_key("key-1", vec![Scope::Read, Scope::Write]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+    let jwt = common::generate_test_jwt("key-1", &[Scope::Read, Scope::Write]);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/token")
+                .header("authorization", format!("Bearer {jwt}"))
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_expired_jwt_returns_401() {
+    let (_plaintext, entry) = common::generate_test_api_key("key-1", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    // JWT signed with a different secret should fail verification.
+    let wrong_signer = aa_api::auth::jwt::JwtSigner::new(b"wrong-secret-that-is-at-least-32-bytes-long!!");
+    let wrong_jwt = wrong_signer
+        .sign("key-1", &[Scope::Read])
+        .expect("signing should succeed");
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/token")
+                .header("authorization", format!("Bearer {wrong_jwt}"))
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_wrong_secret_jwt_returns_401() {
+    let (_plaintext, entry) = common::generate_test_api_key("key-1", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let wrong_signer = aa_api::auth::jwt::JwtSigner::new(
+        b"different-secret-that-is-also-32-bytes-long!!",
+    );
+    let jwt = wrong_signer
+        .sign("key-1", &[Scope::Read])
+        .expect("signing should succeed");
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/token")
+                .header("authorization", format!("Bearer {jwt}"))
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn test_token_endpoint_issues_jwt() {
+    let (plaintext, entry) =
+        common::generate_test_api_key("key-1", vec![Scope::Read, Scope::Write]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/token")
+                .header("authorization", format!("Bearer {plaintext}"))
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(json["token"].is_string(), "response should contain a token");
+    assert!(json["expires_at"].is_u64(), "response should contain expires_at");
+    assert!(json["scopes"].is_array(), "response should contain scopes");
+}
+
+#[tokio::test]
+async fn test_token_endpoint_respects_scope_subset() {
+    let (plaintext, entry) = common::generate_test_api_key("key-1", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    // Request Write scope when caller only has Read — should fail.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/token")
+                .header("authorization", format!("Bearer {plaintext}"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"scopes":["write"]}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}

--- a/aa-api/tests/auth_jwt.rs
+++ b/aa-api/tests/auth_jwt.rs
@@ -62,9 +62,7 @@ async fn test_wrong_secret_jwt_returns_401() {
     let (_plaintext, entry) = common::generate_test_api_key("key-1", vec![Scope::Read]);
     let app = common::test_app_with_auth(&[entry], 1000);
 
-    let wrong_signer = aa_api::auth::jwt::JwtSigner::new(
-        b"different-secret-that-is-also-32-bytes-long!!",
-    );
+    let wrong_signer = aa_api::auth::jwt::JwtSigner::new(b"different-secret-that-is-also-32-bytes-long!!");
     let jwt = wrong_signer
         .sign("key-1", &[Scope::Read])
         .expect("signing should succeed");
@@ -87,8 +85,7 @@ async fn test_wrong_secret_jwt_returns_401() {
 
 #[tokio::test]
 async fn test_token_endpoint_issues_jwt() {
-    let (plaintext, entry) =
-        common::generate_test_api_key("key-1", vec![Scope::Read, Scope::Write]);
+    let (plaintext, entry) = common::generate_test_api_key("key-1", vec![Scope::Read, Scope::Write]);
     let app = common::test_app_with_auth(&[entry], 1000);
 
     let response = app
@@ -106,9 +103,7 @@ async fn test_token_endpoint_issues_jwt() {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-        .await
-        .unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert!(json["token"].is_string(), "response should contain a token");
     assert!(json["expires_at"].is_u64(), "response should contain expires_at");

--- a/aa-api/tests/auth_rate_limit.rs
+++ b/aa-api/tests/auth_rate_limit.rs
@@ -11,14 +11,9 @@ use aa_api::server::build_app;
 
 #[tokio::test]
 async fn test_rate_limit_allows_under_threshold() {
-    let (plaintext, entry) =
-        common::generate_test_api_key("key-1", vec![Scope::Read, Scope::Write]);
+    let (plaintext, entry) = common::generate_test_api_key("key-1", vec![Scope::Read, Scope::Write]);
     // Set RPM high enough that 3 requests are fine.
-    let state = common::test_state_with_auth(
-        aa_api::auth::config::AuthMode::On,
-        &[entry],
-        100,
-    );
+    let state = common::test_state_with_auth(aa_api::auth::config::AuthMode::On, &[entry], 100);
     let app = build_app(state);
 
     // Send 3 requests — all should succeed.
@@ -42,14 +37,9 @@ async fn test_rate_limit_allows_under_threshold() {
 
 #[tokio::test]
 async fn test_rate_limit_returns_429_with_retry_after() {
-    let (plaintext, entry) =
-        common::generate_test_api_key("key-1", vec![Scope::Read, Scope::Write]);
+    let (plaintext, entry) = common::generate_test_api_key("key-1", vec![Scope::Read, Scope::Write]);
     // Set RPM to 2 so we can exhaust it quickly.
-    let state = common::test_state_with_auth(
-        aa_api::auth::config::AuthMode::On,
-        &[entry],
-        2,
-    );
+    let state = common::test_state_with_auth(aa_api::auth::config::AuthMode::On, &[entry], 2);
     let app = build_app(state);
 
     // Exhaust the 2-request limit.
@@ -93,16 +83,10 @@ async fn test_rate_limit_returns_429_with_retry_after() {
 
 #[tokio::test]
 async fn test_rate_limit_per_key_isolation() {
-    let (plaintext_a, entry_a) =
-        common::generate_test_api_key("key-a", vec![Scope::Read, Scope::Write]);
-    let (plaintext_b, entry_b) =
-        common::generate_test_api_key("key-b", vec![Scope::Read, Scope::Write]);
+    let (plaintext_a, entry_a) = common::generate_test_api_key("key-a", vec![Scope::Read, Scope::Write]);
+    let (plaintext_b, entry_b) = common::generate_test_api_key("key-b", vec![Scope::Read, Scope::Write]);
     // RPM = 2: key-a will exhaust its bucket.
-    let state = common::test_state_with_auth(
-        aa_api::auth::config::AuthMode::On,
-        &[entry_a, entry_b],
-        2,
-    );
+    let state = common::test_state_with_auth(aa_api::auth::config::AuthMode::On, &[entry_a, entry_b], 2);
     let app = build_app(state);
 
     // Exhaust key-a.

--- a/aa-api/tests/auth_rate_limit.rs
+++ b/aa-api/tests/auth_rate_limit.rs
@@ -1,0 +1,156 @@
+//! Integration tests for rate limiting.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use aa_api::auth::scope::Scope;
+use aa_api::server::build_app;
+
+#[tokio::test]
+async fn test_rate_limit_allows_under_threshold() {
+    let (plaintext, entry) =
+        common::generate_test_api_key("key-1", vec![Scope::Read, Scope::Write]);
+    // Set RPM high enough that 3 requests are fine.
+    let state = common::test_state_with_auth(
+        aa_api::auth::config::AuthMode::On,
+        &[entry],
+        100,
+    );
+    let app = build_app(state);
+
+    // Send 3 requests — all should succeed.
+    for _ in 0..3 {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/auth/token")
+                    .header("authorization", format!("Bearer {plaintext}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}
+
+#[tokio::test]
+async fn test_rate_limit_returns_429_with_retry_after() {
+    let (plaintext, entry) =
+        common::generate_test_api_key("key-1", vec![Scope::Read, Scope::Write]);
+    // Set RPM to 2 so we can exhaust it quickly.
+    let state = common::test_state_with_auth(
+        aa_api::auth::config::AuthMode::On,
+        &[entry],
+        2,
+    );
+    let app = build_app(state);
+
+    // Exhaust the 2-request limit.
+    for _ in 0..2 {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/auth/token")
+                    .header("authorization", format!("Bearer {plaintext}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    // Third request should be rate-limited.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/token")
+                .header("authorization", format!("Bearer {plaintext}"))
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert!(
+        response.headers().contains_key("retry-after"),
+        "429 response should include Retry-After header"
+    );
+}
+
+#[tokio::test]
+async fn test_rate_limit_per_key_isolation() {
+    let (plaintext_a, entry_a) =
+        common::generate_test_api_key("key-a", vec![Scope::Read, Scope::Write]);
+    let (plaintext_b, entry_b) =
+        common::generate_test_api_key("key-b", vec![Scope::Read, Scope::Write]);
+    // RPM = 2: key-a will exhaust its bucket.
+    let state = common::test_state_with_auth(
+        aa_api::auth::config::AuthMode::On,
+        &[entry_a, entry_b],
+        2,
+    );
+    let app = build_app(state);
+
+    // Exhaust key-a.
+    for _ in 0..2 {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/auth/token")
+                    .header("authorization", format!("Bearer {plaintext_a}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from("{}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    // key-a should now be rate-limited.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/token")
+                .header("authorization", format!("Bearer {plaintext_a}"))
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+
+    // key-b should still work.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/token")
+                .header("authorization", format!("Bearer {plaintext_b}"))
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}

--- a/aa-api/tests/auth_scope.rs
+++ b/aa-api/tests/auth_scope.rs
@@ -57,8 +57,7 @@ async fn test_read_scope_blocks_write_token() {
 
 #[tokio::test]
 async fn test_write_scope_allows_write_token() {
-    let (plaintext, entry) =
-        common::generate_test_api_key("key-1", vec![Scope::Read, Scope::Write]);
+    let (plaintext, entry) = common::generate_test_api_key("key-1", vec![Scope::Read, Scope::Write]);
     let app = common::test_app_with_auth(&[entry], 1000);
 
     let response = app
@@ -79,8 +78,7 @@ async fn test_write_scope_allows_write_token() {
 
 #[tokio::test]
 async fn test_admin_scope_allows_all_token_scopes() {
-    let (plaintext, entry) =
-        common::generate_test_api_key("key-1", vec![Scope::Read, Scope::Write, Scope::Admin]);
+    let (plaintext, entry) = common::generate_test_api_key("key-1", vec![Scope::Read, Scope::Write, Scope::Admin]);
     let app = common::test_app_with_auth(&[entry], 1000);
 
     // Admin caller requests all scopes — allowed.
@@ -99,9 +97,7 @@ async fn test_admin_scope_allows_all_token_scopes() {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-        .await
-        .unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     let scopes = json["scopes"].as_array().expect("scopes should be array");
     assert_eq!(scopes.len(), 3);

--- a/aa-api/tests/auth_scope.rs
+++ b/aa-api/tests/auth_scope.rs
@@ -1,0 +1,108 @@
+//! Integration tests for scope enforcement.
+//!
+//! These tests verify that the token endpoint correctly enforces scope
+//! constraints when issuing JWTs with specific scope subsets.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use aa_api::auth::scope::Scope;
+
+#[tokio::test]
+async fn test_read_scope_allows_token_with_read() {
+    let (plaintext, entry) = common::generate_test_api_key("key-1", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    // Read-only caller requests a token with read scope — allowed.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/token")
+                .header("authorization", format!("Bearer {plaintext}"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"scopes":["read"]}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_read_scope_blocks_write_token() {
+    let (plaintext, entry) = common::generate_test_api_key("key-1", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    // Read-only caller requests a write-scoped token — forbidden.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/token")
+                .header("authorization", format!("Bearer {plaintext}"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"scopes":["write"]}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn test_write_scope_allows_write_token() {
+    let (plaintext, entry) =
+        common::generate_test_api_key("key-1", vec![Scope::Read, Scope::Write]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/token")
+                .header("authorization", format!("Bearer {plaintext}"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"scopes":["write"]}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_admin_scope_allows_all_token_scopes() {
+    let (plaintext, entry) =
+        common::generate_test_api_key("key-1", vec![Scope::Read, Scope::Write, Scope::Admin]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    // Admin caller requests all scopes — allowed.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/token")
+                .header("authorization", format!("Bearer {plaintext}"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"scopes":["read","write","admin"]}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let scopes = json["scopes"].as_array().expect("scopes should be array");
+    assert_eq!(scopes.len(), 3);
+}

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -1,7 +1,7 @@
 //! Shared test utilities for aa-api integration tests.
 
 use std::path::Path;
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicU64, AtomicUsize};
 use std::sync::Arc;
 
 use aa_api::auth::api_key::{ApiKey, ApiKeyEntry, ApiKeyStore};
@@ -22,6 +22,9 @@ use axum::Router;
 /// Default JWT test secret (>= 32 bytes).
 const TEST_SECRET: &[u8] = b"test-secret-key-that-is-at-least-32-bytes-long!!";
 
+/// Counter for generating unique temp file names across concurrent tests.
+static TEMP_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
 /// Build a minimal `AppState` for gateway/non-auth tests (auth disabled).
 #[allow(dead_code)]
 pub fn test_state() -> AppState {
@@ -32,7 +35,8 @@ pub fn test_state() -> AppState {
 #[allow(dead_code)]
 pub fn test_state_with_auth(mode: AuthMode, entries: &[ApiKeyEntry], rpm: u32) -> AppState {
     // PolicyEngine requires a policy file; use a minimal valid policy.
-    let policy_dir = std::env::temp_dir().join("aa-api-test-policy");
+    let policy_id = TEMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let policy_dir = std::env::temp_dir().join(format!("aa-api-test-policy-{}-{policy_id}", std::process::id()));
     std::fs::create_dir_all(&policy_dir).unwrap();
     let policy_path = policy_dir.join("test-policy.yaml");
     std::fs::write(
@@ -82,7 +86,8 @@ spec:
     let key_store = if entries.is_empty() {
         key_store
     } else {
-        let tmp = std::env::temp_dir().join("aa-api-test-keys.json");
+        let id = TEMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("aa-api-test-keys-{}-{id}.json", std::process::id()));
         let json = serde_json::to_string(entries).unwrap();
         std::fs::write(&tmp, &json).unwrap();
         Arc::new(ApiKeyStore::load(&tmp).unwrap())

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -1,8 +1,14 @@
 //! Shared test utilities for aa-api integration tests.
 
+use std::path::Path;
 use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
+use aa_api::auth::api_key::{ApiKey, ApiKeyEntry, ApiKeyStore};
+use aa_api::auth::config::{AuthConfig, AuthMode};
+use aa_api::auth::jwt::{JwtSigner, JwtVerifier};
+use aa_api::auth::rate_limit::RateLimiter;
+use aa_api::auth::scope::Scope;
 use aa_api::events::EventBroadcast;
 use aa_api::replay::ReplayBuffer;
 use aa_api::server::build_app;
@@ -13,8 +19,16 @@ use aa_gateway::engine::PolicyEngine;
 use aa_runtime::approval::ApprovalQueue;
 use axum::Router;
 
-/// Build a test `AppState` with minimal real dependencies.
+/// Default JWT test secret (>= 32 bytes).
+const TEST_SECRET: &[u8] = b"test-secret-key-that-is-at-least-32-bytes-long!!";
+
+/// Build a minimal `AppState` for gateway/non-auth tests (auth disabled).
 pub fn test_state() -> AppState {
+    test_state_with_auth(AuthMode::Off, &[], 1000)
+}
+
+/// Build an `AppState` with auth enabled and the given API key entries.
+pub fn test_state_with_auth(mode: AuthMode, entries: &[ApiKeyEntry], rpm: u32) -> AppState {
     // PolicyEngine requires a policy file; use a minimal valid policy.
     let policy_dir = std::env::temp_dir().join("aa-api-test-policy");
     std::fs::create_dir_all(&policy_dir).unwrap();
@@ -35,7 +49,8 @@ spec:
 
     let events = Arc::new(EventBroadcast::default());
     let budget_alert_tx = events.budget_sender();
-    let policy_engine = Arc::new(PolicyEngine::load_from_file(&policy_path, budget_alert_tx).unwrap());
+    let policy_engine =
+        Arc::new(PolicyEngine::load_from_file(&policy_path, budget_alert_tx).unwrap());
     let budget_tracker = Arc::new(BudgetTracker::new(
         PricingTable::default_table(),
         None,
@@ -44,6 +59,39 @@ spec:
     ));
     let approval_queue = ApprovalQueue::new();
 
+    let jwt_secret = match mode {
+        AuthMode::On => Some(TEST_SECRET.to_vec()),
+        AuthMode::Off => None,
+    };
+
+    let auth_config = Arc::new(AuthConfig {
+        mode,
+        jwt_secret: jwt_secret.clone(),
+        api_keys_path: std::path::PathBuf::from("/dev/null"),
+        rate_limit_rpm: rpm,
+    });
+
+    let key_store = Arc::new(ApiKeyStore::load(Path::new("/dev/null")).unwrap_or_else(|_| {
+        // Fallback: construct empty store
+        ApiKeyStore::load(Path::new("/nonexistent")).unwrap()
+    }));
+
+    // For tests with pre-loaded keys, we need to build the store differently.
+    // We'll use a temp file approach.
+    let key_store = if entries.is_empty() {
+        key_store
+    } else {
+        let tmp = std::env::temp_dir().join("aa-api-test-keys.json");
+        let json = serde_json::to_string(entries).unwrap();
+        std::fs::write(&tmp, &json).unwrap();
+        Arc::new(ApiKeyStore::load(&tmp).unwrap())
+    };
+
+    let secret = jwt_secret.as_deref().unwrap_or(TEST_SECRET);
+    let jwt_signer = Arc::new(JwtSigner::new(secret));
+    let jwt_verifier = Arc::new(JwtVerifier::new(secret));
+    let rate_limiter = Arc::new(RateLimiter::new(rpm));
+
     AppState {
         policy_engine,
         budget_tracker,
@@ -51,11 +99,46 @@ spec:
         events,
         replay_buffer: ReplayBuffer::new(),
         next_event_id: Arc::new(AtomicU64::new(0)),
+        auth_config,
+        key_store,
+        rate_limiter,
+        jwt_signer,
+        jwt_verifier,
     }
 }
 
-/// Build the full app for testing (router + middleware + state).
+/// Build the full app for testing (router + middleware + state, auth disabled).
 #[allow(dead_code)]
 pub fn test_app() -> Router {
     build_app(test_state())
+}
+
+/// Build the full app with auth enabled and the given API key entries.
+pub fn test_app_with_auth(entries: &[ApiKeyEntry], rpm: u32) -> Router {
+    build_app(test_state_with_auth(AuthMode::On, entries, rpm))
+}
+
+/// Build the full app with auth disabled (bypass mode).
+pub fn test_app_no_auth() -> Router {
+    build_app(test_state_with_auth(AuthMode::Off, &[], 1000))
+}
+
+/// Generate a test API key and return (plaintext, ApiKeyEntry).
+pub fn generate_test_api_key(id: &str, scopes: Vec<Scope>) -> (String, ApiKeyEntry) {
+    let key = ApiKey::generate();
+    let hash = key.hash().expect("hashing should succeed");
+    let entry = ApiKeyEntry {
+        id: id.to_string(),
+        key_hash: hash,
+        scopes,
+        created_at: 1700000000,
+        label: Some(format!("test key {id}")),
+    };
+    (key.as_str().to_string(), entry)
+}
+
+/// Generate a test JWT token for the given key ID and scopes.
+pub fn generate_test_jwt(key_id: &str, scopes: &[Scope]) -> String {
+    let signer = JwtSigner::new(TEST_SECRET);
+    signer.sign(key_id, scopes).expect("signing should succeed")
 }

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -23,11 +23,13 @@ use axum::Router;
 const TEST_SECRET: &[u8] = b"test-secret-key-that-is-at-least-32-bytes-long!!";
 
 /// Build a minimal `AppState` for gateway/non-auth tests (auth disabled).
+#[allow(dead_code)]
 pub fn test_state() -> AppState {
     test_state_with_auth(AuthMode::Off, &[], 1000)
 }
 
 /// Build an `AppState` with auth enabled and the given API key entries.
+#[allow(dead_code)]
 pub fn test_state_with_auth(mode: AuthMode, entries: &[ApiKeyEntry], rpm: u32) -> AppState {
     // PolicyEngine requires a policy file; use a minimal valid policy.
     let policy_dir = std::env::temp_dir().join("aa-api-test-policy");
@@ -49,8 +51,7 @@ spec:
 
     let events = Arc::new(EventBroadcast::default());
     let budget_alert_tx = events.budget_sender();
-    let policy_engine =
-        Arc::new(PolicyEngine::load_from_file(&policy_path, budget_alert_tx).unwrap());
+    let policy_engine = Arc::new(PolicyEngine::load_from_file(&policy_path, budget_alert_tx).unwrap());
     let budget_tracker = Arc::new(BudgetTracker::new(
         PricingTable::default_table(),
         None,
@@ -114,16 +115,19 @@ pub fn test_app() -> Router {
 }
 
 /// Build the full app with auth enabled and the given API key entries.
+#[allow(dead_code)]
 pub fn test_app_with_auth(entries: &[ApiKeyEntry], rpm: u32) -> Router {
     build_app(test_state_with_auth(AuthMode::On, entries, rpm))
 }
 
 /// Build the full app with auth disabled (bypass mode).
+#[allow(dead_code)]
 pub fn test_app_no_auth() -> Router {
     build_app(test_state_with_auth(AuthMode::Off, &[], 1000))
 }
 
 /// Generate a test API key and return (plaintext, ApiKeyEntry).
+#[allow(dead_code)]
 pub fn generate_test_api_key(id: &str, scopes: Vec<Scope>) -> (String, ApiKeyEntry) {
     let key = ApiKey::generate();
     let hash = key.hash().expect("hashing should succeed");
@@ -138,6 +142,7 @@ pub fn generate_test_api_key(id: &str, scopes: Vec<Scope>) -> (String, ApiKeyEnt
 }
 
 /// Generate a test JWT token for the given key ID and scopes.
+#[allow(dead_code)]
 pub fn generate_test_jwt(key_id: &str, scopes: &[Scope]) -> String {
     let signer = JwtSigner::new(TEST_SECRET);
     signer.sign(key_id, scopes).expect("signing should succeed")


### PR DESCRIPTION
## Summary

Implements full API key and JWT authentication for `aa-api` endpoints (AAASM-82), part of Epic AAASM-9 (REST API Layer & OpenAPI Contract).

### What changed

- **Auth core modules**: `Scope` enum (Read < Write < Admin), `AuthConfig` with env var parsing and fail-closed validation, `ApiKey` newtype with `aa_<32-hex>` format and argon2 hashing, `ApiKeyStore` with JSON file loading, `JwtSigner`/`JwtVerifier` (HMAC-SHA256, 24h expiry), `RateLimiter` (per-key token bucket via DashMap)
- **Axum extractors**: `AuthenticatedCaller` (`FromRequestParts`) validates API keys or JWTs and enforces rate limits; `RequireRead`/`RequireWrite`/`RequireAdmin` scope-gated extractors
- **Auth error handling**: `AuthError` enum maps to RFC 7807 `ProblemDetail` responses (401/403/429 with `Retry-After` header)
- **Token endpoint**: `POST /api/v1/auth/token` issues JWTs from authenticated API keys with scope subset validation
- **Server wiring**: Auth components injected as `Extension<Arc<T>>` layers; `AppState` extended with auth fields; `ApiConfig::from_env()` now returns `Result` (fail-closed)
- **Bypass mode**: `AA_AUTH=off` env var disables auth and grants synthetic admin access

### Environment variables

| Variable | Required | Default | Description |
|---|---|---|---|
| `AA_AUTH` | No | `on` | Set to `off` to disable auth |
| `AA_JWT_SECRET` | When auth=on | — | HMAC secret (min 32 bytes) |
| `AA_API_KEYS_PATH` | No | `~/.aa/api-keys.json` | Path to API keys file |
| `AA_RATE_LIMIT_RPM` | No | `1000` | Per-key requests per minute |

### Test coverage

- **30 unit tests**: API key (10), JWT (4), rate limiter (4), scope (6), AuthConfig (6)
- **19 integration tests**: API key auth (4), JWT auth (5), rate limiting (3), scope enforcement (4), bypass mode (2), plus 1 existing health test updated

## Test plan

- [x] All 30 unit tests pass (`cargo test -p aa-api --lib`)
- [x] All 19 new integration tests pass (`cargo test -p aa-api --test auth_*`)
- [x] All 5 pre-existing integration tests still pass (health, error_response, event_broadcast)
- [x] Full suite: 53 tests, 0 failures
- [ ] Verify `AA_AUTH=off` bypass in local dev environment
- [ ] Verify 401/403/429 responses match RFC 7807 format

Closes AAASM-82

🤖 Generated with [Claude Code](https://claude.com/claude-code)