### PR TITLE
[AAASM-1444] ✨ (docker): Add Node.js v20/v22 base image variants (F114b)

### DIFF
--- a/docker/Dockerfile.node-20-slim
+++ b/docker/Dockerfile.node-20-slim
@@ -1,0 +1,70 @@
+# syntax=docker/dockerfile:1.7
+#
+# AAASM Node.js 20 base image
+# ---------------------------
+# Ships the AAASM TypeScript/JavaScript SDK (`@agent-assembly/sdk`) + the
+# `aasm` operator binary pre-installed, so containerised agents get
+# governance on first run with no extra install step.
+#
+# Use:
+#   FROM ghcr.io/agent-assembly/node:20-slim
+#
+# Transitional install paths (will simplify once these Stories ship):
+#   * `aasm` is built from source until AAASM-1201 publishes a curl|sh
+#     installer; stage 1 collapses to a `COPY --from=ghcr.io/...` then.
+#   * The Node SDK is installed from git until AAASM-1203 publishes
+#     `@agent-assembly/sdk` to npm; the `npm install` line simplifies then.
+#
+# Issue: AAASM-1444 (sub-task of AAASM-1441 / F114b)
+# Epic:  AAASM-1199 (Release & Distribution Pipeline)
+
+# -----------------------------------------------------------------------------
+# Stage 1 — build the `aasm` binary from source.
+# Same builder as the Python and Go variants; Docker layer-shares the
+# cargo cache across all three images during multi-image CI builds.
+# -----------------------------------------------------------------------------
+FROM rust:alpine AS aasm-builder
+
+RUN apk add --no-cache musl-dev protobuf-dev openssl-dev pkgconfig
+
+WORKDIR /build
+
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/target \
+    cargo build --release -p aa-cli --bin aasm \
+ && cp /build/target/release/aasm /usr/local/bin/aasm
+
+# -----------------------------------------------------------------------------
+# Stage 2 — Node.js 20 runtime.
+# -----------------------------------------------------------------------------
+FROM node:20-slim
+
+# git is needed at build time only — to npm-install the SDK from its git
+# repository (transitional path until AAASM-1203 publishes to npm).
+# Remove it at the end of the layer so it doesn't bloat the runtime image.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git \
+ && rm -rf /var/lib/apt/lists/*
+
+# Drop the prebuilt `aasm` binary into the image PATH.
+COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
+
+# Install the AAASM Node SDK. Transitional git source; switches to
+# `npm install @agent-assembly/sdk` once AAASM-1203 lands.
+RUN npm install -g 'github:AI-agent-assembly/node-sdk'
+
+# Build-time smoke tests — fail the image build (not a runtime surprise)
+# if either side of the install ends up broken.
+RUN aasm --version
+RUN node -e "require('@agent-assembly/sdk')"
+
+# Remove git after install to keep the runtime image lean.
+RUN apt-get purge -y git \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
+
+LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+      org.opencontainers.image.description="AAASM governed Node.js 20 agent base image" \
+      org.opencontainers.image.licenses="Apache-2.0"

--- a/docker/Dockerfile.node-22-slim
+++ b/docker/Dockerfile.node-22-slim
@@ -1,0 +1,70 @@
+# syntax=docker/dockerfile:1.7
+#
+# AAASM Node.js 22 base image
+# ---------------------------
+# Ships the AAASM TypeScript/JavaScript SDK (`@agent-assembly/sdk`) + the
+# `aasm` operator binary pre-installed, so containerised agents get
+# governance on first run with no extra install step.
+#
+# Use:
+#   FROM ghcr.io/agent-assembly/node:22-slim
+#
+# Transitional install paths (will simplify once these Stories ship):
+#   * `aasm` is built from source until AAASM-1201 publishes a curl|sh
+#     installer; stage 1 collapses to a `COPY --from=ghcr.io/...` then.
+#   * The Node SDK is installed from git until AAASM-1203 publishes
+#     `@agent-assembly/sdk` to npm; the `npm install` line simplifies then.
+#
+# Issue: AAASM-1444 (sub-task of AAASM-1441 / F114b)
+# Epic:  AAASM-1199 (Release & Distribution Pipeline)
+
+# -----------------------------------------------------------------------------
+# Stage 1 — build the `aasm` binary from source.
+# Same builder as the Python and Go variants; Docker layer-shares the
+# cargo cache across all three images during multi-image CI builds.
+# -----------------------------------------------------------------------------
+FROM rust:alpine AS aasm-builder
+
+RUN apk add --no-cache musl-dev protobuf-dev openssl-dev pkgconfig
+
+WORKDIR /build
+
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/target \
+    cargo build --release -p aa-cli --bin aasm \
+ && cp /build/target/release/aasm /usr/local/bin/aasm
+
+# -----------------------------------------------------------------------------
+# Stage 2 — Node.js 22 runtime.
+# -----------------------------------------------------------------------------
+FROM node:22-slim
+
+# git is needed at build time only — to npm-install the SDK from its git
+# repository (transitional path until AAASM-1203 publishes to npm).
+# Remove it at the end of the layer so it doesn't bloat the runtime image.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends git \
+ && rm -rf /var/lib/apt/lists/*
+
+# Drop the prebuilt `aasm` binary into the image PATH.
+COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
+
+# Install the AAASM Node SDK. Transitional git source; switches to
+# `npm install @agent-assembly/sdk` once AAASM-1203 lands.
+RUN npm install -g 'github:AI-agent-assembly/node-sdk'
+
+# Build-time smoke tests — fail the image build (not a runtime surprise)
+# if either side of the install ends up broken.
+RUN aasm --version
+RUN node -e "require('@agent-assembly/sdk')"
+
+# Remove git after install to keep the runtime image lean.
+RUN apt-get purge -y git \
+ && apt-get autoremove -y \
+ && rm -rf /var/lib/apt/lists/*
+
+LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+      org.opencontainers.image.description="AAASM governed Node.js 22 agent base image" \
+      org.opencontainers.image.licenses="Apache-2.0"


### PR DESCRIPTION
## Summary

Fan out the F114 Node.js base-image template (currently shipping for v24 only via PR #475 / AAASM-1439) to the older still-supported LTS versions: v20 (Maintenance LTS through April 2026) and v22 (Active LTS through April 2027).

2 new Dockerfiles under `docker/`, each a near-byte-identical copy of `docker/Dockerfile.node-24-slim` — only the stage-2 `FROM node:N-slim` line and the `org.opencontainers.image.description` label change per variant.

Part of AAASM-1441 (F114b) — Phase 2 of F114, splitting the version fan-out work from AAASM-1204's release-critical "latest per language" Sprint 3 cut.

## Why

* Users on Node LTS upgrade tracks need pinnable AAASM Docker tags for the runtime they actually deploy on.
* Node v20 (Maintenance LTS through April 2026) covers users still on the older LTS line; Node v22 (current Active LTS) covers the mainstream LTS deployment path.
* Older / non-LTS / EOL majors (v16, v18, v21, v23) deliberately excluded — they are end-of-support upstream.

## Commits (2 — one per file, per workspace granular-commit convention)

| # | Subject |
| --- | --- |
| 1 | `✨ (docker): Add Dockerfile.node-20-slim base image variant` |
| 2 | `✨ (docker): Add Dockerfile.node-22-slim base image variant` |

## Diff shape

Each Dockerfile differs from `docker/Dockerfile.node-24-slim` (the F114 template merged today via PR #475) on exactly **two lines**:

```diff
-FROM node:24-slim
+FROM node:N-slim
…
-      org.opencontainers.image.description="AAASM governed Node.js 24 agent base image" \
+      org.opencontainers.image.description="AAASM governed Node.js N agent base image" \
```

Everything else carries over verbatim:
* Stage 1 `rust:alpine AS aasm-builder` (cargo build `-p aa-cli --bin aasm` with BuildKit cache mounts — shared across Python/Node/Go variants)
* Stage 2 `git` install/purge dance (transitional, until AAASM-1203 publishes the Node SDK to npm)
* `npm install -g 'github:AI-agent-assembly/node-sdk'` (transitional path)
* Build-time smoke tests: `RUN aasm --version` + `RUN node -e "require('@agent-assembly/sdk')"`
* OCI labels: `source`, `licenses=Apache-2.0`

## Phasing note (deferred)

Per the F114b plan, build/publish/smoke validation is deferred to the verify sub-task (AAASM-1447 / ST-5) after the workflow matrix extension (AAASM-1446 / ST-4) lands — same phasing AAASM-1204 used for the F114 trio. This keeps each PR small and bisectable.

## Test plan

* [ ] `cargo deny check` and `cargo fmt --check` skip cleanly (no Rust changes — see lefthook output)
* [ ] CI workflow extension (separate PR under AAASM-1446) will pick up these new Dockerfiles in the 11-variant matrix
* [ ] Local build + size measurement + smoke runs captured in `verification-reports/AAASM-1441.md` under AAASM-1447

## Related

* Parent: AAASM-1441 (F114b: Extended Docker base image variants)
* Template: AAASM-1439 / PR #475 (F114 Node v24)
* Epic: AAASM-1199 (Release & Distribution Pipeline)
* Sibling PRs (today, parallel): Python 3.10-3.13 under AAASM-1443 (#478), Go 1.24/1.25 under AAASM-1445