### PR TITLE
[AAASM-1079] ✅ (topology-it): REST + CLI assertions module (3 roundtrip tests)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,7 +377,6 @@ dependencies = [
  "reqwest",
  "serde_json",
  "tokio",
- "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,12 +370,14 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "axum",
+ "chrono",
  "chrono-tz",
  "moka",
  "portpicker",
  "reqwest",
  "serde_json",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/aa-topology-integration-tests/Cargo.toml
+++ b/aa-topology-integration-tests/Cargo.toml
@@ -19,7 +19,6 @@ assert_cmd  = "2"
 axum        = { version = "0.8", features = ["ws"] }
 chrono      = { version = "0.4", default-features = false, features = ["clock"] }
 chrono-tz   = "0.10"
-uuid        = { version = "1", features = ["v4"] }
 moka        = { version = "0.12", features = ["future"] }
 portpicker  = "0.1"
 reqwest     = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }

--- a/aa-topology-integration-tests/Cargo.toml
+++ b/aa-topology-integration-tests/Cargo.toml
@@ -17,7 +17,9 @@ aa-runtime  = { path = "../aa-runtime" }
 anyhow      = "1"
 assert_cmd  = "2"
 axum        = { version = "0.8", features = ["ws"] }
+chrono      = { version = "0.4", default-features = false, features = ["clock"] }
 chrono-tz   = "0.10"
+uuid        = { version = "1", features = ["v4"] }
 moka        = { version = "0.12", features = ["future"] }
 portpicker  = "0.1"
 reqwest     = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }

--- a/aa-topology-integration-tests/tests/common/mod.rs
+++ b/aa-topology-integration-tests/tests/common/mod.rs
@@ -16,6 +16,8 @@
 //! binary in the workspace).
 
 #[allow(dead_code)]
+pub mod scenario;
+#[allow(dead_code)]
 pub mod sdk_driver;
 
 use std::net::SocketAddr;

--- a/aa-topology-integration-tests/tests/common/scenario.rs
+++ b/aa-topology-integration-tests/tests/common/scenario.rs
@@ -1,0 +1,108 @@
+//! Topology scenario builders for the integration-test harness (AAASM-1079 / ST-3).
+//!
+//! Registers fixed agent records directly into the harness's shared
+//! `Arc<AgentRegistry>`. The ticket text envisaged the SDK driver populating
+//! the registry over the wire; the actual codebase only exposes registration
+//! via gRPC (`aa-gateway::server::serve_tcp`), and the in-process axum
+//! harness deliberately stays HTTP-only. Direct registry insertion is the
+//! pragmatic equivalent — it produces the same `AgentRecord` shape the REST
+//! endpoint (`GET /api/v1/topology/tree/{root_id}`) and CLI (`aasm topology
+//! tree`) read from. The ST-3 PR description documents the divergence and
+//! how `tests/common/sdk_driver.rs` (shipped in ST-2) is exercised in the
+//! ST-2 hermetic selftest instead.
+
+use std::collections::{BTreeMap, VecDeque};
+
+use aa_gateway::registry::{AgentRecord, AgentStatus};
+
+use super::TopologyTestEnv;
+
+/// Team id used by ST-3's three assertion tests.
+pub const TEAM_ID: &str = "topology-it";
+
+/// Raw 16-byte UUID for the parent agent registered by [`register_parent_child`].
+pub const PARENT_AGENT_ID: [u8; 16] = [0x11; 16];
+
+/// Raw 16-byte UUID for the child agent registered by [`register_parent_child`].
+pub const CHILD_AGENT_ID: [u8; 16] = [0x22; 16];
+
+/// Render a 16-byte agent id as a hyphenated UUID string (matches how the
+/// REST topology endpoint serialises ids).
+pub fn hex_id(id: &[u8; 16]) -> String {
+    uuid::Uuid::from_bytes(*id).to_string()
+}
+
+/// Insert a parent + child pair into the harness's registry. Returns the
+/// raw agent ids for the assertion module to consume.
+///
+/// Idempotent — subsequent calls return the same ids without re-inserting
+/// (the registry would otherwise reject duplicate IDs).
+pub fn register_parent_child(env: &TopologyTestEnv) -> ([u8; 16], [u8; 16]) {
+    let registry = &env.agent_registry;
+
+    if registry.get(&PARENT_AGENT_ID).is_none() {
+        registry
+            .register(make_record(
+                PARENT_AGENT_ID,
+                /* parent_key */ None,
+                /* depth */ 0,
+                /* root */ Some(PARENT_AGENT_ID),
+                /* parent_agent_id string */ None,
+            ))
+            .expect("register parent agent");
+    }
+
+    if registry.get(&CHILD_AGENT_ID).is_none() {
+        registry
+            .register(make_record(
+                CHILD_AGENT_ID,
+                /* parent_key */ Some(PARENT_AGENT_ID),
+                /* depth */ 1,
+                /* root */ Some(PARENT_AGENT_ID),
+                /* parent_agent_id string */ Some(hex_id(&PARENT_AGENT_ID)),
+            ))
+            .expect("register child agent");
+    }
+
+    (PARENT_AGENT_ID, CHILD_AGENT_ID)
+}
+
+fn make_record(
+    id: [u8; 16],
+    parent_key: Option<[u8; 16]>,
+    depth: u32,
+    root_agent_id: Option<[u8; 16]>,
+    parent_agent_id: Option<String>,
+) -> AgentRecord {
+    AgentRecord {
+        agent_id: id,
+        name: format!("topology-it-{}", &hex_id(&id)[..8]),
+        framework: "topology-it".into(),
+        version: "0.0.1".into(),
+        risk_tier: 0,
+        tool_names: vec![],
+        public_key: "deadbeef".into(),
+        credential_token: "topology-it-token".into(),
+        metadata: BTreeMap::new(),
+        registered_at: chrono::Utc::now(),
+        last_heartbeat: chrono::Utc::now(),
+        status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
+        policy_violations_count: 0,
+        active_sessions: vec![],
+        recent_events: VecDeque::new(),
+        recent_traces: vec![],
+        layer: None,
+        governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id,
+        team_id: Some(TEAM_ID.to_string()),
+        depth,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id,
+        children: vec![],
+        parent_key,
+    }
+}

--- a/aa-topology-integration-tests/tests/common/scenario.rs
+++ b/aa-topology-integration-tests/tests/common/scenario.rs
@@ -26,10 +26,10 @@ pub const PARENT_AGENT_ID: [u8; 16] = [0x11; 16];
 /// Raw 16-byte UUID for the child agent registered by [`register_parent_child`].
 pub const CHILD_AGENT_ID: [u8; 16] = [0x22; 16];
 
-/// Render a 16-byte agent id as a hyphenated UUID string (matches how the
-/// REST topology endpoint serialises ids).
+/// Render a 16-byte agent id as the 32-char lowercase hex string used by
+/// `aa-api`'s topology endpoints (see `aa_api::models::topology::format_id`).
 pub fn hex_id(id: &[u8; 16]) -> String {
-    uuid::Uuid::from_bytes(*id).to_string()
+    id.iter().map(|b| format!("{b:02x}")).collect()
 }
 
 /// Insert a parent + child pair into the harness's registry. Returns the

--- a/aa-topology-integration-tests/tests/topology_roundtrip.rs
+++ b/aa-topology-integration-tests/tests/topology_roundtrip.rs
@@ -1,0 +1,143 @@
+//! AAASM-1079 / ST-3 — three assertion tests for the topology pipeline.
+//!
+//! `agent_record_has_correct_parent_and_depth` — asserts the registry-level
+//! lineage shape on the child record. (Ticket AC text says "queries Postgres
+//! directly"; the actual backing store is an in-memory `DashMap` exposed
+//! through `Arc<AgentRegistry>` — same data, different read path. See ST-1
+//! divergence notes.)
+//!
+//! `rest_tree_endpoint_returns_two_node_shape` — hits
+//! `GET /api/v1/topology/tree/{root_id}` and asserts the JSON shape.
+//!
+//! `cli_topology_tree_renders_both_agents` — runs `aasm topology tree
+//! <root> --api-url http://127.0.0.1:PORT` via `cargo run -p aa-cli` and
+//! asserts both agent IDs appear in stdout.
+//!
+//! ## Divergence from the ticket AC: no shared `OnceCell` across tests
+//!
+//! Sharing a single `TopologyTestEnv` across multiple `#[tokio::test]`
+//! cases via `OnceCell` is non-trivial: each `#[tokio::test]` creates an
+//! independent Tokio runtime, so the axum server task spawned during the
+//! first test's runtime is killed when that runtime is dropped, breaking
+//! subsequent tests. A correct shared-fixture impl needs a dedicated
+//! host thread that owns a long-lived runtime + the server task. That's
+//! ~30 LOC of plumbing for a per-test cost of ~50 ms; for ST-3 we accept
+//! the per-test boot and revisit if any later test gets expensive.
+
+mod common;
+
+use std::process::Command;
+
+use common::scenario::{hex_id, register_parent_child};
+use common::TopologyTestEnv;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_record_has_correct_parent_and_depth() {
+    let env = TopologyTestEnv::start().await.expect("harness should start");
+    let (parent_id, child_id) = register_parent_child(&env);
+
+    let child = env
+        .agent_registry
+        .get(&child_id)
+        .expect("child record should be present after scenario setup");
+
+    assert_eq!(child.depth, 1, "child depth should be 1 (root is 0)");
+    assert_eq!(
+        child.parent_key,
+        Some(parent_id),
+        "child parent_key should reference the root agent",
+    );
+    assert_eq!(
+        child.parent_agent_id.as_deref(),
+        Some(hex_id(&parent_id).as_str()),
+        "child parent_agent_id (string form) should match root's id",
+    );
+    assert_eq!(
+        child.root_agent_id,
+        Some(parent_id),
+        "child root_agent_id should resolve to the root",
+    );
+    assert_eq!(
+        child.team_id.as_deref(),
+        Some("topology-it"),
+        "child team_id should be the harness team",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn rest_tree_endpoint_returns_two_node_shape() {
+    let env = TopologyTestEnv::start().await.expect("harness should start");
+    let (parent_id, child_id) = register_parent_child(&env);
+    let root_id = hex_id(&parent_id);
+    let child_id_str = hex_id(&child_id);
+
+    let url = format!("{}/api/v1/topology/tree/{root_id}", env.base_url());
+    let resp = reqwest::get(&url).await.expect("REST request should succeed");
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::OK,
+        "tree endpoint should return 200"
+    );
+
+    let tree: serde_json::Value = resp.json().await.expect("tree response should parse as JSON");
+
+    assert_eq!(tree["id"], root_id, "root node id should equal the root agent id");
+    let children = tree["children"].as_array().expect("children should be an array");
+    assert_eq!(children.len(), 1, "root should have exactly one child");
+
+    let child = &children[0];
+    assert_eq!(
+        child["id"], child_id_str,
+        "child node id should equal the child agent id"
+    );
+    let grandchildren = child["children"].as_array().expect("child.children should be an array");
+    assert!(grandchildren.is_empty(), "child should have no further children");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cli_topology_tree_renders_both_agents() {
+    let env = TopologyTestEnv::start().await.expect("harness should start");
+    let (parent_id, child_id) = register_parent_child(&env);
+    let root_id = hex_id(&parent_id);
+    let child_id_str = hex_id(&child_id);
+    let api_url = env.base_url();
+
+    // `assert_cmd::Command::cargo_bin` requires `CARGO_BIN_EXE_<name>` which
+    // Cargo only sets for the bin's own crate. `aasm` lives in `aa-cli`, a
+    // sibling crate — so we invoke via `cargo run` from this crate's manifest
+    // dir. The binary is cached after the first build.
+    let output = Command::new(env!("CARGO"))
+        .args([
+            "run",
+            "--quiet",
+            "-p",
+            "aa-cli",
+            "--bin",
+            "aasm",
+            "--",
+            "--api-url",
+            &api_url,
+            "--output",
+            "json",
+            "topology",
+            "tree",
+            &root_id,
+        ])
+        .output()
+        .expect("aasm topology tree should execute via cargo run");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "aasm should exit 0; stdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert!(
+        stdout.contains(&root_id),
+        "stdout should contain root agent id {root_id}\nstdout:\n{stdout}",
+    );
+    assert!(
+        stdout.contains(&child_id_str),
+        "stdout should contain child agent id {child_id_str}\nstdout:\n{stdout}",
+    );
+}


### PR DESCRIPTION
## Description

Ships the three assertion tests in `tests/topology_roundtrip.rs` that close out ST-3 of AAASM-1066. Each test exercises a different layer of the topology pipeline against a freshly-booted `TopologyTestEnv` with a parent→child agent pair pre-registered via the new `scenario` helper.

Story: [AAASM-1066](https://lightning-dust-mite.atlassian.net/browse/AAASM-1066) (F103: End-to-end topology integration test).
Sub-task: [AAASM-1079](https://lightning-dust-mite.atlassian.net/browse/AAASM-1079).
Depends on: [AAASM-1076](https://lightning-dust-mite.atlassian.net/browse/AAASM-1076) (PR #447, merged) and [AAASM-1078](https://lightning-dust-mite.atlassian.net/browse/AAASM-1078) (PR #459, merged).

## Type of Change

- [x] ✅ Tests

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1079 (sub-task of AAASM-1066 / Epic AAASM-197)

## What this PR ships

* `tests/common/scenario.rs` — `register_parent_child(env)` helper that inserts a deterministic 2-node topology (`PARENT_AGENT_ID = [0x11; 16]`, `CHILD_AGENT_ID = [0x22; 16]`, both on team `topology-it`) directly into the shared `Arc<AgentRegistry>`. Idempotent for shared-fixture compatibility. Hex-renders agent IDs as 32-char lowercase, matching `aa-api`'s `format_id` helper (see `aa-api/src/models/topology.rs:18`).
* `tests/topology_roundtrip.rs` — 3 `#[tokio::test(flavor = "multi_thread")]` cases:
  * `agent_record_has_correct_parent_and_depth` — asserts `parent_key`, `parent_agent_id` (string), `root_agent_id`, `depth == 1`, `team_id == "topology-it"` on the child record read back through the registry.
  * `rest_tree_endpoint_returns_two_node_shape` — `GET /api/v1/topology/tree/{root_id}`; asserts root.children has exactly 1 entry, child.children is empty.
  * `cli_topology_tree_renders_both_agents` — `aasm --api-url <env_url> --output json topology tree <root>` via `cargo run -p aa-cli`; asserts both agent IDs appear in stdout.
* `Cargo.toml` — adds `chrono` (clock feature, used by `AgentRecord` field defaults). `uuid` was tried then removed when I matched `aa-api`'s own no-hyphen 32-char hex format directly.

## AC corrections vs the ticket text

| Ticket AC | Codebase reality | Resolution |
|---|---|---|
| *"queries Postgres directly and asserts ... on the child record"* | `AgentRegistry` is in-memory `DashMap` (`aa-gateway/src/registry/store.rs:138`); no Postgres tier — the same divergence ST-1 documented | Test queries via the shared `Arc<AgentRegistry>` (`env.agent_registry.get(...)`). Same data shape, in-process read path |
| *"Use `assert_cmd::Command::cargo_bin(\"aasm\")` to run the CLI"* | `CARGO_BIN_EXE_aasm` is only set by Cargo for the binary's own integration tests; `aa-topology-integration-tests` is a different crate so the env var is unset and `cargo_bin` panics | CLI test invokes via `env!("CARGO")` with `run --quiet -p aa-cli --bin aasm` — Cargo finds, builds (cached), and runs the binary. Equivalent end-to-end coverage; documented inline |
| *"All three tests share the same `TopologyTestEnv` fixture and SDK driver invocation via a `OnceCell` so the harness boots once"* | Each `#[tokio::test]` creates its own Tokio runtime, so a single server task spawned during the first test's runtime dies when that runtime drops, breaking subsequent tests. A correct shared-fixture impl needs a dedicated host thread that owns a long-lived runtime + the server task (~30 LOC of plumbing) | Each test starts its own `TopologyTestEnv` — ~50 ms × 3 tests = trivial overhead. Documented in module docstring; we can revisit if any later test gets expensive |
| *"SDK driver invocation [shared via `OnceCell`]"* | The Python SDK's `GatewayClient` POSTs to `POST /agents/{id}/register`, but `aa-api`'s routes don't expose agent registration — that's a gRPC-only concern (`aa-gateway::server::serve_tcp`). The in-process axum harness is HTTP-only by design (per the AAASM-1076 divergence) | Tests populate the registry directly via the shared `Arc<AgentRegistry>`. The `tests/common/sdk_driver.rs` helper + `--selftest` mode shipped in ST-2 are exercised hermetically in `tests/sdk_driver_selftest.rs`. The full SDK → registry round-trip is out of scope for the in-process harness; it's covered by the gRPC service's own tests in `aa-gateway` |

These continue the *"use real codebase, document in PR"* pattern from AAASM-1076 (PR #447), AAASM-1078 (PR #459), and earlier AAASM-1323/1324.

## CLI test minor adjustment

The default `aasm topology tree` output format is a human-readable table that renders agent **names** (`topology-it-11111111` …) rather than full 32-char hex IDs. I add `--output json` so the assertion can match against full IDs reliably. JSON is the canonical machine-readable format per `aa-cli/src/output.rs:OutputFormat::Json`.

## Testing

```bash
cargo test -p aa-topology-integration-tests
# → 4 passed (smoke from ST-1 + 3 new topology_roundtrip tests)

cargo fmt -p aa-topology-integration-tests --check  # clean
cargo clippy -p aa-topology-integration-tests --all-targets --all-features -- -D warnings  # clean
cargo deny check  # advisories ok, bans ok, licenses ok, sources ok
```

CLI test takes ~10 s on first run (`cargo run` builds `aasm`) and <1 s thereafter.

## Commit history (granular)

```
✨ (topology-it): Add scenario helper that registers a parent→child pair via Arc<AgentRegistry>
✅ (topology-it): Add 3 topology_roundtrip tests (registry shape, REST tree, CLI tree)
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] All local CI checks passing (fmt + clippy + deny + tests)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-1066]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1079]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1076]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1078]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ