### PR TITLE
[AAASM-1020] ✨ (policy/expr): Add agent.age TTL variable and registry sweep for aged-out agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,7 @@ dependencies = [
  "dirs",
  "ed25519-dalek",
  "hex",
+ "humantime",
  "metrics",
  "moka",
  "notify",
@@ -2471,6 +2472,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,7 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "humantime",
+ "insta",
  "metrics",
  "moka",
  "notify",

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -45,6 +45,8 @@ pub enum AuditEventType {
     ApprovalRouted = 9,
     /// An approval request was escalated after the initial approver did not respond.
     ApprovalEscalated = 10,
+    /// An agent was force-deregistered by the gateway because it exceeded its configured maximum age.
+    AgentForceDeregistered = 11,
 }
 
 impl AuditEventType {
@@ -64,6 +66,7 @@ impl AuditEventType {
             Self::ApprovalTimedOut => "ApprovalTimedOut",
             Self::ApprovalRouted => "ApprovalRouted",
             Self::ApprovalEscalated => "ApprovalEscalated",
+            Self::AgentForceDeregistered => "AgentForceDeregistered",
         }
     }
 }

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -38,6 +38,7 @@ uuid         = { version = "1", features = ["v4", "v7", "serde"] }
 clap         = { version = "4", features = ["derive"] }
 moka         = { version = "0.12", features = ["sync"] }
 strsim       = "0.11"
+humantime    = "2"
 ahash        = "0.8"
 metrics      = "0.24"
 sqlx         = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "macros", "migrate", "uuid"] }

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -367,12 +367,14 @@ impl PolicyEngine {
             if let Some(tp) = policy.tools.get(name) {
                 if let Some(expr) = &tp.requires_approval_if {
                     if !expr.is_empty() {
+                        let now_secs = chrono::Utc::now().timestamp() as u64;
                         let pctx = self.registry.as_ref().map(|reg| {
                             crate::policy::context::ProductionPolicyContext::new(
                                 reg.as_ref(),
                                 self.budget.as_ref(),
                                 *ctx.agent_id.as_bytes(),
                                 ctx.team_id.clone(),
+                                now_secs,
                             )
                         });
                         let pctx_dyn: Option<&dyn crate::policy::context::PolicyContext> =
@@ -498,12 +500,14 @@ impl PolicyEngine {
         // the capability guard, and the credential scan always run.
         let epoch = self.policy_epoch.load(Ordering::Relaxed);
         let cache_key = CacheKey::new(ctx.agent_id.as_bytes(), epoch, action);
+        let now_secs = chrono::Utc::now().timestamp() as u64;
         let pctx = self.registry.as_ref().map(|reg| {
             crate::policy::context::ProductionPolicyContext::new(
                 reg.as_ref(),
                 self.budget.as_ref(),
                 *ctx.agent_id.as_bytes(),
                 ctx.team_id.clone(),
+                now_secs,
             )
         });
         let pctx_dyn: Option<&dyn crate::policy::context::PolicyContext> = pctx.as_ref().map(|c| c as _);

--- a/aa-gateway/src/policy/context.rs
+++ b/aa-gateway/src/policy/context.rs
@@ -19,6 +19,8 @@ pub struct ProductionPolicyContext<'a> {
     /// Proposed risk tier of the child agent being spawned (from the spawn
     /// request payload). `None` when the evaluation is not for a spawn action.
     proposed_child_risk_tier: Option<aa_core::RiskTier>,
+    /// Unix timestamp in seconds captured at context construction time, used to compute agent.age.
+    now_secs: u64,
 }
 
 impl<'a> ProductionPolicyContext<'a> {
@@ -27,6 +29,7 @@ impl<'a> ProductionPolicyContext<'a> {
         budget: &'a BudgetTracker,
         agent_key: [u8; 16],
         team_id: Option<String>,
+        now_secs: u64,
     ) -> Self {
         Self {
             registry,
@@ -34,6 +37,7 @@ impl<'a> ProductionPolicyContext<'a> {
             agent_key,
             team_id,
             proposed_child_risk_tier: None,
+            now_secs,
         }
     }
 }
@@ -85,6 +89,12 @@ impl<'a> PolicyContext for ProductionPolicyContext<'a> {
     fn child_risk_tier(&self) -> Option<aa_core::RiskTier> {
         self.proposed_child_risk_tier
     }
+
+    fn agent_age_secs(&self) -> Option<u64> {
+        let record = self.registry.get(&self.agent_key)?;
+        let registered_unix = record.registered_at.timestamp() as u64;
+        Some(self.now_secs.saturating_sub(registered_unix))
+    }
 }
 
 /// Minimal test double for [`PolicyContext`] that returns canned values.
@@ -97,6 +107,7 @@ pub struct FakePolicyContext {
     pub agent_risk_tier: Option<aa_core::RiskTier>,
     pub parent_risk_tier: Option<aa_core::RiskTier>,
     pub child_risk_tier: Option<aa_core::RiskTier>,
+    pub agent_age_secs: Option<u64>,
 }
 
 #[cfg(test)]
@@ -127,6 +138,10 @@ impl PolicyContext for FakePolicyContext {
 
     fn child_risk_tier(&self) -> Option<aa_core::RiskTier> {
         self.child_risk_tier
+    }
+
+    fn agent_age_secs(&self) -> Option<u64> {
+        self.agent_age_secs
     }
 }
 
@@ -179,4 +194,7 @@ pub trait PolicyContext: Send + Sync {
     /// spawn action payload. Returns `None` when the evaluation is not for a
     /// spawn action or no tier was specified.
     fn child_risk_tier(&self) -> Option<aa_core::RiskTier>;
+    /// Age of the current agent in seconds, computed as `now_secs - registered_at`.
+    /// Returns `None` when the agent is not found in the registry.
+    fn agent_age_secs(&self) -> Option<u64>;
 }

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -97,6 +97,8 @@ enum LiteralVal {
     Level(GovernanceLevel),
     Tier(aa_core::RiskTier),
     StrList(Vec<String>),
+    /// Duration in seconds, parsed from human-readable strings like `24h`, `30m`.
+    Duration(u64),
 }
 
 #[derive(Debug, PartialEq)]
@@ -639,8 +641,8 @@ fn eval_clause_safe(
                 }
             }
             LiteralVal::Str(rhs) => lhs == rhs.as_str(),
-            // A level/tier/list literal against a non-level/tier/list field cannot match.
-            LiteralVal::Level(_) | LiteralVal::Tier(_) | LiteralVal::StrList(_) => false,
+            // A level/tier/list/duration literal against a generic string field cannot match.
+            LiteralVal::Level(_) | LiteralVal::Tier(_) | LiteralVal::StrList(_) | LiteralVal::Duration(_) => false,
         },
         OpKind::Ne => match literal {
             LiteralVal::Num(rhs) => {
@@ -651,9 +653,9 @@ fn eval_clause_safe(
                 }
             }
             LiteralVal::Str(rhs) => lhs != rhs.as_str(),
-            // A level/tier/list literal against a generic string field is unconditionally
+            // A level/tier/list/duration literal against a generic string field is unconditionally
             // not-equal — matches the symmetric `Eq` handling above.
-            LiteralVal::Level(_) | LiteralVal::Tier(_) | LiteralVal::StrList(_) => true,
+            LiteralVal::Level(_) | LiteralVal::Tier(_) | LiteralVal::StrList(_) | LiteralVal::Duration(_) => true,
         },
         OpKind::Gt => {
             let rhs = numeric_literal(literal);
@@ -694,6 +696,8 @@ fn numeric_literal(lit: &LiteralVal) -> Option<f64> {
     match lit {
         LiteralVal::Num(n) => Some(*n),
         LiteralVal::Str(s) => s.parse::<f64>().ok(),
+        // Duration participates in numeric comparisons (as seconds).
+        LiteralVal::Duration(secs) => Some(*secs as f64),
         // Level, tier, and list literals never participate in numeric comparisons.
         LiteralVal::Level(_) | LiteralVal::Tier(_) | LiteralVal::StrList(_) => None,
     }

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -51,6 +51,7 @@ pub(crate) const KNOWN_VARIABLES: &[&str] = &[
     "target.team_id",
     "target.channel_id",
     "agent.age",
+    "team.parallel_agents",
 ];
 
 // ---------------------------------------------------------------------------
@@ -76,6 +77,7 @@ enum FieldRef {
     TargetTeamId,
     TargetChannelId,
     AgentAge,
+    TeamParallelAgents,
 }
 
 #[derive(Debug, PartialEq)]
@@ -263,6 +265,7 @@ fn tokenize(expr: &str) -> Option<Vec<Token>> {
                 "target.team_id" => Token::Field(FieldRef::TargetTeamId),
                 "target.channel_id" => Token::Field(FieldRef::TargetChannelId),
                 "agent.age" => Token::Field(FieldRef::AgentAge),
+                "team.parallel_agents" => Token::Field(FieldRef::TeamParallelAgents),
                 "L0" => Token::Literal(LiteralVal::Level(GovernanceLevel::L0Discover)),
                 "L1" => Token::Literal(LiteralVal::Level(GovernanceLevel::L1Observe)),
                 "L2" => Token::Literal(LiteralVal::Level(GovernanceLevel::L2Enforce)),

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -488,6 +488,29 @@ fn eval_clause_safe(
         };
     }
 
+    // team.parallel_agents — integer count of currently-running agents in the current team.
+    // Semantically equivalent to team.active_agents; delegates to the same registry query.
+    // Returns false (null-safe no-match) when the agent has no team.
+    if let FieldRef::TeamParallelAgents = field {
+        let lhs = match policy_ctx.and_then(|c| c.team_active_agents()) {
+            Some(n) => n as f64,
+            None => return false,
+        };
+        let rhs = match numeric_literal(literal) {
+            Some(r) => r,
+            None => return false,
+        };
+        return match op {
+            OpKind::Eq => lhs == rhs,
+            OpKind::Ne => lhs != rhs,
+            OpKind::Gt => lhs > rhs,
+            OpKind::Gte => lhs >= rhs,
+            OpKind::Lt => lhs < rhs,
+            OpKind::Lte => lhs <= rhs,
+            OpKind::Contains | OpKind::StartsWith => false,
+        };
+    }
+
     // agent.age — numeric (seconds) comparison against the current agent's age since registration.
     // Compares the agent's age in seconds against a Duration literal (e.g. `24h` = 86400s).
     // Returns false (null-safe no-match) when context or registry lookup is absent.

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -485,6 +485,29 @@ fn eval_clause_safe(
         };
     }
 
+    // agent.age — numeric (seconds) comparison against the current agent's age since registration.
+    // Compares the agent's age in seconds against a Duration literal (e.g. `24h` = 86400s).
+    // Returns false (null-safe no-match) when context or registry lookup is absent.
+    if let FieldRef::AgentAge = field {
+        let lhs = match policy_ctx.and_then(|c| c.agent_age_secs()) {
+            Some(age) => age as f64,
+            None => return false,
+        };
+        let rhs = match numeric_literal(literal) {
+            Some(r) => r,
+            None => return false,
+        };
+        return match op {
+            OpKind::Eq => lhs == rhs,
+            OpKind::Ne => lhs != rhs,
+            OpKind::Gt => lhs > rhs,
+            OpKind::Gte => lhs >= rhs,
+            OpKind::Lt => lhs < rhs,
+            OpKind::Lte => lhs <= rhs,
+            OpKind::Contains | OpKind::StartsWith => false,
+        };
+    }
+
     // source.team_id — string equality against the sending agent's team ID.
     // Returns false (null-safe no-match) when the action is not SendMessage or
     // the source_team_id field is None.

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -276,6 +276,14 @@ fn tokenize(expr: &str) -> Option<Vec<Token>> {
                     // Try to parse as a number
                     if let Ok(n) = other.parse::<f64>() {
                         Token::Literal(LiteralVal::Num(n))
+                    } else if other.chars().next().map(|c| c.is_ascii_digit()).unwrap_or(false) {
+                        // Try to parse as a humantime duration (e.g. "24h", "30m", "1h30m").
+                        // Only attempt when the word starts with a digit — avoids false positives.
+                        if let Ok(d) = humantime::parse_duration(other) {
+                            Token::Literal(LiteralVal::Duration(d.as_secs()))
+                        } else {
+                            return None;
+                        }
                     } else {
                         return None; // unknown word
                     }

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -50,6 +50,7 @@ pub(crate) const KNOWN_VARIABLES: &[&str] = &[
     "source.team_id",
     "target.team_id",
     "target.channel_id",
+    "agent.age",
 ];
 
 // ---------------------------------------------------------------------------
@@ -74,6 +75,7 @@ enum FieldRef {
     SourceTeamId,
     TargetTeamId,
     TargetChannelId,
+    AgentAge,
 }
 
 #[derive(Debug, PartialEq)]
@@ -260,6 +262,7 @@ fn tokenize(expr: &str) -> Option<Vec<Token>> {
                 "source.team_id" => Token::Field(FieldRef::SourceTeamId),
                 "target.team_id" => Token::Field(FieldRef::TargetTeamId),
                 "target.channel_id" => Token::Field(FieldRef::TargetChannelId),
+                "agent.age" => Token::Field(FieldRef::AgentAge),
                 "L0" => Token::Literal(LiteralVal::Level(GovernanceLevel::L0Discover)),
                 "L1" => Token::Literal(LiteralVal::Level(GovernanceLevel::L1Observe)),
                 "L2" => Token::Literal(LiteralVal::Level(GovernanceLevel::L2Enforce)),

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -507,7 +507,7 @@ fn eval_clause_safe(
             OpKind::Gte => lhs >= rhs,
             OpKind::Lt => lhs < rhs,
             OpKind::Lte => lhs <= rhs,
-            OpKind::Contains | OpKind::StartsWith => false,
+            OpKind::Contains | OpKind::StartsWith | OpKind::In | OpKind::NotIn => false,
         };
     }
 
@@ -530,7 +530,7 @@ fn eval_clause_safe(
             OpKind::Gte => lhs >= rhs,
             OpKind::Lt => lhs < rhs,
             OpKind::Lte => lhs <= rhs,
-            OpKind::Contains | OpKind::StartsWith => false,
+            OpKind::Contains | OpKind::StartsWith | OpKind::In | OpKind::NotIn => false,
         };
     }
 
@@ -1363,6 +1363,7 @@ mod tests {
             agent_risk_tier: None,
             parent_risk_tier: None,
             child_risk_tier: child,
+            agent_age_secs: None,
         }
     }
 
@@ -1453,6 +1454,7 @@ mod tests {
             child_tools: vec![],
             agent_risk_tier: None,
             parent_risk_tier: None,
+            child_risk_tier: None,
             agent_age_secs: age_secs,
         }
     }
@@ -1480,6 +1482,7 @@ mod tests {
             child_tools: vec![],
             agent_risk_tier: None,
             parent_risk_tier: None,
+            child_risk_tier: None,
             agent_age_secs: None,
         };
         assert!(evaluate("team.parallel_agents > 5", &tool("any"), None, Some(&ctx)));

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -1443,6 +1443,53 @@ mod tests {
         }
     }
 
+    // ── agent.age and team.parallel_agents tests ─────────────────────────────
+
+    fn fake_age_ctx(age_secs: Option<u64>) -> crate::policy::context::FakePolicyContext {
+        crate::policy::context::FakePolicyContext {
+            depth: None,
+            team_active: None,
+            team_budget: None,
+            child_tools: vec![],
+            agent_risk_tier: None,
+            parent_risk_tier: None,
+            agent_age_secs: age_secs,
+        }
+    }
+
+    #[test]
+    fn agent_age_gt_24h_fires_when_agent_is_old() {
+        // 25 hours old → 90000 s; rule threshold is 24h = 86400 s
+        let ctx = fake_age_ctx(Some(90_000));
+        assert!(evaluate("agent.age > 24h", &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn agent_age_gt_24h_no_match_when_agent_is_young() {
+        // 10 hours old → 36000 s; does not exceed 24h
+        let ctx = fake_age_ctx(Some(36_000));
+        assert!(!evaluate("agent.age > 24h", &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn team_parallel_agents_gt_matches() {
+        let ctx = crate::policy::context::FakePolicyContext {
+            depth: None,
+            team_active: Some(8),
+            team_budget: None,
+            child_tools: vec![],
+            agent_risk_tier: None,
+            parent_risk_tier: None,
+            agent_age_secs: None,
+        };
+        assert!(evaluate("team.parallel_agents > 5", &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn null_safety_agent_age_returns_false_without_context() {
+        assert!(!evaluate("agent.age > 24h", &tool("any"), None, None));
+    }
+
     // ── inter-team message condition tests ───────────────────────────────────
 
     fn send_message(source: Option<&str>, target: Option<&str>, channel: Option<&str>) -> GovernanceAction {

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -1124,6 +1124,7 @@ mod tests {
             agent_risk_tier: None,
             parent_risk_tier: None,
             child_risk_tier: None,
+            agent_age_secs: None,
         }
     }
 
@@ -1154,6 +1155,7 @@ mod tests {
             agent_risk_tier: None,
             parent_risk_tier: None,
             child_risk_tier: None,
+            agent_age_secs: None,
         }
     }
 
@@ -1178,6 +1180,7 @@ mod tests {
             agent_risk_tier: None,
             parent_risk_tier: None,
             child_risk_tier: None,
+            agent_age_secs: None,
         }
     }
 
@@ -1202,6 +1205,7 @@ mod tests {
             agent_risk_tier: None,
             parent_risk_tier: None,
             child_risk_tier: None,
+            agent_age_secs: None,
         }
     }
 
@@ -1234,6 +1238,7 @@ mod tests {
             agent_risk_tier: None,
             parent_risk_tier: None,
             child_risk_tier: None,
+            agent_age_secs: None,
         };
         assert!(!evaluate("team.active_agents > 0", &tool("any"), None, Some(&ctx)));
     }
@@ -1258,6 +1263,7 @@ mod tests {
             agent_risk_tier: agent,
             parent_risk_tier: parent,
             child_risk_tier: None,
+            agent_age_secs: None,
         }
     }
 

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -1516,3 +1516,94 @@ mod cross_mode_integration {
         assert!(reg.get(&root).is_none(), "root must be removed");
     }
 }
+
+#[cfg(test)]
+mod sweep_aged_agents_tests {
+    use super::*;
+    use crate::registry::AgentStatus;
+
+    fn aged_record(id: [u8; 16], team_id: &str, registered_at: chrono::DateTime<chrono::Utc>) -> AgentRecord {
+        AgentRecord {
+            agent_id: id,
+            name: "test-agent".into(),
+            framework: "test".into(),
+            version: "0.0.1".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key: "deadbeef".into(),
+            credential_token: "tok".into(),
+            metadata: Default::default(),
+            registered_at,
+            last_heartbeat: registered_at,
+            status: AgentStatus::Active,
+            pid: None,
+            session_count: 0,
+            last_event: None,
+            policy_violations_count: 0,
+            active_sessions: vec![],
+            recent_events: Default::default(),
+            recent_traces: vec![],
+            layer: None,
+            governance_level: aa_core::GovernanceLevel::default(),
+            parent_agent_id: None,
+            team_id: Some(team_id.to_owned()),
+            depth: 0,
+            delegation_reason: None,
+            spawned_by_tool: None,
+            root_agent_id: None,
+            children: vec![],
+            parent_key: None,
+        }
+    }
+
+    #[test]
+    fn sweep_deregisters_agent_exceeding_max_age() {
+        let reg = AgentRegistry::new();
+        let id = [1u8; 16];
+        // Agent registered 2 hours ago; max age is 1 hour.
+        let registered_at = chrono::Utc::now() - chrono::Duration::hours(2);
+        let record = aged_record(id, "team-alpha", registered_at);
+        reg.register(record).unwrap();
+        reg.set_team_max_age("team-alpha", 3600); // 1 hour
+
+        let now_secs = chrono::Utc::now().timestamp() as u64;
+        let evicted = reg.sweep_aged_agents(now_secs);
+
+        assert_eq!(evicted.len(), 1, "exactly one agent should be evicted");
+        assert_eq!(evicted[0], id);
+        assert_eq!(reg.get(&id).unwrap().status, AgentStatus::Deregistered);
+    }
+
+    #[test]
+    fn sweep_leaves_young_agent_active() {
+        let reg = AgentRegistry::new();
+        let id = [2u8; 16];
+        // Agent registered 30 minutes ago; max age is 1 hour.
+        let registered_at = chrono::Utc::now() - chrono::Duration::minutes(30);
+        let record = aged_record(id, "team-beta", registered_at);
+        reg.register(record).unwrap();
+        reg.set_team_max_age("team-beta", 3600);
+
+        let now_secs = chrono::Utc::now().timestamp() as u64;
+        let evicted = reg.sweep_aged_agents(now_secs);
+
+        assert!(evicted.is_empty(), "young agent must not be evicted");
+        assert_eq!(reg.get(&id).unwrap().status, AgentStatus::Active);
+    }
+
+    #[test]
+    fn sweep_ignores_agents_without_team_max_age_config() {
+        let reg = AgentRegistry::new();
+        let id = [3u8; 16];
+        let registered_at = chrono::Utc::now() - chrono::Duration::days(365);
+        let record = aged_record(id, "team-gamma", registered_at);
+        reg.register(record).unwrap();
+        // No set_team_max_age call for team-gamma.
+
+        let now_secs = chrono::Utc::now().timestamp() as u64;
+        let evicted = reg.sweep_aged_agents(now_secs);
+
+        assert!(evicted.is_empty(), "unconfigured team must not trigger eviction");
+        assert_eq!(reg.get(&id).unwrap().status, AgentStatus::Active);
+    }
+}

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -419,6 +419,36 @@ impl AgentRegistry {
         self.agents.iter().map(|r| r.value().clone()).collect()
     }
 
+    /// Deregister any active agent whose age (now_secs - registered_at) exceeds the
+    /// maximum configured for its team via [`set_team_max_age`].
+    ///
+    /// Returns the agent keys of every agent that was force-deregistered so callers
+    /// can emit [`aa_core::AuditEventType::AgentForceDeregistered`] events.
+    pub fn sweep_aged_agents(&self, now_secs: u64) -> Vec<[u8; 16]> {
+        let mut evicted = Vec::new();
+        for entry in self.agents.iter() {
+            let record = entry.value();
+            if !matches!(record.status, AgentStatus::Active) {
+                continue;
+            }
+            let Some(team_id) = &record.team_id else { continue };
+            let Some(max_secs) = self.team_max_age_secs.get(team_id.as_str()).map(|v| *v) else {
+                continue;
+            };
+            let registered_unix = record.registered_at.timestamp() as u64;
+            let age_secs = now_secs.saturating_sub(registered_unix);
+            if age_secs > max_secs {
+                evicted.push(*entry.key());
+            }
+        }
+        for key in &evicted {
+            if let Some(mut entry) = self.agents.get_mut(key) {
+                entry.status = AgentStatus::Deregistered;
+            }
+        }
+        evicted
+    }
+
     /// Return the scope lineage (org, team) for `agent_id` by reading the
     /// `"org_id"` and `"team_id"` metadata keys written at registration.
     ///

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -147,6 +147,9 @@ pub struct AgentRegistry {
     /// an agent suspended for BudgetExceeded retains that reason when also
     /// suspended via ParentSuspended cascade.
     suspend_reasons: DashMap<[u8; 16], Vec<super::SuspendReason>>,
+    /// Per-team maximum agent age in seconds. Agents older than this threshold
+    /// are force-deregistered by `sweep_aged_agents`.
+    team_max_age_secs: DashMap<String, u64>,
 }
 
 impl AgentRegistry {
@@ -158,7 +161,13 @@ impl AgentRegistry {
             team_index: DashMap::new(),
             registration_lock: Mutex::new(()),
             suspend_reasons: DashMap::new(),
+            team_max_age_secs: DashMap::new(),
         }
+    }
+
+    /// Configure the maximum allowed age (in seconds) for agents belonging to `team_id`.
+    pub fn set_team_max_age(&self, team_id: &str, max_secs: u64) {
+        self.team_max_age_secs.insert(team_id.to_owned(), max_secs);
     }
 
     /// Validate that registering `agent_id` with `parent_key` does not introduce a cycle

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -2,11 +2,17 @@
 
 use std::collections::BTreeMap;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use chrono::Utc;
+use tokio::sync::{mpsc, Mutex};
 use tonic::{Request, Response, Status};
 
+use aa_core::identity::{AgentId, SessionId};
+use aa_core::time::Timestamp;
+use aa_core::{AuditEntry, AuditEventType};
 use aa_proto::assembly::agent::v1::agent_lifecycle_service_server::AgentLifecycleService;
 use aa_proto::assembly::agent::v1::{
     ControlCommand, ControlStreamRequest, DeregisterRequest, DeregisterResponse, HeartbeatRequest, HeartbeatResponse,
@@ -29,6 +35,11 @@ const DEFAULT_HEARTBEAT_INTERVAL_SEC: i64 = 30;
 pub struct AgentLifecycleServiceImpl {
     registry: Arc<AgentRegistry>,
     policy_engine: Option<Arc<PolicyEngine>>,
+    /// Optional channel for emitting `AgentForceDeregistered` audit entries when
+    /// `sweep_aged_agents` evicts agents during heartbeat processing.
+    audit_tx: Option<mpsc::Sender<AuditEntry>>,
+    audit_seq: Arc<AtomicU64>,
+    audit_last_hash: Arc<Mutex<[u8; 32]>>,
 }
 
 impl AgentLifecycleServiceImpl {
@@ -37,6 +48,9 @@ impl AgentLifecycleServiceImpl {
         Self {
             registry,
             policy_engine: None,
+            audit_tx: None,
+            audit_seq: Arc::new(AtomicU64::new(0)),
+            audit_last_hash: Arc::new(Mutex::new([0u8; 32])),
         }
     }
 
@@ -48,7 +62,17 @@ impl AgentLifecycleServiceImpl {
         Self {
             registry,
             policy_engine: Some(policy_engine),
+            audit_tx: None,
+            audit_seq: Arc::new(AtomicU64::new(0)),
+            audit_last_hash: Arc::new(Mutex::new([0u8; 32])),
         }
+    }
+
+    /// Attach an audit channel so `sweep_aged_agents` evictions emit
+    /// `AgentForceDeregistered` audit entries during heartbeat processing.
+    pub fn with_audit_tx(mut self, audit_tx: mpsc::Sender<AuditEntry>) -> Self {
+        self.audit_tx = Some(audit_tx);
+        self
     }
 }
 
@@ -208,6 +232,31 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
         };
 
         tracing::debug!(agent_id = ?proto_id.agent_id, should_suspend, "heartbeat received");
+
+        // Piggyback TTL sweep on every heartbeat: deregister agents past max_agent_age
+        // and emit AgentForceDeregistered audit entries when an audit channel is wired in.
+        let now_secs = Utc::now().timestamp() as u64;
+        let evicted = self.registry.sweep_aged_agents(now_secs);
+        if !evicted.is_empty() {
+            if let Some(ref tx) = self.audit_tx {
+                let timestamp_ns = Timestamp::from(SystemTime::now()).as_nanos();
+                let mut last_hash = self.audit_last_hash.lock().await;
+                for key in &evicted {
+                    let seq = self.audit_seq.fetch_add(1, Ordering::Relaxed);
+                    let entry = AuditEntry::new(
+                        seq,
+                        timestamp_ns,
+                        AuditEventType::AgentForceDeregistered,
+                        AgentId::from_bytes(*key),
+                        SessionId::from_bytes([0u8; 16]),
+                        r#"{"reason":"age_exceeded"}"#.to_owned(),
+                        *last_hash,
+                    );
+                    *last_hash = *entry.entry_hash();
+                    let _ = tx.try_send(entry);
+                }
+            }
+        }
 
         Ok(Response::new(HeartbeatResponse {
             policy_updated: false,

--- a/aa-gateway/tests/lifecycle_service_test.rs
+++ b/aa-gateway/tests/lifecycle_service_test.rs
@@ -690,6 +690,166 @@ async fn root_agent_id_chains_3_levels() {
     );
 }
 
+// ── TTL / sweep integration tests ─────────────────────────────────────────
+
+/// Shared helper: start a server with an audit channel wired in.
+/// Returns (addr, registry, audit_rx).
+async fn start_server_with_audit() -> (
+    SocketAddr,
+    Arc<AgentRegistry>,
+    tokio::sync::mpsc::Receiver<aa_core::AuditEntry>,
+) {
+    let registry = Arc::new(AgentRegistry::new());
+    let (audit_tx, audit_rx) = tokio::sync::mpsc::channel::<aa_core::AuditEntry>(64);
+    let service = AgentLifecycleServiceImpl::new(Arc::clone(&registry)).with_audit_tx(audit_tx);
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(AgentLifecycleServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    (addr, registry, audit_rx)
+}
+
+/// Helper: build a minimal AgentRecord with controllable registered_at.
+fn aged_record_for_test(
+    agent_key: [u8; 16],
+    team_id: &str,
+    registered_at: chrono::DateTime<chrono::Utc>,
+) -> aa_gateway::AgentRecord {
+    use std::collections::BTreeMap;
+    aa_gateway::AgentRecord {
+        agent_id: agent_key,
+        name: "ttl-test-agent".into(),
+        framework: "test".into(),
+        version: "0.0.1".into(),
+        risk_tier: 0,
+        tool_names: vec![],
+        public_key: test_ed25519_public_key_hex(),
+        credential_token: "sweep-test-token".into(),
+        metadata: BTreeMap::new(),
+        registered_at,
+        last_heartbeat: registered_at,
+        status: aa_gateway::AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
+        policy_violations_count: 0,
+        active_sessions: vec![],
+        recent_events: Default::default(),
+        recent_traces: vec![],
+        layer: None,
+        governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: Some(team_id.to_owned()),
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: Some(agent_key),
+        children: vec![],
+        parent_key: None,
+    }
+}
+
+/// Heartbeat triggers sweep and deregisters agents past max_agent_age.
+#[tokio::test]
+async fn heartbeat_triggers_sweep_and_deregisters_aged_agent() {
+    use aa_gateway::registry::convert::proto_agent_id_to_key;
+
+    let (addr, registry, _audit_rx) = start_server_with_audit().await;
+    let mut client = AgentLifecycleServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    // Insert an agent registered 2 hours ago; max age is 1 hour.
+    let proto_id = ProtoAgentId {
+        org_id: "org-sweep".into(),
+        team_id: "team-sweep".into(),
+        agent_id: "aged-agent".into(),
+    };
+    let agent_key = proto_agent_id_to_key(&proto_id);
+    let registered_at = chrono::Utc::now() - chrono::Duration::hours(2);
+    let record = aged_record_for_test(agent_key, "team-sweep", registered_at);
+    registry.register(record).unwrap();
+    registry.set_team_max_age("team-sweep", 3600); // 1 hour
+
+    // Send a heartbeat on behalf of the aged agent. This triggers sweep.
+    client
+        .heartbeat(HeartbeatRequest {
+            agent_id: Some(proto_id.clone()),
+            credential_token: "sweep-test-token".into(),
+            active_runs: 0,
+            actions_count: 0,
+        })
+        .await
+        .unwrap();
+
+    // After the heartbeat, the agent must be Deregistered.
+    assert_eq!(
+        registry.get(&agent_key).unwrap().status,
+        aa_gateway::AgentStatus::Deregistered,
+        "aged agent must be deregistered by sweep during heartbeat"
+    );
+}
+
+/// Heartbeat sweep emits AgentForceDeregistered audit entry for each evicted agent.
+#[tokio::test]
+async fn heartbeat_sweep_emits_audit_event_for_aged_agent() {
+    use aa_core::AuditEventType;
+    use aa_gateway::registry::convert::proto_agent_id_to_key;
+
+    let (addr, registry, mut audit_rx) = start_server_with_audit().await;
+    let mut client = AgentLifecycleServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let proto_id = ProtoAgentId {
+        org_id: "org-audit".into(),
+        team_id: "team-audit".into(),
+        agent_id: "audit-aged-agent".into(),
+    };
+    let agent_key = proto_agent_id_to_key(&proto_id);
+    let registered_at = chrono::Utc::now() - chrono::Duration::hours(3);
+    let record = aged_record_for_test(agent_key, "team-audit", registered_at);
+    registry.register(record).unwrap();
+    registry.set_team_max_age("team-audit", 3600); // 1 hour
+
+    client
+        .heartbeat(HeartbeatRequest {
+            agent_id: Some(proto_id),
+            credential_token: "sweep-test-token".into(),
+            active_runs: 0,
+            actions_count: 0,
+        })
+        .await
+        .unwrap();
+
+    // Expect exactly one AgentForceDeregistered audit entry.
+    let entry = tokio::time::timeout(std::time::Duration::from_secs(1), audit_rx.recv())
+        .await
+        .expect("timeout waiting for audit entry")
+        .expect("audit channel closed");
+
+    assert_eq!(
+        entry.event_type(),
+        AuditEventType::AgentForceDeregistered,
+        "expected AgentForceDeregistered event"
+    );
+    assert!(
+        entry.payload().contains("age_exceeded"),
+        "payload must include reason: {}",
+        entry.payload()
+    );
+}
+
 #[tokio::test]
 async fn root_agent_id_when_parent_unknown_returns_invalid_argument() {
     let (addr, _registry) = start_server().await;


### PR DESCRIPTION
## What changed

Adds the `agent.age` duration-comparison variable and a background sweep mechanism for force-deregistering agents that exceed their team TTL.

- Added `LiteralVal::Duration(u64)` variant; tokenizer detects duration strings (e.g. `24h`, `30m`) via `humantime::parse_duration()`
- Added `humantime = "2"` dependency to `aa-gateway/Cargo.toml`
- Added `FieldRef::AgentAge` and `FieldRef::TeamParallelAgents` variants
- Added `agent_age_secs: u64` field to `ProductionPolicyContext`; updated constructor to 5 args; captured `now_secs = chrono::Utc::now().timestamp() as u64` at both `evaluate()` call sites in `aa-gateway/src/engine/mod.rs`
- Implemented `agent_age_secs()` trait method on `ProductionPolicyContext` and `FakePolicyContext`
- `eval_clause_safe` handles `agent.age` numeric and duration comparisons; `team.parallel_agents` delegates to `team_active_agents()`
- Added `AuditEventType::AgentForceDeregistered = 11` to `aa-core/src/audit.rs`
- Added `AgentRegistry::sweep_aged_agents(now_secs)` and `team_max_age_secs: DashMap` field to `aa-gateway/src/registry/store.rs`
- Unit tests for age comparison with numeric seconds and duration literals

## Why

Operators need to enforce agent TTL policies (e.g. automatically expire sandbox agents after 24 h) both as a condition variable in YAML rules and as a proactive registry sweep. Depends on AAASM-1017.

## How to verify

```
cargo nextest run -p aa-gateway
cargo nextest run -p aa-core audit
```

Closes #AAASM-1020