### PR TITLE
[AAASM-1362] ✨ (capability): Wire empty / loading / error state branches

### DIFF
--- a/dashboard/src/pages/CapabilityPage.tsx
+++ b/dashboard/src/pages/CapabilityPage.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useState } from 'react'
 import { capabilityClient } from '../api/capability'
+import { EmptyState } from '../components/EmptyState'
+import { ErrorState } from '../components/ErrorState'
+import { LoadingState } from '../components/LoadingState'
 import { useToast } from '../components/Toast'
 import { BulkActionBar } from '../features/capability/BulkActionBar'
 import { CapabilityMatrixGrid, type CellSelection } from '../features/capability/CapabilityMatrixGrid'
@@ -18,6 +21,8 @@ export function CapabilityPage() {
   const [tab, setTab] = useState<Tab>('matrix')
   const [verb, setVerb] = useState<Verb>('write')
   const [matrix, setMatrix] = useState<CapabilityMatrix | null>(null)
+  const [loadError, setLoadError] = useState<Error | null>(null)
+  const [reloadKey, setReloadKey] = useState(0)
   const [filters, setFilters] = useState<CapabilityFilters>(EMPTY_FILTERS)
   const [sort, setSort] = useState<SortState>(NO_SORT)
   const [inspected, setInspected] = useState<CellSelection | null>(null)
@@ -64,17 +69,52 @@ export function CapabilityPage() {
 
   useEffect(() => {
     let alive = true
-    capabilityClient.getMatrix().then((m) => {
-      if (alive) setMatrix(m)
-    })
+    capabilityClient.getMatrix().then(
+      (m) => {
+        if (alive) setMatrix(m)
+      },
+      (e: unknown) => {
+        if (alive) setLoadError(e instanceof Error ? e : new Error('failed to load matrix'))
+      },
+    )
     return () => {
       alive = false
     }
-  }, [])
+  }, [reloadKey])
+
+  const handleRetry = () => {
+    setMatrix(null)
+    setLoadError(null)
+    setReloadKey((k) => k + 1)
+  }
 
   const visibleAgents = matrix
     ? sortAgents(applyFilters(matrix.agents, filters), matrix.resources, verb, sort)
     : []
+
+  if (loadError) {
+    return (
+      <div className="capability-page" data-testid="capability-page">
+        <ErrorState kind="generic" onRetry={handleRetry} />
+      </div>
+    )
+  }
+
+  if (!matrix) {
+    return (
+      <div className="capability-page" data-testid="capability-page">
+        <LoadingState page="capability" />
+      </div>
+    )
+  }
+
+  if (matrix.agents.length === 0) {
+    return (
+      <div className="capability-page" data-testid="capability-page">
+        <EmptyState page="capability" />
+      </div>
+    )
+  }
 
   return (
     <div className="capability-page" data-testid="capability-page">


### PR DESCRIPTION
## Description

Wires the shared state components (from AAASM-1355) into `CapabilityPage`:

- `<LoadingState page="capability" />` while the initial `getMatrix()` is in flight (skeleton matrix).
- `<ErrorState kind="generic" onRetry={handleRetry} />` when the call rejects; retry re-issues the fetch.
- `<EmptyState page="capability" />` when the response carries zero agents.

The retry handler resets `matrix` and `loadError` before bumping a `reloadKey`, satisfying the React Compiler `set-state-in-effect` rule.

> **Stacked on AAASM-1361**. Re-base to `master` after #349 merges.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Jira: AAASM-1362 (AAASM-1280 sub-task; AC #5 + #8).

## Testing

- [x] Manual: stub `capabilityClient.getMatrix` to reject → ErrorState renders; click Retry → fetch re-runs.
- Local gates: `pnpm type-check` ✓, `pnpm lint` ✓, 210/210 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)