### PR TITLE
[AAASM-172] 🔌 (openapi): Add auth/token endpoint to OpenAPI spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "chrono-tz",
  "dashmap",
  "futures",
+ "hex",
  "http 1.4.0",
  "hyper",
  "jsonwebtoken",

--- a/aa-api/src/auth/scope.rs
+++ b/aa-api/src/auth/scope.rs
@@ -11,7 +11,7 @@ use super::{AuthError, AuthenticatedCaller};
 ///
 /// Variants are ordered by privilege: `Read < Write < Admin`.
 /// A caller with `Admin` scope satisfies any scope requirement.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum Scope {
     /// Read-only access to resources.

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -1,6 +1,7 @@
 //! OpenAPI spec aggregation via utoipa.
 
 use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
+use utoipa::openapi::ComponentsBuilder;
 use utoipa::{Modify, OpenApi};
 
 use crate::models::trace::{TraceResponse, TraceSpan};
@@ -73,7 +74,9 @@ struct SecurityAddon;
 
 impl Modify for SecurityAddon {
     fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
-        let components = openapi.components.get_or_insert_default();
+        let components = openapi
+            .components
+            .get_or_insert_with(|| ComponentsBuilder::new().build());
         components.add_security_scheme(
             "bearer_auth",
             SecurityScheme::Http(

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -1,9 +1,10 @@
 //! OpenAPI spec aggregation via utoipa.
 
-use utoipa::OpenApi;
+use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
+use utoipa::{Modify, OpenApi};
 
 use crate::models::trace::{TraceResponse, TraceSpan};
-use crate::routes::{agents, alerts, approvals, costs, logs, policies, traces};
+use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, traces};
 
 /// Root OpenAPI document collecting all annotated paths and schemas.
 #[derive(OpenApi)]
@@ -27,6 +28,7 @@ use crate::routes::{agents, alerts, approvals, costs, logs, policies, traces};
         (name = "approvals", description = "Human-in-the-loop approvals"),
         (name = "costs", description = "Cost and budget tracking"),
         (name = "alerts", description = "Governance alerts"),
+        (name = "auth", description = "Authentication and token issuance"),
     ),
     paths(
         crate::routes::health::health,
@@ -43,6 +45,7 @@ use crate::routes::{agents, alerts, approvals, costs, logs, policies, traces};
         approvals::reject_action,
         costs::get_cost_summary,
         alerts::list_alerts,
+        auth::issue_token,
     ),
     components(schemas(
         crate::routes::health::HealthResponse,
@@ -57,6 +60,31 @@ use crate::routes::{agents, alerts, approvals, costs, logs, policies, traces};
         approvals::DecideRequest,
         costs::CostSummary,
         alerts::AlertResponse,
-    ))
+        auth::TokenRequest,
+        auth::TokenResponse,
+        crate::auth::scope::Scope,
+    )),
+    modifiers(&SecurityAddon),
 )]
 pub struct ApiDoc;
+
+/// Adds the `bearer_auth` security scheme to the generated OpenAPI spec.
+struct SecurityAddon;
+
+impl Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        let components = openapi.components.get_or_insert_default();
+        components.add_security_scheme(
+            "bearer_auth",
+            SecurityScheme::Http(
+                HttpBuilder::new()
+                    .scheme(HttpAuthScheme::Bearer)
+                    .bearer_format("JWT")
+                    .description(Some(
+                        "API key (`aa_…` prefix) or JWT bearer token".to_string(),
+                    ))
+                    .build(),
+            ),
+        );
+    }
+}

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -83,9 +83,7 @@ impl Modify for SecurityAddon {
                 HttpBuilder::new()
                     .scheme(HttpAuthScheme::Bearer)
                     .bearer_format("JWT")
-                    .description(Some(
-                        "API key (`aa_…` prefix) or JWT bearer token".to_string(),
-                    ))
+                    .description(Some("API key (`aa_…` prefix) or JWT bearer token".to_string()))
                     .build(),
             ),
         );

--- a/aa-api/src/routes/auth.rs
+++ b/aa-api/src/routes/auth.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use axum::Extension;
 use axum::Json;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::auth::jwt::JwtSigner;
 use crate::auth::scope::Scope;
@@ -15,7 +16,7 @@ use crate::error::ProblemDetail;
 const TOKEN_EXPIRY_SECS: u64 = 24 * 60 * 60;
 
 /// Request body for `POST /auth/token`.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct TokenRequest {
     /// Requested scopes for the issued JWT.
     /// If omitted, the caller's full scopes are used.
@@ -24,7 +25,7 @@ pub struct TokenRequest {
 }
 
 /// Response body for `POST /auth/token`.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct TokenResponse {
     /// The issued JWT token string.
     pub token: String,
@@ -39,6 +40,18 @@ pub struct TokenResponse {
 /// The caller must already be authenticated (via API key or existing JWT).
 /// If `scopes` is provided in the request body, it must be a subset of
 /// the caller's granted scopes.
+#[utoipa::path(
+    post,
+    path = "/api/v1/auth/token",
+    request_body = TokenRequest,
+    responses(
+        (status = 200, description = "JWT issued successfully", body = TokenResponse),
+        (status = 401, description = "Missing or invalid credentials", body = ProblemDetail),
+        (status = 403, description = "Requested scope exceeds caller grants", body = ProblemDetail),
+    ),
+    security(("bearer_auth" = [])),
+    tag = "auth"
+)]
 pub async fn issue_token(
     caller: AuthenticatedCaller,
     Extension(jwt_signer): Extension<Arc<JwtSigner>>,

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -128,6 +128,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/auth/token": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Issue a short-lived JWT token from an authenticated API key.
+         * @description The caller must already be authenticated (via API key or existing JWT).
+         *     If `scopes` is provided in the request body, it must be a subset of
+         *     the caller's granted scopes.
+         */
+        post: operations["issue_token"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/costs": {
         parameters: {
             query?: never;
@@ -387,6 +409,34 @@ export interface components {
             /** @description URI reference identifying the problem type. */
             type: string;
         };
+        /**
+         * @description Authorization scope level for API operations.
+         *
+         *     Variants are ordered by privilege: `Read < Write < Admin`.
+         *     A caller with `Admin` scope satisfies any scope requirement.
+         * @enum {string}
+         */
+        Scope: "read" | "write" | "admin";
+        /** @description Request body for `POST /auth/token`. */
+        TokenRequest: {
+            /**
+             * @description Requested scopes for the issued JWT.
+             *     If omitted, the caller's full scopes are used.
+             */
+            scopes?: components["schemas"]["Scope"][] | null;
+        };
+        /** @description Response body for `POST /auth/token`. */
+        TokenResponse: {
+            /**
+             * Format: int64
+             * @description Unix timestamp when the token expires.
+             */
+            expires_at: number;
+            /** @description Scopes granted in the token. */
+            scopes: components["schemas"]["Scope"][];
+            /** @description The issued JWT token string. */
+            token: string;
+        };
         /** @description Full trace for one agent session. */
         TraceResponse: {
             /** @description Agent that produced this trace. */
@@ -632,6 +682,48 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    issue_token: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TokenRequest"];
+            };
+        };
+        responses: {
+            /** @description JWT issued successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TokenResponse"];
+                };
+            };
+            /** @description Missing or invalid credentials */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Requested scope exceeds caller grants */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
             };
         };
     };

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -229,6 +229,43 @@ paths:
                 $ref: '#/components/schemas/ApprovalResponse'
         '404':
           description: Approval request not found
+  /api/v1/auth/token:
+    post:
+      tags:
+      - auth
+      summary: Issue a short-lived JWT token from an authenticated API key.
+      description: |-
+        The caller must already be authenticated (via API key or existing JWT).
+        If `scopes` is provided in the request body, it must be a subset of
+        the caller's granted scopes.
+      operationId: issue_token
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TokenRequest'
+        required: true
+      responses:
+        '200':
+          description: JWT issued successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+        '401':
+          description: Missing or invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '403':
+          description: Requested scope exceeds caller grants
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+      security:
+      - bearer_auth: []
   /api/v1/costs:
     get:
       tags:
@@ -643,6 +680,50 @@ components:
         status: 404
         title: Not Found
         type: about:blank
+    Scope:
+      type: string
+      description: |-
+        Authorization scope level for API operations.
+
+        Variants are ordered by privilege: `Read < Write < Admin`.
+        A caller with `Admin` scope satisfies any scope requirement.
+      enum:
+      - read
+      - write
+      - admin
+    TokenRequest:
+      type: object
+      description: Request body for `POST /auth/token`.
+      properties:
+        scopes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Scope'
+          description: |-
+            Requested scopes for the issued JWT.
+            If omitted, the caller's full scopes are used.
+          nullable: true
+    TokenResponse:
+      type: object
+      description: Response body for `POST /auth/token`.
+      required:
+      - token
+      - expires_at
+      - scopes
+      properties:
+        expires_at:
+          type: integer
+          format: int64
+          description: Unix timestamp when the token expires.
+          minimum: 0
+        scopes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Scope'
+          description: Scopes granted in the token.
+        token:
+          type: string
+          description: The issued JWT token string.
     TraceResponse:
       type: object
       description: Full trace for one agent session.
@@ -691,6 +772,12 @@ components:
         start_time:
           type: string
           description: Start time of the span (ISO 8601).
+  securitySchemes:
+    bearer_auth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: API key (`aa_…` prefix) or JWT bearer token
 tags:
 - name: health
   description: Liveness and readiness probes
@@ -708,3 +795,5 @@ tags:
   description: Cost and budget tracking
 - name: alerts
   description: Governance alerts
+- name: auth
+  description: Authentication and token issuance


### PR DESCRIPTION
## Description

Add `POST /api/v1/auth/token` to the OpenAPI spec. The endpoint was registered in the Axum router but missing from the generated OpenAPI documentation, violating AAASM-76 AC #5.

Changes:
- Add `#[utoipa::path]` annotation to `issue_token` handler with request/response schemas
- Add `ToSchema` derives to `TokenRequest`, `TokenResponse`, and `Scope`
- Register path, schemas, auth tag, and `bearer_auth` security scheme in `openapi.rs`
- Regenerate `openapi/v1.yaml` and dashboard TypeScript types

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-172
- Parent epic: AAASM-9
- Story: AAASM-76 (AC #5)

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [x] No tests required (annotation-only changes; validated via clippy, Spectral lint, and existing test suite)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention