### PR TITLE
[AAASM-1354] ✨ (api/capability): Add capability mock client functions

### DIFF
--- a/dashboard/src/api/capability.ts
+++ b/dashboard/src/api/capability.ts
@@ -1,0 +1,66 @@
+import type {
+  CapabilityAgent,
+  CapabilityMatrix,
+  OverrideRequest,
+  OverrideResponse,
+} from '../features/capability/types'
+import { CAPABILITY_MATRIX_FIXTURE } from '../features/capability/fixtures'
+
+const MOCK_LATENCY_MS = 120
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+export interface CapabilityClient {
+  getMatrix(): Promise<CapabilityMatrix>
+  applyOverride(req: OverrideRequest): Promise<OverrideResponse>
+}
+
+function applyOverrideToAgents(
+  agents: CapabilityAgent[],
+  req: OverrideRequest,
+): CapabilityAgent[] {
+  return agents.map((agent) => {
+    if (!req.agentIds.includes(agent.id)) return agent
+    const existing = agent.caps[req.resourceId]
+    if (!existing) return agent
+    return {
+      ...agent,
+      caps: {
+        ...agent.caps,
+        [req.resourceId]: { ...existing, [req.verb]: req.decision },
+      },
+    }
+  })
+}
+
+export function createMockCapabilityClient(
+  options: { latencyMs?: number; failOverride?: boolean } = {},
+): CapabilityClient {
+  const latency = options.latencyMs ?? MOCK_LATENCY_MS
+  let state: CapabilityMatrix = clone(CAPABILITY_MATRIX_FIXTURE)
+  return {
+    async getMatrix() {
+      await delay(latency)
+      return clone(state)
+    },
+    async applyOverride(req) {
+      await delay(latency)
+      if (options.failOverride) {
+        throw new Error('capability override rejected by gateway (mock)')
+      }
+      state = { ...state, agents: applyOverrideToAgents(state.agents, req) }
+      const updated = state.agents.filter((a) => req.agentIds.includes(a.id))
+      return { updated: clone(updated) }
+    },
+  }
+}
+
+export const capabilityClient: CapabilityClient = createMockCapabilityClient()


### PR DESCRIPTION
## Description

Adds `dashboard/src/api/capability.ts` exposing `getMatrix()` and `applyOverride()` typed against the AAASM-1353 domain types. The mock client clones `CAPABILITY_MATRIX_FIXTURE` into in-memory state, simulates latency, and supports a `failOverride` option for tests. Designed to be drop-in replaceable with the generated `openapi-fetch` client once `aa-api` ships `/v1/capability/*` endpoints (tracked in AAASM-1366).

> **Stacked on AAASM-1353** — base branch is `v0.0.1/AAASM-1353/feat/capability_types`. Re-base to `master` once #338 merges.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Jira: AAASM-1354 (sub-task of AAASM-1280; depends on AAASM-1353; follow-up tracked in AAASM-1366)

## Testing

- [x] No tests required (downstream unit tests in AAASM-1363 cover the rollback path)
- Local gates: `pnpm type-check` ✓, `pnpm lint` ✓, 210/210 tests pass

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)