### PR TITLE
[AAASM-1356] ✨ (routing): Replace /capability ComingSoon stub with CapabilityPage

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -10,6 +10,7 @@ import { PoliciesPage } from './pages/PoliciesPage'
 import { PolicyEditorPage } from './pages/PolicyEditorPage'
 import { AnalyticsPage } from './pages/AnalyticsPage'
 import { AlertsPage } from './pages/AlertsPage'
+import { CapabilityPage } from './pages/CapabilityPage'
 import { ComingSoon } from './pages/ComingSoon'
 import { TeamDetailPage } from './pages/TeamDetailPage'
 
@@ -32,7 +33,7 @@ function App() {
             <Route path="/alerts" element={<AlertsPage />} />
             <Route path="/audit" element={<ComingSoon name="Audit Log" />} />
             {/* control */}
-            <Route path="/capability" element={<ComingSoon name="Capability" />} />
+            <Route path="/capability" element={<CapabilityPage />} />
             <Route path="/policies" element={<PoliciesPage />} />
             <Route path="/scrub" element={<ComingSoon name="Secret Scrubbing" />} />
             {/* manage */}

--- a/dashboard/src/pages/CapabilityPage.css
+++ b/dashboard/src/pages/CapabilityPage.css
@@ -1,0 +1,88 @@
+.capability-page {
+  display: flex;
+  flex-direction: column;
+  background: var(--paper);
+  min-height: calc(100vh - 56px);
+}
+
+.capability-head {
+  padding: 22px 24px 18px;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper-2);
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 24px;
+}
+
+.capability-title {
+  margin: 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--ink);
+  letter-spacing: -0.5px;
+}
+
+.capability-sub {
+  margin: 6px 0 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  color: var(--ink-3);
+  max-width: 640px;
+  line-height: 1.5;
+}
+
+.capability-head-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.capability-btn {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  padding: 6px 12px;
+  border-radius: 3px;
+  border: 1px solid var(--line);
+  background: var(--paper-2);
+  color: var(--ink);
+  cursor: pointer;
+}
+
+.capability-btn:hover {
+  background: var(--paper-3);
+}
+
+.capability-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper-2);
+  padding: 0 24px;
+}
+
+.capability-tab {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  text-transform: lowercase;
+  padding: 10px 14px;
+  border: none;
+  background: transparent;
+  color: var(--ink-3);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+
+.capability-tab:hover {
+  color: var(--ink);
+}
+
+.capability-tab.is-active {
+  color: var(--ink);
+  border-bottom-color: var(--ink);
+  font-weight: 600;
+}
+
+.capability-body {
+  flex: 1;
+}

--- a/dashboard/src/pages/CapabilityPage.tsx
+++ b/dashboard/src/pages/CapabilityPage.tsx
@@ -1,0 +1,58 @@
+import { useState } from 'react'
+import './CapabilityPage.css'
+
+type Tab = 'matrix' | 'resource' | 'agent'
+
+export function CapabilityPage() {
+  const [tab, setTab] = useState<Tab>('matrix')
+
+  return (
+    <div className="capability-page" data-testid="capability-page">
+      <header className="capability-head">
+        <div>
+          <h1 className="capability-title">Capability</h1>
+          <p className="capability-sub">
+            What agents claim they can do — and what Assembly actually allows. Click any cell to see the
+            policy responsible and edit inline.
+          </p>
+        </div>
+        <div className="capability-head-actions">
+          <button type="button" className="capability-btn">
+            ⊞ Templates
+          </button>
+          <button type="button" className="capability-btn">
+            ↧ Export CSV
+          </button>
+        </div>
+      </header>
+
+      <nav className="capability-tabs" aria-label="capability views">
+        <button
+          type="button"
+          className={`capability-tab${tab === 'matrix' ? ' is-active' : ''}`}
+          onClick={() => setTab('matrix')}
+        >
+          Matrix
+        </button>
+        <button
+          type="button"
+          className={`capability-tab${tab === 'resource' ? ' is-active' : ''}`}
+          onClick={() => setTab('resource')}
+        >
+          Per-resource
+        </button>
+        <button
+          type="button"
+          className={`capability-tab${tab === 'agent' ? ' is-active' : ''}`}
+          onClick={() => setTab('agent')}
+        >
+          Per-agent
+        </button>
+      </nav>
+
+      <section className="capability-body" data-active-tab={tab}>
+        {/* Grid, filters, sort, drawer, and bulk override wired in subsequent sub-tasks. */}
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Description

Swaps the `<ComingSoon name="Capability" />` placeholder at `/capability` for a real `CapabilityPage` skeleton with page-head + tab selector (matrix / per-resource / per-agent), matching `design/v1/hi-fi/capability.jsx`. The matrix grid, filters, sort, drawer, and bulk override land in subsequent sub-tasks.

> **Stacked on AAASM-1355**. Re-base to `master` after #342 merges.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No (the `CANONICAL_ROUTES` config and `ComingSoon` itself are untouched; routes.test.tsx still passes.)

## Related Issues

- Jira: AAASM-1356 (sub-task of AAASM-1280)

## Testing

- [x] Manual: `pnpm dev` → `http://localhost:3000/capability` renders the new page-head + tabs.
- Local gates: `pnpm type-check` ✓, `pnpm lint` ✓, 210/210 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)