### PR TITLE
[AAASM-1351] ✨ (dashboard/onboarding): Add /onboarding 5-step first-run wizard

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -13,6 +13,7 @@ import { CapabilityPage } from './pages/CapabilityPage'
 import { TraceViewPage } from './pages/TraceViewPage'
 import { LiveOpsPage } from './pages/LiveOpsPage'
 import { ScrubPage } from './pages/ScrubPage'
+import { OnboardingPage } from './pages/OnboardingPage'
 import { ComingSoon } from './pages/ComingSoon'
 import { IdentityPage } from './pages/IdentityPage'
 import { TeamDetailPage } from './pages/TeamDetailPage'
@@ -55,6 +56,9 @@ function App() {
             {/* ── Non-canonical pages (kept for working features) ───────── */}
             <Route path="/approvals" element={<ApprovalsPage />} />
             <Route path="/analytics" element={<AnalyticsPage />} />
+
+            {/* ── First-run onboarding wizard (AAASM-1351) ────────────────── */}
+            <Route path="/onboarding" element={<OnboardingPage />} />
           </Route>
         </Route>
         <Route path="*" element={<NotFoundPage />} />

--- a/dashboard/src/features/onboarding/OnboardingWizard.css
+++ b/dashboard/src/features/onboarding/OnboardingWizard.css
@@ -1,0 +1,175 @@
+.onb-scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(8, 9, 11, 0.78);
+  backdrop-filter: blur(2px);
+  z-index: 9000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+}
+
+.onb-modal {
+  width: 760px;
+  max-width: 100%;
+  max-height: calc(100vh - 64px);
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  box-shadow: 0 32px 80px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255, 255, 255, 0.04);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  font-family: 'Inter', sans-serif;
+}
+
+.onb-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 22px;
+  border-bottom: 1px solid var(--line-2);
+  background: var(--paper-2);
+}
+
+.onb-head-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.onb-head-mark {
+  width: 24px;
+  height: 24px;
+  background: var(--ink);
+  color: var(--paper);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 13px;
+  border-radius: 2px;
+}
+
+.onb-head-title {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1.4px;
+  color: var(--ink);
+  margin: 0;
+  font-weight: 700;
+}
+
+.onb-head-sub {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--ink-4);
+  letter-spacing: 0.5px;
+  margin-left: 10px;
+  padding-left: 10px;
+  border-left: 1px solid var(--line-2);
+}
+
+.onb-skip-all {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--ink-4);
+  background: transparent;
+  border: 1px solid var(--line-2);
+  padding: 5px 10px;
+  border-radius: 2px;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  transition: all 120ms;
+}
+
+.onb-skip-all:hover {
+  color: var(--ink-2);
+  border-color: var(--ink-4);
+}
+
+.onb-body {
+  padding: 28px 32px 24px;
+  flex: 1;
+  min-height: 320px;
+  overflow-y: auto;
+}
+
+.onb-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 22px;
+  border-top: 1px solid var(--line-2);
+  background: var(--paper-2);
+}
+
+.onb-foot-meta {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--ink-4);
+  letter-spacing: 0.5px;
+}
+
+.onb-foot-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.onb-btn {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  padding: 7px 14px;
+  border-radius: 2px;
+  cursor: pointer;
+  text-transform: lowercase;
+  letter-spacing: 0.4px;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  color: var(--ink-2);
+  transition: all 120ms;
+}
+
+.onb-btn:hover {
+  color: var(--ink);
+  border-color: var(--ink-4);
+}
+
+.onb-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.onb-btn-skip {
+  color: var(--ink-4);
+  border-color: transparent;
+  text-decoration: underline;
+  text-decoration-color: var(--line-2);
+  text-underline-offset: 3px;
+}
+
+.onb-btn-skip:hover {
+  color: var(--ink-3);
+}
+
+.onb-btn-primary {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}
+
+.onb-btn-primary:hover {
+  background: var(--ink-2);
+  border-color: var(--ink-2);
+  color: var(--paper);
+}
+
+.onb-btn-primary:disabled {
+  background: var(--ink-4);
+  border-color: var(--ink-4);
+  color: var(--paper);
+}

--- a/dashboard/src/features/onboarding/OnboardingWizard.tsx
+++ b/dashboard/src/features/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,166 @@
+import { useCallback, useState } from 'react'
+import { STEPS } from './fixtures'
+import { Stepper } from './Stepper'
+import { Step1Framework } from './steps/Step1Framework'
+import { Step2InstallSdk } from './steps/Step2InstallSdk'
+import { Step3IssueIdentity } from './steps/Step3IssueIdentity'
+import { Step4BaselinePolicy } from './steps/Step4BaselinePolicy'
+import { Step5EnrollAgent } from './steps/Step5EnrollAgent'
+import type { StepId, WizardState } from './types'
+import { EMPTY_STATE } from './types'
+import { canAdvance, isFinalStep, nextStep, prevStep, stepIndex } from './wizardState'
+import './OnboardingWizard.css'
+
+export interface OnboardingWizardProps {
+  initialStep?: StepId
+  initialState?: WizardState
+  onFinish: (state: WizardState) => void
+  onSkipAll: () => void
+}
+
+export function OnboardingWizard({
+  initialStep = 'framework',
+  initialState = EMPTY_STATE,
+  onFinish,
+  onSkipAll,
+}: OnboardingWizardProps) {
+  const [current, setCurrent] = useState<StepId>(initialStep)
+  const [state, setState] = useState<WizardState>(initialState)
+
+  const ready = canAdvance(state, current)
+  const ci = stepIndex(current)
+  const final = isFinalStep(current)
+
+  const patchState = useCallback(
+    (patch: Partial<WizardState>) => setState((prev) => ({ ...prev, ...patch })),
+    [],
+  )
+
+  const handleContinue = () => {
+    if (final) {
+      onFinish(state)
+      return
+    }
+    const next = nextStep(current)
+    if (next) setCurrent(next)
+  }
+
+  const handleSkipStep = () => {
+    if (final) {
+      onFinish(state)
+      return
+    }
+    const next = nextStep(current)
+    if (next) setCurrent(next)
+  }
+
+  const handleBack = () => {
+    const prev = prevStep(current)
+    if (prev) setCurrent(prev)
+  }
+
+  return (
+    <div className="onb-scrim" data-testid="onboarding-wizard">
+      <div
+        className="onb-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="onboarding-title"
+      >
+        <header className="onb-head">
+          <div className="onb-head-left">
+            <span className="onb-head-mark" aria-hidden>
+              ▣
+            </span>
+            <h1 id="onboarding-title" className="onb-head-title">
+              Agent Assembly · setup
+            </h1>
+            <span className="onb-head-sub" data-testid="onboarding-step-counter">
+              step {ci + 1} of {STEPS.length}
+            </span>
+          </div>
+          <button
+            type="button"
+            className="onb-skip-all"
+            data-testid="onboarding-skip-all"
+            onClick={onSkipAll}
+          >
+            skip onboarding ✕
+          </button>
+        </header>
+
+        <Stepper currentStep={current} onJump={setCurrent} />
+
+        <div className="onb-body">
+          {current === 'framework' && (
+            <Step1Framework
+              state={state}
+              onChange={(framework) => patchState({ framework })}
+            />
+          )}
+          {current === 'install' && (
+            <Step2InstallSdk
+              state={state}
+              onVerified={() => patchState({ installVerified: true })}
+            />
+          )}
+          {current === 'identity' && (
+            <Step3IssueIdentity
+              state={state}
+              onIssued={(identity) => patchState({ identity })}
+            />
+          )}
+          {current === 'policy' && (
+            <Step4BaselinePolicy
+              state={state}
+              onChange={(policyPreset) => patchState({ policyPreset })}
+            />
+          )}
+          {current === 'enroll' && (
+            <Step5EnrollAgent
+              state={state}
+              onEnrolled={() => patchState({ enrolled: true })}
+            />
+          )}
+        </div>
+
+        <footer className="onb-foot">
+          <span className="onb-foot-meta">
+            {ready
+              ? '✓ ready to continue'
+              : 'complete this step to advance · or skip'}
+          </span>
+          <div className="onb-foot-actions">
+            {ci > 0 && (
+              <button
+                type="button"
+                className="onb-btn"
+                data-testid="onboarding-back"
+                onClick={handleBack}
+              >
+                ← back
+              </button>
+            )}
+            <button
+              type="button"
+              className="onb-btn onb-btn-skip"
+              data-testid="onboarding-skip-step"
+              onClick={handleSkipStep}
+            >
+              skip step →
+            </button>
+            <button
+              type="button"
+              className="onb-btn onb-btn-primary"
+              data-testid="onboarding-continue"
+              onClick={handleContinue}
+              disabled={!ready}
+            >
+              {final ? 'finish setup ✓' : 'continue →'}
+            </button>
+          </div>
+        </footer>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/features/onboarding/OnboardingWizard.tsx
+++ b/dashboard/src/features/onboarding/OnboardingWizard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { STEPS } from './fixtures'
 import { Stepper } from './Stepper'
 import { Step1Framework } from './steps/Step1Framework'
@@ -16,6 +16,12 @@ export interface OnboardingWizardProps {
   initialState?: WizardState
   onFinish: (state: WizardState) => void
   onSkipAll: () => void
+  /**
+   * Called whenever the current step or wizard state changes — wired by the
+   * page to persist the mid-wizard session to localStorage so the user can
+   * close the modal and resume at the same step + selections later.
+   */
+  onPersist?: (snapshot: { step: StepId; state: WizardState }) => void
 }
 
 export function OnboardingWizard({
@@ -23,9 +29,14 @@ export function OnboardingWizard({
   initialState = EMPTY_STATE,
   onFinish,
   onSkipAll,
+  onPersist,
 }: OnboardingWizardProps) {
   const [current, setCurrent] = useState<StepId>(initialStep)
   const [state, setState] = useState<WizardState>(initialState)
+
+  useEffect(() => {
+    onPersist?.({ step: current, state })
+  }, [current, state, onPersist])
 
   const ready = canAdvance(state, current)
   const ci = stepIndex(current)

--- a/dashboard/src/features/onboarding/Stepper.css
+++ b/dashboard/src/features/onboarding/Stepper.css
@@ -1,0 +1,81 @@
+.onb-rail {
+  display: flex;
+  padding: 10px 22px;
+  gap: 0;
+  background: var(--paper);
+  border-bottom: 1px solid var(--line-2);
+  overflow-x: auto;
+}
+
+.onb-rail-step {
+  flex: 1;
+  min-width: 100px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 6px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--ink-4);
+  text-transform: lowercase;
+  letter-spacing: 0.6px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  cursor: pointer;
+  transition: all 120ms;
+  position: relative;
+  text-align: left;
+}
+
+.onb-rail-step:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  right: -1px;
+  top: 50%;
+  width: 6px;
+  height: 1px;
+  background: var(--line-2);
+  transform: translateY(-50%);
+}
+
+.onb-rail-step.is-done {
+  color: var(--ok);
+}
+
+.onb-rail-step.is-current {
+  color: var(--ink);
+  border-bottom-color: var(--ink);
+}
+
+.onb-rail-step.is-future {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.onb-rail-step:disabled {
+  cursor: not-allowed;
+}
+
+.onb-rail-num {
+  width: 18px;
+  height: 18px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid currentColor;
+  border-radius: 999px;
+  font-size: 9px;
+}
+
+.onb-rail-step.is-done .onb-rail-num {
+  background: var(--ok);
+  color: var(--paper-2);
+  border-color: var(--ok);
+}
+
+.onb-rail-step.is-current .onb-rail-num {
+  background: var(--ink);
+  color: var(--paper);
+  border-color: var(--ink);
+}

--- a/dashboard/src/features/onboarding/Stepper.tsx
+++ b/dashboard/src/features/onboarding/Stepper.tsx
@@ -24,7 +24,7 @@ export function Stepper({ currentStep, onJump }: StepperProps) {
             key={s.id}
             type="button"
             className={`onb-rail-step is-${status}`}
-            data-testid={`onboarding-step-${s.id}`}
+            data-testid={`onboarding-stepper-${s.id}`}
             data-status={status}
             disabled={!reachable}
             aria-current={status === 'current' ? 'step' : undefined}

--- a/dashboard/src/features/onboarding/Stepper.tsx
+++ b/dashboard/src/features/onboarding/Stepper.tsx
@@ -1,0 +1,42 @@
+import { STEPS } from './fixtures'
+import type { StepId } from './types'
+import { stepIndex, stepStatus } from './wizardState'
+import './Stepper.css'
+
+export interface StepperProps {
+  currentStep: StepId
+  onJump?: (step: StepId) => void
+}
+
+export function Stepper({ currentStep, onJump }: StepperProps) {
+  const ci = stepIndex(currentStep)
+  return (
+    <nav
+      className="onb-rail"
+      aria-label="onboarding progress"
+      data-testid="onboarding-stepper"
+    >
+      {STEPS.map((s, i) => {
+        const status = stepStatus(s.id, currentStep)
+        const reachable = i <= ci
+        return (
+          <button
+            key={s.id}
+            type="button"
+            className={`onb-rail-step is-${status}`}
+            data-testid={`onboarding-step-${s.id}`}
+            data-status={status}
+            disabled={!reachable}
+            aria-current={status === 'current' ? 'step' : undefined}
+            onClick={() => reachable && onJump?.(s.id)}
+          >
+            <span className="onb-rail-num" aria-hidden>
+              {status === 'done' ? '✓' : s.num}
+            </span>
+            <span>{s.label}</span>
+          </button>
+        )
+      })}
+    </nav>
+  )
+}

--- a/dashboard/src/features/onboarding/__tests__/OnboardingPage.test.tsx
+++ b/dashboard/src/features/onboarding/__tests__/OnboardingPage.test.tsx
@@ -2,22 +2,31 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { describe, it, expect, beforeEach } from 'vitest'
 import { OnboardingPage } from '../../../pages/OnboardingPage'
+import { ToastProvider } from '../../../components/ToastProvider'
 import { ONBOARDING_COMPLETED_KEY } from '../useGatewayConfiguredGuard'
+import {
+  ONBOARDING_SESSION_KEY,
+  saveWizardSession,
+} from '../useWizardSession'
+import { EMPTY_STATE } from '../types'
 
 function renderAt(path: string) {
   return render(
-    <MemoryRouter initialEntries={[path]}>
-      <Routes>
-        <Route path="/" element={<div data-testid="root-page">root</div>} />
-        <Route path="/onboarding" element={<OnboardingPage />} />
-      </Routes>
-    </MemoryRouter>,
+    <ToastProvider>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/" element={<div data-testid="root-page">root</div>} />
+          <Route path="/onboarding" element={<OnboardingPage />} />
+        </Routes>
+      </MemoryRouter>
+    </ToastProvider>,
   )
 }
 
 describe('OnboardingPage', () => {
   beforeEach(() => {
     window.localStorage.removeItem(ONBOARDING_COMPLETED_KEY)
+    window.localStorage.removeItem(ONBOARDING_SESSION_KEY)
   })
 
   it('renders the wizard when gateway is not yet configured', () => {
@@ -32,10 +41,60 @@ describe('OnboardingPage', () => {
     expect(screen.getByTestId('root-page')).toBeInTheDocument()
   })
 
-  it('marks gateway configured and redirects when "skip onboarding" is clicked', () => {
+  it('hydrates the wizard at the persisted step when a session exists', () => {
+    saveWizardSession({
+      step: 'policy',
+      state: {
+        ...EMPTY_STATE,
+        framework: 'langchain',
+        installVerified: true,
+        identity: {
+          did: 'did:aa:abc',
+          alg: 'Ed25519',
+          fingerprint: 'AA:BB',
+          issuedAt: 'x',
+        },
+      },
+    })
     renderAt('/onboarding')
+    expect(screen.getByTestId('onboarding-step-counter')).toHaveTextContent(
+      'step 4 of 5',
+    )
+    expect(screen.getByTestId('onboarding-step-policy')).toBeInTheDocument()
+  })
+
+  it('clears the persisted session and fires a success toast on "skip onboarding"', () => {
+    renderAt('/onboarding')
+    // The wizard mounts and immediately persists its initial snapshot,
+    // so the session key is present.
+    expect(window.localStorage.getItem(ONBOARDING_SESSION_KEY)).not.toBe(null)
     fireEvent.click(screen.getByTestId('onboarding-skip-all'))
     expect(window.localStorage.getItem(ONBOARDING_COMPLETED_KEY)).toBe('true')
+    expect(window.localStorage.getItem(ONBOARDING_SESSION_KEY)).toBe(null)
     expect(screen.getByTestId('root-page')).toBeInTheDocument()
+    expect(screen.getByTestId('toast-container')).toHaveTextContent(/Onboarding skipped/i)
+  })
+
+  it('fires a success toast and clears the session when wizard is finished', () => {
+    saveWizardSession({
+      step: 'enroll',
+      state: {
+        framework: 'langchain',
+        installVerified: true,
+        identity: {
+          did: 'did:aa:abc',
+          alg: 'Ed25519',
+          fingerprint: 'AA:BB',
+          issuedAt: 'x',
+        },
+        policyPreset: 'read-only',
+        enrolled: true,
+      },
+    })
+    renderAt('/onboarding')
+    fireEvent.click(screen.getByTestId('onboarding-continue'))
+    expect(window.localStorage.getItem(ONBOARDING_COMPLETED_KEY)).toBe('true')
+    expect(window.localStorage.getItem(ONBOARDING_SESSION_KEY)).toBe(null)
+    expect(screen.getByTestId('toast-container')).toHaveTextContent(/Setup complete/i)
   })
 })

--- a/dashboard/src/features/onboarding/__tests__/OnboardingPage.test.tsx
+++ b/dashboard/src/features/onboarding/__tests__/OnboardingPage.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { OnboardingPage } from '../../../pages/OnboardingPage'
+import { ONBOARDING_COMPLETED_KEY } from '../useGatewayConfiguredGuard'
+
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/" element={<div data-testid="root-page">root</div>} />
+        <Route path="/onboarding" element={<OnboardingPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('OnboardingPage', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem(ONBOARDING_COMPLETED_KEY)
+  })
+
+  it('renders the wizard when gateway is not yet configured', () => {
+    renderAt('/onboarding')
+    expect(screen.getByTestId('onboarding-wizard')).toBeInTheDocument()
+  })
+
+  it('redirects to / immediately when gateway is already configured', () => {
+    window.localStorage.setItem(ONBOARDING_COMPLETED_KEY, 'true')
+    renderAt('/onboarding')
+    expect(screen.queryByTestId('onboarding-wizard')).toBeNull()
+    expect(screen.getByTestId('root-page')).toBeInTheDocument()
+  })
+
+  it('marks gateway configured and redirects when "skip onboarding" is clicked', () => {
+    renderAt('/onboarding')
+    fireEvent.click(screen.getByTestId('onboarding-skip-all'))
+    expect(window.localStorage.getItem(ONBOARDING_COMPLETED_KEY)).toBe('true')
+    expect(screen.getByTestId('root-page')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/features/onboarding/__tests__/OnboardingWizard.test.tsx
+++ b/dashboard/src/features/onboarding/__tests__/OnboardingWizard.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { OnboardingWizard } from '../OnboardingWizard'
+import type { WizardState } from '../types'
+
+const FILLED_STATE: WizardState = {
+  framework: 'langchain',
+  installVerified: true,
+  identity: { did: 'did:aa:abc', alg: 'Ed25519', fingerprint: 'AA', issuedAt: 'x' },
+  policyPreset: 'read-only',
+  enrolled: true,
+}
+
+describe('OnboardingWizard', () => {
+  it('renders the framework step by default with continue disabled until selection', () => {
+    render(<OnboardingWizard onFinish={vi.fn()} onSkipAll={vi.fn()} />)
+    expect(screen.getByTestId('onboarding-step-framework')).toBeInTheDocument()
+    expect(screen.getByTestId('onboarding-continue')).toBeDisabled()
+  })
+
+  it('enables continue once a framework is picked', () => {
+    render(<OnboardingWizard onFinish={vi.fn()} onSkipAll={vi.fn()} />)
+    fireEvent.click(screen.getByTestId('onboarding-framework-langchain'))
+    expect(screen.getByTestId('onboarding-continue')).not.toBeDisabled()
+  })
+
+  it('advances on continue, shows back, and walks back to framework', () => {
+    render(
+      <OnboardingWizard
+        initialStep="install"
+        initialState={{ ...FILLED_STATE, enrolled: false }}
+        onFinish={vi.fn()}
+        onSkipAll={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('onboarding-step-install')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('onboarding-back'))
+    expect(screen.getByTestId('onboarding-step-framework')).toBeInTheDocument()
+  })
+
+  it('skip-step advances even when canAdvance is false', () => {
+    render(<OnboardingWizard onFinish={vi.fn()} onSkipAll={vi.fn()} />)
+    expect(screen.getByTestId('onboarding-step-framework')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('onboarding-skip-step'))
+    expect(screen.getByTestId('onboarding-step-install')).toBeInTheDocument()
+  })
+
+  it('the final-step continue button calls onFinish with the wizard state', () => {
+    const onFinish = vi.fn()
+    render(
+      <OnboardingWizard
+        initialStep="enroll"
+        initialState={FILLED_STATE}
+        onFinish={onFinish}
+        onSkipAll={vi.fn()}
+      />,
+    )
+    const cont = screen.getByTestId('onboarding-continue')
+    expect(cont).toHaveTextContent('finish setup')
+    fireEvent.click(cont)
+    expect(onFinish).toHaveBeenCalledWith(FILLED_STATE)
+  })
+
+  it('calls onSkipAll when the top-right "skip onboarding" button is clicked', () => {
+    const onSkipAll = vi.fn()
+    render(<OnboardingWizard onFinish={vi.fn()} onSkipAll={onSkipAll} />)
+    fireEvent.click(screen.getByTestId('onboarding-skip-all'))
+    expect(onSkipAll).toHaveBeenCalled()
+  })
+
+  it('renders the right step counter', () => {
+    render(
+      <OnboardingWizard
+        initialStep="policy"
+        onFinish={vi.fn()}
+        onSkipAll={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('onboarding-step-counter')).toHaveTextContent('step 4 of 5')
+  })
+})

--- a/dashboard/src/features/onboarding/__tests__/Stepper.test.tsx
+++ b/dashboard/src/features/onboarding/__tests__/Stepper.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { Stepper } from '../Stepper'
+
+describe('Stepper', () => {
+  it('renders a button per step with the right status attributes', () => {
+    render(<Stepper currentStep="identity" />)
+    expect(screen.getByTestId('onboarding-stepper-framework')).toHaveAttribute(
+      'data-status',
+      'done',
+    )
+    expect(screen.getByTestId('onboarding-stepper-install')).toHaveAttribute(
+      'data-status',
+      'done',
+    )
+    expect(screen.getByTestId('onboarding-stepper-identity')).toHaveAttribute(
+      'data-status',
+      'current',
+    )
+    expect(screen.getByTestId('onboarding-stepper-policy')).toHaveAttribute(
+      'data-status',
+      'future',
+    )
+    expect(screen.getByTestId('onboarding-stepper-enroll')).toHaveAttribute(
+      'data-status',
+      'future',
+    )
+  })
+
+  it('disables future-step buttons but allows past-step click-jumps', () => {
+    const onJump = vi.fn()
+    render(<Stepper currentStep="identity" onJump={onJump} />)
+    expect(screen.getByTestId('onboarding-stepper-policy')).toBeDisabled()
+    expect(screen.getByTestId('onboarding-stepper-enroll')).toBeDisabled()
+    expect(screen.getByTestId('onboarding-stepper-framework')).not.toBeDisabled()
+
+    fireEvent.click(screen.getByTestId('onboarding-stepper-framework'))
+    expect(onJump).toHaveBeenCalledWith('framework')
+  })
+
+  it('does not call onJump for future steps', () => {
+    const onJump = vi.fn()
+    render(<Stepper currentStep="framework" onJump={onJump} />)
+    fireEvent.click(screen.getByTestId('onboarding-stepper-enroll'))
+    expect(onJump).not.toHaveBeenCalled()
+  })
+})

--- a/dashboard/src/features/onboarding/__tests__/useGatewayConfiguredGuard.test.ts
+++ b/dashboard/src/features/onboarding/__tests__/useGatewayConfiguredGuard.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  ONBOARDING_COMPLETED_KEY,
+  clearGatewayConfigured,
+  isGatewayConfigured,
+  markGatewayConfigured,
+} from '../useGatewayConfiguredGuard'
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>()
+  get length() { return this.store.size }
+  clear() { this.store.clear() }
+  getItem(k: string) { return this.store.has(k) ? this.store.get(k)! : null }
+  key(i: number) { return Array.from(this.store.keys())[i] ?? null }
+  removeItem(k: string) { this.store.delete(k) }
+  setItem(k: string, v: string) { this.store.set(k, v) }
+}
+
+describe('useGatewayConfiguredGuard', () => {
+  let storage: MemoryStorage
+  beforeEach(() => {
+    storage = new MemoryStorage()
+  })
+
+  it('reads false when the key is absent', () => {
+    expect(isGatewayConfigured(storage)).toBe(false)
+  })
+
+  it('reads true after markGatewayConfigured', () => {
+    markGatewayConfigured(storage)
+    expect(storage.getItem(ONBOARDING_COMPLETED_KEY)).toBe('true')
+    expect(isGatewayConfigured(storage)).toBe(true)
+  })
+
+  it('reads false after clearGatewayConfigured', () => {
+    markGatewayConfigured(storage)
+    clearGatewayConfigured(storage)
+    expect(isGatewayConfigured(storage)).toBe(false)
+  })
+
+  it('treats non-true string values as not-configured', () => {
+    storage.setItem(ONBOARDING_COMPLETED_KEY, 'false')
+    expect(isGatewayConfigured(storage)).toBe(false)
+    storage.setItem(ONBOARDING_COMPLETED_KEY, '1')
+    expect(isGatewayConfigured(storage)).toBe(false)
+  })
+})

--- a/dashboard/src/features/onboarding/__tests__/useWizardSession.test.ts
+++ b/dashboard/src/features/onboarding/__tests__/useWizardSession.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ONBOARDING_SESSION_KEY,
+  clearWizardSession,
+  loadWizardSession,
+  resolveInitialSession,
+  saveWizardSession,
+} from '../useWizardSession'
+import { EMPTY_STATE, type WizardState } from '../types'
+
+class MemoryStorage implements Storage {
+  private store = new Map<string, string>()
+  get length() { return this.store.size }
+  clear() { this.store.clear() }
+  getItem(k: string) { return this.store.has(k) ? this.store.get(k)! : null }
+  key(i: number) { return Array.from(this.store.keys())[i] ?? null }
+  removeItem(k: string) { this.store.delete(k) }
+  setItem(k: string, v: string) { this.store.set(k, v) }
+}
+
+const FILLED_STATE: WizardState = {
+  framework: 'langchain',
+  installVerified: true,
+  identity: { did: 'did:aa:abc', alg: 'Ed25519', fingerprint: 'AA:BB', issuedAt: 'x' },
+  policyPreset: 'read-only',
+  enrolled: false,
+}
+
+describe('useWizardSession storage helpers', () => {
+  it('returns null when no session is persisted', () => {
+    const s = new MemoryStorage()
+    expect(loadWizardSession(s)).toBe(null)
+  })
+
+  it('round-trips step + state through save / load', () => {
+    const s = new MemoryStorage()
+    saveWizardSession({ step: 'identity', state: FILLED_STATE }, s)
+    const loaded = loadWizardSession(s)
+    expect(loaded).toEqual({ step: 'identity', state: FILLED_STATE })
+  })
+
+  it('clearWizardSession removes the persisted entry', () => {
+    const s = new MemoryStorage()
+    saveWizardSession({ step: 'install', state: EMPTY_STATE }, s)
+    clearWizardSession(s)
+    expect(loadWizardSession(s)).toBe(null)
+  })
+
+  it('returns null for malformed JSON', () => {
+    const s = new MemoryStorage()
+    s.setItem(ONBOARDING_SESSION_KEY, '{not json')
+    expect(loadWizardSession(s)).toBe(null)
+  })
+
+  it('returns null when the persisted step id is unknown', () => {
+    const s = new MemoryStorage()
+    s.setItem(
+      ONBOARDING_SESSION_KEY,
+      JSON.stringify({ step: 'unknown-step', state: EMPTY_STATE }),
+    )
+    expect(loadWizardSession(s)).toBe(null)
+  })
+
+  it('returns null when state is missing required slice keys', () => {
+    const s = new MemoryStorage()
+    s.setItem(
+      ONBOARDING_SESSION_KEY,
+      JSON.stringify({ step: 'framework', state: { framework: 'langchain' } }),
+    )
+    expect(loadWizardSession(s)).toBe(null)
+  })
+
+  it('resolveInitialSession falls back to step framework + EMPTY_STATE when nothing persisted', () => {
+    const s = new MemoryStorage()
+    expect(resolveInitialSession(s)).toEqual({
+      step: 'framework',
+      state: EMPTY_STATE,
+    })
+  })
+
+  it('resolveInitialSession returns the persisted session when present', () => {
+    const s = new MemoryStorage()
+    saveWizardSession({ step: 'policy', state: FILLED_STATE }, s)
+    expect(resolveInitialSession(s)).toEqual({
+      step: 'policy',
+      state: FILLED_STATE,
+    })
+  })
+})

--- a/dashboard/src/features/onboarding/__tests__/wizardState.test.ts
+++ b/dashboard/src/features/onboarding/__tests__/wizardState.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { EMPTY_STATE, type WizardState } from '../types'
+import {
+  canAdvance,
+  isFinalStep,
+  nextStep,
+  prevStep,
+  stepIndex,
+  stepStatus,
+} from '../wizardState'
+
+describe('wizardState helpers', () => {
+  describe('canAdvance', () => {
+    it('blocks every step on EMPTY_STATE', () => {
+      expect(canAdvance(EMPTY_STATE, 'framework')).toBe(false)
+      expect(canAdvance(EMPTY_STATE, 'install')).toBe(false)
+      expect(canAdvance(EMPTY_STATE, 'identity')).toBe(false)
+      expect(canAdvance(EMPTY_STATE, 'policy')).toBe(false)
+      expect(canAdvance(EMPTY_STATE, 'enroll')).toBe(false)
+    })
+
+    it('unblocks each step when its slice of state is set', () => {
+      const filled: WizardState = {
+        framework: 'langchain',
+        installVerified: true,
+        identity: { did: 'did:aa:abc', alg: 'Ed25519', fingerprint: 'AA', issuedAt: 'x' },
+        policyPreset: 'read-only',
+        enrolled: true,
+      }
+      expect(canAdvance(filled, 'framework')).toBe(true)
+      expect(canAdvance(filled, 'install')).toBe(true)
+      expect(canAdvance(filled, 'identity')).toBe(true)
+      expect(canAdvance(filled, 'policy')).toBe(true)
+      expect(canAdvance(filled, 'enroll')).toBe(true)
+    })
+  })
+
+  describe('nextStep / prevStep', () => {
+    it('walks forward through the 5 steps', () => {
+      expect(nextStep('framework')).toBe('install')
+      expect(nextStep('install')).toBe('identity')
+      expect(nextStep('identity')).toBe('policy')
+      expect(nextStep('policy')).toBe('enroll')
+    })
+
+    it('returns null past the final step', () => {
+      expect(nextStep('enroll')).toBe(null)
+    })
+
+    it('walks backward through the 5 steps', () => {
+      expect(prevStep('install')).toBe('framework')
+      expect(prevStep('identity')).toBe('install')
+      expect(prevStep('policy')).toBe('identity')
+      expect(prevStep('enroll')).toBe('policy')
+    })
+
+    it('returns null before the first step', () => {
+      expect(prevStep('framework')).toBe(null)
+    })
+  })
+
+  describe('isFinalStep / stepIndex', () => {
+    it('returns true only for the last step', () => {
+      expect(isFinalStep('framework')).toBe(false)
+      expect(isFinalStep('enroll')).toBe(true)
+    })
+
+    it('returns 0-based step index', () => {
+      expect(stepIndex('framework')).toBe(0)
+      expect(stepIndex('enroll')).toBe(4)
+    })
+  })
+
+  describe('stepStatus', () => {
+    it('marks earlier steps done, current step current, later steps future', () => {
+      expect(stepStatus('framework', 'identity')).toBe('done')
+      expect(stepStatus('install', 'identity')).toBe('done')
+      expect(stepStatus('identity', 'identity')).toBe('current')
+      expect(stepStatus('policy', 'identity')).toBe('future')
+      expect(stepStatus('enroll', 'identity')).toBe('future')
+    })
+  })
+})

--- a/dashboard/src/features/onboarding/fixtures.ts
+++ b/dashboard/src/features/onboarding/fixtures.ts
@@ -1,0 +1,80 @@
+import type { Framework, PolicyPreset, StepMeta } from './types'
+
+export const STEPS: ReadonlyArray<StepMeta> = [
+  { id: 'framework', num: '01', label: 'pick framework' },
+  { id: 'install', num: '02', label: 'install sdk' },
+  { id: 'identity', num: '03', label: 'issue identity' },
+  { id: 'policy', num: '04', label: 'baseline policy' },
+  { id: 'enroll', num: '05', label: 'enroll agent' },
+]
+
+export const FRAMEWORKS: ReadonlyArray<Framework> = [
+  {
+    id: 'langchain',
+    name: 'LangChain',
+    glyph: '⌬',
+    sub: 'python · async agents · tool calling',
+    popular: true,
+  },
+  {
+    id: 'autogen',
+    name: 'AutoGen',
+    glyph: '⊞',
+    sub: 'multi-agent conversations · ms-research',
+    popular: false,
+  },
+  {
+    id: 'crewai',
+    name: 'CrewAI',
+    glyph: '◇',
+    sub: 'role-based crews · sequential tasks',
+    popular: false,
+  },
+  {
+    id: 'custom',
+    name: 'Custom / SDK',
+    glyph: '✦',
+    sub: 'plain HTTP · any runtime · BYO agent',
+    popular: false,
+  },
+]
+
+export const POLICY_PRESETS: ReadonlyArray<PolicyPreset> = [
+  {
+    id: 'default-deny',
+    name: 'Default deny',
+    sub: 'maximum safety · explicit allow-list',
+    desc: 'Every capability is blocked unless an explicit Allow rule is added. Recommended for production. New agents start with zero capabilities.',
+    blocks: [
+      'all writes',
+      'all external network',
+      'all PII reads',
+      'sandbox: log-only',
+    ],
+    allows: [],
+    risk: 'low',
+  },
+  {
+    id: 'read-only',
+    name: 'Read-only baseline',
+    sub: 'recommended · sensible defaults',
+    desc: 'Allows reads on common SaaS resources (Gmail, Drive, GitHub issues). Writes, scripts, deletes, and PII fields require an explicit policy.',
+    blocks: ['all writes', 'PII fields (email/phone/ssn)', 'shell.exec'],
+    allows: [
+      'gmail.read',
+      'drive.read',
+      'github.issues.read',
+      'http.GET (allow-listed domains)',
+    ],
+    risk: 'medium',
+  },
+  {
+    id: 'monitor-only',
+    name: 'Monitor only',
+    sub: 'observe first · enforce later',
+    desc: "No blocking. All requests pass through but are logged and scored. Use for the first 7 days while you map your agent's actual surface area before turning enforcement on.",
+    blocks: [],
+    allows: ['everything (logged + scored)'],
+    risk: 'high',
+  },
+]

--- a/dashboard/src/features/onboarding/steps/Step1Framework.tsx
+++ b/dashboard/src/features/onboarding/steps/Step1Framework.tsx
@@ -1,0 +1,46 @@
+import { FRAMEWORKS } from '../fixtures'
+import type { FrameworkId, WizardState } from '../types'
+import './Steps.css'
+
+export interface Step1FrameworkProps {
+  state: WizardState
+  onChange: (framework: FrameworkId) => void
+}
+
+export function Step1Framework({ state, onChange }: Step1FrameworkProps) {
+  return (
+    <section data-testid="onboarding-step-framework">
+      <h2 className="onb-body-title">Pick the framework you&apos;re enrolling.</h2>
+      <p className="onb-body-sub">
+        We support most agent runtimes. Your choice determines which SDK package and
+        identity format we install in the next step.
+      </p>
+      <div className="onb-fw-grid" role="radiogroup" aria-label="agent framework">
+        {FRAMEWORKS.map((fw) => {
+          const selected = state.framework === fw.id
+          return (
+            <button
+              key={fw.id}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              className={`onb-fw-card${selected ? ' is-selected' : ''}`}
+              data-testid={`onboarding-framework-${fw.id}`}
+              onClick={() => onChange(fw.id)}
+            >
+              <span className="onb-fw-radio" aria-hidden />
+              <span className="onb-fw-glyph" aria-hidden>
+                {fw.glyph}
+              </span>
+              <span className="onb-fw-info">
+                <span className="onb-fw-name">{fw.name}</span>
+                <span className="onb-fw-sub">{fw.sub}</span>
+              </span>
+              {fw.popular && <span className="onb-fw-pop">most common</span>}
+            </button>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/dashboard/src/features/onboarding/steps/Step2InstallSdk.tsx
+++ b/dashboard/src/features/onboarding/steps/Step2InstallSdk.tsx
@@ -1,0 +1,140 @@
+import { useState } from 'react'
+import type { WizardState } from '../types'
+import './Steps.css'
+
+export interface Step2InstallSdkProps {
+  state: WizardState
+  onVerified: () => void
+}
+
+type PackageManager = 'pip' | 'npm' | 'go'
+type Phase = 'idle' | 'running' | 'verified'
+
+const COMMANDS: Record<PackageManager, string> = {
+  pip: 'pip install agent-assembly',
+  npm: 'npm install @agent-assembly/sdk',
+  go: 'go get github.com/agent-assembly/sdk-go',
+}
+
+interface Line {
+  kind: 'prompt' | 'cmd' | 'out' | 'ok'
+  text: string
+}
+
+const VERIFIED_LINES: Line[] = [
+  { kind: 'prompt', text: '$ ' },
+  { kind: 'cmd', text: 'aa-cli verify' },
+  { kind: 'out', text: 'connecting to runtime…  done.' },
+  { kind: 'out', text: 'sdk version    1.4.2 (latest)' },
+  { kind: 'out', text: 'control-plane  https://api.agent-assembly.io' },
+  { kind: 'ok', text: '✓ verified · ready to enroll' },
+]
+
+export function Step2InstallSdk({ state, onVerified }: Step2InstallSdkProps) {
+  const [pkg, setPkg] = useState<PackageManager>('pip')
+  const [copied, setCopied] = useState(false)
+  const [phase, setPhase] = useState<Phase>(state.installVerified ? 'verified' : 'idle')
+  const [lines, setLines] = useState<Line[]>(state.installVerified ? VERIFIED_LINES : [])
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(COMMANDS[pkg])
+    } catch {
+      // ignore clipboard failure (older browsers / no permission)
+    }
+    setCopied(true)
+    window.setTimeout(() => setCopied(false), 1400)
+  }
+
+  const handleRun = () => {
+    if (phase === 'running') return
+    setPhase('running')
+    setLines([
+      { kind: 'prompt', text: '$ ' },
+      { kind: 'cmd', text: 'aa-cli verify' },
+      { kind: 'out', text: 'connecting to runtime…' },
+    ])
+    window.setTimeout(() => {
+      setLines(VERIFIED_LINES)
+      setPhase('verified')
+      onVerified()
+    }, 600)
+  }
+
+  return (
+    <section data-testid="onboarding-step-install">
+      <h2 className="onb-body-title">Install the SDK.</h2>
+      <p className="onb-body-sub">
+        Drop this in your agent project. It auto-loads on first import — no
+        boilerplate.
+      </p>
+
+      <div className="onb-pkg-row">
+        <div className="onb-pkg-tabs" role="tablist" aria-label="package manager">
+          {(['pip', 'npm', 'go'] as const).map((p) => (
+            <button
+              key={p}
+              type="button"
+              role="tab"
+              aria-selected={pkg === p}
+              className={`onb-pkg-tab${pkg === p ? ' is-active' : ''}`}
+              data-testid={`onboarding-install-tab-${p}`}
+              onClick={() => setPkg(p)}
+            >
+              {p}
+            </button>
+          ))}
+        </div>
+        <code className="onb-pkg-cmd" data-testid="onboarding-install-cmd">
+          $ {COMMANDS[pkg]}
+        </code>
+        <button
+          type="button"
+          className={`onb-pkg-copy${copied ? ' is-copied' : ''}`}
+          data-testid="onboarding-install-copy"
+          onClick={handleCopy}
+        >
+          {copied ? '✓ copied' : 'copy'}
+        </button>
+      </div>
+
+      <div className="onb-term-meta">
+        <span className="onb-term-meta-label">verify connection</span>
+        <button
+          type="button"
+          className="onb-pkg-tab is-active"
+          data-testid="onboarding-install-verify"
+          onClick={handleRun}
+          disabled={phase === 'running'}
+        >
+          {phase === 'idle'
+            ? '▸ run aa-cli verify'
+            : phase === 'running'
+              ? 'verifying…'
+              : '↻ re-run'}
+        </button>
+      </div>
+
+      <div className="onb-term" data-testid="onboarding-install-terminal">
+        {lines.length === 0 ? (
+          <div className="onb-term-line onb-term-faint">
+            # run verify above to check the SDK reaches the control-plane
+          </div>
+        ) : (
+          lines.map((l, i) => (
+            <div key={i} className="onb-term-line">
+              {l.kind === 'prompt' && <span className="onb-term-prompt">{l.text}</span>}
+              {l.kind === 'cmd' && <span className="onb-term-cmd">{l.text}</span>}
+              {l.kind === 'out' && <span className="onb-term-out">{l.text}</span>}
+              {l.kind === 'ok' && (
+                <span className="onb-term-ok" data-testid="onboarding-install-ok">
+                  {l.text}
+                </span>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </section>
+  )
+}

--- a/dashboard/src/features/onboarding/steps/Step3IssueIdentity.tsx
+++ b/dashboard/src/features/onboarding/steps/Step3IssueIdentity.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react'
+import type { AgentIdentity, WizardState } from '../types'
+import './Steps.css'
+
+export interface Step3IssueIdentityProps {
+  state: WizardState
+  onIssued: (identity: AgentIdentity) => void
+}
+
+type Phase = 'idle' | 'spinning' | 'done'
+
+const HEX = '0123456789abcdef'
+
+function randHex(byteCount: number): string {
+  let out = ''
+  for (let i = 0; i < byteCount * 2; i++) {
+    out += HEX[Math.floor(Math.random() * 16)]
+  }
+  return out
+}
+
+function formatFingerprint(): string {
+  const groups: string[] = []
+  for (let i = 0; i < 8; i++) groups.push(randHex(1))
+  return groups.join(':').toUpperCase()
+}
+
+export function Step3IssueIdentity({ state, onIssued }: Step3IssueIdentityProps) {
+  const [phase, setPhase] = useState<Phase>(state.identity ? 'done' : 'idle')
+  const id = state.identity
+
+  const handleGenerate = () => {
+    if (phase !== 'idle') return
+    setPhase('spinning')
+    window.setTimeout(() => {
+      const identity: AgentIdentity = {
+        did: `did:aa:${randHex(16)}`,
+        alg: 'Ed25519',
+        fingerprint: formatFingerprint(),
+        issuedAt: new Date().toISOString().replace('T', ' ').slice(0, 19) + 'Z',
+      }
+      onIssued(identity)
+      setPhase('done')
+    }, 800)
+  }
+
+  return (
+    <section data-testid="onboarding-step-identity">
+      <h2 className="onb-body-title">Issue first agent identity.</h2>
+      <p className="onb-body-sub">
+        Every agent gets a unique cryptographic identity (DID). The keypair is
+        generated locally — the private key never leaves your control plane.
+      </p>
+
+      <div className="onb-id-card">
+        <div
+          className={`onb-id-glyph${phase === 'done' ? ' is-done' : ''}`}
+          aria-hidden
+        >
+          {phase === 'done' ? '✓' : '◯'}
+        </div>
+
+        {phase === 'idle' && (
+          <>
+            <button
+              type="button"
+              className="onb-id-action-btn"
+              data-testid="onboarding-identity-generate"
+              onClick={handleGenerate}
+            >
+              ▸ generate keypair
+            </button>
+            <div className="onb-id-hint">Ed25519 · 256-bit · ~1.4s</div>
+          </>
+        )}
+
+        {phase === 'spinning' && (
+          <>
+            <button type="button" className="onb-id-action-btn" disabled>
+              generating…
+            </button>
+            <div className="onb-id-hint">
+              deriving curve point · signing CSR · publishing to registry
+            </div>
+          </>
+        )}
+
+        {phase === 'done' && id && (
+          <>
+            <div className="onb-id-issued" data-testid="onboarding-identity-issued">
+              ✓ identity issued
+            </div>
+            <dl className="onb-id-out">
+              <div className="onb-id-row">
+                <dt className="onb-id-key">DID</dt>
+                <dd
+                  className="onb-id-val"
+                  data-testid="onboarding-identity-did"
+                >
+                  {id.did}
+                </dd>
+              </div>
+              <div className="onb-id-row">
+                <dt className="onb-id-key">algorithm</dt>
+                <dd className="onb-id-val">{id.alg}</dd>
+              </div>
+              <div className="onb-id-row">
+                <dt className="onb-id-key">fingerprint</dt>
+                <dd className="onb-id-val is-fp">{id.fingerprint}</dd>
+              </div>
+              <div className="onb-id-row">
+                <dt className="onb-id-key">issued</dt>
+                <dd className="onb-id-val">{id.issuedAt}</dd>
+              </div>
+            </dl>
+          </>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/dashboard/src/features/onboarding/steps/Step4BaselinePolicy.tsx
+++ b/dashboard/src/features/onboarding/steps/Step4BaselinePolicy.tsx
@@ -1,0 +1,83 @@
+import { useEffect } from 'react'
+import { POLICY_PRESETS } from '../fixtures'
+import type { PolicyPresetId, WizardState } from '../types'
+import './Steps.css'
+
+export interface Step4BaselinePolicyProps {
+  state: WizardState
+  onChange: (preset: PolicyPresetId) => void
+}
+
+export function Step4BaselinePolicy({ state, onChange }: Step4BaselinePolicyProps) {
+  // Sensible default — the recommended preset is "read-only" per the hi-fi.
+  useEffect(() => {
+    if (!state.policyPreset) onChange('read-only')
+  }, [state.policyPreset, onChange])
+
+  const selectedId = state.policyPreset ?? 'read-only'
+  const preset = POLICY_PRESETS.find((p) => p.id === selectedId) ?? POLICY_PRESETS[1]
+
+  return (
+    <section data-testid="onboarding-step-policy">
+      <h2 className="onb-body-title">Pick a baseline policy.</h2>
+      <p className="onb-body-sub">
+        Every agent starts under this policy. You can refine per-agent rules in the
+        Policy editor afterwards.
+      </p>
+
+      <div className="onb-pp-grid" role="radiogroup" aria-label="baseline policy">
+        {POLICY_PRESETS.map((p) => {
+          const selected = selectedId === p.id
+          return (
+            <button
+              key={p.id}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              className={`onb-pp-card${selected ? ' is-selected' : ''}`}
+              data-testid={`onboarding-policy-${p.id}`}
+              onClick={() => onChange(p.id)}
+            >
+              <span className="onb-pp-name">{p.name}</span>
+              <span className="onb-pp-sub">{p.sub}</span>
+              <span className={`onb-pp-risk is-${p.risk}`}>risk · {p.risk}</span>
+            </button>
+          )
+        })}
+      </div>
+
+      {preset && (
+        <div className="onb-pp-preview" data-testid="onboarding-policy-preview">
+          <div className="onb-pp-preview-h">{preset.name} · what this looks like</div>
+          <p className="onb-pp-preview-desc">{preset.desc}</p>
+          <div className="onb-pp-cols">
+            <div>
+              <div className="onb-pp-col-h">blocks</div>
+              {preset.blocks.length === 0 ? (
+                <div className="onb-pp-rule is-empty">— no blocking rules —</div>
+              ) : (
+                preset.blocks.map((b) => (
+                  <div key={b} className="onb-pp-rule is-block">
+                    {b}
+                  </div>
+                ))
+              )}
+            </div>
+            <div>
+              <div className="onb-pp-col-h">allows</div>
+              {preset.allows.length === 0 ? (
+                <div className="onb-pp-rule is-empty">— no allow rules —</div>
+              ) : (
+                preset.allows.map((a) => (
+                  <div key={a} className="onb-pp-rule is-allow">
+                    {a}
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/dashboard/src/features/onboarding/steps/Step5EnrollAgent.tsx
+++ b/dashboard/src/features/onboarding/steps/Step5EnrollAgent.tsx
@@ -1,0 +1,117 @@
+import { useState } from 'react'
+import type { WizardState } from '../types'
+import './Steps.css'
+
+export interface Step5EnrollAgentProps {
+  state: WizardState
+  onEnrolled: () => void
+}
+
+interface Ping {
+  id: number
+  time: string
+  action: string
+  tag: string
+}
+
+type Phase = 'idle' | 'listening' | 'live'
+
+const COMPLETED_PINGS: Ping[] = [
+  { id: 3, time: '14:02:14', action: 'gmail.read', tag: 'allowed-by-baseline' },
+  { id: 2, time: '14:02:13', action: 'capability.list', tag: 'cached' },
+  { id: 1, time: '14:02:11', action: 'phone-home (heartbeat)', tag: 'identity-verified' },
+]
+
+export function Step5EnrollAgent({ state, onEnrolled }: Step5EnrollAgentProps) {
+  const [phase, setPhase] = useState<Phase>(state.enrolled ? 'live' : 'idle')
+  const [pings, setPings] = useState<Ping[]>(state.enrolled ? COMPLETED_PINGS : [])
+
+  const handleStart = () => {
+    if (phase !== 'idle') return
+    setPhase('listening')
+    window.setTimeout(() => {
+      setPhase('live')
+      setPings(COMPLETED_PINGS)
+      onEnrolled()
+    }, 800)
+  }
+
+  const enrolledCount = phase === 'live' ? 1 : 0
+
+  return (
+    <section data-testid="onboarding-step-enroll">
+      <h2 className="onb-body-title">Enroll your first agent.</h2>
+      <p className="onb-body-sub">
+        Run your agent now (or any test script that imports the SDK). The control
+        plane will detect the first authenticated call and complete enrollment.
+      </p>
+
+      <div className="onb-enroll-meter">
+        <div className="onb-enroll-row">
+          <span className="onb-enroll-label">enrolled agents</span>
+          <span
+            className={`onb-enroll-count${enrolledCount > 0 ? ' is-live' : ''}`}
+            data-testid="onboarding-enroll-count"
+          >
+            {enrolledCount}{' '}
+            <span style={{ fontSize: 14, color: 'var(--ink-4)' }}>/ ∞</span>
+          </span>
+        </div>
+        <div className="onb-enroll-bar" aria-hidden>
+          <div
+            className="onb-enroll-bar-fill"
+            style={{ width: enrolledCount > 0 ? '8%' : '0%' }}
+          />
+        </div>
+      </div>
+
+      <div className="onb-term-meta">
+        <span className="onb-term-meta-label">incoming agent calls</span>
+        {phase === 'idle' && (
+          <button
+            type="button"
+            className="onb-pkg-tab is-active"
+            data-testid="onboarding-enroll-start"
+            onClick={handleStart}
+          >
+            ▸ start listener
+          </button>
+        )}
+        {phase === 'listening' && (
+          <span className="onb-term-meta-label" data-testid="onboarding-enroll-listening">
+            listening…
+          </span>
+        )}
+        {phase === 'live' && (
+          <span className="onb-term-meta-label" data-testid="onboarding-enroll-connected">
+            connected
+          </span>
+        )}
+      </div>
+
+      <div className="onb-enroll-pings" data-testid="onboarding-enroll-pings">
+        {pings.length === 0 && phase === 'idle' && (
+          <div className="onb-enroll-pings-empty">
+            // no calls yet — run your agent to phone home
+          </div>
+        )}
+        {pings.length === 0 && phase === 'listening' && (
+          <div className="onb-enroll-pings-empty">
+            // awaiting first authenticated call…
+          </div>
+        )}
+        {pings.map((p) => (
+          <div
+            key={p.id}
+            className="onb-enroll-ping"
+            data-testid={`onboarding-enroll-ping-${p.id}`}
+          >
+            <span className="onb-ping-time">{p.time}</span>{' '}
+            <span className="onb-ping-action">{p.action}</span>{' '}
+            <span className="onb-ping-tag">· {p.tag}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/dashboard/src/features/onboarding/steps/Steps.css
+++ b/dashboard/src/features/onboarding/steps/Steps.css
@@ -1,0 +1,502 @@
+/* ── Shared step body typography ────────────────────────────────────────── */
+.onb-body-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--ink);
+  margin: 0 0 4px;
+  letter-spacing: -0.2px;
+}
+
+.onb-body-sub {
+  font-size: 13px;
+  color: var(--ink-3);
+  margin: 0 0 22px;
+  line-height: 1.5;
+}
+
+.onb-body-sub code {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  background: var(--paper-2);
+  padding: 1px 5px;
+  border-radius: 2px;
+  border: 1px solid var(--line-2);
+}
+
+/* ── Step 1: framework cards ─────────────────────────────────────────────── */
+.onb-fw-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.onb-fw-card {
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  padding: 14px 16px;
+  cursor: pointer;
+  transition: all 120ms;
+  position: relative;
+  background: var(--paper);
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  width: 100%;
+}
+
+.onb-fw-card:hover {
+  border-color: var(--ink-4);
+  background: var(--paper-2);
+}
+
+.onb-fw-card.is-selected {
+  border-color: var(--ink);
+  background: var(--paper-2);
+  box-shadow: 0 0 0 1px var(--ink) inset;
+}
+
+.onb-fw-glyph {
+  font-size: 22px;
+  line-height: 1;
+  color: var(--ink);
+  margin-top: 1px;
+}
+
+.onb-fw-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.onb-fw-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.onb-fw-sub {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--ink-4);
+  margin-top: 3px;
+  letter-spacing: 0.3px;
+}
+
+.onb-fw-pop {
+  position: absolute;
+  top: 8px;
+  right: 10px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  background: var(--ok);
+  color: var(--paper-2);
+  padding: 1px 6px;
+  border-radius: 2px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.onb-fw-radio {
+  width: 14px;
+  height: 14px;
+  border: 1px solid var(--ink-4);
+  border-radius: 999px;
+  position: relative;
+  flex-shrink: 0;
+  margin-top: 3px;
+}
+
+.onb-fw-card.is-selected .onb-fw-radio {
+  border-color: var(--ink);
+}
+
+.onb-fw-card.is-selected .onb-fw-radio::after {
+  content: '';
+  position: absolute;
+  inset: 3px;
+  background: var(--ink);
+  border-radius: 999px;
+}
+
+/* ── Step 2: install SDK ─────────────────────────────────────────────────── */
+.onb-pkg-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-top: 14px;
+  padding: 10px 12px;
+  background: var(--paper-2);
+  border: 1px solid var(--line-2);
+  border-radius: 3px;
+}
+
+.onb-pkg-tabs {
+  display: flex;
+  gap: 1px;
+  background: var(--line);
+  padding: 1px;
+  border-radius: 2px;
+}
+
+.onb-pkg-tab {
+  padding: 4px 10px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  background: var(--paper);
+  color: var(--ink-3);
+  cursor: pointer;
+  border: none;
+  border-radius: 1px;
+  transition: all 100ms;
+}
+
+.onb-pkg-tab.is-active {
+  background: var(--ink);
+  color: var(--paper);
+}
+
+.onb-pkg-cmd {
+  flex: 1;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--ink-2);
+  background: var(--paper);
+  border: 1px solid var(--line-2);
+  border-radius: 2px;
+  padding: 6px 10px;
+  user-select: all;
+}
+
+.onb-pkg-copy {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  padding: 6px 10px;
+  background: var(--ink);
+  color: var(--paper);
+  border: none;
+  border-radius: 2px;
+  cursor: pointer;
+  text-transform: lowercase;
+  letter-spacing: 0.4px;
+}
+
+.onb-pkg-copy.is-copied {
+  background: var(--ok);
+}
+
+.onb-term {
+  background: #0d0e10;
+  color: #d4d4d4;
+  border-radius: 3px;
+  padding: 14px 16px;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  line-height: 1.55;
+  min-height: 200px;
+  border: 1px solid #1a1b1d;
+  overflow: hidden;
+  margin-top: 8px;
+}
+
+.onb-term-line {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.onb-term-prompt { color: #4a9eff; user-select: none; }
+.onb-term-cmd { color: #f0f0f0; }
+.onb-term-out { color: #a0a0a0; }
+.onb-term-ok { color: #5fd17a; }
+.onb-term-faint { color: #6e6e6e; }
+
+.onb-term-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 18px;
+  margin-bottom: 8px;
+}
+
+.onb-term-meta-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--ink-4);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+/* ── Step 3: identity ───────────────────────────────────────────────────── */
+.onb-id-card {
+  background: var(--paper-2);
+  border: 1px solid var(--line-2);
+  border-radius: 3px;
+  padding: 22px;
+  text-align: center;
+  min-height: 220px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.onb-id-glyph {
+  width: 80px;
+  height: 80px;
+  border: 2px solid var(--line);
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 16px;
+  background: var(--paper);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 32px;
+  color: var(--ink-4);
+}
+
+.onb-id-glyph.is-done {
+  color: var(--ok);
+  font-size: 36px;
+  font-weight: bold;
+  border-color: var(--ok);
+}
+
+.onb-id-action-btn {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  padding: 9px 18px;
+  background: var(--ink);
+  color: var(--paper);
+  border: none;
+  border-radius: 2px;
+  cursor: pointer;
+  text-transform: lowercase;
+  letter-spacing: 0.5px;
+}
+
+.onb-id-action-btn:hover { background: var(--ink-2); }
+
+.onb-id-action-btn:disabled {
+  background: var(--ink-4);
+  cursor: not-allowed;
+}
+
+.onb-id-out {
+  margin-top: 20px;
+  padding: 14px 16px;
+  background: #0d0e10;
+  color: #d4d4d4;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  line-height: 1.7;
+  border-radius: 3px;
+  text-align: left;
+  width: 100%;
+}
+
+.onb-id-row { display: flex; gap: 10px; }
+.onb-id-key { color: #6e94c2; min-width: 90px; }
+.onb-id-val { color: #d4d4d4; word-break: break-all; }
+.onb-id-val.is-fp { color: #5fd17a; }
+
+.onb-id-hint {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--ink-4);
+  margin-top: 12px;
+  letter-spacing: 0.4px;
+}
+
+.onb-id-issued {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--ok);
+  letter-spacing: 0.5px;
+}
+
+/* ── Step 4: policy preset ──────────────────────────────────────────────── */
+.onb-pp-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 10px;
+}
+
+.onb-pp-card {
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  padding: 14px;
+  cursor: pointer;
+  background: var(--paper);
+  transition: all 120ms;
+  display: flex;
+  flex-direction: column;
+  min-height: 140px;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+}
+
+.onb-pp-card:hover {
+  background: var(--paper-2);
+  border-color: var(--ink-4);
+}
+
+.onb-pp-card.is-selected {
+  border-color: var(--ink);
+  background: var(--paper-2);
+  box-shadow: 0 0 0 1px var(--ink) inset;
+}
+
+.onb-pp-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.onb-pp-sub {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9.5px;
+  color: var(--ink-4);
+  margin-top: 3px;
+  letter-spacing: 0.4px;
+  text-transform: lowercase;
+}
+
+.onb-pp-risk {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  margin-top: 8px;
+  padding: 1px 6px;
+  border-radius: 2px;
+  align-self: flex-start;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+.onb-pp-risk.is-low { background: rgba(70, 180, 110, 0.15); color: var(--ok); }
+.onb-pp-risk.is-medium { background: rgba(220, 180, 60, 0.15); color: var(--warn); }
+.onb-pp-risk.is-high { background: rgba(220, 90, 90, 0.15); color: var(--danger); }
+
+.onb-pp-preview {
+  margin-top: 14px;
+  padding: 14px 16px;
+  background: var(--paper-2);
+  border: 1px solid var(--line-2);
+  border-left: 3px solid var(--ink);
+  border-radius: 2px;
+}
+
+.onb-pp-preview-h {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 10px;
+  color: var(--ink-3);
+  margin-bottom: 8px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+}
+
+.onb-pp-preview-desc {
+  font-size: 12px;
+  color: var(--ink-2);
+  line-height: 1.55;
+  margin-bottom: 12px;
+}
+
+.onb-pp-cols {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.onb-pp-col-h {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 9px;
+  color: var(--ink-4);
+  margin-bottom: 6px;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+.onb-pp-rule {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  padding: 3px 0;
+  color: var(--ink-2);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.onb-pp-rule.is-block::before { content: '⊘'; color: var(--danger); font-weight: bold; }
+.onb-pp-rule.is-allow::before { content: '✓'; color: var(--ok); font-weight: bold; }
+.onb-pp-rule.is-empty {
+  color: var(--ink-4);
+  font-style: italic;
+}
+
+/* ── Step 5: enroll ─────────────────────────────────────────────────────── */
+.onb-enroll-meter {
+  background: var(--paper-2);
+  border: 1px solid var(--line-2);
+  border-radius: 3px;
+  padding: 18px 20px;
+  margin-bottom: 16px;
+}
+
+.onb-enroll-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.onb-enroll-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  color: var(--ink-3);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+.onb-enroll-count {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 28px;
+  color: var(--ink);
+  font-weight: 500;
+  letter-spacing: -1px;
+}
+
+.onb-enroll-count.is-live { color: var(--ok); }
+
+.onb-enroll-bar {
+  height: 4px;
+  background: var(--line);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.onb-enroll-bar-fill {
+  height: 100%;
+  background: var(--ok);
+}
+
+.onb-enroll-pings {
+  background: #0d0e10;
+  color: #d4d4d4;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  padding: 12px 14px;
+  border-radius: 3px;
+  height: 130px;
+  overflow-y: auto;
+}
+
+.onb-enroll-pings-empty { color: #6e6e6e; padding: 4px 0; }
+.onb-enroll-ping { padding: 2px 0; }
+.onb-ping-time { color: #6e94c2; }
+.onb-ping-action { color: #d4d4d4; }
+.onb-ping-tag { color: #5fd17a; }

--- a/dashboard/src/features/onboarding/types.ts
+++ b/dashboard/src/features/onboarding/types.ts
@@ -1,0 +1,54 @@
+export type StepId = 'framework' | 'install' | 'identity' | 'policy' | 'enroll'
+
+export interface StepMeta {
+  id: StepId
+  num: string
+  label: string
+}
+
+export type FrameworkId = 'langchain' | 'autogen' | 'crewai' | 'custom'
+
+export interface Framework {
+  id: FrameworkId
+  name: string
+  glyph: string
+  sub: string
+  popular: boolean
+}
+
+export type PolicyPresetId = 'default-deny' | 'read-only' | 'monitor-only'
+
+export type PolicyRisk = 'low' | 'medium' | 'high'
+
+export interface PolicyPreset {
+  id: PolicyPresetId
+  name: string
+  sub: string
+  desc: string
+  blocks: ReadonlyArray<string>
+  allows: ReadonlyArray<string>
+  risk: PolicyRisk
+}
+
+export interface AgentIdentity {
+  did: string
+  alg: string
+  fingerprint: string
+  issuedAt: string
+}
+
+export interface WizardState {
+  framework: FrameworkId | null
+  installVerified: boolean
+  identity: AgentIdentity | null
+  policyPreset: PolicyPresetId | null
+  enrolled: boolean
+}
+
+export const EMPTY_STATE: WizardState = {
+  framework: null,
+  installVerified: false,
+  identity: null,
+  policyPreset: null,
+  enrolled: false,
+}

--- a/dashboard/src/features/onboarding/useGatewayConfiguredGuard.ts
+++ b/dashboard/src/features/onboarding/useGatewayConfiguredGuard.ts
@@ -1,0 +1,40 @@
+export const ONBOARDING_COMPLETED_KEY = 'aa.onboarding.completed'
+
+/**
+ * Reads the localStorage flag the wizard sets when it finishes (or when the
+ * user clicks "skip onboarding"). Synchronous so the page can decide whether
+ * to render the wizard or redirect *before* the first paint — avoiding a
+ * flash of the modal for already-set-up users.
+ */
+export function isGatewayConfigured(storage: Storage = window.localStorage): boolean {
+  try {
+    return storage.getItem(ONBOARDING_COMPLETED_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+export function markGatewayConfigured(storage: Storage = window.localStorage): void {
+  try {
+    storage.setItem(ONBOARDING_COMPLETED_KEY, 'true')
+  } catch {
+    // ignore (private browsing / quota)
+  }
+}
+
+export function clearGatewayConfigured(storage: Storage = window.localStorage): void {
+  try {
+    storage.removeItem(ONBOARDING_COMPLETED_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Hook wrapper around isGatewayConfigured(). Reads once on mount; the
+ * wizard never needs to react to runtime changes (the user can't toggle
+ * gateway-configured state from another tab while the wizard is open).
+ */
+export function useGatewayConfiguredGuard(): boolean {
+  return isGatewayConfigured()
+}

--- a/dashboard/src/features/onboarding/useWizardSession.ts
+++ b/dashboard/src/features/onboarding/useWizardSession.ts
@@ -1,0 +1,84 @@
+import { STEPS } from './fixtures'
+import type { StepId, WizardState } from './types'
+import { EMPTY_STATE } from './types'
+
+export const ONBOARDING_SESSION_KEY = 'aa.onboarding.session'
+
+export interface WizardSession {
+  step: StepId
+  state: WizardState
+}
+
+const VALID_STEP_IDS = new Set<string>(STEPS.map((s) => s.id))
+
+function isStepId(value: unknown): value is StepId {
+  return typeof value === 'string' && VALID_STEP_IDS.has(value)
+}
+
+function isWizardState(value: unknown): value is WizardState {
+  if (!value || typeof value !== 'object') return false
+  const v = value as Record<string, unknown>
+  return (
+    'framework' in v &&
+    'installVerified' in v &&
+    'identity' in v &&
+    'policyPreset' in v &&
+    'enrolled' in v
+  )
+}
+
+/**
+ * Reads the persisted mid-wizard session from localStorage. Returns null
+ * when nothing is persisted, when the payload is malformed, or when the
+ * stored step id is no longer in the STEPS table (e.g. after a wizard
+ * shape change).
+ */
+export function loadWizardSession(
+  storage: Storage = window.localStorage,
+): WizardSession | null {
+  try {
+    const raw = storage.getItem(ONBOARDING_SESSION_KEY)
+    if (!raw) return null
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object') return null
+    const v = parsed as Record<string, unknown>
+    if (!isStepId(v.step) || !isWizardState(v.state)) return null
+    return { step: v.step, state: v.state }
+  } catch {
+    return null
+  }
+}
+
+export function saveWizardSession(
+  session: WizardSession,
+  storage: Storage = window.localStorage,
+): void {
+  try {
+    storage.setItem(ONBOARDING_SESSION_KEY, JSON.stringify(session))
+  } catch {
+    // ignore (private browsing / quota)
+  }
+}
+
+export function clearWizardSession(storage: Storage = window.localStorage): void {
+  try {
+    storage.removeItem(ONBOARDING_SESSION_KEY)
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Resolves the wizard's initial step + state on mount. Falls back to
+ * step 1 with EMPTY_STATE when no session is persisted.
+ */
+export function resolveInitialSession(
+  storage: Storage = window.localStorage,
+): WizardSession {
+  return (
+    loadWizardSession(storage) ?? {
+      step: 'framework',
+      state: EMPTY_STATE,
+    }
+  )
+}

--- a/dashboard/src/features/onboarding/wizardState.ts
+++ b/dashboard/src/features/onboarding/wizardState.ts
@@ -1,0 +1,47 @@
+import { STEPS } from './fixtures'
+import type { StepId, WizardState } from './types'
+
+export function canAdvance(state: WizardState, step: StepId): boolean {
+  switch (step) {
+    case 'framework':
+      return state.framework !== null
+    case 'install':
+      return state.installVerified
+    case 'identity':
+      return state.identity !== null
+    case 'policy':
+      return state.policyPreset !== null
+    case 'enroll':
+      return state.enrolled
+  }
+}
+
+export function stepIndex(step: StepId): number {
+  return STEPS.findIndex((s) => s.id === step)
+}
+
+export function nextStep(step: StepId): StepId | null {
+  const i = stepIndex(step)
+  if (i < 0 || i >= STEPS.length - 1) return null
+  return STEPS[i + 1].id
+}
+
+export function prevStep(step: StepId): StepId | null {
+  const i = stepIndex(step)
+  if (i <= 0) return null
+  return STEPS[i - 1].id
+}
+
+export function isFinalStep(step: StepId): boolean {
+  return stepIndex(step) === STEPS.length - 1
+}
+
+export type StepStatus = 'done' | 'current' | 'future'
+
+export function stepStatus(step: StepId, current: StepId): StepStatus {
+  const ci = stepIndex(current)
+  const si = stepIndex(step)
+  if (si < ci) return 'done'
+  if (si === ci) return 'current'
+  return 'future'
+}

--- a/dashboard/src/pages/OnboardingPage.tsx
+++ b/dashboard/src/pages/OnboardingPage.tsx
@@ -1,22 +1,48 @@
+import { useMemo } from 'react'
 import { Navigate, useNavigate } from 'react-router-dom'
+import { useToast } from '../components/Toast'
 import { OnboardingWizard } from '../features/onboarding/OnboardingWizard'
 import {
   markGatewayConfigured,
   useGatewayConfiguredGuard,
 } from '../features/onboarding/useGatewayConfiguredGuard'
+import {
+  clearWizardSession,
+  resolveInitialSession,
+  saveWizardSession,
+} from '../features/onboarding/useWizardSession'
 
 export function OnboardingPage() {
   const navigate = useNavigate()
+  const { toast } = useToast()
   const alreadyConfigured = useGatewayConfiguredGuard()
+
+  // Hydrate the initial step + state once per mount; subsequent persistence
+  // is driven by the wizard via onPersist.
+  const initialSession = useMemo(() => resolveInitialSession(), [])
 
   if (alreadyConfigured) {
     return <Navigate to="/" replace />
   }
 
-  const finish = () => {
+  const finishWith = (kind: 'finished' | 'skipped') => {
     markGatewayConfigured()
+    clearWizardSession()
+    if (kind === 'finished') {
+      toast('Setup complete — welcome to Agent Assembly.', 'success')
+    } else {
+      toast('Onboarding skipped — you can re-run it from the Tweaks panel.', 'info')
+    }
     navigate('/', { replace: true })
   }
 
-  return <OnboardingWizard onFinish={finish} onSkipAll={finish} />
+  return (
+    <OnboardingWizard
+      initialStep={initialSession.step}
+      initialState={initialSession.state}
+      onPersist={(snapshot) => saveWizardSession(snapshot)}
+      onFinish={() => finishWith('finished')}
+      onSkipAll={() => finishWith('skipped')}
+    />
+  )
 }

--- a/dashboard/src/pages/OnboardingPage.tsx
+++ b/dashboard/src/pages/OnboardingPage.tsx
@@ -1,0 +1,22 @@
+import { Navigate, useNavigate } from 'react-router-dom'
+import { OnboardingWizard } from '../features/onboarding/OnboardingWizard'
+import {
+  markGatewayConfigured,
+  useGatewayConfiguredGuard,
+} from '../features/onboarding/useGatewayConfiguredGuard'
+
+export function OnboardingPage() {
+  const navigate = useNavigate()
+  const alreadyConfigured = useGatewayConfiguredGuard()
+
+  if (alreadyConfigured) {
+    return <Navigate to="/" replace />
+  }
+
+  const finish = () => {
+    markGatewayConfigured()
+    navigate('/', { replace: true })
+  }
+
+  return <OnboardingWizard onFinish={finish} onSkipAll={finish} />
+}


### PR DESCRIPTION
## Description

Adds the `/onboarding` first-run wizard from `design/v1/onboarding.jsx` (1014 lines). The route renders a centered modal scrim over the dashboard shell with a 5-step setup flow:

1. **Pick framework** — radio cards for LangChain / AutoGen / CrewAI / Custom
2. **Install SDK** — pip/npm/go tabs, copy command, `aa-cli verify` simulated terminal output
3. **Issue identity** — generate-button → spinner → DID + Ed25519 fingerprint output
4. **Baseline policy** — three preset cards (default-deny / read-only / monitor-only) + inline blocks/allows preview (auto-selects "read-only" recommended preset)
5. **Enroll agent** — start listener → live agent count + ping stream

Each step's Continue button is gated by its slice of wizard state (`canAdvance(state, currentStep)`); a per-step "skip step →" advances regardless. The final step's Continue becomes "finish setup ✓" and triggers `onFinish(state)`. A top-right "skip onboarding ✕" exits the wizard at any time.

`OnboardingPage` is the route-mounted shell. It reads `localStorage.aa.onboarding.completed` synchronously on mount via `useGatewayConfiguredGuard()` and `<Navigate to="/" replace />`s when the gateway is already configured — so already-set-up users never see a flash of the wizard. When the wizard finishes (or the user explicitly skips), the page calls `markGatewayConfigured()` and navigates to `/` with `replace=true` so the wizard cannot be re-entered with the back button.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: **AAASM-1351** (sub-task of AAASM-1283 — Dashboard PR 10)

## Acceptance criteria mapping

| Implementation rule | Status | Where |
|---|---|---|
| Route `/onboarding` (rule 9) | ✅ | `App.tsx` — new non-canonical route under `ProtectedRoute` + `AppShell` |
| Multi-step first-run wizard (rules 9, 10) | ✅ | `OnboardingWizard` modal with `Stepper` + 5 step components |
| Per-step skip — user may return later (rule 11) | ✅ | "skip step →" button always available; jump-to-past-step from the stepper |
| Final step → redirect to `/` (rule 12) | ✅ | `OnboardingPage.finish` → `markGatewayConfigured()` + `navigate('/', { replace: true })` |
| Already-configured gateway → skip immediately (rule 13) | ✅ | `useGatewayConfiguredGuard` reads localStorage synchronously; renders `<Navigate to="/" replace />` before any wizard markup |
| All color tokens from `design/v1/styles.css` (rule 14) | ✅ | Per-component CSS files using `--paper`, `--ink`, `--ok`, etc. |
| Empty/error state from PR 2 (rule 15) | ⛔ N/A — wizard has no data fetch |
| `pnpm type-check` and `pnpm lint` clean (rule 16) | ✅ |

## Testing

- [x] Unit tests added — **40 vitest cases across 5 test files**:
  - `wizardState.test.ts` (10) — pure helpers
  - `useGatewayConfiguredGuard.test.ts` (4) — localStorage round-trip with injected `MemoryStorage`
  - `Stepper.test.tsx` (3) — status attributes, future-step disabled, click-jump
  - `OnboardingWizard.test.tsx` (7) — initial step, gating, back/skip/continue, final → onFinish, top-right skip
  - `OnboardingPage.test.tsx` (3) — render-when-not-configured, redirect-when-configured, finish-marks-configured
- [x] Manual testing performed — `pnpm type-check` clean, `pnpm lint` clean, `pnpm test` ✅ **601 tests across 71 files**

E2E manual walkthrough is gated on the verification sub-task AAASM-1352.

## Checklist

- [x] Code follows project style guidelines (lefthook Rust hooks skip — no `*.rs` changes)
- [x] Self-review of the diff completed
- [x] All CI checks passing (locally)
- [x] Commits are small and follow the Gitmoji convention (10 commits, see below)

## Commits

| SHA | Message |
|---|---|
| `b8917db2` | ✨ types + fixtures + wizardState pure helpers |
| `4ab7e8e4` | ✨ useGatewayConfiguredGuard hook + Stepper |
| `b9bdcae6` | ✨ Step1Framework — pick agent runtime |
| `12ed9351` | ✨ Step2InstallSdk — copy + simulated verify |
| `060380d0` | ✨ Step3IssueIdentity — generate first agent DID |
| `b08768c4` | ✨ Step4BaselinePolicy — pick a policy preset |
| `09c6fdbb` | ✨ Step5EnrollAgent — listener + ping stream |
| `d7c29d00` | ✨ OnboardingWizard shell — modal + nav + step host |
| `a5fcaf78` | ✨ OnboardingPage + wire /onboarding route |
| `<test SHA>` | ✅ unit + integration tests + Stepper testid rename |

Branch rebased onto latest master before push.