### PR TITLE
[AAASM-1406] 🔧 (ci/sonarcloud): Cache + retry the SonarCloud scanner step

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -96,7 +96,60 @@ jobs:
           pnpm generate:api
           pnpm test:coverage
 
-      - name: SonarCloud scan
+      # Cache Sonar's analysis-state directory across runs. This is the
+      # cache pattern recommended by SonarCloud's own docs — it stores
+      # per-file analysis state so subsequent runs skip work on unchanged
+      # files. Doesn't address the binary download (the action manages that
+      # internally), but trims ~30s off steady-state runs.
+      - name: Cache SonarCloud analysis state
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar-${{ hashFiles('sonar-project.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-sonar-
+
+      # Three-attempt retry pattern. The scanner CLI is downloaded from
+      # `binaries.sonarsource.com` on every run and has been observed to
+      # 403 transiently (AAASM-1406 root cause on PR #421). Attempts 1
+      # and 2 use `continue-on-error: true` so a failure falls through to
+      # the next attempt; attempt 3 has no escape hatch, so all-three-fail
+      # surfaces as job failure.
+      #
+      # Native GitHub Actions retry (instead of a third-party wrapper like
+      # `Wandalen/wretry.action`) keeps SONAR_TOKEN handling on first-party
+      # actions only — the token never crosses an unaudited action boundary.
+      - name: SonarCloud scan (attempt 1)
+        id: sonar-scan-attempt-1
+        continue-on-error: true
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Wait before retry (attempt 2)
+        if: steps.sonar-scan-attempt-1.outcome == 'failure'
+        run: |
+          echo "::warning::SonarCloud scanner failed on attempt 1 (likely transient CDN flake); waiting 30s before retry."
+          sleep 30
+
+      - name: SonarCloud scan (attempt 2)
+        id: sonar-scan-attempt-2
+        if: steps.sonar-scan-attempt-1.outcome == 'failure'
+        continue-on-error: true
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Wait before retry (attempt 3)
+        if: steps.sonar-scan-attempt-1.outcome == 'failure' && steps.sonar-scan-attempt-2.outcome == 'failure'
+        run: |
+          echo "::warning::SonarCloud scanner failed twice; waiting 30s before final retry."
+          sleep 30
+
+      - name: SonarCloud scan (attempt 3 — final)
+        if: steps.sonar-scan-attempt-1.outcome == 'failure' && steps.sonar-scan-attempt-2.outcome == 'failure'
         uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Two changes to `.github/workflows/sonar.yml`:

1. **Cache `~/.sonar/cache`** via `actions/cache@v4` (Sonar's analysis-state cache; SonarCloud-recommended pattern).
2. **Three-attempt native retry** around the SonarCloud scan step.

## Why retry is the primary fix

The reported failure on PR #421 was an HTTP 403 from `binaries.sonarsource.com` during the scanner CLI download. A manual `gh run rerun ... --failed` immediately succeeded — classic transient flake. The three-attempt pattern with 30s sleeps between retries addresses the failure mode directly.

## Architectural decisions

### Why caching the binary itself isn't done

`SonarSource/sonarqube-scan-action@v8.0.0` manages its scanner CLI download internally with no input for "use pre-existing binary." Caching the zip on disk would require monkey-patching the action — out of scope for a CI hygiene fix. The `~/.sonar/cache` cache is the standard analysis-state cache pattern that ships with SonarCloud's own examples — it speeds steady-state runs but doesn't skip the binary download.

### Why native retry instead of `Wandalen/wretry.action`

Native GitHub Actions retry uses `continue-on-error: true` + step-id chaining. More verbose (3 step-pairs vs 1 wrapped step) but keeps `SONAR_TOKEN` flowing only through first-party actions — no third-party action ever sees the token. For a CI hygiene fix, that trust boundary is worth preserving.

### Cache key strategy

`${{ runner.os }}-sonar-${{ hashFiles('sonar-project.properties') }}` — invalidates whenever Sonar config changes (forces fresh analysis state when the analysis surface changes). Restore-keys fall back to `${{ runner.os }}-sonar-` so partial cache hits still work.

## What this doesn't do

* Doesn't change the scanner CLI version (still `v8.0.1.6346` per the pinned action).
* Doesn't change the QG threshold or any quality criteria.
* Doesn't introduce `continue-on-error: true` on the final attempt — failures still surface, just after 2 retry chances first.

## Test plan

* [x] YAML validates locally (`js-yaml` parse)
* [ ] CI on this PR runs the scan step at least once (the `dashboard/**` + `aa-*/**` path filters don't match `.github/workflows/sonar.yml` self-edit but the workflow's own self-filter does — should fire)
* [ ] First merged-to-master run populates `~/.sonar/cache` (cache miss + save in logs)
* [ ] Second run hits the cache (visible in cache-hit log)
* [ ] Retry path: deferred — fires only when CDN flakes again. Confirms latently.

Closes AAASM-1406.