### PR TITLE
[AAASM-182] 🐛 (cli): Wire per-agent budget data and bar charts into aasm status

### DIFF
--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -67,6 +67,7 @@ use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, trac
         approvals::ApprovalResponse,
         approvals::DecideRequest,
         costs::CostSummary,
+        costs::AgentCostEntry,
         alerts::AlertResponse,
         auth::TokenRequest,
         auth::TokenResponse,

--- a/aa-api/src/routes/costs.rs
+++ b/aa-api/src/routes/costs.rs
@@ -25,6 +25,15 @@ pub struct CostSummary {
     pub monthly_spend_usd: Option<String>,
     /// Calendar date (YYYY-MM-DD) the daily spend applies to.
     pub date: String,
+    /// Configured daily budget limit in USD, if set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub daily_limit_usd: Option<String>,
+    /// Configured monthly budget limit in USD, if set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub monthly_limit_usd: Option<String>,
+    /// Per-agent cost breakdown for the current day.
+    #[serde(default)]
+    pub per_agent: Vec<AgentCostEntry>,
 }
 
 /// `GET /api/v1/costs` — cost and budget summary.
@@ -41,10 +50,22 @@ pub struct CostSummary {
 pub async fn get_cost_summary(Extension(state): Extension<AppState>) -> (StatusCode, Json<CostSummary>) {
     let snapshot = state.budget_tracker.snapshot();
 
+    let per_agent: Vec<AgentCostEntry> = snapshot
+        .per_agent
+        .iter()
+        .map(|entry| AgentCostEntry {
+            agent_id: entry.agent_id_hex.clone(),
+            daily_spend_usd: entry.state.spent_usd.to_string(),
+        })
+        .collect();
+
     let summary = CostSummary {
         daily_spend_usd: snapshot.global.spent_usd.to_string(),
         monthly_spend_usd: snapshot.global.monthly_spent_usd.map(|d| d.to_string()),
         date: snapshot.global.date.to_string(),
+        daily_limit_usd: state.budget_tracker.daily_limit_usd().map(|d| d.to_string()),
+        monthly_limit_usd: state.budget_tracker.monthly_limit_usd().map(|d| d.to_string()),
+        per_agent,
     };
 
     (StatusCode::OK, Json(summary))

--- a/aa-api/src/routes/costs.rs
+++ b/aa-api/src/routes/costs.rs
@@ -70,3 +70,60 @@ pub async fn get_cost_summary(Extension(state): Extension<AppState>) -> (StatusC
 
     (StatusCode::OK, Json(summary))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cost_summary_serialization_includes_per_agent() {
+        let summary = CostSummary {
+            daily_spend_usd: "8.10".to_string(),
+            monthly_spend_usd: Some("142.50".to_string()),
+            date: "2026-04-30".to_string(),
+            daily_limit_usd: Some("100.00".to_string()),
+            monthly_limit_usd: Some("2000.00".to_string()),
+            per_agent: vec![AgentCostEntry {
+                agent_id: "abc123".to_string(),
+                daily_spend_usd: "4.10".to_string(),
+            }],
+        };
+        let json = serde_json::to_value(&summary).unwrap();
+        assert_eq!(json["per_agent"][0]["agent_id"], "abc123");
+        assert_eq!(json["per_agent"][0]["daily_spend_usd"], "4.10");
+        assert_eq!(json["daily_limit_usd"], "100.00");
+        assert_eq!(json["monthly_limit_usd"], "2000.00");
+    }
+
+    #[test]
+    fn cost_summary_omits_limits_when_none() {
+        let summary = CostSummary {
+            daily_spend_usd: "0.00".to_string(),
+            monthly_spend_usd: None,
+            date: "2026-04-30".to_string(),
+            daily_limit_usd: None,
+            monthly_limit_usd: None,
+            per_agent: vec![],
+        };
+        let json = serde_json::to_value(&summary).unwrap();
+        assert!(json.get("daily_limit_usd").is_none());
+        assert!(json.get("monthly_limit_usd").is_none());
+        assert!(json["monthly_spend_usd"].is_null());
+    }
+
+    #[test]
+    fn cost_summary_backward_compatible_fields_unchanged() {
+        let summary = CostSummary {
+            daily_spend_usd: "8.10".to_string(),
+            monthly_spend_usd: Some("142.50".to_string()),
+            date: "2026-04-30".to_string(),
+            daily_limit_usd: None,
+            monthly_limit_usd: None,
+            per_agent: vec![],
+        };
+        let json = serde_json::to_value(&summary).unwrap();
+        assert_eq!(json["daily_spend_usd"], "8.10");
+        assert_eq!(json["monthly_spend_usd"], "142.50");
+        assert_eq!(json["date"], "2026-04-30");
+    }
+}

--- a/aa-api/src/routes/costs.rs
+++ b/aa-api/src/routes/costs.rs
@@ -7,6 +7,15 @@ use utoipa::ToSchema;
 
 use crate::state::AppState;
 
+/// Per-agent cost entry within the budget summary.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct AgentCostEntry {
+    /// Agent identifier (hex-encoded).
+    pub agent_id: String,
+    /// Daily spend for this agent in USD.
+    pub daily_spend_usd: String,
+}
+
 /// JSON representation of the cost/budget summary.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct CostSummary {

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -74,7 +74,10 @@ pub async fn fetch_all(client: &StatusClient) -> StatusSnapshot {
         Err(_) => BudgetRow {
             daily_spend_usd: "--".to_string(),
             monthly_spend_usd: None,
+            daily_limit_usd: None,
+            monthly_limit_usd: None,
             date: "--".to_string(),
+            per_agent: vec![],
         },
     };
 
@@ -91,7 +94,10 @@ pub fn build_budget_row(cost: CostResponse) -> BudgetRow {
     BudgetRow {
         daily_spend_usd: cost.daily_spend_usd,
         monthly_spend_usd: cost.monthly_spend_usd,
+        daily_limit_usd: cost.daily_limit_usd,
+        monthly_limit_usd: cost.monthly_limit_usd,
         date: cost.date,
+        per_agent: cost.per_agent,
     }
 }
 

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -81,7 +81,10 @@ mod tests {
             budget: BudgetRow {
                 daily_spend_usd: "0.00".to_string(),
                 monthly_spend_usd: None,
+                daily_limit_usd: None,
+                monthly_limit_usd: None,
                 date: "2026-04-30".to_string(),
+                per_agent: vec![],
             },
         }
     }

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -169,12 +169,22 @@ mod tests {
         let json = r#"{
             "daily_spend_usd": "8.10",
             "monthly_spend_usd": "142.50",
-            "date": "2026-04-30"
+            "date": "2026-04-30",
+            "daily_limit_usd": "100.00",
+            "monthly_limit_usd": "2000.00",
+            "per_agent": [
+                {"agent_id": "abc123", "daily_spend_usd": "4.10"}
+            ]
         }"#;
         let resp: CostResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.daily_spend_usd, "8.10");
         assert_eq!(resp.monthly_spend_usd.as_deref(), Some("142.50"));
         assert_eq!(resp.date, "2026-04-30");
+        assert_eq!(resp.daily_limit_usd.as_deref(), Some("100.00"));
+        assert_eq!(resp.monthly_limit_usd.as_deref(), Some("2000.00"));
+        assert_eq!(resp.per_agent.len(), 1);
+        assert_eq!(resp.per_agent[0].agent_id, "abc123");
+        assert_eq!(resp.per_agent[0].daily_spend_usd, "4.10");
     }
 
     #[test]
@@ -182,5 +192,19 @@ mod tests {
         let json = r#"{"daily_spend_usd": "0.00", "date": "2026-04-30"}"#;
         let resp: CostResponse = serde_json::from_str(json).unwrap();
         assert!(resp.monthly_spend_usd.is_none());
+    }
+
+    #[test]
+    fn cost_response_deserializes_without_new_fields() {
+        let json = r#"{
+            "daily_spend_usd": "5.00",
+            "monthly_spend_usd": "50.00",
+            "date": "2026-04-30"
+        }"#;
+        let resp: CostResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.daily_spend_usd, "5.00");
+        assert!(resp.daily_limit_usd.is_none());
+        assert!(resp.monthly_limit_usd.is_none());
+        assert!(resp.per_agent.is_empty());
     }
 }

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -62,12 +62,25 @@ pub struct ApprovalsSummary {
     pub oldest_pending_age: Option<String>,
 }
 
+/// Per-agent cost entry from the API.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AgentCostEntry {
+    pub agent_id: String,
+    pub daily_spend_usd: String,
+}
+
 /// API response from `GET /api/v1/costs`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CostResponse {
     pub daily_spend_usd: String,
     pub monthly_spend_usd: Option<String>,
     pub date: String,
+    #[serde(default)]
+    pub daily_limit_usd: Option<String>,
+    #[serde(default)]
+    pub monthly_limit_usd: Option<String>,
+    #[serde(default)]
+    pub per_agent: Vec<AgentCostEntry>,
 }
 
 /// Per-agent budget row for display.

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -83,15 +83,21 @@ pub struct CostResponse {
     pub per_agent: Vec<AgentCostEntry>,
 }
 
-/// Per-agent budget row for display.
+/// Budget display model combining global spend, limits, and per-agent breakdown.
 #[derive(Debug, Clone, Serialize)]
 pub struct BudgetRow {
-    /// Total daily spend in USD (aggregated, since per-agent is not yet available).
+    /// Total daily spend in USD.
     pub daily_spend_usd: String,
     /// Monthly spend if available.
     pub monthly_spend_usd: Option<String>,
+    /// Configured daily budget limit in USD.
+    pub daily_limit_usd: Option<String>,
+    /// Configured monthly budget limit in USD.
+    pub monthly_limit_usd: Option<String>,
     /// Reporting date.
     pub date: String,
+    /// Per-agent cost breakdown sorted by spend descending.
+    pub per_agent: Vec<AgentCostEntry>,
 }
 
 /// Paginated API response wrapper.

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -150,7 +150,10 @@ mod tests {
             budget: BudgetRow {
                 daily_spend_usd: "0.00".to_string(),
                 monthly_spend_usd: None,
+                daily_limit_usd: None,
+                monthly_limit_usd: None,
                 date: "2026-04-30".to_string(),
+                per_agent: vec![],
             },
         };
         let json = serde_json::to_string_pretty(&snapshot).unwrap();

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -1,5 +1,6 @@
 //! Rendering functions for `aasm status` output.
 
+use colored::Colorize;
 use comfy_table::{ContentArrangement, Table};
 
 use super::models::{AgentRow, ApprovalsSummary, BudgetRow, RuntimeHealth, StatusSnapshot};
@@ -60,9 +61,6 @@ pub fn render_approvals_summary(summary: &ApprovalsSummary) {
 /// Render an ASCII bar chart: 20-char wide, `█` for used, `░` for remaining.
 ///
 /// `percentage` is clamped to `0..=100`.
-/// Currently used in tests; will be called from `render_budget_table` once
-/// per-agent budget data is available from the API.
-#[allow(dead_code)]
 pub fn format_bar_chart(percentage: u32) -> String {
     let pct = percentage.min(100);
     let filled = (pct as usize * 20) / 100;
@@ -70,15 +68,75 @@ pub fn format_bar_chart(percentage: u32) -> String {
     format!("{}{} {:>3}%", "█".repeat(filled), "░".repeat(empty), pct,)
 }
 
+/// Color a bar chart string based on the percentage threshold.
+///
+/// Green < 50%, yellow 50–80%, red > 80%.
+fn colorize_bar(bar: &str, percentage: u32) -> String {
+    if percentage > 80 {
+        bar.red().to_string()
+    } else if percentage >= 50 {
+        bar.yellow().to_string()
+    } else {
+        bar.green().to_string()
+    }
+}
+
+/// Render a single budget overview line (daily or monthly).
+fn render_budget_line(label: &str, spend: &str, limit: Option<&str>) {
+    match limit {
+        Some(lim) => {
+            let spend_f: f64 = spend.parse().unwrap_or(0.0);
+            let limit_f: f64 = lim.parse().unwrap_or(1.0);
+            let pct = if limit_f > 0.0 {
+                ((spend_f / limit_f) * 100.0).round() as u32
+            } else {
+                0
+            };
+            let bar = format_bar_chart(pct);
+            let colored_bar = colorize_bar(&bar, pct);
+            println!("  {label}: ${spend} / ${lim}  {colored_bar}");
+        }
+        None => {
+            println!("  {label}: ${spend} (no limit set)");
+        }
+    }
+}
+
 /// Render the Budget Status section to stdout.
 pub fn render_budget_table(budget: &BudgetRow) {
     println!("BUDGET STATUS");
     println!("─────────────");
-    println!("  Daily spend:   ${}", budget.daily_spend_usd);
+
+    render_budget_line("Daily spend ", &budget.daily_spend_usd, budget.daily_limit_usd.as_deref());
+
     if let Some(ref monthly) = budget.monthly_spend_usd {
-        println!("  Monthly spend: ${monthly}");
+        render_budget_line("Monthly spend", monthly, budget.monthly_limit_usd.as_deref());
     }
-    println!("  Date:          {}", budget.date);
+
+    println!("  Date:           {}", budget.date);
+
+    if budget.per_agent.is_empty() {
+        println!("  (no per-agent data)");
+    } else {
+        println!();
+        println!("PER-AGENT SPEND (today)");
+        println!("───────────────────────");
+        let mut table = Table::new();
+        table.set_content_arrangement(ContentArrangement::Dynamic);
+        table.set_header(vec!["AGENT_ID", "DAILY_SPEND"]);
+
+        let mut sorted = budget.per_agent.clone();
+        sorted.sort_by(|a, b| {
+            let a_val: f64 = a.daily_spend_usd.parse().unwrap_or(0.0);
+            let b_val: f64 = b.daily_spend_usd.parse().unwrap_or(0.0);
+            b_val.partial_cmp(&a_val).unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        for entry in &sorted {
+            table.add_row(vec![&entry.agent_id, &format!("${}", entry.daily_spend_usd)]);
+        }
+        println!("{table}");
+    }
     println!();
 }
 

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -107,7 +107,11 @@ pub fn render_budget_table(budget: &BudgetRow) {
     println!("BUDGET STATUS");
     println!("─────────────");
 
-    render_budget_line("Daily spend ", &budget.daily_spend_usd, budget.daily_limit_usd.as_deref());
+    render_budget_line(
+        "Daily spend ",
+        &budget.daily_spend_usd,
+        budget.daily_limit_usd.as_deref(),
+    );
 
     if let Some(ref monthly) = budget.monthly_spend_usd {
         render_budget_line("Monthly spend", monthly, budget.monthly_limit_usd.as_deref());
@@ -225,7 +229,7 @@ mod tests {
     #[test]
     fn per_agent_sorted_by_spend_descending() {
         use super::super::models::AgentCostEntry;
-        let mut entries = vec![
+        let mut entries = [
             AgentCostEntry {
                 agent_id: "low".to_string(),
                 daily_spend_usd: "1.00".to_string(),

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -194,6 +194,62 @@ mod tests {
     }
 
     #[test]
+    fn colorize_bar_green_below_50() {
+        let bar = format_bar_chart(30);
+        let colored = colorize_bar(&bar, 30);
+        // The colored string contains ANSI escape codes for green.
+        assert!(colored.contains("30%"));
+    }
+
+    #[test]
+    fn colorize_bar_yellow_at_50() {
+        let bar = format_bar_chart(50);
+        let colored = colorize_bar(&bar, 50);
+        assert!(colored.contains("50%"));
+    }
+
+    #[test]
+    fn colorize_bar_yellow_at_80() {
+        let bar = format_bar_chart(80);
+        let colored = colorize_bar(&bar, 80);
+        assert!(colored.contains("80%"));
+    }
+
+    #[test]
+    fn colorize_bar_red_above_80() {
+        let bar = format_bar_chart(95);
+        let colored = colorize_bar(&bar, 95);
+        assert!(colored.contains("95%"));
+    }
+
+    #[test]
+    fn per_agent_sorted_by_spend_descending() {
+        use super::super::models::AgentCostEntry;
+        let mut entries = vec![
+            AgentCostEntry {
+                agent_id: "low".to_string(),
+                daily_spend_usd: "1.00".to_string(),
+            },
+            AgentCostEntry {
+                agent_id: "high".to_string(),
+                daily_spend_usd: "10.00".to_string(),
+            },
+            AgentCostEntry {
+                agent_id: "mid".to_string(),
+                daily_spend_usd: "5.00".to_string(),
+            },
+        ];
+        entries.sort_by(|a, b| {
+            let a_val: f64 = a.daily_spend_usd.parse().unwrap_or(0.0);
+            let b_val: f64 = b.daily_spend_usd.parse().unwrap_or(0.0);
+            b_val.partial_cmp(&a_val).unwrap_or(std::cmp::Ordering::Equal)
+        });
+        assert_eq!(entries[0].agent_id, "high");
+        assert_eq!(entries[1].agent_id, "mid");
+        assert_eq!(entries[2].agent_id, "low");
+    }
+
+    #[test]
     fn render_status_json_contains_all_keys() {
         let snapshot = StatusSnapshot {
             runtime: RuntimeHealth {

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -362,6 +362,35 @@ mod tests {
     }
 
     #[test]
+    fn daily_limit_usd_returns_configured_limit() {
+        let t = tracker_with_limit("50.00");
+        assert_eq!(t.daily_limit_usd(), Some(Decimal::new(5000, 2)));
+    }
+
+    #[test]
+    fn daily_limit_usd_returns_none_when_unset() {
+        let t = new_tracker();
+        assert_eq!(t.daily_limit_usd(), None);
+    }
+
+    #[test]
+    fn monthly_limit_usd_returns_configured_limit() {
+        let t = BudgetTracker::new(
+            PricingTable::default_table(),
+            None,
+            Some("1000.00".parse().unwrap()),
+            chrono_tz::UTC,
+        );
+        assert_eq!(t.monthly_limit_usd(), Some(Decimal::new(100000, 2)));
+    }
+
+    #[test]
+    fn monthly_limit_usd_returns_none_when_unset() {
+        let t = new_tracker();
+        assert_eq!(t.monthly_limit_usd(), None);
+    }
+
+    #[test]
     fn compute_status_returns_within_budget_below_80() {
         use crate::budget::types::BudgetStatus;
         fn d(s: &str) -> Decimal {

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -171,6 +171,16 @@ impl BudgetTracker {
         self.timezone
     }
 
+    /// Returns the configured daily budget limit in USD, if set.
+    pub fn daily_limit_usd(&self) -> Option<Decimal> {
+        self.daily_limit_usd
+    }
+
+    /// Returns the configured monthly budget limit in USD, if set.
+    pub fn monthly_limit_usd(&self) -> Option<Decimal> {
+        self.monthly_limit_usd
+    }
+
     /// Returns `true` if the agent has met or exceeded the given daily limit.
     ///
     /// Automatically resets spend to zero when the stored date is before today

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -332,6 +332,13 @@ export interface components {
             /** @description Current status of the session. */
             status: string;
         };
+        /** @description Per-agent cost entry within the budget summary. */
+        AgentCostEntry: {
+            /** @description Agent identifier (hex-encoded). */
+            agent_id: string;
+            /** @description Daily spend for this agent in USD. */
+            daily_spend_usd: string;
+        };
         /** @description JSON representation of an agent returned by the API. */
         AgentResponse: {
             /** @description Currently active sessions for this agent. */
@@ -451,12 +458,18 @@ export interface components {
         };
         /** @description JSON representation of the cost/budget summary. */
         CostSummary: {
+            /** @description Configured daily budget limit in USD, if set. */
+            daily_limit_usd?: string | null;
             /** @description Total spend today in USD. */
             daily_spend_usd: string;
             /** @description Calendar date (YYYY-MM-DD) the daily spend applies to. */
             date: string;
+            /** @description Configured monthly budget limit in USD, if set. */
+            monthly_limit_usd?: string | null;
             /** @description Total spend this month in USD (if monthly tracking is enabled). */
             monthly_spend_usd?: string | null;
+            /** @description Per-agent cost breakdown for the current day. */
+            per_agent?: components["schemas"]["AgentCostEntry"][];
         };
         /** @description Request body for creating a new policy. */
         CreatePolicyRequest: {

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -539,6 +539,19 @@ components:
         status:
           type: string
           description: Current status of the session.
+    AgentCostEntry:
+      type: object
+      description: Per-agent cost entry within the budget summary.
+      required:
+      - agent_id
+      - daily_spend_usd
+      properties:
+        agent_id:
+          type: string
+          description: Agent identifier (hex-encoded).
+        daily_spend_usd:
+          type: string
+          description: Daily spend for this agent in USD.
     AgentResponse:
       type: object
       description: JSON representation of an agent returned by the API.
@@ -733,16 +746,29 @@ components:
       - daily_spend_usd
       - date
       properties:
+        daily_limit_usd:
+          type: string
+          description: Configured daily budget limit in USD, if set.
+          nullable: true
         daily_spend_usd:
           type: string
           description: Total spend today in USD.
         date:
           type: string
           description: Calendar date (YYYY-MM-DD) the daily spend applies to.
+        monthly_limit_usd:
+          type: string
+          description: Configured monthly budget limit in USD, if set.
+          nullable: true
         monthly_spend_usd:
           type: string
           description: Total spend this month in USD (if monthly tracking is enabled).
           nullable: true
+        per_agent:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentCostEntry'
+          description: Per-agent cost breakdown for the current day.
     CreatePolicyRequest:
       type: object
       description: Request body for creating a new policy.


### PR DESCRIPTION
## Description

Fix the Budget Status section in `aasm status` to show per-agent cost breakdowns and global budget bar charts instead of aggregate text-only output. The `format_bar_chart()` utility was already built and tested but not wired in because the API lacked per-agent data.

This PR extends the data pipeline end-to-end:
- **aa-gateway**: Add public accessors for `daily_limit_usd` and `monthly_limit_usd` on `BudgetTracker`
- **aa-api**: Extend `GET /api/v1/costs` response with `daily_limit_usd`, `monthly_limit_usd`, and `per_agent` array (backward-compatible, additive fields)
- **aa-cli**: Update models, fetch logic, and rendering to display a color-coded global bar chart and a per-agent spend table sorted by spend descending

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-182
- Parent Epic: AAASM-10

## Testing

- [x] Unit tests added / updated
- [x] Manual testing performed (cargo test across aa-gateway, aa-api, aa-cli — all green)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention