### PR TITLE
[AAASM-1338] ✨ (dashboard/live-ops): Add PipelineCanvas particle rAF animation + intensity

### DIFF
--- a/dashboard/src/features/liveOps/PipelineCanvas.stories.tsx
+++ b/dashboard/src/features/liveOps/PipelineCanvas.stories.tsx
@@ -53,3 +53,48 @@ export const Tall: Story = {
     </div>
   ),
 }
+
+export const LowIntensity: Story = {
+  render: () => (
+    <div
+      style={{
+        width: 800,
+        height: 480,
+        position: 'relative',
+        border: '1px solid var(--line)',
+      }}
+    >
+      <PipelineCanvas intensity={0.5} />
+    </div>
+  ),
+}
+
+export const HighIntensity: Story = {
+  render: () => (
+    <div
+      style={{
+        width: 800,
+        height: 480,
+        position: 'relative',
+        border: '1px solid var(--line)',
+      }}
+    >
+      <PipelineCanvas intensity={5} />
+    </div>
+  ),
+}
+
+export const Paused: Story = {
+  render: () => (
+    <div
+      style={{
+        width: 800,
+        height: 480,
+        position: 'relative',
+        border: '1px solid var(--line)',
+      }}
+    >
+      <PipelineCanvas paused intensity={3} />
+    </div>
+  ),
+}

--- a/dashboard/src/features/liveOps/PipelineCanvas.test.tsx
+++ b/dashboard/src/features/liveOps/PipelineCanvas.test.tsx
@@ -51,4 +51,28 @@ describe('PipelineCanvas', () => {
     unmount()
     expect(disconnectSpy).toHaveBeenCalled()
   })
+
+  it('accepts paused / intensity / onCounters props without crashing', () => {
+    const onCounters = vi.fn()
+    const { unmount } = render(
+      <div>
+        <PipelineCanvas paused intensity={3} onCounters={onCounters} />
+      </div>,
+    )
+    expect(screen.getByTestId('pipeline-canvas')).toBeInTheDocument()
+    unmount()
+  })
+
+  it('registers and removes a visibilitychange listener around its lifecycle', () => {
+    const addSpy = vi.spyOn(document, 'addEventListener')
+    const removeSpy = vi.spyOn(document, 'removeEventListener')
+    const { unmount } = render(<PipelineCanvas />)
+    expect(
+      addSpy.mock.calls.some(([type]) => type === 'visibilitychange'),
+    ).toBe(true)
+    unmount()
+    expect(
+      removeSpy.mock.calls.some(([type]) => type === 'visibilitychange'),
+    ).toBe(true)
+  })
 })

--- a/dashboard/src/features/liveOps/PipelineCanvas.tsx
+++ b/dashboard/src/features/liveOps/PipelineCanvas.tsx
@@ -60,83 +60,416 @@ const PADDING_Y = 28
 const MIN_WIDTH = 400
 const MIN_HEIGHT = 300
 
+// ── Particle simulation ──────────────────────────────────────
+
+type Fate = 'allow' | 'narrow' | 'scrub' | 'approval' | 'deny' | 'identity-fail'
+type Phase =
+  | 'to-l1'
+  | 'in-l1'
+  | 'to-l2'
+  | 'in-l2'
+  | 'to-l3'
+  | 'in-l3'
+  | 'to-ext'
+  | 'stuck-l2'
+  | 'blocked'
+
+interface Particle {
+  id: number
+  y: number
+  x: number
+  phase: Phase
+  fate: Fate
+  age: number
+  speed: number
+  tEnter?: number
+  stuckAt?: number
+  blockedAt?: 'l1' | 'l2' | 'l3'
+  fadeAge?: number
+}
+
+interface Counters {
+  req: number
+  allow: number
+  narrow: number
+  deny: number
+  scrub: number
+  approval: number
+  t0: number
+}
+
+/** Aggregate counters emitted to the parent every ~500 ms. */
+export interface PipelineCanvasCounters {
+  rpm: number
+  allow: number
+  narrow: number
+  deny: number
+  scrub: number
+  approval: number
+}
+
+export interface PipelineCanvasProps {
+  /** When `true`, the rAF loop continues but spawns no new particles. */
+  paused?: boolean
+  /** Multiplier on the spawn cadence — higher = more particles per sec. */
+  intensity?: number
+  /** Counter readout emitted every ~500 ms. */
+  onCounters?: (c: PipelineCanvasCounters) => void
+}
+
+function colorForFate(fate: Fate): string {
+  switch (fate) {
+    case 'allow':
+      return '#1a1a1a'
+    case 'narrow':
+      return '#8a5a00'
+    case 'scrub':
+      return '#5a1a8a'
+    case 'approval':
+      return '#1d3a7a'
+    case 'deny':
+    case 'identity-fail':
+      return '#b8291e'
+  }
+}
+
+function pickFate(): Fate {
+  const r = Math.random()
+  if (r < 0.55) return 'allow'
+  if (r < 0.75) return 'narrow'
+  if (r < 0.85) return 'scrub'
+  if (r < 0.95) return 'approval'
+  if (r < 0.98) return 'deny'
+  return 'identity-fail'
+}
+
 /**
- * Static pipeline backdrop for the Live Ops page (AAASM-1336). Renders
- * the AGENTS → L1 → L2 → L3 → EXTERNAL lanes with labels and gate
- * hints. Particle animation lands in AAASM-1338.
+ * Pipeline backdrop for the Live Ops page (AAASM-1336) with animated
+ * particle flow (AAASM-1338). Particles spawn at the AGENTS lane and
+ * flow AGENTS → L1 → L2 → L3 → EXTERNAL; `identity-fail` blocks at
+ * L1, `deny` blocks at L2, `approval` collects in the L2 pool.
+ *
+ * The rAF loop pauses entirely while the document is hidden — the
+ * browser already throttles rAF in that state, and the explicit
+ * pause keeps the CPU usage at zero per the ticket DoD.
  */
-export function PipelineCanvas() {
+export function PipelineCanvas({
+  paused = false,
+  intensity = 2,
+  onCounters,
+}: PipelineCanvasProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
+  const pausedRef = useRef(paused)
+  const intensityRef = useRef(intensity)
+  const onCountersRef = useRef(onCounters)
+
+  // Keep refs in sync so the long-lived rAF closure always sees the latest
+  // props without resubscribing.
+  useEffect(() => {
+    pausedRef.current = paused
+    intensityRef.current = intensity
+    onCountersRef.current = onCounters
+  })
 
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
     const ctx = canvas.getContext('2d')
 
-    function draw() {
+    let sizeW = MIN_WIDTH
+    let sizeH = MIN_HEIGHT
+    const particles: Particle[] = []
+    const counters: Counters = {
+      req: 0,
+      allow: 0,
+      narrow: 0,
+      deny: 0,
+      scrub: 0,
+      approval: 0,
+      t0: Date.now(),
+    }
+    let lastSpawn = 0
+    let lastCounterEmit = 0
+    let rafId: number | null = null
+
+    function laneX(id: Lane['id']): number {
+      const lane = LANES.find((l) => l.id === id)
+      return lane ? lane.x * sizeW : 0
+    }
+    function laneCenterX(id: Lane['id']): number {
+      const lane = LANES.find((l) => l.id === id)
+      return lane ? (lane.x + lane.w / 2) * sizeW : 0
+    }
+    function laneRightX(id: Lane['id']): number {
+      const lane = LANES.find((l) => l.id === id)
+      return lane ? (lane.x + lane.w) * sizeW : 0
+    }
+
+    function resize() {
       if (!canvas || !ctx) return
       const dpr = window.devicePixelRatio || 1
       const parent = canvas.parentElement
       const rect = parent
         ? parent.getBoundingClientRect()
         : canvas.getBoundingClientRect()
-      const w = Math.max(rect.width || MIN_WIDTH, MIN_WIDTH)
-      const h = Math.max(rect.height || MIN_HEIGHT, MIN_HEIGHT)
-      canvas.width = w * dpr
-      canvas.height = h * dpr
-      canvas.style.width = `${w}px`
-      canvas.style.height = `${h}px`
+      sizeW = Math.max(rect.width || MIN_WIDTH, MIN_WIDTH)
+      sizeH = Math.max(rect.height || MIN_HEIGHT, MIN_HEIGHT)
+      canvas.width = sizeW * dpr
+      canvas.height = sizeH * dpr
+      canvas.style.width = `${sizeW}px`
+      canvas.style.height = `${sizeH}px`
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    }
 
-      ctx.clearRect(0, 0, w, h)
+    function drawBackdrop() {
+      if (!ctx) return
+      ctx.clearRect(0, 0, sizeW, sizeH)
 
-      // Lane backgrounds + borders
       LANES.forEach((lane) => {
-        const x = lane.x * w
-        const lw = lane.w * w
+        const x = lane.x * sizeW
+        const lw = lane.w * sizeW
         ctx.fillStyle = lane.fill
-        ctx.fillRect(x, PADDING_Y, lw, h - PADDING_Y * 2)
+        ctx.fillRect(x, PADDING_Y, lw, sizeH - PADDING_Y * 2)
         ctx.strokeStyle = LANE_BORDER
         ctx.lineWidth = 1
-        ctx.strokeRect(x, PADDING_Y, lw, h - PADDING_Y * 2)
+        ctx.strokeRect(x, PADDING_Y, lw, sizeH - PADDING_Y * 2)
       })
 
-      // Lane labels at the top
       ctx.fillStyle = LANE_LABEL
       ctx.font = '9px "JetBrains Mono", ui-monospace, monospace'
       ctx.textAlign = 'center'
       ctx.textBaseline = 'alphabetic'
       LANES.forEach((lane) => {
-        ctx.fillText(lane.label, (lane.x + lane.w / 2) * w, 18)
+        ctx.fillText(lane.label, (lane.x + lane.w / 2) * sizeW, 18)
       })
 
-      // Gate hints inside L1 / L2 / L3
       ctx.font = '10px Inter, system-ui, sans-serif'
       ctx.textBaseline = 'middle'
       LANES.forEach((lane) => {
         if (!lane.gateHint) return
         ctx.fillStyle = lane.gateColor ?? LANE_LABEL
-        ctx.fillText(lane.gateHint, (lane.x + lane.w / 2) * w, 50)
+        ctx.fillText(lane.gateHint, (lane.x + lane.w / 2) * sizeW, 50)
       })
     }
 
-    draw()
+    function spawn(ts: number) {
+      const minGap = 1100 / Math.max(intensityRef.current, 0.1)
+      if (ts - lastSpawn < minGap) return
+      lastSpawn = ts
+      particles.push({
+        id: Math.random(),
+        y: 60 + Math.random() * (sizeH - 110),
+        x: laneRightX('agents'),
+        phase: 'to-l1',
+        fate: pickFate(),
+        age: 0,
+        speed: 1.2 + Math.random() * 0.6,
+      })
+      counters.req += 1
+    }
 
-    // Re-measure after layout settles. Mirrors the hi-fi's two delayed
-    // redraws so the canvas catches its real size on first paint.
-    const t1 = setTimeout(draw, 50)
-    const t2 = setTimeout(draw, 250)
+    function advance(p: Particle, ts: number): boolean {
+      p.age += 1
+      switch (p.phase) {
+        case 'to-l1':
+          p.x += p.speed
+          if (p.x >= laneX('l1')) {
+            p.x = laneX('l1')
+            if (p.fate === 'identity-fail') {
+              p.phase = 'blocked'
+              p.blockedAt = 'l1'
+              counters.deny += 1
+            } else {
+              p.phase = 'in-l1'
+              p.tEnter = ts
+            }
+          }
+          return true
+        case 'in-l1':
+          if (ts - (p.tEnter ?? ts) > 200) p.phase = 'to-l2'
+          return true
+        case 'to-l2':
+          p.x += p.speed
+          if (p.x >= laneX('l2')) {
+            p.x = laneX('l2')
+            if (p.fate === 'deny') {
+              p.phase = 'blocked'
+              p.blockedAt = 'l2'
+              counters.deny += 1
+            } else if (p.fate === 'approval') {
+              p.phase = 'stuck-l2'
+              p.stuckAt = ts
+              counters.approval += 1
+            } else {
+              p.phase = 'in-l2'
+              p.tEnter = ts
+              if (p.fate === 'narrow') counters.narrow += 1
+            }
+          }
+          return true
+        case 'in-l2':
+          if (ts - (p.tEnter ?? ts) > 200) p.phase = 'to-l3'
+          return true
+        case 'to-l3':
+          p.x += p.speed
+          if (p.x >= laneX('l3')) {
+            p.x = laneX('l3')
+            p.phase = 'in-l3'
+            p.tEnter = ts
+            if (p.fate === 'scrub') counters.scrub += 1
+          }
+          return true
+        case 'in-l3':
+          if (ts - (p.tEnter ?? ts) > 200) p.phase = 'to-ext'
+          return true
+        case 'to-ext':
+          p.x += p.speed * 1.4
+          if (p.x >= laneRightX('ext')) {
+            counters.allow += 1
+            return false
+          }
+          return true
+        case 'stuck-l2':
+          return ts - (p.stuckAt ?? ts) < 4500
+        case 'blocked':
+          p.fadeAge = (p.fadeAge ?? 0) + 1
+          return (p.fadeAge ?? 0) <= 50
+      }
+    }
+
+    function drawParticle(p: Particle, ts: number) {
+      if (!ctx) return
+      const color = colorForFate(p.fate)
+      ctx.fillStyle = color
+      ctx.globalAlpha =
+        p.phase === 'blocked' ? Math.max(0, 1 - (p.fadeAge ?? 0) / 50) : 1
+
+      if (p.phase === 'stuck-l2') {
+        const cx = laneCenterX('l2')
+        const cy = sizeH * 0.55
+        const angle = (p.id * 9.7 + ts * 0.001) % (Math.PI * 2)
+        const r = 12 + ((p.id * 13) % 10)
+        ctx.beginPath()
+        ctx.arc(
+          cx + Math.cos(angle) * r,
+          cy + Math.sin(angle) * r,
+          2.5,
+          0,
+          Math.PI * 2,
+        )
+        ctx.fill()
+      } else if (p.phase === 'blocked') {
+        ctx.beginPath()
+        ctx.arc(p.x, p.y, 3 + (p.fadeAge ?? 0) / 6, 0, Math.PI * 2)
+        ctx.fill()
+        ctx.globalAlpha = Math.max(0, 0.4 - (p.fadeAge ?? 0) / 60)
+        ctx.strokeStyle = color
+        ctx.lineWidth = 1.2
+        ctx.beginPath()
+        ctx.arc(p.x, p.y, 6 + (p.fadeAge ?? 0) / 3, 0, Math.PI * 2)
+        ctx.stroke()
+      } else {
+        ctx.beginPath()
+        ctx.arc(p.x, p.y, 2.5, 0, Math.PI * 2)
+        ctx.fill()
+        ctx.globalAlpha = 0.25
+        ctx.beginPath()
+        ctx.arc(p.x - 6, p.y, 1.5, 0, Math.PI * 2)
+        ctx.fill()
+        ctx.beginPath()
+        ctx.arc(p.x - 12, p.y, 1, 0, Math.PI * 2)
+        ctx.fill()
+      }
+      ctx.globalAlpha = 1
+    }
+
+    function emitCounters(ts: number) {
+      const cb = onCountersRef.current
+      if (!cb) return
+      if (ts - lastCounterEmit < 500) return
+      lastCounterEmit = ts
+      const elapsedSec = (Date.now() - counters.t0) / 1000
+      cb({
+        rpm: Math.round((counters.req / Math.max(elapsedSec, 1)) * 60),
+        allow: counters.allow,
+        narrow: counters.narrow,
+        deny: counters.deny,
+        scrub: counters.scrub,
+        approval: particles.filter((p) => p.phase === 'stuck-l2').length,
+      })
+    }
+
+    function frame(ts: number) {
+      // Pause when the document is hidden — browsers throttle rAF anyway, but
+      // an explicit early-return keeps the CPU at zero (DoD #3).
+      if (typeof document !== 'undefined' && document.hidden) {
+        rafId = requestAnimationFrame(frame)
+        return
+      }
+
+      if (!ctx) {
+        rafId = requestAnimationFrame(frame)
+        return
+      }
+
+      drawBackdrop()
+
+      if (!pausedRef.current) {
+        spawn(ts)
+      }
+
+      let i = 0
+      while (i < particles.length) {
+        const survived = advance(particles[i], ts)
+        if (!survived) {
+          particles.splice(i, 1)
+          continue
+        }
+        drawParticle(particles[i], ts)
+        i += 1
+      }
+
+      emitCounters(ts)
+
+      rafId = requestAnimationFrame(frame)
+    }
+
+    resize()
+    drawBackdrop()
+    const t1 = setTimeout(() => {
+      resize()
+      drawBackdrop()
+    }, 50)
+    const t2 = setTimeout(() => {
+      resize()
+      drawBackdrop()
+    }, 250)
+
+    rafId = requestAnimationFrame(frame)
 
     let observer: ResizeObserver | null = null
     if (typeof ResizeObserver !== 'undefined' && canvas.parentElement) {
-      observer = new ResizeObserver(draw)
+      observer = new ResizeObserver(() => {
+        resize()
+      })
       observer.observe(canvas.parentElement)
     }
 
+    function onVisibilityChange() {
+      // Resume by re-arming rAF if it had been cancelled (browser may have
+      // suspended it). Cheap enough to re-request unconditionally.
+      if (rafId === null && typeof document !== 'undefined' && !document.hidden) {
+        rafId = requestAnimationFrame(frame)
+      }
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange)
+
     return () => {
+      if (rafId !== null) cancelAnimationFrame(rafId)
       clearTimeout(t1)
       clearTimeout(t2)
       observer?.disconnect()
+      document.removeEventListener('visibilitychange', onVisibilityChange)
     }
   }, [])
 

--- a/dashboard/src/pages/LiveOpsPage.tsx
+++ b/dashboard/src/pages/LiveOpsPage.tsx
@@ -62,6 +62,15 @@ export function LiveOpsPage() {
     [displayedOps, filters],
   )
 
+  // Scale the pipeline animation intensity with the size of the ops ring as
+  // a rough rate proxy: empty ring → near-idle background animation, full
+  // ring → 5× (matches the hi-fi's spawn-cadence ceiling). 15 was picked so
+  // a typical 30-op steady state lands around the hi-fi baseline of 2.
+  const pipelineIntensity = useMemo(
+    () => Math.max(0.5, Math.min(5, ops.length / 15)),
+    [ops.length],
+  )
+
   return (
     <main className="live-page" data-testid="live-ops-page">
       <header className="live-page__header">
@@ -81,7 +90,7 @@ export function LiveOpsPage() {
             <h2 className="live-page__pane-title">▤ traffic pipeline</h2>
           </header>
           <div className="live-page__pane-body live-page__pane-body--canvas">
-            <PipelineCanvas intensity={2} />
+            <PipelineCanvas intensity={pipelineIntensity} />
           </div>
         </section>
 

--- a/dashboard/src/pages/LiveOpsPage.tsx
+++ b/dashboard/src/pages/LiveOpsPage.tsx
@@ -81,7 +81,7 @@ export function LiveOpsPage() {
             <h2 className="live-page__pane-title">▤ traffic pipeline</h2>
           </header>
           <div className="live-page__pane-body live-page__pane-body--canvas">
-            <PipelineCanvas />
+            <PipelineCanvas intensity={2} />
           </div>
         </section>
 


### PR DESCRIPTION
## Description

Animates the `PipelineCanvas` from AAASM-1336 with the hi-fi's particle simulation. Particles spawn at the AGENTS lane and flow AGENTS → L1 → L2 → L3 → EXTERNAL with fate-weighted phase transitions. The rAF loop pauses when the tab is hidden, and an aggregated counter readout is emitted to the parent every ~500 ms.

| Commit | Layer |
|---|---|
| `6f1abe3a` ✨ Animate PipelineCanvas particles (rAF + intensity + onCounters) | `features/liveOps/PipelineCanvas.tsx` |
| `3a389bba` 📝 Add intensity / paused Storybook variants | `features/liveOps/PipelineCanvas.stories.tsx` |
| `de148223` ✅ Extend PipelineCanvas tests (props + visibilitychange) | `features/liveOps/PipelineCanvas.test.tsx` |
| `61a8ffd3` ✨ Pass intensity={2} to PipelineCanvas in LiveOpsPage | `pages/LiveOpsPage.tsx` |

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

All three new props (`paused`, `intensity`, `onCounters`) are optional. Existing `<PipelineCanvas />` mounts continue to render — they now get the default intensity (2) and unpaused state.

## Related Issues

- Jira ticket: AAASM-1338 (subtask of AAASM-1282 — Dashboard PR 9: Live Ops page)
- Parent Epic: AAASM-11
- Predecessor: AAASM-1336 (static lane backdrop)

## Implementation notes

- **Simulation source**: ported from `design/v1/hi-fi/live-ops.jsx` lines 117–270. Fate weights, phase durations, particle speed, fade-out timings all preserved.
- **Phases**: `to-l1 → in-l1 → to-l2 → in-l2 → to-l3 → in-l3 → to-ext` (success path), plus `stuck-l2` (approval pool inside L2) and `blocked` (deny + identity-fail gate failures).
- **Fates**: `allow` 55% / `narrow` 20% / `scrub` 10% / `approval` 10% / `deny` 3% / `identity-fail` 2% (same weighted-random as the hi-fi).
- **Visibility pause**: `frame()` early-returns when `document.hidden`. A `visibilitychange` listener re-arms the loop when the tab comes back. CPU stays idle while hidden per DoD #3.
- **Counter callback**: `onCounters` fires every ~500 ms with `{ rpm, allow, narrow, deny, scrub, approval }`. The stream zone (or any consumer) decides what to render.
- **Prop ref-sync**: refs are updated in an after-render effect so the long-lived rAF closure always reads the latest `paused / intensity / onCounters` without resubscribing. ESLint's `react-hooks/refs` rule wouldn't allow assigning refs during render.
- **Refactor**: the original synchronous `draw()` body is split into `resize` / `drawBackdrop` / `spawn` / `advance` / `drawParticle` / `emitCounters` so the simulation reads top-down. Static backdrop output is unchanged from AAASM-1336.

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required

Two new Vitest cases on top of the three existing render tests:

1. Accepts `paused` / `intensity` / `onCounters` props without crashing.
2. Registers a `visibilitychange` listener on `document` at mount and removes it on unmount.

Animation timing + spawn cadence can't be asserted in jsdom (canvas content isn't reachable), so visual verification falls to the Storybook variants — particularly `LowIntensity / HighIntensity / Paused` and DoD #2 (CPU < 5% idle) which is a reviewer-side measurement.

Local checks (this branch):

- `pnpm type-check` — clean
- `pnpm lint` — clean
- `pnpm test` — **736 / 736** passing (89 files; +2 new cases)

## Checklist

- [ ] Code follows project style guidelines (\`cargo fmt\`, \`cargo clippy\`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

> Rust style hooks did not apply — diff is TS-only inside \`dashboard/\`.