### PR TITLE
[AAASM-934] ✨ (aa-core/aa-gateway/aa-cli): Add lineage fields to AuditEntry

### DIFF
--- a/aa-cli/src/commands/audit/mod.rs
+++ b/aa-cli/src/commands/audit/mod.rs
@@ -10,6 +10,7 @@ use crate::output::OutputFormat;
 pub mod export;
 pub mod list;
 pub mod models;
+pub mod verify_chain;
 
 /// Arguments for the `aasm audit` subcommand group.
 #[derive(Debug, Args)]
@@ -25,6 +26,8 @@ pub enum AuditCommands {
     List(list::ListArgs),
     /// Export audit data in CSV or JSON format.
     Export(export::ExportArgs),
+    /// Verify the hash chain of a local JSONL audit log file.
+    VerifyChain(verify_chain::VerifyChainArgs),
 }
 
 /// Dispatch an audit subcommand.
@@ -32,5 +35,6 @@ pub fn dispatch(args: AuditArgs, ctx: &ResolvedContext, output: OutputFormat) ->
     match args.command {
         AuditCommands::List(list_args) => list::run(list_args, ctx, output),
         AuditCommands::Export(export_args) => export::run(export_args, ctx),
+        AuditCommands::VerifyChain(vca) => verify_chain::run(vca),
     }
 }

--- a/aa-cli/src/commands/audit/verify_chain.rs
+++ b/aa-cli/src/commands/audit/verify_chain.rs
@@ -1,0 +1,113 @@
+//! `aasm audit verify-chain` — verify the hash chain of a JSONL audit log file.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Args;
+
+use aa_gateway::audit::AuditWriter;
+
+/// Arguments for `aasm audit verify-chain`.
+#[derive(Debug, Args)]
+pub struct VerifyChainArgs {
+    /// Path to the JSONL audit log file to verify.
+    pub path: PathBuf,
+}
+
+/// Execute `aasm audit verify-chain`.
+pub fn run(args: VerifyChainArgs) -> ExitCode {
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    match rt.block_on(AuditWriter::verify_chain(&args.path)) {
+        Ok(result) if result.is_valid => {
+            println!("OK — {} entries verified", result.entries_checked);
+            ExitCode::SUCCESS
+        }
+        Ok(result) => {
+            eprintln!(
+                "FAIL — hash chain broken at entry {} ({} entries checked)",
+                result.first_invalid.unwrap_or(0),
+                result.entries_checked,
+            );
+            ExitCode::FAILURE
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write as _;
+
+    use aa_core::identity::{AgentId, SessionId};
+    use aa_core::{AuditEntry, AuditEventType};
+
+    use super::*;
+
+    fn make_chain(n: u64) -> Vec<AuditEntry> {
+        let agent = AgentId::from_bytes([1u8; 16]);
+        let session = SessionId::from_bytes([2u8; 16]);
+        let mut entries = Vec::new();
+        let mut prev_hash = [0u8; 32];
+        for seq in 0..n {
+            let e = AuditEntry::new(
+                seq,
+                1_000_000 + seq,
+                AuditEventType::ToolCallIntercepted,
+                agent,
+                session,
+                format!("{{\"seq\":{seq}}}"),
+                prev_hash,
+            );
+            prev_hash = *e.entry_hash();
+            entries.push(e);
+        }
+        entries
+    }
+
+    fn write_chain_to_file(path: &std::path::Path, entries: &[AuditEntry]) {
+        let mut f = std::fs::File::create(path).unwrap();
+        for e in entries {
+            writeln!(f, "{}", serde_json::to_string(e).unwrap()).unwrap();
+        }
+    }
+
+    #[test]
+    fn run_returns_success_for_valid_chain() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let entries = make_chain(5);
+        write_chain_to_file(&path, &entries);
+        let args = VerifyChainArgs { path };
+        assert_eq!(run(args), ExitCode::SUCCESS);
+    }
+
+    #[test]
+    fn run_returns_failure_for_tampered_chain() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("audit.jsonl");
+        let entries = make_chain(3);
+
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(f, "{}", serde_json::to_string(&entries[0]).unwrap()).unwrap();
+        // Entry with tampered payload — seq and previous_hash from original entry[1],
+        // but event_type is different so entry_hash won't match chain linkage.
+        let bad = AuditEntry::new(
+            1,
+            entries[1].timestamp_ns(),
+            AuditEventType::PolicyViolation,
+            entries[1].agent_id(),
+            entries[1].session_id(),
+            "TAMPERED".into(),
+            *entries[1].previous_hash(),
+        );
+        writeln!(f, "{}", serde_json::to_string(&bad).unwrap()).unwrap();
+        writeln!(f, "{}", serde_json::to_string(&entries[2]).unwrap()).unwrap();
+        drop(f);
+
+        let args = VerifyChainArgs { path };
+        assert_eq!(run(args), ExitCode::FAILURE);
+    }
+}

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -63,6 +63,39 @@ impl AuditEventType {
 }
 
 // ---------------------------------------------------------------------------
+// Lineage
+// ---------------------------------------------------------------------------
+
+/// Optional agent-topology fields attached to an [`AuditEntry`].
+///
+/// All fields are `None` for entries emitted without an `AgentContext`
+/// (legacy path). `Lineage::default()` passed to
+/// [`AuditEntry::new_with_lineage`] produces a hash identical to
+/// [`AuditEntry::new`] with the same base fields.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Lineage {
+    /// Root agent identifier at the top of the delegation chain.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    pub root_agent_id: Option<AgentId>,
+    /// Identifier of the agent that directly spawned this agent.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    pub parent_agent_id: Option<AgentId>,
+    /// Team identifier associated with the agent that produced the entry.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    pub team_id: Option<String>,
+    /// Human-readable reason the action was delegated to this agent.
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    pub delegation_reason: Option<String>,
+    /// Name of the tool or framework that spawned this agent (e.g. `"langgraph"`).
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    pub spawned_by_tool: Option<String>,
+    /// Delegation depth from the root agent (`0` = root, `1` = first delegate, …).
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    pub depth: Option<u32>,
+}
+
+// ---------------------------------------------------------------------------
 // AuditEntry
 // ---------------------------------------------------------------------------
 
@@ -96,6 +129,18 @@ pub struct AuditEntry {
     payload: String,
     previous_hash: [u8; 32],
     entry_hash: [u8; 32],
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    root_agent_id: Option<AgentId>,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    parent_agent_id: Option<AgentId>,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    team_id: Option<String>,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    delegation_reason: Option<String>,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    spawned_by_tool: Option<String>,
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    depth: Option<u32>,
 }
 
 impl AuditEntry {
@@ -147,6 +192,7 @@ impl AuditEntry {
             &session_id,
             &previous_hash,
             &payload,
+            &Lineage::default(),
         );
         Self {
             seq,
@@ -157,6 +203,57 @@ impl AuditEntry {
             payload,
             previous_hash,
             entry_hash,
+            root_agent_id: None,
+            parent_agent_id: None,
+            team_id: None,
+            delegation_reason: None,
+            spawned_by_tool: None,
+            depth: None,
+        }
+    }
+
+    /// Create a new [`AuditEntry`] with optional lineage fields, computing `entry_hash`
+    /// over all fields including the lineage data.
+    ///
+    /// When `lineage` is `Lineage::default()` (all fields `None`), the resulting
+    /// `entry_hash` is identical to that produced by [`AuditEntry::new`] with the
+    /// same base fields, preserving backward compatibility.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_lineage(
+        seq: u64,
+        timestamp_ns: u64,
+        event_type: AuditEventType,
+        agent_id: AgentId,
+        session_id: SessionId,
+        payload: String,
+        previous_hash: [u8; 32],
+        lineage: Lineage,
+    ) -> Self {
+        let entry_hash = Self::compute_hash(
+            seq,
+            timestamp_ns,
+            &event_type,
+            &agent_id,
+            &session_id,
+            &previous_hash,
+            &payload,
+            &lineage,
+        );
+        Self {
+            seq,
+            timestamp_ns,
+            event_type,
+            agent_id,
+            session_id,
+            payload,
+            previous_hash,
+            entry_hash,
+            root_agent_id: lineage.root_agent_id,
+            parent_agent_id: lineage.parent_agent_id,
+            team_id: lineage.team_id,
+            delegation_reason: lineage.delegation_reason,
+            spawned_by_tool: lineage.spawned_by_tool,
+            depth: lineage.depth,
         }
     }
 
@@ -212,6 +309,42 @@ impl AuditEntry {
         &self.entry_hash
     }
 
+    /// Root agent identifier in the delegation chain, if present.
+    #[inline]
+    pub fn root_agent_id(&self) -> Option<AgentId> {
+        self.root_agent_id
+    }
+
+    /// Parent agent identifier that directly spawned this agent, if present.
+    #[inline]
+    pub fn parent_agent_id(&self) -> Option<AgentId> {
+        self.parent_agent_id
+    }
+
+    /// Team identifier associated with the agent, if present.
+    #[inline]
+    pub fn team_id(&self) -> Option<&str> {
+        self.team_id.as_deref()
+    }
+
+    /// Reason this agent was delegated the action, if present.
+    #[inline]
+    pub fn delegation_reason(&self) -> Option<&str> {
+        self.delegation_reason.as_deref()
+    }
+
+    /// Name of the tool that spawned this agent, if present.
+    #[inline]
+    pub fn spawned_by_tool(&self) -> Option<&str> {
+        self.spawned_by_tool.as_deref()
+    }
+
+    /// Delegation depth from the root agent, if present.
+    #[inline]
+    pub fn depth(&self) -> Option<u32> {
+        self.depth
+    }
+
     // -----------------------------------------------------------------------
     // Integrity
     // -----------------------------------------------------------------------
@@ -222,6 +355,14 @@ impl AuditEntry {
     /// Returns `false` if any field has been altered after construction — including
     /// via `unsafe` code.
     pub fn verify_integrity(&self) -> bool {
+        let lineage = Lineage {
+            root_agent_id: self.root_agent_id,
+            parent_agent_id: self.parent_agent_id,
+            team_id: self.team_id.clone(),
+            delegation_reason: self.delegation_reason.clone(),
+            spawned_by_tool: self.spawned_by_tool.clone(),
+            depth: self.depth,
+        };
         let expected = Self::compute_hash(
             self.seq,
             self.timestamp_ns,
@@ -230,6 +371,7 @@ impl AuditEntry {
             &self.session_id,
             &self.previous_hash,
             &self.payload,
+            &lineage,
         );
         expected == self.entry_hash
     }
@@ -241,7 +383,9 @@ impl AuditEntry {
     /// Canonical SHA-256 computation over all tamper-meaningful fields.
     ///
     /// Field order and encoding are fixed — see [`AuditEntry::new`] for the
-    /// documented byte sequence.
+    /// documented byte sequence. Lineage fields append only when `Some`;
+    /// when all lineage fields are `None`, output equals the pre-AAASM-934 hash exactly.
+    #[allow(clippy::too_many_arguments)]
     fn compute_hash(
         seq: u64,
         timestamp_ns: u64,
@@ -250,6 +394,7 @@ impl AuditEntry {
         session_id: &SessionId,
         previous_hash: &[u8; 32],
         payload: &str,
+        lineage: &Lineage,
     ) -> [u8; 32] {
         let mut hasher = Sha256::new();
         hasher.update(seq.to_be_bytes());
@@ -259,6 +404,29 @@ impl AuditEntry {
         hasher.update(session_id.as_bytes());
         hasher.update(previous_hash);
         hasher.update(payload.as_bytes());
+        // Lineage — append only when present; None contributes 0 bytes.
+        // When all fields are None, hash equals pre-AAASM-934 output exactly.
+        if let Some(id) = &lineage.root_agent_id {
+            hasher.update(id.as_bytes());
+        }
+        if let Some(id) = &lineage.parent_agent_id {
+            hasher.update(id.as_bytes());
+        }
+        if let Some(s) = &lineage.team_id {
+            hasher.update((s.len() as u32).to_be_bytes());
+            hasher.update(s.as_bytes());
+        }
+        if let Some(s) = &lineage.delegation_reason {
+            hasher.update((s.len() as u32).to_be_bytes());
+            hasher.update(s.as_bytes());
+        }
+        if let Some(s) = &lineage.spawned_by_tool {
+            hasher.update((s.len() as u32).to_be_bytes());
+            hasher.update(s.as_bytes());
+        }
+        if let Some(d) = lineage.depth {
+            hasher.update(d.to_be_bytes());
+        }
         hasher.finalize().into()
     }
 }
@@ -438,6 +606,42 @@ impl AuditLog {
         // next_entry constructs the entry with the correct seq and previous_hash,
         // so push() cannot fail here.
         self.push(entry).expect("next_entry invariant: push cannot fail");
+        self.entries.last().expect("entry was just pushed")
+    }
+
+    /// Build and append the next [`AuditEntry`] with lineage fields in one atomic step.
+    ///
+    /// Equivalent to [`AuditLog::next_entry`] but attaches agent-topology metadata.
+    /// `seq` and `previous_hash` are derived automatically from the log's current state.
+    ///
+    /// ## Parameters
+    ///
+    /// - `event_type` — category of the governance event.
+    /// - `timestamp_ns` — nanoseconds since Unix epoch (caller-supplied for `no_std` compatibility).
+    /// - `payload` — pre-serialized UTF-8 string (JSON in practice).
+    /// - `lineage` — optional agent-topology fields; `Lineage::default()` produces the same hash
+    ///   as [`AuditLog::next_entry`] with the same base fields.
+    ///
+    /// Returns a reference to the newly appended entry.
+    pub fn next_entry_with_lineage(
+        &mut self,
+        event_type: AuditEventType,
+        timestamp_ns: u64,
+        payload: String,
+        lineage: Lineage,
+    ) -> &AuditEntry {
+        let entry = AuditEntry::new_with_lineage(
+            self.next_seq,
+            timestamp_ns,
+            event_type,
+            self.agent_id,
+            self.session_id,
+            payload,
+            self.last_hash,
+            lineage,
+        );
+        self.push(entry)
+            .expect("next_entry_with_lineage invariant: push cannot fail");
         self.entries.last().expect("entry was just pushed")
     }
 
@@ -998,5 +1202,193 @@ mod tests {
             (*ptr)[0] = 0xFF;
         }
         assert!(!log.verify_chain());
+    }
+}
+
+#[cfg(all(test, feature = "alloc", feature = "serde"))]
+mod lineage_tests {
+    use super::*;
+
+    const AGENT: AgentId = AgentId::from_bytes([1u8; 16]);
+    const SESSION: SessionId = SessionId::from_bytes([2u8; 16]);
+    const ROOT: AgentId = AgentId::from_bytes([7u8; 16]);
+    const PARENT: AgentId = AgentId::from_bytes([9u8; 16]);
+
+    fn base_entry() -> AuditEntry {
+        AuditEntry::new(
+            0,
+            1_700_000_000_000_000_000,
+            AuditEventType::ToolCallIntercepted,
+            AGENT,
+            SESSION,
+            r#"{"tool":"bash"}"#.into(),
+            [0u8; 32],
+        )
+    }
+
+    #[test]
+    fn lineage_default_is_all_none() {
+        let l = Lineage::default();
+        assert!(l.root_agent_id.is_none());
+        assert!(l.parent_agent_id.is_none());
+        assert!(l.team_id.is_none());
+        assert!(l.delegation_reason.is_none());
+        assert!(l.spawned_by_tool.is_none());
+        assert!(l.depth.is_none());
+    }
+
+    #[test]
+    fn new_with_empty_lineage_produces_same_hash_as_new() {
+        let legacy = base_entry();
+        let with_lineage = AuditEntry::new_with_lineage(
+            0,
+            1_700_000_000_000_000_000,
+            AuditEventType::ToolCallIntercepted,
+            AGENT,
+            SESSION,
+            r#"{"tool":"bash"}"#.into(),
+            [0u8; 32],
+            Lineage::default(),
+        );
+        assert_eq!(
+            legacy.entry_hash(),
+            with_lineage.entry_hash(),
+            "Lineage::default() must not change the hash"
+        );
+    }
+
+    #[test]
+    fn new_with_lineage_getters_return_correct_values() {
+        let lineage = Lineage {
+            root_agent_id: Some(ROOT),
+            parent_agent_id: Some(PARENT),
+            team_id: Some("team-alpha".into()),
+            delegation_reason: Some("summarise".into()),
+            spawned_by_tool: Some("langgraph".into()),
+            depth: Some(2),
+        };
+        let entry = AuditEntry::new_with_lineage(
+            0,
+            1_000,
+            AuditEventType::PolicyViolation,
+            AGENT,
+            SESSION,
+            "{}".into(),
+            [0u8; 32],
+            lineage,
+        );
+        assert_eq!(entry.root_agent_id(), Some(ROOT));
+        assert_eq!(entry.parent_agent_id(), Some(PARENT));
+        assert_eq!(entry.team_id(), Some("team-alpha"));
+        assert_eq!(entry.delegation_reason(), Some("summarise"));
+        assert_eq!(entry.spawned_by_tool(), Some("langgraph"));
+        assert_eq!(entry.depth(), Some(2));
+    }
+
+    #[test]
+    fn verify_integrity_true_with_lineage() {
+        let lineage = Lineage {
+            root_agent_id: Some(ROOT),
+            team_id: Some("ops".into()),
+            depth: Some(1),
+            ..Lineage::default()
+        };
+        let entry = AuditEntry::new_with_lineage(
+            0,
+            1_000,
+            AuditEventType::ToolCallIntercepted,
+            AGENT,
+            SESSION,
+            "{}".into(),
+            [0u8; 32],
+            lineage,
+        );
+        assert!(entry.verify_integrity());
+    }
+
+    #[test]
+    fn lineage_fields_change_hash() {
+        let no_lineage = base_entry();
+        let lineage = Lineage {
+            depth: Some(1),
+            ..Lineage::default()
+        };
+        let with_depth = AuditEntry::new_with_lineage(
+            0,
+            1_700_000_000_000_000_000,
+            AuditEventType::ToolCallIntercepted,
+            AGENT,
+            SESSION,
+            r#"{"tool":"bash"}"#.into(),
+            [0u8; 32],
+            lineage,
+        );
+        assert_ne!(
+            no_lineage.entry_hash(),
+            with_depth.entry_hash(),
+            "A present lineage field must change the hash"
+        );
+    }
+
+    #[test]
+    fn serde_round_trip_with_lineage() {
+        let lineage = Lineage {
+            root_agent_id: Some(ROOT),
+            parent_agent_id: Some(PARENT),
+            team_id: Some("t1".into()),
+            delegation_reason: Some("r".into()),
+            spawned_by_tool: Some("s".into()),
+            depth: Some(3),
+        };
+        let entry = AuditEntry::new_with_lineage(
+            0,
+            1_000,
+            AuditEventType::ToolCallIntercepted,
+            AGENT,
+            SESSION,
+            "{}".into(),
+            [0u8; 32],
+            lineage,
+        );
+        let json = serde_json::to_string(&entry).unwrap();
+        let restored: AuditEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(entry.entry_hash(), restored.entry_hash());
+        assert_eq!(restored.root_agent_id(), Some(ROOT));
+        assert_eq!(restored.depth(), Some(3));
+    }
+
+    #[test]
+    fn legacy_jsonl_without_lineage_fields_deserialises_and_verifies() {
+        let pre_change_entry = AuditEntry::new(
+            0,
+            1_700_000_000_000_000_000,
+            AuditEventType::ToolCallIntercepted,
+            AGENT,
+            SESSION,
+            r#"{"tool":"bash"}"#.into(),
+            [0u8; 32],
+        );
+        let json = serde_json::to_string(&pre_change_entry).unwrap();
+        assert!(!json.contains("root_agent_id"), "None fields must not appear in JSON");
+        let restored: AuditEntry = serde_json::from_str(&json).unwrap();
+        assert!(restored.root_agent_id().is_none());
+        assert!(
+            restored.verify_integrity(),
+            "Legacy entries must still verify after adding lineage fields"
+        );
+    }
+
+    #[test]
+    fn next_entry_with_lineage_links_chain() {
+        let mut log = AuditLog::new(AGENT, SESSION);
+        let lineage = Lineage {
+            depth: Some(1),
+            team_id: Some("t".into()),
+            ..Lineage::default()
+        };
+        log.next_entry_with_lineage(AuditEventType::ToolCallIntercepted, 1_000, "{}".into(), lineage.clone());
+        log.next_entry_with_lineage(AuditEventType::PolicyViolation, 2_000, "{}".into(), lineage);
+        assert!(log.verify_chain());
+        assert_eq!(log.len(), 2);
     }
 }

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -53,7 +53,7 @@ pub use policy::{ArgsJson, GovernanceAction, PolicyDocument, PolicyEvaluator, Po
 pub use evaluators::{DenyAllEvaluator, PermitAllEvaluator};
 
 #[cfg(feature = "alloc")]
-pub use audit::{AuditEntry, AuditEventType, AuditLog, AuditLogError};
+pub use audit::{AuditEntry, AuditEventType, AuditLog, AuditLogError, Lineage};
 
 #[cfg(feature = "std")]
 pub use scanner::{CredentialFinding, CredentialKind, CredentialScanner, ScanResult, ScannerConfig};

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -160,7 +160,7 @@ pub async fn serve_tcp(
         Arc::clone(&audit_drops),
         initial_hash,
     );
-    let audit_svc = AuditServiceImpl::new(audit_tx, audit_drops, initial_hash);
+    let audit_svc = AuditServiceImpl::new_with_registry(audit_tx, audit_drops, initial_hash, Arc::clone(&registry));
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);
     let approval_svc = ApprovalServiceImpl::new(approval_queue);
 
@@ -206,7 +206,7 @@ pub async fn serve_uds(
         Arc::clone(&audit_drops),
         initial_hash,
     );
-    let audit_svc = AuditServiceImpl::new(audit_tx, audit_drops, initial_hash);
+    let audit_svc = AuditServiceImpl::new_with_registry(audit_tx, audit_drops, initial_hash, Arc::clone(&registry));
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);
     let approval_svc = ApprovalServiceImpl::new(approval_queue);
 

--- a/aa-gateway/src/service/audit_service.rs
+++ b/aa-gateway/src/service/audit_service.rs
@@ -124,7 +124,16 @@ impl AuditServiceImpl {
 
         let mut last_hash = self.last_hash.lock().await;
 
-        let entry = AuditEntry::new_with_lineage(seq, timestamp_ns, event_type, agent_id, session_id, payload, *last_hash, lineage);
+        let entry = AuditEntry::new_with_lineage(
+            seq,
+            timestamp_ns,
+            event_type,
+            agent_id,
+            session_id,
+            payload,
+            *last_hash,
+            lineage,
+        );
 
         *last_hash = *entry.entry_hash();
         drop(last_hash);

--- a/aa-gateway/src/service/audit_service.rs
+++ b/aa-gateway/src/service/audit_service.rs
@@ -9,11 +9,12 @@ use tokio::sync::{mpsc, Mutex};
 use tonic::{Request, Response, Status};
 
 use aa_core::identity::{AgentId, SessionId};
-use aa_core::{AuditEntry, AuditEventType};
+use aa_core::{AuditEntry, AuditEventType, Lineage};
 use aa_proto::assembly::audit::v1::audit_service_server::AuditService;
 use aa_proto::assembly::audit::v1::{AuditEvent, ReportEventsRequest, ReportEventsResponse, StreamEventsResponse};
 use aa_proto::assembly::common::v1::Decision;
 
+use crate::registry::{convert as registry_convert, AgentRegistry};
 use crate::service::convert;
 
 /// gRPC service implementation wiring `ReportEvents` / `StreamEvents` to the
@@ -23,6 +24,7 @@ pub struct AuditServiceImpl {
     audit_drops: Arc<AtomicU64>,
     seq: AtomicU64,
     last_hash: Mutex<[u8; 32]>,
+    registry: Option<Arc<AgentRegistry>>,
 }
 
 impl AuditServiceImpl {
@@ -36,6 +38,24 @@ impl AuditServiceImpl {
             audit_drops,
             seq: AtomicU64::new(0),
             last_hash: Mutex::new(initial_hash),
+            registry: None,
+        }
+    }
+
+    /// Create a new service backed by the given audit channel, with access to
+    /// the agent registry for lineage enrichment.
+    pub fn new_with_registry(
+        audit_tx: mpsc::Sender<AuditEntry>,
+        audit_drops: Arc<AtomicU64>,
+        initial_hash: [u8; 32],
+        registry: Arc<AgentRegistry>,
+    ) -> Self {
+        Self {
+            audit_tx,
+            audit_drops,
+            seq: AtomicU64::new(0),
+            last_hash: Mutex::new(initial_hash),
+            registry: Some(registry),
         }
     }
 
@@ -47,11 +67,21 @@ impl AuditServiceImpl {
         let event_id = event.event_id.clone();
         let seq = self.seq.fetch_add(1, Ordering::Relaxed);
 
-        let agent_id = event
+        // agent_id_bytes: hash of just the agent_id string (existing AuditEntry convention).
+        let agent_id_bytes = event
             .agent_id
             .as_ref()
-            .map(|a| AgentId::from_bytes(convert::hash_to_16(&a.agent_id)))
-            .unwrap_or_else(|| AgentId::from_bytes([0u8; 16]));
+            .map(|a| convert::hash_to_16(&a.agent_id))
+            .unwrap_or([0u8; 16]);
+        let agent_id = AgentId::from_bytes(agent_id_bytes);
+
+        // registry_key: composite hash (org/team/agent_id) matching the lifecycle-service
+        // registration path — must use proto_agent_id_to_key to find the correct record.
+        let registry_key = event
+            .agent_id
+            .as_ref()
+            .map(registry_convert::proto_agent_id_to_key)
+            .unwrap_or([0u8; 16]);
 
         let session_id = if event.trace_id.is_empty() {
             SessionId::from_bytes([0u8; 16])
@@ -75,9 +105,26 @@ impl AuditServiceImpl {
         })
         .to_string();
 
+        let lineage = self
+            .registry
+            .as_ref()
+            .and_then(|r| r.get(&registry_key))
+            .map(|record| Lineage {
+                root_agent_id: record.root_agent_id.map(AgentId::from_bytes),
+                // parent_agent_id is stored as Option<String> in AgentRecord (the raw
+                // string from the registration proto). Converting it to AgentId bytes
+                // requires a separate registry lookup by name — deferred to a follow-up.
+                parent_agent_id: None,
+                team_id: record.team_id.clone(),
+                delegation_reason: record.delegation_reason.clone(),
+                spawned_by_tool: record.spawned_by_tool.clone(),
+                depth: Some(record.depth),
+            })
+            .unwrap_or_default();
+
         let mut last_hash = self.last_hash.lock().await;
 
-        let entry = AuditEntry::new(seq, timestamp_ns, event_type, agent_id, session_id, payload, *last_hash);
+        let entry = AuditEntry::new_with_lineage(seq, timestamp_ns, event_type, agent_id, session_id, payload, *last_hash, lineage);
 
         *last_hash = *entry.entry_hash();
         drop(last_hash);

--- a/aa-gateway/tests/audit_integration_test.rs
+++ b/aa-gateway/tests/audit_integration_test.rs
@@ -364,13 +364,13 @@ async fn audit_service_populates_lineage_from_registry() {
     let event = AuditEvent {
         event_id: "evt-001".into(),
         agent_id: Some(proto_agent_id),
-        occurred_at: Some(Timestamp { unix_ms: 1_700_000_000_000 }),
+        occurred_at: Some(Timestamp {
+            unix_ms: 1_700_000_000_000,
+        }),
         ..Default::default()
     };
 
-    let req = tonic::Request::new(ReportEventsRequest {
-        events: vec![event],
-    });
+    let req = tonic::Request::new(ReportEventsRequest { events: vec![event] });
     svc.report_events(req).await.unwrap();
 
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
@@ -384,8 +384,5 @@ async fn audit_service_populates_lineage_from_registry() {
         "spawned_by_tool from registry"
     );
     assert!(entry.root_agent_id().is_some(), "root_agent_id from registry");
-    assert!(
-        entry.verify_integrity(),
-        "lineage-enriched entry must verify"
-    );
+    assert!(entry.verify_integrity(), "lineage-enriched entry must verify");
 }

--- a/aa-gateway/tests/audit_integration_test.rs
+++ b/aa-gateway/tests/audit_integration_test.rs
@@ -295,3 +295,97 @@ async fn stream_events_ingests_client_stream() {
     assert_eq!(e2.event_type(), AuditEventType::PolicyViolation);
     assert_eq!(e3.event_type(), AuditEventType::ApprovalRequested);
 }
+
+// ── Task 3 (AAASM-965): lineage populated from AgentRegistry ───────────────
+
+#[tokio::test]
+async fn audit_service_populates_lineage_from_registry() {
+    use aa_gateway::registry::store::AgentRecord;
+    use aa_gateway::registry::{AgentRegistry, AgentStatus};
+    use aa_gateway::service::audit_service::AuditServiceImpl;
+    use aa_proto::assembly::audit::v1::audit_service_server::AuditService;
+    use aa_proto::assembly::audit::v1::{AuditEvent, ReportEventsRequest};
+    use aa_proto::assembly::common::v1::{AgentId as ProtoAgentId, Timestamp};
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+    use tokio::sync::mpsc;
+
+    use aa_gateway::registry::convert::proto_agent_id_to_key;
+
+    let registry = Arc::new(AgentRegistry::new());
+
+    let root_bytes = [0x07u8; 16];
+
+    // The proto agent_id that the AuditEvent will carry.
+    let proto_agent_id = ProtoAgentId {
+        org_id: String::new(),
+        team_id: String::new(),
+        agent_id: "test-agent-001".to_string(),
+    };
+    // The registry key must match what ingest_event() will derive (proto_agent_id_to_key).
+    let agent_registry_key = proto_agent_id_to_key(&proto_agent_id);
+
+    registry
+        .register(AgentRecord {
+            agent_id: agent_registry_key,
+            name: "test-agent".into(),
+            framework: "test".into(),
+            version: "0.0.1".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key: String::new(),
+            credential_token: String::new(),
+            metadata: BTreeMap::new(),
+            registered_at: chrono::Utc::now(),
+            last_heartbeat: chrono::Utc::now(),
+            status: AgentStatus::Active,
+            pid: None,
+            session_count: 0,
+            last_event: None,
+            policy_violations_count: 0,
+            active_sessions: vec![],
+            recent_events: std::collections::VecDeque::new(),
+            recent_traces: vec![],
+            layer: None,
+            governance_level: aa_core::GovernanceLevel::default(),
+            parent_agent_id: Some("parent-placeholder".into()),
+            team_id: Some("team-alpha".into()),
+            depth: 2,
+            delegation_reason: Some("summarise".into()),
+            spawned_by_tool: Some("langgraph".into()),
+            root_agent_id: Some(root_bytes),
+        })
+        .unwrap();
+
+    let (tx, mut rx) = mpsc::channel::<aa_core::AuditEntry>(16);
+    let drops = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let svc = AuditServiceImpl::new_with_registry(tx, drops, [0u8; 32], registry);
+
+    let event = AuditEvent {
+        event_id: "evt-001".into(),
+        agent_id: Some(proto_agent_id),
+        occurred_at: Some(Timestamp { unix_ms: 1_700_000_000_000 }),
+        ..Default::default()
+    };
+
+    let req = tonic::Request::new(ReportEventsRequest {
+        events: vec![event],
+    });
+    svc.report_events(req).await.unwrap();
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let entry = rx.try_recv().expect("entry should have been sent");
+    assert_eq!(entry.team_id(), Some("team-alpha"), "team_id from registry");
+    assert_eq!(entry.depth(), Some(2), "depth from registry");
+    assert_eq!(
+        entry.spawned_by_tool(),
+        Some("langgraph"),
+        "spawned_by_tool from registry"
+    );
+    assert!(entry.root_agent_id().is_some(), "root_agent_id from registry");
+    assert!(
+        entry.verify_integrity(),
+        "lineage-enriched entry must verify"
+    );
+}

--- a/aa-gateway/tests/audit_integration_test.rs
+++ b/aa-gateway/tests/audit_integration_test.rs
@@ -158,6 +158,7 @@ async fn report_events_ingests_batch() {
             parent_span_id: String::new(),
             detail: None,
             labels: Default::default(),
+            ..Default::default()
         },
         AuditEvent {
             event_id: "evt-2".into(),
@@ -176,6 +177,7 @@ async fn report_events_ingests_batch() {
             parent_span_id: String::new(),
             detail: None,
             labels: Default::default(),
+            ..Default::default()
         },
     ];
 
@@ -228,6 +230,7 @@ async fn stream_events_ingests_client_stream() {
             parent_span_id: String::new(),
             detail: None,
             labels: Default::default(),
+            ..Default::default()
         },
         AuditEvent {
             event_id: "stream-2".into(),
@@ -246,6 +249,7 @@ async fn stream_events_ingests_client_stream() {
             parent_span_id: String::new(),
             detail: None,
             labels: Default::default(),
+            ..Default::default()
         },
         AuditEvent {
             event_id: "stream-3".into(),
@@ -264,6 +268,7 @@ async fn stream_events_ingests_client_stream() {
             parent_span_id: String::new(),
             detail: None,
             labels: Default::default(),
+            ..Default::default()
         },
     ];
 

--- a/aa-gateway/tests/audit_lineage_test.rs
+++ b/aa-gateway/tests/audit_lineage_test.rs
@@ -1,0 +1,188 @@
+//! Integration + regression tests for AAASM-934: AuditEntry lineage fields.
+
+use aa_core::identity::{AgentId, SessionId};
+use aa_core::{AuditEntry, AuditEventType, Lineage};
+
+const AGENT: AgentId = AgentId::from_bytes([1u8; 16]);
+const SESSION: SessionId = SessionId::from_bytes([2u8; 16]);
+const ROOT: AgentId = AgentId::from_bytes([7u8; 16]);
+const PARENT: AgentId = AgentId::from_bytes([9u8; 16]);
+
+fn make_entry_with_lineage(seq: u64, previous_hash: [u8; 32], lineage: Lineage) -> AuditEntry {
+    AuditEntry::new_with_lineage(
+        seq,
+        1_700_000_000_000_000_000 + seq,
+        AuditEventType::ToolCallIntercepted,
+        AGENT,
+        SESSION,
+        format!("{{\"seq\":{seq}}}"),
+        previous_hash,
+        lineage,
+    )
+}
+
+fn depth2_lineage() -> Lineage {
+    Lineage {
+        root_agent_id: Some(ROOT),
+        parent_agent_id: Some(PARENT),
+        team_id: Some("team-alpha".into()),
+        delegation_reason: Some("summarise results".into()),
+        spawned_by_tool: Some("langgraph.subgraph".into()),
+        depth: Some(2),
+    }
+}
+
+// ── Integration tests: depth-2 agent ─────────────────────────────────────
+
+#[test]
+fn depth2_agent_all_lineage_fields_populated() {
+    let entry = make_entry_with_lineage(0, [0u8; 32], depth2_lineage());
+    assert_eq!(entry.root_agent_id(), Some(ROOT));
+    assert_eq!(entry.parent_agent_id(), Some(PARENT));
+    assert_eq!(entry.team_id(), Some("team-alpha"));
+    assert_eq!(entry.delegation_reason(), Some("summarise results"));
+    assert_eq!(entry.spawned_by_tool(), Some("langgraph.subgraph"));
+    assert_eq!(entry.depth(), Some(2));
+}
+
+#[test]
+fn depth2_entry_passes_verify_integrity() {
+    let entry = make_entry_with_lineage(0, [0u8; 32], depth2_lineage());
+    assert!(entry.verify_integrity(), "depth-2 entry must verify its own hash");
+}
+
+#[test]
+fn multi_entry_chain_with_lineage_is_valid() {
+    let mut log = aa_core::AuditLog::new(AGENT, SESSION);
+    let ts = 1_700_000_000_000_000_000u64;
+
+    log.next_entry_with_lineage(
+        AuditEventType::ToolCallIntercepted,
+        ts,
+        r#"{"tool":"web_search"}"#.into(),
+        depth2_lineage(),
+    );
+    log.next_entry_with_lineage(
+        AuditEventType::PolicyViolation,
+        ts + 1,
+        r#"{"tool":"bash"}"#.into(),
+        depth2_lineage(),
+    );
+    log.next_entry(AuditEventType::ApprovalRequested, ts + 2, r#"{"tool":"bash"}"#.into());
+
+    assert!(log.verify_chain(), "mixed lineage/no-lineage chain must verify");
+    assert_eq!(log.len(), 3);
+}
+
+// ── Integration tests: JSONL write + verify_chain ─────────────────────────
+
+#[tokio::test]
+async fn depth2_chain_written_to_jsonl_verifies_ok() {
+    use aa_gateway::audit::AuditWriter;
+    use tokio::sync::mpsc;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (tx, rx) = mpsc::channel(64);
+
+    let writer = AuditWriter::new(dir.path().to_path_buf(), "agent-l", "sess-l", rx)
+        .await
+        .unwrap();
+    tokio::spawn(writer.run());
+
+    let mut prev_hash = [0u8; 32];
+    for seq in 0..4u64 {
+        let entry = make_entry_with_lineage(seq, prev_hash, depth2_lineage());
+        prev_hash = *entry.entry_hash();
+        tx.send(entry).await.unwrap();
+    }
+    drop(tx);
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let path = dir.path().join("agent-l-sess-l.jsonl");
+    let result = AuditWriter::verify_chain(&path).await.unwrap();
+    assert!(result.is_valid, "depth-2 chain must verify");
+    assert_eq!(result.entries_checked, 4);
+    assert!(result.first_invalid.is_none());
+}
+
+// ── Regression tests: legacy JSONL rows ──────────────────────────────────
+
+#[tokio::test]
+async fn legacy_entries_without_lineage_still_verify() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("legacy.jsonl");
+
+    let mut prev_hash = [0u8; 32];
+    let mut lines = Vec::new();
+    for seq in 0..3u64 {
+        let entry = AuditEntry::new(
+            seq,
+            1_700_000_000_000_000_000 + seq,
+            AuditEventType::ToolCallIntercepted,
+            AGENT,
+            SESSION,
+            format!("{{\"seq\":{seq}}}"),
+            prev_hash,
+        );
+        prev_hash = *entry.entry_hash();
+        lines.push(serde_json::to_string(&entry).unwrap());
+    }
+
+    // None lineage fields must not appear in JSONL (skip_serializing_if = None).
+    assert!(
+        !lines[0].contains("root_agent_id"),
+        "None lineage must not appear in JSONL"
+    );
+    assert!(!lines[0].contains("\"depth\""), "None lineage must not appear in JSONL");
+
+    tokio::fs::write(&path, lines.join("\n") + "\n").await.unwrap();
+
+    let result = aa_gateway::audit::AuditWriter::verify_chain(&path).await.unwrap();
+    assert!(result.is_valid, "legacy entries must still verify");
+    assert_eq!(result.entries_checked, 3);
+}
+
+#[tokio::test]
+async fn mixed_legacy_and_lineage_chain_verifies() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("mixed.jsonl");
+
+    let mut prev_hash = [0u8; 32];
+    let mut lines = Vec::new();
+
+    // Entry 0: no lineage (legacy).
+    let e0 = AuditEntry::new(
+        0,
+        1_000_000,
+        AuditEventType::ToolCallIntercepted,
+        AGENT,
+        SESSION,
+        "{}".into(),
+        prev_hash,
+    );
+    prev_hash = *e0.entry_hash();
+    lines.push(serde_json::to_string(&e0).unwrap());
+
+    // Entry 1: with lineage.
+    let e1 = make_entry_with_lineage(1, prev_hash, depth2_lineage());
+    prev_hash = *e1.entry_hash();
+    lines.push(serde_json::to_string(&e1).unwrap());
+
+    // Entry 2: no lineage again.
+    let e2 = AuditEntry::new(
+        2,
+        1_000_002,
+        AuditEventType::PolicyViolation,
+        AGENT,
+        SESSION,
+        "{}".into(),
+        prev_hash,
+    );
+    lines.push(serde_json::to_string(&e2).unwrap());
+
+    tokio::fs::write(&path, lines.join("\n") + "\n").await.unwrap();
+
+    let result = aa_gateway::audit::AuditWriter::verify_chain(&path).await.unwrap();
+    assert!(result.is_valid, "mixed chain must verify");
+    assert_eq!(result.entries_checked, 3);
+}

--- a/aa-proto/src/lib.rs
+++ b/aa-proto/src/lib.rs
@@ -44,6 +44,9 @@ pub mod assembly {
 
     pub mod event {
         pub mod v1 {
+            // AuditEvent grew with AAASM-934 lineage fields; the Payload oneof
+            // variant size disparity is expected in generated code.
+            #![allow(clippy::large_enum_variant)]
             tonic::include_proto!("assembly.event.v1");
         }
     }

--- a/aa-runtime/src/ipc/message.rs
+++ b/aa-runtime/src/ipc/message.rs
@@ -14,6 +14,9 @@ use aa_proto::assembly::policy::v1::CheckActionRequest;
 /// - `2` = EventReport
 /// - `3` = ApprovalResponse
 /// - `4` = Heartbeat
+// AuditEvent grew with AAASM-934 lineage fields; the size disparity between
+// EventReport and the other variants is inherent to the design.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum IpcFrame {
     /// A policy check request — SDK asks the runtime to evaluate an action.

--- a/proto/audit.proto
+++ b/proto/audit.proto
@@ -53,6 +53,25 @@ message AuditEvent {
 
   // Arbitrary labels attached at event creation for downstream query filtering.
   map<string, string> labels = 20;
+
+  // ── Lineage fields (AAASM-934) ──────────────────────────────────────────
+  // All optional. Populated when the emitting agent registered with lineage
+  // context. Absent (default empty) for legacy events and root agents.
+
+  // Root of the delegation chain; equals agent_id for root agents.
+  string root_agent_id    = 21;
+  // The agent that directly spawned this one; empty for root agents.
+  string parent_agent_id  = 22;
+  // Team this agent belongs to; empty if not set.
+  string team_id          = 23;
+  // Session identifier for this agent run.
+  string session_id       = 24;
+  // Human-readable reason the parent delegated to this agent.
+  string delegation_reason = 25;
+  // Tool or framework that triggered the spawn (e.g. "langgraph.subgraph").
+  string spawned_by_tool  = 26;
+  // Delegation depth — 0 for root agents, +1 per level.
+  uint32 depth            = 27;
 }
 
 // ── Detail messages ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## What changed

Added a `Lineage` struct to `aa-core` and wired 6 new optional topology fields (`root_agent_id`, `parent_agent_id`, `team_id`, `delegation_reason`, `spawned_by_tool`, `depth`) into `AuditEntry`. The gateway's `AuditServiceImpl` now enriches entries from the `AgentRegistry` at event-ingest time. A new `aasm audit verify-chain` CLI subcommand exposes hash-chain verification to operators. Proto `AuditEvent` gains 7 matching lineage fields (numbers 21–27).

## Why it changed

AAASM-934 (F101): audit trail lacks agent topology context — reviewers cannot trace which parent spawned an agent, what team it belongs to, or how deep in a delegation chain it sits. Lineage fields close that gap without breaking the existing hash chain (empty lineage contributes zero bytes, so legacy entries verify unchanged).

## How to verify

```bash
cd agent-assembly
cargo nextest run -p aa-core                  # 130 tests — includes 8 new lineage tests
cargo nextest run -p aa-gateway               # 302 tests — includes new integration test
cargo nextest run -p aa-cli                   # verify-chain subcommand tests pass
cargo clippy --all-targets -- -D warnings     # zero new warnings
```

Key tests:
- `aa_core::audit::lineage_tests::*` — Lineage hash correctness + backward compat
- `aa_gateway::audit_integration_test::audit_service_populates_lineage_from_registry` — registry enrichment E2E
- `aa_gateway::audit_lineage_test::*` — 6 regression/integration tests
- `aa_cli::commands::audit::verify_chain::tests::*` — CLI subcommand

## Related

Closes AAASM-934
Subtasks: AAASM-955, AAASM-960, AAASM-965, AAASM-969, AAASM-975