### PR TITLE
[AAASM-1094] ✨ (analytics): Approval analytics panel + Playwright E2E

### DIFF
--- a/dashboard/src/features/analytics/ApprovalAnalyticsPanel.css
+++ b/dashboard/src/features/analytics/ApprovalAnalyticsPanel.css
@@ -1,0 +1,111 @@
+.approval-analytics-panel {
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+}
+
+.approval-analytics-panel__header {
+  margin-bottom: 1rem;
+}
+
+.approval-analytics-panel__title {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #374151;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.approval-analytics-panel__skeleton {
+  height: 260px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #f3f4f6 25%, #e5e7eb 50%, #f3f4f6 75%);
+  background-size: 200% 100%;
+  animation: approval-analytics-shimmer 1.5s infinite linear;
+}
+
+@keyframes approval-analytics-shimmer {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.approval-analytics-panel__error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 260px;
+  color: #9ca3af;
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.approval-analytics-panel__body {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.approval-analytics-panel__stats {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex-shrink: 0;
+}
+
+.approval-analytics-panel__stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.approval-analytics-panel__stat-value {
+  font-size: 1.375rem;
+  font-weight: 700;
+  color: #111827;
+  line-height: 1.2;
+}
+
+.approval-analytics-panel__stat-label {
+  font-size: 0.75rem;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.approval-analytics-panel__donut {
+  flex: 1;
+  min-width: 0;
+}
+
+.approval-analytics-panel__legend {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.approval-analytics-panel__legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  color: #374151;
+}
+
+.approval-analytics-panel__legend-swatch {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+
+.approval-analytics-panel__legend-count {
+  margin-left: auto;
+  color: #6b7280;
+  font-variant-numeric: tabular-nums;
+}

--- a/dashboard/src/features/analytics/ApprovalAnalyticsPanel.test.tsx
+++ b/dashboard/src/features/analytics/ApprovalAnalyticsPanel.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import { ApprovalAnalyticsPanel } from './ApprovalAnalyticsPanel'
+import type { ApprovalAnalyticsResponse } from './useApprovalAnalyticsQuery'
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = ResizeObserverStub
+
+function makeQC() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={makeQC()}>
+      <MemoryRouter initialEntries={['/analytics']}>{children}</MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+const FIXTURE: ApprovalAnalyticsResponse = {
+  volume: 1240,
+  medianTta: 185,
+  approvalRate: 0.874,
+  byOutcome: { approved: 1083, rejected: 124, expired: 33 },
+}
+
+function mockFetch(data: ApprovalAnalyticsResponse) {
+  globalThis.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(data),
+  } as Response)
+}
+
+// ── formatter unit tests ──────────────────────────────────────────────────────
+
+// These are tested indirectly via the rendered output to avoid exporting
+// implementation details from the component file.
+
+describe('ApprovalAnalyticsPanel — stat formatting', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('formats volume as localized number', async () => {
+    mockFetch(FIXTURE)
+    render(<ApprovalAnalyticsPanel />, { wrapper: Wrapper })
+    expect(await screen.findByText('1,240')).toBeInTheDocument()
+  })
+
+  it('formats medianTta in minutes and seconds', async () => {
+    mockFetch(FIXTURE) // 185s = 3m 5s
+    render(<ApprovalAnalyticsPanel />, { wrapper: Wrapper })
+    expect(await screen.findByText('3m 5s')).toBeInTheDocument()
+  })
+
+  it('formats approvalRate as percentage', async () => {
+    mockFetch(FIXTURE) // 0.874 → 87.4%
+    render(<ApprovalAnalyticsPanel />, { wrapper: Wrapper })
+    expect(await screen.findByText('87.4%')).toBeInTheDocument()
+  })
+})
+
+// ── panel integration tests ───────────────────────────────────────────────────
+
+describe('ApprovalAnalyticsPanel', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('renders panel with data-testid', () => {
+    globalThis.fetch = vi.fn().mockReturnValue(new Promise(() => {}))
+    render(<ApprovalAnalyticsPanel />, { wrapper: Wrapper })
+    expect(screen.getByTestId('approval-analytics-panel')).toBeInTheDocument()
+  })
+
+  it('renders skeleton while loading', () => {
+    globalThis.fetch = vi.fn().mockReturnValue(new Promise(() => {}))
+    render(<ApprovalAnalyticsPanel />, { wrapper: Wrapper })
+    expect(screen.queryByText('Total volume')).toBeNull()
+  })
+
+  it('renders error state when fetch fails', async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 } as Response)
+    render(<ApprovalAnalyticsPanel />, { wrapper: Wrapper })
+    expect(await screen.findByText(/Failed to load approval data/)).toBeInTheDocument()
+  })
+
+  it('renders all three stat labels', async () => {
+    mockFetch(FIXTURE)
+    render(<ApprovalAnalyticsPanel />, { wrapper: Wrapper })
+    await screen.findByText('1,240')
+    expect(screen.getByText('Total volume')).toBeInTheDocument()
+    expect(screen.getByText('Median TTA')).toBeInTheDocument()
+    expect(screen.getByText('Approval rate')).toBeInTheDocument()
+  })
+
+  it('renders approval-donut data-testid', async () => {
+    mockFetch(FIXTURE)
+    render(<ApprovalAnalyticsPanel />, { wrapper: Wrapper })
+    await screen.findByText('1,240')
+    expect(screen.getByTestId('approval-donut')).toBeInTheDocument()
+  })
+
+  it('renders outcome legend with approved / rejected / expired', async () => {
+    mockFetch(FIXTURE)
+    render(<ApprovalAnalyticsPanel />, { wrapper: Wrapper })
+    await screen.findByText('Approved')
+    expect(screen.getByText('Rejected')).toBeInTheDocument()
+    expect(screen.getByText('Expired')).toBeInTheDocument()
+  })
+
+  it('renders outcome counts in the legend', async () => {
+    mockFetch(FIXTURE)
+    render(<ApprovalAnalyticsPanel />, { wrapper: Wrapper })
+    await screen.findByText('1,083')
+    expect(screen.getByText('124')).toBeInTheDocument()
+    expect(screen.getByText('33')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/features/analytics/ApprovalAnalyticsPanel.tsx
+++ b/dashboard/src/features/analytics/ApprovalAnalyticsPanel.tsx
@@ -1,0 +1,114 @@
+import { useMemo } from 'react'
+import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from 'recharts'
+import { useAnalyticsFilters } from './useAnalyticsFilters'
+import { useApprovalAnalyticsQuery } from './useApprovalAnalyticsQuery'
+import { CHART_COLORBLIND_PALETTE } from './chartPalette'
+import type { ApprovalAnalyticsResponse } from './useApprovalAnalyticsQuery'
+
+function formatTta(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  if (m < 60) return s > 0 ? `${m}m ${s}s` : `${m}m`
+  const h = Math.floor(m / 60)
+  const rem = m % 60
+  return rem > 0 ? `${h}h ${rem}m` : `${h}h`
+}
+
+function formatRate(rate: number): string {
+  return `${(rate * 100).toFixed(1)}%`
+}
+
+function buildDonutData(data: ApprovalAnalyticsResponse) {
+  return [
+    { name: 'Approved', value: data.byOutcome.approved },
+    { name: 'Rejected', value: data.byOutcome.rejected },
+    { name: 'Expired',  value: data.byOutcome.expired  },
+  ]
+}
+
+const DONUT_COLORS = [
+  CHART_COLORBLIND_PALETTE[2], // bluish green — approved
+  CHART_COLORBLIND_PALETTE[5], // vermilion — rejected
+  CHART_COLORBLIND_PALETTE[3], // yellow — expired
+]
+
+export function ApprovalAnalyticsPanel() {
+  const { filters } = useAnalyticsFilters()
+  const { data, isPending, isError } = useApprovalAnalyticsQuery(filters)
+
+  const donutData = useMemo(() => (data ? buildDonutData(data) : []), [data])
+
+  return (
+    <div className="approval-analytics-panel" data-testid="approval-analytics-panel">
+      <div className="approval-analytics-panel__header">
+        <h2 className="approval-analytics-panel__title">Approval Analytics</h2>
+      </div>
+
+      {isPending ? (
+        <div className="approval-analytics-panel__skeleton" aria-hidden />
+      ) : isError ? (
+        <p className="approval-analytics-panel__error">Failed to load approval data.</p>
+      ) : !data ? null : (
+        <div className="approval-analytics-panel__body">
+          <div className="approval-analytics-panel__stats">
+            <div className="approval-analytics-panel__stat">
+              <span className="approval-analytics-panel__stat-value">
+                {data.volume.toLocaleString()}
+              </span>
+              <span className="approval-analytics-panel__stat-label">Total volume</span>
+            </div>
+            <div className="approval-analytics-panel__stat">
+              <span className="approval-analytics-panel__stat-value">
+                {formatTta(data.medianTta)}
+              </span>
+              <span className="approval-analytics-panel__stat-label">Median TTA</span>
+            </div>
+            <div className="approval-analytics-panel__stat">
+              <span className="approval-analytics-panel__stat-value">
+                {formatRate(data.approvalRate)}
+              </span>
+              <span className="approval-analytics-panel__stat-label">Approval rate</span>
+            </div>
+          </div>
+
+          <div className="approval-analytics-panel__donut" data-testid="approval-donut">
+            <ResponsiveContainer width="100%" height={180}>
+              <PieChart>
+                <Pie
+                  data={donutData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={48}
+                  outerRadius={72}
+                  dataKey="value"
+                  isAnimationActive={false}
+                >
+                  {donutData.map((entry, i) => (
+                    <Cell key={entry.name} fill={DONUT_COLORS[i % DONUT_COLORS.length]} />
+                  ))}
+                </Pie>
+                {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+                <Tooltip formatter={(value: any) => [value.toLocaleString(), '']} />
+              </PieChart>
+            </ResponsiveContainer>
+            <ul className="approval-analytics-panel__legend" aria-label="Outcome legend">
+              {donutData.map((entry, i) => (
+                <li key={entry.name} className="approval-analytics-panel__legend-item">
+                  <span
+                    className="approval-analytics-panel__legend-swatch"
+                    style={{ background: DONUT_COLORS[i % DONUT_COLORS.length] }}
+                  />
+                  <span>{entry.name}</span>
+                  <span className="approval-analytics-panel__legend-count">
+                    {entry.value.toLocaleString()}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/features/analytics/useApprovalAnalyticsQuery.ts
+++ b/dashboard/src/features/analytics/useApprovalAnalyticsQuery.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query'
+import { encodeFilters } from './urlState'
+import type { FilterParams } from './urlState'
+
+export interface ApprovalOutcome {
+  approved: number
+  rejected: number
+  expired: number
+}
+
+export interface ApprovalAnalyticsResponse {
+  volume: number
+  medianTta: number
+  approvalRate: number
+  byOutcome: ApprovalOutcome
+}
+
+export function useApprovalAnalyticsQuery(filters: FilterParams) {
+  return useQuery({
+    queryKey: ['analytics', 'approvals', filters],
+    queryFn: async (): Promise<ApprovalAnalyticsResponse> => {
+      const params = encodeFilters(filters)
+      const res = await fetch(`/api/v1/analytics/approvals?${params}`)
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      return res.json() as Promise<ApprovalAnalyticsResponse>
+    },
+  })
+}

--- a/dashboard/src/pages/AnalyticsPage.tsx
+++ b/dashboard/src/pages/AnalyticsPage.tsx
@@ -6,6 +6,7 @@ import { CostBreakdownPanel } from '../features/analytics/CostBreakdownPanel'
 import { PolicyEffectivenessPanel } from '../features/analytics/PolicyEffectivenessPanel'
 import { ToolUsagePanel } from '../features/analytics/ToolUsagePanel'
 import { FleetHealthPanel } from '../features/analytics/FleetHealthPanel'
+import { ApprovalAnalyticsPanel } from '../features/analytics/ApprovalAnalyticsPanel'
 import { useAgentsQuery } from '../features/agents/api'
 import { useTeamsQuery } from '../features/analytics/useTeamsQuery'
 import '../features/analytics/KpiStrip.css'
@@ -13,6 +14,7 @@ import '../features/analytics/ActionVolumePanel.css'
 import '../features/analytics/CostBreakdownPanel.css'
 import '../features/analytics/PolicyEffectivenessPanel.css'
 import '../features/analytics/ToolUsageFleetHealth.css'
+import '../features/analytics/ApprovalAnalyticsPanel.css'
 import './AnalyticsPage.css'
 
 export function AnalyticsPage() {
@@ -38,7 +40,7 @@ export function AnalyticsPage() {
         <PolicyEffectivenessPanel />
         <ToolUsagePanel />
         <FleetHealthPanel />
-        {/* Remaining chart panels mounted by subsequent sub-tickets */}
+        <ApprovalAnalyticsPanel />
       </div>
     </main>
   )

--- a/dashboard/tests/e2e/analytics.spec.ts
+++ b/dashboard/tests/e2e/analytics.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from '@playwright/test'
+
+async function injectToken(page: import('@playwright/test').Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('aa_token', 'e2e-test-token')
+  })
+}
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+const AGENT = {
+  id: 'agent-e2e-001',
+  name: 'E2E Agent',
+  framework: 'langchain',
+  version: '0.1.0',
+  status: 'active',
+  layer: 'sdk',
+  session_count: 3,
+  policy_violations_count: 0,
+  last_event: '2026-05-12T10:00:00Z',
+  tool_names: ['search'],
+  recent_events: [],
+}
+
+const KPI = { value: 5, delta: 0.1 }
+
+const ACTION_VOLUME = {
+  series: [{ key: 'allowed', name: 'Allowed', points: [{ t: 1746000000, value: 100 }] }],
+}
+
+const COST_BREAKDOWN = {
+  buckets: [{ label: '2026-05-12', segments: [{ key: 'gpt-4', name: 'GPT-4', value: 10.5 }] }],
+}
+
+const POLICY_EFFECTIVENESS = {
+  rules: [{ id: 'r1', name: 'Rule 1', days: [{ date: '2026-05-12', blocks: 2, warns: 1, passes: 10 }] }],
+}
+
+const TOOL_USAGE = {
+  tools: [{ name: 'search', calls: 100, errorRate: 0.02 }],
+}
+
+const FLEET_HEALTH = {
+  agents: [{ id: 'agent-e2e-001', name: 'E2E Agent', points: [{ t: 1746000000, score: 95 }] }],
+}
+
+const APPROVAL_ANALYTICS = {
+  volume: 1240,
+  medianTta: 185,
+  approvalRate: 0.874,
+  byOutcome: { approved: 1083, rejected: 124, expired: 33 },
+}
+
+// ── Helper ─────────────────────────────────────────────────────────────────────
+
+async function routeAnalyticsApis(page: import('@playwright/test').Page) {
+  await page.route('/api/v1/agents**', route => route.fulfill({ json: [AGENT] }))
+  await page.route('/api/v1/topology/overview', route =>
+    route.fulfill({
+      json: { teams: [{ team_id: 'team-alpha', agent_count: 2, root_agent_count: 1 }] },
+    }),
+  )
+  await page.route('/api/v1/analytics/kpis**', route => route.fulfill({ json: KPI }))
+  await page.route('/api/v1/analytics/action-volume**', route =>
+    route.fulfill({ json: ACTION_VOLUME }),
+  )
+  await page.route('/api/v1/analytics/cost-breakdown**', route =>
+    route.fulfill({ json: COST_BREAKDOWN }),
+  )
+  await page.route('/api/v1/analytics/policy-effectiveness**', route =>
+    route.fulfill({ json: POLICY_EFFECTIVENESS }),
+  )
+  await page.route('/api/v1/analytics/tool-usage**', route =>
+    route.fulfill({ json: TOOL_USAGE }),
+  )
+  await page.route('/api/v1/analytics/fleet-health**', route =>
+    route.fulfill({ json: FLEET_HEALTH }),
+  )
+  await page.route('/api/v1/analytics/approvals**', route =>
+    route.fulfill({ json: APPROVAL_ANALYTICS }),
+  )
+}
+
+// ── Analytics page ─────────────────────────────────────────────────────────────
+
+test.describe('Analytics page', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectToken(page)
+    await routeAnalyticsApis(page)
+  })
+
+  test('renders all 7 panel containers', async ({ page }) => {
+    await page.goto('/analytics')
+    await expect(page.getByTestId('kpi-agents')).toBeVisible()
+    await expect(page.getByTestId('action-volume-panel')).toBeVisible()
+    await expect(page.getByTestId('cost-breakdown-panel')).toBeVisible()
+    await expect(page.getByTestId('policy-effectiveness-panel')).toBeVisible()
+    await expect(page.getByTestId('tool-usage-panel')).toBeVisible()
+    await expect(page.getByTestId('fleet-health-panel')).toBeVisible()
+    await expect(page.getByTestId('approval-analytics-panel')).toBeVisible()
+  })
+
+  test('date-range change updates URL to ?range=30d', async ({ page }) => {
+    await page.goto('/analytics')
+    await page.getByTestId('filter-range').selectOption('30d')
+    await expect(page).toHaveURL(/[?&]range=30d/)
+  })
+
+  test('agent filter selection adds agents param to URL', async ({ page }) => {
+    await page.goto('/analytics')
+    await page.getByTestId('filter-agents').selectOption('agent-e2e-001')
+    await expect(page).toHaveURL(/[?&]agents=agent-e2e-001/)
+  })
+
+  test('filters are restored from URL on page reload', async ({ page }) => {
+    await page.goto('/analytics?range=30d&agents=agent-e2e-001')
+    await expect(page.getByTestId('filter-range')).toHaveValue('30d')
+  })
+
+  test('cost-breakdown group-by toggle updates URL to costBy=team', async ({ page }) => {
+    await page.goto('/analytics')
+    await page.getByTestId('cost-breakdown-toggle-team').click()
+    await expect(page).toHaveURL(/[?&]costBy=team/)
+  })
+})


### PR DESCRIPTION
## What changed

Implements the approval analytics panel for the Analytics page and adds Playwright E2E coverage for the full analytics page:

- `useApprovalAnalyticsQuery` — TanStack Query hook fetching `GET /api/v1/analytics/approvals`
- `ApprovalAnalyticsPanel` — panel with three stat cards (Total volume, Median TTA, Approval rate) and a recharts donut chart showing approved / rejected / expired outcome breakdown using the Wong colorblind-safe palette
- `ApprovalAnalyticsPanel.css` — shimmer skeleton, error state, stat grid, donut + legend layout
- `ApprovalAnalyticsPanel.test.tsx` — 10 unit tests (formatter unit tests + panel integration tests)
- `dashboard/tests/e2e/analytics.spec.ts` — 5 Playwright scenarios covering: all 7 panels visible, date-range URL update, agent filter URL update, filter restore from URL on reload, cost-breakdown toggle URL update
- `AnalyticsPage.tsx` — mounts `<ApprovalAnalyticsPanel />`

## Why it changed

AAASM-1094: Approval analytics panel + Playwright E2E — final implementation sub-ticket under AAASM-120 (Analytics page).

## How to verify

Unit tests: `pnpm test --run` → 194 tests pass  
Type check: `pnpm type-check` → clean  
Lint: `pnpm lint` → clean  
E2E: `pnpm build && pnpm preview` then `npx playwright test tests/e2e/analytics.spec.ts`

## Acceptance criteria

| # | Criterion | Status |
|---|---|---|
| 1 | `useApprovalAnalyticsQuery` fetches `/api/v1/analytics/approvals` with filter params | ✅ |
| 2 | Panel renders `data-testid="approval-analytics-panel"` | ✅ |
| 3 | Three stat cards: Total volume (localized), Median TTA (Xm Ys), Approval rate (X.X%) | ✅ |
| 4 | Donut chart `data-testid="approval-donut"` with approved/rejected/expired segments | ✅ |
| 5 | Outcome legend with colored swatches and counts | ✅ |
| 6 | Skeleton while loading; error message on failure | ✅ |
| 7 | E2E: all 7 panels visible on `/analytics` | ✅ |
| 8 | E2E: date-range change updates URL to `?range=30d` | ✅ |
| 9 | E2E: agent filter selection updates URL with `agents=` param | ✅ |
| 10 | E2E: filters restored from URL on reload | ✅ |
| 11 | E2E: cost-breakdown toggle updates URL to `?costBy=team` | ✅ |

Closes AAASM-1094
