### PR TITLE
[AAASM-1322] ✨ (dashboard): Extract design tokens; remove hex literals from AppShell.css

### DIFF
--- a/dashboard/src/components/AppShell.css
+++ b/dashboard/src/components/AppShell.css
@@ -6,8 +6,8 @@
 .appshell__nav {
   width: 220px;
   flex-shrink: 0;
-  background: #1e293b;
-  color: #f1f5f9;
+  background: var(--shell-nav-bg);
+  color: var(--shell-nav-text);
   display: flex;
   flex-direction: column;
   padding: 1rem 0;
@@ -17,7 +17,7 @@
   font-size: 1rem;
   font-weight: 700;
   padding: 0 1.25rem 1.25rem;
-  border-bottom: 1px solid #334155;
+  border-bottom: 1px solid var(--shell-nav-border);
   margin-bottom: 0.5rem;
   letter-spacing: 0.02em;
 }
@@ -25,7 +25,7 @@
 .appshell__nav-link {
   display: block;
   padding: 0.625rem 1.25rem;
-  color: #cbd5e1;
+  color: var(--shell-nav-text-muted);
   text-decoration: none;
   font-size: 0.875rem;
   border-left: 3px solid transparent;
@@ -33,14 +33,14 @@
 }
 
 .appshell__nav-link:hover {
-  background: #334155;
-  color: #f1f5f9;
+  background: var(--shell-nav-hover-bg);
+  color: var(--shell-nav-text);
 }
 
 .appshell__nav-link--active {
-  border-left-color: #3b82f6;
-  background: #1e3a5f;
-  color: #93c5fd;
+  border-left-color: var(--shell-nav-active-border);
+  background: var(--shell-nav-active-bg);
+  color: var(--shell-nav-active-text);
   font-weight: 600;
 }
 
@@ -57,8 +57,8 @@
   align-items: center;
   justify-content: space-between;
   padding: 0 1.5rem;
-  background: #fff;
-  border-bottom: 1px solid #e2e8f0;
+  background: var(--shell-topbar-bg);
+  border-bottom: 1px solid var(--shell-topbar-border);
   position: sticky;
   top: 0;
   z-index: 100;
@@ -70,13 +70,13 @@
   border: none;
   cursor: pointer;
   padding: 0.25rem;
-  color: #475569;
+  color: var(--shell-text-dim);
   font-size: 1.25rem;
 }
 
 .appshell__user {
   font-size: 0.8rem;
-  color: #64748b;
+  color: var(--shell-text-muted);
 }
 
 .appshell__logout {
@@ -84,14 +84,14 @@
   font-size: 0.75rem;
   padding: 0.25rem 0.625rem;
   border-radius: 0.25rem;
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--shell-button-border);
   background: none;
   cursor: pointer;
-  color: #475569;
+  color: var(--shell-text-dim);
 }
 
 .appshell__logout:hover {
-  background: #f1f5f9;
+  background: var(--shell-button-hover-bg);
 }
 
 .appshell__content {
@@ -101,7 +101,7 @@
 
 .appshell__error {
   padding: 2rem;
-  color: #dc2626;
+  color: var(--shell-error-text);
 }
 
 @media (max-width: 1024px) {

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider } from './auth/AuthProvider'
 import { ToastProvider } from './components/ToastProvider'
 import App from './App'
+import './styles.css'
 
 const queryClient = new QueryClient()
 

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -1,0 +1,62 @@
+/* ============================================================
+   Agent Assembly Dashboard · Design Tokens
+   ============================================================
+
+   The :root block below mirrors design/v1/hi-fi/styles.css so the
+   hi-fi palette is the single source of truth. Component styles
+   must reference these custom properties rather than embedding
+   hex literals, spacing values, or type sizes directly.
+
+   See AAASM-1322 (the verification finding that introduced this
+   sheet) and AAASM-94 AC #8.
+   ============================================================ */
+
+:root {
+  /* ── Hi-fi base palette (paper / ink / line) ─────────────── */
+  --paper: #f5f4f0;
+  --paper-2: #ffffff;
+  --paper-3: #ebe9e2;
+  --ink: #0e0e0e;
+  --ink-2: #2a2a2a;
+  --ink-3: #5a5a5a;
+  --ink-4: #8a8a8a;
+  --ink-5: #b8b6ae;
+  --line: #d8d4c7;
+  --line-2: #c4bfb0;
+  --line-3: #1a1a1a;
+
+  /* ── Hi-fi semantic palette (status / accent) ────────────── */
+  --danger: #b8291e;
+  --danger-bg: #f6dad6;
+  --warn: #8a5a00;
+  --warn-bg: #f5e6c4;
+  --ok: #22592a;
+  --ok-bg: #d4e4d2;
+  --info: #1d3a7a;
+  --info-bg: #d6dfee;
+  --scrub: #5a1a8a;
+  --scrub-bg: #e0d2ec;
+
+  /* ── App shell semantic tokens ───────────────────────────── */
+  /* These name the colors used by the current AppShell so the
+     stylesheet contains no hex literals. Visual values are kept
+     identical to the pre-tokenisation layout; AAASM-94 follow-up
+     can migrate them to the hi-fi palette above when ready. */
+  --shell-nav-bg: #1e293b;
+  --shell-nav-text: #f1f5f9;
+  --shell-nav-text-muted: #cbd5e1;
+  --shell-nav-border: #334155;
+  --shell-nav-hover-bg: #334155;
+  --shell-nav-active-bg: #1e3a5f;
+  --shell-nav-active-text: #93c5fd;
+  --shell-nav-active-border: #3b82f6;
+
+  --shell-topbar-bg: #ffffff;
+  --shell-topbar-border: #e2e8f0;
+
+  --shell-text-muted: #64748b;
+  --shell-text-dim: #475569;
+  --shell-button-border: #cbd5e1;
+  --shell-button-hover-bg: #f1f5f9;
+  --shell-error-text: #dc2626;
+}


### PR DESCRIPTION
## What changed

1. **New `dashboard/src/styles.css`** — single global stylesheet that defines the design-token palette:
   - Hi-fi base + semantic palette mirrored from `design/v1/hi-fi/styles.css` (`--paper`, `--ink`, `--line`, `--danger`, `--warn`, `--ok`, `--info`, `--scrub`, etc.).
   - Shell semantic tokens (`--shell-nav-bg`, `--shell-topbar-bg`, `--shell-error-text`, …) that name the colors currently used by `AppShell.css`.
2. **Imported** in `dashboard/src/main.tsx` so tokens are globally available.
3. **Refactored `AppShell.css`** — every color literal replaced with `var(--shell-*)`. Visual appearance unchanged.

## Why

AAASM-94 AC #8 — "Design tokens from `styles.css` are fully extracted — no hard-coded colors, spacing, or type sizes anywhere in the codebase". The verification (AAASM-1150) found 12+ hex literals in `AppShell.css` alone.

This PR establishes the token system and clears `AppShell.css`. A follow-up sweep can migrate the inline-style hex values used in `AppShell.tsx` and the page components (per the bug description's note that those can be a separate Subtask if scope grows).

Two-tier token design rationale: the hi-fi palette is the long-term source of truth, but the current shell uses a blue-slate look (`#1e293b`, `#334155`, …) that differs from the hi-fi paper/ink direction. Naming the shell colors as semantic tokens (`--shell-*`) lets us eliminate the AC #8 violation immediately without an unrelated visual rewrite — a future PR can repoint `--shell-nav-bg` to `--ink` when the visual direction is settled.

## How to verify

```bash
cd dashboard
pnpm install
grep -E '#[0-9a-fA-F]{3,8}' src/components/AppShell.css   # zero hits
pnpm type-check && pnpm lint && pnpm test                  # 194/194 pass
pnpm build                                                  # succeeds
```

Visually: open `pnpm dev` — the AppShell looks identical to master.

Closes #AAASM-1322