### PR TITLE
[AAASM-1316] 🔧 (dashboard-ci): Add aa-cli-compat job for dashboard embed verification

### DIFF
--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -153,3 +153,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Download dashboard dist artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: dashboard-dist
+          path: dashboard/dist/

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -152,3 +152,4 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -158,3 +158,8 @@ jobs:
         with:
           name: dashboard-dist
           path: dashboard/dist/
+      - name: Cache Cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -163,3 +163,5 @@ jobs:
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
+      - name: Verify aa-cli compiles with embedded assets
+        run: cargo build -p aa-cli

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -145,3 +145,10 @@ jobs:
         run: pnpm generate:api
       - name: Check generated types are up to date
         run: git diff --exit-code src/api/generated/
+
+  aa-cli-compat:
+    name: aa-cli build compat (dashboard embed)
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v6

--- a/.github/workflows/dashboard-ci.yml
+++ b/.github/workflows/dashboard-ci.yml
@@ -152,6 +152,8 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@v6
+      - name: Install protobuf compiler
+        run: sudo apt-get install -y protobuf-compiler
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Download dashboard dist artifact
         uses: actions/download-artifact@v7


### PR DESCRIPTION
## Description

Adds an `aa-cli-compat` job to `.github/workflows/dashboard-ci.yml` that verifies `aa-cli` still compiles with the embedded `dashboard/dist/` assets (via `include_dir!`, AAASM-1292) after any dashboard change. Reuses the `dashboard-dist` artifact produced by the existing `build` job — no redundant `pnpm build`. Compile-only: just `cargo build -p aa-cli` (no clippy / nextest / coverage).

Closes the gap created by PR #325 (AAASM-1293), which removed `dashboard/**` from `ci.yml`'s paths filter so dashboard PRs no longer trigger the full ~20-job Rust suite. That fix was correct, but it also stopped running the narrow `cargo build -p aa-cli` check that catches a dashboard change breaking the `include_dir!` embed. This PR restores exactly that check, scoped to `dashboard-ci.yml`.

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1316 (Story), AAASM-1427 (impl Subtask), AAASM-1428 (verify Subtask)
- Epic: AAASM-11 (Community Dashboard)
- Related GitHub PRs: #325 (removed `dashboard/**` from `ci.yml` paths filter — the fix that created this gap)
- Related Jira tickets: AAASM-1292 (implemented `include_dir!` embedding in aa-cli — Done), AAASM-1293 (created dashboard-ci.yml — Done), AAASM-1300 (release smoke test — deferred follow-up)

## Testing

- [x] No tests required (CI workflow change; the new job itself is the verification mechanism — it will execute on this PR's own CI because `.github/workflows/dashboard-ci.yml` is in the workflow's `paths:` filter)

### Acceptance criteria evidence

Each AC bullet from AAASM-1316:

- [x] `aa-cli-compat` job appears in `dashboard-ci.yml` and runs after the `build` job — see diff
- [x] Job downloads `dashboard-dist` artifact (no redundant `pnpm build`) — see diff
- [x] Job runs only `cargo build -p aa-cli` — not clippy, tests, or coverage — see diff
- [x] A dashboard-only PR shows the `aa-cli-compat` check in its CI list — see this PR's Checks tab once CI completes (this PR modifies `.github/workflows/dashboard-ci.yml`, which is in the workflow's own `paths:` filter)
- [ ] A PR that breaks the aa-cli embed causes `aa-cli-compat` to fail — local deliberate-break smoke test result will be posted as a comment on this PR and on AAASM-1316
- [x] `ci.yml` does NOT have `dashboard/**` in its paths filter — re-verified at HEAD: `ci.yml` lines 6–35 contain `aa-*/**`, `proto/**`, `conformance/**`, `Cargo.toml`, `Cargo.lock`, `deny.toml`, `openapi/v1.yaml`, `.spectral.yaml`, `.github/workflows/ci.yml` — `dashboard/**` absent

## Design notes (deviations from ticket draft)

- **Pinned toolchain SHA** (`dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable`) instead of floating `@stable` — resolves the ticket's "pin the SHA once added" note. Reuses the exact SHA already pinned in `ci.yml` for review consistency.

## Checklist

- [x] Code follows project style guidelines (YAML-only change; `cargo fmt` / `cargo clippy` not applicable to this file)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (no behaviour change — pure CI addition)
- [ ] All CI checks passing (will verify after this PR's CI run completes)
- [x] Commits are small and follow the Gitmoji convention — 5 granular commits, one logical step each:
  1. `🔧 (dashboard-ci): Add aa-cli-compat job skeleton with checkout`
  2. `🔧 (dashboard-ci): Pin dtolnay rust-toolchain step in aa-cli-compat`
  3. `🔧 (dashboard-ci): Download dashboard-dist artifact in aa-cli-compat`
  4. `🔧 (dashboard-ci): Cache Cargo registry in aa-cli-compat by Cargo.lock hash`
  5. `✨ (dashboard-ci): Run cargo build -p aa-cli to verify dashboard embed compat`