### PR TITLE
[AAASM-1048] ✨ (dashboard/fleet): Refresh Fleet page chrome with header, tabs, filter bar and URL sync

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -2,7 +2,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { ProtectedRoute } from './pages/ProtectedRoute'
 import { AppShell } from './components/AppShell'
 import { LoginPage } from './pages/LoginPage'
-import { AgentsPage } from './pages/AgentsPage'
+import { FleetPage } from './pages/FleetPage'
 import { AgentDetailPage } from './pages/AgentDetailPage'
 import { ApprovalsPage } from './pages/ApprovalsPage'
 import { NotFoundPage } from './pages/NotFoundPage'
@@ -25,7 +25,7 @@ function App() {
             {/* ── Canonical 12 routes (AAASM-94 AC #5, #6) ──────────────── */}
             {/* monitor */}
             <Route path="/overview" element={<ComingSoon name="Overview" />} />
-            <Route path="/agents" element={<AgentsPage />} />
+            <Route path="/agents" element={<FleetPage />} />
             <Route path="/topology" element={<ComingSoon name="Topology" />} />
             <Route path="/live" element={<ComingSoon name="Live Ops" />} />
             <Route path="/alerts" element={<ComingSoon name="Alerts" />} />

--- a/dashboard/src/features/agents/api.test.tsx
+++ b/dashboard/src/features/agents/api.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { vi } from 'vitest'
@@ -72,9 +72,10 @@ describe('FleetPage', () => {
     )
     render(<FleetPage />, { wrapper: ({ children }) => <Wrapper path="/">{children}</Wrapper> })
     await waitFor(() => expect(screen.getAllByTestId('agent-row')).toHaveLength(1))
-    expect(screen.getByText('test-agent')).toBeInTheDocument()
-    expect(screen.getByText('langgraph')).toBeInTheDocument()
-    expect(screen.getByText('active')).toBeInTheDocument()
+    const row = screen.getByTestId('agent-row')
+    expect(within(row).getByText('test-agent')).toBeInTheDocument()
+    expect(within(row).getByText('langgraph')).toBeInTheDocument()
+    expect(within(row).getByText('active')).toBeInTheDocument()
   })
 
   it('shows empty state when no agents', async () => {

--- a/dashboard/src/features/agents/api.test.tsx
+++ b/dashboard/src/features/agents/api.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { vi } from 'vitest'
-import { AgentsPage } from '../../pages/AgentsPage'
+import { FleetPage } from '../../pages/FleetPage'
 import { AgentDetailPage } from '../../pages/AgentDetailPage'
 import * as agentsApi from './api'
 import type { Agent, LogEntry } from './api'
@@ -55,14 +55,14 @@ const MOCK_LOG: LogEntry = {
   timestamp: '2026-05-12T00:00:00Z',
 }
 
-describe('AgentsPage', () => {
+describe('FleetPage', () => {
   afterEach(() => { vi.restoreAllMocks() })
 
   it('renders skeleton rows while loading', () => {
     vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
       mockQuery<Agent[]>({ data: undefined, isLoading: true, isError: false, refetch: vi.fn() }),
     )
-    render(<AgentsPage />, { wrapper: ({ children }) => <Wrapper path="/">{children}</Wrapper> })
+    render(<FleetPage />, { wrapper: ({ children }) => <Wrapper path="/">{children}</Wrapper> })
     expect(screen.getAllByTestId('agent-row-skeleton')).toHaveLength(5)
   })
 
@@ -70,7 +70,7 @@ describe('AgentsPage', () => {
     vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
       mockQuery<Agent[]>({ data: [MOCK_AGENT], isLoading: false, isError: false, refetch: vi.fn() }),
     )
-    render(<AgentsPage />, { wrapper: ({ children }) => <Wrapper path="/">{children}</Wrapper> })
+    render(<FleetPage />, { wrapper: ({ children }) => <Wrapper path="/">{children}</Wrapper> })
     await waitFor(() => expect(screen.getAllByTestId('agent-row')).toHaveLength(1))
     expect(screen.getByText('test-agent')).toBeInTheDocument()
     expect(screen.getByText('langgraph')).toBeInTheDocument()
@@ -81,7 +81,7 @@ describe('AgentsPage', () => {
     vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
       mockQuery<Agent[]>({ data: [], isLoading: false, isError: false, refetch: vi.fn() }),
     )
-    render(<AgentsPage />, { wrapper: ({ children }) => <Wrapper path="/">{children}</Wrapper> })
+    render(<FleetPage />, { wrapper: ({ children }) => <Wrapper path="/">{children}</Wrapper> })
     await waitFor(() => expect(screen.getByTestId('agents-empty')).toBeInTheDocument())
   })
 
@@ -89,7 +89,7 @@ describe('AgentsPage', () => {
     vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
       mockQuery<Agent[]>({ data: undefined, isLoading: false, isError: true, refetch: vi.fn() }),
     )
-    render(<AgentsPage />, { wrapper: ({ children }) => <Wrapper path="/">{children}</Wrapper> })
+    render(<FleetPage />, { wrapper: ({ children }) => <Wrapper path="/">{children}</Wrapper> })
     expect(screen.getByTestId('agents-error')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument()
   })

--- a/dashboard/src/features/agents/fleetFilters.test.ts
+++ b/dashboard/src/features/agents/fleetFilters.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest'
+import type { Agent } from './api'
+import { toFleetAgent, type FleetAgent } from './fleetTypes'
+import {
+  DEFAULT_FLEET_FILTERS,
+  applyFleetFilters,
+  fleetFiltersFromParams,
+  fleetFiltersToParamsRecord,
+  frameworkOptions,
+} from './fleetFilters'
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: 'a',
+    name: 'agent',
+    framework: 'langgraph',
+    status: 'active',
+    version: '0.1.0',
+    layer: null,
+    last_event: null,
+    recent_events: [],
+    recent_traces: [],
+    active_sessions: [],
+    session_count: 0,
+    policy_violations_count: 0,
+    tool_names: [],
+    metadata: {},
+    pid: null,
+    ...overrides,
+  }
+}
+
+function makeFleet(...overrides: Partial<Agent>[]): FleetAgent[] {
+  return overrides.map((o, i) => toFleetAgent(makeAgent({ id: `id-${i}`, ...o })))
+}
+
+describe('applyFleetFilters', () => {
+  it('returns the full list when filters are at defaults', () => {
+    const list = makeFleet({ name: 'alpha' }, { name: 'beta' })
+    expect(applyFleetFilters(list, DEFAULT_FLEET_FILTERS)).toHaveLength(2)
+  })
+
+  it('filters by search query against name', () => {
+    const list = makeFleet({ name: 'alpha-agent' }, { name: 'beta-agent' })
+    expect(applyFleetFilters(list, { ...DEFAULT_FLEET_FILTERS, q: 'alpha' })).toHaveLength(1)
+  })
+
+  it('filters by search query against owner (metadata.owner)', () => {
+    const list = makeFleet({ metadata: { owner: 'alice' } }, { metadata: { owner: 'bob' } })
+    expect(applyFleetFilters(list, { ...DEFAULT_FLEET_FILTERS, q: 'bob' })).toHaveLength(1)
+  })
+
+  it('filters by framework when not "all"', () => {
+    const list = makeFleet({ framework: 'langgraph' }, { framework: 'crewai' })
+    expect(applyFleetFilters(list, { ...DEFAULT_FLEET_FILTERS, framework: 'crewai' })).toHaveLength(1)
+  })
+
+  it('filters by status when not "all"', () => {
+    const list = makeFleet({ status: 'active' }, { status: 'suspended' })
+    expect(applyFleetFilters(list, { ...DEFAULT_FLEET_FILTERS, status: 'suspended' })).toHaveLength(1)
+  })
+
+  it('filters out non-flagged agents when flaggedOnly is true', () => {
+    const list = makeFleet(
+      { policy_violations_count: 0 },
+      { policy_violations_count: 100 },
+    )
+    expect(applyFleetFilters(list, { ...DEFAULT_FLEET_FILTERS, flaggedOnly: true })).toHaveLength(1)
+  })
+
+  it('combines filters with AND semantics', () => {
+    const list = makeFleet(
+      { name: 'alpha', framework: 'langgraph', status: 'active' },
+      { name: 'alpha', framework: 'crewai',    status: 'active' },
+      { name: 'beta',  framework: 'langgraph', status: 'active' },
+    )
+    const out = applyFleetFilters(list, { ...DEFAULT_FLEET_FILTERS, q: 'alpha', framework: 'crewai' })
+    expect(out).toHaveLength(1)
+    expect(out[0]?.framework).toBe('crewai')
+  })
+})
+
+describe('frameworkOptions', () => {
+  it('returns sorted distinct framework values', () => {
+    const list = makeFleet({ framework: 'langgraph' }, { framework: 'crewai' }, { framework: 'langgraph' })
+    expect(frameworkOptions(list)).toEqual(['crewai', 'langgraph'])
+  })
+
+  it('returns an empty list when there are no agents', () => {
+    expect(frameworkOptions([])).toEqual([])
+  })
+})
+
+describe('fleetFiltersFromParams', () => {
+  it('reads all four params from the URL', () => {
+    const p = new URLSearchParams('q=foo&framework=crewai&status=suspended&flagged=1')
+    expect(fleetFiltersFromParams(p)).toEqual({
+      q: 'foo',
+      framework: 'crewai',
+      status: 'suspended',
+      flaggedOnly: true,
+    })
+  })
+
+  it('defaults missing params to filter defaults', () => {
+    expect(fleetFiltersFromParams(new URLSearchParams(''))).toEqual(DEFAULT_FLEET_FILTERS)
+  })
+
+  it('treats flagged values other than "1" as false', () => {
+    expect(fleetFiltersFromParams(new URLSearchParams('flagged=true')).flaggedOnly).toBe(false)
+    expect(fleetFiltersFromParams(new URLSearchParams('flagged=0')).flaggedOnly).toBe(false)
+  })
+})
+
+describe('fleetFiltersToParamsRecord', () => {
+  it('omits keys whose values are at the default', () => {
+    expect(fleetFiltersToParamsRecord(DEFAULT_FLEET_FILTERS)).toEqual({})
+  })
+
+  it('includes non-default values', () => {
+    expect(
+      fleetFiltersToParamsRecord({ q: 'foo', framework: 'crewai', status: 'suspended', flaggedOnly: true }),
+    ).toEqual({ q: 'foo', framework: 'crewai', status: 'suspended', flagged: '1' })
+  })
+
+  it('round-trips with fleetFiltersFromParams', () => {
+    const original = { q: 'hello world', framework: 'crewai', status: 'active', flaggedOnly: true }
+    const round = fleetFiltersFromParams(new URLSearchParams(fleetFiltersToParamsRecord(original)))
+    expect(round).toEqual(original)
+  })
+})

--- a/dashboard/src/features/agents/fleetFilters.ts
+++ b/dashboard/src/features/agents/fleetFilters.ts
@@ -42,3 +42,23 @@ export function applyFleetFilters(
 export function frameworkOptions(agents: readonly FleetAgent[]): string[] {
   return Array.from(new Set(agents.map((a) => a.framework))).sort()
 }
+
+/** Parse `FleetFilters` from a URL `URLSearchParams` instance. */
+export function fleetFiltersFromParams(params: URLSearchParams): FleetFilters {
+  return {
+    q: params.get('q') ?? '',
+    framework: params.get('framework') ?? 'all',
+    status: params.get('status') ?? 'all',
+    flaggedOnly: params.get('flagged') === '1',
+  }
+}
+
+/** Produce a `URLSearchParams`-friendly object; default values are omitted. */
+export function fleetFiltersToParamsRecord(filters: FleetFilters): Record<string, string> {
+  const out: Record<string, string> = {}
+  if (filters.q.trim() !== '') out.q = filters.q
+  if (filters.framework !== 'all') out.framework = filters.framework
+  if (filters.status !== 'all') out.status = filters.status
+  if (filters.flaggedOnly) out.flagged = '1'
+  return out
+}

--- a/dashboard/src/features/agents/fleetFilters.ts
+++ b/dashboard/src/features/agents/fleetFilters.ts
@@ -1,0 +1,44 @@
+import type { FleetAgent } from './fleetTypes'
+
+/**
+ * Controlled state for the Fleet page filter bar.
+ *
+ * `framework` and `status` use `"all"` as the sentinel "no filter" value
+ * to mirror the segmented-button selection in `design/v1/fleet.jsx`.
+ */
+export interface FleetFilters {
+  q: string
+  framework: string
+  status: string
+  flaggedOnly: boolean
+}
+
+export const DEFAULT_FLEET_FILTERS: FleetFilters = {
+  q: '',
+  framework: 'all',
+  status: 'all',
+  flaggedOnly: false,
+}
+
+/** Apply filter state to a list of `FleetAgent` view-models. */
+export function applyFleetFilters(
+  agents: readonly FleetAgent[],
+  filters: FleetFilters,
+): FleetAgent[] {
+  const q = filters.q.trim().toLowerCase()
+  return agents.filter((a) => {
+    if (q) {
+      const haystack = `${a.name} ${a.owner ?? ''}`.toLowerCase()
+      if (!haystack.includes(q)) return false
+    }
+    if (filters.framework !== 'all' && a.framework !== filters.framework) return false
+    if (filters.status !== 'all' && a.status !== filters.status) return false
+    if (filters.flaggedOnly && !a.flagged) return false
+    return true
+  })
+}
+
+/** Distinct framework values present in the current agent list. */
+export function frameworkOptions(agents: readonly FleetAgent[]): string[] {
+  return Array.from(new Set(agents.map((a) => a.framework))).sort()
+}

--- a/dashboard/src/pages/FleetFilterBar.tsx
+++ b/dashboard/src/pages/FleetFilterBar.tsx
@@ -1,0 +1,66 @@
+import type { FleetFilters } from '../features/agents/fleetFilters'
+
+interface FleetFilterBarProps {
+  filters: FleetFilters
+  frameworks: readonly string[]
+  onChange: (next: FleetFilters) => void
+}
+
+const STATUS_OPTIONS = ['all', 'active', 'idle', 'suspended', 'error'] as const
+
+export function FleetFilterBar({ filters, frameworks, onChange }: FleetFilterBarProps) {
+  const frameworkOpts = ['all', ...frameworks]
+
+  return (
+    <div className="fleet-filters" data-testid="fleet-filters">
+      <input
+        type="search"
+        className="fleet-filters__search"
+        placeholder="search name, owner…"
+        value={filters.q}
+        onChange={(e) => onChange({ ...filters, q: e.target.value })}
+        data-testid="fleet-filter-search"
+        aria-label="Filter agents by name or owner"
+      />
+
+      <span className="fleet-filters__divider" aria-hidden="true" />
+      <span className="fleet-filters__label">framework:</span>
+      {frameworkOpts.map((fw) => (
+        <button
+          key={fw}
+          type="button"
+          className={`fleet-filters__chip${filters.framework === fw ? ' fleet-filters__chip--active' : ''}`}
+          onClick={() => onChange({ ...filters, framework: fw })}
+          data-testid={`fleet-filter-framework-${fw}`}
+        >
+          {fw}
+        </button>
+      ))}
+
+      <span className="fleet-filters__divider" aria-hidden="true" />
+      <span className="fleet-filters__label">status:</span>
+      {STATUS_OPTIONS.map((s) => (
+        <button
+          key={s}
+          type="button"
+          className={`fleet-filters__chip${filters.status === s ? ' fleet-filters__chip--active' : ''}`}
+          onClick={() => onChange({ ...filters, status: s })}
+          data-testid={`fleet-filter-status-${s}`}
+        >
+          {s}
+        </button>
+      ))}
+
+      <span className="fleet-filters__divider" aria-hidden="true" />
+      <label className="fleet-filters__flag">
+        <input
+          type="checkbox"
+          checked={filters.flaggedOnly}
+          onChange={(e) => onChange({ ...filters, flaggedOnly: e.target.checked })}
+          data-testid="fleet-filter-flagged"
+        />
+        <span>⚑ flagged only</span>
+      </label>
+    </div>
+  )
+}

--- a/dashboard/src/pages/FleetPage.css
+++ b/dashboard/src/pages/FleetPage.css
@@ -80,3 +80,77 @@
   opacity: 0.55;
   cursor: not-allowed;
 }
+
+/* ── View tabs ──────────────────────────────────────────────── */
+
+.fleet-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper-2);
+  padding: 0 24px;
+}
+
+.fleet-tabs__tab {
+  padding: 10px 16px;
+  font-size: 13px;
+  color: var(--ink-3);
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  user-select: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.fleet-tabs__tab:hover {
+  color: var(--ink);
+}
+
+.fleet-tabs__tab--active {
+  color: var(--ink);
+  border-bottom-color: var(--ink);
+  font-weight: 600;
+}
+
+.fleet-tabs__count {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  padding: 1px 5px;
+  background: var(--paper-3);
+  border-radius: 2px;
+  color: var(--ink-3);
+}
+
+.fleet-tabs__tab--active .fleet-tabs__count {
+  background: var(--ink);
+  color: var(--paper-2);
+}
+
+/* ── Tab-level empty state ──────────────────────────────────── */
+
+.fleet-empty {
+  padding: 60px 24px;
+  text-align: center;
+  color: var(--ink-3);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+.fleet-empty__title {
+  margin: 0 0 8px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--ink-4);
+}
+
+.fleet-empty__body {
+  margin: 0 auto;
+  font-size: 12px;
+  max-width: 420px;
+  line-height: 1.5;
+}

--- a/dashboard/src/pages/FleetPage.css
+++ b/dashboard/src/pages/FleetPage.css
@@ -154,3 +154,78 @@
   max-width: 420px;
   line-height: 1.5;
 }
+
+/* ── Filter bar ─────────────────────────────────────────────── */
+
+.fleet-filters {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: 10px 24px;
+  background: var(--paper-2);
+  border-bottom: 1px solid var(--line);
+}
+
+.fleet-filters__search {
+  padding: 5px 10px;
+  border: 1px solid var(--line-2);
+  border-radius: 3px;
+  font-size: 12px;
+  font-family: inherit;
+  min-width: 220px;
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.fleet-filters__search:focus {
+  outline: none;
+  border-color: var(--ink);
+}
+
+.fleet-filters__divider {
+  display: inline-block;
+  width: 1px;
+  height: 18px;
+  background: var(--line);
+  margin: 0 4px;
+}
+
+.fleet-filters__label {
+  font-size: 11px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  color: var(--ink-4);
+}
+
+.fleet-filters__chip {
+  height: 24px;
+  padding: 0 8px;
+  font-size: 11px;
+  font-family: inherit;
+  border: 1px solid var(--line-2);
+  background: var(--paper-2);
+  color: var(--ink);
+  border-radius: 3px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.fleet-filters__chip:hover {
+  background: var(--paper-3);
+}
+
+.fleet-filters__chip--active {
+  background: var(--ink);
+  color: var(--paper-2);
+  border-color: var(--ink);
+}
+
+.fleet-filters__flag {
+  display: inline-flex;
+  gap: 5px;
+  align-items: center;
+  font-size: 11px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  color: var(--danger);
+  cursor: pointer;
+}

--- a/dashboard/src/pages/FleetPage.css
+++ b/dashboard/src/pages/FleetPage.css
@@ -1,0 +1,82 @@
+/* ============================================================
+   Fleet page — chrome styles
+   Tokens defined in dashboard/src/styles.css (hi-fi palette).
+   ============================================================ */
+
+.fleet-page {
+  padding: 0;
+  background: var(--paper);
+  min-height: 100%;
+}
+
+.fleet-page__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 24px;
+  padding: 22px 24px 18px;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper-2);
+}
+
+.fleet-page__heading {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.fleet-page__title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.3px;
+  color: var(--ink);
+}
+
+.fleet-page__count {
+  margin-left: 8px;
+  font-size: 14px;
+  font-weight: 400;
+  color: var(--ink-4);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+.fleet-page__sub {
+  margin: 0;
+  color: var(--ink-3);
+  font-size: 13px;
+  max-width: 720px;
+}
+
+.fleet-page__actions {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.fleet-page__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  padding: 0 12px;
+  border: 1px solid var(--line-2);
+  background: var(--paper-2);
+  color: var(--ink);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 3px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.fleet-page__btn:hover {
+  background: var(--paper-3);
+  border-color: var(--line-3);
+}
+
+.fleet-page__btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}

--- a/dashboard/src/pages/FleetPage.test.tsx
+++ b/dashboard/src/pages/FleetPage.test.tsx
@@ -1,0 +1,205 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import type { UseQueryResult } from '@tanstack/react-query'
+import { FleetPage } from './FleetPage'
+import * as agentsApi from '../features/agents/api'
+import type { Agent } from '../features/agents/api'
+
+function makeClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+function mockQuery<T>(partial: Partial<UseQueryResult<T, Error>>): UseQueryResult<T, Error> {
+  return partial as unknown as UseQueryResult<T, Error>
+}
+
+function LocationProbe({ onChange }: { onChange: (search: string) => void }) {
+  const loc = useLocation()
+  onChange(loc.search)
+  return null
+}
+
+function renderFleet(initialPath = '/agents', onLocation?: (search: string) => void) {
+  return render(
+    <QueryClientProvider client={makeClient()}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          <Route path="/agents" element={<FleetPage />} />
+        </Routes>
+        {onLocation && <LocationProbe onChange={onLocation} />}
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: 'id-a',
+    name: 'alpha',
+    framework: 'langgraph',
+    status: 'active',
+    version: '0.1.0',
+    layer: null,
+    last_event: null,
+    recent_events: [],
+    recent_traces: [],
+    active_sessions: [],
+    session_count: 0,
+    policy_violations_count: 0,
+    tool_names: [],
+    metadata: {},
+    pid: null,
+    ...overrides,
+  }
+}
+
+afterEach(() => { vi.restoreAllMocks() })
+
+describe('FleetPage chrome', () => {
+  it('renders the page-head with N of M counter and disabled stub actions', async () => {
+    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+      mockQuery<Agent[]>({
+        data: [makeAgent({ id: '1' }), makeAgent({ id: '2', name: 'beta' })],
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    )
+    renderFleet()
+    await waitFor(() => expect(screen.getByTestId('fleet-page-head')).toBeInTheDocument())
+    expect(screen.getByTestId('fleet-page-count').textContent).toContain('2 of 2 agents')
+    expect(screen.getByTestId('fleet-action-register')).toBeDisabled()
+    expect(screen.getByTestId('fleet-action-export')).toBeDisabled()
+  })
+
+  it('switches to the Active Sessions empty-state when its tab is selected', async () => {
+    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+      mockQuery<Agent[]>({ data: [makeAgent()], isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    renderFleet()
+    fireEvent.click(screen.getByTestId('fleet-tab-sessions'))
+    await waitFor(() => expect(screen.getByTestId('fleet-sessions-empty')).toBeInTheDocument())
+    expect(screen.queryByTestId('agents-table')).not.toBeInTheDocument()
+  })
+})
+
+describe('FleetPage filter bar', () => {
+  it('narrows the agent list with the search input and updates the counter', async () => {
+    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+      mockQuery<Agent[]>({
+        data: [makeAgent({ id: '1', name: 'alpha' }), makeAgent({ id: '2', name: 'beta' })],
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    )
+    renderFleet()
+    await waitFor(() => expect(screen.getAllByTestId('agent-row')).toHaveLength(2))
+
+    fireEvent.change(screen.getByTestId('fleet-filter-search'), { target: { value: 'beta' } })
+    await waitFor(() => expect(screen.getAllByTestId('agent-row')).toHaveLength(1))
+    expect(screen.getByTestId('fleet-page-count').textContent).toContain('1 of 2 agents')
+  })
+
+  it('filters by status when a status chip is selected', async () => {
+    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+      mockQuery<Agent[]>({
+        data: [
+          makeAgent({ id: '1', status: 'active' }),
+          makeAgent({ id: '2', status: 'suspended' }),
+        ],
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    )
+    renderFleet()
+    await waitFor(() => expect(screen.getAllByTestId('agent-row')).toHaveLength(2))
+
+    fireEvent.click(screen.getByTestId('fleet-filter-status-suspended'))
+    await waitFor(() => expect(screen.getAllByTestId('agent-row')).toHaveLength(1))
+  })
+
+  it('honours the flagged-only checkbox', async () => {
+    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+      mockQuery<Agent[]>({
+        data: [
+          makeAgent({ id: '1', policy_violations_count: 0 }),
+          makeAgent({ id: '2', policy_violations_count: 200 }),
+        ],
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    )
+    renderFleet()
+    await waitFor(() => expect(screen.getAllByTestId('agent-row')).toHaveLength(2))
+
+    fireEvent.click(screen.getByTestId('fleet-filter-flagged'))
+    await waitFor(() => expect(screen.getAllByTestId('agent-row')).toHaveLength(1))
+  })
+})
+
+describe('FleetPage URL filter sync', () => {
+  it('hydrates filter state from the URL on first render', async () => {
+    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+      mockQuery<Agent[]>({
+        data: [
+          makeAgent({ id: '1', status: 'active' }),
+          makeAgent({ id: '2', status: 'suspended' }),
+        ],
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    )
+    renderFleet('/agents?status=suspended')
+    await waitFor(() => expect(screen.getAllByTestId('agent-row')).toHaveLength(1))
+    expect(screen.getByTestId('fleet-filter-status-suspended')).toHaveClass('fleet-filters__chip--active')
+  })
+
+  it('writes non-default filter changes back to the URL', async () => {
+    let lastSearch = ''
+    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+      mockQuery<Agent[]>({ data: [makeAgent()], isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    renderFleet('/agents', (s) => { lastSearch = s })
+
+    fireEvent.change(screen.getByTestId('fleet-filter-search'), { target: { value: 'beta' } })
+    await waitFor(() => expect(lastSearch).toContain('q=beta'))
+
+    fireEvent.change(screen.getByTestId('fleet-filter-search'), { target: { value: '' } })
+    await waitFor(() => expect(lastSearch).not.toContain('q='))
+  })
+})
+
+describe('FleetPage loading and error states', () => {
+  it('renders skeleton rows while loading', () => {
+    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+      mockQuery<Agent[]>({ data: undefined, isLoading: true, isError: false, refetch: vi.fn() }),
+    )
+    renderFleet()
+    expect(screen.getAllByTestId('agent-row-skeleton')).toHaveLength(5)
+  })
+
+  it('renders an empty-state callout when the agent list is empty', () => {
+    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+      mockQuery<Agent[]>({ data: [], isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    renderFleet()
+    expect(screen.getByTestId('agents-empty')).toBeInTheDocument()
+  })
+
+  it('renders the error banner with retry when the query fails', () => {
+    const refetch = vi.fn()
+    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+      mockQuery<Agent[]>({ data: undefined, isLoading: false, isError: true, refetch }),
+    )
+    renderFleet()
+    expect(screen.getByTestId('agents-error')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/dashboard/src/pages/FleetPage.tsx
+++ b/dashboard/src/pages/FleetPage.tsx
@@ -7,8 +7,16 @@ import {
   createColumnHelper,
   type SortingState,
 } from '@tanstack/react-table'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useAgentsQuery, type Agent } from '../features/agents/api'
+import { toFleetAgent } from '../features/agents/fleetTypes'
+import {
+  DEFAULT_FLEET_FILTERS,
+  applyFleetFilters,
+  frameworkOptions,
+  type FleetFilters,
+} from '../features/agents/fleetFilters'
+import { FleetFilterBar } from './FleetFilterBar'
 import './FleetPage.css'
 
 const STATUS_COLOR: Record<string, string> = {
@@ -91,10 +99,23 @@ export function FleetPage() {
   const { data: agents, isLoading, isError, refetch } = useAgentsQuery()
   const [sorting, setSorting] = useState<SortingState>([])
   const [view, setView] = useState<FleetView>('agents')
+  const [filters, setFilters] = useState<FleetFilters>(DEFAULT_FLEET_FILTERS)
+
+  const fleetAgents = useMemo(() => (agents ?? []).map(toFleetAgent), [agents])
+  const frameworks = useMemo(() => frameworkOptions(fleetAgents), [fleetAgents])
+  const filteredFleet = useMemo(
+    () => applyFleetFilters(fleetAgents, filters),
+    [fleetAgents, filters],
+  )
+  const filteredIds = useMemo(() => new Set(filteredFleet.map((a) => a.id)), [filteredFleet])
+  const tableData = useMemo(
+    () => (agents ?? []).filter((a) => filteredIds.has(a.id)),
+    [agents, filteredIds],
+  )
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
-    data: agents ?? [],
+    data: tableData,
     columns,
     state: { sorting },
     onSortingChange: setSorting,
@@ -103,6 +124,7 @@ export function FleetPage() {
   })
 
   const totalAgents = agents?.length ?? 0
+  const filteredCount = filteredFleet.length
 
   return (
     <main className="fleet-page" data-testid="fleet-page">
@@ -111,7 +133,7 @@ export function FleetPage() {
           <h1 className="fleet-page__title">
             Fleet
             <span className="fleet-page__count" data-testid="fleet-page-count">
-              · {totalAgents} agents
+              · {filteredCount} of {totalAgents} agents
             </span>
           </h1>
           <p className="fleet-page__sub">
@@ -138,7 +160,7 @@ export function FleetPage() {
           data-testid="fleet-tab-agents"
         >
           Agents
-          <span className="fleet-tabs__count">{totalAgents}</span>
+          <span className="fleet-tabs__count">{filteredCount}</span>
         </button>
         <button
           type="button"
@@ -160,6 +182,14 @@ export function FleetPage() {
             Detail drawer (AAASM-1052).
           </p>
         </div>
+      )}
+
+      {view === 'agents' && (
+        <FleetFilterBar
+          filters={filters}
+          frameworks={frameworks}
+          onChange={setFilters}
+        />
       )}
 
       {view === 'agents' && isError && (

--- a/dashboard/src/pages/FleetPage.tsx
+++ b/dashboard/src/pages/FleetPage.tsx
@@ -9,6 +9,7 @@ import {
 } from '@tanstack/react-table'
 import { useState } from 'react'
 import { useAgentsQuery, type Agent } from '../features/agents/api'
+import './FleetPage.css'
 
 const STATUS_COLOR: Record<string, string> = {
   active: '#16a34a',
@@ -98,9 +99,31 @@ export function FleetPage() {
     getSortedRowModel: getSortedRowModel(),
   })
 
+  const totalAgents = agents?.length ?? 0
+
   return (
-    <main style={{ padding: '1.5rem' }}>
-      <h1>Agents</h1>
+    <main className="fleet-page" data-testid="fleet-page">
+      <header className="fleet-page__head" data-testid="fleet-page-head">
+        <div className="fleet-page__heading">
+          <h1 className="fleet-page__title">
+            Fleet
+            <span className="fleet-page__count" data-testid="fleet-page-count">
+              · {totalAgents} agents
+            </span>
+          </h1>
+          <p className="fleet-page__sub">
+            All registered agents across frameworks. Click a row to inspect, or select multiple for bulk actions.
+          </p>
+        </div>
+        <div className="fleet-page__actions">
+          <button type="button" className="fleet-page__btn" disabled data-testid="fleet-action-register">
+            + register agent
+          </button>
+          <button type="button" className="fleet-page__btn" disabled data-testid="fleet-action-export">
+            ⏏ export csv
+          </button>
+        </div>
+      </header>
 
       {isError && (
         <div

--- a/dashboard/src/pages/FleetPage.tsx
+++ b/dashboard/src/pages/FleetPage.tsx
@@ -84,7 +84,7 @@ const columns = [
   }),
 ]
 
-export function AgentsPage() {
+export function FleetPage() {
   const { data: agents, isLoading, isError, refetch } = useAgentsQuery()
   const [sorting, setSorting] = useState<SortingState>([])
 

--- a/dashboard/src/pages/FleetPage.tsx
+++ b/dashboard/src/pages/FleetPage.tsx
@@ -7,12 +7,14 @@ import {
   createColumnHelper,
   type SortingState,
 } from '@tanstack/react-table'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { useAgentsQuery, type Agent } from '../features/agents/api'
 import { toFleetAgent } from '../features/agents/fleetTypes'
 import {
-  DEFAULT_FLEET_FILTERS,
   applyFleetFilters,
+  fleetFiltersFromParams,
+  fleetFiltersToParamsRecord,
   frameworkOptions,
   type FleetFilters,
 } from '../features/agents/fleetFilters'
@@ -99,7 +101,18 @@ export function FleetPage() {
   const { data: agents, isLoading, isError, refetch } = useAgentsQuery()
   const [sorting, setSorting] = useState<SortingState>([])
   const [view, setView] = useState<FleetView>('agents')
-  const [filters, setFilters] = useState<FleetFilters>(DEFAULT_FLEET_FILTERS)
+
+  const [searchParams, setSearchParams] = useSearchParams()
+  const filters = useMemo<FleetFilters>(
+    () => fleetFiltersFromParams(searchParams),
+    [searchParams],
+  )
+  const setFilters = useCallback(
+    (next: FleetFilters) => {
+      setSearchParams(fleetFiltersToParamsRecord(next), { replace: true })
+    },
+    [setSearchParams],
+  )
 
   const fleetAgents = useMemo(() => (agents ?? []).map(toFleetAgent), [agents])
   const frameworks = useMemo(() => frameworkOptions(fleetAgents), [fleetAgents])

--- a/dashboard/src/pages/FleetPage.tsx
+++ b/dashboard/src/pages/FleetPage.tsx
@@ -85,9 +85,12 @@ const columns = [
   }),
 ]
 
+type FleetView = 'agents' | 'sessions'
+
 export function FleetPage() {
   const { data: agents, isLoading, isError, refetch } = useAgentsQuery()
   const [sorting, setSorting] = useState<SortingState>([])
+  const [view, setView] = useState<FleetView>('agents')
 
   // eslint-disable-next-line react-hooks/incompatible-library
   const table = useReactTable({
@@ -125,7 +128,41 @@ export function FleetPage() {
         </div>
       </header>
 
-      {isError && (
+      <nav className="fleet-tabs" data-testid="fleet-tabs" role="tablist" aria-label="Fleet views">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={view === 'agents'}
+          className={`fleet-tabs__tab${view === 'agents' ? ' fleet-tabs__tab--active' : ''}`}
+          onClick={() => setView('agents')}
+          data-testid="fleet-tab-agents"
+        >
+          Agents
+          <span className="fleet-tabs__count">{totalAgents}</span>
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={view === 'sessions'}
+          className={`fleet-tabs__tab${view === 'sessions' ? ' fleet-tabs__tab--active' : ''}`}
+          onClick={() => setView('sessions')}
+          data-testid="fleet-tab-sessions"
+        >
+          Active Sessions
+        </button>
+      </nav>
+
+      {view === 'sessions' && (
+        <div className="fleet-empty" data-testid="fleet-sessions-empty">
+          <p className="fleet-empty__title">Active sessions view</p>
+          <p className="fleet-empty__body">
+            Wired in a follow-up sub-task. Tracking continues per agent on the Agent
+            Detail drawer (AAASM-1052).
+          </p>
+        </div>
+      )}
+
+      {view === 'agents' && isError && (
         <div
           data-testid="agents-error"
           style={{ color: '#dc2626', marginBottom: '1rem', display: 'flex', gap: '1rem', alignItems: 'center' }}
@@ -135,7 +172,7 @@ export function FleetPage() {
         </div>
       )}
 
-      {!isLoading && !isError && agents?.length === 0 && (
+      {view === 'agents' && !isLoading && !isError && agents?.length === 0 && (
         <p data-testid="agents-empty">
           No agents registered yet.{' '}
           <a href="https://docs.agent-assembly.io/quickstart" target="_blank" rel="noreferrer">
@@ -144,6 +181,7 @@ export function FleetPage() {
         </p>
       )}
 
+      {view === 'agents' && (
       <table data-testid="agents-table" style={{ width: '100%', borderCollapse: 'collapse' }}>
         <thead>
           {table.getHeaderGroups().map(hg => (
@@ -190,6 +228,7 @@ export function FleetPage() {
           )}
         </tbody>
       </table>
+      )}
     </main>
   )
 }


### PR DESCRIPTION
## Description

Second slice of the F90 Fleet + Agent Detail Story (AAASM-217). Replaces the bare `<h1>Agents</h1>` with the hi-fi Fleet page shell from `design/v1/fleet.jsx`:

- **Component rename**: `AgentsPage.tsx → FleetPage.tsx` for naming consistency with the canonical route id `fleet` defined in `dashboard/src/routes.ts` (AAASM-94). The **route path stays `/agents`** per the canonical 12-route contract — no `/fleet` redirect, no nav-label change.
- **Page-head**: title \"Fleet\", `N of M agents` counter, and disabled stub `+ register agent` / `⏏ export csv` buttons.
- **View tabs**: Agents (renders the existing table + loading/empty/error states) and Active Sessions (empty-state callout pointing to the follow-up sub-task).
- **Filter bar**: text search over name/owner, framework segmented buttons (derived from the live agent list), status segmented buttons, flagged-only checkbox.
- **URL sync**: filter state ↔ `?q=`, `?framework=`, `?status=`, `?flagged=1` via `useSearchParams`. Defaults are stripped from the URL; changes use `replace: true` so filter clicks don't pollute history.

Table rendering, sortable columns, row navigation, and bulk-select land in AAASM-1050 — out of scope here.

## Type of Change

- [x] ✨ New feature
- [x] ♻️ Refactoring _(AgentsPage → FleetPage rename)_
- [ ] 🐛 Bug fix
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

The `/agents` route still resolves and the page still renders an agent registry. The only file rename is `AgentsPage.tsx → FleetPage.tsx` with imports updated in `App.tsx` and `features/agents/api.test.tsx`.

## Scope reconciliation

Three of the originally-planned AC items were already delivered by other tickets after this Story was scoped:

| Originally planned | Status now |
|---|---|
| Route rename `/agents → /fleet` + redirect | **Dropped** — AAASM-94 locked `/agents` as the canonical path. |
| `AppShell` nav label \"Agents\" → \"Fleet\" | **Already done** — `routes.ts` already labels id `fleet` as \"Fleet\". |
| Hi-fi design tokens added to `styles.css` | **Already done** — AAASM-1322 / AAASM-94 added the full `--paper / --ink / --line / --ok / --warn / --danger / --info / --scrub` set. |

The JIRA ticket description was updated in-flight to reflect this. See the `Scope reconciliation` comment on AAASM-1048.

## Related Issues

- Related Jira ticket: [AAASM-1048](https://lightning-dust-mite.atlassian.net/browse/AAASM-1048) (parent Story: [AAASM-217](https://lightning-dust-mite.atlassian.net/browse/AAASM-217), Epic [AAASM-197](https://lightning-dust-mite.atlassian.net/browse/AAASM-197))
- Builds on PR #343 (AAASM-1047 — fleet primitives + view-model)

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required

Local validation in `dashboard/`:

```
pnpm type-check    # tsc --noEmit, clean
pnpm lint          # eslint --max-warnings 0, clean
pnpm test          # 23 files / 262 tests passing (incl. 25 new)
pnpm build         # tsc + vite build, clean
```

New tests:
- `features/agents/fleetFilters.test.ts` (14) — `applyFleetFilters` defaults / search / framework / status / flagged / AND-combined; `frameworkOptions` sorted-distinct + empty; `fleetFiltersFromParams` full read + defaults + non-\"1\" flagged; `fleetFiltersToParamsRecord` omit-defaults + include-non-defaults + round-trip.
- `pages/FleetPage.test.tsx` (11) — page-head counter, tab switching, filter search/status/flagged narrowing, URL hydration on first render, URL write-back on filter change, loading/empty/error states.

## Checklist

- [x] Code follows project style guidelines (`pnpm lint`, `pnpm type-check` clean)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a — no public docs touched)
- [x] All CI checks passing (verified locally)
- [x] Commits are small and follow the Gitmoji convention (6 commits, one logical change each)

[AAASM-1048]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ