### PR TITLE
[AAASM-154] 🐛 (policy): Fix validate CLI output formatting with line numbers

### DIFF
--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -16,7 +16,6 @@ aa-gateway     = { path = "../aa-gateway" }
 chrono         = { version = "0.4", features = ["serde"] }
 clap           = { version = "4", features = ["derive"] }
 clap_complete  = "4"
-chrono         = { version = "0.4", features = ["serde"] }
 colored        = "3"
 comfy-table    = "7"
 crossterm      = "0.28"

--- a/aa-cli/src/commands/policy/validate.rs
+++ b/aa-cli/src/commands/policy/validate.rs
@@ -28,14 +28,14 @@ pub fn run(args: ValidateArgs) -> ExitCode {
     match aa_gateway::policy::PolicyValidator::from_yaml(&yaml) {
         Ok(output) => {
             for w in &output.warnings {
-                eprintln!("warning: {w:?}");
+                eprintln!("warning: {w}");
             }
             println!("Policy is valid: {}", args.file.display());
             ExitCode::SUCCESS
         }
         Err(errors) => {
             for e in &errors {
-                eprintln!("error: {e:?}");
+                eprintln!("error: {e}");
             }
             ExitCode::FAILURE
         }

--- a/aa-cli/src/commands/policy/validate.rs
+++ b/aa-cli/src/commands/policy/validate.rs
@@ -93,4 +93,37 @@ spec:
         };
         assert_eq!(run(args), ExitCode::FAILURE);
     }
+
+    #[test]
+    fn unknown_key_produces_warning_not_error() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmp, "risk_tier: high").unwrap();
+
+        let args = ValidateArgs {
+            file: tmp.path().to_path_buf(),
+        };
+        assert_eq!(run(args), ExitCode::SUCCESS);
+    }
+
+    #[test]
+    fn multiple_errors_all_reported() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            tmp,
+            r#"network:
+  allowlist:
+    - ""
+budget:
+  daily_limit_usd: 0.0
+data:
+  sensitive_patterns:
+    - "[bad""#
+        )
+        .unwrap();
+
+        let args = ValidateArgs {
+            file: tmp.path().to_path_buf(),
+        };
+        assert_eq!(run(args), ExitCode::FAILURE);
+    }
 }

--- a/aa-gateway/src/policy/error.rs
+++ b/aa-gateway/src/policy/error.rs
@@ -112,4 +112,13 @@ mod tests {
         let w = ValidationWarning::unknown_key("network.blocklist");
         assert_eq!(w.field, "network.blocklist");
     }
+
+    #[test]
+    fn validation_warning_display_formatting() {
+        let w = ValidationWarning::unknown_key("risk_tier");
+        assert_eq!(
+            w.to_string(),
+            "risk_tier — Unknown key 'risk_tier' will be ignored"
+        );
+    }
 }

--- a/aa-gateway/src/policy/error.rs
+++ b/aa-gateway/src/policy/error.rs
@@ -84,20 +84,13 @@ mod tests {
     #[test]
     fn validation_error_display_without_line() {
         let e = ValidationError::new("budget.daily_limit_usd", "must be greater than 0");
-        assert_eq!(
-            e.to_string(),
-            "budget.daily_limit_usd — must be greater than 0"
-        );
+        assert_eq!(e.to_string(), "budget.daily_limit_usd — must be greater than 0");
     }
 
     #[test]
     fn validation_error_display_with_line() {
-        let e =
-            ValidationError::new("budget.daily_limit_usd", "invalid value").with_line(12);
-        assert_eq!(
-            e.to_string(),
-            "line 12: budget.daily_limit_usd — invalid value"
-        );
+        let e = ValidationError::new("budget.daily_limit_usd", "invalid value").with_line(12);
+        assert_eq!(e.to_string(), "line 12: budget.daily_limit_usd — invalid value");
     }
 
     #[test]
@@ -116,9 +109,6 @@ mod tests {
     #[test]
     fn validation_warning_display_formatting() {
         let w = ValidationWarning::unknown_key("risk_tier");
-        assert_eq!(
-            w.to_string(),
-            "risk_tier — Unknown key 'risk_tier' will be ignored"
-        );
+        assert_eq!(w.to_string(), "risk_tier — Unknown key 'risk_tier' will be ignored");
     }
 }

--- a/aa-gateway/src/policy/error.rs
+++ b/aa-gateway/src/policy/error.rs
@@ -1,5 +1,7 @@
 //! Validation error and warning types for policy YAML parsing.
 
+use std::fmt;
+
 /// An error produced during policy document validation.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ValidationError {
@@ -25,6 +27,15 @@ impl ValidationError {
     pub fn with_line(mut self, line: u32) -> Self {
         self.line = Some(line);
         self
+    }
+}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.line {
+            Some(line) => write!(f, "line {}: {} — {}", line, self.field, self.message),
+            None => write!(f, "{} — {}", self.field, self.message),
+        }
     }
 }
 

--- a/aa-gateway/src/policy/error.rs
+++ b/aa-gateway/src/policy/error.rs
@@ -76,6 +76,25 @@ mod tests {
     }
 
     #[test]
+    fn validation_error_display_without_line() {
+        let e = ValidationError::new("budget.daily_limit_usd", "must be greater than 0");
+        assert_eq!(
+            e.to_string(),
+            "budget.daily_limit_usd — must be greater than 0"
+        );
+    }
+
+    #[test]
+    fn validation_error_display_with_line() {
+        let e =
+            ValidationError::new("budget.daily_limit_usd", "invalid value").with_line(12);
+        assert_eq!(
+            e.to_string(),
+            "line 12: budget.daily_limit_usd — invalid value"
+        );
+    }
+
+    #[test]
     fn validation_warning_unknown_key_formats_message() {
         let w = ValidationWarning::unknown_key("risk_tier");
         assert_eq!(w.field, "risk_tier");

--- a/aa-gateway/src/policy/error.rs
+++ b/aa-gateway/src/policy/error.rs
@@ -57,6 +57,12 @@ impl ValidationWarning {
     }
 }
 
+impl fmt::Display for ValidationWarning {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{} — {}", self.field, self.message)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Description

Fix `aasm policy validate` CLI output to use human-readable formatting instead of Rust Debug (`{:?}`) format. Implements `Display` for `ValidationError` (with line numbers) and `ValidationWarning` in `aa-gateway`, then updates the CLI to use `{}` instead of `{:?}`.

**Before:** `error: ValidationError { field: "budget.daily_limit_usd", message: "must be greater than 0", line: None }`
**After:** `error: budget.daily_limit_usd — must be greater than 0` or `error: line 12: budget.daily_limit_usd — invalid value`

Also fixes a pre-existing duplicate `chrono` key in `aa-cli/Cargo.toml`.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Closes: AAASM-154
- Parent Epic: AAASM-10
- Related: AAASM-66 (AC #2)

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

**Tests added:**
- `ValidationError` Display with and without line number (2 tests)
- `ValidationWarning` Display formatting (1 test)
- CLI: unknown key produces warning not error (1 test)
- CLI: multiple errors all reported (1 test)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention