### PR TITLE
[AAASM-1363] ✅ (capability): Add unit tests for filters / sort / override

### DIFF
--- a/dashboard/src/features/capability/__tests__/filters.test.ts
+++ b/dashboard/src/features/capability/__tests__/filters.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { applyFilters, EMPTY_FILTERS } from '../filters'
+import { AGENTS } from '../fixtures'
+
+describe('applyFilters', () => {
+  it('returns the full set when filters are empty', () => {
+    expect(applyFilters(AGENTS, EMPTY_FILTERS)).toHaveLength(AGENTS.length)
+  })
+
+  it('matches the search field across name / framework / owner / id', () => {
+    const matchesName = applyFilters(AGENTS, { ...EMPTY_FILTERS, search: 'finance-bot' })
+    expect(matchesName.map((a) => a.id)).toEqual(['finance-bot'])
+
+    const matchesFramework = applyFilters(AGENTS, { ...EMPTY_FILTERS, search: 'AutoGen' })
+    expect(matchesFramework.every((a) => a.framework === 'AutoGen')).toBe(true)
+    expect(matchesFramework.length).toBeGreaterThan(0)
+
+    const matchesOwner = applyFilters(AGENTS, { ...EMPTY_FILTERS, search: 'rev-ops' })
+    expect(matchesOwner.map((a) => a.owner)).toEqual(['rev-ops'])
+  })
+
+  it('respects the framework select', () => {
+    const langchain = applyFilters(AGENTS, { ...EMPTY_FILTERS, framework: 'LangChain' })
+    expect(langchain.every((a) => a.framework === 'LangChain')).toBe(true)
+  })
+
+  it('caps results by trustMax inclusively', () => {
+    const lowTrust = applyFilters(AGENTS, { ...EMPTY_FILTERS, trustMax: 60 })
+    expect(lowTrust.every((a) => a.trust <= 60)).toBe(true)
+    expect(lowTrust.length).toBeGreaterThan(0)
+  })
+})

--- a/dashboard/src/features/capability/__tests__/override.test.ts
+++ b/dashboard/src/features/capability/__tests__/override.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { createMockCapabilityClient } from '../../../api/capability'
+import { applyOverrideLocal } from '../override'
+import { CAPABILITY_MATRIX_FIXTURE } from '../fixtures'
+
+describe('applyOverrideLocal', () => {
+  it('updates only the targeted (agent, resource, verb)', () => {
+    const next = applyOverrideLocal(CAPABILITY_MATRIX_FIXTURE, {
+      agentIds: ['research-bot-04'],
+      resourceId: 'gmail',
+      verb: 'write',
+      decision: 'deny',
+    })
+    const target = next.agents.find((a) => a.id === 'research-bot-04')!
+    expect(target.caps.gmail.write).toBe('deny')
+    // unrelated cells untouched
+    expect(target.caps.s3.write).toBe('allow')
+    // unrelated agents untouched
+    const other = next.agents.find((a) => a.id === 'finance-bot')!
+    expect(other.caps.gmail.write).toBe('deny')
+  })
+})
+
+describe('createMockCapabilityClient', () => {
+  it('returns updated rows on success and persists state across reads', async () => {
+    const client = createMockCapabilityClient({ latencyMs: 0 })
+    await client.applyOverride({
+      agentIds: ['research-bot-04'],
+      resourceId: 'gmail',
+      verb: 'write',
+      decision: 'deny',
+    })
+    const after = await client.getMatrix()
+    const target = after.agents.find((a) => a.id === 'research-bot-04')!
+    expect(target.caps.gmail.write).toBe('deny')
+  })
+
+  it('rejects when failOverride is enabled (drives the rollback path)', async () => {
+    const client = createMockCapabilityClient({ latencyMs: 0, failOverride: true })
+    await expect(
+      client.applyOverride({
+        agentIds: ['research-bot-04'],
+        resourceId: 'gmail',
+        verb: 'write',
+        decision: 'deny',
+      }),
+    ).rejects.toThrow(/rejected/)
+  })
+})

--- a/dashboard/src/features/capability/__tests__/sort.test.ts
+++ b/dashboard/src/features/capability/__tests__/sort.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { NO_SORT, nextSortState, sortAgents } from '../sort'
+import { AGENTS, RESOURCES } from '../fixtures'
+
+describe('nextSortState', () => {
+  it('cycles desc → asc → none on the same column', () => {
+    const first = nextSortState(NO_SORT, 'gmail')
+    expect(first).toEqual({ resourceId: 'gmail', direction: 'desc' })
+    const second = nextSortState(first, 'gmail')
+    expect(second).toEqual({ resourceId: 'gmail', direction: 'asc' })
+    const third = nextSortState(second, 'gmail')
+    expect(third).toEqual(NO_SORT)
+  })
+
+  it('resets to desc when switching columns', () => {
+    const first = nextSortState(NO_SORT, 'gmail')
+    const switched = nextSortState(first, 's3')
+    expect(switched).toEqual({ resourceId: 's3', direction: 'desc' })
+  })
+})
+
+describe('sortAgents', () => {
+  it('returns input order when NO_SORT', () => {
+    const order = sortAgents(AGENTS, RESOURCES, 'write', NO_SORT)
+    expect(order.map((a) => a.id)).toEqual(AGENTS.map((a) => a.id))
+  })
+
+  it('orders agents by decision severity for the selected verb (desc)', () => {
+    const sorted = sortAgents(AGENTS, RESOURCES, 'write', {
+      resourceId: 'gmail',
+      direction: 'desc',
+    })
+    // research-bot-04 still allows gmail/write, docs-summarizer denies it.
+    // desc puts deny first.
+    expect(sorted[0].caps.gmail.write).toBe('deny')
+    expect(sorted[sorted.length - 1].caps.gmail.write).toBe('allow')
+  })
+})


### PR DESCRIPTION
## Description

Adds Vitest coverage for the pure-function helpers underpinning the Capability Matrix page:

- `filters.test.ts` — `applyFilters` across search / framework / owner / `trustMax` axes.
- `sort.test.ts` — `nextSortState` cycles desc → asc → none and resets when switching columns; `sortAgents` orders rows by `DECISION_WEIGHT` for the selected verb.
- `override.test.ts` — `applyOverrideLocal` updates only the targeted cell, and the mock client supports both the success and `failOverride` paths (which drive the AAASM-1361 rollback in `CapabilityPage`).

11 new tests; total `221/221` pass.

> **Stacked on AAASM-1362**. Re-base to `master` after #350 merges.

## Type of Change

- [ ] ✨ New feature
- [x] ✅ Tests

## Breaking Changes

- [x] No

## Related Issues

- Jira: AAASM-1363 (AAASM-1280 sub-task).

## Testing

- `pnpm test` ✓ (221/221).

🤖 Generated with [Claude Code](https://claude.com/claude-code)