### PR TITLE
[AAASM-1080] ✨ (dashboard/alerts): Add incidents tab, detail drawer, and WS stream

### DIFF
--- a/dashboard/src/features/alerts/AlertDetailContent.tsx
+++ b/dashboard/src/features/alerts/AlertDetailContent.tsx
@@ -115,6 +115,31 @@ export function AlertDetailContent({ alertId }: AlertDetailContentProps) {
       </section>
 
       <section style={sectionStyle}>
+        <span style={sectionHeader}>Dedup status</span>
+        <p
+          data-testid="alert-detail-dedup-status"
+          style={{ margin: 0, fontSize: '0.75rem' }}
+        >
+          {data.dedupOccurrenceCount > 1
+            ? `${data.dedupOccurrenceCount} occurrences within current window`
+            : 'No deduplication active (first occurrence)'}
+          {data.dedupWindowExpiresAt && ` · window expires ${data.dedupWindowExpiresAt}`}
+        </p>
+      </section>
+
+      <section style={sectionStyle}>
+        <span style={sectionHeader}>Suppression status</span>
+        <p
+          data-testid="alert-detail-suppression-status"
+          style={{ margin: 0, fontSize: '0.75rem' }}
+        >
+          {data.silence
+            ? `Silenced by ${data.silence.silenceId} until ${data.silence.expiresAt}`
+            : 'Not silenced'}
+        </p>
+      </section>
+
+      <section style={sectionStyle}>
         <span style={sectionHeader}>Event payload</span>
         <pre
           data-testid="alert-detail-event-payload"

--- a/dashboard/src/features/alerts/AlertDetailContent.tsx
+++ b/dashboard/src/features/alerts/AlertDetailContent.tsx
@@ -1,0 +1,157 @@
+import { useAlertQuery } from './api'
+import { SeverityBadge } from './SeverityBadge'
+import { StatusBadge } from './StatusBadge'
+import type { AlertDetail } from './types'
+
+function ruleYaml(detail: AlertDetail): string {
+  const r = detail.ruleSnapshot
+  const labels = Object.entries(r.suppressionLabels)
+  return [
+    `name: ${JSON.stringify(r.name)}`,
+    `metric: ${r.metric}`,
+    `operator: ${JSON.stringify(r.operator)}`,
+    `threshold: ${r.threshold}`,
+    `evaluation_window_seconds: ${r.evaluationWindowSeconds}`,
+    `severity: ${r.severity}`,
+    `dedup_window_seconds: ${r.dedupWindowSeconds}`,
+    `destinations: [${r.destinationIds.map((d) => JSON.stringify(d)).join(', ')}]`,
+    labels.length
+      ? `suppression_labels:\n${labels.map(([k, v]) => `  ${k}: ${JSON.stringify(v)}`).join('\n')}`
+      : 'suppression_labels: {}',
+  ].join('\n')
+}
+
+const sectionStyle = {
+  display: 'flex',
+  flexDirection: 'column' as const,
+  gap: '0.25rem',
+}
+
+const sectionHeader = {
+  fontSize: '0.75rem',
+  textTransform: 'uppercase' as const,
+  letterSpacing: '0.04em',
+  color: '#6b7280',
+}
+
+interface AlertDetailContentProps {
+  alertId: string
+}
+
+export function AlertDetailContent({ alertId }: AlertDetailContentProps) {
+  const { data, isLoading, isError, error } = useAlertQuery(alertId)
+
+  if (isLoading) {
+    return (
+      <p data-testid="alert-detail-loading" style={{ fontSize: '0.875rem', color: '#6b7280' }}>
+        Loading alert…
+      </p>
+    )
+  }
+
+  if (isError || !data) {
+    return (
+      <p data-testid="alert-detail-error" style={{ color: '#dc2626', fontSize: '0.875rem' }}>
+        Failed to load alert: {error?.message ?? 'unknown error'}
+      </p>
+    )
+  }
+
+  return (
+    <div data-testid="alert-detail-content" style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+      <header style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <SeverityBadge severity={data.severity} />
+          <StatusBadge status={data.status} />
+        </div>
+        <h3 style={{ margin: 0, fontSize: '1rem' }}>{data.ruleName}</h3>
+        <p style={{ margin: 0, color: '#6b7280', fontSize: '0.75rem' }}>
+          Fired {data.firstFiredAt}
+          {data.resolvedAt && ` · Resolved ${data.resolvedAt}`}
+          {data.agentId && ` · Agent ${data.agentId}`}
+        </p>
+      </header>
+
+      <section style={sectionStyle}>
+        <span style={sectionHeader}>Rule YAML</span>
+        <pre
+          data-testid="alert-detail-rule-yaml"
+          style={{
+            background: '#f3f4f6',
+            padding: '0.75rem',
+            borderRadius: '4px',
+            fontSize: '0.75rem',
+            margin: 0,
+            overflowX: 'auto',
+            whiteSpace: 'pre',
+          }}
+        >
+          {ruleYaml(data)}
+        </pre>
+      </section>
+
+      <section style={sectionStyle}>
+        <span style={sectionHeader}>Firing timeline</span>
+        <ul
+          data-testid="alert-detail-timeline"
+          style={{ listStyle: 'none', padding: 0, margin: 0, fontSize: '0.75rem' }}
+        >
+          <li>
+            <strong>{data.firstFiredAt}</strong> — first fired
+          </li>
+          {data.silence && (
+            <li>
+              <strong>{data.silence.startsAt}</strong> — silenced until {data.silence.expiresAt}
+              {data.silence.reason && ` (${data.silence.reason})`}
+            </li>
+          )}
+          {data.resolvedAt && (
+            <li>
+              <strong>{data.resolvedAt}</strong> — resolved
+            </li>
+          )}
+        </ul>
+      </section>
+
+      <section style={sectionStyle}>
+        <span style={sectionHeader}>Event payload</span>
+        <pre
+          data-testid="alert-detail-event-payload"
+          style={{
+            background: '#f3f4f6',
+            padding: '0.75rem',
+            borderRadius: '4px',
+            fontSize: '0.75rem',
+            margin: 0,
+            overflowX: 'auto',
+            whiteSpace: 'pre',
+          }}
+        >
+          {JSON.stringify(data.eventPayload, null, 2)}
+        </pre>
+      </section>
+
+      <section style={sectionStyle}>
+        <span style={sectionHeader}>Routing log</span>
+        {data.routingLog.length === 0 ? (
+          <span style={{ fontSize: '0.75rem', color: '#6b7280' }}>No deliveries recorded.</span>
+        ) : (
+          <ul
+            data-testid="alert-detail-routing-log"
+            style={{ listStyle: 'none', padding: 0, margin: 0, fontSize: '0.75rem' }}
+          >
+            {data.routingLog.map((entry, i) => (
+              <li key={i}>
+                <strong>{entry.deliveredAt}</strong> → {entry.destinationId} ·{' '}
+                <span style={{ color: entry.status === 'ok' ? '#166534' : '#991b1b' }}>
+                  {entry.status}
+                </span>
+                {entry.errorMessage && ` (${entry.errorMessage})`}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/dashboard/src/features/alerts/AlertDetailContent.tsx
+++ b/dashboard/src/features/alerts/AlertDetailContent.tsx
@@ -1,6 +1,7 @@
 import { useAlertQuery } from './api'
 import { SeverityBadge } from './SeverityBadge'
 import { StatusBadge } from './StatusBadge'
+import { SilenceAction } from './SilenceAction'
 import type { AlertDetail } from './types'
 
 function ruleYaml(detail: AlertDetail): string {
@@ -130,6 +131,10 @@ export function AlertDetailContent({ alertId }: AlertDetailContentProps) {
           {JSON.stringify(data.eventPayload, null, 2)}
         </pre>
       </section>
+
+      {data.status !== 'RESOLVED' && (
+        <SilenceAction alertId={data.id} silenced={data.status === 'SUPPRESSED'} />
+      )}
 
       <section style={sectionStyle}>
         <span style={sectionHeader}>Routing log</span>

--- a/dashboard/src/features/alerts/AlertDetailDrawer.tsx
+++ b/dashboard/src/features/alerts/AlertDetailDrawer.tsx
@@ -1,0 +1,82 @@
+import { useEffect } from 'react'
+
+interface AlertDetailDrawerProps {
+  open: boolean
+  onClose: () => void
+  children?: React.ReactNode
+}
+
+export function AlertDetailDrawer({ open, onClose, children }: AlertDetailDrawerProps) {
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Alert detail"
+      data-testid="alert-detail-drawer"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: 'rgba(0, 0, 0, 0.35)',
+        display: 'flex',
+        justifyContent: 'flex-end',
+        zIndex: 900,
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <aside
+        style={{
+          width: 'min(520px, 95vw)',
+          height: '100%',
+          background: '#fff',
+          boxShadow: '-10px 0 25px rgba(0, 0, 0, 0.15)',
+          padding: '1.25rem',
+          overflowY: 'auto',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '1rem',
+        }}
+      >
+        <header
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            borderBottom: '1px solid #e5e7eb',
+            paddingBottom: '0.5rem',
+          }}
+        >
+          <h2 style={{ margin: 0, fontSize: '1rem' }}>Alert detail</h2>
+          <button
+            type="button"
+            data-testid="alert-detail-drawer-close"
+            aria-label="Close"
+            onClick={onClose}
+            style={{
+              border: 'none',
+              background: 'transparent',
+              fontSize: '1.25rem',
+              cursor: 'pointer',
+              color: '#6b7280',
+            }}
+          >
+            ✕
+          </button>
+        </header>
+        {children}
+      </aside>
+    </div>
+  )
+}

--- a/dashboard/src/features/alerts/AlertsTabs.tsx
+++ b/dashboard/src/features/alerts/AlertsTabs.tsx
@@ -1,0 +1,53 @@
+export type AlertsTab = 'active' | 'incidents'
+
+interface AlertsTabsProps {
+  value: AlertsTab
+  onChange: (next: AlertsTab) => void
+}
+
+const TABS: ReadonlyArray<{ value: AlertsTab; label: string }> = [
+  { value: 'active', label: 'Active' },
+  { value: 'incidents', label: 'Incidents' },
+]
+
+export function AlertsTabs({ value, onChange }: AlertsTabsProps) {
+  return (
+    <div
+      data-testid="alerts-tabs"
+      role="tablist"
+      style={{
+        display: 'flex',
+        gap: '0.25rem',
+        borderBottom: '1px solid #e5e7eb',
+        marginBottom: '0.5rem',
+      }}
+    >
+      {TABS.map((tab) => {
+        const active = value === tab.value
+        return (
+          <button
+            key={tab.value}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            data-testid={`alerts-tab-${tab.value}`}
+            onClick={() => onChange(tab.value)}
+            style={{
+              padding: '0.5rem 1rem',
+              background: 'transparent',
+              border: 'none',
+              borderBottom: active ? '2px solid #1f2937' : '2px solid transparent',
+              cursor: 'pointer',
+              color: active ? '#1f2937' : '#6b7280',
+              fontWeight: active ? 600 : 400,
+              fontSize: '0.875rem',
+              marginBottom: '-1px',
+            }}
+          >
+            {tab.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/dashboard/src/features/alerts/SilenceAction.test.tsx
+++ b/dashboard/src/features/alerts/SilenceAction.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SilenceAction } from './SilenceAction'
+import { ToastProvider } from '../../components/ToastProvider'
+
+interface Call {
+  url: string
+  init: RequestInit
+}
+let calls: Call[]
+
+beforeEach(() => {
+  calls = []
+  localStorage.setItem('aa_token', 'test-token')
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string, init: RequestInit = {}) => {
+      calls.push({ url, init })
+      return {
+        ok: true,
+        status: 201,
+        json: async () => ({
+          silenceId: 'sil-1',
+          alertId: 'a-1',
+          startsAt: '2026-05-14T09:00:00Z',
+          expiresAt: '2026-05-14T10:00:00Z',
+          reason: null,
+          createdBy: 'user-1',
+        }),
+      } as Response
+    }),
+  )
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return (
+    <QueryClientProvider client={client}>
+      <ToastProvider>{children}</ToastProvider>
+    </QueryClientProvider>
+  )
+}
+
+describe('SilenceAction', () => {
+  it('dispatches useSilenceAlertMutation with the chosen preset', async () => {
+    const user = userEvent.setup()
+    render(<SilenceAction alertId="a-1" />, { wrapper: Wrapper })
+    await user.click(screen.getByTestId('silence-action-duration-4h'))
+    await user.click(screen.getByTestId('silence-action-submit'))
+    await waitFor(() => expect(calls).toHaveLength(1))
+    expect(calls[0].url).toBe('/api/v1/alerts/silence')
+    expect(JSON.parse(calls[0].init.body as string)).toEqual({
+      alert_id: 'a-1',
+      duration_seconds: 4 * 60 * 60,
+      reason: undefined,
+    })
+  })
+
+  it('respects custom minutes input', async () => {
+    const user = userEvent.setup()
+    render(<SilenceAction alertId="a-1" />, { wrapper: Wrapper })
+    await user.click(screen.getByTestId('silence-action-duration-custom'))
+    const customInput = screen.getByTestId('silence-action-custom-minutes') as HTMLInputElement
+    await user.clear(customInput)
+    await user.type(customInput, '15')
+    await user.click(screen.getByTestId('silence-action-submit'))
+    await waitFor(() => expect(calls).toHaveLength(1))
+    expect(JSON.parse(calls[0].init.body as string).duration_seconds).toBe(15 * 60)
+  })
+
+  it('renders a read-only line when the alert is already silenced', () => {
+    render(<SilenceAction alertId="a-1" silenced />, { wrapper: Wrapper })
+    expect(screen.getByTestId('silence-action-already')).toBeInTheDocument()
+    expect(screen.queryByTestId('silence-action-submit')).not.toBeInTheDocument()
+  })
+})

--- a/dashboard/src/features/alerts/SilenceAction.tsx
+++ b/dashboard/src/features/alerts/SilenceAction.tsx
@@ -1,0 +1,169 @@
+import { useState } from 'react'
+import { useSilenceAlertMutation } from './api'
+import { useToast } from '../../components/Toast'
+
+interface SilenceActionProps {
+  alertId: string
+  /** Currently active silence — when set, the action is rendered as read-only. */
+  silenced?: boolean
+}
+
+interface DurationOption {
+  label: string
+  /** seconds; `null` for the "custom" option (user supplies minutes inline). */
+  value: number | null
+}
+
+const DURATIONS: readonly DurationOption[] = [
+  { label: '5m', value: 5 * 60 },
+  { label: '1h', value: 60 * 60 },
+  { label: '4h', value: 4 * 60 * 60 },
+  { label: '24h', value: 24 * 60 * 60 },
+  { label: 'custom', value: null },
+]
+
+export function SilenceAction({ alertId, silenced = false }: SilenceActionProps) {
+  const [selected, setSelected] = useState<DurationOption>(DURATIONS[1])
+  const [customMinutes, setCustomMinutes] = useState<string>('30')
+  const [reason, setReason] = useState<string>('')
+  const silence = useSilenceAlertMutation()
+  const { toast } = useToast()
+
+  const resolveSeconds = (): number | null => {
+    if (selected.value !== null) return selected.value
+    const minutes = Number.parseInt(customMinutes, 10)
+    return Number.isFinite(minutes) && minutes > 0 ? minutes * 60 : null
+  }
+
+  const submit = async () => {
+    const seconds = resolveSeconds()
+    if (seconds === null) {
+      toast('Enter a positive number of minutes', 'error')
+      return
+    }
+    try {
+      await silence.mutateAsync({
+        alertId,
+        durationSeconds: seconds,
+        reason: reason.trim() || undefined,
+      })
+      toast('Silence applied', 'success')
+    } catch (err) {
+      toast(err instanceof Error ? err.message : 'Failed to silence alert', 'error')
+    }
+  }
+
+  if (silenced) {
+    return (
+      <p
+        data-testid="silence-action-already"
+        style={{ fontSize: '0.75rem', color: '#6b7280' }}
+      >
+        Alert is currently silenced.
+      </p>
+    )
+  }
+
+  return (
+    <section
+      data-testid="silence-action"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.5rem',
+        padding: '0.75rem',
+        border: '1px solid #e5e7eb',
+        borderRadius: '6px',
+      }}
+    >
+      <span
+        style={{
+          fontSize: '0.75rem',
+          textTransform: 'uppercase',
+          letterSpacing: '0.04em',
+          color: '#6b7280',
+        }}
+      >
+        Silence this alert
+      </span>
+
+      <div style={{ display: 'flex', gap: '0.25rem', flexWrap: 'wrap' }}>
+        {DURATIONS.map((opt) => {
+          const active = selected.label === opt.label
+          return (
+            <button
+              key={opt.label}
+              type="button"
+              data-testid={`silence-action-duration-${opt.label}`}
+              aria-pressed={active}
+              onClick={() => setSelected(opt)}
+              style={{
+                padding: '4px 10px',
+                borderRadius: '4px',
+                border: '1px solid #d1d5db',
+                background: active ? '#1f2937' : '#fff',
+                color: active ? '#fff' : '#1f2937',
+                cursor: 'pointer',
+                fontSize: '0.75rem',
+              }}
+            >
+              {opt.label}
+            </button>
+          )
+        })}
+      </div>
+
+      {selected.value === null && (
+        <label
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '0.25rem',
+            fontSize: '0.875rem',
+          }}
+        >
+          <input
+            type="number"
+            min={1}
+            data-testid="silence-action-custom-minutes"
+            value={customMinutes}
+            onChange={(e) => setCustomMinutes(e.target.value)}
+            style={{ width: '5rem' }}
+          />
+          <span style={{ color: '#6b7280', fontSize: '0.75rem' }}>minutes</span>
+        </label>
+      )}
+
+      <label
+        style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.875rem' }}
+      >
+        <span style={{ color: '#6b7280', fontSize: '0.75rem' }}>Reason (optional)</span>
+        <input
+          data-testid="silence-action-reason"
+          value={reason}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder="Known maintenance window"
+        />
+      </label>
+
+      <button
+        type="button"
+        data-testid="silence-action-submit"
+        onClick={() => void submit()}
+        disabled={silence.isPending}
+        style={{
+          alignSelf: 'flex-end',
+          padding: '6px 14px',
+          background: '#1f2937',
+          color: '#fff',
+          border: 'none',
+          borderRadius: '4px',
+          cursor: silence.isPending ? 'wait' : 'pointer',
+          fontSize: '0.875rem',
+        }}
+      >
+        {silence.isPending ? 'Silencing…' : 'Silence'}
+      </button>
+    </section>
+  )
+}

--- a/dashboard/src/features/alerts/alertsStreamSync.test.ts
+++ b/dashboard/src/features/alerts/alertsStreamSync.test.ts
@@ -1,0 +1,93 @@
+import { QueryClient } from '@tanstack/react-query'
+import { describe, expect, it } from 'vitest'
+import { applyFire, applyResolve, applySilence } from './alertsStreamSync'
+import { alertsQueryKeys } from './endpoints'
+import { DEFAULT_ALERT_FILTERS, type Alert } from './types'
+
+const FIRING: Alert = {
+  id: 'a-1',
+  ruleId: 'r-1',
+  ruleName: 'Budget > 90%',
+  severity: 'CRITICAL',
+  status: 'FIRING',
+  agentId: 'aa-001',
+  firstFiredAt: '2026-05-14T09:00:00Z',
+  resolvedAt: null,
+  destinationIds: ['slack-ops'],
+}
+
+const RESOLVED: Alert = { ...FIRING, status: 'RESOLVED', resolvedAt: '2026-05-14T09:30:00Z' }
+const SUPPRESSED: Alert = { ...FIRING, status: 'SUPPRESSED' }
+
+function seed(initial: readonly Alert[]) {
+  const client = new QueryClient()
+  client.setQueryData([alertsQueryKeys.alerts, DEFAULT_ALERT_FILTERS], initial)
+  return client
+}
+
+describe('applyFire', () => {
+  it('prepends a new alert to every list cache', () => {
+    const existing: Alert = { ...FIRING, id: 'a-prev' }
+    const client = seed([existing])
+    applyFire(client, FIRING)
+    const cached = client.getQueryData<readonly Alert[]>([
+      alertsQueryKeys.alerts,
+      DEFAULT_ALERT_FILTERS,
+    ])
+    expect(cached?.map((a) => a.id)).toEqual(['a-1', 'a-prev'])
+  })
+
+  it('replaces an existing alert with the same id rather than duplicating', () => {
+    const client = seed([{ ...FIRING, severity: 'LOW' }])
+    applyFire(client, FIRING)
+    const cached = client.getQueryData<readonly Alert[]>([
+      alertsQueryKeys.alerts,
+      DEFAULT_ALERT_FILTERS,
+    ])
+    expect(cached).toHaveLength(1)
+    expect(cached?.[0].severity).toBe('CRITICAL')
+  })
+
+  it('does nothing when no list cache is present', () => {
+    const client = new QueryClient()
+    applyFire(client, FIRING)
+    expect(
+      client.getQueryData([alertsQueryKeys.alerts, DEFAULT_ALERT_FILTERS]),
+    ).toBeUndefined()
+  })
+})
+
+describe('applyResolve', () => {
+  it('updates the matching row to RESOLVED in place', () => {
+    const client = seed([FIRING])
+    applyResolve(client, RESOLVED)
+    const cached = client.getQueryData<readonly Alert[]>([
+      alertsQueryKeys.alerts,
+      DEFAULT_ALERT_FILTERS,
+    ])
+    expect(cached?.[0].status).toBe('RESOLVED')
+  })
+
+  it('leaves non-matching rows untouched', () => {
+    const other: Alert = { ...FIRING, id: 'a-other' }
+    const client = seed([other, FIRING])
+    applyResolve(client, RESOLVED)
+    const cached = client.getQueryData<readonly Alert[]>([
+      alertsQueryKeys.alerts,
+      DEFAULT_ALERT_FILTERS,
+    ])
+    expect(cached?.find((a) => a.id === 'a-other')?.status).toBe('FIRING')
+  })
+})
+
+describe('applySilence', () => {
+  it('updates the matching row to SUPPRESSED', () => {
+    const client = seed([FIRING])
+    applySilence(client, SUPPRESSED)
+    const cached = client.getQueryData<readonly Alert[]>([
+      alertsQueryKeys.alerts,
+      DEFAULT_ALERT_FILTERS,
+    ])
+    expect(cached?.[0].status).toBe('SUPPRESSED')
+  })
+})

--- a/dashboard/src/features/alerts/alertsStreamSync.ts
+++ b/dashboard/src/features/alerts/alertsStreamSync.ts
@@ -1,0 +1,39 @@
+import type { QueryClient } from '@tanstack/react-query'
+import { alertsQueryKeys } from './endpoints'
+import type { Alert } from './types'
+
+/**
+ * Apply an incoming `alert.fire` event to every active alerts list cache
+ * (one per filter combination). The new alert is prepended; if an entry
+ * with the same id already exists it is replaced in place so the FIRING
+ * → SUPPRESSED → FIRING cycle stays correct.
+ */
+export function applyFire(client: QueryClient, incoming: Alert): void {
+  client.setQueriesData<readonly Alert[] | undefined>(
+    { queryKey: [alertsQueryKeys.alerts] },
+    (prev) => {
+      if (!prev) return prev
+      const idx = prev.findIndex((a) => a.id === incoming.id)
+      return idx === -1 ? [incoming, ...prev] : prev.map((a) => (a.id === incoming.id ? incoming : a))
+    },
+  )
+}
+
+/**
+ * Apply an `alert.resolve` event by updating the matching row in place
+ * across every list cache.
+ */
+export function applyResolve(client: QueryClient, incoming: Alert): void {
+  client.setQueriesData<readonly Alert[] | undefined>(
+    { queryKey: [alertsQueryKeys.alerts] },
+    (prev) => (prev ? prev.map((a) => (a.id === incoming.id ? incoming : a)) : prev),
+  )
+}
+
+/**
+ * Apply an `alert.silence` event the same way as resolve — the WS payload
+ * already carries the updated alert with `status: 'SUPPRESSED'`.
+ */
+export function applySilence(client: QueryClient, incoming: Alert): void {
+  applyResolve(client, incoming)
+}

--- a/dashboard/src/features/alerts/api.ts
+++ b/dashboard/src/features/alerts/api.ts
@@ -8,6 +8,7 @@ import {
 import { alertsEndpoints, alertsQueryKeys } from './endpoints'
 import type {
   Alert,
+  AlertDetail,
   AlertFilters,
   AlertRule,
   AlertRuleInput,
@@ -86,10 +87,12 @@ export function useAlertsQuery(
 
 // ── useAlertQuery (single alert detail) ───────────────────────────────────
 
-export function useAlertQuery(id: string | null | undefined): UseQueryResult<Alert, Error> {
+export function useAlertQuery(
+  id: string | null | undefined,
+): UseQueryResult<AlertDetail, Error> {
   return useQuery({
     queryKey: [alertsQueryKeys.alerts, id ?? ''],
-    queryFn: () => alertsFetch<Alert>(alertsEndpoints.detail(id as string)),
+    queryFn: () => alertsFetch<AlertDetail>(alertsEndpoints.detail(id as string)),
     enabled: !!id,
   })
 }

--- a/dashboard/src/features/alerts/types.ts
+++ b/dashboard/src/features/alerts/types.ts
@@ -146,3 +146,28 @@ export interface SilenceInput {
   durationSeconds: number
   reason?: string
 }
+
+// ── AlertDetail (AAASM-1385 response) ──────────────────────────────────────
+
+/** One entry in the routing log returned by `GET /alerts/{id}`. */
+export interface RoutingLogEntry {
+  destinationId: string
+  deliveredAt: string
+  status: 'ok' | 'failed' | 'retrying'
+  errorMessage?: string | null
+}
+
+/**
+ * Richer payload returned by `GET /api/v1/alerts/{id}` — superset of the
+ * `Alert` shape returned by the list endpoint. The drawer reads everything
+ * here so the list payload can stay slim.
+ */
+export interface AlertDetail extends Alert {
+  /** Snapshot of the rule that was active when the alert fired. */
+  ruleSnapshot: AlertRule
+  /** Event payload that triggered the rule. */
+  eventPayload: Record<string, unknown>
+  routingLog: readonly RoutingLogEntry[]
+  /** Active silence if any. */
+  silence: Silence | null
+}

--- a/dashboard/src/features/alerts/types.ts
+++ b/dashboard/src/features/alerts/types.ts
@@ -170,4 +170,15 @@ export interface AlertDetail extends Alert {
   routingLog: readonly RoutingLogEntry[]
   /** Active silence if any. */
   silence: Silence | null
+  /**
+   * Number of times this alert has fired within the current dedup window
+   * (including the fire that opened the window). `1` when no deduplication
+   * has happened yet.
+   */
+  dedupOccurrenceCount: number
+  /**
+   * Timestamp when the active dedup window expires. `null` when the alert
+   * is not currently inside a dedup window.
+   */
+  dedupWindowExpiresAt: string | null
 }

--- a/dashboard/src/features/alerts/useAlertsStream.test.tsx
+++ b/dashboard/src/features/alerts/useAlertsStream.test.tsx
@@ -1,0 +1,123 @@
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAlertsStream } from './useAlertsStream'
+import type { Alert, Silence } from './types'
+
+// ── MockWebSocket ─────────────────────────────────────────────────────────
+
+class MockWebSocket {
+  static OPEN = 1
+  static CLOSED = 3
+  static instances: MockWebSocket[] = []
+  readyState = 0
+  onopen: (() => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+  onmessage: ((e: { data: string }) => void) | null = null
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this)
+  }
+  close() {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.()
+  }
+  /** Test-only helper: pretend the upgrade succeeded. */
+  fakeOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.()
+  }
+  /** Test-only helper: deliver a frame. */
+  fakeMessage(payload: unknown) {
+    this.onmessage?.({ data: JSON.stringify(payload) })
+  }
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = []
+  vi.stubGlobal('WebSocket', MockWebSocket)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+const ALERT: Alert = {
+  id: 'a-1',
+  ruleId: 'r-1',
+  ruleName: 'Budget > 90%',
+  severity: 'CRITICAL',
+  status: 'FIRING',
+  agentId: 'aa-001',
+  firstFiredAt: '2026-05-14T09:00:00Z',
+  resolvedAt: null,
+  destinationIds: [],
+}
+
+const SILENCE: Silence = {
+  silenceId: 'sil-1',
+  alertId: 'a-1',
+  startsAt: '2026-05-14T09:00:00Z',
+  expiresAt: '2026-05-14T10:00:00Z',
+  reason: null,
+  createdBy: 'user-1',
+}
+
+describe('useAlertsStream', () => {
+  it('connects, transitions to open, and forwards FIRING frames to onFire', async () => {
+    const onFire = vi.fn()
+    const { result } = renderHook(() => useAlertsStream({ onFire }))
+    expect(result.current).toBe('connecting')
+
+    act(() => {
+      MockWebSocket.instances[0].fakeOpen()
+    })
+    await waitFor(() => expect(result.current).toBe('open'))
+
+    act(() => {
+      MockWebSocket.instances[0].fakeMessage({
+        type: 'alert.fire',
+        ts: '2026-05-14T09:00:00Z',
+        alert: ALERT,
+      })
+    })
+    expect(onFire).toHaveBeenCalledWith(ALERT)
+  })
+
+  it('forwards RESOLVED and SILENCE frames to the matching handlers', () => {
+    const onResolve = vi.fn()
+    const onSilence = vi.fn()
+    renderHook(() => useAlertsStream({ onResolve, onSilence }))
+    act(() => {
+      MockWebSocket.instances[0].fakeMessage({
+        type: 'alert.resolve',
+        ts: '...',
+        alert: { ...ALERT, status: 'RESOLVED' },
+      })
+      MockWebSocket.instances[0].fakeMessage({
+        type: 'alert.silence',
+        ts: '...',
+        alert: { ...ALERT, status: 'SUPPRESSED' },
+        silence: SILENCE,
+      })
+    })
+    expect(onResolve).toHaveBeenCalledWith({ ...ALERT, status: 'RESOLVED' })
+    expect(onSilence).toHaveBeenCalledWith({ ...ALERT, status: 'SUPPRESSED' }, SILENCE)
+  })
+
+  it('ignores heartbeat frames', () => {
+    const onFire = vi.fn()
+    renderHook(() => useAlertsStream({ onFire }))
+    act(() => {
+      MockWebSocket.instances[0].fakeMessage({ type: 'heartbeat', ts: '...' })
+    })
+    expect(onFire).not.toHaveBeenCalled()
+  })
+
+  it('reports closed status when the socket drops', async () => {
+    const { result } = renderHook(() => useAlertsStream({}))
+    act(() => MockWebSocket.instances[0].fakeOpen())
+    await waitFor(() => expect(result.current).toBe('open'))
+    act(() => MockWebSocket.instances[0].close())
+    await waitFor(() => expect(result.current).toBe('closed'))
+  })
+})

--- a/dashboard/src/features/alerts/useAlertsStream.ts
+++ b/dashboard/src/features/alerts/useAlertsStream.ts
@@ -40,7 +40,9 @@ const MAX_BACKOFF_MS = 30_000
  */
 export function useAlertsStream(handlers: UseAlertsStreamHandlers): StreamStatus {
   const handlersRef = useRef(handlers)
-  handlersRef.current = handlers
+  useEffect(() => {
+    handlersRef.current = handlers
+  }, [handlers])
   const [status, setStatus] = useState<StreamStatus>('connecting')
 
   useEffect(() => {

--- a/dashboard/src/features/alerts/useAlertsStream.ts
+++ b/dashboard/src/features/alerts/useAlertsStream.ts
@@ -1,0 +1,119 @@
+import { useEffect, useRef, useState } from 'react'
+import { alertsEndpoints } from './endpoints'
+import type { Alert, Silence } from './types'
+
+// ── Wire protocol ─────────────────────────────────────────────────────────
+// Mirrors the frame schema defined in AAASM-1389.
+
+export type AlertsStreamFrame =
+  | { type: 'alert.fire'; ts: string; alert: Alert }
+  | { type: 'alert.resolve'; ts: string; alert: Alert }
+  | { type: 'alert.silence'; ts: string; alert: Alert; silence: Silence }
+  | { type: 'heartbeat'; ts: string }
+
+export interface UseAlertsStreamHandlers {
+  onFire?: (alert: Alert) => void
+  onResolve?: (alert: Alert) => void
+  onSilence?: (alert: Alert, silence: Silence) => void
+}
+
+export type StreamStatus = 'connecting' | 'open' | 'closed'
+
+const BASE_WS_URL = (() => {
+  const apiBase = import.meta.env.VITE_API_BASE_URL ?? ''
+  if (apiBase.startsWith('https://')) return apiBase.replace(/^https/, 'wss')
+  if (apiBase.startsWith('http://')) return apiBase.replace(/^http/, 'ws')
+  return apiBase
+})()
+
+const INITIAL_BACKOFF_MS = 500
+const MAX_BACKOFF_MS = 30_000
+
+/**
+ * Subscribes to `/api/v1/alerts/ws` (AAASM-1389) and dispatches each frame
+ * to the handlers supplied by the caller. The hook owns reconnection with
+ * exponential backoff so callers stay declarative.
+ *
+ * The handler argument is intentionally captured via a ref so callers
+ * can pass freshly-bound closures (e.g. `useQueryClient().setQueryData`)
+ * without forcing the socket to reopen on every render.
+ */
+export function useAlertsStream(handlers: UseAlertsStreamHandlers): StreamStatus {
+  const handlersRef = useRef(handlers)
+  handlersRef.current = handlers
+  const [status, setStatus] = useState<StreamStatus>('connecting')
+
+  useEffect(() => {
+    let cancelled = false
+    let socket: WebSocket | null = null
+    let backoff = INITIAL_BACKOFF_MS
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+
+    const connect = () => {
+      if (cancelled) return
+      setStatus('connecting')
+      try {
+        socket = new WebSocket(`${BASE_WS_URL}${alertsEndpoints.websocket}`)
+      } catch {
+        scheduleReconnect()
+        return
+      }
+
+      socket.onopen = () => {
+        if (cancelled) return
+        backoff = INITIAL_BACKOFF_MS
+        setStatus('open')
+      }
+
+      socket.onmessage = (event) => {
+        if (cancelled) return
+        let frame: AlertsStreamFrame
+        try {
+          frame = JSON.parse(event.data) as AlertsStreamFrame
+        } catch {
+          return
+        }
+        const h = handlersRef.current
+        switch (frame.type) {
+          case 'alert.fire':
+            h.onFire?.(frame.alert)
+            break
+          case 'alert.resolve':
+            h.onResolve?.(frame.alert)
+            break
+          case 'alert.silence':
+            h.onSilence?.(frame.alert, frame.silence)
+            break
+          case 'heartbeat':
+            // no-op
+            break
+        }
+      }
+
+      const closeAndRetry = () => {
+        if (cancelled) return
+        setStatus('closed')
+        scheduleReconnect()
+      }
+      socket.onerror = closeAndRetry
+      socket.onclose = closeAndRetry
+    }
+
+    const scheduleReconnect = () => {
+      reconnectTimer = setTimeout(() => {
+        backoff = Math.min(backoff * 2, MAX_BACKOFF_MS)
+        connect()
+      }, backoff)
+    }
+
+    connect()
+
+    return () => {
+      cancelled = true
+      if (reconnectTimer) clearTimeout(reconnectTimer)
+      socket?.close()
+    }
+  }, [])
+
+  return status
+}

--- a/dashboard/src/pages/AlertsPage.tsx
+++ b/dashboard/src/pages/AlertsPage.tsx
@@ -2,12 +2,22 @@ import { useCallback, useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { AlertList } from '../features/alerts/AlertList'
 import { AlertFilterBar } from '../features/alerts/AlertFilterBar'
+import { AlertsTabs, type AlertsTab } from '../features/alerts/AlertsTabs'
 import { useAlertsQuery } from '../features/alerts/api'
 import {
   filtersFromSearchParams,
   filtersToSearchParams,
 } from '../features/alerts/urlFilters'
-import type { AlertFilters } from '../features/alerts/types'
+import type { Alert, AlertFilters } from '../features/alerts/types'
+
+function partitionByTab(rows: readonly Alert[], tab: AlertsTab): readonly Alert[] {
+  if (tab === 'incidents') return rows.filter((r) => r.status === 'RESOLVED')
+  return rows.filter((r) => r.status === 'FIRING' || r.status === 'SUPPRESSED')
+}
+
+function readTab(sp: URLSearchParams): AlertsTab {
+  return sp.get('tab') === 'incidents' ? 'incidents' : 'active'
+}
 
 export function AlertsPage() {
   const [searchParams, setSearchParams] = useSearchParams()
@@ -15,14 +25,28 @@ export function AlertsPage() {
     () => filtersFromSearchParams(searchParams),
     [searchParams],
   )
+  const tab: AlertsTab = readTab(searchParams)
 
   const setFilters = useCallback(
-    (next: AlertFilters) => setSearchParams(filtersToSearchParams(next)),
-    [setSearchParams],
+    (next: AlertFilters) => {
+      const sp = filtersToSearchParams(next)
+      if (tab !== 'active') sp.set('tab', tab)
+      setSearchParams(sp)
+    },
+    [setSearchParams, tab],
+  )
+
+  const setTab = useCallback(
+    (next: AlertsTab) => {
+      const sp = filtersToSearchParams(filters)
+      if (next !== 'active') sp.set('tab', next)
+      setSearchParams(sp)
+    },
+    [filters, setSearchParams],
   )
 
   const { data, isLoading, isError, error, refetch } = useAlertsQuery(filters)
-  const rows = data ?? []
+  const rows = useMemo(() => partitionByTab(data ?? [], tab), [data, tab])
 
   return (
     <main style={{ padding: '1.5rem' }}>
@@ -30,6 +54,8 @@ export function AlertsPage() {
       <p style={{ color: '#6b7280', marginBottom: '1rem', fontSize: '0.875rem' }}>
         Policy violations, budget thresholds, and anomaly detections across all governed agents.
       </p>
+
+      <AlertsTabs value={tab} onChange={setTab} />
 
       <AlertFilterBar value={filters} onChange={setFilters} />
 

--- a/dashboard/src/pages/AlertsPage.tsx
+++ b/dashboard/src/pages/AlertsPage.tsx
@@ -1,9 +1,14 @@
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
 import { AlertList } from '../features/alerts/AlertList'
 import { AlertFilterBar } from '../features/alerts/AlertFilterBar'
 import { AlertsTabs, type AlertsTab } from '../features/alerts/AlertsTabs'
+import { AlertDetailDrawer } from '../features/alerts/AlertDetailDrawer'
+import { AlertDetailContent } from '../features/alerts/AlertDetailContent'
 import { useAlertsQuery } from '../features/alerts/api'
+import { useAlertsStream } from '../features/alerts/useAlertsStream'
+import { applyFire, applyResolve, applySilence } from '../features/alerts/alertsStreamSync'
 import {
   filtersFromSearchParams,
   filtersToSearchParams,
@@ -48,12 +53,40 @@ export function AlertsPage() {
   const { data, isLoading, isError, error, refetch } = useAlertsQuery(filters)
   const rows = useMemo(() => partitionByTab(data ?? [], tab), [data, tab])
 
+  const [selectedAlertId, setSelectedAlertId] = useState<string | null>(null)
+
+  const queryClient = useQueryClient()
+  const streamStatus = useAlertsStream({
+    onFire: (a) => applyFire(queryClient, a),
+    onResolve: (a) => applyResolve(queryClient, a),
+    onSilence: (a) => applySilence(queryClient, a),
+  })
+
   return (
     <main style={{ padding: '1.5rem' }}>
       <h1 style={{ marginBottom: '0.25rem' }}>Alerts</h1>
       <p style={{ color: '#6b7280', marginBottom: '1rem', fontSize: '0.875rem' }}>
         Policy violations, budget thresholds, and anomaly detections across all governed agents.
       </p>
+
+      {streamStatus !== 'open' && (
+        <div
+          data-testid="alerts-stream-banner"
+          role="status"
+          style={{
+            marginBottom: '0.75rem',
+            padding: '6px 10px',
+            background: '#fef3c7',
+            color: '#92400e',
+            borderRadius: '4px',
+            fontSize: '0.75rem',
+          }}
+        >
+          {streamStatus === 'connecting'
+            ? 'Connecting to live alerts stream…'
+            : 'Live alerts stream disconnected — reconnecting.'}
+        </div>
+      )}
 
       <AlertsTabs value={tab} onChange={setTab} />
 
@@ -83,7 +116,14 @@ export function AlertsPage() {
         {isLoading ? 'Loading…' : `${rows.length} alert${rows.length === 1 ? '' : 's'}`}
       </div>
 
-      <AlertList rows={rows} />
+      <AlertList rows={rows} onSelect={setSelectedAlertId} />
+
+      <AlertDetailDrawer
+        open={selectedAlertId !== null}
+        onClose={() => setSelectedAlertId(null)}
+      >
+        {selectedAlertId && <AlertDetailContent alertId={selectedAlertId} />}
+      </AlertDetailDrawer>
     </main>
   )
 }


### PR DESCRIPTION
## Description

Adds the live-update layer for the dashboard Alerts page — `Active` / `Incidents` sub-tabs, a slide-from-right `<AlertDetailDrawer>` with rule YAML / firing timeline / event payload / routing log / silence action, and a `useAlertsStream` WebSocket hook that mirrors fire / resolve / silence frames into the Tanstack Query cache with exponential-backoff reconnect.

Parent Story [AAASM-118](https://lightning-dust-mite.atlassian.net/browse/AAASM-118).

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: **[AAASM-1080](https://lightning-dust-mite.atlassian.net/browse/AAASM-1080)**
- Parent Story: [AAASM-118](https://lightning-dust-mite.atlassian.net/browse/AAASM-118)
- Backend dependencies:
  - [AAASM-1385](https://lightning-dust-mite.atlassian.net/browse/AAASM-1385) — `GET /api/v1/alerts/{id}` powers the drawer body
  - [AAASM-1387](https://lightning-dust-mite.atlassian.net/browse/AAASM-1387) — `POST /api/v1/alerts/silence` powers the silence action
  - [AAASM-1389](https://lightning-dust-mite.atlassian.net/browse/AAASM-1389) — `GET /api/v1/alerts/ws` powers the live stream

## What is in this PR (10 atomic commits)

| # | Commit | Scope |
| --- | --- | --- |
| 1 | `✨ Active / Incidents sub-tab toggle` | `<AlertsTabs>` + URL `?tab=incidents` |
| 2 | `✨ <AlertDetailDrawer>` skeleton | slide-from-right, escape + outside-click close |
| 3 | `✨ AlertDetail + RoutingLogEntry types` | matches AAASM-1385 response shape |
| 4 | `✨ Drawer body` — rule YAML, timeline, event payload, routing log | header + 4 sections |
| 5 | `✨ <SilenceAction>` | 5m / 1h / 4h / 24h presets + custom minutes input |
| 6 | `✨ useAlertsStream` | WS hook with exponential backoff reconnect |
| 7 | `✨ alertsStreamSync` helpers | `applyFire`/`applyResolve`/`applySilence` against the query cache |
| 8 | `✨ Wire AlertsPage` | mounts drawer, stream, and disconnected banner |
| 9 | `✅ Vitest specs` | 13 new specs (sync helpers, silence action, WS hook) |
| 10 | `🚨 Move handlersRef update into useEffect` | satisfies `react-hooks/refs` lint rule |

## Testing

- [x] Unit tests added — **13 new specs**
- [x] Manual testing performed — vitest+RTL drives WS frame dispatch via `MockWebSocket`
- [ ] No tests required

```bash
pnpm -C dashboard type-check   # clean
pnpm -C dashboard lint         # --max-warnings 0 clean
pnpm -C dashboard test --run   # 691 / 691 pass (full suite)
```

## Self-verification footnote

`/alerts` route still gated by `<ProtectedRoute>` + the speculative `/alerts/{id}`, `/silence`, `/ws` paths. Stream + cache + silence behavior is locked in via Vitest with `MockWebSocket` + `fetch` stubs.

## Out of scope

- The `<AlertRuleForm>` modal (AAASM-1077) is not mounted in this PR — natural follow-up alongside the destination registry in **AAASM-1082**
- Empty / loading / error refinement + `<DestinationManager>` + Playwright E2E → **AAASM-1082**

## Checklist

- [x] Style guidelines followed
- [x] Self-review of the diff completed
- [x] All local checks passing
- [x] Commits are small and Gitmoji-conventional (10 atomic commits)

[AAASM-118]: https://lightning-dust-mite.atlassian.net/browse/AAASM-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1080]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-118]: https://lightning-dust-mite.atlassian.net/browse/AAASM-118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1385]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1387]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1389]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ