### PR TITLE
[AAASM-1001] ✨ (aa-gateway/edges): Cross-team edge event publishing

### DIFF
--- a/aa-gateway/src/edges/events.rs
+++ b/aa-gateway/src/edges/events.rs
@@ -1,0 +1,36 @@
+//! Cross-team edge detection events (AAASM-1001).
+//!
+//! Published to the internal broadcast channel whenever an `EdgeRepo::insert`
+//! records an edge whose source and target agents belong to different teams.
+//! Consumers (e.g. the inter-team channel work in AAASM-198) subscribe via
+//! `InMemoryEdgeRepo::subscribe_cross_team_events()`.
+
+use chrono::{DateTime, Utc};
+
+use aa_core::identity::AgentId;
+use aa_core::topology::EdgeType;
+
+/// Capacity of the cross-team edge event broadcast channel.
+pub(crate) const CROSS_TEAM_CHANNEL_CAPACITY: usize = 64;
+
+/// Emitted whenever an edge is inserted between agents in different teams.
+///
+/// Both `source_team_id` and `target_team_id` are always non-empty — the event
+/// is only published when both agents have a known, non-NULL `team_id`.
+#[derive(Debug, Clone)]
+pub struct CrossTeamEdgeEvent {
+    /// The auto-assigned id of the inserted edge.
+    pub edge_id: i64,
+    /// The agent that originated the relationship.
+    pub source_agent_id: AgentId,
+    /// Team the source agent belongs to.
+    pub source_team_id: String,
+    /// The agent that was the target of the relationship.
+    pub target_agent_id: AgentId,
+    /// Team the target agent belongs to.
+    pub target_team_id: String,
+    /// Semantic type of the edge.
+    pub edge_type: EdgeType,
+    /// When the edge was recorded (UTC).
+    pub occurred_at: DateTime<Utc>,
+}

--- a/aa-gateway/src/edges/mod.rs
+++ b/aa-gateway/src/edges/mod.rs
@@ -4,9 +4,11 @@
 //! AAASM-980: append-only rows, `created_at DESC` ordering, and secondary
 //! indexes on `(source_agent_id, edge_type)` and `(target_agent_id, edge_type)`.
 
+pub mod events;
 pub mod repo;
 pub mod store;
 
+pub use events::CrossTeamEdgeEvent;
 pub use repo::InMemoryEdgeRepo;
 pub use store::InMemoryEdgeStore;
 

--- a/aa-gateway/src/edges/repo.rs
+++ b/aa-gateway/src/edges/repo.rs
@@ -5,9 +5,13 @@ use std::sync::{Arc, RwLock};
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use tokio::sync::broadcast;
 
 use aa_core::identity::AgentId;
 use aa_core::topology::{Edge, EdgeRepo, EdgeRepoError, EdgeType, NewEdge};
+
+use crate::edges::events::{CrossTeamEdgeEvent, CROSS_TEAM_CHANNEL_CAPACITY};
+use crate::registry::AgentRegistry;
 
 struct RepoData {
     records: Vec<Edge>,
@@ -36,17 +40,43 @@ impl RepoData {
 /// Writes are `O(1)`. Reads over secondary indexes are `O(result_size)`.
 /// The `limit` parameter on every list method is silently capped at 1 000.
 /// Thread-safe via `Arc<RwLock<_>>`.
+///
+/// When constructed with [`InMemoryEdgeRepo::with_events`], every `insert` that
+/// crosses team boundaries publishes a [`CrossTeamEdgeEvent`] to the internal
+/// broadcast channel. Subscribers call [`InMemoryEdgeRepo::subscribe_cross_team_events`].
 #[derive(Clone)]
 pub struct InMemoryEdgeRepo {
     data: Arc<RwLock<RepoData>>,
+    registry: Option<Arc<AgentRegistry>>,
+    event_tx: Option<broadcast::Sender<CrossTeamEdgeEvent>>,
 }
 
 impl InMemoryEdgeRepo {
-    /// Create an empty `InMemoryEdgeRepo`.
+    /// Create an empty repo with no event publishing.
     pub fn new() -> Self {
         Self {
             data: Arc::new(RwLock::new(RepoData::new())),
+            registry: None,
+            event_tx: None,
         }
+    }
+
+    /// Create a repo that publishes [`CrossTeamEdgeEvent`]s when an inserted
+    /// edge crosses team boundaries.
+    pub fn with_events(registry: Arc<AgentRegistry>) -> (Self, broadcast::Receiver<CrossTeamEdgeEvent>) {
+        let (tx, rx) = broadcast::channel(CROSS_TEAM_CHANNEL_CAPACITY);
+        let repo = Self {
+            data: Arc::new(RwLock::new(RepoData::new())),
+            registry: Some(registry),
+            event_tx: Some(tx),
+        };
+        (repo, rx)
+    }
+
+    /// Subscribe to cross-team edge events.  Returns `None` when the repo was
+    /// constructed without event publishing (i.e. via [`InMemoryEdgeRepo::new`]).
+    pub fn subscribe_cross_team_events(&self) -> Option<broadcast::Receiver<CrossTeamEdgeEvent>> {
+        self.event_tx.as_ref().map(|tx| tx.subscribe())
     }
 }
 
@@ -59,30 +89,62 @@ impl Default for InMemoryEdgeRepo {
 #[async_trait]
 impl EdgeRepo for InMemoryEdgeRepo {
     async fn insert(&self, edge: NewEdge) -> Result<i64, EdgeRepoError> {
-        let mut data = self.data.write().expect("edge repo lock poisoned");
-        let id = data.next_id;
-        data.next_id += 1;
-        let idx = data.records.len();
+        // --- write critical section: hold lock only for the store update ---
+        let (id, source, target, edge_type, occurred_at) = {
+            let mut data = self.data.write().expect("edge repo lock poisoned");
+            let id = data.next_id;
+            data.next_id += 1;
+            let idx = data.records.len();
 
-        data.by_source_type
-            .entry((edge.source, edge.edge_type))
-            .or_default()
-            .push(idx);
-        data.by_target_type
-            .entry((edge.target, edge.edge_type))
-            .or_default()
-            .push(idx);
-        data.by_source.entry(edge.source).or_default().push(idx);
-        data.by_target.entry(edge.target).or_default().push(idx);
+            data.by_source_type
+                .entry((edge.source, edge.edge_type))
+                .or_default()
+                .push(idx);
+            data.by_target_type
+                .entry((edge.target, edge.edge_type))
+                .or_default()
+                .push(idx);
+            data.by_source.entry(edge.source).or_default().push(idx);
+            data.by_target.entry(edge.target).or_default().push(idx);
 
-        data.records.push(Edge {
-            id,
-            source: edge.source,
-            target: edge.target,
-            edge_type: edge.edge_type,
-            created_at: Utc::now(),
-            metadata: edge.metadata,
-        });
+            let occurred_at = Utc::now();
+            data.records.push(Edge {
+                id,
+                source: edge.source,
+                target: edge.target,
+                edge_type: edge.edge_type,
+                created_at: occurred_at,
+                metadata: edge.metadata,
+            });
+            (id, edge.source, edge.target, edge.edge_type, occurred_at)
+        };
+        // --- lock released; now do registry lookup + event publish ---
+
+        if let (Some(registry), Some(tx)) = (&self.registry, &self.event_tx) {
+            let src_team = registry.get(source.as_bytes()).and_then(|r| r.team_id);
+            let tgt_team = registry.get(target.as_bytes()).and_then(|r| r.team_id);
+            match (src_team, tgt_team) {
+                (Some(source_team_id), Some(target_team_id)) if source_team_id != target_team_id => {
+                    let _ = tx.send(CrossTeamEdgeEvent {
+                        edge_id: id,
+                        source_agent_id: source,
+                        source_team_id,
+                        target_agent_id: target,
+                        target_team_id,
+                        edge_type,
+                        occurred_at,
+                    });
+                }
+                (None, _) | (_, None) => {
+                    tracing::info!(
+                        edge_id = id,
+                        "cross-team check skipped: one or both agents have no team_id"
+                    );
+                }
+                _ => {} // same team — no event needed
+            }
+        }
+
         Ok(id)
     }
 

--- a/aa-gateway/tests/cross_team_edge_test.rs
+++ b/aa-gateway/tests/cross_team_edge_test.rs
@@ -1,0 +1,184 @@
+//! Integration tests for cross-team edge event publishing (AAASM-1001).
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use aa_core::identity::AgentId;
+use aa_core::topology::{EdgeRepo, EdgeType, NewEdge};
+use aa_gateway::edges::{CrossTeamEdgeEvent, InMemoryEdgeRepo};
+use aa_gateway::registry::{AgentRecord, AgentRegistry, AgentStatus};
+use chrono::Utc;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn agent_id(n: u8) -> AgentId {
+    AgentId::from_bytes([n; 16])
+}
+
+fn make_record(n: u8, team_id: Option<&str>) -> AgentRecord {
+    AgentRecord {
+        agent_id: [n; 16],
+        name: format!("agent-{n}"),
+        framework: "test".into(),
+        version: "0.0.1".into(),
+        risk_tier: 1,
+        tool_names: vec![],
+        public_key: "pk".into(),
+        credential_token: "tok".into(),
+        metadata: BTreeMap::new(),
+        registered_at: Utc::now(),
+        last_heartbeat: Utc::now(),
+        status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
+        policy_violations_count: 0,
+        active_sessions: vec![],
+        recent_events: std::collections::VecDeque::new(),
+        recent_traces: vec![],
+        layer: None,
+        governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: team_id.map(str::to_string),
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: Some([n; 16]),
+        children: vec![],
+        parent_key: None,
+    }
+}
+
+async fn recv_with_timeout(
+    rx: &mut tokio::sync::broadcast::Receiver<CrossTeamEdgeEvent>,
+) -> Option<CrossTeamEdgeEvent> {
+    tokio::time::timeout(Duration::from_millis(100), rx.recv())
+        .await
+        .ok()
+        .and_then(|r| r.ok())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn cross_team_edge_publishes_event() {
+    let registry = Arc::new(AgentRegistry::new());
+    registry.register(make_record(0x01, Some("team-alpha"))).unwrap();
+    registry.register(make_record(0x02, Some("team-beta"))).unwrap();
+
+    let (repo, mut rx) = InMemoryEdgeRepo::with_events(registry);
+
+    let edge_id = repo
+        .insert(NewEdge {
+            source: agent_id(0x01),
+            target: agent_id(0x02),
+            edge_type: EdgeType::Messages,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    let event = recv_with_timeout(&mut rx)
+        .await
+        .expect("expected CrossTeamEdgeEvent within 100ms");
+
+    assert_eq!(event.edge_id, edge_id);
+    assert_eq!(event.source_agent_id, agent_id(0x01));
+    assert_eq!(event.target_agent_id, agent_id(0x02));
+    assert_eq!(event.source_team_id, "team-alpha");
+    assert_eq!(event.target_team_id, "team-beta");
+    assert_eq!(event.edge_type, EdgeType::Messages);
+}
+
+#[tokio::test]
+async fn same_team_edge_does_not_publish() {
+    let registry = Arc::new(AgentRegistry::new());
+    registry.register(make_record(0x01, Some("team-alpha"))).unwrap();
+    registry.register(make_record(0x02, Some("team-alpha"))).unwrap();
+
+    let (repo, mut rx) = InMemoryEdgeRepo::with_events(registry);
+
+    repo.insert(NewEdge {
+        source: agent_id(0x01),
+        target: agent_id(0x02),
+        edge_type: EdgeType::Messages,
+        metadata: None,
+    })
+    .await
+    .unwrap();
+
+    assert!(
+        recv_with_timeout(&mut rx).await.is_none(),
+        "same-team edge must not publish a CrossTeamEdgeEvent"
+    );
+}
+
+#[tokio::test]
+async fn null_team_id_does_not_publish_event() {
+    let registry = Arc::new(AgentRegistry::new());
+    // source has a team, target does not
+    registry.register(make_record(0x01, Some("team-alpha"))).unwrap();
+    registry.register(make_record(0x02, None)).unwrap();
+
+    let (repo, mut rx) = InMemoryEdgeRepo::with_events(registry);
+
+    repo.insert(NewEdge {
+        source: agent_id(0x01),
+        target: agent_id(0x02),
+        edge_type: EdgeType::DelegatesTo,
+        metadata: None,
+    })
+    .await
+    .unwrap();
+
+    assert!(
+        recv_with_timeout(&mut rx).await.is_none(),
+        "edge with one null team_id must not publish a CrossTeamEdgeEvent"
+    );
+}
+
+#[tokio::test]
+async fn event_payload_contains_correct_edge_type() {
+    let registry = Arc::new(AgentRegistry::new());
+    registry.register(make_record(0x01, Some("team-a"))).unwrap();
+    registry.register(make_record(0x02, Some("team-b"))).unwrap();
+
+    let (repo, mut rx) = InMemoryEdgeRepo::with_events(registry);
+
+    repo.insert(NewEdge {
+        source: agent_id(0x01),
+        target: agent_id(0x02),
+        edge_type: EdgeType::DelegatesTo,
+        metadata: None,
+    })
+    .await
+    .unwrap();
+
+    let event = recv_with_timeout(&mut rx).await.expect("expected event");
+    assert_eq!(event.edge_type, EdgeType::DelegatesTo);
+}
+
+#[tokio::test]
+async fn repo_without_events_still_inserts_correctly() {
+    let repo = InMemoryEdgeRepo::new();
+    assert!(repo.subscribe_cross_team_events().is_none());
+
+    let id = repo
+        .insert(NewEdge {
+            source: agent_id(0x01),
+            target: agent_id(0x02),
+            edge_type: EdgeType::Calls,
+            metadata: None,
+        })
+        .await
+        .unwrap();
+
+    let edges = repo.list_outgoing(agent_id(0x01), None, 10).await.unwrap();
+    assert_eq!(edges.len(), 1);
+    assert_eq!(edges[0].id, id);
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -22,6 +22,10 @@
 
 - [Migration Template](migration/template.md)
 
+# Events
+
+- [Cross-Team Edge](events/cross_team_edge.md)
+
 # Benchmarks
 
 - [Baseline](benchmarks/BASELINE.md)

--- a/docs/src/events/cross_team_edge.md
+++ b/docs/src/events/cross_team_edge.md
@@ -1,0 +1,57 @@
+# Event: `topology.cross_team_edge`
+
+Published by `aa-gateway` whenever an edge is inserted between two agents
+that belong to **different teams**.  Both agents must have a non-NULL `team_id`
+in the agent registry; if either is missing the event is suppressed and an
+`info`-level log line is emitted instead.
+
+## Transport
+
+Internal Tokio broadcast channel (`tokio::sync::broadcast::Sender<CrossTeamEdgeEvent>`).
+Channel capacity: 64.  Slow consumers receive `RecvError::Lagged(n)` when they
+fall behind.
+
+Subscribers call `InMemoryEdgeRepo::subscribe_cross_team_events()`.
+
+## Payload
+
+Rust type: `aa_gateway::edges::CrossTeamEdgeEvent`
+
+| Field | Type | Description |
+|---|---|---|
+| `edge_id` | `i64` | Auto-assigned id of the inserted edge |
+| `source_agent_id` | `AgentId` (`[u8; 16]`) | Agent that originated the relationship |
+| `source_team_id` | `String` | Team the source agent belongs to |
+| `target_agent_id` | `AgentId` (`[u8; 16]`) | Agent that was the target |
+| `target_team_id` | `String` | Team the target agent belongs to |
+| `edge_type` | `EdgeType` | Semantic type: one of `delegates_to`, `calls`, `reads`, `writes`, `approves`, `messages` |
+| `occurred_at` | `DateTime<Utc>` | UTC timestamp when the edge was recorded |
+
+## Example (JSON-serialised for illustration)
+
+```json
+{
+  "edge_id": 42,
+  "source_agent_id": "01010101010101010101010101010101",
+  "source_team_id": "team-alpha",
+  "target_agent_id": "02020202020202020202020202020202",
+  "target_team_id": "team-beta",
+  "edge_type": "messages",
+  "occurred_at": "2026-05-10T04:00:00Z"
+}
+```
+
+## Publishing conditions
+
+| Scenario | Action |
+|---|---|
+| `source.team_id != target.team_id` (both set) | Publish `CrossTeamEdgeEvent` |
+| Either `team_id` is `NULL` | Log at `INFO`; no event |
+| `source.team_id == target.team_id` | No event |
+
+## Consumer notes (AAASM-198)
+
+- Subscribe before inserting edges to avoid missing events on a lagged receiver.
+- The broadcast channel drops events for receivers that fall more than 64 messages
+  behind — design consumers to process promptly or buffer independently.
+- `edge_id` can be used to fetch full edge metadata via `GET /api/v1/agents/{id}/edges`.


### PR DESCRIPTION
## What changed

- New `CrossTeamEdgeEvent` struct in `aa-gateway/src/edges/events.rs` with fields: `edge_id`, `source_agent_id`, `source_team_id`, `target_agent_id`, `target_team_id`, `edge_type`, `occurred_at`
- `InMemoryEdgeRepo::with_events(registry)` constructor — attaches an `AgentRegistry` and a `broadcast::Sender<CrossTeamEdgeEvent>` (capacity 64)
- `InMemoryEdgeRepo::insert` now releases the write lock before doing the registry lookup, then publishes `CrossTeamEdgeEvent` when both agents have non-NULL `team_id` values that differ; logs `INFO` when either `team_id` is NULL
- `InMemoryEdgeRepo::subscribe_cross_team_events()` for consumers (AAASM-198)
- Event schema doc at `docs/src/events/cross_team_edge.md`

## Why

AAASM-1001: surface cross-team edges as structured events so the inter-team channel work (AAASM-198) can subscribe without polling the edge store.

## Event schema coordination (AAASM-198)

Event schema documented in `docs/src/events/cross_team_edge.md`. Key fields agreed with the AAASM-198 scope:

| Field | Type |
|---|---|
| `edge_id` | `i64` |
| `source_agent_id` / `target_agent_id` | `AgentId` |
| `source_team_id` / `target_team_id` | `String` (non-empty, both set) |
| `edge_type` | `EdgeType` |
| `occurred_at` | `DateTime<Utc>` |

Transport: `tokio::sync::broadcast` channel, capacity 64. Subscribe via `InMemoryEdgeRepo::subscribe_cross_team_events()`.

## How to verify

```
cargo nextest run -p aa-gateway --test cross_team_edge_test
# → 5/5 passed
cargo nextest run -p aa-gateway
# → 614/614 passed
```

Closes AAASM-1001