### PR TITLE
[AAASM-1188] 🐛 (scripts): Add curl one-line installer for aasm CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,29 @@
 [![crates.io](https://img.shields.io/badge/crates.io-unpublished-lightgrey)](https://crates.io/)
 
 
+## Install the CLI
+
+```sh
+curl -sSf https://install.ai-agent-assembly.dev | sh
+```
+
+This downloads and installs the `aasm` binary to `~/.local/bin`. Requires a
+[published release](https://github.com/AI-agent-assembly/agent-assembly/releases).
+The installer script lives at [`scripts/install-cli.sh`](scripts/install-cli.sh).
+
+```sh
+# Pin a specific version
+AASM_VERSION=v0.1.0 curl -sSf https://install.ai-agent-assembly.dev | sh
+
+# Custom install directory
+AASM_INSTALL_DIR=/usr/local/bin curl -sSf https://install.ai-agent-assembly.dev | sh
+```
+
 ## Overview
 
-`agent-assembly` is the core runtime that brings governance to AI agents at scale. It provides a three-layer interception model — eBPF kernel hooks, a sidecar proxy, and an SDK shim — backed by a policy engine and audit trail.
+`agent-assembly` is the core runtime that brings governance to AI agents at
+scale. It provides a three-layer interception model — eBPF kernel hooks, a
+sidecar proxy, and an SDK shim — backed by a policy engine and audit trail.
 
 ## Crate Map
 

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# One-line installer for the aasm CLI.
+# Usage: curl -sSf https://install.ai-agent-assembly.dev | sh
+#
+# Environment overrides:
+#   AASM_INSTALL_DIR   Installation directory (default: ~/.local/bin)
+#   AASM_VERSION       Specific release tag to install (default: latest)
+#   AASM_NO_MODIFY_PATH  Set to 1 to skip PATH modification hint
+set -eu
+
+REPO="AI-agent-assembly/agent-assembly"
+BINARY="aasm"
+INSTALL_DIR="${AASM_INSTALL_DIR:-$HOME/.local/bin}"
+VERSION="${AASM_VERSION:-}"
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+say()  { printf '\033[1m%s\033[0m\n' "$*"; }
+warn() { printf '\033[33mwarning:\033[0m %s\n' "$*" >&2; }
+err()  { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || err "required tool not found: $1 — install it and retry"
+}
+
+# ── detect platform ───────────────────────────────────────────────────────────
+
+detect_os() {
+  case "$(uname -s)" in
+    Darwin) echo "macos" ;;
+    Linux)  echo "linux" ;;
+    *)      err "unsupported OS: $(uname -s)" ;;
+  esac
+}
+
+detect_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64)   echo "x86_64" ;;
+    arm64|aarch64)  echo "aarch64" ;;
+    *)              err "unsupported architecture: $(uname -m)" ;;
+  esac
+}
+
+# ── fetch latest release tag ──────────────────────────────────────────────────
+
+latest_release() {
+  need curl
+  tag=$(curl -sSf "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep '"tag_name"' | head -1 | cut -d'"' -f4)
+  [ -n "$tag" ] || err "could not determine latest release — does ${REPO} have a published release?"
+  echo "$tag"
+}
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+main() {
+  need curl
+  need tar
+
+  OS="$(detect_os)"
+  ARCH="$(detect_arch)"
+
+  if [ -z "$VERSION" ]; then
+    say "Fetching latest release ..."
+    VERSION="$(latest_release)"
+  fi
+
+  TARBALL="${BINARY}-${VERSION}-${ARCH}-${OS}.tar.gz"
+  URL="https://github.com/${REPO}/releases/download/${VERSION}/${TARBALL}"
+
+  say "Installing ${BINARY} ${VERSION} (${ARCH}-${OS}) ..."
+
+  TMP="$(mktemp -d)"
+  # shellcheck disable=SC2064
+  trap "rm -rf '$TMP'" EXIT
+
+  curl -sSfL "$URL" -o "${TMP}/${TARBALL}" \
+    || err "download failed: ${URL}\n  Make sure ${VERSION} has a published release for ${ARCH}-${OS}."
+
+  tar -C "$TMP" -xzf "${TMP}/${TARBALL}" "${BINARY}" \
+    || err "failed to extract ${BINARY} from ${TARBALL}"
+
+  mkdir -p "$INSTALL_DIR"
+  install -m755 "${TMP}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+
+  say "Installed: ${INSTALL_DIR}/${BINARY}"
+
+  # PATH hint
+  case ":${PATH}:" in
+    *:"${INSTALL_DIR}":*) ;;
+    *)
+      if [ "${AASM_NO_MODIFY_PATH:-0}" != "1" ]; then
+        warn "${INSTALL_DIR} is not in your PATH."
+        warn "Add the following to your shell profile:"
+        warn "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+      fi
+      ;;
+  esac
+
+  "${INSTALL_DIR}/${BINARY}" --version
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds `scripts/install-cli.sh` — a POSIX shell one-line installer that detects OS/arch, fetches the latest GitHub Release tag, downloads the correct binary tarball, and installs `aasm` to `~/.local/bin`
- Supports `AASM_VERSION` (pin a release), `AASM_INSTALL_DIR` (custom path), and `AASM_NO_MODIFY_PATH` env vars
- Adds `## Install the CLI` section to README documenting `curl -sSf https://install.ai-agent-assembly.dev | sh` with env-var override examples

## What changed and why

AAASM-1154 verification identified that AAASM-109 AC #1 (curl one-line installer / `brew install aasm`) was never implemented. This PR delivers the **script artifact** — the installer shell script that will be hosted at `install.ai-agent-assembly.dev` once a binary release pipeline is in place.

> **Note:** The hosted URL (`install.ai-agent-assembly.dev`) and binary releases on GitHub Releases are prerequisite infrastructure not included here. The script will report an error until at least one release is published.

## How to verify

1. `bash -n scripts/install-cli.sh` — syntax check passes
2. `AASM_VERSION=v0.0.1 AASM_INSTALL_DIR=/tmp/test bash scripts/install-cli.sh` — fails gracefully with "download failed" (no release exists yet), not a crash
3. README shows the `Install the CLI` section with curl command and env-var docs

## Related

Fixes AAASM-1188 (Bug subtask under AAASM-109)

🤖 Generated with [Claude Code](https://claude.com/claude-code)