### PR TITLE
[AAASM-942] ✨ cli(run): Spawn child process + deregister on exit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,7 @@ dependencies = [
  "csv",
  "dirs",
  "futures-util",
+ "libc",
  "owo-colors",
  "ratatui",
  "reqwest",

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -25,6 +25,7 @@ console        = "0.16"
 crossterm      = "0.28"
 dirs           = "6"
 futures-util   = "0.3"
+libc           = "0.2"
 owo-colors     = "4"
 ratatui        = { version = "0.30", features = ["crossterm"] }
 reqwest        = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "blocking"] }

--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -9,6 +9,9 @@ use clap::Args;
 use serde::Deserialize;
 use uuid::Uuid;
 
+#[cfg(unix)]
+use tokio::signal::unix::SignalKind;
+
 use aa_core::{
     AdapterError, DevToolAdapter, DevToolInfo, DevToolKind, GovernanceLevel, McpServerInfo, PolicyDocument, PolicyRule,
 };
@@ -118,6 +121,49 @@ struct RegistrationHandle {
     proxy_addr: Option<String>,
     /// Carried from [`RunArgs::team_id`] (or echoed by the gateway) for `AA_TEAM_ID` injection.
     team_id: Option<String>,
+}
+
+/// RAII guard that sends a best-effort `DELETE /api/v1/agents/<registration_id>` on drop.
+///
+/// The primary deregistration path is the explicit `deregister_with_gateway` async call
+/// in `execute_with_adapters`. Set `deregistered = true` after that call to suppress the
+/// duplicate backup. The backup fires only when a panic unwinds the stack before the
+/// explicit call can run.
+pub struct RegistrationGuard {
+    registration_id: String,
+    api_url: String,
+    api_key: Option<String>,
+    /// True after `deregister_with_gateway` ran; suppresses the backup Drop.
+    pub deregistered: bool,
+}
+
+impl Drop for RegistrationGuard {
+    fn drop(&mut self) {
+        if self.deregistered {
+            return;
+        }
+        let url = format!(
+            "{}/api/v1/agents/{}",
+            self.api_url.trim_end_matches('/'),
+            self.registration_id,
+        );
+        let api_key = self.api_key.clone();
+        // Spawn a detached OS thread so we never block or create a runtime inside
+        // an existing tokio async context. Fire-and-forget: not guaranteed to reach
+        // the gateway before process termination (panic path only).
+        let _ = std::thread::spawn(move || {
+            if let Ok(rt) = tokio::runtime::Builder::new_current_thread().enable_all().build() {
+                rt.block_on(async {
+                    let client = reqwest::Client::new();
+                    let mut req = client.delete(&url);
+                    if let Some(ref key) = api_key {
+                        req = req.header("Authorization", format!("Bearer {key}"));
+                    }
+                    let _ = req.send().await;
+                });
+            }
+        });
+    }
 }
 
 /// Register the detected tool with the Agent Assembly gateway.
@@ -272,12 +318,69 @@ fn resolve_adapter(tool: &str) -> Result<Box<dyn DevToolAdapter>> {
     }
 }
 
-/// Testable core of `execute`: detect, register, apply settings, optionally dry-run.
-async fn execute_with_adapters(
+/// Send `DELETE /api/v1/agents/<registration_id>` using the async HTTP client.
+///
+/// Errors are silently discarded — the DELETE is idempotent and best-effort.
+async fn deregister_with_gateway(registration_id: &str, ctx: &ResolvedContext) {
+    let url = format!(
+        "{}/api/v1/agents/{}",
+        ctx.api_url.trim_end_matches('/'),
+        registration_id,
+    );
+    let client = reqwest::Client::new();
+    let mut req = client.delete(&url);
+    if let Some(ref key) = ctx.api_key {
+        req = req.header("Authorization", format!("Bearer {key}"));
+    }
+    let _ = req.send().await;
+}
+
+/// Spawn `cmd` as a tokio child process, forward SIGTERM/SIGINT on Unix,
+/// and wait for the child to exit. Returns the child's exit code.
+async fn spawn_and_wait(cmd: std::process::Command, child_env: &HashMap<String, String>) -> Result<i32> {
+    let mut tokio_cmd = tokio::process::Command::new(cmd.get_program());
+    tokio_cmd.args(cmd.get_args());
+    tokio_cmd.envs(child_env);
+
+    let mut child = tokio_cmd.spawn()?;
+    let child_pid = child.id().unwrap_or(0) as i32;
+
+    #[cfg(unix)]
+    let status = {
+        let mut sigterm = tokio::signal::unix::signal(SignalKind::terminate())?;
+        let mut sigint = tokio::signal::unix::signal(SignalKind::interrupt())?;
+        tokio::select! {
+            _ = sigterm.recv() => {
+                if child_pid > 0 {
+                    // Safety: child_pid is a valid pid we just spawned.
+                    unsafe { libc::kill(child_pid, libc::SIGTERM); }
+                }
+                child.wait().await?
+            }
+            _ = sigint.recv() => {
+                if child_pid > 0 {
+                    unsafe { libc::kill(child_pid, libc::SIGTERM); }
+                }
+                child.wait().await?
+            }
+            s = child.wait() => s?
+        }
+    };
+
+    #[cfg(not(unix))]
+    let status = child.wait().await?;
+
+    Ok(status.code().unwrap_or(1))
+}
+
+/// Testable core of `execute`: detect, register, apply settings, spawn child.
+///
+/// Returns the child process exit code, or 0 on `--dry-run`.
+pub async fn execute_with_adapters(
     args: &RunArgs,
     ctx: &ResolvedContext,
     adapters: &HashMap<&str, Box<dyn DevToolAdapter>>,
-) -> Result<()> {
+) -> Result<i32> {
     let adapter = adapters.get(args.tool.as_str()).ok_or_else(|| {
         anyhow::anyhow!(
             "unknown tool: {}, supported: claude, codex, copilot, windsurf",
@@ -325,15 +428,28 @@ async fn execute_with_adapters(
 
     if args.dry_run {
         print!("{}", format_dry_run_output(&handle, &settings, &cmd, &child_env));
-        return Ok(());
+        return Ok(0);
     }
 
-    // AAASM-942: exec the child process here.
-    Ok(())
+    let mut guard = RegistrationGuard {
+        registration_id: handle.registration_id.clone(),
+        api_url: ctx.api_url.clone(),
+        api_key: ctx.api_key.clone(),
+        deregistered: false,
+    };
+
+    let code = spawn_and_wait(cmd, &child_env).await?;
+
+    // Primary deregistration path — async, reliable. Mark the guard first so its
+    // Drop does not fire a duplicate request when the function returns normally.
+    guard.deregistered = true;
+    deregister_with_gateway(&handle.registration_id, ctx).await;
+
+    Ok(code)
 }
 
 /// Launch the specified AI dev tool with governance wiring.
-pub async fn execute(args: RunArgs, ctx: &ResolvedContext) -> Result<()> {
+pub async fn execute(args: RunArgs, ctx: &ResolvedContext) -> Result<i32> {
     let mut adapters: HashMap<&str, Box<dyn DevToolAdapter>> = HashMap::new();
     for tool in ["claude", "codex", "copilot", "windsurf"] {
         adapters.insert(tool, resolve_adapter(tool)?);
@@ -345,10 +461,10 @@ pub async fn execute(args: RunArgs, ctx: &ResolvedContext) -> Result<()> {
 pub fn dispatch(args: RunArgs, ctx: &ResolvedContext, _output: OutputFormat) -> ExitCode {
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     match rt.block_on(execute(args, ctx)) {
-        Ok(()) => ExitCode::SUCCESS,
+        Ok(code) => std::process::exit(code),
         Err(e) => {
             eprintln!("error: {e}");
-            ExitCode::FAILURE
+            std::process::exit(1)
         }
     }
 }

--- a/aa-cli/tests/run_command.rs
+++ b/aa-cli/tests/run_command.rs
@@ -1,0 +1,207 @@
+//! Integration tests for `aasm run`: child-process spawn + deregister on exit.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use aa_cli::commands::run::{execute_with_adapters, RunArgs};
+use aa_cli::config::ResolvedContext;
+use aa_core::{AdapterError, DevToolAdapter, DevToolInfo, DevToolKind, GovernanceLevel, McpServerInfo, PolicyDocument};
+use async_trait::async_trait;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn registration_response(registration_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "agent_id": "test-agent",
+        "registration_id": registration_id,
+        "trace_id": "trace-1",
+        "session_id": "session-1",
+        "proxy_addr": null,
+    })
+}
+
+/// Adapter whose child process is `echo hello` (exits 0).
+struct EchoAdapter;
+
+#[async_trait]
+impl DevToolAdapter for EchoAdapter {
+    fn detect(&self) -> Option<DevToolInfo> {
+        Some(DevToolInfo {
+            kind: DevToolKind::ClaudeCode,
+            version: Some("1.0.0".into()),
+            install_path: PathBuf::from("/usr/bin/echo"),
+            governance_level: GovernanceLevel::L0Discover,
+            supports_mcp: false,
+            supports_managed_settings: false,
+        })
+    }
+
+    async fn generate_managed_settings(&self, _p: &PolicyDocument) -> Result<String, AdapterError> {
+        Ok("{}".into())
+    }
+
+    async fn apply_settings(&self, _s: &str) -> Result<(), AdapterError> {
+        Ok(())
+    }
+
+    fn build_launch_command(
+        &self,
+        _args: &[String],
+        _agent_id: &str,
+        _team_id: Option<&str>,
+        _proxy_addr: Option<&str>,
+    ) -> Result<std::process::Command, AdapterError> {
+        let mut cmd = std::process::Command::new("echo");
+        cmd.arg("hello");
+        Ok(cmd)
+    }
+
+    async fn list_mcp_servers(&self) -> Result<Vec<McpServerInfo>, AdapterError> {
+        Ok(vec![])
+    }
+
+    async fn apply_mcp_governance(&self, _a: &[String], _d: &[String]) -> Result<(), AdapterError> {
+        Ok(())
+    }
+
+    fn governance_level(&self) -> GovernanceLevel {
+        GovernanceLevel::L0Discover
+    }
+}
+
+/// Adapter whose child process is `sh -c 'exit 7'` (exits 7).
+struct ExitSevenAdapter;
+
+#[async_trait]
+impl DevToolAdapter for ExitSevenAdapter {
+    fn detect(&self) -> Option<DevToolInfo> {
+        Some(DevToolInfo {
+            kind: DevToolKind::ClaudeCode,
+            version: Some("1.0.0".into()),
+            install_path: PathBuf::from("/usr/bin/sh"),
+            governance_level: GovernanceLevel::L0Discover,
+            supports_mcp: false,
+            supports_managed_settings: false,
+        })
+    }
+
+    async fn generate_managed_settings(&self, _p: &PolicyDocument) -> Result<String, AdapterError> {
+        Ok("{}".into())
+    }
+
+    async fn apply_settings(&self, _s: &str) -> Result<(), AdapterError> {
+        Ok(())
+    }
+
+    fn build_launch_command(
+        &self,
+        _args: &[String],
+        _agent_id: &str,
+        _team_id: Option<&str>,
+        _proxy_addr: Option<&str>,
+    ) -> Result<std::process::Command, AdapterError> {
+        let mut cmd = std::process::Command::new("sh");
+        cmd.args(["-c", "exit 7"]);
+        Ok(cmd)
+    }
+
+    async fn list_mcp_servers(&self) -> Result<Vec<McpServerInfo>, AdapterError> {
+        Ok(vec![])
+    }
+
+    async fn apply_mcp_governance(&self, _a: &[String], _d: &[String]) -> Result<(), AdapterError> {
+        Ok(())
+    }
+
+    fn governance_level(&self) -> GovernanceLevel {
+        GovernanceLevel::L0Discover
+    }
+}
+
+#[tokio::test]
+async fn run_command_exits_zero_and_deregisters() {
+    let server = MockServer::start().await;
+    let reg_id = "integ-reg-001";
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/agents"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(registration_response(reg_id)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("DELETE"))
+        .and(path(format!("/api/v1/agents/{reg_id}")))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut adapters: HashMap<&str, Box<dyn DevToolAdapter>> = HashMap::new();
+    adapters.insert("echo", Box::new(EchoAdapter));
+
+    let ctx = ResolvedContext {
+        name: None,
+        api_url: server.uri(),
+        api_key: None,
+    };
+
+    let args = RunArgs {
+        tool: "echo".into(),
+        tool_args: vec![],
+        agent_id: None,
+        team_id: None,
+        root_agent: None,
+        governance_level: None,
+        no_proxy: false,
+        dry_run: false,
+    };
+
+    let code = execute_with_adapters(&args, &ctx, &adapters).await.unwrap();
+    assert_eq!(code, 0, "echo exits 0");
+    // server drops here — wiremock verifies expect(1) on both POST and DELETE
+}
+
+#[tokio::test]
+async fn run_command_propagates_nonzero_exit_and_deregisters() {
+    let server = MockServer::start().await;
+    let reg_id = "integ-reg-007";
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/agents"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(registration_response(reg_id)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("DELETE"))
+        .and(path(format!("/api/v1/agents/{reg_id}")))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let mut adapters: HashMap<&str, Box<dyn DevToolAdapter>> = HashMap::new();
+    adapters.insert("sh", Box::new(ExitSevenAdapter));
+
+    let ctx = ResolvedContext {
+        name: None,
+        api_url: server.uri(),
+        api_key: None,
+    };
+
+    let args = RunArgs {
+        tool: "sh".into(),
+        tool_args: vec![],
+        agent_id: None,
+        team_id: None,
+        root_agent: None,
+        governance_level: None,
+        no_proxy: false,
+        dry_run: false,
+    };
+
+    let code = execute_with_adapters(&args, &ctx, &adapters).await.unwrap();
+    assert_eq!(code, 7, "sh -c 'exit 7' propagates exit code 7");
+    // server drops here — wiremock verifies DELETE was called despite nonzero exit
+}


### PR DESCRIPTION
## Summary

- Adds child-process spawning in `aasm run`: builds a `tokio::process::Command` from the adapter's `build_launch_command` result and waits for it to exit
- Forwards SIGTERM/SIGINT to the child via `libc::kill` on Unix before waiting for it to exit
- Deregisters with the gateway (`DELETE /api/v1/agents/<id>`) after the child exits using an explicit async call; `RegistrationGuard::drop` fires only as a panic-safety backup via a detached OS thread
- Adds two integration tests in `aa-cli/tests/run_command.rs`: `EchoAdapter` (exit 0 + deregisters) and `ExitSevenAdapter` (exit 7 + deregisters), both backed by wiremock stubs with `expect(1)` on POST and DELETE

## Test plan

- [ ] `cargo nextest run -p aa-cli commands::run::` — 15 unit tests pass
- [ ] `cargo nextest run -p aa-cli --test run_command` — 2 integration tests pass
- [ ] `cargo clippy -p aa-cli --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --all -- --check` — clean

Closes AAASM-942