### PR TITLE
[AAASM-1323] ♻️ (dashboard): Migrate inline hex literals to design tokens

### DIFF
--- a/dashboard/src/components/Badge.css
+++ b/dashboard/src/components/Badge.css
@@ -10,16 +10,16 @@
 }
 
 .badge--blue {
-  background-color: #dbeafe;
-  color: #1d4ed8;
+  background-color: var(--badge-blue-bg);
+  color: var(--badge-blue-text);
 }
 
 .badge--amber {
-  background-color: #fef3c7;
-  color: #b45309;
+  background-color: var(--badge-amber-bg);
+  color: var(--badge-amber-text);
 }
 
 .badge--neutral {
-  background-color: #f3f4f6;
-  color: #6b7280;
+  background-color: var(--badge-neutral-bg);
+  color: var(--badge-neutral-text);
 }

--- a/dashboard/src/components/ToastProvider.tsx
+++ b/dashboard/src/components/ToastProvider.tsx
@@ -38,8 +38,12 @@ export function ToastProvider({ children }: { children: ReactNode }) {
               padding: '0.75rem 1rem',
               borderRadius: '0.375rem',
               background:
-                t.variant === 'success' ? '#16a34a' : t.variant === 'error' ? '#dc2626' : '#2563eb',
-              color: '#fff',
+                t.variant === 'success'
+                  ? 'var(--status-success-solid)'
+                  : t.variant === 'error'
+                    ? 'var(--status-danger-solid)'
+                    : 'var(--status-info-solid)',
+              color: 'var(--toast-text)',
               fontSize: '0.875rem',
               maxWidth: '24rem',
             }}

--- a/dashboard/src/components/Tooltip.css
+++ b/dashboard/src/components/Tooltip.css
@@ -8,8 +8,8 @@
   bottom: calc(100% + 6px);
   left: 50%;
   transform: translateX(-50%);
-  background-color: #1f2937;
-  color: #f9fafb;
+  background-color: var(--tooltip-bg);
+  color: var(--tooltip-text);
   font-size: 0.75rem;
   padding: 4px 8px;
   border-radius: 4px;
@@ -25,5 +25,5 @@
   left: 50%;
   transform: translateX(-50%);
   border: 4px solid transparent;
-  border-top-color: #1f2937;
+  border-top-color: var(--tooltip-bg);
 }

--- a/dashboard/src/features/analytics/ActionVolumePanel.css
+++ b/dashboard/src/features/analytics/ActionVolumePanel.css
@@ -1,6 +1,6 @@
 .action-volume-panel {
-  background: #fff;
-  border: 1px solid #e5e7eb;
+  background: var(--surface-card);
+  border: 1px solid var(--surface-card-border);
   border-radius: 8px;
   padding: 1.25rem 1.5rem;
 }
@@ -8,7 +8,7 @@
 .action-volume-panel__title {
   font-size: 0.875rem;
   font-weight: 600;
-  color: #374151;
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin: 0 0 1rem;
@@ -22,7 +22,12 @@
 .action-volume-panel__skeleton {
   height: 320px;
   border-radius: 4px;
-  background: linear-gradient(90deg, #f3f4f6 25%, #e5e7eb 50%, #f3f4f6 75%);
+  background: linear-gradient(
+    90deg,
+    var(--surface-skeleton-base) 25%,
+    var(--surface-skeleton-shimmer) 50%,
+    var(--surface-skeleton-base) 75%
+  );
   background-size: 200% 100%;
   animation: action-volume-shimmer 1.5s infinite linear;
 }
@@ -40,7 +45,7 @@
   justify-content: center;
   height: 320px;
   gap: 0.5rem;
-  color: #6b7280;
+  color: var(--text-muted);
   font-size: 0.875rem;
 }
 
@@ -49,12 +54,12 @@
 }
 
 .action-volume-panel__empty a {
-  color: #6366f1;
+  color: var(--accent);
   text-decoration: underline;
 }
 
 .action-volume-panel__empty a:hover {
-  color: #4f46e5;
+  color: var(--accent-hover);
 }
 
 /* Error state */
@@ -63,7 +68,7 @@
   align-items: center;
   justify-content: center;
   height: 320px;
-  color: #9ca3af;
+  color: var(--text-disabled);
   font-size: 0.875rem;
   margin: 0;
 }

--- a/dashboard/src/features/analytics/ApprovalAnalyticsPanel.css
+++ b/dashboard/src/features/analytics/ApprovalAnalyticsPanel.css
@@ -1,6 +1,6 @@
 .approval-analytics-panel {
-  background: #fff;
-  border: 1px solid #e5e7eb;
+  background: var(--surface-card);
+  border: 1px solid var(--surface-card-border);
   border-radius: 8px;
   padding: 1.25rem 1.5rem;
 }
@@ -12,7 +12,7 @@
 .approval-analytics-panel__title {
   font-size: 0.875rem;
   font-weight: 600;
-  color: #374151;
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin: 0;
@@ -21,7 +21,12 @@
 .approval-analytics-panel__skeleton {
   height: 260px;
   border-radius: 4px;
-  background: linear-gradient(90deg, #f3f4f6 25%, #e5e7eb 50%, #f3f4f6 75%);
+  background: linear-gradient(
+    90deg,
+    var(--surface-skeleton-base) 25%,
+    var(--surface-skeleton-shimmer) 50%,
+    var(--surface-skeleton-base) 75%
+  );
   background-size: 200% 100%;
   animation: approval-analytics-shimmer 1.5s infinite linear;
 }
@@ -36,7 +41,7 @@
   align-items: center;
   justify-content: center;
   height: 260px;
-  color: #9ca3af;
+  color: var(--text-disabled);
   font-size: 0.875rem;
   margin: 0;
 }
@@ -63,13 +68,13 @@
 .approval-analytics-panel__stat-value {
   font-size: 1.375rem;
   font-weight: 700;
-  color: #111827;
+  color: var(--text-primary);
   line-height: 1.2;
 }
 
 .approval-analytics-panel__stat-label {
   font-size: 0.75rem;
-  color: #6b7280;
+  color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -93,7 +98,7 @@
   align-items: center;
   gap: 0.5rem;
   font-size: 0.8125rem;
-  color: #374151;
+  color: var(--text-secondary);
 }
 
 .approval-analytics-panel__legend-swatch {
@@ -106,6 +111,6 @@
 
 .approval-analytics-panel__legend-count {
   margin-left: auto;
-  color: #6b7280;
+  color: var(--text-muted);
   font-variant-numeric: tabular-nums;
 }

--- a/dashboard/src/features/analytics/CostBreakdownPanel.css
+++ b/dashboard/src/features/analytics/CostBreakdownPanel.css
@@ -1,6 +1,6 @@
 .cost-breakdown-panel {
-  background: #fff;
-  border: 1px solid #e5e7eb;
+  background: var(--surface-card);
+  border: 1px solid var(--surface-card-border);
   border-radius: 8px;
   padding: 1.25rem 1.5rem;
 }
@@ -15,7 +15,7 @@
 .cost-breakdown-panel__title {
   font-size: 0.875rem;
   font-weight: 600;
-  color: #374151;
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin: 0;
@@ -25,7 +25,12 @@
 .cost-breakdown-panel__skeleton {
   height: 320px;
   border-radius: 4px;
-  background: linear-gradient(90deg, #f3f4f6 25%, #e5e7eb 50%, #f3f4f6 75%);
+  background: linear-gradient(
+    90deg,
+    var(--surface-skeleton-base) 25%,
+    var(--surface-skeleton-shimmer) 50%,
+    var(--surface-skeleton-base) 75%
+  );
   background-size: 200% 100%;
   animation: cost-breakdown-shimmer 1.5s infinite linear;
 }
@@ -43,7 +48,7 @@
   justify-content: center;
   height: 320px;
   gap: 0.5rem;
-  color: #6b7280;
+  color: var(--text-muted);
   font-size: 0.875rem;
 }
 
@@ -52,7 +57,7 @@
 }
 
 .cost-breakdown-panel__empty a {
-  color: #6366f1;
+  color: var(--accent);
   text-decoration: underline;
 }
 
@@ -61,7 +66,7 @@
   align-items: center;
   justify-content: center;
   height: 320px;
-  color: #9ca3af;
+  color: var(--text-disabled);
   font-size: 0.875rem;
   margin: 0;
 }
@@ -86,12 +91,12 @@
   padding: 0.25rem 0.5rem;
   border-radius: 4px;
   font-size: 0.8125rem;
-  color: #374151;
+  color: var(--text-secondary);
   transition: opacity 0.15s;
 }
 
 .cost-breakdown-panel__legend-btn:hover {
-  background: #f3f4f6;
+  background: var(--surface-hover-bg);
 }
 
 .cost-breakdown-panel__legend-btn--hidden {
@@ -111,14 +116,14 @@
 }
 
 .cost-breakdown-panel__legend-total {
-  color: #6b7280;
+  color: var(--text-muted);
   font-weight: 400;
 }
 
 /* SegmentedControl */
 .segmented-control {
   display: inline-flex;
-  border: 1px solid #e5e7eb;
+  border: 1px solid var(--surface-card-border);
   border-radius: 6px;
   overflow: hidden;
 }
@@ -126,11 +131,11 @@
 .segmented-control__option {
   background: none;
   border: none;
-  border-right: 1px solid #e5e7eb;
+  border-right: 1px solid var(--surface-card-border);
   cursor: pointer;
   font-size: 0.8125rem;
   font-weight: 500;
-  color: #6b7280;
+  color: var(--text-muted);
   padding: 0.25rem 0.75rem;
   transition: background 0.1s, color 0.1s;
 }
@@ -140,16 +145,16 @@
 }
 
 .segmented-control__option:hover {
-  background: #f3f4f6;
-  color: #374151;
+  background: var(--surface-hover-bg);
+  color: var(--text-secondary);
 }
 
 .segmented-control__option--active {
-  background: #6366f1;
-  color: #fff;
+  background: var(--accent);
+  color: var(--text-on-accent);
 }
 
 .segmented-control__option--active:hover {
-  background: #4f46e5;
-  color: #fff;
+  background: var(--accent-hover);
+  color: var(--text-on-accent);
 }

--- a/dashboard/src/features/analytics/KpiStrip.css
+++ b/dashboard/src/features/analytics/KpiStrip.css
@@ -21,8 +21,8 @@
   flex-direction: column;
   gap: 0.25rem;
   padding: 1rem 1.25rem;
-  background: #fff;
-  border: 1px solid #e5e7eb;
+  background: var(--surface-card);
+  border: 1px solid var(--surface-card-border);
   border-radius: 8px;
   min-height: 90px;
 }
@@ -30,7 +30,7 @@
 .kpi-card__label {
   font-size: 0.75rem;
   font-weight: 500;
-  color: #6b7280;
+  color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -38,14 +38,14 @@
 .kpi-card__value {
   font-size: 1.5rem;
   font-weight: 700;
-  color: #111827;
+  color: var(--text-primary);
   line-height: 1.2;
 }
 
 .kpi-card__unit {
   font-size: 0.875rem;
   font-weight: 400;
-  color: #6b7280;
+  color: var(--text-muted);
 }
 
 .kpi-card__delta {
@@ -55,7 +55,7 @@
 
 .kpi-card__error {
   font-size: 1.5rem;
-  color: #9ca3af;
+  color: var(--text-disabled);
 }
 
 /* Skeleton shimmer */
@@ -66,7 +66,12 @@
 
 .kpi-card__skeleton {
   border-radius: 4px;
-  background: linear-gradient(90deg, #f3f4f6 25%, #e5e7eb 50%, #f3f4f6 75%);
+  background: linear-gradient(
+    90deg,
+    var(--surface-skeleton-base) 25%,
+    var(--surface-skeleton-shimmer) 50%,
+    var(--surface-skeleton-base) 75%
+  );
   background-size: 200% 100%;
   animation: kpi-shimmer 1.5s infinite linear;
 }

--- a/dashboard/src/features/analytics/PolicyEffectivenessPanel.css
+++ b/dashboard/src/features/analytics/PolicyEffectivenessPanel.css
@@ -1,13 +1,9 @@
-/* CSS variables for heatmap color stops — update here for theme switching */
-:root {
-  --heatmap-low: #10b981;
-  --heatmap-mid: #f59e0b;
-  --heatmap-high: #ef4444;
-}
+/* Heatmap color stops are defined in dashboard/src/styles.css (--heatmap-low,
+   --heatmap-mid, --heatmap-high) so all theme tokens live in one place. */
 
 .policy-effectiveness-panel {
-  background: #fff;
-  border: 1px solid #e5e7eb;
+  background: var(--surface-card);
+  border: 1px solid var(--surface-card-border);
   border-radius: 8px;
   padding: 1.25rem 1.5rem;
 }
@@ -22,7 +18,7 @@
 .policy-effectiveness-panel__title {
   font-size: 0.875rem;
   font-weight: 600;
-  color: #374151;
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin: 0;
@@ -32,7 +28,12 @@
 .policy-effectiveness-panel__skeleton {
   height: 320px;
   border-radius: 4px;
-  background: linear-gradient(90deg, #f3f4f6 25%, #e5e7eb 50%, #f3f4f6 75%);
+  background: linear-gradient(
+    90deg,
+    var(--surface-skeleton-base) 25%,
+    var(--surface-skeleton-shimmer) 50%,
+    var(--surface-skeleton-base) 75%
+  );
   background-size: 200% 100%;
   animation: policy-effectiveness-shimmer 1.5s infinite linear;
 }
@@ -50,7 +51,7 @@
   justify-content: center;
   height: 320px;
   gap: 0.5rem;
-  color: #6b7280;
+  color: var(--text-muted);
   font-size: 0.875rem;
 }
 
@@ -59,7 +60,7 @@
 }
 
 .policy-effectiveness-panel__empty a {
-  color: #6366f1;
+  color: var(--accent);
   text-decoration: underline;
 }
 
@@ -68,7 +69,7 @@
   align-items: center;
   justify-content: center;
   height: 320px;
-  color: #9ca3af;
+  color: var(--text-disabled);
   font-size: 0.875rem;
   margin: 0;
 }
@@ -91,7 +92,7 @@
   padding: 0 0.25rem 0.5rem 0;
   font-size: 0.75rem;
   font-weight: 600;
-  color: #374151;
+  color: var(--text-secondary);
 }
 
 .policy-effectiveness-panel__sort-btn {
@@ -100,18 +101,18 @@
   cursor: pointer;
   font-size: 0.75rem;
   font-weight: 600;
-  color: #374151;
+  color: var(--text-secondary);
   padding: 0;
   text-align: left;
 }
 
 .policy-effectiveness-panel__sort-btn:hover {
-  color: #6366f1;
+  color: var(--accent);
 }
 
 .policy-effectiveness-panel__date-cell {
   font-size: 0.6875rem;
-  color: #9ca3af;
+  color: var(--text-disabled);
   text-align: center;
   padding-bottom: 0.5rem;
   white-space: nowrap;
@@ -121,7 +122,7 @@
 
 .policy-effectiveness-panel__rule-label {
   font-size: 0.8125rem;
-  color: #374151;
+  color: var(--text-secondary);
   padding-right: 0.5rem;
   white-space: nowrap;
   overflow: hidden;
@@ -142,7 +143,7 @@
 
 .policy-effectiveness-panel__cell:hover {
   opacity: 0.8;
-  outline: 2px solid #374151;
+  outline: 2px solid var(--tooltip-outline);
   outline-offset: 1px;
 }
 
@@ -150,8 +151,8 @@
 .policy-effectiveness-panel__tooltip {
   position: fixed;
   z-index: 100;
-  background: #1f2937;
-  color: #f9fafb;
+  background: var(--tooltip-bg);
+  color: var(--tooltip-text);
   border-radius: 6px;
   padding: 0.5rem 0.75rem;
   font-size: 0.8125rem;

--- a/dashboard/src/features/analytics/ToolUsageFleetHealth.css
+++ b/dashboard/src/features/analytics/ToolUsageFleetHealth.css
@@ -1,8 +1,8 @@
 /* ── ToolUsagePanel ─────────────────────────────────────────────────────────── */
 
 .tool-usage-panel {
-  background: #fff;
-  border: 1px solid #e5e7eb;
+  background: var(--surface-card);
+  border: 1px solid var(--surface-card-border);
   border-radius: 8px;
   padding: 1.25rem 1.5rem;
 }
@@ -14,7 +14,7 @@
 .tool-usage-panel__title {
   font-size: 0.875rem;
   font-weight: 600;
-  color: #374151;
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin: 0;
@@ -23,7 +23,12 @@
 .tool-usage-panel__skeleton {
   height: 200px;
   border-radius: 4px;
-  background: linear-gradient(90deg, #f3f4f6 25%, #e5e7eb 50%, #f3f4f6 75%);
+  background: linear-gradient(
+    90deg,
+    var(--surface-skeleton-base) 25%,
+    var(--surface-skeleton-shimmer) 50%,
+    var(--surface-skeleton-base) 75%
+  );
   background-size: 200% 100%;
   animation: tool-usage-shimmer 1.5s infinite linear;
 }
@@ -39,7 +44,7 @@
   align-items: center;
   justify-content: center;
   height: 120px;
-  color: #9ca3af;
+  color: var(--text-disabled);
   font-size: 0.875rem;
   margin: 0;
 }
@@ -51,8 +56,8 @@
 /* ── FleetHealthPanel ───────────────────────────────────────────────────────── */
 
 .fleet-health-panel {
-  background: #fff;
-  border: 1px solid #e5e7eb;
+  background: var(--surface-card);
+  border: 1px solid var(--surface-card-border);
   border-radius: 8px;
   padding: 1.25rem 1.5rem;
 }
@@ -64,7 +69,7 @@
 .fleet-health-panel__title {
   font-size: 0.875rem;
   font-weight: 600;
-  color: #374151;
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin: 0;
@@ -73,7 +78,12 @@
 .fleet-health-panel__skeleton {
   height: 200px;
   border-radius: 4px;
-  background: linear-gradient(90deg, #f3f4f6 25%, #e5e7eb 50%, #f3f4f6 75%);
+  background: linear-gradient(
+    90deg,
+    var(--surface-skeleton-base) 25%,
+    var(--surface-skeleton-shimmer) 50%,
+    var(--surface-skeleton-base) 75%
+  );
   background-size: 200% 100%;
   animation: fleet-health-shimmer 1.5s infinite linear;
 }
@@ -88,7 +98,7 @@
   align-items: center;
   justify-content: center;
   height: 120px;
-  color: #9ca3af;
+  color: var(--text-disabled);
   font-size: 0.875rem;
 }
 
@@ -101,7 +111,7 @@
   align-items: center;
   justify-content: center;
   height: 120px;
-  color: #9ca3af;
+  color: var(--text-disabled);
   font-size: 0.875rem;
   margin: 0;
 }
@@ -126,7 +136,7 @@
   flex: 1;
   min-width: 0;
   font-size: 0.8125rem;
-  color: #374151;
+  color: var(--text-secondary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -147,9 +157,9 @@
   border-radius: 10px;
   font-size: 0.6875rem;
   font-weight: 600;
-  color: #fff;
+  color: var(--text-on-accent);
 }
 
-.fleet-health-panel__badge--green { background: #10b981; }
-.fleet-health-panel__badge--amber { background: #f59e0b; }
-.fleet-health-panel__badge--red   { background: #ef4444; }
+.fleet-health-panel__badge--green { background: var(--status-success); }
+.fleet-health-panel__badge--amber { background: var(--status-warning); }
+.fleet-health-panel__badge--red   { background: var(--status-danger); }

--- a/dashboard/src/pages/AgentDetailPage.tsx
+++ b/dashboard/src/pages/AgentDetailPage.tsx
@@ -19,7 +19,7 @@ function TrustGauge({ score }: { score: number | null }) {
     )
   }
   const clamped = Math.max(0, Math.min(100, score))
-  const tone = clamped >= 80 ? '#22592a' : clamped >= 60 ? '#8a5a00' : '#b8291e'
+  const tone = clamped >= 80 ? 'var(--ok)' : clamped >= 60 ? 'var(--warn)' : 'var(--danger)'
   const dash = (clamped / 100) * 125.6
   return (
     <div className="ad-identity__trust">

--- a/dashboard/src/pages/AnalyticsPage.css
+++ b/dashboard/src/pages/AnalyticsPage.css
@@ -21,8 +21,8 @@
   align-items: center;
   gap: 1rem;
   padding: 0.75rem 1rem;
-  background: #f9fafb;
-  border: 1px solid #e5e7eb;
+  background: var(--surface-subtle-bg);
+  border: 1px solid var(--surface-card-border);
   border-radius: 8px;
 }
 
@@ -35,21 +35,21 @@
 .analytics-filter-bar__label {
   font-size: 0.875rem;
   font-weight: 500;
-  color: #374151;
+  color: var(--text-secondary);
   white-space: nowrap;
 }
 
 .analytics-filter-bar__select {
   font-size: 0.875rem;
   padding: 0.25rem 0.5rem;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--form-input-border);
   border-radius: 4px;
-  background: #fff;
-  color: #111827;
+  background: var(--surface-card);
+  color: var(--text-primary);
   cursor: pointer;
 }
 
 .analytics-filter-bar__select:focus {
-  outline: 2px solid #6366f1;
+  outline: 2px solid var(--accent);
   outline-offset: 1px;
 }

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -109,4 +109,7 @@
 
   /* ── Toast (white text on solid status bg) ───────────────── */
   --toast-text: #ffffff;
+
+  /* ── Text on solid accent backgrounds (segmented controls, badges) */
+  --text-on-accent: #ffffff;
 }

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -65,9 +65,11 @@
      KPI strip, badges, and admin pages. */
   --surface-card: #ffffff;
   --surface-card-border: #e5e7eb;
+  --surface-subtle-bg: #f9fafb;
   --surface-skeleton-base: #f3f4f6;
   --surface-skeleton-shimmer: #e5e7eb;
   --surface-hover-bg: #f3f4f6;
+  --form-input-border: #d1d5db;
 
   /* ── Text scale (analytics / admin pages) ────────────────── */
   --text-primary: #111827;

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -59,4 +59,52 @@
   --shell-button-border: #cbd5e1;
   --shell-button-hover-bg: #f1f5f9;
   --shell-error-text: #dc2626;
+
+  /* ── Analytics / admin surface tokens ────────────────────── */
+  /* Cards and skeleton loaders used across analytics panels,
+     KPI strip, badges, and admin pages. */
+  --surface-card: #ffffff;
+  --surface-card-border: #e5e7eb;
+  --surface-skeleton-base: #f3f4f6;
+  --surface-skeleton-shimmer: #e5e7eb;
+  --surface-hover-bg: #f3f4f6;
+
+  /* ── Text scale (analytics / admin pages) ────────────────── */
+  --text-primary: #111827;
+  --text-secondary: #374151;
+  --text-muted: #6b7280;
+  --text-disabled: #9ca3af;
+
+  /* ── Accent (indigo) for primary controls in analytics ───── */
+  --accent: #6366f1;
+  --accent-hover: #4f46e5;
+
+  /* ── Status palette (charts / badges / toasts) ───────────── */
+  --status-success: #10b981;
+  --status-warning: #f59e0b;
+  --status-danger: #ef4444;
+  --status-success-solid: #16a34a;
+  --status-danger-solid: #dc2626;
+  --status-info-solid: #2563eb;
+
+  /* ── Heatmap stops (PolicyEffectivenessPanel) ────────────── */
+  --heatmap-low: var(--status-success);
+  --heatmap-mid: var(--status-warning);
+  --heatmap-high: var(--status-danger);
+
+  /* ── Tooltip ─────────────────────────────────────────────── */
+  --tooltip-bg: #1f2937;
+  --tooltip-text: #f9fafb;
+  --tooltip-outline: #374151;
+
+  /* ── Badge variants (Badge.tsx) ──────────────────────────── */
+  --badge-blue-bg: #dbeafe;
+  --badge-blue-text: #1d4ed8;
+  --badge-amber-bg: #fef3c7;
+  --badge-amber-text: #b45309;
+  --badge-neutral-bg: #f3f4f6;
+  --badge-neutral-text: #6b7280;
+
+  /* ── Toast (white text on solid status bg) ───────────────── */
+  --toast-text: #ffffff;
 }


### PR DESCRIPTION
## Summary

Migrates **96 hard-coded hex color values** across **11 listed-scope files** to `var(--…)` references defined in `dashboard/src/styles.css`. Closes the page-level sweep deferred from AAASM-1322 and resolves the partial check on AAASM-94 AC #8 within the listed scope.

### What changed

* **`dashboard/src/styles.css`** — added 22 new semantic tokens covering analytics surfaces (`--surface-*`), Tailwind grey text scale (`--text-*`), accent (`--accent`, `--accent-hover`), status palette (`--status-*`), heatmap aliases (`--heatmap-*` → `--status-*`), tooltip (`--tooltip-*`), badges (`--badge-*`), and on-accent text. All follow the existing two-tier naming `--<scope>-<role>`. Hi-fi palette and shell tokens are unchanged.
* **11 component / page files** — hex literals replaced with `var(--…)` references. **No visual values change** — every token was defined with the exact prior hex value.
* **`PolicyEffectivenessPanel.css`** — the local `:root { --heatmap-* }` block is moved to `styles.css` so all design tokens live in one place.

### Files migrated (96 hex refs → 0)

| File | Refs migrated |
|---|---|
| `features/analytics/CostBreakdownPanel.css` | 19 |
| `features/analytics/PolicyEffectivenessPanel.css` | 18 |
| `features/analytics/ToolUsageFleetHealth.css` | 16 |
| `features/analytics/ApprovalAnalyticsPanel.css` | 9 |
| `features/analytics/ActionVolumePanel.css` | 8 |
| `features/analytics/KpiStrip.css` | 7 |
| `pages/AnalyticsPage.css` | 7 |
| `components/Badge.css` | 6 |
| `components/Tooltip.css` | 3 |
| `components/ToastProvider.tsx` | 2 |
| `pages/AgentDetailPage.tsx` | 1 |

### Scope vs AC

The original ticket scope listed 18 files, but codebase verification showed:
* 2 files were renamed (`PolicyEditorPage` → `PoliciesPage`, `AgentsPage` → `FleetPage`) and already migrated.
* 5 listed files already had 0 hex refs.

The actual migration touches the **11 files that exist and contain hex refs**. The AC bullet was reworded on the ticket to scope-match (`grep returns zero within the listed Scope files`). The remaining 51 unlisted files (~343 residual hex refs in `alerts/`, `iam/`, `fleet/`, `capability/`, `liveOps/`, `onboarding/`, etc.) are out of scope and will be tracked by a follow-up subtask under AAASM-94 before AAASM-1323 closes.

### Commit shape

14 granular commits — 1 commit per file migrated, plus 3 small token-addition commits as new semantic tokens were needed mid-migration. Each commit is independently reviewable.

## Test plan

* [x] `pnpm type-check` clean
* [x] `pnpm lint` clean
* [x] `pnpm test` — 825/825 passing, 96/96 test files
* [x] `grep -rE '#[0-9a-fA-F]{3,8}' dashboard/src/<listed-files>` returns zero hits
* [ ] Manual visual smoke — open Analytics, Agent Detail, Approvals, badge consumers; confirm no visual regression
* [ ] Confirm Playwright design-fidelity suite (AAASM-1382, just merged) still passes against this branch

Closes the listed-scope portion of [AAASM-1323](https://lightning-dust-mite.atlassian.net/browse/AAASM-1323). Follow-up subtask for the residual 343 hex refs in unlisted files will be filed under AAASM-94 before this ticket closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-1323]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ