### PR TITLE
[AAASM-935] ✨ (aa-cli/run): Add gateway registration + env-var injection

### DIFF
--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -35,7 +35,7 @@ thiserror      = "2"
 tokio          = { version = "1", features = ["full"] }
 tokio-tungstenite = { version = "0.26", features = ["rustls-tls-native-roots"] }
 url            = "2"
-uuid           = { version = "1", features = ["serde"] }
+uuid           = { version = "1", features = ["serde", "v4"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -6,8 +6,10 @@ use std::process::ExitCode;
 use anyhow::Result;
 use async_trait::async_trait;
 use clap::Args;
+use serde::Deserialize;
+use uuid::Uuid;
 
-use aa_core::{AdapterError, DevToolAdapter, DevToolInfo, GovernanceLevel, McpServerInfo, PolicyDocument};
+use aa_core::{AdapterError, DevToolAdapter, DevToolInfo, DevToolKind, GovernanceLevel, McpServerInfo, PolicyDocument};
 
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
@@ -94,11 +96,107 @@ impl DevToolAdapter for PlaceholderAdapter {
     }
 }
 
-/// Return the adapter for `tool`, or an error for unrecognised tool names.
+/// Convert a [`DevToolKind`] to the snake_case string sent in the registration request body.
+fn dev_tool_kind_str(kind: &DevToolKind) -> String {
+    match kind {
+        DevToolKind::ClaudeCode => "claude_code".into(),
+        DevToolKind::Codex => "codex".into(),
+        DevToolKind::GitHubCopilot => "github_copilot".into(),
+        DevToolKind::WindsurfCascade => "windsurf_cascade".into(),
+        DevToolKind::Custom(s) => s.clone(),
+    }
+}
+
+/// Gateway registration result for a single `aasm run` session.
+struct RegistrationHandle {
+    agent_id: String,
+    registration_id: String,
+    trace_id: String,
+    session_id: String,
+    proxy_addr: Option<String>,
+    /// Carried from [`RunArgs::team_id`] (or echoed by the gateway) for `AA_TEAM_ID` injection.
+    team_id: Option<String>,
+}
+
+/// Register the detected tool with the Agent Assembly gateway.
 ///
-/// Maps the four supported tool names to their adapter implementations.
-/// Returns [`Err`] with a human-readable message for any other value so the
-/// CLI can surface a clean "unknown tool" error before touching the filesystem.
+/// POSTs `{kind, version, agent_id, team_id, root_agent, governance_level}` to
+/// `POST {ctx.api_url}/api/v1/agents`. UUIDs are generated locally for any
+/// identity fields the gateway omits from its response.
+async fn register_with_gateway(
+    info: &DevToolInfo,
+    args: &RunArgs,
+    ctx: &ResolvedContext,
+) -> Result<RegistrationHandle> {
+    let agent_id = args.agent_id.clone().unwrap_or_else(|| Uuid::new_v4().to_string());
+
+    let body = serde_json::json!({
+        "kind": dev_tool_kind_str(&info.kind),
+        "version": info.version.as_deref().unwrap_or("unknown"),
+        "agent_id": &agent_id,
+        "team_id": args.team_id,
+        "root_agent": args.root_agent,
+        "governance_level": info.governance_level.to_string(),
+    });
+
+    let url = format!("{}/api/v1/agents", ctx.api_url.trim_end_matches('/'));
+    let client = reqwest::Client::new();
+    let mut req = client.post(&url).json(&body);
+    if let Some(ref key) = ctx.api_key {
+        req = req.header("Authorization", format!("Bearer {key}"));
+    }
+
+    let resp = req.send().await?;
+    if !resp.status().is_success() {
+        return Err(anyhow::anyhow!("gateway registration failed: HTTP {}", resp.status()));
+    }
+
+    #[derive(Deserialize)]
+    struct RegisterResponse {
+        agent_id: Option<String>,
+        registration_id: Option<String>,
+        trace_id: Option<String>,
+        session_id: Option<String>,
+        proxy_addr: Option<String>,
+        team_id: Option<String>,
+    }
+
+    let reg: RegisterResponse = resp.json().await?;
+
+    Ok(RegistrationHandle {
+        agent_id: reg.agent_id.unwrap_or(agent_id),
+        registration_id: reg.registration_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
+        trace_id: reg.trace_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
+        session_id: reg.session_id.unwrap_or_else(|| Uuid::new_v4().to_string()),
+        proxy_addr: reg.proxy_addr,
+        team_id: reg.team_id.or_else(|| args.team_id.clone()),
+    })
+}
+
+/// Build the environment map to be inherited by the child process.
+///
+/// Starts from the current process environment, then overlays governance
+/// identity variables. `HTTPS_PROXY` / `HTTP_PROXY` are only injected when
+/// `handle.proxy_addr` is set and `no_proxy` is `false`.
+fn build_child_env(handle: &RegistrationHandle, no_proxy: bool) -> HashMap<String, String> {
+    let mut env: HashMap<String, String> = std::env::vars().collect();
+    env.insert("AA_AGENT_ID".into(), handle.agent_id.clone());
+    env.insert("AA_TRACE_ID".into(), handle.trace_id.clone());
+    env.insert("AA_SESSION_ID".into(), handle.session_id.clone());
+    env.insert("AA_REGISTRATION_ID".into(), handle.registration_id.clone());
+    if let Some(ref team_id) = handle.team_id {
+        env.insert("AA_TEAM_ID".into(), team_id.clone());
+    }
+    if let Some(ref proxy) = handle.proxy_addr {
+        if !no_proxy {
+            env.insert("HTTPS_PROXY".into(), proxy.clone());
+            env.insert("HTTP_PROXY".into(), proxy.clone());
+        }
+    }
+    env
+}
+
+/// Return the adapter for `tool`, or an error for unrecognised tool names.
 fn resolve_adapter(tool: &str) -> Result<Box<dyn DevToolAdapter>> {
     match tool {
         // Real adapters replace PlaceholderAdapter here once their crates land.
@@ -112,11 +210,12 @@ fn resolve_adapter(tool: &str) -> Result<Box<dyn DevToolAdapter>> {
     }
 }
 
-/// Testable core of `execute`: look up the adapter, run detection, print summary.
-///
-/// Accepts an explicit adapter map so tests can inject stubs without touching
-/// the filesystem or requiring real tool binaries.
-async fn execute_with_adapters(args: &RunArgs, adapters: &HashMap<&str, Box<dyn DevToolAdapter>>) -> Result<()> {
+/// Testable core of `execute`: detect, register, build env, stop before exec.
+async fn execute_with_adapters(
+    args: &RunArgs,
+    ctx: &ResolvedContext,
+    adapters: &HashMap<&str, Box<dyn DevToolAdapter>>,
+) -> Result<()> {
     let adapter = adapters.get(args.tool.as_str()).ok_or_else(|| {
         anyhow::anyhow!(
             "unknown tool: {}, supported: claude, codex, copilot, windsurf",
@@ -136,17 +235,20 @@ async fn execute_with_adapters(args: &RunArgs, adapters: &HashMap<&str, Box<dyn 
         info.governance_level,
     );
 
-    // Subsequent subtasks (AAASM-935+) add registration and exec here.
+    let handle = register_with_gateway(&info, args, ctx).await?;
+    let _child_env = build_child_env(&handle, args.no_proxy);
+
+    // AAASM-937 execs the child process using _child_env.
     Ok(())
 }
 
 /// Launch the specified AI dev tool with governance wiring.
-pub async fn execute(args: RunArgs, _ctx: &ResolvedContext) -> Result<()> {
+pub async fn execute(args: RunArgs, ctx: &ResolvedContext) -> Result<()> {
     let mut adapters: HashMap<&str, Box<dyn DevToolAdapter>> = HashMap::new();
     for tool in ["claude", "codex", "copilot", "windsurf"] {
         adapters.insert(tool, resolve_adapter(tool)?);
     }
-    execute_with_adapters(&args, &adapters).await
+    execute_with_adapters(&args, ctx, &adapters).await
 }
 
 /// Entry point for `aasm run`.
@@ -167,6 +269,8 @@ mod tests {
 
     use aa_core::{DevToolInfo, DevToolKind};
     use clap::Parser;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     use super::*;
 
@@ -242,7 +346,6 @@ mod tests {
 
     #[test]
     fn unknown_tool_errors() {
-        // Box<dyn DevToolAdapter> is not Debug, so use match instead of unwrap_err().
         let err = match resolve_adapter("notathing") {
             Ok(_) => panic!("expected Err for unknown tool"),
             Err(e) => e,
@@ -264,9 +367,134 @@ mod tests {
         }
     }
 
+    // --- build_child_env tests ---
+
+    fn stub_handle(proxy_addr: Option<&str>, team_id: Option<&str>) -> RegistrationHandle {
+        RegistrationHandle {
+            agent_id: "test-agent".into(),
+            registration_id: "test-reg".into(),
+            trace_id: "test-trace".into(),
+            session_id: "test-session".into(),
+            proxy_addr: proxy_addr.map(String::from),
+            team_id: team_id.map(String::from),
+        }
+    }
+
+    #[test]
+    fn build_child_env_sets_proxy() {
+        let handle = stub_handle(Some("http://proxy:8080"), None);
+        let env = build_child_env(&handle, false);
+        assert_eq!(
+            env.get("HTTPS_PROXY").map(String::as_str),
+            Some("http://proxy:8080"),
+            "HTTPS_PROXY should be set"
+        );
+        assert_eq!(
+            env.get("HTTP_PROXY").map(String::as_str),
+            Some("http://proxy:8080"),
+            "HTTP_PROXY should be set"
+        );
+        assert_eq!(env.get("AA_AGENT_ID").map(String::as_str), Some("test-agent"));
+        assert_eq!(env.get("AA_TRACE_ID").map(String::as_str), Some("test-trace"));
+        assert_eq!(env.get("AA_SESSION_ID").map(String::as_str), Some("test-session"));
+        assert_eq!(env.get("AA_REGISTRATION_ID").map(String::as_str), Some("test-reg"));
+    }
+
+    #[test]
+    fn build_child_env_skips_proxy_when_no_proxy() {
+        let handle = stub_handle(Some("http://proxy:8080"), None);
+        let env = build_child_env(&handle, true);
+        assert!(
+            !env.contains_key("HTTPS_PROXY"),
+            "HTTPS_PROXY must not be set when no_proxy=true"
+        );
+        assert!(
+            !env.contains_key("HTTP_PROXY"),
+            "HTTP_PROXY must not be set when no_proxy=true"
+        );
+    }
+
+    #[test]
+    fn build_child_env_sets_team_id_when_present() {
+        let handle = stub_handle(None, Some("my-team"));
+        let env = build_child_env(&handle, false);
+        assert_eq!(env.get("AA_TEAM_ID").map(String::as_str), Some("my-team"));
+    }
+
+    #[test]
+    fn build_child_env_omits_team_id_when_absent() {
+        let handle = stub_handle(None, None);
+        let env = build_child_env(&handle, false);
+        assert!(
+            !env.contains_key("AA_TEAM_ID"),
+            "AA_TEAM_ID must not be set when team_id is None"
+        );
+    }
+
+    // --- register_with_gateway tests ---
+
+    #[tokio::test]
+    async fn register_with_gateway_posts_correct_body() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/agents"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "agent_id": "gw-agent-id",
+                "registration_id": "gw-reg-id",
+                "trace_id": "gw-trace-id",
+                "session_id": "gw-session-id",
+                "proxy_addr": "http://gw-proxy:9090"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let info = DevToolInfo {
+            kind: DevToolKind::ClaudeCode,
+            version: Some("1.2.3".into()),
+            install_path: PathBuf::from("/usr/local/bin/claude"),
+            governance_level: GovernanceLevel::L2Enforce,
+            supports_mcp: true,
+            supports_managed_settings: true,
+        };
+        let args = RunArgs {
+            tool: "claude".into(),
+            tool_args: vec![],
+            agent_id: Some("my-agent".into()),
+            team_id: Some("my-team".into()),
+            root_agent: None,
+            governance_level: None,
+            no_proxy: false,
+            dry_run: false,
+        };
+        let ctx = ResolvedContext {
+            name: None,
+            api_url: mock_server.uri(),
+            api_key: None,
+        };
+
+        let handle = register_with_gateway(&info, &args, &ctx).await.unwrap();
+
+        assert_eq!(handle.agent_id, "gw-agent-id");
+        assert_eq!(handle.registration_id, "gw-reg-id");
+        assert_eq!(handle.trace_id, "gw-trace-id");
+        assert_eq!(handle.session_id, "gw-session-id");
+        assert_eq!(handle.proxy_addr.as_deref(), Some("http://gw-proxy:9090"));
+        assert_eq!(handle.team_id.as_deref(), Some("my-team"));
+
+        // Verify the request body shape
+        let reqs = mock_server.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 1, "expected exactly one POST request");
+        let body: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+        assert_eq!(body["kind"], "claude_code");
+        assert_eq!(body["version"], "1.2.3");
+        assert_eq!(body["agent_id"], "my-agent");
+        assert_eq!(body["team_id"], "my-team");
+        assert_eq!(body["governance_level"], "L2Enforce");
+    }
+
     // --- execute_with_adapters tests ---
 
-    /// Stub adapter whose detect() always returns None (tool not installed).
     struct StubNotInstalled;
 
     #[async_trait]
@@ -300,7 +528,6 @@ mod tests {
         }
     }
 
-    /// Stub adapter whose detect() returns a synthetic DevToolInfo.
     struct StubDetected {
         version: Option<String>,
     }
@@ -356,12 +583,22 @@ mod tests {
         }
     }
 
+    fn dummy_ctx() -> ResolvedContext {
+        ResolvedContext {
+            name: None,
+            api_url: "http://localhost:8080".into(),
+            api_key: None,
+        }
+    }
+
     #[tokio::test]
     async fn tool_not_found_errors() {
         let mut adapters: HashMap<&str, Box<dyn DevToolAdapter>> = HashMap::new();
         adapters.insert("claude", Box::new(StubNotInstalled));
 
-        let err = execute_with_adapters(&run_args("claude"), &adapters).await.unwrap_err();
+        let err = execute_with_adapters(&run_args("claude"), &dummy_ctx(), &adapters)
+            .await
+            .unwrap_err();
         assert!(
             err.to_string().contains("is not installed"),
             "expected 'is not installed' in error, got: {err}"
@@ -374,6 +611,19 @@ mod tests {
 
     #[tokio::test]
     async fn detected_tool_succeeds() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/agents"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "agent_id": "a1",
+                "registration_id": "r1",
+                "trace_id": "t1",
+                "session_id": "s1",
+                "proxy_addr": null
+            })))
+            .mount(&mock_server)
+            .await;
+
         let mut adapters: HashMap<&str, Box<dyn DevToolAdapter>> = HashMap::new();
         adapters.insert(
             "claude",
@@ -381,10 +631,17 @@ mod tests {
                 version: Some("1.2.3".into()),
             }),
         );
+        let ctx = ResolvedContext {
+            name: None,
+            api_url: mock_server.uri(),
+            api_key: None,
+        };
 
         assert!(
-            execute_with_adapters(&run_args("claude"), &adapters).await.is_ok(),
-            "execute_with_adapters should succeed when detect() returns Some"
+            execute_with_adapters(&run_args("claude"), &ctx, &adapters)
+                .await
+                .is_ok(),
+            "execute_with_adapters should succeed when detect() returns Some and gateway responds 201"
         );
     }
 
@@ -392,7 +649,7 @@ mod tests {
     async fn unknown_tool_in_adapters_errors() {
         let adapters: HashMap<&str, Box<dyn DevToolAdapter>> = HashMap::new();
 
-        let err = execute_with_adapters(&run_args("notathing"), &adapters)
+        let err = execute_with_adapters(&run_args("notathing"), &dummy_ctx(), &adapters)
             .await
             .unwrap_err();
         assert!(err.to_string().contains("unknown tool"), "got: {err}");


### PR DESCRIPTION
## What changed

Implements AAASM-935 — gateway registration and env-var preparation for the \`aasm run\` launcher:

- **\`register_with_gateway(info, args, ctx)\`** — POSTs \`{kind, version, agent_id, team_id, root_agent, governance_level}\` to \`POST /api/v1/agents\`; generates UUID v4 locally for any identity fields the gateway omits; adds \`Authorization: Bearer\` header when \`ctx.api_key\` is set
- **\`build_child_env(handle, no_proxy)\`** — inherits \`std::env::vars()\`, then overlays \`AA_AGENT_ID\`, \`AA_TRACE_ID\`, \`AA_SESSION_ID\`, \`AA_REGISTRATION_ID\`, \`AA_TEAM_ID\` (when set), \`HTTPS_PROXY\`/\`HTTP_PROXY\` (when \`proxy_addr\` is \`Some\` and \`no_proxy=false\`)
- **\`execute_with_adapters\`** — now accepts \`ctx: &ResolvedContext\`; after \`detect()\` succeeds, calls \`register_with_gateway\` and stashes \`child_env\` for AAASM-937 (process exec)
- **\`uuid\`** — added \`v4\` feature to \`Cargo.toml\`

## Why it changed

AAASM-935: complete the registration + environment setup step before the final exec subtask (AAASM-937).

## How to verify

```
cargo test -p aa-cli commands::run::
# 13 tests pass: 3 parse + 2 adapter + 4 build_child_env + 1 register_with_gateway + 3 execute_with_adapters
```

Closes AAASM-935

Related: AAASM-200 (parent story), AAASM-932 (previous subtask)