### PR TITLE
[AAASM-210] 🐛 (registry): Handle orphan agents when parent deregisters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,7 @@ version = "0.0.1"
 dependencies = [
  "aa-core",
  "aa-devtool",
+ "aa-devtool-codex",
  "aa-devtool-windsurf",
  "aa-gateway",
  "anyhow",

--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -8,6 +8,8 @@ use axum::{Extension, Json};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+use aa_gateway::registry::OrphanMode;
+
 use crate::error::ProblemDetail;
 use crate::pagination::{PaginatedResponse, PaginationParams};
 use crate::state::AppState;
@@ -266,7 +268,7 @@ pub async fn delete_agent(
 
     state
         .agent_registry
-        .deregister(&agent_id)
+        .deregister(&agent_id, OrphanMode::Suspend)
         .map_err(|_| ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Agent not found: {id}")))?;
 
     Ok(StatusCode::NO_CONTENT)

--- a/aa-gateway/src/events/publisher.rs
+++ b/aa-gateway/src/events/publisher.rs
@@ -13,6 +13,7 @@ use crate::budget::BudgetAlert;
 /// Event type routing keys used in the envelope's `event_type` field.
 pub const EVENT_TYPE_APPROVAL_REQUESTED: &str = "approval.requested";
 pub const EVENT_TYPE_BUDGET_THRESHOLD: &str = "budget.threshold_hit";
+pub const EVENT_TYPE_AGENT_STATUS_CHANGED: &str = "agent.status_changed";
 
 /// Convert a runtime [`ApprovalRequest`] into a JSON envelope for webhook delivery.
 pub fn approval_to_envelope(request: &ApprovalRequest) -> Value {
@@ -32,6 +33,29 @@ pub fn approval_to_envelope(request: &ApprovalRequest) -> Value {
                 "condition_triggered": request.condition_triggered,
                 "submitted_at": request.submitted_at,
                 "timeout_secs": request.timeout_secs,
+            }
+        }
+    })
+}
+
+/// Convert an [`OrphanEffect`] into a JSON envelope for the `agent.status_changed` event.
+pub fn agent_status_changed_to_envelope(
+    effect: &crate::registry::OrphanEffect,
+    reason: &str,
+) -> serde_json::Value {
+    let event_id = uuid::Uuid::now_v7().to_string();
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    json!({
+        "event_id": event_id,
+        "event_type": EVENT_TYPE_AGENT_STATUS_CHANGED,
+        "published_at": { "unix_ms": now_ms },
+        "source": "aa-gateway",
+        "payload": {
+            "agent_status_changed": {
+                "agent_id": effect.agent_id_str,
+                "old_status": effect.old_status,
+                "new_status": effect.new_status,
+                "reason": reason,
             }
         }
     })
@@ -145,6 +169,35 @@ mod tests {
         };
 
         let envelope = budget_alert_to_envelope(&alert);
+        let id_str = envelope["event_id"].as_str().unwrap();
+        let parsed = Uuid::parse_str(id_str).expect("valid UUID");
+        assert_eq!(parsed.get_version_num(), 7);
+    }
+
+    #[test]
+    fn agent_status_changed_envelope_has_correct_fields() {
+        let effect = crate::registry::OrphanEffect {
+            agent_key: [3u8; 16],
+            agent_id_str: "test-agent-id".to_string(),
+            action: "suspended",
+            old_status: "Active".to_string(),
+            new_status: "suspended:parent_deregistered".to_string(),
+        };
+
+        let envelope = agent_status_changed_to_envelope(&effect, "parent agent deregistered");
+
+        assert_eq!(envelope["event_type"], "agent.status_changed");
+        assert_eq!(envelope["source"], "aa-gateway");
+        assert_eq!(envelope["payload"]["agent_status_changed"]["agent_id"], "test-agent-id");
+        assert_eq!(envelope["payload"]["agent_status_changed"]["old_status"], "Active");
+        assert_eq!(
+            envelope["payload"]["agent_status_changed"]["new_status"],
+            "suspended:parent_deregistered"
+        );
+        assert_eq!(
+            envelope["payload"]["agent_status_changed"]["reason"],
+            "parent agent deregistered"
+        );
         let id_str = envelope["event_id"].as_str().unwrap();
         let parsed = Uuid::parse_str(id_str).expect("valid UUID");
         assert_eq!(parsed.get_version_num(), 7);

--- a/aa-gateway/src/events/publisher.rs
+++ b/aa-gateway/src/events/publisher.rs
@@ -39,10 +39,7 @@ pub fn approval_to_envelope(request: &ApprovalRequest) -> Value {
 }
 
 /// Convert an [`OrphanEffect`] into a JSON envelope for the `agent.status_changed` event.
-pub fn agent_status_changed_to_envelope(
-    effect: &crate::registry::OrphanEffect,
-    reason: &str,
-) -> serde_json::Value {
+pub fn agent_status_changed_to_envelope(effect: &crate::registry::OrphanEffect, reason: &str) -> serde_json::Value {
     let event_id = uuid::Uuid::now_v7().to_string();
     let now_ms = chrono::Utc::now().timestamp_millis();
     json!({

--- a/aa-gateway/src/registry/mod.rs
+++ b/aa-gateway/src/registry/mod.rs
@@ -6,10 +6,12 @@
 
 pub mod convert;
 pub mod lineage;
+pub mod orphan;
 pub mod store;
 pub mod token;
 
 pub use lineage::Lineage;
+pub use orphan::{OrphanEffect, OrphanMode};
 pub use store::{ActiveSession, AgentGraph, AgentRecord, AgentRegistry, RecentEvent};
 
 /// Errors returned by [`AgentRegistry`](store::AgentRegistry) operations.
@@ -52,6 +54,8 @@ pub enum SuspendReason {
         /// The direct parent that caused this cascading suspension.
         parent_agent_id: [u8; 16],
     },
+    /// Suspended because the parent agent deregistered. Manually resumable.
+    ParentDeregistered,
 }
 
 /// Runtime status of a registered agent.

--- a/aa-gateway/src/registry/orphan.rs
+++ b/aa-gateway/src/registry/orphan.rs
@@ -1,0 +1,28 @@
+//! Orphan handling policy applied when a parent agent deregisters.
+
+/// Policy controlling what happens to children when their parent deregisters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OrphanMode {
+    /// Suspend each orphaned child with reason `ParentDeregistered` (default).
+    #[default]
+    Suspend,
+    /// Promote each direct child to a root agent: clear parent link, reset depth to 0.
+    PromoteToRoot,
+    /// Recursively deregister all descendants.
+    CascadeDeregister,
+}
+
+/// Records what the registry did to one agent as a result of orphan handling.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OrphanEffect {
+    /// Registry key of the affected agent.
+    pub agent_key: [u8; 16],
+    /// Human-readable agent_id string of the affected agent.
+    pub agent_id_str: String,
+    /// What happened: `"suspended"`, `"promoted_to_root"`, or `"deregistered"`.
+    pub action: &'static str,
+    /// Previous status string for AgentStatusChanged event.
+    pub old_status: String,
+    /// New status string for AgentStatusChanged event.
+    pub new_status: String,
+}

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -12,7 +12,8 @@ use tonic::Status;
 use aa_proto::assembly::agent::v1::control_command::Command;
 use aa_proto::assembly::agent::v1::{ControlCommand, SuspendCommand};
 
-use super::{AgentStatus, LineageError, RegistryError};
+use super::{AgentStatus, LineageError, RegistryError, SuspendReason};
+use super::orphan::{OrphanEffect, OrphanMode};
 
 /// Maximum number of recent events retained per agent.
 pub const MAX_RECENT_EVENTS: usize = 20;
@@ -240,10 +241,18 @@ impl AgentRegistry {
         self.agents.get(agent_id).map(|r| r.clone())
     }
 
-    /// Remove an agent from the registry. Returns the removed record.
+    /// Remove an agent from the registry. Returns the removed record and a list of
+    /// [`OrphanEffect`]s describing what happened to each descendant under `mode`.
     ///
     /// Also removes any associated control stream sender.
-    pub fn deregister(&self, agent_id: &[u8; 16]) -> Result<AgentRecord, RegistryError> {
+    pub fn deregister(
+        &self,
+        agent_id: &[u8; 16],
+        mode: OrphanMode,
+    ) -> Result<(AgentRecord, Vec<OrphanEffect>), RegistryError> {
+        // Collect direct children keys BEFORE removing the agent.
+        let child_keys = self.children_of(agent_id);
+
         self.control_senders.remove(agent_id);
         let (_, record) = self.agents.remove(agent_id).ok_or(RegistryError::NotFound(*agent_id))?;
 
@@ -261,7 +270,106 @@ impl AgentRegistry {
             }
         }
 
-        Ok(record)
+        // Apply orphan policy to each direct child recursively.
+        let mut effects = Vec::new();
+        for child_key in child_keys {
+            self.apply_orphan_mode_recursive(child_key, mode, &mut effects);
+        }
+
+        Ok((record, effects))
+    }
+
+    /// Recursively apply `mode` to `child_key` and all its descendants.
+    ///
+    /// DashMap does not allow recursive locking — child keys are always collected
+    /// into a `Vec` before any mutation so there is no re-entrant `get_mut`.
+    fn apply_orphan_mode_recursive(
+        &self,
+        child_key: [u8; 16],
+        mode: OrphanMode,
+        effects: &mut Vec<OrphanEffect>,
+    ) {
+        match mode {
+            OrphanMode::Suspend => {
+                // Collect grandchildren BEFORE mutating this entry (avoid re-entrant lock).
+                let grandchildren = self.children_of(&child_key);
+
+                if let Some(mut entry) = self.agents.get_mut(&child_key) {
+                    let old_status = format!("{:?}", entry.status);
+                    entry.status = AgentStatus::Suspended(SuspendReason::ParentDeregistered);
+                    effects.push(OrphanEffect {
+                        agent_key: child_key,
+                        agent_id_str: uuid::Uuid::from_bytes(child_key).to_string(),
+                        action: "suspended",
+                        old_status,
+                        new_status: "suspended:parent_deregistered".to_string(),
+                    });
+                }
+
+                for gk in grandchildren {
+                    self.apply_orphan_mode_recursive(gk, mode, effects);
+                }
+            }
+
+            OrphanMode::PromoteToRoot => {
+                // Only direct children become new roots; their children keep relative structure.
+                if let Some(mut entry) = self.agents.get_mut(&child_key) {
+                    let old_status = format!("{:?}", entry.status);
+                    entry.parent_key = None;
+                    entry.parent_agent_id = None;
+                    entry.root_agent_id = None;
+                    entry.depth = 0;
+                    effects.push(OrphanEffect {
+                        agent_key: child_key,
+                        agent_id_str: uuid::Uuid::from_bytes(child_key).to_string(),
+                        action: "promoted_to_root",
+                        old_status,
+                        new_status: "active:root".to_string(),
+                    });
+                }
+
+                // Recalculate depth for this subtree now that the promoted child is depth 0.
+                self.recalculate_depth_recursive(child_key, 0);
+            }
+
+            OrphanMode::CascadeDeregister => {
+                // Post-order teardown: recurse into grandchildren first.
+                let grandchildren = self.children_of(&child_key);
+                for gk in grandchildren {
+                    self.apply_orphan_mode_recursive(gk, mode, effects);
+                }
+
+                // Now remove this child.
+                self.control_senders.remove(&child_key);
+                if let Some((_, record)) = self.agents.remove(&child_key) {
+                    if let Some(ref tid) = record.team_id {
+                        if let Some(set) = self.team_index.get(tid) {
+                            set.remove(&child_key);
+                        }
+                    }
+                    effects.push(OrphanEffect {
+                        agent_key: child_key,
+                        agent_id_str: uuid::Uuid::from_bytes(child_key).to_string(),
+                        action: "deregistered",
+                        old_status: format!("{:?}", record.status),
+                        new_status: "deregistered".to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    /// Recalculate `depth` for the entire subtree rooted at `parent_key`.
+    ///
+    /// Sets each immediate child's depth to `parent_depth + 1` and recurses.
+    fn recalculate_depth_recursive(&self, parent_key: [u8; 16], parent_depth: u32) {
+        let children = self.children_of(&parent_key);
+        for ck in children {
+            if let Some(mut entry) = self.agents.get_mut(&ck) {
+                entry.depth = parent_depth + 1;
+            }
+            self.recalculate_depth_recursive(ck, parent_depth + 1);
+        }
     }
 
     /// Update the `last_heartbeat` timestamp for an agent to now.
@@ -632,7 +740,7 @@ mod tree_tests {
         assert_eq!(reg.agent_depth(&child_id), Some(1));
 
         // deregister child — root's children cleared
-        reg.deregister(&child_id).unwrap();
+        reg.deregister(&child_id, crate::registry::OrphanMode::Suspend).unwrap();
         assert!(reg.children_of(&root_id).is_empty());
 
         // team_index updated

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -12,8 +12,8 @@ use tonic::Status;
 use aa_proto::assembly::agent::v1::control_command::Command;
 use aa_proto::assembly::agent::v1::{ControlCommand, SuspendCommand};
 
-use super::{AgentStatus, LineageError, RegistryError, SuspendReason};
 use super::orphan::{OrphanEffect, OrphanMode};
+use super::{AgentStatus, LineageError, RegistryError, SuspendReason};
 
 /// Maximum number of recent events retained per agent.
 pub const MAX_RECENT_EVENTS: usize = 20;
@@ -283,12 +283,7 @@ impl AgentRegistry {
     ///
     /// DashMap does not allow recursive locking — child keys are always collected
     /// into a `Vec` before any mutation so there is no re-entrant `get_mut`.
-    fn apply_orphan_mode_recursive(
-        &self,
-        child_key: [u8; 16],
-        mode: OrphanMode,
-        effects: &mut Vec<OrphanEffect>,
-    ) {
+    fn apply_orphan_mode_recursive(&self, child_key: [u8; 16], mode: OrphanMode, effects: &mut Vec<OrphanEffect>) {
         match mode {
             OrphanMode::Suspend => {
                 // Collect grandchildren BEFORE mutating this entry (avoid re-entrant lock).
@@ -1084,5 +1079,357 @@ mod cascade_tests {
         reg.suspend_with_cascade(&ROOT, SuspendReason::Manual).unwrap();
 
         assert_eq!(reg.agent_status(&SIBLING).unwrap(), AgentStatus::Active);
+    }
+}
+
+#[cfg(test)]
+mod orphan_mode_tests {
+    use super::*;
+    use crate::registry::{AgentStatus, OrphanMode, SuspendReason};
+
+    fn test_record(id: [u8; 16], parent_key: Option<[u8; 16]>, depth: u32) -> AgentRecord {
+        AgentRecord {
+            agent_id: id,
+            name: format!("agent-{}", id[0]),
+            framework: "test".into(),
+            version: "0.0.1".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key: "deadbeef".into(),
+            credential_token: "tok".into(),
+            metadata: Default::default(),
+            registered_at: chrono::Utc::now(),
+            last_heartbeat: chrono::Utc::now(),
+            status: AgentStatus::Active,
+            pid: None,
+            session_count: 0,
+            last_event: None,
+            policy_violations_count: 0,
+            active_sessions: vec![],
+            recent_events: Default::default(),
+            recent_traces: vec![],
+            layer: None,
+            governance_level: aa_core::GovernanceLevel::default(),
+            parent_agent_id: None,
+            team_id: None,
+            depth,
+            delegation_reason: None,
+            spawned_by_tool: None,
+            root_agent_id: None,
+            children: vec![],
+            parent_key,
+        }
+    }
+
+    fn key(n: u8) -> [u8; 16] {
+        let mut k = [0u8; 16];
+        k[0] = n;
+        k
+    }
+
+    #[test]
+    fn deregister_suspend_mode_suspends_direct_child() {
+        let reg = AgentRegistry::new();
+        let parent = key(1);
+        let child = key(2);
+
+        reg.register(test_record(parent, None, 0)).unwrap();
+        reg.register(test_record(child, Some(parent), 1)).unwrap();
+        // Wire up the parent→child link (register() does this automatically via post-insert).
+
+        let (_, effects) = reg.deregister(&parent, OrphanMode::Suspend).unwrap();
+
+        assert_eq!(effects.len(), 1);
+        assert_eq!(effects[0].action, "suspended");
+        assert_eq!(effects[0].agent_key, child);
+
+        let child_record = reg.get(&child).unwrap();
+        assert_eq!(
+            child_record.status,
+            AgentStatus::Suspended(SuspendReason::ParentDeregistered)
+        );
+    }
+
+    #[test]
+    fn deregister_suspend_mode_recurses_to_grandchild() {
+        let reg = AgentRegistry::new();
+        let root = key(1);
+        let child = key(2);
+        let grandchild = key(3);
+
+        reg.register(test_record(root, None, 0)).unwrap();
+        reg.register(test_record(child, Some(root), 1)).unwrap();
+        reg.register(test_record(grandchild, Some(child), 2)).unwrap();
+
+        let (_, effects) = reg.deregister(&root, OrphanMode::Suspend).unwrap();
+
+        // Both child and grandchild should be suspended.
+        assert_eq!(effects.len(), 2);
+        let actions: Vec<&str> = effects.iter().map(|e| e.action).collect();
+        assert!(actions.iter().all(|&a| a == "suspended"));
+
+        assert_eq!(
+            reg.get(&child).unwrap().status,
+            AgentStatus::Suspended(SuspendReason::ParentDeregistered)
+        );
+        assert_eq!(
+            reg.get(&grandchild).unwrap().status,
+            AgentStatus::Suspended(SuspendReason::ParentDeregistered)
+        );
+    }
+
+    #[test]
+    fn deregister_promote_to_root_clears_parent_link() {
+        let reg = AgentRegistry::new();
+        let parent = key(1);
+        let child = key(2);
+
+        reg.register(test_record(parent, None, 0)).unwrap();
+        reg.register(test_record(child, Some(parent), 1)).unwrap();
+
+        let (_, effects) = reg.deregister(&parent, OrphanMode::PromoteToRoot).unwrap();
+
+        assert_eq!(effects.len(), 1);
+        assert_eq!(effects[0].action, "promoted_to_root");
+
+        let child_record = reg.get(&child).unwrap();
+        assert!(child_record.parent_key.is_none());
+        assert!(child_record.parent_agent_id.is_none());
+        assert!(child_record.root_agent_id.is_none());
+        assert_eq!(child_record.depth, 0);
+    }
+
+    #[test]
+    fn deregister_promote_to_root_recalculates_grandchild_depth() {
+        let reg = AgentRegistry::new();
+        let root = key(1);
+        let child = key(2);
+        let grandchild = key(3);
+
+        reg.register(test_record(root, None, 0)).unwrap();
+        reg.register(test_record(child, Some(root), 1)).unwrap();
+        reg.register(test_record(grandchild, Some(child), 2)).unwrap();
+
+        let (_, effects) = reg.deregister(&root, OrphanMode::PromoteToRoot).unwrap();
+
+        // Only the direct child is promoted; grandchild depth recalculated.
+        assert_eq!(effects.len(), 1);
+        assert_eq!(effects[0].action, "promoted_to_root");
+
+        assert_eq!(reg.get(&child).unwrap().depth, 0);
+        assert_eq!(reg.get(&grandchild).unwrap().depth, 1);
+    }
+
+    #[test]
+    fn deregister_cascade_removes_all_descendants() {
+        let reg = AgentRegistry::new();
+        let root = key(1);
+        let child = key(2);
+        let grandchild = key(3);
+
+        reg.register(test_record(root, None, 0)).unwrap();
+        reg.register(test_record(child, Some(root), 1)).unwrap();
+        reg.register(test_record(grandchild, Some(child), 2)).unwrap();
+
+        let (_, effects) = reg.deregister(&root, OrphanMode::CascadeDeregister).unwrap();
+
+        // Both child and grandchild should be deregistered.
+        assert_eq!(effects.len(), 2);
+        let actions: Vec<&str> = effects.iter().map(|e| e.action).collect();
+        assert!(actions.iter().all(|&a| a == "deregistered"));
+
+        assert!(reg.get(&child).is_none());
+        assert!(reg.get(&grandchild).is_none());
+    }
+
+    #[test]
+    fn deregister_no_children_is_unchanged() {
+        let reg = AgentRegistry::new();
+        let agent = key(1);
+
+        reg.register(test_record(agent, None, 0)).unwrap();
+
+        let (record, effects) = reg.deregister(&agent, OrphanMode::Suspend).unwrap();
+
+        assert_eq!(record.agent_id, agent);
+        assert!(effects.is_empty());
+        assert!(reg.get(&agent).is_none());
+    }
+
+    #[test]
+    fn deregister_already_suspended_child_stays_suspended_under_suspend_mode() {
+        let reg = AgentRegistry::new();
+        let parent = key(1);
+        let child = key(2);
+
+        reg.register(test_record(parent, None, 0)).unwrap();
+        reg.register(test_record(child, Some(parent), 1)).unwrap();
+
+        // Pre-suspend the child for a different reason.
+        reg.suspend_agent(&child, SuspendReason::Manual).unwrap();
+        assert_eq!(
+            reg.get(&child).unwrap().status,
+            AgentStatus::Suspended(SuspendReason::Manual)
+        );
+
+        // Deregistering the parent overwrites with ParentDeregistered.
+        let (_, effects) = reg.deregister(&parent, OrphanMode::Suspend).unwrap();
+
+        assert_eq!(effects.len(), 1);
+        assert_eq!(effects[0].action, "suspended");
+        // Status is now ParentDeregistered (overwritten).
+        assert_eq!(
+            reg.get(&child).unwrap().status,
+            AgentStatus::Suspended(SuspendReason::ParentDeregistered)
+        );
+    }
+}
+
+#[cfg(test)]
+mod cross_mode_integration {
+    use super::*;
+    use crate::registry::{AgentStatus, OrphanMode, SuspendReason};
+
+    fn key(n: u8) -> [u8; 16] {
+        let mut k = [0u8; 16];
+        k[0] = n;
+        k
+    }
+
+    fn test_record(id: [u8; 16], parent_key: Option<[u8; 16]>, depth: u32) -> AgentRecord {
+        AgentRecord {
+            agent_id: id,
+            name: format!("agent-{}", id[0]),
+            framework: "test".into(),
+            version: "0.0.1".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key: "deadbeef".into(),
+            credential_token: "tok".into(),
+            metadata: Default::default(),
+            registered_at: chrono::Utc::now(),
+            last_heartbeat: chrono::Utc::now(),
+            status: AgentStatus::Active,
+            pid: None,
+            session_count: 0,
+            last_event: None,
+            policy_violations_count: 0,
+            active_sessions: vec![],
+            recent_events: Default::default(),
+            recent_traces: vec![],
+            layer: None,
+            governance_level: aa_core::GovernanceLevel::default(),
+            parent_agent_id: None,
+            team_id: None,
+            depth,
+            delegation_reason: None,
+            spawned_by_tool: None,
+            root_agent_id: None,
+            children: vec![],
+            parent_key,
+        }
+    }
+
+    /// Build a 3-level balanced tree of 13 agents:
+    ///   root (key 1)
+    ///     ├── child-A (key 2) → grandchildren 5, 6, 7
+    ///     ├── child-B (key 3) → grandchildren 8, 9, 10
+    ///     └── child-C (key 4) → grandchildren 11, 12, 13
+    fn build_balanced_tree() -> AgentRegistry {
+        let reg = AgentRegistry::new();
+        let root = key(1);
+        reg.register(test_record(root, None, 0)).unwrap();
+
+        // Level-1: direct children of root
+        for n in 2u8..=4 {
+            reg.register(test_record(key(n), Some(root), 1)).unwrap();
+        }
+
+        // Level-2: 3 grandchildren per level-1 node
+        //   key(2) → 5,6,7 | key(3) → 8,9,10 | key(4) → 11,12,13
+        let mut gc: u8 = 5;
+        for parent_n in 2u8..=4 {
+            for _ in 0..3 {
+                reg.register(test_record(key(gc), Some(key(parent_n)), 2)).unwrap();
+                gc += 1;
+            }
+        }
+        reg
+    }
+
+    const DESCENDANT_KEYS: [u8; 12] = [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13];
+    const LEVEL1_KEYS: [u8; 3] = [2, 3, 4];
+    const LEVEL2_KEYS: [u8; 9] = [5, 6, 7, 8, 9, 10, 11, 12, 13];
+
+    #[test]
+    fn balanced_tree_suspend_mode_suspends_all_12_descendants() {
+        let reg = build_balanced_tree();
+        let root = key(1);
+
+        let (_, effects) = reg.deregister(&root, OrphanMode::Suspend).unwrap();
+
+        assert_eq!(effects.len(), 12, "expect one effect per descendant");
+        assert!(
+            effects.iter().all(|e| e.action == "suspended"),
+            "all effects must be 'suspended'"
+        );
+
+        for n in DESCENDANT_KEYS {
+            assert_eq!(
+                reg.get(&key(n)).unwrap().status,
+                AgentStatus::Suspended(SuspendReason::ParentDeregistered),
+                "key {n} must be suspended with ParentDeregistered"
+            );
+        }
+        assert!(reg.get(&root).is_none(), "root must be removed");
+    }
+
+    #[test]
+    fn balanced_tree_promote_to_root_mode_makes_3_new_roots() {
+        let reg = build_balanced_tree();
+        let root = key(1);
+
+        let (_, effects) = reg.deregister(&root, OrphanMode::PromoteToRoot).unwrap();
+
+        // Only direct children are promoted (3 effects).
+        assert_eq!(effects.len(), 3, "expect one effect per direct child");
+        assert!(
+            effects.iter().all(|e| e.action == "promoted_to_root"),
+            "all effects must be 'promoted_to_root'"
+        );
+
+        for n in LEVEL1_KEYS {
+            let record = reg.get(&key(n)).expect("level-1 child must still exist");
+            assert!(record.parent_key.is_none(), "key {n} parent_key must be None");
+            assert!(record.parent_agent_id.is_none(), "key {n} parent_agent_id must be None");
+            assert!(record.root_agent_id.is_none(), "key {n} root_agent_id must be None");
+            assert_eq!(record.depth, 0, "key {n} must be promoted to depth 0");
+        }
+
+        for n in LEVEL2_KEYS {
+            let record = reg.get(&key(n)).expect("level-2 grandchild must still exist");
+            assert_eq!(record.depth, 1, "key {n} must be at depth 1 after promotion");
+        }
+
+        assert!(reg.get(&root).is_none(), "root must be removed");
+    }
+
+    #[test]
+    fn balanced_tree_cascade_deregister_mode_removes_all_12_descendants() {
+        let reg = build_balanced_tree();
+        let root = key(1);
+
+        let (_, effects) = reg.deregister(&root, OrphanMode::CascadeDeregister).unwrap();
+
+        assert_eq!(effects.len(), 12, "expect one effect per descendant");
+        assert!(
+            effects.iter().all(|e| e.action == "deregistered"),
+            "all effects must be 'deregistered'"
+        );
+
+        for n in DESCENDANT_KEYS {
+            assert!(reg.get(&key(n)).is_none(), "key {n} must be removed from registry");
+        }
+        assert!(reg.get(&root).is_none(), "root must be removed");
     }
 }

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -15,10 +15,10 @@ use aa_proto::assembly::agent::v1::{
 use aa_proto::assembly::common::v1::AgentId as ProtoAgentId;
 
 use crate::engine::PolicyEngine;
+use crate::events::publisher::agent_status_changed_to_envelope;
 use crate::registry::convert::{proto_agent_id_to_key, validate_proto_agent_id};
 use crate::registry::store::AgentRecord;
 use crate::registry::token::{generate_credential_token, validate_token};
-use crate::events::publisher::agent_status_changed_to_envelope;
 use crate::registry::{AgentRegistry, AgentStatus, LineageError, OrphanMode, RegistryError, SuspendReason};
 
 /// Default heartbeat interval returned to agents at registration (seconds).

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -18,7 +18,8 @@ use crate::engine::PolicyEngine;
 use crate::registry::convert::{proto_agent_id_to_key, validate_proto_agent_id};
 use crate::registry::store::AgentRecord;
 use crate::registry::token::{generate_credential_token, validate_token};
-use crate::registry::{AgentRegistry, AgentStatus, LineageError, RegistryError, SuspendReason};
+use crate::events::publisher::agent_status_changed_to_envelope;
+use crate::registry::{AgentRegistry, AgentStatus, LineageError, OrphanMode, RegistryError, SuspendReason};
 
 /// Default heartbeat interval returned to agents at registration (seconds).
 const DEFAULT_HEARTBEAT_INTERVAL_SEC: i64 = 30;
@@ -226,9 +227,20 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
         validate_token(&self.registry, &agent_key, &req.credential_token)
             .map_err(|_| Status::unauthenticated("invalid credential token"))?;
 
-        self.registry
-            .deregister(&agent_key)
+        let (_, effects) = self
+            .registry
+            .deregister(&agent_key, OrphanMode::Suspend)
             .map_err(|e| Status::not_found(e.to_string()))?;
+
+        for effect in &effects {
+            let envelope = agent_status_changed_to_envelope(effect, "parent agent deregistered");
+            tracing::debug!(
+                agent_id = %effect.agent_id_str,
+                action = %effect.action,
+                %envelope,
+                "orphan effect applied"
+            );
+        }
 
         tracing::info!(agent_id = ?proto_id.agent_id, reason = %req.reason, "agent deregistered");
 

--- a/aa-gateway/tests/registry_test.rs
+++ b/aa-gateway/tests/registry_test.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, VecDeque};
 use chrono::Utc;
 
 use aa_gateway::registry::store::AgentRecord;
-use aa_gateway::registry::{AgentRegistry, AgentStatus};
+use aa_gateway::registry::{AgentRegistry, AgentStatus, OrphanMode};
 
 /// Build a minimal `AgentRecord` with the given 16-byte key.
 fn make_record(key: [u8; 16]) -> AgentRecord {
@@ -86,7 +86,7 @@ fn deregister_removes_agent() {
     let reg = AgentRegistry::new();
     reg.register(make_record(key(1))).unwrap();
 
-    let removed = reg.deregister(&key(1)).unwrap();
+    let (removed, _effects) = reg.deregister(&key(1), OrphanMode::Suspend).unwrap();
     assert_eq!(removed.name, "test-agent");
     assert!(reg.get(&key(1)).is_none());
 }
@@ -94,7 +94,7 @@ fn deregister_removes_agent() {
 #[test]
 fn deregister_missing_returns_error() {
     let reg = AgentRegistry::new();
-    let err = reg.deregister(&key(1));
+    let err = reg.deregister(&key(1), OrphanMode::Suspend);
     assert!(err.is_err());
     assert!(err.unwrap_err().to_string().contains("not found"));
 }
@@ -188,7 +188,7 @@ async fn deregister_cleans_up_control_sender() {
     reg.register(make_record(key(1))).unwrap();
     let _rx = reg.open_control_stream(&key(1)).unwrap();
 
-    reg.deregister(&key(1)).unwrap();
+    reg.deregister(&key(1), OrphanMode::Suspend).unwrap();
 
     // send_command should fail since sender was removed
     let cmd = ControlCommand {


### PR DESCRIPTION
## Summary

- Extends `AgentRegistry::deregister()` to accept an `OrphanMode` parameter controlling what happens to child agents when their parent deregisters
- Implements three orphan policies: `Suspend` (default — marks children `ParentDeregistered`), `PromoteToRoot` (clears parent link, resets depth to 0), and `CascadeDeregister` (post-order recursive removal)
- Adds `OrphanEffect` result type so callers can observe what happened to each affected descendant; wires effect logging into the lifecycle gRPC service and HTTP API deregister handlers

## Changes

| File | Change |
|---|---|
| `aa-gateway/src/registry/orphan.rs` | New: `OrphanMode` enum + `OrphanEffect` struct |
| `aa-gateway/src/registry/mod.rs` | Export `OrphanMode`/`OrphanEffect`; add `SuspendReason::ParentDeregistered` |
| `aa-gateway/src/registry/store.rs` | Extend `deregister()` signature; add `apply_orphan_mode_recursive()` and `recalculate_depth_recursive()`; 10 unit + 3 cross-mode integration tests |
| `aa-gateway/src/events/publisher.rs` | Add `agent_status_changed_to_envelope()` for orphan events |
| `aa-gateway/src/service/lifecycle_service.rs` | Pass `OrphanMode::Suspend` to `deregister()`; log `OrphanEffect`s |
| `aa-api/src/routes/agents.rs` | Pass `OrphanMode::Suspend` to `deregister()` in HTTP DELETE handler |
| `aa-gateway/tests/registry_test.rs` | Update 3 existing deregister call sites for new signature |

## Test plan

- [x] `cargo nextest run -p aa-gateway` — 514/514 pass
- [x] `cargo clippy -p aa-gateway --all-targets -- -D warnings` — clean
- [ ] Verify `OrphanMode::PromoteToRoot` and `OrphanMode::CascadeDeregister` are exposed in the gRPC `DeregisterRequest` proto for callers to select the mode (follow-up: currently defaults to `Suspend`)

## Related

Closes AAASM-210
Closes AAASM-948
Closes AAASM-950
Closes AAASM-953