### PR TITLE
[AAASM-1009] ✨ (aa-api/models): Add topology response-type module

### DIFF
--- a/aa-api/src/models/mod.rs
+++ b/aa-api/src/models/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod event;
 pub mod event_type;
+pub mod topology;
 pub mod trace;
 pub mod ws_payloads;
 

--- a/aa-api/src/models/topology.rs
+++ b/aa-api/src/models/topology.rs
@@ -1,0 +1,456 @@
+//! Shared response types for all `/v1/topology/*` endpoints.
+//!
+//! All types in this module are pure data definitions — no endpoint logic.
+//! Endpoint handlers in `routes/topology.rs` import these and convert from
+//! `AgentRecord` via the provided `From` impls.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use aa_gateway::registry::{AgentRecord, AgentStatus};
+
+// ---------------------------------------------------------------------------
+// Internal helpers (pub(crate) so routes can reuse without duplication)
+// ---------------------------------------------------------------------------
+
+pub(crate) fn format_id(id: &[u8; 16]) -> String {
+    id.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+pub(crate) fn status_str(status: &AgentStatus) -> &'static str {
+    match status {
+        AgentStatus::Active => "active",
+        AgentStatus::Suspended(_) => "suspended",
+        AgentStatus::Deregistered => "deregistered",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+/// Overview of the entire agent topology across all teams.
+///
+/// # Example JSON
+/// ```json
+/// {
+///   "team_count": 2,
+///   "root_agent_count": 3,
+///   "total_agent_count": 12,
+///   "teams": [{ "team_id": "team-alpha", "agent_count": 7, "root_agent_count": 1 }],
+///   "standalone_root_agents": []
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[schema(example = json!({
+    "team_count": 2,
+    "root_agent_count": 3,
+    "total_agent_count": 12,
+    "teams": [{"team_id": "team-alpha", "agent_count": 7, "root_agent_count": 1}],
+    "standalone_root_agents": []
+}))]
+pub struct TopologyOverview {
+    /// Number of teams with at least one registered agent.
+    pub team_count: usize,
+    /// Number of root agents (depth == 0) across all teams.
+    pub root_agent_count: usize,
+    /// Total number of agents in the registry.
+    pub total_agent_count: usize,
+    /// Per-team agent count summaries, sorted by team_id.
+    pub teams: Vec<TeamSummary>,
+    /// Root agents that are not assigned to any team, sorted by agent id.
+    pub standalone_root_agents: Vec<AgentNode>,
+}
+
+/// High-level statistics for a single team.
+///
+/// # Example JSON
+/// ```json
+/// { "team_id": "team-alpha", "agent_count": 7, "root_agent_count": 1 }
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[schema(example = json!({ "team_id": "team-alpha", "agent_count": 7, "root_agent_count": 1 }))]
+pub struct TeamSummary {
+    /// Team identifier.
+    pub team_id: String,
+    /// Total agents in this team.
+    pub agent_count: usize,
+    /// Root agents (depth == 0) in this team.
+    pub root_agent_count: usize,
+}
+
+/// Minimal agent representation used in list and tree responses.
+///
+/// # Example JSON
+/// ```json
+/// {
+///   "id": "0102030405060708090a0b0c0d0e0f10",
+///   "name": "my-agent",
+///   "depth": 1,
+///   "status": "active",
+///   "team_id": "team-alpha"
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[schema(example = json!({
+    "id": "0102030405060708090a0b0c0d0e0f10",
+    "name": "my-agent",
+    "depth": 1,
+    "status": "active",
+    "team_id": "team-alpha"
+}))]
+pub struct AgentNode {
+    /// Hex-encoded agent UUID.
+    pub id: String,
+    /// Human-readable agent name.
+    pub name: String,
+    /// Delegation depth — 0 for root agents.
+    pub depth: u32,
+    /// Runtime status: `active`, `suspended`, or `deregistered`.
+    pub status: String,
+    /// Team this agent belongs to, if any.
+    pub team_id: Option<String>,
+    /// Governance level — included only when `show_budget=true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub governance_level: Option<String>,
+}
+
+impl From<&AgentRecord> for AgentNode {
+    fn from(r: &AgentRecord) -> Self {
+        AgentNode {
+            id: format_id(&r.agent_id),
+            name: r.name.clone(),
+            depth: r.depth,
+            status: status_str(&r.status).to_owned(),
+            team_id: r.team_id.clone(),
+            governance_level: None,
+        }
+    }
+}
+
+/// Recursive tree node representing an agent and all its descendants.
+///
+/// # Example JSON
+/// ```json
+/// {
+///   "id": "0102030405060708090a0b0c0d0e0f10",
+///   "name": "root-agent",
+///   "depth": 0,
+///   "status": "active",
+///   "team_id": "team-alpha",
+///   "delegation_reason": null,
+///   "spawned_by_tool": null,
+///   "children": []
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[schema(example = json!({
+    "id": "0102030405060708090a0b0c0d0e0f10",
+    "name": "root-agent",
+    "depth": 0,
+    "status": "active",
+    "team_id": "team-alpha",
+    "delegation_reason": null,
+    "spawned_by_tool": null,
+    "children": []
+}))]
+pub struct AgentTree {
+    /// Hex-encoded agent UUID.
+    pub id: String,
+    /// Human-readable agent name.
+    pub name: String,
+    /// Delegation depth — 0 for root agents.
+    pub depth: u32,
+    /// Runtime status: `active`, `suspended`, or `deregistered`.
+    pub status: String,
+    /// Team this agent belongs to, if any.
+    pub team_id: Option<String>,
+    /// Reason this agent was delegated from its parent, if recorded.
+    pub delegation_reason: Option<String>,
+    /// Tool that spawned this agent, if known.
+    pub spawned_by_tool: Option<String>,
+    /// Governance level — included only when `show_budget=true`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub governance_level: Option<String>,
+    /// Direct children of this agent in the delegation tree.
+    #[schema(schema_with = agent_tree_children_schema)]
+    pub children: Vec<AgentTree>,
+}
+
+/// Returns a schema for `Vec<AgentTree>` using a `$ref` to break the recursive cycle.
+///
+/// Without this, utoipa's ToSchema derive recurses infinitely and overflows the stack.
+fn agent_tree_children_schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+    use utoipa::openapi::schema::{ArrayBuilder, Ref};
+    ArrayBuilder::new()
+        .items(Ref::from_schema_name("AgentTree"))
+        .build()
+        .into()
+}
+
+/// All agents belonging to a single team.
+///
+/// # Example JSON
+/// ```json
+/// { "team_id": "team-alpha", "agent_count": 2, "members": [] }
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[schema(example = json!({ "team_id": "team-alpha", "agent_count": 2, "members": [] }))]
+pub struct TeamTopology {
+    /// Team identifier.
+    pub team_id: String,
+    /// Number of agents in this team (after filtering).
+    pub agent_count: usize,
+    /// Agents in this team.
+    pub members: Vec<AgentNode>,
+}
+
+/// An agent's complete ancestry chain ordered root-first.
+///
+/// The first element is the root agent; the last element is the requested
+/// agent itself. A root agent returns a list of length 1 containing only itself.
+///
+/// # Example JSON
+/// ```json
+/// {
+///   "agent_id": "aabbccdd00112233aabbccdd00112233",
+///   "ancestor_count": 2,
+///   "ancestors": [
+///     { "id": "root000000000000root000000000000", "name": "root", "depth": 0, "delegation_reason": null, "team_id": null },
+///     { "id": "aabbccdd00112233aabbccdd00112233", "name": "child", "depth": 1, "delegation_reason": "orchestrate", "team_id": "team-alpha" }
+///   ]
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[schema(example = json!({
+    "agent_id": "aabbccdd00112233aabbccdd00112233",
+    "ancestor_count": 2,
+    "ancestors": [
+        {"id": "root000000000000root000000000000", "name": "root", "depth": 0, "delegation_reason": null, "team_id": null},
+        {"id": "aabbccdd00112233aabbccdd00112233", "name": "child", "depth": 1, "delegation_reason": "orchestrate", "team_id": "team-alpha"}
+    ]
+}))]
+pub struct AgentLineage {
+    /// The subject agent's hex-encoded UUID.
+    pub agent_id: String,
+    /// Number of entries in `ancestors` (includes the agent itself).
+    pub ancestor_count: usize,
+    /// Ordered ancestry: index 0 is the root agent, last element is the requested agent.
+    pub ancestors: Vec<LineageStep>,
+}
+
+/// One step in an agent's ancestry chain.
+///
+/// # Example JSON
+/// ```json
+/// { "id": "root000000000000root000000000000", "name": "root", "depth": 0, "delegation_reason": null, "team_id": null }
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[schema(example = json!({ "id": "root000000000000root000000000000", "name": "root", "depth": 0, "delegation_reason": null, "team_id": null }))]
+pub struct LineageStep {
+    /// Hex-encoded UUID of this ancestor (or the subject agent).
+    pub id: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Delegation depth of this node.
+    pub depth: u32,
+    /// Reason the next agent in the chain was delegated from this node.
+    pub delegation_reason: Option<String>,
+    /// Team this node belongs to.
+    pub team_id: Option<String>,
+}
+
+/// Aggregate topology statistics across all registered agents.
+///
+/// # Example JSON
+/// ```json
+/// {
+///   "total_agents": 15,
+///   "root_agent_count": 3,
+///   "max_depth": 4,
+///   "active_count": 12,
+///   "suspended_count": 2,
+///   "deregistered_count": 1,
+///   "team_count": 2,
+///   "team_sizes": { "team-alpha": 8, "team-beta": 4 }
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[schema(example = json!({
+    "total_agents": 15,
+    "root_agent_count": 3,
+    "max_depth": 4,
+    "active_count": 12,
+    "suspended_count": 2,
+    "deregistered_count": 1,
+    "team_count": 2,
+    "team_sizes": {"team-alpha": 8, "team-beta": 4}
+}))]
+pub struct TopologyStats {
+    /// Total agents in the registry.
+    pub total_agents: usize,
+    /// Number of root agents (depth == 0).
+    pub root_agent_count: usize,
+    /// Maximum observed delegation depth.
+    pub max_depth: u32,
+    /// Agents currently in `Active` status.
+    pub active_count: usize,
+    /// Agents currently in `Suspended` status.
+    pub suspended_count: usize,
+    /// Agents in `Deregistered` status.
+    pub deregistered_count: usize,
+    /// Number of teams with at least one agent.
+    pub team_count: usize,
+    /// Agent count per team.
+    pub team_sizes: HashMap<String, usize>,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+
+    fn roundtrip<T: Serialize + for<'de> Deserialize<'de> + PartialEq + std::fmt::Debug>(val: &T) {
+        let json = serde_json::to_string(val).expect("serialize");
+        let back: T = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(*val, back);
+    }
+
+    fn make_agent_node() -> AgentNode {
+        AgentNode {
+            id: "0102030405060708090a0b0c0d0e0f10".to_string(),
+            name: "agent-x".to_string(),
+            depth: 1,
+            status: "active".to_string(),
+            team_id: Some("team-alpha".to_string()),
+            governance_level: None,
+        }
+    }
+
+    #[test]
+    fn agent_node_roundtrip() {
+        roundtrip(&make_agent_node());
+    }
+
+    #[test]
+    fn agent_node_omits_governance_level_when_none() {
+        let node = make_agent_node();
+        let json: serde_json::Value = serde_json::from_str(&serde_json::to_string(&node).unwrap()).unwrap();
+        assert!(json.get("governance_level").is_none());
+    }
+
+    #[test]
+    fn team_summary_roundtrip() {
+        roundtrip(&TeamSummary {
+            team_id: "team-alpha".to_string(),
+            agent_count: 7,
+            root_agent_count: 1,
+        });
+    }
+
+    #[test]
+    fn topology_overview_roundtrip() {
+        roundtrip(&TopologyOverview {
+            team_count: 2,
+            root_agent_count: 3,
+            total_agent_count: 12,
+            teams: vec![TeamSummary {
+                team_id: "team-alpha".to_string(),
+                agent_count: 7,
+                root_agent_count: 1,
+            }],
+            standalone_root_agents: vec![make_agent_node()],
+        });
+    }
+
+    #[test]
+    fn agent_tree_roundtrip() {
+        let leaf = AgentTree {
+            id: "cc".to_string(),
+            name: "leaf".to_string(),
+            depth: 2,
+            status: "active".to_string(),
+            team_id: None,
+            delegation_reason: Some("sub-task".to_string()),
+            spawned_by_tool: None,
+            governance_level: None,
+            children: vec![],
+        };
+        let root = AgentTree {
+            id: "aa".to_string(),
+            name: "root".to_string(),
+            depth: 0,
+            status: "active".to_string(),
+            team_id: Some("team-alpha".to_string()),
+            delegation_reason: None,
+            spawned_by_tool: None,
+            governance_level: None,
+            children: vec![leaf],
+        };
+        roundtrip(&root);
+    }
+
+    #[test]
+    fn team_topology_roundtrip() {
+        roundtrip(&TeamTopology {
+            team_id: "team-alpha".to_string(),
+            agent_count: 1,
+            members: vec![make_agent_node()],
+        });
+    }
+
+    #[test]
+    fn lineage_step_roundtrip() {
+        roundtrip(&LineageStep {
+            id: "root000000000000root000000000000".to_string(),
+            name: "root".to_string(),
+            depth: 0,
+            delegation_reason: None,
+            team_id: None,
+        });
+    }
+
+    #[test]
+    fn agent_lineage_roundtrip() {
+        roundtrip(&AgentLineage {
+            agent_id: "aabbccdd00112233aabbccdd00112233".to_string(),
+            ancestor_count: 2,
+            ancestors: vec![
+                LineageStep {
+                    id: "root000000000000root000000000000".to_string(),
+                    name: "root".to_string(),
+                    depth: 0,
+                    delegation_reason: None,
+                    team_id: None,
+                },
+                LineageStep {
+                    id: "aabbccdd00112233aabbccdd00112233".to_string(),
+                    name: "child".to_string(),
+                    depth: 1,
+                    delegation_reason: Some("orchestrate".to_string()),
+                    team_id: Some("team-alpha".to_string()),
+                },
+            ],
+        });
+    }
+
+    #[test]
+    fn topology_stats_roundtrip() {
+        roundtrip(&TopologyStats {
+            total_agents: 15,
+            root_agent_count: 3,
+            max_depth: 4,
+            active_count: 12,
+            suspended_count: 2,
+            deregistered_count: 1,
+            team_count: 2,
+            team_sizes: [("team-alpha".to_string(), 8), ("team-beta".to_string(), 4)].into(),
+        });
+    }
+}

--- a/aa-api/src/routes/topology.rs
+++ b/aa-api/src/routes/topology.rs
@@ -9,12 +9,16 @@ use std::collections::HashMap;
 use axum::extract::{Path, Query};
 use axum::http::StatusCode;
 use axum::{Extension, Json};
-use serde::{Deserialize, Serialize};
-use utoipa::{IntoParams, ToSchema};
+use serde::Deserialize;
+use utoipa::IntoParams;
 
 use aa_gateway::registry::{AgentRegistry, AgentStatus};
 
 use crate::error::ProblemDetail;
+use crate::models::topology::{format_id, status_str};
+pub use crate::models::topology::{
+    AgentLineage, AgentNode, AgentTree, LineageStep, TeamSummary, TeamTopology, TopologyOverview, TopologyStats,
+};
 use crate::state::AppState;
 
 // ---------------------------------------------------------------------------
@@ -33,18 +37,6 @@ fn parse_agent_id(id: &str) -> Result<[u8; 16], ProblemDetail> {
         ProblemDetail::from_status(StatusCode::BAD_REQUEST)
             .with_detail(format!("Agent ID must be 32 hex characters: {id}"))
     })
-}
-
-fn format_id(id: &[u8; 16]) -> String {
-    id.iter().map(|b| format!("{b:02x}")).collect()
-}
-
-fn status_str(status: &AgentStatus) -> &'static str {
-    match status {
-        AgentStatus::Active => "active",
-        AgentStatus::Suspended(_) => "suspended",
-        AgentStatus::Deregistered => "deregistered",
-    }
 }
 
 fn matches_status_filter(status: &AgentStatus, filter: &str) -> bool {
@@ -80,148 +72,6 @@ pub struct TreeParams {
     pub status: Option<String>,
     /// When `true`, include the governance level in each tree node.
     pub show_budget: Option<bool>,
-}
-
-// ---------------------------------------------------------------------------
-// Response types
-// ---------------------------------------------------------------------------
-
-/// Overview of the entire agent topology across all teams.
-#[derive(Debug, Serialize, ToSchema)]
-pub struct TopologyOverview {
-    /// Number of teams with at least one registered agent.
-    pub team_count: usize,
-    /// Number of root agents (depth == 0) across all teams.
-    pub root_agent_count: usize,
-    /// Total number of agents in the registry.
-    pub total_agent_count: usize,
-    /// Per-team agent count summaries.
-    pub teams: Vec<TeamSummary>,
-    /// Root agents that are not assigned to any team.
-    pub standalone_root_agents: Vec<AgentNode>,
-}
-
-/// High-level statistics for a single team.
-#[derive(Debug, Serialize, ToSchema)]
-pub struct TeamSummary {
-    /// Team identifier.
-    pub team_id: String,
-    /// Total agents in this team.
-    pub agent_count: usize,
-    /// Root agents (depth == 0) in this team.
-    pub root_agent_count: usize,
-}
-
-/// Minimal agent representation used in list and tree responses.
-#[derive(Debug, Serialize, ToSchema)]
-pub struct AgentNode {
-    /// Hex-encoded agent UUID.
-    pub id: String,
-    /// Human-readable agent name.
-    pub name: String,
-    /// Delegation depth — 0 for root agents.
-    pub depth: u32,
-    /// Runtime status: `active`, `suspended`, or `deregistered`.
-    pub status: String,
-    /// Team this agent belongs to, if any.
-    pub team_id: Option<String>,
-    /// Governance level — included only when `show_budget=true`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub governance_level: Option<String>,
-}
-
-/// Recursive tree node representing an agent and all its descendants.
-#[derive(Debug, Serialize, ToSchema)]
-pub struct AgentTree {
-    /// Hex-encoded agent UUID.
-    pub id: String,
-    /// Human-readable agent name.
-    pub name: String,
-    /// Delegation depth — 0 for root agents.
-    pub depth: u32,
-    /// Runtime status: `active`, `suspended`, or `deregistered`.
-    pub status: String,
-    /// Team this agent belongs to, if any.
-    pub team_id: Option<String>,
-    /// Reason this agent was delegated from its parent, if recorded.
-    pub delegation_reason: Option<String>,
-    /// Tool that spawned this agent, if known.
-    pub spawned_by_tool: Option<String>,
-    /// Governance level — included only when `show_budget=true`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub governance_level: Option<String>,
-    /// Direct children of this agent in the delegation tree.
-    #[schema(schema_with = agent_tree_children_schema)]
-    pub children: Vec<AgentTree>,
-}
-
-/// Returns a schema for `Vec<AgentTree>` using a `$ref` to break the recursive cycle.
-///
-/// Without this, utoipa's ToSchema derive recurses infinitely and overflows the stack.
-fn agent_tree_children_schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-    use utoipa::openapi::schema::{ArrayBuilder, Ref};
-    ArrayBuilder::new()
-        .items(Ref::from_schema_name("AgentTree"))
-        .build()
-        .into()
-}
-
-/// All agents belonging to a single team.
-#[derive(Debug, Serialize, ToSchema)]
-pub struct TeamTopology {
-    /// Team identifier.
-    pub team_id: String,
-    /// Number of agents in this team (after filtering).
-    pub agent_count: usize,
-    /// Agents in this team.
-    pub members: Vec<AgentNode>,
-}
-
-/// An agent's complete ancestry chain from direct parent up to root.
-#[derive(Debug, Serialize, ToSchema)]
-pub struct AgentLineage {
-    /// The subject agent's hex-encoded UUID.
-    pub agent_id: String,
-    /// Number of ancestors — 0 if the agent is a root.
-    pub ancestor_count: usize,
-    /// Ordered ancestors: index 0 is the direct parent, last element is the root.
-    pub ancestors: Vec<LineageStep>,
-}
-
-/// One step in an agent's ancestry chain.
-#[derive(Debug, Serialize, ToSchema)]
-pub struct LineageStep {
-    /// Hex-encoded UUID of this ancestor.
-    pub id: String,
-    /// Human-readable name of this ancestor.
-    pub name: String,
-    /// Delegation depth of this ancestor.
-    pub depth: u32,
-    /// Reason the next agent in the chain was delegated from this ancestor.
-    pub delegation_reason: Option<String>,
-    /// Team this ancestor belongs to.
-    pub team_id: Option<String>,
-}
-
-/// Aggregate topology statistics across all registered agents.
-#[derive(Debug, Serialize, ToSchema)]
-pub struct TopologyStats {
-    /// Total agents in the registry.
-    pub total_agents: usize,
-    /// Number of root agents (depth == 0).
-    pub root_agent_count: usize,
-    /// Maximum observed delegation depth.
-    pub max_depth: u32,
-    /// Agents currently in `Active` status.
-    pub active_count: usize,
-    /// Agents currently in `Suspended` status.
-    pub suspended_count: usize,
-    /// Agents in `Deregistered` status.
-    pub deregistered_count: usize,
-    /// Number of teams with at least one agent.
-    pub team_count: usize,
-    /// Agent count per team.
-    pub team_sizes: HashMap<String, usize>,
 }
 
 // ---------------------------------------------------------------------------
@@ -335,22 +185,18 @@ pub async fn get_overview(
         v
     };
 
-    let standalone_root_agents = filtered
+    let mut standalone_root_agents: Vec<AgentNode> = filtered
         .iter()
         .filter(|r| r.depth == 0 && r.team_id.is_none())
-        .map(|r| AgentNode {
-            id: format_id(&r.agent_id),
-            name: r.name.clone(),
-            depth: r.depth,
-            status: status_str(&r.status).to_owned(),
-            team_id: None,
-            governance_level: if show_budget {
-                Some(format!("{:?}", r.governance_level))
-            } else {
-                None
-            },
+        .map(|r| {
+            let mut node = AgentNode::from(*r);
+            if show_budget {
+                node.governance_level = Some(format!("{:?}", r.governance_level));
+            }
+            node
         })
         .collect();
+    standalone_root_agents.sort_by(|a, b| a.id.cmp(&b.id));
 
     (
         StatusCode::OK,
@@ -446,17 +292,12 @@ pub async fn get_team(
                 .map_or(true, |f| matches_status_filter(&r.status, f))
                 && params.min_depth.map_or(true, |d| r.depth >= d)
         })
-        .map(|r| AgentNode {
-            id: format_id(&r.agent_id),
-            name: r.name.clone(),
-            depth: r.depth,
-            status: status_str(&r.status).to_owned(),
-            team_id: r.team_id.clone(),
-            governance_level: if show_budget {
-                Some(format!("{:?}", r.governance_level))
-            } else {
-                None
-            },
+        .map(|r| {
+            let mut node = AgentNode::from(&r);
+            if show_budget {
+                node.governance_level = Some(format!("{:?}", r.governance_level));
+            }
+            node
         })
         .collect();
     members.sort_by_key(|m| m.depth);
@@ -472,11 +313,12 @@ pub async fn get_team(
     ))
 }
 
-/// `GET /api/v1/topology/lineage/{agent_id}` — ancestor chain from agent up to root.
+/// `GET /api/v1/topology/lineage/{agent_id}` — ancestor chain from root down to agent.
 ///
-/// Returns the ordered list of ancestors for the given agent, starting from its
-/// direct parent and ending at the root agent (depth 0). Each step includes the
-/// delegation reason and team membership. Returns 404 if the agent is unknown.
+/// Returns the ordered ancestry for the given agent, starting from the root
+/// (depth 0) and ending with the requested agent as the last element.
+/// A root agent returns a list of length 1 containing only itself.
+/// Returns 404 if the agent is unknown.
 #[utoipa::path(
     get,
     path = "/api/v1/topology/lineage/{agent_id}",
@@ -496,12 +338,16 @@ pub async fn get_lineage(
 ) -> Result<(StatusCode, Json<AgentLineage>), ProblemDetail> {
     let agent_id = parse_agent_id(&agent_id_str)?;
 
-    state.agent_registry.get(&agent_id).ok_or_else(|| {
+    let record = state.agent_registry.get(&agent_id).ok_or_else(|| {
         ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Agent not found: {agent_id_str}"))
     })?;
 
-    let ancestor_ids = state.agent_registry.ancestors_of(&agent_id);
-    let ancestors: Vec<LineageStep> = ancestor_ids
+    // ancestors_of returns parent-first (direct parent at [0], root at end).
+    // Reverse to root-first, then append the requested agent as the final element.
+    let mut ancestor_ids = state.agent_registry.ancestors_of(&agent_id);
+    ancestor_ids.reverse();
+
+    let mut ancestors: Vec<LineageStep> = ancestor_ids
         .iter()
         .filter_map(|id| state.agent_registry.get(id))
         .map(|r| LineageStep {
@@ -512,6 +358,14 @@ pub async fn get_lineage(
             team_id: r.team_id.clone(),
         })
         .collect();
+
+    ancestors.push(LineageStep {
+        id: format_id(&record.agent_id),
+        name: record.name.clone(),
+        depth: record.depth,
+        delegation_reason: record.delegation_reason.clone(),
+        team_id: record.team_id.clone(),
+    });
 
     let ancestor_count = ancestors.len();
     Ok((
@@ -632,74 +486,5 @@ mod tests {
     fn matches_status_filter_unknown_passes_all() {
         let status = AgentStatus::Active;
         assert!(matches_status_filter(&status, "unknown_value"));
-    }
-
-    #[test]
-    fn topology_stats_serializes() {
-        let stats = TopologyStats {
-            total_agents: 5,
-            root_agent_count: 2,
-            max_depth: 3,
-            active_count: 4,
-            suspended_count: 1,
-            deregistered_count: 0,
-            team_count: 2,
-            team_sizes: [("team-a".to_string(), 3), ("team-b".to_string(), 2)].into(),
-        };
-        let json = serde_json::to_value(&stats).unwrap();
-        assert_eq!(json["total_agents"], 5);
-        assert_eq!(json["root_agent_count"], 2);
-        assert_eq!(json["max_depth"], 3);
-        assert_eq!(json["team_count"], 2);
-    }
-
-    #[test]
-    fn agent_lineage_serializes() {
-        let lineage = AgentLineage {
-            agent_id: "aabbccdd00112233aabbccdd00112233".to_string(),
-            ancestor_count: 1,
-            ancestors: vec![LineageStep {
-                id: "00112233aabbccdd00112233aabbccdd".to_string(),
-                name: "root-agent".to_string(),
-                depth: 0,
-                delegation_reason: Some("spawned by orchestrator".to_string()),
-                team_id: Some("team-a".to_string()),
-            }],
-        };
-        let json = serde_json::to_value(&lineage).unwrap();
-        assert_eq!(json["ancestor_count"], 1);
-        assert_eq!(json["ancestors"][0]["name"], "root-agent");
-        assert_eq!(json["ancestors"][0]["depth"], 0);
-    }
-
-    #[test]
-    fn agent_node_omits_governance_level_when_none() {
-        let node = AgentNode {
-            id: "aa".to_string(),
-            name: "n".to_string(),
-            depth: 0,
-            status: "active".to_string(),
-            team_id: None,
-            governance_level: None,
-        };
-        let json = serde_json::to_value(&node).unwrap();
-        assert!(json.get("governance_level").is_none());
-    }
-
-    #[test]
-    fn agent_tree_leaf_has_empty_children() {
-        let leaf = AgentTree {
-            id: "aa".to_string(),
-            name: "leaf".to_string(),
-            depth: 3,
-            status: "active".to_string(),
-            team_id: None,
-            delegation_reason: None,
-            spawned_by_tool: None,
-            governance_level: None,
-            children: vec![],
-        };
-        let json = serde_json::to_value(&leaf).unwrap();
-        assert_eq!(json["children"].as_array().unwrap().len(), 0);
     }
 }

--- a/aa-api/tests/topology.rs
+++ b/aa-api/tests/topology.rs
@@ -335,8 +335,11 @@ async fn topology_lineage_root_agent_has_no_ancestors() {
     assert_eq!(response.status(), StatusCode::OK);
     let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    assert_eq!(json["ancestor_count"], 0);
-    assert!(json["ancestors"].as_array().unwrap().is_empty());
+    // A root agent's lineage contains only itself as the single element (root-first ordering).
+    assert_eq!(json["ancestor_count"], 1);
+    let ancestors = json["ancestors"].as_array().unwrap();
+    assert_eq!(ancestors.len(), 1);
+    assert_eq!(ancestors[0]["depth"], 0);
 }
 
 // ---------------------------------------------------------------------------

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -307,10 +307,11 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * `GET /api/v1/topology/lineage/{agent_id}` — ancestor chain from agent up to root.
-         * @description Returns the ordered list of ancestors for the given agent, starting from its
-         *     direct parent and ending at the root agent (depth 0). Each step includes the
-         *     delegation reason and team membership. Returns 404 if the agent is unknown.
+         * `GET /api/v1/topology/lineage/{agent_id}` — ancestor chain from root down to agent.
+         * @description Returns the ordered ancestry for the given agent, starting from the root
+         *     (depth 0) and ending with the requested agent as the last element.
+         *     A root agent returns a list of length 1 containing only itself.
+         *     Returns 404 if the agent is unknown.
          */
         get: operations["get_lineage"];
         put?: never;
@@ -498,16 +499,73 @@ export interface components {
             /** @description Total spend this month in USD for this agent (if monthly tracking is enabled). */
             monthly_spend_usd?: string | null;
         };
-        /** @description An agent's complete ancestry chain from direct parent up to root. */
+        /**
+         * @description An agent's complete ancestry chain ordered root-first.
+         *
+         *     The first element is the root agent; the last element is the requested
+         *     agent itself. A root agent returns a list of length 1 containing only itself.
+         *
+         *     # Example JSON
+         *     ```json
+         *     {
+         *       "agent_id": "aabbccdd00112233aabbccdd00112233",
+         *       "ancestor_count": 2,
+         *       "ancestors": [
+         *         { "id": "root000000000000root000000000000", "name": "root", "depth": 0, "delegation_reason": null, "team_id": null },
+         *         { "id": "aabbccdd00112233aabbccdd00112233", "name": "child", "depth": 1, "delegation_reason": "orchestrate", "team_id": "team-alpha" }
+         *       ]
+         *     }
+         *     ```
+         * @example {
+         *       "agent_id": "aabbccdd00112233aabbccdd00112233",
+         *       "ancestor_count": 2,
+         *       "ancestors": [
+         *         {
+         *           "delegation_reason": null,
+         *           "depth": 0,
+         *           "id": "root000000000000root000000000000",
+         *           "name": "root",
+         *           "team_id": null
+         *         },
+         *         {
+         *           "delegation_reason": "orchestrate",
+         *           "depth": 1,
+         *           "id": "aabbccdd00112233aabbccdd00112233",
+         *           "name": "child",
+         *           "team_id": "team-alpha"
+         *         }
+         *       ]
+         *     }
+         */
         AgentLineage: {
             /** @description The subject agent's hex-encoded UUID. */
             agent_id: string;
-            /** @description Number of ancestors — 0 if the agent is a root. */
+            /** @description Number of entries in `ancestors` (includes the agent itself). */
             ancestor_count: number;
-            /** @description Ordered ancestors: index 0 is the direct parent, last element is the root. */
+            /** @description Ordered ancestry: index 0 is the root agent, last element is the requested agent. */
             ancestors: components["schemas"]["LineageStep"][];
         };
-        /** @description Minimal agent representation used in list and tree responses. */
+        /**
+         * @description Minimal agent representation used in list and tree responses.
+         *
+         *     # Example JSON
+         *     ```json
+         *     {
+         *       "id": "0102030405060708090a0b0c0d0e0f10",
+         *       "name": "my-agent",
+         *       "depth": 1,
+         *       "status": "active",
+         *       "team_id": "team-alpha"
+         *     }
+         *     ```
+         * @example {
+         *       "depth": 1,
+         *       "id": "0102030405060708090a0b0c0d0e0f10",
+         *       "name": "my-agent",
+         *       "status": "active",
+         *       "team_id": "team-alpha"
+         *     }
+         */
         AgentNode: {
             /**
              * Format: int32
@@ -569,7 +627,33 @@ export interface components {
             /** @description Semver version string. */
             version: string;
         };
-        /** @description Recursive tree node representing an agent and all its descendants. */
+        /**
+         * @description Recursive tree node representing an agent and all its descendants.
+         *
+         *     # Example JSON
+         *     ```json
+         *     {
+         *       "id": "0102030405060708090a0b0c0d0e0f10",
+         *       "name": "root-agent",
+         *       "depth": 0,
+         *       "status": "active",
+         *       "team_id": "team-alpha",
+         *       "delegation_reason": null,
+         *       "spawned_by_tool": null,
+         *       "children": []
+         *     }
+         *     ```
+         * @example {
+         *       "children": [],
+         *       "delegation_reason": null,
+         *       "depth": 0,
+         *       "id": "0102030405060708090a0b0c0d0e0f10",
+         *       "name": "root-agent",
+         *       "spawned_by_tool": null,
+         *       "status": "active",
+         *       "team_id": "team-alpha"
+         *     }
+         */
         AgentTree: {
             children: components["schemas"]["AgentTree"][];
             /** @description Reason this agent was delegated from its parent, if recorded. */
@@ -772,20 +856,34 @@ export interface components {
             /** @description Gateway version (semver from Cargo.toml). */
             version: string;
         };
-        /** @description One step in an agent's ancestry chain. */
+        /**
+         * @description One step in an agent's ancestry chain.
+         *
+         *     # Example JSON
+         *     ```json
+         *     { "id": "root000000000000root000000000000", "name": "root", "depth": 0, "delegation_reason": null, "team_id": null }
+         *     ```
+         * @example {
+         *       "delegation_reason": null,
+         *       "depth": 0,
+         *       "id": "root000000000000root000000000000",
+         *       "name": "root",
+         *       "team_id": null
+         *     }
+         */
         LineageStep: {
-            /** @description Reason the next agent in the chain was delegated from this ancestor. */
+            /** @description Reason the next agent in the chain was delegated from this node. */
             delegation_reason?: string | null;
             /**
              * Format: int32
-             * @description Delegation depth of this ancestor.
+             * @description Delegation depth of this node.
              */
             depth: number;
-            /** @description Hex-encoded UUID of this ancestor. */
+            /** @description Hex-encoded UUID of this ancestor (or the subject agent). */
             id: string;
-            /** @description Human-readable name of this ancestor. */
+            /** @description Human-readable name. */
             name: string;
-            /** @description Team this ancestor belongs to. */
+            /** @description Team this node belongs to. */
             team_id?: string | null;
         };
         /** @description JSON representation of an audit log entry. */
@@ -900,7 +998,19 @@ export interface components {
             /** @description Team identifier. */
             team_id: string;
         };
-        /** @description High-level statistics for a single team. */
+        /**
+         * @description High-level statistics for a single team.
+         *
+         *     # Example JSON
+         *     ```json
+         *     { "team_id": "team-alpha", "agent_count": 7, "root_agent_count": 1 }
+         *     ```
+         * @example {
+         *       "agent_count": 7,
+         *       "root_agent_count": 1,
+         *       "team_id": "team-alpha"
+         *     }
+         */
         TeamSummary: {
             /** @description Total agents in this team. */
             agent_count: number;
@@ -909,7 +1019,19 @@ export interface components {
             /** @description Team identifier. */
             team_id: string;
         };
-        /** @description All agents belonging to a single team. */
+        /**
+         * @description All agents belonging to a single team.
+         *
+         *     # Example JSON
+         *     ```json
+         *     { "team_id": "team-alpha", "agent_count": 2, "members": [] }
+         *     ```
+         * @example {
+         *       "agent_count": 2,
+         *       "members": [],
+         *       "team_id": "team-alpha"
+         *     }
+         */
         TeamTopology: {
             /** @description Number of agents in this team (after filtering). */
             agent_count: number;
@@ -938,20 +1060,75 @@ export interface components {
             /** @description The issued JWT token string. */
             token: string;
         };
-        /** @description Overview of the entire agent topology across all teams. */
+        /**
+         * @description Overview of the entire agent topology across all teams.
+         *
+         *     # Example JSON
+         *     ```json
+         *     {
+         *       "team_count": 2,
+         *       "root_agent_count": 3,
+         *       "total_agent_count": 12,
+         *       "teams": [{ "team_id": "team-alpha", "agent_count": 7, "root_agent_count": 1 }],
+         *       "standalone_root_agents": []
+         *     }
+         *     ```
+         * @example {
+         *       "root_agent_count": 3,
+         *       "standalone_root_agents": [],
+         *       "team_count": 2,
+         *       "teams": [
+         *         {
+         *           "agent_count": 7,
+         *           "root_agent_count": 1,
+         *           "team_id": "team-alpha"
+         *         }
+         *       ],
+         *       "total_agent_count": 12
+         *     }
+         */
         TopologyOverview: {
             /** @description Number of root agents (depth == 0) across all teams. */
             root_agent_count: number;
-            /** @description Root agents that are not assigned to any team. */
+            /** @description Root agents that are not assigned to any team, sorted by agent id. */
             standalone_root_agents: components["schemas"]["AgentNode"][];
             /** @description Number of teams with at least one registered agent. */
             team_count: number;
-            /** @description Per-team agent count summaries. */
+            /** @description Per-team agent count summaries, sorted by team_id. */
             teams: components["schemas"]["TeamSummary"][];
             /** @description Total number of agents in the registry. */
             total_agent_count: number;
         };
-        /** @description Aggregate topology statistics across all registered agents. */
+        /**
+         * @description Aggregate topology statistics across all registered agents.
+         *
+         *     # Example JSON
+         *     ```json
+         *     {
+         *       "total_agents": 15,
+         *       "root_agent_count": 3,
+         *       "max_depth": 4,
+         *       "active_count": 12,
+         *       "suspended_count": 2,
+         *       "deregistered_count": 1,
+         *       "team_count": 2,
+         *       "team_sizes": { "team-alpha": 8, "team-beta": 4 }
+         *     }
+         *     ```
+         * @example {
+         *       "active_count": 12,
+         *       "deregistered_count": 1,
+         *       "max_depth": 4,
+         *       "root_agent_count": 3,
+         *       "suspended_count": 2,
+         *       "team_count": 2,
+         *       "team_sizes": {
+         *         "team-alpha": 8,
+         *         "team-beta": 4
+         *       },
+         *       "total_agents": 15
+         *     }
+         */
         TopologyStats: {
             /** @description Agents currently in `Active` status. */
             active_count: number;

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -504,11 +504,12 @@ paths:
     get:
       tags:
       - topology
-      summary: '`GET /api/v1/topology/lineage/{agent_id}` — ancestor chain from agent up to root.'
+      summary: '`GET /api/v1/topology/lineage/{agent_id}` — ancestor chain from root down to agent.'
       description: |-
-        Returns the ordered list of ancestors for the given agent, starting from its
-        direct parent and ending at the root agent (depth 0). Each step includes the
-        delegation reason and team membership. Returns 404 if the agent is unknown.
+        Returns the ordered ancestry for the given agent, starting from the root
+        (depth 0) and ending with the requested agent as the last element.
+        A root agent returns a list of length 1 containing only itself.
+        Returns 404 if the agent is unknown.
       operationId: get_lineage
       parameters:
       - name: agent_id
@@ -836,7 +837,23 @@ components:
           description: Total spend this month in USD for this agent (if monthly tracking is enabled).
     AgentLineage:
       type: object
-      description: An agent's complete ancestry chain from direct parent up to root.
+      description: |-
+        An agent's complete ancestry chain ordered root-first.
+
+        The first element is the root agent; the last element is the requested
+        agent itself. A root agent returns a list of length 1 containing only itself.
+
+        # Example JSON
+        ```json
+        {
+          "agent_id": "aabbccdd00112233aabbccdd00112233",
+          "ancestor_count": 2,
+          "ancestors": [
+            { "id": "root000000000000root000000000000", "name": "root", "depth": 0, "delegation_reason": null, "team_id": null },
+            { "id": "aabbccdd00112233aabbccdd00112233", "name": "child", "depth": 1, "delegation_reason": "orchestrate", "team_id": "team-alpha" }
+          ]
+        }
+        ```
       required:
       - agent_id
       - ancestor_count
@@ -847,16 +864,42 @@ components:
           description: The subject agent's hex-encoded UUID.
         ancestor_count:
           type: integer
-          description: Number of ancestors — 0 if the agent is a root.
+          description: Number of entries in `ancestors` (includes the agent itself).
           minimum: 0
         ancestors:
           type: array
           items:
             $ref: '#/components/schemas/LineageStep'
-          description: 'Ordered ancestors: index 0 is the direct parent, last element is the root.'
+          description: 'Ordered ancestry: index 0 is the root agent, last element is the requested agent.'
+      example:
+        agent_id: aabbccdd00112233aabbccdd00112233
+        ancestor_count: 2
+        ancestors:
+        - delegation_reason: null
+          depth: 0
+          id: root000000000000root000000000000
+          name: root
+          team_id: null
+        - delegation_reason: orchestrate
+          depth: 1
+          id: aabbccdd00112233aabbccdd00112233
+          name: child
+          team_id: team-alpha
     AgentNode:
       type: object
-      description: Minimal agent representation used in list and tree responses.
+      description: |-
+        Minimal agent representation used in list and tree responses.
+
+        # Example JSON
+        ```json
+        {
+          "id": "0102030405060708090a0b0c0d0e0f10",
+          "name": "my-agent",
+          "depth": 1,
+          "status": "active",
+          "team_id": "team-alpha"
+        }
+        ```
       required:
       - id
       - name
@@ -887,6 +930,12 @@ components:
           - string
           - 'null'
           description: Team this agent belongs to, if any.
+      example:
+        depth: 1
+        id: 0102030405060708090a0b0c0d0e0f10
+        name: my-agent
+        status: active
+        team_id: team-alpha
     AgentResponse:
       type: object
       description: JSON representation of an agent returned by the API.
@@ -975,7 +1024,22 @@ components:
           description: Semver version string.
     AgentTree:
       type: object
-      description: Recursive tree node representing an agent and all its descendants.
+      description: |-
+        Recursive tree node representing an agent and all its descendants.
+
+        # Example JSON
+        ```json
+        {
+          "id": "0102030405060708090a0b0c0d0e0f10",
+          "name": "root-agent",
+          "depth": 0,
+          "status": "active",
+          "team_id": "team-alpha",
+          "delegation_reason": null,
+          "spawned_by_tool": null,
+          "children": []
+        }
+        ```
       required:
       - id
       - name
@@ -1021,6 +1085,15 @@ components:
           - string
           - 'null'
           description: Team this agent belongs to, if any.
+      example:
+        children: []
+        delegation_reason: null
+        depth: 0
+        id: 0102030405060708090a0b0c0d0e0f10
+        name: root-agent
+        spawned_by_tool: null
+        status: active
+        team_id: team-alpha
     AlertResponse:
       type: object
       description: JSON representation of a governance alert.
@@ -1305,7 +1378,13 @@ components:
           description: Gateway version (semver from Cargo.toml).
     LineageStep:
       type: object
-      description: One step in an agent's ancestry chain.
+      description: |-
+        One step in an agent's ancestry chain.
+
+        # Example JSON
+        ```json
+        { "id": "root000000000000root000000000000", "name": "root", "depth": 0, "delegation_reason": null, "team_id": null }
+        ```
       required:
       - id
       - name
@@ -1315,23 +1394,29 @@ components:
           type:
           - string
           - 'null'
-          description: Reason the next agent in the chain was delegated from this ancestor.
+          description: Reason the next agent in the chain was delegated from this node.
         depth:
           type: integer
           format: int32
-          description: Delegation depth of this ancestor.
+          description: Delegation depth of this node.
           minimum: 0
         id:
           type: string
-          description: Hex-encoded UUID of this ancestor.
+          description: Hex-encoded UUID of this ancestor (or the subject agent).
         name:
           type: string
-          description: Human-readable name of this ancestor.
+          description: Human-readable name.
         team_id:
           type:
           - string
           - 'null'
-          description: Team this ancestor belongs to.
+          description: Team this node belongs to.
+      example:
+        delegation_reason: null
+        depth: 0
+        id: root000000000000root000000000000
+        name: root
+        team_id: null
     LogEntry:
       type: object
       description: JSON representation of an audit log entry.
@@ -1528,7 +1613,13 @@ components:
           description: Team identifier.
     TeamSummary:
       type: object
-      description: High-level statistics for a single team.
+      description: |-
+        High-level statistics for a single team.
+
+        # Example JSON
+        ```json
+        { "team_id": "team-alpha", "agent_count": 7, "root_agent_count": 1 }
+        ```
       required:
       - team_id
       - agent_count
@@ -1545,9 +1636,19 @@ components:
         team_id:
           type: string
           description: Team identifier.
+      example:
+        agent_count: 7
+        root_agent_count: 1
+        team_id: team-alpha
     TeamTopology:
       type: object
-      description: All agents belonging to a single team.
+      description: |-
+        All agents belonging to a single team.
+
+        # Example JSON
+        ```json
+        { "team_id": "team-alpha", "agent_count": 2, "members": [] }
+        ```
       required:
       - team_id
       - agent_count
@@ -1565,6 +1666,10 @@ components:
         team_id:
           type: string
           description: Team identifier.
+      example:
+        agent_count: 2
+        members: []
+        team_id: team-alpha
     TokenRequest:
       type: object
       description: Request body for `POST /auth/token`.
@@ -1601,7 +1706,19 @@ components:
           description: The issued JWT token string.
     TopologyOverview:
       type: object
-      description: Overview of the entire agent topology across all teams.
+      description: |-
+        Overview of the entire agent topology across all teams.
+
+        # Example JSON
+        ```json
+        {
+          "team_count": 2,
+          "root_agent_count": 3,
+          "total_agent_count": 12,
+          "teams": [{ "team_id": "team-alpha", "agent_count": 7, "root_agent_count": 1 }],
+          "standalone_root_agents": []
+        }
+        ```
       required:
       - team_count
       - root_agent_count
@@ -1617,7 +1734,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/AgentNode'
-          description: Root agents that are not assigned to any team.
+          description: Root agents that are not assigned to any team, sorted by agent id.
         team_count:
           type: integer
           description: Number of teams with at least one registered agent.
@@ -1626,14 +1743,38 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/TeamSummary'
-          description: Per-team agent count summaries.
+          description: Per-team agent count summaries, sorted by team_id.
         total_agent_count:
           type: integer
           description: Total number of agents in the registry.
           minimum: 0
+      example:
+        root_agent_count: 3
+        standalone_root_agents: []
+        team_count: 2
+        teams:
+        - agent_count: 7
+          root_agent_count: 1
+          team_id: team-alpha
+        total_agent_count: 12
     TopologyStats:
       type: object
-      description: Aggregate topology statistics across all registered agents.
+      description: |-
+        Aggregate topology statistics across all registered agents.
+
+        # Example JSON
+        ```json
+        {
+          "total_agents": 15,
+          "root_agent_count": 3,
+          "max_depth": 4,
+          "active_count": 12,
+          "suspended_count": 2,
+          "deregistered_count": 1,
+          "team_count": 2,
+          "team_sizes": { "team-alpha": 8, "team-beta": 4 }
+        }
+        ```
       required:
       - total_agents
       - root_agent_count
@@ -1681,6 +1822,17 @@ components:
           type: integer
           description: Total agents in the registry.
           minimum: 0
+      example:
+        active_count: 12
+        deregistered_count: 1
+        max_depth: 4
+        root_agent_count: 3
+        suspended_count: 2
+        team_count: 2
+        team_sizes:
+          team-alpha: 8
+          team-beta: 4
+        total_agents: 15
     TraceResponse:
       type: object
       description: Full trace for one agent session.


### PR DESCRIPTION
## Description

Extracts all topology response types from `routes/topology.rs` into a dedicated `aa-api/src/models/topology.rs` module. Key additions:

- `Deserialize + PartialEq` added to every response type (`TopologyOverview`, `TeamSummary`, `AgentNode`, `AgentTree`, `TeamTopology`, `AgentLineage`, `LineageStep`, `TopologyStats`)
- `#[schema(example = json!(...))]` annotation on every struct for OpenAPI doc generation
- `From<&AgentRecord> for AgentNode` impl so handlers can `.into()` cleanly
- Round-trip serde tests for all 7 types (`serialize → deserialize → assert_eq`)
- `routes/topology.rs` re-exports the types so `openapi.rs` reference paths are unchanged

Also fixes lineage ordering: `ancestors_of` returns parent-first; now reversed so the chain is root-first with the requested agent appended as the last element. Updates the existing `topology_lineage_root_agent_has_no_ancestors` test to match the corrected AC (root agent lineage = `[itself]`, `ancestor_count = 1`).

## Type of Change

- [x] ✨ New feature
- [x] 🐛 Bug fix

## Breaking Changes

- [ ] No
- [x] Yes — `AgentLineage.ancestor_count` for a root agent changes from `0` to `1`; `ancestors` now includes the subject agent as the last element (root-first ordering). Consumers calling `GET /api/v1/topology/lineage/{id}` on a root agent will see this change.

## Related Issues

- Related Jira ticket: AAASM-1009
- Parent story: AAASM-214 (F87: Implement 5 topology REST API endpoints)

## Testing

- [x] Unit tests added / updated — 8 round-trip serde tests in `models/topology.rs`
- [x] Integration tests added / updated — updated `topology_lineage_root_agent_has_no_ancestors` in `tests/topology.rs`
- [ ] Manual testing performed
- [ ] No tests required (explain why)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention