### PR TITLE
[AAASM-1360] ✨ (capability): Add CellInspectDrawer overlay

### DIFF
--- a/dashboard/src/features/capability/CellInspectDrawer.css
+++ b/dashboard/src/features/capability/CellInspectDrawer.css
@@ -1,0 +1,183 @@
+.cap-drawer-scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(14, 14, 14, 0.4);
+  display: flex;
+  justify-content: flex-end;
+  z-index: 100;
+}
+
+.cap-drawer {
+  background: var(--paper);
+  width: min(560px, 100vw);
+  height: 100%;
+  border-left: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.cap-drawer-head {
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper-2);
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.cap-drawer-eyebrow {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--ink-4);
+}
+
+.cap-drawer-title {
+  margin: 4px 0 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.cap-drawer-verb {
+  color: var(--warn);
+  text-transform: lowercase;
+}
+
+.cap-drawer-chips {
+  margin-top: 8px;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.cap-drawer-chip {
+  display: inline-block;
+  padding: 2px 8px;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  background: var(--paper-2);
+  color: var(--ink-3);
+}
+
+.cap-drawer-close {
+  border: none;
+  background: transparent;
+  font-size: 16px;
+  cursor: pointer;
+  color: var(--ink-3);
+  padding: 4px 8px;
+}
+
+.cap-drawer-close:hover {
+  color: var(--ink);
+}
+
+.cap-drawer-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 20px;
+}
+
+.cap-drawer-body section {
+  margin-bottom: 18px;
+}
+
+.cap-drawer-section {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--ink-4);
+  margin: 0 0 8px;
+}
+
+.cap-drawer-claimed {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  padding: 12px;
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  font-size: 12px;
+}
+
+.cap-drawer-mini-label {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--ink-4);
+  margin-bottom: 4px;
+}
+
+.cap-drawer-mini-note {
+  font-size: 10px;
+  color: var(--ink-4);
+  margin-top: 4px;
+}
+
+.cap-drawer-policy {
+  padding: 10px 12px;
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  margin-bottom: 6px;
+  font-size: 12px;
+}
+
+.cap-drawer-policy-id {
+  font-size: 10px;
+  color: var(--ink-4);
+}
+
+.cap-drawer-policy-name {
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.cap-drawer-policy-scope {
+  font-size: 10px;
+  color: var(--ink-3);
+  margin-top: 4px;
+}
+
+.cap-drawer-empty {
+  padding: 10px;
+  font-size: 11px;
+  color: var(--ink-4);
+  border: 1px dashed var(--line);
+  border-radius: 3px;
+  text-align: center;
+}
+
+.cap-drawer-calls {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+}
+
+.cap-drawer-calls th,
+.cap-drawer-calls td {
+  text-align: left;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.cap-drawer-calls th {
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--ink-4);
+}
+
+.mono {
+  font-family: 'JetBrains Mono', monospace;
+}

--- a/dashboard/src/features/capability/CellInspectDrawer.tsx
+++ b/dashboard/src/features/capability/CellInspectDrawer.tsx
@@ -1,0 +1,162 @@
+import { useEffect } from 'react'
+import type { CapabilityAgent, Policy, Resource, SampleCall, Verb } from './types'
+import { DECISIONS } from './types'
+import type { CellSelection } from './CapabilityMatrixGrid'
+import './CellInspectDrawer.css'
+
+export interface CellInspectDrawerProps {
+  cell: CellSelection | null
+  policies: Policy[]
+  sampleCalls: SampleCall[]
+  onClose: () => void
+}
+
+function policiesFor(
+  policies: Policy[],
+  agent: CapabilityAgent,
+  resource: Resource,
+  verb: Verb,
+): Policy[] {
+  return policies.filter(
+    (p) =>
+      p.affects.includes(agent.id) &&
+      p.rules.some((r) => r.resource === resource.id && r.verb.includes(verb)),
+  )
+}
+
+function callsFor(
+  sampleCalls: SampleCall[],
+  agent: CapabilityAgent,
+  verb: Verb,
+): SampleCall[] {
+  return sampleCalls.filter((c) => c.agent === agent.id && c.verb === verb).slice(0, 5)
+}
+
+export function CellInspectDrawer({ cell, policies, sampleCalls, onClose }: CellInspectDrawerProps) {
+  useEffect(() => {
+    if (!cell) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [cell, onClose])
+
+  if (!cell) return null
+  const { agent, resource, verb, decision } = cell
+  const decMeta = DECISIONS[decision]
+  const respPolicies = policiesFor(policies, agent, resource, verb)
+  const recentCalls = callsFor(sampleCalls, agent, verb)
+
+  return (
+    <div className="cap-drawer-scrim" onClick={onClose} data-testid="cell-inspect-scrim">
+      <aside
+        className="cap-drawer"
+        role="dialog"
+        aria-modal
+        aria-label="capability cell inspect"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="cap-drawer-head">
+          <div>
+            <div className="cap-drawer-eyebrow">capability cell</div>
+            <h2 className="cap-drawer-title">
+              <span className="mono">{agent.name}</span>{' '}
+              · <span className="cap-drawer-verb">{verb}</span> ·{' '}
+              <span className="mono">{resource.name}</span>
+            </h2>
+            <div className="cap-drawer-chips">
+              <span
+                className={`cap-drawer-chip cap-drawer-chip--${decision}`}
+                style={{
+                  background: `var(${decMeta.bg})`,
+                  color: `var(${decMeta.color})`,
+                }}
+              >
+                effective: {decMeta.label}
+              </span>
+              <span className="cap-drawer-chip">claimed: full access</span>
+            </div>
+          </div>
+          <button
+            type="button"
+            className="cap-drawer-close"
+            onClick={onClose}
+            aria-label="close drawer"
+          >
+            ✕
+          </button>
+        </header>
+
+        <div className="cap-drawer-body">
+          <section>
+            <h3 className="cap-drawer-section">claimed vs effective</h3>
+            <div className="cap-drawer-claimed">
+              <div>
+                <div className="cap-drawer-mini-label">agent claims</div>
+                <div className="mono">{verb}({resource.id}/*)</div>
+                <div className="cap-drawer-mini-note">declared in agent manifest</div>
+              </div>
+              <div>
+                <div className="cap-drawer-mini-label">assembly grants</div>
+                <div className="mono" style={{ color: `var(${decMeta.color})`, fontWeight: 600 }}>
+                  {decision === 'narrow'
+                    ? `${verb}(${resource.id}/labels/INBOX/*)`
+                    : `${verb}(${resource.id}/*) → ${decision}`}
+                </div>
+                <div className="cap-drawer-mini-note">computed from {respPolicies.length} policies</div>
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h3 className="cap-drawer-section">policies responsible</h3>
+            {respPolicies.length === 0 ? (
+              <div className="cap-drawer-empty">
+                No policy narrows this — agent has full claimed permission.
+              </div>
+            ) : (
+              respPolicies.map((p) => (
+                <div key={p.id} className="cap-drawer-policy">
+                  <div>
+                    <span className="cap-drawer-policy-id mono">
+                      {p.id} · {p.version}
+                    </span>
+                    <div className="cap-drawer-policy-name">{p.name}</div>
+                  </div>
+                  <div className="cap-drawer-policy-scope mono">scope: {p.scope}</div>
+                </div>
+              ))
+            )}
+          </section>
+
+          <section>
+            <h3 className="cap-drawer-section">recent calls (24h)</h3>
+            {recentCalls.length === 0 ? (
+              <div className="cap-drawer-empty">no recent calls</div>
+            ) : (
+              <table className="cap-drawer-calls">
+                <thead>
+                  <tr>
+                    <th>time</th>
+                    <th>path</th>
+                    <th>decision</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {recentCalls.map((c, i) => (
+                    <tr key={`${c.ts}-${i}`}>
+                      <td className="mono">{c.ts}</td>
+                      <td className="mono">{c.resource}</td>
+                      <td>{c.currentDecision}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </section>
+        </div>
+      </aside>
+    </div>
+  )
+}

--- a/dashboard/src/pages/CapabilityPage.tsx
+++ b/dashboard/src/pages/CapabilityPage.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from 'react'
 import { capabilityClient } from '../api/capability'
-import { CapabilityMatrixGrid } from '../features/capability/CapabilityMatrixGrid'
+import { CapabilityMatrixGrid, type CellSelection } from '../features/capability/CapabilityMatrixGrid'
 import { CapabilityFilterBar } from '../features/capability/CapabilityFilterBar'
+import { CellInspectDrawer } from '../features/capability/CellInspectDrawer'
 import { EMPTY_FILTERS, applyFilters, type CapabilityFilters } from '../features/capability/filters'
 import { NO_SORT, nextSortState, sortAgents, type SortState } from '../features/capability/sort'
 import { VERBS } from '../features/capability/types'
@@ -16,6 +17,7 @@ export function CapabilityPage() {
   const [matrix, setMatrix] = useState<CapabilityMatrix | null>(null)
   const [filters, setFilters] = useState<CapabilityFilters>(EMPTY_FILTERS)
   const [sort, setSort] = useState<SortState>(NO_SORT)
+  const [inspected, setInspected] = useState<CellSelection | null>(null)
 
   useEffect(() => {
     let alive = true
@@ -111,9 +113,18 @@ export function CapabilityPage() {
             verb={verb}
             sort={sort}
             onSortChange={(rid) => setSort((prev) => nextSortState(prev, rid))}
+            onCellClick={setInspected}
           />
         )}
       </section>
+      {matrix && (
+        <CellInspectDrawer
+          cell={inspected}
+          policies={matrix.policies}
+          sampleCalls={matrix.sampleCalls}
+          onClose={() => setInspected(null)}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Description

Adds `dashboard/src/features/capability/CellInspectDrawer.tsx`. Clicking a non-NA matrix cell opens a right-side drawer with three sections matching `design/v1/hi-fi/capability.jsx`:

- **Claimed vs effective** — what the agent declared vs what Assembly grants.
- **Policies responsible** — filtered to those affecting the agent for `(resource, verb)`.
- **Recent calls (24h)** — sampled from the fixture call log for the cell's agent + verb.

The drawer overlays the page with a fixed scrim — **no new route** (AC #4). Closes via close button, scrim click, or Esc. Cell click handler wired through `<CapabilityPage>` state.

> **Stacked on AAASM-1359**. Re-base to `master` after #347 merges.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Jira: AAASM-1360 (AAASM-1280 sub-task; AC #2 + #4).

## Testing

- [x] Manual: `pnpm dev` → click any allow/narrow/deny cell → drawer opens with the right policy list; Esc closes it.
- Local gates: `pnpm type-check` ✓, `pnpm lint` ✓, 210/210 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)