### PR TITLE
[AAASM-1005] ✨ (aa-core/aa-gateway): Add root_agent_id lineage field

### DIFF
--- a/aa-api/tests/agents.rs
+++ b/aa-api/tests/agents.rs
@@ -38,6 +38,7 @@ fn test_agent(id_byte: u8) -> AgentRecord {
         depth: 0,
         delegation_reason: None,
         spawned_by_tool: None,
+        root_agent_id: None,
     }
 }
 

--- a/aa-core/src/agent.rs
+++ b/aa-core/src/agent.rs
@@ -62,6 +62,13 @@ pub struct AgentContext {
     /// Tool or framework that triggered the spawn (e.g. `"langgraph.subgraph"`).
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
     pub spawned_by_tool: Option<String>,
+    /// Root of the delegation chain — the top-level agent that ultimately spawned this one.
+    ///
+    /// For root agents this equals `Some(agent_id)`.  For sub-agents it is set
+    /// server-side to `parent.root_agent_id.unwrap_or(parent.agent_id)` so that
+    /// any node in a delegation chain can resolve its root in O(1).
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    pub root_agent_id: Option<AgentId>,
 }
 
 #[cfg(all(feature = "alloc", feature = "std"))]
@@ -82,6 +89,7 @@ impl AgentContext {
             depth: 0,
             delegation_reason: None,
             spawned_by_tool: None,
+            root_agent_id: None,
         }
     }
 
@@ -102,6 +110,7 @@ pub struct AgentContextBuilder {
     depth: u32,
     delegation_reason: Option<String>,
     spawned_by_tool: Option<String>,
+    root_agent_id: Option<AgentId>,
 }
 
 #[cfg(feature = "alloc")]
@@ -113,6 +122,7 @@ impl AgentContextBuilder {
             depth: 0,
             delegation_reason: None,
             spawned_by_tool: None,
+            root_agent_id: None,
         }
     }
 
@@ -145,6 +155,12 @@ impl AgentContextBuilder {
         self.spawned_by_tool = Some(t);
         self
     }
+
+    /// Set the root agent of the delegation chain.
+    pub fn root_agent_id(mut self, id: AgentId) -> Self {
+        self.root_agent_id = Some(id);
+        self
+    }
 }
 
 #[cfg(all(feature = "alloc", feature = "std"))]
@@ -164,6 +180,7 @@ impl AgentContextBuilder {
             depth: self.depth,
             delegation_reason: self.delegation_reason,
             spawned_by_tool: self.spawned_by_tool,
+            root_agent_id: self.root_agent_id,
         }
     }
 }
@@ -188,6 +205,7 @@ mod tests {
             depth: 0,
             delegation_reason: None,
             spawned_by_tool: None,
+            root_agent_id: None,
         }
     }
 
@@ -247,6 +265,7 @@ mod tests {
         assert!(ctx.team_id.is_none());
         assert!(ctx.delegation_reason.is_none());
         assert!(ctx.spawned_by_tool.is_none());
+        assert!(ctx.root_agent_id.is_none());
     }
 
     #[cfg(feature = "std")]
@@ -294,6 +313,7 @@ mod tests {
     #[cfg(feature = "serde")]
     #[test]
     fn serde_round_trip_with_topology_fields() {
+        let root = AgentId::from_bytes([7u8; 16]);
         let original = AgentContext {
             agent_id: AgentId::from_bytes(AGENT_BYTES),
             session_id: SessionId::from_bytes(SESSION_BYTES),
@@ -306,6 +326,7 @@ mod tests {
             depth: 2,
             delegation_reason: Some("summarise results".into()),
             spawned_by_tool: Some("langgraph.subgraph".into()),
+            root_agent_id: Some(root),
         };
         let json = serde_json::to_string(&original).expect("serialize");
         let restored: AgentContext = serde_json::from_str(&json).expect("deserialize");
@@ -330,6 +351,7 @@ mod tests {
         assert!(restored.team_id.is_none());
         assert!(restored.delegation_reason.is_none());
         assert!(restored.spawned_by_tool.is_none());
+        assert!(restored.root_agent_id.is_none());
     }
 
     #[cfg(feature = "serde")]

--- a/aa-core/src/evaluators.rs
+++ b/aa-core/src/evaluators.rs
@@ -87,6 +87,7 @@ mod tests {
             depth: 0,
             delegation_reason: None,
             spawned_by_tool: None,
+            root_agent_id: None,
         }
     }
 

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -574,6 +574,7 @@ mod tests {
             depth: 0,
             delegation_reason: None,
             spawned_by_tool: None,
+            root_agent_id: None,
         }
     }
 

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -108,6 +108,12 @@ pub struct AgentRecord {
     pub delegation_reason: Option<String>,
     /// Tool or framework that triggered the spawn (e.g. `"langgraph.subgraph"`).
     pub spawned_by_tool: Option<String>,
+    /// Root of the delegation chain — computed server-side at registration.
+    ///
+    /// For root agents equals `Some(agent_id)`. For sub-agents set to
+    /// `parent.root_agent_id.unwrap_or(parent.agent_id)` so any node can
+    /// resolve its root in O(1) without walking the parent chain.
+    pub root_agent_id: Option<[u8; 16]>,
 }
 
 /// Channel sender type for pushing [`ControlCommand`]s to an agent's control stream.

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -80,6 +80,7 @@ pub fn request_to_core(req: &CheckActionRequest) -> Result<(AgentContext, Govern
         depth: 0,
         delegation_reason: None,
         spawned_by_tool: None,
+        root_agent_id: None,
     };
 
     // --- Governance action ---

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -117,6 +117,7 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
             depth: 0,
             delegation_reason: req.delegation_reason,
             spawned_by_tool: req.spawned_by_tool,
+            root_agent_id: None, // computed and overwritten below
         };
 
         self.registry

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -12,6 +12,7 @@ use aa_proto::assembly::agent::v1::{
     ControlCommand, ControlStreamRequest, DeregisterRequest, DeregisterResponse, HeartbeatRequest, HeartbeatResponse,
     RegisterRequest, RegisterResponse,
 };
+use aa_proto::assembly::common::v1::AgentId as ProtoAgentId;
 
 use crate::engine::PolicyEngine;
 use crate::registry::convert::{proto_agent_id_to_key, validate_proto_agent_id};
@@ -90,6 +91,25 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
             Some(proto_id.team_id.clone())
         };
 
+        // Compute root_agent_id server-side before building the record.
+        // Root agents: root = self. Sub-agents: inherit parent's root (or parent itself).
+        // Fail with INVALID_ARGUMENT if the declared parent is not registered.
+        let root_agent_id: Option<[u8; 16]> = if let Some(ref parent_str) = echo_parent_agent_id {
+            let parent_proto_id = ProtoAgentId {
+                org_id: proto_id.org_id.clone(),
+                team_id: proto_id.team_id.clone(),
+                agent_id: parent_str.clone(),
+            };
+            let parent_key = proto_agent_id_to_key(&parent_proto_id);
+            let parent = self
+                .registry
+                .get(&parent_key)
+                .ok_or_else(|| Status::invalid_argument("parent_agent_id not found in registry"))?;
+            Some(parent.root_agent_id.unwrap_or(parent.agent_id))
+        } else {
+            Some(agent_key)
+        };
+
         let record = AgentRecord {
             agent_id: agent_key,
             name: req.name,
@@ -117,7 +137,7 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
             depth: 0,
             delegation_reason: req.delegation_reason,
             spawned_by_tool: req.spawned_by_tool,
-            root_agent_id: None, // computed and overwritten below
+            root_agent_id,
         };
 
         self.registry
@@ -126,12 +146,16 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
 
         tracing::info!(agent_id = ?proto_id.agent_id, "agent registered");
 
+        // root_agent_id is Copy ([u8;16]) so we can use it after moving into record above.
+        let echo_root = root_agent_id.map(|b| b.to_vec());
+
         Ok(Response::new(RegisterResponse {
             credential_token,
             assigned_policy: String::new(),
             heartbeat_interval_sec: DEFAULT_HEARTBEAT_INTERVAL_SEC,
             parent_agent_id: echo_parent_agent_id,
             team_id: echo_team_id,
+            root_agent_id: echo_root,
         }))
     }
 

--- a/aa-gateway/src/simulation/engine.rs
+++ b/aa-gateway/src/simulation/engine.rs
@@ -65,6 +65,7 @@ impl SimulationEngine {
             depth: 0,
             delegation_reason: None,
             spawned_by_tool: None,
+            root_agent_id: None,
         };
 
         let result = self.engine.evaluate(&ctx, &action);

--- a/aa-gateway/tests/lifecycle_service_test.rs
+++ b/aa-gateway/tests/lifecycle_service_test.rs
@@ -598,7 +598,11 @@ async fn root_agent_id_for_root_agent_is_set_to_self() {
         .into_inner();
 
     let echoed = resp.root_agent_id.expect("root agent must receive root_agent_id");
-    assert_eq!(echoed.as_slice(), expected_key.as_slice(), "root agent's root_agent_id must equal its own key");
+    assert_eq!(
+        echoed.as_slice(),
+        expected_key.as_slice(),
+        "root agent's root_agent_id must equal its own key"
+    );
 }
 
 #[tokio::test]
@@ -612,37 +616,78 @@ async fn root_agent_id_chains_3_levels() {
     let team = "chain-team";
 
     // Register A (root).
-    let proto_a = ProtoAgentId { org_id: org.into(), team_id: team.into(), agent_id: "agent-A".into() };
+    let proto_a = ProtoAgentId {
+        org_id: org.into(),
+        team_id: team.into(),
+        agent_id: "agent-A".into(),
+    };
     let key_a = aa_gateway::registry::convert::proto_agent_id_to_key(&proto_a);
-    client.register(RegisterRequest {
-        agent_id: Some(proto_a), name: "A".into(), framework: "custom".into(),
-        version: "1.0.0".into(), risk_tier: 0, tool_names: vec![],
-        public_key: test_ed25519_public_key_hex(), metadata: Default::default(),
-        ..Default::default()
-    }).await.unwrap();
+    client
+        .register(RegisterRequest {
+            agent_id: Some(proto_a),
+            name: "A".into(),
+            framework: "custom".into(),
+            version: "1.0.0".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key: test_ed25519_public_key_hex(),
+            metadata: Default::default(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
 
     // Register B (parent = A).
-    let proto_b = ProtoAgentId { org_id: org.into(), team_id: team.into(), agent_id: "agent-B".into() };
-    client.register(RegisterRequest {
-        agent_id: Some(proto_b), name: "B".into(), framework: "custom".into(),
-        version: "1.0.0".into(), risk_tier: 0, tool_names: vec![],
-        public_key: test_ed25519_public_key_hex(), metadata: Default::default(),
-        parent_agent_id: Some("agent-A".into()),
-        ..Default::default()
-    }).await.unwrap();
+    let proto_b = ProtoAgentId {
+        org_id: org.into(),
+        team_id: team.into(),
+        agent_id: "agent-B".into(),
+    };
+    client
+        .register(RegisterRequest {
+            agent_id: Some(proto_b),
+            name: "B".into(),
+            framework: "custom".into(),
+            version: "1.0.0".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key: test_ed25519_public_key_hex(),
+            metadata: Default::default(),
+            parent_agent_id: Some("agent-A".into()),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
 
     // Register C (parent = B). C's root_agent_id must equal A's key.
-    let proto_c = ProtoAgentId { org_id: org.into(), team_id: team.into(), agent_id: "agent-C".into() };
-    let resp_c = client.register(RegisterRequest {
-        agent_id: Some(proto_c), name: "C".into(), framework: "custom".into(),
-        version: "1.0.0".into(), risk_tier: 0, tool_names: vec![],
-        public_key: test_ed25519_public_key_hex(), metadata: Default::default(),
-        parent_agent_id: Some("agent-B".into()),
-        ..Default::default()
-    }).await.unwrap().into_inner();
+    let proto_c = ProtoAgentId {
+        org_id: org.into(),
+        team_id: team.into(),
+        agent_id: "agent-C".into(),
+    };
+    let resp_c = client
+        .register(RegisterRequest {
+            agent_id: Some(proto_c),
+            name: "C".into(),
+            framework: "custom".into(),
+            version: "1.0.0".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key: test_ed25519_public_key_hex(),
+            metadata: Default::default(),
+            parent_agent_id: Some("agent-B".into()),
+            ..Default::default()
+        })
+        .await
+        .unwrap()
+        .into_inner();
 
     let c_root = resp_c.root_agent_id.expect("C must receive root_agent_id");
-    assert_eq!(c_root.as_slice(), key_a.as_slice(), "C's root_agent_id must chain back to A");
+    assert_eq!(
+        c_root.as_slice(),
+        key_a.as_slice(),
+        "C's root_agent_id must chain back to A"
+    );
 }
 
 #[tokio::test]
@@ -673,5 +718,9 @@ async fn root_agent_id_when_parent_unknown_returns_invalid_argument() {
         .unwrap_err();
 
     assert_eq!(err.code(), tonic::Code::InvalidArgument);
-    assert!(err.message().contains("parent_agent_id not found"), "error must name the problem: {}", err.message());
+    assert!(
+        err.message().contains("parent_agent_id not found"),
+        "error must name the problem: {}",
+        err.message()
+    );
 }

--- a/aa-gateway/tests/lifecycle_service_test.rs
+++ b/aa-gateway/tests/lifecycle_service_test.rs
@@ -481,6 +481,27 @@ async fn register_echoes_parent_agent_id_and_team_id() {
         .await
         .unwrap();
 
+    // Register the parent first so the sub-agent can be accepted.
+    let parent_id = ProtoAgentId {
+        org_id: "org-echo".into(),
+        team_id: "team-echo".into(),
+        agent_id: "parent-echo".into(),
+    };
+    client
+        .register(RegisterRequest {
+            agent_id: Some(parent_id),
+            name: "parent-agent".into(),
+            framework: "custom".into(),
+            version: "1.0.0".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key: test_ed25519_public_key_hex(),
+            metadata: Default::default(),
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
     let agent_id = ProtoAgentId {
         org_id: "org-echo".into(),
         team_id: "team-echo".into(),
@@ -506,6 +527,9 @@ async fn register_echoes_parent_agent_id_and_team_id() {
 
     assert_eq!(reg_resp.parent_agent_id, Some("parent-echo".into()));
     assert_eq!(reg_resp.team_id, Some("team-echo".into()));
+    // root_agent_id must be echoed back — parent is root so root = parent's key
+    assert!(reg_resp.root_agent_id.is_some());
+    assert_eq!(reg_resp.root_agent_id.as_deref().unwrap().len(), 16);
 }
 
 #[tokio::test]

--- a/aa-gateway/tests/lifecycle_service_test.rs
+++ b/aa-gateway/tests/lifecycle_service_test.rs
@@ -564,3 +564,114 @@ async fn register_without_topology_returns_none_echo_fields() {
     assert_eq!(reg_resp.parent_agent_id, None);
     assert_eq!(reg_resp.team_id, None, "empty team_id must normalize to None");
 }
+
+// ── root_agent_id computation (AAASM-1005) ────────────────────────────────
+
+#[tokio::test]
+async fn root_agent_id_for_root_agent_is_set_to_self() {
+    let (addr, _registry) = start_server().await;
+    let mut client = AgentLifecycleServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let agent_proto_id = ProtoAgentId {
+        org_id: "root-org".into(),
+        team_id: "root-team".into(),
+        agent_id: "root-agent-A".into(),
+    };
+    let expected_key = aa_gateway::registry::convert::proto_agent_id_to_key(&agent_proto_id);
+
+    let resp = client
+        .register(RegisterRequest {
+            agent_id: Some(agent_proto_id),
+            name: "root-A".into(),
+            framework: "custom".into(),
+            version: "1.0.0".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key: test_ed25519_public_key_hex(),
+            metadata: Default::default(),
+            ..Default::default()
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    let echoed = resp.root_agent_id.expect("root agent must receive root_agent_id");
+    assert_eq!(echoed.as_slice(), expected_key.as_slice(), "root agent's root_agent_id must equal its own key");
+}
+
+#[tokio::test]
+async fn root_agent_id_chains_3_levels() {
+    let (addr, _registry) = start_server().await;
+    let mut client = AgentLifecycleServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let org = "chain-org";
+    let team = "chain-team";
+
+    // Register A (root).
+    let proto_a = ProtoAgentId { org_id: org.into(), team_id: team.into(), agent_id: "agent-A".into() };
+    let key_a = aa_gateway::registry::convert::proto_agent_id_to_key(&proto_a);
+    client.register(RegisterRequest {
+        agent_id: Some(proto_a), name: "A".into(), framework: "custom".into(),
+        version: "1.0.0".into(), risk_tier: 0, tool_names: vec![],
+        public_key: test_ed25519_public_key_hex(), metadata: Default::default(),
+        ..Default::default()
+    }).await.unwrap();
+
+    // Register B (parent = A).
+    let proto_b = ProtoAgentId { org_id: org.into(), team_id: team.into(), agent_id: "agent-B".into() };
+    client.register(RegisterRequest {
+        agent_id: Some(proto_b), name: "B".into(), framework: "custom".into(),
+        version: "1.0.0".into(), risk_tier: 0, tool_names: vec![],
+        public_key: test_ed25519_public_key_hex(), metadata: Default::default(),
+        parent_agent_id: Some("agent-A".into()),
+        ..Default::default()
+    }).await.unwrap();
+
+    // Register C (parent = B). C's root_agent_id must equal A's key.
+    let proto_c = ProtoAgentId { org_id: org.into(), team_id: team.into(), agent_id: "agent-C".into() };
+    let resp_c = client.register(RegisterRequest {
+        agent_id: Some(proto_c), name: "C".into(), framework: "custom".into(),
+        version: "1.0.0".into(), risk_tier: 0, tool_names: vec![],
+        public_key: test_ed25519_public_key_hex(), metadata: Default::default(),
+        parent_agent_id: Some("agent-B".into()),
+        ..Default::default()
+    }).await.unwrap().into_inner();
+
+    let c_root = resp_c.root_agent_id.expect("C must receive root_agent_id");
+    assert_eq!(c_root.as_slice(), key_a.as_slice(), "C's root_agent_id must chain back to A");
+}
+
+#[tokio::test]
+async fn root_agent_id_when_parent_unknown_returns_invalid_argument() {
+    let (addr, _registry) = start_server().await;
+    let mut client = AgentLifecycleServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let err = client
+        .register(RegisterRequest {
+            agent_id: Some(ProtoAgentId {
+                org_id: "unknown-org".into(),
+                team_id: "unknown-team".into(),
+                agent_id: "orphan-B".into(),
+            }),
+            name: "orphan".into(),
+            framework: "custom".into(),
+            version: "1.0.0".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key: test_ed25519_public_key_hex(),
+            metadata: Default::default(),
+            parent_agent_id: Some("does-not-exist".into()),
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    assert!(err.message().contains("parent_agent_id not found"), "error must name the problem: {}", err.message());
+}

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -303,6 +303,7 @@ budget:
         depth: 0,
         delegation_reason: None,
         spawned_by_tool: None,
+        root_agent_id: None,
     };
     engine.record_spend(&agent_ctx, 2.0); // exceeds $1.0 daily limit
 
@@ -388,6 +389,7 @@ budget:
         depth: 0,
         delegation_reason: None,
         spawned_by_tool: None,
+        root_agent_id: None,
     };
     engine.record_spend(&agent_ctx, 2.0);
 

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -286,6 +286,7 @@ budget:
         depth: 0,
         delegation_reason: None,
         spawned_by_tool: None,
+        root_agent_id: None,
     };
     registry.register(record).unwrap();
 
@@ -374,6 +375,7 @@ budget:
         depth: 0,
         delegation_reason: None,
         spawned_by_tool: None,
+        root_agent_id: None,
     };
     registry.register(record).unwrap();
 
@@ -480,6 +482,7 @@ fn level_test_record(
         depth: 0,
         delegation_reason: None,
         spawned_by_tool: None,
+        root_agent_id: None,
     }
 }
 

--- a/aa-gateway/tests/registry_test.rs
+++ b/aa-gateway/tests/registry_test.rs
@@ -424,3 +424,14 @@ fn root_agent_topology_fields_default_to_none_and_zero() {
     assert!(retrieved.delegation_reason.is_none());
     assert!(retrieved.spawned_by_tool.is_none());
 }
+
+#[test]
+fn root_agent_id_field_round_trips_through_registry() {
+    let reg = AgentRegistry::new();
+    let mut record = make_record(key(5));
+    record.root_agent_id = Some([0xAA; 16]);
+    reg.register(record).unwrap();
+
+    let retrieved = reg.get(&key(5)).unwrap();
+    assert_eq!(retrieved.root_agent_id, Some([0xAA; 16]));
+}

--- a/aa-gateway/tests/registry_test.rs
+++ b/aa-gateway/tests/registry_test.rs
@@ -36,6 +36,7 @@ fn make_record(key: [u8; 16]) -> AgentRecord {
         depth: 0,
         delegation_reason: None,
         spawned_by_tool: None,
+        root_agent_id: None,
     }
 }
 
@@ -237,6 +238,7 @@ async fn concurrent_registration_of_100_agents() {
                 depth: 0,
                 delegation_reason: None,
                 spawned_by_tool: None,
+                root_agent_id: None,
             };
             reg.register(record).unwrap();
         }));

--- a/proto/agent.proto
+++ b/proto/agent.proto
@@ -67,7 +67,11 @@ message RegisterResponse {
   optional string parent_agent_id        = 4;
   // Echo of the `team_id` from the request's `AgentId` — confirms the gateway accepted team scoping.
   optional string team_id                = 5;
-  // next: 6
+  // Computed root of the delegation chain — server-side authoritative value.
+  // For root agents equals the registering agent's own UUID bytes.
+  // For sub-agents equals parent.root_agent_id (propagated transitively).
+  optional bytes  root_agent_id          = 6;
+  // next: 7
 }
 
 // ── Heartbeat ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

Adds the 6th lineage field `root_agent_id` to `AgentContext` (aa-core) and `AgentRecord` (aa-gateway), computes it server-side at registration, and echoes it back in `RegisterResponse`.

**Stacked on:** `v0.0.1/AAASM-931/wire_topology_to_registration` → `v0.0.1/AAASM-929/add_topology_fields` — the diff is cleanest once those PRs merge.

**Design:**
- Root agents: `root_agent_id = Some(self.agent_id)` (set automatically)
- Sub-agents: `root_agent_id = parent.root_agent_id.unwrap_or(parent.agent_id)` — O(1), no chain walk
- Registration is rejected with `INVALID_ARGUMENT` if `parent_agent_id` is declared but the parent is not in the registry (no silent NULL)

**4 commits:**
1. `✨ (aa-core): Add root_agent_id field to AgentContext and AgentContextBuilder` — adds `pub root_agent_id: Option<AgentId>` with serde `skip_serializing_if + default`; builder setter; updates all 6 struct literal call sites and serde backward-compat tests.
2. `✨ (aa-gateway): Add root_agent_id field to AgentRecord in registry` — adds `pub root_agent_id: Option<[u8; 16]>` with O(1) doc comment; updates all 6 struct literal call sites.
3. `✨ (aa-gateway): Compute root_agent_id server-side at registration` — adds `optional bytes root_agent_id = 6` to `RegisterResponse` proto; implements root computation logic in `lifecycle_service.register()`; echoes value back to client.
4. `✅ (aa-gateway): Add root_agent_id tests — self, chain, unknown-parent` — 4 tests covering AC: root_agent_id_for_root_agent_is_set_to_self, root_agent_id_chains_3_levels, root_agent_id_when_parent_unknown_returns_invalid_argument, root_agent_id_field_round_trips_through_registry.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1005 (part of Story AAASM-207, Epic AAASM-197)
- Depends on: AAASM-929 (AgentContext topology fields), AAASM-931 (AgentRecord topology fields)

## Testing

- [x] Unit tests added — `registry_test::root_agent_id_field_round_trips_through_registry`
- [x] Integration tests added — `root_agent_id_for_root_agent_is_set_to_self`, `root_agent_id_chains_3_levels`, `root_agent_id_when_parent_unknown_returns_invalid_argument`
- [x] 690 tests pass across aa-core, aa-gateway, aa-api

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention