### PR TITLE
[AAASM-177] 🐛 (simulation): Implement SimulationEngine and HistoricalReplay stubs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3525,7 +3525,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/aa-gateway/src/simulation/engine.rs
+++ b/aa-gateway/src/simulation/engine.rs
@@ -1,6 +1,9 @@
 //! Dry-run policy evaluation engine.
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
+
+use aa_core::{AgentContext, GovernanceAction, PolicyResult};
 
 use crate::PolicyEngine;
 
@@ -35,12 +38,173 @@ impl SimulationEngine {
     /// Evaluate a single event against the loaded policy in dry-run mode.
     ///
     /// Returns the outcome without writing to the audit log or triggering alerts.
-    pub fn simulate_event(&self, _index: usize, _event: &SimulationEvent) -> EventOutcome {
-        todo!("AAASM-73: evaluate event against policy engine pipeline")
+    pub fn simulate_event(&self, index: usize, event: &SimulationEvent) -> EventOutcome {
+        let action: GovernanceAction = match serde_json::from_str(&event.payload) {
+            Ok(a) => a,
+            Err(e) => {
+                return EventOutcome {
+                    event_index: index,
+                    action: format!("(unparseable: {})", event.event_type),
+                    decision: "error".to_string(),
+                    reason: format!("failed to parse payload: {e}"),
+                };
+            }
+        };
+
+        let action_label = action_summary(&action);
+
+        let ctx = AgentContext {
+            agent_id: aa_core::AgentId::from_bytes([0; 16]),
+            session_id: aa_core::SessionId::from_bytes([0; 16]),
+            pid: 0,
+            started_at: aa_core::time::Timestamp::from_nanos(0),
+            metadata: BTreeMap::new(),
+        };
+
+        let result = self.engine.evaluate(&ctx, &action);
+
+        let (decision, reason) = match result.decision {
+            PolicyResult::Allow => ("allow".to_string(), "allowed by policy".to_string()),
+            PolicyResult::Deny { reason } => ("deny".to_string(), reason),
+            PolicyResult::RequiresApproval { timeout_secs } => (
+                "requires_approval".to_string(),
+                format!("requires human approval (timeout: {timeout_secs}s)"),
+            ),
+        };
+
+        EventOutcome {
+            event_index: index,
+            action: action_label,
+            decision,
+            reason,
+        }
     }
 
     /// Run the simulation against a sequence of events, producing an aggregate report.
-    pub fn run(&self, _events: &[SimulationEvent]) -> SimulationReport {
-        todo!("AAASM-73: iterate events and collect into SimulationReport")
+    pub fn run(&self, events: &[SimulationEvent]) -> SimulationReport {
+        let mut allowed = 0usize;
+        let mut denied = 0usize;
+        let mut approval_required = 0usize;
+        let mut flagged_outcomes = Vec::new();
+
+        for (i, event) in events.iter().enumerate() {
+            let outcome = self.simulate_event(i, event);
+            match outcome.decision.as_str() {
+                "allow" => allowed += 1,
+                "deny" => {
+                    denied += 1;
+                    flagged_outcomes.push(outcome);
+                }
+                "requires_approval" => {
+                    approval_required += 1;
+                    flagged_outcomes.push(outcome);
+                }
+                _ => {
+                    // "error" or unknown — treat as flagged
+                    flagged_outcomes.push(outcome);
+                }
+            }
+        }
+
+        SimulationReport {
+            total_events: events.len(),
+            denied,
+            allowed,
+            approval_required,
+            budget_impact_usd: None,
+            flagged_outcomes,
+        }
+    }
+}
+
+/// Produce a short human-readable label for a governance action.
+fn action_summary(action: &GovernanceAction) -> String {
+    match action {
+        GovernanceAction::ToolCall { name, .. } => format!("tool:{name}"),
+        GovernanceAction::FileAccess { path, mode } => format!("file:{mode:?}:{path}"),
+        GovernanceAction::NetworkRequest { url, method, .. } => format!("net:{method}:{url}"),
+        GovernanceAction::ProcessExec { command, .. } => format!("exec:{command}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn make_engine(policy_yaml: &str) -> SimulationEngine {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(policy_yaml.as_bytes()).unwrap();
+        tmp.flush().unwrap();
+        let (tx, _rx) = tokio::sync::broadcast::channel(16);
+        let engine = PolicyEngine::load_from_file(tmp.path(), tx).unwrap();
+        SimulationEngine::new(Arc::new(engine))
+    }
+
+    fn tool_call_event(name: &str) -> SimulationEvent {
+        SimulationEvent {
+            event_type: "ToolCallIntercepted".to_string(),
+            agent_id: "test-agent".to_string(),
+            payload: serde_json::to_string(&GovernanceAction::ToolCall {
+                name: name.to_string(),
+                args: "{}".to_string(),
+            })
+            .unwrap(),
+        }
+    }
+
+    const ALLOW_ALL_POLICY: &str = r#"
+        tier: low
+        rules:
+          - id: allow-all
+            description: Allow everything
+            match:
+              actions: ["*"]
+            effect: allow
+            audit: true
+    "#;
+
+    #[test]
+    fn simulate_event_allow() {
+        let sim = make_engine(ALLOW_ALL_POLICY);
+        let event = tool_call_event("read_file");
+        let outcome = sim.simulate_event(0, &event);
+        assert_eq!(outcome.decision, "allow");
+        assert_eq!(outcome.event_index, 0);
+        assert!(outcome.action.contains("read_file"));
+    }
+
+    #[test]
+    fn simulate_event_unparseable_payload() {
+        let sim = make_engine(ALLOW_ALL_POLICY);
+        let event = SimulationEvent {
+            event_type: "ToolCallIntercepted".to_string(),
+            agent_id: "agent-1".to_string(),
+            payload: "not valid json".to_string(),
+        };
+        let outcome = sim.simulate_event(0, &event);
+        assert_eq!(outcome.decision, "error");
+        assert!(outcome.reason.contains("failed to parse"));
+    }
+
+    #[test]
+    fn run_empty_events() {
+        let sim = make_engine(ALLOW_ALL_POLICY);
+        let report = sim.run(&[]);
+        assert_eq!(report.total_events, 0);
+        assert_eq!(report.allowed, 0);
+        assert_eq!(report.denied, 0);
+        assert!(report.flagged_outcomes.is_empty());
+    }
+
+    #[test]
+    fn run_all_allowed() {
+        let sim = make_engine(ALLOW_ALL_POLICY);
+        let events = vec![tool_call_event("read"), tool_call_event("write")];
+        let report = sim.run(&events);
+        assert_eq!(report.total_events, 2);
+        assert_eq!(report.allowed, 2);
+        assert_eq!(report.denied, 0);
+        assert!(report.flagged_outcomes.is_empty());
     }
 }

--- a/aa-gateway/src/simulation/live.rs
+++ b/aa-gateway/src/simulation/live.rs
@@ -39,10 +39,67 @@ impl LiveSimulation {
 
     /// Run the live simulation, observing events for the configured duration.
     ///
-    /// Subscribes to the event stream, evaluates each event against the loaded
-    /// policy, and collects results into a [`SimulationReport`]. Does not enforce
-    /// any decisions or produce side effects.
+    /// Currently returns an empty report after sleeping for the configured
+    /// duration. Full event-stream subscription will be added when the
+    /// gateway event bus exposes a broadcast receiver for live traffic.
     pub async fn run(&self) -> Result<SimulationReport, SimulationError> {
-        todo!("AAASM-73: subscribe to event stream and evaluate for configured duration")
+        tokio::time::sleep(self.duration).await;
+
+        Ok(SimulationReport {
+            total_events: 0,
+            denied: 0,
+            allowed: 0,
+            approval_required: 0,
+            budget_impact_usd: None,
+            flagged_outcomes: Vec::new(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::sync::Arc;
+
+    use crate::PolicyEngine;
+
+    fn make_live_sim(duration: Duration) -> LiveSimulation {
+        let policy_yaml = r#"
+            tier: low
+            rules:
+              - id: allow-all
+                description: Allow everything
+                match:
+                  actions: ["*"]
+                effect: allow
+                audit: true
+        "#;
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        tmp.write_all(policy_yaml.as_bytes()).unwrap();
+        tmp.flush().unwrap();
+        let (tx, _rx) = tokio::sync::broadcast::channel(16);
+        let engine = PolicyEngine::load_from_file(tmp.path(), tx).unwrap();
+        let sim_engine = SimulationEngine::new(Arc::new(engine));
+        LiveSimulation::new(sim_engine, duration)
+    }
+
+    #[test]
+    fn accessors() {
+        let sim = make_live_sim(Duration::from_secs(5));
+        assert_eq!(sim.duration(), Duration::from_secs(5));
+        // Verify the engine is accessible through the accessor chain.
+        let _ = sim.engine().engine();
+    }
+
+    #[tokio::test]
+    async fn run_returns_empty_report() {
+        let sim = make_live_sim(Duration::from_millis(10));
+        let report = sim.run().await.unwrap();
+        assert_eq!(report.total_events, 0);
+        assert_eq!(report.allowed, 0);
+        assert_eq!(report.denied, 0);
+        assert_eq!(report.approval_required, 0);
+        assert!(report.flagged_outcomes.is_empty());
     }
 }

--- a/aa-gateway/src/simulation/replay.rs
+++ b/aa-gateway/src/simulation/replay.rs
@@ -44,10 +44,8 @@ impl HistoricalReplay {
             if trimmed.is_empty() {
                 continue;
             }
-            let event: SimulationEvent =
-                serde_json::from_str(trimmed).map_err(|e| {
-                    SimulationError::AuditParse(format!("line {}: {e}", line_num + 1))
-                })?;
+            let event: SimulationEvent = serde_json::from_str(trimmed)
+                .map_err(|e| SimulationError::AuditParse(format!("line {}: {e}", line_num + 1)))?;
             events.push(event);
         }
 

--- a/aa-gateway/src/simulation/replay.rs
+++ b/aa-gateway/src/simulation/replay.rs
@@ -1,5 +1,6 @@
 //! Historical audit log replay for dry-run policy simulation.
 
+use std::io::BufRead;
 use std::path::Path;
 
 use serde::Deserialize;
@@ -21,6 +22,7 @@ pub struct SimulationEvent {
 }
 
 /// Reads an audit log JSONL file and produces a sequence of `SimulationEvent`s.
+#[derive(Debug)]
 pub struct HistoricalReplay {
     /// Parsed events from the audit log file.
     events: Vec<SimulationEvent>,
@@ -30,13 +32,96 @@ impl HistoricalReplay {
     /// Parse an audit log JSONL file into a replay sequence.
     ///
     /// Each line of the file is expected to be a JSON object matching
-    /// the `SimulationEvent` schema.
-    pub fn from_file(_path: &Path) -> Result<Self, SimulationError> {
-        todo!("AAASM-73: read JSONL file and deserialize lines into SimulationEvent")
+    /// the `SimulationEvent` schema. Blank lines are skipped.
+    pub fn from_file(path: &Path) -> Result<Self, SimulationError> {
+        let file = std::fs::File::open(path)?;
+        let reader = std::io::BufReader::new(file);
+        let mut events = Vec::new();
+
+        for (line_num, line_result) in reader.lines().enumerate() {
+            let line = line_result?;
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let event: SimulationEvent =
+                serde_json::from_str(trimmed).map_err(|e| {
+                    SimulationError::AuditParse(format!("line {}: {e}", line_num + 1))
+                })?;
+            events.push(event);
+        }
+
+        Ok(Self { events })
     }
 
     /// Returns a slice of all parsed simulation events.
     pub fn events(&self) -> &[SimulationEvent] {
         &self.events
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn parse_valid_jsonl() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(
+            tmp,
+            r#"{{"event_type":"ToolCallIntercepted","agent_id":"agent-1","payload":"{{\"name\":\"read_file\"}}" }}"#
+        )
+        .unwrap();
+        writeln!(
+            tmp,
+            r#"{{"event_type":"PolicyViolation","agent_id":"agent-2","payload":"{{\"name\":\"delete_db\"}}" }}"#
+        )
+        .unwrap();
+
+        let replay = HistoricalReplay::from_file(tmp.path()).unwrap();
+        assert_eq!(replay.events().len(), 2);
+        assert_eq!(replay.events()[0].event_type, "ToolCallIntercepted");
+        assert_eq!(replay.events()[0].agent_id, "agent-1");
+        assert_eq!(replay.events()[1].event_type, "PolicyViolation");
+    }
+
+    #[test]
+    fn parse_empty_file() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let replay = HistoricalReplay::from_file(tmp.path()).unwrap();
+        assert!(replay.events().is_empty());
+    }
+
+    #[test]
+    fn skip_blank_lines() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmp).unwrap();
+        writeln!(
+            tmp,
+            r#"{{"event_type":"ToolCallIntercepted","agent_id":"a1","payload":"{{}}"}}"#
+        )
+        .unwrap();
+        writeln!(tmp).unwrap();
+
+        let replay = HistoricalReplay::from_file(tmp.path()).unwrap();
+        assert_eq!(replay.events().len(), 1);
+    }
+
+    #[test]
+    fn malformed_line_returns_error() {
+        let mut tmp = tempfile::NamedTempFile::new().unwrap();
+        writeln!(tmp, "not valid json").unwrap();
+
+        let result = HistoricalReplay::from_file(tmp.path());
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("line 1"));
+    }
+
+    #[test]
+    fn missing_file_returns_error() {
+        let result = HistoricalReplay::from_file(Path::new("/tmp/nonexistent-audit-log.jsonl"));
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Description

Replace all `todo!()` stubs in the `aa-gateway` simulation module so that `aasm policy simulate` no longer panics at runtime.

**Changes:**
- **HistoricalReplay::from_file** — Reads JSONL audit log files line-by-line, skips blank lines, parses each line as a `SimulationEvent`, reports parse errors with line numbers.
- **SimulationEngine::simulate_event** — Deserializes the event payload into a `GovernanceAction`, constructs a synthetic `AgentContext`, calls `PolicyEngine::evaluate`, and maps the `PolicyResult` to an `EventOutcome`.
- **SimulationEngine::run** — Iterates events, tallies allow/deny/approval counts, collects flagged outcomes into a `SimulationReport`.
- **LiveSimulation::run** — Duration-bounded stub that sleeps for the configured duration and returns an empty report. Full event-stream subscription deferred until the gateway event bus exposes a broadcast receiver.
- **action_summary helper** — Produces human-readable labels for all `GovernanceAction` variants (ToolCall, FileAccess, NetworkRequest, ProcessExec).

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-177
- Parent Epic: AAASM-10

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

**New tests (11 total):**

`simulation::replay` (5 tests):
- `parse_valid_jsonl` — parses multi-line JSONL correctly
- `parse_empty_file` — returns empty vec for empty file
- `skip_blank_lines` — blank lines are ignored
- `malformed_line_returns_error` — reports line number on parse failure
- `missing_file_returns_error` — IO error on nonexistent file

`simulation::engine` (4 tests):
- `simulate_event_allow` — allowed tool call produces "allow" decision
- `simulate_event_unparseable_payload` — bad JSON produces "error" decision
- `run_empty_events` — empty input produces zeroed report
- `run_all_allowed` — multiple allowed events tally correctly

`simulation::live` (2 tests):
- `accessors` — duration and engine accessors work
- `run_returns_empty_report` — stub returns empty report after short sleep

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention