### PR TITLE
[AAASM-1319] ✨ (dashboard): Add pnpm start and pnpm serve scripts

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -19,6 +19,7 @@ pnpm install
 
 ```bash
 # Start dev server at http://localhost:3000 (proxies /api/* to http://localhost:8080)
+# `pnpm start` is an alias for the same command.
 pnpm dev
 
 # Type-check without emitting
@@ -48,9 +49,20 @@ pnpm test:coverage
 pnpm build
 ```
 
-## Serving the built dashboard
+## Serving the built dashboard locally
 
-After `pnpm build` produces `dist/`, use the `aasm` CLI to serve it:
+After `pnpm build` produces `dist/`, you can serve it directly with Vite's preview server:
+
+```bash
+# Serve dist/ at http://localhost:3000 (fails loudly if 3000 is taken)
+pnpm serve
+```
+
+This is the production-build counterpart to `pnpm dev` — useful for smoke-testing the bundle without going through the `aasm` CLI.
+
+## Serving via the embedded aasm CLI
+
+For production-style serving with the `/api/*` proxy baked in, use the `aasm` CLI:
 
 ```bash
 # Start the embedded SPA server (default port 3000)

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -6,7 +6,9 @@
   "description": "Community web UI for Agent Assembly governance dashboard",
   "scripts": {
     "dev": "vite",
+    "start": "vite",
     "build": "tsc --noEmit && vite build",
+    "serve": "vite preview --port 3000 --strictPort",
     "preview": "vite preview",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "type-check": "tsc --noEmit",


### PR DESCRIPTION
## What changed

- Added `"start": "vite"` as an alias for `pnpm dev` (parent AAASM-94 AC #1).
- Added `"serve": "vite preview --port 3000 --strictPort"` so the production-build preview runs on port 3000 like the dev server (AC #2). `--strictPort` makes the script fail loudly if 3000 is taken, instead of silently falling back to 4173.
- Updated `dashboard/README.md`:
  - Notes that `pnpm start` is an alias for `pnpm dev`.
  - New "Serving the built dashboard locally" section covers `pnpm serve`.
  - Renamed the existing CLI-serving section to "Serving via the embedded aasm CLI" so the two options are clearly distinguished.

## Why

Verification of AAASM-94 (see AAASM-1150 report) flagged AC #1 and AC #2 as failing — the dashboard had `pnpm dev` and `pnpm preview` but neither matched the AC wording (`pnpm start`, `pnpm serve` on port 3000). This adds the missing aliases without renaming the existing scripts, so nothing depending on `dev` / `preview` breaks.

## How to verify

```bash
cd dashboard
pnpm install
pnpm run         # lists 'start' and 'serve' alongside dev/preview
pnpm type-check && pnpm lint && pnpm test   # 184/184 pass
```

Closes #AAASM-1319