### PR TITLE
[AAASM-1350] ✨ (dashboard/scrub): Add /scrub patterns library + sandbox payload diff

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -12,6 +12,7 @@ import { AlertsPage } from './pages/AlertsPage'
 import { CapabilityPage } from './pages/CapabilityPage'
 import { TraceViewPage } from './pages/TraceViewPage'
 import { LiveOpsPage } from './pages/LiveOpsPage'
+import { ScrubPage } from './pages/ScrubPage'
 import { ComingSoon } from './pages/ComingSoon'
 import { IdentityPage } from './pages/IdentityPage'
 import { TeamDetailPage } from './pages/TeamDetailPage'
@@ -41,7 +42,7 @@ function App() {
             {/* control */}
             <Route path="/capability" element={<CapabilityPage />} />
             <Route path="/policies" element={<PoliciesPage />} />
-            <Route path="/scrub" element={<ComingSoon name="Secret Scrubbing" />} />
+            <Route path="/scrub" element={<ScrubPage />} />
             {/* manage */}
             <Route path="/costs" element={<ComingSoon name="Cost & Budget" />} />
             <Route path="/teams" element={<TeamsPage />} />

--- a/dashboard/src/features/scrub/PatternDetail.css
+++ b/dashboard/src/features/scrub/PatternDetail.css
@@ -1,0 +1,99 @@
+.scrub-detail {
+  background: var(--paper-2);
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--line);
+}
+
+.scrub-detail-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.scrub-detail-eyebrow {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: var(--ink-4);
+}
+
+.scrub-detail-title {
+  margin: 2px 0 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--ink);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.scrub-detail-sev {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.scrub-detail-sev--critical { color: var(--danger); }
+.scrub-detail-sev--high { color: var(--warn); }
+.scrub-detail-sev--medium { color: var(--info); }
+.scrub-detail-sev--low { color: var(--ink-3); }
+
+.scrub-detail-collapse-btn {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  padding: 3px 9px;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  color: var(--ink-2);
+  cursor: pointer;
+  border-radius: 3px;
+}
+
+.scrub-detail-collapse-btn:hover {
+  background: var(--paper-3);
+}
+
+.scrub-detail-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 14px;
+  margin-top: 12px;
+}
+
+.scrub-detail-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--ink-4);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 3px;
+}
+
+.scrub-detail-code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  padding: 4px 6px;
+  border-radius: 2px;
+  display: block;
+  word-break: break-all;
+}
+
+.scrub-detail-code--regex {
+  background: var(--paper);
+  border: 1px solid var(--line);
+  color: var(--ink);
+}
+
+.scrub-detail-code--example {
+  background: var(--danger-bg);
+  color: var(--danger);
+  text-decoration: line-through;
+}
+
+.scrub-detail-code--replace {
+  background: var(--scrub-bg);
+  color: var(--scrub);
+}

--- a/dashboard/src/features/scrub/PatternDetail.tsx
+++ b/dashboard/src/features/scrub/PatternDetail.tsx
@@ -1,0 +1,79 @@
+import type { ScrubPattern } from './types'
+import './PatternDetail.css'
+
+export interface PatternDetailProps {
+  pattern: ScrubPattern
+  collapsed: boolean
+  onToggleCollapsed: () => void
+}
+
+export function PatternDetail({
+  pattern,
+  collapsed,
+  onToggleCollapsed,
+}: PatternDetailProps) {
+  return (
+    <section
+      className="scrub-detail"
+      aria-label="selected pattern detail"
+      data-testid="scrub-detail"
+      data-collapsed={collapsed}
+    >
+      <header className="scrub-detail-head">
+        <div className="scrub-detail-headings">
+          <div className="scrub-detail-eyebrow">selected pattern · {pattern.id}</div>
+          <h3 className="scrub-detail-title">
+            {pattern.name}
+            <span
+              className={`scrub-detail-sev scrub-detail-sev--${pattern.severity}`}
+              data-testid="scrub-detail-sev"
+            >
+              ● {pattern.severity}
+            </span>
+          </h3>
+        </div>
+        <button
+          type="button"
+          className="scrub-detail-collapse-btn"
+          onClick={onToggleCollapsed}
+          aria-expanded={!collapsed}
+          data-testid="scrub-detail-collapse"
+        >
+          {collapsed ? '+ expand' : '− collapse'}
+        </button>
+      </header>
+
+      {!collapsed && (
+        <div className="scrub-detail-grid" data-testid="scrub-detail-body">
+          <div className="scrub-detail-cell">
+            <div className="scrub-detail-label">regex</div>
+            <code
+              className="scrub-detail-code scrub-detail-code--regex"
+              data-testid="scrub-detail-regex"
+            >
+              {pattern.regex}
+            </code>
+          </div>
+          <div className="scrub-detail-cell">
+            <div className="scrub-detail-label">example match</div>
+            <code
+              className="scrub-detail-code scrub-detail-code--example"
+              data-testid="scrub-detail-example"
+            >
+              {pattern.example}
+            </code>
+          </div>
+          <div className="scrub-detail-cell">
+            <div className="scrub-detail-label">replaced with</div>
+            <code
+              className="scrub-detail-code scrub-detail-code--replace"
+              data-testid="scrub-detail-replace"
+            >
+              {pattern.replace}
+            </code>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/dashboard/src/features/scrub/PatternsLibrary.css
+++ b/dashboard/src/features/scrub/PatternsLibrary.css
@@ -1,0 +1,167 @@
+.scrub-patterns {
+  background: var(--paper);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.scrub-patterns-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper-2);
+}
+
+.scrub-patterns-title {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--ink-2);
+  margin: 0;
+  text-transform: lowercase;
+  letter-spacing: 0.5px;
+}
+
+.scrub-patterns-search {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  padding: 3px 8px;
+  border: 1px solid var(--line-2);
+  border-radius: 2px;
+  width: 110px;
+  background: var(--paper);
+  color: var(--ink);
+}
+
+.scrub-patterns-table-wrap {
+  flex: 1;
+  overflow: auto;
+}
+
+.scrub-patterns-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+}
+
+.scrub-patterns-table th {
+  text-align: left;
+  padding: 6px 10px;
+  background: var(--paper-3);
+  color: var(--ink-3);
+  font-weight: 500;
+  text-transform: uppercase;
+  font-size: 10px;
+  letter-spacing: 0.5px;
+  border-bottom: 1px solid var(--line);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.scrub-patterns-col-toggle {
+  width: 28px;
+}
+
+.scrub-patterns-col-hits {
+  text-align: right;
+}
+
+.scrub-patterns-row {
+  cursor: pointer;
+  border-bottom: 1px solid var(--line);
+}
+
+.scrub-patterns-row:hover {
+  background: var(--paper-2);
+}
+
+.scrub-patterns-row.is-active {
+  background: var(--paper-3);
+}
+
+.scrub-patterns-row.is-disabled {
+  opacity: 0.55;
+}
+
+.scrub-patterns-row td {
+  padding: 8px 10px;
+  vertical-align: middle;
+}
+
+.scrub-patterns-toggle-cell {
+  width: 28px;
+}
+
+.scrub-patterns-toggle-cell input {
+  cursor: pointer;
+}
+
+.scrub-patterns-name {
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--ink);
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.scrub-patterns-id {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--ink-4);
+  margin-top: 1px;
+}
+
+.scrub-patterns-chip {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  background: var(--scrub-bg);
+  color: var(--scrub);
+  padding: 1px 5px;
+  border-radius: 2px;
+  font-weight: 500;
+  text-transform: lowercase;
+}
+
+.scrub-patterns-sev {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.scrub-patterns-sev--critical { color: var(--danger); }
+.scrub-patterns-sev--high { color: var(--warn); }
+.scrub-patterns-sev--medium { color: var(--info); }
+.scrub-patterns-sev--low { color: var(--ink-3); }
+
+.scrub-patterns-hits {
+  text-align: right;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--ink-4);
+}
+
+.scrub-patterns-row.is-active .scrub-patterns-hits {
+  color: var(--scrub);
+}
+
+.scrub-patterns-empty {
+  text-align: center;
+  padding: 16px;
+  color: var(--ink-4);
+  font-size: 12px;
+}
+
+.scrub-sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}

--- a/dashboard/src/features/scrub/PatternsLibrary.tsx
+++ b/dashboard/src/features/scrub/PatternsLibrary.tsx
@@ -1,0 +1,133 @@
+import { useMemo, useState } from 'react'
+import type { ScrubPattern } from './types'
+import './PatternsLibrary.css'
+
+export interface PatternsLibraryProps {
+  patterns: ScrubPattern[]
+  selectedId: string
+  onSelect: (id: string) => void
+  onToggle: (id: string) => void
+  matchCounts: Record<string, number>
+}
+
+export function PatternsLibrary({
+  patterns,
+  selectedId,
+  onSelect,
+  onToggle,
+  matchCounts,
+}: PatternsLibraryProps) {
+  const [search, setSearch] = useState('')
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return patterns
+    return patterns.filter(
+      (p) => p.name.toLowerCase().includes(q) || p.id.toLowerCase().includes(q),
+    )
+  }, [patterns, search])
+
+  return (
+    <section
+      className="scrub-patterns"
+      aria-label="patterns library"
+      data-testid="scrub-patterns"
+    >
+      <header className="scrub-patterns-head">
+        <h3 className="scrub-patterns-title">▤ patterns library</h3>
+        <input
+          type="search"
+          className="scrub-patterns-search"
+          placeholder="search…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          aria-label="search patterns"
+          data-testid="scrub-patterns-search"
+        />
+      </header>
+      <div className="scrub-patterns-table-wrap">
+        <table className="scrub-patterns-table">
+          <thead>
+            <tr>
+              <th scope="col" className="scrub-patterns-col-toggle">
+                <span className="scrub-sr-only">enabled</span>
+              </th>
+              <th scope="col">pattern</th>
+              <th scope="col">sev</th>
+              <th scope="col" className="scrub-patterns-col-hits">
+                24h
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={4}
+                  className="scrub-patterns-empty"
+                  data-testid="scrub-patterns-empty"
+                >
+                  no patterns match &ldquo;{search}&rdquo;
+                </td>
+              </tr>
+            ) : (
+              filtered.map((p) => {
+                const active = p.id === selectedId
+                const matchN = matchCounts[p.id] ?? 0
+                return (
+                  <tr
+                    key={p.id}
+                    className={`scrub-patterns-row${active ? ' is-active' : ''}${
+                      p.enabled ? '' : ' is-disabled'
+                    }`}
+                    onClick={() => onSelect(p.id)}
+                    data-testid={`scrub-patterns-row-${p.id}`}
+                  >
+                    <td
+                      className="scrub-patterns-toggle-cell"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        onToggle(p.id)
+                      }}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={p.enabled}
+                        onChange={() => onToggle(p.id)}
+                        aria-label={`${p.enabled ? 'disable' : 'enable'} pattern ${p.name}`}
+                        data-testid={`scrub-patterns-toggle-${p.id}`}
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                    </td>
+                    <td>
+                      <div className="scrub-patterns-name">
+                        {p.name}
+                        {matchN > 0 && (
+                          <span
+                            className="scrub-patterns-chip"
+                            data-testid={`scrub-patterns-matchchip-${p.id}`}
+                          >
+                            {matchN} in sample
+                          </span>
+                        )}
+                      </div>
+                      <div className="scrub-patterns-id">{p.id}</div>
+                    </td>
+                    <td>
+                      <span
+                        className={`scrub-patterns-sev scrub-patterns-sev--${p.severity}`}
+                        data-testid={`scrub-patterns-sev-${p.id}`}
+                      >
+                        ● {p.severity}
+                      </span>
+                    </td>
+                    <td className="scrub-patterns-hits">{p.hits24h}</td>
+                  </tr>
+                )
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/src/features/scrub/PayloadDiff.css
+++ b/dashboard/src/features/scrub/PayloadDiff.css
@@ -1,0 +1,178 @@
+.scrub-diff {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto 1fr;
+  flex: 1;
+  min-height: 0;
+}
+
+.scrub-diff-headrow {
+  display: contents;
+}
+
+.scrub-diff-paneheader {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  background: var(--paper-2);
+  border-bottom: 1px solid var(--line);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+}
+
+.scrub-diff-paneheader--raw {
+  border-right: 1px solid var(--line);
+}
+
+.scrub-diff-panetitle {
+  font-weight: 600;
+  color: var(--ink);
+  text-transform: lowercase;
+  letter-spacing: 0.5px;
+}
+
+.scrub-diff-panesub {
+  color: var(--ink-3);
+  font-size: 10px;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.scrub-diff-chip {
+  margin-left: auto;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 2px;
+  text-transform: uppercase;
+}
+
+.scrub-diff-chip--danger {
+  background: var(--danger-bg);
+  color: var(--danger);
+}
+
+.scrub-diff-chip--ok {
+  background: var(--ok-bg);
+  color: var(--ok);
+}
+
+.scrub-diff-body {
+  display: contents;
+}
+
+.scrub-diff-pane {
+  background: var(--paper);
+  overflow: auto;
+  padding: 14px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  min-height: 0;
+}
+
+.scrub-diff-pane--raw {
+  border-right: 1px solid var(--line);
+}
+
+.scrub-diff-pane--scrubbed {
+  background: var(--paper-2);
+}
+
+.scrub-diff-textarea {
+  width: 100%;
+  min-height: 220px;
+  border: none;
+  outline: none;
+  resize: vertical;
+  font: inherit;
+  background: transparent;
+  color: var(--ink);
+  padding: 0;
+}
+
+.scrub-diff-preview,
+.scrub-diff-summary {
+  margin-top: 12px;
+  padding-top: 8px;
+  border-top: 1px dashed var(--line);
+}
+
+.scrub-diff-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--ink-4);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 4px;
+}
+
+.scrub-diff-pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 11px;
+  line-height: 1.55;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.scrub-diff-match {
+  background: var(--danger-bg);
+  color: var(--danger);
+  padding: 0 2px;
+  border-radius: 2px;
+  text-decoration: line-through;
+  text-decoration-color: rgba(184, 41, 30, 0.6);
+}
+
+.scrub-diff-redacted {
+  background: var(--scrub-bg);
+  color: var(--scrub);
+  padding: 0 4px;
+  border-radius: 2px;
+  font-weight: 600;
+}
+
+.scrub-diff-summary-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.scrub-diff-summary-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 0;
+  border-bottom: 1px dashed var(--line);
+  font-size: 11px;
+}
+
+.scrub-diff-summary-id {
+  color: var(--ink-4);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  margin-left: 4px;
+}
+
+.scrub-diff-summary-count {
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--scrub);
+  font-weight: 600;
+}
+
+.scrub-diff-summary-empty {
+  font-size: 11px;
+  color: var(--ink-3);
+}
+
+.scrub-diff-sev {
+  margin-right: 6px;
+}
+
+.scrub-diff-sev--critical { color: var(--danger); }
+.scrub-diff-sev--high { color: var(--warn); }
+.scrub-diff-sev--medium { color: var(--info); }
+.scrub-diff-sev--low { color: var(--ink-3); }

--- a/dashboard/src/features/scrub/PayloadDiff.tsx
+++ b/dashboard/src/features/scrub/PayloadDiff.tsx
@@ -1,0 +1,137 @@
+import type { ScrubPattern, ScrubToken } from './types'
+import './PayloadDiff.css'
+
+export interface PayloadDiffProps {
+  payload: string
+  onPayloadChange: (next: string) => void
+  tokens: ScrubToken[]
+  patterns: ScrubPattern[]
+  matchCounts: Record<string, number>
+}
+
+function severityClass(s: ScrubPattern['severity']): string {
+  return `scrub-diff-sev scrub-diff-sev--${s}`
+}
+
+export function PayloadDiff({
+  payload,
+  onPayloadChange,
+  tokens,
+  patterns,
+  matchCounts,
+}: PayloadDiffProps) {
+  const matchCount = tokens.reduce(
+    (n, t) => (t.kind === 'match' ? n + 1 : n),
+    0,
+  )
+
+  return (
+    <div
+      className="scrub-diff"
+      role="region"
+      aria-label="payload diff"
+      data-testid="scrub-diff"
+    >
+      <header className="scrub-diff-headrow">
+        <div className="scrub-diff-paneheader scrub-diff-paneheader--raw">
+          <span className="scrub-diff-panetitle">▶ raw payload</span>
+          <span className="scrub-diff-panesub">(what agent tried to send)</span>
+          <span
+            className="scrub-diff-chip scrub-diff-chip--danger"
+            data-testid="scrub-diff-detected-count"
+          >
+            {matchCount} secrets detected
+          </span>
+        </div>
+        <div className="scrub-diff-paneheader scrub-diff-paneheader--scrubbed">
+          <span className="scrub-diff-panetitle">◀ scrubbed output</span>
+          <span className="scrub-diff-panesub">(what reached destination)</span>
+          <span className="scrub-diff-chip scrub-diff-chip--ok">safe to forward</span>
+        </div>
+      </header>
+
+      <div className="scrub-diff-body">
+        <div className="scrub-diff-pane scrub-diff-pane--raw">
+          <textarea
+            className="scrub-diff-textarea"
+            value={payload}
+            onChange={(e) => onPayloadChange(e.target.value)}
+            spellCheck={false}
+            aria-label="raw payload (editable)"
+            data-testid="scrub-diff-textarea"
+          />
+          <div className="scrub-diff-preview">
+            <div className="scrub-diff-label">highlighted preview</div>
+            <pre className="scrub-diff-pre" data-testid="scrub-diff-preview-raw">
+              {tokens.map((t, i) =>
+                t.kind === 'plain' ? (
+                  <span key={i}>{t.text}</span>
+                ) : (
+                  <span
+                    key={i}
+                    className="scrub-diff-match"
+                    title={`${t.pattern.name} · ${t.pattern.id}`}
+                    data-testid={`scrub-diff-match-${i}`}
+                  >
+                    {t.text}
+                  </span>
+                ),
+              )}
+            </pre>
+          </div>
+        </div>
+
+        <div className="scrub-diff-pane scrub-diff-pane--scrubbed">
+          <pre className="scrub-diff-pre" data-testid="scrub-diff-preview-scrubbed">
+            {tokens.map((t, i) =>
+              t.kind === 'plain' ? (
+                <span key={i}>{t.text}</span>
+              ) : (
+                <span
+                  key={i}
+                  className="scrub-diff-redacted"
+                  title={`replaced by ${t.pattern.id}`}
+                  data-testid={`scrub-diff-redacted-${i}`}
+                >
+                  {t.pattern.replace}
+                </span>
+              ),
+            )}
+          </pre>
+          <div className="scrub-diff-summary">
+            <div className="scrub-diff-label">match summary</div>
+            {matchCount === 0 ? (
+              <div
+                className="scrub-diff-summary-empty"
+                data-testid="scrub-diff-summary-empty"
+              >
+                no secrets matched in this payload
+              </div>
+            ) : (
+              <ul className="scrub-diff-summary-list">
+                {Object.entries(matchCounts).map(([id, n]) => {
+                  const pat = patterns.find((p) => p.id === id)
+                  if (!pat) return null
+                  return (
+                    <li
+                      key={id}
+                      className="scrub-diff-summary-row"
+                      data-testid={`scrub-diff-summary-${id}`}
+                    >
+                      <span>
+                        <span className={severityClass(pat.severity)}>●</span>{' '}
+                        {pat.name}{' '}
+                        <span className="scrub-diff-summary-id">{id}</span>
+                      </span>
+                      <span className="scrub-diff-summary-count">×{n}</span>
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/features/scrub/__tests__/PatternDetail.test.tsx
+++ b/dashboard/src/features/scrub/__tests__/PatternDetail.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { PatternDetail } from '../PatternDetail'
+import type { ScrubPattern } from '../types'
+
+const SAMPLE: ScrubPattern = {
+  id: 'AWS_KEY',
+  name: 'AWS access key ID',
+  regex: 'AKIA[0-9A-Z]{16}',
+  example: 'AKIAIOSFODNN7EXAMPLE',
+  replace: '[REDACTED:AWS_KEY]',
+  severity: 'critical',
+  hits24h: 14,
+  enabled: true,
+}
+
+describe('PatternDetail', () => {
+  it('renders the regex / example / replace cells when not collapsed', () => {
+    render(
+      <PatternDetail
+        pattern={SAMPLE}
+        collapsed={false}
+        onToggleCollapsed={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('scrub-detail-regex')).toHaveTextContent(SAMPLE.regex)
+    expect(screen.getByTestId('scrub-detail-example')).toHaveTextContent(SAMPLE.example)
+    expect(screen.getByTestId('scrub-detail-replace')).toHaveTextContent(SAMPLE.replace)
+    expect(screen.getByTestId('scrub-detail-sev')).toHaveTextContent('critical')
+  })
+
+  it('hides the body when collapsed and shows it when expanded', () => {
+    const { rerender } = render(
+      <PatternDetail
+        pattern={SAMPLE}
+        collapsed={true}
+        onToggleCollapsed={vi.fn()}
+      />,
+    )
+    expect(screen.queryByTestId('scrub-detail-body')).toBeNull()
+    rerender(
+      <PatternDetail
+        pattern={SAMPLE}
+        collapsed={false}
+        onToggleCollapsed={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('scrub-detail-body')).toBeInTheDocument()
+  })
+
+  it('fires onToggleCollapsed when the toggle button is clicked', () => {
+    const onToggle = vi.fn()
+    render(
+      <PatternDetail
+        pattern={SAMPLE}
+        collapsed={false}
+        onToggleCollapsed={onToggle}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('scrub-detail-collapse'))
+    expect(onToggle).toHaveBeenCalledTimes(1)
+  })
+
+  it('reflects collapsed state in the data-collapsed attribute', () => {
+    render(
+      <PatternDetail
+        pattern={SAMPLE}
+        collapsed={true}
+        onToggleCollapsed={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('scrub-detail')).toHaveAttribute('data-collapsed', 'true')
+  })
+})

--- a/dashboard/src/features/scrub/__tests__/PatternsLibrary.test.tsx
+++ b/dashboard/src/features/scrub/__tests__/PatternsLibrary.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { PatternsLibrary } from '../PatternsLibrary'
+import type { ScrubPattern } from '../types'
+
+const PATTERNS: ScrubPattern[] = [
+  {
+    id: 'AWS_KEY',
+    name: 'AWS access key',
+    regex: 'AKIA[0-9A-Z]{16}',
+    example: 'AKIAIOSFODNN7EXAMPLE',
+    replace: '[REDACTED:AWS_KEY]',
+    severity: 'critical',
+    hits24h: 14,
+    enabled: true,
+  },
+  {
+    id: 'PHONE',
+    name: 'Phone',
+    regex: '[0-9]{10}',
+    example: '0123456789',
+    replace: '[REDACTED:PHONE]',
+    severity: 'low',
+    hits24h: 12,
+    enabled: false,
+  },
+  {
+    id: 'EMAIL_PII',
+    name: 'Email',
+    regex: '[a-z]+@[a-z]+',
+    example: 'a@b',
+    replace: '[REDACTED:EMAIL]',
+    severity: 'medium',
+    hits24h: 87,
+    enabled: true,
+  },
+]
+
+describe('PatternsLibrary', () => {
+  it('renders one row per pattern with severity, hits, and a toggle', () => {
+    render(
+      <PatternsLibrary
+        patterns={PATTERNS}
+        selectedId="AWS_KEY"
+        onSelect={vi.fn()}
+        onToggle={vi.fn()}
+        matchCounts={{}}
+      />,
+    )
+    expect(screen.getByTestId('scrub-patterns-row-AWS_KEY')).toBeInTheDocument()
+    expect(screen.getByTestId('scrub-patterns-row-PHONE')).toBeInTheDocument()
+    expect(screen.getByTestId('scrub-patterns-row-EMAIL_PII')).toBeInTheDocument()
+    expect(screen.getByTestId('scrub-patterns-sev-AWS_KEY')).toHaveTextContent('critical')
+  })
+
+  it('shows the in-sample chip only for patterns with non-zero match counts', () => {
+    render(
+      <PatternsLibrary
+        patterns={PATTERNS}
+        selectedId="AWS_KEY"
+        onSelect={vi.fn()}
+        onToggle={vi.fn()}
+        matchCounts={{ AWS_KEY: 3 }}
+      />,
+    )
+    expect(screen.getByTestId('scrub-patterns-matchchip-AWS_KEY')).toHaveTextContent(
+      '3 in sample',
+    )
+    expect(screen.queryByTestId('scrub-patterns-matchchip-EMAIL_PII')).toBeNull()
+  })
+
+  it('calls onSelect when a row is clicked', () => {
+    const onSelect = vi.fn()
+    render(
+      <PatternsLibrary
+        patterns={PATTERNS}
+        selectedId="AWS_KEY"
+        onSelect={onSelect}
+        onToggle={vi.fn()}
+        matchCounts={{}}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('scrub-patterns-row-EMAIL_PII'))
+    expect(onSelect).toHaveBeenCalledWith('EMAIL_PII')
+  })
+
+  it('calls onToggle (and not onSelect) when the checkbox is clicked', () => {
+    const onSelect = vi.fn()
+    const onToggle = vi.fn()
+    render(
+      <PatternsLibrary
+        patterns={PATTERNS}
+        selectedId="AWS_KEY"
+        onSelect={onSelect}
+        onToggle={onToggle}
+        matchCounts={{}}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('scrub-patterns-toggle-EMAIL_PII'))
+    expect(onToggle).toHaveBeenCalledWith('EMAIL_PII')
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('filters by name and id when the search input is non-empty', () => {
+    render(
+      <PatternsLibrary
+        patterns={PATTERNS}
+        selectedId="AWS_KEY"
+        onSelect={vi.fn()}
+        onToggle={vi.fn()}
+        matchCounts={{}}
+      />,
+    )
+    const search = screen.getByTestId('scrub-patterns-search')
+    fireEvent.change(search, { target: { value: 'phone' } })
+    expect(screen.queryByTestId('scrub-patterns-row-AWS_KEY')).toBeNull()
+    expect(screen.getByTestId('scrub-patterns-row-PHONE')).toBeInTheDocument()
+  })
+
+  it('shows the empty-search row when no patterns match', () => {
+    render(
+      <PatternsLibrary
+        patterns={PATTERNS}
+        selectedId="AWS_KEY"
+        onSelect={vi.fn()}
+        onToggle={vi.fn()}
+        matchCounts={{}}
+      />,
+    )
+    fireEvent.change(screen.getByTestId('scrub-patterns-search'), {
+      target: { value: 'xyznomatch' },
+    })
+    expect(screen.getByTestId('scrub-patterns-empty')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/features/scrub/__tests__/PayloadDiff.test.tsx
+++ b/dashboard/src/features/scrub/__tests__/PayloadDiff.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { PayloadDiff } from '../PayloadDiff'
+import type { ScrubPattern, ScrubToken } from '../types'
+
+const AWS: ScrubPattern = {
+  id: 'AWS_KEY',
+  name: 'AWS access key',
+  regex: 'AKIA[0-9A-Z]{16}',
+  example: 'AKIAIOSFODNN7EXAMPLE',
+  replace: '[REDACTED:AWS_KEY]',
+  severity: 'critical',
+  hits24h: 1,
+  enabled: true,
+}
+
+const EMAIL: ScrubPattern = {
+  ...AWS,
+  id: 'EMAIL_PII',
+  name: 'Email',
+  regex: '[a-z]+@[a-z]+',
+  example: 'a@b',
+  replace: '[REDACTED:EMAIL]',
+  severity: 'medium',
+}
+
+const TOKENS: ScrubToken[] = [
+  { kind: 'plain', text: 'key=' },
+  { kind: 'match', text: 'AKIAABCDEFGHIJKLMNOP', pattern: AWS },
+  { kind: 'plain', text: ' for ' },
+  { kind: 'match', text: 'a@b', pattern: EMAIL },
+]
+
+describe('PayloadDiff', () => {
+  it('reflects the detected match count in the header chip', () => {
+    render(
+      <PayloadDiff
+        payload="key=AKIAABCDEFGHIJKLMNOP for a@b"
+        onPayloadChange={vi.fn()}
+        tokens={TOKENS}
+        patterns={[AWS, EMAIL]}
+        matchCounts={{ AWS_KEY: 1, EMAIL_PII: 1 }}
+      />,
+    )
+    expect(screen.getByTestId('scrub-diff-detected-count')).toHaveTextContent(
+      '2 secrets detected',
+    )
+  })
+
+  it('renders matches as struck-through text on the raw side', () => {
+    render(
+      <PayloadDiff
+        payload="key=AKIAABCDEFGHIJKLMNOP for a@b"
+        onPayloadChange={vi.fn()}
+        tokens={TOKENS}
+        patterns={[AWS, EMAIL]}
+        matchCounts={{ AWS_KEY: 1, EMAIL_PII: 1 }}
+      />,
+    )
+    const raw = screen.getByTestId('scrub-diff-preview-raw')
+    expect(raw).toHaveTextContent('AKIAABCDEFGHIJKLMNOP')
+    expect(raw).toHaveTextContent('a@b')
+  })
+
+  it('renders [REDACTED:XXX] placeholders on the scrubbed side, not the raw values', () => {
+    render(
+      <PayloadDiff
+        payload="key=AKIAABCDEFGHIJKLMNOP for a@b"
+        onPayloadChange={vi.fn()}
+        tokens={TOKENS}
+        patterns={[AWS, EMAIL]}
+        matchCounts={{ AWS_KEY: 1, EMAIL_PII: 1 }}
+      />,
+    )
+    const scrubbed = screen.getByTestId('scrub-diff-preview-scrubbed')
+    expect(scrubbed).toHaveTextContent('[REDACTED:AWS_KEY]')
+    expect(scrubbed).toHaveTextContent('[REDACTED:EMAIL]')
+    expect(scrubbed).not.toHaveTextContent('AKIAABCDEFGHIJKLMNOP')
+    expect(scrubbed).not.toHaveTextContent('a@b')
+  })
+
+  it('groups detected matches by pattern in the summary list', () => {
+    render(
+      <PayloadDiff
+        payload="x"
+        onPayloadChange={vi.fn()}
+        tokens={TOKENS}
+        patterns={[AWS, EMAIL]}
+        matchCounts={{ AWS_KEY: 1, EMAIL_PII: 1 }}
+      />,
+    )
+    expect(screen.getByTestId('scrub-diff-summary-AWS_KEY')).toHaveTextContent('×1')
+    expect(screen.getByTestId('scrub-diff-summary-EMAIL_PII')).toHaveTextContent('×1')
+  })
+
+  it('shows the empty summary when there are no matches', () => {
+    render(
+      <PayloadDiff
+        payload="hello"
+        onPayloadChange={vi.fn()}
+        tokens={[{ kind: 'plain', text: 'hello' }]}
+        patterns={[AWS]}
+        matchCounts={{}}
+      />,
+    )
+    expect(screen.getByTestId('scrub-diff-summary-empty')).toBeInTheDocument()
+  })
+
+  it('emits onPayloadChange when the textarea is edited', () => {
+    const onChange = vi.fn()
+    render(
+      <PayloadDiff
+        payload="hello"
+        onPayloadChange={onChange}
+        tokens={[{ kind: 'plain', text: 'hello' }]}
+        patterns={[AWS]}
+        matchCounts={{}}
+      />,
+    )
+    fireEvent.change(screen.getByTestId('scrub-diff-textarea'), {
+      target: { value: 'hi there' },
+    })
+    expect(onChange).toHaveBeenCalledWith('hi there')
+  })
+})

--- a/dashboard/src/features/scrub/__tests__/tokenize.test.ts
+++ b/dashboard/src/features/scrub/__tests__/tokenize.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { countMatchesByPattern, tokenize } from '../tokenize'
+import type { ScrubPattern } from '../types'
+
+const AWS: ScrubPattern = {
+  id: 'AWS_KEY',
+  name: 'AWS access key ID',
+  regex: 'AKIA[0-9A-Z]{16}',
+  example: 'AKIAIOSFODNN7EXAMPLE',
+  replace: '[REDACTED:AWS_KEY]',
+  severity: 'critical',
+  hits24h: 0,
+  enabled: true,
+}
+
+const EMAIL: ScrubPattern = {
+  id: 'EMAIL_PII',
+  name: 'Email',
+  regex: '[a-z0-9._%+-]+@[a-z0-9.-]+',
+  example: 'a@b.co',
+  replace: '[REDACTED:EMAIL]',
+  severity: 'medium',
+  hits24h: 0,
+  enabled: true,
+}
+
+const PHONE_DISABLED: ScrubPattern = {
+  ...EMAIL,
+  id: 'PHONE',
+  name: 'Phone',
+  regex: '[0-9]{10}',
+  example: '0123456789',
+  replace: '[REDACTED:PHONE]',
+  severity: 'low',
+  enabled: false,
+}
+
+describe('tokenize', () => {
+  it('returns a single plain token when no patterns are enabled', () => {
+    const tokens = tokenize('hello world', [PHONE_DISABLED])
+    expect(tokens).toEqual([{ kind: 'plain', text: 'hello world' }])
+  })
+
+  it('returns an empty array for empty input with no enabled patterns', () => {
+    expect(tokenize('', [PHONE_DISABLED])).toEqual([])
+  })
+
+  it('emits a single match token when the entire input is one pattern hit', () => {
+    const tokens = tokenize('AKIAABCDEFGHIJKLMNOP', [AWS])
+    expect(tokens).toHaveLength(1)
+    expect(tokens[0]).toMatchObject({ kind: 'match', text: 'AKIAABCDEFGHIJKLMNOP' })
+    if (tokens[0].kind === 'match') {
+      expect(tokens[0].pattern.id).toBe('AWS_KEY')
+    }
+  })
+
+  it('interleaves plain text and match tokens in the correct order', () => {
+    const text = 'key=AKIAABCDEFGHIJKLMNOP for jane@acme.com end'
+    const tokens = tokenize(text, [AWS, EMAIL])
+    const kinds = tokens.map((t) => t.kind)
+    expect(kinds).toEqual(['plain', 'match', 'plain', 'match', 'plain'])
+    expect(tokens[1]).toMatchObject({ kind: 'match' })
+    if (tokens[1].kind === 'match') expect(tokens[1].pattern.id).toBe('AWS_KEY')
+    if (tokens[3].kind === 'match') expect(tokens[3].pattern.id).toBe('EMAIL_PII')
+  })
+
+  it('skips disabled patterns even when their regex would match', () => {
+    const tokens = tokenize('call 0123456789 then', [PHONE_DISABLED])
+    expect(tokens).toEqual([{ kind: 'plain', text: 'call 0123456789 then' }])
+  })
+
+  it('countMatchesByPattern groups by pattern id', () => {
+    const text = 'a@b.com and AKIAAAAAAAAAAAAAAAAA and c@d.com'
+    const tokens = tokenize(text, [AWS, EMAIL])
+    const counts = countMatchesByPattern(tokens)
+    expect(counts.EMAIL_PII).toBe(2)
+    expect(counts.AWS_KEY).toBe(1)
+  })
+})

--- a/dashboard/src/features/scrub/fixtures.ts
+++ b/dashboard/src/features/scrub/fixtures.ts
@@ -1,0 +1,140 @@
+import type { ScrubPattern } from './types'
+
+export const PATTERNS: ScrubPattern[] = [
+  {
+    id: 'AWS_KEY',
+    name: 'AWS access key ID',
+    regex: 'AKIA[0-9A-Z]{16}',
+    example: 'AKIAIOSFODNN7EXAMPLE',
+    replace: '[REDACTED:AWS_KEY]',
+    severity: 'critical',
+    hits24h: 14,
+    enabled: true,
+  },
+  {
+    id: 'AWS_SECRET',
+    name: 'AWS secret key',
+    regex: '[A-Za-z0-9/+=]{40}',
+    example: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+    replace: '[REDACTED:AWS_SECRET]',
+    severity: 'critical',
+    hits24h: 9,
+    enabled: true,
+  },
+  {
+    id: 'OPENAI_KEY',
+    name: 'OpenAI API key',
+    regex: 'sk-[A-Za-z0-9]{48,}',
+    example: 'sk-proj-abc123def456ghi789jkl0mnopqrs...',
+    replace: '[REDACTED:OPENAI_KEY]',
+    severity: 'critical',
+    hits24h: 22,
+    enabled: true,
+  },
+  {
+    id: 'GH_TOKEN',
+    name: 'GitHub token',
+    regex: 'gh[ps]_[A-Za-z0-9]{36}',
+    example: 'ghp_aB3dE5fG7hI9jK1lM3nO5pQ7rS9tU1vW3xY5z',
+    replace: '[REDACTED:GH_TOKEN]',
+    severity: 'critical',
+    hits24h: 6,
+    enabled: true,
+  },
+  {
+    id: 'JWT',
+    name: 'JWT bearer',
+    regex: 'eyJ[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+',
+    example: 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIi…',
+    replace: '[REDACTED:JWT]',
+    severity: 'high',
+    hits24h: 31,
+    enabled: true,
+  },
+  {
+    id: 'SLACK_TOKEN',
+    name: 'Slack webhook',
+    regex: 'xox[baprs]-[A-Za-z0-9-]+',
+    example: 'xoxb-12345-67890-aBcDeFgHiJk',
+    replace: '[REDACTED:SLACK]',
+    severity: 'high',
+    hits24h: 4,
+    enabled: true,
+  },
+  {
+    id: 'EMAIL_PII',
+    name: 'Email address (PII)',
+    regex: '[a-z0-9._%+-]+@[a-z0-9.-]+',
+    example: 'jane.doe@acme.com',
+    replace: '[REDACTED:EMAIL]',
+    severity: 'medium',
+    hits24h: 87,
+    enabled: true,
+  },
+  {
+    id: 'CC_NUMBER',
+    name: 'Credit card',
+    regex: '[0-9]{4}[\\s-]?[0-9]{4}[\\s-]?[0-9]{4}[\\s-]?[0-9]{4}',
+    example: '4111 1111 1111 1111',
+    replace: '[REDACTED:CC]',
+    severity: 'critical',
+    hits24h: 0,
+    enabled: true,
+  },
+  {
+    id: 'SSN',
+    name: 'US Social Security',
+    regex: '[0-9]{3}-[0-9]{2}-[0-9]{4}',
+    example: '123-45-6789',
+    replace: '[REDACTED:SSN]',
+    severity: 'critical',
+    hits24h: 0,
+    enabled: true,
+  },
+  {
+    id: 'PRIVATE_KEY',
+    name: 'PEM private key',
+    regex: '-----BEGIN [A-Z ]+PRIVATE KEY-----',
+    example: '-----BEGIN RSA PRIVATE KEY-----\\nMIIE…',
+    replace: '[REDACTED:PEM]',
+    severity: 'critical',
+    hits24h: 1,
+    enabled: true,
+  },
+  {
+    id: 'INTERNAL_URL',
+    name: 'Internal URL',
+    regex: 'https?://[^/]*\\.acme\\.internal',
+    example: 'https://billing.acme.internal/api',
+    replace: '[REDACTED:INT_URL]',
+    severity: 'medium',
+    hits24h: 18,
+    enabled: true,
+  },
+  {
+    id: 'PHONE',
+    name: 'Phone (E.164)',
+    regex: '\\+?[0-9]{10,15}',
+    example: '+886912345678',
+    replace: '[REDACTED:PHONE]',
+    severity: 'low',
+    hits24h: 12,
+    enabled: false,
+  },
+]
+
+export const SAMPLE_PAYLOAD = `Hi team — quick note from research-bot-04 sync.
+
+Connecting to billing.acme.internal/api with AKIAIOSFODNN7EXAMPLE
+and writing back to s3://customer-pii/ as service principal.
+
+Found one customer record:
+  name:  Jane Doe
+  email: jane.doe@acme.com
+  phone: +886912345678
+  card:  4111 1111 1111 1111
+
+Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzZXJ2aWNlIn0.tEsT_signature
+will expire at 2026-05-12T08:00Z.
+
+Forwarding to support@external-vendor.io for follow-up.`

--- a/dashboard/src/features/scrub/tokenize.ts
+++ b/dashboard/src/features/scrub/tokenize.ts
@@ -1,0 +1,46 @@
+import type { ScrubPattern, ScrubToken } from './types'
+
+export function tokenize(text: string, patterns: ScrubPattern[]): ScrubToken[] {
+  const enabled = patterns.filter((p) => p.enabled)
+  if (enabled.length === 0) {
+    return text.length > 0 ? [{ kind: 'plain', text }] : []
+  }
+
+  const combined = new RegExp(
+    enabled.map((p) => `(?<${p.id}>${p.regex})`).join('|'),
+    'g',
+  )
+
+  const tokens: ScrubToken[] = []
+  let last = 0
+  for (const match of text.matchAll(combined)) {
+    const idx = match.index ?? 0
+    if (idx > last) {
+      tokens.push({ kind: 'plain', text: text.slice(last, idx) })
+    }
+    const groups = match.groups ?? {}
+    const matchedId = Object.keys(groups).find((k) => groups[k] !== undefined)
+    const pattern = matchedId ? enabled.find((p) => p.id === matchedId) : undefined
+    if (pattern) {
+      tokens.push({ kind: 'match', text: match[0], pattern })
+    } else {
+      tokens.push({ kind: 'plain', text: match[0] })
+    }
+    last = idx + match[0].length
+    if (match[0].length === 0) break
+  }
+  if (last < text.length) {
+    tokens.push({ kind: 'plain', text: text.slice(last) })
+  }
+  return tokens
+}
+
+export function countMatchesByPattern(tokens: ScrubToken[]): Record<string, number> {
+  const counts: Record<string, number> = {}
+  for (const t of tokens) {
+    if (t.kind === 'match') {
+      counts[t.pattern.id] = (counts[t.pattern.id] ?? 0) + 1
+    }
+  }
+  return counts
+}

--- a/dashboard/src/features/scrub/types.ts
+++ b/dashboard/src/features/scrub/types.ts
@@ -1,0 +1,25 @@
+export type ScrubSeverity = 'critical' | 'high' | 'medium' | 'low'
+
+export interface ScrubPattern {
+  id: string
+  name: string
+  regex: string
+  example: string
+  replace: string
+  severity: ScrubSeverity
+  hits24h: number
+  enabled: boolean
+}
+
+export interface ScrubPlainToken {
+  kind: 'plain'
+  text: string
+}
+
+export interface ScrubMatchToken {
+  kind: 'match'
+  text: string
+  pattern: ScrubPattern
+}
+
+export type ScrubToken = ScrubPlainToken | ScrubMatchToken

--- a/dashboard/src/pages/ScrubPage.css
+++ b/dashboard/src/pages/ScrubPage.css
@@ -1,0 +1,86 @@
+.scrub-page {
+  display: flex;
+  flex-direction: column;
+  background: var(--paper);
+  min-height: calc(100vh - 56px);
+}
+
+.scrub-page-head {
+  padding: 22px 24px 18px;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper-2);
+}
+
+.scrub-page-title {
+  margin: 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--ink);
+  letter-spacing: -0.5px;
+}
+
+.scrub-page-subtitle {
+  color: var(--ink-4);
+  font-weight: 400;
+  font-size: 14px;
+  margin-left: 8px;
+}
+
+.scrub-page-sub {
+  margin: 6px 0 0;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  color: var(--ink-3);
+  max-width: 720px;
+  line-height: 1.5;
+}
+
+.scrub-stats {
+  padding: 8px 24px;
+  background: var(--paper-2);
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--ink-3);
+}
+
+.scrub-stats-item {
+  color: var(--ink-3);
+}
+
+.scrub-stats-ok {
+  color: var(--ok);
+}
+
+.scrub-stats-scrubbed {
+  color: var(--scrub);
+}
+
+.scrub-stats-divider {
+  width: 1px;
+  height: 14px;
+  background: var(--line);
+  display: inline-block;
+}
+
+.scrub-body {
+  display: grid;
+  grid-template-columns: 420px 1fr;
+  gap: 1px;
+  background: var(--line);
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.scrub-right {
+  background: var(--paper);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  min-height: 0;
+}

--- a/dashboard/src/pages/ScrubPage.tsx
+++ b/dashboard/src/pages/ScrubPage.tsx
@@ -1,0 +1,90 @@
+import { useMemo, useState } from 'react'
+import { PATTERNS, SAMPLE_PAYLOAD } from '../features/scrub/fixtures'
+import { PatternsLibrary } from '../features/scrub/PatternsLibrary'
+import { PatternDetail } from '../features/scrub/PatternDetail'
+import { PayloadDiff } from '../features/scrub/PayloadDiff'
+import { countMatchesByPattern, tokenize } from '../features/scrub/tokenize'
+import type { ScrubPattern } from '../features/scrub/types'
+import './ScrubPage.css'
+
+export function ScrubPage() {
+  const [patterns, setPatterns] = useState<ScrubPattern[]>(PATTERNS)
+  const [selectedId, setSelectedId] = useState<string>('OPENAI_KEY')
+  const [payload, setPayload] = useState<string>(SAMPLE_PAYLOAD)
+  const [detailCollapsed, setDetailCollapsed] = useState<boolean>(false)
+
+  const tokens = useMemo(() => tokenize(payload, patterns), [payload, patterns])
+  const matchCounts = useMemo(() => countMatchesByPattern(tokens), [tokens])
+
+  const enabled = patterns.filter((p) => p.enabled)
+  const totalHits = enabled.reduce((s, p) => s + p.hits24h, 0)
+  const enabledCount = enabled.length
+
+  const selected = patterns.find((p) => p.id === selectedId) ?? patterns[0]
+
+  const togglePattern = (id: string) =>
+    setPatterns((prev) =>
+      prev.map((p) => (p.id === id ? { ...p, enabled: !p.enabled } : p)),
+    )
+
+  return (
+    <main className="scrub-page" data-testid="scrub-page">
+      <header className="scrub-page-head">
+        <div>
+          <h1 className="scrub-page-title">
+            Secret Scrubbing
+            <span className="scrub-page-subtitle">
+              · L3 · network-layer sanitization
+            </span>
+          </h1>
+          <p className="scrub-page-sub" data-testid="scrub-page-sub">
+            Patterns redact secrets and PII from agent traffic <em>before</em> it
+            reaches external endpoints. {enabledCount} of {patterns.length} patterns
+            active · {totalHits} hits today.
+          </p>
+        </div>
+      </header>
+
+      <div className="scrub-stats" role="status" aria-live="polite">
+        <span className="scrub-stats-item">
+          posture: <strong className="scrub-stats-ok">● 0 leaks (30d)</strong>
+        </span>
+        <span className="scrub-stats-divider" />
+        <span className="scrub-stats-scrubbed" data-testid="scrub-stats-stripped">
+          ● {totalHits} stripped / 24h
+        </span>
+        <span className="scrub-stats-divider" />
+        <span data-testid="scrub-stats-enabled-count">
+          {enabledCount}/{patterns.length} patterns enabled
+        </span>
+      </div>
+
+      <div className="scrub-body">
+        <PatternsLibrary
+          patterns={patterns}
+          selectedId={selected?.id ?? ''}
+          onSelect={setSelectedId}
+          onToggle={togglePattern}
+          matchCounts={matchCounts}
+        />
+
+        <div className="scrub-right">
+          {selected && (
+            <PatternDetail
+              pattern={selected}
+              collapsed={detailCollapsed}
+              onToggleCollapsed={() => setDetailCollapsed((c) => !c)}
+            />
+          )}
+          <PayloadDiff
+            payload={payload}
+            onPayloadChange={setPayload}
+            tokens={tokens}
+            patterns={patterns}
+            matchCounts={matchCounts}
+          />
+        </div>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## Description

Replaces the `<ComingSoon name="Secret Scrubbing" />` stub at the canonical `/scrub` route with a real `<ScrubPage />` matching the hi-fi prototype `design/v1/scrub.jsx` (306 lines).

The page is a two-pane operator tool for **configuring secret-scrubbing patterns**:

- **Left pane — Patterns library:** searchable table of regex patterns (AWS keys, OpenAI keys, JWTs, GitHub tokens, emails, credit cards, SSNs, PEM keys, internal URLs, phone numbers). Each row has an enable / disable checkbox, severity chip, 24h-hits column, and an "in sample" chip when the current sample payload matches the pattern.
- **Right pane top — Pattern detail:** selected pattern's regex / example match / replacement placeholder, in a collapsible 3-column card.
- **Right pane bottom — Payload diff sandbox:** an editable textarea (the operator pastes any text) with two side-by-side previews: the raw text with PII matches struck through in red, and the scrubbed output with `[REDACTED:XXX]` placeholders. A match-summary list groups detected hits by pattern with severity dots and per-pattern counts.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: **AAASM-1350** (sub-task of AAASM-1283 — Dashboard PR 10)

## Background — sub-task scope correction

The original AAASM-1350 ticket text described a "review past flagged events; commit irreversible redactions" feature with a destructive confirmation dialog. The hi-fi `design/v1/scrub.jsx` actually shows a **patterns-library configuration tool with a sandbox payload diff** — no flagged-event queue, no destructive commit. Per the workspace rule "Implement the UI/UX exactly as shown in the hi-fi prototype" (parent AAASM-1283 design reference), this PR delivers the hi-fi feature. The "destructive event-redaction" feature would require a separate design ticket.

This matches the AAASM-1346 / AAASM-1348 pattern (where `data.jsx` and `data-audit.jsx` were fixture files, not page components — repointed in JIRA accordingly).

## Acceptance criteria mapping

| Ticket AC | This PR |
|---|---|
| Route `/scrub` | ✅ — replaces `<ComingSoon>` stub |
| Left panel filterable list (interpreted as **patterns library**) | ✅ — `PatternsLibrary` with name + id search and enable/disable toggle |
| Right panel detail with controls (interpreted as **pattern detail + payload sandbox**) | ✅ — `PatternDetail` card + `PayloadDiff` raw-vs-scrubbed view |
| Destructive confirm dialog before commit | ⛔ — N/A: the hi-fi has no destructive operation |
| `[REDACTED]` placeholder rendering | ✅ — appears in scrubbed-output preview, asserted by `PayloadDiff.test.tsx` |
| Pre-redaction value not recoverable | ⛔ — N/A: textarea is the only payload source; no real event data ever flows through |
| `pnpm type-check` and `pnpm lint` clean | ✅ |
| One PR against `master` with correct title | ✅ |

## Testing

- [x] Unit tests added — 22 vitest cases across 4 test files:
  - `tokenize.test.ts` (6 cases) — empty input, no enabled patterns, single full-match, interleaved plain/match runs, disabled-pattern skip, count-by-pattern grouping
  - `PatternsLibrary.test.tsx` (6 cases) — row rendering, in-sample chip, row-click select, checkbox-only toggle, search filter, empty-search state
  - `PatternDetail.test.tsx` (4 cases) — cell content, collapse hide/show, toggle callback, data-collapsed attribute
  - `PayloadDiff.test.tsx` (6 cases) — detected-count chip, raw vs scrubbed pane content (placeholder MUST appear in scrubbed; raw value MUST NOT appear there), summary grouping, empty-summary state, textarea onChange
- [x] Manual testing performed — full dashboard test suite green (555 tests across 63 files), `pnpm type-check` and `pnpm lint` clean
- [ ] Integration tests added / updated

End-to-end manual walkthrough is gated on the verification sub-task AAASM-1352.

## Checklist

- [x] Code follows project style guidelines (`pnpm type-check` and `pnpm lint` pass; lefthook Rust hooks skip — no `*.rs` changes)
- [x] Self-review of the diff completed
- [x] All CI checks passing (locally)
- [x] Commits are small and follow the Gitmoji convention (6 commits: types/fixtures/tokenize → PatternsLibrary → PatternDetail → PayloadDiff → ScrubPage+route → tests)

Branch rebased onto latest master (`371936e8` — including AAASM-1071 trace export and AAASM-1328 operation row expand).