### PR TITLE
[AAASM-1207] ✨ (ci): Add release.yml cross-platform matrix build for 4 targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]*.[0-9]*.[0-9]*"
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-24.04-arm
+          - target: aarch64-apple-darwin
+            os: macos-14
+          - target: x86_64-apple-darwin
+            os: macos-13
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install protobuf compiler (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y protobuf-compiler
+
+      - name: Install protobuf compiler (macOS)
+        if: runner.os == 'macOS'
+        run: brew install protobuf
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build aasm release binary
+        run: cargo build --release --target ${{ matrix.target }} -p aa-cli
+
+      - name: Archive binary
+        shell: bash
+        run: |
+          tar -czf "aasm-${{ matrix.target }}.tar.gz" \
+            -C "target/${{ matrix.target }}/release" aasm
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: aasm-${{ matrix.target }}
+          path: aasm-${{ matrix.target }}.tar.gz
+          retention-days: 1


### PR DESCRIPTION
## Description

Creates `.github/workflows/release.yml` with a matrix `build` job that compiles the `aasm` binary for all 4 supported platform targets on their native GitHub-hosted runners and uploads each archive as a workflow artifact.

## Type of Change

- [x] ✨ New feature
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1207
- Parent story: AAASM-1200
- Epic: AAASM-1199

## Changes

New file: `.github/workflows/release.yml`

Trigger: `on: push: tags: v[0-9]*.[0-9]*.[0-9]*`

Matrix strategy — native runner per target to avoid cross-compilation complexity:

| Target | Runner |
|---|---|
| `x86_64-unknown-linux-gnu` | `ubuntu-latest` |
| `aarch64-unknown-linux-gnu` | `ubuntu-24.04-arm` |
| `aarch64-apple-darwin` | `macos-14` (M1) |
| `x86_64-apple-darwin` | `macos-13` |

Each job: checkout → install protobuf → `dtolnay/rust-toolchain@stable` → `Swatinem/rust-cache` → `cargo build --release --target <target> -p aa-cli` → `tar -czf aasm-<target>.tar.gz` → `actions/upload-artifact@v4`.

## Testing

- [ ] Unit tests added / updated — N/A (CI workflow change)
- [x] Manual testing performed — end-to-end validation is AAASM-1209: push test tag `v0.0.1-rc1` after this PR and AAASM-1208 merge

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing — tag-triggered workflow, awaiting AAASM-1209 verification
- [x] Commits are small and follow the Gitmoji convention