### PR TITLE
[AAASM-1200] ✨ (ci): Add cross-platform release pipeline for aasm binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,3 +60,51 @@ jobs:
           name: aasm-${{ matrix.target }}
           path: aasm-${{ matrix.target }}.tar.gz
           retention-days: 1
+
+  publish:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts/
+          merge-multiple: true
+
+      - name: Generate SHA256SUMS
+        run: |
+          cd artifacts
+          sha256sum aasm-*.tar.gz > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Upload assets to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            artifacts/aasm-*.tar.gz
+            artifacts/SHA256SUMS
+          generate_release_notes: true
+
+  publish-crate:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install protobuf compiler
+        run: sudo apt-get install -y protobuf-compiler
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Publish aa-cli to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish -p aa-cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]*.[0-9]*.[0-9]*"
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+          - target: aarch64-apple-darwin
+            os: macos-14
+          - target: x86_64-apple-darwin
+            os: macos-13
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install protobuf compiler (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y protobuf-compiler
+
+      - name: Install protobuf compiler (macOS)
+        if: runner.os == 'macOS'
+        run: brew install protobuf
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build aasm release binary
+        run: cargo build --release --target ${{ matrix.target }} -p aa-cli
+
+      - name: Archive binary
+        shell: bash
+        run: |
+          tar -czf "aasm-${{ matrix.target }}.tar.gz" \
+            -C "target/${{ matrix.target }}/release" aasm
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: aasm-${{ matrix.target }}
+          path: aasm-${{ matrix.target }}.tar.gz
+          retention-days: 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,10 @@ suspicious = "deny"
 complexity = "warn"
 perf = "warn"
 style = "warn"
+
+[profile.release]
+opt-level = "z"
+lto = true
+codegen-units = 1
+strip = true
+panic = "abort"


### PR DESCRIPTION
## Description

Implements the cross-platform CI release pipeline for the `aasm` binary (F110). On every `v*.*.*` git tag push, GitHub Actions now builds `aasm` for all 4 supported platform targets, publishes pre-built archives to GitHub Releases, and publishes the crate to crates.io.

## Type of Change

- [x] ✨ New feature
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1200 (Story), AAASM-1199 (Epic)
- Sub-tasks delivered: AAASM-1206, AAASM-1207, AAASM-1208

## Changes

**Commit 1 — AAASM-1206:** `Cargo.toml` — append `[profile.release]` with `opt-level="z"`, `lto=true`, `codegen-units=1`, `strip=true`, `panic="abort"` to hit the 2–8 MB binary size target.

**Commit 2 — AAASM-1207:** `.github/workflows/release.yml` — new workflow with a 4-entry matrix build job. Each target maps to its native GitHub-hosted runner to avoid cross-compilation complexity:

| Target | Runner |
|---|---|
| `x86_64-unknown-linux-gnu` | `ubuntu-latest` |
| `aarch64-unknown-linux-gnu` | `ubuntu-24.04-arm` |
| `aarch64-apple-darwin` | `macos-14` (M1) |
| `x86_64-apple-darwin` | `macos-13` |

Each job builds `aa-cli --release`, archives the binary as `aasm-<target>.tar.gz`, and uploads it as a workflow artifact.

**Commit 3 — AAASM-1208:** Two publish jobs gated on the full matrix succeeding:
- `publish`: downloads all 4 archives, generates `SHA256SUMS` via `sha256sum`, uploads everything to GitHub Release via `softprops/action-gh-release` with auto-generated release notes.
- `publish-crate`: runs `cargo publish -p aa-cli` to crates.io using `CRATES_IO_TOKEN` secret.

## Testing

- [ ] Unit tests added / updated — N/A (CI workflow change)
- [ ] Integration tests added / updated — N/A
- [x] Manual testing performed — workflow will be validated by AAASM-1209: push test tag `v0.0.1-rc1`, confirm all 4 matrix jobs complete and assets appear on the GitHub Release
- [ ] No tests required (explain why)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing — tag-triggered, awaiting AAASM-1209 verification
- [x] Commits are small and follow the Gitmoji convention

## Prerequisites for merge

The `CRATES_IO_TOKEN` secret must be set in the `AI-agent-assembly/agent-assembly` repository settings before the first real release tag is pushed.