### PR TITLE
[AAASM-931] ✨ (aa-gateway): Wire topology fields to AgentRecord registration

### DIFF
--- a/aa-api/tests/agents.rs
+++ b/aa-api/tests/agents.rs
@@ -33,6 +33,11 @@ fn test_agent(id_byte: u8) -> AgentRecord {
         recent_traces: Vec::new(),
         layer: None,
         governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: None,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
     }
 }
 

--- a/aa-core/src/agent.rs
+++ b/aa-core/src/agent.rs
@@ -293,6 +293,47 @@ mod tests {
 
     #[cfg(feature = "serde")]
     #[test]
+    fn serde_round_trip_with_topology_fields() {
+        let original = AgentContext {
+            agent_id: AgentId::from_bytes(AGENT_BYTES),
+            session_id: SessionId::from_bytes(SESSION_BYTES),
+            pid: 42,
+            started_at: Timestamp::from_nanos(1_000_000),
+            metadata: BTreeMap::new(),
+            governance_level: GovernanceLevel::default(),
+            parent_agent_id: Some(AgentId::from_bytes([9u8; 16])),
+            team_id: Some("team-alpha".into()),
+            depth: 2,
+            delegation_reason: Some("summarise results".into()),
+            spawned_by_tool: Some("langgraph.subgraph".into()),
+        };
+        let json = serde_json::to_string(&original).expect("serialize");
+        let restored: AgentContext = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(original, restored);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serde_backward_compat_missing_topology_fields() {
+        // Contexts serialised before topology fields were added must still
+        // deserialise — new fields must default to their zero values.
+        let json = r#"{
+            "agent_id":[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+            "session_id":[2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2],
+            "pid":42,
+            "started_at":1000000,
+            "metadata":{}
+        }"#;
+        let restored: AgentContext = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(restored.depth, 0);
+        assert!(restored.parent_agent_id.is_none());
+        assert!(restored.team_id.is_none());
+        assert!(restored.delegation_reason.is_none());
+        assert!(restored.spawned_by_tool.is_none());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
     fn agent_context_defaults_to_l0_when_governance_level_missing() {
         // Old serialised contexts written before `governance_level` was
         // added must still deserialise — the field must default to

--- a/aa-core/src/agent.rs
+++ b/aa-core/src/agent.rs
@@ -17,7 +17,8 @@ use crate::{
 ///
 /// `AgentContext` flows through every governance event in the system.
 /// It captures the stable agent identity, per-session identity, process ID,
-/// start time, and any additional runtime metadata.
+/// start time, any additional runtime metadata, and optional topology/lineage
+/// fields that describe the agent's position in a delegation hierarchy.
 ///
 /// Requires the `alloc` feature.
 #[cfg(feature = "alloc")]
@@ -46,6 +47,21 @@ pub struct AgentContext {
     /// or construct without churn.
     #[cfg_attr(feature = "serde", serde(default))]
     pub governance_level: GovernanceLevel,
+    /// The agent that spawned this one; `None` for root agents.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    pub parent_agent_id: Option<AgentId>,
+    /// Team this agent belongs to; `None` if no team is assigned.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    pub team_id: Option<String>,
+    /// Delegation depth — 0 for root agents, incremented by 1 per delegation level.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub depth: u32,
+    /// Human-readable reason the parent delegated to this agent.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    pub delegation_reason: Option<String>,
+    /// Tool or framework that triggered the spawn (e.g. `"langgraph.subgraph"`).
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    pub spawned_by_tool: Option<String>,
 }
 
 #[cfg(all(feature = "alloc", feature = "std"))]
@@ -61,6 +77,11 @@ impl AgentContext {
             pid,
             metadata: BTreeMap::new(),
             governance_level: GovernanceLevel::default(),
+            parent_agent_id: None,
+            team_id: None,
+            depth: 0,
+            delegation_reason: None,
+            spawned_by_tool: None,
         }
     }
 }
@@ -80,6 +101,11 @@ mod tests {
             started_at: Timestamp::from_nanos(1_000_000),
             metadata: BTreeMap::new(),
             governance_level: GovernanceLevel::default(),
+            parent_agent_id: None,
+            team_id: None,
+            depth: 0,
+            delegation_reason: None,
+            spawned_by_tool: None,
         }
     }
 

--- a/aa-core/src/agent.rs
+++ b/aa-core/src/agent.rs
@@ -84,6 +84,88 @@ impl AgentContext {
             spawned_by_tool: None,
         }
     }
+
+    /// Return a fresh [`AgentContextBuilder`] for topology-aware construction.
+    pub fn builder() -> AgentContextBuilder {
+        AgentContextBuilder::new()
+    }
+}
+
+/// Fluent builder for [`AgentContext`] that allows populating optional topology
+/// and lineage fields before stamping the context at construction time.
+///
+/// Obtain one via [`AgentContext::builder()`].
+#[cfg(feature = "alloc")]
+pub struct AgentContextBuilder {
+    parent_agent_id: Option<AgentId>,
+    team_id: Option<String>,
+    depth: u32,
+    delegation_reason: Option<String>,
+    spawned_by_tool: Option<String>,
+}
+
+#[cfg(feature = "alloc")]
+impl AgentContextBuilder {
+    fn new() -> Self {
+        Self {
+            parent_agent_id: None,
+            team_id: None,
+            depth: 0,
+            delegation_reason: None,
+            spawned_by_tool: None,
+        }
+    }
+
+    /// Set the agent that spawned this one.
+    pub fn parent_agent_id(mut self, id: AgentId) -> Self {
+        self.parent_agent_id = Some(id);
+        self
+    }
+
+    /// Set the team this agent belongs to.
+    pub fn team_id(mut self, id: String) -> Self {
+        self.team_id = Some(id);
+        self
+    }
+
+    /// Set the delegation depth (0 = root).
+    pub fn depth(mut self, d: u32) -> Self {
+        self.depth = d;
+        self
+    }
+
+    /// Set the human-readable reason the parent delegated to this agent.
+    pub fn delegation_reason(mut self, r: String) -> Self {
+        self.delegation_reason = Some(r);
+        self
+    }
+
+    /// Set the tool or framework that triggered the spawn.
+    pub fn spawned_by_tool(mut self, t: String) -> Self {
+        self.spawned_by_tool = Some(t);
+        self
+    }
+}
+
+#[cfg(all(feature = "alloc", feature = "std"))]
+impl AgentContextBuilder {
+    /// Consume the builder and construct an [`AgentContext`] stamped at the
+    /// current wall-clock time. `metadata` is initialised empty.
+    pub fn build(self, agent_id: AgentId, session_id: SessionId, pid: u32) -> AgentContext {
+        AgentContext {
+            started_at: Timestamp::from(std::time::SystemTime::now()),
+            agent_id,
+            session_id,
+            pid,
+            metadata: BTreeMap::new(),
+            governance_level: GovernanceLevel::default(),
+            parent_agent_id: self.parent_agent_id,
+            team_id: self.team_id,
+            depth: self.depth,
+            delegation_reason: self.delegation_reason,
+            spawned_by_tool: self.spawned_by_tool,
+        }
+    }
 }
 
 #[cfg(all(test, feature = "alloc"))]

--- a/aa-core/src/agent.rs
+++ b/aa-core/src/agent.rs
@@ -234,6 +234,54 @@ mod tests {
         assert!(ctx.metadata.is_empty());
     }
 
+    #[cfg(feature = "std")]
+    #[test]
+    fn builder_defaults_give_root_agent() {
+        let ctx = AgentContext::builder().build(
+            AgentId::from_bytes(AGENT_BYTES),
+            SessionId::from_bytes(SESSION_BYTES),
+            42,
+        );
+        assert_eq!(ctx.depth, 0);
+        assert!(ctx.parent_agent_id.is_none());
+        assert!(ctx.team_id.is_none());
+        assert!(ctx.delegation_reason.is_none());
+        assert!(ctx.spawned_by_tool.is_none());
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn builder_sets_parent_and_team() {
+        let parent = AgentId::from_bytes([9u8; 16]);
+        let ctx = AgentContext::builder()
+            .parent_agent_id(parent)
+            .team_id("team-alpha".into())
+            .depth(1)
+            .build(
+                AgentId::from_bytes(AGENT_BYTES),
+                SessionId::from_bytes(SESSION_BYTES),
+                42,
+            );
+        assert_eq!(ctx.parent_agent_id, Some(parent));
+        assert_eq!(ctx.team_id.as_deref(), Some("team-alpha"));
+        assert_eq!(ctx.depth, 1);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn builder_sets_delegation_fields() {
+        let ctx = AgentContext::builder()
+            .delegation_reason("summarise results".into())
+            .spawned_by_tool("langgraph.subgraph".into())
+            .build(
+                AgentId::from_bytes(AGENT_BYTES),
+                SessionId::from_bytes(SESSION_BYTES),
+                42,
+            );
+        assert_eq!(ctx.delegation_reason.as_deref(), Some("summarise results"));
+        assert_eq!(ctx.spawned_by_tool.as_deref(), Some("langgraph.subgraph"));
+    }
+
     #[cfg(feature = "serde")]
     #[test]
     fn serde_round_trip() {

--- a/aa-core/src/evaluators.rs
+++ b/aa-core/src/evaluators.rs
@@ -82,6 +82,11 @@ mod tests {
             started_at: crate::time::Timestamp::from_nanos(0),
             metadata: alloc::collections::BTreeMap::new(),
             governance_level: crate::GovernanceLevel::default(),
+            parent_agent_id: None,
+            team_id: None,
+            depth: 0,
+            delegation_reason: None,
+            spawned_by_tool: None,
         }
     }
 

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -38,7 +38,7 @@ pub use identity::{AgentId, SessionId};
 pub use policy::{FileMode, PolicyDecision, PolicyError};
 
 #[cfg(feature = "alloc")]
-pub use agent::AgentContext;
+pub use agent::{AgentContext, AgentContextBuilder};
 #[cfg(feature = "alloc")]
 pub use dev_tool::DevToolKind;
 #[cfg(feature = "alloc")]

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -569,6 +569,11 @@ mod tests {
             started_at: Timestamp::from_nanos(0),
             metadata: BTreeMap::new(),
             governance_level: aa_core::GovernanceLevel::default(),
+            parent_agent_id: None,
+            team_id: None,
+            depth: 0,
+            delegation_reason: None,
+            spawned_by_tool: None,
         }
     }
 

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -98,6 +98,16 @@ pub struct AgentRecord {
     /// existing agents registered before this field was introduced retain
     /// the discover-only default.
     pub governance_level: GovernanceLevel,
+    /// Agent ID string of the parent that spawned this agent; `None` for root agents.
+    pub parent_agent_id: Option<String>,
+    /// Team this agent belongs to; `None` if not provided at registration.
+    pub team_id: Option<String>,
+    /// Delegation depth in the agent hierarchy — 0 for root agents.
+    pub depth: u32,
+    /// Human-readable reason the parent delegated to this agent.
+    pub delegation_reason: Option<String>,
+    /// Tool or framework that triggered the spawn (e.g. `"langgraph.subgraph"`).
+    pub spawned_by_tool: Option<String>,
 }
 
 /// Channel sender type for pushing [`ControlCommand`]s to an agent's control stream.

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -75,6 +75,11 @@ pub fn request_to_core(req: &CheckActionRequest) -> Result<(AgentContext, Govern
         // Provisional default — overwritten by the gateway service layer
         // with the agent's registered level before the engine sees it.
         governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: None,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
     };
 
     // --- Governance action ---

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -112,6 +112,11 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
             recent_traces: Vec::new(),
             layer: None,
             governance_level: aa_core::GovernanceLevel::default(),
+            parent_agent_id: None,
+            team_id: None,
+            depth: 0,
+            delegation_reason: None,
+            spawned_by_tool: None,
         };
 
         self.registry

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -112,11 +112,11 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
             recent_traces: Vec::new(),
             layer: None,
             governance_level: aa_core::GovernanceLevel::default(),
-            parent_agent_id: None,
-            team_id: None,
+            parent_agent_id: req.parent_agent_id,
+            team_id: echo_team_id.clone(),
             depth: 0,
-            delegation_reason: None,
-            spawned_by_tool: None,
+            delegation_reason: req.delegation_reason,
+            spawned_by_tool: req.spawned_by_tool,
         };
 
         self.registry

--- a/aa-gateway/src/simulation/engine.rs
+++ b/aa-gateway/src/simulation/engine.rs
@@ -60,6 +60,11 @@ impl SimulationEngine {
             started_at: aa_core::time::Timestamp::from_nanos(0),
             metadata: BTreeMap::new(),
             governance_level: aa_core::GovernanceLevel::default(),
+            parent_agent_id: None,
+            team_id: None,
+            depth: 0,
+            delegation_reason: None,
+            spawned_by_tool: None,
         };
 
         let result = self.engine.evaluate(&ctx, &action);

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -293,6 +293,11 @@ budget:
         started_at: aa_core::time::Timestamp::from_nanos(0),
         metadata: std::collections::BTreeMap::new(),
         governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: None,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
     };
     engine.record_spend(&agent_ctx, 2.0); // exceeds $1.0 daily limit
 
@@ -368,6 +373,11 @@ budget:
         started_at: aa_core::time::Timestamp::from_nanos(0),
         metadata: std::collections::BTreeMap::new(),
         governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: None,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
     };
     engine.record_spend(&agent_ctx, 2.0);
 

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -281,6 +281,11 @@ budget:
         recent_traces: Vec::new(),
         layer: None,
         governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: None,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
     };
     registry.register(record).unwrap();
 
@@ -363,6 +368,11 @@ budget:
         recent_traces: Vec::new(),
         layer: None,
         governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: None,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
     };
     registry.register(record).unwrap();
 
@@ -463,6 +473,11 @@ fn level_test_record(
         recent_traces: Vec::new(),
         layer: None,
         governance_level: level,
+        parent_agent_id: None,
+        team_id: None,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
     }
 }
 

--- a/aa-gateway/tests/registry_test.rs
+++ b/aa-gateway/tests/registry_test.rs
@@ -31,6 +31,11 @@ fn make_record(key: [u8; 16]) -> AgentRecord {
         recent_traces: Vec::new(),
         layer: None,
         governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: None,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
     }
 }
 
@@ -227,6 +232,11 @@ async fn concurrent_registration_of_100_agents() {
                 recent_traces: Vec::new(),
                 layer: None,
                 governance_level: aa_core::GovernanceLevel::default(),
+                parent_agent_id: None,
+                team_id: None,
+                depth: 0,
+                delegation_reason: None,
+                spawned_by_tool: None,
             };
             reg.register(record).unwrap();
         }));

--- a/aa-gateway/tests/registry_test.rs
+++ b/aa-gateway/tests/registry_test.rs
@@ -388,3 +388,37 @@ fn agent_record_governance_level_round_trips_through_registry() {
     let retrieved = reg.get(&key(1)).unwrap();
     assert_eq!(retrieved.governance_level, aa_core::GovernanceLevel::L2Enforce);
 }
+
+// ── Topology fields ──────────────────────────────────────────────────────────
+
+#[test]
+fn sub_agent_topology_fields_survive_registration() {
+    let reg = AgentRegistry::new();
+    let mut record = make_record(key(1));
+    record.parent_agent_id = Some("parent-agent-uuid".into());
+    record.team_id = Some("team-alpha".into());
+    record.depth = 2;
+    record.delegation_reason = Some("handle data extraction".into());
+    record.spawned_by_tool = Some("langgraph.subgraph".into());
+    reg.register(record).unwrap();
+
+    let retrieved = reg.get(&key(1)).unwrap();
+    assert_eq!(retrieved.parent_agent_id.as_deref(), Some("parent-agent-uuid"));
+    assert_eq!(retrieved.team_id.as_deref(), Some("team-alpha"));
+    assert_eq!(retrieved.depth, 2);
+    assert_eq!(retrieved.delegation_reason.as_deref(), Some("handle data extraction"));
+    assert_eq!(retrieved.spawned_by_tool.as_deref(), Some("langgraph.subgraph"));
+}
+
+#[test]
+fn root_agent_topology_fields_default_to_none_and_zero() {
+    let reg = AgentRegistry::new();
+    reg.register(make_record(key(2))).unwrap();
+
+    let retrieved = reg.get(&key(2)).unwrap();
+    assert!(retrieved.parent_agent_id.is_none());
+    assert!(retrieved.team_id.is_none());
+    assert_eq!(retrieved.depth, 0);
+    assert!(retrieved.delegation_reason.is_none());
+    assert!(retrieved.spawned_by_tool.is_none());
+}


### PR DESCRIPTION
## Description

Extends `AgentRecord` in `aa-gateway` with the five topology/lineage fields introduced on `AgentContext` in AAASM-929, and wires those fields from the incoming `RegisterRequest` proto message into the stored registry record.

**Stacked on:** `v0.0.1/AAASM-929/add_topology_fields` — the diff is cleanest once that PR merges to master.

**Commits:**
1. `✨ (aa-gateway): Add topology fields to AgentRecord in registry` — adds `parent_agent_id`, `team_id`, `depth`, `delegation_reason`, `spawned_by_tool` to the `AgentRecord` struct and updates all six struct-literal call sites with `None`/`0` defaults.
2. `✨ (aa-gateway): Populate AgentRecord topology fields from RegisterRequest` — wires the proto `optional string` fields (9–11) from `RegisterRequest` into the record; `depth` stays 0 and will be computed server-side in AAASM-1005.
3. `✅ (aa-gateway): Add topology field round-trip tests to registry_test` — two tests: sub-agent registration persists all five topology fields; root-agent registration carries None/0 defaults.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-931 (part of Story AAASM-207, Epic AAASM-197)
- Depends on: AAASM-929 (AgentContext topology fields in aa-core)

## Testing

- [x] Unit tests added / updated — `registry_test::sub_agent_topology_fields_survive_registration`, `registry_test::root_agent_topology_fields_default_to_none_and_zero`
- [x] Integration tests added / updated — 686 tests across aa-core, aa-gateway, aa-api all pass

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention