### PR TITLE
[AAASM-1111] 📝 (docs): Bring README and CONTRIBUTING up to AAASM-313 acceptance criteria

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thank you for your interest in contributing! This guide explains how to set up y
 - **Rust stable** (≥ 1.75) — install via [rustup](https://rustup.rs/)
 - **cargo-nextest** — `cargo install cargo-nextest`
 - **cargo-deny** — `cargo install cargo-deny`
-- **Lefthook** — `brew install lefthook` (macOS) or see [install guide](https://github.com/evilmartians/lefthook/blob/master/docs/install.md)
+- **Lefthook** — `brew install lefthook` (macOS) or see [install guide](https://github.com/evilmartians/lefthook/blob/master/docs/install.md); the hook configuration lives in [`lefthook.toml`](lefthook.toml)
 
 ## Setup
 
@@ -15,7 +15,8 @@ Thank you for your interest in contributing! This guide explains how to set up y
 git clone https://github.com/AI-agent-assembly/agent-assembly.git
 cd agent-assembly
 
-# Install git hooks (runs fmt, clippy, deny on commit)
+# Install git hooks (runs fmt, clippy, deny on commit; doc on push)
+# See lefthook.toml for the full hook list.
 lefthook install
 
 # Verify the workspace builds

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ The easiest way is to pass `-s` (or `--signoff`) to `git commit`:
 git commit -s -m "✨ (aa-core): Add AgentId newtype wrapper"
 ```
 
-PRs whose commits are missing the sign-off trailer will be blocked by the DCO check.
+Sign-off is currently advisory: please include the trailer on every commit so the history is ready when the DCO GitHub App is enabled (tracked as a follow-up under Epic AAASM-13). At that point unsigned commits will block merge.
 
 ## Code Quality
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,28 @@ Examples:
 - `🐛 (aa-gateway): Fix policy evaluation order for overlapping rules`
 - `🔧 (ci): Add matrix build for MSRV check`
 
+## Adding a new crate
+
+To add a new crate to the workspace:
+
+1. Scaffold the crate with `cargo new --lib aa-<name>` from the repo root.
+2. Add `aa-<name>` to the `members` array in the top-level [`Cargo.toml`](Cargo.toml).
+3. In the new crate's `Cargo.toml`, inherit workspace metadata:
+
+   ```toml
+   [package]
+   name = "aa-<name>"
+   version.workspace = true
+   edition.workspace = true
+   license.workspace = true
+   repository.workspace = true
+   ```
+
+4. Use `[workspace.lints.clippy]` from the top-level `Cargo.toml` — do **not** redefine clippy lints per-crate.
+5. If the crate exposes a binary, declare it explicitly under `[[bin]]` (see [`aa-cli/Cargo.toml`](aa-cli/Cargo.toml) for the canonical example).
+6. Run `cargo build --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo doc --workspace --no-deps` to confirm the new crate integrates cleanly.
+7. Add the crate to the **Crate Map** table and **Repository Layout** tree in [`README.md`](README.md).
+
 ## Pull Requests
 
 - Open a PR against `master`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,26 @@ To add a new crate to the workspace:
 - CI must be green before review is requested.
 - At least **1 approval** from the Pioneer team is required to merge.
 
+## Developer Certificate of Origin (DCO)
+
+Every commit must be signed off under the [Developer Certificate of Origin v1.1](https://developercertificate.org/) — this licenses your contribution to the project under the [Apache License 2.0](LICENSE).
+
+Sign off by adding a `Signed-off-by` trailer to each commit message:
+
+```
+✨ (aa-core): Add AgentId newtype wrapper
+
+Signed-off-by: Jane Doe <jane@example.com>
+```
+
+The easiest way is to pass `-s` (or `--signoff`) to `git commit`:
+
+```bash
+git commit -s -m "✨ (aa-core): Add AgentId newtype wrapper"
+```
+
+PRs whose commits are missing the sign-off trailer will be blocked by the DCO check.
+
 ## Code Quality
 
 Pre-commit hooks enforce these automatically on every `git commit`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,13 +102,15 @@ PRs whose commits are missing the sign-off trailer will be blocked by the DCO ch
 
 Pre-commit hooks enforce these automatically on every `git commit`:
 
-| Check | Command |
-|---|---|
-| Formatting | `cargo fmt --all -- --check` |
-| Linting | `cargo clippy --all-targets -- -D warnings` |
-| Dependencies | `cargo deny check` |
+| Check | Command | Config |
+|---|---|---|
+| Formatting | `cargo fmt --all -- --check` | [`rustfmt.toml`](rustfmt.toml) |
+| Linting | `cargo clippy --all-targets -- -D warnings` | [`clippy.toml`](clippy.toml) + `[workspace.lints.clippy]` in [`Cargo.toml`](Cargo.toml) |
+| Dependencies | `cargo deny check` | [`deny.toml`](deny.toml) |
 
 On `git push`, documentation is also checked: `cargo doc --workspace --no-deps`.
+
+The workspace-level clippy lints (`correctness = deny`, `suspicious = deny`, others `warn`) live in `[workspace.lints.clippy]` of the top-level `Cargo.toml` — do not override them per-crate.
 
 ## Build docs locally
 

--- a/README.md
+++ b/README.md
@@ -14,16 +14,22 @@
 
 | Crate | Role |
 |---|---|
-| `aa-core` | Pure logic, `no_std` compatible domain types and traits |
-| `aa-runtime` | Tokio async runtime wrapper and lifecycle management |
-| `aa-ebpf` | eBPF-based kernel-level monitoring hooks |
-| `aa-proxy` | Sidecar traffic interception proxy |
+| `aa-core` | Pure logic, `no_std`-compatible domain types and traits |
+| `aa-proto` | Protobuf message types — single source of truth for the wire format |
+| `aa-runtime` | Tokio async runtime wrapper and agent lifecycle |
+| `aa-ebpf` | eBPF-based kernel-level monitoring hooks (orchestrator crate) |
+| `aa-ebpf-common` | Shared types between user-space and eBPF programs |
+| `aa-ebpf-probes` | Userspace probe loaders (uprobes for SSL libraries) |
+| `aa-ebpf-programs` | eBPF programs compiled to BPF bytecode |
+| `aa-proxy` | Sidecar HTTPS interception proxy (MitM with per-host CA) |
 | `aa-ffi-python` | Python FFI bindings via PyO3 |
 | `aa-ffi-node` | Node.js FFI bindings via napi-rs |
+| `aa-ffi-go` | Go FFI bindings via cgo |
 | `aa-wasm` | WebAssembly target via wasm-bindgen |
-| `aa-gateway` | Control plane — policy enforcement and agent registry |
+| `aa-gateway` | Control plane — policy enforcement, agent registry, budget tracking |
 | `aa-api` | HTTP presentation layer with OpenAPI spec generation (utoipa) |
 | `aa-cli` | `aasm` command-line tool |
+| `conformance` | Cross-SDK protocol conformance test harness |
 
 ## Project Status
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > Governance-native runtime for AI agents — open-source core.
 
 [![CI](https://github.com/AI-agent-assembly/agent-assembly/actions/workflows/ci.yml/badge.svg)](https://github.com/AI-agent-assembly/agent-assembly/actions/workflows/ci.yml)
+[![Docs](https://github.com/AI-agent-assembly/agent-assembly/actions/workflows/docs.yml/badge.svg)](https://github.com/AI-agent-assembly/agent-assembly/actions/workflows/docs.yml)
 [![codecov](https://codecov.io/gh/AI-agent-assembly/agent-assembly/branch/master/graph/badge.svg)](https://codecov.io/gh/AI-agent-assembly/agent-assembly)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 <!-- crates.io badge will be added once the first public crate (likely `aa-cli`) is published; tracked under Epic AAASM-13. -->

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - [cargo-nextest](https://nexte.st/) for running tests
 - [cargo-deny](https://embarkstudios.github.io/cargo-deny/) for dependency checks
 - [Lefthook](https://github.com/evilmartians/lefthook) for git hooks
+- **Linux only**: `pkg-config` and `libssl-dev` (or `openssl-devel` on RHEL-family) for native TLS in `aa-proxy`; eBPF crates additionally require a recent kernel with BTF and a nightly Rust toolchain (see `aa-ebpf/README.md`)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -94,15 +94,12 @@ The sidecar exposes:
 - The agent IPC socket at `/tmp/aa-runtime-my-agent-001.sock`
 - Readiness probe at `http://localhost:8080/ready`
 
-To exercise the governance gateway directly (without Docker), use one of the bundled YAML policies:
+To run only the governance gateway (without Docker), point it at one of the bundled YAML policies:
 
 ```bash
-# Terminal A — start the gateway against a sample policy file
+# Start the gateway gRPC server with a sample policy file.
+# Listens on 127.0.0.1:50051 by default; SDK shims and aa-proxy connect over gRPC.
 cargo run -p aa-gateway -- --policy policy-examples/low-risk.yaml
-
-# Terminal B — confirm the aasm CLI builds and reaches the gateway
-cargo run -p aa-cli -- version
-cargo run -p aa-cli -- status
 ```
 
 `policy-examples/{low,medium,high}-risk.yaml` are reference policies — pick one or write your own following the same schema.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,36 @@ cargo build --workspace
 cargo nextest run --workspace
 ```
 
+## Quickstart — sidecar + test agent
+
+Run `aa-runtime` as a sidecar against a placeholder agent using the [`examples/docker-compose`](examples/docker-compose/) stack:
+
+```bash
+# 1. Build the workspace (first time only)
+cargo build --workspace --exclude aa-ebpf
+
+# 2. Launch the sidecar + a stub agent container
+cd examples/docker-compose
+AA_API_KEY=dev-local-key docker compose up
+```
+
+The sidecar exposes:
+
+- The agent IPC socket at `/tmp/aa-runtime-my-agent-001.sock`
+- Health and metrics on `http://localhost:8080`
+
+To exercise it without Docker, run the gateway and CLI directly:
+
+```bash
+# Terminal A — start the gateway
+cargo run -p aa-gateway
+
+# Terminal B — confirm registry + topology via the aasm CLI
+cargo run -p aa-cli -- topology
+```
+
+Replace the `agent-stub` service in `examples/docker-compose/docker-compose.yml` with your own SDK-based agent image once `python-sdk`, `node-sdk`, or `go-sdk` is wired into your project.
+
 ## Repository Layout
 
 ```

--- a/README.md
+++ b/README.md
@@ -68,11 +68,12 @@ cd agent-assembly
 # Install git hooks
 lefthook install
 
-# Build all crates
-cargo build --workspace
+# Build all crates except aa-ebpf (eBPF crate requires a nightly toolchain;
+# CI excludes it the same way and validates it in a dedicated job).
+cargo build --workspace --exclude aa-ebpf
 
 # Run tests
-cargo nextest run --workspace
+cargo nextest run --workspace --exclude aa-ebpf
 ```
 
 ## Quickstart — sidecar + test agent
@@ -91,17 +92,20 @@ AA_API_KEY=dev-local-key docker compose up
 The sidecar exposes:
 
 - The agent IPC socket at `/tmp/aa-runtime-my-agent-001.sock`
-- Health and metrics on `http://localhost:8080`
+- Readiness probe at `http://localhost:8080/ready`
 
-To exercise it without Docker, run the gateway and CLI directly:
+To exercise the governance gateway directly (without Docker), use one of the bundled YAML policies:
 
 ```bash
-# Terminal A — start the gateway
-cargo run -p aa-gateway
+# Terminal A — start the gateway against a sample policy file
+cargo run -p aa-gateway -- --policy policy-examples/low-risk.yaml
 
-# Terminal B — confirm registry + topology via the aasm CLI
-cargo run -p aa-cli -- topology
+# Terminal B — confirm the aasm CLI builds and reaches the gateway
+cargo run -p aa-cli -- version
+cargo run -p aa-cli -- status
 ```
+
+`policy-examples/{low,medium,high}-risk.yaml` are reference policies — pick one or write your own following the same schema.
 
 Replace the `agent-stub` service in `examples/docker-compose/docker-compose.yml` with your own SDK-based agent image once `python-sdk`, `node-sdk`, or `go-sdk` is wired into your project.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Docs](https://github.com/AI-agent-assembly/agent-assembly/actions/workflows/docs.yml/badge.svg)](https://github.com/AI-agent-assembly/agent-assembly/actions/workflows/docs.yml)
 [![codecov](https://codecov.io/gh/AI-agent-assembly/agent-assembly/branch/master/graph/badge.svg)](https://codecov.io/gh/AI-agent-assembly/agent-assembly)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-<!-- crates.io badge will be added once the first public crate (likely `aa-cli`) is published; tracked under Epic AAASM-13. -->
+[![crates.io](https://img.shields.io/badge/crates.io-unpublished-lightgrey)](https://crates.io/)
 
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -65,20 +65,28 @@ cargo nextest run --workspace
 
 ```
 agent-assembly/
-├── aa-core/           # Domain types (no_std)
-├── aa-runtime/        # Async runtime wrapper
-├── aa-ebpf/           # eBPF hooks
-├── aa-proxy/          # Sidecar proxy
-├── aa-ffi-python/     # Python bindings
-├── aa-ffi-node/       # Node bindings
-├── aa-wasm/           # WASM target
-├── aa-gateway/        # Control plane
-├── aa-api/            # HTTP API + OpenAPI
-├── aa-cli/            # CLI tool (aasm)
-├── proto/             # Protobuf definitions
-├── openapi/           # OpenAPI spec
-├── dashboard/         # Community web UI (React + TypeScript)
-└── policy-examples/   # Example governance policies
+├── aa-core/             # Domain types (no_std)
+├── aa-proto/            # Protobuf message types (wire format)
+├── aa-runtime/          # Async runtime + agent lifecycle
+├── aa-ebpf/             # eBPF orchestrator
+├── aa-ebpf-common/      # Shared user/kernel types
+├── aa-ebpf-probes/      # Userspace probe loaders
+├── aa-ebpf-programs/    # eBPF programs (BPF bytecode)
+├── aa-proxy/            # Sidecar HTTPS proxy
+├── aa-ffi-python/       # Python bindings (PyO3)
+├── aa-ffi-node/         # Node bindings (napi-rs)
+├── aa-ffi-go/           # Go bindings (cgo)
+├── aa-wasm/             # WASM target
+├── aa-gateway/          # Control plane (policy, registry, budget)
+├── aa-api/              # HTTP API + OpenAPI
+├── aa-cli/              # CLI tool (aasm)
+├── conformance/         # Protocol conformance test harness
+├── proto/               # Protobuf source (.proto files)
+├── openapi/             # Generated OpenAPI v1 spec
+├── schemas/             # JSON schemas (compatibility matrix)
+├── dashboard/           # Community web UI (React + TypeScript)
+├── docs/                # mdBook contributor documentation
+└── policy-examples/     # Reference governance policies
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
 ## Requirements
 
 - Rust stable (≥ 1.75)
+- `protoc` — Protocol Buffers compiler (`brew install protobuf` on macOS, `apt-get install protobuf-compiler` on Debian/Ubuntu); required by `aa-proto` and `aa-gateway` build scripts
 - [cargo-nextest](https://nexte.st/) for running tests
 - [cargo-deny](https://embarkstudios.github.io/cargo-deny/) for dependency checks
 - [Lefthook](https://github.com/evilmartians/lefthook) for git hooks

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 [![CI](https://github.com/AI-agent-assembly/agent-assembly/actions/workflows/ci.yml/badge.svg)](https://github.com/AI-agent-assembly/agent-assembly/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/AI-agent-assembly/agent-assembly/branch/master/graph/badge.svg)](https://codecov.io/gh/AI-agent-assembly/agent-assembly)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+<!-- crates.io badge will be added once the first public crate (likely `aa-cli`) is published; tracked under Epic AAASM-13. -->
+
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -15,15 +15,17 @@
 
 ## Crate Map
 
+The Cargo workspace declares **14 members** in the top-level `Cargo.toml`. Two additional eBPF-target crates live alongside but are intentionally outside the workspace because they compile for the `bpfel-unknown-none` target.
+
+### Workspace members
+
 | Crate | Role |
 |---|---|
 | `aa-core` | Pure logic, `no_std`-compatible domain types and traits |
 | `aa-proto` | Protobuf message types — single source of truth for the wire format |
 | `aa-runtime` | Tokio async runtime wrapper and agent lifecycle |
-| `aa-ebpf` | eBPF-based kernel-level monitoring hooks (orchestrator crate) |
+| `aa-ebpf` | eBPF orchestrator (loads probes/programs via `aya-build`) |
 | `aa-ebpf-common` | Shared types between user-space and eBPF programs |
-| `aa-ebpf-probes` | Userspace probe loaders (uprobes for SSL libraries) |
-| `aa-ebpf-programs` | eBPF programs compiled to BPF bytecode |
 | `aa-proxy` | Sidecar HTTPS interception proxy (MitM with per-host CA) |
 | `aa-ffi-python` | Python FFI bindings via PyO3 |
 | `aa-ffi-node` | Node.js FFI bindings via napi-rs |
@@ -33,6 +35,15 @@
 | `aa-api` | HTTP presentation layer with OpenAPI spec generation (utoipa) |
 | `aa-cli` | `aasm` command-line tool |
 | `conformance` | Cross-SDK protocol conformance test harness |
+
+### Out-of-workspace eBPF target crates
+
+These two are built by `aa-ebpf/build.rs` (via `aya-build`) for the BPF target — they are not part of the host workspace and cannot be selected with `cargo -p`:
+
+| Crate | Role |
+|---|---|
+| `aa-ebpf-probes` | Userspace probe loaders (uprobes for SSL libraries) |
+| `aa-ebpf-programs` | eBPF programs compiled to BPF bytecode (`bpfel-unknown-none`) |
 
 ## Project Status
 
@@ -101,10 +112,10 @@ agent-assembly/
 ├── aa-core/             # Domain types (no_std)
 ├── aa-proto/            # Protobuf message types (wire format)
 ├── aa-runtime/          # Async runtime + agent lifecycle
-├── aa-ebpf/             # eBPF orchestrator
-├── aa-ebpf-common/      # Shared user/kernel types
-├── aa-ebpf-probes/      # Userspace probe loaders
-├── aa-ebpf-programs/    # eBPF programs (BPF bytecode)
+├── aa-ebpf/             # eBPF orchestrator (workspace member)
+├── aa-ebpf-common/      # Shared user/kernel types (workspace member)
+├── aa-ebpf-probes/      # Userspace probe loaders (out-of-workspace, BPF target)
+├── aa-ebpf-programs/    # eBPF programs (out-of-workspace, BPF target)
 ├── aa-proxy/            # Sidecar HTTPS proxy
 ├── aa-ffi-python/       # Python bindings (PyO3)
 ├── aa-ffi-node/         # Node bindings (napi-rs)


### PR DESCRIPTION
## Description

Enhance the top-level `README.md` and `CONTRIBUTING.md` so a new contributor can build, test, and submit a PR without external help, satisfying the acceptance criteria from Story [AAASM-313](https://lightning-dust-mite.atlassian.net/browse/AAASM-313).

Tracked by Jira **[AAASM-1111](https://lightning-dust-mite.atlassian.net/browse/AAASM-1111)**. Stacked on top of [AAASM-1168](https://lightning-dust-mite.atlassian.net/browse/AAASM-1168) (mdBook scaffold) — base remains `master`; once AAASM-1168 merges this PR's diff narrows to README/CONTRIBUTING only.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-1111 (parent: AAASM-313, Epic: AAASM-13)
- Depends on: AAASM-1168
- Related GitHub issues: —

## Testing

Describe the testing performed for this PR:

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

Manual verification on macOS:

- Every command in the README's *Requirements*, *Getting Started*, and *Quickstart* sections copy-pasted and confirmed runnable
- ``cargo build --workspace --exclude aa-ebpf`` succeeds
- ``cargo install --locked --version 0.5.2 mdbook && mdbook build docs`` succeeds (no regression of AAASM-1168)
- All ``[link](path)`` references in the new sections resolve to existing files in the tree

## What changed

- **README.md**
  - Add ``protoc`` and Linux system-deps to prerequisites
  - Sync the *Crate Map* and *Repository Layout* with the actual 14-crate workspace (added ``aa-proto``, ``aa-ffi-go``, ``aa-ebpf-{common,probes,programs}``, ``conformance``, ``schemas/``, ``docs/``)
  - Add a *Quickstart* section showing the ``examples/docker-compose`` sidecar + stub-agent flow plus a non-Docker ``cargo run -p aa-gateway`` path
  - Add a *Docs* badge (linked to ``.github/workflows/docs.yml``) and a comment noting the crates.io badge is deferred until first publish
- **CONTRIBUTING.md**
  - Add an *Adding a new crate* walkthrough referencing ``Cargo.toml`` workspace members and ``[workspace.lints.clippy]``
  - Add a *Developer Certificate of Origin (DCO)* sign-off requirement with ``git commit -s`` example
  - Reference ``clippy.toml``, ``rustfmt.toml``, ``deny.toml`` in the *Code Quality* table
  - Link to ``lefthook.toml`` from the setup section

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

[AAASM-313]: https://lightning-dust-mite.atlassian.net/browse/AAASM-313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1111]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1168]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ