### PR TITLE
[AAASM-1425] ⚡ (aa-ebpf): Capture openat syscall duration via per-tid timestamp map

### DIFF
--- a/aa-ebpf-common/src/file.rs
+++ b/aa-ebpf-common/src/file.rs
@@ -49,6 +49,13 @@ pub struct FileIoEventRaw {
     pub flags: u32,
     /// Syscall return code.
     pub return_code: i64,
+    /// End-to-end syscall duration in nanoseconds (exit_ts − enter_ts).
+    ///
+    /// Populated by kretprobes that pair with an entry kprobe via a
+    /// per-tid timestamp map. `0` when the syscall has only an entry
+    /// hook (currently: read / write / unlink / rename — tracked under
+    /// the AAASM-1425 follow-up for the remaining syscalls).
+    pub duration_ns: u64,
     /// File path as a null-terminated byte array.
     pub path: [u8; MAX_PATH_LEN],
 }

--- a/aa-ebpf-probes/src/main.rs
+++ b/aa-ebpf-probes/src/main.rs
@@ -6,13 +6,13 @@ mod maps;
 
 use aa_ebpf_common::file::{FdPathKey, FileIoEventRaw, SyscallType, MAX_PATH_LEN};
 use aya_ebpf::{
-    helpers::bpf_probe_read_user_str_bytes,
+    helpers::{bpf_ktime_get_ns, bpf_probe_read_user_str_bytes},
     macros::{kprobe, kretprobe},
     programs::{ProbeContext, RetProbeContext},
 };
 
 use crate::helpers::{emit_event, get_pid_tgid, should_monitor};
-use crate::maps::{FD_PATH_MAP, OPENAT_TMP, PATH_ALLOWLIST, PATH_BLOCKLIST};
+use crate::maps::{FD_PATH_MAP, OPENAT_ENTRY_TS, OPENAT_TMP, PATH_ALLOWLIST, PATH_BLOCKLIST};
 
 /// kprobe on `sys_openat` — captures the filename argument and stashes
 /// it in `OPENAT_TMP` keyed by `pid_tgid` so the kretprobe can pair it
@@ -41,6 +41,10 @@ fn try_sys_openat(ctx: &ProbeContext) -> Result<u32, u32> {
 
     let pid_tgid = aya_ebpf::helpers::bpf_get_current_pid_tgid();
     let _ = OPENAT_TMP.insert(&pid_tgid, &buf, 0);
+
+    // Stash the entry timestamp so the kretprobe can compute duration.
+    let entry_ts = unsafe { bpf_ktime_get_ns() };
+    let _ = OPENAT_ENTRY_TS.insert(&pid_tgid, &entry_ts, 0);
 
     Ok(0)
 }
@@ -75,8 +79,16 @@ fn try_sys_openat_ret(ctx: &RetProbeContext) -> Result<u32, u32> {
         syscall: SyscallType::Openat,
         flags: 0,
         return_code: 0,
+        duration_ns: 0,
         path: *path,
     };
+
+    // Compute end-to-end syscall duration from the entry-timestamp map.
+    if let Some(&entry_ts) = unsafe { OPENAT_ENTRY_TS.get(&pid_tgid) } {
+        let now = unsafe { bpf_ktime_get_ns() };
+        event.duration_ns = now.saturating_sub(entry_ts);
+        let _ = OPENAT_ENTRY_TS.remove(&pid_tgid);
+    }
 
     // Clean up the temporary entry.
     let _ = OPENAT_TMP.remove(&pid_tgid);
@@ -143,6 +155,7 @@ fn try_sys_read(ctx: &ProbeContext) -> Result<u32, u32> {
         syscall: SyscallType::Read,
         flags: 0,
         return_code: 0,
+        duration_ns: 0,
         path: *path,
     };
 
@@ -189,6 +202,7 @@ fn try_sys_write(ctx: &ProbeContext) -> Result<u32, u32> {
         syscall: SyscallType::Write,
         flags: 0,
         return_code: 0,
+        duration_ns: 0,
         path: *path,
     };
 
@@ -227,6 +241,7 @@ fn try_sys_unlink(ctx: &ProbeContext) -> Result<u32, u32> {
         syscall: SyscallType::Unlink,
         flags: 0,
         return_code: 0,
+        duration_ns: 0,
         path: [0u8; MAX_PATH_LEN],
     };
     unsafe {
@@ -273,6 +288,7 @@ fn try_sys_rename(ctx: &ProbeContext) -> Result<u32, u32> {
         syscall: SyscallType::Rename,
         flags: 0,
         return_code: 0,
+        duration_ns: 0,
         path: [0u8; MAX_PATH_LEN],
     };
     unsafe {

--- a/aa-ebpf-probes/src/maps.rs
+++ b/aa-ebpf-probes/src/maps.rs
@@ -25,6 +25,12 @@ pub static FD_PATH_MAP: HashMap<FdPathKey, [u8; MAX_PATH_LEN]> =
 pub static OPENAT_TMP: HashMap<u64, [u8; MAX_PATH_LEN]> =
     HashMap::with_max_entries(MAX_ENTRIES, 0);
 
+/// Temporary map to pass the entry timestamp from the openat kprobe
+/// entry to the openat kretprobe (keyed by pid_tgid). Used to compute
+/// end-to-end syscall duration for the emitted `FileIoEventRaw`.
+#[map]
+pub static OPENAT_ENTRY_TS: HashMap<u64, u64> = HashMap::with_max_entries(MAX_ENTRIES, 0);
+
 /// Path pattern blocklist: paths that should trigger an alert.
 /// Key is a hash of the path prefix, value is 1 (deny).
 #[map]

--- a/aa-ebpf/src/alert.rs
+++ b/aa-ebpf/src/alert.rs
@@ -63,6 +63,7 @@ mod tests {
             flags: 0,
             return_code: 0,
             is_sensitive: false,
+            duration_ns: 0,
         }
     }
 

--- a/aa-ebpf/src/events.rs
+++ b/aa-ebpf/src/events.rs
@@ -34,6 +34,12 @@ pub struct FileIoEvent {
     pub return_code: i64,
     /// Whether this event matched a blocklisted path (flags bit 0).
     pub is_sensitive: bool,
+    /// End-to-end syscall duration in nanoseconds (`exit_ts − enter_ts`).
+    ///
+    /// `0` when the syscall has only an entry hook today (read /
+    /// write / unlink / rename — tracked under the AAASM-1425 follow-up).
+    /// Populated for `openat` via the entry-timestamp map.
+    pub duration_ns: u64,
 }
 
 impl FileIoEvent {
@@ -63,6 +69,7 @@ impl FileIoEvent {
             flags: raw.flags,
             return_code: raw.return_code,
             is_sensitive: raw.flags & 1 != 0,
+            duration_ns: raw.duration_ns,
         })
     }
 }
@@ -83,6 +90,7 @@ mod tests {
             syscall,
             flags,
             return_code: 3,
+            duration_ns: 0,
             path: path_buf,
         }
     }
@@ -98,10 +106,19 @@ mod tests {
             flags: 0,
             return_code: 0,
             is_sensitive: false,
+            duration_ns: 0,
         };
         assert_eq!(event.pid, 1234);
         assert_eq!(event.syscall, SyscallKind::Openat);
         assert_eq!(event.path, "/etc/shadow");
+    }
+
+    #[test]
+    fn from_raw_carries_duration_ns_through() {
+        let mut raw = make_raw("/tmp/timed.txt", SyscallType::Openat, 0);
+        raw.duration_ns = 123_456;
+        let event = FileIoEvent::from_raw(&raw).expect("parse");
+        assert_eq!(event.duration_ns, 123_456);
     }
 
     #[test]

--- a/aa-runtime/src/ebpf_bridge.rs
+++ b/aa-runtime/src/ebpf_bridge.rs
@@ -36,9 +36,10 @@ pub fn file_io_to_audit(event: &FileIoEvent) -> AuditEvent {
             path: event.path.clone(),
             bytes: 0,
             source: "ebpf".to_string(),
-            // eBPF events are point-in-time syscall traces, not durations.
-            // Real measurement pending AAASM-1425.
-            latency_ms: 0,
+            // Convert nanoseconds (BPF kretprobe) to milliseconds. `0` when
+            // the syscall has only an entry hook (read / write / unlink /
+            // rename — follow-up under AAASM-1425).
+            latency_ms: (event.duration_ns / 1_000_000) as i64,
         })),
         ..AuditEvent::default()
     }
@@ -204,6 +205,29 @@ mod tests {
                 assert!(p.args.is_empty());
             }
             _ => panic!("expected Process detail"),
+        }
+    }
+
+    #[test]
+    fn file_io_to_audit_propagates_zero_duration_as_zero_latency() {
+        let event = make_file_io(SyscallKind::Read, "/tmp/no-duration");
+        let audit = file_io_to_audit(&event);
+        let detail = audit.detail.expect("detail should be set");
+        match detail {
+            Detail::FileOp(ref fop) => assert_eq!(fop.latency_ms, 0),
+            _ => panic!("expected FileOp detail"),
+        }
+    }
+
+    #[test]
+    fn file_io_to_audit_converts_duration_ns_to_latency_ms() {
+        let mut event = make_file_io(SyscallKind::Openat, "/tmp/timed");
+        event.duration_ns = 2_500_000;
+        let audit = file_io_to_audit(&event);
+        let detail = audit.detail.expect("detail should be set");
+        match detail {
+            Detail::FileOp(ref fop) => assert_eq!(fop.latency_ms, 2),
+            _ => panic!("expected FileOp detail"),
         }
     }
 

--- a/aa-runtime/src/ebpf_bridge.rs
+++ b/aa-runtime/src/ebpf_bridge.rs
@@ -152,6 +152,7 @@ mod tests {
             flags: 0,
             return_code: 0,
             is_sensitive: false,
+            duration_ns: 0,
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds an `OPENAT_ENTRY_TS` BPF hash map keyed by `pid_tgid` so the openat kretprobe can compute `exit_ts − enter_ts` and stamp the result into `FileIoEventRaw.duration_ns` before emitting.
- Threads the new `duration_ns` field through `FileIoEventRaw` → `FileIoEvent` → `FileOpDetail.latency_ms` (nanos → millis) so the dashboard Live Ops row finally shows real syscall latency for `openat`.
- Scope per plan: **openat-only this PR**. The other four syscalls (`read` / `write` / `unlink` / `rename`) remain entry-only and emit `duration_ns: 0`; their kretprobe + duration capture is tracked under the AAASM-1425 follow-up Task.

## Why

Closes AAASM-1425 — the kernel side of the latency story started in AAASM-1421 (which added the proto field + handler mapper but left `latency_ms` at `0`). With this PR, openat events surface meaningful latency end-to-end (eBPF kretprobe → audit pipeline → `aa-api` Live Ops detail → dashboard row).

## How to verify

- `cargo nextest run -p aa-ebpf` — 72 pass (includes new `from_raw_carries_duration_ns_through`).
- `cargo nextest run -p aa-runtime` — 214 pass (includes new `file_io_to_audit_converts_duration_ns_to_latency_ms` and `file_io_to_audit_propagates_zero_duration_as_zero_latency`).
- `cd aa-ebpf-probes && cargo check --bin aa-file-io` — clean (BPF target builds on Linux nightly via existing CI job).
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.

## Commits

- 🔌 `aa-ebpf`: Add `duration_ns` field to `FileIoEvent` + `FileIoEventRaw`
- ⚡ `aa-ebpf-probes`: Capture openat syscall duration via per-tid map
- ✨ `aa-runtime`: Populate `FileOpDetail.latency_ms` from BPF `duration_ns`

## Follow-up

- File a follow-up Task under AAASM-1425 to add kretprobes + duration capture for `read` / `write` / `unlink` / `rename`.

Closes AAASM-1425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)