### PR TITLE
[AAASM-1375] 🎨 (approvals): Migrate ApprovalsPage colors to design tokens

### DIFF
--- a/dashboard/src/pages/ApprovalsPage.css
+++ b/dashboard/src/pages/ApprovalsPage.css
@@ -10,12 +10,12 @@
 }
 
 .approvals-state {
-  color: #6b7280;
+  color: var(--ink-3);
   font-size: 0.875rem;
 }
 
 .approvals-state--error {
-  color: #b91c1c;
+  color: var(--danger);
 }
 
 .approvals-table {
@@ -27,24 +27,24 @@
 .approvals-table th {
   text-align: left;
   padding: 8px 12px;
-  border-bottom: 2px solid #e5e7eb;
-  color: #374151;
+  border-bottom: 2px solid var(--line);
+  color: var(--ink-2);
   font-weight: 600;
 }
 
 .approvals-table td {
   padding: 8px 12px;
-  border-bottom: 1px solid #f3f4f6;
-  color: #111827;
+  border-bottom: 1px solid var(--line);
+  color: var(--ink);
   vertical-align: middle;
 }
 
 .approvals-table__id {
   font-family: monospace;
   font-size: 0.75rem;
-  color: #6b7280;
+  color: var(--ink-3);
 }
 
 .approvals-table__unrouted {
-  color: #9ca3af;
+  color: var(--ink-4);
 }

--- a/dashboard/src/pages/ApprovalsPage.tsx
+++ b/dashboard/src/pages/ApprovalsPage.tsx
@@ -30,7 +30,7 @@ function RejectDialog({ count, onConfirm, onCancel }: RejectDialogProps) {
       data-testid="reject-dialog"
     >
       <div style={{
-        background: '#fff', borderRadius: '0.5rem', padding: '1.5rem',
+        background: 'var(--paper-2)', borderRadius: '0.5rem', padding: '1.5rem',
         width: '24rem', display: 'flex', flexDirection: 'column', gap: '1rem',
       }}>
         <h2 style={{ margin: 0, fontSize: '1rem', fontWeight: 600 }}>
@@ -43,13 +43,13 @@ function RejectDialog({ count, onConfirm, onCancel }: RejectDialogProps) {
             rows={3}
             value={reason}
             onChange={(e) => setReason(e.target.value)}
-            style={{ padding: '0.5rem', borderRadius: '0.25rem', border: '1px solid #d1d5db', resize: 'vertical' }}
+            style={{ padding: '0.5rem', borderRadius: '0.25rem', border: '1px solid var(--line)', resize: 'vertical' }}
           />
         </label>
         <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
           <button
             onClick={onCancel}
-            style={{ padding: '0.4rem 0.75rem', borderRadius: '0.25rem', border: '1px solid #d1d5db', cursor: 'pointer' }}
+            style={{ padding: '0.4rem 0.75rem', borderRadius: '0.25rem', border: '1px solid var(--line)', cursor: 'pointer' }}
           >
             Cancel
           </button>
@@ -59,8 +59,8 @@ function RejectDialog({ count, onConfirm, onCancel }: RejectDialogProps) {
             onClick={() => onConfirm(reason.trim())}
             style={{
               padding: '0.4rem 0.75rem', borderRadius: '0.25rem', border: 'none',
-              background: !reason.trim() ? '#9ca3af' : '#dc2626',
-              color: '#fff', cursor: !reason.trim() ? 'not-allowed' : 'pointer',
+              background: !reason.trim() ? 'var(--ink-4)' : 'var(--danger)',
+              color: 'var(--paper-2)', cursor: !reason.trim() ? 'not-allowed' : 'pointer',
               fontWeight: 600,
             }}
           >

--- a/dashboard/src/pages/ApprovalsPage.tsx
+++ b/dashboard/src/pages/ApprovalsPage.tsx
@@ -89,17 +89,17 @@ function TabBar({
     return {
       padding: '0.5rem 1rem',
       fontWeight: active === t ? 600 : 400,
-      color: active === t ? '#2563eb' : '#6b7280',
+      color: active === t ? 'var(--info)' : 'var(--ink-3)',
       cursor: 'pointer',
       background: 'none',
       border: 'none',
-      borderBottom: `2px solid ${active === t ? '#2563eb' : 'transparent'}`,
+      borderBottom: `2px solid ${active === t ? 'var(--info)' : 'transparent'}`,
       fontSize: '0.875rem',
     } as React.CSSProperties
   }
 
   return (
-    <div style={{ display: 'flex', borderBottom: '1px solid #e5e7eb', marginBottom: '1rem' }} data-testid="tab-bar">
+    <div style={{ display: 'flex', borderBottom: '1px solid var(--line)', marginBottom: '1rem' }} data-testid="tab-bar">
       <button style={tabStyle('pending')} onClick={() => onChange('pending')} data-testid="tab-pending">
         Pending ({pendingCount})
       </button>

--- a/dashboard/src/pages/ApprovalsPage.tsx
+++ b/dashboard/src/pages/ApprovalsPage.tsx
@@ -290,13 +290,13 @@ export function ApprovalsPage() {
                     <tr key={i} data-testid="approval-row-skeleton">
                       {Array.from({ length: 7 }).map((_, j) => (
                         <td key={j} style={{ padding: '8px 12px' }}>
-                          <span style={{ display: 'block', height: '0.875rem', background: '#e5e7eb', borderRadius: '4px' }} />
+                          <span style={{ display: 'block', height: '0.875rem', background: 'var(--line)', borderRadius: '4px' }} />
                         </td>
                       ))}
                     </tr>
                   ))
                   : pending.map((row) => (
-                    <tr key={row.id} data-testid="approval-row" style={{ borderBottom: '1px solid #f3f4f6' }}>
+                    <tr key={row.id} data-testid="approval-row" style={{ borderBottom: '1px solid var(--line)' }}>
                       <td style={{ padding: '8px 12px' }}>
                         <input
                           type="checkbox"
@@ -321,7 +321,7 @@ export function ApprovalsPage() {
                           onClick={() => void handleApprove([row.id])}
                           style={{
                             padding: '0.2rem 0.6rem', borderRadius: '0.25rem',
-                            background: '#16a34a', color: '#fff', border: 'none', cursor: 'pointer', fontSize: '0.75rem',
+                            background: 'var(--ok)', color: 'var(--paper-2)', border: 'none', cursor: 'pointer', fontSize: '0.75rem',
                           }}
                         >
                           Approve
@@ -331,7 +331,7 @@ export function ApprovalsPage() {
                           onClick={() => setRejectFor([row.id])}
                           style={{
                             padding: '0.2rem 0.6rem', borderRadius: '0.25rem',
-                            background: '#dc2626', color: '#fff', border: 'none', cursor: 'pointer', fontSize: '0.75rem',
+                            background: 'var(--danger)', color: 'var(--paper-2)', border: 'none', cursor: 'pointer', fontSize: '0.75rem',
                           }}
                         >
                           Reject

--- a/dashboard/src/pages/ApprovalsPage.tsx
+++ b/dashboard/src/pages/ApprovalsPage.tsx
@@ -221,17 +221,17 @@ export function ApprovalsPage() {
               data-testid="bulk-toolbar"
               style={{
                 display: 'flex', gap: '0.5rem', alignItems: 'center',
-                padding: '0.5rem 0.75rem', background: '#eff6ff',
+                padding: '0.5rem 0.75rem', background: 'var(--info-bg)',
                 borderRadius: '0.375rem', marginBottom: '0.75rem', fontSize: '0.875rem',
               }}
             >
-              <span style={{ color: '#1d4ed8', fontWeight: 500 }}>{selected.size} selected</span>
+              <span style={{ color: 'var(--info)', fontWeight: 500 }}>{selected.size} selected</span>
               <button
                 data-testid="bulk-approve-btn"
                 onClick={() => void handleApprove(Array.from(selected))}
                 style={{
                   padding: '0.25rem 0.75rem', borderRadius: '0.25rem',
-                  background: '#16a34a', color: '#fff', border: 'none', cursor: 'pointer', fontWeight: 600,
+                  background: 'var(--ok)', color: 'var(--paper-2)', border: 'none', cursor: 'pointer', fontWeight: 600,
                 }}
               >
                 Approve selected
@@ -241,7 +241,7 @@ export function ApprovalsPage() {
                 onClick={() => setRejectFor(Array.from(selected))}
                 style={{
                   padding: '0.25rem 0.75rem', borderRadius: '0.25rem',
-                  background: '#dc2626', color: '#fff', border: 'none', cursor: 'pointer', fontWeight: 600,
+                  background: 'var(--danger)', color: 'var(--paper-2)', border: 'none', cursor: 'pointer', fontWeight: 600,
                 }}
               >
                 Reject selected

--- a/dashboard/src/pages/ApprovalsPage.tsx
+++ b/dashboard/src/pages/ApprovalsPage.tsx
@@ -197,8 +197,8 @@ export function ApprovalsPage() {
             data-testid="ws-disconnected-banner"
             style={{
               fontSize: '0.75rem', padding: '0.25rem 0.75rem',
-              background: '#fef9c3', border: '1px solid #fde047',
-              borderRadius: '9999px', color: '#854d0e',
+              background: 'var(--warn-bg)', border: '1px solid var(--warn)',
+              borderRadius: '9999px', color: 'var(--warn)',
             }}
           >
             Live updates disconnected — reconnecting…
@@ -252,7 +252,7 @@ export function ApprovalsPage() {
           {isError && (
             <div
               data-testid="approvals-error"
-              style={{ color: '#dc2626', marginBottom: '0.75rem', display: 'flex', gap: '0.75rem', alignItems: 'center', fontSize: '0.875rem' }}
+              style={{ color: 'var(--danger)', marginBottom: '0.75rem', display: 'flex', gap: '0.75rem', alignItems: 'center', fontSize: '0.875rem' }}
             >
               <span>Failed to load approvals.</span>
               <button onClick={() => void refetch()}>Retry</button>
@@ -350,7 +350,7 @@ export function ApprovalsPage() {
           {decidedHistory.length === 0 ? (
             <p data-testid="decided-empty" className="approvals-state">
               No decisions in this session.{' '}
-              <span style={{ color: '#9ca3af', fontSize: '0.8rem' }}>
+              <span style={{ color: 'var(--ink-4)', fontSize: '0.8rem' }}>
                 (Historical decided approvals are not available via the current API.)
               </span>
             </p>
@@ -375,8 +375,8 @@ export function ApprovalsPage() {
                       <span
                         style={{
                           display: 'inline-block', padding: '2px 8px', borderRadius: '9999px',
-                          fontSize: '0.75rem', fontWeight: 600, color: '#fff',
-                          background: row.status === 'approved' ? '#16a34a' : '#dc2626',
+                          fontSize: '0.75rem', fontWeight: 600, color: 'var(--paper-2)',
+                          background: row.status === 'approved' ? 'var(--ok)' : 'var(--danger)',
                         }}
                       >
                         {row.status}


### PR DESCRIPTION
## Description

Replaces all hard-coded hex literals in `dashboard/src/pages/ApprovalsPage.tsx` and `ApprovalsPage.css` with design tokens from `dashboard/src/styles.css`. No behavioural change — pure refactor.

Closes one of the AAASM-1294 (Dashboard PR 11 — Approvals page) AC items: *"Use `styles.css` color tokens exclusively — no hard-coded hex colors."*

## Type of Change

- [x] ♻️ Refactoring

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1375 (subtask of AAASM-1294 / Epic AAASM-11)
- Verifies AC line: *"Color tokens come exclusively from the design token system — no hard-coded colors."*

## Testing

- [x] Unit tests added / updated — existing `ApprovalsPage.test.tsx` (3 tests) all pass
- [x] Manual testing performed — `pnpm test`, `pnpm type-check`, `pnpm lint` all clean

Verification commands:

```bash
cd dashboard
pnpm test --run src/pages/ApprovalsPage.test.tsx   # 3 passed
pnpm type-check                                    # clean
pnpm lint                                          # clean
grep -nE '#[0-9a-fA-F]{3,6}\b' src/pages/ApprovalsPage.{tsx,css}  # zero matches
```

## Token mapping

| Hard-coded literal | Token | Region |
|---|---|---|
| `#fff` | `--paper-2` | reject dialog bg, button text, decision pill text |
| `#eff6ff` / `#1d4ed8` | `--info-bg` / `--info` | bulk toolbar bg + label |
| `#16a34a` | `--ok` | approve buttons + approved pill |
| `#dc2626` | `--danger` | reject buttons + rejected pill + error text |
| `#d1d5db` / `#e5e7eb` / `#f3f4f6` | `--line` | dialog borders, tab underline, table borders, skeleton |
| `#2563eb` | `--info` | active tab text + underline |
| `#6b7280` / `#374151` | `--ink-3` / `--ink-2` | muted state text, table header |
| `#9ca3af` | `--ink-4` | unrouted column, decided-empty hint, disabled reject btn |
| `#fef9c3` / `#854d0e` / `#fde047` | `--warn-bg` / `--warn` | WS-disconnected banner |
| `#111827` | `--ink` | table cell text |
| `#b91c1c` | `--danger` | `.approvals-state--error` |

## Commit history (granular)

```
🎨 (approvals): Migrate ApprovalsPage.css hex literals to design tokens
🎨 (approvals): Token bulk-toolbar colors
🎨 (approvals): Token reject-dialog colors
🎨 (approvals): Token tab-bar colors
🎨 (approvals): Token row action buttons, skeleton, row border
🎨 (approvals): Token WS banner, decision pill, error and decided-empty text
```

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed — N/A (refactor only)
- [x] All CI checks passing (verified locally)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)