### PR TITLE
[AAASM-1334] ✨ (dashboard/live-ops): Add pause/resume/terminate actions with optimistic+rollback

### DIFF
--- a/dashboard/src/features/liveOps/OperationRow.css
+++ b/dashboard/src/features/liveOps/OperationRow.css
@@ -10,10 +10,22 @@
 
 .op-row__main {
   display: grid;
-  grid-template-columns: 1.5rem 9rem 12rem 5rem 6rem 4.5rem 1fr;
+  grid-template-columns: 1.5rem 9rem 12rem 5rem 6rem 4.5rem 1fr auto auto;
   align-items: center;
   gap: 12px;
   padding: 6px 12px;
+}
+
+.op-row[data-override] .op-row__main {
+  opacity: 0.7;
+}
+
+.op-row__override {
+  font-style: italic;
+  color: var(--ink-3);
+  font-size: 10px;
+  letter-spacing: 0.2px;
+  white-space: nowrap;
 }
 
 .op-row__main:hover {

--- a/dashboard/src/features/liveOps/OperationRow.test.tsx
+++ b/dashboard/src/features/liveOps/OperationRow.test.tsx
@@ -115,4 +115,36 @@ describe('OperationRow', () => {
     expect(screen.getByText('tool').className).toContain('op-row__tree-kind--tool')
     expect(screen.getByText('result').className).toContain('op-row__tree-kind--result')
   })
+
+  it('hides the row action menu when callbacks are not supplied', () => {
+    render(<OperationRow op={{ ...FIXTURE, callStack: undefined }} />)
+    expect(screen.queryByTestId('row-action-menu')).toBeNull()
+  })
+
+  it('renders the row action menu when all three callbacks are supplied', () => {
+    render(
+      <OperationRow
+        op={{ ...FIXTURE, callStack: undefined }}
+        onPause={() => {}}
+        onResume={() => {}}
+        onTerminate={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('row-action-menu')).toBeInTheDocument()
+  })
+
+  it('reflects override prop on data-override and surfaces an inline hint', () => {
+    render(
+      <OperationRow
+        op={{ ...FIXTURE, callStack: undefined }}
+        override="pausing"
+        onPause={() => {}}
+        onResume={() => {}}
+        onTerminate={() => {}}
+      />,
+    )
+    const row = screen.getByTestId('op-row')
+    expect(row).toHaveAttribute('data-override', 'pausing')
+    expect(screen.getByTestId('op-row-override')).toHaveTextContent('pausing…')
+  })
 })

--- a/dashboard/src/features/liveOps/OperationRow.tsx
+++ b/dashboard/src/features/liveOps/OperationRow.tsx
@@ -1,11 +1,22 @@
 import { useId, useState } from 'react'
-import type { CallStackNode, LiveOperation, OperationStatus } from './types'
+import { RowActionMenu } from './RowActionMenu'
+import type {
+  CallStackNode,
+  LiveOperation,
+  OperationOverride,
+  OperationStatus,
+} from './types'
 import './OperationRow.css'
 
 interface OperationRowProps {
   op: LiveOperation
   /** Initial expanded state (uncontrolled). Stories + tests use this. */
   defaultExpanded?: boolean
+  /** Pending row-action; renders an "…ing" hint next to the chip. */
+  override?: OperationOverride
+  onPause?: () => void
+  onResume?: () => void
+  onTerminate?: () => void
 }
 
 const STATUS_LABEL: Record<OperationStatus, string> = {
@@ -13,6 +24,12 @@ const STATUS_LABEL: Record<OperationStatus, string> = {
   pending: 'PENDING',
   blocked: 'BLOCKED',
   completing: 'COMPLETING',
+}
+
+const OVERRIDE_LABEL: Record<OperationOverride, string> = {
+  pausing: 'pausing…',
+  resuming: 'resuming…',
+  terminating: 'terminating…',
 }
 
 function formatStartedAt(iso: string): string {
@@ -37,10 +54,19 @@ function formatLatency(ms: number): string {
  * the row, per AAASM-1282 implementation rule #4 (no drawer, no
  * route change). Row actions land in AAASM-1334.
  */
-export function OperationRow({ op, defaultExpanded = false }: OperationRowProps) {
+export function OperationRow({
+  op,
+  defaultExpanded = false,
+  override,
+  onPause,
+  onResume,
+  onTerminate,
+}: OperationRowProps) {
   const [expanded, setExpanded] = useState(defaultExpanded)
   const treeId = useId()
   const canExpand = (op.callStack?.length ?? 0) > 0
+  const showActions =
+    onPause !== undefined && onResume !== undefined && onTerminate !== undefined
 
   return (
     <div
@@ -49,6 +75,7 @@ export function OperationRow({ op, defaultExpanded = false }: OperationRowProps)
       data-op-id={op.id}
       data-status={op.status}
       data-expanded={expanded ? 'true' : 'false'}
+      data-override={override}
     >
       <div className="op-row__main">
         <button
@@ -75,6 +102,20 @@ export function OperationRow({ op, defaultExpanded = false }: OperationRowProps)
         <span className="op-row__resource" title={op.resource}>
           {op.resource}
         </span>
+        {override && (
+          <span className="op-row__override" data-testid="op-row-override">
+            {OVERRIDE_LABEL[override]}
+          </span>
+        )}
+        {showActions && (
+          <RowActionMenu
+            op={op}
+            override={override}
+            onPause={onPause}
+            onResume={onResume}
+            onTerminate={onTerminate}
+          />
+        )}
       </div>
       {expanded && canExpand && (
         <CallStackTree id={treeId} nodes={op.callStack ?? []} />

--- a/dashboard/src/features/liveOps/RowActionMenu.css
+++ b/dashboard/src/features/liveOps/RowActionMenu.css
@@ -1,0 +1,87 @@
+.row-actions {
+  position: relative;
+  justify-self: end;
+}
+
+.row-actions__trigger {
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 0;
+  width: 1.5rem;
+  height: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: var(--ink-3);
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 1;
+  border-radius: 3px;
+}
+
+.row-actions__trigger:hover {
+  color: var(--ink);
+  background: var(--paper-2);
+}
+
+.row-actions__trigger:focus-visible {
+  outline: 2px solid var(--info);
+  outline-offset: 2px;
+}
+
+.row-actions__menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  z-index: 10;
+  list-style: none;
+  margin: 0;
+  padding: 4px;
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  min-width: 9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.row-actions__item {
+  appearance: none;
+  background: transparent;
+  border: none;
+  width: 100%;
+  padding: 6px 10px;
+  text-align: left;
+  font-family: 'JetBrains Mono', ui-monospace, monospace;
+  font-size: 11px;
+  color: var(--ink);
+  cursor: pointer;
+  border-radius: 2px;
+}
+
+.row-actions__item:hover:not([disabled]) {
+  background: var(--paper-2);
+}
+
+.row-actions__item:focus-visible {
+  outline: 2px solid var(--info);
+  outline-offset: -1px;
+}
+
+.row-actions__item[disabled] {
+  color: var(--ink-3);
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.row-actions__item--danger {
+  color: var(--danger);
+}
+
+.row-actions__item--danger:hover:not([disabled]) {
+  background: var(--danger-bg);
+}

--- a/dashboard/src/features/liveOps/RowActionMenu.stories.tsx
+++ b/dashboard/src/features/liveOps/RowActionMenu.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useEffect } from 'react'
+import { RowActionMenu } from './RowActionMenu'
+import type { LiveOperation } from './types'
+
+function op(status: LiveOperation['status']): LiveOperation {
+  return {
+    id: 'op-1',
+    agent: 'support-agent',
+    opType: 'write',
+    resource: 'pg.users',
+    status,
+    startedAt: '2026-05-14T01:00:00Z',
+    latencyMs: 84,
+  }
+}
+
+const meta: Meta<typeof RowActionMenu> = {
+  title: 'LiveOps/RowActionMenu',
+  component: RowActionMenu,
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          padding: 24,
+          background: 'var(--paper)',
+          display: 'flex',
+          justifyContent: 'flex-end',
+          width: 320,
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    onPause: () => console.log('pause'),
+    onResume: () => console.log('resume'),
+    onTerminate: () => console.log('terminate'),
+  },
+}
+export default meta
+
+type Story = StoryObj<typeof RowActionMenu>
+
+/** Running op — Pause + Terminate enabled, Resume disabled. */
+export const Default: Story = {
+  args: { op: op('running') },
+}
+
+/** Blocked op — Resume + Terminate enabled, Pause disabled. */
+export const BlockedOp: Story = {
+  args: { op: op('blocked') },
+}
+
+/** Pending op — both Pause and Resume disabled (only Terminate fires). */
+export const PendingOp: Story = {
+  args: { op: op('pending') },
+}
+
+/** Override set — the whole menu is disabled while the call is in flight. */
+export const Pausing: Story = {
+  args: { op: op('running'), override: 'pausing' },
+}
+
+/**
+ * Auto-clicks the trigger on mount so the popover renders for visual
+ * comparison without needing the Storybook user to interact.
+ */
+function OpenedMenuStory(args: React.ComponentProps<typeof RowActionMenu>) {
+  useEffect(() => {
+    const trigger = document.querySelector<HTMLButtonElement>(
+      '[data-testid="row-action-trigger"]',
+    )
+    trigger?.click()
+  }, [])
+  return <RowActionMenu {...args} />
+}
+
+export const MenuOpen: Story = {
+  args: { op: op('running') },
+  render: (args) => <OpenedMenuStory {...args} />,
+}

--- a/dashboard/src/features/liveOps/RowActionMenu.test.tsx
+++ b/dashboard/src/features/liveOps/RowActionMenu.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { RowActionMenu } from './RowActionMenu'
+import type { LiveOperation, OperationOverride, OperationStatus } from './types'
+
+function op(status: OperationStatus = 'running'): LiveOperation {
+  return {
+    id: 'op-1',
+    agent: 'support-agent',
+    opType: 'write',
+    resource: 'pg.users',
+    status,
+    startedAt: '2026-05-14T01:00:00Z',
+    latencyMs: 42,
+  }
+}
+
+function setup(overrides?: {
+  status?: OperationStatus
+  override?: OperationOverride
+}) {
+  const onPause = vi.fn()
+  const onResume = vi.fn()
+  const onTerminate = vi.fn()
+  render(
+    <RowActionMenu
+      op={op(overrides?.status)}
+      override={overrides?.override}
+      onPause={onPause}
+      onResume={onResume}
+      onTerminate={onTerminate}
+    />,
+  )
+  return { onPause, onResume, onTerminate, user: userEvent.setup() }
+}
+
+describe('RowActionMenu', () => {
+  it('hides the menu until the kebab is clicked', async () => {
+    const { user } = setup()
+    expect(screen.queryByTestId('row-action-menu-list')).toBeNull()
+    await user.click(screen.getByTestId('row-action-trigger'))
+    expect(screen.getByTestId('row-action-menu-list')).toBeInTheDocument()
+  })
+
+  it('Pause enabled and Resume disabled when status=running', async () => {
+    const { user } = setup({ status: 'running' })
+    await user.click(screen.getByTestId('row-action-trigger'))
+    expect(screen.getByTestId('row-action-pause')).not.toBeDisabled()
+    expect(screen.getByTestId('row-action-resume')).toBeDisabled()
+    expect(screen.getByTestId('row-action-terminate')).not.toBeDisabled()
+  })
+
+  it('Resume enabled and Pause disabled when status=blocked', async () => {
+    const { user } = setup({ status: 'blocked' })
+    await user.click(screen.getByTestId('row-action-trigger'))
+    expect(screen.getByTestId('row-action-pause')).toBeDisabled()
+    expect(screen.getByTestId('row-action-resume')).not.toBeDisabled()
+  })
+
+  it.each(['pending', 'completing'] as const)(
+    'Pause and Resume both disabled when status=%s',
+    async (status) => {
+      const { user } = setup({ status })
+      await user.click(screen.getByTestId('row-action-trigger'))
+      expect(screen.getByTestId('row-action-pause')).toBeDisabled()
+      expect(screen.getByTestId('row-action-resume')).toBeDisabled()
+    },
+  )
+
+  it('all items disabled while override is set', async () => {
+    const { user } = setup({ status: 'running', override: 'pausing' })
+    await user.click(screen.getByTestId('row-action-trigger'))
+    expect(screen.getByTestId('row-action-pause')).toBeDisabled()
+    expect(screen.getByTestId('row-action-resume')).toBeDisabled()
+    expect(screen.getByTestId('row-action-terminate')).toBeDisabled()
+  })
+
+  it('clicking Pause fires onPause and closes the menu', async () => {
+    const { onPause, user } = setup({ status: 'running' })
+    await user.click(screen.getByTestId('row-action-trigger'))
+    await user.click(screen.getByTestId('row-action-pause'))
+    expect(onPause).toHaveBeenCalledTimes(1)
+    expect(screen.queryByTestId('row-action-menu-list')).toBeNull()
+  })
+
+  it('clicking Resume fires onResume', async () => {
+    const { onResume, user } = setup({ status: 'blocked' })
+    await user.click(screen.getByTestId('row-action-trigger'))
+    await user.click(screen.getByTestId('row-action-resume'))
+    expect(onResume).toHaveBeenCalledTimes(1)
+  })
+
+  it('clicking Terminate fires onTerminate', async () => {
+    const { onTerminate, user } = setup({ status: 'running' })
+    await user.click(screen.getByTestId('row-action-trigger'))
+    await user.click(screen.getByTestId('row-action-terminate'))
+    expect(onTerminate).toHaveBeenCalledTimes(1)
+  })
+
+  it('Escape closes the menu', async () => {
+    const { user } = setup()
+    await user.click(screen.getByTestId('row-action-trigger'))
+    expect(screen.getByTestId('row-action-menu-list')).toBeInTheDocument()
+    await user.keyboard('{Escape}')
+    expect(screen.queryByTestId('row-action-menu-list')).toBeNull()
+  })
+
+  it('outside click closes the menu', async () => {
+    const { user } = setup()
+    await user.click(screen.getByTestId('row-action-trigger'))
+    expect(screen.getByTestId('row-action-menu-list')).toBeInTheDocument()
+    await user.click(document.body)
+    expect(screen.queryByTestId('row-action-menu-list')).toBeNull()
+  })
+})

--- a/dashboard/src/features/liveOps/RowActionMenu.test.tsx
+++ b/dashboard/src/features/liveOps/RowActionMenu.test.tsx
@@ -91,11 +91,30 @@ describe('RowActionMenu', () => {
     expect(onResume).toHaveBeenCalledTimes(1)
   })
 
-  it('clicking Terminate fires onTerminate', async () => {
+  it('clicking Terminate opens the confirmation dialog without firing onTerminate', async () => {
     const { onTerminate, user } = setup({ status: 'running' })
     await user.click(screen.getByTestId('row-action-trigger'))
     await user.click(screen.getByTestId('row-action-terminate'))
+    expect(onTerminate).not.toHaveBeenCalled()
+    expect(screen.getByTestId('confirm-dialog')).toBeInTheDocument()
+  })
+
+  it('confirming the terminate dialog fires onTerminate and closes the dialog', async () => {
+    const { onTerminate, user } = setup({ status: 'running' })
+    await user.click(screen.getByTestId('row-action-trigger'))
+    await user.click(screen.getByTestId('row-action-terminate'))
+    await user.click(screen.getByTestId('confirm-dialog-confirm'))
     expect(onTerminate).toHaveBeenCalledTimes(1)
+    expect(screen.queryByTestId('confirm-dialog')).toBeNull()
+  })
+
+  it('cancelling the terminate dialog does not fire onTerminate', async () => {
+    const { onTerminate, user } = setup({ status: 'running' })
+    await user.click(screen.getByTestId('row-action-trigger'))
+    await user.click(screen.getByTestId('row-action-terminate'))
+    await user.click(screen.getByTestId('confirm-dialog-cancel'))
+    expect(onTerminate).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('confirm-dialog')).toBeNull()
   })
 
   it('Escape closes the menu', async () => {

--- a/dashboard/src/features/liveOps/RowActionMenu.tsx
+++ b/dashboard/src/features/liveOps/RowActionMenu.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useRef, useState } from 'react'
+import { ConfirmDialog } from '../../components/ConfirmDialog'
 import type { LiveOperation, OperationOverride } from './types'
 import './RowActionMenu.css'
 
@@ -28,6 +29,7 @@ export function RowActionMenu({
   onTerminate,
 }: RowActionMenuProps) {
   const [open, setOpen] = useState(false)
+  const [confirmingTerminate, setConfirmingTerminate] = useState(false)
   const menuId = useId()
   const rootRef = useRef<HTMLDivElement>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
@@ -61,6 +63,16 @@ export function RowActionMenu({
   function dispatch(action: () => void) {
     setOpen(false)
     action()
+  }
+
+  function handleTerminateClick() {
+    setOpen(false)
+    setConfirmingTerminate(true)
+  }
+
+  function handleConfirmTerminate() {
+    setConfirmingTerminate(false)
+    onTerminate()
   }
 
   return (
@@ -116,13 +128,27 @@ export function RowActionMenu({
               className="row-actions__item row-actions__item--danger"
               disabled={terminateDisabled}
               data-testid="row-action-terminate"
-              onClick={() => dispatch(onTerminate)}
+              onClick={handleTerminateClick}
             >
               Terminate
             </button>
           </li>
         </ul>
       )}
+      <ConfirmDialog
+        open={confirmingTerminate}
+        title="Terminate operation?"
+        body={
+          <p>
+            This will end the operation and free its slot. The agent will see a 499.
+            This cannot be undone.
+          </p>
+        }
+        confirmLabel="Terminate"
+        confirmVariant="danger"
+        onConfirm={handleConfirmTerminate}
+        onCancel={() => setConfirmingTerminate(false)}
+      />
     </div>
   )
 }

--- a/dashboard/src/features/liveOps/RowActionMenu.tsx
+++ b/dashboard/src/features/liveOps/RowActionMenu.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useId, useRef, useState } from 'react'
+import type { LiveOperation, OperationOverride } from './types'
+import './RowActionMenu.css'
+
+interface RowActionMenuProps {
+  op: LiveOperation
+  /** Pending action in flight; disables the whole menu while set. */
+  override?: OperationOverride
+  onPause: () => void
+  onResume: () => void
+  onTerminate: () => void
+}
+
+/**
+ * Kebab-popover row action menu mounted in the Live Ops event-stream row
+ * (AAASM-1334). Exposes pause / resume / terminate. Items disable
+ * themselves based on the operation's current status — pause only on
+ * `running`, resume only on `blocked` — and the whole menu disables
+ * while a previously-clicked action is still in flight (`override`).
+ *
+ * Terminate confirmation is layered on top by the consumer (C4).
+ */
+export function RowActionMenu({
+  op,
+  override,
+  onPause,
+  onResume,
+  onTerminate,
+}: RowActionMenuProps) {
+  const [open, setOpen] = useState(false)
+  const menuId = useId()
+  const rootRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+
+  const pauseDisabled = op.status !== 'running' || override !== undefined
+  const resumeDisabled = op.status !== 'blocked' || override !== undefined
+  const terminateDisabled = override !== undefined
+
+  useEffect(() => {
+    if (!open) return
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        setOpen(false)
+        triggerRef.current?.focus()
+      }
+    }
+    function handleClick(e: MouseEvent) {
+      if (!rootRef.current?.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('keydown', handleKey)
+    document.addEventListener('mousedown', handleClick)
+    return () => {
+      document.removeEventListener('keydown', handleKey)
+      document.removeEventListener('mousedown', handleClick)
+    }
+  }, [open])
+
+  function dispatch(action: () => void) {
+    setOpen(false)
+    action()
+  }
+
+  return (
+    <div className="row-actions" ref={rootRef} data-testid="row-action-menu">
+      <button
+        ref={triggerRef}
+        type="button"
+        className="row-actions__trigger"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        aria-label={`Actions for operation ${op.id}`}
+        data-testid="row-action-trigger"
+        onClick={() => setOpen((v) => !v)}
+      >
+        ⋮
+      </button>
+      {open && (
+        <ul
+          id={menuId}
+          className="row-actions__menu"
+          role="menu"
+          data-testid="row-action-menu-list"
+        >
+          <li role="none">
+            <button
+              type="button"
+              role="menuitem"
+              className="row-actions__item"
+              disabled={pauseDisabled}
+              data-testid="row-action-pause"
+              onClick={() => dispatch(onPause)}
+            >
+              Pause
+            </button>
+          </li>
+          <li role="none">
+            <button
+              type="button"
+              role="menuitem"
+              className="row-actions__item"
+              disabled={resumeDisabled}
+              data-testid="row-action-resume"
+              onClick={() => dispatch(onResume)}
+            >
+              Resume
+            </button>
+          </li>
+          <li role="none">
+            <button
+              type="button"
+              role="menuitem"
+              className="row-actions__item row-actions__item--danger"
+              disabled={terminateDisabled}
+              data-testid="row-action-terminate"
+              onClick={() => dispatch(onTerminate)}
+            >
+              Terminate
+            </button>
+          </li>
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/features/liveOps/actions.test.ts
+++ b/dashboard/src/features/liveOps/actions.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { pauseOp, resumeOp, terminateOp } from './actions'
+
+const fetchSpy = vi.fn()
+const originalFetch = globalThis.fetch
+const originalLocalStorage = globalThis.localStorage
+
+function setToken(token: string | null) {
+  const store: Record<string, string> = {}
+  if (token !== null) store.aa_token = token
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (k: string) => store[k] ?? null,
+      setItem: (k: string, v: string) => {
+        store[k] = v
+      },
+      removeItem: (k: string) => {
+        delete store[k]
+      },
+      clear: () => {
+        for (const k of Object.keys(store)) delete store[k]
+      },
+      length: 0,
+      key: () => null,
+    },
+  })
+}
+
+function okResponse(): Response {
+  return new Response(null, { status: 204 })
+}
+
+function errResponse(status: number, body = ''): Response {
+  return new Response(body, { status })
+}
+
+describe('liveOps/actions', () => {
+  beforeEach(() => {
+    fetchSpy.mockReset()
+    globalThis.fetch = fetchSpy as unknown as typeof fetch
+    setToken(null)
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    if (originalLocalStorage) {
+      Object.defineProperty(globalThis, 'localStorage', {
+        configurable: true,
+        value: originalLocalStorage,
+      })
+    }
+  })
+
+  it.each([
+    ['pauseOp', pauseOp, 'pause'],
+    ['resumeOp', resumeOp, 'resume'],
+    ['terminateOp', terminateOp, 'terminate'],
+  ] as const)(
+    '%s POSTs to /api/v1/ops/:id/%s',
+    async (_name, fn, action) => {
+      fetchSpy.mockResolvedValue(okResponse())
+      await fn('op-123')
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      const [url, init] = fetchSpy.mock.calls[0]
+      expect(url).toBe(`/api/v1/ops/op-123/${action}`)
+      expect(init?.method).toBe('POST')
+    },
+  )
+
+  it('url-encodes the op id', async () => {
+    fetchSpy.mockResolvedValue(okResponse())
+    await pauseOp('op/with weird:chars')
+    expect(fetchSpy.mock.calls[0][0]).toBe(
+      '/api/v1/ops/op%2Fwith%20weird%3Achars/pause',
+    )
+  })
+
+  it('attaches Bearer token from localStorage', async () => {
+    setToken('jwt-abc')
+    fetchSpy.mockResolvedValue(okResponse())
+    await resumeOp('op-1')
+    const headers = fetchSpy.mock.calls[0][1].headers
+    expect(headers.Authorization).toBe('Bearer jwt-abc')
+  })
+
+  it('omits Authorization when no token is stored', async () => {
+    fetchSpy.mockResolvedValue(okResponse())
+    await resumeOp('op-1')
+    const headers = fetchSpy.mock.calls[0][1].headers
+    expect(headers.Authorization).toBeUndefined()
+  })
+
+  it('rejects with status code on 5xx', async () => {
+    fetchSpy.mockResolvedValue(errResponse(500))
+    await expect(pauseOp('op-1')).rejects.toThrow(/500/)
+  })
+
+  it('includes server body text in 4xx errors', async () => {
+    fetchSpy.mockResolvedValue(errResponse(409, 'op already terminated'))
+    await expect(terminateOp('op-1')).rejects.toThrow(/op already terminated/)
+  })
+})

--- a/dashboard/src/features/liveOps/actions.ts
+++ b/dashboard/src/features/liveOps/actions.ts
@@ -1,0 +1,51 @@
+/**
+ * REST helpers for the Live Ops row-action menu (AAASM-1334).
+ *
+ * The gateway does not yet expose per-op `pause` / `resume` / `terminate`
+ * endpoints — they will be added under a separate sub-ticket of
+ * AAASM-1282. Until then these helpers post against the conventional
+ * paths and surface any 4xx/5xx so the LiveOpsPage rollback path can
+ * fire on a real failure.
+ *
+ * The helpers use raw `fetch` instead of the openapi-fetch client
+ * because the paths are not yet in the generated schema. Auth header
+ * mirrors `api/client.ts` — pulls the JWT from `localStorage`.
+ */
+
+type OpAction = 'pause' | 'resume' | 'terminate'
+
+function buildUrl(id: string, action: OpAction): string {
+  const base = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? ''
+  return `${base}/api/v1/ops/${encodeURIComponent(id)}/${action}`
+}
+
+function authHeader(): Record<string, string> {
+  if (typeof localStorage === 'undefined') return {}
+  const token = localStorage.getItem('aa_token')
+  return token ? { Authorization: `Bearer ${token}` } : {}
+}
+
+async function postOpAction(id: string, action: OpAction): Promise<void> {
+  const response = await fetch(buildUrl(id, action), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeader() },
+  })
+  if (!response.ok) {
+    const body = await response.text().catch(() => '')
+    throw new Error(
+      `Failed to ${action} op ${id}: ${response.status}${body ? ` — ${body}` : ''}`,
+    )
+  }
+}
+
+export function pauseOp(id: string): Promise<void> {
+  return postOpAction(id, 'pause')
+}
+
+export function resumeOp(id: string): Promise<void> {
+  return postOpAction(id, 'resume')
+}
+
+export function terminateOp(id: string): Promise<void> {
+  return postOpAction(id, 'terminate')
+}

--- a/dashboard/src/features/liveOps/types.ts
+++ b/dashboard/src/features/liveOps/types.ts
@@ -75,3 +75,17 @@ export const EMPTY_FILTERS: LiveOpsFilters = {
   opType: null,
   status: null,
 }
+
+/**
+ * Pending row-action intent applied optimistically to a single
+ * operation while its REST call is in flight. The override is
+ * cleared either when the next matching WS event arrives or when
+ * the REST call rejects (rollback).
+ */
+export type OperationOverride = 'pausing' | 'resuming' | 'terminating'
+
+/**
+ * Map of `LiveOperation.id` → pending action. Empty map means no
+ * row actions are in flight.
+ */
+export type OperationOverrides = ReadonlyMap<string, OperationOverride>

--- a/dashboard/src/pages/LiveOpsPage.actions.test.tsx
+++ b/dashboard/src/pages/LiveOpsPage.actions.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ToastProvider } from '../components/ToastProvider'
+import { useAgentsQuery } from '../features/agents/api'
+import { useTeamsQuery } from '../features/analytics/useTeamsQuery'
+import * as actions from '../features/liveOps/actions'
+import { useLiveOpsStream } from '../features/liveOps/useLiveOpsStream'
+import type { LiveOperation } from '../features/liveOps/types'
+import { LiveOpsPage } from './LiveOpsPage'
+
+vi.mock('../features/agents/api', () => ({ useAgentsQuery: vi.fn() }))
+vi.mock('../features/analytics/useTeamsQuery', () => ({ useTeamsQuery: vi.fn() }))
+vi.mock('../features/liveOps/useLiveOpsStream', () => ({ useLiveOpsStream: vi.fn() }))
+vi.mock('../features/liveOps/actions', () => ({
+  pauseOp: vi.fn(),
+  resumeOp: vi.fn(),
+  terminateOp: vi.fn(),
+}))
+
+function makeOp(id: string, overrides: Partial<LiveOperation> = {}): LiveOperation {
+  return {
+    id,
+    agent: 'support-agent',
+    opType: 'read',
+    resource: 'gmail.send',
+    status: 'running',
+    startedAt: '2026-05-13T14:23:01Z',
+    latencyMs: 100,
+    ...overrides,
+  }
+}
+
+function mockStream(ops: LiveOperation[]) {
+  vi.mocked(useLiveOpsStream).mockReturnValue({
+    ops,
+    status: 'connected',
+    reconnect: vi.fn(),
+  })
+}
+
+function renderPage() {
+  return render(
+    <ToastProvider>
+      <LiveOpsPage />
+    </ToastProvider>,
+  )
+}
+
+describe('LiveOpsPage row actions', () => {
+  beforeEach(() => {
+    vi.mocked(useAgentsQuery).mockReturnValue({
+      data: [],
+    } as unknown as ReturnType<typeof useAgentsQuery>)
+    vi.mocked(useTeamsQuery).mockReturnValue({
+      data: [],
+    } as unknown as ReturnType<typeof useTeamsQuery>)
+    vi.mocked(actions.pauseOp).mockReset()
+    vi.mocked(actions.resumeOp).mockReset()
+    vi.mocked(actions.terminateOp).mockReset()
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  it('applies the pausing override optimistically and clears it once WS reports blocked', async () => {
+    const user = userEvent.setup()
+    vi.mocked(actions.pauseOp).mockResolvedValue()
+    mockStream([makeOp('op-1', { status: 'running' })])
+    const { rerender } = renderPage()
+
+    await user.click(screen.getByTestId('row-action-trigger'))
+    await user.click(screen.getByTestId('row-action-pause'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('op-row')).toHaveAttribute(
+        'data-override',
+        'pausing',
+      )
+    })
+    expect(actions.pauseOp).toHaveBeenCalledWith('op-1')
+
+    mockStream([makeOp('op-1', { status: 'blocked' })])
+    rerender(
+      <ToastProvider>
+        <LiveOpsPage />
+      </ToastProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('op-row')).not.toHaveAttribute('data-override')
+    })
+  })
+
+  it('clears the override and toasts an error when the action call rejects', async () => {
+    const user = userEvent.setup()
+    vi.mocked(actions.pauseOp).mockRejectedValue(new Error('gateway 500'))
+    mockStream([makeOp('op-1', { status: 'running' })])
+    renderPage()
+
+    await user.click(screen.getByTestId('row-action-trigger'))
+    await user.click(screen.getByTestId('row-action-pause'))
+
+    await waitFor(() => {
+      const toast = screen.getByTestId('toast')
+      expect(toast).toHaveTextContent(/Failed to pause op op-1/i)
+      expect(toast).toHaveTextContent(/gateway 500/)
+      expect(toast).toHaveAttribute('data-variant', 'error')
+    })
+    expect(screen.getByTestId('op-row')).not.toHaveAttribute('data-override')
+  })
+
+  it('terminate fires through the confirmation dialog', async () => {
+    const user = userEvent.setup()
+    vi.mocked(actions.terminateOp).mockResolvedValue()
+    mockStream([makeOp('op-1', { status: 'running' })])
+    renderPage()
+
+    await user.click(screen.getByTestId('row-action-trigger'))
+    await user.click(screen.getByTestId('row-action-terminate'))
+    expect(actions.terminateOp).not.toHaveBeenCalled()
+
+    await user.click(screen.getByTestId('confirm-dialog-confirm'))
+    await waitFor(() => {
+      expect(actions.terminateOp).toHaveBeenCalledWith('op-1')
+    })
+    expect(screen.getByTestId('op-row')).toHaveAttribute(
+      'data-override',
+      'terminating',
+    )
+  })
+
+  it('resume calls resumeOp from a blocked row', async () => {
+    const user = userEvent.setup()
+    vi.mocked(actions.resumeOp).mockResolvedValue()
+    mockStream([makeOp('op-1', { status: 'blocked' })])
+    renderPage()
+
+    await user.click(screen.getByTestId('row-action-trigger'))
+    await user.click(screen.getByTestId('row-action-resume'))
+
+    await waitFor(() => {
+      expect(actions.resumeOp).toHaveBeenCalledWith('op-1')
+    })
+    expect(screen.getByTestId('op-row')).toHaveAttribute(
+      'data-override',
+      'resuming',
+    )
+  })
+})

--- a/dashboard/src/pages/LiveOpsPage.test.tsx
+++ b/dashboard/src/pages/LiveOpsPage.test.tsx
@@ -1,11 +1,17 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type { ReactElement } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ToastProvider } from '../components/ToastProvider'
 import { useAgentsQuery } from '../features/agents/api'
 import { useTeamsQuery } from '../features/analytics/useTeamsQuery'
 import { useLiveOpsStream } from '../features/liveOps/useLiveOpsStream'
 import type { LiveOperation } from '../features/liveOps/types'
 import { LiveOpsPage } from './LiveOpsPage'
+
+function renderWithProviders(ui: ReactElement) {
+  return render(<ToastProvider>{ui}</ToastProvider>)
+}
 
 vi.mock('../features/agents/api', () => ({
   useAgentsQuery: vi.fn(),
@@ -75,7 +81,7 @@ describe('LiveOpsPage', () => {
   })
 
   it('renders the page header and all three zones', () => {
-    render(<LiveOpsPage />)
+    renderWithProviders(<LiveOpsPage />)
     expect(
       screen.getByRole('heading', { name: /live operations/i }),
     ).toBeInTheDocument()
@@ -85,20 +91,20 @@ describe('LiveOpsPage', () => {
   })
 
   it('mounts FilterBar and AutoScrollToggle inside the stream zone', () => {
-    render(<LiveOpsPage />)
+    renderWithProviders(<LiveOpsPage />)
     expect(screen.getByTestId('live-ops-filter-bar')).toBeInTheDocument()
     expect(screen.getByTestId('auto-scroll-toggle')).toBeInTheDocument()
   })
 
   it('renders an OperationRow per streamed op', () => {
     mockStream({ ops: [makeOp('op-1'), makeOp('op-2')] })
-    render(<LiveOpsPage />)
+    renderWithProviders(<LiveOpsPage />)
     expect(screen.getAllByTestId('op-row')).toHaveLength(2)
   })
 
   it('shows the reconnecting strip when hook reports reconnecting', () => {
     mockStream({ status: 'reconnecting' })
-    render(<LiveOpsPage />)
+    renderWithProviders(<LiveOpsPage />)
     expect(screen.getByTestId('live-ops-reconnecting')).toBeInTheDocument()
     expect(screen.queryByTestId('error-state')).toBeNull()
   })
@@ -107,7 +113,7 @@ describe('LiveOpsPage', () => {
     const user = userEvent.setup()
     const reconnect = vi.fn()
     mockStream({ status: 'error', reconnect })
-    render(<LiveOpsPage />)
+    renderWithProviders(<LiveOpsPage />)
     expect(screen.getByTestId('error-state')).toBeInTheDocument()
     await user.click(screen.getByRole('button', { name: /reconnect/i }))
     expect(reconnect).toHaveBeenCalledTimes(1)
@@ -116,7 +122,7 @@ describe('LiveOpsPage', () => {
   it('pauses the displayed list on toggle-off, counts new ops, and flushes on click', async () => {
     const user = userEvent.setup()
     mockStream({ ops: [makeOp('op-1')] })
-    const { rerender } = render(<LiveOpsPage />)
+    const { rerender } = renderWithProviders(<LiveOpsPage />)
     expect(screen.getAllByTestId('op-row')).toHaveLength(1)
 
     // Toggle auto-scroll off — snapshots the currently visible ids.
@@ -124,7 +130,11 @@ describe('LiveOpsPage', () => {
 
     // New op streams in; rendered list stays frozen at 1, pill shows backlog.
     mockStream({ ops: [makeOp('op-2'), makeOp('op-1')] })
-    rerender(<LiveOpsPage />)
+    rerender(
+      <ToastProvider>
+        <LiveOpsPage />
+      </ToastProvider>,
+    )
     expect(screen.getAllByTestId('op-row')).toHaveLength(1)
     expect(screen.getByTestId('auto-scroll-flush')).toHaveTextContent(
       '1 new op — flush',
@@ -139,7 +149,7 @@ describe('LiveOpsPage', () => {
   it('toggling auto-scroll back on clears the frozen snapshot', async () => {
     const user = userEvent.setup()
     mockStream({ ops: [makeOp('op-1')] })
-    render(<LiveOpsPage />)
+    renderWithProviders(<LiveOpsPage />)
 
     // Off → on.
     await user.click(screen.getByTestId('auto-scroll-toggle-input'))

--- a/dashboard/src/pages/LiveOpsPage.tsx
+++ b/dashboard/src/pages/LiveOpsPage.tsx
@@ -1,7 +1,9 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { useToast } from '../components/Toast'
 import { ErrorState } from '../components/states'
 import { useAgentsQuery } from '../features/agents/api'
 import { useTeamsQuery } from '../features/analytics/useTeamsQuery'
+import { pauseOp, resumeOp, terminateOp } from '../features/liveOps/actions'
 import { applyFilters } from '../features/liveOps/applyFilters'
 import { ApprovalPool } from '../features/liveOps/ApprovalPool'
 import { AutoScrollToggle } from '../features/liveOps/AutoScrollToggle'
@@ -9,17 +11,79 @@ import { FilterBar, type FilterOption } from '../features/liveOps/FilterBar'
 import { OperationRow } from '../features/liveOps/OperationRow'
 import { PipelineCanvas } from '../features/liveOps/PipelineCanvas'
 import { useLiveOpsStream } from '../features/liveOps/useLiveOpsStream'
-import { EMPTY_FILTERS, type LiveOpsFilters } from '../features/liveOps/types'
+import {
+  EMPTY_FILTERS,
+  type LiveOpsFilters,
+  type OperationOverride,
+  type OperationStatus,
+} from '../features/liveOps/types'
 import './LiveOpsPage.css'
+
+const OVERRIDE_VERB: Record<OperationOverride, string> = {
+  pausing: 'pause',
+  resuming: 'resume',
+  terminating: 'terminate',
+}
+
+/**
+ * Returns true when the WS-reported `status` reflects the result the
+ * optimistic `intent` was working toward. The override can be cleared
+ * once the wire confirms the action took effect.
+ */
+function matchesIntent(status: OperationStatus, intent: OperationOverride): boolean {
+  if (intent === 'pausing') return status === 'blocked'
+  if (intent === 'resuming') return status === 'running'
+  return status === 'completing'
+}
 
 export function LiveOpsPage() {
   const { ops, status, reconnect } = useLiveOpsStream()
   const [filters, setFilters] = useState<LiveOpsFilters>(EMPTY_FILTERS)
   const [autoScroll, setAutoScroll] = useState(true)
   const [frozenIds, setFrozenIds] = useState<Set<string> | null>(null)
+  const [overrides, setOverrides] = useState<Map<string, OperationOverride>>(
+    () => new Map(),
+  )
+  const { toast } = useToast()
 
   const agentsQuery = useAgentsQuery()
   const teamsQuery = useTeamsQuery()
+
+  useEffect(() => {
+    if (overrides.size === 0) return
+    setOverrides((prev) => {
+      let changed = false
+      const next = new Map(prev)
+      for (const op of ops) {
+        const intent = next.get(op.id)
+        if (!intent) continue
+        if (matchesIntent(op.status, intent)) {
+          next.delete(op.id)
+          changed = true
+        }
+      }
+      return changed ? next : prev
+    })
+  }, [ops, overrides.size])
+
+  async function runAction(
+    opId: string,
+    intent: OperationOverride,
+    call: (id: string) => Promise<void>,
+  ) {
+    setOverrides((prev) => new Map(prev).set(opId, intent))
+    try {
+      await call(opId)
+    } catch (err) {
+      setOverrides((prev) => {
+        const next = new Map(prev)
+        next.delete(opId)
+        return next
+      })
+      const detail = err instanceof Error ? err.message : 'unknown error'
+      toast(`Failed to ${OVERRIDE_VERB[intent]} op ${opId}: ${detail}`, 'error')
+    }
+  }
 
   const agentOptions: FilterOption[] = useMemo(
     () =>
@@ -133,7 +197,16 @@ export function LiveOpsPage() {
                 retryLabel="Reconnect"
               />
             ) : (
-              filteredOps.map((op) => <OperationRow key={op.id} op={op} />)
+              filteredOps.map((op) => (
+                <OperationRow
+                  key={op.id}
+                  op={op}
+                  override={overrides.get(op.id)}
+                  onPause={() => runAction(op.id, 'pausing', pauseOp)}
+                  onResume={() => runAction(op.id, 'resuming', resumeOp)}
+                  onTerminate={() => runAction(op.id, 'terminating', terminateOp)}
+                />
+              ))
             )}
           </div>
         </section>

--- a/dashboard/src/pages/LiveOpsPage.tsx
+++ b/dashboard/src/pages/LiveOpsPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useToast } from '../components/Toast'
 import { ErrorState } from '../components/states'
 import { useAgentsQuery } from '../features/agents/api'
@@ -49,22 +49,23 @@ export function LiveOpsPage() {
   const agentsQuery = useAgentsQuery()
   const teamsQuery = useTeamsQuery()
 
-  useEffect(() => {
-    if (overrides.size === 0) return
-    setOverrides((prev) => {
-      let changed = false
-      const next = new Map(prev)
-      for (const op of ops) {
-        const intent = next.get(op.id)
-        if (!intent) continue
-        if (matchesIntent(op.status, intent)) {
-          next.delete(op.id)
-          changed = true
-        }
+  // Derived map: every override whose WS-reported status already matches
+  // its intent is hidden from the UI. The raw `overrides` state still
+  // holds them until the next action triggers a state update; the cost
+  // is bounded by the page's ops ring (default 100) so they evaporate
+  // naturally when the ops age out.
+  const liveOverrides = useMemo(() => {
+    if (overrides.size === 0) return overrides
+    let pruned: Map<string, OperationOverride> | null = null
+    for (const op of ops) {
+      const intent = overrides.get(op.id)
+      if (intent && matchesIntent(op.status, intent)) {
+        if (!pruned) pruned = new Map(overrides)
+        pruned.delete(op.id)
       }
-      return changed ? next : prev
-    })
-  }, [ops, overrides.size])
+    }
+    return pruned ?? overrides
+  }, [ops, overrides])
 
   async function runAction(
     opId: string,
@@ -201,7 +202,7 @@ export function LiveOpsPage() {
                 <OperationRow
                   key={op.id}
                   op={op}
-                  override={overrides.get(op.id)}
+                  override={liveOverrides.get(op.id)}
                   onPause={() => runAction(op.id, 'pausing', pauseOp)}
                   onResume={() => runAction(op.id, 'resuming', resumeOp)}
                   onTerminate={() => runAction(op.id, 'terminating', terminateOp)}


### PR DESCRIPTION
## Summary

Adds a row-action kebab menu to each Live Ops event-stream row exposing **Pause**, **Resume**, and **Terminate** with optimistic UI + rollback (parent: [AAASM-1282](https://lightning-dust-mite.atlassian.net/browse/AAASM-1282)).

* **Status-aware menu** — Pause enabled only when `running`; Resume only when `blocked`; Terminate always enabled (except while another action is mid-flight on the same row).
* **Optimistic state** — clicking an item immediately sets an `OperationOverride` (`pausing | resuming | terminating`) on the row; the row dims to 0.7 opacity and shows an inline "pausing…" hint next to the chip.
* **Rollback** — if the REST call rejects, the override is cleared and an error toast surfaces the server message.
* **Confirmation gate** — Terminate routes through the existing `ConfirmDialog` (danger variant) so an accidental click cannot end an in-flight operation.

## Architecture

* New `dashboard/src/features/liveOps/actions.ts` — three raw-fetch helpers (`pauseOp/resumeOp/terminateOp`) against `POST /api/v1/ops/{id}/{action}`. Endpoints don't exist in the gateway yet → see follow-up ticket below.
* New `dashboard/src/features/liveOps/RowActionMenu.tsx` — kebab popover (Esc / outside-click close, ARIA `menu` / `menuitem`, focus return on close).
* `OperationRow` gains four optional props (`override`, `onPause/onResume/onTerminate`); the menu mounts only when all three callbacks are supplied so existing tests / stories keep working.
* `LiveOpsPage` owns the `overrides: Map<opId, OperationOverride>` state. A `liveOverrides` derived map filters out any entry whose op already shows the matching confirmed status, so the row's override clears automatically when the gateway WS event lands.

## Backend follow-up

The gateway doesn't yet expose `POST /api/v1/ops/{id}/{pause|resume|terminate}` — only agent-level pause/resume exists. The action helpers POST against the conventional path; a real 404 will exercise the rollback path. A separate sub-ticket of AAASM-1282 will add the gateway endpoints + schema regen.

## Test plan

* [x] `pnpm type-check` clean
* [x] `pnpm lint` clean (0 warnings, `--max-warnings 0`)
* [x] `pnpm test --run` — 781 tests pass across 94 files (4 new test files added: actions.test, RowActionMenu.test, OperationRow.test additions, LiveOpsPage.actions.test)
* [x] Optimistic rollback verified in test (`LiveOpsPage.actions.test.tsx`)
* [x] Confirmation modal blocks accidental terminate (`RowActionMenu.test.tsx`)
* [ ] Storybook visual review of `LiveOps/RowActionMenu` variants

## Commits

8 granular commits — one per logical unit per project commit policy.

Closes AAASM-1334.

[AAASM-1282]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ