### PR TITLE
[AAASM-1429] ✨ (aa-api): Add GET /v1/capability/matrix endpoint

### DIFF
--- a/aa-api/src/models/capability.rs
+++ b/aa-api/src/models/capability.rs
@@ -54,6 +54,19 @@ pub struct Resource {
     pub paths: Vec<String>,
 }
 
+/// One cell in the (agent × resource) matrix: a decision per verb, plus an
+/// optional `flag` marker the UI uses to highlight over-permissioned cells.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct CapCell {
+    pub read: Decision,
+    pub write: Decision,
+    pub delete: Decision,
+    pub exec: Decision,
+    /// Marks this cell for UI attention (e.g. over-permissioned).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub flag: Option<bool>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -101,5 +114,35 @@ mod tests {
         assert_eq!(json["name"], "Postgres");
         assert_eq!(json["group"], "data");
         assert_eq!(json["paths"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn cap_cell_omits_flag_when_none() {
+        let cell = CapCell {
+            read: Decision::Allow,
+            write: Decision::Narrow,
+            delete: Decision::Deny,
+            exec: Decision::Na,
+            flag: None,
+        };
+        let json = serde_json::to_value(&cell).unwrap();
+        assert_eq!(json["read"], "allow");
+        assert_eq!(json["write"], "narrow");
+        assert_eq!(json["delete"], "deny");
+        assert_eq!(json["exec"], "na");
+        assert!(json.get("flag").is_none(), "flag should be omitted when None");
+    }
+
+    #[test]
+    fn cap_cell_includes_flag_when_set() {
+        let cell = CapCell {
+            read: Decision::Allow,
+            write: Decision::Allow,
+            delete: Decision::Allow,
+            exec: Decision::Na,
+            flag: Some(true),
+        };
+        let json = serde_json::to_value(&cell).unwrap();
+        assert_eq!(json["flag"], true);
     }
 }

--- a/aa-api/src/models/capability.rs
+++ b/aa-api/src/models/capability.rs
@@ -120,6 +120,38 @@ pub struct Policy {
     pub rules: Vec<PolicyRule>,
 }
 
+/// Classifier for what a proposed-vs-current decision change represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum ChangeType {
+    NewlyBlocked,
+    Narrowed,
+    Unchanged,
+    Tightened,
+    FalsePositive,
+}
+
+/// A representative call sample shown alongside the matrix to explain the
+/// effect of the current (and any proposed) policy.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SampleCall {
+    pub ts: String,
+    pub agent: String,
+    pub verb: Verb,
+    pub resource: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    pub current_decision: Decision,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub proposed_decision: Option<Decision>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub change_type: Option<ChangeType>,
+    /// Free-form explanation for a `false-positive` change classification.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fp_reason: Option<String>,
+}
+
 /// One agent row in the dashboard Capability Matrix.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -243,6 +275,27 @@ mod tests {
         assert_eq!(json["hits24h"], 1234, "field must be `hits24h`, not `hits_24h`");
         assert!(json.get("hits_24h").is_none());
         assert_eq!(json["rules"][0]["verb"][0], "write");
+    }
+
+    #[test]
+    fn sample_call_serializes_change_type_kebab_case() {
+        let call = SampleCall {
+            ts: "2026-04-23T14:23:01Z".to_string(),
+            agent: "support-triage".to_string(),
+            verb: Verb::Write,
+            resource: "pg".to_string(),
+            detail: Some("UPDATE users SET ...".to_string()),
+            current_decision: Decision::Approval,
+            proposed_decision: Some(Decision::Deny),
+            change_type: Some(ChangeType::NewlyBlocked),
+            fp_reason: None,
+        };
+        let json = serde_json::to_value(&call).unwrap();
+        assert_eq!(json["currentDecision"], "approval");
+        assert_eq!(json["proposedDecision"], "deny");
+        assert_eq!(json["changeType"], "newly-blocked");
+        assert!(json.get("fpReason").is_none());
+        assert!(json.get("change_type").is_none(), "snake_case must not appear");
     }
 
     #[test]

--- a/aa-api/src/models/capability.rs
+++ b/aa-api/src/models/capability.rs
@@ -1,0 +1,58 @@
+//! Capability matrix data model — agent × resource × verb × decision view
+//! consumed by the dashboard Capability Matrix page (AAASM-1280).
+//!
+//! Field names use `serde(rename_all = "camelCase")` on response structs so
+//! the wire shape matches the dashboard's TypeScript types in
+//! `dashboard/src/api/capability.ts`.
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// Verb a capability cell scopes its decision to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum Verb {
+    Read,
+    Write,
+    Delete,
+    Exec,
+}
+
+/// Decision recorded for a single (agent, resource, verb) tuple.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum Decision {
+    Allow,
+    Narrow,
+    Approval,
+    Deny,
+    Na,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn verb_serializes_lowercase() {
+        assert_eq!(serde_json::to_string(&Verb::Read).unwrap(), r#""read""#);
+        assert_eq!(serde_json::to_string(&Verb::Write).unwrap(), r#""write""#);
+        assert_eq!(serde_json::to_string(&Verb::Delete).unwrap(), r#""delete""#);
+        assert_eq!(serde_json::to_string(&Verb::Exec).unwrap(), r#""exec""#);
+    }
+
+    #[test]
+    fn decision_serializes_lowercase_including_na() {
+        assert_eq!(serde_json::to_string(&Decision::Allow).unwrap(), r#""allow""#);
+        assert_eq!(serde_json::to_string(&Decision::Narrow).unwrap(), r#""narrow""#);
+        assert_eq!(serde_json::to_string(&Decision::Approval).unwrap(), r#""approval""#);
+        assert_eq!(serde_json::to_string(&Decision::Deny).unwrap(), r#""deny""#);
+        assert_eq!(serde_json::to_string(&Decision::Na).unwrap(), r#""na""#);
+    }
+
+    #[test]
+    fn verb_deserializes_lowercase() {
+        let v: Verb = serde_json::from_str(r#""exec""#).unwrap();
+        assert_eq!(v, Verb::Exec);
+    }
+}

--- a/aa-api/src/models/capability.rs
+++ b/aa-api/src/models/capability.rs
@@ -152,6 +152,17 @@ pub struct SampleCall {
     pub fp_reason: Option<String>,
 }
 
+/// Top-level response shape for `GET /api/v1/capability/matrix`. Mirrors
+/// the `CapabilityMatrix` interface in `dashboard/src/api/capability.ts`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CapabilityMatrix {
+    pub resources: Vec<Resource>,
+    pub agents: Vec<CapabilityAgent>,
+    pub policies: Vec<Policy>,
+    pub sample_calls: Vec<SampleCall>,
+}
+
 /// One agent row in the dashboard Capability Matrix.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -275,6 +286,22 @@ mod tests {
         assert_eq!(json["hits24h"], 1234, "field must be `hits24h`, not `hits_24h`");
         assert!(json.get("hits_24h").is_none());
         assert_eq!(json["rules"][0]["verb"][0], "write");
+    }
+
+    #[test]
+    fn capability_matrix_serializes_sample_calls_in_camel_case() {
+        let matrix = CapabilityMatrix {
+            resources: vec![],
+            agents: vec![],
+            policies: vec![],
+            sample_calls: vec![],
+        };
+        let json = serde_json::to_value(&matrix).unwrap();
+        assert!(json["resources"].is_array());
+        assert!(json["agents"].is_array());
+        assert!(json["policies"].is_array());
+        assert!(json["sampleCalls"].is_array(), "field must be `sampleCalls`");
+        assert!(json.get("sample_calls").is_none());
     }
 
     #[test]

--- a/aa-api/src/models/capability.rs
+++ b/aa-api/src/models/capability.rs
@@ -86,6 +86,40 @@ pub enum AgentStatus {
     Suspended,
 }
 
+/// Lifecycle status of a policy version in the capability view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum PolicyStatus {
+    Active,
+    Proposed,
+    Archived,
+}
+
+/// A single rule inside a policy — resource, verbs scoped, action, and an
+/// optional condition expression.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct PolicyRule {
+    pub resource: String,
+    pub verb: Vec<Verb>,
+    pub action: String,
+    pub condition: String,
+}
+
+/// A policy version shown in the dashboard Capability Matrix's policies tab.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct Policy {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    pub scope: String,
+    pub status: PolicyStatus,
+    /// Number of times this policy fired in the last 24 hours.
+    #[serde(rename = "hits24h")]
+    pub hits_24h: u64,
+    pub affects: Vec<String>,
+    pub rules: Vec<PolicyRule>,
+}
+
 /// One agent row in the dashboard Capability Matrix.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -185,6 +219,30 @@ mod tests {
         };
         let json = serde_json::to_value(&cell).unwrap();
         assert_eq!(json["flag"], true);
+    }
+
+    #[test]
+    fn policy_serializes_hits_24h_field_name() {
+        let p = Policy {
+            id: "policy-1".to_string(),
+            name: "Default Policy".to_string(),
+            version: "1".to_string(),
+            scope: "global".to_string(),
+            status: PolicyStatus::Active,
+            hits_24h: 1234,
+            affects: vec!["support-triage".to_string()],
+            rules: vec![PolicyRule {
+                resource: "pg".to_string(),
+                verb: vec![Verb::Write, Verb::Delete],
+                action: "approval".to_string(),
+                condition: "amount > 100".to_string(),
+            }],
+        };
+        let json = serde_json::to_value(&p).unwrap();
+        assert_eq!(json["status"], "active");
+        assert_eq!(json["hits24h"], 1234, "field must be `hits24h`, not `hits_24h`");
+        assert!(json.get("hits_24h").is_none());
+        assert_eq!(json["rules"][0]["verb"][0], "write");
     }
 
     #[test]

--- a/aa-api/src/models/capability.rs
+++ b/aa-api/src/models/capability.rs
@@ -29,6 +29,31 @@ pub enum Decision {
     Na,
 }
 
+/// Coarse group a resource belongs to, used for matrix column headings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ResourceGroup {
+    Comm,
+    Files,
+    Data,
+    Infra,
+    Code,
+}
+
+/// A resource that an agent may interact with — one column family in the
+/// dashboard Capability Matrix.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct Resource {
+    /// Stable identifier (e.g. `"gmail"`, `"pg"`, `"shell"`).
+    pub id: String,
+    /// Human-readable display name (e.g. `"Postgres"`).
+    pub name: String,
+    /// Coarse group this resource belongs to.
+    pub group: ResourceGroup,
+    /// Globbed paths covered by this resource (e.g. `["pg.public.*"]`).
+    pub paths: Vec<String>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -54,5 +79,27 @@ mod tests {
     fn verb_deserializes_lowercase() {
         let v: Verb = serde_json::from_str(r#""exec""#).unwrap();
         assert_eq!(v, Verb::Exec);
+    }
+
+    #[test]
+    fn resource_group_serializes_lowercase() {
+        assert_eq!(serde_json::to_string(&ResourceGroup::Comm).unwrap(), r#""comm""#);
+        assert_eq!(serde_json::to_string(&ResourceGroup::Files).unwrap(), r#""files""#);
+        assert_eq!(serde_json::to_string(&ResourceGroup::Infra).unwrap(), r#""infra""#);
+    }
+
+    #[test]
+    fn resource_serializes_fields_in_order() {
+        let r = Resource {
+            id: "pg".to_string(),
+            name: "Postgres".to_string(),
+            group: ResourceGroup::Data,
+            paths: vec!["pg.public.*".to_string(), "pg.public.users".to_string()],
+        };
+        let json = serde_json::to_value(&r).unwrap();
+        assert_eq!(json["id"], "pg");
+        assert_eq!(json["name"], "Postgres");
+        assert_eq!(json["group"], "data");
+        assert_eq!(json["paths"].as_array().unwrap().len(), 2);
     }
 }

--- a/aa-api/src/models/capability.rs
+++ b/aa-api/src/models/capability.rs
@@ -5,6 +5,8 @@
 //! the wire shape matches the dashboard's TypeScript types in
 //! `dashboard/src/api/capability.ts`.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -65,6 +67,45 @@ pub struct CapCell {
     /// Marks this cell for UI attention (e.g. over-permissioned).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub flag: Option<bool>,
+}
+
+/// Enforcement mode for an agent's capability policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentMode {
+    Enforce,
+    Shadow,
+}
+
+/// Liveness status surfaced to the matrix view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentStatus {
+    Active,
+    Idle,
+    Suspended,
+}
+
+/// One agent row in the dashboard Capability Matrix.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CapabilityAgent {
+    pub id: String,
+    pub name: String,
+    pub framework: String,
+    pub owner: String,
+    /// Trust score on a 0–100 scale.
+    pub trust: u8,
+    pub mode: AgentMode,
+    pub status: AgentStatus,
+    /// Human-readable relative-time string (e.g. `"2m ago"`).
+    pub last_seen: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub flagged: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+    /// Resource-id → CapCell mapping for this agent.
+    pub caps: BTreeMap<String, CapCell>,
 }
 
 #[cfg(test)]
@@ -144,5 +185,43 @@ mod tests {
         };
         let json = serde_json::to_value(&cell).unwrap();
         assert_eq!(json["flag"], true);
+    }
+
+    #[test]
+    fn capability_agent_serializes_last_seen_in_camel_case() {
+        let mut caps = BTreeMap::new();
+        caps.insert(
+            "pg".to_string(),
+            CapCell {
+                read: Decision::Allow,
+                write: Decision::Approval,
+                delete: Decision::Deny,
+                exec: Decision::Na,
+                flag: None,
+            },
+        );
+        let agent = CapabilityAgent {
+            id: "support-triage".to_string(),
+            name: "support-triage".to_string(),
+            framework: "CrewAI".to_string(),
+            owner: "cx-tools".to_string(),
+            trust: 78,
+            mode: AgentMode::Enforce,
+            status: AgentStatus::Active,
+            last_seen: "12s ago".to_string(),
+            flagged: None,
+            note: None,
+            caps,
+        };
+        let json = serde_json::to_value(&agent).unwrap();
+        assert_eq!(json["id"], "support-triage");
+        assert_eq!(json["trust"], 78);
+        assert_eq!(json["mode"], "enforce");
+        assert_eq!(json["status"], "active");
+        assert_eq!(json["lastSeen"], "12s ago", "field must be camelCase");
+        assert!(json.get("last_seen").is_none(), "snake_case field must not appear");
+        assert!(json.get("flagged").is_none(), "flagged should be omitted when None");
+        assert!(json.get("note").is_none(), "note should be omitted when None");
+        assert_eq!(json["caps"]["pg"]["write"], "approval");
     }
 }

--- a/aa-api/src/models/mod.rs
+++ b/aa-api/src/models/mod.rs
@@ -1,5 +1,6 @@
 //! Data models for the REST and WebSocket API layer.
 
+pub mod capability;
 pub mod event;
 pub mod event_type;
 pub mod topology;

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -4,11 +4,15 @@ use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
 use utoipa::openapi::ComponentsBuilder;
 use utoipa::{Modify, OpenApi};
 
+use crate::models::capability::{
+    AgentMode, AgentStatus, CapCell, CapabilityAgent, CapabilityMatrix, ChangeType, Decision, Policy, PolicyRule,
+    PolicyStatus, Resource, ResourceGroup, SampleCall, Verb,
+};
 use crate::models::event::GovernanceEvent;
 use crate::models::event_type::EventType;
 use crate::models::trace::{TraceResponse, TraceSpan};
 use crate::models::ws_payloads::{ApprovalPayload, BudgetAlertPayload, EventPayload, ViolationPayload};
-use crate::routes::{agents, alerts, approvals, auth, costs, edges, logs, ops, policies, topology, traces};
+use crate::routes::{agents, alerts, approvals, auth, capability, costs, edges, logs, ops, policies, topology, traces};
 
 /// Root OpenAPI document collecting all annotated paths and schemas.
 #[derive(OpenApi)]
@@ -36,6 +40,7 @@ use crate::routes::{agents, alerts, approvals, auth, costs, edges, logs, ops, po
         (name = "events", description = "Real-time event streaming via WebSocket"),
         (name = "topology", description = "Agent topology — tree, team, lineage, statistics, and mesh edge queries"),
         (name = "ops", description = "Per-operation lifecycle actions (pause / resume / terminate)"),
+        (name = "capability", description = "Dashboard Capability Matrix — agent × resource × verb × decision view"),
     ),
     paths(
         crate::routes::health::health,
@@ -67,6 +72,7 @@ use crate::routes::{agents, alerts, approvals, auth, costs, edges, logs, ops, po
         ops::pause_op,
         ops::resume_op,
         ops::terminate_op,
+        capability::get_matrix,
     ),
     components(schemas(
         crate::routes::health::HealthResponse,
@@ -113,6 +119,20 @@ use crate::routes::{agents, alerts, approvals, auth, costs, edges, logs, ops, po
         ApprovalPayload,
         BudgetAlertPayload,
         EventPayload,
+        Verb,
+        Decision,
+        ResourceGroup,
+        Resource,
+        CapCell,
+        AgentMode,
+        AgentStatus,
+        CapabilityAgent,
+        PolicyStatus,
+        PolicyRule,
+        Policy,
+        ChangeType,
+        SampleCall,
+        CapabilityMatrix,
     )),
     modifiers(&SecurityAddon),
 )]

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -1,0 +1,331 @@
+//! Capability matrix endpoints (AAASM-1366).
+//!
+//! The store holds an in-memory `CapabilityMatrix` seeded to mirror the
+//! dashboard's typed mock client (`dashboard/src/api/capability.ts`). This
+//! lets the dashboard swap the mock for the generated `openapi-fetch`
+//! client without a shape change; a follow-up Story can replace the seed
+//! with a live projection from the policy engine.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use crate::models::capability::{
+    AgentMode, AgentStatus, CapCell, CapabilityAgent, CapabilityMatrix, ChangeType, Decision, Policy, PolicyRule,
+    PolicyStatus, Resource, ResourceGroup, SampleCall, Verb,
+};
+
+/// Thread-safe holder for the dashboard Capability Matrix snapshot.
+#[derive(Debug)]
+pub struct CapabilityStore {
+    inner: RwLock<CapabilityMatrix>,
+}
+
+impl CapabilityStore {
+    /// Build a store seeded with the dashboard fixture data.
+    pub fn new_seeded() -> Arc<Self> {
+        Arc::new(Self {
+            inner: RwLock::new(seeded_matrix()),
+        })
+    }
+
+    /// Return a cloned snapshot of the matrix.
+    pub async fn snapshot(&self) -> CapabilityMatrix {
+        self.inner.read().await.clone()
+    }
+}
+
+// ── Seed data — kept in sync with `dashboard/src/features/capability/fixtures.ts` ──
+
+fn seeded_matrix() -> CapabilityMatrix {
+    CapabilityMatrix {
+        resources: seeded_resources(),
+        agents: seeded_agents(),
+        policies: seeded_policies(),
+        sample_calls: seeded_sample_calls(),
+    }
+}
+
+fn resource(id: &str, name: &str, group: ResourceGroup, paths: &[&str]) -> Resource {
+    Resource {
+        id: id.to_string(),
+        name: name.to_string(),
+        group,
+        paths: paths.iter().map(|p| (*p).to_string()).collect(),
+    }
+}
+
+fn seeded_resources() -> Vec<Resource> {
+    vec![
+        resource(
+            "gmail",
+            "Gmail",
+            ResourceGroup::Comm,
+            &[
+                "gmail/*",
+                "gmail/labels/INBOX/*",
+                "gmail/labels/INBOX/read",
+                "gmail/send",
+            ],
+        ),
+        resource(
+            "gdrive",
+            "Google Drive",
+            ResourceGroup::Files,
+            &["gdrive/*", "gdrive/shared/*", "gdrive/personal/*"],
+        ),
+        resource(
+            "s3",
+            "AWS S3",
+            ResourceGroup::Files,
+            &["s3://*", "s3://reports/*", "s3://customer-pii/*"],
+        ),
+        resource(
+            "pg",
+            "Postgres",
+            ResourceGroup::Data,
+            &[
+                "pg.public.*",
+                "pg.public.users",
+                "pg.public.orders",
+                "pg.public.audit_log",
+            ],
+        ),
+        resource("shell", "Shell exec", ResourceGroup::Infra, &["shell:*"]),
+        resource("http", "HTTP egress", ResourceGroup::Infra, &["http://*", "https://*"]),
+        resource(
+            "github",
+            "GitHub",
+            ResourceGroup::Code,
+            &["github.com/acme/*", "github.com/acme/infra/*"],
+        ),
+        resource(
+            "slack",
+            "Slack",
+            ResourceGroup::Comm,
+            &["slack/channels/*", "slack/dm/*"],
+        ),
+    ]
+}
+
+fn cell(read: Decision, write: Decision, delete: Decision, exec: Decision, flag: bool) -> CapCell {
+    CapCell {
+        read,
+        write,
+        delete,
+        exec,
+        flag: if flag { Some(true) } else { None },
+    }
+}
+
+fn caps_for(entries: &[(&str, CapCell)]) -> BTreeMap<String, CapCell> {
+    entries.iter().map(|(k, v)| ((*k).to_string(), v.clone())).collect()
+}
+
+fn seeded_agents() -> Vec<CapabilityAgent> {
+    use Decision::*;
+    vec![
+        CapabilityAgent {
+            id: "research-bot-04".into(),
+            name: "research-bot-04".into(),
+            framework: "LangChain".into(),
+            owner: "data-platform".into(),
+            trust: 42,
+            mode: AgentMode::Enforce,
+            status: AgentStatus::Active,
+            last_seen: "2m ago".into(),
+            flagged: Some(true),
+            note: Some("over-permissioned · 6 resources still allow, 4 narrowed, 0 deny".into()),
+            caps: caps_for(&[
+                ("gmail", cell(Allow, Allow, Allow, Na, true)),
+                ("gdrive", cell(Allow, Narrow, Allow, Na, true)),
+                ("s3", cell(Allow, Allow, Approval, Na, true)),
+                ("pg", cell(Allow, Approval, Deny, Na, false)),
+                ("shell", cell(Na, Na, Na, Allow, true)),
+                ("http", cell(Allow, Allow, Na, Na, true)),
+                ("github", cell(Allow, Narrow, Deny, Na, false)),
+                ("slack", cell(Allow, Narrow, Na, Na, false)),
+            ]),
+        },
+        CapabilityAgent {
+            id: "support-triage".into(),
+            name: "support-triage".into(),
+            framework: "CrewAI".into(),
+            owner: "cx-tools".into(),
+            trust: 78,
+            mode: AgentMode::Enforce,
+            status: AgentStatus::Active,
+            last_seen: "12s ago".into(),
+            flagged: None,
+            note: None,
+            caps: caps_for(&[
+                ("gmail", cell(Allow, Narrow, Deny, Na, false)),
+                ("gdrive", cell(Narrow, Deny, Deny, Na, false)),
+                ("s3", cell(Narrow, Deny, Deny, Na, false)),
+                ("pg", cell(Narrow, Approval, Deny, Na, false)),
+                ("shell", cell(Na, Na, Na, Deny, false)),
+                ("http", cell(Narrow, Narrow, Na, Na, false)),
+                ("github", cell(Narrow, Deny, Deny, Na, false)),
+                ("slack", cell(Allow, Narrow, Na, Na, false)),
+            ]),
+        },
+        CapabilityAgent {
+            id: "infra-ops-bot".into(),
+            name: "infra-ops-bot".into(),
+            framework: "AutoGen".into(),
+            owner: "platform".into(),
+            trust: 88,
+            mode: AgentMode::Enforce,
+            status: AgentStatus::Active,
+            last_seen: "1m ago".into(),
+            flagged: None,
+            note: None,
+            caps: caps_for(&[
+                ("gmail", cell(Deny, Deny, Deny, Na, false)),
+                ("gdrive", cell(Deny, Deny, Deny, Na, false)),
+                ("s3", cell(Narrow, Narrow, Approval, Na, false)),
+                ("pg", cell(Narrow, Narrow, Approval, Na, false)),
+                ("shell", cell(Na, Na, Na, Narrow, false)),
+                ("http", cell(Allow, Narrow, Na, Na, false)),
+                ("github", cell(Allow, Narrow, Approval, Na, false)),
+                ("slack", cell(Narrow, Approval, Na, Na, false)),
+            ]),
+        },
+        CapabilityAgent {
+            id: "analytics-runner".into(),
+            name: "analytics-runner".into(),
+            framework: "LangChain".into(),
+            owner: "analytics".into(),
+            trust: 71,
+            mode: AgentMode::Enforce,
+            status: AgentStatus::Active,
+            last_seen: "4s ago".into(),
+            flagged: None,
+            note: None,
+            caps: caps_for(&[
+                ("gmail", cell(Deny, Deny, Deny, Na, false)),
+                ("gdrive", cell(Narrow, Deny, Deny, Na, false)),
+                ("s3", cell(Allow, Narrow, Deny, Na, false)),
+                ("pg", cell(Allow, Narrow, Deny, Na, false)),
+                ("shell", cell(Na, Na, Na, Deny, false)),
+                ("http", cell(Narrow, Deny, Na, Na, false)),
+                ("github", cell(Narrow, Deny, Deny, Na, false)),
+                ("slack", cell(Narrow, Deny, Na, Na, false)),
+            ]),
+        },
+    ]
+}
+
+fn seeded_policies() -> Vec<Policy> {
+    vec![
+        Policy {
+            id: "platform-baseline".into(),
+            name: "Platform baseline".into(),
+            version: "v3".into(),
+            scope: "global".into(),
+            status: PolicyStatus::Active,
+            hits_24h: 1284,
+            affects: vec!["research-bot-04".into(), "support-triage".into()],
+            rules: vec![
+                PolicyRule {
+                    resource: "shell".into(),
+                    verb: vec![Verb::Exec],
+                    action: "deny".into(),
+                    condition: "trust < 60".into(),
+                },
+                PolicyRule {
+                    resource: "pg".into(),
+                    verb: vec![Verb::Write, Verb::Delete],
+                    action: "approval".into(),
+                    condition: "table in (public.users, public.orders)".into(),
+                },
+            ],
+        },
+        Policy {
+            id: "pii-guardrail".into(),
+            name: "PII guardrail".into(),
+            version: "v1".into(),
+            scope: "team:cx-tools".into(),
+            status: PolicyStatus::Proposed,
+            hits_24h: 0,
+            affects: vec!["support-triage".into()],
+            rules: vec![PolicyRule {
+                resource: "s3".into(),
+                verb: vec![Verb::Read],
+                action: "narrow".into(),
+                condition: "prefix = customer-pii/".into(),
+            }],
+        },
+    ]
+}
+
+fn seeded_sample_calls() -> Vec<SampleCall> {
+    vec![
+        SampleCall {
+            ts: "2026-04-23T14:23:01Z".into(),
+            agent: "support-triage".into(),
+            verb: Verb::Read,
+            resource: "pg".into(),
+            detail: Some("SELECT * FROM public.users WHERE id = 4521".into()),
+            current_decision: Decision::Allow,
+            proposed_decision: None,
+            change_type: Some(ChangeType::Unchanged),
+            fp_reason: None,
+        },
+        SampleCall {
+            ts: "2026-04-23T14:24:00Z".into(),
+            agent: "support-triage".into(),
+            verb: Verb::Write,
+            resource: "pg".into(),
+            detail: Some("UPDATE public.orders SET refund = 250 WHERE id = 99".into()),
+            current_decision: Decision::Approval,
+            proposed_decision: Some(Decision::Deny),
+            change_type: Some(ChangeType::NewlyBlocked),
+            fp_reason: None,
+        },
+        SampleCall {
+            ts: "2026-04-23T15:01:00Z".into(),
+            agent: "research-bot-04".into(),
+            verb: Verb::Exec,
+            resource: "shell".into(),
+            detail: Some("bash -c 'curl http://unauthorized'".into()),
+            current_decision: Decision::Allow,
+            proposed_decision: Some(Decision::Deny),
+            change_type: Some(ChangeType::NewlyBlocked),
+            fp_reason: None,
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn seeded_store_contains_eight_resources() {
+        let store = CapabilityStore::new_seeded();
+        let m = store.snapshot().await;
+        assert_eq!(m.resources.len(), 8);
+        let ids: Vec<&str> = m.resources.iter().map(|r| r.id.as_str()).collect();
+        assert!(ids.contains(&"pg"));
+        assert!(ids.contains(&"shell"));
+    }
+
+    #[tokio::test]
+    async fn every_agent_has_a_cell_for_every_resource() {
+        let store = CapabilityStore::new_seeded();
+        let m = store.snapshot().await;
+        let resource_ids: Vec<&str> = m.resources.iter().map(|r| r.id.as_str()).collect();
+        assert!(!m.agents.is_empty());
+        for agent in &m.agents {
+            for rid in &resource_ids {
+                assert!(
+                    agent.caps.contains_key(*rid),
+                    "agent {} missing cell for resource {rid}",
+                    agent.id
+                );
+            }
+        }
+    }
+}

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -9,12 +9,15 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use axum::http::StatusCode;
+use axum::{Extension, Json};
 use tokio::sync::RwLock;
 
 use crate::models::capability::{
     AgentMode, AgentStatus, CapCell, CapabilityAgent, CapabilityMatrix, ChangeType, Decision, Policy, PolicyRule,
     PolicyStatus, Resource, ResourceGroup, SampleCall, Verb,
 };
+use crate::state::AppState;
 
 /// Thread-safe holder for the dashboard Capability Matrix snapshot.
 #[derive(Debug)]
@@ -34,6 +37,21 @@ impl CapabilityStore {
     pub async fn snapshot(&self) -> CapabilityMatrix {
         self.inner.read().await.clone()
     }
+}
+
+/// `GET /api/v1/capability/matrix` — return the full agent × resource ×
+/// verb × decision matrix that backs the dashboard Capability Matrix page.
+#[utoipa::path(
+    get,
+    path = "/api/v1/capability/matrix",
+    responses(
+        (status = 200, description = "Full capability matrix snapshot", body = CapabilityMatrix)
+    ),
+    tag = "capability"
+)]
+pub async fn get_matrix(Extension(state): Extension<AppState>) -> (StatusCode, Json<CapabilityMatrix>) {
+    let matrix = state.capability_store.snapshot().await;
+    (StatusCode::OK, Json(matrix))
 }
 
 // ── Seed data — kept in sync with `dashboard/src/features/capability/fixtures.ts` ──

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -41,6 +41,10 @@ impl CapabilityStore {
 
 /// `GET /api/v1/capability/matrix` — return the full agent × resource ×
 /// verb × decision matrix that backs the dashboard Capability Matrix page.
+///
+/// Returns the full snapshot — resources, agents (each with a `caps` map),
+/// policies, and sample calls — in the exact shape the dashboard's
+/// `CapabilityClient.getMatrix()` consumes.
 #[utoipa::path(
     get,
     path = "/api/v1/capability/matrix",

--- a/aa-api/src/routes/mod.rs
+++ b/aa-api/src/routes/mod.rs
@@ -50,6 +50,8 @@ pub fn v1_router() -> Router {
         .route("/approvals/{id}/reject", post(approvals::reject_action))
         // Costs
         .route("/costs", get(costs::get_cost_summary))
+        // Capability matrix (dashboard) — AAASM-1366
+        .route("/capability/matrix", get(capability::get_matrix))
         // Alerts
         .route("/alerts", get(alerts::list_alerts))
         // Dev tool webhooks

--- a/aa-api/src/routes/mod.rs
+++ b/aa-api/src/routes/mod.rs
@@ -6,6 +6,7 @@ pub mod agents;
 pub mod alerts;
 pub mod approvals;
 pub mod auth;
+pub mod capability;
 pub mod costs;
 pub mod devtools;
 pub mod edges;

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -22,6 +22,7 @@ use crate::auth::rate_limit::RateLimiter;
 use crate::events::EventBroadcast;
 use crate::models::topology::{AgentLineage, AgentTree, TeamTopology, TopologyOverview, TopologyStats};
 use crate::replay::ReplayBuffer;
+use crate::routes::capability::CapabilityStore;
 use crate::trace_store::TraceStore;
 
 /// Shared state available to all Axum handlers via `Extension<AppState>`.
@@ -77,4 +78,6 @@ pub struct AppState {
     pub topology_lineage_cache: moka::future::Cache<String, Arc<AgentLineage>>,
     /// Short-lived cache for GET /topology/stats responses (10 s TTL).
     pub topology_stats_cache: moka::future::Cache<&'static str, Arc<TopologyStats>>,
+    /// Dashboard Capability Matrix store (AAASM-1366).
+    pub capability_store: Arc<CapabilityStore>,
 }

--- a/aa-api/tests/capability.rs
+++ b/aa-api/tests/capability.rs
@@ -1,0 +1,75 @@
+//! Integration tests for the dashboard Capability Matrix endpoint (AAASM-1366).
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn get_matrix_returns_200_with_dashboard_shape() {
+    let app = common::test_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/capability/matrix")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    // Top-level shape mirrors dashboard's `CapabilityMatrix` interface.
+    assert!(json["resources"].is_array(), "resources must be an array");
+    assert!(json["agents"].is_array(), "agents must be an array");
+    assert!(json["policies"].is_array(), "policies must be an array");
+    assert!(
+        json["sampleCalls"].is_array(),
+        "sampleCalls must be camelCase, not sample_calls"
+    );
+    assert!(
+        json.get("sample_calls").is_none(),
+        "snake_case sample_calls must not appear"
+    );
+
+    // Seed contract: 8 resources covering every group.
+    assert_eq!(json["resources"].as_array().unwrap().len(), 8);
+
+    // Seed contract: every agent has a cell for every resource, and the
+    // cell carries decisions for all four verbs.
+    let resource_ids: Vec<&str> = json["resources"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r["id"].as_str().unwrap())
+        .collect();
+    assert!(!resource_ids.is_empty());
+
+    let agents = json["agents"].as_array().unwrap();
+    assert!(!agents.is_empty(), "seed must include at least one agent");
+    for agent in agents {
+        // CapabilityAgent uses camelCase `lastSeen`.
+        assert!(agent["lastSeen"].is_string(), "agent {} missing lastSeen", agent["id"]);
+        for rid in &resource_ids {
+            let cell = &agent["caps"][rid];
+            assert!(
+                cell.is_object(),
+                "agent {} missing cell for resource {rid}",
+                agent["id"]
+            );
+            for verb in ["read", "write", "delete", "exec"] {
+                assert!(
+                    cell[verb].is_string(),
+                    "agent {} resource {rid} missing decision for {verb}",
+                    agent["id"]
+                );
+            }
+        }
+    }
+}

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -157,6 +157,7 @@ spec:
         topology_stats_cache: moka::future::Cache::builder()
             .time_to_live(std::time::Duration::from_secs(10))
             .build(),
+        capability_store: aa_api::routes::capability::CapabilityStore::new_seeded(),
     }
 }
 

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -234,6 +234,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/capability/matrix": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * `GET /api/v1/capability/matrix` — return the full agent × resource ×
+         *     verb × decision matrix that backs the dashboard Capability Matrix page.
+         * @description Returns the full snapshot — resources, agents (each with a `caps` map),
+         *     policies, and sample calls — in the exact shape the dashboard's
+         *     `CapabilityClient.getMatrix()` consumes.
+         */
+        get: operations["get_matrix"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/costs": {
         parameters: {
             query?: never;
@@ -674,6 +697,11 @@ export interface components {
             ancestors: components["schemas"]["LineageStep"][];
         };
         /**
+         * @description Enforcement mode for an agent's capability policy.
+         * @enum {string}
+         */
+        AgentMode: "enforce" | "shadow";
+        /**
          * @description Minimal agent representation used in list and tree responses.
          *
          *     # Example JSON
@@ -755,6 +783,11 @@ export interface components {
             /** @description Semver version string. */
             version: string;
         };
+        /**
+         * @description Liveness status surfaced to the matrix view.
+         * @enum {string}
+         */
+        AgentStatus: "active" | "idle" | "suspended";
         /**
          * @description Recursive tree node representing an agent and all its descendants.
          *
@@ -884,6 +917,55 @@ export interface components {
              */
             threshold_pct: number;
         };
+        /**
+         * @description One cell in the (agent × resource) matrix: a decision per verb, plus an
+         *     optional `flag` marker the UI uses to highlight over-permissioned cells.
+         */
+        CapCell: {
+            delete: components["schemas"]["Decision"];
+            exec: components["schemas"]["Decision"];
+            /** @description Marks this cell for UI attention (e.g. over-permissioned). */
+            flag?: boolean | null;
+            read: components["schemas"]["Decision"];
+            write: components["schemas"]["Decision"];
+        };
+        /** @description One agent row in the dashboard Capability Matrix. */
+        CapabilityAgent: {
+            /** @description Resource-id → CapCell mapping for this agent. */
+            caps: {
+                [key: string]: components["schemas"]["CapCell"];
+            };
+            flagged?: boolean | null;
+            framework: string;
+            id: string;
+            /** @description Human-readable relative-time string (e.g. `"2m ago"`). */
+            lastSeen: string;
+            mode: components["schemas"]["AgentMode"];
+            name: string;
+            note?: string | null;
+            owner: string;
+            status: components["schemas"]["AgentStatus"];
+            /**
+             * Format: int32
+             * @description Trust score on a 0–100 scale.
+             */
+            trust: number;
+        };
+        /**
+         * @description Top-level response shape for `GET /api/v1/capability/matrix`. Mirrors
+         *     the `CapabilityMatrix` interface in `dashboard/src/api/capability.ts`.
+         */
+        CapabilityMatrix: {
+            agents: components["schemas"]["CapabilityAgent"][];
+            policies: components["schemas"]["Policy"][];
+            resources: components["schemas"]["Resource"][];
+            sampleCalls: components["schemas"]["SampleCall"][];
+        };
+        /**
+         * @description Classifier for what a proposed-vs-current decision change represents.
+         * @enum {string}
+         */
+        ChangeType: "newly-blocked" | "narrowed" | "unchanged" | "tightened" | "false-positive";
         /** @description JSON representation of the cost/budget summary. */
         CostSummary: {
             /** @description Configured daily budget limit in USD, if set. */
@@ -920,6 +1002,11 @@ export interface components {
             /** @description Optional reason for the decision. */
             reason?: string | null;
         };
+        /**
+         * @description Decision recorded for a single (agent, resource, verb) tuple.
+         * @enum {string}
+         */
+        Decision: "allow" | "narrow" | "approval" | "deny" | "na";
         /** @description Paginated list of directed edges for an agent. */
         EdgeListResponse: {
             /** @description The queried agent ID. */
@@ -1093,6 +1180,21 @@ export interface components {
             /** @description Operation id from the URL path. */
             op_id: string;
         };
+        /** @description A policy version shown in the dashboard Capability Matrix's policies tab. */
+        Policy: {
+            affects: string[];
+            /**
+             * Format: int64
+             * @description Number of times this policy fired in the last 24 hours.
+             */
+            hits24h: number;
+            id: string;
+            name: string;
+            rules: components["schemas"]["PolicyRule"][];
+            scope: string;
+            status: components["schemas"]["PolicyStatus"];
+            version: string;
+        };
         /** @description JSON representation of a governance policy version. */
         PolicyResponse: {
             /** @description Whether this is the currently active policy. */
@@ -1110,6 +1212,21 @@ export interface components {
             /** @description Policy version string. */
             version: string;
         };
+        /**
+         * @description A single rule inside a policy — resource, verbs scoped, action, and an
+         *     optional condition expression.
+         */
+        PolicyRule: {
+            action: string;
+            condition: string;
+            resource: string;
+            verb: components["schemas"]["Verb"][];
+        };
+        /**
+         * @description Lifecycle status of a policy version in the capability view.
+         * @enum {string}
+         */
+        PolicyStatus: "active" | "proposed" | "archived";
         /**
          * @description RFC 7807 Problem Details JSON body.
          * @example {
@@ -1170,6 +1287,25 @@ export interface components {
              */
             id: number;
         };
+        /**
+         * @description A resource that an agent may interact with — one column family in the
+         *     dashboard Capability Matrix.
+         */
+        Resource: {
+            /** @description Coarse group this resource belongs to. */
+            group: components["schemas"]["ResourceGroup"];
+            /** @description Stable identifier (e.g. `"gmail"`, `"pg"`, `"shell"`). */
+            id: string;
+            /** @description Human-readable display name (e.g. `"Postgres"`). */
+            name: string;
+            /** @description Globbed paths covered by this resource (e.g. `["pg.public.*"]`). */
+            paths: string[];
+        };
+        /**
+         * @description Coarse group a resource belongs to, used for matrix column headings.
+         * @enum {string}
+         */
+        ResourceGroup: "comm" | "files" | "data" | "infra" | "code";
         /** @description Response from `POST /api/v1/agents/:id/resume`. */
         ResumeResponse: {
             /** @description Hex-encoded agent UUID. */
@@ -1213,6 +1349,22 @@ export interface components {
             target_role?: string | null;
             /** @description Team the request was routed to, if known. */
             target_team_id?: string | null;
+        };
+        /**
+         * @description A representative call sample shown alongside the matrix to explain the
+         *     effect of the current (and any proposed) policy.
+         */
+        SampleCall: {
+            agent: string;
+            changeType?: null | components["schemas"]["ChangeType"];
+            currentDecision: components["schemas"]["Decision"];
+            detail?: string | null;
+            /** @description Free-form explanation for a `false-positive` change classification. */
+            fpReason?: string | null;
+            proposedDecision?: null | components["schemas"]["Decision"];
+            resource: string;
+            ts: string;
+            verb: components["schemas"]["Verb"];
         };
         /**
          * @description Authorization scope level for API operations.
@@ -1465,6 +1617,11 @@ export interface components {
             /** @description Start time of the span (ISO 8601). */
             start_time: string;
         };
+        /**
+         * @description Verb a capability cell scopes its decision to.
+         * @enum {string}
+         */
+        Verb: "read" | "write" | "delete" | "exec";
         /**
          * @description Payload for `event_type: "violation"` events.
          *
@@ -1975,6 +2132,26 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+        };
+    };
+    get_matrix: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Full capability matrix snapshot */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CapabilityMatrix"];
                 };
             };
         };

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -447,6 +447,21 @@ paths:
                 $ref: '#/components/schemas/ProblemDetail'
       security:
       - bearer_auth: []
+  /api/v1/capability/matrix:
+    get:
+      tags:
+      - capability
+      summary: |-
+        `GET /api/v1/capability/matrix` — return the full agent × resource ×
+        verb × decision matrix that backs the dashboard Capability Matrix page.
+      operationId: get_matrix
+      responses:
+        '200':
+          description: Full capability matrix snapshot
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CapabilityMatrix'
   /api/v1/costs:
     get:
       tags:
@@ -1129,6 +1144,12 @@ components:
           id: aabbccdd00112233aabbccdd00112233
           name: child
           team_id: team-alpha
+    AgentMode:
+      type: string
+      description: Enforcement mode for an agent's capability policy.
+      enum:
+      - enforce
+      - shadow
     AgentNode:
       type: object
       description: |-
@@ -1266,6 +1287,13 @@ components:
         version:
           type: string
           description: Semver version string.
+    AgentStatus:
+      type: string
+      description: Liveness status surfaced to the matrix view.
+      enum:
+      - active
+      - idle
+      - suspended
     AgentTree:
       type: object
       description: |-
@@ -1465,6 +1493,115 @@ components:
           format: int32
           description: Threshold percentage that was crossed (e.g. `80` or `95`).
           minimum: 0
+    CapCell:
+      type: object
+      description: |-
+        One cell in the (agent × resource) matrix: a decision per verb, plus an
+        optional `flag` marker the UI uses to highlight over-permissioned cells.
+      required:
+      - read
+      - write
+      - delete
+      - exec
+      properties:
+        delete:
+          $ref: '#/components/schemas/Decision'
+        exec:
+          $ref: '#/components/schemas/Decision'
+        flag:
+          type:
+          - boolean
+          - 'null'
+          description: Marks this cell for UI attention (e.g. over-permissioned).
+        read:
+          $ref: '#/components/schemas/Decision'
+        write:
+          $ref: '#/components/schemas/Decision'
+    CapabilityAgent:
+      type: object
+      description: One agent row in the dashboard Capability Matrix.
+      required:
+      - id
+      - name
+      - framework
+      - owner
+      - trust
+      - mode
+      - status
+      - lastSeen
+      - caps
+      properties:
+        caps:
+          type: object
+          description: Resource-id → CapCell mapping for this agent.
+          additionalProperties:
+            $ref: '#/components/schemas/CapCell'
+          propertyNames:
+            type: string
+        flagged:
+          type:
+          - boolean
+          - 'null'
+        framework:
+          type: string
+        id:
+          type: string
+        lastSeen:
+          type: string
+          description: Human-readable relative-time string (e.g. `"2m ago"`).
+        mode:
+          $ref: '#/components/schemas/AgentMode'
+        name:
+          type: string
+        note:
+          type:
+          - string
+          - 'null'
+        owner:
+          type: string
+        status:
+          $ref: '#/components/schemas/AgentStatus'
+        trust:
+          type: integer
+          format: int32
+          description: Trust score on a 0–100 scale.
+          minimum: 0
+    CapabilityMatrix:
+      type: object
+      description: |-
+        Top-level response shape for `GET /api/v1/capability/matrix`. Mirrors
+        the `CapabilityMatrix` interface in `dashboard/src/api/capability.ts`.
+      required:
+      - resources
+      - agents
+      - policies
+      - sampleCalls
+      properties:
+        agents:
+          type: array
+          items:
+            $ref: '#/components/schemas/CapabilityAgent'
+        policies:
+          type: array
+          items:
+            $ref: '#/components/schemas/Policy'
+        resources:
+          type: array
+          items:
+            $ref: '#/components/schemas/Resource'
+        sampleCalls:
+          type: array
+          items:
+            $ref: '#/components/schemas/SampleCall'
+    ChangeType:
+      type: string
+      description: Classifier for what a proposed-vs-current decision change represents.
+      enum:
+      - newly-blocked
+      - narrowed
+      - unchanged
+      - tightened
+      - false-positive
     CostSummary:
       type: object
       description: JSON representation of the cost/budget summary.
@@ -1535,6 +1672,15 @@ components:
           - string
           - 'null'
           description: Optional reason for the decision.
+    Decision:
+      type: string
+      description: Decision recorded for a single (agent, resource, verb) tuple.
+      enum:
+      - allow
+      - narrow
+      - approval
+      - deny
+      - na
     EdgeListResponse:
       type: object
       description: Paginated list of directed edges for an agent.
@@ -1806,6 +1952,42 @@ components:
         op_id:
           type: string
           description: Operation id from the URL path.
+    Policy:
+      type: object
+      description: A policy version shown in the dashboard Capability Matrix's policies tab.
+      required:
+      - id
+      - name
+      - version
+      - scope
+      - status
+      - hits24h
+      - affects
+      - rules
+      properties:
+        affects:
+          type: array
+          items:
+            type: string
+        hits24h:
+          type: integer
+          format: int64
+          description: Number of times this policy fired in the last 24 hours.
+          minimum: 0
+        id:
+          type: string
+        name:
+          type: string
+        rules:
+          type: array
+          items:
+            $ref: '#/components/schemas/PolicyRule'
+        scope:
+          type: string
+        status:
+          $ref: '#/components/schemas/PolicyStatus'
+        version:
+          type: string
     PolicyResponse:
       type: object
       description: JSON representation of a governance policy version.
@@ -1835,6 +2017,34 @@ components:
         version:
           type: string
           description: Policy version string.
+    PolicyRule:
+      type: object
+      description: |-
+        A single rule inside a policy — resource, verbs scoped, action, and an
+        optional condition expression.
+      required:
+      - resource
+      - verb
+      - action
+      - condition
+      properties:
+        action:
+          type: string
+        condition:
+          type: string
+        resource:
+          type: string
+        verb:
+          type: array
+          items:
+            $ref: '#/components/schemas/Verb'
+    PolicyStatus:
+      type: string
+      description: Lifecycle status of a policy version in the capability view.
+      enum:
+      - active
+      - proposed
+      - archived
     ProblemDetail:
       type: object
       description: RFC 7807 Problem Details JSON body.
@@ -1932,6 +2142,40 @@ components:
           type: integer
           format: int64
           description: Auto-assigned edge identifier.
+    Resource:
+      type: object
+      description: |-
+        A resource that an agent may interact with — one column family in the
+        dashboard Capability Matrix.
+      required:
+      - id
+      - name
+      - group
+      - paths
+      properties:
+        group:
+          $ref: '#/components/schemas/ResourceGroup'
+          description: Coarse group this resource belongs to.
+        id:
+          type: string
+          description: Stable identifier (e.g. `"gmail"`, `"pg"`, `"shell"`).
+        name:
+          type: string
+          description: Human-readable display name (e.g. `"Postgres"`).
+        paths:
+          type: array
+          items:
+            type: string
+          description: Globbed paths covered by this resource (e.g. `["pg.public.*"]`).
+    ResourceGroup:
+      type: string
+      description: Coarse group a resource belongs to, used for matrix column headings.
+      enum:
+      - comm
+      - files
+      - data
+      - infra
+      - code
     ResumeResponse:
       type: object
       description: Response from `POST /api/v1/agents/:id/resume`.
@@ -2012,6 +2256,45 @@ components:
           - string
           - 'null'
           description: Team the request was routed to, if known.
+    SampleCall:
+      type: object
+      description: |-
+        A representative call sample shown alongside the matrix to explain the
+        effect of the current (and any proposed) policy.
+      required:
+      - ts
+      - agent
+      - verb
+      - resource
+      - currentDecision
+      properties:
+        agent:
+          type: string
+        changeType:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/ChangeType'
+        currentDecision:
+          $ref: '#/components/schemas/Decision'
+        detail:
+          type:
+          - string
+          - 'null'
+        fpReason:
+          type:
+          - string
+          - 'null'
+          description: Free-form explanation for a `false-positive` change classification.
+        proposedDecision:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/Decision'
+        resource:
+          type: string
+        ts:
+          type: string
+        verb:
+          $ref: '#/components/schemas/Verb'
     Scope:
       type: string
       description: |-
@@ -2402,6 +2685,14 @@ components:
         start_time:
           type: string
           description: Start time of the span (ISO 8601).
+    Verb:
+      type: string
+      description: Verb a capability cell scopes its decision to.
+      enum:
+      - read
+      - write
+      - delete
+      - exec
     ViolationPayload:
       oneOf:
       - type: object
@@ -2528,3 +2819,5 @@ tags:
   description: Agent topology — tree, team, lineage, statistics, and mesh edge queries
 - name: ops
   description: Per-operation lifecycle actions (pause / resume / terminate)
+- name: capability
+  description: Dashboard Capability Matrix — agent × resource × verb × decision view

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -454,6 +454,10 @@ paths:
       summary: |-
         `GET /api/v1/capability/matrix` — return the full agent × resource ×
         verb × decision matrix that backs the dashboard Capability Matrix page.
+      description: |-
+        Returns the full snapshot — resources, agents (each with a `caps` map),
+        policies, and sample calls — in the exact shape the dashboard's
+        `CapabilityClient.getMatrix()` consumes.
       operationId: get_matrix
       responses:
         '200':


### PR DESCRIPTION
## Description

Adds the read endpoint backing the dashboard Capability Matrix page (AAASM-1280). Returns the full agent × resource × verb × decision matrix in the exact shape consumed by `dashboard/src/api/capability.ts`'s typed mock client — `CapabilityMatrix { resources, agents, policies, sampleCalls }` — so the next dashboard PR can swap the mock for the generated `openapi-fetch` client with zero shape divergence.

The handler reads from a new in-memory `CapabilityStore` seeded with fixture data that mirrors `dashboard/src/features/capability/fixtures.ts`. The Story (AAASM-1366) doesn't specify whether the matrix should be **computed live from the policy engine** or **stored as a denormalized cache** — going with **stored** here keeps the scope tight; a future Story can swap the seed for a live policy-engine projection without changing the public API contract.

Two-tier coverage:
- `aa-api/src/models/capability.rs::tests` pins per-field serde shape (camelCase `lastSeen`, kebab-case `newly-blocked`, special-cased `hits24h`, omitted-when-None optionals).
- `aa-api/tests/capability.rs` hits the live endpoint and asserts the dashboard-side invariants (8 resources, every agent has a decision per (resource, verb), `sampleCalls` camelCase).

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

This adds a brand-new path (`/api/v1/capability/matrix`) and a new schema set. No existing schema or path is modified.

## Related Issues

- Related Jira ticket: **AAASM-1429** (Sub-task of Story **AAASM-1366** under Epic **AAASM-11** — Community Dashboard)
- Dashboard consumer it enables: AAASM-1280 (Capability Matrix page) — its typed mock client can now be swapped for the generated `openapi-fetch` client in a follow-up dashboard PR
- Follow-up in the same Story: AAASM-1430 (POST /capability/override + RBAC), AAASM-1431 (Story-level acceptance verify)

## Testing

- [x] Unit tests added / updated (11 in `aa-api/src/models/capability.rs::tests` + 2 in `aa-api/src/routes/capability.rs::tests`)
- [x] Integration tests added / updated (1 in `aa-api/tests/capability.rs::get_matrix_returns_200_with_dashboard_shape`)
- [x] Manual testing performed (`cargo nextest run -p aa-api` — 270 tests pass)
- [ ] No tests required (explain why)

Validation run against this branch:

\`\`\`
cargo nextest run -p aa-api                            # 270 passed
cargo fmt --all -- --check                             # clean
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo deny check                                       # clean
cargo doc --workspace --no-deps                        # clean (8 warnings, all pre-existing)
cargo run -p aa-api --bin generate_openapi             # produces the committed openapi/v1.yaml byte-for-byte
\`\`\`

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (`openapi/v1.yaml` regenerated and committed)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Commit list

12 granular GitEmoji commits, one logical unit each, repository in a working state after every commit:

\`\`\`
✨ (aa-api/models): Add Verb and Decision enums for capability matrix
✨ (aa-api/models): Add Resource and ResourceGroup model types
✨ (aa-api/models): Add CapCell record mapping verbs to decisions
✨ (aa-api/models): Add CapabilityAgent model with caps map
✨ (aa-api/models): Add Policy supporting types for capability matrix
✨ (aa-api/models): Add SampleCall and ChangeType for capability matrix
✨ (aa-api/models): Add CapabilityMatrix response envelope
✨ (aa-api/state): Add CapabilityStore seeded with fixture data
✨ (aa-api/state): Wire CapabilityStore into AppState
✨ (aa-api/routes): Add GET /capability/matrix handler
✨ (aa-api/routes): Wire capability route into v1_router
✨ (aa-api/openapi): Register capability matrix path and schemas
✅ (aa-api/routes): Add capability matrix happy-path test
📝 (openapi): Regenerate openapi/v1.yaml with capability matrix
\`\`\`