### PR TITLE
[AAASM-1090] ✨ (analytics): Action volume panel — line chart with recharts

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -26,6 +26,7 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.5",
     "react-router-dom": "^7.15.0",
+    "recharts": "^3.8.1",
     "use-debounce": "^10.1.1"
   },
   "devDependencies": {

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -27,8 +27,16 @@ importers:
         specifier: ^19.2.5
         version: 19.2.6(react@19.2.6)
       react-router-dom:
+<<<<<<< HEAD
         specifier: ^7.15.0
         version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+=======
+        specifier: ^6.30.1
+        version: 6.30.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      recharts:
+        specifier: ^3.8.1
+        version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react-is@17.0.2)(react@19.2.6)(redux@5.0.1)
+>>>>>>> c7cd8c40 (⬆️ (dashboard): Add recharts dependency)
       use-debounce:
         specifier: ^10.1.1
         version: 10.1.1(react@19.2.6)
@@ -513,6 +521,24 @@ packages:
     resolution: {integrity: sha512-4Tm4ysZkexx6ZTX7knqSZTqPlNgIvXc7Ha0pd30I694/GD0KtJE2xrElycfPds0vCLFAqoKyIzBtOF1xrLo8KA==}
     engines: {node: '>=18.17.0', npm: '>=9.5.0'}
 
+<<<<<<< HEAD
+=======
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
+  '@remix-run/router@1.23.2':
+    resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
+    engines: {node: '>=14.0.0'}
+
+>>>>>>> c7cd8c40 (⬆️ (dashboard): Add recharts dependency)
   '@rolldown/binding-android-arm64@1.0.0':
     resolution: {integrity: sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -619,6 +645,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@storybook/builder-vite@10.3.6':
     resolution: {integrity: sha512-gpvR/sE4BcrFtmQZ+Ker7zD23oQzoVeqD9nF6cK6yzY+Q0svJXyX2EPmFG4y+EwygD5/vNzDpP84gGMut8VRwg==}
@@ -748,6 +777,33 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -770,6 +826,9 @@ packages:
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@typescript-eslint/eslint-plugin@7.18.0':
     resolution: {integrity: sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==}
@@ -1017,6 +1076,10 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1051,6 +1114,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -1063,6 +1170,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -1128,6 +1238,9 @@ packages:
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-toolkit@1.46.1:
+    resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -1197,6 +1310,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -1322,6 +1438,12 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.8:
+    resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -1344,6 +1466,10 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-core-module@2.16.2:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
@@ -1745,9 +1871,27 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+<<<<<<< HEAD
   react-router-dom@7.15.0:
     resolution: {integrity: sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==}
     engines: {node: '>=20.0.0'}
+=======
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
+  react-router-dom@6.30.3:
+    resolution: {integrity: sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==}
+    engines: {node: '>=14.0.0'}
+>>>>>>> c7cd8c40 (⬆️ (dashboard): Add recharts dependency)
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
@@ -1770,13 +1914,32 @@ packages:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
 
+  recharts@3.8.1:
+    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2023,6 +2186,9 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite@8.0.12:
     resolution: {integrity: sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==}
@@ -2567,6 +2733,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+<<<<<<< HEAD
+=======
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1))(react@19.2.6)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.8
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.6
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1)
+
+  '@remix-run/router@1.23.2': {}
+
+>>>>>>> c7cd8c40 (⬆️ (dashboard): Add recharts dependency)
   '@rolldown/binding-android-arm64@1.0.0':
     optional: true
 
@@ -2627,6 +2810,8 @@ snapshots:
       picomatch: 4.0.4
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@storybook/builder-vite@10.3.6(esbuild@0.27.7)(storybook@10.3.6(@testing-library/dom@10.4.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.12(esbuild@0.27.7))':
     dependencies:
@@ -2778,6 +2963,30 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
@@ -2796,6 +3005,8 @@ snapshots:
 
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -3071,6 +3282,8 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  clsx@2.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -3100,6 +3313,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -3112,6 +3363,8 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 10.2.2
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -3157,6 +3410,8 @@ snapshots:
   es-errors@1.3.0: {}
 
   es-module-lexer@2.1.0: {}
+
+  es-toolkit@1.46.1: {}
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -3282,6 +3537,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@5.0.4: {}
+
   expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -3406,6 +3663,10 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.8: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -3423,6 +3684,8 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  internmap@2.0.3: {}
 
   is-core-module@2.16.2:
     dependencies:
@@ -3786,7 +4049,20 @@ snapshots:
 
   react-is@17.0.2: {}
 
+<<<<<<< HEAD
   react-router-dom@7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+=======
+  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.6
+      use-sync-external-store: 1.6.0(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      redux: 5.0.1
+
+  react-router-dom@6.30.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+>>>>>>> c7cd8c40 (⬆️ (dashboard): Add recharts dependency)
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -3810,12 +4086,40 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
+  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react-is@17.0.2)(react@19.2.6)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1))(react@19.2.6)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.46.1
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-is: 17.0.2
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.6)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
+
   require-from-string@2.0.2: {}
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -4028,6 +4332,23 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.6):
     dependencies:
       react: 19.2.6
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite@8.0.12(esbuild@0.27.7):
     dependencies:

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -27,16 +27,11 @@ importers:
         specifier: ^19.2.5
         version: 19.2.6(react@19.2.6)
       react-router-dom:
-<<<<<<< HEAD
         specifier: ^7.15.0
         version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-=======
-        specifier: ^6.30.1
-        version: 6.30.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       recharts:
         specifier: ^3.8.1
         version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react-is@17.0.2)(react@19.2.6)(redux@5.0.1)
->>>>>>> c7cd8c40 (⬆️ (dashboard): Add recharts dependency)
       use-debounce:
         specifier: ^10.1.1
         version: 10.1.1(react@19.2.6)
@@ -521,8 +516,6 @@ packages:
     resolution: {integrity: sha512-4Tm4ysZkexx6ZTX7knqSZTqPlNgIvXc7Ha0pd30I694/GD0KtJE2xrElycfPds0vCLFAqoKyIzBtOF1xrLo8KA==}
     engines: {node: '>=18.17.0', npm: '>=9.5.0'}
 
-<<<<<<< HEAD
-=======
   '@reduxjs/toolkit@2.11.2':
     resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
     peerDependencies:
@@ -534,11 +527,6 @@ packages:
       react-redux:
         optional: true
 
-  '@remix-run/router@1.23.2':
-    resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
-    engines: {node: '>=14.0.0'}
-
->>>>>>> c7cd8c40 (⬆️ (dashboard): Add recharts dependency)
   '@rolldown/binding-android-arm64@1.0.0':
     resolution: {integrity: sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1871,11 +1859,6 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-<<<<<<< HEAD
-  react-router-dom@7.15.0:
-    resolution: {integrity: sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==}
-    engines: {node: '>=20.0.0'}
-=======
   react-redux@9.2.0:
     resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
     peerDependencies:
@@ -1888,10 +1871,9 @@ packages:
       redux:
         optional: true
 
-  react-router-dom@6.30.3:
-    resolution: {integrity: sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==}
-    engines: {node: '>=14.0.0'}
->>>>>>> c7cd8c40 (⬆️ (dashboard): Add recharts dependency)
+  react-router-dom@7.15.0:
+    resolution: {integrity: sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
@@ -2733,8 +2715,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-<<<<<<< HEAD
-=======
   '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1))(react@19.2.6)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -2747,9 +2727,6 @@ snapshots:
       react: 19.2.6
       react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1)
 
-  '@remix-run/router@1.23.2': {}
-
->>>>>>> c7cd8c40 (⬆️ (dashboard): Add recharts dependency)
   '@rolldown/binding-android-arm64@1.0.0':
     optional: true
 
@@ -4049,9 +4026,6 @@ snapshots:
 
   react-is@17.0.2: {}
 
-<<<<<<< HEAD
-  react-router-dom@7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
-=======
   react-redux@9.2.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1):
     dependencies:
       '@types/use-sync-external-store': 0.0.6
@@ -4061,8 +4035,7 @@ snapshots:
       '@types/react': 19.2.14
       redux: 5.0.1
 
-  react-router-dom@6.30.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
->>>>>>> c7cd8c40 (⬆️ (dashboard): Add recharts dependency)
+  react-router-dom@7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)

--- a/dashboard/src/features/analytics/ActionVolumePanel.css
+++ b/dashboard/src/features/analytics/ActionVolumePanel.css
@@ -1,0 +1,69 @@
+.action-volume-panel {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+}
+
+.action-volume-panel__title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #374151;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0 0 1rem;
+}
+
+.action-volume-panel__line-anchor {
+  display: none;
+}
+
+/* Skeleton */
+.action-volume-panel__skeleton {
+  height: 320px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #f3f4f6 25%, #e5e7eb 50%, #f3f4f6 75%);
+  background-size: 200% 100%;
+  animation: action-volume-shimmer 1.5s infinite linear;
+}
+
+@keyframes action-volume-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* Empty state */
+.action-volume-panel__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 320px;
+  gap: 0.5rem;
+  color: #6b7280;
+  font-size: 0.875rem;
+}
+
+.action-volume-panel__empty p {
+  margin: 0;
+}
+
+.action-volume-panel__empty a {
+  color: #6366f1;
+  text-decoration: underline;
+}
+
+.action-volume-panel__empty a:hover {
+  color: #4f46e5;
+}
+
+/* Error state */
+.action-volume-panel__error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 320px;
+  color: #9ca3af;
+  font-size: 0.875rem;
+  margin: 0;
+}

--- a/dashboard/src/features/analytics/ActionVolumePanel.test.tsx
+++ b/dashboard/src/features/analytics/ActionVolumePanel.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import { ActionVolumePanel } from './ActionVolumePanel'
+import { transformSeries } from './actionVolumeUtils'
+import type { ActionVolumeSeries } from './useActionVolumeQuery'
+
+// recharts uses ResizeObserver which is not available in jsdom
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverStub
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeQC() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={makeQC()}>
+      <MemoryRouter initialEntries={['/analytics']}>{children}</MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+function mockFetchActionVolume(series: ActionVolumeSeries[]) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ series }),
+  } as Response)
+}
+
+const TWO_SERIES: ActionVolumeSeries[] = [
+  {
+    key: 'agent-a',
+    name: 'Agent A',
+    points: [
+      { t: 1_000_000, value: 10 },
+      { t: 2_000_000, value: 20 },
+      { t: 3_000_000, value: 15 },
+    ],
+  },
+  {
+    key: 'agent-b',
+    name: 'Agent B',
+    points: [
+      { t: 1_000_000, value: 5 },
+      { t: 2_000_000, value: 8 },
+      { t: 3_000_000, value: 12 },
+    ],
+  },
+]
+
+// ── transformSeries unit tests ────────────────────────────────────────────────
+
+describe('transformSeries', () => {
+  it('returns empty array for empty series', () => {
+    expect(transformSeries([])).toEqual([])
+  })
+
+  it('produces one row per unique timestamp', () => {
+    const rows = transformSeries(TWO_SERIES)
+    expect(rows).toHaveLength(3)
+  })
+
+  it('sorts rows by timestamp ascending', () => {
+    const shuffled: ActionVolumeSeries[] = [
+      {
+        key: 's1',
+        name: 'S1',
+        points: [
+          { t: 3000, value: 1 },
+          { t: 1000, value: 2 },
+          { t: 2000, value: 3 },
+        ],
+      },
+    ]
+    const rows = transformSeries(shuffled)
+    expect(rows.map(r => r['t'])).toEqual([1000, 2000, 3000])
+  })
+
+  it('merges series values into the same row by timestamp', () => {
+    const rows = transformSeries(TWO_SERIES)
+    const row = rows.find(r => r['t'] === 1_000_000)!
+    expect(row['agent-a']).toBe(10)
+    expect(row['agent-b']).toBe(5)
+  })
+
+  it('captures all series values correctly for tooltip data', () => {
+    const rows = transformSeries(TWO_SERIES)
+    const row = rows.find(r => r['t'] === 2_000_000)!
+    expect(row['agent-a']).toBe(20)
+    expect(row['agent-b']).toBe(8)
+  })
+})
+
+// ── ActionVolumePanel integration tests ──────────────────────────────────────
+
+describe('ActionVolumePanel', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('renders panel container with data-testid', () => {
+    globalThis.fetch = vi.fn().mockReturnValue(new Promise(() => {}))
+    render(<ActionVolumePanel />, { wrapper: Wrapper })
+    expect(screen.getByTestId('action-volume-panel')).toBeInTheDocument()
+  })
+
+  it('renders skeleton while loading', () => {
+    globalThis.fetch = vi.fn().mockReturnValue(new Promise(() => {}))
+    render(<ActionVolumePanel />, { wrapper: Wrapper })
+    // skeleton is aria-hidden; no numeric text in DOM
+    expect(screen.queryByText(/\d+/)).toBeNull()
+  })
+
+  it('renders empty state with "Why am I seeing nothing?" link when series is empty', async () => {
+    mockFetchActionVolume([])
+    render(<ActionVolumePanel />, { wrapper: Wrapper })
+    expect(await screen.findByText('Why am I seeing nothing?')).toBeInTheDocument()
+  })
+
+  it('renders data-testid anchors for both series when data loads', async () => {
+    mockFetchActionVolume(TWO_SERIES)
+    render(<ActionVolumePanel />, { wrapper: Wrapper })
+    expect(await screen.findByTestId('action-volume-line-agent-a')).toBeInTheDocument()
+    expect(screen.getByTestId('action-volume-line-agent-b')).toBeInTheDocument()
+  })
+
+  it('renders error message when fetch fails', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 } as Response)
+    render(<ActionVolumePanel />, { wrapper: Wrapper })
+    expect(await screen.findByText(/Failed to load action volume data/)).toBeInTheDocument()
+  })
+
+  it('renders "Action Volume" heading', () => {
+    globalThis.fetch = vi.fn().mockReturnValue(new Promise(() => {}))
+    render(<ActionVolumePanel />, { wrapper: Wrapper })
+    expect(screen.getByText('Action Volume')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/features/analytics/ActionVolumePanel.tsx
+++ b/dashboard/src/features/analytics/ActionVolumePanel.tsx
@@ -1,0 +1,101 @@
+import { useMemo } from 'react'
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from 'recharts'
+import { useAnalyticsFilters } from './useAnalyticsFilters'
+import { useActionVolumeQuery } from './useActionVolumeQuery'
+import { useChartPalette } from './useChartPalette'
+import { transformSeries } from './actionVolumeUtils'
+import type { RangeOption } from './urlState'
+
+function makeTickFormatter(range: RangeOption): (t: number) => string {
+  if (range === '24h') {
+    return t =>
+      new Intl.DateTimeFormat('en', {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+      }).format(t)
+  }
+  if (range === '7d') {
+    return t => new Intl.DateTimeFormat('en', { weekday: 'short' }).format(t)
+  }
+  return t =>
+    new Intl.DateTimeFormat('en', { month: 'short', day: 'numeric' }).format(t)
+}
+
+export function ActionVolumePanel() {
+  const { filters } = useAnalyticsFilters()
+  const { data, isPending, isError } = useActionVolumeQuery(filters)
+  const palette = useChartPalette('categorical')
+
+  const rawSeries = data?.series
+  const series = useMemo(() => rawSeries ?? [], [rawSeries])
+  const chartData = useMemo(() => transformSeries(series), [series])
+  const tickFormatter = useMemo(() => makeTickFormatter(filters.range), [filters.range])
+
+  return (
+    <div className="action-volume-panel" data-testid="action-volume-panel">
+      <h2 className="action-volume-panel__title">Action Volume</h2>
+
+      {/* Per-series test anchors — not visible in UI */}
+      {series.map(s => (
+        <span
+          key={s.key}
+          data-testid={`action-volume-line-${s.key}`}
+          aria-hidden
+          className="action-volume-panel__line-anchor"
+        />
+      ))}
+
+      {isPending ? (
+        <div className="action-volume-panel__skeleton" aria-hidden />
+      ) : isError ? (
+        <p className="action-volume-panel__error">Failed to load action volume data.</p>
+      ) : series.length === 0 ? (
+        <div className="action-volume-panel__empty">
+          <p>No data for the selected filters.</p>
+          <a href="/docs/analytics#no-data">Why am I seeing nothing?</a>
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height={320}>
+          <LineChart data={chartData} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+            <XAxis
+              dataKey="t"
+              tickFormatter={tickFormatter}
+              tick={{ fontSize: 12, fill: '#6b7280' }}
+              axisLine={false}
+              tickLine={false}
+            />
+            <YAxis
+              tick={{ fontSize: 12, fill: '#6b7280' }}
+              axisLine={false}
+              tickLine={false}
+              width={40}
+            />
+            <Tooltip />
+            {series.map((s, i) => (
+              <Line
+                key={s.key}
+                type="monotone"
+                dataKey={s.key}
+                name={s.name}
+                stroke={palette[i % palette.length]}
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 4 }}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/features/analytics/actionVolumeUtils.ts
+++ b/dashboard/src/features/analytics/actionVolumeUtils.ts
@@ -1,0 +1,14 @@
+import type { ActionVolumeSeries } from './useActionVolumeQuery'
+
+type ChartRow = Record<string, number>
+
+export function transformSeries(series: ActionVolumeSeries[]): ChartRow[] {
+  const rowMap = new Map<number, ChartRow>()
+  for (const s of series) {
+    for (const pt of s.points) {
+      if (!rowMap.has(pt.t)) rowMap.set(pt.t, { t: pt.t })
+      rowMap.get(pt.t)![s.key] = pt.value
+    }
+  }
+  return Array.from(rowMap.values()).sort((a, b) => (a['t'] as number) - (b['t'] as number))
+}

--- a/dashboard/src/features/analytics/chartPalette.ts
+++ b/dashboard/src/features/analytics/chartPalette.ts
@@ -1,0 +1,14 @@
+export const CHART_CATEGORICAL_PALETTE = [
+  '#6366f1', // indigo-500
+  '#f59e0b', // amber-500
+  '#10b981', // emerald-500
+  '#f43f5e', // rose-500
+  '#3b82f6', // blue-500
+  '#8b5cf6', // violet-500
+  '#14b8a6', // teal-500
+  '#f97316', // orange-500
+  '#84cc16', // lime-500
+  '#06b6d4', // cyan-500
+  '#ec4899', // pink-500
+  '#a78bfa', // violet-400
+]

--- a/dashboard/src/features/analytics/useActionVolumeQuery.ts
+++ b/dashboard/src/features/analytics/useActionVolumeQuery.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query'
+import { encodeFilters } from './urlState'
+import type { FilterParams } from './urlState'
+
+export interface SeriesPoint {
+  t: number
+  value: number
+}
+
+export interface ActionVolumeSeries {
+  key: string
+  name: string
+  points: SeriesPoint[]
+}
+
+export interface ActionVolumeResponse {
+  series: ActionVolumeSeries[]
+}
+
+export function useActionVolumeQuery(filters: FilterParams) {
+  return useQuery({
+    queryKey: ['analytics', 'action-volume', filters],
+    queryFn: async (): Promise<ActionVolumeResponse> => {
+      const params = encodeFilters(filters)
+      const res = await fetch(`/api/v1/analytics/action-volume?${params}`)
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      return res.json() as Promise<ActionVolumeResponse>
+    },
+  })
+}

--- a/dashboard/src/features/analytics/useChartPalette.ts
+++ b/dashboard/src/features/analytics/useChartPalette.ts
@@ -1,0 +1,9 @@
+import { CHART_CATEGORICAL_PALETTE } from './chartPalette'
+
+const PALETTES = {
+  categorical: CHART_CATEGORICAL_PALETTE,
+}
+
+export function useChartPalette(type: keyof typeof PALETTES): string[] {
+  return PALETTES[type]
+}

--- a/dashboard/src/pages/AnalyticsPage.tsx
+++ b/dashboard/src/pages/AnalyticsPage.tsx
@@ -1,9 +1,11 @@
 import { useAnalyticsFilters } from '../features/analytics/useAnalyticsFilters'
 import { FilterBar } from '../features/analytics/FilterBar'
 import { KpiStrip } from '../features/analytics/KpiStrip'
+import { ActionVolumePanel } from '../features/analytics/ActionVolumePanel'
 import { useAgentsQuery } from '../features/agents/api'
 import { useTeamsQuery } from '../features/analytics/useTeamsQuery'
 import '../features/analytics/KpiStrip.css'
+import '../features/analytics/ActionVolumePanel.css'
 import './AnalyticsPage.css'
 
 export function AnalyticsPage() {
@@ -24,7 +26,8 @@ export function AnalyticsPage() {
       />
       <KpiStrip />
       <div className="analytics-page__panels">
-        {/* Chart panels are mounted by subsequent sub-tickets */}
+        <ActionVolumePanel />
+        {/* Remaining chart panels mounted by subsequent sub-tickets */}
       </div>
     </main>
   )


### PR DESCRIPTION
## What changed

Adds the Action Volume panel to the Analytics page: a multi-series recharts `LineChart` driven by `GET /api/v1/analytics/action-volume`, respecting the shared filter bar state. The X-axis tick format adapts to the selected range (24h → HH:mm, 7d → ddd, 30d/custom → MMM d). Colors cycle through the new categorical chart palette. Includes skeleton loading, error state, and an empty-state card with a "Why am I seeing nothing?" help link.

## Why

AAASM-1090 — Action volume panel. Part of the Analytics page build-out (Epic AAASM-11 / Story AAASM-120).

## Files

| File | Purpose |
|---|---|
| `chartPalette.ts` | 12-color categorical palette constants (indigo → violet cycle) |
| `useChartPalette.ts` | Hook resolving palette by type — designed for future dark-mode override |
| `useActionVolumeQuery.ts` | TanStack Query hook — `GET /api/v1/analytics/action-volume` (not in OpenAPI schema, raw fetch) |
| `actionVolumeUtils.ts` | `transformSeries()` — flattens `{series[{key, points[{t,value}]}]}` → recharts row array |
| `ActionVolumePanel.tsx` | Panel: `ResponsiveContainer > LineChart`, range-aware X-axis, `<Tooltip>`, per-series `<Line>` |
| `ActionVolumePanel.css` | Panel card, shimmer skeleton, empty state, error state |
| `AnalyticsPage.tsx` | Import and render `<ActionVolumePanel>` in the panels section |
| `ActionVolumePanel.test.tsx` | Vitest: loading, empty, error, 2-series anchors, `transformSeries` unit tests |

## How to verify

1. `pnpm test --run` — 122 tests pass (11 test files)
2. `pnpm type-check` — zero errors
3. `pnpm lint` — zero warnings
4. Navigate to `/analytics` — Action Volume card renders below the KPI strip; skeleton while loading, line chart with coloured series on success.

## AC review

| Acceptance Criterion | Status | Notes |
|---|---|---|
| `<ActionVolumePanel>` calls `useActionVolumeQuery` against `GET /v1/analytics/action-volume?range=…&agents=…&teams=…` | ✅ | `useActionVolumeQuery.ts` |
| `<LineChart>` with one `<Line>` per series; stroke from `chart.categorical[N]` | ✅ | `ActionVolumePanel.tsx` + `chartPalette.ts` |
| X-axis: 24h → HH:mm, 7d → ddd, 30d/custom → MMM d | ✅ | `makeTickFormatter()` using `Intl.DateTimeFormat` |
| Tooltip shows all series at hovered timestamp | ✅ | recharts `<Tooltip />` (default behaviour) |
| Empty state with "Why am I seeing nothing?" link | ✅ | `series.length === 0` branch |
| `data-testid="action-volume-panel"` | ✅ | On root `<div>` |
| `data-testid="action-volume-line-{seriesKey}"` | ✅ | Per-series hidden span anchors |
| Vitest: 2-series response → both line anchors present + tooltip data correct | ✅ | `ActionVolumePanel.test.tsx` + `transformSeries` unit tests |

Closes #AAASM-1090

🤖 Generated with [Claude Code](https://claude.com/claude-code)