### PR TITLE
[AAASM-1054] ✨ (dashboard/teams): Add team list page

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -15,6 +15,7 @@ import { TraceViewPage } from './pages/TraceViewPage'
 import { ComingSoon } from './pages/ComingSoon'
 import { IdentityPage } from './pages/IdentityPage'
 import { TeamDetailPage } from './pages/TeamDetailPage'
+import { TeamsPage } from './pages/TeamsPage'
 
 function App() {
   return (
@@ -40,7 +41,7 @@ function App() {
             <Route path="/scrub" element={<ComingSoon name="Secret Scrubbing" />} />
             {/* manage */}
             <Route path="/costs" element={<ComingSoon name="Cost & Budget" />} />
-            <Route path="/teams" element={<ComingSoon name="Agent Groups" />} />
+            <Route path="/teams" element={<TeamsPage />} />
             <Route path="/identity" element={<IdentityPage />} />
 
             {/* ── Sub-routes for canonical pages ────────────────────────── */}

--- a/dashboard/src/pages/TeamsPage.stories.tsx
+++ b/dashboard/src/pages/TeamsPage.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TeamsPage } from './TeamsPage'
+import type { CostSummary, TopologyOverview } from '../features/teams/api'
+
+function makeOverview(teamCount: number): TopologyOverview {
+  return {
+    root_agent_count: teamCount,
+    standalone_root_agents: [],
+    team_count: teamCount,
+    total_agent_count: teamCount * 3,
+    teams: Array.from({ length: teamCount }, (_, i) => ({
+      team_id: `team-${String(i).padStart(3, '0')}`,
+      agent_count: 1 + ((teamCount * 7919 + i) % 25),
+      root_agent_count: 1 + (i % 3),
+    })),
+  }
+}
+
+function makeCosts(teamCount: number): CostSummary {
+  return {
+    date: '2026-05-13',
+    daily_spend_usd: '120.00',
+    daily_limit_usd: '200.00',
+    per_team: Array.from({ length: teamCount }, (_, i) => ({
+      team_id: `team-${String(i).padStart(3, '0')}`,
+      date: '2026-05-13',
+      daily_spend_usd: ((i * 11) % 200).toFixed(2),
+      monthly_spend_usd: null,
+    })),
+  }
+}
+
+interface MockArgs {
+  teamCount: number
+}
+
+function MockedTeamsPage({ teamCount }: MockArgs) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } })
+  client.setQueryData(['topology', 'overview'], makeOverview(teamCount))
+  client.setQueryData(['costs', 'summary'], makeCosts(teamCount))
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <TeamsPage />
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+const meta: Meta<MockArgs> = {
+  title: 'Pages/TeamsPage',
+  component: MockedTeamsPage,
+}
+
+export default meta
+type Story = StoryObj<MockArgs>
+
+export const NoTeams: Story = { args: { teamCount: 0 } }
+export const ThreeTeams: Story = { args: { teamCount: 3 } }
+export const HundredTeams: Story = { args: { teamCount: 100 } }

--- a/dashboard/src/pages/TeamsPage.test.tsx
+++ b/dashboard/src/pages/TeamsPage.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { vi } from 'vitest'
+import type { UseQueryResult } from '@tanstack/react-query'
+import { TeamsPage } from './TeamsPage'
+import * as teamsApi from '../features/teams/api'
+import type { CostSummary, TopologyOverview } from '../features/teams/api'
+
+function mockQuery<T>(p: Partial<UseQueryResult<T, Error>>): UseQueryResult<T, Error> {
+  return p as unknown as UseQueryResult<T, Error>
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+function makeOverview(teamCount: number): TopologyOverview {
+  return {
+    root_agent_count: teamCount,
+    standalone_root_agents: [],
+    team_count: teamCount,
+    total_agent_count: teamCount * 3,
+    teams: Array.from({ length: teamCount }, (_, i) => ({
+      team_id: `team-${String(i).padStart(3, '0')}`,
+      agent_count: teamCount - i,
+      root_agent_count: 1,
+    })),
+  }
+}
+
+const COSTS: CostSummary = {
+  date: '2026-05-13',
+  daily_spend_usd: '120.00',
+  daily_limit_usd: '200.00',
+  per_team: [
+    { team_id: 'team-000', daily_spend_usd: '90.00', date: '2026-05-13', monthly_spend_usd: null },
+    { team_id: 'team-001', daily_spend_usd: '30.00', date: '2026-05-13', monthly_spend_usd: null },
+  ],
+}
+
+function setupMocks(overview: TopologyOverview, costs: CostSummary | undefined = COSTS) {
+  vi.spyOn(teamsApi, 'useTopologyOverviewQuery').mockReturnValue(
+    mockQuery<TopologyOverview>({ data: overview, isLoading: false, isError: false, refetch: vi.fn() }),
+  )
+  vi.spyOn(teamsApi, 'useCostSummaryQuery').mockReturnValue(
+    mockQuery<CostSummary>({ data: costs, isLoading: false, isError: false, refetch: vi.fn() }),
+  )
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('TeamsPage', () => {
+  it('shows empty state when no teams exist', async () => {
+    setupMocks(makeOverview(0))
+    render(<TeamsPage />, { wrapper: Wrapper })
+    await waitFor(() => expect(screen.getByTestId('teams-empty')).toBeInTheDocument())
+  })
+
+  it('renders a row per team with burn % from cost summary', async () => {
+    setupMocks(makeOverview(3))
+    render(<TeamsPage />, { wrapper: Wrapper })
+    await waitFor(() => expect(screen.getAllByTestId('team-row')).toHaveLength(3))
+    const firstRow = screen.getAllByTestId('team-row')[0]
+    expect(within(firstRow).getByText('45.0%')).toBeInTheDocument()
+  })
+
+  it('defaults to sort by member count descending', async () => {
+    setupMocks(makeOverview(3))
+    render(<TeamsPage />, { wrapper: Wrapper })
+    await waitFor(() => expect(screen.getAllByTestId('team-row')).toHaveLength(3))
+    const ids = screen.getAllByTestId('team-row').map(r => within(r).getAllByRole('cell')[0].textContent)
+    expect(ids).toEqual(['team-000', 'team-001', 'team-002'])
+  })
+
+  it('flips sort when header clicked', async () => {
+    const user = userEvent.setup()
+    setupMocks(makeOverview(3))
+    render(<TeamsPage />, { wrapper: Wrapper })
+    await waitFor(() => expect(screen.getAllByTestId('team-row')).toHaveLength(3))
+    const memberCountHeader = screen.getByRole('columnheader', { name: /Member Count/ })
+    await user.click(memberCountHeader)
+    const ids = screen.getAllByTestId('team-row').map(r => within(r).getAllByRole('cell')[0].textContent)
+    expect(ids).toEqual(['team-002', 'team-001', 'team-000'])
+  })
+
+  it('filters rows by team-id prefix via search input', async () => {
+    const user = userEvent.setup()
+    setupMocks(makeOverview(5))
+    render(<TeamsPage />, { wrapper: Wrapper })
+    await waitFor(() => expect(screen.getAllByTestId('team-row')).toHaveLength(5))
+    await user.type(screen.getByTestId('teams-search'), 'team-00')
+    expect(screen.getAllByTestId('team-row')).toHaveLength(5)
+    await user.clear(screen.getByTestId('teams-search'))
+    await user.type(screen.getByTestId('teams-search'), 'team-001')
+    expect(screen.getAllByTestId('team-row')).toHaveLength(1)
+  })
+
+  it('paginates rows at page size 25', async () => {
+    const user = userEvent.setup()
+    setupMocks(makeOverview(60))
+    render(<TeamsPage />, { wrapper: Wrapper })
+    await waitFor(() => expect(screen.getAllByTestId('team-row')).toHaveLength(25))
+    expect(screen.getByTestId('teams-pagination')).toBeInTheDocument()
+    await user.click(screen.getByTestId('teams-next'))
+    expect(screen.getAllByTestId('team-row')).toHaveLength(25)
+    await user.click(screen.getByTestId('teams-next'))
+    expect(screen.getAllByTestId('team-row')).toHaveLength(10)
+  })
+})

--- a/dashboard/src/pages/TeamsPage.tsx
+++ b/dashboard/src/pages/TeamsPage.tsx
@@ -1,0 +1,222 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  flexRender,
+  createColumnHelper,
+  type SortingState,
+} from '@tanstack/react-table'
+import {
+  joinTeamRows,
+  useCostSummaryQuery,
+  useTopologyOverviewQuery,
+  type TeamListRow,
+} from '../features/teams/api'
+
+const PAGE_SIZE = 25
+
+function SkeletonRows({ cols }: { cols: number }) {
+  return (
+    <>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <tr key={i} data-testid="team-row-skeleton">
+          {Array.from({ length: cols }).map((_, j) => (
+            <td key={j} style={{ padding: '0.5rem' }}>
+              <span
+                style={{
+                  display: 'block',
+                  height: '1rem',
+                  background: '#e5e7eb',
+                  borderRadius: '4px',
+                }}
+              />
+            </td>
+          ))}
+        </tr>
+      ))}
+    </>
+  )
+}
+
+function BurnCell({ pct }: { pct: number | null }) {
+  if (pct == null) return <span style={{ color: '#6b7280' }}>—</span>
+  const color = pct >= 90 ? '#dc2626' : pct >= 70 ? '#ca8a04' : '#16a34a'
+  return (
+    <span style={{ color, fontFamily: 'JetBrains Mono, monospace' }}>
+      {pct.toFixed(1)}%
+    </span>
+  )
+}
+
+const columnHelper = createColumnHelper<TeamListRow>()
+
+const columns = [
+  columnHelper.accessor('team_id', {
+    header: 'Team ID',
+    cell: info => (
+      <Link to={`/teams/${encodeURIComponent(info.getValue())}`}>{info.getValue()}</Link>
+    ),
+  }),
+  columnHelper.accessor('agent_count', { header: 'Member Count' }),
+  columnHelper.accessor('root_agent_count', { header: 'Root Agents' }),
+  columnHelper.accessor('burn_pct', {
+    header: 'Avg Budget Burn %',
+    cell: info => <BurnCell pct={info.getValue()} />,
+    sortUndefined: 'last',
+  }),
+  columnHelper.display({
+    id: 'created_at',
+    header: 'Created At',
+    cell: () => <span style={{ color: '#6b7280' }}>—</span>,
+  }),
+]
+
+export function TeamsPage() {
+  const overviewQuery = useTopologyOverviewQuery()
+  const costsQuery = useCostSummaryQuery()
+  const [sorting, setSorting] = useState<SortingState>([{ id: 'agent_count', desc: true }])
+  const [search, setSearch] = useState('')
+
+  const rows = useMemo(
+    () => joinTeamRows(overviewQuery.data, costsQuery.data).slice(0, 100),
+    [overviewQuery.data, costsQuery.data],
+  )
+
+  // eslint-disable-next-line react-hooks/incompatible-library
+  const table = useReactTable({
+    data: rows,
+    columns,
+    state: { sorting, globalFilter: search },
+    onSortingChange: setSorting,
+    onGlobalFilterChange: setSearch,
+    globalFilterFn: (row, _columnId, filterValue: string) => {
+      const needle = filterValue.trim().toLowerCase()
+      if (!needle) return true
+      return row.original.team_id.toLowerCase().startsWith(needle)
+    },
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    initialState: { pagination: { pageSize: PAGE_SIZE } },
+  })
+
+  const isLoading = overviewQuery.isLoading || costsQuery.isLoading
+  const isError = overviewQuery.isError
+  const totalRows = table.getFilteredRowModel().rows.length
+  const pageIndex = table.getState().pagination.pageIndex
+  const pageCount = table.getPageCount()
+
+  return (
+    <main style={{ padding: '1.5rem' }}>
+      <h1>Teams</h1>
+
+      {isError && (
+        <div
+          data-testid="teams-error"
+          style={{ color: '#dc2626', marginBottom: '1rem', display: 'flex', gap: '1rem', alignItems: 'center' }}
+        >
+          <span>Failed to load teams.</span>
+          <button onClick={() => void overviewQuery.refetch()}>Retry</button>
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: '1rem', alignItems: 'center', marginBottom: '0.75rem' }}>
+        <input
+          data-testid="teams-search"
+          aria-label="Search teams by ID prefix"
+          placeholder="Filter by team ID prefix…"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          style={{
+            padding: '0.4rem 0.6rem',
+            border: '1px solid #d1d5db',
+            borderRadius: '4px',
+            minWidth: '16rem',
+          }}
+        />
+        <span data-testid="teams-count" style={{ color: '#6b7280', fontSize: '0.875rem' }}>
+          {totalRows} team{totalRows === 1 ? '' : 's'}
+        </span>
+      </div>
+
+      {!isLoading && !isError && rows.length === 0 && (
+        <p data-testid="teams-empty" style={{ color: '#6b7280' }}>
+          No teams registered yet.
+        </p>
+      )}
+
+      <table data-testid="teams-table" style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <thead>
+          {table.getHeaderGroups().map(hg => (
+            <tr key={hg.id}>
+              {hg.headers.map(header => (
+                <th
+                  key={header.id}
+                  style={{
+                    textAlign: 'left',
+                    padding: '0.5rem',
+                    borderBottom: '2px solid #e5e7eb',
+                    cursor: header.column.getCanSort() ? 'pointer' : undefined,
+                  }}
+                  onClick={header.column.getToggleSortingHandler()}
+                >
+                  {flexRender(header.column.columnDef.header, header.getContext())}
+                  {header.column.getIsSorted() === 'asc'
+                    ? ' ↑'
+                    : header.column.getIsSorted() === 'desc'
+                      ? ' ↓'
+                      : ''}
+                </th>
+              ))}
+            </tr>
+          ))}
+        </thead>
+        <tbody>
+          {isLoading ? (
+            <SkeletonRows cols={columns.length} />
+          ) : (
+            table.getRowModel().rows.map(row => (
+              <tr key={row.id} data-testid="team-row" style={{ borderBottom: '1px solid #f3f4f6' }}>
+                {row.getVisibleCells().map(cell => (
+                  <td key={cell.id} style={{ padding: '0.5rem' }}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+
+      {pageCount > 1 && (
+        <div
+          data-testid="teams-pagination"
+          style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', marginTop: '0.75rem' }}
+        >
+          <button
+            data-testid="teams-prev"
+            onClick={() => table.previousPage()}
+            disabled={!table.getCanPreviousPage()}
+          >
+            ←
+          </button>
+          <span style={{ fontSize: '0.875rem', color: '#374151' }}>
+            Page {pageIndex + 1} of {pageCount}
+          </span>
+          <button
+            data-testid="teams-next"
+            onClick={() => table.nextPage()}
+            disabled={!table.getCanNextPage()}
+          >
+            →
+          </button>
+        </div>
+      )}
+    </main>
+  )
+}


### PR DESCRIPTION
## Description

Add `/teams` route to the dashboard listing all teams with member count, root-agent count, and aggregate budget burn. First of three PRs implementing F91 (AAASM-218: Dashboard team management view).

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1054 (sub-task of Story AAASM-218 under Epic AAASM-197)

## Testing

- [x] Unit tests added — `dashboard/src/pages/TeamsPage.test.tsx` covers: empty state, populated rendering, default sort by member count desc, sort flip on header click, prefix-based search filtering, and pagination (page size 25 across 60 fixture rows)
- [x] Storybook fixtures added — `Pages/TeamsPage` with `NoTeams`, `ThreeTeams`, `HundredTeams`
- [x] Manual: `pnpm dev` boots, `/teams` renders (data fetch fails locally since no backend is running — verification subtask AAASM-1153 will confirm against staging)

Local gates passed in worktree `agent-assembly-v0.0.1-AAASM-1054-feat-team_list_page`:
- `pnpm lint` — 0 errors
- `pnpm type-check` — 0 errors
- `pnpm test` — 216 / 216 pass
- `pnpm build` — clean

## Acceptance criteria coverage

- [x] New `/teams` route via existing dashboard layout (replaces `ComingSoon`)
- [x] Columns: Team ID, Member Count, Root Agents, Avg Budget Burn %, Created At
- [x] Sortable columns; default sort = Member Count desc
- [x] Pagination at page size 25
- [x] Search filters teams by ID prefix
- [x] Vitest covers empty, populated, sort, search, pagination
- [x] Storybook stories for 0 / 3 / 100 team fixtures

## Notes on API deviation from the AC

- The AC names `GET /v1/topology/stats` as the source for the team list, but the current OpenAPI exposes the team list under `GET /v1/topology/overview` (`TopologyStats` has aggregate counters, not `teams[]`). This PR uses `overview` and `GET /v1/costs` (which already aggregates per-team daily spend) instead of fanning out `/team/{id}` queries. Burn % is computed against the org-level daily limit, since no per-team limit field exists today.
- `Created At` is rendered as `—`: neither `TeamSummary` nor `TeamTopology` expose a creation timestamp. A backend follow-up can be filed under AAASM-218 if the verification subtask requires this column populated.
- The AC mentions `<DataTable>` / `<SearchInput>` primitives — those don't exist in this codebase yet; this PR follows the existing `AgentsPage` pattern (TanStack Table + inline `<input>`), matching every other page in `dashboard/src/pages/`.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (none required — internal page added)
- [x] All CI checks passing (pre-push)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)