### PR TITLE
[AAASM-1345] ✅ (dashboard/live-ops): Add useLiveOpsStream tests (reconnect, optimistic)

### DIFF
--- a/dashboard/src/features/liveOps/actions.test.ts
+++ b/dashboard/src/features/liveOps/actions.test.ts
@@ -100,4 +100,14 @@ describe('liveOps/actions', () => {
     fetchSpy.mockResolvedValue(errResponse(409, 'op already terminated'))
     await expect(terminateOp('op-1')).rejects.toThrow(/op already terminated/)
   })
+
+  it('sends Content-Type: application/json on every request', async () => {
+    fetchSpy.mockResolvedValue(okResponse())
+    await pauseOp('op-1')
+    await resumeOp('op-1')
+    await terminateOp('op-1')
+    for (const [, init] of fetchSpy.mock.calls) {
+      expect(init.headers['Content-Type']).toBe('application/json')
+    }
+  })
 })

--- a/dashboard/src/features/liveOps/useLiveOpsStream.test.ts
+++ b/dashboard/src/features/liveOps/useLiveOpsStream.test.ts
@@ -221,4 +221,91 @@ describe('useLiveOpsStream', () => {
     unmount()
     expect(ws.readyState).toBe(MockWebSocket.CLOSED)
   })
+
+  it('appends ?token=… to the WS URL when aa_token is present in localStorage', () => {
+    const originalGet = Storage.prototype.getItem
+    Storage.prototype.getItem = function (key: string) {
+      return key === 'aa_token' ? 'jwt-abc' : originalGet.call(this, key)
+    }
+    try {
+      renderHook(() => useLiveOpsStream(opts))
+      expect(MockWebSocket.instances[0].url).toContain('types=violation')
+      expect(MockWebSocket.instances[0].url).toContain('token=jwt-abc')
+    } finally {
+      Storage.prototype.getItem = originalGet
+    }
+  })
+
+  it('caps reconnect backoff at maxBackoffMs', () => {
+    renderHook(() =>
+      useLiveOpsStream({
+        ...opts,
+        initialBackoffMs: 100,
+        maxBackoffMs: 250,
+        maxReconnectAttempts: 5,
+      }),
+    )
+    // 1st backoff: 100 ms (2^0 * 100)
+    act(() => {
+      MockWebSocket.instances[0].serverClose()
+      vi.advanceTimersByTime(100)
+    })
+    expect(MockWebSocket.instances).toHaveLength(2)
+
+    // 2nd backoff: 200 ms (2^1 * 100) — still under cap
+    act(() => {
+      MockWebSocket.instances[1].serverClose()
+      vi.advanceTimersByTime(200)
+    })
+    expect(MockWebSocket.instances).toHaveLength(3)
+
+    // 3rd backoff would be 400 ms (2^2 * 100) but is clamped to 250 ms.
+    act(() => {
+      MockWebSocket.instances[2].serverClose()
+    })
+    act(() => {
+      vi.advanceTimersByTime(249)
+    })
+    expect(MockWebSocket.instances).toHaveLength(3)
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(MockWebSocket.instances).toHaveLength(4)
+  })
+
+  it('successful open resets the backoff counter so the next close starts at initialBackoffMs', () => {
+    renderHook(() => useLiveOpsStream(opts))
+
+    // Drive one backoff escalation: close → reconnect waits 100ms.
+    act(() => {
+      MockWebSocket.instances[0].serverClose()
+      vi.advanceTimersByTime(100)
+    })
+    expect(MockWebSocket.instances).toHaveLength(2)
+
+    // Second close BEFORE the second socket has opened — backoff is now 200ms.
+    act(() => {
+      MockWebSocket.instances[1].serverClose()
+      vi.advanceTimersByTime(200)
+    })
+    expect(MockWebSocket.instances).toHaveLength(3)
+
+    // Now let the third socket actually open — this should reset the counter.
+    act(() => {
+      MockWebSocket.instances[2].open()
+    })
+
+    // Subsequent close should reconnect after initialBackoffMs again (100), not 400.
+    act(() => {
+      MockWebSocket.instances[2].serverClose()
+    })
+    act(() => {
+      vi.advanceTimersByTime(99)
+    })
+    expect(MockWebSocket.instances).toHaveLength(3)
+    act(() => {
+      vi.advanceTimersByTime(1)
+    })
+    expect(MockWebSocket.instances).toHaveLength(4)
+  })
 })


### PR DESCRIPTION
## Summary

Tops up `useLiveOpsStream.test.ts` + `actions.test.ts` coverage per [AAASM-1345](https://lightning-dust-mite.atlassian.net/browse/AAASM-1345) (parent: [AAASM-1282](https://lightning-dust-mite.atlassian.net/browse/AAASM-1282)).

The two files already exceed the DoD bar (the WS hook had 10 cases from AAASM-1332, the actions helpers had 8 from AAASM-1334). This PR fills the actual gaps:

## Changes

| File | Added cases |
|---|---|
| `useLiveOpsStream.test.ts` | WS URL appends `?token=<jwt>` when `aa_token` is in localStorage · backoff is clamped at `maxBackoffMs` · successful open resets the attempt counter so next close starts at `initialBackoffMs` |
| `actions.test.ts` | every POST sends `Content-Type: application/json` |

4 new cases.

## Note on the ticket's second bullet

AAASM-1345's description asks `actions.test.ts` to cover **"pauseOp/resumeOp/terminateOp optimistic update + rollback on rejected response"**. The optimistic+rollback logic doesn't live in `actions.ts` — those are pure REST helpers. The optimistic state machine lives in `LiveOpsPage` and was covered when AAASM-1334 landed: see `LiveOpsPage.actions.test.tsx` (4 cases — optimistic→WS-clears, rejection→rollback+toast, terminate via confirmation, resume from blocked). Calling that out explicitly here.

## Test plan

* [x] `pnpm type-check` clean
* [x] `pnpm lint` clean
* [x] `pnpm test --run` — 825 tests pass across 96 files (4 new)
* [x] DoD "reconnect attempts honour exponential backoff" — already explicitly asserted in the existing "reconnects with exponential backoff after a close" case; this PR adds the cap + reset assertions to round out the backoff state machine

Closes AAASM-1345.

[AAASM-1345]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1282]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ