### PR TITLE
[AAASM-1443] ✨ (docker): Add Python 3.10-3.13 base image variants (F114b)

### DIFF
--- a/docker/Dockerfile.python-3.10-slim
+++ b/docker/Dockerfile.python-3.10-slim
@@ -1,0 +1,74 @@
+# syntax=docker/dockerfile:1.7
+#
+# AAASM Python 3.10 base image
+# ----------------------------
+# Ships the AAASM Python SDK (`agent_assembly`) + the `aasm` operator
+# binary pre-installed, so containerised agents get governance on first
+# run with no extra install step.
+#
+# Use:
+#   FROM ghcr.io/agent-assembly/python:3.10-slim
+#
+# Transitional install paths (will simplify once these Stories ship):
+#   * `aasm` is built from source until AAASM-1201 publishes a curl|sh
+#     installer; stage 1 collapses to a `COPY --from=ghcr.io/...` then.
+#   * The Python SDK is installed from git until AAASM-1202 publishes
+#     `agent-assembly` to PyPI; the `pip install` line simplifies then.
+#
+# Issue: AAASM-1443 (sub-task of AAASM-1441 / F114b)
+# Epic:  AAASM-1199 (Release & Distribution Pipeline)
+
+# -----------------------------------------------------------------------------
+# Stage 1 — build the `aasm` binary from source.
+# -----------------------------------------------------------------------------
+FROM rust:alpine AS aasm-builder
+
+# Build deps. `protobuf-dev` is required by aa-proto's `build.rs`; `musl-dev`
+# + `openssl-dev` + `pkgconfig` round out the toolchain for a static musl
+# build that is portable across glibc and musl runtimes.
+RUN apk add --no-cache musl-dev protobuf-dev openssl-dev pkgconfig
+
+WORKDIR /build
+
+# BuildKit cache mounts let us re-use the cargo registry and target dir
+# across PR builds — same pattern as `aa-runtime/Dockerfile`.
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/target \
+    cargo build --release -p aa-cli --bin aasm \
+ && cp /build/target/release/aasm /usr/local/bin/aasm
+
+# -----------------------------------------------------------------------------
+# Stage 2 — Python 3.10 runtime.
+# -----------------------------------------------------------------------------
+FROM python:3.10-slim
+
+# git is needed at build time only — to pip-install the SDK from its git
+# repository (transitional path until AAASM-1202 publishes to PyPI).
+# Remove it at the end of the layer so it doesn't bloat the runtime image.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git \
+ && rm -rf /var/lib/apt/lists/*
+
+# Drop the prebuilt `aasm` binary into the image PATH.
+COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
+
+# Install the AAASM Python SDK. Transitional git source; switches to
+# `pip install agent-assembly` once AAASM-1202 lands.
+RUN pip install --no-cache-dir \
+        'agent-assembly @ git+https://github.com/AI-agent-assembly/python-sdk.git'
+
+# Build-time smoke tests — fail the image build (not a runtime surprise)
+# if either side of the install ends up broken.
+RUN aasm --version
+RUN python -c "from agent_assembly import init_assembly"
+
+# Remove git after install to keep the runtime image lean.
+RUN apt-get purge -y git \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
+
+LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+      org.opencontainers.image.description="AAASM governed Python 3.10 agent base image" \
+      org.opencontainers.image.licenses="Apache-2.0"

--- a/docker/Dockerfile.python-3.11-slim
+++ b/docker/Dockerfile.python-3.11-slim
@@ -1,0 +1,74 @@
+# syntax=docker/dockerfile:1.7
+#
+# AAASM Python 3.11 base image
+# ----------------------------
+# Ships the AAASM Python SDK (`agent_assembly`) + the `aasm` operator
+# binary pre-installed, so containerised agents get governance on first
+# run with no extra install step.
+#
+# Use:
+#   FROM ghcr.io/agent-assembly/python:3.11-slim
+#
+# Transitional install paths (will simplify once these Stories ship):
+#   * `aasm` is built from source until AAASM-1201 publishes a curl|sh
+#     installer; stage 1 collapses to a `COPY --from=ghcr.io/...` then.
+#   * The Python SDK is installed from git until AAASM-1202 publishes
+#     `agent-assembly` to PyPI; the `pip install` line simplifies then.
+#
+# Issue: AAASM-1443 (sub-task of AAASM-1441 / F114b)
+# Epic:  AAASM-1199 (Release & Distribution Pipeline)
+
+# -----------------------------------------------------------------------------
+# Stage 1 — build the `aasm` binary from source.
+# -----------------------------------------------------------------------------
+FROM rust:alpine AS aasm-builder
+
+# Build deps. `protobuf-dev` is required by aa-proto's `build.rs`; `musl-dev`
+# + `openssl-dev` + `pkgconfig` round out the toolchain for a static musl
+# build that is portable across glibc and musl runtimes.
+RUN apk add --no-cache musl-dev protobuf-dev openssl-dev pkgconfig
+
+WORKDIR /build
+
+# BuildKit cache mounts let us re-use the cargo registry and target dir
+# across PR builds — same pattern as `aa-runtime/Dockerfile`.
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/target \
+    cargo build --release -p aa-cli --bin aasm \
+ && cp /build/target/release/aasm /usr/local/bin/aasm
+
+# -----------------------------------------------------------------------------
+# Stage 2 — Python 3.11 runtime.
+# -----------------------------------------------------------------------------
+FROM python:3.11-slim
+
+# git is needed at build time only — to pip-install the SDK from its git
+# repository (transitional path until AAASM-1202 publishes to PyPI).
+# Remove it at the end of the layer so it doesn't bloat the runtime image.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git \
+ && rm -rf /var/lib/apt/lists/*
+
+# Drop the prebuilt `aasm` binary into the image PATH.
+COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
+
+# Install the AAASM Python SDK. Transitional git source; switches to
+# `pip install agent-assembly` once AAASM-1202 lands.
+RUN pip install --no-cache-dir \
+        'agent-assembly @ git+https://github.com/AI-agent-assembly/python-sdk.git'
+
+# Build-time smoke tests — fail the image build (not a runtime surprise)
+# if either side of the install ends up broken.
+RUN aasm --version
+RUN python -c "from agent_assembly import init_assembly"
+
+# Remove git after install to keep the runtime image lean.
+RUN apt-get purge -y git \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
+
+LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+      org.opencontainers.image.description="AAASM governed Python 3.11 agent base image" \
+      org.opencontainers.image.licenses="Apache-2.0"

--- a/docker/Dockerfile.python-3.12-slim
+++ b/docker/Dockerfile.python-3.12-slim
@@ -1,0 +1,74 @@
+# syntax=docker/dockerfile:1.7
+#
+# AAASM Python 3.12 base image
+# ----------------------------
+# Ships the AAASM Python SDK (`agent_assembly`) + the `aasm` operator
+# binary pre-installed, so containerised agents get governance on first
+# run with no extra install step.
+#
+# Use:
+#   FROM ghcr.io/agent-assembly/python:3.12-slim
+#
+# Transitional install paths (will simplify once these Stories ship):
+#   * `aasm` is built from source until AAASM-1201 publishes a curl|sh
+#     installer; stage 1 collapses to a `COPY --from=ghcr.io/...` then.
+#   * The Python SDK is installed from git until AAASM-1202 publishes
+#     `agent-assembly` to PyPI; the `pip install` line simplifies then.
+#
+# Issue: AAASM-1443 (sub-task of AAASM-1441 / F114b)
+# Epic:  AAASM-1199 (Release & Distribution Pipeline)
+
+# -----------------------------------------------------------------------------
+# Stage 1 — build the `aasm` binary from source.
+# -----------------------------------------------------------------------------
+FROM rust:alpine AS aasm-builder
+
+# Build deps. `protobuf-dev` is required by aa-proto's `build.rs`; `musl-dev`
+# + `openssl-dev` + `pkgconfig` round out the toolchain for a static musl
+# build that is portable across glibc and musl runtimes.
+RUN apk add --no-cache musl-dev protobuf-dev openssl-dev pkgconfig
+
+WORKDIR /build
+
+# BuildKit cache mounts let us re-use the cargo registry and target dir
+# across PR builds — same pattern as `aa-runtime/Dockerfile`.
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/target \
+    cargo build --release -p aa-cli --bin aasm \
+ && cp /build/target/release/aasm /usr/local/bin/aasm
+
+# -----------------------------------------------------------------------------
+# Stage 2 — Python 3.12 runtime.
+# -----------------------------------------------------------------------------
+FROM python:3.12-slim
+
+# git is needed at build time only — to pip-install the SDK from its git
+# repository (transitional path until AAASM-1202 publishes to PyPI).
+# Remove it at the end of the layer so it doesn't bloat the runtime image.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git \
+ && rm -rf /var/lib/apt/lists/*
+
+# Drop the prebuilt `aasm` binary into the image PATH.
+COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
+
+# Install the AAASM Python SDK. Transitional git source; switches to
+# `pip install agent-assembly` once AAASM-1202 lands.
+RUN pip install --no-cache-dir \
+        'agent-assembly @ git+https://github.com/AI-agent-assembly/python-sdk.git'
+
+# Build-time smoke tests — fail the image build (not a runtime surprise)
+# if either side of the install ends up broken.
+RUN aasm --version
+RUN python -c "from agent_assembly import init_assembly"
+
+# Remove git after install to keep the runtime image lean.
+RUN apt-get purge -y git \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
+
+LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+      org.opencontainers.image.description="AAASM governed Python 3.12 agent base image" \
+      org.opencontainers.image.licenses="Apache-2.0"

--- a/docker/Dockerfile.python-3.13-slim
+++ b/docker/Dockerfile.python-3.13-slim
@@ -1,0 +1,74 @@
+# syntax=docker/dockerfile:1.7
+#
+# AAASM Python 3.13 base image
+# ----------------------------
+# Ships the AAASM Python SDK (`agent_assembly`) + the `aasm` operator
+# binary pre-installed, so containerised agents get governance on first
+# run with no extra install step.
+#
+# Use:
+#   FROM ghcr.io/agent-assembly/python:3.13-slim
+#
+# Transitional install paths (will simplify once these Stories ship):
+#   * `aasm` is built from source until AAASM-1201 publishes a curl|sh
+#     installer; stage 1 collapses to a `COPY --from=ghcr.io/...` then.
+#   * The Python SDK is installed from git until AAASM-1202 publishes
+#     `agent-assembly` to PyPI; the `pip install` line simplifies then.
+#
+# Issue: AAASM-1443 (sub-task of AAASM-1441 / F114b)
+# Epic:  AAASM-1199 (Release & Distribution Pipeline)
+
+# -----------------------------------------------------------------------------
+# Stage 1 — build the `aasm` binary from source.
+# -----------------------------------------------------------------------------
+FROM rust:alpine AS aasm-builder
+
+# Build deps. `protobuf-dev` is required by aa-proto's `build.rs`; `musl-dev`
+# + `openssl-dev` + `pkgconfig` round out the toolchain for a static musl
+# build that is portable across glibc and musl runtimes.
+RUN apk add --no-cache musl-dev protobuf-dev openssl-dev pkgconfig
+
+WORKDIR /build
+
+# BuildKit cache mounts let us re-use the cargo registry and target dir
+# across PR builds — same pattern as `aa-runtime/Dockerfile`.
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/target \
+    cargo build --release -p aa-cli --bin aasm \
+ && cp /build/target/release/aasm /usr/local/bin/aasm
+
+# -----------------------------------------------------------------------------
+# Stage 2 — Python 3.13 runtime.
+# -----------------------------------------------------------------------------
+FROM python:3.13-slim
+
+# git is needed at build time only — to pip-install the SDK from its git
+# repository (transitional path until AAASM-1202 publishes to PyPI).
+# Remove it at the end of the layer so it doesn't bloat the runtime image.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git \
+ && rm -rf /var/lib/apt/lists/*
+
+# Drop the prebuilt `aasm` binary into the image PATH.
+COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
+
+# Install the AAASM Python SDK. Transitional git source; switches to
+# `pip install agent-assembly` once AAASM-1202 lands.
+RUN pip install --no-cache-dir \
+        'agent-assembly @ git+https://github.com/AI-agent-assembly/python-sdk.git'
+
+# Build-time smoke tests — fail the image build (not a runtime surprise)
+# if either side of the install ends up broken.
+RUN aasm --version
+RUN python -c "from agent_assembly import init_assembly"
+
+# Remove git after install to keep the runtime image lean.
+RUN apt-get purge -y git \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
+
+LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+      org.opencontainers.image.description="AAASM governed Python 3.13 agent base image" \
+      org.opencontainers.image.licenses="Apache-2.0"


### PR DESCRIPTION
## Summary

Fan out the F114 Python base-image template (currently shipping for 3.14 only via PR #474 / AAASM-1224) to the older still-supported Python versions: 3.10, 3.11, 3.12, 3.13.

4 new Dockerfiles under `docker/`, each a near-byte-identical copy of `docker/Dockerfile.python-3.14-slim` — only the stage-2 `FROM python:X-slim` line and the `org.opencontainers.image.description` label change per variant.

Part of AAASM-1441 (F114b) — Phase 2 of F114, splitting the version fan-out work from AAASM-1204's release-critical "latest per language" Sprint 3 cut.

## Why

* Users on stable / LTS Python upgrade paths need pinnable AAASM Docker tags for the runtime they actually deploy on.
* Python 3.10 (security-fix support through late 2026), 3.11 (security-fix), 3.12 (bug-fix), 3.13 (current bug-fix) all qualify.
* EOL versions (≤ 3.9) deliberately excluded — shipping them as official AAASM base images would expose users to known-EOL runtime CVEs.

## Commits (4 — one per file, per workspace granular-commit convention)

| # | Subject |
| --- | --- |
| 1 | `✨ (docker): Add Dockerfile.python-3.10-slim base image variant` |
| 2 | `✨ (docker): Add Dockerfile.python-3.11-slim base image variant` |
| 3 | `✨ (docker): Add Dockerfile.python-3.12-slim base image variant` |
| 4 | `✨ (docker): Add Dockerfile.python-3.13-slim base image variant` |

## Diff shape

Each Dockerfile differs from `docker/Dockerfile.python-3.14-slim` (the F114 template merged today via PR #474) on exactly **two lines**:

```diff
-FROM python:3.14-slim
+FROM python:3.X-slim
…
-      org.opencontainers.image.description="AAASM governed Python 3.14 agent base image" \
+      org.opencontainers.image.description="AAASM governed Python 3.X agent base image" \
```

Everything else carries over verbatim:
* Stage 1 `rust:alpine AS aasm-builder` (cargo build `-p aa-cli --bin aasm` with BuildKit cache mounts)
* Stage 2 `git` install/purge dance (transitional, until AAASM-1202 publishes the Python SDK to PyPI)
* `pip install 'agent-assembly @ git+…/python-sdk.git'` (transitional path)
* Build-time smoke tests: `RUN aasm --version` + `RUN python -c "from agent_assembly import init_assembly"`
* OCI labels: `source`, `licenses=Apache-2.0`

## Phasing note (deferred)

Per the F114b plan, build/publish/smoke validation is deferred to the verify sub-task (AAASM-1447 / ST-5) after the workflow matrix extension (AAASM-1446 / ST-4) lands — same phasing AAASM-1204 used for the F114 trio (no build verification on the Dockerfile-author PRs themselves; verification batched in AAASM-1226). This keeps each PR small and bisectable.

## Test plan

* [ ] `cargo deny check` and `cargo fmt --check` skip cleanly (no Rust changes — see lefthook output)
* [ ] CI workflow extension (separate PR under AAASM-1446) will pick up these new Dockerfiles in the 11-variant matrix
* [ ] Local build + size measurement + smoke runs captured in `verification-reports/AAASM-1441.md` under AAASM-1447

## Related

* Parent: AAASM-1441 (F114b: Extended Docker base image variants)
* Template: AAASM-1224 / PR #474 (F114 Python 3.14)
* Epic: AAASM-1199 (Release & Distribution Pipeline)
* Sibling PRs (today, parallel): Node v20/v22 under AAASM-1444, Go 1.24/1.25 under AAASM-1445