### PR TITLE
[AAASM-1397] ✨ (iam): Add Rotate API key flow on Service Identities tab

### DIFF
--- a/dashboard/src/features/iam/ApiKeyList.css
+++ b/dashboard/src/features/iam/ApiKeyList.css
@@ -69,6 +69,26 @@
   cursor: not-allowed;
 }
 
+/* AAASM-1397 — Rotate action sits next to Revoke; uses the accent
+   tone (vs Revoke's danger tone) since it's a routine maintenance
+   operation, not destructive. */
+.iam-api-key-list__rotate-btn {
+  border: 1px solid var(--shell-accent);
+  background: transparent;
+  color: var(--shell-accent);
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.6rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  margin-right: 0.25rem;
+}
+
+.iam-api-key-list__rotate-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .iam-api-key-list__row--revoked {
   opacity: 0.55;
 }

--- a/dashboard/src/features/iam/ApiKeyList.test.tsx
+++ b/dashboard/src/features/iam/ApiKeyList.test.tsx
@@ -1,10 +1,11 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ApiKeyList } from './ApiKeyList'
+import { _apiKeysInternal } from './apiKeys'
 import { ToastProvider } from '../../components/ToastProvider'
-import type { ApiKey } from './types'
+import type { ApiKey, GeneratedApiKey } from './types'
 
 // In-memory ApiKey store is wired through `useApiKeysQuery` which reads from
 // the module-level seed in `apiKeys.ts`. The shape comes from there, so we
@@ -114,5 +115,124 @@ describe('ApiKeyList — Story-level column vocabulary (AAASM-1399)', () => {
 
     await userEvent.click(screen.getByTestId(`api-key-revoke-${SEED_KEY_1_ID}`))
     expect(onSelect).not.toHaveBeenCalled()
+  })
+})
+
+describe('ApiKeyList — Rotate API key flow (AAASM-1397)', () => {
+  beforeEach(() => {
+    _apiKeysInternal.reset()
+  })
+
+  it('renders a Rotate action on every active row, but never on revoked rows', async () => {
+    render(<ApiKeyList />, { wrapper: Wrapper })
+    await screen.findByTestId('api-key-row-key-1')
+
+    // key-1 and key-2 are active; key-3 is revoked in the seed.
+    expect(screen.getByTestId('api-key-rotate-key-1')).toBeInTheDocument()
+    expect(screen.getByTestId('api-key-rotate-key-2')).toBeInTheDocument()
+    expect(screen.queryByTestId('api-key-rotate-key-3')).not.toBeInTheDocument()
+  })
+
+  it('clicking Rotate opens the ConfirmRotate modal without firing onSelect', async () => {
+    const onSelect = vi.fn()
+    render(<ApiKeyList selectedKeyId={null} onSelect={onSelect} />, { wrapper: Wrapper })
+    await screen.findByTestId('api-key-row-key-1')
+
+    await userEvent.click(screen.getByTestId('api-key-rotate-key-1'))
+
+    expect(screen.getByTestId('confirm-rotate-key')).toBeInTheDocument()
+    // stopPropagation must keep the row selection handler from firing.
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('Cancel closes the modal without invoking the rotate override', async () => {
+    const rotateOverride = vi.fn<(id: string) => Promise<GeneratedApiKey>>()
+    _apiKeysInternal.setRotateOverride(rotateOverride)
+
+    render(<ApiKeyList />, { wrapper: Wrapper })
+    await screen.findByTestId('api-key-row-key-1')
+
+    await userEvent.click(screen.getByTestId('api-key-rotate-key-1'))
+    await userEvent.click(screen.getByTestId('confirm-rotate-cancel'))
+
+    expect(screen.queryByTestId('confirm-rotate-key')).not.toBeInTheDocument()
+    expect(rotateOverride).not.toHaveBeenCalled()
+  })
+
+  it('Confirm fires onRotateRevealed with the freshly-issued {id, prefix, secret}', async () => {
+    const onRotateRevealed = vi.fn<(g: GeneratedApiKey) => void>()
+    const generated: GeneratedApiKey = {
+      id: 'key-rotated-stub',
+      prefix: 'aa_live_test',
+      secret: 'aa_live_test_xxxxxxxxxxxx',
+    }
+    _apiKeysInternal.setRotateOverride(() => Promise.resolve(generated))
+
+    render(<ApiKeyList onRotateRevealed={onRotateRevealed} />, { wrapper: Wrapper })
+    await screen.findByTestId('api-key-row-key-1')
+
+    await userEvent.click(screen.getByTestId('api-key-rotate-key-1'))
+    await userEvent.click(screen.getByTestId('confirm-rotate-confirm'))
+
+    await waitFor(() => expect(onRotateRevealed).toHaveBeenCalledOnce())
+    expect(onRotateRevealed).toHaveBeenCalledWith(generated)
+    // No fallback toast when the consumer is piping through RevealOnceModal —
+    // the modal is the loud signal.
+    expect(screen.queryByText(/Rotated gateway-ci/i)).not.toBeInTheDocument()
+  })
+
+  it('without onRotateRevealed, the rotate confirmation surfaces a toast', async () => {
+    _apiKeysInternal.setRotateOverride(() =>
+      Promise.resolve({
+        id: 'key-rotated-stub',
+        prefix: 'aa_live_test',
+        secret: 'aa_live_test_xxxxxxxxxxxx',
+      }),
+    )
+
+    render(<ApiKeyList />, { wrapper: Wrapper })
+    await screen.findByTestId('api-key-row-key-1')
+
+    await userEvent.click(screen.getByTestId('api-key-rotate-key-1'))
+    await userEvent.click(screen.getByTestId('confirm-rotate-confirm'))
+
+    expect(await screen.findByText(/Rotated gateway-ci/i)).toBeInTheDocument()
+  })
+
+  it('rotate failure surfaces an error toast and closes the modal', async () => {
+    _apiKeysInternal.setRotateOverride(() => Promise.reject(new Error('upstream 503')))
+
+    render(<ApiKeyList />, { wrapper: Wrapper })
+    await screen.findByTestId('api-key-row-key-1')
+
+    await userEvent.click(screen.getByTestId('api-key-rotate-key-1'))
+    await userEvent.click(screen.getByTestId('confirm-rotate-confirm'))
+
+    expect(await screen.findByText(/upstream 503/i)).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.queryByTestId('confirm-rotate-key')).not.toBeInTheDocument(),
+    )
+  })
+
+  it('default (no override) flips the old row to revoked and prepends the new active row', async () => {
+    render(<ApiKeyList />, { wrapper: Wrapper })
+    await screen.findByTestId('api-key-row-key-1')
+
+    await userEvent.click(screen.getByTestId('api-key-rotate-key-1'))
+    await userEvent.click(screen.getByTestId('confirm-rotate-confirm'))
+
+    // After the rotation flushes, the old row's status cell must read "revoked".
+    await waitFor(() => {
+      expect(screen.getByTestId('api-key-cell-status-key-1')).toHaveTextContent('revoked')
+    })
+    // And a brand-new active row (label inherited) sits at the top of the list.
+    const snapshot = _apiKeysInternal.snapshot()
+    expect(snapshot[0].label).toBe('gateway-ci')
+    expect(snapshot[0].status).toBe('active')
+    expect(snapshot[0].id).not.toBe('key-1')
+    expect(snapshot[0].assigned_policies).toEqual([
+      'read-only-baseline',
+      'audit-export-allow',
+    ])
   })
 })

--- a/dashboard/src/features/iam/ApiKeyList.tsx
+++ b/dashboard/src/features/iam/ApiKeyList.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
-import { useApiKeysQuery, useRevokeApiKeyMutation } from './apiKeys'
+import { useApiKeysQuery, useRevokeApiKeyMutation, useRotateApiKeyMutation } from './apiKeys'
 import { useToast } from '../../components/Toast'
-import type { ApiKey } from './types'
+import type { ApiKey, GeneratedApiKey } from './types'
 import './ApiKeyList.css'
 
 function maskedPrefix(prefix: string): string {
@@ -45,6 +45,46 @@ function ConfirmRevoke({ keyRecord, onCancel, onConfirm }: {
   )
 }
 
+/**
+ * Confirm dialog for the AAASM-1397 rotate flow. Explains the rotate
+ * semantics — a new secret is issued and the old one is invalidated
+ * immediately, so any caller using the old key starts receiving 401.
+ */
+function ConfirmRotate({ keyRecord, onCancel, onConfirm, isRotating }: {
+  keyRecord: ApiKey
+  onCancel: () => void
+  onConfirm: () => void
+  isRotating: boolean
+}) {
+  return (
+    <div className="iam-dialog__backdrop" role="dialog" aria-modal="true" data-testid="confirm-rotate-key">
+      <div className="iam-dialog">
+        <h2 className="iam-dialog__title">Rotate API key?</h2>
+        <p style={{ fontSize: '0.9rem', margin: 0 }}>
+          Rotating <strong>{keyRecord.label}</strong> ({keyRecord.prefix}…) issues a new
+          secret and immediately invalidates the old one. Callers using the old key will
+          start receiving 401 until you distribute the new secret. The replacement
+          inherits the existing owner, role, scopes and policies.
+        </p>
+        <div className="iam-dialog__actions">
+          <button type="button" className="iam-dialog__btn" onClick={onCancel} data-testid="confirm-rotate-cancel">
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="iam-dialog__btn iam-dialog__btn--primary"
+            onClick={onConfirm}
+            data-testid="confirm-rotate-confirm"
+            disabled={isRotating}
+          >
+            {isRotating ? 'Rotating…' : 'Rotate'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export interface ApiKeyListProps {
   /** Currently-selected api-key id, drives the row highlight (AAASM-1396). */
   selectedKeyId?: string | null
@@ -52,13 +92,22 @@ export interface ApiKeyListProps {
    *  can render IdentityDetailCard without re-querying. Omit to disable
    *  row selection (preserves the previous click-through-nothing behaviour). */
   onSelect?: (key: ApiKey) => void
+  /**
+   * Fired when a rotation succeeds (AAASM-1397). The consumer pipes the
+   * `GeneratedApiKey` into the existing `<RevealOnceModal>` so the new
+   * secret is shown to the operator once. Omit to keep the existing
+   * stand-alone behaviour (rotation will toast but not reveal).
+   */
+  onRotateRevealed?: (generated: GeneratedApiKey) => void
 }
 
-export function ApiKeyList({ selectedKeyId = null, onSelect }: ApiKeyListProps = {}) {
+export function ApiKeyList({ selectedKeyId = null, onSelect, onRotateRevealed }: ApiKeyListProps = {}) {
   const { data, isLoading, isError, refetch } = useApiKeysQuery()
   const revoke = useRevokeApiKeyMutation()
+  const rotate = useRotateApiKeyMutation()
   const { toast } = useToast()
   const [pendingRevoke, setPendingRevoke] = useState<ApiKey | null>(null)
+  const [pendingRotate, setPendingRotate] = useState<ApiKey | null>(null)
 
   if (isError) {
     return (
@@ -76,6 +125,30 @@ export function ApiKeyList({ selectedKeyId = null, onSelect }: ApiKeyListProps =
     revoke.mutate(target.id, {
       onSuccess: () => toast(`Revoked ${target.label}`, 'success'),
       onError: (err) => toast(err instanceof Error ? err.message : 'Revoke failed', 'error'),
+    })
+  }
+
+  function handleConfirmRotate() {
+    if (!pendingRotate) return
+    const target = pendingRotate
+    rotate.mutate(target.id, {
+      onSuccess: (generated) => {
+        setPendingRotate(null)
+        if (onRotateRevealed) {
+          // Consumer pipes into <RevealOnceModal>; no extra toast — the
+          // modal is the operator's loud signal.
+          onRotateRevealed(generated)
+        } else {
+          // Stand-alone use of <ApiKeyList>: surface a confirmation toast so
+          // the rotation is at least acknowledged. The new secret can't be
+          // re-shown — operator has to re-run the rotation if they missed it.
+          toast(`Rotated ${target.label}`, 'success')
+        }
+      },
+      onError: (err) => {
+        setPendingRotate(null)
+        toast(err instanceof Error ? err.message : 'Rotate failed', 'error')
+      },
     })
   }
 
@@ -170,19 +243,34 @@ export function ApiKeyList({ selectedKeyId = null, onSelect }: ApiKeyListProps =
                 </td>
                 <td>
                   {!revoked && (
-                    <button
-                      type="button"
-                      className="iam-api-key-list__revoke-btn"
-                      data-testid={`api-key-revoke-${k.id}`}
-                      onClick={(e) => {
-                        // Don't bubble to the row's onClick selection handler.
-                        e.stopPropagation()
-                        setPendingRevoke(k)
-                      }}
-                      disabled={revoke.isPending}
-                    >
-                      Revoke
-                    </button>
+                    <>
+                      <button
+                        type="button"
+                        className="iam-api-key-list__rotate-btn"
+                        data-testid={`api-key-rotate-${k.id}`}
+                        onClick={(e) => {
+                          // Don't bubble to the row's onClick selection handler.
+                          e.stopPropagation()
+                          setPendingRotate(k)
+                        }}
+                        disabled={rotate.isPending}
+                      >
+                        Rotate
+                      </button>
+                      <button
+                        type="button"
+                        className="iam-api-key-list__revoke-btn"
+                        data-testid={`api-key-revoke-${k.id}`}
+                        onClick={(e) => {
+                          // Don't bubble to the row's onClick selection handler.
+                          e.stopPropagation()
+                          setPendingRevoke(k)
+                        }}
+                        disabled={revoke.isPending}
+                      >
+                        Revoke
+                      </button>
+                    </>
                   )}
                 </td>
               </tr>
@@ -196,6 +284,15 @@ export function ApiKeyList({ selectedKeyId = null, onSelect }: ApiKeyListProps =
           keyRecord={pendingRevoke}
           onCancel={() => setPendingRevoke(null)}
           onConfirm={handleConfirmRevoke}
+        />
+      )}
+
+      {pendingRotate && (
+        <ConfirmRotate
+          keyRecord={pendingRotate}
+          onCancel={() => setPendingRotate(null)}
+          onConfirm={handleConfirmRotate}
+          isRotating={rotate.isPending}
         />
       )}
     </>

--- a/dashboard/src/features/iam/ServiceIdentitiesPanel.tsx
+++ b/dashboard/src/features/iam/ServiceIdentitiesPanel.tsx
@@ -73,6 +73,9 @@ export function ServiceIdentitiesPanel() {
           <ApiKeyList
             selectedKeyId={selected?.id ?? null}
             onSelect={setSelected}
+            // AAASM-1397 — pipe the rotated key into the existing
+            // RevealOnceModal flow so the new secret is shown once.
+            onRotateRevealed={reveal.reveal}
           />
         </div>
         <div className="iam-services-panel__detail">

--- a/dashboard/src/features/iam/apiKeys.ts
+++ b/dashboard/src/features/iam/apiKeys.ts
@@ -73,6 +73,7 @@ const keyStore: KeyStore = { keys: [...SEED_API_KEYS] }
 
 let _generateOverride: ((input: GenerateApiKeyInput) => Promise<GeneratedApiKey>) | null = null
 let _revokeOverride: ((id: string) => Promise<void>) | null = null
+let _rotateOverride: ((id: string) => Promise<GeneratedApiKey>) | null = null
 let _keySeq = 0
 
 function fetchApiKeys(): Promise<ApiKey[]> {
@@ -125,6 +126,59 @@ function revokeApiKey(id: string): Promise<void> {
   return Promise.resolve()
 }
 
+/**
+ * Rotate an active API key (AAASM-1397). Atomic in the in-memory store:
+ * the old row is flipped to `revoked` and a fresh `active` row inherits
+ * the previous owner / role / scopes / assigned_policies / label so the
+ * caller's downstream policies survive the rotation. Recent-activity
+ * gets a synthetic "rotated" entry on the new row.
+ *
+ * Returns `{id, prefix, secret}` — the secret MUST be surfaced to the
+ * operator once via `<RevealOnceModal>` and never persisted alongside
+ * the ApiKey record.
+ */
+function rotateApiKey(id: string): Promise<GeneratedApiKey> {
+  if (_rotateOverride) return _rotateOverride(id)
+  const idx = keyStore.keys.findIndex((k) => k.id === id)
+  if (idx === -1) return Promise.reject(new Error(`api key ${id} not found`))
+  const existing = keyStore.keys[idx]
+  if (existing.status !== 'active') {
+    return Promise.reject(new Error(`api key ${id} is not active (status=${existing.status})`))
+  }
+  const newId = `key-gen-${++_keySeq}`
+  const newPrefix = `aa_live_${randomSuffix(4)}`
+  const newSecret = `${newPrefix}_${randomSuffix(32)}`
+  const nowIso = new Date().toISOString()
+  const revokedOld: ApiKey = { ...existing, status: 'revoked' }
+  const fresh: ApiKey = {
+    id: newId,
+    label: existing.label,
+    prefix: newPrefix,
+    scopes: [...existing.scopes],
+    status: 'active',
+    created_at: nowIso,
+    last_used: null,
+    // Inherit owner / role / assigned_policies so the rotation is
+    // transparent for downstream consumers.
+    owner: existing.owner,
+    role: existing.role,
+    assigned_policies: [...existing.assigned_policies],
+    recent_activity: [
+      {
+        id: `${newId}-act-rotate`,
+        timestamp: nowIso,
+        action: 'rotated',
+        target: `replaces ${existing.prefix} (id ${existing.id})`,
+      },
+    ],
+  }
+  // Replace old row in place, then prepend the new row so it surfaces at
+  // the top of the list (mirrors the generateApiKey ordering).
+  const without = [...keyStore.keys.slice(0, idx), revokedOld, ...keyStore.keys.slice(idx + 1)]
+  keyStore.keys = [fresh, ...without]
+  return Promise.resolve({ id: newId, prefix: newPrefix, secret: newSecret })
+}
+
 export function useApiKeysQuery() {
   return useQuery({
     queryKey: iamQueryKeys.apiKeys(),
@@ -152,16 +206,28 @@ export function useRevokeApiKeyMutation() {
   })
 }
 
+export function useRotateApiKeyMutation() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => rotateApiKey(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: iamQueryKeys.apiKeys() })
+    },
+  })
+}
+
 export const _apiKeysInternal: {
   reset: () => void
   snapshot: () => readonly ApiKey[]
   setGenerateOverride: (fn: ((input: GenerateApiKeyInput) => Promise<GeneratedApiKey>) | null) => void
   setRevokeOverride: (fn: ((id: string) => Promise<void>) | null) => void
+  setRotateOverride: (fn: ((id: string) => Promise<GeneratedApiKey>) | null) => void
 } = {
   reset(): void {
     keyStore.keys = [...SEED_API_KEYS]
     _generateOverride = null
     _revokeOverride = null
+    _rotateOverride = null
     _keySeq = 0
   },
   snapshot(): readonly ApiKey[] {
@@ -172,5 +238,8 @@ export const _apiKeysInternal: {
   },
   setRevokeOverride(fn) {
     _revokeOverride = fn
+  },
+  setRotateOverride(fn) {
+    _rotateOverride = fn
   },
 }


### PR DESCRIPTION
## Summary

Implements the **Rotate API key flow** for the Service Identities tab
([AAASM-1397](https://lightning-dust-mite.atlassian.net/browse/AAASM-1397)),
the third action on each `ApiKeyList` row (alongside the existing Revoke and
row-click → IdentityDetailCard flows from AAASM-1396 / AAASM-1399).

Rotation is the standard cure for a leaked credential: issue a new secret,
immediately invalidate the old one, and inherit owner / role / scopes /
policies so downstream policy bindings survive the change. The new secret
flows through the existing `<RevealOnceModal>` from the generate flow so
operators see it exactly once.

## Commits

| # | SHA | What |
|---|---|---|
| C1 | `8dc9360b` | ✨ `apiKeys.ts` — `rotateApiKey(id)` + `useRotateApiKeyMutation` + `_apiKeysInternal.setRotateOverride` |
| C2 | `26cefd93` | ✨ `ApiKeyList.tsx` — Rotate row action + `ConfirmRotate` modal + `onRotateRevealed` prop |
| C3 | `ccad8f9d` | 🔧 `ServiceIdentitiesPanel.tsx` — pipe rotated key into `<RevealOnceModal>` via `reveal.reveal` |
| C4 | `d589252a` | ✅ `ApiKeyList.test.tsx` — 7 vitest cases pinning the rotate contract |

## AC coverage

| AC | Where it's satisfied |
|---|---|
| Active rows expose a Rotate action | `ApiKeyList.tsx:247-259` (button only renders when `!revoked`); test `renders a Rotate action on every active row, but never on revoked rows` |
| Confirm dialog explains the rotate semantics | `ConfirmRotate` (`ApiKeyList.tsx:53-86`) — "issues a new secret and immediately invalidates the old one… callers using the old key will start receiving 401" |
| New secret is shown to the operator once | `ServiceIdentitiesPanel.tsx:76-78` pipes `onRotateRevealed = reveal.reveal` → existing `<RevealOnceModal>` (acknowledge + ConfirmDestroyUnseenKey guard) |
| Replacement inherits owner / role / scopes / policies | `apiKeys.ts:153-174` (rotateApiKey assembles `fresh` from `existing.{owner,role,scopes,assigned_policies,label}`); test `default (no override) flips the old row to revoked and prepends the new active row` |
| Old key is immediately invalidated | `apiKeys.ts:152` (`revokedOld`); test asserts `status === 'revoked'` on the old row after confirm |
| Failure path is surfaced, not silent | `handleConfirmRotate` catches errors → toast; test `rotate failure surfaces an error toast and closes the modal` |
| Action does not bubble to row selection | `ApiKeyList.tsx:251-254` `e.stopPropagation()` on the Rotate button; test `clicking Rotate opens the ConfirmRotate modal without firing onSelect` |

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test --run` — 903/903 passing (includes 7 new rotate-flow cases)
- [x] `pnpm exec vitest run src/features/iam/` — 14/14 in `ApiKeyList.test.tsx`

## OpenAPI gap

`/v1/iam/api-keys` is still not in the schema, so the rotate path uses the
same in-memory store + override seam the generate / revoke flows use today.
When the gateway lands, swapping `rotateApiKey` to a fetch call is a
one-function change; the React Query hook, mutation contract, and component
wiring all stay unchanged.

Closes AAASM-1397.

[AAASM-1397]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ