### PR TITLE
[AAASM-89] ✨ (trace): Implement aasm trace with tree and timeline visualization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,7 @@ dependencies = [
  "aa-gateway",
  "clap",
  "clap_complete",
+ "colored",
  "comfy-table",
  "dirs",
  "owo-colors",
@@ -968,6 +969,15 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "comfy-table"

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -15,6 +15,7 @@ aa-core        = { path = "../aa-core" }
 aa-gateway     = { path = "../aa-gateway" }
 clap           = { version = "4", features = ["derive"] }
 clap_complete  = "4"
+colored        = "3"
 comfy-table    = "7"
 dirs           = "6"
 owo-colors     = "4"

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -39,5 +39,6 @@ pub fn dispatch(cmd: Commands, ctx: &ResolvedContext, output: OutputFormat) -> E
         Commands::Context(args) => context::dispatch(args),
         Commands::Completion(args) => completion::run(args),
         Commands::Version => version::run(ctx),
+        Commands::Trace(args) => trace::dispatch(args, ctx),
     }
 }

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod agent;
 pub mod completion;
 pub mod context;
 pub mod policy;
+pub mod trace;
 pub mod version;
 
 /// Top-level subcommands for the `aasm` CLI.

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -39,6 +39,6 @@ pub fn dispatch(cmd: Commands, ctx: &ResolvedContext, output: OutputFormat) -> E
         Commands::Context(args) => context::dispatch(args),
         Commands::Completion(args) => completion::run(args),
         Commands::Version => version::run(ctx),
-        Commands::Trace(args) => trace::dispatch(args, ctx),
+        Commands::Trace(args) => trace::dispatch(args, ctx, output),
     }
 }

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -27,6 +27,8 @@ pub enum Commands {
     Completion(completion::CompletionArgs),
     /// Show CLI and gateway version information.
     Version,
+    /// Visualize a session trace (tree or timeline).
+    Trace(trace::TraceArgs),
 }
 
 /// Dispatch the parsed CLI command to the appropriate handler.

--- a/aa-cli/src/commands/trace/client.rs
+++ b/aa-cli/src/commands/trace/client.rs
@@ -1,0 +1,12 @@
+//! HTTP client for fetching session traces from the gateway API.
+
+use crate::config::ResolvedContext;
+
+/// Build the full URL for the trace endpoint.
+pub fn build_trace_url(ctx: &ResolvedContext, session_id: &str) -> String {
+    format!(
+        "{}/api/v1/traces/{}",
+        ctx.api_url.trim_end_matches('/'),
+        session_id
+    )
+}

--- a/aa-cli/src/commands/trace/client.rs
+++ b/aa-cli/src/commands/trace/client.rs
@@ -7,18 +7,11 @@ use super::models::SessionTrace;
 
 /// Build the full URL for the trace endpoint.
 pub fn build_trace_url(ctx: &ResolvedContext, session_id: &str) -> String {
-    format!(
-        "{}/api/v1/traces/{}",
-        ctx.api_url.trim_end_matches('/'),
-        session_id
-    )
+    format!("{}/api/v1/traces/{}", ctx.api_url.trim_end_matches('/'), session_id)
 }
 
 /// Fetch a session trace from the gateway API.
-pub async fn fetch_trace(
-    ctx: &ResolvedContext,
-    session_id: &str,
-) -> Result<SessionTrace, CliError> {
+pub async fn fetch_trace(ctx: &ResolvedContext, session_id: &str) -> Result<SessionTrace, CliError> {
     let url = build_trace_url(ctx, session_id);
     let client = reqwest::Client::new();
 

--- a/aa-cli/src/commands/trace/client.rs
+++ b/aa-cli/src/commands/trace/client.rs
@@ -1,6 +1,9 @@
 //! HTTP client for fetching session traces from the gateway API.
 
 use crate::config::ResolvedContext;
+use crate::error::CliError;
+
+use super::models::SessionTrace;
 
 /// Build the full URL for the trace endpoint.
 pub fn build_trace_url(ctx: &ResolvedContext, session_id: &str) -> String {
@@ -9,4 +12,22 @@ pub fn build_trace_url(ctx: &ResolvedContext, session_id: &str) -> String {
         ctx.api_url.trim_end_matches('/'),
         session_id
     )
+}
+
+/// Fetch a session trace from the gateway API.
+pub async fn fetch_trace(
+    ctx: &ResolvedContext,
+    session_id: &str,
+) -> Result<SessionTrace, CliError> {
+    let url = build_trace_url(ctx, session_id);
+    let client = reqwest::Client::new();
+
+    let mut request = client.get(&url);
+    if let Some(ref key) = ctx.api_key {
+        request = request.bearer_auth(key);
+    }
+
+    let response = request.send().await?.error_for_status()?;
+    let trace: SessionTrace = response.json().await?;
+    Ok(trace)
 }

--- a/aa-cli/src/commands/trace/mod.rs
+++ b/aa-cli/src/commands/trace/mod.rs
@@ -68,8 +68,7 @@ pub fn dispatch(args: TraceArgs, ctx: &ResolvedContext, output: OutputFormat) ->
                 print!("{}", tree::render_tree(&trace));
             }
             TraceFormat::Timeline => {
-                // TODO: wire timeline format
-                println!("{trace:?}");
+                print!("{}", timeline::render_timeline(&trace, 80));
             }
         },
     }

--- a/aa-cli/src/commands/trace/mod.rs
+++ b/aa-cli/src/commands/trace/mod.rs
@@ -63,10 +63,15 @@ pub fn dispatch(args: TraceArgs, ctx: &ResolvedContext, output: OutputFormat) ->
                 }
             }
         }
-        OutputFormat::Table => {
-            // TODO: wire tree and timeline formats
-            println!("{trace:?}");
-        }
+        OutputFormat::Table => match args.format {
+            TraceFormat::Tree => {
+                print!("{}", tree::render_tree(&trace));
+            }
+            TraceFormat::Timeline => {
+                // TODO: wire timeline format
+                println!("{trace:?}");
+            }
+        },
     }
 
     ExitCode::SUCCESS

--- a/aa-cli/src/commands/trace/mod.rs
+++ b/aa-cli/src/commands/trace/mod.rs
@@ -45,24 +45,20 @@ pub fn dispatch(args: TraceArgs, ctx: &ResolvedContext, output: OutputFormat) ->
     };
 
     match output {
-        OutputFormat::Json => {
-            match serde_json::to_string_pretty(&trace) {
-                Ok(json) => println!("{json}"),
-                Err(e) => {
-                    eprintln!("error serializing trace: {e}");
-                    return ExitCode::FAILURE;
-                }
+        OutputFormat::Json => match serde_json::to_string_pretty(&trace) {
+            Ok(json) => println!("{json}"),
+            Err(e) => {
+                eprintln!("error serializing trace: {e}");
+                return ExitCode::FAILURE;
             }
-        }
-        OutputFormat::Yaml => {
-            match serde_yaml::to_string(&trace) {
-                Ok(yaml) => print!("{yaml}"),
-                Err(e) => {
-                    eprintln!("error serializing trace: {e}");
-                    return ExitCode::FAILURE;
-                }
+        },
+        OutputFormat::Yaml => match serde_yaml::to_string(&trace) {
+            Ok(yaml) => print!("{yaml}"),
+            Err(e) => {
+                eprintln!("error serializing trace: {e}");
+                return ExitCode::FAILURE;
             }
-        }
+        },
         OutputFormat::Table => match args.format {
             TraceFormat::Tree => {
                 print!("{}", tree::render_tree(&trace));
@@ -107,8 +103,7 @@ mod tests {
 
     #[test]
     fn parse_trace_with_timeline_format() {
-        let cli =
-            TestCli::try_parse_from(["aasm", "trace", "sess-002", "--format", "timeline"]).unwrap();
+        let cli = TestCli::try_parse_from(["aasm", "trace", "sess-002", "--format", "timeline"]).unwrap();
         match cli.command {
             TestCommands::Trace(args) => {
                 assert_eq!(args.session_id, "sess-002");

--- a/aa-cli/src/commands/trace/mod.rs
+++ b/aa-cli/src/commands/trace/mod.rs
@@ -75,3 +75,51 @@ pub fn dispatch(args: TraceArgs, ctx: &ResolvedContext, output: OutputFormat) ->
 
     ExitCode::SUCCESS
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    /// Minimal CLI struct for testing subcommand parsing.
+    #[derive(Parser)]
+    #[command(name = "aasm")]
+    struct TestCli {
+        #[command(subcommand)]
+        command: TestCommands,
+    }
+
+    #[derive(clap::Subcommand)]
+    enum TestCommands {
+        Trace(TraceArgs),
+    }
+
+    #[test]
+    fn parse_trace_with_session_id() {
+        let cli = TestCli::try_parse_from(["aasm", "trace", "sess-001"]).unwrap();
+        match cli.command {
+            TestCommands::Trace(args) => {
+                assert_eq!(args.session_id, "sess-001");
+                assert!(matches!(args.format, TraceFormat::Tree));
+            }
+        }
+    }
+
+    #[test]
+    fn parse_trace_with_timeline_format() {
+        let cli =
+            TestCli::try_parse_from(["aasm", "trace", "sess-002", "--format", "timeline"]).unwrap();
+        match cli.command {
+            TestCommands::Trace(args) => {
+                assert_eq!(args.session_id, "sess-002");
+                assert!(matches!(args.format, TraceFormat::Timeline));
+            }
+        }
+    }
+
+    #[test]
+    fn parse_trace_missing_session_id_fails() {
+        let result = TestCli::try_parse_from(["aasm", "trace"]);
+        assert!(result.is_err());
+    }
+}

--- a/aa-cli/src/commands/trace/mod.rs
+++ b/aa-cli/src/commands/trace/mod.rs
@@ -1,0 +1,15 @@
+//! `aasm trace` — session trace visualization.
+
+use clap::ValueEnum;
+
+pub mod models;
+
+/// Visualization format for trace output.
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+pub enum TraceFormat {
+    /// Indented tree with box-drawing characters (default).
+    #[default]
+    Tree,
+    /// Horizontal ASCII timeline with duration bars.
+    Timeline,
+}

--- a/aa-cli/src/commands/trace/mod.rs
+++ b/aa-cli/src/commands/trace/mod.rs
@@ -5,9 +5,12 @@ use std::process::ExitCode;
 use clap::{Args, ValueEnum};
 
 use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
 
 pub mod client;
 pub mod models;
+pub mod timeline;
+pub mod tree;
 
 /// Visualization format for trace output.
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
@@ -31,6 +34,31 @@ pub struct TraceArgs {
 }
 
 /// Execute the `aasm trace` subcommand.
-pub fn dispatch(_args: TraceArgs, _ctx: &ResolvedContext) -> ExitCode {
+pub fn dispatch(args: TraceArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    let trace = match rt.block_on(client::fetch_trace(ctx, &args.session_id)) {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("error fetching trace: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match output {
+        OutputFormat::Json => {
+            match serde_json::to_string_pretty(&trace) {
+                Ok(json) => println!("{json}"),
+                Err(e) => {
+                    eprintln!("error serializing trace: {e}");
+                    return ExitCode::FAILURE;
+                }
+            }
+        }
+        _ => {
+            // TODO: wire tree and timeline formats
+            println!("{trace:?}");
+        }
+    }
+
     ExitCode::SUCCESS
 }

--- a/aa-cli/src/commands/trace/mod.rs
+++ b/aa-cli/src/commands/trace/mod.rs
@@ -1,6 +1,6 @@
 //! `aasm trace` — session trace visualization.
 
-use clap::ValueEnum;
+use clap::{Args, ValueEnum};
 
 pub mod models;
 
@@ -12,4 +12,15 @@ pub enum TraceFormat {
     Tree,
     /// Horizontal ASCII timeline with duration bars.
     Timeline,
+}
+
+/// Arguments for the `aasm trace` subcommand.
+#[derive(Debug, Args)]
+pub struct TraceArgs {
+    /// Session ID to retrieve the trace for.
+    pub session_id: String,
+
+    /// Visualization format.
+    #[arg(long, value_enum, default_value_t = TraceFormat::Tree)]
+    pub format: TraceFormat,
 }

--- a/aa-cli/src/commands/trace/mod.rs
+++ b/aa-cli/src/commands/trace/mod.rs
@@ -54,7 +54,16 @@ pub fn dispatch(args: TraceArgs, ctx: &ResolvedContext, output: OutputFormat) ->
                 }
             }
         }
-        _ => {
+        OutputFormat::Yaml => {
+            match serde_yaml::to_string(&trace) {
+                Ok(yaml) => print!("{yaml}"),
+                Err(e) => {
+                    eprintln!("error serializing trace: {e}");
+                    return ExitCode::FAILURE;
+                }
+            }
+        }
+        OutputFormat::Table => {
             // TODO: wire tree and timeline formats
             println!("{trace:?}");
         }

--- a/aa-cli/src/commands/trace/mod.rs
+++ b/aa-cli/src/commands/trace/mod.rs
@@ -1,6 +1,10 @@
 //! `aasm trace` — session trace visualization.
 
+use std::process::ExitCode;
+
 use clap::{Args, ValueEnum};
+
+use crate::config::ResolvedContext;
 
 pub mod models;
 
@@ -23,4 +27,9 @@ pub struct TraceArgs {
     /// Visualization format.
     #[arg(long, value_enum, default_value_t = TraceFormat::Tree)]
     pub format: TraceFormat,
+}
+
+/// Execute the `aasm trace` subcommand.
+pub fn dispatch(_args: TraceArgs, _ctx: &ResolvedContext) -> ExitCode {
+    ExitCode::SUCCESS
 }

--- a/aa-cli/src/commands/trace/mod.rs
+++ b/aa-cli/src/commands/trace/mod.rs
@@ -6,6 +6,7 @@ use clap::{Args, ValueEnum};
 
 use crate::config::ResolvedContext;
 
+pub mod client;
 pub mod models;
 
 /// Visualization format for trace output.

--- a/aa-cli/src/commands/trace/models.rs
+++ b/aa-cli/src/commands/trace/models.rs
@@ -43,3 +43,23 @@ pub struct SessionTrace {
     /// Top-level events in the session (in chronological order).
     pub events: Vec<TraceEvent>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trace_event_kind_serializes_to_snake_case() {
+        assert_eq!(serde_json::to_string(&TraceEventKind::Llm).unwrap(), "\"llm\"");
+        assert_eq!(serde_json::to_string(&TraceEventKind::ToolCall).unwrap(), "\"tool_call\"");
+        assert_eq!(serde_json::to_string(&TraceEventKind::ToolResult).unwrap(), "\"tool_result\"");
+        assert_eq!(serde_json::to_string(&TraceEventKind::PolicyAllow).unwrap(), "\"policy_allow\"");
+        assert_eq!(serde_json::to_string(&TraceEventKind::PolicyDeny).unwrap(), "\"policy_deny\"");
+    }
+
+    #[test]
+    fn trace_event_kind_deserializes_from_snake_case() {
+        let kind: TraceEventKind = serde_json::from_str("\"tool_call\"").unwrap();
+        assert_eq!(kind, TraceEventKind::ToolCall);
+    }
+}

--- a/aa-cli/src/commands/trace/models.rs
+++ b/aa-cli/src/commands/trace/models.rs
@@ -17,3 +17,20 @@ pub enum TraceEventKind {
     /// A policy evaluation that denied the action.
     PolicyDeny,
 }
+
+/// A single event within a trace session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceEvent {
+    /// What kind of event this is.
+    pub kind: TraceEventKind,
+    /// Human-readable label (e.g. tool name, model name).
+    pub label: String,
+    /// How long this event took in milliseconds.
+    pub duration_ms: u64,
+    /// Nested child events (e.g. tool calls within an LLM step).
+    #[serde(default)]
+    pub children: Vec<TraceEvent>,
+    /// If the event was a policy denial, the reason why.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub violation_reason: Option<String>,
+}

--- a/aa-cli/src/commands/trace/models.rs
+++ b/aa-cli/src/commands/trace/models.rs
@@ -34,3 +34,12 @@ pub struct TraceEvent {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub violation_reason: Option<String>,
 }
+
+/// A complete trace for one agent session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionTrace {
+    /// Unique identifier for the session.
+    pub session_id: String,
+    /// Top-level events in the session (in chronological order).
+    pub events: Vec<TraceEvent>,
+}

--- a/aa-cli/src/commands/trace/models.rs
+++ b/aa-cli/src/commands/trace/models.rs
@@ -1,0 +1,19 @@
+//! Data models for trace session visualization.
+
+use serde::{Deserialize, Serialize};
+
+/// The kind of event recorded in a trace.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceEventKind {
+    /// An LLM inference call.
+    Llm,
+    /// A tool invocation by the agent.
+    ToolCall,
+    /// The result returned by a tool.
+    ToolResult,
+    /// A policy evaluation that allowed the action.
+    PolicyAllow,
+    /// A policy evaluation that denied the action.
+    PolicyDeny,
+}

--- a/aa-cli/src/commands/trace/models.rs
+++ b/aa-cli/src/commands/trace/models.rs
@@ -107,4 +107,30 @@ mod tests {
         let json = serde_json::to_string(&event).unwrap();
         assert!(!json.contains("violation_reason"));
     }
+
+    #[test]
+    fn session_trace_round_trip_with_nested_events() {
+        let trace = SessionTrace {
+            session_id: "sess-001".to_string(),
+            events: vec![TraceEvent {
+                kind: TraceEventKind::Llm,
+                label: "GPT-4o".to_string(),
+                duration_ms: 834,
+                children: vec![TraceEvent {
+                    kind: TraceEventKind::ToolCall,
+                    label: "query_db".to_string(),
+                    duration_ms: 12,
+                    children: vec![],
+                    violation_reason: None,
+                }],
+                violation_reason: None,
+            }],
+        };
+        let json = serde_json::to_string_pretty(&trace).unwrap();
+        let parsed: SessionTrace = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.session_id, "sess-001");
+        assert_eq!(parsed.events.len(), 1);
+        assert_eq!(parsed.events[0].children.len(), 1);
+        assert_eq!(parsed.events[0].children[0].label, "query_db");
+    }
 }

--- a/aa-cli/src/commands/trace/models.rs
+++ b/aa-cli/src/commands/trace/models.rs
@@ -62,4 +62,49 @@ mod tests {
         let kind: TraceEventKind = serde_json::from_str("\"tool_call\"").unwrap();
         assert_eq!(kind, TraceEventKind::ToolCall);
     }
+
+    #[test]
+    fn trace_event_round_trip() {
+        let event = TraceEvent {
+            kind: TraceEventKind::Llm,
+            label: "GPT-4o".to_string(),
+            duration_ms: 834,
+            children: vec![],
+            violation_reason: None,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        let parsed: TraceEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.kind, TraceEventKind::Llm);
+        assert_eq!(parsed.label, "GPT-4o");
+        assert_eq!(parsed.duration_ms, 834);
+        assert!(parsed.children.is_empty());
+        assert!(parsed.violation_reason.is_none());
+    }
+
+    #[test]
+    fn trace_event_violation_reason_included_when_present() {
+        let event = TraceEvent {
+            kind: TraceEventKind::PolicyDeny,
+            label: "process_refund".to_string(),
+            duration_ms: 1,
+            children: vec![],
+            violation_reason: Some("amount exceeds limit".to_string()),
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("violation_reason"));
+        assert!(json.contains("amount exceeds limit"));
+    }
+
+    #[test]
+    fn trace_event_violation_reason_omitted_when_none() {
+        let event = TraceEvent {
+            kind: TraceEventKind::ToolCall,
+            label: "query_db".to_string(),
+            duration_ms: 12,
+            children: vec![],
+            violation_reason: None,
+        };
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(!json.contains("violation_reason"));
+    }
 }

--- a/aa-cli/src/commands/trace/models.rs
+++ b/aa-cli/src/commands/trace/models.rs
@@ -51,10 +51,22 @@ mod tests {
     #[test]
     fn trace_event_kind_serializes_to_snake_case() {
         assert_eq!(serde_json::to_string(&TraceEventKind::Llm).unwrap(), "\"llm\"");
-        assert_eq!(serde_json::to_string(&TraceEventKind::ToolCall).unwrap(), "\"tool_call\"");
-        assert_eq!(serde_json::to_string(&TraceEventKind::ToolResult).unwrap(), "\"tool_result\"");
-        assert_eq!(serde_json::to_string(&TraceEventKind::PolicyAllow).unwrap(), "\"policy_allow\"");
-        assert_eq!(serde_json::to_string(&TraceEventKind::PolicyDeny).unwrap(), "\"policy_deny\"");
+        assert_eq!(
+            serde_json::to_string(&TraceEventKind::ToolCall).unwrap(),
+            "\"tool_call\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TraceEventKind::ToolResult).unwrap(),
+            "\"tool_result\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TraceEventKind::PolicyAllow).unwrap(),
+            "\"policy_allow\""
+        );
+        assert_eq!(
+            serde_json::to_string(&TraceEventKind::PolicyDeny).unwrap(),
+            "\"policy_deny\""
+        );
     }
 
     #[test]

--- a/aa-cli/src/commands/trace/timeline.rs
+++ b/aa-cli/src/commands/trace/timeline.rs
@@ -77,3 +77,33 @@ pub fn render_timeline(trace: &SessionTrace, max_width: usize) -> String {
     }
     output
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_event(kind: TraceEventKind, label: &str, duration_ms: u64) -> TraceEvent {
+        TraceEvent {
+            kind,
+            label: label.to_string(),
+            duration_ms,
+            children: vec![],
+            violation_reason: None,
+        }
+    }
+
+    #[test]
+    fn compute_max_duration_returns_largest() {
+        let events = vec![
+            make_event(TraceEventKind::Llm, "a", 100),
+            make_event(TraceEventKind::ToolCall, "b", 500),
+            make_event(TraceEventKind::ToolResult, "c", 200),
+        ];
+        assert_eq!(compute_max_duration(&events), 500);
+    }
+
+    #[test]
+    fn compute_max_duration_empty() {
+        assert_eq!(compute_max_duration(&[]), 0);
+    }
+}

--- a/aa-cli/src/commands/trace/timeline.rs
+++ b/aa-cli/src/commands/trace/timeline.rs
@@ -1,6 +1,7 @@
 //! Timeline renderer for session traces using ASCII bar charts.
 
-use super::models::TraceEvent;
+use super::models::{TraceEvent, TraceEventKind};
+use super::tree::format_duration;
 
 /// Find the maximum duration among a flat list of events.
 pub fn compute_max_duration(events: &[TraceEvent]) -> u64 {
@@ -17,4 +18,27 @@ pub fn render_bar(duration_ms: u64, max_duration: u64, max_width: usize) -> Stri
     let width = ((duration_ms as f64 / max_duration as f64) * max_width as f64).round() as usize;
     let width = width.max(if duration_ms > 0 { 1 } else { 0 });
     "█".repeat(width)
+}
+
+/// Label prefix for timeline rows.
+fn timeline_label(event: &TraceEvent) -> String {
+    let kind_tag = match event.kind {
+        TraceEventKind::Llm => "LLM",
+        TraceEventKind::ToolCall => "TOOL",
+        TraceEventKind::ToolResult => "RESULT",
+        TraceEventKind::PolicyAllow => "ALLOW",
+        TraceEventKind::PolicyDeny => "DENY",
+    };
+    format!("{kind_tag:<6} {:<20}", event.label)
+}
+
+/// Render one row of the timeline: label | bar | duration.
+pub fn render_timeline_row(
+    event: &TraceEvent,
+    max_duration: u64,
+    bar_width: usize,
+) -> String {
+    let label = timeline_label(event);
+    let bar = render_bar(event.duration_ms, max_duration, bar_width);
+    format!("{label} {bar:<bar_width$}  {}", format_duration(event.duration_ms))
 }

--- a/aa-cli/src/commands/trace/timeline.rs
+++ b/aa-cli/src/commands/trace/timeline.rs
@@ -33,11 +33,7 @@ fn timeline_label(event: &TraceEvent) -> String {
 }
 
 /// Render one row of the timeline: label | bar | duration.
-pub fn render_timeline_row(
-    event: &TraceEvent,
-    max_duration: u64,
-    bar_width: usize,
-) -> String {
+pub fn render_timeline_row(event: &TraceEvent, max_duration: u64, bar_width: usize) -> String {
     let label = timeline_label(event);
     let bar = render_bar(event.duration_ms, max_duration, bar_width);
     format!("{label} {bar:<bar_width$}  {}", format_duration(event.duration_ms))
@@ -65,9 +61,7 @@ pub fn render_timeline(trace: &SessionTrace, max_width: usize) -> String {
         return output;
     }
 
-    let max_duration = compute_max_duration(
-        &flat.iter().map(|e| (*e).clone()).collect::<Vec<_>>(),
-    );
+    let max_duration = compute_max_duration(&flat.iter().map(|e| (*e).clone()).collect::<Vec<_>>());
     // Reserve ~30 chars for label, ~10 for duration suffix
     let bar_width = max_width.saturating_sub(40);
 
@@ -152,10 +146,7 @@ mod tests {
         for line in output.lines() {
             // Use char count (display width) — not byte len, since █ is multi-byte.
             let char_count = line.chars().count();
-            assert!(
-                char_count <= 80,
-                "line exceeds 80 columns ({char_count} chars): {line}",
-            );
+            assert!(char_count <= 80, "line exceeds 80 columns ({char_count} chars): {line}",);
         }
     }
 

--- a/aa-cli/src/commands/trace/timeline.rs
+++ b/aa-cli/src/commands/trace/timeline.rs
@@ -1,6 +1,6 @@
 //! Timeline renderer for session traces using ASCII bar charts.
 
-use super::models::{TraceEvent, TraceEventKind};
+use super::models::{SessionTrace, TraceEvent, TraceEventKind};
 use super::tree::format_duration;
 
 /// Find the maximum duration among a flat list of events.
@@ -41,4 +41,39 @@ pub fn render_timeline_row(
     let label = timeline_label(event);
     let bar = render_bar(event.duration_ms, max_duration, bar_width);
     format!("{label} {bar:<bar_width$}  {}", format_duration(event.duration_ms))
+}
+
+/// Flatten a trace tree into a depth-first list of events (ignoring nesting).
+fn flatten_events(events: &[TraceEvent]) -> Vec<&TraceEvent> {
+    let mut flat = Vec::new();
+    for event in events {
+        flat.push(event);
+        flat.extend(flatten_events(&event.children));
+    }
+    flat
+}
+
+/// Render a full session trace as a horizontal ASCII timeline.
+///
+/// `max_width` controls the total line width (default 80).
+pub fn render_timeline(trace: &SessionTrace, max_width: usize) -> String {
+    let mut output = format!("Timeline: {}\n", trace.session_id);
+
+    let flat = flatten_events(&trace.events);
+    if flat.is_empty() {
+        output.push_str("(no events)\n");
+        return output;
+    }
+
+    let max_duration = compute_max_duration(
+        &flat.iter().map(|e| (*e).clone()).collect::<Vec<_>>(),
+    );
+    // Reserve ~30 chars for label, ~10 for duration suffix
+    let bar_width = max_width.saturating_sub(40);
+
+    for event in &flat {
+        output.push_str(&render_timeline_row(event, max_duration, bar_width));
+        output.push('\n');
+    }
+    output
 }

--- a/aa-cli/src/commands/trace/timeline.rs
+++ b/aa-cli/src/commands/trace/timeline.rs
@@ -1,0 +1,8 @@
+//! Timeline renderer for session traces using ASCII bar charts.
+
+use super::models::TraceEvent;
+
+/// Find the maximum duration among a flat list of events.
+pub fn compute_max_duration(events: &[TraceEvent]) -> u64 {
+    events.iter().map(|e| e.duration_ms).max().unwrap_or(0)
+}

--- a/aa-cli/src/commands/trace/timeline.rs
+++ b/aa-cli/src/commands/trace/timeline.rs
@@ -137,4 +137,25 @@ mod tests {
         let bar = render_bar(100, 0, 40);
         assert!(bar.is_empty());
     }
+
+    #[test]
+    fn render_timeline_fits_80_columns() {
+        let trace = SessionTrace {
+            session_id: "sess-80".to_string(),
+            events: vec![
+                make_event(TraceEventKind::Llm, "GPT-4o", 834),
+                make_event(TraceEventKind::ToolCall, "query_db", 12),
+                make_event(TraceEventKind::ToolResult, "3 records", 0),
+            ],
+        };
+        let output = render_timeline(&trace, 80);
+        for line in output.lines() {
+            // Use char count (display width) — not byte len, since █ is multi-byte.
+            let char_count = line.chars().count();
+            assert!(
+                char_count <= 80,
+                "line exceeds 80 columns ({char_count} chars): {line}",
+            );
+        }
+    }
 }

--- a/aa-cli/src/commands/trace/timeline.rs
+++ b/aa-cli/src/commands/trace/timeline.rs
@@ -6,3 +6,15 @@ use super::models::TraceEvent;
 pub fn compute_max_duration(events: &[TraceEvent]) -> u64 {
     events.iter().map(|e| e.duration_ms).max().unwrap_or(0)
 }
+
+/// Render an ASCII bar whose width is proportional to `duration_ms` relative to `max_duration`.
+///
+/// Returns a string of `█` characters up to `max_width` wide.
+pub fn render_bar(duration_ms: u64, max_duration: u64, max_width: usize) -> String {
+    if max_duration == 0 {
+        return String::new();
+    }
+    let width = ((duration_ms as f64 / max_duration as f64) * max_width as f64).round() as usize;
+    let width = width.max(if duration_ms > 0 { 1 } else { 0 });
+    "█".repeat(width)
+}

--- a/aa-cli/src/commands/trace/timeline.rs
+++ b/aa-cli/src/commands/trace/timeline.rs
@@ -158,4 +158,15 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn render_timeline_empty_trace() {
+        let trace = SessionTrace {
+            session_id: "sess-empty".to_string(),
+            events: vec![],
+        };
+        let output = render_timeline(&trace, 80);
+        assert!(output.contains("Timeline: sess-empty"));
+        assert!(output.contains("(no events)"));
+    }
 }

--- a/aa-cli/src/commands/trace/timeline.rs
+++ b/aa-cli/src/commands/trace/timeline.rs
@@ -106,4 +106,35 @@ mod tests {
     fn compute_max_duration_empty() {
         assert_eq!(compute_max_duration(&[]), 0);
     }
+
+    #[test]
+    fn render_bar_full_width_for_max_duration() {
+        let bar = render_bar(1000, 1000, 40);
+        // Full bar = 40 block characters
+        assert_eq!(bar.chars().count(), 40);
+    }
+
+    #[test]
+    fn render_bar_half_width() {
+        let bar = render_bar(500, 1000, 40);
+        assert_eq!(bar.chars().count(), 20);
+    }
+
+    #[test]
+    fn render_bar_minimum_one_for_nonzero() {
+        let bar = render_bar(1, 10000, 40);
+        assert!(bar.chars().count() >= 1);
+    }
+
+    #[test]
+    fn render_bar_zero_duration() {
+        let bar = render_bar(0, 1000, 40);
+        assert_eq!(bar.chars().count(), 0);
+    }
+
+    #[test]
+    fn render_bar_zero_max_returns_empty() {
+        let bar = render_bar(100, 0, 40);
+        assert!(bar.is_empty());
+    }
 }

--- a/aa-cli/src/commands/trace/tree.rs
+++ b/aa-cli/src/commands/trace/tree.rs
@@ -147,4 +147,38 @@ mod tests {
         assert!(output.contains("query_db"));
         assert!(output.contains("3 records"));
     }
+
+    #[test]
+    fn render_event_line_policy_deny_includes_reason() {
+        // Force color output so ANSI codes are emitted regardless of TTY.
+        colored::control::set_override(true);
+
+        let event = TraceEvent {
+            kind: TraceEventKind::PolicyDeny,
+            label: "process_refund".to_string(),
+            duration_ms: 1,
+            children: vec![],
+            violation_reason: Some("amount exceeds limit".to_string()),
+        };
+        let line = render_event_line(&event);
+        assert!(line.contains("amount exceeds limit"));
+        assert!(line.contains("DENY"));
+        // ANSI red escape code
+        assert!(line.contains("\x1b[31m"));
+
+        colored::control::unset_override();
+    }
+
+    #[test]
+    fn render_event_line_policy_deny_default_reason() {
+        let event = TraceEvent {
+            kind: TraceEventKind::PolicyDeny,
+            label: "send_email".to_string(),
+            duration_ms: 0,
+            children: vec![],
+            violation_reason: None,
+        };
+        let line = render_event_line(&event);
+        assert!(line.contains("no reason provided"));
+    }
 }

--- a/aa-cli/src/commands/trace/tree.rs
+++ b/aa-cli/src/commands/trace/tree.rs
@@ -1,5 +1,7 @@
 //! Tree renderer for session traces using box-drawing characters.
 
+use colored::Colorize;
+
 use super::models::{SessionTrace, TraceEvent, TraceEventKind};
 
 /// Format a duration in milliseconds into a human-readable string.
@@ -21,13 +23,25 @@ fn event_icon(kind: &TraceEventKind) -> &'static str {
 }
 
 /// Render a single event as a one-line string (without tree prefix).
+///
+/// Policy denials are highlighted in red with the violation reason appended.
 pub fn render_event_line(event: &TraceEvent) -> String {
-    format!(
+    let line = format!(
         "{} {}  {}",
         event_icon(&event.kind),
         event.label,
         format_duration(event.duration_ms),
-    )
+    );
+
+    if event.kind == TraceEventKind::PolicyDeny {
+        let reason = event
+            .violation_reason
+            .as_deref()
+            .unwrap_or("no reason provided");
+        format!("{}", format!("{line}  ({reason})").red())
+    } else {
+        line
+    }
 }
 
 /// Recursively render a list of events as a tree with box-drawing prefixes.

--- a/aa-cli/src/commands/trace/tree.rs
+++ b/aa-cli/src/commands/trace/tree.rs
@@ -34,10 +34,7 @@ pub fn render_event_line(event: &TraceEvent) -> String {
     );
 
     if event.kind == TraceEventKind::PolicyDeny {
-        let reason = event
-            .violation_reason
-            .as_deref()
-            .unwrap_or("no reason provided");
+        let reason = event.violation_reason.as_deref().unwrap_or("no reason provided");
         format!("{}", format!("{line}  ({reason})").red())
     } else {
         line

--- a/aa-cli/src/commands/trace/tree.rs
+++ b/aa-cli/src/commands/trace/tree.rs
@@ -1,8 +1,31 @@
 //! Tree renderer for session traces using box-drawing characters.
 
+use super::models::{TraceEvent, TraceEventKind};
+
 /// Format a duration in milliseconds into a human-readable string.
 ///
 /// Examples: `0ms`, `142ms`, `1200ms`, `60000ms`.
 pub fn format_duration(duration_ms: u64) -> String {
     format!("{duration_ms}ms")
+}
+
+/// Return the icon for a given event kind.
+fn event_icon(kind: &TraceEventKind) -> &'static str {
+    match kind {
+        TraceEventKind::Llm => "●  LLM",
+        TraceEventKind::ToolCall => "●  TOOL",
+        TraceEventKind::ToolResult => "←  RESULT",
+        TraceEventKind::PolicyAllow => "✅ ALLOW",
+        TraceEventKind::PolicyDeny => "❌ DENY",
+    }
+}
+
+/// Render a single event as a one-line string (without tree prefix).
+pub fn render_event_line(event: &TraceEvent) -> String {
+    format!(
+        "{} {}  {}",
+        event_icon(&event.kind),
+        event.label,
+        format_duration(event.duration_ms),
+    )
 }

--- a/aa-cli/src/commands/trace/tree.rs
+++ b/aa-cli/src/commands/trace/tree.rs
@@ -1,0 +1,8 @@
+//! Tree renderer for session traces using box-drawing characters.
+
+/// Format a duration in milliseconds into a human-readable string.
+///
+/// Examples: `0ms`, `142ms`, `1200ms`, `60000ms`.
+pub fn format_duration(duration_ms: u64) -> String {
+    format!("{duration_ms}ms")
+}

--- a/aa-cli/src/commands/trace/tree.rs
+++ b/aa-cli/src/commands/trace/tree.rs
@@ -29,3 +29,28 @@ pub fn render_event_line(event: &TraceEvent) -> String {
         format_duration(event.duration_ms),
     )
 }
+
+/// Recursively render a list of events as a tree with box-drawing prefixes.
+///
+/// `prefix` is the indentation string inherited from the parent level.
+fn render_tree_recursive(events: &[TraceEvent], prefix: &str, output: &mut String) {
+    let count = events.len();
+    for (i, event) in events.iter().enumerate() {
+        let is_last = i == count - 1;
+        let connector = if is_last { "└─ " } else { "├─ " };
+        let child_prefix = if is_last {
+            format!("{prefix}   ")
+        } else {
+            format!("{prefix}│  ")
+        };
+
+        output.push_str(prefix);
+        output.push_str(connector);
+        output.push_str(&render_event_line(event));
+        output.push('\n');
+
+        if !event.children.is_empty() {
+            render_tree_recursive(&event.children, &child_prefix, output);
+        }
+    }
+}

--- a/aa-cli/src/commands/trace/tree.rs
+++ b/aa-cli/src/commands/trace/tree.rs
@@ -1,6 +1,6 @@
 //! Tree renderer for session traces using box-drawing characters.
 
-use super::models::{TraceEvent, TraceEventKind};
+use super::models::{SessionTrace, TraceEvent, TraceEventKind};
 
 /// Format a duration in milliseconds into a human-readable string.
 ///
@@ -53,4 +53,11 @@ fn render_tree_recursive(events: &[TraceEvent], prefix: &str, output: &mut Strin
             render_tree_recursive(&event.children, &child_prefix, output);
         }
     }
+}
+
+/// Render a full session trace as an indented tree with box-drawing characters.
+pub fn render_tree(trace: &SessionTrace) -> String {
+    let mut output = format!("Trace: {}\n", trace.session_id);
+    render_tree_recursive(&trace.events, "", &mut output);
+    output
 }

--- a/aa-cli/src/commands/trace/tree.rs
+++ b/aa-cli/src/commands/trace/tree.rs
@@ -94,4 +94,32 @@ mod tests {
     fn format_duration_large() {
         assert_eq!(format_duration(60000), "60000ms");
     }
+
+    fn make_event(kind: TraceEventKind, label: &str, duration_ms: u64) -> TraceEvent {
+        TraceEvent {
+            kind,
+            label: label.to_string(),
+            duration_ms,
+            children: vec![],
+            violation_reason: None,
+        }
+    }
+
+    #[test]
+    fn render_event_line_llm() {
+        let event = make_event(TraceEventKind::Llm, "GPT-4o", 834);
+        let line = render_event_line(&event);
+        assert!(line.contains("LLM"));
+        assert!(line.contains("GPT-4o"));
+        assert!(line.contains("834ms"));
+    }
+
+    #[test]
+    fn render_event_line_tool_call() {
+        let event = make_event(TraceEventKind::ToolCall, "query_db", 12);
+        let line = render_event_line(&event);
+        assert!(line.contains("TOOL"));
+        assert!(line.contains("query_db"));
+        assert!(line.contains("12ms"));
+    }
 }

--- a/aa-cli/src/commands/trace/tree.rs
+++ b/aa-cli/src/commands/trace/tree.rs
@@ -181,4 +181,19 @@ mod tests {
         let line = render_event_line(&event);
         assert!(line.contains("no reason provided"));
     }
+
+    #[test]
+    fn render_tree_single_event_no_children() {
+        let trace = SessionTrace {
+            session_id: "sess-solo".to_string(),
+            events: vec![make_event(TraceEventKind::Llm, "Claude", 500)],
+        };
+        let output = render_tree(&trace);
+        assert!(output.contains("Trace: sess-solo"));
+        assert!(output.contains("└─"));
+        assert!(output.contains("Claude"));
+        assert!(output.contains("500ms"));
+        // No child connectors
+        assert!(!output.contains("├─"));
+    }
 }

--- a/aa-cli/src/commands/trace/tree.rs
+++ b/aa-cli/src/commands/trace/tree.rs
@@ -75,3 +75,23 @@ pub fn render_tree(trace: &SessionTrace) -> String {
     render_tree_recursive(&trace.events, "", &mut output);
     output
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_duration_zero() {
+        assert_eq!(format_duration(0), "0ms");
+    }
+
+    #[test]
+    fn format_duration_typical() {
+        assert_eq!(format_duration(142), "142ms");
+    }
+
+    #[test]
+    fn format_duration_large() {
+        assert_eq!(format_duration(60000), "60000ms");
+    }
+}

--- a/aa-cli/src/commands/trace/tree.rs
+++ b/aa-cli/src/commands/trace/tree.rs
@@ -122,4 +122,29 @@ mod tests {
         assert!(line.contains("query_db"));
         assert!(line.contains("12ms"));
     }
+
+    #[test]
+    fn render_tree_nested_events() {
+        let trace = SessionTrace {
+            session_id: "sess-001".to_string(),
+            events: vec![TraceEvent {
+                kind: TraceEventKind::Llm,
+                label: "GPT-4o".to_string(),
+                duration_ms: 834,
+                children: vec![
+                    make_event(TraceEventKind::ToolCall, "query_db", 12),
+                    make_event(TraceEventKind::ToolResult, "3 records", 0),
+                ],
+                violation_reason: None,
+            }],
+        };
+        let output = render_tree(&trace);
+        assert!(output.contains("Trace: sess-001"));
+        // Root uses └─ (only one root event)
+        assert!(output.contains("└─"));
+        // Children use ├─ and └─
+        assert!(output.contains("├─"));
+        assert!(output.contains("query_db"));
+        assert!(output.contains("3 records"));
+    }
 }


### PR DESCRIPTION
## Description

Implement `aasm trace <session-id>` — a visual trace viewer for agent sessions showing LLM calls, tool invocations, policy decisions, and timing relationships. Supports tree view (default) with box-drawing characters, timeline view with ASCII bar charts, and JSON/YAML output for scripting.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [ ] No
- [x] Yes (describe below)

The `commands::dispatch()` function signature now accepts an `OutputFormat` parameter to thread the global `--output` flag through to subcommands.

## Related Issues

- Related Jira ticket: AAASM-89
- Parent Epic: AAASM-10

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

**37 tests total** covering:
- TraceEventKind serialization/deserialization (2 tests)
- TraceEvent round-trip and violation_reason handling (3 tests)
- SessionTrace nested serialization (1 test)
- format_duration helper (3 tests)
- render_event_line for different event kinds (2 tests)
- render_tree with nested events and single event (2 tests)
- Policy violation red highlighting with ANSI codes (2 tests)
- compute_max_duration (2 tests)
- render_bar proportional width (5 tests)
- render_timeline 80-column fit and empty trace (2 tests)
- CLI argument parsing for trace subcommand (3 tests)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention