### PR TITLE
[AAASM-925] ✨ (aa-core): Add AdapterError + DevToolAdapter object-safety test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -12,10 +12,11 @@ async-trait  = { version = "0.1", optional = true }
 cfg-if = "1"
 serde  = { version = "1", default-features = false, features = ["derive", "alloc"], optional = true }
 sha2   = { version = "0.11", default-features = false, optional = true }
+thiserror = { version = "2", optional = true }
 
 [features]
 default    = ["std"]
-std        = ["alloc", "dep:aho-corasick", "dep:async-trait", "serde?/std"]
+std        = ["alloc", "dep:aho-corasick", "dep:async-trait", "dep:thiserror", "serde?/std"]
 alloc      = ["dep:sha2"]
 serde      = ["dep:serde"]
 test-utils = []

--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -95,20 +95,73 @@ pub struct McpServerInfo {
     pub args: Vec<String>,
 }
 
-/// Error type for [`DevToolAdapter`] method failures.
+/// Error type returned from [`DevToolAdapter`] method failures.
 ///
-/// This is an intentional minimal stub introduced together with the
-/// `DevToolAdapter` trait so the trait signatures resolve. AAASM-925 will
-/// populate the concrete error variants (`ToolNotFound`,
-/// `DetectionFailed`, `SettingsGenerationFailed`, etc.) and add a
-/// `thiserror::Error` derive. Marked `#[non_exhaustive]` so that addition
-/// is not a breaking change for downstream callers.
+/// Variants are kept narrow so the gateway and the `aa run` launcher can
+/// match on them and respond differently (e.g. `ToolNotFound` is
+/// surfaced as a friendly CLI error, while `Io` is logged and
+/// retried). The `#[from]` attribute on `Io` lets adapter implementations
+/// use the `?` operator with `std::io::Error` without manual
+/// `.map_err(...)` plumbing.
 ///
-/// [`DevToolAdapter`]: <not yet defined; introduced in this same Subtask>
-#[cfg(feature = "alloc")]
-#[derive(Debug)]
+/// Gated on `feature = "std"` because [`AdapterError::SettingsApplyFailed`]
+/// and [`AdapterError::Io`] wrap [`std::io::Error`].
+///
+/// `#[non_exhaustive]` is kept so future variants can be added without
+/// breaking downstream callers that match on this enum.
+#[cfg(feature = "std")]
+#[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
-pub enum AdapterError {}
+pub enum AdapterError {
+    /// The tool's binary or installation marker could not be located on
+    /// the host.
+    #[error("dev tool not found on this host")]
+    ToolNotFound,
+
+    /// Detection failed for a reason other than the tool simply not being
+    /// installed (e.g. permission denied reading the install directory,
+    /// version probe failed).
+    #[error("dev tool detection failed: {0}")]
+    DetectionFailed(String),
+
+    /// The policy contained constructs the tool's native managed-settings
+    /// format cannot express. Returned by
+    /// [`DevToolAdapter::generate_managed_settings`].
+    #[error("managed-settings generation failed: {0}")]
+    SettingsGenerationFailed(String),
+
+    /// Writing rendered managed settings to the tool's configuration
+    /// surface failed. Returned by [`DevToolAdapter::apply_settings`].
+    #[error("managed-settings apply failed: {0}")]
+    SettingsApplyFailed(std::io::Error),
+
+    /// The tool's binary could not be located, or its argument format
+    /// cannot accommodate the launcher's governance wiring. Returned by
+    /// [`DevToolAdapter::build_launch_command`].
+    #[error("launch command construction failed: {0}")]
+    LaunchFailed(String),
+
+    /// The tool's MCP configuration surface could not be read or written
+    /// (malformed file, permission denied, schema mismatch). Returned
+    /// by [`DevToolAdapter::list_mcp_servers`] and
+    /// [`DevToolAdapter::apply_mcp_governance`].
+    #[error("MCP configuration failed: {0}")]
+    McpConfigFailed(String),
+
+    /// Generic I/O failure not covered by a more specific variant. The
+    /// `#[from]` attribute lets adapter implementations use `?` to
+    /// propagate `std::io::Error` directly.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Serialization or deserialization failure during managed-settings
+    /// or MCP-config rendering. Adapter implementations stringify their
+    /// underlying serde error (e.g. `serde_json::Error::to_string()`)
+    /// and pass the message in. Keeps `aa-core` free of a runtime
+    /// `serde_json` dependency.
+    #[error("serialization error: {0}")]
+    Serde(String),
+}
 
 /// Static metadata describing a detected AI dev tool installation.
 ///

--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -360,4 +360,38 @@ mod tests {
         let json2 = serde_json::to_string(&restored).expect("re-serialize");
         assert_eq!(json1, json2);
     }
+
+    // ---- Trait conformance (locks DevToolAdapter's shape) -----------------
+    //
+    // These helpers are compile-time checks. The fact that they reference
+    // `&dyn DevToolAdapter` and `Box<dyn DevToolAdapter>` (which require
+    // `Send + Sync` because the trait inherits those bounds) is what
+    // exercises the assertions — if any future change makes the trait
+    // un-object-safe or drops `Send + Sync`, this module fails to compile.
+
+    #[cfg(feature = "std")]
+    fn _assert_object_safe(_: &dyn DevToolAdapter) {}
+
+    #[cfg(feature = "std")]
+    fn _assert_send_sync<T: Send + Sync>() {}
+
+    /// Compile-time conformance check for `DevToolAdapter`.
+    ///
+    /// Locks two invariants every implementor must satisfy:
+    /// 1. The trait is **object-safe** — `&dyn DevToolAdapter` and
+    ///    `Box<dyn DevToolAdapter>` both compile.
+    /// 2. Trait objects are `Send + Sync` — required so adapters can be
+    ///    stored in a global registry and called from the gateway's
+    ///    Tokio task pool.
+    ///
+    /// If either invariant breaks (someone adds a non-dyn-compatible
+    /// method, removes the `Send + Sync` bound on the trait, etc.) this
+    /// test will fail to compile — which is exactly what AAASM-925
+    /// requires it to do.
+    #[cfg(feature = "std")]
+    #[test]
+    fn trait_is_object_safe() {
+        let _: fn(&dyn DevToolAdapter) = _assert_object_safe;
+        _assert_send_sync::<Box<dyn DevToolAdapter>>();
+    }
 }

--- a/aa-core/src/dev_tool.rs
+++ b/aa-core/src/dev_tool.rs
@@ -226,9 +226,9 @@ pub trait DevToolAdapter: Send + Sync {
     /// ### Contract
     /// * On success, returns the rendered settings document as a UTF-8
     ///   string ready to be written by [`apply_settings`].
-    /// * Returns `AdapterError::SettingsGenerationFailed` (added in
-    ///   AAASM-925) when the policy contains constructs the tool's
-    ///   native config cannot express.
+    /// * Returns [`AdapterError::SettingsGenerationFailed`] when the
+    ///   policy contains constructs the tool's native config cannot
+    ///   express.
     /// * Pure: must not touch the filesystem.
     ///
     /// [`PolicyDocument`]: crate::policy::PolicyDocument
@@ -242,8 +242,7 @@ pub trait DevToolAdapter: Send + Sync {
     /// * On success, the tool will pick up the new policy on its next
     ///   launch (some tools require a restart; the adapter is expected
     ///   to document that in its own crate-level docs).
-    /// * Returns `AdapterError::SettingsApplyFailed` (added in
-    ///   AAASM-925) on filesystem error.
+    /// * Returns [`AdapterError::SettingsApplyFailed`] on filesystem error.
     /// * Idempotent: applying the same `settings` twice is a no-op.
     async fn apply_settings(&self, settings: &str) -> Result<(), AdapterError>;
 
@@ -258,9 +257,9 @@ pub trait DevToolAdapter: Send + Sync {
     ///   proxy; the adapter must inject the appropriate
     ///   `HTTPS_PROXY` / `OPENAI_BASE_URL` / similar env var so the
     ///   tool routes traffic through it.
-    /// * Returns `AdapterError::LaunchFailed` (added in AAASM-925)
-    ///   when the tool's binary cannot be located or its argument
-    ///   format cannot accommodate the wiring.
+    /// * Returns [`AdapterError::LaunchFailed`] when the tool's binary
+    ///   cannot be located or its argument format cannot accommodate
+    ///   the wiring.
     /// * Sync (no I/O performed) — the returned `Command` is *built*,
     ///   not spawned. Spawning is the launcher's job.
     fn build_launch_command(
@@ -279,8 +278,8 @@ pub trait DevToolAdapter: Send + Sync {
     ///   surface (e.g. `~/.claude/mcp_servers.json`).
     /// * Returns an empty `Vec` (not an error) when the tool supports
     ///   MCP but has no servers configured.
-    /// * Returns `AdapterError::McpConfigFailed` (added in
-    ///   AAASM-925) when the config exists but is malformed.
+    /// * Returns [`AdapterError::McpConfigFailed`] when the config
+    ///   exists but is malformed.
     /// * Tools whose `DevToolInfo::supports_mcp == false` should
     ///   instead return an empty `Vec`.
     async fn list_mcp_servers(&self) -> Result<Vec<McpServerInfo>, AdapterError>;
@@ -295,8 +294,8 @@ pub trait DevToolAdapter: Send + Sync {
     /// * `denied` is an explicit blocklist applied even if a server
     ///   appears in `allowed` — `denied` wins on conflict (matches
     ///   policy-engine evaluation order).
-    /// * Returns `AdapterError::McpConfigFailed` (added in
-    ///   AAASM-925) on filesystem write failure.
+    /// * Returns [`AdapterError::McpConfigFailed`] on filesystem write
+    ///   failure.
     /// * Tools without MCP support should return `Ok(())` without
     ///   performing any work.
     async fn apply_mcp_governance(&self, allowed: &[String], denied: &[String]) -> Result<(), AdapterError>;

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -42,9 +42,9 @@ pub use agent::AgentContext;
 #[cfg(feature = "alloc")]
 pub use dev_tool::DevToolKind;
 #[cfg(feature = "alloc")]
-pub use dev_tool::{AdapterError, McpServerInfo};
+pub use dev_tool::McpServerInfo;
 #[cfg(feature = "std")]
-pub use dev_tool::{DevToolAdapter, DevToolInfo};
+pub use dev_tool::{AdapterError, DevToolAdapter, DevToolInfo};
 
 #[cfg(feature = "alloc")]
 pub use policy::{ArgsJson, GovernanceAction, PolicyDocument, PolicyEvaluator, PolicyResult, PolicyRule};


### PR DESCRIPTION
## Description

Replaces the empty `AdapterError` `#[non_exhaustive]` stub left by AAASM-923 with the eight concrete variants every adapter implementation needs, and adds the compile-time `trait_is_object_safe` test that locks in `dyn DevToolAdapter` conformance.

### `AdapterError` variants (per AC)

| Variant | Wraps | Purpose |
|---|---|---|
| `ToolNotFound` | — | Tool binary missing from host. |
| `DetectionFailed(String)` | message | Detection probe failed for a non-absence reason (permission, version probe). |
| `SettingsGenerationFailed(String)` | message | Policy contains constructs the tool's native config can't express. |
| `SettingsApplyFailed(io::Error)` | io::Error | Writing rendered settings failed. |
| `LaunchFailed(String)` | message | `build_launch_command` could not produce a runnable `Command`. |
| `McpConfigFailed(String)` | message | MCP config read or write failed. |
| `Io(#[from] std::io::Error)` | io::Error | Generic I/O `?`-friendly catch-all. |
| `Serde(String)` | message | Serialization error message. **AC's "or equivalent" form** — uses `String` instead of `serde_json::Error` to avoid pulling `serde_json` as a runtime dep of `aa-core`; adapter implementations stringify their own `serde_json::Error` before constructing this variant. |

* Derives `Debug, thiserror::Error`; each variant has an `#[error(...)]` Display message.
* Gated on `feature = "std"` (was `alloc`-gated stub) because `SettingsApplyFailed` and `Io` wrap `std::io::Error`. Stub had zero constructible variants and was `#[non_exhaustive]`, so the gate-narrowing is non-breaking. Re-export gate in `aa-core/src/lib.rs` updated to match.
* Stays `#[non_exhaustive]` for forward-compat.

### `trait_is_object_safe` — compile-time conformance test

Locks two invariants every `DevToolAdapter` implementor must satisfy:

1. **Object-safety** — `&dyn DevToolAdapter` and `Box<dyn DevToolAdapter>` both compile. The `_assert_object_safe(_: &dyn DevToolAdapter)` helper fails to compile if the trait becomes un-object-safe (e.g. someone removes `async-trait`, adds a generic method without `where Self: Sized`).
2. **`Send + Sync`** — `_assert_send_sync::<Box<dyn DevToolAdapter>>()` forces the trait object through the `Send + Sync` bound, required for the gateway's Tokio task pool.

Both helpers gated under `feature = "std"` since `DevToolAdapter` itself is std-gated.

### Polish

The `DevToolAdapter` trait method docs referenced `AdapterError` variants as plain code text in AAASM-923 (because the variants didn't exist yet). Five references promoted to proper rustdoc intra-doc links (`[`AdapterError::SettingsGenerationFailed`]`, etc.) now that they resolve. `cargo doc -p aa-core --no-deps --all-features` is **0 warnings**.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

The `AdapterError` gate moved from `feature = "alloc"` to `feature = "std"`, but the previous stub had zero constructible variants and was `#[non_exhaustive]` — no real callers can be affected. `DevToolAdapter` (the only consumer of `AdapterError`) is also `feature = "std"`-gated, so the gate change is consistent.

## Related Issues

- Related Jira ticket: [AAASM-925](https://lightning-dust-mite.atlassian.net/browse/AAASM-925) (parent Story [AAASM-199](https://lightning-dust-mite.atlassian.net/browse/AAASM-199); Epic [AAASM-196](https://lightning-dust-mite.atlassian.net/browse/AAASM-196)).
- Related GitHub issues: n/a.

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

One new test: `aa-core::dev_tool::tests::trait_is_object_safe`. Local validation matrix:

| Check | Command | Result |
|---|---|---|
| Build (default) | `cargo check -p aa-core` | OK |
| Build (no_std, zero features) | `cargo check -p aa-core --no-default-features` | OK |
| Build (no_std + alloc) | `cargo check -p aa-core --no-default-features --features alloc` | OK |
| Build (no_std + alloc + serde) | `cargo check -p aa-core --no-default-features --features alloc,serde` | OK |
| Build (all features) | `cargo check -p aa-core --all-features` | OK |
| Tests (dev_tool with serde) | `cargo test -p aa-core --features serde dev_tool::` | 4 / 4 passed (incl. `trait_is_object_safe`) |
| Full aa-core test suite | `cargo test -p aa-core --features serde` | 117 / 117 passed |
| Format | `cargo fmt --all -- --check` | clean |
| Clippy | `cargo clippy -p aa-core --all-targets --all-features -- -D warnings` | clean |
| Doc | `cargo doc -p aa-core --no-deps --all-features` | clean (**0 warnings**, including the 5 promoted intra-doc links) |
| Workspace check (excl. eBPF) | `cargo check --workspace --exclude aa-ebpf*` | OK |

## Commit history (5 small commits, granular per the convention used by AAASM-919 / AAASM-923)

1. `🔧 (aa-core): Add thiserror dep for AdapterError enum`
2. `✨ (aa-core): Populate AdapterError with full variant set + thiserror derive`
3. `📝 (aa-core): Promote AdapterError variant references to intra-doc links`
4. `✅ (aa-core): Add trait_is_object_safe compile-time conformance test`
5. `🔧 (workspace): Lock thiserror into aa-core deps`

Each commit leaves the crate buildable (bisectable).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing (verified locally; CI will confirm)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-925]: https://lightning-dust-mite.atlassian.net/browse/AAASM-925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ