### PR TITLE
[AAASM-1346] ✨ (dashboard/capability): Wire per-resource and per-agent tabs on CapabilityPage

### DIFF
--- a/dashboard/src/features/capability/PerAgentTab.css
+++ b/dashboard/src/features/capability/PerAgentTab.css
@@ -1,0 +1,184 @@
+.cap-pat {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 1px;
+  background: var(--line);
+  min-height: 480px;
+}
+
+.cap-pat-tree {
+  background: var(--paper-2);
+  padding: 16px 12px;
+  overflow-y: auto;
+}
+
+.cap-pat-tree-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--ink-4);
+  margin-bottom: 8px;
+  padding: 0 4px;
+}
+
+.cap-pat-tree-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.cap-pat-tree-node {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  background: transparent;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  color: var(--ink-2);
+  cursor: pointer;
+  border-radius: 3px;
+  text-align: left;
+}
+
+.cap-pat-tree-node:hover {
+  background: var(--paper-3);
+}
+
+.cap-pat-tree-node.is-active {
+  background: var(--ink);
+  color: var(--paper-2);
+}
+
+.cap-pat-tree-caret {
+  color: var(--ink-4);
+  font-size: 10px;
+}
+
+.cap-pat-tree-node.is-active .cap-pat-tree-caret {
+  color: var(--paper-3);
+}
+
+.cap-pat-tree-name {
+  flex: 1;
+}
+
+.cap-pat-flag-dot {
+  color: var(--danger);
+  font-size: 10px;
+}
+
+.cap-pat-tree-node.is-active .cap-pat-flag-dot {
+  color: #fca5a5;
+}
+
+.cap-pat-flag-dot--head {
+  font-size: 14px;
+}
+
+.cap-pat-body {
+  background: var(--paper);
+  padding: 20px 24px;
+  overflow-y: auto;
+}
+
+.cap-pat-head {
+  margin-bottom: 16px;
+}
+
+.cap-pat-title {
+  margin: 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 16px;
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.cap-pat-meta {
+  margin: 4px 0 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  color: var(--ink-3);
+}
+
+.cap-pat-meta-note {
+  color: var(--danger);
+}
+
+.cap-pat-empty {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  color: var(--ink-4);
+  padding: 24px;
+  text-align: center;
+}
+
+.cap-pat-table-wrap {
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.cap-pat-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+}
+
+.cap-pat-table th {
+  text-align: left;
+  padding: 8px 12px;
+  background: var(--paper-3);
+  color: var(--ink-3);
+  font-weight: 500;
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--line);
+}
+
+.cap-pat-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--line);
+  vertical-align: middle;
+}
+
+.cap-pat-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.cap-pat-resource-group {
+  color: var(--ink-4);
+  font-size: 10px;
+}
+
+.cap-pat-cell {
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 10px;
+}
+
+.cap-pat-cell--allow .cap-pat-cell-label { color: var(--ink-2); }
+.cap-pat-cell--narrow .cap-pat-cell-label { color: var(--warn); }
+.cap-pat-cell--approval .cap-pat-cell-label { color: var(--info); }
+.cap-pat-cell--deny .cap-pat-cell-label { color: var(--danger); }
+.cap-pat-cell--na .cap-pat-cell-label { color: var(--ink-5); font-weight: 400; }
+
+.cap-pat-cell--allow,
+.cap-pat-cell--narrow,
+.cap-pat-cell--approval,
+.cap-pat-cell--deny {
+  cursor: pointer;
+}
+
+.cap-pat-cell--allow:hover,
+.cap-pat-cell--narrow:hover,
+.cap-pat-cell--approval:hover,
+.cap-pat-cell--deny:hover {
+  background: var(--paper-3);
+}

--- a/dashboard/src/features/capability/PerAgentTab.tsx
+++ b/dashboard/src/features/capability/PerAgentTab.tsx
@@ -1,0 +1,153 @@
+import { useMemo } from 'react'
+import type { CapabilityAgent, Decision, Resource } from './types'
+import { DECISIONS, VERBS } from './types'
+import type { CellSelection } from './CapabilityMatrixGrid'
+import './PerAgentTab.css'
+
+export interface PerAgentTabProps {
+  agents: CapabilityAgent[]
+  resources: Resource[]
+  selectedAgentId: string
+  onSelectAgent: (agentId: string) => void
+  onCellClick?: (cell: CellSelection) => void
+}
+
+export function PerAgentTab({
+  agents,
+  resources,
+  selectedAgentId,
+  onSelectAgent,
+  onCellClick,
+}: PerAgentTabProps) {
+  const selected = useMemo(
+    () => agents.find((a) => a.id === selectedAgentId) ?? agents[0],
+    [agents, selectedAgentId],
+  )
+
+  if (!selected) {
+    return (
+      <div className="cap-pat-empty" data-testid="per-agent-empty">
+        No agents available.
+      </div>
+    )
+  }
+
+  return (
+    <div className="cap-pat" data-testid="per-agent-tab">
+      <aside className="cap-pat-tree" aria-label="agents">
+        <div className="cap-pat-tree-label">Agents</div>
+        <ul className="cap-pat-tree-list">
+          {agents.map((a) => {
+            const active = a.id === selected.id
+            return (
+              <li key={a.id}>
+                <button
+                  type="button"
+                  className={`cap-pat-tree-node${active ? ' is-active' : ''}`}
+                  aria-current={active ? 'true' : undefined}
+                  data-testid={`per-agent-node-${a.id}`}
+                  onClick={() => onSelectAgent(a.id)}
+                >
+                  <span className="cap-pat-tree-caret" aria-hidden>
+                    ▸
+                  </span>
+                  <span className="cap-pat-tree-name">{a.name}</span>
+                  {a.flagged && (
+                    <span
+                      className="cap-pat-flag-dot"
+                      aria-label="agent flagged"
+                    >
+                      ●
+                    </span>
+                  )}
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      </aside>
+
+      <section className="cap-pat-body">
+        <header className="cap-pat-head">
+          <h2 className="cap-pat-title">
+            {selected.name}
+            {selected.flagged && (
+              <span
+                className="cap-pat-flag-dot cap-pat-flag-dot--head"
+                aria-label="agent flagged"
+              >
+                {' '}
+                ●
+              </span>
+            )}
+          </h2>
+          <p className="cap-pat-meta">
+            {selected.framework} · {selected.owner} · trust {selected.trust} ·{' '}
+            {selected.mode} mode
+            {selected.note && (
+              <>
+                {' '}
+                <span className="cap-pat-meta-note">— {selected.note}</span>
+              </>
+            )}
+          </p>
+        </header>
+
+        <div className="cap-pat-table-wrap">
+          <table className="cap-pat-table">
+            <thead>
+              <tr>
+                <th scope="col">resource</th>
+                {VERBS.map((v) => (
+                  <th key={v} scope="col">
+                    {v}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {resources.map((r) => {
+                const cap = selected.caps[r.id]
+                return (
+                  <tr key={r.id} data-testid={`per-agent-row-${r.id}`}>
+                    <td>
+                      <strong>{r.name}</strong>{' '}
+                      <span className="cap-pat-resource-group">· {r.group}</span>
+                    </td>
+                    {VERBS.map((v) => {
+                      const decision: Decision = cap?.[v] ?? 'na'
+                      const interactive = decision !== 'na'
+                      return (
+                        <td
+                          key={v}
+                          className={`cap-pat-cell cap-pat-cell--${decision}`}
+                          data-decision={decision}
+                          data-testid={`per-agent-cell-${r.id}-${v}`}
+                          onClick={
+                            interactive && onCellClick
+                              ? () =>
+                                  onCellClick({
+                                    agent: selected,
+                                    resource: r,
+                                    verb: v,
+                                    decision,
+                                  })
+                              : undefined
+                          }
+                        >
+                          <span className="cap-pat-cell-label">
+                            {DECISIONS[decision].label}
+                          </span>
+                        </td>
+                      )
+                    })}
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/dashboard/src/features/capability/PerResourceTab.css
+++ b/dashboard/src/features/capability/PerResourceTab.css
@@ -1,0 +1,233 @@
+.cap-prt {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 1px;
+  background: var(--line);
+  min-height: 480px;
+}
+
+.cap-prt-tree {
+  background: var(--paper-2);
+  padding: 16px 12px;
+  overflow-y: auto;
+}
+
+.cap-prt-tree-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--ink-4);
+  margin-bottom: 8px;
+  padding: 0 4px;
+}
+
+.cap-prt-tree-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.cap-prt-tree-node {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  background: transparent;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  color: var(--ink-2);
+  cursor: pointer;
+  border-radius: 3px;
+  text-align: left;
+}
+
+.cap-prt-tree-node:hover {
+  background: var(--paper-3);
+}
+
+.cap-prt-tree-node.is-active {
+  background: var(--ink);
+  color: var(--paper-2);
+}
+
+.cap-prt-tree-caret {
+  color: var(--ink-4);
+  font-size: 10px;
+}
+
+.cap-prt-tree-node.is-active .cap-prt-tree-caret {
+  color: var(--paper-3);
+}
+
+.cap-prt-tree-name {
+  flex: 1;
+}
+
+.cap-prt-tree-count {
+  font-size: 10px;
+  color: var(--ink-4);
+}
+
+.cap-prt-tree-node.is-active .cap-prt-tree-count {
+  color: var(--paper-3);
+}
+
+.cap-prt-body {
+  background: var(--paper);
+  padding: 20px 24px;
+  overflow-y: auto;
+}
+
+.cap-prt-head {
+  margin-bottom: 16px;
+}
+
+.cap-prt-title {
+  margin: 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 16px;
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.cap-prt-title-verb {
+  color: var(--warn);
+  text-transform: uppercase;
+}
+
+.cap-prt-title-resource {
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--ink);
+}
+
+.cap-prt-meta {
+  margin: 4px 0 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  color: var(--ink-3);
+}
+
+.cap-prt-empty {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  color: var(--ink-4);
+  padding: 24px;
+  text-align: center;
+  background: var(--paper-2);
+  border: 1px dashed var(--line-2);
+  border-radius: 3px;
+}
+
+.cap-prt-table-wrap {
+  background: var(--paper-2);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.cap-prt-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+}
+
+.cap-prt-table th {
+  text-align: left;
+  padding: 8px 12px;
+  background: var(--paper-3);
+  color: var(--ink-3);
+  font-weight: 500;
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--line);
+}
+
+.cap-prt-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--line);
+  vertical-align: middle;
+}
+
+.cap-prt-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.cap-prt-flag-dot {
+  color: var(--danger);
+}
+
+.cap-prt-trust {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cap-prt-trust-num {
+  width: 24px;
+  color: var(--ink-2);
+}
+
+.cap-prt-trust-bar {
+  flex: 1;
+  height: 4px;
+  background: var(--paper-3);
+  border-radius: 2px;
+  overflow: hidden;
+  max-width: 80px;
+}
+
+.cap-prt-trust-bar-fill {
+  display: block;
+  height: 100%;
+}
+
+.cap-prt-trust--danger { background: var(--danger); }
+.cap-prt-trust--warn { background: var(--warn); }
+.cap-prt-trust--ok { background: var(--ok); }
+
+.cap-prt-decision {
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 2px;
+}
+
+.cap-prt-decision--allow { color: var(--ink-2); background: var(--paper-3); }
+.cap-prt-decision--narrow { color: var(--warn); background: var(--warn-bg); }
+.cap-prt-decision--approval { color: var(--info); background: var(--info-bg); }
+.cap-prt-decision--deny { color: var(--danger); background: var(--danger-bg); }
+.cap-prt-decision--na { color: var(--ink-5); background: var(--paper-3); }
+
+.cap-prt-last-seen {
+  color: var(--ink-4);
+  font-size: 11px;
+}
+
+.cap-prt-inspect-btn {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  padding: 4px 10px;
+  border: 1px solid var(--line);
+  background: var(--paper-2);
+  color: var(--ink-2);
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.cap-prt-inspect-btn:hover {
+  background: var(--paper-3);
+}
+
+.cap-prt-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}

--- a/dashboard/src/features/capability/PerResourceTab.tsx
+++ b/dashboard/src/features/capability/PerResourceTab.tsx
@@ -1,0 +1,176 @@
+import { useMemo } from 'react'
+import type { CapabilityAgent, Resource, Verb } from './types'
+import { DECISIONS } from './types'
+import type { CellSelection } from './CapabilityMatrixGrid'
+import './PerResourceTab.css'
+
+export interface PerResourceTabProps {
+  resources: Resource[]
+  agents: CapabilityAgent[]
+  verb: Verb
+  selectedResourceId: string
+  onSelectResource: (resourceId: string) => void
+  onCellClick?: (cell: CellSelection) => void
+}
+
+function trustToneClass(trust: number): string {
+  if (trust < 60) return 'cap-prt-trust--danger'
+  if (trust < 80) return 'cap-prt-trust--warn'
+  return 'cap-prt-trust--ok'
+}
+
+export function PerResourceTab({
+  resources,
+  agents,
+  verb,
+  selectedResourceId,
+  onSelectResource,
+  onCellClick,
+}: PerResourceTabProps) {
+  const selected = useMemo(
+    () => resources.find((r) => r.id === selectedResourceId) ?? resources[0],
+    [resources, selectedResourceId],
+  )
+
+  const inScope = useMemo(
+    () =>
+      selected
+        ? agents.filter((a) => (a.caps[selected.id]?.[verb] ?? 'na') !== 'na')
+        : [],
+    [agents, selected, verb],
+  )
+
+  if (!selected) {
+    return (
+      <div className="cap-prt-empty" data-testid="per-resource-empty">
+        No resources available.
+      </div>
+    )
+  }
+
+  return (
+    <div className="cap-prt" data-testid="per-resource-tab">
+      <aside className="cap-prt-tree" aria-label="resources">
+        <div className="cap-prt-tree-label">Resources</div>
+        <ul className="cap-prt-tree-list">
+          {resources.map((r) => {
+            const count = agents.filter(
+              (a) => (a.caps[r.id]?.[verb] ?? 'na') !== 'na',
+            ).length
+            const active = r.id === selected.id
+            return (
+              <li key={r.id}>
+                <button
+                  type="button"
+                  className={`cap-prt-tree-node${active ? ' is-active' : ''}`}
+                  aria-current={active ? 'true' : undefined}
+                  data-testid={`per-resource-node-${r.id}`}
+                  onClick={() => onSelectResource(r.id)}
+                >
+                  <span className="cap-prt-tree-caret" aria-hidden>
+                    ▸
+                  </span>
+                  <span className="cap-prt-tree-name">{r.name}</span>
+                  <span className="cap-prt-tree-count">{count}</span>
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      </aside>
+
+      <section className="cap-prt-body">
+        <header className="cap-prt-head">
+          <h2 className="cap-prt-title">
+            Who can <span className="cap-prt-title-verb">{verb}</span> on{' '}
+            <span className="cap-prt-title-resource">{selected.name}</span>?
+          </h2>
+          <p className="cap-prt-meta">
+            {selected.paths.length} resource paths · {inScope.length} agent
+            {inScope.length === 1 ? '' : 's'} in scope
+          </p>
+        </header>
+
+        {inScope.length === 0 ? (
+          <div className="cap-prt-empty" data-testid="per-resource-empty-body">
+            No agent declares <code>{verb}</code> on <code>{selected.name}</code>.
+          </div>
+        ) : (
+          <div className="cap-prt-table-wrap">
+            <table className="cap-prt-table">
+              <thead>
+                <tr>
+                  <th scope="col">agent</th>
+                  <th scope="col">trust</th>
+                  <th scope="col">effective</th>
+                  <th scope="col">last call</th>
+                  <th scope="col">
+                    <span className="cap-prt-sr">actions</span>
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {inScope.map((a) => {
+                  const decision = a.caps[selected.id][verb]
+                  return (
+                    <tr key={a.id} data-testid={`per-resource-row-${a.id}`}>
+                      <td>
+                        <strong>{a.name}</strong>
+                        {a.flagged && (
+                          <span
+                            className="cap-prt-flag-dot"
+                            aria-label="agent flagged"
+                          >
+                            {' '}
+                            ●
+                          </span>
+                        )}
+                      </td>
+                      <td>
+                        <div className="cap-prt-trust">
+                          <span className="cap-prt-trust-num">{a.trust}</span>
+                          <span className="cap-prt-trust-bar" aria-hidden>
+                            <span
+                              className={`cap-prt-trust-bar-fill ${trustToneClass(a.trust)}`}
+                              style={{ width: `${a.trust}%` }}
+                            />
+                          </span>
+                        </div>
+                      </td>
+                      <td>
+                        <span
+                          className={`cap-prt-decision cap-prt-decision--${decision}`}
+                          data-decision={decision}
+                        >
+                          {DECISIONS[decision].label}
+                        </span>
+                      </td>
+                      <td className="cap-prt-last-seen">{a.lastSeen}</td>
+                      <td>
+                        <button
+                          type="button"
+                          className="cap-prt-inspect-btn"
+                          data-testid={`per-resource-inspect-${a.id}`}
+                          onClick={() =>
+                            onCellClick?.({
+                              agent: a,
+                              resource: selected,
+                              verb,
+                              decision,
+                            })
+                          }
+                        >
+                          inspect
+                        </button>
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/dashboard/src/features/capability/__tests__/PerAgentTab.test.tsx
+++ b/dashboard/src/features/capability/__tests__/PerAgentTab.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { PerAgentTab } from '../PerAgentTab'
+import type { CapabilityAgent, Resource } from '../types'
+
+const RESOURCES: Resource[] = [
+  { id: 'gmail', name: 'Gmail', group: 'comm', paths: ['gmail/*'] },
+  { id: 's3', name: 'AWS S3', group: 'files', paths: ['s3://*'] },
+]
+
+const AGENTS: CapabilityAgent[] = [
+  {
+    id: 'agent-a',
+    name: 'agent-a',
+    framework: 'LangChain',
+    owner: 'team-x',
+    trust: 50,
+    mode: 'enforce',
+    status: 'active',
+    lastSeen: '1m ago',
+    flagged: true,
+    note: 'over-permissioned',
+    caps: {
+      gmail: { read: 'allow', write: 'narrow', delete: 'deny', exec: 'na' },
+      s3: { read: 'na', write: 'na', delete: 'na', exec: 'na' },
+    },
+  },
+  {
+    id: 'agent-b',
+    name: 'agent-b',
+    framework: 'CrewAI',
+    owner: 'team-y',
+    trust: 85,
+    mode: 'enforce',
+    status: 'active',
+    lastSeen: '3s ago',
+    caps: {
+      gmail: { read: 'narrow', write: 'na', delete: 'na', exec: 'na' },
+      s3: { read: 'allow', write: 'na', delete: 'na', exec: 'na' },
+    },
+  },
+]
+
+describe('PerAgentTab', () => {
+  it('lists every agent in the tree', () => {
+    render(
+      <PerAgentTab
+        agents={AGENTS}
+        resources={RESOURCES}
+        selectedAgentId="agent-a"
+        onSelectAgent={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('per-agent-node-agent-a')).toBeInTheDocument()
+    expect(screen.getByTestId('per-agent-node-agent-b')).toBeInTheDocument()
+  })
+
+  it('renders one row per resource with all four verb columns for the selected agent', () => {
+    render(
+      <PerAgentTab
+        agents={AGENTS}
+        resources={RESOURCES}
+        selectedAgentId="agent-a"
+        onSelectAgent={vi.fn()}
+      />,
+    )
+    const gmailRow = screen.getByTestId('per-agent-row-gmail')
+    expect(gmailRow).toBeInTheDocument()
+    expect(screen.getByTestId('per-agent-cell-gmail-read')).toHaveAttribute(
+      'data-decision',
+      'allow',
+    )
+    expect(screen.getByTestId('per-agent-cell-gmail-write')).toHaveAttribute(
+      'data-decision',
+      'narrow',
+    )
+    expect(screen.getByTestId('per-agent-cell-gmail-delete')).toHaveAttribute(
+      'data-decision',
+      'deny',
+    )
+    expect(screen.getByTestId('per-agent-cell-gmail-exec')).toHaveAttribute(
+      'data-decision',
+      'na',
+    )
+  })
+
+  it('calls onSelectAgent when a tree node is clicked', () => {
+    const onSelect = vi.fn()
+    render(
+      <PerAgentTab
+        agents={AGENTS}
+        resources={RESOURCES}
+        selectedAgentId="agent-a"
+        onSelectAgent={onSelect}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('per-agent-node-agent-b'))
+    expect(onSelect).toHaveBeenCalledWith('agent-b')
+  })
+
+  it('emits onCellClick for non-na cells with the right selection', () => {
+    const onCellClick = vi.fn()
+    render(
+      <PerAgentTab
+        agents={AGENTS}
+        resources={RESOURCES}
+        selectedAgentId="agent-a"
+        onSelectAgent={vi.fn()}
+        onCellClick={onCellClick}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('per-agent-cell-gmail-write'))
+    expect(onCellClick).toHaveBeenCalledWith({
+      agent: AGENTS[0],
+      resource: RESOURCES[0],
+      verb: 'write',
+      decision: 'narrow',
+    })
+  })
+
+  it('does not call onCellClick for na cells', () => {
+    const onCellClick = vi.fn()
+    render(
+      <PerAgentTab
+        agents={AGENTS}
+        resources={RESOURCES}
+        selectedAgentId="agent-a"
+        onSelectAgent={vi.fn()}
+        onCellClick={onCellClick}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('per-agent-cell-gmail-exec'))
+    expect(onCellClick).not.toHaveBeenCalled()
+  })
+
+  it('shows the empty state when no agents are provided', () => {
+    render(
+      <PerAgentTab
+        agents={[]}
+        resources={RESOURCES}
+        selectedAgentId=""
+        onSelectAgent={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('per-agent-empty')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/features/capability/__tests__/PerResourceTab.test.tsx
+++ b/dashboard/src/features/capability/__tests__/PerResourceTab.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { PerResourceTab } from '../PerResourceTab'
+import type { CapabilityAgent, Resource } from '../types'
+
+const RESOURCES: Resource[] = [
+  { id: 'gmail', name: 'Gmail', group: 'comm', paths: ['gmail/*'] },
+  { id: 's3', name: 'AWS S3', group: 'files', paths: ['s3://*'] },
+]
+
+const AGENTS: CapabilityAgent[] = [
+  {
+    id: 'agent-a',
+    name: 'agent-a',
+    framework: 'LangChain',
+    owner: 'team-x',
+    trust: 50,
+    mode: 'enforce',
+    status: 'active',
+    lastSeen: '1m ago',
+    flagged: true,
+    caps: {
+      gmail: { read: 'allow', write: 'deny', delete: 'na', exec: 'na' },
+      s3: { read: 'na', write: 'na', delete: 'na', exec: 'na' },
+    },
+  },
+  {
+    id: 'agent-b',
+    name: 'agent-b',
+    framework: 'CrewAI',
+    owner: 'team-y',
+    trust: 85,
+    mode: 'enforce',
+    status: 'active',
+    lastSeen: '3s ago',
+    caps: {
+      gmail: { read: 'narrow', write: 'na', delete: 'na', exec: 'na' },
+      s3: { read: 'allow', write: 'na', delete: 'na', exec: 'na' },
+    },
+  },
+]
+
+describe('PerResourceTab', () => {
+  it('lists every resource and shows the in-scope agent count for the current verb', () => {
+    render(
+      <PerResourceTab
+        resources={RESOURCES}
+        agents={AGENTS}
+        verb="read"
+        selectedResourceId="gmail"
+        onSelectResource={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByTestId('per-resource-node-gmail')).toHaveTextContent('Gmail')
+    expect(screen.getByTestId('per-resource-node-s3')).toHaveTextContent('AWS S3')
+    // Both agents declare read on gmail (allow + narrow), only one on s3 (allow).
+    expect(screen.getByTestId('per-resource-node-gmail')).toHaveTextContent('2')
+    expect(screen.getByTestId('per-resource-node-s3')).toHaveTextContent('1')
+  })
+
+  it('renders only agents whose decision for the current verb is non-na', () => {
+    render(
+      <PerResourceTab
+        resources={RESOURCES}
+        agents={AGENTS}
+        verb="write"
+        selectedResourceId="gmail"
+        onSelectResource={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('per-resource-row-agent-a')).toBeInTheDocument()
+    expect(screen.queryByTestId('per-resource-row-agent-b')).not.toBeInTheDocument()
+  })
+
+  it('calls onSelectResource when a tree node is clicked', () => {
+    const onSelect = vi.fn()
+    render(
+      <PerResourceTab
+        resources={RESOURCES}
+        agents={AGENTS}
+        verb="read"
+        selectedResourceId="gmail"
+        onSelectResource={onSelect}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('per-resource-node-s3'))
+    expect(onSelect).toHaveBeenCalledWith('s3')
+  })
+
+  it('emits onCellClick with the inspected cell when the inspect button is clicked', () => {
+    const onCellClick = vi.fn()
+    render(
+      <PerResourceTab
+        resources={RESOURCES}
+        agents={AGENTS}
+        verb="read"
+        selectedResourceId="gmail"
+        onSelectResource={vi.fn()}
+        onCellClick={onCellClick}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('per-resource-inspect-agent-b'))
+    expect(onCellClick).toHaveBeenCalledWith({
+      agent: AGENTS[1],
+      resource: RESOURCES[0],
+      verb: 'read',
+      decision: 'narrow',
+    })
+  })
+
+  it('shows the empty body when no agents declare the verb on the selected resource', () => {
+    render(
+      <PerResourceTab
+        resources={RESOURCES}
+        agents={AGENTS}
+        verb="exec"
+        selectedResourceId="gmail"
+        onSelectResource={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('per-resource-empty-body')).toBeInTheDocument()
+  })
+
+  it('shows the page-level empty state when no resources are provided', () => {
+    render(
+      <PerResourceTab
+        resources={[]}
+        agents={AGENTS}
+        verb="read"
+        selectedResourceId=""
+        onSelectResource={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('per-resource-empty')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/pages/CapabilityPage.tsx
+++ b/dashboard/src/pages/CapabilityPage.tsx
@@ -8,6 +8,8 @@ import { BulkActionBar } from '../features/capability/BulkActionBar'
 import { CapabilityMatrixGrid, type CellSelection } from '../features/capability/CapabilityMatrixGrid'
 import { CapabilityFilterBar } from '../features/capability/CapabilityFilterBar'
 import { CellInspectDrawer } from '../features/capability/CellInspectDrawer'
+import { PerAgentTab } from '../features/capability/PerAgentTab'
+import { PerResourceTab } from '../features/capability/PerResourceTab'
 import { EMPTY_FILTERS, applyFilters, type CapabilityFilters } from '../features/capability/filters'
 import { applyOverrideLocal } from '../features/capability/override'
 import { NO_SORT, nextSortState, sortAgents, type SortState } from '../features/capability/sort'
@@ -27,6 +29,8 @@ export function CapabilityPage() {
   const [sort, setSort] = useState<SortState>(NO_SORT)
   const [inspected, setInspected] = useState<CellSelection | null>(null)
   const [selected, setSelected] = useState<Set<string>>(new Set())
+  const [perResourceId, setPerResourceId] = useState<string | null>(null)
+  const [perAgentId, setPerAgentId] = useState<string | null>(null)
   const { toast } = useToast()
 
   const toggleSelect = (agentId: string) => {
@@ -208,6 +212,25 @@ export function CapabilityPage() {
             selectedIds={selected}
             onToggleSelect={toggleSelect}
             onToggleSelectAll={toggleSelectAll}
+          />
+        )}
+        {tab === 'resource' && matrix && (
+          <PerResourceTab
+            resources={matrix.resources}
+            agents={visibleAgents}
+            verb={verb}
+            selectedResourceId={perResourceId ?? matrix.resources[0]?.id ?? ''}
+            onSelectResource={setPerResourceId}
+            onCellClick={setInspected}
+          />
+        )}
+        {tab === 'agent' && matrix && (
+          <PerAgentTab
+            agents={visibleAgents}
+            resources={matrix.resources}
+            selectedAgentId={perAgentId ?? visibleAgents[0]?.id ?? ''}
+            onSelectAgent={setPerAgentId}
+            onCellClick={setInspected}
           />
         )}
       </section>


### PR DESCRIPTION
## Description

Completes the `/capability` page by wiring the **Per-resource** and **Per-agent** tab bodies. Previously the two tab buttons existed in the page header but switching to them rendered nothing — the page only displayed the matrix.

This PR:

- Adds `PerResourceTab` — left tree of all resources (with per-verb agent counts), right table listing every agent that declares the current verb on the selected resource, with per-row `inspect` button that opens the existing `CellInspectDrawer`.
- Adds `PerAgentTab` — left tree of all agents (with flag dots), right table with one row per resource and one column per verb. Non-`na` cells click through to the same drawer.
- Wires both into `CapabilityPage` body and threads the cell-click handler so all three tabs share the same drawer state.
- Adds component tests covering tree rendering, in-scope filtering, click-to-select, inspect/cell click-through, `na`-cell non-interactivity, and empty-state branches.

All decision colours and trust-bar tones come from `design/v1/styles.css` tokens; no hard-coded hex values.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: **AAASM-1346** (sub-task of AAASM-1283 — Dashboard PR 10)

## Background — sub-task scope correction

AAASM-1346 was originally scoped as \"Implement /data overview page with expandable detail drawer\". Discovery during pickup revealed that `design/v1/data.jsx` is a **fixture file** (`window.RESOURCES`, `window.AGENTS`), not a page component. The actual page that consumes those fixtures is `capability.jsx`, and the canonical 12-route layout already has a `/capability` route. The `CapabilityPage` matrix tab + filter / sort / drawer / bulk-override + tests were already built in earlier capability commits — only the per-resource and per-agent tab bodies were missing.

This PR finishes the page by delivering the missing two tabs. AAASM-1283 has been updated; AAASM-1348 (`/data/audit`) was closed as obsolete (no such route in the hi-fi).

## Testing

- [x] Unit tests added — `PerResourceTab.test.tsx` (6 cases), `PerAgentTab.test.tsx` (6 cases)
- [x] Manual testing performed — full dashboard test suite green (398 tests across 43 files), `pnpm type-check` and `pnpm lint` clean
- [ ] Integration tests added / updated

Manual walkthrough still TODO — gated on the Sprint 3 verification sub-task AAASM-1352.

## Checklist

- [x] Code follows project style guidelines (`pnpm type-check` and `pnpm lint` pass; lefthook Rust hooks skip — no `*.rs` changes)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed (no public-facing docs change; sub-task description in JIRA updated)
- [x] All CI checks passing (locally)
- [x] Commits are small and follow the Gitmoji convention (4 commits: PerResourceTab → PerAgentTab → wiring → tests)