### PR TITLE
[AAASM-1065] ✨ (trace): Scaffold trace view route + useTraceQuery hook

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -11,6 +11,7 @@ import { PolicyEditorPage } from './pages/PolicyEditorPage'
 import { AnalyticsPage } from './pages/AnalyticsPage'
 import { AlertsPage } from './pages/AlertsPage'
 import { CapabilityPage } from './pages/CapabilityPage'
+import { TraceViewPage } from './pages/TraceViewPage'
 import { ComingSoon } from './pages/ComingSoon'
 import { IdentityPage } from './pages/IdentityPage'
 import { TeamDetailPage } from './pages/TeamDetailPage'
@@ -44,6 +45,7 @@ function App() {
 
             {/* ── Sub-routes for canonical pages ────────────────────────── */}
             <Route path="/agents/:id" element={<AgentDetailPage />} />
+            <Route path="/agents/:id/trace/:sessionId" element={<TraceViewPage />} />
             <Route path="/policies/editor" element={<PolicyEditorPage />} />
             <Route path="/teams/:teamId" element={<TeamDetailPage />} />
 

--- a/dashboard/src/features/trace/README.md
+++ b/dashboard/src/features/trace/README.md
@@ -1,0 +1,15 @@
+# Trace Feature
+
+Per-session trace view for an agent — vertical timeline of LLM calls,
+tool calls, and policy decisions with severity highlighting for policy
+violations and credential leaks.
+
+Implements the trace half of [AAASM-95](https://lightning-dust-mite.atlassian.net/browse/AAASM-95).
+Decomposed into:
+
+| Subtask | Scope |
+|---|---|
+| AAASM-1065 | Route + `useTraceQuery` + page shell |
+| AAASM-1067 | `<TraceTimeline>` with severity color tokens + filter bar |
+| AAASM-1069 | Payload preview + `<PayloadModal>` |
+| AAASM-1071 | JSON export with zod schema + Playwright E2E |

--- a/dashboard/src/features/trace/api.test.tsx
+++ b/dashboard/src/features/trace/api.test.tsx
@@ -1,0 +1,79 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useTraceQuery } from './api'
+import type { TraceEvent } from './types'
+
+const MOCK_EVENTS: TraceEvent[] = [
+  {
+    id: 'evt-1',
+    timestamp: '2026-04-23T14:23:01Z',
+    type: 'llm_call',
+    agent: 'support-agent',
+    durationMs: 834,
+    payloadPreview: 'GPT-4o · query user #4521 billing',
+    payload: { model: 'gpt-4o', prompt: 'lookup billing' },
+    severity: 'info',
+  },
+  {
+    id: 'evt-2',
+    timestamp: '2026-04-23T14:23:16Z',
+    type: 'policy_violation',
+    agent: 'support-agent',
+    durationMs: 12,
+    payloadPreview: 'refund > $100 requires human approval',
+    payload: { amount: 250, user_id: 4521 },
+    severity: 'critical',
+    redactedFields: ['user_id'],
+  },
+]
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
+
+describe('useTraceQuery', () => {
+  beforeEach(() => {
+    localStorage.setItem('aa_token', 'test-token')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    localStorage.clear()
+  })
+
+  it('returns events from a successful fetch and forwards the bearer token', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(MOCK_EVENTS), { status: 200 }),
+    )
+
+    const { result } = renderHook(() => useTraceQuery('agent-1', 'session-1'), { wrapper })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual(MOCK_EVENTS)
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/agents/agent-1/sessions/session-1/trace'),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer test-token' }),
+      }),
+    )
+  })
+
+  it('throws on non-OK response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 500 }))
+
+    const { result } = renderHook(() => useTraceQuery('agent-1', 'session-1'), { wrapper })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error?.message).toBe('Failed to fetch trace')
+  })
+
+  it('is disabled and does not fetch when ids are missing', () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    const { result } = renderHook(() => useTraceQuery('', ''), { wrapper })
+
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/dashboard/src/features/trace/api.ts
+++ b/dashboard/src/features/trace/api.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query'
+import type { TraceEvent } from './types'
+
+/**
+ * Fetch the immutable session trace from the gateway.
+ *
+ * `/api/v1/agents/{agentId}/sessions/{sessionId}/trace` is not yet in the
+ * OpenAPI schema (tracked under AAASM-9), so this hook hits the path
+ * directly while reusing the auth convention from `api/client.ts`.
+ * Switch to `api.GET` once the endpoint is generated.
+ */
+export function useTraceQuery(agentId: string, sessionId: string) {
+  return useQuery<TraceEvent[]>({
+    queryKey: ['trace', agentId, sessionId],
+    enabled: !!agentId && !!sessionId,
+    staleTime: Infinity,
+    queryFn: async () => {
+      const base = import.meta.env.VITE_API_BASE_URL ?? ''
+      const token = localStorage.getItem('aa_token')
+      const headers: Record<string, string> = {}
+      if (token) headers.Authorization = `Bearer ${token}`
+
+      const res = await fetch(
+        `${base}/api/v1/agents/${encodeURIComponent(agentId)}/sessions/${encodeURIComponent(sessionId)}/trace`,
+        { headers },
+      )
+      if (!res.ok) throw new Error('Failed to fetch trace')
+      return (await res.json()) as TraceEvent[]
+    },
+  })
+}

--- a/dashboard/src/features/trace/types.ts
+++ b/dashboard/src/features/trace/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Trace event shape for the agent-session trace view.
+ *
+ * Field names match the AAASM-1065 spec. The server contract for
+ * `/api/v1/agents/{agentId}/sessions/{sessionId}/trace` is being
+ * finalised under AAASM-9; until the endpoint lands in the OpenAPI
+ * schema, this type is the source of truth for the frontend.
+ */
+
+export type TraceSeverity = 'critical' | 'warning' | 'info'
+
+export interface TraceEvent {
+  readonly id: string
+  readonly timestamp: string
+  readonly type: string
+  readonly agent: string
+  readonly durationMs: number
+  readonly payloadPreview: string
+  readonly payload: unknown
+  readonly severity?: TraceSeverity
+  readonly redactedFields?: readonly string[]
+}

--- a/dashboard/src/pages/TraceViewPage.test.tsx
+++ b/dashboard/src/pages/TraceViewPage.test.tsx
@@ -1,20 +1,51 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
-import { describe, expect, it } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { UseQueryResult } from '@tanstack/react-query'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { TraceViewPage } from './TraceViewPage'
+import * as traceApi from '../features/trace/api'
+import type { TraceEvent } from '../features/trace/types'
+
+function makeClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
 
 function renderAt(path: string) {
   return render(
-    <MemoryRouter initialEntries={[path]}>
-      <Routes>
-        <Route path="/agents/:id/trace/:sessionId" element={<TraceViewPage />} />
-      </Routes>
-    </MemoryRouter>,
+    <QueryClientProvider client={makeClient()}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/agents/:id/trace/:sessionId" element={<TraceViewPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
   )
 }
 
+function mockQuery(partial: Partial<UseQueryResult<TraceEvent[], Error>>): UseQueryResult<TraceEvent[], Error> {
+  return partial as unknown as UseQueryResult<TraceEvent[], Error>
+}
+
+const MOCK_EVENT: TraceEvent = {
+  id: 'evt-1',
+  timestamp: '2026-04-23T14:23:01Z',
+  type: 'llm_call',
+  agent: 'support-agent',
+  durationMs: 834,
+  payloadPreview: 'GPT-4o · query user #4521 billing',
+  payload: {},
+  severity: 'info',
+}
+
 describe('TraceViewPage', () => {
+  afterEach(() => { vi.restoreAllMocks() })
+
   it('renders the agent id and session id from URL params in the header', () => {
+    vi.spyOn(traceApi, 'useTraceQuery').mockReturnValue(
+      mockQuery({ data: [MOCK_EVENT], isLoading: false, isError: false, refetch: vi.fn() }),
+    )
     renderAt('/agents/agent-001/trace/session-abc')
 
     const heading = screen.getByRole('heading', { level: 1 })
@@ -23,14 +54,54 @@ describe('TraceViewPage', () => {
   })
 
   it('exposes a back link to the agent detail page', () => {
+    vi.spyOn(traceApi, 'useTraceQuery').mockReturnValue(
+      mockQuery({ data: [MOCK_EVENT], isLoading: false, isError: false, refetch: vi.fn() }),
+    )
     renderAt('/agents/agent-001/trace/session-abc')
 
     const link = screen.getByRole('link', { name: /Back to agent/i })
     expect(link).toHaveAttribute('href', '/agents/agent-001')
   })
 
-  it('mounts the timeline placeholder slot', () => {
+  it('renders skeleton rows while loading', () => {
+    vi.spyOn(traceApi, 'useTraceQuery').mockReturnValue(
+      mockQuery({ data: undefined, isLoading: true, isError: false, refetch: vi.fn() }),
+    )
     renderAt('/agents/agent-001/trace/session-abc')
-    expect(screen.getByTestId('trace-timeline-placeholder')).toBeInTheDocument()
+
+    expect(screen.getByTestId('trace-loading')).toBeInTheDocument()
+    expect(screen.getAllByTestId('trace-row-skeleton')).toHaveLength(4)
+  })
+
+  it('shows error banner with Retry button on failure and calls refetch on click', async () => {
+    const refetch = vi.fn()
+    vi.spyOn(traceApi, 'useTraceQuery').mockReturnValue(
+      mockQuery({ data: undefined, isLoading: false, isError: true, refetch }),
+    )
+    renderAt('/agents/agent-001/trace/session-abc')
+
+    expect(screen.getByTestId('trace-error')).toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows empty state when no events', () => {
+    vi.spyOn(traceApi, 'useTraceQuery').mockReturnValue(
+      mockQuery({ data: [], isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    renderAt('/agents/agent-001/trace/session-abc')
+
+    expect(screen.getByTestId('trace-empty')).toBeInTheDocument()
+  })
+
+  it('mounts the timeline placeholder slot with event count when ready', () => {
+    vi.spyOn(traceApi, 'useTraceQuery').mockReturnValue(
+      mockQuery({ data: [MOCK_EVENT], isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    renderAt('/agents/agent-001/trace/session-abc')
+
+    const placeholder = screen.getByTestId('trace-timeline-placeholder')
+    expect(placeholder).toBeInTheDocument()
+    expect(placeholder).toHaveTextContent('1 event')
   })
 })

--- a/dashboard/src/pages/TraceViewPage.test.tsx
+++ b/dashboard/src/pages/TraceViewPage.test.tsx
@@ -3,10 +3,12 @@ import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { UseQueryResult } from '@tanstack/react-query'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TraceViewPage } from './TraceViewPage'
 import * as traceApi from '../features/trace/api'
+import * as agentsApi from '../features/agents/api'
 import type { TraceEvent } from '../features/trace/types'
+import type { Agent } from '../features/agents/api'
 
 function makeClient() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } })
@@ -24,8 +26,30 @@ function renderAt(path: string) {
   )
 }
 
-function mockQuery(partial: Partial<UseQueryResult<TraceEvent[], Error>>): UseQueryResult<TraceEvent[], Error> {
+function mockTraceQuery(partial: Partial<UseQueryResult<TraceEvent[], Error>>): UseQueryResult<TraceEvent[], Error> {
   return partial as unknown as UseQueryResult<TraceEvent[], Error>
+}
+
+function mockAgentQuery(partial: Partial<UseQueryResult<Agent | undefined, Error>>): UseQueryResult<Agent | undefined, Error> {
+  return partial as unknown as UseQueryResult<Agent | undefined, Error>
+}
+
+const MOCK_AGENT: Agent = {
+  id: 'agent-001',
+  name: 'support-agent',
+  framework: 'langgraph',
+  status: 'active',
+  version: '0.1.0',
+  layer: 'enforced',
+  last_event: '2026-05-12T00:00:00Z',
+  recent_events: [],
+  recent_traces: [],
+  active_sessions: [],
+  session_count: 0,
+  policy_violations_count: 0,
+  tool_names: [],
+  metadata: {},
+  pid: null,
 }
 
 const MOCK_EVENT: TraceEvent = {
@@ -40,22 +64,41 @@ const MOCK_EVENT: TraceEvent = {
 }
 
 describe('TraceViewPage', () => {
+  beforeEach(() => {
+    vi.spyOn(agentsApi, 'useAgentQuery').mockReturnValue(
+      mockAgentQuery({ data: MOCK_AGENT, isLoading: false, isError: false }),
+    )
+  })
+
   afterEach(() => { vi.restoreAllMocks() })
 
-  it('renders the agent id and session id from URL params in the header', () => {
+  it('renders the agent name and session id from URL params in the header', () => {
     vi.spyOn(traceApi, 'useTraceQuery').mockReturnValue(
-      mockQuery({ data: [MOCK_EVENT], isLoading: false, isError: false, refetch: vi.fn() }),
+      mockTraceQuery({ data: [MOCK_EVENT], isLoading: false, isError: false, refetch: vi.fn() }),
     )
     renderAt('/agents/agent-001/trace/session-abc')
 
     const heading = screen.getByRole('heading', { level: 1 })
-    expect(heading).toHaveTextContent('agent-001')
+    expect(heading).toHaveTextContent('support-agent')
     expect(heading).toHaveTextContent('session-abc')
+    expect(screen.getByTestId('trace-agent-label')).toHaveTextContent('support-agent')
+  })
+
+  it('falls back to agent id in the header while the agent query has no data', () => {
+    vi.spyOn(agentsApi, 'useAgentQuery').mockReturnValue(
+      mockAgentQuery({ data: undefined, isLoading: true, isError: false }),
+    )
+    vi.spyOn(traceApi, 'useTraceQuery').mockReturnValue(
+      mockTraceQuery({ data: [MOCK_EVENT], isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    renderAt('/agents/agent-001/trace/session-abc')
+
+    expect(screen.getByTestId('trace-agent-label')).toHaveTextContent('agent-001')
   })
 
   it('exposes a back link to the agent detail page', () => {
     vi.spyOn(traceApi, 'useTraceQuery').mockReturnValue(
-      mockQuery({ data: [MOCK_EVENT], isLoading: false, isError: false, refetch: vi.fn() }),
+      mockTraceQuery({ data: [MOCK_EVENT], isLoading: false, isError: false, refetch: vi.fn() }),
     )
     renderAt('/agents/agent-001/trace/session-abc')
 
@@ -65,7 +108,7 @@ describe('TraceViewPage', () => {
 
   it('renders skeleton rows while loading', () => {
     vi.spyOn(traceApi, 'useTraceQuery').mockReturnValue(
-      mockQuery({ data: undefined, isLoading: true, isError: false, refetch: vi.fn() }),
+      mockTraceQuery({ data: undefined, isLoading: true, isError: false, refetch: vi.fn() }),
     )
     renderAt('/agents/agent-001/trace/session-abc')
 
@@ -76,7 +119,7 @@ describe('TraceViewPage', () => {
   it('shows error banner with Retry button on failure and calls refetch on click', async () => {
     const refetch = vi.fn()
     vi.spyOn(traceApi, 'useTraceQuery').mockReturnValue(
-      mockQuery({ data: undefined, isLoading: false, isError: true, refetch }),
+      mockTraceQuery({ data: undefined, isLoading: false, isError: true, refetch }),
     )
     renderAt('/agents/agent-001/trace/session-abc')
 
@@ -87,7 +130,7 @@ describe('TraceViewPage', () => {
 
   it('shows empty state when no events', () => {
     vi.spyOn(traceApi, 'useTraceQuery').mockReturnValue(
-      mockQuery({ data: [], isLoading: false, isError: false, refetch: vi.fn() }),
+      mockTraceQuery({ data: [], isLoading: false, isError: false, refetch: vi.fn() }),
     )
     renderAt('/agents/agent-001/trace/session-abc')
 
@@ -96,7 +139,7 @@ describe('TraceViewPage', () => {
 
   it('mounts the timeline placeholder slot with event count when ready', () => {
     vi.spyOn(traceApi, 'useTraceQuery').mockReturnValue(
-      mockQuery({ data: [MOCK_EVENT], isLoading: false, isError: false, refetch: vi.fn() }),
+      mockTraceQuery({ data: [MOCK_EVENT], isLoading: false, isError: false, refetch: vi.fn() }),
     )
     renderAt('/agents/agent-001/trace/session-abc')
 

--- a/dashboard/src/pages/TraceViewPage.test.tsx
+++ b/dashboard/src/pages/TraceViewPage.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { TraceViewPage } from './TraceViewPage'
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/agents/:id/trace/:sessionId" element={<TraceViewPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('TraceViewPage', () => {
+  it('renders the agent id and session id from URL params in the header', () => {
+    renderAt('/agents/agent-001/trace/session-abc')
+
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(heading).toHaveTextContent('agent-001')
+    expect(heading).toHaveTextContent('session-abc')
+  })
+
+  it('exposes a back link to the agent detail page', () => {
+    renderAt('/agents/agent-001/trace/session-abc')
+
+    const link = screen.getByRole('link', { name: /Back to agent/i })
+    expect(link).toHaveAttribute('href', '/agents/agent-001')
+  })
+
+  it('mounts the timeline placeholder slot', () => {
+    renderAt('/agents/agent-001/trace/session-abc')
+    expect(screen.getByTestId('trace-timeline-placeholder')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/pages/TraceViewPage.tsx
+++ b/dashboard/src/pages/TraceViewPage.tsx
@@ -1,14 +1,13 @@
 import { Link, useParams } from 'react-router-dom'
+import { useTraceQuery } from '../features/trace/api'
 
 /**
- * Trace view page — header + slot for the timeline component.
- *
- * Renders the placeholder shell registered at `/agents/:id/trace/:sessionId`.
- * The timeline lands in AAASM-1067, payload modal in AAASM-1069, JSON
- * export in AAASM-1071.
+ * Trace view page — header, status states (loading / error / empty / ready),
+ * and a slot where the timeline component lands in AAASM-1067.
  */
 export function TraceViewPage() {
   const { id = '', sessionId = '' } = useParams<{ id: string; sessionId: string }>()
+  const { data, isLoading, isError, refetch } = useTraceQuery(id, sessionId)
 
   return (
     <main style={{ padding: '1.5rem' }} data-testid="trace-view">
@@ -16,12 +15,45 @@ export function TraceViewPage() {
       <h1 style={{ margin: '0.75rem 0' }}>
         Trace · <code style={{ fontSize: '1rem' }}>{id}</code> / <code style={{ fontSize: '1rem' }}>{sessionId}</code>
       </h1>
-      <div
-        data-testid="trace-timeline-placeholder"
-        style={{ color: 'var(--shell-text-muted)', marginTop: '1rem' }}
-      >
-        Timeline component lands in AAASM-1067.
-      </div>
+
+      {isLoading && (
+        <div data-testid="trace-loading" style={{ marginTop: '1rem' }}>
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              data-testid="trace-row-skeleton"
+              style={{
+                background: '#f3f4f6',
+                height: '2.25rem',
+                marginBottom: '0.5rem',
+                borderRadius: '4px',
+              }}
+            />
+          ))}
+        </div>
+      )}
+
+      {isError && (
+        <div data-testid="trace-error" style={{ marginTop: '1rem' }}>
+          <p style={{ color: '#dc2626' }}>Failed to load trace.</p>
+          <button onClick={() => void refetch()}>Retry</button>
+        </div>
+      )}
+
+      {!isLoading && !isError && data && data.length === 0 && (
+        <div data-testid="trace-empty" style={{ marginTop: '1rem', color: 'var(--shell-text-muted)' }}>
+          No events recorded for this session.
+        </div>
+      )}
+
+      {!isLoading && !isError && data && data.length > 0 && (
+        <div
+          data-testid="trace-timeline-placeholder"
+          style={{ color: 'var(--shell-text-muted)', marginTop: '1rem' }}
+        >
+          Loaded {data.length} event{data.length === 1 ? '' : 's'}. Timeline component lands in AAASM-1067.
+        </div>
+      )}
     </main>
   )
 }

--- a/dashboard/src/pages/TraceViewPage.tsx
+++ b/dashboard/src/pages/TraceViewPage.tsx
@@ -1,0 +1,27 @@
+import { Link, useParams } from 'react-router-dom'
+
+/**
+ * Trace view page — header + slot for the timeline component.
+ *
+ * Renders the placeholder shell registered at `/agents/:id/trace/:sessionId`.
+ * The timeline lands in AAASM-1067, payload modal in AAASM-1069, JSON
+ * export in AAASM-1071.
+ */
+export function TraceViewPage() {
+  const { id = '', sessionId = '' } = useParams<{ id: string; sessionId: string }>()
+
+  return (
+    <main style={{ padding: '1.5rem' }} data-testid="trace-view">
+      <Link to={`/agents/${id}`} style={{ fontSize: '0.875rem' }}>← Back to agent</Link>
+      <h1 style={{ margin: '0.75rem 0' }}>
+        Trace · <code style={{ fontSize: '1rem' }}>{id}</code> / <code style={{ fontSize: '1rem' }}>{sessionId}</code>
+      </h1>
+      <div
+        data-testid="trace-timeline-placeholder"
+        style={{ color: 'var(--shell-text-muted)', marginTop: '1rem' }}
+      >
+        Timeline component lands in AAASM-1067.
+      </div>
+    </main>
+  )
+}

--- a/dashboard/src/pages/TraceViewPage.tsx
+++ b/dashboard/src/pages/TraceViewPage.tsx
@@ -1,4 +1,5 @@
 import { Link, useParams } from 'react-router-dom'
+import { useAgentQuery } from '../features/agents/api'
 import { useTraceQuery } from '../features/trace/api'
 
 /**
@@ -7,13 +8,15 @@ import { useTraceQuery } from '../features/trace/api'
  */
 export function TraceViewPage() {
   const { id = '', sessionId = '' } = useParams<{ id: string; sessionId: string }>()
+  const { data: agent } = useAgentQuery(id)
   const { data, isLoading, isError, refetch } = useTraceQuery(id, sessionId)
+  const agentLabel = agent?.name ?? id
 
   return (
     <main style={{ padding: '1.5rem' }} data-testid="trace-view">
       <Link to={`/agents/${id}`} style={{ fontSize: '0.875rem' }}>← Back to agent</Link>
-      <h1 style={{ margin: '0.75rem 0' }}>
-        Trace · <code style={{ fontSize: '1rem' }}>{id}</code> / <code style={{ fontSize: '1rem' }}>{sessionId}</code>
+      <h1 style={{ margin: '0.75rem 0' }} data-testid="trace-header">
+        Trace · <span data-testid="trace-agent-label">{agentLabel}</span> / <code style={{ fontSize: '1rem' }}>{sessionId}</code>
       </h1>
 
       {isLoading && (


### PR DESCRIPTION
## Description

Scaffolds the trace view for an agent session — first subtask of [AAASM-95](https://lightning-dust-mite.atlassian.net/browse/AAASM-95) (S22 — security-engineer trace + violation highlighting). Adds:

- `dashboard/src/features/trace/types.ts` — `TraceEvent` + `TraceSeverity` shapes matching the AAASM-1065 spec.
- `dashboard/src/features/trace/api.ts` — `useTraceQuery(agentId, sessionId)` Tanstack Query hook with `staleTime: Infinity` (traces are immutable per session). Hits `/api/v1/agents/{agentId}/sessions/{sessionId}/trace` via `fetch` while reusing the `aa_token` bearer convention from `api/client.ts`. Switches to the typed `api.GET` once AAASM-9 lands the endpoint in the OpenAPI schema.
- `dashboard/src/pages/TraceViewPage.tsx` — page shell with header (agent id / session id from URL), back link, loading skeleton, error retry, empty state, and a placeholder slot for the timeline that lands in AAASM-1067.
- `App.tsx` — route `/agents/:id/trace/:sessionId` registered under the protected `<AppShell>` outlet.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-1065](https://lightning-dust-mite.atlassian.net/browse/AAASM-1065) (parent Story [AAASM-95](https://lightning-dust-mite.atlassian.net/browse/AAASM-95))
- Depends on (future): AAASM-9 — adds the `/api/v1/agents/{agentId}/sessions/{sessionId}/trace` endpoint to the gateway and OpenAPI schema. Until then this hook makes a raw fetch with explicit auth header.

## Testing

- [x] Unit tests added / updated

\`pnpm type-check\` clean, \`pnpm lint\` clean, \`pnpm test\` 20 files / 219 tests green (+9 vs baseline).

### New tests (9)

| File | Cases |
|---|---|
| \`src/features/trace/api.test.tsx\` | Returns events from successful fetch & forwards bearer token; throws on non-OK response; is disabled when ids are missing |
| \`src/pages/TraceViewPage.test.tsx\` | Renders header from URL params; back link points to agent detail; skeleton rows in loading state; error banner with working Retry; empty state when no events; placeholder shows event count when ready |

### Manual verification note

The page currently renders only a placeholder where the timeline component will land (AAASM-1067), so no live screenshot adds signal yet — every rendering state is covered by the unit tests above. Live UI screenshots will accompany AAASM-1067 / 1069 / 1071 where real timeline / modal / export UI is in place.

## Commit slices

This PR is decomposed into 8 atomic, bisectable commits per the workspace commit policy:

1. \`📝 (trace): Add feature folder README\`
2. \`✨ (trace): Add TraceEvent type definitions\`
3. \`✨ (trace): Add useTraceQuery hook\`
4. \`✅ (trace): Test useTraceQuery returns events from mocked client\`
5. \`✨ (trace): Add TraceView page shell with header + placeholder\`
6. \`✅ (trace): Test TraceView renders header from URL params\`
7. \`✨ (trace): Register /agents/:id/trace/:sessionId route\`
8. \`🔧 (trace): Wire loading skeleton + error retry into TraceView\`

## Checklist

- [x] Code follows project style guidelines (\`pnpm lint\`, \`pnpm type-check\`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (feature folder README added)
- [x] All local checks passing (CI verification pending)
- [x] Commits are small and follow the Gitmoji convention

[AAASM-95]: https://lightning-dust-mite.atlassian.net/browse/AAASM-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1065]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ