### PR TITLE
[AAASM-1445] ✨ (docker): Add Go 1.24/1.25 base image variants (F114b)

### DIFF
--- a/docker/Dockerfile.go-1.24-alpine
+++ b/docker/Dockerfile.go-1.24-alpine
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1.7
+#
+# AAASM Go 1.24 base image
+# ------------------------
+# Ships the AAASM Go SDK (`github.com/agent-assembly/go-sdk`) + the
+# `aasm` operator binary pre-installed, so containerised agents get
+# governance on first run with no extra install step.
+#
+# Use:
+#   FROM ghcr.io/agent-assembly/go:1.24-alpine
+#
+# Transitional install path (will simplify once this Story ships):
+#   * `aasm` is built from source until AAASM-1201 publishes a curl|sh
+#     installer; stage 1 collapses to a `COPY --from=ghcr.io/...` then.
+#
+# Note: unlike Python and Node, the Go SDK does not need a PyPI/npm
+# equivalent — Go's `go install` reads directly from git, so no
+# downstream publish-to-registry Story is needed for the SDK install.
+#
+# Issue: AAASM-1445 (sub-task of AAASM-1441 / F114b)
+# Epic:  AAASM-1199 (Release & Distribution Pipeline)
+
+# -----------------------------------------------------------------------------
+# Stage 1 — build the `aasm` binary from source.
+# Same builder as the Python and Node variants; Docker layer-shares the
+# cargo cache across all three images during multi-image CI builds.
+# -----------------------------------------------------------------------------
+FROM rust:alpine AS aasm-builder
+
+RUN apk add --no-cache musl-dev protobuf-dev openssl-dev pkgconfig
+
+WORKDIR /build
+
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/target \
+    cargo build --release -p aa-cli --bin aasm \
+ && cp /build/target/release/aasm /usr/local/bin/aasm
+
+# -----------------------------------------------------------------------------
+# Stage 2 — Go 1.24 runtime.
+# Using the alpine variant for size (Go base images publish both -alpine
+# and -bookworm; alpine is the smaller default).
+# -----------------------------------------------------------------------------
+FROM golang:1.24-alpine
+
+# git is needed at build time for `go install` to fetch the SDK from
+# its git repository. Keep it installed — `go install` for downstream
+# user packages also needs git at runtime in many real-world use cases,
+# and Go's alpine image already includes it.
+
+# Drop the prebuilt `aasm` binary into the image PATH.
+COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
+
+# Install the AAASM Go SDK. `go install` uses Go's native git-based
+# distribution model — no registry-publish prerequisite (unlike pip/npm).
+RUN go install github.com/AI-agent-assembly/go-sdk/...@latest
+
+# Build-time smoke tests — fail the image build (not a runtime surprise)
+# if either side of the install ends up broken.
+RUN aasm --version
+RUN go list github.com/agent-assembly/go-sdk
+
+LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+      org.opencontainers.image.description="AAASM governed Go 1.24 agent base image" \
+      org.opencontainers.image.licenses="Apache-2.0"

--- a/docker/Dockerfile.go-1.25-alpine
+++ b/docker/Dockerfile.go-1.25-alpine
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1.7
+#
+# AAASM Go 1.25 base image
+# ------------------------
+# Ships the AAASM Go SDK (`github.com/agent-assembly/go-sdk`) + the
+# `aasm` operator binary pre-installed, so containerised agents get
+# governance on first run with no extra install step.
+#
+# Use:
+#   FROM ghcr.io/agent-assembly/go:1.25-alpine
+#
+# Transitional install path (will simplify once this Story ships):
+#   * `aasm` is built from source until AAASM-1201 publishes a curl|sh
+#     installer; stage 1 collapses to a `COPY --from=ghcr.io/...` then.
+#
+# Note: unlike Python and Node, the Go SDK does not need a PyPI/npm
+# equivalent — Go's `go install` reads directly from git, so no
+# downstream publish-to-registry Story is needed for the SDK install.
+#
+# Issue: AAASM-1445 (sub-task of AAASM-1441 / F114b)
+# Epic:  AAASM-1199 (Release & Distribution Pipeline)
+
+# -----------------------------------------------------------------------------
+# Stage 1 — build the `aasm` binary from source.
+# Same builder as the Python and Node variants; Docker layer-shares the
+# cargo cache across all three images during multi-image CI builds.
+# -----------------------------------------------------------------------------
+FROM rust:alpine AS aasm-builder
+
+RUN apk add --no-cache musl-dev protobuf-dev openssl-dev pkgconfig
+
+WORKDIR /build
+
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/build/target \
+    cargo build --release -p aa-cli --bin aasm \
+ && cp /build/target/release/aasm /usr/local/bin/aasm
+
+# -----------------------------------------------------------------------------
+# Stage 2 — Go 1.25 runtime.
+# Using the alpine variant for size (Go base images publish both -alpine
+# and -bookworm; alpine is the smaller default).
+# -----------------------------------------------------------------------------
+FROM golang:1.25-alpine
+
+# git is needed at build time for `go install` to fetch the SDK from
+# its git repository. Keep it installed — `go install` for downstream
+# user packages also needs git at runtime in many real-world use cases,
+# and Go's alpine image already includes it.
+
+# Drop the prebuilt `aasm` binary into the image PATH.
+COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
+
+# Install the AAASM Go SDK. `go install` uses Go's native git-based
+# distribution model — no registry-publish prerequisite (unlike pip/npm).
+RUN go install github.com/AI-agent-assembly/go-sdk/...@latest
+
+# Build-time smoke tests — fail the image build (not a runtime surprise)
+# if either side of the install ends up broken.
+RUN aasm --version
+RUN go list github.com/agent-assembly/go-sdk
+
+LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+      org.opencontainers.image.description="AAASM governed Go 1.25 agent base image" \
+      org.opencontainers.image.licenses="Apache-2.0"


### PR DESCRIPTION
## Summary

Fan out the F114 Go base-image template (currently shipping for 1.26 only via PR #476 / AAASM-1440) to the older versions: 1.24 (one-version courtesy buffer beyond Go's official last-2 policy) and 1.25 (officially supported per Go's last-2 policy).

2 new Dockerfiles under `docker/`, each a near-byte-identical copy of `docker/Dockerfile.go-1.26-alpine` — only the stage-2 `FROM golang:X.Y-alpine` line and the `org.opencontainers.image.description` label change per variant.

Part of AAASM-1441 (F114b) — Phase 2 of F114, splitting the version fan-out work from AAASM-1204's release-critical "latest per language" Sprint 3 cut.

## Why

* Users on stable Go upgrade tracks need pinnable AAASM Docker tags for the runtime they actually deploy on.
* Go 1.25 (one minor behind 1.26) is officially supported per Go's last-2 stable policy.
* Go 1.24 is shipped as a one-version courtesy buffer — Go's official policy supports the last two minors only, but real-world rollouts lag.
* Older Go versions (≤ 1.23) deliberately excluded — they are out of Go's official support window.

## Commits (2 — one per file, per workspace granular-commit convention)

| # | Subject |
| --- | --- |
| 1 | `✨ (docker): Add Dockerfile.go-1.24-alpine base image variant` |
| 2 | `✨ (docker): Add Dockerfile.go-1.25-alpine base image variant` |

## Diff shape

Each Dockerfile differs from `docker/Dockerfile.go-1.26-alpine` (the F114 template merged today via PR #476) on exactly **two lines**:

```diff
-FROM golang:1.26-alpine
+FROM golang:1.X-alpine
…
-      org.opencontainers.image.description="AAASM governed Go 1.26 agent base image" \
+      org.opencontainers.image.description="AAASM governed Go 1.X agent base image" \
```

Everything else carries over verbatim:
* Stage 1 `rust:alpine AS aasm-builder` (cargo build `-p aa-cli --bin aasm` with BuildKit cache mounts — shared across Python/Node/Go variants)
* Stage 2 uses `golang:X.Y-alpine` (alpine variant for size; alpine already ships git, so no `git` install/purge dance needed unlike the Python/Node variants)
* `go install github.com/AI-agent-assembly/go-sdk/...@latest` (Go's native git-based distribution — no PyPI/npm-equivalent prerequisite)
* Build-time smoke tests: `RUN aasm --version` + `RUN go list github.com/agent-assembly/go-sdk`
* OCI labels: `source`, `licenses=Apache-2.0`

## Phasing note (deferred)

Per the F114b plan, build/publish/smoke validation is deferred to the verify sub-task (AAASM-1447 / ST-5) after the workflow matrix extension (AAASM-1446 / ST-4) lands — same phasing AAASM-1204 used for the F114 trio. This keeps each PR small and bisectable.

## Test plan

* [ ] `cargo deny check` and `cargo fmt --check` skip cleanly (no Rust changes — see lefthook output)
* [ ] CI workflow extension (separate PR under AAASM-1446) will pick up these new Dockerfiles in the 11-variant matrix
* [ ] Local build + size measurement + smoke runs captured in `verification-reports/AAASM-1441.md` under AAASM-1447

## Related

* Parent: AAASM-1441 (F114b: Extended Docker base image variants)
* Template: AAASM-1440 / PR #476 (F114 Go 1.26)
* Epic: AAASM-1199 (Release & Distribution Pipeline)
* Sibling PRs (today, parallel): Python 3.10-3.13 under AAASM-1443 (#478), Node v20/v22 under AAASM-1444 (#479)