### PR TITLE
[AAASM-947] ✨ (policy/scope): Add PolicyScope enum + YAML parser

### DIFF
--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -516,6 +516,7 @@ mod tests {
             name: None,
             policy_version: None,
             version: None,
+            scope: crate::policy::scope::PolicyScope::Global,
             network: None,
             schedule: None,
             budget: None,

--- a/aa-gateway/src/policy/document.rs
+++ b/aa-gateway/src/policy/document.rs
@@ -1,5 +1,7 @@
 //! Validated, strongly-typed policy document types for aa-gateway.
 
+use crate::policy::scope::PolicyScope;
+
 /// Validated network egress policy.
 #[derive(Debug, Clone, PartialEq)]
 pub struct NetworkPolicy {
@@ -77,6 +79,10 @@ pub struct PolicyDocument {
     pub policy_version: Option<String>,
     /// Schema version string.
     pub version: Option<String>,
+    /// Hierarchical scope this policy applies to. Defaults to
+    /// [`PolicyScope::Global`] when the `scope` YAML field is absent so
+    /// pre-F92 policies keep their existing semantics.
+    pub scope: PolicyScope,
     /// Network egress policy.
     pub network: Option<NetworkPolicy>,
     /// Schedule / active-hours policy.
@@ -101,6 +107,7 @@ mod tests {
             name: None,
             policy_version: None,
             version: None,
+            scope: PolicyScope::Global,
             network: None,
             schedule: None,
             budget: None,

--- a/aa-gateway/src/policy/error.rs
+++ b/aa-gateway/src/policy/error.rs
@@ -2,6 +2,34 @@
 
 use std::fmt;
 
+/// An error produced while parsing a policy fragment from its string form.
+///
+/// Distinct from [`ValidationError`] because it is raised during low-level
+/// `FromStr` parsing (e.g. of [`super::scope::PolicyScope`]) before any
+/// document-level validation runs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PolicyParseError {
+    /// The raw scope string did not match any recognised form.
+    InvalidScope {
+        /// The original string that failed to parse.
+        raw: String,
+        /// Human-readable explanation of the failure.
+        reason: String,
+    },
+}
+
+impl fmt::Display for PolicyParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidScope { raw, reason } => {
+                write!(f, "invalid policy scope {:?}: {}", raw, reason)
+            }
+        }
+    }
+}
+
+impl std::error::Error for PolicyParseError {}
+
 /// An error produced during policy document validation.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ValidationError {

--- a/aa-gateway/src/policy/mod.rs
+++ b/aa-gateway/src/policy/mod.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub(crate) mod expr;
 pub mod history;
 pub mod raw;
+pub mod scope;
 pub mod validator;
 
 pub use document::{ActiveHours, BudgetPolicy, DataPolicy, NetworkPolicy, PolicyDocument, SchedulePolicy, ToolPolicy};

--- a/aa-gateway/src/policy/mod.rs
+++ b/aa-gateway/src/policy/mod.rs
@@ -11,5 +11,6 @@ pub mod scope;
 pub mod validator;
 
 pub use document::{ActiveHours, BudgetPolicy, DataPolicy, NetworkPolicy, PolicyDocument, SchedulePolicy, ToolPolicy};
-pub use error::{ValidationError, ValidationWarning};
+pub use error::{PolicyParseError, ValidationError, ValidationWarning};
+pub use scope::{OrgId, PolicyScope, TeamId};
 pub use validator::{PolicyValidator, PolicyValidatorOutput};

--- a/aa-gateway/src/policy/raw.rs
+++ b/aa-gateway/src/policy/raw.rs
@@ -100,6 +100,10 @@ pub struct GovernancePolicyEnvelope {
 pub struct RawPolicyDocument {
     /// Version tag from the YAML front-matter.
     pub version: Option<String>,
+    /// Optional hierarchical scope this policy applies to. When absent the
+    /// validator defaults to [`crate::policy::scope::PolicyScope::Global`] so
+    /// pre-F92 policy files keep their existing semantics.
+    pub scope: Option<crate::policy::scope::PolicyScope>,
     /// Network egress policy.
     pub network: Option<RawNetworkPolicy>,
     /// Schedule / active-hours policy.

--- a/aa-gateway/src/policy/scope.rs
+++ b/aa-gateway/src/policy/scope.rs
@@ -2,3 +2,28 @@
 //!
 //! See AAASM-219 (F92) for the design. Subsequent Sub-tasks will extend this
 //! module with the `Tool(...)` variant and a scope index inside `PolicyEngine`.
+
+use aa_core::identity::AgentId;
+
+/// String identifier for an organisation. May be promoted to a newtype later.
+pub type OrgId = String;
+
+/// String identifier for a team. May be promoted to a newtype later.
+pub type TeamId = String;
+
+/// Hierarchical scope a policy applies to.
+///
+/// Resolution order is `Global → Org → Team → Agent`, with most-restrictive-wins
+/// merging performed by [`crate::engine::PolicyEngine`] (wired in F93). The
+/// `Tool` variant for a 5-level chain is added by AAASM-1008.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum PolicyScope {
+    /// Applies to every agent — the default for backward compatibility.
+    Global,
+    /// Applies to every agent inside the named organisation.
+    Org(OrgId),
+    /// Applies to every agent that belongs to the named team.
+    Team(TeamId),
+    /// Applies to a single specific agent.
+    Agent(AgentId),
+}

--- a/aa-gateway/src/policy/scope.rs
+++ b/aa-gateway/src/policy/scope.rs
@@ -114,8 +114,8 @@ impl FromStr for PolicyScope {
             "org" => Ok(Self::Org(value.to_owned())),
             "team" => Ok(Self::Team(value.to_owned())),
             "agent" => {
-                let uuid = Uuid::parse_str(value)
-                    .map_err(|e| invalid(&format!("agent id is not a valid UUID: {}", e)))?;
+                let uuid =
+                    Uuid::parse_str(value).map_err(|e| invalid(&format!("agent id is not a valid UUID: {}", e)))?;
                 Ok(Self::Agent(AgentId::from_bytes(*uuid.as_bytes())))
             }
             other => Err(invalid(&format!("unknown scope kind {:?}", other))),

--- a/aa-gateway/src/policy/scope.rs
+++ b/aa-gateway/src/policy/scope.rs
@@ -3,7 +3,10 @@
 //! See AAASM-219 (F92) for the design. Subsequent Sub-tasks will extend this
 //! module with the `Tool(...)` variant and a scope index inside `PolicyEngine`.
 
+use std::fmt;
+
 use aa_core::identity::AgentId;
+use uuid::Uuid;
 
 /// String identifier for an organisation. May be promoted to a newtype later.
 pub type OrgId = String;
@@ -26,4 +29,15 @@ pub enum PolicyScope {
     Team(TeamId),
     /// Applies to a single specific agent.
     Agent(AgentId),
+}
+
+impl fmt::Display for PolicyScope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Global => f.write_str("global"),
+            Self::Org(id) => write!(f, "org:{}", id),
+            Self::Team(id) => write!(f, "team:{}", id),
+            Self::Agent(id) => write!(f, "agent:{}", Uuid::from_bytes(*id.as_bytes())),
+        }
+    }
 }

--- a/aa-gateway/src/policy/scope.rs
+++ b/aa-gateway/src/policy/scope.rs
@@ -1,0 +1,4 @@
+//! Policy scope hierarchy types (`global` / `org:<id>` / `team:<id>` / `agent:<uuid>`).
+//!
+//! See AAASM-219 (F92) for the design. Subsequent Sub-tasks will extend this
+//! module with the `Tool(...)` variant and a scope index inside `PolicyEngine`.

--- a/aa-gateway/src/policy/scope.rs
+++ b/aa-gateway/src/policy/scope.rs
@@ -4,9 +4,12 @@
 //! module with the `Tool(...)` variant and a scope index inside `PolicyEngine`.
 
 use std::fmt;
+use std::str::FromStr;
 
 use aa_core::identity::AgentId;
 use uuid::Uuid;
+
+use crate::policy::error::PolicyParseError;
 
 /// String identifier for an organisation. May be promoted to a newtype later.
 pub type OrgId = String;
@@ -38,6 +41,41 @@ impl fmt::Display for PolicyScope {
             Self::Org(id) => write!(f, "org:{}", id),
             Self::Team(id) => write!(f, "team:{}", id),
             Self::Agent(id) => write!(f, "agent:{}", Uuid::from_bytes(*id.as_bytes())),
+        }
+    }
+}
+
+impl FromStr for PolicyScope {
+    type Err = PolicyParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let invalid = |reason: &str| PolicyParseError::InvalidScope {
+            raw: s.to_owned(),
+            reason: reason.to_owned(),
+        };
+
+        if s == "global" {
+            return Ok(Self::Global);
+        }
+
+        let (kind, value) = match s.split_once(':') {
+            Some(parts) => parts,
+            None => return Err(invalid("expected `global` or `<kind>:<id>`")),
+        };
+
+        if value.is_empty() {
+            return Err(invalid("identifier after ':' must not be empty"));
+        }
+
+        match kind {
+            "org" => Ok(Self::Org(value.to_owned())),
+            "team" => Ok(Self::Team(value.to_owned())),
+            "agent" => {
+                let uuid = Uuid::parse_str(value)
+                    .map_err(|e| invalid(&format!("agent id is not a valid UUID: {}", e)))?;
+                Ok(Self::Agent(AgentId::from_bytes(*uuid.as_bytes())))
+            }
+            other => Err(invalid(&format!("unknown scope kind {:?}", other))),
         }
     }
 }

--- a/aa-gateway/src/policy/scope.rs
+++ b/aa-gateway/src/policy/scope.rs
@@ -23,6 +23,48 @@ pub type TeamId = String;
 /// Resolution order is `Global → Org → Team → Agent`, with most-restrictive-wins
 /// merging performed by [`crate::engine::PolicyEngine`] (wired in F93). The
 /// `Tool` variant for a 5-level chain is added by AAASM-1008.
+///
+/// # Wire format
+///
+/// `PolicyScope` uses a single colon-separated string in YAML and other serde
+/// formats. The forms are:
+///
+/// | Variant         | Wire form                             |
+/// |-----------------|---------------------------------------|
+/// | `Global`        | `global`                              |
+/// | `Org(id)`       | `org:<id>`                            |
+/// | `Team(id)`      | `team:<id>`                           |
+/// | `Agent(uuid)`   | `agent:<hyphenated-uuid>`             |
+///
+/// # Examples
+///
+/// Round-tripping through `Display` and `FromStr`:
+///
+/// ```
+/// use aa_gateway::policy::scope::PolicyScope;
+///
+/// let scope: PolicyScope = "team:platform".parse().unwrap();
+/// assert_eq!(scope.to_string(), "team:platform");
+/// ```
+///
+/// Reading from YAML (`scope:` is the canonical key on a policy document):
+///
+/// ```
+/// use aa_gateway::policy::scope::PolicyScope;
+///
+/// let scope: PolicyScope = serde_yaml::from_str("org:acme").unwrap();
+/// assert_eq!(scope, PolicyScope::Org("acme".to_owned()));
+/// ```
+///
+/// Malformed inputs surface as
+/// [`PolicyParseError::InvalidScope`](crate::policy::error::PolicyParseError::InvalidScope):
+///
+/// ```
+/// use aa_gateway::policy::scope::PolicyScope;
+///
+/// assert!("project:foo".parse::<PolicyScope>().is_err());
+/// assert!("team:".parse::<PolicyScope>().is_err());
+/// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PolicyScope {
     /// Applies to every agent — the default for backward compatibility.

--- a/aa-gateway/src/policy/scope.rs
+++ b/aa-gateway/src/policy/scope.rs
@@ -7,6 +7,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use aa_core::identity::AgentId;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
 
 use crate::policy::error::PolicyParseError;
@@ -77,5 +78,18 @@ impl FromStr for PolicyScope {
             }
             other => Err(invalid(&format!("unknown scope kind {:?}", other))),
         }
+    }
+}
+
+impl Serialize for PolicyScope {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for PolicyScope {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        s.parse().map_err(serde::de::Error::custom)
     }
 }

--- a/aa-gateway/src/policy/scope.rs
+++ b/aa-gateway/src/policy/scope.rs
@@ -93,3 +93,114 @@ impl<'de> Deserialize<'de> for PolicyScope {
         s.parse().map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::error::PolicyParseError;
+
+    const AGENT_UUID: &str = "01234567-89ab-cdef-0123-456789abcdef";
+    const AGENT_BYTES: [u8; 16] = [
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+    ];
+
+    // ── FromStr happy paths ─────────────────────────────────────────────────
+
+    #[test]
+    fn parses_global() {
+        assert_eq!("global".parse::<PolicyScope>().unwrap(), PolicyScope::Global);
+    }
+
+    #[test]
+    fn parses_org_with_identifier() {
+        assert_eq!(
+            "org:acme".parse::<PolicyScope>().unwrap(),
+            PolicyScope::Org("acme".to_owned()),
+        );
+    }
+
+    #[test]
+    fn parses_team_with_identifier() {
+        assert_eq!(
+            "team:platform".parse::<PolicyScope>().unwrap(),
+            PolicyScope::Team("platform".to_owned()),
+        );
+    }
+
+    #[test]
+    fn parses_agent_with_uuid() {
+        let parsed = format!("agent:{}", AGENT_UUID).parse::<PolicyScope>().unwrap();
+        assert_eq!(parsed, PolicyScope::Agent(AgentId::from_bytes(AGENT_BYTES)));
+    }
+
+    // ── Display round-trip ──────────────────────────────────────────────────
+
+    #[test]
+    fn display_round_trips_for_each_variant() {
+        let cases = [
+            PolicyScope::Global,
+            PolicyScope::Org("acme".to_owned()),
+            PolicyScope::Team("platform".to_owned()),
+            PolicyScope::Agent(AgentId::from_bytes(AGENT_BYTES)),
+        ];
+        for original in cases {
+            let rendered = original.to_string();
+            let reparsed: PolicyScope = rendered.parse().unwrap();
+            assert_eq!(reparsed, original, "round-trip failed for {}", rendered);
+        }
+    }
+
+    // ── serde YAML round-trip ───────────────────────────────────────────────
+
+    #[test]
+    fn serde_yaml_round_trips_for_each_variant() {
+        let cases = [
+            PolicyScope::Global,
+            PolicyScope::Org("acme".to_owned()),
+            PolicyScope::Team("platform".to_owned()),
+            PolicyScope::Agent(AgentId::from_bytes(AGENT_BYTES)),
+        ];
+        for original in cases {
+            let yaml = serde_yaml::to_string(&original).unwrap();
+            let reparsed: PolicyScope = serde_yaml::from_str(&yaml).unwrap();
+            assert_eq!(reparsed, original, "serde round-trip failed for {}", yaml);
+        }
+    }
+
+    // ── FromStr error paths ─────────────────────────────────────────────────
+
+    fn assert_invalid_scope(raw: &str, expected_substring: &str) {
+        let err = raw.parse::<PolicyScope>().unwrap_err();
+        match err {
+            PolicyParseError::InvalidScope { raw: got_raw, reason } => {
+                assert_eq!(got_raw, raw);
+                assert!(
+                    reason.contains(expected_substring),
+                    "reason {:?} did not contain {:?}",
+                    reason,
+                    expected_substring
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_string_without_colon_or_global() {
+        assert_invalid_scope("acme", "expected `global`");
+    }
+
+    #[test]
+    fn rejects_unknown_scope_kind() {
+        assert_invalid_scope("project:foo", "unknown scope kind");
+    }
+
+    #[test]
+    fn rejects_empty_identifier_after_kind() {
+        assert_invalid_scope("team:", "must not be empty");
+    }
+
+    #[test]
+    fn rejects_agent_with_non_uuid_value() {
+        assert_invalid_scope("agent:not-a-uuid", "valid UUID");
+    }
+}

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -770,6 +770,44 @@ data:
         );
     }
 
+    /// Parameterised coverage for every malformed-scope shape the validator
+    /// must reject. Each row is `(quoted YAML scalar, substring expected in
+    /// the diagnostic)`. The substring lets the test stay robust against
+    /// minor wording changes in `PolicyParseError::Display`.
+    #[test]
+    fn every_malformed_scope_form_is_rejected_with_useful_diagnostic() {
+        let cases: &[(&str, &str)] = &[
+            // Empty quoted string — neither `global` nor `<kind>:<id>`.
+            ("\"\"", "expected `global`"),
+            // No colon and not `global`.
+            ("acme", "expected `global`"),
+            // Empty identifier after the colon.
+            ("\"team:\"", "must not be empty"),
+            // Unknown scope kind.
+            ("project:foo", "unknown scope kind"),
+            // Agent variant with a non-UUID identifier.
+            ("agent:not-a-uuid", "valid UUID"),
+        ];
+
+        for (yaml_scalar, expected_substring) in cases {
+            let yaml = format!("scope: {}\n", yaml_scalar);
+            let result = PolicyValidator::from_yaml(&yaml);
+            assert!(
+                result.is_err(),
+                "expected error for malformed scope {:?}",
+                yaml_scalar,
+            );
+            let errs = result.unwrap_err();
+            assert!(
+                errs.iter().any(|e| e.message.contains(expected_substring)),
+                "for scope {:?} expected diagnostic containing {:?}, got {:?}",
+                yaml_scalar,
+                expected_substring,
+                errs,
+            );
+        }
+    }
+
     // ── Approval timeout validation ──────────────────────────────────────────
 
     #[test]

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -9,6 +9,7 @@ use crate::policy::{
     },
     error::{ValidationError, ValidationWarning},
     raw::{GovernancePolicyEnvelope, RawPolicyDocument},
+    scope::PolicyScope,
 };
 
 /// Result of a successful parse+validate pass.
@@ -71,6 +72,7 @@ impl PolicyValidator {
                 name: meta_name,
                 policy_version: meta_version,
                 version: raw.version,
+                scope: raw.scope.unwrap_or(PolicyScope::Global),
                 network,
                 schedule,
                 budget,

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -792,11 +792,7 @@ data:
         for (yaml_scalar, expected_substring) in cases {
             let yaml = format!("scope: {}\n", yaml_scalar);
             let result = PolicyValidator::from_yaml(&yaml);
-            assert!(
-                result.is_err(),
-                "expected error for malformed scope {:?}",
-                yaml_scalar,
-            );
+            assert!(result.is_err(), "expected error for malformed scope {:?}", yaml_scalar,);
             let errs = result.unwrap_err();
             assert!(
                 errs.iter().any(|e| e.message.contains(expected_substring)),

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -727,6 +727,49 @@ data:
         assert!(out.document.network.is_none());
     }
 
+    // ── Scope field (F92) ───────────────────────────────────────────────────
+
+    #[test]
+    fn scope_absent_defaults_to_global_for_backward_compatibility() {
+        let yaml = "{}\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        assert_eq!(out.document.scope, PolicyScope::Global);
+    }
+
+    #[test]
+    fn scope_team_field_round_trips_through_validator() {
+        let yaml = "scope: team:platform\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        assert_eq!(out.document.scope, PolicyScope::Team("platform".to_owned()));
+    }
+
+    #[test]
+    fn scope_org_field_round_trips_through_validator() {
+        let yaml = "scope: org:acme\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        assert_eq!(out.document.scope, PolicyScope::Org("acme".to_owned()));
+    }
+
+    #[test]
+    fn scope_global_field_is_accepted() {
+        let yaml = "scope: global\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        assert_eq!(out.document.scope, PolicyScope::Global);
+    }
+
+    #[test]
+    fn malformed_scope_field_is_rejected_at_parse_time() {
+        let yaml = "scope: project:foo\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err(), "expected validation error for unknown scope kind");
+        let errs = result.unwrap_err();
+        assert!(
+            errs.iter().any(|e| e.message.contains("invalid policy scope")),
+            "expected error message mentioning invalid scope, got {:?}",
+            errs,
+        );
+    }
+
     // ── Approval timeout validation ──────────────────────────────────────────
 
     #[test]


### PR DESCRIPTION
## Description

Implements **AAASM-947** — Phase A of the F92 policy scope hierarchy
(parent Story `AAASM-219`, Epic `AAASM-198`).

Introduces a new `aa-gateway::policy::scope` module containing the
`PolicyScope` enum (`Global` / `Org(String)` / `Team(String)` /
`Agent(AgentId)`), its YAML wire format, and the supporting parse
error type. The `Tool(...)` variant for the 5-level chain is
deliberately deferred to AAASM-1008.

### What's in the diff

* `aa-gateway/src/policy/scope.rs` — new module with the `PolicyScope`
  enum, `Display`/`FromStr` round-trip, manual serde impls that route
  through the canonical string form, and rustdoc with three runnable
  examples.
* `aa-gateway/src/policy/error.rs` — adds `PolicyParseError`
  with the `InvalidScope { raw, reason }` variant.
* `aa-gateway/src/policy/raw.rs` — `RawPolicyDocument` gains
  `scope: Option<PolicyScope>`.
* `aa-gateway/src/policy/document.rs` — `PolicyDocument` gains
  `scope: PolicyScope`, populated by the validator and defaulting
  to `PolicyScope::Global` when the `scope:` YAML field is absent.
* `aa-gateway/src/policy/validator.rs` — wires the field through
  the validator pipeline; adds five new validator tests covering
  the full happy / unhappy paths plus a backward-compat assertion.
* `aa-gateway/src/engine/mod.rs` — updates the existing `empty_doc()`
  test helper to construct `PolicyDocument` with `scope: Global`.

### Module placement note

The Sub-task description references `aa-policy-engine::scope`, but no
such crate exists in this repo. The policy YAML schema lives in
`aa-gateway::policy`, so `PolicyScope` is co-located with
`document` / `raw` / `validator`. The Phase B Sub-task (`AAASM-951`)
will extend this module with the scope index inside `PolicyEngine`
without merge conflicts.

### Dependency on `AAASM-209`

`AAASM-209` (Registry tree index for *agent → team* runtime resolution)
is still `To Do`. F92's acceptance criteria are about schema, parser,
and (in Phase B) the scope index — they do not require runtime team
resolution. Wiring agents to their team is owned by F93 (`AAASM-220`).
This Sub-task therefore unblocks itself cleanly.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No (`PolicyDocument` gains a new field but the validator defaults
      to `PolicyScope::Global` when the `scope:` YAML key is absent —
      every pre-F92 policy keeps its existing semantics).

## Related Issues

- Related Jira ticket: AAASM-947 (Sub-task) → AAASM-219 (Story F92) → AAASM-198 (Epic)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated (validator-level scope tests)
- [ ] Manual testing performed
- [ ] No tests required (explain why)

### Local validation

| Command | Result |
| --- | --- |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -p aa-gateway --all-targets -- -D warnings` | clean |
| `cargo test -p aa-gateway --lib policy::` | **126** passed, 0 failed |
| `cargo test -p aa-gateway --doc policy::scope::` | 3 passed, 0 failed |

### Pre-existing flaky perf test

`tests/policy_latency_test.rs::sustained_load_p99_under_5ms` failed
once on the developer machine in the **debug build** while the
machine was still warm from compilation. The test passes cleanly
when re-run in `--release`, which is the mode it was actually
designed for. The diff in this PR does not touch the perf test or
any code on the gRPC `PolicyService::CheckAction` hot path — full
diff against `remote/master` for `aa-gateway/tests/policy_latency_test.rs`
is empty. Flagging here so reviewers don't waste time chasing it
on CI; if it reappears it's an environmental issue or a pre-existing
flake to track separately.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc + 3 doc tests)
- [ ] All CI checks passing (CI not yet run at PR-open time)
- [x] Commits are small and follow the Gitmoji convention