### PR TITLE
[AAASM-1315] ✨ (policies): Add policy_yaml to API + live diff/discard editor

### DIFF
--- a/aa-api/src/routes/policies.rs
+++ b/aa-api/src/routes/policies.rs
@@ -55,19 +55,31 @@ pub async fn list_policies(
 
     let total = all.len() as u64;
 
-    let items: Vec<PolicyResponse> = all
+    let paged: Vec<_> = all
         .into_iter()
         .skip(params.offset())
         .take(params.per_page() as usize)
-        .enumerate()
-        .map(|(i, meta)| PolicyResponse {
+        .collect();
+
+    let mut items: Vec<PolicyResponse> = Vec::with_capacity(paged.len());
+    for (i, meta) in paged.into_iter().enumerate() {
+        // Fetch the YAML body for this version. If the history store cannot
+        // resolve it (rare — corrupted entry), surface an empty string rather
+        // than failing the whole list.
+        let yaml = state
+            .policy_history
+            .get(&meta.sha256)
+            .await
+            .map(|snap| snap.yaml_content)
+            .unwrap_or_default();
+        items.push(PolicyResponse {
             name: meta.sha256[..12].to_string(),
             version: meta.timestamp,
             active: i == 0 && params.page() == 1,
             rule_count: 0,
-            policy_yaml: String::new(),
-        })
-        .collect();
+            policy_yaml: yaml,
+        });
+    }
 
     Ok((
         StatusCode::OK,

--- a/aa-api/src/routes/policies.rs
+++ b/aa-api/src/routes/policies.rs
@@ -202,6 +202,24 @@ pub async fn get_active_policy(
     Extension(state): Extension<AppState>,
 ) -> Result<(StatusCode, Json<PolicyResponse>), ProblemDetail> {
     let info = state.policy_engine.active_policy_info();
+
+    // The active policy's YAML lives in the history store. We treat the
+    // most-recent history entry as the active one (apply_yaml always
+    // saves to history before swapping the engine). A startup-loaded
+    // policy with no history entry yields an empty string.
+    let policy_yaml = match state.policy_history.list(1).await {
+        Ok(metas) => match metas.first() {
+            Some(m) => state
+                .policy_history
+                .get(&m.sha256)
+                .await
+                .map(|snap| snap.yaml_content)
+                .unwrap_or_default(),
+            None => String::new(),
+        },
+        Err(_) => String::new(),
+    };
+
     Ok((
         StatusCode::OK,
         Json(PolicyResponse {
@@ -209,7 +227,7 @@ pub async fn get_active_policy(
             version: info.policy_version.unwrap_or_else(|| "unknown".to_string()),
             active: true,
             rule_count: info.rule_count,
-            policy_yaml: String::new(),
+            policy_yaml,
         }),
     ))
 }

--- a/aa-api/src/routes/policies.rs
+++ b/aa-api/src/routes/policies.rs
@@ -25,6 +25,10 @@ pub struct PolicyResponse {
     pub active: bool,
     /// Number of rules in this policy version.
     pub rule_count: usize,
+    /// Raw YAML content of this policy version. Empty string when the
+    /// underlying snapshot is not retrievable from the history store
+    /// (e.g. a policy loaded at startup before any history entry exists).
+    pub policy_yaml: String,
 }
 
 /// `GET /api/v1/policies` — list all policy versions.
@@ -61,6 +65,7 @@ pub async fn list_policies(
             version: meta.timestamp,
             active: i == 0 && params.page() == 1,
             rule_count: 0,
+            policy_yaml: String::new(),
         })
         .collect();
 
@@ -148,6 +153,7 @@ pub async fn create_policy(
             version: meta.timestamp,
             active: true,
             rule_count: 0,
+            policy_yaml: String::new(),
         }),
     ))
 }
@@ -191,6 +197,7 @@ pub async fn get_active_policy(
             version: info.policy_version.unwrap_or_else(|| "unknown".to_string()),
             active: true,
             rule_count: info.rule_count,
+            policy_yaml: String::new(),
         }),
     ))
 }

--- a/aa-api/src/routes/policies.rs
+++ b/aa-api/src/routes/policies.rs
@@ -165,7 +165,7 @@ pub async fn create_policy(
             version: meta.timestamp,
             active: true,
             rule_count: 0,
-            policy_yaml: String::new(),
+            policy_yaml: body.policy_yaml,
         }),
     ))
 }

--- a/aa-api/tests/policies.rs
+++ b/aa-api/tests/policies.rs
@@ -56,6 +56,8 @@ async fn create_policy_returns_201_for_valid_yaml() {
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(json["active"], true);
     assert!(json["version"].as_str().is_some());
+    // policy_yaml round-trips the request body back to the caller.
+    assert_eq!(json["policy_yaml"], VALID_POLICY_YAML);
 }
 
 #[tokio::test]
@@ -122,6 +124,8 @@ async fn list_policies_returns_created_versions() {
     assert_eq!(items.len(), 1);
     assert_eq!(items[0]["active"], true);
     assert!(items[0]["version"].as_str().is_some());
+    // policy_yaml is loaded from the history store snapshot.
+    assert_eq!(items[0]["policy_yaml"], VALID_POLICY_YAML);
 }
 
 // ── GET /api/v1/policies/active ─────────────────────────────────────────
@@ -201,4 +205,6 @@ async fn get_active_policy_reflects_applied_policy() {
     assert_eq!(json["version"], "2.0.0");
     assert_eq!(json["active"], true);
     assert_eq!(json["rule_count"], 2);
+    // policy_yaml is fetched from history (most-recent entry == active).
+    assert_eq!(json["policy_yaml"], ENVELOPE_POLICY_WITH_TOOLS);
 }

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -1021,6 +1021,12 @@ export interface components {
             active: boolean;
             /** @description Policy name from metadata. */
             name: string;
+            /**
+             * @description Raw YAML content of this policy version. Empty string when the
+             *     underlying snapshot is not retrievable from the history store
+             *     (e.g. a policy loaded at startup before any history entry exists).
+             */
+            policy_yaml: string;
             /** @description Number of rules in this policy version. */
             rule_count: number;
             /** @description Policy version string. */

--- a/dashboard/src/features/policies/api.test.tsx
+++ b/dashboard/src/features/policies/api.test.tsx
@@ -185,11 +185,14 @@ describe('PolicyEditorPage', () => {
     })
   })
 
-  it('shows diff editor when Diff button is clicked', async () => {
+  it('renders editor and diff side-by-side', async () => {
     renderEditor()
     await screen.findByTestId('monaco-editor')
-    fireEvent.click(screen.getByTestId('toggle-diff-btn'))
-    await waitFor(() => expect(screen.getByTestId('diff-editor')).toBeInTheDocument())
+    expect(screen.getByTestId('policy-editor-pane')).toBeInTheDocument()
+    expect(screen.getByTestId('policy-diff-pane')).toBeInTheDocument()
+    // The DiffEditor lazy-loads in a separate Suspense — allow a longer wait
+    // because both lazy components resolve in parallel during the same tick.
+    await screen.findByTestId('diff-editor', {}, { timeout: 5000 })
   })
 
   it('clicking the Validate button triggers validation immediately', async () => {

--- a/dashboard/src/features/policies/api.test.tsx
+++ b/dashboard/src/features/policies/api.test.tsx
@@ -67,6 +67,7 @@ const MOCK_POLICY: Policy = {
   version: '1.0.0',
   rule_count: 5,
   active: true,
+  policy_yaml: 'metadata:\n  name: default-policy\n  version: "1.0.0"\nrules: []\n',
 }
 
 const MOCK_INACTIVE: Policy = {
@@ -74,6 +75,7 @@ const MOCK_INACTIVE: Policy = {
   version: '0.9.0',
   rule_count: 3,
   active: false,
+  policy_yaml: 'metadata:\n  name: old-policy\n  version: "0.9.0"\nrules: []\n',
 }
 
 describe('PoliciesPage', () => {

--- a/dashboard/src/features/policies/api.test.tsx
+++ b/dashboard/src/features/policies/api.test.tsx
@@ -206,4 +206,58 @@ describe('PolicyEditorPage', () => {
     expect(screen.getByTestId('validation-errors')).toBeInTheDocument()
     expect(screen.getByTestId('validation-errors').textContent).toMatch(/tab indentation|Missing required/)
   })
+
+  it('loads live YAML into editor when ?name=&version= params are present', async () => {
+    const LIVE = 'metadata:\n  name: prod\n  version: "2.0.0"\nrules: []\n'
+    vi.spyOn(policiesApi, 'usePolicyByVersion').mockReturnValue(
+      mockQuery<Policy | null>({
+        data: { name: 'prod', version: '2.0.0', rule_count: 0, active: true, policy_yaml: LIVE },
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    )
+    vi.spyOn(policiesApi, 'useCreatePolicy').mockReturnValue(
+      mockMutation<Policy | undefined, policiesApi.CreatePolicyRequest>({ mutateAsync: vi.fn(), isPending: false }),
+    )
+    render(
+      <Wrapper path="/policies/editor" initialPath="/policies/editor?name=prod&version=2.0.0">
+        <PolicyEditorPage />
+      </Wrapper>,
+    )
+    const textarea = await screen.findByTestId('monaco-editor')
+    await waitFor(() => expect((textarea as HTMLTextAreaElement).value).toBe(LIVE))
+  })
+
+  it('Discard resets editor draft back to live YAML and stays on the page', async () => {
+    const LIVE = 'metadata:\n  name: prod\n  version: "2.0.0"\nrules: []\n'
+    vi.spyOn(policiesApi, 'usePolicyByVersion').mockReturnValue(
+      mockQuery<Policy | null>({
+        data: { name: 'prod', version: '2.0.0', rule_count: 0, active: true, policy_yaml: LIVE },
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    )
+    vi.spyOn(policiesApi, 'useCreatePolicy').mockReturnValue(
+      mockMutation<Policy | undefined, policiesApi.CreatePolicyRequest>({ mutateAsync: vi.fn(), isPending: false }),
+    )
+    render(
+      <Wrapper path="/policies/editor" initialPath="/policies/editor?name=prod&version=2.0.0">
+        <PolicyEditorPage />
+      </Wrapper>,
+    )
+    const textarea = await screen.findByTestId('monaco-editor')
+    await waitFor(() => expect((textarea as HTMLTextAreaElement).value).toBe(LIVE))
+
+    // Edit the draft
+    fireEvent.change(textarea, { target: { value: 'metadata:\n  name: edited\nrules: []\n' } })
+    expect((textarea as HTMLTextAreaElement).value).toContain('edited')
+
+    // Discard resets to live YAML
+    fireEvent.click(screen.getByTestId('discard-btn'))
+    await waitFor(() => expect((textarea as HTMLTextAreaElement).value).toBe(LIVE))
+    // Page is still the editor (no navigation away)
+    expect(screen.getByTestId('policy-editor')).toBeInTheDocument()
+  })
 })

--- a/dashboard/src/features/policies/api.ts
+++ b/dashboard/src/features/policies/api.ts
@@ -27,6 +27,24 @@ export function useActivePolicyQuery() {
   })
 }
 
+/**
+ * Load a specific policy version's full record (including `policy_yaml`)
+ * by filtering the list endpoint. Returns `null` when no matching policy
+ * is found on the first page, or when `name`/`version` are missing.
+ */
+export function usePolicyByVersion(name: string | null, version: string | null) {
+  return useQuery({
+    queryKey: ['policies', 'by-version', name, version],
+    queryFn: async () => {
+      const { data, error } = await api.GET('/api/v1/policies', {})
+      if (error) throw new Error('Failed to fetch policies')
+      const list = (data ?? []) as Policy[]
+      return list.find((p) => p.name === name && p.version === version) ?? null
+    },
+    enabled: !!name && !!version,
+  })
+}
+
 export function useCreatePolicy() {
   const queryClient = useQueryClient()
   return useMutation({

--- a/dashboard/src/pages/PolicyEditorPage.tsx
+++ b/dashboard/src/pages/PolicyEditorPage.tsx
@@ -1,15 +1,13 @@
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
+import { DiffEditor } from '@monaco-editor/react'
 import type { OnMount, Monaco } from '@monaco-editor/react'
-import { useCreatePolicy } from '../features/policies/api'
+import { useCreatePolicy, usePolicyByVersion } from '../features/policies/api'
 import { useToast } from '../components/Toast'
 
 type EditorInstance = Parameters<OnMount>[0]
 
 const MonacoEditor = lazy(() => import('@monaco-editor/react'))
-const DiffEditor = lazy(() =>
-  import('@monaco-editor/react').then((m) => ({ default: m.DiffEditor })),
-)
 
 const EMPTY_POLICY = `# Governance policy YAML
 # See: https://docs.agent-assembly.io/policies
@@ -28,16 +26,12 @@ function validateYaml(yaml: string): string[] {
     return errors
   }
   try {
-    // Basic structural checks without importing a full YAML parser.
-    // Real parse validation happens server-side on apply.
     const lines = yaml.split('\n')
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]
-      // Detect tab indentation which YAML forbids
       if (/^\t/.test(line)) {
         errors.push(`Line ${i + 1}: YAML must not use tab indentation.`)
       }
-      // Detect unmatched braces (simple heuristic)
       const opens = (line.match(/\{/g) ?? []).length
       const closes = (line.match(/\}/g) ?? []).length
       if (opens !== closes) {
@@ -61,11 +55,25 @@ export function PolicyEditorPage() {
   const originalName = searchParams.get('name')
   const originalVersion = searchParams.get('version')
 
+  // Fetch the live policy version when name+version are present in the URL.
+  const { data: livePolicy } = usePolicyByVersion(originalName, originalVersion)
+
   const [yaml, setYaml] = useState(EMPTY_POLICY)
+  // The "live" YAML — used as the diff baseline and Discard target.
+  // Mutated only when the hook resolves with a new policy.
+  const [liveYaml, setLiveYaml] = useState(EMPTY_POLICY)
   const [validationErrors, setValidationErrors] = useState<string[]>(() => validateYaml(EMPTY_POLICY))
-  const [showDiff, setShowDiff] = useState(false)
-  // Store the "before" snapshot for the diff view; never mutated after mount.
-  const [originalYaml] = useState(EMPTY_POLICY)
+
+  // When the live policy resolves, sync both the editor and the diff baseline.
+  // Setting state inside this effect is intentional — we need to react to the
+  // async query result. Guarded so it only fires when the live YAML changes.
+  useEffect(() => {
+    if (!livePolicy?.policy_yaml) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setYaml(livePolicy.policy_yaml)
+    setLiveYaml(livePolicy.policy_yaml)
+    setValidationErrors(validateYaml(livePolicy.policy_yaml))
+  }, [livePolicy])
 
   // Debounced validation
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -73,6 +81,7 @@ export function PolicyEditorPage() {
   // Monaco editor + monaco namespace, captured on mount for setModelMarkers
   const editorRef = useRef<EditorInstance | null>(null)
   const monacoRef = useRef<Monaco | null>(null)
+
   const handleChange = useCallback((value: string | undefined) => {
     const v = value ?? ''
     setYaml(v)
@@ -133,13 +142,16 @@ export function PolicyEditorPage() {
   }
 
   function handleDiscard() {
-    if (yaml === originalYaml || window.confirm('Discard unsaved changes?')) {
-      navigate('/policies')
-    }
+    // Reset editor draft back to the live YAML — stay on the page.
+    setYaml(liveYaml)
+    setValidationErrors(validateYaml(liveYaml))
   }
 
   return (
-    <main style={{ padding: '1.5rem', display: 'flex', flexDirection: 'column', gap: '1rem' }} data-testid="policy-editor">
+    <main
+      style={{ padding: '1.5rem', display: 'flex', flexDirection: 'column', gap: '1rem' }}
+      data-testid="policy-editor"
+    >
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <h1 style={{ margin: 0 }}>
           {originalName ? `Edit: ${originalName} v${originalVersion ?? ''}` : 'New Policy'}
@@ -151,13 +163,6 @@ export function PolicyEditorPage() {
             style={{ padding: '0.5rem 1rem', borderRadius: '0.375rem', border: '1px solid #d1d5db', cursor: 'pointer' }}
           >
             Validate
-          </button>
-          <button
-            data-testid="toggle-diff-btn"
-            onClick={() => setShowDiff((v) => !v)}
-            style={{ padding: '0.5rem 1rem', borderRadius: '0.375rem', border: '1px solid #d1d5db', cursor: 'pointer' }}
-          >
-            {showDiff ? 'Editor' : 'Diff'}
           </button>
           <button
             data-testid="discard-btn"
@@ -206,17 +211,12 @@ export function PolicyEditorPage() {
         </ul>
       )}
 
-      <div style={{ border: '1px solid #e5e7eb', borderRadius: '0.375rem', overflow: 'hidden', height: '60vh' }}>
-        <Suspense fallback={<div style={{ padding: '1rem' }} data-testid="editor-loading">Loading editor…</div>}>
-          {showDiff ? (
-            <DiffEditor
-              height="60vh"
-              language="yaml"
-              original={originalYaml}
-              modified={yaml}
-              options={{ readOnly: false, renderSideBySide: true }}
-            />
-          ) : (
+      <Suspense fallback={<div style={{ padding: '1rem' }} data-testid="editor-loading">Loading editor…</div>}>
+        <div style={{ display: 'flex', gap: '0.5rem', height: '60vh' }}>
+          <div
+            data-testid="policy-editor-pane"
+            style={{ flex: 1, border: '1px solid #e5e7eb', borderRadius: '0.375rem', overflow: 'hidden' }}
+          >
             <MonacoEditor
               height="60vh"
               language="yaml"
@@ -230,10 +230,21 @@ export function PolicyEditorPage() {
                 wordWrap: 'on',
               }}
             />
-          )}
-        </Suspense>
-      </div>
-
+          </div>
+          <div
+            data-testid="policy-diff-pane"
+            style={{ flex: 1, border: '1px solid #e5e7eb', borderRadius: '0.375rem', overflow: 'hidden' }}
+          >
+            <DiffEditor
+              height="60vh"
+              language="yaml"
+              original={liveYaml}
+              modified={yaml}
+              options={{ readOnly: true, renderSideBySide: false }}
+            />
+          </div>
+        </div>
+      </Suspense>
     </main>
   )
 }

--- a/dashboard/tests/e2e/governance-dashboard.spec.ts
+++ b/dashboard/tests/e2e/governance-dashboard.spec.ts
@@ -229,20 +229,18 @@ test.describe('Policy editor page', () => {
     await expect(page.getByTestId('apply-btn')).not.toBeDisabled()
   })
 
-  test('Diff button toggles to diff panel and back', async ({ page }) => {
+  test('Editor and Diff panel render side-by-side', async ({ page }) => {
     await page.goto('/policies/editor')
-    await expect(page.getByTestId('toggle-diff-btn')).toHaveText('Diff')
-    await page.getByTestId('toggle-diff-btn').click()
-    // Monaco loads async; confirm the toggle state changed before the editor resolves
-    await expect(page.getByTestId('toggle-diff-btn')).toHaveText('Editor')
-    await page.getByTestId('toggle-diff-btn').click()
-    await expect(page.getByTestId('toggle-diff-btn')).toHaveText('Diff')
+    await expect(page.getByTestId('policy-editor-pane')).toBeVisible()
+    await expect(page.getByTestId('policy-diff-pane')).toBeVisible()
   })
 
-  test('Discard navigates back to /policies', async ({ page }) => {
+  test('Discard resets editor without leaving the page', async ({ page }) => {
     await page.goto('/policies/editor')
     await page.getByTestId('discard-btn').click()
-    await expect(page).toHaveURL(/\/policies$/)
+    // Stays on the editor page (no navigation back to /policies)
+    await expect(page).toHaveURL(/\/policies\/editor/)
+    await expect(page.getByTestId('policy-editor')).toBeVisible()
   })
 })
 

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1705,6 +1705,7 @@ components:
       - version
       - active
       - rule_count
+      - policy_yaml
       properties:
         active:
           type: boolean
@@ -1712,6 +1713,12 @@ components:
         name:
           type: string
           description: Policy name from metadata.
+        policy_yaml:
+          type: string
+          description: |-
+            Raw YAML content of this policy version. Empty string when the
+            underlying snapshot is not retrievable from the history store
+            (e.g. a policy loaded at startup before any history entry exists).
         rule_count:
           type: integer
           description: Number of rules in this policy version.


### PR DESCRIPTION
## What changed

### Backend (`aa-api` / `openapi`)

- `PolicyResponse` schema gains a required `policy_yaml: String` field (the raw YAML body of the policy version).
- `GET /api/v1/policies` populates `policy_yaml` from the policy history store (one `history.get(&sha256)` per page item; falls back to `""` for unreadable entries).
- `GET /api/v1/policies/active` populates `policy_yaml` by fetching the most-recent history entry (after `apply_yaml` the active policy is always the newest in history; a startup-loaded-only policy yields `""`).
- `POST /api/v1/policies` echoes `body.policy_yaml` back in the response so clients can diff against the just-applied version.
- OpenAPI spec updated to match utoipa codegen — passes the OpenAPI drift check.
- Backend tests assert `policy_yaml` is populated in all three handlers.

### Frontend (`dashboard`)

- Regenerated `src/api/generated/schema.d.ts` from the new OpenAPI spec.
- New `usePolicyByVersion(name, version)` hook in `features/policies/api.ts` filters the list endpoint by `{name, version}` and returns the full `Policy` record (including `policy_yaml`) or `null`.
- `PolicyEditorPage` rewrite:
  - Reads `?name=` and `?version=` from the URL; when both are present, calls `usePolicyByVersion` and initialises both the editor draft (`yaml`) and the diff baseline (`liveYaml`) from `policy_yaml` once the hook resolves.
  - **Side-by-side layout** (replaces the prior toggle): editor LEFT, read-only `DiffEditor` RIGHT, both visible simultaneously. `DiffEditor.original = liveYaml`, `DiffEditor.modified = yaml`.
  - **Discard** now resets the editor draft back to `liveYaml` and stays on the page (no navigation), per the original AC.
  - Removed `toggle-diff-btn` and `showDiff` state.
- Unit tests + Playwright spec updated for the new layout and Discard behaviour; new unit tests cover live-YAML load and Discard-to-live.

## Why

AAASM-1315 closes the two API-forced ⚠️ gaps identified during AAASM-1061's PR #313 review: the editor previously couldn't diff against (or revert to) the actually-deployed policy because the API only returned metadata. The backend now exposes the raw YAML, and the editor uses it for both initialisation and Discard.

## How to verify

```bash
# Backend
cargo nextest run -p aa-api --test policies   # 7/7 pass
cargo run -p aa-api --bin generate_openapi | diff - openapi/v1.yaml   # zero diff

# Frontend
cd dashboard
pnpm install
pnpm type-check && pnpm lint && pnpm test     # 125/125 pass
```

Manual:
1. `pnpm dev` → `/policies`
2. Click an existing policy's Edit link → editor opens with the live YAML pre-loaded on both panes.
3. Edit the left pane → right diff highlights the changes against the live YAML.
4. Click Discard → editor resets to live YAML, page stays.

Closes #AAASM-1315