### PR TITLE
[AAASM-1417] ♻️ (dashboard/test): Extract MockWebSocket helper for reuse across WS hook tests

### DIFF
--- a/dashboard/src/features/alerts/useAlertsStream.test.tsx
+++ b/dashboard/src/features/alerts/useAlertsStream.test.tsx
@@ -1,39 +1,11 @@
 import { renderHook, act, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MockWebSocket, resetMockWebSockets } from '../../test/mockWebSocket'
 import { useAlertsStream } from './useAlertsStream'
 import type { Alert, Silence } from './types'
 
-// ── MockWebSocket ─────────────────────────────────────────────────────────
-
-class MockWebSocket {
-  static OPEN = 1
-  static CLOSED = 3
-  static instances: MockWebSocket[] = []
-  readyState = 0
-  onopen: (() => void) | null = null
-  onclose: (() => void) | null = null
-  onerror: (() => void) | null = null
-  onmessage: ((e: { data: string }) => void) | null = null
-  constructor(public url: string) {
-    MockWebSocket.instances.push(this)
-  }
-  close() {
-    this.readyState = MockWebSocket.CLOSED
-    this.onclose?.()
-  }
-  /** Test-only helper: pretend the upgrade succeeded. */
-  fakeOpen() {
-    this.readyState = MockWebSocket.OPEN
-    this.onopen?.()
-  }
-  /** Test-only helper: deliver a frame. */
-  fakeMessage(payload: unknown) {
-    this.onmessage?.({ data: JSON.stringify(payload) })
-  }
-}
-
 beforeEach(() => {
-  MockWebSocket.instances = []
+  resetMockWebSockets()
   vi.stubGlobal('WebSocket', MockWebSocket)
 })
 
@@ -69,12 +41,12 @@ describe('useAlertsStream', () => {
     expect(result.current).toBe('connecting')
 
     act(() => {
-      MockWebSocket.instances[0].fakeOpen()
+      MockWebSocket.instances[0].open()
     })
     await waitFor(() => expect(result.current).toBe('open'))
 
     act(() => {
-      MockWebSocket.instances[0].fakeMessage({
+      MockWebSocket.instances[0].emit({
         type: 'alert.fire',
         ts: '2026-05-14T09:00:00Z',
         alert: ALERT,
@@ -88,12 +60,12 @@ describe('useAlertsStream', () => {
     const onSilence = vi.fn()
     renderHook(() => useAlertsStream({ onResolve, onSilence }))
     act(() => {
-      MockWebSocket.instances[0].fakeMessage({
+      MockWebSocket.instances[0].emit({
         type: 'alert.resolve',
         ts: '...',
         alert: { ...ALERT, status: 'RESOLVED' },
       })
-      MockWebSocket.instances[0].fakeMessage({
+      MockWebSocket.instances[0].emit({
         type: 'alert.silence',
         ts: '...',
         alert: { ...ALERT, status: 'SUPPRESSED' },
@@ -108,14 +80,14 @@ describe('useAlertsStream', () => {
     const onFire = vi.fn()
     renderHook(() => useAlertsStream({ onFire }))
     act(() => {
-      MockWebSocket.instances[0].fakeMessage({ type: 'heartbeat', ts: '...' })
+      MockWebSocket.instances[0].emit({ type: 'heartbeat', ts: '...' })
     })
     expect(onFire).not.toHaveBeenCalled()
   })
 
   it('reports closed status when the socket drops', async () => {
     const { result } = renderHook(() => useAlertsStream({}))
-    act(() => MockWebSocket.instances[0].fakeOpen())
+    act(() => MockWebSocket.instances[0].open())
     await waitFor(() => expect(result.current).toBe('open'))
     act(() => MockWebSocket.instances[0].close())
     await waitFor(() => expect(result.current).toBe('closed'))

--- a/dashboard/src/features/liveOps/useLiveOpsStream.test.ts
+++ b/dashboard/src/features/liveOps/useLiveOpsStream.test.ts
@@ -1,50 +1,7 @@
 import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MockWebSocket, resetMockWebSockets } from '../../test/mockWebSocket'
 import { useLiveOpsStream } from './useLiveOpsStream'
-
-class MockWebSocket {
-  static instances: MockWebSocket[] = []
-  static OPEN = 1
-  static CLOSED = 3
-
-  static reset() {
-    MockWebSocket.instances = []
-  }
-
-  readyState = 0
-  url: string
-  onopen: ((ev?: Event) => void) | null = null
-  onmessage: ((ev: { data: string }) => void) | null = null
-  onclose: (() => void) | null = null
-  onerror: ((ev?: Event) => void) | null = null
-
-  constructor(url: string) {
-    this.url = url
-    MockWebSocket.instances.push(this)
-  }
-
-  // ── Test helpers ────────────────────────────────────────
-  open() {
-    this.readyState = MockWebSocket.OPEN
-    this.onopen?.()
-  }
-  emit(data: unknown) {
-    this.onmessage?.({ data: JSON.stringify(data) })
-  }
-  serverClose() {
-    if (this.readyState === MockWebSocket.CLOSED) return
-    this.readyState = MockWebSocket.CLOSED
-    this.onclose?.()
-  }
-
-  // ── WebSocket API ──────────────────────────────────────
-  close() {
-    this.serverClose()
-  }
-  send() {
-    /* noop */
-  }
-}
 
 const VIOLATION_EVENT = {
   id: 1,
@@ -74,7 +31,7 @@ const opts = {
 
 describe('useLiveOpsStream', () => {
   beforeEach(() => {
-    MockWebSocket.reset()
+    resetMockWebSockets()
     vi.useFakeTimers()
   })
 

--- a/dashboard/src/test/mockWebSocket.ts
+++ b/dashboard/src/test/mockWebSocket.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared `MockWebSocket` for testing WS-driven hooks.
+ *
+ * Provides a tiny subset of the browser `WebSocket` API plus three
+ * test-only helpers that drive the connection lifecycle from the
+ * test side:
+ *
+ * | helper | effect |
+ * |---|---|
+ * | `open()` | sets `readyState = OPEN` + fires `onopen` |
+ * | `emit(data)` | fires `onmessage` with `JSON.stringify(data)` |
+ * | `serverClose()` | sets `readyState = CLOSED` + fires `onclose` (idempotent) |
+ *
+ * Two ways to inject it into a hook under test:
+ *
+ * ```ts
+ * // 1. ctor-injection (preferred — explicit at the call site):
+ * useLiveOpsStream({ webSocketCtor: MockWebSocket as unknown as typeof WebSocket })
+ *
+ * // 2. global stub (when the hook hard-codes `new WebSocket(...)`):
+ * vi.stubGlobal('WebSocket', MockWebSocket)
+ * ```
+ *
+ * Per-test cleanup: call `resetMockWebSockets()` in `beforeEach` so
+ * the `MockWebSocket.instances` registry doesn't leak across cases.
+ */
+export class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  static OPEN = 1
+  static CLOSED = 3
+
+  readyState = 0
+  url: string
+  onopen: ((ev?: Event) => void) | null = null
+  onmessage: ((ev: { data: string }) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: ((ev?: Event) => void) | null = null
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+
+  // ── Test helpers ────────────────────────────────────────
+
+  /** Pretend the WS upgrade succeeded. */
+  open() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.()
+  }
+
+  /** Deliver a frame from the server side. */
+  emit(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) })
+  }
+
+  /** Pretend the server closed the connection. Idempotent. */
+  serverClose() {
+    if (this.readyState === MockWebSocket.CLOSED) return
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.()
+  }
+
+  // ── WebSocket API ──────────────────────────────────────
+
+  close() {
+    this.serverClose()
+  }
+  send() {
+    /* noop */
+  }
+}
+
+/**
+ * Clear the `MockWebSocket.instances` registry between test cases.
+ * Call this in `beforeEach` to prevent cross-test pollution.
+ */
+export function resetMockWebSockets(): void {
+  MockWebSocket.instances = []
+}


### PR DESCRIPTION
## Summary

Promotes the inline `MockWebSocket` class from `useLiveOpsStream.test.ts` into a shared `dashboard/src/test/mockWebSocket.ts` so future WS-hook tests can reuse it. Two of three WS-touching test files ported; one deferred for harness-shape reasons.

## Files changed (3)

| File | Change |
|---|---|
| `dashboard/src/test/mockWebSocket.ts` | **New.** Canonical `MockWebSocket` class + `resetMockWebSockets()` helper. Test-friendly method names: `open()` / `emit(data)` / `serverClose()`. |
| `dashboard/src/features/liveOps/useLiveOpsStream.test.ts` | Inline class deleted (~50 lines); imports shared mock. 17 cases unchanged. |
| `dashboard/src/features/alerts/useAlertsStream.test.tsx` | Inline class deleted; imports shared mock. 6 call sites renamed (`fakeOpen` → `open`, `fakeMessage` → `emit`). 4 cases unchanged. |

Net diff: **+90 / −81** lines.

## Audit table (DoD bullet 3)

| File | Has WS mock? | Ported? | Why |
|---|---|---|---|
| `dashboard/src/features/liveOps/useLiveOpsStream.test.ts` | ✅ yes | ✅ ported | Canonical shape — became the source of truth |
| `dashboard/src/features/alerts/useAlertsStream.test.tsx` | ✅ yes | ✅ ported | Same shape with cosmetic helper-name differences (`fakeOpen` / `fakeMessage`) — renamed at 6 call sites |
| `dashboard/src/features/approvals/api.test.tsx` | ✅ yes | ❌ **deferred** | Uses `vi.stubGlobal('WebSocket', MockWebSocket)` + auto-open via `setTimeout(..., 0)` — fundamentally different bootstrap model. Porting needs a rebuild of the test's setup pattern; out of scope per ticket's "skip if porting requires non-trivial assertion changes" guidance |

No other WS-using test files exist in `dashboard/src/`.

## Bonus

This is a **tests-only PR** — first real-world test of AAASM-1403's `sonar.coverage.exclusions`. Watching to see if SonarCloud QG stays green.

## Test plan

* [x] `pnpm type-check` clean
* [x] `pnpm lint` clean
* [x] `pnpm test --run` — 843 / 843 across 97 files (no regressions)
* [x] `useLiveOpsStream.test.ts` — 17 cases pass
* [x] `useAlertsStream.test.tsx` — 4 cases pass
* [ ] SonarCloud Code Analysis QG — should pass post-1403 (first observable on this PR)

Closes AAASM-1417.