### PR TITLE
[AAASM-184] 🐛 cli(policy): Implement aasm policy list subcommand

### DIFF
--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -51,7 +51,7 @@ pub fn dispatch(cmd: Commands, ctx: &ResolvedContext, output: OutputFormat) -> E
     match cmd {
         Commands::Agent(args) => agent::dispatch(args, ctx, output),
         Commands::Logs(args) => logs::dispatch(args, ctx),
-        Commands::Policy(args) => policy::dispatch(args, ctx),
+        Commands::Policy(args) => policy::dispatch(args, ctx, output),
         Commands::Context(args) => context::dispatch(args),
         Commands::Completion(args) => completion::run(args),
         Commands::Status(args) => status::dispatch(args, ctx, output),

--- a/aa-cli/src/commands/policy/list.rs
+++ b/aa-cli/src/commands/policy/list.rs
@@ -1,0 +1,216 @@
+//! `aasm policy list` — list all policies deployed to the governance runtime.
+
+use std::process::ExitCode;
+
+use clap::Args;
+use comfy_table::{Cell, Color, Table};
+use serde::{Deserialize, Serialize};
+
+use crate::client;
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
+
+/// Arguments for `aasm policy list`.
+#[derive(Args)]
+pub struct ListArgs {}
+
+/// API response item from `GET /api/v1/policies`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct PolicyResponse {
+    /// Policy name (SHA-256 prefix).
+    pub name: String,
+    /// Version timestamp string.
+    pub version: String,
+    /// Whether this is the currently active policy.
+    pub active: bool,
+    /// Number of rules in this policy.
+    pub rule_count: usize,
+}
+
+/// Paginated API response wrapper for policies.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PaginatedResponse {
+    pub items: Vec<PolicyResponse>,
+    #[allow(dead_code)]
+    pub page: u32,
+    #[allow(dead_code)]
+    pub per_page: u32,
+    #[allow(dead_code)]
+    pub total: u64,
+}
+
+/// Fetch policies from the gateway API.
+async fn fetch_policies(ctx: &ResolvedContext) -> Result<Vec<PolicyResponse>, crate::error::CliError> {
+    let resp: PaginatedResponse = client::get_json(ctx, "/api/v1/policies").await?;
+    Ok(resp.items)
+}
+
+/// Map a policy active flag to a display status string.
+fn status_label(active: bool) -> &'static str {
+    if active {
+        "Active"
+    } else {
+        "Inactive"
+    }
+}
+
+/// Map a policy active flag to a terminal color.
+fn status_color(active: bool) -> Color {
+    if active {
+        Color::Green
+    } else {
+        Color::DarkGrey
+    }
+}
+
+/// Render policies as a table using comfy-table.
+fn render_table(policies: &[PolicyResponse]) {
+    let mut table = Table::new();
+    table.set_header(vec!["NAME", "VERSION", "STATUS", "RULES"]);
+
+    for p in policies {
+        table.add_row(vec![
+            Cell::new(&p.name),
+            Cell::new(&p.version),
+            Cell::new(status_label(p.active)).fg(status_color(p.active)),
+            Cell::new(p.rule_count),
+        ]);
+    }
+
+    println!("{table}");
+}
+
+/// Render policies as JSON.
+fn render_json(policies: &[PolicyResponse]) {
+    match serde_json::to_string_pretty(policies) {
+        Ok(json) => println!("{json}"),
+        Err(e) => eprintln!("error serializing JSON: {e}"),
+    }
+}
+
+/// Render policies as YAML.
+fn render_yaml(policies: &[PolicyResponse]) {
+    match serde_yaml::to_string(policies) {
+        Ok(yaml) => print!("{yaml}"),
+        Err(e) => eprintln!("error serializing YAML: {e}"),
+    }
+}
+
+/// Render policies in the requested output format.
+fn render(policies: &[PolicyResponse], output: OutputFormat) {
+    match output {
+        OutputFormat::Table => render_table(policies),
+        OutputFormat::Json => render_json(policies),
+        OutputFormat::Yaml => render_yaml(policies),
+    }
+}
+
+/// Run the `aasm policy list` command.
+pub fn run(args: ListArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    let _ = args;
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+
+    let policies = match rt.block_on(fetch_policies(ctx)) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if policies.is_empty() {
+        println!("No policies found. Use `aasm policy apply` to deploy one.");
+    } else {
+        render(&policies, output);
+    }
+
+    ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_policies() -> Vec<PolicyResponse> {
+        vec![
+            PolicyResponse {
+                name: "abc123def456".to_string(),
+                version: "2026-04-30T10:00:00Z".to_string(),
+                active: true,
+                rule_count: 5,
+            },
+            PolicyResponse {
+                name: "789012345678".to_string(),
+                version: "2026-04-29T08:00:00Z".to_string(),
+                active: false,
+                rule_count: 3,
+            },
+        ]
+    }
+
+    #[test]
+    fn status_label_active() {
+        assert_eq!(status_label(true), "Active");
+    }
+
+    #[test]
+    fn status_label_inactive() {
+        assert_eq!(status_label(false), "Inactive");
+    }
+
+    #[test]
+    fn status_color_active_is_green() {
+        assert_eq!(status_color(true), Color::Green);
+    }
+
+    #[test]
+    fn status_color_inactive_is_grey() {
+        assert_eq!(status_color(false), Color::DarkGrey);
+    }
+
+    #[test]
+    fn render_table_does_not_panic() {
+        let policies = sample_policies();
+        render_table(&policies);
+    }
+
+    #[test]
+    fn render_table_empty_does_not_panic() {
+        render_table(&[]);
+    }
+
+    #[test]
+    fn json_output_is_valid() {
+        let policies = sample_policies();
+        let json = serde_json::to_string_pretty(&policies).unwrap();
+        let parsed: Vec<PolicyResponse> = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].name, "abc123def456");
+        assert!(parsed[0].active);
+        assert_eq!(parsed[1].rule_count, 3);
+    }
+
+    #[test]
+    fn yaml_output_is_valid() {
+        let policies = sample_policies();
+        let yaml = serde_yaml::to_string(&policies).unwrap();
+        let parsed: Vec<PolicyResponse> = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed.len(), 2);
+    }
+
+    #[test]
+    fn deserialize_paginated_response() {
+        let json = r#"{
+            "items": [
+                {"name": "abc123", "version": "2026-04-30T10:00:00Z", "active": true, "rule_count": 5}
+            ],
+            "page": 1,
+            "per_page": 20,
+            "total": 1
+        }"#;
+        let resp: PaginatedResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.items.len(), 1);
+        assert_eq!(resp.items[0].name, "abc123");
+        assert!(resp.items[0].active);
+    }
+}

--- a/aa-cli/src/commands/policy/list.rs
+++ b/aa-cli/src/commands/policy/list.rs
@@ -66,13 +66,13 @@ fn status_color(active: bool) -> Color {
 /// Render policies as a table using comfy-table.
 fn render_table(policies: &[PolicyResponse]) {
     let mut table = Table::new();
-    table.set_header(vec!["NAME", "VERSION", "STATUS", "RULES"]);
+    table.set_header(vec!["NAME", "STATUS", "UPDATED_AT", "RULES"]);
 
     for p in policies {
         table.add_row(vec![
             Cell::new(&p.name),
-            Cell::new(&p.version),
             Cell::new(status_label(p.active)).fg(status_color(p.active)),
+            Cell::new(&p.version),
             Cell::new(p.rule_count),
         ]);
     }

--- a/aa-cli/src/commands/policy/mod.rs
+++ b/aa-cli/src/commands/policy/mod.rs
@@ -5,9 +5,11 @@ use std::process::ExitCode;
 use clap::{Args, Subcommand};
 
 use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
 
 pub mod get;
 pub mod history;
+pub mod list;
 pub mod simulate;
 pub mod validate;
 
@@ -35,10 +37,12 @@ pub enum PolicyCommands {
     Validate(validate::ValidateArgs),
     /// Show the currently active policy YAML (or a specific version).
     Get(get::GetArgs),
+    /// List all policies deployed to the governance runtime.
+    List(list::ListArgs),
 }
 
 /// Dispatch a policy subcommand.
-pub fn dispatch(args: PolicyArgs, ctx: &ResolvedContext) -> ExitCode {
+pub fn dispatch(args: PolicyArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
     match args.command {
         PolicyCommands::Apply(apply_args) => history::run_apply(apply_args, ctx),
         PolicyCommands::History(history_args) => history::run_history(history_args),
@@ -47,5 +51,6 @@ pub fn dispatch(args: PolicyArgs, ctx: &ResolvedContext) -> ExitCode {
         PolicyCommands::Simulate(sim_args) => simulate::run(sim_args),
         PolicyCommands::Validate(val_args) => validate::run(val_args),
         PolicyCommands::Get(get_args) => get::run(get_args),
+        PolicyCommands::List(list_args) => list::run(list_args, ctx, output),
     }
 }


### PR DESCRIPTION
## Summary

- Thread `OutputFormat` through `policy::dispatch()` so `aasm policy list` supports `--output json/yaml`
- Implement `aasm policy list` subcommand querying `GET /api/v1/policies` with table/json/yaml rendering
- Show helpful empty-list message: "No policies found. Use `aasm policy apply` to deploy one."

## Changes

| File | Change |
|---|---|
| `aa-cli/src/commands/mod.rs` | Pass `output` to `policy::dispatch()` |
| `aa-cli/src/commands/policy/mod.rs` | Add `List` variant, `list` module, accept `OutputFormat` param |
| `aa-cli/src/commands/policy/list.rs` | **NEW** — `PolicyResponse` model, `PaginatedResponse`, fetch/render/run, 8 unit tests |

## Test plan

- [x] 8 new unit tests: status labels, color mapping, JSON/YAML round-trips, table rendering, paginated response deserialization
- [x] All 232 aa-cli tests pass
- [x] `cargo clippy -p aa-cli -- -D warnings` clean
- [x] `cargo fmt -p aa-cli -- --check` clean

Closes AAASM-184

🤖 Generated with [Claude Code](https://claude.com/claude-code)