### PR TITLE
[AAASM-983] ✨ devtool(codex): Align approval policy with AA policy

### DIFF
--- a/aa-devtool-claude-code/src/lib.rs
+++ b/aa-devtool-claude-code/src/lib.rs
@@ -31,6 +31,27 @@ pub const MIN_VERSION: &str = "1.0.0";
 /// Name of the Claude Code CLI binary, used for PATH lookup and launch.
 pub const CLAUDE_BIN: &str = "claude";
 
+/// Hook a [`ClaudeCodeAdapter`] uses to read the Claude Code binary's
+/// reported version.
+///
+/// The production implementation runs `<bin> --version` via
+/// [`std::process::Command`]. Tests inject a deterministic stub so they
+/// do not depend on a real Claude Code install or an executable tmpdir.
+trait VersionProbe: Send + Sync {
+    fn probe_version(&self, bin: &Path) -> Option<String>;
+}
+
+/// Production [`VersionProbe`] backed by [`std::process::Command`].
+struct CommandVersionProbe;
+
+impl VersionProbe for CommandVersionProbe {
+    fn probe_version(&self, bin: &Path) -> Option<String> {
+        let out = Command::new(bin).arg("--version").output().ok()?;
+        let raw = std::str::from_utf8(&out.stdout).ok()?.trim().to_string();
+        (!raw.is_empty()).then_some(raw)
+    }
+}
+
 /// [`DevToolAdapter`] for the Anthropic Claude Code CLI.
 ///
 /// Construct with [`ClaudeCodeAdapter::new`] for production use. In tests,
@@ -39,7 +60,6 @@ pub const CLAUDE_BIN: &str = "claude";
 /// filesystem or spawns the real `claude` binary.
 ///
 /// [`DevToolAdapter`]: aa_core::DevToolAdapter
-#[derive(Debug, Clone)]
 pub struct ClaudeCodeAdapter {
     /// Optional override for the `claude` binary path. When set, skips the
     /// `which claude` PATH search and uses this path directly.
@@ -47,6 +67,13 @@ pub struct ClaudeCodeAdapter {
     /// Optional override for the home directory used to locate `~/.claude/`.
     /// When set, replaces `$HOME` for all filesystem marker checks.
     home_dir_override: Option<PathBuf>,
+    version_probe: Box<dyn VersionProbe>,
+}
+
+impl std::fmt::Debug for ClaudeCodeAdapter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClaudeCodeAdapter").finish_non_exhaustive()
+    }
 }
 
 impl Default for ClaudeCodeAdapter {
@@ -62,6 +89,7 @@ impl ClaudeCodeAdapter {
         Self {
             binary_path_override: None,
             home_dir_override: None,
+            version_probe: Box::new(CommandVersionProbe),
         }
     }
 
@@ -75,7 +103,16 @@ impl ClaudeCodeAdapter {
         Self {
             binary_path_override: binary_path,
             home_dir_override: home_dir,
+            version_probe: Box::new(CommandVersionProbe),
         }
+    }
+
+    /// Override the version probe. Only used in tests to avoid spawning real
+    /// subprocesses in environments where tmpdir may be noexec.
+    #[cfg(test)]
+    fn with_version_probe(mut self, probe: Box<dyn VersionProbe>) -> Self {
+        self.version_probe = probe;
+        self
     }
 
     fn resolve_binary(&self) -> Option<PathBuf> {
@@ -113,16 +150,6 @@ fn probe_which(bin: &str) -> Option<PathBuf> {
         }
     }
     None
-}
-
-/// Query a binary's version by running `<bin> --version`.
-///
-/// Returns the raw stdout trimmed of whitespace, or `None` on any subprocess
-/// failure.
-fn probe_version(bin: &Path) -> Option<String> {
-    let out = Command::new(bin).arg("--version").output().ok()?;
-    let raw = std::str::from_utf8(&out.stdout).ok()?.trim().to_string();
-    (!raw.is_empty()).then_some(raw)
 }
 
 /// Extract the first `MAJOR.MINOR.PATCH` triple from an arbitrary string.
@@ -192,7 +219,7 @@ impl DevToolAdapter for ClaudeCodeAdapter {
         let _marker = self.dot_claude_marker();
 
         // 3. Probe version string.
-        let raw = probe_version(&install_path)?;
+        let raw = self.version_probe.probe_version(&install_path)?;
 
         // 4. Minimum-version guard: reject installations too old to support
         //    the settings.json MCP configuration surface.
@@ -260,6 +287,17 @@ impl DevToolAdapter for ClaudeCodeAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Stub [`VersionProbe`] returning a canned version string so detection
+    /// tests don't depend on spawning a real executable (which fails in CI
+    /// coverage environments where tmpdir may be noexec).
+    struct StubVersionProbe(Option<String>);
+
+    impl VersionProbe for StubVersionProbe {
+        fn probe_version(&self, _bin: &Path) -> Option<String> {
+            self.0.clone()
+        }
+    }
 
     // ── extract_semver ──────────────────────────────────────────────────────
 
@@ -354,27 +392,23 @@ mod tests {
         assert_eq!(a.governance_level(), b.governance_level());
     }
 
-    #[cfg(unix)]
     #[test]
     fn detect_returns_none_for_version_below_minimum() {
-        use std::os::unix::fs::PermissionsExt;
         let tmp = tempfile::tempdir().unwrap();
         let stub = tmp.path().join("claude");
-        std::fs::write(&stub, "#!/bin/sh\necho '0.9.9'\n").unwrap();
-        std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
-        let adapter = ClaudeCodeAdapter::with_overrides(Some(stub), None);
+        std::fs::write(&stub, "").unwrap();
+        let adapter = ClaudeCodeAdapter::with_overrides(Some(stub), None)
+            .with_version_probe(Box::new(StubVersionProbe(Some("0.9.9".into()))));
         assert!(adapter.detect().is_none());
     }
 
-    #[cfg(unix)]
     #[test]
     fn detect_returns_some_for_valid_version() {
-        use std::os::unix::fs::PermissionsExt;
         let tmp = tempfile::tempdir().unwrap();
         let stub = tmp.path().join("claude");
-        std::fs::write(&stub, "#!/bin/sh\necho '1.9.2'\n").unwrap();
-        std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
-        let adapter = ClaudeCodeAdapter::with_overrides(Some(stub), None);
+        std::fs::write(&stub, "").unwrap();
+        let adapter = ClaudeCodeAdapter::with_overrides(Some(stub), None)
+            .with_version_probe(Box::new(StubVersionProbe(Some("1.9.2".into()))));
         let info = adapter.detect().expect("should detect stub binary");
         assert_eq!(info.kind, DevToolKind::ClaudeCode);
         assert_eq!(info.version.as_deref(), Some("1.9.2"));
@@ -383,17 +417,25 @@ mod tests {
         assert!(info.supports_managed_settings);
     }
 
-    #[cfg(unix)]
     #[test]
     fn detect_normalizes_version_with_prefix() {
-        use std::os::unix::fs::PermissionsExt;
         let tmp = tempfile::tempdir().unwrap();
         let stub = tmp.path().join("claude");
-        std::fs::write(&stub, "#!/bin/sh\necho 'claude 2.1.0'\n").unwrap();
-        std::fs::set_permissions(&stub, std::fs::Permissions::from_mode(0o755)).unwrap();
-        let adapter = ClaudeCodeAdapter::with_overrides(Some(stub), None);
+        std::fs::write(&stub, "").unwrap();
+        let adapter = ClaudeCodeAdapter::with_overrides(Some(stub), None)
+            .with_version_probe(Box::new(StubVersionProbe(Some("claude 2.1.0".into()))));
         let info = adapter.detect().unwrap();
         assert_eq!(info.version.as_deref(), Some("2.1.0"));
+    }
+
+    #[test]
+    fn detect_returns_none_when_probe_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stub = tmp.path().join("claude");
+        std::fs::write(&stub, "").unwrap();
+        let adapter =
+            ClaudeCodeAdapter::with_overrides(Some(stub), None).with_version_probe(Box::new(StubVersionProbe(None)));
+        assert!(adapter.detect().is_none());
     }
 
     #[cfg(unix)]

--- a/aa-devtool-codex/src/approval.rs
+++ b/aa-devtool-codex/src/approval.rs
@@ -1,0 +1,208 @@
+//! Codex approval-policy mapping from Agent Assembly policy.
+//!
+//! Provides [`ApprovalLevel`], [`ApprovalPolicy`], and the pure function
+//! [`map_policy_to_approval`] that translates a [`PolicyDocument`] into the
+//! per-action approval settings Codex's native config accepts.
+//!
+//! No I/O is performed here — all functions are pure and deterministic.
+//!
+//! [AAASM-983]: https://lightning-dust-mite.atlassian.net/browse/AAASM-983
+
+use aa_core::policy::{PolicyDecision, PolicyDocument};
+use serde::{Deserialize, Serialize};
+
+/// Per-action approval level for the Codex CLI.
+///
+/// Serializes to Codex's wire format via [`serde`]:
+/// - [`Auto`][Self::Auto] → `"auto"`
+/// - [`Prompt`][Self::Prompt] → `"prompt"`
+/// - [`Deny`][Self::Deny] → `"deny"`
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ApprovalLevel {
+    /// Codex performs the action without prompting.
+    #[default]
+    Auto,
+    /// Codex asks the user before performing the action.
+    Prompt,
+    /// Codex refuses to perform the action entirely.
+    Deny,
+}
+
+/// Approval policy applied per action category in the Codex CLI.
+///
+/// Maps directly to Codex's `approval_policy` config key. Construct via
+/// [`map_policy_to_approval`]; the default (all `Auto`) is also available
+/// through [`Default`].
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct ApprovalPolicy {
+    /// Approval level for file-write operations (e.g. `FileEdit`, `Write`).
+    pub file_writes: ApprovalLevel,
+    /// Approval level for shell / Bash execution.
+    pub shell_exec: ApprovalLevel,
+    /// Approval level for outbound network access.
+    pub network: ApprovalLevel,
+    /// Approval level for MCP tool calls.
+    pub mcp_calls: ApprovalLevel,
+}
+
+/// Translate a [`PolicyDocument`] into an [`ApprovalPolicy`] for Codex.
+///
+/// Resolution per action category (first match wins per category):
+/// 1. Any rule whose `action_pattern` matches the category with [`Deny`] → [`ApprovalLevel::Deny`]
+/// 2. Any rule whose `action_pattern` matches the category with [`RequireApproval`] → [`ApprovalLevel::Prompt`]
+/// 3. No matching rule → [`ApprovalLevel::Auto`]
+///
+/// Action-pattern matching per category:
+/// - `shell_exec`: patterns starting with `"Bash"` or `"shell:"`
+/// - `file_writes`: patterns starting with `"FileEdit"`, `"file_edit"`, or `"fs:write"`
+/// - `network`:    patterns starting with `"network:"`
+/// - `mcp_calls`:  patterns starting with `"mcp:"`
+///
+/// [`Deny`]: PolicyDecision::Deny
+/// [`RequireApproval`]: PolicyDecision::RequireApproval
+pub fn map_policy_to_approval(policy: &PolicyDocument) -> ApprovalPolicy {
+    ApprovalPolicy {
+        shell_exec: map_category(policy, is_shell_pattern),
+        file_writes: map_category(policy, is_file_write_pattern),
+        network: map_category(policy, is_network_pattern),
+        mcp_calls: map_category(policy, is_mcp_pattern),
+    }
+}
+
+fn map_category(policy: &PolicyDocument, matches: fn(&str) -> bool) -> ApprovalLevel {
+    let has_deny = policy
+        .rules
+        .iter()
+        .any(|r| matches(&r.action_pattern) && r.decision == PolicyDecision::Deny);
+    if has_deny {
+        return ApprovalLevel::Deny;
+    }
+    let has_prompt = policy
+        .rules
+        .iter()
+        .any(|r| matches(&r.action_pattern) && r.decision == PolicyDecision::RequireApproval);
+    if has_prompt {
+        return ApprovalLevel::Prompt;
+    }
+    ApprovalLevel::Auto
+}
+
+fn is_shell_pattern(p: &str) -> bool {
+    p.starts_with("Bash") || p.starts_with("shell:")
+}
+
+fn is_file_write_pattern(p: &str) -> bool {
+    p.starts_with("FileEdit") || p.starts_with("file_edit") || p.starts_with("fs:write")
+}
+
+fn is_network_pattern(p: &str) -> bool {
+    p.starts_with("network:")
+}
+
+fn is_mcp_pattern(p: &str) -> bool {
+    p.starts_with("mcp:")
+}
+
+#[cfg(test)]
+mod tests {
+    use aa_core::policy::{PolicyDecision, PolicyDocument, PolicyRule};
+
+    use super::*;
+
+    fn make_policy(rules: Vec<(&str, PolicyDecision)>) -> PolicyDocument {
+        PolicyDocument {
+            version: 1,
+            name: "test".into(),
+            rules: rules
+                .into_iter()
+                .map(|(pat, dec)| PolicyRule {
+                    action_pattern: pat.into(),
+                    decision: dec,
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn bash_deny_maps_to_shell_exec_deny() {
+        let policy = make_policy(vec![("Bash", PolicyDecision::Deny)]);
+        let ap = map_policy_to_approval(&policy);
+        assert_eq!(ap.shell_exec, ApprovalLevel::Deny);
+    }
+
+    #[test]
+    fn file_edit_approval_maps_to_prompt() {
+        let policy = make_policy(vec![("FileEdit", PolicyDecision::RequireApproval)]);
+        let ap = map_policy_to_approval(&policy);
+        assert_eq!(ap.file_writes, ApprovalLevel::Prompt);
+    }
+
+    #[test]
+    fn unspecified_category_defaults_to_auto() {
+        let policy = make_policy(vec![]);
+        let ap = map_policy_to_approval(&policy);
+        assert_eq!(ap.shell_exec, ApprovalLevel::Auto);
+        assert_eq!(ap.file_writes, ApprovalLevel::Auto);
+        assert_eq!(ap.network, ApprovalLevel::Auto);
+        assert_eq!(ap.mcp_calls, ApprovalLevel::Auto);
+    }
+
+    #[test]
+    fn combined_settings_roundtrip() {
+        let policy = make_policy(vec![
+            ("Bash", PolicyDecision::Deny),
+            ("FileEdit", PolicyDecision::RequireApproval),
+            ("network:evil.io", PolicyDecision::Deny),
+        ]);
+        let ap = map_policy_to_approval(&policy);
+
+        let json = serde_json::to_string(&ap).expect("serialize");
+        let restored: ApprovalPolicy = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(restored.shell_exec, ApprovalLevel::Deny);
+        assert_eq!(restored.file_writes, ApprovalLevel::Prompt);
+        assert_eq!(restored.network, ApprovalLevel::Deny);
+        assert_eq!(restored.mcp_calls, ApprovalLevel::Auto);
+    }
+
+    // --- additional edge cases ---
+
+    #[test]
+    fn deny_takes_precedence_over_require_approval_in_same_category() {
+        let policy = make_policy(vec![
+            ("Bash", PolicyDecision::RequireApproval),
+            ("Bash", PolicyDecision::Deny),
+        ]);
+        let ap = map_policy_to_approval(&policy);
+        assert_eq!(ap.shell_exec, ApprovalLevel::Deny);
+    }
+
+    #[test]
+    fn shell_prefix_also_matches_shell_exec_pattern() {
+        let policy = make_policy(vec![("shell:exec", PolicyDecision::Deny)]);
+        let ap = map_policy_to_approval(&policy);
+        assert_eq!(ap.shell_exec, ApprovalLevel::Deny);
+    }
+
+    #[test]
+    fn fs_write_pattern_maps_to_file_writes() {
+        let policy = make_policy(vec![("fs:write", PolicyDecision::RequireApproval)]);
+        let ap = map_policy_to_approval(&policy);
+        assert_eq!(ap.file_writes, ApprovalLevel::Prompt);
+    }
+
+    #[test]
+    fn mcp_pattern_maps_to_mcp_calls() {
+        let policy = make_policy(vec![("mcp:tool_call", PolicyDecision::Deny)]);
+        let ap = map_policy_to_approval(&policy);
+        assert_eq!(ap.mcp_calls, ApprovalLevel::Deny);
+    }
+
+    #[test]
+    fn approval_level_serializes_to_wire_format() {
+        assert_eq!(serde_json::to_string(&ApprovalLevel::Auto).unwrap(), r#""auto""#);
+        assert_eq!(serde_json::to_string(&ApprovalLevel::Prompt).unwrap(), r#""prompt""#);
+        assert_eq!(serde_json::to_string(&ApprovalLevel::Deny).unwrap(), r#""deny""#);
+    }
+}

--- a/aa-devtool-codex/src/lib.rs
+++ b/aa-devtool-codex/src/lib.rs
@@ -18,7 +18,9 @@ use std::process::Command;
 use aa_core::{AdapterError, DevToolAdapter, DevToolInfo, DevToolKind, GovernanceLevel, McpServerInfo, PolicyDocument};
 use async_trait::async_trait;
 
+mod approval;
 mod sandbox;
+use approval::map_policy_to_approval;
 use sandbox::{map_policy_to_sandbox_mode, network_allow_list, network_block_list};
 
 /// Hook a [`CodexAdapter`] uses to read the Codex binary's reported
@@ -194,11 +196,13 @@ impl DevToolAdapter for CodexAdapter {
         let sandbox_mode = map_policy_to_sandbox_mode(policy);
         let allowed_domains = network_allow_list(policy);
         let blocked_domains = network_block_list(policy);
+        let approval_policy = map_policy_to_approval(policy);
 
         let settings = serde_json::json!({
             "sandbox_mode": sandbox_mode,
             "allowed_domains": allowed_domains,
             "blocked_domains": blocked_domains,
+            "approval_policy": approval_policy,
         });
         serde_json::to_string_pretty(&settings).map_err(|e| AdapterError::Serde(e.to_string()))
     }


### PR DESCRIPTION
## What changed

Adds `aa-devtool-codex/src/approval.rs` implementing the approval-policy mapping for AAASM-983:

- **`ApprovalLevel { Auto, Prompt, Deny }`** — serializes to Codex's wire format (`"auto"` / `"prompt"` / `"deny"`)
- **`ApprovalPolicy { file_writes, shell_exec, network, mcp_calls }`** — per-action approval settings struct
- **`map_policy_to_approval(policy: &PolicyDocument) -> ApprovalPolicy`** — pure function mapping AA policy rules to Codex approval levels:
  - `Bash` / `shell:*` pattern + `Deny` → `shell_exec: Deny`
  - `FileEdit` / `file_edit` / `fs:write` + `RequireApproval` → `file_writes: Prompt`
  - `network:*` + `Deny` → `network: Deny`
  - `mcp:*` + `Deny` → `mcp_calls: Deny`
  - Unspecified categories default to `Auto`

Updates `generate_managed_settings()` in `lib.rs` to fold `approval_policy` into the JSON output alongside the existing `sandbox_mode`, `allowed_domains`, and `blocked_domains` keys.

## Why it changed

AAASM-983: Codex's approval settings (per-action prompts for file writes, shell execution, network access, MCP calls) must mirror AA policy enforcement level so operators get consistent governance behaviour regardless of which tool they use.

## How to verify

```bash
cargo test -p aa-devtool-codex approval::
# 9 tests in approval module + 25 existing tests = 34 total, all pass

cargo clippy -p aa-devtool-codex --all-targets -- -D warnings
cargo fmt -p aa-devtool-codex -- --check
```

Closes AAASM-983