### PR TITLE
[AAASM-1331] ✨ (dashboard/live-ops): Add useLiveOpsStream WS hook (reconnect + buffer)

### DIFF
--- a/dashboard/src/features/liveOps/useLiveOpsStream.test.ts
+++ b/dashboard/src/features/liveOps/useLiveOpsStream.test.ts
@@ -1,0 +1,224 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useLiveOpsStream } from './useLiveOpsStream'
+
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  static OPEN = 1
+  static CLOSED = 3
+
+  static reset() {
+    MockWebSocket.instances = []
+  }
+
+  readyState = 0
+  url: string
+  onopen: ((ev?: Event) => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: ((ev?: Event) => void) | null = null
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  // ── Test helpers ────────────────────────────────────────
+  open() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.()
+  }
+  emit(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) })
+  }
+  serverClose() {
+    if (this.readyState === MockWebSocket.CLOSED) return
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.()
+  }
+
+  // ── WebSocket API ──────────────────────────────────────
+  close() {
+    this.serverClose()
+  }
+  send() {
+    /* noop */
+  }
+}
+
+const VIOLATION_EVENT = {
+  id: 1,
+  agent_id: 'support-agent',
+  event_type: 'violation',
+  timestamp: '2026-05-13T14:23:01Z',
+  payload: { kind: 'audit', received_at_ms: 0, sequence_number: 1, source: 'sdk' },
+}
+
+const opts = {
+  webSocketCtor: MockWebSocket as unknown as typeof WebSocket,
+  initialBackoffMs: 100,
+  maxBackoffMs: 1000,
+  maxReconnectAttempts: 3,
+  maxOps: 50,
+}
+
+describe('useLiveOpsStream', () => {
+  beforeEach(() => {
+    MockWebSocket.reset()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('connects on mount and exposes connecting status', () => {
+    const { result } = renderHook(() => useLiveOpsStream(opts))
+    expect(MockWebSocket.instances).toHaveLength(1)
+    expect(result.current.status).toBe('connecting')
+  })
+
+  it('transitions to connected on socket open', () => {
+    const { result } = renderHook(() => useLiveOpsStream(opts))
+    act(() => {
+      MockWebSocket.instances[0].open()
+    })
+    expect(result.current.status).toBe('connected')
+  })
+
+  it('appends violation events to the ops ring (most-recent-first)', () => {
+    const { result } = renderHook(() => useLiveOpsStream(opts))
+    act(() => {
+      MockWebSocket.instances[0].open()
+      MockWebSocket.instances[0].emit(VIOLATION_EVENT)
+      MockWebSocket.instances[0].emit({ ...VIOLATION_EVENT, id: 2 })
+    })
+    expect(result.current.ops.map((o) => o.id)).toEqual(['2', '1'])
+    expect(result.current.ops[1]).toMatchObject({
+      id: '1',
+      agent: 'support-agent',
+      startedAt: '2026-05-13T14:23:01Z',
+      status: 'running',
+    })
+  })
+
+  it('ignores non-violation event types', () => {
+    const { result } = renderHook(() => useLiveOpsStream(opts))
+    act(() => {
+      MockWebSocket.instances[0].open()
+      MockWebSocket.instances[0].emit({ ...VIOLATION_EVENT, event_type: 'approval' })
+    })
+    expect(result.current.ops).toHaveLength(0)
+  })
+
+  it('drops malformed frames without throwing', () => {
+    const { result } = renderHook(() => useLiveOpsStream(opts))
+    act(() => {
+      MockWebSocket.instances[0].open()
+      MockWebSocket.instances[0].onmessage?.({ data: 'not json' })
+    })
+    expect(result.current.ops).toHaveLength(0)
+  })
+
+  it('caps the ring at maxOps', () => {
+    const { result } = renderHook(() => useLiveOpsStream({ ...opts, maxOps: 3 }))
+    act(() => {
+      MockWebSocket.instances[0].open()
+      for (let i = 1; i <= 5; i++) {
+        MockWebSocket.instances[0].emit({ ...VIOLATION_EVENT, id: i })
+      }
+    })
+    expect(result.current.ops.map((o) => o.id)).toEqual(['5', '4', '3'])
+  })
+
+  it('reconnects with exponential backoff after a close', () => {
+    const { result } = renderHook(() => useLiveOpsStream(opts))
+    act(() => {
+      MockWebSocket.instances[0].open()
+    })
+    expect(result.current.status).toBe('connected')
+
+    act(() => {
+      MockWebSocket.instances[0].serverClose()
+    })
+    expect(result.current.status).toBe('reconnecting')
+    expect(MockWebSocket.instances).toHaveLength(1)
+
+    // First reconnect: 100 ms (initialBackoffMs * 2^0)
+    act(() => {
+      vi.advanceTimersByTime(99)
+    })
+    expect(MockWebSocket.instances).toHaveLength(1)
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(MockWebSocket.instances).toHaveLength(2)
+
+    // Second close, second reconnect: 200 ms
+    act(() => {
+      MockWebSocket.instances[1].serverClose()
+    })
+    act(() => {
+      vi.advanceTimersByTime(199)
+    })
+    expect(MockWebSocket.instances).toHaveLength(2)
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(MockWebSocket.instances).toHaveLength(3)
+  })
+
+  it('transitions to error after maxReconnectAttempts', () => {
+    const { result } = renderHook(() =>
+      useLiveOpsStream({ ...opts, maxReconnectAttempts: 2 }),
+    )
+    act(() => {
+      MockWebSocket.instances[0].serverClose()
+    })
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+    act(() => {
+      MockWebSocket.instances[1].serverClose()
+    })
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+    act(() => {
+      MockWebSocket.instances[2].serverClose()
+    })
+    expect(result.current.status).toBe('error')
+  })
+
+  it('manual reconnect() restarts the connection from error', () => {
+    const { result } = renderHook(() =>
+      useLiveOpsStream({ ...opts, maxReconnectAttempts: 1 }),
+    )
+    act(() => {
+      MockWebSocket.instances[0].serverClose()
+    })
+    act(() => {
+      vi.advanceTimersByTime(100)
+    })
+    act(() => {
+      MockWebSocket.instances[1].serverClose()
+    })
+    expect(result.current.status).toBe('error')
+
+    act(() => {
+      result.current.reconnect()
+    })
+    expect(MockWebSocket.instances.length).toBeGreaterThan(2)
+    expect(result.current.status).not.toBe('error')
+  })
+
+  it('closes the socket on unmount', () => {
+    const { unmount } = renderHook(() => useLiveOpsStream(opts))
+    const ws = MockWebSocket.instances[0]
+    act(() => {
+      ws.open()
+    })
+    unmount()
+    expect(ws.readyState).toBe(MockWebSocket.CLOSED)
+  })
+})

--- a/dashboard/src/features/liveOps/useLiveOpsStream.ts
+++ b/dashboard/src/features/liveOps/useLiveOpsStream.ts
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { components } from '../../api/generated/schema'
+import type { LiveOperation } from './types'
+
+type GovernanceEvent = components['schemas']['GovernanceEvent']
+
+export type StreamStatus = 'connecting' | 'connected' | 'reconnecting' | 'error'
+
+export interface UseLiveOpsStreamOptions {
+  /** Maximum number of operations retained in the in-memory ring. Default 100. */
+  maxOps?: number
+  /** Initial reconnect delay in ms. Doubles each attempt up to `maxBackoffMs`. Default 250. */
+  initialBackoffMs?: number
+  /** Reconnect ceiling in ms. Default 8000. */
+  maxBackoffMs?: number
+  /** Max consecutive reconnect attempts before transitioning to `error`. Default 5. */
+  maxReconnectAttempts?: number
+  /** Test seam — defaults to the global `WebSocket`. */
+  webSocketCtor?: typeof WebSocket
+}
+
+export interface UseLiveOpsStreamResult {
+  ops: LiveOperation[]
+  status: StreamStatus
+  /** Manually trigger a reconnect; resets the attempt counter. */
+  reconnect: () => void
+}
+
+function buildWsUrl(): string {
+  const base = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? ''
+  const wsBase = base
+    ? base.replace(/^https/, 'wss').replace(/^http/, 'ws')
+    : `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}`
+  const token =
+    typeof localStorage !== 'undefined' ? localStorage.getItem('aa_token') : null
+  const query = [
+    'types=violation',
+    token ? `token=${encodeURIComponent(token)}` : '',
+  ]
+    .filter(Boolean)
+    .join('&')
+  return `${wsBase}/api/v1/ws/events?${query}`
+}
+
+function mapEvent(event: GovernanceEvent): LiveOperation | null {
+  if (event.event_type !== 'violation') return null
+  return {
+    id: String(event.id),
+    agent: event.agent_id,
+    opType: 'unknown',
+    resource: '',
+    status: 'running',
+    startedAt: event.timestamp,
+    latencyMs: 0,
+  }
+}
+
+/**
+ * Subscribe to the gateway WebSocket and project violation events into a
+ * ring of live operations. Patterned after `useApprovalsStream` but with
+ * a richer state machine (`connecting | connected | reconnecting | error`)
+ * and a manual `reconnect()` escape hatch for the parent's ErrorState retry.
+ *
+ * The hook is pure logic — no DOM. Wiring on `LiveOpsPage` lands in
+ * AAASM-1332.
+ */
+export function useLiveOpsStream({
+  maxOps = 100,
+  initialBackoffMs = 250,
+  maxBackoffMs = 8000,
+  maxReconnectAttempts = 5,
+  webSocketCtor: WS = WebSocket,
+}: UseLiveOpsStreamOptions = {}): UseLiveOpsStreamResult {
+  const [ops, setOps] = useState<LiveOperation[]>([])
+  const [status, setStatus] = useState<StreamStatus>('connecting')
+  const [reconnectTick, setReconnectTick] = useState(0)
+
+  const wsRef = useRef<WebSocket | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const attemptsRef = useRef(0)
+  const deadRef = useRef(false)
+
+  const reconnect = useCallback(() => {
+    attemptsRef.current = 0
+    setReconnectTick((v) => v + 1)
+  }, [])
+
+  useEffect(() => {
+    deadRef.current = false
+
+    function connect() {
+      if (deadRef.current) return
+      setStatus(attemptsRef.current === 0 ? 'connecting' : 'reconnecting')
+      const ws = new WS(buildWsUrl())
+      wsRef.current = ws
+
+      ws.onopen = () => {
+        if (deadRef.current) {
+          ws.close()
+          return
+        }
+        attemptsRef.current = 0
+        setStatus('connected')
+      }
+
+      ws.onmessage = (evt) => {
+        try {
+          const parsed = JSON.parse(evt.data as string) as GovernanceEvent
+          const op = mapEvent(parsed)
+          if (!op) return
+          setOps((prev) => {
+            const next = [op, ...prev]
+            return next.length > maxOps ? next.slice(0, maxOps) : next
+          })
+        } catch {
+          // Malformed frame — drop silently.
+        }
+      }
+
+      ws.onclose = () => {
+        if (deadRef.current) return
+        attemptsRef.current += 1
+        if (attemptsRef.current > maxReconnectAttempts) {
+          setStatus('error')
+          return
+        }
+        const delay = Math.min(
+          initialBackoffMs * 2 ** (attemptsRef.current - 1),
+          maxBackoffMs,
+        )
+        setStatus('reconnecting')
+        timerRef.current = setTimeout(connect, delay)
+      }
+
+      ws.onerror = () => {
+        ws.close()
+      }
+    }
+
+    connect()
+
+    return () => {
+      deadRef.current = true
+      if (timerRef.current) clearTimeout(timerRef.current)
+      wsRef.current?.close()
+    }
+  }, [
+    reconnectTick,
+    WS,
+    maxOps,
+    initialBackoffMs,
+    maxBackoffMs,
+    maxReconnectAttempts,
+  ])
+
+  return { ops, status, reconnect }
+}


### PR DESCRIPTION
## Description

Adds the WebSocket data layer for the Live Ops event-stream zone. Pure logic — no DOM. Connects to the existing `GET /api/v1/ws/events?types=violation` endpoint, projects governance events into a thin `LiveOperation` ring, and exposes `{ ops, status, reconnect }`. Wiring on `LiveOpsPage` (mount + ErrorState + filter pipeline) ships in AAASM-1332.

| Commit | Layer |
|---|---|
| `eb082b30` ✨ Add useLiveOpsStream hook (WS + reconnect + ring buffer) | `features/liveOps/useLiveOpsStream.ts` |
| `cca45dd4` ✅ Add useLiveOpsStream tests (mock WS + fake timers) | `features/liveOps/useLiveOpsStream.test.ts` |

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Jira ticket: AAASM-1331 (subtask of AAASM-1282 — Dashboard PR 9: Live Ops page)
- Parent Epic: AAASM-11 (Community Dashboard)
- Predecessor: AAASM-1330 (AutoScrollToggle, merged in PR #380)

## Implementation notes

- **Endpoint**: existing `GET /api/v1/ws/events` from `aa-api` — no new gateway endpoint. Connection sends `types=violation` query param (uses the filter already documented in `aa-api/src/models/event_type.rs`).
- **State machine**: `connecting → connected → reconnecting → error`. `error` is terminal until manual `reconnect()` is called.
- **Reconnect**: exponential backoff (default `250 ms × 2^attempt`, capped at 8 s), max 5 consecutive attempts. All four knobs are options so tests can compress the timeline.
- **Ring**: most-recent-first, capped at `maxOps` (default 100).
- **Mapping**: `mapEvent` does best-effort `GovernanceEvent → LiveOperation`. The gateway's `ViolationPayload` doesn't yet carry op-type / resource / latency, so those fields stay placeholder until the gateway enriches the payload. Hook doesn't block dashboard work on that.
- **Auth**: appends `localStorage.aa_token` as a `token=` query param (same pattern as `useApprovalsStream`).
- **Test seam**: `webSocketCtor` option lets tests inject a `MockWebSocket` so the reconnect timeline is deterministic under `vi.useFakeTimers()`.

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required

10 Vitest cases covering mount, connect, message ingest, message ordering, type filtering, malformed-frame tolerance, ring cap, reconnect backoff (verifies the boundary at 100 ms → 200 ms), error after max attempts, manual reconnect from error, and unmount cleanup.

Local checks (this branch):

- `pnpm type-check` — clean
- `pnpm lint` — clean
- `pnpm test` — **585 / 585** passing (67 files)

## Checklist

- [ ] Code follows project style guidelines (\`cargo fmt\`, \`cargo clippy\`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

> Rust style hooks did not apply — diff is TS-only inside \`dashboard/\`.