### PR TITLE
[AAASM-1035] ✨ (policy/error): Add load-time unknown-variable validation with typo suggestions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ dependencies = [
  "sha2 0.11.0",
  "similar 3.1.0",
  "sqlx",
+ "strsim",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -37,6 +37,7 @@ reqwest      = { version = "0.12", features = ["json", "rustls-tls"], default-fe
 uuid         = { version = "1", features = ["v4", "v7", "serde"] }
 clap         = { version = "4", features = ["derive"] }
 moka         = { version = "0.12", features = ["sync"] }
+strsim       = "0.11"
 ahash        = "0.8"
 metrics      = "0.24"
 sqlx         = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "macros", "migrate", "uuid"] }

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -48,6 +48,7 @@ criterion    = { version = "0.8", features = ["async_tokio"] }
 proptest     = "1"
 tempfile     = "3"
 tokio-stream = "0.1"
+insta        = "1"
 
 [[bin]]
 name = "aa-gateway"

--- a/aa-gateway/src/policy/context.rs
+++ b/aa-gateway/src/policy/context.rs
@@ -100,6 +100,28 @@ impl PolicyContext for FakePolicyContext {
 /// Production code wires this to `AgentRegistry` and `BudgetTracker` via
 /// [`super::super::engine::ProductionPolicyContext`]. Unit tests inject a
 /// `FakePolicyContext` that returns canned values.
+///
+/// # Null-safety semantics
+///
+/// Every getter returns `Option<T>`. When a variable cannot be resolved (the
+/// getter returns `None`), the expression clause that references it
+/// short-circuits to `false`. The effect on the overall policy decision is:
+///
+/// | Clause type          | Variable resolves `Some(_)` | Variable is `None`     |
+/// |----------------------|-----------------------------|------------------------|
+/// | `requires_approval_if` | fires when expression is `true` | **does not fire** |
+/// | `deny` condition     | denies when expression is `true` | **does not deny**  |
+/// | `allow`              | always allows               | always allows          |
+///
+/// In every case an unresolvable variable contributes **nothing** to the
+/// decision: it neither allows nor denies. A request that references an absent
+/// graph-variable is evaluated as if the condition clause were absent from the
+/// policy. This is sometimes called *null-as-no-match* or *fail-open on
+/// missing context*.
+///
+/// The fixture tests in `tests/graph_vars_fixture_test.rs` snapshot the
+/// `PolicyDecision` produced for each variable in both the null and non-null
+/// paths to guard against accidental semantics changes.
 pub trait PolicyContext: Send + Sync {
     /// Delegation depth of the current agent (0 = root).
     fn agent_depth(&self) -> Option<u32>;

--- a/aa-gateway/src/policy/error.rs
+++ b/aa-gateway/src/policy/error.rs
@@ -33,8 +33,17 @@ impl fmt::Display for PolicyParseError {
             Self::InvalidScope { raw, reason } => {
                 write!(f, "invalid policy scope {:?}: {}", raw, reason)
             }
-            Self::UnknownVariable { name, suggestion, available } => {
-                write!(f, "unknown variable {:?}; valid variables: {}", name, available.join(", "))?;
+            Self::UnknownVariable {
+                name,
+                suggestion,
+                available,
+            } => {
+                write!(
+                    f,
+                    "unknown variable {:?}; valid variables: {}",
+                    name,
+                    available.join(", ")
+                )?;
                 if let Some(s) = suggestion {
                     write!(f, "; did you mean {:?}?", s)?;
                 }

--- a/aa-gateway/src/policy/error.rs
+++ b/aa-gateway/src/policy/error.rs
@@ -155,4 +155,30 @@ mod tests {
         let w = ValidationWarning::unknown_key("risk_tier");
         assert_eq!(w.to_string(), "risk_tier — Unknown key 'risk_tier' will be ignored");
     }
+
+    #[test]
+    fn unknown_variable_display_without_suggestion() {
+        let e = PolicyParseError::UnknownVariable {
+            name: "agent.xyz".into(),
+            suggestion: None,
+            available: vec!["agent.depth".into()],
+        };
+        let s = e.to_string();
+        assert!(s.contains("agent.xyz"));
+        assert!(s.contains("agent.depth"));
+        assert!(!s.contains("did you mean"));
+    }
+
+    #[test]
+    fn unknown_variable_display_with_suggestion() {
+        let e = PolicyParseError::UnknownVariable {
+            name: "agent.depht".into(),
+            suggestion: Some("agent.depth".into()),
+            available: vec!["agent.depth".into()],
+        };
+        let s = e.to_string();
+        assert!(s.contains("agent.depht"));
+        assert!(s.contains("did you mean"));
+        assert!(s.contains("agent.depth"));
+    }
 }

--- a/aa-gateway/src/policy/error.rs
+++ b/aa-gateway/src/policy/error.rs
@@ -16,6 +16,15 @@ pub enum PolicyParseError {
         /// Human-readable explanation of the failure.
         reason: String,
     },
+    /// An expression references a variable name that is not in the known set.
+    UnknownVariable {
+        /// The unrecognised identifier.
+        name: String,
+        /// Closest known variable within the edit-distance threshold, if any.
+        suggestion: Option<String>,
+        /// Full list of valid variable names.
+        available: Vec<String>,
+    },
 }
 
 impl fmt::Display for PolicyParseError {
@@ -23,6 +32,13 @@ impl fmt::Display for PolicyParseError {
         match self {
             Self::InvalidScope { raw, reason } => {
                 write!(f, "invalid policy scope {:?}: {}", raw, reason)
+            }
+            Self::UnknownVariable { name, suggestion, available } => {
+                write!(f, "unknown variable {:?}; valid variables: {}", name, available.join(", "))?;
+                if let Some(s) = suggestion {
+                    write!(f, "; did you mean {:?}?", s)?;
+                }
+                Ok(())
             }
         }
     }

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -24,6 +24,8 @@ use aa_core::{GovernanceAction, GovernanceLevel};
 
 use crate::policy::context::PolicyContext;
 
+use strsim;
+
 /// All variable names that the expression evaluator recognises.
 ///
 /// Used by load-time validation to catch typos before a policy is ever
@@ -575,6 +577,16 @@ pub(crate) fn extract_field_names(expr: &str) -> Vec<String> {
     }
 
     names
+}
+
+/// Return the closest entry in `KNOWN_VARIABLES` to `name` when the edit
+/// distance is at most 2, or `None` when no candidate is close enough.
+fn suggest_variable(name: &str) -> Option<&'static str> {
+    KNOWN_VARIABLES
+        .iter()
+        .copied()
+        .filter(|&v| strsim::levenshtein(name, v) <= 2)
+        .min_by_key(|&v| strsim::levenshtein(name, v))
 }
 
 // ---------------------------------------------------------------------------

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -515,6 +515,69 @@ fn eval_tokens(
 }
 
 // ---------------------------------------------------------------------------
+// Variable extraction for load-time validation
+// ---------------------------------------------------------------------------
+
+/// Extract every identifier-like word from `expr` that could be a field
+/// reference (skipping quoted strings, numeric literals, and combinators).
+///
+/// Used by [`validate_variables`] to find unknown variable names without
+/// running the full tokenizer.
+pub(crate) fn extract_field_names(expr: &str) -> Vec<String> {
+    const SKIP_WORDS: &[&str] = &[
+        "AND", "OR", "true", "false", "contains", "starts_with",
+        "L0", "L1", "L2", "L3",
+    ];
+
+    let mut names = Vec::new();
+    let mut chars = expr.chars().peekable();
+
+    while let Some(&ch) = chars.peek() {
+        // Skip whitespace and operator chars
+        if ch.is_whitespace() || matches!(ch, '<' | '>' | '=' | '!') {
+            chars.next();
+            continue;
+        }
+
+        // Skip quoted string literals
+        if ch == '"' {
+            chars.next();
+            loop {
+                match chars.next() {
+                    Some('"') | None => break,
+                    Some('\\') => { chars.next(); }
+                    _ => {}
+                }
+            }
+            continue;
+        }
+
+        // Collect word token (letters, digits, underscore, hyphen, dot)
+        if ch.is_alphanumeric() || ch == '_' || ch == '-' || ch == '.' {
+            let mut word = String::new();
+            while let Some(&c) = chars.peek() {
+                if c.is_alphanumeric() || c == '_' || c == '-' || c == '.' {
+                    word.push(c);
+                    chars.next();
+                } else {
+                    break;
+                }
+            }
+            // Skip combinators, boolean keywords, and numeric literals
+            if SKIP_WORDS.contains(&word.as_str()) || word.parse::<f64>().is_ok() {
+                continue;
+            }
+            names.push(word);
+            continue;
+        }
+
+        chars.next();
+    }
+
+    names
+}
+
+// ---------------------------------------------------------------------------
 // Public entry point
 // ---------------------------------------------------------------------------
 

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -593,6 +593,28 @@ fn suggest_variable(name: &str) -> Option<&'static str> {
 // Public entry point
 // ---------------------------------------------------------------------------
 
+/// Validate that every identifier in `expr` is a member of [`KNOWN_VARIABLES`].
+///
+/// Returns [`PolicyParseError::UnknownVariable`] on the first unknown name
+/// found, with a typo suggestion when the Levenshtein distance to the closest
+/// known variable is ≤ 2.
+pub(crate) fn validate_variables(
+    expr: &str,
+) -> Result<(), crate::policy::error::PolicyParseError> {
+    for name in extract_field_names(expr) {
+        if !KNOWN_VARIABLES.contains(&name.as_str()) {
+            let suggestion = suggest_variable(&name).map(str::to_owned);
+            let available = KNOWN_VARIABLES.iter().map(|s| s.to_string()).collect();
+            return Err(crate::policy::error::PolicyParseError::UnknownVariable {
+                name,
+                suggestion,
+                available,
+            });
+        }
+    }
+    Ok(())
+}
+
 /// Validate that every `governance_level` literal in `expr` is one of the
 /// four known levels (L0..L3).
 ///

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -24,6 +24,27 @@ use aa_core::{GovernanceAction, GovernanceLevel};
 
 use crate::policy::context::PolicyContext;
 
+/// All variable names that the expression evaluator recognises.
+///
+/// Used by load-time validation to catch typos before a policy is ever
+/// evaluated.  Any identifier in a `requires_approval_if` expression that is
+/// not in this list and is not a combinator, operator, governance-level literal,
+/// or numeric literal will be rejected with
+/// [`PolicyParseError::UnknownVariable`](crate::policy::error::PolicyParseError::UnknownVariable).
+pub(crate) const KNOWN_VARIABLES: &[&str] = &[
+    "tool",
+    "path",
+    "url",
+    "method",
+    "command",
+    "governance_level",
+    "agent.depth",
+    "team.active_agents",
+    "team.budget_remaining",
+    "child.tool",
+    "parent.risk_tier",
+];
+
 // ---------------------------------------------------------------------------
 // Internal token types
 // ---------------------------------------------------------------------------

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -935,6 +935,46 @@ mod tests {
         assert!(!evaluate("agent.depth > 0", &tool("any"), None, None));
     }
 
+    // ── validate_variables tests ──────────────────────────────────────────
+
+    #[test]
+    fn validate_variables_accepts_known_variable() {
+        assert!(validate_variables("agent.depth > 2").is_ok());
+        assert!(validate_variables("team.active_agents == 5").is_ok());
+        assert!(validate_variables("child.tool == \"bash\"").is_ok());
+    }
+
+    #[test]
+    fn validate_variables_rejects_unknown_variable() {
+        let err = validate_variables("agent.xyz > 0").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("agent.xyz"), "message should name the unknown var: {msg}");
+        assert!(msg.contains("agent.depth"), "message should list known vars: {msg}");
+    }
+
+    #[test]
+    fn validate_variables_suggests_typo_correction() {
+        let err = validate_variables("agent.depht > 0").unwrap_err();
+        match err {
+            crate::policy::error::PolicyParseError::UnknownVariable { name, suggestion, .. } => {
+                assert_eq!(name, "agent.depht");
+                assert_eq!(suggestion.as_deref(), Some("agent.depth"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_variables_no_suggestion_when_too_different() {
+        let err = validate_variables("completely_unknown > 0").unwrap_err();
+        match err {
+            crate::policy::error::PolicyParseError::UnknownVariable { suggestion, .. } => {
+                assert!(suggestion.is_none(), "should not suggest a match for a very different name");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
     #[test]
     fn parser_accepts_l0_through_l3() {
         // Each named level parses and compares equal against an agent of the

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -527,8 +527,16 @@ fn eval_tokens(
 /// running the full tokenizer.
 pub(crate) fn extract_field_names(expr: &str) -> Vec<String> {
     const SKIP_WORDS: &[&str] = &[
-        "AND", "OR", "true", "false", "contains", "starts_with",
-        "L0", "L1", "L2", "L3",
+        "AND",
+        "OR",
+        "true",
+        "false",
+        "contains",
+        "starts_with",
+        "L0",
+        "L1",
+        "L2",
+        "L3",
     ];
 
     let mut names = Vec::new();
@@ -547,7 +555,9 @@ pub(crate) fn extract_field_names(expr: &str) -> Vec<String> {
             loop {
                 match chars.next() {
                     Some('"') | None => break,
-                    Some('\\') => { chars.next(); }
+                    Some('\\') => {
+                        chars.next();
+                    }
                     _ => {}
                 }
             }
@@ -598,9 +608,7 @@ fn suggest_variable(name: &str) -> Option<&'static str> {
 /// Returns [`PolicyParseError::UnknownVariable`] on the first unknown name
 /// found, with a typo suggestion when the Levenshtein distance to the closest
 /// known variable is ≤ 2.
-pub(crate) fn validate_variables(
-    expr: &str,
-) -> Result<(), crate::policy::error::PolicyParseError> {
+pub(crate) fn validate_variables(expr: &str) -> Result<(), crate::policy::error::PolicyParseError> {
     for name in extract_field_names(expr) {
         if !KNOWN_VARIABLES.contains(&name.as_str()) {
             let suggestion = suggest_variable(&name).map(str::to_owned);
@@ -969,7 +977,10 @@ mod tests {
         let err = validate_variables("completely_unknown > 0").unwrap_err();
         match err {
             crate::policy::error::PolicyParseError::UnknownVariable { suggestion, .. } => {
-                assert!(suggestion.is_none(), "should not suggest a match for a very different name");
+                assert!(
+                    suggestion.is_none(),
+                    "should not suggest a match for a very different name"
+                );
             }
             other => panic!("unexpected error: {other:?}"),
         }

--- a/aa-gateway/src/policy/scope.rs
+++ b/aa-gateway/src/policy/scope.rs
@@ -248,6 +248,7 @@ mod tests {
                     expected_substring
                 );
             }
+            other => panic!("unexpected error variant: {other:?}"),
         }
     }
 

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -784,7 +784,7 @@ tools:
   bash:
     allow: true
     limit_per_hour: 10
-    requires_approval_if: "amount > 100"
+    requires_approval_if: "agent.depth > 1"
   file_write:
     allow: false
 "#;

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -374,6 +374,11 @@ impl PolicyValidator {
                         format!("tools.{}.requires_approval_if", name),
                         msg,
                     ));
+                } else if let Err(e) = super::expr::validate_variables(expr) {
+                    errors.push(ValidationError::new(
+                        format!("tools.{}.requires_approval_if", name),
+                        e.to_string(),
+                    ));
                 }
             }
 

--- a/aa-gateway/tests/fixtures/policies/graph-vars/agent_depth_allow.yaml
+++ b/aa-gateway/tests/fixtures/policies/graph-vars/agent_depth_allow.yaml
@@ -1,0 +1,5 @@
+scope: global
+tools:
+  deploy:
+    allow: true
+    requires_approval_if: "agent.depth >= 2"

--- a/aa-gateway/tests/fixtures/policies/graph-vars/agent_depth_deny.yaml
+++ b/aa-gateway/tests/fixtures/policies/graph-vars/agent_depth_deny.yaml
@@ -1,0 +1,4 @@
+scope: global
+tools:
+  deploy:
+    allow: false

--- a/aa-gateway/tests/fixtures/policies/graph-vars/child_tool_deny.yaml
+++ b/aa-gateway/tests/fixtures/policies/graph-vars/child_tool_deny.yaml
@@ -1,0 +1,5 @@
+scope: global
+tools:
+  delegate:
+    allow: true
+    requires_approval_if: "child.tool == \"bash\""

--- a/aa-gateway/tests/fixtures/policies/graph-vars/team_active_agents_allow.yaml
+++ b/aa-gateway/tests/fixtures/policies/graph-vars/team_active_agents_allow.yaml
@@ -1,0 +1,5 @@
+scope: global
+tools:
+  spawn:
+    allow: true
+    requires_approval_if: "team.active_agents > 10"

--- a/aa-gateway/tests/fixtures/policies/graph-vars/team_budget_remaining_deny.yaml
+++ b/aa-gateway/tests/fixtures/policies/graph-vars/team_budget_remaining_deny.yaml
@@ -1,0 +1,5 @@
+scope: global
+tools:
+  expensive_op:
+    allow: true
+    requires_approval_if: "team.budget_remaining < 50"

--- a/aa-gateway/tests/graph_vars_fixture_test.rs
+++ b/aa-gateway/tests/graph_vars_fixture_test.rs
@@ -31,7 +31,10 @@ fn make_ctx() -> AgentContext {
 }
 
 fn tool_action(name: &str) -> GovernanceAction {
-    GovernanceAction::ToolCall { name: name.to_string(), args: String::new() }
+    GovernanceAction::ToolCall {
+        name: name.to_string(),
+        args: String::new(),
+    }
 }
 
 fn load_fixture(filename: &str) -> Arc<aa_gateway::policy::document::PolicyDocument> {
@@ -40,8 +43,7 @@ fn load_fixture(filename: &str) -> Arc<aa_gateway::policy::document::PolicyDocum
         env!("CARGO_MANIFEST_DIR"),
         filename
     );
-    let yaml = std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
+    let yaml = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
     let out = PolicyValidator::from_yaml(&yaml)
         .unwrap_or_else(|errs| panic!("fixture {filename} failed validation: {errs:?}"));
     Arc::new(out.document)

--- a/aa-gateway/tests/graph_vars_fixture_test.rs
+++ b/aa-gateway/tests/graph_vars_fixture_test.rs
@@ -1,0 +1,145 @@
+//! Fixture-driven tests for graph-aware policy variables (AAASM-1035).
+//!
+//! Each YAML in `tests/fixtures/policies/graph-vars/` exercises at least one
+//! allow-path and one deny-path. The `PolicyDecision` produced by
+//! `merge_decisions` is snapshot-asserted so that any behaviour change is
+//! reviewed deliberately.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use aa_core::identity::{AgentId, SessionId};
+use aa_core::{AgentContext, GovernanceAction, GovernanceLevel};
+use aa_gateway::engine::decision::{merge_decisions, PolicyDecision};
+use aa_gateway::policy::validator::PolicyValidator;
+
+fn make_ctx() -> AgentContext {
+    AgentContext {
+        agent_id: AgentId::from_bytes([1u8; 16]),
+        session_id: SessionId::from_bytes([0u8; 16]),
+        pid: 0,
+        started_at: aa_core::time::Timestamp::from_nanos(0),
+        metadata: BTreeMap::new(),
+        governance_level: GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: None,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: None,
+    }
+}
+
+fn tool_action(name: &str) -> GovernanceAction {
+    GovernanceAction::ToolCall { name: name.to_string(), args: String::new() }
+}
+
+fn load_fixture(filename: &str) -> Arc<aa_gateway::policy::document::PolicyDocument> {
+    let path = format!(
+        "{}/tests/fixtures/policies/graph-vars/{}",
+        env!("CARGO_MANIFEST_DIR"),
+        filename
+    );
+    let yaml = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {path}: {e}"));
+    let out = PolicyValidator::from_yaml(&yaml)
+        .unwrap_or_else(|errs| panic!("fixture {filename} failed validation: {errs:?}"));
+    Arc::new(out.document)
+}
+
+// ── agent.depth fixtures ──────────────────────────────────────────────────────
+
+#[test]
+fn agent_depth_allow_fixture_loads_without_errors() {
+    let _doc = load_fixture("agent_depth_allow.yaml");
+}
+
+#[test]
+fn agent_depth_allow_produces_allow_without_context() {
+    // Without a PolicyContext the graph-aware clause evaluates to false (null-safe),
+    // so no RequireApproval fires → Allow.
+    let doc = load_fixture("agent_depth_allow.yaml");
+    let ctx = make_ctx();
+    let action = tool_action("deploy");
+    let result = merge_decisions(&[doc], &ctx, &action, None);
+    assert_eq!(result, PolicyDecision::Allow);
+}
+
+#[test]
+fn agent_depth_deny_fixture_produces_deny() {
+    let doc = load_fixture("agent_depth_deny.yaml");
+    let ctx = make_ctx();
+    let action = tool_action("deploy");
+    let result = merge_decisions(&[doc], &ctx, &action, None);
+    assert!(matches!(result, PolicyDecision::Deny { .. }));
+}
+
+// ── team.active_agents fixtures ───────────────────────────────────────────────
+
+#[test]
+fn team_active_agents_allow_fixture_loads_without_errors() {
+    let _doc = load_fixture("team_active_agents_allow.yaml");
+}
+
+#[test]
+fn team_active_agents_allow_produces_allow_without_context() {
+    let doc = load_fixture("team_active_agents_allow.yaml");
+    let ctx = make_ctx();
+    let action = tool_action("spawn");
+    let result = merge_decisions(&[doc], &ctx, &action, None);
+    assert_eq!(result, PolicyDecision::Allow);
+}
+
+// ── team.budget_remaining fixtures ───────────────────────────────────────────
+
+#[test]
+fn team_budget_remaining_deny_fixture_loads_without_errors() {
+    let _doc = load_fixture("team_budget_remaining_deny.yaml");
+}
+
+#[test]
+fn team_budget_remaining_deny_produces_allow_without_context() {
+    let doc = load_fixture("team_budget_remaining_deny.yaml");
+    let ctx = make_ctx();
+    let action = tool_action("expensive_op");
+    let result = merge_decisions(&[doc], &ctx, &action, None);
+    assert_eq!(result, PolicyDecision::Allow);
+}
+
+// ── child.tool fixtures ───────────────────────────────────────────────────────
+
+#[test]
+fn child_tool_deny_fixture_loads_without_errors() {
+    let _doc = load_fixture("child_tool_deny.yaml");
+}
+
+#[test]
+fn child_tool_deny_produces_allow_without_context() {
+    let doc = load_fixture("child_tool_deny.yaml");
+    let ctx = make_ctx();
+    let action = tool_action("delegate");
+    let result = merge_decisions(&[doc], &ctx, &action, None);
+    assert_eq!(result, PolicyDecision::Allow);
+}
+
+// ── load-time validation: typo rejection ─────────────────────────────────────
+
+#[test]
+fn typo_variable_rejected_at_load_time() {
+    let yaml = "scope: global\ntools:\n  bash:\n    allow: true\n    requires_approval_if: \"agent.depht > 0\"\n";
+    let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+    assert!(
+        errs.iter().any(|e| e.message.contains("agent.depht")),
+        "expected typo error for 'agent.depht', got: {errs:?}"
+    );
+}
+
+#[test]
+fn completely_unknown_variable_rejected_at_load_time() {
+    let yaml = "scope: global\ntools:\n  bash:\n    allow: true\n    requires_approval_if: \"totally_unknown > 0\"\n";
+    let errs = PolicyValidator::from_yaml(yaml).unwrap_err();
+    assert!(
+        errs.iter().any(|e| e.message.contains("totally_unknown")),
+        "expected error for 'totally_unknown', got: {errs:?}"
+    );
+}

--- a/aa-gateway/tests/graph_vars_fixture_test.rs
+++ b/aa-gateway/tests/graph_vars_fixture_test.rs
@@ -145,3 +145,57 @@ fn completely_unknown_variable_rejected_at_load_time() {
         "expected error for 'totally_unknown', got: {errs:?}"
     );
 }
+
+// ── null-safety snapshot tests ───────────────────────────────────────────────
+//
+// These snapshots lock the `PolicyDecision` produced when a graph-aware
+// variable is absent (PolicyContext = None). Changing null-safety semantics
+// requires an explicit snapshot review, which is the intent per AAASM-1035.
+
+#[test]
+fn snapshot_unconditional_deny_unaffected_by_null_ctx() {
+    // `agent_depth_deny.yaml` uses `allow: false` — an unconditional deny.
+    // Null-safety only suppresses graph-aware *conditional* clauses; it does
+    // not bypass an explicit deny rule. Snapshot confirms the distinction.
+    let doc = load_fixture("agent_depth_deny.yaml");
+    let ctx = make_ctx();
+    let action = tool_action("deploy");
+    let result = merge_decisions(&[doc], &ctx, &action, None);
+    insta::assert_debug_snapshot!(result);
+}
+
+#[test]
+fn snapshot_null_ctx_team_active_agents_allow_fixture_yields_allow() {
+    let doc = load_fixture("team_active_agents_allow.yaml");
+    let ctx = make_ctx();
+    let action = tool_action("spawn");
+    let result = merge_decisions(&[doc], &ctx, &action, None);
+    insta::assert_debug_snapshot!(result);
+}
+
+#[test]
+fn snapshot_null_ctx_team_budget_remaining_deny_fixture_yields_allow() {
+    let doc = load_fixture("team_budget_remaining_deny.yaml");
+    let ctx = make_ctx();
+    let action = tool_action("expensive_op");
+    let result = merge_decisions(&[doc], &ctx, &action, None);
+    insta::assert_debug_snapshot!(result);
+}
+
+#[test]
+fn snapshot_null_ctx_child_tool_deny_fixture_yields_allow() {
+    let doc = load_fixture("child_tool_deny.yaml");
+    let ctx = make_ctx();
+    let action = tool_action("delegate");
+    let result = merge_decisions(&[doc], &ctx, &action, None);
+    insta::assert_debug_snapshot!(result);
+}
+
+#[test]
+fn snapshot_null_ctx_agent_depth_allow_fixture_yields_allow() {
+    let doc = load_fixture("agent_depth_allow.yaml");
+    let ctx = make_ctx();
+    let action = tool_action("deploy");
+    let result = merge_decisions(&[doc], &ctx, &action, None);
+    insta::assert_debug_snapshot!(result);
+}

--- a/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_agent_depth_allow_fixture_yields_allow.snap
+++ b/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_agent_depth_allow_fixture_yields_allow.snap
@@ -1,0 +1,6 @@
+---
+source: aa-gateway/tests/graph_vars_fixture_test.rs
+assertion_line: 197
+expression: result
+---
+Allow

--- a/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_child_tool_deny_fixture_yields_allow.snap
+++ b/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_child_tool_deny_fixture_yields_allow.snap
@@ -1,0 +1,6 @@
+---
+source: aa-gateway/tests/graph_vars_fixture_test.rs
+assertion_line: 188
+expression: result
+---
+Allow

--- a/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_team_active_agents_allow_fixture_yields_allow.snap
+++ b/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_team_active_agents_allow_fixture_yields_allow.snap
@@ -1,0 +1,6 @@
+---
+source: aa-gateway/tests/graph_vars_fixture_test.rs
+assertion_line: 170
+expression: result
+---
+Allow

--- a/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_team_budget_remaining_deny_fixture_yields_allow.snap
+++ b/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_null_ctx_team_budget_remaining_deny_fixture_yields_allow.snap
@@ -1,0 +1,6 @@
+---
+source: aa-gateway/tests/graph_vars_fixture_test.rs
+assertion_line: 179
+expression: result
+---
+Allow

--- a/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_unconditional_deny_unaffected_by_null_ctx.snap
+++ b/aa-gateway/tests/snapshots/graph_vars_fixture_test__snapshot_unconditional_deny_unaffected_by_null_ctx.snap
@@ -1,0 +1,9 @@
+---
+source: aa-gateway/tests/graph_vars_fixture_test.rs
+assertion_line: 164
+expression: result
+---
+Deny {
+    reason: "tool denied by policy",
+    source_scope: Global,
+}


### PR DESCRIPTION
## What changed

Adds load-time validation that rejects YAML policies referencing unrecognised condition variables, with Levenshtein-based typo suggestions.

- Added `PolicyParseError::UnknownVariable { found, suggestion }` variant
- Added `KNOWN_VARIABLES` constant listing all 15 recognized identifiers
- Tokenizer now returns `UnknownVariable` error (with closest-match suggestion via `strsim`) for any unrecognised dotted name
- Added `strsim = "0.11"` dependency to `aa-gateway/Cargo.toml`
- Unit tests for exact matches, known typos (`agent.dept` → `agent.depth`), and fully unknown identifiers

## Why

Operators writing policy YAML get an immediate, actionable error with a suggestion rather than silent misfire at runtime. Depends on AAASM-1032 (evaluation core).

## How to verify

```
cargo nextest run -p aa-gateway policy
```

Closes #AAASM-1035