### PR TITLE
[AAASM-1186] 🐛 (ci): Exclude policy_latency_test from llvm-cov coverage passes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,8 +131,11 @@ jobs:
         # and doesn't add instrumented coverage. Running it under --all-features would
         # add 8+ minutes of Docker build time with zero coverage benefit.
         run: |
+          # sustained_load_p99_under_5ms is a timing-sensitive latency test that fails
+          # under llvm-cov instrumentation overhead — skipped in coverage runs only.
           cargo llvm-cov --no-report --all-features --workspace \
-            --exclude aa-ebpf --exclude aa-ffi-python --exclude aa-devtool-claude-code
+            --exclude aa-ebpf --exclude aa-ffi-python --exclude aa-devtool-claude-code \
+            -- --skip sustained_load_p99_under_5ms
           cargo llvm-cov --no-report -p aa-devtool-claude-code
           cargo llvm-cov --no-run --codecov --output-path codecov.xml
       - name: Upload to Codecov

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,22 @@ On `git push`, documentation is also checked: `cargo doc --workspace --no-deps`.
 
 The workspace-level clippy lints (`correctness = deny`, `suspicious = deny`, others `warn`) live in `[workspace.lints.clippy]` of the top-level `Cargo.toml` — do not override them per-crate.
 
+## Performance and Latency Tests
+
+Latency and performance tests assert absolute timing thresholds (e.g. p99 < 15 ms). They **must not run under `cargo llvm-cov`** or any other coverage/instrumentation tool, because instrumentation adds 2–10× overhead per instruction and makes timing guarantees unreliable on shared CI runners.
+
+**Rule:** every `cargo llvm-cov` invocation that covers the workspace must pass `-- --skip <test-name>` for each timing-sensitive test.
+
+Example (`ci.yml` and `sonar.yml`):
+
+```yaml
+cargo llvm-cov --no-report --all-features --workspace \
+  --exclude aa-ebpf --exclude aa-ffi-python \
+  -- --skip sustained_load_p99_under_5ms
+```
+
+Latency tests run in the dedicated **Benchmark** CI job (`cargo test -p aa-gateway --test policy_latency_test`) which uses an unmodified binary with no instrumentation.
+
 ## Build docs locally
 
 Contributor documentation is an [mdBook](https://rust-lang.github.io/mdBook/) rooted at `docs/`. To build or preview it:


### PR DESCRIPTION
## Description

`sustained_load_p99_under_5ms` in `aa-gateway/tests/policy_latency_test.rs` asserts an absolute p99 timing threshold (15 ms). It was already excluded from the SonarCloud coverage pass (`sonar.yml`), but was still executing under `cargo llvm-cov` in the **Codecov coverage job** (`ci.yml`). Under instrumentation, occasional OS scheduling jitter pushes the p99 tail well past the threshold, causing non-deterministic CI failures unrelated to any code change.

This PR applies the same skip already in `sonar.yml` to `ci.yml`, and documents the rule in `CONTRIBUTING.md` to prevent the same antipattern from recurring.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-1186
- Parent Epic: AAASM-1185

## Testing

- [x] No tests required — this is a CI configuration fix. The latency test continues to run in the dedicated **Benchmark** job (`cargo test -p aa-gateway --test policy_latency_test`) which uses an uninstrumented binary. The fix only removes the test from the coverage instrumentation pass where timing assertions are invalid.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (`CONTRIBUTING.md` — new "Performance and Latency Tests" section)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention