### PR TITLE
[AAASM-173] 📝 openapi(ws): Document WebSocket events endpoint

### DIFF
--- a/aa-api/src/models/event.rs
+++ b/aa-api/src/models/event.rs
@@ -5,6 +5,9 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use super::event_type::EventType;
+// Used in #[schema(value_type = ...)] attribute for OpenAPI generation.
+#[allow(unused_imports)]
+use super::ws_payloads::EventPayload;
 
 /// Unique identifier for a governance event in the replay buffer.
 pub type EventId = u64;
@@ -24,7 +27,9 @@ pub struct GovernanceEvent {
     pub event_type: EventType,
     /// Agent that produced or is associated with the event.
     pub agent_id: String,
-    /// Event-specific payload serialised as a JSON value.
+    /// Event-specific payload whose schema depends on `event_type`:
+    /// `ViolationPayload`, `ApprovalPayload`, or `BudgetAlertPayload`.
+    #[schema(value_type = EventPayload)]
     pub payload: serde_json::Value,
     /// Timestamp when the event was received by the API layer (ISO 8601).
     #[schema(value_type = String)]

--- a/aa-api/src/models/event.rs
+++ b/aa-api/src/models/event.rs
@@ -18,6 +18,7 @@ pub type EventId = u64;
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct GovernanceEvent {
     /// Monotonically increasing event identifier.
+    #[schema(value_type = u64)]
     pub id: EventId,
     /// Classification of the event for client-side filtering.
     pub event_type: EventType,

--- a/aa-api/src/models/event.rs
+++ b/aa-api/src/models/event.rs
@@ -25,6 +25,7 @@ pub struct GovernanceEvent {
     pub agent_id: String,
     /// Event-specific payload serialised as a JSON value.
     pub payload: serde_json::Value,
-    /// Timestamp when the event was received by the API layer.
+    /// Timestamp when the event was received by the API layer (ISO 8601).
+    #[schema(value_type = String)]
     pub timestamp: DateTime<Utc>,
 }

--- a/aa-api/src/models/mod.rs
+++ b/aa-api/src/models/mod.rs
@@ -3,6 +3,7 @@
 pub mod event;
 pub mod event_type;
 pub mod trace;
+pub mod ws_payloads;
 
 pub use event::{EventId, GovernanceEvent};
 pub use event_type::EventType;

--- a/aa-api/src/models/ws_payloads.rs
+++ b/aa-api/src/models/ws_payloads.rs
@@ -66,3 +66,20 @@ pub struct BudgetAlertPayload {
     /// Configured daily limit in USD.
     pub limit_usd: f64,
 }
+
+/// Discriminated union of all possible `GovernanceEvent.payload` shapes.
+///
+/// The concrete variant is determined by the sibling `event_type` field:
+/// - `"violation"` → [`ViolationPayload`]
+/// - `"approval"` → [`ApprovalPayload`]
+/// - `"budget"` → [`BudgetAlertPayload`]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(untagged)]
+pub enum EventPayload {
+    /// Pipeline / violation event payload.
+    Violation(ViolationPayload),
+    /// Approval request event payload.
+    Approval(ApprovalPayload),
+    /// Budget threshold alert payload.
+    Budget(BudgetAlertPayload),
+}

--- a/aa-api/src/models/ws_payloads.rs
+++ b/aa-api/src/models/ws_payloads.rs
@@ -1,0 +1,68 @@
+//! OpenAPI schemas for WebSocket event payloads.
+//!
+//! These types document the JSON structure of `GovernanceEvent.payload`
+//! for each [`EventType`] variant.  They mirror the internal runtime
+//! and gateway types (`PipelineEvent`, `ApprovalRequest`, `BudgetAlert`)
+//! without pulling `utoipa` into those crates.
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// Payload for `event_type: "violation"` events.
+///
+/// Represents a governance audit event from the pipeline — either an
+/// action that violated policy or an interception layer degradation.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ViolationPayload {
+    /// A governance audit event enriched with runtime metadata.
+    Audit {
+        /// Source that delivered the event: `"sdk"`, `"ebpf"`, or `"proxy"`.
+        source: String,
+        /// Unix milliseconds when the pipeline received the event.
+        received_at_ms: i64,
+        /// Monotonic sequence number assigned by the pipeline.
+        sequence_number: u64,
+    },
+    /// An interception layer became unavailable.
+    LayerDegradation {
+        /// Name of the degraded layer (e.g. `"ebpf"`, `"proxy"`).
+        layer: String,
+        /// Human-readable reason for the degradation.
+        reason: String,
+        /// Remaining active layers after degradation.
+        remaining_layers: Vec<String>,
+    },
+}
+
+/// Payload for `event_type: "approval"` events.
+///
+/// Represents a human-in-the-loop approval request submitted by the
+/// policy engine when an action requires explicit authorisation.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ApprovalPayload {
+    /// Unique ID for the approval request (UUID v4).
+    pub request_id: String,
+    /// Human-readable description of the action awaiting approval.
+    pub action: String,
+    /// Policy condition that triggered this request.
+    pub condition_triggered: String,
+    /// Unix epoch timestamp (seconds) when the request was submitted.
+    pub submitted_at: u64,
+    /// Seconds before the request times out.
+    pub timeout_secs: u64,
+}
+
+/// Payload for `event_type: "budget"` events.
+///
+/// Emitted when an agent's spend crosses a configured daily threshold
+/// (80 % or 95 % of the daily limit).
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct BudgetAlertPayload {
+    /// Threshold percentage that was crossed (e.g. `80` or `95`).
+    pub threshold_pct: u8,
+    /// Current total spend in USD at the time of the alert.
+    pub spent_usd: f64,
+    /// Configured daily limit in USD.
+    pub limit_usd: f64,
+}

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -7,6 +7,7 @@ use utoipa::{Modify, OpenApi};
 use crate::models::event::GovernanceEvent;
 use crate::models::event_type::EventType;
 use crate::models::trace::{TraceResponse, TraceSpan};
+use crate::models::ws_payloads::{ApprovalPayload, BudgetAlertPayload, ViolationPayload};
 use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, traces};
 
 /// Root OpenAPI document collecting all annotated paths and schemas.
@@ -70,6 +71,9 @@ use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, trac
         crate::auth::scope::Scope,
         GovernanceEvent,
         EventType,
+        ViolationPayload,
+        ApprovalPayload,
+        BudgetAlertPayload,
     )),
     modifiers(&SecurityAddon),
 )]

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -4,7 +4,7 @@ use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
 use utoipa::openapi::ComponentsBuilder;
 use utoipa::{Modify, OpenApi};
 
-use crate::models::event::{GovernanceEvent};
+use crate::models::event::GovernanceEvent;
 use crate::models::event_type::EventType;
 use crate::models::trace::{TraceResponse, TraceSpan};
 use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, traces};

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -7,7 +7,7 @@ use utoipa::{Modify, OpenApi};
 use crate::models::event::GovernanceEvent;
 use crate::models::event_type::EventType;
 use crate::models::trace::{TraceResponse, TraceSpan};
-use crate::models::ws_payloads::{ApprovalPayload, BudgetAlertPayload, ViolationPayload};
+use crate::models::ws_payloads::{ApprovalPayload, BudgetAlertPayload, EventPayload, ViolationPayload};
 use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, traces};
 
 /// Root OpenAPI document collecting all annotated paths and schemas.
@@ -74,6 +74,7 @@ use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, trac
         ViolationPayload,
         ApprovalPayload,
         BudgetAlertPayload,
+        EventPayload,
     )),
     modifiers(&SecurityAddon),
 )]

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -4,6 +4,8 @@ use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
 use utoipa::openapi::ComponentsBuilder;
 use utoipa::{Modify, OpenApi};
 
+use crate::models::event::{GovernanceEvent};
+use crate::models::event_type::EventType;
 use crate::models::trace::{TraceResponse, TraceSpan};
 use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, traces};
 
@@ -30,6 +32,7 @@ use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, trac
         (name = "costs", description = "Cost and budget tracking"),
         (name = "alerts", description = "Governance alerts"),
         (name = "auth", description = "Authentication and token issuance"),
+        (name = "events", description = "Real-time event streaming via WebSocket"),
     ),
     paths(
         crate::routes::health::health,
@@ -47,6 +50,7 @@ use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, trac
         costs::get_cost_summary,
         alerts::list_alerts,
         auth::issue_token,
+        crate::ws::handler::ws_events_handler,
     ),
     components(schemas(
         crate::routes::health::HealthResponse,
@@ -64,6 +68,8 @@ use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, trac
         auth::TokenRequest,
         auth::TokenResponse,
         crate::auth::scope::Scope,
+        GovernanceEvent,
+        EventType,
     )),
     modifiers(&SecurityAddon),
 )]

--- a/aa-api/src/ws/handler.rs
+++ b/aa-api/src/ws/handler.rs
@@ -16,6 +16,41 @@ use futures::{SinkExt, StreamExt};
 const PING_INTERVAL: Duration = Duration::from_secs(30);
 
 /// `GET /api/v1/ws/events` — upgrade to WebSocket and stream events.
+///
+/// Initiates a WebSocket connection for real-time governance event streaming.
+///
+/// ## Protocol
+///
+/// 1. Client sends an HTTP GET with `Upgrade: websocket` headers.
+/// 2. Server responds with `101 Switching Protocols` and upgrades the connection.
+/// 3. Server sends `GovernanceEvent` JSON objects as text frames.
+/// 4. Server sends periodic ping frames (every 30s); client must respond with pong.
+/// 5. Either side may close the connection with a close frame.
+///
+/// ## Replay
+///
+/// The server maintains a circular buffer of the last 1000 events. Pass the
+/// `since` query parameter with a previously received event `id` to replay
+/// all buffered events after that id before switching to live streaming.
+///
+/// ## Event Types
+///
+/// Filter events using the `types` query parameter (comma-separated):
+/// - `violation` — audit / pipeline events (policy violations)
+/// - `approval` — human-in-the-loop approval requests
+/// - `budget` — budget threshold alerts
+///
+/// All types are streamed when the parameter is omitted.
+#[utoipa::path(
+    get,
+    path = "/api/v1/ws/events",
+    params(WsQueryParams),
+    responses(
+        (status = 101, description = "WebSocket upgrade successful. Server streams GovernanceEvent JSON text frames."),
+        (status = 400, description = "Bad request (invalid query parameters)")
+    ),
+    tag = "events"
+)]
 pub async fn ws_events_handler(
     ws: WebSocketUpgrade,
     Query(params): Query<WsQueryParams>,

--- a/aa-api/src/ws/handler.rs
+++ b/aa-api/src/ws/handler.rs
@@ -47,6 +47,7 @@ const PING_INTERVAL: Duration = Duration::from_secs(30);
     params(WsQueryParams),
     responses(
         (status = 101, description = "WebSocket upgrade successful. Server streams GovernanceEvent JSON text frames."),
+        (status = 200, description = "Event message schema (delivered as WebSocket text frames, not as an HTTP response body).", body = GovernanceEvent),
         (status = 400, description = "Bad request (invalid query parameters)")
     ),
     tag = "events"

--- a/aa-api/src/ws/params.rs
+++ b/aa-api/src/ws/params.rs
@@ -1,6 +1,7 @@
 //! Query parameters for the WebSocket events endpoint.
 
 use serde::Deserialize;
+use utoipa::IntoParams;
 
 use crate::models::{EventId, EventType};
 
@@ -11,13 +12,15 @@ use crate::models::{EventId, EventType};
 ///   All types are included when omitted.
 /// - `agent_id`: restrict events to a single agent.
 /// - `since`: replay buffered events whose id is greater than this value.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, IntoParams)]
 pub struct WsQueryParams {
-    /// Comma-separated event type filter.
+    /// Comma-separated event type filter (e.g. `violation,budget`).
+    /// All types are included when omitted.
     pub types: Option<String>,
-    /// Filter events by agent identifier.
+    /// Filter events by agent identifier (hex-encoded).
     pub agent_id: Option<String>,
-    /// Replay events after this event id on reconnect.
+    /// Replay buffered events whose id is greater than this value.
+    /// The server keeps the last 1000 events in a circular buffer.
     pub since: Option<EventId>,
 }
 

--- a/aa-api/src/ws/params.rs
+++ b/aa-api/src/ws/params.rs
@@ -21,6 +21,7 @@ pub struct WsQueryParams {
     pub agent_id: Option<String>,
     /// Replay buffered events whose id is greater than this value.
     /// The server keeps the last 1000 events in a circular buffer.
+    #[param(value_type = Option<u64>)]
     pub since: Option<EventId>,
 }
 

--- a/aa-api/tests/openapi_spec.rs
+++ b/aa-api/tests/openapi_spec.rs
@@ -101,10 +101,7 @@ fn governance_event_schema_exists() {
         schemas.contains_key("BudgetAlertPayload"),
         "BudgetAlertPayload schema missing"
     );
-    assert!(
-        schemas.contains_key("EventPayload"),
-        "EventPayload schema missing"
-    );
+    assert!(schemas.contains_key("EventPayload"), "EventPayload schema missing");
 }
 
 #[test]

--- a/aa-api/tests/openapi_spec.rs
+++ b/aa-api/tests/openapi_spec.rs
@@ -71,7 +71,10 @@ fn ws_events_has_query_params() {
     let spec = aa_api::ApiDoc::openapi();
     let yaml = serde_yaml::to_string(&spec).unwrap();
     // WsQueryParams fields should appear as query parameters
-    assert!(yaml.contains("operationId: ws_events_handler"), "ws operationId missing");
+    assert!(
+        yaml.contains("operationId: ws_events_handler"),
+        "ws operationId missing"
+    );
     assert!(yaml.contains("name: types"), "types query param missing");
     assert!(yaml.contains("name: agent_id"), "agent_id query param missing");
     assert!(yaml.contains("name: since"), "since query param missing");
@@ -81,7 +84,10 @@ fn ws_events_has_query_params() {
 fn governance_event_schema_exists() {
     let spec = aa_api::ApiDoc::openapi();
     let schemas = &spec.components.as_ref().expect("components should exist").schemas;
-    assert!(schemas.contains_key("GovernanceEvent"), "GovernanceEvent schema missing");
+    assert!(
+        schemas.contains_key("GovernanceEvent"),
+        "GovernanceEvent schema missing"
+    );
     assert!(schemas.contains_key("EventType"), "EventType schema missing");
 }
 

--- a/aa-api/tests/openapi_spec.rs
+++ b/aa-api/tests/openapi_spec.rs
@@ -54,3 +54,43 @@ fn health_get_has_operation_id() {
         "health operationId missing from spec"
     );
 }
+
+#[test]
+fn ws_events_path_exists() {
+    let spec = aa_api::ApiDoc::openapi();
+    let paths = &spec.paths;
+    assert!(
+        paths.paths.contains_key("/api/v1/ws/events"),
+        "expected /api/v1/ws/events in paths, got: {:?}",
+        paths.paths.keys().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn ws_events_has_query_params() {
+    let spec = aa_api::ApiDoc::openapi();
+    let yaml = serde_yaml::to_string(&spec).unwrap();
+    // WsQueryParams fields should appear as query parameters
+    assert!(yaml.contains("operationId: ws_events_handler"), "ws operationId missing");
+    assert!(yaml.contains("name: types"), "types query param missing");
+    assert!(yaml.contains("name: agent_id"), "agent_id query param missing");
+    assert!(yaml.contains("name: since"), "since query param missing");
+}
+
+#[test]
+fn governance_event_schema_exists() {
+    let spec = aa_api::ApiDoc::openapi();
+    let schemas = &spec.components.as_ref().expect("components should exist").schemas;
+    assert!(schemas.contains_key("GovernanceEvent"), "GovernanceEvent schema missing");
+    assert!(schemas.contains_key("EventType"), "EventType schema missing");
+}
+
+#[test]
+fn event_type_enum_variants() {
+    let spec = aa_api::ApiDoc::openapi();
+    let yaml = serde_yaml::to_string(&spec).unwrap();
+    // EventType enum should list all three variants in snake_case
+    assert!(yaml.contains("violation"), "violation variant missing from EventType");
+    assert!(yaml.contains("approval"), "approval variant missing from EventType");
+    assert!(yaml.contains("budget"), "budget variant missing from EventType");
+}

--- a/aa-api/tests/openapi_spec.rs
+++ b/aa-api/tests/openapi_spec.rs
@@ -89,6 +89,22 @@ fn governance_event_schema_exists() {
         "GovernanceEvent schema missing"
     );
     assert!(schemas.contains_key("EventType"), "EventType schema missing");
+    assert!(
+        schemas.contains_key("ViolationPayload"),
+        "ViolationPayload schema missing"
+    );
+    assert!(
+        schemas.contains_key("ApprovalPayload"),
+        "ApprovalPayload schema missing"
+    );
+    assert!(
+        schemas.contains_key("BudgetAlertPayload"),
+        "BudgetAlertPayload schema missing"
+    );
+    assert!(
+        schemas.contains_key("EventPayload"),
+        "EventPayload schema missing"
+    );
 }
 
 #[test]

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -1020,6 +1020,15 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Event message schema (delivered as WebSocket text frames, not as an HTTP response body). */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GovernanceEvent"];
+                };
+            };
             /** @description Bad request (invalid query parameters) */
             400: {
                 headers: {

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -276,6 +276,49 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/ws/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * `GET /api/v1/ws/events` — upgrade to WebSocket and stream events.
+         * @description Initiates a WebSocket connection for real-time governance event streaming.
+         *
+         *     ## Protocol
+         *
+         *     1. Client sends an HTTP GET with `Upgrade: websocket` headers.
+         *     2. Server responds with `101 Switching Protocols` and upgrades the connection.
+         *     3. Server sends `GovernanceEvent` JSON objects as text frames.
+         *     4. Server sends periodic ping frames (every 30s); client must respond with pong.
+         *     5. Either side may close the connection with a close frame.
+         *
+         *     ## Replay
+         *
+         *     The server maintains a circular buffer of the last 1000 events. Pass the
+         *     `since` query parameter with a previously received event `id` to replay
+         *     all buffered events after that id before switching to live streaming.
+         *
+         *     ## Event Types
+         *
+         *     Filter events using the `types` query parameter (comma-separated):
+         *     - `violation` — audit / pipeline events (policy violations)
+         *     - `approval` — human-in-the-loop approval requests
+         *     - `budget` — budget threshold alerts
+         *
+         *     All types are streamed when the parameter is omitted.
+         */
+        get: operations["ws_events_handler"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -349,6 +392,36 @@ export interface components {
             by?: string | null;
             /** @description Optional reason for the decision. */
             reason?: string | null;
+        };
+        /**
+         * @description Classification of governance events for client-side filtering.
+         *
+         *     Clients specify a comma-separated list of these values in the `types`
+         *     query parameter to receive only matching events on the WebSocket.
+         * @enum {string}
+         */
+        EventType: "violation" | "approval" | "budget";
+        /**
+         * @description A governance event delivered to WebSocket subscribers.
+         *
+         *     This is the unified JSON representation sent over the wire.
+         *     It wraps events from all three domain channels (pipeline,
+         *     approval, budget) into a single schema that clients can
+         *     filter by [`EventType`].
+         */
+        GovernanceEvent: {
+            /** @description Agent that produced or is associated with the event. */
+            agent_id: string;
+            event_type: components["schemas"]["EventType"];
+            /**
+             * Format: int64
+             * @description Monotonically increasing event identifier.
+             */
+            id: number;
+            /** @description Event-specific payload serialised as a JSON value. */
+            payload: unknown;
+            /** @description Timestamp when the event was received by the API layer (ISO 8601). */
+            timestamp: string;
         };
         /** @description Response body for the health endpoint. */
         HealthResponse: {
@@ -911,6 +984,44 @@ export interface operations {
             };
             /** @description Session not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ws_events_handler: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Comma-separated event type filter (e.g. `violation,budget`).
+                 *     All types are included when omitted.
+                 */
+                types?: string | null;
+                /** @description Filter events by agent identifier (hex-encoded). */
+                agent_id?: string | null;
+                /**
+                 * @description Replay buffered events whose id is greater than this value.
+                 *     The server keeps the last 1000 events in a circular buffer.
+                 */
+                since?: number | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description WebSocket upgrade successful. Server streams GovernanceEvent JSON text frames. */
+            101: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad request (invalid query parameters) */
+            400: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -357,6 +357,30 @@ export interface components {
             /** @description ISO 8601 timestamp when the alert was raised. */
             timestamp: string;
         };
+        /**
+         * @description Payload for `event_type: "approval"` events.
+         *
+         *     Represents a human-in-the-loop approval request submitted by the
+         *     policy engine when an action requires explicit authorisation.
+         */
+        ApprovalPayload: {
+            /** @description Human-readable description of the action awaiting approval. */
+            action: string;
+            /** @description Policy condition that triggered this request. */
+            condition_triggered: string;
+            /** @description Unique ID for the approval request (UUID v4). */
+            request_id: string;
+            /**
+             * Format: int64
+             * @description Unix epoch timestamp (seconds) when the request was submitted.
+             */
+            submitted_at: number;
+            /**
+             * Format: int64
+             * @description Seconds before the request times out.
+             */
+            timeout_secs: number;
+        };
         /** @description JSON representation of a pending approval request. */
         ApprovalResponse: {
             /** @description The governance action requiring approval. */
@@ -371,6 +395,29 @@ export interface components {
             reason: string;
             /** @description Current status: "pending", "approved", or "rejected". */
             status: string;
+        };
+        /**
+         * @description Payload for `event_type: "budget"` events.
+         *
+         *     Emitted when an agent's spend crosses a configured daily threshold
+         *     (80 % or 95 % of the daily limit).
+         */
+        BudgetAlertPayload: {
+            /**
+             * Format: double
+             * @description Configured daily limit in USD.
+             */
+            limit_usd: number;
+            /**
+             * Format: double
+             * @description Current total spend in USD at the time of the alert.
+             */
+            spent_usd: number;
+            /**
+             * Format: int32
+             * @description Threshold percentage that was crossed (e.g. `80` or `95`).
+             */
+            threshold_pct: number;
         };
         /** @description JSON representation of the cost/budget summary. */
         CostSummary: {
@@ -393,6 +440,15 @@ export interface components {
             /** @description Optional reason for the decision. */
             reason?: string | null;
         };
+        /**
+         * @description Discriminated union of all possible `GovernanceEvent.payload` shapes.
+         *
+         *     The concrete variant is determined by the sibling `event_type` field:
+         *     - `"violation"` → [`ViolationPayload`]
+         *     - `"approval"` → [`ApprovalPayload`]
+         *     - `"budget"` → [`BudgetAlertPayload`]
+         */
+        EventPayload: components["schemas"]["ViolationPayload"] | components["schemas"]["ApprovalPayload"] | components["schemas"]["BudgetAlertPayload"];
         /**
          * @description Classification of governance events for client-side filtering.
          *
@@ -418,8 +474,7 @@ export interface components {
              * @description Monotonically increasing event identifier.
              */
             id: number;
-            /** @description Event-specific payload serialised as a JSON value. */
-            payload: unknown;
+            payload: components["schemas"]["EventPayload"];
             /** @description Timestamp when the event was received by the API layer (ISO 8601). */
             timestamp: string;
         };
@@ -533,6 +588,37 @@ export interface components {
             span_id: string;
             /** @description Start time of the span (ISO 8601). */
             start_time: string;
+        };
+        /**
+         * @description Payload for `event_type: "violation"` events.
+         *
+         *     Represents a governance audit event from the pipeline — either an
+         *     action that violated policy or an interception layer degradation.
+         */
+        ViolationPayload: {
+            /** @enum {string} */
+            kind: "audit";
+            /**
+             * Format: int64
+             * @description Unix milliseconds when the pipeline received the event.
+             */
+            received_at_ms: number;
+            /**
+             * Format: int64
+             * @description Monotonic sequence number assigned by the pipeline.
+             */
+            sequence_number: number;
+            /** @description Source that delivered the event: `"sdk"`, `"ebpf"`, or `"proxy"`. */
+            source: string;
+        } | {
+            /** @enum {string} */
+            kind: "layer_degradation";
+            /** @description Name of the degraded layer (e.g. `"ebpf"`, `"proxy"`). */
+            layer: string;
+            /** @description Human-readable reason for the degradation. */
+            reason: string;
+            /** @description Remaining active layers after degradation. */
+            remaining_layers: string[];
         };
     };
     responses: never;

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -450,6 +450,70 @@ paths:
                 $ref: '#/components/schemas/TraceResponse'
         '404':
           description: Session not found
+  /api/v1/ws/events:
+    get:
+      tags:
+      - events
+      summary: '`GET /api/v1/ws/events` — upgrade to WebSocket and stream events.'
+      description: |-
+        Initiates a WebSocket connection for real-time governance event streaming.
+
+        ## Protocol
+
+        1. Client sends an HTTP GET with `Upgrade: websocket` headers.
+        2. Server responds with `101 Switching Protocols` and upgrades the connection.
+        3. Server sends `GovernanceEvent` JSON objects as text frames.
+        4. Server sends periodic ping frames (every 30s); client must respond with pong.
+        5. Either side may close the connection with a close frame.
+
+        ## Replay
+
+        The server maintains a circular buffer of the last 1000 events. Pass the
+        `since` query parameter with a previously received event `id` to replay
+        all buffered events after that id before switching to live streaming.
+
+        ## Event Types
+
+        Filter events using the `types` query parameter (comma-separated):
+        - `violation` — audit / pipeline events (policy violations)
+        - `approval` — human-in-the-loop approval requests
+        - `budget` — budget threshold alerts
+
+        All types are streamed when the parameter is omitted.
+      operationId: ws_events_handler
+      parameters:
+      - name: types
+        in: query
+        description: |-
+          Comma-separated event type filter (e.g. `violation,budget`).
+          All types are included when omitted.
+        required: false
+        schema:
+          type: string
+          nullable: true
+      - name: agent_id
+        in: query
+        description: Filter events by agent identifier (hex-encoded).
+        required: false
+        schema:
+          type: string
+          nullable: true
+      - name: since
+        in: query
+        description: |-
+          Replay buffered events whose id is greater than this value.
+          The server keeps the last 1000 events in a circular buffer.
+        required: false
+        schema:
+          type: integer
+          format: int64
+          nullable: true
+          minimum: 0
+      responses:
+        '101':
+          description: WebSocket upgrade successful. Server streams GovernanceEvent JSON text frames.
+        '400':
+          description: Bad request (invalid query parameters)
 components:
   schemas:
     AgentResponse:
@@ -585,6 +649,48 @@ components:
           type: string
           description: Optional reason for the decision.
           nullable: true
+    EventType:
+      type: string
+      description: |-
+        Classification of governance events for client-side filtering.
+
+        Clients specify a comma-separated list of these values in the `types`
+        query parameter to receive only matching events on the WebSocket.
+      enum:
+      - violation
+      - approval
+      - budget
+    GovernanceEvent:
+      type: object
+      description: |-
+        A governance event delivered to WebSocket subscribers.
+
+        This is the unified JSON representation sent over the wire.
+        It wraps events from all three domain channels (pipeline,
+        approval, budget) into a single schema that clients can
+        filter by [`EventType`].
+      required:
+      - id
+      - event_type
+      - agent_id
+      - payload
+      - timestamp
+      properties:
+        agent_id:
+          type: string
+          description: Agent that produced or is associated with the event.
+        event_type:
+          $ref: '#/components/schemas/EventType'
+        id:
+          type: integer
+          format: int64
+          description: Monotonically increasing event identifier.
+          minimum: 0
+        payload:
+          description: Event-specific payload serialised as a JSON value.
+        timestamp:
+          type: string
+          description: Timestamp when the event was received by the API layer (ISO 8601).
     HealthResponse:
       type: object
       description: Response body for the health endpoint.
@@ -797,3 +903,5 @@ tags:
   description: Governance alerts
 - name: auth
   description: Authentication and token issuance
+- name: events
+  description: Real-time event streaming via WebSocket

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -588,6 +588,39 @@ components:
         timestamp:
           type: string
           description: ISO 8601 timestamp when the alert was raised.
+    ApprovalPayload:
+      type: object
+      description: |-
+        Payload for `event_type: "approval"` events.
+
+        Represents a human-in-the-loop approval request submitted by the
+        policy engine when an action requires explicit authorisation.
+      required:
+      - request_id
+      - action
+      - condition_triggered
+      - submitted_at
+      - timeout_secs
+      properties:
+        action:
+          type: string
+          description: Human-readable description of the action awaiting approval.
+        condition_triggered:
+          type: string
+          description: Policy condition that triggered this request.
+        request_id:
+          type: string
+          description: Unique ID for the approval request (UUID v4).
+        submitted_at:
+          type: integer
+          format: int64
+          description: Unix epoch timestamp (seconds) when the request was submitted.
+          minimum: 0
+        timeout_secs:
+          type: integer
+          format: int64
+          description: Seconds before the request times out.
+          minimum: 0
     ApprovalResponse:
       type: object
       description: JSON representation of a pending approval request.
@@ -617,6 +650,31 @@ components:
         status:
           type: string
           description: 'Current status: "pending", "approved", or "rejected".'
+    BudgetAlertPayload:
+      type: object
+      description: |-
+        Payload for `event_type: "budget"` events.
+
+        Emitted when an agent's spend crosses a configured daily threshold
+        (80 % or 95 % of the daily limit).
+      required:
+      - threshold_pct
+      - spent_usd
+      - limit_usd
+      properties:
+        limit_usd:
+          type: number
+          format: double
+          description: Configured daily limit in USD.
+        spent_usd:
+          type: number
+          format: double
+          description: Current total spend in USD at the time of the alert.
+        threshold_pct:
+          type: integer
+          format: int32
+          description: Threshold percentage that was crossed (e.g. `80` or `95`).
+          minimum: 0
     CostSummary:
       type: object
       description: JSON representation of the cost/budget summary.
@@ -655,6 +713,18 @@ components:
           type: string
           description: Optional reason for the decision.
           nullable: true
+    EventPayload:
+      oneOf:
+      - $ref: '#/components/schemas/ViolationPayload'
+      - $ref: '#/components/schemas/ApprovalPayload'
+      - $ref: '#/components/schemas/BudgetAlertPayload'
+      description: |-
+        Discriminated union of all possible `GovernanceEvent.payload` shapes.
+
+        The concrete variant is determined by the sibling `event_type` field:
+        - `"violation"` → [`ViolationPayload`]
+        - `"approval"` → [`ApprovalPayload`]
+        - `"budget"` → [`BudgetAlertPayload`]
     EventType:
       type: string
       description: |-
@@ -693,7 +763,7 @@ components:
           description: Monotonically increasing event identifier.
           minimum: 0
         payload:
-          description: Event-specific payload serialised as a JSON value.
+          $ref: '#/components/schemas/EventPayload'
         timestamp:
           type: string
           description: Timestamp when the event was received by the API layer (ISO 8601).
@@ -884,6 +954,62 @@ components:
         start_time:
           type: string
           description: Start time of the span (ISO 8601).
+    ViolationPayload:
+      oneOf:
+      - type: object
+        description: A governance audit event enriched with runtime metadata.
+        required:
+        - source
+        - received_at_ms
+        - sequence_number
+        - kind
+        properties:
+          kind:
+            type: string
+            enum:
+            - audit
+          received_at_ms:
+            type: integer
+            format: int64
+            description: Unix milliseconds when the pipeline received the event.
+          sequence_number:
+            type: integer
+            format: int64
+            description: Monotonic sequence number assigned by the pipeline.
+            minimum: 0
+          source:
+            type: string
+            description: 'Source that delivered the event: `"sdk"`, `"ebpf"`, or `"proxy"`.'
+      - type: object
+        description: An interception layer became unavailable.
+        required:
+        - layer
+        - reason
+        - remaining_layers
+        - kind
+        properties:
+          kind:
+            type: string
+            enum:
+            - layer_degradation
+          layer:
+            type: string
+            description: Name of the degraded layer (e.g. `"ebpf"`, `"proxy"`).
+          reason:
+            type: string
+            description: Human-readable reason for the degradation.
+          remaining_layers:
+            type: array
+            items:
+              type: string
+            description: Remaining active layers after degradation.
+      description: |-
+        Payload for `event_type: "violation"` events.
+
+        Represents a governance audit event from the pipeline — either an
+        action that violated policy or an interception layer degradation.
+      discriminator:
+        propertyName: kind
   securitySchemes:
     bearer_auth:
       type: http

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -512,6 +512,12 @@ paths:
       responses:
         '101':
           description: WebSocket upgrade successful. Server streams GovernanceEvent JSON text frames.
+        '200':
+          description: Event message schema (delivered as WebSocket text frames, not as an HTTP response body).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GovernanceEvent'
         '400':
           description: Bad request (invalid query parameters)
 components:


### PR DESCRIPTION
## Description

Document the WebSocket `/api/v1/ws/events` endpoint in the OpenAPI spec. Adds utoipa annotations to the handler and query parameters, registers the endpoint and schemas (`GovernanceEvent`, `EventType`) in the OpenAPI document, fixes broken `$ref` for `EventId` type alias and `DateTime<Utc>`, regenerates the committed spec and dashboard TypeScript types, and adds spec validation tests.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-173
- Parent epic: AAASM-9 (REST API Layer & OpenAPI Contract)

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

**Tests added:**
- `ws_events_path_exists` — verifies `/api/v1/ws/events` path is in the spec
- `ws_events_has_query_params` — verifies `types`, `agent_id`, `since` query params and operationId
- `governance_event_schema_exists` — verifies `GovernanceEvent` and `EventType` schemas registered
- `event_type_enum_variants` — verifies `violation`, `approval`, `budget` enum values present

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention