### PR TITLE
[AAASM-1325] 🔧 (dashboard/live-ops): Add /live route LiveOpsPage stub

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -12,6 +12,7 @@ import { AnalyticsPage } from './pages/AnalyticsPage'
 import { AlertsPage } from './pages/AlertsPage'
 import { CapabilityPage } from './pages/CapabilityPage'
 import { TraceViewPage } from './pages/TraceViewPage'
+import { LiveOpsPage } from './pages/LiveOpsPage'
 import { ComingSoon } from './pages/ComingSoon'
 import { IdentityPage } from './pages/IdentityPage'
 import { TeamDetailPage } from './pages/TeamDetailPage'
@@ -31,7 +32,7 @@ function App() {
             <Route path="/overview" element={<ComingSoon name="Overview" />} />
             <Route path="/agents" element={<FleetPage />} />
             <Route path="/topology" element={<ComingSoon name="Topology" />} />
-            <Route path="/live" element={<ComingSoon name="Live Ops" />} />
+            <Route path="/live" element={<LiveOpsPage />} />
             <Route path="/alerts" element={<AlertsPage />} />
             <Route path="/audit" element={<ComingSoon name="Audit Log" />} />
             {/* control */}

--- a/dashboard/src/pages/LiveOpsPage.tsx
+++ b/dashboard/src/pages/LiveOpsPage.tsx
@@ -1,0 +1,14 @@
+/**
+ * Live Operations page — entry stub for AAASM-1282 (Dashboard PR 9).
+ *
+ * Renders the page header only; the real content (PipelineCanvas, row
+ * stream, ApprovalPool, filters, auto-scroll, WebSocket wiring) lands
+ * in follow-up subtasks of AAASM-1282.
+ */
+export function LiveOpsPage() {
+  return (
+    <main data-testid="live-ops-page" style={{ padding: '2rem', maxWidth: '60rem' }}>
+      <h1 style={{ marginTop: 0 }}>Live Operations</h1>
+    </main>
+  )
+}


### PR DESCRIPTION
## Description

Adds a thin `LiveOpsPage` stub and replaces the `<ComingSoon name=\"Live Ops\" />` placeholder at the canonical `/live` route with the new component. This is the entry point for the AAASM-1282 (Dashboard PR 9: Live Ops page) implementation; the real page content — PipelineCanvas, row stream, ApprovalPool, FilterBar, AutoScrollToggle, WebSocket hook, row actions — lands in the follow-up subtasks under AAASM-1282.

Route note: kept the existing canonical path `/live` (AAASM-94 / AAASM-1318 12-route invariant). The parent ticket's description references `/live-ops`, but the dashboard shell wires `/live`; using the existing route avoids breaking the canonical-routes test surface.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-1325 (subtask of AAASM-1282 — Dashboard PR 9: Live Ops page)
- Parent Epic: AAASM-11 (Community Dashboard)
- Related GitHub issues: —

## Testing

Describe the testing performed for this PR:

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [x] No tests required (explain why)

This commit only introduces an empty page stub and re-points one route to it; existing route + ComingSoon coverage from AAASM-94 and AAASM-1318 still applies. Targeted unit tests for the Live Ops page will land alongside the components in AAASM-1344 and AAASM-1345.

Local checks (in this branch):

- `pnpm type-check` — clean
- `pnpm lint` — clean
- `pnpm test` — **210 / 210** passing (18 files)

## Checklist

- [ ] Code follows project style guidelines (\`cargo fmt\`, \`cargo clippy\`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

> Rust style hooks did not apply — diff is TS-only inside \`dashboard/\`.