### PR TITLE
[AAASM-980] ✨ (edges): Add in-memory EdgeStore with append-only log and secondary indexes

### DIFF
--- a/aa-gateway/src/edges/mod.rs
+++ b/aa-gateway/src/edges/mod.rs
@@ -6,6 +6,19 @@
 
 use chrono::{DateTime, Utc};
 
+/// Input used when inserting a new edge into the store.
+#[derive(Debug, Clone)]
+pub struct NewEdge {
+    /// Raw UUID bytes of the originating agent.
+    pub source_agent_id: [u8; 16],
+    /// Raw UUID bytes of the target agent.
+    pub target_agent_id: [u8; 16],
+    /// Relationship kind — must be one of the six `VALID_EDGE_TYPES` strings.
+    pub edge_type: String,
+    /// Optional structured metadata (e.g. graph name, reason, key names).
+    pub metadata: Option<serde_json::Value>,
+}
+
 /// A recorded edge between two agents in the topology graph.
 #[derive(Debug, Clone)]
 pub struct EdgeRecord {

--- a/aa-gateway/src/edges/mod.rs
+++ b/aa-gateway/src/edges/mod.rs
@@ -4,7 +4,29 @@
 //! AAASM-980: append-only rows, `created_at DESC` ordering, and secondary
 //! indexes on `(source_agent_id, edge_type)` and `(target_agent_id, edge_type)`.
 
+pub mod store;
+
+pub use store::InMemoryEdgeStore;
+
 use chrono::{DateTime, Utc};
+
+/// The six valid edge type strings, matching the `EdgeType` enum variants that
+/// AAASM-985 will introduce. Validated on every insert.
+pub const VALID_EDGE_TYPES: &[&str] = &[
+    "delegates_to",
+    "calls",
+    "reads",
+    "writes",
+    "approves",
+    "messages",
+];
+
+/// Error returned when an insert or lookup is given an unrecognised edge type.
+#[derive(Debug, thiserror::Error)]
+pub enum EdgeStoreError {
+    #[error("invalid edge type: {0:?}")]
+    InvalidEdgeType(String),
+}
 
 /// Input used when inserting a new edge into the store.
 #[derive(Debug, Clone)]

--- a/aa-gateway/src/edges/mod.rs
+++ b/aa-gateway/src/edges/mod.rs
@@ -12,14 +12,7 @@ use chrono::{DateTime, Utc};
 
 /// The six valid edge type strings, matching the `EdgeType` enum variants that
 /// AAASM-985 will introduce. Validated on every insert.
-pub const VALID_EDGE_TYPES: &[&str] = &[
-    "delegates_to",
-    "calls",
-    "reads",
-    "writes",
-    "approves",
-    "messages",
-];
+pub const VALID_EDGE_TYPES: &[&str] = &["delegates_to", "calls", "reads", "writes", "approves", "messages"];
 
 /// Error returned when an insert or lookup is given an unrecognised edge type.
 #[derive(Debug, thiserror::Error)]

--- a/aa-gateway/src/edges/mod.rs
+++ b/aa-gateway/src/edges/mod.rs
@@ -1,0 +1,24 @@
+//! Append-only in-memory edge store for the agent-graph mesh model.
+//!
+//! Mirrors the logical schema of the `agent_graph_edges` table defined in
+//! AAASM-980: append-only rows, `created_at DESC` ordering, and secondary
+//! indexes on `(source_agent_id, edge_type)` and `(target_agent_id, edge_type)`.
+
+use chrono::{DateTime, Utc};
+
+/// A recorded edge between two agents in the topology graph.
+#[derive(Debug, Clone)]
+pub struct EdgeRecord {
+    /// Auto-assigned monotonically increasing identifier.
+    pub id: i64,
+    /// Raw UUID bytes of the agent that originated the relationship.
+    pub source_agent_id: [u8; 16],
+    /// Raw UUID bytes of the agent that was the target of the relationship.
+    pub target_agent_id: [u8; 16],
+    /// Relationship kind — one of the six valid `VALID_EDGE_TYPES` strings.
+    pub edge_type: String,
+    /// When this edge was recorded.
+    pub created_at: DateTime<Utc>,
+    /// Optional structured metadata attached at emission time.
+    pub metadata: Option<serde_json::Value>,
+}

--- a/aa-gateway/src/edges/store.rs
+++ b/aa-gateway/src/edges/store.rs
@@ -66,14 +66,8 @@ impl InMemoryEdgeStore {
             .entry((edge.target_agent_id, edge.edge_type.clone()))
             .or_default()
             .push(idx);
-        data.by_source
-            .entry(edge.source_agent_id)
-            .or_default()
-            .push(idx);
-        data.by_target
-            .entry(edge.target_agent_id)
-            .or_default()
-            .push(idx);
+        data.by_source.entry(edge.source_agent_id).or_default().push(idx);
+        data.by_target.entry(edge.target_agent_id).or_default().push(idx);
 
         data.records.push(EdgeRecord {
             id,
@@ -87,12 +81,7 @@ impl InMemoryEdgeStore {
     }
 
     /// Return up to `limit` outgoing edges from `source`, newest first.
-    pub fn list_outgoing(
-        &self,
-        source: [u8; 16],
-        edge_type: Option<&str>,
-        limit: usize,
-    ) -> Vec<EdgeRecord> {
+    pub fn list_outgoing(&self, source: [u8; 16], edge_type: Option<&str>, limit: usize) -> Vec<EdgeRecord> {
         let limit = limit.min(1000);
         let data = self.data.read().expect("edge store lock poisoned");
         let idxs: &[usize] = match edge_type {
@@ -103,16 +92,15 @@ impl InMemoryEdgeStore {
                 .unwrap_or_default(),
             None => data.by_source.get(&source).map(Vec::as_slice).unwrap_or_default(),
         };
-        idxs.iter().rev().take(limit).map(|&i| data.records[i].clone()).collect()
+        idxs.iter()
+            .rev()
+            .take(limit)
+            .map(|&i| data.records[i].clone())
+            .collect()
     }
 
     /// Return up to `limit` incoming edges to `target`, newest first.
-    pub fn list_incoming(
-        &self,
-        target: [u8; 16],
-        edge_type: Option<&str>,
-        limit: usize,
-    ) -> Vec<EdgeRecord> {
+    pub fn list_incoming(&self, target: [u8; 16], edge_type: Option<&str>, limit: usize) -> Vec<EdgeRecord> {
         let limit = limit.min(1000);
         let data = self.data.read().expect("edge store lock poisoned");
         let idxs: &[usize] = match edge_type {
@@ -123,16 +111,15 @@ impl InMemoryEdgeStore {
                 .unwrap_or_default(),
             None => data.by_target.get(&target).map(Vec::as_slice).unwrap_or_default(),
         };
-        idxs.iter().rev().take(limit).map(|&i| data.records[i].clone()).collect()
+        idxs.iter()
+            .rev()
+            .take(limit)
+            .map(|&i| data.records[i].clone())
+            .collect()
     }
 
     /// Return up to `limit` edges of `edge_type` with `created_at >= since`, newest first.
-    pub fn list_by_type(
-        &self,
-        edge_type: &str,
-        since: DateTime<Utc>,
-        limit: usize,
-    ) -> Vec<EdgeRecord> {
+    pub fn list_by_type(&self, edge_type: &str, since: DateTime<Utc>, limit: usize) -> Vec<EdgeRecord> {
         let limit = limit.min(1000);
         let data = self.data.read().expect("edge store lock poisoned");
         data.records

--- a/aa-gateway/src/edges/store.rs
+++ b/aa-gateway/src/edges/store.rs
@@ -1,0 +1,146 @@
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use chrono::{DateTime, Utc};
+
+use super::{EdgeRecord, EdgeStoreError, NewEdge, VALID_EDGE_TYPES};
+
+struct EdgeData {
+    records: Vec<EdgeRecord>,
+    next_id: i64,
+    /// Secondary index: (source_id, edge_type) → indices into `records`.
+    by_source_type: HashMap<([u8; 16], String), Vec<usize>>,
+    /// Secondary index: (target_id, edge_type) → indices into `records`.
+    by_target_type: HashMap<([u8; 16], String), Vec<usize>>,
+    /// Secondary index: source_id → all indices, for unfiltered outgoing queries.
+    by_source: HashMap<[u8; 16], Vec<usize>>,
+    /// Secondary index: target_id → all indices, for unfiltered incoming queries.
+    by_target: HashMap<[u8; 16], Vec<usize>>,
+}
+
+impl EdgeData {
+    fn new() -> Self {
+        Self {
+            records: Vec::new(),
+            next_id: 1,
+            by_source_type: HashMap::new(),
+            by_target_type: HashMap::new(),
+            by_source: HashMap::new(),
+            by_target: HashMap::new(),
+        }
+    }
+}
+
+/// Append-only in-memory store for agent-graph mesh edges.
+///
+/// All writes are `O(1)`. Reads over secondary indexes are `O(result_size)`.
+/// The `limit` parameter on every list method is silently capped at 1 000 to
+/// bound response size, matching the intent of the DB index design.
+#[derive(Clone, Default)]
+pub struct InMemoryEdgeStore {
+    data: Arc<RwLock<EdgeData>>,
+}
+
+impl InMemoryEdgeStore {
+    pub fn new() -> Self {
+        Self {
+            data: Arc::new(RwLock::new(EdgeData::new())),
+        }
+    }
+
+    /// Insert a new edge. Returns the auto-assigned `id`. Rejects unknown edge types.
+    pub fn insert(&self, edge: NewEdge) -> Result<i64, EdgeStoreError> {
+        if !VALID_EDGE_TYPES.contains(&edge.edge_type.as_str()) {
+            return Err(EdgeStoreError::InvalidEdgeType(edge.edge_type));
+        }
+        let mut data = self.data.write().expect("edge store lock poisoned");
+        let id = data.next_id;
+        data.next_id += 1;
+        let idx = data.records.len();
+
+        data.by_source_type
+            .entry((edge.source_agent_id, edge.edge_type.clone()))
+            .or_default()
+            .push(idx);
+        data.by_target_type
+            .entry((edge.target_agent_id, edge.edge_type.clone()))
+            .or_default()
+            .push(idx);
+        data.by_source
+            .entry(edge.source_agent_id)
+            .or_default()
+            .push(idx);
+        data.by_target
+            .entry(edge.target_agent_id)
+            .or_default()
+            .push(idx);
+
+        data.records.push(EdgeRecord {
+            id,
+            source_agent_id: edge.source_agent_id,
+            target_agent_id: edge.target_agent_id,
+            edge_type: edge.edge_type,
+            created_at: Utc::now(),
+            metadata: edge.metadata,
+        });
+        Ok(id)
+    }
+
+    /// Return up to `limit` outgoing edges from `source`, newest first.
+    pub fn list_outgoing(
+        &self,
+        source: [u8; 16],
+        edge_type: Option<&str>,
+        limit: usize,
+    ) -> Vec<EdgeRecord> {
+        let limit = limit.min(1000);
+        let data = self.data.read().expect("edge store lock poisoned");
+        let idxs: &[usize] = match edge_type {
+            Some(et) => data
+                .by_source_type
+                .get(&(source, et.to_string()))
+                .map(Vec::as_slice)
+                .unwrap_or_default(),
+            None => data.by_source.get(&source).map(Vec::as_slice).unwrap_or_default(),
+        };
+        idxs.iter().rev().take(limit).map(|&i| data.records[i].clone()).collect()
+    }
+
+    /// Return up to `limit` incoming edges to `target`, newest first.
+    pub fn list_incoming(
+        &self,
+        target: [u8; 16],
+        edge_type: Option<&str>,
+        limit: usize,
+    ) -> Vec<EdgeRecord> {
+        let limit = limit.min(1000);
+        let data = self.data.read().expect("edge store lock poisoned");
+        let idxs: &[usize] = match edge_type {
+            Some(et) => data
+                .by_target_type
+                .get(&(target, et.to_string()))
+                .map(Vec::as_slice)
+                .unwrap_or_default(),
+            None => data.by_target.get(&target).map(Vec::as_slice).unwrap_or_default(),
+        };
+        idxs.iter().rev().take(limit).map(|&i| data.records[i].clone()).collect()
+    }
+
+    /// Return up to `limit` edges of `edge_type` with `created_at >= since`, newest first.
+    pub fn list_by_type(
+        &self,
+        edge_type: &str,
+        since: DateTime<Utc>,
+        limit: usize,
+    ) -> Vec<EdgeRecord> {
+        let limit = limit.min(1000);
+        let data = self.data.read().expect("edge store lock poisoned");
+        data.records
+            .iter()
+            .filter(|r| r.edge_type == edge_type && r.created_at >= since)
+            .rev()
+            .take(limit)
+            .cloned()
+            .collect()
+    }
+}

--- a/aa-gateway/src/edges/store.rs
+++ b/aa-gateway/src/edges/store.rs
@@ -36,7 +36,7 @@ impl EdgeData {
 /// All writes are `O(1)`. Reads over secondary indexes are `O(result_size)`.
 /// The `limit` parameter on every list method is silently capped at 1 000 to
 /// bound response size, matching the intent of the DB index design.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct InMemoryEdgeStore {
     data: Arc<RwLock<EdgeData>>,
 }
@@ -142,5 +142,11 @@ impl InMemoryEdgeStore {
             .take(limit)
             .cloned()
             .collect()
+    }
+}
+
+impl Default for InMemoryEdgeStore {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -5,6 +5,7 @@
 //! back to proxies and SDK shims, and writes the audit trail.
 
 pub mod anomaly;
+pub mod edges;
 pub mod approval;
 pub mod audit;
 pub mod audit_reader;

--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -5,11 +5,11 @@
 //! back to proxies and SDK shims, and writes the audit trail.
 
 pub mod anomaly;
-pub mod edges;
 pub mod approval;
 pub mod audit;
 pub mod audit_reader;
 pub mod budget;
+pub mod edges;
 pub mod engine;
 pub mod events;
 pub mod policy;

--- a/aa-gateway/tests/edge_store_test.rs
+++ b/aa-gateway/tests/edge_store_test.rs
@@ -1,0 +1,113 @@
+use aa_gateway::edges::{EdgeStoreError, InMemoryEdgeStore, NewEdge, VALID_EDGE_TYPES};
+use chrono::Utc;
+
+fn agent(n: u8) -> [u8; 16] {
+    let mut id = [0u8; 16];
+    id[0] = n;
+    id
+}
+
+fn edge(src: u8, tgt: u8, edge_type: &str) -> NewEdge {
+    NewEdge {
+        source_agent_id: agent(src),
+        target_agent_id: agent(tgt),
+        edge_type: edge_type.to_string(),
+        metadata: None,
+    }
+}
+
+#[test]
+fn all_six_valid_edge_types_accepted() {
+    let store = InMemoryEdgeStore::new();
+    for &et in VALID_EDGE_TYPES {
+        let id = store.insert(edge(1, 2, et)).expect("valid edge type should insert");
+        assert!(id > 0, "returned id must be positive");
+    }
+}
+
+#[test]
+fn invalid_edge_type_is_rejected() {
+    let store = InMemoryEdgeStore::new();
+    let err = store.insert(edge(1, 2, "teleports")).unwrap_err();
+    assert!(
+        matches!(err, EdgeStoreError::InvalidEdgeType(_)),
+        "unknown type must return InvalidEdgeType"
+    );
+}
+
+#[test]
+fn ids_are_monotonically_increasing() {
+    let store = InMemoryEdgeStore::new();
+    let id1 = store.insert(edge(1, 2, "calls")).unwrap();
+    let id2 = store.insert(edge(1, 2, "calls")).unwrap();
+    let id3 = store.insert(edge(1, 2, "calls")).unwrap();
+    assert!(id1 < id2 && id2 < id3);
+}
+
+#[test]
+fn list_outgoing_returns_newest_first() {
+    let store = InMemoryEdgeStore::new();
+    store.insert(edge(1, 2, "calls")).unwrap();
+    store.insert(edge(1, 3, "calls")).unwrap();
+    store.insert(edge(1, 4, "reads")).unwrap();
+
+    let result = store.list_outgoing(agent(1), None, 100);
+    assert_eq!(result.len(), 3);
+    assert!(result[0].id > result[1].id, "newest edge must come first");
+}
+
+#[test]
+fn list_outgoing_filtered_by_edge_type() {
+    let store = InMemoryEdgeStore::new();
+    store.insert(edge(1, 2, "calls")).unwrap();
+    store.insert(edge(1, 3, "reads")).unwrap();
+    store.insert(edge(1, 4, "calls")).unwrap();
+
+    let calls = store.list_outgoing(agent(1), Some("calls"), 100);
+    assert_eq!(calls.len(), 2);
+    assert!(calls.iter().all(|e| e.edge_type == "calls"));
+}
+
+#[test]
+fn list_incoming_returns_only_edges_to_target() {
+    let store = InMemoryEdgeStore::new();
+    store.insert(edge(1, 3, "messages")).unwrap();
+    store.insert(edge(2, 3, "messages")).unwrap();
+    store.insert(edge(1, 4, "messages")).unwrap(); // different target
+
+    let incoming = store.list_incoming(agent(3), None, 100);
+    assert_eq!(incoming.len(), 2);
+    assert!(incoming.iter().all(|e| e.target_agent_id == agent(3)));
+}
+
+#[test]
+fn list_by_type_filters_by_type_and_since() {
+    let store = InMemoryEdgeStore::new();
+    // Use a timestamp slightly in the past so all inserts land after it.
+    let since = Utc::now() - chrono::TimeDelta::milliseconds(50);
+    store.insert(edge(1, 2, "approves")).unwrap();
+    store.insert(edge(1, 3, "approves")).unwrap();
+    store.insert(edge(1, 4, "delegates_to")).unwrap();
+
+    let approves = store.list_by_type("approves", since, 100);
+    assert_eq!(approves.len(), 2);
+    assert!(approves.iter().all(|e| e.edge_type == "approves"));
+}
+
+#[test]
+fn limit_is_capped_at_1000() {
+    let store = InMemoryEdgeStore::new();
+    for _ in 0..1500 {
+        store.insert(edge(1, 2, "writes")).unwrap();
+    }
+    let result = store.list_outgoing(agent(1), None, 9999);
+    assert_eq!(result.len(), 1000, "limit must be capped at 1000");
+}
+
+#[test]
+fn empty_store_returns_empty_vecs() {
+    let store = InMemoryEdgeStore::new();
+    assert!(store.list_outgoing(agent(1), None, 10).is_empty());
+    assert!(store.list_incoming(agent(1), None, 10).is_empty());
+    assert!(store.list_by_type("calls", Utc::now(), 10).is_empty());
+}


### PR DESCRIPTION
## Description

Adds `aa-gateway/src/edges/` — the append-only in-memory edge store that underpins the F102 mesh topology model (AAASM-940). This is the storage-layer equivalent of the `agent_graph_edges` SQL table specified in AAASM-980, adapted for the project's in-memory architecture.

**What was added:**
- `EdgeRecord` — stored edge with id, source/target agent ids, edge_type, created_at, metadata
- `NewEdge` — input struct for insertions
- `VALID_EDGE_TYPES` — the 6 valid edge type strings (`delegates_to`, `calls`, `reads`, `writes`, `approves`, `messages`); invalid types are rejected with `EdgeStoreError::InvalidEdgeType`
- `InMemoryEdgeStore` — `Arc<RwLock<_>>` backed store with four secondary indexes:
  - `by_source_type`: `(source_id, edge_type)` → indices (mirrors the DB `(source_agent_id, edge_type, created_at DESC)` index)
  - `by_target_type`: `(target_id, edge_type)` → indices (mirrors the DB `(target_agent_id, edge_type, created_at DESC)` index)
  - `by_source` / `by_target`: unfiltered lookups without type constraint
- All list methods return results **newest first** and cap `limit` at 1 000

**Architecture note:** The project uses in-memory storage throughout (DashMap/RwLock). The `agent_graph_edges` SQL migration specified in AAASM-980 is fulfilled by this module, which preserves the same logical schema and index semantics.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-980
- Parent story: AAASM-940 (F102: Mesh agent-team edge model)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

`aa-gateway/tests/edge_store_test.rs` — 9 tests covering:
- All 6 valid edge types accepted
- Invalid edge type rejected
- Monotonically increasing IDs
- `list_outgoing` newest-first ordering and edge-type filter
- `list_incoming` target isolation
- `list_by_type` type + since filter
- 1 000 limit cap
- Empty store returns empty vecs

Full gateway suite: **569/569 pass**, 0 regressions.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention