### PR TITLE
[AAASM-1034] ✨ (aa-cli/topology): Add topology module and render submodule scaffold

### DIFF
--- a/aa-cli/src/commands/topology/mod.rs
+++ b/aa-cli/src/commands/topology/mod.rs
@@ -1,0 +1,8 @@
+//! `aasm topology` — visualize agent topology and lineage.
+
+pub mod lineage;
+pub mod overview;
+pub mod render;
+pub mod stats;
+pub mod team;
+pub mod tree;

--- a/aa-cli/src/commands/topology/mod.rs
+++ b/aa-cli/src/commands/topology/mod.rs
@@ -1,6 +1,11 @@
 //! `aasm topology` — visualize agent topology and lineage.
 
+use std::process::ExitCode;
+
 use clap::{Args, Subcommand};
+
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
 
 pub mod lineage;
 pub mod overview;
@@ -29,4 +34,15 @@ pub enum TopologyCommands {
     Lineage(lineage::LineageArgs),
     /// Show aggregate topology statistics.
     Stats(stats::StatsArgs),
+}
+
+/// Dispatch a topology subcommand.
+pub fn dispatch(args: TopologyArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    match args.command {
+        TopologyCommands::Overview(a) => overview::run(a, ctx, output),
+        TopologyCommands::Tree(a) => tree::run(a, ctx, output),
+        TopologyCommands::Team(a) => team::run(a, ctx, output),
+        TopologyCommands::Lineage(a) => lineage::run(a, ctx, output),
+        TopologyCommands::Stats(a) => stats::run(a, ctx, output),
+    }
 }

--- a/aa-cli/src/commands/topology/mod.rs
+++ b/aa-cli/src/commands/topology/mod.rs
@@ -1,6 +1,6 @@
 //! `aasm topology` — visualize agent topology and lineage.
 
-use clap::Args;
+use clap::{Args, Subcommand};
 
 pub mod lineage;
 pub mod overview;
@@ -14,4 +14,19 @@ pub mod tree;
 pub struct TopologyArgs {
     #[command(subcommand)]
     pub command: TopologyCommands,
+}
+
+/// Available topology subcommands.
+#[derive(Subcommand)]
+pub enum TopologyCommands {
+    /// Show fleet-wide topology overview.
+    Overview(overview::OverviewArgs),
+    /// Render a subtree rooted at a given agent.
+    Tree(tree::TreeArgs),
+    /// Show all agents in a team.
+    Team(team::TeamArgs),
+    /// Show ancestry chain for a given agent.
+    Lineage(lineage::LineageArgs),
+    /// Show aggregate topology statistics.
+    Stats(stats::StatsArgs),
 }

--- a/aa-cli/src/commands/topology/mod.rs
+++ b/aa-cli/src/commands/topology/mod.rs
@@ -1,8 +1,17 @@
 //! `aasm topology` — visualize agent topology and lineage.
 
+use clap::Args;
+
 pub mod lineage;
 pub mod overview;
 pub mod render;
 pub mod stats;
 pub mod team;
 pub mod tree;
+
+/// Arguments for the `aasm topology` subcommand group.
+#[derive(Args)]
+pub struct TopologyArgs {
+    #[command(subcommand)]
+    pub command: TopologyCommands,
+}

--- a/aa-cli/src/commands/topology/render/json.rs
+++ b/aa-cli/src/commands/topology/render/json.rs
@@ -1,0 +1,18 @@
+//! JSON and YAML serialisation for topology payloads.
+
+use super::TopologyPayload;
+
+/// Render a topology payload as pretty-printed JSON to stdout.
+pub fn render_json(payload: &TopologyPayload<'_>) {
+    let result = match payload {
+        TopologyPayload::Overview(v) => serde_json::to_string_pretty(v),
+        TopologyPayload::Tree(v) => serde_json::to_string_pretty(v),
+        TopologyPayload::Team(v) => serde_json::to_string_pretty(v),
+        TopologyPayload::Lineage(v) => serde_json::to_string_pretty(v),
+        TopologyPayload::Stats(v) => serde_json::to_string_pretty(v),
+    };
+    match result {
+        Ok(json) => println!("{json}"),
+        Err(e) => eprintln!("error serializing JSON: {e}"),
+    }
+}

--- a/aa-cli/src/commands/topology/render/json.rs
+++ b/aa-cli/src/commands/topology/render/json.rs
@@ -16,3 +16,18 @@ pub fn render_json(payload: &TopologyPayload<'_>) {
         Err(e) => eprintln!("error serializing JSON: {e}"),
     }
 }
+
+/// Render a topology payload as YAML to stdout.
+pub fn render_yaml(payload: &TopologyPayload<'_>) {
+    let result = match payload {
+        TopologyPayload::Overview(v) => serde_yaml::to_string(v),
+        TopologyPayload::Tree(v) => serde_yaml::to_string(v),
+        TopologyPayload::Team(v) => serde_yaml::to_string(v),
+        TopologyPayload::Lineage(v) => serde_yaml::to_string(v),
+        TopologyPayload::Stats(v) => serde_yaml::to_string(v),
+    };
+    match result {
+        Ok(yaml) => print!("{yaml}"),
+        Err(e) => eprintln!("error serializing YAML: {e}"),
+    }
+}

--- a/aa-cli/src/commands/topology/render/mod.rs
+++ b/aa-cli/src/commands/topology/render/mod.rs
@@ -96,3 +96,12 @@ pub struct TopologyStats {
     pub orphan_count: usize,
     pub avg_children_per_parent: f64,
 }
+
+/// Union of all topology API response shapes for rendering.
+pub enum TopologyPayload<'a> {
+    Overview(&'a TopologyOverview),
+    Tree(&'a AgentTree),
+    Team(&'a TeamTopology),
+    Lineage(&'a AgentLineage),
+    Stats(&'a TopologyStats),
+}

--- a/aa-cli/src/commands/topology/render/mod.rs
+++ b/aa-cli/src/commands/topology/render/mod.rs
@@ -1,5 +1,98 @@
 //! Rendering utilities for topology subcommands.
 
+use std::collections::{BTreeMap, HashMap};
+
+use serde::{Deserialize, Serialize};
+
 pub mod json;
 pub mod table;
 pub mod tree;
+
+/// Overview of the entire agent topology across all teams.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopologyOverview {
+    pub team_count: usize,
+    pub root_agent_count: usize,
+    pub total_agent_count: usize,
+    pub teams: Vec<TeamSummary>,
+    pub standalone_root_agents: Vec<AgentNode>,
+}
+
+/// High-level statistics for a single team.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamSummary {
+    pub team_id: String,
+    pub agent_count: usize,
+    pub root_agent_count: usize,
+}
+
+/// Minimal agent representation used in list and tree responses.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentNode {
+    pub id: String,
+    pub name: String,
+    pub depth: u32,
+    pub status: String,
+    pub team_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub governance_level: Option<String>,
+}
+
+/// Recursive tree node representing an agent and all its descendants.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentTree {
+    pub id: String,
+    pub name: String,
+    pub depth: u32,
+    pub status: String,
+    pub team_id: Option<String>,
+    pub delegation_reason: Option<String>,
+    pub spawned_by_tool: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub governance_level: Option<String>,
+    pub children: Vec<AgentTree>,
+}
+
+/// All agents belonging to a single team.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TeamTopology {
+    pub team_id: String,
+    pub agent_count: usize,
+    pub members: Vec<AgentNode>,
+}
+
+/// An agent's complete ancestry chain ordered root-first.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentLineage {
+    pub agent_id: String,
+    pub ancestor_count: usize,
+    pub ancestors: Vec<LineageStep>,
+}
+
+/// One step in an agent's ancestry chain.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LineageStep {
+    pub id: String,
+    pub name: String,
+    pub depth: u32,
+    pub delegation_reason: Option<String>,
+    pub team_id: Option<String>,
+}
+
+/// Aggregate topology statistics across all registered agents.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TopologyStats {
+    pub total_agents: usize,
+    pub root_agent_count: usize,
+    pub max_depth: u32,
+    pub active_count: usize,
+    pub suspended_count: usize,
+    pub deregistered_count: usize,
+    pub team_count: usize,
+    pub team_sizes: HashMap<String, usize>,
+    pub depth_histogram: BTreeMap<String, u32>,
+    pub team_size_histogram: BTreeMap<String, u32>,
+    pub spawn_count_histogram: BTreeMap<String, u32>,
+    pub orphan_count: usize,
+    pub avg_children_per_parent: f64,
+}

--- a/aa-cli/src/commands/topology/render/mod.rs
+++ b/aa-cli/src/commands/topology/render/mod.rs
@@ -1,0 +1,5 @@
+//! Rendering utilities for topology subcommands.
+
+pub mod json;
+pub mod table;
+pub mod tree;

--- a/aa-cli/src/commands/topology/render/mod.rs
+++ b/aa-cli/src/commands/topology/render/mod.rs
@@ -4,6 +4,8 @@ use std::collections::{BTreeMap, HashMap};
 
 use serde::{Deserialize, Serialize};
 
+use crate::output::OutputFormat;
+
 pub mod json;
 pub mod table;
 pub mod tree;
@@ -104,4 +106,19 @@ pub enum TopologyPayload<'a> {
     Team(&'a TeamTopology),
     Lineage(&'a AgentLineage),
     Stats(&'a TopologyStats),
+}
+
+/// Render a topology payload in the requested output format.
+pub fn render(payload: TopologyPayload<'_>, output: OutputFormat) {
+    match output {
+        OutputFormat::Json => json::render_json(&payload),
+        OutputFormat::Yaml => json::render_yaml(&payload),
+        OutputFormat::Table => match payload {
+            TopologyPayload::Overview(v) => table::render_overview_table(v),
+            TopologyPayload::Tree(v) => tree::render_agent_tree(v, "", true),
+            TopologyPayload::Team(v) => table::render_team_table(v),
+            TopologyPayload::Lineage(v) => table::render_lineage_table(v),
+            TopologyPayload::Stats(v) => table::render_stats_table(v),
+        },
+    }
 }

--- a/aa-cli/src/commands/topology/render/table.rs
+++ b/aa-cli/src/commands/topology/render/table.rs
@@ -1,0 +1,13 @@
+//! Table rendering for topology responses.
+
+use comfy_table::Color;
+
+/// Map an agent status string to a terminal colour.
+pub fn status_color(status: &str) -> Color {
+    match status.to_lowercase().as_str() {
+        "active" => Color::Green,
+        s if s.starts_with("suspended") => Color::Yellow,
+        "deregistered" => Color::Red,
+        _ => Color::Reset,
+    }
+}

--- a/aa-cli/src/commands/topology/render/table.rs
+++ b/aa-cli/src/commands/topology/render/table.rs
@@ -1,6 +1,8 @@
 //! Table rendering for topology responses.
 
-use comfy_table::Color;
+use comfy_table::{Cell, Color, Table};
+
+use super::{AgentLineage, TeamTopology, TopologyOverview, TopologyStats};
 
 /// Map an agent status string to a terminal colour.
 pub fn status_color(status: &str) -> Color {
@@ -9,5 +11,40 @@ pub fn status_color(status: &str) -> Color {
         s if s.starts_with("suspended") => Color::Yellow,
         "deregistered" => Color::Red,
         _ => Color::Reset,
+    }
+}
+
+/// Render a topology overview as a comfy-table.
+pub fn render_overview_table(overview: &TopologyOverview) {
+    println!(
+        "Teams: {}  |  Agents: {}  |  Roots: {}\n",
+        overview.team_count, overview.total_agent_count, overview.root_agent_count,
+    );
+
+    if !overview.teams.is_empty() {
+        let mut table = Table::new();
+        table.set_header(vec!["TEAM_ID", "AGENTS", "ROOT_AGENTS"]);
+        for t in &overview.teams {
+            table.add_row(vec![
+                Cell::new(&t.team_id),
+                Cell::new(t.agent_count),
+                Cell::new(t.root_agent_count),
+            ]);
+        }
+        println!("{table}");
+    }
+
+    if !overview.standalone_root_agents.is_empty() {
+        println!("\nStandalone root agents:");
+        let mut table = Table::new();
+        table.set_header(vec!["AGENT_ID", "NAME", "STATUS"]);
+        for a in &overview.standalone_root_agents {
+            table.add_row(vec![
+                Cell::new(&a.id),
+                Cell::new(&a.name),
+                Cell::new(&a.status).fg(status_color(&a.status)),
+            ]);
+        }
+        println!("{table}");
     }
 }

--- a/aa-cli/src/commands/topology/render/table.rs
+++ b/aa-cli/src/commands/topology/render/table.rs
@@ -96,3 +96,41 @@ pub fn render_lineage_table(lineage: &AgentLineage) {
     }
     println!("{table}");
 }
+
+/// Render aggregate topology statistics as a comfy-table.
+pub fn render_stats_table(stats: &TopologyStats) {
+    let mut table = Table::new();
+    table.set_header(vec!["METRIC", "VALUE"]);
+    table.add_row(vec![Cell::new("Total agents"), Cell::new(stats.total_agents)]);
+    table.add_row(vec![Cell::new("Root agents"), Cell::new(stats.root_agent_count)]);
+    table.add_row(vec![Cell::new("Max depth"), Cell::new(stats.max_depth)]);
+    table.add_row(vec![
+        Cell::new("Active"),
+        Cell::new(stats.active_count).fg(Color::Green),
+    ]);
+    table.add_row(vec![
+        Cell::new("Suspended"),
+        Cell::new(stats.suspended_count).fg(Color::Yellow),
+    ]);
+    table.add_row(vec![
+        Cell::new("Deregistered"),
+        Cell::new(stats.deregistered_count).fg(Color::Red),
+    ]);
+    table.add_row(vec![Cell::new("Teams"), Cell::new(stats.team_count)]);
+    table.add_row(vec![Cell::new("Orphans"), Cell::new(stats.orphan_count)]);
+    table.add_row(vec![
+        Cell::new("Avg children/parent"),
+        Cell::new(format!("{:.2}", stats.avg_children_per_parent)),
+    ]);
+    println!("{table}");
+
+    if !stats.depth_histogram.is_empty() {
+        println!("\nDepth histogram:");
+        let mut htable = Table::new();
+        htable.set_header(vec!["DEPTH", "COUNT"]);
+        for (depth, count) in &stats.depth_histogram {
+            htable.add_row(vec![Cell::new(depth), Cell::new(count)]);
+        }
+        println!("{htable}");
+    }
+}

--- a/aa-cli/src/commands/topology/render/table.rs
+++ b/aa-cli/src/commands/topology/render/table.rs
@@ -70,3 +70,29 @@ pub fn render_team_table(team: &TeamTopology) {
     }
     println!("{table}");
 }
+
+/// Render an agent lineage as a flat comfy-table.
+pub fn render_lineage_table(lineage: &AgentLineage) {
+    println!(
+        "Agent: {}  |  Ancestors: {}\n",
+        lineage.agent_id, lineage.ancestor_count,
+    );
+
+    if lineage.ancestors.is_empty() {
+        println!("No ancestry data.");
+        return;
+    }
+
+    let mut table = Table::new();
+    table.set_header(vec!["DEPTH", "AGENT_ID", "NAME", "TEAM", "DELEGATION_REASON"]);
+    for step in &lineage.ancestors {
+        table.add_row(vec![
+            Cell::new(step.depth),
+            Cell::new(&step.id),
+            Cell::new(&step.name),
+            Cell::new(step.team_id.as_deref().unwrap_or("-")),
+            Cell::new(step.delegation_reason.as_deref().unwrap_or("-")),
+        ]);
+    }
+    println!("{table}");
+}

--- a/aa-cli/src/commands/topology/render/table.rs
+++ b/aa-cli/src/commands/topology/render/table.rs
@@ -48,3 +48,25 @@ pub fn render_overview_table(overview: &TopologyOverview) {
         println!("{table}");
     }
 }
+
+/// Render a team topology as a comfy-table.
+pub fn render_team_table(team: &TeamTopology) {
+    println!("Team: {}  |  Agents: {}\n", team.team_id, team.agent_count);
+
+    if team.members.is_empty() {
+        println!("No agents in this team.");
+        return;
+    }
+
+    let mut table = Table::new();
+    table.set_header(vec!["AGENT_ID", "NAME", "DEPTH", "STATUS"]);
+    for a in &team.members {
+        table.add_row(vec![
+            Cell::new(&a.id),
+            Cell::new(&a.name),
+            Cell::new(a.depth),
+            Cell::new(&a.status).fg(status_color(&a.status)),
+        ]);
+    }
+    println!("{table}");
+}

--- a/aa-cli/src/commands/topology/render/tree.rs
+++ b/aa-cli/src/commands/topology/render/tree.rs
@@ -1,6 +1,6 @@
 //! Tree-style rendering for AgentTree and AgentLineage.
 
-use super::AgentTree;
+use super::{AgentLineage, AgentTree};
 
 /// Render an agent tree recursively using box-drawing characters.
 pub fn render_agent_tree(node: &AgentTree, prefix: &str, is_last: bool) {
@@ -17,5 +17,22 @@ pub fn render_agent_tree(node: &AgentTree, prefix: &str, is_last: bool) {
     let count = node.children.len();
     for (i, child) in node.children.iter().enumerate() {
         render_agent_tree(child, &child_prefix, i + 1 == count);
+    }
+}
+
+/// Render an agent lineage chain using box-drawing characters.
+pub fn render_lineage_chain(lineage: &AgentLineage) {
+    println!("Lineage for agent: {}\n", lineage.agent_id);
+    let count = lineage.ancestors.len();
+    for (i, step) in lineage.ancestors.iter().enumerate() {
+        let is_last = i + 1 == count;
+        let connector = if is_last { "└── " } else { "├── " };
+        let indent = "│   ".repeat(i);
+        let reason = step
+            .delegation_reason
+            .as_deref()
+            .map(|r| format!(" ({r})"))
+            .unwrap_or_default();
+        println!("{indent}{connector}{} [depth={}]{reason}", step.name, step.depth);
     }
 }

--- a/aa-cli/src/commands/topology/render/tree.rs
+++ b/aa-cli/src/commands/topology/render/tree.rs
@@ -1,0 +1,21 @@
+//! Tree-style rendering for AgentTree and AgentLineage.
+
+use super::AgentTree;
+
+/// Render an agent tree recursively using box-drawing characters.
+pub fn render_agent_tree(node: &AgentTree, prefix: &str, is_last: bool) {
+    let connector = if is_last { "└── " } else { "├── " };
+    let status_tag = format!("[{}]", node.status);
+    let team_tag = node
+        .team_id
+        .as_deref()
+        .map(|t| format!(" <{t}>"))
+        .unwrap_or_default();
+    println!("{prefix}{connector}{} {status_tag}{team_tag}", node.name);
+
+    let child_prefix = format!("{prefix}{}", if is_last { "    " } else { "│   " });
+    let count = node.children.len();
+    for (i, child) in node.children.iter().enumerate() {
+        render_agent_tree(child, &child_prefix, i + 1 == count);
+    }
+}


### PR DESCRIPTION
## Description

Creates the `aasm topology` module skeleton and all rendering infrastructure in `aa-cli`:

- `topology/mod.rs` — `TopologyArgs`, `TopologyCommands` enum, `dispatch()` function, and all submodule declarations
- `topology/render/mod.rs` — local response type structs (mirroring `aa-api` without the utoipa/axum dependency), `TopologyPayload` enum, and `render()` dispatch
- `topology/render/json.rs` — `render_json()` and `render_yaml()` for all payload variants
- `topology/render/table.rs` — `status_color()`, `render_overview_table()`, `render_team_table()`, `render_lineage_table()`, `render_stats_table()`
- `topology/render/tree.rs` — `render_agent_tree()` (box-drawing recursive tree) and `render_lineage_chain()`

Stub files for all five subcommands (`overview`, `tree`, `team`, `lineage`, `stats`) are also introduced so the module compiles. Subcommand implementations follow in subsequent PRs.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1034
- Parent story: AAASM-216
- Epic: AAASM-197

## Testing

- [x] `cargo check -p aa-cli` — clean
- [x] `cargo clippy -p aa-cli --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt --all -- --check` — clean

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention