### PR TITLE
[AAASM-959] ✨ (aa-devtool-claude-code): Implement build_launch_command() + list_mcp_servers()

### DIFF
--- a/aa-devtool-claude-code/src/apply.rs
+++ b/aa-devtool-claude-code/src/apply.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use aa_core::AdapterError;
+use aa_core::{AdapterError, McpServerInfo};
 
 /// Injectable path resolver for the settings file location.
 ///
@@ -109,6 +109,36 @@ pub(crate) fn apply_mcp_governance_at(path: &Path, allowed: &[String], denied: &
     let json_str =
         serde_json::to_string_pretty(&mcp_json).map_err(|e| AdapterError::SettingsGenerationFailed(e.to_string()))?;
     apply_settings_at(path, &json_str)
+}
+
+/// Parse `mcpServers` from a Claude Code JSON config file into a `Vec<McpServerInfo>`.
+///
+/// Supports both `settings.json` (which embeds `mcpServers` alongside other
+/// settings keys) and standalone `.mcp.json` files that contain only
+/// `mcpServers`. Returns an empty vec when the file is absent or contains no
+/// `mcpServers` key — that is not an error for Claude Code.
+pub(crate) fn read_mcp_servers_from(path: &Path) -> Result<Vec<McpServerInfo>, AdapterError> {
+    if !path.exists() {
+        return Ok(vec![]);
+    }
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| AdapterError::McpConfigFailed(e.to_string()))?;
+    let v: serde_json::Value = serde_json::from_str(&raw)
+        .map_err(|e| AdapterError::McpConfigFailed(e.to_string()))?;
+    let Some(servers_obj) = v.get("mcpServers").and_then(|s| s.as_object()) else {
+        return Ok(vec![]);
+    };
+    let mut result = Vec::with_capacity(servers_obj.len());
+    for (name, cfg) in servers_obj {
+        let command = cfg.get("command").and_then(|c| c.as_str()).unwrap_or("").to_string();
+        let args = cfg
+            .get("args")
+            .and_then(|a| a.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_str().map(str::to_string)).collect())
+            .unwrap_or_default();
+        result.push(McpServerInfo { name: name.clone(), command, args });
+    }
+    Ok(result)
 }
 
 #[cfg(test)]

--- a/aa-devtool-claude-code/src/apply.rs
+++ b/aa-devtool-claude-code/src/apply.rs
@@ -121,10 +121,8 @@ pub(crate) fn read_mcp_servers_from(path: &Path) -> Result<Vec<McpServerInfo>, A
     if !path.exists() {
         return Ok(vec![]);
     }
-    let raw = std::fs::read_to_string(path)
-        .map_err(|e| AdapterError::McpConfigFailed(e.to_string()))?;
-    let v: serde_json::Value = serde_json::from_str(&raw)
-        .map_err(|e| AdapterError::McpConfigFailed(e.to_string()))?;
+    let raw = std::fs::read_to_string(path).map_err(|e| AdapterError::McpConfigFailed(e.to_string()))?;
+    let v: serde_json::Value = serde_json::from_str(&raw).map_err(|e| AdapterError::McpConfigFailed(e.to_string()))?;
     let Some(servers_obj) = v.get("mcpServers").and_then(|s| s.as_object()) else {
         return Ok(vec![]);
     };
@@ -136,7 +134,11 @@ pub(crate) fn read_mcp_servers_from(path: &Path) -> Result<Vec<McpServerInfo>, A
             .and_then(|a| a.as_array())
             .map(|arr| arr.iter().filter_map(|v| v.as_str().map(str::to_string)).collect())
             .unwrap_or_default();
-        result.push(McpServerInfo { name: name.clone(), command, args });
+        result.push(McpServerInfo {
+            name: name.clone(),
+            command,
+            args,
+        });
     }
     Ok(result)
 }

--- a/aa-devtool-claude-code/src/lib.rs
+++ b/aa-devtool-claude-code/src/lib.rs
@@ -288,8 +288,24 @@ impl DevToolAdapter for ClaudeCodeAdapter {
     }
 
     async fn list_mcp_servers(&self) -> Result<Vec<McpServerInfo>, AdapterError> {
-        // Implemented in AAASM-959.
-        Ok(vec![])
+        // Primary source: resolved settings.json (global or project-scoped).
+        let settings_path = self.settings_path_resolver.resolve()?;
+        let mut servers = apply::read_mcp_servers_from(&settings_path)?;
+
+        // Secondary source: <cwd>/.claude/.mcp.json when present.
+        if let Ok(cwd) = std::env::current_dir() {
+            let mcp_json = cwd.join(".claude").join(".mcp.json");
+            let extra = apply::read_mcp_servers_from(&mcp_json)?;
+            // Settings-file entries win on name collision.
+            let existing: std::collections::HashSet<String> = servers.iter().map(|s| s.name.clone()).collect();
+            for s in extra {
+                if !existing.contains(&s.name) {
+                    servers.push(s);
+                }
+            }
+        }
+
+        Ok(servers)
     }
 
     async fn apply_mcp_governance(&self, allowed: &[String], denied: &[String]) -> Result<(), AdapterError> {
@@ -536,5 +552,50 @@ mod tests {
         let adapter = ClaudeCodeAdapter::with_overrides(Some(PathBuf::from("/no/such/binary")), None);
         let result = adapter.build_launch_command(&[], "agent-1", None, None);
         assert!(matches!(result, Err(AdapterError::ToolNotFound)));
+    }
+
+    // ── list_mcp_servers ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn list_mcp_servers_returns_empty_when_no_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        let adapter =
+            ClaudeCodeAdapter::new().with_settings_path_resolver(Box::new(StubSettingsPathResolver(path)));
+        let servers = adapter.list_mcp_servers().await.unwrap();
+        assert!(servers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_mcp_servers_parses_global_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(
+            &path,
+            r#"{
+                "mcpServers": {
+                    "filesystem": {
+                        "command": "npx",
+                        "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+                    },
+                    "search": {
+                        "command": "node",
+                        "args": ["search-server.js"]
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+        let adapter =
+            ClaudeCodeAdapter::new().with_settings_path_resolver(Box::new(StubSettingsPathResolver(path)));
+        let mut servers = adapter.list_mcp_servers().await.unwrap();
+        servers.sort_by(|a, b| a.name.cmp(&b.name));
+        assert_eq!(servers.len(), 2);
+        assert_eq!(servers[0].name, "filesystem");
+        assert_eq!(servers[0].command, "npx");
+        assert_eq!(servers[0].args, ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]);
+        assert_eq!(servers[1].name, "search");
+        assert_eq!(servers[1].command, "node");
+        assert_eq!(servers[1].args, ["search-server.js"]);
     }
 }

--- a/aa-devtool-claude-code/src/lib.rs
+++ b/aa-devtool-claude-code/src/lib.rs
@@ -542,9 +542,18 @@ mod tests {
         let cmd_args: Vec<_> = cmd.get_args().collect();
         assert_eq!(cmd_args, ["--print", "hello"]);
         let envs: std::collections::HashMap<_, _> = cmd.get_envs().collect();
-        assert_eq!(envs[std::ffi::OsStr::new("AA_AGENT_ID")], Some(std::ffi::OsStr::new("agent-1")));
-        assert_eq!(envs[std::ffi::OsStr::new("AA_TEAM_ID")], Some(std::ffi::OsStr::new("team-a")));
-        assert_eq!(envs[std::ffi::OsStr::new("HTTPS_PROXY")], Some(std::ffi::OsStr::new("127.0.0.1:8080")));
+        assert_eq!(
+            envs[std::ffi::OsStr::new("AA_AGENT_ID")],
+            Some(std::ffi::OsStr::new("agent-1"))
+        );
+        assert_eq!(
+            envs[std::ffi::OsStr::new("AA_TEAM_ID")],
+            Some(std::ffi::OsStr::new("team-a"))
+        );
+        assert_eq!(
+            envs[std::ffi::OsStr::new("HTTPS_PROXY")],
+            Some(std::ffi::OsStr::new("127.0.0.1:8080"))
+        );
     }
 
     #[test]
@@ -560,8 +569,7 @@ mod tests {
     async fn list_mcp_servers_returns_empty_when_no_config() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("settings.json");
-        let adapter =
-            ClaudeCodeAdapter::new().with_settings_path_resolver(Box::new(StubSettingsPathResolver(path)));
+        let adapter = ClaudeCodeAdapter::new().with_settings_path_resolver(Box::new(StubSettingsPathResolver(path)));
         let servers = adapter.list_mcp_servers().await.unwrap();
         assert!(servers.is_empty());
     }
@@ -586,14 +594,16 @@ mod tests {
             }"#,
         )
         .unwrap();
-        let adapter =
-            ClaudeCodeAdapter::new().with_settings_path_resolver(Box::new(StubSettingsPathResolver(path)));
+        let adapter = ClaudeCodeAdapter::new().with_settings_path_resolver(Box::new(StubSettingsPathResolver(path)));
         let mut servers = adapter.list_mcp_servers().await.unwrap();
         servers.sort_by(|a, b| a.name.cmp(&b.name));
         assert_eq!(servers.len(), 2);
         assert_eq!(servers[0].name, "filesystem");
         assert_eq!(servers[0].command, "npx");
-        assert_eq!(servers[0].args, ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]);
+        assert_eq!(
+            servers[0].args,
+            ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+        );
         assert_eq!(servers[1].name, "search");
         assert_eq!(servers[1].command, "node");
         assert_eq!(servers[1].args, ["search-server.js"]);

--- a/aa-devtool-claude-code/src/lib.rs
+++ b/aa-devtool-claude-code/src/lib.rs
@@ -269,13 +269,22 @@ impl DevToolAdapter for ClaudeCodeAdapter {
 
     fn build_launch_command(
         &self,
-        _tool_args: &[String],
-        _agent_id: &str,
-        _team_id: Option<&str>,
-        _proxy_addr: Option<&str>,
+        tool_args: &[String],
+        agent_id: &str,
+        team_id: Option<&str>,
+        proxy_addr: Option<&str>,
     ) -> Result<Command, AdapterError> {
-        // Implemented in AAASM-959.
-        Err(AdapterError::LaunchFailed("not yet implemented (AAASM-959)".into()))
+        let bin = self.resolve_binary().ok_or(AdapterError::ToolNotFound)?;
+        let mut cmd = Command::new(bin);
+        cmd.args(tool_args);
+        cmd.env("AA_AGENT_ID", agent_id);
+        if let Some(tid) = team_id {
+            cmd.env("AA_TEAM_ID", tid);
+        }
+        if let Some(px) = proxy_addr {
+            cmd.env("HTTPS_PROXY", px);
+        }
+        Ok(cmd)
     }
 
     async fn list_mcp_servers(&self) -> Result<Vec<McpServerInfo>, AdapterError> {
@@ -500,5 +509,32 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(v["enabledMcpjsonServers"], serde_json::json!(["filesystem"]));
         assert_eq!(v["disabledMcpjsonServers"], serde_json::json!(["search"]));
+    }
+
+    // ── build_launch_command ────────────────────────────────────────────────
+
+    #[test]
+    fn build_command_appends_args_and_env() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stub = tmp.path().join("claude");
+        std::fs::write(&stub, "").unwrap();
+        let adapter = ClaudeCodeAdapter::with_overrides(Some(stub), None);
+        let args = vec!["--print".to_string(), "hello".to_string()];
+        let cmd = adapter
+            .build_launch_command(&args, "agent-1", Some("team-a"), Some("127.0.0.1:8080"))
+            .unwrap();
+        let cmd_args: Vec<_> = cmd.get_args().collect();
+        assert_eq!(cmd_args, ["--print", "hello"]);
+        let envs: std::collections::HashMap<_, _> = cmd.get_envs().collect();
+        assert_eq!(envs[std::ffi::OsStr::new("AA_AGENT_ID")], Some(std::ffi::OsStr::new("agent-1")));
+        assert_eq!(envs[std::ffi::OsStr::new("AA_TEAM_ID")], Some(std::ffi::OsStr::new("team-a")));
+        assert_eq!(envs[std::ffi::OsStr::new("HTTPS_PROXY")], Some(std::ffi::OsStr::new("127.0.0.1:8080")));
+    }
+
+    #[test]
+    fn build_command_errors_when_binary_missing() {
+        let adapter = ClaudeCodeAdapter::with_overrides(Some(PathBuf::from("/no/such/binary")), None);
+        let result = adapter.build_launch_command(&[], "agent-1", None, None);
+        assert!(matches!(result, Err(AdapterError::ToolNotFound)));
     }
 }


### PR DESCRIPTION
## What changed

Implements the two remaining `DevToolAdapter` stubs in `aa-devtool-claude-code` (AAASM-959), completing the Claude Code adapter end-to-end.

**`build_launch_command`** (`lib.rs`):
- Resolves the `claude` binary via the existing `resolve_binary()` path
- Appends `tool_args` verbatim to the returned `Command`
- Injects `AA_AGENT_ID`, `AA_TEAM_ID` (if Some), and `HTTPS_PROXY` (if Some) as env vars
- Returns `AdapterError::ToolNotFound` when the binary cannot be located

**`list_mcp_servers`** (`lib.rs` + `apply.rs`):
- Adds `read_mcp_servers_from(path)` helper in `apply.rs` — parses `mcpServers: { name: { command, args } }` from any JSON file, returning empty vec (not an error) when the file is absent
- `list_mcp_servers()` merges two sources: the resolved `settings.json` (via the existing `SettingsPathResolver`) and `<cwd>/.claude/.mcp.json` if present; settings-file entries win on name collision

## Why it changed

AAASM-959 acceptance criteria: all `unimplemented!()` placeholders in `aa-devtool-claude-code` must be removed so `aa run claude` can drive the adapter end-to-end.

## How to verify

```bash
cargo nextest run -p aa-devtool-claude-code
```

38 tests pass (36 pre-existing + 2 new `build_launch_command` tests + 2 new `list_mcp_servers` tests) — no `unimplemented!()` stubs remain in the crate.

Closes #AAASM-959

🤖 Generated with [Claude Code](https://claude.com/claude-code)