### PR TITLE
[AAASM-1081] 🔧 (ci): Add topology-integration.yml workflow + Drop cleanup

### DIFF
--- a/.github/workflows/topology-integration.yml
+++ b/.github/workflows/topology-integration.yml
@@ -1,0 +1,88 @@
+name: Topology integration tests
+
+# End-to-end topology integration test suite (AAASM-1066). Runs the
+# `aa-topology-integration-tests` crate on Linux + macOS so the assertion
+# tests (REST + CLI roundtrip) are exercised on both platforms before
+# anything depending on them ships.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "aa-topology-integration-tests/**"
+      - "aa-api/**"
+      - "aa-gateway/**"
+      - "aa-cli/**"
+      - "aa-runtime/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/topology-integration.yml"
+  pull_request:
+    branches: [master]
+    paths:
+      - "aa-topology-integration-tests/**"
+      - "aa-api/**"
+      - "aa-gateway/**"
+      - "aa-cli/**"
+      - "aa-runtime/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/topology-integration.yml"
+
+jobs:
+  topology-integration-tests:
+    name: Topology integration tests (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+      - name: Checkout agent-assembly
+        uses: actions/checkout@v4
+
+      - name: Checkout sibling python-sdk
+        uses: actions/checkout@v4
+        with:
+          repository: AI-agent-assembly/python-sdk
+          path: python-sdk
+
+      - name: Install protobuf compiler (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Install protobuf compiler (macOS)
+        if: matrix.os == 'macos-latest'
+        run: brew install protobuf
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: topology-it-${{ matrix.os }}
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@83c419a40a2e48673b2c523337e57f602dfe53c9 # cargo-nextest
+
+      - name: Run topology integration tests
+        env:
+          PYTHON_SDK_PATH: ${{ github.workspace }}/python-sdk
+        run: cargo nextest run -p aa-topology-integration-tests --test-threads=1
+
+      - name: Upload gateway logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: topology-it-gateway-logs-${{ matrix.os }}
+          path: |
+            target/nextest/**/*.log
+            target/debug/build/aa-topology-integration-tests-*/output
+            **/*.log
+          if-no-files-found: ignore
+          retention-days: 7

--- a/aa-topology-integration-tests/tests/common/mod.rs
+++ b/aa-topology-integration-tests/tests/common/mod.rs
@@ -42,7 +42,7 @@ use aa_gateway::budget::tracker::BudgetTracker;
 use aa_gateway::edges::InMemoryEdgeRepo;
 use aa_gateway::engine::PolicyEngine;
 use aa_gateway::policy::history::{FsHistoryStore, HistoryConfig};
-use aa_gateway::registry::AgentRegistry;
+use aa_gateway::registry::{AgentRegistry, OrphanMode};
 use aa_gateway::AuditReader;
 use aa_runtime::approval::ApprovalQueue;
 use tokio::sync::oneshot;
@@ -63,6 +63,10 @@ pub struct TopologyTestEnv {
     shutdown_tx: Option<oneshot::Sender<()>>,
     /// Handle for the spawned axum task; awaited during teardown.
     server_handle: Option<JoinHandle<()>>,
+    /// Idempotency guard for the cleanup helper — set once `cleanup()` runs
+    /// successfully so an explicit cleanup + Drop don't double-tap the
+    /// registry.
+    cleaned: bool,
 }
 
 impl TopologyTestEnv {
@@ -93,6 +97,7 @@ impl TopologyTestEnv {
             agent_registry,
             shutdown_tx: Some(shutdown_tx),
             server_handle: Some(server_handle),
+            cleaned: false,
         };
         env.await_ready().await?;
         Ok(env)
@@ -102,6 +107,31 @@ impl TopologyTestEnv {
     #[allow(dead_code)]
     pub fn base_url(&self) -> String {
         format!("http://{}", self.addr)
+    }
+
+    /// Tear down per-test state: cascade-deregister every agent under the
+    /// `topology-it` team from the shared `Arc<AgentRegistry>`. Adapted
+    /// from the ticket AC text (DELETE + TRUNCATE against Postgres) — see
+    /// the ST-1 / ST-3 divergence notes for why registry deregistration is
+    /// the in-process equivalent. Idempotent via `self.cleaned`; errors
+    /// are logged but never panic so `Drop` stays safe.
+    pub fn cleanup(&mut self) {
+        if self.cleaned {
+            return;
+        }
+        let team_id = "topology-it";
+        for agent_key in self.agent_registry.team_members(team_id) {
+            if let Err(err) = self
+                .agent_registry
+                .deregister(&agent_key, OrphanMode::CascadeDeregister)
+            {
+                eprintln!(
+                    "topology-it cleanup: failed to deregister agent {}: {err:?}",
+                    uuid_string(&agent_key),
+                );
+            }
+        }
+        self.cleaned = true;
     }
 
     /// Poll `/api/v1/health` until it returns 200 or a 5 s budget is exhausted.
@@ -123,6 +153,10 @@ impl TopologyTestEnv {
 
 impl Drop for TopologyTestEnv {
     fn drop(&mut self) {
+        // Cleanup runs unconditionally but is idempotent (guarded by
+        // `self.cleaned`), so an explicit `env.cleanup()` in test code
+        // doesn't double-deregister.
+        self.cleanup();
         if let Some(tx) = self.shutdown_tx.take() {
             let _ = tx.send(());
         }
@@ -132,6 +166,12 @@ impl Drop for TopologyTestEnv {
             handle.abort();
         }
     }
+}
+
+/// Render a 16-byte agent key as the 32-char lowercase hex string used
+/// across the test surface (matches `aa_api::models::topology::format_id`).
+fn uuid_string(key: &[u8; 16]) -> String {
+    key.iter().map(|b| format!("{b:02x}")).collect()
 }
 
 /// Build a minimal `AppState` for the harness. Adapted from


### PR DESCRIPTION
## Description

Wires `aa-topology-integration-tests` into CI with a Linux + macOS matrix and extends `TopologyTestEnv::Drop` with an idempotent registry-cleanup helper.

Story: [AAASM-1066](https://lightning-dust-mite.atlassian.net/browse/AAASM-1066) (F103: End-to-end topology integration test).
Sub-task: [AAASM-1081](https://lightning-dust-mite.atlassian.net/browse/AAASM-1081).
Depends on: AAASM-1076 / 1078 / 1079 (all merged).

## Type of Change

- [x] 🔧 Configuration / CI change
- [x] ✨ New feature (Drop cleanup helper)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1081 (sub-task of AAASM-1066 / Epic AAASM-197)

## What this PR ships

**Drop cleanup helper** (`tests/common/mod.rs`):

* New `cleaned: bool` field on `TopologyTestEnv` — idempotency guard
* New `pub fn cleanup(&mut self)` — walks `agent_registry.team_members("topology-it")` and `deregister(.., OrphanMode::CascadeDeregister)` for each; logs errors via `eprintln!` instead of panicking so `Drop` stays safe
* `impl Drop` now calls `self.cleanup()` unconditionally before tearing down the server task

**CI workflow** (`.github/workflows/topology-integration.yml`):

* `os: [ubuntu-latest, macos-latest]` matrix with `fail-fast: false` and `timeout-minutes: 10` per entry
* Second `actions/checkout` for `AI-agent-assembly/python-sdk` into `$GITHUB_WORKSPACE/python-sdk` (sibling layout; `PYTHON_SDK_PATH` env points at it for future real-mode tests)
* Platform-specific protoc install — `apt-get` on Linux, `brew` on macOS (per the [[project_aa_cli_compat_protoc_requirement]] workspace convention — `aa-proto`'s `build.rs` needs `protoc`)
* `setup-python@v5` with Python 3.11
* `dtolnay/rust-toolchain` (stable, pinned by SHA) + `Swatinem/rust-cache` keyed by `topology-it-${{ matrix.os }}`
* `cargo-nextest` via `taiki-e/install-action` (matches workspace convention — `agent-assembly/CLAUDE.md`: *"Use `cargo nextest`, not `cargo test`"*)
* `cargo nextest run -p aa-topology-integration-tests --test-threads=1` — `--test-threads=1` keeps the 3 `topology_roundtrip` cases sequential so they don't race for ports
* `actions/upload-artifact@v4` on `failure()` collecting nextest output + build dir logs as `topology-it-gateway-logs-${{ matrix.os }}` (7-day retention, `if-no-files-found: ignore`)
* Path filter triggers the workflow on changes to the test crate, the four crates it depends on (`aa-api`, `aa-gateway`, `aa-cli`, `aa-runtime`), workspace manifests, or the workflow file itself

## AC corrections vs the ticket text

| Ticket AC | Codebase reality | Resolution |
|---|---|---|
| *"new GitHub Actions job in the existing CI workflow"* | `ci.yml` is already 600+ lines with strict path filters; adding a Linux + macOS matrix there would pull every other job into the matrix | New dedicated `topology-integration.yml` workflow — keeps the matrix isolated, makes the job legible, matches the per-concern split already in use (`dashboard-ci.yml`, `docs.yml`, `release.yml`, …) |
| *"installs Docker (macOS uses `docker/setup-docker-action` or Colima)"* | No Docker / testcontainers / Postgres in the harness (ST-1 fact — `AgentRegistry` is in-memory `DashMap`) | Docker step omitted entirely |
| *"`TopologyTestEnv::Drop` issues `DELETE /v1/agents?team_id=topology-it` + truncates `agent_records`/`sessions` tables"* | `aa-api` exposes no agent-DELETE endpoint (registration is gRPC-only); no Postgres tier | `cleanup()` walks `agent_registry.team_members("topology-it")` and cascade-deregisters via `Arc<AgentRegistry>` — same end state, in-process path |

These adaptations are consistent with the deviations approved across AAASM-1076 / 1078 / 1079.

## Testing

```bash
# Local — full crate suite green
cargo nextest run -p aa-topology-integration-tests --test-threads=1
# → 4 passed (smoke + 3 topology_roundtrip)

cargo fmt --all --check                    # clean
cargo clippy -p aa-topology-integration-tests --all-targets --all-features -- -D warnings  # clean
cargo deny check                            # advisories ok, bans ok, licenses ok, sources ok
```

The workflow itself runs on CI on this PR — both matrix entries (`ubuntu-latest` + `macos-latest`) need to land green before merge per the AC.

## Commit history (granular)

```
✨ (topology-it): Extend TopologyTestEnv::Drop with idempotent registry cleanup
🔧 (ci): Add topology-integration.yml workflow (Linux + macOS matrix, nextest, artifact upload)
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] All local CI checks passing (fmt + clippy + deny + tests)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-1066]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1081]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ