### PR TITLE
[AAASM-919] ✨ (aa-core): Add DevToolKind, GovernanceLevel, DevToolInfo types

### DIFF
--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -14,7 +14,7 @@ sha2   = { version = "0.11", default-features = false, optional = true }
 
 [features]
 default    = ["std"]
-std        = ["alloc", "dep:aho-corasick"]
+std        = ["alloc", "dep:aho-corasick", "serde?/std"]
 alloc      = ["dep:sha2"]
 serde      = ["dep:serde"]
 test-utils = []

--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -7,6 +7,8 @@
 
 #[cfg(feature = "alloc")]
 use alloc::string::String;
+#[cfg(feature = "std")]
+use std::path::PathBuf;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -61,4 +63,26 @@ pub enum DevToolKind {
     WindsurfCascade,
     /// Adapter-defined custom tool identified by an opaque name string.
     Custom(String),
+}
+
+/// Static metadata describing a detected AI dev tool installation.
+///
+/// Returned by `DevToolAdapter::detect` and used to drive registry
+/// decisions, managed-settings generation, and per-tool launch wiring.
+#[cfg(feature = "std")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct DevToolInfo {
+    /// Concrete tool variant.
+    pub kind: DevToolKind,
+    /// Tool version string, if reported by the binary.
+    pub version: Option<String>,
+    /// Absolute path to the installed tool binary.
+    pub install_path: PathBuf,
+    /// Highest governance level this installation can operate at.
+    pub governance_level: GovernanceLevel,
+    /// Whether the tool exposes MCP server configuration we can govern.
+    pub supports_mcp: bool,
+    /// Whether the tool reads governance config from a managed-settings file.
+    pub supports_managed_settings: bool,
 }

--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -86,3 +86,16 @@ pub struct DevToolInfo {
     /// Whether the tool reads governance config from a managed-settings file.
     pub supports_managed_settings: bool,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn governance_level_orders_l0_through_l3() {
+        assert!(GovernanceLevel::L0Discover < GovernanceLevel::L1Observe);
+        assert!(GovernanceLevel::L1Observe < GovernanceLevel::L2Enforce);
+        assert!(GovernanceLevel::L2Enforce < GovernanceLevel::L3Native);
+        assert!(GovernanceLevel::L0Discover < GovernanceLevel::L3Native);
+    }
+}

--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -115,4 +115,21 @@ mod tests {
             assert_eq!(restored, original);
         }
     }
+
+    #[cfg(all(feature = "serde", feature = "std"))]
+    #[test]
+    fn dev_tool_info_round_trips_via_serde_json() {
+        let original = DevToolInfo {
+            kind: DevToolKind::ClaudeCode,
+            version: Some(String::from("1.2.3")),
+            install_path: PathBuf::from("/usr/local/bin/claude"),
+            governance_level: GovernanceLevel::L2Enforce,
+            supports_mcp: true,
+            supports_managed_settings: false,
+        };
+        let json1 = serde_json::to_string(&original).expect("serialize");
+        let restored: DevToolInfo = serde_json::from_str(&json1).expect("deserialize");
+        let json2 = serde_json::to_string(&restored).expect("re-serialize");
+        assert_eq!(json1, json2);
+    }
 }

--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -1,0 +1,39 @@
+//! Foundational types for the AI dev tool governance framework.
+//!
+//! These types are referenced by the `DevToolAdapter` trait and by every
+//! per-tool adapter (Claude Code, Codex, GitHub Copilot, Windsurf Cascade).
+//! They are intentionally light and free of runtime dependencies so that
+//! adapters can be implemented in `no_std` contexts where applicable.
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Governance level applied to a managed AI dev tool or agent.
+///
+/// Variants are ordered such that
+/// `L0Discover < L1Observe < L2Enforce < L3Native`. The derived `Ord`
+/// implementation enables policies to express "at-least-this-level" rules,
+/// for example `governance_level >= L2Enforce`.
+///
+/// | Level | Capability |
+/// | --- | --- |
+/// | [`L0Discover`][Self::L0Discover] | eBPF / proxy detects unknown agents and their external behavior. |
+/// | [`L1Observe`][Self::L1Observe] | Network, file, process, and MCP observability without enforcement. |
+/// | [`L2Enforce`][Self::L2Enforce] | Allow / deny, approval, redaction, and budget enforcement. |
+/// | [`L3Native`][Self::L3Native] | Full SDK-integrated governance with identity, lineage, and semantic context. |
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum GovernanceLevel {
+    /// L0 — Discover. eBPF / proxy detects unknown agents and their
+    /// external behavior; no policy enforcement is applied.
+    L0Discover,
+    /// L1 — Observe. Network, file, process, and MCP observability
+    /// without enforcement.
+    L1Observe,
+    /// L2 — Enforce. Allow / deny, approval, redaction, and budget
+    /// enforcement applied to the governed tool.
+    L2Enforce,
+    /// L3 — Native. Full SDK-integrated governance with identity,
+    /// lineage, and semantic context awareness.
+    L3Native,
+}

--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -98,4 +98,21 @@ mod tests {
         assert!(GovernanceLevel::L2Enforce < GovernanceLevel::L3Native);
         assert!(GovernanceLevel::L0Discover < GovernanceLevel::L3Native);
     }
+
+    #[cfg(all(feature = "serde", feature = "alloc"))]
+    #[test]
+    fn dev_tool_kind_round_trips_via_serde_json() {
+        let cases = [
+            DevToolKind::ClaudeCode,
+            DevToolKind::Codex,
+            DevToolKind::GitHubCopilot,
+            DevToolKind::WindsurfCascade,
+            DevToolKind::Custom(String::from("MyEditor")),
+        ];
+        for original in cases {
+            let json = serde_json::to_string(&original).expect("serialize");
+            let restored: DevToolKind = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(restored, original);
+        }
+    }
 }

--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -5,6 +5,9 @@
 //! They are intentionally light and free of runtime dependencies so that
 //! adapters can be implemented in `no_std` contexts where applicable.
 
+#[cfg(feature = "alloc")]
+use alloc::string::String;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -36,4 +39,26 @@ pub enum GovernanceLevel {
     /// L3 — Native. Full SDK-integrated governance with identity,
     /// lineage, and semantic context awareness.
     L3Native,
+}
+
+/// Concrete kind of AI dev tool being governed.
+///
+/// Concrete variants are matched against built-in `DevToolAdapter`
+/// implementations. The [`Custom`][Self::Custom] variant lets out-of-tree
+/// adapters identify themselves by name without requiring a code change
+/// to this enum.
+#[cfg(feature = "alloc")]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum DevToolKind {
+    /// Anthropic Claude Code (CLI).
+    ClaudeCode,
+    /// OpenAI Codex CLI.
+    Codex,
+    /// GitHub Copilot operating in agent mode.
+    GitHubCopilot,
+    /// Codeium Windsurf Cascade IDE agent.
+    WindsurfCascade,
+    /// Adapter-defined custom tool identified by an opaque name string.
+    Custom(String),
 }

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -39,10 +39,10 @@ pub use policy::{FileMode, PolicyDecision, PolicyError};
 
 #[cfg(feature = "alloc")]
 pub use agent::AgentContext;
-#[cfg(feature = "alloc")]
-pub use dev_tool::DevToolKind;
 #[cfg(feature = "std")]
 pub use dev_tool::DevToolInfo;
+#[cfg(feature = "alloc")]
+pub use dev_tool::DevToolKind;
 
 #[cfg(feature = "alloc")]
 pub use policy::{ArgsJson, GovernanceAction, PolicyDocument, PolicyEvaluator, PolicyResult, PolicyRule};

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -25,6 +25,7 @@ cfg_if::cfg_if! {
 pub mod agent;
 #[cfg(feature = "alloc")]
 pub mod audit;
+pub mod dev_tool;
 pub mod evaluators;
 pub mod identity;
 pub mod policy;

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -33,11 +33,16 @@ pub mod policy;
 pub mod scanner;
 pub mod time;
 
+pub use dev_tool::GovernanceLevel;
 pub use identity::{AgentId, SessionId};
 pub use policy::{FileMode, PolicyDecision, PolicyError};
 
 #[cfg(feature = "alloc")]
 pub use agent::AgentContext;
+#[cfg(feature = "alloc")]
+pub use dev_tool::DevToolKind;
+#[cfg(feature = "std")]
+pub use dev_tool::DevToolInfo;
 
 #[cfg(feature = "alloc")]
 pub use policy::{ArgsJson, GovernanceAction, PolicyDocument, PolicyEvaluator, PolicyResult, PolicyRule};


### PR DESCRIPTION
## Description

Introduces the foundational data types for the dev tool governance framework as a focused, additive change in `aa-core`:

- `GovernanceLevel` enum (L0–L3) with documented `Ord` invariant `L0Discover < L1Observe < L2Enforce < L3Native`.
- `DevToolKind` enum naming the four built-in adapters plus a `Custom(String)` escape hatch.
- `DevToolInfo` struct capturing detection metadata (kind, version, install path, level, capability flags).
- Re-exports from `aa-core/src/lib.rs` for ergonomic access.
- Cargo feature plumbing: `std` now forwards to `serde?/std` so `PathBuf` participates in serde derives when both features are active.
- Unit tests covering ordering invariant + `DevToolKind` and `DevToolInfo` serde round-trips.

These types are the minimum surface unblocked of `DevToolAdapter` (next AAASM-199 sub-task) and downstream consumers — including AAASM-1041 (F79 governance level in policy schema), which is gated on this PR.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Purely additive: no existing public items renamed, removed, or behavior changed.

## Related Issues

- Related Jira ticket: [AAASM-919](https://lightning-dust-mite.atlassian.net/browse/AAASM-919)
- Parent Story: [AAASM-199](https://lightning-dust-mite.atlassian.net/browse/AAASM-199) (F72: Define DevToolAdapter trait)
- Unblocks: [AAASM-1041](https://lightning-dust-mite.atlassian.net/browse/AAASM-1041) (F79 governance level in policy schema)
- Epic: [AAASM-196](https://lightning-dust-mite.atlassian.net/browse/AAASM-196)

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Three unit tests in `aa_core::dev_tool::tests`:

- `governance_level_orders_l0_through_l3` — locks the documented ordering.
- `dev_tool_kind_round_trips_via_serde_json` — every variant + `Custom`.
- `dev_tool_info_round_trips_via_serde_json` — round-trip equivalence by re-serialization (the AC does not require `PartialEq` on `DevToolInfo`).

Local validation:

```
cargo check -p aa-core --all-features        # clean
cargo check -p aa-core --no-default-features # clean (no_std build)
cargo fmt --all -- --check                   # clean
cargo clippy -p aa-core --all-targets --all-features -- -D warnings  # clean
cargo test  -p aa-core --all-features        # 118 passed, 0 failed
cargo doc   -p aa-core --no-deps --all-features  # clean
```

`cargo deny check` could not run locally due to a CVSS 4.0 advisory parse issue in my local advisory DB; CI will run the canonical version.

`cargo clippy --workspace --all-targets --all-features` flags one pre-existing `clippy::items_after_test_module` violation in `aa-ebpf/src/tracepoint.rs` (line 130) — confirmed reproducible on `master` without this PR's changes; out of scope here.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing (will be confirmed by CI)
- [x] Commits are small and follow the Gitmoji convention

## Commit history

8 small commits, each a single logical unit:

1. `✨ (aa-core): Add GovernanceLevel enum (L0–L3)`
2. `✨ (aa-core): Add DevToolKind enum`
3. `✨ (aa-core): Add DevToolInfo struct`
4. `🔧 (aa-core): Re-export dev_tool types from lib.rs`
5. `✅ (aa-core): Test GovernanceLevel ordering invariant`
6. `✅ (aa-core): Test DevToolKind serde round-trip`
7. `✅ (aa-core): Test DevToolInfo serde round-trip`
8. `🚨 (aa-core): Fix dev_tool re-export ordering for cargo fmt`

[AAASM-919]: https://lightning-dust-mite.atlassian.net/browse/AAASM-919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ