### PR TITLE
[AAASM-1379] ✨ (shell): Wire pending-approvals count badge to AppShell top nav

### DIFF
--- a/dashboard/src/components/AppShell.tsx
+++ b/dashboard/src/components/AppShell.tsx
@@ -3,6 +3,7 @@ import { NavLink, Outlet } from 'react-router-dom'
 import { useAuth } from '../auth/useAuth'
 import { OverlayProvider } from './OverlayProvider'
 import { OVERLAY_NAMES } from './OverlayContext'
+import { ApprovalsBellButton } from '../features/approvals/ApprovalsBellButton'
 import { CANONICAL_ROUTES, ROUTE_GROUPS, type RouteGroup } from '../routes'
 import './AppShell.css'
 
@@ -94,6 +95,7 @@ export function AppShell() {
           </button>
           <div />
           <div className="appshell__user">
+            <ApprovalsBellButton />
             <span data-testid="appshell-user">{token ?? ''}</span>
             <button
               className="appshell__logout"

--- a/dashboard/src/components/Overlay.test.tsx
+++ b/dashboard/src/components/Overlay.test.tsx
@@ -1,12 +1,18 @@
 import { render, screen, act, renderHook } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { describe, it, expect } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AppShell } from './AppShell'
 import { OverlayProvider } from './OverlayProvider'
 import { useOverlay } from './useOverlay'
 import { OVERLAY_NAMES } from './OverlayContext'
 import { AuthProvider } from '../auth/AuthProvider'
 import { CANONICAL_ROUTES, ROUTE_GROUPS } from '../routes'
+
+function withQueryClient(children: React.ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+}
 
 describe('OverlayProvider + useOverlay', () => {
   function wrapper({ children }: { children: React.ReactNode }) {
@@ -67,7 +73,7 @@ describe('OverlayProvider + useOverlay', () => {
 describe('AppShell overlay mount points', () => {
   it('renders one <div data-overlay={name}> per OVERLAY_NAMES entry', () => {
     localStorage.setItem('aa_token', 'test-token')
-    render(
+    render(withQueryClient(
       <MemoryRouter initialEntries={['/']}>
         <AuthProvider>
           <Routes>
@@ -77,7 +83,7 @@ describe('AppShell overlay mount points', () => {
           </Routes>
         </AuthProvider>
       </MemoryRouter>,
-    )
+    ))
     for (const name of OVERLAY_NAMES) {
       const mount = screen.getByTestId(`overlay-mount-${name}`)
       expect(mount).toBeInTheDocument()
@@ -90,7 +96,7 @@ describe('AppShell overlay mount points', () => {
 describe('AppShell canonical nav', () => {
   function renderShell() {
     localStorage.setItem('aa_token', 'test-token')
-    render(
+    render(withQueryClient(
       <MemoryRouter initialEntries={['/']}>
         <AuthProvider>
           <Routes>
@@ -100,7 +106,7 @@ describe('AppShell canonical nav', () => {
           </Routes>
         </AuthProvider>
       </MemoryRouter>,
-    )
+    ))
     return () => localStorage.clear()
   }
 

--- a/dashboard/src/features/approvals/ApprovalsBellButton.test.tsx
+++ b/dashboard/src/features/approvals/ApprovalsBellButton.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import type { UseQueryResult } from '@tanstack/react-query'
+import { ApprovalsBellButton } from './ApprovalsBellButton'
+import * as approvalsApi from './api'
+import type { Approval } from './api'
+
+function mockQuery<T>(p: Partial<UseQueryResult<T, Error>>): UseQueryResult<T, Error> {
+  return p as unknown as UseQueryResult<T, Error>
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+const MOCK_APPROVAL: Approval = {
+  id: 'a1', agent_id: 'agent-1', action: 'send_email', reason: 'r',
+  status: 'pending', created_at: '2026-05-13T00:00:00Z', routing_status: null, team_id: null,
+}
+
+afterEach(() => { vi.restoreAllMocks() })
+
+describe('ApprovalsBellButton', () => {
+  it('hides the badge when pending count is zero', async () => {
+    vi.spyOn(approvalsApi, 'useApprovalsQuery').mockReturnValue(
+      mockQuery<Approval[]>({ data: [] }),
+    )
+    render(<ApprovalsBellButton />, { wrapper: Wrapper })
+    await waitFor(() => expect(screen.getByTestId('approvals-bell')).toBeInTheDocument())
+    expect(screen.queryByTestId('approvals-bell-badge')).not.toBeInTheDocument()
+  })
+
+  it('shows the badge with the count when pending count is positive', async () => {
+    vi.spyOn(approvalsApi, 'useApprovalsQuery').mockReturnValue(
+      mockQuery<Approval[]>({ data: [MOCK_APPROVAL, { ...MOCK_APPROVAL, id: 'a2' }, { ...MOCK_APPROVAL, id: 'a3' }] }),
+    )
+    render(<ApprovalsBellButton />, { wrapper: Wrapper })
+    const badge = await screen.findByTestId('approvals-bell-badge')
+    expect(badge).toHaveTextContent('3')
+  })
+
+  it('treats undefined data as zero (loading state)', async () => {
+    vi.spyOn(approvalsApi, 'useApprovalsQuery').mockReturnValue(
+      mockQuery<Approval[]>({ data: undefined }),
+    )
+    render(<ApprovalsBellButton />, { wrapper: Wrapper })
+    await waitFor(() => expect(screen.getByTestId('approvals-bell')).toBeInTheDocument())
+    expect(screen.queryByTestId('approvals-bell-badge')).not.toBeInTheDocument()
+  })
+
+  it('links to /approvals', async () => {
+    vi.spyOn(approvalsApi, 'useApprovalsQuery').mockReturnValue(
+      mockQuery<Approval[]>({ data: [] }),
+    )
+    render(<ApprovalsBellButton />, { wrapper: Wrapper })
+    const link = await screen.findByTestId('approvals-bell')
+    expect(link).toHaveAttribute('href', '/approvals')
+  })
+})

--- a/dashboard/src/features/approvals/ApprovalsBellButton.tsx
+++ b/dashboard/src/features/approvals/ApprovalsBellButton.tsx
@@ -1,0 +1,53 @@
+import { Link } from 'react-router-dom'
+import { useApprovalsQuery } from './api'
+
+export function ApprovalsBellButton() {
+  const { data } = useApprovalsQuery()
+  const count = data?.length ?? 0
+  const hasPending = count > 0
+
+  return (
+    <Link
+      to="/approvals"
+      data-testid="approvals-bell"
+      aria-label={hasPending ? `${count} pending approvals` : 'Approval queue'}
+      style={{
+        position: 'relative',
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: '0.25rem',
+        padding: '0.25rem 0.5rem',
+        border: '1px solid var(--line)',
+        borderRadius: '0.25rem',
+        background: 'var(--paper-2)',
+        color: 'var(--ink-2)',
+        textDecoration: 'none',
+        fontFamily: 'JetBrains Mono, monospace',
+        fontSize: '0.75rem',
+      }}
+    >
+      <span aria-hidden>▣</span>
+      <span>approvals</span>
+      {hasPending && (
+        <span
+          data-testid="approvals-bell-badge"
+          aria-hidden
+          style={{
+            display: 'inline-block',
+            minWidth: '1.25rem',
+            padding: '0 0.35rem',
+            borderRadius: '9999px',
+            background: 'var(--danger)',
+            color: 'var(--paper-2)',
+            fontWeight: 600,
+            textAlign: 'center',
+            fontSize: '0.7rem',
+            lineHeight: '1.1rem',
+          }}
+        >
+          {count}
+        </span>
+      )}
+    </Link>
+  )
+}


### PR DESCRIPTION
## Description

Adds an `<ApprovalsBellButton>` to the `AppShell` top bar that links to `/approvals` and shows a live pending-count badge. Closes the AAASM-1294 AC line: *"Top nav badge shows live pending count; hides when count is zero."*

The button uses the same `useApprovalsQuery` cache as the `ApprovalsPage`, so there is no extra fetch — the existing WebSocket-driven cache invalidation keeps the badge live without further wiring.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1379 (subtask of AAASM-1294 / Epic AAASM-11)

## Behaviour notes

* Badge is **hidden** when pending count is `0` or `undefined` (loading state).
* Badge background uses `--danger` token (red, per hi-fi).
* Button is always visible in the top bar — links to `/approvals`.
* WebSocket updates (`useApprovalsStream` in `ApprovalsPage`) populate the same React Query cache, so the badge ticks without page navigation.
* Other tests rendering `AppShell` now require a `QueryClientProvider` wrapper — `Overlay.test.tsx` updated accordingly.

## Testing

- [x] Unit tests added — 4 new tests covering: zero hides badge, positive shows count, loading state, `/approvals` link
- [x] All 573 dashboard tests pass; `pnpm type-check` and `pnpm lint` clean

## Commit history (granular)

```
✨ (approvals): Add ApprovalsBellButton with live pending count badge
✨ (shell): Mount ApprovalsBellButton in AppShell topbar with QueryClient wrapper in tests
✅ (approvals): Test bell badge visibility threshold, count, and /approvals link
```

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] All CI checks passing (verified locally — 573/573 tests)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)