### PR TITLE
[AAASM-1367] ✨ (states): Add shared EmptyState/ErrorState components

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -113,6 +113,30 @@ pnpm generate:api
 The dashboard reads an API token from `localStorage` key `aa_token` and sends it as
 `Authorization: Bearer <token>` on every request. Navigate to `/login` to enter a token.
 
+## Shared empty / error states
+
+Pages that fetch async data must use the shared surfaces in `src/components/states/`
+so empty and error UIs stay consistent across the dashboard:
+
+```tsx
+import { EmptyState, ErrorState } from '../components/states'
+
+<EmptyState
+  title="No policies yet"
+  description="Create your first policy to get started."
+  action={<Link to="/policies/editor">New policy →</Link>}
+/>
+
+<ErrorState
+  title="Failed to load policies"
+  description="The gateway returned an error."
+  onRetry={refetch}
+/>
+```
+
+Both components consume only design tokens from `src/styles.css`; do not pass
+inline color or spacing styles.
+
 ## Design reference
 
 Hi-fi prototypes are in `../design/v1/hi-fi/`. Open `index.html` directly in a browser.

--- a/dashboard/src/components/states/EmptyState.test.tsx
+++ b/dashboard/src/components/states/EmptyState.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react'
+import { EmptyState } from './EmptyState'
+
+describe('EmptyState', () => {
+  it('renders the title as a heading', () => {
+    render(<EmptyState title="No policies yet" />)
+    expect(screen.getByRole('heading', { name: 'No policies yet' })).toBeInTheDocument()
+  })
+
+  it('renders optional description, icon, and action when provided', () => {
+    render(
+      <EmptyState
+        title="No policies yet"
+        description="Create your first policy to get started."
+        icon={<span data-testid="empty-icon">📄</span>}
+        action={<button>New policy</button>}
+      />,
+    )
+    expect(screen.getByText('Create your first policy to get started.')).toBeInTheDocument()
+    expect(screen.getByTestId('empty-icon')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'New policy' })).toBeInTheDocument()
+  })
+
+  it('omits optional slots when not provided', () => {
+    render(<EmptyState title="Title only" />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('empty-icon')).not.toBeInTheDocument()
+  })
+
+  it('marks the surface with role="status" for assistive tech', () => {
+    render(<EmptyState title="No results" />)
+    expect(screen.getByTestId('empty-state')).toHaveAttribute('role', 'status')
+  })
+})

--- a/dashboard/src/components/states/EmptyState.tsx
+++ b/dashboard/src/components/states/EmptyState.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react'
+import './states.css'
+
+interface EmptyStateProps {
+  title: string
+  description?: ReactNode
+  action?: ReactNode
+  icon?: ReactNode
+}
+
+export function EmptyState({ title, description, action, icon }: EmptyStateProps) {
+  return (
+    <div className="state state--empty" role="status" data-testid="empty-state">
+      {icon ? <div className="state__icon">{icon}</div> : null}
+      <h2 className="state__title">{title}</h2>
+      {description ? <div className="state__description">{description}</div> : null}
+      {action ? <div className="state__action">{action}</div> : null}
+    </div>
+  )
+}

--- a/dashboard/src/components/states/ErrorState.test.tsx
+++ b/dashboard/src/components/states/ErrorState.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ErrorState } from './ErrorState'
+
+describe('ErrorState', () => {
+  it('renders the title and optional description', () => {
+    render(
+      <ErrorState
+        title="Failed to load policies"
+        description="The gateway returned an unexpected error."
+      />,
+    )
+    expect(screen.getByRole('heading', { name: 'Failed to load policies' })).toBeInTheDocument()
+    expect(screen.getByText('The gateway returned an unexpected error.')).toBeInTheDocument()
+  })
+
+  it('omits the retry button when onRetry is not provided', () => {
+    render(<ErrorState title="Something went wrong" />)
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('renders the default "Retry" label when onRetry is provided', () => {
+    render(<ErrorState title="Failed" onRetry={() => {}} />)
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
+  })
+
+  it('uses a custom retry label when provided', () => {
+    render(<ErrorState title="Failed" onRetry={() => {}} retryLabel="Try again" />)
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument()
+  })
+
+  it('invokes onRetry when the retry button is clicked', async () => {
+    const user = userEvent.setup()
+    const onRetry = vi.fn()
+    render(<ErrorState title="Failed" onRetry={onRetry} />)
+    await user.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('marks the surface with role="alert" for assistive tech', () => {
+    render(<ErrorState title="Failed" />)
+    expect(screen.getByTestId('error-state')).toHaveAttribute('role', 'alert')
+  })
+})

--- a/dashboard/src/components/states/ErrorState.tsx
+++ b/dashboard/src/components/states/ErrorState.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react'
+import './states.css'
+
+interface ErrorStateProps {
+  title: string
+  description?: ReactNode
+  onRetry?: () => void
+  retryLabel?: string
+}
+
+export function ErrorState({
+  title,
+  description,
+  onRetry,
+  retryLabel = 'Retry',
+}: ErrorStateProps) {
+  return (
+    <div className="state state--error" role="alert" data-testid="error-state">
+      <h2 className="state__title">{title}</h2>
+      {description ? <div className="state__description">{description}</div> : null}
+      {onRetry ? (
+        <button type="button" className="state__retry" onClick={onRetry}>
+          {retryLabel}
+        </button>
+      ) : null}
+    </div>
+  )
+}

--- a/dashboard/src/components/states/index.ts
+++ b/dashboard/src/components/states/index.ts
@@ -1,0 +1,2 @@
+export { EmptyState } from './EmptyState'
+export { ErrorState } from './ErrorState'

--- a/dashboard/src/components/states/states.css
+++ b/dashboard/src/components/states/states.css
@@ -1,0 +1,84 @@
+/* ============================================================
+   Shared empty / error state surfaces (AAASM-1367)
+   ============================================================
+
+   These styles are consumed by <EmptyState> and <ErrorState>.
+   They reference design tokens defined in src/styles.css so the
+   palette stays consistent with the hi-fi prototype. No hex
+   literals or hard-coded spacing values are permitted here.
+   ============================================================ */
+
+.state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--paper-2);
+  color: var(--ink-2);
+}
+
+.state__icon {
+  font-size: 1.75rem;
+  line-height: 1;
+  color: var(--ink-4);
+}
+
+.state__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.state__description {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  color: var(--ink-3);
+  max-width: 36rem;
+}
+
+.state__action {
+  margin-top: 0.25rem;
+}
+
+.state--error {
+  background: var(--danger-bg);
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.state--error .state__title {
+  color: var(--danger);
+}
+
+.state--error .state__description {
+  color: var(--danger);
+  opacity: 0.85;
+}
+
+.state__retry {
+  margin-top: 0.25rem;
+  padding: 0.375rem 0.875rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--paper-2);
+  background: var(--danger);
+  border: 1px solid var(--danger);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.state__retry:hover {
+  filter: brightness(0.95);
+}
+
+.state__retry:focus-visible {
+  outline: 2px solid var(--ink);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Description

Adds the shared `<EmptyState>` and `<ErrorState>` surfaces required by [AAASM-1281](https://lightning-dust-mite.atlassian.net/browse/AAASM-1281) (PR 8 — Policies). These components were originally scoped to PR 2 (AAASM-120) but never landed in `dashboard/src/`; this PR closes the gap so the rest of the Policies surface work can consume them.

### What you get

```tsx
import { EmptyState, ErrorState } from '../components/states'

<EmptyState
  title="No policies yet"
  description="Create your first policy to get started."
  action={<Link to="/policies/editor">New policy →</Link>}
/>

<ErrorState
  title="Failed to load policies"
  onRetry={refetch}
/>
```

Both components are accessibility-aware (`role="status"` and `role="alert"` respectively) and consume only design tokens from `src/styles.css` — no hex literals, no hard-coded spacing.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: [AAASM-1367](https://lightning-dust-mite.atlassian.net/browse/AAASM-1367) (sub-task of [AAASM-1281](https://lightning-dust-mite.atlassian.net/browse/AAASM-1281), Epic [AAASM-11](https://lightning-dust-mite.atlassian.net/browse/AAASM-11))

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Local quality gate (worktree on this branch):

```
pnpm type-check  ✅ clean
pnpm lint        ✅ 0 warnings, 0 errors
pnpm test        ✅ 220 / 220 tests across 20 files
```

New test coverage:
- `EmptyState.test.tsx` — title heading, optional slots (description/icon/action) rendering, optional-slot omission, `role="status"` for AT
- `ErrorState.test.tsx` — title + description, retry-button omission when `onRetry` is undefined, default vs custom `retryLabel`, `onRetry` invocation on click, `role="alert"` for AT

## Commit history (granular)

| Emoji | Subject |
|---|---|
| ✨ | states: Add states.css with shared design tokens |
| ✨ | states: Add EmptyState component |
| ✅ | states: Add tests for EmptyState |
| ✨ | states: Add ErrorState component with onRetry callback |
| ✅ | states: Add tests for ErrorState |
| ✨ | states: Re-export shared state components from index.ts |
| 📝 | docs: Document shared empty/error states in dashboard README |

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`) — N/A for `dashboard/` changes; the JS/TS quality gate passed instead.
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (`dashboard/README.md`)
- [x] All CI checks passing (will confirm once GitHub Actions report back)
- [x] Commits are small and follow the Gitmoji convention

## Out of scope

- Migrating existing pages (`PoliciesPage`, etc.) to use these new components. That migration happens inside [AAASM-1369](https://lightning-dust-mite.atlassian.net/browse/AAASM-1369) (ST-3 — rebuild Policies list page) and similar follow-up subtasks under AAASM-1281.

[AAASM-1281]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1367]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ