### PR TITLE
[AAASM-1042] ✨ (aa-cli/topology/lineage): Add aasm topology lineage subcommand

### DIFF
--- a/aa-cli/src/commands/topology/lineage.rs
+++ b/aa-cli/src/commands/topology/lineage.rs
@@ -12,6 +12,10 @@ use crate::output::OutputFormat;
 
 /// Arguments for `aasm topology lineage`.
 #[derive(Args)]
+#[command(after_help = "\
+Examples:
+  aasm topology lineage aabbccdd00112233aabbccdd00112233
+  aasm topology lineage aabbccdd00112233aabbccdd00112233 --output json")]
 pub struct LineageArgs {
     /// Agent ID (hex-encoded UUID).
     pub agent_id: String,

--- a/aa-cli/src/commands/topology/lineage.rs
+++ b/aa-cli/src/commands/topology/lineage.rs
@@ -7,6 +7,7 @@ use clap::Args;
 use super::render::{render, AgentLineage, TopologyPayload};
 use crate::client;
 use crate::config::ResolvedContext;
+use crate::error::CliError;
 use crate::output::OutputFormat;
 
 /// Arguments for `aasm topology lineage`.
@@ -23,6 +24,10 @@ pub fn run(args: LineageArgs, ctx: &ResolvedContext, output: OutputFormat) -> Ex
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     let lineage: AgentLineage = match rt.block_on(client::get_json(ctx, &path)) {
         Ok(v) => v,
+        Err(CliError::Api(ref e)) if e.status() == Some(reqwest::StatusCode::NOT_FOUND) => {
+            eprintln!("error: agent {} not found", args.agent_id);
+            return ExitCode::from(4u8);
+        }
         Err(e) => {
             eprintln!("error: {e}");
             return ExitCode::FAILURE;

--- a/aa-cli/src/commands/topology/lineage.rs
+++ b/aa-cli/src/commands/topology/lineage.rs
@@ -1,0 +1,10 @@
+//! `aasm topology lineage` — show ancestry chain for a given agent.
+
+use clap::Args;
+
+/// Arguments for `aasm topology lineage`.
+#[derive(Args)]
+pub struct LineageArgs {
+    /// Agent ID (hex-encoded UUID).
+    pub agent_id: String,
+}

--- a/aa-cli/src/commands/topology/lineage.rs
+++ b/aa-cli/src/commands/topology/lineage.rs
@@ -1,10 +1,34 @@
 //! `aasm topology lineage` — show ancestry chain for a given agent.
 
+use std::process::ExitCode;
+
 use clap::Args;
+
+use super::render::{render, AgentLineage, TopologyPayload};
+use crate::client;
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
 
 /// Arguments for `aasm topology lineage`.
 #[derive(Args)]
 pub struct LineageArgs {
     /// Agent ID (hex-encoded UUID).
     pub agent_id: String,
+}
+
+/// Run the `aasm topology lineage` command.
+pub fn run(args: LineageArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    let path = format!("/api/v1/topology/lineage/{}", args.agent_id);
+
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    let lineage: AgentLineage = match rt.block_on(client::get_json(ctx, &path)) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    render(TopologyPayload::Lineage(&lineage), output);
+    ExitCode::SUCCESS
 }


### PR DESCRIPTION
## Description

Implements `aasm topology lineage <agent_id>` — shows the full ancestry chain for a given agent via `GET /api/v1/topology/lineage/{agent_id}`.

- `topology/lineage.rs` — `LineageArgs` struct and `run()` function
- Table output renders a flat table with DEPTH, AGENT_ID, NAME, TEAM, DELEGATION_REASON for each ancestor
- JSON/YAML output serializes the full `AgentLineage` response (ancestors ordered root-first)

> **Depends on:** AAASM-1034 + AAASM-1037 + AAASM-1038 + AAASM-1040 — review/merge those PRs first.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1042
- Parent story: AAASM-216
- Epic: AAASM-197

## Testing

- [x] `cargo check -p aa-cli` — clean
- [x] `cargo clippy -p aa-cli --all-targets -- -D warnings` — zero warnings

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention