### PR TITLE
[AAASM-1041] ✨ (policy): Add governance_level (L0–L3) to schema + AgentRecord + evaluator

### DIFF
--- a/aa-api/tests/agents.rs
+++ b/aa-api/tests/agents.rs
@@ -32,6 +32,7 @@ fn test_agent(id_byte: u8) -> AgentRecord {
         recent_events: std::collections::VecDeque::new(),
         recent_traces: Vec::new(),
         layer: None,
+        governance_level: aa_core::GovernanceLevel::default(),
     }
 }
 

--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -14,7 +14,7 @@ sha2   = { version = "0.11", default-features = false, optional = true }
 
 [features]
 default    = ["std"]
-std        = ["alloc", "dep:aho-corasick"]
+std        = ["alloc", "dep:aho-corasick", "serde?/std"]
 alloc      = ["dep:sha2"]
 serde      = ["dep:serde"]
 test-utils = []

--- a/aa-core/src/agent.rs
+++ b/aa-core/src/agent.rs
@@ -39,11 +39,11 @@ pub struct AgentContext {
     pub metadata: BTreeMap<String, String>,
     /// Governance level (L0–L3) carried for level-conditional policy rules.
     ///
-    /// Populated by the gateway from the agent's [`AgentRecord`] at the
-    /// boundary between transport and the policy engine. Defaults to
-    /// [`GovernanceLevel::L0Discover`] so old serialised contexts (and
-    /// callers that have not yet been updated) deserialise / construct
-    /// without churn.
+    /// Populated by the gateway from the agent's `AgentRecord` (defined in
+    /// `aa-gateway`) at the boundary between transport and the policy
+    /// engine. Defaults to [`GovernanceLevel::L0Discover`] so old serialised
+    /// contexts — and callers that have not yet been updated — deserialise
+    /// or construct without churn.
     #[cfg_attr(feature = "serde", serde(default))]
     pub governance_level: GovernanceLevel,
 }

--- a/aa-core/src/agent.rs
+++ b/aa-core/src/agent.rs
@@ -8,9 +8,9 @@ use alloc::{collections::BTreeMap, string::String};
 
 #[cfg(feature = "alloc")]
 use crate::{
-    GovernanceLevel,
     identity::{AgentId, SessionId},
     time::Timestamp,
+    GovernanceLevel,
 };
 
 /// Identity carrier for an agent execution.

--- a/aa-core/src/agent.rs
+++ b/aa-core/src/agent.rs
@@ -8,6 +8,7 @@ use alloc::{collections::BTreeMap, string::String};
 
 #[cfg(feature = "alloc")]
 use crate::{
+    GovernanceLevel,
     identity::{AgentId, SessionId},
     time::Timestamp,
 };
@@ -36,6 +37,15 @@ pub struct AgentContext {
     /// Keys are owned `String` so the map is serde-compatible and accepts
     /// both string-literal keys and computed keys at runtime.
     pub metadata: BTreeMap<String, String>,
+    /// Governance level (L0–L3) carried for level-conditional policy rules.
+    ///
+    /// Populated by the gateway from the agent's [`AgentRecord`] at the
+    /// boundary between transport and the policy engine. Defaults to
+    /// [`GovernanceLevel::L0Discover`] so old serialised contexts (and
+    /// callers that have not yet been updated) deserialise / construct
+    /// without churn.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub governance_level: GovernanceLevel,
 }
 
 #[cfg(all(feature = "alloc", feature = "std"))]
@@ -50,6 +60,7 @@ impl AgentContext {
             session_id,
             pid,
             metadata: BTreeMap::new(),
+            governance_level: GovernanceLevel::default(),
         }
     }
 }
@@ -68,6 +79,7 @@ mod tests {
             pid: 42,
             started_at: Timestamp::from_nanos(1_000_000),
             metadata: BTreeMap::new(),
+            governance_level: GovernanceLevel::default(),
         }
     }
 
@@ -121,5 +133,23 @@ mod tests {
         let json = serde_json::to_string(&original).expect("serialize");
         let restored: AgentContext = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(original, restored);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn agent_context_defaults_to_l0_when_governance_level_missing() {
+        // Old serialised contexts written before `governance_level` was
+        // added must still deserialise — the field must default to
+        // `L0Discover`. This is the runtime-stable backward-compat
+        // guarantee called out by AAASM-1041.
+        let json = r#"{
+            "agent_id":[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+            "session_id":[2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2],
+            "pid":42,
+            "started_at":1000000,
+            "metadata":{}
+        }"#;
+        let restored: AgentContext = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(restored.governance_level, GovernanceLevel::L0Discover);
     }
 }

--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -7,6 +7,8 @@
 
 #[cfg(feature = "alloc")]
 use alloc::string::String;
+#[cfg(feature = "std")]
+use std::path::PathBuf;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -61,4 +63,26 @@ pub enum DevToolKind {
     WindsurfCascade,
     /// Adapter-defined custom tool identified by an opaque name string.
     Custom(String),
+}
+
+/// Static metadata describing a detected AI dev tool installation.
+///
+/// Returned by `DevToolAdapter::detect` and used to drive registry
+/// decisions, managed-settings generation, and per-tool launch wiring.
+#[cfg(feature = "std")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct DevToolInfo {
+    /// Concrete tool variant.
+    pub kind: DevToolKind,
+    /// Tool version string, if reported by the binary.
+    pub version: Option<String>,
+    /// Absolute path to the installed tool binary.
+    pub install_path: PathBuf,
+    /// Highest governance level this installation can operate at.
+    pub governance_level: GovernanceLevel,
+    /// Whether the tool exposes MCP server configuration we can govern.
+    pub supports_mcp: bool,
+    /// Whether the tool reads governance config from a managed-settings file.
+    pub supports_managed_settings: bool,
 }

--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -86,3 +86,16 @@ pub struct DevToolInfo {
     /// Whether the tool reads governance config from a managed-settings file.
     pub supports_managed_settings: bool,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn governance_level_orders_l0_through_l3() {
+        assert!(GovernanceLevel::L0Discover < GovernanceLevel::L1Observe);
+        assert!(GovernanceLevel::L1Observe < GovernanceLevel::L2Enforce);
+        assert!(GovernanceLevel::L2Enforce < GovernanceLevel::L3Native);
+        assert!(GovernanceLevel::L0Discover < GovernanceLevel::L3Native);
+    }
+}

--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -115,4 +115,21 @@ mod tests {
             assert_eq!(restored, original);
         }
     }
+
+    #[cfg(all(feature = "serde", feature = "std"))]
+    #[test]
+    fn dev_tool_info_round_trips_via_serde_json() {
+        let original = DevToolInfo {
+            kind: DevToolKind::ClaudeCode,
+            version: Some(String::from("1.2.3")),
+            install_path: PathBuf::from("/usr/local/bin/claude"),
+            governance_level: GovernanceLevel::L2Enforce,
+            supports_mcp: true,
+            supports_managed_settings: false,
+        };
+        let json1 = serde_json::to_string(&original).expect("serialize");
+        let restored: DevToolInfo = serde_json::from_str(&json1).expect("deserialize");
+        let json2 = serde_json::to_string(&restored).expect("re-serialize");
+        assert_eq!(json1, json2);
+    }
 }

--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -1,0 +1,39 @@
+//! Foundational types for the AI dev tool governance framework.
+//!
+//! These types are referenced by the `DevToolAdapter` trait and by every
+//! per-tool adapter (Claude Code, Codex, GitHub Copilot, Windsurf Cascade).
+//! They are intentionally light and free of runtime dependencies so that
+//! adapters can be implemented in `no_std` contexts where applicable.
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// Governance level applied to a managed AI dev tool or agent.
+///
+/// Variants are ordered such that
+/// `L0Discover < L1Observe < L2Enforce < L3Native`. The derived `Ord`
+/// implementation enables policies to express "at-least-this-level" rules,
+/// for example `governance_level >= L2Enforce`.
+///
+/// | Level | Capability |
+/// | --- | --- |
+/// | [`L0Discover`][Self::L0Discover] | eBPF / proxy detects unknown agents and their external behavior. |
+/// | [`L1Observe`][Self::L1Observe] | Network, file, process, and MCP observability without enforcement. |
+/// | [`L2Enforce`][Self::L2Enforce] | Allow / deny, approval, redaction, and budget enforcement. |
+/// | [`L3Native`][Self::L3Native] | Full SDK-integrated governance with identity, lineage, and semantic context. |
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum GovernanceLevel {
+    /// L0 — Discover. eBPF / proxy detects unknown agents and their
+    /// external behavior; no policy enforcement is applied.
+    L0Discover,
+    /// L1 — Observe. Network, file, process, and MCP observability
+    /// without enforcement.
+    L1Observe,
+    /// L2 — Enforce. Allow / deny, approval, redaction, and budget
+    /// enforcement applied to the governed tool.
+    L2Enforce,
+    /// L3 — Native. Full SDK-integrated governance with identity,
+    /// lineage, and semantic context awareness.
+    L3Native,
+}

--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -98,4 +98,21 @@ mod tests {
         assert!(GovernanceLevel::L2Enforce < GovernanceLevel::L3Native);
         assert!(GovernanceLevel::L0Discover < GovernanceLevel::L3Native);
     }
+
+    #[cfg(all(feature = "serde", feature = "alloc"))]
+    #[test]
+    fn dev_tool_kind_round_trips_via_serde_json() {
+        let cases = [
+            DevToolKind::ClaudeCode,
+            DevToolKind::Codex,
+            DevToolKind::GitHubCopilot,
+            DevToolKind::WindsurfCascade,
+            DevToolKind::Custom(String::from("MyEditor")),
+        ];
+        for original in cases {
+            let json = serde_json::to_string(&original).expect("serialize");
+            let restored: DevToolKind = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(restored, original);
+        }
+    }
 }

--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -5,6 +5,9 @@
 //! They are intentionally light and free of runtime dependencies so that
 //! adapters can be implemented in `no_std` contexts where applicable.
 
+#[cfg(feature = "alloc")]
+use alloc::string::String;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -36,4 +39,26 @@ pub enum GovernanceLevel {
     /// L3 — Native. Full SDK-integrated governance with identity,
     /// lineage, and semantic context awareness.
     L3Native,
+}
+
+/// Concrete kind of AI dev tool being governed.
+///
+/// Concrete variants are matched against built-in `DevToolAdapter`
+/// implementations. The [`Custom`][Self::Custom] variant lets out-of-tree
+/// adapters identify themselves by name without requiring a code change
+/// to this enum.
+#[cfg(feature = "alloc")]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum DevToolKind {
+    /// Anthropic Claude Code (CLI).
+    ClaudeCode,
+    /// OpenAI Codex CLI.
+    Codex,
+    /// GitHub Copilot operating in agent mode.
+    GitHubCopilot,
+    /// Codeium Windsurf Cascade IDE agent.
+    WindsurfCascade,
+    /// Adapter-defined custom tool identified by an opaque name string.
+    Custom(String),
 }

--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -26,11 +26,15 @@ use serde::{Deserialize, Serialize};
 /// | [`L1Observe`][Self::L1Observe] | Network, file, process, and MCP observability without enforcement. |
 /// | [`L2Enforce`][Self::L2Enforce] | Allow / deny, approval, redaction, and budget enforcement. |
 /// | [`L3Native`][Self::L3Native] | Full SDK-integrated governance with identity, lineage, and semantic context. |
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum GovernanceLevel {
     /// L0 — Discover. eBPF / proxy detects unknown agents and their
     /// external behavior; no policy enforcement is applied.
+    ///
+    /// This is also the [`Default`] for [`GovernanceLevel`]: any agent or
+    /// rule that does not declare a level is treated as L0 (discover-only).
+    #[default]
     L0Discover,
     /// L1 — Observe. Network, file, process, and MCP observability
     /// without enforcement.

--- a/aa-core/src/evaluators.rs
+++ b/aa-core/src/evaluators.rs
@@ -81,6 +81,7 @@ mod tests {
             pid: 42,
             started_at: crate::time::Timestamp::from_nanos(0),
             metadata: alloc::collections::BTreeMap::new(),
+            governance_level: crate::GovernanceLevel::default(),
         }
     }
 

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -39,10 +39,10 @@ pub use policy::{FileMode, PolicyDecision, PolicyError};
 
 #[cfg(feature = "alloc")]
 pub use agent::AgentContext;
-#[cfg(feature = "alloc")]
-pub use dev_tool::DevToolKind;
 #[cfg(feature = "std")]
 pub use dev_tool::DevToolInfo;
+#[cfg(feature = "alloc")]
+pub use dev_tool::DevToolKind;
 
 #[cfg(feature = "alloc")]
 pub use policy::{ArgsJson, GovernanceAction, PolicyDocument, PolicyEvaluator, PolicyResult, PolicyRule};

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -25,6 +25,7 @@ cfg_if::cfg_if! {
 pub mod agent;
 #[cfg(feature = "alloc")]
 pub mod audit;
+pub mod dev_tool;
 pub mod evaluators;
 pub mod identity;
 pub mod policy;

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -33,11 +33,16 @@ pub mod policy;
 pub mod scanner;
 pub mod time;
 
+pub use dev_tool::GovernanceLevel;
 pub use identity::{AgentId, SessionId};
 pub use policy::{FileMode, PolicyDecision, PolicyError};
 
 #[cfg(feature = "alloc")]
 pub use agent::AgentContext;
+#[cfg(feature = "alloc")]
+pub use dev_tool::DevToolKind;
+#[cfg(feature = "std")]
+pub use dev_tool::DevToolInfo;
 
 #[cfg(feature = "alloc")]
 pub use policy::{ArgsJson, GovernanceAction, PolicyDocument, PolicyEvaluator, PolicyResult, PolicyRule};

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -300,7 +300,9 @@ impl PolicyEngine {
         if let aa_core::GovernanceAction::ToolCall { name, .. } = action {
             if let Some(tp) = policy.tools.get(name) {
                 if let Some(expr) = &tp.requires_approval_if {
-                    if !expr.is_empty() && crate::policy::expr::evaluate(expr, action, None) {
+                    if !expr.is_empty()
+                        && crate::policy::expr::evaluate(expr, action, Some(ctx.governance_level))
+                    {
                         return EvaluationResult {
                             decision: aa_core::PolicyResult::RequiresApproval {
                                 timeout_secs: policy.approval_timeout_secs,

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -300,9 +300,7 @@ impl PolicyEngine {
         if let aa_core::GovernanceAction::ToolCall { name, .. } = action {
             if let Some(tp) = policy.tools.get(name) {
                 if let Some(expr) = &tp.requires_approval_if {
-                    if !expr.is_empty()
-                        && crate::policy::expr::evaluate(expr, action, Some(ctx.governance_level))
-                    {
+                    if !expr.is_empty() && crate::policy::expr::evaluate(expr, action, Some(ctx.governance_level)) {
                         return EvaluationResult {
                             decision: aa_core::PolicyResult::RequiresApproval {
                                 timeout_secs: policy.approval_timeout_secs,

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -300,7 +300,7 @@ impl PolicyEngine {
         if let aa_core::GovernanceAction::ToolCall { name, .. } = action {
             if let Some(tp) = policy.tools.get(name) {
                 if let Some(expr) = &tp.requires_approval_if {
-                    if !expr.is_empty() && crate::policy::expr::evaluate(expr, action) {
+                    if !expr.is_empty() && crate::policy::expr::evaluate(expr, action, None) {
                         return EvaluationResult {
                             decision: aa_core::PolicyResult::RequiresApproval {
                                 timeout_secs: policy.approval_timeout_secs,

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -508,6 +508,7 @@ mod tests {
             pid: 1,
             started_at: Timestamp::from_nanos(0),
             metadata: BTreeMap::new(),
+            governance_level: aa_core::GovernanceLevel::default(),
         }
     }
 

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -495,6 +495,16 @@ mod tests {
     }
 
     #[test]
+    fn rule_with_ge_l2_does_not_fire_for_l1_agent() {
+        // An L1 agent does not satisfy `governance_level >= L2`.
+        assert!(!evaluate(
+            "governance_level >= L2",
+            &tool("any"),
+            Some(GovernanceLevel::L1Observe),
+        ));
+    }
+
+    #[test]
     fn parser_accepts_l0_through_l3() {
         // Each named level parses and compares equal against an agent of the
         // same level — covering all four members of the `GovernanceLevel`

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -33,6 +33,7 @@ enum FieldRef {
     Url,
     Method,
     Command,
+    GovernanceLevel,
 }
 
 #[derive(Debug, PartialEq)]
@@ -51,6 +52,7 @@ enum OpKind {
 enum LiteralVal {
     Str(String),
     Num(f64),
+    Level(GovernanceLevel),
 }
 
 #[derive(Debug, PartialEq)]
@@ -147,6 +149,11 @@ fn tokenize(expr: &str) -> Option<Vec<Token>> {
                 "url" => Token::Field(FieldRef::Url),
                 "method" => Token::Field(FieldRef::Method),
                 "command" => Token::Field(FieldRef::Command),
+                "governance_level" => Token::Field(FieldRef::GovernanceLevel),
+                "L0" => Token::Literal(LiteralVal::Level(GovernanceLevel::L0Discover)),
+                "L1" => Token::Literal(LiteralVal::Level(GovernanceLevel::L1Observe)),
+                "L2" => Token::Literal(LiteralVal::Level(GovernanceLevel::L2Enforce)),
+                "L3" => Token::Literal(LiteralVal::Level(GovernanceLevel::L3Native)),
                 "contains" => Token::Op(OpKind::Contains),
                 "starts_with" => Token::Op(OpKind::StartsWith),
                 other => {
@@ -180,7 +187,8 @@ fn field_value<'a>(field: &FieldRef, action: &'a GovernanceAction) -> &'a str {
         (FieldRef::Url, GovernanceAction::NetworkRequest { url, .. }) => url.as_str(),
         (FieldRef::Method, GovernanceAction::NetworkRequest { method, .. }) => method.as_str(),
         (FieldRef::Command, GovernanceAction::ProcessExec { command }) => command.as_str(),
-        // Field does not match the action variant → treat as empty string
+        // Field does not match the action variant, or governance_level is
+        // handled out-of-band in `eval_clause_safe` → treat as empty string.
         _ => "",
     }
 }
@@ -189,7 +197,40 @@ fn field_value<'a>(field: &FieldRef, action: &'a GovernanceAction) -> &'a str {
 // Clause evaluation
 // ---------------------------------------------------------------------------
 
-fn eval_clause_safe(field: &FieldRef, op: &OpKind, literal: &LiteralVal, action: &GovernanceAction) -> bool {
+fn eval_clause_safe(
+    field: &FieldRef,
+    op: &OpKind,
+    literal: &LiteralVal,
+    action: &GovernanceAction,
+    agent_level: Option<GovernanceLevel>,
+) -> bool {
+    // governance_level is the only field whose value type is not a string;
+    // route it through an Ord-based comparison and return early.
+    if let FieldRef::GovernanceLevel = field {
+        let rhs = match literal {
+            LiteralVal::Level(l) => *l,
+            // Mismatched literal kind (e.g. `governance_level == "L2"`) cannot
+            // match — treat as no-fire rather than fail-safe approval, since
+            // the validator should have rejected it before evaluation.
+            _ => return false,
+        };
+        let lhs = match agent_level {
+            Some(l) => l,
+            // No agent level supplied → cannot compare; treat as no-match.
+            None => return false,
+        };
+        return match op {
+            OpKind::Eq => lhs == rhs,
+            OpKind::Ne => lhs != rhs,
+            OpKind::Gt => lhs > rhs,
+            OpKind::Gte => lhs >= rhs,
+            OpKind::Lt => lhs < rhs,
+            OpKind::Lte => lhs <= rhs,
+            // String operators do not apply to governance_level.
+            OpKind::Contains | OpKind::StartsWith => false,
+        };
+    }
+
     let lhs = field_value(field, action);
 
     match op {
@@ -216,6 +257,8 @@ fn eval_clause_safe(field: &FieldRef, op: &OpKind, literal: &LiteralVal, action:
                 }
             }
             LiteralVal::Str(rhs) => lhs == rhs.as_str(),
+            // A level literal against a non-level field cannot match.
+            LiteralVal::Level(_) => false,
         },
         OpKind::Ne => match literal {
             LiteralVal::Num(rhs) => {
@@ -226,6 +269,9 @@ fn eval_clause_safe(field: &FieldRef, op: &OpKind, literal: &LiteralVal, action:
                 }
             }
             LiteralVal::Str(rhs) => lhs != rhs.as_str(),
+            // A level literal against a non-level field is unconditionally
+            // not-equal — matches the symmetric `Eq` handling above.
+            LiteralVal::Level(_) => true,
         },
         OpKind::Gt => {
             let rhs = numeric_literal(literal);
@@ -266,6 +312,8 @@ fn numeric_literal(lit: &LiteralVal) -> Option<f64> {
     match lit {
         LiteralVal::Num(n) => Some(*n),
         LiteralVal::Str(s) => s.parse::<f64>().ok(),
+        // Level literals never participate in numeric comparisons.
+        LiteralVal::Level(_) => None,
     }
 }
 
@@ -280,7 +328,7 @@ struct Clause<'t> {
     literal: &'t LiteralVal,
 }
 
-fn eval_tokens(tokens: &[Token], action: &GovernanceAction, _agent_level: Option<GovernanceLevel>) -> bool {
+fn eval_tokens(tokens: &[Token], action: &GovernanceAction, agent_level: Option<GovernanceLevel>) -> bool {
     // Parse tokens into a sequence of clauses separated by AND/OR.
     // Strategy: split into OR-groups where each group is a slice of
     // AND-connected clauses.  Result = any OR-group where all clauses are true.
@@ -329,7 +377,7 @@ fn eval_tokens(tokens: &[Token], action: &GovernanceAction, _agent_level: Option
     // Evaluate: OR across groups, AND within each group
     or_groups
         .iter()
-        .any(|group| group.iter().all(|c| eval_clause_safe(c.field, c.op, c.literal, action)))
+        .any(|group| group.iter().all(|c| eval_clause_safe(c.field, c.op, c.literal, action, agent_level)))
 }
 
 // ---------------------------------------------------------------------------

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -20,7 +20,7 @@
 // rustc sees them as dead code.  The allow is intentional and temporary.
 #![allow(dead_code)]
 
-use aa_core::GovernanceAction;
+use aa_core::{GovernanceAction, GovernanceLevel};
 
 // ---------------------------------------------------------------------------
 // Internal token types
@@ -280,7 +280,7 @@ struct Clause<'t> {
     literal: &'t LiteralVal,
 }
 
-fn eval_tokens(tokens: &[Token], action: &GovernanceAction) -> bool {
+fn eval_tokens(tokens: &[Token], action: &GovernanceAction, _agent_level: Option<GovernanceLevel>) -> bool {
     // Parse tokens into a sequence of clauses separated by AND/OR.
     // Strategy: split into OR-groups where each group is a slice of
     // AND-connected clauses.  Result = any OR-group where all clauses are true.
@@ -336,16 +336,22 @@ fn eval_tokens(tokens: &[Token], action: &GovernanceAction) -> bool {
 // Public entry point
 // ---------------------------------------------------------------------------
 
-/// Evaluate a flat boolean expression against a [`GovernanceAction`].
+/// Evaluate a flat boolean expression against a [`GovernanceAction`] and the
+/// governing agent's [`GovernanceLevel`].
+///
+/// `agent_level` is consulted only by clauses referencing the
+/// `governance_level` field; pass `None` when the caller does not know the
+/// agent's level (e.g. legacy code paths) — clauses that depend on the
+/// level are then treated as unknown comparisons (no-match).
 ///
 /// Returns `true` if the expression matches (approval required).
 /// Returns `true` on ANY parse/tokenization error (fail-safe).
-pub(crate) fn evaluate(expr: &str, action: &GovernanceAction) -> bool {
+pub(crate) fn evaluate(expr: &str, action: &GovernanceAction, agent_level: Option<GovernanceLevel>) -> bool {
     let tokens = match tokenize(expr) {
         Some(t) if !t.is_empty() => t,
         _ => return true, // fail-safe
     };
-    eval_tokens(&tokens, action)
+    eval_tokens(&tokens, action, agent_level)
 }
 
 // ---------------------------------------------------------------------------
@@ -386,47 +392,47 @@ mod tests {
 
     #[test]
     fn eq_operator_matches_tool_name() {
-        assert!(evaluate(r#"tool == "search""#, &tool("search")));
+        assert!(evaluate(r#"tool == "search""#, &tool("search"), None));
     }
 
     #[test]
     fn ne_operator_false_when_equal() {
-        assert!(!evaluate(r#"tool != "search""#, &tool("search")));
+        assert!(!evaluate(r#"tool != "search""#, &tool("search"), None));
     }
 
     #[test]
     fn contains_operator_on_url() {
-        assert!(evaluate(r#"url contains "evil""#, &network("https://evil.com", "GET")));
+        assert!(evaluate(r#"url contains "evil""#, &network("https://evil.com", "GET"), None));
     }
 
     #[test]
     fn starts_with_operator_on_path() {
-        assert!(evaluate(r#"path starts_with "/etc""#, &file("/etc/passwd")));
+        assert!(evaluate(r#"path starts_with "/etc""#, &file("/etc/passwd"), None));
     }
 
     #[test]
     fn and_combinator_all_true() {
-        assert!(evaluate(r#"tool == "search" AND tool == "search""#, &tool("search")));
+        assert!(evaluate(r#"tool == "search" AND tool == "search""#, &tool("search"), None));
     }
 
     #[test]
     fn and_combinator_short_circuits() {
-        assert!(!evaluate(r#"tool == "search" AND tool == "other""#, &tool("search")));
+        assert!(!evaluate(r#"tool == "search" AND tool == "other""#, &tool("search"), None));
     }
 
     #[test]
     fn or_combinator_first_true() {
-        assert!(evaluate(r#"tool == "x" OR tool == "search""#, &tool("search")));
+        assert!(evaluate(r#"tool == "x" OR tool == "search""#, &tool("search"), None));
     }
 
     #[test]
     fn fail_safe_on_bad_expr() {
-        assert!(evaluate("not valid @@@ expr", &tool("anything")));
+        assert!(evaluate("not valid @@@ expr", &tool("anything"), None));
     }
 
     #[test]
     fn field_absent_for_action_variant_returns_false() {
         // `tool` field is "" for ProcessExec → should NOT match "foo"
-        assert!(!evaluate(r#"tool == "foo""#, &process("ls")));
+        assert!(!evaluate(r#"tool == "foo""#, &process("ls"), None));
     }
 }

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -483,4 +483,23 @@ mod tests {
         // `tool` field is "" for ProcessExec → should NOT match "foo"
         assert!(!evaluate(r#"tool == "foo""#, &process("ls"), None));
     }
+
+    #[test]
+    fn parser_accepts_l0_through_l3() {
+        // Each named level parses and compares equal against an agent of the
+        // same level — covering all four members of the `GovernanceLevel`
+        // enum in a single test.
+        for (literal, level) in [
+            ("L0", GovernanceLevel::L0Discover),
+            ("L1", GovernanceLevel::L1Observe),
+            ("L2", GovernanceLevel::L2Enforce),
+            ("L3", GovernanceLevel::L3Native),
+        ] {
+            let expr = format!("governance_level == {literal}");
+            assert!(
+                evaluate(&expr, &tool("any"), Some(level)),
+                "{literal} did not parse / compare equal for matching agent level"
+            );
+        }
+    }
 }

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -505,6 +505,23 @@ mod tests {
     }
 
     #[test]
+    fn rule_without_level_condition_fires_for_all_levels() {
+        // Backward compat: a condition that does not mention
+        // `governance_level` evaluates the same way at every level.
+        for level in [
+            GovernanceLevel::L0Discover,
+            GovernanceLevel::L1Observe,
+            GovernanceLevel::L2Enforce,
+            GovernanceLevel::L3Native,
+        ] {
+            assert!(
+                evaluate(r#"tool == "search""#, &tool("search"), Some(level)),
+                "tool-only condition unexpectedly skipped for {level:?}"
+            );
+        }
+    }
+
+    #[test]
     fn parser_accepts_l0_through_l3() {
         // Each named level parses and compares equal against an agent of the
         // same level — covering all four members of the `GovernanceLevel`

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -485,6 +485,16 @@ mod tests {
     }
 
     #[test]
+    fn rule_with_ge_l2_fires_for_l2_agent() {
+        // An L2 agent satisfies `governance_level >= L2`.
+        assert!(evaluate(
+            "governance_level >= L2",
+            &tool("any"),
+            Some(GovernanceLevel::L2Enforce),
+        ));
+    }
+
+    #[test]
     fn parser_accepts_l0_through_l3() {
         // Each named level parses and compares equal against an agent of the
         // same level — covering all four members of the `GovernanceLevel`

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -375,9 +375,11 @@ fn eval_tokens(tokens: &[Token], action: &GovernanceAction, agent_level: Option<
     }
 
     // Evaluate: OR across groups, AND within each group
-    or_groups
-        .iter()
-        .any(|group| group.iter().all(|c| eval_clause_safe(c.field, c.op, c.literal, action, agent_level)))
+    or_groups.iter().any(|group| {
+        group
+            .iter()
+            .all(|c| eval_clause_safe(c.field, c.op, c.literal, action, agent_level))
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -492,7 +494,11 @@ mod tests {
 
     #[test]
     fn contains_operator_on_url() {
-        assert!(evaluate(r#"url contains "evil""#, &network("https://evil.com", "GET"), None));
+        assert!(evaluate(
+            r#"url contains "evil""#,
+            &network("https://evil.com", "GET"),
+            None
+        ));
     }
 
     #[test]
@@ -502,12 +508,20 @@ mod tests {
 
     #[test]
     fn and_combinator_all_true() {
-        assert!(evaluate(r#"tool == "search" AND tool == "search""#, &tool("search"), None));
+        assert!(evaluate(
+            r#"tool == "search" AND tool == "search""#,
+            &tool("search"),
+            None
+        ));
     }
 
     #[test]
     fn and_combinator_short_circuits() {
-        assert!(!evaluate(r#"tool == "search" AND tool == "other""#, &tool("search"), None));
+        assert!(!evaluate(
+            r#"tool == "search" AND tool == "other""#,
+            &tool("search"),
+            None
+        ));
     }
 
     #[test]

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -384,6 +384,48 @@ fn eval_tokens(tokens: &[Token], action: &GovernanceAction, agent_level: Option<
 // Public entry point
 // ---------------------------------------------------------------------------
 
+/// Validate that every `governance_level` literal in `expr` is one of the
+/// four known levels (L0..L3).
+///
+/// Returns the spec-mandated error message
+/// `unknown governance level: <value>; valid values: L0, L1, L2, L3` when the
+/// expression mentions an unknown level (e.g. `L4` or `LX`). Other shapes are
+/// not rejected here — the runtime evaluator is fail-safe for everything else.
+pub(crate) fn validate_governance_levels(expr: &str) -> Result<(), String> {
+    let mut chars = expr.chars().peekable();
+    while let Some(&ch) = chars.peek() {
+        if ch == 'L' {
+            // Collect the identifier-like word starting with 'L'.
+            let mut word = String::new();
+            while let Some(&c) = chars.peek() {
+                if c.is_alphanumeric() || c == '_' {
+                    word.push(c);
+                    chars.next();
+                } else {
+                    break;
+                }
+            }
+            // Only reject `L<digit>+` shapes — these are clearly intended as
+            // level literals. Anything else (`Logger`, `Limit`, …) is left
+            // for the runtime tokenizer to handle.
+            let rest = &word[1..];
+            if !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit()) {
+                match word.as_str() {
+                    "L0" | "L1" | "L2" | "L3" => {}
+                    _ => {
+                        return Err(format!(
+                            "unknown governance level: {word}; valid values: L0, L1, L2, L3"
+                        ));
+                    }
+                }
+            }
+            continue;
+        }
+        chars.next();
+    }
+    Ok(())
+}
+
 /// Evaluate a flat boolean expression against a [`GovernanceAction`] and the
 /// governing agent's [`GovernanceLevel`].
 ///

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -420,6 +420,36 @@ mod tests {
     }
 
     #[test]
+    fn parser_rejects_unknown_governance_level() {
+        // A condition referencing `L4` (or any non-L0..L3 level) must be
+        // rejected at validation time with the spec-mandated message.
+        let yaml = "tools:\n  bash:\n    allow: true\n    requires_approval_if: \"governance_level >= L4\"\n";
+        let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+        let err = errs
+            .iter()
+            .find(|e| e.field == "tools.bash.requires_approval_if")
+            .expect("validator should flag the unknown level on the requires_approval_if field");
+        assert_eq!(
+            err.message,
+            "unknown governance level: L4; valid values: L0, L1, L2, L3"
+        );
+    }
+
+    #[test]
+    fn validator_accepts_all_known_governance_levels() {
+        // Backward-compat sanity: valid L0..L3 conditions pass validation.
+        for lvl in ["L0", "L1", "L2", "L3"] {
+            let yaml = format!(
+                "tools:\n  bash:\n    allow: true\n    requires_approval_if: \"governance_level == {lvl}\"\n",
+            );
+            assert!(
+                PolicyValidator::from_yaml(&yaml).is_ok(),
+                "validator unexpectedly rejected condition with {lvl}",
+            );
+        }
+    }
+
+    #[test]
     fn tool_allow_defaults_to_true_when_absent() {
         let yaml = "tools:\n  bash:\n    limit_per_hour: 5\n";
         let out = PolicyValidator::from_yaml(yaml).unwrap();

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -329,6 +329,11 @@ impl PolicyValidator {
                         format!("tools.{}.requires_approval_if", name),
                         "CEL expression must not be empty",
                     ));
+                } else if let Err(msg) = super::expr::validate_governance_levels(expr) {
+                    errors.push(ValidationError::new(
+                        format!("tools.{}.requires_approval_if", name),
+                        msg,
+                    ));
                 }
             }
 

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -439,9 +439,8 @@ mod tests {
     fn validator_accepts_all_known_governance_levels() {
         // Backward-compat sanity: valid L0..L3 conditions pass validation.
         for lvl in ["L0", "L1", "L2", "L3"] {
-            let yaml = format!(
-                "tools:\n  bash:\n    allow: true\n    requires_approval_if: \"governance_level == {lvl}\"\n",
-            );
+            let yaml =
+                format!("tools:\n  bash:\n    allow: true\n    requires_approval_if: \"governance_level == {lvl}\"\n",);
             assert!(
                 PolicyValidator::from_yaml(&yaml).is_ok(),
                 "validator unexpectedly rejected condition with {lvl}",

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -2,6 +2,7 @@
 
 use std::collections::{BTreeMap, VecDeque};
 
+use aa_core::GovernanceLevel;
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use tokio::sync::mpsc;
@@ -89,6 +90,14 @@ pub struct AgentRecord {
     pub recent_traces: Vec<RecentTrace>,
     /// Governance layer this agent is assigned to (e.g. "advisory", "enforced").
     pub layer: Option<String>,
+    /// Governance level (L0–L3) the registry tracks for this agent.
+    ///
+    /// Determined by the dev-tool adapter at registration time and consulted
+    /// by `PolicyEngine::evaluate` for level-conditional rules. Defaults to
+    /// [`GovernanceLevel::L0Discover`] when not declared by the registrant —
+    /// existing agents registered before this field was introduced retain
+    /// the discover-only default.
+    pub governance_level: GovernanceLevel,
 }
 
 /// Channel sender type for pushing [`ControlCommand`]s to an agent's control stream.

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -72,6 +72,9 @@ pub fn request_to_core(req: &CheckActionRequest) -> Result<(AgentContext, Govern
         pid: 0, // not available in proto — set to 0
         started_at: Timestamp::from_nanos(0),
         metadata,
+        // Provisional default — overwritten by the gateway service layer
+        // with the agent's registered level before the engine sees it.
+        governance_level: aa_core::GovernanceLevel::default(),
     };
 
     // --- Governance action ---

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -103,6 +103,7 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
             recent_events: std::collections::VecDeque::new(),
             recent_traces: Vec::new(),
             layer: None,
+            governance_level: aa_core::GovernanceLevel::default(),
         };
 
         self.registry

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -108,10 +108,22 @@ impl PolicyServiceImpl {
     /// the conversion.
     #[allow(clippy::result_large_err)] // tonic::Status is the standard gRPC error type
     fn evaluate_one(&self, req: &CheckActionRequest) -> Result<(EvaluationResult, i64, String), Status> {
-        let (ctx, action) = convert::request_to_core(req).map_err(|e| {
+        let (mut ctx, action) = convert::request_to_core(req).map_err(|e| {
             tracing::error!(error = %e, "failed to convert CheckActionRequest");
             Status::invalid_argument(e.to_string())
         })?;
+
+        // Populate `ctx.governance_level` from the registered `AgentRecord`
+        // so level-conditional policy rules (e.g. `governance_level >= L2`)
+        // see the agent's actual level instead of the proto-default. Falls
+        // back to whatever default `request_to_core` produced when the
+        // registry is not attached or the agent is not registered.
+        if let (Some(registry), Some(proto_agent)) = (&self.registry, req.agent_id.as_ref()) {
+            let agent_key = proto_agent_id_to_key(proto_agent);
+            if let Some(record) = registry.get(&agent_key) {
+                ctx.governance_level = record.governance_level;
+            }
+        }
 
         let start = Instant::now();
         let eval = self.engine.evaluate(&ctx, &action);

--- a/aa-gateway/src/simulation/engine.rs
+++ b/aa-gateway/src/simulation/engine.rs
@@ -59,6 +59,7 @@ impl SimulationEngine {
             pid: 0,
             started_at: aa_core::time::Timestamp::from_nanos(0),
             metadata: BTreeMap::new(),
+            governance_level: aa_core::GovernanceLevel::default(),
         };
 
         let result = self.engine.evaluate(&ctx, &action);

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -418,3 +418,186 @@ async fn gateway_client_connect_failure() {
     let result = aa_runtime::gateway_client::GatewayClient::connect("http://127.0.0.1:1").await;
     assert!(result.is_err(), "should fail to connect to closed port");
 }
+
+// ── Governance-level conditional rules (AAASM-1041 / AAASM-206) ──────────────
+
+/// Helper: build an `AgentRecord` with the given `governance_level` and the
+/// 16-byte key derived from `proto_id`.
+fn level_test_record(
+    proto_id: &ProtoAgentId,
+    level: aa_core::GovernanceLevel,
+) -> aa_gateway::registry::store::AgentRecord {
+    use aa_gateway::registry::convert::proto_agent_id_to_key;
+    use aa_gateway::registry::store::AgentRecord;
+    use aa_gateway::registry::AgentStatus;
+
+    AgentRecord {
+        agent_id: proto_agent_id_to_key(proto_id),
+        name: "level-test-agent".into(),
+        framework: "custom".into(),
+        version: "1.0.0".into(),
+        risk_tier: 0,
+        tool_names: vec![],
+        public_key: "pk_test".into(),
+        credential_token: "tok_test".into(),
+        metadata: std::collections::BTreeMap::new(),
+        registered_at: chrono::Utc::now(),
+        last_heartbeat: chrono::Utc::now(),
+        status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
+        policy_violations_count: 0,
+        active_sessions: Vec::new(),
+        recent_events: std::collections::VecDeque::new(),
+        recent_traces: Vec::new(),
+        layer: None,
+        governance_level: level,
+    }
+}
+
+/// Start a `PolicyService` with both an `AgentRegistry` AND an `ApprovalQueue`
+/// attached, so `RequiresApproval` evaluations can be observed and responded
+/// to in-test.
+async fn start_server_with_registry_and_approval(
+    policy_yaml: &str,
+) -> (
+    SocketAddr,
+    Arc<aa_gateway::registry::AgentRegistry>,
+    Arc<aa_runtime::approval::ApprovalQueue>,
+) {
+    use aa_gateway::registry::AgentRegistry;
+    use aa_runtime::approval::ApprovalQueue;
+
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", policy_yaml).unwrap();
+    tmp.flush().unwrap();
+
+    let (alert_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    let engine = Arc::new(PolicyEngine::load_from_file(tmp.path(), alert_tx).unwrap());
+    let registry = Arc::new(AgentRegistry::new());
+    let approval_queue = ApprovalQueue::new();
+    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+    let service = PolicyServiceImpl::with_registry_and_approval(
+        engine,
+        Arc::clone(&registry),
+        Arc::clone(&approval_queue),
+        audit_tx,
+        audit_drops,
+        [0u8; 32],
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let _tmp = tmp;
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(PolicyServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    (addr, registry, approval_queue)
+}
+
+#[tokio::test]
+async fn governance_level_rule_fires_for_registered_l2_agent() {
+    use aa_runtime::approval::ApprovalDecision;
+
+    // Policy: any tool call must request approval when the agent is L2+.
+    let yaml = r#"
+version: "1"
+tools:
+  any_tool:
+    allow: true
+    requires_approval_if: "governance_level >= L2"
+"#;
+    let (addr, registry, queue) = start_server_with_registry_and_approval(yaml).await;
+
+    // Register the request's agent at L2Enforce.
+    let proto_id = ProtoAgentId {
+        org_id: "org".into(),
+        team_id: "team".into(),
+        agent_id: "agent-1".into(),
+    };
+    registry
+        .register(level_test_record(&proto_id, aa_core::GovernanceLevel::L2Enforce))
+        .unwrap();
+
+    // Issue the request on a background task so we can inspect the approval
+    // queue while the server is blocked on the operator decision.
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let client_task = tokio::spawn(async move { client.check_action(tool_call_request("any_tool")).await });
+
+    // Allow the server time to enqueue the request.
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    // The rule must have fired → exactly one pending entry.
+    let pending = queue.list();
+    assert_eq!(
+        pending.len(),
+        1,
+        "rule with `governance_level >= L2` must enqueue an approval request for an L2 agent",
+    );
+    assert_eq!(pending[0].agent_id, "agent-1");
+
+    // Decide approve so the client task can complete cleanly.
+    queue
+        .decide(
+            pending[0].request_id,
+            ApprovalDecision::Approved {
+                by: "test".to_string(),
+                reason: None,
+            },
+        )
+        .unwrap();
+
+    let resp = client_task.await.unwrap().unwrap().into_inner();
+    assert_eq!(resp.decision, Decision::Allow as i32);
+}
+
+#[tokio::test]
+async fn governance_level_rule_does_not_fire_for_registered_l1_agent() {
+    // Same policy as above, but the agent is L1Observe — below the L2
+    // threshold, so the approval rule must NOT fire and the request must
+    // pass through directly with `Decision::Allow`.
+    let yaml = r#"
+version: "1"
+tools:
+  any_tool:
+    allow: true
+    requires_approval_if: "governance_level >= L2"
+"#;
+    let (addr, registry, queue) = start_server_with_registry_and_approval(yaml).await;
+
+    let proto_id = ProtoAgentId {
+        org_id: "org".into(),
+        team_id: "team".into(),
+        agent_id: "agent-1".into(),
+    };
+    registry
+        .register(level_test_record(&proto_id, aa_core::GovernanceLevel::L1Observe))
+        .unwrap();
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let resp = client
+        .check_action(tool_call_request("any_tool"))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        resp.decision,
+        Decision::Allow as i32,
+        "rule should not fire for an L1 agent below the L2 threshold",
+    );
+    assert!(
+        queue.list().is_empty(),
+        "no approval entry should have been enqueued for an L1 agent",
+    );
+}

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -292,6 +292,7 @@ budget:
         pid: 0,
         started_at: aa_core::time::Timestamp::from_nanos(0),
         metadata: std::collections::BTreeMap::new(),
+        governance_level: aa_core::GovernanceLevel::default(),
     };
     engine.record_spend(&agent_ctx, 2.0); // exceeds $1.0 daily limit
 
@@ -366,6 +367,7 @@ budget:
         pid: 0,
         started_at: aa_core::time::Timestamp::from_nanos(0),
         metadata: std::collections::BTreeMap::new(),
+        governance_level: aa_core::GovernanceLevel::default(),
     };
     engine.record_spend(&agent_ctx, 2.0);
 

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -280,6 +280,7 @@ budget:
         recent_events: std::collections::VecDeque::new(),
         recent_traces: Vec::new(),
         layer: None,
+        governance_level: aa_core::GovernanceLevel::default(),
     };
     registry.register(record).unwrap();
 
@@ -355,6 +356,7 @@ budget:
         recent_events: std::collections::VecDeque::new(),
         recent_traces: Vec::new(),
         layer: None,
+        governance_level: aa_core::GovernanceLevel::default(),
     };
     registry.register(record).unwrap();
 

--- a/aa-gateway/tests/registry_test.rs
+++ b/aa-gateway/tests/registry_test.rs
@@ -359,3 +359,22 @@ fn active_sessions_and_recent_events_survive_retrieval() {
     assert_eq!(retrieved.recent_events[0].event_type, "violation");
     assert_eq!(retrieved.recent_events[0].summary, "unauthorized tool call");
 }
+
+#[test]
+fn agent_record_defaults_governance_level_to_l0_discover() {
+    // Records constructed via the standard test builder (which mirrors the
+    // production lifecycle path) start at the safest level — discover-only.
+    let record = make_record(key(0));
+    assert_eq!(record.governance_level, aa_core::GovernanceLevel::L0Discover);
+}
+
+#[test]
+fn agent_record_governance_level_round_trips_through_registry() {
+    let reg = AgentRegistry::new();
+    let mut record = make_record(key(1));
+    record.governance_level = aa_core::GovernanceLevel::L2Enforce;
+    reg.register(record).unwrap();
+
+    let retrieved = reg.get(&key(1)).unwrap();
+    assert_eq!(retrieved.governance_level, aa_core::GovernanceLevel::L2Enforce);
+}

--- a/aa-gateway/tests/registry_test.rs
+++ b/aa-gateway/tests/registry_test.rs
@@ -30,6 +30,7 @@ fn make_record(key: [u8; 16]) -> AgentRecord {
         recent_events: VecDeque::new(),
         recent_traces: Vec::new(),
         layer: None,
+        governance_level: aa_core::GovernanceLevel::default(),
     }
 }
 
@@ -225,6 +226,7 @@ async fn concurrent_registration_of_100_agents() {
                 recent_events: VecDeque::new(),
                 recent_traces: Vec::new(),
                 layer: None,
+                governance_level: aa_core::GovernanceLevel::default(),
             };
             reg.register(record).unwrap();
         }));


### PR DESCRIPTION
## Description

Implements F79 (governance level classification in the policy schema) by extending three components with an L0–L3 governance level concept, gated entirely behind the existing condition language so legacy rules keep evaluating identically.

**Changes**

- `aa-core` — adds `Default` to `GovernanceLevel` (`L0Discover` is the documented backward-compat default; required by `AgentRecord`'s default-on-missing semantics).
- `aa-gateway/src/registry/store.rs` — `AgentRecord` gains `pub governance_level: GovernanceLevel`. Every existing constructor (production lifecycle path + 4 tests) initialises the field via `GovernanceLevel::default()`.
- `aa-gateway/src/policy/expr.rs` — extends the mini-grammar with the `governance_level` field token and `L0`/`L1`/`L2`/`L3` literal tokens; `evaluate` now takes an `Option<GovernanceLevel>` agent level; `eval_clause_safe` routes the level field through an `Ord`-based comparison.
- `aa-gateway/src/policy/validator.rs` — schema validation rejects unknown `governance_level` values with the spec error `unknown governance level: <value>; valid values: L0, L1, L2, L3`.
- `aa-gateway/src/engine/mod.rs` — single existing `expr::evaluate` call site updated to pass `None`; integrating the registry's per-agent level into engine evaluation is intentionally deferred (engine has no registry handle today).

**AC location note** — AAASM-1041's description references `aa-core/src/policy/schema.rs` and `aa-core/src/registry/agent.rs`. Those paths do not exist in this repo; the policy schema actually lives in `aa-gateway/src/policy/` and the agent registry in `aa-gateway/src/registry/`. Implementation targets the real locations; AC items are otherwise satisfied verbatim.

**`AgentRecord` serde note** — The AC mentions `deserialize_with default` on `AgentRecord`. The struct has no serde derives today (only `Debug + Clone`), so I implemented "default `L0Discover` for backward compat" as a Rust-level default rather than a serde-level default. Adding full serde to `AgentRecord` would cascade to several other registry types (`ActiveSession`, `RecentEvent`, …) and is out of scope for AAASM-1041.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [ ] No
- [x] Yes (describe below)

`AgentRecord` gains a new `governance_level` field. All in-tree constructors are updated. The `pub(crate) fn evaluate` in `aa-gateway/src/policy/expr.rs` gains a third parameter (`Option<GovernanceLevel>`); only one call site exists (`engine/mod.rs`) and is updated. No public API outside the crate is affected.

## Related Issues

- Related Jira ticket: [AAASM-1041](https://lightning-dust-mite.atlassian.net/browse/AAASM-1041)
- Parent Story: [AAASM-206](https://lightning-dust-mite.atlassian.net/browse/AAASM-206) (F79 governance level classification)
- Depends on: [AAASM-919 / PR #154](https://github.com/AI-agent-assembly/agent-assembly/pull/154) — provides `GovernanceLevel`. **Merge PR #154 first**, then rebase this PR; until then this branch carries PR #154's commits as ancestors.
- Verification: [AAASM-1127](https://lightning-dust-mite.atlassian.net/browse/AAASM-1127)
- Epic: [AAASM-196](https://lightning-dust-mite.atlassian.net/browse/AAASM-196)

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Tests covering each AC bullet:

- `agent_record_defaults_governance_level_to_l0_discover` — record defaults to L0Discover.
- `agent_record_governance_level_round_trips_through_registry` — explicit L2 survives store/retrieve.
- `parser_accepts_l0_through_l3` — every named level tokenises and compares equal.
- `rule_with_ge_l2_fires_for_l2_agent` — `governance_level >= L2` fires for an L2 agent.
- `rule_with_ge_l2_does_not_fire_for_l1_agent` — same rule does not fire for an L1 agent.
- `rule_without_level_condition_fires_for_all_levels` — backward compat: tool-only conditions remain level-independent.
- `parser_rejects_unknown_governance_level` — validator rejects `L4` with the exact spec message.
- `validator_accepts_all_known_governance_levels` — backward compat for L0..L3.

Local validation:

```
cargo fmt --all -- --check                 # clean
cargo clippy -p aa-core -p aa-gateway --all-targets --all-features -- -D warnings  # clean
cargo test --workspace                     # all green
cargo doc   --workspace --no-deps          # no new warnings (5 pre-existing)
```

`cargo deny check` is gated by a CVSS 4.0 advisory parse issue in my local advisory DB; CI runs the canonical version. `cargo clippy --workspace --all-targets` flags one pre-existing `clippy::items_after_test_module` violation in `aa-ebpf/src/tracepoint.rs:130` — confirmed reproducible on `master` without this PR; out of scope here.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing (will be confirmed by CI)
- [x] Commits are small and follow the Gitmoji convention

## Commit history (this PR's commits beyond AAASM-919)

12 small commits on top of PR #154's 8:

1. `✨ (aa-core): Default GovernanceLevel to L0Discover`
2. `✨ (registry): Add governance_level field to AgentRecord`
3. `✅ (registry): Test AgentRecord defaults governance_level to L0Discover`
4. `✨ (policy/expr): Add agent_level parameter to evaluate()`
5. `✨ (policy/expr): Add governance_level field + L0–L3 literal grammar`
6. `✅ (policy/expr): Test parser accepts L0 through L3`
7. `✅ (policy/expr): Test rule with >= L2 fires for L2 agent`
8. `✅ (policy/expr): Test rule with >= L2 skips L1 agent`
9. `✅ (policy/expr): Test rule without level condition fires for all levels`
10. `🚨 (policy/validator): Reject unknown governance_level values`
11. `✅ (policy/validator): Test rejection of unknown governance_level values`
12. `🚨 (policy/validator): Collapse format! call for cargo fmt`

[AAASM-1041]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ