### PR TITLE
[AAASM-1433] ✨ (dashboard): Swap CapabilityClient mock for generated openapi-fetch client

### DIFF
--- a/dashboard/src/api/__tests__/capability.test.ts
+++ b/dashboard/src/api/__tests__/capability.test.ts
@@ -76,4 +76,31 @@ describe('createApiCapabilityClient', () => {
     expect(res.updated).toHaveLength(1)
     expect(res.updated[0].id).toBe('support-triage')
   })
+
+  it('applyOverride throws when the gateway returns an error response', async () => {
+    vi.spyOn(api, 'POST').mockResolvedValue({
+      data: undefined,
+      error: { status: 403, detail: 'policy mutation denied' },
+    } as unknown as never)
+
+    const client = createApiCapabilityClient()
+    await expect(
+      client.applyOverride({
+        agentIds: ['support-triage'],
+        resourceId: 'pg',
+        verb: 'write',
+        decision: 'deny',
+      }),
+    ).rejects.toThrow(/capability override rejected by gateway/)
+  })
+
+  it('getMatrix throws when the gateway returns an error response', async () => {
+    vi.spyOn(api, 'GET').mockResolvedValue({
+      data: undefined,
+      error: { status: 500, detail: 'internal error' },
+    } as unknown as never)
+
+    const client = createApiCapabilityClient()
+    await expect(client.getMatrix()).rejects.toThrow(/capability matrix fetch failed/)
+  })
 })

--- a/dashboard/src/api/__tests__/capability.test.ts
+++ b/dashboard/src/api/__tests__/capability.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApiCapabilityClient } from '../capability'
+import { api } from '../client'
+import type { CapabilityMatrix, OverrideResponse } from '../../features/capability/types'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function stubMatrix(): CapabilityMatrix {
+  return {
+    resources: [{ id: 'pg', name: 'Postgres', group: 'data', paths: ['pg.public.*'] }],
+    agents: [
+      {
+        id: 'support-triage',
+        name: 'support-triage',
+        framework: 'CrewAI',
+        owner: 'cx-tools',
+        trust: 78,
+        mode: 'enforce',
+        status: 'active',
+        lastSeen: '12s ago',
+        caps: {
+          pg: { read: 'allow', write: 'approval', delete: 'deny', exec: 'na' },
+        },
+      },
+    ],
+    policies: [],
+    sampleCalls: [],
+  }
+}
+
+describe('createApiCapabilityClient', () => {
+  it('getMatrix returns the response body cast to CapabilityMatrix', async () => {
+    const stub = stubMatrix()
+    const getSpy = vi
+      .spyOn(api, 'GET')
+      // openapi-fetch's GET signature is complex; the runtime contract is `{ data, error }`,
+      // and the test only depends on that runtime shape — so we narrow the cast at the
+      // call site rather than reconstructing the full overload type here.
+      // openapi-fetch's per-path generic return types are awkward to satisfy
+      // from a Vitest spy; the runtime contract is `{ data, error }` and that
+      // is what the factory consumes, so the mock-side narrow uses `unknown`.
+      .mockResolvedValue({ data: stub, error: undefined } as unknown as never)
+
+    const client = createApiCapabilityClient()
+    const matrix = await client.getMatrix()
+
+    expect(getSpy).toHaveBeenCalledWith('/api/v1/capability/matrix')
+    expect(matrix.agents[0].caps.pg.write).toBe('approval')
+    expect(matrix.resources[0].id).toBe('pg')
+  })
+
+  it('applyOverride forwards camelCase body and returns updated rows', async () => {
+    const stubUpdated: OverrideResponse = { updated: stubMatrix().agents }
+    const postSpy = vi
+      .spyOn(api, 'POST')
+      .mockResolvedValue({ data: stubUpdated, error: undefined } as unknown as never)
+
+    const client = createApiCapabilityClient()
+    const res = await client.applyOverride({
+      agentIds: ['support-triage'],
+      resourceId: 'pg',
+      verb: 'write',
+      decision: 'deny',
+    })
+
+    expect(postSpy).toHaveBeenCalledWith('/api/v1/capability/override', {
+      body: {
+        agentIds: ['support-triage'],
+        resourceId: 'pg',
+        verb: 'write',
+        decision: 'deny',
+      },
+    })
+    expect(res.updated).toHaveLength(1)
+    expect(res.updated[0].id).toBe('support-triage')
+  })
+})

--- a/dashboard/src/api/capability.ts
+++ b/dashboard/src/api/capability.ts
@@ -96,4 +96,4 @@ export function createApiCapabilityClient(): CapabilityClient {
   }
 }
 
-export const capabilityClient: CapabilityClient = createMockCapabilityClient()
+export const capabilityClient: CapabilityClient = createApiCapabilityClient()

--- a/dashboard/src/api/capability.ts
+++ b/dashboard/src/api/capability.ts
@@ -5,6 +5,7 @@ import type {
   OverrideResponse,
 } from '../features/capability/types'
 import { CAPABILITY_MATRIX_FIXTURE } from '../features/capability/fixtures'
+import { api } from './client'
 
 const MOCK_LATENCY_MS = 120
 
@@ -59,6 +60,38 @@ export function createMockCapabilityClient(
       state = { ...state, agents: applyOverrideToAgents(state.agents, req) }
       const updated = state.agents.filter((a) => req.agentIds.includes(a.id))
       return { updated: clone(updated) }
+    },
+  }
+}
+
+/**
+ * Live `CapabilityClient` backed by the generated `openapi-fetch` client
+ * (AAASM-1433). The hand-written feature-side types in `features/capability/types`
+ * and the codegen'd types in `api/generated/schema` are structurally identical
+ * for these payloads, so the response body casts at the API boundary are safe.
+ */
+export function createApiCapabilityClient(): CapabilityClient {
+  return {
+    async getMatrix() {
+      const { data, error } = await api.GET('/api/v1/capability/matrix')
+      if (error || !data) {
+        throw new Error('capability matrix fetch failed')
+      }
+      return data as CapabilityMatrix
+    },
+    async applyOverride(req) {
+      const { data, error } = await api.POST('/api/v1/capability/override', {
+        body: {
+          agentIds: req.agentIds,
+          resourceId: req.resourceId,
+          verb: req.verb,
+          decision: req.decision,
+        },
+      })
+      if (error || !data) {
+        throw new Error('capability override rejected by gateway')
+      }
+      return data as OverrideResponse
     },
   }
 }


### PR DESCRIPTION
## Description

Closes the last unchecked AC of the now-merged Story **AAASM-1366** — *"Dashboard mock client swapped for the generated openapi-fetch client in a follow-up PR."* The Capability Matrix page now talks to the real gateway via the `openapi-fetch`-generated client introduced in #446 / #448; the typed mock factory stays exported because `override.test.ts` and other test fixtures still depend on it.

### Implementation

* New `createApiCapabilityClient()` factory in `dashboard/src/api/capability.ts` delegates to the existing `api` client from `dashboard/src/api/client.ts` (which already auto-injects the JWT).
* The module-level `capabilityClient` export switches from the mock factory to the API-backed factory. `CapabilityPage.tsx` consumes `capabilityClient` by reference — no change needed there.
* `createMockCapabilityClient` remains exported for tests / Storybook.

### Type-safety note

The hand-written feature-side types in `features/capability/types.ts` and the codegen'd schema types in `api/generated/schema.d.ts` are **structurally identical** for these payloads (same field names, same enums). Casting at the API boundary (`as CapabilityMatrix` / `as OverrideResponse`) is safe and avoids a much larger refactor that would swap feature-side types wholesale.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

Dev / preview mode now requires `VITE_API_BASE_URL` to point at a running gateway. Storybook and Vitest stay unaffected because they consume the mock factory directly.

## Related Issues

- Related Jira ticket: **AAASM-1433** (Sub-task of Story **AAASM-1366** under Epic **AAASM-11** — Community Dashboard)
- Closes the *Dashboard mock client swap* AC of the parent Story (the last AC item left open at Story-close time).

## Testing

- [x] Unit tests added / updated (4 new tests in `dashboard/src/api/__tests__/capability.test.ts` — happy + error path for both methods)
- [ ] Integration tests added / updated
- [x] Manual testing performed (`pnpm test --run` — 861 passed, full dashboard suite)
- [ ] No tests required (explain why)

### Validation

\`\`\`
pnpm install --frozen-lockfile
pnpm type-check       # clean
pnpm lint             # clean
pnpm test --run       # 861 passed, 100 files
pnpm build            # success (large-chunk warning is pre-existing)
\`\`\`

## Checklist

- [x] Code follows project style guidelines (`pnpm lint`, `pnpm type-check`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (no docs needed — internal API client swap)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Commit list

4 granular GitEmoji commits:

\`\`\`
✨ (dashboard/api): Add createApiCapabilityClient factory delegating to openapi-fetch
♻️ (dashboard/api): Swap default capabilityClient export to the API-backed client
✅ (dashboard/api): Add createApiCapabilityClient happy-path tests
✅ (dashboard/api): Test API factory error path raises with mock 4xx/5xx response
\`\`\`