### PR TITLE
[AAASM-1208] ✨ (ci): Add GitHub Release upload, SHA256SUMS, and crates.io publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,3 +60,51 @@ jobs:
           name: aasm-${{ matrix.target }}
           path: aasm-${{ matrix.target }}.tar.gz
           retention-days: 1
+
+  publish:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts/
+          merge-multiple: true
+
+      - name: Generate SHA256SUMS
+        run: |
+          cd artifacts
+          sha256sum aasm-*.tar.gz > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Upload assets to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            artifacts/aasm-*.tar.gz
+            artifacts/SHA256SUMS
+          generate_release_notes: true
+
+  publish-crate:
+    name: Publish to crates.io
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install protobuf compiler
+        run: sudo apt-get install -y protobuf-compiler
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Publish aa-cli to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish -p aa-cli


### PR DESCRIPTION
## Description

Extends `.github/workflows/release.yml` with two jobs (`publish` and `publish-crate`) that run after all 4 matrix builds succeed. Together they upload the release archives + checksum file to GitHub Releases and publish the `aa-cli` crate to crates.io.

> **Depends on AAASM-1207** — this branch builds on top of the matrix build job introduced there. Merge AAASM-1207 first.

## Type of Change

- [x] ✨ New feature
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1208
- Parent story: AAASM-1200
- Epic: AAASM-1199

## Changes

`.github/workflows/release.yml` — two new jobs (both `needs: build`):

**`publish` job** (`ubuntu-latest`, `permissions: contents: write`):
1. `actions/download-artifact@v4` — collects all 4 `aasm-<target>.tar.gz` archives
2. `sha256sum aasm-*.tar.gz > SHA256SUMS` — generates checksum file
3. `softprops/action-gh-release@v2` — uploads all archives + `SHA256SUMS`, auto-generates release notes from commits

**`publish-crate` job** (`ubuntu-latest`):
1. Checkout + protobuf + `dtolnay/rust-toolchain@stable`
2. `cargo publish -p aa-cli` using `CRATES_IO_TOKEN` secret

## Prerequisites

`CRATES_IO_TOKEN` must be set as a repository secret before the first real release tag is pushed.

## Testing

- [ ] Unit tests added / updated — N/A (CI workflow change)
- [x] Manual testing performed — end-to-end validation is AAASM-1209: push test tag `v0.0.1-rc1` after both this PR and AAASM-1207 merge

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing — tag-triggered workflow, awaiting AAASM-1209 verification
- [x] Commits are small and follow the Gitmoji convention