### PR TITLE
[AAASM-936] ✨ devtool(sample): Add aa-devtool-sample-myeditor + plugins.md authoring guide

### DIFF
--- a/.ci/check-compatibility-matrix.sh
+++ b/.ci/check-compatibility-matrix.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # check-compatibility-matrix.sh
 #
-# Enforces that docs/compatibility.md is updated whenever a version-carrying
+# Enforces that docs/src/compatibility.md is updated whenever a version-carrying
 # file is modified in a pull request.
 #
 # Usage: run from the repository root on a PR branch.
@@ -25,7 +25,7 @@ CHANGED=$(git diff --name-only "${MERGE_BASE}"...HEAD)
 #   sdk/node/package.json
 #   sdk/go/go.mod
 VERSION_FILES=$(echo "${CHANGED}" | grep -E "^(Cargo\.toml|crates/[^/]+/Cargo\.toml)$" || true)
-COMPAT_CHANGED=$(echo "${CHANGED}" | grep -E "^docs/compatibility\.md$" || true)
+COMPAT_CHANGED=$(echo "${CHANGED}" | grep -E "^docs/src/compatibility\.md$" || true)
 
 if [ -n "${VERSION_FILES}" ] && [ -z "${COMPAT_CHANGED}" ]; then
   echo "──────────────────────────────────────────────────────"
@@ -36,10 +36,10 @@ if [ -n "${VERSION_FILES}" ] && [ -z "${COMPAT_CHANGED}" ]; then
   echo ""
   echo "${VERSION_FILES}" | sed 's/^/  /'
   echo ""
-  echo "But docs/compatibility.md was NOT updated."
+  echo "But docs/src/compatibility.md was NOT updated."
   echo ""
-  echo "Please update docs/compatibility.md to reflect the version change."
-  echo "See docs/versioning.md for instructions."
+  echo "Please update docs/src/compatibility.md to reflect the version change."
+  echo "See docs/src/versioning.md for instructions."
   echo "──────────────────────────────────────────────────────"
   exit 1
 fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "aa-devtool-sample-myeditor"
+version = "0.0.1"
+dependencies = [
+ "aa-core",
+ "async-trait",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "aa-ebpf"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "aa-api",
     "aa-cli",
     "conformance",
+    "examples/aa-devtool-sample-myeditor",
 ]
 resolver = "2"
 

--- a/docs/devtools/plugins.md
+++ b/docs/devtools/plugins.md
@@ -1,0 +1,214 @@
+# Authoring a custom `DevToolAdapter` plugin
+
+This guide explains how to write a custom AI-dev-tool adapter that plugs
+into Agent Assembly's governance framework. The reference
+implementation is the in-repo sample at
+[`examples/aa-devtool-sample-myeditor/`][sample-crate] — copy and
+adapt.
+
+[sample-crate]: https://github.com/AI-agent-assembly/agent-assembly/tree/master/examples/aa-devtool-sample-myeditor
+
+---
+
+## Trait surface — what you implement
+
+The contract lives in [`aa_core::DevToolAdapter`][trait]:
+
+| Method | Async | Purpose |
+|---|---|---|
+| `fn detect(&self) -> Option<DevToolInfo>` | sync | Probe the host: is the tool installed and readable? |
+| `async fn generate_managed_settings(&self, policy: &PolicyDocument) -> Result<String, AdapterError>` | async | Translate the Agent Assembly policy into the tool's native config format. |
+| `async fn apply_settings(&self, settings: &str) -> Result<(), AdapterError>` | async | Write the rendered settings into the tool's configuration surface. |
+| `fn build_launch_command(&self, tool_args, agent_id, team_id, proxy_addr) -> Result<Command, AdapterError>` | sync | Build a `std::process::Command` with governance wiring (identity, proxy). |
+| `async fn list_mcp_servers(&self) -> Result<Vec<McpServerInfo>, AdapterError>` | async | Read the tool's currently-configured MCP servers. |
+| `async fn apply_mcp_governance(&self, allowed, denied) -> Result<(), AdapterError>` | async | Apply an allow/deny list to the tool's MCP config. |
+| `fn governance_level(&self) -> GovernanceLevel` | sync | Static cap (`L0Discover`–`L3Native`) for what this adapter can achieve. |
+
+[trait]: https://docs.rs/aa-core/latest/aa_core/trait.DevToolAdapter.html
+
+The trait is **object-safe** — it can be used as `&dyn DevToolAdapter`
+or `Box<dyn DevToolAdapter>`. This is enforced by a compile-time test
+in `aa-core/src/dev_tool.rs::tests::trait_is_object_safe` (added by
+AAASM-925). Object-safety is required because the gateway and the
+forthcoming `aa run` launcher dispatch through trait objects, not
+generics.
+
+The async methods are implemented via the [`async_trait`][async-trait]
+macro, which desugars `async fn` into `Pin<Box<dyn Future + Send + '_>>`
+return types. Your adapter crate must `use async_trait::async_trait`
+and annotate the impl block with `#[async_trait]` exactly as the sample
+does.
+
+[async-trait]: https://docs.rs/async-trait
+
+---
+
+## Crate layout — copy from the sample
+
+```
+your-adapter/
+├── Cargo.toml
+├── src/
+│   └── lib.rs           # impl DevToolAdapter for YourAdapter
+├── tests/
+│   └── contract.rs      # one test per trait method (mirror the sample)
+└── fixtures/            # hand-rolled inputs for tests; no real binary needed
+    └── mcp_servers.json
+```
+
+Required `Cargo.toml` dependencies (see the sample's `Cargo.toml` for the exact lines):
+
+| Dep | Purpose |
+|---|---|
+| `aa-core` (path or version) with `features = ["std", "serde"]` | trait + types + error |
+| `async-trait = "0.1"` | for the `#[async_trait]` impl |
+| `serde` + `serde_json` | rendering managed settings, parsing tool config |
+
+For dev-dependencies the sample uses `tempfile` (filesystem tests) and
+`tokio` (async test driver). Pick what your tests need.
+
+---
+
+## How adapters get loaded — current pattern
+
+Right now Agent Assembly uses **build-time linking**: an adapter is
+loaded by linking its crate into a binary that constructs the adapter
+explicitly and either calls it directly or registers it in an
+in-memory map keyed by the tool's discriminator (e.g. by
+`DevToolKind::Custom("myeditor".into())`).
+
+There is **no** `inventory::submit!`-style runtime registration in
+`aa-core` today, and there is no dynamic shared-library loading. Both
+were proposed in early designs but neither has been implemented; do
+not write code that assumes either exists. When the `aa run` launcher
+(AAASM-200) lands, it will publish the contract for how it expects to
+discover adapters; until then, the integration shape is "construct an
+instance and pass it in."
+
+If you are publishing an out-of-tree adapter today, the pattern is:
+
+1. Publish your adapter as a normal crate (`cargo publish` or path /
+   git dependency in the consuming binary).
+2. Have the consuming binary depend on your crate and call
+   `YourAdapter::new(...)` to construct it.
+3. Pass the `Box<dyn DevToolAdapter>` to whatever code consumes
+   adapters.
+
+This is the same pattern the sample's contract tests use.
+
+---
+
+## Versioning expectations
+
+Adapters are tightly coupled to the `aa-core` major version they were
+built against. Pin `aa-core` exactly in your `Cargo.toml`:
+
+```toml
+[dependencies]
+aa-core = { version = "=0.0.1", features = ["std", "serde"] }
+```
+
+When `aa-core` makes a breaking change to `DevToolAdapter`, every
+adapter crate has to be rebuilt against the new major. `AdapterError`
+is `#[non_exhaustive]` — adding new error variants is **not** a
+breaking change, so do not match exhaustively on it.
+
+---
+
+## Contract tests — required for every adapter
+
+The sample's [`tests/contract.rs`][sample-tests] is the **reference
+test suite** every adapter should mirror. Adapt each test to your
+tool's specifics:
+
+[sample-tests]: https://github.com/AI-agent-assembly/agent-assembly/blob/master/examples/aa-devtool-sample-myeditor/tests/contract.rs
+
+| Sample test | What it verifies | What you change |
+|---|---|---|
+| `myeditor_adapter_is_object_safe_and_send_sync` | `&dyn YourAdapter` and `Box<dyn YourAdapter>: Send + Sync` compile. | Replace the type. The test body is mechanical. |
+| `detect_returns_none_when_env_var_unset` / `..._when_env_var_set` | `detect` returns `None` when the tool is absent and a populated `DevToolInfo` when it's present. | Replace the env-var probe with whatever your detection mechanism is (`which`, install-marker file, etc.). |
+| `generate_managed_settings_returns_valid_json` | Output is parseable as the tool's native format. | Replace the parse target with your tool's actual schema. |
+| `apply_settings_writes_managed_json_next_to_fixture` | Side effect is observable on disk. | Use `tempfile::tempdir()` so tests don't leak. |
+| `build_launch_command_injects_identity_and_proxy` / `..._errors_when_binary_unset` | `AA_AGENT_ID` / `AA_TEAM_ID` / `HTTPS_PROXY` end up in `cmd.get_envs()`; missing binary returns `LaunchFailed`. | Adjust the env-var names if your tool uses different conventions. |
+| `list_mcp_servers_*` (×3) | Parses the fixture; returns `Io` on missing file; returns `McpConfigFailed` on malformed JSON. | Use a fixture matching your tool's actual MCP config layout. |
+| `apply_mcp_governance_is_a_noop_in_sample` | The method completes successfully. | Replace with assertions about the actual side effect your adapter performs. |
+| `governance_level_is_l1_observe` | Static cap value. | Pick the right level for your tool category (see below). |
+
+If your tests touch process-wide state (env vars, current working
+directory, etc.), use a `Mutex<()>` to serialize them, exactly as the
+sample's `EnvVarGuard` does. `cargo test` runs tests in parallel
+threads of the same process; unscoped mutation races otherwise.
+
+---
+
+## Picking the right `GovernanceLevel`
+
+Each adapter publishes the **highest** governance level it can
+practically achieve. Use this rough mapping (from the spec, Epic 14
+section 4486–4558):
+
+| Tool category | Typical level | Why |
+|---|---|---|
+| CLI / local agent (e.g. Claude Code, Codex CLI) | **L3Native** when SDK-integrated; **L2Enforce** otherwise | Full process control + filesystem access |
+| IDE agent (Copilot, Windsurf, MyEditor) | **L1Observe** | IDE host limits hooks; usually no enforcement surface |
+| SaaS / cloud agent | **L0Discover** to **L1Observe** | Mostly black-box; eBPF/proxy may surface external traffic |
+| Custom / unknown | **L0Discover** | Default until measured |
+
+`detect()`'s `DevToolInfo::governance_level` and the trait's
+`governance_level()` method **must agree** — the gateway uses one to
+sanity-check the other.
+
+---
+
+## Error handling — use `AdapterError`
+
+Return [`aa_core::AdapterError`][adapter-error] from every fallible
+method. The variants and when to use them:
+
+[adapter-error]: https://docs.rs/aa-core/latest/aa_core/enum.AdapterError.html
+
+| Variant | When |
+|---|---|
+| `ToolNotFound` | Tool is genuinely not installed (don't conflate with errors). |
+| `DetectionFailed(String)` | Permission denied, version probe failed, but the tool may exist. |
+| `SettingsGenerationFailed(String)` | Policy contains constructs the tool's native config can't express. |
+| `SettingsApplyFailed(io::Error)` | File write failed. |
+| `LaunchFailed(String)` | Can't construct a runnable `Command`. |
+| `McpConfigFailed(String)` | MCP config malformed or schema mismatch. |
+| `Io(#[from] std::io::Error)` | Catch-all for unexpected I/O errors — use `?`. |
+| `Serde(String)` | Stringify your `serde_json::Error` (`.to_string()`) before constructing this; `aa-core` deliberately does not depend on `serde_json` at runtime. |
+
+The enum is `#[non_exhaustive]`, so future variants will not break
+your matches **as long as you include a `_ =>` arm**.
+
+---
+
+## What's not yet in scope (out-of-scope today)
+
+The following extension points are reasonable and may be added later,
+but are **not** in `aa-core` or `aa-cli` as of this writing. If you
+need any of these, file a ticket; do not invent a workaround.
+
+| Future extension point | Status | Tracking |
+|---|---|---|
+| Automated registration mechanism (`inventory::submit!`, dynamic shared-library loading, etc.) | Not implemented. Adapters are constructed explicitly today. | (no ticket yet — open one if needed) |
+| Shared `aa-devtool-contract-tests` crate that every adapter imports | Not implemented. The sample's `tests/contract.rs` is the reference; copy and adapt for now. | (no ticket yet — open one if needed) |
+| Per-tool adapter examples for Claude Code / Codex / Copilot / Windsurf / SaaS | In flight. | AAASM-201..205, AAASM-918 |
+| `aa run` launcher CLI (the binary that consumes `Box<dyn DevToolAdapter>` registrations) | In flight. | AAASM-200 |
+| L0–L3 governance capability matrix doc with per-tool boundaries | In flight. | AAASM-1064 |
+
+---
+
+## Submitting your adapter
+
+1. Implement `DevToolAdapter` in your crate; mirror `tests/contract.rs`.
+2. Run `cargo test -p your-adapter` locally.
+3. If you want your adapter merged into the workspace alongside the
+   sample, open a PR adding it to `[workspace.members]` in the root
+   `Cargo.toml`.
+4. If you want it as a third-party crate, publish it to `crates.io`
+   with `aa-core` pinned to the exact version you tested against.
+
+The sample at
+[`examples/aa-devtool-sample-myeditor/`][sample-crate] is intentionally
+small and complete — when in doubt, follow it.

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -78,3 +78,4 @@ See [versioning.md](versioning.md) for the full versioning and deprecation polic
 | AAASM-37  | Added `aa-ebpf-common` workspace crate (no_std shared eBPF event types, not shipped as a public API) | None — internal kernel/userspace bridge only |
 | AAASM-39 (impl) | Added exec tracepoint BPF programs, ProcessLineageTracker, ShellDetector, ExecLoader in `aa-ebpf` | None — kernel-level monitoring, not a public API |
 | AAASM-64 | Added `aa-ffi-go` workspace crate (Go C-ABI staticlib bindings) | None — new FFI crate, no existing API changes |
+| AAASM-936 | Added `examples/aa-devtool-sample-myeditor` workspace crate (sample `DevToolAdapter` impl + plugin authoring reference; `publish = false`) | None — example only, not shipped, depends on existing `aa-core` API surface |

--- a/examples/aa-devtool-sample-myeditor/Cargo.toml
+++ b/examples/aa-devtool-sample-myeditor/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "aa-devtool-sample-myeditor"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Sample DevToolAdapter implementation for a fictional MyEditor — extension-point reference for AAASM-936"
+publish = false
+
+[dependencies]
+aa-core      = { path = "../../aa-core", features = ["std", "serde"] }
+async-trait  = "0.1"
+serde        = { version = "1", features = ["derive"] }
+serde_json   = "1"
+
+[dev-dependencies]
+tempfile = "3"
+tokio    = { version = "1", features = ["macros", "rt"] }
+
+[lints]
+workspace = true

--- a/examples/aa-devtool-sample-myeditor/fixtures/mcp_servers.json
+++ b/examples/aa-devtool-sample-myeditor/fixtures/mcp_servers.json
@@ -1,0 +1,17 @@
+{
+  "_comment": "Hand-rolled MCP server fixture for the MyEditor sample adapter. Mirrors the shape MyEditor uses to record connected MCP servers (mcpServers map keyed by server name). Real per-tool adapters will read the tool's actual config file; this fixture exists so the sample's tests have a deterministic input without needing a real binary.",
+  "mcpServers": {
+    "filesystem": {
+      "command": "myeditor-mcp-fs",
+      "args": ["--root", "/workspace"]
+    },
+    "github": {
+      "command": "myeditor-mcp-github",
+      "args": ["--token-env", "GITHUB_TOKEN"]
+    },
+    "internal-search": {
+      "command": "myeditor-mcp-search",
+      "args": []
+    }
+  }
+}

--- a/examples/aa-devtool-sample-myeditor/src/lib.rs
+++ b/examples/aa-devtool-sample-myeditor/src/lib.rs
@@ -1,0 +1,14 @@
+//! Sample [`DevToolAdapter`] implementation for a fictional `MyEditor` IDE.
+//!
+//! This crate exists as a **reference for plugin authors** (see
+//! [`docs/devtools/plugins.md`]). It is intentionally hand-rolled — no
+//! real `myeditor` binary exists. Detection succeeds when an env var
+//! pointing at a stub binary is set; MCP-server discovery reads a
+//! fixture JSON shipped under `fixtures/events.json`. Concrete per-tool
+//! adapters (Claude Code, Codex, Copilot, Windsurf, SaaS) are tracked
+//! separately in AAASM-201..205 and AAASM-918.
+//!
+//! [`DevToolAdapter`]: aa_core::DevToolAdapter
+//! [`docs/devtools/plugins.md`]: https://github.com/AI-agent-assembly/agent-assembly/blob/master/docs/devtools/plugins.md
+
+#![warn(missing_docs)]

--- a/examples/aa-devtool-sample-myeditor/src/lib.rs
+++ b/examples/aa-devtool-sample-myeditor/src/lib.rs
@@ -4,11 +4,187 @@
 //! [`docs/devtools/plugins.md`]). It is intentionally hand-rolled — no
 //! real `myeditor` binary exists. Detection succeeds when an env var
 //! pointing at a stub binary is set; MCP-server discovery reads a
-//! fixture JSON shipped under `fixtures/events.json`. Concrete per-tool
-//! adapters (Claude Code, Codex, Copilot, Windsurf, SaaS) are tracked
-//! separately in AAASM-201..205 and AAASM-918.
+//! fixture JSON shipped under `fixtures/mcp_servers.json`. Concrete
+//! per-tool adapters (Claude Code, Codex, Copilot, Windsurf, SaaS) are
+//! tracked separately in AAASM-201..205 and AAASM-918.
 //!
 //! [`DevToolAdapter`]: aa_core::DevToolAdapter
 //! [`docs/devtools/plugins.md`]: https://github.com/AI-agent-assembly/agent-assembly/blob/master/docs/devtools/plugins.md
 
 #![warn(missing_docs)]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use aa_core::{AdapterError, DevToolAdapter, DevToolInfo, DevToolKind, GovernanceLevel, McpServerInfo, PolicyDocument};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+/// Environment variable consulted by [`MyEditorAdapter::detect`] to locate
+/// the (fictional) `myeditor` binary on the host.
+pub const MYEDITOR_BIN_ENV: &str = "MYEDITOR_BIN";
+
+/// Stable identifier this sample adapter registers itself under in the
+/// [`DevToolKind::Custom`] discriminator. Plugin authors publishing a
+/// real adapter should pick a stable, namespaced string of their own
+/// (e.g. `acme.myeditor`).
+pub const MYEDITOR_KIND_ID: &str = "myeditor";
+
+/// Reference [`DevToolAdapter`] implementation for the fictional
+/// `MyEditor` IDE.
+///
+/// Constructor takes an explicit fixture path so tests can point at the
+/// in-repo `fixtures/mcp_servers.json` and adapter authors can see how a
+/// real adapter would consult its own tool's native config file.
+#[derive(Debug, Clone)]
+pub struct MyEditorAdapter {
+    /// Filesystem path to the MCP-servers fixture (or, in a real
+    /// adapter, the tool's native config file).
+    mcp_config_path: PathBuf,
+}
+
+impl MyEditorAdapter {
+    /// Construct an adapter that reads its MCP server list from
+    /// `mcp_config_path`.
+    pub fn new(mcp_config_path: impl Into<PathBuf>) -> Self {
+        Self {
+            mcp_config_path: mcp_config_path.into(),
+        }
+    }
+
+    /// Path the adapter will read for MCP-server discovery. Exposed for
+    /// tests so they can assert the adapter's wiring without
+    /// roundtripping through the filesystem.
+    pub fn mcp_config_path(&self) -> &Path {
+        &self.mcp_config_path
+    }
+}
+
+/// Native MCP-config shape for `MyEditor`. Mirrors the JSON layout
+/// shipped in `fixtures/mcp_servers.json`.
+#[derive(Debug, Deserialize)]
+struct MyEditorMcpConfig {
+    #[serde(rename = "mcpServers")]
+    mcp_servers: std::collections::BTreeMap<String, MyEditorMcpEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MyEditorMcpEntry {
+    command: String,
+    #[serde(default)]
+    args: Vec<String>,
+}
+
+/// Managed-settings document the sample adapter would write into a real
+/// MyEditor config. Defined as a typed struct so
+/// [`MyEditorAdapter::generate_managed_settings`] can serialize a
+/// reproducible JSON document without ad-hoc string formatting.
+#[derive(Debug, Serialize)]
+struct ManagedSettings<'a> {
+    /// Stamp identifying which Agent Assembly policy generated this
+    /// settings document. Real adapters may include the policy hash;
+    /// this sample uses the policy's tenant scope.
+    generated_by: &'static str,
+    /// Permitted MCP server names (placeholder list — production
+    /// adapters consult `policy.mcp_allowlist()`).
+    mcp_allow: &'a [&'a str],
+}
+
+#[async_trait]
+impl DevToolAdapter for MyEditorAdapter {
+    fn detect(&self) -> Option<DevToolInfo> {
+        // Real adapter would `which myeditor` or read a known install
+        // marker. Sample uses an env-var probe so the test suite can
+        // toggle detection without filesystem mocking.
+        let install_path = std::env::var_os(MYEDITOR_BIN_ENV).map(PathBuf::from)?;
+        Some(DevToolInfo {
+            kind: DevToolKind::Custom(MYEDITOR_KIND_ID.to_string()),
+            version: Some("0.0.0-sample".to_string()),
+            install_path,
+            governance_level: GovernanceLevel::L1Observe,
+            supports_mcp: true,
+            supports_managed_settings: true,
+        })
+    }
+
+    async fn generate_managed_settings(&self, _policy: &PolicyDocument) -> Result<String, AdapterError> {
+        // Production adapters translate `policy` into the tool's native
+        // config schema. The sample emits a tiny placeholder document
+        // so plugin authors see the shape and the serialization
+        // boundary without drowning in domain detail.
+        let settings = ManagedSettings {
+            generated_by: "aa-devtool-sample-myeditor",
+            mcp_allow: &["filesystem", "github", "internal-search"],
+        };
+        serde_json::to_string_pretty(&settings).map_err(|e| AdapterError::Serde(e.to_string()))
+    }
+
+    async fn apply_settings(&self, settings: &str) -> Result<(), AdapterError> {
+        // Real adapter would write to MyEditor's managed-settings file
+        // (e.g. `~/.config/myeditor/managed.json`). The sample writes
+        // beside the MCP fixture so tests can assert the write
+        // happened without leaking outside `tempfile`-managed scope.
+        let target = self
+            .mcp_config_path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join("managed.json");
+        std::fs::write(&target, settings).map_err(AdapterError::SettingsApplyFailed)?;
+        Ok(())
+    }
+
+    fn build_launch_command(
+        &self,
+        tool_args: &[String],
+        agent_id: &str,
+        team_id: Option<&str>,
+        proxy_addr: Option<&str>,
+    ) -> Result<Command, AdapterError> {
+        // The launcher invokes this to start MyEditor with governance
+        // wiring. Sample injects identity via env vars (idiomatic for
+        // most CLIs) and HTTPS_PROXY when a proxy address is set.
+        let bin = std::env::var(MYEDITOR_BIN_ENV)
+            .map_err(|_| AdapterError::LaunchFailed(format!("{MYEDITOR_BIN_ENV} unset")))?;
+        let mut cmd = Command::new(bin);
+        cmd.args(tool_args);
+        cmd.env("AA_AGENT_ID", agent_id);
+        if let Some(team) = team_id {
+            cmd.env("AA_TEAM_ID", team);
+        }
+        if let Some(proxy) = proxy_addr {
+            cmd.env("HTTPS_PROXY", proxy);
+        }
+        Ok(cmd)
+    }
+
+    async fn list_mcp_servers(&self) -> Result<Vec<McpServerInfo>, AdapterError> {
+        let raw = std::fs::read_to_string(&self.mcp_config_path)?;
+        let parsed: MyEditorMcpConfig =
+            serde_json::from_str(&raw).map_err(|e| AdapterError::McpConfigFailed(format!("parse failed: {e}")))?;
+        Ok(parsed
+            .mcp_servers
+            .into_iter()
+            .map(|(name, entry)| McpServerInfo {
+                name,
+                command: entry.command,
+                args: entry.args,
+            })
+            .collect())
+    }
+
+    async fn apply_mcp_governance(&self, _allowed: &[String], _denied: &[String]) -> Result<(), AdapterError> {
+        // Real adapter rewrites MyEditor's MCP config to drop denied
+        // servers and trim non-allowed entries. Sample is a no-op so
+        // adapter authors see the call site without test fixtures
+        // making assertions about a side effect that varies by tool.
+        Ok(())
+    }
+
+    fn governance_level(&self) -> GovernanceLevel {
+        // IDE-host adapters cap at L1 (Observe) per Epic 14's
+        // capability matrix — the IDE sandbox prevents MyEditor from
+        // surfacing the hooks needed for L2 (Enforce) without
+        // launcher-side process control.
+        GovernanceLevel::L1Observe
+    }
+}

--- a/examples/aa-devtool-sample-myeditor/tests/contract.rs
+++ b/examples/aa-devtool-sample-myeditor/tests/contract.rs
@@ -1,0 +1,243 @@
+//! Contract tests for the [`MyEditorAdapter`] sample.
+//!
+//! These tests double as the **reference contract suite** plugin
+//! authors should mirror in their own out-of-tree adapter crates: each
+//! test corresponds to one [`DevToolAdapter`] method's documented
+//! contract from [`aa-core`'s rustdoc][`DevToolAdapter`]. When the
+//! workspace later grows a shared `aa-devtool-contract-tests` crate
+//! (currently out of scope; see `docs/devtools/plugins.md` "What's not
+//! yet in scope"), this file moves there and gets imported by every
+//! adapter crate.
+//!
+//! [`DevToolAdapter`]: aa_core::DevToolAdapter
+//! [`MyEditorAdapter`]: aa_devtool_sample_myeditor::MyEditorAdapter
+
+use std::path::PathBuf;
+
+use aa_core::{DevToolAdapter, DevToolKind, GovernanceLevel};
+use aa_devtool_sample_myeditor::{MyEditorAdapter, MYEDITOR_BIN_ENV, MYEDITOR_KIND_ID};
+
+/// Path to the in-repo MCP fixture, computed at compile time so tests
+/// don't depend on the working directory cargo invokes them from.
+fn fixture_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("fixtures/mcp_servers.json")
+}
+
+fn adapter() -> MyEditorAdapter {
+    MyEditorAdapter::new(fixture_path())
+}
+
+// --- Object-safety / Send + Sync (mirrors aa-core's trait_is_object_safe) --
+
+fn _assert_object_safe(_: &dyn DevToolAdapter) {}
+fn _assert_send_sync<T: Send + Sync>() {}
+
+#[test]
+fn myeditor_adapter_is_object_safe_and_send_sync() {
+    // Compile-time check: if `MyEditorAdapter` were not object-safe via
+    // the trait, the cast below would fail. If the trait were not
+    // `Send + Sync`, the boxed assertion would fail.
+    let a = adapter();
+    let dyn_ref: &dyn DevToolAdapter = &a;
+    _assert_object_safe(dyn_ref);
+    _assert_send_sync::<Box<dyn DevToolAdapter>>();
+}
+
+// --- detect ----------------------------------------------------------------
+
+#[test]
+fn detect_returns_none_when_env_var_unset() {
+    // Use a scoped lock to avoid clobbering parallel tests that read the
+    // env var. cargo test runs tests in threads of the same process by
+    // default, so we mutate env carefully.
+    let _guard = EnvVarGuard::unset(MYEDITOR_BIN_ENV);
+    assert!(adapter().detect().is_none());
+}
+
+#[test]
+fn detect_returns_devtoolinfo_when_env_var_set() {
+    let _guard = EnvVarGuard::set(MYEDITOR_BIN_ENV, "/usr/local/bin/myeditor");
+    let info = adapter().detect().expect("detect");
+    assert_eq!(info.kind, DevToolKind::Custom(MYEDITOR_KIND_ID.to_string()));
+    assert_eq!(info.install_path.to_str(), Some("/usr/local/bin/myeditor"));
+    assert_eq!(info.governance_level, GovernanceLevel::L1Observe);
+    assert!(info.supports_mcp);
+    assert!(info.supports_managed_settings);
+    assert_eq!(info.version.as_deref(), Some("0.0.0-sample"));
+}
+
+// --- generate_managed_settings + apply_settings ---------------------------
+
+#[tokio::test]
+async fn generate_managed_settings_returns_valid_json() {
+    let policy = aa_core::PolicyDocument {
+        version: 1,
+        name: "sample-test-policy".into(),
+        rules: vec![],
+    };
+    let rendered = adapter().generate_managed_settings(&policy).await.expect("generate");
+    let parsed: serde_json::Value = serde_json::from_str(&rendered).expect("valid json");
+    assert!(parsed.get("generated_by").is_some());
+    assert!(parsed.get("mcp_allow").and_then(|v| v.as_array()).is_some());
+}
+
+#[tokio::test]
+async fn apply_settings_writes_managed_json_next_to_fixture() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mcp_path = tmp.path().join("mcp_servers.json");
+    std::fs::write(&mcp_path, "{\"mcpServers\":{}}").unwrap();
+    let a = MyEditorAdapter::new(&mcp_path);
+    a.apply_settings("hello").await.expect("apply");
+    let written = std::fs::read_to_string(tmp.path().join("managed.json")).expect("read");
+    assert_eq!(written, "hello");
+}
+
+// --- build_launch_command -------------------------------------------------
+
+#[test]
+fn build_launch_command_injects_identity_and_proxy() {
+    let _guard = EnvVarGuard::set(MYEDITOR_BIN_ENV, "/usr/local/bin/myeditor");
+    let cmd = adapter()
+        .build_launch_command(
+            &["--workspace".to_string(), "/code".to_string()],
+            "agent-42",
+            Some("team-pioneer"),
+            Some("127.0.0.1:8443"),
+        )
+        .expect("build");
+    let envs: std::collections::HashMap<_, _> = cmd
+        .get_envs()
+        .filter_map(|(k, v)| Some((k.to_str()?.to_string(), v?.to_str()?.to_string())))
+        .collect();
+    assert_eq!(envs.get("AA_AGENT_ID").map(String::as_str), Some("agent-42"));
+    assert_eq!(envs.get("AA_TEAM_ID").map(String::as_str), Some("team-pioneer"));
+    assert_eq!(envs.get("HTTPS_PROXY").map(String::as_str), Some("127.0.0.1:8443"));
+    let args: Vec<&str> = cmd.get_args().filter_map(|a| a.to_str()).collect();
+    assert_eq!(args, vec!["--workspace", "/code"]);
+}
+
+#[test]
+fn build_launch_command_errors_when_binary_unset() {
+    let _guard = EnvVarGuard::unset(MYEDITOR_BIN_ENV);
+    let err = adapter()
+        .build_launch_command(&[], "agent-1", None, None)
+        .expect_err("should fail");
+    let msg = err.to_string();
+    assert!(msg.contains("MYEDITOR_BIN"), "unexpected error: {msg}");
+}
+
+// --- list_mcp_servers -----------------------------------------------------
+
+#[tokio::test]
+async fn list_mcp_servers_parses_fixture_into_three_servers() {
+    let servers = adapter().list_mcp_servers().await.expect("list");
+    let names: Vec<&str> = servers.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(names, vec!["filesystem", "github", "internal-search"]);
+    let filesystem = &servers[0];
+    assert_eq!(filesystem.command, "myeditor-mcp-fs");
+    assert_eq!(filesystem.args, vec!["--root", "/workspace"]);
+    let internal_search = &servers[2];
+    assert!(internal_search.args.is_empty());
+}
+
+#[tokio::test]
+async fn list_mcp_servers_returns_io_error_for_missing_fixture() {
+    let a = MyEditorAdapter::new("/nonexistent/path/mcp_servers.json");
+    let err = a.list_mcp_servers().await.expect_err("should fail");
+    // The Io variant carries the underlying NotFound — its Display
+    // message is the OS-level "No such file or directory" string.
+    assert!(matches!(err, aa_core::AdapterError::Io(_)));
+}
+
+#[tokio::test]
+async fn list_mcp_servers_returns_mcp_config_failed_on_malformed_json() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = tmp.path().join("mcp_servers.json");
+    std::fs::write(&path, "{not json").unwrap();
+    let err = MyEditorAdapter::new(&path)
+        .list_mcp_servers()
+        .await
+        .expect_err("should fail");
+    assert!(matches!(err, aa_core::AdapterError::McpConfigFailed(_)));
+}
+
+// --- apply_mcp_governance + governance_level ------------------------------
+
+#[tokio::test]
+async fn apply_mcp_governance_is_a_noop_in_sample() {
+    let allow: Vec<String> = vec!["filesystem".into()];
+    let deny: Vec<String> = vec!["github".into()];
+    adapter().apply_mcp_governance(&allow, &deny).await.expect("noop ok");
+}
+
+#[test]
+fn governance_level_is_l1_observe() {
+    assert_eq!(adapter().governance_level(), GovernanceLevel::L1Observe);
+}
+
+// --- env-var test plumbing -------------------------------------------------
+//
+// `cargo test` runs tests in parallel threads of the same process, so
+// any test that mutates a process-wide env var must serialize against
+// every other env-var-touching test. `EnvVarGuard` does two things:
+//
+// 1. Holds a process-wide `Mutex` for the duration of the test, so
+//    parallel env-var-touching tests can never interleave.
+// 2. Saves the prior value on construction and restores on drop, so
+//    a single test's mutation does not leak into the next test that
+//    happens to grab the lock.
+
+use std::sync::{Mutex, MutexGuard};
+
+fn env_var_lock() -> MutexGuard<'static, ()> {
+    static LOCK: Mutex<()> = Mutex::new(());
+    // PoisonError carries the inner guard; tests that panic while
+    // holding the lock should still let later tests proceed rather
+    // than cascade-failing on poison.
+    LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+struct EnvVarGuard {
+    key: &'static str,
+    prior: Option<std::ffi::OsString>,
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let lock = env_var_lock();
+        let prior = std::env::var_os(key);
+        // SAFETY: env-var mutation is serialized by `lock`; no other
+        // thread can observe a torn read while this guard is alive.
+        unsafe { std::env::set_var(key, value) };
+        Self {
+            key,
+            prior,
+            _lock: lock,
+        }
+    }
+
+    fn unset(key: &'static str) -> Self {
+        let lock = env_var_lock();
+        let prior = std::env::var_os(key);
+        // SAFETY: same reasoning as `set`.
+        unsafe { std::env::remove_var(key) };
+        Self {
+            key,
+            prior,
+            _lock: lock,
+        }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: same reasoning as the constructors.
+        unsafe {
+            match &self.prior {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds a working sample `DevToolAdapter` implementation (`aa-devtool-sample-myeditor`) and a plugin authoring guide at `docs/devtools/plugins.md`. Closes the AAASM-936 acceptance criteria — converts the trait from "theoretically extensible" to "verifiably extensible".

* **Sample crate:** new workspace member at `examples/aa-devtool-sample-myeditor/`. Implements `DevToolAdapter` for a fictional `MyEditor` IDE, with every method exercised against a hand-rolled `fixtures/mcp_servers.json` fixture (no real binary needed). 12 contract tests covering object-safety, every method's success path, and the documented error variants. `cargo test -p aa-devtool-sample-myeditor` runs in CI on every PR (workspace member).
* **`docs/devtools/plugins.md`:** authoring guide covering trait surface, crate layout, adapter loading pattern, versioning expectations, contract-test requirements, and `GovernanceLevel`/`AdapterError` cheat sheets. Ends with an honest **"What's not yet in scope"** section listing future extension points (registration mechanism, shared contract-test crate, `aa run` launcher, capability-matrix doc).

## ⚠ Three intentional AC divergences — please review

The AAASM-936 description references infrastructure that **does not exist in the repo today**. I shipped Option A from our earlier review: build what makes sense given current state, flag the mismatches honestly. The deviations:

| AC text | Reality | What I shipped |
|---|---|---|
| *"Mirror the structure of the smallest existing per-tool adapter"* | **No per-tool adapters exist yet** (AAASM-201..205, AAASM-918 are future). | Mirrored the structure of small workspace members (`aa-runtime`, `aa-proto`) for layout. The sample crate is the *first* per-tool-adapter-shaped crate in the workspace — future per-tool adapters will mirror **this** one. |
| *"passes the DevToolAdapter contract test suite (same one used by Claude Code / Codex adapters)"* | **No shared contract test suite exists.** Only `trait_is_object_safe` from AAASM-925. | Wrote the contract tests directly in the sample (`tests/contract.rs`). The doc explains plugin authors mirror this file in their own crates, and notes the future shared `aa-devtool-contract-tests` crate is out of scope today (linked from "What's not yet in scope" in plugins.md). |
| *"registration mechanism (`inventory::submit!` or equivalent already used by core)"* | **No registration mechanism in `aa-core` or anywhere in the workspace.** No `inventory`/`linkme`/`ctor` deps. | `plugins.md` documents the **build-time linking** pattern that actually exists today, and explicitly warns plugin authors not to assume `inventory::submit!` is wired in. Lists "Automated registration mechanism" under "What's not yet in scope" with no tracking ticket — open one if you want this added. |

If you'd rather actually add `inventory` (or equivalent) to `aa-core` as part of this PR, that's a substantial scope expansion (new public API surface, new runtime dep) that should probably be its own ticket. Happy to spin one up.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: [AAASM-936](https://lightning-dust-mite.atlassian.net/browse/AAASM-936) (parent Story [AAASM-199](https://lightning-dust-mite.atlassian.net/browse/AAASM-199); Epic [AAASM-196](https://lightning-dust-mite.atlassian.net/browse/AAASM-196))
- Related GitHub issues: n/a

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

12 contract tests in `examples/aa-devtool-sample-myeditor/tests/contract.rs`:

| Test | Verifies |
|---|---|
| `myeditor_adapter_is_object_safe_and_send_sync` | `&dyn DevToolAdapter` and `Box<dyn DevToolAdapter>: Send + Sync` for `MyEditorAdapter`. |
| `detect_returns_none_when_env_var_unset` / `..._when_env_var_set` | `detect`'s `None` and `Some(DevToolInfo)` paths. |
| `generate_managed_settings_returns_valid_json` | Output parses as JSON with documented top-level keys. |
| `apply_settings_writes_managed_json_next_to_fixture` | Side effect observable on disk (in `tempfile::tempdir()`). |
| `build_launch_command_injects_identity_and_proxy` / `..._errors_when_binary_unset` | Identity / proxy env-var injection; `LaunchFailed` when binary unset. |
| `list_mcp_servers_parses_fixture_into_three_servers` | Fixture parses to expected `McpServerInfo` list. |
| `list_mcp_servers_returns_io_error_for_missing_fixture` | `Io` variant on missing file. |
| `list_mcp_servers_returns_mcp_config_failed_on_malformed_json` | `McpConfigFailed` variant on parse error. |
| `apply_mcp_governance_is_a_noop_in_sample` | Documented no-op completes. |
| `governance_level_is_l1_observe` | Static cap value. |

**Env-var test plumbing:** the tests use a process-wide `Mutex<()>` (in `EnvVarGuard`) to serialize parallel env-var-touching tests. `cargo test` runs in parallel threads of the same process; without serialization, `set`/`unset` from different tests race. Documented in the test file.

Local validation matrix:

| Check | Command | Result |
|---|---|---|
| Build (sample, default) | `cargo check -p aa-devtool-sample-myeditor` | OK |
| Build (aa-core, all features) | `cargo check -p aa-core --all-features` | OK (no regression) |
| Sample tests | `cargo test -p aa-devtool-sample-myeditor` | **12 / 12 passed** |
| aa-core tests | `cargo test -p aa-core --features serde` | 117 / 117 passed (no regression) |
| Format | `cargo fmt --all -- --check` | clean |
| Clippy (workspace, all targets) | `cargo clippy --workspace --exclude aa-ebpf* --all-targets -- -D warnings` | clean |
| Doc | `cargo doc -p aa-devtool-sample-myeditor --no-deps` | clean (0 warnings) |
| Workspace check (excl. eBPF) | `cargo check --workspace --exclude aa-ebpf*` | OK |

## Commit history (6 small commits)

1. `✨ devtool(sample): Add aa-devtool-sample-myeditor crate skeleton` — Cargo.toml + stub `lib.rs` + workspace-member registration.
2. `✨ devtool(sample): Add MCP servers fixture for MyEditor sample adapter` — `fixtures/mcp_servers.json`.
3. `✨ devtool(sample): Implement DevToolAdapter for MyEditorAdapter` — every method, with inline rationale on each implementation choice.
4. `✅ devtool(sample): Add DevToolAdapter contract tests for MyEditor sample` — 12 tests + serializing `EnvVarGuard`.
5. `📝 docs(devtools): Add plugins.md authoring guide for DevToolAdapter` — full author guide, "What's not yet in scope" section.
6. `🔧 (workspace): Lock aa-devtool-sample-myeditor into Cargo.lock` — lockfile follow-up.

Each commit leaves the repo buildable (bisectable).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing (verified locally; CI will confirm)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-936]: https://lightning-dust-mite.atlassian.net/browse/AAASM-936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ