### PR TITLE
[AAASM-1373] ✨ (shell): Add icon support to AppShell nav entries (🔔 for Alerts)

### DIFF
--- a/dashboard/src/components/AppShell.css
+++ b/dashboard/src/components/AppShell.css
@@ -51,6 +51,16 @@
   min-width: 1.5rem;
 }
 
+.appshell__nav-icon {
+  /* Optional glyph (AAASM-1373) rendered between the num prefix and the
+     label. Aligns visually with .appshell__nav-num — same vertical centre
+     via the parent flex row, slightly larger font for legibility. */
+  font-size: 0.95rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+}
+
 .appshell__nav-link:hover {
   background: var(--shell-nav-hover-bg);
   color: var(--shell-nav-text);

--- a/dashboard/src/components/AppShell.tsx
+++ b/dashboard/src/components/AppShell.tsx
@@ -79,6 +79,15 @@ export function AppShell() {
                 data-testid={`nav-link-${r.id}`}
               >
                 <span className="appshell__nav-num">{r.num}</span>
+                {r.icon && (
+                  <span
+                    className="appshell__nav-icon"
+                    data-testid={`nav-icon-${r.id}`}
+                    aria-hidden="true"
+                  >
+                    {r.icon}
+                  </span>
+                )}
                 {r.label}
               </NavLink>
             ))}

--- a/dashboard/src/routes.test.tsx
+++ b/dashboard/src/routes.test.tsx
@@ -1,8 +1,18 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { CANONICAL_ROUTES, ROUTE_GROUPS } from './routes'
 import { ComingSoon } from './pages/ComingSoon'
+
+// Mock the AppShell's external dependencies so the render test below can
+// mount it without auth / approvals network calls. Both mocks are scoped
+// to this file — no global side effects.
+vi.mock('./auth/useAuth', () => ({
+  useAuth: () => ({ token: 'aaasm1373-token', logout: vi.fn() }),
+}))
+vi.mock('./features/approvals/ApprovalsBellButton', () => ({
+  ApprovalsBellButton: () => null,
+}))
 
 describe('CANONICAL_ROUTES config', () => {
   it('declares exactly 12 routes', () => {
@@ -41,6 +51,43 @@ describe('CANONICAL_ROUTES config', () => {
     expect(nums).toEqual([
       '01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12',
     ])
+  })
+
+  it('alerts route ships a bell icon (AAASM-1373)', () => {
+    const alerts = CANONICAL_ROUTES.find((r) => r.id === 'alerts')
+    expect(alerts).toBeDefined()
+    expect(alerts!.icon).toBe('🔔')
+  })
+
+  it('only alerts has an icon today — the other 11 routes leave icon undefined', () => {
+    const withIcon = CANONICAL_ROUTES.filter((r) => r.icon !== undefined).map((r) => r.id)
+    expect(withIcon).toEqual(['alerts'])
+  })
+})
+
+describe('AppShell nav-icon rendering (AAASM-1373)', () => {
+  it('renders the bell icon for /alerts and nothing for the other 11 routes', async () => {
+    // Import lazily so the vi.mock hoisting at file scope is honoured before
+    // the real AppShell module is loaded.
+    const { AppShell } = await import('./components/AppShell')
+    render(
+      <MemoryRouter initialEntries={['/alerts']}>
+        <AppShell />
+      </MemoryRouter>,
+    )
+
+    // The /alerts entry renders the bell glyph inside the dedicated span.
+    const alertsIcon = screen.getByTestId('nav-icon-alerts')
+    expect(alertsIcon).toBeInTheDocument()
+    expect(alertsIcon.textContent).toBe('🔔')
+    expect(alertsIcon).toHaveAttribute('aria-hidden', 'true')
+
+    // No other route ships an icon today — the other 11 nav-icon-* testids
+    // must not appear in the document.
+    for (const route of CANONICAL_ROUTES) {
+      if (route.id === 'alerts') continue
+      expect(screen.queryByTestId(`nav-icon-${route.id}`)).toBeNull()
+    }
   })
 })
 

--- a/dashboard/src/routes.ts
+++ b/dashboard/src/routes.ts
@@ -19,6 +19,13 @@ export interface CanonicalRoute {
   group: RouteGroup
   /** Route path. */
   path: string
+  /**
+   * Optional glyph rendered alongside the numbered prefix (AAASM-1373).
+   * Only the routes with established iconography ship one today; routes
+   * without an icon fall back to the bare `num` + `label` layout so no
+   * visual regression hits the other entries.
+   */
+  icon?: string
 }
 
 export const CANONICAL_ROUTES: readonly CanonicalRoute[] = [
@@ -26,7 +33,7 @@ export const CANONICAL_ROUTES: readonly CanonicalRoute[] = [
   { id: 'fleet',      num: '02', label: 'Fleet',            group: 'monitor', path: '/agents' },
   { id: 'topology',   num: '03', label: 'Topology',         group: 'monitor', path: '/topology' },
   { id: 'live',       num: '04', label: 'Live Ops',         group: 'monitor', path: '/live' },
-  { id: 'alerts',     num: '05', label: 'Alerts',           group: 'monitor', path: '/alerts' },
+  { id: 'alerts',     num: '05', label: 'Alerts',           group: 'monitor', path: '/alerts', icon: '🔔' },
   { id: 'audit',      num: '06', label: 'Audit Log',        group: 'monitor', path: '/audit' },
   { id: 'capability', num: '07', label: 'Capability',       group: 'control', path: '/capability' },
   { id: 'policy',     num: '08', label: 'Policy',           group: 'control', path: '/policies' },


### PR DESCRIPTION
## Summary

Implements **AAASM-1373** — extends the AppShell nav so each canonical
route can ship an optional glyph alongside the numbered prefix, and
supplies the bell icon for `/alerts` as the first consumer.

## What changes

- `CanonicalRoute.icon?: string` — new optional field in `src/routes.ts`.
- `/alerts` route entry adds `icon: '🔔'`.
- `AppShell.tsx` renders `<span class="appshell__nav-icon" data-testid="nav-icon-<id>" aria-hidden="true">` after the numbered prefix when present.
- `AppShell.css` adds `.appshell__nav-icon` rule (font 0.95rem, vertically centred in the existing flex row).
- Three new assertions in `routes.test.tsx`:
  1. Schema: alerts ships `icon: '🔔'`.
  2. Schema invariant: only alerts has an icon today.
  3. Render: AppShell mounted in MemoryRouter → `nav-icon-alerts` shows `🔔` with `aria-hidden="true"`, no `nav-icon-<id>` for the other 11 routes.

## AC results (all pass)

| # | AC bullet | Status |
|---|---|---|
| 1 | `CanonicalRoute` gains optional `icon?: string` | ✅ |
| 2 | `AppShell` renders the icon when present; falls through cleanly for the 11 routes without an icon (no visual regression) | ✅ |
| 3 | `/alerts` route entry includes a bell icon (🔔 glyph) | ✅ |
| 4 | `routes.test.tsx` updated to assert the bell icon renders on the alerts nav link | ✅ (schema + render assertions) |
| 5 | `pnpm type-check`, `lint`, `test` all pass | ✅ |

## Layout decision

Icon goes **alongside** the numbered prefix (`01 🔔 Alerts`) — keeps the visual hierarchy of the other 11 routes intact while adding a glanceable hint where one is wanted. AC explicitly permits "alongside (or instead of)"; alongside has zero impact on the other entries.

## Commits

| # | Commit |
|---|---|
| 1 | `✨ (routes): Add optional icon field to CanonicalRoute and 🔔 for alerts` |
| 2 | `✨ (shell): Render route icon in AppShell nav link` |
| 3 | `✅ (routes): Assert bell icon renders on alerts nav link` |

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — clean (`--max-warnings 0`)
- [x] `pnpm test` — vitest 97 files / 846 tests green (was 843, +3 new)
- [x] No visual regression for the other 11 nav entries — schema invariant test enforces it

## Impact on parent Story AAASM-118

Closes one of 4 remaining AAASM-118 sub-tasks. Remaining: AAASM-1374 (severity-scheme reconciliation), AAASM-1393 (Rule Configuration tab), AAASM-1394 (Monaco YAML in drawer).

Refs Story AAASM-118.