### PR TITLE
[AAASM-1440] ✨ (docker): Add Dockerfile.go-1.26-alpine base image

### DIFF
--- a/docker/Dockerfile.go-1.26-alpine
+++ b/docker/Dockerfile.go-1.26-alpine
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1.7
+#
+# AAASM Go 1.26 base image
+# ------------------------
+# Ships the AAASM Go SDK (`github.com/agent-assembly/go-sdk`) + the
+# `aasm` operator binary pre-installed, so containerised agents get
+# governance on first run with no extra install step.
+#
+# Use:
+#   FROM ghcr.io/agent-assembly/go:1.26-alpine
+#
+# Transitional install path (will simplify once this Story ships):
+#   * `aasm` is built from source until AAASM-1201 publishes a curl|sh
+#     installer; stage 1 collapses to a `COPY --from=ghcr.io/...` then.
+#
+# Note: unlike Python and Node, the Go SDK does not need a PyPI/npm
+# equivalent — Go's `go install` reads directly from git, so no
+# downstream publish-to-registry Story is needed for the SDK install.
+#
+# Issue: AAASM-1440 (sub-task of AAASM-1204 / F114)
+# Epic:  AAASM-1199 (Release & Distribution Pipeline)
+
+# -----------------------------------------------------------------------------
+# Stage 1 — build the `aasm` binary from source.
+# Same builder as the Python and Node variants; Docker layer-shares the
+# cargo cache across all three images during multi-image CI builds.
+# -----------------------------------------------------------------------------
+FROM rust:alpine AS aasm-builder
+
+RUN apk add --no-cache musl-dev protobuf-dev openssl-dev pkgconfig
+
+WORKDIR /build
+
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/target \
+    cargo build --release -p aa-cli --bin aasm \
+ && cp /build/target/release/aasm /usr/local/bin/aasm
+
+# -----------------------------------------------------------------------------
+# Stage 2 — Go 1.26 runtime.
+# Using the alpine variant for size (Go base images publish both -alpine
+# and -bookworm; alpine is the smaller default).
+# -----------------------------------------------------------------------------
+FROM golang:1.26-alpine
+
+# git is needed at build time for `go install` to fetch the SDK from
+# its git repository. Keep it installed — `go install` for downstream
+# user packages also needs git at runtime in many real-world use cases,
+# and Go's alpine image already includes it.
+
+# Drop the prebuilt `aasm` binary into the image PATH.
+COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
+
+# Install the AAASM Go SDK. `go install` uses Go's native git-based
+# distribution model — no registry-publish prerequisite (unlike pip/npm).
+RUN go install github.com/AI-agent-assembly/go-sdk/...@latest
+
+# Build-time smoke tests — fail the image build (not a runtime surprise)
+# if either side of the install ends up broken.
+RUN aasm --version
+RUN go list github.com/agent-assembly/go-sdk
+
+LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+      org.opencontainers.image.description="AAASM governed Go 1.26 agent base image" \
+      org.opencontainers.image.licenses="Apache-2.0"


### PR DESCRIPTION
## Description

Adds `docker/Dockerfile.go-1.26-alpine` — the Go variant of the latest-per-language base images shipping under AAASM-1204 (F114). Same multi-stage shape as the Python (PR #474) + Node (PR #475) siblings: cargo-builder for `aasm`, `golang:1.26-alpine` runtime + `go install` of the AAASM Go SDK.

Story: [AAASM-1204](https://lightning-dust-mite.atlassian.net/browse/AAASM-1204).
Sub-task: [AAASM-1440](https://lightning-dust-mite.atlassian.net/browse/AAASM-1440).
Sibling PRs: [#474](https://github.com/AI-agent-assembly/agent-assembly/pull/474) (Python 3.14), [#475](https://github.com/AI-agent-assembly/agent-assembly/pull/475) (Node 24).

## Type of Change

- [x] ✨ New feature (Docker base image)

## Breaking Changes

- [x] No

## What this PR ships

`docker/Dockerfile.go-1.26-alpine` (67 lines):

* **Stage 1 — `aasm-builder`**: same alpine/cargo stage as Python + Node variants. Cargo cache layer-shared across all three images in multi-image CI builds.
* **Stage 2 — runtime**: `golang:1.26-alpine`, `COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm`, then `go install github.com/AI-agent-assembly/go-sdk/...@latest`. Note: unlike Python (which needs `git` apt-install then purge) and Node (same pattern), the Go alpine base image already ships `git` so no install/purge dance is needed.
* **Build-time smoke tests**: `RUN aasm --version` + `RUN go list github.com/agent-assembly/go-sdk`.
* OCI labels for source / description / license.

## Transitional install paths (documented in Dockerfile header)

| What | Now | After |
|---|---|---|
| `aasm` binary | Built from source in stage 1 | `COPY --from=ghcr.io/...` once [AAASM-1201](https://lightning-dust-mite.atlassian.net/browse/AAASM-1201) ships the curl\|sh installer |
| Go SDK | `go install` from git | **No registry-publish prerequisite** — Go's native distribution is git-based. No follow-up Story needed for the SDK install line |

## Why this Dockerfile differs from the Python + Node siblings

* **No `git` install/purge dance** — alpine's `golang` image already includes git for `go install`'s native git-based fetches.
* **No `--no-cache-dir` or equivalent** — `go install` writes into `$GOPATH/pkg/mod` (cleanable separately if size concerns appear in the verification report).

Both Dockerfiles still match the shared multi-stage cargo-builder shape, so the cargo layer cache reuses across all three image builds.

## Testing

Local Docker build deferred to AAASM-1226 verification (Sprint 4) per the F114 phasing plan.

## Compressed image size

Measured + reported in AAASM-1226 verification report. Target per parent Story AC: <250 MB. Go base images tend to be smaller than Python or Node so this should land well under target.

## Commit history

```
✨ (docker): Add Dockerfile.go-1.26-alpine base image for governed Go agents
```

## Checklist

- [x] Dockerfile follows the multi-stage / BuildKit-cache pattern (matches PR #474 + #475 + `aa-runtime/Dockerfile`)
- [x] Build-time smoke tests included
- [x] Transitional install path documented inline + in PR description
- [x] OCI labels set
- [ ] Local Docker build smoke — deferred to AAASM-1226

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-1204]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1440]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1201]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ