### PR TITLE
[AAASM-1195] 🐛 (aa-gateway): Wire CrossTeamEdgeEvent emission in production server

### DIFF
--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -329,7 +329,8 @@ pub async fn serve_tcp(
     )
     .with_db_scheduler(db_scheduler.clone());
     let audit_svc = AuditServiceImpl::new_with_registry(audit_tx, audit_drops, initial_hash, Arc::clone(&registry));
-    let topology_svc = TopologyServiceImpl::new(Arc::clone(&registry), InMemoryEdgeRepo::new());
+    let (edge_repo, _cross_team_rx) = InMemoryEdgeRepo::with_events(Arc::clone(&registry));
+    let topology_svc = TopologyServiceImpl::new(Arc::clone(&registry), edge_repo);
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);
     let approval_svc =
         ApprovalServiceImpl::new_with_escalation(approval_queue, escalation_scheduler).with_db_scheduler(db_scheduler);
@@ -391,7 +392,8 @@ pub async fn serve_uds(
     )
     .with_db_scheduler(db_scheduler.clone());
     let audit_svc = AuditServiceImpl::new_with_registry(audit_tx, audit_drops, initial_hash, Arc::clone(&registry));
-    let topology_svc = TopologyServiceImpl::new(Arc::clone(&registry), InMemoryEdgeRepo::new());
+    let (edge_repo, _cross_team_rx) = InMemoryEdgeRepo::with_events(Arc::clone(&registry));
+    let topology_svc = TopologyServiceImpl::new(Arc::clone(&registry), edge_repo);
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);
     let approval_svc =
         ApprovalServiceImpl::new_with_escalation(approval_queue, escalation_scheduler).with_db_scheduler(db_scheduler);


### PR DESCRIPTION
## Summary

Both `serve_tcp` and `serve_uds` in `aa-gateway/src/server.rs` were constructing `InMemoryEdgeRepo::new()`, which leaves the `CrossTeamEdgeEvent` broadcast channel permanently inactive. This violated AAASM-940 AC 6 — cross-team edges were never emitted to the inter-team channel (AAASM-198).

**Fix**: Switch both call sites to `InMemoryEdgeRepo::with_events(Arc::clone(&registry))`. The initial `Receiver` is dropped (`_cross_team_rx`) — the `Sender` lives inside the repo, keeping the channel alive for future subscribers via `repo.subscribe_cross_team_events()`.

## Why

Discovered during full AAASM-940 story-level AC re-verification. The emission logic and unit tests (`cross_team_edge_test.rs`) were correct; the wiring at the server level was missing.

## How to verify

```bash
cargo nextest run -p aa-gateway --test cross_team_edge_test  # 5/5 pass
cargo nextest run -p aa-gateway --lib                        # 416/416 pass
cargo clippy -p aa-gateway --all-targets -- -D warnings      # clean
```

Closes #AAASM-1195

🤖 Generated with [Claude Code](https://claude.com/claude-code)