### PR TITLE
[AAASM-92] ✨ (status): Implement aasm status with kubectl-style tabular overview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,10 +43,12 @@ version = "0.0.1"
 dependencies = [
  "aa-core",
  "aa-gateway",
+ "chrono",
  "clap",
  "clap_complete",
  "colored",
  "comfy-table",
+ "crossterm 0.28.1",
  "dirs",
  "owo-colors",
  "reqwest",
@@ -985,7 +987,7 @@ version = "7.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
- "crossterm",
+ "crossterm 0.29.0",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -1160,6 +1162,22 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossterm_winapi",
+ "mio 1.2.0",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
@@ -1168,7 +1186,7 @@ dependencies = [
  "crossterm_winapi",
  "document-features",
  "parking_lot",
- "rustix",
+ "rustix 1.1.4",
  "winapi",
 ]
 
@@ -2197,6 +2215,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -2377,6 +2401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -3468,6 +3493,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -3475,7 +3513,7 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -3726,6 +3764,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 1.2.0",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3909,7 +3968,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4735,7 +4794,7 @@ checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
  "env_home",
- "rustix",
+ "rustix 1.1.4",
  "winsafe",
 ]
 

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -15,8 +15,10 @@ aa-core        = { path = "../aa-core" }
 aa-gateway     = { path = "../aa-gateway" }
 clap           = { version = "4", features = ["derive"] }
 clap_complete  = "4"
+chrono         = { version = "0.4", features = ["serde"] }
 colored        = "3"
 comfy-table    = "7"
+crossterm      = "0.28"
 dirs           = "6"
 owo-colors     = "4"
 reqwest        = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod agent;
 pub mod completion;
 pub mod context;
 pub mod policy;
+pub mod status;
 pub mod trace;
 pub mod version;
 
@@ -25,6 +26,8 @@ pub enum Commands {
     Context(context::ContextArgs),
     /// Generate shell completion scripts.
     Completion(completion::CompletionArgs),
+    /// Show fleet health, agents, approvals, and budget at a glance.
+    Status(status::StatusArgs),
     /// Show CLI and gateway version information.
     Version,
     /// Visualize a session trace (tree or timeline).
@@ -38,6 +41,7 @@ pub fn dispatch(cmd: Commands, ctx: &ResolvedContext, output: OutputFormat) -> E
         Commands::Policy(args) => policy::dispatch(args),
         Commands::Context(args) => context::dispatch(args),
         Commands::Completion(args) => completion::run(args),
+        Commands::Status(args) => status::dispatch(args, ctx, output),
         Commands::Version => version::run(ctx),
         Commands::Trace(args) => trace::dispatch(args, ctx, output),
     }

--- a/aa-cli/src/commands/status/client.rs
+++ b/aa-cli/src/commands/status/client.rs
@@ -1,0 +1,37 @@
+//! HTTP client for fetching status data from the governance gateway.
+
+use reqwest::Client;
+
+use crate::error::CliError;
+
+/// Client for making status-related API requests.
+pub struct StatusClient {
+    base_url: String,
+    http: Client,
+}
+
+impl StatusClient {
+    /// Create a new `StatusClient` targeting the given gateway base URL.
+    pub fn new(base_url: &str) -> Self {
+        Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            http: Client::new(),
+        }
+    }
+
+    /// Build a full URL for the given API path.
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.base_url, path)
+    }
+
+    /// Return a reference to the underlying HTTP client (for testing).
+    #[cfg(test)]
+    pub fn http(&self) -> &Client {
+        &self.http
+    }
+
+    /// Return the base URL (for error messages).
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+}

--- a/aa-cli/src/commands/status/client.rs
+++ b/aa-cli/src/commands/status/client.rs
@@ -32,6 +32,7 @@ impl StatusClient {
     }
 
     /// Return the base URL (for error messages).
+    #[allow(dead_code)]
     pub fn base_url(&self) -> &str {
         &self.base_url
     }

--- a/aa-cli/src/commands/status/client.rs
+++ b/aa-cli/src/commands/status/client.rs
@@ -2,7 +2,7 @@
 
 use reqwest::Client;
 
-use super::models::{AgentResponse, HealthResponse, PaginatedResponse};
+use super::models::{AgentResponse, ApprovalResponse, HealthResponse, PaginatedResponse};
 use crate::error::CliError;
 
 /// Client for making status-related API requests.
@@ -52,6 +52,18 @@ impl StatusClient {
             .send()
             .await?;
         let body = resp.json::<PaginatedResponse<AgentResponse>>().await?;
+        Ok(body.items)
+    }
+
+    /// List all approvals via `GET /api/v1/approvals`.
+    pub async fn list_approvals(&self) -> Result<Vec<ApprovalResponse>, CliError> {
+        let resp = self
+            .http
+            .get(self.url("/api/v1/approvals"))
+            .query(&[("per_page", "100")])
+            .send()
+            .await?;
+        let body = resp.json::<PaginatedResponse<ApprovalResponse>>().await?;
         Ok(body.items)
     }
 }

--- a/aa-cli/src/commands/status/client.rs
+++ b/aa-cli/src/commands/status/client.rs
@@ -2,7 +2,7 @@
 
 use reqwest::Client;
 
-use super::models::HealthResponse;
+use super::models::{AgentResponse, HealthResponse, PaginatedResponse};
 use crate::error::CliError;
 
 /// Client for making status-related API requests.
@@ -41,5 +41,17 @@ impl StatusClient {
         let resp = self.http.get(self.url("/api/v1/health")).send().await?;
         let body = resp.json::<HealthResponse>().await?;
         Ok(body)
+    }
+
+    /// List all agents via `GET /api/v1/agents`.
+    pub async fn list_agents(&self) -> Result<Vec<AgentResponse>, CliError> {
+        let resp = self
+            .http
+            .get(self.url("/api/v1/agents"))
+            .query(&[("per_page", "100")])
+            .send()
+            .await?;
+        let body = resp.json::<PaginatedResponse<AgentResponse>>().await?;
+        Ok(body.items)
     }
 }

--- a/aa-cli/src/commands/status/client.rs
+++ b/aa-cli/src/commands/status/client.rs
@@ -2,6 +2,7 @@
 
 use reqwest::Client;
 
+use super::models::HealthResponse;
 use crate::error::CliError;
 
 /// Client for making status-related API requests.
@@ -33,5 +34,12 @@ impl StatusClient {
     /// Return the base URL (for error messages).
     pub fn base_url(&self) -> &str {
         &self.base_url
+    }
+
+    /// Check gateway health via `GET /api/v1/health`.
+    pub async fn check_health(&self) -> Result<HealthResponse, CliError> {
+        let resp = self.http.get(self.url("/api/v1/health")).send().await?;
+        let body = resp.json::<HealthResponse>().await?;
+        Ok(body)
     }
 }

--- a/aa-cli/src/commands/status/client.rs
+++ b/aa-cli/src/commands/status/client.rs
@@ -2,7 +2,9 @@
 
 use reqwest::Client;
 
-use super::models::{AgentResponse, ApprovalResponse, HealthResponse, PaginatedResponse};
+use super::models::{
+    AgentResponse, ApprovalResponse, CostResponse, HealthResponse, PaginatedResponse,
+};
 use crate::error::CliError;
 
 /// Client for making status-related API requests.
@@ -65,5 +67,12 @@ impl StatusClient {
             .await?;
         let body = resp.json::<PaginatedResponse<ApprovalResponse>>().await?;
         Ok(body.items)
+    }
+
+    /// Fetch cost summary via `GET /api/v1/costs`.
+    pub async fn get_costs(&self) -> Result<CostResponse, CliError> {
+        let resp = self.http.get(self.url("/api/v1/costs")).send().await?;
+        let body = resp.json::<CostResponse>().await?;
+        Ok(body)
     }
 }

--- a/aa-cli/src/commands/status/client.rs
+++ b/aa-cli/src/commands/status/client.rs
@@ -2,9 +2,7 @@
 
 use reqwest::Client;
 
-use super::models::{
-    AgentResponse, ApprovalResponse, CostResponse, HealthResponse, PaginatedResponse,
-};
+use super::models::{AgentResponse, ApprovalResponse, CostResponse, HealthResponse, PaginatedResponse};
 use crate::error::CliError;
 
 /// Client for making status-related API requests.

--- a/aa-cli/src/commands/status/client.rs
+++ b/aa-cli/src/commands/status/client.rs
@@ -25,12 +25,6 @@ impl StatusClient {
         format!("{}{}", self.base_url, path)
     }
 
-    /// Return a reference to the underlying HTTP client (for testing).
-    #[cfg(test)]
-    pub fn http(&self) -> &Client {
-        &self.http
-    }
-
     /// Return the base URL (for error messages).
     #[allow(dead_code)]
     pub fn base_url(&self) -> &str {

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -110,3 +110,105 @@ fn format_duration(dur: chrono::Duration) -> String {
         format!("{minutes}m")
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    #[test]
+    fn build_runtime_health_reachable() {
+        let resp = Some(HealthResponse {
+            status: "ok".to_string(),
+        });
+        let health = build_runtime_health(resp);
+        assert!(health.reachable);
+        assert_eq!(health.status, "ok");
+    }
+
+    #[test]
+    fn build_runtime_health_unreachable() {
+        let health = build_runtime_health(None);
+        assert!(!health.reachable);
+        assert_eq!(health.status, "unreachable");
+    }
+
+    #[test]
+    fn build_agent_rows_maps_fields() {
+        let agents = vec![AgentResponse {
+            id: "abc".to_string(),
+            name: "test-agent".to_string(),
+            framework: "langgraph".to_string(),
+            version: "1.0.0".to_string(),
+            status: "Running".to_string(),
+            tool_names: vec!["tool_a".to_string()],
+            metadata: BTreeMap::new(),
+        }];
+        let rows = build_agent_rows(agents);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, "abc");
+        assert_eq!(rows[0].name, "test-agent");
+        assert_eq!(rows[0].framework, "langgraph");
+        assert_eq!(rows[0].status, "Running");
+        assert_eq!(rows[0].violations_today, 0);
+    }
+
+    #[test]
+    fn build_approvals_summary_with_pending() {
+        let approvals = vec![
+            ApprovalResponse {
+                id: "ap-1".to_string(),
+                agent_id: "a1".to_string(),
+                action: "refund".to_string(),
+                reason: "amount".to_string(),
+                status: "pending".to_string(),
+                created_at: "2026-04-30T08:00:00Z".to_string(),
+            },
+            ApprovalResponse {
+                id: "ap-2".to_string(),
+                agent_id: "a2".to_string(),
+                action: "delete".to_string(),
+                reason: "test".to_string(),
+                status: "approved".to_string(),
+                created_at: "2026-04-30T07:00:00Z".to_string(),
+            },
+        ];
+        let summary = build_approvals_summary(&approvals);
+        assert_eq!(summary.pending_count, 1);
+        assert!(summary.oldest_pending_age.is_some());
+    }
+
+    #[test]
+    fn build_approvals_summary_no_pending() {
+        let approvals = vec![ApprovalResponse {
+            id: "ap-1".to_string(),
+            agent_id: "a1".to_string(),
+            action: "refund".to_string(),
+            reason: "done".to_string(),
+            status: "approved".to_string(),
+            created_at: "2026-04-30T08:00:00Z".to_string(),
+        }];
+        let summary = build_approvals_summary(&approvals);
+        assert_eq!(summary.pending_count, 0);
+        assert!(summary.oldest_pending_age.is_none());
+    }
+
+    #[test]
+    fn format_duration_minutes_only() {
+        let dur = chrono::Duration::minutes(5);
+        assert_eq!(format_duration(dur), "5m");
+    }
+
+    #[test]
+    fn format_duration_hours_and_minutes() {
+        let dur = chrono::Duration::hours(2) + chrono::Duration::minutes(15);
+        assert_eq!(format_duration(dur), "2h 15m");
+    }
+
+    #[test]
+    fn format_duration_days() {
+        let dur = chrono::Duration::days(1) + chrono::Duration::hours(3);
+        assert_eq!(format_duration(dur), "1d 3h");
+    }
+}

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -1,6 +1,6 @@
 //! Data composition — transform API responses into display models.
 
-use super::models::{HealthResponse, RuntimeHealth};
+use super::models::{AgentResponse, AgentRow, HealthResponse, RuntimeHealth};
 
 /// Convert a health API response into a display-ready `RuntimeHealth`.
 pub fn build_runtime_health(resp: Option<HealthResponse>) -> RuntimeHealth {
@@ -14,4 +14,19 @@ pub fn build_runtime_health(resp: Option<HealthResponse>) -> RuntimeHealth {
             status: "unreachable".to_string(),
         },
     }
+}
+
+/// Convert API agent responses into display-ready rows.
+pub fn build_agent_rows(agents: Vec<AgentResponse>) -> Vec<AgentRow> {
+    agents
+        .into_iter()
+        .map(|a| AgentRow {
+            id: a.id,
+            name: a.name,
+            framework: a.framework,
+            status: a.status,
+            // Per-agent violation count not yet available from the API.
+            violations_today: 0,
+        })
+        .collect()
 }

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -3,7 +3,8 @@
 use chrono::Utc;
 
 use super::models::{
-    AgentResponse, AgentRow, ApprovalResponse, ApprovalsSummary, HealthResponse, RuntimeHealth,
+    AgentResponse, AgentRow, ApprovalResponse, ApprovalsSummary, BudgetRow, CostResponse,
+    HealthResponse, RuntimeHealth,
 };
 
 /// Convert a health API response into a display-ready `RuntimeHealth`.
@@ -52,6 +53,15 @@ pub fn build_approvals_summary(approvals: &[ApprovalResponse]) -> ApprovalsSumma
     ApprovalsSummary {
         pending_count,
         oldest_pending_age,
+    }
+}
+
+/// Convert cost API response into a display-ready `BudgetRow`.
+pub fn build_budget_row(cost: CostResponse) -> BudgetRow {
+    BudgetRow {
+        daily_spend_usd: cost.daily_spend_usd,
+        monthly_spend_usd: cost.monthly_spend_usd,
+        date: cost.date,
     }
 }
 

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -1,0 +1,1 @@
+//! Data composition — transform API responses into display models.

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -1,1 +1,17 @@
 //! Data composition — transform API responses into display models.
+
+use super::models::{HealthResponse, RuntimeHealth};
+
+/// Convert a health API response into a display-ready `RuntimeHealth`.
+pub fn build_runtime_health(resp: Option<HealthResponse>) -> RuntimeHealth {
+    match resp {
+        Some(h) => RuntimeHealth {
+            reachable: true,
+            status: h.status,
+        },
+        None => RuntimeHealth {
+            reachable: false,
+            status: "unreachable".to_string(),
+        },
+    }
+}

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -1,6 +1,10 @@
 //! Data composition — transform API responses into display models.
 
-use super::models::{AgentResponse, AgentRow, HealthResponse, RuntimeHealth};
+use chrono::Utc;
+
+use super::models::{
+    AgentResponse, AgentRow, ApprovalResponse, ApprovalsSummary, HealthResponse, RuntimeHealth,
+};
 
 /// Convert a health API response into a display-ready `RuntimeHealth`.
 pub fn build_runtime_health(resp: Option<HealthResponse>) -> RuntimeHealth {
@@ -29,4 +33,40 @@ pub fn build_agent_rows(agents: Vec<AgentResponse>) -> Vec<AgentRow> {
             violations_today: 0,
         })
         .collect()
+}
+
+/// Compute approvals summary from the raw approval list.
+pub fn build_approvals_summary(approvals: &[ApprovalResponse]) -> ApprovalsSummary {
+    let pending: Vec<&ApprovalResponse> = approvals.iter().filter(|a| a.status == "pending").collect();
+    let pending_count = pending.len();
+
+    let oldest_pending_age = pending
+        .iter()
+        .filter_map(|a| chrono::DateTime::parse_from_rfc3339(&a.created_at).ok())
+        .min()
+        .map(|oldest| {
+            let age = Utc::now().signed_duration_since(oldest);
+            format_duration(age)
+        });
+
+    ApprovalsSummary {
+        pending_count,
+        oldest_pending_age,
+    }
+}
+
+/// Format a chrono duration into a human-readable string (e.g. `"2h 15m"`).
+fn format_duration(dur: chrono::Duration) -> String {
+    let total_secs = dur.num_seconds().max(0);
+    let days = total_secs / 86400;
+    let hours = (total_secs % 86400) / 3600;
+    let minutes = (total_secs % 3600) / 60;
+
+    if days > 0 {
+        format!("{days}d {hours}h")
+    } else if hours > 0 {
+        format!("{hours}h {minutes}m")
+    } else {
+        format!("{minutes}m")
+    }
 }

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -2,9 +2,10 @@
 
 use chrono::Utc;
 
+use super::client::StatusClient;
 use super::models::{
     AgentResponse, AgentRow, ApprovalResponse, ApprovalsSummary, BudgetRow, CostResponse,
-    HealthResponse, RuntimeHealth,
+    HealthResponse, RuntimeHealth, StatusSnapshot,
 };
 
 /// Convert a health API response into a display-ready `RuntimeHealth`.
@@ -53,6 +54,35 @@ pub fn build_approvals_summary(approvals: &[ApprovalResponse]) -> ApprovalsSumma
     ApprovalsSummary {
         pending_count,
         oldest_pending_age,
+    }
+}
+
+/// Fetch all status data from the gateway in parallel and compose a `StatusSnapshot`.
+pub async fn fetch_all(client: &StatusClient) -> StatusSnapshot {
+    let (health_result, agents_result, approvals_result, costs_result) = tokio::join!(
+        client.check_health(),
+        client.list_agents(),
+        client.list_approvals(),
+        client.get_costs(),
+    );
+
+    let runtime = build_runtime_health(health_result.ok());
+    let agents = build_agent_rows(agents_result.unwrap_or_default());
+    let approvals = build_approvals_summary(&approvals_result.unwrap_or_default());
+    let budget = match costs_result {
+        Ok(c) => build_budget_row(c),
+        Err(_) => BudgetRow {
+            daily_spend_usd: "--".to_string(),
+            monthly_spend_usd: None,
+            date: "--".to_string(),
+        },
+    };
+
+    StatusSnapshot {
+        runtime,
+        agents,
+        approvals,
+        budget,
     }
 }
 

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -4,8 +4,8 @@ use chrono::Utc;
 
 use super::client::StatusClient;
 use super::models::{
-    AgentResponse, AgentRow, ApprovalResponse, ApprovalsSummary, BudgetRow, CostResponse,
-    HealthResponse, RuntimeHealth, StatusSnapshot,
+    AgentResponse, AgentRow, ApprovalResponse, ApprovalsSummary, BudgetRow, CostResponse, HealthResponse,
+    RuntimeHealth, StatusSnapshot,
 };
 
 /// Convert a health API response into a display-ready `RuntimeHealth`.

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -4,12 +4,14 @@ pub mod client;
 pub mod fetch;
 pub mod models;
 pub mod render;
+pub mod watch;
 
 use std::process::ExitCode;
 
 use clap::Args;
 
 use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
 
 /// Arguments for the `aasm status` subcommand.
 #[derive(Debug, Args)]
@@ -38,7 +40,18 @@ pub fn compute_exit_code(snapshot: &StatusSnapshot) -> ExitCode {
 }
 
 /// Entry point for `aasm status`.
-pub fn dispatch(_args: StatusArgs, _ctx: &ResolvedContext) -> ExitCode {
-    eprintln!("status: not yet implemented");
-    ExitCode::FAILURE
+pub fn dispatch(args: StatusArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    rt.block_on(async {
+        let api_client = client::StatusClient::new(&ctx.api_url);
+
+        if args.watch {
+            watch::run_watch_loop(&api_client, output).await;
+            ExitCode::SUCCESS
+        } else {
+            let snapshot = fetch::fetch_all(&api_client).await;
+            render::render_all(&snapshot, output);
+            compute_exit_code(&snapshot)
+        }
+    })
 }

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -1,6 +1,7 @@
 //! `aasm status` — kubectl-style tabular overview of governance state.
 
 pub mod client;
+pub mod fetch;
 pub mod models;
 
 use std::process::ExitCode;

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -1,1 +1,11 @@
 //! `aasm status` — kubectl-style tabular overview of governance state.
+
+use clap::Args;
+
+/// Arguments for the `aasm status` subcommand.
+#[derive(Debug, Args)]
+pub struct StatusArgs {
+    /// Auto-refresh the status display every 5 seconds.
+    #[arg(long)]
+    pub watch: bool,
+}

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -55,3 +55,62 @@ pub fn dispatch(args: StatusArgs, ctx: &ResolvedContext, output: OutputFormat) -
         }
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::models::*;
+    use super::*;
+
+    fn healthy_snapshot() -> StatusSnapshot {
+        StatusSnapshot {
+            runtime: RuntimeHealth {
+                reachable: true,
+                status: "ok".to_string(),
+            },
+            agents: vec![AgentRow {
+                id: "a1".to_string(),
+                name: "agent".to_string(),
+                framework: "langgraph".to_string(),
+                status: "Running".to_string(),
+                violations_today: 0,
+            }],
+            approvals: ApprovalsSummary {
+                pending_count: 0,
+                oldest_pending_age: None,
+            },
+            budget: BudgetRow {
+                daily_spend_usd: "0.00".to_string(),
+                monthly_spend_usd: None,
+                date: "2026-04-30".to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn exit_code_0_when_healthy() {
+        let snapshot = healthy_snapshot();
+        assert_eq!(compute_exit_code(&snapshot), ExitCode::SUCCESS);
+    }
+
+    #[test]
+    fn exit_code_1_when_violations() {
+        let mut snapshot = healthy_snapshot();
+        snapshot.agents[0].violations_today = 3;
+        assert_eq!(compute_exit_code(&snapshot), ExitCode::from(1));
+    }
+
+    #[test]
+    fn exit_code_2_when_unreachable() {
+        let mut snapshot = healthy_snapshot();
+        snapshot.runtime.reachable = false;
+        assert_eq!(compute_exit_code(&snapshot), ExitCode::from(2));
+    }
+
+    #[test]
+    fn exit_code_2_takes_precedence_over_violations() {
+        let mut snapshot = healthy_snapshot();
+        snapshot.runtime.reachable = false;
+        snapshot.agents[0].violations_today = 5;
+        assert_eq!(compute_exit_code(&snapshot), ExitCode::from(2));
+    }
+}

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -19,6 +19,24 @@ pub struct StatusArgs {
     pub watch: bool,
 }
 
+use models::StatusSnapshot;
+
+/// Compute the process exit code from a status snapshot.
+///
+/// - `0` — all healthy
+/// - `1` — at least one agent has violations
+/// - `2` — runtime API is unreachable
+pub fn compute_exit_code(snapshot: &StatusSnapshot) -> ExitCode {
+    if !snapshot.runtime.reachable {
+        return ExitCode::from(2);
+    }
+    let has_violations = snapshot.agents.iter().any(|a| a.violations_today > 0);
+    if has_violations {
+        return ExitCode::from(1);
+    }
+    ExitCode::SUCCESS
+}
+
 /// Entry point for `aasm status`.
 pub fn dispatch(_args: StatusArgs, _ctx: &ResolvedContext) -> ExitCode {
     eprintln!("status: not yet implemented");

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -1,0 +1,1 @@
+//! `aasm status` — kubectl-style tabular overview of governance state.

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -1,5 +1,7 @@
 //! `aasm status` — kubectl-style tabular overview of governance state.
 
+pub mod models;
+
 use std::process::ExitCode;
 
 use clap::Args;

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -1,6 +1,10 @@
 //! `aasm status` — kubectl-style tabular overview of governance state.
 
+use std::process::ExitCode;
+
 use clap::Args;
+
+use crate::config::ResolvedContext;
 
 /// Arguments for the `aasm status` subcommand.
 #[derive(Debug, Args)]
@@ -8,4 +12,10 @@ pub struct StatusArgs {
     /// Auto-refresh the status display every 5 seconds.
     #[arg(long)]
     pub watch: bool,
+}
+
+/// Entry point for `aasm status`.
+pub fn dispatch(_args: StatusArgs, _ctx: &ResolvedContext) -> ExitCode {
+    eprintln!("status: not yet implemented");
+    ExitCode::FAILURE
 }

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -3,6 +3,7 @@
 pub mod client;
 pub mod fetch;
 pub mod models;
+pub mod render;
 
 use std::process::ExitCode;
 

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -1,5 +1,6 @@
 //! `aasm status` — kubectl-style tabular overview of governance state.
 
+pub mod client;
 pub mod models;
 
 use std::process::ExitCode;

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -8,3 +8,12 @@ pub struct HealthResponse {
     /// Liveness status string, always `"ok"` when the service is running.
     pub status: String,
 }
+
+/// Computed runtime health for display.
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeHealth {
+    /// Whether the API gateway is reachable.
+    pub reachable: bool,
+    /// Status string from the health endpoint (e.g. `"ok"`).
+    pub status: String,
+}

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -61,3 +61,11 @@ pub struct ApprovalsSummary {
     /// Human-readable age of the oldest pending approval (e.g. `"2h 15m"`).
     pub oldest_pending_age: Option<String>,
 }
+
+/// API response from `GET /api/v1/costs`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CostResponse {
+    pub daily_spend_usd: String,
+    pub monthly_spend_usd: Option<String>,
+    pub date: String,
+}

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -31,3 +31,13 @@ pub struct AgentResponse {
     pub tool_names: Vec<String>,
     pub metadata: BTreeMap<String, String>,
 }
+
+/// Flattened agent row for tabular display.
+#[derive(Debug, Clone, Serialize)]
+pub struct AgentRow {
+    pub id: String,
+    pub name: String,
+    pub framework: String,
+    pub status: String,
+    pub violations_today: u64,
+}

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -1,0 +1,1 @@
+//! Data models for the `aasm status` command.

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -1,5 +1,7 @@
 //! Data models for the `aasm status` command.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 /// API response from `GET /api/v1/health`.
@@ -16,4 +18,16 @@ pub struct RuntimeHealth {
     pub reachable: bool,
     /// Status string from the health endpoint (e.g. `"ok"`).
     pub status: String,
+}
+
+/// API response item from `GET /api/v1/agents`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AgentResponse {
+    pub id: String,
+    pub name: String,
+    pub framework: String,
+    pub version: String,
+    pub status: String,
+    pub tool_names: Vec<String>,
+    pub metadata: BTreeMap<String, String>,
 }

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -98,3 +98,70 @@ pub struct StatusSnapshot {
     pub approvals: ApprovalsSummary,
     pub budget: BudgetRow,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn health_response_deserializes() {
+        let json = r#"{"status":"ok"}"#;
+        let resp: HealthResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.status, "ok");
+    }
+
+    #[test]
+    fn agent_response_deserializes() {
+        let json = r#"{
+            "id": "abc123",
+            "name": "support-agent",
+            "framework": "langgraph",
+            "version": "1.0.0",
+            "status": "Running",
+            "tool_names": ["query_db", "send_slack"],
+            "metadata": {"team": "support"}
+        }"#;
+        let resp: AgentResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.id, "abc123");
+        assert_eq!(resp.name, "support-agent");
+        assert_eq!(resp.framework, "langgraph");
+        assert_eq!(resp.tool_names.len(), 2);
+        assert_eq!(resp.metadata.get("team").unwrap(), "support");
+    }
+
+    #[test]
+    fn approval_response_deserializes() {
+        let json = r#"{
+            "id": "ap-001",
+            "agent_id": "abc123",
+            "action": "process_refund",
+            "reason": "amount exceeds $100",
+            "status": "pending",
+            "created_at": "2026-04-30T10:00:00Z"
+        }"#;
+        let resp: ApprovalResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.id, "ap-001");
+        assert_eq!(resp.status, "pending");
+        assert_eq!(resp.created_at, "2026-04-30T10:00:00Z");
+    }
+
+    #[test]
+    fn cost_response_deserializes() {
+        let json = r#"{
+            "daily_spend_usd": "8.10",
+            "monthly_spend_usd": "142.50",
+            "date": "2026-04-30"
+        }"#;
+        let resp: CostResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.daily_spend_usd, "8.10");
+        assert_eq!(resp.monthly_spend_usd.as_deref(), Some("142.50"));
+        assert_eq!(resp.date, "2026-04-30");
+    }
+
+    #[test]
+    fn cost_response_deserializes_without_monthly() {
+        let json = r#"{"daily_spend_usd": "0.00", "date": "2026-04-30"}"#;
+        let resp: CostResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.monthly_spend_usd.is_none());
+    }
+}

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -80,3 +80,21 @@ pub struct BudgetRow {
     /// Reporting date.
     pub date: String,
 }
+
+/// Paginated API response wrapper.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PaginatedResponse<T> {
+    pub items: Vec<T>,
+    pub page: u32,
+    pub per_page: u32,
+    pub total: u64,
+}
+
+/// Complete status snapshot combining all sections.
+#[derive(Debug, Clone, Serialize)]
+pub struct StatusSnapshot {
+    pub runtime: RuntimeHealth,
+    pub agents: Vec<AgentRow>,
+    pub approvals: ApprovalsSummary,
+    pub budget: BudgetRow,
+}

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -52,3 +52,12 @@ pub struct ApprovalResponse {
     pub status: String,
     pub created_at: String,
 }
+
+/// Computed approvals summary for display.
+#[derive(Debug, Clone, Serialize)]
+pub struct ApprovalsSummary {
+    /// Number of approvals currently in `"pending"` status.
+    pub pending_count: usize,
+    /// Human-readable age of the oldest pending approval (e.g. `"2h 15m"`).
+    pub oldest_pending_age: Option<String>,
+}

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -1,1 +1,10 @@
 //! Data models for the `aasm status` command.
+
+use serde::{Deserialize, Serialize};
+
+/// API response from `GET /api/v1/health`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct HealthResponse {
+    /// Liveness status string, always `"ok"` when the service is running.
+    pub status: String,
+}

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -41,3 +41,14 @@ pub struct AgentRow {
     pub status: String,
     pub violations_today: u64,
 }
+
+/// API response item from `GET /api/v1/approvals`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ApprovalResponse {
+    pub id: String,
+    pub agent_id: String,
+    pub action: String,
+    pub reason: String,
+    pub status: String,
+    pub created_at: String,
+}

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -69,3 +69,14 @@ pub struct CostResponse {
     pub monthly_spend_usd: Option<String>,
     pub date: String,
 }
+
+/// Per-agent budget row for display.
+#[derive(Debug, Clone, Serialize)]
+pub struct BudgetRow {
+    /// Total daily spend in USD (aggregated, since per-agent is not yet available).
+    pub daily_spend_usd: String,
+    /// Monthly spend if available.
+    pub monthly_spend_usd: Option<String>,
+    /// Reporting date.
+    pub date: String,
+}

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -60,6 +60,9 @@ pub fn render_approvals_summary(summary: &ApprovalsSummary) {
 /// Render an ASCII bar chart: 20-char wide, `█` for used, `░` for remaining.
 ///
 /// `percentage` is clamped to `0..=100`.
+/// Currently used in tests; will be called from `render_budget_table` once
+/// per-agent budget data is available from the API.
+#[allow(dead_code)]
 pub fn format_bar_chart(percentage: u32) -> String {
     let pct = percentage.min(100);
     let filled = (pct as usize * 20) / 100;

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -1,0 +1,1 @@
+//! Rendering functions for `aasm status` output.

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -1,1 +1,12 @@
 //! Rendering functions for `aasm status` output.
+
+use super::models::RuntimeHealth;
+
+/// Render the Runtime Health section to stdout.
+pub fn render_runtime_health(health: &RuntimeHealth) {
+    println!("RUNTIME HEALTH");
+    println!("──────────────");
+    let indicator = if health.reachable { "✓" } else { "✗" };
+    println!("  API:    {indicator} {}", health.status);
+    println!();
+}

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -2,7 +2,7 @@
 
 use comfy_table::{ContentArrangement, Table};
 
-use super::models::{AgentRow, ApprovalsSummary, BudgetRow, RuntimeHealth};
+use super::models::{AgentRow, ApprovalsSummary, BudgetRow, RuntimeHealth, StatusSnapshot};
 
 /// Render the Runtime Health section to stdout.
 pub fn render_runtime_health(health: &RuntimeHealth) {
@@ -81,4 +81,12 @@ pub fn render_budget_table(budget: &BudgetRow) {
     }
     println!("  Date:          {}", budget.date);
     println!();
+}
+
+/// Render the full status snapshot as JSON to stdout.
+pub fn render_status_json(snapshot: &StatusSnapshot) {
+    match serde_json::to_string_pretty(snapshot) {
+        Ok(json) => println!("{json}"),
+        Err(e) => eprintln!("error serializing status to JSON: {e}"),
+    }
 }

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -64,12 +64,7 @@ pub fn format_bar_chart(percentage: u32) -> String {
     let pct = percentage.min(100);
     let filled = (pct as usize * 20) / 100;
     let empty = 20 - filled;
-    format!(
-        "{}{} {:>3}%",
-        "█".repeat(filled),
-        "░".repeat(empty),
-        pct,
-    )
+    format!("{}{} {:>3}%", "█".repeat(filled), "░".repeat(empty), pct,)
 }
 
 /// Render the Budget Status section to stdout.
@@ -96,12 +91,10 @@ pub fn render_status_json(snapshot: &StatusSnapshot) {
 pub fn render_all(snapshot: &StatusSnapshot, format: OutputFormat) {
     match format {
         OutputFormat::Json => render_status_json(snapshot),
-        OutputFormat::Yaml => {
-            match serde_yaml::to_string(snapshot) {
-                Ok(yaml) => print!("{yaml}"),
-                Err(e) => eprintln!("error serializing status to YAML: {e}"),
-            }
-        }
+        OutputFormat::Yaml => match serde_yaml::to_string(snapshot) {
+            Ok(yaml) => print!("{yaml}"),
+            Err(e) => eprintln!("error serializing status to YAML: {e}"),
+        },
         OutputFormat::Table => {
             render_runtime_health(&snapshot.runtime);
             render_agents_table(&snapshot.agents);

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -2,7 +2,7 @@
 
 use comfy_table::{ContentArrangement, Table};
 
-use super::models::{AgentRow, RuntimeHealth};
+use super::models::{AgentRow, ApprovalsSummary, RuntimeHealth};
 
 /// Render the Runtime Health section to stdout.
 pub fn render_runtime_health(health: &RuntimeHealth) {
@@ -42,5 +42,16 @@ pub fn render_agents_table(agents: &[AgentRow]) {
         ]);
     }
     println!("{table}");
+    println!();
+}
+
+/// Render the Pending Approvals section to stdout.
+pub fn render_approvals_summary(summary: &ApprovalsSummary) {
+    println!("PENDING APPROVALS");
+    println!("─────────────────");
+    println!("  Count:  {}", summary.pending_count);
+    if let Some(ref age) = summary.oldest_pending_age {
+        println!("  Oldest: {age} ago");
+    }
     println!();
 }

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -1,6 +1,8 @@
 //! Rendering functions for `aasm status` output.
 
-use super::models::RuntimeHealth;
+use comfy_table::{ContentArrangement, Table};
+
+use super::models::{AgentRow, RuntimeHealth};
 
 /// Render the Runtime Health section to stdout.
 pub fn render_runtime_health(health: &RuntimeHealth) {
@@ -8,5 +10,37 @@ pub fn render_runtime_health(health: &RuntimeHealth) {
     println!("──────────────");
     let indicator = if health.reachable { "✓" } else { "✗" };
     println!("  API:    {indicator} {}", health.status);
+    println!();
+}
+
+/// Render the Active Agents section as a table to stdout.
+pub fn render_agents_table(agents: &[AgentRow]) {
+    println!("ACTIVE AGENTS");
+    println!("─────────────");
+    if agents.is_empty() {
+        println!("  (no agents registered)");
+        println!();
+        return;
+    }
+
+    let mut table = Table::new();
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+    table.set_header(vec!["AGENT_ID", "NAME", "FRAMEWORK", "STATUS", "VIOLATIONS_TODAY"]);
+    for agent in agents {
+        let status_icon = match agent.status.as_str() {
+            "Running" => "●",
+            "Idle" => "○",
+            "Suspended" => "⚠",
+            _ => "?",
+        };
+        table.add_row(vec![
+            &agent.id,
+            &agent.name,
+            &agent.framework,
+            &format!("{status_icon} {}", agent.status),
+            &agent.violations_today.to_string(),
+        ]);
+    }
+    println!("{table}");
     println!();
 }

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -110,3 +110,57 @@ pub fn render_all(snapshot: &StatusSnapshot, format: OutputFormat) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bar_chart_at_zero_percent() {
+        let bar = format_bar_chart(0);
+        assert_eq!(bar, "░░░░░░░░░░░░░░░░░░░░   0%");
+    }
+
+    #[test]
+    fn bar_chart_at_fifty_percent() {
+        let bar = format_bar_chart(50);
+        assert_eq!(bar, "██████████░░░░░░░░░░  50%");
+    }
+
+    #[test]
+    fn bar_chart_at_hundred_percent() {
+        let bar = format_bar_chart(100);
+        assert_eq!(bar, "████████████████████ 100%");
+    }
+
+    #[test]
+    fn bar_chart_clamps_above_hundred() {
+        let bar = format_bar_chart(150);
+        assert_eq!(bar, "████████████████████ 100%");
+    }
+
+    #[test]
+    fn render_status_json_contains_all_keys() {
+        let snapshot = StatusSnapshot {
+            runtime: RuntimeHealth {
+                reachable: true,
+                status: "ok".to_string(),
+            },
+            agents: vec![],
+            approvals: ApprovalsSummary {
+                pending_count: 0,
+                oldest_pending_age: None,
+            },
+            budget: BudgetRow {
+                daily_spend_usd: "0.00".to_string(),
+                monthly_spend_usd: None,
+                date: "2026-04-30".to_string(),
+            },
+        };
+        let json = serde_json::to_string_pretty(&snapshot).unwrap();
+        assert!(json.contains("\"runtime\""));
+        assert!(json.contains("\"agents\""));
+        assert!(json.contains("\"approvals\""));
+        assert!(json.contains("\"budget\""));
+    }
+}

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -3,6 +3,7 @@
 use comfy_table::{ContentArrangement, Table};
 
 use super::models::{AgentRow, ApprovalsSummary, BudgetRow, RuntimeHealth, StatusSnapshot};
+use crate::output::OutputFormat;
 
 /// Render the Runtime Health section to stdout.
 pub fn render_runtime_health(health: &RuntimeHealth) {
@@ -88,5 +89,24 @@ pub fn render_status_json(snapshot: &StatusSnapshot) {
     match serde_json::to_string_pretty(snapshot) {
         Ok(json) => println!("{json}"),
         Err(e) => eprintln!("error serializing status to JSON: {e}"),
+    }
+}
+
+/// Render the full status snapshot using the selected output format.
+pub fn render_all(snapshot: &StatusSnapshot, format: OutputFormat) {
+    match format {
+        OutputFormat::Json => render_status_json(snapshot),
+        OutputFormat::Yaml => {
+            match serde_yaml::to_string(snapshot) {
+                Ok(yaml) => print!("{yaml}"),
+                Err(e) => eprintln!("error serializing status to YAML: {e}"),
+            }
+        }
+        OutputFormat::Table => {
+            render_runtime_health(&snapshot.runtime);
+            render_agents_table(&snapshot.agents);
+            render_approvals_summary(&snapshot.approvals);
+            render_budget_table(&snapshot.budget);
+        }
     }
 }

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -55,3 +55,18 @@ pub fn render_approvals_summary(summary: &ApprovalsSummary) {
     }
     println!();
 }
+
+/// Render an ASCII bar chart: 20-char wide, `█` for used, `░` for remaining.
+///
+/// `percentage` is clamped to `0..=100`.
+pub fn format_bar_chart(percentage: u32) -> String {
+    let pct = percentage.min(100);
+    let filled = (pct as usize * 20) / 100;
+    let empty = 20 - filled;
+    format!(
+        "{}{} {:>3}%",
+        "█".repeat(filled),
+        "░".repeat(empty),
+        pct,
+    )
+}

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -2,7 +2,7 @@
 
 use comfy_table::{ContentArrangement, Table};
 
-use super::models::{AgentRow, ApprovalsSummary, RuntimeHealth};
+use super::models::{AgentRow, ApprovalsSummary, BudgetRow, RuntimeHealth};
 
 /// Render the Runtime Health section to stdout.
 pub fn render_runtime_health(health: &RuntimeHealth) {
@@ -69,4 +69,16 @@ pub fn format_bar_chart(percentage: u32) -> String {
         "░".repeat(empty),
         pct,
     )
+}
+
+/// Render the Budget Status section to stdout.
+pub fn render_budget_table(budget: &BudgetRow) {
+    println!("BUDGET STATUS");
+    println!("─────────────");
+    println!("  Daily spend:   ${}", budget.daily_spend_usd);
+    if let Some(ref monthly) = budget.monthly_spend_usd {
+        println!("  Monthly spend: ${monthly}");
+    }
+    println!("  Date:          {}", budget.date);
+    println!();
 }

--- a/aa-cli/src/commands/status/watch.rs
+++ b/aa-cli/src/commands/status/watch.rs
@@ -6,7 +6,11 @@ use crossterm::cursor::MoveTo;
 use crossterm::execute;
 use crossterm::terminal::{Clear, ClearType};
 
+use tokio::time::{self, Duration};
+
 use super::client::StatusClient;
+use super::fetch;
+use super::render;
 use crate::output::OutputFormat;
 
 /// Clear the terminal screen without flickering.
@@ -16,6 +20,14 @@ fn clear_screen() {
 }
 
 /// Run the watch loop: fetch, render, clear, repeat every 5 seconds.
-pub async fn run_watch_loop(_client: &StatusClient, _output: OutputFormat) {
-    eprintln!("watch: not yet implemented");
+///
+/// Continues until the process is killed (e.g. Ctrl+C).
+pub async fn run_watch_loop(client: &StatusClient, output: OutputFormat) {
+    loop {
+        clear_screen();
+        let snapshot = fetch::fetch_all(client).await;
+        render::render_all(&snapshot, output);
+        eprintln!("(refreshing every 5s — press Ctrl+C to stop)");
+        time::sleep(Duration::from_secs(5)).await;
+    }
 }

--- a/aa-cli/src/commands/status/watch.rs
+++ b/aa-cli/src/commands/status/watch.rs
@@ -1,7 +1,19 @@
 //! Watch mode — auto-refresh status display every 5 seconds.
 
+use std::io::{self, Write};
+
+use crossterm::cursor::MoveTo;
+use crossterm::execute;
+use crossterm::terminal::{Clear, ClearType};
+
 use super::client::StatusClient;
 use crate::output::OutputFormat;
+
+/// Clear the terminal screen without flickering.
+fn clear_screen() {
+    let _ = execute!(io::stdout(), Clear(ClearType::All), MoveTo(0, 0));
+    let _ = io::stdout().flush();
+}
 
 /// Run the watch loop: fetch, render, clear, repeat every 5 seconds.
 pub async fn run_watch_loop(_client: &StatusClient, _output: OutputFormat) {

--- a/aa-cli/src/commands/status/watch.rs
+++ b/aa-cli/src/commands/status/watch.rs
@@ -1,0 +1,9 @@
+//! Watch mode — auto-refresh status display every 5 seconds.
+
+use super::client::StatusClient;
+use crate::output::OutputFormat;
+
+/// Run the watch loop: fetch, render, clear, repeat every 5 seconds.
+pub async fn run_watch_loop(_client: &StatusClient, _output: OutputFormat) {
+    eprintln!("watch: not yet implemented");
+}


### PR DESCRIPTION
## Description

Implement `aasm status` — a kubectl-style tabular overview showing runtime health, active agents, pending approvals, and budget status in a single glanceable output.

The command fetches data from four REST API endpoints in parallel (`tokio::join!`) and renders it as a formatted table, JSON, or YAML. Includes `--watch` mode for auto-refresh every 5 seconds with flicker-free `crossterm` terminal clearing.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [ ] No
- [x] Yes (describe below)

The `commands::dispatch()` function signature now includes an `OutputFormat` parameter, threaded from the top-level CLI struct. This is an internal change — no external CLI interface changes.

## Related Issues

- Related Jira ticket: AAASM-92
- Parent Epic: AAASM-10 (CLI Tool — aasm)

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [x] No tests required (explain why)

22 unit tests covering:
- Model deserialization (HealthResponse, AgentResponse, ApprovalResponse, CostResponse)
- Builder functions (build_runtime_health, build_agent_rows, build_approvals_summary)
- Duration formatting (minutes, hours, days)
- Bar chart rendering (0%, 50%, 100%, clamp >100%)
- Exit code computation (0=healthy, 1=violations, 2=unreachable)
- JSON output structure validation

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Architecture

```
aa-cli/src/commands/status/
├── mod.rs       # StatusArgs, dispatch(), compute_exit_code()
├── client.rs    # StatusClient — HTTP calls to gateway API
├── models.rs    # Data models (API responses + display structs)
├── fetch.rs     # Parallel data composition (tokio::join!)
├── render.rs    # Table/JSON/YAML rendering (comfy-table + bar charts)
└── watch.rs     # --watch loop with crossterm clear
```

## API Gaps

Some fields from the ticket spec are not yet available from current API endpoints:
- **Uptime**: `HealthResponse` only has `status`, no `started_at`
- **Per-agent violations**: Must be computed from audit logs (shown as `0` for now)
- **Per-agent budget**: `CostResponse` is aggregate only (shown as global totals)

These will be wired in when the corresponding API fields are added.