### PR TITLE
[AAASM-1187] 🐛 (.devcontainer): Add GitHub Codespaces devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "name": "agent-assembly",
+  "image": "mcr.microsoft.com/devcontainers/rust:1",
+  "features": {
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "stable"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.12"
+    }
+  },
+  "postCreateCommand": "sudo apt-get install -y protobuf-compiler && cargo install cargo-nextest --locked && cargo install cargo-deny --locked && pip install pre-commit && pre-commit install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "serayuzgur.crates",
+        "tamasfe.even-better-toml",
+        "fill-labs.dependi"
+      ],
+      "settings": {
+        "rust-analyzer.cargo.buildScripts.enable": true,
+        "rust-analyzer.checkOnSave.command": "clippy"
+      }
+    }
+  },
+  "remoteEnv": {
+    "CARGO_INCREMENTAL": "1"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ These two are built by `aa-ebpf/build.rs` (via `aya-build`) for the BPF target â
 <!-- docs-site: <asciinema-player src="quickstart.cast" cols="220" rows="50" preload="true"></asciinema-player> -->
 
 > **Demo recording:** `asciinema play docs/quickstart.cast`
+>
+> **Prefer Codespaces?** [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/AI-agent-assembly/agent-assembly)
+> The `.devcontainer/` config installs all dependencies automatically.
 
 Get from a fresh clone to a verified local environment in under 10 minutes.
 


### PR DESCRIPTION
## Summary

- Adds `.devcontainer/devcontainer.json` using `mcr.microsoft.com/devcontainers/rust:1` as the base image
- Installs Go (stable), Node 20, and Python 3.12 as devcontainer features
- `postCreateCommand` installs `protoc`, `cargo-nextest`, `cargo-deny`, and `pre-commit` so `make dev-setup` and `make dev-verify` pass inside the container without any manual setup
- Adds VS Code extension recommendations (`rust-analyzer`, `crates`, `even-better-toml`, `dependi`) and sets `checkOnSave` to clippy
- Adds "Open in GitHub Codespaces" badge to the README Quickstart section

## What changed and why

AAASM-1154 verification identified that AAASM-109 AC #6 (GitHub Codespaces `.devcontainer/` config) was never implemented. This PR closes that gap, allowing contributors without a local Rust toolchain to open the repo in Codespaces and have a fully working dev environment automatically.

## How to verify

1. Open the repo in GitHub Codespaces — container builds without error
2. Inside the container: `cargo build --workspace --exclude aa-ebpf` succeeds
3. Inside the container: `cargo nextest run --workspace --exclude aa-ebpf` passes
4. README shows the "Open in GitHub Codespaces" badge in the Quickstart section

## Related

Fixes AAASM-1187 (Bug subtask under AAASM-109)

🤖 Generated with [Claude Code](https://claude.com/claude-code)