### PR TITLE
[AAASM-93] ✨ cli(dashboard): Add interactive Ratatui TUI dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,7 @@ dependencies = [
  "dirs",
  "futures-util",
  "owo-colors",
+ "ratatui",
  "reqwest",
  "serde",
  "serde_json",
@@ -180,7 +181,7 @@ dependencies = [
  "dirs",
  "hyper",
  "hyper-util",
- "lru",
+ "lru 0.16.4",
  "rcgen",
  "rustls",
  "rustls-native-certs",
@@ -822,10 +823,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -996,7 +1012,21 @@ checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
 dependencies = [
  "crossterm 0.29.0",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1036,7 +1066,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -1268,6 +1298,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
  "quote",
  "syn 2.0.117",
 ]
@@ -2042,6 +2106,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2104,6 +2174,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2141,6 +2224,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -2295,6 +2387,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru"
@@ -2716,6 +2817,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
@@ -3253,6 +3360,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.11.1",
+ "cassowary",
+ "compact_str",
+ "crossterm 0.28.1",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru 0.12.5",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3555,7 +3683,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3948,10 +4076,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "subtle"
@@ -4559,10 +4715,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
+name = "unicode-truncate"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -23,6 +23,7 @@ crossterm      = "0.28"
 dirs           = "6"
 futures-util   = "0.3"
 owo-colors     = "4"
+ratatui        = { version = "0.29", features = ["crossterm"] }
 reqwest        = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "blocking"] }
 serde          = { version = "1", features = ["derive"] }
 serde_json     = "1"

--- a/aa-cli/src/commands/dashboard/dialog.rs
+++ b/aa-cli/src/commands/dashboard/dialog.rs
@@ -1,0 +1,108 @@
+//! Confirmation dialog overlay for approve/reject actions.
+
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Line;
+use ratatui::widgets::{Block, Borders, Clear, Paragraph};
+use ratatui::Frame;
+
+use crate::commands::status::models::ApprovalResponse;
+
+/// Which action the dialog is confirming.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DialogAction {
+    Approve,
+    Reject,
+}
+
+/// Render a centered confirmation dialog over the dashboard.
+pub fn draw_confirm_dialog(
+    f: &mut Frame,
+    approval: &ApprovalResponse,
+    action: DialogAction,
+) {
+    let area = centered_rect(50, 30, f.area());
+
+    // Clear the area behind the dialog.
+    f.render_widget(Clear, area);
+
+    let (title, color) = match action {
+        DialogAction::Approve => ("Approve?", Color::Green),
+        DialogAction::Reject => ("Reject?", Color::Red),
+    };
+
+    let block = Block::default()
+        .title(format!(" {title} "))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(color));
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(3), Constraint::Length(2)])
+        .split(inner);
+
+    // Summary of what is being approved/rejected.
+    let summary = Paragraph::new(vec![
+        Line::from(format!("ID:     {}", approval.id)),
+        Line::from(format!("Agent:  {}", approval.agent_id)),
+        Line::from(format!("Action: {}", approval.action)),
+        Line::from(format!("Reason: {}", approval.reason)),
+    ]);
+    f.render_widget(summary, chunks[0]);
+
+    // Instruction line.
+    let instruction = Paragraph::new(Line::from(vec![
+        ratatui::text::Span::styled("y", Style::default().add_modifier(Modifier::BOLD)),
+        ratatui::text::Span::raw(" confirm  "),
+        ratatui::text::Span::styled("n", Style::default().add_modifier(Modifier::BOLD)),
+        ratatui::text::Span::raw("/"),
+        ratatui::text::Span::styled("Esc", Style::default().add_modifier(Modifier::BOLD)),
+        ratatui::text::Span::raw(" cancel"),
+    ]))
+    .style(Style::default().fg(Color::DarkGray));
+    f.render_widget(instruction, chunks[1]);
+}
+
+/// Compute a centered rectangle within `area`.
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+
+    let horizontal = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1]);
+
+    horizontal[1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn centered_rect_produces_inner_rect() {
+        let area = Rect::new(0, 0, 100, 50);
+        let center = centered_rect(50, 40, area);
+        // Should be roughly centered.
+        assert!(center.x > 0);
+        assert!(center.y > 0);
+        assert!(center.width > 0);
+        assert!(center.height > 0);
+        assert!(center.x + center.width <= area.width);
+        assert!(center.y + center.height <= area.height);
+    }
+}

--- a/aa-cli/src/commands/dashboard/dialog.rs
+++ b/aa-cli/src/commands/dashboard/dialog.rs
@@ -16,11 +16,7 @@ pub enum DialogAction {
 }
 
 /// Render a centered confirmation dialog over the dashboard.
-pub fn draw_confirm_dialog(
-    f: &mut Frame,
-    approval: &ApprovalResponse,
-    action: DialogAction,
-) {
+pub fn draw_confirm_dialog(f: &mut Frame, approval: &ApprovalResponse, action: DialogAction) {
     let area = centered_rect(50, 30, f.area());
 
     // Clear the area behind the dialog.

--- a/aa-cli/src/commands/dashboard/feed.rs
+++ b/aa-cli/src/commands/dashboard/feed.rs
@@ -9,9 +9,7 @@ use tokio_tungstenite::tungstenite::Message;
 
 use crate::commands::status::client::StatusClient;
 use crate::commands::status::fetch;
-use crate::commands::status::models::{
-    AgentRow, ApprovalResponse, ApprovalsSummary, BudgetRow, RuntimeHealth,
-};
+use crate::commands::status::models::{AgentRow, ApprovalResponse, ApprovalsSummary, BudgetRow, RuntimeHealth};
 
 use super::state::EventEntry;
 

--- a/aa-cli/src/commands/dashboard/feed.rs
+++ b/aa-cli/src/commands/dashboard/feed.rs
@@ -1,0 +1,196 @@
+//! Data feed — REST polling and WebSocket event streaming for the dashboard.
+
+use std::sync::Arc;
+
+use futures_util::StreamExt;
+use serde::Deserialize;
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::Message;
+
+use crate::commands::status::client::StatusClient;
+use crate::commands::status::fetch;
+use crate::commands::status::models::{
+    AgentRow, ApprovalResponse, ApprovalsSummary, BudgetRow, RuntimeHealth,
+};
+
+use super::state::EventEntry;
+
+/// Messages sent from background data tasks to the main event loop.
+#[derive(Debug)]
+pub enum FeedMessage {
+    /// A full status snapshot from REST polling.
+    StatusUpdate {
+        runtime: RuntimeHealth,
+        agents: Vec<AgentRow>,
+        approvals_summary: ApprovalsSummary,
+        pending_approvals: Vec<ApprovalResponse>,
+        budget: BudgetRow,
+    },
+    /// A single governance event from the WebSocket stream.
+    Event(EventEntry),
+    /// The WebSocket connection was closed or failed.
+    WsDisconnected,
+}
+
+/// A governance event as received from the WebSocket stream.
+#[derive(Debug, Deserialize)]
+struct WsEvent {
+    #[allow(dead_code)]
+    id: u64,
+    event_type: String,
+    agent_id: String,
+    payload: serde_json::Value,
+    timestamp: String,
+}
+
+/// Interval between REST status polls.
+const POLL_INTERVAL_SECS: u64 = 5;
+
+/// Spawn the REST polling task that periodically fetches all status data.
+///
+/// Sends `FeedMessage::StatusUpdate` on every successful poll cycle.
+pub fn spawn_rest_poller(api_url: &str, tx: mpsc::UnboundedSender<FeedMessage>) {
+    let client = StatusClient::new(api_url);
+
+    tokio::spawn(async move {
+        loop {
+            let snapshot = fetch::fetch_all(&client).await;
+
+            // Fetch the raw approvals list so we have individual pending items.
+            let pending_approvals = client
+                .list_approvals()
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|a| a.status == "pending")
+                .collect();
+
+            let msg = FeedMessage::StatusUpdate {
+                runtime: snapshot.runtime,
+                agents: snapshot.agents,
+                approvals_summary: snapshot.approvals,
+                pending_approvals,
+                budget: snapshot.budget,
+            };
+
+            if tx.send(msg).is_err() {
+                break; // receiver dropped — main loop exited
+            }
+
+            tokio::time::sleep(tokio::time::Duration::from_secs(POLL_INTERVAL_SECS)).await;
+        }
+    });
+}
+
+/// Spawn the WebSocket event streaming task.
+///
+/// Connects to the gateway's `/api/v1/ws/events` endpoint and forwards
+/// each governance event as `FeedMessage::Event`. Sends
+/// `FeedMessage::WsDisconnected` if the connection drops.
+pub fn spawn_ws_listener(api_url: &str, tx: mpsc::UnboundedSender<FeedMessage>) {
+    let ws_url = build_ws_url(api_url);
+    let tx = Arc::new(tx);
+
+    tokio::spawn(async move {
+        let (ws_stream, _) = match tokio_tungstenite::connect_async(&ws_url).await {
+            Ok(conn) => conn,
+            Err(_) => {
+                let _ = tx.send(FeedMessage::WsDisconnected);
+                return;
+            }
+        };
+
+        let (_write, mut read) = ws_stream.split();
+
+        while let Some(msg) = read.next().await {
+            match msg {
+                Ok(Message::Text(text)) => {
+                    let event: WsEvent = match serde_json::from_str(&text) {
+                        Ok(e) => e,
+                        Err(_) => continue,
+                    };
+                    let entry = ws_event_to_entry(&event);
+                    if tx.send(FeedMessage::Event(entry)).is_err() {
+                        break;
+                    }
+                }
+                Ok(Message::Close(_)) => break,
+                Ok(_) => {} // ping/pong/binary
+                Err(_) => break,
+            }
+        }
+
+        let _ = tx.send(FeedMessage::WsDisconnected);
+    });
+}
+
+/// Convert the HTTP API URL to a WebSocket URL for the events endpoint.
+fn build_ws_url(api_url: &str) -> String {
+    let base = api_url
+        .replacen("https://", "wss://", 1)
+        .replacen("http://", "ws://", 1);
+    format!("{base}/api/v1/ws/events")
+}
+
+/// Convert a deserialized WsEvent into an EventEntry for the dashboard state.
+fn ws_event_to_entry(event: &WsEvent) -> EventEntry {
+    let message = match &event.payload {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    };
+    EventEntry {
+        timestamp: event.timestamp.clone(),
+        event_type: event.event_type.clone(),
+        agent_id: event.agent_id.clone(),
+        message,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_ws_url_http() {
+        assert_eq!(
+            build_ws_url("http://localhost:8080"),
+            "ws://localhost:8080/api/v1/ws/events"
+        );
+    }
+
+    #[test]
+    fn build_ws_url_https() {
+        assert_eq!(
+            build_ws_url("https://api.example.com"),
+            "wss://api.example.com/api/v1/ws/events"
+        );
+    }
+
+    #[test]
+    fn ws_event_string_payload() {
+        let event = WsEvent {
+            id: 1,
+            event_type: "violation".to_string(),
+            agent_id: "a1".to_string(),
+            payload: serde_json::Value::String("denied".to_string()),
+            timestamp: "2026-04-30T10:00:00Z".to_string(),
+        };
+        let entry = ws_event_to_entry(&event);
+        assert_eq!(entry.message, "denied");
+        assert_eq!(entry.event_type, "violation");
+    }
+
+    #[test]
+    fn ws_event_object_payload() {
+        let event = WsEvent {
+            id: 2,
+            event_type: "budget".to_string(),
+            agent_id: "a2".to_string(),
+            payload: serde_json::json!({"action": "alert", "amount": 100}),
+            timestamp: "2026-04-30T11:00:00Z".to_string(),
+        };
+        let entry = ws_event_to_entry(&event);
+        assert!(entry.message.contains("alert"));
+        assert!(entry.message.contains("100"));
+    }
+}

--- a/aa-cli/src/commands/dashboard/input.rs
+++ b/aa-cli/src/commands/dashboard/input.rs
@@ -1,0 +1,261 @@
+//! Keyboard input handling for the TUI dashboard.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use super::state::{DashboardState, Panel};
+
+/// The action the caller should take after handling a key event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InputAction {
+    /// Nothing special — just redraw.
+    None,
+    /// The user wants to approve the selected approval.
+    Approve,
+    /// The user wants to reject the selected approval.
+    Reject,
+}
+
+/// Process a single key event against the current dashboard state.
+///
+/// Returns an `InputAction` indicating whether any follow-up is needed.
+pub fn handle_key(state: &mut DashboardState, key: KeyEvent) -> InputAction {
+    // Global shortcuts — work regardless of panel focus.
+    match key.code {
+        KeyCode::Char('q') | KeyCode::Esc => {
+            state.should_quit = true;
+            return InputAction::None;
+        }
+        KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            state.should_quit = true;
+            return InputAction::None;
+        }
+        KeyCode::Char('?') => {
+            state.show_help = !state.show_help;
+            return InputAction::None;
+        }
+        KeyCode::Tab => {
+            if key.modifiers.contains(KeyModifiers::SHIFT) {
+                state.active_panel = state.active_panel.prev();
+            } else {
+                state.active_panel = state.active_panel.next();
+            }
+            return InputAction::None;
+        }
+        KeyCode::BackTab => {
+            state.active_panel = state.active_panel.prev();
+            return InputAction::None;
+        }
+        _ => {}
+    }
+
+    // Panel-specific shortcuts.
+    match state.active_panel {
+        Panel::EventLog => handle_event_log_key(state, key),
+        Panel::Approvals => handle_approvals_key(state, key),
+        _ => InputAction::None,
+    }
+}
+
+/// Handle keys when the event log panel is focused.
+fn handle_event_log_key(state: &mut DashboardState, key: KeyEvent) -> InputAction {
+    match key.code {
+        KeyCode::Up | KeyCode::Char('k') => {
+            state.event_log_scroll = state.event_log_scroll.saturating_add(1);
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            state.event_log_scroll = state.event_log_scroll.saturating_sub(1);
+        }
+        _ => {}
+    }
+    InputAction::None
+}
+
+/// Handle keys when the approvals panel is focused.
+fn handle_approvals_key(state: &mut DashboardState, key: KeyEvent) -> InputAction {
+    match key.code {
+        KeyCode::Up | KeyCode::Char('k') => {
+            state.approval_selected = state.approval_selected.saturating_sub(1);
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            if !state.pending_approvals.is_empty() {
+                state.approval_selected = (state.approval_selected + 1)
+                    .min(state.pending_approvals.len() - 1);
+            }
+        }
+        KeyCode::Char('a') => {
+            if !state.pending_approvals.is_empty() {
+                return InputAction::Approve;
+            }
+        }
+        KeyCode::Char('r') => {
+            if !state.pending_approvals.is_empty() {
+                return InputAction::Reject;
+            }
+        }
+        _ => {}
+    }
+    InputAction::None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    fn make_key_with_mod(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(code, modifiers)
+    }
+
+    #[test]
+    fn quit_on_q() {
+        let mut state = DashboardState::new();
+        handle_key(&mut state, make_key(KeyCode::Char('q')));
+        assert!(state.should_quit);
+    }
+
+    #[test]
+    fn quit_on_esc() {
+        let mut state = DashboardState::new();
+        handle_key(&mut state, make_key(KeyCode::Esc));
+        assert!(state.should_quit);
+    }
+
+    #[test]
+    fn quit_on_ctrl_c() {
+        let mut state = DashboardState::new();
+        handle_key(
+            &mut state,
+            make_key_with_mod(KeyCode::Char('c'), KeyModifiers::CONTROL),
+        );
+        assert!(state.should_quit);
+    }
+
+    #[test]
+    fn toggle_help() {
+        let mut state = DashboardState::new();
+        assert!(!state.show_help);
+        handle_key(&mut state, make_key(KeyCode::Char('?')));
+        assert!(state.show_help);
+        handle_key(&mut state, make_key(KeyCode::Char('?')));
+        assert!(!state.show_help);
+    }
+
+    #[test]
+    fn tab_cycles_panels() {
+        let mut state = DashboardState::new();
+        assert_eq!(state.active_panel, Panel::Agents);
+        handle_key(&mut state, make_key(KeyCode::Tab));
+        assert_eq!(state.active_panel, Panel::EventLog);
+        handle_key(&mut state, make_key(KeyCode::Tab));
+        assert_eq!(state.active_panel, Panel::Approvals);
+    }
+
+    #[test]
+    fn backtab_cycles_backwards() {
+        let mut state = DashboardState::new();
+        handle_key(&mut state, make_key(KeyCode::BackTab));
+        assert_eq!(state.active_panel, Panel::Budget);
+    }
+
+    #[test]
+    fn shift_tab_cycles_backwards() {
+        let mut state = DashboardState::new();
+        handle_key(
+            &mut state,
+            make_key_with_mod(KeyCode::Tab, KeyModifiers::SHIFT),
+        );
+        assert_eq!(state.active_panel, Panel::Budget);
+    }
+
+    #[test]
+    fn event_log_scroll_up_down() {
+        let mut state = DashboardState::new();
+        state.active_panel = Panel::EventLog;
+        handle_key(&mut state, make_key(KeyCode::Up));
+        assert_eq!(state.event_log_scroll, 1);
+        handle_key(&mut state, make_key(KeyCode::Down));
+        assert_eq!(state.event_log_scroll, 0);
+        // Cannot go below 0.
+        handle_key(&mut state, make_key(KeyCode::Down));
+        assert_eq!(state.event_log_scroll, 0);
+    }
+
+    #[test]
+    fn approval_selection_navigation() {
+        let mut state = DashboardState::new();
+        state.active_panel = Panel::Approvals;
+        state.pending_approvals = vec![
+            crate::commands::status::models::ApprovalResponse {
+                id: "1".to_string(),
+                agent_id: "a1".to_string(),
+                action: "act".to_string(),
+                reason: "r".to_string(),
+                status: "pending".to_string(),
+                created_at: "2026-04-30T10:00:00Z".to_string(),
+            },
+            crate::commands::status::models::ApprovalResponse {
+                id: "2".to_string(),
+                agent_id: "a2".to_string(),
+                action: "act2".to_string(),
+                reason: "r2".to_string(),
+                status: "pending".to_string(),
+                created_at: "2026-04-30T11:00:00Z".to_string(),
+            },
+        ];
+        assert_eq!(state.approval_selected, 0);
+        handle_key(&mut state, make_key(KeyCode::Down));
+        assert_eq!(state.approval_selected, 1);
+        // Cannot go beyond list length.
+        handle_key(&mut state, make_key(KeyCode::Down));
+        assert_eq!(state.approval_selected, 1);
+        handle_key(&mut state, make_key(KeyCode::Up));
+        assert_eq!(state.approval_selected, 0);
+    }
+
+    #[test]
+    fn approve_action_returned() {
+        let mut state = DashboardState::new();
+        state.active_panel = Panel::Approvals;
+        state.pending_approvals = vec![
+            crate::commands::status::models::ApprovalResponse {
+                id: "1".to_string(),
+                agent_id: "a1".to_string(),
+                action: "act".to_string(),
+                reason: "r".to_string(),
+                status: "pending".to_string(),
+                created_at: "2026-04-30T10:00:00Z".to_string(),
+            },
+        ];
+        let action = handle_key(&mut state, make_key(KeyCode::Char('a')));
+        assert_eq!(action, InputAction::Approve);
+    }
+
+    #[test]
+    fn reject_action_returned() {
+        let mut state = DashboardState::new();
+        state.active_panel = Panel::Approvals;
+        state.pending_approvals = vec![
+            crate::commands::status::models::ApprovalResponse {
+                id: "1".to_string(),
+                agent_id: "a1".to_string(),
+                action: "act".to_string(),
+                reason: "r".to_string(),
+                status: "pending".to_string(),
+                created_at: "2026-04-30T10:00:00Z".to_string(),
+            },
+        ];
+        let action = handle_key(&mut state, make_key(KeyCode::Char('r')));
+        assert_eq!(action, InputAction::Reject);
+    }
+
+    #[test]
+    fn approve_noop_when_no_approvals() {
+        let mut state = DashboardState::new();
+        state.active_panel = Panel::Approvals;
+        let action = handle_key(&mut state, make_key(KeyCode::Char('a')));
+        assert_eq!(action, InputAction::None);
+    }
+}

--- a/aa-cli/src/commands/dashboard/input.rs
+++ b/aa-cli/src/commands/dashboard/input.rs
@@ -77,8 +77,7 @@ fn handle_approvals_key(state: &mut DashboardState, key: KeyEvent) -> InputActio
             state.approval_selected = state.approval_selected.saturating_sub(1);
         }
         KeyCode::Down | KeyCode::Char('j') if !state.pending_approvals.is_empty() => {
-            state.approval_selected = (state.approval_selected + 1)
-                .min(state.pending_approvals.len() - 1);
+            state.approval_selected = (state.approval_selected + 1).min(state.pending_approvals.len() - 1);
         }
         KeyCode::Char('a') if !state.pending_approvals.is_empty() => {
             return InputAction::Approve;
@@ -120,10 +119,7 @@ mod tests {
     #[test]
     fn quit_on_ctrl_c() {
         let mut state = DashboardState::new();
-        handle_key(
-            &mut state,
-            make_key_with_mod(KeyCode::Char('c'), KeyModifiers::CONTROL),
-        );
+        handle_key(&mut state, make_key_with_mod(KeyCode::Char('c'), KeyModifiers::CONTROL));
         assert!(state.should_quit);
     }
 
@@ -157,10 +153,7 @@ mod tests {
     #[test]
     fn shift_tab_cycles_backwards() {
         let mut state = DashboardState::new();
-        handle_key(
-            &mut state,
-            make_key_with_mod(KeyCode::Tab, KeyModifiers::SHIFT),
-        );
+        handle_key(&mut state, make_key_with_mod(KeyCode::Tab, KeyModifiers::SHIFT));
         assert_eq!(state.active_panel, Panel::Budget);
     }
 
@@ -213,16 +206,14 @@ mod tests {
     fn approve_action_returned() {
         let mut state = DashboardState::new();
         state.active_panel = Panel::Approvals;
-        state.pending_approvals = vec![
-            crate::commands::status::models::ApprovalResponse {
-                id: "1".to_string(),
-                agent_id: "a1".to_string(),
-                action: "act".to_string(),
-                reason: "r".to_string(),
-                status: "pending".to_string(),
-                created_at: "2026-04-30T10:00:00Z".to_string(),
-            },
-        ];
+        state.pending_approvals = vec![crate::commands::status::models::ApprovalResponse {
+            id: "1".to_string(),
+            agent_id: "a1".to_string(),
+            action: "act".to_string(),
+            reason: "r".to_string(),
+            status: "pending".to_string(),
+            created_at: "2026-04-30T10:00:00Z".to_string(),
+        }];
         let action = handle_key(&mut state, make_key(KeyCode::Char('a')));
         assert_eq!(action, InputAction::Approve);
     }
@@ -231,16 +222,14 @@ mod tests {
     fn reject_action_returned() {
         let mut state = DashboardState::new();
         state.active_panel = Panel::Approvals;
-        state.pending_approvals = vec![
-            crate::commands::status::models::ApprovalResponse {
-                id: "1".to_string(),
-                agent_id: "a1".to_string(),
-                action: "act".to_string(),
-                reason: "r".to_string(),
-                status: "pending".to_string(),
-                created_at: "2026-04-30T10:00:00Z".to_string(),
-            },
-        ];
+        state.pending_approvals = vec![crate::commands::status::models::ApprovalResponse {
+            id: "1".to_string(),
+            agent_id: "a1".to_string(),
+            action: "act".to_string(),
+            reason: "r".to_string(),
+            status: "pending".to_string(),
+            created_at: "2026-04-30T10:00:00Z".to_string(),
+        }];
         let action = handle_key(&mut state, make_key(KeyCode::Char('r')));
         assert_eq!(action, InputAction::Reject);
     }

--- a/aa-cli/src/commands/dashboard/input.rs
+++ b/aa-cli/src/commands/dashboard/input.rs
@@ -13,6 +13,10 @@ pub enum InputAction {
     Approve,
     /// The user wants to reject the selected approval.
     Reject,
+    /// The user pressed Enter to inspect the selected item.
+    Inspect,
+    /// The user pressed `p` to open the policy viewer.
+    PolicyView,
 }
 
 /// Process a single key event against the current dashboard state.
@@ -33,6 +37,9 @@ pub fn handle_key(state: &mut DashboardState, key: KeyEvent) -> InputAction {
             state.show_help = !state.show_help;
             return InputAction::None;
         }
+        KeyCode::Char('p') => {
+            return InputAction::PolicyView;
+        }
         KeyCode::Tab => {
             if key.modifiers.contains(KeyModifiers::SHIFT) {
                 state.active_panel = state.active_panel.prev();
@@ -50,10 +57,28 @@ pub fn handle_key(state: &mut DashboardState, key: KeyEvent) -> InputAction {
 
     // Panel-specific shortcuts.
     match state.active_panel {
+        Panel::Agents => handle_agents_key(state, key),
         Panel::EventLog => handle_event_log_key(state, key),
         Panel::Approvals => handle_approvals_key(state, key),
-        _ => InputAction::None,
+        Panel::Budget => InputAction::None,
     }
+}
+
+/// Handle keys when the agents panel is focused.
+fn handle_agents_key(state: &mut DashboardState, key: KeyEvent) -> InputAction {
+    match key.code {
+        KeyCode::Up | KeyCode::Char('k') => {
+            state.agent_selected = state.agent_selected.saturating_sub(1);
+        }
+        KeyCode::Down | KeyCode::Char('j') if !state.agents.is_empty() => {
+            state.agent_selected = (state.agent_selected + 1).min(state.agents.len() - 1);
+        }
+        KeyCode::Enter if !state.agents.is_empty() => {
+            return InputAction::Inspect;
+        }
+        _ => {}
+    }
+    InputAction::None
 }
 
 /// Handle keys when the event log panel is focused.
@@ -84,6 +109,9 @@ fn handle_approvals_key(state: &mut DashboardState, key: KeyEvent) -> InputActio
         }
         KeyCode::Char('r') if !state.pending_approvals.is_empty() => {
             return InputAction::Reject;
+        }
+        KeyCode::Enter if !state.pending_approvals.is_empty() => {
+            return InputAction::Inspect;
         }
         _ => {}
     }
@@ -240,5 +268,78 @@ mod tests {
         state.active_panel = Panel::Approvals;
         let action = handle_key(&mut state, make_key(KeyCode::Char('a')));
         assert_eq!(action, InputAction::None);
+    }
+
+    #[test]
+    fn p_key_returns_policy_view() {
+        let mut state = DashboardState::new();
+        let action = handle_key(&mut state, make_key(KeyCode::Char('p')));
+        assert_eq!(action, InputAction::PolicyView);
+    }
+
+    #[test]
+    fn enter_on_agents_returns_inspect() {
+        let mut state = DashboardState::new();
+        state.active_panel = Panel::Agents;
+        state.agents = vec![crate::commands::status::models::AgentRow {
+            id: "a1".to_string(),
+            name: "agent".to_string(),
+            framework: "fw".to_string(),
+            status: "Running".to_string(),
+            sessions: 0,
+            violations_today: 0,
+            layer: "-".to_string(),
+        }];
+        let action = handle_key(&mut state, make_key(KeyCode::Enter));
+        assert_eq!(action, InputAction::Inspect);
+    }
+
+    #[test]
+    fn enter_on_approvals_returns_inspect() {
+        let mut state = DashboardState::new();
+        state.active_panel = Panel::Approvals;
+        state.pending_approvals = vec![crate::commands::status::models::ApprovalResponse {
+            id: "1".to_string(),
+            agent_id: "a1".to_string(),
+            action: "act".to_string(),
+            reason: "r".to_string(),
+            status: "pending".to_string(),
+            created_at: "2026-04-30T10:00:00Z".to_string(),
+        }];
+        let action = handle_key(&mut state, make_key(KeyCode::Enter));
+        assert_eq!(action, InputAction::Inspect);
+    }
+
+    #[test]
+    fn agent_selection_navigation() {
+        let mut state = DashboardState::new();
+        state.active_panel = Panel::Agents;
+        state.agents = vec![
+            crate::commands::status::models::AgentRow {
+                id: "a1".to_string(),
+                name: "agent1".to_string(),
+                framework: "fw".to_string(),
+                status: "Running".to_string(),
+                sessions: 0,
+                violations_today: 0,
+                layer: "-".to_string(),
+            },
+            crate::commands::status::models::AgentRow {
+                id: "a2".to_string(),
+                name: "agent2".to_string(),
+                framework: "fw".to_string(),
+                status: "Running".to_string(),
+                sessions: 0,
+                violations_today: 0,
+                layer: "-".to_string(),
+            },
+        ];
+        assert_eq!(state.agent_selected, 0);
+        handle_key(&mut state, make_key(KeyCode::Down));
+        assert_eq!(state.agent_selected, 1);
+        handle_key(&mut state, make_key(KeyCode::Down));
+        assert_eq!(state.agent_selected, 1); // clamped
+        handle_key(&mut state, make_key(KeyCode::Up));
+        assert_eq!(state.agent_selected, 0);
     }
 }

--- a/aa-cli/src/commands/dashboard/input.rs
+++ b/aa-cli/src/commands/dashboard/input.rs
@@ -76,21 +76,15 @@ fn handle_approvals_key(state: &mut DashboardState, key: KeyEvent) -> InputActio
         KeyCode::Up | KeyCode::Char('k') => {
             state.approval_selected = state.approval_selected.saturating_sub(1);
         }
-        KeyCode::Down | KeyCode::Char('j') => {
-            if !state.pending_approvals.is_empty() {
-                state.approval_selected = (state.approval_selected + 1)
-                    .min(state.pending_approvals.len() - 1);
-            }
+        KeyCode::Down | KeyCode::Char('j') if !state.pending_approvals.is_empty() => {
+            state.approval_selected = (state.approval_selected + 1)
+                .min(state.pending_approvals.len() - 1);
         }
-        KeyCode::Char('a') => {
-            if !state.pending_approvals.is_empty() {
-                return InputAction::Approve;
-            }
+        KeyCode::Char('a') if !state.pending_approvals.is_empty() => {
+            return InputAction::Approve;
         }
-        KeyCode::Char('r') => {
-            if !state.pending_approvals.is_empty() {
-                return InputAction::Reject;
-            }
+        KeyCode::Char('r') if !state.pending_approvals.is_empty() => {
+            return InputAction::Reject;
         }
         _ => {}
     }

--- a/aa-cli/src/commands/dashboard/mod.rs
+++ b/aa-cli/src/commands/dashboard/mod.rs
@@ -1,5 +1,6 @@
 //! `aasm dashboard` — interactive TUI dashboard for real-time governance monitoring.
 
+pub mod feed;
 pub mod input;
 pub mod state;
 pub mod ui;

--- a/aa-cli/src/commands/dashboard/mod.rs
+++ b/aa-cli/src/commands/dashboard/mod.rs
@@ -7,17 +7,23 @@ pub mod ui;
 
 use std::io::{self, stdout};
 use std::process::ExitCode;
+use std::time::Duration;
 
 use clap::Args;
-use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
+use crossterm::event::{self as ct_event, DisableMouseCapture, EnableMouseCapture, Event};
 use crossterm::execute;
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
+use tokio::sync::mpsc;
 
 use crate::config::ResolvedContext;
+
+use self::feed::FeedMessage;
+use self::input::InputAction;
+use self::state::DashboardState;
 
 /// Arguments for the `aasm dashboard` subcommand.
 #[derive(Debug, Args)]
@@ -30,7 +36,7 @@ pub fn dispatch(args: DashboardArgs, ctx: &ResolvedContext) -> ExitCode {
 }
 
 /// Set up the terminal, run the dashboard, and restore the terminal on exit.
-async fn run(_args: DashboardArgs, _ctx: &ResolvedContext) -> ExitCode {
+async fn run(_args: DashboardArgs, ctx: &ResolvedContext) -> ExitCode {
     // Install a panic hook that restores the terminal before printing the panic.
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
@@ -55,7 +61,71 @@ async fn run(_args: DashboardArgs, _ctx: &ResolvedContext) -> ExitCode {
 
     terminal.clear().ok();
 
-    // TODO: run the main event loop here (Task 7).
+    let mut state = DashboardState::new();
+
+    // Spawn background data tasks.
+    let (tx, mut rx) = mpsc::unbounded_channel::<FeedMessage>();
+    feed::spawn_rest_poller(&ctx.api_url, tx.clone());
+    feed::spawn_ws_listener(&ctx.api_url, tx);
+
+    // Main event loop: poll terminal events and feed messages.
+    loop {
+        // Draw the current state.
+        terminal
+            .draw(|f| ui::draw(f, &state))
+            .ok();
+
+        // Check for terminal input events (non-blocking, 50ms timeout).
+        if ct_event::poll(Duration::from_millis(50)).unwrap_or(false) {
+            if let Ok(Event::Key(key)) = ct_event::read() {
+                let action = input::handle_key(&mut state, key);
+                match action {
+                    InputAction::Approve | InputAction::Reject => {
+                        state.show_confirm_dialog = true;
+                        // TODO: wire approve/reject API calls (Task 8).
+                    }
+                    InputAction::None => {}
+                }
+            }
+        }
+
+        // Drain all pending feed messages.
+        while let Ok(msg) = rx.try_recv() {
+            match msg {
+                FeedMessage::StatusUpdate {
+                    runtime,
+                    agents,
+                    approvals_summary,
+                    pending_approvals,
+                    budget,
+                } => {
+                    state.runtime = runtime;
+                    state.agents = agents;
+                    state.approvals_summary = approvals_summary;
+                    state.pending_approvals = pending_approvals;
+                    state.budget = budget;
+                    // Clamp approval selection to valid range.
+                    if !state.pending_approvals.is_empty() {
+                        state.approval_selected = state
+                            .approval_selected
+                            .min(state.pending_approvals.len() - 1);
+                    } else {
+                        state.approval_selected = 0;
+                    }
+                }
+                FeedMessage::Event(entry) => {
+                    state.push_event(entry);
+                }
+                FeedMessage::WsDisconnected => {
+                    // WS dropped — REST poller keeps going, so just note it.
+                }
+            }
+        }
+
+        if state.should_quit {
+            break;
+        }
+    }
 
     let _ = restore_terminal();
     ExitCode::SUCCESS

--- a/aa-cli/src/commands/dashboard/mod.rs
+++ b/aa-cli/src/commands/dashboard/mod.rs
@@ -1,5 +1,6 @@
 //! `aasm dashboard` — interactive TUI dashboard for real-time governance monitoring.
 
+pub mod dialog;
 pub mod feed;
 pub mod input;
 pub mod state;
@@ -10,7 +11,7 @@ use std::process::ExitCode;
 use std::time::Duration;
 
 use clap::Args;
-use crossterm::event::{self as ct_event, DisableMouseCapture, EnableMouseCapture, Event};
+use crossterm::event::{self as ct_event, DisableMouseCapture, EnableMouseCapture, Event, KeyCode};
 use crossterm::execute;
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
@@ -19,8 +20,10 @@ use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 use tokio::sync::mpsc;
 
+use crate::commands::approvals::client as approvals_client;
 use crate::config::ResolvedContext;
 
+use self::dialog::DialogAction;
 use self::feed::FeedMessage;
 use self::input::InputAction;
 use self::state::DashboardState;
@@ -70,21 +73,65 @@ async fn run(_args: DashboardArgs, ctx: &ResolvedContext) -> ExitCode {
 
     // Main event loop: poll terminal events and feed messages.
     loop {
-        // Draw the current state.
+        // Draw the current state, with optional dialog overlay.
+        let confirm_dialog = state.confirm_dialog;
+        let dialog_approval = confirm_dialog.and_then(|_| {
+            state.pending_approvals.get(state.approval_selected).cloned()
+        });
         terminal
-            .draw(|f| ui::draw(f, &state))
+            .draw(|f| {
+                ui::draw(f, &state);
+                if let (Some(action), Some(ref approval)) = (confirm_dialog, &dialog_approval) {
+                    dialog::draw_confirm_dialog(f, approval, action);
+                }
+            })
             .ok();
 
         // Check for terminal input events (non-blocking, 50ms timeout).
         if ct_event::poll(Duration::from_millis(50)).unwrap_or(false) {
             if let Ok(Event::Key(key)) = ct_event::read() {
-                let action = input::handle_key(&mut state, key);
-                match action {
-                    InputAction::Approve | InputAction::Reject => {
-                        state.show_confirm_dialog = true;
-                        // TODO: wire approve/reject API calls (Task 8).
+                // If a confirm dialog is showing, intercept y/n/Esc.
+                if let Some(dialog_action) = state.confirm_dialog {
+                    match key.code {
+                        KeyCode::Char('y') => {
+                            if let Some(ref approval) = dialog_approval {
+                                match dialog_action {
+                                    DialogAction::Approve => {
+                                        let _ = approvals_client::approve_action(
+                                            ctx,
+                                            &approval.id,
+                                            Some("approved via dashboard"),
+                                        )
+                                        .await;
+                                    }
+                                    DialogAction::Reject => {
+                                        let _ = approvals_client::reject_action(
+                                            ctx,
+                                            &approval.id,
+                                            "rejected via dashboard",
+                                        )
+                                        .await;
+                                    }
+                                }
+                            }
+                            state.confirm_dialog = None;
+                        }
+                        KeyCode::Char('n') | KeyCode::Esc => {
+                            state.confirm_dialog = None;
+                        }
+                        _ => {}
                     }
-                    InputAction::None => {}
+                } else {
+                    let action = input::handle_key(&mut state, key);
+                    match action {
+                        InputAction::Approve => {
+                            state.confirm_dialog = Some(DialogAction::Approve);
+                        }
+                        InputAction::Reject => {
+                            state.confirm_dialog = Some(DialogAction::Reject);
+                        }
+                        InputAction::None => {}
+                    }
                 }
             }
         }

--- a/aa-cli/src/commands/dashboard/mod.rs
+++ b/aa-cli/src/commands/dashboard/mod.rs
@@ -1,6 +1,7 @@
 //! `aasm dashboard` — interactive TUI dashboard for real-time governance monitoring.
 
 pub mod state;
+pub mod ui;
 
 use std::io::{self, stdout};
 use std::process::ExitCode;

--- a/aa-cli/src/commands/dashboard/mod.rs
+++ b/aa-cli/src/commands/dashboard/mod.rs
@@ -1,5 +1,7 @@
 //! `aasm dashboard` — interactive TUI dashboard for real-time governance monitoring.
 
+pub mod state;
+
 use std::io::{self, stdout};
 use std::process::ExitCode;
 

--- a/aa-cli/src/commands/dashboard/mod.rs
+++ b/aa-cli/src/commands/dashboard/mod.rs
@@ -87,6 +87,19 @@ async fn run(_args: DashboardArgs, ctx: &ResolvedContext) -> ExitCode {
         // Check for terminal input events (non-blocking, 50ms timeout).
         if ct_event::poll(Duration::from_millis(50)).unwrap_or(false) {
             if let Ok(Event::Key(key)) = ct_event::read() {
+                // If an overlay is showing, Esc dismisses it.
+                if state.show_inspect {
+                    if matches!(key.code, KeyCode::Esc | KeyCode::Char('q')) {
+                        state.show_inspect = false;
+                    }
+                    continue;
+                }
+                if state.show_policy {
+                    if matches!(key.code, KeyCode::Esc | KeyCode::Char('q')) {
+                        state.show_policy = false;
+                    }
+                    continue;
+                }
                 // If a confirm dialog is showing, intercept y/n/Esc.
                 if let Some(dialog_action) = state.confirm_dialog {
                     match key.code {
@@ -127,6 +140,16 @@ async fn run(_args: DashboardArgs, ctx: &ResolvedContext) -> ExitCode {
                         InputAction::Reject => {
                             state.confirm_dialog = Some(DialogAction::Reject);
                         }
+                        InputAction::Inspect => {
+                            state.show_inspect = true;
+                        }
+                        InputAction::PolicyView => {
+                            // Fetch policy YAML in background if not cached.
+                            if state.policy_yaml.is_none() {
+                                state.policy_yaml = fetch_policy_yaml();
+                            }
+                            state.show_policy = true;
+                        }
                         InputAction::None => {}
                     }
                 }
@@ -148,7 +171,12 @@ async fn run(_args: DashboardArgs, ctx: &ResolvedContext) -> ExitCode {
                     state.approvals_summary = approvals_summary;
                     state.pending_approvals = pending_approvals;
                     state.budget = budget;
-                    // Clamp approval selection to valid range.
+                    // Clamp selections to valid range.
+                    if !state.agents.is_empty() {
+                        state.agent_selected = state.agent_selected.min(state.agents.len() - 1);
+                    } else {
+                        state.agent_selected = 0;
+                    }
                     if !state.pending_approvals.is_empty() {
                         state.approval_selected = state.approval_selected.min(state.pending_approvals.len() - 1);
                     } else {
@@ -171,6 +199,20 @@ async fn run(_args: DashboardArgs, ctx: &ResolvedContext) -> ExitCode {
 
     let _ = restore_terminal();
     ExitCode::SUCCESS
+}
+
+/// Attempt to load the active policy YAML from the local policy history store.
+fn fetch_policy_yaml() -> Option<String> {
+    use aa_gateway::policy::history::{FsHistoryStore, HistoryConfig, PolicyHistoryStore};
+
+    let config = HistoryConfig::default_config();
+    let store = FsHistoryStore::new(config);
+
+    let rt = tokio::runtime::Handle::current();
+    let versions = rt.block_on(store.list(1)).ok()?;
+    let latest = versions.first()?;
+    let snapshot = rt.block_on(store.get(&latest.sha256)).ok()?;
+    Some(snapshot.yaml_content)
 }
 
 /// Enter raw mode and alternate screen for the TUI.

--- a/aa-cli/src/commands/dashboard/mod.rs
+++ b/aa-cli/src/commands/dashboard/mod.rs
@@ -1,0 +1,71 @@
+//! `aasm dashboard` — interactive TUI dashboard for real-time governance monitoring.
+
+use std::io::{self, stdout};
+use std::process::ExitCode;
+
+use clap::Args;
+use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
+use crossterm::execute;
+use crossterm::terminal::{
+    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+};
+use ratatui::backend::CrosstermBackend;
+use ratatui::Terminal;
+
+use crate::config::ResolvedContext;
+
+/// Arguments for the `aasm dashboard` subcommand.
+#[derive(Debug, Args)]
+pub struct DashboardArgs {}
+
+/// Entry point for `aasm dashboard`.
+pub fn dispatch(args: DashboardArgs, ctx: &ResolvedContext) -> ExitCode {
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    rt.block_on(async { run(args, ctx).await })
+}
+
+/// Set up the terminal, run the dashboard, and restore the terminal on exit.
+async fn run(_args: DashboardArgs, _ctx: &ResolvedContext) -> ExitCode {
+    // Install a panic hook that restores the terminal before printing the panic.
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = restore_terminal();
+        original_hook(info);
+    }));
+
+    if let Err(e) = setup_terminal() {
+        eprintln!("error: failed to initialise terminal: {e}");
+        return ExitCode::FAILURE;
+    }
+
+    let backend = CrosstermBackend::new(stdout());
+    let mut terminal = match Terminal::new(backend) {
+        Ok(t) => t,
+        Err(e) => {
+            let _ = restore_terminal();
+            eprintln!("error: failed to create terminal: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    terminal.clear().ok();
+
+    // TODO: run the main event loop here (Task 7).
+
+    let _ = restore_terminal();
+    ExitCode::SUCCESS
+}
+
+/// Enter raw mode and alternate screen for the TUI.
+fn setup_terminal() -> io::Result<()> {
+    enable_raw_mode()?;
+    execute!(stdout(), EnterAlternateScreen, EnableMouseCapture)?;
+    Ok(())
+}
+
+/// Restore the terminal to its original state.
+fn restore_terminal() -> io::Result<()> {
+    disable_raw_mode()?;
+    execute!(stdout(), LeaveAlternateScreen, DisableMouseCapture)?;
+    Ok(())
+}

--- a/aa-cli/src/commands/dashboard/mod.rs
+++ b/aa-cli/src/commands/dashboard/mod.rs
@@ -13,9 +13,7 @@ use std::time::Duration;
 use clap::Args;
 use crossterm::event::{self as ct_event, DisableMouseCapture, EnableMouseCapture, Event, KeyCode};
 use crossterm::execute;
-use crossterm::terminal::{
-    EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
-};
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen};
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 use tokio::sync::mpsc;
@@ -75,9 +73,8 @@ async fn run(_args: DashboardArgs, ctx: &ResolvedContext) -> ExitCode {
     loop {
         // Draw the current state, with optional dialog overlay.
         let confirm_dialog = state.confirm_dialog;
-        let dialog_approval = confirm_dialog.and_then(|_| {
-            state.pending_approvals.get(state.approval_selected).cloned()
-        });
+        let dialog_approval =
+            confirm_dialog.and_then(|_| state.pending_approvals.get(state.approval_selected).cloned());
         terminal
             .draw(|f| {
                 ui::draw(f, &state);
@@ -153,9 +150,7 @@ async fn run(_args: DashboardArgs, ctx: &ResolvedContext) -> ExitCode {
                     state.budget = budget;
                     // Clamp approval selection to valid range.
                     if !state.pending_approvals.is_empty() {
-                        state.approval_selected = state
-                            .approval_selected
-                            .min(state.pending_approvals.len() - 1);
+                        state.approval_selected = state.approval_selected.min(state.pending_approvals.len() - 1);
                     } else {
                         state.approval_selected = 0;
                     }

--- a/aa-cli/src/commands/dashboard/mod.rs
+++ b/aa-cli/src/commands/dashboard/mod.rs
@@ -1,5 +1,6 @@
 //! `aasm dashboard` — interactive TUI dashboard for real-time governance monitoring.
 
+pub mod input;
 pub mod state;
 pub mod ui;
 

--- a/aa-cli/src/commands/dashboard/state.rs
+++ b/aa-cli/src/commands/dashboard/state.rs
@@ -6,6 +6,8 @@ use crate::commands::status::models::{
     AgentRow, ApprovalResponse, ApprovalsSummary, BudgetRow, RuntimeHealth,
 };
 
+use super::dialog::DialogAction;
+
 /// Maximum number of events retained in the scrollback buffer.
 pub const EVENT_LOG_CAPACITY: usize = 200;
 
@@ -80,8 +82,8 @@ pub struct DashboardState {
 
     /// Whether the help overlay is currently visible.
     pub show_help: bool,
-    /// Whether the approve/reject confirmation dialog is visible.
-    pub show_confirm_dialog: bool,
+    /// The pending confirm dialog action, if any.
+    pub confirm_dialog: Option<DialogAction>,
 
     /// Whether the dashboard should quit on the next tick.
     pub should_quit: bool,
@@ -117,7 +119,7 @@ impl DashboardState {
             event_log_scroll: 0,
             approval_selected: 0,
             show_help: false,
-            show_confirm_dialog: false,
+            confirm_dialog: None,
             should_quit: false,
         }
     }
@@ -170,7 +172,7 @@ mod tests {
         assert_eq!(state.approvals_summary.pending_count, 0);
         assert!(state.pending_approvals.is_empty());
         assert!(!state.show_help);
-        assert!(!state.show_confirm_dialog);
+        assert!(state.confirm_dialog.is_none());
         assert!(!state.should_quit);
     }
 

--- a/aa-cli/src/commands/dashboard/state.rs
+++ b/aa-cli/src/commands/dashboard/state.rs
@@ -2,9 +2,7 @@
 
 use std::collections::VecDeque;
 
-use crate::commands::status::models::{
-    AgentRow, ApprovalResponse, ApprovalsSummary, BudgetRow, RuntimeHealth,
-};
+use crate::commands::status::models::{AgentRow, ApprovalResponse, ApprovalsSummary, BudgetRow, RuntimeHealth};
 
 use super::dialog::DialogAction;
 

--- a/aa-cli/src/commands/dashboard/state.rs
+++ b/aa-cli/src/commands/dashboard/state.rs
@@ -89,6 +89,12 @@ pub struct DashboardState {
     pub should_quit: bool,
 }
 
+impl Default for DashboardState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl DashboardState {
     /// Create an initial empty state with defaults.
     pub fn new() -> Self {

--- a/aa-cli/src/commands/dashboard/state.rs
+++ b/aa-cli/src/commands/dashboard/state.rs
@@ -16,14 +16,14 @@ pub enum Panel {
     Agents,
     /// Real-time event log (top-right).
     EventLog,
-    /// Pending approvals list (bottom-left).
-    Approvals,
-    /// Budget / cost gauge (bottom-right).
+    /// Budget / cost utilization bars (bottom-left).
     Budget,
+    /// Pending approvals queue with countdown timers (bottom-right).
+    Approvals,
 }
 
 impl Panel {
-    /// Cycle to the next panel in Tab order.
+    /// Cycle to the next panel in Tab order (clockwise).
     pub fn next(self) -> Self {
         match self {
             Self::Agents => Self::EventLog,
@@ -33,7 +33,7 @@ impl Panel {
         }
     }
 
-    /// Cycle to the previous panel in Shift+Tab order.
+    /// Cycle to the previous panel in Shift+Tab order (counter-clockwise).
     pub fn prev(self) -> Self {
         match self {
             Self::Agents => Self::Budget,
@@ -75,11 +75,19 @@ pub struct DashboardState {
 
     /// Scroll offset in the event log panel.
     pub event_log_scroll: u16,
+    /// Selected index in the agents table.
+    pub agent_selected: usize,
     /// Selected index in the pending approvals list.
     pub approval_selected: usize,
 
     /// Whether the help overlay is currently visible.
     pub show_help: bool,
+    /// Whether the inspect detail overlay is visible.
+    pub show_inspect: bool,
+    /// Whether the policy viewer overlay is visible.
+    pub show_policy: bool,
+    /// Cached policy YAML content for the policy overlay.
+    pub policy_yaml: Option<String>,
     /// The pending confirm dialog action, if any.
     pub confirm_dialog: Option<DialogAction>,
 
@@ -121,8 +129,12 @@ impl DashboardState {
             },
             event_log: VecDeque::with_capacity(EVENT_LOG_CAPACITY),
             event_log_scroll: 0,
+            agent_selected: 0,
             approval_selected: 0,
             show_help: false,
+            show_inspect: false,
+            show_policy: false,
+            policy_yaml: None,
             confirm_dialog: None,
             should_quit: false,
         }
@@ -176,6 +188,9 @@ mod tests {
         assert_eq!(state.approvals_summary.pending_count, 0);
         assert!(state.pending_approvals.is_empty());
         assert!(!state.show_help);
+        assert!(!state.show_inspect);
+        assert!(!state.show_policy);
+        assert!(state.policy_yaml.is_none());
         assert!(state.confirm_dialog.is_none());
         assert!(!state.should_quit);
     }

--- a/aa-cli/src/commands/dashboard/state.rs
+++ b/aa-cli/src/commands/dashboard/state.rs
@@ -1,0 +1,212 @@
+//! Dashboard application state and panel definitions.
+
+use std::collections::VecDeque;
+
+use crate::commands::status::models::{
+    AgentRow, ApprovalResponse, ApprovalsSummary, BudgetRow, RuntimeHealth,
+};
+
+/// Maximum number of events retained in the scrollback buffer.
+pub const EVENT_LOG_CAPACITY: usize = 200;
+
+/// Which panel is currently focused / highlighted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Panel {
+    /// Fleet health + agents table (top-left).
+    Agents,
+    /// Real-time event log (top-right).
+    EventLog,
+    /// Pending approvals list (bottom-left).
+    Approvals,
+    /// Budget / cost gauge (bottom-right).
+    Budget,
+}
+
+impl Panel {
+    /// Cycle to the next panel in Tab order.
+    pub fn next(self) -> Self {
+        match self {
+            Self::Agents => Self::EventLog,
+            Self::EventLog => Self::Approvals,
+            Self::Approvals => Self::Budget,
+            Self::Budget => Self::Agents,
+        }
+    }
+
+    /// Cycle to the previous panel in Shift+Tab order.
+    pub fn prev(self) -> Self {
+        match self {
+            Self::Agents => Self::Budget,
+            Self::EventLog => Self::Agents,
+            Self::Approvals => Self::EventLog,
+            Self::Budget => Self::Approvals,
+        }
+    }
+}
+
+/// A single event line received from the WebSocket stream.
+#[derive(Debug, Clone)]
+pub struct EventEntry {
+    pub timestamp: String,
+    pub event_type: String,
+    pub agent_id: String,
+    pub message: String,
+}
+
+/// Full application state for the TUI dashboard.
+#[derive(Debug)]
+pub struct DashboardState {
+    /// Which panel currently has focus.
+    pub active_panel: Panel,
+
+    /// Runtime health summary.
+    pub runtime: RuntimeHealth,
+    /// Agent rows for the agents table.
+    pub agents: Vec<AgentRow>,
+    /// Aggregated approvals summary (count + oldest age).
+    pub approvals_summary: ApprovalsSummary,
+    /// Individual pending approval requests (for the approvals list).
+    pub pending_approvals: Vec<ApprovalResponse>,
+    /// Budget / cost summary.
+    pub budget: BudgetRow,
+
+    /// Ring buffer of recent governance events from the WebSocket.
+    pub event_log: VecDeque<EventEntry>,
+
+    /// Scroll offset in the event log panel.
+    pub event_log_scroll: u16,
+    /// Selected index in the pending approvals list.
+    pub approval_selected: usize,
+
+    /// Whether the help overlay is currently visible.
+    pub show_help: bool,
+    /// Whether the approve/reject confirmation dialog is visible.
+    pub show_confirm_dialog: bool,
+
+    /// Whether the dashboard should quit on the next tick.
+    pub should_quit: bool,
+}
+
+impl DashboardState {
+    /// Create an initial empty state with defaults.
+    pub fn new() -> Self {
+        Self {
+            active_panel: Panel::Agents,
+            runtime: RuntimeHealth {
+                reachable: false,
+                status: "connecting…".to_string(),
+                uptime_secs: 0,
+                active_connections: 0,
+                pipeline_lag_ms: 0,
+            },
+            agents: Vec::new(),
+            approvals_summary: ApprovalsSummary {
+                pending_count: 0,
+                oldest_pending_age: None,
+            },
+            pending_approvals: Vec::new(),
+            budget: BudgetRow {
+                daily_spend_usd: "0.00".to_string(),
+                monthly_spend_usd: None,
+                daily_limit_usd: None,
+                monthly_limit_usd: None,
+                date: String::new(),
+                per_agent: vec![],
+            },
+            event_log: VecDeque::with_capacity(EVENT_LOG_CAPACITY),
+            event_log_scroll: 0,
+            approval_selected: 0,
+            show_help: false,
+            show_confirm_dialog: false,
+            should_quit: false,
+        }
+    }
+
+    /// Append an event to the log ring buffer, evicting the oldest if full.
+    pub fn push_event(&mut self, entry: EventEntry) {
+        if self.event_log.len() >= EVENT_LOG_CAPACITY {
+            self.event_log.pop_front();
+        }
+        self.event_log.push_back(entry);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn panel_next_cycles_through_all() {
+        let start = Panel::Agents;
+        let second = start.next();
+        assert_eq!(second, Panel::EventLog);
+        let third = second.next();
+        assert_eq!(third, Panel::Approvals);
+        let fourth = third.next();
+        assert_eq!(fourth, Panel::Budget);
+        let back = fourth.next();
+        assert_eq!(back, Panel::Agents);
+    }
+
+    #[test]
+    fn panel_prev_cycles_backwards() {
+        let start = Panel::Agents;
+        let last = start.prev();
+        assert_eq!(last, Panel::Budget);
+        let third = last.prev();
+        assert_eq!(third, Panel::Approvals);
+        let second = third.prev();
+        assert_eq!(second, Panel::EventLog);
+        let first = second.prev();
+        assert_eq!(first, Panel::Agents);
+    }
+
+    #[test]
+    fn new_state_defaults() {
+        let state = DashboardState::new();
+        assert_eq!(state.active_panel, Panel::Agents);
+        assert!(!state.runtime.reachable);
+        assert!(state.agents.is_empty());
+        assert_eq!(state.approvals_summary.pending_count, 0);
+        assert!(state.pending_approvals.is_empty());
+        assert!(!state.show_help);
+        assert!(!state.show_confirm_dialog);
+        assert!(!state.should_quit);
+    }
+
+    #[test]
+    fn push_event_within_capacity() {
+        let mut state = DashboardState::new();
+        state.push_event(EventEntry {
+            timestamp: "2026-04-30T10:00:00Z".to_string(),
+            event_type: "violation".to_string(),
+            agent_id: "a1".to_string(),
+            message: "test".to_string(),
+        });
+        assert_eq!(state.event_log.len(), 1);
+    }
+
+    #[test]
+    fn push_event_evicts_oldest_at_capacity() {
+        let mut state = DashboardState::new();
+        for i in 0..EVENT_LOG_CAPACITY {
+            state.push_event(EventEntry {
+                timestamp: format!("t{i}"),
+                event_type: "test".to_string(),
+                agent_id: "a1".to_string(),
+                message: format!("msg {i}"),
+            });
+        }
+        assert_eq!(state.event_log.len(), EVENT_LOG_CAPACITY);
+        // Push one more — oldest should be evicted.
+        state.push_event(EventEntry {
+            timestamp: "overflow".to_string(),
+            event_type: "test".to_string(),
+            agent_id: "a1".to_string(),
+            message: "overflow".to_string(),
+        });
+        assert_eq!(state.event_log.len(), EVENT_LOG_CAPACITY);
+        assert_eq!(state.event_log.front().unwrap().timestamp, "t1");
+        assert_eq!(state.event_log.back().unwrap().timestamp, "overflow");
+    }
+}

--- a/aa-cli/src/commands/dashboard/ui.rs
+++ b/aa-cli/src/commands/dashboard/ui.rs
@@ -1,0 +1,398 @@
+//! TUI rendering — draws the 4-panel dashboard layout.
+
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Cell, Gauge, List, ListItem, Paragraph, Row, Table};
+use ratatui::Frame;
+
+use super::state::{DashboardState, Panel};
+
+/// Render the entire dashboard UI to the terminal frame.
+pub fn draw(f: &mut Frame, state: &DashboardState) {
+    let size = f.area();
+
+    // Split vertically: top half and bottom half, plus a 1-line footer.
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage(50),
+            Constraint::Percentage(50),
+            Constraint::Min(1),
+        ])
+        .split(size);
+
+    // Top: Agents (left) | Event Log (right)
+    let top = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+        .split(outer[0]);
+
+    // Bottom: Approvals (left) | Budget (right)
+    let bottom = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+        .split(outer[1]);
+
+    draw_agents_panel(f, top[0], state);
+    draw_event_log_panel(f, top[1], state);
+    draw_approvals_panel(f, bottom[0], state);
+    draw_budget_panel(f, bottom[1], state);
+    draw_footer(f, outer[2], state);
+}
+
+/// Build a Block with a highlighted border when the panel is focused.
+fn panel_block(title: &str, panel: Panel, state: &DashboardState) -> Block<'static> {
+    let is_active = state.active_panel == panel;
+    let border_style = if is_active {
+        Style::default().fg(Color::Cyan)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+    Block::default()
+        .title(format!(" {title} "))
+        .borders(Borders::ALL)
+        .border_style(border_style)
+}
+
+/// Top-left: runtime health header + agents table.
+fn draw_agents_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
+    let block = panel_block("Agents", Panel::Agents, state);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    // Reserve 2 lines for the health header.
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(2), Constraint::Min(1)])
+        .split(inner);
+
+    // Health header line.
+    let status_indicator = if state.runtime.reachable { "●" } else { "○" };
+    let status_color = if state.runtime.reachable {
+        Color::Green
+    } else {
+        Color::Red
+    };
+    let uptime = format_duration(state.runtime.uptime_secs);
+    let header_line = Line::from(vec![
+        Span::styled(
+            format!("{status_indicator} "),
+            Style::default().fg(status_color),
+        ),
+        Span::raw(format!(
+            "{} | up {} | {} conns | lag {}ms",
+            state.runtime.status,
+            uptime,
+            state.runtime.active_connections,
+            state.runtime.pipeline_lag_ms,
+        )),
+    ]);
+    f.render_widget(Paragraph::new(header_line), chunks[0]);
+
+    // Agents table.
+    let header = Row::new(vec!["ID", "NAME", "STATUS", "FW", "SESS", "VIOL", "LAYER"])
+        .style(Style::default().add_modifier(Modifier::BOLD))
+        .bottom_margin(0);
+
+    let rows: Vec<Row> = state
+        .agents
+        .iter()
+        .map(|a| {
+            let status_style = match a.status.as_str() {
+                "Running" | "Active" => Style::default().fg(Color::Green),
+                "Error" | "Failed" => Style::default().fg(Color::Red),
+                _ => Style::default().fg(Color::Yellow),
+            };
+            Row::new(vec![
+                Cell::from(truncate(&a.id, 8)),
+                Cell::from(a.name.as_str()),
+                Cell::from(a.status.as_str()).style(status_style),
+                Cell::from(a.framework.as_str()),
+                Cell::from(a.sessions.to_string()),
+                Cell::from(a.violations_today.to_string()),
+                Cell::from(a.layer.as_str()),
+            ])
+        })
+        .collect();
+
+    let table = Table::new(
+        rows,
+        [
+            Constraint::Length(9),
+            Constraint::Min(10),
+            Constraint::Length(8),
+            Constraint::Length(10),
+            Constraint::Length(5),
+            Constraint::Length(5),
+            Constraint::Length(8),
+        ],
+    )
+    .header(header);
+
+    f.render_widget(table, chunks[1]);
+}
+
+/// Top-right: scrollable event log from the WebSocket stream.
+fn draw_event_log_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
+    let block = panel_block("Event Log", Panel::EventLog, state);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let items: Vec<ListItem> = state
+        .event_log
+        .iter()
+        .rev()
+        .map(|e| {
+            let type_color = match e.event_type.as_str() {
+                "violation" => Color::Red,
+                "approval" => Color::Yellow,
+                "budget" => Color::Magenta,
+                _ => Color::White,
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(
+                    format!("[{}] ", short_timestamp(&e.timestamp)),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::styled(
+                    format!("{:<10} ", e.event_type),
+                    Style::default().fg(type_color),
+                ),
+                Span::raw(&e.message),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items);
+    f.render_widget(list, inner);
+}
+
+/// Bottom-left: pending approval requests with selection highlight.
+fn draw_approvals_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
+    let title = format!(
+        "Approvals ({} pending)",
+        state.approvals_summary.pending_count
+    );
+    let block = panel_block(&title, Panel::Approvals, state);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    if state.pending_approvals.is_empty() {
+        let msg = Paragraph::new("No pending approvals")
+            .style(Style::default().fg(Color::DarkGray));
+        f.render_widget(msg, inner);
+        return;
+    }
+
+    let items: Vec<ListItem> = state
+        .pending_approvals
+        .iter()
+        .enumerate()
+        .map(|(i, ap)| {
+            let style = if i == state.approval_selected {
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(
+                    format!("[{}] ", short_timestamp(&ap.created_at)),
+                    Style::default().fg(Color::DarkGray),
+                ),
+                Span::raw(format!(
+                    "{} — {} ({})",
+                    ap.agent_id, ap.action, ap.reason
+                )),
+            ]))
+            .style(style)
+        })
+        .collect();
+
+    let list = List::new(items);
+    f.render_widget(list, inner);
+}
+
+/// Bottom-right: budget gauge and cost breakdown.
+fn draw_budget_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
+    let block = panel_block("Budget", Panel::Budget, state);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(3), Constraint::Min(1)])
+        .split(inner);
+
+    // Daily spend gauge.
+    let (ratio, label) = compute_budget_ratio(state);
+    let gauge_color = if ratio > 0.9 {
+        Color::Red
+    } else if ratio > 0.7 {
+        Color::Yellow
+    } else {
+        Color::Green
+    };
+    let gauge = Gauge::default()
+        .gauge_style(Style::default().fg(gauge_color))
+        .ratio(ratio)
+        .label(label);
+    f.render_widget(gauge, chunks[0]);
+
+    // Per-agent cost breakdown.
+    let items: Vec<ListItem> = state
+        .budget
+        .per_agent
+        .iter()
+        .map(|entry| {
+            ListItem::new(format!(
+                "  {} — ${}",
+                entry.agent_id, entry.daily_spend_usd
+            ))
+        })
+        .collect();
+    let list = List::new(items);
+    f.render_widget(list, chunks[1]);
+}
+
+/// Footer bar with keyboard shortcuts.
+fn draw_footer(f: &mut Frame, area: Rect, _state: &DashboardState) {
+    let footer = Line::from(vec![
+        Span::styled(" Tab", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(" panel  "),
+        Span::styled("↑↓", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(" scroll  "),
+        Span::styled("a", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw("/"),
+        Span::styled("r", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(" approve/reject  "),
+        Span::styled("?", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(" help  "),
+        Span::styled("q", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(" quit"),
+    ]);
+    f.render_widget(
+        Paragraph::new(footer).style(Style::default().fg(Color::DarkGray)),
+        area,
+    );
+}
+
+/// Compute the budget gauge ratio and label string.
+fn compute_budget_ratio(state: &DashboardState) -> (f64, String) {
+    let spend: f64 = state
+        .budget
+        .daily_spend_usd
+        .parse()
+        .unwrap_or(0.0);
+
+    let limit: Option<f64> = state
+        .budget
+        .daily_limit_usd
+        .as_deref()
+        .and_then(|s| s.parse().ok());
+
+    match limit {
+        Some(lim) if lim > 0.0 => {
+            let ratio = (spend / lim).min(1.0);
+            (ratio, format!("${spend:.2} / ${lim:.2}"))
+        }
+        _ => (0.0, format!("${spend:.2} (no limit set)")),
+    }
+}
+
+/// Truncate a string to `max` characters, appending "…" if shortened.
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max - 1])
+    }
+}
+
+/// Extract HH:MM:SS from an ISO timestamp for compact display.
+fn short_timestamp(ts: &str) -> &str {
+    // "2026-04-30T10:00:00Z" → "10:00:00"
+    if ts.len() >= 19 {
+        &ts[11..19]
+    } else {
+        ts
+    }
+}
+
+/// Format seconds into a human-readable duration string.
+fn format_duration(secs: u64) -> String {
+    let h = secs / 3600;
+    let m = (secs % 3600) / 60;
+    if h > 0 {
+        format!("{h}h {m}m")
+    } else {
+        format!("{m}m")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_short_string_unchanged() {
+        assert_eq!(truncate("abc", 5), "abc");
+    }
+
+    #[test]
+    fn truncate_long_string_adds_ellipsis() {
+        assert_eq!(truncate("abcdef", 4), "abc…");
+    }
+
+    #[test]
+    fn short_timestamp_extracts_time() {
+        assert_eq!(short_timestamp("2026-04-30T10:15:30Z"), "10:15:30");
+    }
+
+    #[test]
+    fn short_timestamp_returns_input_if_too_short() {
+        assert_eq!(short_timestamp("short"), "short");
+    }
+
+    #[test]
+    fn format_duration_hours_and_minutes() {
+        assert_eq!(format_duration(3661), "1h 1m");
+    }
+
+    #[test]
+    fn format_duration_minutes_only() {
+        assert_eq!(format_duration(300), "5m");
+    }
+
+    #[test]
+    fn compute_budget_ratio_with_limit() {
+        let state = DashboardState::new();
+        let mut state = state;
+        state.budget.daily_spend_usd = "50.00".to_string();
+        state.budget.daily_limit_usd = Some("100.00".to_string());
+        let (ratio, label) = compute_budget_ratio(&state);
+        assert!((ratio - 0.5).abs() < 0.01);
+        assert!(label.contains("50.00"));
+        assert!(label.contains("100.00"));
+    }
+
+    #[test]
+    fn compute_budget_ratio_no_limit() {
+        let state = DashboardState::new();
+        let (ratio, label) = compute_budget_ratio(&state);
+        assert!((ratio - 0.0).abs() < 0.01);
+        assert!(label.contains("no limit"));
+    }
+
+    #[test]
+    fn compute_budget_ratio_capped_at_one() {
+        let mut state = DashboardState::new();
+        state.budget.daily_spend_usd = "150.00".to_string();
+        state.budget.daily_limit_usd = Some("100.00".to_string());
+        let (ratio, _) = compute_budget_ratio(&state);
+        assert!((ratio - 1.0).abs() < 0.01);
+    }
+}

--- a/aa-cli/src/commands/dashboard/ui.rs
+++ b/aa-cli/src/commands/dashboard/ui.rs
@@ -80,16 +80,10 @@ fn draw_agents_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
     };
     let uptime = format_duration(state.runtime.uptime_secs);
     let header_line = Line::from(vec![
-        Span::styled(
-            format!("{status_indicator} "),
-            Style::default().fg(status_color),
-        ),
+        Span::styled(format!("{status_indicator} "), Style::default().fg(status_color)),
         Span::raw(format!(
             "{} | up {} | {} conns | lag {}ms",
-            state.runtime.status,
-            uptime,
-            state.runtime.active_connections,
-            state.runtime.pipeline_lag_ms,
+            state.runtime.status, uptime, state.runtime.active_connections, state.runtime.pipeline_lag_ms,
         )),
     ]);
     f.render_widget(Paragraph::new(header_line), chunks[0]);
@@ -159,10 +153,7 @@ fn draw_event_log_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
                     format!("[{}] ", short_timestamp(&e.timestamp)),
                     Style::default().fg(Color::DarkGray),
                 ),
-                Span::styled(
-                    format!("{:<10} ", e.event_type),
-                    Style::default().fg(type_color),
-                ),
+                Span::styled(format!("{:<10} ", e.event_type), Style::default().fg(type_color)),
                 Span::raw(&e.message),
             ]))
         })
@@ -174,17 +165,13 @@ fn draw_event_log_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
 
 /// Bottom-left: pending approval requests with selection highlight.
 fn draw_approvals_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
-    let title = format!(
-        "Approvals ({} pending)",
-        state.approvals_summary.pending_count
-    );
+    let title = format!("Approvals ({} pending)", state.approvals_summary.pending_count);
     let block = panel_block(&title, Panel::Approvals, state);
     let inner = block.inner(area);
     f.render_widget(block, area);
 
     if state.pending_approvals.is_empty() {
-        let msg = Paragraph::new("No pending approvals")
-            .style(Style::default().fg(Color::DarkGray));
+        let msg = Paragraph::new("No pending approvals").style(Style::default().fg(Color::DarkGray));
         f.render_widget(msg, inner);
         return;
     }
@@ -207,10 +194,7 @@ fn draw_approvals_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
                     format!("[{}] ", short_timestamp(&ap.created_at)),
                     Style::default().fg(Color::DarkGray),
                 ),
-                Span::raw(format!(
-                    "{} — {} ({})",
-                    ap.agent_id, ap.action, ap.reason
-                )),
+                Span::raw(format!("{} — {} ({})", ap.agent_id, ap.action, ap.reason)),
             ]))
             .style(style)
         })
@@ -251,12 +235,7 @@ fn draw_budget_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
         .budget
         .per_agent
         .iter()
-        .map(|entry| {
-            ListItem::new(format!(
-                "  {} — ${}",
-                entry.agent_id, entry.daily_spend_usd
-            ))
-        })
+        .map(|entry| ListItem::new(format!("  {} — ${}", entry.agent_id, entry.daily_spend_usd)))
         .collect();
     let list = List::new(items);
     f.render_widget(list, chunks[1]);
@@ -278,10 +257,7 @@ fn draw_footer(f: &mut Frame, area: Rect, _state: &DashboardState) {
         Span::styled("q", Style::default().add_modifier(Modifier::BOLD)),
         Span::raw(" quit"),
     ]);
-    f.render_widget(
-        Paragraph::new(footer).style(Style::default().fg(Color::DarkGray)),
-        area,
-    );
+    f.render_widget(Paragraph::new(footer).style(Style::default().fg(Color::DarkGray)), area);
 }
 
 /// Render a centered help overlay listing all keyboard shortcuts.
@@ -363,17 +339,9 @@ fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
 
 /// Compute the budget gauge ratio and label string.
 fn compute_budget_ratio(state: &DashboardState) -> (f64, String) {
-    let spend: f64 = state
-        .budget
-        .daily_spend_usd
-        .parse()
-        .unwrap_or(0.0);
+    let spend: f64 = state.budget.daily_spend_usd.parse().unwrap_or(0.0);
 
-    let limit: Option<f64> = state
-        .budget
-        .daily_limit_usd
-        .as_deref()
-        .and_then(|s| s.parse().ok());
+    let limit: Option<f64> = state.budget.daily_limit_usd.as_deref().and_then(|s| s.parse().ok());
 
     match limit {
         Some(lim) if lim > 0.0 => {

--- a/aa-cli/src/commands/dashboard/ui.rs
+++ b/aa-cli/src/commands/dashboard/ui.rs
@@ -3,7 +3,7 @@
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Cell, Gauge, List, ListItem, Paragraph, Row, Table};
+use ratatui::widgets::{Block, Borders, Cell, Clear, Gauge, List, ListItem, Paragraph, Row, Table};
 use ratatui::Frame;
 
 use super::state::{DashboardState, Panel};
@@ -39,6 +39,10 @@ pub fn draw(f: &mut Frame, state: &DashboardState) {
     draw_approvals_panel(f, bottom[0], state);
     draw_budget_panel(f, bottom[1], state);
     draw_footer(f, outer[2], state);
+
+    if state.show_help {
+        draw_help_overlay(f, size);
+    }
 }
 
 /// Build a Block with a highlighted border when the panel is focused.
@@ -278,6 +282,83 @@ fn draw_footer(f: &mut Frame, area: Rect, _state: &DashboardState) {
         Paragraph::new(footer).style(Style::default().fg(Color::DarkGray)),
         area,
     );
+}
+
+/// Render a centered help overlay listing all keyboard shortcuts.
+fn draw_help_overlay(f: &mut Frame, area: Rect) {
+    let overlay = centered_rect(60, 60, area);
+    f.render_widget(Clear, overlay);
+
+    let block = Block::default()
+        .title(" Help — Keyboard Shortcuts ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(overlay);
+    f.render_widget(block, overlay);
+
+    let lines = vec![
+        Line::from(vec![
+            Span::styled("Tab      ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw("Next panel"),
+        ]),
+        Line::from(vec![
+            Span::styled("Shift+Tab", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw("Previous panel"),
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("↑ / k    ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw("Scroll up / select previous"),
+        ]),
+        Line::from(vec![
+            Span::styled("↓ / j    ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw("Scroll down / select next"),
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("a        ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw("Approve selected request"),
+        ]),
+        Line::from(vec![
+            Span::styled("r        ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw("Reject selected request"),
+        ]),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("?        ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw("Toggle this help overlay"),
+        ]),
+        Line::from(vec![
+            Span::styled("q / Esc  ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw("Quit dashboard"),
+        ]),
+    ];
+
+    let help = Paragraph::new(lines);
+    f.render_widget(help, inner);
+}
+
+/// Compute a centered rectangle within `area`.
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+
+    let horizontal = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1]);
+
+    horizontal[1]
 }
 
 /// Compute the budget gauge ratio and label string.

--- a/aa-cli/src/commands/dashboard/ui.rs
+++ b/aa-cli/src/commands/dashboard/ui.rs
@@ -3,10 +3,15 @@
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Cell, Clear, Gauge, List, ListItem, Paragraph, Row, Table};
+use ratatui::widgets::{Block, Borders, Cell, Clear, Gauge, List, ListItem, Paragraph, Row, Table, Wrap};
 use ratatui::Frame;
 
+use crate::commands::approvals::models::{compute_timeout_color, format_countdown, TimeoutColor};
+
 use super::state::{DashboardState, Panel};
+
+/// Approval timeout in seconds (5 minutes, matching `approvals watch`).
+const APPROVAL_TIMEOUT_SECS: i64 = 300;
 
 /// Render the entire dashboard UI to the terminal frame.
 pub fn draw(f: &mut Frame, state: &DashboardState) {
@@ -28,20 +33,26 @@ pub fn draw(f: &mut Frame, state: &DashboardState) {
         .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
         .split(outer[0]);
 
-    // Bottom: Approvals (left) | Budget (right)
+    // Bottom: Budget (left) | Approvals (right)
     let bottom = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
+        .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
         .split(outer[1]);
 
     draw_agents_panel(f, top[0], state);
     draw_event_log_panel(f, top[1], state);
-    draw_approvals_panel(f, bottom[0], state);
-    draw_budget_panel(f, bottom[1], state);
+    draw_budget_panel(f, bottom[0], state);
+    draw_approvals_panel(f, bottom[1], state);
     draw_footer(f, outer[2], state);
 
     if state.show_help {
         draw_help_overlay(f, size);
+    }
+    if state.show_inspect {
+        draw_inspect_overlay(f, state);
+    }
+    if state.show_policy {
+        draw_policy_overlay(f, state);
     }
 }
 
@@ -96,13 +107,15 @@ fn draw_agents_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
     let rows: Vec<Row> = state
         .agents
         .iter()
-        .map(|a| {
+        .enumerate()
+        .map(|(i, a)| {
+            let is_selected = i == state.agent_selected;
             let status_style = match a.status.as_str() {
                 "Running" | "Active" => Style::default().fg(Color::Green),
                 "Error" | "Failed" => Style::default().fg(Color::Red),
                 _ => Style::default().fg(Color::Yellow),
             };
-            Row::new(vec![
+            let row = Row::new(vec![
                 Cell::from(truncate(&a.id, 8)),
                 Cell::from(a.name.as_str()),
                 Cell::from(a.status.as_str()).style(status_style),
@@ -110,7 +123,17 @@ fn draw_agents_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
                 Cell::from(a.sessions.to_string()),
                 Cell::from(a.violations_today.to_string()),
                 Cell::from(a.layer.as_str()),
-            ])
+            ]);
+            if is_selected {
+                row.style(
+                    Style::default()
+                        .fg(Color::Black)
+                        .bg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                )
+            } else {
+                row
+            }
         })
         .collect();
 
@@ -163,7 +186,7 @@ fn draw_event_log_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
     f.render_widget(list, inner);
 }
 
-/// Bottom-left: pending approval requests with selection highlight.
+/// Bottom-right: pending approval requests with countdown timers and selection highlight.
 fn draw_approvals_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
     let title = format!("Approvals ({} pending)", state.approvals_summary.pending_count);
     let block = panel_block(&title, Panel::Approvals, state);
@@ -175,6 +198,8 @@ fn draw_approvals_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
         f.render_widget(msg, inner);
         return;
     }
+
+    let now = chrono::Utc::now().timestamp();
 
     let items: Vec<ListItem> = state
         .pending_approvals
@@ -189,11 +214,21 @@ fn draw_approvals_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
             } else {
                 Style::default()
             };
+
+            // Compute countdown timer.
+            let submitted = chrono::DateTime::parse_from_rfc3339(&ap.created_at)
+                .map(|dt| dt.timestamp())
+                .unwrap_or(0);
+            let remaining = (submitted + APPROVAL_TIMEOUT_SECS) - now;
+            let countdown = format_countdown(remaining);
+            let countdown_color = match compute_timeout_color(remaining) {
+                TimeoutColor::Red => Color::Red,
+                TimeoutColor::Yellow => Color::Yellow,
+                TimeoutColor::Green => Color::Green,
+            };
+
             ListItem::new(Line::from(vec![
-                Span::styled(
-                    format!("[{}] ", short_timestamp(&ap.created_at)),
-                    Style::default().fg(Color::DarkGray),
-                ),
+                Span::styled(format!("{countdown:<8} "), Style::default().fg(countdown_color)),
                 Span::raw(format!("{} — {} ({})", ap.agent_id, ap.action, ap.reason)),
             ]))
             .style(style)
@@ -204,18 +239,25 @@ fn draw_approvals_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
     f.render_widget(list, inner);
 }
 
-/// Bottom-right: budget gauge and cost breakdown.
+/// Bottom-left: budget utilization bars per agent.
 fn draw_budget_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
     let block = panel_block("Budget", Panel::Budget, state);
     let inner = block.inner(area);
     f.render_widget(block, area);
 
+    let agent_count = state.budget.per_agent.len();
+    // Reserve 3 lines for the total gauge, then 1 line per agent bar.
+    let mut constraints: Vec<Constraint> = vec![Constraint::Length(3)];
+    for _ in 0..agent_count {
+        constraints.push(Constraint::Length(1));
+    }
+    constraints.push(Constraint::Min(0)); // absorb remaining space
     let chunks = Layout::default()
         .direction(Direction::Vertical)
-        .constraints([Constraint::Length(3), Constraint::Min(1)])
+        .constraints(constraints)
         .split(inner);
 
-    // Daily spend gauge.
+    // Total daily spend gauge.
     let (ratio, label) = compute_budget_ratio(state);
     let gauge_color = if ratio > 0.9 {
         Color::Red
@@ -230,15 +272,34 @@ fn draw_budget_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
         .label(label);
     f.render_widget(gauge, chunks[0]);
 
-    // Per-agent cost breakdown.
-    let items: Vec<ListItem> = state
+    // Per-agent utilization bars.
+    let daily_limit: f64 = state
         .budget
-        .per_agent
-        .iter()
-        .map(|entry| ListItem::new(format!("  {} — ${}", entry.agent_id, entry.daily_spend_usd)))
-        .collect();
-    let list = List::new(items);
-    f.render_widget(list, chunks[1]);
+        .daily_limit_usd
+        .as_deref()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0.0);
+
+    for (i, entry) in state.budget.per_agent.iter().enumerate() {
+        let spend: f64 = entry.daily_spend_usd.parse().unwrap_or(0.0);
+        let agent_ratio = if daily_limit > 0.0 {
+            (spend / daily_limit).min(1.0)
+        } else {
+            0.0
+        };
+        let bar_width = chunks[1 + i].width.saturating_sub(2) as usize; // leave margins
+        let filled = ((agent_ratio * bar_width as f64) as usize).min(bar_width);
+        let empty = bar_width.saturating_sub(filled);
+        let bar_color = if agent_ratio > 0.5 { Color::Yellow } else { Color::Green };
+        let label = format!("{:<8} ", truncate(&entry.agent_id, 8));
+        let bar_line = Line::from(vec![
+            Span::raw(label),
+            Span::styled("█".repeat(filled), Style::default().fg(bar_color)),
+            Span::styled("░".repeat(empty), Style::default().fg(Color::DarkGray)),
+            Span::raw(format!(" ${}", entry.daily_spend_usd)),
+        ]);
+        f.render_widget(Paragraph::new(bar_line), chunks[1 + i]);
+    }
 }
 
 /// Footer bar with keyboard shortcuts.
@@ -248,10 +309,14 @@ fn draw_footer(f: &mut Frame, area: Rect, _state: &DashboardState) {
         Span::raw(" panel  "),
         Span::styled("↑↓", Style::default().add_modifier(Modifier::BOLD)),
         Span::raw(" scroll  "),
+        Span::styled("Enter", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(" inspect  "),
         Span::styled("a", Style::default().add_modifier(Modifier::BOLD)),
         Span::raw("/"),
         Span::styled("r", Style::default().add_modifier(Modifier::BOLD)),
         Span::raw(" approve/reject  "),
+        Span::styled("p", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(" policy  "),
         Span::styled("?", Style::default().add_modifier(Modifier::BOLD)),
         Span::raw(" help  "),
         Span::styled("q", Style::default().add_modifier(Modifier::BOLD)),
@@ -290,6 +355,10 @@ fn draw_help_overlay(f: &mut Frame, area: Rect) {
             Span::styled("↓ / j    ", Style::default().add_modifier(Modifier::BOLD)),
             Span::raw("Scroll down / select next"),
         ]),
+        Line::from(vec![
+            Span::styled("Enter    ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw("Inspect selected agent/approval"),
+        ]),
         Line::from(""),
         Line::from(vec![
             Span::styled("a        ", Style::default().add_modifier(Modifier::BOLD)),
@@ -298,6 +367,10 @@ fn draw_help_overlay(f: &mut Frame, area: Rect) {
         Line::from(vec![
             Span::styled("r        ", Style::default().add_modifier(Modifier::BOLD)),
             Span::raw("Reject selected request"),
+        ]),
+        Line::from(vec![
+            Span::styled("p        ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw("View active policy"),
         ]),
         Line::from(""),
         Line::from(vec![
@@ -312,6 +385,132 @@ fn draw_help_overlay(f: &mut Frame, area: Rect) {
 
     let help = Paragraph::new(lines);
     f.render_widget(help, inner);
+}
+
+/// Render a centered inspect overlay showing details of the selected agent or approval.
+pub fn draw_inspect_overlay(f: &mut Frame, state: &DashboardState) {
+    let area = f.area();
+    let overlay = centered_rect(70, 60, area);
+    f.render_widget(Clear, overlay);
+
+    match state.active_panel {
+        Panel::Agents => {
+            let block = Block::default()
+                .title(" Agent Detail ")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan));
+            let inner = block.inner(overlay);
+            f.render_widget(block, overlay);
+
+            if let Some(agent) = state.agents.get(state.agent_selected) {
+                let lines = vec![
+                    Line::from(vec![
+                        Span::styled("ID:          ", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::raw(&agent.id),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("Name:        ", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::raw(&agent.name),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("Framework:   ", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::raw(&agent.framework),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("Status:      ", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::styled(
+                            &agent.status,
+                            match agent.status.as_str() {
+                                "Running" | "Active" => Style::default().fg(Color::Green),
+                                "Error" | "Failed" => Style::default().fg(Color::Red),
+                                _ => Style::default().fg(Color::Yellow),
+                            },
+                        ),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("Sessions:    ", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::raw(agent.sessions.to_string()),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("Violations:  ", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::raw(agent.violations_today.to_string()),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("Layer:       ", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::raw(&agent.layer),
+                    ]),
+                    Line::from(""),
+                    Line::from(Span::styled("Press Esc to close", Style::default().fg(Color::DarkGray))),
+                ];
+                f.render_widget(Paragraph::new(lines), inner);
+            }
+        }
+        Panel::Approvals => {
+            let block = Block::default()
+                .title(" Approval Detail ")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Cyan));
+            let inner = block.inner(overlay);
+            f.render_widget(block, overlay);
+
+            if let Some(ap) = state.pending_approvals.get(state.approval_selected) {
+                let lines = vec![
+                    Line::from(vec![
+                        Span::styled("ID:          ", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::raw(&ap.id),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("Agent:       ", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::raw(&ap.agent_id),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("Action:      ", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::raw(&ap.action),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("Reason:      ", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::raw(&ap.reason),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("Status:      ", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::raw(&ap.status),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("Created:     ", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::raw(&ap.created_at),
+                    ]),
+                    Line::from(""),
+                    Line::from(Span::styled("Press Esc to close", Style::default().fg(Color::DarkGray))),
+                ];
+                f.render_widget(Paragraph::new(lines), inner);
+            }
+        }
+        _ => {
+            // No inspect for EventLog or Budget panels.
+        }
+    }
+}
+
+/// Render a centered policy viewer overlay showing policy YAML content.
+pub fn draw_policy_overlay(f: &mut Frame, state: &DashboardState) {
+    let area = f.area();
+    let overlay = centered_rect(75, 80, area);
+    f.render_widget(Clear, overlay);
+
+    let block = Block::default()
+        .title(" Policy Viewer ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    let inner = block.inner(overlay);
+    f.render_widget(block, overlay);
+
+    let content = match &state.policy_yaml {
+        Some(yaml) => yaml.as_str(),
+        None => "(loading policy…)",
+    };
+
+    let paragraph = Paragraph::new(content).wrap(Wrap { trim: false });
+    f.render_widget(paragraph, inner);
 }
 
 /// Compute a centered rectangle within `area`.

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod approvals;
 pub mod completion;
 pub mod context;
 pub mod cost;
+pub mod dashboard;
 pub mod logs;
 pub mod policy;
 pub mod status;
@@ -41,6 +42,8 @@ pub enum Commands {
     Approvals(approvals::ApprovalsArgs),
     /// Query cost summary and forecast spending.
     Cost(cost::CostArgs),
+    /// Open an interactive TUI dashboard for real-time governance monitoring.
+    Dashboard(dashboard::DashboardArgs),
 }
 
 /// Dispatch the parsed CLI command to the appropriate handler.
@@ -56,5 +59,6 @@ pub fn dispatch(cmd: Commands, ctx: &ResolvedContext, output: OutputFormat) -> E
         Commands::Trace(args) => trace::dispatch(args, ctx, output),
         Commands::Approvals(args) => approvals::dispatch(args, ctx, output),
         Commands::Cost(args) => cost::dispatch(args, ctx, output),
+        Commands::Dashboard(args) => dashboard::dispatch(args, ctx),
     }
 }


### PR DESCRIPTION
## Summary

- Add `aasm dashboard` subcommand providing a real-time interactive TUI built with ratatui 0.29 + crossterm 0.28
- Four-panel layout: Agents table (with runtime health header), Event Log (WebSocket stream), Approvals list (with approve/reject via `a`/`r` keys), and Budget gauge (with per-agent breakdown)
- Background REST polling (5s interval) for status data + WebSocket event streaming from `/api/v1/ws/events`
- Keyboard navigation: Tab/Shift+Tab for panel cycling, ↑↓/jk for scroll/selection, `?` for help overlay, `q`/Esc to quit
- Approve/reject confirmation dialog with `y` to confirm and `n`/Esc to cancel, calling the existing approvals API

## Architecture

```
aa-cli/src/commands/dashboard/
├── mod.rs     — DashboardArgs, dispatch, terminal setup/teardown, main event loop
├── state.rs   — DashboardState, Panel enum, EventEntry
├── ui.rs      — 4-panel ratatui layout rendering + help overlay
├── input.rs   — Keyboard event handler with InputAction
├── feed.rs    — REST poller + WebSocket listener (FeedMessage via mpsc)
└── dialog.rs  — Centered confirmation dialog for approve/reject
```

## Test plan

- [x] 31 unit tests covering: Panel cycling, DashboardState defaults, event ring buffer eviction, keyboard handling (quit, tab, scroll, approve/reject actions, help toggle), WS URL construction, event payload parsing, budget ratio computation, timestamp formatting, centered rect layout
- [x] Full `aa-cli` test suite passes (224 tests)
- [x] Clippy clean across workspace
- [x] `cargo check --workspace` passes

Closes AAASM-93

🤖 Generated with [Claude Code](https://claude.com/claude-code)