### PR TITLE
[AAASM-1361] ✨ (capability): Add bulk override with optimistic UI + rollback toast

### DIFF
--- a/dashboard/src/features/capability/BulkActionBar.css
+++ b/dashboard/src/features/capability/BulkActionBar.css
@@ -1,0 +1,67 @@
+.cap-bulk {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 24px;
+  background: var(--ink);
+  color: var(--paper);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+}
+
+.cap-bulk-count {
+  font-weight: 600;
+}
+
+.cap-bulk-sep {
+  color: var(--ink-5);
+}
+
+.cap-bulk-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--ink-5);
+}
+
+.cap-bulk-verb {
+  font-size: 11px;
+  background: var(--paper-3);
+  color: var(--ink);
+  padding: 2px 8px;
+  border-radius: 2px;
+  text-transform: lowercase;
+}
+
+.cap-bulk-select {
+  font-family: inherit;
+  font-size: 11px;
+  background: var(--paper-2);
+  color: var(--ink);
+  border: 1px solid var(--line);
+  padding: 4px 8px;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.cap-bulk-btn {
+  font-family: inherit;
+  font-size: 11px;
+  padding: 5px 12px;
+  border-radius: 3px;
+  cursor: pointer;
+  background: var(--paper-2);
+  color: var(--ink);
+  border: 1px solid var(--paper-2);
+}
+
+.cap-bulk-btn--primary {
+  background: var(--warn-bg);
+  color: var(--warn);
+  border-color: var(--warn);
+  font-weight: 600;
+}
+
+.cap-bulk-btn:hover {
+  filter: brightness(0.95);
+}

--- a/dashboard/src/features/capability/BulkActionBar.tsx
+++ b/dashboard/src/features/capability/BulkActionBar.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+import type { Decision, Resource, Verb } from './types'
+import './BulkActionBar.css'
+
+export interface BulkActionBarProps {
+  count: number
+  resources: Resource[]
+  verb: Verb
+  onApply: (args: { resourceId: string; decision: Decision }) => void
+  onClear: () => void
+}
+
+const DECISION_OPTIONS: Decision[] = ['allow', 'narrow', 'approval', 'deny']
+
+export function BulkActionBar({ count, resources, verb, onApply, onClear }: BulkActionBarProps) {
+  const [resourceId, setResourceId] = useState<string>(resources[0]?.id ?? '')
+  const [decision, setDecision] = useState<Decision>('narrow')
+
+  if (count === 0 || resources.length === 0) return null
+
+  return (
+    <div className="cap-bulk" role="region" aria-label="bulk override">
+      <span className="cap-bulk-count">
+        {count} agent{count === 1 ? '' : 's'} selected
+      </span>
+      <span className="cap-bulk-sep">·</span>
+      <span className="cap-bulk-label">apply</span>
+      <select
+        className="cap-bulk-select"
+        value={decision}
+        onChange={(e) => setDecision(e.target.value as Decision)}
+        aria-label="decision"
+      >
+        {DECISION_OPTIONS.map((d) => (
+          <option key={d} value={d}>
+            {d}
+          </option>
+        ))}
+      </select>
+      <span className="cap-bulk-label">for</span>
+      <span className="cap-bulk-verb">{verb}</span>
+      <span className="cap-bulk-label">on</span>
+      <select
+        className="cap-bulk-select"
+        value={resourceId}
+        onChange={(e) => setResourceId(e.target.value)}
+        aria-label="resource"
+      >
+        {resources.map((r) => (
+          <option key={r.id} value={r.id}>
+            {r.name}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        className="cap-bulk-btn cap-bulk-btn--primary"
+        onClick={() => onApply({ resourceId, decision })}
+      >
+        Apply override
+      </button>
+      <button type="button" className="cap-bulk-btn" onClick={onClear}>
+        Clear
+      </button>
+    </div>
+  )
+}

--- a/dashboard/src/features/capability/CapabilityMatrixGrid.css
+++ b/dashboard/src/features/capability/CapabilityMatrixGrid.css
@@ -44,6 +44,18 @@
   text-transform: uppercase;
   letter-spacing: 1px;
   color: var(--ink-4);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cap-mx-select-all,
+.cap-mx-row-select {
+  cursor: pointer;
+}
+
+.cap-mx-row-h.is-selected {
+  background: var(--warn-bg);
 }
 
 .cap-mx-col-h {

--- a/dashboard/src/features/capability/CapabilityMatrixGrid.tsx
+++ b/dashboard/src/features/capability/CapabilityMatrixGrid.tsx
@@ -10,6 +10,9 @@ export interface CapabilityMatrixGridProps {
   onCellClick?: (cell: CellSelection) => void
   sort?: SortState
   onSortChange?: (resourceId: string) => void
+  selectedIds?: Set<string>
+  onToggleSelect?: (agentId: string) => void
+  onToggleSelectAll?: (next: boolean) => void
 }
 
 export interface CellSelection {
@@ -32,7 +35,13 @@ export function CapabilityMatrixGrid({
   onCellClick,
   sort,
   onSortChange,
+  selectedIds,
+  onToggleSelect,
+  onToggleSelectAll,
 }: CapabilityMatrixGridProps) {
+  const selectable = Boolean(selectedIds && onToggleSelect)
+  const allSelected =
+    selectable && agents.length > 0 && agents.every((a) => selectedIds?.has(a.id))
   const templateColumns = `260px repeat(${resources.length}, minmax(110px, 1fr))`
 
   function sortIndicator(resourceId: string): string {
@@ -55,7 +64,16 @@ export function CapabilityMatrixGrid({
         style={{ gridTemplateColumns: templateColumns }}
       >
         <div className="cap-mx-corner" role="columnheader">
-          agent ↓ · resource →
+          {selectable && (
+            <input
+              type="checkbox"
+              aria-label="select all agents"
+              checked={allSelected}
+              onChange={(e) => onToggleSelectAll?.(e.target.checked)}
+              className="cap-mx-select-all"
+            />
+          )}
+          <span>agent ↓ · resource →</span>
         </div>
         {resources.map((r) => {
           const sortable = Boolean(onSortChange)
@@ -87,6 +105,8 @@ export function CapabilityMatrixGrid({
             resources={resources}
             verb={verb}
             onCellClick={onCellClick}
+            selected={selectedIds?.has(agent.id) ?? false}
+            onToggleSelect={onToggleSelect}
           />
         ))}
       </div>
@@ -99,13 +119,34 @@ interface RowGroupProps {
   resources: Resource[]
   verb: Verb
   onCellClick?: (cell: CellSelection) => void
+  selected?: boolean
+  onToggleSelect?: (agentId: string) => void
 }
 
-function RowGroup({ agent, resources, verb, onCellClick }: RowGroupProps) {
+function RowGroup({
+  agent,
+  resources,
+  verb,
+  onCellClick,
+  selected,
+  onToggleSelect,
+}: RowGroupProps) {
   return (
     <>
-      <div className="cap-mx-row-h" role="rowheader">
+      <div
+        className={`cap-mx-row-h${selected ? ' is-selected' : ''}`}
+        role="rowheader"
+      >
         <div className="cap-mx-row-h-name">
+          {onToggleSelect && (
+            <input
+              type="checkbox"
+              aria-label={`select ${agent.name}`}
+              checked={selected ?? false}
+              onChange={() => onToggleSelect(agent.id)}
+              className="cap-mx-row-select"
+            />
+          )}
           {agent.name}
           {agent.flagged && (
             <span className="cap-flag-dot" aria-label="agent flagged">

--- a/dashboard/src/features/capability/override.ts
+++ b/dashboard/src/features/capability/override.ts
@@ -1,0 +1,22 @@
+import type { CapabilityMatrix, OverrideRequest } from './types'
+
+export function applyOverrideLocal(
+  matrix: CapabilityMatrix,
+  req: OverrideRequest,
+): CapabilityMatrix {
+  return {
+    ...matrix,
+    agents: matrix.agents.map((agent) => {
+      if (!req.agentIds.includes(agent.id)) return agent
+      const existing = agent.caps[req.resourceId]
+      if (!existing) return agent
+      return {
+        ...agent,
+        caps: {
+          ...agent.caps,
+          [req.resourceId]: { ...existing, [req.verb]: req.decision },
+        },
+      }
+    }),
+  }
+}

--- a/dashboard/src/pages/CapabilityPage.tsx
+++ b/dashboard/src/pages/CapabilityPage.tsx
@@ -1,12 +1,15 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { capabilityClient } from '../api/capability'
+import { useToast } from '../components/Toast'
+import { BulkActionBar } from '../features/capability/BulkActionBar'
 import { CapabilityMatrixGrid, type CellSelection } from '../features/capability/CapabilityMatrixGrid'
 import { CapabilityFilterBar } from '../features/capability/CapabilityFilterBar'
 import { CellInspectDrawer } from '../features/capability/CellInspectDrawer'
 import { EMPTY_FILTERS, applyFilters, type CapabilityFilters } from '../features/capability/filters'
+import { applyOverrideLocal } from '../features/capability/override'
 import { NO_SORT, nextSortState, sortAgents, type SortState } from '../features/capability/sort'
 import { VERBS } from '../features/capability/types'
-import type { CapabilityMatrix, Verb } from '../features/capability/types'
+import type { CapabilityMatrix, Decision, Verb } from '../features/capability/types'
 import './CapabilityPage.css'
 
 type Tab = 'matrix' | 'resource' | 'agent'
@@ -18,6 +21,46 @@ export function CapabilityPage() {
   const [filters, setFilters] = useState<CapabilityFilters>(EMPTY_FILTERS)
   const [sort, setSort] = useState<SortState>(NO_SORT)
   const [inspected, setInspected] = useState<CellSelection | null>(null)
+  const [selected, setSelected] = useState<Set<string>>(new Set())
+  const { toast } = useToast()
+
+  const toggleSelect = (agentId: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(agentId)) next.delete(agentId)
+      else next.add(agentId)
+      return next
+    })
+  }
+
+  const toggleSelectAll = (next: boolean) => {
+    if (next) setSelected(new Set(visibleAgents.map((a) => a.id)))
+    else setSelected(new Set())
+  }
+
+  const handleBulkApply = async ({
+    resourceId,
+    decision,
+  }: {
+    resourceId: string
+    decision: Decision
+  }) => {
+    if (!matrix) return
+    const agentIds = [...selected]
+    if (agentIds.length === 0) return
+    const prev = matrix
+    const optimistic = applyOverrideLocal(matrix, { agentIds, resourceId, verb, decision })
+    setMatrix(optimistic)
+    setSelected(new Set())
+    try {
+      await capabilityClient.applyOverride({ agentIds, resourceId, verb, decision })
+      toast(`override applied to ${agentIds.length} agent${agentIds.length === 1 ? '' : 's'}`, 'success')
+    } catch (e) {
+      setMatrix(prev)
+      const msg = e instanceof Error ? e.message : 'override failed'
+      toast(`rollback: ${msg}`, 'error')
+    }
+  }
 
   useEffect(() => {
     let alive = true
@@ -29,11 +72,9 @@ export function CapabilityPage() {
     }
   }, [])
 
-  const visibleAgents = useMemo(() => {
-    if (!matrix) return []
-    const filtered = applyFilters(matrix.agents, filters)
-    return sortAgents(filtered, matrix.resources, verb, sort)
-  }, [matrix, filters, verb, sort])
+  const visibleAgents = matrix
+    ? sortAgents(applyFilters(matrix.agents, filters), matrix.resources, verb, sort)
+    : []
 
   return (
     <div className="capability-page" data-testid="capability-page">
@@ -105,6 +146,16 @@ export function CapabilityPage() {
         />
       )}
 
+      {tab === 'matrix' && matrix && (
+        <BulkActionBar
+          count={selected.size}
+          resources={matrix.resources}
+          verb={verb}
+          onApply={handleBulkApply}
+          onClear={() => setSelected(new Set())}
+        />
+      )}
+
       <section className="capability-body" data-active-tab={tab}>
         {tab === 'matrix' && matrix && (
           <CapabilityMatrixGrid
@@ -114,6 +165,9 @@ export function CapabilityPage() {
             sort={sort}
             onSortChange={(rid) => setSort((prev) => nextSortState(prev, rid))}
             onCellClick={setInspected}
+            selectedIds={selected}
+            onToggleSelect={toggleSelect}
+            onToggleSelectAll={toggleSelectAll}
           />
         )}
       </section>


### PR DESCRIPTION
## Description

Implements the bulk override flow:

- Row checkboxes (with a select-all in the corner) added to `CapabilityMatrixGrid`.
- New `<BulkActionBar>` appears whenever ≥1 agent is selected — operator picks a resource + decision, click Apply.
- `applyOverrideLocal()` performs an optimistic update on the local matrix; we then call `capabilityClient.applyOverride()`.
- On rejection, we roll back to the prior matrix snapshot and surface an error toast via `useToast()` (existing `ToastProvider`).
- Sub-task description's tests for the rollback path land in AAASM-1363.

> **Stacked on AAASM-1360**. Re-base to `master` after #348 merges.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Jira: AAASM-1361 (AAASM-1280 sub-task; AC #4 + #7).

## Testing

- [x] Manual: `pnpm dev` → check two rows → BulkActionBar opens → Apply → cells update; with `failOverride` flag, error toast appears and state rolls back.
- Local gates: `pnpm type-check` ✓, `pnpm lint` ✓, 210/210 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)