### PR TITLE
[AAASM-1394] ✨ (alerts): Render rule YAML with Monaco in AlertDetailDrawer

### DIFF
--- a/dashboard/src/features/alerts/AlertDetailContent.tsx
+++ b/dashboard/src/features/alerts/AlertDetailContent.tsx
@@ -2,6 +2,7 @@ import { useAlertQuery } from './api'
 import { SeverityBadge } from './SeverityBadge'
 import { StatusBadge } from './StatusBadge'
 import { SilenceAction } from './SilenceAction'
+import { RuleYamlViewer } from './RuleYamlViewer'
 import type { AlertDetail } from './types'
 
 function ruleYaml(detail: AlertDetail): string {
@@ -75,20 +76,7 @@ export function AlertDetailContent({ alertId }: AlertDetailContentProps) {
 
       <section style={sectionStyle}>
         <span style={sectionHeader}>Rule YAML</span>
-        <pre
-          data-testid="alert-detail-rule-yaml"
-          style={{
-            background: 'var(--surface-hover-bg)',
-            padding: '0.75rem',
-            borderRadius: '4px',
-            fontSize: '0.75rem',
-            margin: 0,
-            overflowX: 'auto',
-            whiteSpace: 'pre',
-          }}
-        >
-          {ruleYaml(data)}
-        </pre>
+        <RuleYamlViewer yaml={ruleYaml(data)} />
       </section>
 
       <section style={sectionStyle}>

--- a/dashboard/src/features/alerts/RuleYamlViewer.test.tsx
+++ b/dashboard/src/features/alerts/RuleYamlViewer.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { RuleYamlViewer } from './RuleYamlViewer'
+
+// Mock @monaco-editor/react so the test stays fast and deterministic:
+// the real Editor pulls Monaco from a CDN and won't render in jsdom.
+// The mock captures all props on a data-* attribute string so the
+// assertions below can read them back synchronously.
+vi.mock('@monaco-editor/react', () => ({
+  __esModule: true,
+  default: (props: Record<string, unknown>) => (
+    <div
+      data-testid="monaco-editor-mock"
+      data-language={props.language as string}
+      data-theme={props.theme as string}
+      data-height={String(props.height as number | string)}
+      data-options={JSON.stringify(props.options)}
+    >
+      {(props.value as string) ?? ''}
+    </div>
+  ),
+}))
+
+const YAML_SAMPLE = `name: "Budget guardrail"
+metric: budget_spent_pct
+operator: ">"
+threshold: 90
+severity: CRITICAL
+`
+
+describe('RuleYamlViewer', () => {
+  it('renders the alert-detail-rule-yaml wrapper around Monaco', async () => {
+    render(<RuleYamlViewer yaml={YAML_SAMPLE} />)
+
+    // Wrapper is rendered synchronously — keeps the existing e2e selector working.
+    const wrapper = screen.getByTestId('alert-detail-rule-yaml')
+    expect(wrapper).toBeInTheDocument()
+
+    // The lazy-loaded Editor resolves via the vi.mock above; wait for it.
+    const editor = await waitFor(() => screen.getByTestId('monaco-editor-mock'))
+    expect(wrapper.contains(editor)).toBe(true)
+  })
+
+  it('passes the YAML body verbatim to the Monaco Editor', async () => {
+    render(<RuleYamlViewer yaml={YAML_SAMPLE} />)
+    const editor = await waitFor(() => screen.getByTestId('monaco-editor-mock'))
+    expect(editor.textContent).toBe(YAML_SAMPLE)
+  })
+
+  it('configures Monaco for read-only YAML rendering at 200px height with vs-dark theme', async () => {
+    render(<RuleYamlViewer yaml={YAML_SAMPLE} />)
+    const editor = await waitFor(() => screen.getByTestId('monaco-editor-mock'))
+
+    expect(editor).toHaveAttribute('data-language', 'yaml')
+    expect(editor).toHaveAttribute('data-theme', 'vs-dark')
+    expect(editor).toHaveAttribute('data-height', '200')
+
+    const options = JSON.parse(editor.getAttribute('data-options') ?? '{}') as Record<string, unknown>
+    // Read-only contract — locked in to prevent any future regression that
+    // would let an alert-rule snapshot get edited from the drawer.
+    expect(options.readOnly).toBe(true)
+    expect(options.domReadOnly).toBe(true)
+    // Minimap off keeps the drawer's 200px height usable.
+    expect((options.minimap as { enabled: boolean }).enabled).toBe(false)
+    expect(options.scrollBeyondLastLine).toBe(false)
+    expect(options.lineNumbers).toBe('off')
+    expect(options.folding).toBe(false)
+    expect(options.wordWrap).toBe('on')
+  })
+})

--- a/dashboard/src/features/alerts/RuleYamlViewer.tsx
+++ b/dashboard/src/features/alerts/RuleYamlViewer.tsx
@@ -1,0 +1,73 @@
+import { Suspense, lazy } from 'react'
+
+// Lazy-load Monaco so the editor JS is fetched only when the alert
+// detail drawer actually opens — keeps the first-paint of the Alerts
+// page slim (AAASM-1394).
+const Editor = lazy(() =>
+  import('@monaco-editor/react').then((m) => ({ default: m.default })),
+)
+
+const HEIGHT_PX = 200
+
+interface RuleYamlViewerProps {
+  /** Pre-rendered YAML text for the alert rule snapshot. */
+  yaml: string
+}
+
+/**
+ * Read-only Monaco viewer for an alert-rule YAML payload (AAASM-1394).
+ *
+ * Renders the same `data-testid="alert-detail-rule-yaml"` as the
+ * previous `<pre>` block so the AAASM-1082 Playwright spec and the
+ * AAASM-1395 design-fidelity spec continue to find it. The wrapping
+ * `<div>` is the only thing rendered synchronously; Monaco itself is
+ * lazy-loaded inside a `<Suspense>` boundary.
+ */
+export function RuleYamlViewer({ yaml }: RuleYamlViewerProps) {
+  return (
+    <div
+      data-testid="alert-detail-rule-yaml"
+      style={{
+        background: 'var(--surface-hover-bg)',
+        borderRadius: '4px',
+        overflow: 'hidden',
+      }}
+    >
+      <Suspense
+        fallback={
+          <div
+            data-testid="alert-detail-rule-yaml-loading"
+            style={{
+              padding: '0.75rem',
+              fontFamily: 'ui-monospace, monospace',
+              fontSize: '0.75rem',
+              color: 'var(--text-muted)',
+              minHeight: `${HEIGHT_PX}px`,
+            }}
+          >
+            Loading editor…
+          </div>
+        }
+      >
+        <Editor
+          height={HEIGHT_PX}
+          language="yaml"
+          value={yaml}
+          theme="vs-dark"
+          options={{
+            readOnly: true,
+            domReadOnly: true,
+            minimap: { enabled: false },
+            scrollBeyondLastLine: false,
+            lineNumbers: 'off',
+            folding: false,
+            renderLineHighlight: 'none',
+            scrollbar: { vertical: 'auto', horizontal: 'auto' },
+            wordWrap: 'on',
+            fontSize: 12,
+          }}
+        />
+      </Suspense>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Implements **AAASM-1394** — replaces the plain `<pre>` block in the
alert detail drawer's Rule YAML section with a read-only Monaco
editor for syntax highlighting.

## What changes

- New `src/features/alerts/RuleYamlViewer.tsx` — Monaco read-only viewer
  isolated from `AlertDetailContent`. Monaco itself is `React.lazy()`-loaded
  so the editor JS is fetched only when an AlertDetailDrawer opens —
  no impact on first-paint of the Alerts page.
- `AlertDetailContent.tsx` swaps the `<pre>` for `<RuleYamlViewer yaml={…} />`.
  `data-testid="alert-detail-rule-yaml"` moves with the wrapper so the
  AAASM-1082 alerts spec and AAASM-1395 design-fidelity spec keep working.
- New `RuleYamlViewer.test.tsx` — 3 vitest assertions on wrapper render,
  YAML content pass-through, and Monaco config (language / theme /
  height / readOnly / minimap / lineNumbers / wordWrap).

## Monaco configuration

| Option | Value |
|---|---|
| `language` | `yaml` |
| `theme` | `vs-dark` (per AC) |
| `height` | `200` |
| `readOnly` | `true` |
| `domReadOnly` | `true` |
| `minimap.enabled` | `false` |
| `scrollBeyondLastLine` | `false` |
| `lineNumbers` | `off` |
| `folding` | `false` |
| `wordWrap` | `on` |
| `fontSize` | `12` |

## AC results (all pass)

| # | AC bullet | Status |
|---|---|---|
| 1 | `AlertDetailContent.tsx` renders rule YAML via `<Editor>` from `@monaco-editor/react` | ✅ (via RuleYamlViewer composition) |
| 2 | Editor configured: `language="yaml"`, `readOnly`, `theme="vs-dark"`, `minimap.enabled: false`, height ≈ 200px | ✅ (all locked in by test 3) |
| 3 | `data-testid="alert-detail-rule-yaml"` stays on the rendering element | ✅ (moved from `<pre>` to RuleYamlViewer's wrapper `<div>`) |
| 4 | `pnpm type-check`, `lint`, `test` all pass | ✅ |

## How-to-approach guidance followed

- **Lazy-load with `React.lazy()`** — perf win, deferred Monaco bundle.
- **Reuse loader options from `PolicyEditorPage`** — N/A, no existing Monaco usage in `src/` today (PolicyEditorPage referenced in the ticket isn't merged yet). This PR establishes the read-only YAML pattern; future Monaco consumers can lift from here.

## Commits

| # | Commit |
|---|---|
| 1 | `✨ (alerts): Add RuleYamlViewer with lazy-loaded Monaco editor` |
| 2 | `♻️ (alerts): Use RuleYamlViewer in AlertDetailContent (replaces <pre>)` |
| 3 | `✅ (alerts): Cover RuleYamlViewer Monaco config + content` |

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — clean (`--max-warnings 0`)
- [x] `pnpm test` — vitest 98 files / 849 tests green (was 846; +3 new)
- [x] `pnpm test:e2e tests/e2e/alerts.spec.ts tests/e2e/alerts-design-fidelity.spec.ts` — 8/8 pass (rule-yaml selector keeps working)

## Impact on parent Story AAASM-118

Closes one of 3 remaining AAASM-118 sub-tasks. Remaining: AAASM-1374 (severity-scheme reconciliation), AAASM-1393 (Rule Configuration tab).

Refs Story AAASM-118.