### PR TITLE
[AAASM-1424] ⚡ (ci): Improve Docker CI build performance — skip arm64 on PR + cargo-chef + cache mounts

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           context: .
           file: aa-runtime/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
           tags: |
             ghcr.io/ai-agent-assembly/aa-runtime:${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha }}

--- a/aa-runtime/Dockerfile
+++ b/aa-runtime/Dockerfile
@@ -1,16 +1,32 @@
-# Builder stage: compiles aa-runtime for the target musl architecture
-FROM rust:alpine AS builder
+# syntax=docker/dockerfile:1.7
 
-# Install build-time dependencies
+# cargo-chef + BuildKit cache mounts let us reuse the dependency build
+# layer across PRs as long as Cargo.lock is unchanged, and persist the
+# cargo registry / git / target directories across builds.
+
+FROM rust:alpine AS chef
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    cargo install cargo-chef --locked
+WORKDIR /app
+
+# Planner: emit recipe.json describing the dependency graph. This layer's
+# output only changes when Cargo.toml / Cargo.lock change.
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Builder: install system deps, pick the musl target for TARGETARCH,
+# cook (compile) dependencies from recipe.json, then compile app code.
+# The cook step is layer-cached on Cargo.lock; the final cargo build only
+# rebuilds workspace crates.
+FROM chef AS builder
 RUN apk add --no-cache \
     musl-dev \
     protobuf-dev \
     openssl-dev \
     pkgconfig
 
-# Select the correct musl target based on Docker's TARGETARCH build arg,
-# add the target, build the release binary, strip it, and place it at a
-# fixed path so the final stage can copy it regardless of architecture.
 ARG TARGETARCH
 RUN case "$TARGETARCH" in \
       amd64) TARGET=x86_64-unknown-linux-musl ;; \
@@ -20,16 +36,23 @@ RUN case "$TARGETARCH" in \
     rustup target add "$TARGET" && \
     echo "$TARGET" > /tmp/rust_target
 
-WORKDIR /app
+COPY --from=planner /app/recipe.json recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target,id=aa-runtime-target-${TARGETARCH} \
+    TARGET=$(cat /tmp/rust_target) && \
+    cargo chef cook --release --target "$TARGET" --recipe-path recipe.json
 
 COPY . .
-
-RUN TARGET=$(cat /tmp/rust_target) && \
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target,id=aa-runtime-target-${TARGETARCH} \
+    TARGET=$(cat /tmp/rust_target) && \
     cargo build --release --target "$TARGET" -p aa-runtime && \
     strip "target/$TARGET/release/aa-runtime" && \
     cp "target/$TARGET/release/aa-runtime" /app/aa-runtime
 
-# Final stage: minimal distroless image running as non-root
+# Final stage: minimal distroless image running as non-root.
 FROM gcr.io/distroless/static:nonroot AS runtime
 
 COPY --from=builder /app/aa-runtime /aa-runtime

--- a/aa-runtime/Dockerfile
+++ b/aa-runtime/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 # output only changes when Cargo.toml / Cargo.lock change.
 FROM chef AS planner
 COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
+RUN cargo chef prepare --recipe-path recipe.json --bin aa-runtime
 
 # Builder: install system deps, pick the musl target for TARGETARCH,
 # cook (compile) dependencies from recipe.json, then compile app code.
@@ -41,7 +41,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/app/target,id=aa-runtime-target-${TARGETARCH} \
     TARGET=$(cat /tmp/rust_target) && \
-    cargo chef cook --release --target "$TARGET" --recipe-path recipe.json
+    cargo chef cook --release --target "$TARGET" --recipe-path recipe.json --bin aa-runtime
 
 COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \


### PR DESCRIPTION
## Summary

Three layered optimizations to the `Docker` workflow, targeting the 41-minute PR build observed on PR #440.

| # | Change | File | Expected savings |
|---|---|---|---|
| 1 | Skip `linux/arm64` on PR (only on tag push) | `.github/workflows/docker.yml` | ~25-30 min/PR |
| 2 | cargo-chef pattern + BuildKit cache mounts | `aa-runtime/Dockerfile` | ~10-15 min/PR (when `Cargo.lock` unchanged); ongoing savings on tag publish |

## Why

`linux/arm64` via QEMU emulation on x86 runners is 5-10× slower than native for cargo --release. On PR we only need to verify the image compiles, not produce both arches.

The previous Dockerfile's `COPY . .` invalidates the layer cache on any file change, so cargo re-downloaded + recompiled every dependency every PR. The existing `cache-from: type=gha` was mostly inert. cargo-chef splits dependency build into its own layer keyed on `Cargo.lock`; BuildKit cache mounts persist cargo registry/git/target across builds.

## Expected results

| Scenario | Before | After |
|---|---|---|
| PR — `Cargo.lock` unchanged, source edit | ~41 min | **~5-8 min** |
| PR — `Cargo.lock` changed (new dep) | ~41 min | **~15-20 min** |
| Tag push — full multi-arch publish | ~41 min | ~25-30 min |

## Equivalence

- **PR builds**: identical to before for the amd64 image. arm64 is verified on tag push, not PR.
- **Tag push**: produces the same multi-arch manifest list (`linux/amd64` + `linux/arm64`) under the same GHCR tags.
- **Runtime image**: unchanged — same `gcr.io/distroless/static:nonroot` base, same `aa-runtime` binary, same `ENTRYPOINT`.

## How to verify

This PR's own Docker job is the verification — if the amd64 build succeeds with the new Dockerfile, the cargo-chef + cache-mount machinery works. The first run won't show the full cache benefit (cache is cold); the second run on the same branch will.

A tag-push smoke test will need to be performed separately to confirm the multi-arch publish path still functions (suggest cutting a `v0.0.1-rc.X` pre-release after merge to validate).

Closes AAASM-1424