### PR TITLE
[AAASM-1096] ✨ (make): Add Makefile dev-setup target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ clone-sdks:
 		fi; \
 	done < scripts/sdk-repos.txt
 
+## install-hooks: Install git pre-commit hooks via pre-commit
+install-hooks:
+	@pre-commit install
+
 ## install-tools: Check required toolchains via scripts/install.sh
 install-tools:
 	@bash scripts/install.sh

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ clone-sdks:
 		fi; \
 	done < scripts/sdk-repos.txt
 
+## build-workspace: Build the Cargo workspace (excludes eBPF crates requiring nightly)
+build-workspace:
+	@cargo build --workspace --exclude aa-ebpf
+
 ## install-hooks: Install git pre-commit hooks via pre-commit
 install-hooks:
 	@pre-commit install

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 .DEFAULT_GOAL := help
 
 .PHONY: help dev-setup install-tools clone-sdks install-hooks build-workspace \
-        dev-verify smoke-python smoke-node smoke-go gateway-health \
+        test dev-verify smoke-python smoke-node smoke-go gateway-health \
         demo-record
 
 ## dev-setup: Bootstrap the full local development environment (install tools, clone SDKs, install hooks, build)
@@ -25,6 +25,10 @@ clone-sdks:
 			git clone "$$url" "$$dest"; \
 		fi; \
 	done < scripts/sdk-repos.txt
+
+## test: Run the full test suite across all workspace crates
+test:
+	@cargo nextest run --workspace --exclude aa-ebpf
 
 ## build-workspace: Build the Cargo workspace (excludes eBPF crates requiring nightly)
 build-workspace:

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ SHELL := /bin/bash
         dev-verify smoke-python smoke-node smoke-go gateway-health \
         demo-record
 
+## install-tools: Check required toolchains via scripts/install.sh
+install-tools:
+	@bash scripts/install.sh
+
 ## help: Show this help message
 help:
 	@echo "Usage: make <target>"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+SHELL := /bin/bash
+
+.DEFAULT_GOAL := help
+
+.PHONY: help dev-setup install-tools clone-sdks install-hooks build-workspace \
+        dev-verify smoke-python smoke-node smoke-go gateway-health \
+        demo-record
+
+## help: Show this help message
+help:
+	@echo "Usage: make <target>"
+	@echo ""
+	@grep -E '^## [a-zA-Z_-]+:' $(MAKEFILE_LIST) \
+		| sed 's/^## /  /' \
+		| column -t -s ':'

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,11 @@ SHELL := /bin/bash
         dev-verify smoke-python smoke-node smoke-go gateway-health \
         demo-record
 
+## dev-setup: Bootstrap the full local development environment (install tools, clone SDKs, install hooks, build)
+dev-setup: install-tools clone-sdks install-hooks build-workspace
+	@echo ""
+	@echo "dev-setup complete. Run 'make dev-verify' to validate."
+
 ## clone-sdks: Clone (or pull) SDK polyrepos listed in scripts/sdk-repos.txt into sibling dirs
 clone-sdks:
 	@while IFS= read -r url || [ -n "$$url" ]; do \

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,21 @@ SHELL := /bin/bash
         dev-verify smoke-python smoke-node smoke-go gateway-health \
         demo-record
 
+## clone-sdks: Clone (or pull) SDK polyrepos listed in scripts/sdk-repos.txt into sibling dirs
+clone-sdks:
+	@while IFS= read -r url || [ -n "$$url" ]; do \
+		[ -z "$$url" ] && continue; \
+		repo=$$(basename "$$url" .git); \
+		dest="$$(dirname $$(pwd))/$$repo"; \
+		if [ -d "$$dest/.git" ]; then \
+			echo "  Updating $$repo ..."; \
+			git -C "$$dest" pull --ff-only; \
+		else \
+			echo "  Cloning $$repo ..."; \
+			git clone "$$url" "$$dest"; \
+		fi; \
+	done < scripts/sdk-repos.txt
+
 ## install-tools: Check required toolchains via scripts/install.sh
 install-tools:
 	@bash scripts/install.sh

--- a/scripts/sdk-repos.txt
+++ b/scripts/sdk-repos.txt
@@ -1,0 +1,3 @@
+git@github.com:AI-agent-assembly/python-sdk.git
+git@github.com:AI-agent-assembly/node-sdk.git
+git@github.com:AI-agent-assembly/go-sdk.git


### PR DESCRIPTION
## Description

Adds a `Makefile` with a `make dev-setup` target that bootstraps the full local development environment in one command: checks toolchain prerequisites, clones SDK polyrepos as siblings, installs git pre-commit hooks, and builds the Cargo workspace. Also adds `scripts/sdk-repos.txt` as the single source of truth for SDK clone URLs.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1096
- Parent story: AAASM-109
- Depends on: AAASM-1095 (merged — `scripts/install.sh` now on master)

## Testing

- [x] Manual testing performed — `make help` verified all targets render correctly; `make install-tools` runs `scripts/install.sh` as expected; Makefile syntax validated locally
- [x] No unit tests required — Makefile targets are integration-level; covered by `make dev-verify` (AAASM-1097)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] Commits are small and follow the Gitmoji convention

## Commit log

- `✨ (scripts): Add scripts/sdk-repos.txt with SDK polyrepo SSH URLs`
- `✨ (make): Add Makefile skeleton with SHELL, .PHONY, and help target`
- `✨ (make): Add install-tools sub-target (delegates to scripts/install.sh)`
- `✨ (make): Add clone-sdks sub-target (idempotent clone/pull from sdk-repos.txt)`
- `✨ (make): Add install-hooks sub-target (pre-commit install)`
- `✨ (make): Add build-workspace sub-target (cargo build --workspace --exclude aa-ebpf)`
- `✨ (make): Wire dev-setup target as chain of install-tools → clone-sdks → install-hooks → build-workspace`