### PR TITLE
[AAASM-170] ✨ (alerts): Wire GET /api/v1/alerts with AlertStore

### DIFF
--- a/aa-api/src/alerts/capture.rs
+++ b/aa-api/src/alerts/capture.rs
@@ -1,1 +1,39 @@
 //! Background task that captures budget alerts from the broadcast channel.
+
+use std::sync::Arc;
+
+use tokio::sync::broadcast;
+
+use aa_gateway::budget::types::BudgetAlert;
+
+use super::AlertStore;
+
+/// Spawn a background task that subscribes to the budget alert broadcast
+/// channel and records each alert into the given store.
+///
+/// The task runs until the broadcast channel is closed (all senders dropped).
+/// `RecvError::Lagged` is handled gracefully by logging and continuing.
+pub fn spawn_alert_capture(
+    mut rx: broadcast::Receiver<BudgetAlert>,
+    store: Arc<dyn AlertStore>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(alert) => {
+                    store.record(&alert);
+                }
+                Err(broadcast::error::RecvError::Lagged(count)) => {
+                    tracing::warn!(
+                        count,
+                        "alert capture task lagged behind broadcast, skipped {count} alerts"
+                    );
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    tracing::info!("budget alert broadcast channel closed, stopping capture task");
+                    break;
+                }
+            }
+        }
+    })
+}

--- a/aa-api/src/alerts/capture.rs
+++ b/aa-api/src/alerts/capture.rs
@@ -1,0 +1,1 @@
+//! Background task that captures budget alerts from the broadcast channel.

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -1,0 +1,112 @@
+//! Alert storage and capture for the API layer.
+//!
+//! Budget alerts are broadcast ephemerally via `tokio::broadcast`. This module
+//! provides persistent storage so the `GET /api/v1/alerts` endpoint can return
+//! historical alerts.
+
+pub mod capture;
+pub mod store;
+
+use aa_gateway::budget::types::BudgetAlert;
+use serde::Serialize;
+
+/// Stored representation of a budget alert with metadata.
+#[derive(Debug, Clone, Serialize)]
+pub struct StoredAlert {
+    /// Auto-incremented alert identifier.
+    pub id: u64,
+    /// Alert severity level derived from `threshold_pct`.
+    pub severity: AlertSeverity,
+    /// Human-readable alert message.
+    pub message: String,
+    /// Hex-encoded agent ID that triggered the alert.
+    pub agent_id: String,
+    /// ISO 8601 timestamp when the alert was captured.
+    pub timestamp: String,
+    /// Budget threshold percentage that was crossed.
+    pub threshold_pct: u8,
+    /// Current spend in USD at the time of the alert.
+    pub spent_usd: f64,
+    /// Configured daily limit in USD.
+    pub limit_usd: f64,
+}
+
+/// Alert severity level derived from the budget threshold percentage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AlertSeverity {
+    /// Informational alert (threshold < 75%).
+    Info,
+    /// Warning alert (75% <= threshold < 90%).
+    Warning,
+    /// Critical alert (threshold >= 90%).
+    Critical,
+}
+
+impl std::fmt::Display for AlertSeverity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AlertSeverity::Info => write!(f, "info"),
+            AlertSeverity::Warning => write!(f, "warning"),
+            AlertSeverity::Critical => write!(f, "critical"),
+        }
+    }
+}
+
+/// Derive severity from a budget threshold percentage.
+pub fn severity_from_threshold(threshold_pct: u8) -> AlertSeverity {
+    if threshold_pct >= 90 {
+        AlertSeverity::Critical
+    } else if threshold_pct >= 75 {
+        AlertSeverity::Warning
+    } else {
+        AlertSeverity::Info
+    }
+}
+
+/// Format an `AgentId` as a hex string for display in API responses.
+fn format_agent_id(agent_id: &aa_core::AgentId) -> String {
+    agent_id
+        .as_bytes()
+        .iter()
+        .map(|b| format!("{b:02x}"))
+        .collect()
+}
+
+/// Build a human-readable alert message from a `BudgetAlert`.
+fn build_alert_message(alert: &BudgetAlert) -> String {
+    format!(
+        "Budget alert: agent {} crossed {}% threshold (${:.2} / ${:.2})",
+        format_agent_id(&alert.agent_id),
+        alert.threshold_pct,
+        alert.spent_usd,
+        alert.limit_usd,
+    )
+}
+
+/// Convert a `BudgetAlert` into a `StoredAlert` with the given ID and timestamp.
+pub fn stored_alert_from(alert: &BudgetAlert, id: u64, timestamp: String) -> StoredAlert {
+    StoredAlert {
+        id,
+        severity: severity_from_threshold(alert.threshold_pct),
+        message: build_alert_message(alert),
+        agent_id: format_agent_id(&alert.agent_id),
+        timestamp,
+        threshold_pct: alert.threshold_pct,
+        spent_usd: alert.spent_usd,
+        limit_usd: alert.limit_usd,
+    }
+}
+
+/// Trait for storing and querying alerts.
+///
+/// Implementations must be thread-safe (`Send + Sync`).
+pub trait AlertStore: Send + Sync {
+    /// Record a new budget alert, returning the assigned ID.
+    fn record(&self, alert: &BudgetAlert) -> u64;
+
+    /// List stored alerts with pagination.
+    ///
+    /// Returns `(alerts, total_count)`. Results are ordered newest-first.
+    fn list(&self, limit: usize, offset: usize) -> (Vec<StoredAlert>, u64);
+}

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -66,11 +66,7 @@ pub fn severity_from_threshold(threshold_pct: u8) -> AlertSeverity {
 
 /// Format an `AgentId` as a hex string for display in API responses.
 fn format_agent_id(agent_id: &aa_core::AgentId) -> String {
-    agent_id
-        .as_bytes()
-        .iter()
-        .map(|b| format!("{b:02x}"))
-        .collect()
+    agent_id.as_bytes().iter().map(|b| format!("{b:02x}")).collect()
 }
 
 /// Build a human-readable alert message from a `BudgetAlert`.

--- a/aa-api/src/alerts/store.rs
+++ b/aa-api/src/alerts/store.rs
@@ -1,1 +1,184 @@
-//! In-memory alert store implementation.
+//! In-memory alert store backed by a bounded ring buffer.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::RwLock;
+
+use aa_gateway::budget::types::BudgetAlert;
+
+use super::{stored_alert_from, AlertStore, StoredAlert};
+
+/// Default maximum number of alerts retained in the ring buffer.
+const DEFAULT_CAPACITY: usize = 10_000;
+
+/// In-memory alert store using a `VecDeque` ring buffer.
+///
+/// When the buffer reaches capacity, the oldest alert is evicted on each
+/// new insertion. Thread-safe via `RwLock`.
+pub struct InMemoryAlertStore {
+    alerts: RwLock<VecDeque<StoredAlert>>,
+    capacity: usize,
+    next_id: AtomicU64,
+}
+
+impl InMemoryAlertStore {
+    /// Create a new store with the default capacity (10,000 alerts).
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_CAPACITY)
+    }
+
+    /// Create a new store with the given maximum capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            alerts: RwLock::new(VecDeque::with_capacity(capacity.min(DEFAULT_CAPACITY))),
+            capacity,
+            next_id: AtomicU64::new(1),
+        }
+    }
+}
+
+impl Default for InMemoryAlertStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AlertStore for InMemoryAlertStore {
+    fn record(&self, alert: &BudgetAlert) -> u64 {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let timestamp = chrono::Utc::now().to_rfc3339();
+        let stored = stored_alert_from(alert, id, timestamp);
+
+        let mut buf = self.alerts.write().expect("alert store lock poisoned");
+        if buf.len() >= self.capacity {
+            buf.pop_front();
+        }
+        buf.push_back(stored);
+        id
+    }
+
+    fn list(&self, limit: usize, offset: usize) -> (Vec<StoredAlert>, u64) {
+        let buf = self.alerts.read().expect("alert store lock poisoned");
+        let total = buf.len() as u64;
+
+        // Return newest-first by iterating in reverse.
+        let items: Vec<StoredAlert> = buf.iter().rev().skip(offset).take(limit).cloned().collect();
+
+        (items, total)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aa_core::AgentId;
+
+    fn test_alert(threshold_pct: u8) -> BudgetAlert {
+        BudgetAlert {
+            agent_id: AgentId::from_bytes([1u8; 16]),
+            threshold_pct,
+            spent_usd: 8.0,
+            limit_usd: 10.0,
+        }
+    }
+
+    #[test]
+    fn record_and_list_single_alert() {
+        let store = InMemoryAlertStore::new();
+        let id = store.record(&test_alert(80));
+        assert_eq!(id, 1);
+
+        let (items, total) = store.list(10, 0);
+        assert_eq!(total, 1);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, 1);
+        assert_eq!(items[0].threshold_pct, 80);
+    }
+
+    #[test]
+    fn list_returns_newest_first() {
+        let store = InMemoryAlertStore::new();
+        store.record(&test_alert(80));
+        store.record(&test_alert(95));
+
+        let (items, total) = store.list(10, 0);
+        assert_eq!(total, 2);
+        assert_eq!(items[0].id, 2); // newest
+        assert_eq!(items[1].id, 1); // oldest
+    }
+
+    #[test]
+    fn list_pagination_limit_and_offset() {
+        let store = InMemoryAlertStore::new();
+        for i in 0..5 {
+            store.record(&test_alert(80 + i));
+        }
+
+        // Page 1: limit=2, offset=0 → IDs 5, 4
+        let (items, total) = store.list(2, 0);
+        assert_eq!(total, 5);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].id, 5);
+        assert_eq!(items[1].id, 4);
+
+        // Page 2: limit=2, offset=2 → IDs 3, 2
+        let (items, _) = store.list(2, 2);
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].id, 3);
+        assert_eq!(items[1].id, 2);
+
+        // Page 3: limit=2, offset=4 → ID 1
+        let (items, _) = store.list(2, 4);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, 1);
+    }
+
+    #[test]
+    fn capacity_evicts_oldest() {
+        let store = InMemoryAlertStore::with_capacity(3);
+        store.record(&test_alert(70)); // id=1
+        store.record(&test_alert(80)); // id=2
+        store.record(&test_alert(90)); // id=3
+        store.record(&test_alert(95)); // id=4 — evicts id=1
+
+        let (items, total) = store.list(10, 0);
+        assert_eq!(total, 3);
+        assert_eq!(items[0].id, 4);
+        assert_eq!(items[2].id, 2);
+        // id=1 was evicted
+        assert!(!items.iter().any(|a| a.id == 1));
+    }
+
+    #[test]
+    fn empty_store_returns_empty_list() {
+        let store = InMemoryAlertStore::new();
+        let (items, total) = store.list(10, 0);
+        assert_eq!(total, 0);
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    fn severity_derived_correctly() {
+        let store = InMemoryAlertStore::new();
+        store.record(&test_alert(50));
+        store.record(&test_alert(80));
+        store.record(&test_alert(95));
+
+        let (items, _) = store.list(10, 0);
+        // newest first: 95, 80, 50
+        assert_eq!(items[0].severity, super::super::AlertSeverity::Critical);
+        assert_eq!(items[1].severity, super::super::AlertSeverity::Warning);
+        assert_eq!(items[2].severity, super::super::AlertSeverity::Info);
+    }
+
+    #[test]
+    fn ids_auto_increment() {
+        let store = InMemoryAlertStore::new();
+        let id1 = store.record(&test_alert(80));
+        let id2 = store.record(&test_alert(90));
+        let id3 = store.record(&test_alert(95));
+        assert_eq!(id1, 1);
+        assert_eq!(id2, 2);
+        assert_eq!(id3, 3);
+    }
+}

--- a/aa-api/src/alerts/store.rs
+++ b/aa-api/src/alerts/store.rs
@@ -1,0 +1,1 @@
+//! In-memory alert store implementation.

--- a/aa-api/src/lib.rs
+++ b/aa-api/src/lib.rs
@@ -5,6 +5,7 @@
 //! via `utoipa`. CI validates that `openapi/v1.yaml` stays in sync with
 //! the generated spec — a drift failure blocks merge.
 
+pub mod alerts;
 pub mod auth;
 pub mod config;
 pub mod error;

--- a/aa-api/src/routes/alerts.rs
+++ b/aa-api/src/routes/alerts.rs
@@ -39,11 +39,25 @@ pub struct AlertResponse {
     tag = "alerts"
 )]
 pub async fn list_alerts(
-    Extension(_state): Extension<AppState>,
+    Extension(state): Extension<AppState>,
     axum::extract::Query(params): axum::extract::Query<PaginationParams>,
 ) -> impl IntoResponse {
-    // TODO: wire to alert store once available
-    let items: Vec<AlertResponse> = Vec::new();
+    let limit = params.per_page() as usize;
+    let offset = params.offset();
+
+    let (stored, total) = state.alert_store.list(limit, offset);
+
+    let items: Vec<AlertResponse> = stored
+        .into_iter()
+        .map(|a| AlertResponse {
+            id: a.id.to_string(),
+            severity: a.severity.to_string(),
+            category: "budget".to_string(),
+            message: a.message,
+            timestamp: a.timestamp,
+            agent_id: Some(a.agent_id),
+        })
+        .collect();
 
     (
         StatusCode::OK,
@@ -51,7 +65,7 @@ pub async fn list_alerts(
             items,
             page: params.page(),
             per_page: params.per_page(),
-            total: 0,
+            total,
         }),
     )
 }

--- a/aa-api/src/server.rs
+++ b/aa-api/src/server.rs
@@ -41,6 +41,11 @@ pub fn build_app(state: AppState) -> Router {
 ///
 /// [`DRAIN_TIMEOUT`]: crate::shutdown::DRAIN_TIMEOUT
 pub async fn run_server(config: ApiConfig, state: AppState) -> Result<(), Box<dyn std::error::Error>> {
+    // Spawn background task to capture budget alerts into the alert store.
+    let budget_rx = state.events.subscribe_budget();
+    let _alert_capture_handle =
+        crate::alerts::capture::spawn_alert_capture(budget_rx, state.alert_store.clone());
+
     let app = build_app(state);
 
     let listener = TcpListener::bind(config.bind_addr).await?;

--- a/aa-api/src/server.rs
+++ b/aa-api/src/server.rs
@@ -43,8 +43,7 @@ pub fn build_app(state: AppState) -> Router {
 pub async fn run_server(config: ApiConfig, state: AppState) -> Result<(), Box<dyn std::error::Error>> {
     // Spawn background task to capture budget alerts into the alert store.
     let budget_rx = state.events.subscribe_budget();
-    let _alert_capture_handle =
-        crate::alerts::capture::spawn_alert_capture(budget_rx, state.alert_store.clone());
+    let _alert_capture_handle = crate::alerts::capture::spawn_alert_capture(budget_rx, state.alert_store.clone());
 
     let app = build_app(state);
 

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -9,6 +9,7 @@ use aa_gateway::policy::history::PolicyHistoryStore;
 use aa_gateway::registry::AgentRegistry;
 use aa_runtime::approval::ApprovalQueue;
 
+use crate::alerts::AlertStore;
 use crate::auth::api_key::ApiKeyStore;
 use crate::auth::config::AuthConfig;
 use crate::auth::jwt::{JwtSigner, JwtVerifier};
@@ -29,6 +30,8 @@ pub struct AppState {
     pub approval_queue: Arc<ApprovalQueue>,
     /// Policy version history store.
     pub policy_history: Arc<dyn PolicyHistoryStore>,
+    /// Persistent alert store for budget alerts.
+    pub alert_store: Arc<dyn AlertStore>,
     /// Unified event broadcast bus for streaming to clients.
     pub events: Arc<EventBroadcast>,
     /// Circular replay buffer for reconnecting WebSocket clients.

--- a/aa-api/tests/alerts.rs
+++ b/aa-api/tests/alerts.rs
@@ -2,6 +2,8 @@
 
 mod common;
 
+use aa_core::AgentId;
+use aa_gateway::budget::types::BudgetAlert;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use tower::ServiceExt;
@@ -44,4 +46,137 @@ async fn list_alerts_respects_pagination_params() {
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["page"], 3);
     assert_eq!(json["per_page"], 5);
+}
+
+#[tokio::test]
+async fn list_alerts_returns_alerts_after_recording() {
+    let state = common::test_state();
+    let alert_store = state.alert_store.clone();
+
+    // Record an alert directly into the store.
+    let alert = BudgetAlert {
+        agent_id: AgentId::from_bytes([0xAB; 16]),
+        threshold_pct: 80,
+        spent_usd: 8.0,
+        limit_usd: 10.0,
+    };
+    alert_store.record(&alert);
+
+    let app = aa_api::server::build_app(state);
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/alerts").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["total"], 1);
+
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["severity"], "warning");
+    assert_eq!(items[0]["category"], "budget");
+    assert!(items[0]["message"].as_str().unwrap().contains("80%"));
+    assert!(items[0]["agent_id"].is_string());
+    assert!(items[0]["timestamp"].is_string());
+    assert!(items[0]["id"].is_string());
+}
+
+#[tokio::test]
+async fn list_alerts_via_broadcast_capture() {
+    let state = common::test_state();
+    let budget_tx = state.events.budget_sender();
+    let budget_rx = state.events.subscribe_budget();
+    let alert_store = state.alert_store.clone();
+
+    // Spawn the capture task.
+    let _handle = aa_api::alerts::capture::spawn_alert_capture(budget_rx, alert_store);
+
+    // Send an alert via broadcast.
+    let alert = BudgetAlert {
+        agent_id: AgentId::from_bytes([0xCD; 16]),
+        threshold_pct: 95,
+        spent_usd: 9.5,
+        limit_usd: 10.0,
+    };
+    budget_tx.send(alert).unwrap();
+
+    // Give the capture task a moment to process.
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let app = aa_api::server::build_app(state);
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/alerts").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["total"], 1);
+
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items[0]["severity"], "critical");
+}
+
+#[tokio::test]
+async fn list_alerts_pagination_with_multiple_alerts() {
+    let state = common::test_state();
+    let alert_store = state.alert_store.clone();
+
+    // Record 5 alerts.
+    for i in 0..5u8 {
+        let alert = BudgetAlert {
+            agent_id: AgentId::from_bytes([i + 1; 16]),
+            threshold_pct: 80 + i,
+            spent_usd: 8.0 + f64::from(i),
+            limit_usd: 15.0,
+        };
+        alert_store.record(&alert);
+    }
+
+    let app = aa_api::server::build_app(state);
+
+    // Request page 1 with 2 items per page.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/alerts?page=1&per_page=2")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["total"], 5);
+    assert_eq!(json["page"], 1);
+    assert_eq!(json["per_page"], 2);
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 2);
+    // Newest first: IDs 5, 4
+    assert_eq!(items[0]["id"], "5");
+    assert_eq!(items[1]["id"], "4");
+
+    // Request page 3 with 2 items per page → should get 1 item (ID 1).
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/alerts?page=3&per_page=2")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["id"], "1");
 }

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use std::sync::atomic::{AtomicU64, AtomicUsize};
 use std::sync::Arc;
 
+use aa_api::alerts::store::InMemoryAlertStore;
 use aa_api::auth::api_key::{ApiKey, ApiKeyEntry, ApiKeyStore};
 use aa_api::auth::config::{AuthConfig, AuthMode};
 use aa_api::auth::jwt::{JwtSigner, JwtVerifier};
@@ -108,6 +109,7 @@ spec:
     let jwt_signer = Arc::new(JwtSigner::new(secret));
     let jwt_verifier = Arc::new(JwtVerifier::new(secret));
     let rate_limiter = Arc::new(RateLimiter::new(rpm));
+    let alert_store: Arc<InMemoryAlertStore> = Arc::new(InMemoryAlertStore::new());
 
     AppState {
         agent_registry,
@@ -115,6 +117,7 @@ spec:
         budget_tracker,
         approval_queue,
         policy_history,
+        alert_store,
         events,
         replay_buffer: ReplayBuffer::new(),
         next_event_id: Arc::new(AtomicU64::new(0)),


### PR DESCRIPTION
## Summary

- **AlertStore trait + InMemoryAlertStore**: Bounded ring buffer (VecDeque, 10k default capacity) that stores `BudgetAlert` events with auto-incremented IDs, timestamps, and derived severity levels. Supports paginated listing in newest-first order.
- **Background capture task**: Spawns a tokio task on server startup that subscribes to the existing `BudgetAlert` broadcast channel and records each alert to the store. Handles `RecvError::Lagged` gracefully.
- **Wired `GET /api/v1/alerts`**: Replaces the empty stub from AAASM-81 with real queries to the AlertStore, mapping `StoredAlert` to `AlertResponse` with proper pagination.

### New modules

| File | Purpose |
|---|---|
| `aa-api/src/alerts/mod.rs` | `StoredAlert`, `AlertSeverity`, `AlertStore` trait, severity derivation |
| `aa-api/src/alerts/store.rs` | `InMemoryAlertStore` (VecDeque ring buffer) |
| `aa-api/src/alerts/capture.rs` | Background broadcast → store capture task |

### Modified files

| File | Change |
|---|---|
| `aa-api/src/state.rs` | Added `alert_store: Arc<dyn AlertStore>` |
| `aa-api/src/server.rs` | Spawn capture task on startup |
| `aa-api/src/routes/alerts.rs` | Wire handler to AlertStore |
| `aa-api/src/lib.rs` | Export `alerts` module |
| `aa-api/tests/common/mod.rs` | Add InMemoryAlertStore to test state |

### Test coverage

- **7 unit tests**: record/list, newest-first ordering, pagination, capacity eviction, severity derivation, auto-increment IDs
- **5 integration tests**: empty state, pagination params, direct recording, broadcast capture, multi-page pagination

Closes AAASM-170

## Test plan

- [x] All 7 alert store unit tests pass
- [x] All 5 alert integration tests pass
- [x] Full aa-api test suite passes (0 failures)
- [x] Clippy and fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)