### PR TITLE
[AAASM-1321] ✨ (dashboard): Add global overlay mount points (tweaks/alerts/trace/identity/teams)

### DIFF
--- a/dashboard/src/components/AppShell.tsx
+++ b/dashboard/src/components/AppShell.tsx
@@ -1,6 +1,8 @@
 import { useState, Component, type ReactNode, type ErrorInfo } from 'react'
 import { NavLink, Outlet } from 'react-router-dom'
 import { useAuth } from '../auth/useAuth'
+import { OverlayProvider } from './OverlayProvider'
+import { OVERLAY_NAMES } from './OverlayContext'
 import './AppShell.css'
 
 // ── Error boundary ─────────────────────────────────────────────────────────────
@@ -51,6 +53,7 @@ export function AppShell() {
   const [navOpen, setNavOpen] = useState(false)
 
   return (
+    <OverlayProvider>
     <div className="appshell" data-testid="appshell">
       <nav
         className={`appshell__nav${navOpen ? ' appshell__nav--open' : ''}`}
@@ -101,6 +104,14 @@ export function AppShell() {
           </ErrorBoundary>
         </main>
       </div>
+
+      {/* Global overlay mount points (AAASM-94 AC #7).
+          Empty by default; future overlay components portal into the
+          matching surface via `useOverlay(name)` from `useOverlay.ts`. */}
+      {OVERLAY_NAMES.map((name) => (
+        <div key={name} data-overlay={name} data-testid={`overlay-mount-${name}`} />
+      ))}
     </div>
+    </OverlayProvider>
   )
 }

--- a/dashboard/src/components/Overlay.test.tsx
+++ b/dashboard/src/components/Overlay.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, act, renderHook } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import { AppShell } from './AppShell'
+import { OverlayProvider } from './OverlayProvider'
+import { useOverlay } from './useOverlay'
+import { OVERLAY_NAMES } from './OverlayContext'
+import { AuthProvider } from '../auth/AuthProvider'
+
+describe('OverlayProvider + useOverlay', () => {
+  function wrapper({ children }: { children: React.ReactNode }) {
+    return <OverlayProvider>{children}</OverlayProvider>
+  }
+
+  it('exposes one entry per OVERLAY_NAMES with open=false by default', () => {
+    const hooks = OVERLAY_NAMES.map((name) =>
+      renderHook(() => useOverlay(name), { wrapper }),
+    )
+    hooks.forEach(({ result }) => {
+      expect(result.current.open).toBe(false)
+      expect(result.current.props).toEqual({})
+    })
+  })
+
+  it('openOverlay flips open to true and passes props through', () => {
+    const { result } = renderHook(() => useOverlay('tweaks'), { wrapper })
+    expect(result.current.open).toBe(false)
+    act(() => result.current.openOverlay({ source: 'unit-test' }))
+    expect(result.current.open).toBe(true)
+    expect(result.current.props).toEqual({ source: 'unit-test' })
+  })
+
+  it('closeOverlay resets the entry back to closed with empty props', () => {
+    const { result } = renderHook(() => useOverlay('trace'), { wrapper })
+    act(() => result.current.openOverlay({ traceId: 'abc' }))
+    expect(result.current.open).toBe(true)
+    act(() => result.current.closeOverlay())
+    expect(result.current.open).toBe(false)
+    expect(result.current.props).toEqual({})
+  })
+
+  it('overlays are independent — opening one does not affect siblings', () => {
+    const tweaks = renderHook(() => useOverlay('tweaks'), { wrapper })
+    const alerts = renderHook(() => useOverlay('alerts'), { wrapper })
+    act(() => tweaks.result.current.openOverlay())
+    expect(tweaks.result.current.open).toBe(true)
+    expect(alerts.result.current.open).toBe(false)
+  })
+
+  it('useOverlay throws when used outside an OverlayProvider', () => {
+    expect(() => renderHook(() => useOverlay('alerts'))).toThrow(
+      /useOverlay must be used within an OverlayProvider/,
+    )
+  })
+
+  it('OverlayProvider renders its children', () => {
+    render(
+      <OverlayProvider>
+        <span data-testid="child">hello</span>
+      </OverlayProvider>,
+    )
+    expect(screen.getByTestId('child')).toHaveTextContent('hello')
+  })
+})
+
+describe('AppShell overlay mount points', () => {
+  it('renders one <div data-overlay={name}> per OVERLAY_NAMES entry', () => {
+    localStorage.setItem('aa_token', 'test-token')
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <AuthProvider>
+          <Routes>
+            <Route element={<AppShell />}>
+              <Route path="/" element={<div>page</div>} />
+            </Route>
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>,
+    )
+    for (const name of OVERLAY_NAMES) {
+      const mount = screen.getByTestId(`overlay-mount-${name}`)
+      expect(mount).toBeInTheDocument()
+      expect(mount.getAttribute('data-overlay')).toBe(name)
+    }
+    localStorage.clear()
+  })
+})

--- a/dashboard/src/components/OverlayContext.ts
+++ b/dashboard/src/components/OverlayContext.ts
@@ -1,0 +1,26 @@
+import { createContext } from 'react'
+
+/**
+ * Named overlay surfaces exposed at the AppShell level.
+ * Each entry corresponds to a `<div data-overlay="…" />` portal target
+ * rendered by `AppShell` so pages can trigger global panels/drawers
+ * without re-mounting them.
+ */
+export const OVERLAY_NAMES = ['tweaks', 'alerts', 'trace', 'identity', 'teams'] as const
+
+export type OverlayName = (typeof OVERLAY_NAMES)[number]
+
+export interface OverlayState {
+  /** Whether the overlay is currently open. */
+  open: boolean
+  /** Arbitrary props handed to the (future) overlay component. */
+  props: Record<string, unknown>
+}
+
+export interface OverlayContextValue {
+  states: Record<OverlayName, OverlayState>
+  openOverlay: (name: OverlayName, props?: Record<string, unknown>) => void
+  closeOverlay: (name: OverlayName) => void
+}
+
+export const OverlayContext = createContext<OverlayContextValue | null>(null)

--- a/dashboard/src/components/OverlayProvider.tsx
+++ b/dashboard/src/components/OverlayProvider.tsx
@@ -1,0 +1,27 @@
+import { useCallback, useState, type ReactNode } from 'react'
+import { OverlayContext, OVERLAY_NAMES, type OverlayName, type OverlayState } from './OverlayContext'
+
+const INITIAL_STATES: Record<OverlayName, OverlayState> = Object.fromEntries(
+  OVERLAY_NAMES.map((n) => [n, { open: false, props: {} }]),
+) as Record<OverlayName, OverlayState>
+
+export function OverlayProvider({ children }: { children: ReactNode }) {
+  const [states, setStates] = useState<Record<OverlayName, OverlayState>>(INITIAL_STATES)
+
+  const openOverlay = useCallback(
+    (name: OverlayName, props: Record<string, unknown> = {}) => {
+      setStates((prev) => ({ ...prev, [name]: { open: true, props } }))
+    },
+    [],
+  )
+
+  const closeOverlay = useCallback((name: OverlayName) => {
+    setStates((prev) => ({ ...prev, [name]: { open: false, props: {} } }))
+  }, [])
+
+  return (
+    <OverlayContext.Provider value={{ states, openOverlay, closeOverlay }}>
+      {children}
+    </OverlayContext.Provider>
+  )
+}

--- a/dashboard/src/components/useOverlay.ts
+++ b/dashboard/src/components/useOverlay.ts
@@ -1,0 +1,19 @@
+import { useContext } from 'react'
+import { OverlayContext, type OverlayName } from './OverlayContext'
+
+/**
+ * Access the named overlay surface from any descendant of `<OverlayProvider>`.
+ * Returns the current `open` flag, the `props` last passed to `openOverlay`,
+ * and a pair of action callbacks bound to this overlay name.
+ */
+export function useOverlay(name: OverlayName) {
+  const ctx = useContext(OverlayContext)
+  if (!ctx) throw new Error('useOverlay must be used within an OverlayProvider')
+  const state = ctx.states[name]
+  return {
+    open: state.open,
+    props: state.props,
+    openOverlay: (props?: Record<string, unknown>) => ctx.openOverlay(name, props),
+    closeOverlay: () => ctx.closeOverlay(name),
+  }
+}


### PR DESCRIPTION
## What changed

1. **New `OverlayContext` + `OverlayProvider` + `useOverlay`** in `dashboard/src/components/`:
   - `OVERLAY_NAMES = ['tweaks', 'alerts', 'trace', 'identity', 'teams']` — the five surfaces called out in AAASM-94's implementation rules.
   - `OverlayProvider` holds a `Record<OverlayName, { open, props }>` and exposes `openOverlay(name, props?)` / `closeOverlay(name)`.
   - `useOverlay(name)` returns `{ open, props, openOverlay, closeOverlay }` bound to a single name; throws when used outside the provider.
2. **`AppShell` wraps its tree in `<OverlayProvider>` and renders one `<div data-overlay={name}>` mount point per `OVERLAY_NAMES` entry** — empty markers that future overlay components portal into via `useOverlay`.
3. **Tests** (`Overlay.test.tsx`) — 7 new cases covering the hook + provider behavior and the AppShell mount points.

Files split into `OverlayContext.ts` / `OverlayProvider.tsx` / `useOverlay.ts` to satisfy the `react-refresh/only-export-components` lint rule — same pattern as `AuthContext + AuthProvider + useAuth` and `ToastContext + ToastProvider + useToast`.

## Why

AAASM-94 AC #7 — "Global overlay mount points exist at shell level (no overlays rendered yet — that is PR 2)". The verification (AAASM-1150) found zero overlay infrastructure in `AppShell.tsx`. This PR establishes the registry; future PRs build the actual overlay components (tweaks panel, alert feed, trace drawer, identity drawer, team panel).

## How to verify

```bash
cd dashboard
pnpm install
pnpm type-check && pnpm lint && pnpm test   # 201/201 pass (7 new)
```

Manual: open `pnpm dev`, inspect the DOM under `<div data-testid="appshell">` — you'll see five `<div data-overlay="…">` elements at the end of the shell, one per `OVERLAY_NAMES` entry.

Closes #AAASM-1321