### PR TITLE
[AAASM-1015] ✨ (aa-api): Add RequireRead auth, 422 non-root check, and 5 s cache to GET /topology/tree/{root_id}

### DIFF
--- a/aa-api/src/routes/topology.rs
+++ b/aa-api/src/routes/topology.rs
@@ -230,6 +230,7 @@ pub async fn get_overview(
 /// Recursively walks the delegation tree starting from the given agent, up to
 /// a configurable depth (default 10, maximum 10). Nodes can be filtered by
 /// status. Returns a nested JSON tree with each agent's children inline.
+/// Returns 422 if the agent exists but is not a root (depth > 0).
 #[utoipa::path(
     get,
     path = "/api/v1/topology/tree/{root_id}",
@@ -240,11 +241,13 @@ pub async fn get_overview(
     responses(
         (status = 200, description = "Agent subtree", body = AgentTree),
         (status = 400, description = "Invalid agent ID format"),
-        (status = 404, description = "Agent not found")
+        (status = 404, description = "Agent not found"),
+        (status = 422, description = "Agent is not a root agent")
     ),
     tag = "topology"
 )]
 pub async fn get_tree(
+    _auth: RequireRead,
     Extension(state): Extension<AppState>,
     Path(root_id): Path<String>,
     Query(params): Query<TreeParams>,
@@ -252,6 +255,29 @@ pub async fn get_tree(
     let agent_id = parse_agent_id(&root_id)?;
     let max_depth = params.depth.unwrap_or(MAX_TREE_DEPTH).min(MAX_TREE_DEPTH);
     let show_budget = params.show_budget.unwrap_or(false);
+
+    // Validate the starting agent exists and is a root before hitting the cache.
+    if let Some(record) = state.agent_registry.get(&agent_id) {
+        if record.depth > 0 {
+            return Err(ProblemDetail::from_status(StatusCode::UNPROCESSABLE_ENTITY)
+                .with_detail(format!("Agent {root_id} is not a root agent (depth {})", record.depth)));
+        }
+    } else {
+        return Err(
+            ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Agent not found: {root_id}"))
+        );
+    }
+
+    let cache_key = format!(
+        "{}|{}|{}|{}",
+        root_id,
+        max_depth,
+        params.status.as_deref().unwrap_or(""),
+        show_budget,
+    );
+    if let Some(cached) = state.topology_tree_cache.get(&cache_key).await {
+        return Ok((StatusCode::OK, Json((*cached).clone())));
+    }
 
     let tree = build_tree(
         &state.agent_registry,
@@ -264,6 +290,10 @@ pub async fn get_tree(
         ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Agent not found: {root_id}"))
     })?;
 
+    state
+        .topology_tree_cache
+        .insert(cache_key, Arc::new(tree.clone()))
+        .await;
     Ok((StatusCode::OK, Json(tree)))
 }
 

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -20,7 +20,7 @@ use crate::auth::config::AuthConfig;
 use crate::auth::jwt::{JwtSigner, JwtVerifier};
 use crate::auth::rate_limit::RateLimiter;
 use crate::events::EventBroadcast;
-use crate::models::topology::TopologyOverview;
+use crate::models::topology::{AgentTree, TopologyOverview};
 use crate::replay::ReplayBuffer;
 use crate::trace_store::TraceStore;
 
@@ -69,4 +69,6 @@ pub struct AppState {
     pub edge_repo: Arc<dyn EdgeRepo>,
     /// Short-lived cache for GET /topology/overview responses (1 s TTL).
     pub topology_overview_cache: moka::future::Cache<String, Arc<TopologyOverview>>,
+    /// Short-lived cache for GET /topology/tree/{root_id} responses (5 s TTL).
+    pub topology_tree_cache: moka::future::Cache<String, Arc<AgentTree>>,
 }

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -145,6 +145,9 @@ spec:
         topology_overview_cache: moka::future::Cache::builder()
             .time_to_live(std::time::Duration::from_secs(1))
             .build(),
+        topology_tree_cache: moka::future::Cache::builder()
+            .time_to_live(std::time::Duration::from_secs(5))
+            .build(),
     }
 }
 

--- a/aa-api/tests/topology.rs
+++ b/aa-api/tests/topology.rs
@@ -289,6 +289,33 @@ async fn topology_tree_returns_subtree_for_known_agent() {
     assert_eq!(json["status"], "active");
 }
 
+#[tokio::test]
+async fn topology_tree_returns_422_for_non_root_agent() {
+    let state = common::test_state();
+    state
+        .agent_registry
+        .register(make_agent(0x01, "root", 0, None, None))
+        .unwrap();
+    state
+        .agent_registry
+        .register(make_agent(0x02, "child", 1, None, Some([0x01; 16])))
+        .unwrap();
+
+    let app = aa_api::server::build_app(state);
+    let id = hex_id(0x02); // child at depth 1 — not a root
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/topology/tree/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
 // ---------------------------------------------------------------------------
 // Team
 // ---------------------------------------------------------------------------

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -467,6 +467,7 @@ export interface paths {
          * @description Recursively walks the delegation tree starting from the given agent, up to
          *     a configurable depth (default 10, maximum 10). Nodes can be filtered by
          *     status. Returns a nested JSON tree with each agent's children inline.
+         *     Returns 422 if the agent exists but is not a root (depth > 0).
          */
         get: operations["get_tree"];
         put?: never;
@@ -2155,6 +2156,13 @@ export interface operations {
             };
             /** @description Agent not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Agent is not a root agent */
+            422: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -808,6 +808,7 @@ paths:
         Recursively walks the delegation tree starting from the given agent, up to
         a configurable depth (default 10, maximum 10). Nodes can be filtered by
         status. Returns a nested JSON tree with each agent's children inline.
+        Returns 422 if the agent exists but is not a root (depth > 0).
       operationId: get_tree
       parameters:
       - name: root_id
@@ -853,6 +854,8 @@ paths:
           description: Invalid agent ID format
         '404':
           description: Agent not found
+        '422':
+          description: Agent is not a root agent
   /api/v1/traces/{session_id}:
     get:
       tags:


### PR DESCRIPTION
## Description

Implements AAASM-1015: hardens the `GET /api/v1/topology/tree/{root_id}` endpoint with:

- **RequireRead auth extractor** — consistent with the overview endpoint.
- **422 Unprocessable Entity** when the target agent exists but has `depth > 0` (i.e. is a sub-agent, not a root). The check happens before the cache lookup.
- **5-second moka cache** — `topology_tree_cache: Cache<String, Arc<AgentTree>>` keyed on `root_id|max_depth|status|show_budget`. New `AppState` field initialised in `test_state_with_auth`.

Stacked on AAASM-1011 (PR #257).

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1015
- Parent story: AAASM-214

## Testing

- [x] Integration tests added / updated
  - 15 topology integration tests pass (14 pre-existing + 1 new: `topology_tree_returns_422_for_non_root_agent`).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-1015