### PR TITLE
[AAASM-1095] ✨ (scripts): Add scripts/install.sh toolchain prerequisite checker

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Toolchain prerequisite checker for agent-assembly.
+# Checks for required tools and emits friendly install instructions for anything missing.
+# Usage: bash scripts/install.sh [--quiet]
+set -euo pipefail
+
+QUIET=0
+for arg in "$@"; do
+  case "$arg" in
+    --quiet) QUIET=1 ;;
+  esac
+done
+
+PASS=0
+FAIL=0
+
+# _ver_gte <actual> <required>
+# Returns 0 (true) when actual >= required using dot-separated version comparison.
+_ver_gte() {
+  # Split both versions into major/minor/patch components, compare numerically.
+  local actual="$1" required="$2"
+  local IFS=.
+  # shellcheck disable=SC2206
+  local a=($actual) r=($required)
+  local i
+  for i in 0 1 2; do
+    local av="${a[$i]:-0}" rv="${r[$i]:-0}"
+    if [ "$av" -gt "$rv" ]; then return 0; fi
+    if [ "$av" -lt "$rv" ]; then return 1; fi
+  done
+  return 0
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -68,13 +68,59 @@ _check_tool() {
   fi
 }
 
+# --- Install hint functions -------------------------------------------------
+_hint_rustc() {
+  echo ""
+  echo "  ► rustc / cargo  (install via rustup):"
+  echo "    macOS/Linux : curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+  echo "    URL         : https://rustup.rs"
+  echo ""
+}
+
+_hint_python3() {
+  echo ""
+  echo "  ► python3 >= 3.11:"
+  echo "    macOS       : brew install python@3.11"
+  echo "    Linux (deb) : sudo apt-get install -y python3.11"
+  echo "    Linux (rpm) : sudo dnf install -y python3.11"
+  echo "    URL         : https://www.python.org/downloads/"
+  echo ""
+}
+
+_hint_node() {
+  echo ""
+  echo "  ► node >= 20:"
+  echo "    macOS       : brew install node@20"
+  echo "    Linux       : curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash - && sudo apt-get install -y nodejs"
+  echo "    URL         : https://nodejs.org/en/download/"
+  echo ""
+}
+
+_hint_go() {
+  echo ""
+  echo "  ► go >= 1.22:"
+  echo "    macOS       : brew install go"
+  echo "    Linux       : sudo apt-get install -y golang-1.22"
+  echo "    URL         : https://go.dev/dl/"
+  echo ""
+}
+
+_hint_docker() {
+  echo ""
+  echo "  ► docker >= 24:"
+  echo "    macOS       : brew install --cask docker"
+  echo "    Linux       : sudo apt-get install -y docker.io"
+  echo "    URL         : https://docs.docker.com/get-docker/"
+  echo ""
+}
+
 # --- Toolchain checks -------------------------------------------------------
 echo "Checking required toolchains..."
 echo ""
 
-_check_tool "rustc"   "rustc"   "1.75" "rustc --version"   || true
-_check_tool "cargo"   "cargo"   "0"    "cargo --version"   || true
-_check_tool "python3" "python3" "3.11" "python3 --version" || true
-_check_tool "node"    "node"    "20"   "node --version"    || true
-_check_tool "go"      "go"      "1.22" "go version"        || true
-_check_tool "docker"  "docker"  "24"   "docker --version"  || true
+_check_tool "rustc"   "rustc"   "1.75" "rustc --version"   || _hint_rustc
+_check_tool "cargo"   "cargo"   "0"    "cargo --version"   || _hint_rustc
+_check_tool "python3" "python3" "3.11" "python3 --version" || _hint_python3
+_check_tool "node"    "node"    "20"   "node --version"    || _hint_node
+_check_tool "go"      "go"      "1.22" "go version"        || _hint_go
+_check_tool "docker"  "docker"  "24"   "docker --version"  || _hint_docker

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -30,3 +30,51 @@ _ver_gte() {
   done
   return 0
 }
+
+# _check_tool <label> <binary> <min_version> <version_cmd>
+# Extracts the first version-like token from <version_cmd> output and compares
+# it against <min_version>. Sets PASS/FAIL and prints result line.
+_check_tool() {
+  local label="$1" binary="$2" min_ver="$3" ver_cmd="$4"
+
+  if ! command -v "$binary" >/dev/null 2>&1; then
+    echo "  MISSING  $label (required >= $min_ver)"
+    FAIL=$((FAIL + 1))
+    return 1
+  fi
+
+  local raw
+  raw=$(eval "$ver_cmd" 2>&1 | head -1)
+  # Extract first token that looks like a version number (digits and dots).
+  local actual
+  actual=$(printf '%s' "$raw" | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)
+
+  if [ -z "$actual" ]; then
+    echo "  UNKNOWN  $label (could not parse version from: $raw)"
+    FAIL=$((FAIL + 1))
+    return 1
+  fi
+
+  if _ver_gte "$actual" "$min_ver"; then
+    if [ "$QUIET" -eq 0 ]; then
+      echo "  OK       $label $actual (>= $min_ver)"
+    fi
+    PASS=$((PASS + 1))
+    return 0
+  else
+    echo "  OLD      $label $actual (required >= $min_ver)"
+    FAIL=$((FAIL + 1))
+    return 1
+  fi
+}
+
+# --- Toolchain checks -------------------------------------------------------
+echo "Checking required toolchains..."
+echo ""
+
+_check_tool "rustc"   "rustc"   "1.75" "rustc --version"   || true
+_check_tool "cargo"   "cargo"   "0"    "cargo --version"   || true
+_check_tool "python3" "python3" "3.11" "python3 --version" || true
+_check_tool "node"    "node"    "20"   "node --version"    || true
+_check_tool "go"      "go"      "1.22" "go version"        || true
+_check_tool "docker"  "docker"  "24"   "docker --version"  || true

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -124,3 +124,16 @@ _check_tool "python3" "python3" "3.11" "python3 --version" || _hint_python3
 _check_tool "node"    "node"    "20"   "node --version"    || _hint_node
 _check_tool "go"      "go"      "1.22" "go version"        || _hint_go
 _check_tool "docker"  "docker"  "24"   "docker --version"  || _hint_docker
+
+# --- Summary ----------------------------------------------------------------
+echo ""
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -eq 0 ]; then
+  if [ "$QUIET" -eq 0 ]; then
+    echo "OK: $PASS/$TOTAL toolchains satisfied"
+  fi
+  exit 0
+else
+  echo "ERROR: $FAIL/$TOTAL toolchains missing or out of date — see hints above"
+  exit 1
+fi

--- a/tests/install_sh.bats
+++ b/tests/install_sh.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+# bats tests for scripts/install.sh
+# Run with: bats tests/install_sh.bats
+# Install bats-core: brew install bats-core  |  apt-get install bats
+
+INSTALL_SH="$BATS_TEST_DIRNAME/../scripts/install.sh"
+
+# ---------------------------------------------------------------------------
+# Helper: write a stub binary that prints a fixed version string, place it
+# first on PATH so install.sh finds it instead of the real binary.
+# ---------------------------------------------------------------------------
+setup() {
+  STUB_DIR="$(mktemp -d)"
+  export PATH="$STUB_DIR:$PATH"
+}
+
+teardown() {
+  rm -rf "$STUB_DIR"
+}
+
+_stub() {
+  local name="$1" output="$2"
+  printf '#!/bin/sh\necho "%s"\n' "$output" >"$STUB_DIR/$name"
+  chmod +x "$STUB_DIR/$name"
+}
+
+# ---------------------------------------------------------------------------
+# All 6 tools present at or above required versions → exit 0
+# ---------------------------------------------------------------------------
+@test "all tools present at required versions exits 0" {
+  _stub rustc   "rustc 1.80.0 (abc 2024)"
+  _stub cargo   "cargo 1.80.0"
+  _stub python3 "Python 3.12.0"
+  _stub node    "v20.0.0"
+  _stub go      "go version go1.22.0 darwin/arm64"
+  _stub docker  "Docker version 24.0.0, build abc"
+
+  run bash "$INSTALL_SH"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"OK: 6/6 toolchains satisfied"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# One tool missing → exit 1, hint printed
+# ---------------------------------------------------------------------------
+@test "one missing tool exits 1 and prints install hint" {
+  _stub rustc   "rustc 1.80.0"
+  _stub cargo   "cargo 1.80.0"
+  _stub python3 "Python 3.12.0"
+  # node intentionally absent (not stubbed)
+  _stub go      "go version go1.22.0 darwin/arm64"
+  _stub docker  "Docker version 24.0.0, build abc"
+
+  # Make sure real node is not reachable
+  rm -f "$STUB_DIR/node"
+
+  run bash "$INSTALL_SH"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"MISSING  node"* ]]
+  [[ "$output" == *"nodejs.org"* ]]
+  [[ "$output" == *"ERROR: 1/6"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Tool present but version below minimum → exit 1, OLD line printed
+# ---------------------------------------------------------------------------
+@test "tool at version below minimum exits 1 and prints OLD line" {
+  _stub rustc   "rustc 1.60.0"
+  _stub cargo   "cargo 1.60.0"
+  _stub python3 "Python 3.12.0"
+  _stub node    "v20.0.0"
+  _stub go      "go version go1.22.0 darwin/arm64"
+  _stub docker  "Docker version 24.0.0, build abc"
+
+  run bash "$INSTALL_SH"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"OLD      rustc 1.60.0"* ]]
+  [[ "$output" == *"rustup.rs"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# --quiet flag suppresses OK lines but keeps error output
+# ---------------------------------------------------------------------------
+@test "--quiet suppresses OK lines and keeps error blocks" {
+  _stub rustc   "rustc 1.80.0"
+  _stub cargo   "cargo 1.80.0"
+  _stub python3 "Python 3.12.0"
+  _stub node    "v20.0.0"
+  # go absent
+  _stub docker  "Docker version 24.0.0, build abc"
+
+  run bash "$INSTALL_SH" --quiet
+  [ "$status" -eq 1 ]
+  [[ "$output" != *"OK       rustc"* ]]
+  [[ "$output" == *"MISSING  go"* ]]
+}


### PR DESCRIPTION
## Description

Adds `scripts/install.sh` — a Bash 3.2-compatible toolchain prerequisite checker that detects whether all 6 required tools (`rustc`, `cargo`, `python3`, `node`, `go`, `docker`) are present at their minimum required versions, and prints friendly per-tool install hints (macOS/Linux/URL) for anything missing or out of date.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1095
- Parent story: AAASM-109

## Testing

- [x] Unit tests added / updated — `tests/install_sh.bats` covers: all-present (exit 0), one-missing (exit 1 + hint), version-too-low (exit 1 + OLD line), `--quiet` flag behaviour
- [x] Manual testing performed — smoke-tested on macOS; all present tools detected correctly, missing `go` shows hint and exits 1

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

## Commit log

- `✨ (scripts): Add check_tool() semver version-comparison helper in install.sh`
- `✨ (scripts): Add 6-toolchain version checks (rustc, cargo, python3, node, go, docker)`
- `✨ (scripts): Add per-tool macOS/Linux/URL install hint blocks`
- `✨ (scripts): Add --quiet flag and OK/failure summary line to install.sh`
- `✅ (tests): Add bats tests for install.sh (all-present, one-missing, version-too-low)`