### PR TITLE
[AAASM-923] ✨ (aa-core): Define DevToolAdapter async trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,7 @@ name = "aa-core"
 version = "0.0.1"
 dependencies = [
  "aho-corasick",
+ "async-trait",
  "cfg-if",
  "criterion",
  "serde",

--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -8,13 +8,14 @@ description = "Pure domain logic for Agent Assembly — no_std compatible"
 
 [dependencies]
 aho-corasick = { version = "1", optional = true }
+async-trait  = { version = "0.1", optional = true }
 cfg-if = "1"
 serde  = { version = "1", default-features = false, features = ["derive", "alloc"], optional = true }
 sha2   = { version = "0.11", default-features = false, optional = true }
 
 [features]
 default    = ["std"]
-std        = ["alloc", "dep:aho-corasick", "serde?/std"]
+std        = ["alloc", "dep:aho-corasick", "dep:async-trait", "serde?/std"]
 alloc      = ["dep:sha2"]
 serde      = ["dep:serde"]
 test-utils = []

--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -69,6 +69,21 @@ pub enum DevToolKind {
     Custom(String),
 }
 
+/// Error type for [`DevToolAdapter`] method failures.
+///
+/// This is an intentional minimal stub introduced together with the
+/// `DevToolAdapter` trait so the trait signatures resolve. AAASM-925 will
+/// populate the concrete error variants (`ToolNotFound`,
+/// `DetectionFailed`, `SettingsGenerationFailed`, etc.) and add a
+/// `thiserror::Error` derive. Marked `#[non_exhaustive]` so that addition
+/// is not a breaking change for downstream callers.
+///
+/// [`DevToolAdapter`]: <not yet defined; introduced in this same Subtask>
+#[cfg(feature = "alloc")]
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum AdapterError {}
+
 /// Static metadata describing a detected AI dev tool installation.
 ///
 /// Returned by `DevToolAdapter::detect` and used to drive registry

--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -7,6 +7,8 @@
 
 #[cfg(feature = "alloc")]
 use alloc::string::String;
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use std::path::PathBuf;
 
@@ -67,6 +69,30 @@ pub enum DevToolKind {
     WindsurfCascade,
     /// Adapter-defined custom tool identified by an opaque name string.
     Custom(String),
+}
+
+/// Lightweight description of an MCP server an adapter is aware of.
+///
+/// Returned by [`DevToolAdapter::list_mcp_servers`] and consumed by
+/// [`DevToolAdapter::apply_mcp_governance`]. This is a minimal placeholder;
+/// when `aa-core` grows a richer MCP type (e.g. transport-aware
+/// description), this struct will be replaced or wrapped without any
+/// trait-method signature change.
+///
+/// [`DevToolAdapter::list_mcp_servers`]: <not yet defined; introduced in this same Subtask>
+/// [`DevToolAdapter::apply_mcp_governance`]: <not yet defined; introduced in this same Subtask>
+#[cfg(feature = "alloc")]
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct McpServerInfo {
+    /// Stable identifier the tool uses for this MCP server (matches the
+    /// key under which the server appears in the tool's native
+    /// configuration file).
+    pub name: String,
+    /// Executable invoked to start the MCP server process.
+    pub command: String,
+    /// Arguments passed to `command` when the MCP server is started.
+    pub args: Vec<String>,
 }
 
 /// Error type for [`DevToolAdapter`] method failures.

--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -132,6 +132,137 @@ pub struct DevToolInfo {
     pub supports_managed_settings: bool,
 }
 
+/// Per-tool integration contract for the dev tool governance framework.
+///
+/// Every per-tool adapter (Claude Code, Codex, GitHub Copilot, Windsurf
+/// Cascade, third-party SaaS coding agents) implements this trait. The
+/// gateway and the `aa run` launcher consume adapters via `dyn
+/// DevToolAdapter`, so the trait must be object-safe — that property is
+/// locked in by an explicit compile-time check added in AAASM-925.
+///
+/// Implementations live in their own crates / Stories and are out of
+/// scope for this Subtask (see AAASM-201 through AAASM-205, AAASM-918).
+///
+/// ## Async dispatch
+///
+/// The `async fn` methods are macro-desugared by `async_trait::async_trait`
+/// into boxed-future return types so that `dyn DevToolAdapter` is
+/// dyn-safe on stable Rust. The boxing cost is negligible compared to
+/// the I/O these methods perform (filesystem reads, subprocess writes,
+/// MCP discovery).
+#[cfg(feature = "std")]
+#[async_trait::async_trait]
+pub trait DevToolAdapter: Send + Sync {
+    /// Detect whether the tool this adapter targets is installed on the
+    /// current host.
+    ///
+    /// ### Contract
+    /// * Returns `Some(DevToolInfo)` when the tool's binary or
+    ///   well-known installation marker is present and readable.
+    /// * Returns `None` when the tool is not installed, is unreadable,
+    ///   or cannot be confirmed (e.g. the user lacks filesystem
+    ///   permission).
+    /// * Must not perform network I/O — detection runs at every CLI
+    ///   invocation and is on the hot path.
+    fn detect(&self) -> Option<DevToolInfo>;
+
+    /// Translate an Agent Assembly [`PolicyDocument`] into the tool's
+    /// native managed-settings format (e.g. JSON for Claude Code,
+    /// `.codex/config.toml` for Codex).
+    ///
+    /// ### Contract
+    /// * On success, returns the rendered settings document as a UTF-8
+    ///   string ready to be written by [`apply_settings`].
+    /// * Returns `AdapterError::SettingsGenerationFailed` (added in
+    ///   AAASM-925) when the policy contains constructs the tool's
+    ///   native config cannot express.
+    /// * Pure: must not touch the filesystem.
+    ///
+    /// [`PolicyDocument`]: crate::policy::PolicyDocument
+    /// [`apply_settings`]: Self::apply_settings
+    async fn generate_managed_settings(&self, policy: &crate::policy::PolicyDocument) -> Result<String, AdapterError>;
+
+    /// Write the rendered managed settings into the tool's
+    /// configuration surface, replacing any prior managed block.
+    ///
+    /// ### Contract
+    /// * On success, the tool will pick up the new policy on its next
+    ///   launch (some tools require a restart; the adapter is expected
+    ///   to document that in its own crate-level docs).
+    /// * Returns `AdapterError::SettingsApplyFailed` (added in
+    ///   AAASM-925) on filesystem error.
+    /// * Idempotent: applying the same `settings` twice is a no-op.
+    async fn apply_settings(&self, settings: &str) -> Result<(), AdapterError>;
+
+    /// Build the [`std::process::Command`] used by the `aa run` launcher
+    /// to start the tool with governance wiring (proxy, env vars,
+    /// agent identity, optional team identity).
+    ///
+    /// ### Contract
+    /// * Caller passes raw `tool_args` plus the agent and (optional)
+    ///   team identity that the gateway issued for this run.
+    /// * `proxy_addr`, when set, is the `host:port` of the local MitM
+    ///   proxy; the adapter must inject the appropriate
+    ///   `HTTPS_PROXY` / `OPENAI_BASE_URL` / similar env var so the
+    ///   tool routes traffic through it.
+    /// * Returns `AdapterError::LaunchFailed` (added in AAASM-925)
+    ///   when the tool's binary cannot be located or its argument
+    ///   format cannot accommodate the wiring.
+    /// * Sync (no I/O performed) — the returned `Command` is *built*,
+    ///   not spawned. Spawning is the launcher's job.
+    fn build_launch_command(
+        &self,
+        tool_args: &[String],
+        agent_id: &str,
+        team_id: Option<&str>,
+        proxy_addr: Option<&str>,
+    ) -> Result<std::process::Command, AdapterError>;
+
+    /// Enumerate the MCP servers the tool is currently configured to
+    /// connect to.
+    ///
+    /// ### Contract
+    /// * Returns the parsed list from the tool's native MCP config
+    ///   surface (e.g. `~/.claude/mcp_servers.json`).
+    /// * Returns an empty `Vec` (not an error) when the tool supports
+    ///   MCP but has no servers configured.
+    /// * Returns `AdapterError::McpConfigFailed` (added in
+    ///   AAASM-925) when the config exists but is malformed.
+    /// * Tools whose `DevToolInfo::supports_mcp == false` should
+    ///   instead return an empty `Vec`.
+    async fn list_mcp_servers(&self) -> Result<Vec<McpServerInfo>, AdapterError>;
+
+    /// Apply an MCP allow / deny list to the tool's configuration.
+    ///
+    /// ### Contract
+    /// * `allowed` lists MCP server names that are permitted; any
+    ///   server not in `allowed` and present in `denied` (or in the
+    ///   currently-configured set) must be removed from the tool's
+    ///   active config.
+    /// * `denied` is an explicit blocklist applied even if a server
+    ///   appears in `allowed` — `denied` wins on conflict (matches
+    ///   policy-engine evaluation order).
+    /// * Returns `AdapterError::McpConfigFailed` (added in
+    ///   AAASM-925) on filesystem write failure.
+    /// * Tools without MCP support should return `Ok(())` without
+    ///   performing any work.
+    async fn apply_mcp_governance(&self, allowed: &[String], denied: &[String]) -> Result<(), AdapterError>;
+
+    /// Highest governance level this adapter can achieve for the tool
+    /// it targets.
+    ///
+    /// ### Contract
+    /// * Returns the static, build-time-known cap for this adapter
+    ///   (e.g. an SDK-integrated adapter returns `L3Native`; a SaaS
+    ///   coding agent's observability-only adapter returns
+    ///   `L1Observe`).
+    /// * Must agree with `detect()`'s `DevToolInfo::governance_level`
+    ///   for any successful detection — gateway uses this to
+    ///   short-circuit policy decisions when an action would require
+    ///   a level the adapter cannot enforce.
+    fn governance_level(&self) -> GovernanceLevel;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -39,10 +39,12 @@ pub use policy::{FileMode, PolicyDecision, PolicyError};
 
 #[cfg(feature = "alloc")]
 pub use agent::AgentContext;
-#[cfg(feature = "std")]
-pub use dev_tool::DevToolInfo;
 #[cfg(feature = "alloc")]
 pub use dev_tool::DevToolKind;
+#[cfg(feature = "alloc")]
+pub use dev_tool::{AdapterError, McpServerInfo};
+#[cfg(feature = "std")]
+pub use dev_tool::{DevToolAdapter, DevToolInfo};
 
 #[cfg(feature = "alloc")]
 pub use policy::{ArgsJson, GovernanceAction, PolicyDocument, PolicyEvaluator, PolicyResult, PolicyRule};


### PR DESCRIPTION
## Description

Defines `aa_core::DevToolAdapter` — the per-tool integration contract every adapter (Claude Code, Codex, GitHub Copilot, Windsurf Cascade, SaaS coding agents) implements. Signatures + doc comments only; no concrete impls live here (those land in AAASM-201..205, AAASM-918).

Together with the trait, this PR adds the two minimum supporting types the trait surface needs:

* `AdapterError` — empty `#[non_exhaustive]` enum stub. **AAASM-925 will populate variants** (`ToolNotFound`, `DetectionFailed`, `SettingsGenerationFailed`, `SettingsApplyFailed`, `LaunchFailed`, `McpConfigFailed`, `Io`, `Serde`) and add `thiserror::Error` derive without breaking anything here.
* `McpServerInfo` — minimal placeholder `{ name, command, args }` per AAASM-923 acceptance criteria.

Trait methods (per AC):

| Method | Signature |
|---|---|
| `detect` | `fn detect(&self) -> Option<DevToolInfo>` |
| `generate_managed_settings` | `async fn (..., policy: &PolicyDocument) -> Result<String, AdapterError>` |
| `apply_settings` | `async fn (..., settings: &str) -> Result<(), AdapterError>` |
| `build_launch_command` | `fn (..., tool_args: &[String], agent_id: &str, team_id: Option<&str>, proxy_addr: Option<&str>) -> Result<std::process::Command, AdapterError>` |
| `list_mcp_servers` | `async fn (...) -> Result<Vec<McpServerInfo>, AdapterError>` |
| `apply_mcp_governance` | `async fn (..., allowed: &[String], denied: &[String]) -> Result<(), AdapterError>` |
| `governance_level` | `fn governance_level(&self) -> GovernanceLevel` |

Each method has a `### Contract` doc section spelling out preconditions, success postconditions, and which (forthcoming) `AdapterError` variant is expected on failure.

### One AC tension I diverged from — please review

The AC says: *"Use `async_trait::async_trait` if not already idiomatic in `aa-core`; otherwise use native AFIT."* I added `async-trait` as a new dep on `aa-core` (gated under `feature = "std"`) and used the macro. **Reason:** AAASM-925 will assert `_assert_object_safe(_: &dyn DevToolAdapter)`; native async-fn-in-trait is not dyn-compatible on stable Rust, so the AAASM-925 test would not compile if AFIT were used. The `async-trait` macro desugars `async fn` into boxed-future return types, restoring object safety. Rationale captured in the trait-level rustdoc.

If you'd rather keep `aa-core` async-trait-free, the alternatives are: (a) drop AAASM-925's object-safety requirement (move per-tool dispatch behind generics or an enum), or (b) hand-roll boxed `Pin<Box<dyn Future<Output = ...> + Send + '_>>` return types. Happy to switch if you prefer.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

The `AdapterError` enum stub is `#[non_exhaustive]` so AAASM-925's variant addition will not be a breaking change for downstream callers.

## Related Issues

- Related Jira ticket: [AAASM-923](https://lightning-dust-mite.atlassian.net/browse/AAASM-923) (parent Story [AAASM-199](https://lightning-dust-mite.atlassian.net/browse/AAASM-199); Epic [AAASM-196](https://lightning-dust-mite.atlassian.net/browse/AAASM-196)).
- Related GitHub issues: n/a.

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [x] No tests required (explain why)

This Subtask is signatures + doc comments only — by AAASM-923's explicit instruction *"This subtask is signatures + doc comments only; no implementation lives here"* — so there is nothing concrete to test yet. AAASM-925 adds the `_assert_object_safe(&dyn DevToolAdapter)` compile-time test. Verified locally that the trait IS object-safe by appending a temporary `const _OBJSAFE_SMOKE: fn(&dyn DevToolAdapter) = |_| {};` before commit; it compiled clean (line-for-line proof of dyn-compatibility), then the smoke check was reverted prior to commit so the AAASM-925 PR can land it intentionally.

Local validation run on this branch (worktree from latest `master` `164a26a`):

| Check | Command | Result |
|---|---|---|
| Build (default) | `cargo check -p aa-core` | OK |
| Build (no-default) | `cargo check -p aa-core --no-default-features` | OK |
| Build (alloc only) | `cargo check -p aa-core --no-default-features --features alloc` | OK |
| Build (alloc + serde) | `cargo check -p aa-core --no-default-features --features alloc,serde` | OK |
| Build (all features) | `cargo check -p aa-core --all-features` | OK |
| Tests | `cargo test -p aa-core --features serde` | 115 / 115 passed |
| Format | `cargo fmt --all -- --check` | clean |
| Clippy | `cargo clippy -p aa-core --all-targets --all-features -- -D warnings` | clean |
| Doc | `cargo doc -p aa-core --no-deps --all-features` | clean (0 warnings) |
| Workspace check (ex-eBPF) | `cargo check --workspace --exclude aa-ebpf*` | OK |
| Cargo deny (bans + licenses) | `cargo deny check bans licenses` | OK |

(`cargo nextest` not available locally; CI will run the canonical suite. `cargo deny check` advisory phase fails locally on an unrelated CVSS 4.0 advisory parse error in the host's `~/.cargo/advisory-dbs` — pre-existing and reproduces on `master` too.)

## Commit history (5 small commits, granular per the repo convention demonstrated by PR #154)

1. `✨ (aa-core): Add minimal AdapterError stub for DevToolAdapter` — empty `#[non_exhaustive]` enum, AAASM-925 will populate.
2. `✨ (aa-core): Add McpServerInfo placeholder type` — `{ name, command, args }`.
3. `🔧 (aa-core): Add async-trait dep for DevToolAdapter trait` — Cargo.toml only, gated under `std`.
4. `✨ (aa-core): Define DevToolAdapter async trait` — the trait + 7 method signatures + per-method Contract doc sections.
5. `🔧 (aa-core): Re-export DevToolAdapter, AdapterError, McpServerInfo` — `lib.rs` re-exports under matching feature gates.

Each commit leaves the crate in a buildable state (bisectable).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing (verified locally; CI will confirm)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-923]: https://lightning-dust-mite.atlassian.net/browse/AAASM-923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ