### PR TITLE
[AAASM-1340] ✨ (dashboard): Wire View trace from topology node panel to shell-level trace drawer

### DIFF
--- a/dashboard/src/components/AppShell.tsx
+++ b/dashboard/src/components/AppShell.tsx
@@ -5,6 +5,8 @@ import { OverlayProvider } from './OverlayProvider'
 import { OVERLAY_NAMES } from './OverlayContext'
 import { ApprovalsBellButton } from '../features/approvals/ApprovalsBellButton'
 import { CANONICAL_ROUTES, ROUTE_GROUPS, type RouteGroup } from '../routes'
+import { TraceDrawerProvider } from './trace/TraceDrawerProvider'
+import { TraceDrawer } from './trace/TraceDrawer'
 import './AppShell.css'
 
 const GROUP_LABEL: Record<RouteGroup, string> = {
@@ -54,6 +56,7 @@ export function AppShell() {
 
   return (
     <OverlayProvider>
+    <TraceDrawerProvider>
     <div className="appshell" data-testid="appshell">
       <nav
         className={`appshell__nav${navOpen ? ' appshell__nav--open' : ''}`}
@@ -120,7 +123,9 @@ export function AppShell() {
       {OVERLAY_NAMES.map((name) => (
         <div key={name} data-overlay={name} data-testid={`overlay-mount-${name}`} />
       ))}
+      <TraceDrawer />
     </div>
+    </TraceDrawerProvider>
     </OverlayProvider>
   )
 }

--- a/dashboard/src/components/topology/NodeDetailPanel.test.tsx
+++ b/dashboard/src/components/topology/NodeDetailPanel.test.tsx
@@ -18,6 +18,7 @@ const NODE: TopologyNode = {
   budgetSpend: 4.1,
   budgetLimit: 10,
   framework: 'langgraph',
+  latestSessionId: 'sess-7',
 }
 
 const RECENT: RecentEvent[] = [
@@ -107,7 +108,7 @@ describe('NodeDetailPanel', () => {
     expect(screen.getByText('No recent activity.')).toBeInTheDocument()
   })
 
-  it('View trace button fires onViewTrace with the node id', async () => {
+  it('View trace button fires onViewTrace with the node id and latest session id', async () => {
     vi.spyOn(topologyApi, 'useTopologyNodeRecentEvents').mockReturnValue(
       mockRecent({ data: [], isLoading: false, isError: false }),
     )
@@ -115,7 +116,26 @@ describe('NodeDetailPanel', () => {
     renderPanel(NODE, vi.fn(), onViewTrace)
 
     await userEvent.click(screen.getByTestId('node-detail-view-trace'))
-    expect(onViewTrace).toHaveBeenCalledWith('agent-001')
+    expect(onViewTrace).toHaveBeenCalledWith('agent-001', 'sess-7')
+  })
+
+  it('disables View trace and shows a tooltip when latestSessionId is missing', async () => {
+    vi.spyOn(topologyApi, 'useTopologyNodeRecentEvents').mockReturnValue(
+      mockRecent({ data: [], isLoading: false, isError: false }),
+    )
+    const onViewTrace = vi.fn()
+    const nodeWithoutSession: TopologyNode = { ...NODE, latestSessionId: undefined }
+    renderPanel(nodeWithoutSession, vi.fn(), onViewTrace)
+
+    const btn = screen.getByTestId('node-detail-view-trace') as HTMLButtonElement
+    expect(btn).toBeDisabled()
+    expect(btn).toHaveAttribute(
+      'title',
+      'No recent session for this agent yet — run a trace to enable.',
+    )
+
+    await userEvent.click(btn)
+    expect(onViewTrace).not.toHaveBeenCalled()
   })
 
   it('Close button + Esc key both fire onClose', async () => {

--- a/dashboard/src/components/topology/NodeDetailPanel.tsx
+++ b/dashboard/src/components/topology/NodeDetailPanel.tsx
@@ -8,7 +8,12 @@ const RECENT_EVENT_LIMIT = 5
 export interface NodeDetailPanelProps {
   readonly node: TopologyNode | null
   readonly onClose: () => void
-  readonly onViewTrace: (agentId: string) => void
+  /**
+   * Fired only when the agent has a `latestSessionId`. When absent, the
+   * View-trace button is disabled and renders a tooltip explaining why,
+   * so this handler never sees a null session id. (AAASM-1340)
+   */
+  readonly onViewTrace: (agentId: string, sessionId: string) => void
 }
 
 /**
@@ -159,7 +164,15 @@ export function NodeDetailPanel({ node, onClose, onViewTrace }: NodeDetailPanelP
           type="button"
           className="node-detail-panel__action node-detail-panel__action--primary"
           data-testid="node-detail-view-trace"
-          onClick={() => onViewTrace(node.id)}
+          disabled={!node.latestSessionId}
+          title={
+            node.latestSessionId
+              ? undefined
+              : 'No recent session for this agent yet — run a trace to enable.'
+          }
+          onClick={() => {
+            if (node.latestSessionId) onViewTrace(node.id, node.latestSessionId)
+          }}
         >
           View trace →
         </button>

--- a/dashboard/src/components/trace/TraceDrawer.css
+++ b/dashboard/src/components/trace/TraceDrawer.css
@@ -1,0 +1,73 @@
+/* ============================================================
+   TraceDrawer — shell-level trace overlay (AAASM-1340)
+   ============================================================
+
+   Right-anchored drawer. Slides in from the right via a CSS keyframe
+   on the drawer panel. All colors via design tokens in src/styles.css.
+   ============================================================ */
+
+.trace-drawer-scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(14, 14, 14, 0.4);
+  display: flex;
+  justify-content: flex-end;
+  z-index: 250;
+}
+
+.trace-drawer {
+  width: min(640px, 95vw);
+  height: 100vh;
+  background: var(--paper-2);
+  border-left: 1px solid var(--line);
+  display: flex;
+  flex-direction: column;
+  box-shadow: -12px 0 32px rgba(14, 14, 14, 0.2);
+  animation: trace-drawer-slide-in 200ms ease-out;
+}
+
+@keyframes trace-drawer-slide-in {
+  from { transform: translateX(20px); opacity: 0; }
+  to   { transform: translateX(0);    opacity: 1; }
+}
+
+.trace-drawer__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.trace-drawer__eyebrow {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--ink-4);
+}
+
+.trace-drawer__close {
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 0.125rem 0.4rem;
+  color: var(--ink-2);
+}
+
+.trace-drawer__close:hover {
+  background: var(--paper-3);
+}
+
+.trace-drawer__body {
+  flex: 1;
+  overflow-y: auto;
+  background: var(--paper);
+}
+
+.trace-drawer__loading {
+  padding: 1.5rem;
+  color: var(--ink-4);
+}

--- a/dashboard/src/components/trace/TraceDrawer.test.tsx
+++ b/dashboard/src/components/trace/TraceDrawer.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { TraceDrawer } from './TraceDrawer'
+import { TraceDrawerProvider } from './TraceDrawerProvider'
+import { useTraceDrawer } from './useTraceDrawer'
+
+// Mock the lazy-loaded page so the drawer test doesn't need QueryClient + Router.
+vi.mock('../../pages/TraceViewPage', () => ({
+  TraceViewPage: ({ agentId, sessionId }: { agentId: string; sessionId: string }) => (
+    <div data-testid="trace-view-stub">
+      <span data-testid="trace-view-agent">{agentId}</span>
+      <span data-testid="trace-view-session">{sessionId}</span>
+      <button type="button" data-testid="stub-action">Action</button>
+    </div>
+  ),
+}))
+
+function Opener({ agentId, sessionId, label }: { agentId: string; sessionId: string; label: string }) {
+  const { open } = useTraceDrawer()
+  return (
+    <button type="button" onClick={() => open(agentId, sessionId)}>
+      {label}
+    </button>
+  )
+}
+
+function Harness({ openers }: { openers: Array<{ agentId: string; sessionId: string; label: string }> }) {
+  return (
+    <TraceDrawerProvider>
+      {openers.map(o => (
+        <Opener key={o.label} {...o} />
+      ))}
+      <TraceDrawer />
+    </TraceDrawerProvider>
+  )
+}
+
+async function findTraceView() {
+  return await screen.findByTestId('trace-view-stub')
+}
+
+describe('TraceDrawer', () => {
+  it('is hidden by default and not rendered in the DOM', () => {
+    render(<Harness openers={[{ agentId: 'a1', sessionId: 's1', label: 'open' }]} />)
+    expect(screen.queryByTestId('trace-drawer')).not.toBeInTheDocument()
+  })
+
+  it('opens with the given agentId / sessionId and renders the trace view body', async () => {
+    const user = userEvent.setup()
+    render(<Harness openers={[{ agentId: 'support-bot', sessionId: 'sess-42', label: 'open' }]} />)
+
+    await user.click(screen.getByText('open'))
+
+    expect(await screen.findByTestId('trace-drawer')).toBeInTheDocument()
+    await findTraceView()
+    expect(screen.getByTestId('trace-view-agent')).toHaveTextContent('support-bot')
+    expect(screen.getByTestId('trace-view-session')).toHaveTextContent('sess-42')
+  })
+
+  it('closes when the Esc key is pressed', async () => {
+    const user = userEvent.setup()
+    render(<Harness openers={[{ agentId: 'a', sessionId: 's', label: 'open' }]} />)
+
+    await user.click(screen.getByText('open'))
+    await screen.findByTestId('trace-drawer')
+
+    await user.keyboard('{Escape}')
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('trace-drawer')).not.toBeInTheDocument()
+    })
+  })
+
+  it('closes when the scrim (backdrop) is clicked', async () => {
+    const user = userEvent.setup()
+    render(<Harness openers={[{ agentId: 'a', sessionId: 's', label: 'open' }]} />)
+
+    await user.click(screen.getByText('open'))
+    await screen.findByTestId('trace-drawer')
+
+    await user.click(screen.getByTestId('trace-drawer-scrim'))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('trace-drawer')).not.toBeInTheDocument()
+    })
+  })
+
+  it('does not close when clicking inside the drawer body', async () => {
+    const user = userEvent.setup()
+    render(<Harness openers={[{ agentId: 'a', sessionId: 's', label: 'open' }]} />)
+
+    await user.click(screen.getByText('open'))
+    await findTraceView()
+
+    await user.click(screen.getByTestId('trace-view-stub'))
+    expect(screen.getByTestId('trace-drawer')).toBeInTheDocument()
+  })
+
+  it('closes when the close button is clicked', async () => {
+    const user = userEvent.setup()
+    render(<Harness openers={[{ agentId: 'a', sessionId: 's', label: 'open' }]} />)
+
+    await user.click(screen.getByText('open'))
+    await screen.findByTestId('trace-drawer')
+
+    await user.click(screen.getByTestId('trace-drawer-close'))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('trace-drawer')).not.toBeInTheDocument()
+    })
+  })
+
+  it('focuses the close button when opened (focus trap entry point)', async () => {
+    const user = userEvent.setup()
+    render(<Harness openers={[{ agentId: 'a', sessionId: 's', label: 'open' }]} />)
+
+    await user.click(screen.getByText('open'))
+    await screen.findByTestId('trace-drawer')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('trace-drawer-close')).toHaveFocus()
+    })
+  })
+
+  it('replaces ids when open() is called a second time with different ids', async () => {
+    const user = userEvent.setup()
+    render(
+      <Harness
+        openers={[
+          { agentId: 'agent-a', sessionId: 'sess-a', label: 'open-a' },
+          { agentId: 'agent-b', sessionId: 'sess-b', label: 'open-b' },
+        ]}
+      />,
+    )
+
+    await user.click(screen.getByText('open-a'))
+    await findTraceView()
+    expect(screen.getByTestId('trace-view-agent')).toHaveTextContent('agent-a')
+
+    // Open again with new ids — drawer must update to the new agent/session.
+    await user.click(screen.getByText('open-b'))
+    await waitFor(() => {
+      expect(screen.getByTestId('trace-view-agent')).toHaveTextContent('agent-b')
+    })
+    expect(screen.getByTestId('trace-view-session')).toHaveTextContent('sess-b')
+  })
+
+  it('throws when useTraceDrawer is used outside the provider', () => {
+    // Silence the React error boundary console output for this expected failure.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => render(<Opener agentId="a" sessionId="s" label="x" />)).toThrow(
+      /useTraceDrawer must be used inside <TraceDrawerProvider>/,
+    )
+    spy.mockRestore()
+  })
+})

--- a/dashboard/src/components/trace/TraceDrawer.tsx
+++ b/dashboard/src/components/trace/TraceDrawer.tsx
@@ -1,0 +1,97 @@
+import { Suspense, lazy, useEffect, useRef, type KeyboardEvent } from 'react'
+import { useTraceDrawer } from './useTraceDrawer'
+import './TraceDrawer.css'
+
+const TraceViewPage = lazy(() =>
+  import('../../pages/TraceViewPage').then(m => ({ default: m.TraceViewPage })),
+)
+
+const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+
+/**
+ * Shell-level trace overlay. A single instance is mounted by `<AppShell>`;
+ * any routed page calls `useTraceDrawer().open(agentId, sessionId)` to
+ * surface it.
+ *
+ * - Animates in from the right.
+ * - Esc + backdrop click close.
+ * - Tab cycles focus between focusables inside the drawer.
+ * - TraceViewPage is lazy-loaded so the initial bundle stays slim.
+ */
+export function TraceDrawer() {
+  const { state, close } = useTraceDrawer()
+  const drawerRef = useRef<HTMLDivElement>(null)
+  const closeBtnRef = useRef<HTMLButtonElement>(null)
+  const open = state.agentId !== null && state.sessionId !== null
+
+  useEffect(() => {
+    if (!open) return
+    const handleKey = (e: globalThis.KeyboardEvent) => {
+      if (e.key === 'Escape') close()
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [open, close])
+
+  // Focus the close button when the drawer opens for a new agent/session.
+  useEffect(() => {
+    if (!open) return
+    closeBtnRef.current?.focus()
+  }, [open, state.agentId, state.sessionId])
+
+  if (!open) return null
+
+  const handleFocusTrap = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== 'Tab' || !drawerRef.current) return
+    const focusables = drawerRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+    if (focusables.length === 0) return
+    const first = focusables[0]
+    const last = focusables[focusables.length - 1]
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault()
+      last.focus()
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault()
+      first.focus()
+    }
+  }
+
+  return (
+    <div
+      className="trace-drawer-scrim"
+      data-testid="trace-drawer-scrim"
+      onClick={close}
+    >
+      <div
+        ref={drawerRef}
+        className="trace-drawer"
+        role="dialog"
+        aria-modal
+        aria-label="Agent trace"
+        data-testid="trace-drawer"
+        onClick={e => e.stopPropagation()}
+        onKeyDown={handleFocusTrap}
+      >
+        <header className="trace-drawer__head">
+          <div className="trace-drawer__eyebrow">trace</div>
+          <button
+            ref={closeBtnRef}
+            type="button"
+            className="trace-drawer__close"
+            data-testid="trace-drawer-close"
+            aria-label="Close trace drawer"
+            onClick={close}
+          >
+            ✕
+          </button>
+        </header>
+        <div className="trace-drawer__body" data-testid="trace-drawer-body">
+          <Suspense fallback={<div className="trace-drawer__loading">Loading trace…</div>}>
+            <TraceViewPage agentId={state.agentId!} sessionId={state.sessionId!} />
+          </Suspense>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/components/trace/TraceDrawerContext.ts
+++ b/dashboard/src/components/trace/TraceDrawerContext.ts
@@ -1,0 +1,23 @@
+import { createContext } from 'react'
+
+/**
+ * State + actions exposed by `useTraceDrawer()`. The provider owns the
+ * `open(agentId, sessionId)` and `close()` actions; consumers (topology
+ * node panel, audit log link, etc.) call `open()` to surface the trace
+ * drawer at the shell level.
+ *
+ * Lives in its own module so `TraceDrawerProvider.tsx` only exports a
+ * component (satisfies `react-refresh/only-export-components`).
+ */
+export interface TraceDrawerState {
+  readonly agentId: string | null
+  readonly sessionId: string | null
+}
+
+export interface TraceDrawerContextValue {
+  readonly state: TraceDrawerState
+  open(agentId: string, sessionId: string): void
+  close(): void
+}
+
+export const TraceDrawerContext = createContext<TraceDrawerContextValue | null>(null)

--- a/dashboard/src/components/trace/TraceDrawerProvider.tsx
+++ b/dashboard/src/components/trace/TraceDrawerProvider.tsx
@@ -1,0 +1,33 @@
+import { useCallback, useMemo, useState, type ReactNode } from 'react'
+import {
+  TraceDrawerContext,
+  type TraceDrawerContextValue,
+  type TraceDrawerState,
+} from './TraceDrawerContext'
+
+/**
+ * Mounts the trace-drawer state at the shell level so any routed page
+ * can call `useTraceDrawer().open(agentId, sessionId)` to surface the
+ * trace overlay without leaving its own page.
+ *
+ * AAASM-1340 — paired with `<TraceDrawer />` which subscribes to the
+ * same context and renders the drawer body.
+ */
+export function TraceDrawerProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<TraceDrawerState>({ agentId: null, sessionId: null })
+
+  const open = useCallback((agentId: string, sessionId: string) => {
+    setState({ agentId, sessionId })
+  }, [])
+
+  const close = useCallback(() => {
+    setState({ agentId: null, sessionId: null })
+  }, [])
+
+  const value = useMemo<TraceDrawerContextValue>(
+    () => ({ state, open, close }),
+    [state, open, close],
+  )
+
+  return <TraceDrawerContext.Provider value={value}>{children}</TraceDrawerContext.Provider>
+}

--- a/dashboard/src/components/trace/useTraceDrawer.ts
+++ b/dashboard/src/components/trace/useTraceDrawer.ts
@@ -1,0 +1,16 @@
+import { useContext } from 'react'
+import { TraceDrawerContext, type TraceDrawerContextValue } from './TraceDrawerContext'
+
+/**
+ * Access the trace drawer state + actions from any routed page wrapped
+ * by `<TraceDrawerProvider>` at the shell level (AAASM-1340).
+ *
+ * Throws if used outside the provider — surfaces wiring bugs early.
+ */
+export function useTraceDrawer(): TraceDrawerContextValue {
+  const ctx = useContext(TraceDrawerContext)
+  if (!ctx) {
+    throw new Error('useTraceDrawer must be used inside <TraceDrawerProvider>')
+  }
+  return ctx
+}

--- a/dashboard/src/features/topology/types.ts
+++ b/dashboard/src/features/topology/types.ts
@@ -22,6 +22,12 @@ export interface TopologyNode {
   readonly budgetSpend: number
   readonly budgetLimit: number
   readonly framework?: string
+  /**
+   * Most recent session id for this agent. Used to open the trace drawer
+   * from the node detail panel (AAASM-1340). Optional — the View trace
+   * button is disabled when this is missing.
+   */
+  readonly latestSessionId?: string
 }
 
 export interface TopologyEdge {

--- a/dashboard/src/pages/TopologyPage.test.tsx
+++ b/dashboard/src/pages/TopologyPage.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import type { UseQueryResult } from '@tanstack/react-query'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { TopologyPage } from './TopologyPage'
+import { TraceDrawerProvider } from '../components/trace/TraceDrawerProvider'
 import * as topologyApi from '../features/topology/api'
 import type { TopologyGraph } from '../features/topology/types'
 
@@ -14,7 +15,9 @@ function makeClient() {
 function renderPage() {
   return render(
     <QueryClientProvider client={makeClient()}>
-      <TopologyPage />
+      <TraceDrawerProvider>
+        <TopologyPage />
+      </TraceDrawerProvider>
     </QueryClientProvider>,
   )
 }

--- a/dashboard/src/pages/TopologyPage.tsx
+++ b/dashboard/src/pages/TopologyPage.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { useTopologyQuery } from '../features/topology/api'
 import { TopologyGraph } from '../components/topology/TopologyGraph'
 import { NodeDetailPanel } from '../components/topology/NodeDetailPanel'
+import { useTraceDrawer } from '../components/trace/useTraceDrawer'
 import type { TopologyNode } from '../features/topology/types'
 import './TopologyPage.css'
 
@@ -17,14 +18,15 @@ import './TopologyPage.css'
 export function TopologyPage() {
   const { data, isLoading, isError, refetch } = useTopologyQuery()
   const [selectedNode, setSelectedNode] = useState<TopologyNode | null>(null)
+  const { open: openTraceDrawer } = useTraceDrawer()
   const teamCount = useMemo(() => {
     if (!data) return 0
     return new Set(data.nodes.map(n => n.team)).size
   }, [data])
   const agentCount = data?.nodes.length ?? 0
 
-  const handleViewTrace = () => {
-    // Wires to the shell-level trace drawer in AAASM-1340.
+  const handleViewTrace = (agentId: string, sessionId: string) => {
+    openTraceDrawer(agentId, sessionId)
   }
 
   return (

--- a/dashboard/src/pages/TraceViewPage.tsx
+++ b/dashboard/src/pages/TraceViewPage.tsx
@@ -18,12 +18,24 @@ function applyFilter(events: readonly TraceEvent[], filter: SeverityFilter): Tra
   })
 }
 
+export interface TraceViewPageProps {
+  /** Override URL params — used when rendered inside the trace drawer (AAASM-1340). */
+  readonly agentId?: string
+  readonly sessionId?: string
+}
+
 /**
  * Trace view page — header, status states (loading / error / empty / ready),
  * severity filter, and the trace timeline introduced in AAASM-1067.
+ *
+ * Accepts optional `agentId` / `sessionId` props so the same component can
+ * render at the routed `/agents/:id/trace/:sessionId` URL *or* be mounted
+ * directly inside the shell-level trace drawer with no URL change.
  */
-export function TraceViewPage() {
-  const { id = '', sessionId = '' } = useParams<{ id: string; sessionId: string }>()
+export function TraceViewPage({ agentId, sessionId: sessionIdProp }: TraceViewPageProps = {}) {
+  const params = useParams<{ id: string; sessionId: string }>()
+  const id = agentId ?? params.id ?? ''
+  const sessionId = sessionIdProp ?? params.sessionId ?? ''
   const { data: agent } = useAgentQuery(id)
   const { data, isLoading, isError, refetch } = useTraceQuery(id, sessionId)
   const agentLabel = agent?.name ?? id


### PR DESCRIPTION
## Summary

Implements **AAASM-1340** — clicking *View trace* on a selected topology
node now opens the agent's most recent trace in a shell-level drawer,
without leaving the topology page.

- Adds `latestSessionId?: string` to `TopologyNode`.
- Makes `TraceViewPage` accept optional `agentId` / `sessionId` props so
  the same component renders at `/agents/:id/trace/:sessionId` *or*
  inside the drawer.
- Introduces a shell-level `TraceDrawerProvider` + `useTraceDrawer` hook
  (state lifted to `AppShell`), and a `TraceDrawer` overlay with focus
  trap, Esc and backdrop close, and lazy-loaded `TraceViewPage` inside.
- Wires `NodeDetailPanel`'s *View trace* button to the drawer; the
  button is disabled with an explanatory tooltip when the selected
  agent has no recent session yet.

## Commits (one logical unit each)

| # | Commit | Why |
|---|---|---|
| 1 | `✨ (topology): Add latestSessionId to TopologyNode` | Carries the session id needed to open the trace. |
| 2 | `♻️ (trace): Accept optional agentId / sessionId props on TraceViewPage` | Same component serves the route and the drawer. |
| 3 | `✨ (trace): Add TraceDrawerProvider context + useTraceDrawer hook` | Shell-level state; any page can open the drawer. |
| 4 | `✨ (trace): Add TraceDrawer with focus trap, Esc, backdrop close` | The overlay UI itself. |
| 5 | `✅ (trace): Test TraceDrawer open/close, focus, and id-replace behaviour` | Behaviour coverage. |
| 6 | `🔧 (shell): Wrap AppShell with TraceDrawerProvider + mount TraceDrawer` | One global instance. |
| 7 | `🔧 (topology): Wire NodeDetailPanel View trace to useTraceDrawer` | Closes the loop; covers the disabled-no-session path. |

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — clean (`--max-warnings 0`)
- [x] `pnpm test` — full vitest suite 781/781 green
- [x] New TraceDrawer tests: hidden by default, opens with given ids,
      Esc / scrim / close-button all close, inner clicks do not close,
      focus lands on the close button, re-open with new ids updates
      content, and `useTraceDrawer` outside the provider throws.
- [x] Updated `NodeDetailPanel` tests: new two-arg `onViewTrace`
      signature, disabled-button + tooltip when `latestSessionId` is
      missing.
- [x] Updated `TopologyPage` test: mounts inside `TraceDrawerProvider`
      so `useTraceDrawer` resolves.

Refs Epic AAASM-11, Story AAASM-95.