### PR TITLE
[AAASM-216] ✨ (aa-cli/topology): Implement aasm topology CLI subcommands with filtering

### DIFF
--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -20,6 +20,7 @@ pub mod policy;
 pub mod run;
 pub mod status;
 pub mod tools;
+pub mod topology;
 pub mod trace;
 pub mod version;
 
@@ -56,6 +57,8 @@ pub enum Commands {
     Run(run::RunArgs),
     /// List and manage AI dev tools on this system.
     Tools(tools::ToolsArgs),
+    /// Visualize agent topology, trees, lineage, and statistics.
+    Topology(topology::TopologyArgs),
 }
 
 /// Dispatch the parsed CLI command to the appropriate handler.
@@ -76,5 +79,6 @@ pub fn dispatch(cmd: Commands, ctx: &ResolvedContext, output: OutputFormat) -> E
         Commands::Dashboard(args) => dashboard::dispatch(args, ctx),
         Commands::Run(args) => run::dispatch(args, ctx, output),
         Commands::Tools(args) => tools::dispatch(args),
+        Commands::Topology(args) => topology::dispatch(args, ctx, output),
     }
 }

--- a/aa-cli/src/commands/topology/lineage.rs
+++ b/aa-cli/src/commands/topology/lineage.rs
@@ -1,0 +1,10 @@
+//! `aasm topology lineage` — show ancestry chain for a given agent.
+
+use clap::Args;
+
+/// Arguments for `aasm topology lineage`.
+#[derive(Args)]
+pub struct LineageArgs {
+    /// Agent ID (hex-encoded UUID).
+    pub agent_id: String,
+}

--- a/aa-cli/src/commands/topology/lineage.rs
+++ b/aa-cli/src/commands/topology/lineage.rs
@@ -1,10 +1,34 @@
 //! `aasm topology lineage` — show ancestry chain for a given agent.
 
+use std::process::ExitCode;
+
 use clap::Args;
+
+use super::render::{render, AgentLineage, TopologyPayload};
+use crate::client;
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
 
 /// Arguments for `aasm topology lineage`.
 #[derive(Args)]
 pub struct LineageArgs {
     /// Agent ID (hex-encoded UUID).
     pub agent_id: String,
+}
+
+/// Run the `aasm topology lineage` command.
+pub fn run(args: LineageArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    let path = format!("/api/v1/topology/lineage/{}", args.agent_id);
+
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    let lineage: AgentLineage = match rt.block_on(client::get_json(ctx, &path)) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    render(TopologyPayload::Lineage(&lineage), output);
+    ExitCode::SUCCESS
 }

--- a/aa-cli/src/commands/topology/mod.rs
+++ b/aa-cli/src/commands/topology/mod.rs
@@ -1,0 +1,8 @@
+//! `aasm topology` — visualize agent topology and lineage.
+
+pub mod lineage;
+pub mod overview;
+pub mod render;
+pub mod stats;
+pub mod team;
+pub mod tree;

--- a/aa-cli/src/commands/topology/mod.rs
+++ b/aa-cli/src/commands/topology/mod.rs
@@ -1,6 +1,11 @@
 //! `aasm topology` — visualize agent topology and lineage.
 
+use std::process::ExitCode;
+
 use clap::{Args, Subcommand};
+
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
 
 pub mod lineage;
 pub mod overview;
@@ -29,4 +34,15 @@ pub enum TopologyCommands {
     Lineage(lineage::LineageArgs),
     /// Show aggregate topology statistics.
     Stats(stats::StatsArgs),
+}
+
+/// Dispatch a topology subcommand.
+pub fn dispatch(args: TopologyArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    match args.command {
+        TopologyCommands::Overview(a) => overview::run(a, ctx, output),
+        TopologyCommands::Tree(a) => tree::run(a, ctx, output),
+        TopologyCommands::Team(a) => team::run(a, ctx, output),
+        TopologyCommands::Lineage(a) => lineage::run(a, ctx, output),
+        TopologyCommands::Stats(a) => stats::run(a, ctx, output),
+    }
 }

--- a/aa-cli/src/commands/topology/mod.rs
+++ b/aa-cli/src/commands/topology/mod.rs
@@ -1,6 +1,6 @@
 //! `aasm topology` — visualize agent topology and lineage.
 
-use clap::Args;
+use clap::{Args, Subcommand};
 
 pub mod lineage;
 pub mod overview;
@@ -14,4 +14,19 @@ pub mod tree;
 pub struct TopologyArgs {
     #[command(subcommand)]
     pub command: TopologyCommands,
+}
+
+/// Available topology subcommands.
+#[derive(Subcommand)]
+pub enum TopologyCommands {
+    /// Show fleet-wide topology overview.
+    Overview(overview::OverviewArgs),
+    /// Render a subtree rooted at a given agent.
+    Tree(tree::TreeArgs),
+    /// Show all agents in a team.
+    Team(team::TeamArgs),
+    /// Show ancestry chain for a given agent.
+    Lineage(lineage::LineageArgs),
+    /// Show aggregate topology statistics.
+    Stats(stats::StatsArgs),
 }

--- a/aa-cli/src/commands/topology/mod.rs
+++ b/aa-cli/src/commands/topology/mod.rs
@@ -1,8 +1,17 @@
 //! `aasm topology` — visualize agent topology and lineage.
 
+use clap::Args;
+
 pub mod lineage;
 pub mod overview;
 pub mod render;
 pub mod stats;
 pub mod team;
 pub mod tree;
+
+/// Arguments for the `aasm topology` subcommand group.
+#[derive(Args)]
+pub struct TopologyArgs {
+    #[command(subcommand)]
+    pub command: TopologyCommands,
+}

--- a/aa-cli/src/commands/topology/overview.rs
+++ b/aa-cli/src/commands/topology/overview.rs
@@ -1,0 +1,14 @@
+//! `aasm topology overview` — fleet-wide topology summary.
+
+use clap::Args;
+
+/// Arguments for `aasm topology overview`.
+#[derive(Args)]
+pub struct OverviewArgs {
+    /// Filter agents by status (active, suspended, deregistered).
+    #[arg(long)]
+    pub status: Option<String>,
+    /// Include governance level in agent nodes.
+    #[arg(long)]
+    pub show_budget: bool,
+}

--- a/aa-cli/src/commands/topology/overview.rs
+++ b/aa-cli/src/commands/topology/overview.rs
@@ -1,6 +1,13 @@
 //! `aasm topology overview` — fleet-wide topology summary.
 
+use std::process::ExitCode;
+
 use clap::Args;
+
+use super::render::{render, TopologyOverview, TopologyPayload};
+use crate::client;
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
 
 /// Arguments for `aasm topology overview`.
 #[derive(Args)]
@@ -11,4 +18,31 @@ pub struct OverviewArgs {
     /// Include governance level in agent nodes.
     #[arg(long)]
     pub show_budget: bool,
+}
+
+/// Run the `aasm topology overview` command.
+pub fn run(args: OverviewArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    let mut path = "/api/v1/topology/overview".to_string();
+    let mut params: Vec<String> = vec![];
+    if let Some(ref s) = args.status {
+        params.push(format!("status={s}"));
+    }
+    if args.show_budget {
+        params.push("show_budget=true".to_string());
+    }
+    if !params.is_empty() {
+        path = format!("{path}?{}", params.join("&"));
+    }
+
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    let overview: TopologyOverview = match rt.block_on(client::get_json(ctx, &path)) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    render(TopologyPayload::Overview(&overview), output);
+    ExitCode::SUCCESS
 }

--- a/aa-cli/src/commands/topology/render/json.rs
+++ b/aa-cli/src/commands/topology/render/json.rs
@@ -1,0 +1,18 @@
+//! JSON and YAML serialisation for topology payloads.
+
+use super::TopologyPayload;
+
+/// Render a topology payload as pretty-printed JSON to stdout.
+pub fn render_json(payload: &TopologyPayload<'_>) {
+    let result = match payload {
+        TopologyPayload::Overview(v) => serde_json::to_string_pretty(v),
+        TopologyPayload::Tree(v) => serde_json::to_string_pretty(v),
+        TopologyPayload::Team(v) => serde_json::to_string_pretty(v),
+        TopologyPayload::Lineage(v) => serde_json::to_string_pretty(v),
+        TopologyPayload::Stats(v) => serde_json::to_string_pretty(v),
+    };
+    match result {
+        Ok(json) => println!("{json}"),
+        Err(e) => eprintln!("error serializing JSON: {e}"),
+    }
+}

--- a/aa-cli/src/commands/topology/render/json.rs
+++ b/aa-cli/src/commands/topology/render/json.rs
@@ -16,3 +16,18 @@ pub fn render_json(payload: &TopologyPayload<'_>) {
         Err(e) => eprintln!("error serializing JSON: {e}"),
     }
 }
+
+/// Render a topology payload as YAML to stdout.
+pub fn render_yaml(payload: &TopologyPayload<'_>) {
+    let result = match payload {
+        TopologyPayload::Overview(v) => serde_yaml::to_string(v),
+        TopologyPayload::Tree(v) => serde_yaml::to_string(v),
+        TopologyPayload::Team(v) => serde_yaml::to_string(v),
+        TopologyPayload::Lineage(v) => serde_yaml::to_string(v),
+        TopologyPayload::Stats(v) => serde_yaml::to_string(v),
+    };
+    match result {
+        Ok(yaml) => print!("{yaml}"),
+        Err(e) => eprintln!("error serializing YAML: {e}"),
+    }
+}

--- a/aa-cli/src/commands/topology/render/mod.rs
+++ b/aa-cli/src/commands/topology/render/mod.rs
@@ -96,3 +96,12 @@ pub struct TopologyStats {
     pub orphan_count: usize,
     pub avg_children_per_parent: f64,
 }
+
+/// Union of all topology API response shapes for rendering.
+pub enum TopologyPayload<'a> {
+    Overview(&'a TopologyOverview),
+    Tree(&'a AgentTree),
+    Team(&'a TeamTopology),
+    Lineage(&'a AgentLineage),
+    Stats(&'a TopologyStats),
+}

--- a/aa-cli/src/commands/topology/render/mod.rs
+++ b/aa-cli/src/commands/topology/render/mod.rs
@@ -1,5 +1,98 @@
 //! Rendering utilities for topology subcommands.
 
+use std::collections::{BTreeMap, HashMap};
+
+use serde::{Deserialize, Serialize};
+
 pub mod json;
 pub mod table;
 pub mod tree;
+
+/// Overview of the entire agent topology across all teams.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopologyOverview {
+    pub team_count: usize,
+    pub root_agent_count: usize,
+    pub total_agent_count: usize,
+    pub teams: Vec<TeamSummary>,
+    pub standalone_root_agents: Vec<AgentNode>,
+}
+
+/// High-level statistics for a single team.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamSummary {
+    pub team_id: String,
+    pub agent_count: usize,
+    pub root_agent_count: usize,
+}
+
+/// Minimal agent representation used in list and tree responses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentNode {
+    pub id: String,
+    pub name: String,
+    pub depth: u32,
+    pub status: String,
+    pub team_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub governance_level: Option<String>,
+}
+
+/// Recursive tree node representing an agent and all its descendants.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentTree {
+    pub id: String,
+    pub name: String,
+    pub depth: u32,
+    pub status: String,
+    pub team_id: Option<String>,
+    pub delegation_reason: Option<String>,
+    pub spawned_by_tool: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub governance_level: Option<String>,
+    pub children: Vec<AgentTree>,
+}
+
+/// All agents belonging to a single team.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamTopology {
+    pub team_id: String,
+    pub agent_count: usize,
+    pub members: Vec<AgentNode>,
+}
+
+/// An agent's complete ancestry chain ordered root-first.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentLineage {
+    pub agent_id: String,
+    pub ancestor_count: usize,
+    pub ancestors: Vec<LineageStep>,
+}
+
+/// One step in an agent's ancestry chain.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LineageStep {
+    pub id: String,
+    pub name: String,
+    pub depth: u32,
+    pub delegation_reason: Option<String>,
+    pub team_id: Option<String>,
+}
+
+/// Aggregate topology statistics across all registered agents.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopologyStats {
+    pub total_agents: usize,
+    pub root_agent_count: usize,
+    pub max_depth: u32,
+    pub active_count: usize,
+    pub suspended_count: usize,
+    pub deregistered_count: usize,
+    pub team_count: usize,
+    pub team_sizes: HashMap<String, usize>,
+    pub depth_histogram: BTreeMap<String, u32>,
+    pub team_size_histogram: BTreeMap<String, u32>,
+    pub spawn_count_histogram: BTreeMap<String, u32>,
+    pub orphan_count: usize,
+    pub avg_children_per_parent: f64,
+}

--- a/aa-cli/src/commands/topology/render/mod.rs
+++ b/aa-cli/src/commands/topology/render/mod.rs
@@ -1,0 +1,5 @@
+//! Rendering utilities for topology subcommands.
+
+pub mod json;
+pub mod table;
+pub mod tree;

--- a/aa-cli/src/commands/topology/render/mod.rs
+++ b/aa-cli/src/commands/topology/render/mod.rs
@@ -4,6 +4,8 @@ use std::collections::{BTreeMap, HashMap};
 
 use serde::{Deserialize, Serialize};
 
+use crate::output::OutputFormat;
+
 pub mod json;
 pub mod table;
 pub mod tree;
@@ -104,4 +106,19 @@ pub enum TopologyPayload<'a> {
     Team(&'a TeamTopology),
     Lineage(&'a AgentLineage),
     Stats(&'a TopologyStats),
+}
+
+/// Render a topology payload in the requested output format.
+pub fn render(payload: TopologyPayload<'_>, output: OutputFormat) {
+    match output {
+        OutputFormat::Json => json::render_json(&payload),
+        OutputFormat::Yaml => json::render_yaml(&payload),
+        OutputFormat::Table => match payload {
+            TopologyPayload::Overview(v) => table::render_overview_table(v),
+            TopologyPayload::Tree(v) => tree::render_agent_tree(v, "", true),
+            TopologyPayload::Team(v) => table::render_team_table(v),
+            TopologyPayload::Lineage(v) => table::render_lineage_table(v),
+            TopologyPayload::Stats(v) => table::render_stats_table(v),
+        },
+    }
 }

--- a/aa-cli/src/commands/topology/render/table.rs
+++ b/aa-cli/src/commands/topology/render/table.rs
@@ -1,0 +1,13 @@
+//! Table rendering for topology responses.
+
+use comfy_table::Color;
+
+/// Map an agent status string to a terminal colour.
+pub fn status_color(status: &str) -> Color {
+    match status.to_lowercase().as_str() {
+        "active" => Color::Green,
+        s if s.starts_with("suspended") => Color::Yellow,
+        "deregistered" => Color::Red,
+        _ => Color::Reset,
+    }
+}

--- a/aa-cli/src/commands/topology/render/table.rs
+++ b/aa-cli/src/commands/topology/render/table.rs
@@ -1,6 +1,8 @@
 //! Table rendering for topology responses.
 
-use comfy_table::Color;
+use comfy_table::{Cell, Color, Table};
+
+use super::{AgentLineage, TeamTopology, TopologyOverview, TopologyStats};
 
 /// Map an agent status string to a terminal colour.
 pub fn status_color(status: &str) -> Color {
@@ -9,5 +11,40 @@ pub fn status_color(status: &str) -> Color {
         s if s.starts_with("suspended") => Color::Yellow,
         "deregistered" => Color::Red,
         _ => Color::Reset,
+    }
+}
+
+/// Render a topology overview as a comfy-table.
+pub fn render_overview_table(overview: &TopologyOverview) {
+    println!(
+        "Teams: {}  |  Agents: {}  |  Roots: {}\n",
+        overview.team_count, overview.total_agent_count, overview.root_agent_count,
+    );
+
+    if !overview.teams.is_empty() {
+        let mut table = Table::new();
+        table.set_header(vec!["TEAM_ID", "AGENTS", "ROOT_AGENTS"]);
+        for t in &overview.teams {
+            table.add_row(vec![
+                Cell::new(&t.team_id),
+                Cell::new(t.agent_count),
+                Cell::new(t.root_agent_count),
+            ]);
+        }
+        println!("{table}");
+    }
+
+    if !overview.standalone_root_agents.is_empty() {
+        println!("\nStandalone root agents:");
+        let mut table = Table::new();
+        table.set_header(vec!["AGENT_ID", "NAME", "STATUS"]);
+        for a in &overview.standalone_root_agents {
+            table.add_row(vec![
+                Cell::new(&a.id),
+                Cell::new(&a.name),
+                Cell::new(&a.status).fg(status_color(&a.status)),
+            ]);
+        }
+        println!("{table}");
     }
 }

--- a/aa-cli/src/commands/topology/render/table.rs
+++ b/aa-cli/src/commands/topology/render/table.rs
@@ -96,3 +96,41 @@ pub fn render_lineage_table(lineage: &AgentLineage) {
     }
     println!("{table}");
 }
+
+/// Render aggregate topology statistics as a comfy-table.
+pub fn render_stats_table(stats: &TopologyStats) {
+    let mut table = Table::new();
+    table.set_header(vec!["METRIC", "VALUE"]);
+    table.add_row(vec![Cell::new("Total agents"), Cell::new(stats.total_agents)]);
+    table.add_row(vec![Cell::new("Root agents"), Cell::new(stats.root_agent_count)]);
+    table.add_row(vec![Cell::new("Max depth"), Cell::new(stats.max_depth)]);
+    table.add_row(vec![
+        Cell::new("Active"),
+        Cell::new(stats.active_count).fg(Color::Green),
+    ]);
+    table.add_row(vec![
+        Cell::new("Suspended"),
+        Cell::new(stats.suspended_count).fg(Color::Yellow),
+    ]);
+    table.add_row(vec![
+        Cell::new("Deregistered"),
+        Cell::new(stats.deregistered_count).fg(Color::Red),
+    ]);
+    table.add_row(vec![Cell::new("Teams"), Cell::new(stats.team_count)]);
+    table.add_row(vec![Cell::new("Orphans"), Cell::new(stats.orphan_count)]);
+    table.add_row(vec![
+        Cell::new("Avg children/parent"),
+        Cell::new(format!("{:.2}", stats.avg_children_per_parent)),
+    ]);
+    println!("{table}");
+
+    if !stats.depth_histogram.is_empty() {
+        println!("\nDepth histogram:");
+        let mut htable = Table::new();
+        htable.set_header(vec!["DEPTH", "COUNT"]);
+        for (depth, count) in &stats.depth_histogram {
+            htable.add_row(vec![Cell::new(depth), Cell::new(count)]);
+        }
+        println!("{htable}");
+    }
+}

--- a/aa-cli/src/commands/topology/render/table.rs
+++ b/aa-cli/src/commands/topology/render/table.rs
@@ -70,3 +70,29 @@ pub fn render_team_table(team: &TeamTopology) {
     }
     println!("{table}");
 }
+
+/// Render an agent lineage as a flat comfy-table.
+pub fn render_lineage_table(lineage: &AgentLineage) {
+    println!(
+        "Agent: {}  |  Ancestors: {}\n",
+        lineage.agent_id, lineage.ancestor_count,
+    );
+
+    if lineage.ancestors.is_empty() {
+        println!("No ancestry data.");
+        return;
+    }
+
+    let mut table = Table::new();
+    table.set_header(vec!["DEPTH", "AGENT_ID", "NAME", "TEAM", "DELEGATION_REASON"]);
+    for step in &lineage.ancestors {
+        table.add_row(vec![
+            Cell::new(step.depth),
+            Cell::new(&step.id),
+            Cell::new(&step.name),
+            Cell::new(step.team_id.as_deref().unwrap_or("-")),
+            Cell::new(step.delegation_reason.as_deref().unwrap_or("-")),
+        ]);
+    }
+    println!("{table}");
+}

--- a/aa-cli/src/commands/topology/render/table.rs
+++ b/aa-cli/src/commands/topology/render/table.rs
@@ -48,3 +48,25 @@ pub fn render_overview_table(overview: &TopologyOverview) {
         println!("{table}");
     }
 }
+
+/// Render a team topology as a comfy-table.
+pub fn render_team_table(team: &TeamTopology) {
+    println!("Team: {}  |  Agents: {}\n", team.team_id, team.agent_count);
+
+    if team.members.is_empty() {
+        println!("No agents in this team.");
+        return;
+    }
+
+    let mut table = Table::new();
+    table.set_header(vec!["AGENT_ID", "NAME", "DEPTH", "STATUS"]);
+    for a in &team.members {
+        table.add_row(vec![
+            Cell::new(&a.id),
+            Cell::new(&a.name),
+            Cell::new(a.depth),
+            Cell::new(&a.status).fg(status_color(&a.status)),
+        ]);
+    }
+    println!("{table}");
+}

--- a/aa-cli/src/commands/topology/render/tree.rs
+++ b/aa-cli/src/commands/topology/render/tree.rs
@@ -6,11 +6,7 @@ use super::{AgentLineage, AgentTree};
 pub fn render_agent_tree(node: &AgentTree, prefix: &str, is_last: bool) {
     let connector = if is_last { "└── " } else { "├── " };
     let status_tag = format!("[{}]", node.status);
-    let team_tag = node
-        .team_id
-        .as_deref()
-        .map(|t| format!(" <{t}>"))
-        .unwrap_or_default();
+    let team_tag = node.team_id.as_deref().map(|t| format!(" <{t}>")).unwrap_or_default();
     println!("{prefix}{connector}{} {status_tag}{team_tag}", node.name);
 
     let child_prefix = format!("{prefix}{}", if is_last { "    " } else { "│   " });

--- a/aa-cli/src/commands/topology/render/tree.rs
+++ b/aa-cli/src/commands/topology/render/tree.rs
@@ -1,6 +1,6 @@
 //! Tree-style rendering for AgentTree and AgentLineage.
 
-use super::AgentTree;
+use super::{AgentLineage, AgentTree};
 
 /// Render an agent tree recursively using box-drawing characters.
 pub fn render_agent_tree(node: &AgentTree, prefix: &str, is_last: bool) {
@@ -17,5 +17,22 @@ pub fn render_agent_tree(node: &AgentTree, prefix: &str, is_last: bool) {
     let count = node.children.len();
     for (i, child) in node.children.iter().enumerate() {
         render_agent_tree(child, &child_prefix, i + 1 == count);
+    }
+}
+
+/// Render an agent lineage chain using box-drawing characters.
+pub fn render_lineage_chain(lineage: &AgentLineage) {
+    println!("Lineage for agent: {}\n", lineage.agent_id);
+    let count = lineage.ancestors.len();
+    for (i, step) in lineage.ancestors.iter().enumerate() {
+        let is_last = i + 1 == count;
+        let connector = if is_last { "└── " } else { "├── " };
+        let indent = "│   ".repeat(i);
+        let reason = step
+            .delegation_reason
+            .as_deref()
+            .map(|r| format!(" ({r})"))
+            .unwrap_or_default();
+        println!("{indent}{connector}{} [depth={}]{reason}", step.name, step.depth);
     }
 }

--- a/aa-cli/src/commands/topology/render/tree.rs
+++ b/aa-cli/src/commands/topology/render/tree.rs
@@ -1,0 +1,21 @@
+//! Tree-style rendering for AgentTree and AgentLineage.
+
+use super::AgentTree;
+
+/// Render an agent tree recursively using box-drawing characters.
+pub fn render_agent_tree(node: &AgentTree, prefix: &str, is_last: bool) {
+    let connector = if is_last { "└── " } else { "├── " };
+    let status_tag = format!("[{}]", node.status);
+    let team_tag = node
+        .team_id
+        .as_deref()
+        .map(|t| format!(" <{t}>"))
+        .unwrap_or_default();
+    println!("{prefix}{connector}{} {status_tag}{team_tag}", node.name);
+
+    let child_prefix = format!("{prefix}{}", if is_last { "    " } else { "│   " });
+    let count = node.children.len();
+    for (i, child) in node.children.iter().enumerate() {
+        render_agent_tree(child, &child_prefix, i + 1 == count);
+    }
+}

--- a/aa-cli/src/commands/topology/stats.rs
+++ b/aa-cli/src/commands/topology/stats.rs
@@ -1,0 +1,7 @@
+//! `aasm topology stats` — aggregate topology statistics.
+
+use clap::Args;
+
+/// Arguments for `aasm topology stats`.
+#[derive(Args)]
+pub struct StatsArgs {}

--- a/aa-cli/src/commands/topology/stats.rs
+++ b/aa-cli/src/commands/topology/stats.rs
@@ -1,7 +1,29 @@
 //! `aasm topology stats` — aggregate topology statistics.
 
+use std::process::ExitCode;
+
 use clap::Args;
+
+use super::render::{render, TopologyPayload, TopologyStats};
+use crate::client;
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
 
 /// Arguments for `aasm topology stats`.
 #[derive(Args)]
 pub struct StatsArgs {}
+
+/// Run the `aasm topology stats` command.
+pub fn run(_args: StatsArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    let stats: TopologyStats = match rt.block_on(client::get_json(ctx, "/api/v1/topology/stats")) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    render(TopologyPayload::Stats(&stats), output);
+    ExitCode::SUCCESS
+}

--- a/aa-cli/src/commands/topology/team.rs
+++ b/aa-cli/src/commands/topology/team.rs
@@ -1,6 +1,13 @@
 //! `aasm topology team` — show all agents in a team.
 
+use std::process::ExitCode;
+
 use clap::Args;
+
+use super::render::{render, TeamTopology, TopologyPayload};
+use crate::client;
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
 
 /// Arguments for `aasm topology team`.
 #[derive(Args)]
@@ -13,4 +20,31 @@ pub struct TeamArgs {
     /// Include governance level in agent nodes.
     #[arg(long)]
     pub show_budget: bool,
+}
+
+/// Run the `aasm topology team` command.
+pub fn run(args: TeamArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    let mut path = format!("/api/v1/topology/team/{}", args.team_id);
+    let mut params: Vec<String> = vec![];
+    if let Some(ref s) = args.status {
+        params.push(format!("status={s}"));
+    }
+    if args.show_budget {
+        params.push("show_budget=true".to_string());
+    }
+    if !params.is_empty() {
+        path = format!("{path}?{}", params.join("&"));
+    }
+
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    let team: TeamTopology = match rt.block_on(client::get_json(ctx, &path)) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    render(TopologyPayload::Team(&team), output);
+    ExitCode::SUCCESS
 }

--- a/aa-cli/src/commands/topology/team.rs
+++ b/aa-cli/src/commands/topology/team.rs
@@ -1,0 +1,16 @@
+//! `aasm topology team` — show all agents in a team.
+
+use clap::Args;
+
+/// Arguments for `aasm topology team`.
+#[derive(Args)]
+pub struct TeamArgs {
+    /// Team ID.
+    pub team_id: String,
+    /// Filter members by status.
+    #[arg(long)]
+    pub status: Option<String>,
+    /// Include governance level in agent nodes.
+    #[arg(long)]
+    pub show_budget: bool,
+}

--- a/aa-cli/src/commands/topology/tree.rs
+++ b/aa-cli/src/commands/topology/tree.rs
@@ -1,0 +1,19 @@
+//! `aasm topology tree` — render agent subtree.
+
+use clap::Args;
+
+/// Arguments for `aasm topology tree`.
+#[derive(Args)]
+pub struct TreeArgs {
+    /// Root agent ID (hex-encoded UUID).
+    pub agent_id: String,
+    /// Maximum traversal depth from the root (default 10).
+    #[arg(long)]
+    pub depth: Option<u32>,
+    /// Filter tree nodes by status.
+    #[arg(long)]
+    pub status: Option<String>,
+    /// Include governance level in tree nodes.
+    #[arg(long)]
+    pub show_budget: bool,
+}

--- a/aa-cli/src/commands/topology/tree.rs
+++ b/aa-cli/src/commands/topology/tree.rs
@@ -1,6 +1,13 @@
 //! `aasm topology tree` — render agent subtree.
 
+use std::process::ExitCode;
+
 use clap::Args;
+
+use super::render::{render, AgentTree, TopologyPayload};
+use crate::client;
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
 
 /// Arguments for `aasm topology tree`.
 #[derive(Args)]
@@ -16,4 +23,34 @@ pub struct TreeArgs {
     /// Include governance level in tree nodes.
     #[arg(long)]
     pub show_budget: bool,
+}
+
+/// Run the `aasm topology tree` command.
+pub fn run(args: TreeArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    let mut path = format!("/api/v1/topology/tree/{}", args.agent_id);
+    let mut params: Vec<String> = vec![];
+    if let Some(d) = args.depth {
+        params.push(format!("depth={d}"));
+    }
+    if let Some(ref s) = args.status {
+        params.push(format!("status={s}"));
+    }
+    if args.show_budget {
+        params.push("show_budget=true".to_string());
+    }
+    if !params.is_empty() {
+        path = format!("{path}?{}", params.join("&"));
+    }
+
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    let tree: AgentTree = match rt.block_on(client::get_json(ctx, &path)) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    render(TopologyPayload::Tree(&tree), output);
+    ExitCode::SUCCESS
 }

--- a/aa-cli/tests/topology.rs
+++ b/aa-cli/tests/topology.rs
@@ -122,3 +122,39 @@ async fn tree_returns_success() {
 
     assert_eq!(result, ExitCode::SUCCESS);
 }
+
+// ── topology team ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn team_returns_success() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/topology/team/team-alpha"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "team_id": "team-alpha",
+            "agent_count": 2,
+            "members": [
+                {"id": "aabb", "name": "agent-1", "depth": 0, "status": "active", "team_id": "team-alpha"},
+                {"id": "ccdd", "name": "agent-2", "depth": 1, "status": "active", "team_id": "team-alpha"}
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let result = std::thread::spawn(move || {
+        let args = aa_cli::commands::topology::team::TeamArgs {
+            team_id: "team-alpha".to_string(),
+            status: None,
+            show_budget: false,
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::topology::team::run(args, &ctx, OutputFormat::Table)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+}

--- a/aa-cli/tests/topology.rs
+++ b/aa-cli/tests/topology.rs
@@ -1,0 +1,57 @@
+//! Integration tests for `aasm topology` subcommands.
+
+use std::process::ExitCode;
+
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use aa_cli::output::OutputFormat;
+
+fn make_context(api_url: &str) -> aa_cli::config::ResolvedContext {
+    aa_cli::config::ResolvedContext {
+        name: None,
+        api_url: api_url.to_string(),
+        api_key: None,
+    }
+}
+
+fn sample_overview_json() -> serde_json::Value {
+    serde_json::json!({
+        "team_count": 2,
+        "root_agent_count": 3,
+        "total_agent_count": 12,
+        "teams": [
+            {"team_id": "team-alpha", "agent_count": 7, "root_agent_count": 1},
+            {"team_id": "team-beta",  "agent_count": 5, "root_agent_count": 2}
+        ],
+        "standalone_root_agents": []
+    })
+}
+
+// ── topology overview ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn overview_returns_success() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/topology/overview"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sample_overview_json()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let result = std::thread::spawn(move || {
+        let args = aa_cli::commands::topology::overview::OverviewArgs {
+            status: None,
+            show_budget: false,
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::topology::overview::run(args, &ctx, OutputFormat::Table)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+}

--- a/aa-cli/tests/topology.rs
+++ b/aa-cli/tests/topology.rs
@@ -55,3 +55,29 @@ async fn overview_returns_success() {
 
     assert_eq!(result, ExitCode::SUCCESS);
 }
+
+#[tokio::test]
+async fn overview_json_output() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/topology/overview"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sample_overview_json()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let result = std::thread::spawn(move || {
+        let args = aa_cli::commands::topology::overview::OverviewArgs {
+            status: None,
+            show_budget: false,
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::topology::overview::run(args, &ctx, OutputFormat::Json)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+}

--- a/aa-cli/tests/topology.rs
+++ b/aa-cli/tests/topology.rs
@@ -158,3 +158,39 @@ async fn team_returns_success() {
 
     assert_eq!(result, ExitCode::SUCCESS);
 }
+
+// ── topology lineage ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn lineage_returns_success() {
+    let server = MockServer::start().await;
+
+    let agent_id = "aabbccdd00112233aabbccdd00112233";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/api/v1/topology/lineage/{agent_id}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "agent_id": agent_id,
+            "ancestor_count": 2,
+            "ancestors": [
+                {"id": "root0000000000000000000000000000", "name": "root", "depth": 0, "delegation_reason": null, "team_id": null},
+                {"id": agent_id, "name": "child", "depth": 1, "delegation_reason": "orchestrate", "team_id": "team-alpha"}
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let result = std::thread::spawn(move || {
+        let args = aa_cli::commands::topology::lineage::LineageArgs {
+            agent_id: agent_id.to_string(),
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::topology::lineage::run(args, &ctx, OutputFormat::Table)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+}

--- a/aa-cli/tests/topology.rs
+++ b/aa-cli/tests/topology.rs
@@ -81,3 +81,44 @@ async fn overview_json_output() {
 
     assert_eq!(result, ExitCode::SUCCESS);
 }
+
+// ── topology tree ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn tree_returns_success() {
+    let server = MockServer::start().await;
+
+    let root_id = "0102030405060708090a0b0c0d0e0f10";
+
+    Mock::given(method("GET"))
+        .and(path(format!("/api/v1/topology/tree/{root_id}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": root_id,
+            "name": "root-agent",
+            "depth": 0,
+            "status": "active",
+            "team_id": "team-alpha",
+            "delegation_reason": null,
+            "spawned_by_tool": null,
+            "children": []
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let result = std::thread::spawn(move || {
+        let args = aa_cli::commands::topology::tree::TreeArgs {
+            agent_id: root_id.to_string(),
+            depth: None,
+            status: None,
+            show_budget: false,
+        };
+        let ctx = make_context(&uri);
+        aa_cli::commands::topology::tree::run(args, &ctx, OutputFormat::Table)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+}

--- a/aa-cli/tests/topology.rs
+++ b/aa-cli/tests/topology.rs
@@ -194,3 +194,42 @@ async fn lineage_returns_success() {
 
     assert_eq!(result, ExitCode::SUCCESS);
 }
+
+// ── topology stats ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn stats_returns_success() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v1/topology/stats"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "total_agents": 15,
+            "root_agent_count": 3,
+            "max_depth": 4,
+            "active_count": 12,
+            "suspended_count": 2,
+            "deregistered_count": 1,
+            "team_count": 2,
+            "team_sizes": {"team-alpha": 8, "team-beta": 4},
+            "depth_histogram": {"0": 3, "1": 7, "2": 5},
+            "team_size_histogram": {"4": 1, "8": 1},
+            "spawn_count_histogram": {"0": 8, "2": 4, "4": 1},
+            "orphan_count": 2,
+            "avg_children_per_parent": 2.5
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let result = std::thread::spawn(move || {
+        let args = aa_cli::commands::topology::stats::StatsArgs {};
+        let ctx = make_context(&uri);
+        aa_cli::commands::topology::stats::run(args, &ctx, OutputFormat::Table)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+}


### PR DESCRIPTION
## Description

Implements the `aasm topology` command group (AAASM-216) with five subcommands for querying and visualizing agent topology from the gateway REST API:

- `aasm topology overview` — fleet-wide summary (team counts, root agents, standalone agents)
- `aasm topology tree <agent_id>` — recursive delegation tree from a root agent
- `aasm topology team <team_id>` — all agents in a given team
- `aasm topology lineage <agent_id>` — full ancestry chain for an agent
- `aasm topology stats` — aggregate statistics (depth histogram, team sizes, status counts)

All subcommands support `--output table|json|yaml`. Table output uses `comfy-table` with status colour-coding; JSON/YAML output uses serde. The `tree` subcommand renders using box-drawing characters (`├──`, `└──`, `│`). Filter flags (`--status`, `--show-budget`, `--depth`) are forwarded as query parameters to the REST API.

Response types are defined locally in `aa-cli` (no dependency on `aa-api`) to avoid pulling in axum/utoipa. All types mirror the API structs exactly and are serde round-trip compatible.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-216 (Story), AAASM-1034, AAASM-1037, AAASM-1038, AAASM-1040, AAASM-1042, AAASM-1044
- Epic: AAASM-197 (Agent Topology & Lineage)

## Testing

- [x] Integration tests added / updated — 6 wiremock-based E2E tests in `aa-cli/tests/topology.rs` covering all 5 subcommands (overview ×2, tree, team, lineage, stats)
- [x] All 361 tests pass (`cargo nextest run -p aa-cli`)
- [x] Zero clippy warnings (`cargo clippy -p aa-cli --all-targets -- -D warnings`)
- [x] Clean `cargo fmt` check

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention