### PR TITLE
[AAASM-1037] ✨ (aa-cli/topology/overview): Add aasm topology overview subcommand

### DIFF
--- a/aa-cli/src/commands/topology/overview.rs
+++ b/aa-cli/src/commands/topology/overview.rs
@@ -1,0 +1,14 @@
+//! `aasm topology overview` — fleet-wide topology summary.
+
+use clap::Args;
+
+/// Arguments for `aasm topology overview`.
+#[derive(Args)]
+pub struct OverviewArgs {
+    /// Filter agents by status (active, suspended, deregistered).
+    #[arg(long)]
+    pub status: Option<String>,
+    /// Include governance level in agent nodes.
+    #[arg(long)]
+    pub show_budget: bool,
+}

--- a/aa-cli/src/commands/topology/overview.rs
+++ b/aa-cli/src/commands/topology/overview.rs
@@ -7,6 +7,7 @@ use clap::Args;
 use super::render::{render, TopologyOverview, TopologyPayload};
 use crate::client;
 use crate::config::ResolvedContext;
+use crate::error::CliError;
 use crate::output::OutputFormat;
 
 /// Arguments for `aasm topology overview`.
@@ -37,6 +38,18 @@ pub fn run(args: OverviewArgs, ctx: &ResolvedContext, output: OutputFormat) -> E
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     let overview: TopologyOverview = match rt.block_on(client::get_json(ctx, &path)) {
         Ok(v) => v,
+        Err(CliError::Api(ref e)) if e.is_connect() => {
+            eprintln!("error: registry unreachable — check --api-url");
+            return ExitCode::FAILURE;
+        }
+        Err(CliError::Api(ref e)) if e.status() == Some(reqwest::StatusCode::UNAUTHORIZED) => {
+            eprintln!("error: unauthorized — check your API key");
+            return ExitCode::FAILURE;
+        }
+        Err(CliError::Api(ref e)) if e.status() == Some(reqwest::StatusCode::FORBIDDEN) => {
+            eprintln!("error: forbidden — insufficient permissions");
+            return ExitCode::FAILURE;
+        }
         Err(e) => {
             eprintln!("error: {e}");
             return ExitCode::FAILURE;

--- a/aa-cli/src/commands/topology/overview.rs
+++ b/aa-cli/src/commands/topology/overview.rs
@@ -1,6 +1,13 @@
 //! `aasm topology overview` — fleet-wide topology summary.
 
+use std::process::ExitCode;
+
 use clap::Args;
+
+use super::render::{render, TopologyOverview, TopologyPayload};
+use crate::client;
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
 
 /// Arguments for `aasm topology overview`.
 #[derive(Args)]
@@ -11,4 +18,31 @@ pub struct OverviewArgs {
     /// Include governance level in agent nodes.
     #[arg(long)]
     pub show_budget: bool,
+}
+
+/// Run the `aasm topology overview` command.
+pub fn run(args: OverviewArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    let mut path = "/api/v1/topology/overview".to_string();
+    let mut params: Vec<String> = vec![];
+    if let Some(ref s) = args.status {
+        params.push(format!("status={s}"));
+    }
+    if args.show_budget {
+        params.push("show_budget=true".to_string());
+    }
+    if !params.is_empty() {
+        path = format!("{path}?{}", params.join("&"));
+    }
+
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    let overview: TopologyOverview = match rt.block_on(client::get_json(ctx, &path)) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    render(TopologyPayload::Overview(&overview), output);
+    ExitCode::SUCCESS
 }


### PR DESCRIPTION
## Description

Implements `aasm topology overview` — a subcommand that calls `GET /api/v1/topology/overview` and displays a fleet-wide agent topology summary.

- `topology/overview.rs` — `OverviewArgs` struct (`--status`, `--show-budget` flags) and `run()` function
- Query parameters are forwarded to the REST endpoint as URL query strings
- Table output prints team counts, per-team agent breakdown, and standalone root agents
- JSON/YAML output serializes the full `TopologyOverview` response

> **Depends on:** AAASM-1034 (topology module + render scaffold) — review/merge that PR first.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1037
- Parent story: AAASM-216
- Epic: AAASM-197

## Testing

- [x] `cargo check -p aa-cli` — clean
- [x] `cargo clippy -p aa-cli --all-targets -- -D warnings` — zero warnings

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention