### PR TITLE
[AAASM-90] ✨ (policy): Add validate, get, and simulate subcommands

### DIFF
--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -24,5 +24,8 @@ serde_yaml     = "0.9"
 thiserror      = "2"
 tokio          = { version = "1", features = ["full"] }
 
+[dev-dependencies]
+tempfile = "3"
+
 [lints]
 workspace = true

--- a/aa-cli/src/commands/policy/get.rs
+++ b/aa-cli/src/commands/policy/get.rs
@@ -1,0 +1,64 @@
+//! `aasm policy get` — display the currently active (or a specific) policy.
+
+use std::process::ExitCode;
+
+use aa_gateway::policy::history::{FsHistoryStore, HistoryConfig, PolicyHistoryStore};
+use clap::Args;
+
+/// Arguments for `aasm policy get`.
+#[derive(Args)]
+pub struct GetArgs {
+    /// Version identifier (SHA-256 prefix) to retrieve.
+    /// Shows the latest active policy when omitted.
+    #[arg(long)]
+    pub version: Option<String>,
+}
+
+/// Execute the `aasm policy get` command.
+///
+/// When `--version` is provided, retrieves that specific policy version.
+/// Otherwise, retrieves the most recently applied (active) policy.
+pub fn run(args: GetArgs) -> ExitCode {
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    rt.block_on(async {
+        let store = FsHistoryStore::new(HistoryConfig::default_config());
+
+        if let Some(ref version) = args.version {
+            match store.get(version).await {
+                Ok(snapshot) => {
+                    print!("{}", snapshot.yaml_content);
+                    ExitCode::SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    ExitCode::FAILURE
+                }
+            }
+        } else {
+            match store.list(1).await {
+                Ok(versions) if versions.is_empty() => {
+                    eprintln!("No policy versions found.");
+                    ExitCode::FAILURE
+                }
+                Ok(versions) => {
+                    let latest = &versions[0];
+                    let version_id = &latest.sha256;
+                    match store.get(version_id).await {
+                        Ok(snapshot) => {
+                            print!("{}", snapshot.yaml_content);
+                            ExitCode::SUCCESS
+                        }
+                        Err(e) => {
+                            eprintln!("error: {e}");
+                            ExitCode::FAILURE
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    ExitCode::FAILURE
+                }
+            }
+        }
+    })
+}

--- a/aa-cli/src/commands/policy/get.rs
+++ b/aa-cli/src/commands/policy/get.rs
@@ -19,9 +19,14 @@ pub struct GetArgs {
 /// When `--version` is provided, retrieves that specific policy version.
 /// Otherwise, retrieves the most recently applied (active) policy.
 pub fn run(args: GetArgs) -> ExitCode {
+    run_with_config(args, HistoryConfig::default_config())
+}
+
+/// Inner implementation that accepts a [`HistoryConfig`] for testability.
+fn run_with_config(args: GetArgs, config: HistoryConfig) -> ExitCode {
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     rt.block_on(async {
-        let store = FsHistoryStore::new(HistoryConfig::default_config());
+        let store = FsHistoryStore::new(config);
 
         if let Some(ref version) = args.version {
             match store.get(version).await {
@@ -61,4 +66,56 @@ pub fn run(args: GetArgs) -> ExitCode {
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config(dir: &std::path::Path) -> HistoryConfig {
+        HistoryConfig {
+            history_dir: dir.join("policy-history"),
+            max_versions: 100,
+        }
+    }
+
+    #[test]
+    fn get_no_versions_exits_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = test_config(tmp.path());
+        let args = GetArgs { version: None };
+        assert_eq!(run_with_config(args, config), ExitCode::FAILURE);
+    }
+
+    #[test]
+    fn get_latest_after_apply_exits_success() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = test_config(tmp.path());
+
+        // Apply a policy first
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let store = FsHistoryStore::new(config.clone());
+        let yaml = "tier: low\nrules:\n  - id: r1\n    description: test\n    match:\n      actions: [\"*\"]\n    effect: allow\n    audit: true\n";
+        let meta = rt.block_on(store.save(yaml, Some("test"))).unwrap();
+
+        // Now get latest
+        let args = GetArgs { version: None };
+        assert_eq!(run_with_config(args, config.clone()), ExitCode::SUCCESS);
+
+        // Get by specific version
+        let args = GetArgs {
+            version: Some(meta.sha256[..12].to_string()),
+        };
+        assert_eq!(run_with_config(args, config), ExitCode::SUCCESS);
+    }
+
+    #[test]
+    fn get_unknown_version_exits_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config = test_config(tmp.path());
+        let args = GetArgs {
+            version: Some("nonexistent123".to_string()),
+        };
+        assert_eq!(run_with_config(args, config), ExitCode::FAILURE);
+    }
 }

--- a/aa-cli/src/commands/policy/mod.rs
+++ b/aa-cli/src/commands/policy/mod.rs
@@ -4,6 +4,7 @@ use std::process::ExitCode;
 
 use clap::{Args, Subcommand};
 
+pub mod get;
 pub mod history;
 pub mod simulate;
 pub mod validate;
@@ -30,6 +31,8 @@ pub enum PolicyCommands {
     Simulate(simulate::SimulateArgs),
     /// Validate a policy YAML file locally (no apply).
     Validate(validate::ValidateArgs),
+    /// Show the currently active policy YAML (or a specific version).
+    Get(get::GetArgs),
 }
 
 /// Dispatch a policy subcommand.
@@ -41,5 +44,6 @@ pub fn dispatch(args: PolicyArgs) -> ExitCode {
         PolicyCommands::Diff(diff_args) => history::run_diff(diff_args),
         PolicyCommands::Simulate(sim_args) => simulate::run(sim_args),
         PolicyCommands::Validate(val_args) => validate::run(val_args),
+        PolicyCommands::Get(get_args) => get::run(get_args),
     }
 }

--- a/aa-cli/src/commands/policy/mod.rs
+++ b/aa-cli/src/commands/policy/mod.rs
@@ -6,6 +6,7 @@ use clap::{Args, Subcommand};
 
 pub mod history;
 pub mod simulate;
+pub mod validate;
 
 /// Arguments for the `aasm policy` subcommand group.
 #[derive(Args)]
@@ -27,6 +28,8 @@ pub enum PolicyCommands {
     Diff(history::DiffArgs),
     /// Simulate a policy against historical events or live traffic (dry-run).
     Simulate(simulate::SimulateArgs),
+    /// Validate a policy YAML file locally (no apply).
+    Validate(validate::ValidateArgs),
 }
 
 /// Dispatch a policy subcommand.
@@ -37,5 +40,6 @@ pub fn dispatch(args: PolicyArgs) -> ExitCode {
         PolicyCommands::Rollback(rollback_args) => history::run_rollback(rollback_args),
         PolicyCommands::Diff(diff_args) => history::run_diff(diff_args),
         PolicyCommands::Simulate(sim_args) => simulate::run(sim_args),
+        PolicyCommands::Validate(val_args) => validate::run(val_args),
     }
 }

--- a/aa-cli/src/commands/policy/simulate.rs
+++ b/aa-cli/src/commands/policy/simulate.rs
@@ -113,10 +113,7 @@ fn print_report(report: &SimulationReport) {
 
     if !report.flagged_outcomes.is_empty() {
         println!();
-        println!(
-            "{:<8} {:<20} {:<12} REASON",
-            "EVENT#", "ACTION", "DECISION"
-        );
+        println!("{:<8} {:<20} {:<12} REASON", "EVENT#", "ACTION", "DECISION");
         println!("{}", "-".repeat(70));
         for outcome in &report.flagged_outcomes {
             println!(

--- a/aa-cli/src/commands/policy/simulate.rs
+++ b/aa-cli/src/commands/policy/simulate.rs
@@ -126,3 +126,100 @@ fn print_report(report: &SimulationReport) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_policy_file_exits_failure() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut tmp, b"not: valid: policy: [[[").unwrap();
+
+        let args = SimulateArgs {
+            policy: tmp.path().to_path_buf(),
+            against: None,
+            live: false,
+            duration: None,
+            output: None,
+        };
+        assert_eq!(run(args), ExitCode::FAILURE);
+    }
+
+    #[test]
+    fn missing_policy_file_exits_failure() {
+        let args = SimulateArgs {
+            policy: PathBuf::from("/tmp/nonexistent-policy-simulate.yaml"),
+            against: None,
+            live: false,
+            duration: None,
+            output: None,
+        };
+        assert_eq!(run(args), ExitCode::FAILURE);
+    }
+
+    #[test]
+    fn missing_against_flag_exits_failure() {
+        // Create a valid policy file but don't provide --against
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(
+            &mut tmp,
+            br#"apiVersion: agent-assembly/v1
+kind: Policy
+metadata:
+  name: sim-test
+spec:
+  tier: low
+  rules:
+    - id: allow-all
+      description: Allow all
+      match:
+        actions: ["*"]
+      effect: allow
+      audit: true
+"#,
+        )
+        .unwrap();
+
+        let args = SimulateArgs {
+            policy: tmp.path().to_path_buf(),
+            against: None,
+            live: false,
+            duration: None,
+            output: None,
+        };
+        assert_eq!(run(args), ExitCode::FAILURE);
+    }
+
+    #[test]
+    fn live_mode_exits_failure_not_implemented() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(
+            &mut tmp,
+            br#"apiVersion: agent-assembly/v1
+kind: Policy
+metadata:
+  name: sim-test
+spec:
+  tier: low
+  rules:
+    - id: allow-all
+      description: Allow all
+      match:
+        actions: ["*"]
+      effect: allow
+      audit: true
+"#,
+        )
+        .unwrap();
+
+        let args = SimulateArgs {
+            policy: tmp.path().to_path_buf(),
+            against: None,
+            live: true,
+            duration: Some("30s".to_string()),
+            output: None,
+        };
+        assert_eq!(run(args), ExitCode::FAILURE);
+    }
+}

--- a/aa-cli/src/commands/policy/simulate.rs
+++ b/aa-cli/src/commands/policy/simulate.rs
@@ -2,12 +2,12 @@
 
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::sync::Arc;
 
 use clap::Args;
 
-// Gateway types will be used when simulation logic is implemented.
-#[allow(unused_imports)]
-use aa_gateway::simulation::{SimulationEngine, SimulationReport};
+use aa_gateway::simulation::{HistoricalReplay, SimulationEngine, SimulationReport};
+use aa_gateway::PolicyEngine;
 
 /// Arguments for `aasm policy simulate`.
 #[derive(Args)]
@@ -38,6 +38,91 @@ pub struct SimulateArgs {
 /// Returns [`ExitCode::SUCCESS`] if no violations were found,
 /// or [`ExitCode::FAILURE`] if the simulation detected policy violations.
 /// This allows CI pipelines to gate on `aasm policy simulate` exit status.
-pub fn run(_args: SimulateArgs) -> ExitCode {
-    todo!("AAASM-73: implement policy simulation CLI handler")
+pub fn run(args: SimulateArgs) -> ExitCode {
+    // Load the policy engine from the provided YAML file.
+    let (budget_tx, _budget_rx) = tokio::sync::broadcast::channel(16);
+    let engine = match PolicyEngine::load_from_file(&args.policy, budget_tx) {
+        Ok(e) => Arc::new(e),
+        Err(e) => {
+            eprintln!("error: failed to load policy: {e:?}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let sim_engine = SimulationEngine::new(engine);
+
+    if args.live {
+        eprintln!("error: live simulation is not yet supported (requires AAASM-73)");
+        return ExitCode::FAILURE;
+    }
+
+    let log_path = match &args.against {
+        Some(p) => p,
+        None => {
+            eprintln!("error: --against <log-file> is required for file-based simulation");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let replay = match HistoricalReplay::from_file(log_path) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: failed to read audit log: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let report = sim_engine.run(replay.events());
+
+    // Write report to file if --output is provided.
+    if let Some(ref output_path) = args.output {
+        match serde_json::to_string_pretty(&report) {
+            Ok(json) => {
+                if let Err(e) = std::fs::write(output_path, &json) {
+                    eprintln!("error: failed to write report to {}: {e}", output_path.display());
+                    return ExitCode::FAILURE;
+                }
+            }
+            Err(e) => {
+                eprintln!("error: failed to serialize report: {e}");
+                return ExitCode::FAILURE;
+            }
+        }
+    }
+
+    print_report(&report);
+
+    if report.denied > 0 {
+        ExitCode::FAILURE
+    } else {
+        ExitCode::SUCCESS
+    }
+}
+
+/// Print a tabular summary of the simulation report.
+fn print_report(report: &SimulationReport) {
+    println!("Simulation Report");
+    println!("{}", "-".repeat(50));
+    println!("Total events:       {}", report.total_events);
+    println!("Allowed:            {}", report.allowed);
+    println!("Denied:             {}", report.denied);
+    println!("Approval required:  {}", report.approval_required);
+    if let Some(budget) = report.budget_impact_usd {
+        println!("Budget impact:      ${budget:.2}");
+    }
+
+    if !report.flagged_outcomes.is_empty() {
+        println!();
+        println!(
+            "{:<8} {:<20} {:<12} REASON",
+            "EVENT#", "ACTION", "DECISION"
+        );
+        println!("{}", "-".repeat(70));
+        for outcome in &report.flagged_outcomes {
+            println!(
+                "{:<8} {:<20} {:<12} {}",
+                outcome.event_index, outcome.action, outcome.decision, outcome.reason
+            );
+        }
+    }
 }

--- a/aa-cli/src/commands/policy/validate.rs
+++ b/aa-cli/src/commands/policy/validate.rs
@@ -1,0 +1,43 @@
+//! `aasm policy validate` — local-only policy YAML validation.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Args;
+
+/// Arguments for `aasm policy validate`.
+#[derive(Args)]
+pub struct ValidateArgs {
+    /// Path to the policy YAML file to validate.
+    pub file: PathBuf,
+}
+
+/// Execute the `aasm policy validate` command.
+///
+/// Validates the policy YAML file locally using [`PolicyValidator::from_yaml`].
+/// Exits 0 if valid, 1 if invalid with error details printed to stderr.
+pub fn run(args: ValidateArgs) -> ExitCode {
+    let yaml = match std::fs::read_to_string(&args.file) {
+        Ok(y) => y,
+        Err(e) => {
+            eprintln!("error: failed to read {}: {e}", args.file.display());
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match aa_gateway::policy::PolicyValidator::from_yaml(&yaml) {
+        Ok(output) => {
+            for w in &output.warnings {
+                eprintln!("warning: {w:?}");
+            }
+            println!("Policy is valid: {}", args.file.display());
+            ExitCode::SUCCESS
+        }
+        Err(errors) => {
+            for e in &errors {
+                eprintln!("error: {e:?}");
+            }
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/aa-cli/src/commands/policy/validate.rs
+++ b/aa-cli/src/commands/policy/validate.rs
@@ -41,3 +41,56 @@ pub fn run(args: ValidateArgs) -> ExitCode {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::io::Write;
+
+    #[test]
+    fn valid_policy_exits_success() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            tmp,
+            r#"apiVersion: agent-assembly/v1
+kind: Policy
+metadata:
+  name: test-policy
+spec:
+  tier: low
+  rules:
+    - id: allow-all
+      description: Allow all
+      match:
+        actions: ["*"]
+      effect: allow
+      audit: true"#
+        )
+        .unwrap();
+
+        let args = ValidateArgs {
+            file: tmp.path().to_path_buf(),
+        };
+        assert_eq!(run(args), ExitCode::SUCCESS);
+    }
+
+    #[test]
+    fn invalid_yaml_exits_failure() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmp, "not: valid: yaml: [[[").unwrap();
+
+        let args = ValidateArgs {
+            file: tmp.path().to_path_buf(),
+        };
+        assert_eq!(run(args), ExitCode::FAILURE);
+    }
+
+    #[test]
+    fn missing_file_exits_failure() {
+        let args = ValidateArgs {
+            file: PathBuf::from("/tmp/nonexistent-policy-file-that-does-not-exist.yaml"),
+        };
+        assert_eq!(run(args), ExitCode::FAILURE);
+    }
+}


### PR DESCRIPTION
## Description

Implements the missing `aasm policy` subcommands for AAASM-90 (F51):

- **`aasm policy validate <file>`** — local-only YAML validation using `PolicyValidator::from_yaml()`. Exits 0 if valid, 1 with error details if invalid.
- **`aasm policy get [--version <hash>]`** — displays the currently active policy YAML, or a specific version by hash prefix.
- **`aasm policy simulate`** — wires `SimulationEngine` and `HistoricalReplay` from `aa-gateway`. Loads policy, replays audit log events, prints tabular report. Exits non-zero if violations found. (Note: underlying `SimulationEngine::run()` depends on AAASM-73 for full end-to-end functionality.)

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [ ] No
- [x] Yes (describe below)

No breaking changes to existing commands. New subcommands only.

Actually: No breaking changes.

## Related Issues

- Related Jira ticket: AAASM-90
- Parent Epic: AAASM-10 (CLI Tool — aasm)

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

10 new tests added (3 validate + 3 get + 4 simulate). All 20 aa-cli tests pass.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention