### PR TITLE
[AAASM-1037] 📝 (aa-cli/topology/overview): Add --help usage examples per AC

### DIFF
--- a/aa-cli/src/commands/topology/overview.rs
+++ b/aa-cli/src/commands/topology/overview.rs
@@ -12,6 +12,11 @@ use crate::output::OutputFormat;
 
 /// Arguments for `aasm topology overview`.
 #[derive(Args)]
+#[command(after_help = "\
+Examples:
+  aasm topology overview
+  aasm topology overview --output json
+  aasm topology overview --status active")]
 pub struct OverviewArgs {
     /// Filter agents by status (active, suspended, deregistered).
     #[arg(long)]


### PR DESCRIPTION
## Summary
- Adds `#[command(after_help)]` to `OverviewArgs` with three example invocations, satisfying the AAASM-1037 AC requirement that `--help` text includes a usage example.

## Why it changed
This gap was missed during the original AAASM-1037 PR (#282). Identical fixes were applied to AAASM-1040 (team), AAASM-1042 (lineage), and AAASM-1044 (stats) in their respective PRs.

## How to verify
\`\`\`bash
aasm topology overview --help
# Expect: "Examples:" section at the bottom with three invocation lines
\`\`\`

Closes AAASM-1037