### PR TITLE
[AAASM-180] ✨ (api): Add uptime, active_connections, pipeline_lag to health endpoint

### DIFF
--- a/aa-api/src/routes/health.rs
+++ b/aa-api/src/routes/health.rs
@@ -1,15 +1,25 @@
 //! Health check endpoint.
 
+use std::sync::atomic::Ordering;
+
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::Json;
+use axum::{Extension, Json};
 use serde::Serialize;
+
+use crate::state::AppState;
 
 /// Response body for the health endpoint.
 #[derive(Serialize, utoipa::ToSchema)]
 pub struct HealthResponse {
     /// Liveness status string, always `"ok"` when the service is running.
     pub status: String,
+    /// Server uptime in seconds since startup.
+    pub uptime_secs: u64,
+    /// Number of currently active WebSocket/SSE connections.
+    pub active_connections: i64,
+    /// Pipeline processing lag in milliseconds (placeholder, always 0 for now).
+    pub pipeline_lag_ms: u64,
 }
 
 /// `GET /api/v1/health` — liveness probe.
@@ -25,11 +35,17 @@ pub struct HealthResponse {
         (status = 404, description = "Not found", body = ProblemDetail)
     )
 )]
-pub async fn health() -> impl IntoResponse {
+pub async fn health(Extension(state): Extension<AppState>) -> impl IntoResponse {
+    let uptime_secs = state.startup_time.elapsed().as_secs();
+    let active_connections = state.active_connections.load(Ordering::Relaxed);
+
     (
         StatusCode::OK,
         Json(HealthResponse {
             status: "ok".to_string(),
+            uptime_secs,
+            active_connections,
+            pipeline_lag_ms: 0,
         }),
     )
 }

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -1,7 +1,8 @@
 //! Shared application state for the Axum server.
 
-use std::sync::atomic::AtomicU64;
+use std::sync::atomic::{AtomicI64, AtomicU64};
 use std::sync::Arc;
+use std::time::Instant;
 
 use aa_gateway::budget::tracker::BudgetTracker;
 use aa_gateway::engine::PolicyEngine;
@@ -54,4 +55,8 @@ pub struct AppState {
     pub trace_store: Arc<dyn TraceStore>,
     /// Audit log reader for querying JSONL entries.
     pub audit_reader: Arc<AuditReader>,
+    /// Timestamp when the server started, used to compute uptime.
+    pub startup_time: Instant,
+    /// Number of currently active WebSocket/SSE connections.
+    pub active_connections: Arc<AtomicI64>,
 }

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -1,8 +1,9 @@
 //! Shared test utilities for aa-api integration tests.
 
 use std::path::Path;
-use std::sync::atomic::{AtomicU64, AtomicUsize};
+use std::sync::atomic::{AtomicI64, AtomicU64, AtomicUsize};
 use std::sync::Arc;
+use std::time::Instant;
 
 use aa_api::alerts::store::InMemoryAlertStore;
 use aa_api::auth::api_key::{ApiKey, ApiKeyEntry, ApiKeyStore};
@@ -135,6 +136,8 @@ spec:
         jwt_verifier,
         trace_store: Arc::new(InMemoryTraceStore::new()),
         audit_reader,
+        startup_time: Instant::now(),
+        active_connections: Arc::new(AtomicI64::new(0)),
     }
 }
 

--- a/aa-api/tests/health.rs
+++ b/aa-api/tests/health.rs
@@ -21,3 +21,45 @@ async fn health_returns_200_with_ok_status() {
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["status"], "ok");
 }
+
+#[tokio::test]
+async fn health_returns_uptime_secs() {
+    let app = common::test_app();
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(json["uptime_secs"].is_u64(), "uptime_secs should be a u64");
+}
+
+#[tokio::test]
+async fn health_returns_active_connections() {
+    let app = common::test_app();
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["active_connections"], 0);
+}
+
+#[tokio::test]
+async fn health_returns_pipeline_lag_ms() {
+    let app = common::test_app();
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["pipeline_lag_ms"], 0);
+}

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -127,10 +127,16 @@ mod tests {
     fn build_runtime_health_reachable() {
         let resp = Some(HealthResponse {
             status: "ok".to_string(),
+            uptime_secs: 120,
+            active_connections: 3,
+            pipeline_lag_ms: 5,
         });
         let health = build_runtime_health(resp);
         assert!(health.reachable);
         assert_eq!(health.status, "ok");
+        assert_eq!(health.uptime_secs, 120);
+        assert_eq!(health.active_connections, 3);
+        assert_eq!(health.pipeline_lag_ms, 5);
     }
 
     #[test]
@@ -138,6 +144,9 @@ mod tests {
         let health = build_runtime_health(None);
         assert!(!health.reachable);
         assert_eq!(health.status, "unreachable");
+        assert_eq!(health.uptime_secs, 0);
+        assert_eq!(health.active_connections, 0);
+        assert_eq!(health.pipeline_lag_ms, 0);
     }
 
     #[test]

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -14,10 +14,16 @@ pub fn build_runtime_health(resp: Option<HealthResponse>) -> RuntimeHealth {
         Some(h) => RuntimeHealth {
             reachable: true,
             status: h.status,
+            uptime_secs: h.uptime_secs,
+            active_connections: h.active_connections,
+            pipeline_lag_ms: h.pipeline_lag_ms,
         },
         None => RuntimeHealth {
             reachable: false,
             status: "unreachable".to_string(),
+            uptime_secs: 0,
+            active_connections: 0,
+            pipeline_lag_ms: 0,
         },
     }
 }

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -66,6 +66,9 @@ mod tests {
             runtime: RuntimeHealth {
                 reachable: true,
                 status: "ok".to_string(),
+                uptime_secs: 3600,
+                active_connections: 5,
+                pipeline_lag_ms: 0,
             },
             agents: vec![AgentRow {
                 id: "a1".to_string(),

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -9,6 +9,15 @@ use serde::{Deserialize, Serialize};
 pub struct HealthResponse {
     /// Liveness status string, always `"ok"` when the service is running.
     pub status: String,
+    /// Server uptime in seconds since startup.
+    #[serde(default)]
+    pub uptime_secs: u64,
+    /// Number of currently active WebSocket/SSE connections.
+    #[serde(default)]
+    pub active_connections: i64,
+    /// Pipeline processing lag in milliseconds.
+    #[serde(default)]
+    pub pipeline_lag_ms: u64,
 }
 
 /// Computed runtime health for display.
@@ -18,6 +27,12 @@ pub struct RuntimeHealth {
     pub reachable: bool,
     /// Status string from the health endpoint (e.g. `"ok"`).
     pub status: String,
+    /// Server uptime in seconds since startup.
+    pub uptime_secs: u64,
+    /// Number of currently active WebSocket/SSE connections.
+    pub active_connections: i64,
+    /// Pipeline processing lag in milliseconds.
+    pub pipeline_lag_ms: u64,
 }
 
 /// API response item from `GET /api/v1/agents`.

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -119,10 +119,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn health_response_deserializes() {
+    fn health_response_deserializes_minimal() {
         let json = r#"{"status":"ok"}"#;
         let resp: HealthResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.status, "ok");
+        assert_eq!(resp.uptime_secs, 0);
+        assert_eq!(resp.active_connections, 0);
+        assert_eq!(resp.pipeline_lag_ms, 0);
+    }
+
+    #[test]
+    fn health_response_deserializes_with_new_fields() {
+        let json = r#"{"status":"ok","uptime_secs":3600,"active_connections":5,"pipeline_lag_ms":12}"#;
+        let resp: HealthResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.status, "ok");
+        assert_eq!(resp.uptime_secs, 3600);
+        assert_eq!(resp.active_connections, 5);
+        assert_eq!(resp.pipeline_lag_ms, 12);
     }
 
     #[test]

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -178,5 +178,28 @@ mod tests {
         assert!(json.contains("\"agents\""));
         assert!(json.contains("\"approvals\""));
         assert!(json.contains("\"budget\""));
+        assert!(json.contains("\"uptime_secs\""));
+        assert!(json.contains("\"active_connections\""));
+        assert!(json.contains("\"pipeline_lag_ms\""));
+    }
+
+    #[test]
+    fn format_duration_seconds_only() {
+        assert_eq!(format_duration(45), "45s");
+    }
+
+    #[test]
+    fn format_duration_minutes_and_seconds() {
+        assert_eq!(format_duration(125), "2m 5s");
+    }
+
+    #[test]
+    fn format_duration_hours_minutes_seconds() {
+        assert_eq!(format_duration(3661), "1h 1m 1s");
+    }
+
+    #[test]
+    fn format_duration_zero() {
+        assert_eq!(format_duration(0), "0s");
     }
 }

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -141,6 +141,9 @@ mod tests {
             runtime: RuntimeHealth {
                 reachable: true,
                 status: "ok".to_string(),
+                uptime_secs: 120,
+                active_connections: 3,
+                pipeline_lag_ms: 0,
             },
             agents: vec![],
             approvals: ApprovalsSummary {

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -10,8 +10,25 @@ pub fn render_runtime_health(health: &RuntimeHealth) {
     println!("RUNTIME HEALTH");
     println!("──────────────");
     let indicator = if health.reachable { "✓" } else { "✗" };
-    println!("  API:    {indicator} {}", health.status);
+    println!("  API:         {indicator} {}", health.status);
+    println!("  Uptime:      {}", format_duration(health.uptime_secs));
+    println!("  Connections: {}", health.active_connections);
+    println!("  Lag:         {} ms", health.pipeline_lag_ms);
     println!();
+}
+
+/// Format a duration in seconds into a human-readable string (e.g. `"1h 30m 5s"`).
+fn format_duration(secs: u64) -> String {
+    let hours = secs / 3600;
+    let minutes = (secs % 3600) / 60;
+    let seconds = secs % 60;
+    if hours > 0 {
+        format!("{hours}h {minutes}m {seconds}s")
+    } else if minutes > 0 {
+        format!("{minutes}m {seconds}s")
+    } else {
+        format!("{seconds}s")
+    }
 }
 
 /// Render the Active Agents section as a table to stdout.

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -510,8 +510,23 @@ export interface components {
         };
         /** @description Response body for the health endpoint. */
         HealthResponse: {
+            /**
+             * Format: int64
+             * @description Number of currently active WebSocket/SSE connections.
+             */
+            active_connections: number;
+            /**
+             * Format: int64
+             * @description Pipeline processing lag in milliseconds (placeholder, always 0 for now).
+             */
+            pipeline_lag_ms: number;
             /** @description Liveness status string, always `"ok"` when the service is running. */
             status: string;
+            /**
+             * Format: int64
+             * @description Server uptime in seconds since startup.
+             */
+            uptime_secs: number;
         };
         /** @description JSON representation of an audit log entry. */
         LogEntry: {

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -823,10 +823,27 @@ components:
       description: Response body for the health endpoint.
       required:
       - status
+      - uptime_secs
+      - active_connections
+      - pipeline_lag_ms
       properties:
+        active_connections:
+          type: integer
+          format: int64
+          description: Number of currently active WebSocket/SSE connections.
+        pipeline_lag_ms:
+          type: integer
+          format: int64
+          description: Pipeline processing lag in milliseconds (placeholder, always 0 for now).
+          minimum: 0
         status:
           type: string
           description: Liveness status string, always `"ok"` when the service is running.
+        uptime_secs:
+          type: integer
+          format: int64
+          description: Server uptime in seconds since startup.
+          minimum: 0
     LogEntry:
       type: object
       description: JSON representation of an audit log entry.


### PR DESCRIPTION
## Summary

- Add `startup_time` (Instant) and `active_connections` (AtomicI64) fields to `AppState` for runtime health tracking
- Extend `GET /api/v1/health` response with `uptime_secs`, `active_connections`, and `pipeline_lag_ms` fields
- Update CLI `aasm status` to display uptime (human-readable), connection count, and pipeline lag in the RUNTIME HEALTH section
- Regenerate OpenAPI spec and dashboard TypeScript types
- Add integration tests (API) and unit tests (CLI: format_duration, serde defaults, field propagation)

## Test plan

- [x] `cargo test --workspace` — all tests pass (0 failures)
- [x] `cargo fmt --all -- --check` — clean
- [x] OpenAPI spec regenerated and matches code
- [x] Dashboard TypeScript types regenerated

Closes AAASM-180

🤖 Generated with [Claude Code](https://claude.com/claude-code)