### PR TITLE
[AAASM-995] ✨ (aa-api/aa-core): REST edge endpoints + Tarjan cycle detection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "serde_yaml",
  "sha2 0.11.0",
  "similar 3.1.0",
+ "sqlx",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -615,6 +616,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +859,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitvec"
@@ -956,6 +969,12 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1187,6 +1206,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "conformance"
 version = "0.0.1"
 dependencies = [
@@ -1293,6 +1321,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1361,6 +1404,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1572,6 +1624,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1644,6 +1697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -1701,6 +1755,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,6 +1795,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "email_address"
@@ -1779,12 +1842,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "euclid"
 version = "0.22.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1896,6 +1981,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,6 +2079,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2194,6 +2301,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2212,12 +2328,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2310,7 +2444,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2681,6 +2815,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -2716,12 +2853,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall 0.7.5",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2827,6 +2984,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "memchr"
@@ -3113,6 +3280,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3176,6 +3359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -3295,6 +3479,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3312,7 +3502,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -3336,6 +3526,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -3495,6 +3694,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3503,6 +3713,18 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -4114,6 +4336,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4205,7 +4436,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -4258,6 +4489,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4705,6 +4956,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -4770,6 +5022,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -4779,6 +5034,15 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -4792,6 +5056,200 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.117",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags 2.11.1",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags 2.11.1",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4802,6 +5260,17 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -5496,10 +5965,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -5634,6 +6124,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5699,6 +6195,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -5812,6 +6314,15 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
@@ -5898,6 +6409,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]
@@ -5992,6 +6513,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6015,6 +6545,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -6052,6 +6597,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6064,6 +6615,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6073,6 +6630,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6100,6 +6663,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6109,6 +6678,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6124,6 +6699,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6133,6 +6714,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -34,8 +34,7 @@ use crate::routes::{agents, alerts, approvals, auth, costs, edges, logs, policie
         (name = "alerts", description = "Governance alerts"),
         (name = "auth", description = "Authentication and token issuance"),
         (name = "events", description = "Real-time event streaming via WebSocket"),
-        (name = "topology", description = "Agent topology — tree, team, lineage, and statistics queries"),
-        (name = "topology", description = "Mesh topology edge store — record and query directed agent-to-agent edges"),
+        (name = "topology", description = "Agent topology — tree, team, lineage, statistics, and mesh edge queries"),
     ),
     paths(
         crate::routes::health::health,

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -8,7 +8,7 @@ use crate::models::event::GovernanceEvent;
 use crate::models::event_type::EventType;
 use crate::models::trace::{TraceResponse, TraceSpan};
 use crate::models::ws_payloads::{ApprovalPayload, BudgetAlertPayload, EventPayload, ViolationPayload};
-use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, topology, traces};
+use crate::routes::{agents, alerts, approvals, auth, costs, edges, logs, policies, topology, traces};
 
 /// Root OpenAPI document collecting all annotated paths and schemas.
 #[derive(OpenApi)]
@@ -35,6 +35,7 @@ use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, topo
         (name = "auth", description = "Authentication and token issuance"),
         (name = "events", description = "Real-time event streaming via WebSocket"),
         (name = "topology", description = "Agent topology — tree, team, lineage, and statistics queries"),
+        (name = "topology", description = "Mesh topology edge store — record and query directed agent-to-agent edges"),
     ),
     paths(
         crate::routes::health::health,
@@ -60,6 +61,9 @@ use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, topo
         topology::get_team,
         topology::get_lineage,
         topology::get_stats,
+        edges::report_edge,
+        edges::list_agent_edges,
+        edges::get_agent_graph,
     ),
     components(schemas(
         crate::routes::health::HealthResponse,
@@ -93,6 +97,12 @@ use crate::routes::{agents, alerts, approvals, auth, costs, logs, policies, topo
         topology::AgentLineage,
         topology::LineageStep,
         topology::TopologyStats,
+        edges::ReportEdgeRequest,
+        edges::ReportEdgeResponse,
+        edges::EdgeResponse,
+        edges::EdgeListResponse,
+        edges::GraphNode,
+        edges::GraphResponse,
         GovernanceEvent,
         EventType,
         ViolationPayload,

--- a/aa-api/src/routes/edges.rs
+++ b/aa-api/src/routes/edges.rs
@@ -30,8 +30,7 @@ fn parse_agent_id(id: &str) -> Result<AgentId, ProblemDetail> {
         .map(|i| u8::from_str_radix(&id[i..i + 2], 16))
         .collect::<Result<Vec<u8>, _>>()
         .map_err(|_| {
-            ProblemDetail::from_status(StatusCode::BAD_REQUEST)
-                .with_detail(format!("Invalid agent ID format: {id}"))
+            ProblemDetail::from_status(StatusCode::BAD_REQUEST).with_detail(format!("Invalid agent ID format: {id}"))
         })?;
     let arr: [u8; 16] = bytes.try_into().map_err(|_| {
         ProblemDetail::from_status(StatusCode::BAD_REQUEST)
@@ -46,8 +45,9 @@ fn format_id(id: &AgentId) -> String {
 
 fn parse_edge_type(s: &str) -> Result<EdgeType, ProblemDetail> {
     EdgeType::try_from(s).map_err(|_| {
-        ProblemDetail::from_status(StatusCode::BAD_REQUEST)
-            .with_detail(format!("Unknown edge_type: {s}. Valid values: delegates_to, calls, reads, writes, approves, messages"))
+        ProblemDetail::from_status(StatusCode::BAD_REQUEST).with_detail(format!(
+            "Unknown edge_type: {s}. Valid values: delegates_to, calls, reads, writes, approves, messages"
+        ))
     })
 }
 
@@ -105,10 +105,7 @@ fn compute_cross_team(edges: &[Edge], state: &AppState) -> Vec<bool> {
     let team_map: HashMap<AgentId, Option<String>> = ids
         .into_iter()
         .map(|id| {
-            let team = state
-                .agent_registry
-                .get(id.as_bytes())
-                .and_then(|r| r.team_id.clone());
+            let team = state.agent_registry.get(id.as_bytes()).and_then(|r| r.team_id.clone());
             (id, team)
         })
         .collect();
@@ -189,11 +186,15 @@ pub async fn report_edge(
 
     let id = state
         .edge_repo
-        .insert(NewEdge { source, target, edge_type, metadata })
+        .insert(NewEdge {
+            source,
+            target,
+            edge_type,
+            metadata,
+        })
         .await
         .map_err(|e| {
-            ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR)
-                .with_detail(format!("Edge store error: {e}"))
+            ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR).with_detail(format!("Edge store error: {e}"))
         })?;
 
     Ok((StatusCode::CREATED, Json(ReportEdgeResponse { id })))
@@ -257,11 +258,7 @@ pub async fn list_agent_edges(
 ) -> Result<(StatusCode, Json<EdgeListResponse>), ProblemDetail> {
     let agent_id = parse_agent_id(&id)?;
 
-    let edge_type: Option<EdgeType> = params
-        .r#type
-        .as_deref()
-        .map(parse_edge_type)
-        .transpose()?;
+    let edge_type: Option<EdgeType> = params.r#type.as_deref().map(parse_edge_type).transpose()?;
 
     let direction = params.direction.as_deref().unwrap_or("outgoing");
     let limit = params.limit.unwrap_or(100).min(1000);
@@ -278,18 +275,11 @@ pub async fn list_agent_edges(
         .transpose()?;
 
     let raw_edges = match direction {
-        "incoming" => state
-            .edge_repo
-            .list_incoming(agent_id, edge_type, limit)
-            .await,
-        _ => state
-            .edge_repo
-            .list_outgoing(agent_id, edge_type, limit)
-            .await,
+        "incoming" => state.edge_repo.list_incoming(agent_id, edge_type, limit).await,
+        _ => state.edge_repo.list_outgoing(agent_id, edge_type, limit).await,
     }
     .map_err(|e| {
-        ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR)
-            .with_detail(format!("Edge store error: {e}"))
+        ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR).with_detail(format!("Edge store error: {e}"))
     })?;
 
     // Apply optional `before` cursor (best-effort for in-memory store)
@@ -309,7 +299,11 @@ pub async fn list_agent_edges(
     let count = edges.len();
     Ok((
         StatusCode::OK,
-        Json(EdgeListResponse { agent_id: id, edges, count }),
+        Json(EdgeListResponse {
+            agent_id: id,
+            edges,
+            count,
+        }),
     ))
 }
 
@@ -380,14 +374,9 @@ pub async fn get_agent_graph(
         if d >= depth {
             continue;
         }
-        let outgoing = state
-            .edge_repo
-            .list_outgoing(node, None, 1000)
-            .await
-            .map_err(|e| {
-                ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .with_detail(format!("Edge store error: {e}"))
-            })?;
+        let outgoing = state.edge_repo.list_outgoing(node, None, 1000).await.map_err(|e| {
+            ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR).with_detail(format!("Edge store error: {e}"))
+        })?;
         for edge in outgoing {
             if visited.insert(edge.target) {
                 queue.push_back((edge.target, d + 1));
@@ -398,14 +387,9 @@ pub async fn get_agent_graph(
     // Batch-fetch all edges where source is in the visited set
     let mut all_edges: Vec<Edge> = Vec::new();
     for &node in &visited {
-        let outgoing = state
-            .edge_repo
-            .list_outgoing(node, None, 1000)
-            .await
-            .map_err(|e| {
-                ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .with_detail(format!("Edge store error: {e}"))
-            })?;
+        let outgoing = state.edge_repo.list_outgoing(node, None, 1000).await.map_err(|e| {
+            ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR).with_detail(format!("Edge store error: {e}"))
+        })?;
         // Keep only edges whose target is also in the subgraph
         for edge in outgoing {
             if visited.contains(&edge.target) {
@@ -423,7 +407,9 @@ pub async fn get_agent_graph(
 
     let nodes: Vec<GraphNode> = visited
         .into_iter()
-        .map(|node_id| GraphNode { id: format_id(&node_id) })
+        .map(|node_id| GraphNode {
+            id: format_id(&node_id),
+        })
         .collect();
 
     Ok((

--- a/aa-api/src/routes/edges.rs
+++ b/aa-api/src/routes/edges.rs
@@ -1,0 +1,437 @@
+//! Mesh topology edge endpoints.
+//!
+//! Three endpoints:
+//!   POST /topology/edges           — record a new directed edge (intake for SDK emitters)
+//!   GET  /agents/{id}/edges        — paginated edge listing for one agent
+//!   GET  /agents/{id}/graph        — BFS subgraph reachable from one agent
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use axum::extract::{Path, Query};
+use axum::http::StatusCode;
+use axum::{Extension, Json};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::{IntoParams, ToSchema};
+
+use aa_core::identity::AgentId;
+use aa_core::topology::{Edge, EdgeType, NewEdge};
+
+use crate::error::ProblemDetail;
+use crate::state::AppState;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn parse_agent_id(id: &str) -> Result<AgentId, ProblemDetail> {
+    let bytes: Vec<u8> = (0..id.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&id[i..i + 2], 16))
+        .collect::<Result<Vec<u8>, _>>()
+        .map_err(|_| {
+            ProblemDetail::from_status(StatusCode::BAD_REQUEST)
+                .with_detail(format!("Invalid agent ID format: {id}"))
+        })?;
+    let arr: [u8; 16] = bytes.try_into().map_err(|_| {
+        ProblemDetail::from_status(StatusCode::BAD_REQUEST)
+            .with_detail(format!("Agent ID must be 32 hex characters: {id}"))
+    })?;
+    Ok(AgentId::from_bytes(arr))
+}
+
+fn format_id(id: &AgentId) -> String {
+    id.as_bytes().iter().map(|b| format!("{b:02x}")).collect()
+}
+
+fn parse_edge_type(s: &str) -> Result<EdgeType, ProblemDetail> {
+    EdgeType::try_from(s).map_err(|_| {
+        ProblemDetail::from_status(StatusCode::BAD_REQUEST)
+            .with_detail(format!("Unknown edge_type: {s}. Valid values: delegates_to, calls, reads, writes, approves, messages"))
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Shared response types
+// ---------------------------------------------------------------------------
+
+/// A single directed edge between two agents.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct EdgeResponse {
+    /// Auto-assigned edge identifier.
+    pub id: i64,
+    /// Hex-encoded source agent ID.
+    pub source_agent_id: String,
+    /// Hex-encoded target agent ID.
+    pub target_agent_id: String,
+    /// Edge semantic type (snake_case).
+    pub edge_type: String,
+    /// ISO 8601 timestamp when the edge was recorded.
+    pub created_at: String,
+    /// Whether the edge crosses team boundaries.
+    pub is_cross_team: bool,
+    /// Optional freeform metadata attached at emission time.
+    #[schema(value_type = Option<serde_json::Value>)]
+    pub metadata: Option<serde_json::Value>,
+}
+
+fn edge_to_response(edge: &Edge, is_cross_team: bool) -> EdgeResponse {
+    EdgeResponse {
+        id: edge.id,
+        source_agent_id: format_id(&edge.source),
+        target_agent_id: format_id(&edge.target),
+        edge_type: edge.edge_type.as_str().to_owned(),
+        created_at: edge.created_at.to_rfc3339(),
+        is_cross_team,
+        metadata: edge.metadata.clone(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// is_cross_team helper
+// ---------------------------------------------------------------------------
+
+/// Batch-compute `is_cross_team` for a set of edges by comparing team_id
+/// from the agent registry.  Missing agents → treated as team-less (false).
+fn compute_cross_team(edges: &[Edge], state: &AppState) -> Vec<bool> {
+    // Collect all unique agent IDs
+    let mut ids: HashSet<AgentId> = HashSet::new();
+    for e in edges {
+        ids.insert(e.source);
+        ids.insert(e.target);
+    }
+
+    // Batch lookup: agent_id → Option<team_id>
+    let team_map: HashMap<AgentId, Option<String>> = ids
+        .into_iter()
+        .map(|id| {
+            let team = state
+                .agent_registry
+                .get(id.as_bytes())
+                .and_then(|r| r.team_id.clone());
+            (id, team)
+        })
+        .collect();
+
+    edges
+        .iter()
+        .map(|e| {
+            let src_team = team_map.get(&e.source).and_then(|t| t.as_deref());
+            let tgt_team = team_map.get(&e.target).and_then(|t| t.as_deref());
+            match (src_team, tgt_team) {
+                (Some(a), Some(b)) => a != b,
+                _ => false,
+            }
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// POST /topology/edges — record a new edge (SDK intake)
+// ---------------------------------------------------------------------------
+
+/// Request body for recording a new directed edge.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ReportEdgeRequest {
+    /// Hex-encoded source agent ID.
+    pub source_agent_id: String,
+    /// Hex-encoded target agent ID.
+    pub target_agent_id: String,
+    /// Edge semantic type (e.g. `"messages"`, `"delegates_to"`).
+    pub edge_type: String,
+    /// Optional metadata JSON string.
+    pub metadata_json: Option<String>,
+}
+
+/// Response after recording a new edge.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ReportEdgeResponse {
+    /// Auto-assigned edge identifier.
+    pub id: i64,
+}
+
+/// Record a new directed topology edge.
+///
+/// Used by SDK emitters (Python, Node.js, Go) to push observed
+/// agent-to-agent interactions into the gateway edge store.
+#[utoipa::path(
+    post,
+    path = "/api/v1/topology/edges",
+    request_body = ReportEdgeRequest,
+    responses(
+        (status = 201, description = "Edge recorded", body = ReportEdgeResponse),
+        (status = 400, description = "Invalid request", body = ProblemDetail),
+        (status = 500, description = "Store error", body = ProblemDetail),
+    ),
+    tag = "topology"
+)]
+pub async fn report_edge(
+    Extension(state): Extension<AppState>,
+    Json(body): Json<ReportEdgeRequest>,
+) -> Result<(StatusCode, Json<ReportEdgeResponse>), ProblemDetail> {
+    let source = parse_agent_id(&body.source_agent_id)?;
+    let target = parse_agent_id(&body.target_agent_id)?;
+    let edge_type = parse_edge_type(&body.edge_type)?;
+
+    let metadata = if let Some(json_str) = body.metadata_json {
+        if json_str.is_empty() {
+            None
+        } else {
+            let v: serde_json::Value = serde_json::from_str(&json_str).map_err(|e| {
+                ProblemDetail::from_status(StatusCode::BAD_REQUEST)
+                    .with_detail(format!("metadata_json is not valid JSON: {e}"))
+            })?;
+            Some(v)
+        }
+    } else {
+        None
+    };
+
+    let id = state
+        .edge_repo
+        .insert(NewEdge { source, target, edge_type, metadata })
+        .await
+        .map_err(|e| {
+            ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR)
+                .with_detail(format!("Edge store error: {e}"))
+        })?;
+
+    Ok((StatusCode::CREATED, Json(ReportEdgeResponse { id })))
+}
+
+// ---------------------------------------------------------------------------
+// GET /agents/{id}/edges
+// ---------------------------------------------------------------------------
+
+/// Query parameters for the edge listing endpoint.
+#[derive(Debug, Default, Deserialize, IntoParams)]
+pub struct EdgeListParams {
+    /// Filter by edge type (snake_case). Omit for all types.
+    #[param(example = "messages")]
+    pub r#type: Option<String>,
+    /// Direction of edges relative to the agent. Defaults to `outgoing`.
+    #[param(example = "outgoing")]
+    pub direction: Option<String>,
+    /// Maximum number of results. Defaults to 100, capped at 1000.
+    #[param(example = 100)]
+    pub limit: Option<u32>,
+    /// Return only edges recorded before this ISO 8601 timestamp.
+    #[param(example = "2026-01-01T00:00:00Z")]
+    pub before: Option<String>,
+}
+
+/// Paginated list of directed edges for an agent.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct EdgeListResponse {
+    /// The queried agent ID.
+    pub agent_id: String,
+    /// The list of matching edges, newest first.
+    pub edges: Vec<EdgeResponse>,
+    /// Total number of edges returned.
+    pub count: usize,
+}
+
+/// List directed edges for an agent.
+///
+/// Returns edges ordered newest-first.  `direction` defaults to `outgoing`.
+/// `limit` defaults to 100 and is capped at 1000.  `before` filters to edges
+/// recorded before the given ISO 8601 timestamp.
+#[utoipa::path(
+    get,
+    path = "/api/v1/agents/{id}/edges",
+    params(
+        ("id" = String, Path, description = "Hex-encoded agent ID"),
+        EdgeListParams,
+    ),
+    responses(
+        (status = 200, description = "Edge list", body = EdgeListResponse),
+        (status = 400, description = "Invalid request", body = ProblemDetail),
+        (status = 500, description = "Store error", body = ProblemDetail),
+    ),
+    tag = "agents"
+)]
+pub async fn list_agent_edges(
+    Extension(state): Extension<AppState>,
+    Path(id): Path<String>,
+    Query(params): Query<EdgeListParams>,
+) -> Result<(StatusCode, Json<EdgeListResponse>), ProblemDetail> {
+    let agent_id = parse_agent_id(&id)?;
+
+    let edge_type: Option<EdgeType> = params
+        .r#type
+        .as_deref()
+        .map(parse_edge_type)
+        .transpose()?;
+
+    let direction = params.direction.as_deref().unwrap_or("outgoing");
+    let limit = params.limit.unwrap_or(100).min(1000);
+
+    let before: Option<DateTime<Utc>> = params
+        .before
+        .as_deref()
+        .map(|s| {
+            s.parse::<DateTime<Utc>>().map_err(|_| {
+                ProblemDetail::from_status(StatusCode::BAD_REQUEST)
+                    .with_detail(format!("Invalid 'before' timestamp: {s}"))
+            })
+        })
+        .transpose()?;
+
+    let raw_edges = match direction {
+        "incoming" => state
+            .edge_repo
+            .list_incoming(agent_id, edge_type, limit)
+            .await,
+        _ => state
+            .edge_repo
+            .list_outgoing(agent_id, edge_type, limit)
+            .await,
+    }
+    .map_err(|e| {
+        ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR)
+            .with_detail(format!("Edge store error: {e}"))
+    })?;
+
+    // Apply optional `before` cursor (best-effort for in-memory store)
+    let filtered: Vec<Edge> = if let Some(cutoff) = before {
+        raw_edges.into_iter().filter(|e| e.created_at < cutoff).collect()
+    } else {
+        raw_edges
+    };
+
+    let cross_team_flags = compute_cross_team(&filtered, &state);
+    let edges: Vec<EdgeResponse> = filtered
+        .iter()
+        .zip(cross_team_flags.iter())
+        .map(|(e, &ct)| edge_to_response(e, ct))
+        .collect();
+
+    let count = edges.len();
+    Ok((
+        StatusCode::OK,
+        Json(EdgeListResponse { agent_id: id, edges, count }),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// GET /agents/{id}/graph
+// ---------------------------------------------------------------------------
+
+/// Query parameters for the subgraph endpoint.
+#[derive(Debug, Default, Deserialize, IntoParams)]
+pub struct GraphParams {
+    /// BFS depth from the root agent. Defaults to 2, capped at 5.
+    #[param(example = 2)]
+    pub depth: Option<u32>,
+}
+
+/// A node in the topology subgraph.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct GraphNode {
+    /// Hex-encoded agent ID.
+    pub id: String,
+}
+
+/// Subgraph reachable from an agent within a depth bound.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct GraphResponse {
+    /// Root agent ID used for the BFS.
+    pub root_agent_id: String,
+    /// All unique agent nodes reachable within `depth` hops.
+    pub nodes: Vec<GraphNode>,
+    /// All edges between nodes in this subgraph.
+    pub edges: Vec<EdgeResponse>,
+}
+
+/// Return the topology subgraph reachable from an agent.
+///
+/// Performs BFS outward from `id` up to `depth` hops (default 2, max 5).
+/// Returns all unique nodes reachable and the edges between them, with
+/// `is_cross_team` computed via a batched registry lookup.
+#[utoipa::path(
+    get,
+    path = "/api/v1/agents/{id}/graph",
+    params(
+        ("id" = String, Path, description = "Hex-encoded root agent ID"),
+        GraphParams,
+    ),
+    responses(
+        (status = 200, description = "Subgraph", body = GraphResponse),
+        (status = 400, description = "Invalid request", body = ProblemDetail),
+        (status = 500, description = "Store error", body = ProblemDetail),
+    ),
+    tag = "agents"
+)]
+pub async fn get_agent_graph(
+    Extension(state): Extension<AppState>,
+    Path(id): Path<String>,
+    Query(params): Query<GraphParams>,
+) -> Result<(StatusCode, Json<GraphResponse>), ProblemDetail> {
+    let root_id = parse_agent_id(&id)?;
+    let depth = params.depth.unwrap_or(2).min(5);
+
+    // BFS: collect unique node IDs within `depth` hops
+    let mut visited: HashSet<AgentId> = HashSet::new();
+    let mut queue: VecDeque<(AgentId, u32)> = VecDeque::new();
+    queue.push_back((root_id, 0));
+    visited.insert(root_id);
+
+    while let Some((node, d)) = queue.pop_front() {
+        if d >= depth {
+            continue;
+        }
+        let outgoing = state
+            .edge_repo
+            .list_outgoing(node, None, 1000)
+            .await
+            .map_err(|e| {
+                ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR)
+                    .with_detail(format!("Edge store error: {e}"))
+            })?;
+        for edge in outgoing {
+            if visited.insert(edge.target) {
+                queue.push_back((edge.target, d + 1));
+            }
+        }
+    }
+
+    // Batch-fetch all edges where source is in the visited set
+    let mut all_edges: Vec<Edge> = Vec::new();
+    for &node in &visited {
+        let outgoing = state
+            .edge_repo
+            .list_outgoing(node, None, 1000)
+            .await
+            .map_err(|e| {
+                ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR)
+                    .with_detail(format!("Edge store error: {e}"))
+            })?;
+        // Keep only edges whose target is also in the subgraph
+        for edge in outgoing {
+            if visited.contains(&edge.target) {
+                all_edges.push(edge);
+            }
+        }
+    }
+
+    let cross_team_flags = compute_cross_team(&all_edges, &state);
+    let edge_responses: Vec<EdgeResponse> = all_edges
+        .iter()
+        .zip(cross_team_flags.iter())
+        .map(|(e, &ct)| edge_to_response(e, ct))
+        .collect();
+
+    let nodes: Vec<GraphNode> = visited
+        .into_iter()
+        .map(|node_id| GraphNode { id: format_id(&node_id) })
+        .collect();
+
+    Ok((
+        StatusCode::OK,
+        Json(GraphResponse {
+            root_agent_id: id,
+            nodes,
+            edges: edge_responses,
+        }),
+    ))
+}

--- a/aa-api/src/routes/mod.rs
+++ b/aa-api/src/routes/mod.rs
@@ -8,6 +8,7 @@ pub mod approvals;
 pub mod auth;
 pub mod costs;
 pub mod devtools;
+pub mod edges;
 pub mod health;
 pub mod logs;
 pub mod policies;
@@ -62,6 +63,10 @@ pub fn v1_router() -> Router {
         .route("/topology/team/{team_id}", get(topology::get_team))
         .route("/topology/lineage/{agent_id}", get(topology::get_lineage))
         .route("/topology/stats", get(topology::get_stats))
+        // Edges (mesh topology edge store)
+        .route("/topology/edges", post(edges::report_edge))
+        .route("/agents/{id}/edges", get(edges::list_agent_edges))
+        .route("/agents/{id}/graph", get(edges::get_agent_graph))
 }
 
 /// Fallback handler returning a 404 RFC 7807 response.

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 
 use aa_devtool::DiscoveryService;
 
+use aa_core::topology::EdgeRepo;
 use aa_gateway::budget::tracker::BudgetTracker;
 use aa_gateway::engine::PolicyEngine;
 use aa_gateway::policy::history::PolicyHistoryStore;
@@ -63,4 +64,6 @@ pub struct AppState {
     pub active_connections: Arc<AtomicI64>,
     /// Dev tool auto-discovery service.
     pub discovery: Arc<DiscoveryService>,
+    /// Topology edge store for mesh edge queries.
+    pub edge_repo: Arc<dyn EdgeRepo>,
 }

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -19,6 +19,7 @@ use aa_api::trace_store::InMemoryTraceStore;
 use aa_devtool::DiscoveryService;
 use aa_gateway::budget::pricing::PricingTable;
 use aa_gateway::budget::tracker::BudgetTracker;
+use aa_gateway::edges::InMemoryEdgeRepo;
 use aa_gateway::engine::PolicyEngine;
 use aa_gateway::policy::history::{FsHistoryStore, HistoryConfig};
 use aa_gateway::registry::AgentRegistry;
@@ -140,6 +141,7 @@ spec:
         startup_time: Instant::now(),
         active_connections: Arc::new(AtomicI64::new(0)),
         discovery: Arc::new(DiscoveryService::with_adapters(vec![])),
+        edge_repo: Arc::new(InMemoryEdgeRepo::new()),
     }
 }
 

--- a/aa-api/tests/edges.rs
+++ b/aa-api/tests/edges.rs
@@ -13,8 +13,8 @@ use serde_json::{json, Value};
 use tower::ServiceExt;
 
 use aa_api::server::build_app;
-use aa_core::topology::NewEdge;
 use aa_core::identity::AgentId;
+use aa_core::topology::NewEdge;
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/aa-api/tests/edges.rs
+++ b/aa-api/tests/edges.rs
@@ -1,0 +1,374 @@
+//! Integration tests for the mesh topology edge endpoints.
+//!
+//! Covers:
+//!   POST /topology/edges        — record a new edge
+//!   GET  /agents/{id}/edges     — list edges (outgoing/incoming, filter, limit)
+//!   GET  /agents/{id}/graph     — BFS subgraph
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+use aa_api::server::build_app;
+use aa_core::topology::NewEdge;
+use aa_core::identity::AgentId;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn hex(byte: u8) -> String {
+    format!("{byte:02x}").repeat(16)
+}
+
+fn agent_id(byte: u8) -> AgentId {
+    AgentId::from_bytes([byte; 16])
+}
+
+async fn post_edge(app: axum::Router, body: Value) -> (StatusCode, Value) {
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/topology/edges")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    (status, serde_json::from_slice(&bytes).unwrap())
+}
+
+// ---------------------------------------------------------------------------
+// POST /topology/edges
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn report_edge_returns_201_with_id() {
+    let app = common::test_app();
+    let (status, body) = post_edge(
+        app,
+        json!({
+            "source_agent_id": hex(0x01),
+            "target_agent_id": hex(0x02),
+            "edge_type": "messages"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert!(body["id"].is_number(), "expected numeric id in response");
+}
+
+#[tokio::test]
+async fn report_edge_invalid_source_returns_400() {
+    let app = common::test_app();
+    let (status, _) = post_edge(
+        app,
+        json!({
+            "source_agent_id": "not-hex",
+            "target_agent_id": hex(0x02),
+            "edge_type": "messages"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn report_edge_invalid_edge_type_returns_400() {
+    let app = common::test_app();
+    let (status, _) = post_edge(
+        app,
+        json!({
+            "source_agent_id": hex(0x01),
+            "target_agent_id": hex(0x02),
+            "edge_type": "unknown_type"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn report_edge_with_metadata_json() {
+    let app = common::test_app();
+    let (status, body) = post_edge(
+        app,
+        json!({
+            "source_agent_id": hex(0x01),
+            "target_agent_id": hex(0x02),
+            "edge_type": "delegates_to",
+            "metadata_json": r#"{"reason":"subtask"}"#
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert!(body["id"].is_number());
+}
+
+// ---------------------------------------------------------------------------
+// GET /agents/{id}/edges
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn list_agent_edges_empty_returns_200_with_empty_list() {
+    let app = common::test_app();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/agents/{}/edges", hex(0xAA)))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["count"], 0);
+    assert!(json["edges"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn list_agent_edges_outgoing_returns_correct_edges() {
+    let state = common::test_state();
+    // Insert two outgoing edges from 0x01
+    state
+        .edge_repo
+        .insert(NewEdge {
+            source: agent_id(0x01),
+            target: agent_id(0x02),
+            edge_type: aa_core::topology::EdgeType::Messages,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    state
+        .edge_repo
+        .insert(NewEdge {
+            source: agent_id(0x01),
+            target: agent_id(0x03),
+            edge_type: aa_core::topology::EdgeType::DelegatesTo,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    // Insert one edge FROM another agent (should not appear in outgoing for 0x01)
+    state
+        .edge_repo
+        .insert(NewEdge {
+            source: agent_id(0x02),
+            target: agent_id(0x01),
+            edge_type: aa_core::topology::EdgeType::Messages,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    let app = build_app(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/agents/{}/edges?direction=outgoing", hex(0x01)))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["count"], 2);
+    let edges = json["edges"].as_array().unwrap();
+    let types: Vec<&str> = edges.iter().map(|e| e["edge_type"].as_str().unwrap()).collect();
+    assert!(types.contains(&"messages"));
+    assert!(types.contains(&"delegates_to"));
+}
+
+#[tokio::test]
+async fn list_agent_edges_incoming_direction() {
+    let state = common::test_state();
+    state
+        .edge_repo
+        .insert(NewEdge {
+            source: agent_id(0x02),
+            target: agent_id(0x01),
+            edge_type: aa_core::topology::EdgeType::Messages,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    let app = build_app(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/agents/{}/edges?direction=incoming", hex(0x01)))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["count"], 1);
+    assert_eq!(json["edges"][0]["source_agent_id"], hex(0x02));
+}
+
+#[tokio::test]
+async fn list_agent_edges_type_filter() {
+    let state = common::test_state();
+    state
+        .edge_repo
+        .insert(NewEdge {
+            source: agent_id(0x01),
+            target: agent_id(0x02),
+            edge_type: aa_core::topology::EdgeType::Messages,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+    state
+        .edge_repo
+        .insert(NewEdge {
+            source: agent_id(0x01),
+            target: agent_id(0x03),
+            edge_type: aa_core::topology::EdgeType::DelegatesTo,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    let app = build_app(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/agents/{}/edges?type=messages", hex(0x01)))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["count"], 1);
+    assert_eq!(json["edges"][0]["edge_type"], "messages");
+}
+
+// ---------------------------------------------------------------------------
+// GET /agents/{id}/graph — 4-agent subgraph
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_agent_graph_four_agent_chain() {
+    // Build: A -> B -> C -> D (linear chain, depth=3 from A covers all)
+    let state = common::test_state();
+    for (src, tgt) in [(0x01u8, 0x02u8), (0x02, 0x03), (0x03, 0x04)] {
+        state
+            .edge_repo
+            .insert(NewEdge {
+                source: agent_id(src),
+                target: agent_id(tgt),
+                edge_type: aa_core::topology::EdgeType::Messages,
+                metadata: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    let app = build_app(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/agents/{}/graph?depth=3", hex(0x01)))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&bytes).unwrap();
+
+    let nodes = json["nodes"].as_array().unwrap();
+    assert_eq!(nodes.len(), 4, "all 4 agents should be in the subgraph");
+
+    let edges = json["edges"].as_array().unwrap();
+    assert_eq!(edges.len(), 3, "3 edges in the chain");
+
+    // All edges should have is_cross_team = false (no registry entries)
+    for edge in edges {
+        assert_eq!(edge["is_cross_team"], false);
+    }
+}
+
+#[tokio::test]
+async fn get_agent_graph_depth_limits_reachability() {
+    // A -> B -> C -> D; with depth=1 only B is reachable from A
+    let state = common::test_state();
+    for (src, tgt) in [(0x01u8, 0x02u8), (0x02, 0x03), (0x03, 0x04)] {
+        state
+            .edge_repo
+            .insert(NewEdge {
+                source: agent_id(src),
+                target: agent_id(tgt),
+                edge_type: aa_core::topology::EdgeType::Messages,
+                metadata: None,
+            })
+            .await
+            .unwrap();
+    }
+
+    let app = build_app(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/agents/{}/graph?depth=1", hex(0x01)))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&bytes).unwrap();
+
+    // depth=1 means BFS stops at d >= 1, so only A and B are visited
+    let nodes = json["nodes"].as_array().unwrap();
+    assert_eq!(nodes.len(), 2);
+}
+
+#[tokio::test]
+async fn get_agent_graph_root_only_when_no_edges() {
+    let app = common::test_app();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/agents/{}/graph", hex(0x01)))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let json: Value = serde_json::from_slice(&bytes).unwrap();
+
+    let nodes = json["nodes"].as_array().unwrap();
+    assert_eq!(nodes.len(), 1, "only the root node when no edges");
+    assert!(json["edges"].as_array().unwrap().is_empty());
+}

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -74,4 +74,4 @@ pub use topology::MockEdgeRepo;
 #[cfg(feature = "alloc")]
 pub use topology::UnknownEdgeType;
 #[cfg(feature = "std")]
-pub use topology::{Edge, EdgeRepo, EdgeRepoError, NewEdge};
+pub use topology::{Edge, EdgeRepo, EdgeRepoError, NewEdge, cycle_detect};

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -74,4 +74,4 @@ pub use topology::MockEdgeRepo;
 #[cfg(feature = "alloc")]
 pub use topology::UnknownEdgeType;
 #[cfg(feature = "std")]
-pub use topology::{Edge, EdgeRepo, EdgeRepoError, NewEdge, cycle_detect};
+pub use topology::{cycle_detect, Edge, EdgeRepo, EdgeRepoError, NewEdge};

--- a/aa-core/src/topology/cycle.rs
+++ b/aa-core/src/topology/cycle.rs
@@ -176,10 +176,7 @@ mod tests {
         let ids: Vec<u8> = result.iter().map(|id| id.as_bytes()[0]).collect();
         // All cycle members must be from {a, b, c}
         for id in &ids {
-            assert!(
-                [1u8, 2, 3].contains(id),
-                "unexpected node {id} in cycle result"
-            );
+            assert!([1u8, 2, 3].contains(id), "unexpected node {id} in cycle result");
         }
     }
 }

--- a/aa-core/src/topology/cycle.rs
+++ b/aa-core/src/topology/cycle.rs
@@ -1,0 +1,185 @@
+//! Cycle detection for agent-topology graphs via Tarjan's SCC algorithm.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::identity::AgentId;
+
+use super::edge::Edge;
+
+/// Detect a cycle in the directed graph described by `edges`.
+///
+/// Returns the node members of the first strongly-connected component (SCC)
+/// that forms a cycle — either an SCC with more than one member, or a
+/// single-member SCC whose sole node has a self-loop — or `None` when the
+/// graph is acyclic (a DAG).
+///
+/// Uses Tarjan's SCC algorithm (linear time, O(V + E)).
+#[cfg(feature = "std")]
+pub fn cycle_detect(edges: &[Edge]) -> Option<Vec<AgentId>> {
+    let mut adj: HashMap<AgentId, Vec<AgentId>> = HashMap::new();
+    let mut all_nodes: HashSet<AgentId> = HashSet::new();
+    let mut self_loops: HashSet<AgentId> = HashSet::new();
+
+    for edge in edges {
+        all_nodes.insert(edge.source);
+        all_nodes.insert(edge.target);
+        if edge.source == edge.target {
+            self_loops.insert(edge.source);
+        }
+        adj.entry(edge.source).or_default().push(edge.target);
+    }
+
+    let mut state = TarjanState {
+        adj: &adj,
+        self_loops: &self_loops,
+        index_counter: 0,
+        stack: Vec::new(),
+        on_stack: HashSet::new(),
+        index_map: HashMap::new(),
+        lowlink: HashMap::new(),
+    };
+
+    for node in all_nodes {
+        if !state.index_map.contains_key(&node) {
+            if let Some(cycle) = state.strongconnect(node) {
+                return Some(cycle);
+            }
+        }
+    }
+
+    None
+}
+
+struct TarjanState<'a> {
+    adj: &'a HashMap<AgentId, Vec<AgentId>>,
+    self_loops: &'a HashSet<AgentId>,
+    index_counter: u32,
+    stack: Vec<AgentId>,
+    on_stack: HashSet<AgentId>,
+    index_map: HashMap<AgentId, u32>,
+    lowlink: HashMap<AgentId, u32>,
+}
+
+impl TarjanState<'_> {
+    fn strongconnect(&mut self, v: AgentId) -> Option<Vec<AgentId>> {
+        self.index_map.insert(v, self.index_counter);
+        self.lowlink.insert(v, self.index_counter);
+        self.index_counter += 1;
+        self.stack.push(v);
+        self.on_stack.insert(v);
+
+        // Clone to avoid simultaneous borrow of self.adj and self.*
+        let neighbors: Vec<AgentId> = self.adj.get(&v).cloned().unwrap_or_default();
+
+        for w in neighbors {
+            if !self.index_map.contains_key(&w) {
+                if let Some(cycle) = self.strongconnect(w) {
+                    return Some(cycle);
+                }
+                let w_low = self.lowlink[&w];
+                *self.lowlink.get_mut(&v).unwrap() = self.lowlink[&v].min(w_low);
+            } else if self.on_stack.contains(&w) {
+                let w_idx = self.index_map[&w];
+                *self.lowlink.get_mut(&v).unwrap() = self.lowlink[&v].min(w_idx);
+            }
+        }
+
+        // v is the root of an SCC when its lowlink equals its discovery index.
+        if self.lowlink[&v] == self.index_map[&v] {
+            let mut scc: Vec<AgentId> = Vec::new();
+            loop {
+                let w = self.stack.pop().expect("Tarjan stack invariant violated");
+                self.on_stack.remove(&w);
+                scc.push(w);
+                if w == v {
+                    break;
+                }
+            }
+            // A real cycle: SCC with > 1 member, or a single node with a self-loop.
+            if scc.len() > 1 || self.self_loops.contains(&scc[0]) {
+                return Some(scc);
+            }
+        }
+
+        None
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use chrono::Utc;
+
+    use crate::identity::AgentId;
+    use crate::topology::edge::{Edge, EdgeType};
+
+    use super::cycle_detect;
+
+    fn agent(n: u8) -> AgentId {
+        AgentId::from_bytes([n; 16])
+    }
+
+    fn edge(src: AgentId, tgt: AgentId) -> Edge {
+        Edge {
+            id: 0,
+            source: src,
+            target: tgt,
+            edge_type: EdgeType::Messages,
+            created_at: Utc::now(),
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn dag_returns_none() {
+        // A → B → C (no back edges)
+        let a = agent(1);
+        let b = agent(2);
+        let c = agent(3);
+        let edges = [edge(a, b), edge(b, c)];
+        assert!(cycle_detect(&edges).is_none());
+    }
+
+    #[test]
+    fn simple_two_node_cycle_returns_both() {
+        // A → B → A
+        let a = agent(1);
+        let b = agent(2);
+        let edges = [edge(a, b), edge(b, a)];
+        let result = cycle_detect(&edges).expect("cycle must be detected");
+        let mut ids: Vec<u8> = result.iter().map(|id| id.as_bytes()[0]).collect();
+        ids.sort();
+        assert_eq!(ids, vec![1, 2]);
+    }
+
+    #[test]
+    fn self_loop_returns_single_node() {
+        // A → A
+        let a = agent(1);
+        let edges = [edge(a, a)];
+        let result = cycle_detect(&edges).expect("self-loop is a cycle");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0], a);
+    }
+
+    #[test]
+    fn disconnected_graph_with_one_cycle_returns_the_cycle() {
+        // DAG component: X → Y
+        // Cycle component: A → B → C → A
+        let x = agent(10);
+        let y = agent(11);
+        let a = agent(1);
+        let b = agent(2);
+        let c = agent(3);
+        let edges = [edge(x, y), edge(a, b), edge(b, c), edge(c, a)];
+        let result = cycle_detect(&edges).expect("cycle must be detected");
+        assert!(result.len() >= 2, "cycle has at least 2 members");
+        let ids: Vec<u8> = result.iter().map(|id| id.as_bytes()[0]).collect();
+        // All cycle members must be from {a, b, c}
+        for id in &ids {
+            assert!(
+                [1u8, 2, 3].contains(id),
+                "unexpected node {id} in cycle result"
+            );
+        }
+    }
+}

--- a/aa-core/src/topology/mod.rs
+++ b/aa-core/src/topology/mod.rs
@@ -1,5 +1,6 @@
 //! Agent-graph mesh topology types and repository trait (AAASM-985).
 
+#[cfg(feature = "std")]
 pub mod cycle;
 pub mod edge;
 

--- a/aa-core/src/topology/mod.rs
+++ b/aa-core/src/topology/mod.rs
@@ -1,5 +1,6 @@
 //! Agent-graph mesh topology types and repository trait (AAASM-985).
 
+pub mod cycle;
 pub mod edge;
 
 pub use edge::EdgeType;
@@ -9,6 +10,9 @@ pub use edge::UnknownEdgeType;
 
 #[cfg(feature = "std")]
 pub use edge::{Edge, EdgeRepo, EdgeRepoError, NewEdge};
+
+#[cfg(feature = "std")]
+pub use cycle::cycle_detect;
 
 #[cfg(all(feature = "std", feature = "test-utils"))]
 pub use edge::MockEdgeRepo;

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -48,6 +48,50 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/agents/{id}/edges": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List directed edges for an agent.
+         * @description Returns edges ordered newest-first.  `direction` defaults to `outgoing`.
+         *     `limit` defaults to 100 and is capped at 1000.  `before` filters to edges
+         *     recorded before the given ISO 8601 timestamp.
+         */
+        get: operations["list_agent_edges"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/agents/{id}/graph": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Return the topology subgraph reachable from an agent.
+         * @description Performs BFS outward from `id` up to `depth` hops (default 2, max 5).
+         *     Returns all unique nodes reachable and the edges between them, with
+         *     `is_cross_team` computed via a batched registry lookup.
+         */
+        get: operations["get_agent_graph"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/agents/{id}/resume": {
         parameters: {
             query?: never;
@@ -293,6 +337,27 @@ export interface paths {
         get: operations["get_active_policy"];
         put?: never;
         post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/topology/edges": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Record a new directed topology edge.
+         * @description Used by SDK emitters (Python, Node.js, Go) to push observed
+         *     agent-to-agent interactions into the gateway edge store.
+         */
+        post: operations["report_edge"];
         delete?: never;
         options?: never;
         head?: never;
@@ -705,6 +770,35 @@ export interface components {
             /** @description Optional reason for the decision. */
             reason?: string | null;
         };
+        /** @description Paginated list of directed edges for an agent. */
+        EdgeListResponse: {
+            /** @description The queried agent ID. */
+            agent_id: string;
+            /** @description Total number of edges returned. */
+            count: number;
+            /** @description The list of matching edges, newest first. */
+            edges: components["schemas"]["EdgeResponse"][];
+        };
+        /** @description A single directed edge between two agents. */
+        EdgeResponse: {
+            /** @description ISO 8601 timestamp when the edge was recorded. */
+            created_at: string;
+            /** @description Edge semantic type (snake_case). */
+            edge_type: string;
+            /**
+             * Format: int64
+             * @description Auto-assigned edge identifier.
+             */
+            id: number;
+            /** @description Whether the edge crosses team boundaries. */
+            is_cross_team: boolean;
+            /** @description Optional freeform metadata attached at emission time. */
+            metadata?: unknown;
+            /** @description Hex-encoded source agent ID. */
+            source_agent_id: string;
+            /** @description Hex-encoded target agent ID. */
+            target_agent_id: string;
+        };
         /**
          * @description Discriminated union of all possible `GovernanceEvent.payload` shapes.
          *
@@ -747,6 +841,20 @@ export interface components {
             payload: components["schemas"]["EventPayload"];
             /** @description Timestamp when the event was received by the API layer (ISO 8601). */
             timestamp: string;
+        };
+        /** @description A node in the topology subgraph. */
+        GraphNode: {
+            /** @description Hex-encoded agent ID. */
+            id: string;
+        };
+        /** @description Subgraph reachable from an agent within a depth bound. */
+        GraphResponse: {
+            /** @description All edges between nodes in this subgraph. */
+            edges: components["schemas"]["EdgeResponse"][];
+            /** @description All unique agent nodes reachable within `depth` hops. */
+            nodes: components["schemas"]["GraphNode"][];
+            /** @description Root agent ID used for the BFS. */
+            root_agent_id: string;
         };
         /** @description Response body for the health endpoint. */
         HealthResponse: {
@@ -857,6 +965,25 @@ export interface components {
             session_id: string;
             /** @description ISO 8601 timestamp when the trace session started. */
             timestamp: string;
+        };
+        /** @description Request body for recording a new directed edge. */
+        ReportEdgeRequest: {
+            /** @description Edge semantic type (e.g. `"messages"`, `"delegates_to"`). */
+            edge_type: string;
+            /** @description Optional metadata JSON string. */
+            metadata_json?: string | null;
+            /** @description Hex-encoded source agent ID. */
+            source_agent_id: string;
+            /** @description Hex-encoded target agent ID. */
+            target_agent_id: string;
+        };
+        /** @description Response after recording a new edge. */
+        ReportEdgeResponse: {
+            /**
+             * Format: int64
+             * @description Auto-assigned edge identifier.
+             */
+            id: number;
         };
         /** @description Response from `POST /api/v1/agents/:id/resume`. */
         ResumeResponse: {
@@ -1133,6 +1260,115 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    list_agent_edges: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Filter by edge type (snake_case). Omit for all types.
+                 * @example messages
+                 */
+                type?: string | null;
+                /**
+                 * @description Direction of edges relative to the agent. Defaults to `outgoing`.
+                 * @example outgoing
+                 */
+                direction?: string | null;
+                /**
+                 * @description Maximum number of results. Defaults to 100, capped at 1000.
+                 * @example 100
+                 */
+                limit?: number | null;
+                /**
+                 * @description Return only edges recorded before this ISO 8601 timestamp.
+                 * @example 2026-01-01T00:00:00Z
+                 */
+                before?: string | null;
+            };
+            header?: never;
+            path: {
+                /** @description Hex-encoded agent ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Edge list */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EdgeListResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Store error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+        };
+    };
+    get_agent_graph: {
+        parameters: {
+            query?: {
+                /**
+                 * @description BFS depth from the root agent. Defaults to 2, capped at 5.
+                 * @example 2
+                 */
+                depth?: number | null;
+            };
+            header?: never;
+            path: {
+                /** @description Hex-encoded root agent ID */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Subgraph */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GraphResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Store error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
             };
         };
     };
@@ -1539,6 +1775,48 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    report_edge: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ReportEdgeRequest"];
+            };
+        };
+        responses: {
+            /** @description Edge recorded */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReportEdgeResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Store error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
             };
         };
     };

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -2083,6 +2083,4 @@ tags:
 - name: events
   description: Real-time event streaming via WebSocket
 - name: topology
-  description: Agent topology — tree, team, lineage, and statistics queries
-- name: topology
-  description: Mesh topology edge store — record and query directed agent-to-agent edges
+  description: Agent topology — tree, team, lineage, statistics, and mesh edge queries

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -99,6 +99,127 @@ paths:
           description: Invalid agent ID format
         '404':
           description: Agent not found
+  /api/v1/agents/{id}/edges:
+    get:
+      tags:
+      - agents
+      summary: List directed edges for an agent.
+      description: |-
+        Returns edges ordered newest-first.  `direction` defaults to `outgoing`.
+        `limit` defaults to 100 and is capped at 1000.  `before` filters to edges
+        recorded before the given ISO 8601 timestamp.
+      operationId: list_agent_edges
+      parameters:
+      - name: id
+        in: path
+        description: Hex-encoded agent ID
+        required: true
+        schema:
+          type: string
+      - name: type
+        in: query
+        description: Filter by edge type (snake_case). Omit for all types.
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
+        example: messages
+      - name: direction
+        in: query
+        description: Direction of edges relative to the agent. Defaults to `outgoing`.
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
+        example: outgoing
+      - name: limit
+        in: query
+        description: Maximum number of results. Defaults to 100, capped at 1000.
+        required: false
+        schema:
+          type:
+          - integer
+          - 'null'
+          format: int32
+          minimum: 0
+        example: 100
+      - name: before
+        in: query
+        description: Return only edges recorded before this ISO 8601 timestamp.
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
+        example: 2026-01-01T00:00:00Z
+      responses:
+        '200':
+          description: Edge list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EdgeListResponse'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '500':
+          description: Store error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+  /api/v1/agents/{id}/graph:
+    get:
+      tags:
+      - agents
+      summary: Return the topology subgraph reachable from an agent.
+      description: |-
+        Performs BFS outward from `id` up to `depth` hops (default 2, max 5).
+        Returns all unique nodes reachable and the edges between them, with
+        `is_cross_team` computed via a batched registry lookup.
+      operationId: get_agent_graph
+      parameters:
+      - name: id
+        in: path
+        description: Hex-encoded root agent ID
+        required: true
+        schema:
+          type: string
+      - name: depth
+        in: query
+        description: BFS depth from the root agent. Defaults to 2, capped at 5.
+        required: false
+        schema:
+          type:
+          - integer
+          - 'null'
+          format: int32
+          minimum: 0
+        example: 2
+      responses:
+        '200':
+          description: Subgraph
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GraphResponse'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '500':
+          description: Store error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
   /api/v1/agents/{id}/resume:
     post:
       tags:
@@ -500,6 +621,40 @@ paths:
                 $ref: '#/components/schemas/PolicyResponse'
         '404':
           description: No active policy loaded
+  /api/v1/topology/edges:
+    post:
+      tags:
+      - topology
+      summary: Record a new directed topology edge.
+      description: |-
+        Used by SDK emitters (Python, Node.js, Go) to push observed
+        agent-to-agent interactions into the gateway edge store.
+      operationId: report_edge
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReportEdgeRequest'
+        required: true
+      responses:
+        '201':
+          description: Edge recorded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReportEdgeResponse'
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '500':
+          description: Store error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
   /api/v1/topology/lineage/{agent_id}:
     get:
       tags:
@@ -1208,6 +1363,58 @@ components:
           - string
           - 'null'
           description: Optional reason for the decision.
+    EdgeListResponse:
+      type: object
+      description: Paginated list of directed edges for an agent.
+      required:
+      - agent_id
+      - edges
+      - count
+      properties:
+        agent_id:
+          type: string
+          description: The queried agent ID.
+        count:
+          type: integer
+          description: Total number of edges returned.
+          minimum: 0
+        edges:
+          type: array
+          items:
+            $ref: '#/components/schemas/EdgeResponse'
+          description: The list of matching edges, newest first.
+    EdgeResponse:
+      type: object
+      description: A single directed edge between two agents.
+      required:
+      - id
+      - source_agent_id
+      - target_agent_id
+      - edge_type
+      - created_at
+      - is_cross_team
+      properties:
+        created_at:
+          type: string
+          description: ISO 8601 timestamp when the edge was recorded.
+        edge_type:
+          type: string
+          description: Edge semantic type (snake_case).
+        id:
+          type: integer
+          format: int64
+          description: Auto-assigned edge identifier.
+        is_cross_team:
+          type: boolean
+          description: Whether the edge crosses team boundaries.
+        metadata:
+          description: Optional freeform metadata attached at emission time.
+        source_agent_id:
+          type: string
+          description: Hex-encoded source agent ID.
+        target_agent_id:
+          type: string
+          description: Hex-encoded target agent ID.
     EventPayload:
       oneOf:
       - $ref: '#/components/schemas/ViolationPayload'
@@ -1269,6 +1476,36 @@ components:
         timestamp:
           type: string
           description: Timestamp when the event was received by the API layer (ISO 8601).
+    GraphNode:
+      type: object
+      description: A node in the topology subgraph.
+      required:
+      - id
+      properties:
+        id:
+          type: string
+          description: Hex-encoded agent ID.
+    GraphResponse:
+      type: object
+      description: Subgraph reachable from an agent within a depth bound.
+      required:
+      - root_agent_id
+      - nodes
+      - edges
+      properties:
+        edges:
+          type: array
+          items:
+            $ref: '#/components/schemas/EdgeResponse'
+          description: All edges between nodes in this subgraph.
+        nodes:
+          type: array
+          items:
+            $ref: '#/components/schemas/GraphNode'
+          description: All unique agent nodes reachable within `depth` hops.
+        root_agent_id:
+          type: string
+          description: Root agent ID used for the BFS.
     HealthResponse:
       type: object
       description: Response body for the health endpoint.
@@ -1450,6 +1687,38 @@ components:
         timestamp:
           type: string
           description: ISO 8601 timestamp when the trace session started.
+    ReportEdgeRequest:
+      type: object
+      description: Request body for recording a new directed edge.
+      required:
+      - source_agent_id
+      - target_agent_id
+      - edge_type
+      properties:
+        edge_type:
+          type: string
+          description: Edge semantic type (e.g. `"messages"`, `"delegates_to"`).
+        metadata_json:
+          type:
+          - string
+          - 'null'
+          description: Optional metadata JSON string.
+        source_agent_id:
+          type: string
+          description: Hex-encoded source agent ID.
+        target_agent_id:
+          type: string
+          description: Hex-encoded target agent ID.
+    ReportEdgeResponse:
+      type: object
+      description: Response after recording a new edge.
+      required:
+      - id
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Auto-assigned edge identifier.
     ResumeResponse:
       type: object
       description: Response from `POST /api/v1/agents/:id/resume`.
@@ -1815,3 +2084,5 @@ tags:
   description: Real-time event streaming via WebSocket
 - name: topology
   description: Agent topology — tree, team, lineage, and statistics queries
+- name: topology
+  description: Mesh topology edge store — record and query directed agent-to-agent edges


### PR DESCRIPTION
## What changed

Three new REST endpoints for the mesh topology edge store, plus a pure Rust implementation of Tarjan's SCC algorithm for cycle detection:

- **`POST /api/v1/topology/edges`** — ingest SDK-emitted agent-to-agent edges into the in-memory edge repo
- **`GET /api/v1/agents/{id}/edges`** — paginated edge listing for one agent (direction, edge_type, limit, before filters)
- **`GET /api/v1/agents/{id}/graph`** — BFS subgraph up to N hops (default 2, max 5) with batched `is_cross_team` lookup
- **`cycle_detect(edges)`** in `aa-core::topology::cycle` — Tarjan's SCC with self-loop detection; returns the first cycle found

All endpoints are utoipa-annotated (OpenAPI 3.1.0). AppState gains an `edge_repo: Arc<dyn EdgeRepo>` field backed by `InMemoryEdgeRepo` in tests.

## Why

AAASM-995: establish the REST transport layer so Python SDK and other HTTP consumers can push and query topology edges.

## How to verify

- `cargo nextest run -p aa-core` — 162 tests pass (includes 4 cycle_detect unit tests)
- `cargo nextest run -p aa-api` — 221 tests pass (includes 11 new edge endpoint integration tests)

Closes AAASM-995