### PR TITLE
[AAASM-1040] ✨ (aa-cli/topology/team): Add aasm topology team subcommand

### DIFF
--- a/aa-cli/src/commands/topology/render/table.rs
+++ b/aa-cli/src/commands/topology/render/table.rs
@@ -54,13 +54,16 @@ pub fn render_team_table(team: &TeamTopology) {
     println!("Team: {}  |  Agents: {}\n", team.team_id, team.agent_count);
 
     if team.members.is_empty() {
-        println!("No agents in this team.");
+        println!("(no members)");
         return;
     }
 
+    let mut members: Vec<&super::AgentNode> = team.members.iter().collect();
+    members.sort_by_key(|a| a.id.as_str());
+
     let mut table = Table::new();
     table.set_header(vec!["AGENT_ID", "NAME", "DEPTH", "STATUS"]);
-    for a in &team.members {
+    for a in &members {
         table.add_row(vec![
             Cell::new(&a.id),
             Cell::new(&a.name),
@@ -91,10 +94,20 @@ pub fn render_lineage_table(lineage: &AgentLineage) {
             Cell::new(&step.id),
             Cell::new(&step.name),
             Cell::new(step.team_id.as_deref().unwrap_or("-")),
-            Cell::new(step.delegation_reason.as_deref().unwrap_or("-")),
+            Cell::new(
+                step.delegation_reason
+                    .as_deref()
+                    .map(|r| if r.len() > 60 { &r[..60] } else { r })
+                    .unwrap_or("-"),
+            ),
         ]);
     }
     println!("{table}");
+
+    let is_root = lineage.ancestors.len() == 1 && lineage.ancestors[0].depth == 0;
+    if is_root {
+        println!("\n(this is a root agent)");
+    }
 }
 
 /// Render aggregate topology statistics as a comfy-table.

--- a/aa-cli/src/commands/topology/team.rs
+++ b/aa-cli/src/commands/topology/team.rs
@@ -1,6 +1,13 @@
 //! `aasm topology team` — show all agents in a team.
 
+use std::process::ExitCode;
+
 use clap::Args;
+
+use super::render::{render, TeamTopology, TopologyPayload};
+use crate::client;
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
 
 /// Arguments for `aasm topology team`.
 #[derive(Args)]
@@ -13,4 +20,31 @@ pub struct TeamArgs {
     /// Include governance level in agent nodes.
     #[arg(long)]
     pub show_budget: bool,
+}
+
+/// Run the `aasm topology team` command.
+pub fn run(args: TeamArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    let mut path = format!("/api/v1/topology/team/{}", args.team_id);
+    let mut params: Vec<String> = vec![];
+    if let Some(ref s) = args.status {
+        params.push(format!("status={s}"));
+    }
+    if args.show_budget {
+        params.push("show_budget=true".to_string());
+    }
+    if !params.is_empty() {
+        path = format!("{path}?{}", params.join("&"));
+    }
+
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    let team: TeamTopology = match rt.block_on(client::get_json(ctx, &path)) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    render(TopologyPayload::Team(&team), output);
+    ExitCode::SUCCESS
 }

--- a/aa-cli/src/commands/topology/team.rs
+++ b/aa-cli/src/commands/topology/team.rs
@@ -7,6 +7,7 @@ use clap::Args;
 use super::render::{render, TeamTopology, TopologyPayload};
 use crate::client;
 use crate::config::ResolvedContext;
+use crate::error::CliError;
 use crate::output::OutputFormat;
 
 /// Arguments for `aasm topology team`.
@@ -39,6 +40,10 @@ pub fn run(args: TeamArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitC
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     let team: TeamTopology = match rt.block_on(client::get_json(ctx, &path)) {
         Ok(v) => v,
+        Err(CliError::Api(ref e)) if e.status() == Some(reqwest::StatusCode::NOT_FOUND) => {
+            eprintln!("error: team {} not found", args.team_id);
+            return ExitCode::from(4u8);
+        }
         Err(e) => {
             eprintln!("error: {e}");
             return ExitCode::FAILURE;

--- a/aa-cli/src/commands/topology/team.rs
+++ b/aa-cli/src/commands/topology/team.rs
@@ -1,0 +1,16 @@
+//! `aasm topology team` — show all agents in a team.
+
+use clap::Args;
+
+/// Arguments for `aasm topology team`.
+#[derive(Args)]
+pub struct TeamArgs {
+    /// Team ID.
+    pub team_id: String,
+    /// Filter members by status.
+    #[arg(long)]
+    pub status: Option<String>,
+    /// Include governance level in agent nodes.
+    #[arg(long)]
+    pub show_budget: bool,
+}

--- a/aa-cli/src/commands/topology/team.rs
+++ b/aa-cli/src/commands/topology/team.rs
@@ -12,6 +12,12 @@ use crate::output::OutputFormat;
 
 /// Arguments for `aasm topology team`.
 #[derive(Args)]
+#[command(after_help = "\
+Examples:
+  aasm topology team team-abc123
+  aasm topology team team-abc123 --output json
+  aasm topology team team-abc123 --status active
+  aasm topology team team-abc123 --show-budget")]
 pub struct TeamArgs {
     /// Team ID.
     pub team_id: String,


### PR DESCRIPTION
## Description

Implements `aasm topology team <team_id>` — lists all agents belonging to a given team via `GET /api/v1/topology/team/{team_id}`.

- `topology/team.rs` — `TeamArgs` struct (`--status`, `--show-budget` flags) and `run()` function
- Table output renders a comfy-table with AGENT_ID, NAME, DEPTH, STATUS (colour-coded)
- JSON/YAML output serializes the full `TeamTopology` response

> **Depends on:** AAASM-1034 + AAASM-1037 + AAASM-1038 — review/merge those PRs first.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1040
- Parent story: AAASM-216
- Epic: AAASM-197

## Testing

- [x] `cargo check -p aa-cli` — clean
- [x] `cargo clippy -p aa-cli --all-targets -- -D warnings` — zero warnings

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention