### PR TITLE
[AAASM-86] ✨ (cli): Add CLI foundation with config, context, and output management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,14 @@ dependencies = [
  "aa-core",
  "aa-gateway",
  "clap",
+ "clap_complete",
+ "comfy-table",
+ "dirs",
+ "reqwest",
+ "serde",
  "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -919,6 +926,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,6 +966,17 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
+]
 
 [[package]]
 name = "compression-codecs"
@@ -1120,6 +1147,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,6 +1333,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -2135,6 +2194,12 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -4355,6 +4420,12 @@ name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -11,11 +11,18 @@ name = "aasm"
 path = "src/main.rs"
 
 [dependencies]
-aa-core    = { path = "../aa-core" }
-aa-gateway = { path = "../aa-gateway" }
-clap       = { version = "4", features = ["derive"] }
-serde_json = "1"
-tokio      = { version = "1", features = ["full"] }
+aa-core        = { path = "../aa-core" }
+aa-gateway     = { path = "../aa-gateway" }
+clap           = { version = "4", features = ["derive"] }
+clap_complete  = "4"
+comfy-table    = "7"
+dirs           = "6"
+reqwest        = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+serde          = { version = "1", features = ["derive"] }
+serde_json     = "1"
+serde_yaml     = "0.9"
+thiserror      = "2"
+tokio          = { version = "1", features = ["full"] }
 
 [lints]
 workspace = true

--- a/aa-cli/src/commands/completion.rs
+++ b/aa-cli/src/commands/completion.rs
@@ -1,0 +1,20 @@
+//! `aasm completion` — generate shell completion scripts.
+
+use std::process::ExitCode;
+
+use clap::{Args, CommandFactory};
+use clap_complete::{generate, Shell};
+
+/// Arguments for `aasm completion`.
+#[derive(Args)]
+pub struct CompletionArgs {
+    /// Shell to generate completions for.
+    pub shell: Shell,
+}
+
+/// Generate shell completion script and write to stdout.
+pub fn run(args: CompletionArgs) -> ExitCode {
+    let mut cmd = crate::Cli::command();
+    generate(args.shell, &mut cmd, "aasm", &mut std::io::stdout());
+    ExitCode::SUCCESS
+}

--- a/aa-cli/src/commands/context.rs
+++ b/aa-cli/src/commands/context.rs
@@ -71,11 +71,7 @@ fn run_list() -> ExitCode {
     let default_name = cfg.default_context.as_deref().unwrap_or("");
     for (name, ctx) in &cfg.contexts {
         let marker = if name == default_name { " *" } else { "" };
-        let key_status = if ctx.api_key.is_some() {
-            " (key set)"
-        } else {
-            ""
-        };
+        let key_status = if ctx.api_key.is_some() { " (key set)" } else { "" };
         println!("{name}{marker}  {}{key_status}", ctx.api_url);
     }
     ExitCode::SUCCESS

--- a/aa-cli/src/commands/context.rs
+++ b/aa-cli/src/commands/context.rs
@@ -43,3 +43,40 @@ pub struct UseArgs {
     /// Name of the context to set as default.
     pub name: String,
 }
+
+/// Dispatch a context subcommand.
+pub fn dispatch(args: ContextArgs) -> ExitCode {
+    match args.command {
+        ContextCommands::List => run_list(),
+        ContextCommands::Set(set_args) => run_set(set_args),
+        ContextCommands::Use(use_args) => run_use(use_args),
+    }
+}
+
+/// List all configured contexts with their API URLs.
+fn run_list() -> ExitCode {
+    let cfg = match config::load() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if cfg.contexts.is_empty() {
+        println!("No contexts configured. Use `aasm context set` to add one.");
+        return ExitCode::SUCCESS;
+    }
+
+    let default_name = cfg.default_context.as_deref().unwrap_or("");
+    for (name, ctx) in &cfg.contexts {
+        let marker = if name == default_name { " *" } else { "" };
+        let key_status = if ctx.api_key.is_some() {
+            " (key set)"
+        } else {
+            ""
+        };
+        println!("{name}{marker}  {}{key_status}", ctx.api_url);
+    }
+    ExitCode::SUCCESS
+}

--- a/aa-cli/src/commands/context.rs
+++ b/aa-cli/src/commands/context.rs
@@ -1,0 +1,45 @@
+//! `aasm context` — manage named API contexts.
+
+use std::process::ExitCode;
+
+use clap::{Args, Subcommand};
+
+use crate::config;
+
+/// Arguments for the `aasm context` subcommand group.
+#[derive(Args)]
+pub struct ContextArgs {
+    #[command(subcommand)]
+    pub command: ContextCommands,
+}
+
+/// Available context subcommands.
+#[derive(Subcommand)]
+pub enum ContextCommands {
+    /// List all configured contexts.
+    List,
+    /// Set or create a named context.
+    Set(SetArgs),
+    /// Switch the default context.
+    Use(UseArgs),
+}
+
+/// Arguments for `aasm context set`.
+#[derive(Args)]
+pub struct SetArgs {
+    /// Name of the context to create or update.
+    pub name: String,
+    /// API URL for this context.
+    #[arg(long)]
+    pub api_url: String,
+    /// API key for this context (optional).
+    #[arg(long)]
+    pub api_key: Option<String>,
+}
+
+/// Arguments for `aasm context use`.
+#[derive(Args)]
+pub struct UseArgs {
+    /// Name of the context to set as default.
+    pub name: String,
+}

--- a/aa-cli/src/commands/context.rs
+++ b/aa-cli/src/commands/context.rs
@@ -112,3 +112,33 @@ fn run_set(args: SetArgs) -> ExitCode {
     println!("Context '{}' saved.", args.name);
     ExitCode::SUCCESS
 }
+
+/// Switch the default context.
+fn run_use(args: UseArgs) -> ExitCode {
+    let mut cfg = match config::load() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if !cfg.contexts.contains_key(&args.name) {
+        eprintln!("error: context '{}' not found", args.name);
+        eprintln!("Available contexts:");
+        for name in cfg.contexts.keys() {
+            eprintln!("  {name}");
+        }
+        return ExitCode::FAILURE;
+    }
+
+    cfg.default_context = Some(args.name.clone());
+
+    if let Err(e) = config::save(&cfg) {
+        eprintln!("error: {e}");
+        return ExitCode::FAILURE;
+    }
+
+    println!("Switched to context '{}'.", args.name);
+    ExitCode::SUCCESS
+}

--- a/aa-cli/src/commands/context.rs
+++ b/aa-cli/src/commands/context.rs
@@ -80,3 +80,35 @@ fn run_list() -> ExitCode {
     }
     ExitCode::SUCCESS
 }
+
+/// Create or update a named context in the config file.
+fn run_set(args: SetArgs) -> ExitCode {
+    let mut cfg = match config::load() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    cfg.contexts.insert(
+        args.name.clone(),
+        config::ContextConfig {
+            api_url: args.api_url,
+            api_key: args.api_key,
+        },
+    );
+
+    // If this is the first context, make it the default.
+    if cfg.contexts.len() == 1 {
+        cfg.default_context = Some(args.name.clone());
+    }
+
+    if let Err(e) = config::save(&cfg) {
+        eprintln!("error: {e}");
+        return ExitCode::FAILURE;
+    }
+
+    println!("Context '{}' saved.", args.name);
+    ExitCode::SUCCESS
+}

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -4,18 +4,32 @@ use std::process::ExitCode;
 
 use clap::Subcommand;
 
+use crate::config::ResolvedContext;
+
+pub mod completion;
+pub mod context;
 pub mod policy;
+pub mod version;
 
 /// Top-level subcommands for the `aasm` CLI.
 #[derive(Subcommand)]
 pub enum Commands {
     /// Manage governance policies.
     Policy(policy::PolicyArgs),
+    /// Manage named API contexts (connection profiles).
+    Context(context::ContextArgs),
+    /// Generate shell completion scripts.
+    Completion(completion::CompletionArgs),
+    /// Show CLI and gateway version information.
+    Version,
 }
 
 /// Dispatch the parsed CLI command to the appropriate handler.
-pub fn dispatch(cmd: Commands) -> ExitCode {
+pub fn dispatch(cmd: Commands, ctx: &ResolvedContext) -> ExitCode {
     match cmd {
         Commands::Policy(args) => policy::dispatch(args),
+        Commands::Context(args) => context::dispatch(args),
+        Commands::Completion(args) => completion::run(args),
+        Commands::Version => version::run(ctx),
     }
 }

--- a/aa-cli/src/commands/version.rs
+++ b/aa-cli/src/commands/version.rs
@@ -1,0 +1,29 @@
+//! `aasm version` — display CLI and runtime version information.
+
+use std::process::ExitCode;
+
+use crate::config::ResolvedContext;
+
+/// Print CLI version and, if reachable, the gateway runtime version.
+pub fn run(ctx: &ResolvedContext) -> ExitCode {
+    println!("aasm {}", env!("CARGO_PKG_VERSION"));
+    println!("api:  {}", ctx.api_url);
+
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    rt.block_on(async {
+        let client = reqwest::Client::new();
+        let url = format!("{}/api/v1/health", ctx.api_url);
+        match client.get(&url).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                println!("gateway: reachable");
+            }
+            Ok(resp) => {
+                println!("gateway: responded with {}", resp.status());
+            }
+            Err(_) => {
+                println!("gateway: unreachable");
+            }
+        }
+    });
+    ExitCode::SUCCESS
+}

--- a/aa-cli/src/config.rs
+++ b/aa-cli/src/config.rs
@@ -19,3 +19,14 @@ pub struct ContextConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
 }
+
+/// Top-level CLI configuration file schema (`~/.aa/config.yaml`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CliConfig {
+    /// Name of the default context to use when `--context` is not specified.
+    #[serde(default)]
+    pub default_context: Option<String>,
+    /// Named contexts mapping (e.g. `{ "production": { api_url: "..." } }`).
+    #[serde(default)]
+    pub contexts: BTreeMap<String, ContextConfig>,
+}

--- a/aa-cli/src/config.rs
+++ b/aa-cli/src/config.rs
@@ -33,9 +33,7 @@ pub struct CliConfig {
 
 /// Return the config directory path (`~/.aa/`).
 pub fn config_dir() -> PathBuf {
-    dirs::home_dir()
-        .expect("cannot determine home directory")
-        .join(".aa")
+    dirs::home_dir().expect("cannot determine home directory").join(".aa")
 }
 
 /// Return the config file path (`~/.aa/config.yaml`).
@@ -126,9 +124,7 @@ pub fn resolve_context(
         return Ok(ResolvedContext {
             name: Some(name.clone()),
             api_url: ctx.api_url.clone(),
-            api_key: api_key_flag
-                .map(String::from)
-                .or_else(|| ctx.api_key.clone()),
+            api_key: api_key_flag.map(String::from).or_else(|| ctx.api_key.clone()),
         });
     }
 
@@ -204,8 +200,7 @@ mod tests {
     #[test]
     fn resolve_api_url_flag_overrides_everything() {
         let cfg = sample_config();
-        let resolved =
-            resolve_context(&cfg, Some("production"), Some("http://custom:9090"), None).unwrap();
+        let resolved = resolve_context(&cfg, Some("production"), Some("http://custom:9090"), None).unwrap();
         assert!(resolved.name.is_none());
         assert_eq!(resolved.api_url, "http://custom:9090");
     }
@@ -213,8 +208,7 @@ mod tests {
     #[test]
     fn resolve_api_key_flag_overrides_config_key() {
         let cfg = sample_config();
-        let resolved =
-            resolve_context(&cfg, Some("production"), None, Some("override-key")).unwrap();
+        let resolved = resolve_context(&cfg, Some("production"), None, Some("override-key")).unwrap();
         assert_eq!(resolved.api_key.as_deref(), Some("override-key"));
     }
 

--- a/aa-cli/src/config.rs
+++ b/aa-cli/src/config.rs
@@ -78,6 +78,7 @@ pub fn save(config: &CliConfig) -> Result<(), CliError> {
 }
 
 /// Resolved connection parameters after merging CLI flags and config file.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct ResolvedContext {
     /// The context name that was resolved (if any).

--- a/aa-cli/src/config.rs
+++ b/aa-cli/src/config.rs
@@ -139,3 +139,100 @@ pub fn resolve_context(
         api_key: api_key_flag.map(String::from),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_config() -> CliConfig {
+        let mut contexts = BTreeMap::new();
+        contexts.insert(
+            "production".to_string(),
+            ContextConfig {
+                api_url: "https://api.example.com".to_string(),
+                api_key: Some("prod-key".to_string()),
+            },
+        );
+        contexts.insert(
+            "staging".to_string(),
+            ContextConfig {
+                api_url: "https://staging.example.com".to_string(),
+                api_key: None,
+            },
+        );
+        CliConfig {
+            default_context: Some("production".to_string()),
+            contexts,
+        }
+    }
+
+    #[test]
+    fn config_round_trip_yaml() {
+        let cfg = sample_config();
+        let yaml = serde_yaml::to_string(&cfg).unwrap();
+        let parsed: CliConfig = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed.default_context, cfg.default_context);
+        assert_eq!(parsed.contexts.len(), 2);
+    }
+
+    #[test]
+    fn empty_config_deserializes() {
+        let yaml = "{}";
+        let cfg: CliConfig = serde_yaml::from_str(yaml).unwrap();
+        assert!(cfg.default_context.is_none());
+        assert!(cfg.contexts.is_empty());
+    }
+
+    #[test]
+    fn resolve_uses_default_context() {
+        let cfg = sample_config();
+        let resolved = resolve_context(&cfg, None, None, None).unwrap();
+        assert_eq!(resolved.name.as_deref(), Some("production"));
+        assert_eq!(resolved.api_url, "https://api.example.com");
+        assert_eq!(resolved.api_key.as_deref(), Some("prod-key"));
+    }
+
+    #[test]
+    fn resolve_explicit_context_overrides_default() {
+        let cfg = sample_config();
+        let resolved = resolve_context(&cfg, Some("staging"), None, None).unwrap();
+        assert_eq!(resolved.name.as_deref(), Some("staging"));
+        assert_eq!(resolved.api_url, "https://staging.example.com");
+        assert!(resolved.api_key.is_none());
+    }
+
+    #[test]
+    fn resolve_api_url_flag_overrides_everything() {
+        let cfg = sample_config();
+        let resolved =
+            resolve_context(&cfg, Some("production"), Some("http://custom:9090"), None).unwrap();
+        assert!(resolved.name.is_none());
+        assert_eq!(resolved.api_url, "http://custom:9090");
+    }
+
+    #[test]
+    fn resolve_api_key_flag_overrides_config_key() {
+        let cfg = sample_config();
+        let resolved =
+            resolve_context(&cfg, Some("production"), None, Some("override-key")).unwrap();
+        assert_eq!(resolved.api_key.as_deref(), Some("override-key"));
+    }
+
+    #[test]
+    fn resolve_unknown_context_returns_error() {
+        let cfg = sample_config();
+        let result = resolve_context(&cfg, Some("nonexistent"), None, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn resolve_no_config_uses_default_url() {
+        let cfg = CliConfig {
+            default_context: None,
+            contexts: BTreeMap::new(),
+        };
+        let resolved = resolve_context(&cfg, None, None, None).unwrap();
+        assert_eq!(resolved.api_url, "http://localhost:8080");
+        assert!(resolved.name.is_none());
+    }
+}

--- a/aa-cli/src/config.rs
+++ b/aa-cli/src/config.rs
@@ -61,3 +61,20 @@ pub fn load() -> Result<CliConfig, CliError> {
     let config: CliConfig = serde_yaml::from_str(&contents)?;
     Ok(config)
 }
+
+/// Save the CLI configuration to `~/.aa/config.yaml`.
+///
+/// Creates the `~/.aa/` directory if it does not exist.
+pub fn save(config: &CliConfig) -> Result<(), CliError> {
+    let dir = config_dir();
+    if !dir.exists() {
+        std::fs::create_dir_all(&dir).map_err(|e| CliError::Config {
+            path: dir.clone(),
+            source: e,
+        })?;
+    }
+    let path = config_path();
+    let yaml = serde_yaml::to_string(config)?;
+    std::fs::write(&path, yaml).map_err(|e| CliError::Config { path, source: e })?;
+    Ok(())
+}

--- a/aa-cli/src/config.rs
+++ b/aa-cli/src/config.rs
@@ -30,3 +30,34 @@ pub struct CliConfig {
     #[serde(default)]
     pub contexts: BTreeMap<String, ContextConfig>,
 }
+
+/// Return the config directory path (`~/.aa/`).
+pub fn config_dir() -> PathBuf {
+    dirs::home_dir()
+        .expect("cannot determine home directory")
+        .join(".aa")
+}
+
+/// Return the config file path (`~/.aa/config.yaml`).
+pub fn config_path() -> PathBuf {
+    config_dir().join("config.yaml")
+}
+
+/// Load the CLI configuration from `~/.aa/config.yaml`.
+///
+/// Returns a default (empty) config if the file does not exist.
+pub fn load() -> Result<CliConfig, CliError> {
+    let path = config_path();
+    if !path.exists() {
+        return Ok(CliConfig {
+            default_context: None,
+            contexts: BTreeMap::new(),
+        });
+    }
+    let contents = std::fs::read_to_string(&path).map_err(|e| CliError::Config {
+        path: path.clone(),
+        source: e,
+    })?;
+    let config: CliConfig = serde_yaml::from_str(&contents)?;
+    Ok(config)
+}

--- a/aa-cli/src/config.rs
+++ b/aa-cli/src/config.rs
@@ -78,3 +78,64 @@ pub fn save(config: &CliConfig) -> Result<(), CliError> {
     std::fs::write(&path, yaml).map_err(|e| CliError::Config { path, source: e })?;
     Ok(())
 }
+
+/// Resolved connection parameters after merging CLI flags and config file.
+#[derive(Debug, Clone)]
+pub struct ResolvedContext {
+    /// The context name that was resolved (if any).
+    pub name: Option<String>,
+    /// Base URL of the API gateway.
+    pub api_url: String,
+    /// API key for authentication (if any).
+    pub api_key: Option<String>,
+}
+
+/// Resolve the active API context by merging CLI flags with the config file.
+///
+/// Precedence (highest to lowest):
+/// 1. Explicit CLI flags (`--api-url`, `--api-key`)
+/// 2. Named context from config (`--context <name>` or `default_context`)
+/// 3. Built-in default (`http://localhost:8080`)
+pub fn resolve_context(
+    config: &CliConfig,
+    context_flag: Option<&str>,
+    api_url_flag: Option<&str>,
+    api_key_flag: Option<&str>,
+) -> Result<ResolvedContext, CliError> {
+    let default_url = "http://localhost:8080";
+
+    // If explicit --api-url is provided, use it directly (no context lookup).
+    if let Some(url) = api_url_flag {
+        return Ok(ResolvedContext {
+            name: None,
+            api_url: url.to_string(),
+            api_key: api_key_flag.map(String::from),
+        });
+    }
+
+    // Determine which context name to look up.
+    let context_name = context_flag
+        .map(String::from)
+        .or_else(|| config.default_context.clone());
+
+    if let Some(ref name) = context_name {
+        let ctx = config
+            .contexts
+            .get(name)
+            .ok_or_else(|| CliError::ContextNotFound(name.clone()))?;
+        return Ok(ResolvedContext {
+            name: Some(name.clone()),
+            api_url: ctx.api_url.clone(),
+            api_key: api_key_flag
+                .map(String::from)
+                .or_else(|| ctx.api_key.clone()),
+        });
+    }
+
+    // No context specified, no default — use built-in default.
+    Ok(ResolvedContext {
+        name: None,
+        api_url: default_url.to_string(),
+        api_key: api_key_flag.map(String::from),
+    })
+}

--- a/aa-cli/src/config.rs
+++ b/aa-cli/src/config.rs
@@ -1,0 +1,21 @@
+//! Configuration file management for the `aasm` CLI.
+//!
+//! Config is stored at `~/.aa/config.yaml` and contains named contexts,
+//! each with an API URL and optional API key.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::CliError;
+
+/// A named API context (e.g. "production", "staging").
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ContextConfig {
+    /// Base URL of the Agent Assembly API (e.g. `http://localhost:8080`).
+    pub api_url: String,
+    /// Optional API key for authentication.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+}

--- a/aa-cli/src/error.rs
+++ b/aa-cli/src/error.rs
@@ -7,10 +7,7 @@ use std::path::PathBuf;
 pub enum CliError {
     /// Failed to read or write the configuration file.
     #[error("config error at {path}: {source}")]
-    Config {
-        path: PathBuf,
-        source: std::io::Error,
-    },
+    Config { path: PathBuf, source: std::io::Error },
 
     /// The configuration file contains invalid YAML.
     #[error("invalid config YAML: {0}")]

--- a/aa-cli/src/error.rs
+++ b/aa-cli/src/error.rs
@@ -1,0 +1,30 @@
+//! Unified error type for the `aasm` CLI.
+
+use std::path::PathBuf;
+
+/// Errors that can occur during CLI execution.
+#[derive(Debug, thiserror::Error)]
+pub enum CliError {
+    /// Failed to read or write the configuration file.
+    #[error("config error at {path}: {source}")]
+    Config {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    /// The configuration file contains invalid YAML.
+    #[error("invalid config YAML: {0}")]
+    ConfigParse(#[from] serde_yaml::Error),
+
+    /// The requested named context does not exist.
+    #[error("context not found: {0}")]
+    ContextNotFound(String),
+
+    /// An HTTP request to the gateway failed.
+    #[error("API request failed: {0}")]
+    Api(#[from] reqwest::Error),
+
+    /// Generic I/O error.
+    #[error("{0}")]
+    Io(#[from] std::io::Error),
+}

--- a/aa-cli/src/main.rs
+++ b/aa-cli/src/main.rs
@@ -8,11 +8,30 @@ use std::process::ExitCode;
 use clap::Parser;
 
 mod commands;
+mod config;
+mod error;
+mod output;
 
 /// Agent Assembly CLI — governance gateway management tool.
 #[derive(Parser)]
 #[command(name = "aasm", version, about)]
 struct Cli {
+    /// Named context from ~/.aa/config.yaml to use.
+    #[arg(long, global = true)]
+    context: Option<String>,
+
+    /// Output format for list/get commands.
+    #[arg(long, global = true, value_enum, default_value_t = output::OutputFormat::Table)]
+    output: output::OutputFormat,
+
+    /// Override the API URL (takes precedence over context config).
+    #[arg(long, global = true)]
+    api_url: Option<String>,
+
+    /// Override the API key (takes precedence over context config).
+    #[arg(long, global = true)]
+    api_key: Option<String>,
+
     #[command(subcommand)]
     command: commands::Commands,
 }

--- a/aa-cli/src/main.rs
+++ b/aa-cli/src/main.rs
@@ -38,5 +38,27 @@ struct Cli {
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
-    commands::dispatch(cli.command)
+
+    let cfg = match config::load() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error loading config: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let resolved = match config::resolve_context(
+        &cfg,
+        cli.context.as_deref(),
+        cli.api_url.as_deref(),
+        cli.api_key.as_deref(),
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    commands::dispatch(cli.command, &resolved)
 }

--- a/aa-cli/src/output.rs
+++ b/aa-cli/src/output.rs
@@ -1,0 +1,31 @@
+//! Output format selection for CLI commands.
+
+use clap::ValueEnum;
+
+/// Output format for list and get commands.
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+pub enum OutputFormat {
+    /// Human-readable table (default).
+    #[default]
+    Table,
+    /// Machine-readable JSON.
+    Json,
+    /// Machine-readable YAML.
+    Yaml,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_table() {
+        assert!(matches!(OutputFormat::default(), OutputFormat::Table));
+    }
+
+    #[test]
+    fn value_variants_contains_all_formats() {
+        let variants = OutputFormat::value_variants();
+        assert_eq!(variants.len(), 3);
+    }
+}


### PR DESCRIPTION
## Description

Bootstrap the `aa-cli` crate with full CLI foundation infrastructure for the `aasm` command-line tool. This establishes the shared scaffolding that all future subcommands (agent, logs, trace, approvals, status, cost, alerts, dashboard) will build upon.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-86
- Parent Epic: AAASM-10 (CLI Tool — aasm)

## What Changed

### New modules
- **`error.rs`** — `CliError` enum with config, API, I/O error variants
- **`output.rs`** — `OutputFormat` enum (Table/Json/Yaml) with clap `ValueEnum`
- **`config.rs`** — Config file management (`~/.aa/config.yaml`)
  - `ContextConfig` — named API context (url + key)
  - `CliConfig` — top-level config with named contexts
  - `load()` / `save()` — read/write config YAML
  - `resolve_context()` — merge CLI flags > config > defaults
- **`commands/context.rs`** — `aasm context list/set/use` subcommands
- **`commands/completion.rs`** — `aasm completion <shell>` (bash/zsh/fish)
- **`commands/version.rs`** — `aasm version` showing CLI + gateway status

### Updated modules
- **`main.rs`** — global flags (`--context`, `--output`, `--api-url`, `--api-key`), config loading
- **`commands/mod.rs`** — wired Context, Completion, Version into Commands enum
- **`Cargo.toml`** — added serde, serde_yaml, thiserror, dirs, clap_complete, reqwest, comfy-table

### New dependencies
| Crate | Purpose |
|---|---|
| `serde` + `serde_yaml` | Config file serialization |
| `thiserror` | Error enum derives |
| `dirs` | Cross-platform `~/.aa/` resolution |
| `clap_complete` | Shell completion generation |
| `reqwest` (rustls-tls) | HTTP client for REST API (no OpenSSL) |
| `comfy-table` | Table output rendering |

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

### Test coverage
- 8 tests for config module (YAML round-trip, context resolution precedence, error cases)
- 2 tests for output module (default format, variant count)
- Manual smoke test: `--help`, `context set/list/use`, `version`, `completion zsh`, `policy --help`

### Acceptance Criteria verification
- [x] `aasm --help` shows all subcommands with descriptions
- [x] `aasm completion zsh` generates valid completion script
- [x] Context switching works: `--context <name>` resolves correct URL
- [x] `--output json/yaml/table` flag available globally
- [x] No OpenSSL dependency (reqwest with rustls-tls)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention