### PR TITLE
[AAASM-951] ✨ (engine): Index PolicyEngine policies by scope

### DIFF
--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1068,7 +1068,12 @@ mod tests {
             name: "stub".to_string(),
             rules: vec![],
         };
-        let result = engine.load_policy(&stub);
+        // PolicyEngine now also exposes an inherent `load_policy` that
+        // returns a `PolicyId` (AAASM-951). Use fully-qualified syntax so
+        // method resolution picks the trait stub under test rather than
+        // the inherent method, mirroring the trait-vs-inherent disambiguation
+        // already used for `evaluate` above.
+        let result = <PolicyEngine as PolicyEvaluator>::load_policy(&mut engine, &stub);
         assert_eq!(result, Err(aa_core::PolicyError::InvalidDocument));
     }
 

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -3,6 +3,7 @@
 //! Core rate limiting and enforcement mechanisms for the Agent Assembly policy engine.
 
 pub(crate) mod rate_limit;
+pub mod scope_index;
 pub(crate) mod watcher;
 
 use arc_swap::ArcSwap;

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -473,6 +473,39 @@ impl PolicyEngine {
     pub fn budget_tracker(&self) -> Arc<BudgetTracker> {
         Arc::clone(&self.budget)
     }
+
+    // ── F92 Phase B (AAASM-951): scope-keyed policy index ──────────────────
+
+    /// Register `doc` in the scope-keyed index and return the freshly
+    /// allocated [`scope_index::PolicyId`].
+    ///
+    /// Distinct from the [`aa_core::PolicyEvaluator::load_policy`] trait
+    /// method (which is a stub on this type — see `impl PolicyEvaluator`
+    /// below): this inherent method takes the gateway's own
+    /// [`PolicyDocument`] and returns an id rather than a `Result<()>`.
+    ///
+    /// Phase B does not yet have the cascading evaluator consult this
+    /// index — that wiring lands in F93 (AAASM-220). For now `load_policy`
+    /// is purely about populating the index for backward-compat tests
+    /// and so consumers can prepare scoped policies in advance.
+    pub fn load_policy(&mut self, doc: PolicyDocument) -> scope_index::PolicyId {
+        self.scope_index.insert(doc)
+    }
+
+    /// Drop a previously-registered policy by id, keeping `by_scope`
+    /// consistent. Returns the dropped `Arc<PolicyDocument>` if the id
+    /// was present, or `None` if it had already been removed.
+    pub fn remove_policy(&mut self, id: scope_index::PolicyId) -> Option<Arc<PolicyDocument>> {
+        self.scope_index.remove(id)
+    }
+
+    /// Return the [`scope_index::PolicyId`]s registered under `scope`,
+    /// in load order. Returns an empty slice when no policy has ever
+    /// been registered under that scope (or all of them have been
+    /// removed).
+    pub fn policies_for_scope(&self, scope: &crate::policy::PolicyScope) -> &[scope_index::PolicyId] {
+        self.scope_index.policies_for_scope(scope)
+    }
 }
 
 /// Implement the `aa_core::PolicyEvaluator` trait so `PolicyEngine` can be used

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -6,6 +6,8 @@ pub(crate) mod rate_limit;
 pub mod scope_index;
 pub(crate) mod watcher;
 
+pub use scope_index::PolicyId;
+
 use arc_swap::ArcSwap;
 use dashmap::DashMap;
 use std::{

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -506,6 +506,20 @@ impl PolicyEngine {
     pub fn policies_for_scope(&self, scope: &crate::policy::PolicyScope) -> &[scope_index::PolicyId] {
         self.scope_index.policies_for_scope(scope)
     }
+
+    /// Look up a policy previously registered via [`Self::load_policy`]
+    /// by its [`scope_index::PolicyId`].
+    ///
+    /// Returns `None` if the id was never issued, or if the policy
+    /// has since been removed via [`Self::remove_policy`]. Cheap —
+    /// backed by a `HashMap` lookup with no allocation.
+    ///
+    /// F93 (AAASM-220) will use this to materialise the cascading
+    /// chain of `(scope, doc)` pairs once it consults
+    /// [`Self::policies_for_scope`].
+    pub fn policy(&self, id: scope_index::PolicyId) -> Option<&Arc<PolicyDocument>> {
+        self.scope_index.policy(id)
+    }
 }
 
 /// Implement the `aa_core::PolicyEvaluator` trait so `PolicyEngine` can be used

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -15,6 +15,7 @@ use std::{
 
 use crate::budget::BudgetTracker;
 
+use crate::engine::scope_index::ScopeIndex;
 use crate::policy::document::ActionOnExceed;
 use crate::policy::{PolicyDocument, PolicyValidator};
 
@@ -77,6 +78,13 @@ pub struct PolicyEngine {
     compiled_patterns: Vec<regex::Regex>,
     rate_state: DashMap<String, Mutex<crate::engine::rate_limit::TokenBucket>>,
     budget: Arc<BudgetTracker>,
+    /// Scope-keyed index of additionally-loaded policies (AAASM-951).
+    ///
+    /// Populated via [`PolicyEngine::load_policy`]. The single primary
+    /// policy held in `policy` (above) is unaffected — F93 (AAASM-220)
+    /// will migrate the evaluator to consult this index for cascading
+    /// most-restrictive-wins resolution.
+    scope_index: ScopeIndex,
     _watcher: Option<notify::RecommendedWatcher>,
 }
 
@@ -148,6 +156,7 @@ impl PolicyEngine {
             compiled_patterns,
             rate_state: DashMap::new(),
             budget,
+            scope_index: ScopeIndex::new(),
             _watcher: watcher,
         })
     }
@@ -178,6 +187,7 @@ impl PolicyEngine {
             compiled_patterns,
             rate_state: DashMap::new(),
             budget,
+            scope_index: ScopeIndex::new(),
             _watcher: watcher,
         })
     }
@@ -560,6 +570,7 @@ mod tests {
                 monthly_limit,
                 chrono_tz::UTC,
             )),
+            scope_index: ScopeIndex::new(),
             _watcher: None,
         }
     }
@@ -1230,6 +1241,7 @@ mod tests {
                 chrono_tz::UTC,
                 alert_tx,
             )),
+            scope_index: ScopeIndex::new(),
             _watcher: None,
         }
     }

--- a/aa-gateway/src/engine/scope_index.rs
+++ b/aa-gateway/src/engine/scope_index.rs
@@ -1,0 +1,6 @@
+//! Scope-keyed index of loaded policies (`PolicyId` ↔ `PolicyScope`).
+//!
+//! Built for AAASM-951 (F92 Phase B). Stores policy documents alongside a
+//! map from each [`crate::policy::PolicyScope`] to the list of policy ids
+//! loaded under that scope, in insertion order, so the cascading evaluator
+//! added by AAASM-220 (F93) can resolve applicable policies in O(1).

--- a/aa-gateway/src/engine/scope_index.rs
+++ b/aa-gateway/src/engine/scope_index.rs
@@ -114,3 +114,115 @@ impl ScopeIndex {
         self.by_scope.get(scope).map(Vec::as_slice).unwrap_or(&[])
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Build an empty `PolicyDocument` carrying just the requested scope.
+    /// Keeps tests focused on the index, not on policy validation.
+    fn doc_with_scope(scope: PolicyScope) -> PolicyDocument {
+        PolicyDocument {
+            name: None,
+            policy_version: None,
+            version: None,
+            scope,
+            network: None,
+            schedule: None,
+            budget: None,
+            data: None,
+            approval_timeout_secs: 300,
+            tools: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn empty_index_reports_no_policies() {
+        let idx = ScopeIndex::new();
+        assert_eq!(idx.len(), 0);
+        assert!(idx.is_empty());
+        assert!(idx.policies_for_scope(&PolicyScope::Global).is_empty());
+    }
+
+    #[test]
+    fn insert_returns_distinct_ids_in_order() {
+        let mut idx = ScopeIndex::new();
+        let id_a = idx.insert(doc_with_scope(PolicyScope::Global));
+        let id_b = idx.insert(doc_with_scope(PolicyScope::Global));
+        assert_ne!(id_a, id_b, "ids must be unique within an index");
+        assert!(id_b.as_raw() > id_a.as_raw(), "ids must be monotonic");
+    }
+
+    #[test]
+    fn policies_for_scope_returns_load_order() {
+        let mut idx = ScopeIndex::new();
+        let team = PolicyScope::Team("platform".to_owned());
+        let id1 = idx.insert(doc_with_scope(team.clone()));
+        idx.insert(doc_with_scope(PolicyScope::Global));
+        let id3 = idx.insert(doc_with_scope(team.clone()));
+
+        assert_eq!(
+            idx.policies_for_scope(&team),
+            &[id1, id3],
+            "team bucket must hold ids in insertion order, with the global \
+             policy that landed in between excluded",
+        );
+    }
+
+    #[test]
+    fn policies_for_scope_groups_by_distinct_scopes() {
+        let mut idx = ScopeIndex::new();
+        let id_g = idx.insert(doc_with_scope(PolicyScope::Global));
+        let id_org = idx.insert(doc_with_scope(PolicyScope::Org("acme".to_owned())));
+        let id_team = idx.insert(doc_with_scope(PolicyScope::Team("platform".to_owned())));
+
+        assert_eq!(idx.policies_for_scope(&PolicyScope::Global), &[id_g]);
+        assert_eq!(idx.policies_for_scope(&PolicyScope::Org("acme".to_owned())), &[id_org]);
+        assert_eq!(
+            idx.policies_for_scope(&PolicyScope::Team("platform".to_owned())),
+            &[id_team],
+        );
+    }
+
+    #[test]
+    fn remove_drops_doc_and_strips_id_from_scope_bucket() {
+        let mut idx = ScopeIndex::new();
+        let team = PolicyScope::Team("platform".to_owned());
+        let id_a = idx.insert(doc_with_scope(team.clone()));
+        let id_b = idx.insert(doc_with_scope(team.clone()));
+
+        let removed = idx.remove(id_a);
+        assert!(removed.is_some(), "remove returns the dropped doc");
+        assert_eq!(idx.policies_for_scope(&team), &[id_b]);
+        assert!(idx.policy(id_a).is_none(), "doc lookup must miss after removal");
+    }
+
+    #[test]
+    fn remove_drops_empty_scope_bucket_entirely() {
+        let mut idx = ScopeIndex::new();
+        let team = PolicyScope::Team("platform".to_owned());
+        let id = idx.insert(doc_with_scope(team.clone()));
+
+        idx.remove(id);
+        assert!(
+            idx.policies_for_scope(&team).is_empty(),
+            "lookup must report empty for a fully-emptied bucket",
+        );
+    }
+
+    #[test]
+    fn remove_unknown_id_returns_none() {
+        let mut idx = ScopeIndex::new();
+        let bogus = PolicyId::from_raw(9_999);
+        assert!(idx.remove(bogus).is_none());
+    }
+
+    #[test]
+    fn policy_lookup_returns_inserted_document() {
+        let mut idx = ScopeIndex::new();
+        let id = idx.insert(doc_with_scope(PolicyScope::Org("acme".to_owned())));
+        let stored = idx.policy(id).expect("inserted doc must be retrievable");
+        assert_eq!(stored.scope, PolicyScope::Org("acme".to_owned()));
+    }
+}

--- a/aa-gateway/src/engine/scope_index.rs
+++ b/aa-gateway/src/engine/scope_index.rs
@@ -50,3 +50,40 @@ pub struct ScopeIndex {
     /// Monotonic counter feeding new [`PolicyId`] values.
     next_id: u64,
 }
+
+impl ScopeIndex {
+    /// Construct an empty index.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register `doc` under its declared `scope`, returning the freshly
+    /// allocated [`PolicyId`].
+    ///
+    /// The id is appended to the scope's bucket so subsequent
+    /// [`Self::policies_for_scope`] calls observe insertion order.
+    pub fn insert(&mut self, doc: PolicyDocument) -> PolicyId {
+        let id = PolicyId(self.next_id);
+        self.next_id += 1;
+
+        let scope = doc.scope.clone();
+        self.policies.insert(id, Arc::new(doc));
+        self.by_scope.entry(scope).or_default().push(id);
+        id
+    }
+
+    /// Look up a stored document by id.
+    pub fn policy(&self, id: PolicyId) -> Option<&Arc<PolicyDocument>> {
+        self.policies.get(&id)
+    }
+
+    /// Total number of policies currently indexed.
+    pub fn len(&self) -> usize {
+        self.policies.len()
+    }
+
+    /// Whether the index holds any policies.
+    pub fn is_empty(&self) -> bool {
+        self.policies.is_empty()
+    }
+}

--- a/aa-gateway/src/engine/scope_index.rs
+++ b/aa-gateway/src/engine/scope_index.rs
@@ -41,6 +41,21 @@ impl PolicyId {
 ///
 /// Phase B (this Sub-task) only populates the index; the cascading
 /// evaluator that *consumes* it lands in F93 (AAASM-220).
+///
+/// # Invariants
+///
+/// * Every id in any `by_scope` bucket points to a live entry in
+///   `policies`. [`Self::remove`] preserves this by editing both
+///   collections atomically.
+/// * Empty buckets are not retained — once the last id under a scope
+///   is removed, the scope itself is dropped from `by_scope`.
+///   [`Self::policies_for_scope`] therefore returns `&[]` both for
+///   "scope was never used" and "scope is now empty"; callers cannot
+///   distinguish these two states (and shouldn't need to).
+/// * Buckets preserve **insertion order**: ids appear in the order
+///   their corresponding documents were passed to [`Self::insert`].
+///   Documents inserted under unrelated scopes between two same-scope
+///   inserts do not affect the relative order of the same-scope ids.
 #[derive(Debug, Default)]
 pub struct ScopeIndex {
     /// Owned policy documents keyed by their assigned id.

--- a/aa-gateway/src/engine/scope_index.rs
+++ b/aa-gateway/src/engine/scope_index.rs
@@ -5,6 +5,11 @@
 //! loaded under that scope, in insertion order, so the cascading evaluator
 //! added by AAASM-220 (F93) can resolve applicable policies in O(1).
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::policy::{PolicyDocument, PolicyScope};
+
 /// Opaque identifier returned by [`ScopeIndex::insert`] (and by
 /// [`crate::engine::PolicyEngine::load_policy`] in turn).
 ///
@@ -28,4 +33,20 @@ impl PolicyId {
     pub const fn as_raw(&self) -> u64 {
         self.0
     }
+}
+
+/// Owns loaded policy documents and a secondary index from
+/// [`PolicyScope`] to the list of [`PolicyId`]s registered under that
+/// scope, preserving insertion order within each bucket.
+///
+/// Phase B (this Sub-task) only populates the index; the cascading
+/// evaluator that *consumes* it lands in F93 (AAASM-220).
+#[derive(Debug, Default)]
+pub struct ScopeIndex {
+    /// Owned policy documents keyed by their assigned id.
+    policies: HashMap<PolicyId, Arc<PolicyDocument>>,
+    /// Per-scope insertion-ordered list of policy ids.
+    by_scope: HashMap<PolicyScope, Vec<PolicyId>>,
+    /// Monotonic counter feeding new [`PolicyId`] values.
+    next_id: u64,
 }

--- a/aa-gateway/src/engine/scope_index.rs
+++ b/aa-gateway/src/engine/scope_index.rs
@@ -104,4 +104,13 @@ impl ScopeIndex {
     pub fn is_empty(&self) -> bool {
         self.policies.is_empty()
     }
+
+    /// Return the ids of every policy registered under `scope`, in
+    /// insertion order. Returns an empty slice when no policy has ever
+    /// been registered (or all of them have since been removed).
+    ///
+    /// Cheap — backed directly by the index `Vec`, no allocation.
+    pub fn policies_for_scope(&self, scope: &PolicyScope) -> &[PolicyId] {
+        self.by_scope.get(scope).map(Vec::as_slice).unwrap_or(&[])
+    }
 }

--- a/aa-gateway/src/engine/scope_index.rs
+++ b/aa-gateway/src/engine/scope_index.rs
@@ -77,6 +77,24 @@ impl ScopeIndex {
         self.policies.get(&id)
     }
 
+    /// Remove the policy registered under `id`, keeping `by_scope` in sync.
+    ///
+    /// Returns the dropped `Arc<PolicyDocument>` if the id was present, or
+    /// `None` if it had already been removed (or was never inserted). When
+    /// the affected scope bucket becomes empty it is dropped from the map
+    /// so callers can rely on the bucket's presence implying at least one
+    /// live policy.
+    pub fn remove(&mut self, id: PolicyId) -> Option<Arc<PolicyDocument>> {
+        let doc = self.policies.remove(&id)?;
+        if let Some(bucket) = self.by_scope.get_mut(&doc.scope) {
+            bucket.retain(|existing| *existing != id);
+            if bucket.is_empty() {
+                self.by_scope.remove(&doc.scope);
+            }
+        }
+        Some(doc)
+    }
+
     /// Total number of policies currently indexed.
     pub fn len(&self) -> usize {
         self.policies.len()

--- a/aa-gateway/src/engine/scope_index.rs
+++ b/aa-gateway/src/engine/scope_index.rs
@@ -4,3 +4,28 @@
 //! map from each [`crate::policy::PolicyScope`] to the list of policy ids
 //! loaded under that scope, in insertion order, so the cascading evaluator
 //! added by AAASM-220 (F93) can resolve applicable policies in O(1).
+
+/// Opaque identifier returned by [`ScopeIndex::insert`] (and by
+/// [`crate::engine::PolicyEngine::load_policy`] in turn).
+///
+/// Monotonically increasing within a single `ScopeIndex` instance, but
+/// callers must treat the inner value as opaque — it is not stable
+/// across processes and not suitable as a database key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PolicyId(u64);
+
+impl PolicyId {
+    /// Construct a `PolicyId` from a raw counter value. Intended for tests
+    /// and for `ScopeIndex` itself; production callers should obtain ids
+    /// from `ScopeIndex::insert`.
+    #[inline]
+    pub const fn from_raw(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    /// Return the raw counter value of this id.
+    #[inline]
+    pub const fn as_raw(&self) -> u64 {
+        self.0
+    }
+}

--- a/aa-gateway/tests/fixtures/policies/scoped/agent_specific.yaml
+++ b/aa-gateway/tests/fixtures/policies/scoped/agent_specific.yaml
@@ -1,0 +1,4 @@
+scope: agent:01234567-89ab-cdef-0123-456789abcdef
+network:
+  allowlist:
+    - agent.acme.internal

--- a/aa-gateway/tests/fixtures/policies/scoped/global.yaml
+++ b/aa-gateway/tests/fixtures/policies/scoped/global.yaml
@@ -1,0 +1,4 @@
+scope: global
+network:
+  allowlist:
+    - api.example.com

--- a/aa-gateway/tests/fixtures/policies/scoped/org_acme.yaml
+++ b/aa-gateway/tests/fixtures/policies/scoped/org_acme.yaml
@@ -1,0 +1,4 @@
+scope: org:acme
+network:
+  allowlist:
+    - acme.internal

--- a/aa-gateway/tests/fixtures/policies/scoped/team_platform.yaml
+++ b/aa-gateway/tests/fixtures/policies/scoped/team_platform.yaml
@@ -1,0 +1,4 @@
+scope: team:platform
+network:
+  allowlist:
+    - platform.acme.internal

--- a/aa-gateway/tests/scope_index_fixtures_test.rs
+++ b/aa-gateway/tests/scope_index_fixtures_test.rs
@@ -107,6 +107,25 @@ fn pre_f92_fixture_without_scope_field_lands_in_global() {
 }
 
 #[test]
+fn engine_policy_accessor_round_trips_loaded_doc() {
+    let doc = load_fixture("team_platform");
+    let team = PolicyScope::Team("platform".to_owned());
+
+    let mut engine = empty_engine();
+    let id = engine.load_policy(doc);
+
+    let stored = engine.policy(id).expect("just-loaded policy must be retrievable");
+    assert_eq!(stored.scope, team, "policy(id) returns the same doc that was loaded");
+
+    let removed = engine.remove_policy(id);
+    assert!(removed.is_some(), "remove returns the dropped doc");
+    assert!(
+        engine.policy(id).is_none(),
+        "policy(id) returns None after the doc is removed",
+    );
+}
+
+#[test]
 fn distinct_scoped_fixtures_do_not_contaminate_other_buckets() {
     let global = load_fixture("global");
     let org = load_fixture("org_acme");

--- a/aa-gateway/tests/scope_index_fixtures_test.rs
+++ b/aa-gateway/tests/scope_index_fixtures_test.rs
@@ -82,6 +82,30 @@ fn agent_scoped_fixture_lands_in_matching_agent_bucket() {
     assert_eq!(engine.policies_for_scope(&expected_scope), &[id]);
 }
 
+/// Backward-compat: a YAML fixture from before F92 (no `scope:` field, in
+/// the envelope format used by `policy-examples/`) must validate cleanly
+/// and land under `PolicyScope::Global` when registered with the engine.
+#[test]
+fn pre_f92_fixture_without_scope_field_lands_in_global() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root")
+        .join("policy-examples/high-risk.yaml");
+    let yaml = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    let doc = PolicyValidator::from_yaml(&yaml)
+        .unwrap_or_else(|errs| panic!("validate {}: {errs:?}", path.display()))
+        .document;
+    assert_eq!(doc.scope, PolicyScope::Global, "missing scope: must default to Global");
+
+    let mut engine = empty_engine();
+    let id = engine.load_policy(doc);
+    assert_eq!(
+        engine.policies_for_scope(&PolicyScope::Global),
+        &[id],
+        "pre-F92 fixture must register under Global without any code change to the YAML",
+    );
+}
+
 #[test]
 fn distinct_scoped_fixtures_do_not_contaminate_other_buckets() {
     let global = load_fixture("global");

--- a/aa-gateway/tests/scope_index_fixtures_test.rs
+++ b/aa-gateway/tests/scope_index_fixtures_test.rs
@@ -1,0 +1,105 @@
+//! Integration tests for the F92 Phase B scope index (AAASM-951).
+//!
+//! Loads each scoped fixture through the YAML validator, feeds the
+//! resulting `PolicyDocument` into a fresh `PolicyEngine` via the new
+//! `load_policy` method, and asserts that the engine indexes it under
+//! the expected `PolicyScope` bucket.
+
+use std::path::Path;
+
+use aa_core::identity::AgentId;
+use aa_gateway::engine::PolicyEngine;
+use aa_gateway::policy::{PolicyDocument, PolicyScope, PolicyValidator};
+
+/// Parse a scoped fixture from `tests/fixtures/policies/scoped/<name>.yaml`.
+fn load_fixture(name: &str) -> PolicyDocument {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/policies/scoped")
+        .join(format!("{name}.yaml"));
+    let yaml = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    PolicyValidator::from_yaml(&yaml)
+        .unwrap_or_else(|errs| panic!("validate {}: {errs:?}", path.display()))
+        .document
+}
+
+/// Build an empty `PolicyEngine` for the index tests. We deliberately
+/// avoid `load_from_file` because that constructor is geared toward the
+/// single-policy ArcSwap flow; for the index tests we just want a fresh
+/// empty `scope_index` and we exercise it via the new `load_policy`
+/// inherent method.
+fn empty_engine() -> PolicyEngine {
+    let yaml = "{}\n";
+    let path = std::env::temp_dir().join(format!("aaasm951-empty-{}.yaml", std::process::id()));
+    std::fs::write(&path, yaml).unwrap();
+    let (alert_tx, _rx) = tokio::sync::broadcast::channel(8);
+    PolicyEngine::load_from_file(&path, alert_tx).expect("empty policy loads")
+}
+
+#[test]
+fn global_scoped_fixture_lands_in_global_bucket() {
+    let doc = load_fixture("global");
+    assert_eq!(doc.scope, PolicyScope::Global);
+
+    let mut engine = empty_engine();
+    let id = engine.load_policy(doc);
+    assert_eq!(engine.policies_for_scope(&PolicyScope::Global), &[id]);
+}
+
+#[test]
+fn org_scoped_fixture_lands_in_matching_org_bucket() {
+    let doc = load_fixture("org_acme");
+    assert_eq!(doc.scope, PolicyScope::Org("acme".to_owned()));
+
+    let mut engine = empty_engine();
+    let id = engine.load_policy(doc);
+    assert_eq!(engine.policies_for_scope(&PolicyScope::Org("acme".to_owned())), &[id]);
+}
+
+#[test]
+fn team_scoped_fixture_lands_in_matching_team_bucket() {
+    let doc = load_fixture("team_platform");
+    assert_eq!(doc.scope, PolicyScope::Team("platform".to_owned()));
+
+    let mut engine = empty_engine();
+    let id = engine.load_policy(doc);
+    assert_eq!(
+        engine.policies_for_scope(&PolicyScope::Team("platform".to_owned())),
+        &[id],
+    );
+}
+
+#[test]
+fn agent_scoped_fixture_lands_in_matching_agent_bucket() {
+    const EXPECTED_BYTES: [u8; 16] = [
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+    ];
+    let doc = load_fixture("agent_specific");
+    let expected_scope = PolicyScope::Agent(AgentId::from_bytes(EXPECTED_BYTES));
+    assert_eq!(doc.scope, expected_scope);
+
+    let mut engine = empty_engine();
+    let id = engine.load_policy(doc);
+    assert_eq!(engine.policies_for_scope(&expected_scope), &[id]);
+}
+
+#[test]
+fn distinct_scoped_fixtures_do_not_contaminate_other_buckets() {
+    let global = load_fixture("global");
+    let org = load_fixture("org_acme");
+    let team = load_fixture("team_platform");
+
+    let mut engine = empty_engine();
+    let id_global = engine.load_policy(global);
+    let id_org = engine.load_policy(org);
+    let id_team = engine.load_policy(team);
+
+    assert_eq!(engine.policies_for_scope(&PolicyScope::Global), &[id_global]);
+    assert_eq!(
+        engine.policies_for_scope(&PolicyScope::Org("acme".to_owned())),
+        &[id_org],
+    );
+    assert_eq!(
+        engine.policies_for_scope(&PolicyScope::Team("platform".to_owned())),
+        &[id_team],
+    );
+}


### PR DESCRIPTION
## Description

Implements **AAASM-951** — Phase B of the F92 policy scope hierarchy
(parent Story `AAASM-219`, Epic `AAASM-198`).

Adds a scope-keyed index of loaded policies inside `PolicyEngine` so
the cascading evaluator landing in F93 (`AAASM-220`) can resolve
applicable policies in O(1). Phase B only **populates** the index;
the evaluator that consumes it remains untouched here.

### What's in the diff

* New `aa-gateway/src/engine/scope_index.rs` module:
  * `pub struct PolicyId(u64)` newtype.
  * `pub struct ScopeIndex` owning `policies: HashMap<PolicyId, Arc<PolicyDocument>>` plus `by_scope: HashMap<PolicyScope, Vec<PolicyId>>` and a monotonic `next_id` counter.
  * `insert` / `remove` / `policies_for_scope` / `policy` / `len` / `is_empty` methods, all documented.
* `aa-gateway/src/engine/mod.rs`:
  * `PolicyEngine` gains a `scope_index: ScopeIndex` field, initialised empty in all four constructors (`load_from_file`, `load_from_file_with_budget`, the `make_engine` test helper, and the alert-channel test helper).
  * Three new inherent methods: `load_policy(doc) -> PolicyId`, `remove_policy(id) -> Option<Arc<PolicyDocument>>`, `policies_for_scope(scope) -> &[PolicyId]`. Rustdoc explicitly distinguishes the new inherent `load_policy` from the existing `aa_core::PolicyEvaluator::load_policy` trait stub.
  * One existing trait-stub test updated to fully-qualified syntax (`<PolicyEngine as PolicyEvaluator>::load_policy(...)`) since the inherent method now shadows the trait method by dot-notation method resolution.
* New scoped fixtures under `aa-gateway/tests/fixtures/policies/scoped/` (`global.yaml`, `org_acme.yaml`, `team_platform.yaml`, `agent_specific.yaml`).
* New integration test file `aa-gateway/tests/scope_index_fixtures_test.rs` driving each fixture through the YAML validator and into a fresh engine, plus a backward-compat test using `policy-examples/high-risk.yaml` (a pre-F92 envelope-format fixture with no `scope:` field) that asserts the doc lands under `PolicyScope::Global`.

### Architectural choice (additive)

The single-policy `Arc<ArcSwap<PolicyDocument>>` slot stays intact. The
new index lives **alongside** it. F93 will migrate the evaluator to
consult `scope_index` for cascading; this PR keeps the change small
and bisectable, and avoids touching the gRPC `PolicyService`, the
hot-reload watcher, and `apply_yaml`'s history pipeline.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactoring (one trait-shadow test disambiguation)
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update (rustdoc invariants)
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No (purely additive — existing `load_from_file` and the
      `ArcSwap`-driven hot-reload flow are untouched; the new index is
      empty until callers explicitly invoke `load_policy`).

## Related Issues

- Related Jira ticket: AAASM-951 (Sub-task) → AAASM-219 (Story F92) → AAASM-198 (Epic)

## Testing

- [x] Unit tests added / updated (8 tests in `scope_index::tests`)
- [x] Integration tests added / updated (6 tests in `scope_index_fixtures_test`)
- [ ] Manual testing performed
- [ ] No tests required (explain why)

### Local validation

| Command | Result |
| --- | --- |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -p aa-gateway --all-targets --all-features -- -D warnings` | clean |
| `cargo nextest run -p aa-gateway` (excluding `sustained_load_p99_under_5ms`) | **404 / 404** pass |
| `cargo nextest run -p aa-gateway --release sustained_load_p99_under_5ms` | passes in release |
| `cargo doc -p aa-gateway --no-deps` | builds (no new warnings) |

### Acceptance criteria coverage

| AC | Where covered |
| --- | --- |
| `PolicyEngine` exposes `policies_by_scope: HashMap<PolicyScope, Vec<PolicyId>>` | `ScopeIndex.by_scope`, accessed via `PolicyEngine::policies_for_scope` |
| `load_policy` populates the index when a policy is added; removal keeps the index consistent | `ScopeIndex::insert` and `remove`; verified by `remove_drops_doc_and_strips_id_from_scope_bucket` and `remove_drops_empty_scope_bucket_entirely` |
| Policies parsed without a `scope:` field are inserted under `Global` | covered by `pre_f92_fixture_without_scope_field_lands_in_global` (uses real `policy-examples/high-risk.yaml`) |
| `policies_for_scope(&PolicyScope) -> &[PolicyId]` returns matches in load order | covered by `policies_for_scope_returns_load_order` (asserts that an ID inserted *after* a different-scope ID is still last in its own bucket) |
| Backward-compat test loads a pre-F92 fixture and asserts it lands in `Global` | `pre_f92_fixture_without_scope_field_lands_in_global` |
| New scoped fixtures for `org`, `team`, `agent` each load into their respective bucket | four fixture files + four `*_fixture_lands_in_matching_*_bucket` tests |
| No regression in existing `PolicyEngine` unit tests | confirmed via full `cargo nextest -p aa-gateway` run (404 passing) |

### Pre-existing flake noted

Same as on AAASM-947: `tests/policy_latency_test.rs::sustained_load_p99_under_5ms` flakes in **debug** mode on a hot machine (p99 over the 15ms SLA after a fresh full-workspace compile). It passes cleanly in `--release`. The diff in this PR does **not** touch the perf test or the gRPC `PolicyService::CheckAction` hot path. Flagging here so reviewers don't waste time on it. CI should be unaffected.

### Local `cargo deny check` note

Local cargo-deny 0.18.3 fails to parse the new `libcrux-poly1305` RUSTSEC-2026-0073 advisory because it uses CVSS:4.0, which this version of cargo-deny does not yet understand. The error is in the advisory database, not in this PR's diff. CI's cargo-deny version is expected to be newer and handle the entry.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --all-features -D warnings`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on `ScopeIndex` invariants + `PolicyEngine::load_policy`)
- [ ] All CI checks passing (CI not yet run at PR-open time)
- [x] Commits are small and follow the Gitmoji convention (13 commits, all bisectable)