### PR TITLE
[AAASM-223] ✨ (aa-gateway): Add per-team budget tracking and rollup

### DIFF
--- a/aa-api/src/alerts/store.rs
+++ b/aa-api/src/alerts/store.rs
@@ -76,6 +76,7 @@ mod tests {
     fn test_alert(threshold_pct: u8) -> BudgetAlert {
         BudgetAlert {
             agent_id: AgentId::from_bytes([1u8; 16]),
+            team_id: None,
             threshold_pct,
             spent_usd: 8.0,
             limit_usd: 10.0,

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -74,6 +74,7 @@ use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, trac
         approvals::DecideRequest,
         costs::CostSummary,
         costs::AgentCostEntry,
+        costs::TeamCostEntry,
         alerts::AlertResponse,
         auth::TokenRequest,
         auth::TokenResponse,

--- a/aa-api/src/routes/costs.rs
+++ b/aa-api/src/routes/costs.rs
@@ -20,6 +20,19 @@ pub struct AgentCostEntry {
     pub date: String,
 }
 
+/// Per-team cost entry within the budget summary.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct TeamCostEntry {
+    /// Team identifier.
+    pub team_id: String,
+    /// Daily spend for this team in USD (sum of all member agent spends today).
+    pub daily_spend_usd: String,
+    /// Total spend this month in USD for this team (if monthly tracking is enabled).
+    pub monthly_spend_usd: Option<String>,
+    /// Calendar date (YYYY-MM-DD) the daily spend applies to.
+    pub date: String,
+}
+
 /// JSON representation of the cost/budget summary.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct CostSummary {
@@ -38,6 +51,9 @@ pub struct CostSummary {
     /// Per-agent cost breakdown for the current day.
     #[serde(default)]
     pub per_agent: Vec<AgentCostEntry>,
+    /// Per-team cost rollup for the current day.
+    #[serde(default)]
+    pub per_team: Vec<TeamCostEntry>,
 }
 
 /// `GET /api/v1/costs` — cost and budget summary.
@@ -66,6 +82,18 @@ pub async fn get_cost_summary(Extension(state): Extension<AppState>) -> (StatusC
         })
         .collect();
 
+    let mut per_team: Vec<TeamCostEntry> = snapshot
+        .team_budgets
+        .iter()
+        .map(|(team_id, state)| TeamCostEntry {
+            team_id: team_id.clone(),
+            daily_spend_usd: state.spent_usd.to_string(),
+            monthly_spend_usd: state.monthly_spent_usd.map(|d| d.to_string()),
+            date: state.date.to_string(),
+        })
+        .collect();
+    per_team.sort_by(|a, b| a.team_id.cmp(&b.team_id));
+
     let summary = CostSummary {
         daily_spend_usd: snapshot.global.spent_usd.to_string(),
         monthly_spend_usd: snapshot.global.monthly_spent_usd.map(|d| d.to_string()),
@@ -73,6 +101,7 @@ pub async fn get_cost_summary(Extension(state): Extension<AppState>) -> (StatusC
         daily_limit_usd: state.budget_tracker.daily_limit_usd().map(|d| d.to_string()),
         monthly_limit_usd: state.budget_tracker.monthly_limit_usd().map(|d| d.to_string()),
         per_agent,
+        per_team,
     };
 
     (StatusCode::OK, Json(summary))
@@ -96,6 +125,7 @@ mod tests {
                 monthly_spend_usd: Some("80.00".to_string()),
                 date: "2026-04-30".to_string(),
             }],
+            per_team: vec![],
         };
         let json = serde_json::to_value(&summary).unwrap();
         assert_eq!(json["per_agent"][0]["agent_id"], "abc123");
@@ -113,6 +143,7 @@ mod tests {
             daily_limit_usd: None,
             monthly_limit_usd: None,
             per_agent: vec![],
+            per_team: vec![],
         };
         let json = serde_json::to_value(&summary).unwrap();
         assert!(json.get("daily_limit_usd").is_none());
@@ -129,10 +160,34 @@ mod tests {
             daily_limit_usd: None,
             monthly_limit_usd: None,
             per_agent: vec![],
+            per_team: vec![],
         };
         let json = serde_json::to_value(&summary).unwrap();
         assert_eq!(json["daily_spend_usd"], "8.10");
         assert_eq!(json["monthly_spend_usd"], "142.50");
         assert_eq!(json["date"], "2026-04-30");
+    }
+
+    #[test]
+    fn cost_summary_serialization_includes_per_team() {
+        let summary = CostSummary {
+            daily_spend_usd: "12.00".to_string(),
+            monthly_spend_usd: None,
+            date: "2026-04-30".to_string(),
+            daily_limit_usd: None,
+            monthly_limit_usd: None,
+            per_agent: vec![],
+            per_team: vec![TeamCostEntry {
+                team_id: "platform".to_string(),
+                daily_spend_usd: "12.00".to_string(),
+                monthly_spend_usd: None,
+                date: "2026-04-30".to_string(),
+            }],
+        };
+        let json = serde_json::to_value(&summary).unwrap();
+        assert!(json["per_team"].is_array());
+        assert_eq!(json["per_team"][0]["team_id"], "platform");
+        assert_eq!(json["per_team"][0]["daily_spend_usd"], "12.00");
+        assert!(json["per_team"][0]["monthly_spend_usd"].is_null());
     }
 }

--- a/aa-api/tests/alerts.rs
+++ b/aa-api/tests/alerts.rs
@@ -56,7 +56,7 @@ async fn list_alerts_returns_alerts_after_recording() {
     // Record an alert directly into the store.
     let alert = BudgetAlert {
         agent_id: AgentId::from_bytes([0xAB; 16]),
-            team_id: None,
+        team_id: None,
         threshold_pct: 80,
         spent_usd: 8.0,
         limit_usd: 10.0,
@@ -99,7 +99,7 @@ async fn list_alerts_via_broadcast_capture() {
     // Send an alert via broadcast.
     let alert = BudgetAlert {
         agent_id: AgentId::from_bytes([0xCD; 16]),
-            team_id: None,
+        team_id: None,
         threshold_pct: 95,
         spent_usd: 9.5,
         limit_usd: 10.0,

--- a/aa-api/tests/alerts.rs
+++ b/aa-api/tests/alerts.rs
@@ -56,6 +56,7 @@ async fn list_alerts_returns_alerts_after_recording() {
     // Record an alert directly into the store.
     let alert = BudgetAlert {
         agent_id: AgentId::from_bytes([0xAB; 16]),
+            team_id: None,
         threshold_pct: 80,
         spent_usd: 8.0,
         limit_usd: 10.0,
@@ -98,6 +99,7 @@ async fn list_alerts_via_broadcast_capture() {
     // Send an alert via broadcast.
     let alert = BudgetAlert {
         agent_id: AgentId::from_bytes([0xCD; 16]),
+            team_id: None,
         threshold_pct: 95,
         spent_usd: 9.5,
         limit_usd: 10.0,
@@ -131,6 +133,7 @@ async fn list_alerts_pagination_with_multiple_alerts() {
     for i in 0..5u8 {
         let alert = BudgetAlert {
             agent_id: AgentId::from_bytes([i + 1; 16]),
+            team_id: None,
             threshold_pct: 80 + i,
             spent_usd: 8.0 + f64::from(i),
             limit_usd: 15.0,

--- a/aa-api/tests/costs.rs
+++ b/aa-api/tests/costs.rs
@@ -79,3 +79,27 @@ async fn get_cost_summary_includes_limit_fields() {
     assert!(json["daily_limit_usd"].is_null());
     assert!(json["monthly_limit_usd"].is_null());
 }
+
+#[tokio::test]
+async fn get_cost_summary_includes_per_team_array() {
+    let app = common::test_app();
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/costs").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert!(
+        json["per_team"].is_array(),
+        "per_team field should be present and an array"
+    );
+    assert_eq!(
+        json["per_team"].as_array().unwrap().len(),
+        0,
+        "fresh tracker has no per-team data"
+    );
+}

--- a/aa-api/tests/event_broadcast.rs
+++ b/aa-api/tests/event_broadcast.rs
@@ -52,7 +52,7 @@ async fn subscribe_budget_receives_published_alert() {
 
     let alert = BudgetAlert {
         agent_id: aa_core::AgentId::from_bytes([1; 16]),
-            team_id: None,
+        team_id: None,
         threshold_pct: 80,
         spent_usd: 8.0,
         limit_usd: 10.0,

--- a/aa-api/tests/event_broadcast.rs
+++ b/aa-api/tests/event_broadcast.rs
@@ -52,6 +52,7 @@ async fn subscribe_budget_receives_published_alert() {
 
     let alert = BudgetAlert {
         agent_id: aa_core::AgentId::from_bytes([1; 16]),
+            team_id: None,
         threshold_pct: 80,
         spent_usd: 8.0,
         limit_usd: 10.0,

--- a/aa-api/tests/ws_streaming.rs
+++ b/aa-api/tests/ws_streaming.rs
@@ -278,6 +278,7 @@ async fn ws_cli_logs_follow_integration() {
     budget_tx
         .send(aa_gateway::budget::types::BudgetAlert {
             agent_id: aa_core::AgentId::from_bytes([0xAA; 16]),
+            team_id: None,
             threshold_pct: 80,
             spent_usd: 8.0,
             limit_usd: 10.0,

--- a/aa-gateway/src/budget/persistence.rs
+++ b/aa-gateway/src/budget/persistence.rs
@@ -11,6 +11,8 @@ pub struct PersistedAgentEntry {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PersistedBudget {
     pub per_agent: Vec<PersistedAgentEntry>,
+    #[serde(default)]
+    pub team_budgets: std::collections::HashMap<String, BudgetState>,
     pub global: BudgetState,
     #[serde(default = "default_timezone")]
     pub timezone: chrono_tz::Tz,
@@ -50,6 +52,7 @@ pub fn load_from_disk(path: &std::path::Path) -> Result<PersistedBudget, Persist
         Ok(json) => serde_json::from_str(&json).map_err(PersistenceError::Json),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(PersistedBudget {
             per_agent: vec![],
+            team_budgets: Default::default(),
             global: crate::budget::types::BudgetState::new_today(),
             timezone: default_timezone(),
         }),
@@ -166,6 +169,7 @@ mod tests {
                     s
                 },
             }],
+            team_budgets: Default::default(),
             global: crate::budget::types::BudgetState::new_today(),
             timezone: chrono_tz::UTC,
         };
@@ -182,6 +186,7 @@ mod tests {
             &path,
             &PersistedBudget {
                 per_agent: vec![],
+                team_budgets: Default::default(),
                 global: crate::budget::types::BudgetState::new_today(),
                 timezone: chrono_tz::UTC,
             },
@@ -194,6 +199,7 @@ mod tests {
     fn persisted_budget_holds_entries_and_global() {
         let budget = PersistedBudget {
             per_agent: vec![],
+            team_budgets: Default::default(),
             global: BudgetState::new_today(),
             timezone: chrono_tz::UTC,
         };
@@ -235,6 +241,7 @@ mod tests {
         let path = dir.path().join("budget.json");
         let budget = PersistedBudget {
             per_agent: vec![],
+            team_budgets: Default::default(),
             global: crate::budget::types::BudgetState::new_today(),
             timezone: chrono_tz::Asia::Tokyo,
         };
@@ -270,6 +277,7 @@ mod tests {
                 agent_id_hex: "0102030405060708090a0b0c0d0e0f10".to_string(),
                 state,
             }],
+            team_budgets: Default::default(),
             global: crate::budget::types::BudgetState::new_today(),
             timezone: chrono_tz::UTC,
         };

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -315,22 +315,42 @@ impl BudgetTracker {
                     s
                 });
 
-            // Enforce team monthly limit before agent/global checks.
+            // Check team monthly limit and emit alerts.
             if let Some(team_monthly_limit) = self.team_monthly_limit_usd {
                 if let Some(team_state) = self.team_budgets.get(tid) {
                     if let Some(team_monthly) = team_state.monthly_spent_usd {
-                        if compute_status(team_monthly, team_monthly_limit) == BudgetStatus::LimitExceeded {
+                        let m_status = compute_status(team_monthly, team_monthly_limit);
+                        if m_status == BudgetStatus::LimitExceeded {
                             return BudgetStatus::LimitExceeded;
+                        }
+                        if let BudgetStatus::ThresholdAlert { pct } = &m_status {
+                            let _ = self.alert_tx.send(BudgetAlert {
+                                agent_id,
+                                team_id: Some(tid.to_string()),
+                                threshold_pct: *pct,
+                                spent_usd: team_monthly.to_f64().unwrap_or(0.0),
+                                limit_usd: team_monthly_limit.to_f64().unwrap_or(0.0),
+                            });
                         }
                     }
                 }
             }
 
-            // Enforce team daily limit before agent/global checks.
+            // Check team daily limit and emit alerts.
             if let Some(team_daily_limit) = self.team_daily_limit_usd {
                 if let Some(team_state) = self.team_budgets.get(tid) {
-                    if compute_status(team_state.spent_usd, team_daily_limit) == BudgetStatus::LimitExceeded {
+                    let d_status = compute_status(team_state.spent_usd, team_daily_limit);
+                    if d_status == BudgetStatus::LimitExceeded {
                         return BudgetStatus::LimitExceeded;
+                    }
+                    if let BudgetStatus::ThresholdAlert { pct } = &d_status {
+                        let _ = self.alert_tx.send(BudgetAlert {
+                            agent_id,
+                            team_id: Some(tid.to_string()),
+                            threshold_pct: *pct,
+                            spent_usd: team_state.spent_usd.to_f64().unwrap_or(0.0),
+                            limit_usd: team_daily_limit.to_f64().unwrap_or(0.0),
+                        });
                     }
                 }
             }
@@ -897,5 +917,42 @@ mod tests {
         // No team_id — team limit should not apply
         let status = t.record_raw_spend(id, None, "100.00".parse().unwrap());
         assert!(matches!(status, BudgetStatus::WithinBudget { .. }));
+    }
+
+    // ── Team threshold alerts (AAASM-1012) ─────────────────────────────
+
+    #[test]
+    fn team_daily_80_pct_fires_alert_with_team_id() {
+        let t = tracker_with_team_daily_limit("10.00");
+        let mut rx = t.subscribe_alerts();
+        let id = agent(60);
+        // 8.00 / 10.00 = 80%
+        t.record_raw_spend(id, Some("team-delta"), "8.00".parse().unwrap());
+        let alert = rx.try_recv().expect("expected 80% team alert");
+        assert_eq!(alert.threshold_pct, 80);
+        assert_eq!(alert.team_id.as_deref(), Some("team-delta"));
+    }
+
+    #[test]
+    fn team_daily_95_pct_fires_alert_with_team_id() {
+        let t = tracker_with_team_daily_limit("10.00");
+        let mut rx = t.subscribe_alerts();
+        let id = agent(61);
+        // 9.50 / 10.00 = 95%
+        t.record_raw_spend(id, Some("team-epsilon"), "9.50".parse().unwrap());
+        let alert = rx.try_recv().expect("expected 95% team alert");
+        assert_eq!(alert.threshold_pct, 95);
+        assert_eq!(alert.team_id.as_deref(), Some("team-epsilon"));
+    }
+
+    #[test]
+    fn team_monthly_80_pct_fires_alert_with_team_id() {
+        let t = tracker_with_team_monthly_limit("10.00");
+        let mut rx = t.subscribe_alerts();
+        let id = agent(62);
+        t.record_raw_spend(id, Some("team-zeta"), "8.00".parse().unwrap());
+        let alert = rx.try_recv().expect("expected 80% monthly team alert");
+        assert_eq!(alert.threshold_pct, 80);
+        assert_eq!(alert.team_id.as_deref(), Some("team-zeta"));
     }
 }

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -72,18 +72,7 @@ impl BudgetTracker {
         timezone: chrono_tz::Tz,
     ) -> Self {
         let (alert_tx, _) = broadcast::channel(ALERT_CHANNEL_CAPACITY);
-        Self {
-            per_agent: DashMap::new(),
-            team_budgets: DashMap::new(),
-            global: Mutex::new(BudgetState::new_for_date(today_in_tz(timezone))),
-            pricing,
-            daily_limit_usd,
-            monthly_limit_usd,
-            team_daily_limit_usd: None,
-            team_monthly_limit_usd: None,
-            alert_tx,
-            timezone,
-        }
+        Self::new_with_alert_sender(pricing, daily_limit_usd, monthly_limit_usd, timezone, alert_tx)
     }
 
     /// Create a new tracker that sends alerts on an externally-owned channel.
@@ -130,30 +119,8 @@ impl BudgetTracker {
         monthly_limit_usd: Option<Decimal>,
         initial: crate::budget::persistence::PersistedBudget,
     ) -> Self {
-        let timezone = initial.timezone;
         let (alert_tx, _) = broadcast::channel(ALERT_CHANNEL_CAPACITY);
-        let per_agent: DashMap<AgentId, BudgetState> = initial
-            .per_agent
-            .into_iter()
-            .filter_map(|e| {
-                crate::budget::persistence::hex_to_agent_id(&e.agent_id_hex)
-                    .ok()
-                    .map(|id| (id, e.state))
-            })
-            .collect();
-        let team_budgets: DashMap<String, BudgetState> = initial.team_budgets.into_iter().collect();
-        Self {
-            per_agent,
-            team_budgets,
-            global: Mutex::new(initial.global),
-            pricing,
-            daily_limit_usd,
-            monthly_limit_usd,
-            team_daily_limit_usd: None,
-            team_monthly_limit_usd: None,
-            alert_tx,
-            timezone,
-        }
+        Self::with_state_and_alert_sender(pricing, daily_limit_usd, monthly_limit_usd, initial, alert_tx)
     }
 
     /// Create a tracker pre-loaded with persisted state that sends alerts on an
@@ -267,6 +234,28 @@ impl BudgetTracker {
         self.record_cost(agent_id, team_id, cost)
     }
 
+    /// Compute status for `spent` against `limit`, emit a [`BudgetAlert`] on the broadcast
+    /// channel if at a threshold, and return the resulting [`BudgetStatus`].
+    fn check_limit_and_alert(
+        &self,
+        agent_id: AgentId,
+        team_id: Option<&str>,
+        spent: Decimal,
+        limit: Decimal,
+    ) -> BudgetStatus {
+        let status = compute_status(spent, limit);
+        if let BudgetStatus::ThresholdAlert { pct } = &status {
+            let _ = self.alert_tx.send(BudgetAlert {
+                agent_id,
+                team_id: team_id.map(str::to_string),
+                threshold_pct: *pct,
+                spent_usd: spent.to_f64().unwrap_or(0.0),
+                limit_usd: limit.to_f64().unwrap_or(0.0),
+            });
+        }
+        status
+    }
+
     /// Shared cost-recording logic used by both [`record_usage`](Self::record_usage)
     /// and [`record_raw_spend`](Self::record_raw_spend).
     fn record_cost(&self, agent_id: AgentId, team_id: Option<&str>, cost: Decimal) -> BudgetStatus {
@@ -309,42 +298,25 @@ impl BudgetTracker {
                     s
                 });
 
-            // Check team monthly limit and emit alerts.
+            // Check team monthly limit and emit alert.
             if let Some(team_monthly_limit) = self.team_monthly_limit_usd {
                 if let Some(team_state) = self.team_budgets.get(tid) {
                     if let Some(team_monthly) = team_state.monthly_spent_usd {
-                        let m_status = compute_status(team_monthly, team_monthly_limit);
-                        if m_status == BudgetStatus::LimitExceeded {
+                        let status = self.check_limit_and_alert(agent_id, Some(tid), team_monthly, team_monthly_limit);
+                        if status == BudgetStatus::LimitExceeded {
                             return BudgetStatus::LimitExceeded;
-                        }
-                        if let BudgetStatus::ThresholdAlert { pct } = &m_status {
-                            let _ = self.alert_tx.send(BudgetAlert {
-                                agent_id,
-                                team_id: Some(tid.to_string()),
-                                threshold_pct: *pct,
-                                spent_usd: team_monthly.to_f64().unwrap_or(0.0),
-                                limit_usd: team_monthly_limit.to_f64().unwrap_or(0.0),
-                            });
                         }
                     }
                 }
             }
 
-            // Check team daily limit and emit alerts.
+            // Check team daily limit and emit alert.
             if let Some(team_daily_limit) = self.team_daily_limit_usd {
                 if let Some(team_state) = self.team_budgets.get(tid) {
-                    let d_status = compute_status(team_state.spent_usd, team_daily_limit);
-                    if d_status == BudgetStatus::LimitExceeded {
+                    let status =
+                        self.check_limit_and_alert(agent_id, Some(tid), team_state.spent_usd, team_daily_limit);
+                    if status == BudgetStatus::LimitExceeded {
                         return BudgetStatus::LimitExceeded;
-                    }
-                    if let BudgetStatus::ThresholdAlert { pct } = &d_status {
-                        let _ = self.alert_tx.send(BudgetAlert {
-                            agent_id,
-                            team_id: Some(tid.to_string()),
-                            threshold_pct: *pct,
-                            spent_usd: team_state.spent_usd.to_f64().unwrap_or(0.0),
-                            limit_usd: team_daily_limit.to_f64().unwrap_or(0.0),
-                        });
                     }
                 }
             }
@@ -361,44 +333,21 @@ impl BudgetTracker {
             g.spent_usd += cost;
         }
 
-        // Check monthly limit first — monthly exceeded takes precedence
+        // Check monthly limit first — monthly exceeded takes precedence.
         if let (Some(limit), Some(m_spent)) = (self.monthly_limit_usd, monthly_spent) {
-            let m_status = compute_status(m_spent, limit);
-            if matches!(m_status, BudgetStatus::LimitExceeded) {
+            let status = self.check_limit_and_alert(agent_id, None, m_spent, limit);
+            if matches!(status, BudgetStatus::LimitExceeded) {
                 return BudgetStatus::LimitExceeded;
-            }
-            if let BudgetStatus::ThresholdAlert { pct } = &m_status {
-                let _ = self.alert_tx.send(BudgetAlert {
-                    agent_id,
-                    team_id: None,
-                    threshold_pct: *pct,
-                    spent_usd: m_spent.to_f64().unwrap_or(0.0),
-                    limit_usd: limit.to_f64().unwrap_or(0.0),
-                });
             }
         }
 
-        let status = match self.daily_limit_usd {
+        match self.daily_limit_usd {
             None => BudgetStatus::WithinBudget {
                 spent_usd: spent.to_f64().unwrap_or(0.0),
                 remaining_usd: f64::INFINITY,
             },
-            Some(limit) => compute_status(spent, limit),
-        };
-
-        if let Some(limit) = self.daily_limit_usd {
-            if let BudgetStatus::ThresholdAlert { pct } = &status {
-                let _ = self.alert_tx.send(BudgetAlert {
-                    agent_id,
-                    team_id: None,
-                    threshold_pct: *pct,
-                    spent_usd: spent.to_f64().unwrap_or(0.0),
-                    limit_usd: limit.to_f64().unwrap_or(0.0),
-                });
-            }
+            Some(limit) => self.check_limit_and_alert(agent_id, None, spent, limit),
         }
-
-        status
     }
 
     /// Return the current spend state for a specific team, or `None` if the team has no spend.

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -49,6 +49,8 @@ fn today_in_tz(tz: chrono_tz::Tz) -> chrono::NaiveDate {
 pub struct BudgetTracker {
     /// Per-agent daily spend. `pub(crate)` for test date manipulation.
     pub(crate) per_agent: DashMap<AgentId, BudgetState>,
+    /// Per-team daily/monthly spend rollup. `pub(crate)` for test date manipulation.
+    pub(crate) team_budgets: DashMap<String, BudgetState>,
     pub(crate) global: Mutex<BudgetState>,
     pricing: PricingTable,
     daily_limit_usd: Option<Decimal>,
@@ -68,6 +70,7 @@ impl BudgetTracker {
         let (alert_tx, _) = broadcast::channel(ALERT_CHANNEL_CAPACITY);
         Self {
             per_agent: DashMap::new(),
+            team_budgets: DashMap::new(),
             global: Mutex::new(BudgetState::new_for_date(today_in_tz(timezone))),
             pricing,
             daily_limit_usd,
@@ -90,6 +93,7 @@ impl BudgetTracker {
     ) -> Self {
         Self {
             per_agent: DashMap::new(),
+            team_budgets: DashMap::new(),
             global: Mutex::new(BudgetState::new_for_date(today_in_tz(timezone))),
             pricing,
             daily_limit_usd,
@@ -117,8 +121,13 @@ impl BudgetTracker {
                     .map(|id| (id, e.state))
             })
             .collect();
+        let team_budgets: DashMap<String, BudgetState> = initial
+            .team_budgets
+            .into_iter()
+            .collect();
         Self {
             per_agent,
+            team_budgets,
             global: Mutex::new(initial.global),
             pricing,
             daily_limit_usd,
@@ -150,8 +159,13 @@ impl BudgetTracker {
                     .map(|id| (id, e.state))
             })
             .collect();
+        let team_budgets: DashMap<String, BudgetState> = initial
+            .team_budgets
+            .into_iter()
+            .collect();
         Self {
             per_agent,
+            team_budgets,
             global: Mutex::new(initial.global),
             pricing,
             daily_limit_usd,
@@ -216,27 +230,28 @@ impl BudgetTracker {
     /// rather than raw token counts.
     ///
     /// Fires 80%/95% threshold alerts on the broadcast channel and updates the
-    /// global spend accumulator.
-    pub fn record_raw_spend(&self, agent_id: AgentId, amount_usd: Decimal) {
-        self.record_cost(agent_id, amount_usd);
+    /// global and team spend accumulators.
+    pub fn record_raw_spend(&self, agent_id: AgentId, team_id: Option<&str>, amount_usd: Decimal) {
+        self.record_cost(agent_id, team_id, amount_usd);
     }
 
     /// Record token usage and return the resulting [`BudgetStatus`].
     pub fn record_usage(
         &self,
         agent_id: AgentId,
+        team_id: Option<&str>,
         provider: crate::budget::types::Provider,
         model: crate::budget::types::Model,
         input_tokens: u64,
         output_tokens: u64,
     ) -> BudgetStatus {
         let cost = self.pricing.cost_usd(provider, model, input_tokens, output_tokens);
-        self.record_cost(agent_id, cost)
+        self.record_cost(agent_id, team_id, cost)
     }
 
     /// Shared cost-recording logic used by both [`record_usage`](Self::record_usage)
     /// and [`record_raw_spend`](Self::record_raw_spend).
-    fn record_cost(&self, agent_id: AgentId, cost: Decimal) -> BudgetStatus {
+    fn record_cost(&self, agent_id: AgentId, team_id: Option<&str>, cost: Decimal) -> BudgetStatus {
         let has_monthly = self.monthly_limit_usd.is_some();
 
         self.per_agent
@@ -256,6 +271,26 @@ impl BudgetTracker {
                 }
                 s
             });
+
+        if let Some(tid) = team_id {
+            self.team_budgets
+                .entry(tid.to_string())
+                .and_modify(|s| {
+                    s.maybe_reset(today_in_tz(self.timezone));
+                    s.spent_usd += cost;
+                    if let Some(m) = s.monthly_spent_usd.as_mut() {
+                        *m += cost;
+                    }
+                })
+                .or_insert_with(|| {
+                    let mut s = BudgetState::new_for_date(today_in_tz(self.timezone));
+                    s.spent_usd += cost;
+                    if has_monthly {
+                        s.monthly_spent_usd = Some(cost);
+                    }
+                    s
+                });
+        }
 
         let (spent, monthly_spent) = self
             .per_agent
@@ -277,6 +312,7 @@ impl BudgetTracker {
             if let BudgetStatus::ThresholdAlert { pct } = &m_status {
                 let _ = self.alert_tx.send(BudgetAlert {
                     agent_id,
+                    team_id: None,
                     threshold_pct: *pct,
                     spent_usd: m_spent.to_f64().unwrap_or(0.0),
                     limit_usd: limit.to_f64().unwrap_or(0.0),
@@ -296,6 +332,7 @@ impl BudgetTracker {
             if let BudgetStatus::ThresholdAlert { pct } = &status {
                 let _ = self.alert_tx.send(BudgetAlert {
                     agent_id,
+                    team_id: None,
                     threshold_pct: *pct,
                     spent_usd: spent.to_f64().unwrap_or(0.0),
                     limit_usd: limit.to_f64().unwrap_or(0.0),
@@ -324,8 +361,14 @@ impl BudgetTracker {
                 state: entry.value().clone(),
             })
             .collect();
+        let team_budgets = self
+            .team_budgets
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect();
         crate::budget::persistence::PersistedBudget {
             per_agent,
+            team_budgets,
             global: self.global_state(),
             timezone: self.timezone,
         }
@@ -434,7 +477,7 @@ mod tests {
     fn record_usage_no_limit_returns_within_budget() {
         use crate::budget::types::{BudgetStatus, Model, Provider};
         let t = new_tracker();
-        let s = t.record_usage(agent(1), Provider::OpenAi, Model::Gpt4o, 100, 100);
+        let s = t.record_usage(agent(1), None, Provider::OpenAi, Model::Gpt4o, 100, 100);
         assert!(matches!(s, BudgetStatus::WithinBudget { .. }));
     }
 
@@ -443,7 +486,7 @@ mod tests {
         use crate::budget::types::{BudgetStatus, Model, Provider};
         // GPT-4o: 100k input=$0.50 + 40k output=$0.60 = $1.10 > $1.00 limit
         let t = tracker_with_limit("1.00");
-        let s = t.record_usage(agent(2), Provider::OpenAi, Model::Gpt4o, 100_000, 40_000);
+        let s = t.record_usage(agent(2), None, Provider::OpenAi, Model::Gpt4o, 100_000, 40_000);
         assert_eq!(s, BudgetStatus::LimitExceeded);
     }
 
@@ -452,7 +495,7 @@ mod tests {
         use crate::budget::types::{BudgetStatus, Model, Provider};
         // 100k input=$0.50 + 20k output=$0.30 = $0.80 = 80% of $1.00
         let t = tracker_with_limit("1.00");
-        let s = t.record_usage(agent(3), Provider::OpenAi, Model::Gpt4o, 100_000, 20_000);
+        let s = t.record_usage(agent(3), None, Provider::OpenAi, Model::Gpt4o, 100_000, 20_000);
         assert_eq!(s, BudgetStatus::ThresholdAlert { pct: 80 });
     }
 
@@ -461,12 +504,12 @@ mod tests {
         use crate::budget::types::{BudgetStatus, Model, Provider};
         let t = tracker_with_limit("1.00");
         let id = agent(4);
-        t.record_usage(id, Provider::OpenAi, Model::Gpt4o, 100_000, 30_000); // $0.95
+        t.record_usage(id, None, Provider::OpenAi, Model::Gpt4o, 100_000, 30_000); // $0.95
         t.per_agent.alter(&id, |_, mut s| {
             s.date = chrono::Utc::now().date_naive() - chrono::Duration::days(1);
             s
         });
-        let s = t.record_usage(id, Provider::OpenAi, Model::Gpt4o, 100, 0);
+        let s = t.record_usage(id, None, Provider::OpenAi, Model::Gpt4o, 100, 0);
         assert!(matches!(s, BudgetStatus::WithinBudget { .. }));
     }
 
@@ -493,6 +536,7 @@ mod tests {
                 agent_id_hex: agent_id_to_hex(&id),
                 state: state.clone(),
             }],
+            team_budgets: Default::default(),
             global: BudgetState::new_today(),
             timezone: chrono_tz::UTC,
         };
@@ -507,7 +551,7 @@ mod tests {
         use crate::budget::types::{Model, Provider};
         let t = new_tracker();
         let id = agent(7);
-        t.record_usage(id, Provider::OpenAi, Model::Gpt4o, 1_000, 0);
+        t.record_usage(id, None, Provider::OpenAi, Model::Gpt4o, 1_000, 0);
         let snap = t.snapshot();
         assert_eq!(snap.per_agent.len(), 1);
         assert_eq!(snap.global.spent_usd, snap.per_agent[0].state.spent_usd);
@@ -517,8 +561,8 @@ mod tests {
     fn global_state_accumulates_all_agents() {
         use crate::budget::types::{Model, Provider};
         let t = new_tracker();
-        t.record_usage(agent(5), Provider::OpenAi, Model::Gpt4o, 1_000, 0); // $0.005
-        t.record_usage(agent(6), Provider::OpenAi, Model::Gpt4o, 1_000, 0); // $0.005
+        t.record_usage(agent(5), None, Provider::OpenAi, Model::Gpt4o, 1_000, 0); // $0.005
+        t.record_usage(agent(6), None, Provider::OpenAi, Model::Gpt4o, 1_000, 0); // $0.005
         let g = t.global_state();
         let expected: Decimal = "0.010".parse().unwrap();
         assert_eq!(g.spent_usd, expected);
@@ -533,7 +577,7 @@ mod tests {
         let t = BudgetTracker::new(PricingTable::default_table(), Some("1.00".parse().unwrap()), None, tz);
         let id = agent(10);
         // First call — establishes the agent entry
-        t.record_usage(id, Provider::OpenAi, Model::Gpt4o, 100_000, 30_000); // $0.95
+        t.record_usage(id, None, Provider::OpenAi, Model::Gpt4o, 100_000, 30_000); // $0.95
                                                                              // Backdate the agent entry by 1 day in the Tokyo timezone
         let yesterday_tokyo = today_in_tz(tz) - chrono::Duration::days(1);
         t.per_agent.alter(&id, |_, mut s| {
@@ -541,7 +585,7 @@ mod tests {
             s
         });
         // Next call should reset (yesterday < today in Tokyo)
-        let s = t.record_usage(id, Provider::OpenAi, Model::Gpt4o, 100, 0);
+        let s = t.record_usage(id, None, Provider::OpenAi, Model::Gpt4o, 100, 0);
         assert!(
             matches!(s, BudgetStatus::WithinBudget { .. }),
             "Expected reset after Tokyo midnight, got: {:?}",
@@ -563,7 +607,7 @@ mod tests {
         use crate::budget::types::{BudgetStatus, Model, Provider};
         // Monthly limit $1.00. GPT-4o: 100k input=$0.50 + 40k output=$0.60 = $1.10 > $1.00
         let t = tracker_with_monthly_limit("1.00");
-        let s = t.record_usage(agent(20), Provider::OpenAi, Model::Gpt4o, 100_000, 40_000);
+        let s = t.record_usage(agent(20), None, Provider::OpenAi, Model::Gpt4o, 100_000, 40_000);
         assert_eq!(s, BudgetStatus::LimitExceeded);
     }
 
@@ -572,7 +616,7 @@ mod tests {
         use crate::budget::types::{BudgetStatus, Model, Provider};
         // Monthly limit $10.00. Small usage should be within budget.
         let t = tracker_with_monthly_limit("10.00");
-        let s = t.record_usage(agent(21), Provider::OpenAi, Model::Gpt4o, 1_000, 0);
+        let s = t.record_usage(agent(21), None, Provider::OpenAi, Model::Gpt4o, 1_000, 0);
         assert!(matches!(s, BudgetStatus::WithinBudget { .. }));
     }
 
@@ -583,14 +627,14 @@ mod tests {
         let t = tracker_with_monthly_limit("1.00");
         let id = agent(22);
         // Day 1: $0.50 (100k input)
-        t.record_usage(id, Provider::OpenAi, Model::Gpt4o, 100_000, 0);
+        t.record_usage(id, None, Provider::OpenAi, Model::Gpt4o, 100_000, 0);
         // Backdate the entry by 1 day — daily resets, monthly stays
         t.per_agent.alter(&id, |_, mut s| {
             s.date = chrono::Utc::now().date_naive() - chrono::Duration::days(1);
             s
         });
         // Day 2: another $0.60 (40k output) — total monthly $1.10 > $1.00
-        let s = t.record_usage(id, Provider::OpenAi, Model::Gpt4o, 0, 40_000);
+        let s = t.record_usage(id, None, Provider::OpenAi, Model::Gpt4o, 0, 40_000);
         assert_eq!(s, BudgetStatus::LimitExceeded);
     }
 
@@ -601,7 +645,7 @@ mod tests {
         let t = tracker_with_monthly_limit("1.00");
         let id = agent(23);
         // Record $0.95
-        t.record_usage(id, Provider::OpenAi, Model::Gpt4o, 100_000, 30_000);
+        t.record_usage(id, None, Provider::OpenAi, Model::Gpt4o, 100_000, 30_000);
         // Backdate to last month — both daily and monthly should reset
         let last_month = chrono::Utc::now().date_naive() - chrono::Duration::days(32);
         t.per_agent.alter(&id, |_, mut s| {
@@ -610,7 +654,7 @@ mod tests {
             s
         });
         // New usage should start fresh — well within budget
-        let s = t.record_usage(id, Provider::OpenAi, Model::Gpt4o, 100, 0);
+        let s = t.record_usage(id, None, Provider::OpenAi, Model::Gpt4o, 100, 0);
         assert!(
             matches!(s, BudgetStatus::WithinBudget { .. }),
             "Expected within budget after monthly reset, got: {:?}",
@@ -630,7 +674,7 @@ mod tests {
     fn check_daily_returns_true_when_exceeded() {
         let t = tracker_with_limit("1.00");
         let id = agent(31);
-        t.record_raw_spend(id, "1.00".parse().unwrap());
+        t.record_raw_spend(id, None, "1.00".parse().unwrap());
         assert!(t.check_daily(&id, "1.00".parse().unwrap()));
     }
 
@@ -644,7 +688,7 @@ mod tests {
     fn check_monthly_returns_true_when_exceeded() {
         let t = tracker_with_monthly_limit("5.00");
         let id = agent(33);
-        t.record_raw_spend(id, "5.00".parse().unwrap());
+        t.record_raw_spend(id, None, "5.00".parse().unwrap());
         assert!(t.check_monthly(&id, "5.00".parse().unwrap()));
     }
 
@@ -652,8 +696,8 @@ mod tests {
     fn record_raw_spend_accumulates() {
         let t = tracker_with_limit("10.00");
         let id = agent(34);
-        t.record_raw_spend(id, "3.00".parse().unwrap());
-        t.record_raw_spend(id, "4.00".parse().unwrap());
+        t.record_raw_spend(id, None, "3.00".parse().unwrap());
+        t.record_raw_spend(id, None, "4.00".parse().unwrap());
         // 7.00 >= 7.00
         assert!(t.check_daily(&id, "7.00".parse().unwrap()));
         // 7.00 < 8.00
@@ -666,7 +710,7 @@ mod tests {
         let mut rx = t.subscribe_alerts();
         let id = agent(35);
         // 8.00 / 10.00 = 80%
-        t.record_raw_spend(id, "8.00".parse().unwrap());
+        t.record_raw_spend(id, None, "8.00".parse().unwrap());
         let alert = rx.try_recv().expect("expected 80% alert");
         assert_eq!(alert.threshold_pct, 80);
         assert_eq!(alert.agent_id, id);
@@ -678,7 +722,7 @@ mod tests {
         let mut rx = t.subscribe_alerts();
         let id = agent(36);
         // 9.50 / 10.00 = 95%
-        t.record_raw_spend(id, "9.50".parse().unwrap());
+        t.record_raw_spend(id, None, "9.50".parse().unwrap());
         let alert = rx.try_recv().expect("expected 95% alert");
         assert_eq!(alert.threshold_pct, 95);
     }
@@ -694,7 +738,7 @@ mod tests {
             tx,
         );
         let id = agent(37);
-        t.record_raw_spend(id, "8.00".parse().unwrap());
+        t.record_raw_spend(id, None, "8.00".parse().unwrap());
         let alert = rx.try_recv().expect("alert should arrive on external channel");
         assert_eq!(alert.threshold_pct, 80);
     }
@@ -705,7 +749,7 @@ mod tests {
     fn check_daily_exact_limit_is_exceeded() {
         let t = tracker_with_limit("1.00");
         let id = agent(40);
-        t.record_raw_spend(id, "1.00".parse().unwrap());
+        t.record_raw_spend(id, None, "1.00".parse().unwrap());
         // 1.00 >= 1.00 is true (not strictly greater)
         assert!(t.check_daily(&id, "1.00".parse().unwrap()));
     }
@@ -714,7 +758,7 @@ mod tests {
     fn check_daily_resets_on_new_date() {
         let t = tracker_with_limit("1.00");
         let id = agent(41);
-        t.record_raw_spend(id, "0.90".parse().unwrap());
+        t.record_raw_spend(id, None, "0.90".parse().unwrap());
         // Backdate the entry to yesterday
         t.per_agent.alter(&id, |_, mut s| {
             s.date = chrono::Utc::now().date_naive() - chrono::Duration::days(1);
@@ -728,8 +772,8 @@ mod tests {
     fn check_monthly_accumulates_raw_spend() {
         let t = tracker_with_monthly_limit("7.00");
         let id = agent(42);
-        t.record_raw_spend(id, "3.00".parse().unwrap());
-        t.record_raw_spend(id, "4.00".parse().unwrap());
+        t.record_raw_spend(id, None, "3.00".parse().unwrap());
+        t.record_raw_spend(id, None, "4.00".parse().unwrap());
         // 7.00 >= 7.00
         assert!(t.check_monthly(&id, "7.00".parse().unwrap()));
         // 7.00 < 8.00
@@ -741,7 +785,7 @@ mod tests {
         use chrono::Datelike;
         let t = tracker_with_monthly_limit("5.00");
         let id = agent(43);
-        t.record_raw_spend(id, "5.00".parse().unwrap());
+        t.record_raw_spend(id, None, "5.00".parse().unwrap());
         // Backdate to last month
         let last_month = chrono::Utc::now().date_naive() - chrono::Duration::days(32);
         t.per_agent.alter(&id, |_, mut s| {

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -407,6 +407,11 @@ impl BudgetTracker {
         status
     }
 
+    /// Return the current spend state for a specific team, or `None` if the team has no spend.
+    pub fn team_state(&self, team_id: &str) -> Option<BudgetState> {
+        self.team_budgets.get(team_id).map(|s| s.clone())
+    }
+
     /// Return a snapshot of the current global (all-agents combined) budget state.
     pub fn global_state(&self) -> BudgetState {
         self.global

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -141,10 +141,7 @@ impl BudgetTracker {
                     .map(|id| (id, e.state))
             })
             .collect();
-        let team_budgets: DashMap<String, BudgetState> = initial
-            .team_budgets
-            .into_iter()
-            .collect();
+        let team_budgets: DashMap<String, BudgetState> = initial.team_budgets.into_iter().collect();
         Self {
             per_agent,
             team_budgets,
@@ -181,10 +178,7 @@ impl BudgetTracker {
                     .map(|id| (id, e.state))
             })
             .collect();
-        let team_budgets: DashMap<String, BudgetState> = initial
-            .team_budgets
-            .into_iter()
-            .collect();
+        let team_budgets: DashMap<String, BudgetState> = initial.team_budgets.into_iter().collect();
         Self {
             per_agent,
             team_budgets,
@@ -647,7 +641,7 @@ mod tests {
         let id = agent(10);
         // First call — establishes the agent entry
         t.record_usage(id, None, Provider::OpenAi, Model::Gpt4o, 100_000, 30_000); // $0.95
-                                                                             // Backdate the agent entry by 1 day in the Tokyo timezone
+                                                                                   // Backdate the agent entry by 1 day in the Tokyo timezone
         let yesterday_tokyo = today_in_tz(tz) - chrono::Duration::days(1);
         t.per_agent.alter(&id, |_, mut s| {
             s.date = yesterday_tokyo;

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -55,6 +55,10 @@ pub struct BudgetTracker {
     pricing: PricingTable,
     daily_limit_usd: Option<Decimal>,
     monthly_limit_usd: Option<Decimal>,
+    /// Per-team daily spend limit. Applied to each team independently.
+    team_daily_limit_usd: Option<Decimal>,
+    /// Per-team monthly spend limit. Applied to each team independently.
+    team_monthly_limit_usd: Option<Decimal>,
     alert_tx: broadcast::Sender<BudgetAlert>,
     timezone: chrono_tz::Tz,
 }
@@ -75,6 +79,8 @@ impl BudgetTracker {
             pricing,
             daily_limit_usd,
             monthly_limit_usd,
+            team_daily_limit_usd: None,
+            team_monthly_limit_usd: None,
             alert_tx,
             timezone,
         }
@@ -98,9 +104,23 @@ impl BudgetTracker {
             pricing,
             daily_limit_usd,
             monthly_limit_usd,
+            team_daily_limit_usd: None,
+            team_monthly_limit_usd: None,
             alert_tx,
             timezone,
         }
+    }
+
+    /// Set the per-team daily spend limit in USD. Enforced in `record_cost` for every team.
+    pub fn with_team_daily_limit(mut self, limit: Decimal) -> Self {
+        self.team_daily_limit_usd = Some(limit);
+        self
+    }
+
+    /// Set the per-team monthly spend limit in USD. Enforced in `record_cost` for every team.
+    pub fn with_team_monthly_limit(mut self, limit: Decimal) -> Self {
+        self.team_monthly_limit_usd = Some(limit);
+        self
     }
 
     /// Create a tracker pre-loaded with persisted state (call after `load_from_disk`).
@@ -132,6 +152,8 @@ impl BudgetTracker {
             pricing,
             daily_limit_usd,
             monthly_limit_usd,
+            team_daily_limit_usd: None,
+            team_monthly_limit_usd: None,
             alert_tx,
             timezone,
         }
@@ -170,6 +192,8 @@ impl BudgetTracker {
             pricing,
             daily_limit_usd,
             monthly_limit_usd,
+            team_daily_limit_usd: None,
+            team_monthly_limit_usd: None,
             alert_tx,
             timezone,
         }
@@ -230,9 +254,9 @@ impl BudgetTracker {
     /// rather than raw token counts.
     ///
     /// Fires 80%/95% threshold alerts on the broadcast channel and updates the
-    /// global and team spend accumulators.
-    pub fn record_raw_spend(&self, agent_id: AgentId, team_id: Option<&str>, amount_usd: Decimal) {
-        self.record_cost(agent_id, team_id, amount_usd);
+    /// global and team spend accumulators. Returns the resulting [`BudgetStatus`].
+    pub fn record_raw_spend(&self, agent_id: AgentId, team_id: Option<&str>, amount_usd: Decimal) -> BudgetStatus {
+        self.record_cost(agent_id, team_id, amount_usd)
     }
 
     /// Record token usage and return the resulting [`BudgetStatus`].
@@ -252,7 +276,7 @@ impl BudgetTracker {
     /// Shared cost-recording logic used by both [`record_usage`](Self::record_usage)
     /// and [`record_raw_spend`](Self::record_raw_spend).
     fn record_cost(&self, agent_id: AgentId, team_id: Option<&str>, cost: Decimal) -> BudgetStatus {
-        let has_monthly = self.monthly_limit_usd.is_some();
+        let has_monthly = self.monthly_limit_usd.is_some() || self.team_monthly_limit_usd.is_some();
 
         self.per_agent
             .entry(agent_id)
@@ -290,6 +314,26 @@ impl BudgetTracker {
                     }
                     s
                 });
+
+            // Enforce team monthly limit before agent/global checks.
+            if let Some(team_monthly_limit) = self.team_monthly_limit_usd {
+                if let Some(team_state) = self.team_budgets.get(tid) {
+                    if let Some(team_monthly) = team_state.monthly_spent_usd {
+                        if compute_status(team_monthly, team_monthly_limit) == BudgetStatus::LimitExceeded {
+                            return BudgetStatus::LimitExceeded;
+                        }
+                    }
+                }
+            }
+
+            // Enforce team daily limit before agent/global checks.
+            if let Some(team_daily_limit) = self.team_daily_limit_usd {
+                if let Some(team_state) = self.team_budgets.get(tid) {
+                    if compute_status(team_state.spent_usd, team_daily_limit) == BudgetStatus::LimitExceeded {
+                        return BudgetStatus::LimitExceeded;
+                    }
+                }
+            }
         }
 
         let (spent, monthly_spent) = self
@@ -795,5 +839,63 @@ mod tests {
         });
         // After month change, monthly spend resets — not exceeded
         assert!(!t.check_monthly(&id, "5.00".parse().unwrap()));
+    }
+
+    // ── Team limit enforcement (AAASM-1007) ────────────────────────────
+
+    fn tracker_with_team_daily_limit(daily: &str) -> BudgetTracker {
+        BudgetTracker::new(PricingTable::default_table(), None, None, chrono_tz::UTC)
+            .with_team_daily_limit(daily.parse().unwrap())
+    }
+
+    fn tracker_with_team_monthly_limit(monthly: &str) -> BudgetTracker {
+        BudgetTracker::new(PricingTable::default_table(), None, None, chrono_tz::UTC)
+            .with_team_monthly_limit(monthly.parse().unwrap())
+    }
+
+    #[test]
+    fn team_daily_limit_exceeded_blocks_agent_in_same_team() {
+        let t = tracker_with_team_daily_limit("5.00");
+        let id = agent(50);
+        // Spend $5.00 — exactly at limit
+        let status = t.record_raw_spend(id, Some("team-alpha"), "5.00".parse().unwrap());
+        assert_eq!(status, BudgetStatus::LimitExceeded);
+    }
+
+    #[test]
+    fn team_daily_limit_not_exceeded_before_threshold() {
+        let t = tracker_with_team_daily_limit("10.00");
+        let id = agent(51);
+        let status = t.record_raw_spend(id, Some("team-alpha"), "3.00".parse().unwrap());
+        assert!(matches!(status, BudgetStatus::WithinBudget { .. }));
+    }
+
+    #[test]
+    fn team_daily_limit_aggregates_across_multiple_agents() {
+        let t = tracker_with_team_daily_limit("5.00");
+        let id_a = agent(52);
+        let id_b = agent(53);
+        // Agent A spends $3.00
+        t.record_raw_spend(id_a, Some("team-beta"), "3.00".parse().unwrap());
+        // Agent B spends $2.00 — pushes team total to $5.00 (exactly at limit)
+        let status = t.record_raw_spend(id_b, Some("team-beta"), "2.00".parse().unwrap());
+        assert_eq!(status, BudgetStatus::LimitExceeded);
+    }
+
+    #[test]
+    fn team_monthly_limit_exceeded_blocks() {
+        let t = tracker_with_team_monthly_limit("10.00");
+        let id = agent(54);
+        let status = t.record_raw_spend(id, Some("team-gamma"), "10.00".parse().unwrap());
+        assert_eq!(status, BudgetStatus::LimitExceeded);
+    }
+
+    #[test]
+    fn team_with_no_team_id_ignores_team_limits() {
+        let t = tracker_with_team_daily_limit("1.00");
+        let id = agent(55);
+        // No team_id — team limit should not apply
+        let status = t.record_raw_spend(id, None, "100.00".parse().unwrap());
+        assert!(matches!(status, BudgetStatus::WithinBudget { .. }));
     }
 }

--- a/aa-gateway/src/budget/types.rs
+++ b/aa-gateway/src/budget/types.rs
@@ -99,11 +99,13 @@ impl BudgetState {
     }
 }
 
-/// Alert emitted via broadcast when spend crosses 80% or 95% of the daily limit.
+/// Alert emitted via broadcast when spend crosses 80% or 95% of a daily or monthly limit.
 #[derive(Debug, Clone)]
 pub struct BudgetAlert {
     /// The agent whose spend triggered the alert.
     pub agent_id: aa_core::AgentId,
+    /// Team whose budget triggered the alert, if this is a team-level alert.
+    pub team_id: Option<String>,
     /// Threshold percentage crossed: 80 or 95.
     pub threshold_pct: u8,
     /// Current total spend in USD.
@@ -295,6 +297,7 @@ mod tests {
         let id = AgentId::from_bytes([1u8; 16]);
         let alert = BudgetAlert {
             agent_id: id,
+            team_id: None,
             threshold_pct: 80,
             spent_usd: 8.0,
             limit_usd: 10.0,

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -622,7 +622,7 @@ impl PolicyEngine {
     /// tracker's `record_raw_spend`, which fires 80%/95% threshold alerts.
     pub fn record_spend(&self, ctx: &aa_core::AgentContext, amount_usd: f64) {
         if let Ok(amount) = rust_decimal::Decimal::try_from(amount_usd) {
-            self.budget.record_raw_spend(ctx.agent_id, amount);
+            self.budget.record_raw_spend(ctx.agent_id, ctx.team_id.as_deref(), amount);
         }
     }
 

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -622,7 +622,8 @@ impl PolicyEngine {
     /// tracker's `record_raw_spend`, which fires 80%/95% threshold alerts.
     pub fn record_spend(&self, ctx: &aa_core::AgentContext, amount_usd: f64) {
         if let Ok(amount) = rust_decimal::Decimal::try_from(amount_usd) {
-            self.budget.record_raw_spend(ctx.agent_id, ctx.team_id.as_deref(), amount);
+            self.budget
+                .record_raw_spend(ctx.agent_id, ctx.team_id.as_deref(), amount);
         }
     }
 

--- a/aa-gateway/src/events/publisher.rs
+++ b/aa-gateway/src/events/publisher.rs
@@ -120,6 +120,7 @@ mod tests {
     fn budget_alert_envelope_has_correct_fields() {
         let alert = BudgetAlert {
             agent_id: AgentId::from_bytes([1; 16]),
+            team_id: None,
             threshold_pct: 80,
             spent_usd: 80.0,
             limit_usd: 100.0,
@@ -137,6 +138,7 @@ mod tests {
     fn budget_alert_envelope_has_uuid_v7_event_id() {
         let alert = BudgetAlert {
             agent_id: AgentId::from_bytes([2; 16]),
+            team_id: None,
             threshold_pct: 95,
             spent_usd: 95.0,
             limit_usd: 100.0,

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -69,6 +69,7 @@ fn setup_budget(policy_path: &Path, budget_alert_tx: broadcast::Sender<BudgetAle
         tracing::warn!(error = %e, "failed to load budget state, starting fresh");
         crate::budget::persistence::PersistedBudget {
             per_agent: vec![],
+            team_budgets: Default::default(),
             global: crate::budget::types::BudgetState::new_today(),
             timezone: chrono_tz::UTC,
         }

--- a/aa-gateway/tests/budget_persistence_test.rs
+++ b/aa-gateway/tests/budget_persistence_test.rs
@@ -32,7 +32,7 @@ fn round_trip_preserves_spend() {
         alert_tx.clone(),
     );
     let agent = test_agent_id();
-    tracker.record_raw_spend(agent, Decimal::from_str("42.50").unwrap());
+    tracker.record_raw_spend(agent, None, Decimal::from_str("42.50").unwrap());
 
     // 2. Snapshot and persist.
     let snapshot = tracker.snapshot();
@@ -74,7 +74,7 @@ fn restored_tracker_accumulates_further_spend() {
         alert_tx.clone(),
     );
     let agent = test_agent_id();
-    tracker.record_raw_spend(agent, Decimal::from_str("10.00").unwrap());
+    tracker.record_raw_spend(agent, None, Decimal::from_str("10.00").unwrap());
 
     let snapshot = tracker.snapshot();
     save_to_disk_atomic(&path, &snapshot).unwrap();
@@ -89,7 +89,7 @@ fn restored_tracker_accumulates_further_spend() {
     ));
 
     // Record more spend on the restored tracker.
-    restored.record_raw_spend(agent, Decimal::from_str("5.00").unwrap());
+    restored.record_raw_spend(agent, None, Decimal::from_str("5.00").unwrap());
 
     let final_snapshot = restored.snapshot();
     assert_eq!(
@@ -120,6 +120,7 @@ fn corrupt_file_fallback_produces_empty_tracker() {
     // Mirror the fallback logic from server::setup_budget.
     let persisted = load_from_disk(&path).unwrap_or_else(|_| PersistedBudget {
         per_agent: vec![],
+        team_budgets: Default::default(),
         global: aa_gateway::budget::types::BudgetState::new_today(),
         timezone: chrono_tz::UTC,
     });

--- a/aa-gateway/tests/team_budget_test.rs
+++ b/aa-gateway/tests/team_budget_test.rs
@@ -1,0 +1,153 @@
+//! Integration tests for per-team budget tracking (AAASM-223 / AAASM-1016).
+//!
+//! Covers the full AAASM-223 acceptance criteria:
+//!   AC1 – record_usage accumulates spend under the agent's team key
+//!   AC2 – record_raw_spend also participates in team rollup
+//!   AC3 – Budget-check order: agent → team → org; team limit blocks call
+//!   AC4 – BudgetAlert fires at 80%/95% of team limits via broadcast channel
+//!   AC5 – Team budget state persists through snapshot/with_state and resets daily/monthly
+//!   AC6 – Integration: two agents, one team, team limit reached
+
+use aa_core::AgentId;
+use aa_gateway::budget::{
+    persistence::{load_from_disk, save_to_disk_atomic},
+    pricing::PricingTable,
+    tracker::BudgetTracker,
+    types::{BudgetAlert, BudgetStatus, Model, Provider},
+};
+use rust_decimal::Decimal;
+use std::str::FromStr;
+
+fn agent(b: u8) -> AgentId {
+    AgentId::from_bytes([b; 16])
+}
+
+fn base_tracker() -> BudgetTracker {
+    BudgetTracker::new(PricingTable::default_table(), None, None, chrono_tz::UTC)
+}
+
+// AC1: record_usage accumulates spend under the team key.
+#[test]
+fn record_usage_accumulates_in_team_budgets() {
+    let t = base_tracker();
+    let id = agent(1);
+    t.record_usage(id, Some("team-a"), Provider::OpenAi, Model::Gpt4o, 1_000, 0);
+    let state = t.team_state("team-a").expect("team-a must have a state after record_usage");
+    assert!(state.spent_usd > Decimal::ZERO, "team-a spend must be non-zero");
+}
+
+// AC2: record_raw_spend also rolls up to the team bucket.
+#[test]
+fn record_raw_spend_accumulates_in_team_budgets() {
+    let t = base_tracker();
+    let id = agent(2);
+    t.record_raw_spend(id, Some("team-b"), Decimal::from_str("7.50").unwrap());
+    let state = t.team_state("team-b").expect("team-b must have a state after record_raw_spend");
+    assert_eq!(state.spent_usd, Decimal::from_str("7.50").unwrap());
+}
+
+// AC3: team limit enforced — two agents sharing a team, combined spend breaches limit.
+#[test]
+fn team_limit_blocks_second_agent_when_team_total_exceeded() {
+    let t = base_tracker().with_team_daily_limit(Decimal::from_str("5.00").unwrap());
+    let agent_a = agent(10);
+    let agent_b = agent(11);
+    // Agent A spends $3.00 — within budget
+    let s1 = t.record_raw_spend(agent_a, Some("shared-team"), Decimal::from_str("3.00").unwrap());
+    assert!(matches!(s1, BudgetStatus::WithinBudget { .. }), "agent_a should be within budget");
+    // Agent B spends $2.00 — pushes team total to $5.00 (exactly at limit)
+    let s2 = t.record_raw_spend(agent_b, Some("shared-team"), Decimal::from_str("2.00").unwrap());
+    assert_eq!(s2, BudgetStatus::LimitExceeded, "team limit must block agent_b");
+}
+
+// AC3: individual agent spend below team limit still passes.
+#[test]
+fn individual_agent_below_team_limit_is_not_blocked() {
+    let t = base_tracker().with_team_daily_limit(Decimal::from_str("10.00").unwrap());
+    let s = t.record_raw_spend(agent(12), Some("solo-team"), Decimal::from_str("3.00").unwrap());
+    assert!(matches!(s, BudgetStatus::WithinBudget { .. }));
+}
+
+// AC4: BudgetAlert fires at 80% of team daily limit with correct team_id.
+#[test]
+fn budget_alert_fires_at_80_pct_of_team_daily_limit() {
+    let (alert_tx, mut alert_rx) = tokio::sync::broadcast::channel::<BudgetAlert>(16);
+    let t = BudgetTracker::new_with_alert_sender(
+        PricingTable::default_table(),
+        None,
+        None,
+        chrono_tz::UTC,
+        alert_tx,
+    )
+    .with_team_daily_limit(Decimal::from_str("10.00").unwrap());
+
+    // 8.00 / 10.00 = 80%
+    t.record_raw_spend(agent(20), Some("alert-team"), Decimal::from_str("8.00").unwrap());
+    let alert = alert_rx.try_recv().expect("expected 80% alert");
+    assert_eq!(alert.threshold_pct, 80);
+    assert_eq!(alert.team_id.as_deref(), Some("alert-team"));
+}
+
+// AC4: BudgetAlert fires at 95% of team daily limit.
+#[test]
+fn budget_alert_fires_at_95_pct_of_team_daily_limit() {
+    let (alert_tx, mut alert_rx) = tokio::sync::broadcast::channel::<BudgetAlert>(16);
+    let t = BudgetTracker::new_with_alert_sender(
+        PricingTable::default_table(),
+        None,
+        None,
+        chrono_tz::UTC,
+        alert_tx,
+    )
+    .with_team_daily_limit(Decimal::from_str("10.00").unwrap());
+
+    // 9.50 / 10.00 = 95%
+    t.record_raw_spend(agent(21), Some("alert-team-95"), Decimal::from_str("9.50").unwrap());
+    let alert = alert_rx.try_recv().expect("expected 95% alert");
+    assert_eq!(alert.threshold_pct, 95);
+    assert_eq!(alert.team_id.as_deref(), Some("alert-team-95"));
+}
+
+// AC5: Team budget state persists through snapshot/with_state round-trip.
+#[test]
+fn team_budget_persists_through_snapshot_round_trip() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("budget.json");
+
+    let t = base_tracker();
+    t.record_raw_spend(agent(30), Some("persist-team"), Decimal::from_str("4.20").unwrap());
+
+    let snap = t.snapshot();
+    assert!(snap.team_budgets.contains_key("persist-team"), "snapshot must include team");
+
+    save_to_disk_atomic(&path, &snap).unwrap();
+    let loaded = load_from_disk(&path).unwrap();
+    let restored = BudgetTracker::with_state(PricingTable::default_table(), None, None, loaded);
+
+    let state = restored.team_state("persist-team").expect("team must be restored");
+    assert_eq!(state.spent_usd, Decimal::from_str("4.20").unwrap());
+}
+
+// AC5: Team daily spend resets when date advances (via snapshot manipulation).
+#[test]
+fn team_daily_spend_resets_on_date_advance() {
+    let t = base_tracker().with_team_daily_limit(Decimal::from_str("5.00").unwrap());
+    let id = agent(31);
+
+    // Spend at limit — subsequent calls should be blocked
+    t.record_raw_spend(id, Some("reset-team"), Decimal::from_str("5.00").unwrap());
+    let before = t.record_raw_spend(agent(32), Some("reset-team"), Decimal::from_str("0.01").unwrap());
+    assert_eq!(before, BudgetStatus::LimitExceeded, "should be blocked before reset");
+
+    // Take snapshot, backdate the team entry by 1 day, restore into a new tracker
+    let mut snap = t.snapshot();
+    if let Some(team_state) = snap.team_budgets.get_mut("reset-team") {
+        team_state.date = chrono::Utc::now().date_naive() - chrono::Duration::days(1);
+    }
+    let restored = BudgetTracker::with_state(PricingTable::default_table(), None, None, snap)
+        .with_team_daily_limit(Decimal::from_str("5.00").unwrap());
+
+    // After date advance, team spend resets — new call should be within budget
+    let s = restored.record_raw_spend(agent(33), Some("reset-team"), Decimal::from_str("1.00").unwrap());
+    assert!(matches!(s, BudgetStatus::WithinBudget { .. }), "team spend must reset after date advance");
+}

--- a/aa-gateway/tests/team_budget_test.rs
+++ b/aa-gateway/tests/team_budget_test.rs
@@ -32,7 +32,9 @@ fn record_usage_accumulates_in_team_budgets() {
     let t = base_tracker();
     let id = agent(1);
     t.record_usage(id, Some("team-a"), Provider::OpenAi, Model::Gpt4o, 1_000, 0);
-    let state = t.team_state("team-a").expect("team-a must have a state after record_usage");
+    let state = t
+        .team_state("team-a")
+        .expect("team-a must have a state after record_usage");
     assert!(state.spent_usd > Decimal::ZERO, "team-a spend must be non-zero");
 }
 
@@ -42,7 +44,9 @@ fn record_raw_spend_accumulates_in_team_budgets() {
     let t = base_tracker();
     let id = agent(2);
     t.record_raw_spend(id, Some("team-b"), Decimal::from_str("7.50").unwrap());
-    let state = t.team_state("team-b").expect("team-b must have a state after record_raw_spend");
+    let state = t
+        .team_state("team-b")
+        .expect("team-b must have a state after record_raw_spend");
     assert_eq!(state.spent_usd, Decimal::from_str("7.50").unwrap());
 }
 
@@ -54,7 +58,10 @@ fn team_limit_blocks_second_agent_when_team_total_exceeded() {
     let agent_b = agent(11);
     // Agent A spends $3.00 — within budget
     let s1 = t.record_raw_spend(agent_a, Some("shared-team"), Decimal::from_str("3.00").unwrap());
-    assert!(matches!(s1, BudgetStatus::WithinBudget { .. }), "agent_a should be within budget");
+    assert!(
+        matches!(s1, BudgetStatus::WithinBudget { .. }),
+        "agent_a should be within budget"
+    );
     // Agent B spends $2.00 — pushes team total to $5.00 (exactly at limit)
     let s2 = t.record_raw_spend(agent_b, Some("shared-team"), Decimal::from_str("2.00").unwrap());
     assert_eq!(s2, BudgetStatus::LimitExceeded, "team limit must block agent_b");
@@ -72,14 +79,8 @@ fn individual_agent_below_team_limit_is_not_blocked() {
 #[test]
 fn budget_alert_fires_at_80_pct_of_team_daily_limit() {
     let (alert_tx, mut alert_rx) = tokio::sync::broadcast::channel::<BudgetAlert>(16);
-    let t = BudgetTracker::new_with_alert_sender(
-        PricingTable::default_table(),
-        None,
-        None,
-        chrono_tz::UTC,
-        alert_tx,
-    )
-    .with_team_daily_limit(Decimal::from_str("10.00").unwrap());
+    let t = BudgetTracker::new_with_alert_sender(PricingTable::default_table(), None, None, chrono_tz::UTC, alert_tx)
+        .with_team_daily_limit(Decimal::from_str("10.00").unwrap());
 
     // 8.00 / 10.00 = 80%
     t.record_raw_spend(agent(20), Some("alert-team"), Decimal::from_str("8.00").unwrap());
@@ -92,14 +93,8 @@ fn budget_alert_fires_at_80_pct_of_team_daily_limit() {
 #[test]
 fn budget_alert_fires_at_95_pct_of_team_daily_limit() {
     let (alert_tx, mut alert_rx) = tokio::sync::broadcast::channel::<BudgetAlert>(16);
-    let t = BudgetTracker::new_with_alert_sender(
-        PricingTable::default_table(),
-        None,
-        None,
-        chrono_tz::UTC,
-        alert_tx,
-    )
-    .with_team_daily_limit(Decimal::from_str("10.00").unwrap());
+    let t = BudgetTracker::new_with_alert_sender(PricingTable::default_table(), None, None, chrono_tz::UTC, alert_tx)
+        .with_team_daily_limit(Decimal::from_str("10.00").unwrap());
 
     // 9.50 / 10.00 = 95%
     t.record_raw_spend(agent(21), Some("alert-team-95"), Decimal::from_str("9.50").unwrap());
@@ -118,7 +113,10 @@ fn team_budget_persists_through_snapshot_round_trip() {
     t.record_raw_spend(agent(30), Some("persist-team"), Decimal::from_str("4.20").unwrap());
 
     let snap = t.snapshot();
-    assert!(snap.team_budgets.contains_key("persist-team"), "snapshot must include team");
+    assert!(
+        snap.team_budgets.contains_key("persist-team"),
+        "snapshot must include team"
+    );
 
     save_to_disk_atomic(&path, &snap).unwrap();
     let loaded = load_from_disk(&path).unwrap();
@@ -149,5 +147,8 @@ fn team_daily_spend_resets_on_date_advance() {
 
     // After date advance, team spend resets — new call should be within budget
     let s = restored.record_raw_spend(agent(33), Some("reset-team"), Decimal::from_str("1.00").unwrap());
-    assert!(matches!(s, BudgetStatus::WithinBudget { .. }), "team spend must reset after date advance");
+    assert!(
+        matches!(s, BudgetStatus::WithinBudget { .. }),
+        "team spend must reset after date advance"
+    );
 }

--- a/aa-gateway/tests/webhook_delivery_test.rs
+++ b/aa-gateway/tests/webhook_delivery_test.rs
@@ -107,6 +107,7 @@ async fn budget_alert_is_delivered_as_webhook_post() {
     // Send a budget alert through the broadcast channel.
     let alert = BudgetAlert {
         agent_id: aa_core::AgentId::from_bytes([42; 16]),
+        team_id: None,
         threshold_pct: 95,
         spent_usd: 95.0,
         limit_usd: 100.0,

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -519,6 +519,8 @@ export interface components {
             monthly_spend_usd?: string | null;
             /** @description Per-agent cost breakdown for the current day. */
             per_agent?: components["schemas"]["AgentCostEntry"][];
+            /** @description Per-team cost rollup for the current day. */
+            per_team?: components["schemas"]["TeamCostEntry"][];
         };
         /** @description Request body for creating a new policy. */
         CreatePolicyRequest: {
@@ -699,6 +701,17 @@ export interface components {
             new_status: string;
             /** @description Agent status before the suspend operation. */
             previous_status: string;
+        };
+        /** @description Per-team cost entry within the budget summary. */
+        TeamCostEntry: {
+            /** @description Daily spend for this team in USD (sum of all member agent spends today). */
+            daily_spend_usd: string;
+            /** @description Calendar date (YYYY-MM-DD) the daily spend applies to. */
+            date: string;
+            /** @description Total spend this month in USD for this team (if monthly tracking is enabled). */
+            monthly_spend_usd?: string | null;
+            /** @description Team identifier. */
+            team_id: string;
         };
         /** @description Request body for `POST /auth/token`. */
         TokenRequest: {

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -868,6 +868,11 @@ components:
           items:
             $ref: '#/components/schemas/AgentCostEntry'
           description: Per-agent cost breakdown for the current day.
+        per_team:
+          type: array
+          items:
+            $ref: '#/components/schemas/TeamCostEntry'
+          description: Per-team cost rollup for the current day.
     CreatePolicyRequest:
       type: object
       description: Request body for creating a new policy.
@@ -1158,6 +1163,28 @@ components:
         previous_status:
           type: string
           description: Agent status before the suspend operation.
+    TeamCostEntry:
+      type: object
+      description: Per-team cost entry within the budget summary.
+      required:
+      - team_id
+      - daily_spend_usd
+      - date
+      properties:
+        daily_spend_usd:
+          type: string
+          description: Daily spend for this team in USD (sum of all member agent spends today).
+        date:
+          type: string
+          description: Calendar date (YYYY-MM-DD) the daily spend applies to.
+        monthly_spend_usd:
+          type:
+          - string
+          - 'null'
+          description: Total spend this month in USD for this team (if monthly tracking is enabled).
+        team_id:
+          type: string
+          description: Team identifier.
     TokenRequest:
       type: object
       description: Request body for `POST /auth/token`.


### PR DESCRIPTION
## What changed

Implements per-team budget tracking and rollup in `aa-gateway` (AAASM-223 / F96). Each agent call now optionally carries a `team_id`; spend is accumulated in a per-team `DashMap<String, BudgetState>` inside `BudgetTracker`. Team daily and monthly limits can be configured via builder methods (`with_team_daily_limit`, `with_team_monthly_limit`). When a team limit is breached, `record_cost` returns `BudgetStatus::LimitExceeded` immediately — blocking the call even when the individual agent's spend is below their own limit. `BudgetAlert` events are emitted at 80% and 95% of team limits with the `team_id` field populated, allowing downstream webhook and Slack consumers to distinguish team alerts from agent alerts.

Team budget state is persisted in `PersistedBudget` via a new `#[serde(default)] team_budgets: HashMap<String, BudgetState>` field, enabling backward-compatible deserialization of existing `budget.json` files. Daily and monthly resets reuse the existing `BudgetState::maybe_reset()` path.

## Why it changed

F96 (AAASM-223) introduces team-level cost governance so operators can cap spend across all agents belonging to a team, not just per-agent. This is a prerequisite for the `team.budget_remaining` policy variable used by AAASM-225.

## How to verify

All 6 acceptance criteria are covered by integration tests in `aa-gateway/tests/team_budget_test.rs`:

| AC | Test |
|---|---|
| AC1 — `record_usage` accumulates under team key | `record_usage_accumulates_in_team_budgets` |
| AC2 — `record_raw_spend` participates in team rollup | `record_raw_spend_accumulates_in_team_budgets` |
| AC3 — Team limit blocks spend when team total exceeded | `team_limit_blocks_second_agent_when_team_total_exceeded`, `individual_agent_below_team_limit_is_not_blocked` |
| AC4 — `BudgetAlert` fires at 80%/95% with `team_id` | `budget_alert_fires_at_80_pct_of_team_daily_limit`, `budget_alert_fires_at_95_pct_of_team_daily_limit` |
| AC5 — Persists through snapshot/with_state and resets daily | `team_budget_persists_through_snapshot_round_trip`, `team_daily_spend_resets_on_date_advance` |
| AC6 — Two agents, one team, limit reached | `team_limit_blocks_second_agent_when_team_total_exceeded` |

```bash
cargo nextest run -p aa-gateway  # 462 passed, 0 failed
cargo clippy -p aa-gateway --all-targets -- -D warnings  # clean
```

Closes AAASM-223