### PR TITLE
[AAASM-952] ✨ (aa-devtool-claude-code): Implement generate_managed_settings()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,7 @@ version = "0.0.1"
 dependencies = [
  "aa-core",
  "async-trait",
+ "insta",
  "serde",
  "serde_json",
  "tempfile",
@@ -260,7 +261,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.11.0",
- "similar",
+ "similar 3.1.0",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2511,6 +2512,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar 2.7.0",
+ "tempfile",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4651,6 +4665,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "similar"

--- a/aa-devtool-claude-code/Cargo.toml
+++ b/aa-devtool-claude-code/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 [dev-dependencies]
+insta = { version = "1", features = ["json"] }
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt"] }
 

--- a/aa-devtool-claude-code/src/lib.rs
+++ b/aa-devtool-claude-code/src/lib.rs
@@ -245,11 +245,10 @@ impl DevToolAdapter for ClaudeCodeAdapter {
         })
     }
 
-    async fn generate_managed_settings(&self, _policy: &PolicyDocument) -> Result<String, AdapterError> {
-        // Implemented in AAASM-952.
-        Err(AdapterError::SettingsGenerationFailed(
-            "not yet implemented (AAASM-952)".into(),
-        ))
+    async fn generate_managed_settings(&self, policy: &PolicyDocument) -> Result<String, AdapterError> {
+        let s = settings::map_policy_to_settings(policy);
+        serde_json::to_string_pretty(&s)
+            .map_err(|e| AdapterError::SettingsGenerationFailed(e.to_string()))
     }
 
     async fn apply_settings(&self, _settings: &str) -> Result<(), AdapterError> {

--- a/aa-devtool-claude-code/src/lib.rs
+++ b/aa-devtool-claude-code/src/lib.rs
@@ -247,8 +247,7 @@ impl DevToolAdapter for ClaudeCodeAdapter {
 
     async fn generate_managed_settings(&self, policy: &PolicyDocument) -> Result<String, AdapterError> {
         let s = settings::map_policy_to_settings(policy);
-        serde_json::to_string_pretty(&s)
-            .map_err(|e| AdapterError::SettingsGenerationFailed(e.to_string()))
+        serde_json::to_string_pretty(&s).map_err(|e| AdapterError::SettingsGenerationFailed(e.to_string()))
     }
 
     async fn apply_settings(&self, _settings: &str) -> Result<(), AdapterError> {

--- a/aa-devtool-claude-code/src/lib.rs
+++ b/aa-devtool-claude-code/src/lib.rs
@@ -14,6 +14,8 @@
 
 #![warn(missing_docs)]
 
+mod settings;
+
 use std::path::{Path, PathBuf};
 use std::process::Command;
 

--- a/aa-devtool-claude-code/src/settings.rs
+++ b/aa-devtool-claude-code/src/settings.rs
@@ -78,7 +78,11 @@ mod tests {
     }
 
     fn doc(rules: Vec<PolicyRule>) -> PolicyDocument {
-        PolicyDocument { version: 1, name: "test".to_string(), rules }
+        PolicyDocument {
+            version: 1,
+            name: "test".to_string(),
+            rules,
+        }
     }
 
     #[test]

--- a/aa-devtool-claude-code/src/settings.rs
+++ b/aa-devtool-claude-code/src/settings.rs
@@ -1,3 +1,4 @@
+use aa_core::{PolicyDecision, PolicyDocument};
 use serde::Serialize;
 
 #[derive(Debug, Clone, Serialize)]
@@ -13,4 +14,53 @@ pub(crate) struct ClaudeSettings {
     pub permission_mode: String,
     pub enabled_mcpjson_servers: Vec<String>,
     pub disabled_mcpjson_servers: Vec<String>,
+}
+
+pub(crate) fn map_policy_to_settings(policy: &PolicyDocument) -> ClaudeSettings {
+    let mut allow = Vec::new();
+    let mut deny = Vec::new();
+    let mut enabled_mcp = Vec::new();
+    let mut disabled_mcp = Vec::new();
+    let mut has_deny = false;
+    let mut has_require_approval = false;
+
+    for rule in &policy.rules {
+        let pattern = &rule.action_pattern;
+        if let Some(server) = pattern.strip_prefix("mcp:") {
+            match rule.decision {
+                PolicyDecision::Allow => enabled_mcp.push(server.to_string()),
+                PolicyDecision::Deny | PolicyDecision::RequireApproval => {
+                    disabled_mcp.push(server.to_string());
+                }
+            }
+        } else {
+            match rule.decision {
+                PolicyDecision::Allow => allow.push(pattern.clone()),
+                PolicyDecision::Deny => {
+                    deny.push(pattern.clone());
+                    has_deny = true;
+                }
+                PolicyDecision::RequireApproval => {
+                    deny.push(pattern.clone());
+                    has_require_approval = true;
+                }
+            }
+        }
+    }
+
+    let permission_mode = if has_require_approval {
+        "plan"
+    } else if has_deny {
+        "default"
+    } else {
+        "acceptEdits"
+    }
+    .to_string();
+
+    ClaudeSettings {
+        permissions: ClaudePermissions { allow, deny },
+        permission_mode,
+        enabled_mcpjson_servers: enabled_mcp,
+        disabled_mcpjson_servers: disabled_mcp,
+    }
 }

--- a/aa-devtool-claude-code/src/settings.rs
+++ b/aa-devtool-claude-code/src/settings.rs
@@ -64,3 +64,86 @@ pub(crate) fn map_policy_to_settings(policy: &PolicyDocument) -> ClaudeSettings 
         disabled_mcpjson_servers: disabled_mcp,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aa_core::{PolicyDecision, PolicyDocument, PolicyRule};
+
+    fn rule(pattern: &str, decision: PolicyDecision) -> PolicyRule {
+        PolicyRule {
+            action_pattern: pattern.to_string(),
+            decision,
+        }
+    }
+
+    fn doc(rules: Vec<PolicyRule>) -> PolicyDocument {
+        PolicyDocument { version: 1, name: "test".to_string(), rules }
+    }
+
+    #[test]
+    fn policy_with_bash_allow_emits_allow_bash() {
+        let policy = doc(vec![rule("Bash", PolicyDecision::Allow)]);
+        let s = map_policy_to_settings(&policy);
+        assert_eq!(s.permissions.allow, vec!["Bash"]);
+        assert!(s.permissions.deny.is_empty());
+    }
+
+    #[test]
+    fn enforce_policy_maps_to_default_mode() {
+        let policy = doc(vec![
+            rule("Bash", PolicyDecision::Allow),
+            rule("Edit", PolicyDecision::Deny),
+        ]);
+        let s = map_policy_to_settings(&policy);
+        assert_eq!(s.permission_mode, "default");
+        assert_eq!(s.permissions.deny, vec!["Edit"]);
+    }
+
+    #[test]
+    fn permissive_policy_maps_to_accept_edits() {
+        let policy = doc(vec![
+            rule("Bash", PolicyDecision::Allow),
+            rule("Read", PolicyDecision::Allow),
+        ]);
+        let s = map_policy_to_settings(&policy);
+        assert_eq!(s.permission_mode, "acceptEdits");
+    }
+
+    #[test]
+    fn mcp_allow_list_emits_enabled_servers() {
+        let policy = doc(vec![
+            rule("mcp:filesystem", PolicyDecision::Allow),
+            rule("mcp:search", PolicyDecision::Deny),
+        ]);
+        let s = map_policy_to_settings(&policy);
+        assert_eq!(s.enabled_mcpjson_servers, vec!["filesystem"]);
+        assert_eq!(s.disabled_mcpjson_servers, vec!["search"]);
+    }
+
+    #[test]
+    fn require_approval_maps_to_plan_mode() {
+        let policy = doc(vec![
+            rule("Bash", PolicyDecision::Allow),
+            rule("Edit", PolicyDecision::RequireApproval),
+        ]);
+        let s = map_policy_to_settings(&policy);
+        assert_eq!(s.permission_mode, "plan");
+        assert_eq!(s.permissions.deny, vec!["Edit"]);
+    }
+
+    #[test]
+    fn snapshot_full_policy_fixture() {
+        let policy = doc(vec![
+            rule("Bash", PolicyDecision::Allow),
+            rule("Read", PolicyDecision::Allow),
+            rule("Edit", PolicyDecision::Deny),
+            rule("WebFetch", PolicyDecision::RequireApproval),
+            rule("mcp:filesystem", PolicyDecision::Allow),
+            rule("mcp:search", PolicyDecision::Deny),
+        ]);
+        let s = map_policy_to_settings(&policy);
+        let json = serde_json::to_string_pretty(&s).unwrap();
+        insta::assert_snapshot!(json);
+    }
+}

--- a/aa-devtool-claude-code/src/settings.rs
+++ b/aa-devtool-claude-code/src/settings.rs
@@ -1,0 +1,16 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ClaudePermissions {
+    pub allow: Vec<String>,
+    pub deny: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ClaudeSettings {
+    pub permissions: ClaudePermissions,
+    pub permission_mode: String,
+    pub enabled_mcpjson_servers: Vec<String>,
+    pub disabled_mcpjson_servers: Vec<String>,
+}

--- a/aa-devtool-claude-code/src/snapshots/aa_devtool_claude_code__settings__tests__snapshot_full_policy_fixture.snap
+++ b/aa-devtool-claude-code/src/snapshots/aa_devtool_claude_code__settings__tests__snapshot_full_policy_fixture.snap
@@ -1,0 +1,24 @@
+---
+source: aa-devtool-claude-code/src/settings.rs
+assertion_line: 147
+expression: json
+---
+{
+  "permissions": {
+    "allow": [
+      "Bash",
+      "Read"
+    ],
+    "deny": [
+      "Edit",
+      "WebFetch"
+    ]
+  },
+  "permissionMode": "plan",
+  "enabledMcpjsonServers": [
+    "filesystem"
+  ],
+  "disabledMcpjsonServers": [
+    "search"
+  ]
+}


### PR DESCRIPTION
## What changed

Implements `generate_managed_settings()` for the Claude Code `DevToolAdapter` (AAASM-952). The method converts an `aa-core` `PolicyDocument` into the JSON payload that maps to Claude Code's `~/.claude/settings.json` structure.

Key additions in `aa-devtool-claude-code`:
- `src/settings.rs` — new module: `ClaudeSettings` / `ClaudePermissions` structs (camelCase JSON via serde), and `map_policy_to_settings()` which derives `permissionMode` from the dominant `PolicyDecision` in the rule set (`RequireApproval` → `"plan"`, any `Deny` → `"default"`, all-Allow → `"acceptEdits"`) and routes `mcp:`-prefixed patterns to `enabledMcpjsonServers` / `disabledMcpjsonServers`.
- `src/lib.rs` — wires `generate_managed_settings()` to call the new mapper and serialize with `serde_json::to_string_pretty`.
- 6 tests (4 unit + 1 insta snapshot) covering all `permissionMode` variants, MCP routing, and a full-policy fixture.
- `insta` added as dev-dependency.

## Why it changed

AAASM-952 acceptance criteria: `generate_managed_settings()` must return a JSON string matching Claude Code's `settings.json` format, derived from the `PolicyDocument` passed in at runtime.

## How to verify

```bash
cargo nextest run -p aa-devtool-claude-code
```

All 28 tests pass (22 pre-existing detection tests + 6 new settings tests).

Closes #AAASM-952

🤖 Generated with [Claude Code](https://claude.com/claude-code)