### PR TITLE
[AAASM-1268] 🐛 (ci): Skip policy_latency_test in llvm-cov coverage job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,8 +131,11 @@ jobs:
         # and doesn't add instrumented coverage. Running it under --all-features would
         # add 8+ minutes of Docker build time with zero coverage benefit.
         run: |
+          # sustained_load_p99_under_5ms is a timing-sensitive latency test that fails
+          # under llvm-cov instrumentation overhead — skipped in coverage runs only.
           cargo llvm-cov --no-report --all-features --workspace \
-            --exclude aa-ebpf --exclude aa-ffi-python --exclude aa-devtool-claude-code
+            --exclude aa-ebpf --exclude aa-ffi-python --exclude aa-devtool-claude-code \
+            -- --skip sustained_load_p99_under_5ms
           cargo llvm-cov --no-report -p aa-devtool-claude-code
           cargo llvm-cov --no-run --codecov --output-path codecov.xml
       - name: Upload to Codecov


### PR DESCRIPTION
## Description

`sustained_load_p99_under_5ms` in `aa-gateway/tests/policy_latency_test.rs` asserts an absolute p99 latency threshold (15 ms). Under `cargo llvm-cov` instrumentation, 2–10× per-instruction overhead causes occasional OS scheduling jitter to push the p99 tail past the threshold, producing non-deterministic CI failures that have nothing to do with code quality.

`sonar.yml` already skips this test with `-- --skip sustained_load_p99_under_5ms`. This PR applies the identical fix to the **Codecov coverage job** in `ci.yml`, which was still running the test under instrumentation.

The test continues to run un-instrumented in the dedicated **Benchmark** job (`cargo test -p aa-gateway --test policy_latency_test`).

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-1268
- Parent bug: AAASM-1186
- Parent Epic: AAASM-1185

## Testing

- [x] No tests required — CI configuration fix only. The latency test continues to run in the uninstrumented Benchmark job.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention