### PR TITLE
[AAASM-179] 🐛 (policy): Switch aasm policy apply from FsHistoryStore to REST API

### DIFF
--- a/aa-cli/src/client.rs
+++ b/aa-cli/src/client.rs
@@ -1,6 +1,7 @@
 //! Shared HTTP client for communicating with the Agent Assembly gateway.
 
 use serde::de::DeserializeOwned;
+use serde::Serialize;
 
 use crate::config::ResolvedContext;
 use crate::error::CliError;
@@ -23,6 +24,25 @@ pub async fn get_json<T: DeserializeOwned>(ctx: &ResolvedContext, path: &str) ->
     let resp = req.send().await?.error_for_status()?;
     let body = resp.json::<T>().await?;
     Ok(body)
+}
+
+/// Perform a POST request to the gateway with a JSON body and deserialize the response.
+pub async fn post_json<B: Serialize, T: DeserializeOwned>(
+    ctx: &ResolvedContext,
+    path: &str,
+    body: &B,
+) -> Result<T, CliError> {
+    let url = format!("{}{path}", ctx.api_url);
+    let client = build_client();
+
+    let mut req = client.post(&url).json(body);
+    if let Some(ref key) = ctx.api_key {
+        req = req.bearer_auth(key);
+    }
+
+    let resp = req.send().await?.error_for_status()?;
+    let result = resp.json::<T>().await?;
+    Ok(result)
 }
 
 /// Perform a DELETE request to the gateway.

--- a/aa-cli/src/commands/approvals/watch.rs
+++ b/aa-cli/src/commands/approvals/watch.rs
@@ -50,6 +50,12 @@ pub struct InteractiveState {
     pub dirty: bool,
 }
 
+impl Default for InteractiveState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl InteractiveState {
     /// Create a new empty interactive state.
     pub fn new() -> Self {

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -45,7 +45,7 @@ pub fn dispatch(cmd: Commands, ctx: &ResolvedContext, output: OutputFormat) -> E
     match cmd {
         Commands::Agent(args) => agent::dispatch(args, ctx, output),
         Commands::Logs(args) => logs::dispatch(args, ctx),
-        Commands::Policy(args) => policy::dispatch(args),
+        Commands::Policy(args) => policy::dispatch(args, ctx),
         Commands::Context(args) => context::dispatch(args),
         Commands::Completion(args) => completion::run(args),
         Commands::Status(args) => status::dispatch(args, ctx, output),

--- a/aa-cli/src/commands/policy/history.rs
+++ b/aa-cli/src/commands/policy/history.rs
@@ -9,6 +9,8 @@ use clap::Args;
 use owo_colors::OwoColorize;
 use serde::{Deserialize, Serialize};
 
+use crate::config::ResolvedContext;
+
 /// Request body for `POST /api/v1/policies`.
 #[derive(Debug, Serialize)]
 pub struct CreatePolicyRequest {
@@ -64,7 +66,7 @@ pub struct DiffArgs {
 }
 
 /// Execute the `aasm policy apply` command.
-pub fn run_apply(args: ApplyArgs) -> ExitCode {
+pub fn run_apply(args: ApplyArgs, ctx: &ResolvedContext) -> ExitCode {
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     rt.block_on(async {
         let store = FsHistoryStore::new(HistoryConfig::default_config());

--- a/aa-cli/src/commands/policy/history.rs
+++ b/aa-cli/src/commands/policy/history.rs
@@ -7,6 +7,27 @@ use std::process::ExitCode;
 use aa_gateway::policy::history::{FsHistoryStore, HistoryConfig, PolicyHistoryStore};
 use clap::Args;
 use owo_colors::OwoColorize;
+use serde::{Deserialize, Serialize};
+
+/// Request body for `POST /api/v1/policies`.
+#[derive(Debug, Serialize)]
+pub struct CreatePolicyRequest {
+    /// Raw YAML content of the governance policy.
+    pub policy_yaml: String,
+}
+
+/// Response from `POST /api/v1/policies`.
+#[derive(Debug, Deserialize)]
+pub struct PolicyApplyResponse {
+    /// Policy name (SHA-256 prefix).
+    pub name: String,
+    /// Policy version string (timestamp).
+    pub version: String,
+    /// Whether this is the currently active policy.
+    pub active: bool,
+    /// Number of rules in this policy version.
+    pub rule_count: usize,
+}
 
 /// Arguments for `aasm policy apply`.
 #[derive(Args)]

--- a/aa-cli/src/commands/policy/history.rs
+++ b/aa-cli/src/commands/policy/history.rs
@@ -69,7 +69,6 @@ pub struct DiffArgs {
 pub fn run_apply(args: ApplyArgs, ctx: &ResolvedContext) -> ExitCode {
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     rt.block_on(async {
-        let store = FsHistoryStore::new(HistoryConfig::default_config());
         let yaml = match std::fs::read_to_string(&args.file) {
             Ok(y) => y,
             Err(e) => {
@@ -81,15 +80,14 @@ pub fn run_apply(args: ApplyArgs, ctx: &ResolvedContext) -> ExitCode {
             eprintln!("error: policy validation failed: {:?}", errs);
             return ExitCode::FAILURE;
         }
-        match store.save(&yaml, args.applied_by.as_deref()).await {
-            Ok(meta) => {
+        let body = CreatePolicyRequest { policy_yaml: yaml };
+        match crate::client::post_json::<_, PolicyApplyResponse>(ctx, "/api/v1/policies", &body).await {
+            Ok(resp) => {
                 println!("Policy applied successfully.");
-                println!("  Version:    {}", &meta.sha256[..12]);
-                println!("  Timestamp:  {}", meta.timestamp);
-                println!("  SHA-256:    {}", meta.sha256);
-                if let Some(by) = &meta.applied_by {
-                    println!("  Applied by: {}", by);
-                }
+                println!("  Version:    {}", resp.name);
+                println!("  Timestamp:  {}", resp.version);
+                println!("  Active:     {}", resp.active);
+                println!("  Rules:      {}", resp.rule_count);
                 ExitCode::SUCCESS
             }
             Err(e) => {

--- a/aa-cli/src/commands/policy/mod.rs
+++ b/aa-cli/src/commands/policy/mod.rs
@@ -4,6 +4,8 @@ use std::process::ExitCode;
 
 use clap::{Args, Subcommand};
 
+use crate::config::ResolvedContext;
+
 pub mod get;
 pub mod history;
 pub mod simulate;
@@ -36,9 +38,9 @@ pub enum PolicyCommands {
 }
 
 /// Dispatch a policy subcommand.
-pub fn dispatch(args: PolicyArgs) -> ExitCode {
+pub fn dispatch(args: PolicyArgs, ctx: &ResolvedContext) -> ExitCode {
     match args.command {
-        PolicyCommands::Apply(apply_args) => history::run_apply(apply_args),
+        PolicyCommands::Apply(apply_args) => history::run_apply(apply_args, ctx),
         PolicyCommands::History(history_args) => history::run_history(history_args),
         PolicyCommands::Rollback(rollback_args) => history::run_rollback(rollback_args),
         PolicyCommands::Diff(diff_args) => history::run_diff(diff_args),

--- a/aa-cli/src/lib.rs
+++ b/aa-cli/src/lib.rs
@@ -1,0 +1,33 @@
+//! `aa-cli` library — shared types for the `aasm` binary and integration tests.
+
+use clap::Parser;
+
+pub mod client;
+pub mod commands;
+pub mod config;
+pub mod error;
+pub mod output;
+
+/// Agent Assembly CLI — governance gateway management tool.
+#[derive(Parser)]
+#[command(name = "aasm", version, about)]
+pub struct Cli {
+    /// Named context from ~/.aa/config.yaml to use.
+    #[arg(long, global = true)]
+    pub context: Option<String>,
+
+    /// Output format for list/get commands.
+    #[arg(long, global = true, value_enum, default_value_t = output::OutputFormat::Table)]
+    pub output: output::OutputFormat,
+
+    /// Override the API URL (takes precedence over context config).
+    #[arg(long, global = true)]
+    pub api_url: Option<String>,
+
+    /// Override the API key (takes precedence over context config).
+    #[arg(long, global = true)]
+    pub api_key: Option<String>,
+
+    #[command(subcommand)]
+    pub command: commands::Commands,
+}

--- a/aa-cli/src/main.rs
+++ b/aa-cli/src/main.rs
@@ -5,37 +5,8 @@
 
 use std::process::ExitCode;
 
+use aa_cli::{commands, config, Cli};
 use clap::Parser;
-
-mod client;
-mod commands;
-mod config;
-mod error;
-mod output;
-
-/// Agent Assembly CLI — governance gateway management tool.
-#[derive(Parser)]
-#[command(name = "aasm", version, about)]
-struct Cli {
-    /// Named context from ~/.aa/config.yaml to use.
-    #[arg(long, global = true)]
-    context: Option<String>,
-
-    /// Output format for list/get commands.
-    #[arg(long, global = true, value_enum, default_value_t = output::OutputFormat::Table)]
-    output: output::OutputFormat,
-
-    /// Override the API URL (takes precedence over context config).
-    #[arg(long, global = true)]
-    api_url: Option<String>,
-
-    /// Override the API key (takes precedence over context config).
-    #[arg(long, global = true)]
-    api_key: Option<String>,
-
-    #[command(subcommand)]
-    command: commands::Commands,
-}
 
 fn main() -> ExitCode {
     let cli = Cli::parse();

--- a/aa-cli/tests/policy_apply.rs
+++ b/aa-cli/tests/policy_apply.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{body_partial_json, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn make_context(api_url: &str) -> aa_cli::config::ResolvedContext {
@@ -21,6 +21,9 @@ async fn apply_sends_post_to_api_and_prints_response() {
 
     Mock::given(method("POST"))
         .and(path("/api/v1/policies"))
+        .and(body_partial_json(serde_json::json!({
+            "policy_yaml": "apiVersion: agent-assembly.dev/v1alpha1\nkind: GovernancePolicy\nmetadata:\n  name: test-policy\n  version: \"1.0.0\"\nspec:\n  rules: []\n"
+        })))
         .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
             "name": "abc123def456",
             "version": "2026-04-30T12:00:00Z",

--- a/aa-cli/tests/policy_apply.rs
+++ b/aa-cli/tests/policy_apply.rs
@@ -1,0 +1,92 @@
+//! Integration tests for `aasm policy apply` via REST API.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn make_context(api_url: &str) -> aa_cli::config::ResolvedContext {
+    aa_cli::config::ResolvedContext {
+        name: None,
+        api_url: api_url.to_string(),
+        api_key: None,
+    }
+}
+
+#[tokio::test]
+async fn apply_sends_post_to_api_and_prints_response() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/policies"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "name": "abc123def456",
+            "version": "2026-04-30T12:00:00Z",
+            "active": true,
+            "rule_count": 0
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(b"apiVersion: agent-assembly.dev/v1alpha1\nkind: GovernancePolicy\nmetadata:\n  name: test-policy\n  version: \"1.0.0\"\nspec:\n  rules: []\n").unwrap();
+
+    let file_path = tmp.path().to_path_buf();
+    let uri = server.uri();
+
+    // run_apply creates its own tokio runtime via block_on, so run it
+    // on a separate thread to avoid nesting inside the #[tokio::test] runtime.
+    let result = std::thread::spawn(move || {
+        let args = aa_cli::commands::policy::history::ApplyArgs {
+            file: file_path,
+            applied_by: None,
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::policy::history::run_apply(args, &ctx)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+}
+
+#[tokio::test]
+async fn apply_fails_fast_on_invalid_yaml_without_api_call() {
+    let server = MockServer::start().await;
+
+    // No mock mounted — any API call would cause an unmatched request error.
+
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(b"this is not valid yaml: [").unwrap();
+
+    let file_path = tmp.path().to_path_buf();
+    let uri = server.uri();
+
+    let result = std::thread::spawn(move || {
+        let args = aa_cli::commands::policy::history::ApplyArgs {
+            file: file_path,
+            applied_by: None,
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::policy::history::run_apply(args, &ctx)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::FAILURE);
+}
+
+#[test]
+fn apply_fails_on_missing_file() {
+    let args = aa_cli::commands::policy::history::ApplyArgs {
+        file: PathBuf::from("/tmp/nonexistent-policy-file-aaasm179.yaml"),
+        applied_by: None,
+    };
+    let ctx = make_context("http://localhost:9999");
+
+    let result = aa_cli::commands::policy::history::run_apply(args, &ctx);
+    assert_eq!(result, ExitCode::FAILURE);
+}


### PR DESCRIPTION
## Description

Switch `aasm policy apply` from writing to the local filesystem via `FsHistoryStore` to calling `POST /api/v1/policies` on the configured gateway API. Local YAML validation is still performed before sending the request (fail fast).

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [ ] No
- [x] Yes (describe below)

`aasm policy apply` now requires a reachable API gateway. Previously it wrote locally to `~/.aa/policy-history/`. Users who relied on local-only apply must now have a running gateway or configure `--api-url`.

## Related Issues

- Related Jira ticket: AAASM-179
- Parent Epic: AAASM-10

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

### Tests added:
- `apply_sends_post_to_api_and_prints_response` — wiremock-based test verifying POST to `/api/v1/policies` with correct body and response handling
- `apply_fails_fast_on_invalid_yaml_without_api_call` — verifies invalid YAML is rejected locally before any API call
- `apply_fails_on_missing_file` — verifies missing file path returns FAILURE

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention