### PR TITLE
[AAASM-1270] 📝 (docs): Add rule — latency tests must be excluded from coverage passes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,22 @@ On `git push`, documentation is also checked: `cargo doc --workspace --no-deps`.
 
 The workspace-level clippy lints (`correctness = deny`, `suspicious = deny`, others `warn`) live in `[workspace.lints.clippy]` of the top-level `Cargo.toml` — do not override them per-crate.
 
+## Performance and Latency Tests
+
+Latency and performance tests assert absolute timing thresholds (e.g. p99 < 15 ms). They **must not run under `cargo llvm-cov`** or any other coverage/instrumentation tool, because instrumentation adds 2–10× overhead per instruction and makes timing guarantees unreliable on shared CI runners.
+
+**Rule:** every `cargo llvm-cov` invocation that covers the workspace must pass `-- --skip <test-name>` for each timing-sensitive test.
+
+Example (`ci.yml` and `sonar.yml`):
+
+```yaml
+cargo llvm-cov --no-report --all-features --workspace \
+  --exclude aa-ebpf --exclude aa-ffi-python \
+  -- --skip sustained_load_p99_under_5ms
+```
+
+Latency tests run in the dedicated **Benchmark** CI job (`cargo test -p aa-gateway --test policy_latency_test`) which uses an unmodified binary with no instrumentation.
+
 ## Build docs locally
 
 Contributor documentation is an [mdBook](https://rust-lang.github.io/mdBook/) rooted at `docs/`. To build or preview it:


### PR DESCRIPTION
## Description

Documents the rule that timing-sensitive tests (latency / performance tests asserting absolute millisecond thresholds) **must not run under `cargo llvm-cov`** or any other coverage instrumentation tool. Adds a new "Performance and Latency Tests" subsection to `CONTRIBUTING.md` under "Code Quality" so future contributors know the constraint and how to apply it.

The companion CI fix (excluding `sustained_load_p99_under_5ms` from the Codecov coverage job) is in AAASM-1268 / PR #272.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-1270
- Parent bug: AAASM-1186
- Parent Epic: AAASM-1185

## Testing

- [x] No tests required — documentation-only change.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention