### PR TITLE
[AAASM-1314] ✨ (dashboard/policy-editor): Add Monaco gutter markers, Validate button, 500ms debounce

### DIFF
--- a/dashboard/src/features/policies/api.test.tsx
+++ b/dashboard/src/features/policies/api.test.tsx
@@ -189,4 +189,16 @@ describe('PolicyEditorPage', () => {
     fireEvent.click(screen.getByTestId('toggle-diff-btn'))
     await waitFor(() => expect(screen.getByTestId('diff-editor')).toBeInTheDocument())
   })
+
+  it('clicking the Validate button triggers validation immediately', async () => {
+    renderEditor()
+    const textarea = await screen.findByTestId('monaco-editor')
+    // Change to invalid YAML but do not wait for the 500ms debounce
+    fireEvent.change(textarea, { target: { value: INVALID_YAML } })
+    expect(screen.queryByTestId('validation-errors')).not.toBeInTheDocument()
+    // Clicking Validate should bypass the debounce and run validation now
+    fireEvent.click(screen.getByTestId('validate-btn'))
+    expect(screen.getByTestId('validation-errors')).toBeInTheDocument()
+    expect(screen.getByTestId('validation-errors').textContent).toMatch(/tab indentation|Missing required/)
+  })
 })

--- a/dashboard/src/pages/PolicyEditorPage.tsx
+++ b/dashboard/src/pages/PolicyEditorPage.tsx
@@ -72,7 +72,7 @@ export function PolicyEditorPage() {
     if (debounceRef.current) clearTimeout(debounceRef.current)
     debounceRef.current = setTimeout(() => {
       setValidationErrors(validateYaml(v))
-    }, 400)
+    }, 500)
   }, [])
 
   const hasErrors = validationErrors.length > 0

--- a/dashboard/src/pages/PolicyEditorPage.tsx
+++ b/dashboard/src/pages/PolicyEditorPage.tsx
@@ -1,7 +1,10 @@
-import { lazy, Suspense, useCallback, useRef, useState } from 'react'
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
+import type { OnMount, Monaco } from '@monaco-editor/react'
 import { useCreatePolicy } from '../features/policies/api'
 import { useToast } from '../components/Toast'
+
+type EditorInstance = Parameters<OnMount>[0]
 
 const MonacoEditor = lazy(() => import('@monaco-editor/react'))
 const DiffEditor = lazy(() =>
@@ -66,6 +69,10 @@ export function PolicyEditorPage() {
 
   // Debounced validation
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Monaco editor + monaco namespace, captured on mount for setModelMarkers
+  const editorRef = useRef<EditorInstance | null>(null)
+  const monacoRef = useRef<Monaco | null>(null)
   const handleChange = useCallback((value: string | undefined) => {
     const v = value ?? ''
     setYaml(v)
@@ -76,6 +83,38 @@ export function PolicyEditorPage() {
   }, [])
 
   const hasErrors = validationErrors.length > 0
+
+  const applyMarkers = useCallback((errors: string[], source: string) => {
+    const editor = editorRef.current
+    const monaco = monacoRef.current
+    if (!editor || !monaco) return
+    const model = editor.getModel()
+    if (!model) return
+    const lines = source.split('\n')
+    const markers = errors.map((msg) => {
+      const lineMatch = msg.match(/^Line (\d+):/)
+      const lineNum = lineMatch ? Math.max(1, parseInt(lineMatch[1], 10)) : 1
+      const lineContent = lines[lineNum - 1] ?? ''
+      return {
+        startLineNumber: lineNum,
+        endLineNumber: lineNum,
+        startColumn: 1,
+        endColumn: Math.max(lineContent.length + 1, 2),
+        message: msg,
+        severity: monaco.MarkerSeverity.Error,
+      }
+    })
+    monaco.editor.setModelMarkers(model, 'policy-validator', markers)
+  }, [])
+
+  useEffect(() => {
+    applyMarkers(validationErrors, yaml)
+  }, [validationErrors, yaml, applyMarkers])
+
+  const handleEditorMount: OnMount = useCallback((editor, monaco) => {
+    editorRef.current = editor
+    monacoRef.current = monaco
+  }, [])
 
   function handleValidate() {
     if (debounceRef.current) clearTimeout(debounceRef.current)
@@ -183,6 +222,7 @@ export function PolicyEditorPage() {
               language="yaml"
               value={yaml}
               onChange={handleChange}
+              onMount={handleEditorMount}
               options={{
                 minimap: { enabled: false },
                 fontSize: 14,

--- a/dashboard/src/pages/PolicyEditorPage.tsx
+++ b/dashboard/src/pages/PolicyEditorPage.tsx
@@ -77,6 +77,11 @@ export function PolicyEditorPage() {
 
   const hasErrors = validationErrors.length > 0
 
+  function handleValidate() {
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    setValidationErrors(validateYaml(yaml))
+  }
+
   async function handleApply() {
     if (hasErrors) return
     try {
@@ -101,6 +106,13 @@ export function PolicyEditorPage() {
           {originalName ? `Edit: ${originalName} v${originalVersion ?? ''}` : 'New Policy'}
         </h1>
         <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <button
+            data-testid="validate-btn"
+            onClick={handleValidate}
+            style={{ padding: '0.5rem 1rem', borderRadius: '0.375rem', border: '1px solid #d1d5db', cursor: 'pointer' }}
+          >
+            Validate
+          </button>
           <button
             data-testid="toggle-diff-btn"
             onClick={() => setShowDiff((v) => !v)}


### PR DESCRIPTION
## What changed

Polish for `PolicyEditorPage` to satisfy the three frontend-fixable ⚠️ AC items identified during AAASM-1061 PR review:

1. **Monaco gutter markers** — captured `editor` + `monaco` instances in `onMount`; `useEffect` calls `monaco.editor.setModelMarkers(model, 'policy-validator', ...)` whenever `validationErrors` or `yaml` change. Marker line number is parsed from the existing `"Line N:"` prefix in `validateYaml()` messages; markers render as red squiggles at the exact line.
2. **`Validate` button** — new button next to `Diff` with `data-testid="validate-btn"`. Clicking it cancels the pending debounce and runs `validateYaml(yaml)` synchronously, so users can force a re-check without waiting.
3. **Debounce bumped 400ms → 500ms** — matches the original AAASM-1061 spec.
4. **Test** — new unit test asserts that clicking `validate-btn` immediately surfaces validation errors without waiting for the debounce.

## Why

These items came from the AAASM-1061 PR #313 review — pure frontend changes, no backend API surface required, so they unblock the parent Story's AC checklist without waiting for `aa-api` work (which is tracked separately under AAASM-1315).

## How to verify

```bash
cd dashboard
pnpm install
pnpm type-check && pnpm lint && pnpm test
# 112/112 tests pass; type-check clean; eslint zero violations
```

Manual:
1. `pnpm dev` → `/policies/editor`
2. Type a tab character on a line → red squiggle appears on that line in the Monaco gutter
3. Type rapidly, then immediately click `Validate` → errors appear instantly (no 500ms wait)

Closes #AAASM-1314