### PR TITLE
[AAASM-214] ✨ (aa-api): Add 5 topology REST API endpoints

### DIFF
--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -8,7 +8,7 @@ use crate::models::event::GovernanceEvent;
 use crate::models::event_type::EventType;
 use crate::models::trace::{TraceResponse, TraceSpan};
 use crate::models::ws_payloads::{ApprovalPayload, BudgetAlertPayload, EventPayload, ViolationPayload};
-use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, traces};
+use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, topology, traces};
 
 /// Root OpenAPI document collecting all annotated paths and schemas.
 #[derive(OpenApi)]
@@ -34,6 +34,7 @@ use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, trac
         (name = "alerts", description = "Governance alerts"),
         (name = "auth", description = "Authentication and token issuance"),
         (name = "events", description = "Real-time event streaming via WebSocket"),
+        (name = "topology", description = "Agent topology — tree, team, lineage, and statistics queries"),
     ),
     paths(
         crate::routes::health::health,
@@ -54,6 +55,11 @@ use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, trac
         alerts::list_alerts,
         auth::issue_token,
         crate::ws::handler::ws_events_handler,
+        topology::get_overview,
+        topology::get_tree,
+        topology::get_team,
+        topology::get_lineage,
+        topology::get_stats,
     ),
     components(schemas(
         crate::routes::health::HealthResponse,
@@ -79,6 +85,14 @@ use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, trac
         auth::TokenRequest,
         auth::TokenResponse,
         crate::auth::scope::Scope,
+        topology::TopologyOverview,
+        topology::TeamSummary,
+        topology::AgentNode,
+        topology::AgentTree,
+        topology::TeamTopology,
+        topology::AgentLineage,
+        topology::LineageStep,
+        topology::TopologyStats,
         GovernanceEvent,
         EventType,
         ViolationPayload,

--- a/aa-api/src/routes/mod.rs
+++ b/aa-api/src/routes/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod agents;
 pub mod alerts;
+pub mod topology;
 pub mod approvals;
 pub mod auth;
 pub mod costs;

--- a/aa-api/src/routes/mod.rs
+++ b/aa-api/src/routes/mod.rs
@@ -4,7 +4,6 @@
 
 pub mod agents;
 pub mod alerts;
-pub mod topology;
 pub mod approvals;
 pub mod auth;
 pub mod costs;
@@ -13,6 +12,7 @@ pub mod health;
 pub mod logs;
 pub mod policies;
 pub mod tools;
+pub mod topology;
 pub mod traces;
 
 use axum::routing::{get, post};

--- a/aa-api/src/routes/mod.rs
+++ b/aa-api/src/routes/mod.rs
@@ -56,6 +56,12 @@ pub fn v1_router() -> Router {
         )
         // Tools
         .route("/tools", get(tools::list_tools))
+        // Topology
+        .route("/topology/overview", get(topology::get_overview))
+        .route("/topology/tree/{root_id}", get(topology::get_tree))
+        .route("/topology/team/{team_id}", get(topology::get_team))
+        .route("/topology/lineage/{agent_id}", get(topology::get_lineage))
+        .route("/topology/stats", get(topology::get_stats))
 }
 
 /// Fallback handler returning a 404 RFC 7807 response.

--- a/aa-api/src/routes/topology.rs
+++ b/aa-api/src/routes/topology.rs
@@ -27,8 +27,7 @@ fn parse_agent_id(id: &str) -> Result<[u8; 16], ProblemDetail> {
         .map(|i| u8::from_str_radix(&id[i..i + 2], 16))
         .collect::<Result<Vec<u8>, _>>()
         .map_err(|_| {
-            ProblemDetail::from_status(StatusCode::BAD_REQUEST)
-                .with_detail(format!("Invalid agent ID format: {id}"))
+            ProblemDetail::from_status(StatusCode::BAD_REQUEST).with_detail(format!("Invalid agent ID format: {id}"))
         })?;
     bytes.try_into().map_err(|_| {
         ProblemDetail::from_status(StatusCode::BAD_REQUEST)
@@ -152,7 +151,19 @@ pub struct AgentTree {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub governance_level: Option<String>,
     /// Direct children of this agent in the delegation tree.
+    #[schema(schema_with = agent_tree_children_schema)]
     pub children: Vec<AgentTree>,
+}
+
+/// Returns a schema for `Vec<AgentTree>` using a `$ref` to break the recursive cycle.
+///
+/// Without this, utoipa's ToSchema derive recurses infinitely and overflows the stack.
+fn agent_tree_children_schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+    use utoipa::openapi::schema::{ArrayBuilder, Ref};
+    ArrayBuilder::new()
+        .items(Ref::from_schema_name("AgentTree"))
+        .build()
+        .into()
 }
 
 /// All agents belonging to a single team.
@@ -194,7 +205,8 @@ pub struct LineageStep {
 
 /// Aggregate topology statistics across all registered agents.
 #[derive(Debug, Serialize, ToSchema)]
-pub struct TopologyStats {    /// Total agents in the registry.
+pub struct TopologyStats {
+    /// Total agents in the registry.
     pub total_agents: usize,
     /// Number of root agents (depth == 0).
     pub root_agent_count: usize,
@@ -235,9 +247,7 @@ fn build_tree(
         registry
             .children_of(agent_id)
             .iter()
-            .filter_map(|child_id| {
-                build_tree(registry, child_id, remaining_depth - 1, status_filter, show_budget)
-            })
+            .filter_map(|child_id| build_tree(registry, child_id, remaining_depth - 1, status_filter, show_budget))
             .collect()
     } else {
         vec![]
@@ -283,7 +293,10 @@ pub async fn get_overview(
     let filtered: Vec<_> = all
         .iter()
         .filter(|r| {
-            params.status.as_deref().map_or(true, |f| matches_status_filter(&r.status, f))
+            params
+                .status
+                .as_deref()
+                .map_or(true, |f| matches_status_filter(&r.status, f))
                 && params.min_depth.map_or(true, |d| r.depth >= d)
         })
         .collect();
@@ -378,8 +391,7 @@ pub async fn get_tree(
         show_budget,
     )
     .ok_or_else(|| {
-        ProblemDetail::from_status(StatusCode::NOT_FOUND)
-            .with_detail(format!("Agent not found: {root_id}"))
+        ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Agent not found: {root_id}"))
     })?;
 
     Ok((StatusCode::OK, Json(tree)))
@@ -415,7 +427,10 @@ pub async fn get_team(
         .iter()
         .filter_map(|id| state.agent_registry.get(id))
         .filter(|r| {
-            params.status.as_deref().map_or(true, |f| matches_status_filter(&r.status, f))
+            params
+                .status
+                .as_deref()
+                .map_or(true, |f| matches_status_filter(&r.status, f))
                 && params.min_depth.map_or(true, |d| r.depth >= d)
         })
         .map(|r| AgentNode {
@@ -434,7 +449,14 @@ pub async fn get_team(
     members.sort_by_key(|m| m.depth);
 
     let agent_count = members.len();
-    Ok((StatusCode::OK, Json(TeamTopology { team_id, agent_count, members })))
+    Ok((
+        StatusCode::OK,
+        Json(TeamTopology {
+            team_id,
+            agent_count,
+            members,
+        }),
+    ))
 }
 
 /// `GET /api/v1/topology/lineage/{agent_id}` — ancestor chain from agent up to root.
@@ -458,8 +480,7 @@ pub async fn get_lineage(
     let agent_id = parse_agent_id(&agent_id_str)?;
 
     state.agent_registry.get(&agent_id).ok_or_else(|| {
-        ProblemDetail::from_status(StatusCode::NOT_FOUND)
-            .with_detail(format!("Agent not found: {agent_id_str}"))
+        ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Agent not found: {agent_id_str}"))
     })?;
 
     let ancestor_ids = state.agent_registry.ancestors_of(&agent_id);
@@ -478,7 +499,11 @@ pub async fn get_lineage(
     let ancestor_count = ancestors.len();
     Ok((
         StatusCode::OK,
-        Json(AgentLineage { agent_id: agent_id_str, ancestor_count, ancestors }),
+        Json(AgentLineage {
+            agent_id: agent_id_str,
+            ancestor_count,
+            ancestors,
+        }),
     ))
 }
 
@@ -491,9 +516,7 @@ pub async fn get_lineage(
     ),
     tag = "topology"
 )]
-pub async fn get_stats(
-    Extension(state): Extension<AppState>,
-) -> (StatusCode, Json<TopologyStats>) {
+pub async fn get_stats(Extension(state): Extension<AppState>) -> (StatusCode, Json<TopologyStats>) {
     let all = state.agent_registry.list();
 
     let mut root_agent_count = 0usize;
@@ -549,8 +572,7 @@ mod tests {
     #[test]
     fn format_id_roundtrip() {
         let id: [u8; 16] = [
-            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
-            0x0f, 0x10,
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
         ];
         let hex = format_id(&id);
         assert_eq!(hex, "0102030405060708090a0b0c0d0e0f10");

--- a/aa-api/src/routes/topology.rs
+++ b/aa-api/src/routes/topology.rs
@@ -274,6 +274,11 @@ fn build_tree(
 // ---------------------------------------------------------------------------
 
 /// `GET /api/v1/topology/overview` — summary of all teams and root agents.
+///
+/// Returns a count of teams, root agents, and total agents across the registry,
+/// with a per-team breakdown and a list of standalone root agents not assigned
+/// to any team. Supports optional filtering by status, minimum depth, and
+/// governance level visibility.
 #[utoipa::path(
     get,
     path = "/api/v1/topology/overview",
@@ -360,6 +365,10 @@ pub async fn get_overview(
 }
 
 /// `GET /api/v1/topology/tree/{root_id}` — full subtree from a given root agent.
+///
+/// Recursively walks the delegation tree starting from the given agent, up to
+/// a configurable depth (default 10, maximum 10). Nodes can be filtered by
+/// status. Returns a nested JSON tree with each agent's children inline.
 #[utoipa::path(
     get,
     path = "/api/v1/topology/tree/{root_id}",
@@ -398,6 +407,10 @@ pub async fn get_tree(
 }
 
 /// `GET /api/v1/topology/team/{team_id}` — all agents in a team with depth info.
+///
+/// Returns all agents belonging to the given team, sorted by delegation depth.
+/// Results can be filtered by status and minimum depth. Returns 404 if the
+/// team identifier is not known to the registry.
 #[utoipa::path(
     get,
     path = "/api/v1/topology/team/{team_id}",
@@ -460,6 +473,10 @@ pub async fn get_team(
 }
 
 /// `GET /api/v1/topology/lineage/{agent_id}` — ancestor chain from agent up to root.
+///
+/// Returns the ordered list of ancestors for the given agent, starting from its
+/// direct parent and ending at the root agent (depth 0). Each step includes the
+/// delegation reason and team membership. Returns 404 if the agent is unknown.
 #[utoipa::path(
     get,
     path = "/api/v1/topology/lineage/{agent_id}",
@@ -508,6 +525,11 @@ pub async fn get_lineage(
 }
 
 /// `GET /api/v1/topology/stats` — aggregate topology statistics.
+///
+/// Returns aggregate counts across the entire registry: total agents, root
+/// agents, maximum delegation depth, per-status counts, and per-team agent
+/// counts. This endpoint never returns 404; an empty registry returns all
+/// zero counts.
 #[utoipa::path(
     get,
     path = "/api/v1/topology/stats",

--- a/aa-api/src/routes/topology.rs
+++ b/aa-api/src/routes/topology.rs
@@ -1,0 +1,214 @@
+//! Topology REST API endpoints.
+//!
+//! Five read-only endpoints for querying the agent topology tree, team
+//! membership, ancestry lineage, and aggregate statistics — all backed by
+//! the in-memory `AgentRegistry`.
+
+use std::collections::HashMap;
+
+use axum::extract::{Path, Query};
+use axum::http::StatusCode;
+use axum::{Extension, Json};
+use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
+
+use aa_gateway::registry::{AgentRegistry, AgentStatus};
+
+use crate::error::ProblemDetail;
+use crate::state::AppState;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn parse_agent_id(id: &str) -> Result<[u8; 16], ProblemDetail> {
+    let bytes: Vec<u8> = (0..id.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&id[i..i + 2], 16))
+        .collect::<Result<Vec<u8>, _>>()
+        .map_err(|_| {
+            ProblemDetail::from_status(StatusCode::BAD_REQUEST)
+                .with_detail(format!("Invalid agent ID format: {id}"))
+        })?;
+    bytes.try_into().map_err(|_| {
+        ProblemDetail::from_status(StatusCode::BAD_REQUEST)
+            .with_detail(format!("Agent ID must be 32 hex characters: {id}"))
+    })
+}
+
+fn format_id(id: &[u8; 16]) -> String {
+    id.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn status_str(status: &AgentStatus) -> &'static str {
+    match status {
+        AgentStatus::Active => "active",
+        AgentStatus::Suspended(_) => "suspended",
+        AgentStatus::Deregistered => "deregistered",
+    }
+}
+
+fn matches_status_filter(status: &AgentStatus, filter: &str) -> bool {
+    match filter.to_ascii_lowercase().as_str() {
+        "active" => matches!(status, AgentStatus::Active),
+        "suspended" => matches!(status, AgentStatus::Suspended(_)),
+        "deregistered" => matches!(status, AgentStatus::Deregistered),
+        _ => true,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Query parameter structs
+// ---------------------------------------------------------------------------
+
+/// Common filter parameters for topology listing endpoints.
+#[derive(Debug, Default, Deserialize, IntoParams)]
+pub struct TopologyFilterParams {
+    /// Filter by agent status: `active`, `suspended`, or `deregistered`.
+    pub status: Option<String>,
+    /// Only include agents at or above this delegation depth.
+    pub min_depth: Option<u32>,
+    /// When `true`, include the governance level in each agent node.
+    pub show_budget: Option<bool>,
+}
+
+/// Query parameters for the tree endpoint.
+#[derive(Debug, Default, Deserialize, IntoParams)]
+pub struct TreeParams {
+    /// Maximum traversal depth from the root (default 10, capped at 10).
+    pub depth: Option<u32>,
+    /// Filter tree nodes by status: `active`, `suspended`, or `deregistered`.
+    pub status: Option<String>,
+    /// When `true`, include the governance level in each tree node.
+    pub show_budget: Option<bool>,
+}
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+/// Overview of the entire agent topology across all teams.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct TopologyOverview {
+    /// Number of teams with at least one registered agent.
+    pub team_count: usize,
+    /// Number of root agents (depth == 0) across all teams.
+    pub root_agent_count: usize,
+    /// Total number of agents in the registry.
+    pub total_agent_count: usize,
+    /// Per-team agent count summaries.
+    pub teams: Vec<TeamSummary>,
+    /// Root agents that are not assigned to any team.
+    pub standalone_root_agents: Vec<AgentNode>,
+}
+
+/// High-level statistics for a single team.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct TeamSummary {
+    /// Team identifier.
+    pub team_id: String,
+    /// Total agents in this team.
+    pub agent_count: usize,
+    /// Root agents (depth == 0) in this team.
+    pub root_agent_count: usize,
+}
+
+/// Minimal agent representation used in list and tree responses.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AgentNode {
+    /// Hex-encoded agent UUID.
+    pub id: String,
+    /// Human-readable agent name.
+    pub name: String,
+    /// Delegation depth — 0 for root agents.
+    pub depth: u32,
+    /// Runtime status: `active`, `suspended`, or `deregistered`.
+    pub status: String,
+    /// Team this agent belongs to, if any.
+    pub team_id: Option<String>,
+    /// Governance level — included only when `show_budget=true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub governance_level: Option<String>,
+}
+
+/// Recursive tree node representing an agent and all its descendants.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AgentTree {
+    /// Hex-encoded agent UUID.
+    pub id: String,
+    /// Human-readable agent name.
+    pub name: String,
+    /// Delegation depth — 0 for root agents.
+    pub depth: u32,
+    /// Runtime status: `active`, `suspended`, or `deregistered`.
+    pub status: String,
+    /// Team this agent belongs to, if any.
+    pub team_id: Option<String>,
+    /// Reason this agent was delegated from its parent, if recorded.
+    pub delegation_reason: Option<String>,
+    /// Tool that spawned this agent, if known.
+    pub spawned_by_tool: Option<String>,
+    /// Governance level — included only when `show_budget=true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub governance_level: Option<String>,
+    /// Direct children of this agent in the delegation tree.
+    pub children: Vec<AgentTree>,
+}
+
+/// All agents belonging to a single team.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct TeamTopology {
+    /// Team identifier.
+    pub team_id: String,
+    /// Number of agents in this team (after filtering).
+    pub agent_count: usize,
+    /// Agents in this team.
+    pub members: Vec<AgentNode>,
+}
+
+/// An agent's complete ancestry chain from direct parent up to root.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AgentLineage {
+    /// The subject agent's hex-encoded UUID.
+    pub agent_id: String,
+    /// Number of ancestors — 0 if the agent is a root.
+    pub ancestor_count: usize,
+    /// Ordered ancestors: index 0 is the direct parent, last element is the root.
+    pub ancestors: Vec<LineageStep>,
+}
+
+/// One step in an agent's ancestry chain.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct LineageStep {
+    /// Hex-encoded UUID of this ancestor.
+    pub id: String,
+    /// Human-readable name of this ancestor.
+    pub name: String,
+    /// Delegation depth of this ancestor.
+    pub depth: u32,
+    /// Reason the next agent in the chain was delegated from this ancestor.
+    pub delegation_reason: Option<String>,
+    /// Team this ancestor belongs to.
+    pub team_id: Option<String>,
+}
+
+/// Aggregate topology statistics across all registered agents.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct TopologyStats {
+    /// Total agents in the registry.
+    pub total_agents: usize,
+    /// Number of root agents (depth == 0).
+    pub root_agent_count: usize,
+    /// Maximum observed delegation depth.
+    pub max_depth: u32,
+    /// Agents currently in `Active` status.
+    pub active_count: usize,
+    /// Agents currently in `Suspended` status.
+    pub suspended_count: usize,
+    /// Agents in `Deregistered` status.
+    pub deregistered_count: usize,
+    /// Number of teams with at least one agent.
+    pub team_count: usize,
+    /// Agent count per team.
+    pub team_sizes: HashMap<String, usize>,
+}

--- a/aa-api/src/routes/topology.rs
+++ b/aa-api/src/routes/topology.rs
@@ -194,8 +194,7 @@ pub struct LineageStep {
 
 /// Aggregate topology statistics across all registered agents.
 #[derive(Debug, Serialize, ToSchema)]
-pub struct TopologyStats {
-    /// Total agents in the registry.
+pub struct TopologyStats {    /// Total agents in the registry.
     pub total_agents: usize,
     /// Number of root agents (depth == 0).
     pub root_agent_count: usize,
@@ -211,4 +210,452 @@ pub struct TopologyStats {
     pub team_count: usize,
     /// Agent count per team.
     pub team_sizes: HashMap<String, usize>,
+}
+
+// ---------------------------------------------------------------------------
+// Tree builder helper
+// ---------------------------------------------------------------------------
+
+const MAX_TREE_DEPTH: u32 = 10;
+
+fn build_tree(
+    registry: &AgentRegistry,
+    agent_id: &[u8; 16],
+    remaining_depth: u32,
+    status_filter: Option<&str>,
+    show_budget: bool,
+) -> Option<AgentTree> {
+    let record = registry.get(agent_id)?;
+    if let Some(f) = status_filter {
+        if !matches_status_filter(&record.status, f) {
+            return None;
+        }
+    }
+    let children = if remaining_depth > 0 {
+        registry
+            .children_of(agent_id)
+            .iter()
+            .filter_map(|child_id| {
+                build_tree(registry, child_id, remaining_depth - 1, status_filter, show_budget)
+            })
+            .collect()
+    } else {
+        vec![]
+    };
+    Some(AgentTree {
+        id: format_id(agent_id),
+        name: record.name,
+        depth: record.depth,
+        status: status_str(&record.status).to_owned(),
+        team_id: record.team_id,
+        delegation_reason: record.delegation_reason,
+        spawned_by_tool: record.spawned_by_tool,
+        governance_level: if show_budget {
+            Some(format!("{:?}", record.governance_level))
+        } else {
+            None
+        },
+        children,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `GET /api/v1/topology/overview` — summary of all teams and root agents.
+#[utoipa::path(
+    get,
+    path = "/api/v1/topology/overview",
+    params(TopologyFilterParams),
+    responses(
+        (status = 200, description = "Topology overview", body = TopologyOverview)
+    ),
+    tag = "topology"
+)]
+pub async fn get_overview(
+    Extension(state): Extension<AppState>,
+    Query(params): Query<TopologyFilterParams>,
+) -> (StatusCode, Json<TopologyOverview>) {
+    let all = state.agent_registry.list();
+    let show_budget = params.show_budget.unwrap_or(false);
+
+    let filtered: Vec<_> = all
+        .iter()
+        .filter(|r| {
+            params.status.as_deref().map_or(true, |f| matches_status_filter(&r.status, f))
+                && params.min_depth.map_or(true, |d| r.depth >= d)
+        })
+        .collect();
+
+    let total_agent_count = filtered.len();
+
+    let mut team_map: HashMap<String, (usize, usize)> = HashMap::new();
+    for r in &filtered {
+        if let Some(tid) = &r.team_id {
+            let entry = team_map.entry(tid.clone()).or_insert((0, 0));
+            entry.0 += 1;
+            if r.depth == 0 {
+                entry.1 += 1;
+            }
+        }
+    }
+
+    let team_count = team_map.len();
+    let root_agent_count = filtered.iter().filter(|r| r.depth == 0).count();
+
+    let teams = {
+        let mut v: Vec<TeamSummary> = team_map
+            .into_iter()
+            .map(|(team_id, (agent_count, root_count))| TeamSummary {
+                team_id,
+                agent_count,
+                root_agent_count: root_count,
+            })
+            .collect();
+        v.sort_by(|a, b| a.team_id.cmp(&b.team_id));
+        v
+    };
+
+    let standalone_root_agents = filtered
+        .iter()
+        .filter(|r| r.depth == 0 && r.team_id.is_none())
+        .map(|r| AgentNode {
+            id: format_id(&r.agent_id),
+            name: r.name.clone(),
+            depth: r.depth,
+            status: status_str(&r.status).to_owned(),
+            team_id: None,
+            governance_level: if show_budget {
+                Some(format!("{:?}", r.governance_level))
+            } else {
+                None
+            },
+        })
+        .collect();
+
+    (
+        StatusCode::OK,
+        Json(TopologyOverview {
+            team_count,
+            root_agent_count,
+            total_agent_count,
+            teams,
+            standalone_root_agents,
+        }),
+    )
+}
+
+/// `GET /api/v1/topology/tree/{root_id}` — full subtree from a given root agent.
+#[utoipa::path(
+    get,
+    path = "/api/v1/topology/tree/{root_id}",
+    params(
+        ("root_id" = String, Path, description = "Hex-encoded UUID of the starting agent"),
+        TreeParams
+    ),
+    responses(
+        (status = 200, description = "Agent subtree", body = AgentTree),
+        (status = 400, description = "Invalid agent ID format"),
+        (status = 404, description = "Agent not found")
+    ),
+    tag = "topology"
+)]
+pub async fn get_tree(
+    Extension(state): Extension<AppState>,
+    Path(root_id): Path<String>,
+    Query(params): Query<TreeParams>,
+) -> Result<(StatusCode, Json<AgentTree>), ProblemDetail> {
+    let agent_id = parse_agent_id(&root_id)?;
+    let max_depth = params.depth.unwrap_or(MAX_TREE_DEPTH).min(MAX_TREE_DEPTH);
+    let show_budget = params.show_budget.unwrap_or(false);
+
+    let tree = build_tree(
+        &state.agent_registry,
+        &agent_id,
+        max_depth,
+        params.status.as_deref(),
+        show_budget,
+    )
+    .ok_or_else(|| {
+        ProblemDetail::from_status(StatusCode::NOT_FOUND)
+            .with_detail(format!("Agent not found: {root_id}"))
+    })?;
+
+    Ok((StatusCode::OK, Json(tree)))
+}
+
+/// `GET /api/v1/topology/team/{team_id}` — all agents in a team with depth info.
+#[utoipa::path(
+    get,
+    path = "/api/v1/topology/team/{team_id}",
+    params(
+        ("team_id" = String, Path, description = "Team identifier"),
+        TopologyFilterParams
+    ),
+    responses(
+        (status = 200, description = "Team topology", body = TeamTopology),
+        (status = 404, description = "Team not found")
+    ),
+    tag = "topology"
+)]
+pub async fn get_team(
+    Extension(state): Extension<AppState>,
+    Path(team_id): Path<String>,
+    Query(params): Query<TopologyFilterParams>,
+) -> Result<(StatusCode, Json<TeamTopology>), ProblemDetail> {
+    let member_ids = state.agent_registry.team_members(&team_id);
+    if member_ids.is_empty() {
+        return Err(ProblemDetail::from_status(StatusCode::NOT_FOUND)
+            .with_detail(format!("Team not found or has no agents: {team_id}")));
+    }
+    let show_budget = params.show_budget.unwrap_or(false);
+
+    let mut members: Vec<AgentNode> = member_ids
+        .iter()
+        .filter_map(|id| state.agent_registry.get(id))
+        .filter(|r| {
+            params.status.as_deref().map_or(true, |f| matches_status_filter(&r.status, f))
+                && params.min_depth.map_or(true, |d| r.depth >= d)
+        })
+        .map(|r| AgentNode {
+            id: format_id(&r.agent_id),
+            name: r.name.clone(),
+            depth: r.depth,
+            status: status_str(&r.status).to_owned(),
+            team_id: r.team_id.clone(),
+            governance_level: if show_budget {
+                Some(format!("{:?}", r.governance_level))
+            } else {
+                None
+            },
+        })
+        .collect();
+    members.sort_by_key(|m| m.depth);
+
+    let agent_count = members.len();
+    Ok((StatusCode::OK, Json(TeamTopology { team_id, agent_count, members })))
+}
+
+/// `GET /api/v1/topology/lineage/{agent_id}` — ancestor chain from agent up to root.
+#[utoipa::path(
+    get,
+    path = "/api/v1/topology/lineage/{agent_id}",
+    params(
+        ("agent_id" = String, Path, description = "Hex-encoded UUID of the agent")
+    ),
+    responses(
+        (status = 200, description = "Agent lineage chain", body = AgentLineage),
+        (status = 400, description = "Invalid agent ID format"),
+        (status = 404, description = "Agent not found")
+    ),
+    tag = "topology"
+)]
+pub async fn get_lineage(
+    Extension(state): Extension<AppState>,
+    Path(agent_id_str): Path<String>,
+) -> Result<(StatusCode, Json<AgentLineage>), ProblemDetail> {
+    let agent_id = parse_agent_id(&agent_id_str)?;
+
+    state.agent_registry.get(&agent_id).ok_or_else(|| {
+        ProblemDetail::from_status(StatusCode::NOT_FOUND)
+            .with_detail(format!("Agent not found: {agent_id_str}"))
+    })?;
+
+    let ancestor_ids = state.agent_registry.ancestors_of(&agent_id);
+    let ancestors: Vec<LineageStep> = ancestor_ids
+        .iter()
+        .filter_map(|id| state.agent_registry.get(id))
+        .map(|r| LineageStep {
+            id: format_id(&r.agent_id),
+            name: r.name.clone(),
+            depth: r.depth,
+            delegation_reason: r.delegation_reason.clone(),
+            team_id: r.team_id.clone(),
+        })
+        .collect();
+
+    let ancestor_count = ancestors.len();
+    Ok((
+        StatusCode::OK,
+        Json(AgentLineage { agent_id: agent_id_str, ancestor_count, ancestors }),
+    ))
+}
+
+/// `GET /api/v1/topology/stats` — aggregate topology statistics.
+#[utoipa::path(
+    get,
+    path = "/api/v1/topology/stats",
+    responses(
+        (status = 200, description = "Topology statistics", body = TopologyStats)
+    ),
+    tag = "topology"
+)]
+pub async fn get_stats(
+    Extension(state): Extension<AppState>,
+) -> (StatusCode, Json<TopologyStats>) {
+    let all = state.agent_registry.list();
+
+    let mut root_agent_count = 0usize;
+    let mut max_depth = 0u32;
+    let mut active_count = 0usize;
+    let mut suspended_count = 0usize;
+    let mut deregistered_count = 0usize;
+    let mut team_sizes: HashMap<String, usize> = HashMap::new();
+
+    for r in &all {
+        if r.depth == 0 {
+            root_agent_count += 1;
+        }
+        if r.depth > max_depth {
+            max_depth = r.depth;
+        }
+        match &r.status {
+            AgentStatus::Active => active_count += 1,
+            AgentStatus::Suspended(_) => suspended_count += 1,
+            AgentStatus::Deregistered => deregistered_count += 1,
+        }
+        if let Some(tid) = &r.team_id {
+            *team_sizes.entry(tid.clone()).or_insert(0) += 1;
+        }
+    }
+
+    let team_count = team_sizes.len();
+    let total_agents = all.len();
+
+    (
+        StatusCode::OK,
+        Json(TopologyStats {
+            total_agents,
+            root_agent_count,
+            max_depth,
+            active_count,
+            suspended_count,
+            deregistered_count,
+            team_count,
+            team_sizes,
+        }),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_id_roundtrip() {
+        let id: [u8; 16] = [
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+            0x0f, 0x10,
+        ];
+        let hex = format_id(&id);
+        assert_eq!(hex, "0102030405060708090a0b0c0d0e0f10");
+        let parsed = parse_agent_id(&hex).unwrap();
+        assert_eq!(parsed, id);
+    }
+
+    #[test]
+    fn parse_agent_id_rejects_short_input() {
+        assert!(parse_agent_id("aabb").is_err());
+    }
+
+    #[test]
+    fn parse_agent_id_rejects_non_hex() {
+        let non_hex = "z".repeat(32);
+        assert!(parse_agent_id(&non_hex).is_err());
+    }
+
+    #[test]
+    fn matches_status_filter_active() {
+        let status = AgentStatus::Active;
+        assert!(matches_status_filter(&status, "active"));
+        assert!(!matches_status_filter(&status, "suspended"));
+        assert!(!matches_status_filter(&status, "deregistered"));
+    }
+
+    #[test]
+    fn matches_status_filter_case_insensitive() {
+        let status = AgentStatus::Active;
+        assert!(matches_status_filter(&status, "ACTIVE"));
+        assert!(matches_status_filter(&status, "Active"));
+    }
+
+    #[test]
+    fn matches_status_filter_unknown_passes_all() {
+        let status = AgentStatus::Active;
+        assert!(matches_status_filter(&status, "unknown_value"));
+    }
+
+    #[test]
+    fn topology_stats_serializes() {
+        let stats = TopologyStats {
+            total_agents: 5,
+            root_agent_count: 2,
+            max_depth: 3,
+            active_count: 4,
+            suspended_count: 1,
+            deregistered_count: 0,
+            team_count: 2,
+            team_sizes: [("team-a".to_string(), 3), ("team-b".to_string(), 2)].into(),
+        };
+        let json = serde_json::to_value(&stats).unwrap();
+        assert_eq!(json["total_agents"], 5);
+        assert_eq!(json["root_agent_count"], 2);
+        assert_eq!(json["max_depth"], 3);
+        assert_eq!(json["team_count"], 2);
+    }
+
+    #[test]
+    fn agent_lineage_serializes() {
+        let lineage = AgentLineage {
+            agent_id: "aabbccdd00112233aabbccdd00112233".to_string(),
+            ancestor_count: 1,
+            ancestors: vec![LineageStep {
+                id: "00112233aabbccdd00112233aabbccdd".to_string(),
+                name: "root-agent".to_string(),
+                depth: 0,
+                delegation_reason: Some("spawned by orchestrator".to_string()),
+                team_id: Some("team-a".to_string()),
+            }],
+        };
+        let json = serde_json::to_value(&lineage).unwrap();
+        assert_eq!(json["ancestor_count"], 1);
+        assert_eq!(json["ancestors"][0]["name"], "root-agent");
+        assert_eq!(json["ancestors"][0]["depth"], 0);
+    }
+
+    #[test]
+    fn agent_node_omits_governance_level_when_none() {
+        let node = AgentNode {
+            id: "aa".to_string(),
+            name: "n".to_string(),
+            depth: 0,
+            status: "active".to_string(),
+            team_id: None,
+            governance_level: None,
+        };
+        let json = serde_json::to_value(&node).unwrap();
+        assert!(json.get("governance_level").is_none());
+    }
+
+    #[test]
+    fn agent_tree_leaf_has_empty_children() {
+        let leaf = AgentTree {
+            id: "aa".to_string(),
+            name: "leaf".to_string(),
+            depth: 3,
+            status: "active".to_string(),
+            team_id: None,
+            delegation_reason: None,
+            spawned_by_tool: None,
+            governance_level: None,
+            children: vec![],
+        };
+        let json = serde_json::to_value(&leaf).unwrap();
+        assert_eq!(json["children"].as_array().unwrap().len(), 0);
+    }
 }

--- a/aa-api/tests/topology.rs
+++ b/aa-api/tests/topology.rs
@@ -1,0 +1,348 @@
+//! Integration tests for the topology endpoints.
+
+mod common;
+
+use std::collections::BTreeMap;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use aa_gateway::registry::{AgentRecord, AgentStatus, SuspendReason};
+
+fn make_agent(id_byte: u8, name: &str, depth: u32, team_id: Option<&str>, parent_id: Option<[u8; 16]>) -> AgentRecord {
+    AgentRecord {
+        agent_id: [id_byte; 16],
+        name: name.to_string(),
+        framework: "langgraph".to_string(),
+        version: "0.1.0".to_string(),
+        risk_tier: 1,
+        tool_names: vec![],
+        public_key: "test-pubkey".to_string(),
+        credential_token: "test-token".to_string(),
+        metadata: BTreeMap::new(),
+        registered_at: chrono::Utc::now(),
+        last_heartbeat: chrono::Utc::now(),
+        status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
+        policy_violations_count: 0,
+        active_sessions: Vec::new(),
+        recent_events: std::collections::VecDeque::new(),
+        recent_traces: Vec::new(),
+        layer: None,
+        governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: parent_id.map(|b| format!("{}", b[0])),
+        team_id: team_id.map(str::to_string),
+        depth,
+        delegation_reason: if depth > 0 { Some("subtask".to_string()) } else { None },
+        spawned_by_tool: None,
+        root_agent_id: if depth == 0 { Some([id_byte; 16]) } else { parent_id },
+        children: Vec::new(),
+        parent_key: None,
+    }
+}
+
+fn hex_id(id_byte: u8) -> String {
+    format!("{id_byte:02x}").repeat(16)
+}
+
+// ---------------------------------------------------------------------------
+// Overview
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn topology_overview_empty_registry_returns_200() {
+    let app = common::test_app();
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/topology/overview").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["team_count"], 0);
+    assert_eq!(json["total_agent_count"], 0);
+    assert_eq!(json["root_agent_count"], 0);
+    assert!(json["teams"].as_array().unwrap().is_empty());
+    assert!(json["standalone_root_agents"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn topology_overview_with_agents_returns_correct_counts() {
+    let state = common::test_state();
+    // root in team-a, child in team-a, standalone root
+    state.agent_registry.register(make_agent(0x01, "root-a", 0, Some("team-a"), None)).unwrap();
+    state.agent_registry.register(make_agent(0x02, "child-a", 1, Some("team-a"), Some([0x01; 16]))).unwrap();
+    state.agent_registry.register(make_agent(0x03, "standalone", 0, None, None)).unwrap();
+
+    let app = aa_api::server::build_app(state);
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/topology/overview").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["team_count"], 1);
+    assert_eq!(json["total_agent_count"], 3);
+    assert_eq!(json["root_agent_count"], 2);
+    assert_eq!(json["teams"].as_array().unwrap().len(), 1);
+    assert_eq!(json["teams"][0]["team_id"], "team-a");
+    assert_eq!(json["teams"][0]["agent_count"], 2);
+    assert_eq!(json["standalone_root_agents"].as_array().unwrap().len(), 1);
+    assert_eq!(json["standalone_root_agents"][0]["name"], "standalone");
+}
+
+#[tokio::test]
+async fn topology_overview_status_filter_works() {
+    let state = common::test_state();
+    state.agent_registry.register(make_agent(0x01, "active-agent", 0, None, None)).unwrap();
+    let mut suspended = make_agent(0x02, "suspended-agent", 0, None, None);
+    suspended.status = AgentStatus::Suspended(SuspendReason::Manual);
+    state.agent_registry.register(suspended).unwrap();
+
+    let app = aa_api::server::build_app(state);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/topology/overview?status=active")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["total_agent_count"], 1);
+}
+
+// ---------------------------------------------------------------------------
+// Tree
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn topology_tree_returns_400_for_invalid_id() {
+    let app = common::test_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/topology/tree/not-a-valid-hex-id")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn topology_tree_returns_404_for_unknown_agent() {
+    let app = common::test_app();
+    let id = hex_id(0xAA);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/topology/tree/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn topology_tree_returns_subtree_for_known_agent() {
+    let state = common::test_state();
+    state.agent_registry.register(make_agent(0x01, "root", 0, None, None)).unwrap();
+    state.agent_registry.register(make_agent(0x02, "child", 1, None, Some([0x01; 16]))).unwrap();
+
+    let app = aa_api::server::build_app(state);
+    let id = hex_id(0x01);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/topology/tree/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["name"], "root");
+    assert_eq!(json["depth"], 0);
+    assert_eq!(json["status"], "active");
+}
+
+// ---------------------------------------------------------------------------
+// Team
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn topology_team_returns_404_for_unknown_team() {
+    let app = common::test_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/topology/team/nonexistent-team")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn topology_team_returns_members_for_known_team() {
+    let state = common::test_state();
+    state.agent_registry.register(make_agent(0x01, "root-a", 0, Some("team-x"), None)).unwrap();
+    state.agent_registry.register(make_agent(0x02, "child-a", 1, Some("team-x"), Some([0x01; 16]))).unwrap();
+
+    let app = aa_api::server::build_app(state);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/topology/team/team-x")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["team_id"], "team-x");
+    assert_eq!(json["agent_count"], 2);
+    let members = json["members"].as_array().unwrap();
+    assert_eq!(members.len(), 2);
+    // members are sorted by depth; depth-0 first
+    assert_eq!(members[0]["depth"], 0);
+    assert_eq!(members[1]["depth"], 1);
+}
+
+// ---------------------------------------------------------------------------
+// Lineage
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn topology_lineage_returns_400_for_invalid_id() {
+    let app = common::test_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/topology/lineage/not-hex")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn topology_lineage_returns_404_for_unknown_agent() {
+    let app = common::test_app();
+    let id = hex_id(0xCC);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/topology/lineage/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn topology_lineage_root_agent_has_no_ancestors() {
+    let state = common::test_state();
+    state.agent_registry.register(make_agent(0x01, "root", 0, None, None)).unwrap();
+
+    let app = aa_api::server::build_app(state);
+    let id = hex_id(0x01);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/topology/lineage/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["ancestor_count"], 0);
+    assert!(json["ancestors"].as_array().unwrap().is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// Stats
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn topology_stats_empty_registry_returns_zeros() {
+    let app = common::test_app();
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/topology/stats").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["total_agents"], 0);
+    assert_eq!(json["root_agent_count"], 0);
+    assert_eq!(json["active_count"], 0);
+    assert_eq!(json["team_count"], 0);
+}
+
+#[tokio::test]
+async fn topology_stats_with_agents_returns_correct_counts() {
+    let state = common::test_state();
+    state.agent_registry.register(make_agent(0x01, "root", 0, Some("team-a"), None)).unwrap();
+    state.agent_registry.register(make_agent(0x02, "child", 1, Some("team-a"), Some([0x01; 16]))).unwrap();
+
+    let app = aa_api::server::build_app(state);
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/topology/stats").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["total_agents"], 2);
+    assert_eq!(json["root_agent_count"], 1);
+    assert_eq!(json["active_count"], 2);
+    assert_eq!(json["max_depth"], 1);
+    assert_eq!(json["team_count"], 1);
+    assert_eq!(json["team_sizes"]["team-a"], 2);
+}

--- a/aa-api/tests/topology.rs
+++ b/aa-api/tests/topology.rs
@@ -57,7 +57,12 @@ async fn topology_overview_empty_registry_returns_200() {
     let app = common::test_app();
 
     let response = app
-        .oneshot(Request::builder().uri("/api/v1/topology/overview").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/topology/overview")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
 
@@ -75,13 +80,27 @@ async fn topology_overview_empty_registry_returns_200() {
 async fn topology_overview_with_agents_returns_correct_counts() {
     let state = common::test_state();
     // root in team-a, child in team-a, standalone root
-    state.agent_registry.register(make_agent(0x01, "root-a", 0, Some("team-a"), None)).unwrap();
-    state.agent_registry.register(make_agent(0x02, "child-a", 1, Some("team-a"), Some([0x01; 16]))).unwrap();
-    state.agent_registry.register(make_agent(0x03, "standalone", 0, None, None)).unwrap();
+    state
+        .agent_registry
+        .register(make_agent(0x01, "root-a", 0, Some("team-a"), None))
+        .unwrap();
+    state
+        .agent_registry
+        .register(make_agent(0x02, "child-a", 1, Some("team-a"), Some([0x01; 16])))
+        .unwrap();
+    state
+        .agent_registry
+        .register(make_agent(0x03, "standalone", 0, None, None))
+        .unwrap();
 
     let app = aa_api::server::build_app(state);
     let response = app
-        .oneshot(Request::builder().uri("/api/v1/topology/overview").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/topology/overview")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
 
@@ -102,7 +121,10 @@ async fn topology_overview_with_agents_returns_correct_counts() {
 #[tokio::test]
 async fn topology_overview_status_filter_works() {
     let state = common::test_state();
-    state.agent_registry.register(make_agent(0x01, "active-agent", 0, None, None)).unwrap();
+    state
+        .agent_registry
+        .register(make_agent(0x01, "active-agent", 0, None, None))
+        .unwrap();
     let mut suspended = make_agent(0x02, "suspended-agent", 0, None, None);
     suspended.status = AgentStatus::Suspended(SuspendReason::Manual);
     state.agent_registry.register(suspended).unwrap();
@@ -166,8 +188,14 @@ async fn topology_tree_returns_404_for_unknown_agent() {
 #[tokio::test]
 async fn topology_tree_returns_subtree_for_known_agent() {
     let state = common::test_state();
-    state.agent_registry.register(make_agent(0x01, "root", 0, None, None)).unwrap();
-    state.agent_registry.register(make_agent(0x02, "child", 1, None, Some([0x01; 16]))).unwrap();
+    state
+        .agent_registry
+        .register(make_agent(0x01, "root", 0, None, None))
+        .unwrap();
+    state
+        .agent_registry
+        .register(make_agent(0x02, "child", 1, None, Some([0x01; 16])))
+        .unwrap();
 
     let app = aa_api::server::build_app(state);
     let id = hex_id(0x01);
@@ -213,8 +241,14 @@ async fn topology_team_returns_404_for_unknown_team() {
 #[tokio::test]
 async fn topology_team_returns_members_for_known_team() {
     let state = common::test_state();
-    state.agent_registry.register(make_agent(0x01, "root-a", 0, Some("team-x"), None)).unwrap();
-    state.agent_registry.register(make_agent(0x02, "child-a", 1, Some("team-x"), Some([0x01; 16]))).unwrap();
+    state
+        .agent_registry
+        .register(make_agent(0x01, "root-a", 0, Some("team-x"), None))
+        .unwrap();
+    state
+        .agent_registry
+        .register(make_agent(0x02, "child-a", 1, Some("team-x"), Some([0x01; 16])))
+        .unwrap();
 
     let app = aa_api::server::build_app(state);
     let response = app
@@ -281,7 +315,10 @@ async fn topology_lineage_returns_404_for_unknown_agent() {
 #[tokio::test]
 async fn topology_lineage_root_agent_has_no_ancestors() {
     let state = common::test_state();
-    state.agent_registry.register(make_agent(0x01, "root", 0, None, None)).unwrap();
+    state
+        .agent_registry
+        .register(make_agent(0x01, "root", 0, None, None))
+        .unwrap();
 
     let app = aa_api::server::build_app(state);
     let id = hex_id(0x01);
@@ -311,7 +348,12 @@ async fn topology_stats_empty_registry_returns_zeros() {
     let app = common::test_app();
 
     let response = app
-        .oneshot(Request::builder().uri("/api/v1/topology/stats").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/topology/stats")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
 
@@ -327,12 +369,23 @@ async fn topology_stats_empty_registry_returns_zeros() {
 #[tokio::test]
 async fn topology_stats_with_agents_returns_correct_counts() {
     let state = common::test_state();
-    state.agent_registry.register(make_agent(0x01, "root", 0, Some("team-a"), None)).unwrap();
-    state.agent_registry.register(make_agent(0x02, "child", 1, Some("team-a"), Some([0x01; 16]))).unwrap();
+    state
+        .agent_registry
+        .register(make_agent(0x01, "root", 0, Some("team-a"), None))
+        .unwrap();
+    state
+        .agent_registry
+        .register(make_agent(0x02, "child", 1, Some("team-a"), Some([0x01; 16])))
+        .unwrap();
 
     let app = aa_api::server::build_app(state);
     let response = app
-        .oneshot(Request::builder().uri("/api/v1/topology/stats").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/topology/stats")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
 

--- a/aa-devtool-claude-code/Cargo.toml
+++ b/aa-devtool-claude-code/Cargo.toml
@@ -15,7 +15,7 @@ serde_json = "1"
 [dev-dependencies]
 insta = { version = "1", features = ["json"] }
 tempfile = "3"
-tokio = { version = "1", features = ["macros", "rt"] }
+tokio = { version = "1", features = ["macros", "rt", "sync"] }
 
 [lints]
 workspace = true

--- a/aa-devtool-claude-code/tests/settings_merge.rs
+++ b/aa-devtool-claude-code/tests/settings_merge.rs
@@ -16,7 +16,9 @@ use aa_devtool_claude_code::ClaudeCodeAdapter;
 
 // Serialize all tests in this binary: set_current_dir is process-global state
 // and cargo-llvm-cov runs tests in parallel threads within the same process.
-static TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+// tokio::sync::Mutex is used so the guard can be held across .await points
+// without triggering clippy::await_holding_lock.
+static TEST_MUTEX: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 fn full_settings(permission_mode: &str) -> String {
     serde_json::json!({
@@ -36,7 +38,7 @@ fn read_json(path: &std::path::Path) -> serde_json::Value {
 
 #[tokio::test]
 async fn global_only_writes_to_global_path() {
-    let _guard = TEST_MUTEX.lock().unwrap();
+    let _guard = TEST_MUTEX.lock().await;
     let home = tempfile::tempdir().unwrap();
     let other = tempfile::tempdir().unwrap(); // no .claude/ subdir — triggers global scope
     std::env::set_current_dir(other.path()).unwrap();
@@ -52,7 +54,7 @@ async fn global_only_writes_to_global_path() {
 
 #[tokio::test]
 async fn project_present_writes_to_project_path() {
-    let _guard = TEST_MUTEX.lock().unwrap();
+    let _guard = TEST_MUTEX.lock().await;
     let home = tempfile::tempdir().unwrap();
     let project = tempfile::tempdir().unwrap();
     std::fs::create_dir(project.path().join(".claude")).unwrap();
@@ -70,7 +72,7 @@ async fn project_present_writes_to_project_path() {
 
 #[tokio::test]
 async fn project_settings_override_global_at_runtime() {
-    let _guard = TEST_MUTEX.lock().unwrap();
+    let _guard = TEST_MUTEX.lock().await;
     let home = tempfile::tempdir().unwrap();
     let global_dir = home.path().join(".claude");
     std::fs::create_dir_all(&global_dir).unwrap();
@@ -101,7 +103,7 @@ async fn project_settings_override_global_at_runtime() {
 
 #[tokio::test]
 async fn merge_preserves_user_keys_at_both_levels() {
-    let _guard = TEST_MUTEX.lock().unwrap();
+    let _guard = TEST_MUTEX.lock().await;
     let home = tempfile::tempdir().unwrap();
     let global_dir = home.path().join(".claude");
     std::fs::create_dir_all(&global_dir).unwrap();
@@ -139,7 +141,7 @@ async fn merge_preserves_user_keys_at_both_levels() {
 
 #[tokio::test]
 async fn mcp_governance_only_touches_active_scope() {
-    let _guard = TEST_MUTEX.lock().unwrap();
+    let _guard = TEST_MUTEX.lock().await;
     let home = tempfile::tempdir().unwrap();
     let global_dir = home.path().join(".claude");
     std::fs::create_dir_all(&global_dir).unwrap();

--- a/aa-devtool-claude-code/tests/settings_merge.rs
+++ b/aa-devtool-claude-code/tests/settings_merge.rs
@@ -14,6 +14,10 @@
 use aa_core::DevToolAdapter;
 use aa_devtool_claude_code::ClaudeCodeAdapter;
 
+// Serialize all tests in this binary: set_current_dir is process-global state
+// and cargo-llvm-cov runs tests in parallel threads within the same process.
+static TEST_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 fn full_settings(permission_mode: &str) -> String {
     serde_json::json!({
         "permissions": { "allow": [], "deny": [] },
@@ -32,6 +36,7 @@ fn read_json(path: &std::path::Path) -> serde_json::Value {
 
 #[tokio::test]
 async fn global_only_writes_to_global_path() {
+    let _guard = TEST_MUTEX.lock().unwrap();
     let home = tempfile::tempdir().unwrap();
     let other = tempfile::tempdir().unwrap(); // no .claude/ subdir — triggers global scope
     std::env::set_current_dir(other.path()).unwrap();
@@ -47,6 +52,7 @@ async fn global_only_writes_to_global_path() {
 
 #[tokio::test]
 async fn project_present_writes_to_project_path() {
+    let _guard = TEST_MUTEX.lock().unwrap();
     let home = tempfile::tempdir().unwrap();
     let project = tempfile::tempdir().unwrap();
     std::fs::create_dir(project.path().join(".claude")).unwrap();
@@ -64,6 +70,7 @@ async fn project_present_writes_to_project_path() {
 
 #[tokio::test]
 async fn project_settings_override_global_at_runtime() {
+    let _guard = TEST_MUTEX.lock().unwrap();
     let home = tempfile::tempdir().unwrap();
     let global_dir = home.path().join(".claude");
     std::fs::create_dir_all(&global_dir).unwrap();
@@ -94,6 +101,7 @@ async fn project_settings_override_global_at_runtime() {
 
 #[tokio::test]
 async fn merge_preserves_user_keys_at_both_levels() {
+    let _guard = TEST_MUTEX.lock().unwrap();
     let home = tempfile::tempdir().unwrap();
     let global_dir = home.path().join(".claude");
     std::fs::create_dir_all(&global_dir).unwrap();
@@ -131,6 +139,7 @@ async fn merge_preserves_user_keys_at_both_levels() {
 
 #[tokio::test]
 async fn mcp_governance_only_touches_active_scope() {
+    let _guard = TEST_MUTEX.lock().unwrap();
     let home = tempfile::tempdir().unwrap();
     let global_dir = home.path().join(".claude");
     std::fs::create_dir_all(&global_dir).unwrap();

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -299,6 +299,118 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/topology/lineage/{agent_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * `GET /api/v1/topology/lineage/{agent_id}` — ancestor chain from agent up to root.
+         * @description Returns the ordered list of ancestors for the given agent, starting from its
+         *     direct parent and ending at the root agent (depth 0). Each step includes the
+         *     delegation reason and team membership. Returns 404 if the agent is unknown.
+         */
+        get: operations["get_lineage"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/topology/overview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * `GET /api/v1/topology/overview` — summary of all teams and root agents.
+         * @description Returns a count of teams, root agents, and total agents across the registry,
+         *     with a per-team breakdown and a list of standalone root agents not assigned
+         *     to any team. Supports optional filtering by status, minimum depth, and
+         *     governance level visibility.
+         */
+        get: operations["get_overview"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/topology/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * `GET /api/v1/topology/stats` — aggregate topology statistics.
+         * @description Returns aggregate counts across the entire registry: total agents, root
+         *     agents, maximum delegation depth, per-status counts, and per-team agent
+         *     counts. This endpoint never returns 404; an empty registry returns all
+         *     zero counts.
+         */
+        get: operations["get_stats"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/topology/team/{team_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * `GET /api/v1/topology/team/{team_id}` — all agents in a team with depth info.
+         * @description Returns all agents belonging to the given team, sorted by delegation depth.
+         *     Results can be filtered by status and minimum depth. Returns 404 if the
+         *     team identifier is not known to the registry.
+         */
+        get: operations["get_team"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/topology/tree/{root_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * `GET /api/v1/topology/tree/{root_id}` — full subtree from a given root agent.
+         * @description Recursively walks the delegation tree starting from the given agent, up to
+         *     a configurable depth (default 10, maximum 10). Nodes can be filtered by
+         *     status. Returns a nested JSON tree with each agent's children inline.
+         */
+        get: operations["get_tree"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/traces/{session_id}": {
         parameters: {
             query?: never;
@@ -386,6 +498,33 @@ export interface components {
             /** @description Total spend this month in USD for this agent (if monthly tracking is enabled). */
             monthly_spend_usd?: string | null;
         };
+        /** @description An agent's complete ancestry chain from direct parent up to root. */
+        AgentLineage: {
+            /** @description The subject agent's hex-encoded UUID. */
+            agent_id: string;
+            /** @description Number of ancestors — 0 if the agent is a root. */
+            ancestor_count: number;
+            /** @description Ordered ancestors: index 0 is the direct parent, last element is the root. */
+            ancestors: components["schemas"]["LineageStep"][];
+        };
+        /** @description Minimal agent representation used in list and tree responses. */
+        AgentNode: {
+            /**
+             * Format: int32
+             * @description Delegation depth — 0 for root agents.
+             */
+            depth: number;
+            /** @description Governance level — included only when `show_budget=true`. */
+            governance_level?: string | null;
+            /** @description Hex-encoded agent UUID. */
+            id: string;
+            /** @description Human-readable agent name. */
+            name: string;
+            /** @description Runtime status: `active`, `suspended`, or `deregistered`. */
+            status: string;
+            /** @description Team this agent belongs to, if any. */
+            team_id?: string | null;
+        };
         /** @description JSON representation of an agent returned by the API. */
         AgentResponse: {
             /** @description Currently active sessions for this agent. */
@@ -429,6 +568,29 @@ export interface components {
             tool_names: string[];
             /** @description Semver version string. */
             version: string;
+        };
+        /** @description Recursive tree node representing an agent and all its descendants. */
+        AgentTree: {
+            children: components["schemas"]["AgentTree"][];
+            /** @description Reason this agent was delegated from its parent, if recorded. */
+            delegation_reason?: string | null;
+            /**
+             * Format: int32
+             * @description Delegation depth — 0 for root agents.
+             */
+            depth: number;
+            /** @description Governance level — included only when `show_budget=true`. */
+            governance_level?: string | null;
+            /** @description Hex-encoded agent UUID. */
+            id: string;
+            /** @description Human-readable agent name. */
+            name: string;
+            /** @description Tool that spawned this agent, if known. */
+            spawned_by_tool?: string | null;
+            /** @description Runtime status: `active`, `suspended`, or `deregistered`. */
+            status: string;
+            /** @description Team this agent belongs to, if any. */
+            team_id?: string | null;
         };
         /** @description JSON representation of a governance alert. */
         AlertResponse: {
@@ -610,6 +772,22 @@ export interface components {
             /** @description Gateway version (semver from Cargo.toml). */
             version: string;
         };
+        /** @description One step in an agent's ancestry chain. */
+        LineageStep: {
+            /** @description Reason the next agent in the chain was delegated from this ancestor. */
+            delegation_reason?: string | null;
+            /**
+             * Format: int32
+             * @description Delegation depth of this ancestor.
+             */
+            depth: number;
+            /** @description Hex-encoded UUID of this ancestor. */
+            id: string;
+            /** @description Human-readable name of this ancestor. */
+            name: string;
+            /** @description Team this ancestor belongs to. */
+            team_id?: string | null;
+        };
         /** @description JSON representation of an audit log entry. */
         LogEntry: {
             /** @description Hex-encoded agent ID that produced this log entry. */
@@ -722,6 +900,24 @@ export interface components {
             /** @description Team identifier. */
             team_id: string;
         };
+        /** @description High-level statistics for a single team. */
+        TeamSummary: {
+            /** @description Total agents in this team. */
+            agent_count: number;
+            /** @description Root agents (depth == 0) in this team. */
+            root_agent_count: number;
+            /** @description Team identifier. */
+            team_id: string;
+        };
+        /** @description All agents belonging to a single team. */
+        TeamTopology: {
+            /** @description Number of agents in this team (after filtering). */
+            agent_count: number;
+            /** @description Agents in this team. */
+            members: components["schemas"]["AgentNode"][];
+            /** @description Team identifier. */
+            team_id: string;
+        };
         /** @description Request body for `POST /auth/token`. */
         TokenRequest: {
             /**
@@ -741,6 +937,43 @@ export interface components {
             scopes: components["schemas"]["Scope"][];
             /** @description The issued JWT token string. */
             token: string;
+        };
+        /** @description Overview of the entire agent topology across all teams. */
+        TopologyOverview: {
+            /** @description Number of root agents (depth == 0) across all teams. */
+            root_agent_count: number;
+            /** @description Root agents that are not assigned to any team. */
+            standalone_root_agents: components["schemas"]["AgentNode"][];
+            /** @description Number of teams with at least one registered agent. */
+            team_count: number;
+            /** @description Per-team agent count summaries. */
+            teams: components["schemas"]["TeamSummary"][];
+            /** @description Total number of agents in the registry. */
+            total_agent_count: number;
+        };
+        /** @description Aggregate topology statistics across all registered agents. */
+        TopologyStats: {
+            /** @description Agents currently in `Active` status. */
+            active_count: number;
+            /** @description Agents in `Deregistered` status. */
+            deregistered_count: number;
+            /**
+             * Format: int32
+             * @description Maximum observed delegation depth.
+             */
+            max_depth: number;
+            /** @description Number of root agents (depth == 0). */
+            root_agent_count: number;
+            /** @description Agents currently in `Suspended` status. */
+            suspended_count: number;
+            /** @description Number of teams with at least one agent. */
+            team_count: number;
+            /** @description Agent count per team. */
+            team_sizes: {
+                [key: string]: number;
+            };
+            /** @description Total agents in the registry. */
+            total_agents: number;
         };
         /** @description Full trace for one agent session. */
         TraceResponse: {
@@ -1301,6 +1534,171 @@ export interface operations {
                 };
             };
             /** @description No active policy loaded */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    get_lineage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Hex-encoded UUID of the agent */
+                agent_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Agent lineage chain */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentLineage"];
+                };
+            };
+            /** @description Invalid agent ID format */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Agent not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    get_overview: {
+        parameters: {
+            query?: {
+                /** @description Filter by agent status: `active`, `suspended`, or `deregistered`. */
+                status?: string | null;
+                /** @description Only include agents at or above this delegation depth. */
+                min_depth?: number | null;
+                /** @description When `true`, include the governance level in each agent node. */
+                show_budget?: boolean | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Topology overview */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyOverview"];
+                };
+            };
+        };
+    };
+    get_stats: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Topology statistics */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyStats"];
+                };
+            };
+        };
+    };
+    get_team: {
+        parameters: {
+            query?: {
+                /** @description Filter by agent status: `active`, `suspended`, or `deregistered`. */
+                status?: string | null;
+                /** @description Only include agents at or above this delegation depth. */
+                min_depth?: number | null;
+                /** @description When `true`, include the governance level in each agent node. */
+                show_budget?: boolean | null;
+            };
+            header?: never;
+            path: {
+                /** @description Team identifier */
+                team_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Team topology */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TeamTopology"];
+                };
+            };
+            /** @description Team not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    get_tree: {
+        parameters: {
+            query?: {
+                /** @description Maximum traversal depth from the root (default 10, capped at 10). */
+                depth?: number | null;
+                /** @description Filter tree nodes by status: `active`, `suspended`, or `deregistered`. */
+                status?: string | null;
+                /** @description When `true`, include the governance level in each tree node. */
+                show_budget?: boolean | null;
+            };
+            header?: never;
+            path: {
+                /** @description Hex-encoded UUID of the starting agent */
+                root_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Agent subtree */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentTree"];
+                };
+            };
+            /** @description Invalid agent ID format */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Agent not found */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -500,6 +500,181 @@ paths:
                 $ref: '#/components/schemas/PolicyResponse'
         '404':
           description: No active policy loaded
+  /api/v1/topology/lineage/{agent_id}:
+    get:
+      tags:
+      - topology
+      summary: '`GET /api/v1/topology/lineage/{agent_id}` — ancestor chain from agent up to root.'
+      operationId: get_lineage
+      parameters:
+      - name: agent_id
+        in: path
+        description: Hex-encoded UUID of the agent
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Agent lineage chain
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentLineage'
+        '400':
+          description: Invalid agent ID format
+        '404':
+          description: Agent not found
+  /api/v1/topology/overview:
+    get:
+      tags:
+      - topology
+      summary: '`GET /api/v1/topology/overview` — summary of all teams and root agents.'
+      operationId: get_overview
+      parameters:
+      - name: status
+        in: query
+        description: 'Filter by agent status: `active`, `suspended`, or `deregistered`.'
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
+      - name: min_depth
+        in: query
+        description: Only include agents at or above this delegation depth.
+        required: false
+        schema:
+          type:
+          - integer
+          - 'null'
+          format: int32
+          minimum: 0
+      - name: show_budget
+        in: query
+        description: When `true`, include the governance level in each agent node.
+        required: false
+        schema:
+          type:
+          - boolean
+          - 'null'
+      responses:
+        '200':
+          description: Topology overview
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TopologyOverview'
+  /api/v1/topology/stats:
+    get:
+      tags:
+      - topology
+      summary: '`GET /api/v1/topology/stats` — aggregate topology statistics.'
+      operationId: get_stats
+      responses:
+        '200':
+          description: Topology statistics
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TopologyStats'
+  /api/v1/topology/team/{team_id}:
+    get:
+      tags:
+      - topology
+      summary: '`GET /api/v1/topology/team/{team_id}` — all agents in a team with depth info.'
+      operationId: get_team
+      parameters:
+      - name: team_id
+        in: path
+        description: Team identifier
+        required: true
+        schema:
+          type: string
+      - name: status
+        in: query
+        description: 'Filter by agent status: `active`, `suspended`, or `deregistered`.'
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
+      - name: min_depth
+        in: query
+        description: Only include agents at or above this delegation depth.
+        required: false
+        schema:
+          type:
+          - integer
+          - 'null'
+          format: int32
+          minimum: 0
+      - name: show_budget
+        in: query
+        description: When `true`, include the governance level in each agent node.
+        required: false
+        schema:
+          type:
+          - boolean
+          - 'null'
+      responses:
+        '200':
+          description: Team topology
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TeamTopology'
+        '404':
+          description: Team not found
+  /api/v1/topology/tree/{root_id}:
+    get:
+      tags:
+      - topology
+      summary: '`GET /api/v1/topology/tree/{root_id}` — full subtree from a given root agent.'
+      operationId: get_tree
+      parameters:
+      - name: root_id
+        in: path
+        description: Hex-encoded UUID of the starting agent
+        required: true
+        schema:
+          type: string
+      - name: depth
+        in: query
+        description: Maximum traversal depth from the root (default 10, capped at 10).
+        required: false
+        schema:
+          type:
+          - integer
+          - 'null'
+          format: int32
+          minimum: 0
+      - name: status
+        in: query
+        description: 'Filter tree nodes by status: `active`, `suspended`, or `deregistered`.'
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
+      - name: show_budget
+        in: query
+        description: When `true`, include the governance level in each tree node.
+        required: false
+        schema:
+          type:
+          - boolean
+          - 'null'
+      responses:
+        '200':
+          description: Agent subtree
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentTree'
+        '400':
+          description: Invalid agent ID format
+        '404':
+          description: Agent not found
   /api/v1/traces/{session_id}:
     get:
       tags:
@@ -637,6 +812,59 @@ components:
           - string
           - 'null'
           description: Total spend this month in USD for this agent (if monthly tracking is enabled).
+    AgentLineage:
+      type: object
+      description: An agent's complete ancestry chain from direct parent up to root.
+      required:
+      - agent_id
+      - ancestor_count
+      - ancestors
+      properties:
+        agent_id:
+          type: string
+          description: The subject agent's hex-encoded UUID.
+        ancestor_count:
+          type: integer
+          description: Number of ancestors — 0 if the agent is a root.
+          minimum: 0
+        ancestors:
+          type: array
+          items:
+            $ref: '#/components/schemas/LineageStep'
+          description: 'Ordered ancestors: index 0 is the direct parent, last element is the root.'
+    AgentNode:
+      type: object
+      description: Minimal agent representation used in list and tree responses.
+      required:
+      - id
+      - name
+      - depth
+      - status
+      properties:
+        depth:
+          type: integer
+          format: int32
+          description: Delegation depth — 0 for root agents.
+          minimum: 0
+        governance_level:
+          type:
+          - string
+          - 'null'
+          description: Governance level — included only when `show_budget=true`.
+        id:
+          type: string
+          description: Hex-encoded agent UUID.
+        name:
+          type: string
+          description: Human-readable agent name.
+        status:
+          type: string
+          description: 'Runtime status: `active`, `suspended`, or `deregistered`.'
+        team_id:
+          type:
+          - string
+          - 'null'
+          description: Team this agent belongs to, if any.
     AgentResponse:
       type: object
       description: JSON representation of an agent returned by the API.
@@ -723,6 +951,54 @@ components:
         version:
           type: string
           description: Semver version string.
+    AgentTree:
+      type: object
+      description: Recursive tree node representing an agent and all its descendants.
+      required:
+      - id
+      - name
+      - depth
+      - status
+      - children
+      properties:
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentTree'
+        delegation_reason:
+          type:
+          - string
+          - 'null'
+          description: Reason this agent was delegated from its parent, if recorded.
+        depth:
+          type: integer
+          format: int32
+          description: Delegation depth — 0 for root agents.
+          minimum: 0
+        governance_level:
+          type:
+          - string
+          - 'null'
+          description: Governance level — included only when `show_budget=true`.
+        id:
+          type: string
+          description: Hex-encoded agent UUID.
+        name:
+          type: string
+          description: Human-readable agent name.
+        spawned_by_tool:
+          type:
+          - string
+          - 'null'
+          description: Tool that spawned this agent, if known.
+        status:
+          type: string
+          description: 'Runtime status: `active`, `suspended`, or `deregistered`.'
+        team_id:
+          type:
+          - string
+          - 'null'
+          description: Team this agent belongs to, if any.
     AlertResponse:
       type: object
       description: JSON representation of a governance alert.
@@ -1005,6 +1281,35 @@ components:
         version:
           type: string
           description: Gateway version (semver from Cargo.toml).
+    LineageStep:
+      type: object
+      description: One step in an agent's ancestry chain.
+      required:
+      - id
+      - name
+      - depth
+      properties:
+        delegation_reason:
+          type:
+          - string
+          - 'null'
+          description: Reason the next agent in the chain was delegated from this ancestor.
+        depth:
+          type: integer
+          format: int32
+          description: Delegation depth of this ancestor.
+          minimum: 0
+        id:
+          type: string
+          description: Hex-encoded UUID of this ancestor.
+        name:
+          type: string
+          description: Human-readable name of this ancestor.
+        team_id:
+          type:
+          - string
+          - 'null'
+          description: Team this ancestor belongs to.
     LogEntry:
       type: object
       description: JSON representation of an audit log entry.
@@ -1199,6 +1504,45 @@ components:
         team_id:
           type: string
           description: Team identifier.
+    TeamSummary:
+      type: object
+      description: High-level statistics for a single team.
+      required:
+      - team_id
+      - agent_count
+      - root_agent_count
+      properties:
+        agent_count:
+          type: integer
+          description: Total agents in this team.
+          minimum: 0
+        root_agent_count:
+          type: integer
+          description: Root agents (depth == 0) in this team.
+          minimum: 0
+        team_id:
+          type: string
+          description: Team identifier.
+    TeamTopology:
+      type: object
+      description: All agents belonging to a single team.
+      required:
+      - team_id
+      - agent_count
+      - members
+      properties:
+        agent_count:
+          type: integer
+          description: Number of agents in this team (after filtering).
+          minimum: 0
+        members:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentNode'
+          description: Agents in this team.
+        team_id:
+          type: string
+          description: Team identifier.
     TokenRequest:
       type: object
       description: Request body for `POST /auth/token`.
@@ -1233,6 +1577,88 @@ components:
         token:
           type: string
           description: The issued JWT token string.
+    TopologyOverview:
+      type: object
+      description: Overview of the entire agent topology across all teams.
+      required:
+      - team_count
+      - root_agent_count
+      - total_agent_count
+      - teams
+      - standalone_root_agents
+      properties:
+        root_agent_count:
+          type: integer
+          description: Number of root agents (depth == 0) across all teams.
+          minimum: 0
+        standalone_root_agents:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentNode'
+          description: Root agents that are not assigned to any team.
+        team_count:
+          type: integer
+          description: Number of teams with at least one registered agent.
+          minimum: 0
+        teams:
+          type: array
+          items:
+            $ref: '#/components/schemas/TeamSummary'
+          description: Per-team agent count summaries.
+        total_agent_count:
+          type: integer
+          description: Total number of agents in the registry.
+          minimum: 0
+    TopologyStats:
+      type: object
+      description: Aggregate topology statistics across all registered agents.
+      required:
+      - total_agents
+      - root_agent_count
+      - max_depth
+      - active_count
+      - suspended_count
+      - deregistered_count
+      - team_count
+      - team_sizes
+      properties:
+        active_count:
+          type: integer
+          description: Agents currently in `Active` status.
+          minimum: 0
+        deregistered_count:
+          type: integer
+          description: Agents in `Deregistered` status.
+          minimum: 0
+        max_depth:
+          type: integer
+          format: int32
+          description: Maximum observed delegation depth.
+          minimum: 0
+        root_agent_count:
+          type: integer
+          description: Number of root agents (depth == 0).
+          minimum: 0
+        suspended_count:
+          type: integer
+          description: Agents currently in `Suspended` status.
+          minimum: 0
+        team_count:
+          type: integer
+          description: Number of teams with at least one agent.
+          minimum: 0
+        team_sizes:
+          type: object
+          description: Agent count per team.
+          additionalProperties:
+            type: integer
+            minimum: 0
+          propertyNames:
+            type: string
+        total_agents:
+          type: integer
+          description: Total agents in the registry.
+          minimum: 0
     TraceResponse:
       type: object
       description: Full trace for one agent session.
@@ -1365,3 +1791,5 @@ tags:
   description: Authentication and token issuance
 - name: events
   description: Real-time event streaming via WebSocket
+- name: topology
+  description: Agent topology — tree, team, lineage, and statistics queries

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -505,6 +505,10 @@ paths:
       tags:
       - topology
       summary: '`GET /api/v1/topology/lineage/{agent_id}` — ancestor chain from agent up to root.'
+      description: |-
+        Returns the ordered list of ancestors for the given agent, starting from its
+        direct parent and ending at the root agent (depth 0). Each step includes the
+        delegation reason and team membership. Returns 404 if the agent is unknown.
       operationId: get_lineage
       parameters:
       - name: agent_id
@@ -529,6 +533,11 @@ paths:
       tags:
       - topology
       summary: '`GET /api/v1/topology/overview` — summary of all teams and root agents.'
+      description: |-
+        Returns a count of teams, root agents, and total agents across the registry,
+        with a per-team breakdown and a list of standalone root agents not assigned
+        to any team. Supports optional filtering by status, minimum depth, and
+        governance level visibility.
       operationId: get_overview
       parameters:
       - name: status
@@ -569,6 +578,11 @@ paths:
       tags:
       - topology
       summary: '`GET /api/v1/topology/stats` — aggregate topology statistics.'
+      description: |-
+        Returns aggregate counts across the entire registry: total agents, root
+        agents, maximum delegation depth, per-status counts, and per-team agent
+        counts. This endpoint never returns 404; an empty registry returns all
+        zero counts.
       operationId: get_stats
       responses:
         '200':
@@ -582,6 +596,10 @@ paths:
       tags:
       - topology
       summary: '`GET /api/v1/topology/team/{team_id}` — all agents in a team with depth info.'
+      description: |-
+        Returns all agents belonging to the given team, sorted by delegation depth.
+        Results can be filtered by status and minimum depth. Returns 404 if the
+        team identifier is not known to the registry.
       operationId: get_team
       parameters:
       - name: team_id
@@ -630,6 +648,10 @@ paths:
       tags:
       - topology
       summary: '`GET /api/v1/topology/tree/{root_id}` — full subtree from a given root agent.'
+      description: |-
+        Recursively walks the delegation tree starting from the given agent, up to
+        a configurable depth (default 10, maximum 10). Nodes can be filtered by
+        status. Returns a nested JSON tree with each agent's children inline.
       operationId: get_tree
       parameters:
       - name: root_id


### PR DESCRIPTION
## What changed

Implements AAASM-214 (F87): five read-only topology REST API endpoints backed by the in-memory `AgentRegistry`:

| Method | Path | Description |
|---|---|---|
| GET | `/api/v1/topology/overview` | Team + root-agent summary across all teams |
| GET | `/api/v1/topology/tree/{root_id}` | Recursive subtree from a given root agent |
| GET | `/api/v1/topology/team/{team_id}` | All agents in a team with depth info |
| GET | `/api/v1/topology/lineage/{agent_id}` | Ancestor chain from agent up to root |
| GET | `/api/v1/topology/stats` | Aggregate statistics (counts, depths, team sizes) |

All endpoints are read-only (no writes to registry), support optional query filters (`status`, `min_depth`, `show_budget`, `depth`), and return RFC 7807 `ProblemDetail` on error.

## Why

Closes AAASM-214. The dashboard and CLI need structured topology data; these endpoints expose what the registry already tracks without adding new state.

## Key implementation detail

`AgentTree` is a recursive type (`children: Vec<AgentTree>`). utoipa 5.x's `ToSchema` derive would infinitely recurse and overflow the stack at runtime. Fixed by annotating `children` with `#[schema(schema_with = agent_tree_children_schema)]`, which emits an `Array($ref: AgentTree)` instead of trying to inline the schema.

## How to verify

```bash
cargo nextest run -p aa-api                          # 197/197
cargo nextest run -p aa-api --test openapi_spec      # 9/9
cargo nextest run --workspace --exclude aa-ebpf      # 1750/1750
cargo fmt --all -- --check                           # clean
cargo clippy -p aa-api --all-targets -- -D warnings  # clean
```

## Commits

- `44f266df` ✨ Add topology response types and query param structs
- `48145e1e` ✨ Add 5 topology handlers and unit tests
- `b98ecc4b` ✨ Wire topology routes into v1_router() and OpenAPI schema
- `48a2c4ca` 🐛 Fix stack overflow in AgentTree ToSchema via schema_with

Closes #AAASM-214