### PR TITLE
[AAASM-1343] ✨ (dashboard/live-ops): Wire empty-state when no ops via shared EmptyState

### DIFF
--- a/dashboard/src/pages/LiveOpsPage.test.tsx
+++ b/dashboard/src/pages/LiveOpsPage.test.tsx
@@ -109,6 +109,34 @@ describe('LiveOpsPage', () => {
     expect(screen.queryByTestId('error-state')).toBeNull()
   })
 
+  it('renders the live EmptyState when stream is connected and ops list is empty', () => {
+    mockStream({ ops: [], status: 'connected' })
+    renderWithProviders(<LiveOpsPage />)
+    expect(screen.getByTestId('empty-state-live')).toBeInTheDocument()
+    expect(screen.queryByTestId('op-row')).toBeNull()
+  })
+
+  it('hides the EmptyState as soon as the first op arrives', () => {
+    mockStream({ ops: [makeOp('op-1')], status: 'connected' })
+    renderWithProviders(<LiveOpsPage />)
+    expect(screen.queryByTestId('empty-state-live')).toBeNull()
+    expect(screen.getByTestId('op-row')).toBeInTheDocument()
+  })
+
+  it('does not render the EmptyState while reconnecting', () => {
+    mockStream({ ops: [], status: 'reconnecting' })
+    renderWithProviders(<LiveOpsPage />)
+    expect(screen.queryByTestId('empty-state-live')).toBeNull()
+    expect(screen.getByTestId('live-ops-reconnecting')).toBeInTheDocument()
+  })
+
+  it('does not render the EmptyState while errored — ErrorState wins', () => {
+    mockStream({ ops: [], status: 'error' })
+    renderWithProviders(<LiveOpsPage />)
+    expect(screen.queryByTestId('empty-state-live')).toBeNull()
+    expect(screen.getByTestId('error-state')).toBeInTheDocument()
+  })
+
   it('renders ErrorState with a working reconnect retry when hook errors', async () => {
     const user = userEvent.setup()
     const reconnect = vi.fn()

--- a/dashboard/src/pages/LiveOpsPage.tsx
+++ b/dashboard/src/pages/LiveOpsPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react'
 import { useToast } from '../components/Toast'
+import { EmptyState } from '../components/EmptyState'
 import { ErrorState } from '../components/states'
 import { useAgentsQuery } from '../features/agents/api'
 import { useTeamsQuery } from '../features/analytics/useTeamsQuery'
@@ -197,6 +198,8 @@ export function LiveOpsPage() {
                 onRetry={reconnect}
                 retryLabel="Reconnect"
               />
+            ) : status === 'connected' && ops.length === 0 ? (
+              <EmptyState page="live" />
             ) : (
               filteredOps.map((op) => (
                 <OperationRow


### PR DESCRIPTION
## Summary

Renders the shared `<EmptyState page="live" />` in the Live Ops event-stream zone when `useLiveOpsStream` reports `status === 'connected'` but the ops ring is empty (parent: [AAASM-1282](https://lightning-dust-mite.atlassian.net/browse/AAASM-1282)).

## Render order (stream zone)

1. `status === 'error'` → `ErrorState` (existing)
2. `status === 'connected' && ops.length === 0` → `EmptyState page="live"` (new)
3. otherwise → `OperationRow` list (existing)

## Notes

* Reuses the pre-canned `'live'` copy from `EmptyState` (PR 2 / AAASM-120) — "No traffic in the last 60s" already matches the ticket's "no active operations + explanation" intent.
* Empty-state lives in the **stream zone only** — `PipelineCanvas` and `ApprovalPool` keep their normal renders.
* `ops.length` (not `filteredOps.length`) so a filter narrowing to zero doesn't trigger the empty-state — that's a filter-result situation, not an empty-stream one.

## Test plan

* [x] `pnpm type-check` clean
* [x] `pnpm lint` clean
* [x] `pnpm test --run` — 813 tests pass across 96 files
* [x] New tests in `LiveOpsPage.test.tsx`:
  * empty-state visible when `ops=[] && status='connected'`
  * empty-state hidden as soon as an op arrives
  * empty-state hidden while reconnecting (reconnect strip wins)
  * empty-state hidden while errored (ErrorState wins)

Closes AAASM-1343.

[AAASM-1282]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ