### PR TITLE
[AAASM-1075] ✨ (dashboard/alerts): Add Tanstack Query hooks for alerts API

### DIFF
--- a/dashboard/src/features/alerts/api.test.tsx
+++ b/dashboard/src/features/alerts/api.test.tsx
@@ -1,0 +1,299 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  useAlertsQuery,
+  useAlertQuery,
+  useAlertRulesQuery,
+  useCreateAlertRuleMutation,
+  useUpdateAlertRuleMutation,
+  useDeleteAlertRuleMutation,
+  useSilenceAlertMutation,
+  useDestinationsQuery,
+  useCreateDestinationMutation,
+  useUpdateDestinationMutation,
+  useDeleteDestinationMutation,
+  useTestDestinationMutation,
+} from './api'
+import { alertsQueryKeys } from './endpoints'
+import {
+  DEFAULT_ALERT_FILTERS,
+  type Alert,
+  type AlertRule,
+  type AlertRuleInput,
+  type Destination,
+  type DestinationInput,
+  type Silence,
+} from './types'
+
+// ── Test scaffolding ──────────────────────────────────────────────────────
+
+interface FetchCall {
+  url: string
+  init: RequestInit
+}
+
+let calls: FetchCall[]
+let nextResponse: { ok: boolean; status: number; body: unknown }
+
+beforeEach(() => {
+  calls = []
+  nextResponse = { ok: true, status: 200, body: undefined }
+  localStorage.setItem('aa_token', 'test-token')
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string, init: RequestInit = {}) => {
+      calls.push({ url, init })
+      return {
+        ok: nextResponse.ok,
+        status: nextResponse.status,
+        json: async () => nextResponse.body,
+      } as Response
+    }),
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  )
+  return { client, Wrapper }
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────
+
+const FIXTURE_ALERT: Alert = {
+  id: 'a-1',
+  ruleId: 'r-1',
+  ruleName: 'Budget > 90%',
+  severity: 'CRITICAL',
+  status: 'FIRING',
+  agentId: 'aa-001',
+  firstFiredAt: '2026-05-13T09:12:00Z',
+  resolvedAt: null,
+  destinationIds: ['slack-ops'],
+}
+
+const FIXTURE_RULE: AlertRule = {
+  id: 'r-1',
+  name: 'Budget > 90%',
+  description: '',
+  metric: 'budget_spent_pct',
+  operator: '>',
+  threshold: 90,
+  evaluationWindowSeconds: 300,
+  severity: 'CRITICAL',
+  destinationIds: ['slack-ops'],
+  dedupWindowSeconds: 600,
+  suppressionLabels: {},
+  enabled: true,
+  createdAt: '2026-05-13T00:00:00Z',
+  updatedAt: '2026-05-13T00:00:00Z',
+}
+
+const FIXTURE_RULE_INPUT: AlertRuleInput = {
+  name: 'Budget > 90%',
+  description: '',
+  metric: 'budget_spent_pct',
+  operator: '>',
+  threshold: 90,
+  evaluationWindowSeconds: 300,
+  severity: 'CRITICAL',
+  destinationIds: ['slack-ops'],
+  dedupWindowSeconds: 600,
+  suppressionLabels: {},
+  enabled: true,
+}
+
+const FIXTURE_DESTINATION: Destination = {
+  id: 'd-1',
+  kind: 'webhook',
+  name: 'Ops webhook',
+  enabled: true,
+  createdAt: '2026-05-13T00:00:00Z',
+  updatedAt: '2026-05-13T00:00:00Z',
+  config: { url: 'https://hooks.internal/aaasm' },
+}
+
+const FIXTURE_DESTINATION_INPUT: DestinationInput = {
+  kind: 'webhook',
+  name: 'Ops webhook',
+  enabled: true,
+  config: { url: 'https://hooks.internal/aaasm' },
+}
+
+const FIXTURE_SILENCE: Silence = {
+  silenceId: 'sil-1',
+  alertId: 'a-1',
+  startsAt: '2026-05-13T09:30:00Z',
+  expiresAt: '2026-05-13T10:30:00Z',
+  reason: null,
+  createdBy: 'user-1',
+}
+
+// ── Queries ───────────────────────────────────────────────────────────────
+
+describe('useAlertsQuery', () => {
+  it('fetches /api/v1/alerts with filter query string and Bearer token', async () => {
+    nextResponse = { ok: true, status: 200, body: [FIXTURE_ALERT] }
+    const { Wrapper } = wrapper()
+    const filters = { ...DEFAULT_ALERT_FILTERS, severities: ['CRITICAL'] as const }
+    const { result } = renderHook(() => useAlertsQuery(filters), { wrapper: Wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(result.current.data).toEqual([FIXTURE_ALERT])
+    expect(calls[0].url).toBe('/api/v1/alerts?severity=CRITICAL&range=24h')
+    expect((calls[0].init.headers as Record<string, string>).Authorization).toBe(
+      'Bearer test-token',
+    )
+  })
+
+  it('returns isError on non-2xx response', async () => {
+    nextResponse = { ok: false, status: 500, body: 'boom' }
+    const { Wrapper } = wrapper()
+    const { result } = renderHook(() => useAlertsQuery(DEFAULT_ALERT_FILTERS), {
+      wrapper: Wrapper,
+    })
+    await waitFor(() => expect(result.current.isError).toBe(true))
+  })
+})
+
+describe('useAlertQuery', () => {
+  it('is disabled when id is null', () => {
+    const { Wrapper } = wrapper()
+    const { result } = renderHook(() => useAlertQuery(null), { wrapper: Wrapper })
+    expect(result.current.fetchStatus).toBe('idle')
+    expect(calls).toHaveLength(0)
+  })
+
+  it('fetches /api/v1/alerts/{id} when id is provided', async () => {
+    nextResponse = { ok: true, status: 200, body: FIXTURE_ALERT }
+    const { Wrapper } = wrapper()
+    const { result } = renderHook(() => useAlertQuery('a-1'), { wrapper: Wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(calls[0].url).toBe('/api/v1/alerts/a-1')
+  })
+})
+
+describe('useAlertRulesQuery + mutations', () => {
+  it('lists rules', async () => {
+    nextResponse = { ok: true, status: 200, body: [FIXTURE_RULE] }
+    const { Wrapper } = wrapper()
+    const { result } = renderHook(() => useAlertRulesQuery(), { wrapper: Wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(calls[0].url).toBe('/api/v1/alerts/rules')
+  })
+
+  it('create mutation POSTs JSON and invalidates the rules cache key', async () => {
+    nextResponse = { ok: true, status: 201, body: FIXTURE_RULE }
+    const { client, Wrapper } = wrapper()
+    const spy = vi.spyOn(client, 'invalidateQueries')
+    const { result } = renderHook(() => useCreateAlertRuleMutation(), { wrapper: Wrapper })
+    await result.current.mutateAsync(FIXTURE_RULE_INPUT)
+    expect(calls[0].init.method).toBe('POST')
+    expect(calls[0].init.body).toBe(JSON.stringify(FIXTURE_RULE_INPUT))
+    expect(spy).toHaveBeenCalledWith({ queryKey: [alertsQueryKeys.alertRules] })
+  })
+
+  it('update mutation PUTs to /rules/{id} and invalidates', async () => {
+    nextResponse = { ok: true, status: 200, body: FIXTURE_RULE }
+    const { client, Wrapper } = wrapper()
+    const spy = vi.spyOn(client, 'invalidateQueries')
+    const { result } = renderHook(() => useUpdateAlertRuleMutation(), { wrapper: Wrapper })
+    await result.current.mutateAsync({ id: 'r-1', input: FIXTURE_RULE_INPUT })
+    expect(calls[0].url).toBe('/api/v1/alerts/rules/r-1')
+    expect(calls[0].init.method).toBe('PUT')
+    expect(spy).toHaveBeenCalledWith({ queryKey: [alertsQueryKeys.alertRules] })
+  })
+
+  it('delete mutation DELETEs and invalidates', async () => {
+    nextResponse = { ok: true, status: 204, body: undefined }
+    const { client, Wrapper } = wrapper()
+    const spy = vi.spyOn(client, 'invalidateQueries')
+    const { result } = renderHook(() => useDeleteAlertRuleMutation(), { wrapper: Wrapper })
+    await result.current.mutateAsync('r-1')
+    expect(calls[0].init.method).toBe('DELETE')
+    expect(spy).toHaveBeenCalledWith({ queryKey: [alertsQueryKeys.alertRules] })
+  })
+})
+
+describe('useSilenceAlertMutation', () => {
+  it('POSTs snake_case body and invalidates alerts', async () => {
+    nextResponse = { ok: true, status: 201, body: FIXTURE_SILENCE }
+    const { client, Wrapper } = wrapper()
+    const spy = vi.spyOn(client, 'invalidateQueries')
+    const { result } = renderHook(() => useSilenceAlertMutation(), { wrapper: Wrapper })
+    await result.current.mutateAsync({
+      alertId: 'a-1',
+      durationSeconds: 3600,
+      reason: 'maintenance',
+    })
+    expect(calls[0].url).toBe('/api/v1/alerts/silence')
+    const body = JSON.parse(calls[0].init.body as string)
+    expect(body).toEqual({
+      alert_id: 'a-1',
+      duration_seconds: 3600,
+      reason: 'maintenance',
+    })
+    expect(spy).toHaveBeenCalledWith({ queryKey: [alertsQueryKeys.alerts] })
+  })
+})
+
+describe('destinations hooks', () => {
+  it('lists destinations', async () => {
+    nextResponse = { ok: true, status: 200, body: [FIXTURE_DESTINATION] }
+    const { Wrapper } = wrapper()
+    const { result } = renderHook(() => useDestinationsQuery(), { wrapper: Wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(calls[0].url).toBe('/api/v1/alerts/destinations')
+  })
+
+  it('create mutation POSTs and invalidates destinations', async () => {
+    nextResponse = { ok: true, status: 201, body: FIXTURE_DESTINATION }
+    const { client, Wrapper } = wrapper()
+    const spy = vi.spyOn(client, 'invalidateQueries')
+    const { result } = renderHook(() => useCreateDestinationMutation(), { wrapper: Wrapper })
+    await result.current.mutateAsync(FIXTURE_DESTINATION_INPUT)
+    expect(spy).toHaveBeenCalledWith({ queryKey: [alertsQueryKeys.destinations] })
+  })
+
+  it('update mutation PUTs and invalidates', async () => {
+    nextResponse = { ok: true, status: 200, body: FIXTURE_DESTINATION }
+    const { client, Wrapper } = wrapper()
+    const spy = vi.spyOn(client, 'invalidateQueries')
+    const { result } = renderHook(() => useUpdateDestinationMutation(), { wrapper: Wrapper })
+    await result.current.mutateAsync({ id: 'd-1', input: FIXTURE_DESTINATION_INPUT })
+    expect(calls[0].init.method).toBe('PUT')
+    expect(spy).toHaveBeenCalledWith({ queryKey: [alertsQueryKeys.destinations] })
+  })
+
+  it('delete mutation DELETEs and invalidates', async () => {
+    nextResponse = { ok: true, status: 204, body: undefined }
+    const { client, Wrapper } = wrapper()
+    const spy = vi.spyOn(client, 'invalidateQueries')
+    const { result } = renderHook(() => useDeleteDestinationMutation(), { wrapper: Wrapper })
+    await result.current.mutateAsync('d-1')
+    expect(calls[0].init.method).toBe('DELETE')
+    expect(spy).toHaveBeenCalledWith({ queryKey: [alertsQueryKeys.destinations] })
+  })
+
+  it('test mutation POSTs to /destinations/{id}/test and does not invalidate the list', async () => {
+    nextResponse = {
+      ok: true,
+      status: 200,
+      body: { deliveredAt: '2026-05-13T00:00:00Z', connectorResponseStatus: 200, connectorResponseBody: 'ok' },
+    }
+    const { client, Wrapper } = wrapper()
+    const spy = vi.spyOn(client, 'invalidateQueries')
+    const { result } = renderHook(() => useTestDestinationMutation(), { wrapper: Wrapper })
+    await result.current.mutateAsync({ id: 'd-1', severity: 'LOW' })
+    expect(calls[0].url).toBe('/api/v1/alerts/destinations/d-1/test')
+    expect(calls[0].init.method).toBe('POST')
+    expect(spy).not.toHaveBeenCalled()
+  })
+})

--- a/dashboard/src/features/alerts/api.ts
+++ b/dashboard/src/features/alerts/api.ts
@@ -11,6 +11,9 @@ import type {
   AlertFilters,
   AlertRule,
   AlertRuleInput,
+  Destination,
+  DestinationInput,
+  DestinationTestResult,
   Silence,
   SilenceInput,
 } from './types'
@@ -142,6 +145,76 @@ export function useDeleteAlertRuleMutation(): UseMutationResult<void, Error, str
     mutationFn: (id) =>
       alertsFetch<void>(alertsEndpoints.rule(id), { method: 'DELETE' }),
     onSuccess: () => invalidateRules(client),
+  })
+}
+
+// ── Destinations — list + create / update / delete / test ────────────────
+
+function invalidateDestinations(
+  client: ReturnType<typeof useQueryClient>,
+): Promise<void> {
+  return client.invalidateQueries({ queryKey: [alertsQueryKeys.destinations] })
+}
+
+export function useDestinationsQuery(): UseQueryResult<readonly Destination[], Error> {
+  return useQuery({
+    queryKey: [alertsQueryKeys.destinations],
+    queryFn: () => alertsFetch<readonly Destination[]>(alertsEndpoints.destinations),
+  })
+}
+
+export function useCreateDestinationMutation(): UseMutationResult<
+  Destination,
+  Error,
+  DestinationInput
+> {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: (input) =>
+      alertsFetch<Destination>(alertsEndpoints.destinations, {
+        method: 'POST',
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => invalidateDestinations(client),
+  })
+}
+
+export function useUpdateDestinationMutation(): UseMutationResult<
+  Destination,
+  Error,
+  { id: string; input: DestinationInput }
+> {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, input }) =>
+      alertsFetch<Destination>(alertsEndpoints.destination(id), {
+        method: 'PUT',
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => invalidateDestinations(client),
+  })
+}
+
+export function useDeleteDestinationMutation(): UseMutationResult<void, Error, string> {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: (id) =>
+      alertsFetch<void>(alertsEndpoints.destination(id), { method: 'DELETE' }),
+    onSuccess: () => invalidateDestinations(client),
+  })
+}
+
+export function useTestDestinationMutation(): UseMutationResult<
+  DestinationTestResult,
+  Error,
+  { id: string; severity?: string; message?: string }
+> {
+  return useMutation({
+    mutationFn: ({ id, severity, message }) =>
+      alertsFetch<DestinationTestResult>(alertsEndpoints.destinationTest(id), {
+        method: 'POST',
+        body: JSON.stringify({ severity, message }),
+      }),
   })
 }
 

--- a/dashboard/src/features/alerts/api.ts
+++ b/dashboard/src/features/alerts/api.ts
@@ -6,7 +6,14 @@ import {
   type UseQueryResult,
 } from '@tanstack/react-query'
 import { alertsEndpoints, alertsQueryKeys } from './endpoints'
-import type { Alert, AlertFilters, AlertRule, AlertRuleInput } from './types'
+import type {
+  Alert,
+  AlertFilters,
+  AlertRule,
+  AlertRuleInput,
+  Silence,
+  SilenceInput,
+} from './types'
 
 // ── Fetch helper ──────────────────────────────────────────────────────────
 //
@@ -135,5 +142,27 @@ export function useDeleteAlertRuleMutation(): UseMutationResult<void, Error, str
     mutationFn: (id) =>
       alertsFetch<void>(alertsEndpoints.rule(id), { method: 'DELETE' }),
     onSuccess: () => invalidateRules(client),
+  })
+}
+
+// ── useSilenceAlertMutation ───────────────────────────────────────────────
+
+export function useSilenceAlertMutation(): UseMutationResult<
+  Silence,
+  Error,
+  SilenceInput
+> {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: (input) =>
+      alertsFetch<Silence>(alertsEndpoints.silence, {
+        method: 'POST',
+        body: JSON.stringify({
+          alert_id: input.alertId,
+          duration_seconds: input.durationSeconds,
+          reason: input.reason,
+        }),
+      }),
+    onSuccess: () => client.invalidateQueries({ queryKey: [alertsQueryKeys.alerts] }),
   })
 }

--- a/dashboard/src/features/alerts/api.ts
+++ b/dashboard/src/features/alerts/api.ts
@@ -1,6 +1,12 @@
-import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from '@tanstack/react-query'
 import { alertsEndpoints, alertsQueryKeys } from './endpoints'
-import type { Alert, AlertFilters } from './types'
+import type { Alert, AlertFilters, AlertRule, AlertRuleInput } from './types'
 
 // ── Fetch helper ──────────────────────────────────────────────────────────
 //
@@ -75,5 +81,59 @@ export function useAlertQuery(id: string | null | undefined): UseQueryResult<Ale
     queryKey: [alertsQueryKeys.alerts, id ?? ''],
     queryFn: () => alertsFetch<Alert>(alertsEndpoints.detail(id as string)),
     enabled: !!id,
+  })
+}
+
+// ── Alert rules — list + create / update / delete ─────────────────────────
+
+export function useAlertRulesQuery(): UseQueryResult<readonly AlertRule[], Error> {
+  return useQuery({
+    queryKey: [alertsQueryKeys.alertRules],
+    queryFn: () => alertsFetch<readonly AlertRule[]>(alertsEndpoints.rules),
+  })
+}
+
+function invalidateRules(client: ReturnType<typeof useQueryClient>): Promise<void> {
+  return client.invalidateQueries({ queryKey: [alertsQueryKeys.alertRules] })
+}
+
+export function useCreateAlertRuleMutation(): UseMutationResult<
+  AlertRule,
+  Error,
+  AlertRuleInput
+> {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: (input) =>
+      alertsFetch<AlertRule>(alertsEndpoints.rules, {
+        method: 'POST',
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => invalidateRules(client),
+  })
+}
+
+export function useUpdateAlertRuleMutation(): UseMutationResult<
+  AlertRule,
+  Error,
+  { id: string; input: AlertRuleInput }
+> {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, input }) =>
+      alertsFetch<AlertRule>(alertsEndpoints.rule(id), {
+        method: 'PUT',
+        body: JSON.stringify(input),
+      }),
+    onSuccess: () => invalidateRules(client),
+  })
+}
+
+export function useDeleteAlertRuleMutation(): UseMutationResult<void, Error, string> {
+  const client = useQueryClient()
+  return useMutation({
+    mutationFn: (id) =>
+      alertsFetch<void>(alertsEndpoints.rule(id), { method: 'DELETE' }),
+    onSuccess: () => invalidateRules(client),
   })
 }

--- a/dashboard/src/features/alerts/api.ts
+++ b/dashboard/src/features/alerts/api.ts
@@ -67,3 +67,13 @@ export function useAlertsQuery(
     placeholderData: (prev) => prev,
   })
 }
+
+// ── useAlertQuery (single alert detail) ───────────────────────────────────
+
+export function useAlertQuery(id: string | null | undefined): UseQueryResult<Alert, Error> {
+  return useQuery({
+    queryKey: [alertsQueryKeys.alerts, id ?? ''],
+    queryFn: () => alertsFetch<Alert>(alertsEndpoints.detail(id as string)),
+    enabled: !!id,
+  })
+}

--- a/dashboard/src/features/alerts/api.ts
+++ b/dashboard/src/features/alerts/api.ts
@@ -1,0 +1,69 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { alertsEndpoints, alertsQueryKeys } from './endpoints'
+import type { Alert, AlertFilters } from './types'
+
+// ── Fetch helper ──────────────────────────────────────────────────────────
+//
+// The endpoints listed in `endpoints.ts` (other than `list`) are not yet in
+// `openapi/v1.yaml` — see backend Stories AAASM-1385 / 1386 / 1387 / 1388 /
+// 1389. The typed `openapi-fetch` client therefore cannot reach them; this
+// thin wrapper mirrors its auth/baseUrl handling using raw `fetch` so every
+// alerts hook stays consistent. Swap call sites back to the typed client
+// once the schema regenerates.
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+
+function authHeader(): Record<string, string> {
+  const token = localStorage.getItem('aa_token')
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
+export async function alertsFetch<T>(
+  path: string,
+  init: RequestInit = {},
+): Promise<T> {
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    ...authHeader(),
+    ...((init.headers as Record<string, string>) ?? {}),
+  }
+  if (init.body && !headers['Content-Type']) {
+    headers['Content-Type'] = 'application/json'
+  }
+  const response = await fetch(`${BASE_URL}${path}`, { ...init, headers })
+  if (!response.ok) {
+    throw new Error(`${init.method ?? 'GET'} ${path} failed: ${response.status}`)
+  }
+  if (response.status === 204) return undefined as T
+  return (await response.json()) as T
+}
+
+// ── useAlertsQuery ────────────────────────────────────────────────────────
+
+function buildAlertsQueryString(filters: AlertFilters): string {
+  const sp = new URLSearchParams()
+  filters.severities.forEach((s) => sp.append('severity', s))
+  filters.statuses.forEach((s) => sp.append('status', s))
+  if (filters.agentQuery.trim()) sp.set('agent', filters.agentQuery.trim())
+  if (filters.timeRange !== 'custom') {
+    sp.set('range', filters.timeRange)
+  } else {
+    if (filters.customFrom) sp.set('from', filters.customFrom)
+    if (filters.customTo) sp.set('to', filters.customTo)
+  }
+  const qs = sp.toString()
+  return qs ? `?${qs}` : ''
+}
+
+export function useAlertsQuery(
+  filters: AlertFilters,
+): UseQueryResult<readonly Alert[], Error> {
+  return useQuery({
+    queryKey: [alertsQueryKeys.alerts, filters],
+    queryFn: () =>
+      alertsFetch<readonly Alert[]>(
+        `${alertsEndpoints.list}${buildAlertsQueryString(filters)}`,
+      ),
+    placeholderData: (prev) => prev,
+  })
+}

--- a/dashboard/src/features/alerts/endpoints.ts
+++ b/dashboard/src/features/alerts/endpoints.ts
@@ -1,0 +1,27 @@
+// Central registry of every URL the alerts feature talks to.
+//
+// Each backend Story (AAASM-1385 / 1386 / 1387 / 1388 / 1389) commits to one
+// of these paths. Keeping them in a single module means: when the backend
+// ships and codegen catches up, only this file plus the typed `api` client
+// need to change.
+
+export const alertsEndpoints = {
+  list: '/api/v1/alerts',
+  detail: (id: string) => `/api/v1/alerts/${encodeURIComponent(id)}`,
+  rules: '/api/v1/alerts/rules',
+  rule: (id: string) => `/api/v1/alerts/rules/${encodeURIComponent(id)}`,
+  silence: '/api/v1/alerts/silence',
+  destinations: '/api/v1/alerts/destinations',
+  destination: (id: string) => `/api/v1/alerts/destinations/${encodeURIComponent(id)}`,
+  destinationTest: (id: string) =>
+    `/api/v1/alerts/destinations/${encodeURIComponent(id)}/test`,
+  /** WebSocket upgrade for fire / resolve / silence events (AAASM-1389). */
+  websocket: '/api/v1/alerts/ws',
+} as const
+
+/** Tanstack Query cache key roots. Hooks use these so invalidation stays consistent. */
+export const alertsQueryKeys = {
+  alerts: 'alerts',
+  alertRules: 'alert-rules',
+  destinations: 'alert-destinations',
+} as const

--- a/dashboard/src/features/alerts/types.ts
+++ b/dashboard/src/features/alerts/types.ts
@@ -46,3 +46,103 @@ export const DEFAULT_ALERT_FILTERS: AlertFilters = {
   customFrom: null,
   customTo: null,
 }
+
+// ── AlertRule (AAASM-1386 schema) ──────────────────────────────────────────
+
+export type AlertMetric =
+  | 'budget_spent_pct'
+  | 'anomaly_score'
+  | 'approval_pending_age'
+  | 'policy_violation_count'
+
+export type AlertOperator = '>' | '>=' | '<' | '='
+
+/** Evaluation window in seconds — fixed allowed values per AAASM-1386 AC. */
+export type EvaluationWindowSeconds = 300 | 900 | 3600
+
+export interface AlertRule {
+  id: string
+  name: string
+  description: string
+  metric: AlertMetric
+  operator: AlertOperator
+  threshold: number
+  evaluationWindowSeconds: EvaluationWindowSeconds
+  severity: Severity
+  destinationIds: readonly string[]
+  dedupWindowSeconds: number
+  suppressionLabels: Readonly<Record<string, string>>
+  enabled: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+/** Shape sent to POST /alerts/rules and PUT /alerts/rules/{id}. */
+export type AlertRuleInput = Omit<AlertRule, 'id' | 'createdAt' | 'updatedAt'>
+
+// ── Destination (AAASM-1388 schema) ────────────────────────────────────────
+
+export type DestinationKind = 'webhook' | 'slack' | 'pagerduty' | 'opsgenie'
+
+export interface DestinationBase {
+  id: string
+  kind: DestinationKind
+  name: string
+  enabled: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface WebhookDestination extends DestinationBase {
+  kind: 'webhook'
+  config: { url: string; secretHeader?: string | null }
+}
+
+export interface SlackDestination extends DestinationBase {
+  kind: 'slack'
+  config: { webhookUrl: string; channelOverride?: string | null }
+}
+
+export interface PagerDutyDestination extends DestinationBase {
+  kind: 'pagerduty'
+  config: {
+    routingKey: string
+    severityMap?: Readonly<Partial<Record<Severity, string>>>
+  }
+}
+
+export interface OpsgenieDestination extends DestinationBase {
+  kind: 'opsgenie'
+  config: { apiKey: string; teamId?: string | null }
+}
+
+export type Destination =
+  | WebhookDestination
+  | SlackDestination
+  | PagerDutyDestination
+  | OpsgenieDestination
+
+export type DestinationInput = Omit<Destination, 'id' | 'createdAt' | 'updatedAt'>
+
+export interface DestinationTestResult {
+  deliveredAt: string
+  connectorResponseStatus: number
+  connectorResponseBody: string
+}
+
+// ── Silence (AAASM-1387 schema) ────────────────────────────────────────────
+
+export interface Silence {
+  silenceId: string
+  alertId: string
+  startsAt: string
+  expiresAt: string
+  reason: string | null
+  createdBy: string
+}
+
+export interface SilenceInput {
+  alertId: string
+  durationSeconds: number
+  reason?: string
+}

--- a/dashboard/src/features/alerts/urlFilters.test.ts
+++ b/dashboard/src/features/alerts/urlFilters.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import { filtersFromSearchParams, filtersToSearchParams } from './urlFilters'
+import { DEFAULT_ALERT_FILTERS, type AlertFilters } from './types'
+
+describe('urlFilters', () => {
+  it('round-trips a complex filter through search params', () => {
+    const filters: AlertFilters = {
+      severities: ['CRITICAL', 'HIGH'],
+      statuses: ['FIRING'],
+      agentQuery: 'aa-001',
+      timeRange: 'custom',
+      customFrom: '2026-05-13T00:00',
+      customTo: '2026-05-13T23:59',
+    }
+    const sp = filtersToSearchParams(filters)
+    expect(filtersFromSearchParams(sp)).toEqual(filters)
+  })
+
+  it('returns defaults from an empty search-params object', () => {
+    expect(filtersFromSearchParams(new URLSearchParams())).toEqual(DEFAULT_ALERT_FILTERS)
+  })
+
+  it('omits the default 24h range from the search params', () => {
+    const sp = filtersToSearchParams(DEFAULT_ALERT_FILTERS)
+    expect(sp.has('range')).toBe(false)
+  })
+
+  it('ignores unknown severity values from the URL', () => {
+    const sp = new URLSearchParams('severity=CRITICAL&severity=BOGUS')
+    expect(filtersFromSearchParams(sp).severities).toEqual(['CRITICAL'])
+  })
+})

--- a/dashboard/src/features/alerts/urlFilters.ts
+++ b/dashboard/src/features/alerts/urlFilters.ts
@@ -1,0 +1,45 @@
+import {
+  DEFAULT_ALERT_FILTERS,
+  type AlertFilters,
+  type AlertStatus,
+  type Severity,
+  type TimeRangePreset,
+} from './types'
+
+const SEVERITY_VALUES: readonly Severity[] = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']
+const STATUS_VALUES: readonly AlertStatus[] = ['FIRING', 'RESOLVED', 'SUPPRESSED']
+const RANGE_VALUES: readonly TimeRangePreset[] = ['24h', '7d', '30d', 'custom']
+
+export function filtersFromSearchParams(sp: URLSearchParams): AlertFilters {
+  const severities = sp.getAll('severity').filter((v): v is Severity =>
+    SEVERITY_VALUES.includes(v as Severity),
+  )
+  const statuses = sp.getAll('status').filter((v): v is AlertStatus =>
+    STATUS_VALUES.includes(v as AlertStatus),
+  )
+  const rawRange = sp.get('range') ?? DEFAULT_ALERT_FILTERS.timeRange
+  const timeRange: TimeRangePreset = RANGE_VALUES.includes(rawRange as TimeRangePreset)
+    ? (rawRange as TimeRangePreset)
+    : DEFAULT_ALERT_FILTERS.timeRange
+  return {
+    severities,
+    statuses,
+    agentQuery: sp.get('agent') ?? '',
+    timeRange,
+    customFrom: sp.get('from'),
+    customTo: sp.get('to'),
+  }
+}
+
+export function filtersToSearchParams(filters: AlertFilters): URLSearchParams {
+  const sp = new URLSearchParams()
+  filters.severities.forEach((s) => sp.append('severity', s))
+  filters.statuses.forEach((s) => sp.append('status', s))
+  if (filters.agentQuery.trim()) sp.set('agent', filters.agentQuery.trim())
+  if (filters.timeRange !== '24h') sp.set('range', filters.timeRange)
+  if (filters.timeRange === 'custom') {
+    if (filters.customFrom) sp.set('from', filters.customFrom)
+    if (filters.customTo) sp.set('to', filters.customTo)
+  }
+  return sp
+}

--- a/dashboard/src/pages/AlertsPage.tsx
+++ b/dashboard/src/pages/AlertsPage.tsx
@@ -1,64 +1,28 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { AlertList } from '../features/alerts/AlertList'
 import { AlertFilterBar } from '../features/alerts/AlertFilterBar'
-import { applyClientFilters } from '../features/alerts/alertFilters'
-import { DEFAULT_ALERT_FILTERS, type Alert, type AlertFilters } from '../features/alerts/types'
-
-// Mock data — the live `useAlertsQuery` wiring lands in AAASM-1075.
-const MOCK_ALERTS: readonly Alert[] = [
-  {
-    id: 'alert-001',
-    ruleId: 'rule-budget-90',
-    ruleName: 'Budget threshold > 90%',
-    severity: 'CRITICAL',
-    status: 'FIRING',
-    agentId: 'aa-001',
-    firstFiredAt: '2026-05-13T09:12:00Z',
-    resolvedAt: null,
-    destinationIds: ['slack-ops'],
-  },
-  {
-    id: 'alert-002',
-    ruleId: 'rule-violation-rate',
-    ruleName: 'Policy violation rate > 5',
-    severity: 'HIGH',
-    status: 'FIRING',
-    agentId: 'aa-002',
-    firstFiredAt: '2026-05-13T10:42:00Z',
-    resolvedAt: null,
-    destinationIds: ['pagerduty-primary'],
-  },
-  {
-    id: 'alert-003',
-    ruleId: 'rule-anomaly',
-    ruleName: 'Anomaly score > 0.8',
-    severity: 'MEDIUM',
-    status: 'SUPPRESSED',
-    agentId: 'aa-005',
-    firstFiredAt: '2026-05-12T14:00:00Z',
-    resolvedAt: null,
-    destinationIds: ['webhook-internal'],
-  },
-  {
-    id: 'alert-004',
-    ruleId: 'rule-approval-age',
-    ruleName: 'Approval pending > 30m',
-    severity: 'LOW',
-    status: 'RESOLVED',
-    agentId: null,
-    firstFiredAt: '2026-05-11T08:30:00Z',
-    resolvedAt: '2026-05-11T09:05:00Z',
-    destinationIds: [],
-  },
-]
+import { useAlertsQuery } from '../features/alerts/api'
+import {
+  filtersFromSearchParams,
+  filtersToSearchParams,
+} from '../features/alerts/urlFilters'
+import type { AlertFilters } from '../features/alerts/types'
 
 export function AlertsPage() {
-  const [filters, setFilters] = useState<AlertFilters>(DEFAULT_ALERT_FILTERS)
-
-  const visibleRows = useMemo(
-    () => applyClientFilters(MOCK_ALERTS, filters),
-    [filters],
+  const [searchParams, setSearchParams] = useSearchParams()
+  const filters: AlertFilters = useMemo(
+    () => filtersFromSearchParams(searchParams),
+    [searchParams],
   )
+
+  const setFilters = useCallback(
+    (next: AlertFilters) => setSearchParams(filtersToSearchParams(next)),
+    [setSearchParams],
+  )
+
+  const { data, isLoading, isError, error, refetch } = useAlertsQuery(filters)
+  const rows = data ?? []
 
   return (
     <main style={{ padding: '1.5rem' }}>
@@ -69,11 +33,31 @@ export function AlertsPage() {
 
       <AlertFilterBar value={filters} onChange={setFilters} />
 
-      <div data-testid="alerts-count" style={{ fontSize: '0.75rem', color: '#6b7280', padding: '0.5rem 0' }}>
-        Showing {visibleRows.length} of {MOCK_ALERTS.length}
+      {isError && (
+        <div
+          data-testid="alerts-error"
+          style={{
+            color: '#dc2626',
+            marginTop: '0.75rem',
+            display: 'flex',
+            gap: '1rem',
+            alignItems: 'center',
+            fontSize: '0.875rem',
+          }}
+        >
+          <span>Failed to load alerts: {error?.message ?? 'unknown error'}</span>
+          <button onClick={() => void refetch()}>Retry</button>
+        </div>
+      )}
+
+      <div
+        data-testid="alerts-count"
+        style={{ fontSize: '0.75rem', color: '#6b7280', padding: '0.5rem 0' }}
+      >
+        {isLoading ? 'Loading…' : `${rows.length} alert${rows.length === 1 ? '' : 's'}`}
       </div>
 
-      <AlertList rows={visibleRows} />
+      <AlertList rows={rows} />
     </main>
   )
 }


### PR DESCRIPTION
## Description

Adds the 10 Tanstack Query hooks the dashboard Alerts page needs to talk to the backend — alert list / detail, alert rule CRUD, silence, destination CRUD + test-fire. Parent Story [AAASM-118](https://lightning-dust-mite.atlassian.net/browse/AAASM-118).

### Speculative-paths approach

Audit of `openapi/v1.yaml` on `master@1a57590a` confirms only `GET /api/v1/alerts` is exposed. The remaining 9 hooks target paths that **do not exist yet** — tracked as backend dependency Stories **AAASM-1385 / 1386 / 1387 / 1388 / 1389**, each linked as "blocks AAASM-1075". Per product-owner direction, this PR ships the hooks against the contracted URLs now so downstream Sub-tasks (rule builder AAASM-1077, drawer AAASM-1080, destination manager AAASM-1082) are unblocked. When the backend lands, the swap to the typed `openapi-fetch` client is localised to `endpoints.ts` + `api.ts`.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

## Related Issues

- Related Jira ticket: **[AAASM-1075](https://lightning-dust-mite.atlassian.net/browse/AAASM-1075)**
- Parent Story: [AAASM-118](https://lightning-dust-mite.atlassian.net/browse/AAASM-118)
- Backend dependencies (each links as "blocks AAASM-1075"):
  - [AAASM-1385](https://lightning-dust-mite.atlassian.net/browse/AAASM-1385) — `GET /api/v1/alerts/{id}`
  - [AAASM-1386](https://lightning-dust-mite.atlassian.net/browse/AAASM-1386) — `/api/v1/alerts/rules` CRUD
  - [AAASM-1387](https://lightning-dust-mite.atlassian.net/browse/AAASM-1387) — `POST /api/v1/alerts/silence`
  - [AAASM-1388](https://lightning-dust-mite.atlassian.net/browse/AAASM-1388) — `/api/v1/alerts/destinations` CRUD + test
  - [AAASM-1389](https://lightning-dust-mite.atlassian.net/browse/AAASM-1389) — `GET /api/v1/alerts/ws` (WebSocket — wired up in AAASM-1080)

## What is in this PR (9 atomic commits)

| Commit | Scope |
| --- | --- |
| 1 | `🔧 endpoints.ts` — single source of truth for URLs + cache-key roots |
| 2 | `✨ types.ts` — AlertRule, Destination (discriminated union), Silence + Input shapes |
| 3 | `✨ useAlertsQuery` + `alertsFetch` Bearer-token / baseUrl helper |
| 4 | `✨ useAlertQuery(id)` — single-alert detail |
| 5 | `✨ useAlertRulesQuery` + create / update / delete mutations |
| 6 | `✨ useSilenceAlertMutation` |
| 7 | `✨ useDestinations*` — list / create / update / delete / test |
| 8 | `♻️ AlertsPage` wired to `useAlertsQuery` + URL filter state via `useSearchParams` (replaces MOCK_ALERTS) |
| 9 | `✅ Vitest specs` — 14 hook specs + 4 URL round-trip specs |

## Testing

- [x] Unit tests added — 18 new specs (hooks + URL round-trip)
- [ ] Integration tests added / updated
- [x] Manual testing performed — vitest+RTL drives every hook and mutation
- [ ] No tests required

```bash
pnpm -C dashboard type-check   # tsc --noEmit — clean
pnpm -C dashboard lint         # eslint --max-warnings 0 — clean
pnpm -C dashboard test --run   # 593 / 593 pass (full suite)
```

## Self-verification

`pnpm dev` runtime smoke-test is skipped for the same reason as AAASM-1073 — the `/alerts` route is gated by `<ProtectedRoute>` and the speculative endpoints return 404 against the current gateway. The hook contracts are instead locked in via the 18 specs which mock `fetch` and assert URL / method / body / cache-invalidation per hook.

## Out of scope (deferred per the plan)

- `<AlertRuleForm>` modal → **AAASM-1077**
- `<AlertDetailDrawer>` + `useAlertsStream` (WebSocket) → **AAASM-1080**
- Empty / loading / error refinement + `<DestinationManager>` + Playwright E2E → **AAASM-1082**

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed (no public API change)
- [x] All local checks passing (type-check, lint, vitest)
- [x] Commits are small and follow the Gitmoji convention (9 atomic commits)

[AAASM-118]: https://lightning-dust-mite.atlassian.net/browse/AAASM-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1075]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ