### PR TITLE
[AAASM-1056] ✨ (dashboard/teams): Add team drill-down and member list

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -10,6 +10,7 @@ import { PoliciesPage } from './pages/PoliciesPage'
 import { PolicyEditorPage } from './pages/PolicyEditorPage'
 import { AnalyticsPage } from './pages/AnalyticsPage'
 import { ComingSoon } from './pages/ComingSoon'
+import { TeamDetailPage } from './pages/TeamDetailPage'
 
 function App() {
   return (
@@ -41,6 +42,7 @@ function App() {
             {/* ── Sub-routes for canonical pages ────────────────────────── */}
             <Route path="/agents/:id" element={<AgentDetailPage />} />
             <Route path="/policies/editor" element={<PolicyEditorPage />} />
+            <Route path="/teams/:teamId" element={<TeamDetailPage />} />
 
             {/* ── Non-canonical pages (kept for working features) ───────── */}
             <Route path="/approvals" element={<ApprovalsPage />} />

--- a/dashboard/src/features/teams/api.ts
+++ b/dashboard/src/features/teams/api.ts
@@ -1,0 +1,123 @@
+import { useQuery } from '@tanstack/react-query'
+import { api } from '../../api/client'
+import type { components } from '../../api/generated/schema'
+
+export type TopologyOverview = components['schemas']['TopologyOverview']
+export type TeamSummary = components['schemas']['TeamSummary']
+export type TeamCostEntry = components['schemas']['TeamCostEntry']
+export type CostSummary = components['schemas']['CostSummary']
+export type TeamTopology = components['schemas']['TeamTopology']
+export type AgentLineage = components['schemas']['AgentLineage']
+export type LineageStep = components['schemas']['LineageStep']
+export type AgentNode = components['schemas']['AgentNode']
+
+export interface TeamListRow {
+  team_id: string
+  agent_count: number
+  root_agent_count: number
+  daily_spend_usd: number | null
+  daily_limit_usd: number | null
+  burn_pct: number | null
+}
+
+export function useTopologyOverviewQuery() {
+  return useQuery({
+    queryKey: ['topology', 'overview'],
+    queryFn: async () => {
+      const { data, error } = await api.GET('/api/v1/topology/overview')
+      if (error) throw new Error('Failed to fetch topology overview')
+      return data as TopologyOverview
+    },
+  })
+}
+
+export function useCostSummaryQuery() {
+  return useQuery({
+    queryKey: ['costs', 'summary'],
+    queryFn: async () => {
+      const { data, error } = await api.GET('/api/v1/costs')
+      if (error) throw new Error('Failed to fetch cost summary')
+      return data as CostSummary
+    },
+  })
+}
+
+export interface TeamTopologyResult {
+  data: TeamTopology | undefined
+  notFound: boolean
+  isLoading: boolean
+  isError: boolean
+}
+
+export function useTeamTopologyQuery(teamId: string | undefined): TeamTopologyResult {
+  const query = useQuery({
+    queryKey: ['topology', 'team', teamId],
+    enabled: !!teamId,
+    retry: false,
+    queryFn: async () => {
+      const { data, error, response } = await api.GET('/api/v1/topology/team/{team_id}', {
+        params: { path: { team_id: teamId! } },
+      })
+      if (response?.status === 404) {
+        const err = new Error('Team not found') as Error & { notFound?: boolean }
+        err.notFound = true
+        throw err
+      }
+      if (error) throw new Error('Failed to fetch team topology')
+      return data as TeamTopology
+    },
+  })
+  const notFound = !!(query.error && (query.error as Error & { notFound?: boolean }).notFound)
+  return {
+    data: query.data,
+    notFound,
+    isLoading: query.isLoading,
+    isError: query.isError && !notFound,
+  }
+}
+
+export function useAgentLineageQuery(agentId: string | undefined) {
+  return useQuery({
+    queryKey: ['topology', 'lineage', agentId],
+    enabled: !!agentId,
+    queryFn: async () => {
+      const { data, error } = await api.GET('/api/v1/topology/lineage/{agent_id}', {
+        params: { path: { agent_id: agentId! } },
+      })
+      if (error) throw new Error('Failed to fetch agent lineage')
+      return data as AgentLineage
+    },
+  })
+}
+
+function parseUsd(value: string | null | undefined): number | null {
+  if (value == null) return null
+  const n = Number.parseFloat(value)
+  return Number.isFinite(n) ? n : null
+}
+
+export function joinTeamRows(overview: TopologyOverview | undefined, costs: CostSummary | undefined): TeamListRow[] {
+  if (!overview) return []
+  const dailyLimit = parseUsd(costs?.daily_limit_usd)
+  const costByTeam = new Map<string, TeamCostEntry>()
+  for (const entry of costs?.per_team ?? []) costByTeam.set(entry.team_id, entry)
+  return overview.teams.map((team): TeamListRow => {
+    const cost = costByTeam.get(team.team_id)
+    const dailySpend = parseUsd(cost?.daily_spend_usd)
+    const burnPct = dailySpend != null && dailyLimit != null && dailyLimit > 0
+      ? (dailySpend / dailyLimit) * 100
+      : null
+    return {
+      team_id: team.team_id,
+      agent_count: team.agent_count,
+      root_agent_count: team.root_agent_count,
+      daily_spend_usd: dailySpend,
+      daily_limit_usd: dailyLimit,
+      burn_pct: burnPct,
+    }
+  })
+}
+
+export function teamCostFor(teamId: string, costs: CostSummary | undefined): TeamCostEntry | undefined {
+  return costs?.per_team?.find(entry => entry.team_id === teamId)
+}

--- a/dashboard/src/pages/TeamDetailPage.stories.tsx
+++ b/dashboard/src/pages/TeamDetailPage.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { TeamDetailPage } from './TeamDetailPage'
+import type { CostSummary, TeamTopology } from '../features/teams/api'
+
+const FIVE_MEMBER_TEAM: TeamTopology = {
+  team_id: 'team-alpha',
+  agent_count: 5,
+  members: [
+    { id: '11111111111111111111111111111111', name: 'orchestrator', status: 'active', depth: 0, team_id: 'team-alpha' },
+    { id: '22222222222222222222222222222222', name: 'planner', status: 'active', depth: 1, team_id: 'team-alpha' },
+    { id: '33333333333333333333333333333333', name: 'researcher', status: 'suspended', depth: 1, team_id: 'team-alpha' },
+    { id: '44444444444444444444444444444444', name: 'writer', status: 'active', depth: 2, team_id: 'team-alpha' },
+    { id: '55555555555555555555555555555555', name: 'reviewer', status: 'active', depth: 2, team_id: 'team-alpha' },
+  ],
+}
+
+const EMPTY_TEAM: TeamTopology = {
+  team_id: 'team-beta',
+  agent_count: 0,
+  members: [],
+}
+
+const COSTS: CostSummary = {
+  date: '2026-05-13',
+  daily_spend_usd: '120.00',
+  daily_limit_usd: '200.00',
+  per_team: [{ team_id: 'team-alpha', date: '2026-05-13', daily_spend_usd: '42.00', monthly_spend_usd: null }],
+}
+
+interface MockArgs {
+  team: TeamTopology
+}
+
+function MockedTeamDetailPage({ team }: MockArgs) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } })
+  client.setQueryData(['topology', 'team', team.team_id], team)
+  client.setQueryData(['costs', 'summary'], COSTS)
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={[`/teams/${team.team_id}`]}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+const meta: Meta<MockArgs> = {
+  title: 'Pages/TeamDetailPage',
+  component: MockedTeamDetailPage,
+}
+
+export default meta
+type Story = StoryObj<MockArgs>
+
+export const FiveMembers: Story = { args: { team: FIVE_MEMBER_TEAM } }
+export const Empty: Story = { args: { team: EMPTY_TEAM } }

--- a/dashboard/src/pages/TeamDetailPage.test.tsx
+++ b/dashboard/src/pages/TeamDetailPage.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { vi } from 'vitest'
+import type { UseQueryResult } from '@tanstack/react-query'
+import { TeamDetailPage } from './TeamDetailPage'
+import * as teamsApi from '../features/teams/api'
+import type { AgentLineage, CostSummary, TeamTopology, TeamTopologyResult } from '../features/teams/api'
+
+function mockQuery<T>(p: Partial<UseQueryResult<T, Error>>): UseQueryResult<T, Error> {
+  return p as unknown as UseQueryResult<T, Error>
+}
+
+function LocationProbe() {
+  const loc = useLocation()
+  return <div data-testid="location">{loc.pathname + loc.search}</div>
+}
+
+function Wrapper({ initialEntries, children }: { initialEntries: string[]; children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={initialEntries}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<>{children}<LocationProbe /></>} />
+          <Route path="/topology" element={<><div data-testid="topology-page">topology</div><LocationProbe /></>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+const COSTS: CostSummary = {
+  date: '2026-05-13',
+  daily_spend_usd: '120.00',
+  daily_limit_usd: '200.00',
+  per_team: [{ team_id: 'team-alpha', date: '2026-05-13', daily_spend_usd: '42.00', monthly_spend_usd: null }],
+}
+
+const FIVE_MEMBER_TEAM: TeamTopology = {
+  team_id: 'team-alpha',
+  agent_count: 5,
+  members: [
+    { id: 'a'.repeat(32), name: 'orchestrator', status: 'active', depth: 0, team_id: 'team-alpha' },
+    { id: 'b'.repeat(32), name: 'worker-1', status: 'active', depth: 1, team_id: 'team-alpha' },
+    { id: 'c'.repeat(32), name: 'worker-2', status: 'suspended', depth: 1, team_id: 'team-alpha' },
+    { id: 'd'.repeat(32), name: 'worker-3', status: 'active', depth: 2, team_id: 'team-alpha' },
+    { id: 'e'.repeat(32), name: 'worker-4', status: 'active', depth: 2, team_id: 'team-alpha' },
+  ],
+}
+
+const EMPTY_TEAM: TeamTopology = { team_id: 'team-beta', agent_count: 0, members: [] }
+
+function mockTeam(result: Partial<TeamTopologyResult>) {
+  vi.spyOn(teamsApi, 'useTeamTopologyQuery').mockReturnValue({
+    data: undefined,
+    notFound: false,
+    isLoading: false,
+    isError: false,
+    ...result,
+  })
+}
+
+function mockCosts(costs: CostSummary | undefined = COSTS) {
+  vi.spyOn(teamsApi, 'useCostSummaryQuery').mockReturnValue(
+    mockQuery<CostSummary>({ data: costs, isLoading: false, isError: false, refetch: vi.fn() }),
+  )
+}
+
+function mockLineage(rootId: string) {
+  const lineage: AgentLineage = {
+    agent_id: 'agent',
+    ancestor_count: 1,
+    ancestors: [{ id: rootId, name: 'root', depth: 0 }],
+  }
+  vi.spyOn(teamsApi, 'useAgentLineageQuery').mockReturnValue(
+    mockQuery<AgentLineage>({ data: lineage, isLoading: false, isError: false }),
+  )
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('TeamDetailPage', () => {
+  it('renders header and member rows when team has members', async () => {
+    mockTeam({ data: FIVE_MEMBER_TEAM })
+    mockCosts()
+    mockLineage('a'.repeat(32))
+    render(<TeamDetailPage />, { wrapper: ({ children }) => <Wrapper initialEntries={['/teams/team-alpha']}>{children}</Wrapper> })
+    await waitFor(() => expect(screen.getByTestId('team-detail-header')).toBeInTheDocument())
+    expect(screen.getByRole('heading', { name: 'team-alpha' })).toBeInTheDocument()
+    expect(screen.getByTestId('team-member-count')).toHaveTextContent('5 members')
+    expect(screen.getByTestId('team-total-spend')).toHaveTextContent('$42.00')
+    expect(screen.getAllByTestId('team-member-row')).toHaveLength(5)
+  })
+
+  it('renders empty-members message when team has no members', async () => {
+    mockTeam({ data: EMPTY_TEAM })
+    mockCosts(undefined)
+    mockLineage('x')
+    render(<TeamDetailPage />, { wrapper: ({ children }) => <Wrapper initialEntries={['/teams/team-beta']}>{children}</Wrapper> })
+    await waitFor(() => expect(screen.getByTestId('team-members-empty')).toBeInTheDocument())
+  })
+
+  it('renders NotFoundPage when team id is unknown', async () => {
+    mockTeam({ notFound: true })
+    mockCosts()
+    mockLineage('x')
+    render(<TeamDetailPage />, { wrapper: ({ children }) => <Wrapper initialEntries={['/teams/missing']}>{children}</Wrapper> })
+    await waitFor(() => expect(screen.getByRole('heading', { name: /404/ })).toBeInTheDocument())
+  })
+
+  it('navigates to /topology?root=<topmost ancestor> when Open in topology clicked', async () => {
+    const user = userEvent.setup()
+    const rootId = 'f'.repeat(32)
+    mockTeam({ data: FIVE_MEMBER_TEAM })
+    mockCosts()
+    mockLineage(rootId)
+    render(<TeamDetailPage />, { wrapper: ({ children }) => <Wrapper initialEntries={['/teams/team-alpha']}>{children}</Wrapper> })
+    await waitFor(() => expect(screen.getAllByTestId('open-in-topology')).toHaveLength(5))
+    await user.click(screen.getAllByTestId('open-in-topology')[0])
+    await waitFor(() => expect(screen.getByTestId('topology-page')).toBeInTheDocument())
+    expect(screen.getByTestId('location')).toHaveTextContent(`/topology?root=${rootId}`)
+  })
+
+  it('falls back to the member id when lineage is unavailable', async () => {
+    const user = userEvent.setup()
+    mockTeam({ data: FIVE_MEMBER_TEAM })
+    mockCosts()
+    vi.spyOn(teamsApi, 'useAgentLineageQuery').mockReturnValue(
+      mockQuery<AgentLineage>({ data: undefined, isLoading: false, isError: false }),
+    )
+    render(<TeamDetailPage />, { wrapper: ({ children }) => <Wrapper initialEntries={['/teams/team-alpha']}>{children}</Wrapper> })
+    await user.click((await screen.findAllByTestId('open-in-topology'))[0])
+    expect(screen.getByTestId('location')).toHaveTextContent(`/topology?root=${'a'.repeat(32)}`)
+  })
+})

--- a/dashboard/src/pages/TeamDetailPage.tsx
+++ b/dashboard/src/pages/TeamDetailPage.tsx
@@ -1,0 +1,149 @@
+import { useMemo } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import {
+  teamCostFor,
+  useAgentLineageQuery,
+  useCostSummaryQuery,
+  useTeamTopologyQuery,
+  type AgentNode,
+} from '../features/teams/api'
+import { NotFoundPage } from './NotFoundPage'
+
+const STATUS_COLOR: Record<string, string> = {
+  active: '#16a34a',
+  suspended: '#d97706',
+  deregistered: '#6b7280',
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const color = STATUS_COLOR[status] ?? '#6b7280'
+  return (
+    <span
+      data-testid="team-member-status"
+      style={{
+        display: 'inline-block',
+        padding: '2px 8px',
+        borderRadius: '9999px',
+        fontSize: '0.75rem',
+        fontWeight: 600,
+        color: '#fff',
+        background: color,
+      }}
+    >
+      {status}
+    </span>
+  )
+}
+
+function ShortId({ id }: { id: string }) {
+  return (
+    <code style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '0.8125rem' }}>
+      {id.length > 12 ? `${id.slice(0, 8)}…${id.slice(-4)}` : id}
+    </code>
+  )
+}
+
+function OpenInTopologyButton({ agentId }: { agentId: string }) {
+  const lineage = useAgentLineageQuery(agentId)
+  const navigate = useNavigate()
+  const rootId = lineage.data?.ancestors?.[0]?.id ?? agentId
+  return (
+    <button
+      data-testid="open-in-topology"
+      onClick={() => navigate(`/topology?root=${encodeURIComponent(rootId)}`)}
+      disabled={lineage.isLoading}
+      style={{ padding: '0.2rem 0.6rem' }}
+    >
+      Open in topology
+    </button>
+  )
+}
+
+function MemberRow({ member }: { member: AgentNode }) {
+  return (
+    <tr data-testid="team-member-row" style={{ borderBottom: '1px solid #f3f4f6' }}>
+      <td style={{ padding: '0.5rem' }}>
+        <Link to={`/agents/${encodeURIComponent(member.id)}`}>
+          <ShortId id={member.id} />
+        </Link>
+        <div style={{ fontSize: '0.75rem', color: '#6b7280' }}>{member.name}</div>
+      </td>
+      <td style={{ padding: '0.5rem' }}>
+        <StatusBadge status={member.status} />
+      </td>
+      <td style={{ padding: '0.5rem', fontFamily: 'JetBrains Mono, monospace' }}>{member.depth}</td>
+      <td style={{ padding: '0.5rem' }}>
+        <OpenInTopologyButton agentId={member.id} />
+      </td>
+    </tr>
+  )
+}
+
+export function TeamDetailPage() {
+  const { teamId: encodedTeamId } = useParams<{ teamId: string }>()
+  const teamId = encodedTeamId ? decodeURIComponent(encodedTeamId) : undefined
+  const teamQuery = useTeamTopologyQuery(teamId)
+  const costsQuery = useCostSummaryQuery()
+
+  const teamCost = useMemo(() => teamCostFor(teamId ?? '', costsQuery.data), [teamId, costsQuery.data])
+
+  if (teamQuery.notFound) {
+    return <NotFoundPage />
+  }
+
+  return (
+    <main style={{ padding: '1.5rem' }}>
+      <p>
+        <Link to="/teams">← All teams</Link>
+      </p>
+
+      {teamQuery.isError && (
+        <div data-testid="team-detail-error" style={{ color: '#dc2626', marginBottom: '1rem' }}>
+          Failed to load team.
+        </div>
+      )}
+
+      {teamQuery.isLoading ? (
+        <p data-testid="team-detail-loading">Loading…</p>
+      ) : teamQuery.data ? (
+        <>
+          <header data-testid="team-detail-header" style={{ marginBottom: '1rem' }}>
+            <h1 style={{ marginBottom: '0.25rem' }}>{teamQuery.data.team_id}</h1>
+            <div style={{ display: 'flex', gap: '1rem', color: '#6b7280', fontSize: '0.875rem' }}>
+              <span data-testid="team-member-count">{teamQuery.data.agent_count} member{teamQuery.data.agent_count === 1 ? '' : 's'}</span>
+              <span data-testid="team-total-spend">
+                Daily spend:{' '}
+                {teamCost?.daily_spend_usd ? `$${teamCost.daily_spend_usd}` : '—'}
+              </span>
+              <span data-testid="team-created-at" style={{ color: '#9ca3af' }}>Created at: —</span>
+            </div>
+          </header>
+
+          {teamQuery.data.members.length === 0 ? (
+            <p data-testid="team-members-empty">No members in this team yet.</p>
+          ) : (
+            <table data-testid="team-members-table" style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr>
+                  {['Agent ID', 'Status', 'Depth', 'Actions'].map(h => (
+                    <th
+                      key={h}
+                      style={{ textAlign: 'left', padding: '0.5rem', borderBottom: '2px solid #e5e7eb' }}
+                    >
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {teamQuery.data.members.map(m => (
+                  <MemberRow key={m.id} member={m} />
+                ))}
+              </tbody>
+            </table>
+          )}
+        </>
+      ) : null}
+    </main>
+  )
+}


### PR DESCRIPTION
## Description

Add `/teams/:teamId` drill-down page rendering team header (id, member count, daily spend), a member table with status badge + depth + "Open in topology" action, and the dashboard's `NotFoundPage` when the team is unknown. Second of three PRs implementing F91 (AAASM-218).

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1056 (sub-task of Story AAASM-218 under Epic AAASM-197)
- Depends on / overlaps with PR #340 (AAASM-1054): both add `dashboard/src/features/teams/api.ts`. This PR's file is a superset (adds `useTeamTopologyQuery`, `useAgentLineageQuery`, `teamCostFor`). Merge #340 first; this PR will rebase cleanly.

## Testing

- [x] Unit tests added — `dashboard/src/pages/TeamDetailPage.test.tsx` covers: render with members, empty team, 404, "Open in topology" navigation, and lineage-unavailable fallback to the clicked member's id
- [x] Storybook fixtures added — `Pages/TeamDetailPage` with `FiveMembers` and `Empty`

Local gates passed in worktree `agent-assembly-v0.0.1-AAASM-1056-feat-team_drilldown`:
- `pnpm lint` — 0 errors
- `pnpm type-check` — 0 errors
- `pnpm test` — 215 / 215 pass
- `pnpm build` — clean

## Acceptance criteria coverage

- [x] Route `/teams/:teamId` renders via dashboard layout
- [x] Header shows team id, member count, daily spend (total cost spend)
- [x] Member table: agent id (linked), status badge, depth, "Open in topology" action
- [x] Loads from `GET /v1/topology/team/{team_id}`; team cost from `GET /v1/costs` per-team rollup
- [x] 404 page rendered when team unknown — `NotFoundPage` shared component
- [x] "Open in topology" navigates to `/topology?root=<topmost ancestor>` (via `GET /v1/topology/lineage/{agent_id}`)
- [x] Vitest covers render with members, empty members, 404, navigation
- [x] Storybook with five-member and empty fixtures

## Notes on AC deviation

- AC mentions per-member `GET /v1/agents/{id}/budget`; this PR uses `GET /v1/costs` (per-team aggregate) since no per-agent budget endpoint exists today. The team header shows daily team spend.
- `delegation_reason` and `parent_agent_id` columns deferred to AAASM-218 verification: neither field is present on `AgentNode` returned by `/topology/team/{team_id}`. Backend follow-up may be needed.
- `Created At` is rendered as `—` (same gap as #340).

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (none required — internal page added)
- [x] All CI checks passing (pre-push)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)