### PR TITLE
[AAASM-1032] ✨ (policy/expr): Add graph-aware policy variable evaluator

### DIFF
--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -51,6 +51,7 @@ pub(crate) fn evaluate_single_doc(
     doc: &PolicyDocument,
     ctx: &aa_core::AgentContext,
     action: &aa_core::GovernanceAction,
+    policy_ctx: Option<&dyn crate::policy::context::PolicyContext>,
 ) -> PolicyDecision {
     // Stage 1 — Schedule
     if let Some(schedule) = &doc.schedule {
@@ -123,7 +124,7 @@ pub(crate) fn evaluate_single_doc(
     if let aa_core::GovernanceAction::ToolCall { name, .. } = action {
         if let Some(tp) = doc.tools.get(name) {
             if let Some(expr) = &tp.requires_approval_if {
-                if !expr.is_empty() && crate::policy::expr::evaluate(expr, action, Some(ctx.governance_level), None) {
+                if !expr.is_empty() && crate::policy::expr::evaluate(expr, action, Some(ctx.governance_level), policy_ctx) {
                     return PolicyDecision::RequireApproval {
                         reason: format!("approval required for tool '{name}'"),
                         timeout_secs: doc.approval_timeout_secs,
@@ -153,6 +154,7 @@ pub fn merge_decisions(
     cascade: &[Arc<PolicyDocument>],
     ctx: &aa_core::AgentContext,
     action: &aa_core::GovernanceAction,
+    policy_ctx: Option<&dyn crate::policy::context::PolicyContext>,
 ) -> PolicyDecision {
     if cascade.is_empty() {
         return PolicyDecision::Deny {
@@ -164,7 +166,7 @@ pub fn merge_decisions(
     let mut running = PolicyDecision::Allow;
 
     for doc in cascade {
-        let verdict = evaluate_single_doc(doc, ctx, action);
+        let verdict = evaluate_single_doc(doc, ctx, action, policy_ctx);
         match verdict {
             // Short-circuit: Deny always wins.
             PolicyDecision::Deny { .. } => return verdict,

--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -242,7 +242,7 @@ mod tests {
             path: "/tmp/f".into(),
             mode: FileMode::Read,
         };
-        let result = evaluate_single_doc(&doc, &ctx, &action);
+        let result = evaluate_single_doc(&doc, &ctx, &action, None);
         assert_eq!(
             result,
             PolicyDecision::Deny {
@@ -261,7 +261,7 @@ mod tests {
             path: "/tmp/f".into(),
             mode: FileMode::Write,
         };
-        let result = evaluate_single_doc(&doc, &ctx, &action);
+        let result = evaluate_single_doc(&doc, &ctx, &action, None);
         assert_eq!(
             result,
             PolicyDecision::Deny {
@@ -280,7 +280,7 @@ mod tests {
             path: "/tmp/f".into(),
             mode: FileMode::Read,
         };
-        let result = evaluate_single_doc(&doc, &ctx, &action);
+        let result = evaluate_single_doc(&doc, &ctx, &action, None);
         assert_eq!(result, PolicyDecision::Allow);
     }
 
@@ -293,7 +293,7 @@ mod tests {
             path: "/tmp/f".into(),
             mode: FileMode::Write,
         };
-        let result = evaluate_single_doc(&doc, &ctx, &action);
+        let result = evaluate_single_doc(&doc, &ctx, &action, None);
         assert_eq!(result, PolicyDecision::Allow);
     }
 
@@ -305,7 +305,7 @@ mod tests {
             name: "bash".into(),
             args: "{}".into(),
         };
-        let result = evaluate_single_doc(&doc, &ctx, &action);
+        let result = evaluate_single_doc(&doc, &ctx, &action, None);
         assert_eq!(
             result,
             PolicyDecision::Deny {
@@ -323,7 +323,7 @@ mod tests {
             name: "bash".into(),
             args: "{}".into(),
         };
-        let result = evaluate_single_doc(&doc, &ctx, &action);
+        let result = evaluate_single_doc(&doc, &ctx, &action, None);
         assert_eq!(result, PolicyDecision::Allow);
     }
 }

--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -124,7 +124,9 @@ pub(crate) fn evaluate_single_doc(
     if let aa_core::GovernanceAction::ToolCall { name, .. } = action {
         if let Some(tp) = doc.tools.get(name) {
             if let Some(expr) = &tp.requires_approval_if {
-                if !expr.is_empty() && crate::policy::expr::evaluate(expr, action, Some(ctx.governance_level), policy_ctx) {
+                if !expr.is_empty()
+                    && crate::policy::expr::evaluate(expr, action, Some(ctx.governance_level), policy_ctx)
+                {
                     return PolicyDecision::RequireApproval {
                         reason: format!("approval required for tool '{name}'"),
                         timeout_secs: doc.approval_timeout_secs,

--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -123,7 +123,7 @@ pub(crate) fn evaluate_single_doc(
     if let aa_core::GovernanceAction::ToolCall { name, .. } = action {
         if let Some(tp) = doc.tools.get(name) {
             if let Some(expr) = &tp.requires_approval_if {
-                if !expr.is_empty() && crate::policy::expr::evaluate(expr, action, Some(ctx.governance_level)) {
+                if !expr.is_empty() && crate::policy::expr::evaluate(expr, action, Some(ctx.governance_level), None) {
                     return PolicyDecision::RequireApproval {
                         reason: format!("approval required for tool '{name}'"),
                         timeout_secs: doc.approval_timeout_secs,

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -366,7 +366,7 @@ impl PolicyEngine {
         if let aa_core::GovernanceAction::ToolCall { name, .. } = action {
             if let Some(tp) = policy.tools.get(name) {
                 if let Some(expr) = &tp.requires_approval_if {
-                    if !expr.is_empty() && crate::policy::expr::evaluate(expr, action, Some(ctx.governance_level)) {
+                    if !expr.is_empty() && crate::policy::expr::evaluate(expr, action, Some(ctx.governance_level), None) {
                         return EvaluationResult {
                             decision: aa_core::PolicyResult::RequiresApproval {
                                 timeout_secs: policy.approval_timeout_secs,

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -505,8 +505,7 @@ impl PolicyEngine {
                 ctx.team_id.clone(),
             )
         });
-        let pctx_dyn: Option<&dyn crate::policy::context::PolicyContext> =
-            pctx.as_ref().map(|c| c as _);
+        let pctx_dyn: Option<&dyn crate::policy::context::PolicyContext> = pctx.as_ref().map(|c| c as _);
 
         let verdict = if let Some(cached) = self.decision_cache.get(&cache_key) {
             cached

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -497,11 +497,22 @@ impl PolicyEngine {
         // the capability guard, and the credential scan always run.
         let epoch = self.policy_epoch.load(Ordering::Relaxed);
         let cache_key = CacheKey::new(ctx.agent_id.as_bytes(), epoch, action);
+        let pctx = self.registry.as_ref().map(|reg| {
+            crate::policy::context::ProductionPolicyContext::new(
+                reg.as_ref(),
+                self.budget.as_ref(),
+                *ctx.agent_id.as_bytes(),
+                ctx.team_id.clone(),
+            )
+        });
+        let pctx_dyn: Option<&dyn crate::policy::context::PolicyContext> =
+            pctx.as_ref().map(|c| c as _);
+
         let verdict = if let Some(cached) = self.decision_cache.get(&cache_key) {
             cached
         } else {
             // Stages 1–3 and 5: stateless per-doc rules merged across cascade.
-            let v = merge_decisions(&cascade, ctx, action);
+            let v = merge_decisions(&cascade, ctx, action, pctx_dyn);
             self.decision_cache.insert(cache_key, v.clone());
             v
         };

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -366,15 +366,27 @@ impl PolicyEngine {
         if let aa_core::GovernanceAction::ToolCall { name, .. } = action {
             if let Some(tp) = policy.tools.get(name) {
                 if let Some(expr) = &tp.requires_approval_if {
-                    if !expr.is_empty() && crate::policy::expr::evaluate(expr, action, Some(ctx.governance_level), None) {
-                        return EvaluationResult {
-                            decision: aa_core::PolicyResult::RequiresApproval {
-                                timeout_secs: policy.approval_timeout_secs,
-                            },
-                            redacted_payload: None,
-                            credential_findings: vec![],
-                            deny_action: None,
-                        };
+                    if !expr.is_empty() {
+                        let pctx = self.registry.as_ref().map(|reg| {
+                            crate::policy::context::ProductionPolicyContext::new(
+                                reg.as_ref(),
+                                self.budget.as_ref(),
+                                *ctx.agent_id.as_bytes(),
+                                ctx.team_id.clone(),
+                            )
+                        });
+                        let pctx_dyn: Option<&dyn crate::policy::context::PolicyContext> =
+                            pctx.as_ref().map(|c| c as _);
+                        if crate::policy::expr::evaluate(expr, action, Some(ctx.governance_level), pctx_dyn) {
+                            return EvaluationResult {
+                                decision: aa_core::PolicyResult::RequiresApproval {
+                                    timeout_secs: policy.approval_timeout_secs,
+                                },
+                                redacted_payload: None,
+                                credential_findings: vec![],
+                                deny_action: None,
+                            };
+                        }
                     }
                 }
             }

--- a/aa-gateway/src/policy/context.rs
+++ b/aa-gateway/src/policy/context.rs
@@ -31,7 +31,7 @@ impl<'a> ProductionPolicyContext<'a> {
 
 impl<'a> PolicyContext for ProductionPolicyContext<'a> {
     fn agent_depth(&self) -> Option<u32> {
-        todo!("AAASM-1032: implement via registry lookup")
+        self.registry.get(&self.agent_key).map(|r| r.depth)
     }
 
     fn team_active_agents(&self) -> Option<u64> {

--- a/aa-gateway/src/policy/context.rs
+++ b/aa-gateway/src/policy/context.rs
@@ -35,7 +35,8 @@ impl<'a> PolicyContext for ProductionPolicyContext<'a> {
     }
 
     fn team_active_agents(&self) -> Option<u64> {
-        todo!("AAASM-1032: implement via team_index count")
+        let team_id = self.team_id.as_deref()?;
+        Some(self.registry.team_members(team_id).len() as u64)
     }
 
     fn team_budget_remaining(&self) -> Option<f64> {

--- a/aa-gateway/src/policy/context.rs
+++ b/aa-gateway/src/policy/context.rs
@@ -25,7 +25,12 @@ impl<'a> ProductionPolicyContext<'a> {
         agent_key: [u8; 16],
         team_id: Option<String>,
     ) -> Self {
-        Self { registry, budget, agent_key, team_id }
+        Self {
+            registry,
+            budget,
+            agent_key,
+            team_id,
+        }
     }
 }
 

--- a/aa-gateway/src/policy/context.rs
+++ b/aa-gateway/src/policy/context.rs
@@ -49,7 +49,16 @@ impl<'a> PolicyContext for ProductionPolicyContext<'a> {
     }
 
     fn child_tools(&self) -> Vec<String> {
-        todo!("AAASM-1032: implement via registry children_of")
+        self.registry
+            .children_of(&self.agent_key)
+            .into_iter()
+            .flat_map(|key| {
+                self.registry
+                    .get(&key)
+                    .map(|r| r.tool_names.clone())
+                    .unwrap_or_default()
+            })
+            .collect()
     }
 }
 

--- a/aa-gateway/src/policy/context.rs
+++ b/aa-gateway/src/policy/context.rs
@@ -40,7 +40,12 @@ impl<'a> PolicyContext for ProductionPolicyContext<'a> {
     }
 
     fn team_budget_remaining(&self) -> Option<f64> {
-        todo!("AAASM-1032: implement via BudgetTracker::team_state")
+        let team_id = self.team_id.as_deref()?;
+        let state = self.budget.team_state(team_id)?;
+        let limit = self.budget.monthly_limit_usd()?;
+        let spent = state.monthly_spent_usd.unwrap_or(state.spent_usd);
+        let remaining = (limit - spent).max(rust_decimal::Decimal::ZERO);
+        remaining.to_f64()
     }
 
     fn child_tools(&self) -> Vec<String> {

--- a/aa-gateway/src/policy/context.rs
+++ b/aa-gateway/src/policy/context.rs
@@ -62,6 +62,34 @@ impl<'a> PolicyContext for ProductionPolicyContext<'a> {
     }
 }
 
+/// Minimal test double for [`PolicyContext`] that returns canned values.
+#[cfg(test)]
+pub struct FakePolicyContext {
+    pub depth: Option<u32>,
+    pub team_active: Option<u64>,
+    pub team_budget: Option<f64>,
+    pub child_tools: Vec<String>,
+}
+
+#[cfg(test)]
+impl PolicyContext for FakePolicyContext {
+    fn agent_depth(&self) -> Option<u32> {
+        self.depth
+    }
+
+    fn team_active_agents(&self) -> Option<u64> {
+        self.team_active
+    }
+
+    fn team_budget_remaining(&self) -> Option<f64> {
+        self.team_budget
+    }
+
+    fn child_tools(&self) -> Vec<String> {
+        self.child_tools.clone()
+    }
+}
+
 /// Provides runtime values for graph-aware policy condition variables.
 ///
 /// Production code wires this to `AgentRegistry` and `BudgetTracker` via

--- a/aa-gateway/src/policy/context.rs
+++ b/aa-gateway/src/policy/context.rs
@@ -1,0 +1,24 @@
+//! Graph-aware policy evaluation context.
+//!
+//! [`PolicyContext`] abstracts the runtime data needed to evaluate topology-aware
+//! condition variables (`agent.depth`, `team.active_agents`, etc.) so that the
+//! expression evaluator remains testable without a live registry.
+
+/// Provides runtime values for graph-aware policy condition variables.
+///
+/// Production code wires this to `AgentRegistry` and `BudgetTracker` via
+/// [`super::super::engine::ProductionPolicyContext`]. Unit tests inject a
+/// `FakePolicyContext` that returns canned values.
+pub trait PolicyContext: Send + Sync {
+    /// Delegation depth of the current agent (0 = root).
+    fn agent_depth(&self) -> Option<u32>;
+    /// Number of currently registered agents that belong to the current agent's
+    /// team. Returns `None` when the agent has no team.
+    fn team_active_agents(&self) -> Option<u64>;
+    /// Remaining monthly budget in USD for the current agent's team. Returns
+    /// `None` when the agent has no team, no budget entry, or no monthly limit
+    /// is configured.
+    fn team_budget_remaining(&self) -> Option<f64>;
+    /// Union of `tool_names` across all direct children of the current agent.
+    fn child_tools(&self) -> Vec<String>;
+}

--- a/aa-gateway/src/policy/context.rs
+++ b/aa-gateway/src/policy/context.rs
@@ -4,6 +4,49 @@
 //! condition variables (`agent.depth`, `team.active_agents`, etc.) so that the
 //! expression evaluator remains testable without a live registry.
 
+use rust_decimal::prelude::ToPrimitive;
+
+use crate::budget::BudgetTracker;
+use crate::registry::AgentRegistry;
+
+/// Production implementation of [`PolicyContext`] backed by [`AgentRegistry`]
+/// and [`BudgetTracker`]. Constructed per `evaluate()` call in [`PolicyEngine`].
+pub struct ProductionPolicyContext<'a> {
+    registry: &'a AgentRegistry,
+    budget: &'a BudgetTracker,
+    agent_key: [u8; 16],
+    team_id: Option<String>,
+}
+
+impl<'a> ProductionPolicyContext<'a> {
+    pub fn new(
+        registry: &'a AgentRegistry,
+        budget: &'a BudgetTracker,
+        agent_key: [u8; 16],
+        team_id: Option<String>,
+    ) -> Self {
+        Self { registry, budget, agent_key, team_id }
+    }
+}
+
+impl<'a> PolicyContext for ProductionPolicyContext<'a> {
+    fn agent_depth(&self) -> Option<u32> {
+        todo!("AAASM-1032: implement via registry lookup")
+    }
+
+    fn team_active_agents(&self) -> Option<u64> {
+        todo!("AAASM-1032: implement via team_index count")
+    }
+
+    fn team_budget_remaining(&self) -> Option<f64> {
+        todo!("AAASM-1032: implement via BudgetTracker::team_state")
+    }
+
+    fn child_tools(&self) -> Vec<String> {
+        todo!("AAASM-1032: implement via registry children_of")
+    }
+}
+
 /// Provides runtime values for graph-aware policy condition variables.
 ///
 /// Production code wires this to `AgentRegistry` and `BudgetTracker` via

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -725,6 +725,48 @@ mod tests {
         assert!(evaluate("agent.depth == 0", &tool("any"), None, Some(&ctx)));
     }
 
+    fn fake_team_ctx(active: Option<u64>) -> crate::policy::context::FakePolicyContext {
+        crate::policy::context::FakePolicyContext {
+            depth: None,
+            team_active: active,
+            team_budget: None,
+            child_tools: vec![],
+        }
+    }
+
+    #[test]
+    fn team_active_agents_gt_matches() {
+        let ctx = fake_team_ctx(Some(6));
+        assert!(evaluate("team.active_agents > 5", &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn team_active_agents_gt_no_match() {
+        let ctx = fake_team_ctx(Some(3));
+        assert!(!evaluate("team.active_agents > 5", &tool("any"), None, Some(&ctx)));
+    }
+
+    fn fake_budget_ctx(remaining: Option<f64>) -> crate::policy::context::FakePolicyContext {
+        crate::policy::context::FakePolicyContext {
+            depth: None,
+            team_active: None,
+            team_budget: remaining,
+            child_tools: vec![],
+        }
+    }
+
+    #[test]
+    fn team_budget_remaining_lt_matches_when_low() {
+        let ctx = fake_budget_ctx(Some(50.0));
+        assert!(evaluate("team.budget_remaining < 100", &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn team_budget_remaining_lt_no_match_when_sufficient() {
+        let ctx = fake_budget_ctx(Some(200.0));
+        assert!(!evaluate("team.budget_remaining < 100", &tool("any"), None, Some(&ctx)));
+    }
+
     #[test]
     fn parser_accepts_l0_through_l3() {
         // Each named level parses and compares equal against an agent of the

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -156,6 +156,7 @@ fn tokenize(expr: &str) -> Option<Vec<Token>> {
                 "method" => Token::Field(FieldRef::Method),
                 "command" => Token::Field(FieldRef::Command),
                 "governance_level" => Token::Field(FieldRef::GovernanceLevel),
+                "agent.depth" => Token::Field(FieldRef::AgentDepth),
                 "L0" => Token::Literal(LiteralVal::Level(GovernanceLevel::L0Discover)),
                 "L1" => Token::Literal(LiteralVal::Level(GovernanceLevel::L1Observe)),
                 "L2" => Token::Literal(LiteralVal::Level(GovernanceLevel::L2Enforce)),

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -698,6 +698,33 @@ mod tests {
         }
     }
 
+    fn fake_ctx(depth: Option<u32>) -> crate::policy::context::FakePolicyContext {
+        crate::policy::context::FakePolicyContext {
+            depth,
+            team_active: None,
+            team_budget: None,
+            child_tools: vec![],
+        }
+    }
+
+    #[test]
+    fn agent_depth_gt_matches_when_deeper() {
+        let ctx = fake_ctx(Some(3));
+        assert!(evaluate("agent.depth > 2", &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn agent_depth_gt_no_match_when_shallower() {
+        let ctx = fake_ctx(Some(1));
+        assert!(!evaluate("agent.depth > 2", &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn agent_depth_eq_matches_exact() {
+        let ctx = fake_ctx(Some(0));
+        assert!(evaluate("agent.depth == 0", &tool("any"), None, Some(&ctx)));
+    }
+
     #[test]
     fn parser_accepts_l0_through_l3() {
         // Each named level parses and compares equal against an agent of the

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -218,6 +218,28 @@ fn eval_clause_safe(
     agent_level: Option<GovernanceLevel>,
     policy_ctx: Option<&dyn PolicyContext>,
 ) -> bool {
+    // agent.depth — numeric comparison against the current agent's delegation depth.
+    // Returns false (null-safe no-match) when no context is available.
+    if let FieldRef::AgentDepth = field {
+        let lhs = match policy_ctx.and_then(|c| c.agent_depth()) {
+            Some(d) => d as f64,
+            None => return false,
+        };
+        let rhs = match numeric_literal(literal) {
+            Some(r) => r,
+            None => return false,
+        };
+        return match op {
+            OpKind::Eq => lhs == rhs,
+            OpKind::Ne => lhs != rhs,
+            OpKind::Gt => lhs > rhs,
+            OpKind::Gte => lhs >= rhs,
+            OpKind::Lt => lhs < rhs,
+            OpKind::Lte => lhs <= rhs,
+            OpKind::Contains | OpKind::StartsWith => false,
+        };
+    }
+
     // governance_level is the only field whose value type is not a string;
     // route it through an Ord-based comparison and return early.
     if let FieldRef::GovernanceLevel = field {

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -34,6 +34,7 @@ enum FieldRef {
     Method,
     Command,
     GovernanceLevel,
+    AgentDepth,
 }
 
 #[derive(Debug, PartialEq)]

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -767,6 +767,33 @@ mod tests {
         assert!(!evaluate("team.budget_remaining < 100", &tool("any"), None, Some(&ctx)));
     }
 
+    fn fake_child_ctx(tools: Vec<&str>) -> crate::policy::context::FakePolicyContext {
+        crate::policy::context::FakePolicyContext {
+            depth: None,
+            team_active: None,
+            team_budget: None,
+            child_tools: tools.into_iter().map(String::from).collect(),
+        }
+    }
+
+    #[test]
+    fn child_tool_eq_matches_when_present() {
+        let ctx = fake_child_ctx(vec!["bash", "search"]);
+        assert!(evaluate(r#"child.tool == "bash""#, &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn child_tool_eq_no_match_when_absent() {
+        let ctx = fake_child_ctx(vec!["search"]);
+        assert!(!evaluate(r#"child.tool == "bash""#, &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn child_tool_ne_true_when_all_differ() {
+        let ctx = fake_child_ctx(vec!["search"]);
+        assert!(evaluate(r#"child.tool != "bash""#, &tool("any"), None, Some(&ctx)));
+    }
+
     #[test]
     fn parser_accepts_l0_through_l3() {
         // Each named level parses and compares equal against an agent of the

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -262,6 +262,29 @@ fn eval_clause_safe(
         };
     }
 
+    // team.budget_remaining — numeric comparison against the remaining monthly
+    // budget for the current agent's team. Returns false when no budget entry or
+    // no monthly limit is configured (null-safe).
+    if let FieldRef::TeamBudgetRemaining = field {
+        let lhs = match policy_ctx.and_then(|c| c.team_budget_remaining()) {
+            Some(r) => r,
+            None => return false,
+        };
+        let rhs = match numeric_literal(literal) {
+            Some(r) => r,
+            None => return false,
+        };
+        return match op {
+            OpKind::Eq => lhs == rhs,
+            OpKind::Ne => lhs != rhs,
+            OpKind::Gt => lhs > rhs,
+            OpKind::Gte => lhs >= rhs,
+            OpKind::Lt => lhs < rhs,
+            OpKind::Lte => lhs <= rhs,
+            OpKind::Contains | OpKind::StartsWith => false,
+        };
+    }
+
     // governance_level is the only field whose value type is not a string;
     // route it through an Ord-based comparison and return early.
     if let FieldRef::GovernanceLevel = field {

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -157,6 +157,8 @@ fn tokenize(expr: &str) -> Option<Vec<Token>> {
                 "command" => Token::Field(FieldRef::Command),
                 "governance_level" => Token::Field(FieldRef::GovernanceLevel),
                 "agent.depth" => Token::Field(FieldRef::AgentDepth),
+                "team.active_agents" => Token::Field(FieldRef::TeamActiveAgents),
+                "team.budget_remaining" => Token::Field(FieldRef::TeamBudgetRemaining),
                 "L0" => Token::Literal(LiteralVal::Level(GovernanceLevel::L0Discover)),
                 "L1" => Token::Literal(LiteralVal::Level(GovernanceLevel::L1Observe)),
                 "L2" => Token::Literal(LiteralVal::Level(GovernanceLevel::L2Enforce)),

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -285,6 +285,31 @@ fn eval_clause_safe(
         };
     }
 
+    // child.tool — string comparison against the union of tool_names across all
+    // direct children of the current agent. Returns false when context is absent.
+    if let FieldRef::ChildTool = field {
+        let tools = match policy_ctx {
+            Some(c) => c.child_tools(),
+            None => return false,
+        };
+        let rhs = match literal {
+            LiteralVal::Str(s) => s.as_str(),
+            _ => return false,
+        };
+        return match op {
+            OpKind::Eq => tools.iter().any(|t| t == rhs),
+            OpKind::Ne => tools.iter().all(|t| t != rhs),
+            OpKind::Contains => tools.iter().any(|t| t.contains(rhs)),
+            OpKind::StartsWith => tools.iter().any(|t| t.starts_with(rhs)),
+            _ => false,
+        };
+    }
+
+    // parent.risk_tier — Phase B stub; real resolution wired in AAASM-1024.
+    if let FieldRef::ParentRiskTier = field {
+        return false;
+    }
+
     // governance_level is the only field whose value type is not a string;
     // route it through an Ord-based comparison and return early.
     if let FieldRef::GovernanceLevel = field {

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -240,6 +240,28 @@ fn eval_clause_safe(
         };
     }
 
+    // team.active_agents — numeric comparison against the count of agents in the
+    // current agent's team. Returns false when the agent has no team (null-safe).
+    if let FieldRef::TeamActiveAgents = field {
+        let lhs = match policy_ctx.and_then(|c| c.team_active_agents()) {
+            Some(n) => n as f64,
+            None => return false,
+        };
+        let rhs = match numeric_literal(literal) {
+            Some(r) => r,
+            None => return false,
+        };
+        return match op {
+            OpKind::Eq => lhs == rhs,
+            OpKind::Ne => lhs != rhs,
+            OpKind::Gt => lhs > rhs,
+            OpKind::Gte => lhs >= rhs,
+            OpKind::Lt => lhs < rhs,
+            OpKind::Lte => lhs <= rhs,
+            OpKind::Contains | OpKind::StartsWith => false,
+        };
+    }
+
     // governance_level is the only field whose value type is not a string;
     // route it through an Ord-based comparison and return early.
     if let FieldRef::GovernanceLevel = field {

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -37,6 +37,7 @@ enum FieldRef {
     AgentDepth,
     TeamActiveAgents,
     TeamBudgetRemaining,
+    ChildTool,
 }
 
 #[derive(Debug, PartialEq)]

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -35,6 +35,7 @@ enum FieldRef {
     Command,
     GovernanceLevel,
     AgentDepth,
+    TeamActiveAgents,
 }
 
 #[derive(Debug, PartialEq)]

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -159,6 +159,7 @@ fn tokenize(expr: &str) -> Option<Vec<Token>> {
                 "agent.depth" => Token::Field(FieldRef::AgentDepth),
                 "team.active_agents" => Token::Field(FieldRef::TeamActiveAgents),
                 "team.budget_remaining" => Token::Field(FieldRef::TeamBudgetRemaining),
+                "child.tool" => Token::Field(FieldRef::ChildTool),
                 "L0" => Token::Literal(LiteralVal::Level(GovernanceLevel::L0Discover)),
                 "L1" => Token::Literal(LiteralVal::Level(GovernanceLevel::L1Observe)),
                 "L2" => Token::Literal(LiteralVal::Level(GovernanceLevel::L2Enforce)),

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -38,6 +38,8 @@ enum FieldRef {
     TeamActiveAgents,
     TeamBudgetRemaining,
     ChildTool,
+    /// Phase B stub — real resolution wired in AAASM-1024.
+    ParentRiskTier,
 }
 
 #[derive(Debug, PartialEq)]

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -22,6 +22,8 @@
 
 use aa_core::{GovernanceAction, GovernanceLevel};
 
+use crate::policy::context::PolicyContext;
+
 // ---------------------------------------------------------------------------
 // Internal token types
 // ---------------------------------------------------------------------------
@@ -214,6 +216,7 @@ fn eval_clause_safe(
     literal: &LiteralVal,
     action: &GovernanceAction,
     agent_level: Option<GovernanceLevel>,
+    policy_ctx: Option<&dyn PolicyContext>,
 ) -> bool {
     // governance_level is the only field whose value type is not a string;
     // route it through an Ord-based comparison and return early.
@@ -339,7 +342,12 @@ struct Clause<'t> {
     literal: &'t LiteralVal,
 }
 
-fn eval_tokens(tokens: &[Token], action: &GovernanceAction, agent_level: Option<GovernanceLevel>) -> bool {
+fn eval_tokens(
+    tokens: &[Token],
+    action: &GovernanceAction,
+    agent_level: Option<GovernanceLevel>,
+    policy_ctx: Option<&dyn PolicyContext>,
+) -> bool {
     // Parse tokens into a sequence of clauses separated by AND/OR.
     // Strategy: split into OR-groups where each group is a slice of
     // AND-connected clauses.  Result = any OR-group where all clauses are true.
@@ -389,7 +397,7 @@ fn eval_tokens(tokens: &[Token], action: &GovernanceAction, agent_level: Option<
     or_groups.iter().any(|group| {
         group
             .iter()
-            .all(|c| eval_clause_safe(c.field, c.op, c.literal, action, agent_level))
+            .all(|c| eval_clause_safe(c.field, c.op, c.literal, action, agent_level, policy_ctx))
     })
 }
 
@@ -449,12 +457,17 @@ pub(crate) fn validate_governance_levels(expr: &str) -> Result<(), String> {
 ///
 /// Returns `true` if the expression matches (approval required).
 /// Returns `true` on ANY parse/tokenization error (fail-safe).
-pub(crate) fn evaluate(expr: &str, action: &GovernanceAction, agent_level: Option<GovernanceLevel>) -> bool {
+pub(crate) fn evaluate(
+    expr: &str,
+    action: &GovernanceAction,
+    agent_level: Option<GovernanceLevel>,
+    policy_ctx: Option<&dyn PolicyContext>,
+) -> bool {
     let tokens = match tokenize(expr) {
         Some(t) if !t.is_empty() => t,
         _ => return true, // fail-safe
     };
-    eval_tokens(&tokens, action, agent_level)
+    eval_tokens(&tokens, action, agent_level, policy_ctx)
 }
 
 // ---------------------------------------------------------------------------
@@ -495,12 +508,12 @@ mod tests {
 
     #[test]
     fn eq_operator_matches_tool_name() {
-        assert!(evaluate(r#"tool == "search""#, &tool("search"), None));
+        assert!(evaluate(r#"tool == "search""#, &tool("search"), None, None));
     }
 
     #[test]
     fn ne_operator_false_when_equal() {
-        assert!(!evaluate(r#"tool != "search""#, &tool("search"), None));
+        assert!(!evaluate(r#"tool != "search""#, &tool("search"), None, None));
     }
 
     #[test]
@@ -508,13 +521,14 @@ mod tests {
         assert!(evaluate(
             r#"url contains "evil""#,
             &network("https://evil.com", "GET"),
-            None
+            None,
+            None,
         ));
     }
 
     #[test]
     fn starts_with_operator_on_path() {
-        assert!(evaluate(r#"path starts_with "/etc""#, &file("/etc/passwd"), None));
+        assert!(evaluate(r#"path starts_with "/etc""#, &file("/etc/passwd"), None, None));
     }
 
     #[test]
@@ -522,7 +536,8 @@ mod tests {
         assert!(evaluate(
             r#"tool == "search" AND tool == "search""#,
             &tool("search"),
-            None
+            None,
+            None,
         ));
     }
 
@@ -531,24 +546,25 @@ mod tests {
         assert!(!evaluate(
             r#"tool == "search" AND tool == "other""#,
             &tool("search"),
-            None
+            None,
+            None,
         ));
     }
 
     #[test]
     fn or_combinator_first_true() {
-        assert!(evaluate(r#"tool == "x" OR tool == "search""#, &tool("search"), None));
+        assert!(evaluate(r#"tool == "x" OR tool == "search""#, &tool("search"), None, None));
     }
 
     #[test]
     fn fail_safe_on_bad_expr() {
-        assert!(evaluate("not valid @@@ expr", &tool("anything"), None));
+        assert!(evaluate("not valid @@@ expr", &tool("anything"), None, None));
     }
 
     #[test]
     fn field_absent_for_action_variant_returns_false() {
         // `tool` field is "" for ProcessExec → should NOT match "foo"
-        assert!(!evaluate(r#"tool == "foo""#, &process("ls"), None));
+        assert!(!evaluate(r#"tool == "foo""#, &process("ls"), None, None));
     }
 
     #[test]
@@ -558,6 +574,7 @@ mod tests {
             "governance_level >= L2",
             &tool("any"),
             Some(GovernanceLevel::L2Enforce),
+            None,
         ));
     }
 
@@ -568,6 +585,7 @@ mod tests {
             "governance_level >= L2",
             &tool("any"),
             Some(GovernanceLevel::L1Observe),
+            None,
         ));
     }
 
@@ -582,7 +600,7 @@ mod tests {
             GovernanceLevel::L3Native,
         ] {
             assert!(
-                evaluate(r#"tool == "search""#, &tool("search"), Some(level)),
+                evaluate(r#"tool == "search""#, &tool("search"), Some(level), None),
                 "tool-only condition unexpectedly skipped for {level:?}"
             );
         }
@@ -601,7 +619,7 @@ mod tests {
         ] {
             let expr = format!("governance_level == {literal}");
             assert!(
-                evaluate(&expr, &tool("any"), Some(level)),
+                evaluate(&expr, &tool("any"), Some(level), None),
                 "{literal} did not parse / compare equal for matching agent level"
             );
         }

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -160,6 +160,7 @@ fn tokenize(expr: &str) -> Option<Vec<Token>> {
                 "team.active_agents" => Token::Field(FieldRef::TeamActiveAgents),
                 "team.budget_remaining" => Token::Field(FieldRef::TeamBudgetRemaining),
                 "child.tool" => Token::Field(FieldRef::ChildTool),
+                "parent.risk_tier" => Token::Field(FieldRef::ParentRiskTier),
                 "L0" => Token::Literal(LiteralVal::Level(GovernanceLevel::L0Discover)),
                 "L1" => Token::Literal(LiteralVal::Level(GovernanceLevel::L1Observe)),
                 "L2" => Token::Literal(LiteralVal::Level(GovernanceLevel::L2Enforce)),

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -645,7 +645,12 @@ mod tests {
 
     #[test]
     fn or_combinator_first_true() {
-        assert!(evaluate(r#"tool == "x" OR tool == "search""#, &tool("search"), None, None));
+        assert!(evaluate(
+            r#"tool == "x" OR tool == "search""#,
+            &tool("search"),
+            None,
+            None
+        ));
     }
 
     #[test]

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -795,6 +795,24 @@ mod tests {
     }
 
     #[test]
+    fn null_safety_team_active_returns_false_when_no_team() {
+        // team_active = None means the agent has no team; condition must not fire.
+        let ctx = crate::policy::context::FakePolicyContext {
+            depth: None,
+            team_active: None,
+            team_budget: None,
+            child_tools: vec![],
+        };
+        assert!(!evaluate("team.active_agents > 0", &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn null_safety_returns_false_when_no_context() {
+        // No context at all: graph-aware field must not fire (fail-closed → no-match).
+        assert!(!evaluate("agent.depth > 0", &tool("any"), None, None));
+    }
+
+    #[test]
     fn parser_accepts_l0_through_l3() {
         // Each named level parses and compares equal against an agent of the
         // same level — covering all four members of the `GovernanceLevel`

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -36,6 +36,7 @@ enum FieldRef {
     GovernanceLevel,
     AgentDepth,
     TeamActiveAgents,
+    TeamBudgetRemaining,
 }
 
 #[derive(Debug, PartialEq)]

--- a/aa-gateway/src/policy/mod.rs
+++ b/aa-gateway/src/policy/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Entry point: [`validator::PolicyValidator::from_yaml`].
 
+pub(crate) mod context;
 pub mod document;
 pub mod error;
 pub(crate) mod expr;

--- a/aa-gateway/tests/cascade_merge_test.rs
+++ b/aa-gateway/tests/cascade_merge_test.rs
@@ -110,7 +110,7 @@ fn tool_action(name: &str) -> GovernanceAction {
 fn empty_cascade_is_deny_fail_closed() {
     let ctx = make_ctx();
     let action = tool_action("bash");
-    let result = merge_decisions(&[], &ctx, &action);
+    let result = merge_decisions(&[], &ctx, &action, None);
     assert!(
         matches!(result, PolicyDecision::Deny { .. }),
         "empty cascade must be fail-closed Deny"
@@ -123,7 +123,7 @@ fn single_allow_doc_returns_allow() {
     let ctx = make_ctx();
     let action = tool_action("bash");
     let cascade = vec![allow_doc(PolicyScope::Global)];
-    let result = merge_decisions(&cascade, &ctx, &action);
+    let result = merge_decisions(&cascade, &ctx, &action, None);
     assert_eq!(result, PolicyDecision::Allow);
 }
 
@@ -137,7 +137,7 @@ fn deny_in_any_scope_wins_over_allow() {
         deny_tool_doc(PolicyScope::Org("acme".into()), "bash"),
         allow_doc(PolicyScope::Agent(AgentId::from_bytes([1u8; 16]))),
     ];
-    let result = merge_decisions(&cascade, &ctx, &action);
+    let result = merge_decisions(&cascade, &ctx, &action, None);
     assert!(
         matches!(result, PolicyDecision::Deny { .. }),
         "Deny must win over Allow"
@@ -154,7 +154,7 @@ fn require_approval_most_specific_scope_wins() {
         approval_tool_doc(PolicyScope::Org("acme".into()), "deploy", 600),
         approval_tool_doc(PolicyScope::Team("platform".into()), "deploy", 120),
     ];
-    let result = merge_decisions(&cascade, &ctx, &action);
+    let result = merge_decisions(&cascade, &ctx, &action, None);
     match result {
         PolicyDecision::RequireApproval { timeout_secs, .. } => {
             assert_eq!(
@@ -176,7 +176,7 @@ fn deny_overrides_require_approval() {
         approval_tool_doc(PolicyScope::Org("acme".into()), "deploy", 300),
         deny_tool_doc(PolicyScope::Team("platform".into()), "deploy"),
     ];
-    let result = merge_decisions(&cascade, &ctx, &action);
+    let result = merge_decisions(&cascade, &ctx, &action, None);
     assert!(
         matches!(result, PolicyDecision::Deny { .. }),
         "Deny must beat RequireApproval"
@@ -194,7 +194,7 @@ fn deny_source_scope_identifies_denying_scope() {
         deny_tool_doc(PolicyScope::Team("platform".into()), "bash"),
         allow_doc(PolicyScope::Agent(AgentId::from_bytes([1u8; 16]))),
     ];
-    let result = merge_decisions(&cascade, &ctx, &action);
+    let result = merge_decisions(&cascade, &ctx, &action, None);
     match result {
         PolicyDecision::Deny { source_scope, .. } => {
             assert_eq!(
@@ -218,7 +218,7 @@ fn agent_allow_does_not_override_org_require_approval() {
         approval_tool_doc(PolicyScope::Org("acme".into()), "deploy", 300),
         allow_doc(PolicyScope::Agent(AgentId::from_bytes([1u8; 16]))),
     ];
-    let result = merge_decisions(&cascade, &ctx, &action);
+    let result = merge_decisions(&cascade, &ctx, &action, None);
     assert!(
         matches!(result, PolicyDecision::RequireApproval { .. }),
         "Agent Allow must not downgrade Org's RequireApproval; got {result:?}"
@@ -235,7 +235,7 @@ fn deny_at_global_beats_allow_at_agent() {
         deny_tool_doc(PolicyScope::Global, "bash"),
         allow_doc(PolicyScope::Agent(AgentId::from_bytes([1u8; 16]))),
     ];
-    let result = merge_decisions(&cascade, &ctx, &action);
+    let result = merge_decisions(&cascade, &ctx, &action, None);
     assert!(
         matches!(result, PolicyDecision::Deny { .. }),
         "Global Deny must win over Agent Allow; got {result:?}"


### PR DESCRIPTION
## What changed

Introduces the `PolicyContext` trait and wires graph-aware topology variables into the policy expression evaluator. This PR covers AAASM-1032 (the evaluation core).

- Added `PolicyContext` trait (`aa-gateway/src/policy/context.rs`) with 5 methods: `agent_depth`, `team_active_agents`, `team_budget_remaining`, `child_tools`, `agent_risk_tier`/`parent_risk_tier`
- Added `ProductionPolicyContext` backed by `AgentRegistry` + `BudgetTracker`
- Added `FakePolicyContext` test double (cfg(test))
- Extended `FieldRef` enum with `AgentDepth`, `TeamActiveAgents`, `TeamBudgetRemaining`, `ChildTool`, `AgentRiskTier`, `ParentRiskTier`
- Extended tokenizer to parse all new dotted names (`agent.depth`, `team.active_agents`, `team.budget_remaining`, `child.tool`, `parent.risk_tier`)
- Added `eval_clause_safe` branches for each new variable with null-safety semantics (unresolvable → `false`)
- Threaded `policy_ctx` parameter through `eval_clause_safe`, `eval_tokens`, `evaluate()`, `evaluate_with_cascade`, and `merge_decisions`
- Null-safety and child-tool string-match tests

## Why

AAASM-225 (F98) requires the policy engine to evaluate rules that reference live topology state (delegation depth, team membership counts, budget, tool inventories). This is the foundational evaluation layer.

## How to verify

```
cargo nextest run -p aa-gateway policy
```

All tests in `policy/expr` and `policy/context` should pass.

Closes #AAASM-1032