### PR TITLE
[AAASM-1344] ✅ (dashboard/live-ops): Add unit tests for OperationRow / FilterBar / AutoScroll

### DIFF
--- a/dashboard/src/features/liveOps/AutoScrollToggle.test.tsx
+++ b/dashboard/src/features/liveOps/AutoScrollToggle.test.tsx
@@ -98,4 +98,13 @@ describe('AutoScrollToggle', () => {
     await user.click(pill)
     expect(screen.queryByTestId('auto-scroll-flush')).toBeNull()
   })
+
+  it('exposes the enabled state via the checkbox input', () => {
+    const { rerender } = render(<StaticHarness enabled pendingCount={0} />)
+    const input = screen.getByTestId('auto-scroll-toggle-input') as HTMLInputElement
+    expect(input.type).toBe('checkbox')
+    expect(input.checked).toBe(true)
+    rerender(<StaticHarness enabled={false} pendingCount={0} />)
+    expect(input.checked).toBe(false)
+  })
 })

--- a/dashboard/src/features/liveOps/FilterBar.test.tsx
+++ b/dashboard/src/features/liveOps/FilterBar.test.tsx
@@ -93,4 +93,53 @@ describe('FilterBar', () => {
     const labels = Array.from(opType.querySelectorAll('option')).map((o) => o.value)
     expect(labels).toEqual(['', 'read', 'write', 'delete', 'exec'])
   })
+
+  it('emits onFiltersChange with the next team selection', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<ControlledHarness onChange={onChange} />)
+    await user.selectOptions(screen.getByTestId('filter-team'), 'devops')
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ team: 'devops' }),
+    )
+  })
+
+  it('emits onFiltersChange with the next opType selection', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<ControlledHarness onChange={onChange} />)
+    await user.selectOptions(screen.getByTestId('filter-op-type'), 'write')
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ opType: 'write' }),
+    )
+  })
+
+  it('emits onFiltersChange with the next status selection', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<ControlledHarness onChange={onChange} />)
+    await user.selectOptions(screen.getByTestId('filter-status'), 'blocked')
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'blocked' }),
+    )
+  })
+
+  it('renders gracefully when agentOptions / teamOptions are empty', () => {
+    const onChange = vi.fn()
+    render(
+      <FilterBar
+        filters={EMPTY_FILTERS}
+        onFiltersChange={onChange}
+        agentOptions={[]}
+        teamOptions={[]}
+      />,
+    )
+    // Each select still mounts with the "All" sentinel option only.
+    const agent = screen.getByTestId('filter-agent')
+    const team = screen.getByTestId('filter-team')
+    expect(agent.querySelectorAll('option')).toHaveLength(1)
+    expect(team.querySelectorAll('option')).toHaveLength(1)
+    expect(agent.querySelector('option')?.value).toBe('')
+    expect(team.querySelector('option')?.value).toBe('')
+  })
 })

--- a/dashboard/src/features/liveOps/OperationRow.test.tsx
+++ b/dashboard/src/features/liveOps/OperationRow.test.tsx
@@ -147,4 +147,13 @@ describe('OperationRow', () => {
     expect(row).toHaveAttribute('data-override', 'pausing')
     expect(screen.getByTestId('op-row-override')).toHaveTextContent('pausing…')
   })
+
+  it('starts expanded when defaultExpanded is true', () => {
+    render(<OperationRow op={FIXTURE} defaultExpanded />)
+    const row = screen.getByTestId('op-row')
+    const chevron = screen.getByTestId('op-row-chevron')
+    expect(row).toHaveAttribute('data-expanded', 'true')
+    expect(chevron).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByTestId('op-row-tree')).toBeInTheDocument()
+  })
 })

--- a/dashboard/src/features/liveOps/applyFilters.test.ts
+++ b/dashboard/src/features/liveOps/applyFilters.test.ts
@@ -102,4 +102,24 @@ describe('applyFilters', () => {
     expect(applyFilters(OPS, { agent: '' as unknown as string }).map((o) => o.id))
       .toEqual(['op-1', 'op-2', 'op-3', 'op-4'])
   })
+
+  it('excludes ops without a team field when the team axis is set', () => {
+    const opNoTeam: LiveOperation = {
+      id: 'op-no-team',
+      agent: 'support-agent',
+      opType: 'read',
+      resource: 'gmail.send',
+      status: 'running',
+      startedAt: '2026-05-13T14:23:05Z',
+      latencyMs: 10,
+    }
+    const result = applyFilters([...OPS, opNoTeam], { team: 'support' })
+    expect(result.map((o) => o.id)).toEqual(['op-1', 'op-3', 'op-4'])
+    expect(result.find((o) => o.id === 'op-no-team')).toBeUndefined()
+  })
+
+  it('returns an empty array when given an empty op list', () => {
+    expect(applyFilters([], EMPTY_FILTERS)).toEqual([])
+    expect(applyFilters([], { agent: 'support-agent' })).toEqual([])
+  })
 })


### PR DESCRIPTION
## Summary

Tops up edge-case coverage for the four Live Ops unit tests called out in [AAASM-1344](https://lightning-dust-mite.atlassian.net/browse/AAASM-1344) (parent: [AAASM-1282](https://lightning-dust-mite.atlassian.net/browse/AAASM-1282)).

The four files already exceed the DoD bar (≥3 cases each) from prior subtasks — this PR fills the actual gaps visible in the existing test names rather than adding redundant baseline coverage.

## Changes

| File | Added cases |
|---|---|
| `OperationRow.test.tsx` | `defaultExpanded` opens the chevron on mount |
| `FilterBar.test.tsx` | onFiltersChange with team selection · onFiltersChange with opType selection · onFiltersChange with status selection · renders gracefully when `agentOptions` / `teamOptions` are empty |
| `AutoScrollToggle.test.tsx` | exposes `enabled` state via the checkbox input |
| `applyFilters.test.ts` | excludes ops without a `team` field when the team axis is set · returns `[]` for empty op list |

8 new test cases total.

## Why FilterBar got the bulk

The pre-existing FilterBar test suite exercised only the **agent** axis directly — team / opType / status were never asserted, even though the component handles all four. The new cases close that gap.

## Test plan

* [x] `pnpm type-check` clean
* [x] `pnpm lint` clean
* [x] `pnpm test --run` — 820 tests pass across 96 files (8 new cases added)
* [x] Each component still exceeds DoD's ≥3-case bar (OperationRow 11, FilterBar 9, AutoScrollToggle 7, applyFilters 11)

Closes AAASM-1344.

[AAASM-1344]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1282]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ