### PR TITLE
[AAASM-1180] 🐛 (aa-cli): Wire CodexAdapter into aasm run codex CLI

### DIFF
--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -13,6 +13,7 @@ path = "src/main.rs"
 [dependencies]
 aa-core              = { path = "../aa-core" }
 aa-devtool           = { path = "../aa-devtool" }
+aa-devtool-codex     = { path = "../aa-devtool-codex" }
 aa-devtool-windsurf  = { path = "../aa-devtool-windsurf" }
 aa-gateway           = { path = "../aa-gateway" }
 anyhow         = "1"

--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -15,6 +15,7 @@ use tokio::signal::unix::SignalKind;
 use aa_core::{
     AdapterError, DevToolAdapter, DevToolInfo, DevToolKind, GovernanceLevel, McpServerInfo, PolicyDocument, PolicyRule,
 };
+use aa_devtool_codex::CodexAdapter;
 use aa_devtool_windsurf::WindsurfCascadeAdapter;
 
 use crate::config::ResolvedContext;
@@ -310,7 +311,7 @@ fn resolve_adapter(tool: &str) -> Result<Box<dyn DevToolAdapter>> {
     match tool {
         // Real adapters replace PlaceholderAdapter here once their crates land.
         "claude" => Ok(Box::new(PlaceholderAdapter)),
-        "codex" => Ok(Box::new(PlaceholderAdapter)),
+        "codex" => Ok(Box::new(CodexAdapter::default())),
         "copilot" => Ok(Box::new(PlaceholderAdapter)),
         "windsurf" => Ok(Box::new(WindsurfCascadeAdapter::new())),
         _ => Err(anyhow::anyhow!(
@@ -576,6 +577,17 @@ mod tests {
         for tool in ["claude", "codex", "copilot", "windsurf"] {
             assert!(resolve_adapter(tool).is_ok(), "resolve_adapter({tool}) should succeed");
         }
+    }
+
+    #[test]
+    fn codex_adapter_is_not_placeholder() {
+        let adapter = resolve_adapter("codex").expect("codex must resolve");
+        // CodexAdapter reports L2Enforce; PlaceholderAdapter reports L0Discover.
+        assert_eq!(
+            adapter.governance_level(),
+            GovernanceLevel::L2Enforce,
+            "codex must use CodexAdapter (L2Enforce), not PlaceholderAdapter (L0Discover)"
+        );
     }
 
     // --- build_child_env tests ---


### PR DESCRIPTION
## Summary

- Adds `aa-devtool-codex` as a dependency of `aa-cli`
- Replaces `PlaceholderAdapter` with `CodexAdapter::default()` in `resolve_adapter("codex")` (`run.rs:314`)
- Adds `codex_adapter_is_not_placeholder` regression test asserting `governance_level() == L2Enforce`

## Why

`aasm run codex` always failed with "codex is not installed" because the codex arm of `resolve_adapter()` was still returning a `PlaceholderAdapter` whose `detect()` always returns `None`. The `CodexAdapter` implementation was complete (40/40 tests, PRs #218–#223) but was never wired into the CLI.

Discovered by AAASM-1115 acceptance validation — AC #4 of AAASM-202.

## Test plan

- [ ] `cargo nextest run -p aa-cli` — 354/354 pass (includes new `codex_adapter_is_not_placeholder`)
- [ ] `cargo clippy -p aa-cli` — clean
- [ ] `cargo fmt -p aa-cli` — no changes

Closes AAASM-1180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)