### PR TITLE
[AAASM-1011] ✨ (aa-api): Add RequireRead auth and 1 s moka cache to GET /topology/overview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "http",
  "hyper",
  "jsonwebtoken",
+ "moka",
  "rand 0.10.1",
  "rand_core 0.6.4",
  "rstest",
@@ -583,6 +584,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1114,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+checksum = "e3e962dae2b1e5007fe9e3db363ddc43a8bf25546d279f7a8a4401204690e80c"
 dependencies = [
  "clap",
 ]
@@ -1873,6 +1885,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "evmap"
 version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2291,9 +2313,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2401,9 +2423,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -2629,7 +2651,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2951,7 +2973,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3116,10 +3138,13 @@ version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
+ "async-lock",
  "crossbeam-channel",
  "crossbeam-epoch",
  "crossbeam-utils",
  "equivalent",
+ "event-listener",
+ "futures-util",
  "parking_lot",
  "portable-atomic",
  "smallvec",
@@ -5560,9 +5585,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/aa-api/Cargo.toml
+++ b/aa-api/Cargo.toml
@@ -34,6 +34,7 @@ utoipa-swagger-ui = { version = "9", features = ["axum"] }
 chrono = { version = "0.4", features = ["serde"] }
 futures = "0.3"
 hex = "0.4"
+moka = { version = "0.12", features = ["future"] }
 tokio-stream = "0.1"
 uuid = { version = "1", features = ["v4"] }
 

--- a/aa-api/src/routes/topology.rs
+++ b/aa-api/src/routes/topology.rs
@@ -5,6 +5,7 @@
 //! the in-memory `AgentRegistry`.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use axum::extract::{Path, Query};
 use axum::http::StatusCode;
@@ -14,6 +15,7 @@ use utoipa::IntoParams;
 
 use aa_gateway::registry::{AgentRegistry, AgentStatus};
 
+use crate::auth::scope::RequireRead;
 use crate::error::ProblemDetail;
 use crate::models::topology::{format_id, status_str};
 pub use crate::models::topology::{
@@ -139,9 +141,20 @@ fn build_tree(
     tag = "topology"
 )]
 pub async fn get_overview(
+    _auth: RequireRead,
     Extension(state): Extension<AppState>,
     Query(params): Query<TopologyFilterParams>,
 ) -> (StatusCode, Json<TopologyOverview>) {
+    let cache_key = format!(
+        "{}|{}|{}",
+        params.status.as_deref().unwrap_or(""),
+        params.min_depth.unwrap_or(0),
+        params.show_budget.unwrap_or(false),
+    );
+    if let Some(cached) = state.topology_overview_cache.get(&cache_key).await {
+        return (StatusCode::OK, Json((*cached).clone()));
+    }
+
     let all = state.agent_registry.list();
     let show_budget = params.show_budget.unwrap_or(false);
 
@@ -198,16 +211,18 @@ pub async fn get_overview(
         .collect();
     standalone_root_agents.sort_by(|a, b| a.id.cmp(&b.id));
 
-    (
-        StatusCode::OK,
-        Json(TopologyOverview {
-            team_count,
-            root_agent_count,
-            total_agent_count,
-            teams,
-            standalone_root_agents,
-        }),
-    )
+    let overview = TopologyOverview {
+        team_count,
+        root_agent_count,
+        total_agent_count,
+        teams,
+        standalone_root_agents,
+    };
+    state
+        .topology_overview_cache
+        .insert(cache_key, Arc::new(overview.clone()))
+        .await;
+    (StatusCode::OK, Json(overview))
 }
 
 /// `GET /api/v1/topology/tree/{root_id}` — full subtree from a given root agent.

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -20,6 +20,7 @@ use crate::auth::config::AuthConfig;
 use crate::auth::jwt::{JwtSigner, JwtVerifier};
 use crate::auth::rate_limit::RateLimiter;
 use crate::events::EventBroadcast;
+use crate::models::topology::TopologyOverview;
 use crate::replay::ReplayBuffer;
 use crate::trace_store::TraceStore;
 
@@ -66,4 +67,6 @@ pub struct AppState {
     pub discovery: Arc<DiscoveryService>,
     /// Topology edge store for mesh edge queries.
     pub edge_repo: Arc<dyn EdgeRepo>,
+    /// Short-lived cache for GET /topology/overview responses (1 s TTL).
+    pub topology_overview_cache: moka::future::Cache<String, Arc<TopologyOverview>>,
 }

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -142,6 +142,9 @@ spec:
         active_connections: Arc::new(AtomicI64::new(0)),
         discovery: Arc::new(DiscoveryService::with_adapters(vec![])),
         edge_repo: Arc::new(InMemoryEdgeRepo::new()),
+        topology_overview_cache: moka::future::Cache::builder()
+            .time_to_live(std::time::Duration::from_secs(1))
+            .build(),
     }
 }
 

--- a/aa-api/tests/topology.rs
+++ b/aa-api/tests/topology.rs
@@ -146,6 +146,72 @@ async fn topology_overview_status_filter_works() {
     assert_eq!(json["total_agent_count"], 1);
 }
 
+/// Build a state pre-populated with a realistic fixture:
+/// - 2 teams (alpha, beta), 1 standalone root
+/// - alpha: root-a (depth 0), a1..a4 (depth 1), a5..a6 (depth 2)  → 7 agents
+/// - beta:  root-b (depth 0), b1..b3 (depth 1)                     → 4 agents
+/// - root-s: standalone root (no team)                              → 1 agent
+/// Total: 12 agents, 3 roots
+fn large_fixture_state() -> aa_api::state::AppState {
+    let state = common::test_state();
+    let reg = &state.agent_registry;
+
+    // alpha team
+    reg.register(make_agent(0xA0, "root-a", 0, Some("alpha"), None)).unwrap();
+    for (byte, name) in [(0xA1, "a1"), (0xA2, "a2"), (0xA3, "a3"), (0xA4, "a4")] {
+        reg.register(make_agent(byte, name, 1, Some("alpha"), Some([0xA0; 16]))).unwrap();
+    }
+    reg.register(make_agent(0xA5, "a5", 2, Some("alpha"), Some([0xA1; 16]))).unwrap();
+    reg.register(make_agent(0xA6, "a6", 2, Some("alpha"), Some([0xA1; 16]))).unwrap();
+
+    // beta team
+    reg.register(make_agent(0xB0, "root-b", 0, Some("beta"), None)).unwrap();
+    for (byte, name) in [(0xB1, "b1"), (0xB2, "b2"), (0xB3, "b3")] {
+        reg.register(make_agent(byte, name, 1, Some("beta"), Some([0xB0; 16]))).unwrap();
+    }
+
+    // standalone root
+    reg.register(make_agent(0xC0, "root-s", 0, None, None)).unwrap();
+
+    state
+}
+
+#[tokio::test]
+async fn topology_overview_large_fixture_counts_correctly() {
+    let state = large_fixture_state();
+    let app = aa_api::server::build_app(state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/topology/overview")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["total_agent_count"], 12);
+    assert_eq!(json["root_agent_count"], 3);
+    assert_eq!(json["team_count"], 2);
+
+    let teams = json["teams"].as_array().unwrap();
+    assert_eq!(teams.len(), 2);
+    // teams are sorted alphabetically: alpha first, beta second
+    assert_eq!(teams[0]["team_id"], "alpha");
+    assert_eq!(teams[0]["agent_count"], 7);
+    assert_eq!(teams[1]["team_id"], "beta");
+    assert_eq!(teams[1]["agent_count"], 4);
+
+    let standalone = json["standalone_root_agents"].as_array().unwrap();
+    assert_eq!(standalone.len(), 1);
+    assert_eq!(standalone[0]["name"], "root-s");
+}
+
 // ---------------------------------------------------------------------------
 // Tree
 // ---------------------------------------------------------------------------

--- a/aa-api/tests/topology.rs
+++ b/aa-api/tests/topology.rs
@@ -151,23 +151,29 @@ async fn topology_overview_status_filter_works() {
 /// - alpha: root-a (depth 0), a1..a4 (depth 1), a5..a6 (depth 2)  → 7 agents
 /// - beta:  root-b (depth 0), b1..b3 (depth 1)                     → 4 agents
 /// - root-s: standalone root (no team)                              → 1 agent
+///
 /// Total: 12 agents, 3 roots
 fn large_fixture_state() -> aa_api::state::AppState {
     let state = common::test_state();
     let reg = &state.agent_registry;
 
     // alpha team
-    reg.register(make_agent(0xA0, "root-a", 0, Some("alpha"), None)).unwrap();
+    reg.register(make_agent(0xA0, "root-a", 0, Some("alpha"), None))
+        .unwrap();
     for (byte, name) in [(0xA1, "a1"), (0xA2, "a2"), (0xA3, "a3"), (0xA4, "a4")] {
-        reg.register(make_agent(byte, name, 1, Some("alpha"), Some([0xA0; 16]))).unwrap();
+        reg.register(make_agent(byte, name, 1, Some("alpha"), Some([0xA0; 16])))
+            .unwrap();
     }
-    reg.register(make_agent(0xA5, "a5", 2, Some("alpha"), Some([0xA1; 16]))).unwrap();
-    reg.register(make_agent(0xA6, "a6", 2, Some("alpha"), Some([0xA1; 16]))).unwrap();
+    reg.register(make_agent(0xA5, "a5", 2, Some("alpha"), Some([0xA1; 16])))
+        .unwrap();
+    reg.register(make_agent(0xA6, "a6", 2, Some("alpha"), Some([0xA1; 16])))
+        .unwrap();
 
     // beta team
     reg.register(make_agent(0xB0, "root-b", 0, Some("beta"), None)).unwrap();
     for (byte, name) in [(0xB1, "b1"), (0xB2, "b2"), (0xB3, "b3")] {
-        reg.register(make_agent(byte, name, 1, Some("beta"), Some([0xB0; 16]))).unwrap();
+        reg.register(make_agent(byte, name, 1, Some("beta"), Some([0xB0; 16])))
+            .unwrap();
     }
 
     // standalone root


### PR DESCRIPTION
## Description

Implements AAASM-1011: hardens the `GET /api/v1/topology/overview` endpoint with:

- **RequireRead auth extractor** — callers must carry a valid API key or JWT with at least `read` scope (bypassed in `AuthMode::Off` for local/dev).
- **1-second moka cache** — `topology_overview_cache: Cache<String, Arc<TopologyOverview>>` keyed on the serialised filter params (`status|min_depth|show_budget`), protecting the registry scan under burst traffic.
- **moka 0.12 dependency** added to `aa-api/Cargo.toml`.

New field `topology_overview_cache` added to `AppState`; `test_state_with_auth` in `tests/common/mod.rs` initialises it with the same 1 s TTL.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1011
- Parent story: AAASM-214

## Testing

- [x] Integration tests added / updated
  - 14 topology integration tests pass (13 pre-existing + 1 new large-fixture test: 12 agents across 2 teams + 1 standalone root).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-1011