### PR TITLE
[AAASM-1403] 🔧 (ci/sonarcloud): Exempt test + stories files from new_coverage denominator

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -74,5 +74,27 @@ sonar.exclusions=\
   aa-ebpf/src/**,\
   aa-ffi-python/src/**
 
+# ── Coverage exclusions ───────────────────────────────────────────────────────
+# Files that are still analysed for lint / code smells / security hotspots
+# but excluded from the `new_coverage` *denominator*. Without this, a PR that
+# adds many test-file lines drives down `new_coverage` (formula:
+# covered_prod_lines / total_new_lines) even when every production line in
+# the diff is fully covered. The Quality Gate then trips its 80% threshold
+# on test-heavy PRs, which has been the recurring false positive on AAASM
+# tickets (PRs #388, #415, #417, #428, #433 — see AAASM-1403).
+#
+# After this exemption: a tests-only PR has zero new "needs-coverage" lines
+# → metric reports `—` (n/a) → QG passes. A real production-code regression
+# without tests still trips the gate (regression-protection intact).
+sonar.coverage.exclusions=\
+  **/*.test.ts,\
+  **/*.test.tsx,\
+  **/*.stories.ts,\
+  **/*.stories.tsx,\
+  dashboard/src/test-setup.ts,\
+  dashboard/tests/e2e/**,\
+  **/tests/**/*.rs,\
+  **/benches/**/*.rs
+
 sonar.sourceEncoding=UTF-8
 sonar.scm.provider=git


### PR DESCRIPTION
## Summary

Adds `sonar.coverage.exclusions` to `sonar-project.properties` so test code is analysed for quality (lint / code smells / security hotspots) but excluded from the `new_coverage` denominator.

## Why this matters

SonarCloud computes `new_coverage = covered_prod_lines / total_new_lines`. When a PR adds many test-file lines, those count in the denominator without being testable themselves, dragging `new_coverage` below the 80% threshold even when every production line in the diff is fully covered. The QG trips → reviewers dismiss the signal → real regressions become invisible.

This has tripped on **five consecutive AAASM PRs**:

| PR | new_coverage | Root cause |
|---|---|---|
| #388 (AAASM-1332) | 0.0% | Pure tests-only |
| #415 (AAASM-1343) | 20.0% | Tiny prod + 4 tests |
| #417 (AAASM-1344) | 0.0% | Pure tests-only |
| #428 (AAASM-1418) | 49.0% | Mixed; test code dominates |
| #433 (AAASM-1416) | 22.2% | 2 prod lines + 10 tests |

In every case the production code in the diff was fully covered — the metric just couldn't see that.

## Exempted patterns

| Pattern | Purpose |
|---|---|
| `**/*.test.ts`, `**/*.test.tsx` | Vitest tests |
| `**/*.stories.ts`, `**/*.stories.tsx` | Storybook |
| `dashboard/src/test-setup.ts` | Vitest global setup |
| `dashboard/tests/e2e/**` | Playwright e2e |
| `**/tests/**/*.rs` | Rust integration tests |
| `**/benches/**/*.rs` | Rust benches |

## What's preserved

* Test files still get lint / code-smell / security-hotspot analysis (`sonar.exclusions` is unchanged; that's for full analysis exclusion — `sonar.coverage.exclusions` is the coverage-denominator-only knob).
* New uncovered **production** lines still trip the QG — regression-protection signal unchanged.

## Verification plan

Verification is by observation on the next test-heavy PR after this merges. Given the recent cadence (5 PRs in ~5 days), the next data point will land quickly. If a future tests-only PR's QG still trips on `new_coverage`, this exemption needs tuning — open a follow-up against AAASM-1403.

The regression-protection case (a real prod-code coverage gap) is left as opportunistic verification — it'll happen the first time someone adds prod code without coverage.

## Test plan

* [x] Config change is syntactically valid (committed file uses same continuation-line style as existing `sonar.exclusions`)
* [ ] SonarCloud QG state on this PR itself observed — this PR touches only config, no Rust / TS code → `new_coverage` should report `—` post-merge
* [ ] First test-heavy PR after merge — QG should no longer trip on `new_coverage` false positive

Closes AAASM-1403.