### PR TITLE
[AAASM-1421] 🔌 (proto+aa-api): Add latency_ms schema to FileOp + PolicyViolation

### DIFF
--- a/aa-api/src/ws/handler.rs
+++ b/aa-api/src/ws/handler.rs
@@ -338,8 +338,8 @@ fn decision_label(raw: i32) -> Option<String> {
 ///
 /// `FileOpDetail.latency_ms` and `PolicyViolation.latency_ms` are
 /// read here so the wire path is ready for when measurement
-/// instrumentation lands (AAASM-1424 for eBPF FileOp timing,
-/// AAASM-1425 for gateway-side PolicyViolation timing). Until those
+/// instrumentation lands (AAASM-1425 for eBPF FileOp timing,
+/// AAASM-1426 for gateway-side PolicyViolation timing). Until those
 /// land, both fields default to `0` and we surface them as `None`
 /// so the dashboard keeps its existing placeholder behaviour.
 fn detail_op_fields(

--- a/aa-api/src/ws/handler.rs
+++ b/aa-api/src/ws/handler.rs
@@ -335,21 +335,39 @@ fn decision_label(raw: i32) -> Option<String> {
 /// is the most-identifying string per variant (model / tool name /
 /// path / host / command / blocked action); latency comes from the
 /// variants that carry an end-to-end duration.
+///
+/// `FileOpDetail.latency_ms` and `PolicyViolation.latency_ms` are
+/// read here so the wire path is ready for when measurement
+/// instrumentation lands (AAASM-1424 for eBPF FileOp timing,
+/// AAASM-1425 for gateway-side PolicyViolation timing). Until those
+/// land, both fields default to `0` and we surface them as `None`
+/// so the dashboard keeps its existing placeholder behaviour.
 fn detail_op_fields(
     detail: Option<&aa_proto::assembly::audit::v1::audit_event::Detail>,
 ) -> (Option<String>, Option<u64>) {
     use aa_proto::assembly::audit::v1::audit_event::Detail;
 
+    /// Returns `Some(ms)` when the proto latency field is positive,
+    /// or `None` when zero (default / unmeasured) — keeps the
+    /// dashboard's existing zero-as-placeholder semantics intact.
+    fn nonzero_latency(latency_ms: i64) -> Option<u64> {
+        if latency_ms > 0 {
+            u64::try_from(latency_ms).ok()
+        } else {
+            None
+        }
+    }
+
     let Some(detail) = detail else {
         return (None, None);
     };
     match detail {
-        Detail::LlmCall(d) => (Some(d.model.clone()), u64::try_from(d.latency_ms).ok()),
-        Detail::ToolCall(d) => (Some(d.tool_name.clone()), u64::try_from(d.latency_ms).ok()),
-        Detail::FileOp(d) => (Some(d.path.clone()), None),
-        Detail::Network(d) => (Some(format!("{}:{}", d.host, d.port)), u64::try_from(d.latency_ms).ok()),
-        Detail::Process(d) => (Some(d.command.clone()), u64::try_from(d.duration_ms).ok()),
-        Detail::Violation(d) => (Some(d.blocked_action.clone()), None),
+        Detail::LlmCall(d) => (Some(d.model.clone()), nonzero_latency(d.latency_ms)),
+        Detail::ToolCall(d) => (Some(d.tool_name.clone()), nonzero_latency(d.latency_ms)),
+        Detail::FileOp(d) => (Some(d.path.clone()), nonzero_latency(d.latency_ms)),
+        Detail::Network(d) => (Some(format!("{}:{}", d.host, d.port)), nonzero_latency(d.latency_ms)),
+        Detail::Process(d) => (Some(d.command.clone()), nonzero_latency(d.duration_ms)),
+        Detail::Violation(d) => (Some(d.blocked_action.clone()), nonzero_latency(d.latency_ms)),
         Detail::Approval(_) => (None, None),
     }
 }
@@ -516,6 +534,7 @@ mod tests {
                 path: "/etc/passwd".into(),
                 bytes: 1024,
                 source: "sdk_hook".into(),
+                latency_ms: 0,
             })),
         );
         let fields = unwrap_audit_fields(build_violation_payload(&ev));
@@ -574,11 +593,47 @@ mod tests {
                 policy_rule: "no-secrets".into(),
                 blocked_action: "read /etc/shadow".into(),
                 reason: "policy denied".into(),
+                latency_ms: 0,
             })),
         );
         let fields = unwrap_audit_fields(build_violation_payload(&ev));
         assert_eq!(fields.resource.as_deref(), Some("read /etc/shadow"));
         assert_eq!(fields.status.as_deref(), Some("blocked"));
+    }
+
+    #[test]
+    fn audit_file_op_with_nonzero_latency_maps_through() {
+        let ev = pipeline_audit(
+            ActionType::FileOperation,
+            Decision::Allow,
+            "",
+            Some(Detail::FileOp(FileOpDetail {
+                operation: "read".into(),
+                path: "/etc/passwd".into(),
+                bytes: 1024,
+                source: "ebpf".into(),
+                latency_ms: 42,
+            })),
+        );
+        let fields = unwrap_audit_fields(build_violation_payload(&ev));
+        assert_eq!(fields.latency_ms, Some(42));
+    }
+
+    #[test]
+    fn audit_policy_violation_with_nonzero_latency_maps_through() {
+        let ev = pipeline_audit(
+            ActionType::ToolCall,
+            Decision::Deny,
+            "",
+            Some(Detail::Violation(PolicyViolation {
+                policy_rule: "no-secrets".into(),
+                blocked_action: "read /etc/shadow".into(),
+                reason: "policy denied".into(),
+                latency_ms: 7,
+            })),
+        );
+        let fields = unwrap_audit_fields(build_violation_payload(&ev));
+        assert_eq!(fields.latency_ms, Some(7));
     }
 
     #[test]

--- a/aa-runtime/src/ebpf_bridge.rs
+++ b/aa-runtime/src/ebpf_bridge.rs
@@ -36,6 +36,9 @@ pub fn file_io_to_audit(event: &FileIoEvent) -> AuditEvent {
             path: event.path.clone(),
             bytes: 0,
             source: "ebpf".to_string(),
+            // eBPF events are point-in-time syscall traces, not durations.
+            // Real measurement pending AAASM-1424.
+            latency_ms: 0,
         })),
         ..AuditEvent::default()
     }

--- a/aa-runtime/src/ebpf_bridge.rs
+++ b/aa-runtime/src/ebpf_bridge.rs
@@ -37,7 +37,7 @@ pub fn file_io_to_audit(event: &FileIoEvent) -> AuditEvent {
             bytes: 0,
             source: "ebpf".to_string(),
             // eBPF events are point-in-time syscall traces, not durations.
-            // Real measurement pending AAASM-1424.
+            // Real measurement pending AAASM-1425.
             latency_ms: 0,
         })),
         ..AuditEvent::default()

--- a/aa-runtime/src/ipc/codec.rs
+++ b/aa-runtime/src/ipc/codec.rs
@@ -366,6 +366,7 @@ mod tests {
             policy_rule: "block-files".to_string(),
             blocked_action: "FILE_OPERATION".to_string(),
             reason: "file access not permitted".to_string(),
+            latency_ms: 0,
         };
 
         let bytes = encode_response(IpcResponse::ViolationAlert(violation)).await;

--- a/aa-runtime/src/ipc/server.rs
+++ b/aa-runtime/src/ipc/server.rs
@@ -675,6 +675,7 @@ mod tests {
             policy_rule: "test-rule".to_string(),
             blocked_action: "FILE_OPERATION".to_string(),
             reason: "blocked".to_string(),
+            latency_ms: 0,
         };
         let event = AuditEvent {
             detail: Some(Detail::Violation(violation)),

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -411,6 +411,7 @@ mod tests {
                 policy_rule: "test-rule".to_string(),
                 blocked_action: "test-action".to_string(),
                 reason: "test-reason".to_string(),
+                latency_ms: 0,
             })),
             ..Default::default()
         }
@@ -555,6 +556,7 @@ mod tests {
                 policy_rule: "rule".to_string(),
                 blocked_action: "action".to_string(),
                 reason: "reason".to_string(),
+                latency_ms: 0,
             })),
             ..Default::default()
         }

--- a/proto/audit.proto
+++ b/proto/audit.proto
@@ -111,13 +111,18 @@ message ToolCallDetail {
 // FileOpDetail records the outcome of a filesystem operation.
 message FileOpDetail {
   // Operation type: "read", "write", "delete", or "create".
-  string operation = 1;
+  string operation  = 1;
   // Absolute path of the file that was accessed.
-  string path      = 2;
+  string path       = 2;
   // Number of bytes read or written (0 for delete/create).
-  int64  bytes     = 3;
+  int64  bytes      = 3;
   // Detection source: "sdk_hook" (interceptor) or "ebpf" (kernel-level).
-  string source    = 4;
+  string source     = 4;
+  // End-to-end syscall latency in milliseconds. Currently `0` (default)
+  // until the eBPF probes are extended to record enter/exit timestamps —
+  // tracked under AAASM-1424. Schema lives here so the wire path is
+  // ready when the kernel-side instrumentation lands.
+  int64  latency_ms = 5;
 }
 
 // NetworkCallDetail records the outcome of an outbound network request.
@@ -158,6 +163,13 @@ message PolicyViolation {
   string blocked_action = 2;
   // Human-readable reason for the block (copied from CheckActionResponse).
   string reason         = 3;
+  // Policy-engine evaluation latency in milliseconds. Currently `0`
+  // (default) — no production code in this repo constructs
+  // `Detail::Violation` today; the gateway tracks the verdict as a
+  // string in its audit reader. Schema lives here so when the gateway
+  // is wired to emit structured `PolicyViolation` events with timing
+  // (tracked under AAASM-1425), the wire path is ready.
+  int64  latency_ms     = 4;
 }
 
 // ApprovalEvent records the resolution of a human-in-the-loop approval request.

--- a/proto/audit.proto
+++ b/proto/audit.proto
@@ -120,7 +120,7 @@ message FileOpDetail {
   string source     = 4;
   // End-to-end syscall latency in milliseconds. Currently `0` (default)
   // until the eBPF probes are extended to record enter/exit timestamps —
-  // tracked under AAASM-1424. Schema lives here so the wire path is
+  // tracked under AAASM-1425. Schema lives here so the wire path is
   // ready when the kernel-side instrumentation lands.
   int64  latency_ms = 5;
 }
@@ -168,7 +168,7 @@ message PolicyViolation {
   // `Detail::Violation` today; the gateway tracks the verdict as a
   // string in its audit reader. Schema lives here so when the gateway
   // is wired to emit structured `PolicyViolation` events with timing
-  // (tracked under AAASM-1425), the wire path is ready.
+  // (tracked under AAASM-1426), the wire path is ready.
   int64  latency_ms     = 4;
 }
 


### PR DESCRIPTION
## Summary

Schema-only change. Adds `int64 latency_ms = N;` to two proto messages in `proto/audit.proto`:

| Message | Field | Tracked measurement work |
|---|---|---|
| `FileOpDetail.latency_ms = 5` | End-to-end syscall latency in ms | **AAASM-1425** (eBPF probes) |
| `PolicyViolation.latency_ms = 4` | Policy-engine evaluation latency in ms | **AAASM-1426** (gateway-side) |

## ⚠ Scope-significant honest framing

The ticket assumed aa-runtime had measurable latency data for both variants. **It doesn't:**

* **FileOpDetail** is constructed only by `aa-runtime/src/ebpf_bridge.rs::file_io_to_audit()` — from point-in-time eBPF syscall traces. No duration measurement available kernel-side without new probe instrumentation.
* **PolicyViolation** has **no production constructor in this repo** today. The gateway tracks `AuditEventType::PolicyViolation` as a classification string in its audit reader; the proto message itself is only constructed in test fixtures.

So this PR delivers the **wire path** today; the **measurement instrumentation** is two follow-up Tasks (filed at PR-open time).

## What this PR delivers

1. Proto fields added with explicit doc comments pointing at the measurement follow-ups.
2. `aa-api/src/ws/handler.rs::detail_op_fields()` reads `latency_ms` from both variants (was hard-coded to `None`).
3. New `nonzero_latency()` helper preserves the dashboard's existing zero-as-placeholder semantics — `0` stays as the placeholder, `> 0` flows through to `ViolationPayload::Audit.latency_ms`.
4. Same helper applied uniformly to all 5 latency-carrying detail variants — keeps the logic consistent.
5. Four test-fixture updates in `aa-runtime` (PolicyViolation constructors) + ebpf_bridge production code (FileOpDetail constructor) to include `latency_ms: 0` per the new schema.
6. Two new unit tests in `aa-api/src/ws/handler.rs` asserting non-zero latency flows through correctly for FileOp and PolicyViolation.

## What this PR doesn't deliver

* No new measurement source — the field stays at `0` until AAASM-1425 / AAASM-1426 land.
* No OpenAPI / dashboard schema regen needed — the new proto fields flow through the existing `ViolationPayload::Audit.latency_ms` slot.

## Test plan

* [x] `cargo nextest run -p aa-api` — 256/256 (was 254; +2 new)
* [x] `cargo nextest run -p aa-runtime -p aa-gateway -p aa-proxy` — 1020/1020 (struct-literal updates verified across all test fixtures)
* [x] `cargo clippy --all-targets -- -D warnings` clean
* [x] `cargo fmt --all` clean
* [ ] `buf lint` + `buf breaking` — relying on CI (no local buf install)
* [ ] No dashboard behaviour change — verified by construction (`detail_op_fields()` returns `None` for `latency_ms == 0`)

Closes AAASM-1421.

## Commits (2)

1. `🔌 (proto+aa-api): Add latency_ms schema to FileOp + PolicyViolation`
2. `🚨 (proto+aa-api): Fix follow-up ticket references (1424→1425, 1425→1426)` — fixes off-by-one ticket-number references after a Jira numbering race.