### PR TITLE
[AAASM-919] ✨ core(dev-tool): Add DevToolKind, GovernanceLevel, DevToolInfo types

### DIFF
--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -1,0 +1,215 @@
+//! Dev-tool governance — foundational types describing AI development tools
+//! governed by Agent Assembly.
+//!
+//! This module establishes the data vocabulary that the [`DevToolAdapter`]
+//! trait (added by AAASM-923) and every per-tool adapter (Claude Code, Codex,
+//! GitHub Copilot, Windsurf Cascade, and SaaS coding agents) consume.
+//!
+//! Gated on the `std` feature because [`DevToolInfo::install_path`] is a
+//! [`std::path::PathBuf`].
+//!
+//! [`DevToolAdapter`]: <not yet defined; introduced in AAASM-923>
+
+use std::path::PathBuf;
+use std::string::String;
+
+// ---------------------------------------------------------------------------
+// DevToolKind
+// ---------------------------------------------------------------------------
+
+/// Identifier for an AI development tool that Agent Assembly governs.
+///
+/// Built-in variants cover the four major commercial tools tracked by
+/// Epic 14 (Dev Tool Governance). Use [`DevToolKind::Custom`] for any tool
+/// integration shipped via the plugin extension point — the inner string
+/// is a stable identifier supplied by the adapter author.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum DevToolKind {
+    /// Anthropic's Claude Code CLI / desktop / IDE tool family.
+    ClaudeCode,
+    /// OpenAI's Codex CLI.
+    Codex,
+    /// GitHub Copilot in agent mode (IDE-host bound).
+    GitHubCopilot,
+    /// Codeium's Windsurf Cascade IDE agent.
+    WindsurfCascade,
+    /// A user-supplied tool integration; the inner [`String`] is a stable
+    /// identifier supplied by the adapter author.
+    Custom(String),
+}
+
+// ---------------------------------------------------------------------------
+// GovernanceLevel
+// ---------------------------------------------------------------------------
+
+/// Capability tier an Agent Assembly adapter can achieve for a given tool.
+///
+/// Levels form a strict total order:
+/// `L0Discover < L1Observe < L2Enforce < L3Native`. A higher level always
+/// subsumes the capabilities of every lower level, so policies and operator
+/// UIs can compare levels directly with `>=`.
+///
+/// | Level | Capability                                                        |
+/// |-------|-------------------------------------------------------------------|
+/// | L0    | Discover — eBPF / proxy detects the tool exists.                  |
+/// | L1    | Observe — network, file, process, MCP observability.              |
+/// | L2    | Enforce — allow / deny, approval, redaction, budget enforcement.  |
+/// | L3    | Native — full SDK-integrated identity, lineage, semantic context. |
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum GovernanceLevel {
+    /// Detection only — the eBPF / proxy layer sees the tool but cannot read its semantics.
+    L0Discover = 0,
+    /// Observability — network, file, process, and MCP events are surfaced.
+    L1Observe = 1,
+    /// Enforcement — policy decisions can allow, deny, redact, or budget actions.
+    L2Enforce = 2,
+    /// Native governance — the tool participates via SDK with identity, team tree, lineage.
+    L3Native = 3,
+}
+
+// ---------------------------------------------------------------------------
+// DevToolInfo
+// ---------------------------------------------------------------------------
+
+/// Detection-time description of an installed AI development tool.
+///
+/// Returned by an adapter's `detect` method when the tool is present on the
+/// host. All fields are public because this struct is a plain data record;
+/// adapters and the launcher inspect every field directly.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct DevToolInfo {
+    /// Which tool family this is.
+    pub kind: DevToolKind,
+    /// Reported tool version, if the adapter can resolve it.
+    pub version: Option<String>,
+    /// Absolute path to the tool's executable or installation root.
+    pub install_path: PathBuf,
+    /// Capability tier the adapter can achieve for this tool on this host.
+    pub governance_level: GovernanceLevel,
+    /// Whether this tool participates in the Model Context Protocol.
+    pub supports_mcp: bool,
+    /// Whether this tool exposes a managed-settings surface that
+    /// Agent Assembly can write into.
+    pub supports_managed_settings: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- GovernanceLevel ---
+
+    #[test]
+    fn governance_level_ordering_l0_to_l3() {
+        assert!(GovernanceLevel::L0Discover < GovernanceLevel::L1Observe);
+        assert!(GovernanceLevel::L1Observe < GovernanceLevel::L2Enforce);
+        assert!(GovernanceLevel::L2Enforce < GovernanceLevel::L3Native);
+        assert!(GovernanceLevel::L0Discover < GovernanceLevel::L3Native);
+    }
+
+    #[test]
+    fn governance_level_discriminants_are_0_through_3() {
+        assert_eq!(GovernanceLevel::L0Discover as u8, 0);
+        assert_eq!(GovernanceLevel::L1Observe as u8, 1);
+        assert_eq!(GovernanceLevel::L2Enforce as u8, 2);
+        assert_eq!(GovernanceLevel::L3Native as u8, 3);
+    }
+
+    // --- DevToolKind ---
+
+    #[test]
+    fn devtool_kind_built_in_variants_are_distinct() {
+        let variants = [
+            DevToolKind::ClaudeCode,
+            DevToolKind::Codex,
+            DevToolKind::GitHubCopilot,
+            DevToolKind::WindsurfCascade,
+        ];
+        for i in 0..variants.len() {
+            for j in (i + 1)..variants.len() {
+                assert_ne!(variants[i], variants[j]);
+            }
+        }
+    }
+
+    #[test]
+    fn devtool_kind_custom_carries_identifier() {
+        let a = DevToolKind::Custom(String::from("internal-editor"));
+        let b = DevToolKind::Custom(String::from("internal-editor"));
+        let c = DevToolKind::Custom(String::from("other-editor"));
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    // --- Serde round-trips (gated on `serde` feature) ---
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn devtool_kind_serde_round_trip_built_in() {
+        let kinds = [
+            DevToolKind::ClaudeCode,
+            DevToolKind::Codex,
+            DevToolKind::GitHubCopilot,
+            DevToolKind::WindsurfCascade,
+        ];
+        for kind in kinds {
+            let json = serde_json::to_string(&kind).expect("serialize");
+            let parsed: DevToolKind = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(parsed, kind);
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn devtool_kind_serde_round_trip_custom() {
+        let kind = DevToolKind::Custom(String::from("internal-editor"));
+        let json = serde_json::to_string(&kind).expect("serialize");
+        let parsed: DevToolKind = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed, kind);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn governance_level_serde_round_trip() {
+        let levels = [
+            GovernanceLevel::L0Discover,
+            GovernanceLevel::L1Observe,
+            GovernanceLevel::L2Enforce,
+            GovernanceLevel::L3Native,
+        ];
+        for level in levels {
+            let json = serde_json::to_string(&level).expect("serialize");
+            let parsed: GovernanceLevel = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(parsed, level);
+        }
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn devtool_info_serde_round_trip() {
+        let info = DevToolInfo {
+            kind: DevToolKind::ClaudeCode,
+            version: Some(String::from("1.2.3")),
+            install_path: PathBuf::from("/usr/local/bin/claude"),
+            governance_level: GovernanceLevel::L2Enforce,
+            supports_mcp: true,
+            supports_managed_settings: true,
+        };
+        let json = serde_json::to_string(&info).expect("serialize");
+        let parsed: DevToolInfo = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed.kind, info.kind);
+        assert_eq!(parsed.version, info.version);
+        assert_eq!(parsed.install_path, info.install_path);
+        assert_eq!(parsed.governance_level, info.governance_level);
+        assert_eq!(parsed.supports_mcp, info.supports_mcp);
+        assert_eq!(parsed.supports_managed_settings, info.supports_managed_settings);
+    }
+}

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -25,6 +25,8 @@ cfg_if::cfg_if! {
 pub mod agent;
 #[cfg(feature = "alloc")]
 pub mod audit;
+#[cfg(feature = "std")]
+pub mod dev_tool;
 pub mod evaluators;
 pub mod identity;
 pub mod policy;
@@ -49,3 +51,6 @@ pub use audit::{AuditEntry, AuditEventType, AuditLog, AuditLogError};
 
 #[cfg(feature = "std")]
 pub use scanner::{CredentialFinding, CredentialKind, CredentialScanner, ScanResult, ScannerConfig};
+
+#[cfg(feature = "std")]
+pub use dev_tool::{DevToolInfo, DevToolKind, GovernanceLevel};


### PR DESCRIPTION
## Description

Adds the foundational data types for the dev-tool governance framework as a new `aa-core::dev_tool` module. These types are the vocabulary that the `DevToolAdapter` trait (AAASM-923), `AdapterError` (AAASM-925), and every per-tool adapter (Claude Code, Codex, Copilot, Windsurf, SaaS coding agents) will consume.

* **`DevToolKind`** — `ClaudeCode | Codex | GitHubCopilot | WindsurfCascade | Custom(String)`. Derives `Debug, Clone, PartialEq, Eq, Hash` so registries can key on it. Serde derives gated on `feature = "serde"`.
* **`GovernanceLevel`** — `repr(u8)` with explicit discriminants `0..=3`, derives `PartialOrd, Ord` such that `L0Discover < L1Observe < L2Enforce < L3Native`. Higher level subsumes lower level so policies/UIs can compare with `>=`.
* **`DevToolInfo`** — `kind`, `version: Option<String>`, `install_path: PathBuf`, `governance_level`, `supports_mcp`, `supports_managed_settings`. Returned by `DevToolAdapter::detect`.

Module gated on `feature = "std"` because `install_path` is a `PathBuf` (matches the existing `scanner` module convention). Re-exported from `aa-core/src/lib.rs` behind the same gate.

Purely additive — no existing module is modified beyond the `lib.rs` declarations.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: [AAASM-919](https://lightning-dust-mite.atlassian.net/browse/AAASM-919) (parent Story [AAASM-199](https://lightning-dust-mite.atlassian.net/browse/AAASM-199); Epic [AAASM-196](https://lightning-dust-mite.atlassian.net/browse/AAASM-196))
- Related GitHub issues: n/a

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

8 unit tests in `aa-core/src/dev_tool.rs` covering:

* `governance_level_ordering_l0_to_l3` — strict total order.
* `governance_level_discriminants_are_0_through_3` — repr-stable discriminants.
* `devtool_kind_built_in_variants_are_distinct` — variant disjointness.
* `devtool_kind_custom_carries_identifier` — `Custom(String)` equality semantics.
* `devtool_kind_serde_round_trip_built_in` (serde) — JSON round-trip for built-in variants.
* `devtool_kind_serde_round_trip_custom` (serde) — JSON round-trip for `Custom`.
* `governance_level_serde_round_trip` (serde) — JSON round-trip for all 4 levels.
* `devtool_info_serde_round_trip` (serde) — JSON round-trip preserves every field.

Local validation run on this branch (worktree from latest `master`):

| Check | Command | Result |
|---|---|---|
| Build (default) | `cargo build -p aa-core` | OK |
| Build (no_std) | `cargo check -p aa-core --no-default-features` | OK |
| Tests (default) | `cargo test -p aa-core dev_tool::` | 4 / 4 passed |
| Tests (serde) | `cargo test -p aa-core --features serde dev_tool::` | 8 / 8 passed |
| Full aa-core suite | `cargo test -p aa-core --features serde` | 120 / 120 passed |
| Format | `cargo fmt --all -- --check` | clean |
| Clippy | `cargo clippy -p aa-core --all-targets --all-features -- -D warnings` | clean |
| Doc | `cargo doc -p aa-core --no-deps --all-features` | clean |
| Workspace check | `cargo check --workspace --exclude aa-ebpf*` | OK |

(`cargo nextest` not available locally; CI will run the canonical suite.)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing (verified locally; CI will confirm)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-919]: https://lightning-dust-mite.atlassian.net/browse/AAASM-919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ