### PR TITLE
[AAASM-168] ✨ (logs): Wire GET /api/v1/logs with AuditReader

### DIFF
--- a/aa-api/Cargo.toml
+++ b/aa-api/Cargo.toml
@@ -30,6 +30,7 @@ utoipa = { version = "4", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "7", features = ["axum"] }
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
+hex = "0.4"
 tokio-stream = "0.1"
 uuid = { version = "1", features = ["v4"] }
 

--- a/aa-api/src/routes/logs.rs
+++ b/aa-api/src/routes/logs.rs
@@ -3,8 +3,8 @@
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::{Extension, Json};
-use serde::Serialize;
-use utoipa::ToSchema;
+use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
 
 use crate::pagination::{PaginatedResponse, PaginationParams};
 use crate::state::AppState;
@@ -12,38 +12,80 @@ use crate::state::AppState;
 /// JSON representation of an audit log entry.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct LogEntry {
-    /// Unique log entry identifier.
-    pub id: String,
+    /// Monotonic sequence number within the session.
+    pub seq: u64,
     /// ISO 8601 timestamp of the event.
     pub timestamp: String,
-    /// Agent ID that produced this log entry.
+    /// Hex-encoded agent ID that produced this log entry.
     pub agent_id: String,
-    /// Session ID for the agent run.
+    /// Hex-encoded session ID for the agent run.
     pub session_id: String,
     /// Type of audit event.
     pub event_type: String,
-    /// Human-readable summary of the event.
-    pub summary: String,
+    /// Pre-serialized JSON payload.
+    pub payload: String,
+}
+
+/// Optional filter parameters for the audit log query.
+#[derive(Debug, Clone, Deserialize, IntoParams)]
+pub struct LogFilterParams {
+    /// Filter by hex-encoded agent ID.
+    pub agent_id: Option<String>,
+    /// Filter by event type name (e.g. `PolicyViolation`).
+    pub event_type: Option<String>,
 }
 
 /// `GET /api/v1/logs` — paginated audit log query.
 ///
 /// Query the paginated audit log of governance events.
+/// Supports optional filtering by agent ID and event type.
 #[utoipa::path(
     get,
     path = "/api/v1/logs",
-    params(PaginationParams),
+    params(PaginationParams, LogFilterParams),
     responses(
         (status = 200, description = "Paginated audit log entries", body = Vec<LogEntry>)
     ),
     tag = "logs"
 )]
 pub async fn list_logs(
-    Extension(_state): Extension<AppState>,
+    Extension(state): Extension<AppState>,
     axum::extract::Query(params): axum::extract::Query<PaginationParams>,
+    axum::extract::Query(filters): axum::extract::Query<LogFilterParams>,
 ) -> impl IntoResponse {
-    // TODO: wire to audit store once available
-    let items: Vec<LogEntry> = Vec::new();
+    let limit = params.per_page() as usize;
+    let offset = params.offset();
+
+    let (entries, total) = state
+        .audit_reader
+        .list(
+            limit,
+            offset,
+            filters.agent_id.as_deref(),
+            filters.event_type.as_deref(),
+        )
+        .await
+        .unwrap_or_default();
+
+    let items: Vec<LogEntry> = entries
+        .into_iter()
+        .map(|e| {
+            let ts_secs = e.timestamp_ns() / 1_000_000_000;
+            let ts_nanos = (e.timestamp_ns() % 1_000_000_000) as u32;
+            let timestamp = chrono::DateTime::from_timestamp(ts_secs as i64, ts_nanos)
+                .map(|dt| dt.to_rfc3339())
+                .unwrap_or_default();
+
+            LogEntry {
+                seq: e.seq(),
+                timestamp,
+                agent_id: hex::encode(e.agent_id().as_bytes()),
+                session_id: hex::encode(e.session_id().as_bytes()),
+                event_type: e.event_type().as_str().to_string(),
+                payload: e.payload().to_string(),
+            }
+        })
+        .collect();
 
     (
         StatusCode::OK,
@@ -51,7 +93,7 @@ pub async fn list_logs(
             items,
             page: params.page(),
             per_page: params.per_page(),
-            total: 0,
+            total,
         }),
     )
 }

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -7,6 +7,7 @@ use aa_gateway::budget::tracker::BudgetTracker;
 use aa_gateway::engine::PolicyEngine;
 use aa_gateway::policy::history::PolicyHistoryStore;
 use aa_gateway::registry::AgentRegistry;
+use aa_gateway::AuditReader;
 use aa_runtime::approval::ApprovalQueue;
 
 use crate::alerts::AlertStore;
@@ -51,4 +52,6 @@ pub struct AppState {
     pub jwt_verifier: Arc<JwtVerifier>,
     /// Session trace storage for the trace query endpoint.
     pub trace_store: Arc<dyn TraceStore>,
+    /// Audit log reader for querying JSONL entries.
+    pub audit_reader: Arc<AuditReader>,
 }

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -20,6 +20,7 @@ use aa_gateway::budget::tracker::BudgetTracker;
 use aa_gateway::engine::PolicyEngine;
 use aa_gateway::policy::history::{FsHistoryStore, HistoryConfig};
 use aa_gateway::registry::AgentRegistry;
+use aa_gateway::AuditReader;
 use aa_runtime::approval::ApprovalQueue;
 use axum::Router;
 
@@ -112,6 +113,11 @@ spec:
     let rate_limiter = Arc::new(RateLimiter::new(rpm));
     let alert_store: Arc<InMemoryAlertStore> = Arc::new(InMemoryAlertStore::new());
 
+    let audit_id = TEMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let audit_dir = std::env::temp_dir().join(format!("aa-api-test-audit-{}-{audit_id}", std::process::id()));
+    std::fs::create_dir_all(&audit_dir).unwrap();
+    let audit_reader = Arc::new(AuditReader::new(audit_dir));
+
     AppState {
         agent_registry,
         policy_engine,
@@ -128,6 +134,7 @@ spec:
         jwt_signer,
         jwt_verifier,
         trace_store: Arc::new(InMemoryTraceStore::new()),
+        audit_reader,
     }
 }
 

--- a/aa-api/tests/logs.rs
+++ b/aa-api/tests/logs.rs
@@ -2,9 +2,68 @@
 
 mod common;
 
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+
+use aa_core::audit::{AuditEntry, AuditEventType};
+use aa_core::{AgentId, SessionId};
+use aa_gateway::AuditReader;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use tower::ServiceExt;
+
+const AGENT_BYTES: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+const SESSION_BYTES: [u8; 16] = [17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32];
+const GENESIS_HASH: [u8; 32] = [0u8; 32];
+
+/// Counter for unique temp directories.
+static DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Create a test state with a custom audit directory.
+fn test_app_with_audit_dir(audit_dir: &std::path::Path) -> axum::Router {
+    let mut state = common::test_state();
+    state.audit_reader = Arc::new(AuditReader::new(audit_dir.to_path_buf()));
+    aa_api::server::build_app(state)
+}
+
+/// Write JSONL audit entries to a file in the given directory.
+fn write_entries_to_dir(dir: &std::path::Path, entries: &[AuditEntry]) {
+    let filename = format!("{}-{}.jsonl", hex::encode(AGENT_BYTES), hex::encode(SESSION_BYTES));
+    let path = dir.join(filename);
+    let mut contents = String::new();
+    for entry in entries {
+        contents.push_str(&serde_json::to_string(entry).unwrap());
+        contents.push('\n');
+    }
+    std::fs::write(path, contents).unwrap();
+}
+
+/// Build a chain of N audit entries.
+fn make_entry_chain(n: usize, event_type: AuditEventType) -> Vec<AuditEntry> {
+    let mut entries = Vec::with_capacity(n);
+    let mut prev_hash = GENESIS_HASH;
+    for i in 0..n {
+        let entry = AuditEntry::new(
+            i as u64,
+            1_714_222_134_000_000_000 + (i as u64 * 1_000_000_000),
+            event_type,
+            AgentId::from_bytes(AGENT_BYTES),
+            SessionId::from_bytes(SESSION_BYTES),
+            format!("{{\"seq\":{i}}}"),
+            prev_hash,
+        );
+        prev_hash = *entry.entry_hash();
+        entries.push(entry);
+    }
+    entries
+}
+
+fn unique_audit_dir() -> std::path::PathBuf {
+    let id = DIR_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("aa-logs-test-{}-{id}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
 
 #[tokio::test]
 async fn list_logs_returns_200_empty() {
@@ -44,4 +103,113 @@ async fn list_logs_respects_pagination_params() {
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["page"], 2);
     assert_eq!(json["per_page"], 10);
+}
+
+#[tokio::test]
+async fn list_logs_returns_entries_after_write() {
+    let dir = unique_audit_dir();
+    let entries = make_entry_chain(3, AuditEventType::ToolCallIntercepted);
+    write_entries_to_dir(&dir, &entries);
+
+    let app = test_app_with_audit_dir(&dir);
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/logs").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["total"], 3);
+
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 3);
+
+    // Entries should be in reverse chronological order (newest first).
+    let first_seq = items[0]["seq"].as_u64().unwrap();
+    let last_seq = items[2]["seq"].as_u64().unwrap();
+    assert!(first_seq > last_seq);
+
+    // Verify fields are present.
+    assert!(items[0]["timestamp"].as_str().unwrap().contains("2024-"));
+    assert_eq!(items[0]["event_type"], "ToolCallIntercepted");
+    assert_eq!(items[0]["agent_id"], hex::encode(AGENT_BYTES));
+    assert_eq!(items[0]["session_id"], hex::encode(SESSION_BYTES));
+}
+
+#[tokio::test]
+async fn list_logs_pagination_works() {
+    let dir = unique_audit_dir();
+    let entries = make_entry_chain(5, AuditEventType::PolicyViolation);
+    write_entries_to_dir(&dir, &entries);
+
+    let app = test_app_with_audit_dir(&dir);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/logs?page=1&per_page=2")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["total"], 5);
+    assert_eq!(json["page"], 1);
+    assert_eq!(json["per_page"], 2);
+    assert_eq!(json["items"].as_array().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn list_logs_filters_by_agent_id() {
+    let dir = unique_audit_dir();
+
+    // Write entries for the standard agent.
+    let entries = make_entry_chain(3, AuditEventType::ToolCallIntercepted);
+    write_entries_to_dir(&dir, &entries);
+
+    // Write entries for a different agent in a separate file.
+    let other_agent: [u8; 16] = [99; 16];
+    let other_session: [u8; 16] = [88; 16];
+    let other_entry = AuditEntry::new(
+        0,
+        1_714_222_134_000_000_000,
+        AuditEventType::PolicyViolation,
+        AgentId::from_bytes(other_agent),
+        SessionId::from_bytes(other_session),
+        String::from("{}"),
+        GENESIS_HASH,
+    );
+    let other_file = dir.join(format!(
+        "{}-{}.jsonl",
+        hex::encode(other_agent),
+        hex::encode(other_session)
+    ));
+    std::fs::write(
+        other_file,
+        format!("{}\n", serde_json::to_string(&other_entry).unwrap()),
+    )
+    .unwrap();
+
+    let app = test_app_with_audit_dir(&dir);
+
+    // Filter by the standard agent — should return 3 entries.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(&format!("/api/v1/logs?agent_id={}", hex::encode(AGENT_BYTES)))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["total"], 3);
 }

--- a/aa-api/tests/logs.rs
+++ b/aa-api/tests/logs.rs
@@ -202,7 +202,7 @@ async fn list_logs_filters_by_agent_id() {
     let response = app
         .oneshot(
             Request::builder()
-                .uri(&format!("/api/v1/logs?agent_id={}", hex::encode(AGENT_BYTES)))
+                .uri(format!("/api/v1/logs?agent_id={}", hex::encode(AGENT_BYTES)))
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/aa-gateway/src/audit_reader.rs
+++ b/aa-gateway/src/audit_reader.rs
@@ -1,0 +1,133 @@
+//! Read-only query interface for JSONL audit log files.
+//!
+//! [`AuditReader`] scans the audit directory produced by [`super::audit::AuditWriter`],
+//! parses JSONL entries, and returns paginated results in reverse chronological order.
+
+use std::io;
+use std::path::PathBuf;
+
+use tokio::io::AsyncBufReadExt;
+
+use aa_core::audit::AuditEventType;
+use aa_core::{AgentId, AuditEntry};
+
+/// Read-only query interface for the JSONL audit log directory.
+///
+/// Reads files directly — does not tap the `AuditWriter` mpsc channel.
+/// Safe to use concurrently with an active writer because each JSONL line
+/// is self-contained and the reader skips incomplete trailing lines.
+pub struct AuditReader {
+    dir: PathBuf,
+}
+
+impl AuditReader {
+    /// Create a new reader targeting the given audit directory.
+    pub fn new(dir: PathBuf) -> Self {
+        Self { dir }
+    }
+
+    /// List audit entries with pagination and optional filters.
+    ///
+    /// Returns `(entries, total_matching)` where entries are sorted in
+    /// reverse chronological order (newest first) and sliced to the
+    /// requested `limit`/`offset` window.
+    pub async fn list(
+        &self,
+        limit: usize,
+        offset: usize,
+        agent_id: Option<&str>,
+        event_type: Option<&str>,
+    ) -> io::Result<(Vec<AuditEntry>, u64)> {
+        let mut all_entries = self.read_all_entries().await?;
+
+        // Parse filter values once.
+        let agent_filter: Option<AgentId> = agent_id.and_then(|s| parse_agent_id(s));
+        let event_filter: Option<AuditEventType> = event_type.and_then(|s| parse_event_type(s));
+
+        // Apply filters.
+        if agent_filter.is_some() || event_filter.is_some() {
+            all_entries.retain(|entry| {
+                if let Some(aid) = &agent_filter {
+                    if entry.agent_id() != *aid {
+                        return false;
+                    }
+                }
+                if let Some(et) = &event_filter {
+                    if entry.event_type() != *et {
+                        return false;
+                    }
+                }
+                true
+            });
+        }
+
+        // Sort by timestamp descending (newest first).
+        all_entries.sort_by(|a, b| b.timestamp_ns().cmp(&a.timestamp_ns()));
+
+        let total = all_entries.len() as u64;
+        let page: Vec<AuditEntry> = all_entries.into_iter().skip(offset).take(limit).collect();
+
+        Ok((page, total))
+    }
+
+    /// Read and parse all JSONL files in the audit directory.
+    async fn read_all_entries(&self) -> io::Result<Vec<AuditEntry>> {
+        let mut entries = Vec::new();
+
+        let mut dir = match tokio::fs::read_dir(&self.dir).await {
+            Ok(d) => d,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(entries),
+            Err(e) => return Err(e),
+        };
+
+        while let Some(entry) = dir.next_entry().await? {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                continue;
+            }
+
+            let file = tokio::fs::File::open(&path).await?;
+            let reader = tokio::io::BufReader::new(file);
+            let mut lines = reader.lines();
+
+            while let Some(line) = lines.next_line().await? {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                // Skip incomplete or corrupt lines (e.g. partial writes).
+                if let Ok(audit_entry) = serde_json::from_str::<AuditEntry>(&line) {
+                    entries.push(audit_entry);
+                }
+            }
+        }
+
+        Ok(entries)
+    }
+}
+
+/// Parse a hex-encoded agent ID string into an [`AgentId`].
+fn parse_agent_id(s: &str) -> Option<AgentId> {
+    let bytes = hex::decode(s).ok()?;
+    if bytes.len() != 16 {
+        return None;
+    }
+    let mut arr = [0u8; 16];
+    arr.copy_from_slice(&bytes);
+    Some(AgentId::from_bytes(arr))
+}
+
+/// Parse an event type string (e.g. `"PolicyViolation"`) into an [`AuditEventType`].
+fn parse_event_type(s: &str) -> Option<AuditEventType> {
+    match s {
+        "ToolCallIntercepted" => Some(AuditEventType::ToolCallIntercepted),
+        "PolicyViolation" => Some(AuditEventType::PolicyViolation),
+        "CredentialLeakBlocked" => Some(AuditEventType::CredentialLeakBlocked),
+        "ApprovalRequested" => Some(AuditEventType::ApprovalRequested),
+        "ApprovalGranted" => Some(AuditEventType::ApprovalGranted),
+        "ApprovalDenied" => Some(AuditEventType::ApprovalDenied),
+        "BudgetLimitApproached" => Some(AuditEventType::BudgetLimitApproached),
+        "BudgetLimitExceeded" => Some(AuditEventType::BudgetLimitExceeded),
+        "ApprovalTimedOut" => Some(AuditEventType::ApprovalTimedOut),
+        _ => None,
+    }
+}

--- a/aa-gateway/src/audit_reader.rs
+++ b/aa-gateway/src/audit_reader.rs
@@ -41,8 +41,8 @@ impl AuditReader {
         let mut all_entries = self.read_all_entries().await?;
 
         // Parse filter values once.
-        let agent_filter: Option<AgentId> = agent_id.and_then(|s| parse_agent_id(s));
-        let event_filter: Option<AuditEventType> = event_type.and_then(|s| parse_event_type(s));
+        let agent_filter: Option<AgentId> = agent_id.and_then(parse_agent_id);
+        let event_filter: Option<AuditEventType> = event_type.and_then(parse_event_type);
 
         // Apply filters.
         if agent_filter.is_some() || event_filter.is_some() {
@@ -62,7 +62,7 @@ impl AuditReader {
         }
 
         // Sort by timestamp descending (newest first).
-        all_entries.sort_by(|a, b| b.timestamp_ns().cmp(&a.timestamp_ns()));
+        all_entries.sort_by_key(|e| std::cmp::Reverse(e.timestamp_ns()));
 
         let total = all_entries.len() as u64;
         let page: Vec<AuditEntry> = all_entries.into_iter().skip(offset).take(limit).collect();

--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod anomaly;
 pub mod audit;
+pub mod audit_reader;
 pub mod budget;
 pub mod engine;
 pub mod events;
@@ -15,6 +16,7 @@ pub mod server;
 pub mod service;
 pub mod simulation;
 
+pub use audit_reader::AuditReader;
 pub use engine::{EvaluationResult, PolicyEngine, PolicyLoadError};
 pub use registry::{AgentRecord, AgentRegistry, AgentStatus};
 pub use service::PolicyServiceImpl;

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -179,6 +179,7 @@ export interface paths {
         /**
          * `GET /api/v1/logs` — paginated audit log query.
          * @description Query the paginated audit log of governance events.
+         *     Supports optional filtering by agent ID and event type.
          */
         get: operations["list_logs"];
         put?: never;
@@ -334,16 +335,19 @@ export interface components {
         };
         /** @description JSON representation of an audit log entry. */
         LogEntry: {
-            /** @description Agent ID that produced this log entry. */
+            /** @description Hex-encoded agent ID that produced this log entry. */
             agent_id: string;
             /** @description Type of audit event. */
             event_type: string;
-            /** @description Unique log entry identifier. */
-            id: string;
-            /** @description Session ID for the agent run. */
+            /** @description Pre-serialized JSON payload. */
+            payload: string;
+            /**
+             * Format: int64
+             * @description Monotonic sequence number within the session.
+             */
+            seq: number;
+            /** @description Hex-encoded session ID for the agent run. */
             session_id: string;
-            /** @description Human-readable summary of the event. */
-            summary: string;
             /** @description ISO 8601 timestamp of the event. */
             timestamp: string;
         };
@@ -687,6 +691,10 @@ export interface operations {
                 page?: number | null;
                 /** @description Items per page (max 100). Defaults to 50. */
                 per_page?: number | null;
+                /** @description Filter by hex-encoded agent ID. */
+                agent_id?: string | null;
+                /** @description Filter by event type name (e.g. `PolicyViolation`). */
+                event_type?: string | null;
             };
             header?: never;
             path?: never;

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -270,7 +270,9 @@ paths:
       tags:
       - logs
       summary: '`GET /api/v1/logs` — paginated audit log query.'
-      description: Query the paginated audit log of governance events.
+      description: |-
+        Query the paginated audit log of governance events.
+        Supports optional filtering by agent ID and event type.
       operationId: list_logs
       parameters:
       - name: page
@@ -292,6 +294,20 @@ paths:
           nullable: true
           maximum: 100
           minimum: 1
+      - name: agent_id
+        in: query
+        description: Filter by hex-encoded agent ID.
+        required: false
+        schema:
+          type: string
+          nullable: true
+      - name: event_type
+        in: query
+        description: Filter by event type name (e.g. `PolicyViolation`).
+        required: false
+        schema:
+          type: string
+          nullable: true
       responses:
         '200':
           description: Paginated audit log entries
@@ -545,28 +561,30 @@ components:
       type: object
       description: JSON representation of an audit log entry.
       required:
-      - id
+      - seq
       - timestamp
       - agent_id
       - session_id
       - event_type
-      - summary
+      - payload
       properties:
         agent_id:
           type: string
-          description: Agent ID that produced this log entry.
+          description: Hex-encoded agent ID that produced this log entry.
         event_type:
           type: string
           description: Type of audit event.
-        id:
+        payload:
           type: string
-          description: Unique log entry identifier.
+          description: Pre-serialized JSON payload.
+        seq:
+          type: integer
+          format: int64
+          description: Monotonic sequence number within the session.
+          minimum: 0
         session_id:
           type: string
-          description: Session ID for the agent run.
-        summary:
-          type: string
-          description: Human-readable summary of the event.
+          description: Hex-encoded session ID for the agent run.
         timestamp:
           type: string
           description: ISO 8601 timestamp of the event.


### PR DESCRIPTION
## Description

Wire the `GET /api/v1/logs` stub endpoint to read real audit log entries from JSONL files produced by `AuditWriter`. Introduces `AuditReader` in `aa-gateway` as a complementary read-only query interface, adds it to `AppState`, and maps `AuditEntry` fields to `LogEntry` response DTOs with ISO 8601 timestamps, hex-encoded IDs, and optional `agent_id`/`event_type` query filters.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] Yes — `LogEntry` fields changed from `{id, summary}` to `{seq, payload}` to reflect actual audit data. `AppState` gains a new required `audit_reader` field.

## Related Issues

- Related Jira ticket: AAASM-168
- Epic: AAASM-9

## Testing

- [x] Integration tests added / updated
  - `list_logs_returns_200_empty` — fresh state returns empty items
  - `list_logs_returns_entries_after_write` — writes JSONL, queries, verifies reverse chronological order and field mapping
  - `list_logs_pagination_works` — writes 5 entries, requests page=1 per_page=2, verifies total/page/items
  - `list_logs_filters_by_agent_id` — writes entries for 2 agents, filters by one, verifies count
  - `list_logs_respects_pagination_params` — verifies page/per_page params are echoed

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention