### PR TITLE
[AAASM-1008] ✨ (policy/scope): Add Tool variant for 5-level scope chain

### DIFF
--- a/aa-gateway/src/policy/scope.rs
+++ b/aa-gateway/src/policy/scope.rs
@@ -75,6 +75,10 @@ pub enum PolicyScope {
     Team(TeamId),
     /// Applies to a single specific agent.
     Agent(AgentId),
+    /// Applies to a specific tool / MCP server, across every agent
+    /// otherwise admitted by higher scopes. Sits at the most-restrictive
+    /// end of the cascading chain (`Global → Org → Team → Agent → Tool`).
+    Tool(String),
 }
 
 impl fmt::Display for PolicyScope {
@@ -84,6 +88,7 @@ impl fmt::Display for PolicyScope {
             Self::Org(id) => write!(f, "org:{}", id),
             Self::Team(id) => write!(f, "team:{}", id),
             Self::Agent(id) => write!(f, "agent:{}", Uuid::from_bytes(*id.as_bytes())),
+            Self::Tool(name) => write!(f, "tool:{}", name),
         }
     }
 }
@@ -118,6 +123,7 @@ impl FromStr for PolicyScope {
                     Uuid::parse_str(value).map_err(|e| invalid(&format!("agent id is not a valid UUID: {}", e)))?;
                 Ok(Self::Agent(AgentId::from_bytes(*uuid.as_bytes())))
             }
+            "tool" => Ok(Self::Tool(value.to_owned())),
             other => Err(invalid(&format!("unknown scope kind {:?}", other))),
         }
     }

--- a/aa-gateway/src/policy/scope.rs
+++ b/aa-gateway/src/policy/scope.rs
@@ -1,7 +1,12 @@
-//! Policy scope hierarchy types (`global` / `org:<id>` / `team:<id>` / `agent:<uuid>`).
+//! Policy scope hierarchy types
+//! (`global` / `org:<id>` / `team:<id>` / `agent:<uuid>` / `tool:<name>`).
 //!
-//! See AAASM-219 (F92) for the design. Subsequent Sub-tasks will extend this
-//! module with the `Tool(...)` variant and a scope index inside `PolicyEngine`.
+//! See AAASM-219 (F92) for the design. The 5-level chain is the
+//! complete scope vocabulary; the `ScopeIndex` in
+//! [`crate::engine::scope_index`] indexes loaded policies by these
+//! variants, and the cascading evaluator in F93 (AAASM-220) consults
+//! them in `Global → Org → Team → Agent → Tool` order
+//! (most-restrictive-wins).
 
 use std::fmt;
 use std::str::FromStr;
@@ -20,9 +25,12 @@ pub type TeamId = String;
 
 /// Hierarchical scope a policy applies to.
 ///
-/// Resolution order is `Global → Org → Team → Agent`, with most-restrictive-wins
-/// merging performed by [`crate::engine::PolicyEngine`] (wired in F93). The
-/// `Tool` variant for a 5-level chain is added by AAASM-1008.
+/// Resolution order is `Global → Org → Team → Agent → Tool`, with
+/// most-restrictive-wins merging performed by
+/// [`crate::engine::PolicyEngine`] (wired in F93, AAASM-220). `Tool`
+/// sits at the most-restrictive end of the chain so a policy can,
+/// for example, deny `slack-mcp` for every agent in `team-x` even
+/// when team- and agent-level policies would otherwise allow it.
 ///
 /// # Wire format
 ///
@@ -35,6 +43,7 @@ pub type TeamId = String;
 /// | `Org(id)`       | `org:<id>`                            |
 /// | `Team(id)`      | `team:<id>`                           |
 /// | `Agent(uuid)`   | `agent:<hyphenated-uuid>`             |
+/// | `Tool(name)`    | `tool:<tool-name>`                    |
 ///
 /// # Examples
 ///

--- a/aa-gateway/src/policy/scope.rs
+++ b/aa-gateway/src/policy/scope.rs
@@ -181,6 +181,14 @@ mod tests {
         assert_eq!(parsed, PolicyScope::Agent(AgentId::from_bytes(AGENT_BYTES)));
     }
 
+    #[test]
+    fn parses_tool_with_name() {
+        assert_eq!(
+            "tool:slack-mcp".parse::<PolicyScope>().unwrap(),
+            PolicyScope::Tool("slack-mcp".to_owned()),
+        );
+    }
+
     // ── Display round-trip ──────────────────────────────────────────────────
 
     #[test]
@@ -190,6 +198,7 @@ mod tests {
             PolicyScope::Org("acme".to_owned()),
             PolicyScope::Team("platform".to_owned()),
             PolicyScope::Agent(AgentId::from_bytes(AGENT_BYTES)),
+            PolicyScope::Tool("slack-mcp".to_owned()),
         ];
         for original in cases {
             let rendered = original.to_string();
@@ -207,6 +216,7 @@ mod tests {
             PolicyScope::Org("acme".to_owned()),
             PolicyScope::Team("platform".to_owned()),
             PolicyScope::Agent(AgentId::from_bytes(AGENT_BYTES)),
+            PolicyScope::Tool("slack-mcp".to_owned()),
         ];
         for original in cases {
             let yaml = serde_yaml::to_string(&original).unwrap();
@@ -250,5 +260,12 @@ mod tests {
     #[test]
     fn rejects_agent_with_non_uuid_value() {
         assert_invalid_scope("agent:not-a-uuid", "valid UUID");
+    }
+
+    #[test]
+    fn rejects_empty_tool_name() {
+        // Same empty-identifier guard as `team:` / `org:` / `agent:`,
+        // applied to `tool:`. Verifies the AAASM-1008 AC explicitly.
+        assert_invalid_scope("tool:", "must not be empty");
     }
 }

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -817,6 +817,8 @@ data:
             ("acme", "expected `global`"),
             // Empty identifier after the colon.
             ("\"team:\"", "must not be empty"),
+            // Empty identifier on the Tool variant (AAASM-1008 AC).
+            ("\"tool:\"", "must not be empty"),
             // Unknown scope kind.
             ("project:foo", "unknown scope kind"),
             // Agent variant with a non-UUID identifier.

--- a/aa-gateway/tests/fixtures/policies/scoped/tool_slack_mcp.yaml
+++ b/aa-gateway/tests/fixtures/policies/scoped/tool_slack_mcp.yaml
@@ -1,0 +1,4 @@
+scope: tool:slack-mcp
+network:
+  allowlist:
+    - slack.com

--- a/aa-gateway/tests/scope_index_fixtures_test.rs
+++ b/aa-gateway/tests/scope_index_fixtures_test.rs
@@ -82,6 +82,17 @@ fn agent_scoped_fixture_lands_in_matching_agent_bucket() {
     assert_eq!(engine.policies_for_scope(&expected_scope), &[id]);
 }
 
+#[test]
+fn tool_scoped_fixture_lands_in_matching_tool_bucket() {
+    let doc = load_fixture("tool_slack_mcp");
+    let expected_scope = PolicyScope::Tool("slack-mcp".to_owned());
+    assert_eq!(doc.scope, expected_scope);
+
+    let mut engine = empty_engine();
+    let id = engine.load_policy(doc);
+    assert_eq!(engine.policies_for_scope(&expected_scope), &[id]);
+}
+
 /// Backward-compat: a YAML fixture from before F92 (no `scope:` field, in
 /// the envelope format used by `policy-examples/`) must validate cleanly
 /// and land under `PolicyScope::Global` when registered with the engine.
@@ -130,11 +141,13 @@ fn distinct_scoped_fixtures_do_not_contaminate_other_buckets() {
     let global = load_fixture("global");
     let org = load_fixture("org_acme");
     let team = load_fixture("team_platform");
+    let tool = load_fixture("tool_slack_mcp");
 
     let mut engine = empty_engine();
     let id_global = engine.load_policy(global);
     let id_org = engine.load_policy(org);
     let id_team = engine.load_policy(team);
+    let id_tool = engine.load_policy(tool);
 
     assert_eq!(engine.policies_for_scope(&PolicyScope::Global), &[id_global]);
     assert_eq!(
@@ -144,5 +157,9 @@ fn distinct_scoped_fixtures_do_not_contaminate_other_buckets() {
     assert_eq!(
         engine.policies_for_scope(&PolicyScope::Team("platform".to_owned())),
         &[id_team],
+    );
+    assert_eq!(
+        engine.policies_for_scope(&PolicyScope::Tool("slack-mcp".to_owned())),
+        &[id_tool],
     );
 }


### PR DESCRIPTION
## Description

Implements **AAASM-1008** — Phase C of the F92 policy scope hierarchy
(parent Story `AAASM-219`, Epic `AAASM-198`).

Adds the 5th and final scope variant — `Tool(String)` — to
`PolicyScope`, completing the wire vocabulary that started in
AAASM-947 and was indexed in AAASM-951. The cascading evaluator
that *consumes* Tool-scoped policies is owned by F93 (`AAASM-220`)
and is deliberately out of scope here.

### What's in the diff

* `aa-gateway/src/policy/scope.rs`:
  * `PolicyScope::Tool(String)` variant
  * `Display` arm renders `tool:<name>`
  * `FromStr` arm parses `tool:<name>` (the existing empty-identifier guard rejects bare `tool:` for free)
  * Module-level docstring + enum rustdoc updated to document the full 5-level chain (`Global → Org → Team → Agent → Tool`)
  * Existing parameterised `display_round_trips_for_each_variant` and `serde_yaml_round_trips_for_each_variant` extended to include Tool
  * New unit tests: `parses_tool_with_name`, `rejects_empty_tool_name`
* `aa-gateway/src/policy/validator.rs`:
  * One row added to `every_malformed_scope_form_is_rejected_with_useful_diagnostic`: `("\"tool:\"", "must not be empty")` so the AC is exercised end-to-end through the YAML pipeline.
* `aa-gateway/tests/fixtures/policies/scoped/tool_slack_mcp.yaml` — new fixture.
* `aa-gateway/tests/scope_index_fixtures_test.rs`:
  * New `tool_scoped_fixture_lands_in_matching_tool_bucket` — proves the existing `ScopeIndex` (AAASM-951) handles the new variant without any change.
  * `distinct_scoped_fixtures_do_not_contaminate_other_buckets` extended to load a Tool fixture alongside Global/Org/Team and assert all four buckets stay isolated.

### Scope split — deferred items

The Sub-task description's AC mixes Phase C (this) with F93 (`AAASM-220`):

| AC item | Status |
| --- | --- |
| `Tool(String)` variant + `Display` renders `tool:<name>` | ✅ |
| YAML/serde round-trip for `tool:<name>` | ✅ |
| Scope **index** returns Tool-scoped policies | ✅ |
| **Cascading evaluator** with Tool consultation order | ⚠ deferred to F93 |
| `PolicyEngine::evaluate` consults Tool-scoped policies after Agent-scoped policies | ⚠ deferred to F93 |
| Backward-compat: pre-Tool YAMLs evaluate identically | ✅ |
| Parser unit tests: `tool:foo` accepted, `tool:` rejected | ✅ |
| Cascading test: Tool-level deny vs parent-level allow | ⚠ deferred to F93 — impossible without the evaluator wiring |

This split was approved by the engineer before work started and is documented in the AAASM-1008 Jira comment. The cascading items wait for F93.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No (purely additive — adds one enum variant; existing variants
      and existing wire format unchanged; pre-Tool policies continue
      to parse, validate, and index identically).

## Related Issues

- Related Jira ticket: AAASM-1008 (Sub-task) → AAASM-219 (Story F92) → AAASM-198 (Epic)

## Testing

- [x] Unit tests added / updated (2 new + 2 parameterised tests now cover Tool)
- [x] Integration tests added / updated (1 new `tool_scoped_fixture_lands_in_matching_tool_bucket` + cross-contamination test extended)
- [ ] Manual testing performed
- [ ] No tests required

### Local validation

| Command | Result |
| --- | --- |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -p aa-gateway --all-targets --all-features -- -D warnings` | clean |
| `cargo nextest run -p aa-gateway` (excluding pre-existing flaky `sustained_load_p99_under_5ms`) | **408 / 408** pass (was 405; +3 for new tool tests) |
| `cargo doc -p aa-gateway --no-deps` | builds (no new warnings) |

### Pre-existing flake noted

Same as the prior two PRs in this Story:
`tests/policy_latency_test.rs::sustained_load_p99_under_5ms` flakes
in **debug** mode on a hot machine. The diff in this PR does not
touch the perf test or the gRPC `PolicyService::CheckAction` hot
path. CI should be unaffected.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --all-features -D warnings`)
- [x] Self-review of the diff completed
- [x] Documentation updated (rustdoc table updated, doc tests still green)
- [ ] All CI checks passing (CI not yet run at PR-open time)
- [x] Commits are small and follow the Gitmoji convention (5 commits, all bisectable, branch rebased onto current `master`)