### PR TITLE
[AAASM-1077] ✨ (dashboard/alerts): Add alert rule builder modal

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -21,17 +21,19 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.10.0",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.80.5",
     "@tanstack/react-table": "^8.21.3",
     "openapi-fetch": "^0.17.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.5",
+    "react-hook-form": "^7.75.0",
     "react-router-dom": "^7.15.0",
     "recharts": "^3.8.1",
     "use-debounce": "^10.1.1",
     "yaml": "^2.9.0",
-    "zod": "^4.4.3"
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@playwright/test": "^1.60.0",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^3.10.0
+        version: 3.10.0(react-hook-form@7.75.0(react@19.2.6))
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -26,6 +29,9 @@ importers:
       react-dom:
         specifier: ^19.2.5
         version: 19.2.6(react@19.2.6)
+      react-hook-form:
+        specifier: ^7.75.0
+        version: 7.75.0(react@19.2.6)
       react-router-dom:
         specifier: ^7.15.0
         version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -39,8 +45,8 @@ importers:
         specifier: ^2.9.0
         version: 2.9.0
       zod:
-        specifier: ^4.4.3
-        version: 4.4.3
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@playwright/test':
         specifier: ^1.60.0
@@ -437,6 +443,11 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@hookform/resolvers@3.10.0':
+    resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
+    peerDependencies:
+      react-hook-form: ^7.0.0
 
   '@humanwhocodes/config-array@0.13.0':
     resolution: {integrity: sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==}
@@ -1862,6 +1873,12 @@ packages:
     peerDependencies:
       react: ^19.2.6
 
+  react-hook-form@7.75.0:
+    resolution: {integrity: sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
@@ -2346,6 +2363,9 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -2627,6 +2647,10 @@ snapshots:
   '@eslint/js@8.57.1': {}
 
   '@exodus/bytes@1.15.0': {}
+
+  '@hookform/resolvers@3.10.0(react-hook-form@7.75.0(react@19.2.6))':
+    dependencies:
+      react-hook-form: 7.75.0(react@19.2.6)
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -4035,6 +4059,10 @@ snapshots:
       react: 19.2.6
       scheduler: 0.27.0
 
+  react-hook-form@7.75.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
   react-is@17.0.2: {}
 
   react-redux@9.2.0(@types/react@19.2.14)(react@19.2.6)(redux@5.0.1):
@@ -4428,5 +4456,7 @@ snapshots:
   zod-validation-error@4.0.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}

--- a/dashboard/src/features/alerts/AlertRuleForm.test.tsx
+++ b/dashboard/src/features/alerts/AlertRuleForm.test.tsx
@@ -1,0 +1,208 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AlertRuleForm } from './AlertRuleForm'
+import { ToastProvider } from '../../components/ToastProvider'
+import type { AlertRule, Destination } from './types'
+
+// ── fetch stub mirroring the AAASM-1075 test setup ─────────────────────────
+
+interface FetchCall {
+  url: string
+  init: RequestInit
+}
+
+let calls: FetchCall[]
+/** Map URL prefix → response body. Set per-test in `beforeEach`. */
+let responses: Record<string, unknown>
+
+beforeEach(() => {
+  calls = []
+  responses = {}
+  localStorage.setItem('aa_token', 'test-token')
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string, init: RequestInit = {}) => {
+      calls.push({ url, init })
+      for (const prefix of Object.keys(responses)) {
+        if (url.startsWith(prefix)) {
+          return {
+            ok: true,
+            status: init.method === 'POST' ? 201 : 200,
+            json: async () => responses[prefix],
+          } as Response
+        }
+      }
+      return {
+        ok: false,
+        status: 500,
+        json: async () => ({ error: 'no stub for ' + url }),
+      } as Response
+    }),
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+// ── fixtures ───────────────────────────────────────────────────────────────
+
+const SLACK: Destination = {
+  id: 'd-slack',
+  kind: 'slack',
+  name: 'ops',
+  enabled: true,
+  createdAt: '2026-05-13T00:00:00Z',
+  updatedAt: '2026-05-13T00:00:00Z',
+  config: { webhookUrl: 'https://hooks.slack.com/services/x' },
+}
+
+const FIXTURE_RULE: AlertRule = {
+  id: 'r-1',
+  name: 'Budget > 90%',
+  description: '',
+  metric: 'budget_spent_pct',
+  operator: '>',
+  threshold: 90,
+  evaluationWindowSeconds: 300,
+  severity: 'CRITICAL',
+  destinationIds: ['d-slack'],
+  dedupWindowSeconds: 600,
+  suppressionLabels: {},
+  enabled: true,
+  createdAt: '2026-05-13T00:00:00Z',
+  updatedAt: '2026-05-13T00:00:00Z',
+}
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return (
+    <QueryClientProvider client={client}>
+      <ToastProvider>{children}</ToastProvider>
+    </QueryClientProvider>
+  )
+}
+
+// ── specs ──────────────────────────────────────────────────────────────────
+
+describe('AlertRuleForm', () => {
+  it('does not render anything when closed', () => {
+    render(<AlertRuleForm open={false} onClose={vi.fn()} />, { wrapper: Wrapper })
+    expect(screen.queryByTestId('alert-rule-form')).not.toBeInTheDocument()
+  })
+
+  it('renders the create heading when no initialValue is supplied', async () => {
+    responses['/api/v1/alerts/destinations'] = [SLACK]
+    render(<AlertRuleForm open={true} onClose={vi.fn()} />, { wrapper: Wrapper })
+    expect(
+      screen.getByRole('heading', { name: 'New alert rule' }),
+    ).toBeInTheDocument()
+  })
+
+  it('blocks submit when the threshold is missing (zod required)', async () => {
+    responses['/api/v1/alerts/destinations'] = [SLACK]
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(<AlertRuleForm open={true} onClose={onClose} />, { wrapper: Wrapper })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('rule-destination-d-slack')).toBeInTheDocument(),
+    )
+    await user.click(screen.getByTestId('rule-destination-d-slack'))
+    await user.type(screen.getByTestId('rule-name'), 'Budget guardrail')
+    await user.clear(screen.getByTestId('rule-threshold'))
+    await user.click(screen.getByTestId('alert-rule-form-submit'))
+
+    await waitFor(() =>
+      expect(screen.getByText(/threshold must be (a number|a finite number)/i)).toBeInTheDocument(),
+    )
+    expect(onClose).not.toHaveBeenCalled()
+    expect(calls.some((c) => c.init.method === 'POST' && c.url.endsWith('/rules'))).toBe(false)
+  })
+
+  it('blocks submit when no destination is selected', async () => {
+    responses['/api/v1/alerts/destinations'] = [SLACK]
+    const user = userEvent.setup()
+    render(<AlertRuleForm open={true} onClose={vi.fn()} />, { wrapper: Wrapper })
+    await user.type(screen.getByTestId('rule-name'), 'Budget guardrail')
+    await user.click(screen.getByTestId('alert-rule-form-submit'))
+    await waitFor(() =>
+      expect(
+        screen.getByText(/at least one destination is required/i),
+      ).toBeInTheDocument(),
+    )
+  })
+
+  it('POSTs to /alerts/rules on a valid create submit and closes the modal', async () => {
+    responses['/api/v1/alerts/destinations'] = [SLACK]
+    responses['/api/v1/alerts/rules'] = FIXTURE_RULE
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    const onSaved = vi.fn()
+    render(
+      <AlertRuleForm open={true} onClose={onClose} onSaved={onSaved} />,
+      { wrapper: Wrapper },
+    )
+
+    await waitFor(() =>
+      expect(screen.getByTestId('rule-destination-d-slack')).toBeInTheDocument(),
+    )
+    await user.type(screen.getByTestId('rule-name'), 'Budget guardrail')
+    await user.click(screen.getByTestId('rule-destination-d-slack'))
+    await user.click(screen.getByTestId('alert-rule-form-submit'))
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+    expect(onSaved).toHaveBeenCalledWith(FIXTURE_RULE)
+    const post = calls.find((c) => c.init.method === 'POST' && c.url.endsWith('/rules'))
+    expect(post).toBeDefined()
+    const body = JSON.parse(post!.init.body as string)
+    expect(body.name).toBe('Budget guardrail')
+    expect(body.destinationIds).toEqual(['d-slack'])
+  })
+
+  it('PUTs to /alerts/rules/{id} when initialValue is supplied', async () => {
+    responses['/api/v1/alerts/destinations'] = [SLACK]
+    responses[`/api/v1/alerts/rules/${FIXTURE_RULE.id}`] = FIXTURE_RULE
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(
+      <AlertRuleForm open={true} onClose={onClose} initialValue={FIXTURE_RULE} />,
+      { wrapper: Wrapper },
+    )
+
+    expect(
+      screen.getByRole('heading', { name: 'Edit alert rule' }),
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByTestId('alert-rule-form-submit'))
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))
+    const put = calls.find((c) => c.init.method === 'PUT')
+    expect(put).toBeDefined()
+    expect(put!.url).toContain(`/rules/${FIXTURE_RULE.id}`)
+  })
+
+  it('shows an error toast and keeps the modal open when the API call fails', async () => {
+    responses['/api/v1/alerts/destinations'] = [SLACK]
+    // /rules deliberately unstubbed → falls through to 500
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    render(<AlertRuleForm open={true} onClose={onClose} />, { wrapper: Wrapper })
+
+    await waitFor(() =>
+      expect(screen.getByTestId('rule-destination-d-slack')).toBeInTheDocument(),
+    )
+    await user.type(screen.getByTestId('rule-name'), 'Budget guardrail')
+    await user.click(screen.getByTestId('rule-destination-d-slack'))
+    await user.click(screen.getByTestId('alert-rule-form-submit'))
+
+    // Error toast is rendered by the global ToastProvider — the wrapper is
+    // mounted above the form, so the toast region appears in the DOM tree.
+    await waitFor(() =>
+      expect(within(document.body).getByText(/POST .* failed: 500/i)).toBeInTheDocument(),
+    )
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})

--- a/dashboard/src/features/alerts/AlertRuleForm.tsx
+++ b/dashboard/src/features/alerts/AlertRuleForm.tsx
@@ -7,6 +7,7 @@ import { DestinationsPicker } from './DestinationsPicker'
 import { DedupAndSuppressionFields } from './DedupAndSuppressionFields'
 import { useCreateAlertRuleMutation, useUpdateAlertRuleMutation } from './api'
 import { ruleFormSchema, type RuleFormValues } from './ruleFormSchema'
+import { useToast } from '../../components/Toast'
 import type { AlertRule, AlertRuleInput } from './types'
 
 interface AlertRuleFormProps {
@@ -89,16 +90,23 @@ export function AlertRuleForm({
 
   const create = useCreateAlertRuleMutation()
   const update = useUpdateAlertRuleMutation()
+  const { toast } = useToast()
 
   const submitting = create.isPending || update.isPending
 
   const handleSubmit = methods.handleSubmit(async (values) => {
     const input = toRuleInput(values)
-    const saved = initialValue
-      ? await update.mutateAsync({ id: initialValue.id, input })
-      : await create.mutateAsync(input)
-    onSaved?.(saved)
-    onClose()
+    try {
+      const saved = initialValue
+        ? await update.mutateAsync({ id: initialValue.id, input })
+        : await create.mutateAsync(input)
+      toast(initialValue ? `Updated rule "${saved.name}"` : `Created rule "${saved.name}"`, 'success')
+      onSaved?.(saved)
+      onClose()
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to save rule'
+      toast(message, 'error')
+    }
   })
 
   if (!open) return null

--- a/dashboard/src/features/alerts/AlertRuleForm.tsx
+++ b/dashboard/src/features/alerts/AlertRuleForm.tsx
@@ -1,0 +1,252 @@
+import { useEffect } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { ConditionBuilder } from './ConditionBuilder'
+import { SeveritySelect } from './SeveritySelect'
+import { DestinationsPicker } from './DestinationsPicker'
+import { DedupAndSuppressionFields } from './DedupAndSuppressionFields'
+import { useCreateAlertRuleMutation, useUpdateAlertRuleMutation } from './api'
+import { ruleFormSchema, type RuleFormValues } from './ruleFormSchema'
+import type { AlertRule, AlertRuleInput } from './types'
+
+interface AlertRuleFormProps {
+  open: boolean
+  onClose: () => void
+  /** When present, the form is in edit mode; otherwise it creates a new rule. */
+  initialValue?: AlertRule
+  /** Optional callback fired after a successful save (mutation resolves). */
+  onSaved?: (rule: AlertRule) => void
+}
+
+function defaultValues(initial: AlertRule | undefined): RuleFormValues {
+  if (initial) {
+    return {
+      name: initial.name,
+      description: initial.description,
+      metric: initial.metric,
+      operator: initial.operator,
+      threshold: initial.threshold,
+      evaluationWindowSeconds: initial.evaluationWindowSeconds,
+      severity: initial.severity,
+      destinationIds: [...initial.destinationIds],
+      dedupWindowSeconds: initial.dedupWindowSeconds,
+      suppressionLabels: Object.entries(initial.suppressionLabels).map(([key, value]) => ({
+        key,
+        value,
+      })),
+      enabled: initial.enabled,
+    }
+  }
+  return {
+    name: '',
+    description: '',
+    metric: 'budget_spent_pct',
+    operator: '>',
+    threshold: 90,
+    evaluationWindowSeconds: 300,
+    severity: 'CRITICAL',
+    destinationIds: [],
+    dedupWindowSeconds: 600,
+    suppressionLabels: [],
+    enabled: true,
+  }
+}
+
+function toRuleInput(values: RuleFormValues): AlertRuleInput {
+  return {
+    name: values.name.trim(),
+    description: values.description.trim(),
+    metric: values.metric,
+    operator: values.operator,
+    threshold: values.threshold,
+    evaluationWindowSeconds: values.evaluationWindowSeconds,
+    severity: values.severity,
+    destinationIds: values.destinationIds,
+    dedupWindowSeconds: values.dedupWindowSeconds,
+    suppressionLabels: Object.fromEntries(
+      values.suppressionLabels.map((l) => [l.key, l.value]),
+    ),
+    enabled: values.enabled,
+  }
+}
+
+export function AlertRuleForm({
+  open,
+  onClose,
+  initialValue,
+  onSaved,
+}: AlertRuleFormProps) {
+  const methods = useForm<RuleFormValues>({
+    resolver: zodResolver(ruleFormSchema),
+    defaultValues: defaultValues(initialValue),
+    mode: 'onSubmit',
+  })
+
+  // Reset when opening for a different rule.
+  useEffect(() => {
+    if (open) methods.reset(defaultValues(initialValue))
+  }, [open, initialValue, methods])
+
+  const create = useCreateAlertRuleMutation()
+  const update = useUpdateAlertRuleMutation()
+
+  const submitting = create.isPending || update.isPending
+
+  const handleSubmit = methods.handleSubmit(async (values) => {
+    const input = toRuleInput(values)
+    const saved = initialValue
+      ? await update.mutateAsync({ id: initialValue.id, input })
+      : await create.mutateAsync(input)
+    onSaved?.(saved)
+    onClose()
+  })
+
+  if (!open) return null
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="alert-rule-form-title"
+      data-testid="alert-rule-form"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0, 0, 0, 0.4)',
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
+        padding: '2rem',
+        zIndex: 1000,
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div
+        style={{
+          width: 'min(720px, 100%)',
+          background: '#fff',
+          borderRadius: '8px',
+          boxShadow: '0 10px 25px rgba(0, 0, 0, 0.2)',
+          padding: '1.25rem',
+          maxHeight: '90vh',
+          overflow: 'auto',
+        }}
+      >
+        <header
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            marginBottom: '1rem',
+          }}
+        >
+          <h2 id="alert-rule-form-title" style={{ fontSize: '1.125rem', margin: 0 }}>
+            {initialValue ? 'Edit alert rule' : 'New alert rule'}
+          </h2>
+          <button
+            type="button"
+            data-testid="alert-rule-form-close"
+            aria-label="Close"
+            onClick={onClose}
+            style={{
+              border: 'none',
+              background: 'transparent',
+              fontSize: '1.25rem',
+              cursor: 'pointer',
+              color: '#6b7280',
+            }}
+          >
+            ✕
+          </button>
+        </header>
+
+        <FormProvider {...methods}>
+          <form
+            onSubmit={handleSubmit}
+            style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem' }}
+          >
+            <label
+              style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.875rem' }}
+            >
+              <span>Name</span>
+              <input
+                id="rule-name"
+                data-testid="rule-name"
+                {...methods.register('name')}
+              />
+              {methods.formState.errors.name && (
+                <span style={{ color: '#dc2626', fontSize: '0.75rem' }}>
+                  {methods.formState.errors.name.message}
+                </span>
+              )}
+            </label>
+
+            <label
+              style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.875rem' }}
+            >
+              <span>Description (optional)</span>
+              <textarea
+                id="rule-description"
+                data-testid="rule-description"
+                rows={2}
+                {...methods.register('description')}
+              />
+            </label>
+
+            <ConditionBuilder />
+            <SeveritySelect />
+            <DestinationsPicker />
+            <DedupAndSuppressionFields />
+
+            <label
+              style={{ display: 'inline-flex', gap: '0.5rem', alignItems: 'center', fontSize: '0.875rem' }}
+            >
+              <input
+                type="checkbox"
+                data-testid="rule-enabled"
+                {...methods.register('enabled')}
+              />
+              Enabled
+            </label>
+
+            <footer
+              style={{
+                display: 'flex',
+                gap: '0.5rem',
+                justifyContent: 'flex-end',
+                marginTop: '0.5rem',
+              }}
+            >
+              <button
+                type="button"
+                data-testid="alert-rule-form-cancel"
+                onClick={onClose}
+                disabled={submitting}
+                style={{ padding: '6px 14px' }}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                data-testid="alert-rule-form-submit"
+                disabled={submitting}
+                style={{
+                  padding: '6px 14px',
+                  background: '#1f2937',
+                  color: '#fff',
+                  border: 'none',
+                  borderRadius: '4px',
+                  cursor: submitting ? 'wait' : 'pointer',
+                }}
+              >
+                {submitting ? 'Saving…' : initialValue ? 'Save changes' : 'Create rule'}
+              </button>
+            </footer>
+          </form>
+        </FormProvider>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/features/alerts/ConditionBuilder.tsx
+++ b/dashboard/src/features/alerts/ConditionBuilder.tsx
@@ -1,0 +1,115 @@
+import { useFormContext } from 'react-hook-form'
+import type { RuleFormValues } from './ruleFormSchema'
+
+const METRIC_OPTIONS: ReadonlyArray<{ value: RuleFormValues['metric']; label: string }> = [
+  { value: 'budget_spent_pct', label: 'Budget spent (%)' },
+  { value: 'anomaly_score', label: 'Anomaly score' },
+  { value: 'approval_pending_age', label: 'Approval pending age (seconds)' },
+  { value: 'policy_violation_count', label: 'Policy violations' },
+]
+
+const OPERATOR_OPTIONS: RuleFormValues['operator'][] = ['>', '>=', '<', '=']
+
+const WINDOW_OPTIONS: ReadonlyArray<{
+  value: RuleFormValues['evaluationWindowSeconds']
+  label: string
+}> = [
+  { value: 300, label: '5m' },
+  { value: 900, label: '15m' },
+  { value: 3600, label: '1h' },
+]
+
+const fieldStyle = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: '0.25rem',
+  fontSize: '0.875rem',
+}
+
+const errorStyle = { color: '#dc2626', fontSize: '0.75rem' }
+
+export function ConditionBuilder() {
+  const { register, formState, watch } = useFormContext<RuleFormValues>()
+  const errors = formState.errors
+  const metric = watch('metric')
+  const isPercentage = metric === 'budget_spent_pct' || metric === 'anomaly_score'
+
+  return (
+    <fieldset
+      data-testid="rule-condition-builder"
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(4, 1fr)',
+        gap: '0.75rem',
+        border: '1px solid #e5e7eb',
+        borderRadius: '6px',
+        padding: '0.75rem',
+      }}
+    >
+      <legend style={{ padding: '0 0.5rem', color: '#6b7280', fontSize: '0.75rem' }}>
+        Condition
+      </legend>
+
+      <label style={fieldStyle}>
+        <span>Metric</span>
+        <select id="rule-metric" data-testid="rule-metric" {...register('metric')}>
+          {METRIC_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+        {errors.metric && <span style={errorStyle}>{errors.metric.message}</span>}
+      </label>
+
+      <label style={fieldStyle}>
+        <span>Operator</span>
+        <select id="rule-operator" data-testid="rule-operator" {...register('operator')}>
+          {OPERATOR_OPTIONS.map((op) => (
+            <option key={op} value={op}>
+              {op}
+            </option>
+          ))}
+        </select>
+        {errors.operator && <span style={errorStyle}>{errors.operator.message}</span>}
+      </label>
+
+      <label style={fieldStyle}>
+        <span>
+          Threshold
+          {isPercentage && (
+            <span style={{ color: '#6b7280', marginLeft: '0.25rem' }}>(0–100)</span>
+          )}
+        </span>
+        <input
+          id="rule-threshold"
+          data-testid="rule-threshold"
+          type="number"
+          step="any"
+          min={0}
+          max={isPercentage ? 100 : undefined}
+          {...register('threshold', { valueAsNumber: true })}
+        />
+        {errors.threshold && <span style={errorStyle}>{errors.threshold.message}</span>}
+      </label>
+
+      <label style={fieldStyle}>
+        <span>Window</span>
+        <select
+          id="rule-window"
+          data-testid="rule-window"
+          {...register('evaluationWindowSeconds', { valueAsNumber: true })}
+        >
+          {WINDOW_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+        {errors.evaluationWindowSeconds && (
+          <span style={errorStyle}>{errors.evaluationWindowSeconds.message}</span>
+        )}
+      </label>
+    </fieldset>
+  )
+}

--- a/dashboard/src/features/alerts/DedupAndSuppressionFields.tsx
+++ b/dashboard/src/features/alerts/DedupAndSuppressionFields.tsx
@@ -1,0 +1,128 @@
+import { useFieldArray, useFormContext } from 'react-hook-form'
+import type { RuleFormValues } from './ruleFormSchema'
+
+const errorStyle = { color: '#dc2626', fontSize: '0.75rem' }
+
+export function DedupAndSuppressionFields() {
+  const { register, control, formState } = useFormContext<RuleFormValues>()
+  const errors = formState.errors
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: 'suppressionLabels',
+  })
+
+  return (
+    <fieldset
+      data-testid="rule-dedup-suppression"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.75rem',
+        border: '1px solid #e5e7eb',
+        borderRadius: '6px',
+        padding: '0.75rem',
+      }}
+    >
+      <legend style={{ padding: '0 0.5rem', color: '#6b7280', fontSize: '0.75rem' }}>
+        Deduplication &amp; suppression
+      </legend>
+
+      <label
+        style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.875rem' }}
+      >
+        <span>Dedup window (seconds)</span>
+        <input
+          id="rule-dedup"
+          data-testid="rule-dedup-window"
+          type="number"
+          step="1"
+          min={0}
+          {...register('dedupWindowSeconds', { valueAsNumber: true })}
+        />
+        {errors.dedupWindowSeconds && (
+          <span style={errorStyle}>{errors.dedupWindowSeconds.message}</span>
+        )}
+      </label>
+
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '0.35rem' }}>
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            fontSize: '0.875rem',
+          }}
+        >
+          <span>Suppression labels (key = value)</span>
+          <button
+            type="button"
+            data-testid="rule-suppression-add"
+            onClick={() => append({ key: '', value: '' })}
+            style={{
+              padding: '2px 8px',
+              border: '1px solid #d1d5db',
+              borderRadius: '4px',
+              background: '#fff',
+              cursor: 'pointer',
+              fontSize: '0.75rem',
+            }}
+          >
+            + Add
+          </button>
+        </div>
+
+        {fields.length === 0 && (
+          <span style={{ fontSize: '0.75rem', color: '#6b7280' }}>
+            No suppression labels — the rule will fire regardless of labels.
+          </span>
+        )}
+
+        {fields.map((field, idx) => (
+          <div
+            key={field.id}
+            data-testid={`rule-suppression-row-${idx}`}
+            style={{ display: 'flex', gap: '0.35rem', alignItems: 'flex-start' }}
+          >
+            <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+              <input
+                placeholder="env"
+                data-testid={`rule-suppression-key-${idx}`}
+                {...register(`suppressionLabels.${idx}.key` as const)}
+              />
+              {errors.suppressionLabels?.[idx]?.key && (
+                <span style={errorStyle}>{errors.suppressionLabels[idx]?.key?.message}</span>
+              )}
+            </div>
+            <span style={{ alignSelf: 'center', color: '#6b7280' }}>=</span>
+            <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
+              <input
+                placeholder="prod"
+                data-testid={`rule-suppression-value-${idx}`}
+                {...register(`suppressionLabels.${idx}.value` as const)}
+              />
+              {errors.suppressionLabels?.[idx]?.value && (
+                <span style={errorStyle}>{errors.suppressionLabels[idx]?.value?.message}</span>
+              )}
+            </div>
+            <button
+              type="button"
+              data-testid={`rule-suppression-remove-${idx}`}
+              onClick={() => remove(idx)}
+              aria-label="Remove suppression label"
+              style={{
+                padding: '0 8px',
+                border: '1px solid #d1d5db',
+                borderRadius: '4px',
+                background: '#fff',
+                cursor: 'pointer',
+                fontSize: '0.875rem',
+              }}
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+      </div>
+    </fieldset>
+  )
+}

--- a/dashboard/src/features/alerts/DestinationsPicker.tsx
+++ b/dashboard/src/features/alerts/DestinationsPicker.tsx
@@ -1,0 +1,95 @@
+import { Controller, useFormContext } from 'react-hook-form'
+import { useDestinationsQuery } from './api'
+import type { RuleFormValues } from './ruleFormSchema'
+
+export function DestinationsPicker() {
+  const { control, formState } = useFormContext<RuleFormValues>()
+  const { data, isLoading, isError } = useDestinationsQuery()
+  const destinations = data ?? []
+  const error = formState.errors.destinationIds
+
+  return (
+    <fieldset
+      data-testid="rule-destinations"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.5rem',
+        border: '1px solid #e5e7eb',
+        borderRadius: '6px',
+        padding: '0.75rem',
+      }}
+    >
+      <legend style={{ padding: '0 0.5rem', color: '#6b7280', fontSize: '0.75rem' }}>
+        Routing destinations
+      </legend>
+
+      {isLoading && <span style={{ fontSize: '0.75rem', color: '#6b7280' }}>Loading…</span>}
+      {isError && (
+        <span data-testid="rule-destinations-error" style={{ fontSize: '0.75rem', color: '#dc2626' }}>
+          Failed to load destinations
+        </span>
+      )}
+      {!isLoading && !isError && destinations.length === 0 && (
+        <span
+          data-testid="rule-destinations-empty"
+          style={{ fontSize: '0.75rem', color: '#6b7280' }}
+        >
+          No destinations configured yet — add one in the Destination Registry.
+        </span>
+      )}
+
+      <Controller
+        control={control}
+        name="destinationIds"
+        render={({ field }) => {
+          const selected = new Set(field.value ?? [])
+          const toggle = (id: string) => {
+            const next = new Set(selected)
+            if (next.has(id)) next.delete(id)
+            else next.add(id)
+            field.onChange(Array.from(next))
+          }
+          return (
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem' }}>
+              {destinations.map((d) => {
+                const active = selected.has(d.id)
+                return (
+                  <label
+                    key={d.id}
+                    data-testid={`rule-destination-${d.id}`}
+                    style={{
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      gap: '0.35rem',
+                      padding: '4px 10px',
+                      borderRadius: '6px',
+                      border: '1px solid #d1d5db',
+                      background: active ? '#1f2937' : '#fff',
+                      color: active ? '#fff' : '#1f2937',
+                      cursor: 'pointer',
+                      fontSize: '0.75rem',
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={active}
+                      onChange={() => toggle(d.id)}
+                      style={{ display: 'none' }}
+                    />
+                    <span style={{ fontWeight: 600, textTransform: 'uppercase' }}>{d.kind}</span>
+                    <span>{d.name}</span>
+                  </label>
+                )
+              })}
+            </div>
+          )
+        }}
+      />
+
+      {error && (
+        <span style={{ color: '#dc2626', fontSize: '0.75rem' }}>{error.message}</span>
+      )}
+    </fieldset>
+  )
+}

--- a/dashboard/src/features/alerts/SeveritySelect.tsx
+++ b/dashboard/src/features/alerts/SeveritySelect.tsx
@@ -1,0 +1,48 @@
+import { useFormContext } from 'react-hook-form'
+import { SeverityBadge } from './SeverityBadge'
+import type { Severity } from './types'
+import type { RuleFormValues } from './ruleFormSchema'
+
+const OPTIONS: readonly Severity[] = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW']
+
+export function SeveritySelect() {
+  const { register, formState } = useFormContext<RuleFormValues>()
+  const error = formState.errors.severity
+
+  return (
+    <fieldset
+      data-testid="rule-severity"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.5rem',
+        border: '1px solid #e5e7eb',
+        borderRadius: '6px',
+        padding: '0.75rem',
+      }}
+    >
+      <legend style={{ padding: '0 0.5rem', color: '#6b7280', fontSize: '0.75rem' }}>
+        Severity
+      </legend>
+      <div style={{ display: 'flex', gap: '0.75rem' }}>
+        {OPTIONS.map((sev) => (
+          <label
+            key={sev}
+            style={{ display: 'inline-flex', alignItems: 'center', gap: '0.35rem', cursor: 'pointer' }}
+          >
+            <input
+              type="radio"
+              value={sev}
+              data-testid={`rule-severity-${sev}`}
+              {...register('severity')}
+            />
+            <SeverityBadge severity={sev} />
+          </label>
+        ))}
+      </div>
+      {error && (
+        <span style={{ color: '#dc2626', fontSize: '0.75rem' }}>{error.message}</span>
+      )}
+    </fieldset>
+  )
+}

--- a/dashboard/src/features/alerts/ruleFormSchema.ts
+++ b/dashboard/src/features/alerts/ruleFormSchema.ts
@@ -1,0 +1,76 @@
+import { z } from 'zod'
+
+// Allowed enums — must stay in sync with `types.ts`. zod's enum-from-tuple
+// pattern keeps the runtime validation aligned with the static types via
+// the `satisfies` checks below.
+
+const METRICS = ['budget_spent_pct', 'anomaly_score', 'approval_pending_age', 'policy_violation_count'] as const
+const OPERATORS = ['>', '>=', '<', '='] as const
+const SEVERITIES = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW'] as const
+const EVAL_WINDOWS = [300, 900, 3600] as const
+
+const SUPPRESSION_KEY = /^[A-Za-z_][A-Za-z0-9_.-]*$/
+
+/**
+ * zod schema for the rule builder form. Threshold range is metric-aware:
+ * percentage metrics (`budget_spent_pct`, `anomaly_score`) are clamped to
+ * 0-100; the others accept any positive integer.
+ */
+export const ruleFormSchema = z
+  .object({
+    name: z.string().trim().min(1, 'name is required').max(128, 'name must be ≤ 128 chars'),
+    description: z.string().trim().max(500, 'description must be ≤ 500 chars').default(''),
+    metric: z.enum(METRICS, { errorMap: () => ({ message: 'select a metric' }) }),
+    operator: z.enum(OPERATORS, { errorMap: () => ({ message: 'select an operator' }) }),
+    threshold: z
+      .number({ invalid_type_error: 'threshold must be a number' })
+      .finite('threshold must be a finite number'),
+    evaluationWindowSeconds: z.union([z.literal(300), z.literal(900), z.literal(3600)]),
+    severity: z.enum(SEVERITIES),
+    destinationIds: z
+      .array(z.string().min(1))
+      .min(1, 'at least one destination is required'),
+    dedupWindowSeconds: z
+      .number({ invalid_type_error: 'dedup window must be a number' })
+      .int('dedup window must be a whole minute')
+      .min(0, 'dedup window cannot be negative'),
+    suppressionLabels: z
+      .array(
+        z.object({
+          key: z.string().regex(SUPPRESSION_KEY, 'key must match [A-Za-z_][A-Za-z0-9_.-]*'),
+          value: z.string().min(1, 'value cannot be empty'),
+        }),
+      )
+      .default([]),
+    enabled: z.boolean().default(true),
+  })
+  .superRefine((data, ctx) => {
+    const isPercentage =
+      data.metric === 'budget_spent_pct' || data.metric === 'anomaly_score'
+    const max = isPercentage ? 100 : Number.MAX_SAFE_INTEGER
+    if (data.threshold < 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['threshold'],
+        message: 'threshold must be ≥ 0',
+      })
+    }
+    if (data.threshold > max) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['threshold'],
+        message: `threshold must be ≤ ${max} for metric ${data.metric}`,
+      })
+    }
+  })
+
+export type RuleFormValues = z.infer<typeof ruleFormSchema>
+
+// Compile-time sanity: the literal arrays the schema relies on must match
+// the unions exported from `types.ts`.
+import type { AlertMetric, AlertOperator, Severity, EvaluationWindowSeconds } from './types'
+const _metricCheck: readonly AlertMetric[] = METRICS satisfies readonly AlertMetric[]
+const _operatorCheck: readonly AlertOperator[] = OPERATORS satisfies readonly AlertOperator[]
+const _severityCheck: readonly Severity[] = SEVERITIES satisfies readonly Severity[]
+const _windowCheck: readonly EvaluationWindowSeconds[] = EVAL_WINDOWS satisfies readonly EvaluationWindowSeconds[]
+void [_metricCheck, _operatorCheck, _severityCheck, _windowCheck]


### PR DESCRIPTION
## Description

Adds the `<AlertRuleForm>` modal that lets operators create and edit alert rules through a structured form — metric / operator / threshold condition, severity, evaluation window, routing destinations, dedup window, and free-form key=value suppression labels. Parent Story [AAASM-118](https://lightning-dust-mite.atlassian.net/browse/AAASM-118).

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade (one commit only — `react-hook-form`, `zod`, `@hookform/resolvers`)
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

## Related Issues

- Related Jira ticket: **[AAASM-1077](https://lightning-dust-mite.atlassian.net/browse/AAASM-1077)**
- Parent Story: [AAASM-118](https://lightning-dust-mite.atlassian.net/browse/AAASM-118)
- Backend dependency: [AAASM-1386](https://lightning-dust-mite.atlassian.net/browse/AAASM-1386) (alert-rules CRUD)

## What is in this PR (9 atomic commits)

| # | Commit | Scope |
| --- | --- | --- |
| 1 | `⬆️ Add react-hook-form + zod + @hookform/resolvers deps` | only manifest + lockfile change |
| 2 | `✨ ruleFormSchema` | zod validation, metric-aware threshold range, satisfies-checks tying enums to `types.ts` |
| 3 | `✨ <ConditionBuilder>` | metric / operator / threshold / window 4-column grid |
| 4 | `✨ <SeveritySelect>` | 4-tier radio with `<SeverityBadge>` preview |
| 5 | `✨ <DestinationsPicker>` | multi-select pulling `useDestinationsQuery`, min-1 enforced |
| 6 | `✨ <DedupAndSuppressionFields>` | dedup seconds + `useFieldArray` key=value list |
| 7 | `✨ <AlertRuleForm>` modal | composes every field group; dispatches create or update mutation based on `initialValue` |
| 8 | `✨ Toast on save success / error` | reuses `useToast`; modal stays open on error so the user can retry |
| 9 | `✅ Vitest specs` | 7 new specs covering invalid threshold, missing destination, valid create POST, edit PUT, and API-failure flow |

## Testing

- [x] Unit tests added — **7 new specs** in `AlertRuleForm.test.tsx`
- [ ] Integration tests added / updated
- [x] Manual testing performed — RTL drives the full submit lifecycle through `vi.stubGlobal('fetch')`
- [ ] No tests required

```bash
pnpm -C dashboard type-check   # tsc --noEmit — clean
pnpm -C dashboard lint         # eslint --max-warnings 0 — clean
pnpm -C dashboard test --run   # 624 / 624 pass (full suite)
```

## Self-verification

`pnpm dev` runtime smoke-test still gated by `<ProtectedRoute>` + the speculative `POST /api/v1/alerts/rules` endpoint (AAASM-1386 not yet shipped). Form behavior is locked in via the 7 specs: invalid-input blocking, mutation dispatch, toast on success / error, modal close on success / stay open on error.

## Out of scope (deferred per the plan)

- `<AlertDetailDrawer>` + WebSocket cache sync + Active / Incidents tabs → **AAASM-1080**
- Empty / loading / error refinement + `<DestinationManager>` + Playwright E2E → **AAASM-1082**
- Mounting the form into AlertsPage with a "New rule" button → can land in AAASM-1080 alongside the drawer wiring, or a small follow-up

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed (no public API change)
- [x] All local checks passing (type-check, lint, vitest)
- [x] Commits are small and follow the Gitmoji convention (9 atomic commits)

[AAASM-118]: https://lightning-dust-mite.atlassian.net/browse/AAASM-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1077]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-118]: https://lightning-dust-mite.atlassian.net/browse/AAASM-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1386]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ