### PR TITLE
[AAASM-1052] ✨ (dashboard/fleet): Rebuild Agent Detail as right-side drawer with identity strip + tabs

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -30,7 +30,10 @@ function App() {
             {/* ── Canonical 12 routes (AAASM-94 AC #5, #6) ──────────────── */}
             {/* monitor */}
             <Route path="/overview" element={<ComingSoon name="Overview" />} />
-            <Route path="/agents" element={<FleetPage />} />
+            <Route path="/agents" element={<FleetPage />}>
+              {/* Agent Detail drawer overlays the Fleet page so filter state stays mounted. */}
+              <Route path=":id" element={<AgentDetailPage />} />
+            </Route>
             <Route path="/topology" element={<ComingSoon name="Topology" />} />
             <Route path="/live" element={<LiveOpsPage />} />
             <Route path="/alerts" element={<AlertsPage />} />
@@ -45,7 +48,6 @@ function App() {
             <Route path="/identity" element={<IdentityPage />} />
 
             {/* ── Sub-routes for canonical pages ────────────────────────── */}
-            <Route path="/agents/:id" element={<AgentDetailPage />} />
             <Route path="/agents/:id/trace/:sessionId" element={<TraceViewPage />} />
             <Route path="/teams/:teamId" element={<TeamDetailPage />} />
 

--- a/dashboard/src/components/Drawer.css
+++ b/dashboard/src/components/Drawer.css
@@ -1,0 +1,19 @@
+.drawer-scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 10, 10, 0.4);
+  z-index: 50;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.drawer-panel {
+  width: 580px;
+  max-width: 100vw;
+  height: 100vh;
+  background: var(--paper-2);
+  border-left: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+  overflow: auto;
+}

--- a/dashboard/src/components/Drawer.test.tsx
+++ b/dashboard/src/components/Drawer.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { Drawer } from './Drawer'
+
+describe('Drawer', () => {
+  it('renders nothing when open is false', () => {
+    render(
+      <Drawer open={false} onClose={vi.fn()}>
+        body
+      </Drawer>,
+    )
+    expect(screen.queryByTestId('drawer-scrim')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('drawer-panel')).not.toBeInTheDocument()
+  })
+
+  it('renders the scrim and panel when open is true', () => {
+    render(
+      <Drawer open onClose={vi.fn()} ariaLabel="Test drawer">
+        <p>hello</p>
+      </Drawer>,
+    )
+    expect(screen.getByTestId('drawer-scrim')).toBeInTheDocument()
+    const panel = screen.getByTestId('drawer-panel')
+    expect(panel).toBeInTheDocument()
+    expect(panel).toHaveAttribute('aria-label', 'Test drawer')
+    expect(panel).toHaveAttribute('aria-modal', 'true')
+    expect(screen.getByText('hello')).toBeInTheDocument()
+  })
+
+  it('fires onClose when the scrim is clicked', () => {
+    const onClose = vi.fn()
+    render(
+      <Drawer open onClose={onClose}>
+        <p>body</p>
+      </Drawer>,
+    )
+    fireEvent.click(screen.getByTestId('drawer-scrim'))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire onClose when a click bubbles up from inside the panel', () => {
+    const onClose = vi.fn()
+    render(
+      <Drawer open onClose={onClose}>
+        <button>inner</button>
+      </Drawer>,
+    )
+    fireEvent.click(screen.getByText('inner'))
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('fires onClose when the Escape key is pressed', () => {
+    const onClose = vi.fn()
+    render(
+      <Drawer open onClose={onClose}>
+        <p>body</p>
+      </Drawer>,
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores non-Escape keys', () => {
+    const onClose = vi.fn()
+    render(
+      <Drawer open onClose={onClose}>
+        <p>body</p>
+      </Drawer>,
+    )
+    fireEvent.keyDown(document, { key: 'Enter' })
+    fireEvent.keyDown(document, { key: ' ' })
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('stops listening for Escape after open flips to false', () => {
+    const onClose = vi.fn()
+    const { rerender } = render(
+      <Drawer open onClose={onClose}>
+        <p>body</p>
+      </Drawer>,
+    )
+    rerender(
+      <Drawer open={false} onClose={onClose}>
+        <p>body</p>
+      </Drawer>,
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/dashboard/src/components/Drawer.tsx
+++ b/dashboard/src/components/Drawer.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useRef, type MouseEvent, type ReactNode } from 'react'
+import './Drawer.css'
+
+interface DrawerProps {
+  /** When `true`, drawer + scrim render; when `false`, nothing is rendered. */
+  open: boolean
+  /** Fires on ESC keypress, scrim click, or close-button click. */
+  onClose: () => void
+  /** Drawer body. Drawer is unstyled inside; the caller supplies its layout. */
+  children: ReactNode
+  /** Accessible label for the dialog. */
+  ariaLabel?: string
+}
+
+/**
+ * Right-side modal drawer matching `design/v1/styles.css` `.drawer`.
+ *
+ * Closes on:
+ *   * `Escape` keypress (handled at `document` level so focus inside the
+ *     drawer doesn't prevent the shortcut),
+ *   * click on the scrim (the surrounding dimmed area), or
+ *   * click on the close button rendered in the drawer head by the caller.
+ *
+ * The component is presentational only — opening/closing the drawer is the
+ * caller's responsibility (typically by mounting / unmounting at a routed
+ * URL). No focus trap; v1 relies on the underlying page being inert behind
+ * the scrim.
+ */
+export function Drawer({ open, onClose, children, ariaLabel }: DrawerProps) {
+  const onCloseRef = useRef(onClose)
+  useEffect(() => {
+    onCloseRef.current = onClose
+  }, [onClose])
+
+  useEffect(() => {
+    if (!open) return
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCloseRef.current()
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [open])
+
+  if (!open) return null
+
+  function handleScrimClick(e: MouseEvent<HTMLDivElement>) {
+    // Only the scrim itself should dismiss; clicks bubbling up from the panel
+    // (the drawer body) must be ignored.
+    if (e.target === e.currentTarget) onClose()
+  }
+
+  return (
+    <div
+      className="drawer-scrim"
+      data-testid="drawer-scrim"
+      onClick={handleScrimClick}
+      role="presentation"
+    >
+      <aside
+        className="drawer-panel"
+        data-testid="drawer-panel"
+        role="dialog"
+        aria-modal="true"
+        aria-label={ariaLabel}
+      >
+        {children}
+      </aside>
+    </div>
+  )
+}

--- a/dashboard/src/features/agents/api.test.tsx
+++ b/dashboard/src/features/agents/api.test.tsx
@@ -118,8 +118,9 @@ describe('AgentDetailPage', () => {
 
     await waitFor(() => expect(screen.getByTestId('agent-detail')).toBeInTheDocument())
     expect(screen.getByText('test-agent')).toBeInTheDocument()
-    expect(screen.getByText('langgraph')).toBeInTheDocument()
-    expect(screen.getByText('enforced')).toBeInTheDocument()
+    // Framework chip + recent events table both surface "langgraph" / "enforced".
+    expect(screen.getAllByText('langgraph').length).toBeGreaterThan(0)
+    expect(screen.getByText(/enforced/)).toBeInTheDocument()
     expect(screen.getAllByTestId('event-row')).toHaveLength(1)
   })
 

--- a/dashboard/src/pages/AgentDetailDrawer.css
+++ b/dashboard/src/pages/AgentDetailDrawer.css
@@ -165,6 +165,37 @@
   margin-top: 0;
 }
 
+/* ── Tabs ──────────────────────────────────────────────────── */
+
+.ad-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper-2);
+  padding: 0 24px;
+}
+
+.ad-tabs__tab {
+  padding: 10px 16px;
+  font-size: 13px;
+  color: var(--ink-3);
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  user-select: none;
+}
+
+.ad-tabs__tab:hover { color: var(--ink); }
+
+.ad-tabs__tab--active {
+  color: var(--ink);
+  border-bottom-color: var(--ink);
+  font-weight: 600;
+}
+
 /* ── Body containers ───────────────────────────────────────── */
 
 .ad-body {
@@ -172,4 +203,26 @@
   overflow: auto;
   padding: 20px;
   background: var(--paper);
+}
+
+.ad-tab-empty {
+  padding: 60px 24px;
+  text-align: center;
+  color: var(--ink-3);
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+.ad-tab-empty__title {
+  margin: 0 0 8px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--ink-4);
+}
+
+.ad-tab-empty__body {
+  margin: 0 auto;
+  font-size: 12px;
+  max-width: 420px;
+  line-height: 1.5;
 }

--- a/dashboard/src/pages/AgentDetailDrawer.css
+++ b/dashboard/src/pages/AgentDetailDrawer.css
@@ -226,3 +226,126 @@
   max-width: 420px;
   line-height: 1.5;
 }
+
+/* ── Overview tab ──────────────────────────────────────────── */
+
+.ad-overview {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.ad-card {
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  padding: 16px;
+}
+
+.ad-card__title {
+  font-size: 10px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--ink-4);
+  margin: 0 0 10px;
+}
+
+.ad-card--span-2 {
+  grid-column: span 2;
+}
+
+.ad-minibar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+}
+
+.ad-minibar__label {
+  width: 130px;
+  font-size: 11px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  color: var(--ink-3);
+}
+
+.ad-minibar__track {
+  flex: 1;
+  height: 6px;
+  background: var(--paper-3);
+  border-radius: 1px;
+  overflow: hidden;
+}
+
+.ad-minibar__fill {
+  display: block;
+  height: 100%;
+}
+
+.ad-minibar__fill--ok    { background: var(--ok); }
+.ad-minibar__fill--warn  { background: var(--warn); }
+.ad-minibar__fill--deny  { background: var(--danger); }
+.ad-minibar__fill--info  { background: var(--info); }
+
+.ad-minibar__value {
+  width: 60px;
+  text-align: right;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--ink-2);
+}
+
+.ad-traffic-mix {
+  display: flex;
+  height: 36px;
+  border: 1px solid var(--line-2);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-top: 6px;
+}
+
+.ad-traffic-mix__seg {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 10px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  border-right: 1px solid var(--line-2);
+}
+
+.ad-traffic-mix__seg:last-child { border-right: 0; }
+
+.ad-traffic-mix__seg--placeholder {
+  background: var(--paper-3);
+  color: var(--ink-4);
+  flex: 1;
+}
+
+.ad-events {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.ad-events th,
+.ad-events td {
+  padding: 7px 10px;
+  border-bottom: 1px solid var(--line);
+  text-align: left;
+}
+
+.ad-events th {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--ink-3);
+}
+
+.ad-events__code {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  color: var(--ink-2);
+}

--- a/dashboard/src/pages/AgentDetailDrawer.css
+++ b/dashboard/src/pages/AgentDetailDrawer.css
@@ -1,0 +1,175 @@
+/* ============================================================
+   Agent Detail drawer — hi-fi chrome
+   Tokens come from dashboard/src/styles.css (hi-fi palette).
+   ============================================================ */
+
+.ad {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--paper);
+}
+
+/* ── Header (breadcrumb + title + actions) ─────────────────── */
+
+.ad-head {
+  padding: 22px 24px 18px;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper-2);
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  gap: 24px;
+}
+
+.ad-head__crumbs {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  color: var(--ink-4);
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.ad-head__crumb-link {
+  color: inherit;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.ad-head__title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.3px;
+  color: var(--ink);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.ad-head__flag {
+  color: var(--danger);
+}
+
+.ad-head__chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 7px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 10px;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+  border: 1px solid var(--line-2);
+  background: var(--paper-2);
+  color: var(--ink-2);
+  border-radius: 2px;
+}
+
+.ad-head__owner {
+  font-size: 12px;
+  font-weight: 400;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  color: var(--ink-3);
+}
+
+/* ── Identity strip (DID / trust / mode-status / blocked / scrubbed) ── */
+
+.ad-identity {
+  padding: 14px 24px;
+  background: var(--paper-2);
+  border-bottom: 1px solid var(--line);
+  display: grid;
+  grid-template-columns: 1.2fr 1fr 1fr 1fr 1fr;
+  gap: 16px;
+}
+
+.ad-identity__label {
+  font-size: 10px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--ink-4);
+  margin: 0 0 4px;
+}
+
+.ad-identity__did {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  color: var(--ink-2);
+  word-break: break-all;
+}
+
+.ad-identity__did-meta {
+  font-size: 10px;
+  color: var(--ink-4);
+  margin-top: 4px;
+}
+
+.ad-identity__trust {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.ad-identity__trust-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.ad-identity__trust-summary {
+  font-size: 11px;
+  color: var(--ink-3);
+}
+
+.ad-identity__chips {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+
+.ad-identity__last-seen {
+  font-size: 10px;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  color: var(--ink-3);
+  margin-top: 6px;
+}
+
+.ad-identity__metric {
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--ink);
+  margin-top: 4px;
+}
+
+.ad-identity__metric--scrub {
+  color: var(--scrub);
+}
+
+.ad-identity__metric--danger {
+  color: var(--danger);
+}
+
+.ad-identity__metric-sub {
+  font-size: 10px;
+  color: var(--ink-4);
+  margin-top: 0;
+}
+
+/* ── Body containers ───────────────────────────────────────── */
+
+.ad-body {
+  flex: 1;
+  overflow: auto;
+  padding: 20px;
+  background: var(--paper);
+}

--- a/dashboard/src/pages/AgentDetailPage.test.tsx
+++ b/dashboard/src/pages/AgentDetailPage.test.tsx
@@ -1,0 +1,220 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import type { UseQueryResult } from '@tanstack/react-query'
+import { FleetPage } from './FleetPage'
+import { AgentDetailPage } from './AgentDetailPage'
+import { ToastProvider } from '../components/ToastProvider'
+import * as agentsApi from '../features/agents/api'
+import type { Agent, LogEntry } from '../features/agents/api'
+
+function makeClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+function mockQuery<T>(partial: Partial<UseQueryResult<T, Error>>): UseQueryResult<T, Error> {
+  return partial as unknown as UseQueryResult<T, Error>
+}
+
+function LocationProbe({ onChange }: { onChange: (path: string, search: string) => void }) {
+  const loc = useLocation()
+  onChange(loc.pathname, loc.search)
+  return null
+}
+
+function renderApp(initialPath: string, onLocation?: (path: string, search: string) => void) {
+  return render(
+    <QueryClientProvider client={makeClient()}>
+      <ToastProvider>
+        <MemoryRouter initialEntries={[initialPath]}>
+          <Routes>
+            <Route path="/agents" element={<FleetPage />}>
+              <Route path=":id" element={<AgentDetailPage />} />
+            </Route>
+          </Routes>
+          {onLocation && <LocationProbe onChange={onLocation} />}
+        </MemoryRouter>
+      </ToastProvider>
+    </QueryClientProvider>,
+  )
+}
+
+const MOCK_AGENT: Agent = {
+  id: 'abc123',
+  name: 'alpha-agent',
+  framework: 'langgraph',
+  status: 'active',
+  version: '0.1.0',
+  layer: 'enforced',
+  last_event: '2026-05-12T00:00:00Z',
+  recent_events: [],
+  recent_traces: [],
+  active_sessions: [],
+  session_count: 10,
+  policy_violations_count: 4,
+  tool_names: ['web_search'],
+  metadata: { owner: 'alice' },
+  pid: null,
+}
+
+const MOCK_LOG: LogEntry = {
+  agent_id: 'abc123',
+  event_type: 'PolicyViolation',
+  payload: '{}',
+  seq: 1,
+  session_id: 'session-12345678',
+  timestamp: '2026-05-12T00:00:00Z',
+}
+
+function mockHappyPath() {
+  vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+    mockQuery<Agent[]>({ data: [MOCK_AGENT], isLoading: false, isError: false, refetch: vi.fn() }),
+  )
+  vi.spyOn(agentsApi, 'useAgentQuery').mockReturnValue(
+    mockQuery<Agent | undefined>({ data: MOCK_AGENT, isLoading: false, isError: false, refetch: vi.fn() }),
+  )
+  vi.spyOn(agentsApi, 'useAgentEventsQuery').mockReturnValue(
+    mockQuery<LogEntry[]>({ data: [MOCK_LOG], isLoading: false, isError: false }),
+  )
+}
+
+afterEach(() => { vi.restoreAllMocks() })
+
+describe('AgentDetailPage deep link', () => {
+  it('renders the drawer when navigated directly to /agents/:id', async () => {
+    mockHappyPath()
+    renderApp('/agents/abc123')
+    expect(await screen.findByTestId('drawer-panel')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-detail')).toBeInTheDocument()
+  })
+
+  it('renders the Fleet table underneath the drawer (route is nested)', async () => {
+    mockHappyPath()
+    renderApp('/agents/abc123')
+    expect(await screen.findByTestId('fleet-page')).toBeInTheDocument()
+    expect(screen.getByTestId('drawer-panel')).toBeInTheDocument()
+  })
+
+  it('formats the DID using metadata.owner', async () => {
+    mockHappyPath()
+    renderApp('/agents/abc123')
+    expect(await screen.findByTestId('agent-detail-did')).toHaveTextContent('did:agent:alice:abc123')
+  })
+
+  it('falls back to the agent-assembly slug when owner metadata is missing', async () => {
+    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+      mockQuery<Agent[]>({ data: [MOCK_AGENT], isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    vi.spyOn(agentsApi, 'useAgentQuery').mockReturnValue(
+      mockQuery<Agent | undefined>({
+        data: { ...MOCK_AGENT, metadata: {} },
+        isLoading: false,
+        isError: false,
+        refetch: vi.fn(),
+      }),
+    )
+    vi.spyOn(agentsApi, 'useAgentEventsQuery').mockReturnValue(
+      mockQuery<LogEntry[]>({ data: [MOCK_LOG], isLoading: false, isError: false }),
+    )
+    renderApp('/agents/abc123')
+    expect(await screen.findByTestId('agent-detail-did')).toHaveTextContent('did:agent:agent-assembly:abc123')
+  })
+})
+
+describe('AgentDetailPage close behavior', () => {
+  it('closes back to /agents when the breadcrumb button is clicked', async () => {
+    mockHappyPath()
+    let lastPath = ''
+    renderApp('/agents/abc123', (p) => { lastPath = p })
+    fireEvent.click(await screen.findByTestId('agent-detail-close'))
+    await waitFor(() => expect(lastPath).toBe('/agents'))
+  })
+
+  it('preserves the Fleet filter query string when closing', async () => {
+    mockHappyPath()
+    let lastSearch = ''
+    renderApp('/agents/abc123?q=alpha&status=active', (_, s) => { lastSearch = s })
+    fireEvent.click(await screen.findByTestId('agent-detail-close'))
+    await waitFor(() => expect(lastSearch).toContain('q=alpha'))
+    expect(lastSearch).toContain('status=active')
+  })
+
+  it('closes when the scrim is clicked', async () => {
+    mockHappyPath()
+    let lastPath = ''
+    renderApp('/agents/abc123', (p) => { lastPath = p })
+    const scrim = await screen.findByTestId('drawer-scrim')
+    fireEvent.click(scrim)
+    await waitFor(() => expect(lastPath).toBe('/agents'))
+  })
+
+  it('closes when Escape is pressed', async () => {
+    mockHappyPath()
+    let lastPath = ''
+    renderApp('/agents/abc123', (p) => { lastPath = p })
+    await screen.findByTestId('drawer-panel')
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(lastPath).toBe('/agents'))
+  })
+})
+
+describe('AgentDetailPage tab navigation', () => {
+  it('starts on the Overview tab with posture and recent-events panels', async () => {
+    mockHappyPath()
+    renderApp('/agents/abc123')
+    expect(await screen.findByTestId('agent-detail-posture')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-events')).toBeInTheDocument()
+    expect(screen.getByTestId('agent-detail-tab-overview')).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('switches to Capability empty-state when its tab is selected', async () => {
+    mockHappyPath()
+    renderApp('/agents/abc123')
+    fireEvent.click(await screen.findByTestId('agent-detail-tab-capability'))
+    await waitFor(() => expect(screen.getByTestId('ad-tab-empty-capability')).toBeInTheDocument())
+    expect(screen.queryByTestId('agent-detail-posture')).not.toBeInTheDocument()
+  })
+
+  it('renders the other follow-up tabs each with their empty state', async () => {
+    mockHappyPath()
+    renderApp('/agents/abc123')
+    for (const id of ['traffic', 'policies', 'lineage', 'config'] as const) {
+      fireEvent.click(screen.getByTestId(`agent-detail-tab-${id}`))
+      await waitFor(() => expect(screen.getByTestId(`ad-tab-empty-${id}`)).toBeInTheDocument())
+    }
+  })
+})
+
+describe('AgentDetailPage loading and error states', () => {
+  it('shows the loading state while the agent query is in flight', () => {
+    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+      mockQuery<Agent[]>({ data: [], isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    vi.spyOn(agentsApi, 'useAgentQuery').mockReturnValue(
+      mockQuery<Agent | undefined>({ data: undefined, isLoading: true, isError: false, refetch: vi.fn() }),
+    )
+    vi.spyOn(agentsApi, 'useAgentEventsQuery').mockReturnValue(
+      mockQuery<LogEntry[]>({ data: undefined, isLoading: true, isError: false }),
+    )
+    renderApp('/agents/abc123')
+    expect(screen.getByTestId('agent-detail-loading')).toBeInTheDocument()
+  })
+
+  it('shows an error banner with Retry when the agent query fails', () => {
+    const refetch = vi.fn()
+    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+      mockQuery<Agent[]>({ data: [], isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    vi.spyOn(agentsApi, 'useAgentQuery').mockReturnValue(
+      mockQuery<Agent | undefined>({ data: undefined, isLoading: false, isError: true, refetch }),
+    )
+    vi.spyOn(agentsApi, 'useAgentEventsQuery').mockReturnValue(
+      mockQuery<LogEntry[]>({ data: undefined, isLoading: false, isError: true }),
+    )
+    renderApp('/agents/abc123')
+    expect(screen.getByTestId('agent-detail-error')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(refetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/dashboard/src/pages/AgentDetailPage.tsx
+++ b/dashboard/src/pages/AgentDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import { useAgentQuery, useAgentEventsQuery, type Agent } from '../features/agents/api'
 import { toFleetAgent } from '../features/agents/fleetTypes'
@@ -96,12 +96,33 @@ function IdentityStrip({ agent }: { agent: Agent }) {
   )
 }
 
+type AgentDetailTab = 'overview' | 'capability' | 'traffic' | 'policies' | 'lineage' | 'config'
+
+const TABS: ReadonlyArray<{ id: AgentDetailTab; label: string }> = [
+  { id: 'overview',   label: 'Overview' },
+  { id: 'capability', label: 'Capability' },
+  { id: 'traffic',    label: 'Traffic' },
+  { id: 'policies',   label: 'Policies' },
+  { id: 'lineage',    label: 'Lineage' },
+  { id: 'config',     label: 'Config' },
+]
+
+function TabEmpty({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="ad-tab-empty" data-testid={`ad-tab-empty-${title.toLowerCase()}`}>
+      <p className="ad-tab-empty__title">{title}</p>
+      <p className="ad-tab-empty__body">{body}</p>
+    </div>
+  )
+}
+
 export function AgentDetailPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const location = useLocation()
   const { data: agent, isLoading: agentLoading, isError: agentError, refetch: refetchAgent } = useAgentQuery(id ?? '')
   const { data: events, isLoading: eventsLoading, isError: eventsError } = useAgentEventsQuery(id ?? '')
+  const [tab, setTab] = useState<AgentDetailTab>('overview')
 
   const close = useCallback(() => {
     navigate({ pathname: '/agents', search: location.search })
@@ -163,50 +184,101 @@ export function AgentDetailPage() {
 
             <IdentityStrip agent={agent} />
 
-            <div className="ad-body" data-testid="agent-detail-body">
-              <section
-                data-testid="agent-profile"
-                style={{ background: 'var(--paper-2)', border: '1px solid var(--line)', borderRadius: 4, padding: '1rem', marginBottom: '1rem' }}
-              >
-                <h2 style={{ marginTop: 0 }}>Identity Profile</h2>
-                <p><b>Version</b> {agent.version}</p>
-                <p><b>Sessions</b> {agent.session_count}</p>
-                <p><b>Policy violations</b> {agent.policy_violations_count}</p>
-                {agent.tool_names.length > 0 && (
-                  <p><b>Tools</b> {agent.tool_names.join(', ')}</p>
-                )}
-              </section>
+            <nav className="ad-tabs" data-testid="agent-detail-tabs" role="tablist" aria-label="Agent detail sections">
+              {TABS.map((t) => (
+                <button
+                  key={t.id}
+                  type="button"
+                  role="tab"
+                  aria-selected={tab === t.id}
+                  className={`ad-tabs__tab${tab === t.id ? ' ad-tabs__tab--active' : ''}`}
+                  onClick={() => setTab(t.id)}
+                  data-testid={`agent-detail-tab-${t.id}`}
+                >
+                  {t.label}
+                </button>
+              ))}
+            </nav>
 
-              <section data-testid="agent-events">
-                <h2>Recent Events</h2>
-                {eventsLoading && <p>Loading events…</p>}
-                {eventsError && <p style={{ color: 'var(--danger)' }}>Failed to load events.</p>}
-                {!eventsLoading && !eventsError && (!events || events.length === 0) && (
-                  <p>No events recorded for this agent.</p>
-                )}
-                {events && events.length > 0 && (
-                  <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' }}>
-                    <thead>
-                      <tr>
-                        <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid var(--line)' }}>Timestamp</th>
-                        <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid var(--line)' }}>Type</th>
-                        <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid var(--line)' }}>Session</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {events.map(ev => (
-                        <tr key={`${ev.seq}-${ev.session_id}`} data-testid="event-row" style={{ borderBottom: '1px solid var(--line)' }}>
-                          <td style={{ padding: '0.4rem' }}>{ev.timestamp}</td>
-                          <td style={{ padding: '0.4rem' }}>{ev.event_type}</td>
-                          <td style={{ padding: '0.4rem' }}>
-                            <code style={{ fontSize: '0.75rem' }}>{ev.session_id.slice(0, 12)}…</code>
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                )}
-              </section>
+            <div className="ad-body" data-testid="agent-detail-body">
+              {tab === 'overview' && (
+                <>
+                  <section
+                    data-testid="agent-profile"
+                    style={{ background: 'var(--paper-2)', border: '1px solid var(--line)', borderRadius: 4, padding: '1rem', marginBottom: '1rem' }}
+                  >
+                    <h2 style={{ marginTop: 0 }}>Identity Profile</h2>
+                    <p><b>Version</b> {agent.version}</p>
+                    <p><b>Sessions</b> {agent.session_count}</p>
+                    <p><b>Policy violations</b> {agent.policy_violations_count}</p>
+                    {agent.tool_names.length > 0 && (
+                      <p><b>Tools</b> {agent.tool_names.join(', ')}</p>
+                    )}
+                  </section>
+
+                  <section data-testid="agent-events">
+                    <h2>Recent Events</h2>
+                    {eventsLoading && <p>Loading events…</p>}
+                    {eventsError && <p style={{ color: 'var(--danger)' }}>Failed to load events.</p>}
+                    {!eventsLoading && !eventsError && (!events || events.length === 0) && (
+                      <p>No events recorded for this agent.</p>
+                    )}
+                    {events && events.length > 0 && (
+                      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' }}>
+                        <thead>
+                          <tr>
+                            <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid var(--line)' }}>Timestamp</th>
+                            <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid var(--line)' }}>Type</th>
+                            <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid var(--line)' }}>Session</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {events.map(ev => (
+                            <tr key={`${ev.seq}-${ev.session_id}`} data-testid="event-row" style={{ borderBottom: '1px solid var(--line)' }}>
+                              <td style={{ padding: '0.4rem' }}>{ev.timestamp}</td>
+                              <td style={{ padding: '0.4rem' }}>{ev.event_type}</td>
+                              <td style={{ padding: '0.4rem' }}>
+                                <code style={{ fontSize: '0.75rem' }}>{ev.session_id.slice(0, 12)}…</code>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    )}
+                  </section>
+                </>
+              )}
+
+              {tab === 'capability' && (
+                <TabEmpty
+                  title="Capability"
+                  body="The capability matrix scoped to this agent is rendered on the global Capability page (AAASM-1280). Inline view lands in a follow-up sub-task."
+                />
+              )}
+              {tab === 'traffic' && (
+                <TabEmpty
+                  title="Traffic"
+                  body="Recent-decisions stream for this agent is on the Live Ops page. Inline view lands in a follow-up sub-task."
+                />
+              )}
+              {tab === 'policies' && (
+                <TabEmpty
+                  title="Policies"
+                  body="Per-agent policy assignments will reuse the Policies page tagging engine. Inline view lands in a follow-up sub-task."
+                />
+              )}
+              {tab === 'lineage' && (
+                <TabEmpty
+                  title="Lineage"
+                  body="Delegation chain visualisation depends on the Topology graph (AAASM-95). Inline view lands in a follow-up sub-task."
+                />
+              )}
+              {tab === 'config' && (
+                <TabEmpty
+                  title="Config"
+                  body="Read-only YAML view of the agent's current enforcement config. Inline view lands in a follow-up sub-task."
+                />
+              )}
             </div>
           </>
         )}

--- a/dashboard/src/pages/AgentDetailPage.tsx
+++ b/dashboard/src/pages/AgentDetailPage.tsx
@@ -1,5 +1,7 @@
-import { useParams, Link } from 'react-router-dom'
+import { useCallback } from 'react'
+import { useParams, useNavigate, useLocation, Link } from 'react-router-dom'
 import { useAgentQuery, useAgentEventsQuery } from '../features/agents/api'
+import { Drawer } from '../components/Drawer'
 
 function Field({ label, value }: { label: string; value: React.ReactNode }) {
   return (
@@ -12,81 +14,94 @@ function Field({ label, value }: { label: string; value: React.ReactNode }) {
 
 export function AgentDetailPage() {
   const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const location = useLocation()
   const { data: agent, isLoading: agentLoading, isError: agentError, refetch: refetchAgent } = useAgentQuery(id ?? '')
   const { data: events, isLoading: eventsLoading, isError: eventsError } = useAgentEventsQuery(id ?? '')
 
-  if (agentLoading) {
-    return (
-      <main style={{ padding: '1.5rem' }} data-testid="agent-detail-loading">
-        <p>Loading agent…</p>
-      </main>
-    )
-  }
-
-  if (agentError || !agent) {
-    return (
-      <main style={{ padding: '1.5rem' }} data-testid="agent-detail-error">
-        <p style={{ color: '#dc2626' }}>Failed to load agent.</p>
-        <button onClick={() => void refetchAgent()}>Retry</button>
-        <br />
-        <Link to="/agents">← Back to agents</Link>
-      </main>
-    )
-  }
+  const close = useCallback(() => {
+    navigate({ pathname: '/agents', search: location.search })
+  }, [navigate, location.search])
 
   return (
-    <main style={{ padding: '1.5rem' }} data-testid="agent-detail">
-      <Link to="/agents" style={{ fontSize: '0.875rem' }}>← Back to agents</Link>
-      <h1 style={{ margin: '0.75rem 0' }}>{agent.name}</h1>
+    <Drawer open onClose={close} ariaLabel={agent ? `Agent ${agent.name}` : 'Agent detail'}>
+      {agentLoading && (
+        <div style={{ padding: '1.5rem' }} data-testid="agent-detail-loading">
+          <p>Loading agent…</p>
+        </div>
+      )}
 
-      <section
-        data-testid="agent-profile"
-        style={{ background: '#f9fafb', border: '1px solid #e5e7eb', borderRadius: '8px', padding: '1rem', marginBottom: '1.5rem' }}
-      >
-        <h2 style={{ marginTop: 0 }}>Identity Profile</h2>
-        <Field label="ID" value={<code style={{ fontSize: '0.8rem' }}>{agent.id}</code>} />
-        <Field label="Framework" value={agent.framework} />
-        <Field label="Version" value={agent.version} />
-        <Field label="Status" value={agent.status} />
-        <Field label="Governance layer" value={agent.layer} />
-        <Field label="Sessions" value={agent.session_count} />
-        <Field label="Policy violations" value={agent.policy_violations_count} />
-        <Field label="Last seen" value={agent.last_event} />
-        {agent.tool_names.length > 0 && (
-          <Field label="Tools" value={agent.tool_names.join(', ')} />
-        )}
-      </section>
+      {!agentLoading && (agentError || !agent) && (
+        <div style={{ padding: '1.5rem' }} data-testid="agent-detail-error">
+          <p style={{ color: '#dc2626' }}>Failed to load agent.</p>
+          <button onClick={() => void refetchAgent()}>Retry</button>
+          <br />
+          <Link to="/agents">← Back to agents</Link>
+        </div>
+      )}
 
-      <section data-testid="agent-events">
-        <h2>Recent Events</h2>
-        {eventsLoading && <p>Loading events…</p>}
-        {eventsError && <p style={{ color: '#dc2626' }}>Failed to load events.</p>}
-        {!eventsLoading && !eventsError && (!events || events.length === 0) && (
-          <p>No events recorded for this agent.</p>
-        )}
-        {events && events.length > 0 && (
-          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' }}>
-            <thead>
-              <tr>
-                <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid #e5e7eb' }}>Timestamp</th>
-                <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid #e5e7eb' }}>Type</th>
-                <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid #e5e7eb' }}>Session</th>
-              </tr>
-            </thead>
-            <tbody>
-              {events.map(ev => (
-                <tr key={`${ev.seq}-${ev.session_id}`} data-testid="event-row" style={{ borderBottom: '1px solid #f3f4f6' }}>
-                  <td style={{ padding: '0.4rem' }}>{ev.timestamp}</td>
-                  <td style={{ padding: '0.4rem' }}>{ev.event_type}</td>
-                  <td style={{ padding: '0.4rem' }}>
-                    <code style={{ fontSize: '0.75rem' }}>{ev.session_id.slice(0, 12)}…</code>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </section>
-    </main>
+      {!agentLoading && !agentError && agent && (
+        <div data-testid="agent-detail" style={{ padding: '1.5rem' }}>
+          <button
+            type="button"
+            onClick={close}
+            data-testid="agent-detail-close"
+            style={{ fontSize: '0.875rem', background: 'transparent', border: 0, cursor: 'pointer', color: 'var(--ink-3, #5a5a5a)' }}
+          >
+            ← Back to agents
+          </button>
+          <h1 style={{ margin: '0.75rem 0' }}>{agent.name}</h1>
+
+          <section
+            data-testid="agent-profile"
+            style={{ background: '#f9fafb', border: '1px solid #e5e7eb', borderRadius: '8px', padding: '1rem', marginBottom: '1.5rem' }}
+          >
+            <h2 style={{ marginTop: 0 }}>Identity Profile</h2>
+            <Field label="ID" value={<code style={{ fontSize: '0.8rem' }}>{agent.id}</code>} />
+            <Field label="Framework" value={agent.framework} />
+            <Field label="Version" value={agent.version} />
+            <Field label="Status" value={agent.status} />
+            <Field label="Governance layer" value={agent.layer} />
+            <Field label="Sessions" value={agent.session_count} />
+            <Field label="Policy violations" value={agent.policy_violations_count} />
+            <Field label="Last seen" value={agent.last_event} />
+            {agent.tool_names.length > 0 && (
+              <Field label="Tools" value={agent.tool_names.join(', ')} />
+            )}
+          </section>
+
+          <section data-testid="agent-events">
+            <h2>Recent Events</h2>
+            {eventsLoading && <p>Loading events…</p>}
+            {eventsError && <p style={{ color: '#dc2626' }}>Failed to load events.</p>}
+            {!eventsLoading && !eventsError && (!events || events.length === 0) && (
+              <p>No events recorded for this agent.</p>
+            )}
+            {events && events.length > 0 && (
+              <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' }}>
+                <thead>
+                  <tr>
+                    <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid #e5e7eb' }}>Timestamp</th>
+                    <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid #e5e7eb' }}>Type</th>
+                    <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid #e5e7eb' }}>Session</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {events.map(ev => (
+                    <tr key={`${ev.seq}-${ev.session_id}`} data-testid="event-row" style={{ borderBottom: '1px solid #f3f4f6' }}>
+                      <td style={{ padding: '0.4rem' }}>{ev.timestamp}</td>
+                      <td style={{ padding: '0.4rem' }}>{ev.event_type}</td>
+                      <td style={{ padding: '0.4rem' }}>
+                        <code style={{ fontSize: '0.75rem' }}>{ev.session_id.slice(0, 12)}…</code>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </section>
+        </div>
+      )}
+    </Drawer>
   )
 }

--- a/dashboard/src/pages/AgentDetailPage.tsx
+++ b/dashboard/src/pages/AgentDetailPage.tsx
@@ -116,6 +116,52 @@ function TabEmpty({ title, body }: { title: string; body: string }) {
   )
 }
 
+interface MiniBarProps {
+  label: string
+  value: number
+  max: number
+  tone: 'ok' | 'warn' | 'deny' | 'info'
+}
+
+function MiniBar({ label, value, max, tone }: MiniBarProps) {
+  const pct = max === 0 ? 0 : Math.min(100, Math.max(0, (value / max) * 100))
+  return (
+    <div className="ad-minibar" data-testid={`ad-minibar-${tone}`}>
+      <div className="ad-minibar__label">{label}</div>
+      <div className="ad-minibar__track">
+        <span
+          className={`ad-minibar__fill ad-minibar__fill--${tone}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <div className="ad-minibar__value">{value}</div>
+    </div>
+  )
+}
+
+interface PostureSummaryProps {
+  agent: Agent
+}
+
+function PostureSummary({ agent }: PostureSummaryProps) {
+  // The dashboard has not yet wired a per-decision breakdown endpoint
+  // (cf. AAASM-1280 capability matrix). Until that lands, the panel
+  // derives an approximate decisions-this-session view from the two
+  // counters the API exposes today: total sessions handled and
+  // policy violations recorded.
+  const denyCount = agent.policy_violations_count
+  const allowCount = Math.max(0, agent.session_count - denyCount)
+  const max = Math.max(allowCount, denyCount, 1)
+  return (
+    <div data-testid="agent-detail-posture">
+      <MiniBar label="Allow"    value={allowCount} max={max} tone="ok" />
+      <MiniBar label="Narrow"   value={0}          max={max} tone="warn" />
+      <MiniBar label="Deny"     value={denyCount}  max={max} tone="deny" />
+      <MiniBar label="Approval" value={0}          max={max} tone="info" />
+    </div>
+  )
+}
+
 export function AgentDetailPage() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
@@ -202,43 +248,44 @@ export function AgentDetailPage() {
 
             <div className="ad-body" data-testid="agent-detail-body">
               {tab === 'overview' && (
-                <>
-                  <section
-                    data-testid="agent-profile"
-                    style={{ background: 'var(--paper-2)', border: '1px solid var(--line)', borderRadius: 4, padding: '1rem', marginBottom: '1rem' }}
-                  >
-                    <h2 style={{ marginTop: 0 }}>Identity Profile</h2>
-                    <p><b>Version</b> {agent.version}</p>
-                    <p><b>Sessions</b> {agent.session_count}</p>
-                    <p><b>Policy violations</b> {agent.policy_violations_count}</p>
-                    {agent.tool_names.length > 0 && (
-                      <p><b>Tools</b> {agent.tool_names.join(', ')}</p>
-                    )}
+                <div className="ad-overview" data-testid="agent-profile">
+                  <section className="ad-card">
+                    <h2 className="ad-card__title">posture summary</h2>
+                    <PostureSummary agent={agent} />
                   </section>
 
-                  <section data-testid="agent-events">
-                    <h2>Recent Events</h2>
+                  <section className="ad-card">
+                    <h2 className="ad-card__title">traffic mix · last 24h</h2>
+                    <div className="ad-traffic-mix" data-testid="agent-detail-traffic-mix">
+                      <div className="ad-traffic-mix__seg ad-traffic-mix__seg--placeholder">
+                        wired in a follow-up sub-task
+                      </div>
+                    </div>
+                  </section>
+
+                  <section className="ad-card ad-card--span-2" data-testid="agent-events">
+                    <h2 className="ad-card__title">recent events</h2>
                     {eventsLoading && <p>Loading events…</p>}
                     {eventsError && <p style={{ color: 'var(--danger)' }}>Failed to load events.</p>}
                     {!eventsLoading && !eventsError && (!events || events.length === 0) && (
-                      <p>No events recorded for this agent.</p>
+                      <p style={{ color: 'var(--ink-4)', fontSize: 12 }}>No events recorded for this agent.</p>
                     )}
                     {events && events.length > 0 && (
-                      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' }}>
+                      <table className="ad-events">
                         <thead>
                           <tr>
-                            <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid var(--line)' }}>Timestamp</th>
-                            <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid var(--line)' }}>Type</th>
-                            <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid var(--line)' }}>Session</th>
+                            <th>Timestamp</th>
+                            <th>Type</th>
+                            <th>Session</th>
                           </tr>
                         </thead>
                         <tbody>
-                          {events.map(ev => (
-                            <tr key={`${ev.seq}-${ev.session_id}`} data-testid="event-row" style={{ borderBottom: '1px solid var(--line)' }}>
-                              <td style={{ padding: '0.4rem' }}>{ev.timestamp}</td>
-                              <td style={{ padding: '0.4rem' }}>{ev.event_type}</td>
-                              <td style={{ padding: '0.4rem' }}>
-                                <code style={{ fontSize: '0.75rem' }}>{ev.session_id.slice(0, 12)}…</code>
+                          {events.map((ev) => (
+                            <tr key={`${ev.seq}-${ev.session_id}`} data-testid="event-row">
+                              <td>{ev.timestamp}</td>
+                              <td>{ev.event_type}</td>
+                              <td>
+                                <code className="ad-events__code">{ev.session_id.slice(0, 12)}…</code>
                               </td>
                             </tr>
                           ))}
@@ -246,7 +293,7 @@ export function AgentDetailPage() {
                       </table>
                     )}
                   </section>
-                </>
+                </div>
               )}
 
               {tab === 'capability' && (

--- a/dashboard/src/pages/AgentDetailPage.tsx
+++ b/dashboard/src/pages/AgentDetailPage.tsx
@@ -1,14 +1,98 @@
-import { useCallback } from 'react'
-import { useParams, useNavigate, useLocation, Link } from 'react-router-dom'
-import { useAgentQuery, useAgentEventsQuery } from '../features/agents/api'
+import { useCallback, useMemo } from 'react'
+import { useParams, useNavigate, useLocation } from 'react-router-dom'
+import { useAgentQuery, useAgentEventsQuery, type Agent } from '../features/agents/api'
+import { toFleetAgent } from '../features/agents/fleetTypes'
 import { Drawer } from '../components/Drawer'
+import { StatusChip } from '../components/fleet/StatusChip'
+import { ModeChip } from '../components/fleet/ModeChip'
+import './AgentDetailDrawer.css'
 
-function Field({ label, value }: { label: string; value: React.ReactNode }) {
+function TrustGauge({ score }: { score: number | null }) {
+  if (score === null) {
+    return (
+      <div className="ad-identity__trust">
+        <span className="ad-identity__trust-summary">—</span>
+      </div>
+    )
+  }
+  const clamped = Math.max(0, Math.min(100, score))
+  const tone = clamped >= 80 ? '#22592a' : clamped >= 60 ? '#8a5a00' : '#b8291e'
+  const dash = (clamped / 100) * 125.6
   return (
-    <div style={{ marginBottom: '0.5rem' }}>
-      <span style={{ fontWeight: 600, marginRight: '0.5rem' }}>{label}:</span>
-      <span>{value ?? '—'}</span>
+    <div className="ad-identity__trust">
+      <svg width="48" height="48" viewBox="0 0 48 48" aria-hidden="true">
+        <circle cx="24" cy="24" r="20" fill="none" stroke="var(--line-2)" strokeWidth="4" />
+        <circle
+          cx="24" cy="24" r="20" fill="none" stroke={tone} strokeWidth="4"
+          strokeDasharray={`${dash} 125.6`}
+          strokeLinecap="round"
+          transform="rotate(-90 24 24)"
+        />
+        <text x="24" y="28" textAnchor="middle" fontFamily="JetBrains Mono" fontSize="13" fontWeight="600" fill={tone}>
+          {clamped}
+        </text>
+      </svg>
+      <div className="ad-identity__trust-meta">
+        <p className="ad-identity__label">trust score</p>
+        <span className="ad-identity__trust-summary">
+          {clamped < 50 ? 'low — needs review' : clamped < 75 ? 'moderate' : 'good standing'}
+        </span>
+      </div>
     </div>
+  )
+}
+
+function IdentityStrip({ agent }: { agent: Agent }) {
+  const fleetAgent = useMemo(() => toFleetAgent(agent), [agent])
+  const ownerSlug = fleetAgent.owner ?? 'agent-assembly'
+
+  return (
+    <section className="ad-identity" data-testid="agent-detail-identity">
+      <div>
+        <p className="ad-identity__label">identity (did)</p>
+        <p className="ad-identity__did" data-testid="agent-detail-did">
+          did:agent:{ownerSlug}:{agent.id}
+        </p>
+        {fleetAgent.lastSeen && (
+          <p className="ad-identity__did-meta">last seen {fleetAgent.lastSeen}</p>
+        )}
+      </div>
+
+      <TrustGauge score={fleetAgent.trust} />
+
+      <div>
+        <p className="ad-identity__label">mode / status</p>
+        <div className="ad-identity__chips">
+          <ModeChip mode={fleetAgent.mode} />
+          <StatusChip status={agent.status} />
+        </div>
+        {agent.layer && (
+          <p className="ad-identity__last-seen">layer {agent.layer}</p>
+        )}
+      </div>
+
+      <div>
+        <p className="ad-identity__label">blocked / 24h</p>
+        <p
+          className={`ad-identity__metric${fleetAgent.blocked24h !== null && fleetAgent.blocked24h > 50 ? ' ad-identity__metric--danger' : ''}`}
+          data-testid="agent-detail-blocked"
+        >
+          {fleetAgent.blocked24h === null ? '—' : fleetAgent.blocked24h}
+        </p>
+        <p className="ad-identity__metric-sub">capability denials</p>
+      </div>
+
+      <div>
+        <p className="ad-identity__label">scrubbed / 24h</p>
+        <p
+          className="ad-identity__metric ad-identity__metric--scrub"
+          data-testid="agent-detail-scrubbed"
+        >
+          {fleetAgent.scrubbed24h === null ? '—' : fleetAgent.scrubbed24h}
+        </p>
+        <p className="ad-identity__metric-sub">secrets stripped at L3</p>
+      </div>
+    </section>
   )
 }
 
@@ -25,83 +109,108 @@ export function AgentDetailPage() {
 
   return (
     <Drawer open onClose={close} ariaLabel={agent ? `Agent ${agent.name}` : 'Agent detail'}>
-      {agentLoading && (
-        <div style={{ padding: '1.5rem' }} data-testid="agent-detail-loading">
-          <p>Loading agent…</p>
-        </div>
-      )}
+      <div className="ad">
+        {agentLoading && (
+          <div style={{ padding: '1.5rem' }} data-testid="agent-detail-loading">
+            <p>Loading agent…</p>
+          </div>
+        )}
 
-      {!agentLoading && (agentError || !agent) && (
-        <div style={{ padding: '1.5rem' }} data-testid="agent-detail-error">
-          <p style={{ color: '#dc2626' }}>Failed to load agent.</p>
-          <button onClick={() => void refetchAgent()}>Retry</button>
-          <br />
-          <Link to="/agents">← Back to agents</Link>
-        </div>
-      )}
+        {!agentLoading && (agentError || !agent) && (
+          <div style={{ padding: '1.5rem' }} data-testid="agent-detail-error">
+            <p style={{ color: 'var(--danger)' }}>Failed to load agent.</p>
+            <button onClick={() => void refetchAgent()}>Retry</button>
+            <br />
+            <button
+              type="button"
+              onClick={close}
+              data-testid="agent-detail-close"
+              style={{ background: 'transparent', border: 0, cursor: 'pointer', padding: 0 }}
+            >
+              ← Back to agents
+            </button>
+          </div>
+        )}
 
-      {!agentLoading && !agentError && agent && (
-        <div data-testid="agent-detail" style={{ padding: '1.5rem' }}>
-          <button
-            type="button"
-            onClick={close}
-            data-testid="agent-detail-close"
-            style={{ fontSize: '0.875rem', background: 'transparent', border: 0, cursor: 'pointer', color: 'var(--ink-3, #5a5a5a)' }}
-          >
-            ← Back to agents
-          </button>
-          <h1 style={{ margin: '0.75rem 0' }}>{agent.name}</h1>
+        {!agentLoading && !agentError && agent && (
+          <>
+            <header className="ad-head" data-testid="agent-detail">
+              <div>
+                <div className="ad-head__crumbs">
+                  <button
+                    type="button"
+                    className="ad-head__crumb-link"
+                    onClick={close}
+                    data-testid="agent-detail-close"
+                  >
+                    ← fleet
+                  </button>
+                  <span>›</span>
+                  <span>{agent.id}</span>
+                </div>
+                <h1 className="ad-head__title">
+                  {toFleetAgent(agent).flagged && (
+                    <span className="ad-head__flag" aria-label="flagged">●</span>
+                  )}
+                  {agent.name}
+                  <span className="ad-head__chip">{agent.framework}</span>
+                  {toFleetAgent(agent).owner && (
+                    <span className="ad-head__owner">@{toFleetAgent(agent).owner}</span>
+                  )}
+                </h1>
+              </div>
+            </header>
 
-          <section
-            data-testid="agent-profile"
-            style={{ background: '#f9fafb', border: '1px solid #e5e7eb', borderRadius: '8px', padding: '1rem', marginBottom: '1.5rem' }}
-          >
-            <h2 style={{ marginTop: 0 }}>Identity Profile</h2>
-            <Field label="ID" value={<code style={{ fontSize: '0.8rem' }}>{agent.id}</code>} />
-            <Field label="Framework" value={agent.framework} />
-            <Field label="Version" value={agent.version} />
-            <Field label="Status" value={agent.status} />
-            <Field label="Governance layer" value={agent.layer} />
-            <Field label="Sessions" value={agent.session_count} />
-            <Field label="Policy violations" value={agent.policy_violations_count} />
-            <Field label="Last seen" value={agent.last_event} />
-            {agent.tool_names.length > 0 && (
-              <Field label="Tools" value={agent.tool_names.join(', ')} />
-            )}
-          </section>
+            <IdentityStrip agent={agent} />
 
-          <section data-testid="agent-events">
-            <h2>Recent Events</h2>
-            {eventsLoading && <p>Loading events…</p>}
-            {eventsError && <p style={{ color: '#dc2626' }}>Failed to load events.</p>}
-            {!eventsLoading && !eventsError && (!events || events.length === 0) && (
-              <p>No events recorded for this agent.</p>
-            )}
-            {events && events.length > 0 && (
-              <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' }}>
-                <thead>
-                  <tr>
-                    <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid #e5e7eb' }}>Timestamp</th>
-                    <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid #e5e7eb' }}>Type</th>
-                    <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid #e5e7eb' }}>Session</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {events.map(ev => (
-                    <tr key={`${ev.seq}-${ev.session_id}`} data-testid="event-row" style={{ borderBottom: '1px solid #f3f4f6' }}>
-                      <td style={{ padding: '0.4rem' }}>{ev.timestamp}</td>
-                      <td style={{ padding: '0.4rem' }}>{ev.event_type}</td>
-                      <td style={{ padding: '0.4rem' }}>
-                        <code style={{ fontSize: '0.75rem' }}>{ev.session_id.slice(0, 12)}…</code>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            )}
-          </section>
-        </div>
-      )}
+            <div className="ad-body" data-testid="agent-detail-body">
+              <section
+                data-testid="agent-profile"
+                style={{ background: 'var(--paper-2)', border: '1px solid var(--line)', borderRadius: 4, padding: '1rem', marginBottom: '1rem' }}
+              >
+                <h2 style={{ marginTop: 0 }}>Identity Profile</h2>
+                <p><b>Version</b> {agent.version}</p>
+                <p><b>Sessions</b> {agent.session_count}</p>
+                <p><b>Policy violations</b> {agent.policy_violations_count}</p>
+                {agent.tool_names.length > 0 && (
+                  <p><b>Tools</b> {agent.tool_names.join(', ')}</p>
+                )}
+              </section>
+
+              <section data-testid="agent-events">
+                <h2>Recent Events</h2>
+                {eventsLoading && <p>Loading events…</p>}
+                {eventsError && <p style={{ color: 'var(--danger)' }}>Failed to load events.</p>}
+                {!eventsLoading && !eventsError && (!events || events.length === 0) && (
+                  <p>No events recorded for this agent.</p>
+                )}
+                {events && events.length > 0 && (
+                  <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' }}>
+                    <thead>
+                      <tr>
+                        <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid var(--line)' }}>Timestamp</th>
+                        <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid var(--line)' }}>Type</th>
+                        <th style={{ textAlign: 'left', padding: '0.4rem', borderBottom: '2px solid var(--line)' }}>Session</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {events.map(ev => (
+                        <tr key={`${ev.seq}-${ev.session_id}`} data-testid="event-row" style={{ borderBottom: '1px solid var(--line)' }}>
+                          <td style={{ padding: '0.4rem' }}>{ev.timestamp}</td>
+                          <td style={{ padding: '0.4rem' }}>{ev.event_type}</td>
+                          <td style={{ padding: '0.4rem' }}>
+                            <code style={{ fontSize: '0.75rem' }}>{ev.session_id.slice(0, 12)}…</code>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                )}
+              </section>
+            </div>
+          </>
+        )}
+      </div>
     </Drawer>
   )
 }

--- a/dashboard/src/pages/FleetPage.tsx
+++ b/dashboard/src/pages/FleetPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, Outlet, useNavigate } from 'react-router-dom'
 import {
   useReactTable,
   getCoreRowModel,
@@ -453,6 +453,11 @@ export function FleetPage() {
           </table>
         </div>
       )}
+
+      {/* Drawer overlay (Agent Detail) renders via nested route — sits on top
+          of the page via fixed positioning, so the Fleet table stays mounted
+          underneath and filter state is preserved when the drawer closes. */}
+      <Outlet />
     </main>
   )
 }


### PR DESCRIPTION
## Description

Fourth slice of the F90 Fleet + Agent Detail Story (AAASM-217). Converts the current full-page `AgentDetailPage` into a right-side drawer that overlays the Fleet page, matching `design/v1/agent-detail.jsx`. The Fleet table stays mounted underneath, so closing the drawer returns to `/agents` without re-fetching the agent list or losing filter / sort / selection state.

- **`<Drawer>` primitive** (`components/Drawer.{tsx,css}`) — right-side panel, dimmed scrim, ESC + scrim-click + caller-provided close button all dismiss. No focus trap in v1; scrim makes the rest of the page inert.
- **Nested route** — `/agents/:id` moves from a sibling page route into a child of `/agents`. `FleetPage` renders `<Outlet />` at the end of its tree; the trace sub-route `/agents/:id/trace/:sessionId` stays a sibling (it's a full-page view).
- **Drawer chrome** — breadcrumb \"← fleet › id\" (the back button is the close control), agent name + flag dot + framework chip + owner @-handle, five-column identity strip with DID / SVG trust gauge / mode+status chips / blocked24h / scrubbed24h.
- **Six tabs** — `Overview / Capability / Traffic / Policies / Lineage / Config` with `role=\"tablist\"` + `aria-selected`. Overview is fully wired (posture summary mini-bars derived from `session_count` + `policy_violations_count`, traffic-mix placeholder, recent events table reusing `useAgentEventsQuery`). The other five render an empty-state callout pointing at the most relevant follow-up.
- **Close behavior** — breadcrumb / scrim / Escape all navigate to `/agents` while preserving the URL filter search string, so `/agents/:id?q=alpha` closes back to `/agents?q=alpha`.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

The route path `/agents/:id` is unchanged from the consumer's perspective — only the rendering switches from full page to drawer overlay. Existing tests against `data-testid=\"agent-detail\"` still work.

## Scope reconciliation

The original AAASM-1052 description targeted `/fleet/:id` as the drawer path. Per the same canonical-route caveat applied to AAASM-1048 and AAASM-1050, AAASM-94 locks the Agent Detail path to `/agents/:id`. JIRA description updated in-flight with a `Scope reconciliation` comment.

## Related Issues

- Related Jira ticket: [AAASM-1052](https://lightning-dust-mite.atlassian.net/browse/AAASM-1052) (parent Story: [AAASM-217](https://lightning-dust-mite.atlassian.net/browse/AAASM-217), Epic [AAASM-197](https://lightning-dust-mite.atlassian.net/browse/AAASM-197))
- Builds on PRs #343 (AAASM-1047), #359 (AAASM-1048), #361 (AAASM-1050)

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required

Local validation in `dashboard/`:

```
pnpm type-check   # tsc --noEmit, clean
pnpm lint         # eslint --max-warnings 0, clean
pnpm test         # 40 files / 372 tests passing (incl. 20 new)
pnpm build        # tsc + vite build, clean
```

New tests:
- `components/Drawer.test.tsx` (7) — open-state / closed-state rendering, scrim click, panel-bubble immunity, Escape, non-Escape ignored, listener cleanup on close
- `pages/AgentDetailPage.test.tsx` (13) — deep-link rendering with Fleet underneath, DID formatting (with + without `metadata.owner`), close via breadcrumb / scrim / Escape, filter query-string preserved on close, Overview start state with posture + events, tab switching through the five follow-up empty states, loading + error states with Retry

## Checklist

- [x] Code follows project style guidelines (`pnpm lint`, `pnpm type-check` clean)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a — no public docs touched)
- [x] All CI checks passing (verified locally)
- [x] Commits are small and follow the Gitmoji convention (7 commits, one logical change each)

[AAASM-1052]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ