### PR TITLE
[AAASM-1019] ✨ (aa-api): Add RequireRead auth and 5 s moka cache to GET /topology/team and /lineage

### DIFF
--- a/aa-api/src/routes/topology.rs
+++ b/aa-api/src/routes/topology.rs
@@ -316,10 +316,22 @@ pub async fn get_tree(
     tag = "topology"
 )]
 pub async fn get_team(
+    _auth: RequireRead,
     Extension(state): Extension<AppState>,
     Path(team_id): Path<String>,
     Query(params): Query<TopologyFilterParams>,
 ) -> Result<(StatusCode, Json<TeamTopology>), ProblemDetail> {
+    let cache_key = format!(
+        "{}|{}|{}|{}",
+        team_id,
+        params.status.as_deref().unwrap_or(""),
+        params.min_depth.unwrap_or(0),
+        params.show_budget.unwrap_or(false),
+    );
+    if let Some(cached) = state.topology_team_cache.get(&cache_key).await {
+        return Ok((StatusCode::OK, Json((*cached).clone())));
+    }
+
     let member_ids = state.agent_registry.team_members(&team_id);
     if member_ids.is_empty() {
         return Err(ProblemDetail::from_status(StatusCode::NOT_FOUND)
@@ -348,14 +360,16 @@ pub async fn get_team(
     members.sort_by_key(|m| m.depth);
 
     let agent_count = members.len();
-    Ok((
-        StatusCode::OK,
-        Json(TeamTopology {
-            team_id,
-            agent_count,
-            members,
-        }),
-    ))
+    let topology = TeamTopology {
+        team_id,
+        agent_count,
+        members,
+    };
+    state
+        .topology_team_cache
+        .insert(cache_key, Arc::new(topology.clone()))
+        .await;
+    Ok((StatusCode::OK, Json(topology)))
 }
 
 /// `GET /api/v1/topology/lineage/{agent_id}` — ancestor chain from root down to agent.
@@ -378,9 +392,14 @@ pub async fn get_team(
     tag = "topology"
 )]
 pub async fn get_lineage(
+    _auth: RequireRead,
     Extension(state): Extension<AppState>,
     Path(agent_id_str): Path<String>,
 ) -> Result<(StatusCode, Json<AgentLineage>), ProblemDetail> {
+    if let Some(cached) = state.topology_lineage_cache.get(&agent_id_str).await {
+        return Ok((StatusCode::OK, Json((*cached).clone())));
+    }
+
     let agent_id = parse_agent_id(&agent_id_str)?;
 
     let record = state.agent_registry.get(&agent_id).ok_or_else(|| {
@@ -413,14 +432,16 @@ pub async fn get_lineage(
     });
 
     let ancestor_count = ancestors.len();
-    Ok((
-        StatusCode::OK,
-        Json(AgentLineage {
-            agent_id: agent_id_str,
-            ancestor_count,
-            ancestors,
-        }),
-    ))
+    let lineage = AgentLineage {
+        agent_id: agent_id_str.clone(),
+        ancestor_count,
+        ancestors,
+    };
+    state
+        .topology_lineage_cache
+        .insert(agent_id_str, Arc::new(lineage.clone()))
+        .await;
+    Ok((StatusCode::OK, Json(lineage)))
 }
 
 /// `GET /api/v1/topology/stats` — aggregate topology statistics.

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -20,7 +20,7 @@ use crate::auth::config::AuthConfig;
 use crate::auth::jwt::{JwtSigner, JwtVerifier};
 use crate::auth::rate_limit::RateLimiter;
 use crate::events::EventBroadcast;
-use crate::models::topology::{AgentTree, TopologyOverview};
+use crate::models::topology::{AgentLineage, AgentTree, TeamTopology, TopologyOverview};
 use crate::replay::ReplayBuffer;
 use crate::trace_store::TraceStore;
 
@@ -71,4 +71,8 @@ pub struct AppState {
     pub topology_overview_cache: moka::future::Cache<String, Arc<TopologyOverview>>,
     /// Short-lived cache for GET /topology/tree/{root_id} responses (5 s TTL).
     pub topology_tree_cache: moka::future::Cache<String, Arc<AgentTree>>,
+    /// Short-lived cache for GET /topology/team/{team_id} responses (5 s TTL).
+    pub topology_team_cache: moka::future::Cache<String, Arc<TeamTopology>>,
+    /// Short-lived cache for GET /topology/lineage/{agent_id} responses (5 s TTL).
+    pub topology_lineage_cache: moka::future::Cache<String, Arc<AgentLineage>>,
 }

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -148,6 +148,12 @@ spec:
         topology_tree_cache: moka::future::Cache::builder()
             .time_to_live(std::time::Duration::from_secs(5))
             .build(),
+        topology_team_cache: moka::future::Cache::builder()
+            .time_to_live(std::time::Duration::from_secs(5))
+            .build(),
+        topology_lineage_cache: moka::future::Cache::builder()
+            .time_to_live(std::time::Duration::from_secs(5))
+            .build(),
     }
 }
 

--- a/aa-api/tests/topology.rs
+++ b/aa-api/tests/topology.rs
@@ -40,7 +40,7 @@ fn make_agent(id_byte: u8, name: &str, depth: u32, team_id: Option<&str>, parent
         spawned_by_tool: None,
         root_agent_id: if depth == 0 { Some([id_byte; 16]) } else { parent_id },
         children: Vec::new(),
-        parent_key: None,
+        parent_key: parent_id,
     }
 }
 
@@ -439,6 +439,43 @@ async fn topology_lineage_root_agent_has_no_ancestors() {
     let ancestors = json["ancestors"].as_array().unwrap();
     assert_eq!(ancestors.len(), 1);
     assert_eq!(ancestors[0]["depth"], 0);
+}
+
+#[tokio::test]
+async fn topology_lineage_multi_hop_returns_root_first_ordering() {
+    let state = common::test_state();
+    let reg = &state.agent_registry;
+    // root → child → grandchild
+    reg.register(make_agent(0x01, "root", 0, None, None)).unwrap();
+    reg.register(make_agent(0x02, "child", 1, None, Some([0x01; 16]))).unwrap();
+    reg.register(make_agent(0x03, "grandchild", 2, None, Some([0x02; 16]))).unwrap();
+
+    let app = aa_api::server::build_app(state);
+    let id = hex_id(0x03);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/topology/lineage/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["ancestor_count"], 3);
+    let ancestors = json["ancestors"].as_array().unwrap();
+    assert_eq!(ancestors.len(), 3);
+    // root-first ordering: depth 0, 1, 2
+    assert_eq!(ancestors[0]["depth"], 0);
+    assert_eq!(ancestors[0]["name"], "root");
+    assert_eq!(ancestors[1]["depth"], 1);
+    assert_eq!(ancestors[1]["name"], "child");
+    assert_eq!(ancestors[2]["depth"], 2);
+    assert_eq!(ancestors[2]["name"], "grandchild");
 }
 
 // ---------------------------------------------------------------------------

--- a/aa-api/tests/topology.rs
+++ b/aa-api/tests/topology.rs
@@ -447,8 +447,10 @@ async fn topology_lineage_multi_hop_returns_root_first_ordering() {
     let reg = &state.agent_registry;
     // root → child → grandchild
     reg.register(make_agent(0x01, "root", 0, None, None)).unwrap();
-    reg.register(make_agent(0x02, "child", 1, None, Some([0x01; 16]))).unwrap();
-    reg.register(make_agent(0x03, "grandchild", 2, None, Some([0x02; 16]))).unwrap();
+    reg.register(make_agent(0x02, "child", 1, None, Some([0x01; 16])))
+        .unwrap();
+    reg.register(make_agent(0x03, "grandchild", 2, None, Some([0x02; 16])))
+        .unwrap();
 
     let app = aa_api::server::build_app(state);
     let id = hex_id(0x03);


### PR DESCRIPTION
## Description

Implements AAASM-1019: hardens the `GET /api/v1/topology/team/{team_id}` and `GET /api/v1/topology/lineage/{agent_id}` endpoints with:

- **RequireRead auth extractor** on both handlers.
- **5-second moka caches** — `topology_team_cache` keyed on `team_id|status|min_depth|show_budget`, `topology_lineage_cache` keyed on `agent_id`. Both as `Cache<String, Arc<T>>` fields on `AppState`.

Bug fix: `make_agent` in `tests/topology.rs` now sets `parent_key: parent_id` so the registry's `ancestors_of` and `children_of` traverse real parent chains — without this fix the multi-hop lineage test correctly caught missing lineage traversal.

Stacked on AAASM-1015 (PR #258).

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1019
- Parent story: AAASM-214

## Testing

- [x] Integration tests added / updated
  - 16 topology integration tests pass (15 pre-existing + 1 new: `topology_lineage_multi_hop_returns_root_first_ordering` — verifies 3-hop root-first ancestor ordering).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-1019