### PR TITLE
[AAASM-186] ✨ (alerts): Add alerts subcommand group with list, get, and resolve

### DIFF
--- a/aa-cli/src/client.rs
+++ b/aa-cli/src/client.rs
@@ -60,6 +60,28 @@ pub async fn post_empty<T: DeserializeOwned>(ctx: &ResolvedContext, path: &str) 
     Ok(result)
 }
 
+/// Perform a POST request to the gateway with an optional JSON body and deserialize the response.
+pub async fn post_opt_json<B: Serialize, T: DeserializeOwned>(
+    ctx: &ResolvedContext,
+    path: &str,
+    body: Option<&B>,
+) -> Result<T, CliError> {
+    let url = format!("{}{path}", ctx.api_url);
+    let client = build_client();
+
+    let mut req = match body {
+        Some(b) => client.post(&url).json(b),
+        None => client.post(&url),
+    };
+    if let Some(ref key) = ctx.api_key {
+        req = req.bearer_auth(key);
+    }
+
+    let resp = req.send().await?.error_for_status()?;
+    let result = resp.json::<T>().await?;
+    Ok(result)
+}
+
 /// Perform a DELETE request to the gateway.
 pub async fn delete(ctx: &ResolvedContext, path: &str) -> Result<(), CliError> {
     let url = format!("{}{path}", ctx.api_url);

--- a/aa-cli/src/commands/alerts/get.rs
+++ b/aa-cli/src/commands/alerts/get.rs
@@ -3,7 +3,10 @@
 use std::process::ExitCode;
 
 use clap::Args;
+use comfy_table::{Cell, Table};
 
+use super::models::{AlertResponse, AlertSeverity, AlertStatusKind};
+use crate::client;
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
 
@@ -14,7 +17,117 @@ pub struct GetArgs {
     pub alert_id: String,
 }
 
+/// Render a detailed key-value view of an alert.
+pub fn render_detail(alert: &AlertResponse) {
+    let mut table = Table::new();
+    table.set_header(vec!["Field", "Value"]);
+
+    table.add_row(vec!["ID", &alert.id]);
+
+    let agent = alert.agent_id.as_deref().unwrap_or("-");
+    table.add_row(vec!["Agent", agent]);
+
+    let sev = AlertSeverity::from_str(&alert.severity);
+    table.add_row(vec![
+        Cell::new("Severity"),
+        Cell::new(&alert.severity).fg(sev.color()),
+    ]);
+
+    table.add_row(vec!["Type", &alert.category]);
+    table.add_row(vec!["Message", &alert.message]);
+
+    let status = AlertStatusKind::from_str(&alert.status);
+    table.add_row(vec![
+        Cell::new("Status"),
+        Cell::new(&alert.status).fg(status.color()),
+    ]);
+
+    table.add_row(vec!["Created", &alert.created_at]);
+
+    let updated = alert.updated_at.as_deref().unwrap_or("-");
+    table.add_row(vec!["Updated", updated]);
+
+    if let Some(ref ctx) = alert.context {
+        let ctx_str = serde_json::to_string_pretty(ctx).unwrap_or_else(|_| ctx.to_string());
+        table.add_row(vec!["Context".to_string(), ctx_str]);
+    }
+
+    println!("{table}");
+}
+
 /// Run the `aasm alerts get` command.
-pub fn run(_args: GetArgs, _ctx: &ResolvedContext, _output: OutputFormat) -> ExitCode {
-    todo!()
+pub fn run(args: GetArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+
+    let path = format!("/api/v1/alerts/{}", args.alert_id);
+    let alert: AlertResponse = match rt.block_on(client::get_json(ctx, &path)) {
+        Ok(a) => a,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    match output {
+        OutputFormat::Table => render_detail(&alert),
+        OutputFormat::Json => match serde_json::to_string_pretty(&alert) {
+            Ok(json) => println!("{json}"),
+            Err(e) => eprintln!("error serializing JSON: {e}"),
+        },
+        OutputFormat::Yaml => match serde_yaml::to_string(&alert) {
+            Ok(yaml) => print!("{yaml}"),
+            Err(e) => eprintln!("error serializing YAML: {e}"),
+        },
+    }
+
+    ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_alert() -> AlertResponse {
+        AlertResponse {
+            id: "alert-001".to_string(),
+            agent_id: Some("agent-abc".to_string()),
+            severity: "critical".to_string(),
+            category: "budget".to_string(),
+            message: "Budget exceeded".to_string(),
+            status: "unresolved".to_string(),
+            created_at: "2026-04-30T10:00:00Z".to_string(),
+            updated_at: Some("2026-04-30T11:00:00Z".to_string()),
+            context: Some(serde_json::json!({"tool": "shell_exec", "amount": 500})),
+        }
+    }
+
+    #[test]
+    fn render_detail_does_not_panic() {
+        render_detail(&sample_alert());
+    }
+
+    #[test]
+    fn render_detail_without_optional_fields() {
+        let alert = AlertResponse {
+            id: "alert-002".to_string(),
+            agent_id: None,
+            severity: "info".to_string(),
+            category: "policy_violation".to_string(),
+            message: "Minor issue".to_string(),
+            status: "resolved".to_string(),
+            created_at: "2026-04-30T08:00:00Z".to_string(),
+            updated_at: None,
+            context: None,
+        };
+        render_detail(&alert);
+    }
+
+    #[test]
+    fn json_output_is_valid() {
+        let alert = sample_alert();
+        let json = serde_json::to_string_pretty(&alert).unwrap();
+        let parsed: AlertResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.id, "alert-001");
+        assert_eq!(parsed.context.unwrap()["tool"], "shell_exec");
+    }
 }

--- a/aa-cli/src/commands/alerts/get.rs
+++ b/aa-cli/src/commands/alerts/get.rs
@@ -1,0 +1,20 @@
+//! `aasm alerts get` — show full alert detail.
+
+use std::process::ExitCode;
+
+use clap::Args;
+
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
+
+/// Arguments for `aasm alerts get`.
+#[derive(Args)]
+pub struct GetArgs {
+    /// Alert ID to inspect.
+    pub alert_id: String,
+}
+
+/// Run the `aasm alerts get` command.
+pub fn run(_args: GetArgs, _ctx: &ResolvedContext, _output: OutputFormat) -> ExitCode {
+    todo!()
+}

--- a/aa-cli/src/commands/alerts/get.rs
+++ b/aa-cli/src/commands/alerts/get.rs
@@ -27,7 +27,7 @@ pub fn render_detail(alert: &AlertResponse) {
     let agent = alert.agent_id.as_deref().unwrap_or("-");
     table.add_row(vec!["Agent", agent]);
 
-    let sev = AlertSeverity::from_str(&alert.severity);
+    let sev = AlertSeverity::parse(&alert.severity);
     table.add_row(vec![
         Cell::new("Severity"),
         Cell::new(&alert.severity).fg(sev.color()),
@@ -36,7 +36,7 @@ pub fn render_detail(alert: &AlertResponse) {
     table.add_row(vec!["Type", &alert.category]);
     table.add_row(vec!["Message", &alert.message]);
 
-    let status = AlertStatusKind::from_str(&alert.status);
+    let status = AlertStatusKind::parse(&alert.status);
     table.add_row(vec![
         Cell::new("Status"),
         Cell::new(&alert.status).fg(status.color()),

--- a/aa-cli/src/commands/alerts/get.rs
+++ b/aa-cli/src/commands/alerts/get.rs
@@ -28,19 +28,13 @@ pub fn render_detail(alert: &AlertResponse) {
     table.add_row(vec!["Agent", agent]);
 
     let sev = AlertSeverity::parse(&alert.severity);
-    table.add_row(vec![
-        Cell::new("Severity"),
-        Cell::new(&alert.severity).fg(sev.color()),
-    ]);
+    table.add_row(vec![Cell::new("Severity"), Cell::new(&alert.severity).fg(sev.color())]);
 
     table.add_row(vec!["Type", &alert.category]);
     table.add_row(vec!["Message", &alert.message]);
 
     let status = AlertStatusKind::parse(&alert.status);
-    table.add_row(vec![
-        Cell::new("Status"),
-        Cell::new(&alert.status).fg(status.color()),
-    ]);
+    table.add_row(vec![Cell::new("Status"), Cell::new(&alert.status).fg(status.color())]);
 
     table.add_row(vec!["Created", &alert.created_at]);
 

--- a/aa-cli/src/commands/alerts/list.rs
+++ b/aa-cli/src/commands/alerts/list.rs
@@ -63,7 +63,13 @@ pub fn apply_filters(alerts: Vec<AlertResponse>, args: &ListArgs) -> Vec<AlertRe
 pub fn render_table(alerts: &[AlertResponse]) {
     let mut table = Table::new();
     table.set_header(vec![
-        "ID", "AGENT", "SEVERITY", "TYPE", "MESSAGE", "STATUS", "CREATED_AT",
+        "ID",
+        "AGENT",
+        "SEVERITY",
+        "TYPE",
+        "MESSAGE",
+        "STATUS",
+        "CREATED_AT",
     ]);
 
     for alert in alerts {

--- a/aa-cli/src/commands/alerts/list.rs
+++ b/aa-cli/src/commands/alerts/list.rs
@@ -68,8 +68,8 @@ pub fn render_table(alerts: &[AlertResponse]) {
 
     for alert in alerts {
         let agent = alert.agent_id.as_deref().unwrap_or("-");
-        let sev = AlertSeverity::from_str(&alert.severity);
-        let status = AlertStatusKind::from_str(&alert.status);
+        let sev = AlertSeverity::parse(&alert.severity);
+        let status = AlertStatusKind::parse(&alert.status);
 
         table.add_row(vec![
             Cell::new(&alert.id),

--- a/aa-cli/src/commands/alerts/list.rs
+++ b/aa-cli/src/commands/alerts/list.rs
@@ -3,7 +3,11 @@
 use std::process::ExitCode;
 
 use clap::Args;
+use comfy_table::{Cell, Table};
 
+use super::models::{AlertResponse, AlertSeverity, AlertStatusKind};
+use crate::client;
+use crate::commands::agent::PaginatedResponse;
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
 
@@ -23,7 +27,216 @@ pub struct ListArgs {
     pub status: Option<String>,
 }
 
+/// Fetch alerts from the gateway API.
+async fn fetch_alerts(ctx: &ResolvedContext) -> Result<Vec<AlertResponse>, crate::error::CliError> {
+    let resp: PaginatedResponse<AlertResponse> = client::get_json(ctx, "/api/v1/alerts").await?;
+    Ok(resp.items)
+}
+
+/// Apply client-side filters for --agent, --severity, --status.
+pub fn apply_filters(alerts: Vec<AlertResponse>, args: &ListArgs) -> Vec<AlertResponse> {
+    alerts
+        .into_iter()
+        .filter(|a| {
+            if let Some(ref agent) = args.agent {
+                match &a.agent_id {
+                    Some(id) if id.eq_ignore_ascii_case(agent) => {}
+                    _ => return false,
+                }
+            }
+            if let Some(ref sev) = args.severity {
+                if !a.severity.eq_ignore_ascii_case(sev) {
+                    return false;
+                }
+            }
+            if let Some(ref status) = args.status {
+                if !a.status.eq_ignore_ascii_case(status) {
+                    return false;
+                }
+            }
+            true
+        })
+        .collect()
+}
+
+/// Render alerts as a color-coded table.
+pub fn render_table(alerts: &[AlertResponse]) {
+    let mut table = Table::new();
+    table.set_header(vec![
+        "ID", "AGENT", "SEVERITY", "TYPE", "MESSAGE", "STATUS", "CREATED_AT",
+    ]);
+
+    for alert in alerts {
+        let agent = alert.agent_id.as_deref().unwrap_or("-");
+        let sev = AlertSeverity::from_str(&alert.severity);
+        let status = AlertStatusKind::from_str(&alert.status);
+
+        table.add_row(vec![
+            Cell::new(&alert.id),
+            Cell::new(agent),
+            Cell::new(&alert.severity).fg(sev.color()),
+            Cell::new(&alert.category),
+            Cell::new(&alert.message),
+            Cell::new(&alert.status).fg(status.color()),
+            Cell::new(&alert.created_at),
+        ]);
+    }
+
+    println!("{table}");
+}
+
 /// Run the `aasm alerts list` command.
-pub fn run(_args: ListArgs, _ctx: &ResolvedContext, _output: OutputFormat) -> ExitCode {
-    todo!()
+pub fn run(args: ListArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+
+    let alerts = match rt.block_on(fetch_alerts(ctx)) {
+        Ok(a) => apply_filters(a, &args),
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if alerts.is_empty() {
+        println!("No alerts found.");
+    } else {
+        match output {
+            OutputFormat::Table => render_table(&alerts),
+            OutputFormat::Json => match serde_json::to_string_pretty(&alerts) {
+                Ok(json) => println!("{json}"),
+                Err(e) => eprintln!("error serializing JSON: {e}"),
+            },
+            OutputFormat::Yaml => match serde_yaml::to_string(&alerts) {
+                Ok(yaml) => print!("{yaml}"),
+                Err(e) => eprintln!("error serializing YAML: {e}"),
+            },
+        }
+    }
+
+    ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_alerts() -> Vec<AlertResponse> {
+        vec![
+            AlertResponse {
+                id: "alert-001".to_string(),
+                agent_id: Some("agent-abc".to_string()),
+                severity: "critical".to_string(),
+                category: "budget".to_string(),
+                message: "Budget exceeded".to_string(),
+                status: "unresolved".to_string(),
+                created_at: "2026-04-30T10:00:00Z".to_string(),
+                updated_at: None,
+                context: None,
+            },
+            AlertResponse {
+                id: "alert-002".to_string(),
+                agent_id: Some("agent-def".to_string()),
+                severity: "warning".to_string(),
+                category: "anomaly".to_string(),
+                message: "Unusual activity".to_string(),
+                status: "acknowledged".to_string(),
+                created_at: "2026-04-30T09:00:00Z".to_string(),
+                updated_at: None,
+                context: None,
+            },
+            AlertResponse {
+                id: "alert-003".to_string(),
+                agent_id: None,
+                severity: "info".to_string(),
+                category: "policy_violation".to_string(),
+                message: "Policy updated".to_string(),
+                status: "resolved".to_string(),
+                created_at: "2026-04-30T08:00:00Z".to_string(),
+                updated_at: None,
+                context: None,
+            },
+        ]
+    }
+
+    #[test]
+    fn filter_by_agent() {
+        let alerts = sample_alerts();
+        let args = ListArgs {
+            agent: Some("agent-abc".to_string()),
+            severity: None,
+            status: None,
+        };
+        let filtered = apply_filters(alerts, &args);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].id, "alert-001");
+    }
+
+    #[test]
+    fn filter_by_severity() {
+        let alerts = sample_alerts();
+        let args = ListArgs {
+            agent: None,
+            severity: Some("warning".to_string()),
+            status: None,
+        };
+        let filtered = apply_filters(alerts, &args);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].id, "alert-002");
+    }
+
+    #[test]
+    fn filter_by_status_default_unresolved() {
+        let alerts = sample_alerts();
+        let args = ListArgs {
+            agent: None,
+            severity: None,
+            status: Some("unresolved".to_string()),
+        };
+        let filtered = apply_filters(alerts, &args);
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].id, "alert-001");
+    }
+
+    #[test]
+    fn filter_no_status_returns_all() {
+        let alerts = sample_alerts();
+        let args = ListArgs {
+            agent: None,
+            severity: None,
+            status: None,
+        };
+        let filtered = apply_filters(alerts, &args);
+        assert_eq!(filtered.len(), 3);
+    }
+
+    #[test]
+    fn filter_agent_without_agent_id_excluded() {
+        let alerts = sample_alerts();
+        let args = ListArgs {
+            agent: Some("agent-xyz".to_string()),
+            severity: None,
+            status: None,
+        };
+        let filtered = apply_filters(alerts, &args);
+        assert!(filtered.is_empty());
+    }
+
+    #[test]
+    fn render_table_does_not_panic() {
+        let alerts = sample_alerts();
+        render_table(&alerts);
+    }
+
+    #[test]
+    fn render_table_empty_does_not_panic() {
+        render_table(&[]);
+    }
+
+    #[test]
+    fn json_output_is_valid() {
+        let alerts = sample_alerts();
+        let json = serde_json::to_string_pretty(&alerts).unwrap();
+        let parsed: Vec<AlertResponse> = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.len(), 3);
+    }
 }

--- a/aa-cli/src/commands/alerts/list.rs
+++ b/aa-cli/src/commands/alerts/list.rs
@@ -1,0 +1,29 @@
+//! `aasm alerts list` — list governance alerts.
+
+use std::process::ExitCode;
+
+use clap::Args;
+
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
+
+/// Arguments for `aasm alerts list`.
+#[derive(Args)]
+pub struct ListArgs {
+    /// Filter by agent ID.
+    #[arg(long)]
+    pub agent: Option<String>,
+
+    /// Filter by severity (critical, warning, info).
+    #[arg(long)]
+    pub severity: Option<String>,
+
+    /// Filter by status (unresolved, acknowledged, resolved). Default: unresolved.
+    #[arg(long, default_value = "unresolved")]
+    pub status: Option<String>,
+}
+
+/// Run the `aasm alerts list` command.
+pub fn run(_args: ListArgs, _ctx: &ResolvedContext, _output: OutputFormat) -> ExitCode {
+    todo!()
+}

--- a/aa-cli/src/commands/alerts/mod.rs
+++ b/aa-cli/src/commands/alerts/mod.rs
@@ -1,0 +1,40 @@
+//! `aasm alerts` — manage governance alerts.
+
+use std::process::ExitCode;
+
+use clap::{Args, Subcommand};
+
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
+
+pub mod get;
+pub mod list;
+pub mod models;
+pub mod resolve;
+
+/// Arguments for the `aasm alerts` subcommand group.
+#[derive(Args)]
+pub struct AlertsArgs {
+    #[command(subcommand)]
+    pub command: AlertsCommands,
+}
+
+/// Available alerts subcommands.
+#[derive(Subcommand)]
+pub enum AlertsCommands {
+    /// List governance alerts.
+    List(list::ListArgs),
+    /// Show full detail for a specific alert.
+    Get(get::GetArgs),
+    /// Resolve an alert.
+    Resolve(resolve::ResolveArgs),
+}
+
+/// Dispatch an alerts subcommand.
+pub fn dispatch(args: AlertsArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    match args.command {
+        AlertsCommands::List(list_args) => list::run(list_args, ctx, output),
+        AlertsCommands::Get(get_args) => get::run(get_args, ctx, output),
+        AlertsCommands::Resolve(resolve_args) => resolve::run(resolve_args, ctx),
+    }
+}

--- a/aa-cli/src/commands/alerts/mod.rs
+++ b/aa-cli/src/commands/alerts/mod.rs
@@ -35,6 +35,6 @@ pub fn dispatch(args: AlertsArgs, ctx: &ResolvedContext, output: OutputFormat) -
     match args.command {
         AlertsCommands::List(list_args) => list::run(list_args, ctx, output),
         AlertsCommands::Get(get_args) => get::run(get_args, ctx, output),
-        AlertsCommands::Resolve(resolve_args) => resolve::run(resolve_args, ctx),
+        AlertsCommands::Resolve(resolve_args) => resolve::run(resolve_args, ctx, output),
     }
 }

--- a/aa-cli/src/commands/alerts/models.rs
+++ b/aa-cli/src/commands/alerts/models.rs
@@ -57,7 +57,7 @@ pub enum AlertSeverity {
 
 impl AlertSeverity {
     /// Parse a severity string (case-insensitive).
-    pub fn from_str(s: &str) -> Self {
+    pub fn parse(s: &str) -> Self {
         match s.to_lowercase().as_str() {
             "critical" => Self::Critical,
             "warning" => Self::Warning,
@@ -99,7 +99,7 @@ pub enum AlertStatusKind {
 
 impl AlertStatusKind {
     /// Parse a status string (case-insensitive).
-    pub fn from_str(s: &str) -> Self {
+    pub fn parse(s: &str) -> Self {
         match s.to_lowercase().as_str() {
             "unresolved" => Self::Unresolved,
             "acknowledged" => Self::Acknowledged,
@@ -136,10 +136,10 @@ mod tests {
 
     #[test]
     fn severity_from_str_case_insensitive() {
-        assert_eq!(AlertSeverity::from_str("Critical"), AlertSeverity::Critical);
-        assert_eq!(AlertSeverity::from_str("WARNING"), AlertSeverity::Warning);
-        assert_eq!(AlertSeverity::from_str("info"), AlertSeverity::Info);
-        assert_eq!(AlertSeverity::from_str("other"), AlertSeverity::Unknown);
+        assert_eq!(AlertSeverity::parse("Critical"), AlertSeverity::Critical);
+        assert_eq!(AlertSeverity::parse("WARNING"), AlertSeverity::Warning);
+        assert_eq!(AlertSeverity::parse("info"), AlertSeverity::Info);
+        assert_eq!(AlertSeverity::parse("other"), AlertSeverity::Unknown);
     }
 
     #[test]
@@ -152,10 +152,10 @@ mod tests {
 
     #[test]
     fn status_from_str_case_insensitive() {
-        assert_eq!(AlertStatusKind::from_str("unresolved"), AlertStatusKind::Unresolved);
-        assert_eq!(AlertStatusKind::from_str("ACKNOWLEDGED"), AlertStatusKind::Acknowledged);
-        assert_eq!(AlertStatusKind::from_str("Resolved"), AlertStatusKind::Resolved);
-        assert_eq!(AlertStatusKind::from_str("other"), AlertStatusKind::Unknown);
+        assert_eq!(AlertStatusKind::parse("unresolved"), AlertStatusKind::Unresolved);
+        assert_eq!(AlertStatusKind::parse("ACKNOWLEDGED"), AlertStatusKind::Acknowledged);
+        assert_eq!(AlertStatusKind::parse("Resolved"), AlertStatusKind::Resolved);
+        assert_eq!(AlertStatusKind::parse("other"), AlertStatusKind::Unknown);
     }
 
     #[test]

--- a/aa-cli/src/commands/alerts/models.rs
+++ b/aa-cli/src/commands/alerts/models.rs
@@ -1,0 +1,234 @@
+//! Data models for the `aasm alerts` subcommands.
+
+use std::fmt;
+
+use comfy_table::Color;
+use serde::{Deserialize, Serialize};
+
+/// JSON representation of a governance alert returned by the gateway API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AlertResponse {
+    /// Unique alert identifier.
+    pub id: String,
+    /// Agent ID that triggered the alert (if applicable).
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    /// Alert severity level.
+    pub severity: String,
+    /// Alert category (e.g. "budget", "policy_violation", "anomaly").
+    #[serde(default)]
+    pub category: String,
+    /// Human-readable alert message.
+    pub message: String,
+    /// Alert status (unresolved, acknowledged, resolved).
+    #[serde(default = "default_status")]
+    pub status: String,
+    /// ISO 8601 timestamp when the alert was created.
+    #[serde(alias = "timestamp")]
+    pub created_at: String,
+    /// ISO 8601 timestamp when the alert was last updated.
+    #[serde(default)]
+    pub updated_at: Option<String>,
+    /// Additional context payload.
+    #[serde(default)]
+    pub context: Option<serde_json::Value>,
+}
+
+fn default_status() -> String {
+    "unresolved".to_string()
+}
+
+/// Request body for `POST /api/v1/alerts/:id/resolve`.
+#[derive(Debug, Serialize)]
+pub struct ResolveAlertRequest {
+    /// Optional resolution note.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Known severity levels with associated terminal colors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlertSeverity {
+    Critical,
+    Warning,
+    Info,
+    Unknown,
+}
+
+impl AlertSeverity {
+    /// Parse a severity string (case-insensitive).
+    pub fn from_str(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "critical" => Self::Critical,
+            "warning" => Self::Warning,
+            "info" => Self::Info,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// Terminal color for this severity level.
+    pub fn color(self) -> Color {
+        match self {
+            Self::Critical => Color::Red,
+            Self::Warning => Color::Yellow,
+            Self::Info => Color::White,
+            Self::Unknown => Color::Reset,
+        }
+    }
+}
+
+impl fmt::Display for AlertSeverity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Critical => write!(f, "critical"),
+            Self::Warning => write!(f, "warning"),
+            Self::Info => write!(f, "info"),
+            Self::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+/// Known alert status values with associated terminal colors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AlertStatusKind {
+    Unresolved,
+    Acknowledged,
+    Resolved,
+    Unknown,
+}
+
+impl AlertStatusKind {
+    /// Parse a status string (case-insensitive).
+    pub fn from_str(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "unresolved" => Self::Unresolved,
+            "acknowledged" => Self::Acknowledged,
+            "resolved" => Self::Resolved,
+            _ => Self::Unknown,
+        }
+    }
+
+    /// Terminal color for this status.
+    pub fn color(self) -> Color {
+        match self {
+            Self::Unresolved => Color::Red,
+            Self::Acknowledged => Color::Yellow,
+            Self::Resolved => Color::Green,
+            Self::Unknown => Color::Reset,
+        }
+    }
+}
+
+impl fmt::Display for AlertStatusKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unresolved => write!(f, "unresolved"),
+            Self::Acknowledged => write!(f, "acknowledged"),
+            Self::Resolved => write!(f, "resolved"),
+            Self::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn severity_from_str_case_insensitive() {
+        assert_eq!(AlertSeverity::from_str("Critical"), AlertSeverity::Critical);
+        assert_eq!(AlertSeverity::from_str("WARNING"), AlertSeverity::Warning);
+        assert_eq!(AlertSeverity::from_str("info"), AlertSeverity::Info);
+        assert_eq!(AlertSeverity::from_str("other"), AlertSeverity::Unknown);
+    }
+
+    #[test]
+    fn severity_colors() {
+        assert_eq!(AlertSeverity::Critical.color(), Color::Red);
+        assert_eq!(AlertSeverity::Warning.color(), Color::Yellow);
+        assert_eq!(AlertSeverity::Info.color(), Color::White);
+        assert_eq!(AlertSeverity::Unknown.color(), Color::Reset);
+    }
+
+    #[test]
+    fn status_from_str_case_insensitive() {
+        assert_eq!(AlertStatusKind::from_str("unresolved"), AlertStatusKind::Unresolved);
+        assert_eq!(AlertStatusKind::from_str("ACKNOWLEDGED"), AlertStatusKind::Acknowledged);
+        assert_eq!(AlertStatusKind::from_str("Resolved"), AlertStatusKind::Resolved);
+        assert_eq!(AlertStatusKind::from_str("other"), AlertStatusKind::Unknown);
+    }
+
+    #[test]
+    fn status_colors() {
+        assert_eq!(AlertStatusKind::Unresolved.color(), Color::Red);
+        assert_eq!(AlertStatusKind::Acknowledged.color(), Color::Yellow);
+        assert_eq!(AlertStatusKind::Resolved.color(), Color::Green);
+        assert_eq!(AlertStatusKind::Unknown.color(), Color::Reset);
+    }
+
+    #[test]
+    fn alert_response_deserializes_with_defaults() {
+        let json = r#"{
+            "id": "alert-001",
+            "severity": "warning",
+            "message": "Budget threshold exceeded",
+            "timestamp": "2026-04-30T10:00:00Z"
+        }"#;
+        let alert: AlertResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(alert.id, "alert-001");
+        assert_eq!(alert.status, "unresolved");
+        assert_eq!(alert.created_at, "2026-04-30T10:00:00Z");
+        assert!(alert.agent_id.is_none());
+        assert!(alert.context.is_none());
+    }
+
+    #[test]
+    fn alert_response_round_trip() {
+        let alert = AlertResponse {
+            id: "alert-002".to_string(),
+            agent_id: Some("agent-abc".to_string()),
+            severity: "critical".to_string(),
+            category: "policy_violation".to_string(),
+            message: "Blocked tool call".to_string(),
+            status: "resolved".to_string(),
+            created_at: "2026-04-30T10:00:00Z".to_string(),
+            updated_at: Some("2026-04-30T11:00:00Z".to_string()),
+            context: Some(serde_json::json!({"tool": "shell_exec"})),
+        };
+        let json = serde_json::to_string(&alert).unwrap();
+        let parsed: AlertResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.id, "alert-002");
+        assert_eq!(parsed.status, "resolved");
+        assert_eq!(parsed.context.unwrap()["tool"], "shell_exec");
+    }
+
+    #[test]
+    fn resolve_request_skips_none_reason() {
+        let req = ResolveAlertRequest { reason: None };
+        let json = serde_json::to_string(&req).unwrap();
+        assert_eq!(json, "{}");
+    }
+
+    #[test]
+    fn resolve_request_includes_reason() {
+        let req = ResolveAlertRequest {
+            reason: Some("False positive".to_string()),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("False positive"));
+    }
+
+    #[test]
+    fn severity_display() {
+        assert_eq!(format!("{}", AlertSeverity::Critical), "critical");
+        assert_eq!(format!("{}", AlertSeverity::Warning), "warning");
+        assert_eq!(format!("{}", AlertSeverity::Info), "info");
+    }
+
+    #[test]
+    fn status_display() {
+        assert_eq!(format!("{}", AlertStatusKind::Unresolved), "unresolved");
+        assert_eq!(format!("{}", AlertStatusKind::Acknowledged), "acknowledged");
+        assert_eq!(format!("{}", AlertStatusKind::Resolved), "resolved");
+    }
+}

--- a/aa-cli/src/commands/alerts/resolve.rs
+++ b/aa-cli/src/commands/alerts/resolve.rs
@@ -8,6 +8,7 @@ use clap::Args;
 use super::models::{AlertResponse, ResolveAlertRequest};
 use crate::client;
 use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
 
 /// Arguments for `aasm alerts resolve`.
 #[derive(Args)]
@@ -38,7 +39,7 @@ fn confirm_resolve(alert_id: &str) -> bool {
 }
 
 /// Run the `aasm alerts resolve` command.
-pub fn run(args: ResolveArgs, ctx: &ResolvedContext) -> ExitCode {
+pub fn run(args: ResolveArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
     if !args.force && !confirm_resolve(&args.alert_id) {
         eprintln!("Aborted.");
         return ExitCode::FAILURE;
@@ -54,7 +55,17 @@ pub fn run(args: ResolveArgs, ctx: &ResolvedContext) -> ExitCode {
         Some(&body),
     )) {
         Ok(alert) => {
-            println!("Alert {} resolved.", alert.id);
+            match output {
+                OutputFormat::Table => println!("Alert {} resolved.", alert.id),
+                OutputFormat::Json => match serde_json::to_string_pretty(&alert) {
+                    Ok(json) => println!("{json}"),
+                    Err(e) => eprintln!("error serializing JSON: {e}"),
+                },
+                OutputFormat::Yaml => match serde_yaml::to_string(&alert) {
+                    Ok(yaml) => print!("{yaml}"),
+                    Err(e) => eprintln!("error serializing YAML: {e}"),
+                },
+            }
             ExitCode::SUCCESS
         }
         Err(e) => {

--- a/aa-cli/src/commands/alerts/resolve.rs
+++ b/aa-cli/src/commands/alerts/resolve.rs
@@ -46,9 +46,7 @@ pub fn run(args: ResolveArgs, ctx: &ResolvedContext) -> ExitCode {
 
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
 
-    let body = ResolveAlertRequest {
-        reason: args.reason,
-    };
+    let body = ResolveAlertRequest { reason: args.reason };
     let path = format!("/api/v1/alerts/{}/resolve", args.alert_id);
     match rt.block_on(client::post_opt_json::<ResolveAlertRequest, AlertResponse>(
         ctx,

--- a/aa-cli/src/commands/alerts/resolve.rs
+++ b/aa-cli/src/commands/alerts/resolve.rs
@@ -1,9 +1,12 @@
 //! `aasm alerts resolve` — resolve an alert.
 
+use std::io::{self, Write};
 use std::process::ExitCode;
 
 use clap::Args;
 
+use super::models::{AlertResponse, ResolveAlertRequest};
+use crate::client;
 use crate::config::ResolvedContext;
 
 /// Arguments for `aasm alerts resolve`.
@@ -21,7 +24,44 @@ pub struct ResolveArgs {
     pub force: bool,
 }
 
+/// Prompt the user for confirmation. Returns true if confirmed.
+fn confirm_resolve(alert_id: &str) -> bool {
+    eprint!("Are you sure you want to resolve alert {alert_id}? [y/N] ");
+    io::stderr().flush().ok();
+
+    let mut input = String::new();
+    if io::stdin().read_line(&mut input).is_err() {
+        return false;
+    }
+
+    matches!(input.trim().to_lowercase().as_str(), "y" | "yes")
+}
+
 /// Run the `aasm alerts resolve` command.
-pub fn run(_args: ResolveArgs, _ctx: &ResolvedContext) -> ExitCode {
-    todo!()
+pub fn run(args: ResolveArgs, ctx: &ResolvedContext) -> ExitCode {
+    if !args.force && !confirm_resolve(&args.alert_id) {
+        eprintln!("Aborted.");
+        return ExitCode::FAILURE;
+    }
+
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+
+    let body = ResolveAlertRequest {
+        reason: args.reason,
+    };
+    let path = format!("/api/v1/alerts/{}/resolve", args.alert_id);
+    match rt.block_on(client::post_opt_json::<ResolveAlertRequest, AlertResponse>(
+        ctx,
+        &path,
+        Some(&body),
+    )) {
+        Ok(alert) => {
+            println!("Alert {} resolved.", alert.id);
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
 }

--- a/aa-cli/src/commands/alerts/resolve.rs
+++ b/aa-cli/src/commands/alerts/resolve.rs
@@ -1,0 +1,27 @@
+//! `aasm alerts resolve` — resolve an alert.
+
+use std::process::ExitCode;
+
+use clap::Args;
+
+use crate::config::ResolvedContext;
+
+/// Arguments for `aasm alerts resolve`.
+#[derive(Args)]
+pub struct ResolveArgs {
+    /// Alert ID to resolve.
+    pub alert_id: String,
+
+    /// Optional resolution note.
+    #[arg(long)]
+    pub reason: Option<String>,
+
+    /// Skip the confirmation prompt.
+    #[arg(long)]
+    pub force: bool,
+}
+
+/// Run the `aasm alerts resolve` command.
+pub fn run(_args: ResolveArgs, _ctx: &ResolvedContext) -> ExitCode {
+    todo!()
+}

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -8,6 +8,7 @@ use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
 
 pub mod agent;
+pub mod alerts;
 pub mod approvals;
 pub mod audit;
 pub mod completion;
@@ -25,6 +26,8 @@ pub mod version;
 pub enum Commands {
     /// Manage monitored agent processes.
     Agent(agent::AgentArgs),
+    /// Manage governance alerts.
+    Alerts(alerts::AlertsArgs),
     /// Query audit log entries and export compliance reports.
     Audit(audit::AuditArgs),
     /// Query and stream audit log events.
@@ -53,6 +56,7 @@ pub enum Commands {
 pub fn dispatch(cmd: Commands, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
     match cmd {
         Commands::Agent(args) => agent::dispatch(args, ctx, output),
+        Commands::Alerts(args) => alerts::dispatch(args, ctx, output),
         Commands::Audit(args) => audit::dispatch(args, ctx, output),
         Commands::Logs(args) => logs::dispatch(args, ctx),
         Commands::Policy(args) => policy::dispatch(args, ctx),

--- a/aa-cli/tests/alerts.rs
+++ b/aa-cli/tests/alerts.rs
@@ -139,9 +139,7 @@ async fn get_alert_returns_success() {
 
     Mock::given(method("GET"))
         .and(path("/api/v1/alerts/alert-001"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_json(sample_alert_json()),
-        )
+        .respond_with(ResponseTemplate::new(200).set_body_json(sample_alert_json()))
         .expect(1)
         .mount(&server)
         .await;

--- a/aa-cli/tests/alerts.rs
+++ b/aa-cli/tests/alerts.rs
@@ -214,7 +214,41 @@ async fn resolve_alert_with_force_returns_success() {
             force: true,
         };
         let ctx = make_context(&uri);
-        aa_cli::commands::alerts::resolve::run(args, &ctx)
+        aa_cli::commands::alerts::resolve::run(args, &ctx, OutputFormat::Table)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+}
+
+#[tokio::test]
+async fn resolve_alert_json_output() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/alerts/alert-001/resolve"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "alert-001",
+            "severity": "critical",
+            "category": "budget",
+            "message": "Budget exceeded",
+            "status": "resolved",
+            "created_at": "2026-04-30T10:00:00Z"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let result = std::thread::spawn(move || {
+        let args = ResolveArgs {
+            alert_id: "alert-001".to_string(),
+            reason: None,
+            force: true,
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::alerts::resolve::run(args, &ctx, OutputFormat::Json)
     })
     .join()
     .unwrap();
@@ -248,7 +282,7 @@ async fn resolve_alert_without_reason_sends_empty_body() {
             force: true,
         };
         let ctx = make_context(&uri);
-        aa_cli::commands::alerts::resolve::run(args, &ctx)
+        aa_cli::commands::alerts::resolve::run(args, &ctx, OutputFormat::Table)
     })
     .join()
     .unwrap();
@@ -275,7 +309,7 @@ async fn resolve_alert_server_error_returns_failure() {
             force: true,
         };
         let ctx = make_context(&uri);
-        aa_cli::commands::alerts::resolve::run(args, &ctx)
+        aa_cli::commands::alerts::resolve::run(args, &ctx, OutputFormat::Table)
     })
     .join()
     .unwrap();

--- a/aa-cli/tests/alerts.rs
+++ b/aa-cli/tests/alerts.rs
@@ -1,0 +1,286 @@
+//! Integration tests for `aasm alerts` subcommands.
+
+use std::process::ExitCode;
+
+use wiremock::matchers::{body_partial_json, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use aa_cli::commands::alerts::get::GetArgs;
+use aa_cli::commands::alerts::list::ListArgs;
+use aa_cli::commands::alerts::resolve::ResolveArgs;
+use aa_cli::output::OutputFormat;
+
+fn make_context(api_url: &str) -> aa_cli::config::ResolvedContext {
+    aa_cli::config::ResolvedContext {
+        name: None,
+        api_url: api_url.to_string(),
+        api_key: None,
+    }
+}
+
+fn sample_alert_json() -> serde_json::Value {
+    serde_json::json!({
+        "id": "alert-001",
+        "agent_id": "agent-abc",
+        "severity": "critical",
+        "category": "budget",
+        "message": "Budget exceeded",
+        "status": "unresolved",
+        "created_at": "2026-04-30T10:00:00Z",
+        "updated_at": "2026-04-30T11:00:00Z",
+        "context": {"tool": "shell_exec"}
+    })
+}
+
+// ── alerts list ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_alerts_returns_success() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/alerts"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "items": [sample_alert_json()],
+            "page": 1,
+            "per_page": 50,
+            "total": 1
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let result = std::thread::spawn(move || {
+        let args = ListArgs {
+            agent: None,
+            severity: None,
+            status: None,
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::alerts::list::run(args, &ctx, OutputFormat::Table)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+}
+
+#[tokio::test]
+async fn list_alerts_json_output() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/alerts"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "items": [sample_alert_json()],
+            "page": 1,
+            "per_page": 50,
+            "total": 1
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let result = std::thread::spawn(move || {
+        let args = ListArgs {
+            agent: None,
+            severity: None,
+            status: None,
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::alerts::list::run(args, &ctx, OutputFormat::Json)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+}
+
+#[tokio::test]
+async fn list_alerts_with_filter_returns_empty() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/alerts"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "items": [sample_alert_json()],
+            "page": 1,
+            "per_page": 50,
+            "total": 1
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let result = std::thread::spawn(move || {
+        let args = ListArgs {
+            agent: Some("nonexistent-agent".to_string()),
+            severity: None,
+            status: None,
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::alerts::list::run(args, &ctx, OutputFormat::Table)
+    })
+    .join()
+    .unwrap();
+
+    // Filters out all alerts but still returns SUCCESS with "No alerts found."
+    assert_eq!(result, ExitCode::SUCCESS);
+}
+
+// ── alerts get ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn get_alert_returns_success() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/alerts/alert-001"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(sample_alert_json()),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let result = std::thread::spawn(move || {
+        let args = GetArgs {
+            alert_id: "alert-001".to_string(),
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::alerts::get::run(args, &ctx, OutputFormat::Table)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+}
+
+#[tokio::test]
+async fn get_alert_not_found_returns_failure() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/alerts/no-such-id"))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let result = std::thread::spawn(move || {
+        let args = GetArgs {
+            alert_id: "no-such-id".to_string(),
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::alerts::get::run(args, &ctx, OutputFormat::Table)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::FAILURE);
+}
+
+// ── alerts resolve ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn resolve_alert_with_force_returns_success() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/alerts/alert-001/resolve"))
+        .and(body_partial_json(serde_json::json!({
+            "reason": "False positive"
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "alert-001",
+            "severity": "critical",
+            "category": "budget",
+            "message": "Budget exceeded",
+            "status": "resolved",
+            "created_at": "2026-04-30T10:00:00Z"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let result = std::thread::spawn(move || {
+        let args = ResolveArgs {
+            alert_id: "alert-001".to_string(),
+            reason: Some("False positive".to_string()),
+            force: true,
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::alerts::resolve::run(args, &ctx)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+}
+
+#[tokio::test]
+async fn resolve_alert_without_reason_sends_empty_body() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/alerts/alert-002/resolve"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "alert-002",
+            "severity": "info",
+            "category": "policy_violation",
+            "message": "Minor issue",
+            "status": "resolved",
+            "created_at": "2026-04-30T08:00:00Z"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let result = std::thread::spawn(move || {
+        let args = ResolveArgs {
+            alert_id: "alert-002".to_string(),
+            reason: None,
+            force: true,
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::alerts::resolve::run(args, &ctx)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+}
+
+#[tokio::test]
+async fn resolve_alert_server_error_returns_failure() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/alerts/alert-999/resolve"))
+        .respond_with(ResponseTemplate::new(500))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let result = std::thread::spawn(move || {
+        let args = ResolveArgs {
+            alert_id: "alert-999".to_string(),
+            reason: None,
+            force: true,
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::alerts::resolve::run(args, &ctx)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::FAILURE);
+}


### PR DESCRIPTION
## Description

Implement the full `aasm alerts` subcommand group for managing governance alerts. Adds three subcommands:

- **`aasm alerts list`** — List governance alerts with client-side filters (`--agent`, `--severity`, `--status`) and color-coded severity/status columns. Supports Table, JSON, and YAML output formats.
- **`aasm alerts get <alert-id>`** — Show full detail for a specific alert in a key-value table with color-coded severity and status, pretty-printed JSON context.
- **`aasm alerts resolve <alert-id>`** — Resolve an alert with optional `--reason` note and `--force` to skip the confirmation prompt. Posts to `POST /api/v1/alerts/:id/resolve`.

Also adds `post_opt_json()` helper to the shared HTTP client for POST requests with an optional body.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-186
- Epic: AAASM-10 (CLI Tool — aasm)

## Testing

- [x] Unit tests added / updated (21 unit tests across models, list, get)
- [x] Integration tests added / updated (8 wiremock integration tests covering list, get, resolve)
- [x] Manual testing performed (cargo check, cargo test, cargo clippy all pass)

### Test summary

| Module | Unit tests | Integration tests |
|--------|-----------|-------------------|
| `models.rs` | 10 (serde, colors, display, resolve request) | — |
| `list.rs` | 8 (filters, render, JSON output) | 3 (list success, JSON output, filter empty) |
| `get.rs` | 3 (render detail, optional fields, JSON) | 2 (success, 404 failure) |
| `resolve.rs` | — | 3 (with reason, without reason, server error) |

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention