### PR TITLE
[AAASM-1027] ✨ (aa-gateway): Add TopologyService proto + service skeleton returning Unimplemented

### DIFF
--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -9,12 +9,13 @@ use tonic::transport::Server;
 use crate::audit::AuditWriter;
 use crate::engine::PolicyEngine;
 use crate::registry::AgentRegistry;
-use crate::service::{AgentLifecycleServiceImpl, ApprovalServiceImpl, AuditServiceImpl, PolicyServiceImpl};
+use crate::service::{AgentLifecycleServiceImpl, ApprovalServiceImpl, AuditServiceImpl, PolicyServiceImpl, TopologyServiceImpl};
 use aa_core::{AuditEntry, AuditEventType};
 use aa_proto::assembly::agent::v1::agent_lifecycle_service_server::AgentLifecycleServiceServer;
 use aa_proto::assembly::approval::v1::approval_service_server::ApprovalServiceServer;
 use aa_proto::assembly::audit::v1::audit_service_server::AuditServiceServer;
 use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
+use aa_proto::assembly::topology::v1::topology_service_server::TopologyServiceServer;
 use tokio::sync::broadcast;
 
 use aa_runtime::approval::ApprovalQueue;
@@ -255,6 +256,7 @@ pub async fn serve_tcp(
         initial_hash,
     );
     let audit_svc = AuditServiceImpl::new_with_registry(audit_tx, audit_drops, initial_hash, Arc::clone(&registry));
+    let topology_svc = TopologyServiceImpl::new(Arc::clone(&registry));
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);
     let approval_svc = ApprovalServiceImpl::new_with_escalation(approval_queue, escalation_scheduler);
 
@@ -266,6 +268,7 @@ pub async fn serve_tcp(
         .add_service(AuditServiceServer::new(audit_svc))
         .add_service(AgentLifecycleServiceServer::new(lifecycle_svc))
         .add_service(ApprovalServiceServer::new(approval_svc))
+        .add_service(TopologyServiceServer::new(topology_svc))
         .serve_with_shutdown(addr, shutdown_signal())
         .await?;
 
@@ -308,6 +311,7 @@ pub async fn serve_uds(
         initial_hash,
     );
     let audit_svc = AuditServiceImpl::new_with_registry(audit_tx, audit_drops, initial_hash, Arc::clone(&registry));
+    let topology_svc = TopologyServiceImpl::new(Arc::clone(&registry));
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);
     let approval_svc = ApprovalServiceImpl::new_with_escalation(approval_queue, escalation_scheduler);
 
@@ -325,6 +329,7 @@ pub async fn serve_uds(
         .add_service(AuditServiceServer::new(audit_svc))
         .add_service(AgentLifecycleServiceServer::new(lifecycle_svc))
         .add_service(ApprovalServiceServer::new(approval_svc))
+        .add_service(TopologyServiceServer::new(topology_svc))
         .serve_with_incoming_shutdown(incoming, shutdown_signal())
         .await?;
 

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -9,7 +9,9 @@ use tonic::transport::Server;
 use crate::audit::AuditWriter;
 use crate::engine::PolicyEngine;
 use crate::registry::AgentRegistry;
-use crate::service::{AgentLifecycleServiceImpl, ApprovalServiceImpl, AuditServiceImpl, PolicyServiceImpl, TopologyServiceImpl};
+use crate::service::{
+    AgentLifecycleServiceImpl, ApprovalServiceImpl, AuditServiceImpl, PolicyServiceImpl, TopologyServiceImpl,
+};
 use aa_core::{AuditEntry, AuditEventType};
 use aa_proto::assembly::agent::v1::agent_lifecycle_service_server::AgentLifecycleServiceServer;
 use aa_proto::assembly::approval::v1::approval_service_server::ApprovalServiceServer;

--- a/aa-gateway/src/service/mod.rs
+++ b/aa-gateway/src/service/mod.rs
@@ -5,8 +5,10 @@ pub mod audit_service;
 pub mod convert;
 pub mod lifecycle_service;
 pub mod policy_service;
+pub mod topology_service;
 
 pub use approval_service::ApprovalServiceImpl;
 pub use audit_service::AuditServiceImpl;
 pub use lifecycle_service::AgentLifecycleServiceImpl;
 pub use policy_service::PolicyServiceImpl;
+pub use topology_service::TopologyServiceImpl;

--- a/aa-gateway/src/service/topology_service.rs
+++ b/aa-gateway/src/service/topology_service.rs
@@ -17,6 +17,8 @@ use crate::registry::AgentRegistry;
 /// All RPCs are currently unimplemented stubs — handlers are wired in subsequent
 /// subtasks (AAASM-1029, AAASM-1030).
 pub struct TopologyServiceImpl {
+    // Suppressed: field is read by RPC handlers added in AAASM-1029 and AAASM-1030.
+    #[allow(dead_code)]
     registry: Arc<AgentRegistry>,
 }
 

--- a/aa-gateway/src/service/topology_service.rs
+++ b/aa-gateway/src/service/topology_service.rs
@@ -1,0 +1,51 @@
+//! `TopologyServiceImpl` tonic trait implementation for agent graph queries.
+
+use std::sync::Arc;
+
+use tonic::{Request, Response, Status};
+
+use aa_proto::assembly::topology::v1::topology_service_server::TopologyService;
+use aa_proto::assembly::topology::v1::{
+    GetAgentTreeRequest, GetAgentTreeResponse, GetLineageRequest, GetLineageResponse,
+    GetTeamMembersRequest, GetTeamMembersResponse,
+};
+
+use crate::registry::AgentRegistry;
+
+/// gRPC service implementation for topology queries.
+///
+/// All RPCs are currently unimplemented stubs — handlers are wired in subsequent
+/// subtasks (AAASM-1029, AAASM-1030).
+pub struct TopologyServiceImpl {
+    registry: Arc<AgentRegistry>,
+}
+
+impl TopologyServiceImpl {
+    pub fn new(registry: Arc<AgentRegistry>) -> Self {
+        Self { registry }
+    }
+}
+
+#[tonic::async_trait]
+impl TopologyService for TopologyServiceImpl {
+    async fn get_agent_tree(
+        &self,
+        _request: Request<GetAgentTreeRequest>,
+    ) -> Result<Response<GetAgentTreeResponse>, Status> {
+        Err(Status::unimplemented("GetAgentTree not yet implemented"))
+    }
+
+    async fn get_lineage(
+        &self,
+        _request: Request<GetLineageRequest>,
+    ) -> Result<Response<GetLineageResponse>, Status> {
+        Err(Status::unimplemented("GetLineage not yet implemented"))
+    }
+
+    async fn get_team_members(
+        &self,
+        _request: Request<GetTeamMembersRequest>,
+    ) -> Result<Response<GetTeamMembersResponse>, Status> {
+        Err(Status::unimplemented("GetTeamMembers not yet implemented"))
+    }
+}

--- a/aa-gateway/src/service/topology_service.rs
+++ b/aa-gateway/src/service/topology_service.rs
@@ -6,8 +6,8 @@ use tonic::{Request, Response, Status};
 
 use aa_proto::assembly::topology::v1::topology_service_server::TopologyService;
 use aa_proto::assembly::topology::v1::{
-    GetAgentTreeRequest, GetAgentTreeResponse, GetLineageRequest, GetLineageResponse,
-    GetTeamMembersRequest, GetTeamMembersResponse,
+    GetAgentTreeRequest, GetAgentTreeResponse, GetLineageRequest, GetLineageResponse, GetTeamMembersRequest,
+    GetTeamMembersResponse,
 };
 
 use crate::registry::AgentRegistry;
@@ -37,10 +37,7 @@ impl TopologyService for TopologyServiceImpl {
         Err(Status::unimplemented("GetAgentTree not yet implemented"))
     }
 
-    async fn get_lineage(
-        &self,
-        _request: Request<GetLineageRequest>,
-    ) -> Result<Response<GetLineageResponse>, Status> {
+    async fn get_lineage(&self, _request: Request<GetLineageRequest>) -> Result<Response<GetLineageResponse>, Status> {
         Err(Status::unimplemented("GetLineage not yet implemented"))
     }
 

--- a/aa-gateway/tests/topology_service_test.rs
+++ b/aa-gateway/tests/topology_service_test.rs
@@ -1,0 +1,87 @@
+//! Unit tests for the TopologyService skeleton — each RPC must return Code::Unimplemented.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use aa_gateway::registry::AgentRegistry;
+use aa_gateway::service::TopologyServiceImpl;
+use aa_proto::assembly::topology::v1::topology_service_client::TopologyServiceClient;
+use aa_proto::assembly::topology::v1::topology_service_server::TopologyServiceServer;
+use aa_proto::assembly::topology::v1::{GetAgentTreeRequest, GetLineageRequest, GetTeamMembersRequest};
+use tokio::net::TcpListener;
+use tonic::transport::Server;
+use tonic::Code;
+
+// ── Helper ─────────────────────────────────────────────────────────────────
+
+async fn start_server() -> (SocketAddr, Arc<AgentRegistry>) {
+    let registry = Arc::new(AgentRegistry::new());
+    let service = TopologyServiceImpl::new(Arc::clone(&registry));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(TopologyServiceServer::new(service))
+            .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+            .await
+            .unwrap();
+    });
+
+    (addr, registry)
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn get_agent_tree_returns_unimplemented() {
+    let (addr, _registry) = start_server().await;
+    let mut client = TopologyServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let status = client
+        .get_agent_tree(GetAgentTreeRequest {
+            agent_id: "deadbeef".into(),
+            max_depth: 0,
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(status.code(), Code::Unimplemented);
+}
+
+#[tokio::test]
+async fn get_lineage_returns_unimplemented() {
+    let (addr, _registry) = start_server().await;
+    let mut client = TopologyServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let status = client
+        .get_lineage(GetLineageRequest {
+            agent_id: "deadbeef".into(),
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(status.code(), Code::Unimplemented);
+}
+
+#[tokio::test]
+async fn get_team_members_returns_unimplemented() {
+    let (addr, _registry) = start_server().await;
+    let mut client = TopologyServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let status = client
+        .get_team_members(GetTeamMembersRequest {
+            team_id: "team-alpha".into(),
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(status.code(), Code::Unimplemented);
+}

--- a/aa-gateway/tests/topology_service_test.rs
+++ b/aa-gateway/tests/topology_service_test.rs
@@ -37,9 +37,7 @@ async fn start_server() -> (SocketAddr, Arc<AgentRegistry>) {
 #[tokio::test]
 async fn get_agent_tree_returns_unimplemented() {
     let (addr, _registry) = start_server().await;
-    let mut client = TopologyServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = TopologyServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let status = client
         .get_agent_tree(GetAgentTreeRequest {
@@ -55,9 +53,7 @@ async fn get_agent_tree_returns_unimplemented() {
 #[tokio::test]
 async fn get_lineage_returns_unimplemented() {
     let (addr, _registry) = start_server().await;
-    let mut client = TopologyServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = TopologyServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let status = client
         .get_lineage(GetLineageRequest {
@@ -72,9 +68,7 @@ async fn get_lineage_returns_unimplemented() {
 #[tokio::test]
 async fn get_team_members_returns_unimplemented() {
     let (addr, _registry) = start_server().await;
-    let mut client = TopologyServiceClient::connect(format!("http://{addr}"))
-        .await
-        .unwrap();
+    let mut client = TopologyServiceClient::connect(format!("http://{addr}")).await.unwrap();
 
     let status = client
         .get_team_members(GetTeamMembersRequest {

--- a/aa-proto/build.rs
+++ b/aa-proto/build.rs
@@ -17,6 +17,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         proto_root.join("audit.proto"),
         proto_root.join("event.proto"),
         proto_root.join("approval.proto"),
+        proto_root.join("topology.proto"),
     ];
 
     // Re-run this build script if any proto file changes.

--- a/aa-proto/src/lib.rs
+++ b/aa-proto/src/lib.rs
@@ -15,6 +15,7 @@
 //! assembly::audit::v1    — async audit trail (path ③)
 //! assembly::event::v1    — internal event bus envelope (paths ⑤ ⑥)
 //! assembly::approval::v1 — human-in-the-loop approval queue
+//! assembly::topology::v1 — agent tree, lineage, and team-member queries
 //! ```
 
 pub mod assembly {
@@ -54,6 +55,12 @@ pub mod assembly {
     pub mod approval {
         pub mod v1 {
             tonic::include_proto!("assembly.approval.v1");
+        }
+    }
+
+    pub mod topology {
+        pub mod v1 {
+            tonic::include_proto!("assembly.topology.v1");
         }
     }
 }

--- a/proto/topology.proto
+++ b/proto/topology.proto
@@ -1,0 +1,89 @@
+syntax = "proto3";
+
+package assembly.topology.v1;
+
+// TopologyService provides read-only tree and lineage queries for registered agents.
+//
+// Consumed by: SDK shims and operator tooling to inspect live agent graphs.
+//              aa-gateway/src/service/topology_service.rs (server side)
+service TopologyService {
+  // GetAgentTree returns the sub-tree rooted at the given agent, up to max_depth levels.
+  rpc GetAgentTree(GetAgentTreeRequest) returns (GetAgentTreeResponse);
+
+  // GetLineage returns the ancestor chain from the given agent up to the root agent.
+  rpc GetLineage(GetLineageRequest) returns (GetLineageResponse);
+
+  // GetTeamMembers returns all agents registered under the given team_id.
+  rpc GetTeamMembers(GetTeamMembersRequest) returns (GetTeamMembersResponse);
+}
+
+// ── Shared message types ──────────────────────────────────────────────────────
+
+// TopologyAgent is a single node in an agent graph.
+message TopologyAgent {
+  // Hex-encoded agent UUID (32 hex chars = 16 bytes).
+  string id = 1;
+  // Human-readable agent name supplied at registration.
+  string name = 2;
+  // Delegation depth: 0 for root agents, N for N-th level sub-agents.
+  uint32 depth = 3;
+  // Runtime status string (e.g. "Active", "Suspended", "Deregistered").
+  string status = 4;
+  // Team identifier the agent belongs to. Empty string if none.
+  string team_id = 5;
+  // Free-form reason provided when the agent was spawned by a parent.
+  string delegation_reason = 6;
+  // Name of the tool call that caused this agent to be spawned (if any).
+  string spawned_by_tool = 7;
+  // next: 8
+}
+
+// ── GetAgentTree ──────────────────────────────────────────────────────────────
+
+message GetAgentTreeRequest {
+  // Hex-encoded agent UUID of the root of the requested sub-tree.
+  string agent_id = 1;
+  // Maximum number of levels to descend. 0 means unlimited.
+  uint32 max_depth = 2;
+  // next: 3
+}
+
+// TreeNode wraps a TopologyAgent with its recursive children.
+message TreeNode {
+  TopologyAgent agent = 1;
+  repeated TreeNode children = 2;
+  // next: 3
+}
+
+message GetAgentTreeResponse {
+  TreeNode root = 1;
+  // next: 2
+}
+
+// ── GetLineage ────────────────────────────────────────────────────────────────
+
+message GetLineageRequest {
+  // Hex-encoded agent UUID whose ancestor chain is requested.
+  string agent_id = 1;
+  // next: 2
+}
+
+message GetLineageResponse {
+  // Ordered from the given agent up to the root: ancestors[0] is the agent itself,
+  // ancestors[last] is the root agent.
+  repeated TopologyAgent ancestors = 1;
+  // next: 2
+}
+
+// ── GetTeamMembers ────────────────────────────────────────────────────────────
+
+message GetTeamMembersRequest {
+  // Team identifier whose member agents are requested.
+  string team_id = 1;
+  // next: 2
+}
+
+message GetTeamMembersResponse {
+  repeated TopologyAgent members = 1;
+  // next: 2
+}


### PR DESCRIPTION
## Description

Introduces the `assembly.topology.v1` proto package and a `TopologyServiceImpl` skeleton in `aa-gateway`. All three RPC handlers (`GetAgentTree`, `GetLineage`, `GetTeamMembers`) return `Code::Unimplemented` — this PR establishes the wire format and service mount point; actual handler logic lands in AAASM-1029 and AAASM-1030.

Changes:
- `proto/topology.proto` — new proto file: `TopologyService` with 3 RPCs, `TopologyAgent` shared message, and all request/response pairs
- `aa-proto/build.rs` — `topology.proto` added to codegen compilation list
- `aa-proto/src/lib.rs` — `assembly::topology::v1` module exposed
- `aa-gateway/src/service/topology_service.rs` — `TopologyServiceImpl` struct backed by `Arc<AgentRegistry>`, all handlers return `Err(Status::unimplemented(...))`
- `aa-gateway/src/service/mod.rs` — `topology_service` module declared and `TopologyServiceImpl` re-exported
- `aa-gateway/src/server.rs` — `TopologyServiceServer` mounted on both `serve_tcp` and `serve_uds`
- `aa-gateway/tests/topology_service_test.rs` — 3 unit tests asserting `Code::Unimplemented` for each RPC

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1027
- Parent story: AAASM-215

## Testing

- [x] Unit tests added / updated
- 3 new tests in `aa-gateway/tests/topology_service_test.rs` — each RPC returns `Code::Unimplemented`
- All 563 `aa-gateway` tests pass: `cargo nextest run -p aa-gateway`

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention