### PR TITLE
[AAASM-1357] ✨ (capability): Add CapabilityMatrixGrid component

### DIFF
--- a/dashboard/src/features/capability/CapabilityMatrixGrid.css
+++ b/dashboard/src/features/capability/CapabilityMatrixGrid.css
@@ -1,0 +1,181 @@
+.cap-matrix-wrap {
+  padding: 16px 24px;
+}
+
+.cap-matrix-meta {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--ink-4);
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.cap-matrix-meta strong {
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.cap-matrix-grid {
+  display: grid;
+  gap: 1px;
+  background: var(--line);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  overflow: hidden;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.cap-mx-corner,
+.cap-mx-col-h,
+.cap-mx-row-h,
+.cap-mx-cell {
+  background: var(--paper-2);
+  padding: 8px 10px;
+  font-size: 11px;
+  color: var(--ink-3);
+}
+
+.cap-mx-corner {
+  background: var(--paper-3);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--ink-4);
+}
+
+.cap-mx-col-h {
+  background: var(--paper-3);
+  color: var(--ink-2);
+  font-weight: 600;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.cap-mx-col-h-group {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--ink-4);
+  font-weight: 500;
+}
+
+.cap-mx-row-h {
+  background: var(--paper-2);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  border-right: 1px solid var(--line);
+}
+
+.cap-mx-row-h-name {
+  color: var(--ink);
+  font-weight: 600;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.cap-mx-row-h-meta {
+  font-size: 10px;
+  color: var(--ink-4);
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.cap-mx-row-h-trust {
+  margin-left: auto;
+}
+
+.cap-trust-bar {
+  height: 3px;
+  background: var(--paper-3);
+  border-radius: 2px;
+  margin-top: 4px;
+  overflow: hidden;
+}
+
+.cap-trust-bar-fill {
+  height: 100%;
+  border-radius: 2px;
+}
+
+.cap-trust--ok {
+  background: var(--ok);
+}
+
+.cap-trust--warn {
+  background: var(--warn);
+}
+
+.cap-trust--danger {
+  background: var(--danger);
+}
+
+.cap-flag-dot {
+  color: var(--danger);
+  font-size: 10px;
+}
+
+.cap-mx-cell {
+  text-align: center;
+  text-transform: uppercase;
+  font-size: 10px;
+  font-weight: 600;
+  position: relative;
+  cursor: pointer;
+  user-select: none;
+}
+
+.cap-mx-cell[aria-disabled='true'] {
+  cursor: default;
+}
+
+.cap-mx-cell--allow {
+  background: var(--paper-2);
+  color: var(--ink-3);
+}
+
+.cap-mx-cell--narrow {
+  background: var(--warn-bg);
+  color: var(--warn);
+  border: 1px solid var(--warn);
+}
+
+.cap-mx-cell--approval {
+  background: var(--info-bg);
+  color: var(--info);
+  border: 1px solid var(--info);
+}
+
+.cap-mx-cell--deny {
+  background: var(--danger-bg);
+  color: var(--danger);
+  border: 1px solid var(--danger);
+}
+
+.cap-mx-cell--na {
+  background: var(--paper-3);
+  color: var(--ink-5);
+}
+
+.cap-mx-cell:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: -2px;
+}
+
+.cap-mx-cell-flag {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 6px;
+  height: 6px;
+  background: var(--danger);
+  border-radius: 50%;
+}

--- a/dashboard/src/features/capability/CapabilityMatrixGrid.tsx
+++ b/dashboard/src/features/capability/CapabilityMatrixGrid.tsx
@@ -1,0 +1,143 @@
+import type { CapabilityAgent, Decision, Resource, Verb } from './types'
+import { DECISIONS } from './types'
+import './CapabilityMatrixGrid.css'
+
+export interface CapabilityMatrixGridProps {
+  agents: CapabilityAgent[]
+  resources: Resource[]
+  verb: Verb
+  onCellClick?: (cell: CellSelection) => void
+}
+
+export interface CellSelection {
+  agent: CapabilityAgent
+  resource: Resource
+  verb: Verb
+  decision: Decision
+}
+
+function trustToneClass(trust: number): string {
+  if (trust < 60) return 'cap-trust--danger'
+  if (trust < 80) return 'cap-trust--warn'
+  return 'cap-trust--ok'
+}
+
+export function CapabilityMatrixGrid({
+  agents,
+  resources,
+  verb,
+  onCellClick,
+}: CapabilityMatrixGridProps) {
+  const templateColumns = `260px repeat(${resources.length}, minmax(110px, 1fr))`
+
+  return (
+    <div className="cap-matrix-wrap">
+      <div className="cap-matrix-meta">
+        <span>
+          verb: <strong>{verb.toUpperCase()}</strong> · cells show effective decision
+        </span>
+        <span>● red dot = recent flag · click a cell to inspect</span>
+      </div>
+      <div
+        className="cap-matrix-grid"
+        role="grid"
+        aria-label="capability matrix"
+        style={{ gridTemplateColumns: templateColumns }}
+      >
+        <div className="cap-mx-corner" role="columnheader">
+          agent ↓ · resource →
+        </div>
+        {resources.map((r) => (
+          <div key={r.id} className="cap-mx-col-h" role="columnheader">
+            <div className="cap-mx-col-h-group">{r.group}</div>
+            {r.name}
+          </div>
+        ))}
+
+        {agents.map((agent) => (
+          <RowGroup
+            key={agent.id}
+            agent={agent}
+            resources={resources}
+            verb={verb}
+            onCellClick={onCellClick}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface RowGroupProps {
+  agent: CapabilityAgent
+  resources: Resource[]
+  verb: Verb
+  onCellClick?: (cell: CellSelection) => void
+}
+
+function RowGroup({ agent, resources, verb, onCellClick }: RowGroupProps) {
+  return (
+    <>
+      <div className="cap-mx-row-h" role="rowheader">
+        <div className="cap-mx-row-h-name">
+          {agent.name}
+          {agent.flagged && (
+            <span className="cap-flag-dot" aria-label="agent flagged">
+              ●
+            </span>
+          )}
+        </div>
+        <div className="cap-mx-row-h-meta">
+          <span>{agent.framework}</span>
+          <span aria-hidden>·</span>
+          <span>{agent.owner}</span>
+          <span className="cap-mx-row-h-trust">trust {agent.trust}</span>
+        </div>
+        <div className="cap-trust-bar" aria-hidden>
+          <div
+            className={`cap-trust-bar-fill ${trustToneClass(agent.trust)}`}
+            style={{ width: `${agent.trust}%` }}
+          />
+        </div>
+      </div>
+      {resources.map((r) => {
+        const cap = agent.caps[r.id]
+        if (!cap) {
+          return (
+            <div key={r.id} className="cap-mx-cell cap-mx-cell--na" role="gridcell">
+              {DECISIONS.na.label}
+            </div>
+          )
+        }
+        const decision: Decision = cap[verb] ?? 'na'
+        const flagged = Boolean(cap.flag) && decision !== 'na'
+        const interactive = decision !== 'na'
+        return (
+          <div
+            key={r.id}
+            className={`cap-mx-cell cap-mx-cell--${decision}`}
+            role="gridcell"
+            tabIndex={interactive ? 0 : -1}
+            aria-disabled={!interactive}
+            data-decision={decision}
+            onClick={
+              interactive && onCellClick
+                ? () => onCellClick({ agent, resource: r, verb, decision })
+                : undefined
+            }
+            onKeyDown={(e) => {
+              if (!interactive || !onCellClick) return
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                onCellClick({ agent, resource: r, verb, decision })
+              }
+            }}
+          >
+            {DECISIONS[decision].label}
+            {flagged && <span className="cap-mx-cell-flag" aria-label="recent flag" />}
+          </div>
+        )
+      })}
+    </>
+  )
+}

--- a/dashboard/src/pages/CapabilityPage.css
+++ b/dashboard/src/pages/CapabilityPage.css
@@ -86,3 +86,42 @@
 .capability-body {
   flex: 1;
 }
+
+.capability-verbs {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 0;
+}
+
+.capability-verbs-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--ink-4);
+  margin-right: 4px;
+}
+
+.capability-verb {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  padding: 4px 10px;
+  border: 1px solid var(--line);
+  background: var(--paper-2);
+  color: var(--ink-3);
+  border-radius: 3px;
+  cursor: pointer;
+  text-transform: lowercase;
+}
+
+.capability-verb:hover {
+  color: var(--ink);
+}
+
+.capability-verb.is-active {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}

--- a/dashboard/src/pages/CapabilityPage.tsx
+++ b/dashboard/src/pages/CapabilityPage.tsx
@@ -1,10 +1,26 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { capabilityClient } from '../api/capability'
+import { CapabilityMatrixGrid } from '../features/capability/CapabilityMatrixGrid'
+import { VERBS } from '../features/capability/types'
+import type { CapabilityMatrix, Verb } from '../features/capability/types'
 import './CapabilityPage.css'
 
 type Tab = 'matrix' | 'resource' | 'agent'
 
 export function CapabilityPage() {
   const [tab, setTab] = useState<Tab>('matrix')
+  const [verb, setVerb] = useState<Verb>('write')
+  const [matrix, setMatrix] = useState<CapabilityMatrix | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    capabilityClient.getMatrix().then((m) => {
+      if (alive) setMatrix(m)
+    })
+    return () => {
+      alive = false
+    }
+  }, [])
 
   return (
     <div className="capability-page" data-testid="capability-page">
@@ -48,10 +64,32 @@ export function CapabilityPage() {
         >
           Per-agent
         </button>
+
+        <div className="capability-verbs" role="radiogroup" aria-label="verb">
+          <span className="capability-verbs-label">verb</span>
+          {VERBS.map((v) => (
+            <button
+              key={v}
+              type="button"
+              role="radio"
+              aria-checked={verb === v}
+              className={`capability-verb${verb === v ? ' is-active' : ''}`}
+              onClick={() => setVerb(v)}
+            >
+              {v}
+            </button>
+          ))}
+        </div>
       </nav>
 
       <section className="capability-body" data-active-tab={tab}>
-        {/* Grid, filters, sort, drawer, and bulk override wired in subsequent sub-tasks. */}
+        {tab === 'matrix' && matrix && (
+          <CapabilityMatrixGrid
+            agents={matrix.agents}
+            resources={matrix.resources}
+            verb={verb}
+          />
+        )}
       </section>
     </div>
   )


### PR DESCRIPTION
## Description

Adds the 2-D capability matrix as `dashboard/src/features/capability/CapabilityMatrixGrid.tsx`:

- Rows = agent (with name, framework, owner, trust bar), columns = resource grouped by category (`comm`, `files`, `data`, `infra`, `code`).
- Cells render the decision (`allow` / `narrow` / `approval` / `deny` / `na`) for the currently-selected verb (`read` / `write` / `delete` / `exec`).
- All color tokens come exclusively from `dashboard/src/styles.css` — no hard-coded hex (AC #3).
- Cells expose an `onCellClick` prop and `tabIndex` for the drawer wiring in AAASM-1360.
- `CapabilityPage` fetches the matrix via the mock client and renders the grid; verb selector + Matrix tab are now live.

> **Stacked on AAASM-1356**. Re-base to `master` after #344 merges.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Jira: AAASM-1357 (AAASM-1280 sub-task; satisfies AC #1 + AC #3)

## Testing

- [x] Manual: `pnpm dev` → `/capability` renders an 8-agent × 8-resource matrix with verb toggle.
- Local gates: `pnpm type-check` ✓, `pnpm lint` ✓, 210/210 tests pass (new component test coverage lands in AAASM-1363).

🤖 Generated with [Claude Code](https://claude.com/claude-code)