### PR TITLE
[AAASM-226] ✨ (aa-core/aa-gateway/aa-devtool): Add per-level capability restrictions

### DIFF
--- a/aa-core/src/capability.rs
+++ b/aa-core/src/capability.rs
@@ -1,0 +1,174 @@
+//! Per-level capability types for fine-grained agent permission control.
+//!
+//! A [`Capability`] represents a discrete action category that policy can allow
+//! or deny. A [`CapabilitySet`] aggregates allow and deny sets for a given scope.
+
+use alloc::collections::BTreeSet;
+use alloc::string::{String, ToString};
+use core::str::FromStr;
+
+/// A discrete action category that policy can allow or deny for an agent.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Capability {
+    /// Read access to the filesystem.
+    FileRead,
+    /// Write access to the filesystem.
+    FileWrite,
+    /// Outbound network connections.
+    NetworkOutbound,
+    /// Inbound network connections.
+    NetworkInbound,
+    /// Execute commands in a terminal/shell.
+    TerminalExec,
+    /// Use a named MCP tool.
+    McpTool(String),
+    /// Use a named AI model.
+    Model(String),
+    /// Spawn child agents.
+    AgentSpawn,
+}
+
+/// Aggregates allow and deny capability sets for a given policy scope.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct CapabilitySet {
+    /// Capabilities explicitly allowed.
+    pub allow: BTreeSet<Capability>,
+    /// Capabilities explicitly denied.
+    pub deny: BTreeSet<Capability>,
+}
+
+impl FromStr for Capability {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "file_read" => Ok(Capability::FileRead),
+            "file_write" => Ok(Capability::FileWrite),
+            "network_outbound" => Ok(Capability::NetworkOutbound),
+            "network_inbound" => Ok(Capability::NetworkInbound),
+            "terminal_exec" => Ok(Capability::TerminalExec),
+            "agent_spawn" => Ok(Capability::AgentSpawn),
+            _ => {
+                if let Some(name) = s.strip_prefix("mcp_tool:") {
+                    if name.is_empty() {
+                        return Err("mcp_tool: name must not be empty".to_string());
+                    }
+                    Ok(Capability::McpTool(name.to_string()))
+                } else if let Some(name) = s.strip_prefix("model:") {
+                    if name.is_empty() {
+                        return Err("model: name must not be empty".to_string());
+                    }
+                    Ok(Capability::Model(name.to_string()))
+                } else {
+                    Err(alloc::format!("unknown capability: '{s}'"))
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloc::collections::BTreeSet;
+
+    #[test]
+    fn capability_variants_are_distinct() {
+        assert_ne!(Capability::FileRead, Capability::FileWrite);
+        assert_ne!(
+            Capability::McpTool("a".to_string()),
+            Capability::McpTool("b".to_string())
+        );
+    }
+
+    #[test]
+    fn mcp_tool_same_name_eq() {
+        assert_eq!(
+            Capability::McpTool("bash".to_string()),
+            Capability::McpTool("bash".to_string())
+        );
+    }
+
+    #[test]
+    fn capability_hashable_in_set() {
+        let mut set: BTreeSet<Capability> = BTreeSet::new();
+        set.insert(Capability::FileRead);
+        set.insert(Capability::FileWrite);
+        set.insert(Capability::McpTool("bash".to_string()));
+        assert_eq!(set.len(), 3);
+    }
+
+    #[test]
+    fn capability_set_default_is_empty() {
+        let cs = CapabilitySet::default();
+        assert!(cs.allow.is_empty());
+        assert!(cs.deny.is_empty());
+    }
+
+    #[test]
+    fn capability_from_str_file_read() {
+        assert_eq!("file_read".parse::<Capability>().unwrap(), Capability::FileRead);
+    }
+
+    #[test]
+    fn capability_from_str_file_write() {
+        assert_eq!("file_write".parse::<Capability>().unwrap(), Capability::FileWrite);
+    }
+
+    #[test]
+    fn capability_from_str_network_outbound() {
+        assert_eq!(
+            "network_outbound".parse::<Capability>().unwrap(),
+            Capability::NetworkOutbound
+        );
+    }
+
+    #[test]
+    fn capability_from_str_network_inbound() {
+        assert_eq!(
+            "network_inbound".parse::<Capability>().unwrap(),
+            Capability::NetworkInbound
+        );
+    }
+
+    #[test]
+    fn capability_from_str_terminal_exec() {
+        assert_eq!("terminal_exec".parse::<Capability>().unwrap(), Capability::TerminalExec);
+    }
+
+    #[test]
+    fn capability_from_str_mcp_tool() {
+        assert_eq!(
+            "mcp_tool:bash".parse::<Capability>().unwrap(),
+            Capability::McpTool("bash".to_string())
+        );
+    }
+
+    #[test]
+    fn capability_from_str_model() {
+        assert_eq!(
+            "model:gpt-4o".parse::<Capability>().unwrap(),
+            Capability::Model("gpt-4o".to_string())
+        );
+    }
+
+    #[test]
+    fn capability_from_str_agent_spawn() {
+        assert_eq!("agent_spawn".parse::<Capability>().unwrap(), Capability::AgentSpawn);
+    }
+
+    #[test]
+    fn capability_from_str_unknown_returns_err() {
+        assert!("unknown_cap".parse::<Capability>().is_err());
+    }
+
+    #[test]
+    fn capability_from_str_mcp_tool_empty_name_returns_err() {
+        assert!("mcp_tool:".parse::<Capability>().is_err());
+    }
+
+    #[test]
+    fn capability_from_str_model_empty_name_returns_err() {
+        assert!("model:".parse::<Capability>().is_err());
+    }
+}

--- a/aa-core/src/capability.rs
+++ b/aa-core/src/capability.rs
@@ -9,6 +9,7 @@ use core::str::FromStr;
 
 /// A discrete action category that policy can allow or deny for an agent.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Capability {
     /// Read access to the filesystem.
     FileRead,
@@ -30,6 +31,7 @@ pub enum Capability {
 
 /// Aggregates allow and deny capability sets for a given policy scope.
 #[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CapabilitySet {
     /// Capabilities explicitly allowed.
     pub allow: BTreeSet<Capability>,
@@ -63,6 +65,21 @@ impl FromStr for Capability {
                     Err(alloc::format!("unknown capability: '{s}'"))
                 }
             }
+        }
+    }
+}
+
+impl core::fmt::Display for Capability {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Capability::FileRead => f.write_str("file_read"),
+            Capability::FileWrite => f.write_str("file_write"),
+            Capability::NetworkOutbound => f.write_str("network_outbound"),
+            Capability::NetworkInbound => f.write_str("network_inbound"),
+            Capability::TerminalExec => f.write_str("terminal_exec"),
+            Capability::AgentSpawn => f.write_str("agent_spawn"),
+            Capability::McpTool(name) => write!(f, "mcp_tool:{name}"),
+            Capability::Model(name) => write!(f, "model:{name}"),
         }
     }
 }
@@ -170,5 +187,17 @@ mod tests {
     #[test]
     fn capability_from_str_model_empty_name_returns_err() {
         assert!("model:".parse::<Capability>().is_err());
+    }
+
+    #[test]
+    fn capability_display_round_trips_simple_variant() {
+        let cap = Capability::FileRead;
+        assert_eq!(cap.to_string().parse::<Capability>().unwrap(), cap);
+    }
+
+    #[test]
+    fn capability_display_round_trips_mcp_tool() {
+        let cap = Capability::McpTool("bash".to_string());
+        assert_eq!(cap.to_string().parse::<Capability>().unwrap(), cap);
     }
 }

--- a/aa-core/src/capability.rs
+++ b/aa-core/src/capability.rs
@@ -84,6 +84,61 @@ impl core::fmt::Display for Capability {
     }
 }
 
+/// Merge a parent [`CapabilitySet`] with a child [`CapabilitySet`] using
+/// parent-deny-wins semantics.
+///
+/// Rules:
+/// - `deny` = union of both deny sets; parent deny always wins over child allow.
+/// - `allow`:
+///   - Both empty → empty (no allow-list restriction).
+///   - Parent empty, child non-empty → `child.allow` minus merged deny.
+///   - Parent non-empty, child empty → `parent.allow` minus merged deny.
+///   - Both non-empty → intersection of `parent.allow` and `child.allow`, minus merged deny.
+#[cfg(feature = "alloc")]
+pub fn merge_capabilities(parent: &CapabilitySet, child: &CapabilitySet) -> CapabilitySet {
+    // deny = union of both deny sets
+    let deny: BTreeSet<Capability> = parent.deny.union(&child.deny).cloned().collect();
+
+    let allow: BTreeSet<Capability> = match (parent.allow.is_empty(), child.allow.is_empty()) {
+        // Both empty → no allow-list restriction
+        (true, true) => BTreeSet::new(),
+        // Parent empty, child non-empty → use child.allow
+        (true, false) => child.allow.difference(&deny).cloned().collect(),
+        // Parent non-empty, child empty → use parent.allow
+        (false, true) => parent.allow.difference(&deny).cloned().collect(),
+        // Both non-empty → intersection, then subtract deny
+        (false, false) => parent
+            .allow
+            .intersection(&child.allow)
+            .filter(|c| !deny.contains(c))
+            .cloned()
+            .collect(),
+    };
+
+    CapabilitySet { allow, deny }
+}
+
+/// Map a [`crate::GovernanceAction`] to the [`Capability`] it exercises,
+/// or `None` if the action does not map to a known capability.
+#[cfg(feature = "alloc")]
+pub fn action_to_capability(action: &crate::GovernanceAction) -> Option<Capability> {
+    use crate::policy::FileMode;
+    use crate::GovernanceAction;
+
+    match action {
+        GovernanceAction::ToolCall { name, .. } => Some(Capability::McpTool(name.clone())),
+        GovernanceAction::FileAccess {
+            mode: FileMode::Read, ..
+        } => Some(Capability::FileRead),
+        GovernanceAction::FileAccess {
+            mode: FileMode::Write | FileMode::Append | FileMode::Delete,
+            ..
+        } => Some(Capability::FileWrite),
+        GovernanceAction::NetworkRequest { .. } => Some(Capability::NetworkOutbound),
+        GovernanceAction::ProcessExec { .. } => Some(Capability::TerminalExec),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -199,5 +254,164 @@ mod tests {
     fn capability_display_round_trips_mcp_tool() {
         let cap = Capability::McpTool("bash".to_string());
         assert_eq!(cap.to_string().parse::<Capability>().unwrap(), cap);
+    }
+
+    // ------------------------------------------------------------------
+    // merge_capabilities tests
+    // ------------------------------------------------------------------
+
+    fn cap_set(allow: &[Capability], deny: &[Capability]) -> CapabilitySet {
+        CapabilitySet {
+            allow: allow.iter().cloned().collect(),
+            deny: deny.iter().cloned().collect(),
+        }
+    }
+
+    #[test]
+    fn merge_empty_parent_with_child_deny() {
+        let parent = CapabilitySet::default();
+        let child = cap_set(&[], &[Capability::FileWrite]);
+        let result = super::merge_capabilities(&parent, &child);
+        assert!(result.deny.contains(&Capability::FileWrite));
+        assert!(result.allow.is_empty());
+    }
+
+    #[test]
+    fn merge_parent_deny_wins_over_child_allow() {
+        let parent = cap_set(&[], &[Capability::NetworkOutbound]);
+        let child = cap_set(&[Capability::FileRead, Capability::NetworkOutbound], &[]);
+        let result = super::merge_capabilities(&parent, &child);
+        assert!(result.allow.contains(&Capability::FileRead));
+        assert!(!result.allow.contains(&Capability::NetworkOutbound));
+    }
+
+    #[test]
+    fn merge_deny_is_union() {
+        let parent = cap_set(&[], &[Capability::FileWrite]);
+        let child = cap_set(&[], &[Capability::TerminalExec]);
+        let result = super::merge_capabilities(&parent, &child);
+        assert!(result.deny.contains(&Capability::FileWrite));
+        assert!(result.deny.contains(&Capability::TerminalExec));
+    }
+
+    #[test]
+    fn merge_both_allow_nonempty_takes_intersection() {
+        let parent = cap_set(&[Capability::FileRead, Capability::FileWrite], &[]);
+        let child = cap_set(&[Capability::FileRead, Capability::NetworkOutbound], &[]);
+        let result = super::merge_capabilities(&parent, &child);
+        assert_eq!(
+            result.allow,
+            [Capability::FileRead].iter().cloned().collect::<BTreeSet<_>>()
+        );
+    }
+
+    #[test]
+    fn merge_parent_allow_nonempty_child_allow_empty_uses_parent() {
+        let parent = cap_set(&[Capability::FileRead], &[]);
+        let child = cap_set(&[], &[]);
+        let result = super::merge_capabilities(&parent, &child);
+        assert_eq!(
+            result.allow,
+            [Capability::FileRead].iter().cloned().collect::<BTreeSet<_>>()
+        );
+    }
+
+    #[test]
+    fn merge_parent_allow_empty_child_allow_nonempty_uses_child() {
+        let parent = cap_set(&[], &[]);
+        let child = cap_set(&[Capability::FileRead], &[]);
+        let result = super::merge_capabilities(&parent, &child);
+        assert_eq!(
+            result.allow,
+            [Capability::FileRead].iter().cloned().collect::<BTreeSet<_>>()
+        );
+    }
+
+    #[test]
+    fn merge_parent_deny_overrides_intersection_allow() {
+        let parent = cap_set(&[Capability::FileRead, Capability::FileWrite], &[Capability::FileRead]);
+        let child = cap_set(&[Capability::FileRead], &[]);
+        let result = super::merge_capabilities(&parent, &child);
+        assert!(
+            result.allow.is_empty(),
+            "FileRead was denied by parent, should be absent from allow"
+        );
+    }
+
+    #[test]
+    fn merge_both_empty_returns_empty() {
+        let parent = CapabilitySet::default();
+        let child = CapabilitySet::default();
+        let result = super::merge_capabilities(&parent, &child);
+        assert_eq!(result, CapabilitySet::default());
+    }
+
+    // ------------------------------------------------------------------
+    // action_to_capability tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn action_to_capability_tool_call() {
+        let action = crate::GovernanceAction::ToolCall {
+            name: "bash".to_string(),
+            args: "{}".to_string(),
+        };
+        assert_eq!(
+            super::action_to_capability(&action),
+            Some(Capability::McpTool("bash".to_string()))
+        );
+    }
+
+    #[test]
+    fn action_to_capability_file_read() {
+        let action = crate::GovernanceAction::FileAccess {
+            path: "/tmp/f".to_string(),
+            mode: crate::policy::FileMode::Read,
+        };
+        assert_eq!(super::action_to_capability(&action), Some(Capability::FileRead));
+    }
+
+    #[test]
+    fn action_to_capability_file_write() {
+        let action = crate::GovernanceAction::FileAccess {
+            path: "/tmp/f".to_string(),
+            mode: crate::policy::FileMode::Write,
+        };
+        assert_eq!(super::action_to_capability(&action), Some(Capability::FileWrite));
+    }
+
+    #[test]
+    fn action_to_capability_file_append_is_file_write() {
+        let action = crate::GovernanceAction::FileAccess {
+            path: "/tmp/f".to_string(),
+            mode: crate::policy::FileMode::Append,
+        };
+        assert_eq!(super::action_to_capability(&action), Some(Capability::FileWrite));
+    }
+
+    #[test]
+    fn action_to_capability_file_delete_is_file_write() {
+        let action = crate::GovernanceAction::FileAccess {
+            path: "/tmp/f".to_string(),
+            mode: crate::policy::FileMode::Delete,
+        };
+        assert_eq!(super::action_to_capability(&action), Some(Capability::FileWrite));
+    }
+
+    #[test]
+    fn action_to_capability_network_request() {
+        let action = crate::GovernanceAction::NetworkRequest {
+            url: "https://example.com".to_string(),
+            method: "GET".to_string(),
+        };
+        assert_eq!(super::action_to_capability(&action), Some(Capability::NetworkOutbound));
+    }
+
+    #[test]
+    fn action_to_capability_process_exec() {
+        let action = crate::GovernanceAction::ProcessExec {
+            command: "ls".to_string(),
+        };
+        assert_eq!(super::action_to_capability(&action), Some(Capability::TerminalExec));
     }
 }

--- a/aa-core/src/capability.rs
+++ b/aa-core/src/capability.rs
@@ -94,6 +94,8 @@ impl core::fmt::Display for Capability {
 ///   - Parent empty, child non-empty → `child.allow` minus merged deny.
 ///   - Parent non-empty, child empty → `parent.allow` minus merged deny.
 ///   - Both non-empty → intersection of `parent.allow` and `child.allow`, minus merged deny.
+///
+/// Requires the `alloc` feature.
 #[cfg(feature = "alloc")]
 pub fn merge_capabilities(parent: &CapabilitySet, child: &CapabilitySet) -> CapabilitySet {
     // deny = union of both deny sets
@@ -120,11 +122,16 @@ pub fn merge_capabilities(parent: &CapabilitySet, child: &CapabilitySet) -> Capa
 
 /// Map a [`crate::GovernanceAction`] to the [`Capability`] it exercises,
 /// or `None` if the action does not map to a known capability.
+///
+/// Requires the `alloc` feature.
 #[cfg(feature = "alloc")]
 pub fn action_to_capability(action: &crate::GovernanceAction) -> Option<Capability> {
     use crate::policy::FileMode;
     use crate::GovernanceAction;
 
+    // NOTE: Capability::AgentSpawn, NetworkInbound, and Model variants have no
+    // corresponding GovernanceAction yet. When new action variants land, add
+    // mappings here to avoid silent policy bypasses.
     match action {
         GovernanceAction::ToolCall { name, .. } => Some(Capability::McpTool(name.clone())),
         GovernanceAction::FileAccess {
@@ -336,6 +343,7 @@ mod tests {
             result.allow.is_empty(),
             "FileRead was denied by parent, should be absent from allow"
         );
+        assert!(result.deny.contains(&Capability::FileRead));
     }
 
     #[test]

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -58,7 +58,7 @@ pub use evaluators::{DenyAllEvaluator, PermitAllEvaluator};
 pub use audit::{AuditEntry, AuditEventType, AuditLog, AuditLogError, Lineage};
 
 #[cfg(feature = "alloc")]
-pub use capability::{Capability, CapabilitySet};
+pub use capability::{action_to_capability, merge_capabilities, Capability, CapabilitySet};
 
 #[cfg(feature = "std")]
 pub use scanner::{CredentialFinding, CredentialKind, CredentialScanner, ScanResult, ScannerConfig};

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -25,6 +25,8 @@ cfg_if::cfg_if! {
 pub mod agent;
 #[cfg(feature = "alloc")]
 pub mod audit;
+#[cfg(feature = "alloc")]
+pub mod capability;
 pub mod dev_tool;
 pub mod evaluators;
 pub mod identity;
@@ -54,6 +56,9 @@ pub use evaluators::{DenyAllEvaluator, PermitAllEvaluator};
 
 #[cfg(feature = "alloc")]
 pub use audit::{AuditEntry, AuditEventType, AuditLog, AuditLogError, Lineage};
+
+#[cfg(feature = "alloc")]
+pub use capability::{Capability, CapabilitySet};
 
 #[cfg(feature = "std")]
 pub use scanner::{CredentialFinding, CredentialKind, CredentialScanner, ScanResult, ScannerConfig};

--- a/aa-devtool/src/capability_bridge.rs
+++ b/aa-devtool/src/capability_bridge.rs
@@ -1,0 +1,167 @@
+use aa_core::{AdapterError, Capability, CapabilitySet, DevToolAdapter};
+
+/// Translate a [`CapabilitySet`] into an `apply_mcp_governance` call on `adapter`.
+///
+/// Only [`Capability::McpTool`] variants are relevant — all other capability
+/// kinds (file, network, process) are enforced at the gateway/proxy/eBPF layers
+/// and have no corresponding MCP configuration surface.
+pub async fn apply_capability_policy(adapter: &dyn DevToolAdapter, caps: &CapabilitySet) -> Result<(), AdapterError> {
+    let allowed: Vec<String> = caps
+        .allow
+        .iter()
+        .filter_map(|c| {
+            if let Capability::McpTool(name) = c {
+                Some(name.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let denied: Vec<String> = caps
+        .deny
+        .iter()
+        .filter_map(|c| {
+            if let Capability::McpTool(name) = c {
+                Some(name.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    adapter.apply_mcp_governance(&allowed, &denied).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aa_core::{Capability, CapabilitySet};
+    use std::sync::Mutex;
+
+    struct MockAdapter {
+        calls: Mutex<Vec<(Vec<String>, Vec<String>)>>,
+    }
+
+    impl MockAdapter {
+        fn new() -> Self {
+            Self {
+                calls: Mutex::new(vec![]),
+            }
+        }
+
+        fn recorded_calls(&self) -> Vec<(Vec<String>, Vec<String>)> {
+            self.calls.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl DevToolAdapter for MockAdapter {
+        fn detect(&self) -> Option<aa_core::DevToolInfo> {
+            None
+        }
+
+        async fn generate_managed_settings(&self, _: &aa_core::PolicyDocument) -> Result<String, AdapterError> {
+            Err(AdapterError::SettingsGenerationFailed("mock".into()))
+        }
+
+        async fn apply_settings(&self, _: &str) -> Result<(), AdapterError> {
+            Ok(())
+        }
+
+        fn build_launch_command(
+            &self,
+            _: &[String],
+            _: &str,
+            _: Option<&str>,
+            _: Option<&str>,
+        ) -> Result<std::process::Command, AdapterError> {
+            Err(AdapterError::LaunchFailed("mock".into()))
+        }
+
+        async fn list_mcp_servers(&self) -> Result<Vec<aa_core::McpServerInfo>, AdapterError> {
+            Ok(vec![])
+        }
+
+        async fn apply_mcp_governance(&self, allowed: &[String], denied: &[String]) -> Result<(), AdapterError> {
+            self.calls.lock().unwrap().push((allowed.to_vec(), denied.to_vec()));
+            Ok(())
+        }
+
+        fn governance_level(&self) -> aa_core::GovernanceLevel {
+            aa_core::GovernanceLevel::L2Enforce
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_empty_capability_set_calls_apply_with_empty_lists() {
+        let adapter = MockAdapter::new();
+        let caps = CapabilitySet::default();
+
+        apply_capability_policy(&adapter, &caps).await.unwrap();
+
+        let calls = adapter.recorded_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0], (vec![] as Vec<String>, vec![] as Vec<String>));
+    }
+
+    #[tokio::test]
+    async fn apply_denied_mcp_tool_passes_to_denied_list() {
+        let adapter = MockAdapter::new();
+        let mut caps = CapabilitySet::default();
+        caps.deny.insert(Capability::McpTool("bash".into()));
+
+        apply_capability_policy(&adapter, &caps).await.unwrap();
+
+        let calls = adapter.recorded_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, Vec::<String>::new());
+        assert_eq!(calls[0].1, vec!["bash"]);
+    }
+
+    #[tokio::test]
+    async fn apply_allowed_mcp_tools_pass_to_allowed_list() {
+        let adapter = MockAdapter::new();
+        let mut caps = CapabilitySet::default();
+        caps.allow.insert(Capability::McpTool("bash".into()));
+        caps.allow.insert(Capability::McpTool("git".into()));
+
+        apply_capability_policy(&adapter, &caps).await.unwrap();
+
+        let calls = adapter.recorded_calls();
+        assert_eq!(calls.len(), 1);
+        let mut allowed = calls[0].0.clone();
+        allowed.sort();
+        assert_eq!(allowed, vec!["bash", "git"]);
+        assert_eq!(calls[0].1, Vec::<String>::new());
+    }
+
+    #[tokio::test]
+    async fn apply_non_mcp_capabilities_not_in_lists() {
+        let adapter = MockAdapter::new();
+        let mut caps = CapabilitySet::default();
+        caps.deny.insert(Capability::FileWrite);
+        caps.deny.insert(Capability::TerminalExec);
+
+        apply_capability_policy(&adapter, &caps).await.unwrap();
+
+        let calls = adapter.recorded_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0], (vec![] as Vec<String>, vec![] as Vec<String>));
+    }
+
+    #[tokio::test]
+    async fn apply_both_allow_and_deny_mcp_tools() {
+        let adapter = MockAdapter::new();
+        let mut caps = CapabilitySet::default();
+        caps.allow.insert(Capability::McpTool("git".into()));
+        caps.deny.insert(Capability::McpTool("bash".into()));
+
+        apply_capability_policy(&adapter, &caps).await.unwrap();
+
+        let calls = adapter.recorded_calls();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, vec!["git"]);
+        assert_eq!(calls[0].1, vec!["bash"]);
+    }
+}

--- a/aa-devtool/src/lib.rs
+++ b/aa-devtool/src/lib.rs
@@ -1,5 +1,6 @@
 //! Dev tool auto-discovery for Agent Assembly.
 pub mod adapters;
+pub mod capability_bridge;
 pub mod discovery;
 
 pub use discovery::DiscoveryService;

--- a/aa-gateway/benches/policy_cascade.rs
+++ b/aa-gateway/benches/policy_cascade.rs
@@ -32,6 +32,7 @@ fn allow_doc(scope: PolicyScope) -> PolicyDocument {
         data: None,
         approval_timeout_secs: 300,
         tools: HashMap::new(),
+        capabilities: None,
     }
 }
 

--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -101,6 +101,24 @@ pub(crate) fn evaluate_single_doc(
         }
     }
 
+    // Stage 3.5 — Capability check
+    if let Some(caps) = &doc.capabilities {
+        if let Some(cap) = aa_core::action_to_capability(action) {
+            if caps.deny.contains(&cap) {
+                return PolicyDecision::Deny {
+                    reason: "capability denied by policy".into(),
+                    source_scope: doc.scope.clone(),
+                };
+            }
+            if !caps.allow.is_empty() && !caps.allow.contains(&cap) {
+                return PolicyDecision::Deny {
+                    reason: "capability not in allow list".into(),
+                    source_scope: doc.scope.clone(),
+                };
+            }
+        }
+    }
+
     // Stage 5 — Approval condition
     if let aa_core::GovernanceAction::ToolCall { name, .. } = action {
         if let Some(tp) = doc.tools.get(name) {
@@ -159,4 +177,177 @@ pub fn merge_decisions(
     }
 
     running
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::document::PolicyDocument;
+    use crate::policy::scope::PolicyScope;
+    use aa_core::{
+        identity::{AgentId, SessionId},
+        time::Timestamp,
+        AgentContext, Capability, CapabilitySet, FileMode, GovernanceAction, GovernanceLevel,
+    };
+    use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+    fn make_ctx() -> AgentContext {
+        AgentContext {
+            agent_id: AgentId::from_bytes([1u8; 16]),
+            session_id: SessionId::from_bytes([2u8; 16]),
+            pid: 1,
+            started_at: Timestamp::from_nanos(0),
+            metadata: BTreeMap::new(),
+            governance_level: GovernanceLevel::default(),
+            parent_agent_id: None,
+            team_id: None,
+            depth: 0,
+            delegation_reason: None,
+            spawned_by_tool: None,
+            root_agent_id: None,
+        }
+    }
+
+    fn minimal_doc(caps: Option<CapabilitySet>) -> PolicyDocument {
+        PolicyDocument {
+            name: None,
+            policy_version: None,
+            version: None,
+            scope: PolicyScope::Global,
+            network: None,
+            schedule: None,
+            budget: None,
+            data: None,
+            approval_timeout_secs: 300,
+            tools: HashMap::new(),
+            capabilities: caps,
+        }
+    }
+
+    fn cap_set(allow: &[Capability], deny: &[Capability]) -> CapabilitySet {
+        CapabilitySet {
+            allow: allow.iter().cloned().collect::<BTreeSet<_>>(),
+            deny: deny.iter().cloned().collect::<BTreeSet<_>>(),
+        }
+    }
+
+    #[test]
+    fn evaluate_single_doc_denies_capability_in_deny_set() {
+        let doc = minimal_doc(Some(cap_set(&[], &[Capability::FileRead])));
+        let ctx = make_ctx();
+        let action = GovernanceAction::FileAccess {
+            path: "/tmp/f".into(),
+            mode: FileMode::Read,
+        };
+        let result = evaluate_single_doc(&doc, &ctx, &action);
+        assert_eq!(
+            result,
+            PolicyDecision::Deny {
+                reason: "capability denied by policy".into(),
+                source_scope: PolicyScope::Global,
+            }
+        );
+    }
+
+    #[test]
+    fn evaluate_single_doc_denies_capability_not_in_allow_set() {
+        // allow = {FileRead} only — FileWrite should be denied
+        let doc = minimal_doc(Some(cap_set(&[Capability::FileRead], &[])));
+        let ctx = make_ctx();
+        let action = GovernanceAction::FileAccess {
+            path: "/tmp/f".into(),
+            mode: FileMode::Write,
+        };
+        let result = evaluate_single_doc(&doc, &ctx, &action);
+        assert_eq!(
+            result,
+            PolicyDecision::Deny {
+                reason: "capability not in allow list".into(),
+                source_scope: PolicyScope::Global,
+            }
+        );
+    }
+
+    #[test]
+    fn evaluate_single_doc_allows_capability_in_allow_set() {
+        // allow = {FileRead} — FileRead should pass the capability stage
+        let doc = minimal_doc(Some(cap_set(&[Capability::FileRead], &[])));
+        let ctx = make_ctx();
+        let action = GovernanceAction::FileAccess {
+            path: "/tmp/f".into(),
+            mode: FileMode::Read,
+        };
+        let result = evaluate_single_doc(&doc, &ctx, &action);
+        assert_ne!(
+            result,
+            PolicyDecision::Deny {
+                reason: "capability denied by policy".into(),
+                source_scope: PolicyScope::Global,
+            }
+        );
+        assert_ne!(
+            result,
+            PolicyDecision::Deny {
+                reason: "capability not in allow list".into(),
+                source_scope: PolicyScope::Global,
+            }
+        );
+    }
+
+    #[test]
+    fn evaluate_single_doc_no_capabilities_field_allows_all() {
+        // No capabilities block → no restriction from stage 3.5
+        let doc = minimal_doc(None);
+        let ctx = make_ctx();
+        let action = GovernanceAction::FileAccess {
+            path: "/tmp/f".into(),
+            mode: FileMode::Write,
+        };
+        let result = evaluate_single_doc(&doc, &ctx, &action);
+        assert_eq!(result, PolicyDecision::Allow);
+    }
+
+    #[test]
+    fn evaluate_single_doc_mcp_tool_denied_by_name() {
+        let doc = minimal_doc(Some(cap_set(&[], &[Capability::McpTool("bash".into())])));
+        let ctx = make_ctx();
+        let action = GovernanceAction::ToolCall {
+            name: "bash".into(),
+            args: "{}".into(),
+        };
+        let result = evaluate_single_doc(&doc, &ctx, &action);
+        assert_eq!(
+            result,
+            PolicyDecision::Deny {
+                reason: "capability denied by policy".into(),
+                source_scope: PolicyScope::Global,
+            }
+        );
+    }
+
+    #[test]
+    fn evaluate_single_doc_mcp_tool_allowed_by_name() {
+        let doc = minimal_doc(Some(cap_set(&[Capability::McpTool("bash".into())], &[])));
+        let ctx = make_ctx();
+        let action = GovernanceAction::ToolCall {
+            name: "bash".into(),
+            args: "{}".into(),
+        };
+        let result = evaluate_single_doc(&doc, &ctx, &action);
+        // Must not be denied by capability stage
+        assert_ne!(
+            result,
+            PolicyDecision::Deny {
+                reason: "capability denied by policy".into(),
+                source_scope: PolicyScope::Global,
+            }
+        );
+        assert_ne!(
+            result,
+            PolicyDecision::Deny {
+                reason: "capability not in allow list".into(),
+                source_scope: PolicyScope::Global,
+            }
+        );
+    }
 }

--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -278,20 +278,7 @@ mod tests {
             mode: FileMode::Read,
         };
         let result = evaluate_single_doc(&doc, &ctx, &action);
-        assert_ne!(
-            result,
-            PolicyDecision::Deny {
-                reason: "capability denied by policy".into(),
-                source_scope: PolicyScope::Global,
-            }
-        );
-        assert_ne!(
-            result,
-            PolicyDecision::Deny {
-                reason: "capability not in allow list".into(),
-                source_scope: PolicyScope::Global,
-            }
-        );
+        assert_eq!(result, PolicyDecision::Allow);
     }
 
     #[test]
@@ -334,20 +321,6 @@ mod tests {
             args: "{}".into(),
         };
         let result = evaluate_single_doc(&doc, &ctx, &action);
-        // Must not be denied by capability stage
-        assert_ne!(
-            result,
-            PolicyDecision::Deny {
-                reason: "capability denied by policy".into(),
-                source_scope: PolicyScope::Global,
-            }
-        );
-        assert_ne!(
-            result,
-            PolicyDecision::Deny {
-                reason: "capability not in allow list".into(),
-                source_scope: PolicyScope::Global,
-            }
-        );
+        assert_eq!(result, PolicyDecision::Allow);
     }
 }

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -481,7 +481,8 @@ impl PolicyEngine {
         ctx: &aa_core::AgentContext,
         action: &aa_core::GovernanceAction,
     ) -> EvaluationResult {
-        // Cache lookup: stateless stages only (1–3, 5). Stateful stages (4, 7) always run.
+        // Cache lookup: stateless stages only (1–3, 5). Stateful stages (4, 7),
+        // the capability guard, and the credential scan always run.
         let epoch = self.policy_epoch.load(Ordering::Relaxed);
         let cache_key = CacheKey::new(ctx.agent_id.as_bytes(), epoch, action);
         let verdict = if let Some(cached) = self.decision_cache.get(&cache_key) {
@@ -503,10 +504,11 @@ impl PolicyEngine {
             };
         }
 
-        // Cascade capability guard: re-check the merged capability set.
-        // Per-doc stage 3.5 in evaluate_single_doc() catches intra-doc denials;
-        // this guard catches cross-doc scenarios and exposes the merged set
-        // for dev-tool wiring (AAASM-1046).
+        // Cascade capability guard: checks the allow-list intersection case where no single
+        // doc denies the capability but the merged allow-list (after merge_capabilities)
+        // does not contain it. Per-doc stage 3.5 handles intra-doc denials; this guard
+        // handles cross-doc scenarios. The merged set is also used for dev-tool wiring
+        // (AAASM-1046).
         let merged_caps = Self::collect_merged_capabilities(&cascade);
         if let Some(cap) = aa_core::action_to_capability(action) {
             if merged_caps.deny.contains(&cap) {
@@ -649,7 +651,7 @@ impl PolicyEngine {
     ///
     /// Returns an empty `CapabilitySet` (no restrictions) when no policy in the
     /// cascade defines a `capabilities` block.
-    pub fn collect_merged_capabilities(cascade: &[std::sync::Arc<PolicyDocument>]) -> aa_core::CapabilitySet {
+    pub(crate) fn collect_merged_capabilities(cascade: &[std::sync::Arc<PolicyDocument>]) -> aa_core::CapabilitySet {
         cascade.iter().fold(aa_core::CapabilitySet::default(), |acc, doc| {
             if let Some(caps) = &doc.capabilities {
                 aa_core::merge_capabilities(&acc, caps)

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -503,6 +503,34 @@ impl PolicyEngine {
             };
         }
 
+        // Cascade capability guard: re-check the merged capability set.
+        // Per-doc stage 3.5 in evaluate_single_doc() catches intra-doc denials;
+        // this guard catches cross-doc scenarios and exposes the merged set
+        // for dev-tool wiring (AAASM-1046).
+        let merged_caps = Self::collect_merged_capabilities(&cascade);
+        if let Some(cap) = aa_core::action_to_capability(action) {
+            if merged_caps.deny.contains(&cap) {
+                return EvaluationResult {
+                    decision: aa_core::PolicyResult::Deny {
+                        reason: "capability denied by policy".into(),
+                    },
+                    redacted_payload: None,
+                    credential_findings: vec![],
+                    deny_action: None,
+                };
+            }
+            if !merged_caps.allow.is_empty() && !merged_caps.allow.contains(&cap) {
+                return EvaluationResult {
+                    decision: aa_core::PolicyResult::Deny {
+                        reason: "capability not in allow list".into(),
+                    },
+                    redacted_payload: None,
+                    credential_findings: vec![],
+                    deny_action: None,
+                };
+            }
+        }
+
         // Stage 4 — Rate limiting: use the most restrictive (minimum) limit_per_hour
         // found across all cascade policies for the requested tool.
         if let aa_core::GovernanceAction::ToolCall { name, .. } = action {
@@ -614,6 +642,21 @@ impl PolicyEngine {
             credential_findings,
             deny_action,
         }
+    }
+
+    /// Build the merged `CapabilitySet` for the given cascade by folding
+    /// `merge_capabilities` left-to-right (Global → Org → Team → Agent).
+    ///
+    /// Returns an empty `CapabilitySet` (no restrictions) when no policy in the
+    /// cascade defines a `capabilities` block.
+    pub fn collect_merged_capabilities(cascade: &[std::sync::Arc<PolicyDocument>]) -> aa_core::CapabilitySet {
+        cascade.iter().fold(aa_core::CapabilitySet::default(), |acc, doc| {
+            if let Some(caps) = &doc.capabilities {
+                aa_core::merge_capabilities(&acc, caps)
+            } else {
+                acc
+            }
+        })
     }
 
     /// Record a spend amount for an agent after an action completes.
@@ -1618,6 +1661,127 @@ mod tests {
             engine.evaluate(&ctx, &action).decision,
             PolicyResult::Deny {
                 reason: "daily budget exceeded".into()
+            }
+        );
+    }
+
+    // ── Cascade capability guard tests ────────────────────────────────────────
+
+    fn scoped_doc(scope: crate::policy::scope::PolicyScope, caps: Option<aa_core::CapabilitySet>) -> PolicyDocument {
+        PolicyDocument {
+            name: None,
+            policy_version: None,
+            version: None,
+            scope,
+            network: None,
+            schedule: None,
+            budget: None,
+            data: None,
+            approval_timeout_secs: 300,
+            tools: HashMap::new(),
+            capabilities: caps,
+        }
+    }
+
+    fn cap_set_cascade(allow: &[aa_core::Capability], deny: &[aa_core::Capability]) -> aa_core::CapabilitySet {
+        use std::collections::BTreeSet;
+        aa_core::CapabilitySet {
+            allow: allow.iter().cloned().collect::<BTreeSet<_>>(),
+            deny: deny.iter().cloned().collect::<BTreeSet<_>>(),
+        }
+    }
+
+    #[test]
+    fn cascade_capability_deny_from_global_blocks_narrower_allow() {
+        // Global deny = {FileWrite}; Agent allow = {FileRead, FileWrite} — global deny wins.
+        let mut engine = make_engine(empty_doc());
+        let global_caps = cap_set_cascade(&[], &[aa_core::Capability::FileWrite]);
+        engine.load_policy(scoped_doc(crate::policy::scope::PolicyScope::Global, Some(global_caps)));
+        let agent_id = AgentId::from_bytes([1u8; 16]);
+        let agent_caps = cap_set_cascade(&[aa_core::Capability::FileRead, aa_core::Capability::FileWrite], &[]);
+        engine.load_policy(scoped_doc(
+            crate::policy::scope::PolicyScope::Agent(agent_id),
+            Some(agent_caps),
+        ));
+
+        let ctx = make_ctx();
+        let action = aa_core::GovernanceAction::FileAccess {
+            path: "/tmp/f".into(),
+            mode: aa_core::FileMode::Write,
+        };
+        assert_eq!(
+            engine.evaluate(&ctx, &action).decision,
+            PolicyResult::Deny {
+                reason: "capability denied by policy".into()
+            }
+        );
+    }
+
+    #[test]
+    fn cascade_capability_merged_allow_list_is_intersection() {
+        // Global allow = {FileRead, FileWrite}; Agent allow = {FileRead}.
+        // After merge: allow is narrowed to {FileRead}. FileWrite should be denied.
+        // Uses Global + Agent scopes because collect_cascade walks those without a registry.
+        let agent_id = AgentId::from_bytes([1u8; 16]);
+        let mut engine = make_engine(empty_doc());
+        let global_caps = cap_set_cascade(&[aa_core::Capability::FileRead, aa_core::Capability::FileWrite], &[]);
+        engine.load_policy(scoped_doc(crate::policy::scope::PolicyScope::Global, Some(global_caps)));
+        let agent_caps = cap_set_cascade(&[aa_core::Capability::FileRead], &[]);
+        engine.load_policy(scoped_doc(
+            crate::policy::scope::PolicyScope::Agent(agent_id),
+            Some(agent_caps),
+        ));
+
+        let ctx = make_ctx();
+
+        // FileWrite must be denied (not in merged allow list)
+        let write_action = aa_core::GovernanceAction::FileAccess {
+            path: "/tmp/f".into(),
+            mode: aa_core::FileMode::Write,
+        };
+        assert_eq!(
+            engine.evaluate(&ctx, &write_action).decision,
+            PolicyResult::Deny {
+                reason: "capability not in allow list".into()
+            }
+        );
+
+        // FileRead must be allowed (in merged allow list)
+        let read_action = aa_core::GovernanceAction::FileAccess {
+            path: "/tmp/f".into(),
+            mode: aa_core::FileMode::Read,
+        };
+        assert_ne!(
+            engine.evaluate(&ctx, &read_action).decision,
+            PolicyResult::Deny {
+                reason: "capability not in allow list".into()
+            }
+        );
+    }
+
+    #[test]
+    fn cascade_no_capabilities_configured_allows_all_actions() {
+        // No capabilities blocks in any cascade doc → capability guard is no-op.
+        let mut engine = make_engine(empty_doc());
+        engine.load_policy(scoped_doc(crate::policy::scope::PolicyScope::Global, None));
+        let agent_id = AgentId::from_bytes([1u8; 16]);
+        engine.load_policy(scoped_doc(crate::policy::scope::PolicyScope::Agent(agent_id), None));
+
+        let ctx = make_ctx();
+        let action = aa_core::GovernanceAction::FileAccess {
+            path: "/tmp/f".into(),
+            mode: aa_core::FileMode::Write,
+        };
+        assert_ne!(
+            engine.evaluate(&ctx, &action).decision,
+            PolicyResult::Deny {
+                reason: "capability denied by policy".into()
+            }
+        );
+        assert_ne!(
+            engine.evaluate(&ctx, &action).decision,
+            PolicyResult::Deny {
+                reason: "capability not in allow list".into()
             }
         );
     }

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -854,6 +854,7 @@ mod tests {
             data: None,
             approval_timeout_secs: 300,
             tools: HashMap::new(),
+            capabilities: None,
         }
     }
 

--- a/aa-gateway/src/engine/scope_index.rs
+++ b/aa-gateway/src/engine/scope_index.rs
@@ -149,6 +149,7 @@ mod tests {
             data: None,
             approval_timeout_secs: 300,
             tools: HashMap::new(),
+            capabilities: None,
         }
     }
 

--- a/aa-gateway/src/policy/document.rs
+++ b/aa-gateway/src/policy/document.rs
@@ -95,6 +95,8 @@ pub struct PolicyDocument {
     pub approval_timeout_secs: u32,
     /// Per-tool policies keyed by tool name.
     pub tools: std::collections::HashMap<String, ToolPolicy>,
+    /// Capability allow/deny restrictions for this policy scope.
+    pub capabilities: Option<aa_core::CapabilitySet>,
 }
 
 #[cfg(test)]
@@ -114,6 +116,7 @@ mod tests {
             data: None,
             approval_timeout_secs: 300,
             tools: std::collections::HashMap::new(),
+            capabilities: None,
         };
         assert!(doc.tools.is_empty());
     }

--- a/aa-gateway/src/policy/raw.rs
+++ b/aa-gateway/src/policy/raw.rs
@@ -64,6 +64,18 @@ pub struct RawDataPolicy {
     pub unknown: HashMap<String, serde_yaml::Value>,
 }
 
+/// Raw (unvalidated) deserialization target for the `capabilities` policy section.
+#[derive(Debug, Deserialize)]
+pub struct RawCapabilitySet {
+    /// Capability strings that are explicitly permitted.
+    pub allow: Option<Vec<String>>,
+    /// Capability strings that are explicitly denied.
+    pub deny: Option<Vec<String>>,
+    /// Unknown keys captured for warning emission.
+    #[serde(flatten)]
+    pub unknown: HashMap<String, serde_yaml::Value>,
+}
+
 /// Raw (unvalidated) deserialization target for the `metadata` section
 /// of the governance policy YAML envelope.
 #[derive(Debug, Deserialize)]
@@ -114,6 +126,8 @@ pub struct RawPolicyDocument {
     pub data: Option<RawDataPolicy>,
     /// Per-tool policies keyed by tool name.
     pub tools: Option<HashMap<String, RawToolPolicy>>,
+    /// Per-level capability restrictions.
+    pub capabilities: Option<RawCapabilitySet>,
     /// Seconds before an approval request times out.
     /// Defaults to 300 when absent.
     pub approval_timeout_secs: Option<u32>,
@@ -302,5 +316,30 @@ mod tests {
         let yaml = "allow: true\nconstraint: \"read-only\"\n";
         let raw: RawToolPolicy = serde_yaml::from_str(yaml).unwrap();
         assert!(raw.unknown.contains_key("constraint"));
+    }
+
+    // ── RawCapabilitySet ────────────────────────────────────────────────────
+
+    #[test]
+    fn raw_capabilities_deserializes_allow_and_deny() {
+        let yaml = "capabilities:\n  allow:\n    - file_read\n  deny:\n    - terminal_exec\n";
+        let raw: RawPolicyDocument = serde_yaml::from_str(yaml).unwrap();
+        let caps = raw.capabilities.as_ref().unwrap();
+        assert_eq!(caps.allow, Some(vec!["file_read".to_string()]));
+        assert_eq!(caps.deny, Some(vec!["terminal_exec".to_string()]));
+    }
+
+    #[test]
+    fn raw_capabilities_absent_is_none() {
+        let yaml = "{}\n";
+        let raw: RawPolicyDocument = serde_yaml::from_str(yaml).unwrap();
+        assert!(raw.capabilities.is_none());
+    }
+
+    #[test]
+    fn raw_capabilities_captures_unknown_key() {
+        let yaml = "capabilities:\n  allow: []\n  extra_field: true\n";
+        let raw: RawPolicyDocument = serde_yaml::from_str(yaml).unwrap();
+        assert!(raw.capabilities.as_ref().unwrap().unknown.contains_key("extra_field"));
     }
 }

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -48,6 +48,7 @@ impl PolicyValidator {
         let budget = Self::validate_budget(raw.budget, &mut errors);
         let data = Self::validate_data(raw.data, &mut errors);
         let tools = Self::validate_tools(raw.tools, &mut errors, &mut warnings);
+        let capabilities = Self::validate_capabilities(raw.capabilities, &mut errors, &mut warnings);
 
         let approval_timeout_secs = match raw.approval_timeout_secs {
             Some(0) => {
@@ -79,6 +80,7 @@ impl PolicyValidator {
                 data,
                 approval_timeout_secs,
                 tools,
+                capabilities,
             },
             warnings,
         })
@@ -307,6 +309,40 @@ impl PolicyValidator {
         Some(DataPolicy {
             sensitive_patterns: patterns,
         })
+    }
+
+    fn validate_capabilities(
+        raw: Option<crate::policy::raw::RawCapabilitySet>,
+        errors: &mut Vec<ValidationError>,
+        warnings: &mut Vec<ValidationWarning>,
+    ) -> Option<aa_core::CapabilitySet> {
+        let raw = raw?;
+
+        for key in raw.unknown.keys() {
+            warnings.push(ValidationWarning::unknown_key(format!("capabilities.{}", key)));
+        }
+
+        let mut allow = std::collections::BTreeSet::new();
+        for (i, s) in raw.allow.unwrap_or_default().iter().enumerate() {
+            match s.parse::<aa_core::Capability>() {
+                Ok(cap) => {
+                    allow.insert(cap);
+                }
+                Err(msg) => errors.push(ValidationError::new(format!("capabilities.allow[{}]", i), msg)),
+            }
+        }
+
+        let mut deny = std::collections::BTreeSet::new();
+        for (i, s) in raw.deny.unwrap_or_default().iter().enumerate() {
+            match s.parse::<aa_core::Capability>() {
+                Ok(cap) => {
+                    deny.insert(cap);
+                }
+                Err(msg) => errors.push(ValidationError::new(format!("capabilities.deny[{}]", i), msg)),
+            }
+        }
+
+        Some(aa_core::CapabilitySet { allow, deny })
     }
 
     fn validate_tools(
@@ -654,6 +690,50 @@ mod tests {
         assert_eq!(ah.start, "09:00");
         assert_eq!(ah.end, "18:00");
         assert_eq!(ah.timezone, "Asia/Taipei");
+    }
+
+    // ── Capabilities validation ─────────────────────────────────────────────
+
+    #[test]
+    fn capabilities_valid_round_trips() {
+        let yaml = "capabilities:\n  allow:\n    - file_read\n    - mcp_tool:bash\n  deny:\n    - terminal_exec\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        let caps = out.document.capabilities.as_ref().unwrap();
+        assert!(caps.allow.contains(&aa_core::Capability::FileRead));
+        assert!(caps.allow.contains(&aa_core::Capability::McpTool("bash".to_string())));
+        assert!(caps.deny.contains(&aa_core::Capability::TerminalExec));
+    }
+
+    #[test]
+    fn capabilities_absent_is_none() {
+        let yaml = "{}\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        assert!(out.document.capabilities.is_none());
+    }
+
+    #[test]
+    fn capabilities_unknown_string_is_validation_error() {
+        let yaml = "capabilities:\n  allow:\n    - unknown_thing\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err());
+        let errs = result.unwrap_err();
+        assert!(errs.iter().any(|e| e.field == "capabilities.allow[0]"));
+    }
+
+    #[test]
+    fn capabilities_mcp_tool_no_name_is_error() {
+        let yaml = "capabilities:\n  allow:\n    - \"mcp_tool:\"\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err());
+        let errs = result.unwrap_err();
+        assert!(errs.iter().any(|e| e.field == "capabilities.allow[0]"));
+    }
+
+    #[test]
+    fn capabilities_unknown_key_produces_warning() {
+        let yaml = "capabilities:\n  allow: []\n  extra_key: true\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        assert!(out.warnings.iter().any(|w| w.field.contains("capabilities.")));
     }
 
     // ── Full-policy integration ─────────────────────────────────────────────

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -733,7 +733,7 @@ mod tests {
     fn capabilities_unknown_key_produces_warning() {
         let yaml = "capabilities:\n  allow: []\n  extra_key: true\n";
         let out = PolicyValidator::from_yaml(yaml).unwrap();
-        assert!(out.warnings.iter().any(|w| w.field.contains("capabilities.")));
+        assert!(out.warnings.iter().any(|w| w.field == "capabilities.extra_key"));
     }
 
     // ── Full-policy integration ─────────────────────────────────────────────

--- a/aa-gateway/tests/capability_integration_test.rs
+++ b/aa-gateway/tests/capability_integration_test.rs
@@ -1,0 +1,273 @@
+//! Integration tests for per-level capability policy restrictions (AAASM-226 / AAASM-1126).
+//!
+//! These tests exercise the full path from YAML → `PolicyValidator` →
+//! `PolicyEngine::load_policy` → `PolicyEngine::evaluate`, verifying that
+//! capability allow/deny sets are correctly enforced across the cascade.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::io::Write;
+
+use aa_core::identity::{AgentId, SessionId};
+use aa_core::{AgentContext, Capability, CapabilitySet, GovernanceAction, GovernanceLevel, PolicyResult};
+use aa_gateway::engine::PolicyEngine;
+use aa_gateway::policy::document::PolicyDocument;
+use aa_gateway::policy::scope::PolicyScope;
+use aa_gateway::policy::PolicyValidator;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn make_engine() -> PolicyEngine {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    writeln!(tmp, "version: \"1\"").unwrap();
+    tmp.flush().unwrap();
+    let (alert_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    PolicyEngine::load_from_file(tmp.path(), alert_tx).unwrap()
+}
+
+fn make_ctx() -> AgentContext {
+    AgentContext {
+        agent_id: AgentId::from_bytes([1u8; 16]),
+        session_id: SessionId::from_bytes([0u8; 16]),
+        pid: 0,
+        started_at: aa_core::time::Timestamp::from_nanos(0),
+        metadata: BTreeMap::new(),
+        governance_level: GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: None,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: None,
+    }
+}
+
+fn cap_doc(scope: PolicyScope, allow: &[Capability], deny: &[Capability]) -> PolicyDocument {
+    PolicyDocument {
+        name: None,
+        policy_version: None,
+        version: None,
+        scope,
+        network: None,
+        schedule: None,
+        budget: None,
+        data: None,
+        approval_timeout_secs: 300,
+        tools: HashMap::new(),
+        capabilities: Some(CapabilitySet {
+            allow: allow.iter().cloned().collect::<BTreeSet<_>>(),
+            deny: deny.iter().cloned().collect::<BTreeSet<_>>(),
+        }),
+    }
+}
+
+fn no_cap_doc(scope: PolicyScope) -> PolicyDocument {
+    PolicyDocument {
+        name: None,
+        policy_version: None,
+        version: None,
+        scope,
+        network: None,
+        schedule: None,
+        budget: None,
+        data: None,
+        approval_timeout_secs: 300,
+        tools: HashMap::new(),
+        capabilities: None,
+    }
+}
+
+// ── Test 1 ────────────────────────────────────────────────────────────────────
+
+/// Parse the canonical capability YAML fixture and verify the round-trip through
+/// `PolicyValidator`. Ensures the envelope format, allow list, deny list, and
+/// named MCP tool capabilities are all correctly parsed.
+#[test]
+fn capability_policy_yaml_round_trip_via_validator() {
+    let yaml = r#"
+apiVersion: agent-assembly/v1
+kind: Policy
+metadata:
+  name: capability-example
+  version: "1.0.0"
+spec:
+  scope: global
+  capabilities:
+    allow:
+      - file_read
+      - network_outbound
+      - mcp_tool:git
+      - mcp_tool:bash
+    deny:
+      - terminal_exec
+      - file_write
+"#;
+
+    let output = PolicyValidator::from_yaml(yaml);
+    assert!(output.is_ok(), "expected Ok, got: {:?}", output.err());
+
+    let doc = output.unwrap().document;
+    let caps = doc.capabilities.as_ref().expect("capabilities must be Some");
+
+    assert!(caps.allow.contains(&Capability::FileRead));
+    assert!(caps.allow.contains(&Capability::NetworkOutbound));
+    assert!(caps.allow.contains(&Capability::McpTool("git".to_string())));
+    assert!(caps.allow.contains(&Capability::McpTool("bash".to_string())));
+    assert!(caps.deny.contains(&Capability::TerminalExec));
+    assert!(caps.deny.contains(&Capability::FileWrite));
+}
+
+// ── Test 2 ────────────────────────────────────────────────────────────────────
+
+/// A Global-scoped policy with `capabilities.deny = {FileWrite}` must deny a
+/// `FileAccess(Write)` action through the full evaluation path.
+#[test]
+fn full_cascade_capability_deny_blocks_file_write() {
+    let mut engine = make_engine();
+    engine.load_policy(cap_doc(PolicyScope::Global, &[], &[Capability::FileWrite]));
+
+    let ctx = make_ctx();
+    let action = GovernanceAction::FileAccess {
+        path: "/tmp/secret.txt".into(),
+        mode: aa_core::FileMode::Write,
+    };
+
+    let result = engine.evaluate(&ctx, &action).decision;
+    assert!(
+        matches!(result, PolicyResult::Deny { .. }),
+        "expected Deny for FileWrite denied by capability policy, got {:?}",
+        result
+    );
+}
+
+// ── Test 3 ────────────────────────────────────────────────────────────────────
+
+/// A Global-scoped policy with `capabilities.allow = {FileRead}` must allow a
+/// `FileAccess(Read)` action.
+#[test]
+fn full_cascade_capability_allows_file_read_when_in_allow_set() {
+    let mut engine = make_engine();
+    engine.load_policy(cap_doc(PolicyScope::Global, &[Capability::FileRead], &[]));
+
+    let ctx = make_ctx();
+    let action = GovernanceAction::FileAccess {
+        path: "/tmp/readme.txt".into(),
+        mode: aa_core::FileMode::Read,
+    };
+
+    let result = engine.evaluate(&ctx, &action).decision;
+    assert_eq!(
+        result,
+        PolicyResult::Allow,
+        "expected Allow for FileRead in allow set, got {:?}",
+        result
+    );
+}
+
+// ── Test 4 ────────────────────────────────────────────────────────────────────
+
+/// A Global-scoped policy with `capabilities.allow = {FileRead}` only must deny
+/// a `FileAccess(Write)` action because `FileWrite` is not in the allow list.
+#[test]
+fn full_cascade_capability_denies_file_write_when_not_in_allow_set() {
+    let mut engine = make_engine();
+    engine.load_policy(cap_doc(PolicyScope::Global, &[Capability::FileRead], &[]));
+
+    let ctx = make_ctx();
+    let action = GovernanceAction::FileAccess {
+        path: "/tmp/data.txt".into(),
+        mode: aa_core::FileMode::Write,
+    };
+
+    let result = engine.evaluate(&ctx, &action).decision;
+    assert!(
+        matches!(result, PolicyResult::Deny { .. }),
+        "expected Deny for FileWrite not in allow set, got {:?}",
+        result
+    );
+}
+
+// ── Test 5 ────────────────────────────────────────────────────────────────────
+
+/// Two cascade policies with `capabilities: None` must not block any action
+/// through the capability guard. The evaluation result must be `Allow` when no
+/// other policy section (tool deny, budget, etc.) restricts the action.
+#[test]
+fn cascade_empty_capabilities_does_not_block_any_action() {
+    let mut engine = make_engine();
+    engine.load_policy(no_cap_doc(PolicyScope::Global));
+    let agent_id = AgentId::from_bytes([1u8; 16]);
+    engine.load_policy(no_cap_doc(PolicyScope::Agent(agent_id)));
+
+    let ctx = make_ctx();
+    let action = GovernanceAction::FileAccess {
+        path: "/tmp/file.txt".into(),
+        mode: aa_core::FileMode::Write,
+    };
+
+    let result = engine.evaluate(&ctx, &action).decision;
+    assert_eq!(
+        result,
+        PolicyResult::Allow,
+        "expected Allow when no capabilities are configured, got {:?}",
+        result
+    );
+}
+
+// ── Test 6 ────────────────────────────────────────────────────────────────────
+
+/// A Global-level deny must override an agent-level allow for the same capability.
+///
+/// Setup:
+/// - Global policy: `capabilities.deny = {TerminalExec}`
+/// - Agent-scoped policy: `capabilities.allow = {TerminalExec, FileRead}`
+///
+/// Expected: `ProcessExec` is denied because parent deny wins.
+#[test]
+fn parent_deny_overrides_child_allow_in_full_cascade() {
+    let agent_id = AgentId::from_bytes([1u8; 16]);
+
+    let mut engine = make_engine();
+    engine.load_policy(cap_doc(PolicyScope::Global, &[], &[Capability::TerminalExec]));
+    engine.load_policy(cap_doc(
+        PolicyScope::Agent(agent_id),
+        &[Capability::TerminalExec, Capability::FileRead],
+        &[],
+    ));
+
+    let ctx = make_ctx();
+    let action = GovernanceAction::ProcessExec { command: "ls".into() };
+
+    let result = engine.evaluate(&ctx, &action).decision;
+    assert!(
+        matches!(result, PolicyResult::Deny { .. }),
+        "expected Deny: global deny of TerminalExec must override agent allow, got {:?}",
+        result
+    );
+}
+
+// ── Test 7 ────────────────────────────────────────────────────────────────────
+
+/// A `capabilities.deny = {McpTool("bash")}` policy must deny a `ToolCall` for
+/// the "bash" tool through the full evaluation path.
+#[test]
+fn mcp_tool_capability_denied_blocks_tool_call() {
+    let mut engine = make_engine();
+    engine.load_policy(cap_doc(
+        PolicyScope::Global,
+        &[],
+        &[Capability::McpTool("bash".to_string())],
+    ));
+
+    let ctx = make_ctx();
+    let action = GovernanceAction::ToolCall {
+        name: "bash".into(),
+        args: "{}".into(),
+    };
+
+    let result = engine.evaluate(&ctx, &action).decision;
+    assert!(
+        matches!(result, PolicyResult::Deny { .. }),
+        "expected Deny: McpTool(bash) denied by capability policy, got {:?}",
+        result
+    );
+}

--- a/aa-gateway/tests/capability_integration_test.rs
+++ b/aa-gateway/tests/capability_integration_test.rs
@@ -214,6 +214,7 @@ fn cascade_empty_capabilities_does_not_block_any_action() {
     let agent_id = AgentId::from_bytes([1u8; 16]);
     engine.load_policy(no_cap_doc(PolicyScope::Agent(agent_id)));
 
+    // agent_id matches the policy scope above — make_ctx() also uses [1u8; 16]
     let ctx = make_ctx();
     let action = GovernanceAction::FileAccess {
         path: "/tmp/file.txt".into(),

--- a/aa-gateway/tests/capability_integration_test.rs
+++ b/aa-gateway/tests/capability_integration_test.rs
@@ -118,12 +118,20 @@ spec:
 
 // ── Test 2 ────────────────────────────────────────────────────────────────────
 
-/// A Global-scoped policy with `capabilities.deny = {FileWrite}` must deny a
-/// `FileAccess(Write)` action through the full evaluation path.
+/// Two-policy cascade (Global: allow=[file_read]; Team: allow=[file_read], deny=[file_write])
+/// must deny a `FileAccess(Write)` action because `FileWrite` is explicitly denied at the
+/// team scope.
 #[test]
-fn full_cascade_capability_deny_blocks_file_write() {
+fn full_cascade_capability_policy_denies_disallowed_file_write() {
     let mut engine = make_engine();
-    engine.load_policy(cap_doc(PolicyScope::Global, &[], &[Capability::FileWrite]));
+    // Global policy: allow file_read only
+    engine.load_policy(cap_doc(PolicyScope::Global, &[Capability::FileRead], &[]));
+    // Team policy: allow file_read, deny file_write
+    engine.load_policy(cap_doc(
+        PolicyScope::Team("alpha".to_string()),
+        &[Capability::FileRead],
+        &[Capability::FileWrite],
+    ));
 
     let ctx = make_ctx();
     let action = GovernanceAction::FileAccess {
@@ -134,19 +142,27 @@ fn full_cascade_capability_deny_blocks_file_write() {
     let result = engine.evaluate(&ctx, &action).decision;
     assert!(
         matches!(result, PolicyResult::Deny { .. }),
-        "expected Deny for FileWrite denied by capability policy, got {:?}",
+        "expected Deny for FileWrite denied in two-policy cascade, got {:?}",
         result
     );
 }
 
 // ── Test 3 ────────────────────────────────────────────────────────────────────
 
-/// A Global-scoped policy with `capabilities.allow = {FileRead}` must allow a
-/// `FileAccess(Read)` action.
+/// Two-policy cascade (Global: allow=[file_read]; Team: allow=[file_read], deny=[file_write])
+/// must allow a `FileAccess(Read)` action because `FileRead` is in the allow set at both
+/// scopes and is not denied anywhere.
 #[test]
-fn full_cascade_capability_allows_file_read_when_in_allow_set() {
+fn full_cascade_capability_policy_allows_permitted_file_read() {
     let mut engine = make_engine();
+    // Global policy: allow file_read only
     engine.load_policy(cap_doc(PolicyScope::Global, &[Capability::FileRead], &[]));
+    // Team policy: allow file_read, deny file_write
+    engine.load_policy(cap_doc(
+        PolicyScope::Team("alpha".to_string()),
+        &[Capability::FileRead],
+        &[Capability::FileWrite],
+    ));
 
     let ctx = make_ctx();
     let action = GovernanceAction::FileAccess {
@@ -158,7 +174,7 @@ fn full_cascade_capability_allows_file_read_when_in_allow_set() {
     assert_eq!(
         result,
         PolicyResult::Allow,
-        "expected Allow for FileRead in allow set, got {:?}",
+        "expected Allow for FileRead in two-policy cascade allow set, got {:?}",
         result
     );
 }
@@ -269,5 +285,55 @@ fn mcp_tool_capability_denied_blocks_tool_call() {
         matches!(result, PolicyResult::Deny { .. }),
         "expected Deny: McpTool(bash) denied by capability policy, got {:?}",
         result
+    );
+}
+
+// ── Test 8 ────────────────────────────────────────────────────────────────────
+
+/// A `capabilities.allow = {McpTool("git")}` policy (no deny entries) must deny
+/// a `ToolCall` for "bash" (not in allowlist) and allow a `ToolCall` for "git"
+/// (in allowlist).
+#[test]
+fn mcp_tool_capability_allowlist_permits_only_listed_tools() {
+    let mut engine = make_engine();
+    engine.load_policy(cap_doc(
+        PolicyScope::Global,
+        &[Capability::McpTool("git".to_string())],
+        &[],
+    ));
+
+    let ctx = make_ctx();
+
+    // bash is NOT in the allowlist → must be denied
+    let bash_result = engine
+        .evaluate(
+            &ctx,
+            &GovernanceAction::ToolCall {
+                name: "bash".into(),
+                args: "{}".into(),
+            },
+        )
+        .decision;
+    assert!(
+        matches!(bash_result, PolicyResult::Deny { .. }),
+        "expected Deny for bash (not in MCP tool allowlist), got {:?}",
+        bash_result
+    );
+
+    // git IS in the allowlist → must be allowed
+    let git_result = engine
+        .evaluate(
+            &ctx,
+            &GovernanceAction::ToolCall {
+                name: "git".into(),
+                args: "{}".into(),
+            },
+        )
+        .decision;
+    assert_eq!(
+        git_result,
+        PolicyResult::Allow,
+        "expected Allow for git (in MCP tool allowlist), got {:?}",
+        git_result
     );
 }

--- a/aa-gateway/tests/cascade_collect_test.rs
+++ b/aa-gateway/tests/cascade_collect_test.rs
@@ -36,6 +36,7 @@ fn doc_for_scope(scope: PolicyScope) -> PolicyDocument {
         data: None,
         approval_timeout_secs: 300,
         tools: HashMap::new(),
+        capabilities: None,
     }
 }
 

--- a/aa-gateway/tests/cascade_epoch_test.rs
+++ b/aa-gateway/tests/cascade_epoch_test.rs
@@ -31,6 +31,7 @@ fn allow_doc(scope: PolicyScope) -> PolicyDocument {
         data: None,
         approval_timeout_secs: 300,
         tools: HashMap::new(),
+        capabilities: None,
     }
 }
 

--- a/aa-gateway/tests/cascade_merge_test.rs
+++ b/aa-gateway/tests/cascade_merge_test.rs
@@ -22,6 +22,7 @@ fn allow_doc(scope: PolicyScope) -> Arc<PolicyDocument> {
         data: None,
         approval_timeout_secs: 300,
         tools: HashMap::new(),
+        capabilities: None,
     })
 }
 
@@ -47,6 +48,7 @@ fn deny_tool_doc(scope: PolicyScope, tool_name: &str) -> Arc<PolicyDocument> {
         data: None,
         approval_timeout_secs: 300,
         tools,
+        capabilities: None,
     })
 }
 
@@ -72,6 +74,7 @@ fn approval_tool_doc(scope: PolicyScope, tool_name: &str, timeout: u32) -> Arc<P
         data: None,
         approval_timeout_secs: timeout,
         tools,
+        capabilities: None,
     })
 }
 

--- a/aa-gateway/tests/cascade_version_test.rs
+++ b/aa-gateway/tests/cascade_version_test.rs
@@ -30,6 +30,7 @@ fn allow_doc(scope: PolicyScope) -> PolicyDocument {
         data: None,
         approval_timeout_secs: 300,
         tools: HashMap::new(),
+        capabilities: None,
     }
 }
 

--- a/policy-examples/capability-policy.yaml
+++ b/policy-examples/capability-policy.yaml
@@ -1,0 +1,16 @@
+apiVersion: agent-assembly/v1
+kind: Policy
+metadata:
+  name: capability-example
+  version: "1.0.0"
+spec:
+  scope: global
+  capabilities:
+    allow:
+      - file_read
+      - network_outbound
+      - mcp_tool:git
+      - mcp_tool:bash
+    deny:
+      - terminal_exec
+      - file_write


### PR DESCRIPTION
## What changed

Introduces `Capability` / `CapabilitySet` types and per-scope capability restrictions (F99 / AAASM-226). Operators can now declare which discrete action categories (file read/write, network, terminal, MCP tools, model calls, agent spawning) are allowed or denied at any policy scope, with parent-deny-wins cascade semantics enforced end-to-end from YAML through the policy engine to dev-tool MCP governance.

## Why it changed

Closes AAASM-226. Implements F99 from the product spec: governance policies lacked the ability to restrict capabilities at a per-scope level, making it impossible to allow `file_read` globally while denying `terminal_exec` at an agent scope or blocking specific MCP tools at the team level.

## Changes

- **`aa-core/src/capability.rs`** (new) — `Capability` enum (8 variants: `FileRead`, `FileWrite`, `NetworkOutbound`, `NetworkInbound`, `TerminalExec`, `McpTool(String)`, `Model(String)`, `AgentSpawn`), `CapabilitySet { allow, deny }`, `merge_capabilities` (parent-deny-wins), `action_to_capability` mapping; serde + Display + FromStr + 30 unit tests
- **`aa-gateway/src/policy/`** — `RawCapabilitySet` in `raw.rs`; `capabilities: Option<CapabilitySet>` field on `PolicyDocument`; `validate_capabilities()` helper in `validator.rs` with error/warning surfacing for unknown strings
- **`aa-gateway/src/engine/decision.rs`** — Stage 3.5 capability check inserted between Stage 3 (tool deny) and Stage 5 (approval condition)
- **`aa-gateway/src/engine/mod.rs`** — `collect_merged_capabilities` helper; cascade capability guard (defense-in-depth on cache-hit paths)
- **`aa-devtool/src/capability_bridge.rs`** (new) — `apply_capability_policy` translates a `CapabilitySet` into `apply_mcp_governance` calls (MCP-tool variants only; non-MCP capabilities enforced at gateway/proxy/eBPF layers)
- **`aa-gateway/tests/capability_integration_test.rs`** (new) — 8 integration tests covering YAML round-trip, two-policy cascade deny/allow, parent-deny-override, MCP allowlist, and empty-capabilities no-op
- **`policy-examples/capability-policy.yaml`** (new) — reference YAML fixture in envelope format

## How to verify

```bash
cargo nextest run -p aa-core -p aa-gateway -p aa-devtool
# 671 tests, 671 passed

cargo clippy --workspace --all-targets --all-features --exclude aa-ebpf -- -D warnings
# clean

cargo nextest run -p aa-gateway --test capability_integration_test
# 8 integration tests pass
```

Capability YAML block:
```yaml
spec:
  scope: global
  capabilities:
    allow:
      - file_read
      - network_outbound
      - mcp_tool:git
    deny:
      - terminal_exec
      - file_write
```

## Related

Closes #AAASM-226
Subtasks: AAASM-1039, AAASM-1043, AAASM-1045, AAASM-1046, AAASM-1126