### PR TITLE
[AAASM-1412] ♻️ (dashboard): Migrate analytics TSX/TS hex literals to design tokens

### DIFF
--- a/dashboard/src/features/analytics/ActionVolumePanel.tsx
+++ b/dashboard/src/features/analytics/ActionVolumePanel.tsx
@@ -66,16 +66,16 @@ export function ActionVolumePanel() {
       ) : (
         <ResponsiveContainer width="100%" height={320}>
           <LineChart data={chartData} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--surface-card-border)" />
             <XAxis
               dataKey="t"
               tickFormatter={tickFormatter}
-              tick={{ fontSize: 12, fill: '#6b7280' }}
+              tick={{ fontSize: 12, fill: 'var(--text-muted)' }}
               axisLine={false}
               tickLine={false}
             />
             <YAxis
-              tick={{ fontSize: 12, fill: '#6b7280' }}
+              tick={{ fontSize: 12, fill: 'var(--text-muted)' }}
               axisLine={false}
               tickLine={false}
               width={40}

--- a/dashboard/src/features/analytics/CostBreakdownPanel.tsx
+++ b/dashboard/src/features/analytics/CostBreakdownPanel.tsx
@@ -95,16 +95,16 @@ export function CostBreakdownPanel() {
         <>
           <ResponsiveContainer width="100%" height={320}>
             <BarChart data={chartData} margin={{ top: 8, right: 16, left: 8, bottom: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" vertical={false} />
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--surface-card-border)" vertical={false} />
               <XAxis
                 dataKey="label"
-                tick={{ fontSize: 12, fill: '#6b7280' }}
+                tick={{ fontSize: 12, fill: 'var(--text-muted)' }}
                 axisLine={false}
                 tickLine={false}
               />
               <YAxis
                 tickFormatter={USD_TICK}
-                tick={{ fontSize: 12, fill: '#6b7280' }}
+                tick={{ fontSize: 12, fill: 'var(--text-muted)' }}
                 axisLine={false}
                 tickLine={false}
                 width={56}

--- a/dashboard/src/features/analytics/KpiCard.tsx
+++ b/dashboard/src/features/analytics/KpiCard.tsx
@@ -11,8 +11,8 @@ interface KpiCardProps {
   isError: boolean
 }
 
-const DELTA_POSITIVE_COLOR = '#10b981'  // emerald-500
-const DELTA_NEGATIVE_COLOR = '#f43f5e'  // rose-500
+const DELTA_POSITIVE_COLOR = 'var(--trend-positive)'
+const DELTA_NEGATIVE_COLOR = 'var(--trend-negative)'
 
 export function KpiCard({ metric, label, value, delta, unit, isLoading, isError }: KpiCardProps) {
   return (

--- a/dashboard/src/features/analytics/KpiStrip.test.tsx
+++ b/dashboard/src/features/analytics/KpiStrip.test.tsx
@@ -54,20 +54,20 @@ describe('KpiCard', () => {
     expect(screen.getByText('ms')).toBeInTheDocument()
   })
 
-  it('colors delta green (#10b981) when trend is positive for agents', () => {
+  it('colors delta with --trend-positive when trend is positive for agents', () => {
     render(
       <KpiCard metric="agents" label="Total Agents" value={10} delta={0.12} isLoading={false} isError={false} />,
     )
     const delta = screen.getByText('+12.0%')
-    expect(delta).toHaveStyle({ color: '#10b981' })
+    expect(delta).toHaveStyle({ color: 'var(--trend-positive)' })
   })
 
-  it('colors delta red (#f43f5e) when trend is negative for agents', () => {
+  it('colors delta with --trend-negative when trend is negative for agents', () => {
     render(
       <KpiCard metric="agents" label="Total Agents" value={10} delta={-0.05} isLoading={false} isError={false} />,
     )
     const delta = screen.getByText('-5.0%')
-    expect(delta).toHaveStyle({ color: '#f43f5e' })
+    expect(delta).toHaveStyle({ color: 'var(--trend-negative)' })
   })
 
   it('colors delta green for p99 when delta is negative (lower latency = good)', () => {
@@ -75,7 +75,7 @@ describe('KpiCard', () => {
       <KpiCard metric="p99" label="p99 Latency" value={95} delta={-0.08} unit="ms" isLoading={false} isError={false} />,
     )
     const delta = screen.getByText('-8.0%')
-    expect(delta).toHaveStyle({ color: '#10b981' })
+    expect(delta).toHaveStyle({ color: 'var(--trend-positive)' })
   })
 
   it('colors delta red for p99 when delta is positive (higher latency = bad)', () => {
@@ -83,21 +83,21 @@ describe('KpiCard', () => {
       <KpiCard metric="p99" label="p99 Latency" value={150} delta={0.2} unit="ms" isLoading={false} isError={false} />,
     )
     const delta = screen.getByText('+20.0%')
-    expect(delta).toHaveStyle({ color: '#f43f5e' })
+    expect(delta).toHaveStyle({ color: 'var(--trend-negative)' })
   })
 
   it('colors delta green for cost when delta is negative (lower cost = good)', () => {
     render(
       <KpiCard metric="cost" label="Total Cost" value={50} delta={-0.1} unit="USD" isLoading={false} isError={false} />,
     )
-    expect(screen.getByText('-10.0%')).toHaveStyle({ color: '#10b981' })
+    expect(screen.getByText('-10.0%')).toHaveStyle({ color: 'var(--trend-positive)' })
   })
 
   it('colors delta green for anomalies when delta is negative (fewer anomalies = good)', () => {
     render(
       <KpiCard metric="anomalies" label="Anomaly Count" value={3} delta={-0.5} isLoading={false} isError={false} />,
     )
-    expect(screen.getByText('-50.0%')).toHaveStyle({ color: '#10b981' })
+    expect(screen.getByText('-50.0%')).toHaveStyle({ color: 'var(--trend-positive)' })
   })
 
   it('renders dash on error state', () => {

--- a/dashboard/src/features/analytics/ToolUsagePanel.test.tsx
+++ b/dashboard/src/features/analytics/ToolUsagePanel.test.tsx
@@ -41,19 +41,19 @@ function mockFetch(tools: ToolStat[]) {
 // ── toolUsageUtils unit tests ─────────────────────────────────────────────────
 
 describe('errorRateColor', () => {
-  it('returns green for rate < 1%', () => {
-    expect(errorRateColor(0)).toBe('#10b981')
-    expect(errorRateColor(0.009)).toBe('#10b981')
+  it('returns the success token for rate < 1%', () => {
+    expect(errorRateColor(0)).toBe('var(--status-success)')
+    expect(errorRateColor(0.009)).toBe('var(--status-success)')
   })
 
-  it('returns amber for rate 1-5%', () => {
-    expect(errorRateColor(0.01)).toBe('#f59e0b')
-    expect(errorRateColor(0.05)).toBe('#f59e0b')
+  it('returns the warning token for rate 1-5%', () => {
+    expect(errorRateColor(0.01)).toBe('var(--status-warning)')
+    expect(errorRateColor(0.05)).toBe('var(--status-warning)')
   })
 
-  it('returns red for rate > 5%', () => {
-    expect(errorRateColor(0.051)).toBe('#ef4444')
-    expect(errorRateColor(1)).toBe('#ef4444')
+  it('returns the danger token for rate > 5%', () => {
+    expect(errorRateColor(0.051)).toBe('var(--status-danger)')
+    expect(errorRateColor(1)).toBe('var(--status-danger)')
   })
 })
 

--- a/dashboard/src/features/analytics/ToolUsagePanel.tsx
+++ b/dashboard/src/features/analytics/ToolUsagePanel.tsx
@@ -54,7 +54,7 @@ export function ToolUsagePanel() {
           >
             <XAxis
               type="number"
-              tick={{ fontSize: 11, fill: '#6b7280' }}
+              tick={{ fontSize: 11, fill: 'var(--text-muted)' }}
               axisLine={false}
               tickLine={false}
             />
@@ -62,7 +62,7 @@ export function ToolUsagePanel() {
               type="category"
               dataKey="name"
               width={130}
-              tick={{ fontSize: 12, fill: '#374151' }}
+              tick={{ fontSize: 12, fill: 'var(--text-secondary)' }}
               axisLine={false}
               tickLine={false}
             />

--- a/dashboard/src/features/analytics/chartPalette.ts
+++ b/dashboard/src/features/analytics/chartPalette.ts
@@ -39,11 +39,11 @@ const CHART_COLORBLIND_VARS: readonly string[] = [
   '--chart-cb-7',
 ]
 
-function resolvePalette(varNames: readonly string[]): readonly string[] {
+function resolvePalette(varNames: readonly string[]): string[] {
   if (typeof document === 'undefined') return varNames.map(() => '')
   const root = getComputedStyle(document.documentElement)
   return varNames.map((v) => root.getPropertyValue(v).trim())
 }
 
-export const CHART_CATEGORICAL_PALETTE: readonly string[] = resolvePalette(CHART_CATEGORICAL_VARS)
-export const CHART_COLORBLIND_PALETTE: readonly string[] = resolvePalette(CHART_COLORBLIND_VARS)
+export const CHART_CATEGORICAL_PALETTE: string[] = resolvePalette(CHART_CATEGORICAL_VARS)
+export const CHART_COLORBLIND_PALETTE: string[] = resolvePalette(CHART_COLORBLIND_VARS)

--- a/dashboard/src/features/analytics/chartPalette.ts
+++ b/dashboard/src/features/analytics/chartPalette.ts
@@ -1,25 +1,49 @@
-export const CHART_CATEGORICAL_PALETTE = [
-  '#6366f1', // indigo-500
-  '#f59e0b', // amber-500
-  '#10b981', // emerald-500
-  '#f43f5e', // rose-500
-  '#3b82f6', // blue-500
-  '#8b5cf6', // violet-500
-  '#14b8a6', // teal-500
-  '#f97316', // orange-500
-  '#84cc16', // lime-500
-  '#06b6d4', // cyan-500
-  '#ec4899', // pink-500
-  '#a78bfa', // violet-400
+/**
+ * Chart series colour palettes.
+ *
+ * Values are sourced from CSS custom properties (`--chart-cat-*`, `--chart-cb-*`)
+ * defined in `dashboard/src/styles.css`, resolved at module load via
+ * `getComputedStyle`. This keeps a single source of truth for chart palette
+ * tokens; consumers (Recharts components, FleetHealthPanel sparkline, etc.)
+ * continue to receive plain hex strings via the unchanged `readonly string[]`
+ * export shape.
+ *
+ * `getComputedStyle` returns the substituted/computed value of CSS custom
+ * properties on `:root`, so aliases like `var(--status-success)` resolve to
+ * the underlying hex automatically.
+ */
+
+const CHART_CATEGORICAL_VARS: readonly string[] = [
+  '--chart-cat-1',
+  '--chart-cat-2',
+  '--chart-cat-3',
+  '--chart-cat-4',
+  '--chart-cat-5',
+  '--chart-cat-6',
+  '--chart-cat-7',
+  '--chart-cat-8',
+  '--chart-cat-9',
+  '--chart-cat-10',
+  '--chart-cat-11',
+  '--chart-cat-12',
 ]
 
-// Wong (2011) colorblind-safe palette — distinguishable under deuteranopia/protanopia
-export const CHART_COLORBLIND_PALETTE = [
-  '#e69f00', // orange
-  '#56b4e9', // sky blue
-  '#009e73', // bluish green
-  '#f0e442', // yellow
-  '#0072b2', // blue
-  '#d55e00', // vermilion
-  '#cc79a7', // reddish purple
+// Wong (2011) colorblind-safe palette — distinguishable under deuteranopia/protanopia.
+const CHART_COLORBLIND_VARS: readonly string[] = [
+  '--chart-cb-1',
+  '--chart-cb-2',
+  '--chart-cb-3',
+  '--chart-cb-4',
+  '--chart-cb-5',
+  '--chart-cb-6',
+  '--chart-cb-7',
 ]
+
+function resolvePalette(varNames: readonly string[]): readonly string[] {
+  if (typeof document === 'undefined') return varNames.map(() => '')
+  const root = getComputedStyle(document.documentElement)
+  return varNames.map((v) => root.getPropertyValue(v).trim())
+}
+
+export const CHART_CATEGORICAL_PALETTE: readonly string[] = resolvePalette(CHART_CATEGORICAL_VARS)
+export const CHART_COLORBLIND_PALETTE: readonly string[] = resolvePalette(CHART_COLORBLIND_VARS)

--- a/dashboard/src/features/analytics/policyEffectivenessUtils.ts
+++ b/dashboard/src/features/analytics/policyEffectivenessUtils.ts
@@ -16,10 +16,33 @@ export function computeRatio(day: PolicyDay): number {
   return total === 0 ? 0 : day.blocks / total
 }
 
-// Color stops matching CSS variables --heatmap-low / --heatmap-mid / --heatmap-high
-const LOW: [number, number, number] = [16, 185, 129]   // #10b981 green
-const MID: [number, number, number] = [245, 158, 11]   // #f59e0b amber
-const HIGH: [number, number, number] = [239, 68, 68]   // #ef4444 red
+// Heatmap colour stops are sourced from CSS custom properties
+// --heatmap-low / --heatmap-mid / --heatmap-high declared in
+// dashboard/src/styles.css. getComputedStyle returns the substituted
+// value (resolving var(--status-success/-warning/-danger)), and we
+// parse it into a numeric RGB triple for lerp().
+
+const FALLBACK_LOW: [number, number, number] = [16, 185, 129]
+const FALLBACK_MID: [number, number, number] = [245, 158, 11]
+const FALLBACK_HIGH: [number, number, number] = [239, 68, 68]
+
+function rgbFromCssVar(
+  varName: string,
+  fallback: [number, number, number],
+): [number, number, number] {
+  if (typeof document === 'undefined') return fallback
+  const hex = getComputedStyle(document.documentElement)
+    .getPropertyValue(varName)
+    .trim()
+    .replace(/^#/, '')
+  const m = hex.match(/^([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/)
+  if (!m) return fallback
+  return [parseInt(m[1], 16), parseInt(m[2], 16), parseInt(m[3], 16)]
+}
+
+const LOW = rgbFromCssVar('--heatmap-low', FALLBACK_LOW)
+const MID = rgbFromCssVar('--heatmap-mid', FALLBACK_MID)
+const HIGH = rgbFromCssVar('--heatmap-high', FALLBACK_HIGH)
 
 function lerp(a: number, b: number, t: number): number {
   return Math.round(a + (b - a) * t)

--- a/dashboard/src/features/analytics/toolUsageUtils.ts
+++ b/dashboard/src/features/analytics/toolUsageUtils.ts
@@ -5,10 +5,13 @@ export interface ToolStat {
 }
 
 // green < 1%, amber 1-5%, red > 5%
+// Returns CSS custom-property references (from styles.css); consumers
+// pass these directly to SVG `fill` attributes (Recharts Cell etc.),
+// which the browser resolves to the underlying hex value.
 export function errorRateColor(rate: number): string {
-  if (rate < 0.01) return '#10b981'
-  if (rate <= 0.05) return '#f59e0b'
-  return '#ef4444'
+  if (rate < 0.01) return 'var(--status-success)'
+  if (rate <= 0.05) return 'var(--status-warning)'
+  return 'var(--status-danger)'
 }
 
 export function sortToolsByCallsDesc(tools: ToolStat[]): ToolStat[] {

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -173,4 +173,33 @@
 
   /* ── Soft danger (red-300) for hover/active overlays ─────── */
   --danger-soft: #fca5a5;
+
+  /* ── Chart categorical palette ───────────────────────────── */
+  /* 12 distinguishable hues for series colors in Recharts panels.
+     Order matches CHART_CATEGORICAL_PALETTE in chartPalette.ts. */
+  --chart-cat-1: #6366f1;
+  --chart-cat-2: #f59e0b;
+  --chart-cat-3: #10b981;
+  --chart-cat-4: #f43f5e;
+  --chart-cat-5: #3b82f6;
+  --chart-cat-6: #8b5cf6;
+  --chart-cat-7: #14b8a6;
+  --chart-cat-8: #f97316;
+  --chart-cat-9: #84cc16;
+  --chart-cat-10: #06b6d4;
+  --chart-cat-11: #ec4899;
+  --chart-cat-12: #a78bfa;
+
+  /* ── Chart colorblind-safe palette (Wong 2011) ───────────── */
+  --chart-cb-1: #e69f00;
+  --chart-cb-2: #56b4e9;
+  --chart-cb-3: #009e73;
+  --chart-cb-4: #f0e442;
+  --chart-cb-5: #0072b2;
+  --chart-cb-6: #d55e00;
+  --chart-cb-7: #cc79a7;
+
+  /* ── Trend indicators (Kpi delta) ────────────────────────── */
+  --trend-positive: #10b981;
+  --trend-negative: #f43f5e;
 }


### PR DESCRIPTION
## Summary

Migrates **49 hex color literals across 9 TSX/TS files** in `dashboard/src/features/analytics/` to design tokens. Part 3 of 5 in the AAASM-1407 residual sweep.

After this merges, `grep -rE '#[0-9a-fA-F]{3,8}' dashboard/src/features/analytics/` returns **zero** hits across both `.css` and `.tsx`/`.ts` files (AAASM-1323 already cleared the CSS files).

### What changed

* **`dashboard/src/styles.css`** — added 21 new tokens:
  - **Chart categorical palette** (12): `--chart-cat-1` through `--chart-cat-12` for Recharts series colors
  - **Chart colorblind-safe palette** (7): `--chart-cb-1` through `--chart-cb-7` (Wong 2011)
  - **Trend indicators** (2): `--trend-positive` (#10b981) / `--trend-negative` (#f43f5e) for KpiCard deltas
* **`chartPalette.ts`** — refactored to resolve palettes from CSS vars at module load. `CHART_CATEGORICAL_PALETTE` and `CHART_COLORBLIND_PALETTE` exports are now populated via `getComputedStyle(document.documentElement).getPropertyValue(...)` for each `--chart-cat-*` / `--chart-cb-*` variable. Public API unchanged — every existing consumer (`useChartPalette`, `FleetHealthPanel`, `ApprovalAnalyticsPanel`) keeps working.
* **`policyEffectivenessUtils.ts`** — RGB tuples for heatmap interpolation now resolved at module load from `--heatmap-low/-mid/-high` via `getComputedStyle` + hex parsing. SSR-safe fallback tuples preserve behaviour where `document` is undefined.
* **`toolUsageUtils.ts`** — `errorRateColor` now returns `var(--status-success/-warning/-danger)` strings. The only production consumer (`ToolUsagePanel` Recharts `<Cell fill={...}>`) renders the value as an SVG fill attribute, which the browser resolves through the CSS variable mechanism.
* **`ActionVolumePanel.tsx`, `CostBreakdownPanel.tsx`, `ToolUsagePanel.tsx`** — Recharts CartesianGrid stroke and X/Y axis tick fill props migrate from hex literals to `var(--surface-card-border)` / `var(--text-muted)` / `var(--text-secondary)`. CSS variables work in SVG attribute strings.
* **`KpiCard.tsx`** — `DELTA_POSITIVE_COLOR` / `DELTA_NEGATIVE_COLOR` constants now reference `var(--trend-positive)` / `var(--trend-negative)`.
* **`KpiStrip.test.tsx`, `ToolUsagePanel.test.tsx`** — assertions updated to match new return shapes (e.g. `toHaveStyle({ color: 'var(--trend-positive)' })`, `expect(errorRateColor(0)).toBe('var(--status-success)')`).

### Files migrated (49 hex refs → 0)

| File | Refs |
|---|---|
| `chartPalette.ts` | 19 (categorical 12 + colorblind 7) |
| `KpiStrip.test.tsx` | 8 (assertions + descriptive `it()` strings) |
| `ToolUsagePanel.test.tsx` | 6 |
| `ActionVolumePanel.tsx` | 3 |
| `CostBreakdownPanel.tsx` | 3 |
| `policyEffectivenessUtils.ts` | 3 (comments + RGB tuples → runtime resolution) |
| `toolUsageUtils.ts` | 3 |
| `KpiCard.tsx` | 2 |
| `ToolUsagePanel.tsx` | 2 |

### Commit shape

9 granular commits: 1 token addition + 8 per-file migrations (with a small `🚨` follow-up to fix a `readonly string[]` → `string[]` type signature on the chartPalette exports to keep `useChartPalette` compiling).

## Test plan

* [x] `grep -rE '#[0-9a-fA-F]{3,8}' dashboard/src/features/analytics/` returns zero hits across the 9 TSX/TS files
* [x] `pnpm type-check` clean
* [x] `pnpm lint` clean
* [x] `pnpm test` — 833/833 passing across 96 test files
* [ ] Manual visual smoke — open Analytics page; verify all panels (Approval donut, Cost breakdown bars, Action volume lines, Tool usage bars, Fleet health sparklines, Policy effectiveness heatmap) render with correct colors
* [ ] Playwright design-fidelity suite (AAASM-1382) still passes against this branch

Part of the AAASM-1407 decomposition. Sibling tickets: AAASM-1410 (alerts/), AAASM-1411 (iam/ — merged), AAASM-1413 (small features — merged), AAASM-1414 (pages/ — merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)