### PR TITLE
[AAASM-1415] ✨ (aa-api): Add pause/resume/terminate stub endpoints for Live Ops

### DIFF
--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -8,7 +8,7 @@ use crate::models::event::GovernanceEvent;
 use crate::models::event_type::EventType;
 use crate::models::trace::{TraceResponse, TraceSpan};
 use crate::models::ws_payloads::{ApprovalPayload, BudgetAlertPayload, EventPayload, ViolationPayload};
-use crate::routes::{agents, alerts, approvals, auth, costs, edges, logs, policies, topology, traces};
+use crate::routes::{agents, alerts, approvals, auth, costs, edges, logs, ops, policies, topology, traces};
 
 /// Root OpenAPI document collecting all annotated paths and schemas.
 #[derive(OpenApi)]
@@ -35,6 +35,7 @@ use crate::routes::{agents, alerts, approvals, auth, costs, edges, logs, policie
         (name = "auth", description = "Authentication and token issuance"),
         (name = "events", description = "Real-time event streaming via WebSocket"),
         (name = "topology", description = "Agent topology — tree, team, lineage, statistics, and mesh edge queries"),
+        (name = "ops", description = "Per-operation lifecycle actions (pause / resume / terminate)"),
     ),
     paths(
         crate::routes::health::health,
@@ -63,6 +64,9 @@ use crate::routes::{agents, alerts, approvals, auth, costs, edges, logs, policie
         edges::report_edge,
         edges::list_agent_edges,
         edges::get_agent_graph,
+        ops::pause_op,
+        ops::resume_op,
+        ops::terminate_op,
     ),
     components(schemas(
         crate::routes::health::HealthResponse,
@@ -102,6 +106,7 @@ use crate::routes::{agents, alerts, approvals, auth, costs, edges, logs, policie
         edges::EdgeListResponse,
         edges::GraphNode,
         edges::GraphResponse,
+        ops::OpActionAck,
         GovernanceEvent,
         EventType,
         ViolationPayload,

--- a/aa-api/src/routes/mod.rs
+++ b/aa-api/src/routes/mod.rs
@@ -11,6 +11,7 @@ pub mod devtools;
 pub mod edges;
 pub mod health;
 pub mod logs;
+pub mod ops;
 pub mod policies;
 pub mod tools;
 pub mod topology;
@@ -67,6 +68,10 @@ pub fn v1_router() -> Router {
         .route("/topology/edges", post(edges::report_edge))
         .route("/agents/{id}/edges", get(edges::list_agent_edges))
         .route("/agents/{id}/graph", get(edges::get_agent_graph))
+        // Per-op lifecycle actions (stubs — see routes/ops.rs)
+        .route("/ops/{id}/pause", post(ops::pause_op))
+        .route("/ops/{id}/resume", post(ops::resume_op))
+        .route("/ops/{id}/terminate", post(ops::terminate_op))
 }
 
 /// Fallback handler returning a 404 RFC 7807 response.

--- a/aa-api/src/routes/ops.rs
+++ b/aa-api/src/routes/ops.rs
@@ -1,0 +1,117 @@
+//! Per-operation lifecycle endpoints — pause / resume / terminate.
+//!
+//! These endpoints accept a request to change an in-flight operation's
+//! lifecycle state and return `202 Accepted`. They are intentionally
+//! **stubs** today:
+//!
+//! * No in-flight-ops registry exists in the gateway yet, so there is no
+//!   state machine to update.
+//! * No SDK-side enforcement channel exists, so the agent is not actually
+//!   paused / resumed / terminated.
+//!
+//! The handlers exist so the Live Ops dashboard can call the conventional
+//! `POST /api/v1/ops/{id}/{action}` paths without 404-ing, which exercises
+//! its optimistic UI's success path instead of its rollback path. Real
+//! enforcement is tracked under a separate architecture follow-up Task.
+
+use axum::extract::Path;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use crate::error::ProblemDetail;
+
+/// Acknowledgement returned by the per-op lifecycle endpoints.
+///
+/// The fields are deliberately minimal — they document what the
+/// gateway received, not the resulting state (which the dashboard
+/// observes via the WebSocket event stream).
+#[derive(Debug, Serialize, ToSchema)]
+pub struct OpActionAck {
+    /// Operation id from the URL path.
+    pub op_id: String,
+    /// Action that was requested — one of `"pause"`, `"resume"`, `"terminate"`.
+    pub action: String,
+    /// Server-side timestamp when the request was accepted (RFC 3339).
+    pub accepted_at: String,
+}
+
+fn validate_op_id(raw: &str) -> Result<String, ProblemDetail> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(ProblemDetail::from_status(StatusCode::BAD_REQUEST)
+            .with_detail("Operation id must not be empty".to_string()));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn ack(op_id: String, action: &'static str) -> impl IntoResponse {
+    tracing::info!(target: "aa_api::ops", op_id = %op_id, action, "op lifecycle action accepted");
+    (
+        StatusCode::ACCEPTED,
+        Json(OpActionAck {
+            op_id,
+            action: action.to_string(),
+            accepted_at: chrono::Utc::now().to_rfc3339(),
+        }),
+    )
+}
+
+/// `POST /api/v1/ops/{id}/pause` — request that an in-flight operation
+/// be paused. Stub today: returns 202 and logs the request without
+/// updating any state.
+#[utoipa::path(
+    post,
+    path = "/api/v1/ops/{id}/pause",
+    tag = "ops",
+    params(
+        ("id" = String, Path, description = "Operation id (string form of `GovernanceEvent.id`).")
+    ),
+    responses(
+        (status = 202, description = "Pause request accepted", body = OpActionAck),
+        (status = 400, description = "Empty or malformed operation id", body = ProblemDetail)
+    )
+)]
+pub async fn pause_op(Path(id): Path<String>) -> Result<impl IntoResponse, ProblemDetail> {
+    Ok(ack(validate_op_id(&id)?, "pause"))
+}
+
+/// `POST /api/v1/ops/{id}/resume` — request that a paused operation
+/// resume. Stub today: returns 202 and logs the request without
+/// updating any state.
+#[utoipa::path(
+    post,
+    path = "/api/v1/ops/{id}/resume",
+    tag = "ops",
+    params(
+        ("id" = String, Path, description = "Operation id (string form of `GovernanceEvent.id`).")
+    ),
+    responses(
+        (status = 202, description = "Resume request accepted", body = OpActionAck),
+        (status = 400, description = "Empty or malformed operation id", body = ProblemDetail)
+    )
+)]
+pub async fn resume_op(Path(id): Path<String>) -> Result<impl IntoResponse, ProblemDetail> {
+    Ok(ack(validate_op_id(&id)?, "resume"))
+}
+
+/// `POST /api/v1/ops/{id}/terminate` — request that an in-flight
+/// operation be terminated. Stub today: returns 202 and logs the
+/// request without updating any state.
+#[utoipa::path(
+    post,
+    path = "/api/v1/ops/{id}/terminate",
+    tag = "ops",
+    params(
+        ("id" = String, Path, description = "Operation id (string form of `GovernanceEvent.id`).")
+    ),
+    responses(
+        (status = 202, description = "Terminate request accepted", body = OpActionAck),
+        (status = 400, description = "Empty or malformed operation id", body = ProblemDetail)
+    )
+)]
+pub async fn terminate_op(Path(id): Path<String>) -> Result<impl IntoResponse, ProblemDetail> {
+    Ok(ack(validate_op_id(&id)?, "terminate"))
+}

--- a/aa-api/src/routes/ops.rs
+++ b/aa-api/src/routes/ops.rs
@@ -59,9 +59,10 @@ fn ack(op_id: String, action: &'static str) -> impl IntoResponse {
     )
 }
 
-/// `POST /api/v1/ops/{id}/pause` — request that an in-flight operation
-/// be paused. Stub today: returns 202 and logs the request without
-/// updating any state.
+/// `POST /api/v1/ops/{id}/pause` — request that an in-flight operation be paused.
+///
+/// Stub today: returns 202 Accepted and logs the request without updating
+/// any state. Real enforcement awaits the in-flight-ops registry architecture.
 #[utoipa::path(
     post,
     path = "/api/v1/ops/{id}/pause",
@@ -78,9 +79,10 @@ pub async fn pause_op(Path(id): Path<String>) -> Result<impl IntoResponse, Probl
     Ok(ack(validate_op_id(&id)?, "pause"))
 }
 
-/// `POST /api/v1/ops/{id}/resume` — request that a paused operation
-/// resume. Stub today: returns 202 and logs the request without
-/// updating any state.
+/// `POST /api/v1/ops/{id}/resume` — request that a paused operation resume.
+///
+/// Stub today: returns 202 Accepted and logs the request without updating
+/// any state. Real enforcement awaits the in-flight-ops registry architecture.
 #[utoipa::path(
     post,
     path = "/api/v1/ops/{id}/resume",
@@ -97,9 +99,10 @@ pub async fn resume_op(Path(id): Path<String>) -> Result<impl IntoResponse, Prob
     Ok(ack(validate_op_id(&id)?, "resume"))
 }
 
-/// `POST /api/v1/ops/{id}/terminate` — request that an in-flight
-/// operation be terminated. Stub today: returns 202 and logs the
-/// request without updating any state.
+/// `POST /api/v1/ops/{id}/terminate` — request that an in-flight operation be terminated.
+///
+/// Stub today: returns 202 Accepted and logs the request without updating
+/// any state. Real enforcement awaits the in-flight-ops registry architecture.
 #[utoipa::path(
     post,
     path = "/api/v1/ops/{id}/terminate",

--- a/aa-api/tests/ops_lifecycle.rs
+++ b/aa-api/tests/ops_lifecycle.rs
@@ -1,0 +1,85 @@
+//! Integration tests for the per-op lifecycle endpoints
+//! (`POST /api/v1/ops/{id}/{pause,resume,terminate}`).
+//!
+//! These endpoints are stubs today (see `routes/ops.rs`) — they validate
+//! the op id, log the request, and return 202 Accepted. The tests cover
+//! the happy path for each action and the 400-on-empty-id failure path.
+
+mod common;
+
+use aa_api::server::build_app;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::Value;
+use tower::ServiceExt;
+
+async fn post(action: &str, path_id: &str) -> (StatusCode, Value) {
+    let state = common::test_state();
+    let app = build_app(state);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/ops/{path_id}/{action}"))
+                .header("content-type", "application/json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), 1024 * 64).await.unwrap();
+    let body: Value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    (status, body)
+}
+
+#[tokio::test]
+async fn pause_op_returns_202_with_ack() {
+    let (status, body) = post("pause", "op-1").await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+    assert_eq!(body["op_id"], "op-1");
+    assert_eq!(body["action"], "pause");
+    assert!(body["accepted_at"].is_string());
+}
+
+#[tokio::test]
+async fn resume_op_returns_202_with_ack() {
+    let (status, body) = post("resume", "op-42").await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+    assert_eq!(body["op_id"], "op-42");
+    assert_eq!(body["action"], "resume");
+}
+
+#[tokio::test]
+async fn terminate_op_returns_202_with_ack() {
+    let (status, body) = post("terminate", "op-7").await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+    assert_eq!(body["op_id"], "op-7");
+    assert_eq!(body["action"], "terminate");
+}
+
+#[tokio::test]
+async fn op_id_with_url_encoded_chars_is_accepted_verbatim() {
+    let (status, body) = post("pause", "op%2F123").await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+    // axum's Path extractor decodes the path segment.
+    assert_eq!(body["op_id"], "op/123");
+}
+
+#[tokio::test]
+async fn whitespace_only_op_id_returns_400() {
+    let (status, body) = post("pause", "%20%20").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(body["detail"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("Operation id must not be empty"));
+}
+
+#[tokio::test]
+async fn unknown_action_falls_through_to_404() {
+    // Sanity check: only pause/resume/terminate are routed; anything else
+    // hits the catch-all `fallback_404`.
+    let (status, _body) = post("delete", "op-1").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -297,6 +297,69 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/ops/{id}/pause": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * `POST /api/v1/ops/{id}/pause` — request that an in-flight operation be paused.
+         * @description Stub today: returns 202 Accepted and logs the request without updating
+         *     any state. Real enforcement awaits the in-flight-ops registry architecture.
+         */
+        post: operations["pause_op"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/ops/{id}/resume": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * `POST /api/v1/ops/{id}/resume` — request that a paused operation resume.
+         * @description Stub today: returns 202 Accepted and logs the request without updating
+         *     any state. Real enforcement awaits the in-flight-ops registry architecture.
+         */
+        post: operations["resume_op"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/ops/{id}/terminate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * `POST /api/v1/ops/{id}/terminate` — request that an in-flight operation be terminated.
+         * @description Stub today: returns 202 Accepted and logs the request without updating
+         *     any state. Real enforcement awaits the in-flight-ops registry architecture.
+         */
+        post: operations["terminate_op"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/policies": {
         parameters: {
             query?: never;
@@ -1014,6 +1077,21 @@ export interface components {
             session_id: string;
             /** @description ISO 8601 timestamp of the event. */
             timestamp: string;
+        };
+        /**
+         * @description Acknowledgement returned by the per-op lifecycle endpoints.
+         *
+         *     The fields are deliberately minimal — they document what the
+         *     gateway received, not the resulting state (which the dashboard
+         *     observes via the WebSocket event stream).
+         */
+        OpActionAck: {
+            /** @description Server-side timestamp when the request was accepted (RFC 3339). */
+            accepted_at: string;
+            /** @description Action that was requested — one of `"pause"`, `"resume"`, `"terminate"`. */
+            action: string;
+            /** @description Operation id from the URL path. */
+            op_id: string;
         };
         /** @description JSON representation of a governance policy version. */
         PolicyResponse: {
@@ -1975,6 +2053,102 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["LogEntry"][];
+                };
+            };
+        };
+    };
+    pause_op: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Operation id (string form of `GovernanceEvent.id`). */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Pause request accepted */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OpActionAck"];
+                };
+            };
+            /** @description Empty or malformed operation id */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+        };
+    };
+    resume_op: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Operation id (string form of `GovernanceEvent.id`). */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Resume request accepted */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OpActionAck"];
+                };
+            };
+            /** @description Empty or malformed operation id */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+        };
+    };
+    terminate_op: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Operation id (string form of `GovernanceEvent.id`). */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Terminate request accepted */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OpActionAck"];
+                };
+            };
+            /** @description Empty or malformed operation id */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
                 };
             };
         };

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -541,6 +541,93 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/LogEntry'
+  /api/v1/ops/{id}/pause:
+    post:
+      tags:
+      - ops
+      summary: '`POST /api/v1/ops/{id}/pause` — request that an in-flight operation be paused.'
+      description: |-
+        Stub today: returns 202 Accepted and logs the request without updating
+        any state. Real enforcement awaits the in-flight-ops registry architecture.
+      operationId: pause_op
+      parameters:
+      - name: id
+        in: path
+        description: Operation id (string form of `GovernanceEvent.id`).
+        required: true
+        schema:
+          type: string
+      responses:
+        '202':
+          description: Pause request accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpActionAck'
+        '400':
+          description: Empty or malformed operation id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+  /api/v1/ops/{id}/resume:
+    post:
+      tags:
+      - ops
+      summary: '`POST /api/v1/ops/{id}/resume` — request that a paused operation resume.'
+      description: |-
+        Stub today: returns 202 Accepted and logs the request without updating
+        any state. Real enforcement awaits the in-flight-ops registry architecture.
+      operationId: resume_op
+      parameters:
+      - name: id
+        in: path
+        description: Operation id (string form of `GovernanceEvent.id`).
+        required: true
+        schema:
+          type: string
+      responses:
+        '202':
+          description: Resume request accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpActionAck'
+        '400':
+          description: Empty or malformed operation id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+  /api/v1/ops/{id}/terminate:
+    post:
+      tags:
+      - ops
+      summary: '`POST /api/v1/ops/{id}/terminate` — request that an in-flight operation be terminated.'
+      description: |-
+        Stub today: returns 202 Accepted and logs the request without updating
+        any state. Real enforcement awaits the in-flight-ops registry architecture.
+      operationId: terminate_op
+      parameters:
+      - name: id
+        in: path
+        description: Operation id (string form of `GovernanceEvent.id`).
+        required: true
+        schema:
+          type: string
+      responses:
+        '202':
+          description: Terminate request accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OpActionAck'
+        '400':
+          description: Empty or malformed operation id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
   /api/v1/policies:
     get:
       tags:
@@ -1697,6 +1784,28 @@ components:
         timestamp:
           type: string
           description: ISO 8601 timestamp of the event.
+    OpActionAck:
+      type: object
+      description: |-
+        Acknowledgement returned by the per-op lifecycle endpoints.
+
+        The fields are deliberately minimal — they document what the
+        gateway received, not the resulting state (which the dashboard
+        observes via the WebSocket event stream).
+      required:
+      - op_id
+      - action
+      - accepted_at
+      properties:
+        accepted_at:
+          type: string
+          description: Server-side timestamp when the request was accepted (RFC 3339).
+        action:
+          type: string
+          description: Action that was requested — one of `"pause"`, `"resume"`, `"terminate"`.
+        op_id:
+          type: string
+          description: Operation id from the URL path.
     PolicyResponse:
       type: object
       description: JSON representation of a governance policy version.
@@ -2417,3 +2526,5 @@ tags:
   description: Real-time event streaming via WebSocket
 - name: topology
   description: Agent topology — tree, team, lineage, statistics, and mesh edge queries
+- name: ops
+  description: Per-operation lifecycle actions (pause / resume / terminate)


### PR DESCRIPTION
## Summary

Adds three new POST endpoints under `/api/v1/ops/{id}/` so the Live Ops dashboard's row-action menu (AAASM-1334) stops 404-ing against the conventional paths:

* `POST /api/v1/ops/{id}/pause`
* `POST /api/v1/ops/{id}/resume`
* `POST /api/v1/ops/{id}/terminate`

Each returns **202 Accepted** with a small `OpActionAck { op_id, action, accepted_at }` body. Empty / whitespace-only op ids reject with 400.

## ⚠ Important framing — these are stubs

The original ticket assumed the gateway had an in-flight ops registry against which to validate op ids and run a state machine. **It does not.** What the codebase has today:

* `aa-gateway/src/registry/` tracks **agents**, not in-flight operations.
* `AuditEvent` is post-facto event-stream data, not mutable state.
* There is no SDK-side enforcement channel.
* The dashboard's `LiveOperation.id` is the string form of `GovernanceEvent.id` (monotonic counter) — there's no concept of "the same op id arrives later with a new status."

The handlers therefore **log the request and return 202** — no state change, no SDK signal. The dashboard now exercises its optimistic-UI success path instead of its rollback path, but the optimistic state itself won't clear because the gateway has no way to emit a "same op id, new status" WS event.

**Real enforcement** — in-flight ops registry + state machine + IPC return-channel for SDK enforcement + dashboard id-model rethink — is a separate architecture project. A follow-up Task will be filed at PR merge time.

## Commits (3 granular)

1. `✨ (aa-api/routes): Stub pause/resume/terminate ops endpoints + integration tests` — handlers + router wiring + utoipa annotations + 6 integration tests in `aa-api/tests/ops_lifecycle.rs`
2. `🔧 (openapi): Regenerate v1.yaml for ops lifecycle endpoints`
3. `🔧 (dashboard/api): Regenerate schema.d.ts for ops lifecycle endpoints`

## DoD checklist

| Criterion | Status |
|---|---|
| `cargo nextest run --workspace` green | ✅ — `cargo nextest run -p aa-api` 252/252 |
| OpenAPI regen + dashboard `pnpm type-check` passes | ✅ — spectral clean (0 errors), dashboard type-check clean |
| Dashboard `LiveOpsPage` rollback path stops firing on success | ✅ — 2xx return means `actions.ts` doesn't reject; optimistic state is preserved (real clearance pending the architecture follow-up) |
| Three integration tests in `tests/ops_lifecycle.rs` cover happy path + 404 + 409 | ⚠ partial — happy path: ✅ (one per action). 400 for empty id: ✅. 404/409: ❌ N/A — there's no state machine to drive 409, and 404 against a fictional op registry would always trigger; instead I added a 404-on-unknown-action sanity check |

## Test plan

* [x] `cargo nextest run -p aa-api` — 252 / 252
* [x] `cargo fmt`, `cargo clippy -- -D warnings` clean
* [x] `npx @stoplight/spectral-cli lint openapi/v1.yaml` clean (0 errors)
* [x] `pnpm type-check`, `pnpm lint` clean
* [x] `pnpm test --run` — 833 / 833 across 96 files (no regressions)

Closes AAASM-1415.