### PR TITLE
[AAASM-1320] 🐛 (dashboard): Emit relative asset paths in production build

### DIFF
--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  // Emit relative asset paths so the embedded `aasm dashboard` server
+  // (AAASM-1292) can mount the SPA at any sub-path without breaking
+  // resource resolution.
+  base: './',
   plugins: [react()],
   server: {
     port: 3000,


### PR DESCRIPTION
## What changed

Added `base: './'` to `dashboard/vite.config.ts`.

## Why

Verification of AAASM-94 (AAASM-1150 report) found that `pnpm build` emits **absolute** asset references in `dist/index.html`:

```html
<script src="/assets/index-XXX.js"></script>
<link href="/assets/index-YYY.css">
```

When the `aasm dashboard` CLI (AAASM-1292) embeds the bundle and serves it from a sub-path, absolute paths break asset resolution. Setting `base: './'` makes Vite emit relative paths that resolve correctly from any mount point.

## How to verify

```bash
cd dashboard
pnpm install
pnpm build
grep 'src=\|href=' dist/index.html
# src="./assets/index-XXX.js"
# href="./assets/index-YYY.css"
```

Full local validation:
- `pnpm type-check` ✅
- `pnpm lint` ✅
- `pnpm test` ✅ (194/194)
- `pnpm build` ✅

Closes #AAASM-1320