### PR TITLE
[AAASM-1410] ♻️ (dashboard): Migrate features/alerts/ hex literals to design tokens

### DIFF
--- a/dashboard/src/features/alerts/AlertDetailContent.tsx
+++ b/dashboard/src/features/alerts/AlertDetailContent.tsx
@@ -32,7 +32,7 @@ const sectionHeader = {
   fontSize: '0.75rem',
   textTransform: 'uppercase' as const,
   letterSpacing: '0.04em',
-  color: '#6b7280',
+  color: 'var(--text-muted)',
 }
 
 interface AlertDetailContentProps {
@@ -44,7 +44,7 @@ export function AlertDetailContent({ alertId }: AlertDetailContentProps) {
 
   if (isLoading) {
     return (
-      <p data-testid="alert-detail-loading" style={{ fontSize: '0.875rem', color: '#6b7280' }}>
+      <p data-testid="alert-detail-loading" style={{ fontSize: '0.875rem', color: 'var(--text-muted)' }}>
         Loading alert…
       </p>
     )
@@ -52,7 +52,7 @@ export function AlertDetailContent({ alertId }: AlertDetailContentProps) {
 
   if (isError || !data) {
     return (
-      <p data-testid="alert-detail-error" style={{ color: '#dc2626', fontSize: '0.875rem' }}>
+      <p data-testid="alert-detail-error" style={{ color: 'var(--status-danger-solid)', fontSize: '0.875rem' }}>
         Failed to load alert: {error?.message ?? 'unknown error'}
       </p>
     )
@@ -66,7 +66,7 @@ export function AlertDetailContent({ alertId }: AlertDetailContentProps) {
           <StatusBadge status={data.status} />
         </div>
         <h3 style={{ margin: 0, fontSize: '1rem' }}>{data.ruleName}</h3>
-        <p style={{ margin: 0, color: '#6b7280', fontSize: '0.75rem' }}>
+        <p style={{ margin: 0, color: 'var(--text-muted)', fontSize: '0.75rem' }}>
           Fired {data.firstFiredAt}
           {data.resolvedAt && ` · Resolved ${data.resolvedAt}`}
           {data.agentId && ` · Agent ${data.agentId}`}
@@ -78,7 +78,7 @@ export function AlertDetailContent({ alertId }: AlertDetailContentProps) {
         <pre
           data-testid="alert-detail-rule-yaml"
           style={{
-            background: '#f3f4f6',
+            background: 'var(--surface-hover-bg)',
             padding: '0.75rem',
             borderRadius: '4px',
             fontSize: '0.75rem',
@@ -144,7 +144,7 @@ export function AlertDetailContent({ alertId }: AlertDetailContentProps) {
         <pre
           data-testid="alert-detail-event-payload"
           style={{
-            background: '#f3f4f6',
+            background: 'var(--surface-hover-bg)',
             padding: '0.75rem',
             borderRadius: '4px',
             fontSize: '0.75rem',
@@ -164,7 +164,7 @@ export function AlertDetailContent({ alertId }: AlertDetailContentProps) {
       <section style={sectionStyle}>
         <span style={sectionHeader}>Routing log</span>
         {data.routingLog.length === 0 ? (
-          <span style={{ fontSize: '0.75rem', color: '#6b7280' }}>No deliveries recorded.</span>
+          <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>No deliveries recorded.</span>
         ) : (
           <ul
             data-testid="alert-detail-routing-log"
@@ -173,7 +173,7 @@ export function AlertDetailContent({ alertId }: AlertDetailContentProps) {
             {data.routingLog.map((entry, i) => (
               <li key={i}>
                 <strong>{entry.deliveredAt}</strong> → {entry.destinationId} ·{' '}
-                <span style={{ color: entry.status === 'ok' ? '#166534' : '#991b1b' }}>
+                <span style={{ color: entry.status === 'ok' ? 'var(--status-success-text-strong)' : 'var(--status-danger-text-strong)' }}>
                   {entry.status}
                 </span>
                 {entry.errorMessage && ` (${entry.errorMessage})`}

--- a/dashboard/src/features/alerts/AlertDetailDrawer.tsx
+++ b/dashboard/src/features/alerts/AlertDetailDrawer.tsx
@@ -40,7 +40,7 @@ export function AlertDetailDrawer({ open, onClose, children }: AlertDetailDrawer
         style={{
           width: 'min(520px, 95vw)',
           height: '100%',
-          background: '#fff',
+          background: 'var(--surface-card)',
           boxShadow: '-10px 0 25px rgba(0, 0, 0, 0.15)',
           padding: '1.25rem',
           overflowY: 'auto',
@@ -54,7 +54,7 @@ export function AlertDetailDrawer({ open, onClose, children }: AlertDetailDrawer
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'center',
-            borderBottom: '1px solid #e5e7eb',
+            borderBottom: '1px solid var(--surface-card-border)',
             paddingBottom: '0.5rem',
           }}
         >
@@ -69,7 +69,7 @@ export function AlertDetailDrawer({ open, onClose, children }: AlertDetailDrawer
               background: 'transparent',
               fontSize: '1.25rem',
               cursor: 'pointer',
-              color: '#6b7280',
+              color: 'var(--text-muted)',
             }}
           >
             ✕

--- a/dashboard/src/features/alerts/AlertFilterBar.tsx
+++ b/dashboard/src/features/alerts/AlertFilterBar.tsx
@@ -23,7 +23,7 @@ export function AlertFilterBar({ value, onChange }: AlertFilterBarProps) {
         gap: '0.75rem',
         alignItems: 'center',
         padding: '0.75rem 0',
-        borderBottom: '1px solid #e5e7eb',
+        borderBottom: '1px solid var(--surface-card-border)',
         fontSize: '0.875rem',
       }}
     >
@@ -31,7 +31,7 @@ export function AlertFilterBar({ value, onChange }: AlertFilterBarProps) {
         data-testid="alerts-filter-severity"
         style={{ display: 'flex', gap: '0.25rem', border: 'none', padding: 0 }}
       >
-        <legend style={{ color: '#6b7280', marginRight: '0.5rem' }}>Severity</legend>
+        <legend style={{ color: 'var(--text-muted)', marginRight: '0.5rem' }}>Severity</legend>
         {ALL_SEVERITIES.map((sev) => {
           const active = value.severities.includes(sev)
           return (
@@ -44,9 +44,9 @@ export function AlertFilterBar({ value, onChange }: AlertFilterBarProps) {
               style={{
                 padding: '2px 8px',
                 borderRadius: '4px',
-                border: '1px solid #d1d5db',
-                background: active ? '#1f2937' : '#fff',
-                color: active ? '#fff' : '#1f2937',
+                border: '1px solid var(--form-input-border)',
+                background: active ? 'var(--button-primary-bg)' : 'var(--surface-card)',
+                color: active ? 'var(--text-on-accent)' : 'var(--button-primary-bg)',
                 cursor: 'pointer',
                 fontSize: '0.75rem',
               }}
@@ -61,7 +61,7 @@ export function AlertFilterBar({ value, onChange }: AlertFilterBarProps) {
         data-testid="alerts-filter-status"
         style={{ display: 'flex', gap: '0.25rem', border: 'none', padding: 0 }}
       >
-        <legend style={{ color: '#6b7280', marginRight: '0.5rem' }}>Status</legend>
+        <legend style={{ color: 'var(--text-muted)', marginRight: '0.5rem' }}>Status</legend>
         {ALL_STATUSES.map((st) => {
           const active = value.statuses.includes(st)
           return (
@@ -74,9 +74,9 @@ export function AlertFilterBar({ value, onChange }: AlertFilterBarProps) {
               style={{
                 padding: '2px 8px',
                 borderRadius: '4px',
-                border: '1px solid #d1d5db',
-                background: active ? '#1f2937' : '#fff',
-                color: active ? '#fff' : '#1f2937',
+                border: '1px solid var(--form-input-border)',
+                background: active ? 'var(--button-primary-bg)' : 'var(--surface-card)',
+                color: active ? 'var(--text-on-accent)' : 'var(--button-primary-bg)',
                 cursor: 'pointer',
                 fontSize: '0.75rem',
               }}
@@ -88,7 +88,7 @@ export function AlertFilterBar({ value, onChange }: AlertFilterBarProps) {
       </fieldset>
 
       <label
-        style={{ display: 'flex', alignItems: 'center', gap: '0.25rem', color: '#6b7280' }}
+        style={{ display: 'flex', alignItems: 'center', gap: '0.25rem', color: 'var(--text-muted)' }}
       >
         Agent
         <input
@@ -99,7 +99,7 @@ export function AlertFilterBar({ value, onChange }: AlertFilterBarProps) {
           onChange={(e) => onChange({ ...value, agentQuery: e.target.value })}
           style={{
             padding: '2px 8px',
-            border: '1px solid #d1d5db',
+            border: '1px solid var(--form-input-border)',
             borderRadius: '4px',
             fontSize: '0.75rem',
             minWidth: '12rem',
@@ -108,7 +108,7 @@ export function AlertFilterBar({ value, onChange }: AlertFilterBarProps) {
       </label>
 
       <label
-        style={{ display: 'flex', alignItems: 'center', gap: '0.25rem', color: '#6b7280' }}
+        style={{ display: 'flex', alignItems: 'center', gap: '0.25rem', color: 'var(--text-muted)' }}
       >
         Range
         <select
@@ -117,7 +117,7 @@ export function AlertFilterBar({ value, onChange }: AlertFilterBarProps) {
           onChange={(e) => onChange({ ...value, timeRange: e.target.value as TimeRangePreset })}
           style={{
             padding: '2px 8px',
-            border: '1px solid #d1d5db',
+            border: '1px solid var(--form-input-border)',
             borderRadius: '4px',
             fontSize: '0.75rem',
           }}
@@ -133,14 +133,14 @@ export function AlertFilterBar({ value, onChange }: AlertFilterBarProps) {
       {value.timeRange === 'custom' && (
         <div
           data-testid="alerts-filter-custom"
-          style={{ display: 'flex', gap: '0.25rem', alignItems: 'center', color: '#6b7280' }}
+          style={{ display: 'flex', gap: '0.25rem', alignItems: 'center', color: 'var(--text-muted)' }}
         >
           <input
             type="datetime-local"
             data-testid="alerts-filter-custom-from"
             value={value.customFrom ?? ''}
             onChange={(e) => onChange({ ...value, customFrom: e.target.value || null })}
-            style={{ padding: '2px 6px', border: '1px solid #d1d5db', borderRadius: '4px' }}
+            style={{ padding: '2px 6px', border: '1px solid var(--form-input-border)', borderRadius: '4px' }}
           />
           <span>→</span>
           <input
@@ -148,7 +148,7 @@ export function AlertFilterBar({ value, onChange }: AlertFilterBarProps) {
             data-testid="alerts-filter-custom-to"
             value={value.customTo ?? ''}
             onChange={(e) => onChange({ ...value, customTo: e.target.value || null })}
-            style={{ padding: '2px 6px', border: '1px solid #d1d5db', borderRadius: '4px' }}
+            style={{ padding: '2px 6px', border: '1px solid var(--form-input-border)', borderRadius: '4px' }}
           />
         </div>
       )}

--- a/dashboard/src/features/alerts/AlertList.tsx
+++ b/dashboard/src/features/alerts/AlertList.tsx
@@ -107,14 +107,14 @@ function SkeletonRows({ columnCount }: { columnCount: number }) {
   return (
     <>
       {Array.from({ length: 5 }).map((_, i) => (
-        <tr key={i} data-testid="alert-row-skeleton" style={{ borderBottom: '1px solid #f3f4f6' }}>
+        <tr key={i} data-testid="alert-row-skeleton" style={{ borderBottom: '1px solid var(--surface-hover-bg)' }}>
           {Array.from({ length: columnCount }).map((_, j) => (
             <td key={j} style={{ padding: '0.5rem' }}>
               <span
                 style={{
                   display: 'block',
                   height: '0.875rem',
-                  background: '#e5e7eb',
+                  background: 'var(--surface-card-border)',
                   borderRadius: '4px',
                   opacity: 0.6 + (i % 2) * 0.2,
                 }}
@@ -158,10 +158,10 @@ export function AlertList({ rows, onSelect, loading = false }: AlertListProps) {
                 style={{
                   textAlign: 'left',
                   padding: '0.5rem',
-                  borderBottom: '2px solid #e5e7eb',
+                  borderBottom: '2px solid var(--surface-card-border)',
                   fontSize: '0.75rem',
                   textTransform: 'uppercase',
-                  color: '#6b7280',
+                  color: 'var(--text-muted)',
                   letterSpacing: '0.04em',
                   cursor: header.column.getCanSort() ? 'pointer' : 'default',
                   userSelect: 'none',
@@ -189,7 +189,7 @@ export function AlertList({ rows, onSelect, loading = false }: AlertListProps) {
               data-testid="alert-row"
               onClick={() => onSelect?.(row.original.id)}
               style={{
-                borderBottom: '1px solid #f3f4f6',
+                borderBottom: '1px solid var(--surface-hover-bg)',
                 cursor: onSelect ? 'pointer' : 'default',
               }}
             >

--- a/dashboard/src/features/alerts/AlertRuleForm.tsx
+++ b/dashboard/src/features/alerts/AlertRuleForm.tsx
@@ -134,7 +134,7 @@ export function AlertRuleForm({
       <div
         style={{
           width: 'min(720px, 100%)',
-          background: '#fff',
+          background: 'var(--surface-card)',
           borderRadius: '8px',
           boxShadow: '0 10px 25px rgba(0, 0, 0, 0.2)',
           padding: '1.25rem',
@@ -163,7 +163,7 @@ export function AlertRuleForm({
               background: 'transparent',
               fontSize: '1.25rem',
               cursor: 'pointer',
-              color: '#6b7280',
+              color: 'var(--text-muted)',
             }}
           >
             ✕
@@ -185,7 +185,7 @@ export function AlertRuleForm({
                 {...methods.register('name')}
               />
               {methods.formState.errors.name && (
-                <span style={{ color: '#dc2626', fontSize: '0.75rem' }}>
+                <span style={{ color: 'var(--status-danger-solid)', fontSize: '0.75rem' }}>
                   {methods.formState.errors.name.message}
                 </span>
               )}
@@ -242,8 +242,8 @@ export function AlertRuleForm({
                 disabled={submitting}
                 style={{
                   padding: '6px 14px',
-                  background: '#1f2937',
-                  color: '#fff',
+                  background: 'var(--button-primary-bg)',
+                  color: 'var(--text-on-accent)',
                   border: 'none',
                   borderRadius: '4px',
                   cursor: submitting ? 'wait' : 'pointer',

--- a/dashboard/src/features/alerts/AlertsErrorBanner.tsx
+++ b/dashboard/src/features/alerts/AlertsErrorBanner.tsx
@@ -14,8 +14,8 @@ export function AlertsErrorBanner({ message, onRetry }: AlertsErrorBannerProps) 
         alignItems: 'center',
         marginTop: '0.75rem',
         padding: '8px 12px',
-        background: '#fee2e2',
-        color: '#991b1b',
+        background: 'var(--status-danger-bg)',
+        color: 'var(--status-danger-text-strong)',
         borderRadius: '4px',
         fontSize: '0.875rem',
       }}
@@ -27,8 +27,8 @@ export function AlertsErrorBanner({ message, onRetry }: AlertsErrorBannerProps) 
         onClick={onRetry}
         style={{
           padding: '4px 10px',
-          background: '#991b1b',
-          color: '#fff',
+          background: 'var(--status-danger-text-strong)',
+          color: 'var(--text-on-accent)',
           border: 'none',
           borderRadius: '4px',
           cursor: 'pointer',

--- a/dashboard/src/features/alerts/AlertsTabs.tsx
+++ b/dashboard/src/features/alerts/AlertsTabs.tsx
@@ -18,7 +18,7 @@ export function AlertsTabs({ value, onChange }: AlertsTabsProps) {
       style={{
         display: 'flex',
         gap: '0.25rem',
-        borderBottom: '1px solid #e5e7eb',
+        borderBottom: '1px solid var(--surface-card-border)',
         marginBottom: '0.5rem',
       }}
     >
@@ -36,9 +36,9 @@ export function AlertsTabs({ value, onChange }: AlertsTabsProps) {
               padding: '0.5rem 1rem',
               background: 'transparent',
               border: 'none',
-              borderBottom: active ? '2px solid #1f2937' : '2px solid transparent',
+              borderBottom: active ? '2px solid var(--button-primary-bg)' : '2px solid transparent',
               cursor: 'pointer',
-              color: active ? '#1f2937' : '#6b7280',
+              color: active ? 'var(--button-primary-bg)' : 'var(--text-muted)',
               fontWeight: active ? 600 : 400,
               fontSize: '0.875rem',
               marginBottom: '-1px',

--- a/dashboard/src/features/alerts/ConditionBuilder.tsx
+++ b/dashboard/src/features/alerts/ConditionBuilder.tsx
@@ -26,7 +26,7 @@ const fieldStyle = {
   fontSize: '0.875rem',
 }
 
-const errorStyle = { color: '#dc2626', fontSize: '0.75rem' }
+const errorStyle = { color: 'var(--status-danger-solid)', fontSize: '0.75rem' }
 
 export function ConditionBuilder() {
   const { register, formState, watch } = useFormContext<RuleFormValues>()
@@ -41,12 +41,12 @@ export function ConditionBuilder() {
         display: 'grid',
         gridTemplateColumns: 'repeat(4, 1fr)',
         gap: '0.75rem',
-        border: '1px solid #e5e7eb',
+        border: '1px solid var(--surface-card-border)',
         borderRadius: '6px',
         padding: '0.75rem',
       }}
     >
-      <legend style={{ padding: '0 0.5rem', color: '#6b7280', fontSize: '0.75rem' }}>
+      <legend style={{ padding: '0 0.5rem', color: 'var(--text-muted)', fontSize: '0.75rem' }}>
         Condition
       </legend>
 
@@ -78,7 +78,7 @@ export function ConditionBuilder() {
         <span>
           Threshold
           {isPercentage && (
-            <span style={{ color: '#6b7280', marginLeft: '0.25rem' }}>(0–100)</span>
+            <span style={{ color: 'var(--text-muted)', marginLeft: '0.25rem' }}>(0–100)</span>
           )}
         </span>
         <input

--- a/dashboard/src/features/alerts/DedupAndSuppressionFields.tsx
+++ b/dashboard/src/features/alerts/DedupAndSuppressionFields.tsx
@@ -1,7 +1,7 @@
 import { useFieldArray, useFormContext } from 'react-hook-form'
 import type { RuleFormValues } from './ruleFormSchema'
 
-const errorStyle = { color: '#dc2626', fontSize: '0.75rem' }
+const errorStyle = { color: 'var(--status-danger-solid)', fontSize: '0.75rem' }
 
 export function DedupAndSuppressionFields() {
   const { register, control, formState } = useFormContext<RuleFormValues>()
@@ -18,12 +18,12 @@ export function DedupAndSuppressionFields() {
         display: 'flex',
         flexDirection: 'column',
         gap: '0.75rem',
-        border: '1px solid #e5e7eb',
+        border: '1px solid var(--surface-card-border)',
         borderRadius: '6px',
         padding: '0.75rem',
       }}
     >
-      <legend style={{ padding: '0 0.5rem', color: '#6b7280', fontSize: '0.75rem' }}>
+      <legend style={{ padding: '0 0.5rem', color: 'var(--text-muted)', fontSize: '0.75rem' }}>
         Deduplication &amp; suppression
       </legend>
 
@@ -60,9 +60,9 @@ export function DedupAndSuppressionFields() {
             onClick={() => append({ key: '', value: '' })}
             style={{
               padding: '2px 8px',
-              border: '1px solid #d1d5db',
+              border: '1px solid var(--form-input-border)',
               borderRadius: '4px',
-              background: '#fff',
+              background: 'var(--surface-card)',
               cursor: 'pointer',
               fontSize: '0.75rem',
             }}
@@ -72,7 +72,7 @@ export function DedupAndSuppressionFields() {
         </div>
 
         {fields.length === 0 && (
-          <span style={{ fontSize: '0.75rem', color: '#6b7280' }}>
+          <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>
             No suppression labels — the rule will fire regardless of labels.
           </span>
         )}
@@ -93,7 +93,7 @@ export function DedupAndSuppressionFields() {
                 <span style={errorStyle}>{errors.suppressionLabels[idx]?.key?.message}</span>
               )}
             </div>
-            <span style={{ alignSelf: 'center', color: '#6b7280' }}>=</span>
+            <span style={{ alignSelf: 'center', color: 'var(--text-muted)' }}>=</span>
             <div style={{ display: 'flex', flexDirection: 'column', flex: 1 }}>
               <input
                 placeholder="prod"
@@ -111,9 +111,9 @@ export function DedupAndSuppressionFields() {
               aria-label="Remove suppression label"
               style={{
                 padding: '0 8px',
-                border: '1px solid #d1d5db',
+                border: '1px solid var(--form-input-border)',
                 borderRadius: '4px',
-                background: '#fff',
+                background: 'var(--surface-card)',
                 cursor: 'pointer',
                 fontSize: '0.875rem',
               }}

--- a/dashboard/src/features/alerts/DestinationManager.tsx
+++ b/dashboard/src/features/alerts/DestinationManager.tsx
@@ -133,7 +133,7 @@ export function DestinationManager({ open, onClose }: DestinationManagerProps) {
           width: 'min(720px, 100%)',
           maxHeight: '90vh',
           overflow: 'auto',
-          background: '#fff',
+          background: 'var(--surface-card)',
           borderRadius: '8px',
           boxShadow: '0 10px 25px rgba(0, 0, 0, 0.2)',
           padding: '1.25rem',
@@ -158,7 +158,7 @@ export function DestinationManager({ open, onClose }: DestinationManagerProps) {
               background: 'transparent',
               fontSize: '1.25rem',
               cursor: 'pointer',
-              color: '#6b7280',
+              color: 'var(--text-muted)',
             }}
           >
             ✕
@@ -166,18 +166,18 @@ export function DestinationManager({ open, onClose }: DestinationManagerProps) {
         </header>
 
         {isLoading && (
-          <p data-testid="destination-manager-loading" style={{ fontSize: '0.875rem', color: '#6b7280' }}>
+          <p data-testid="destination-manager-loading" style={{ fontSize: '0.875rem', color: 'var(--text-muted)' }}>
             Loading destinations…
           </p>
         )}
         {isError && (
-          <p data-testid="destination-manager-error" style={{ color: '#dc2626', fontSize: '0.875rem' }}>
+          <p data-testid="destination-manager-error" style={{ color: 'var(--status-danger-solid)', fontSize: '0.875rem' }}>
             Failed to load destinations: {error?.message ?? 'unknown error'}
           </p>
         )}
 
         {!isLoading && !isError && destinations.length === 0 && (
-          <p data-testid="destination-manager-empty" style={{ fontSize: '0.875rem', color: '#6b7280' }}>
+          <p data-testid="destination-manager-empty" style={{ fontSize: '0.875rem', color: 'var(--text-muted)' }}>
             No destinations configured yet.
           </p>
         )}
@@ -189,13 +189,13 @@ export function DestinationManager({ open, onClose }: DestinationManagerProps) {
           >
             <thead>
               <tr>
-                <th style={{ textAlign: 'left', padding: '0.25rem', borderBottom: '1px solid #e5e7eb' }}>
+                <th style={{ textAlign: 'left', padding: '0.25rem', borderBottom: '1px solid var(--surface-card-border)' }}>
                   Kind
                 </th>
-                <th style={{ textAlign: 'left', padding: '0.25rem', borderBottom: '1px solid #e5e7eb' }}>
+                <th style={{ textAlign: 'left', padding: '0.25rem', borderBottom: '1px solid var(--surface-card-border)' }}>
                   Name
                 </th>
-                <th style={{ textAlign: 'right', padding: '0.25rem', borderBottom: '1px solid #e5e7eb' }}>
+                <th style={{ textAlign: 'right', padding: '0.25rem', borderBottom: '1px solid var(--surface-card-border)' }}>
                   Actions
                 </th>
               </tr>
@@ -230,7 +230,7 @@ export function DestinationManager({ open, onClose }: DestinationManagerProps) {
                       data-testid={`destination-delete-${d.id}`}
                       onClick={() => void remove(d)}
                       disabled={deleteMut.isPending}
-                      style={{ padding: '2px 8px', fontSize: '0.75rem', color: '#991b1b' }}
+                      style={{ padding: '2px 8px', fontSize: '0.75rem', color: 'var(--status-danger-text-strong)' }}
                     >
                       Delete
                     </button>
@@ -247,7 +247,7 @@ export function DestinationManager({ open, onClose }: DestinationManagerProps) {
             display: 'flex',
             flexDirection: 'column',
             gap: '0.5rem',
-            border: '1px solid #e5e7eb',
+            border: '1px solid var(--surface-card-border)',
             borderRadius: '6px',
             padding: '0.75rem',
           }}
@@ -311,8 +311,8 @@ export function DestinationManager({ open, onClose }: DestinationManagerProps) {
               disabled={createMut.isPending || updateMut.isPending}
               style={{
                 padding: '4px 12px',
-                background: '#1f2937',
-                color: '#fff',
+                background: 'var(--button-primary-bg)',
+                color: 'var(--text-on-accent)',
                 border: 'none',
                 borderRadius: '4px',
                 fontSize: '0.75rem',

--- a/dashboard/src/features/alerts/DestinationsPicker.tsx
+++ b/dashboard/src/features/alerts/DestinationsPicker.tsx
@@ -15,25 +15,25 @@ export function DestinationsPicker() {
         display: 'flex',
         flexDirection: 'column',
         gap: '0.5rem',
-        border: '1px solid #e5e7eb',
+        border: '1px solid var(--surface-card-border)',
         borderRadius: '6px',
         padding: '0.75rem',
       }}
     >
-      <legend style={{ padding: '0 0.5rem', color: '#6b7280', fontSize: '0.75rem' }}>
+      <legend style={{ padding: '0 0.5rem', color: 'var(--text-muted)', fontSize: '0.75rem' }}>
         Routing destinations
       </legend>
 
-      {isLoading && <span style={{ fontSize: '0.75rem', color: '#6b7280' }}>Loading…</span>}
+      {isLoading && <span style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>Loading…</span>}
       {isError && (
-        <span data-testid="rule-destinations-error" style={{ fontSize: '0.75rem', color: '#dc2626' }}>
+        <span data-testid="rule-destinations-error" style={{ fontSize: '0.75rem', color: 'var(--status-danger-solid)' }}>
           Failed to load destinations
         </span>
       )}
       {!isLoading && !isError && destinations.length === 0 && (
         <span
           data-testid="rule-destinations-empty"
-          style={{ fontSize: '0.75rem', color: '#6b7280' }}
+          style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}
         >
           No destinations configured yet — add one in the Destination Registry.
         </span>
@@ -64,9 +64,9 @@ export function DestinationsPicker() {
                       gap: '0.35rem',
                       padding: '4px 10px',
                       borderRadius: '6px',
-                      border: '1px solid #d1d5db',
-                      background: active ? '#1f2937' : '#fff',
-                      color: active ? '#fff' : '#1f2937',
+                      border: '1px solid var(--form-input-border)',
+                      background: active ? 'var(--button-primary-bg)' : 'var(--surface-card)',
+                      color: active ? 'var(--text-on-accent)' : 'var(--button-primary-bg)',
                       cursor: 'pointer',
                       fontSize: '0.75rem',
                     }}
@@ -88,7 +88,7 @@ export function DestinationsPicker() {
       />
 
       {error && (
-        <span style={{ color: '#dc2626', fontSize: '0.75rem' }}>{error.message}</span>
+        <span style={{ color: 'var(--status-danger-solid)', fontSize: '0.75rem' }}>{error.message}</span>
       )}
     </fieldset>
   )

--- a/dashboard/src/features/alerts/EmptyStateNoAlerts.tsx
+++ b/dashboard/src/features/alerts/EmptyStateNoAlerts.tsx
@@ -5,19 +5,19 @@ export function EmptyStateNoAlerts() {
       style={{
         textAlign: 'center',
         padding: '2.5rem 1.5rem',
-        border: '1px dashed #d1d5db',
+        border: '1px dashed var(--form-input-border)',
         borderRadius: '8px',
-        background: '#fafafa',
+        background: 'var(--shell-surface-subtle)',
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
         gap: '0.5rem',
       }}
     >
-      <h2 style={{ margin: 0, fontSize: '1rem', color: '#1f2937' }}>
+      <h2 style={{ margin: 0, fontSize: '1rem', color: 'var(--button-primary-bg)' }}>
         No alerts in this window
       </h2>
-      <p style={{ margin: 0, fontSize: '0.875rem', color: '#6b7280', maxWidth: '32rem' }}>
+      <p style={{ margin: 0, fontSize: '0.875rem', color: 'var(--text-muted)', maxWidth: '32rem' }}>
         No matching alerts fired in the selected time range. Adjust the filters
         above, or read the docs for tips on tuning rule thresholds.
       </p>
@@ -26,7 +26,7 @@ export function EmptyStateNoAlerts() {
         target="_blank"
         rel="noreferrer"
         data-testid="alerts-empty-docs-link"
-        style={{ marginTop: '0.25rem', fontSize: '0.75rem', color: '#1f2937' }}
+        style={{ marginTop: '0.25rem', fontSize: '0.75rem', color: 'var(--button-primary-bg)' }}
       >
         Read the alerts docs →
       </a>

--- a/dashboard/src/features/alerts/EmptyStateNoRules.tsx
+++ b/dashboard/src/features/alerts/EmptyStateNoRules.tsx
@@ -9,19 +9,19 @@ export function EmptyStateNoRules({ onCreateRule }: EmptyStateNoRulesProps) {
       style={{
         textAlign: 'center',
         padding: '3rem 1.5rem',
-        border: '1px dashed #d1d5db',
+        border: '1px dashed var(--form-input-border)',
         borderRadius: '8px',
-        background: '#fafafa',
+        background: 'var(--shell-surface-subtle)',
         display: 'flex',
         flexDirection: 'column',
         alignItems: 'center',
         gap: '0.5rem',
       }}
     >
-      <h2 style={{ margin: 0, fontSize: '1rem', color: '#1f2937' }}>
+      <h2 style={{ margin: 0, fontSize: '1rem', color: 'var(--button-primary-bg)' }}>
         No alert rules configured
       </h2>
-      <p style={{ margin: 0, fontSize: '0.875rem', color: '#6b7280', maxWidth: '32rem' }}>
+      <p style={{ margin: 0, fontSize: '0.875rem', color: 'var(--text-muted)', maxWidth: '32rem' }}>
         Alert rules detect budget overruns, policy violations, and anomalies across
         your governed agents. Configure your first rule to start receiving
         actionable signals.
@@ -33,8 +33,8 @@ export function EmptyStateNoRules({ onCreateRule }: EmptyStateNoRulesProps) {
         style={{
           marginTop: '0.5rem',
           padding: '6px 14px',
-          background: '#1f2937',
-          color: '#fff',
+          background: 'var(--button-primary-bg)',
+          color: 'var(--text-on-accent)',
           border: 'none',
           borderRadius: '4px',
           cursor: 'pointer',

--- a/dashboard/src/features/alerts/SeverityBadge.tsx
+++ b/dashboard/src/features/alerts/SeverityBadge.tsx
@@ -1,10 +1,10 @@
 import type { Severity } from './types'
 
 const SEVERITY_BG: Record<Severity, string> = {
-  CRITICAL: '#dc2626',
-  HIGH: '#f97316',
-  MEDIUM: '#eab308',
-  LOW: '#60a5fa',
+  CRITICAL: 'var(--severity-critical)',
+  HIGH: 'var(--severity-high)',
+  MEDIUM: 'var(--severity-medium)',
+  LOW: 'var(--severity-low)',
 }
 
 export function SeverityBadge({ severity }: { severity: Severity }) {
@@ -18,7 +18,7 @@ export function SeverityBadge({ severity }: { severity: Severity }) {
         fontSize: '0.7rem',
         fontWeight: 700,
         letterSpacing: '0.04em',
-        color: '#fff',
+        color: 'var(--text-on-accent)',
         background: SEVERITY_BG[severity],
       }}
     >

--- a/dashboard/src/features/alerts/SeveritySelect.tsx
+++ b/dashboard/src/features/alerts/SeveritySelect.tsx
@@ -16,12 +16,12 @@ export function SeveritySelect() {
         display: 'flex',
         flexDirection: 'column',
         gap: '0.5rem',
-        border: '1px solid #e5e7eb',
+        border: '1px solid var(--surface-card-border)',
         borderRadius: '6px',
         padding: '0.75rem',
       }}
     >
-      <legend style={{ padding: '0 0.5rem', color: '#6b7280', fontSize: '0.75rem' }}>
+      <legend style={{ padding: '0 0.5rem', color: 'var(--text-muted)', fontSize: '0.75rem' }}>
         Severity
       </legend>
       <div style={{ display: 'flex', gap: '0.75rem' }}>
@@ -41,7 +41,7 @@ export function SeveritySelect() {
         ))}
       </div>
       {error && (
-        <span style={{ color: '#dc2626', fontSize: '0.75rem' }}>{error.message}</span>
+        <span style={{ color: 'var(--status-danger-solid)', fontSize: '0.75rem' }}>{error.message}</span>
       )}
     </fieldset>
   )

--- a/dashboard/src/features/alerts/SilenceAction.tsx
+++ b/dashboard/src/features/alerts/SilenceAction.tsx
@@ -57,7 +57,7 @@ export function SilenceAction({ alertId, silenced = false }: SilenceActionProps)
     return (
       <p
         data-testid="silence-action-already"
-        style={{ fontSize: '0.75rem', color: '#6b7280' }}
+        style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}
       >
         Alert is currently silenced.
       </p>
@@ -72,7 +72,7 @@ export function SilenceAction({ alertId, silenced = false }: SilenceActionProps)
         flexDirection: 'column',
         gap: '0.5rem',
         padding: '0.75rem',
-        border: '1px solid #e5e7eb',
+        border: '1px solid var(--surface-card-border)',
         borderRadius: '6px',
       }}
     >
@@ -81,7 +81,7 @@ export function SilenceAction({ alertId, silenced = false }: SilenceActionProps)
           fontSize: '0.75rem',
           textTransform: 'uppercase',
           letterSpacing: '0.04em',
-          color: '#6b7280',
+          color: 'var(--text-muted)',
         }}
       >
         Silence this alert
@@ -100,9 +100,9 @@ export function SilenceAction({ alertId, silenced = false }: SilenceActionProps)
               style={{
                 padding: '4px 10px',
                 borderRadius: '4px',
-                border: '1px solid #d1d5db',
-                background: active ? '#1f2937' : '#fff',
-                color: active ? '#fff' : '#1f2937',
+                border: '1px solid var(--form-input-border)',
+                background: active ? 'var(--button-primary-bg)' : 'var(--surface-card)',
+                color: active ? 'var(--text-on-accent)' : 'var(--button-primary-bg)',
                 cursor: 'pointer',
                 fontSize: '0.75rem',
               }}
@@ -130,14 +130,14 @@ export function SilenceAction({ alertId, silenced = false }: SilenceActionProps)
             onChange={(e) => setCustomMinutes(e.target.value)}
             style={{ width: '5rem' }}
           />
-          <span style={{ color: '#6b7280', fontSize: '0.75rem' }}>minutes</span>
+          <span style={{ color: 'var(--text-muted)', fontSize: '0.75rem' }}>minutes</span>
         </label>
       )}
 
       <label
         style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.875rem' }}
       >
-        <span style={{ color: '#6b7280', fontSize: '0.75rem' }}>Reason (optional)</span>
+        <span style={{ color: 'var(--text-muted)', fontSize: '0.75rem' }}>Reason (optional)</span>
         <input
           data-testid="silence-action-reason"
           value={reason}
@@ -154,8 +154,8 @@ export function SilenceAction({ alertId, silenced = false }: SilenceActionProps)
         style={{
           alignSelf: 'flex-end',
           padding: '6px 14px',
-          background: '#1f2937',
-          color: '#fff',
+          background: 'var(--button-primary-bg)',
+          color: 'var(--text-on-accent)',
           border: 'none',
           borderRadius: '4px',
           cursor: silence.isPending ? 'wait' : 'pointer',

--- a/dashboard/src/features/alerts/StatusBadge.tsx
+++ b/dashboard/src/features/alerts/StatusBadge.tsx
@@ -1,9 +1,9 @@
 import type { AlertStatus } from './types'
 
 const STATUS_STYLE: Record<AlertStatus, { bg: string; fg: string }> = {
-  FIRING: { bg: '#fee2e2', fg: '#991b1b' },
-  RESOLVED: { bg: '#dcfce7', fg: '#166534' },
-  SUPPRESSED: { bg: '#e5e7eb', fg: '#374151' },
+  FIRING: { bg: 'var(--status-danger-bg)', fg: 'var(--status-danger-text-strong)' },
+  RESOLVED: { bg: 'var(--status-success-bg)', fg: 'var(--status-success-text-strong)' },
+  SUPPRESSED: { bg: 'var(--surface-card-border)', fg: 'var(--text-secondary)' },
 }
 
 export function StatusBadge({ status }: { status: AlertStatus }) {

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -202,4 +202,13 @@
   /* ── Trend indicators (Kpi delta) ────────────────────────── */
   --trend-positive: #10b981;
   --trend-negative: #f43f5e;
+
+  /* ── Severity palette (alert badges) ─────────────────────── */
+  /* Ordered from highest to lowest severity. CRITICAL matches
+     --status-danger-solid; HIGH matches --chart-cat-8; MEDIUM/LOW
+     introduce new yellow-500 / blue-400 tokens for alerts only. */
+  --severity-critical: #dc2626;
+  --severity-high: #f97316;
+  --severity-medium: #eab308;
+  --severity-low: #60a5fa;
 }


### PR DESCRIPTION
## Summary

Migrates **~110 hex color literals across 17 TSX files** in `dashboard/src/features/alerts/` to `var(--…)` references. **Final ticket** in the AAASM-1407 residual sweep — once this merges, AAASM-94 AC #8 (`grep -rE '#[0-9a-fA-F]{3,8}' dashboard/src/` returns zero hits, excl. `styles.css`) closes.

### What changed

* **`dashboard/src/styles.css`** — added 4 new severity tokens:
  - `--severity-critical` (#dc2626) — matches `--status-danger-solid` value
  - `--severity-high` (#f97316) — matches `--chart-cat-8` value
  - `--severity-medium` (#eab308) — yellow-500, new
  - `--severity-low` (#60a5fa) — blue-400, new
* **17 TSX files migrated** — every hex literal in alerts/ replaced with the appropriate design token. Heavy reuse of existing tokens (`--surface-*`, `--text-*`, `--status-*`, `--button-primary-bg`, `--form-input-border`, `--shell-surface-subtle`, `--text-on-accent`).

### Files migrated (110 hex refs → 0)

| File | Refs |
|---|---|
| `alerts/AlertFilterBar.tsx` | 16 |
| `alerts/DestinationManager.tsx` | 12 |
| `alerts/SilenceAction.tsx` | 10 |
| `alerts/DedupAndSuppressionFields.tsx` | 9 |
| `alerts/DestinationsPicker.tsx` | 9 |
| `alerts/AlertDetailContent.tsx` | 8 |
| `alerts/EmptyStateNoRules.tsx` | 6 |
| `alerts/AlertList.tsx` | 5 |
| `alerts/AlertRuleForm.tsx` | 5 |
| `alerts/EmptyStateNoAlerts.tsx` | 5 |
| `alerts/SeverityBadge.tsx` | 5 |
| `alerts/AlertsErrorBanner.tsx` | 4 |
| `alerts/ConditionBuilder.tsx` | 4 |
| `alerts/AlertDetailDrawer.tsx` | 3 |
| `alerts/AlertsTabs.tsx` | 3 |
| `alerts/SeveritySelect.tsx` | 3 |
| `alerts/StatusBadge.tsx` | 3 |

### Commit shape

18 granular commits: 1 token addition + 17 per-file migrations. Each commit is independently reviewable.

### AAASM-1407 progress (this PR closes the chain)

* AAASM-1411 (iam/) — merged ✅
* AAASM-1412 (analytics tsx/ts) — merged ✅
* AAASM-1413 (small features) — merged ✅
* AAASM-1414 (pages/) — merged ✅
* **AAASM-1410** (alerts/) — this PR

Once this merges, **AAASM-94 AC #8 finally closes** — all of `dashboard/src/` (excl. `styles.css`) is design-token clean.

## Test plan

* [x] `grep -rE '#[0-9a-fA-F]{3,8}' dashboard/src/features/alerts/` returns zero hits
* [x] `pnpm type-check` clean
* [x] `pnpm lint` clean
* [x] `pnpm test` — 843/843 passing across 97 test files
* [ ] Manual visual smoke — open Alerts page; verify severity badges (critical/high/medium/low), status badges (firing/resolved/suppressed), filter bar toggles, alert detail drawer, destination manager, silence action, rule form all look unchanged
* [ ] Playwright design-fidelity suite (AAASM-1382) still passes against this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)