### PR TITLE
[AAASM-176] ✨ (agent): Wire agent inspect to link most recent session traces

### DIFF
--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -59,6 +59,7 @@ use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, trac
         agents::AgentResponse,
         agents::ActiveSessionResponse,
         agents::RecentEventResponse,
+        agents::RecentTraceResponse,
         logs::LogEntry,
         TraceResponse,
         TraceSpan,

--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -52,6 +52,15 @@ fn record_to_response(r: aa_gateway::registry::AgentRecord) -> AgentResponse {
         })
         .collect();
 
+    let recent_traces = r
+        .recent_traces
+        .into_iter()
+        .map(|t| RecentTraceResponse {
+            session_id: t.session_id,
+            timestamp: t.timestamp.to_rfc3339(),
+        })
+        .collect();
+
     AgentResponse {
         id: r.agent_id.iter().map(|b| format!("{b:02x}")).collect::<String>(),
         name: r.name,
@@ -66,6 +75,7 @@ fn record_to_response(r: aa_gateway::registry::AgentRecord) -> AgentResponse {
         policy_violations_count: r.policy_violations_count,
         active_sessions,
         recent_events,
+        recent_traces,
     }
 }
 
@@ -98,6 +108,8 @@ pub struct AgentResponse {
     pub active_sessions: Vec<ActiveSessionResponse>,
     /// Most recent events emitted by this agent.
     pub recent_events: Vec<RecentEventResponse>,
+    /// Most recent trace session IDs for this agent.
+    pub recent_traces: Vec<RecentTraceResponse>,
 }
 
 /// Summary of an active session in the API response.
@@ -119,6 +131,15 @@ pub struct RecentEventResponse {
     /// Short human-readable summary.
     pub summary: String,
     /// ISO 8601 timestamp when the event occurred.
+    pub timestamp: String,
+}
+
+/// Summary of a recent trace session for an agent.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct RecentTraceResponse {
+    /// Hex-encoded session UUID, usable with `aasm trace <session-id>`.
+    pub session_id: String,
+    /// ISO 8601 timestamp when the trace session started.
     pub timestamp: String,
 }
 

--- a/aa-api/tests/agents.rs
+++ b/aa-api/tests/agents.rs
@@ -30,6 +30,7 @@ fn test_agent(id_byte: u8) -> AgentRecord {
         policy_violations_count: 0,
         active_sessions: Vec::new(),
         recent_events: std::collections::VecDeque::new(),
+        recent_traces: Vec::new(),
     }
 }
 

--- a/aa-cli/src/commands/agent/inspect.rs
+++ b/aa-cli/src/commands/agent/inspect.rs
@@ -111,6 +111,55 @@ fn render_detail(agent: &AgentResponse) {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::commands::agent::RecentTraceResponse;
+
+    fn base_agent() -> AgentResponse {
+        AgentResponse {
+            id: "aabb".to_string(),
+            name: "test-agent".to_string(),
+            framework: "custom".to_string(),
+            version: "1.0.0".to_string(),
+            status: "Active".to_string(),
+            tool_names: vec![],
+            metadata: BTreeMap::new(),
+            pid: None,
+            session_count: None,
+            last_event: None,
+            policy_violations_count: None,
+            active_sessions: vec![],
+            recent_events: vec![],
+            recent_traces: vec![],
+        }
+    }
+
+    #[test]
+    fn render_detail_without_traces_does_not_panic() {
+        let agent = base_agent();
+        render_detail(&agent);
+    }
+
+    #[test]
+    fn render_detail_with_traces_does_not_panic() {
+        let mut agent = base_agent();
+        agent.recent_traces = vec![
+            RecentTraceResponse {
+                session_id: "sess-abc123".to_string(),
+                timestamp: "2026-04-30T10:00:00Z".to_string(),
+            },
+            RecentTraceResponse {
+                session_id: "sess-def456".to_string(),
+                timestamp: "2026-04-30T09:30:00Z".to_string(),
+            },
+        ];
+        render_detail(&agent);
+    }
+}
+
 /// Run the `aasm agent inspect` command.
 pub fn run(args: InspectArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");

--- a/aa-cli/src/commands/agent/inspect.rs
+++ b/aa-cli/src/commands/agent/inspect.rs
@@ -101,10 +101,7 @@ fn render_detail(agent: &AgentResponse) {
         let mut traces_table = Table::new();
         traces_table.set_header(vec!["SESSION_ID", "TIMESTAMP"]);
         for t in &agent.recent_traces {
-            traces_table.add_row(vec![
-                Cell::new(&t.session_id),
-                Cell::new(&t.timestamp),
-            ]);
+            traces_table.add_row(vec![Cell::new(&t.session_id), Cell::new(&t.timestamp)]);
         }
         println!("{traces_table}");
         println!("Tip: run `aasm trace <session-id>` to visualize a trace");

--- a/aa-cli/src/commands/agent/inspect.rs
+++ b/aa-cli/src/commands/agent/inspect.rs
@@ -94,6 +94,21 @@ fn render_detail(agent: &AgentResponse) {
         }
         println!("{events_table}");
     }
+
+    // Recent traces section
+    if !agent.recent_traces.is_empty() {
+        println!("\nRecent Traces:");
+        let mut traces_table = Table::new();
+        traces_table.set_header(vec!["SESSION_ID", "TIMESTAMP"]);
+        for t in &agent.recent_traces {
+            traces_table.add_row(vec![
+                Cell::new(&t.session_id),
+                Cell::new(&t.timestamp),
+            ]);
+        }
+        println!("{traces_table}");
+        println!("Tip: run `aasm trace <session-id>` to visualize a trace");
+    }
 }
 
 /// Run the `aasm agent inspect` command.

--- a/aa-cli/src/commands/agent/inspect.rs
+++ b/aa-cli/src/commands/agent/inspect.rs
@@ -108,6 +108,34 @@ fn render_detail(agent: &AgentResponse) {
     }
 }
 
+/// Run the `aasm agent inspect` command.
+pub fn run(args: InspectArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+
+    let path = format!("/api/v1/agents/{}", args.agent_id);
+    let agent: AgentResponse = match rt.block_on(client::get_json(ctx, &path)) {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match output {
+        OutputFormat::Table => render_detail(&agent),
+        OutputFormat::Json => match serde_json::to_string_pretty(&agent) {
+            Ok(json) => println!("{json}"),
+            Err(e) => eprintln!("error serializing JSON: {e}"),
+        },
+        OutputFormat::Yaml => match serde_yaml::to_string(&agent) {
+            Ok(yaml) => print!("{yaml}"),
+            Err(e) => eprintln!("error serializing YAML: {e}"),
+        },
+    }
+
+    ExitCode::SUCCESS
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
@@ -155,32 +183,4 @@ mod tests {
         ];
         render_detail(&agent);
     }
-}
-
-/// Run the `aasm agent inspect` command.
-pub fn run(args: InspectArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
-    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
-
-    let path = format!("/api/v1/agents/{}", args.agent_id);
-    let agent: AgentResponse = match rt.block_on(client::get_json(ctx, &path)) {
-        Ok(a) => a,
-        Err(e) => {
-            eprintln!("error: {e}");
-            return ExitCode::FAILURE;
-        }
-    };
-
-    match output {
-        OutputFormat::Table => render_detail(&agent),
-        OutputFormat::Json => match serde_json::to_string_pretty(&agent) {
-            Ok(json) => println!("{json}"),
-            Err(e) => eprintln!("error serializing JSON: {e}"),
-        },
-        OutputFormat::Yaml => match serde_yaml::to_string(&agent) {
-            Ok(yaml) => print!("{yaml}"),
-            Err(e) => eprintln!("error serializing YAML: {e}"),
-        },
-    }
-
-    ExitCode::SUCCESS
 }

--- a/aa-cli/src/commands/agent/list.rs
+++ b/aa-cli/src/commands/agent/list.rs
@@ -182,6 +182,7 @@ mod tests {
                 policy_violations_count: Some(0),
                 active_sessions: vec![],
                 recent_events: vec![],
+                recent_traces: vec![],
             },
             AgentResponse {
                 id: "11223344556677881122334455667788".to_string(),
@@ -197,6 +198,7 @@ mod tests {
                 policy_violations_count: Some(1),
                 active_sessions: vec![],
                 recent_events: vec![],
+                recent_traces: vec![],
             },
         ]
     }

--- a/aa-cli/src/commands/agent/mod.rs
+++ b/aa-cli/src/commands/agent/mod.rs
@@ -75,6 +75,9 @@ pub struct AgentResponse {
     /// Most recent events emitted by this agent.
     #[serde(default)]
     pub recent_events: Vec<RecentEventResponse>,
+    /// Most recent trace session IDs for this agent.
+    #[serde(default)]
+    pub recent_traces: Vec<RecentTraceResponse>,
 }
 
 /// Summary of an active session returned by the API.
@@ -162,6 +165,7 @@ mod tests {
             policy_violations_count: Some(2),
             active_sessions: vec![],
             recent_events: vec![],
+            recent_traces: vec![],
         };
 
         let json = serde_json::to_string(&agent).unwrap();
@@ -274,6 +278,7 @@ mod tests {
             policy_violations_count: Some(0),
             active_sessions: vec![],
             recent_events: vec![],
+            recent_traces: vec![],
         };
 
         let json = serde_json::to_string(&agent).unwrap();

--- a/aa-cli/src/commands/agent/mod.rs
+++ b/aa-cli/src/commands/agent/mod.rs
@@ -373,12 +373,10 @@ mod tests {
             policy_violations_count: None,
             active_sessions: vec![],
             recent_events: vec![],
-            recent_traces: vec![
-                RecentTraceResponse {
-                    session_id: "sess-111".to_string(),
-                    timestamp: "2026-04-30T08:00:00Z".to_string(),
-                },
-            ],
+            recent_traces: vec![RecentTraceResponse {
+                session_id: "sess-111".to_string(),
+                timestamp: "2026-04-30T08:00:00Z".to_string(),
+            }],
         };
 
         let json = serde_json::to_string(&agent).unwrap();

--- a/aa-cli/src/commands/agent/mod.rs
+++ b/aa-cli/src/commands/agent/mod.rs
@@ -99,6 +99,15 @@ pub struct RecentEventResponse {
     pub timestamp: String,
 }
 
+/// Summary of a recent trace session returned by the API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecentTraceResponse {
+    /// Hex-encoded session UUID, usable with `aasm trace <session-id>`.
+    pub session_id: String,
+    /// ISO 8601 timestamp when the trace session started.
+    pub timestamp: String,
+}
+
 /// Paginated API response wrapper.
 #[derive(Debug, Clone, Deserialize)]
 pub struct PaginatedResponse<T> {

--- a/aa-cli/src/commands/agent/mod.rs
+++ b/aa-cli/src/commands/agent/mod.rs
@@ -317,4 +317,74 @@ mod tests {
         assert_eq!(agent.recent_events[0].event_type, "violation");
         assert_eq!(agent.recent_events[0].summary, "blocked call");
     }
+
+    #[test]
+    fn recent_traces_defaults_to_empty_when_missing() {
+        let json = r#"{
+            "id": "ee",
+            "name": "no-traces",
+            "framework": "custom",
+            "version": "1.0.0",
+            "status": "Active",
+            "tool_names": [],
+            "metadata": {}
+        }"#;
+
+        let agent: AgentResponse = serde_json::from_str(json).unwrap();
+        assert!(agent.recent_traces.is_empty());
+    }
+
+    #[test]
+    fn recent_traces_deserialize_when_present() {
+        let json = r#"{
+            "id": "ff",
+            "name": "traced-agent",
+            "framework": "langgraph",
+            "version": "1.0.0",
+            "status": "Active",
+            "tool_names": [],
+            "metadata": {},
+            "recent_traces": [
+                {"session_id": "sess-abc123", "timestamp": "2026-04-30T10:00:00Z"},
+                {"session_id": "sess-def456", "timestamp": "2026-04-30T09:30:00Z"}
+            ]
+        }"#;
+
+        let agent: AgentResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(agent.recent_traces.len(), 2);
+        assert_eq!(agent.recent_traces[0].session_id, "sess-abc123");
+        assert_eq!(agent.recent_traces[0].timestamp, "2026-04-30T10:00:00Z");
+        assert_eq!(agent.recent_traces[1].session_id, "sess-def456");
+    }
+
+    #[test]
+    fn recent_traces_round_trip() {
+        let agent = AgentResponse {
+            id: "gg".to_string(),
+            name: "rt-traces".to_string(),
+            framework: "crewai".to_string(),
+            version: "1.0.0".to_string(),
+            status: "Active".to_string(),
+            tool_names: vec![],
+            metadata: BTreeMap::new(),
+            pid: None,
+            session_count: None,
+            last_event: None,
+            policy_violations_count: None,
+            active_sessions: vec![],
+            recent_events: vec![],
+            recent_traces: vec![
+                RecentTraceResponse {
+                    session_id: "sess-111".to_string(),
+                    timestamp: "2026-04-30T08:00:00Z".to_string(),
+                },
+            ],
+        };
+
+        let json = serde_json::to_string(&agent).unwrap();
+        let parsed: AgentResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.recent_traces.len(), 1);
+        assert_eq!(parsed.recent_traces[0].session_id, "sess-111");
+        assert_eq!(parsed.recent_traces[0].timestamp, "2026-04-30T08:00:00Z");
+    }
 }

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -37,6 +37,15 @@ pub struct RecentEvent {
     pub timestamp: DateTime<Utc>,
 }
 
+/// Summary of a recent trace session for an agent.
+#[derive(Debug, Clone)]
+pub struct RecentTrace {
+    /// Hex-encoded session UUID, usable with `aasm trace <session-id>`.
+    pub session_id: String,
+    /// Timestamp when the trace session started.
+    pub timestamp: DateTime<Utc>,
+}
+
 /// Identity and runtime state record for a single registered agent.
 #[derive(Debug, Clone)]
 pub struct AgentRecord {
@@ -76,6 +85,8 @@ pub struct AgentRecord {
     pub active_sessions: Vec<ActiveSession>,
     /// Most recent events emitted by this agent (bounded by [`MAX_RECENT_EVENTS`]).
     pub recent_events: VecDeque<RecentEvent>,
+    /// Most recent trace session IDs for this agent.
+    pub recent_traces: Vec<RecentTrace>,
 }
 
 /// Channel sender type for pushing [`ControlCommand`]s to an agent's control stream.

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -101,6 +101,7 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
             policy_violations_count: 0,
             active_sessions: Vec::new(),
             recent_events: std::collections::VecDeque::new(),
+            recent_traces: Vec::new(),
         };
 
         self.registry

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -278,6 +278,7 @@ budget:
         policy_violations_count: 0,
         active_sessions: Vec::new(),
         recent_events: std::collections::VecDeque::new(),
+        recent_traces: Vec::new(),
     };
     registry.register(record).unwrap();
 
@@ -351,6 +352,7 @@ budget:
         policy_violations_count: 0,
         active_sessions: Vec::new(),
         recent_events: std::collections::VecDeque::new(),
+        recent_traces: Vec::new(),
     };
     registry.register(record).unwrap();
 

--- a/aa-gateway/tests/registry_test.rs
+++ b/aa-gateway/tests/registry_test.rs
@@ -28,6 +28,7 @@ fn make_record(key: [u8; 16]) -> AgentRecord {
         policy_violations_count: 0,
         active_sessions: Vec::new(),
         recent_events: VecDeque::new(),
+        recent_traces: Vec::new(),
     }
 }
 
@@ -221,6 +222,7 @@ async fn concurrent_registration_of_100_agents() {
                 policy_violations_count: 0,
                 active_sessions: Vec::new(),
                 recent_events: VecDeque::new(),
+                recent_traces: Vec::new(),
             };
             reg.register(record).unwrap();
         }));

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -360,6 +360,8 @@ export interface components {
             policy_violations_count: number;
             /** @description Most recent events emitted by this agent. */
             recent_events: components["schemas"]["RecentEventResponse"][];
+            /** @description Most recent trace session IDs for this agent. */
+            recent_traces: components["schemas"]["RecentTraceResponse"][];
             /**
              * Format: int32
              * @description Number of sessions handled.
@@ -574,6 +576,13 @@ export interface components {
             /** @description Short human-readable summary. */
             summary: string;
             /** @description ISO 8601 timestamp when the event occurred. */
+            timestamp: string;
+        };
+        /** @description Summary of a recent trace session for an agent. */
+        RecentTraceResponse: {
+            /** @description Hex-encoded session UUID, usable with `aasm trace <session-id>`. */
+            session_id: string;
+            /** @description ISO 8601 timestamp when the trace session started. */
             timestamp: string;
         };
         /**

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -594,6 +594,11 @@ components:
           items:
             $ref: '#/components/schemas/RecentEventResponse'
           description: Most recent events emitted by this agent.
+        recent_traces:
+          type: array
+          items:
+            $ref: '#/components/schemas/RecentTraceResponse'
+          description: Most recent trace session IDs for this agent.
         session_count:
           type: integer
           format: int32
@@ -930,6 +935,19 @@ components:
         timestamp:
           type: string
           description: ISO 8601 timestamp when the event occurred.
+    RecentTraceResponse:
+      type: object
+      description: Summary of a recent trace session for an agent.
+      required:
+      - session_id
+      - timestamp
+      properties:
+        session_id:
+          type: string
+          description: Hex-encoded session UUID, usable with `aasm trace <session-id>`.
+        timestamp:
+          type: string
+          description: ISO 8601 timestamp when the trace session started.
     Scope:
       type: string
       description: |-

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -554,6 +554,7 @@ components:
       - policy_violations_count
       - active_sessions
       - recent_events
+      - recent_traces
       properties:
         active_sessions:
           type: array


### PR DESCRIPTION
## Description

Wire `aasm agent inspect <agent-id>` output to include links to the most recent session traces for that agent. This allows engineers to quickly drill down from an agent overview into specific trace sessions by copy-pasting session IDs into `aasm trace <session-id>`.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-176
- Parent Epic: AAASM-10

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

### Tests added:
- `recent_traces_defaults_to_empty_when_missing` — backward compatibility with older API servers
- `recent_traces_deserialize_when_present` — verifies deserialization with trace data
- `recent_traces_round_trip` — serialize then deserialize preserves all fields
- `render_detail_without_traces_does_not_panic` — inspect view handles empty traces
- `render_detail_with_traces_does_not_panic` — inspect view renders traces table

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention