### PR TITLE
[AAASM-1318] ✨ (dashboard): Wire all 12 canonical routes + grouped nav

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -9,6 +9,7 @@ import { NotFoundPage } from './pages/NotFoundPage'
 import { PoliciesPage } from './pages/PoliciesPage'
 import { PolicyEditorPage } from './pages/PolicyEditorPage'
 import { AnalyticsPage } from './pages/AnalyticsPage'
+import { ComingSoon } from './pages/ComingSoon'
 
 function App() {
   return (
@@ -17,11 +18,31 @@ function App() {
         <Route path="/login" element={<LoginPage />} />
         <Route element={<ProtectedRoute />}>
           <Route element={<AppShell />}>
+            {/* Landing — keeps the working approvals queue at root for now. */}
             <Route path="/" element={<ApprovalsPage />} />
+
+            {/* ── Canonical 12 routes (AAASM-94 AC #5, #6) ──────────────── */}
+            {/* monitor */}
+            <Route path="/overview" element={<ComingSoon name="Overview" />} />
             <Route path="/agents" element={<AgentsPage />} />
-            <Route path="/agents/:id" element={<AgentDetailPage />} />
+            <Route path="/topology" element={<ComingSoon name="Topology" />} />
+            <Route path="/live" element={<ComingSoon name="Live Ops" />} />
+            <Route path="/alerts" element={<ComingSoon name="Alerts" />} />
+            <Route path="/audit" element={<ComingSoon name="Audit Log" />} />
+            {/* control */}
+            <Route path="/capability" element={<ComingSoon name="Capability" />} />
             <Route path="/policies" element={<PoliciesPage />} />
+            <Route path="/scrub" element={<ComingSoon name="Secret Scrubbing" />} />
+            {/* manage */}
+            <Route path="/costs" element={<ComingSoon name="Cost & Budget" />} />
+            <Route path="/teams" element={<ComingSoon name="Agent Groups" />} />
+            <Route path="/identity" element={<ComingSoon name="Members & Access" />} />
+
+            {/* ── Sub-routes for canonical pages ────────────────────────── */}
+            <Route path="/agents/:id" element={<AgentDetailPage />} />
             <Route path="/policies/editor" element={<PolicyEditorPage />} />
+
+            {/* ── Non-canonical pages (kept for working features) ───────── */}
             <Route path="/approvals" element={<ApprovalsPage />} />
             <Route path="/analytics" element={<AnalyticsPage />} />
           </Route>

--- a/dashboard/src/components/AppShell.css
+++ b/dashboard/src/components/AppShell.css
@@ -22,14 +22,33 @@
   letter-spacing: 0.02em;
 }
 
+.appshell__nav-section {
+  padding: 0.875rem 1.25rem 0.375rem;
+  font-family: ui-monospace, monospace;
+  font-size: 0.6875rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--shell-nav-text-muted);
+  opacity: 0.7;
+}
+
 .appshell__nav-link {
-  display: block;
-  padding: 0.625rem 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  padding: 0.5rem 1.25rem;
   color: var(--shell-nav-text-muted);
   text-decoration: none;
   font-size: 0.875rem;
   border-left: 3px solid transparent;
   transition: background 0.1s, color 0.1s;
+}
+
+.appshell__nav-num {
+  font-family: ui-monospace, monospace;
+  font-size: 0.6875rem;
+  opacity: 0.65;
+  min-width: 1.5rem;
 }
 
 .appshell__nav-link:hover {

--- a/dashboard/src/components/AppShell.tsx
+++ b/dashboard/src/components/AppShell.tsx
@@ -3,7 +3,14 @@ import { NavLink, Outlet } from 'react-router-dom'
 import { useAuth } from '../auth/useAuth'
 import { OverlayProvider } from './OverlayProvider'
 import { OVERLAY_NAMES } from './OverlayContext'
+import { CANONICAL_ROUTES, ROUTE_GROUPS, type RouteGroup } from '../routes'
 import './AppShell.css'
+
+const GROUP_LABEL: Record<RouteGroup, string> = {
+  monitor: 'monitor',
+  control: 'control',
+  manage: 'manage',
+}
 
 // ── Error boundary ─────────────────────────────────────────────────────────────
 
@@ -38,14 +45,6 @@ class ErrorBoundary extends Component<{ children: ReactNode }, ErrorBoundaryStat
   }
 }
 
-// ── Nav links config ───────────────────────────────────────────────────────────
-
-const NAV_LINKS = [
-  { to: '/approvals', label: 'Approvals' },
-  { to: '/agents', label: 'Agents' },
-  { to: '/policies', label: 'Policies' },
-] as const
-
 // ── AppShell ───────────────────────────────────────────────────────────────────
 
 export function AppShell() {
@@ -61,17 +60,25 @@ export function AppShell() {
         onClick={() => setNavOpen(false)}
       >
         <div className="appshell__nav-brand">Agent Assembly</div>
-        {NAV_LINKS.map(({ to, label }) => (
-          <NavLink
-            key={to}
-            to={to}
-            className={({ isActive }) =>
-              `appshell__nav-link${isActive ? ' appshell__nav-link--active' : ''}`
-            }
-            data-testid={`nav-link-${label.toLowerCase()}`}
-          >
-            {label}
-          </NavLink>
+        {ROUTE_GROUPS.map((group) => (
+          <div key={group} data-testid={`nav-group-${group}`}>
+            <div className="appshell__nav-section" data-testid={`nav-section-${group}`}>
+              {GROUP_LABEL[group]}
+            </div>
+            {CANONICAL_ROUTES.filter((r) => r.group === group).map((r) => (
+              <NavLink
+                key={r.id}
+                to={r.path}
+                className={({ isActive }) =>
+                  `appshell__nav-link${isActive ? ' appshell__nav-link--active' : ''}`
+                }
+                data-testid={`nav-link-${r.id}`}
+              >
+                <span className="appshell__nav-num">{r.num}</span>
+                {r.label}
+              </NavLink>
+            ))}
+          </div>
         ))}
       </nav>
 

--- a/dashboard/src/components/Overlay.test.tsx
+++ b/dashboard/src/components/Overlay.test.tsx
@@ -6,6 +6,7 @@ import { OverlayProvider } from './OverlayProvider'
 import { useOverlay } from './useOverlay'
 import { OVERLAY_NAMES } from './OverlayContext'
 import { AuthProvider } from '../auth/AuthProvider'
+import { CANONICAL_ROUTES, ROUTE_GROUPS } from '../routes'
 
 describe('OverlayProvider + useOverlay', () => {
   function wrapper({ children }: { children: React.ReactNode }) {
@@ -83,5 +84,40 @@ describe('AppShell overlay mount points', () => {
       expect(mount.getAttribute('data-overlay')).toBe(name)
     }
     localStorage.clear()
+  })
+})
+
+describe('AppShell canonical nav', () => {
+  function renderShell() {
+    localStorage.setItem('aa_token', 'test-token')
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <AuthProvider>
+          <Routes>
+            <Route element={<AppShell />}>
+              <Route path="/" element={<div>page</div>} />
+            </Route>
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>,
+    )
+    return () => localStorage.clear()
+  }
+
+  it('renders one nav-link-{id} per CANONICAL_ROUTES entry', () => {
+    const cleanup = renderShell()
+    for (const r of CANONICAL_ROUTES) {
+      expect(screen.getByTestId(`nav-link-${r.id}`)).toBeInTheDocument()
+    }
+    cleanup()
+  })
+
+  it('groups the nav into monitor / control / manage sections', () => {
+    const cleanup = renderShell()
+    for (const group of ROUTE_GROUPS) {
+      expect(screen.getByTestId(`nav-group-${group}`)).toBeInTheDocument()
+      expect(screen.getByTestId(`nav-section-${group}`)).toBeInTheDocument()
+    }
+    cleanup()
   })
 })

--- a/dashboard/src/pages/ComingSoon.tsx
+++ b/dashboard/src/pages/ComingSoon.tsx
@@ -1,0 +1,30 @@
+import { Link, useLocation } from 'react-router-dom'
+
+/**
+ * Placeholder page rendered for canonical AAASM-94 routes that
+ * are wired but whose feature implementation lands in a later
+ * Subtask. Keeps the nav and routing surface complete so users
+ * never hit a 404 inside the shell (AAASM-94 AC #5, #6).
+ */
+export function ComingSoon({ name }: { name?: string }) {
+  const location = useLocation()
+  const fromPath = location.pathname.replace(/^\//, '').replace(/-/g, ' ')
+  const heading = name ?? (fromPath || 'this page')
+
+  return (
+    <main
+      data-testid="coming-soon"
+      data-route={location.pathname}
+      style={{ padding: '2rem', maxWidth: '40rem' }}
+    >
+      <h1 style={{ marginTop: 0, textTransform: 'capitalize' }}>{heading}</h1>
+      <p style={{ color: 'var(--shell-text-muted)', fontSize: '0.95rem' }}>
+        This page is part of the governance dashboard but is not implemented yet.
+        Track progress under the AAASM-94 Story.
+      </p>
+      <p style={{ marginTop: '1.5rem', fontSize: '0.9rem' }}>
+        <Link to="/">← Back to dashboard</Link>
+      </p>
+    </main>
+  )
+}

--- a/dashboard/src/routes.test.tsx
+++ b/dashboard/src/routes.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, it, expect } from 'vitest'
+import { CANONICAL_ROUTES, ROUTE_GROUPS } from './routes'
+import { ComingSoon } from './pages/ComingSoon'
+
+describe('CANONICAL_ROUTES config', () => {
+  it('declares exactly 12 routes', () => {
+    expect(CANONICAL_ROUTES).toHaveLength(12)
+  })
+
+  it('covers all three groups (monitor, control, manage)', () => {
+    const groups = new Set(CANONICAL_ROUTES.map((r) => r.group))
+    expect([...groups].sort()).toEqual(['control', 'manage', 'monitor'])
+    for (const group of ROUTE_GROUPS) {
+      expect(CANONICAL_ROUTES.filter((r) => r.group === group).length).toBeGreaterThan(0)
+    }
+  })
+
+  it('has unique id, num, and path for every entry', () => {
+    const ids = CANONICAL_ROUTES.map((r) => r.id)
+    const nums = CANONICAL_ROUTES.map((r) => r.num)
+    const paths = CANONICAL_ROUTES.map((r) => r.path)
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(new Set(nums).size).toBe(nums.length)
+    expect(new Set(paths).size).toBe(paths.length)
+  })
+
+  it('includes the 12 canonical ids from design/v1/hi-fi/shell.jsx', () => {
+    const ids = CANONICAL_ROUTES.map((r) => r.id).sort()
+    expect(ids).toEqual(
+      [
+        'alerts', 'audit', 'capability', 'costs', 'fleet', 'identity',
+        'live', 'overview', 'policy', 'scrub', 'teams', 'topology',
+      ].sort(),
+    )
+  })
+
+  it('every num is a zero-padded two-digit sequence 01..12', () => {
+    const nums = CANONICAL_ROUTES.map((r) => r.num).sort()
+    expect(nums).toEqual([
+      '01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12',
+    ])
+  })
+})
+
+describe('ComingSoon', () => {
+  it('renders the provided name as the heading', () => {
+    render(
+      <MemoryRouter>
+        <ComingSoon name="Topology" />
+      </MemoryRouter>,
+    )
+    expect(screen.getByRole('heading', { name: 'Topology' })).toBeInTheDocument()
+    expect(screen.getByTestId('coming-soon')).toBeInTheDocument()
+  })
+
+  it('falls back to the pathname when no name prop is given', () => {
+    render(
+      <MemoryRouter initialEntries={['/scrub']}>
+        <ComingSoon />
+      </MemoryRouter>,
+    )
+    // Heading is capitalised via CSS, but DOM text is the raw pathname stripped.
+    expect(screen.getByTestId('coming-soon').textContent).toContain('scrub')
+  })
+})

--- a/dashboard/src/routes.ts
+++ b/dashboard/src/routes.ts
@@ -1,0 +1,39 @@
+/**
+ * Canonical 12-route navigation for the governance dashboard.
+ *
+ * Mirrors the `ROUTES` const defined in `design/v1/hi-fi/shell.jsx`.
+ * The AppShell nav renders entries grouped by `group`; `App.tsx` wires
+ * each `path` to either an implemented page or `<ComingSoon />`.
+ */
+
+export type RouteGroup = 'monitor' | 'control' | 'manage'
+
+export interface CanonicalRoute {
+  /** Stable id, matches hi-fi `ROUTES[].id`. Used in test-id and key. */
+  id: string
+  /** Two-digit sequence number shown in the nav prefix. */
+  num: string
+  /** Human label shown in the nav. */
+  label: string
+  /** Section header the entry sits under in the nav. */
+  group: RouteGroup
+  /** Route path. */
+  path: string
+}
+
+export const CANONICAL_ROUTES: readonly CanonicalRoute[] = [
+  { id: 'overview',   num: '01', label: 'Overview',         group: 'monitor', path: '/overview' },
+  { id: 'fleet',      num: '02', label: 'Fleet',            group: 'monitor', path: '/agents' },
+  { id: 'topology',   num: '03', label: 'Topology',         group: 'monitor', path: '/topology' },
+  { id: 'live',       num: '04', label: 'Live Ops',         group: 'monitor', path: '/live' },
+  { id: 'alerts',     num: '05', label: 'Alerts',           group: 'monitor', path: '/alerts' },
+  { id: 'audit',      num: '06', label: 'Audit Log',        group: 'monitor', path: '/audit' },
+  { id: 'capability', num: '07', label: 'Capability',       group: 'control', path: '/capability' },
+  { id: 'policy',     num: '08', label: 'Policy',           group: 'control', path: '/policies' },
+  { id: 'scrub',      num: '09', label: 'Secret Scrubbing', group: 'control', path: '/scrub' },
+  { id: 'costs',      num: '10', label: 'Cost & Budget',    group: 'manage',  path: '/costs' },
+  { id: 'teams',      num: '11', label: 'Agent Groups',     group: 'manage',  path: '/teams' },
+  { id: 'identity',   num: '12', label: 'Members & Access', group: 'manage',  path: '/identity' },
+] as const
+
+export const ROUTE_GROUPS: readonly RouteGroup[] = ['monitor', 'control', 'manage'] as const

--- a/dashboard/tests/e2e/governance-dashboard.spec.ts
+++ b/dashboard/tests/e2e/governance-dashboard.spec.ts
@@ -72,12 +72,26 @@ test.describe('AppShell', () => {
     await page.route('/api/v1/ws/events**', (route) => route.abort())
   })
 
-  test('shows nav with Approvals, Agents, Policies links', async ({ page }) => {
+  test('shows canonical 12-route nav grouped by monitor/control/manage', async ({ page }) => {
     await page.goto('/approvals')
     await expect(page.getByTestId('appshell-nav')).toBeVisible()
-    await expect(page.getByTestId('nav-link-approvals')).toBeVisible()
-    await expect(page.getByTestId('nav-link-agents')).toBeVisible()
-    await expect(page.getByTestId('nav-link-policies')).toBeVisible()
+
+    // Three section headers
+    await expect(page.getByTestId('nav-group-monitor')).toBeVisible()
+    await expect(page.getByTestId('nav-group-control')).toBeVisible()
+    await expect(page.getByTestId('nav-group-manage')).toBeVisible()
+
+    // Spot-check a few canonical entries across the three groups
+    await expect(page.getByTestId('nav-link-overview')).toBeVisible()
+    await expect(page.getByTestId('nav-link-fleet')).toBeVisible()
+    await expect(page.getByTestId('nav-link-policy')).toBeVisible()
+    await expect(page.getByTestId('nav-link-identity')).toBeVisible()
+  })
+
+  test('navigating to an unimplemented canonical route renders ComingSoon (no 404)', async ({ page }) => {
+    await page.goto('/topology')
+    await expect(page.getByTestId('coming-soon')).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'Topology' })).toBeVisible()
   })
 
   test('shows top bar with logout button', async ({ page }) => {


### PR DESCRIPTION
## What changed

1. **New `ComingSoon` placeholder** (`dashboard/src/pages/ComingSoon.tsx`) — shown for canonical routes whose feature page is not yet implemented. Carries a `data-testid="coming-soon"` and a back-to-dashboard link.
2. **New `dashboard/src/routes.ts`** — `CANONICAL_ROUTES` mirrors `design/v1/hi-fi/shell.jsx` `ROUTES` (`id`, `num`, `label`, `group`, `path`). Used by both `App.tsx` and the AppShell nav as the single source of truth.
3. **`App.tsx` wires all 12 canonical paths** — `Fleet` (`/agents`) and `Policy` (`/policies`) target their existing page components; the other 10 (`/overview`, `/topology`, `/live`, `/alerts`, `/audit`, `/capability`, `/scrub`, `/costs`, `/teams`, `/identity`) render `<ComingSoon />`. Non-canonical routes (`/approvals`, `/analytics`) are retained so the working pages stay reachable.
4. **`AppShell` nav refactored** — renders three section headers (monitor / control / manage), each followed by its canonical entries. Each link has `data-testid="nav-link-{id}"`. CSS additions: `.appshell__nav-section`, `.appshell__nav-num`, updated `.appshell__nav-link` to flex.
5. **Tests** — 9 new vitest cases (`routes.test.tsx` + nav-grouping tests in `Overlay.test.tsx`) + Playwright spec updated for the new nav-link test-ids and a `/topology → ComingSoon` regression check.

## Why

Verification (AAASM-1150) found AAASM-94 AC #5 and #6 failing — the dashboard had only ~7 wired routes (of which 3 in the nav), missing 9 of the 12 canonical paths from the hi-fi prototype. Hitting any of those paths fell through to `<NotFoundPage />`. This PR closes that gap without dropping any existing working page; future subtasks can fill in the `<ComingSoon />` slots one canonical id at a time.

## How to verify

```bash
cd dashboard
pnpm install
pnpm type-check && pnpm lint && pnpm test   # 210/210 pass (9 new)
pnpm build                                   # succeeds
```

Manual: `pnpm dev` → the left nav now shows three sections (monitor / control / manage) with 12 entries, each prefixed by a two-digit num. Visiting `/topology`, `/live`, `/audit`, etc. shows the ComingSoon page instead of 404.

Closes #AAASM-1318