### PR TITLE
[AAASM-187] 🐛 cli(version): Add tabular output with gateway and API versions

### DIFF
--- a/aa-api/src/routes/health.rs
+++ b/aa-api/src/routes/health.rs
@@ -14,6 +14,10 @@ use crate::state::AppState;
 pub struct HealthResponse {
     /// Liveness status string, always `"ok"` when the service is running.
     pub status: String,
+    /// Gateway version (semver from Cargo.toml).
+    pub version: String,
+    /// API version prefix (e.g. `"v1"`).
+    pub api_version: String,
     /// Server uptime in seconds since startup.
     pub uptime_secs: u64,
     /// Number of currently active WebSocket/SSE connections.
@@ -43,6 +47,8 @@ pub async fn health(Extension(state): Extension<AppState>) -> impl IntoResponse 
         StatusCode::OK,
         Json(HealthResponse {
             status: "ok".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            api_version: "v1".to_string(),
             uptime_secs,
             active_connections,
             pipeline_lag_ms: 0,

--- a/aa-api/tests/health.rs
+++ b/aa-api/tests/health.rs
@@ -63,3 +63,32 @@ async fn health_returns_pipeline_lag_ms() {
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["pipeline_lag_ms"], 0);
 }
+
+#[tokio::test]
+async fn health_returns_version() {
+    let app = common::test_app();
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let version = json["version"].as_str().expect("version should be a string");
+    assert!(!version.is_empty(), "version should not be empty");
+}
+
+#[tokio::test]
+async fn health_returns_api_version() {
+    let app = common::test_app();
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["api_version"], "v1");
+}

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -55,7 +55,7 @@ pub fn dispatch(cmd: Commands, ctx: &ResolvedContext, output: OutputFormat) -> E
         Commands::Context(args) => context::dispatch(args),
         Commands::Completion(args) => completion::run(args),
         Commands::Status(args) => status::dispatch(args, ctx, output),
-        Commands::Version => version::run(ctx),
+        Commands::Version => version::run(ctx, output),
         Commands::Trace(args) => trace::dispatch(args, ctx, output),
         Commands::Approvals(args) => approvals::dispatch(args, ctx, output),
         Commands::Cost(args) => cost::dispatch(args, ctx, output),

--- a/aa-cli/src/commands/version.rs
+++ b/aa-cli/src/commands/version.rs
@@ -108,3 +108,86 @@ pub fn run(ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
 
     ExitCode::SUCCESS
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reachable_rows() -> Vec<VersionRow> {
+        vec![
+            VersionRow {
+                component: "cli".to_string(),
+                version: "0.0.1".to_string(),
+                status: "-".to_string(),
+            },
+            VersionRow {
+                component: "gateway".to_string(),
+                version: "0.3.2".to_string(),
+                status: "reachable".to_string(),
+            },
+            VersionRow {
+                component: "api".to_string(),
+                version: "v1".to_string(),
+                status: "reachable".to_string(),
+            },
+        ]
+    }
+
+    fn unreachable_version_rows() -> Vec<VersionRow> {
+        let (gw, api) = unreachable_rows();
+        vec![
+            VersionRow {
+                component: "cli".to_string(),
+                version: "0.0.1".to_string(),
+                status: "-".to_string(),
+            },
+            gw,
+            api,
+        ]
+    }
+
+    #[test]
+    fn render_table_reachable_does_not_panic() {
+        render_table(&reachable_rows());
+    }
+
+    #[test]
+    fn render_table_unreachable_does_not_panic() {
+        render_table(&unreachable_version_rows());
+    }
+
+    #[test]
+    fn unreachable_rows_have_dash_versions() {
+        let (gw, api) = unreachable_rows();
+        assert_eq!(gw.version, "-");
+        assert_eq!(gw.status, "unreachable");
+        assert_eq!(api.version, "-");
+        assert_eq!(api.status, "unreachable");
+    }
+
+    #[test]
+    fn json_output_has_three_entries() {
+        let rows = reachable_rows();
+        let json = serde_json::to_string_pretty(&rows).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0]["component"], "cli");
+        assert_eq!(arr[1]["component"], "gateway");
+        assert_eq!(arr[1]["version"], "0.3.2");
+        assert_eq!(arr[2]["component"], "api");
+        assert_eq!(arr[2]["version"], "v1");
+    }
+
+    #[test]
+    fn json_output_unreachable_shows_dash() {
+        let rows = unreachable_version_rows();
+        let json = serde_json::to_string_pretty(&rows).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = parsed.as_array().unwrap();
+        assert_eq!(arr[1]["version"], "-");
+        assert_eq!(arr[1]["status"], "unreachable");
+        assert_eq!(arr[2]["version"], "-");
+        assert_eq!(arr[2]["status"], "unreachable");
+    }
+}

--- a/aa-cli/src/commands/version.rs
+++ b/aa-cli/src/commands/version.rs
@@ -2,28 +2,109 @@
 
 use std::process::ExitCode;
 
-use crate::config::ResolvedContext;
+use comfy_table::Table;
+use serde::{Deserialize, Serialize};
 
-/// Print CLI version and, if reachable, the gateway runtime version.
-pub fn run(ctx: &ResolvedContext) -> ExitCode {
-    println!("aasm {}", env!("CARGO_PKG_VERSION"));
-    println!("api:  {}", ctx.api_url);
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
+
+/// Subset of the gateway health response used for version extraction.
+#[derive(Debug, Deserialize)]
+struct HealthInfo {
+    version: String,
+    api_version: String,
+}
+
+/// A single row in the version output.
+#[derive(Debug, Serialize)]
+struct VersionRow {
+    component: String,
+    version: String,
+    status: String,
+}
+
+/// Build version rows by probing the gateway health endpoint.
+fn build_rows(ctx: &ResolvedContext) -> Vec<VersionRow> {
+    let cli_row = VersionRow {
+        component: "cli".to_string(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        status: "-".to_string(),
+    };
 
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
-    rt.block_on(async {
+    let (gateway_row, api_row) = rt.block_on(async {
         let client = reqwest::Client::new();
         let url = format!("{}/api/v1/health", ctx.api_url);
-        match client.get(&url).send().await {
-            Ok(resp) if resp.status().is_success() => {
-                println!("gateway: reachable");
-            }
-            Ok(resp) => {
-                println!("gateway: responded with {}", resp.status());
-            }
-            Err(_) => {
-                println!("gateway: unreachable");
-            }
+
+        let mut req = client.get(&url);
+        if let Some(ref key) = ctx.api_key {
+            req = req.bearer_auth(key);
+        }
+
+        match req.send().await {
+            Ok(resp) if resp.status().is_success() => match resp.json::<HealthInfo>().await {
+                Ok(info) => (
+                    VersionRow {
+                        component: "gateway".to_string(),
+                        version: info.version,
+                        status: "reachable".to_string(),
+                    },
+                    VersionRow {
+                        component: "api".to_string(),
+                        version: info.api_version,
+                        status: "reachable".to_string(),
+                    },
+                ),
+                Err(_) => unreachable_rows(),
+            },
+            _ => unreachable_rows(),
         }
     });
+
+    vec![cli_row, gateway_row, api_row]
+}
+
+/// Produce gateway and api rows for the unreachable case.
+fn unreachable_rows() -> (VersionRow, VersionRow) {
+    (
+        VersionRow {
+            component: "gateway".to_string(),
+            version: "-".to_string(),
+            status: "unreachable".to_string(),
+        },
+        VersionRow {
+            component: "api".to_string(),
+            version: "-".to_string(),
+            status: "unreachable".to_string(),
+        },
+    )
+}
+
+/// Render version rows as a comfy-table.
+fn render_table(rows: &[VersionRow]) {
+    let mut table = Table::new();
+    table.set_header(vec!["COMPONENT", "VERSION", "STATUS"]);
+    for r in rows {
+        table.add_row(vec![&r.component, &r.version, &r.status]);
+    }
+    println!("{table}");
+}
+
+/// Run the `aasm version` command.
+pub fn run(ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    let rows = build_rows(ctx);
+
+    match output {
+        OutputFormat::Table => render_table(&rows),
+        OutputFormat::Json => match serde_json::to_string_pretty(&rows) {
+            Ok(json) => println!("{json}"),
+            Err(e) => eprintln!("error serializing JSON: {e}"),
+        },
+        OutputFormat::Yaml => match serde_yaml::to_string(&rows) {
+            Ok(yaml) => print!("{yaml}"),
+            Err(e) => eprintln!("error serializing YAML: {e}"),
+        },
+    }
+
     ExitCode::SUCCESS
 }

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -537,6 +537,8 @@ export interface components {
              * @description Number of currently active WebSocket/SSE connections.
              */
             active_connections: number;
+            /** @description API version prefix (e.g. `"v1"`). */
+            api_version: string;
             /**
              * Format: int64
              * @description Pipeline processing lag in milliseconds (placeholder, always 0 for now).
@@ -549,6 +551,8 @@ export interface components {
              * @description Server uptime in seconds since startup.
              */
             uptime_secs: number;
+            /** @description Gateway version (semver from Cargo.toml). */
+            version: string;
         };
         /** @description JSON representation of an audit log entry. */
         LogEntry: {

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -869,6 +869,8 @@ components:
       description: Response body for the health endpoint.
       required:
       - status
+      - version
+      - api_version
       - uptime_secs
       - active_connections
       - pipeline_lag_ms
@@ -877,6 +879,9 @@ components:
           type: integer
           format: int64
           description: Number of currently active WebSocket/SSE connections.
+        api_version:
+          type: string
+          description: API version prefix (e.g. `"v1"`).
         pipeline_lag_ms:
           type: integer
           format: int64
@@ -890,6 +895,9 @@ components:
           format: int64
           description: Server uptime in seconds since startup.
           minimum: 0
+        version:
+          type: string
+          description: Gateway version (semver from Cargo.toml).
     LogEntry:
       type: object
       description: JSON representation of an audit log entry.


### PR DESCRIPTION
## Summary

- Adds `version` and `api_version` fields to the gateway `HealthResponse` (`GET /api/v1/health`)
- Rewrites `aasm version` to parse the health response and render a three-row table (`cli`, `gateway`, `api`) with `COMPONENT / VERSION / STATUS` columns
- Falls back to `"-" / "unreachable"` when the gateway cannot be reached
- Threads `--output` flag into the version command to support `json` and `yaml` output
- Regenerates OpenAPI spec and dashboard TypeScript types

## Test plan

- [x] `cargo test -p aa-api --test health` — 6 tests pass (including new `version` and `api_version` assertions)
- [x] `cargo test -p aa-cli` — 228 tests pass (including 5 new version rendering tests)
- [x] `cargo clippy -p aa-cli -p aa-api -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] CI passes all checks (format, clippy, test, OpenAPI drift, dashboard codegen drift)

Closes AAASM-187

🤖 Generated with [Claude Code](https://claude.com/claude-code)