### PR TITLE
[AAASM-1053] ✨ (dashboard): Inherited-permissions panel on agent-detail Capability tab

### DIFF
--- a/dashboard/src/components/InheritedPermissionsPanel.css
+++ b/dashboard/src/components/InheritedPermissionsPanel.css
@@ -1,0 +1,132 @@
+.ipp {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 4px 0;
+}
+
+.ipp__summary {
+  display: flex;
+  gap: 24px;
+  padding: 12px 16px;
+  background: var(--surface-2);
+  border-radius: 6px;
+  border: 1px solid var(--line-2);
+}
+
+.ipp__summary-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.ipp__summary-num {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--ink-1);
+}
+
+.ipp__summary-label {
+  font-size: 11px;
+  color: var(--ink-4);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.ipp__group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ipp__group-title {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--ink-3);
+  margin: 0;
+}
+
+.ipp__rows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.ipp__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 8px 12px;
+  background: var(--surface-1);
+  border: 1px solid var(--line-2);
+  border-radius: 4px;
+}
+
+.ipp__capability {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 12px;
+  color: var(--ink-1);
+}
+
+.ipp__chips {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.ipp__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-family: 'JetBrains Mono', monospace;
+  border: 1px solid transparent;
+}
+
+.ipp__chip--allow {
+  background: color-mix(in srgb, var(--ok) 12%, transparent);
+  color: var(--ok);
+  border-color: color-mix(in srgb, var(--ok) 30%, transparent);
+}
+
+.ipp__chip--deny {
+  background: color-mix(in srgb, var(--danger) 12%, transparent);
+  color: var(--danger);
+  border-color: color-mix(in srgb, var(--danger) 30%, transparent);
+}
+
+.ipp--empty {
+  align-items: flex-start;
+  padding: 24px 0;
+}
+
+.ipp__empty-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--ink-2);
+  margin: 0 0 4px 0;
+}
+
+.ipp__empty-body {
+  font-size: 12px;
+  color: var(--ink-4);
+  margin: 0;
+  max-width: 56ch;
+  line-height: 1.5;
+}
+
+.ipp__empty-body code {
+  font-family: 'JetBrains Mono', monospace;
+  background: var(--surface-2);
+  padding: 1px 4px;
+  border-radius: 3px;
+}

--- a/dashboard/src/components/InheritedPermissionsPanel.test.tsx
+++ b/dashboard/src/components/InheritedPermissionsPanel.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+import type { UseQueryResult } from '@tanstack/react-query'
+import { InheritedPermissionsPanel } from './InheritedPermissionsPanel'
+import * as agentsApi from '../features/agents/api'
+import type { EffectivePermissions } from '../features/agents/api'
+
+function makeClient() {
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } })
+}
+
+function mockQuery<T>(partial: Partial<UseQueryResult<T, Error>>): UseQueryResult<T, Error> {
+  return partial as unknown as UseQueryResult<T, Error>
+}
+
+function renderPanel(agentId = 'aabbccdd00112233aabbccdd00112233') {
+  return render(
+    <QueryClientProvider client={makeClient()}>
+      <InheritedPermissionsPanel agentId={agentId} />
+    </QueryClientProvider>,
+  )
+}
+
+let useAgentCapabilitiesQuery: Mock
+
+beforeEach(() => {
+  useAgentCapabilitiesQuery = vi.spyOn(agentsApi, 'useAgentCapabilitiesQuery') as unknown as Mock
+})
+
+describe('InheritedPermissionsPanel — loading and error states', () => {
+  it('renders loading state while query is pending', () => {
+    useAgentCapabilitiesQuery.mockReturnValue(
+      mockQuery<EffectivePermissions>({ isLoading: true }),
+    )
+    renderPanel()
+    expect(screen.getByTestId('inherited-permissions-loading')).toBeInTheDocument()
+  })
+
+  it('renders error state when query fails', () => {
+    useAgentCapabilitiesQuery.mockReturnValue(
+      mockQuery<EffectivePermissions>({
+        isLoading: false,
+        isError: true,
+        error: new Error('boom'),
+        refetch: vi.fn(),
+      }),
+    )
+    renderPanel()
+    expect(screen.getByTestId('inherited-permissions-error')).toBeInTheDocument()
+  })
+})
+
+describe('InheritedPermissionsPanel — empty cascade', () => {
+  it('renders the explicit no-cascade-contribution message when sources is empty', () => {
+    useAgentCapabilitiesQuery.mockReturnValue(
+      mockQuery<EffectivePermissions>({
+        isLoading: false,
+        data: { allow: [], deny: [], sources: [] },
+      }),
+    )
+    renderPanel()
+    expect(screen.getByTestId('inherited-permissions-empty')).toBeInTheDocument()
+    expect(screen.getByText(/No cascade contribution/)).toBeInTheDocument()
+  })
+})
+
+describe('InheritedPermissionsPanel — populated cascade', () => {
+  const data: EffectivePermissions = {
+    allow: ['file_read', 'network_outbound', 'mcp_tool:github'],
+    deny: ['file_write'],
+    sources: [
+      {
+        scope: 'global',
+        allow: ['file_read', 'file_write', 'network_outbound', 'mcp_tool:github'],
+        deny: [],
+      },
+      {
+        scope: 'team:platform',
+        allow: ['file_read', 'network_outbound', 'mcp_tool:github'],
+        deny: ['file_write'],
+      },
+    ],
+  }
+
+  beforeEach(() => {
+    useAgentCapabilitiesQuery.mockReturnValue(
+      mockQuery<EffectivePermissions>({ isLoading: false, data }),
+    )
+  })
+
+  it('renders the summary counts', () => {
+    renderPanel()
+    expect(screen.getByTestId('ipp-allow-count')).toHaveTextContent('3')
+    expect(screen.getByTestId('ipp-deny-count')).toHaveTextContent('1')
+    expect(screen.getByTestId('ipp-source-count')).toHaveTextContent('2')
+  })
+
+  it('groups capabilities by category', () => {
+    renderPanel()
+    // file_read and file_write → Filesystem group
+    expect(screen.getByTestId('ipp-group-filesystem')).toBeInTheDocument()
+    // network_outbound → Network
+    expect(screen.getByTestId('ipp-group-network')).toBeInTheDocument()
+    // mcp_tool:github → MCP
+    expect(screen.getByTestId('ipp-group-mcp')).toBeInTheDocument()
+  })
+
+  it('shows granted-by chip pointing at the first source that allows each capability', () => {
+    renderPanel()
+    const fileReadAllow = screen.getByTestId('ipp-allow-file_read')
+    expect(fileReadAllow).toHaveTextContent('granted by')
+    expect(fileReadAllow).toHaveTextContent('global')
+  })
+
+  it('shows denied-by chip pointing at the first source that denies a capability', () => {
+    renderPanel()
+    const fileWriteDeny = screen.getByTestId('ipp-deny-file_write')
+    expect(fileWriteDeny).toHaveTextContent('denied by')
+    expect(fileWriteDeny).toHaveTextContent('team:platform')
+  })
+
+  it('shows both granted-by and denied-by chips when an ancestor allows but a descendant denies', () => {
+    // file_write is allow-listed at the global scope but explicitly denied at
+    // team:platform. The panel surfaces both, so operators can see the source
+    // of the deny while still understanding that a broader scope intended it
+    // to be allowed.
+    renderPanel()
+    expect(screen.getByTestId('ipp-allow-file_write')).toHaveTextContent('global')
+    expect(screen.getByTestId('ipp-deny-file_write')).toHaveTextContent('team:platform')
+  })
+})

--- a/dashboard/src/components/InheritedPermissionsPanel.test.tsx
+++ b/dashboard/src/components/InheritedPermissionsPanel.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
 import type { UseQueryResult } from '@tanstack/react-query'
 import { InheritedPermissionsPanel } from './InheritedPermissionsPanel'
@@ -17,7 +18,9 @@ function mockQuery<T>(partial: Partial<UseQueryResult<T, Error>>): UseQueryResul
 function renderPanel(agentId = 'aabbccdd00112233aabbccdd00112233') {
   return render(
     <QueryClientProvider client={makeClient()}>
-      <InheritedPermissionsPanel agentId={agentId} />
+      <MemoryRouter>
+        <InheritedPermissionsPanel agentId={agentId} />
+      </MemoryRouter>
     </QueryClientProvider>,
   )
 }
@@ -128,5 +131,21 @@ describe('InheritedPermissionsPanel — populated cascade', () => {
     renderPanel()
     expect(screen.getByTestId('ipp-allow-file_write')).toHaveTextContent('global')
     expect(screen.getByTestId('ipp-deny-file_write')).toHaveTextContent('team:platform')
+  })
+
+  it('renders granted-by and denied-by chips as Links to /policies', () => {
+    // AC: "granted-by-scope (clickable -> jumps to that policy)". The
+    // dashboard currently has only the /policies list page, so the chip
+    // navigates there for now. The link helper is centralised in the
+    // component; a follow-up will retarget to /policies/:id once the wire
+    // schema exposes a policy_id alongside scope.
+    renderPanel()
+    const allowChip = screen.getByTestId('ipp-allow-file_read')
+    expect(allowChip.tagName).toBe('A')
+    expect(allowChip).toHaveAttribute('href', '/policies')
+
+    const denyChip = screen.getByTestId('ipp-deny-file_write')
+    expect(denyChip.tagName).toBe('A')
+    expect(denyChip).toHaveAttribute('href', '/policies')
   })
 })

--- a/dashboard/src/components/InheritedPermissionsPanel.tsx
+++ b/dashboard/src/components/InheritedPermissionsPanel.tsx
@@ -1,0 +1,163 @@
+/**
+ * AAASM-1053 (F100) — Inherited-permissions panel for the agent-detail
+ * Capability tab.
+ *
+ * Renders the per-agent effective `CapabilitySet` returned by the
+ * `/api/v1/agents/{id}/capabilities` endpoint (AAASM-1049). Capabilities are
+ * grouped by category (Filesystem / Network / Terminal / MCP / Model / Spawn /
+ * Other); each row shows where it was `granted_by` and, when the parent
+ * cascade explicitly denies it, where it was `denied_by_ancestor`.
+ */
+import { useMemo } from 'react'
+import { useAgentCapabilitiesQuery } from '../features/agents/api'
+import type { EffectivePermissions, PermissionSource } from '../features/agents/api'
+import { LoadingState } from './LoadingState'
+import { ErrorState } from './ErrorState'
+import './InheritedPermissionsPanel.css'
+
+const CATEGORY_ORDER: ReadonlyArray<Category> = [
+  'Filesystem',
+  'Network',
+  'Terminal',
+  'MCP',
+  'Model',
+  'Spawn',
+  'Other',
+]
+
+type Category = 'Filesystem' | 'Network' | 'Terminal' | 'MCP' | 'Model' | 'Spawn' | 'Other'
+
+interface PermissionRow {
+  readonly capability: string
+  readonly category: Category
+  readonly grantedBy: PermissionSource | null
+  readonly deniedByAncestor: PermissionSource | null
+}
+
+export function InheritedPermissionsPanel({ agentId }: { agentId: string }) {
+  const { data, isLoading, isError, refetch } = useAgentCapabilitiesQuery(agentId)
+
+  const rows = useMemo<PermissionRow[]>(() => (data ? buildRows(data) : []), [data])
+
+  if (isLoading) {
+    return (
+      <div className="ipp" data-testid="inherited-permissions-loading">
+        <LoadingState page="capability" />
+      </div>
+    )
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="ipp" data-testid="inherited-permissions-error">
+        <ErrorState onRetry={() => void refetch()} />
+      </div>
+    )
+  }
+
+  if (data.sources.length === 0) {
+    return (
+      <div className="ipp ipp--empty" data-testid="inherited-permissions-empty">
+        <p className="ipp__empty-title">No cascade contribution</p>
+        <p className="ipp__empty-body">
+          No policy in this agent&apos;s cascade declares a <code>capabilities</code> block. The
+          agent has no allow-list restriction and no explicit denials.
+        </p>
+      </div>
+    )
+  }
+
+  const grouped = groupByCategory(rows)
+
+  return (
+    <section className="ipp" data-testid="inherited-permissions-panel">
+      <header className="ipp__summary">
+        <div className="ipp__summary-stat" data-testid="ipp-allow-count">
+          <span className="ipp__summary-num">{data.allow.length}</span>
+          <span className="ipp__summary-label">allowed</span>
+        </div>
+        <div className="ipp__summary-stat" data-testid="ipp-deny-count">
+          <span className="ipp__summary-num">{data.deny.length}</span>
+          <span className="ipp__summary-label">denied</span>
+        </div>
+        <div className="ipp__summary-stat" data-testid="ipp-source-count">
+          <span className="ipp__summary-num">{data.sources.length}</span>
+          <span className="ipp__summary-label">cascade source{data.sources.length === 1 ? '' : 's'}</span>
+        </div>
+      </header>
+
+      {CATEGORY_ORDER.map((cat) => {
+        const rowsForCat = grouped.get(cat)
+        if (!rowsForCat || rowsForCat.length === 0) return null
+        return (
+          <div key={cat} className="ipp__group" data-testid={`ipp-group-${cat.toLowerCase()}`}>
+            <h3 className="ipp__group-title">{cat}</h3>
+            <ul className="ipp__rows">
+              {rowsForCat.map((row) => (
+                <li key={row.capability} className="ipp__row" data-testid={`ipp-row-${row.capability}`}>
+                  <code className="ipp__capability">{row.capability}</code>
+                  <div className="ipp__chips">
+                    {row.grantedBy && (
+                      <span className="ipp__chip ipp__chip--allow" data-testid={`ipp-allow-${row.capability}`}>
+                        granted by <strong>{row.grantedBy.scope}</strong>
+                      </span>
+                    )}
+                    {row.deniedByAncestor && (
+                      <span className="ipp__chip ipp__chip--deny" data-testid={`ipp-deny-${row.capability}`}>
+                        denied by <strong>{row.deniedByAncestor.scope}</strong>
+                      </span>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )
+      })}
+    </section>
+  )
+}
+
+function categoryFor(capability: string): Category {
+  if (capability.startsWith('file_')) return 'Filesystem'
+  if (capability.startsWith('network_')) return 'Network'
+  if (capability.startsWith('terminal_')) return 'Terminal'
+  if (capability.startsWith('mcp_tool:')) return 'MCP'
+  if (capability.startsWith('model:')) return 'Model'
+  if (capability === 'agent_spawn') return 'Spawn'
+  return 'Other'
+}
+
+function buildRows(perms: EffectivePermissions): PermissionRow[] {
+  // Union of allow + deny gives every capability touched by the cascade.
+  const universe = new Set<string>([...perms.allow, ...perms.deny])
+  return Array.from(universe)
+    .sort()
+    .map((cap) => ({
+      capability: cap,
+      category: categoryFor(cap),
+      grantedBy: firstSourceContaining(perms.sources, cap, 'allow'),
+      deniedByAncestor: firstSourceContaining(perms.sources, cap, 'deny'),
+    }))
+}
+
+function firstSourceContaining(
+  sources: PermissionSource[],
+  cap: string,
+  field: 'allow' | 'deny',
+): PermissionSource | null {
+  for (const src of sources) {
+    if (src[field].includes(cap)) return src
+  }
+  return null
+}
+
+function groupByCategory(rows: PermissionRow[]): Map<Category, PermissionRow[]> {
+  const out = new Map<Category, PermissionRow[]>()
+  for (const row of rows) {
+    const list = out.get(row.category) ?? []
+    list.push(row)
+    out.set(row.category, list)
+  }
+  return out
+}

--- a/dashboard/src/components/InheritedPermissionsPanel.tsx
+++ b/dashboard/src/components/InheritedPermissionsPanel.tsx
@@ -9,11 +9,20 @@
  * cascade explicitly denies it, where it was `denied_by_ancestor`.
  */
 import { useMemo } from 'react'
+import { Link } from 'react-router-dom'
 import { useAgentCapabilitiesQuery } from '../features/agents/api'
 import type { EffectivePermissions, PermissionSource } from '../features/agents/api'
 import { LoadingState } from './LoadingState'
 import { ErrorState } from './ErrorState'
 import './InheritedPermissionsPanel.css'
+
+// Route the granted-by / denied-by chips navigate to. There's no
+// per-policy detail route in the dashboard yet, so the chip jumps to the
+// policy list page where the operator can find the matching scope. The
+// helper is centralised so a follow-up Subtask can swap in
+// `/policies/:id` once the wire schema exposes a policy_id alongside the
+// scope label.
+const POLICY_HREF = '/policies'
 
 const CATEGORY_ORDER: ReadonlyArray<Category> = [
   'Filesystem',
@@ -98,14 +107,24 @@ export function InheritedPermissionsPanel({ agentId }: { agentId: string }) {
                   <code className="ipp__capability">{row.capability}</code>
                   <div className="ipp__chips">
                     {row.grantedBy && (
-                      <span className="ipp__chip ipp__chip--allow" data-testid={`ipp-allow-${row.capability}`}>
+                      <Link
+                        className="ipp__chip ipp__chip--allow"
+                        data-testid={`ipp-allow-${row.capability}`}
+                        to={POLICY_HREF}
+                        aria-label={`Jump to policies — granted by ${row.grantedBy.scope}`}
+                      >
                         granted by <strong>{row.grantedBy.scope}</strong>
-                      </span>
+                      </Link>
                     )}
                     {row.deniedByAncestor && (
-                      <span className="ipp__chip ipp__chip--deny" data-testid={`ipp-deny-${row.capability}`}>
+                      <Link
+                        className="ipp__chip ipp__chip--deny"
+                        data-testid={`ipp-deny-${row.capability}`}
+                        to={POLICY_HREF}
+                        aria-label={`Jump to policies — denied by ${row.deniedByAncestor.scope}`}
+                      >
                         denied by <strong>{row.deniedByAncestor.scope}</strong>
-                      </span>
+                      </Link>
                     )}
                   </div>
                 </li>

--- a/dashboard/src/features/agents/api.ts
+++ b/dashboard/src/features/agents/api.ts
@@ -8,6 +8,8 @@ export type SubtreeBurn = components['schemas']['SubtreeBurnResponse']
 export type DailyBurnPoint = components['schemas']['DailyBurnPointResponse']
 export type ChildSpend = components['schemas']['ChildSpendResponse']
 export type BurnPeriod = '7d' | '30d'
+export type EffectivePermissions = components['schemas']['EffectivePermissionsResponse']
+export type PermissionSource = components['schemas']['PermissionSourceResponse']
 
 export function useAgentsQuery() {
   return useQuery({
@@ -45,6 +47,21 @@ export function useAgentSubtreeBurnQuery(id: string, period: BurnPeriod = '7d') 
       })
       if (error) throw new Error('Failed to fetch subtree burn')
       if (!data) throw new Error('Subtree burn response was empty')
+      return data
+    },
+    enabled: !!id,
+  })
+}
+
+export function useAgentCapabilitiesQuery(id: string) {
+  return useQuery<EffectivePermissions>({
+    queryKey: ['agents', id, 'capabilities'],
+    queryFn: async () => {
+      const { data, error } = await api.GET('/api/v1/agents/{id}/capabilities', {
+        params: { path: { id } },
+      })
+      if (error) throw new Error('Failed to fetch agent capabilities')
+      if (!data) throw new Error('Agent capabilities response was empty')
       return data
     },
     enabled: !!id,

--- a/dashboard/src/pages/AgentDetailPage.test.tsx
+++ b/dashboard/src/pages/AgentDetailPage.test.tsx
@@ -77,6 +77,16 @@ function mockHappyPath() {
   vi.spyOn(agentsApi, 'useAgentEventsQuery').mockReturnValue(
     mockQuery<LogEntry[]>({ data: [MOCK_LOG], isLoading: false, isError: false }),
   )
+  // AAASM-1053: the Capability tab now renders InheritedPermissionsPanel,
+  // which calls useAgentCapabilitiesQuery. Mock to a stable empty cascade
+  // so the panel hits its no-cascade-contribution empty state.
+  vi.spyOn(agentsApi, 'useAgentCapabilitiesQuery').mockReturnValue(
+    mockQuery<agentsApi.EffectivePermissions>({
+      data: { allow: [], deny: [], sources: [] },
+      isLoading: false,
+      isError: false,
+    }),
+  )
 }
 
 afterEach(() => { vi.restoreAllMocks() })
@@ -168,11 +178,15 @@ describe('AgentDetailPage tab navigation', () => {
     expect(screen.getByTestId('agent-detail-tab-overview')).toHaveAttribute('aria-selected', 'true')
   })
 
-  it('switches to Capability empty-state when its tab is selected', async () => {
+  it('switches to the InheritedPermissionsPanel when the Capability tab is selected', async () => {
+    // AAASM-1053: Capability tab no longer renders the TabEmpty placeholder;
+    // it mounts the live InheritedPermissionsPanel. With mockHappyPath's
+    // empty cascade the panel renders its no-cascade-contribution empty
+    // state.
     mockHappyPath()
     renderApp('/agents/abc123')
     fireEvent.click(await screen.findByTestId('agent-detail-tab-capability'))
-    await waitFor(() => expect(screen.getByTestId('ad-tab-empty-capability')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByTestId('inherited-permissions-empty')).toBeInTheDocument())
     expect(screen.queryByTestId('agent-detail-posture')).not.toBeInTheDocument()
   })
 

--- a/dashboard/src/pages/AgentDetailPage.tsx
+++ b/dashboard/src/pages/AgentDetailPage.tsx
@@ -9,6 +9,7 @@ import { StatusChip } from '../components/fleet/StatusChip'
 import { ModeChip } from '../components/fleet/ModeChip'
 import { useToast } from '../components/Toast'
 import { LoadingState } from '../components/LoadingState'
+import { InheritedPermissionsPanel } from '../components/InheritedPermissionsPanel'
 // AAASM-1055 "how to approach": "Lazy-load the chart component so the agent
 // detail page does not pay its bundle cost up front" (recharts is large).
 const SubtreeBurnChart = lazy(() =>
@@ -386,12 +387,7 @@ export function AgentDetailPage() {
                 </div>
               )}
 
-              {tab === 'capability' && (
-                <TabEmpty
-                  title="Capability"
-                  body="The capability matrix scoped to this agent is rendered on the global Capability page (AAASM-1280). Inline view lands in a follow-up sub-task."
-                />
-              )}
+              {tab === 'capability' && <InheritedPermissionsPanel agentId={agent.id} />}
               {tab === 'traffic' && (
                 <TabEmpty
                   title="Traffic"


### PR DESCRIPTION
## Description

Replace the placeholder TabEmpty on the agent-detail Capability tab
with a live **InheritedPermissionsPanel** that renders the effective
`CapabilitySet` returned by `GET /api/v1/agents/{id}/capabilities`
(endpoint shipped by AAASM-1049 and now on master via PR #458).

The page is already a right-side `<Drawer>` mounted at `/agents/:id`,
so the AC's "right-side drawer" requirement is satisfied by the
existing routing — the panel renders inside the existing tab rather
than introducing a new modal pattern.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1053
- Parent Story: AAASM-227 (F100)
- Endpoint dependency: AAASM-1049 (PR #458) — merged

## Testing

- [x] 8 Vitest cases in `InheritedPermissionsPanel.test.tsx` — loading / error / empty states, summary counts, category grouping, granted-by / denied-by chip resolution, ancestor-allow + descendant-deny edge case
- [x] `pnpm test --run src/components/InheritedPermissionsPanel.test.tsx` — 8 / 8 green
- [x] `pnpm type-check` — clean

## Commit map

| Commit | Change |
| --- | --- |
| `f4311b8e` | ✨ (dashboard/agents) `useAgentCapabilitiesQuery` hook + TS re-exports |
| `df939862` | ✨ (dashboard/components) `InheritedPermissionsPanel` + CSS |
| `2511d3c3` | ✨ (dashboard/AgentDetailPage) Wire panel into Capability tab |
| `a8eb13b2` | ✅ (dashboard/components) 8 Vitest cases for the panel |

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] All local CI gates passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
