### PR TITLE
[AAASM-988] ✨ devtool(codex): Apply settings + build launch command + e2e test

### DIFF
--- a/aa-devtool-codex/Cargo.toml
+++ b/aa-devtool-codex/Cargo.toml
@@ -13,5 +13,9 @@ serde        = { version = "1", features = ["derive"] }
 serde_json   = "1"
 which        = "8"
 
+[dev-dependencies]
+tempfile = "3"
+tokio    = { version = "1", features = ["macros", "rt"] }
+
 [lints]
 workspace = true

--- a/aa-devtool-codex/src/lib.rs
+++ b/aa-devtool-codex/src/lib.rs
@@ -147,13 +147,34 @@ pub const NPM_PACKAGE_BIN_RELATIVE: &str = "bin/codex";
 pub struct CodexAdapter {
     locator: Box<dyn BinaryLocator>,
     probe: Box<dyn VersionProbe>,
+    /// Overrides `$HOME` for config-path resolution. `None` → read `$HOME`.
+    /// Set via [`Self::with_home_dir`]; intended for integration tests only.
+    home_dir_override: Option<PathBuf>,
 }
 
 impl CodexAdapter {
     /// Build an adapter with custom hook implementations. Only useful
     /// in tests; production code should use [`Self::default`].
     pub fn new(locator: Box<dyn BinaryLocator>, probe: Box<dyn VersionProbe>) -> Self {
-        Self { locator, probe }
+        Self {
+            locator,
+            probe,
+            home_dir_override: None,
+        }
+    }
+
+    /// Override the home directory used to locate `~/.codex/config.json`.
+    /// Intended for integration tests; production code uses `$HOME`.
+    #[doc(hidden)]
+    pub fn with_home_dir(mut self, path: PathBuf) -> Self {
+        self.home_dir_override = Some(path);
+        self
+    }
+
+    fn home_dir(&self) -> Option<PathBuf> {
+        self.home_dir_override
+            .clone()
+            .or_else(|| std::env::var_os("HOME").map(PathBuf::from))
     }
 }
 
@@ -162,6 +183,7 @@ impl Default for CodexAdapter {
         Self {
             locator: Box::new(DefaultBinaryLocator),
             probe: Box::new(CommandVersionProbe),
+            home_dir_override: None,
         }
     }
 }
@@ -207,20 +229,76 @@ impl DevToolAdapter for CodexAdapter {
         serde_json::to_string_pretty(&settings).map_err(|e| AdapterError::Serde(e.to_string()))
     }
 
-    async fn apply_settings(&self, _settings: &str) -> Result<(), AdapterError> {
-        // Writing to ~/.codex/config.toml lands in AAASM-988.
-        unimplemented!("apply_settings — implemented in AAASM-988")
+    async fn apply_settings(&self, settings: &str) -> Result<(), AdapterError> {
+        let home = self.home_dir().ok_or_else(|| {
+            AdapterError::SettingsApplyFailed(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "HOME directory not found",
+            ))
+        })?;
+        let config_path = home.join(".codex").join("config.json");
+
+        // Parse incoming AA-managed settings.
+        let new_val: serde_json::Value =
+            serde_json::from_str(settings).map_err(|e| AdapterError::Serde(e.to_string()))?;
+
+        // Load existing config (if any) so user-managed keys are preserved.
+        let mut merged: serde_json::Map<String, serde_json::Value> = if config_path.exists() {
+            let raw = std::fs::read_to_string(&config_path).map_err(AdapterError::SettingsApplyFailed)?;
+            serde_json::from_str::<serde_json::Value>(&raw)
+                .ok()
+                .and_then(|v| match v {
+                    serde_json::Value::Object(m) => Some(m),
+                    _ => None,
+                })
+                .unwrap_or_default()
+        } else {
+            serde_json::Map::new()
+        };
+
+        // AA-managed keys win; user-managed keys not present in `settings` survive.
+        if let serde_json::Value::Object(new_map) = new_val {
+            merged.extend(new_map);
+        }
+
+        let content = serde_json::to_string_pretty(&merged).map_err(|e| AdapterError::Serde(e.to_string()))?;
+
+        // Ensure ~/.codex/ exists.
+        if let Some(parent) = config_path.parent() {
+            std::fs::create_dir_all(parent).map_err(AdapterError::SettingsApplyFailed)?;
+        }
+
+        // Atomic write: write to a sibling tmp file then rename.
+        let tmp_path = config_path.with_extension("tmp");
+        std::fs::write(&tmp_path, content.as_bytes()).map_err(AdapterError::SettingsApplyFailed)?;
+        std::fs::rename(&tmp_path, &config_path).map_err(AdapterError::SettingsApplyFailed)?;
+
+        Ok(())
     }
 
     fn build_launch_command(
         &self,
-        _tool_args: &[String],
-        _agent_id: &str,
-        _team_id: Option<&str>,
-        _proxy_addr: Option<&str>,
+        tool_args: &[String],
+        agent_id: &str,
+        team_id: Option<&str>,
+        proxy_addr: Option<&str>,
     ) -> Result<Command, AdapterError> {
-        // Launch wiring lands in AAASM-988.
-        unimplemented!("build_launch_command — implemented in AAASM-988")
+        let bin = self
+            .locator
+            .locate_via_path()
+            .or_else(|| self.locator.locate_via_npm_global())
+            .ok_or_else(|| AdapterError::LaunchFailed("codex binary not found on PATH or npm global".into()))?;
+
+        let mut cmd = Command::new(bin);
+        cmd.args(tool_args);
+        cmd.env("AA_AGENT_ID", agent_id);
+        if let Some(tid) = team_id {
+            cmd.env("AA_TEAM_ID", tid);
+        }
+        if let Some(proxy) = proxy_addr {
+            cmd.env("HTTPS_PROXY", proxy);
+        }
+        Ok(cmd)
     }
 
     async fn list_mcp_servers(&self) -> Result<Vec<McpServerInfo>, AdapterError> {

--- a/aa-devtool-codex/tests/wrapper.rs
+++ b/aa-devtool-codex/tests/wrapper.rs
@@ -1,0 +1,215 @@
+//! Integration tests for `CodexAdapter::apply_settings` and
+//! `CodexAdapter::build_launch_command` (AAASM-988).
+//!
+//! These tests use `tempfile::TempDir` for `$HOME` so they never touch
+//! the real filesystem. The Codex binary is never spawned — only the
+//! prepared `Command` value is inspected.
+
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+
+use aa_core::policy::{PolicyDecision, PolicyDocument, PolicyRule};
+use aa_core::{AdapterError, DevToolAdapter};
+use aa_devtool_codex::{BinaryLocator, CodexAdapter, VersionProbe};
+
+// ---------------------------------------------------------------------------
+// Shared stubs
+// ---------------------------------------------------------------------------
+
+struct FixedLocator(PathBuf);
+
+impl BinaryLocator for FixedLocator {
+    fn locate_via_path(&self) -> Option<PathBuf> {
+        Some(self.0.clone())
+    }
+    fn locate_via_npm_global(&self) -> Option<PathBuf> {
+        None
+    }
+}
+
+struct FixedProbe;
+
+impl VersionProbe for FixedProbe {
+    fn probe_version(&self, _bin: &Path) -> Option<String> {
+        Some("0.125.0".into())
+    }
+}
+
+struct NullLocator;
+
+impl BinaryLocator for NullLocator {
+    fn locate_via_path(&self) -> Option<PathBuf> {
+        None
+    }
+    fn locate_via_npm_global(&self) -> Option<PathBuf> {
+        None
+    }
+}
+
+fn fixture_policy() -> PolicyDocument {
+    PolicyDocument {
+        version: 1,
+        name: "test".into(),
+        rules: vec![
+            PolicyRule {
+                action_pattern: "shell:exec".into(),
+                decision: PolicyDecision::Deny,
+            },
+            PolicyRule {
+                action_pattern: "network:api.openai.com".into(),
+                decision: PolicyDecision::Allow,
+            },
+        ],
+    }
+}
+
+// ---------------------------------------------------------------------------
+// apply_settings
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn apply_settings_creates_config_json_with_correct_content() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bin = tmp.path().join("codex");
+    std::fs::write(&bin, "").unwrap();
+
+    let adapter =
+        CodexAdapter::new(Box::new(FixedLocator(bin)), Box::new(FixedProbe)).with_home_dir(tmp.path().to_path_buf());
+
+    let settings = adapter.generate_managed_settings(&fixture_policy()).await.unwrap();
+    adapter.apply_settings(&settings).await.unwrap();
+
+    let config_path = tmp.path().join(".codex").join("config.json");
+    assert!(config_path.exists(), "config.json must be created");
+
+    let parsed: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+
+    assert_eq!(parsed["sandbox_mode"], "ask", "Deny rule → ask sandbox mode");
+    let allowed = parsed["allowed_domains"].as_array().unwrap();
+    assert!(
+        allowed.contains(&serde_json::json!("api.openai.com")),
+        "allowed_domains must include api.openai.com"
+    );
+}
+
+#[tokio::test]
+async fn apply_settings_merges_preserving_user_managed_keys() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bin = tmp.path().join("codex");
+    std::fs::write(&bin, "").unwrap();
+
+    // Pre-seed the config with a user-managed key.
+    let codex_dir = tmp.path().join(".codex");
+    std::fs::create_dir_all(&codex_dir).unwrap();
+    std::fs::write(
+        codex_dir.join("config.json"),
+        r#"{"user_theme": "dark", "sandbox_mode": "stale"}"#,
+    )
+    .unwrap();
+
+    let adapter =
+        CodexAdapter::new(Box::new(FixedLocator(bin)), Box::new(FixedProbe)).with_home_dir(tmp.path().to_path_buf());
+
+    // Apply an all-Allow policy — sandbox_mode becomes full-auto.
+    let allow_policy = PolicyDocument {
+        version: 1,
+        name: "allow-all".into(),
+        rules: vec![PolicyRule {
+            action_pattern: "*".into(),
+            decision: PolicyDecision::Allow,
+        }],
+    };
+    let settings = adapter.generate_managed_settings(&allow_policy).await.unwrap();
+    adapter.apply_settings(&settings).await.unwrap();
+
+    let config_path = codex_dir.join("config.json");
+    let parsed: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+
+    assert_eq!(parsed["user_theme"], "dark", "user-managed key must be preserved");
+    assert_eq!(parsed["sandbox_mode"], "full-auto", "AA-managed key must be updated");
+}
+
+#[tokio::test]
+async fn apply_settings_is_idempotent() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bin = tmp.path().join("codex");
+    std::fs::write(&bin, "").unwrap();
+
+    let adapter =
+        CodexAdapter::new(Box::new(FixedLocator(bin)), Box::new(FixedProbe)).with_home_dir(tmp.path().to_path_buf());
+
+    let settings = adapter.generate_managed_settings(&fixture_policy()).await.unwrap();
+    adapter.apply_settings(&settings).await.unwrap();
+    adapter.apply_settings(&settings).await.unwrap(); // second write must not fail
+
+    let config_path = tmp.path().join(".codex").join("config.json");
+    let parsed: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+    assert_eq!(parsed["sandbox_mode"], "ask");
+}
+
+// ---------------------------------------------------------------------------
+// build_launch_command
+// ---------------------------------------------------------------------------
+
+#[test]
+fn build_launch_command_sets_program_args_and_env() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bin = tmp.path().join("codex");
+    std::fs::write(&bin, "").unwrap();
+
+    let adapter = CodexAdapter::new(Box::new(FixedLocator(bin.clone())), Box::new(FixedProbe));
+
+    let cmd = adapter
+        .build_launch_command(
+            &["chat".to_string()],
+            "agent-1",
+            Some("team-1"),
+            Some("http://127.0.0.1:8080"),
+        )
+        .unwrap();
+
+    assert_eq!(cmd.get_program(), bin.as_os_str(), "program must be the codex binary");
+
+    let args: Vec<&OsStr> = cmd.get_args().collect();
+    assert!(args.contains(&OsStr::new("chat")), "tool_args must be forwarded");
+
+    let env: std::collections::HashMap<&OsStr, Option<&OsStr>> = cmd.get_envs().collect();
+    assert_eq!(env[OsStr::new("AA_AGENT_ID")], Some(OsStr::new("agent-1")));
+    assert_eq!(env[OsStr::new("AA_TEAM_ID")], Some(OsStr::new("team-1")));
+    assert_eq!(
+        env[OsStr::new("HTTPS_PROXY")],
+        Some(OsStr::new("http://127.0.0.1:8080"))
+    );
+}
+
+#[test]
+fn build_launch_command_omits_optional_env_when_none() {
+    let tmp = tempfile::tempdir().unwrap();
+    let bin = tmp.path().join("codex");
+    std::fs::write(&bin, "").unwrap();
+
+    let adapter = CodexAdapter::new(Box::new(FixedLocator(bin)), Box::new(FixedProbe));
+
+    let cmd = adapter.build_launch_command(&[], "agent-2", None, None).unwrap();
+
+    let env_keys: Vec<&OsStr> = cmd.get_envs().map(|(k, _)| k).collect();
+    assert!(
+        !env_keys.contains(&OsStr::new("AA_TEAM_ID")),
+        "AA_TEAM_ID must not be set when team_id is None"
+    );
+    assert!(
+        !env_keys.contains(&OsStr::new("HTTPS_PROXY")),
+        "HTTPS_PROXY must not be set when proxy_addr is None"
+    );
+}
+
+#[test]
+fn build_launch_command_fails_when_binary_not_found() {
+    let adapter = CodexAdapter::new(Box::new(NullLocator), Box::new(FixedProbe));
+
+    let result = adapter.build_launch_command(&[], "a", None, None);
+    assert!(
+        matches!(result, Err(AdapterError::LaunchFailed(_))),
+        "must return LaunchFailed when binary is not on PATH or npm global"
+    );
+}


### PR DESCRIPTION
## Summary

- Implements `apply_settings`: writes AA-managed settings JSON to `~/.codex/config.json` via atomic tmp+rename; merges with existing config to preserve user-managed keys.
- Implements `build_launch_command`: locates the codex binary via `BinaryLocator`, forwards `tool_args`, and sets `AA_AGENT_ID` / `AA_TEAM_ID` / `HTTPS_PROXY` env vars.
- Adds `tests/wrapper.rs` with 6 integration tests (config creation, merge-preservation, idempotency, env forwarding, optional-env omission, launch-failure). No `unimplemented!()` placeholders remain in the crate.

## Test plan

- [ ] `cargo nextest run -p aa-devtool-codex` — 40/40 pass locally
- [ ] `cargo clippy -p aa-devtool-codex --all-targets -- -D warnings` — clean
- [ ] `cargo fmt -p aa-devtool-codex --check` — clean
- [ ] CI Coverage, Test, Build, Clippy, Format all green

Closes AAASM-988.

🤖 Generated with [Claude Code](https://claude.com/claude-code)