### PR TITLE
[AAASM-1047] ✨ (dashboard/fleet): Add fleet view primitives and view-model

### DIFF
--- a/dashboard/src/components/fleet/ModeChip.css
+++ b/dashboard/src/components/fleet/ModeChip.css
@@ -1,0 +1,33 @@
+.fleet-mode {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 2px 7px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  font-weight: 500;
+  line-height: 1;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+  white-space: nowrap;
+  border-radius: 2px;
+  border: 1px solid;
+}
+
+.fleet-mode--enforce {
+  background-color: #d4e4d2;
+  border-color: #22592a;
+  color: #22592a;
+}
+
+.fleet-mode--shadow {
+  background-color: #f5e6c4;
+  border-color: #8a5a00;
+  color: #8a5a00;
+}
+
+.fleet-mode--off {
+  background-color: #ffffff;
+  border-color: #c4bfb0;
+  color: #5a5a5a;
+}

--- a/dashboard/src/components/fleet/ModeChip.stories.tsx
+++ b/dashboard/src/components/fleet/ModeChip.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { ModeChip } from './ModeChip'
+
+const meta: Meta<typeof ModeChip> = {
+  title: 'Fleet/ModeChip',
+  component: ModeChip,
+}
+export default meta
+
+type Story = StoryObj<typeof ModeChip>
+
+export const Enforce: Story = { args: { mode: 'enforce' } }
+export const Shadow: Story = { args: { mode: 'shadow' } }
+export const Off: Story = { args: { mode: 'off' } }

--- a/dashboard/src/components/fleet/ModeChip.tsx
+++ b/dashboard/src/components/fleet/ModeChip.tsx
@@ -1,0 +1,26 @@
+import './ModeChip.css'
+import type { FleetMode } from '../../features/agents/fleetTypes'
+
+interface ModeChipProps {
+  mode: FleetMode
+}
+
+const GLYPH: Record<FleetMode, string> = {
+  enforce: '●',
+  shadow: '◐',
+  off: '○',
+}
+
+/**
+ * Enforcement-mode chip matching the `ModeChip` helper in
+ * `design/v1/fleet.jsx`. `enforce` uses the OK token, `shadow` uses
+ * warn, `off` uses the neutral muted token.
+ */
+export function ModeChip({ mode }: ModeChipProps) {
+  return (
+    <span className={`fleet-mode fleet-mode--${mode}`} data-testid="fleet-mode">
+      <span aria-hidden="true">{GLYPH[mode]}</span>
+      {mode}
+    </span>
+  )
+}

--- a/dashboard/src/components/fleet/StatusChip.css
+++ b/dashboard/src/components/fleet/StatusChip.css
@@ -1,0 +1,16 @@
+.fleet-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.fleet-status--active { color: #22592a; }
+.fleet-status--idle { color: #8a8a8a; }
+.fleet-status--suspended { color: #b8291e; }
+.fleet-status--error { color: #b8291e; }
+.fleet-status--unknown { color: #8a8a8a; }

--- a/dashboard/src/components/fleet/StatusChip.stories.tsx
+++ b/dashboard/src/components/fleet/StatusChip.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { StatusChip } from './StatusChip'
+
+const meta: Meta<typeof StatusChip> = {
+  title: 'Fleet/StatusChip',
+  component: StatusChip,
+}
+export default meta
+
+type Story = StoryObj<typeof StatusChip>
+
+export const Active: Story = { args: { status: 'active' } }
+export const Suspended: Story = { args: { status: 'suspended' } }
+export const Error: Story = { args: { status: 'error' } }

--- a/dashboard/src/components/fleet/StatusChip.tsx
+++ b/dashboard/src/components/fleet/StatusChip.tsx
@@ -1,0 +1,36 @@
+import './StatusChip.css'
+
+export type FleetStatusKind = 'active' | 'idle' | 'suspended' | 'error'
+
+interface StatusChipProps {
+  status: string
+}
+
+const GLYPH: Record<FleetStatusKind, string> = {
+  active: '●',
+  idle: '○',
+  suspended: '■',
+  error: '✕',
+}
+
+const KNOWN: readonly FleetStatusKind[] = ['active', 'idle', 'suspended', 'error']
+
+function classify(status: string): FleetStatusKind | 'unknown' {
+  return (KNOWN as readonly string[]).includes(status) ? (status as FleetStatusKind) : 'unknown'
+}
+
+/**
+ * Status chip matching the `StatusChip` helper in `design/v1/fleet.jsx`.
+ * Renders the hi-fi glyph + label using the design-system colour tokens
+ * (palette literals; design tokens land project-wide in AAASM-1048).
+ */
+export function StatusChip({ status }: StatusChipProps) {
+  const kind = classify(status)
+  const glyph = kind === 'unknown' ? '○' : GLYPH[kind]
+  return (
+    <span className={`fleet-status fleet-status--${kind}`} data-testid="fleet-status">
+      <span aria-hidden="true">{glyph}</span>
+      {status}
+    </span>
+  )
+}

--- a/dashboard/src/components/fleet/TrustBar.css
+++ b/dashboard/src/components/fleet/TrustBar.css
@@ -1,0 +1,35 @@
+.fleet-trust {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  line-height: 1;
+}
+
+.fleet-trust__track {
+  width: 60px;
+  height: 6px;
+  background: #d8d4c7;
+  border-radius: 1px;
+  overflow: hidden;
+  display: inline-block;
+}
+
+.fleet-trust__fill {
+  display: block;
+  height: 100%;
+  background: currentColor;
+}
+
+.fleet-trust__value {
+  font-weight: 600;
+}
+
+.fleet-trust--ok { color: #22592a; }
+.fleet-trust--warn { color: #8a5a00; }
+.fleet-trust--danger { color: #b8291e; }
+
+.fleet-trust--empty {
+  color: #8a8a8a;
+}

--- a/dashboard/src/components/fleet/TrustBar.stories.tsx
+++ b/dashboard/src/components/fleet/TrustBar.stories.tsx
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { TrustBar } from './TrustBar'
+
+const meta: Meta<typeof TrustBar> = {
+  title: 'Fleet/TrustBar',
+  component: TrustBar,
+}
+export default meta
+
+type Story = StoryObj<typeof TrustBar>
+
+export const Healthy: Story = { args: { score: 92 } }
+export const Watch: Story = { args: { score: 67 } }
+export const AtRisk: Story = { args: { score: 31 } }
+export const Unwired: Story = { args: { score: null } }

--- a/dashboard/src/components/fleet/TrustBar.tsx
+++ b/dashboard/src/components/fleet/TrustBar.tsx
@@ -1,0 +1,38 @@
+import './TrustBar.css'
+
+interface TrustBarProps {
+  /** Trust score 0-100. `null` renders an em-dash placeholder. */
+  score: number | null
+}
+
+function band(score: number): 'ok' | 'warn' | 'danger' {
+  if (score >= 80) return 'ok'
+  if (score >= 60) return 'warn'
+  return 'danger'
+}
+
+/**
+ * Colour-graded progress bar matching the `TrustBar` helper in
+ * `design/v1/fleet.jsx`. Thresholds: ≥80 ok, ≥60 warn, otherwise danger.
+ * A `null` score renders an em-dash so unwired analytics columns remain
+ * visually inert.
+ */
+export function TrustBar({ score }: TrustBarProps) {
+  if (score === null) {
+    return (
+      <span className="fleet-trust fleet-trust--empty" data-testid="fleet-trust">
+        —
+      </span>
+    )
+  }
+  const clamped = Math.max(0, Math.min(100, score))
+  const tone = band(clamped)
+  return (
+    <span className={`fleet-trust fleet-trust--${tone}`} data-testid="fleet-trust">
+      <span className="fleet-trust__track">
+        <span className="fleet-trust__fill" style={{ width: `${clamped}%` }} />
+      </span>
+      <span className="fleet-trust__value">{clamped}</span>
+    </span>
+  )
+}

--- a/dashboard/src/components/fleet/primitives.test.tsx
+++ b/dashboard/src/components/fleet/primitives.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { StatusChip } from './StatusChip'
+import { ModeChip } from './ModeChip'
+import { TrustBar } from './TrustBar'
+
+describe('StatusChip', () => {
+  it.each(['active', 'idle', 'suspended', 'error'] as const)(
+    'applies the matching modifier for status %s',
+    (status) => {
+      render(<StatusChip status={status} />)
+      const chip = screen.getByTestId('fleet-status')
+      expect(chip).toHaveClass('fleet-status', `fleet-status--${status}`)
+      expect(chip.textContent).toContain(status)
+    },
+  )
+
+  it('falls back to the unknown modifier for unrecognised statuses', () => {
+    render(<StatusChip status="deregistered" />)
+    const chip = screen.getByTestId('fleet-status')
+    expect(chip).toHaveClass('fleet-status--unknown')
+    expect(chip.textContent).toContain('deregistered')
+  })
+})
+
+describe('ModeChip', () => {
+  it.each(['enforce', 'shadow', 'off'] as const)('applies the matching modifier for %s mode', (mode) => {
+    render(<ModeChip mode={mode} />)
+    const chip = screen.getByTestId('fleet-mode')
+    expect(chip).toHaveClass('fleet-mode', `fleet-mode--${mode}`)
+    expect(chip.textContent?.toLowerCase()).toContain(mode)
+  })
+})
+
+describe('TrustBar', () => {
+  it('renders an em-dash when the score is null', () => {
+    render(<TrustBar score={null} />)
+    const bar = screen.getByTestId('fleet-trust')
+    expect(bar).toHaveClass('fleet-trust--empty')
+    expect(bar.textContent).toBe('—')
+  })
+
+  it.each([
+    [95, 'fleet-trust--ok'],
+    [80, 'fleet-trust--ok'],
+    [75, 'fleet-trust--warn'],
+    [60, 'fleet-trust--warn'],
+    [42, 'fleet-trust--danger'],
+    [0, 'fleet-trust--danger'],
+  ])('applies the matching band for score %s → %s', (score, expectedClass) => {
+    render(<TrustBar score={score} />)
+    const bar = screen.getByTestId('fleet-trust')
+    expect(bar).toHaveClass(expectedClass)
+    expect(bar.textContent).toContain(String(score))
+  })
+
+  it('clamps the rendered width into 0–100', () => {
+    render(<TrustBar score={150} />)
+    const fill = document.querySelector('.fleet-trust__fill') as HTMLElement | null
+    expect(fill?.style.width).toBe('100%')
+  })
+})

--- a/dashboard/src/features/agents/fleetTypes.test.ts
+++ b/dashboard/src/features/agents/fleetTypes.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import type { Agent } from './api'
+import { FLEET_FLAGGED_THRESHOLD, toFleetAgent } from './fleetTypes'
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: 'abc',
+    name: 'agent-name',
+    framework: 'langgraph',
+    status: 'active',
+    version: '0.1.0',
+    layer: null,
+    last_event: null,
+    recent_events: [],
+    recent_traces: [],
+    active_sessions: [],
+    session_count: 0,
+    policy_violations_count: 0,
+    tool_names: [],
+    metadata: {},
+    pid: null,
+    ...overrides,
+  }
+}
+
+describe('toFleetAgent', () => {
+  it('copies through identity fields', () => {
+    const fa = toFleetAgent(makeAgent({ id: 'id-1', name: 'alpha', framework: 'crewai', status: 'idle' }))
+    expect(fa.id).toBe('id-1')
+    expect(fa.name).toBe('alpha')
+    expect(fa.framework).toBe('crewai')
+    expect(fa.status).toBe('idle')
+    expect(fa.source.id).toBe('id-1')
+  })
+
+  it('derives owner / note from metadata; missing keys become null', () => {
+    const withMeta = toFleetAgent(makeAgent({ metadata: { owner: 'alice', note: 'flaky' } }))
+    expect(withMeta.owner).toBe('alice')
+    expect(withMeta.note).toBe('flaky')
+
+    const withoutMeta = toFleetAgent(makeAgent({ metadata: {} }))
+    expect(withoutMeta.owner).toBeNull()
+    expect(withoutMeta.note).toBeNull()
+  })
+
+  it('parses mode from metadata; invalid or missing values default to enforce', () => {
+    expect(toFleetAgent(makeAgent({ metadata: { mode: 'shadow' } })).mode).toBe('shadow')
+    expect(toFleetAgent(makeAgent({ metadata: { mode: 'off' } })).mode).toBe('off')
+    expect(toFleetAgent(makeAgent({ metadata: { mode: 'enforce' } })).mode).toBe('enforce')
+    expect(toFleetAgent(makeAgent({ metadata: { mode: 'gibberish' } })).mode).toBe('enforce')
+    expect(toFleetAgent(makeAgent({ metadata: {} })).mode).toBe('enforce')
+  })
+
+  it('marks the agent flagged at or above the violations threshold', () => {
+    expect(toFleetAgent(makeAgent({ policy_violations_count: FLEET_FLAGGED_THRESHOLD - 1 })).flagged).toBe(false)
+    expect(toFleetAgent(makeAgent({ policy_violations_count: FLEET_FLAGGED_THRESHOLD })).flagged).toBe(true)
+    expect(toFleetAgent(makeAgent({ policy_violations_count: FLEET_FLAGGED_THRESHOLD + 100 })).flagged).toBe(true)
+  })
+
+  it('surfaces last_event as lastSeen; null when absent', () => {
+    expect(toFleetAgent(makeAgent({ last_event: '2026-05-13T00:00:00Z' })).lastSeen).toBe('2026-05-13T00:00:00Z')
+    expect(toFleetAgent(makeAgent({ last_event: null })).lastSeen).toBeNull()
+  })
+
+  it('leaves unwired analytics metrics as null so tables render an em-dash', () => {
+    const fa = toFleetAgent(makeAgent())
+    expect(fa.trust).toBeNull()
+    expect(fa.blocked24h).toBeNull()
+    expect(fa.scrubbed24h).toBeNull()
+  })
+})

--- a/dashboard/src/features/agents/fleetTypes.ts
+++ b/dashboard/src/features/agents/fleetTypes.ts
@@ -1,0 +1,63 @@
+import type { Agent } from './api'
+
+/**
+ * `policy_violations_count` at or above this threshold marks an agent as
+ * "flagged" in the Fleet view (rendered with a danger-tinted row in
+ * `design/v1/fleet.jsx`).
+ */
+export const FLEET_FLAGGED_THRESHOLD = 50
+
+/** Enforcement modes rendered by `ModeChip`. */
+export type FleetMode = 'enforce' | 'shadow' | 'off'
+
+const MODE_VALUES: readonly FleetMode[] = ['enforce', 'shadow', 'off']
+
+/**
+ * Projection of an `AgentResponse` onto the columns the Fleet page renders.
+ *
+ * Numeric metrics not yet backed by an analytics endpoint (`trust`,
+ * `blocked24h`, `scrubbed24h`) are represented as `null` so table cells can
+ * render an unambiguous `—` placeholder rather than misleading zeros.
+ */
+export interface FleetAgent {
+  readonly source: Agent
+  readonly id: string
+  readonly name: string
+  readonly framework: string
+  readonly status: string
+  readonly owner: string | null
+  readonly mode: FleetMode
+  readonly flagged: boolean
+  readonly lastSeen: string | null
+  readonly trust: number | null
+  readonly blocked24h: number | null
+  readonly scrubbed24h: number | null
+  readonly note: string | null
+}
+
+function parseMode(raw: string | undefined): FleetMode {
+  if (raw && (MODE_VALUES as readonly string[]).includes(raw)) {
+    return raw as FleetMode
+  }
+  return 'enforce'
+}
+
+/** Project an `AgentResponse` onto the Fleet page view-model. */
+export function toFleetAgent(agent: Agent): FleetAgent {
+  const metadata = agent.metadata ?? {}
+  return {
+    source: agent,
+    id: agent.id,
+    name: agent.name,
+    framework: agent.framework,
+    status: agent.status,
+    owner: metadata.owner ?? null,
+    mode: parseMode(metadata.mode),
+    flagged: agent.policy_violations_count >= FLEET_FLAGGED_THRESHOLD,
+    lastSeen: agent.last_event ?? null,
+    trust: null,
+    blocked24h: null,
+    scrubbed24h: null,
+    note: metadata.note ?? null,
+  }
+}


### PR DESCRIPTION
## Description

Adds the foundation pieces for the upcoming Fleet page (parent Story AAASM-217, PR 4 — Fleet + Agent Detail drawer):

- `features/agents/fleetTypes.ts` — `FleetAgent` view-model and `toFleetAgent()` projection. Maps `AgentResponse` onto the columns rendered in `design/v1/fleet.jsx`. Unwired analytics metrics (`trust`, `blocked24h`, `scrubbed24h`) are surfaced as `null` so cells can render `—` rather than misleading zeros.
- `components/fleet/StatusChip` — status glyph + label, mirrors the `StatusChip` helper from the hi-fi.
- `components/fleet/ModeChip` — enforcement-mode chip (enforce / shadow / off).
- `components/fleet/TrustBar` — colour-graded progress bar with ≥80 ok / ≥60 warn / else danger thresholds and a `null`-aware empty state.
- Storybook stories (3-4 fixtures each) for the three primitives.

No routing or page wiring yet — that lands in AAASM-1048. No new API surface; no new colour tokens (palette literals match the hi-fi tokens that will land project-wide in AAASM-1048).

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: [AAASM-1047](https://lightning-dust-mite.atlassian.net/browse/AAASM-1047) (parent Story: [AAASM-217](https://lightning-dust-mite.atlassian.net/browse/AAASM-217), Epic [AAASM-197](https://lightning-dust-mite.atlassian.net/browse/AAASM-197))
- Related GitHub issues: —

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Local validation in `dashboard/`:

```
pnpm type-check   # tsc --noEmit, clean
pnpm lint         # eslint --max-warnings 0, clean
pnpm test         # 20 files / 232 tests passing (incl. 22 new)
pnpm build        # tsc + vite build, clean
```

The 7 new tests for `fleetTypes` cover identity field pass-through, owner/note derivation, mode parsing fallback to `enforce`, the violations-count flagged boundary, `lastSeen` mapping, and the null-default for unwired analytics metrics. The 16 new primitive tests cover modifier classes (including the unknown-status fallback), trust banding at the 80/60 boundaries, null-score em-dash rendering, and the 0–100 fill clamp.

## Checklist

- [x] Code follows project style guidelines (`pnpm lint`, `pnpm type-check` clean)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a — no public docs touched)
- [x] All CI checks passing (verified locally)
- [x] Commits are small and follow the Gitmoji convention (7 commits, one logical change each)

[AAASM-1047]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ