### PR TITLE
[AAASM-1359] ✨ (capability): Add column-header sort

### DIFF
--- a/dashboard/src/features/capability/CapabilityMatrixGrid.css
+++ b/dashboard/src/features/capability/CapabilityMatrixGrid.css
@@ -55,6 +55,31 @@
   gap: 2px;
 }
 
+.cap-mx-col-h-btn {
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+}
+
+.cap-mx-col-h-btn:disabled {
+  cursor: default;
+}
+
+.cap-mx-col-h-btn.is-sorted {
+  background: var(--paper-2);
+  color: var(--ink);
+}
+
+.cap-mx-sort-ind {
+  color: var(--ink-4);
+  margin-left: 4px;
+}
+
+.cap-mx-col-h-btn.is-sorted .cap-mx-sort-ind {
+  color: var(--ink);
+}
+
 .cap-mx-col-h-group {
   font-size: 9px;
   text-transform: uppercase;

--- a/dashboard/src/features/capability/CapabilityMatrixGrid.tsx
+++ b/dashboard/src/features/capability/CapabilityMatrixGrid.tsx
@@ -1,5 +1,6 @@
 import type { CapabilityAgent, Decision, Resource, Verb } from './types'
 import { DECISIONS } from './types'
+import type { SortState } from './sort'
 import './CapabilityMatrixGrid.css'
 
 export interface CapabilityMatrixGridProps {
@@ -7,6 +8,8 @@ export interface CapabilityMatrixGridProps {
   resources: Resource[]
   verb: Verb
   onCellClick?: (cell: CellSelection) => void
+  sort?: SortState
+  onSortChange?: (resourceId: string) => void
 }
 
 export interface CellSelection {
@@ -27,8 +30,15 @@ export function CapabilityMatrixGrid({
   resources,
   verb,
   onCellClick,
+  sort,
+  onSortChange,
 }: CapabilityMatrixGridProps) {
   const templateColumns = `260px repeat(${resources.length}, minmax(110px, 1fr))`
+
+  function sortIndicator(resourceId: string): string {
+    if (!sort || sort.resourceId !== resourceId || !sort.direction) return '↕'
+    return sort.direction === 'desc' ? '↓' : '↑'
+  }
 
   return (
     <div className="cap-matrix-wrap">
@@ -47,12 +57,28 @@ export function CapabilityMatrixGrid({
         <div className="cap-mx-corner" role="columnheader">
           agent ↓ · resource →
         </div>
-        {resources.map((r) => (
-          <div key={r.id} className="cap-mx-col-h" role="columnheader">
-            <div className="cap-mx-col-h-group">{r.group}</div>
-            {r.name}
-          </div>
-        ))}
+        {resources.map((r) => {
+          const sortable = Boolean(onSortChange)
+          const active = sort?.resourceId === r.id && sort?.direction
+          return (
+            <button
+              key={r.id}
+              type="button"
+              className={`cap-mx-col-h cap-mx-col-h-btn${active ? ' is-sorted' : ''}`}
+              role="columnheader"
+              aria-sort={
+                active ? (sort?.direction === 'asc' ? 'ascending' : 'descending') : 'none'
+              }
+              disabled={!sortable}
+              onClick={sortable ? () => onSortChange?.(r.id) : undefined}
+            >
+              <div className="cap-mx-col-h-group">{r.group}</div>
+              <span>
+                {r.name} <span className="cap-mx-sort-ind">{sortIndicator(r.id)}</span>
+              </span>
+            </button>
+          )
+        })}
 
         {agents.map((agent) => (
           <RowGroup

--- a/dashboard/src/features/capability/sort.ts
+++ b/dashboard/src/features/capability/sort.ts
@@ -1,0 +1,41 @@
+import type { CapabilityAgent, Decision, Resource, Verb } from './types'
+
+export type SortDirection = 'asc' | 'desc' | null
+
+export interface SortState {
+  resourceId: string | null
+  direction: SortDirection
+}
+
+export const NO_SORT: SortState = { resourceId: null, direction: null }
+
+const DECISION_WEIGHT: Record<Decision, number> = {
+  na: 0,
+  allow: 1,
+  narrow: 2,
+  approval: 3,
+  deny: 4,
+}
+
+export function nextSortState(prev: SortState, resourceId: string): SortState {
+  if (prev.resourceId !== resourceId) return { resourceId, direction: 'desc' }
+  if (prev.direction === 'desc') return { resourceId, direction: 'asc' }
+  return NO_SORT
+}
+
+export function sortAgents(
+  agents: CapabilityAgent[],
+  resources: Resource[],
+  verb: Verb,
+  sort: SortState,
+): CapabilityAgent[] {
+  if (!sort.resourceId || !sort.direction) return agents
+  const ids = resources.map((r) => r.id)
+  if (!ids.includes(sort.resourceId)) return agents
+  const factor = sort.direction === 'asc' ? 1 : -1
+  return [...agents].sort((a, b) => {
+    const da = (a.caps[sort.resourceId as string]?.[verb] ?? 'na') as Decision
+    const db = (b.caps[sort.resourceId as string]?.[verb] ?? 'na') as Decision
+    return factor * (DECISION_WEIGHT[da] - DECISION_WEIGHT[db])
+  })
+}

--- a/dashboard/src/pages/CapabilityPage.tsx
+++ b/dashboard/src/pages/CapabilityPage.tsx
@@ -3,6 +3,7 @@ import { capabilityClient } from '../api/capability'
 import { CapabilityMatrixGrid } from '../features/capability/CapabilityMatrixGrid'
 import { CapabilityFilterBar } from '../features/capability/CapabilityFilterBar'
 import { EMPTY_FILTERS, applyFilters, type CapabilityFilters } from '../features/capability/filters'
+import { NO_SORT, nextSortState, sortAgents, type SortState } from '../features/capability/sort'
 import { VERBS } from '../features/capability/types'
 import type { CapabilityMatrix, Verb } from '../features/capability/types'
 import './CapabilityPage.css'
@@ -14,6 +15,7 @@ export function CapabilityPage() {
   const [verb, setVerb] = useState<Verb>('write')
   const [matrix, setMatrix] = useState<CapabilityMatrix | null>(null)
   const [filters, setFilters] = useState<CapabilityFilters>(EMPTY_FILTERS)
+  const [sort, setSort] = useState<SortState>(NO_SORT)
 
   useEffect(() => {
     let alive = true
@@ -25,10 +27,11 @@ export function CapabilityPage() {
     }
   }, [])
 
-  const visibleAgents = useMemo(
-    () => (matrix ? applyFilters(matrix.agents, filters) : []),
-    [matrix, filters],
-  )
+  const visibleAgents = useMemo(() => {
+    if (!matrix) return []
+    const filtered = applyFilters(matrix.agents, filters)
+    return sortAgents(filtered, matrix.resources, verb, sort)
+  }, [matrix, filters, verb, sort])
 
   return (
     <div className="capability-page" data-testid="capability-page">
@@ -106,6 +109,8 @@ export function CapabilityPage() {
             agents={visibleAgents}
             resources={matrix.resources}
             verb={verb}
+            sort={sort}
+            onSortChange={(rid) => setSort((prev) => nextSortState(prev, rid))}
           />
         )}
       </section>


### PR DESCRIPTION
## Description

Makes the matrix column headers sortable.

- New `sort.ts`: `SortState`, `NO_SORT`, `nextSortState()` (desc → asc → none cycle), `sortAgents()` (orders rows by `DECISION_WEIGHT` for the active verb).
- `CapabilityMatrixGrid` headers become `<button>` elements with `aria-sort`. Inactive columns show ↕; the active sort shows ↑ / ↓.
- `CapabilityPage` plumbs `sort` state through `useMemo` after filters; sorts respect the currently selected verb.

> **Stacked on AAASM-1358**. Re-base to `master` after #346 merges.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Jira: AAASM-1359 (AAASM-1280 sub-task; AC #5).

## Testing

- [x] Manual: `pnpm dev` → click an `s3` column header → rows reorder by decision severity; click twice more → asc → unsorted.
- Local gates: `pnpm type-check` ✓, `pnpm lint` ✓, 210/210 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)