### PR TITLE
[AAASM-1358] ✨ (capability): Add row search + filter bar

### DIFF
--- a/dashboard/src/features/capability/CapabilityFilterBar.css
+++ b/dashboard/src/features/capability/CapabilityFilterBar.css
@@ -1,0 +1,86 @@
+.cap-filterbar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  padding: 10px 24px;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper-2);
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.cap-search {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  padding: 4px 8px;
+  border-radius: 3px;
+  min-width: 280px;
+}
+
+.cap-search-icon {
+  color: var(--ink-4);
+  font-size: 12px;
+}
+
+.cap-search input {
+  border: none;
+  outline: none;
+  background: transparent;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--ink);
+  width: 100%;
+}
+
+.cap-filter-field {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--ink-3);
+  border: 1px solid var(--line);
+  background: var(--paper);
+  padding: 4px 8px;
+  border-radius: 3px;
+}
+
+.cap-filter-field--em {
+  border-color: var(--warn);
+  color: var(--warn);
+}
+
+.cap-filter-field-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--ink-4);
+}
+
+.cap-filter-field--em .cap-filter-field-label {
+  color: var(--warn);
+}
+
+.cap-filter-field select,
+.cap-filter-field input {
+  font-family: inherit;
+  font-size: 11px;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.cap-filter-field input {
+  width: 48px;
+}
+
+.cap-filter-count {
+  margin-left: auto;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--ink-4);
+}

--- a/dashboard/src/features/capability/CapabilityFilterBar.tsx
+++ b/dashboard/src/features/capability/CapabilityFilterBar.tsx
@@ -1,0 +1,110 @@
+import type { CapabilityAgent } from './types'
+import type { CapabilityFilters } from './filters'
+import './CapabilityFilterBar.css'
+
+export interface CapabilityFilterBarProps {
+  filters: CapabilityFilters
+  onChange: (next: CapabilityFilters) => void
+  totalAgents: number
+  visibleAgents: number
+  agents: CapabilityAgent[]
+}
+
+function uniqueSorted(values: string[]): string[] {
+  return [...new Set(values)].sort()
+}
+
+export function CapabilityFilterBar({
+  filters,
+  onChange,
+  totalAgents,
+  visibleAgents,
+  agents,
+}: CapabilityFilterBarProps) {
+  const frameworks = uniqueSorted(agents.map((a) => a.framework))
+  const owners = uniqueSorted(agents.map((a) => a.owner))
+  const modes = uniqueSorted(agents.map((a) => a.mode))
+
+  return (
+    <div className="cap-filterbar" role="search">
+      <label className="cap-search">
+        <span className="cap-search-icon" aria-hidden>
+          ⌕
+        </span>
+        <input
+          type="search"
+          placeholder="search agent · framework · owner · DID"
+          value={filters.search}
+          onChange={(e) => onChange({ ...filters, search: e.target.value })}
+          aria-label="search agents"
+        />
+      </label>
+
+      <label className="cap-filter-field">
+        <span className="cap-filter-field-label">framework</span>
+        <select
+          value={filters.framework}
+          onChange={(e) => onChange({ ...filters, framework: e.target.value })}
+        >
+          <option value="any">any</option>
+          {frameworks.map((f) => (
+            <option key={f} value={f}>
+              {f}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="cap-filter-field">
+        <span className="cap-filter-field-label">owner</span>
+        <select
+          value={filters.owner}
+          onChange={(e) => onChange({ ...filters, owner: e.target.value })}
+        >
+          <option value="any">any</option>
+          {owners.map((o) => (
+            <option key={o} value={o}>
+              {o}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="cap-filter-field">
+        <span className="cap-filter-field-label">mode</span>
+        <select
+          value={filters.mode}
+          onChange={(e) => onChange({ ...filters, mode: e.target.value })}
+        >
+          <option value="any">any</option>
+          {modes.map((m) => (
+            <option key={m} value={m}>
+              {m}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="cap-filter-field cap-filter-field--em">
+        <span className="cap-filter-field-label">trust ≤</span>
+        <input
+          type="number"
+          min={0}
+          max={100}
+          step={5}
+          value={filters.trustMax ?? ''}
+          placeholder="—"
+          onChange={(e) => {
+            const v = e.target.value
+            onChange({ ...filters, trustMax: v === '' ? null : Number(v) })
+          }}
+          aria-label="filter by trust at most"
+        />
+      </label>
+
+      <span className="cap-filter-count">
+        {visibleAgents} of {totalAgents} agents
+      </span>
+    </div>
+  )
+}

--- a/dashboard/src/features/capability/filters.ts
+++ b/dashboard/src/features/capability/filters.ts
@@ -1,0 +1,37 @@
+import type { CapabilityAgent } from './types'
+
+export interface CapabilityFilters {
+  search: string
+  framework: string
+  owner: string
+  mode: string
+  trustMax: number | null
+}
+
+export const EMPTY_FILTERS: CapabilityFilters = {
+  search: '',
+  framework: 'any',
+  owner: 'any',
+  mode: 'any',
+  trustMax: null,
+}
+
+export function applyFilters(
+  agents: CapabilityAgent[],
+  filters: CapabilityFilters,
+): CapabilityAgent[] {
+  const q = filters.search.trim().toLowerCase()
+  return agents.filter((a) => {
+    if (filters.framework !== 'any' && a.framework !== filters.framework) return false
+    if (filters.owner !== 'any' && a.owner !== filters.owner) return false
+    if (filters.mode !== 'any' && a.mode !== filters.mode) return false
+    if (filters.trustMax !== null && a.trust > filters.trustMax) return false
+    if (!q) return true
+    return (
+      a.name.toLowerCase().includes(q) ||
+      a.framework.toLowerCase().includes(q) ||
+      a.owner.toLowerCase().includes(q) ||
+      a.id.toLowerCase().includes(q)
+    )
+  })
+}

--- a/dashboard/src/pages/CapabilityPage.tsx
+++ b/dashboard/src/pages/CapabilityPage.tsx
@@ -1,6 +1,8 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { capabilityClient } from '../api/capability'
 import { CapabilityMatrixGrid } from '../features/capability/CapabilityMatrixGrid'
+import { CapabilityFilterBar } from '../features/capability/CapabilityFilterBar'
+import { EMPTY_FILTERS, applyFilters, type CapabilityFilters } from '../features/capability/filters'
 import { VERBS } from '../features/capability/types'
 import type { CapabilityMatrix, Verb } from '../features/capability/types'
 import './CapabilityPage.css'
@@ -11,6 +13,7 @@ export function CapabilityPage() {
   const [tab, setTab] = useState<Tab>('matrix')
   const [verb, setVerb] = useState<Verb>('write')
   const [matrix, setMatrix] = useState<CapabilityMatrix | null>(null)
+  const [filters, setFilters] = useState<CapabilityFilters>(EMPTY_FILTERS)
 
   useEffect(() => {
     let alive = true
@@ -21,6 +24,11 @@ export function CapabilityPage() {
       alive = false
     }
   }, [])
+
+  const visibleAgents = useMemo(
+    () => (matrix ? applyFilters(matrix.agents, filters) : []),
+    [matrix, filters],
+  )
 
   return (
     <div className="capability-page" data-testid="capability-page">
@@ -82,10 +90,20 @@ export function CapabilityPage() {
         </div>
       </nav>
 
+      {tab === 'matrix' && matrix && (
+        <CapabilityFilterBar
+          filters={filters}
+          onChange={setFilters}
+          totalAgents={matrix.agents.length}
+          visibleAgents={visibleAgents.length}
+          agents={matrix.agents}
+        />
+      )}
+
       <section className="capability-body" data-active-tab={tab}>
         {tab === 'matrix' && matrix && (
           <CapabilityMatrixGrid
-            agents={matrix.agents}
+            agents={visibleAgents}
             resources={matrix.resources}
             verb={verb}
           />


### PR DESCRIPTION
## Description

Adds the filter bar described in `design/v1/hi-fi/capability.jsx`:

- `<CapabilityFilterBar>` with search input + framework/owner/mode selects + `trust ≤` cap.
- `filters.ts` exposes `CapabilityFilters`, `EMPTY_FILTERS`, and `applyFilters()` — split out so the component file satisfies `react-refresh/only-export-components`.
- `CapabilityPage` plumbs filters through `useMemo`, recomputes `visibleAgents`, and forwards the filtered list to the matrix.
- Counter shows `N of M agents` matching current filters.

> **Stacked on AAASM-1357**. Re-base to `master` after #345 merges.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Jira: AAASM-1358 (AAASM-1280 sub-task; AC #5).

## Testing

- [x] Manual: `pnpm dev` → type "rev-ops" in search → only `sales-outreach-v2` remains; clear filter → 8 rows return.
- Local gates: `pnpm type-check` ✓, `pnpm lint` ✓, 210/210 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)