### PR TITLE
[AAASM-1293] 🔧 (ci): Dashboard CI/CD pipeline — PR checks, build ordering, and release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,19 @@ jobs:
         run: sudo apt-get install -y protobuf-compiler
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
+        with:
+          version: 10.9.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: dashboard/pnpm-lock.yaml
+      - name: Build dashboard assets (required by aa-cli)
+        working-directory: dashboard
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
       - name: Build workspace
         # aa-ebpf requires nightly (aya-build invokes rustup run nightly).
         # It is validated by the dedicated ebpf-build job.
@@ -69,6 +82,19 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
+        with:
+          version: 10.9.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: dashboard/pnpm-lock.yaml
+      - name: Build dashboard assets (required by aa-cli)
+        working-directory: dashboard
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
       - name: Run Clippy
         # aa-ebpf requires nightly (aya-build invokes rustup run nightly).
         # It is linted by the dedicated ebpf-build job.
@@ -97,6 +123,19 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install cargo-nextest
         uses: taiki-e/install-action@83c419a40a2e48673b2c523337e57f602dfe53c9 # cargo-nextest
+      - uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
+        with:
+          version: 10.9.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: dashboard/pnpm-lock.yaml
+      - name: Build dashboard assets (required by aa-cli)
+        working-directory: dashboard
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
       - name: Run tests
         # aa-ebpf requires nightly (aya-build invokes rustup run nightly) and has no
         # unit tests. Validated by the dedicated ebpf-build job.
@@ -123,6 +162,19 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@3f7f2bd74f95d407a45d96b106f26d4f6c238fab # cargo-llvm-cov
+      - uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
+        with:
+          version: 10.9.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: dashboard/pnpm-lock.yaml
+      - name: Build dashboard assets (required by aa-cli)
+        working-directory: dashboard
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
       - name: Generate coverage report
         # aa-ebpf requires nightly and has no testable userspace logic — excluded.
         # aa-ffi-python requires Python dev headers for linking — excluded.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,54 +161,6 @@ jobs:
           command: check
           arguments: --all-features
 
-  dashboard:
-    name: Dashboard (type-check + lint)
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: dashboard
-    steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
-        with:
-          version: 10.9.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 20
-          cache: pnpm
-          cache-dependency-path: dashboard/pnpm-lock.yaml
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Generate API types from OpenAPI spec
-        run: pnpm generate:api
-      - name: Type check
-        run: pnpm type-check
-      - name: Lint
-        run: pnpm lint
-
-  dashboard-codegen-drift:
-    name: Dashboard codegen drift check
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: dashboard
-    steps:
-      - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
-        with:
-          version: 10.9.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 20
-          cache: pnpm
-          cache-dependency-path: dashboard/pnpm-lock.yaml
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Regenerate API types
-        run: pnpm generate:api
-      - name: Check generated types are up to date
-        run: git diff --exit-code src/api/generated/
-
   no-std:
     name: no_std targets
     runs-on: ubuntu-latest

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -40,6 +40,36 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+  build:
+    name: Dashboard build
+    runs-on: ubuntu-latest
+    needs: [typecheck-and-lint]
+    defaults:
+      run:
+        working-directory: dashboard
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
+        with:
+          version: 10.9.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: dashboard/pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Generate API types from OpenAPI spec
+        run: pnpm generate:api
+      - name: Build production bundle
+        run: pnpm build
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: dashboard-dist
+          path: dashboard/dist/
+          retention-days: 1
+
   codegen-drift:
     name: Dashboard codegen drift check
     runs-on: ubuntu-latest

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -1,0 +1,64 @@
+name: Dashboard CI
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "dashboard/**"
+      - "openapi/v1.yaml"
+      - ".github/workflows/dashboard-ci.yml"
+  pull_request:
+    branches: [master]
+    paths:
+      - "dashboard/**"
+      - "openapi/v1.yaml"
+      - ".github/workflows/dashboard-ci.yml"
+
+jobs:
+  typecheck-and-lint:
+    name: Dashboard (type-check + lint)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dashboard
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
+        with:
+          version: 10.9.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: dashboard/pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Generate API types from OpenAPI spec
+        run: pnpm generate:api
+      - name: Type check
+        run: pnpm type-check
+      - name: Lint
+        run: pnpm lint
+
+  codegen-drift:
+    name: Dashboard codegen drift check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dashboard
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
+        with:
+          version: 10.9.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: dashboard/pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Regenerate API types
+        run: pnpm generate:api
+      - name: Check generated types are up to date
+        run: git diff --exit-code src/api/generated/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,21 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
+      - name: Set up pnpm
+        uses: pnpm/action-setup@739bfe42ca9233c5e6aca07c1a25a9d34aca49b0 # v6.0.7
+        with:
+          version: 10.9.0
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: dashboard/pnpm-lock.yaml
+      - name: Build dashboard assets
+        working-directory: dashboard
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
       - name: Build aasm release binary
         run: cargo build --release --target ${{ matrix.target }} -p aa-cli
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,98 @@
+# Releasing `aasm`
+
+This document describes how to cut a release of the `aasm` binary.
+Releases are tagged from `master`; the release workflow handles binary
+compilation, packaging, and GitHub Release publication automatically.
+
+## Prerequisites
+
+Ensure all of the following are installed locally before tagging:
+
+| Tool | Version | Install |
+|---|---|---|
+| Rust (stable) | ≥ 1.75 | `rustup update stable` |
+| pnpm | 10.9.0 | `corepack enable && corepack prepare pnpm@10.9.0 --activate` |
+| Node.js | 20 | `nvm use 20` or via your system package manager |
+| protobuf compiler | any recent | `apt install protobuf-compiler` / `brew install protobuf` |
+
+## Pre-release checklist
+
+Run these steps locally before pushing the release tag. All checks must
+pass with a clean exit code.
+
+```bash
+# 1. Ensure local master is up to date
+git fetch remote && git checkout master && git merge remote/master --ff-only
+
+# 2. Build the dashboard — REQUIRED; aa-cli embeds dashboard/dist/
+cd dashboard
+pnpm install --frozen-lockfile
+pnpm type-check
+pnpm lint
+pnpm build           # produces dashboard/dist/; must exit 0
+cd ..
+
+# 3. Run the full Rust test suite
+cargo nextest run --workspace --exclude aa-ebpf
+
+# 4. Clippy clean
+cargo clippy --workspace --all-targets --all-features --exclude aa-ebpf -- -D warnings
+
+# 5. Dependency audit
+cargo deny check
+
+# 6. Verify aasm binary builds and embeds the dashboard
+cargo build --release -p aa-cli
+./target/release/aasm --version
+```
+
+## Tagging and triggering the release workflow
+
+Once the checklist passes, push a semver tag. The release workflow
+(`.github/workflows/release.yml`) triggers automatically:
+
+```bash
+git tag v0.1.0        # replace with the actual version
+git push remote v0.1.0
+```
+
+The workflow will:
+
+1. Build the dashboard (`pnpm build` inside `dashboard/`) for each target.
+2. Compile `aasm` for all four release targets in parallel:
+   - `x86_64-unknown-linux-gnu`
+   - `aarch64-unknown-linux-gnu`
+   - `aarch64-apple-darwin`
+   - `x86_64-apple-darwin`
+3. Package each binary as `aasm-<target>.tar.gz`.
+4. Generate `SHA256SUMS`.
+5. Publish the GitHub Release with generated release notes.
+6. Publish `aa-cli` to crates.io.
+
+> **Note — release smoke test (pending AAASM-1292):** Once `aasm dashboard start`
+> is implemented, the release workflow will also verify the embedded assets by
+> starting the server and asserting HTTP 200 before publishing. Until then,
+> the binary smoke test is performed manually in step 6 of the checklist above.
+
+## Post-release verification
+
+After the workflow completes:
+
+1. Check the GitHub Release page for all four `.tar.gz` files and `SHA256SUMS`.
+2. Download and test one binary on the target platform:
+
+```bash
+tar -xzf aasm-x86_64-unknown-linux-gnu.tar.gz
+./aasm --version
+./aasm topology list   # basic sanity check
+```
+
+3. Verify the crates.io publish succeeded at `https://crates.io/crates/aa-cli`.
+
+## Versioning
+
+The dashboard has no independent version. It ships as part of `aasm` and
+inherits the release tag. Do not publish the dashboard to npm.
+
+All crate versions are unified under `[workspace.package] version` in
+`Cargo.toml`. Bump only that single field before tagging.


### PR DESCRIPTION
## Description

Wire up the `dashboard/` workspace into CI/CD across three scopes:

1. **`dashboard-ci.yml`** — dedicated workflow for dashboard PRs: type-check, lint, API codegen drift, and production bundle build with `dashboard/dist/` uploaded as an artifact. The `actions/setup-node` `cache: pnpm` option caches `~/.pnpm-store` keyed on `pnpm-lock.yaml` for fast warm runs.
2. **Cargo CI build ordering** — add `pnpm build` pre-build steps to the `build`, `test`, `clippy`, and `coverage` jobs in `ci.yml` so `aa-cli` compilation never fails due to missing `dashboard/dist/` assets (required once AAASM-1292 lands).
3. **Release workflow** — add `pnpm build` before `cargo build --release -p aa-cli` in all four matrix targets; create `RELEASING.md` documenting the dashboard build as a required release step.

The existing `dashboard` and `dashboard-codegen-drift` jobs are moved out of `ci.yml` into `dashboard-ci.yml` to eliminate duplication. The `ci.yml` paths filter retains `dashboard/**` so Cargo jobs still fire when dashboard code changes.

> **Note:** The release smoke test (`aasm dashboard start` → `curl` → HTTP 200) is a separate follow-up in AAASM-1300, blocked on AAASM-1292 implementing the `aasm dashboard start` subcommand.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-1293
- Sub-tasks: AAASM-1295, AAASM-1296, AAASM-1297, AAASM-1298, AAASM-1299, AAASM-1301
- Follow-up (smoke test, after AAASM-1292): AAASM-1300

## Testing

- [x] Manual testing performed — verified commit log, confirmed pre-build steps appear in correct positions in both `ci.yml` and `release.yml`
- [x] No unit tests required — CI/CD workflow changes only

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated (`RELEASING.md` created)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention