### PR TITLE
[AAASM-1272] 🐛 (policy/expr): Add 5 missing AAASM-225 topology variables

### DIFF
--- a/aa-gateway/src/policy/context.rs
+++ b/aa-gateway/src/policy/context.rs
@@ -112,6 +112,7 @@ impl<'a> PolicyContext for ProductionPolicyContext<'a> {
 
 /// Minimal test double for [`PolicyContext`] that returns canned values.
 #[cfg(test)]
+#[derive(Default)]
 pub struct FakePolicyContext {
     pub depth: Option<u32>,
     pub team_active: Option<u64>,

--- a/aa-gateway/src/policy/context.rs
+++ b/aa-gateway/src/policy/context.rs
@@ -95,6 +95,19 @@ impl<'a> PolicyContext for ProductionPolicyContext<'a> {
         let registered_unix = record.registered_at.timestamp() as u64;
         Some(self.now_secs.saturating_sub(registered_unix))
     }
+
+    fn agent_parent_id(&self) -> Option<String> {
+        self.registry.get(&self.agent_key)?.parent_agent_id.clone()
+    }
+
+    fn agent_team_id(&self) -> Option<String> {
+        self.team_id.clone()
+    }
+
+    fn agent_children_count(&self) -> Option<u32> {
+        let record = self.registry.get(&self.agent_key)?;
+        Some(record.children.len() as u32)
+    }
 }
 
 /// Minimal test double for [`PolicyContext`] that returns canned values.
@@ -108,6 +121,9 @@ pub struct FakePolicyContext {
     pub parent_risk_tier: Option<aa_core::RiskTier>,
     pub child_risk_tier: Option<aa_core::RiskTier>,
     pub agent_age_secs: Option<u64>,
+    pub agent_parent_id: Option<String>,
+    pub agent_team_id: Option<String>,
+    pub agent_children_count: Option<u32>,
 }
 
 #[cfg(test)]
@@ -142,6 +158,18 @@ impl PolicyContext for FakePolicyContext {
 
     fn agent_age_secs(&self) -> Option<u64> {
         self.agent_age_secs
+    }
+
+    fn agent_parent_id(&self) -> Option<String> {
+        self.agent_parent_id.clone()
+    }
+
+    fn agent_team_id(&self) -> Option<String> {
+        self.agent_team_id.clone()
+    }
+
+    fn agent_children_count(&self) -> Option<u32> {
+        self.agent_children_count
     }
 }
 
@@ -197,4 +225,12 @@ pub trait PolicyContext: Send + Sync {
     /// Age of the current agent in seconds, computed as `now_secs - registered_at`.
     /// Returns `None` when the agent is not found in the registry.
     fn agent_age_secs(&self) -> Option<u64>;
+    /// Parent agent ID string of the current agent. Returns `None` when the agent
+    /// has no parent (i.e. it is a root agent).
+    fn agent_parent_id(&self) -> Option<String>;
+    /// Team ID of the current agent. Returns `None` when the agent has no team.
+    fn agent_team_id(&self) -> Option<String>;
+    /// Number of direct children of the current agent. Returns `None` when the
+    /// agent is not found in the registry.
+    fn agent_children_count(&self) -> Option<u32>;
 }

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -1821,37 +1821,67 @@ mod tests {
     #[test]
     fn agent_parent_id_eq_matches_known_parent() {
         let ctx = fake_topology_ctx(Some("parent-abc"), None, None);
-        assert!(evaluate(r#"agent.parent_id == "parent-abc""#, &tool("any"), None, Some(&ctx)));
+        assert!(evaluate(
+            r#"agent.parent_id == "parent-abc""#,
+            &tool("any"),
+            None,
+            Some(&ctx)
+        ));
     }
 
     #[test]
     fn agent_parent_id_eq_no_match_different_parent() {
         let ctx = fake_topology_ctx(Some("parent-xyz"), None, None);
-        assert!(!evaluate(r#"agent.parent_id == "parent-abc""#, &tool("any"), None, Some(&ctx)));
+        assert!(!evaluate(
+            r#"agent.parent_id == "parent-abc""#,
+            &tool("any"),
+            None,
+            Some(&ctx)
+        ));
     }
 
     #[test]
     fn agent_parent_id_null_safe_when_no_parent() {
         let ctx = fake_topology_ctx(None, None, None);
-        assert!(!evaluate(r#"agent.parent_id == "parent-abc""#, &tool("any"), None, Some(&ctx)));
+        assert!(!evaluate(
+            r#"agent.parent_id == "parent-abc""#,
+            &tool("any"),
+            None,
+            Some(&ctx)
+        ));
     }
 
     #[test]
     fn agent_team_id_eq_matches_known_team() {
         let ctx = fake_topology_ctx(None, Some("team-alpha"), None);
-        assert!(evaluate(r#"agent.team_id == "team-alpha""#, &tool("any"), None, Some(&ctx)));
+        assert!(evaluate(
+            r#"agent.team_id == "team-alpha""#,
+            &tool("any"),
+            None,
+            Some(&ctx)
+        ));
     }
 
     #[test]
     fn agent_team_id_eq_no_match_different_team() {
         let ctx = fake_topology_ctx(None, Some("team-beta"), None);
-        assert!(!evaluate(r#"agent.team_id == "team-alpha""#, &tool("any"), None, Some(&ctx)));
+        assert!(!evaluate(
+            r#"agent.team_id == "team-alpha""#,
+            &tool("any"),
+            None,
+            Some(&ctx)
+        ));
     }
 
     #[test]
     fn agent_team_id_null_safe_when_no_team() {
         let ctx = fake_topology_ctx(None, None, None);
-        assert!(!evaluate(r#"agent.team_id == "team-alpha""#, &tool("any"), None, Some(&ctx)));
+        assert!(!evaluate(
+            r#"agent.team_id == "team-alpha""#,
+            &tool("any"),
+            None,
+            Some(&ctx)
+        ));
     }
 
     #[test]

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -1260,16 +1260,7 @@ mod tests {
     fn fake_ctx(depth: Option<u32>) -> crate::policy::context::FakePolicyContext {
         crate::policy::context::FakePolicyContext {
             depth,
-            team_active: None,
-            team_budget: None,
-            child_tools: vec![],
-            agent_risk_tier: None,
-            parent_risk_tier: None,
-            child_risk_tier: None,
-            agent_age_secs: None,
-            agent_parent_id: None,
-            agent_team_id: None,
-            agent_children_count: None,
+            ..Default::default()
         }
     }
 
@@ -1293,17 +1284,8 @@ mod tests {
 
     fn fake_team_ctx(active: Option<u64>) -> crate::policy::context::FakePolicyContext {
         crate::policy::context::FakePolicyContext {
-            depth: None,
             team_active: active,
-            team_budget: None,
-            child_tools: vec![],
-            agent_risk_tier: None,
-            parent_risk_tier: None,
-            child_risk_tier: None,
-            agent_age_secs: None,
-            agent_parent_id: None,
-            agent_team_id: None,
-            agent_children_count: None,
+            ..Default::default()
         }
     }
 
@@ -1321,17 +1303,8 @@ mod tests {
 
     fn fake_budget_ctx(remaining: Option<f64>) -> crate::policy::context::FakePolicyContext {
         crate::policy::context::FakePolicyContext {
-            depth: None,
-            team_active: None,
             team_budget: remaining,
-            child_tools: vec![],
-            agent_risk_tier: None,
-            parent_risk_tier: None,
-            child_risk_tier: None,
-            agent_age_secs: None,
-            agent_parent_id: None,
-            agent_team_id: None,
-            agent_children_count: None,
+            ..Default::default()
         }
     }
 
@@ -1349,17 +1322,8 @@ mod tests {
 
     fn fake_child_ctx(tools: Vec<&str>) -> crate::policy::context::FakePolicyContext {
         crate::policy::context::FakePolicyContext {
-            depth: None,
-            team_active: None,
-            team_budget: None,
             child_tools: tools.into_iter().map(String::from).collect(),
-            agent_risk_tier: None,
-            parent_risk_tier: None,
-            child_risk_tier: None,
-            agent_age_secs: None,
-            agent_parent_id: None,
-            agent_team_id: None,
-            agent_children_count: None,
+            ..Default::default()
         }
     }
 
@@ -1384,19 +1348,7 @@ mod tests {
     #[test]
     fn null_safety_team_active_returns_false_when_no_team() {
         // team_active = None means the agent has no team; condition must not fire.
-        let ctx = crate::policy::context::FakePolicyContext {
-            depth: None,
-            team_active: None,
-            team_budget: None,
-            child_tools: vec![],
-            agent_risk_tier: None,
-            parent_risk_tier: None,
-            child_risk_tier: None,
-            agent_age_secs: None,
-            agent_parent_id: None,
-            agent_team_id: None,
-            agent_children_count: None,
-        };
+        let ctx = crate::policy::context::FakePolicyContext::default();
         assert!(!evaluate("team.active_agents > 0", &tool("any"), None, Some(&ctx)));
     }
 
@@ -1413,17 +1365,9 @@ mod tests {
         parent: Option<aa_core::RiskTier>,
     ) -> crate::policy::context::FakePolicyContext {
         crate::policy::context::FakePolicyContext {
-            depth: None,
-            team_active: None,
-            team_budget: None,
-            child_tools: vec![],
             agent_risk_tier: agent,
             parent_risk_tier: parent,
-            child_risk_tier: None,
-            agent_age_secs: None,
-            agent_parent_id: None,
-            agent_team_id: None,
-            agent_children_count: None,
+            ..Default::default()
         }
     }
 
@@ -1467,17 +1411,8 @@ mod tests {
 
     fn fake_child_tier_ctx(child: Option<aa_core::RiskTier>) -> crate::policy::context::FakePolicyContext {
         crate::policy::context::FakePolicyContext {
-            depth: None,
-            team_active: None,
-            team_budget: None,
-            child_tools: vec![],
-            agent_risk_tier: None,
-            parent_risk_tier: None,
             child_risk_tier: child,
-            agent_age_secs: None,
-            agent_parent_id: None,
-            agent_team_id: None,
-            agent_children_count: None,
+            ..Default::default()
         }
     }
 
@@ -1562,17 +1497,8 @@ mod tests {
 
     fn fake_age_ctx(age_secs: Option<u64>) -> crate::policy::context::FakePolicyContext {
         crate::policy::context::FakePolicyContext {
-            depth: None,
-            team_active: None,
-            team_budget: None,
-            child_tools: vec![],
-            agent_risk_tier: None,
-            parent_risk_tier: None,
-            child_risk_tier: None,
             agent_age_secs: age_secs,
-            agent_parent_id: None,
-            agent_team_id: None,
-            agent_children_count: None,
+            ..Default::default()
         }
     }
 
@@ -1593,17 +1519,8 @@ mod tests {
     #[test]
     fn team_parallel_agents_gt_matches() {
         let ctx = crate::policy::context::FakePolicyContext {
-            depth: None,
             team_active: Some(8),
-            team_budget: None,
-            child_tools: vec![],
-            agent_risk_tier: None,
-            parent_risk_tier: None,
-            child_risk_tier: None,
-            agent_age_secs: None,
-            agent_parent_id: None,
-            agent_team_id: None,
-            agent_children_count: None,
+            ..Default::default()
         };
         assert!(evaluate("team.parallel_agents > 5", &tool("any"), None, Some(&ctx)));
     }
@@ -1780,17 +1697,10 @@ mod tests {
         children_count: Option<u32>,
     ) -> crate::policy::context::FakePolicyContext {
         crate::policy::context::FakePolicyContext {
-            depth: None,
-            team_active: None,
-            team_budget: None,
-            child_tools: vec![],
-            agent_risk_tier: None,
-            parent_risk_tier: None,
-            child_risk_tier: None,
-            agent_age_secs: None,
             agent_parent_id: parent_id.map(String::from),
             agent_team_id: team_id.map(String::from),
             agent_children_count: children_count,
+            ..Default::default()
         }
     }
 
@@ -1882,16 +1792,8 @@ mod tests {
     fn fake_depth_children_ctx(depth: Option<u32>, children: Option<u32>) -> crate::policy::context::FakePolicyContext {
         crate::policy::context::FakePolicyContext {
             depth,
-            team_active: None,
-            team_budget: None,
-            child_tools: vec![],
-            agent_risk_tier: None,
-            parent_risk_tier: None,
-            child_risk_tier: None,
-            agent_age_secs: None,
-            agent_parent_id: None,
-            agent_team_id: None,
             agent_children_count: children,
+            ..Default::default()
         }
     }
 

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -549,11 +549,16 @@ fn eval_clause_safe(
         };
     }
 
-    // agent.parent_id — string comparison against the current agent's parent agent ID.
-    // Returns false when the agent has no parent (null-safe no-match).
-    if let FieldRef::AgentParentId = field {
-        let parent_id = match policy_ctx.and_then(|c| c.agent_parent_id()) {
-            Some(id) => id,
+    // agent.parent_id / agent.team_id — string comparison against an agent identity field.
+    // Returns false when the field resolves to None (null-safe no-match).
+    if matches!(field, FieldRef::AgentParentId | FieldRef::AgentTeamId) {
+        let val = match field {
+            FieldRef::AgentParentId => policy_ctx.and_then(|c| c.agent_parent_id()),
+            FieldRef::AgentTeamId => policy_ctx.and_then(|c| c.agent_team_id()),
+            _ => unreachable!(),
+        };
+        let id = match val {
+            Some(v) => v,
             None => return false,
         };
         let rhs = match literal {
@@ -561,30 +566,10 @@ fn eval_clause_safe(
             _ => return false,
         };
         return match op {
-            OpKind::Eq => parent_id == rhs,
-            OpKind::Ne => parent_id != rhs,
-            OpKind::Contains => parent_id.contains(rhs),
-            OpKind::StartsWith => parent_id.starts_with(rhs),
-            _ => false,
-        };
-    }
-
-    // agent.team_id — string comparison against the current agent's team ID.
-    // Returns false when the agent has no team (null-safe no-match).
-    if let FieldRef::AgentTeamId = field {
-        let team_id = match policy_ctx.and_then(|c| c.agent_team_id()) {
-            Some(id) => id,
-            None => return false,
-        };
-        let rhs = match literal {
-            LiteralVal::Str(s) => s.as_str(),
-            _ => return false,
-        };
-        return match op {
-            OpKind::Eq => team_id == rhs,
-            OpKind::Ne => team_id != rhs,
-            OpKind::Contains => team_id.contains(rhs),
-            OpKind::StartsWith => team_id.starts_with(rhs),
+            OpKind::Eq => id == rhs,
+            OpKind::Ne => id != rhs,
+            OpKind::Contains => id.contains(rhs),
+            OpKind::StartsWith => id.starts_with(rhs),
             _ => false,
         };
     }
@@ -611,42 +596,33 @@ fn eval_clause_safe(
         };
     }
 
-    // agent.is_root — boolean (0/1) indicating whether the agent is a root agent
-    // (depth == 0). Supports only Eq and Ne against numeric 1 or 0.
-    // Returns false when the agent is not found in the registry (null-safe no-match).
-    if let FieldRef::AgentIsRoot = field {
-        let depth = match policy_ctx.and_then(|c| c.agent_depth()) {
-            Some(d) => d,
+    // agent.is_root / agent.is_leaf — boolean (0/1) topology flags.
+    // is_root fires when depth == 0; is_leaf fires when children_count == 0.
+    // Only Eq/Ne against numeric 1 or 0 are meaningful; other ops return false.
+    // Returns false when the backing data is unavailable (null-safe no-match).
+    if matches!(field, FieldRef::AgentIsRoot | FieldRef::AgentIsLeaf) {
+        let flag: Option<bool> = match field {
+            FieldRef::AgentIsRoot => policy_ctx.and_then(|c| c.agent_depth()).map(|d| d == 0),
+            FieldRef::AgentIsLeaf => policy_ctx.and_then(|c| c.agent_children_count()).map(|n| n == 0),
+            _ => unreachable!(),
+        };
+        let lhs = match flag {
+            Some(v) => {
+                if v {
+                    1.0_f64
+                } else {
+                    0.0_f64
+                }
+            }
             None => return false,
         };
-        let is_root = if depth == 0 { 1.0_f64 } else { 0.0_f64 };
         let rhs = match numeric_literal(literal) {
             Some(r) => r,
             None => return false,
         };
         return match op {
-            OpKind::Eq => is_root == rhs,
-            OpKind::Ne => is_root != rhs,
-            _ => false,
-        };
-    }
-
-    // agent.is_leaf — boolean (0/1) indicating whether the agent has no children
-    // (children_count == 0). Supports only Eq and Ne against numeric 1 or 0.
-    // Returns false when the agent is not found in the registry (null-safe no-match).
-    if let FieldRef::AgentIsLeaf = field {
-        let count = match policy_ctx.and_then(|c| c.agent_children_count()) {
-            Some(n) => n,
-            None => return false,
-        };
-        let is_leaf = if count == 0 { 1.0_f64 } else { 0.0_f64 };
-        let rhs = match numeric_literal(literal) {
-            Some(r) => r,
-            None => return false,
-        };
-        return match op {
-            OpKind::Eq => is_leaf == rhs,
-            OpKind::Ne => is_leaf != rhs,
+            OpKind::Eq => lhs == rhs,
+            OpKind::Ne => lhs != rhs,
             _ => false,
         };
     }

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -52,6 +52,11 @@ pub(crate) const KNOWN_VARIABLES: &[&str] = &[
     "target.channel_id",
     "agent.age",
     "team.parallel_agents",
+    "agent.parent_id",
+    "agent.team_id",
+    "agent.children_count",
+    "agent.is_root",
+    "agent.is_leaf",
 ];
 
 // ---------------------------------------------------------------------------
@@ -78,6 +83,11 @@ enum FieldRef {
     TargetChannelId,
     AgentAge,
     TeamParallelAgents,
+    AgentParentId,
+    AgentTeamId,
+    AgentChildrenCount,
+    AgentIsRoot,
+    AgentIsLeaf,
 }
 
 #[derive(Debug, PartialEq)]
@@ -266,6 +276,11 @@ fn tokenize(expr: &str) -> Option<Vec<Token>> {
                 "target.channel_id" => Token::Field(FieldRef::TargetChannelId),
                 "agent.age" => Token::Field(FieldRef::AgentAge),
                 "team.parallel_agents" => Token::Field(FieldRef::TeamParallelAgents),
+                "agent.parent_id" => Token::Field(FieldRef::AgentParentId),
+                "agent.team_id" => Token::Field(FieldRef::AgentTeamId),
+                "agent.children_count" => Token::Field(FieldRef::AgentChildrenCount),
+                "agent.is_root" => Token::Field(FieldRef::AgentIsRoot),
+                "agent.is_leaf" => Token::Field(FieldRef::AgentIsLeaf),
                 "L0" => Token::Literal(LiteralVal::Level(GovernanceLevel::L0Discover)),
                 "L1" => Token::Literal(LiteralVal::Level(GovernanceLevel::L1Observe)),
                 "L2" => Token::Literal(LiteralVal::Level(GovernanceLevel::L2Enforce)),
@@ -531,6 +546,108 @@ fn eval_clause_safe(
             OpKind::Lt => lhs < rhs,
             OpKind::Lte => lhs <= rhs,
             OpKind::Contains | OpKind::StartsWith | OpKind::In | OpKind::NotIn => false,
+        };
+    }
+
+    // agent.parent_id — string comparison against the current agent's parent agent ID.
+    // Returns false when the agent has no parent (null-safe no-match).
+    if let FieldRef::AgentParentId = field {
+        let parent_id = match policy_ctx.and_then(|c| c.agent_parent_id()) {
+            Some(id) => id,
+            None => return false,
+        };
+        let rhs = match literal {
+            LiteralVal::Str(s) => s.as_str(),
+            _ => return false,
+        };
+        return match op {
+            OpKind::Eq => parent_id == rhs,
+            OpKind::Ne => parent_id != rhs,
+            OpKind::Contains => parent_id.contains(rhs),
+            OpKind::StartsWith => parent_id.starts_with(rhs),
+            _ => false,
+        };
+    }
+
+    // agent.team_id — string comparison against the current agent's team ID.
+    // Returns false when the agent has no team (null-safe no-match).
+    if let FieldRef::AgentTeamId = field {
+        let team_id = match policy_ctx.and_then(|c| c.agent_team_id()) {
+            Some(id) => id,
+            None => return false,
+        };
+        let rhs = match literal {
+            LiteralVal::Str(s) => s.as_str(),
+            _ => return false,
+        };
+        return match op {
+            OpKind::Eq => team_id == rhs,
+            OpKind::Ne => team_id != rhs,
+            OpKind::Contains => team_id.contains(rhs),
+            OpKind::StartsWith => team_id.starts_with(rhs),
+            _ => false,
+        };
+    }
+
+    // agent.children_count — numeric comparison against the number of direct children.
+    // Returns false when the agent is not found in the registry (null-safe no-match).
+    if let FieldRef::AgentChildrenCount = field {
+        let lhs = match policy_ctx.and_then(|c| c.agent_children_count()) {
+            Some(n) => n as f64,
+            None => return false,
+        };
+        let rhs = match numeric_literal(literal) {
+            Some(r) => r,
+            None => return false,
+        };
+        return match op {
+            OpKind::Eq => lhs == rhs,
+            OpKind::Ne => lhs != rhs,
+            OpKind::Gt => lhs > rhs,
+            OpKind::Gte => lhs >= rhs,
+            OpKind::Lt => lhs < rhs,
+            OpKind::Lte => lhs <= rhs,
+            OpKind::Contains | OpKind::StartsWith | OpKind::In | OpKind::NotIn => false,
+        };
+    }
+
+    // agent.is_root — boolean (0/1) indicating whether the agent is a root agent
+    // (depth == 0). Supports only Eq and Ne against numeric 1 or 0.
+    // Returns false when the agent is not found in the registry (null-safe no-match).
+    if let FieldRef::AgentIsRoot = field {
+        let depth = match policy_ctx.and_then(|c| c.agent_depth()) {
+            Some(d) => d,
+            None => return false,
+        };
+        let is_root = if depth == 0 { 1.0_f64 } else { 0.0_f64 };
+        let rhs = match numeric_literal(literal) {
+            Some(r) => r,
+            None => return false,
+        };
+        return match op {
+            OpKind::Eq => is_root == rhs,
+            OpKind::Ne => is_root != rhs,
+            _ => false,
+        };
+    }
+
+    // agent.is_leaf — boolean (0/1) indicating whether the agent has no children
+    // (children_count == 0). Supports only Eq and Ne against numeric 1 or 0.
+    // Returns false when the agent is not found in the registry (null-safe no-match).
+    if let FieldRef::AgentIsLeaf = field {
+        let count = match policy_ctx.and_then(|c| c.agent_children_count()) {
+            Some(n) => n,
+            None => return false,
+        };
+        let is_leaf = if count == 0 { 1.0_f64 } else { 0.0_f64 };
+        let rhs = match numeric_literal(literal) {
+            Some(r) => r,
+            None => return false,
+        };
+        return match op {
+            OpKind::Eq => is_leaf == rhs,
+            OpKind::Ne => is_leaf != rhs,
+            _ => false,
         };
     }
 
@@ -1174,6 +1291,9 @@ mod tests {
             parent_risk_tier: None,
             child_risk_tier: None,
             agent_age_secs: None,
+            agent_parent_id: None,
+            agent_team_id: None,
+            agent_children_count: None,
         }
     }
 
@@ -1205,6 +1325,9 @@ mod tests {
             parent_risk_tier: None,
             child_risk_tier: None,
             agent_age_secs: None,
+            agent_parent_id: None,
+            agent_team_id: None,
+            agent_children_count: None,
         }
     }
 
@@ -1230,6 +1353,9 @@ mod tests {
             parent_risk_tier: None,
             child_risk_tier: None,
             agent_age_secs: None,
+            agent_parent_id: None,
+            agent_team_id: None,
+            agent_children_count: None,
         }
     }
 
@@ -1255,6 +1381,9 @@ mod tests {
             parent_risk_tier: None,
             child_risk_tier: None,
             agent_age_secs: None,
+            agent_parent_id: None,
+            agent_team_id: None,
+            agent_children_count: None,
         }
     }
 
@@ -1288,6 +1417,9 @@ mod tests {
             parent_risk_tier: None,
             child_risk_tier: None,
             agent_age_secs: None,
+            agent_parent_id: None,
+            agent_team_id: None,
+            agent_children_count: None,
         };
         assert!(!evaluate("team.active_agents > 0", &tool("any"), None, Some(&ctx)));
     }
@@ -1313,6 +1445,9 @@ mod tests {
             parent_risk_tier: parent,
             child_risk_tier: None,
             agent_age_secs: None,
+            agent_parent_id: None,
+            agent_team_id: None,
+            agent_children_count: None,
         }
     }
 
@@ -1364,6 +1499,9 @@ mod tests {
             parent_risk_tier: None,
             child_risk_tier: child,
             agent_age_secs: None,
+            agent_parent_id: None,
+            agent_team_id: None,
+            agent_children_count: None,
         }
     }
 
@@ -1456,6 +1594,9 @@ mod tests {
             parent_risk_tier: None,
             child_risk_tier: None,
             agent_age_secs: age_secs,
+            agent_parent_id: None,
+            agent_team_id: None,
+            agent_children_count: None,
         }
     }
 
@@ -1484,6 +1625,9 @@ mod tests {
             parent_risk_tier: None,
             child_risk_tier: None,
             agent_age_secs: None,
+            agent_parent_id: None,
+            agent_team_id: None,
+            agent_children_count: None,
         };
         assert!(evaluate("team.parallel_agents > 5", &tool("any"), None, Some(&ctx)));
     }
@@ -1650,5 +1794,141 @@ mod tests {
                 "{literal} did not parse / compare equal for matching agent level"
             );
         }
+    }
+
+    // ── agent.parent_id, agent.team_id, agent.children_count tests ──────────
+
+    fn fake_topology_ctx(
+        parent_id: Option<&str>,
+        team_id: Option<&str>,
+        children_count: Option<u32>,
+    ) -> crate::policy::context::FakePolicyContext {
+        crate::policy::context::FakePolicyContext {
+            depth: None,
+            team_active: None,
+            team_budget: None,
+            child_tools: vec![],
+            agent_risk_tier: None,
+            parent_risk_tier: None,
+            child_risk_tier: None,
+            agent_age_secs: None,
+            agent_parent_id: parent_id.map(String::from),
+            agent_team_id: team_id.map(String::from),
+            agent_children_count: children_count,
+        }
+    }
+
+    #[test]
+    fn agent_parent_id_eq_matches_known_parent() {
+        let ctx = fake_topology_ctx(Some("parent-abc"), None, None);
+        assert!(evaluate(r#"agent.parent_id == "parent-abc""#, &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn agent_parent_id_eq_no_match_different_parent() {
+        let ctx = fake_topology_ctx(Some("parent-xyz"), None, None);
+        assert!(!evaluate(r#"agent.parent_id == "parent-abc""#, &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn agent_parent_id_null_safe_when_no_parent() {
+        let ctx = fake_topology_ctx(None, None, None);
+        assert!(!evaluate(r#"agent.parent_id == "parent-abc""#, &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn agent_team_id_eq_matches_known_team() {
+        let ctx = fake_topology_ctx(None, Some("team-alpha"), None);
+        assert!(evaluate(r#"agent.team_id == "team-alpha""#, &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn agent_team_id_eq_no_match_different_team() {
+        let ctx = fake_topology_ctx(None, Some("team-beta"), None);
+        assert!(!evaluate(r#"agent.team_id == "team-alpha""#, &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn agent_team_id_null_safe_when_no_team() {
+        let ctx = fake_topology_ctx(None, None, None);
+        assert!(!evaluate(r#"agent.team_id == "team-alpha""#, &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn agent_children_count_gt_matches_when_has_children() {
+        let ctx = fake_topology_ctx(None, None, Some(3));
+        assert!(evaluate("agent.children_count > 0", &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn agent_children_count_eq_zero_matches_leaf() {
+        let ctx = fake_topology_ctx(None, None, Some(0));
+        assert!(evaluate("agent.children_count == 0", &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn agent_children_count_null_safe_without_context() {
+        assert!(!evaluate("agent.children_count > 0", &tool("any"), None, None));
+    }
+
+    // ── agent.is_root, agent.is_leaf tests ───────────────────────────────────
+
+    fn fake_depth_children_ctx(depth: Option<u32>, children: Option<u32>) -> crate::policy::context::FakePolicyContext {
+        crate::policy::context::FakePolicyContext {
+            depth,
+            team_active: None,
+            team_budget: None,
+            child_tools: vec![],
+            agent_risk_tier: None,
+            parent_risk_tier: None,
+            child_risk_tier: None,
+            agent_age_secs: None,
+            agent_parent_id: None,
+            agent_team_id: None,
+            agent_children_count: children,
+        }
+    }
+
+    #[test]
+    fn agent_is_root_eq_1_matches_root_agent() {
+        let ctx = fake_depth_children_ctx(Some(0), None);
+        assert!(evaluate("agent.is_root == 1", &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn agent_is_root_eq_1_no_match_non_root_agent() {
+        let ctx = fake_depth_children_ctx(Some(2), None);
+        assert!(!evaluate("agent.is_root == 1", &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn agent_is_root_null_safe_without_context() {
+        assert!(!evaluate("agent.is_root == 1", &tool("any"), None, None));
+    }
+
+    #[test]
+    fn agent_is_leaf_eq_1_matches_agent_with_no_children() {
+        let ctx = fake_depth_children_ctx(None, Some(0));
+        assert!(evaluate("agent.is_leaf == 1", &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn agent_is_leaf_eq_1_no_match_agent_with_children() {
+        let ctx = fake_depth_children_ctx(None, Some(2));
+        assert!(!evaluate("agent.is_leaf == 1", &tool("any"), None, Some(&ctx)));
+    }
+
+    #[test]
+    fn agent_is_leaf_null_safe_without_context() {
+        assert!(!evaluate("agent.is_leaf == 1", &tool("any"), None, None));
+    }
+
+    #[test]
+    fn validate_variables_accepts_new_topology_variables() {
+        assert!(validate_variables(r#"agent.parent_id == "abc""#).is_ok());
+        assert!(validate_variables(r#"agent.team_id == "t1""#).is_ok());
+        assert!(validate_variables("agent.children_count > 0").is_ok());
+        assert!(validate_variables("agent.is_root == 1").is_ok());
+        assert!(validate_variables("agent.is_leaf == 1").is_ok());
     }
 }

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -52,7 +52,7 @@ pub(crate) const KNOWN_VARIABLES: &[&str] = &[
     "target.channel_id",
     "agent.age",
     "team.parallel_agents",
-    "agent.parent_id",
+    "agent.parent_agent_id",
     "agent.team_id",
     "agent.children_count",
     "agent.is_root",
@@ -276,7 +276,7 @@ fn tokenize(expr: &str) -> Option<Vec<Token>> {
                 "target.channel_id" => Token::Field(FieldRef::TargetChannelId),
                 "agent.age" => Token::Field(FieldRef::AgentAge),
                 "team.parallel_agents" => Token::Field(FieldRef::TeamParallelAgents),
-                "agent.parent_id" => Token::Field(FieldRef::AgentParentId),
+                "agent.parent_agent_id" => Token::Field(FieldRef::AgentParentId),
                 "agent.team_id" => Token::Field(FieldRef::AgentTeamId),
                 "agent.children_count" => Token::Field(FieldRef::AgentChildrenCount),
                 "agent.is_root" => Token::Field(FieldRef::AgentIsRoot),
@@ -549,7 +549,7 @@ fn eval_clause_safe(
         };
     }
 
-    // agent.parent_id / agent.team_id — string comparison against an agent identity field.
+    // agent.parent_agent_id / agent.team_id — string comparison against an agent identity field.
     // Returns false when the field resolves to None (null-safe no-match).
     if matches!(field, FieldRef::AgentParentId | FieldRef::AgentTeamId) {
         let val = match field {
@@ -1798,7 +1798,7 @@ mod tests {
     fn agent_parent_id_eq_matches_known_parent() {
         let ctx = fake_topology_ctx(Some("parent-abc"), None, None);
         assert!(evaluate(
-            r#"agent.parent_id == "parent-abc""#,
+            r#"agent.parent_agent_id == "parent-abc""#,
             &tool("any"),
             None,
             Some(&ctx)
@@ -1809,7 +1809,7 @@ mod tests {
     fn agent_parent_id_eq_no_match_different_parent() {
         let ctx = fake_topology_ctx(Some("parent-xyz"), None, None);
         assert!(!evaluate(
-            r#"agent.parent_id == "parent-abc""#,
+            r#"agent.parent_agent_id == "parent-abc""#,
             &tool("any"),
             None,
             Some(&ctx)
@@ -1820,7 +1820,7 @@ mod tests {
     fn agent_parent_id_null_safe_when_no_parent() {
         let ctx = fake_topology_ctx(None, None, None);
         assert!(!evaluate(
-            r#"agent.parent_id == "parent-abc""#,
+            r#"agent.parent_agent_id == "parent-abc""#,
             &tool("any"),
             None,
             Some(&ctx)
@@ -1931,7 +1931,7 @@ mod tests {
 
     #[test]
     fn validate_variables_accepts_new_topology_variables() {
-        assert!(validate_variables(r#"agent.parent_id == "abc""#).is_ok());
+        assert!(validate_variables(r#"agent.parent_agent_id == "abc""#).is_ok());
         assert!(validate_variables(r#"agent.team_id == "t1""#).is_ok());
         assert!(validate_variables("agent.children_count > 0").is_ok());
         assert!(validate_variables("agent.is_root == 1").is_ok());


### PR DESCRIPTION
## Summary

- Extends `PolicyContext` trait with `agent_parent_id()`, `agent_team_id()`, and `agent_children_count()` methods, implemented in `ProductionPolicyContext` from existing `AgentRecord` fields
- Registers 5 new topology variables in `KNOWN_VARIABLES`, `FieldRef`, tokenizer, and `eval_clause_safe()`: `agent.parent_id`, `agent.team_id`, `agent.children_count`, `agent.is_root`, `agent.is_leaf`
- `agent.is_root` delegates to `agent_depth() == 0`; `agent.is_leaf` delegates to `agent_children_count() == 0` — boolean 0/1 semantics, Eq/Ne only
- Updates all 10 `FakePolicyContext` construction sites in `expr.rs` tests; adds 16 new unit tests covering match, no-match, and null-safe paths

## Why

AAASM-225 specified 8 topology-aware variables. Five were never implemented: `agent.parent_id`, `agent.team_id`, `agent.children_count`, `agent.is_root`, and `agent.is_leaf`. This closes the AC1 gap identified during the AAASM-1123 verification.

## How to verify

```bash
RUSTUP_TOOLCHAIN=stable cargo nextest run -p aa-gateway
```

743 tests pass (all existing + 16 new topology variable tests).

Closes https://lightning-dust-mite.atlassian.net/browse/AAASM-1272