### PR TITLE
[AAASM-1411] ♻️ (dashboard): Migrate features/iam/ hex literals to design tokens

### DIFF
--- a/dashboard/src/features/iam/AgentPermissionsPanel.css
+++ b/dashboard/src/features/iam/AgentPermissionsPanel.css
@@ -1,7 +1,7 @@
 .iam-agent-perm-panel {
-  border: 1px solid var(--shell-border, #e4e4e7);
+  border: 1px solid var(--shell-border-subtle);
   border-radius: 0.5rem;
-  background: var(--shell-surface, #fff);
+  background: var(--shell-surface);
   padding: 1rem;
   display: flex;
   flex-direction: column;
@@ -14,7 +14,7 @@
   justify-content: space-between;
   align-items: flex-start;
   gap: 0.5rem;
-  border-bottom: 1px solid var(--shell-border, #e4e4e7);
+  border-bottom: 1px solid var(--shell-border-subtle);
   padding-bottom: 0.5rem;
 }
 
@@ -26,7 +26,7 @@
 .iam-agent-perm-panel__sub {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
   font-size: 0.75rem;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
 }
 
 .iam-agent-perm-panel__close {
@@ -34,32 +34,32 @@
   background: transparent;
   border: 0;
   font-size: 1.25rem;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
   cursor: pointer;
   line-height: 1;
   padding: 0 0.25rem;
 }
 
 .iam-agent-perm-panel__close:hover {
-  color: var(--shell-text, #18181b);
+  color: var(--shell-text);
 }
 
 .iam-agent-perm-panel__loading,
 .iam-agent-perm-panel__error {
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
   font-size: 0.85rem;
 }
 
 .iam-agent-perm-panel__error {
-  color: #b91c1c;
+  color: var(--status-danger-hover-text);
 }
 
 .iam-agent-perm-panel__empty {
   padding: 1rem;
   text-align: center;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
   font-size: 0.85rem;
-  border: 1px dashed var(--shell-border, #e4e4e7);
+  border: 1px dashed var(--shell-border-subtle);
   border-radius: 0.375rem;
 }
 
@@ -75,7 +75,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
 }
 
 .iam-agent-perm-group__list {
@@ -93,7 +93,7 @@
   gap: 0.5rem;
   align-items: center;
   padding: 0.25rem 0.5rem;
-  background: var(--shell-surface-muted, #fafafa);
+  background: var(--shell-surface-subtle);
   border-radius: 0.25rem;
   font-size: 0.8rem;
 }
@@ -106,11 +106,11 @@
 .iam-agent-perm-row__source {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
   font-size: 0.75rem;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
 }
 
 .iam-agent-perm-row__granted {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
   font-size: 0.7rem;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
 }

--- a/dashboard/src/features/iam/AgentRegistryList.css
+++ b/dashboard/src/features/iam/AgentRegistryList.css
@@ -8,7 +8,7 @@
 .iam-agent-list td {
   padding: 0.5rem 0.75rem;
   text-align: left;
-  border-bottom: 1px solid var(--shell-border, #e4e4e7);
+  border-bottom: 1px solid var(--shell-border-subtle);
 }
 
 .iam-agent-list th {
@@ -16,7 +16,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
 }
 
 .iam-agent-list__row {
@@ -24,7 +24,7 @@
 }
 
 .iam-agent-list__row:hover {
-  background: var(--shell-surface-muted, #f4f4f5);
+  background: var(--shell-surface-muted);
 }
 
 .iam-agent-list__row--selected {
@@ -38,14 +38,14 @@
 .iam-agent-list__loading,
 .iam-agent-list__empty {
   text-align: center;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
   padding: 1.5rem 0;
 }
 
 .iam-agent-list__mono {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
   font-size: 0.8rem;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
 }
 
 .iam-agent-list__name {
@@ -56,7 +56,7 @@
   display: flex;
   align-items: center;
   gap: 1rem;
-  color: #b91c1c;
+  color: var(--status-danger-hover-text);
   padding: 0.75rem 0;
 }
 
@@ -70,6 +70,6 @@
   letter-spacing: 0.04em;
 }
 
-.iam-agent-status--online { background: #dcfce7; color: #166534; }
-.iam-agent-status--offline { background: #f4f4f5; color: #525252; }
-.iam-agent-status--degraded { background: #fef3c7; color: #92400e; }
+.iam-agent-status--online { background: var(--status-success-bg); color: var(--status-success-text-strong); }
+.iam-agent-status--offline { background: var(--shell-surface-muted); color: var(--shell-text-strong); }
+.iam-agent-status--degraded { background: var(--badge-amber-bg); color: var(--alert-banner-text); }

--- a/dashboard/src/features/iam/ApiKeyList.css
+++ b/dashboard/src/features/iam/ApiKeyList.css
@@ -8,7 +8,7 @@
 .iam-api-key-list td {
   padding: 0.5rem 0.75rem;
   text-align: left;
-  border-bottom: 1px solid var(--shell-border, #e4e4e7);
+  border-bottom: 1px solid var(--shell-border-subtle);
 }
 
 .iam-api-key-list th {
@@ -16,20 +16,20 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
 }
 
 .iam-api-key-list__loading,
 .iam-api-key-list__empty {
   text-align: center;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
   padding: 1.5rem 0;
 }
 
 .iam-api-key-list__mono {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
   font-size: 0.8rem;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
 }
 
 .iam-api-key-list__label {
@@ -47,16 +47,16 @@
   padding: 1px 6px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
   font-size: 0.7rem;
-  background: var(--shell-surface-muted, #f4f4f5);
-  border: 1px solid var(--shell-border, #e4e4e7);
+  background: var(--shell-surface-muted);
+  border: 1px solid var(--shell-border-subtle);
   border-radius: 0.25rem;
-  color: var(--shell-text, #18181b);
+  color: var(--shell-text);
 }
 
 .iam-api-key-list__revoke-btn {
-  border: 1px solid #ef4444;
+  border: 1px solid var(--status-danger);
   background: transparent;
-  color: #ef4444;
+  color: var(--status-danger);
   font-size: 0.75rem;
   font-weight: 600;
   padding: 0.25rem 0.6rem;
@@ -77,12 +77,12 @@
   display: flex;
   align-items: center;
   gap: 1rem;
-  color: #b91c1c;
+  color: var(--status-danger-hover-text);
   padding: 0.75rem 0;
 }
 
 .iam-dialog__btn--danger {
-  background: #dc2626;
-  color: #fff;
+  background: var(--status-danger-solid);
+  color: var(--text-on-accent);
   border-color: transparent;
 }

--- a/dashboard/src/features/iam/ConfirmRoleChangeModal.tsx
+++ b/dashboard/src/features/iam/ConfirmRoleChangeModal.tsx
@@ -28,7 +28,7 @@ export function ConfirmRoleChangeModal({
         <p style={{ fontSize: '0.9rem', margin: '0 0 0.75rem' }}>
           Change <strong>{member.name}</strong>’s role from <strong>{member.role}</strong> to <strong>{nextRole}</strong>?
         </p>
-        <p style={{ fontSize: '0.85rem', color: '#b91c1c', margin: 0 }} data-testid="confirm-role-warning">
+        <p style={{ fontSize: '0.85rem', color: 'var(--status-danger-hover-text)', margin: 0 }} data-testid="confirm-role-warning">
           {danger.message}
         </p>
         <div className="iam-dialog__actions">

--- a/dashboard/src/features/iam/CustomRolePanel.css
+++ b/dashboard/src/features/iam/CustomRolePanel.css
@@ -4,7 +4,7 @@
   gap: 1rem;
   margin-top: 2rem;
   padding-top: 1.5rem;
-  border-top: 1px solid var(--shell-border, #e4e4e7);
+  border-top: 1px solid var(--shell-border-subtle);
 }
 
 .iam-custom-roles__header h3 {
@@ -15,15 +15,15 @@
 .iam-custom-roles__sub {
   margin: 0.25rem 0 0;
   font-size: 0.85rem;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
 }
 
 .iam-custom-roles__cta {
   display: inline-block;
   padding: 0.4rem 0.85rem;
-  border: 1px solid var(--shell-accent, #2563eb);
+  border: 1px solid var(--shell-accent);
   border-radius: 0.375rem;
-  color: var(--shell-accent, #2563eb);
+  color: var(--shell-accent);
   text-decoration: none;
   font-size: 0.85rem;
   font-weight: 600;
@@ -48,19 +48,19 @@
   flex-direction: column;
   gap: 0.25rem;
   padding: 0.6rem 0.75rem;
-  border: 1px solid var(--shell-border, #e4e4e7);
+  border: 1px solid var(--shell-border-subtle);
   border-radius: 0.375rem;
-  background: var(--shell-surface, #fff);
+  background: var(--shell-surface);
 }
 
 .iam-custom-roles__role-id {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
   font-size: 0.85rem;
   font-weight: 600;
-  color: var(--shell-text, #18181b);
+  color: var(--shell-text);
 }
 
 .iam-custom-roles__role-desc {
   font-size: 0.8rem;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
 }

--- a/dashboard/src/features/iam/GenerateKeyDialog.css
+++ b/dashboard/src/features/iam/GenerateKeyDialog.css
@@ -3,9 +3,9 @@
   grid-template-columns: 1fr 1fr;
   gap: 0.25rem 1rem;
   padding: 0.5rem 0.75rem;
-  border: 1px solid var(--shell-border, #d4d4d8);
+  border: 1px solid var(--shell-border);
   border-radius: 0.375rem;
-  background: var(--shell-surface-muted, #fafafa);
+  background: var(--shell-surface-subtle);
 }
 
 .iam-scope-checklist__row {

--- a/dashboard/src/features/iam/InviteMemberDialog.css
+++ b/dashboard/src/features/iam/InviteMemberDialog.css
@@ -9,8 +9,8 @@
 }
 
 .iam-dialog {
-  background: var(--shell-surface, #fff);
-  color: var(--shell-text, #18181b);
+  background: var(--shell-surface);
+  color: var(--shell-text);
   border-radius: 0.5rem;
   padding: 1.5rem;
   width: min(28rem, 92vw);
@@ -29,28 +29,28 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
   margin-top: 0.75rem;
   margin-bottom: 0.25rem;
 }
 
 .iam-dialog__input {
   padding: 0.5rem 0.75rem;
-  border: 1px solid var(--shell-border, #d4d4d8);
+  border: 1px solid var(--shell-border);
   border-radius: 0.375rem;
   font-size: 0.9rem;
-  background: var(--shell-surface, #fff);
+  background: var(--shell-surface);
   color: inherit;
 }
 
 .iam-dialog__input[aria-invalid='true'] {
-  border-color: #dc2626;
+  border-color: var(--status-danger-solid);
 }
 
 .iam-dialog__error {
   margin-top: 0.25rem;
   font-size: 0.75rem;
-  color: #dc2626;
+  color: var(--status-danger-solid);
 }
 
 .iam-dialog__actions {
@@ -63,8 +63,8 @@
 .iam-dialog__btn {
   padding: 0.5rem 1rem;
   border-radius: 0.375rem;
-  border: 1px solid var(--shell-border, #d4d4d8);
-  background: var(--shell-surface, #fff);
+  border: 1px solid var(--shell-border);
+  background: var(--shell-surface);
   font-size: 0.875rem;
   cursor: pointer;
 }
@@ -75,7 +75,7 @@
 }
 
 .iam-dialog__btn--primary {
-  background: var(--shell-accent, #2563eb);
-  color: #fff;
+  background: var(--shell-accent);
+  color: var(--text-on-accent);
   border-color: transparent;
 }

--- a/dashboard/src/features/iam/LockedFeatureCard.css
+++ b/dashboard/src/features/iam/LockedFeatureCard.css
@@ -4,8 +4,8 @@
   gap: 1rem;
   align-items: center;
   padding: 1rem 1.25rem;
-  border: 1px solid var(--shell-border, #e4e4e7);
-  background: var(--shell-surface-muted, #fafafa);
+  border: 1px solid var(--shell-border-subtle);
+  background: var(--shell-surface-subtle);
   border-radius: 0.5rem;
 }
 
@@ -22,7 +22,7 @@
 .iam-locked-card__body {
   margin: 0;
   font-size: 0.875rem;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
   line-height: 1.5;
 }
 

--- a/dashboard/src/features/iam/MemberList.css
+++ b/dashboard/src/features/iam/MemberList.css
@@ -8,7 +8,7 @@
 .iam-member-list td {
   padding: 0.5rem 0.75rem;
   text-align: left;
-  border-bottom: 1px solid var(--shell-border, #e4e4e7);
+  border-bottom: 1px solid var(--shell-border-subtle);
 }
 
 .iam-member-list th {
@@ -16,27 +16,27 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
 }
 
 .iam-member-list__loading,
 .iam-member-list__empty {
   text-align: center;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
   padding: 1.5rem 0;
 }
 
 .iam-member-list__mono {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
   font-size: 0.8rem;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
 }
 
 .iam-member-list__error {
   display: flex;
   align-items: center;
   gap: 1rem;
-  color: #b91c1c;
+  color: var(--status-danger-hover-text);
   padding: 0.75rem 0;
 }
 
@@ -53,21 +53,21 @@
 .iam-member-cell__email {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
   font-size: 0.75rem;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
 }
 
 .iam-avatar {
   width: 1.75rem;
   height: 1.75rem;
   border-radius: 9999px;
-  background: var(--shell-surface-muted, #f4f4f5);
-  border: 1px solid var(--shell-border, #e4e4e7);
+  background: var(--shell-surface-muted);
+  border: 1px solid var(--shell-border-subtle);
   display: flex;
   align-items: center;
   justify-content: center;
   font-size: 0.75rem;
   font-weight: 700;
-  color: var(--shell-text, #18181b);
+  color: var(--shell-text);
   flex-shrink: 0;
 }
 
@@ -79,13 +79,13 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: #fff;
+  color: var(--text-on-accent);
 }
 
-.iam-role-badge--owner { background: #b91c1c; }
-.iam-role-badge--admin { background: #a16207; }
-.iam-role-badge--member { background: #2563eb; }
-.iam-role-badge--viewer { background: #525252; }
+.iam-role-badge--owner { background: var(--status-danger-hover-text); }
+.iam-role-badge--admin { background: var(--role-admin-bg); }
+.iam-role-badge--member { background: var(--shell-accent); }
+.iam-role-badge--viewer { background: var(--shell-text-strong); }
 
 .iam-status {
   display: inline-block;
@@ -97,9 +97,9 @@
   letter-spacing: 0.04em;
 }
 
-.iam-status--active { background: #dcfce7; color: #166534; }
-.iam-status--invited { background: #dbeafe; color: #1e40af; }
-.iam-status--suspended { background: #fee2e2; color: #991b1b; }
+.iam-status--active { background: var(--status-success-bg); color: var(--status-success-text-strong); }
+.iam-status--invited { background: var(--badge-blue-bg); color: var(--badge-blue-text-strong); }
+.iam-status--suspended { background: var(--status-danger-bg); color: var(--status-danger-text-strong); }
 
 .iam-role-cell {
   display: flex;

--- a/dashboard/src/features/iam/MembersPanel.css
+++ b/dashboard/src/features/iam/MembersPanel.css
@@ -16,8 +16,8 @@
 
 .iam-members-panel__invite-btn {
   padding: 0.4rem 0.9rem;
-  background: var(--shell-accent, #2563eb);
-  color: #fff;
+  background: var(--shell-accent);
+  color: var(--text-on-accent);
   border: 0;
   border-radius: 0.375rem;
   font-size: 0.875rem;

--- a/dashboard/src/features/iam/RevealOnceModal.tsx
+++ b/dashboard/src/features/iam/RevealOnceModal.tsx
@@ -74,7 +74,7 @@ export function RevealOnceModal({
         />
         <div className="iam-dialog__actions">
           {copied && (
-            <span data-testid="reveal-once-copied" style={{ marginRight: 'auto', color: '#16a34a', fontSize: '0.85rem' }}>
+            <span data-testid="reveal-once-copied" style={{ marginRight: 'auto', color: 'var(--status-success-solid)', fontSize: '0.85rem' }}>
               Copied — closing…
             </span>
           )}

--- a/dashboard/src/features/iam/RolesPermissionsPanel.css
+++ b/dashboard/src/features/iam/RolesPermissionsPanel.css
@@ -14,7 +14,7 @@
 .iam-roles-panel__sub {
   margin: 0.25rem 0 0;
   font-size: 0.85rem;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
 }
 
 .iam-roles-panel__layout {
@@ -34,11 +34,11 @@
 .iam-roles-panel__hint {
   padding: 1.5rem 1rem;
   text-align: center;
-  color: var(--shell-text-muted, #71717a);
+  color: var(--shell-text-muted);
   font-size: 0.85rem;
-  border: 1px dashed var(--shell-border, #e4e4e7);
+  border: 1px dashed var(--shell-border-subtle);
   border-radius: 0.5rem;
-  background: var(--shell-surface-muted, #fafafa);
+  background: var(--shell-surface-subtle);
 }
 
 @media (max-width: 60rem) {

--- a/dashboard/src/features/iam/ServiceIdentitiesPanel.css
+++ b/dashboard/src/features/iam/ServiceIdentitiesPanel.css
@@ -16,8 +16,8 @@
 
 .iam-services-panel__generate-btn {
   padding: 0.4rem 0.9rem;
-  background: var(--shell-accent, #2563eb);
-  color: #fff;
+  background: var(--shell-accent);
+  color: var(--text-on-accent);
   border: 0;
   border-radius: 0.375rem;
   font-size: 0.875rem;
@@ -27,10 +27,10 @@
 
 .iam-shown-once-banner {
   padding: 0.6rem 0.9rem;
-  background: #fef3c7;
-  border: 1px solid #fcd34d;
+  background: var(--badge-amber-bg);
+  border: 1px solid var(--badge-warning-border);
   border-radius: 0.375rem;
   font-size: 0.8rem;
-  color: #92400e;
+  color: var(--alert-banner-text);
   margin-bottom: 1rem;
 }

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -130,4 +130,25 @@
 
   /* ── Alert banner (amber-100 bg + amber-800 text) ────────── */
   --alert-banner-text: #92400e;
+
+  /* ── Shell surface/border extensions (IAM panels) ────────── */
+  /* The IAM pages and panels use a Tailwind zinc palette variant.
+     These tokens were previously inline fallbacks in iam/*.css. */
+  --shell-surface: #ffffff;
+  --shell-surface-muted: #f4f4f5;
+  --shell-surface-subtle: #fafafa;
+  --shell-border-subtle: #e4e4e7;
+  --shell-text-strong: #525252;
+
+  /* ── Status bg / strong-text variants (badges, banners) ──── */
+  --status-success-bg: #dcfce7;
+  --status-success-text-strong: #166534;
+  --status-danger-bg: #fee2e2;
+  --status-danger-text-strong: #991b1b;
+  --status-danger-hover-text: #b91c1c;
+
+  /* ── Badge / role extension tokens ───────────────────────── */
+  --badge-blue-text-strong: #1e40af;
+  --badge-warning-border: #fcd34d;
+  --role-admin-bg: #a16207;
 }


### PR DESCRIPTION
## Summary

Migrates **~95 hex color literals across 13 files in `dashboard/src/features/iam/`** to `var(--…)` references. Part 2 of 5 in the AAASM-1407 residual sweep.

After this merges, `grep -rE '#[0-9a-fA-F]{3,8}' dashboard/src/features/iam/` returns **zero** hits.

### What changed

* **`dashboard/src/styles.css`** — added 13 new semantic tokens for the IAM panels' Tailwind zinc palette:
  - **Shell surface/border extensions** — `--shell-surface`, `--shell-surface-muted` (zinc-100), `--shell-surface-subtle` (zinc-50), `--shell-border-subtle` (zinc-200), `--shell-text-strong` (neutral-600).
  - **Status bg + strong-text variants** — `--status-success-bg` (green-100), `--status-success-text-strong` (green-800), `--status-danger-bg` (red-100), `--status-danger-text-strong` (red-800), `--status-danger-hover-text` (red-700).
  - **Badge/role extensions** — `--badge-blue-text-strong` (blue-700), `--badge-warning-border` (amber-300), `--role-admin-bg` (yellow-700).
* **11 IAM CSS files migrated** — all the inline `var(--shell-X, #fallback)` patterns drop their fallback hex now that the tokens are defined globally. Role badges (owner/admin/member/viewer), status pills (active/invited/suspended, online/offline/degraded), buttons, dialogs, banners, scope chips, locked-feature cards, and table styles all reference tokens.
* **2 IAM TSX files migrated** — `ConfirmRoleChangeModal.tsx` (warning text) and `RevealOnceModal.tsx` (copied success indicator) inline-style hex colors swapped for `var(--…)`.

### Files migrated (95 hex refs → 0)

| File | Refs |
|---|---|
| `iam/MemberList.css` | 17 |
| `iam/AgentPermissionsPanel.css` | 14 |
| `iam/ApiKeyList.css` | 12 |
| `iam/InviteMemberDialog.css` | 11 |
| `iam/AgentRegistryList.css` | 9 |
| `iam/CustomRolePanel.css` | 8 |
| `iam/ServiceIdentitiesPanel.css` | 5 |
| `iam/RolesPermissionsPanel.css` | 4 |
| `iam/LockedFeatureCard.css` | 3 |
| `iam/GenerateKeyDialog.css` | 2 |
| `iam/MembersPanel.css` | 2 |
| `iam/ConfirmRoleChangeModal.tsx` | 1 |
| `iam/RevealOnceModal.tsx` | 1 |

### Commit shape

13 granular commits: 1 token addition + 11 file migrations + 1 bundled TSX migration (2 small TSX inline-style fixes that share semantic intent).

## Test plan

* [x] `grep -rE '#[0-9a-fA-F]{3,8}' dashboard/src/features/iam/` returns zero hits
* [x] `pnpm type-check` clean
* [x] `pnpm lint` clean
* [x] `pnpm test` — 829/829 passing across 96 test files
* [ ] Manual visual smoke — open IAM tabs (Members, Roles, Service Identities, Permissions); verify badges, tables, and dialogs look unchanged
* [ ] Playwright design-fidelity suite (AAASM-1382) still passes against this branch

Part of the AAASM-1407 decomposition. Sibling tickets: AAASM-1410 (alerts/), AAASM-1412 (analytics tsx/ts), AAASM-1413 (small features bundle), AAASM-1414 (pages/ — merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)