### PR TITLE
[AAASM-1292] ✨ (aa-cli): Add aasm dashboard start/open/stop subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "async-trait",
+ "axum",
  "chrono",
  "clap",
  "clap_complete",
@@ -64,7 +65,10 @@ dependencies = [
  "csv",
  "dirs",
  "futures-util",
+ "include_dir",
  "libc",
+ "mime_guess",
+ "open",
  "owo-colors",
  "ratatui",
  "reqwest",
@@ -2713,6 +2717,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2793,6 +2816,25 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3536,6 +3578,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "open"
+version = "5.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3611,6 +3664,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pem"

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -18,9 +18,9 @@ aa-devtool-windsurf  = { path = "../aa-devtool-windsurf" }
 aa-gateway           = { path = "../aa-gateway" }
 anyhow         = "1"
 async-trait    = "0.1"
-axum           = { version = "0.8", features = ["macros"] }
+axum           = "0.8"
 chrono         = { version = "0.4", features = ["serde"] }
-clap           = { version = "4", features = ["derive"] }
+clap           = { version = "4", features = ["derive", "env"] }
 clap_complete  = "4"
 colored        = "3"
 csv            = "1"

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -18,6 +18,7 @@ aa-devtool-windsurf  = { path = "../aa-devtool-windsurf" }
 aa-gateway           = { path = "../aa-gateway" }
 anyhow         = "1"
 async-trait    = "0.1"
+axum           = { version = "0.8", features = ["macros"] }
 chrono         = { version = "0.4", features = ["serde"] }
 clap           = { version = "4", features = ["derive"] }
 clap_complete  = "4"
@@ -28,7 +29,10 @@ console        = "0.16"
 crossterm      = "0.29"
 dirs           = "6"
 futures-util   = "0.3"
+include_dir    = "0.7"
 libc           = "0.2"
+mime_guess     = "2"
+open           = "5"
 owo-colors     = "4"
 ratatui        = { version = "0.30", features = ["crossterm"] }
 reqwest        = { version = "0.12", default-features = false, features = ["rustls-tls", "json", "blocking"] }

--- a/aa-cli/build.rs
+++ b/aa-cli/build.rs
@@ -1,0 +1,18 @@
+use std::path::PathBuf;
+
+fn main() {
+    let dist = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+        .join("../dashboard/dist");
+
+    // Create a stub dist directory so include_dir! compiles when the SPA has not been built.
+    if !dist.exists() {
+        std::fs::create_dir_all(&dist).expect("cannot create dashboard/dist");
+        std::fs::write(
+            dist.join("index.html"),
+            "<!doctype html><html><body>Dashboard not built. Run <code>pnpm build</code> in dashboard/.</body></html>\n",
+        )
+        .expect("cannot write dashboard/dist/index.html");
+    }
+
+    println!("cargo:rerun-if-changed=../dashboard/dist");
+}

--- a/aa-cli/build.rs
+++ b/aa-cli/build.rs
@@ -1,8 +1,7 @@
 use std::path::PathBuf;
 
 fn main() {
-    let dist = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
-        .join("../dashboard/dist");
+    let dist = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("../dashboard/dist");
 
     // Create a stub index.html so include_dir! compiles when the SPA has not been built yet.
     let index = dist.join("index.html");

--- a/aa-cli/build.rs
+++ b/aa-cli/build.rs
@@ -4,11 +4,12 @@ fn main() {
     let dist = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
         .join("../dashboard/dist");
 
-    // Create a stub dist directory so include_dir! compiles when the SPA has not been built.
-    if !dist.exists() {
+    // Create a stub index.html so include_dir! compiles when the SPA has not been built yet.
+    let index = dist.join("index.html");
+    if !index.exists() {
         std::fs::create_dir_all(&dist).expect("cannot create dashboard/dist");
         std::fs::write(
-            dist.join("index.html"),
+            &index,
             "<!doctype html><html><body>Dashboard not built. Run <code>pnpm build</code> in dashboard/.</body></html>\n",
         )
         .expect("cannot write dashboard/dist/index.html");

--- a/aa-cli/src/commands/dashboard/mod.rs
+++ b/aa-cli/src/commands/dashboard/mod.rs
@@ -1,16 +1,20 @@
-//! `aasm dashboard` — interactive TUI dashboard for real-time governance monitoring.
+//! `aasm dashboard` — governance dashboard: interactive TUI and embedded web server.
 
 pub mod dialog;
 pub mod feed;
 pub mod input;
+pub mod open;
+pub mod pid;
+pub mod start;
 pub mod state;
+pub mod stop;
 pub mod ui;
 
 use std::io::{self, stdout};
 use std::process::ExitCode;
 use std::time::Duration;
 
-use clap::Args;
+use clap::{Args, Subcommand};
 use crossterm::event::{self as ct_event, DisableMouseCapture, EnableMouseCapture, Event, KeyCode};
 use crossterm::execute;
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen};
@@ -26,18 +30,46 @@ use self::feed::FeedMessage;
 use self::input::InputAction;
 use self::state::DashboardState;
 
-/// Arguments for the `aasm dashboard` subcommand.
-#[derive(Debug, Args)]
-pub struct DashboardArgs {}
-
-/// Entry point for `aasm dashboard`.
-pub fn dispatch(args: DashboardArgs, ctx: &ResolvedContext) -> ExitCode {
-    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
-    rt.block_on(async { run(args, ctx).await })
+/// Web-server subcommands for `aasm dashboard`.
+#[derive(Debug, Subcommand)]
+pub enum DashboardCommands {
+    /// Serve the embedded SPA at http://127.0.0.1:<port>. Blocks until Ctrl-C.
+    Start(start::StartArgs),
+    /// Open the browser to an already-running dashboard.
+    Open(open::OpenArgs),
+    /// Stop a dashboard server started with `aasm dashboard start`.
+    Stop,
 }
 
-/// Set up the terminal, run the dashboard, and restore the terminal on exit.
-async fn run(_args: DashboardArgs, ctx: &ResolvedContext) -> ExitCode {
+/// Arguments for the `aasm dashboard` subcommand.
+#[derive(Debug, Args)]
+pub struct DashboardArgs {
+    #[command(subcommand)]
+    pub command: Option<DashboardCommands>,
+}
+
+/// Entry point for `aasm dashboard [start|open|stop]`.
+pub fn dispatch(args: DashboardArgs, ctx: &ResolvedContext) -> ExitCode {
+    match args.command {
+        None => {
+            // No subcommand: run the interactive TUI (existing behaviour).
+            let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+            rt.block_on(async { run_tui(ctx).await })
+        }
+        Some(DashboardCommands::Start(start_args)) => {
+            let cfg = crate::config::load().unwrap_or_default();
+            start::dispatch(start_args, ctx, &cfg)
+        }
+        Some(DashboardCommands::Open(open_args)) => {
+            let cfg = crate::config::load().unwrap_or_default();
+            open::dispatch(open_args, &cfg)
+        }
+        Some(DashboardCommands::Stop) => stop::dispatch(),
+    }
+}
+
+/// Set up the terminal, run the TUI dashboard, and restore the terminal on exit.
+async fn run_tui(ctx: &ResolvedContext) -> ExitCode {
     // Install a panic hook that restores the terminal before printing the panic.
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {

--- a/aa-cli/src/commands/dashboard/open.rs
+++ b/aa-cli/src/commands/dashboard/open.rs
@@ -1,0 +1,44 @@
+//! `aasm dashboard open` — open the browser to a running dashboard.
+
+use std::process::ExitCode;
+
+use clap::Args;
+
+use crate::config::{resolve_dashboard_port, CliConfig};
+
+use super::pid;
+
+/// Arguments for `aasm dashboard open`.
+#[derive(Debug, Args)]
+pub struct OpenArgs {
+    /// Port to connect to (overrides config and AASM_DASHBOARD_PORT env var).
+    #[arg(long, env = "AASM_DASHBOARD_PORT")]
+    pub port: Option<u16>,
+}
+
+pub fn dispatch(args: OpenArgs, config: &CliConfig) -> ExitCode {
+    // Prefer port from PID file (records the actual running port), then fall back to flags/config.
+    let port = pid::read_pid()
+        .map(|(_, p)| p)
+        .unwrap_or_else(|| resolve_dashboard_port(config, args.port));
+
+    let url = format!("http://127.0.0.1:{port}");
+
+    // Verify the server is reachable before launching the browser.
+    let reachable = reqwest::blocking::get(&url)
+        .map(|r| r.status().is_success() || r.status().as_u16() < 500)
+        .unwrap_or(false);
+
+    if !reachable {
+        eprintln!("error: dashboard is not running at {url}");
+        eprintln!("hint: start it first with `aasm dashboard start`");
+        return ExitCode::FAILURE;
+    }
+
+    if let Err(e) = open::that(&url) {
+        eprintln!("error: could not open browser: {e}");
+        return ExitCode::FAILURE;
+    }
+
+    ExitCode::SUCCESS
+}

--- a/aa-cli/src/commands/dashboard/pid.rs
+++ b/aa-cli/src/commands/dashboard/pid.rs
@@ -1,0 +1,43 @@
+//! PID file helpers for `aasm dashboard start` / `stop`.
+//!
+//! File location: `~/.local/share/aasm/dashboard.pid`
+//! File format:   `<pid>\n<port>\n`
+
+use std::io;
+use std::path::PathBuf;
+
+/// Returns the path to the dashboard PID file.
+pub fn pid_path() -> PathBuf {
+    dirs::data_local_dir()
+        .expect("cannot determine local data directory")
+        .join("aasm")
+        .join("dashboard.pid")
+}
+
+/// Write `<pid>\n<port>\n` to the PID file, creating parent directories as needed.
+pub fn write_pid(port: u16) -> io::Result<()> {
+    let path = pid_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let content = format!("{}\n{}\n", std::process::id(), port);
+    std::fs::write(&path, content)
+}
+
+/// Read `(pid, port)` from the PID file. Returns `None` if the file is absent or malformed.
+pub fn read_pid() -> Option<(u32, u16)> {
+    let content = std::fs::read_to_string(pid_path()).ok()?;
+    let mut lines = content.lines();
+    let pid: u32 = lines.next()?.parse().ok()?;
+    let port: u16 = lines.next()?.parse().ok()?;
+    Some((pid, port))
+}
+
+/// Remove the PID file. Succeeds silently if the file does not exist.
+pub fn remove_pid() -> io::Result<()> {
+    let path = pid_path();
+    if path.exists() {
+        std::fs::remove_file(path)?;
+    }
+    Ok(())
+}

--- a/aa-cli/src/commands/dashboard/start.rs
+++ b/aa-cli/src/commands/dashboard/start.rs
@@ -1,0 +1,157 @@
+//! `aasm dashboard start` — serve the embedded governance dashboard SPA.
+
+use std::net::SocketAddr;
+use std::process::ExitCode;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::extract::State;
+use axum::http::{header, HeaderMap, Method, StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use axum::routing::any;
+use axum::Router;
+use clap::Args;
+use include_dir::{include_dir, Dir};
+use tokio::net::TcpListener;
+
+use crate::config::{resolve_dashboard_port, CliConfig, ResolvedContext};
+
+use super::pid;
+
+static ASSETS: Dir = include_dir!("$CARGO_MANIFEST_DIR/../dashboard/dist");
+
+/// Arguments for `aasm dashboard start`.
+#[derive(Debug, Args)]
+pub struct StartArgs {
+    /// Port to listen on (overrides config and AASM_DASHBOARD_PORT env var).
+    #[arg(long, env = "AASM_DASHBOARD_PORT")]
+    pub port: Option<u16>,
+    /// Open the system browser after the server is ready.
+    #[arg(long)]
+    pub open: bool,
+}
+
+pub fn dispatch(args: StartArgs, ctx: &ResolvedContext, config: &CliConfig) -> ExitCode {
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    rt.block_on(run(args, ctx, config))
+}
+
+async fn run(args: StartArgs, ctx: &ResolvedContext, config: &CliConfig) -> ExitCode {
+    let port = resolve_dashboard_port(config, args.port);
+    let addr: SocketAddr = format!("127.0.0.1:{port}").parse().expect("invalid socket address");
+
+    let listener = match TcpListener::bind(addr).await {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("error: cannot bind to {addr}: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if let Err(e) = pid::write_pid(port) {
+        eprintln!("warning: could not write PID file: {e}");
+    }
+
+    let gateway_url = Arc::new(ctx.api_url.clone());
+
+    let app = Router::new()
+        .route("/api/{*path}", any(proxy_handler))
+        .fallback(static_handler)
+        .with_state(gateway_url);
+
+    let url = format!("http://127.0.0.1:{port}");
+    println!("Dashboard running at {url}");
+    println!("Press Ctrl-C to stop.");
+
+    let auto_open = args.open || config.dashboard.auto_open;
+    if auto_open {
+        if let Err(e) = open::that(&url) {
+            eprintln!("warning: could not open browser: {e}");
+        }
+    }
+
+    let serve = axum::serve(listener, app).with_graceful_shutdown(async {
+        let _ = tokio::signal::ctrl_c().await;
+    });
+
+    if let Err(e) = serve.await {
+        eprintln!("error: server error: {e}");
+        let _ = pid::remove_pid();
+        return ExitCode::FAILURE;
+    }
+
+    let _ = pid::remove_pid();
+    ExitCode::SUCCESS
+}
+
+/// Serve embedded static files; fall back to `index.html` for SPA routing.
+async fn static_handler(uri: Uri) -> impl IntoResponse {
+    let raw = uri.path().trim_start_matches('/');
+    let path = if raw.is_empty() { "index.html" } else { raw };
+
+    if let Some(file) = ASSETS.get_file(path) {
+        let mime = mime_guess::from_path(path).first_or_octet_stream();
+        return (
+            [(header::CONTENT_TYPE, mime.as_ref().to_string())],
+            file.contents().to_vec(),
+        )
+            .into_response();
+    }
+
+    // SPA fallback: any unmatched path returns index.html.
+    if let Some(index) = ASSETS.get_file("index.html") {
+        return (
+            [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+            index.contents().to_vec(),
+        )
+            .into_response();
+    }
+
+    (StatusCode::NOT_FOUND, "Not found").into_response()
+}
+
+/// Reverse-proxy `/api/*` to the configured gateway address.
+async fn proxy_handler(
+    State(gateway_url): State<Arc<String>>,
+    method: Method,
+    uri: Uri,
+    req_headers: HeaderMap,
+    body: axum::body::Bytes,
+) -> impl IntoResponse {
+    let path_and_query = uri
+        .path_and_query()
+        .map(|pq| pq.as_str())
+        .unwrap_or(uri.path());
+    let target = format!("{}{}", gateway_url, path_and_query);
+
+    let client = reqwest::Client::new();
+    let reqwest_method = reqwest::Method::from_bytes(method.as_str().as_bytes())
+        .unwrap_or(reqwest::Method::GET);
+
+    let mut builder = client.request(reqwest_method, &target);
+    for (name, value) in &req_headers {
+        if name != header::HOST {
+            builder = builder.header(name.as_str(), value.as_bytes());
+        }
+    }
+    builder = builder.body(body.to_vec());
+
+    let upstream = match builder.send().await {
+        Ok(r) => r,
+        Err(e) => {
+            return (StatusCode::BAD_GATEWAY, e.to_string()).into_response();
+        }
+    };
+
+    let status = StatusCode::from_u16(upstream.status().as_u16())
+        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let resp_headers = upstream.headers().clone();
+    let resp_body = upstream.bytes().await.unwrap_or_default();
+
+    let mut response = Response::new(Body::from(resp_body));
+    *response.status_mut() = status;
+    for (name, value) in &resp_headers {
+        response.headers_mut().insert(name, value.clone());
+    }
+    response
+}

--- a/aa-cli/src/commands/dashboard/start.rs
+++ b/aa-cli/src/commands/dashboard/start.rs
@@ -118,15 +118,11 @@ async fn proxy_handler(
     req_headers: HeaderMap,
     body: axum::body::Bytes,
 ) -> impl IntoResponse {
-    let path_and_query = uri
-        .path_and_query()
-        .map(|pq| pq.as_str())
-        .unwrap_or(uri.path());
+    let path_and_query = uri.path_and_query().map(|pq| pq.as_str()).unwrap_or(uri.path());
     let target = format!("{}{}", gateway_url, path_and_query);
 
     let client = reqwest::Client::new();
-    let reqwest_method = reqwest::Method::from_bytes(method.as_str().as_bytes())
-        .unwrap_or(reqwest::Method::GET);
+    let reqwest_method = reqwest::Method::from_bytes(method.as_str().as_bytes()).unwrap_or(reqwest::Method::GET);
 
     let mut builder = client.request(reqwest_method, &target);
     for (name, value) in &req_headers {
@@ -143,8 +139,7 @@ async fn proxy_handler(
         }
     };
 
-    let status = StatusCode::from_u16(upstream.status().as_u16())
-        .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let status = StatusCode::from_u16(upstream.status().as_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
     let resp_headers = upstream.headers().clone();
     let resp_body = upstream.bytes().await.unwrap_or_default();
 

--- a/aa-cli/src/commands/dashboard/stop.rs
+++ b/aa-cli/src/commands/dashboard/stop.rs
@@ -1,0 +1,53 @@
+//! `aasm dashboard stop` — terminate a running dashboard server via PID file.
+
+use std::process::ExitCode;
+
+use super::pid;
+
+pub fn dispatch() -> ExitCode {
+    let Some((server_pid, _port)) = pid::read_pid() else {
+        println!("No running dashboard found.");
+        return ExitCode::SUCCESS;
+    };
+
+    #[cfg(unix)]
+    {
+        let ret = unsafe { libc::kill(server_pid as libc::pid_t, libc::SIGTERM) };
+        if ret != 0 {
+            let err = std::io::Error::last_os_error();
+            eprintln!("error: could not send SIGTERM to PID {server_pid}: {err}");
+            return ExitCode::FAILURE;
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::io::FromRawHandle;
+        let handle = unsafe {
+            windows_sys::Win32::System::Threading::OpenProcess(
+                windows_sys::Win32::System::Threading::PROCESS_TERMINATE,
+                0,
+                server_pid,
+            )
+        };
+        if handle.is_null() {
+            eprintln!("error: could not open process {server_pid}");
+            return ExitCode::FAILURE;
+        }
+        let ok = unsafe {
+            windows_sys::Win32::System::Threading::TerminateProcess(handle, 1)
+        };
+        unsafe { windows_sys::Win32::Foundation::CloseHandle(handle) };
+        if ok == 0 {
+            eprintln!("error: TerminateProcess failed for PID {server_pid}");
+            return ExitCode::FAILURE;
+        }
+    }
+
+    if let Err(e) = pid::remove_pid() {
+        eprintln!("warning: could not remove PID file: {e}");
+    }
+
+    println!("Dashboard stopped.");
+    ExitCode::SUCCESS
+}

--- a/aa-cli/src/commands/dashboard/stop.rs
+++ b/aa-cli/src/commands/dashboard/stop.rs
@@ -34,9 +34,7 @@ pub fn dispatch() -> ExitCode {
             eprintln!("error: could not open process {server_pid}");
             return ExitCode::FAILURE;
         }
-        let ok = unsafe {
-            windows_sys::Win32::System::Threading::TerminateProcess(handle, 1)
-        };
+        let ok = unsafe { windows_sys::Win32::System::Threading::TerminateProcess(handle, 1) };
         unsafe { windows_sys::Win32::Foundation::CloseHandle(handle) };
         if ok == 0 {
             eprintln!("error: TerminateProcess failed for PID {server_pid}");

--- a/aa-cli/src/config.rs
+++ b/aa-cli/src/config.rs
@@ -39,12 +39,15 @@ impl DashboardConfig {
 
 impl Default for DashboardConfig {
     fn default() -> Self {
-        Self { port: 3000, auto_open: false }
+        Self {
+            port: 3000,
+            auto_open: false,
+        }
     }
 }
 
 /// Top-level CLI configuration file schema (`~/.aa/config.yaml`).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CliConfig {
     /// Name of the default context to use when `--context` is not specified.
     #[serde(default)]
@@ -70,16 +73,6 @@ pub fn resolve_dashboard_port(config: &CliConfig, port_flag: Option<u16>) -> u16
     port_flag.unwrap_or(config.dashboard.port)
 }
 
-impl Default for CliConfig {
-    fn default() -> Self {
-        Self {
-            default_context: None,
-            contexts: BTreeMap::new(),
-            dashboard: DashboardConfig::default(),
-        }
-    }
-}
-
 /// Return the config directory path (`~/.aa/`).
 pub fn config_dir() -> PathBuf {
     dirs::home_dir().expect("cannot determine home directory").join(".aa")
@@ -96,11 +89,7 @@ pub fn config_path() -> PathBuf {
 pub fn load() -> Result<CliConfig, CliError> {
     let path = config_path();
     if !path.exists() {
-        return Ok(CliConfig {
-            default_context: None,
-            contexts: BTreeMap::new(),
-            dashboard: DashboardConfig::default(),
-        });
+        return Ok(CliConfig::default());
     }
     let contents = std::fs::read_to_string(&path).map_err(|e| CliError::Config {
         path: path.clone(),

--- a/aa-cli/src/config.rs
+++ b/aa-cli/src/config.rs
@@ -70,6 +70,16 @@ pub fn resolve_dashboard_port(config: &CliConfig, port_flag: Option<u16>) -> u16
     port_flag.unwrap_or(config.dashboard.port)
 }
 
+impl Default for CliConfig {
+    fn default() -> Self {
+        Self {
+            default_context: None,
+            contexts: BTreeMap::new(),
+            dashboard: DashboardConfig::default(),
+        }
+    }
+}
+
 /// Return the config directory path (`~/.aa/`).
 pub fn config_dir() -> PathBuf {
     dirs::home_dir().expect("cannot determine home directory").join(".aa")

--- a/aa-cli/src/config.rs
+++ b/aa-cli/src/config.rs
@@ -20,6 +20,29 @@ pub struct ContextConfig {
     pub api_key: Option<String>,
 }
 
+/// Dashboard server configuration, stored under `dashboard:` in `~/.aa/config.yaml`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DashboardConfig {
+    /// TCP port the embedded SPA server listens on (default: 3000).
+    #[serde(default = "DashboardConfig::default_port")]
+    pub port: u16,
+    /// Open the system browser automatically after `aasm dashboard start` is ready.
+    #[serde(default)]
+    pub auto_open: bool,
+}
+
+impl DashboardConfig {
+    fn default_port() -> u16 {
+        3000
+    }
+}
+
+impl Default for DashboardConfig {
+    fn default() -> Self {
+        Self { port: 3000, auto_open: false }
+    }
+}
+
 /// Top-level CLI configuration file schema (`~/.aa/config.yaml`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CliConfig {
@@ -29,6 +52,22 @@ pub struct CliConfig {
     /// Named contexts mapping (e.g. `{ "production": { api_url: "..." } }`).
     #[serde(default)]
     pub contexts: BTreeMap<String, ContextConfig>,
+    /// Dashboard server settings (`aasm dashboard start`).
+    #[serde(default)]
+    pub dashboard: DashboardConfig,
+}
+
+/// Resolve the dashboard port from (highest to lowest priority):
+/// 1. `AASM_DASHBOARD_PORT` environment variable
+/// 2. `port_flag` — the `--port` CLI argument
+/// 3. `config.dashboard.port`
+pub fn resolve_dashboard_port(config: &CliConfig, port_flag: Option<u16>) -> u16 {
+    if let Ok(val) = std::env::var("AASM_DASHBOARD_PORT") {
+        if let Ok(p) = val.parse::<u16>() {
+            return p;
+        }
+    }
+    port_flag.unwrap_or(config.dashboard.port)
 }
 
 /// Return the config directory path (`~/.aa/`).
@@ -50,6 +89,7 @@ pub fn load() -> Result<CliConfig, CliError> {
         return Ok(CliConfig {
             default_context: None,
             contexts: BTreeMap::new(),
+            dashboard: DashboardConfig::default(),
         });
     }
     let contents = std::fs::read_to_string(&path).map_err(|e| CliError::Config {
@@ -160,6 +200,7 @@ mod tests {
         CliConfig {
             default_context: Some("production".to_string()),
             contexts,
+            dashboard: DashboardConfig::default(),
         }
     }
 
@@ -225,6 +266,7 @@ mod tests {
         let cfg = CliConfig {
             default_context: None,
             contexts: BTreeMap::new(),
+            dashboard: DashboardConfig::default(),
         };
         let resolved = resolve_context(&cfg, None, None, None).unwrap();
         assert_eq!(resolved.api_url, "http://localhost:8080");

--- a/aa-cli/src/config.rs
+++ b/aa-cli/src/config.rs
@@ -189,7 +189,11 @@ pub fn resolve_context(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn sample_config() -> CliConfig {
         let mut contexts = BTreeMap::new();
@@ -281,5 +285,47 @@ mod tests {
         let resolved = resolve_context(&cfg, None, None, None).unwrap();
         assert_eq!(resolved.api_url, "http://localhost:8080");
         assert!(resolved.name.is_none());
+    }
+
+    #[test]
+    fn dashboard_config_defaults() {
+        let cfg: DashboardConfig = serde_yaml::from_str("{}").unwrap();
+        assert_eq!(cfg.port, 3000);
+        assert!(!cfg.auto_open);
+    }
+
+    #[test]
+    fn dashboard_config_round_trip_yaml() {
+        let yaml = "port: 4000\nauto_open: true\n";
+        let cfg: DashboardConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.port, 4000);
+        assert!(cfg.auto_open);
+        let roundtripped = serde_yaml::to_string(&cfg).unwrap();
+        let cfg2: DashboardConfig = serde_yaml::from_str(&roundtripped).unwrap();
+        assert_eq!(cfg2.port, 4000);
+        assert!(cfg2.auto_open);
+    }
+
+    #[test]
+    fn resolve_dashboard_port_env_overrides_all() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AASM_DASHBOARD_PORT", "9999");
+        let port = resolve_dashboard_port(&CliConfig::default(), Some(5000));
+        std::env::remove_var("AASM_DASHBOARD_PORT");
+        assert_eq!(port, 9999);
+    }
+
+    #[test]
+    fn resolve_dashboard_port_flag_beats_config() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("AASM_DASHBOARD_PORT");
+        assert_eq!(resolve_dashboard_port(&CliConfig::default(), Some(4321)), 4321);
+    }
+
+    #[test]
+    fn resolve_dashboard_port_uses_config_default() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("AASM_DASHBOARD_PORT");
+        assert_eq!(resolve_dashboard_port(&CliConfig::default(), None), 3000);
     }
 }

--- a/aa-cli/tests/dashboard_start.rs
+++ b/aa-cli/tests/dashboard_start.rs
@@ -1,0 +1,72 @@
+use std::net::TcpListener;
+use std::process::Command;
+use std::thread;
+use std::time::{Duration, Instant};
+
+fn free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0").unwrap().local_addr().unwrap().port()
+}
+
+/// Spawn `aasm dashboard start --port <port>` and wait up to 5s for it to
+/// answer HTTP requests. Returns the child process so the caller can kill it.
+fn spawn_dashboard(port: u16) -> std::process::Child {
+    Command::new(env!("CARGO_BIN_EXE_aasm"))
+        .args(["dashboard", "start", "--port", &port.to_string()])
+        .spawn()
+        .expect("failed to spawn aasm dashboard start")
+}
+
+fn wait_for_http(url: &str, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if reqwest::blocking::get(url)
+            .map(|r| r.status().as_u16() < 500)
+            .unwrap_or(false)
+        {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    false
+}
+
+#[test]
+fn dashboard_start_serves_static_files() {
+    let port = free_port();
+    let url = format!("http://127.0.0.1:{port}/");
+
+    let mut child = spawn_dashboard(port);
+
+    let started = wait_for_http(&url, Duration::from_secs(10));
+
+    child.kill().ok();
+    child.wait().ok();
+
+    assert!(started, "dashboard did not become reachable within 10s on port {port}");
+}
+
+#[test]
+fn dashboard_start_returns_200_for_root() {
+    let port = free_port();
+    let url = format!("http://127.0.0.1:{port}/");
+
+    let mut child = spawn_dashboard(port);
+
+    let status = {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let mut result = None;
+        while Instant::now() < deadline {
+            if let Ok(resp) = reqwest::blocking::get(&url) {
+                result = Some(resp.status().as_u16());
+                break;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+        result
+    };
+
+    child.kill().ok();
+    child.wait().ok();
+
+    assert_eq!(status, Some(200), "expected HTTP 200 from /");
+}

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -48,6 +48,45 @@ pnpm test:coverage
 pnpm build
 ```
 
+## Serving the built dashboard
+
+After `pnpm build` produces `dist/`, use the `aasm` CLI to serve it:
+
+```bash
+# Start the embedded SPA server (default port 3000)
+aasm dashboard start
+
+# Override the port
+aasm dashboard start --port 4000
+
+# Start and open the browser automatically
+aasm dashboard start --open
+
+# Port can also be set via environment variable
+AASM_DASHBOARD_PORT=4000 aasm dashboard start
+```
+
+Other dashboard commands:
+
+```bash
+# Open the browser to a running dashboard (reads port from PID file)
+aasm dashboard open
+
+# Stop a running dashboard server
+aasm dashboard stop
+```
+
+Dashboard config can also be set in `~/.aa/config.yaml`:
+
+```yaml
+dashboard:
+  port: 4000       # default: 3000
+  auto_open: true  # default: false
+```
+
+The server proxies `/api/*` requests to the configured gateway address
+(default `http://localhost:8080`, overridden via `--api-url` or context config).
+
 ## API client
 
 The typed client lives in `src/api/client.ts` and is generated from `../openapi/v1.yaml`.


### PR DESCRIPTION
## Description

Adds three web-serving subcommands to `aasm dashboard` so operators can serve the compiled governance dashboard SPA directly from the CLI:

- **`aasm dashboard start`** — serves the embedded `dashboard/dist/` SPA via an axum HTTP server (default port 3000). Proxies `/api/*` to the configured gateway. Writes a PID file for `stop`. Supports `--port`, `--open`, `AASM_DASHBOARD_PORT` env var, and `dashboard.auto_open` config.
- **`aasm dashboard open`** — opens the system browser to a running dashboard (reads port from PID file).
- **`aasm dashboard stop`** — sends SIGTERM (Unix) or TerminateProcess (Windows) to a PID-file-tracked server.

Bare `aasm dashboard` (no subcommand) continues to run the interactive TUI unchanged.

Config is extended with a `dashboard:` section in `~/.aa/config.yaml` (`port`, `auto_open`). A `build.rs` creates a stub `dashboard/dist/index.html` at compile time so the binary always builds even before `pnpm build` is run.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1292
- Epic: AAASM-11

## Testing

- [x] Unit tests added / updated — `config::tests`: port resolution precedence (env > flag > config > default), `DashboardConfig` YAML round-trip and defaults (13 total)
- [x] Integration tests added / updated — `tests/dashboard_start.rs`: spawns the binary, asserts HTTP 200 from `/`
- [x] Manual testing performed — `aasm dashboard start --port 3001` verified in browser

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated — `dashboard/README.md` extended with serving section
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)