### PR TITLE
[AAASM-133] 🔧 (sonar): Fix sonar-project.properties coverage source gaps

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -25,7 +25,6 @@ sonar.sources=\
   aa-proxy/src,\
   aa-ebpf-common/src,\
   aa-ffi-go/src,\
-  aa-ffi-python/src,\
   aa-ffi-node/src,\
   aa-wasm/src,\
   aa-gateway/src,\
@@ -58,11 +57,19 @@ sonar.javascript.file.suffixes=.js,.jsx
 # aa-ebpf: build.rs invokes the nightly toolchain for BPF cross-compilation,
 #   which is not installed in the Sonar CI job. The crate also depends on
 #   Linux-only aya kernel APIs. Validated by the dedicated ebpf-build CI job.
+#
+# aa-ffi-python: PyO3's extension-module feature (activated by --all-features)
+#   requires libpython development headers for linking. Those headers are not
+#   available in the Sonar CI job, so the crate is excluded from both
+#   cargo clippy and cargo llvm-cov in sonar.yml. Excluded here to keep
+#   sonar.sources and the CI build exclusions consistent — SonarCloud must
+#   not analyse files it has neither Clippy nor coverage data for.
 sonar.exclusions=\
   **/node_modules/**,\
   dashboard/dist/**,\
   **/target/**,\
-  aa-ebpf/src/**
+  aa-ebpf/src/**,\
+  aa-ffi-python/src/**
 
 sonar.sourceEncoding=UTF-8
 sonar.scm.provider=git

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,10 +10,21 @@ sonar.projectBaseDir=./
 # ── Sources ───────────────────────────────────────────────────────────────────
 # Rust crates and the React/TypeScript dashboard are listed separately so
 # SonarCloud applies the correct language analyser to each directory.
+#
+# Inclusion/exclusion policy for workspace members:
+#   INCLUDED  — crate compiles cleanly with stable Rust in the Sonar CI job.
+#   EXCLUDED  — crate cannot be compiled in the Sonar CI job due to a hard
+#               build-time constraint (see sonar.exclusions below for details).
+#
+# Intentionally omitted (not in sonar.sources and not excluded):
+#   aa-proto     — auto-generated prost/tonic code; analysis would produce noise.
+#   conformance  — protocol conformance test harness, not production library code.
 sonar.sources=\
   aa-core/src,\
   aa-runtime/src,\
   aa-proxy/src,\
+  aa-ebpf-common/src,\
+  aa-ffi-go/src,\
   aa-ffi-python/src,\
   aa-ffi-node/src,\
   aa-wasm/src,\
@@ -43,15 +54,15 @@ sonar.javascript.file.suffixes=.js,.jsx
 # ── Exclusions ────────────────────────────────────────────────────────────────
 # Exclude generated files, build output, and dependencies from analysis to
 # avoid noise and inflated metrics.
+#
+# aa-ebpf: build.rs invokes the nightly toolchain for BPF cross-compilation,
+#   which is not installed in the Sonar CI job. The crate also depends on
+#   Linux-only aya kernel APIs. Validated by the dedicated ebpf-build CI job.
 sonar.exclusions=\
   **/node_modules/**,\
   dashboard/dist/**,\
   **/target/**,\
   aa-ebpf/src/**
-
-# aa-ebpf is excluded because its build.rs invokes the nightly toolchain
-# (required for BPF cross-compilation) which is not installed in the Sonar job.
-# eBPF-side code is validated by the dedicated ebpf-build CI job instead.
 
 sonar.sourceEncoding=UTF-8
 sonar.scm.provider=git


### PR DESCRIPTION
## Summary

- Add `aa-ebpf-common/src` and `aa-ffi-go/src` to `sonar.sources` — both are real production Rust crates that compile cleanly with stable Rust; their LCOV coverage was already being generated by `cargo llvm-cov --workspace` but SonarCloud was silently ignoring it because the source paths were not registered.
- Remove `aa-ffi-python/src` from `sonar.sources` and add it to `sonar.exclusions` — `aa-ffi-python` is already excluded from both `cargo clippy` and `cargo llvm-cov` in `sonar.yml` (PyO3's `extension-module` feature requires `libpython` dev headers not available in the Sonar CI job). Keeping it in `sonar.sources` caused SonarCloud to analyse files with neither Clippy nor coverage data, which is misleading.
- Add an inclusion/exclusion policy comment to `sonar.sources` and per-crate reason comments to `sonar.exclusions` so future contributors understand why each workspace member is present or absent.

## Test plan

- [ ] Verify the SonarCloud scan in CI completes without errors after this PR merges
- [ ] Confirm `aa-ebpf-common` and `aa-ffi-go` source files appear in SonarCloud with coverage data
- [ ] Confirm `aa-ffi-python` no longer appears in SonarCloud analysis
- [ ] Confirm `aa-ebpf` remains excluded (no change)

Closes #AAASM-133

🤖 Generated with [Claude Code](https://claude.com/claude-code)