### PR TITLE
[AAASM-1416] 🎨 (dashboard/EmptyState): Suppress action buttons when handlers absent

### DIFF
--- a/dashboard/src/components/EmptyState.test.tsx
+++ b/dashboard/src/components/EmptyState.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { EmptyState } from './EmptyState'
+
+describe('EmptyState', () => {
+  describe('button suppression when handlers are absent', () => {
+    it('renders no buttons and no actions wrapper when neither handler is supplied', () => {
+      const { container } = render(<EmptyState page="live" />)
+      expect(screen.queryByRole('button')).toBeNull()
+      expect(container.querySelector('.state-actions')).toBeNull()
+    })
+
+    it('renders only the primary button when only onCta is supplied', () => {
+      render(<EmptyState page="live" onCta={() => {}} />)
+      const buttons = screen.getAllByRole('button')
+      expect(buttons).toHaveLength(1)
+      expect(buttons[0].textContent).toMatch(/Generate test traffic/)
+    })
+
+    it('renders only the secondary button when only onSecondary is supplied', () => {
+      render(<EmptyState page="live" onSecondary={() => {}} />)
+      const buttons = screen.getAllByRole('button')
+      expect(buttons).toHaveLength(1)
+      expect(buttons[0].textContent).toMatch(/View 24h history/)
+    })
+
+    it('renders both buttons when both handlers are supplied', () => {
+      render(<EmptyState page="live" onCta={() => {}} onSecondary={() => {}} />)
+      expect(screen.getAllByRole('button')).toHaveLength(2)
+    })
+  })
+
+  describe('button click wiring', () => {
+    it('clicking the primary button calls onCta', async () => {
+      const user = userEvent.setup()
+      const onCta = vi.fn()
+      render(<EmptyState page="live" onCta={onCta} />)
+      await user.click(screen.getByRole('button', { name: /Generate test traffic/ }))
+      expect(onCta).toHaveBeenCalledTimes(1)
+    })
+
+    it('clicking the secondary button calls onSecondary', async () => {
+      const user = userEvent.setup()
+      const onSecondary = vi.fn()
+      render(<EmptyState page="live" onSecondary={onSecondary} />)
+      await user.click(screen.getByRole('button', { name: /View 24h history/ }))
+      expect(onSecondary).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('variants with null CTA in COPY', () => {
+    it('approvals variant never renders buttons regardless of handlers', () => {
+      // The `approvals` COPY entry has cta: null + secondary: null.
+      // Supplying handlers must not conjure buttons that don't exist in copy.
+      render(
+        <EmptyState page="approvals" onCta={() => {}} onSecondary={() => {}} />,
+      )
+      expect(screen.queryByRole('button')).toBeNull()
+    })
+
+    it('scrub variant never renders buttons regardless of handlers', () => {
+      render(<EmptyState page="scrub" onCta={() => {}} onSecondary={() => {}} />)
+      expect(screen.queryByRole('button')).toBeNull()
+    })
+  })
+
+  describe('content rendering', () => {
+    it('renders the canned icon / tag / title / message for the live variant', () => {
+      render(<EmptyState page="live" />)
+      expect(screen.getByText(/No traffic in the last 60s/)).toBeInTheDocument()
+      expect(screen.getByText(/runtime · idle/)).toBeInTheDocument()
+    })
+
+    it('exposes a `data-testid` keyed on the page slug', () => {
+      const { rerender } = render(<EmptyState page="live" />)
+      expect(screen.getByTestId('empty-state-live')).toBeInTheDocument()
+      rerender(<EmptyState page="capability" />)
+      expect(screen.getByTestId('empty-state-capability')).toBeInTheDocument()
+    })
+  })
+})

--- a/dashboard/src/components/EmptyState.tsx
+++ b/dashboard/src/components/EmptyState.tsx
@@ -136,14 +136,14 @@ export function EmptyState({ page = 'overview', onCta, onSecondary }: EmptyState
         <div className="state-tag">{c.tag}</div>
         <div className="state-title">{c.title}</div>
         <div className="state-msg">{c.msg}</div>
-        {(c.cta || c.secondary) && (
+        {((c.cta && onCta) || (c.secondary && onSecondary)) && (
           <div className="state-actions">
-            {c.cta && (
+            {c.cta && onCta && (
               <button type="button" className="state-btn state-btn--primary" onClick={onCta}>
                 ▸ {c.cta}
               </button>
             )}
-            {c.secondary && (
+            {c.secondary && onSecondary && (
               <button type="button" className="state-btn" onClick={onSecondary}>
                 {c.secondary}
               </button>


### PR DESCRIPTION
## Summary

Fixes the shared `EmptyState` component so each canned action button renders **only when a click handler is supplied**, instead of unconditionally rendering whenever its COPY entry is set.

## Why this matters

`EmptyState` ships canned CTA labels for 6 of its 8 page variants. Consumers that pass `<EmptyState page="..." />` without handlers got dead buttons — visible to users but no-op on click. Surveying call sites:

| Page | Variant | Handlers | Before | After |
|---|---|---|---|---|
| `LiveOpsPage` | `live` | none | 2 dead buttons (`Generate test traffic`, `View 24h history`) | no buttons |
| `CapabilityPage` | `capability` | none | 2 dead buttons (`Connect resource`, `Onboard agent`) | no buttons |
| `ApprovalsPage` | `approvals` | none | no buttons (COPY has `cta: null`) | unchanged |

No other consumers exist for this `EmptyState` (the `components/states/EmptyState.tsx` is a separate component with a different prop API; not affected).

## Change

Single edit in `dashboard/src/components/EmptyState.tsx`: each button's render predicate adds the `&& onCta` / `&& onSecondary` check; the wrapping `.state-actions` div collapses when both buttons are suppressed.

## Tests

New `dashboard/src/components/EmptyState.test.tsx` — 10 cases:

* button suppression matrix (no handlers / only `onCta` / only `onSecondary` / both)
* clicking each button fires the correct handler
* `approvals` + `scrub` variants (`cta: null` in COPY) never conjure buttons even with handlers — regression guard for the inverted case
* canned icon / tag / title / message render correctly
* `data-testid` keyed on the page slug

## Test plan

* [x] `pnpm type-check` clean
* [x] `pnpm lint` clean
* [x] `pnpm test --run` — 843 / 843 across 97 files (was 833; +10 new)
* [ ] Manual visual check at `/live` and `/capability` confirms no dead buttons — easy to run with `pnpm dev`; left for reviewer if desired

Closes AAASM-1416.