### PR TITLE
[AAASM-1067] ✨ (trace): Build trace timeline component with severity color tokens

### DIFF
--- a/dashboard/src/components/trace/TraceTimeline.css
+++ b/dashboard/src/components/trace/TraceTimeline.css
@@ -1,0 +1,81 @@
+/* ============================================================
+   TraceTimeline — severity color tokens (AAASM-1067)
+   ============================================================
+
+   Each row's background is keyed off the data-severity attribute.
+   All colors come from CSS variables defined in src/styles.css.
+   Adding a new severity = adding a new selector here; no other
+   file needs to change.
+   ============================================================ */
+
+.trace-timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.trace-event {
+  display: grid;
+  grid-template-columns: 9rem 1.5rem 8rem 1fr 5rem;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  font-size: 0.875rem;
+  background: var(--paper-2);
+  color: var(--ink);
+}
+
+.trace-event[data-severity='critical'] {
+  background: var(--danger-bg);
+  border-color: var(--danger);
+}
+
+.trace-event[data-severity='warning'] {
+  background: var(--warn-bg);
+  border-color: var(--warn);
+}
+
+.trace-event[data-severity='info'] {
+  background: var(--info-bg);
+  border-color: var(--info);
+}
+
+.trace-event[data-severity='neutral'] {
+  background: var(--paper);
+}
+
+.trace-event__time {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.75rem;
+  color: var(--ink-3);
+}
+
+.trace-event__icon {
+  font-size: 1rem;
+  text-align: center;
+  color: var(--ink-2);
+}
+
+.trace-event__agent {
+  font-weight: 600;
+  color: var(--ink-2);
+}
+
+.trace-event__preview {
+  color: var(--ink-3);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trace-event__duration {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.75rem;
+  color: var(--ink-4);
+  text-align: right;
+}

--- a/dashboard/src/components/trace/TraceTimeline.css
+++ b/dashboard/src/components/trace/TraceTimeline.css
@@ -49,6 +49,14 @@
   background: var(--paper);
 }
 
+/* Credential leak events always render with the warning tone regardless
+   of the severity the gateway assigns. Severity remains on
+   data-severity for filtering; only the visual is overridden. */
+.trace-event[data-event-type='credential_leak'] {
+  background: var(--warn-bg);
+  border-color: var(--warn);
+}
+
 .trace-event__time {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 0.75rem;

--- a/dashboard/src/components/trace/TraceTimeline.test.tsx
+++ b/dashboard/src/components/trace/TraceTimeline.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { TraceTimeline } from './TraceTimeline'
+import type { TraceEvent } from '../../features/trace/types'
+
+const BASE_EVENT: Omit<TraceEvent, 'id' | 'severity' | 'type'> = {
+  timestamp: '2026-04-23T14:23:01Z',
+  agent: 'support-agent',
+  durationMs: 100,
+  payloadPreview: 'preview text',
+  payload: {},
+}
+
+const MIXED_EVENTS: TraceEvent[] = [
+  { ...BASE_EVENT, id: 'e1', type: 'policy_violation', severity: 'critical' },
+  { ...BASE_EVENT, id: 'e2', type: 'credential_leak', severity: 'warning' },
+  { ...BASE_EVENT, id: 'e3', type: 'llm_call', severity: 'info' },
+  { ...BASE_EVENT, id: 'e4', type: 'tool_call' },
+]
+
+describe('TraceTimeline', () => {
+  it('renders one row per event with timestamp, agent, preview, duration', () => {
+    render(<TraceTimeline events={MIXED_EVENTS} />)
+    const rows = screen.getAllByTestId('trace-event')
+    expect(rows).toHaveLength(4)
+    expect(rows[0]).toHaveTextContent('support-agent')
+    expect(rows[0]).toHaveTextContent('preview text')
+    expect(rows[0]).toHaveTextContent('100')
+  })
+
+  it('reflects severity on each row via data-severity', () => {
+    render(<TraceTimeline events={MIXED_EVENTS} />)
+    const rows = screen.getAllByTestId('trace-event')
+    expect(rows[0]).toHaveAttribute('data-severity', 'critical')
+    expect(rows[1]).toHaveAttribute('data-severity', 'warning')
+    expect(rows[2]).toHaveAttribute('data-severity', 'info')
+    expect(rows[3]).toHaveAttribute('data-severity', 'neutral')
+  })
+
+  it('exposes the event type on each row via data-event-type', () => {
+    render(<TraceTimeline events={MIXED_EVENTS} />)
+    const rows = screen.getAllByTestId('trace-event')
+    expect(rows[0]).toHaveAttribute('data-event-type', 'policy_violation')
+    expect(rows[1]).toHaveAttribute('data-event-type', 'credential_leak')
+  })
+
+  it('renders an empty <ol> when given no events', () => {
+    render(<TraceTimeline events={[]} />)
+    expect(screen.getByTestId('trace-timeline')).toBeInTheDocument()
+    expect(screen.queryAllByTestId('trace-event')).toHaveLength(0)
+  })
+})

--- a/dashboard/src/components/trace/TraceTimeline.test.tsx
+++ b/dashboard/src/components/trace/TraceTimeline.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, expect, it } from 'vitest'
 import { TraceTimeline } from './TraceTimeline'
 import type { TraceEvent } from '../../features/trace/types'
@@ -48,5 +49,57 @@ describe('TraceTimeline', () => {
     render(<TraceTimeline events={[]} />)
     expect(screen.getByTestId('trace-timeline')).toBeInTheDocument()
     expect(screen.queryAllByTestId('trace-event')).toHaveLength(0)
+  })
+
+  it('shows the violation reason in a tooltip on policy_violation rows when hovered', async () => {
+    const events: TraceEvent[] = [
+      {
+        ...BASE_EVENT,
+        id: 'pv',
+        type: 'policy_violation',
+        severity: 'critical',
+        violationReason: 'refund > $100 requires human approval',
+      },
+    ]
+    render(<TraceTimeline events={events} />)
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+    const row = screen.getByTestId('trace-event')
+    await userEvent.hover(row.querySelector('.trace-event__icon')!)
+    expect(screen.getByRole('tooltip')).toHaveTextContent('refund > $100 requires human approval')
+  })
+
+  it('does not wrap the icon in a tooltip when violationReason is missing', () => {
+    const events: TraceEvent[] = [
+      { ...BASE_EVENT, id: 'pv-no-reason', type: 'policy_violation', severity: 'critical' },
+    ]
+    render(<TraceTimeline events={events} />)
+
+    const row = screen.getByTestId('trace-event')
+    expect(row.querySelector('.tooltip-wrapper')).toBeNull()
+  })
+
+  it('does not wrap non-violation events in a tooltip even with violationReason set', () => {
+    const events: TraceEvent[] = [
+      // Defensive: violationReason set but type isn't a policy violation — should be ignored
+      { ...BASE_EVENT, id: 'llm', type: 'llm_call', severity: 'info', violationReason: 'noise' },
+    ]
+    render(<TraceTimeline events={events} />)
+
+    const row = screen.getByTestId('trace-event')
+    expect(row.querySelector('.tooltip-wrapper')).toBeNull()
+  })
+
+  it('flags credential leak events for the warning tone via data-event-type', () => {
+    const events: TraceEvent[] = [
+      { ...BASE_EVENT, id: 'cl', type: 'credential_leak', severity: 'info' },
+    ]
+    render(<TraceTimeline events={events} />)
+
+    // The CSS rule keys off data-event-type to override the severity background
+    // (severity stays on data-severity so the filter can still find/hide the row).
+    const row = screen.getByTestId('trace-event')
+    expect(row).toHaveAttribute('data-event-type', 'credential_leak')
+    expect(row).toHaveAttribute('data-severity', 'info')
   })
 })

--- a/dashboard/src/components/trace/TraceTimeline.tsx
+++ b/dashboard/src/components/trace/TraceTimeline.tsx
@@ -1,4 +1,5 @@
 import type { TraceEvent, TraceSeverity } from '../../features/trace/types'
+import { Tooltip } from '../Tooltip'
 import './TraceTimeline.css'
 
 const ICON_BY_TYPE: Record<string, string> = {
@@ -26,6 +27,11 @@ export function TraceTimeline({ events }: TraceTimelineProps) {
       {events.map(event => {
         const sev = severityKey(event)
         const icon = ICON_BY_TYPE[event.type] ?? '·'
+        const tooltipReason =
+          event.type === 'policy_violation' ? event.violationReason : undefined
+        const iconNode = (
+          <span className="trace-event__icon" aria-hidden="true">{icon}</span>
+        )
         return (
           <li
             key={event.id}
@@ -35,7 +41,11 @@ export function TraceTimeline({ events }: TraceTimelineProps) {
             data-event-type={event.type}
           >
             <span className="trace-event__time">{formatTime(event.timestamp)}</span>
-            <span className="trace-event__icon" aria-hidden="true">{icon}</span>
+            {tooltipReason ? (
+              <Tooltip content={tooltipReason}>{iconNode}</Tooltip>
+            ) : (
+              iconNode
+            )}
             <span className="trace-event__agent">{event.agent}</span>
             <span className="trace-event__preview">{event.payloadPreview}</span>
             <span className="trace-event__duration">{event.durationMs}&nbsp;ms</span>

--- a/dashboard/src/components/trace/TraceTimeline.tsx
+++ b/dashboard/src/components/trace/TraceTimeline.tsx
@@ -1,0 +1,46 @@
+import type { TraceEvent, TraceSeverity } from '../../features/trace/types'
+
+const ICON_BY_TYPE: Record<string, string> = {
+  llm_call: '⌬',
+  tool_call: '⌗',
+  policy_violation: '⚠',
+  credential_leak: '⚿',
+}
+
+function severityKey(event: TraceEvent): TraceSeverity | 'neutral' {
+  return event.severity ?? 'neutral'
+}
+
+function formatTime(iso: string): string {
+  return iso.replace('T', ' ').replace(/\.\d+Z$/, 'Z').replace(/Z$/, ' UTC')
+}
+
+export interface TraceTimelineProps {
+  readonly events: readonly TraceEvent[]
+}
+
+export function TraceTimeline({ events }: TraceTimelineProps) {
+  return (
+    <ol className="trace-timeline" data-testid="trace-timeline">
+      {events.map(event => {
+        const sev = severityKey(event)
+        const icon = ICON_BY_TYPE[event.type] ?? '·'
+        return (
+          <li
+            key={event.id}
+            className="trace-event"
+            data-testid="trace-event"
+            data-severity={sev}
+            data-event-type={event.type}
+          >
+            <span className="trace-event__time">{formatTime(event.timestamp)}</span>
+            <span className="trace-event__icon" aria-hidden="true">{icon}</span>
+            <span className="trace-event__agent">{event.agent}</span>
+            <span className="trace-event__preview">{event.payloadPreview}</span>
+            <span className="trace-event__duration">{event.durationMs}&nbsp;ms</span>
+          </li>
+        )
+      })}
+    </ol>
+  )
+}

--- a/dashboard/src/components/trace/TraceTimeline.tsx
+++ b/dashboard/src/components/trace/TraceTimeline.tsx
@@ -1,4 +1,5 @@
 import type { TraceEvent, TraceSeverity } from '../../features/trace/types'
+import './TraceTimeline.css'
 
 const ICON_BY_TYPE: Record<string, string> = {
   llm_call: '⌬',

--- a/dashboard/src/components/trace/TraceTimelineFilter.css
+++ b/dashboard/src/components/trace/TraceTimelineFilter.css
@@ -1,0 +1,28 @@
+/* ============================================================
+   TraceTimelineFilter — severity checkbox group (AAASM-1067)
+   ============================================================ */
+
+.trace-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.75rem;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--paper-2);
+  font-size: 0.875rem;
+  color: var(--ink-2);
+}
+
+.trace-filter__option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  cursor: pointer;
+  user-select: none;
+}
+
+.trace-filter__option input[type='checkbox'] {
+  cursor: pointer;
+}

--- a/dashboard/src/components/trace/TraceTimelineFilter.test.tsx
+++ b/dashboard/src/components/trace/TraceTimelineFilter.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
-import { TraceTimelineFilter, ALL_ON } from './TraceTimelineFilter'
-import type { SeverityFilter } from './TraceTimelineFilter'
+import { TraceTimelineFilter } from './TraceTimelineFilter'
+import { ALL_ON, type SeverityFilter } from './severityFilter'
 
 function setup(initial: SeverityFilter = ALL_ON) {
   const onChange = vi.fn<(next: SeverityFilter) => void>()

--- a/dashboard/src/components/trace/TraceTimelineFilter.test.tsx
+++ b/dashboard/src/components/trace/TraceTimelineFilter.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { TraceTimelineFilter, ALL_ON } from './TraceTimelineFilter'
+import type { SeverityFilter } from './TraceTimelineFilter'
+
+function setup(initial: SeverityFilter = ALL_ON) {
+  const onChange = vi.fn<(next: SeverityFilter) => void>()
+  const utils = render(<TraceTimelineFilter value={initial} onChange={onChange} />)
+  return { onChange, ...utils }
+}
+
+describe('TraceTimelineFilter', () => {
+  it('renders four checkboxes labelled Critical / Warning / Info / Neutral, all on by default', () => {
+    setup()
+    expect(screen.getByTestId('trace-filter-critical')).toBeChecked()
+    expect(screen.getByTestId('trace-filter-warning')).toBeChecked()
+    expect(screen.getByTestId('trace-filter-info')).toBeChecked()
+    expect(screen.getByTestId('trace-filter-neutral')).toBeChecked()
+    expect(screen.getByLabelText('Critical')).toBeInTheDocument()
+  })
+
+  it('emits a new filter with the toggled key flipped on click', async () => {
+    const { onChange } = setup()
+    await userEvent.click(screen.getByTestId('trace-filter-warning'))
+    expect(onChange).toHaveBeenCalledWith({ ...ALL_ON, warning: false })
+  })
+
+  it('reflects controlled value — unchecked keys show as unchecked', () => {
+    setup({ critical: true, warning: false, info: true, neutral: false })
+    expect(screen.getByTestId('trace-filter-critical')).toBeChecked()
+    expect(screen.getByTestId('trace-filter-warning')).not.toBeChecked()
+    expect(screen.getByTestId('trace-filter-info')).toBeChecked()
+    expect(screen.getByTestId('trace-filter-neutral')).not.toBeChecked()
+  })
+
+  it('clears the filter (resets to ALL_ON) when Escape is pressed', async () => {
+    const { onChange } = setup({ critical: false, warning: false, info: false, neutral: false })
+    await userEvent.click(screen.getByTestId('trace-filter-critical'))
+    onChange.mockClear()
+    screen.getByTestId('trace-filter').focus()
+    await userEvent.keyboard('{Escape}')
+    expect(onChange).toHaveBeenCalledWith(ALL_ON)
+  })
+
+  it('exposes role=group with an accessible label for screen readers', () => {
+    setup()
+    expect(screen.getByRole('group', { name: /Filter trace events by severity/i })).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/trace/TraceTimelineFilter.tsx
+++ b/dashboard/src/components/trace/TraceTimelineFilter.tsx
@@ -1,19 +1,6 @@
 import type { KeyboardEvent } from 'react'
-import type { TraceSeverity } from '../../features/trace/types'
+import { ALL_ON, SEVERITY_KEYS, type SeverityFilter, type SeverityKey } from './severityFilter'
 import './TraceTimelineFilter.css'
-
-export type SeverityKey = TraceSeverity | 'neutral'
-
-export const SEVERITY_KEYS: readonly SeverityKey[] = ['critical', 'warning', 'info', 'neutral'] as const
-
-export type SeverityFilter = Readonly<Record<SeverityKey, boolean>>
-
-export const ALL_ON: SeverityFilter = {
-  critical: true,
-  warning: true,
-  info: true,
-  neutral: true,
-}
 
 export interface TraceTimelineFilterProps {
   readonly value: SeverityFilter

--- a/dashboard/src/components/trace/TraceTimelineFilter.tsx
+++ b/dashboard/src/components/trace/TraceTimelineFilter.tsx
@@ -1,0 +1,62 @@
+import type { KeyboardEvent } from 'react'
+import type { TraceSeverity } from '../../features/trace/types'
+import './TraceTimelineFilter.css'
+
+export type SeverityKey = TraceSeverity | 'neutral'
+
+export const SEVERITY_KEYS: readonly SeverityKey[] = ['critical', 'warning', 'info', 'neutral'] as const
+
+export type SeverityFilter = Readonly<Record<SeverityKey, boolean>>
+
+export const ALL_ON: SeverityFilter = {
+  critical: true,
+  warning: true,
+  info: true,
+  neutral: true,
+}
+
+export interface TraceTimelineFilterProps {
+  readonly value: SeverityFilter
+  readonly onChange: (next: SeverityFilter) => void
+}
+
+const LABELS: Record<SeverityKey, string> = {
+  critical: 'Critical',
+  warning: 'Warning',
+  info: 'Info',
+  neutral: 'Neutral',
+}
+
+export function TraceTimelineFilter({ value, onChange }: TraceTimelineFilterProps) {
+  const toggle = (key: SeverityKey) => onChange({ ...value, [key]: !value[key] })
+  const clear = () => onChange(ALL_ON)
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      clear()
+    }
+  }
+
+  return (
+    <div
+      className="trace-filter"
+      data-testid="trace-filter"
+      role="group"
+      aria-label="Filter trace events by severity"
+      onKeyDown={handleKeyDown}
+    >
+      {SEVERITY_KEYS.map(key => (
+        <label key={key} className="trace-filter__option">
+          <input
+            type="checkbox"
+            checked={value[key]}
+            onChange={() => toggle(key)}
+            data-testid={`trace-filter-${key}`}
+          />
+          <span>{LABELS[key]}</span>
+        </label>
+      ))}
+    </div>
+  )
+}

--- a/dashboard/src/components/trace/severityFilter.ts
+++ b/dashboard/src/components/trace/severityFilter.ts
@@ -1,0 +1,14 @@
+import type { TraceSeverity } from '../../features/trace/types'
+
+export type SeverityKey = TraceSeverity | 'neutral'
+
+export const SEVERITY_KEYS: readonly SeverityKey[] = ['critical', 'warning', 'info', 'neutral'] as const
+
+export type SeverityFilter = Readonly<Record<SeverityKey, boolean>>
+
+export const ALL_ON: SeverityFilter = {
+  critical: true,
+  warning: true,
+  info: true,
+  neutral: true,
+}

--- a/dashboard/src/features/trace/types.ts
+++ b/dashboard/src/features/trace/types.ts
@@ -19,4 +19,6 @@ export interface TraceEvent {
   readonly payload: unknown
   readonly severity?: TraceSeverity
   readonly redactedFields?: readonly string[]
+  /** Human-readable reason the gateway recorded for a policy violation. Surfaced as a hover tooltip on the timeline row. */
+  readonly violationReason?: string
 }

--- a/dashboard/src/pages/TraceViewPage.test.tsx
+++ b/dashboard/src/pages/TraceViewPage.test.tsx
@@ -128,23 +128,70 @@ describe('TraceViewPage', () => {
     expect(refetch).toHaveBeenCalledTimes(1)
   })
 
-  it('shows empty state when no events', () => {
+  it('shows the shared EmptyState when the session has no events', () => {
     vi.spyOn(traceApi, 'useTraceQuery').mockReturnValue(
       mockTraceQuery({ data: [], isLoading: false, isError: false, refetch: vi.fn() }),
     )
     renderAt('/agents/agent-001/trace/session-abc')
 
-    expect(screen.getByTestId('trace-empty')).toBeInTheDocument()
+    const empty = screen.getByTestId('empty-state')
+    expect(empty).toBeInTheDocument()
+    expect(empty).toHaveTextContent('No events recorded for this session')
+    // Filter must not render when there are no events to filter.
+    expect(screen.queryByTestId('trace-filter')).not.toBeInTheDocument()
   })
 
-  it('mounts the timeline placeholder slot with event count when ready', () => {
+  it('mounts the timeline + filter when events are present', () => {
     vi.spyOn(traceApi, 'useTraceQuery').mockReturnValue(
       mockTraceQuery({ data: [MOCK_EVENT], isLoading: false, isError: false, refetch: vi.fn() }),
     )
     renderAt('/agents/agent-001/trace/session-abc')
 
-    const placeholder = screen.getByTestId('trace-timeline-placeholder')
-    expect(placeholder).toBeInTheDocument()
-    expect(placeholder).toHaveTextContent('1 event')
+    expect(screen.getByTestId('trace-filter')).toBeInTheDocument()
+    expect(screen.getByTestId('trace-timeline')).toBeInTheDocument()
+    expect(screen.getAllByTestId('trace-event')).toHaveLength(1)
+  })
+
+  it('hides rows whose severity is unchecked in the filter', async () => {
+    const events: TraceEvent[] = [
+      { ...MOCK_EVENT, id: 'a', severity: 'critical', type: 'policy_violation' },
+      { ...MOCK_EVENT, id: 'b', severity: 'info', type: 'llm_call' },
+    ]
+    vi.spyOn(traceApi, 'useTraceQuery').mockReturnValue(
+      mockTraceQuery({ data: events, isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    renderAt('/agents/agent-001/trace/session-abc')
+
+    expect(screen.getAllByTestId('trace-event')).toHaveLength(2)
+    await userEvent.click(screen.getByTestId('trace-filter-info'))
+    const remaining = screen.getAllByTestId('trace-event')
+    expect(remaining).toHaveLength(1)
+    expect(remaining[0]).toHaveAttribute('data-severity', 'critical')
+  })
+
+  it('shows the filter-empty state when every severity is unchecked', async () => {
+    vi.spyOn(traceApi, 'useTraceQuery').mockReturnValue(
+      mockTraceQuery({
+        data: [
+          { ...MOCK_EVENT, id: 'a', severity: 'critical' },
+          { ...MOCK_EVENT, id: 'b', severity: 'warning' },
+          { ...MOCK_EVENT, id: 'c', severity: 'info' },
+          { ...MOCK_EVENT, id: 'd', severity: undefined },
+        ],
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    )
+    renderAt('/agents/agent-001/trace/session-abc')
+
+    await userEvent.click(screen.getByTestId('trace-filter-critical'))
+    await userEvent.click(screen.getByTestId('trace-filter-warning'))
+    await userEvent.click(screen.getByTestId('trace-filter-info'))
+    await userEvent.click(screen.getByTestId('trace-filter-neutral'))
+
+    expect(screen.getByTestId('trace-filter-empty')).toBeInTheDocument()
+    expect(screen.getByText('All events hidden by filter')).toBeInTheDocument()
+    expect(screen.queryByTestId('trace-event')).not.toBeInTheDocument()
   })
 })

--- a/dashboard/src/pages/TraceViewPage.tsx
+++ b/dashboard/src/pages/TraceViewPage.tsx
@@ -1,16 +1,31 @@
+import { useMemo, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { useAgentQuery } from '../features/agents/api'
 import { useTraceQuery } from '../features/trace/api'
+import { TraceTimeline } from '../components/trace/TraceTimeline'
+import { TraceTimelineFilter } from '../components/trace/TraceTimelineFilter'
+import { ALL_ON, type SeverityFilter } from '../components/trace/severityFilter'
+import { EmptyState } from '../components/states'
+import type { TraceEvent } from '../features/trace/types'
+
+function applyFilter(events: readonly TraceEvent[], filter: SeverityFilter): TraceEvent[] {
+  return events.filter(event => {
+    const key = event.severity ?? 'neutral'
+    return filter[key]
+  })
+}
 
 /**
  * Trace view page — header, status states (loading / error / empty / ready),
- * and a slot where the timeline component lands in AAASM-1067.
+ * severity filter, and the trace timeline introduced in AAASM-1067.
  */
 export function TraceViewPage() {
   const { id = '', sessionId = '' } = useParams<{ id: string; sessionId: string }>()
   const { data: agent } = useAgentQuery(id)
   const { data, isLoading, isError, refetch } = useTraceQuery(id, sessionId)
   const agentLabel = agent?.name ?? id
+  const [filter, setFilter] = useState<SeverityFilter>(ALL_ON)
+  const filteredEvents = useMemo(() => applyFilter(data ?? [], filter), [data, filter])
 
   return (
     <main style={{ padding: '1.5rem' }} data-testid="trace-view">
@@ -26,7 +41,7 @@ export function TraceViewPage() {
               key={i}
               data-testid="trace-row-skeleton"
               style={{
-                background: '#f3f4f6',
+                background: 'var(--paper-3)',
                 height: '2.25rem',
                 marginBottom: '0.5rem',
                 borderRadius: '4px',
@@ -38,24 +53,32 @@ export function TraceViewPage() {
 
       {isError && (
         <div data-testid="trace-error" style={{ marginTop: '1rem' }}>
-          <p style={{ color: '#dc2626' }}>Failed to load trace.</p>
+          <p style={{ color: 'var(--danger)' }}>Failed to load trace.</p>
           <button onClick={() => void refetch()}>Retry</button>
         </div>
       )}
 
       {!isLoading && !isError && data && data.length === 0 && (
-        <div data-testid="trace-empty" style={{ marginTop: '1rem', color: 'var(--shell-text-muted)' }}>
-          No events recorded for this session.
-        </div>
+        <EmptyState
+          title="No events recorded for this session"
+          description="The agent ran but produced no governed actions in this session."
+        />
       )}
 
       {!isLoading && !isError && data && data.length > 0 && (
-        <div
-          data-testid="trace-timeline-placeholder"
-          style={{ color: 'var(--shell-text-muted)', marginTop: '1rem' }}
-        >
-          Loaded {data.length} event{data.length === 1 ? '' : 's'}. Timeline component lands in AAASM-1067.
-        </div>
+        <>
+          <TraceTimelineFilter value={filter} onChange={setFilter} />
+          {filteredEvents.length === 0 ? (
+            <div data-testid="trace-filter-empty">
+              <EmptyState
+                title="All events hidden by filter"
+                description="Re-enable a severity above (or press Esc) to see events again."
+              />
+            </div>
+          ) : (
+            <TraceTimeline events={filteredEvents} />
+          )}
+        </>
       )}
     </main>
   )


### PR DESCRIPTION
## Description

Implements the vertical trace timeline for an agent session — second subtask of [AAASM-95](https://lightning-dust-mite.atlassian.net/browse/AAASM-95) (S22). Replaces the placeholder slot left by AAASM-1065 with the real timeline + a severity-checkbox filter bar, all using design tokens from `styles.css` (no hex literals).

### New components

- `components/trace/TraceTimeline.tsx` + `.css` — vertical list, one row per `TraceEvent` with timestamp gutter, type icon, agent label, payload preview, duration badge. `data-testid="trace-event"`, `data-severity={severity ?? 'neutral'}`, `data-event-type` per row.
- `components/trace/TraceTimelineFilter.tsx` + `.css` — checkbox group (Critical / Warning / Info / Neutral), all on by default, semantic `<label>` + `<input type="checkbox">`. Esc resets to ALL_ON. `role="group"` with accessible name.
- `components/trace/severityFilter.ts` — shared constants (`SEVERITY_KEYS`, `ALL_ON`) and types (`SeverityKey`, `SeverityFilter`) extracted into a dedicated module so the filter file only exports its component (satisfies `react-refresh/only-export-components`).

### Page wiring

`pages/TraceViewPage.tsx` now:

- Holds filter state and applies it to the trace events.
- Mounts `<TraceTimelineFilter>` above `<TraceTimeline>` when events exist.
- Renders the shared `<EmptyState>` for two distinct empty conditions:
  1. The session has zero events (`No events recorded for this session`).
  2. The filter excludes everything (`All events hidden by filter` — distinct `data-testid="trace-filter-empty"`).

### Visual / token rules

- Severity → token mapping is in `TraceTimeline.css` only:
  - `data-severity='critical'` → `--danger-bg` / `--danger`
  - `data-severity='warning'` → `--warn-bg` / `--warn`
  - `data-severity='info'` → `--info-bg` / `--info`
  - `data-severity='neutral'` → `--paper`
- `data-event-type='credential_leak'` forces the warning tone regardless of severity, while keeping the underlying `data-severity` intact so the filter can still hide it. Zero hex literals in any new CSS file.

### Behavior

- Policy violation rows (`type === 'policy_violation'`) with a `violationReason` wrap their icon in the existing `<Tooltip>`. If `violationReason` is missing, no tooltip wrapper renders. Defensive: non-violation events ignore `violationReason` entirely.
- The trace timeline component stays pure-presentational (takes `events`, no internal state), so AAASM-1340 can mount it inside the shell-level trace drawer with no changes.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No (additive: `violationReason?: string` added to `TraceEvent` as optional)

## Related Issues

- Related Jira ticket: [AAASM-1067](https://lightning-dust-mite.atlassian.net/browse/AAASM-1067) (parent Story [AAASM-95](https://lightning-dust-mite.atlassian.net/browse/AAASM-95))
- Builds on: AAASM-1065 (route + scaffold; merged via PR #356)
- Unblocks: AAASM-1069 (payload modal — clicks rows added by this PR), AAASM-1071 (JSON export — toolbar lands next to the filter), AAASM-1340 (View-trace drawer reuses the same `<TraceTimeline>`)

## Testing

- [x] Unit tests added / updated

\`pnpm type-check\` clean, \`pnpm lint\` clean (0 warnings, 0 errors), \`pnpm test\` 32 files / 314 tests green (+15 vs the 299 baseline at branch point).

### Tests added (15)

| File | Cases |
|---|---|
| `components/trace/TraceTimeline.test.tsx` | 8 — row count + content; `data-severity` per severity (critical/warning/info/neutral); `data-event-type` exposure; empty-events array renders empty `<ol>`; policy-violation tooltip on hover; missing-reason → no tooltip wrapper; non-violation events ignore violationReason; credential leak retains its `data-severity` while CSS overrides background via `data-event-type`. |
| `components/trace/TraceTimelineFilter.test.tsx` | 5 — initial all-on render; toggle emits new filter; controlled value reflected; Esc resets to `ALL_ON`; `role="group"` + accessible label present. |
| `pages/TraceViewPage.test.tsx` (updated) | 2 net-new — filter + timeline mounted together when events exist; severity-unchecked rows hidden; **all-unchecked → `trace-filter-empty` EmptyState**. |

### Manual verification note

Same as AAASM-1065: live screenshots are deferred until the gateway endpoint (AAASM-9) is in place — the timeline renders fixture-driven in Storybook / tests today, no real session traces to surface. Every render state is covered by the 15 new unit tests above.

## Commit slices (9, atomic, all bisectable)

1. `✨ (trace): Add violationReason field to TraceEvent`
2. `✨ (trace): Add TraceTimeline component with severity-keyed rendering`
3. `✨ (trace): Style TraceTimeline severities with design tokens`
4. `✅ (trace): Test TraceTimeline renders mixed-severity events correctly`
5. `✨ (trace): Add policy violation tooltip + credential leak warning tone`
6. `✨ (trace): Add TraceTimelineFilter with keyboard-accessible checkboxes`
7. `✅ (trace): Test TraceTimelineFilter toggles, controlled value, and Esc reset`
8. `♻️ (trace): Extract severity filter constants to dedicated module` *(satisfies react-refresh lint rule)*
9. `🔧 (trace): Mount TraceTimeline + filter in TraceViewPage`

## Checklist

- [x] Code follows project style guidelines (`pnpm lint`, `pnpm type-check`)
- [x] Self-review of the diff completed
- [x] No hex literals in any new CSS — all severity colors come from `styles.css` tokens
- [x] All local checks passing (CI verification pending)
- [x] Commits are small and follow the Gitmoji convention

[AAASM-95]: https://lightning-dust-mite.atlassian.net/browse/AAASM-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1067]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ