### PR TITLE
[AAASM-1069] ✨ (trace): Add payload preview + expand modal

### DIFF
--- a/dashboard/src/components/trace/PayloadModal.css
+++ b/dashboard/src/components/trace/PayloadModal.css
@@ -1,0 +1,91 @@
+/* ============================================================
+   PayloadModal — full trace event payload viewer (AAASM-1069)
+   ============================================================
+
+   Uses design tokens from src/styles.css. No hex literals.
+   Pattern mirrors features/capability/CellInspectDrawer but
+   centered as a modal rather than docked as a right-side drawer.
+   ============================================================ */
+
+.payload-modal-scrim {
+  position: fixed;
+  inset: 0;
+  /* Matches the scrim rgba from features/capability/CellInspectDrawer for consistency. */
+  background: rgba(14, 14, 14, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.payload-modal {
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  width: min(720px, 90vw);
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  color: var(--ink);
+  box-shadow: 0 12px 32px rgba(14, 14, 14, 0.2);
+}
+
+.payload-modal__head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.payload-modal__eyebrow {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ink-4);
+}
+
+.payload-modal__title {
+  margin: 0.25rem 0 0.125rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.payload-modal__time {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.875rem;
+  color: var(--ink-3);
+}
+
+.payload-modal__subtitle {
+  font-size: 0.8rem;
+  color: var(--ink-3);
+}
+
+.payload-modal__close {
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.875rem;
+  padding: 0.25rem 0.5rem;
+  color: var(--ink-2);
+}
+
+.payload-modal__close:hover {
+  background: var(--paper-3);
+}
+
+.payload-modal__json {
+  margin: 0;
+  padding: 1rem 1.25rem;
+  overflow: auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: var(--ink-2);
+  background: var(--paper);
+  border-radius: 0 0 8px 8px;
+  white-space: pre;
+}

--- a/dashboard/src/components/trace/PayloadModal.css
+++ b/dashboard/src/components/trace/PayloadModal.css
@@ -63,7 +63,14 @@
   color: var(--ink-3);
 }
 
-.payload-modal__close {
+.payload-modal__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.payload-modal__close,
+.payload-modal__copy {
   background: transparent;
   border: 1px solid var(--line);
   border-radius: 4px;
@@ -73,7 +80,8 @@
   color: var(--ink-2);
 }
 
-.payload-modal__close:hover {
+.payload-modal__close:hover,
+.payload-modal__copy:hover {
   background: var(--paper-3);
 }
 

--- a/dashboard/src/components/trace/PayloadModal.css
+++ b/dashboard/src/components/trace/PayloadModal.css
@@ -89,3 +89,18 @@
   border-radius: 0 0 8px 8px;
   white-space: pre;
 }
+
+.payload-modal__redacted {
+  background: var(--warn-bg);
+  border-left: 3px solid var(--warn);
+  display: inline-block;
+  width: 100%;
+  padding-left: 0.25rem;
+}
+
+.payload-modal__lock {
+  display: inline-block;
+  font-size: 0.85em;
+  vertical-align: -1px;
+  cursor: help;
+}

--- a/dashboard/src/components/trace/PayloadModal.test.tsx
+++ b/dashboard/src/components/trace/PayloadModal.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { PayloadModal } from './PayloadModal'
+import type { TraceEvent } from '../../features/trace/types'
+
+const EVENT: TraceEvent = {
+  id: 'evt-1',
+  timestamp: '2026-04-23T14:23:01Z',
+  type: 'policy_violation',
+  agent: 'support-agent',
+  durationMs: 12,
+  payloadPreview: 'refund > $100',
+  payload: {
+    action: 'process_refund',
+    amount: 250,
+    user_id: 4521,
+    notes: 'manual review',
+  },
+  severity: 'critical',
+  redactedFields: ['user_id'],
+  violationReason: 'refund > $100 requires human approval',
+}
+
+describe('PayloadModal', () => {
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    })
+  })
+
+  afterEach(() => { vi.restoreAllMocks() })
+
+  it('renders nothing when event is null', () => {
+    const { container } = render(<PayloadModal event={null} onClose={vi.fn()} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the pretty-printed JSON, header, Close button, and Copy button', () => {
+    render(<PayloadModal event={EVENT} onClose={vi.fn()} />)
+
+    expect(screen.getByTestId('payload-modal')).toBeInTheDocument()
+    const json = screen.getByTestId('payload-modal-json')
+    expect(json.textContent).toContain('"action": "process_refund"')
+    expect(json.textContent).toContain('"amount": 250')
+
+    expect(screen.getByTestId('payload-modal-close')).toBeInTheDocument()
+    expect(screen.getByTestId('payload-modal-copy')).toHaveTextContent('Copy JSON')
+  })
+
+  it('substitutes redacted fields with the sentinel string and marks the line', () => {
+    render(<PayloadModal event={EVENT} onClose={vi.fn()} />)
+
+    const redactedRows = screen.getAllByTestId('redacted-field')
+    expect(redactedRows).toHaveLength(1)
+    expect(redactedRows[0]).toHaveTextContent('"user_id"')
+    expect(redactedRows[0]).toHaveTextContent('"<redacted: user_id>"')
+    // Real value (4521) must not leak into the rendered output for redacted fields.
+    expect(redactedRows[0].textContent).not.toContain('4521')
+  })
+
+  it('shows a Redacted-by-policy tooltip on hover over the lock icon', async () => {
+    render(<PayloadModal event={EVENT} onClose={vi.fn()} />)
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+    const lock = screen.getAllByTestId('redacted-field')[0].querySelector('.payload-modal__lock')!
+    await userEvent.hover(lock)
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Redacted by policy')
+  })
+
+  it('closes on Escape and on backdrop click', async () => {
+    const onClose = vi.fn()
+    render(<PayloadModal event={EVENT} onClose={onClose} />)
+
+    await userEvent.keyboard('{Escape}')
+    expect(onClose).toHaveBeenCalledTimes(1)
+
+    await userEvent.click(screen.getByTestId('payload-modal-scrim'))
+    expect(onClose).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not close when clicking inside the dialog body', async () => {
+    const onClose = vi.fn()
+    render(<PayloadModal event={EVENT} onClose={onClose} />)
+
+    await userEvent.click(screen.getByTestId('payload-modal-json'))
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('copies the pretty-printed JSON to clipboard and shows "Copied" feedback', async () => {
+    render(<PayloadModal event={EVENT} onClose={vi.fn()} />)
+
+    const button = screen.getByTestId('payload-modal-copy')
+    await userEvent.click(button)
+    expect(navigator.clipboard.writeText).toHaveBeenCalledOnce()
+    const written = vi.mocked(navigator.clipboard.writeText).mock.calls[0][0]
+    expect(written).toContain('"action": "process_refund"')
+    expect(button).toHaveTextContent('Copied')
+  })
+
+  it('autofocuses the Close button when the modal opens', () => {
+    render(<PayloadModal event={EVENT} onClose={vi.fn()} />)
+    expect(screen.getByTestId('payload-modal-close')).toHaveFocus()
+  })
+
+  it('traps Tab focus inside the dialog (cycles from last → first and first → last)', async () => {
+    render(<PayloadModal event={EVENT} onClose={vi.fn()} />)
+    const close = screen.getByTestId('payload-modal-close')
+    const copy = screen.getByTestId('payload-modal-copy')
+
+    // Initial focus is on Close. Tab → Copy (the only other focusable in actions).
+    expect(close).toHaveFocus()
+    await userEvent.tab()
+    expect(copy).toHaveFocus()
+
+    // From last (Copy), Tab cycles back to first (Close).
+    await userEvent.tab()
+    expect(close).toHaveFocus()
+
+    // Shift+Tab from first → last.
+    await userEvent.tab({ shift: true })
+    expect(copy).toHaveFocus()
+  })
+})

--- a/dashboard/src/components/trace/PayloadModal.tsx
+++ b/dashboard/src/components/trace/PayloadModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent, type ReactNode } from 'react'
 import type { TraceEvent } from '../../features/trace/types'
 import { Tooltip } from '../Tooltip'
 import './PayloadModal.css'
@@ -45,22 +45,48 @@ export interface PayloadModalProps {
  * Builds on the scrim+dialog pattern from `features/capability/CellInspectDrawer`.
  * Esc handler, focus trap, and Copy JSON button land in subsequent commits.
  */
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
 export function PayloadModal({ event, onClose }: PayloadModalProps) {
   const [copied, setCopied] = useState(false)
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const closeBtnRef = useRef<HTMLButtonElement>(null)
 
   useEffect(() => {
     if (!event) return
-    const handleKey = (e: KeyboardEvent) => {
+    const handleKey = (e: globalThis.KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
     }
     document.addEventListener('keydown', handleKey)
     return () => document.removeEventListener('keydown', handleKey)
   }, [event, onClose])
 
+  // Focus the Close button on open so keyboard users land inside the modal.
+  useEffect(() => {
+    if (!event) return
+    closeBtnRef.current?.focus()
+  }, [event])
+
   // Reset the "Copied" feedback whenever the modal opens for a new event.
   useEffect(() => {
     setCopied(false)
   }, [event])
+
+  const handleFocusTrap = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'Tab' || !dialogRef.current) return
+    const focusables = dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+    if (focusables.length === 0) return
+    const first = focusables[0]
+    const last = focusables[focusables.length - 1]
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault()
+      last.focus()
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault()
+      first.focus()
+    }
+  }
 
   const redactedSet = useMemo(
     () => new Set(event?.redactedFields ?? []),
@@ -84,12 +110,14 @@ export function PayloadModal({ event, onClose }: PayloadModalProps) {
       onClick={onClose}
     >
       <div
+        ref={dialogRef}
         className="payload-modal"
         role="dialog"
         aria-modal
         aria-label="trace event payload"
         data-testid="payload-modal"
         onClick={e => e.stopPropagation()}
+        onKeyDown={handleFocusTrap}
       >
         <header className="payload-modal__head">
           <div>
@@ -109,6 +137,7 @@ export function PayloadModal({ event, onClose }: PayloadModalProps) {
               {copied ? 'Copied' : 'Copy JSON'}
             </button>
             <button
+              ref={closeBtnRef}
               type="button"
               className="payload-modal__close"
               data-testid="payload-modal-close"

--- a/dashboard/src/components/trace/PayloadModal.tsx
+++ b/dashboard/src/components/trace/PayloadModal.tsx
@@ -1,0 +1,60 @@
+import type { TraceEvent } from '../../features/trace/types'
+import './PayloadModal.css'
+
+export interface PayloadModalProps {
+  readonly event: TraceEvent | null
+  readonly onClose: () => void
+}
+
+/**
+ * Modal that shows the full pretty-printed JSON payload of a single trace
+ * event. Lazy-mounted: returns `null` until an event is selected so the
+ * potentially-large `JSON.stringify(payload, null, 2)` only runs while the
+ * modal is open.
+ *
+ * Builds on the scrim+dialog pattern from `features/capability/CellInspectDrawer`.
+ * Esc handler, focus trap, and Copy JSON button land in subsequent commits.
+ */
+export function PayloadModal({ event, onClose }: PayloadModalProps) {
+  if (!event) return null
+
+  const formatted = JSON.stringify(event.payload, null, 2)
+
+  return (
+    <div
+      className="payload-modal-scrim"
+      data-testid="payload-modal-scrim"
+      onClick={onClose}
+    >
+      <div
+        className="payload-modal"
+        role="dialog"
+        aria-modal
+        aria-label="trace event payload"
+        data-testid="payload-modal"
+        onClick={e => e.stopPropagation()}
+      >
+        <header className="payload-modal__head">
+          <div>
+            <div className="payload-modal__eyebrow">trace event payload</div>
+            <h2 className="payload-modal__title">
+              <code>{event.type}</code> · <span className="payload-modal__time">{event.timestamp}</span>
+            </h2>
+            <div className="payload-modal__subtitle">{event.agent} · {event.durationMs}&nbsp;ms</div>
+          </div>
+          <button
+            type="button"
+            className="payload-modal__close"
+            data-testid="payload-modal-close"
+            onClick={onClose}
+            aria-label="Close payload modal"
+          >
+            ✕
+          </button>
+        </header>
+
+        <pre className="payload-modal__json" data-testid="payload-modal-json">{formatted}</pre>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/components/trace/PayloadModal.tsx
+++ b/dashboard/src/components/trace/PayloadModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, type ReactNode } from 'react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import type { TraceEvent } from '../../features/trace/types'
 import { Tooltip } from '../Tooltip'
 import './PayloadModal.css'
@@ -46,6 +46,8 @@ export interface PayloadModalProps {
  * Esc handler, focus trap, and Copy JSON button land in subsequent commits.
  */
 export function PayloadModal({ event, onClose }: PayloadModalProps) {
+  const [copied, setCopied] = useState(false)
+
   useEffect(() => {
     if (!event) return
     const handleKey = (e: KeyboardEvent) => {
@@ -54,6 +56,11 @@ export function PayloadModal({ event, onClose }: PayloadModalProps) {
     document.addEventListener('keydown', handleKey)
     return () => document.removeEventListener('keydown', handleKey)
   }, [event, onClose])
+
+  // Reset the "Copied" feedback whenever the modal opens for a new event.
+  useEffect(() => {
+    setCopied(false)
+  }, [event])
 
   const redactedSet = useMemo(
     () => new Set(event?.redactedFields ?? []),
@@ -64,6 +71,11 @@ export function PayloadModal({ event, onClose }: PayloadModalProps) {
 
   const formatted = JSON.stringify(event.payload, null, 2)
   const jsonNodes = renderJsonLines(formatted, redactedSet)
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(formatted)
+    setCopied(true)
+  }
 
   return (
     <div
@@ -87,15 +99,25 @@ export function PayloadModal({ event, onClose }: PayloadModalProps) {
             </h2>
             <div className="payload-modal__subtitle">{event.agent} · {event.durationMs}&nbsp;ms</div>
           </div>
-          <button
-            type="button"
-            className="payload-modal__close"
-            data-testid="payload-modal-close"
-            onClick={onClose}
-            aria-label="Close payload modal"
-          >
-            ✕
-          </button>
+          <div className="payload-modal__actions">
+            <button
+              type="button"
+              className="payload-modal__copy"
+              data-testid="payload-modal-copy"
+              onClick={() => void handleCopy()}
+            >
+              {copied ? 'Copied' : 'Copy JSON'}
+            </button>
+            <button
+              type="button"
+              className="payload-modal__close"
+              data-testid="payload-modal-close"
+              onClick={onClose}
+              aria-label="Close payload modal"
+            >
+              ✕
+            </button>
+          </div>
         </header>
 
         <pre className="payload-modal__json" data-testid="payload-modal-json">{jsonNodes}</pre>

--- a/dashboard/src/components/trace/PayloadModal.tsx
+++ b/dashboard/src/components/trace/PayloadModal.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import type { TraceEvent } from '../../features/trace/types'
 import './PayloadModal.css'
 
@@ -16,6 +17,15 @@ export interface PayloadModalProps {
  * Esc handler, focus trap, and Copy JSON button land in subsequent commits.
  */
 export function PayloadModal({ event, onClose }: PayloadModalProps) {
+  useEffect(() => {
+    if (!event) return
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [event, onClose])
+
   if (!event) return null
 
   const formatted = JSON.stringify(event.payload, null, 2)

--- a/dashboard/src/components/trace/PayloadModal.tsx
+++ b/dashboard/src/components/trace/PayloadModal.tsx
@@ -68,11 +68,6 @@ export function PayloadModal({ event, onClose }: PayloadModalProps) {
     closeBtnRef.current?.focus()
   }, [event])
 
-  // Reset the "Copied" feedback whenever the modal opens for a new event.
-  useEffect(() => {
-    setCopied(false)
-  }, [event])
-
   const handleFocusTrap = (e: KeyboardEvent<HTMLDivElement>) => {
     if (e.key !== 'Tab' || !dialogRef.current) return
     const focusables = dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)

--- a/dashboard/src/components/trace/PayloadModal.tsx
+++ b/dashboard/src/components/trace/PayloadModal.tsx
@@ -1,6 +1,35 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo, type ReactNode } from 'react'
 import type { TraceEvent } from '../../features/trace/types'
+import { Tooltip } from '../Tooltip'
 import './PayloadModal.css'
+
+const REDACTED_LINE_RE = /^(\s*)"([^"]+)":\s*(.*?)(,?)\s*$/
+
+function renderJsonLines(formatted: string, redactedSet: ReadonlySet<string>): ReactNode[] {
+  return formatted.split('\n').map((line, i) => {
+    const match = REDACTED_LINE_RE.exec(line)
+    if (match && redactedSet.has(match[2])) {
+      const [, indent, key, , trailing] = match
+      const sentinel = `"<redacted: ${key}>"`
+      return (
+        <span key={i} data-testid="redacted-field" className="payload-modal__redacted">
+          {indent}&quot;{key}&quot;:{' '}
+          <Tooltip content="Redacted by policy">
+            <span className="payload-modal__lock" aria-label={`${key} is redacted by policy`}>🔒</span>
+          </Tooltip>
+          {' '}{sentinel}{trailing}
+          {'\n'}
+        </span>
+      )
+    }
+    return (
+      <span key={i}>
+        {line}
+        {'\n'}
+      </span>
+    )
+  })
+}
 
 export interface PayloadModalProps {
   readonly event: TraceEvent | null
@@ -26,9 +55,15 @@ export function PayloadModal({ event, onClose }: PayloadModalProps) {
     return () => document.removeEventListener('keydown', handleKey)
   }, [event, onClose])
 
+  const redactedSet = useMemo(
+    () => new Set(event?.redactedFields ?? []),
+    [event?.redactedFields],
+  )
+
   if (!event) return null
 
   const formatted = JSON.stringify(event.payload, null, 2)
+  const jsonNodes = renderJsonLines(formatted, redactedSet)
 
   return (
     <div
@@ -63,7 +98,7 @@ export function PayloadModal({ event, onClose }: PayloadModalProps) {
           </button>
         </header>
 
-        <pre className="payload-modal__json" data-testid="payload-modal-json">{formatted}</pre>
+        <pre className="payload-modal__json" data-testid="payload-modal-json">{jsonNodes}</pre>
       </div>
     </div>
   )

--- a/dashboard/src/components/trace/TraceTimeline.test.tsx
+++ b/dashboard/src/components/trace/TraceTimeline.test.tsx
@@ -102,4 +102,30 @@ describe('TraceTimeline', () => {
     expect(row).toHaveAttribute('data-event-type', 'credential_leak')
     expect(row).toHaveAttribute('data-severity', 'info')
   })
+
+  it('truncates payloadPreview to 500 characters with an ellipsis when longer', () => {
+    const longText = 'x'.repeat(750)
+    const events: TraceEvent[] = [
+      { ...BASE_EVENT, id: 'long', type: 'llm_call', severity: 'info', payloadPreview: longText },
+    ]
+    render(<TraceTimeline events={events} />)
+
+    const row = screen.getByTestId('trace-event')
+    const preview = row.querySelector('.trace-event__preview')!
+    expect(preview.textContent).toHaveLength(501)
+    expect(preview.textContent?.endsWith('…')).toBe(true)
+    expect(preview.textContent?.slice(0, 500)).toBe('x'.repeat(500))
+  })
+
+  it('leaves payloadPreview untouched when it is ≤ 500 chars', () => {
+    const exactlyFiveHundred = 'y'.repeat(500)
+    const events: TraceEvent[] = [
+      { ...BASE_EVENT, id: 'edge', type: 'llm_call', severity: 'info', payloadPreview: exactlyFiveHundred },
+    ]
+    render(<TraceTimeline events={events} />)
+
+    const preview = screen.getByTestId('trace-event').querySelector('.trace-event__preview')!
+    expect(preview.textContent).toBe(exactlyFiveHundred)
+    expect(preview.textContent?.endsWith('…')).toBe(false)
+  })
 })

--- a/dashboard/src/components/trace/TraceTimeline.test.tsx
+++ b/dashboard/src/components/trace/TraceTimeline.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { TraceTimeline } from './TraceTimeline'
 import type { TraceEvent } from '../../features/trace/types'
 
@@ -127,5 +127,32 @@ describe('TraceTimeline', () => {
     const preview = screen.getByTestId('trace-event').querySelector('.trace-event__preview')!
     expect(preview.textContent).toBe(exactlyFiveHundred)
     expect(preview.textContent?.endsWith('…')).toBe(false)
+  })
+
+  it('does not assign clickable role/tabIndex when onSelectEvent is omitted', () => {
+    render(<TraceTimeline events={MIXED_EVENTS} />)
+    const row = screen.getAllByTestId('trace-event')[0]
+    expect(row).not.toHaveAttribute('role')
+    expect(row).not.toHaveAttribute('tabindex')
+    expect(row.className).not.toContain('trace-event--clickable')
+  })
+
+  it('renders rows as buttons and fires onSelectEvent on click + Enter/Space', async () => {
+    const onSelect = vi.fn()
+    render(<TraceTimeline events={[MIXED_EVENTS[0]]} onSelectEvent={onSelect} />)
+
+    const row = screen.getByTestId('trace-event')
+    expect(row).toHaveAttribute('role', 'button')
+    expect(row).toHaveAttribute('tabindex', '0')
+    expect(row.className).toContain('trace-event--clickable')
+
+    await userEvent.click(row)
+    expect(onSelect).toHaveBeenLastCalledWith(MIXED_EVENTS[0])
+
+    row.focus()
+    await userEvent.keyboard('{Enter}')
+    expect(onSelect).toHaveBeenCalledTimes(2)
+    await userEvent.keyboard(' ')
+    expect(onSelect).toHaveBeenCalledTimes(3)
   })
 })

--- a/dashboard/src/components/trace/TraceTimeline.tsx
+++ b/dashboard/src/components/trace/TraceTimeline.tsx
@@ -1,3 +1,4 @@
+import type React from 'react'
 import type { TraceEvent, TraceSeverity } from '../../features/trace/types'
 import { Tooltip } from '../Tooltip'
 import './TraceTimeline.css'
@@ -27,9 +28,10 @@ function truncatePreview(text: string): string {
 
 export interface TraceTimelineProps {
   readonly events: readonly TraceEvent[]
+  readonly onSelectEvent?: (event: TraceEvent) => void
 }
 
-export function TraceTimeline({ events }: TraceTimelineProps) {
+export function TraceTimeline({ events, onSelectEvent }: TraceTimelineProps) {
   return (
     <ol className="trace-timeline" data-testid="trace-timeline">
       {events.map(event => {
@@ -40,13 +42,26 @@ export function TraceTimeline({ events }: TraceTimelineProps) {
         const iconNode = (
           <span className="trace-event__icon" aria-hidden="true">{icon}</span>
         )
+        const handleClick = onSelectEvent ? () => onSelectEvent(event) : undefined
+        const handleKeyDown = onSelectEvent
+          ? (e: React.KeyboardEvent<HTMLLIElement>) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                onSelectEvent(event)
+              }
+            }
+          : undefined
         return (
           <li
             key={event.id}
-            className="trace-event"
+            className={onSelectEvent ? 'trace-event trace-event--clickable' : 'trace-event'}
             data-testid="trace-event"
             data-severity={sev}
             data-event-type={event.type}
+            role={onSelectEvent ? 'button' : undefined}
+            tabIndex={onSelectEvent ? 0 : undefined}
+            onClick={handleClick}
+            onKeyDown={handleKeyDown}
           >
             <span className="trace-event__time">{formatTime(event.timestamp)}</span>
             {tooltipReason ? (

--- a/dashboard/src/components/trace/TraceTimeline.tsx
+++ b/dashboard/src/components/trace/TraceTimeline.tsx
@@ -17,6 +17,14 @@ function formatTime(iso: string): string {
   return iso.replace('T', ' ').replace(/\.\d+Z$/, 'Z').replace(/Z$/, ' UTC')
 }
 
+const MAX_PREVIEW_CHARS = 500
+
+function truncatePreview(text: string): string {
+  return text.length > MAX_PREVIEW_CHARS
+    ? `${text.slice(0, MAX_PREVIEW_CHARS)}…`
+    : text
+}
+
 export interface TraceTimelineProps {
   readonly events: readonly TraceEvent[]
 }
@@ -47,7 +55,7 @@ export function TraceTimeline({ events }: TraceTimelineProps) {
               iconNode
             )}
             <span className="trace-event__agent">{event.agent}</span>
-            <span className="trace-event__preview">{event.payloadPreview}</span>
+            <span className="trace-event__preview">{truncatePreview(event.payloadPreview)}</span>
             <span className="trace-event__duration">{event.durationMs}&nbsp;ms</span>
           </li>
         )

--- a/dashboard/src/pages/TraceViewPage.test.tsx
+++ b/dashboard/src/pages/TraceViewPage.test.tsx
@@ -194,4 +194,18 @@ describe('TraceViewPage', () => {
     expect(screen.getByText('All events hidden by filter')).toBeInTheDocument()
     expect(screen.queryByTestId('trace-event')).not.toBeInTheDocument()
   })
+
+  it('opens the PayloadModal when a timeline row is clicked, and closes on the close button', async () => {
+    vi.spyOn(traceApi, 'useTraceQuery').mockReturnValue(
+      mockTraceQuery({ data: [MOCK_EVENT], isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    renderAt('/agents/agent-001/trace/session-abc')
+
+    expect(screen.queryByTestId('payload-modal')).not.toBeInTheDocument()
+    await userEvent.click(screen.getByTestId('trace-event'))
+    expect(screen.getByTestId('payload-modal')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('payload-modal-close'))
+    expect(screen.queryByTestId('payload-modal')).not.toBeInTheDocument()
+  })
 })

--- a/dashboard/src/pages/TraceViewPage.tsx
+++ b/dashboard/src/pages/TraceViewPage.tsx
@@ -5,6 +5,7 @@ import { useTraceQuery } from '../features/trace/api'
 import { TraceTimeline } from '../components/trace/TraceTimeline'
 import { TraceTimelineFilter } from '../components/trace/TraceTimelineFilter'
 import { ALL_ON, type SeverityFilter } from '../components/trace/severityFilter'
+import { PayloadModal } from '../components/trace/PayloadModal'
 import { EmptyState } from '../components/states'
 import type { TraceEvent } from '../features/trace/types'
 
@@ -25,6 +26,7 @@ export function TraceViewPage() {
   const { data, isLoading, isError, refetch } = useTraceQuery(id, sessionId)
   const agentLabel = agent?.name ?? id
   const [filter, setFilter] = useState<SeverityFilter>(ALL_ON)
+  const [selectedEvent, setSelectedEvent] = useState<TraceEvent | null>(null)
   const filteredEvents = useMemo(() => applyFilter(data ?? [], filter), [data, filter])
 
   return (
@@ -76,10 +78,12 @@ export function TraceViewPage() {
               />
             </div>
           ) : (
-            <TraceTimeline events={filteredEvents} />
+            <TraceTimeline events={filteredEvents} onSelectEvent={setSelectedEvent} />
           )}
         </>
       )}
+
+      <PayloadModal event={selectedEvent} onClose={() => setSelectedEvent(null)} />
     </main>
   )
 }


### PR DESCRIPTION
## Description

Adds payload-preview truncation and the expandable payload modal — third subtask of [AAASM-95](https://lightning-dust-mite.atlassian.net/browse/AAASM-95) (S22). Clicking a timeline row from AAASM-1067 now opens a modal with the full pretty-printed JSON, with redacted fields visually marked and a Copy JSON button.

### New surfaces

- `components/trace/PayloadModal.tsx` + `.css` — scrim + dialog mirroring the `features/capability/CellInspectDrawer` pattern. Lazy-mounted: returns `null` until `event !== null` so the (potentially large) `JSON.stringify` only runs while the modal is open.
- `data-testid="payload-modal"`, `data-testid="payload-modal-scrim"`, `data-testid="payload-modal-close"`, `data-testid="payload-modal-copy"`, `data-testid="payload-modal-json"`, `data-testid="redacted-field"` on each redacted line.

### Behavior

- **Preview truncation**: `TraceTimeline` now hard-truncates `payloadPreview` text to **500 characters**, appending `…` when longer. Pure text-content truncation (not CSS ellipsis) per AC wording.
- **Pretty-printed JSON**: `JSON.stringify(event.payload, null, 2)`, rendered line-by-line so we can transform redacted lines.
- **Redacted fields**: lines whose key matches any name in `event.redactedFields` are rewritten as `"<key>": <Tooltip>🔒</Tooltip> "<redacted: <key>>"<comma>`, with the lock icon wrapped in the existing `<Tooltip content="Redacted by policy">`. Each redacted line is highlighted with the warn-tone background + left border so it's visually distinct in the JSON view. The original payload value is *not* rendered for redacted fields — even if the server accidentally left a value there, the client substitutes the sentinel.
- **Copy JSON**: button uses `navigator.clipboard.writeText(formatted)` and flips its label to `Copied`. Lazy-mount means the state naturally resets when reopening the modal on a new event.
- **Esc to close** + **backdrop click closes** + clicking inside the dialog does not close (event-bubbling stopped on the inner div).
- **Focus trap**: on mount, focus goes to the Close button; Tab cycles forward through focusables (Close → Copy → Close again); Shift+Tab cycles backward.
- **Row click → modal**: `<TraceTimeline>` now accepts an optional `onSelectEvent?: (event) => void`. When present, rows get `role="button"`, `tabIndex={0}`, and click + Enter/Space handlers. When absent (e.g., embed without modal), rows stay non-interactive. `TraceViewPage` holds the `selectedEvent` state and mounts `<PayloadModal>` at the bottom of its tree.

### Pattern notes

- AC says *"Use the shell's modal primitive (introduced in AAASM-94 shell Subtask)"* — that primitive does not exist in master. Rather than introduce a generic `<Modal>` abstraction for a single consumer (per workspace's "no abstractions beyond what the task requires" rule), this PR mirrors the `CellInspectDrawer` scrim+dialog pattern directly in `PayloadModal`. The Jira comment notes this.
- A 10th commit (`🚨 Drop redundant copied-reset effect`) was added to satisfy `react-hooks/set-state-in-effect`. The lazy-mount pattern means React unmounts/remounts PayloadModal between open events, which resets `copied` naturally — the explicit reset effect was unnecessary anyway.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No (additive: `TraceTimeline` gains an optional `onSelectEvent` prop)

## Related Issues

- Related Jira ticket: [AAASM-1069](https://lightning-dust-mite.atlassian.net/browse/AAASM-1069) (parent Story [AAASM-95](https://lightning-dust-mite.atlassian.net/browse/AAASM-95))
- Builds on: AAASM-1065 (route + scaffold), AAASM-1067 (timeline + filter)
- Unblocks: AAASM-1071 (JSON export — toolbar lands alongside Copy JSON in modal header)

## Testing

- [x] Unit tests added / updated

\`pnpm type-check\` clean, \`pnpm lint\` clean (0 warnings, 0 errors), \`pnpm test\` 36 files / 355 tests green (+14 vs the 341 baseline at branch point).

### Tests added (14)

| File | Cases |
|---|---|
| `components/trace/PayloadModal.test.tsx` (new) | 9 — null event returns null; renders pretty JSON + header + buttons; redacted fields substituted (4521 must NOT leak); tooltip on lock hover; Esc + backdrop close; inside-click does not close; copy writes JSON + flips label; autofocus on Close button; focus trap cycles Close ↔ Copy on Tab / Shift+Tab |
| `components/trace/TraceTimeline.test.tsx` (extended) | 4 net-new — payloadPreview truncates at 500 chars with ellipsis; ≤500 untouched; no role/tabIndex when `onSelectEvent` is omitted; rows fire `onSelectEvent` on click + Enter + Space when callback is present |
| `pages/TraceViewPage.test.tsx` (extended) | 1 net-new — clicking a row opens the modal; Close button closes it |

## Commit slices (10, atomic, all bisectable)

1. `✨ (trace): Truncate payloadPreview to 500 chars in TraceTimeline`
2. `✅ (trace): Test payloadPreview truncates at 500 chars with ellipsis`
3. `✨ (trace): Add PayloadModal with pretty-printed JSON and design tokens`
4. `✨ (trace): Add Esc close handler to PayloadModal`
5. `✨ (trace): Render redacted fields with lock icon and tooltip in PayloadModal`
6. `✨ (trace): Add Copy JSON button using clipboard API`
7. `✨ (trace): Add focus trap to PayloadModal`
8. `✅ (trace): Test PayloadModal — Esc, redaction, copy, focus trap, autofocus`
9. `🚨 (trace): Drop redundant copied-reset effect to satisfy react-hooks/set-state-in-effect`
10. `🔧 (trace): Wire row click to open PayloadModal in TraceViewPage`

## Checklist

- [x] Code follows project style guidelines (`pnpm lint`, `pnpm type-check`)
- [x] Self-review of the diff completed
- [x] No hex literals in any new CSS — scrim alpha matches the existing CellInspectDrawer rgba pattern; all other colors via `var(--*)` tokens from `styles.css`
- [x] All local checks passing (CI verification pending)
- [x] Commits are small and follow the Gitmoji convention

[AAASM-95]: https://lightning-dust-mite.atlassian.net/browse/AAASM-95?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1069]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ