### PR TITLE
[AAASM-1423] 🐛 (ci): Exclude binary image files from code CI workflow paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,12 @@ on:
       - ".github/workflows/ci.yml"
       - "!**/*.md"
       - "!**/LICENSE"
+      - "!**/*.png"
+      - "!**/*.jpg"
+      - "!**/*.jpeg"
+      - "!**/*.gif"
+      - "!**/*.webp"
+      - "!**/*.ico"
   pull_request:
     branches: [master]
     paths:
@@ -29,6 +35,12 @@ on:
       - ".github/workflows/ci.yml"
       - "!**/*.md"
       - "!**/LICENSE"
+      - "!**/*.png"
+      - "!**/*.jpg"
+      - "!**/*.jpeg"
+      - "!**/*.gif"
+      - "!**/*.webp"
+      - "!**/*.ico"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -9,6 +9,12 @@ on:
       - ".github/workflows/dashboard-ci.yml"
       - "!**/*.md"
       - "!**/LICENSE"
+      - "!**/*.png"
+      - "!**/*.jpg"
+      - "!**/*.jpeg"
+      - "!**/*.gif"
+      - "!**/*.webp"
+      - "!**/*.ico"
   pull_request:
     branches: [master]
     paths:
@@ -17,6 +23,12 @@ on:
       - ".github/workflows/dashboard-ci.yml"
       - "!**/*.md"
       - "!**/LICENSE"
+      - "!**/*.png"
+      - "!**/*.jpg"
+      - "!**/*.jpeg"
+      - "!**/*.gif"
+      - "!**/*.webp"
+      - "!**/*.ico"
 
 jobs:
   typecheck-and-lint:

--- a/.github/workflows/dev-verify.yml
+++ b/.github/workflows/dev-verify.yml
@@ -9,6 +9,12 @@ on:
       - ".github/workflows/dev-verify.yml"
       - "!**/*.md"
       - "!**/LICENSE"
+      - "!**/*.png"
+      - "!**/*.jpg"
+      - "!**/*.jpeg"
+      - "!**/*.gif"
+      - "!**/*.webp"
+      - "!**/*.ico"
   pull_request:
     branches: [master]
     paths:
@@ -17,6 +23,12 @@ on:
       - ".github/workflows/dev-verify.yml"
       - "!**/*.md"
       - "!**/LICENSE"
+      - "!**/*.png"
+      - "!**/*.jpg"
+      - "!**/*.jpeg"
+      - "!**/*.gif"
+      - "!**/*.webp"
+      - "!**/*.ico"
 
 jobs:
   dev-verify:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,12 @@ on:
       - ".github/workflows/docker.yml"
       - "!**/*.md"
       - "!**/LICENSE"
+      - "!**/*.png"
+      - "!**/*.jpg"
+      - "!**/*.jpeg"
+      - "!**/*.gif"
+      - "!**/*.webp"
+      - "!**/*.ico"
   push:
     tags: ["v*"]
 

--- a/.github/workflows/ffi-go-staticlib.yml
+++ b/.github/workflows/ffi-go-staticlib.yml
@@ -8,6 +8,12 @@ on:
       - ".github/workflows/ffi-go-staticlib.yml"
       - "!**/*.md"
       - "!**/LICENSE"
+      - "!**/*.png"
+      - "!**/*.jpg"
+      - "!**/*.jpeg"
+      - "!**/*.gif"
+      - "!**/*.webp"
+      - "!**/*.ico"
   pull_request:
     branches: [master]
     paths:
@@ -15,6 +21,12 @@ on:
       - ".github/workflows/ffi-go-staticlib.yml"
       - "!**/*.md"
       - "!**/LICENSE"
+      - "!**/*.png"
+      - "!**/*.jpg"
+      - "!**/*.jpeg"
+      - "!**/*.gif"
+      - "!**/*.webp"
+      - "!**/*.ico"
 
 jobs:
   build-aa-ffi-go:

--- a/.github/workflows/integration-bypass-permissions.yml
+++ b/.github/workflows/integration-bypass-permissions.yml
@@ -10,6 +10,12 @@ on:
       - ".github/workflows/integration-bypass-permissions.yml"
       - "!**/*.md"
       - "!**/LICENSE"
+      - "!**/*.png"
+      - "!**/*.jpg"
+      - "!**/*.jpeg"
+      - "!**/*.gif"
+      - "!**/*.webp"
+      - "!**/*.ico"
   push:
     branches: [master]
     paths:
@@ -19,6 +25,12 @@ on:
       - ".github/workflows/integration-bypass-permissions.yml"
       - "!**/*.md"
       - "!**/LICENSE"
+      - "!**/*.png"
+      - "!**/*.jpg"
+      - "!**/*.jpeg"
+      - "!**/*.gif"
+      - "!**/*.webp"
+      - "!**/*.ico"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -10,6 +10,12 @@ on:
       - ".github/workflows/sonar.yml"
       - "!**/*.md"
       - "!**/LICENSE"
+      - "!**/*.png"
+      - "!**/*.jpg"
+      - "!**/*.jpeg"
+      - "!**/*.gif"
+      - "!**/*.webp"
+      - "!**/*.ico"
   pull_request:
     branches: [master]
     paths:
@@ -19,6 +25,12 @@ on:
       - ".github/workflows/sonar.yml"
       - "!**/*.md"
       - "!**/LICENSE"
+      - "!**/*.png"
+      - "!**/*.jpg"
+      - "!**/*.jpeg"
+      - "!**/*.gif"
+      - "!**/*.webp"
+      - "!**/*.ico"
 
 jobs:
   sonar:


### PR DESCRIPTION
## Summary

Extension of AAASM-1408. Adds raster image extensions to the path-filter negations in all 7 code-CI workflows so that PNG-only / image-only PRs no longer trigger code CI.

## Why

After AAASM-1408 excluded `.md` and `LICENSE`, PRs that contain *only* binary image files still trigger the full Rust + Dashboard CI suite. The most common case is Playwright visual regression snapshot regeneration — `pnpm playwright test --update-snapshots` produces a diff of only `.png` files under `dashboard/tests/e2e/*-snapshots/`, but there's nothing to build, lint, or test against those images.

## Files changed

Same 7 workflows AAASM-1408 modified — each `paths:` block (both push and pull_request) now appends:

```yaml
- "!**/*.png"
- "!**/*.jpg"
- "!**/*.jpeg"
- "!**/*.gif"
- "!**/*.webp"
- "!**/*.ico"
```

| Workflow | Blocks updated |
|---|---|
| `ci.yml` | push + pull_request |
| `dashboard-ci.yml` | push + pull_request |
| `dev-verify.yml` | push + pull_request |
| `docker.yml` | pull_request only (push is tag-triggered) |
| `ffi-go-staticlib.yml` | push + pull_request |
| `integration-bypass-permissions.yml` | push + pull_request |
| `sonar.yml` | push + pull_request |

## Why `.svg` is NOT in the exclusion list

SVGs in the dashboard are imported as React components or resolved by Vite at build time — they're real source inputs that affect the production bundle. A change to an SVG must still trigger CI. Raster formats (`.png`, `.jpg`, etc.) are pure binary fixtures used only by visual regression tests, so they're safe to exclude.

## Scope: only agent-assembly

node-sdk, go-sdk, python-sdk are pure backend code repos with no front-end and no image fixtures, so they don't need this exclusion.

## Effect after merge

| PR contents | CI runs? |
|---|---|
| Only `.md` files | No (already from AAASM-1408) |
| Only `.png` snapshots | **No (NEW)** |
| `.md` + `.png` mixed | **No (NEW)** |
| `.md` + `.ts` test code (PR #439 pattern) | Yes — `.ts` doesn't match any negation ✅ |
| `.svg` icon update | Yes — SVG is a build input ✅ |
| Code + images mixed | Yes ✅ |

## How to verify

After merge, regenerate a Playwright snapshot (or open a test PR touching only `dashboard/tests/e2e/*-snapshots/*.png`) and confirm none of the 7 code-CI workflows appear in the checks list.

Closes AAASM-1423