### PR TITLE
[AAASM-1408] 🐛 (ci): Exclude docs-only changes from code CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ on:
       - "openapi/v1.yaml"
       - ".spectral.yaml"
       - ".github/workflows/ci.yml"
+      - "!**/*.md"
+      - "!**/LICENSE"
   pull_request:
     branches: [master]
     paths:
@@ -25,6 +27,8 @@ on:
       - "openapi/v1.yaml"
       - ".spectral.yaml"
       - ".github/workflows/ci.yml"
+      - "!**/*.md"
+      - "!**/LICENSE"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -7,12 +7,16 @@ on:
       - "dashboard/**"
       - "openapi/v1.yaml"
       - ".github/workflows/dashboard-ci.yml"
+      - "!**/*.md"
+      - "!**/LICENSE"
   pull_request:
     branches: [master]
     paths:
       - "dashboard/**"
       - "openapi/v1.yaml"
       - ".github/workflows/dashboard-ci.yml"
+      - "!**/*.md"
+      - "!**/LICENSE"
 
 jobs:
   typecheck-and-lint:

--- a/.github/workflows/dev-verify.yml
+++ b/.github/workflows/dev-verify.yml
@@ -7,12 +7,16 @@ on:
       - "Makefile"
       - "scripts/**"
       - ".github/workflows/dev-verify.yml"
+      - "!**/*.md"
+      - "!**/LICENSE"
   pull_request:
     branches: [master]
     paths:
       - "Makefile"
       - "scripts/**"
       - ".github/workflows/dev-verify.yml"
+      - "!**/*.md"
+      - "!**/LICENSE"
 
 jobs:
   dev-verify:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,8 @@ on:
     paths:
       - "aa-runtime/**"
       - ".github/workflows/docker.yml"
+      - "!**/*.md"
+      - "!**/LICENSE"
   push:
     tags: ["v*"]
 

--- a/.github/workflows/ffi-go-staticlib.yml
+++ b/.github/workflows/ffi-go-staticlib.yml
@@ -6,11 +6,15 @@ on:
     paths:
       - "aa-ffi-go/**"
       - ".github/workflows/ffi-go-staticlib.yml"
+      - "!**/*.md"
+      - "!**/LICENSE"
   pull_request:
     branches: [master]
     paths:
       - "aa-ffi-go/**"
       - ".github/workflows/ffi-go-staticlib.yml"
+      - "!**/*.md"
+      - "!**/LICENSE"
 
 jobs:
   build-aa-ffi-go:

--- a/.github/workflows/integration-bypass-permissions.yml
+++ b/.github/workflows/integration-bypass-permissions.yml
@@ -8,6 +8,8 @@ on:
       - "aa-proxy/**"
       - "ci/integration/bypass-permissions/**"
       - ".github/workflows/integration-bypass-permissions.yml"
+      - "!**/*.md"
+      - "!**/LICENSE"
   push:
     branches: [master]
     paths:
@@ -15,6 +17,8 @@ on:
       - "aa-proxy/**"
       - "ci/integration/bypass-permissions/**"
       - ".github/workflows/integration-bypass-permissions.yml"
+      - "!**/*.md"
+      - "!**/LICENSE"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -8,6 +8,8 @@ on:
       - "dashboard/**"
       - "sonar-project.properties"
       - ".github/workflows/sonar.yml"
+      - "!**/*.md"
+      - "!**/LICENSE"
   pull_request:
     branches: [master]
     paths:
@@ -15,6 +17,8 @@ on:
       - "dashboard/**"
       - "sonar-project.properties"
       - ".github/workflows/sonar.yml"
+      - "!**/*.md"
+      - "!**/LICENSE"
 
 jobs:
   sonar:


### PR DESCRIPTION
## Summary

Adds negation patterns (`!**/*.md`, `!**/LICENSE`) to every `paths:` filter in all 7 code-CI workflows in this repo, so documentation-only PRs no longer trigger code CI.

## Why

PR https://github.com/AI-agent-assembly/agent-assembly/pull/421 (`dashboard/README.md` +32 lines only) ran the full Dashboard CI because `paths: ["dashboard/**", ...]` matched the README. The same pattern existed in 6 other workflows.

## Files changed

| Workflow | Existing paths |
|---|---|
| `ci.yml` | `aa-*/**`, `proto/**`, `conformance/**`, ... |
| `dashboard-ci.yml` | `dashboard/**`, `openapi/v1.yaml` |
| `dev-verify.yml` | `Makefile`, `scripts/**` |
| `docker.yml` (PR only) | `aa-runtime/**` |
| `ffi-go-staticlib.yml` | `aa-ffi-go/**` |
| `integration-bypass-permissions.yml` | `aa-devtool-claude-code/**`, `aa-proxy/**`, `ci/integration/bypass-permissions/**` |
| `sonar.yml` | `aa-*/**`, `dashboard/**`, `sonar-project.properties` |

Each block (both `push.paths` and `pull_request.paths`) gains:
```yaml
- "!**/*.md"
- "!**/LICENSE"
```

## How GitHub evaluates this

`paths:` is positive-match; entries starting with `!` are negative-match. The workflow runs only if there's at least one positively matched path AND not every changed file matches a negation. So:
- README-only PR → matches `dashboard/**` (positive), then matches `!**/*.md` (negation) → workflow does NOT run ✅
- Code PR → matches `dashboard/src/foo.tsx` (positive), doesn't match negation → workflow runs ✅
- Mixed PR → at least one non-md file changes → workflow runs ✅

## Out of scope

`docs.yml` and `release.yml` are unchanged — they should fire on docs/tags respectively.

## How to verify

After merge, open a PR touching only a `.md` file under any of the path-scoped directories. None of the 7 code-CI workflows should appear.

Closes AAASM-1408