### PR TITLE
[AAASM-1430] ✨ (aa-api): Add POST /v1/capability/override endpoint with RBAC

### DIFF
--- a/aa-api/src/models/capability.rs
+++ b/aa-api/src/models/capability.rs
@@ -200,6 +200,14 @@ pub struct CapabilityOverrideRequest {
     pub decision: Decision,
 }
 
+/// Response envelope for `POST /api/v1/capability/override`: the subset of
+/// agent rows that actually changed (matches `OverrideResponse` in the
+/// dashboard's TypeScript mock).
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct CapabilityOverrideResponse {
+    pub updated: Vec<CapabilityAgent>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -376,6 +384,14 @@ mod tests {
         assert!(json.get("flagged").is_none(), "flagged should be omitted when None");
         assert!(json.get("note").is_none(), "note should be omitted when None");
         assert_eq!(json["caps"]["pg"]["write"], "approval");
+    }
+
+    #[test]
+    fn override_response_serializes_updated_array() {
+        let resp = CapabilityOverrideResponse { updated: vec![] };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert!(json["updated"].is_array());
+        assert_eq!(json["updated"].as_array().unwrap().len(), 0);
     }
 
     #[test]

--- a/aa-api/src/models/capability.rs
+++ b/aa-api/src/models/capability.rs
@@ -185,6 +185,21 @@ pub struct CapabilityAgent {
     pub caps: BTreeMap<String, CapCell>,
 }
 
+/// Request payload for `POST /api/v1/capability/override` — apply a single
+/// (resource, verb, decision) override across one or more agents.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CapabilityOverrideRequest {
+    /// Agents to apply the override to.
+    pub agent_ids: Vec<String>,
+    /// Identifier of the resource whose cell is being overridden.
+    pub resource_id: String,
+    /// Verb (read / write / delete / exec) within the cell.
+    pub verb: Verb,
+    /// New decision to record for that (resource, verb) pair.
+    pub decision: Decision,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -361,5 +376,20 @@ mod tests {
         assert!(json.get("flagged").is_none(), "flagged should be omitted when None");
         assert!(json.get("note").is_none(), "note should be omitted when None");
         assert_eq!(json["caps"]["pg"]["write"], "approval");
+    }
+
+    #[test]
+    fn override_request_deserializes_camel_case() {
+        let raw = r#"{
+            "agentIds": ["support-triage", "research-bot-04"],
+            "resourceId": "pg",
+            "verb": "write",
+            "decision": "deny"
+        }"#;
+        let req: CapabilityOverrideRequest = serde_json::from_str(raw).unwrap();
+        assert_eq!(req.agent_ids, vec!["support-triage", "research-bot-04"]);
+        assert_eq!(req.resource_id, "pg");
+        assert_eq!(req.verb, Verb::Write);
+        assert_eq!(req.decision, Decision::Deny);
     }
 }

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -5,8 +5,9 @@ use utoipa::openapi::ComponentsBuilder;
 use utoipa::{Modify, OpenApi};
 
 use crate::models::capability::{
-    AgentMode, AgentStatus, CapCell, CapabilityAgent, CapabilityMatrix, ChangeType, Decision, Policy, PolicyRule,
-    PolicyStatus, Resource, ResourceGroup, SampleCall, Verb,
+    AgentMode, AgentStatus, CapCell, CapabilityAgent, CapabilityMatrix, CapabilityOverrideRequest,
+    CapabilityOverrideResponse, ChangeType, Decision, Policy, PolicyRule, PolicyStatus, Resource, ResourceGroup,
+    SampleCall, Verb,
 };
 use crate::models::event::GovernanceEvent;
 use crate::models::event_type::EventType;
@@ -73,6 +74,7 @@ use crate::routes::{agents, alerts, approvals, auth, capability, costs, edges, l
         ops::resume_op,
         ops::terminate_op,
         capability::get_matrix,
+        capability::apply_override,
     ),
     components(schemas(
         crate::routes::health::HealthResponse,
@@ -133,6 +135,8 @@ use crate::routes::{agents, alerts, approvals, auth, capability, costs, edges, l
         ChangeType,
         SampleCall,
         CapabilityMatrix,
+        CapabilityOverrideRequest,
+        CapabilityOverrideResponse,
     )),
     modifiers(&SecurityAddon),
 )]

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -110,6 +110,11 @@ pub async fn get_matrix(Extension(state): Extension<AppState>) -> (StatusCode, J
 /// one or more agents. Mutating capability state is treated as a
 /// `Global`-scope policy update, so the caller must hold the `OrgAdmin`
 /// role (Admin API scope).
+///
+/// Returns the subset of agent rows that actually changed — the dashboard
+/// uses this to drive an optimistic-UI rollback when an override fails.
+/// An unknown `agentId` rejects the request with 400 and leaves the store
+/// untouched; an unknown `resourceId` on an agent is silently skipped.
 #[utoipa::path(
     post,
     path = "/api/v1/capability/override",

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -10,12 +10,19 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use axum::http::StatusCode;
+use axum::response::IntoResponse;
 use axum::{Extension, Json};
 use tokio::sync::RwLock;
 
+use aa_gateway::policy::rbac::MutationKind;
+use aa_gateway::policy::scope::PolicyScope;
+
+use crate::auth::policy_auth::{PolicyAuthorizationDenied, PolicyWriteAuth};
+use crate::error::ProblemDetail;
 use crate::models::capability::{
-    AgentMode, AgentStatus, CapCell, CapabilityAgent, CapabilityMatrix, CapabilityOverrideRequest, ChangeType,
-    Decision, Policy, PolicyRule, PolicyStatus, Resource, ResourceGroup, SampleCall, Verb,
+    AgentMode, AgentStatus, CapCell, CapabilityAgent, CapabilityMatrix, CapabilityOverrideRequest,
+    CapabilityOverrideResponse, ChangeType, Decision, Policy, PolicyRule, PolicyStatus, Resource, ResourceGroup,
+    SampleCall, Verb,
 };
 use crate::state::AppState;
 
@@ -97,6 +104,61 @@ impl CapabilityStore {
 pub async fn get_matrix(Extension(state): Extension<AppState>) -> (StatusCode, Json<CapabilityMatrix>) {
     let matrix = state.capability_store.snapshot().await;
     (StatusCode::OK, Json(matrix))
+}
+
+/// `POST /api/v1/capability/override` — apply a capability override across
+/// one or more agents. Mutating capability state is treated as a
+/// `Global`-scope policy update, so the caller must hold the `OrgAdmin`
+/// role (Admin API scope).
+#[utoipa::path(
+    post,
+    path = "/api/v1/capability/override",
+    request_body = CapabilityOverrideRequest,
+    responses(
+        (status = 200, description = "Updated agent rows", body = CapabilityOverrideResponse),
+        (status = 400, description = "Unknown agent id"),
+        (status = 403, description = "Caller lacks the role required to mutate capability state")
+    ),
+    tag = "capability"
+)]
+pub async fn apply_override(
+    policy_auth: PolicyWriteAuth,
+    Extension(state): Extension<AppState>,
+    Json(body): Json<CapabilityOverrideRequest>,
+) -> Result<(StatusCode, Json<CapabilityOverrideResponse>), OverrideHandlerError> {
+    policy_auth
+        .check_mutation(&PolicyScope::Global, MutationKind::Update)
+        .map_err(OverrideHandlerError::Forbidden)?;
+
+    let updated = state
+        .capability_store
+        .apply_override(&body)
+        .await
+        .map_err(|e| match e {
+            OverrideError::UnknownAgent(id) => OverrideHandlerError::BadRequest(
+                ProblemDetail::from_status(StatusCode::BAD_REQUEST).with_detail(format!("Unknown agent id: {id}")),
+            ),
+        })?;
+
+    Ok((StatusCode::OK, Json(CapabilityOverrideResponse { updated })))
+}
+
+/// Unified error type for the override handler so 400 and 403 paths render
+/// through their respective ProblemDetail / PolicyAuthorizationDenied
+/// `IntoResponse` impls.
+#[derive(Debug)]
+pub enum OverrideHandlerError {
+    BadRequest(ProblemDetail),
+    Forbidden(PolicyAuthorizationDenied),
+}
+
+impl IntoResponse for OverrideHandlerError {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+            Self::BadRequest(p) => p.into_response(),
+            Self::Forbidden(d) => d.into_response(),
+        }
+    }
 }
 
 // ── Seed data — kept in sync with `dashboard/src/features/capability/fixtures.ts` ──

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -14,10 +14,18 @@ use axum::{Extension, Json};
 use tokio::sync::RwLock;
 
 use crate::models::capability::{
-    AgentMode, AgentStatus, CapCell, CapabilityAgent, CapabilityMatrix, ChangeType, Decision, Policy, PolicyRule,
-    PolicyStatus, Resource, ResourceGroup, SampleCall, Verb,
+    AgentMode, AgentStatus, CapCell, CapabilityAgent, CapabilityMatrix, CapabilityOverrideRequest, ChangeType,
+    Decision, Policy, PolicyRule, PolicyStatus, Resource, ResourceGroup, SampleCall, Verb,
 };
 use crate::state::AppState;
+
+/// Reasons an override request can fail before reaching the handler's
+/// response path. Mapped to ProblemDetail by the handler.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OverrideError {
+    /// The request named an agent id that the store does not know about.
+    UnknownAgent(String),
+}
 
 /// Thread-safe holder for the dashboard Capability Matrix snapshot.
 #[derive(Debug)]
@@ -36,6 +44,39 @@ impl CapabilityStore {
     /// Return a cloned snapshot of the matrix.
     pub async fn snapshot(&self) -> CapabilityMatrix {
         self.inner.read().await.clone()
+    }
+
+    /// Apply a single `(resource_id, verb, decision)` override across the
+    /// requested agents and return the rows that changed.
+    ///
+    /// Rejects unknown `agent_id` values with `OverrideError::UnknownAgent`.
+    /// An unknown `resource_id` is silently ignored for that agent (matches
+    /// the dashboard mock at `capability.ts::applyOverrideToAgents`).
+    pub async fn apply_override(&self, req: &CapabilityOverrideRequest) -> Result<Vec<CapabilityAgent>, OverrideError> {
+        let mut matrix = self.inner.write().await;
+        // Validate every requested agent_id up front so a single unknown id
+        // rejects the whole request without partial mutation.
+        for id in &req.agent_ids {
+            if !matrix.agents.iter().any(|a| &a.id == id) {
+                return Err(OverrideError::UnknownAgent(id.clone()));
+            }
+        }
+        let mut updated = Vec::with_capacity(req.agent_ids.len());
+        for agent in matrix.agents.iter_mut() {
+            if !req.agent_ids.contains(&agent.id) {
+                continue;
+            }
+            if let Some(cell) = agent.caps.get_mut(&req.resource_id) {
+                match req.verb {
+                    Verb::Read => cell.read = req.decision,
+                    Verb::Write => cell.write = req.decision,
+                    Verb::Delete => cell.delete = req.decision,
+                    Verb::Exec => cell.exec = req.decision,
+                }
+                updated.push(agent.clone());
+            }
+        }
+        Ok(updated)
     }
 }
 
@@ -332,6 +373,65 @@ mod tests {
         let ids: Vec<&str> = m.resources.iter().map(|r| r.id.as_str()).collect();
         assert!(ids.contains(&"pg"));
         assert!(ids.contains(&"shell"));
+    }
+
+    #[tokio::test]
+    async fn apply_override_mutates_targeted_cells_only() {
+        let store = CapabilityStore::new_seeded();
+        let before = store.snapshot().await;
+        let target_agent = before.agents[0].id.clone();
+        let untouched_agent = before.agents[1].id.clone();
+
+        let req = CapabilityOverrideRequest {
+            agent_ids: vec![target_agent.clone()],
+            resource_id: "pg".into(),
+            verb: Verb::Write,
+            decision: Decision::Deny,
+        };
+        let updated = store.apply_override(&req).await.unwrap();
+        assert_eq!(updated.len(), 1);
+        assert_eq!(updated[0].id, target_agent);
+        assert_eq!(updated[0].caps.get("pg").unwrap().write, Decision::Deny);
+
+        let after = store.snapshot().await;
+        let other_after = after.agents.iter().find(|a| a.id == untouched_agent).unwrap();
+        let other_before = before.agents.iter().find(|a| a.id == untouched_agent).unwrap();
+        assert_eq!(
+            other_after.caps.get("pg").unwrap().write,
+            other_before.caps.get("pg").unwrap().write,
+            "untouched agent's `pg.write` must be unchanged"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_override_rejects_unknown_agent() {
+        let store = CapabilityStore::new_seeded();
+        let err = store
+            .apply_override(&CapabilityOverrideRequest {
+                agent_ids: vec!["does-not-exist".into()],
+                resource_id: "pg".into(),
+                verb: Verb::Read,
+                decision: Decision::Allow,
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(err, OverrideError::UnknownAgent("does-not-exist".into()));
+    }
+
+    #[tokio::test]
+    async fn apply_override_skips_unknown_resource_silently() {
+        let store = CapabilityStore::new_seeded();
+        let target = store.snapshot().await.agents[0].id.clone();
+        let updated = store
+            .apply_override(&CapabilityOverrideRequest {
+                agent_ids: vec![target],
+                resource_id: "nonexistent-resource".into(),
+                verb: Verb::Read,
+                decision: Decision::Deny,
+            })
+            .await
+            .unwrap();
+        assert!(updated.is_empty(), "agent without that resource cell yields no row");
     }
 
     #[tokio::test]

--- a/aa-api/src/routes/mod.rs
+++ b/aa-api/src/routes/mod.rs
@@ -52,6 +52,7 @@ pub fn v1_router() -> Router {
         .route("/costs", get(costs::get_cost_summary))
         // Capability matrix (dashboard) — AAASM-1366
         .route("/capability/matrix", get(capability::get_matrix))
+        .route("/capability/override", post(capability::apply_override))
         // Alerts
         .route("/alerts", get(alerts::list_alerts))
         // Dev tool webhooks

--- a/aa-api/tests/capability.rs
+++ b/aa-api/tests/capability.rs
@@ -7,6 +7,8 @@ use axum::http::{Request, StatusCode};
 use serde_json::json;
 use tower::ServiceExt;
 
+use aa_api::auth::scope::Scope;
+
 /// Build a POST /capability/override request with the given body and an
 /// optional Bearer token.
 fn post_override_request(body: serde_json::Value, token: Option<&str>) -> Request<Body> {
@@ -115,5 +117,38 @@ async fn apply_override_returns_only_updated_rows() {
     assert_eq!(
         updated[0]["caps"]["pg"]["write"], "deny",
         "the targeted cell must reflect the new decision"
+    );
+}
+
+#[tokio::test]
+async fn apply_override_rejects_viewer_scope_with_403() {
+    let (token, entry) = common::generate_test_api_key("viewer-key", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(post_override_request(
+            json!({
+                "agentIds": ["support-triage"],
+                "resourceId": "pg",
+                "verb": "write",
+                "decision": "deny"
+            }),
+            Some(&token),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "Viewer (Read-only scope) must be denied"
+    );
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let detail = json["detail"].as_str().unwrap_or("");
+    assert!(
+        detail.contains("policy mutation denied"),
+        "ProblemDetail body should describe the deny; got: {detail}"
     );
 }

--- a/aa-api/tests/capability.rs
+++ b/aa-api/tests/capability.rs
@@ -152,3 +152,31 @@ async fn apply_override_rejects_viewer_scope_with_403() {
         "ProblemDetail body should describe the deny; got: {detail}"
     );
 }
+
+#[tokio::test]
+async fn apply_override_rejects_unknown_agent_with_400() {
+    let app = common::test_app(); // auth off → RBAC pass; failure must be from validation
+
+    let response = app
+        .oneshot(post_override_request(
+            json!({
+                "agentIds": ["does-not-exist"],
+                "resourceId": "pg",
+                "verb": "write",
+                "decision": "deny"
+            }),
+            None,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let detail = json["detail"].as_str().unwrap_or("");
+    assert!(
+        detail.contains("does-not-exist"),
+        "ProblemDetail should name the offending agent id; got: {detail}"
+    );
+}

--- a/aa-api/tests/capability.rs
+++ b/aa-api/tests/capability.rs
@@ -4,7 +4,21 @@ mod common;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
+use serde_json::json;
 use tower::ServiceExt;
+
+/// Build a POST /capability/override request with the given body and an
+/// optional Bearer token.
+fn post_override_request(body: serde_json::Value, token: Option<&str>) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri("/api/v1/capability/override")
+        .header("content-type", "application/json");
+    if let Some(t) = token {
+        builder = builder.header("authorization", format!("Bearer {t}"));
+    }
+    builder.body(Body::from(serde_json::to_vec(&body).unwrap())).unwrap()
+}
 
 #[tokio::test]
 async fn get_matrix_returns_200_with_dashboard_shape() {
@@ -72,4 +86,34 @@ async fn get_matrix_returns_200_with_dashboard_shape() {
             }
         }
     }
+}
+
+#[tokio::test]
+async fn apply_override_returns_only_updated_rows() {
+    let app = common::test_app(); // auth off → caller is OrgAdmin, RBAC pass
+
+    let response = app
+        .oneshot(post_override_request(
+            json!({
+                "agentIds": ["support-triage"],
+                "resourceId": "pg",
+                "verb": "write",
+                "decision": "deny"
+            }),
+            None,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let updated = json["updated"].as_array().unwrap();
+    assert_eq!(updated.len(), 1, "only one row should change");
+    assert_eq!(updated[0]["id"], "support-triage");
+    assert_eq!(
+        updated[0]["caps"]["pg"]["write"], "deny",
+        "the targeted cell must reflect the new decision"
+    );
 }

--- a/aa-topology-integration-tests/tests/common/mod.rs
+++ b/aa-topology-integration-tests/tests/common/mod.rs
@@ -225,5 +225,6 @@ spec:
         topology_stats_cache: moka::future::Cache::builder()
             .time_to_live(Duration::from_secs(10))
             .build(),
+        capability_store: aa_api::routes::capability::CapabilityStore::new_seeded(),
     })
 }

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -257,6 +257,32 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/capability/override": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * `POST /api/v1/capability/override` — apply a capability override across
+         *     one or more agents. Mutating capability state is treated as a
+         *     `Global`-scope policy update, so the caller must hold the `OrgAdmin`
+         *     role (Admin API scope).
+         * @description Returns the subset of agent rows that actually changed — the dashboard
+         *     uses this to drive an optimistic-UI rollback when an override fails.
+         *     An unknown `agentId` rejects the request with 400 and leaves the store
+         *     untouched; an unknown `resourceId` on an agent is silently skipped.
+         */
+        post: operations["apply_override"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/costs": {
         parameters: {
             query?: never;
@@ -960,6 +986,28 @@ export interface components {
             policies: components["schemas"]["Policy"][];
             resources: components["schemas"]["Resource"][];
             sampleCalls: components["schemas"]["SampleCall"][];
+        };
+        /**
+         * @description Request payload for `POST /api/v1/capability/override` — apply a single
+         *     (resource, verb, decision) override across one or more agents.
+         */
+        CapabilityOverrideRequest: {
+            /** @description Agents to apply the override to. */
+            agentIds: string[];
+            /** @description New decision to record for that (resource, verb) pair. */
+            decision: components["schemas"]["Decision"];
+            /** @description Identifier of the resource whose cell is being overridden. */
+            resourceId: string;
+            /** @description Verb (read / write / delete / exec) within the cell. */
+            verb: components["schemas"]["Verb"];
+        };
+        /**
+         * @description Response envelope for `POST /api/v1/capability/override`: the subset of
+         *     agent rows that actually changed (matches `OverrideResponse` in the
+         *     dashboard's TypeScript mock).
+         */
+        CapabilityOverrideResponse: {
+            updated: components["schemas"]["CapabilityAgent"][];
         };
         /**
          * @description Classifier for what a proposed-vs-current decision change represents.
@@ -2153,6 +2201,44 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["CapabilityMatrix"];
                 };
+            };
+        };
+    };
+    apply_override: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CapabilityOverrideRequest"];
+            };
+        };
+        responses: {
+            /** @description Updated agent rows */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CapabilityOverrideResponse"];
+                };
+            };
+            /** @description Unknown agent id */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Caller lacks the role required to mutate capability state */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -466,6 +466,33 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CapabilityMatrix'
+  /api/v1/capability/override:
+    post:
+      tags:
+      - capability
+      summary: |-
+        `POST /api/v1/capability/override` — apply a capability override across
+        one or more agents. Mutating capability state is treated as a
+        `Global`-scope policy update, so the caller must hold the `OrgAdmin`
+        role (Admin API scope).
+      operationId: apply_override
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CapabilityOverrideRequest'
+        required: true
+      responses:
+        '200':
+          description: Updated agent rows
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CapabilityOverrideResponse'
+        '400':
+          description: Unknown agent id
+        '403':
+          description: Caller lacks the role required to mutate capability state
   /api/v1/costs:
     get:
       tags:
@@ -1597,6 +1624,44 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SampleCall'
+    CapabilityOverrideRequest:
+      type: object
+      description: |-
+        Request payload for `POST /api/v1/capability/override` — apply a single
+        (resource, verb, decision) override across one or more agents.
+      required:
+      - agentIds
+      - resourceId
+      - verb
+      - decision
+      properties:
+        agentIds:
+          type: array
+          items:
+            type: string
+          description: Agents to apply the override to.
+        decision:
+          $ref: '#/components/schemas/Decision'
+          description: New decision to record for that (resource, verb) pair.
+        resourceId:
+          type: string
+          description: Identifier of the resource whose cell is being overridden.
+        verb:
+          $ref: '#/components/schemas/Verb'
+          description: Verb (read / write / delete / exec) within the cell.
+    CapabilityOverrideResponse:
+      type: object
+      description: |-
+        Response envelope for `POST /api/v1/capability/override`: the subset of
+        agent rows that actually changed (matches `OverrideResponse` in the
+        dashboard's TypeScript mock).
+      required:
+      - updated
+      properties:
+        updated:
+          type: array
+          items:
+            $ref: '#/components/schemas/CapabilityAgent'
     ChangeType:
       type: string
       description: Classifier for what a proposed-vs-current decision change represents.

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -475,6 +475,11 @@ paths:
         one or more agents. Mutating capability state is treated as a
         `Global`-scope policy update, so the caller must hold the `OrgAdmin`
         role (Admin API scope).
+      description: |-
+        Returns the subset of agent rows that actually changed — the dashboard
+        uses this to drive an optimistic-UI rollback when an override fails.
+        An unknown `agentId` rejects the request with 400 and leaves the store
+        untouched; an unknown `resourceId` on an agent is silently skipped.
       operationId: apply_override
       requestBody:
         content:


### PR DESCRIPTION
## Description

Adds the write endpoint completing Story **AAASM-1366** (the read endpoint shipped in #446 / AAASM-1429). The handler accepts the dashboard's `OverrideRequest` shape verbatim (`{ agentIds, resourceId, verb, decision }`), mutates the in-memory `CapabilityStore` under its write lock, and returns only the agent rows that actually changed in `{ updated: CapabilityAgent[] }`.

RBAC reuses the existing `PolicyWriteAuth` extractor at `PolicyScope::Global` / `MutationKind::Update`, mirroring `POST /api/v1/policies`. Practical effect under the current scope→role mapping:

| API Scope | Mapped role | Outcome |
|---|---|---|
| Admin | OrgAdmin | 200 |
| Write | Developer | 403 (no Update at Global scope) |
| Read | Viewer | 403 |
| (auth off) | OrgAdmin (bypass) | 200 |

Failure surface:
- Unknown `agent_id` → 400 with an RFC-7807 `ProblemDetail` that names the offending id, no partial mutation.
- Unknown `resource_id` for an agent → that agent silently skipped (matches the dashboard mock's `applyOverrideToAgents` behavior at `capability.ts:30`).

## ⚠️ Stacked PR

This branch is stacked on **#446 (AAASM-1429)** — the diff includes those 14 commits until #446 merges. After #446 lands on master, GitHub will narrow this PR's diff to the 10 commits below automatically. Please review/merge in order: #446 → this.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

Adds a new path (`/api/v1/capability/override`) and two new schemas. No existing path or schema is modified.

## Related Issues

- Related Jira ticket: **AAASM-1430** (Sub-task of Story **AAASM-1366** under Epic **AAASM-11**)
- Depends on: **#446** / AAASM-1429 (GET matrix endpoint — establishes the store and types)
- Closes the Story alongside AAASM-1431 (verification, no PR)

## Testing

- [x] Unit tests added / updated (2 in `models::capability::tests` + 3 in `routes::capability::tests`)
- [x] Integration tests added / updated (3 in `aa-api/tests/capability.rs`: happy path, RBAC deny, invalid payload)
- [x] Manual testing performed (`cargo nextest run -p aa-api` — **278 passed**)
- [ ] No tests required (explain why)

Validation run against this branch:

\`\`\`
cargo nextest run -p aa-api                            # 278 passed (was 270 pre-Sub-2; +8 new)
cargo fmt --all -- --check                             # clean
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo deny check                                       # clean
cargo doc --workspace --no-deps                        # clean
cargo run -p aa-api --bin generate_openapi             # produces the committed openapi/v1.yaml byte-for-byte
\`\`\`

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (`openapi/v1.yaml` regenerated and committed)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Commit list (this PR — Sub-2 only)

10 granular GitEmoji commits, one logical unit each:

\`\`\`
✨ (aa-api/models): Add CapabilityOverrideRequest payload
✨ (aa-api/models): Add CapabilityOverrideResponse envelope
✨ (aa-api/state): Add CapabilityStore::apply_override
✨ (aa-api/routes): Add POST /capability/override handler with RBAC gate
✨ (aa-api/routes): Wire capability override route into v1_router
✨ (aa-api/openapi): Register capability override path and schemas
✅ (aa-api/routes): Add capability override happy-path test
✅ (aa-api/routes): Add capability override RBAC deny test (Viewer scope)
✅ (aa-api/routes): Add capability override invalid-payload test (unknown agent_id)
📝 (openapi): Regenerate openapi/v1.yaml with capability override
\`\`\`