### PR TITLE
[AAASM-932] ✨ (aa-cli/run): Add adapter resolution + detect-or-error flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,7 @@ dependencies = [
  "aa-core",
  "aa-gateway",
  "anyhow",
+ "async-trait",
  "chrono",
  "clap",
  "clap_complete",

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 aa-core        = { path = "../aa-core" }
 aa-gateway     = { path = "../aa-gateway" }
 anyhow         = "1"
+async-trait    = "0.1"
 chrono         = { version = "0.4", features = ["serde"] }
 clap           = { version = "4", features = ["derive"] }
 clap_complete  = "4"

--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -1,11 +1,13 @@
 //! `aasm run` — launch an AI dev tool with governance wiring.
 
+use std::collections::HashMap;
 use std::process::ExitCode;
 
 use anyhow::Result;
+use async_trait::async_trait;
 use clap::Args;
 
-use aa_core::GovernanceLevel;
+use aa_core::{AdapterError, DevToolAdapter, DevToolInfo, GovernanceLevel, McpServerInfo, PolicyDocument};
 
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
@@ -45,9 +47,106 @@ pub struct RunArgs {
     pub dry_run: bool,
 }
 
+// Placeholder until per-tool adapter crates (AAASM-201..205) are ready.
+// Each of the four known tools maps to this struct; replace individual arms
+// in resolve_adapter() when the real crate lands.
+struct PlaceholderAdapter;
+
+#[async_trait]
+impl DevToolAdapter for PlaceholderAdapter {
+    fn detect(&self) -> Option<DevToolInfo> {
+        None
+    }
+
+    async fn generate_managed_settings(&self, _policy: &PolicyDocument) -> Result<String, AdapterError> {
+        Err(AdapterError::SettingsGenerationFailed(
+            "adapter not yet implemented".into(),
+        ))
+    }
+
+    async fn apply_settings(&self, _settings: &str) -> Result<(), AdapterError> {
+        Err(AdapterError::SettingsApplyFailed(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "adapter not yet implemented",
+        )))
+    }
+
+    fn build_launch_command(
+        &self,
+        _tool_args: &[String],
+        _agent_id: &str,
+        _team_id: Option<&str>,
+        _proxy_addr: Option<&str>,
+    ) -> Result<std::process::Command, AdapterError> {
+        Err(AdapterError::LaunchFailed("adapter not yet implemented".into()))
+    }
+
+    async fn list_mcp_servers(&self) -> Result<Vec<McpServerInfo>, AdapterError> {
+        Ok(vec![])
+    }
+
+    async fn apply_mcp_governance(&self, _allowed: &[String], _denied: &[String]) -> Result<(), AdapterError> {
+        Ok(())
+    }
+
+    fn governance_level(&self) -> GovernanceLevel {
+        GovernanceLevel::L0Discover
+    }
+}
+
+/// Return the adapter for `tool`, or an error for unrecognised tool names.
+///
+/// Maps the four supported tool names to their adapter implementations.
+/// Returns [`Err`] with a human-readable message for any other value so the
+/// CLI can surface a clean "unknown tool" error before touching the filesystem.
+fn resolve_adapter(tool: &str) -> Result<Box<dyn DevToolAdapter>> {
+    match tool {
+        // Real adapters replace PlaceholderAdapter here once their crates land.
+        "claude" => Ok(Box::new(PlaceholderAdapter)),
+        "codex" => Ok(Box::new(PlaceholderAdapter)),
+        "copilot" => Ok(Box::new(PlaceholderAdapter)),
+        "windsurf" => Ok(Box::new(PlaceholderAdapter)),
+        _ => Err(anyhow::anyhow!(
+            "unknown tool: {tool}, supported: claude, codex, copilot, windsurf"
+        )),
+    }
+}
+
+/// Testable core of `execute`: look up the adapter, run detection, print summary.
+///
+/// Accepts an explicit adapter map so tests can inject stubs without touching
+/// the filesystem or requiring real tool binaries.
+async fn execute_with_adapters(args: &RunArgs, adapters: &HashMap<&str, Box<dyn DevToolAdapter>>) -> Result<()> {
+    let adapter = adapters.get(args.tool.as_str()).ok_or_else(|| {
+        anyhow::anyhow!(
+            "unknown tool: {}, supported: claude, codex, copilot, windsurf",
+            args.tool
+        )
+    })?;
+
+    let info = adapter
+        .detect()
+        .ok_or_else(|| anyhow::anyhow!("{} is not installed", args.tool))?;
+
+    eprintln!(
+        "tool={} version={} path={} governance_level={}",
+        args.tool,
+        info.version.as_deref().unwrap_or("unknown"),
+        info.install_path.display(),
+        info.governance_level,
+    );
+
+    // Subsequent subtasks (AAASM-935+) add registration and exec here.
+    Ok(())
+}
+
 /// Launch the specified AI dev tool with governance wiring.
-pub async fn execute(_args: RunArgs, _ctx: &ResolvedContext) -> Result<()> {
-    Err(anyhow::anyhow!("not yet implemented"))
+pub async fn execute(args: RunArgs, _ctx: &ResolvedContext) -> Result<()> {
+    let mut adapters: HashMap<&str, Box<dyn DevToolAdapter>> = HashMap::new();
+    for tool in ["claude", "codex", "copilot", "windsurf"] {
+        adapters.insert(tool, resolve_adapter(tool)?);
+    }
+    execute_with_adapters(&args, &adapters).await
 }
 
 /// Entry point for `aasm run`.
@@ -64,8 +163,12 @@ pub fn dispatch(args: RunArgs, ctx: &ResolvedContext, _output: OutputFormat) -> 
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::path::PathBuf;
+
+    use aa_core::{DevToolInfo, DevToolKind};
     use clap::Parser;
+
+    use super::*;
 
     /// Minimal CLI wrapper for testing `run` subcommand parsing.
     #[derive(Parser)]
@@ -79,6 +182,8 @@ mod tests {
     enum TestCommands {
         Run(RunArgs),
     }
+
+    // --- parse tests (carried forward from AAASM-927) ---
 
     #[test]
     fn parse_basic_run_command() {
@@ -131,5 +236,165 @@ mod tests {
                 }
             }
         }
+    }
+
+    // --- adapter resolution tests ---
+
+    #[test]
+    fn unknown_tool_errors() {
+        // Box<dyn DevToolAdapter> is not Debug, so use match instead of unwrap_err().
+        let err = match resolve_adapter("notathing") {
+            Ok(_) => panic!("expected Err for unknown tool"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().contains("unknown tool"),
+            "expected 'unknown tool' in error, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("notathing"),
+            "expected tool name in error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn known_tools_resolve_without_error() {
+        for tool in ["claude", "codex", "copilot", "windsurf"] {
+            assert!(resolve_adapter(tool).is_ok(), "resolve_adapter({tool}) should succeed");
+        }
+    }
+
+    // --- execute_with_adapters tests ---
+
+    /// Stub adapter whose detect() always returns None (tool not installed).
+    struct StubNotInstalled;
+
+    #[async_trait]
+    impl DevToolAdapter for StubNotInstalled {
+        fn detect(&self) -> Option<DevToolInfo> {
+            None
+        }
+        async fn generate_managed_settings(&self, _p: &PolicyDocument) -> Result<String, AdapterError> {
+            unimplemented!()
+        }
+        async fn apply_settings(&self, _s: &str) -> Result<(), AdapterError> {
+            unimplemented!()
+        }
+        fn build_launch_command(
+            &self,
+            _a: &[String],
+            _b: &str,
+            _c: Option<&str>,
+            _d: Option<&str>,
+        ) -> Result<std::process::Command, AdapterError> {
+            unimplemented!()
+        }
+        async fn list_mcp_servers(&self) -> Result<Vec<McpServerInfo>, AdapterError> {
+            unimplemented!()
+        }
+        async fn apply_mcp_governance(&self, _a: &[String], _d: &[String]) -> Result<(), AdapterError> {
+            unimplemented!()
+        }
+        fn governance_level(&self) -> GovernanceLevel {
+            GovernanceLevel::L0Discover
+        }
+    }
+
+    /// Stub adapter whose detect() returns a synthetic DevToolInfo.
+    struct StubDetected {
+        version: Option<String>,
+    }
+
+    #[async_trait]
+    impl DevToolAdapter for StubDetected {
+        fn detect(&self) -> Option<DevToolInfo> {
+            Some(DevToolInfo {
+                kind: DevToolKind::ClaudeCode,
+                version: self.version.clone(),
+                install_path: PathBuf::from("/usr/local/bin/claude"),
+                governance_level: GovernanceLevel::L2Enforce,
+                supports_mcp: true,
+                supports_managed_settings: true,
+            })
+        }
+        async fn generate_managed_settings(&self, _p: &PolicyDocument) -> Result<String, AdapterError> {
+            unimplemented!()
+        }
+        async fn apply_settings(&self, _s: &str) -> Result<(), AdapterError> {
+            unimplemented!()
+        }
+        fn build_launch_command(
+            &self,
+            _a: &[String],
+            _b: &str,
+            _c: Option<&str>,
+            _d: Option<&str>,
+        ) -> Result<std::process::Command, AdapterError> {
+            unimplemented!()
+        }
+        async fn list_mcp_servers(&self) -> Result<Vec<McpServerInfo>, AdapterError> {
+            unimplemented!()
+        }
+        async fn apply_mcp_governance(&self, _a: &[String], _d: &[String]) -> Result<(), AdapterError> {
+            unimplemented!()
+        }
+        fn governance_level(&self) -> GovernanceLevel {
+            GovernanceLevel::L2Enforce
+        }
+    }
+
+    fn run_args(tool: &str) -> RunArgs {
+        RunArgs {
+            tool: tool.to_string(),
+            tool_args: vec![],
+            agent_id: None,
+            team_id: None,
+            root_agent: None,
+            governance_level: None,
+            no_proxy: false,
+            dry_run: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_not_found_errors() {
+        let mut adapters: HashMap<&str, Box<dyn DevToolAdapter>> = HashMap::new();
+        adapters.insert("claude", Box::new(StubNotInstalled));
+
+        let err = execute_with_adapters(&run_args("claude"), &adapters).await.unwrap_err();
+        assert!(
+            err.to_string().contains("is not installed"),
+            "expected 'is not installed' in error, got: {err}"
+        );
+        assert!(
+            err.to_string().contains("claude"),
+            "expected tool name in error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn detected_tool_succeeds() {
+        let mut adapters: HashMap<&str, Box<dyn DevToolAdapter>> = HashMap::new();
+        adapters.insert(
+            "claude",
+            Box::new(StubDetected {
+                version: Some("1.2.3".into()),
+            }),
+        );
+
+        assert!(
+            execute_with_adapters(&run_args("claude"), &adapters).await.is_ok(),
+            "execute_with_adapters should succeed when detect() returns Some"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_in_adapters_errors() {
+        let adapters: HashMap<&str, Box<dyn DevToolAdapter>> = HashMap::new();
+
+        let err = execute_with_adapters(&run_args("notathing"), &adapters)
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("unknown tool"), "got: {err}");
     }
 }


### PR DESCRIPTION
## What changed

Implements the first half of `run::execute()` per AAASM-932:

- **`resolve_adapter(tool)`** — maps `claude`, `codex`, `copilot`, `windsurf` to `PlaceholderAdapter` (replaced per-tool once adapter crates land, AAASM-201..205); returns `Err("unknown tool: ...")` for anything else
- **`execute_with_adapters(args, adapters)`** — testable core: looks up the adapter in the map, calls `detect()`, errors with `"{tool} is not installed"` on `None`, prints detection summary to stderr (`tool=… version=… path=… governance_level=…`), then returns `Ok(())` (registration/launch added in AAASM-935+)
- **`execute()`** — builds the production adapter map from `resolve_adapter` and delegates to `execute_with_adapters`
- **`PlaceholderAdapter`** — implements `DevToolAdapter` with `detect() → None` until per-tool crates are ready
- **`async-trait = "0.1"`** added to `aa-cli/Cargo.toml` (required to implement `DevToolAdapter` in test stubs)

## Why it changed

AAASM-932: complete the detect-and-error step of the `aasm run` launcher before wiring in registration and exec in subsequent subtasks.

## How to verify

```
cargo test -p aa-cli commands::run::
# 8 tests pass: 3 parse tests (from AAASM-927) + 5 new adapter/detect tests
```

Closes AAASM-932

Related: AAASM-200 (parent story), AAASM-927 (previous subtask)