### PR TITLE
[AAASM-1038] ✨ (aa-cli/topology/tree): Add aasm topology tree subcommand

### DIFF
--- a/aa-cli/src/commands/topology/tree.rs
+++ b/aa-cli/src/commands/topology/tree.rs
@@ -1,0 +1,19 @@
+//! `aasm topology tree` — render agent subtree.
+
+use clap::Args;
+
+/// Arguments for `aasm topology tree`.
+#[derive(Args)]
+pub struct TreeArgs {
+    /// Root agent ID (hex-encoded UUID).
+    pub agent_id: String,
+    /// Maximum traversal depth from the root (default 10).
+    #[arg(long)]
+    pub depth: Option<u32>,
+    /// Filter tree nodes by status.
+    #[arg(long)]
+    pub status: Option<String>,
+    /// Include governance level in tree nodes.
+    #[arg(long)]
+    pub show_budget: bool,
+}

--- a/aa-cli/src/commands/topology/tree.rs
+++ b/aa-cli/src/commands/topology/tree.rs
@@ -16,7 +16,7 @@ pub struct TreeArgs {
     /// Root agent ID (hex-encoded UUID).
     pub agent_id: String,
     /// Maximum traversal depth from the root (default 10).
-    #[arg(long)]
+    #[arg(long = "max-depth")]
     pub depth: Option<u32>,
     /// Filter tree nodes by status.
     #[arg(long)]
@@ -30,7 +30,7 @@ pub struct TreeArgs {
 pub fn run(args: TreeArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
     if let Some(d) = args.depth {
         if d == 0 {
-            eprintln!("error: --depth must be at least 1");
+            eprintln!("error: --max-depth must be at least 1");
             return ExitCode::FAILURE;
         }
     }

--- a/aa-cli/src/commands/topology/tree.rs
+++ b/aa-cli/src/commands/topology/tree.rs
@@ -7,6 +7,7 @@ use clap::Args;
 use super::render::{render, AgentTree, TopologyPayload};
 use crate::client;
 use crate::config::ResolvedContext;
+use crate::error::CliError;
 use crate::output::OutputFormat;
 
 /// Arguments for `aasm topology tree`.
@@ -27,6 +28,13 @@ pub struct TreeArgs {
 
 /// Run the `aasm topology tree` command.
 pub fn run(args: TreeArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    if let Some(d) = args.depth {
+        if d == 0 {
+            eprintln!("error: --depth must be at least 1");
+            return ExitCode::FAILURE;
+        }
+    }
+
     let mut path = format!("/api/v1/topology/tree/{}", args.agent_id);
     let mut params: Vec<String> = vec![];
     if let Some(d) = args.depth {
@@ -45,6 +53,14 @@ pub fn run(args: TreeArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitC
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     let tree: AgentTree = match rt.block_on(client::get_json(ctx, &path)) {
         Ok(v) => v,
+        Err(CliError::Api(ref e)) if e.status() == Some(reqwest::StatusCode::NOT_FOUND) => {
+            eprintln!("error: agent {} not found", args.agent_id);
+            return ExitCode::from(4u8);
+        }
+        Err(CliError::Api(ref e)) if e.status() == Some(reqwest::StatusCode::UNPROCESSABLE_ENTITY) => {
+            eprintln!("error: {} is not a root agent", args.agent_id);
+            return ExitCode::from(5u8);
+        }
         Err(e) => {
             eprintln!("error: {e}");
             return ExitCode::FAILURE;

--- a/aa-cli/src/commands/topology/tree.rs
+++ b/aa-cli/src/commands/topology/tree.rs
@@ -1,6 +1,13 @@
 //! `aasm topology tree` — render agent subtree.
 
+use std::process::ExitCode;
+
 use clap::Args;
+
+use super::render::{render, AgentTree, TopologyPayload};
+use crate::client;
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
 
 /// Arguments for `aasm topology tree`.
 #[derive(Args)]
@@ -16,4 +23,34 @@ pub struct TreeArgs {
     /// Include governance level in tree nodes.
     #[arg(long)]
     pub show_budget: bool,
+}
+
+/// Run the `aasm topology tree` command.
+pub fn run(args: TreeArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    let mut path = format!("/api/v1/topology/tree/{}", args.agent_id);
+    let mut params: Vec<String> = vec![];
+    if let Some(d) = args.depth {
+        params.push(format!("depth={d}"));
+    }
+    if let Some(ref s) = args.status {
+        params.push(format!("status={s}"));
+    }
+    if args.show_budget {
+        params.push("show_budget=true".to_string());
+    }
+    if !params.is_empty() {
+        path = format!("{path}?{}", params.join("&"));
+    }
+
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    let tree: AgentTree = match rt.block_on(client::get_json(ctx, &path)) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    render(TopologyPayload::Tree(&tree), output);
+    ExitCode::SUCCESS
 }


### PR DESCRIPTION
## Description

Implements `aasm topology tree <agent_id>` — renders a recursive delegation tree rooted at a given agent using `GET /api/v1/topology/tree/{agent_id}`.

- `topology/tree.rs` — `TreeArgs` struct (`--depth`, `--status`, `--show-budget` flags) and `run()` function
- Table output uses `render_agent_tree()` with box-drawing characters (`├──`, `└──`, `│`)
- JSON/YAML output serializes the full recursive `AgentTree` response

> **Depends on:** AAASM-1034 + AAASM-1037 — review/merge those PRs first.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1038
- Parent story: AAASM-216
- Epic: AAASM-197

## Testing

- [x] `cargo check -p aa-cli` — clean
- [x] `cargo clippy -p aa-cli --all-targets -- -D warnings` — zero warnings

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention