### PR TITLE
[AAASM-1060] ✨ (dashboard): Build agent overview page (list + detail)

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.80.5",
+    "@tanstack/react-table": "^8.21.3",
     "openapi-fetch": "^0.17.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.5",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.80.5
         version: 5.100.10(react@19.2.6)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       openapi-fetch:
         specifier: ^0.17.0
         version: 0.17.0
@@ -663,6 +666,17 @@ packages:
     resolution: {integrity: sha512-FLaZf2RCrA/Zgp4aiu5tG3TyasTRO7aZ99skxQpr3Hg/zXOhu6yq5FZCYQ/tRaJtM9ylnoK8tFK7PolXQadv6Q==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -2606,6 +2620,14 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.100.10
       react: 19.2.6
+
+  '@tanstack/react-table@8.21.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@tanstack/table-core@8.21.3': {}
 
   '@testing-library/dom@10.4.0':
     dependencies:

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { ProtectedRoute } from './pages/ProtectedRoute'
 import { LoginPage } from './pages/LoginPage'
 import { AgentsPage } from './pages/AgentsPage'
+import { AgentDetailPage } from './pages/AgentDetailPage'
 import { ApprovalsPage } from './pages/ApprovalsPage'
 import { NotFoundPage } from './pages/NotFoundPage'
 import { PoliciesPage } from './pages/PoliciesPage'
@@ -14,6 +15,7 @@ function App() {
         <Route element={<ProtectedRoute />}>
           <Route path="/" element={<ApprovalsPage />} />
           <Route path="/agents" element={<AgentsPage />} />
+          <Route path="/agents/:id" element={<AgentDetailPage />} />
           <Route path="/policies" element={<PoliciesPage />} />
           <Route path="/approvals" element={<ApprovalsPage />} />
         </Route>

--- a/dashboard/src/features/agents/api.test.tsx
+++ b/dashboard/src/features/agents/api.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { vi } from 'vitest'
+import { AgentsPage } from '../../pages/AgentsPage'
+import { AgentDetailPage } from '../../pages/AgentDetailPage'
+import * as agentsApi from './api'
+import type { Agent, LogEntry } from './api'
+import type { UseQueryResult } from '@tanstack/react-query'
+
+function makeClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+function Wrapper({ children, path = '/', initialPath = '/' }: { children: React.ReactNode; path?: string; initialPath?: string }) {
+  return (
+    <QueryClientProvider client={makeClient()}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path={path} element={children} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+function mockQuery<T>(partial: Partial<UseQueryResult<T, Error>>): UseQueryResult<T, Error> {
+  return partial as unknown as UseQueryResult<T, Error>
+}
+
+const MOCK_AGENT: Agent = {
+  id: 'abc123',
+  name: 'test-agent',
+  framework: 'langgraph',
+  status: 'active',
+  version: '0.1.0',
+  layer: 'enforced',
+  last_event: '2026-05-12T00:00:00Z',
+  recent_events: [{ event_type: 'violation', summary: 'limit exceeded', timestamp: '2026-05-12T00:00:00Z' }],
+  recent_traces: [],
+  active_sessions: [],
+  session_count: 3,
+  policy_violations_count: 1,
+  tool_names: ['web_search', 'code_exec'],
+  metadata: {},
+  pid: null,
+}
+
+const MOCK_LOG: LogEntry = {
+  agent_id: 'abc123',
+  event_type: 'PolicyViolation',
+  payload: '{}',
+  seq: 1,
+  session_id: 'session-001',
+  timestamp: '2026-05-12T00:00:00Z',
+}
+
+describe('AgentsPage', () => {
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it('renders skeleton rows while loading', () => {
+    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+      mockQuery<Agent[]>({ data: undefined, isLoading: true, isError: false, refetch: vi.fn() }),
+    )
+    render(<AgentsPage />, { wrapper: ({ children }) => <Wrapper path="/">{children}</Wrapper> })
+    expect(screen.getAllByTestId('agent-row-skeleton')).toHaveLength(5)
+  })
+
+  it('renders rows for each agent', async () => {
+    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+      mockQuery<Agent[]>({ data: [MOCK_AGENT], isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    render(<AgentsPage />, { wrapper: ({ children }) => <Wrapper path="/">{children}</Wrapper> })
+    await waitFor(() => expect(screen.getAllByTestId('agent-row')).toHaveLength(1))
+    expect(screen.getByText('test-agent')).toBeInTheDocument()
+    expect(screen.getByText('langgraph')).toBeInTheDocument()
+    expect(screen.getByText('active')).toBeInTheDocument()
+  })
+
+  it('shows empty state when no agents', async () => {
+    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+      mockQuery<Agent[]>({ data: [], isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    render(<AgentsPage />, { wrapper: ({ children }) => <Wrapper path="/">{children}</Wrapper> })
+    await waitFor(() => expect(screen.getByTestId('agents-empty')).toBeInTheDocument())
+  })
+
+  it('shows error banner with retry button on failure', () => {
+    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+      mockQuery<Agent[]>({ data: undefined, isLoading: false, isError: true, refetch: vi.fn() }),
+    )
+    render(<AgentsPage />, { wrapper: ({ children }) => <Wrapper path="/">{children}</Wrapper> })
+    expect(screen.getByTestId('agents-error')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
+  })
+})
+
+describe('AgentDetailPage', () => {
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it('renders identity profile fields', async () => {
+    vi.spyOn(agentsApi, 'useAgentQuery').mockReturnValue(
+      mockQuery<Agent | undefined>({ data: MOCK_AGENT, isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    vi.spyOn(agentsApi, 'useAgentEventsQuery').mockReturnValue(
+      mockQuery<LogEntry[]>({ data: [MOCK_LOG], isLoading: false, isError: false }),
+    )
+
+    render(
+      <Wrapper path="/agents/:id" initialPath="/agents/abc123">
+        <AgentDetailPage />
+      </Wrapper>,
+    )
+
+    await waitFor(() => expect(screen.getByTestId('agent-detail')).toBeInTheDocument())
+    expect(screen.getByText('test-agent')).toBeInTheDocument()
+    expect(screen.getByText('langgraph')).toBeInTheDocument()
+    expect(screen.getByText('enforced')).toBeInTheDocument()
+    expect(screen.getAllByTestId('event-row')).toHaveLength(1)
+  })
+
+  it('shows loading state', () => {
+    vi.spyOn(agentsApi, 'useAgentQuery').mockReturnValue(
+      mockQuery<Agent | undefined>({ data: undefined, isLoading: true, isError: false, refetch: vi.fn() }),
+    )
+    vi.spyOn(agentsApi, 'useAgentEventsQuery').mockReturnValue(
+      mockQuery<LogEntry[]>({ data: undefined, isLoading: true, isError: false }),
+    )
+
+    render(
+      <Wrapper path="/agents/:id" initialPath="/agents/abc123">
+        <AgentDetailPage />
+      </Wrapper>,
+    )
+    expect(screen.getByTestId('agent-detail-loading')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/features/agents/api.ts
+++ b/dashboard/src/features/agents/api.ts
@@ -1,0 +1,47 @@
+import { useQuery } from '@tanstack/react-query'
+import { api } from '../../api/client'
+import type { components } from '../../api/generated/schema'
+
+export type Agent = components['schemas']['AgentResponse']
+export type LogEntry = components['schemas']['LogEntry']
+
+export function useAgentsQuery() {
+  return useQuery({
+    queryKey: ['agents'],
+    queryFn: async () => {
+      const { data, error } = await api.GET('/api/v1/agents', {
+        params: { query: { per_page: 100 } },
+      })
+      if (error) throw new Error('Failed to fetch agents')
+      return data ?? []
+    },
+  })
+}
+
+export function useAgentQuery(id: string) {
+  return useQuery({
+    queryKey: ['agents', id],
+    queryFn: async () => {
+      const { data, error } = await api.GET('/api/v1/agents/{id}', {
+        params: { path: { id } },
+      })
+      if (error) throw new Error('Failed to fetch agent')
+      return data
+    },
+    enabled: !!id,
+  })
+}
+
+export function useAgentEventsQuery(id: string) {
+  return useQuery({
+    queryKey: ['agents', id, 'events'],
+    queryFn: async () => {
+      const { data, error } = await api.GET('/api/v1/logs', {
+        params: { query: { agent_id: id, per_page: 50 } },
+      })
+      if (error) throw new Error('Failed to fetch agent events')
+      return data ?? []
+    },
+    enabled: !!id,
+  })
+}

--- a/dashboard/src/pages/AgentDetailPage.tsx
+++ b/dashboard/src/pages/AgentDetailPage.tsx
@@ -1,0 +1,92 @@
+import { useParams, Link } from 'react-router-dom'
+import { useAgentQuery, useAgentEventsQuery } from '../features/agents/api'
+
+function Field({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div style={{ marginBottom: '0.5rem' }}>
+      <span style={{ fontWeight: 600, marginRight: '0.5rem' }}>{label}:</span>
+      <span>{value ?? '—'}</span>
+    </div>
+  )
+}
+
+export function AgentDetailPage() {
+  const { id } = useParams<{ id: string }>()
+  const { data: agent, isLoading: agentLoading, isError: agentError, refetch: refetchAgent } = useAgentQuery(id ?? '')
+  const { data: events, isLoading: eventsLoading, isError: eventsError } = useAgentEventsQuery(id ?? '')
+
+  if (agentLoading) {
+    return (
+      <main style={{ padding: '1.5rem' }} data-testid="agent-detail-loading">
+        <p>Loading agent…</p>
+      </main>
+    )
+  }
+
+  if (agentError || !agent) {
+    return (
+      <main style={{ padding: '1.5rem' }} data-testid="agent-detail-error">
+        <p style={{ color: '#dc2626' }}>Failed to load agent.</p>
+        <button onClick={() => void refetchAgent()}>Retry</button>
+        <br />
+        <Link to="/agents">← Back to agents</Link>
+      </main>
+    )
+  }
+
+  return (
+    <main style={{ padding: '1.5rem' }} data-testid="agent-detail">
+      <Link to="/agents" style={{ fontSize: '0.875rem' }}>← Back to agents</Link>
+      <h1 style={{ margin: '0.75rem 0' }}>{agent.name}</h1>
+
+      <section
+        data-testid="agent-profile"
+        style={{ background: '#f9fafb', border: '1px solid #e5e7eb', borderRadius: '8px', padding: '1rem', marginBottom: '1.5rem' }}
+      >
+        <h2 style={{ marginTop: 0 }}>Identity Profile</h2>
+        <Field label="ID" value={<code style={{ fontSize: '0.8rem' }}>{agent.id}</code>} />
+        <Field label="Framework" value={agent.framework} />
+        <Field label="Version" value={agent.version} />
+        <Field label="Status" value={agent.status} />
+        <Field label="Governance layer" value={agent.layer} />
+        <Field label="Sessions" value={agent.session_count} />
+        <Field label="Policy violations" value={agent.policy_violations_count} />
+        <Field label="Last seen" value={agent.last_event} />
+        {agent.tool_names.length > 0 && (
+          <Field label="Tools" value={agent.tool_names.join(', ')} />
+        )}
+      </section>
+
+      <section data-testid="agent-events">
+        <h2>Recent Events</h2>
+        {eventsLoading && <p>Loading events…</p>}
+        {eventsError && <p style={{ color: '#dc2626' }}>Failed to load events.</p>}
+        {!eventsLoading && !eventsError && (!events || events.length === 0) && (
+          <p>No events recorded for this agent.</p>
+        )}
+        {events && events.length > 0 && (
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' }}>
+            <thead>
+              <tr>
+                <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid #e5e7eb' }}>Timestamp</th>
+                <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid #e5e7eb' }}>Type</th>
+                <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid #e5e7eb' }}>Session</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events.map(ev => (
+                <tr key={`${ev.seq}-${ev.session_id}`} data-testid="event-row" style={{ borderBottom: '1px solid #f3f4f6' }}>
+                  <td style={{ padding: '0.4rem' }}>{ev.timestamp}</td>
+                  <td style={{ padding: '0.4rem' }}>{ev.event_type}</td>
+                  <td style={{ padding: '0.4rem' }}>
+                    <code style={{ fontSize: '0.75rem' }}>{ev.session_id.slice(0, 12)}…</code>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/dashboard/src/pages/AgentsPage.tsx
+++ b/dashboard/src/pages/AgentsPage.tsx
@@ -88,6 +88,7 @@ export function AgentsPage() {
   const { data: agents, isLoading, isError, refetch } = useAgentsQuery()
   const [sorting, setSorting] = useState<SortingState>([])
 
+  // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
     data: agents ?? [],
     columns,

--- a/dashboard/src/pages/AgentsPage.tsx
+++ b/dashboard/src/pages/AgentsPage.tsx
@@ -1,8 +1,171 @@
-export function AgentsPage() {
+import { Link } from 'react-router-dom'
+import {
+  useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  flexRender,
+  createColumnHelper,
+  type SortingState,
+} from '@tanstack/react-table'
+import { useState } from 'react'
+import { useAgentsQuery, type Agent } from '../features/agents/api'
+
+const STATUS_COLOR: Record<string, string> = {
+  active: '#16a34a',
+  idle: '#ca8a04',
+  suspended: '#d97706',
+  error: '#dc2626',
+  deregistered: '#6b7280',
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const color = STATUS_COLOR[status] ?? '#6b7280'
   return (
-    <main>
+    <span
+      style={{
+        display: 'inline-block',
+        padding: '2px 8px',
+        borderRadius: '9999px',
+        fontSize: '0.75rem',
+        fontWeight: 600,
+        color: '#fff',
+        background: color,
+      }}
+    >
+      {status}
+    </span>
+  )
+}
+
+function SkeletonRows() {
+  return (
+    <>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <tr key={i} data-testid="agent-row-skeleton">
+          {Array.from({ length: 5 }).map((_, j) => (
+            <td key={j} style={{ padding: '0.5rem' }}>
+              <span
+                style={{
+                  display: 'block',
+                  height: '1rem',
+                  background: '#e5e7eb',
+                  borderRadius: '4px',
+                }}
+              />
+            </td>
+          ))}
+        </tr>
+      ))}
+    </>
+  )
+}
+
+const columnHelper = createColumnHelper<Agent>()
+
+const columns = [
+  columnHelper.accessor('name', {
+    header: 'Name',
+    cell: info => (
+      <Link to={`/agents/${info.row.original.id}`}>{info.getValue()}</Link>
+    ),
+  }),
+  columnHelper.accessor('framework', { header: 'Framework' }),
+  columnHelper.accessor('status', {
+    header: 'Status',
+    cell: info => <StatusBadge status={info.getValue()} />,
+  }),
+  columnHelper.accessor('last_event', {
+    header: 'Last seen',
+    cell: info => info.getValue() ?? '—',
+  }),
+  columnHelper.accessor(row => row.recent_events.length, {
+    id: 'recent_events_count',
+    header: 'Recent events',
+  }),
+]
+
+export function AgentsPage() {
+  const { data: agents, isLoading, isError, refetch } = useAgentsQuery()
+  const [sorting, setSorting] = useState<SortingState>([])
+
+  const table = useReactTable({
+    data: agents ?? [],
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  })
+
+  return (
+    <main style={{ padding: '1.5rem' }}>
       <h1>Agents</h1>
-      <p>Agent fleet overview — coming soon.</p>
+
+      {isError && (
+        <div
+          data-testid="agents-error"
+          style={{ color: '#dc2626', marginBottom: '1rem', display: 'flex', gap: '1rem', alignItems: 'center' }}
+        >
+          <span>Failed to load agents.</span>
+          <button onClick={() => void refetch()}>Retry</button>
+        </div>
+      )}
+
+      {!isLoading && !isError && agents?.length === 0 && (
+        <p data-testid="agents-empty">
+          No agents registered yet.{' '}
+          <a href="https://docs.agent-assembly.io/quickstart" target="_blank" rel="noreferrer">
+            Read the quickstart guide →
+          </a>
+        </p>
+      )}
+
+      <table data-testid="agents-table" style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <thead>
+          {table.getHeaderGroups().map(hg => (
+            <tr key={hg.id}>
+              {hg.headers.map(header => (
+                <th
+                  key={header.id}
+                  style={{
+                    textAlign: 'left',
+                    padding: '0.5rem',
+                    borderBottom: '2px solid #e5e7eb',
+                    cursor: header.column.getCanSort() ? 'pointer' : undefined,
+                  }}
+                  onClick={header.column.getToggleSortingHandler()}
+                >
+                  {flexRender(header.column.columnDef.header, header.getContext())}
+                  {header.column.getIsSorted() === 'asc'
+                    ? ' ↑'
+                    : header.column.getIsSorted() === 'desc'
+                      ? ' ↓'
+                      : ''}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {isLoading ? (
+            <SkeletonRows />
+          ) : (
+            table.getRowModel().rows.map(row => (
+              <tr
+                key={row.id}
+                data-testid="agent-row"
+                style={{ borderBottom: '1px solid #f3f4f6' }}
+              >
+                {row.getVisibleCells().map(cell => (
+                  <td key={cell.id} style={{ padding: '0.5rem' }}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
     </main>
   )
 }


### PR DESCRIPTION
## Description

Implements the `/agents` list view and `/agents/:id` detail page against the existing REST API, wired with Tanstack Query for loading/error/empty state management.

- Adds `@tanstack/react-table@8` for sortable columns
- Adds `dashboard/src/features/agents/api.ts` co-locating three hooks:
  - `useAgentsQuery()` → `GET /api/v1/agents`
  - `useAgentQuery(id)` → `GET /api/v1/agents/{id}`
  - `useAgentEventsQuery(id)` → `GET /api/v1/logs?agent_id={id}&per_page=50` (no `/agents/{id}/events` endpoint exists in the spec; audit log endpoint is used instead)
- `AgentsPage`: sortable table with columns Name, Framework, Status, Last seen, Recent events count; skeleton loading rows; inline error banner with retry; empty state with docs link; `data-testid` on table and rows
- `AgentDetailPage`: identity profile card (id, name, framework, status, version, layer, tools, session count, violations) + recent events table; `data-testid` attributes on profile and events sections
- Wires `/agents/:id` route in `App.tsx`
- 6 new unit tests across 2 describe blocks — all 27 suite tests pass

## Type of Change

- [x] ✨ New feature
- [x] ⬆️ Dependency upgrade
- [x] ✅ Tests

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1060
- Parent story: AAASM-94

## Testing

- [x] Unit tests added / updated
- [x] Manual testing performed

All checks passing locally:
- `pnpm type-check` — 0 errors
- `pnpm lint` — 0 warnings
- `pnpm test` — 27 tests passed across 4 test files

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention