### PR TITLE
[AAASM-1418] 🔌 (aa-api): Enrich ViolationPayload with operation details for Live Ops

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "aa-devtool",
  "aa-devtool-saas",
  "aa-gateway",
+ "aa-proto",
  "aa-runtime",
  "argon2",
  "axum",

--- a/aa-api/Cargo.toml
+++ b/aa-api/Cargo.toml
@@ -11,6 +11,7 @@ aa-core = { path = "../aa-core" }
 aa-devtool       = { path = "../aa-devtool" }
 aa-devtool-saas  = { path = "../aa-devtool-saas" }
 aa-gateway = { path = "../aa-gateway" }
+aa-proto = { path = "../aa-proto" }
 aa-runtime = { path = "../aa-runtime" }
 argon2 = "0.5"
 axum = { version = "0.8", features = ["ws"] }

--- a/aa-api/src/models/ws_payloads.rs
+++ b/aa-api/src/models/ws_payloads.rs
@@ -23,6 +23,30 @@ pub enum ViolationPayload {
         received_at_ms: i64,
         /// Monotonic sequence number assigned by the pipeline.
         sequence_number: u64,
+        /// Operation kind from the underlying `AuditEvent.action_type` — one of
+        /// `"llm_call"`, `"tool_call"`, `"file_op"`, `"network"`, `"process"`,
+        /// `"spawn"`, or `"unknown"` when unspecified. Drives the Live Ops
+        /// dashboard's per-row "op type" column.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        op_type: Option<String>,
+        /// Target resource derived from the action's `detail` variant — e.g.
+        /// `LLMCallDetail.model_name`, `ToolCallDetail.tool_name`,
+        /// `FileOpDetail.path`. Drives the Live Ops "resource" column.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        resource: Option<String>,
+        /// Operation lifecycle status mapped from the proto `Decision`:
+        /// `"running"` (allow / redact), `"blocked"` (deny), `"pending"`
+        /// (awaiting human approval).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        status: Option<String>,
+        /// Observed latency in milliseconds. Optional today — populated once
+        /// the audit pipeline tracks per-action duration end-to-end.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        latency_ms: Option<u64>,
+        /// Team identifier from the agent's lineage context. Empty for
+        /// legacy events and root agents without a team set.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        team: Option<String>,
     },
     /// An interception layer became unavailable.
     LayerDegradation {
@@ -65,6 +89,104 @@ pub struct BudgetAlertPayload {
     pub spent_usd: f64,
     /// Configured daily limit in USD.
     pub limit_usd: f64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn audit_serializes_with_op_fields() {
+        let payload = ViolationPayload::Audit {
+            source: "sdk".into(),
+            received_at_ms: 1_700_000_000_000,
+            sequence_number: 42,
+            op_type: Some("tool_call".into()),
+            resource: Some("gmail.send".into()),
+            status: Some("running".into()),
+            latency_ms: Some(834),
+            team: Some("support".into()),
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["kind"], "audit");
+        assert_eq!(json["op_type"], "tool_call");
+        assert_eq!(json["resource"], "gmail.send");
+        assert_eq!(json["status"], "running");
+        assert_eq!(json["latency_ms"], 834);
+        assert_eq!(json["team"], "support");
+    }
+
+    #[test]
+    fn audit_round_trips_through_serde() {
+        let original = ViolationPayload::Audit {
+            source: "sdk".into(),
+            received_at_ms: 1_700_000_000_000,
+            sequence_number: 42,
+            op_type: Some("llm_call".into()),
+            resource: Some("gpt-4o".into()),
+            status: Some("running".into()),
+            latency_ms: Some(600),
+            team: None,
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: ViolationPayload = serde_json::from_str(&json).unwrap();
+        let ViolationPayload::Audit {
+            op_type,
+            resource,
+            status,
+            latency_ms,
+            team,
+            ..
+        } = decoded
+        else {
+            panic!("expected Audit variant");
+        };
+        assert_eq!(op_type.as_deref(), Some("llm_call"));
+        assert_eq!(resource.as_deref(), Some("gpt-4o"));
+        assert_eq!(status.as_deref(), Some("running"));
+        assert_eq!(latency_ms, Some(600));
+        assert_eq!(team, None);
+    }
+
+    #[test]
+    fn audit_omits_none_fields_from_json() {
+        // Mirrors the back-compat path: an event constructed without op
+        // metadata should serialize like the pre-1418 shape so legacy
+        // consumers don't see unexpected null fields.
+        let payload = ViolationPayload::Audit {
+            source: "sdk".into(),
+            received_at_ms: 1_700_000_000_000,
+            sequence_number: 1,
+            op_type: None,
+            resource: None,
+            status: None,
+            latency_ms: None,
+            team: None,
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        let obj = json.as_object().unwrap();
+        assert!(!obj.contains_key("op_type"));
+        assert!(!obj.contains_key("resource"));
+        assert!(!obj.contains_key("status"));
+        assert!(!obj.contains_key("latency_ms"));
+        assert!(!obj.contains_key("team"));
+    }
+
+    #[test]
+    fn audit_decodes_legacy_json_without_op_fields() {
+        // Pre-1418 payload shape — no op fields. Must still decode cleanly.
+        let legacy = serde_json::json!({
+            "kind": "audit",
+            "source": "sdk",
+            "received_at_ms": 1700000000000_i64,
+            "sequence_number": 1
+        });
+        let decoded: ViolationPayload = serde_json::from_value(legacy).unwrap();
+        let ViolationPayload::Audit { op_type, .. } = decoded else {
+            panic!("expected Audit variant");
+        };
+        assert_eq!(op_type, None);
+    }
 }
 
 /// Discriminated union of all possible `GovernanceEvent.payload` shapes.

--- a/aa-api/src/ws/handler.rs
+++ b/aa-api/src/ws/handler.rs
@@ -2,6 +2,7 @@
 
 use std::time::Duration;
 
+use crate::models::ws_payloads::{EventPayload, ViolationPayload};
 use crate::models::{EventType, GovernanceEvent};
 use crate::state::AppState;
 use crate::ws::params::WsQueryParams;
@@ -143,7 +144,10 @@ async fn handle_socket(socket: WebSocket, params: WsQueryParams, state: AppState
                     id,
                     event_type: EventType::Violation,
                     agent_id: extract_pipeline_agent_id(&pipeline_ev),
-                    payload: serde_json::to_value(format!("{pipeline_ev:?}")).unwrap_or_default(),
+                    payload: serde_json::to_value(EventPayload::Violation(
+                        build_violation_payload(&pipeline_ev),
+                    ))
+                    .unwrap_or_default(),
                     timestamp: chrono::Utc::now(),
                 })
             }
@@ -211,6 +215,111 @@ fn extract_pipeline_agent_id(ev: &aa_runtime::pipeline::event::PipelineEvent) ->
     }
 }
 
+/// Build a structured `ViolationPayload` from a `PipelineEvent` so the
+/// Live Ops dashboard receives op-level metadata (op type, target
+/// resource, lifecycle status, etc.) rather than a Debug-format string.
+///
+/// `latency_ms` is sourced from the relevant `Detail` variant when
+/// available (LLM / tool / network / process); `FileOp`, `Violation`,
+/// and `Approval` details don't carry an end-to-end latency and leave
+/// the field as `None`. `call_stack` is intentionally absent — that
+/// requires a proto-level addition tracked elsewhere.
+fn build_violation_payload(ev: &aa_runtime::pipeline::event::PipelineEvent) -> ViolationPayload {
+    use aa_runtime::pipeline::event::{EventSource, PipelineEvent};
+
+    match ev {
+        PipelineEvent::Audit(enriched) => {
+            let source = match enriched.source {
+                EventSource::Sdk => "sdk",
+                EventSource::EBpf => "ebpf",
+                EventSource::Proxy => "proxy",
+            }
+            .to_string();
+
+            let op_type = action_type_label(enriched.inner.action_type);
+            let status = decision_label(enriched.inner.decision);
+            let team = if enriched.inner.team_id.is_empty() {
+                None
+            } else {
+                Some(enriched.inner.team_id.clone())
+            };
+            let (resource, latency_ms) = detail_op_fields(enriched.inner.detail.as_ref());
+
+            ViolationPayload::Audit {
+                source,
+                received_at_ms: enriched.received_at_ms,
+                sequence_number: enriched.sequence_number,
+                op_type,
+                resource,
+                status,
+                latency_ms,
+                team,
+            }
+        }
+        PipelineEvent::LayerDegradation(info) => ViolationPayload::LayerDegradation {
+            layer: info.layer.clone(),
+            reason: info.reason.clone(),
+            remaining_layers: info.remaining_layers.clone(),
+        },
+    }
+}
+
+/// Map the proto `ActionType` enum (raw `i32`) to the dashboard's
+/// op-type string. Returns `None` when the value is unspecified or
+/// outside the enum's known range so the field is omitted from JSON.
+fn action_type_label(raw: i32) -> Option<String> {
+    use aa_proto::assembly::common::v1::ActionType;
+    let action_type = ActionType::try_from(raw).ok()?;
+    let label = match action_type {
+        ActionType::LlmCall => "llm_call",
+        ActionType::ToolCall => "tool_call",
+        ActionType::FileOperation => "file_op",
+        ActionType::NetworkCall => "network",
+        ActionType::ProcessExec => "process",
+        ActionType::AgentSpawn => "spawn",
+        ActionType::ActionUnspecified => return None,
+    };
+    Some(label.to_string())
+}
+
+/// Map the proto `Decision` enum (raw `i32`) to the dashboard's
+/// `OperationStatus` discriminant. Treats Allow / Redact as `running`
+/// (the action proceeded); Deny → `blocked`; Pending → `pending`.
+fn decision_label(raw: i32) -> Option<String> {
+    use aa_proto::assembly::common::v1::Decision;
+    let decision = Decision::try_from(raw).ok()?;
+    let label = match decision {
+        Decision::Allow | Decision::Redact => "running",
+        Decision::Deny => "blocked",
+        Decision::Pending => "pending",
+        Decision::Unspecified => return None,
+    };
+    Some(label.to_string())
+}
+
+/// Extract per-detail resource + latency fields. The resource label
+/// is the most-identifying string per variant (model / tool name /
+/// path / host / command / blocked action); latency comes from the
+/// variants that carry an end-to-end duration.
+fn detail_op_fields(
+    detail: Option<&aa_proto::assembly::audit::v1::audit_event::Detail>,
+) -> (Option<String>, Option<u64>) {
+    use aa_proto::assembly::audit::v1::audit_event::Detail;
+
+    let Some(detail) = detail else {
+        return (None, None);
+    };
+    match detail {
+        Detail::LlmCall(d) => (Some(d.model.clone()), u64::try_from(d.latency_ms).ok()),
+        Detail::ToolCall(d) => (Some(d.tool_name.clone()), u64::try_from(d.latency_ms).ok()),
+        Detail::FileOp(d) => (Some(d.path.clone()), None),
+        Detail::Network(d) => (Some(format!("{}:{}", d.host, d.port)), u64::try_from(d.latency_ms).ok()),
+        Detail::Process(d) => (Some(d.command.clone()), u64::try_from(d.duration_ms).ok()),
+        Detail::Violation(d) => (Some(d.blocked_action.clone()), None),
+        Detail::Approval(_) => (None, None),
+    }
+}
+
 /// Serialise a governance event and send it as a WebSocket text frame.
 async fn send_event(
     sender: &std::sync::Arc<tokio::sync::Mutex<SplitSink<WebSocket, Message>>>,
@@ -223,4 +332,261 @@ async fn send_event(
         .send(Message::Text(json.into()))
         .await
         .map_err(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aa_proto::assembly::audit::v1::{
+        audit_event::Detail, AuditEvent, FileOpDetail, LayerDegradationEvent, LlmCallDetail, NetworkCallDetail,
+        PolicyViolation, ProcessExecDetail, ToolCallDetail,
+    };
+    use aa_proto::assembly::common::v1::{ActionType, Decision};
+    use aa_runtime::pipeline::event::{EnrichedEvent, EventSource, LayerDegradationInfo, PipelineEvent};
+    use std::boxed::Box;
+
+    fn make_audit_event(
+        action_type: ActionType,
+        decision: Decision,
+        team_id: &str,
+        detail: Option<Detail>,
+    ) -> AuditEvent {
+        AuditEvent {
+            event_id: "evt-1".into(),
+            agent_id: None,
+            occurred_at: None,
+            action_type: action_type.into(),
+            decision: decision.into(),
+            trace_id: "trace-1".into(),
+            span_id: "span-1".into(),
+            parent_span_id: String::new(),
+            detail,
+            labels: Default::default(),
+            root_agent_id: String::new(),
+            parent_agent_id: String::new(),
+            team_id: team_id.into(),
+            session_id: String::new(),
+            delegation_reason: String::new(),
+            spawned_by_tool: String::new(),
+            depth: 0,
+        }
+    }
+
+    fn pipeline_audit(
+        action_type: ActionType,
+        decision: Decision,
+        team_id: &str,
+        detail: Option<Detail>,
+    ) -> PipelineEvent {
+        PipelineEvent::Audit(Box::new(EnrichedEvent {
+            inner: make_audit_event(action_type, decision, team_id, detail),
+            received_at_ms: 1_700_000_000_000,
+            source: EventSource::Sdk,
+            agent_id: "support-agent".into(),
+            connection_id: 0,
+            sequence_number: 42,
+        }))
+    }
+
+    /// Test-only flattened view of the `Audit` variant for ergonomic asserts.
+    struct AuditFields {
+        source: String,
+        sequence_number: u64,
+        op_type: Option<String>,
+        resource: Option<String>,
+        status: Option<String>,
+        latency_ms: Option<u64>,
+        team: Option<String>,
+    }
+
+    fn unwrap_audit_fields(p: ViolationPayload) -> AuditFields {
+        match p {
+            ViolationPayload::Audit {
+                source,
+                received_at_ms: _,
+                sequence_number,
+                op_type,
+                resource,
+                status,
+                latency_ms,
+                team,
+            } => AuditFields {
+                source,
+                sequence_number,
+                op_type,
+                resource,
+                status,
+                latency_ms,
+                team,
+            },
+            ViolationPayload::LayerDegradation { .. } => panic!("expected Audit variant"),
+        }
+    }
+
+    #[test]
+    fn audit_llm_call_maps_model_and_latency() {
+        let ev = pipeline_audit(
+            ActionType::LlmCall,
+            Decision::Allow,
+            "support",
+            Some(Detail::LlmCall(LlmCallDetail {
+                model: "gpt-4o".into(),
+                prompt_tokens: 100,
+                completion_tokens: 50,
+                latency_ms: 834,
+                pii_detected: false,
+                pii_redacted: false,
+                provider: "openai".into(),
+            })),
+        );
+        let fields = unwrap_audit_fields(build_violation_payload(&ev));
+        assert_eq!(fields.source, "sdk");
+        assert_eq!(fields.sequence_number, 42);
+        assert_eq!(fields.op_type.as_deref(), Some("llm_call"));
+        assert_eq!(fields.resource.as_deref(), Some("gpt-4o"));
+        assert_eq!(fields.status.as_deref(), Some("running"));
+        assert_eq!(fields.latency_ms, Some(834));
+        assert_eq!(fields.team.as_deref(), Some("support"));
+    }
+
+    #[test]
+    fn audit_tool_call_maps_tool_name() {
+        let ev = pipeline_audit(
+            ActionType::ToolCall,
+            Decision::Deny,
+            "",
+            Some(Detail::ToolCall(ToolCallDetail {
+                tool_name: "web_search".into(),
+                tool_source: "mcp".into(),
+                latency_ms: 41,
+                succeeded: false,
+                error_message: "blocked by policy".into(),
+            })),
+        );
+        let fields = unwrap_audit_fields(build_violation_payload(&ev));
+        assert_eq!(fields.op_type.as_deref(), Some("tool_call"));
+        assert_eq!(fields.resource.as_deref(), Some("web_search"));
+        assert_eq!(fields.status.as_deref(), Some("blocked"));
+        assert_eq!(fields.latency_ms, Some(41));
+        assert_eq!(fields.team, None, "empty team_id should serialize as None");
+    }
+
+    #[test]
+    fn audit_file_op_maps_path_no_latency() {
+        let ev = pipeline_audit(
+            ActionType::FileOperation,
+            Decision::Allow,
+            "",
+            Some(Detail::FileOp(FileOpDetail {
+                operation: "read".into(),
+                path: "/etc/passwd".into(),
+                bytes: 1024,
+                source: "sdk_hook".into(),
+            })),
+        );
+        let fields = unwrap_audit_fields(build_violation_payload(&ev));
+        assert_eq!(fields.op_type.as_deref(), Some("file_op"));
+        assert_eq!(fields.resource.as_deref(), Some("/etc/passwd"));
+        assert_eq!(fields.latency_ms, None);
+    }
+
+    #[test]
+    fn audit_network_call_maps_host_port() {
+        let ev = pipeline_audit(
+            ActionType::NetworkCall,
+            Decision::Allow,
+            "",
+            Some(Detail::Network(NetworkCallDetail {
+                host: "example.com".into(),
+                port: 443,
+                protocol: "https".into(),
+                latency_ms: 220,
+                status_code: 200,
+                succeeded: true,
+            })),
+        );
+        let fields = unwrap_audit_fields(build_violation_payload(&ev));
+        assert_eq!(fields.resource.as_deref(), Some("example.com:443"));
+        assert_eq!(fields.latency_ms, Some(220));
+    }
+
+    #[test]
+    fn audit_process_exec_maps_command_and_duration() {
+        let ev = pipeline_audit(
+            ActionType::ProcessExec,
+            Decision::Allow,
+            "",
+            Some(Detail::Process(ProcessExecDetail {
+                command: "/bin/sh".into(),
+                args: vec!["-c".into(), "echo hi".into()],
+                exit_code: 0,
+                duration_ms: 12,
+                succeeded: true,
+            })),
+        );
+        let fields = unwrap_audit_fields(build_violation_payload(&ev));
+        assert_eq!(fields.op_type.as_deref(), Some("process"));
+        assert_eq!(fields.resource.as_deref(), Some("/bin/sh"));
+        assert_eq!(fields.latency_ms, Some(12));
+    }
+
+    #[test]
+    fn audit_policy_violation_resource_is_blocked_action() {
+        let ev = pipeline_audit(
+            ActionType::ToolCall,
+            Decision::Deny,
+            "",
+            Some(Detail::Violation(PolicyViolation {
+                policy_rule: "no-secrets".into(),
+                blocked_action: "read /etc/shadow".into(),
+                reason: "policy denied".into(),
+            })),
+        );
+        let fields = unwrap_audit_fields(build_violation_payload(&ev));
+        assert_eq!(fields.resource.as_deref(), Some("read /etc/shadow"));
+        assert_eq!(fields.status.as_deref(), Some("blocked"));
+    }
+
+    #[test]
+    fn audit_pending_decision_maps_to_pending_status() {
+        let ev = pipeline_audit(ActionType::ToolCall, Decision::Pending, "", None);
+        let fields = unwrap_audit_fields(build_violation_payload(&ev));
+        assert_eq!(fields.status.as_deref(), Some("pending"));
+    }
+
+    #[test]
+    fn audit_redact_decision_maps_to_running_status() {
+        let ev = pipeline_audit(ActionType::ToolCall, Decision::Redact, "", None);
+        let fields = unwrap_audit_fields(build_violation_payload(&ev));
+        assert_eq!(fields.status.as_deref(), Some("running"));
+    }
+
+    #[test]
+    fn layer_degradation_passes_through() {
+        let _unused = LayerDegradationEvent {
+            agent_id: String::new(),
+            session_id: String::new(),
+            timestamp_ns: 0,
+            layer: String::new(),
+            reason: String::new(),
+            remaining_layers: vec![],
+        };
+        let ev = PipelineEvent::LayerDegradation(LayerDegradationInfo {
+            layer: "ebpf".into(),
+            reason: "uprobe attach failed".into(),
+            remaining_layers: vec!["proxy".into(), "sdk".into()],
+        });
+        match build_violation_payload(&ev) {
+            ViolationPayload::LayerDegradation {
+                layer,
+                reason,
+                remaining_layers,
+            } => {
+                assert_eq!(layer, "ebpf");
+                assert_eq!(reason, "uprobe attach failed");
+                assert_eq!(remaining_layers, vec!["proxy".to_string(), "sdk".to_string()]);
+            }
+            ViolationPayload::Audit { .. } => panic!("expected LayerDegradation variant"),
+        }
+    }
 }

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -1398,9 +1398,28 @@ export interface components {
             kind: "audit";
             /**
              * Format: int64
+             * @description Observed latency in milliseconds. Optional today — populated once
+             *     the audit pipeline tracks per-action duration end-to-end.
+             */
+            latency_ms?: number | null;
+            /**
+             * @description Operation kind from the underlying `AuditEvent.action_type` — one of
+             *     `"llm_call"`, `"tool_call"`, `"file_op"`, `"network"`, `"process"`,
+             *     `"spawn"`, or `"unknown"` when unspecified. Drives the Live Ops
+             *     dashboard's per-row "op type" column.
+             */
+            op_type?: string | null;
+            /**
+             * Format: int64
              * @description Unix milliseconds when the pipeline received the event.
              */
             received_at_ms: number;
+            /**
+             * @description Target resource derived from the action's `detail` variant — e.g.
+             *     `LLMCallDetail.model_name`, `ToolCallDetail.tool_name`,
+             *     `FileOpDetail.path`. Drives the Live Ops "resource" column.
+             */
+            resource?: string | null;
             /**
              * Format: int64
              * @description Monotonic sequence number assigned by the pipeline.
@@ -1408,6 +1427,17 @@ export interface components {
             sequence_number: number;
             /** @description Source that delivered the event: `"sdk"`, `"ebpf"`, or `"proxy"`. */
             source: string;
+            /**
+             * @description Operation lifecycle status mapped from the proto `Decision`:
+             *     `"running"` (allow / redact), `"blocked"` (deny), `"pending"`
+             *     (awaiting human approval).
+             */
+            status?: string | null;
+            /**
+             * @description Team identifier from the agent's lineage context. Empty for
+             *     legacy events and root agents without a team set.
+             */
+            team?: string | null;
         } | {
             /** @enum {string} */
             kind: "layer_degradation";

--- a/dashboard/src/features/liveOps/useLiveOpsStream.test.ts
+++ b/dashboard/src/features/liveOps/useLiveOpsStream.test.ts
@@ -51,7 +51,17 @@ const VIOLATION_EVENT = {
   agent_id: 'support-agent',
   event_type: 'violation',
   timestamp: '2026-05-13T14:23:01Z',
-  payload: { kind: 'audit', received_at_ms: 0, sequence_number: 1, source: 'sdk' },
+  payload: {
+    kind: 'audit',
+    received_at_ms: 0,
+    sequence_number: 1,
+    source: 'sdk',
+    op_type: 'tool_call',
+    resource: 'web_search',
+    status: 'running',
+    latency_ms: 41,
+    team: 'support',
+  },
 }
 
 const opts = {
@@ -100,6 +110,72 @@ describe('useLiveOpsStream', () => {
       startedAt: '2026-05-13T14:23:01Z',
       status: 'running',
     })
+  })
+
+  it('populates every LiveOperation field from the structured payload', () => {
+    const { result } = renderHook(() => useLiveOpsStream(opts))
+    act(() => {
+      MockWebSocket.instances[0].open()
+      MockWebSocket.instances[0].emit(VIOLATION_EVENT)
+    })
+    expect(result.current.ops[0]).toEqual({
+      id: '1',
+      agent: 'support-agent',
+      team: 'support',
+      opType: 'tool_call',
+      resource: 'web_search',
+      status: 'running',
+      startedAt: '2026-05-13T14:23:01Z',
+      latencyMs: 41,
+    })
+  })
+
+  it('falls back to safe defaults when the payload is missing op fields', () => {
+    const { result } = renderHook(() => useLiveOpsStream(opts))
+    act(() => {
+      MockWebSocket.instances[0].open()
+      MockWebSocket.instances[0].emit({
+        ...VIOLATION_EVENT,
+        payload: { kind: 'audit', received_at_ms: 0, sequence_number: 1, source: 'sdk' },
+      })
+    })
+    expect(result.current.ops[0]).toMatchObject({
+      opType: 'unknown',
+      resource: '',
+      status: 'running',
+      latencyMs: 0,
+      team: undefined,
+    })
+  })
+
+  it('coerces an unknown status string to running', () => {
+    const { result } = renderHook(() => useLiveOpsStream(opts))
+    act(() => {
+      MockWebSocket.instances[0].open()
+      MockWebSocket.instances[0].emit({
+        ...VIOLATION_EVENT,
+        payload: { ...VIOLATION_EVENT.payload, status: 'something-else' },
+      })
+    })
+    expect(result.current.ops[0]?.status).toBe('running')
+  })
+
+  it('maps blocked / pending status values through unchanged', () => {
+    const { result } = renderHook(() => useLiveOpsStream(opts))
+    act(() => {
+      MockWebSocket.instances[0].open()
+      MockWebSocket.instances[0].emit({
+        ...VIOLATION_EVENT,
+        id: 10,
+        payload: { ...VIOLATION_EVENT.payload, status: 'blocked' },
+      })
+      MockWebSocket.instances[0].emit({
+        ...VIOLATION_EVENT,
+        id: 11,
+        payload: { ...VIOLATION_EVENT.payload, status: 'pending' },
+      })
+    })
+    expect(result.current.ops.map((o) => o.status)).toEqual(['pending', 'blocked'])
   })
 
   it('ignores non-violation event types', () => {

--- a/dashboard/src/features/liveOps/useLiveOpsStream.ts
+++ b/dashboard/src/features/liveOps/useLiveOpsStream.ts
@@ -1,8 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { components } from '../../api/generated/schema'
-import type { LiveOperation } from './types'
+import type { LiveOperation, OperationStatus } from './types'
+import { OPERATION_STATUSES } from './types'
 
 type GovernanceEvent = components['schemas']['GovernanceEvent']
+type ViolationPayload = components['schemas']['ViolationPayload']
+type ViolationAuditPayload = Extract<ViolationPayload, { kind: 'audit' }>
 
 export type StreamStatus = 'connecting' | 'connected' | 'reconnecting' | 'error'
 
@@ -42,16 +45,29 @@ function buildWsUrl(): string {
   return `${wsBase}/api/v1/ws/events?${query}`
 }
 
+function isAuditPayload(p: unknown): p is ViolationAuditPayload {
+  return typeof p === 'object' && p !== null && (p as { kind?: unknown }).kind === 'audit'
+}
+
+function coerceStatus(raw: string | null | undefined): OperationStatus {
+  if (raw && (OPERATION_STATUSES as readonly string[]).includes(raw)) {
+    return raw as OperationStatus
+  }
+  return 'running'
+}
+
 function mapEvent(event: GovernanceEvent): LiveOperation | null {
   if (event.event_type !== 'violation') return null
+  const audit = isAuditPayload(event.payload) ? event.payload : null
   return {
     id: String(event.id),
     agent: event.agent_id,
-    opType: 'unknown',
-    resource: '',
-    status: 'running',
+    team: audit?.team ?? undefined,
+    opType: audit?.op_type ?? 'unknown',
+    resource: audit?.resource ?? '',
+    status: coerceStatus(audit?.status),
     startedAt: event.timestamp,
-    latencyMs: 0,
+    latencyMs: audit?.latency_ms ?? 0,
   }
 }
 

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -2307,10 +2307,36 @@ components:
             type: string
             enum:
             - audit
+          latency_ms:
+            type:
+            - integer
+            - 'null'
+            format: int64
+            description: |-
+              Observed latency in milliseconds. Optional today — populated once
+              the audit pipeline tracks per-action duration end-to-end.
+            minimum: 0
+          op_type:
+            type:
+            - string
+            - 'null'
+            description: |-
+              Operation kind from the underlying `AuditEvent.action_type` — one of
+              `"llm_call"`, `"tool_call"`, `"file_op"`, `"network"`, `"process"`,
+              `"spawn"`, or `"unknown"` when unspecified. Drives the Live Ops
+              dashboard's per-row "op type" column.
           received_at_ms:
             type: integer
             format: int64
             description: Unix milliseconds when the pipeline received the event.
+          resource:
+            type:
+            - string
+            - 'null'
+            description: |-
+              Target resource derived from the action's `detail` variant — e.g.
+              `LLMCallDetail.model_name`, `ToolCallDetail.tool_name`,
+              `FileOpDetail.path`. Drives the Live Ops "resource" column.
           sequence_number:
             type: integer
             format: int64
@@ -2319,6 +2345,21 @@ components:
           source:
             type: string
             description: 'Source that delivered the event: `"sdk"`, `"ebpf"`, or `"proxy"`.'
+          status:
+            type:
+            - string
+            - 'null'
+            description: |-
+              Operation lifecycle status mapped from the proto `Decision`:
+              `"running"` (allow / redact), `"blocked"` (deny), `"pending"`
+              (awaiting human approval).
+          team:
+            type:
+            - string
+            - 'null'
+            description: |-
+              Team identifier from the agent's lineage context. Empty for
+              legacy events and root agents without a team set.
       - type: object
         description: An interception layer became unavailable.
         required:


### PR DESCRIPTION
## Summary

Stops the WS event-stream from emitting `payload: format!("{pipeline_ev:?}")` (Debug-format string) and starts emitting a fully-structured `ViolationPayload::Audit` enriched with op-level metadata pulled from the underlying `AuditEvent`. The Live Ops dashboard's `useLiveOpsStream.mapEvent` is rewired to read those fields, replacing the placeholder defaults that have been in the dashboard since AAASM-1331.

## What changes end-to-end

| Field | Before | After |
|---|---|---|
| `opType` | `'unknown'` (placeholder) | proto `ActionType` → `"llm_call"` / `"tool_call"` / `"file_op"` / `"network"` / `"process"` / `"spawn"` |
| `resource` | `''` (placeholder) | per-Detail variant: `LlmCallDetail.model`, `ToolCallDetail.tool_name`, `FileOpDetail.path`, `NetworkCallDetail.host:port`, `ProcessExecDetail.command`, `PolicyViolation.blocked_action` |
| `status` | `'running'` (hardcoded) | proto `Decision` → `running` (Allow/Redact) · `blocked` (Deny) · `pending` (Pending) |
| `latencyMs` | `0` (placeholder) | `latency_ms` from LLM / tool / network / process Detail variants; `0` fallback for variants without duration |
| `team` | always `undefined` | `AuditEvent.team_id` (empty string → `undefined`) |

## Commit map (6 granular commits)

| # | Commit | Scope |
|---|---|---|
| 1 | `✨ (aa-api/payloads): Add op metadata fields to ViolationPayload::Audit` | Widen the Rust enum with five `Option<...>` fields + serde-skip-when-None + utoipa annotations + 4 serde round-trip tests |
| 2 | `✨ (aa-api/ws): Build structured ViolationPayload from PipelineEvent + emit it` | `build_violation_payload` helper translates `PipelineEvent` → `ViolationPayload`; ActionType/Decision/Detail extraction helpers; replaces the Debug-stringification at the WS dispatch site; 9 unit tests |
| 3 | `🔧 (openapi): Regenerate v1.yaml for ViolationPayload enrichment` | `cargo run -p aa-api --bin generate_openapi > openapi/v1.yaml`; spectral-lint clean |
| 4 | `🔧 (dashboard/api): Regenerate schema.d.ts for ViolationPayload enrichment` | `pnpm generate:api` |
| 5 | `✨ (live-ops/hook): Read structured payload fields in mapEvent` | `mapEvent` narrows to audit variant + pulls all 5 new fields with sensible defaults; status string coerced into the dashboard's `OperationStatus` union |
| 6 | `✅ (live-ops/hook): Assert every LiveOperation field is populated end-to-end` | Updates `VIOLATION_EVENT` fixture + 4 new cases (full population / back-compat fallback / unknown status coerces / blocked-pending pass through) |

## Dependencies

`aa-api` gains a direct `aa-proto` dep — previously it used proto types transitively via `aa-runtime`'s public API. The new dispatch site needs direct access to `audit_event::Detail` and the `ActionType` / `Decision` enums.

## Deferred (filed at PR-merge time as separate Tasks)

* **`call_stack`** — would require a proto-level addition + SDK regen across Python / Node / Go. Out of scope here.
* **Approval + Budget event paths** — `aa-api/src/ws/handler.rs:154-172` still uses Debug-stringification for those two payloads. Different schemas, separate Task.
* **Real `latency_ms` for FileOp / PolicyViolation / Approval** — those Detail variants don't track per-action duration today.

## Test plan

* [x] `cargo nextest run -p aa-api` — 246 / 246 pass
* [x] `cargo fmt --all` clean, `cargo clippy -p aa-api --all-targets -- -D warnings` clean
* [x] `npx @stoplight/spectral-cli lint openapi/v1.yaml` clean
* [x] `pnpm type-check` clean, `pnpm lint` clean
* [x] `pnpm test --run` — 833 / 833 across 96 files (was 825; 4 new test cases + reused 4 from C2)

Closes AAASM-1418.