### PR TITLE
[AAASM-185] ✨ cli(audit): Add audit list and export subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ dependencies = [
  "comfy-table",
  "console",
  "crossterm 0.28.1",
+ "csv",
  "dirs",
  "futures-util",
  "owo-colors",
@@ -1263,6 +1264,27 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -17,6 +17,7 @@ chrono         = { version = "0.4", features = ["serde"] }
 clap           = { version = "4", features = ["derive"] }
 clap_complete  = "4"
 colored        = "3"
+csv            = "1"
 comfy-table    = "7"
 console        = "0.15"
 crossterm      = "0.28"

--- a/aa-cli/src/commands/audit/export.rs
+++ b/aa-cli/src/commands/audit/export.rs
@@ -106,7 +106,15 @@ pub fn compliance_header(format: ComplianceFormat) -> String {
 /// Write audit entries as CSV to the given writer.
 pub fn write_csv<W: Write>(entries: &[AuditEntry], mut writer: W) -> Result<(), Box<dyn std::error::Error>> {
     let mut wtr = csv::Writer::from_writer(&mut writer);
-    wtr.write_record(["timestamp", "agent_id", "session_id", "event_type", "tool", "result", "policy"])?;
+    wtr.write_record([
+        "timestamp",
+        "agent_id",
+        "session_id",
+        "event_type",
+        "tool",
+        "result",
+        "policy",
+    ])?;
 
     for entry in entries {
         let result = extract_result(entry).unwrap_or_default();

--- a/aa-cli/src/commands/audit/export.rs
+++ b/aa-cli/src/commands/audit/export.rs
@@ -1,10 +1,12 @@
 //! `aasm audit export` — export audit data in CSV or JSON format.
 
+use std::io::Write;
 use std::process::ExitCode;
 
 use clap::Args;
 
-use super::models::{AuditResult, ComplianceFormat, ExportFormat};
+use super::list::{apply_filters, extract_policy, extract_result, extract_tool, ListArgs};
+use super::models::{AuditEntry, AuditResult, ComplianceFormat, ExportFormat, PaginatedAuditResponse};
 use crate::config::ResolvedContext;
 
 /// Arguments for `aasm audit export`.
@@ -47,8 +49,315 @@ pub struct ExportArgs {
     pub limit: u32,
 }
 
+impl ExportArgs {
+    /// Convert export filter flags into the shared `ListArgs` for reuse.
+    fn as_list_args(&self) -> ListArgs {
+        ListArgs {
+            agent: self.agent.clone(),
+            action: self.action.clone(),
+            result: self.result,
+            since: self.since.clone(),
+            until: self.until.clone(),
+            limit: self.limit,
+        }
+    }
+}
+
+/// Build the query URL for `GET /api/v1/logs` with filter parameters.
+fn build_url(ctx: &ResolvedContext, args: &ExportArgs) -> String {
+    let mut url = format!("{}/api/v1/logs?per_page={}&page=1", ctx.api_url, args.limit);
+
+    if let Some(ref agent) = args.agent {
+        url.push_str(&format!("&agent_id={agent}"));
+    }
+
+    if let Some(ref action) = args.action {
+        url.push_str(&format!("&event_type={action}"));
+    }
+
+    url
+}
+
+/// Generate compliance metadata header block.
+pub fn compliance_header(format: ComplianceFormat) -> String {
+    let now = chrono::Utc::now().to_rfc3339();
+    match format {
+        ComplianceFormat::EuAiAct => {
+            format!(
+                "# EU AI Act Compliance Report\n\
+                 # Generated: {now}\n\
+                 # Framework: EU Artificial Intelligence Act (Regulation 2024/1689)\n\
+                 # Category: High-risk AI system audit log\n\
+                 #\n"
+            )
+        }
+        ComplianceFormat::Soc2 => {
+            format!(
+                "# SOC 2 Type II Audit Report\n\
+                 # Generated: {now}\n\
+                 # Framework: AICPA SOC 2 Trust Services Criteria\n\
+                 # Scope: AI governance decision log\n\
+                 #\n"
+            )
+        }
+    }
+}
+
+/// Write audit entries as CSV to the given writer.
+pub fn write_csv<W: Write>(entries: &[AuditEntry], mut writer: W) -> Result<(), Box<dyn std::error::Error>> {
+    let mut wtr = csv::Writer::from_writer(&mut writer);
+    wtr.write_record(["timestamp", "agent_id", "session_id", "event_type", "tool", "result", "policy"])?;
+
+    for entry in entries {
+        let result = extract_result(entry).unwrap_or_default();
+        let tool = extract_tool(entry);
+        let policy = extract_policy(entry);
+
+        wtr.write_record([
+            &entry.timestamp,
+            &entry.agent_id,
+            &entry.session_id,
+            &entry.event_type,
+            &tool,
+            &result,
+            &policy,
+        ])?;
+    }
+    wtr.flush()?;
+    Ok(())
+}
+
+/// Write audit entries as a JSON array to the given writer.
+pub fn write_json<W: Write>(entries: &[AuditEntry], mut writer: W) -> Result<(), Box<dyn std::error::Error>> {
+    let json = serde_json::to_string_pretty(entries)?;
+    writer.write_all(json.as_bytes())?;
+    writer.write_all(b"\n")?;
+    Ok(())
+}
+
+/// Write compliance header (if any) and formatted entries to a writer.
+fn write_to<W: Write>(
+    entries: &[AuditEntry],
+    args: &ExportArgs,
+    writer: &mut W,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(compliance) = args.compliance {
+        let header = compliance_header(compliance);
+        writer.write_all(header.as_bytes())?;
+    }
+    match args.format {
+        ExportFormat::Csv => write_csv(entries, writer),
+        ExportFormat::Json => write_json(entries, writer),
+    }
+}
+
 /// Execute `aasm audit export`.
-pub fn run(_args: ExportArgs, _ctx: &ResolvedContext) -> ExitCode {
-    // Implemented in a subsequent commit.
-    ExitCode::SUCCESS
+pub fn run(args: ExportArgs, ctx: &ResolvedContext) -> ExitCode {
+    let url = build_url(ctx, &args);
+
+    let response = match reqwest::blocking::get(&url) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: failed to connect to {}: {e}", ctx.api_url);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if !response.status().is_success() {
+        eprintln!("error: API returned status {}", response.status());
+        return ExitCode::FAILURE;
+    }
+
+    let paginated: PaginatedAuditResponse = match response.json() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: failed to parse API response: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let list_args = args.as_list_args();
+    let filtered = apply_filters(&paginated.items, &list_args);
+
+    // Determine output destination.
+    let write_result: Result<(), Box<dyn std::error::Error>> = if let Some(ref path) = args.output {
+        let file = match std::fs::File::create(path) {
+            Ok(f) => f,
+            Err(e) => {
+                eprintln!("error: cannot create file {path}: {e}");
+                return ExitCode::FAILURE;
+            }
+        };
+        let mut writer = std::io::BufWriter::new(file);
+        write_to(&filtered, &args, &mut writer)
+    } else {
+        let stdout = std::io::stdout();
+        let mut writer = stdout.lock();
+        write_to(&filtered, &args, &mut writer)
+    };
+
+    match write_result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: export failed: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_entries() -> Vec<AuditEntry> {
+        vec![
+            AuditEntry {
+                seq: 0,
+                timestamp: "2026-04-30T10:00:00Z".to_string(),
+                agent_id: "aa001".to_string(),
+                session_id: "sess001".to_string(),
+                event_type: "ToolCallIntercepted".to_string(),
+                payload: r#"{"tool":"bash","result":"allow","policy":"default"}"#.to_string(),
+            },
+            AuditEntry {
+                seq: 1,
+                timestamp: "2026-04-30T10:01:00Z".to_string(),
+                agent_id: "aa002".to_string(),
+                session_id: "sess002".to_string(),
+                event_type: "PolicyViolation".to_string(),
+                payload: r#"{"tool":"rm","result":"deny","policy":"deny-rm"}"#.to_string(),
+            },
+        ]
+    }
+
+    #[test]
+    fn write_csv_produces_valid_output() {
+        let entries = sample_entries();
+        let mut buf = Vec::new();
+        write_csv(&entries, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines[0], "timestamp,agent_id,session_id,event_type,tool,result,policy");
+        assert!(lines[1].contains("aa001"));
+        assert!(lines[1].contains("allow"));
+        assert!(lines[2].contains("aa002"));
+        assert!(lines[2].contains("deny"));
+    }
+
+    #[test]
+    fn write_csv_empty_entries() {
+        let mut buf = Vec::new();
+        write_csv(&[], &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        let lines: Vec<&str> = output.lines().collect();
+        assert_eq!(lines.len(), 1); // header only
+        assert!(lines[0].contains("timestamp"));
+    }
+
+    #[test]
+    fn write_json_produces_valid_array() {
+        let entries = sample_entries();
+        let mut buf = Vec::new();
+        write_json(&entries, &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        let parsed: Vec<AuditEntry> = serde_json::from_str(&output).unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].agent_id, "aa001");
+        assert_eq!(parsed[1].agent_id, "aa002");
+    }
+
+    #[test]
+    fn write_json_empty_entries() {
+        let mut buf = Vec::new();
+        write_json(&[], &mut buf).unwrap();
+        let output = String::from_utf8(buf).unwrap();
+
+        let parsed: Vec<AuditEntry> = serde_json::from_str(&output).unwrap();
+        assert!(parsed.is_empty());
+    }
+
+    #[test]
+    fn compliance_header_eu_ai_act() {
+        let header = compliance_header(ComplianceFormat::EuAiAct);
+        assert!(header.contains("EU AI Act"));
+        assert!(header.contains("Regulation 2024/1689"));
+        assert!(header.contains("Generated:"));
+    }
+
+    #[test]
+    fn compliance_header_soc2() {
+        let header = compliance_header(ComplianceFormat::Soc2);
+        assert!(header.contains("SOC 2"));
+        assert!(header.contains("AICPA"));
+        assert!(header.contains("Generated:"));
+    }
+
+    #[test]
+    fn build_url_no_filters() {
+        let ctx = ResolvedContext {
+            name: None,
+            api_url: "http://localhost:8080".to_string(),
+            api_key: None,
+        };
+        let args = ExportArgs {
+            format: ExportFormat::Csv,
+            compliance: None,
+            output: None,
+            agent: None,
+            action: None,
+            result: None,
+            since: None,
+            until: None,
+            limit: 1000,
+        };
+        let url = build_url(&ctx, &args);
+        assert_eq!(url, "http://localhost:8080/api/v1/logs?per_page=1000&page=1");
+    }
+
+    #[test]
+    fn build_url_with_filters() {
+        let ctx = ResolvedContext {
+            name: None,
+            api_url: "http://localhost:8080".to_string(),
+            api_key: None,
+        };
+        let args = ExportArgs {
+            format: ExportFormat::Json,
+            compliance: None,
+            output: None,
+            agent: Some("aa001".to_string()),
+            action: Some("PolicyViolation".to_string()),
+            result: None,
+            since: None,
+            until: None,
+            limit: 500,
+        };
+        let url = build_url(&ctx, &args);
+        assert!(url.contains("agent_id=aa001"));
+        assert!(url.contains("event_type=PolicyViolation"));
+    }
+
+    #[test]
+    fn export_args_as_list_args_preserves_filters() {
+        let args = ExportArgs {
+            format: ExportFormat::Csv,
+            compliance: None,
+            output: None,
+            agent: Some("aa001".to_string()),
+            action: Some("PolicyViolation".to_string()),
+            result: Some(AuditResult::Deny),
+            since: Some("30m".to_string()),
+            until: Some("2026-04-30T12:00:00Z".to_string()),
+            limit: 100,
+        };
+        let list_args = args.as_list_args();
+        assert_eq!(list_args.agent.as_deref(), Some("aa001"));
+        assert_eq!(list_args.action.as_deref(), Some("PolicyViolation"));
+        assert_eq!(list_args.result, Some(AuditResult::Deny));
+        assert_eq!(list_args.since.as_deref(), Some("30m"));
+        assert_eq!(list_args.until.as_deref(), Some("2026-04-30T12:00:00Z"));
+        assert_eq!(list_args.limit, 100);
+    }
 }

--- a/aa-cli/src/commands/audit/export.rs
+++ b/aa-cli/src/commands/audit/export.rs
@@ -1,0 +1,54 @@
+//! `aasm audit export` — export audit data in CSV or JSON format.
+
+use std::process::ExitCode;
+
+use clap::Args;
+
+use super::models::{AuditResult, ComplianceFormat, ExportFormat};
+use crate::config::ResolvedContext;
+
+/// Arguments for `aasm audit export`.
+#[derive(Debug, Args)]
+pub struct ExportArgs {
+    /// Export file format.
+    #[arg(long, value_enum)]
+    pub format: ExportFormat,
+
+    /// Compliance report format (adds metadata headers).
+    #[arg(long, value_enum)]
+    pub compliance: Option<ComplianceFormat>,
+
+    /// Write output to a file instead of stdout.
+    #[arg(long)]
+    pub output: Option<String>,
+
+    /// Filter by agent identifier.
+    #[arg(long)]
+    pub agent: Option<String>,
+
+    /// Filter by action type.
+    #[arg(long)]
+    pub action: Option<String>,
+
+    /// Filter by policy decision result.
+    #[arg(long, value_enum)]
+    pub result: Option<AuditResult>,
+
+    /// Show events after this duration or ISO 8601 timestamp.
+    #[arg(long)]
+    pub since: Option<String>,
+
+    /// Show events before this ISO 8601 timestamp.
+    #[arg(long)]
+    pub until: Option<String>,
+
+    /// Maximum number of entries to fetch.
+    #[arg(long, default_value_t = 1000)]
+    pub limit: u32,
+}
+
+/// Execute `aasm audit export`.
+pub fn run(_args: ExportArgs, _ctx: &ResolvedContext) -> ExitCode {
+    // Implemented in a subsequent commit.
+    ExitCode::SUCCESS
+}

--- a/aa-cli/src/commands/audit/list.rs
+++ b/aa-cli/src/commands/audit/list.rs
@@ -3,8 +3,11 @@
 use std::process::ExitCode;
 
 use clap::Args;
+use colored::Colorize;
+use comfy_table::{ContentArrangement, Table};
 
-use super::models::AuditResult;
+use super::models::{AuditEntry, AuditResult, PaginatedAuditResponse};
+use crate::commands::logs::format::{is_within_time_range, parse_since, parse_until};
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
 
@@ -15,7 +18,7 @@ pub struct ListArgs {
     #[arg(long)]
     pub agent: Option<String>,
 
-    /// Filter by action type (e.g. `tool_call`, `llm_request`).
+    /// Filter by action type (e.g. `ToolCallIntercepted`, `PolicyViolation`).
     #[arg(long)]
     pub action: Option<String>,
 
@@ -36,8 +39,348 @@ pub struct ListArgs {
     pub limit: u32,
 }
 
+/// Build the query URL for `GET /api/v1/logs` with filter parameters.
+fn build_url(ctx: &ResolvedContext, args: &ListArgs) -> String {
+    let mut url = format!("{}/api/v1/logs?per_page={}&page=1", ctx.api_url, args.limit);
+
+    if let Some(ref agent) = args.agent {
+        url.push_str(&format!("&agent_id={agent}"));
+    }
+
+    if let Some(ref action) = args.action {
+        url.push_str(&format!("&event_type={action}"));
+    }
+
+    url
+}
+
+/// Extract a policy result string from the entry's payload JSON.
+///
+/// Looks for a `"result"` key in the payload. Returns `None` if the payload
+/// is not valid JSON or does not contain the key.
+pub fn extract_result(entry: &AuditEntry) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(&entry.payload)
+        .ok()
+        .and_then(|v| v.get("result").and_then(|r| r.as_str()).map(String::from))
+}
+
+/// Extract a tool name from the entry's payload JSON.
+pub fn extract_tool(entry: &AuditEntry) -> String {
+    serde_json::from_str::<serde_json::Value>(&entry.payload)
+        .ok()
+        .and_then(|v| v.get("tool").and_then(|t| t.as_str()).map(String::from))
+        .unwrap_or_else(|| "-".to_string())
+}
+
+/// Extract a policy name from the entry's payload JSON.
+pub fn extract_policy(entry: &AuditEntry) -> String {
+    serde_json::from_str::<serde_json::Value>(&entry.payload)
+        .ok()
+        .and_then(|v| v.get("policy").and_then(|p| p.as_str()).map(String::from))
+        .unwrap_or_else(|| "-".to_string())
+}
+
+/// Check whether an entry matches the `--result` filter.
+fn matches_result_filter(entry: &AuditEntry, filter: &AuditResult) -> bool {
+    match extract_result(entry) {
+        Some(result) => result == filter.as_filter_str(),
+        None => false,
+    }
+}
+
+/// Apply client-side filters (time range and result) to entries.
+pub fn apply_filters(entries: &[AuditEntry], args: &ListArgs) -> Vec<AuditEntry> {
+    let since = args.since.as_deref().and_then(parse_since);
+    let until = args.until.as_deref().and_then(parse_until);
+
+    entries
+        .iter()
+        .filter(|e| is_within_time_range(&e.timestamp, since.as_ref(), until.as_ref()))
+        .filter(|e| {
+            args.result
+                .as_ref()
+                .map_or(true, |r| matches_result_filter(e, r))
+        })
+        .cloned()
+        .collect()
+}
+
+/// Color-code the result string: allow=green, deny=red, pending=yellow.
+fn colorize_result(result: &str) -> String {
+    match result {
+        "allow" => result.green().to_string(),
+        "deny" => result.red().to_string(),
+        "pending" => result.yellow().to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Render audit entries as a table to stdout.
+pub fn render_table(entries: &[AuditEntry]) {
+    if entries.is_empty() {
+        println!("(no audit entries found)");
+        return;
+    }
+
+    let mut table = Table::new();
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+    table.set_header(vec!["TIMESTAMP", "AGENT", "ACTION", "TOOL", "RESULT", "POLICY"]);
+
+    for entry in entries {
+        let result_raw = extract_result(entry).unwrap_or_else(|| "-".to_string());
+        let result_colored = colorize_result(&result_raw);
+        let tool = extract_tool(entry);
+        let policy = extract_policy(entry);
+
+        table.add_row(vec![
+            &entry.timestamp,
+            &entry.agent_id,
+            &entry.event_type,
+            &tool,
+            &result_colored,
+            &policy,
+        ]);
+    }
+    println!("{table}");
+}
+
+/// Render audit entries as JSON to stdout.
+fn render_json(entries: &[AuditEntry]) {
+    match serde_json::to_string_pretty(entries) {
+        Ok(json) => println!("{json}"),
+        Err(e) => eprintln!("error serializing audit entries to JSON: {e}"),
+    }
+}
+
+/// Render audit entries as YAML to stdout.
+fn render_yaml(entries: &[AuditEntry]) {
+    match serde_yaml::to_string(entries) {
+        Ok(yaml) => print!("{yaml}"),
+        Err(e) => eprintln!("error serializing audit entries to YAML: {e}"),
+    }
+}
+
 /// Execute `aasm audit list`.
-pub fn run(_args: ListArgs, _ctx: &ResolvedContext, _output: OutputFormat) -> ExitCode {
-    // Implemented in a subsequent commit.
+pub fn run(args: ListArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    let url = build_url(ctx, &args);
+
+    let response = match reqwest::blocking::get(&url) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("error: failed to connect to {}: {e}", ctx.api_url);
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if !response.status().is_success() {
+        eprintln!("error: API returned status {}", response.status());
+        return ExitCode::FAILURE;
+    }
+
+    let paginated: PaginatedAuditResponse = match response.json() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("error: failed to parse API response: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let filtered = apply_filters(&paginated.items, &args);
+
+    match output {
+        OutputFormat::Table => render_table(&filtered),
+        OutputFormat::Json => render_json(&filtered),
+        OutputFormat::Yaml => render_yaml(&filtered),
+    }
+
     ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_entry(event_type: &str, payload: &str) -> AuditEntry {
+        AuditEntry {
+            seq: 0,
+            timestamp: "2026-04-30T10:00:00Z".to_string(),
+            agent_id: "aa001".to_string(),
+            session_id: "sess001".to_string(),
+            event_type: event_type.to_string(),
+            payload: payload.to_string(),
+        }
+    }
+
+    #[test]
+    fn extract_result_from_valid_payload() {
+        let entry = sample_entry("PolicyViolation", r#"{"result":"deny","tool":"bash"}"#);
+        assert_eq!(extract_result(&entry).as_deref(), Some("deny"));
+    }
+
+    #[test]
+    fn extract_result_missing_key() {
+        let entry = sample_entry("ToolCallIntercepted", r#"{"tool":"bash"}"#);
+        assert_eq!(extract_result(&entry), None);
+    }
+
+    #[test]
+    fn extract_result_invalid_json() {
+        let entry = sample_entry("ToolCallIntercepted", "not json");
+        assert_eq!(extract_result(&entry), None);
+    }
+
+    #[test]
+    fn extract_tool_from_payload() {
+        let entry = sample_entry("ToolCallIntercepted", r#"{"tool":"bash","result":"allow"}"#);
+        assert_eq!(extract_tool(&entry), "bash");
+    }
+
+    #[test]
+    fn extract_tool_missing_returns_dash() {
+        let entry = sample_entry("ToolCallIntercepted", r#"{"result":"allow"}"#);
+        assert_eq!(extract_tool(&entry), "-");
+    }
+
+    #[test]
+    fn extract_policy_from_payload() {
+        let entry = sample_entry("PolicyViolation", r#"{"policy":"deny-rm","result":"deny"}"#);
+        assert_eq!(extract_policy(&entry), "deny-rm");
+    }
+
+    #[test]
+    fn extract_policy_missing_returns_dash() {
+        let entry = sample_entry("PolicyViolation", r#"{"result":"deny"}"#);
+        assert_eq!(extract_policy(&entry), "-");
+    }
+
+    #[test]
+    fn matches_result_filter_allow() {
+        let entry = sample_entry("ToolCallIntercepted", r#"{"result":"allow"}"#);
+        assert!(matches_result_filter(&entry, &AuditResult::Allow));
+        assert!(!matches_result_filter(&entry, &AuditResult::Deny));
+    }
+
+    #[test]
+    fn matches_result_filter_deny() {
+        let entry = sample_entry("PolicyViolation", r#"{"result":"deny"}"#);
+        assert!(matches_result_filter(&entry, &AuditResult::Deny));
+        assert!(!matches_result_filter(&entry, &AuditResult::Allow));
+    }
+
+    #[test]
+    fn matches_result_filter_no_result_in_payload() {
+        let entry = sample_entry("BudgetLimitApproached", "{}");
+        assert!(!matches_result_filter(&entry, &AuditResult::Allow));
+    }
+
+    #[test]
+    fn apply_filters_no_filters() {
+        let entries = vec![
+            sample_entry("ToolCallIntercepted", r#"{"result":"allow"}"#),
+            sample_entry("PolicyViolation", r#"{"result":"deny"}"#),
+        ];
+        let args = ListArgs {
+            agent: None,
+            action: None,
+            result: None,
+            since: None,
+            until: None,
+            limit: 50,
+        };
+        let filtered = apply_filters(&entries, &args);
+        assert_eq!(filtered.len(), 2);
+    }
+
+    #[test]
+    fn apply_filters_by_result() {
+        let entries = vec![
+            sample_entry("ToolCallIntercepted", r#"{"result":"allow"}"#),
+            sample_entry("PolicyViolation", r#"{"result":"deny"}"#),
+            sample_entry("ApprovalRequested", r#"{"result":"pending"}"#),
+        ];
+        let args = ListArgs {
+            agent: None,
+            action: None,
+            result: Some(AuditResult::Deny),
+            since: None,
+            until: None,
+            limit: 50,
+        };
+        let filtered = apply_filters(&entries, &args);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].event_type, "PolicyViolation");
+    }
+
+    #[test]
+    fn apply_filters_by_time_range() {
+        let mut e1 = sample_entry("ToolCallIntercepted", r#"{"result":"allow"}"#);
+        e1.timestamp = "2026-04-30T08:00:00Z".to_string();
+        let mut e2 = sample_entry("PolicyViolation", r#"{"result":"deny"}"#);
+        e2.timestamp = "2026-04-30T12:00:00Z".to_string();
+
+        let entries = vec![e1, e2];
+        let args = ListArgs {
+            agent: None,
+            action: None,
+            result: None,
+            since: Some("2026-04-30T10:00:00Z".to_string()),
+            until: None,
+            limit: 50,
+        };
+        let filtered = apply_filters(&entries, &args);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].timestamp, "2026-04-30T12:00:00Z");
+    }
+
+    #[test]
+    fn build_url_no_filters() {
+        let ctx = ResolvedContext {
+            name: None,
+            api_url: "http://localhost:8080".to_string(),
+            api_key: None,
+        };
+        let args = ListArgs {
+            agent: None,
+            action: None,
+            result: None,
+            since: None,
+            until: None,
+            limit: 50,
+        };
+        let url = build_url(&ctx, &args);
+        assert_eq!(url, "http://localhost:8080/api/v1/logs?per_page=50&page=1");
+    }
+
+    #[test]
+    fn build_url_with_agent_and_action() {
+        let ctx = ResolvedContext {
+            name: None,
+            api_url: "http://localhost:8080".to_string(),
+            api_key: None,
+        };
+        let args = ListArgs {
+            agent: Some("aa001".to_string()),
+            action: Some("PolicyViolation".to_string()),
+            result: None,
+            since: None,
+            until: None,
+            limit: 25,
+        };
+        let url = build_url(&ctx, &args);
+        assert!(url.contains("agent_id=aa001"));
+        assert!(url.contains("event_type=PolicyViolation"));
+        assert!(url.contains("per_page=25"));
+    }
+
+    #[test]
+    fn colorize_result_colors() {
+        let allow = colorize_result("allow");
+        assert!(allow.contains("allow"));
+        let deny = colorize_result("deny");
+        assert!(deny.contains("deny"));
+        let pending = colorize_result("pending");
+        assert!(pending.contains("pending"));
+        let unknown = colorize_result("other");
+        assert_eq!(unknown, "other");
+    }
 }

--- a/aa-cli/src/commands/audit/list.rs
+++ b/aa-cli/src/commands/audit/list.rs
@@ -96,11 +96,7 @@ pub fn apply_filters(entries: &[AuditEntry], args: &ListArgs) -> Vec<AuditEntry>
     entries
         .iter()
         .filter(|e| is_within_time_range(&e.timestamp, since.as_ref(), until.as_ref()))
-        .filter(|e| {
-            args.result
-                .as_ref()
-                .map_or(true, |r| matches_result_filter(e, r))
-        })
+        .filter(|e| args.result.as_ref().map_or(true, |r| matches_result_filter(e, r)))
         .cloned()
         .collect()
 }

--- a/aa-cli/src/commands/audit/list.rs
+++ b/aa-cli/src/commands/audit/list.rs
@@ -1,0 +1,43 @@
+//! `aasm audit list` — query and display audit log entries.
+
+use std::process::ExitCode;
+
+use clap::Args;
+
+use super::models::AuditResult;
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
+
+/// Arguments for `aasm audit list`.
+#[derive(Debug, Args)]
+pub struct ListArgs {
+    /// Filter by agent identifier.
+    #[arg(long)]
+    pub agent: Option<String>,
+
+    /// Filter by action type (e.g. `tool_call`, `llm_request`).
+    #[arg(long)]
+    pub action: Option<String>,
+
+    /// Filter by policy decision result.
+    #[arg(long, value_enum)]
+    pub result: Option<AuditResult>,
+
+    /// Show events after this duration or ISO 8601 timestamp (e.g. `30m`, `2h`, `2026-04-30T10:00:00Z`).
+    #[arg(long)]
+    pub since: Option<String>,
+
+    /// Show events before this ISO 8601 timestamp.
+    #[arg(long)]
+    pub until: Option<String>,
+
+    /// Maximum number of entries to return.
+    #[arg(long, default_value_t = 50)]
+    pub limit: u32,
+}
+
+/// Execute `aasm audit list`.
+pub fn run(_args: ListArgs, _ctx: &ResolvedContext, _output: OutputFormat) -> ExitCode {
+    // Implemented in a subsequent commit.
+    ExitCode::SUCCESS
+}

--- a/aa-cli/src/commands/audit/mod.rs
+++ b/aa-cli/src/commands/audit/mod.rs
@@ -1,3 +1,36 @@
 //! `aasm audit` — audit log query and compliance export.
 
+use std::process::ExitCode;
+
+use clap::{Args, Subcommand};
+
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
+
+pub mod export;
+pub mod list;
 pub mod models;
+
+/// Arguments for the `aasm audit` subcommand group.
+#[derive(Debug, Args)]
+pub struct AuditArgs {
+    #[command(subcommand)]
+    pub command: AuditCommands,
+}
+
+/// Available audit subcommands.
+#[derive(Debug, Subcommand)]
+pub enum AuditCommands {
+    /// Query audit log entries with optional filters.
+    List(list::ListArgs),
+    /// Export audit data in CSV or JSON format.
+    Export(export::ExportArgs),
+}
+
+/// Dispatch an audit subcommand.
+pub fn dispatch(args: AuditArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    match args.command {
+        AuditCommands::List(list_args) => list::run(list_args, ctx, output),
+        AuditCommands::Export(export_args) => export::run(export_args, ctx),
+    }
+}

--- a/aa-cli/src/commands/audit/mod.rs
+++ b/aa-cli/src/commands/audit/mod.rs
@@ -1,0 +1,3 @@
+//! `aasm audit` — audit log query and compliance export.
+
+pub mod models;

--- a/aa-cli/src/commands/audit/models.rs
+++ b/aa-cli/src/commands/audit/models.rs
@@ -1,0 +1,90 @@
+//! Data models for the `aasm audit` command.
+
+use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
+
+/// A single audit log entry as returned by `GET /api/v1/logs`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AuditEntry {
+    /// Monotonic sequence number within the session.
+    pub seq: u64,
+    /// ISO 8601 timestamp of the event.
+    pub timestamp: String,
+    /// Hex-encoded agent ID.
+    pub agent_id: String,
+    /// Hex-encoded session ID.
+    pub session_id: String,
+    /// Audit event type (e.g. `ToolCallIntercepted`, `PolicyViolation`).
+    pub event_type: String,
+    /// Pre-serialized JSON payload.
+    pub payload: String,
+}
+
+/// Paginated response envelope from `GET /api/v1/logs`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PaginatedAuditResponse {
+    pub items: Vec<AuditEntry>,
+    pub page: u32,
+    pub per_page: u32,
+    pub total: u64,
+}
+
+/// Export file format for `aasm audit export`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ExportFormat {
+    /// Comma-separated values.
+    Csv,
+    /// JSON array.
+    Json,
+}
+
+/// Compliance report format for `aasm audit export --compliance`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ComplianceFormat {
+    /// EU AI Act compliance metadata.
+    #[value(name = "eu-ai-act")]
+    EuAiAct,
+    /// SOC 2 compliance metadata.
+    #[value(name = "soc2")]
+    Soc2,
+}
+
+/// Policy decision result for the `--result` filter.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum AuditResult {
+    /// Action was allowed by policy.
+    Allow,
+    /// Action was denied by policy.
+    Deny,
+    /// Action is pending human approval.
+    Pending,
+}
+
+impl AuditResult {
+    /// Return the string representation used for matching against event types.
+    pub fn as_filter_str(&self) -> &'static str {
+        match self {
+            Self::Allow => "allow",
+            Self::Deny => "deny",
+            Self::Pending => "pending",
+        }
+    }
+}
+
+impl std::fmt::Display for ExportFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Csv => f.write_str("csv"),
+            Self::Json => f.write_str("json"),
+        }
+    }
+}
+
+impl std::fmt::Display for ComplianceFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EuAiAct => f.write_str("eu-ai-act"),
+            Self::Soc2 => f.write_str("soc2"),
+        }
+    }
+}

--- a/aa-cli/src/commands/audit/models.rs
+++ b/aa-cli/src/commands/audit/models.rs
@@ -88,3 +88,102 @@ impl std::fmt::Display for ComplianceFormat {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn audit_entry_deserializes() {
+        let json = r#"{
+            "seq": 42,
+            "timestamp": "2026-04-30T10:00:00Z",
+            "agent_id": "aa001",
+            "session_id": "sess001",
+            "event_type": "PolicyViolation",
+            "payload": "{\"tool\":\"bash\",\"result\":\"deny\"}"
+        }"#;
+        let entry: AuditEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.seq, 42);
+        assert_eq!(entry.timestamp, "2026-04-30T10:00:00Z");
+        assert_eq!(entry.agent_id, "aa001");
+        assert_eq!(entry.session_id, "sess001");
+        assert_eq!(entry.event_type, "PolicyViolation");
+        assert!(entry.payload.contains("deny"));
+    }
+
+    #[test]
+    fn paginated_audit_response_deserializes() {
+        let json = r#"{
+            "items": [{
+                "seq": 0,
+                "timestamp": "2026-04-30T10:00:00Z",
+                "agent_id": "aa001",
+                "session_id": "sess001",
+                "event_type": "ToolCallIntercepted",
+                "payload": "{}"
+            }],
+            "page": 1,
+            "per_page": 50,
+            "total": 1
+        }"#;
+        let resp: PaginatedAuditResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.items.len(), 1);
+        assert_eq!(resp.page, 1);
+        assert_eq!(resp.per_page, 50);
+        assert_eq!(resp.total, 1);
+    }
+
+    #[test]
+    fn audit_result_as_filter_str() {
+        assert_eq!(AuditResult::Allow.as_filter_str(), "allow");
+        assert_eq!(AuditResult::Deny.as_filter_str(), "deny");
+        assert_eq!(AuditResult::Pending.as_filter_str(), "pending");
+    }
+
+    #[test]
+    fn audit_result_value_variants_contains_all() {
+        let variants = AuditResult::value_variants();
+        assert_eq!(variants.len(), 3);
+    }
+
+    #[test]
+    fn export_format_display() {
+        assert_eq!(ExportFormat::Csv.to_string(), "csv");
+        assert_eq!(ExportFormat::Json.to_string(), "json");
+    }
+
+    #[test]
+    fn export_format_value_variants_contains_all() {
+        let variants = ExportFormat::value_variants();
+        assert_eq!(variants.len(), 2);
+    }
+
+    #[test]
+    fn compliance_format_display() {
+        assert_eq!(ComplianceFormat::EuAiAct.to_string(), "eu-ai-act");
+        assert_eq!(ComplianceFormat::Soc2.to_string(), "soc2");
+    }
+
+    #[test]
+    fn compliance_format_value_variants_contains_all() {
+        let variants = ComplianceFormat::value_variants();
+        assert_eq!(variants.len(), 2);
+    }
+
+    #[test]
+    fn audit_entry_round_trip_serialization() {
+        let entry = AuditEntry {
+            seq: 1,
+            timestamp: "2026-04-30T10:00:00Z".to_string(),
+            agent_id: "aa001".to_string(),
+            session_id: "sess001".to_string(),
+            event_type: "ToolCallIntercepted".to_string(),
+            payload: "{}".to_string(),
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        let parsed: AuditEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.seq, entry.seq);
+        assert_eq!(parsed.agent_id, entry.agent_id);
+    }
+}

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -9,6 +9,7 @@ use crate::output::OutputFormat;
 
 pub mod agent;
 pub mod approvals;
+pub mod audit;
 pub mod completion;
 pub mod context;
 pub mod cost;
@@ -24,6 +25,8 @@ pub mod version;
 pub enum Commands {
     /// Manage monitored agent processes.
     Agent(agent::AgentArgs),
+    /// Query audit log entries and export compliance reports.
+    Audit(audit::AuditArgs),
     /// Query and stream audit log events.
     Logs(logs::LogsArgs),
     /// Manage governance policies.
@@ -50,6 +53,7 @@ pub enum Commands {
 pub fn dispatch(cmd: Commands, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
     match cmd {
         Commands::Agent(args) => agent::dispatch(args, ctx, output),
+        Commands::Audit(args) => audit::dispatch(args, ctx, output),
         Commands::Logs(args) => logs::dispatch(args, ctx),
         Commands::Policy(args) => policy::dispatch(args, ctx),
         Commands::Context(args) => context::dispatch(args),

--- a/aa-cli/tests/audit_list_export.rs
+++ b/aa-cli/tests/audit_list_export.rs
@@ -204,8 +204,7 @@ async fn audit_export_json_to_file_creates_output() {
 
     // Verify the file contains valid JSON.
     let contents = std::fs::read_to_string(tmp.path()).unwrap();
-    let entries: Vec<aa_cli::commands::audit::models::AuditEntry> =
-        serde_json::from_str(&contents).unwrap();
+    let entries: Vec<aa_cli::commands::audit::models::AuditEntry> = serde_json::from_str(&contents).unwrap();
     assert_eq!(entries.len(), 2);
 }
 

--- a/aa-cli/tests/audit_list_export.rs
+++ b/aa-cli/tests/audit_list_export.rs
@@ -1,0 +1,250 @@
+//! Integration tests for `aasm audit list` and `aasm audit export` via mock HTTP server.
+
+use std::process::ExitCode;
+
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn make_context(api_url: &str) -> aa_cli::config::ResolvedContext {
+    aa_cli::config::ResolvedContext {
+        name: None,
+        api_url: api_url.to_string(),
+        api_key: None,
+    }
+}
+
+fn sample_response() -> serde_json::Value {
+    serde_json::json!({
+        "items": [
+            {
+                "seq": 0,
+                "timestamp": "2026-04-30T10:00:00Z",
+                "agent_id": "aa001",
+                "session_id": "sess001",
+                "event_type": "ToolCallIntercepted",
+                "payload": "{\"tool\":\"bash\",\"result\":\"allow\",\"policy\":\"default\"}"
+            },
+            {
+                "seq": 1,
+                "timestamp": "2026-04-30T10:01:00Z",
+                "agent_id": "aa002",
+                "session_id": "sess002",
+                "event_type": "PolicyViolation",
+                "payload": "{\"tool\":\"rm\",\"result\":\"deny\",\"policy\":\"deny-rm\"}"
+            }
+        ],
+        "page": 1,
+        "per_page": 50,
+        "total": 2
+    })
+}
+
+#[tokio::test]
+async fn audit_list_returns_success_with_mock_data() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/logs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sample_response()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+
+    let result = std::thread::spawn(move || {
+        let args = aa_cli::commands::audit::list::ListArgs {
+            agent: None,
+            action: None,
+            result: None,
+            since: None,
+            until: None,
+            limit: 50,
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::audit::list::run(args, &ctx, aa_cli::output::OutputFormat::Table)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+}
+
+#[tokio::test]
+async fn audit_list_with_agent_filter_sends_query_param() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/logs"))
+        .and(query_param("agent_id", "aa001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sample_response()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+
+    let result = std::thread::spawn(move || {
+        let args = aa_cli::commands::audit::list::ListArgs {
+            agent: Some("aa001".to_string()),
+            action: None,
+            result: None,
+            since: None,
+            until: None,
+            limit: 50,
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::audit::list::run(args, &ctx, aa_cli::output::OutputFormat::Json)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+}
+
+#[tokio::test]
+async fn audit_list_fails_on_server_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/logs"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+
+    let result = std::thread::spawn(move || {
+        let args = aa_cli::commands::audit::list::ListArgs {
+            agent: None,
+            action: None,
+            result: None,
+            since: None,
+            until: None,
+            limit: 50,
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::audit::list::run(args, &ctx, aa_cli::output::OutputFormat::Table)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::FAILURE);
+}
+
+#[tokio::test]
+async fn audit_export_csv_returns_success() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/logs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sample_response()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+
+    let result = std::thread::spawn(move || {
+        let args = aa_cli::commands::audit::export::ExportArgs {
+            format: aa_cli::commands::audit::models::ExportFormat::Csv,
+            compliance: None,
+            output: None,
+            agent: None,
+            action: None,
+            result: None,
+            since: None,
+            until: None,
+            limit: 1000,
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::audit::export::run(args, &ctx)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+}
+
+#[tokio::test]
+async fn audit_export_json_to_file_creates_output() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/logs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sample_response()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let tmp_path = tmp.path().to_string_lossy().to_string();
+
+    let result = std::thread::spawn(move || {
+        let args = aa_cli::commands::audit::export::ExportArgs {
+            format: aa_cli::commands::audit::models::ExportFormat::Json,
+            compliance: None,
+            output: Some(tmp_path),
+            agent: None,
+            action: None,
+            result: None,
+            since: None,
+            until: None,
+            limit: 1000,
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::audit::export::run(args, &ctx)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+
+    // Verify the file contains valid JSON.
+    let contents = std::fs::read_to_string(tmp.path()).unwrap();
+    let entries: Vec<aa_cli::commands::audit::models::AuditEntry> =
+        serde_json::from_str(&contents).unwrap();
+    assert_eq!(entries.len(), 2);
+}
+
+#[tokio::test]
+async fn audit_export_csv_with_compliance_header() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/logs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sample_response()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    let tmp_path = tmp.path().to_string_lossy().to_string();
+
+    let result = std::thread::spawn(move || {
+        let args = aa_cli::commands::audit::export::ExportArgs {
+            format: aa_cli::commands::audit::models::ExportFormat::Csv,
+            compliance: Some(aa_cli::commands::audit::models::ComplianceFormat::EuAiAct),
+            output: Some(tmp_path),
+            agent: None,
+            action: None,
+            result: None,
+            since: None,
+            until: None,
+            limit: 1000,
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::audit::export::run(args, &ctx)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+
+    let contents = std::fs::read_to_string(tmp.path()).unwrap();
+    assert!(contents.contains("EU AI Act"));
+    assert!(contents.contains("timestamp,agent_id"));
+}


### PR DESCRIPTION
## Description

Implements the `aasm audit list` and `aasm audit export` subcommands for querying and exporting audit log entries from the Agent Assembly gateway.

- **`audit list`**: Fetches audit entries from `GET /api/v1/logs` with `--agent`, `--action`, `--result`, `--since`, `--until`, and `--limit` filters. Renders as table (with color-coded results), JSON, or YAML.
- **`audit export`**: Exports filtered audit data as CSV or JSON, optionally to a file. Supports `--compliance` flag for EU AI Act and SOC 2 metadata headers.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-185
- Related GitHub issues: N/A

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated (35 unit tests across models, list, and export modules)
- [x] Integration tests added / updated (6 integration tests using wiremock mock HTTP server)
- [x] Manual testing performed (cargo fmt, cargo clippy, full test suite green)
- [ ] No tests required (explain why)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention