### PR TITLE
[AAASM-175] ✨ (agent): Add missing fields to Agent API response

### DIFF
--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -52,6 +52,8 @@ use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, trac
         crate::routes::health::HealthResponse,
         crate::error::ProblemDetail,
         agents::AgentResponse,
+        agents::ActiveSessionResponse,
+        agents::RecentEventResponse,
         logs::LogEntry,
         TraceResponse,
         TraceSpan,

--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -40,6 +40,10 @@ fn record_to_response(r: aa_gateway::registry::AgentRecord) -> AgentResponse {
         status: format!("{:?}", r.status),
         tool_names: r.tool_names,
         metadata: r.metadata,
+        pid: r.pid,
+        session_count: r.session_count,
+        last_event: r.last_event.map(|t| t.to_rfc3339()),
+        policy_violations_count: r.policy_violations_count,
     }
 }
 
@@ -60,6 +64,14 @@ pub struct AgentResponse {
     pub tool_names: Vec<String>,
     /// Arbitrary metadata key-value pairs.
     pub metadata: BTreeMap<String, String>,
+    /// OS process ID, if known.
+    pub pid: Option<u32>,
+    /// Number of sessions handled.
+    pub session_count: u32,
+    /// ISO 8601 timestamp of the most recent event.
+    pub last_event: Option<String>,
+    /// Number of policy violations recorded.
+    pub policy_violations_count: u32,
 }
 
 /// `GET /api/v1/agents` — list all registered agents with pagination.

--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -32,6 +32,26 @@ fn parse_agent_id(id: &str) -> Result<[u8; 16], ProblemDetail> {
 
 /// Convert an [`AgentRecord`] into an [`AgentResponse`].
 fn record_to_response(r: aa_gateway::registry::AgentRecord) -> AgentResponse {
+    let active_sessions = r
+        .active_sessions
+        .into_iter()
+        .map(|s| ActiveSessionResponse {
+            session_id: s.session_id,
+            started_at: s.started_at.to_rfc3339(),
+            status: s.status,
+        })
+        .collect();
+
+    let recent_events = r
+        .recent_events
+        .into_iter()
+        .map(|e| RecentEventResponse {
+            event_type: e.event_type,
+            summary: e.summary,
+            timestamp: e.timestamp.to_rfc3339(),
+        })
+        .collect();
+
     AgentResponse {
         id: r.agent_id.iter().map(|b| format!("{b:02x}")).collect::<String>(),
         name: r.name,
@@ -44,6 +64,8 @@ fn record_to_response(r: aa_gateway::registry::AgentRecord) -> AgentResponse {
         session_count: r.session_count,
         last_event: r.last_event.map(|t| t.to_rfc3339()),
         policy_violations_count: r.policy_violations_count,
+        active_sessions,
+        recent_events,
     }
 }
 
@@ -72,6 +94,32 @@ pub struct AgentResponse {
     pub last_event: Option<String>,
     /// Number of policy violations recorded.
     pub policy_violations_count: u32,
+    /// Currently active sessions for this agent.
+    pub active_sessions: Vec<ActiveSessionResponse>,
+    /// Most recent events emitted by this agent.
+    pub recent_events: Vec<RecentEventResponse>,
+}
+
+/// Summary of an active session in the API response.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct ActiveSessionResponse {
+    /// Hex-encoded session UUID.
+    pub session_id: String,
+    /// ISO 8601 timestamp when the session started.
+    pub started_at: String,
+    /// Current status of the session.
+    pub status: String,
+}
+
+/// Summary of a recent event in the API response.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct RecentEventResponse {
+    /// Event type classification (e.g. "violation", "approval", "budget").
+    pub event_type: String,
+    /// Short human-readable summary.
+    pub summary: String,
+    /// ISO 8601 timestamp when the event occurred.
+    pub timestamp: String,
 }
 
 /// `GET /api/v1/agents` — list all registered agents with pagination.

--- a/aa-api/tests/agents.rs
+++ b/aa-api/tests/agents.rs
@@ -297,4 +297,55 @@ async fn get_agent_response_null_optional_fields() {
     assert_eq!(json["session_count"], 0);
     assert!(json["last_event"].is_null());
     assert_eq!(json["policy_violations_count"], 0);
+    assert!(json["active_sessions"].as_array().unwrap().is_empty());
+    assert!(json["recent_events"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn get_agent_response_includes_active_sessions_and_recent_events() {
+    use aa_gateway::registry::{ActiveSession, RecentEvent};
+
+    let state = common::test_state();
+    let mut agent = test_agent(0xCC);
+    agent.active_sessions = vec![ActiveSession {
+        session_id: "sess-001".into(),
+        started_at: chrono::Utc::now(),
+        status: "running".into(),
+    }];
+    agent.recent_events.push_back(RecentEvent {
+        event_type: "violation".into(),
+        summary: "blocked tool call".into(),
+        timestamp: chrono::Utc::now(),
+    });
+    state.agent_registry.register(agent).unwrap();
+
+    let app = aa_api::server::build_app(state);
+    let id = hex_id(0xCC);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/agents/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    let sessions = json["active_sessions"].as_array().unwrap();
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0]["session_id"], "sess-001");
+    assert_eq!(sessions[0]["status"], "running");
+    assert!(sessions[0]["started_at"].as_str().is_some());
+
+    let events = json["recent_events"].as_array().unwrap();
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["event_type"], "violation");
+    assert_eq!(events[0]["summary"], "blocked tool call");
+    assert!(events[0]["timestamp"].as_str().is_some());
 }

--- a/aa-api/tests/agents.rs
+++ b/aa-api/tests/agents.rs
@@ -27,6 +27,7 @@ fn test_agent(id_byte: u8) -> AgentRecord {
         pid: None,
         session_count: 0,
         last_event: None,
+        policy_violations_count: 0,
     }
 }
 

--- a/aa-api/tests/agents.rs
+++ b/aa-api/tests/agents.rs
@@ -235,3 +235,64 @@ async fn list_agents_pagination_works() {
     assert_eq!(json["per_page"], 2);
     assert_eq!(json["items"].as_array().unwrap().len(), 2);
 }
+
+#[tokio::test]
+async fn get_agent_response_includes_new_fields() {
+    let state = common::test_state();
+    let mut agent = test_agent(0xDD);
+    agent.pid = Some(9876);
+    agent.session_count = 7;
+    agent.last_event = Some(chrono::Utc::now());
+    agent.policy_violations_count = 2;
+    state.agent_registry.register(agent).unwrap();
+
+    let app = aa_api::server::build_app(state);
+    let id = hex_id(0xDD);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/agents/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["pid"], 9876);
+    assert_eq!(json["session_count"], 7);
+    assert!(json["last_event"].as_str().is_some());
+    assert_eq!(json["policy_violations_count"], 2);
+}
+
+#[tokio::test]
+async fn get_agent_response_null_optional_fields() {
+    let state = common::test_state();
+    state.agent_registry.register(test_agent(0xEE)).unwrap();
+
+    let app = aa_api::server::build_app(state);
+    let id = hex_id(0xEE);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/agents/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(json["pid"].is_null());
+    assert_eq!(json["session_count"], 0);
+    assert!(json["last_event"].is_null());
+    assert_eq!(json["policy_violations_count"], 0);
+}

--- a/aa-api/tests/agents.rs
+++ b/aa-api/tests/agents.rs
@@ -28,6 +28,8 @@ fn test_agent(id_byte: u8) -> AgentRecord {
         session_count: 0,
         last_event: None,
         policy_violations_count: 0,
+        active_sessions: Vec::new(),
+        recent_events: std::collections::VecDeque::new(),
     }
 }
 

--- a/aa-api/tests/agents.rs
+++ b/aa-api/tests/agents.rs
@@ -24,6 +24,9 @@ fn test_agent(id_byte: u8) -> AgentRecord {
         registered_at: chrono::Utc::now(),
         last_heartbeat: chrono::Utc::now(),
         status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
     }
 }
 

--- a/aa-cli/src/commands/agent/inspect.rs
+++ b/aa-cli/src/commands/agent/inspect.rs
@@ -41,6 +41,20 @@ fn render_detail(agent: &AgentResponse) {
     };
     table.add_row(vec!["Tools".to_string(), tools]);
 
+    let pid_str = agent.pid.map_or("-".to_string(), |p| p.to_string());
+    table.add_row(vec!["PID".to_string(), pid_str]);
+
+    let sessions_str = agent.session_count.map_or("-".to_string(), |s| s.to_string());
+    table.add_row(vec!["Sessions".to_string(), sessions_str]);
+
+    let last_event_str = agent.last_event.as_deref().unwrap_or("-").to_string();
+    table.add_row(vec!["Last Event".to_string(), last_event_str]);
+
+    let violations_str = agent
+        .policy_violations_count
+        .map_or("-".to_string(), |v| v.to_string());
+    table.add_row(vec!["Policy Violations".to_string(), violations_str]);
+
     if !agent.metadata.is_empty() {
         let meta = agent
             .metadata

--- a/aa-cli/src/commands/agent/inspect.rs
+++ b/aa-cli/src/commands/agent/inspect.rs
@@ -50,9 +50,7 @@ fn render_detail(agent: &AgentResponse) {
     let last_event_str = agent.last_event.as_deref().unwrap_or("-").to_string();
     table.add_row(vec!["Last Event".to_string(), last_event_str]);
 
-    let violations_str = agent
-        .policy_violations_count
-        .map_or("-".to_string(), |v| v.to_string());
+    let violations_str = agent.policy_violations_count.map_or("-".to_string(), |v| v.to_string());
     table.add_row(vec!["Policy Violations".to_string(), violations_str]);
 
     if !agent.metadata.is_empty() {

--- a/aa-cli/src/commands/agent/inspect.rs
+++ b/aa-cli/src/commands/agent/inspect.rs
@@ -64,6 +64,36 @@ fn render_detail(agent: &AgentResponse) {
     }
 
     println!("{table}");
+
+    // Active sessions section
+    if !agent.active_sessions.is_empty() {
+        println!("\nActive Sessions:");
+        let mut sessions_table = Table::new();
+        sessions_table.set_header(vec!["SESSION_ID", "STARTED_AT", "STATUS"]);
+        for s in &agent.active_sessions {
+            sessions_table.add_row(vec![
+                Cell::new(&s.session_id),
+                Cell::new(&s.started_at),
+                Cell::new(&s.status),
+            ]);
+        }
+        println!("{sessions_table}");
+    }
+
+    // Recent events section
+    if !agent.recent_events.is_empty() {
+        println!("\nRecent Events:");
+        let mut events_table = Table::new();
+        events_table.set_header(vec!["TYPE", "SUMMARY", "TIMESTAMP"]);
+        for e in &agent.recent_events {
+            events_table.add_row(vec![
+                Cell::new(&e.event_type),
+                Cell::new(&e.summary),
+                Cell::new(&e.timestamp),
+            ]);
+        }
+        println!("{events_table}");
+    }
 }
 
 /// Run the `aasm agent inspect` command.

--- a/aa-cli/src/commands/agent/list.rs
+++ b/aa-cli/src/commands/agent/list.rs
@@ -67,15 +67,24 @@ fn status_color(status: &str) -> Color {
 /// Render agents as a table using comfy-table.
 fn render_table(agents: &[AgentResponse]) {
     let mut table = Table::new();
-    table.set_header(vec!["AGENT_ID", "NAME", "FRAMEWORK", "VERSION", "STATUS"]);
+    table.set_header(vec![
+        "AGENT_ID", "NAME", "FRAMEWORK", "VERSION", "STATUS", "PID", "SESSIONS", "LAST_EVENT",
+    ]);
 
     for agent in agents {
+        let pid_str = agent.pid.map_or("-".to_string(), |p| p.to_string());
+        let sessions_str = agent.session_count.map_or("-".to_string(), |s| s.to_string());
+        let last_event_str = agent.last_event.as_deref().unwrap_or("-");
+
         table.add_row(vec![
             Cell::new(&agent.id),
             Cell::new(&agent.name),
             Cell::new(&agent.framework),
             Cell::new(&agent.version),
             Cell::new(&agent.status).fg(status_color(&agent.status)),
+            Cell::new(&pid_str),
+            Cell::new(&sessions_str),
+            Cell::new(last_event_str),
         ]);
     }
 
@@ -160,6 +169,10 @@ mod tests {
                 status: "Active".to_string(),
                 tool_names: vec!["search".to_string()],
                 metadata: Default::default(),
+                pid: Some(1234),
+                session_count: Some(3),
+                last_event: Some("2025-01-15T10:30:00Z".to_string()),
+                policy_violations_count: Some(0),
             },
             AgentResponse {
                 id: "11223344556677881122334455667788".to_string(),
@@ -169,6 +182,10 @@ mod tests {
                 status: "Suspended".to_string(),
                 tool_names: vec![],
                 metadata: Default::default(),
+                pid: None,
+                session_count: None,
+                last_event: None,
+                policy_violations_count: Some(1),
             },
         ]
     }

--- a/aa-cli/src/commands/agent/list.rs
+++ b/aa-cli/src/commands/agent/list.rs
@@ -180,6 +180,8 @@ mod tests {
                 session_count: Some(3),
                 last_event: Some("2025-01-15T10:30:00Z".to_string()),
                 policy_violations_count: Some(0),
+                active_sessions: vec![],
+                recent_events: vec![],
             },
             AgentResponse {
                 id: "11223344556677881122334455667788".to_string(),
@@ -193,6 +195,8 @@ mod tests {
                 session_count: None,
                 last_event: None,
                 policy_violations_count: Some(1),
+                active_sessions: vec![],
+                recent_events: vec![],
             },
         ]
     }

--- a/aa-cli/src/commands/agent/list.rs
+++ b/aa-cli/src/commands/agent/list.rs
@@ -68,7 +68,14 @@ fn status_color(status: &str) -> Color {
 fn render_table(agents: &[AgentResponse]) {
     let mut table = Table::new();
     table.set_header(vec![
-        "AGENT_ID", "NAME", "FRAMEWORK", "VERSION", "STATUS", "PID", "SESSIONS", "LAST_EVENT",
+        "AGENT_ID",
+        "NAME",
+        "FRAMEWORK",
+        "VERSION",
+        "STATUS",
+        "PID",
+        "SESSIONS",
+        "LAST_EVENT",
     ]);
 
     for agent in agents {

--- a/aa-cli/src/commands/agent/mod.rs
+++ b/aa-cli/src/commands/agent/mod.rs
@@ -174,4 +174,70 @@ mod tests {
         assert!(agent.metadata.is_empty());
         assert!(agent.tool_names.is_empty());
     }
+
+    #[test]
+    fn new_fields_default_to_none_when_missing() {
+        let json = r#"{
+            "id": "aa",
+            "name": "old-server",
+            "framework": "custom",
+            "version": "0.0.1",
+            "status": "Active",
+            "tool_names": [],
+            "metadata": {}
+        }"#;
+
+        let agent: AgentResponse = serde_json::from_str(json).unwrap();
+        assert!(agent.pid.is_none());
+        assert!(agent.session_count.is_none());
+        assert!(agent.last_event.is_none());
+        assert!(agent.policy_violations_count.is_none());
+    }
+
+    #[test]
+    fn new_fields_deserialize_when_present() {
+        let json = r#"{
+            "id": "bb",
+            "name": "full-agent",
+            "framework": "langgraph",
+            "version": "1.0.0",
+            "status": "Active",
+            "tool_names": ["search"],
+            "metadata": {},
+            "pid": 4567,
+            "session_count": 12,
+            "last_event": "2025-06-15T08:30:00Z",
+            "policy_violations_count": 3
+        }"#;
+
+        let agent: AgentResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(agent.pid, Some(4567));
+        assert_eq!(agent.session_count, Some(12));
+        assert_eq!(agent.last_event.as_deref(), Some("2025-06-15T08:30:00Z"));
+        assert_eq!(agent.policy_violations_count, Some(3));
+    }
+
+    #[test]
+    fn round_trip_preserves_new_fields() {
+        let agent = AgentResponse {
+            id: "cc".to_string(),
+            name: "rt-agent".to_string(),
+            framework: "crewai".to_string(),
+            version: "2.0.0".to_string(),
+            status: "Active".to_string(),
+            tool_names: vec![],
+            metadata: BTreeMap::new(),
+            pid: Some(9999),
+            session_count: Some(42),
+            last_event: Some("2025-03-01T12:00:00Z".to_string()),
+            policy_violations_count: Some(0),
+        };
+
+        let json = serde_json::to_string(&agent).unwrap();
+        let parsed: AgentResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.pid, Some(9999));
+        assert_eq!(parsed.session_count, Some(42));
+        assert_eq!(parsed.last_event.as_deref(), Some("2025-03-01T12:00:00Z"));
+        assert_eq!(parsed.policy_violations_count, Some(0));
+    }
 }

--- a/aa-cli/src/commands/agent/mod.rs
+++ b/aa-cli/src/commands/agent/mod.rs
@@ -69,6 +69,34 @@ pub struct AgentResponse {
     /// Number of policy violations recorded.
     #[serde(default)]
     pub policy_violations_count: Option<u32>,
+    /// Currently active sessions for this agent.
+    #[serde(default)]
+    pub active_sessions: Vec<ActiveSessionResponse>,
+    /// Most recent events emitted by this agent.
+    #[serde(default)]
+    pub recent_events: Vec<RecentEventResponse>,
+}
+
+/// Summary of an active session returned by the API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ActiveSessionResponse {
+    /// Hex-encoded session UUID.
+    pub session_id: String,
+    /// ISO 8601 timestamp when the session started.
+    pub started_at: String,
+    /// Current status of the session.
+    pub status: String,
+}
+
+/// Summary of a recent event returned by the API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecentEventResponse {
+    /// Event type classification (e.g. "violation", "approval", "budget").
+    pub event_type: String,
+    /// Short human-readable summary.
+    pub summary: String,
+    /// ISO 8601 timestamp when the event occurred.
+    pub timestamp: String,
 }
 
 /// Paginated API response wrapper.

--- a/aa-cli/src/commands/agent/mod.rs
+++ b/aa-cli/src/commands/agent/mod.rs
@@ -57,6 +57,18 @@ pub struct AgentResponse {
     pub tool_names: Vec<String>,
     /// Arbitrary metadata key-value pairs.
     pub metadata: BTreeMap<String, String>,
+    /// OS process ID, if known.
+    #[serde(default)]
+    pub pid: Option<u32>,
+    /// Number of sessions handled.
+    #[serde(default)]
+    pub session_count: Option<u32>,
+    /// ISO 8601 timestamp of the most recent event.
+    #[serde(default)]
+    pub last_event: Option<String>,
+    /// Number of policy violations recorded.
+    #[serde(default)]
+    pub policy_violations_count: Option<u32>,
 }
 
 /// Paginated API response wrapper.
@@ -107,6 +119,10 @@ mod tests {
             status: "Suspended(PolicyViolation)".to_string(),
             tool_names: vec![],
             metadata: BTreeMap::new(),
+            pid: Some(1234),
+            session_count: Some(5),
+            last_event: Some("2025-01-01T00:00:00Z".to_string()),
+            policy_violations_count: Some(2),
         };
 
         let json = serde_json::to_string(&agent).unwrap();

--- a/aa-cli/src/commands/agent/mod.rs
+++ b/aa-cli/src/commands/agent/mod.rs
@@ -151,6 +151,8 @@ mod tests {
             session_count: Some(5),
             last_event: Some("2025-01-01T00:00:00Z".to_string()),
             policy_violations_count: Some(2),
+            active_sessions: vec![],
+            recent_events: vec![],
         };
 
         let json = serde_json::to_string(&agent).unwrap();
@@ -220,6 +222,8 @@ mod tests {
         assert!(agent.session_count.is_none());
         assert!(agent.last_event.is_none());
         assert!(agent.policy_violations_count.is_none());
+        assert!(agent.active_sessions.is_empty());
+        assert!(agent.recent_events.is_empty());
     }
 
     #[test]
@@ -259,6 +263,8 @@ mod tests {
             session_count: Some(42),
             last_event: Some("2025-03-01T12:00:00Z".to_string()),
             policy_violations_count: Some(0),
+            active_sessions: vec![],
+            recent_events: vec![],
         };
 
         let json = serde_json::to_string(&agent).unwrap();
@@ -267,5 +273,34 @@ mod tests {
         assert_eq!(parsed.session_count, Some(42));
         assert_eq!(parsed.last_event.as_deref(), Some("2025-03-01T12:00:00Z"));
         assert_eq!(parsed.policy_violations_count, Some(0));
+    }
+
+    #[test]
+    fn active_sessions_and_recent_events_deserialize() {
+        let json = r#"{
+            "id": "dd",
+            "name": "session-agent",
+            "framework": "custom",
+            "version": "1.0.0",
+            "status": "Active",
+            "tool_names": [],
+            "metadata": {},
+            "active_sessions": [
+                {"session_id": "s1", "started_at": "2025-06-01T10:00:00Z", "status": "running"},
+                {"session_id": "s2", "started_at": "2025-06-01T11:00:00Z", "status": "idle"}
+            ],
+            "recent_events": [
+                {"event_type": "violation", "summary": "blocked call", "timestamp": "2025-06-01T10:05:00Z"}
+            ]
+        }"#;
+
+        let agent: AgentResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(agent.active_sessions.len(), 2);
+        assert_eq!(agent.active_sessions[0].session_id, "s1");
+        assert_eq!(agent.active_sessions[0].status, "running");
+        assert_eq!(agent.active_sessions[1].session_id, "s2");
+        assert_eq!(agent.recent_events.len(), 1);
+        assert_eq!(agent.recent_events[0].event_type, "violation");
+        assert_eq!(agent.recent_events[0].summary, "blocked call");
     }
 }

--- a/aa-gateway/src/registry/mod.rs
+++ b/aa-gateway/src/registry/mod.rs
@@ -8,7 +8,7 @@ pub mod convert;
 pub mod store;
 pub mod token;
 
-pub use store::{AgentRecord, AgentRegistry};
+pub use store::{ActiveSession, AgentRecord, AgentRegistry, RecentEvent};
 
 /// Errors returned by [`AgentRegistry`](store::AgentRegistry) operations.
 #[derive(Debug, thiserror::Error)]

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -1,6 +1,6 @@
 //! Agent registry store — `AgentRecord` and `AgentRegistry` backed by `DashMap`.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
@@ -11,6 +11,31 @@ use aa_proto::assembly::agent::v1::control_command::Command;
 use aa_proto::assembly::agent::v1::{ControlCommand, SuspendCommand};
 
 use super::{AgentStatus, RegistryError};
+
+/// Maximum number of recent events retained per agent.
+pub const MAX_RECENT_EVENTS: usize = 20;
+
+/// Summary of an active session associated with an agent.
+#[derive(Debug, Clone)]
+pub struct ActiveSession {
+    /// Hex-encoded session UUID.
+    pub session_id: String,
+    /// Timestamp when the session started.
+    pub started_at: DateTime<Utc>,
+    /// Current status of the session (e.g. "running", "idle").
+    pub status: String,
+}
+
+/// Summary of a recent event emitted by an agent.
+#[derive(Debug, Clone)]
+pub struct RecentEvent {
+    /// Event type classification (e.g. "violation", "approval", "budget").
+    pub event_type: String,
+    /// Short human-readable summary of the event.
+    pub summary: String,
+    /// Timestamp when the event occurred.
+    pub timestamp: DateTime<Utc>,
+}
 
 /// Identity and runtime state record for a single registered agent.
 #[derive(Debug, Clone)]
@@ -47,6 +72,10 @@ pub struct AgentRecord {
     pub last_event: Option<DateTime<Utc>>,
     /// Number of policy violations recorded for this agent.
     pub policy_violations_count: u32,
+    /// Currently active sessions for this agent.
+    pub active_sessions: Vec<ActiveSession>,
+    /// Most recent events emitted by this agent (bounded by [`MAX_RECENT_EVENTS`]).
+    pub recent_events: VecDeque<RecentEvent>,
 }
 
 /// Channel sender type for pushing [`ControlCommand`]s to an agent's control stream.

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -45,6 +45,8 @@ pub struct AgentRecord {
     pub session_count: u32,
     /// Timestamp of the most recent event emitted by this agent.
     pub last_event: Option<DateTime<Utc>>,
+    /// Number of policy violations recorded for this agent.
+    pub policy_violations_count: u32,
 }
 
 /// Channel sender type for pushing [`ControlCommand`]s to an agent's control stream.

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -39,6 +39,12 @@ pub struct AgentRecord {
     pub last_heartbeat: DateTime<Utc>,
     /// Current runtime status of the agent.
     pub status: AgentStatus,
+    /// OS process ID of the agent, if known.
+    pub pid: Option<u32>,
+    /// Number of sessions this agent has handled.
+    pub session_count: u32,
+    /// Timestamp of the most recent event emitted by this agent.
+    pub last_event: Option<DateTime<Utc>>,
 }
 
 /// Channel sender type for pushing [`ControlCommand`]s to an agent's control stream.

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -95,6 +95,9 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
             registered_at: now,
             last_heartbeat: now,
             status: AgentStatus::Active,
+            pid: None,
+            session_count: 0,
+            last_event: None,
         };
 
         self.registry

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -99,6 +99,8 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
             session_count: 0,
             last_event: None,
             policy_violations_count: 0,
+            active_sessions: Vec::new(),
+            recent_events: std::collections::VecDeque::new(),
         };
 
         self.registry

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -98,6 +98,7 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
             pid: None,
             session_count: 0,
             last_event: None,
+            policy_violations_count: 0,
         };
 
         self.registry

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -275,6 +275,7 @@ budget:
         pid: None,
         session_count: 0,
         last_event: None,
+        policy_violations_count: 0,
     };
     registry.register(record).unwrap();
 
@@ -345,6 +346,7 @@ budget:
         pid: None,
         session_count: 0,
         last_event: None,
+        policy_violations_count: 0,
     };
     registry.register(record).unwrap();
 

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -276,6 +276,8 @@ budget:
         session_count: 0,
         last_event: None,
         policy_violations_count: 0,
+        active_sessions: Vec::new(),
+        recent_events: std::collections::VecDeque::new(),
     };
     registry.register(record).unwrap();
 
@@ -347,6 +349,8 @@ budget:
         session_count: 0,
         last_event: None,
         policy_violations_count: 0,
+        active_sessions: Vec::new(),
+        recent_events: std::collections::VecDeque::new(),
     };
     registry.register(record).unwrap();
 

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -272,6 +272,9 @@ budget:
         registered_at: chrono::Utc::now(),
         last_heartbeat: chrono::Utc::now(),
         status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
     };
     registry.register(record).unwrap();
 
@@ -339,6 +342,9 @@ budget:
         registered_at: chrono::Utc::now(),
         last_heartbeat: chrono::Utc::now(),
         status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
     };
     registry.register(record).unwrap();
 

--- a/aa-gateway/tests/registry_test.rs
+++ b/aa-gateway/tests/registry_test.rs
@@ -306,6 +306,8 @@ fn new_fields_default_values_on_registration() {
     assert_eq!(record.session_count, 0);
     assert!(record.last_event.is_none());
     assert_eq!(record.policy_violations_count, 0);
+    assert!(record.active_sessions.is_empty());
+    assert!(record.recent_events.is_empty());
 }
 
 #[test]
@@ -323,4 +325,31 @@ fn new_fields_survive_clone_and_retrieval() {
     assert_eq!(retrieved.session_count, 10);
     assert!(retrieved.last_event.is_some());
     assert_eq!(retrieved.policy_violations_count, 3);
+}
+
+#[test]
+fn active_sessions_and_recent_events_survive_retrieval() {
+    use aa_gateway::registry::{ActiveSession, RecentEvent};
+
+    let reg = AgentRegistry::new();
+    let mut record = make_record(key(3));
+    record.active_sessions = vec![ActiveSession {
+        session_id: "aabb".into(),
+        started_at: Utc::now(),
+        status: "running".into(),
+    }];
+    record.recent_events.push_back(RecentEvent {
+        event_type: "violation".into(),
+        summary: "unauthorized tool call".into(),
+        timestamp: Utc::now(),
+    });
+    reg.register(record).unwrap();
+
+    let retrieved = reg.get(&key(3)).unwrap();
+    assert_eq!(retrieved.active_sessions.len(), 1);
+    assert_eq!(retrieved.active_sessions[0].session_id, "aabb");
+    assert_eq!(retrieved.active_sessions[0].status, "running");
+    assert_eq!(retrieved.recent_events.len(), 1);
+    assert_eq!(retrieved.recent_events[0].event_type, "violation");
+    assert_eq!(retrieved.recent_events[0].summary, "unauthorized tool call");
 }

--- a/aa-gateway/tests/registry_test.rs
+++ b/aa-gateway/tests/registry_test.rs
@@ -291,3 +291,32 @@ async fn suspend_and_notify_sends_command_on_control_stream() {
         other => panic!("expected Suspend command, got {other:?}"),
     }
 }
+
+#[test]
+fn new_fields_default_values_on_registration() {
+    let reg = AgentRegistry::new();
+    reg.register(make_record(key(1))).unwrap();
+
+    let record = reg.get(&key(1)).unwrap();
+    assert!(record.pid.is_none());
+    assert_eq!(record.session_count, 0);
+    assert!(record.last_event.is_none());
+    assert_eq!(record.policy_violations_count, 0);
+}
+
+#[test]
+fn new_fields_survive_clone_and_retrieval() {
+    let reg = AgentRegistry::new();
+    let mut record = make_record(key(2));
+    record.pid = Some(5678);
+    record.session_count = 10;
+    record.last_event = Some(Utc::now());
+    record.policy_violations_count = 3;
+    reg.register(record).unwrap();
+
+    let retrieved = reg.get(&key(2)).unwrap();
+    assert_eq!(retrieved.pid, Some(5678));
+    assert_eq!(retrieved.session_count, 10);
+    assert!(retrieved.last_event.is_some());
+    assert_eq!(retrieved.policy_violations_count, 3);
+}

--- a/aa-gateway/tests/registry_test.rs
+++ b/aa-gateway/tests/registry_test.rs
@@ -1,6 +1,6 @@
 //! Unit tests for `AgentRegistry` CRUD operations and control stream infrastructure.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 
 use chrono::Utc;
 
@@ -26,6 +26,8 @@ fn make_record(key: [u8; 16]) -> AgentRecord {
         session_count: 0,
         last_event: None,
         policy_violations_count: 0,
+        active_sessions: Vec::new(),
+        recent_events: VecDeque::new(),
     }
 }
 
@@ -217,6 +219,8 @@ async fn concurrent_registration_of_100_agents() {
                 session_count: 0,
                 last_event: None,
                 policy_violations_count: 0,
+                active_sessions: Vec::new(),
+                recent_events: VecDeque::new(),
             };
             reg.register(record).unwrap();
         }));

--- a/aa-gateway/tests/registry_test.rs
+++ b/aa-gateway/tests/registry_test.rs
@@ -25,6 +25,7 @@ fn make_record(key: [u8; 16]) -> AgentRecord {
         pid: None,
         session_count: 0,
         last_event: None,
+        policy_violations_count: 0,
     }
 }
 
@@ -215,6 +216,7 @@ async fn concurrent_registration_of_100_agents() {
                 pid: None,
                 session_count: 0,
                 last_event: None,
+                policy_violations_count: 0,
             };
             reg.register(record).unwrap();
         }));

--- a/aa-gateway/tests/registry_test.rs
+++ b/aa-gateway/tests/registry_test.rs
@@ -22,6 +22,9 @@ fn make_record(key: [u8; 16]) -> AgentRecord {
         registered_at: Utc::now(),
         last_heartbeat: Utc::now(),
         status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
     }
 }
 
@@ -209,6 +212,9 @@ async fn concurrent_registration_of_100_agents() {
                 registered_at: Utc::now(),
                 last_heartbeat: Utc::now(),
                 status: AgentStatus::Active,
+                pid: None,
+                session_count: 0,
+                last_event: None,
             };
             reg.register(record).unwrap();
         }));

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -280,8 +280,19 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** @description Summary of an active session in the API response. */
+        ActiveSessionResponse: {
+            /** @description Hex-encoded session UUID. */
+            session_id: string;
+            /** @description ISO 8601 timestamp when the session started. */
+            started_at: string;
+            /** @description Current status of the session. */
+            status: string;
+        };
         /** @description JSON representation of an agent returned by the API. */
         AgentResponse: {
+            /** @description Currently active sessions for this agent. */
+            active_sessions: components["schemas"]["ActiveSessionResponse"][];
             /** @description Agent framework (e.g. "langgraph", "crewai"). */
             framework: string;
             /** @description Hex-encoded agent UUID. */
@@ -304,6 +315,8 @@ export interface components {
              * @description Number of policy violations recorded.
              */
             policy_violations_count: number;
+            /** @description Most recent events emitted by this agent. */
+            recent_events: components["schemas"]["RecentEventResponse"][];
             /**
              * Format: int32
              * @description Number of sessions handled.
@@ -425,6 +438,15 @@ export interface components {
             title: string;
             /** @description URI reference identifying the problem type. */
             type: string;
+        };
+        /** @description Summary of a recent event in the API response. */
+        RecentEventResponse: {
+            /** @description Event type classification (e.g. "violation", "approval", "budget"). */
+            event_type: string;
+            /** @description Short human-readable summary. */
+            summary: string;
+            /** @description ISO 8601 timestamp when the event occurred. */
+            timestamp: string;
         };
         /**
          * @description Authorization scope level for API operations.

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -286,12 +286,29 @@ export interface components {
             framework: string;
             /** @description Hex-encoded agent UUID. */
             id: string;
+            /** @description ISO 8601 timestamp of the most recent event. */
+            last_event?: string | null;
             /** @description Arbitrary metadata key-value pairs. */
             metadata: {
                 [key: string]: string;
             };
             /** @description Human-readable agent name. */
             name: string;
+            /**
+             * Format: int32
+             * @description OS process ID, if known.
+             */
+            pid?: number | null;
+            /**
+             * Format: int32
+             * @description Number of policy violations recorded.
+             */
+            policy_violations_count: number;
+            /**
+             * Format: int32
+             * @description Number of sessions handled.
+             */
+            session_count: number;
             /** @description Current runtime status. */
             status: string;
             /** @description Tools declared at registration. */

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -463,6 +463,8 @@ components:
       - status
       - tool_names
       - metadata
+      - session_count
+      - policy_violations_count
       properties:
         framework:
           type: string
@@ -470,6 +472,10 @@ components:
         id:
           type: string
           description: Hex-encoded agent UUID.
+        last_event:
+          type: string
+          description: ISO 8601 timestamp of the most recent event.
+          nullable: true
         metadata:
           type: object
           description: Arbitrary metadata key-value pairs.
@@ -478,6 +484,22 @@ components:
         name:
           type: string
           description: Human-readable agent name.
+        pid:
+          type: integer
+          format: int32
+          description: OS process ID, if known.
+          nullable: true
+          minimum: 0
+        policy_violations_count:
+          type: integer
+          format: int32
+          description: Number of policy violations recorded.
+          minimum: 0
+        session_count:
+          type: integer
+          format: int32
+          description: Number of sessions handled.
+          minimum: 0
         status:
           type: string
           description: Current runtime status.

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -452,6 +452,23 @@ paths:
           description: Session not found
 components:
   schemas:
+    ActiveSessionResponse:
+      type: object
+      description: Summary of an active session in the API response.
+      required:
+      - session_id
+      - started_at
+      - status
+      properties:
+        session_id:
+          type: string
+          description: Hex-encoded session UUID.
+        started_at:
+          type: string
+          description: ISO 8601 timestamp when the session started.
+        status:
+          type: string
+          description: Current status of the session.
     AgentResponse:
       type: object
       description: JSON representation of an agent returned by the API.
@@ -465,7 +482,14 @@ components:
       - metadata
       - session_count
       - policy_violations_count
+      - active_sessions
+      - recent_events
       properties:
+        active_sessions:
+          type: array
+          items:
+            $ref: '#/components/schemas/ActiveSessionResponse'
+          description: Currently active sessions for this agent.
         framework:
           type: string
           description: Agent framework (e.g. "langgraph", "crewai").
@@ -495,6 +519,11 @@ components:
           format: int32
           description: Number of policy violations recorded.
           minimum: 0
+        recent_events:
+          type: array
+          items:
+            $ref: '#/components/schemas/RecentEventResponse'
+          description: Most recent events emitted by this agent.
         session_count:
           type: integer
           format: int32
@@ -702,6 +731,23 @@ components:
         status: 404
         title: Not Found
         type: about:blank
+    RecentEventResponse:
+      type: object
+      description: Summary of a recent event in the API response.
+      required:
+      - event_type
+      - summary
+      - timestamp
+      properties:
+        event_type:
+          type: string
+          description: Event type classification (e.g. "violation", "approval", "budget").
+        summary:
+          type: string
+          description: Short human-readable summary.
+        timestamp:
+          type: string
+          description: ISO 8601 timestamp when the event occurred.
     Scope:
       type: string
       description: |-


### PR DESCRIPTION
## Summary
- Add `pid`, `session_count`, `last_event`, and `policy_violations_count` fields to `AgentRecord` in `aa-gateway`
- Expose all new fields in the API `AgentResponse` (aa-api) with proper serialization
- Add new fields to CLI `AgentResponse` with `#[serde(default)]` for backwards compatibility
- Add PID, SESSIONS, LAST_EVENT columns to `aasm agent list` table
- Add PID, Sessions, Last Event, Policy Violations rows to `aasm agent inspect` detail view
- Add comprehensive tests across all three crates (gateway, api, cli)

## Test plan
- [x] All existing tests pass after changes
- [x] New gateway tests verify default values and field persistence through clone/retrieval
- [x] New API integration tests verify JSON response includes new fields (both populated and null)
- [x] New CLI tests verify backwards-compatible deserialization (missing fields default to None) and round-trip serialization
- [x] `cargo check` passes for full workspace
- [x] `cargo test -p aa-gateway -p aa-api -p aa-cli` — all pass

Closes AAASM-175

🤖 Generated with [Claude Code](https://claude.com/claude-code)