### PR TITLE
[AAASM-181] 🐛 status: Add SESSIONS and LAYER columns to Active Agents table

### DIFF
--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -76,6 +76,7 @@ fn record_to_response(r: aa_gateway::registry::AgentRecord) -> AgentResponse {
         active_sessions,
         recent_events,
         recent_traces,
+        layer: r.layer,
     }
 }
 
@@ -110,6 +111,8 @@ pub struct AgentResponse {
     pub recent_events: Vec<RecentEventResponse>,
     /// Most recent trace session IDs for this agent.
     pub recent_traces: Vec<RecentTraceResponse>,
+    /// Governance layer this agent is assigned to (e.g. "advisory", "enforced").
+    pub layer: Option<String>,
 }
 
 /// Summary of an active session in the API response.

--- a/aa-api/tests/agents.rs
+++ b/aa-api/tests/agents.rs
@@ -31,6 +31,7 @@ fn test_agent(id_byte: u8) -> AgentRecord {
         active_sessions: Vec::new(),
         recent_events: std::collections::VecDeque::new(),
         recent_traces: Vec::new(),
+        layer: None,
     }
 }
 

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -37,8 +37,9 @@ pub fn build_agent_rows(agents: Vec<AgentResponse>) -> Vec<AgentRow> {
             name: a.name,
             framework: a.framework,
             status: a.status,
-            // Per-agent violation count not yet available from the API.
-            violations_today: 0,
+            sessions: a.session_count,
+            violations_today: a.policy_violations_count,
+            layer: a.layer.unwrap_or_else(|| "-".to_string()),
         })
         .collect()
 }
@@ -165,6 +166,9 @@ mod tests {
             status: "Running".to_string(),
             tool_names: vec!["tool_a".to_string()],
             metadata: BTreeMap::new(),
+            session_count: 3,
+            policy_violations_count: 1,
+            layer: Some("advisory".to_string()),
         }];
         let rows = build_agent_rows(agents);
         assert_eq!(rows.len(), 1);
@@ -172,7 +176,27 @@ mod tests {
         assert_eq!(rows[0].name, "test-agent");
         assert_eq!(rows[0].framework, "langgraph");
         assert_eq!(rows[0].status, "Running");
-        assert_eq!(rows[0].violations_today, 0);
+        assert_eq!(rows[0].sessions, 3);
+        assert_eq!(rows[0].violations_today, 1);
+        assert_eq!(rows[0].layer, "advisory");
+    }
+
+    #[test]
+    fn build_agent_rows_defaults_layer_when_none() {
+        let agents = vec![AgentResponse {
+            id: "def".to_string(),
+            name: "no-layer-agent".to_string(),
+            framework: "custom".to_string(),
+            version: "0.1.0".to_string(),
+            status: "Active".to_string(),
+            tool_names: vec![],
+            metadata: BTreeMap::new(),
+            session_count: 0,
+            policy_violations_count: 0,
+            layer: None,
+        }];
+        let rows = build_agent_rows(agents);
+        assert_eq!(rows[0].layer, "-");
     }
 
     #[test]

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -75,7 +75,9 @@ mod tests {
                 name: "agent".to_string(),
                 framework: "langgraph".to_string(),
                 status: "Running".to_string(),
+                sessions: 0,
                 violations_today: 0,
+                layer: "-".to_string(),
             }],
             approvals: ApprovalsSummary {
                 pending_count: 0,

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -45,6 +45,15 @@ pub struct AgentResponse {
     pub status: String,
     pub tool_names: Vec<String>,
     pub metadata: BTreeMap<String, String>,
+    /// Number of sessions handled by this agent.
+    #[serde(default)]
+    pub session_count: u32,
+    /// Number of policy violations recorded for this agent.
+    #[serde(default)]
+    pub policy_violations_count: u32,
+    /// Governance layer this agent is assigned to.
+    #[serde(default)]
+    pub layer: Option<String>,
 }
 
 /// Flattened agent row for tabular display.
@@ -54,7 +63,9 @@ pub struct AgentRow {
     pub name: String,
     pub framework: String,
     pub status: String,
-    pub violations_today: u64,
+    pub sessions: u32,
+    pub violations_today: u32,
+    pub layer: String,
 }
 
 /// API response item from `GET /api/v1/approvals`.
@@ -174,6 +185,30 @@ mod tests {
         assert_eq!(resp.framework, "langgraph");
         assert_eq!(resp.tool_names.len(), 2);
         assert_eq!(resp.metadata.get("team").unwrap(), "support");
+        // New fields default when missing from JSON.
+        assert_eq!(resp.session_count, 0);
+        assert_eq!(resp.policy_violations_count, 0);
+        assert!(resp.layer.is_none());
+    }
+
+    #[test]
+    fn agent_response_deserializes_with_new_fields() {
+        let json = r#"{
+            "id": "abc123",
+            "name": "full-agent",
+            "framework": "crewai",
+            "version": "2.0.0",
+            "status": "Active",
+            "tool_names": [],
+            "metadata": {},
+            "session_count": 5,
+            "policy_violations_count": 2,
+            "layer": "enforced"
+        }"#;
+        let resp: AgentResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.session_count, 5);
+        assert_eq!(resp.policy_violations_count, 2);
+        assert_eq!(resp.layer.as_deref(), Some("enforced"));
     }
 
     #[test]

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -44,7 +44,15 @@ pub fn render_agents_table(agents: &[AgentRow]) {
 
     let mut table = Table::new();
     table.set_content_arrangement(ContentArrangement::Dynamic);
-    table.set_header(vec!["AGENT_ID", "NAME", "FRAMEWORK", "STATUS", "VIOLATIONS_TODAY"]);
+    table.set_header(vec![
+        "AGENT_ID",
+        "NAME",
+        "STATUS",
+        "FRAMEWORK",
+        "SESSIONS",
+        "VIOLATIONS_TODAY",
+        "LAYER",
+    ]);
     for agent in agents {
         let status_icon = match agent.status.as_str() {
             "Running" => "●",
@@ -55,9 +63,11 @@ pub fn render_agents_table(agents: &[AgentRow]) {
         table.add_row(vec![
             &agent.id,
             &agent.name,
-            &agent.framework,
             &format!("{status_icon} {}", agent.status),
+            &agent.framework,
+            &agent.sessions.to_string(),
             &agent.violations_today.to_string(),
+            &agent.layer,
         ]);
     }
     println!("{table}");

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -87,6 +87,8 @@ pub struct AgentRecord {
     pub recent_events: VecDeque<RecentEvent>,
     /// Most recent trace session IDs for this agent.
     pub recent_traces: Vec<RecentTrace>,
+    /// Governance layer this agent is assigned to (e.g. "advisory", "enforced").
+    pub layer: Option<String>,
 }
 
 /// Channel sender type for pushing [`ControlCommand`]s to an agent's control stream.

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -102,6 +102,7 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
             active_sessions: Vec::new(),
             recent_events: std::collections::VecDeque::new(),
             recent_traces: Vec::new(),
+            layer: None,
         };
 
         self.registry

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -279,6 +279,7 @@ budget:
         active_sessions: Vec::new(),
         recent_events: std::collections::VecDeque::new(),
         recent_traces: Vec::new(),
+        layer: None,
     };
     registry.register(record).unwrap();
 
@@ -353,6 +354,7 @@ budget:
         active_sessions: Vec::new(),
         recent_events: std::collections::VecDeque::new(),
         recent_traces: Vec::new(),
+        layer: None,
     };
     registry.register(record).unwrap();
 

--- a/aa-gateway/tests/registry_test.rs
+++ b/aa-gateway/tests/registry_test.rs
@@ -29,6 +29,7 @@ fn make_record(key: [u8; 16]) -> AgentRecord {
         active_sessions: Vec::new(),
         recent_events: VecDeque::new(),
         recent_traces: Vec::new(),
+        layer: None,
     }
 }
 
@@ -223,6 +224,7 @@ async fn concurrent_registration_of_100_agents() {
                 active_sessions: Vec::new(),
                 recent_events: VecDeque::new(),
                 recent_traces: Vec::new(),
+                layer: None,
             };
             reg.register(record).unwrap();
         }));

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -349,6 +349,8 @@ export interface components {
             id: string;
             /** @description ISO 8601 timestamp of the most recent event. */
             last_event?: string | null;
+            /** @description Governance layer this agent is assigned to (e.g. "advisory", "enforced"). */
+            layer?: string | null;
             /** @description Arbitrary metadata key-value pairs. */
             metadata: {
                 [key: string]: string;

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -584,6 +584,10 @@ components:
           type: string
           description: ISO 8601 timestamp of the most recent event.
           nullable: true
+        layer:
+          type: string
+          description: Governance layer this agent is assigned to (e.g. "advisory", "enforced").
+          nullable: true
         metadata:
           type: object
           description: Arbitrary metadata key-value pairs.


### PR DESCRIPTION
## Summary

- Add `layer` field to `AgentRecord` (gateway), API `AgentResponse`, and CLI status models
- Wire `session_count` and `policy_violations_count` from the API into the status table (previously `violations_today` was hardcoded to `0`)
- Update `render_agents_table()` column order to: `AGENT_ID, NAME, STATUS, FRAMEWORK, SESSIONS, VIOLATIONS_TODAY, LAYER`
- `layer` defaults to `"-"` when not set (backward compatible with agents registered before this change)

## Test plan

- [x] All existing tests updated and passing
- [x] New tests: `agent_response_deserializes_with_new_fields`, `build_agent_rows_defaults_layer_when_none`
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean
- [x] Full workspace test suite: 0 failures

Closes AAASM-181

🤖 Generated with [Claude Code](https://claude.com/claude-code)