### PR TITLE
[AAASM-167] ✨ api(policies): Wire GET /api/v1/policies/active endpoint

### DIFF
--- a/aa-api/src/routes/policies.rs
+++ b/aa-api/src/routes/policies.rs
@@ -127,8 +127,16 @@ pub async fn create_policy(
     tag = "policies"
 )]
 pub async fn get_active_policy(
-    Extension(_state): Extension<AppState>,
+    Extension(state): Extension<AppState>,
 ) -> Result<(StatusCode, Json<PolicyResponse>), ProblemDetail> {
-    // TODO: read active policy from engine
-    Err(ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail("No active policy loaded"))
+    let info = state.policy_engine.active_policy_info();
+    Ok((
+        StatusCode::OK,
+        Json(PolicyResponse {
+            name: info.name.unwrap_or_else(|| "unnamed".to_string()),
+            version: info.policy_version.unwrap_or_else(|| "unknown".to_string()),
+            active: true,
+            rule_count: info.rule_count,
+        }),
+    ))
 }

--- a/aa-api/tests/policies.rs
+++ b/aa-api/tests/policies.rs
@@ -16,6 +16,21 @@ spec:
   rules: []
 "#;
 
+const ENVELOPE_POLICY_WITH_TOOLS: &str = r#"
+apiVersion: agent-assembly.dev/v1alpha1
+kind: GovernancePolicy
+metadata:
+  name: production-policy
+  version: "2.0.0"
+spec:
+  tools:
+    shell_exec:
+      allow: false
+    web_search:
+      allow: true
+      limit_per_hour: 50
+"#;
+
 const INVALID_POLICY_YAML: &str = "this is not valid yaml: [";
 
 #[tokio::test]
@@ -107,4 +122,83 @@ async fn list_policies_returns_created_versions() {
     assert_eq!(items.len(), 1);
     assert_eq!(items[0]["active"], true);
     assert!(items[0]["version"].as_str().is_some());
+}
+
+// ── GET /api/v1/policies/active ─────────────────────────────────────────
+
+#[tokio::test]
+async fn get_active_policy_returns_200() {
+    let app = common::test_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/policies/active")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn get_active_policy_returns_metadata_from_envelope() {
+    let app = common::test_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/policies/active")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    // The test_state() loads an envelope policy with name=test-policy, version=0.1.0.
+    assert_eq!(json["name"], "test-policy");
+    assert_eq!(json["version"], "0.1.0");
+    assert_eq!(json["active"], true);
+    assert_eq!(json["rule_count"], 0);
+}
+
+#[tokio::test]
+async fn get_active_policy_reflects_applied_policy() {
+    let state = common::test_state();
+
+    // Apply a policy with tool rules so rule_count > 0.
+    state
+        .policy_engine
+        .apply_yaml(ENVELOPE_POLICY_WITH_TOOLS, Some("test"), state.policy_history.as_ref())
+        .await
+        .unwrap();
+
+    let app = aa_api::server::build_app(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/policies/active")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["name"], "production-policy");
+    assert_eq!(json["version"], "2.0.0");
+    assert_eq!(json["active"], true);
+    assert_eq!(json["rule_count"], 2);
 }

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -449,6 +449,16 @@ impl PolicyEngine {
     ///
     /// Used by the persistence layer to spawn the background writer and
     /// to perform the final save on graceful shutdown.
+    /// Return a lightweight summary of the currently active policy.
+    pub fn active_policy_info(&self) -> ActivePolicyInfo {
+        let doc = self.policy.load();
+        ActivePolicyInfo {
+            name: doc.name.clone(),
+            policy_version: doc.policy_version.clone(),
+            rule_count: doc.tools.len(),
+        }
+    }
+
     pub fn budget_tracker(&self) -> Arc<BudgetTracker> {
         Arc::clone(&self.budget)
     }

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -48,6 +48,18 @@ pub struct EvaluationResult {
     pub deny_action: Option<DenyAction>,
 }
 
+/// Summary of the currently active policy, returned by
+/// [`PolicyEngine::active_policy_info`].
+#[derive(Debug, Clone)]
+pub struct ActivePolicyInfo {
+    /// Policy name from YAML envelope `metadata.name`.
+    pub name: Option<String>,
+    /// Policy version from YAML envelope `metadata.version`.
+    pub policy_version: Option<String>,
+    /// Number of per-tool rules in the active policy.
+    pub rule_count: usize,
+}
+
 /// Assembled policy engine that evaluates governance actions through a 7-step pipeline.
 pub struct PolicyEngine {
     policy: Arc<ArcSwap<PolicyDocument>>,

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -491,6 +491,8 @@ mod tests {
 
     fn empty_doc() -> PolicyDocument {
         PolicyDocument {
+            name: None,
+            policy_version: None,
             version: None,
             network: None,
             schedule: None,

--- a/aa-gateway/src/policy/document.rs
+++ b/aa-gateway/src/policy/document.rs
@@ -69,6 +69,12 @@ pub struct ToolPolicy {
 /// Fully validated policy document produced by [`super::validator::PolicyValidator`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct PolicyDocument {
+    /// Human-readable policy name from the YAML envelope `metadata.name`.
+    /// `None` when parsed from the flat (non-envelope) format.
+    pub name: Option<String>,
+    /// Policy revision version from the YAML envelope `metadata.version`.
+    /// `None` when parsed from the flat (non-envelope) format.
+    pub policy_version: Option<String>,
     /// Schema version string.
     pub version: Option<String>,
     /// Network egress policy.
@@ -92,6 +98,8 @@ mod tests {
     #[test]
     fn policy_document_default_tools_is_empty_map() {
         let doc = PolicyDocument {
+            name: None,
+            policy_version: None,
             version: None,
             network: None,
             schedule: None,

--- a/aa-gateway/src/policy/raw.rs
+++ b/aa-gateway/src/policy/raw.rs
@@ -64,6 +64,18 @@ pub struct RawDataPolicy {
     pub unknown: HashMap<String, serde_yaml::Value>,
 }
 
+/// Raw (unvalidated) deserialization target for the `metadata` section
+/// of the governance policy YAML envelope.
+#[derive(Debug, Deserialize)]
+pub struct RawMetadata {
+    /// Human-readable policy name.
+    pub name: Option<String>,
+    /// Semver version string for this policy revision.
+    pub version: Option<String>,
+    /// Optional description text.
+    pub description: Option<String>,
+}
+
 /// Raw (unvalidated) top-level deserialization target for a policy document.
 #[derive(Debug, Deserialize)]
 pub struct RawPolicyDocument {

--- a/aa-gateway/src/policy/raw.rs
+++ b/aa-gateway/src/policy/raw.rs
@@ -76,6 +76,25 @@ pub struct RawMetadata {
     pub description: Option<String>,
 }
 
+/// Raw deserialization target for the governance policy YAML envelope.
+///
+/// Detects the `apiVersion`/`kind`/`metadata`/`spec` wrapper format used by
+/// `policy-examples/*.yaml`. When `spec` is present the inner value is
+/// re-parsed as [`RawPolicyDocument`].
+#[derive(Debug, Deserialize)]
+pub struct GovernancePolicyEnvelope {
+    /// Schema version URI (e.g. `"agent-assembly/v1"`).
+    #[serde(rename = "apiVersion")]
+    pub api_version: Option<String>,
+    /// Resource kind (e.g. `"Policy"`).
+    pub kind: Option<String>,
+    /// Policy metadata (name, version, description).
+    pub metadata: Option<RawMetadata>,
+    /// The inner spec section, kept as an opaque YAML value so it can be
+    /// re-parsed as [`RawPolicyDocument`] by the validator.
+    pub spec: Option<serde_yaml::Value>,
+}
+
 /// Raw (unvalidated) top-level deserialization target for a policy document.
 #[derive(Debug, Deserialize)]
 pub struct RawPolicyDocument {

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -751,4 +751,88 @@ data:
         let errs = result.unwrap_err();
         assert!(errs.iter().any(|e| e.field == "approval_timeout_secs"));
     }
+
+    // ── Envelope vs flat format ────────────────────────────────────────────
+
+    #[test]
+    fn envelope_format_extracts_metadata_name_and_version() {
+        let yaml = r#"
+apiVersion: agent-assembly/v1
+kind: Policy
+metadata:
+  name: my-policy
+  version: "2.0.0"
+spec:
+  budget:
+    daily_limit_usd: 10.0
+"#;
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        assert_eq!(out.document.name, Some("my-policy".to_string()));
+        assert_eq!(out.document.policy_version, Some("2.0.0".to_string()));
+        assert_eq!(out.document.budget.unwrap().daily_limit_usd, Some(10.0));
+    }
+
+    #[test]
+    fn envelope_format_with_tools_parses_spec_correctly() {
+        let yaml = r#"
+apiVersion: agent-assembly/v1
+kind: Policy
+metadata:
+  name: test-policy
+  version: "1.0.0"
+spec:
+  tools:
+    bash:
+      allow: true
+      limit_per_hour: 5
+    file_write:
+      allow: false
+"#;
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        assert_eq!(out.document.name, Some("test-policy".to_string()));
+        assert_eq!(out.document.tools.len(), 2);
+        assert!(out.document.tools["bash"].allow);
+        assert!(!out.document.tools["file_write"].allow);
+    }
+
+    #[test]
+    fn flat_format_has_no_metadata() {
+        let yaml = "budget:\n  daily_limit_usd: 25.0\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        assert!(out.document.name.is_none());
+        assert!(out.document.policy_version.is_none());
+        assert_eq!(out.document.budget.unwrap().daily_limit_usd, Some(25.0));
+    }
+
+    #[test]
+    fn envelope_format_without_metadata_section() {
+        let yaml = r#"
+apiVersion: agent-assembly/v1
+kind: Policy
+spec:
+  budget:
+    daily_limit_usd: 5.0
+"#;
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        assert!(out.document.name.is_none());
+        assert!(out.document.policy_version.is_none());
+        assert_eq!(out.document.budget.unwrap().daily_limit_usd, Some(5.0));
+    }
+
+    #[test]
+    fn envelope_format_validation_errors_propagate() {
+        let yaml = r#"
+apiVersion: agent-assembly/v1
+kind: Policy
+metadata:
+  name: bad-policy
+spec:
+  budget:
+    daily_limit_usd: -1.0
+"#;
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err());
+        let errs = result.unwrap_err();
+        assert!(errs.iter().any(|e| e.field == "budget.daily_limit_usd"));
+    }
 }

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -8,7 +8,7 @@ use crate::policy::{
         ToolPolicy,
     },
     error::{ValidationError, ValidationWarning},
-    raw::RawPolicyDocument,
+    raw::{GovernancePolicyEnvelope, RawPolicyDocument},
 };
 
 /// Result of a successful parse+validate pass.
@@ -30,15 +30,8 @@ impl PolicyValidator {
     /// Returns `Err` with accumulated [`ValidationError`]s when at least one
     /// hard constraint is violated, or when the YAML cannot be parsed.
     pub fn from_yaml(yaml_str: &str) -> Result<PolicyValidatorOutput, Vec<ValidationError>> {
-        // Step 1 — parse raw YAML
-        let raw: RawPolicyDocument = serde_yaml::from_str(yaml_str).map_err(|e| {
-            let line = e.location().map(|l| l.line() as u32);
-            let mut err = ValidationError::new("(document)", format!("YAML parse error: {}", e));
-            if let Some(l) = line {
-                err = err.with_line(l);
-            }
-            vec![err]
-        })?;
+        // Step 1 — try envelope format first (apiVersion/kind/metadata/spec)
+        let (raw, metadata) = Self::parse_yaml(yaml_str)?;
 
         let mut errors: Vec<ValidationError> = Vec::new();
         let mut warnings: Vec<ValidationWarning> = Vec::new();
@@ -82,6 +75,37 @@ impl PolicyValidator {
             },
             warnings,
         })
+    }
+
+    /// Parse YAML string, detecting envelope vs flat format.
+    ///
+    /// Returns the parsed `RawPolicyDocument` and optional metadata extracted
+    /// from the envelope wrapper.
+    fn parse_yaml(
+        yaml_str: &str,
+    ) -> Result<(RawPolicyDocument, Option<crate::policy::raw::RawMetadata>), Vec<ValidationError>> {
+        let make_parse_error = |e: serde_yaml::Error| {
+            let line = e.location().map(|l| l.line() as u32);
+            let mut err = ValidationError::new("(document)", format!("YAML parse error: {}", e));
+            if let Some(l) = line {
+                err = err.with_line(l);
+            }
+            vec![err]
+        };
+
+        // Try envelope format: if it has a `spec` key, treat it as wrapped.
+        if let Ok(envelope) = serde_yaml::from_str::<GovernancePolicyEnvelope>(yaml_str) {
+            if let Some(spec_value) = envelope.spec {
+                let raw: RawPolicyDocument =
+                    serde_yaml::from_value(spec_value).map_err(make_parse_error)?;
+                return Ok((raw, envelope.metadata));
+            }
+        }
+
+        // Fall back to flat format (no envelope).
+        let raw: RawPolicyDocument =
+            serde_yaml::from_str(yaml_str).map_err(make_parse_error)?;
+        Ok((raw, None))
     }
 
     // ── Section validators ──────────────────────────────────────────────────

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -61,10 +61,15 @@ impl PolicyValidator {
             return Err(errors);
         }
 
+        let (meta_name, meta_version) = match metadata {
+            Some(m) => (m.name, m.version),
+            None => (None, None),
+        };
+
         Ok(PolicyValidatorOutput {
             document: PolicyDocument {
-                name: None,
-                policy_version: None,
+                name: meta_name,
+                policy_version: meta_version,
                 version: raw.version,
                 network,
                 schedule,

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -101,15 +101,13 @@ impl PolicyValidator {
         // Try envelope format: if it has a `spec` key, treat it as wrapped.
         if let Ok(envelope) = serde_yaml::from_str::<GovernancePolicyEnvelope>(yaml_str) {
             if let Some(spec_value) = envelope.spec {
-                let raw: RawPolicyDocument =
-                    serde_yaml::from_value(spec_value).map_err(make_parse_error)?;
+                let raw: RawPolicyDocument = serde_yaml::from_value(spec_value).map_err(make_parse_error)?;
                 return Ok((raw, envelope.metadata));
             }
         }
 
         // Fall back to flat format (no envelope).
-        let raw: RawPolicyDocument =
-            serde_yaml::from_str(yaml_str).map_err(make_parse_error)?;
+        let raw: RawPolicyDocument = serde_yaml::from_str(yaml_str).map_err(make_parse_error)?;
         Ok((raw, None))
     }
 

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -70,6 +70,8 @@ impl PolicyValidator {
 
         Ok(PolicyValidatorOutput {
             document: PolicyDocument {
+                name: None,
+                policy_version: None,
                 version: raw.version,
                 network,
                 schedule,


### PR DESCRIPTION
## Summary

- Add YAML envelope detection (`GovernancePolicyEnvelope` + `RawMetadata`) so the policy validator correctly parses both envelope (`apiVersion`/`kind`/`metadata`/`spec`) and flat YAML formats
- Propagate `metadata.name` and `metadata.version` from envelope into `PolicyDocument` as `name` and `policy_version` fields
- Add `ActivePolicyInfo` struct and `PolicyEngine::active_policy_info()` accessor
- Wire `GET /api/v1/policies/active` endpoint to return live policy name, version, and rule count instead of a hardcoded 404
- Add 3 integration tests and 5 unit tests covering envelope/flat parsing and endpoint behavior

## Test plan

- [x] All 5 new validator unit tests pass (envelope parsing, flat fallback, metadata wiring)
- [x] All 3 new integration tests pass (200 response, metadata propagation, rule count after apply)
- [x] Full workspace test suite passes (0 failures)
- [x] `cargo check` clean for both `aa-gateway` and `aa-api`

Closes AAASM-167

🤖 Generated with [Claude Code](https://claude.com/claude-code)