### PR TITLE
[AAASM-188] 🐛 cli(dashboard): Add missing last event column to agents panel

### DIFF
--- a/aa-cli/src/commands/dashboard/input.rs
+++ b/aa-cli/src/commands/dashboard/input.rs
@@ -288,6 +288,7 @@ mod tests {
             status: "Running".to_string(),
             sessions: 0,
             violations_today: 0,
+            last_event: "-".to_string(),
             layer: "-".to_string(),
         }];
         let action = handle_key(&mut state, make_key(KeyCode::Enter));
@@ -322,6 +323,7 @@ mod tests {
                 status: "Running".to_string(),
                 sessions: 0,
                 violations_today: 0,
+                last_event: "-".to_string(),
                 layer: "-".to_string(),
             },
             crate::commands::status::models::AgentRow {
@@ -331,6 +333,7 @@ mod tests {
                 status: "Running".to_string(),
                 sessions: 0,
                 violations_today: 0,
+                last_event: "-".to_string(),
                 layer: "-".to_string(),
             },
         ];

--- a/aa-cli/src/commands/dashboard/ui.rs
+++ b/aa-cli/src/commands/dashboard/ui.rs
@@ -146,7 +146,7 @@ fn draw_agents_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
             Constraint::Length(8),
             Constraint::Length(10),
             Constraint::Length(5),
-            Constraint::Length(10),
+            Constraint::Length(20),
             Constraint::Length(5),
             Constraint::Length(8),
         ],

--- a/aa-cli/src/commands/dashboard/ui.rs
+++ b/aa-cli/src/commands/dashboard/ui.rs
@@ -100,7 +100,7 @@ fn draw_agents_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
     f.render_widget(Paragraph::new(header_line), chunks[0]);
 
     // Agents table.
-    let header = Row::new(vec!["ID", "NAME", "STATUS", "FW", "SESS", "VIOL", "LAYER"])
+    let header = Row::new(vec!["ID", "NAME", "STATUS", "FW", "SESS", "LAST EVT", "VIOL", "LAYER"])
         .style(Style::default().add_modifier(Modifier::BOLD))
         .bottom_margin(0);
 
@@ -121,6 +121,7 @@ fn draw_agents_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
                 Cell::from(a.status.as_str()).style(status_style),
                 Cell::from(a.framework.as_str()),
                 Cell::from(a.sessions.to_string()),
+                Cell::from(a.last_event.as_str()),
                 Cell::from(a.violations_today.to_string()),
                 Cell::from(a.layer.as_str()),
             ]);
@@ -145,6 +146,7 @@ fn draw_agents_panel(f: &mut Frame, area: Rect, state: &DashboardState) {
             Constraint::Length(8),
             Constraint::Length(10),
             Constraint::Length(5),
+            Constraint::Length(10),
             Constraint::Length(5),
             Constraint::Length(8),
         ],

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -32,15 +32,19 @@ pub fn build_runtime_health(resp: Option<HealthResponse>) -> RuntimeHealth {
 pub fn build_agent_rows(agents: Vec<AgentResponse>) -> Vec<AgentRow> {
     agents
         .into_iter()
-        .map(|a| AgentRow {
-            id: a.id,
-            name: a.name,
-            framework: a.framework,
-            status: a.status,
-            sessions: a.session_count,
-            violations_today: a.policy_violations_count,
-            last_event: format_relative_time(a.last_event.as_deref()),
-            layer: a.layer.unwrap_or_else(|| "-".to_string()),
+        .map(|a| {
+            let event_type = a.recent_events.first().map(|e| e.event_type.as_str());
+            let last_event = format_last_event(a.last_event.as_deref(), event_type);
+            AgentRow {
+                id: a.id,
+                name: a.name,
+                framework: a.framework,
+                status: a.status,
+                sessions: a.session_count,
+                violations_today: a.policy_violations_count,
+                last_event,
+                layer: a.layer.unwrap_or_else(|| "-".to_string()),
+            }
         })
         .collect()
 }
@@ -109,6 +113,21 @@ pub fn build_budget_row(cost: CostResponse) -> BudgetRow {
     }
 }
 
+/// Combine a relative timestamp with the latest event type for display.
+///
+/// Returns `"-"` when no timestamp is available.
+/// Examples: `"2m ago tool_call"`, `"1h ago violation"`, `"just now"`.
+pub fn format_last_event(iso_timestamp: Option<&str>, event_type: Option<&str>) -> String {
+    let relative = format_relative_time(iso_timestamp);
+    if relative == "-" {
+        return relative;
+    }
+    match event_type {
+        Some(et) => format!("{relative} {et}"),
+        None => relative,
+    }
+}
+
 /// Format an optional ISO 8601 timestamp as a compact relative time string.
 ///
 /// Returns `"-"` when the input is `None` or unparseable.
@@ -156,6 +175,7 @@ fn format_duration(dur: chrono::Duration) -> String {
 mod tests {
     use std::collections::BTreeMap;
 
+    use super::super::models::RecentEventResponse;
     use super::*;
 
     #[test]
@@ -198,6 +218,11 @@ mod tests {
             policy_violations_count: 1,
             layer: Some("advisory".to_string()),
             last_event: Some("2026-05-01T08:00:00Z".to_string()),
+            recent_events: vec![RecentEventResponse {
+                event_type: "tool_call".to_string(),
+                summary: "called bash".to_string(),
+                timestamp: "2026-05-01T08:00:00Z".to_string(),
+            }],
         }];
         let rows = build_agent_rows(agents);
         assert_eq!(rows.len(), 1);
@@ -207,6 +232,8 @@ mod tests {
         assert_eq!(rows[0].status, "Running");
         assert_eq!(rows[0].sessions, 3);
         assert_eq!(rows[0].violations_today, 1);
+        // last_event should contain both relative time and event type
+        assert!(rows[0].last_event.contains("tool_call"));
         assert_ne!(rows[0].last_event, "-");
         assert_eq!(rows[0].layer, "advisory");
     }
@@ -225,6 +252,7 @@ mod tests {
             policy_violations_count: 0,
             layer: None,
             last_event: None,
+            recent_events: vec![],
         }];
         let rows = build_agent_rows(agents);
         assert_eq!(rows[0].last_event, "-");
@@ -321,5 +349,28 @@ mod tests {
     fn format_duration_days() {
         let dur = chrono::Duration::days(1) + chrono::Duration::hours(3);
         assert_eq!(format_duration(dur), "1d 3h");
+    }
+
+    #[test]
+    fn format_last_event_none_timestamp_returns_dash() {
+        assert_eq!(format_last_event(None, Some("tool_call")), "-");
+    }
+
+    #[test]
+    fn format_last_event_with_event_type() {
+        let ts = (Utc::now() - chrono::Duration::minutes(2)).to_rfc3339();
+        assert_eq!(format_last_event(Some(&ts), Some("tool_call")), "2m ago tool_call");
+    }
+
+    #[test]
+    fn format_last_event_without_event_type() {
+        let ts = (Utc::now() - chrono::Duration::minutes(5)).to_rfc3339();
+        assert_eq!(format_last_event(Some(&ts), None), "5m ago");
+    }
+
+    #[test]
+    fn format_last_event_just_now_with_event_type() {
+        let ts = Utc::now().to_rfc3339();
+        assert_eq!(format_last_event(Some(&ts), Some("violation")), "just now violation");
     }
 }

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -39,6 +39,7 @@ pub fn build_agent_rows(agents: Vec<AgentResponse>) -> Vec<AgentRow> {
             status: a.status,
             sessions: a.session_count,
             violations_today: a.policy_violations_count,
+            last_event: format_relative_time(a.last_event.as_deref()),
             layer: a.layer.unwrap_or_else(|| "-".to_string()),
         })
         .collect()
@@ -108,6 +109,33 @@ pub fn build_budget_row(cost: CostResponse) -> BudgetRow {
     }
 }
 
+/// Format an optional ISO 8601 timestamp as a compact relative time string.
+///
+/// Returns `"-"` when the input is `None` or unparseable.
+/// Examples: `"just now"`, `"2m ago"`, `"1h ago"`, `"3d ago"`.
+pub fn format_relative_time(iso_timestamp: Option<&str>) -> String {
+    let ts = match iso_timestamp {
+        Some(s) => match chrono::DateTime::parse_from_rfc3339(s) {
+            Ok(dt) => dt,
+            Err(_) => return "-".to_string(),
+        },
+        None => return "-".to_string(),
+    };
+
+    let age = Utc::now().signed_duration_since(ts);
+    let total_secs = age.num_seconds();
+
+    if total_secs < 60 {
+        "just now".to_string()
+    } else if total_secs < 3600 {
+        format!("{}m ago", total_secs / 60)
+    } else if total_secs < 86400 {
+        format!("{}h ago", total_secs / 3600)
+    } else {
+        format!("{}d ago", total_secs / 86400)
+    }
+}
+
 /// Format a chrono duration into a human-readable string (e.g. `"2h 15m"`).
 fn format_duration(dur: chrono::Duration) -> String {
     let total_secs = dur.num_seconds().max(0);
@@ -169,6 +197,7 @@ mod tests {
             session_count: 3,
             policy_violations_count: 1,
             layer: Some("advisory".to_string()),
+            last_event: Some("2026-05-01T08:00:00Z".to_string()),
         }];
         let rows = build_agent_rows(agents);
         assert_eq!(rows.len(), 1);
@@ -178,6 +207,7 @@ mod tests {
         assert_eq!(rows[0].status, "Running");
         assert_eq!(rows[0].sessions, 3);
         assert_eq!(rows[0].violations_today, 1);
+        assert_ne!(rows[0].last_event, "-");
         assert_eq!(rows[0].layer, "advisory");
     }
 
@@ -194,8 +224,10 @@ mod tests {
             session_count: 0,
             policy_violations_count: 0,
             layer: None,
+            last_event: None,
         }];
         let rows = build_agent_rows(agents);
+        assert_eq!(rows[0].last_event, "-");
         assert_eq!(rows[0].layer, "-");
     }
 
@@ -237,6 +269,40 @@ mod tests {
         let summary = build_approvals_summary(&approvals);
         assert_eq!(summary.pending_count, 0);
         assert!(summary.oldest_pending_age.is_none());
+    }
+
+    #[test]
+    fn format_relative_time_none_returns_dash() {
+        assert_eq!(format_relative_time(None), "-");
+    }
+
+    #[test]
+    fn format_relative_time_invalid_returns_dash() {
+        assert_eq!(format_relative_time(Some("not-a-timestamp")), "-");
+    }
+
+    #[test]
+    fn format_relative_time_just_now() {
+        let now = Utc::now().to_rfc3339();
+        assert_eq!(format_relative_time(Some(&now)), "just now");
+    }
+
+    #[test]
+    fn format_relative_time_minutes_ago() {
+        let ts = (Utc::now() - chrono::Duration::minutes(5)).to_rfc3339();
+        assert_eq!(format_relative_time(Some(&ts)), "5m ago");
+    }
+
+    #[test]
+    fn format_relative_time_hours_ago() {
+        let ts = (Utc::now() - chrono::Duration::hours(3)).to_rfc3339();
+        assert_eq!(format_relative_time(Some(&ts)), "3h ago");
+    }
+
+    #[test]
+    fn format_relative_time_days_ago() {
+        let ts = (Utc::now() - chrono::Duration::days(2)).to_rfc3339();
+        assert_eq!(format_relative_time(Some(&ts)), "2d ago");
     }
 
     #[test]

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -77,6 +77,7 @@ mod tests {
                 status: "Running".to_string(),
                 sessions: 0,
                 violations_today: 0,
+                last_event: "-".to_string(),
                 layer: "-".to_string(),
             }],
             approvals: ApprovalsSummary {

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -57,6 +57,20 @@ pub struct AgentResponse {
     /// ISO 8601 timestamp of the most recent event.
     #[serde(default)]
     pub last_event: Option<String>,
+    /// Most recent events emitted by this agent.
+    #[serde(default)]
+    pub recent_events: Vec<RecentEventResponse>,
+}
+
+/// Summary of a recent event from the API response.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RecentEventResponse {
+    /// Event type classification (e.g. "violation", "tool_call").
+    pub event_type: String,
+    /// Short human-readable summary.
+    pub summary: String,
+    /// ISO 8601 timestamp when the event occurred.
+    pub timestamp: String,
 }
 
 /// Flattened agent row for tabular display.
@@ -194,6 +208,7 @@ mod tests {
         assert_eq!(resp.policy_violations_count, 0);
         assert!(resp.layer.is_none());
         assert!(resp.last_event.is_none());
+        assert!(resp.recent_events.is_empty());
     }
 
     #[test]
@@ -209,13 +224,18 @@ mod tests {
             "session_count": 5,
             "policy_violations_count": 2,
             "layer": "enforced",
-            "last_event": "2026-05-01T08:00:00Z"
+            "last_event": "2026-05-01T08:00:00Z",
+            "recent_events": [
+                {"event_type": "tool_call", "summary": "called bash", "timestamp": "2026-05-01T08:00:00Z"}
+            ]
         }"#;
         let resp: AgentResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.session_count, 5);
         assert_eq!(resp.policy_violations_count, 2);
         assert_eq!(resp.layer.as_deref(), Some("enforced"));
         assert_eq!(resp.last_event.as_deref(), Some("2026-05-01T08:00:00Z"));
+        assert_eq!(resp.recent_events.len(), 1);
+        assert_eq!(resp.recent_events[0].event_type, "tool_call");
     }
 
     #[test]

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -54,6 +54,9 @@ pub struct AgentResponse {
     /// Governance layer this agent is assigned to.
     #[serde(default)]
     pub layer: Option<String>,
+    /// ISO 8601 timestamp of the most recent event.
+    #[serde(default)]
+    pub last_event: Option<String>,
 }
 
 /// Flattened agent row for tabular display.
@@ -65,6 +68,7 @@ pub struct AgentRow {
     pub status: String,
     pub sessions: u32,
     pub violations_today: u32,
+    pub last_event: String,
     pub layer: String,
 }
 
@@ -189,6 +193,7 @@ mod tests {
         assert_eq!(resp.session_count, 0);
         assert_eq!(resp.policy_violations_count, 0);
         assert!(resp.layer.is_none());
+        assert!(resp.last_event.is_none());
     }
 
     #[test]
@@ -203,12 +208,14 @@ mod tests {
             "metadata": {},
             "session_count": 5,
             "policy_violations_count": 2,
-            "layer": "enforced"
+            "layer": "enforced",
+            "last_event": "2026-05-01T08:00:00Z"
         }"#;
         let resp: AgentResponse = serde_json::from_str(json).unwrap();
         assert_eq!(resp.session_count, 5);
         assert_eq!(resp.policy_violations_count, 2);
         assert_eq!(resp.layer.as_deref(), Some("enforced"));
+        assert_eq!(resp.last_event.as_deref(), Some("2026-05-01T08:00:00Z"));
     }
 
     #[test]

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -50,6 +50,7 @@ pub fn render_agents_table(agents: &[AgentRow]) {
         "STATUS",
         "FRAMEWORK",
         "SESSIONS",
+        "LAST_EVENT",
         "VIOLATIONS_TODAY",
         "LAYER",
     ]);
@@ -66,6 +67,7 @@ pub fn render_agents_table(agents: &[AgentRow]) {
             &format!("{status_icon} {}", agent.status),
             &agent.framework,
             &agent.sessions.to_string(),
+            &agent.last_event,
             &agent.violations_today.to_string(),
             &agent.layer,
         ]);


### PR DESCRIPTION
## Summary

- Add `last_event` field to status `AgentResponse` (optional, serde default) and `AgentRow` (display-ready string)
- Add `format_relative_time()` helper that converts ISO 8601 timestamps to compact relative strings ("just now", "5m ago", "3h ago", "2d ago"); shows "-" when absent
- Add `LAST_EVENT` column to `aasm status` agents table
- Add `LAST EVT` column to dashboard agents panel (TUI)
- Update all `AgentRow` test fixtures across status and dashboard modules

## Motivation

AAASM-85 AC #2 requires the dashboard to show "agent list (status, session count, **last event**)". The `last_event` field was already available in the API response (added in AAASM-175) but was not mapped through to `AgentRow` or rendered in either the dashboard or `aasm status` table.

## Test plan

- [x] `cargo test --workspace` — all tests pass, zero failures
- [x] `cargo fmt --all -- --check` — clean
- [x] 6 new unit tests for `format_relative_time`: None, invalid, just now, minutes, hours, days
- [x] Existing `build_agent_rows` tests updated to verify `last_event` mapping
- [x] Dashboard input tests updated with `last_event` field in `AgentRow` fixtures

Closes AAASM-188

🤖 Generated with [Claude Code](https://claude.com/claude-code)