### PR TITLE
[AAASM-1397] ✨ (iam): Add /v1/iam/api-keys family + Rotate flow in dashboard

### DIFF
--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -13,7 +13,9 @@ use crate::models::event::GovernanceEvent;
 use crate::models::event_type::EventType;
 use crate::models::trace::{TraceResponse, TraceSpan};
 use crate::models::ws_payloads::{ApprovalPayload, BudgetAlertPayload, EventPayload, ViolationPayload};
-use crate::routes::{agents, alerts, approvals, auth, capability, costs, edges, logs, ops, policies, topology, traces};
+use crate::routes::{
+    agents, alerts, approvals, auth, capability, costs, edges, iam, logs, ops, policies, topology, traces,
+};
 
 /// Root OpenAPI document collecting all annotated paths and schemas.
 #[derive(OpenApi)]
@@ -42,6 +44,7 @@ use crate::routes::{agents, alerts, approvals, auth, capability, costs, edges, l
         (name = "topology", description = "Agent topology — tree, team, lineage, statistics, and mesh edge queries"),
         (name = "ops", description = "Per-operation lifecycle actions (pause / resume / terminate)"),
         (name = "capability", description = "Dashboard Capability Matrix — agent × resource × verb × decision view"),
+        (name = "iam", description = "Identity & Access — API key list / generate / revoke / rotate"),
     ),
     paths(
         crate::routes::health::health,
@@ -78,6 +81,10 @@ use crate::routes::{agents, alerts, approvals, auth, capability, costs, edges, l
         ops::terminate_op,
         capability::get_matrix,
         capability::apply_override,
+        iam::list_api_keys,
+        iam::generate_api_key,
+        iam::revoke_api_key,
+        iam::rotate_api_key,
     ),
     components(schemas(
         crate::routes::health::HealthResponse,
@@ -147,6 +154,12 @@ use crate::routes::{agents, alerts, approvals, auth, capability, costs, edges, l
         CapabilityMatrix,
         CapabilityOverrideRequest,
         CapabilityOverrideResponse,
+        iam::ApiKeyScopeResponse,
+        iam::ApiKeyStatusResponse,
+        iam::RecentActivityResponse,
+        iam::ApiKeyResponse,
+        iam::GeneratedApiKeyResponse,
+        iam::GenerateApiKeyRequest,
     )),
     modifiers(&SecurityAddon),
 )]

--- a/aa-api/src/routes/iam.rs
+++ b/aa-api/src/routes/iam.rs
@@ -1,0 +1,420 @@
+//! Identity & Access (`/api/v1/iam/...`) endpoints (AAASM-1397).
+//!
+//! Backs the dashboard's Identity & Access page (AAASM-119). The store is
+//! [`aa_gateway::iam::IamApiKeyStore`] — see `iam/mod.rs` there for the
+//! deliberate boundary against `aa-api::auth::api_key`, which authenticates
+//! *incoming* bearer tokens.
+
+use std::sync::Arc;
+
+use aa_gateway::iam::{
+    api_keys::{RevokeError, RotateError},
+    ApiKeyEntry, ApiKeyScope as GwApiKeyScope, ApiKeyStatus as GwApiKeyStatus, GeneratedApiKey as GwGeneratedApiKey,
+    IamApiKeyStore, RecentActivityEntry,
+};
+use aa_gateway::policy::rbac::MutationKind;
+use aa_gateway::policy::scope::PolicyScope;
+use axum::extract::Path;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::{Extension, Json};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::auth::policy_auth::{PolicyAuthorizationDenied, PolicyWriteAuth};
+use crate::error::ProblemDetail;
+use crate::state::AppState;
+
+// ── Wire types — mirror the dashboard's TypeScript ApiKey shape exactly. ──
+
+/// Scopes a key may hold. Wire form matches the dashboard's TS union.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub enum ApiKeyScopeResponse {
+    #[serde(rename = "read:members")]
+    ReadMembers,
+    #[serde(rename = "write:members")]
+    WriteMembers,
+    #[serde(rename = "read:policies")]
+    ReadPolicies,
+    #[serde(rename = "write:policies")]
+    WritePolicies,
+    #[serde(rename = "read:audit")]
+    ReadAudit,
+    #[serde(rename = "admin")]
+    Admin,
+}
+
+impl From<GwApiKeyScope> for ApiKeyScopeResponse {
+    fn from(s: GwApiKeyScope) -> Self {
+        match s {
+            GwApiKeyScope::ReadMembers => Self::ReadMembers,
+            GwApiKeyScope::WriteMembers => Self::WriteMembers,
+            GwApiKeyScope::ReadPolicies => Self::ReadPolicies,
+            GwApiKeyScope::WritePolicies => Self::WritePolicies,
+            GwApiKeyScope::ReadAudit => Self::ReadAudit,
+            GwApiKeyScope::Admin => Self::Admin,
+        }
+    }
+}
+
+impl From<ApiKeyScopeResponse> for GwApiKeyScope {
+    fn from(s: ApiKeyScopeResponse) -> Self {
+        match s {
+            ApiKeyScopeResponse::ReadMembers => Self::ReadMembers,
+            ApiKeyScopeResponse::WriteMembers => Self::WriteMembers,
+            ApiKeyScopeResponse::ReadPolicies => Self::ReadPolicies,
+            ApiKeyScopeResponse::WritePolicies => Self::WritePolicies,
+            ApiKeyScopeResponse::ReadAudit => Self::ReadAudit,
+            ApiKeyScopeResponse::Admin => Self::Admin,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ApiKeyStatusResponse {
+    Active,
+    Revoked,
+}
+
+impl From<GwApiKeyStatus> for ApiKeyStatusResponse {
+    fn from(s: GwApiKeyStatus) -> Self {
+        match s {
+            GwApiKeyStatus::Active => Self::Active,
+            GwApiKeyStatus::Revoked => Self::Revoked,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct RecentActivityResponse {
+    pub id: String,
+    pub timestamp: String,
+    pub action: String,
+    pub target: String,
+}
+
+impl From<RecentActivityEntry> for RecentActivityResponse {
+    fn from(e: RecentActivityEntry) -> Self {
+        Self {
+            id: e.id,
+            timestamp: e.timestamp.to_rfc3339(),
+            action: e.action,
+            target: e.target,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ApiKeyResponse {
+    pub id: String,
+    pub label: String,
+    pub prefix: String,
+    pub scopes: Vec<ApiKeyScopeResponse>,
+    pub status: ApiKeyStatusResponse,
+    pub created_at: String,
+    pub last_used: Option<String>,
+    pub owner: String,
+    pub role: String,
+    pub assigned_policies: Vec<String>,
+    pub recent_activity: Vec<RecentActivityResponse>,
+}
+
+impl From<ApiKeyEntry> for ApiKeyResponse {
+    fn from(e: ApiKeyEntry) -> Self {
+        Self {
+            id: e.id,
+            label: e.label,
+            prefix: e.prefix,
+            scopes: e.scopes.into_iter().map(Into::into).collect(),
+            status: e.status.into(),
+            created_at: e.created_at.to_rfc3339(),
+            last_used: e.last_used.map(|d| d.to_rfc3339()),
+            owner: e.owner,
+            role: e.role,
+            assigned_policies: e.assigned_policies,
+            recent_activity: e.recent_activity.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+/// One-shot reveal shape returned by generate / rotate. `secret` MUST be
+/// captured by the caller — the server does not store it.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct GeneratedApiKeyResponse {
+    pub id: String,
+    pub prefix: String,
+    pub secret: String,
+}
+
+impl From<GwGeneratedApiKey> for GeneratedApiKeyResponse {
+    fn from(g: GwGeneratedApiKey) -> Self {
+        Self {
+            id: g.id,
+            prefix: g.prefix,
+            secret: g.secret,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct GenerateApiKeyRequest {
+    pub label: String,
+    pub scopes: Vec<ApiKeyScopeResponse>,
+}
+
+// ── Handlers ──
+
+/// `GET /api/v1/iam/api-keys` — list every API key the IAM store knows.
+///
+/// Returned in newest-first order. Active and revoked keys are both
+/// included; the dashboard filters by status in its tabs.
+#[utoipa::path(
+    get,
+    path = "/api/v1/iam/api-keys",
+    responses(
+        (status = 200, description = "All API keys, newest first", body = [ApiKeyResponse])
+    ),
+    tag = "iam"
+)]
+pub async fn list_api_keys(Extension(state): Extension<AppState>) -> (StatusCode, Json<Vec<ApiKeyResponse>>) {
+    let keys = state
+        .iam_api_key_store
+        .list()
+        .into_iter()
+        .map(ApiKeyResponse::from)
+        .collect();
+    (StatusCode::OK, Json(keys))
+}
+
+/// `POST /api/v1/iam/api-keys` — issue a new API key.
+///
+/// IAM mutations are gated as a `Global`-scope policy update — the caller
+/// must hold the `OrgAdmin` role.
+///
+/// The response `secret` field is shown to the caller **once**; the server
+/// does not persist it.
+#[utoipa::path(
+    post,
+    path = "/api/v1/iam/api-keys",
+    request_body = GenerateApiKeyRequest,
+    responses(
+        (status = 200, description = "Generated key (with one-shot secret)", body = GeneratedApiKeyResponse),
+        (status = 403, description = "Caller lacks the role required to mutate IAM state")
+    ),
+    tag = "iam"
+)]
+pub async fn generate_api_key(
+    policy_auth: PolicyWriteAuth,
+    Extension(state): Extension<AppState>,
+    Json(body): Json<GenerateApiKeyRequest>,
+) -> Result<(StatusCode, Json<GeneratedApiKeyResponse>), IamHandlerError> {
+    policy_auth
+        .check_mutation(&PolicyScope::Global, MutationKind::Create)
+        .map_err(IamHandlerError::Forbidden)?;
+
+    let scopes: Vec<GwApiKeyScope> = body.scopes.into_iter().map(Into::into).collect();
+    let generated = state
+        .iam_api_key_store
+        .generate(&body.label, scopes, &policy_auth.caller.key_id);
+    Ok((StatusCode::OK, Json(generated.into())))
+}
+
+/// `POST /api/v1/iam/api-keys/{id}/revoke` — revoke an existing key.
+///
+/// 404 if the key is unknown, 409 if it is already revoked.
+#[utoipa::path(
+    post,
+    path = "/api/v1/iam/api-keys/{id}/revoke",
+    params(("id" = String, Path, description = "API key id")),
+    responses(
+        (status = 204, description = "Key revoked"),
+        (status = 404, description = "Unknown api key id"),
+        (status = 409, description = "Key is already revoked"),
+        (status = 403, description = "Caller lacks the role required to mutate IAM state")
+    ),
+    tag = "iam"
+)]
+pub async fn revoke_api_key(
+    policy_auth: PolicyWriteAuth,
+    Path(id): Path<String>,
+    Extension(state): Extension<AppState>,
+) -> Result<StatusCode, IamHandlerError> {
+    policy_auth
+        .check_mutation(&PolicyScope::Global, MutationKind::Update)
+        .map_err(IamHandlerError::Forbidden)?;
+
+    state
+        .iam_api_key_store
+        .revoke(&id, &policy_auth.caller.key_id)
+        .map_err(|e| match e {
+            RevokeError::NotFound => IamHandlerError::NotFound(
+                ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Unknown api key id: {id}")),
+            ),
+            RevokeError::AlreadyRevoked => IamHandlerError::Conflict(
+                ProblemDetail::from_status(StatusCode::CONFLICT)
+                    .with_detail(format!("Api key {id} is already revoked")),
+            ),
+        })?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `POST /api/v1/iam/api-keys/{id}/rotate` — atomically revoke `id` and
+/// issue a replacement carrying the same label, scopes, and owner.
+///
+/// Returns the new key's one-shot reveal. 404 if `id` is unknown, 409 if
+/// the source key is already revoked.
+#[utoipa::path(
+    post,
+    path = "/api/v1/iam/api-keys/{id}/rotate",
+    params(("id" = String, Path, description = "API key id to rotate")),
+    responses(
+        (status = 200, description = "Replacement key with one-shot secret", body = GeneratedApiKeyResponse),
+        (status = 404, description = "Unknown api key id"),
+        (status = 409, description = "Source key is already revoked"),
+        (status = 403, description = "Caller lacks the role required to mutate IAM state")
+    ),
+    tag = "iam"
+)]
+pub async fn rotate_api_key(
+    policy_auth: PolicyWriteAuth,
+    Path(id): Path<String>,
+    Extension(state): Extension<AppState>,
+) -> Result<(StatusCode, Json<GeneratedApiKeyResponse>), IamHandlerError> {
+    policy_auth
+        .check_mutation(&PolicyScope::Global, MutationKind::Update)
+        .map_err(IamHandlerError::Forbidden)?;
+
+    let generated = state
+        .iam_api_key_store
+        .rotate(&id, &policy_auth.caller.key_id)
+        .map_err(|e| match e {
+            RotateError::NotFound => IamHandlerError::NotFound(
+                ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Unknown api key id: {id}")),
+            ),
+            RotateError::AlreadyRevoked => IamHandlerError::Conflict(
+                ProblemDetail::from_status(StatusCode::CONFLICT)
+                    .with_detail(format!("Api key {id} is already revoked")),
+            ),
+        })?;
+
+    Ok((StatusCode::OK, Json(generated.into())))
+}
+
+/// Unified handler error so 404 / 409 / 403 each render through their own
+/// `IntoResponse` impl without leaking the gateway error variants.
+#[derive(Debug)]
+pub enum IamHandlerError {
+    NotFound(ProblemDetail),
+    Conflict(ProblemDetail),
+    Forbidden(PolicyAuthorizationDenied),
+}
+
+impl IntoResponse for IamHandlerError {
+    fn into_response(self) -> axum::response::Response {
+        match self {
+            Self::NotFound(p) | Self::Conflict(p) => p.into_response(),
+            Self::Forbidden(d) => d.into_response(),
+        }
+    }
+}
+
+/// Build a seeded [`IamApiKeyStore`] mirroring the dashboard's mock fixture.
+///
+/// Kept here (rather than in `aa-gateway::iam`) so the seed shape stays close
+/// to the dashboard-facing wire definitions. The seeded entries match the
+/// `SEED_API_KEYS` array in `dashboard/src/features/iam/apiKeys.ts`.
+pub fn seeded_iam_store() -> Arc<IamApiKeyStore> {
+    use chrono::{DateTime, Utc};
+    fn ts(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s)
+            .expect("valid rfc3339 seed")
+            .with_timezone(&Utc)
+    }
+    let store = IamApiKeyStore::new();
+    store.seed([
+        ApiKeyEntry {
+            id: "key-1".into(),
+            label: "gateway-ci".into(),
+            prefix: "aa_live_3f9c".into(),
+            scopes: vec![GwApiKeyScope::ReadMembers, GwApiKeyScope::ReadPolicies],
+            status: GwApiKeyStatus::Active,
+            created_at: ts("2026-04-30T09:12:00Z"),
+            last_used: Some(ts("2026-05-13T07:55:00Z")),
+            owner: "alice".into(),
+            role: "service:reader".into(),
+            assigned_policies: vec!["read-only-baseline".into(), "audit-export-allow".into()],
+            recent_activity: vec![
+                RecentActivityEntry {
+                    id: "act-1-a".into(),
+                    timestamp: ts("2026-05-13T07:55:00Z"),
+                    action: "called".into(),
+                    target: "GET /api/v1/agents".into(),
+                },
+                RecentActivityEntry {
+                    id: "act-1-b".into(),
+                    timestamp: ts("2026-05-13T07:54:00Z"),
+                    action: "called".into(),
+                    target: "GET /api/v1/policies".into(),
+                },
+                RecentActivityEntry {
+                    id: "act-1-c".into(),
+                    timestamp: ts("2026-04-30T09:12:00Z"),
+                    action: "issued".into(),
+                    target: "key issued by alice".into(),
+                },
+            ],
+        },
+        ApiKeyEntry {
+            id: "key-2".into(),
+            label: "observability-exporter".into(),
+            prefix: "aa_live_8b2a".into(),
+            scopes: vec![GwApiKeyScope::ReadAudit],
+            status: GwApiKeyStatus::Active,
+            created_at: ts("2026-05-02T14:30:00Z"),
+            last_used: None,
+            owner: "carol".into(),
+            role: "service:observer".into(),
+            assigned_policies: vec!["audit-export-allow".into()],
+            recent_activity: vec![RecentActivityEntry {
+                id: "act-2-a".into(),
+                timestamp: ts("2026-05-02T14:30:00Z"),
+                action: "issued".into(),
+                target: "key issued by carol".into(),
+            }],
+        },
+        ApiKeyEntry {
+            id: "key-3".into(),
+            label: "retired-runner".into(),
+            prefix: "aa_live_d041".into(),
+            scopes: vec![GwApiKeyScope::Admin],
+            status: GwApiKeyStatus::Revoked,
+            created_at: ts("2026-03-14T11:00:00Z"),
+            last_used: Some(ts("2026-04-21T10:18:00Z")),
+            owner: "bob".into(),
+            role: "service:admin".into(),
+            assigned_policies: vec!["admin-baseline".into()],
+            recent_activity: vec![
+                RecentActivityEntry {
+                    id: "act-3-a".into(),
+                    timestamp: ts("2026-04-25T16:00:00Z"),
+                    action: "revoked".into(),
+                    target: "key revoked by alice".into(),
+                },
+                RecentActivityEntry {
+                    id: "act-3-b".into(),
+                    timestamp: ts("2026-04-21T10:18:00Z"),
+                    action: "called".into(),
+                    target: "POST /api/v1/policies".into(),
+                },
+                RecentActivityEntry {
+                    id: "act-3-c".into(),
+                    timestamp: ts("2026-03-14T11:00:00Z"),
+                    action: "issued".into(),
+                    target: "key issued by bob".into(),
+                },
+            ],
+        },
+    ]);
+    Arc::new(store)
+}

--- a/aa-api/src/routes/mod.rs
+++ b/aa-api/src/routes/mod.rs
@@ -11,6 +11,7 @@ pub mod costs;
 pub mod devtools;
 pub mod edges;
 pub mod health;
+pub mod iam;
 pub mod logs;
 pub mod ops;
 pub mod policies;
@@ -56,6 +57,10 @@ pub fn v1_router() -> Router {
         // Capability matrix (dashboard) — AAASM-1366
         .route("/capability/matrix", get(capability::get_matrix))
         .route("/capability/override", post(capability::apply_override))
+        // Identity & Access — API key management (dashboard) — AAASM-1397
+        .route("/iam/api-keys", get(iam::list_api_keys).post(iam::generate_api_key))
+        .route("/iam/api-keys/{id}/revoke", post(iam::revoke_api_key))
+        .route("/iam/api-keys/{id}/rotate", post(iam::rotate_api_key))
         // Alerts
         .route("/alerts", get(alerts::list_alerts))
         // Dev tool webhooks

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -9,6 +9,7 @@ use aa_devtool::DiscoveryService;
 use aa_core::topology::EdgeRepo;
 use aa_gateway::budget::tracker::BudgetTracker;
 use aa_gateway::engine::PolicyEngine;
+use aa_gateway::iam::IamApiKeyStore;
 use aa_gateway::policy::history::PolicyHistoryStore;
 use aa_gateway::registry::AgentRegistry;
 use aa_gateway::AuditReader;
@@ -80,4 +81,6 @@ pub struct AppState {
     pub topology_stats_cache: moka::future::Cache<&'static str, Arc<TopologyStats>>,
     /// Dashboard Capability Matrix store (AAASM-1366).
     pub capability_store: Arc<CapabilityStore>,
+    /// Dashboard Identity & Access — IAM API key management (AAASM-1397).
+    pub iam_api_key_store: Arc<IamApiKeyStore>,
 }

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -158,6 +158,7 @@ spec:
             .time_to_live(std::time::Duration::from_secs(10))
             .build(),
         capability_store: aa_api::routes::capability::CapabilityStore::new_seeded(),
+        iam_api_key_store: aa_api::routes::iam::seeded_iam_store(),
     }
 }
 

--- a/aa-api/tests/iam.rs
+++ b/aa-api/tests/iam.rs
@@ -1,0 +1,229 @@
+//! Integration tests for the IAM API key endpoints (AAASM-1397).
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::json;
+use tower::ServiceExt;
+
+use aa_api::auth::scope::Scope;
+
+fn get_request(uri: &str, token: Option<&str>) -> Request<Body> {
+    let mut builder = Request::builder().method("GET").uri(uri);
+    if let Some(t) = token {
+        builder = builder.header("authorization", format!("Bearer {t}"));
+    }
+    builder.body(Body::empty()).unwrap()
+}
+
+fn post_json_request(uri: &str, body: serde_json::Value, token: Option<&str>) -> Request<Body> {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json");
+    if let Some(t) = token {
+        builder = builder.header("authorization", format!("Bearer {t}"));
+    }
+    builder.body(Body::from(serde_json::to_vec(&body).unwrap())).unwrap()
+}
+
+fn post_empty_request(uri: &str, token: Option<&str>) -> Request<Body> {
+    let mut builder = Request::builder().method("POST").uri(uri);
+    if let Some(t) = token {
+        builder = builder.header("authorization", format!("Bearer {t}"));
+    }
+    builder.body(Body::empty()).unwrap()
+}
+
+#[tokio::test]
+async fn list_api_keys_returns_seeded_entries_newest_first() {
+    let app = common::test_app();
+
+    let response = app.oneshot(get_request("/api/v1/iam/api-keys", None)).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let keys = json.as_array().expect("array");
+    assert_eq!(keys.len(), 3, "seed mirrors the dashboard's three-entry fixture");
+
+    // Newest-first ordering: key-2 (2026-05-02) before key-1 (2026-04-30) before key-3 (2026-03-14).
+    assert_eq!(keys[0]["id"], "key-2");
+    assert_eq!(keys[1]["id"], "key-1");
+    assert_eq!(keys[2]["id"], "key-3");
+
+    // Shape contract — snake_case fields matching dashboard's TS ApiKey interface.
+    assert!(keys[0]["created_at"].is_string());
+    assert!(keys[0]["scopes"].is_array());
+    assert!(keys[0]["recent_activity"].is_array());
+    assert!(keys[0]["assigned_policies"].is_array());
+    assert_eq!(keys[2]["status"], "revoked");
+}
+
+#[tokio::test]
+async fn generate_api_key_returns_one_shot_secret_and_persists_entry() {
+    let app = common::test_app();
+
+    let body = json!({ "label": "ci-bot", "scopes": ["read:audit"] });
+    let response = app
+        .clone()
+        .oneshot(post_json_request("/api/v1/iam/api-keys", body, None))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json: serde_json::Value =
+        serde_json::from_slice(&axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
+    assert!(json["id"].is_string(), "generated id present");
+    assert!(json["prefix"].as_str().unwrap().starts_with("aa_live_"));
+    let secret = json["secret"].as_str().expect("secret reveal present");
+    assert!(secret.contains(json["prefix"].as_str().unwrap()));
+
+    // The new entry must now show up in list().
+    let list_resp = app.oneshot(get_request("/api/v1/iam/api-keys", None)).await.unwrap();
+    let list_body = axum::body::to_bytes(list_resp.into_body(), usize::MAX).await.unwrap();
+    let list_json: serde_json::Value = serde_json::from_slice(&list_body).unwrap();
+    let labels: Vec<&str> = list_json
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|k| k["label"].as_str().unwrap())
+        .collect();
+    assert!(labels.contains(&"ci-bot"));
+}
+
+#[tokio::test]
+async fn revoke_api_key_marks_entry_revoked() {
+    let app = common::test_app();
+
+    let response = app
+        .clone()
+        .oneshot(post_empty_request("/api/v1/iam/api-keys/key-1/revoke", None))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    // After revoke, the entry must report status: revoked.
+    let list_resp = app.oneshot(get_request("/api/v1/iam/api-keys", None)).await.unwrap();
+    let body = axum::body::to_bytes(list_resp.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let key1 = json
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|k| k["id"] == "key-1")
+        .expect("key-1 still present");
+    assert_eq!(key1["status"], "revoked");
+}
+
+#[tokio::test]
+async fn revoke_unknown_id_returns_404() {
+    let app = common::test_app();
+
+    let response = app
+        .oneshot(post_empty_request("/api/v1/iam/api-keys/nope/revoke", None))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let detail = json["detail"].as_str().unwrap_or("");
+    assert!(
+        detail.contains("nope"),
+        "ProblemDetail names the offending id; got: {detail}"
+    );
+}
+
+#[tokio::test]
+async fn revoke_already_revoked_returns_409() {
+    let app = common::test_app();
+
+    // key-3 is seeded as already revoked.
+    let response = app
+        .oneshot(post_empty_request("/api/v1/iam/api-keys/key-3/revoke", None))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn rotate_api_key_returns_new_secret_and_revokes_old() {
+    let app = common::test_app();
+
+    let response = app
+        .clone()
+        .oneshot(post_empty_request("/api/v1/iam/api-keys/key-1/rotate", None))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let new_id = json["id"].as_str().expect("new id present");
+    assert_ne!(new_id, "key-1", "replacement carries a distinct id");
+    assert!(json["secret"].as_str().unwrap().starts_with("aa_live_"));
+
+    // The list must now have key-1 marked revoked and the new entry present
+    // with the same label / scopes as key-1.
+    let list_resp = app.oneshot(get_request("/api/v1/iam/api-keys", None)).await.unwrap();
+    let list_body = axum::body::to_bytes(list_resp.into_body(), usize::MAX).await.unwrap();
+    let list: serde_json::Value = serde_json::from_slice(&list_body).unwrap();
+
+    let old = list.as_array().unwrap().iter().find(|k| k["id"] == "key-1").unwrap();
+    assert_eq!(old["status"], "revoked");
+
+    let new_entry = list.as_array().unwrap().iter().find(|k| k["id"] == new_id).unwrap();
+    assert_eq!(new_entry["label"], "gateway-ci");
+    assert_eq!(new_entry["scopes"], json!(["read:members", "read:policies"]));
+    assert_eq!(new_entry["status"], "active");
+}
+
+#[tokio::test]
+async fn rotate_unknown_id_returns_404() {
+    let app = common::test_app();
+
+    let response = app
+        .oneshot(post_empty_request("/api/v1/iam/api-keys/nope/rotate", None))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn rotate_already_revoked_returns_409() {
+    let app = common::test_app();
+
+    let response = app
+        .oneshot(post_empty_request("/api/v1/iam/api-keys/key-3/rotate", None))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn generate_with_read_only_scope_is_forbidden() {
+    let (token, entry) = common::generate_test_api_key("viewer-key", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(post_json_request(
+            "/api/v1/iam/api-keys",
+            json!({ "label": "x", "scopes": ["admin"] }),
+            Some(&token),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn rotate_with_read_only_scope_is_forbidden() {
+    let (token, entry) = common::generate_test_api_key("viewer-key", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(post_empty_request("/api/v1/iam/api-keys/key-1/rotate", Some(&token)))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}

--- a/aa-gateway/src/iam/api_keys.rs
+++ b/aa-gateway/src/iam/api_keys.rs
@@ -1,0 +1,384 @@
+//! In-memory IAM API-key management store (AAASM-1397).
+//!
+//! Backs the dashboard Identity & Access page's "Service Identities" tab.
+//! See the module-level note in `iam/mod.rs` for the boundary against
+//! `aa-api::auth::api_key` (which authenticates *incoming* requests).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use chrono::{DateTime, Utc};
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+
+/// Scopes a key may hold. Matches the dashboard's `ApiKeyScope` union exactly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ApiKeyScope {
+    #[serde(rename = "read:members")]
+    ReadMembers,
+    #[serde(rename = "write:members")]
+    WriteMembers,
+    #[serde(rename = "read:policies")]
+    ReadPolicies,
+    #[serde(rename = "write:policies")]
+    WritePolicies,
+    #[serde(rename = "read:audit")]
+    ReadAudit,
+    #[serde(rename = "admin")]
+    Admin,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ApiKeyStatus {
+    Active,
+    Revoked,
+}
+
+/// One entry in the "Recent activity" timeline shown in the dashboard's
+/// IdentityDetailCard. Seeded inline alongside the key record until the
+/// audit-query surface is wired in.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecentActivityEntry {
+    pub id: String,
+    pub timestamp: DateTime<Utc>,
+    pub action: String,
+    pub target: String,
+}
+
+/// A persisted API key record — *never* contains the raw secret.
+///
+/// `prefix` is the displayable, public portion (e.g. `aa_live_3f9c`) used
+/// to identify the key in lists and audit entries. The secret half is only
+/// returned once, from `generate` / `rotate`, inside [`GeneratedApiKey`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiKeyEntry {
+    pub id: String,
+    pub label: String,
+    pub prefix: String,
+    pub scopes: Vec<ApiKeyScope>,
+    pub status: ApiKeyStatus,
+    pub created_at: DateTime<Utc>,
+    pub last_used: Option<DateTime<Utc>>,
+    /// Operator who owns the key (display only).
+    pub owner: String,
+    /// Service role label (e.g. `service:reader`).
+    pub role: String,
+    /// Policies assigned to this key by name.
+    pub assigned_policies: Vec<String>,
+    /// Audit-style activity feed for the IdentityDetailCard.
+    pub recent_activity: Vec<RecentActivityEntry>,
+}
+
+/// One-shot reveal returned by `generate` and `rotate`. The `secret` field
+/// is the raw key the caller must capture before it is gone — the store
+/// does not persist it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GeneratedApiKey {
+    pub id: String,
+    pub prefix: String,
+    pub secret: String,
+}
+
+/// In-memory IAM API-key store. Shared via `Arc` across handlers.
+pub struct IamApiKeyStore {
+    keys: DashMap<String, ApiKeyEntry>,
+    seq: AtomicU64,
+}
+
+impl Default for IamApiKeyStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IamApiKeyStore {
+    pub fn new() -> Self {
+        Self {
+            keys: DashMap::new(),
+            seq: AtomicU64::new(0),
+        }
+    }
+
+    /// Seed the store with a fixture set (development / test convenience).
+    /// Each entry is inserted as-is; collisions on `id` overwrite.
+    pub fn seed(&self, entries: impl IntoIterator<Item = ApiKeyEntry>) {
+        for entry in entries {
+            self.keys.insert(entry.id.clone(), entry);
+        }
+    }
+
+    /// Return every entry, sorted by `created_at` descending (newest first).
+    pub fn list(&self) -> Vec<ApiKeyEntry> {
+        let mut out: Vec<ApiKeyEntry> = self.keys.iter().map(|e| e.value().clone()).collect();
+        out.sort_by_key(|e| std::cmp::Reverse(e.created_at));
+        out
+    }
+
+    /// Issue a new key. Returns the [`GeneratedApiKey`] one-shot reveal.
+    pub fn generate(&self, label: &str, scopes: Vec<ApiKeyScope>, owner: &str) -> GeneratedApiKey {
+        let seq = self.seq.fetch_add(1, Ordering::Relaxed);
+        let id = format!("key-gen-{seq}");
+        let prefix = format!("aa_live_{}", random_suffix(4));
+        let secret = format!("{prefix}_{}", random_suffix(32));
+        let now = Utc::now();
+
+        let entry = ApiKeyEntry {
+            id: id.clone(),
+            label: label.to_string(),
+            prefix: prefix.clone(),
+            scopes,
+            status: ApiKeyStatus::Active,
+            created_at: now,
+            last_used: None,
+            owner: owner.to_string(),
+            role: "service:reader".to_string(),
+            assigned_policies: Vec::new(),
+            recent_activity: vec![RecentActivityEntry {
+                id: format!("{id}-act-issue"),
+                timestamp: now,
+                action: "issued".to_string(),
+                target: format!("key issued (label {label})"),
+            }],
+        };
+
+        self.keys.insert(id.clone(), entry);
+
+        GeneratedApiKey { id, prefix, secret }
+    }
+
+    /// Revoke an existing key in place. Returns `Err` if the key is unknown
+    /// or already revoked.
+    pub fn revoke(&self, id: &str, actor: &str) -> Result<(), RevokeError> {
+        let mut entry = self.keys.get_mut(id).ok_or(RevokeError::NotFound)?;
+        if entry.status == ApiKeyStatus::Revoked {
+            return Err(RevokeError::AlreadyRevoked);
+        }
+        let now = Utc::now();
+        entry.status = ApiKeyStatus::Revoked;
+        entry.recent_activity.insert(
+            0,
+            RecentActivityEntry {
+                id: format!("{id}-act-revoke-{}", now.timestamp_millis()),
+                timestamp: now,
+                action: "revoked".to_string(),
+                target: format!("key revoked by {actor}"),
+            },
+        );
+        Ok(())
+    }
+
+    /// Atomically revoke an existing key and issue a replacement with the
+    /// same `label`, `scopes`, and `owner`. The replacement is a brand-new
+    /// record (different `id` and `prefix`); the caller receives the new
+    /// secret in the returned [`GeneratedApiKey`].
+    pub fn rotate(&self, id: &str, actor: &str) -> Result<GeneratedApiKey, RotateError> {
+        // Snapshot the old entry up front so we can re-use its label / scopes
+        // / owner without holding a write reference across `generate`.
+        let (label, scopes, owner) = {
+            let entry = self.keys.get(id).ok_or(RotateError::NotFound)?;
+            if entry.status == ApiKeyStatus::Revoked {
+                return Err(RotateError::AlreadyRevoked);
+            }
+            (entry.label.clone(), entry.scopes.clone(), entry.owner.clone())
+        };
+
+        // Revoke the old entry first so the audit trail records the
+        // revocation before the new issuance.
+        self.revoke(id, actor).map_err(RotateError::from)?;
+        let generated = self.generate(&label, scopes, &owner);
+
+        // Note the rotation linkage on the *new* entry's activity feed so
+        // operators can trace it back.
+        if let Some(mut new_entry) = self.keys.get_mut(&generated.id) {
+            let now = Utc::now();
+            new_entry.recent_activity.insert(
+                0,
+                RecentActivityEntry {
+                    id: format!("{}-act-rotate", generated.id),
+                    timestamp: now,
+                    action: "rotated".to_string(),
+                    target: format!("rotated from {id} by {actor}"),
+                },
+            );
+        }
+
+        Ok(generated)
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq)]
+pub enum RevokeError {
+    #[error("api key not found")]
+    NotFound,
+    #[error("api key is already revoked")]
+    AlreadyRevoked,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq)]
+pub enum RotateError {
+    #[error("api key not found")]
+    NotFound,
+    #[error("api key is already revoked")]
+    AlreadyRevoked,
+}
+
+impl From<RevokeError> for RotateError {
+    fn from(e: RevokeError) -> Self {
+        match e {
+            RevokeError::NotFound => RotateError::NotFound,
+            RevokeError::AlreadyRevoked => RotateError::AlreadyRevoked,
+        }
+    }
+}
+
+/// 31-char base32-ish alphabet — no visually-ambiguous characters.
+const SUFFIX_ALPHABET: &[u8] = b"abcdefghjkmnpqrstuvwxyz23456789";
+
+/// Generate a pseudo-random suffix using a hash of the system nanosecond
+/// clock plus a per-call counter. **Not cryptographically secure** — these
+/// are in-memory mock keys for the dashboard's Identity & Access page; the
+/// follow-up that wires this to durable storage should swap in a CSPRNG
+/// (e.g. `rand::rngs::OsRng`).
+fn random_suffix(length: usize) -> String {
+    use std::hash::{DefaultHasher, Hash, Hasher};
+    use std::sync::atomic::AtomicU64;
+    use std::time::SystemTime;
+
+    static CALL_COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0);
+    let seq = CALL_COUNTER.fetch_add(1, Ordering::Relaxed);
+
+    let mut out = String::with_capacity(length);
+    let mut hasher = DefaultHasher::new();
+    (nanos, seq).hash(&mut hasher);
+    let mut state = hasher.finish();
+    for _ in 0..length {
+        let idx = (state % SUFFIX_ALPHABET.len() as u64) as usize;
+        out.push(SUFFIX_ALPHABET[idx] as char);
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn store() -> IamApiKeyStore {
+        IamApiKeyStore::new()
+    }
+
+    #[test]
+    fn new_store_is_empty() {
+        assert!(store().list().is_empty());
+    }
+
+    #[test]
+    fn generate_returns_secret_and_persists_active_entry() {
+        let s = store();
+        let gen = s.generate("gateway-ci", vec![ApiKeyScope::ReadMembers], "alice");
+        assert!(
+            gen.secret.starts_with(&gen.prefix),
+            "secret should embed the public prefix"
+        );
+        assert!(gen.secret.len() > gen.prefix.len(), "secret should carry random tail");
+
+        let entries = s.list();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, gen.id);
+        assert_eq!(entries[0].label, "gateway-ci");
+        assert_eq!(entries[0].status, ApiKeyStatus::Active);
+        assert_eq!(entries[0].owner, "alice");
+        assert_eq!(
+            entries[0].recent_activity[0].action, "issued",
+            "first activity row should record issuance"
+        );
+    }
+
+    #[test]
+    fn generate_assigns_distinct_ids_under_concurrent_calls() {
+        let s = store();
+        let a = s.generate("k-a", vec![], "alice");
+        let b = s.generate("k-b", vec![], "alice");
+        assert_ne!(a.id, b.id);
+        assert_ne!(a.prefix, b.prefix);
+    }
+
+    #[test]
+    fn revoke_marks_entry_revoked_and_appends_activity() {
+        let s = store();
+        let gen = s.generate("k", vec![], "alice");
+        assert!(s.revoke(&gen.id, "alice").is_ok());
+
+        let entry = s.list().into_iter().find(|e| e.id == gen.id).unwrap();
+        assert_eq!(entry.status, ApiKeyStatus::Revoked);
+        assert_eq!(entry.recent_activity[0].action, "revoked");
+    }
+
+    #[test]
+    fn revoke_returns_not_found_for_unknown_id() {
+        assert_eq!(store().revoke("nope", "alice"), Err(RevokeError::NotFound));
+    }
+
+    #[test]
+    fn revoke_is_idempotent_only_in_the_sense_of_returning_an_explicit_error_on_second_call() {
+        let s = store();
+        let gen = s.generate("k", vec![], "alice");
+        s.revoke(&gen.id, "alice").unwrap();
+        assert_eq!(s.revoke(&gen.id, "alice"), Err(RevokeError::AlreadyRevoked));
+    }
+
+    #[test]
+    fn rotate_revokes_old_and_issues_new_entry_preserving_label_and_owner() {
+        let s = store();
+        let gen = s.generate("ci-runner", vec![ApiKeyScope::ReadAudit], "alice");
+        let rotated = s.rotate(&gen.id, "alice").unwrap();
+
+        assert_ne!(rotated.id, gen.id);
+        assert_ne!(rotated.prefix, gen.prefix);
+
+        let old = s.list().into_iter().find(|e| e.id == gen.id).unwrap();
+        assert_eq!(old.status, ApiKeyStatus::Revoked);
+
+        let new = s.list().into_iter().find(|e| e.id == rotated.id).unwrap();
+        assert_eq!(new.status, ApiKeyStatus::Active);
+        assert_eq!(new.label, "ci-runner");
+        assert_eq!(new.owner, "alice");
+        assert_eq!(new.scopes, vec![ApiKeyScope::ReadAudit]);
+        assert_eq!(
+            new.recent_activity[0].action, "rotated",
+            "new entry should record its rotation provenance"
+        );
+    }
+
+    #[test]
+    fn rotate_returns_not_found_for_unknown_id() {
+        assert_eq!(store().rotate("nope", "alice"), Err(RotateError::NotFound));
+    }
+
+    #[test]
+    fn rotate_refuses_already_revoked_key() {
+        let s = store();
+        let gen = s.generate("k", vec![], "alice");
+        s.revoke(&gen.id, "alice").unwrap();
+        assert_eq!(s.rotate(&gen.id, "alice"), Err(RotateError::AlreadyRevoked));
+    }
+
+    #[test]
+    fn list_sorts_newest_first() {
+        let s = store();
+        let _a = s.generate("a", vec![], "alice");
+        std::thread::sleep(std::time::Duration::from_millis(2));
+        let b = s.generate("b", vec![], "alice");
+
+        let entries = s.list();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].id, b.id, "newest entry should appear first");
+    }
+}

--- a/aa-gateway/src/iam/mod.rs
+++ b/aa-gateway/src/iam/mod.rs
@@ -1,0 +1,14 @@
+//! Identity & Access governance state — API key lifecycle for the dashboard.
+//!
+//! This module is intentionally **distinct** from `aa-api::auth::api_key`,
+//! which authenticates *incoming* bearer tokens. `iam::api_keys` is the
+//! management surface that backs the dashboard's Identity & Access page
+//! (AAASM-119): list / generate / revoke / rotate operations that the
+//! operator-facing UI performs.
+//!
+//! Persistence is **in-memory only** (`DashMap`-backed). Durable storage
+//! across gateway restarts is explicitly out of scope; flagging the
+//! follow-up if needed.
+
+pub mod api_keys;
+pub use api_keys::{ApiKeyEntry, ApiKeyScope, ApiKeyStatus, GeneratedApiKey, IamApiKeyStore, RecentActivityEntry};

--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -12,6 +12,7 @@ pub mod budget;
 pub mod edges;
 pub mod engine;
 pub mod events;
+pub mod iam;
 pub mod message_router;
 pub mod policy;
 pub mod registry;

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -279,5 +279,6 @@ spec:
             .time_to_live(Duration::from_secs(10))
             .build(),
         capability_store: aa_api::routes::capability::CapabilityStore::new_seeded(),
+        iam_api_key_store: aa_api::routes::iam::seeded_iam_store(),
     })
 }

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -406,6 +406,77 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/iam/api-keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * `GET /api/v1/iam/api-keys` — list every API key the IAM store knows.
+         * @description Returned in newest-first order. Active and revoked keys are both
+         *     included; the dashboard filters by status in its tabs.
+         */
+        get: operations["list_api_keys"];
+        put?: never;
+        /**
+         * `POST /api/v1/iam/api-keys` — issue a new API key.
+         * @description IAM mutations are gated as a `Global`-scope policy update — the caller
+         *     must hold the `OrgAdmin` role.
+         *
+         *     The response `secret` field is shown to the caller **once**; the server
+         *     does not persist it.
+         */
+        post: operations["generate_api_key"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/iam/api-keys/{id}/revoke": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * `POST /api/v1/iam/api-keys/{id}/revoke` — revoke an existing key.
+         * @description 404 if the key is unknown, 409 if it is already revoked.
+         */
+        post: operations["revoke_api_key"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/iam/api-keys/{id}/rotate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * `POST /api/v1/iam/api-keys/{id}/rotate` — atomically revoke `id` and
+         *     issue a replacement carrying the same label, scopes, and owner.
+         * @description Returns the new key's one-shot reveal. 404 if `id` is unknown, 409 if
+         *     the source key is already revoked.
+         */
+        post: operations["rotate_api_key"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/logs": {
         parameters: {
             query?: never;
@@ -959,6 +1030,26 @@ export interface components {
             /** @description ISO 8601 timestamp when the alert was raised. */
             timestamp: string;
         };
+        ApiKeyResponse: {
+            assigned_policies: string[];
+            created_at: string;
+            id: string;
+            label: string;
+            last_used?: string | null;
+            owner: string;
+            prefix: string;
+            recent_activity: components["schemas"]["RecentActivityResponse"][];
+            role: string;
+            scopes: components["schemas"]["ApiKeyScopeResponse"][];
+            status: components["schemas"]["ApiKeyStatusResponse"];
+        };
+        /**
+         * @description Scopes a key may hold. Wire form matches the dashboard's TS union.
+         * @enum {string}
+         */
+        ApiKeyScopeResponse: "read:members" | "write:members" | "read:policies" | "write:policies" | "read:audit" | "admin";
+        /** @enum {string} */
+        ApiKeyStatusResponse: "active" | "revoked";
         /**
          * @description Payload for `event_type: "approval"` events.
          *
@@ -1261,6 +1352,19 @@ export interface components {
          * @enum {string}
          */
         EventType: "violation" | "approval" | "budget";
+        GenerateApiKeyRequest: {
+            label: string;
+            scopes: components["schemas"]["ApiKeyScopeResponse"][];
+        };
+        /**
+         * @description One-shot reveal shape returned by generate / rotate. `secret` MUST be
+         *     captured by the caller — the server does not store it.
+         */
+        GeneratedApiKeyResponse: {
+            id: string;
+            prefix: string;
+            secret: string;
+        };
         /**
          * @description A governance event delivered to WebSocket subscribers.
          *
@@ -1468,6 +1572,12 @@ export interface components {
             title: string;
             /** @description URI reference identifying the problem type. */
             type: string;
+        };
+        RecentActivityResponse: {
+            action: string;
+            id: string;
+            target: string;
+            timestamp: string;
         };
         /** @description Summary of a recent event in the API response. */
         RecentEventResponse: {
@@ -2585,6 +2695,143 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["ProblemDetail"];
                 };
+            };
+        };
+    };
+    list_api_keys: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description All API keys, newest first */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiKeyResponse"][];
+                };
+            };
+        };
+    };
+    generate_api_key: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["GenerateApiKeyRequest"];
+            };
+        };
+        responses: {
+            /** @description Generated key (with one-shot secret) */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GeneratedApiKeyResponse"];
+                };
+            };
+            /** @description Caller lacks the role required to mutate IAM state */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    revoke_api_key: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description API key id */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Key revoked */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Caller lacks the role required to mutate IAM state */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unknown api key id */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Key is already revoked */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    rotate_api_key: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description API key id to rotate */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Replacement key with one-shot secret */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GeneratedApiKeyResponse"];
+                };
+            };
+            /** @description Caller lacks the role required to mutate IAM state */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unknown api key id */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Source key is already revoked */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/dashboard/src/features/iam/AccessLogPanel.test.tsx
+++ b/dashboard/src/features/iam/AccessLogPanel.test.tsx
@@ -2,9 +2,10 @@ import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { AccessLogPanel } from './AccessLogPanel'
 import { _accessLogInternal, type AccessLogEvent } from './accessLog'
+import { _apiKeysInternal } from './apiKeys'
 
 function LocationDisplay() {
   const location = useLocation()
@@ -49,6 +50,14 @@ function makeEvent(over: Partial<AccessLogEvent>, hoursAgo: number): AccessLogEv
 describe('AccessLogPanel (AAASM-1398)', () => {
   beforeEach(() => {
     _accessLogInternal.reset()
+    // AAASM-1397: useApiKeysQuery now hits the openapi-fetch client; this
+    // installs the default list override that serves the seed (so the
+    // identity-filter dropdown's api-key options include `gateway-ci`).
+    _apiKeysInternal.reset()
+  })
+
+  afterEach(() => {
+    _apiKeysInternal.reset()
   })
 
   it('renders the iam-panel-access-log section with seeded rows', async () => {

--- a/dashboard/src/features/iam/ApiKeyList.css
+++ b/dashboard/src/features/iam/ApiKeyList.css
@@ -53,6 +53,12 @@
   color: var(--shell-text);
 }
 
+.iam-api-key-list__row-actions {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
 .iam-api-key-list__revoke-btn {
   border: 1px solid var(--status-danger);
   background: transparent;
@@ -64,9 +70,21 @@
   cursor: pointer;
 }
 
-.iam-api-key-list__revoke-btn:disabled {
+.iam-api-key-list__revoke-btn:disabled,
+.iam-api-key-list__rotate-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.iam-api-key-list__rotate-btn {
+  border: 1px solid var(--shell-border-subtle);
+  background: transparent;
+  color: var(--shell-text);
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.25rem 0.6rem;
+  border-radius: 0.25rem;
+  cursor: pointer;
 }
 
 .iam-api-key-list__row--revoked {

--- a/dashboard/src/features/iam/ApiKeyList.test.tsx
+++ b/dashboard/src/features/iam/ApiKeyList.test.tsx
@@ -1,15 +1,16 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ApiKeyList } from './ApiKeyList'
 import { ToastProvider } from '../../components/ToastProvider'
+import { _apiKeysInternal } from './apiKeys'
 import type { ApiKey } from './types'
 
-// In-memory ApiKey store is wired through `useApiKeysQuery` which reads from
-// the module-level seed in `apiKeys.ts`. The shape comes from there, so we
-// don't need a fetch stub — but we do need fresh QueryClients per render to
-// avoid cross-test leakage.
+// AAASM-1397: `useApiKeysQuery` now calls the typed openapi-fetch client.
+// `_apiKeysInternal.reset()` installs a default list override that serves
+// the seeded 3-row fixture, so these tests render against the same shape
+// the gateway produces without needing to mock the openapi-fetch client.
 
 function Wrapper({ children }: { children: React.ReactNode }) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
@@ -22,7 +23,12 @@ function Wrapper({ children }: { children: React.ReactNode }) {
 
 const SEED_KEY_1_ID = 'key-1'
 
+beforeEach(() => {
+  _apiKeysInternal.reset()
+})
+
 afterEach(() => {
+  _apiKeysInternal.reset()
   vi.restoreAllMocks()
 })
 

--- a/dashboard/src/features/iam/ApiKeyList.tsx
+++ b/dashboard/src/features/iam/ApiKeyList.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
-import { useApiKeysQuery, useRevokeApiKeyMutation } from './apiKeys'
+import { useApiKeysQuery, useRevokeApiKeyMutation, useRotateApiKeyMutation } from './apiKeys'
 import { useToast } from '../../components/Toast'
-import type { ApiKey } from './types'
+import type { ApiKey, GeneratedApiKey } from './types'
 import './ApiKeyList.css'
 
 function maskedPrefix(prefix: string): string {
@@ -45,6 +45,46 @@ function ConfirmRevoke({ keyRecord, onCancel, onConfirm }: {
   )
 }
 
+function ConfirmRotate({ keyRecord, onCancel, onConfirm, isPending }: {
+  keyRecord: ApiKey
+  onCancel: () => void
+  onConfirm: () => void
+  isPending: boolean
+}) {
+  return (
+    <div className="iam-dialog__backdrop" role="dialog" aria-modal="true" data-testid="confirm-rotate-key">
+      <div className="iam-dialog">
+        <h2 className="iam-dialog__title">Rotate API key?</h2>
+        <p style={{ fontSize: '0.9rem', margin: 0 }}>
+          Rotating <strong>{keyRecord.label}</strong> ({keyRecord.prefix}…) revokes it
+          immediately and issues a replacement with the same label, scopes, and owner.
+          The new secret is shown <strong>once</strong> — copy it before closing the reveal.
+        </p>
+        <div className="iam-dialog__actions">
+          <button
+            type="button"
+            className="iam-dialog__btn"
+            onClick={onCancel}
+            data-testid="confirm-rotate-cancel"
+            disabled={isPending}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="iam-dialog__btn iam-dialog__btn--primary"
+            onClick={onConfirm}
+            data-testid="confirm-rotate-confirm"
+            disabled={isPending}
+          >
+            {isPending ? 'Rotating…' : 'Rotate'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export interface ApiKeyListProps {
   /** Currently-selected api-key id, drives the row highlight (AAASM-1396). */
   selectedKeyId?: string | null
@@ -52,13 +92,19 @@ export interface ApiKeyListProps {
    *  can render IdentityDetailCard without re-querying. Omit to disable
    *  row selection (preserves the previous click-through-nothing behaviour). */
   onSelect?: (key: ApiKey) => void
+  /** Receives the new key's one-shot reveal when a rotate succeeds, so
+   *  the parent panel can drive the RevealOnceModal exactly as it does
+   *  for the generate flow (AAASM-1397). */
+  onRotated?: (generated: GeneratedApiKey) => void
 }
 
-export function ApiKeyList({ selectedKeyId = null, onSelect }: ApiKeyListProps = {}) {
+export function ApiKeyList({ selectedKeyId = null, onSelect, onRotated }: ApiKeyListProps = {}) {
   const { data, isLoading, isError, refetch } = useApiKeysQuery()
   const revoke = useRevokeApiKeyMutation()
+  const rotate = useRotateApiKeyMutation()
   const { toast } = useToast()
   const [pendingRevoke, setPendingRevoke] = useState<ApiKey | null>(null)
+  const [pendingRotate, setPendingRotate] = useState<ApiKey | null>(null)
 
   if (isError) {
     return (
@@ -76,6 +122,22 @@ export function ApiKeyList({ selectedKeyId = null, onSelect }: ApiKeyListProps =
     revoke.mutate(target.id, {
       onSuccess: () => toast(`Revoked ${target.label}`, 'success'),
       onError: (err) => toast(err instanceof Error ? err.message : 'Revoke failed', 'error'),
+    })
+  }
+
+  function handleConfirmRotate() {
+    if (!pendingRotate) return
+    const target = pendingRotate
+    rotate.mutate(target.id, {
+      onSuccess: (generated) => {
+        setPendingRotate(null)
+        toast(`Rotated ${target.label}`, 'success')
+        onRotated?.(generated)
+      },
+      onError: (err) => {
+        setPendingRotate(null)
+        toast(err instanceof Error ? err.message : 'Rotate failed', 'error')
+      },
     })
   }
 
@@ -170,19 +232,33 @@ export function ApiKeyList({ selectedKeyId = null, onSelect }: ApiKeyListProps =
                 </td>
                 <td>
                   {!revoked && (
-                    <button
-                      type="button"
-                      className="iam-api-key-list__revoke-btn"
-                      data-testid={`api-key-revoke-${k.id}`}
-                      onClick={(e) => {
-                        // Don't bubble to the row's onClick selection handler.
-                        e.stopPropagation()
-                        setPendingRevoke(k)
-                      }}
-                      disabled={revoke.isPending}
-                    >
-                      Revoke
-                    </button>
+                    <div className="iam-api-key-list__row-actions">
+                      <button
+                        type="button"
+                        className="iam-api-key-list__rotate-btn"
+                        data-testid={`api-key-rotate-${k.id}`}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          setPendingRotate(k)
+                        }}
+                        disabled={rotate.isPending}
+                      >
+                        Rotate
+                      </button>
+                      <button
+                        type="button"
+                        className="iam-api-key-list__revoke-btn"
+                        data-testid={`api-key-revoke-${k.id}`}
+                        onClick={(e) => {
+                          // Don't bubble to the row's onClick selection handler.
+                          e.stopPropagation()
+                          setPendingRevoke(k)
+                        }}
+                        disabled={revoke.isPending}
+                      >
+                        Revoke
+                      </button>
+                    </div>
                   )}
                 </td>
               </tr>
@@ -196,6 +272,15 @@ export function ApiKeyList({ selectedKeyId = null, onSelect }: ApiKeyListProps =
           keyRecord={pendingRevoke}
           onCancel={() => setPendingRevoke(null)}
           onConfirm={handleConfirmRevoke}
+        />
+      )}
+
+      {pendingRotate && (
+        <ConfirmRotate
+          keyRecord={pendingRotate}
+          onCancel={() => setPendingRotate(null)}
+          onConfirm={handleConfirmRotate}
+          isPending={rotate.isPending}
         />
       )}
     </>

--- a/dashboard/src/features/iam/ServiceIdentitiesPanel.test.tsx
+++ b/dashboard/src/features/iam/ServiceIdentitiesPanel.test.tsx
@@ -203,11 +203,40 @@ describe('ServiceIdentitiesPanel — revoke', () => {
 })
 
 describe('ServiceIdentitiesPanel — rotate', () => {
-  it('confirms before rotating, then reveals the replacement key one-shot secret', async () => {
-    const rotateSpy = vi.fn().mockResolvedValue({
-      id: 'gen-rotated-1',
-      prefix: 'aa_live_zzzz',
-      secret: 'aa_live_zzzz_freshlyminted9999',
+  it('confirms before rotating, reveals the replacement key one-shot secret, and transitions the source row to revoked', async () => {
+    // Stateful override: when rotate is called for `key-1`, the next list
+    // refetch must show key-1 as `revoked` and a new entry with the new id /
+    // prefix as `active` — matching the contract the gateway provides.
+    const rotatedFrom = new Set<string>()
+    let newEntryId: string | null = null
+    let newEntryPrefix: string | null = null
+    _apiKeysInternal.setListOverride(() => {
+      const seed = _apiKeysInternal.seedSnapshot()
+      const transformed = seed.map((k) =>
+        rotatedFrom.has(k.id) ? { ...k, status: 'revoked' as const } : k,
+      )
+      if (newEntryId && newEntryPrefix) {
+        const source = seed.find((k) => rotatedFrom.has(k.id))
+        if (source) {
+          transformed.unshift({
+            ...source,
+            id: newEntryId,
+            prefix: newEntryPrefix,
+            status: 'active',
+          })
+        }
+      }
+      return Promise.resolve(transformed)
+    })
+    const rotateSpy = vi.fn(async (id: string) => {
+      rotatedFrom.add(id)
+      newEntryId = 'gen-rotated-1'
+      newEntryPrefix = 'aa_live_zzzz'
+      return {
+        id: 'gen-rotated-1',
+        prefix: 'aa_live_zzzz',
+        secret: 'aa_live_zzzz_freshlyminted9999',
+      }
     })
     _apiKeysInternal.setRotateOverride(rotateSpy)
 
@@ -233,6 +262,18 @@ describe('ServiceIdentitiesPanel — rotate', () => {
     expect(modal).toBeInTheDocument()
     const secret = screen.getByTestId('reveal-once-secret') as HTMLInputElement
     expect(secret.value).toBe('aa_live_zzzz_freshlyminted9999')
+
+    // The source row transitions to revoked (no rotate / revoke buttons),
+    // and the replacement row appears with the new prefix.
+    await waitFor(() =>
+      expect(screen.queryByTestId('api-key-rotate-key-1')).not.toBeInTheDocument(),
+    )
+    await waitFor(() =>
+      expect(screen.getByTestId('api-key-row-gen-rotated-1')).toBeInTheDocument(),
+    )
+    expect(
+      screen.getByTestId('api-key-row-gen-rotated-1').textContent,
+    ).toContain('aa_live_zzzz')
   })
 
   it('surfaces a failure via toast and closes the confirm without revealing', async () => {

--- a/dashboard/src/features/iam/ServiceIdentitiesPanel.test.tsx
+++ b/dashboard/src/features/iam/ServiceIdentitiesPanel.test.tsx
@@ -173,7 +173,20 @@ describe('ServiceIdentitiesPanel — generate-and-reveal flow', () => {
 })
 
 describe('ServiceIdentitiesPanel — revoke', () => {
-  it('confirms before revoking, then toggles the row to revoked', async () => {
+  it('confirms before revoking, calls the revoke endpoint, and removes the revoke button', async () => {
+    const revokedIds = new Set<string>()
+    _apiKeysInternal.setListOverride(() =>
+      Promise.resolve(
+        _apiKeysInternal.seedSnapshot().map((k) =>
+          revokedIds.has(k.id) ? { ...k, status: 'revoked' as const } : k,
+        ),
+      ),
+    )
+    const revokeSpy = vi.fn(async (id: string) => {
+      revokedIds.add(id)
+    })
+    _apiKeysInternal.setRevokeOverride(revokeSpy)
+
     const user = userEvent.setup()
     renderPanel()
     await screen.findByTestId('api-key-row-key-1')
@@ -182,10 +195,10 @@ describe('ServiceIdentitiesPanel — revoke', () => {
     expect(await screen.findByTestId('confirm-revoke-key')).toBeInTheDocument()
     await user.click(screen.getByTestId('confirm-revoke-confirm'))
 
+    await waitFor(() => expect(revokeSpy).toHaveBeenCalledWith('key-1'))
     await waitFor(() =>
-      expect(_apiKeysInternal.snapshot().find((k) => k.id === 'key-1')?.status).toBe('revoked'),
+      expect(screen.queryByTestId('api-key-revoke-key-1')).not.toBeInTheDocument(),
     )
-    expect(screen.queryByTestId('api-key-revoke-key-1')).not.toBeInTheDocument()
   })
 })
 

--- a/dashboard/src/features/iam/ServiceIdentitiesPanel.test.tsx
+++ b/dashboard/src/features/iam/ServiceIdentitiesPanel.test.tsx
@@ -202,5 +202,68 @@ describe('ServiceIdentitiesPanel — revoke', () => {
   })
 })
 
+describe('ServiceIdentitiesPanel — rotate', () => {
+  it('confirms before rotating, then reveals the replacement key one-shot secret', async () => {
+    const rotateSpy = vi.fn().mockResolvedValue({
+      id: 'gen-rotated-1',
+      prefix: 'aa_live_zzzz',
+      secret: 'aa_live_zzzz_freshlyminted9999',
+    })
+    _apiKeysInternal.setRotateOverride(rotateSpy)
+
+    const user = userEvent.setup()
+    renderPanel()
+    await screen.findByTestId('api-key-row-key-1')
+
+    // Open the rotate confirm.
+    await user.click(screen.getByTestId('api-key-rotate-key-1'))
+    expect(await screen.findByTestId('confirm-rotate-key')).toBeInTheDocument()
+
+    // Cancel path leaves the row alone.
+    await user.click(screen.getByTestId('confirm-rotate-cancel'))
+    expect(screen.queryByTestId('confirm-rotate-key')).not.toBeInTheDocument()
+    expect(rotateSpy).not.toHaveBeenCalled()
+
+    // Confirm path triggers the rotate + reveal.
+    await user.click(screen.getByTestId('api-key-rotate-key-1'))
+    await user.click(screen.getByTestId('confirm-rotate-confirm'))
+
+    await waitFor(() => expect(rotateSpy).toHaveBeenCalledWith('key-1'))
+    const modal = await screen.findByTestId('reveal-once-modal')
+    expect(modal).toBeInTheDocument()
+    const secret = screen.getByTestId('reveal-once-secret') as HTMLInputElement
+    expect(secret.value).toBe('aa_live_zzzz_freshlyminted9999')
+  })
+
+  it('surfaces a failure via toast and closes the confirm without revealing', async () => {
+    const rotateSpy = vi.fn().mockRejectedValue(new Error('source key already revoked'))
+    _apiKeysInternal.setRotateOverride(rotateSpy)
+
+    const user = userEvent.setup()
+    renderPanel()
+    await screen.findByTestId('api-key-row-key-1')
+
+    await user.click(screen.getByTestId('api-key-rotate-key-1'))
+    await user.click(screen.getByTestId('confirm-rotate-confirm'))
+
+    await waitFor(() => expect(rotateSpy).toHaveBeenCalledWith('key-1'))
+    await waitFor(() =>
+      expect(screen.queryByTestId('confirm-rotate-key')).not.toBeInTheDocument(),
+    )
+    // No reveal modal must appear on failure.
+    expect(screen.queryByTestId('reveal-once-modal')).not.toBeInTheDocument()
+
+    const toastContainer = screen.getByTestId('toast-container')
+    expect(toastContainer.textContent).toContain('source key already revoked')
+  })
+
+  it('does not render a rotate button on already-revoked rows', async () => {
+    renderPanel()
+    await screen.findByTestId('api-key-row-key-3')
+    expect(screen.queryByTestId('api-key-rotate-key-3')).not.toBeInTheDocument()
+    expect(screen.getByTestId('api-key-rotate-key-1')).toBeInTheDocument()
+  })
+})
+
 // helper import kept after definitions to avoid hoisting hassles in tests
 import { within } from '@testing-library/react'

--- a/dashboard/src/features/iam/ServiceIdentitiesPanel.tsx
+++ b/dashboard/src/features/iam/ServiceIdentitiesPanel.tsx
@@ -73,6 +73,7 @@ export function ServiceIdentitiesPanel() {
           <ApiKeyList
             selectedKeyId={selected?.id ?? null}
             onSelect={setSelected}
+            onRotated={(generated) => reveal.reveal(generated)}
           />
         </div>
         <div className="iam-services-panel__detail">

--- a/dashboard/src/features/iam/apiKeys.ts
+++ b/dashboard/src/features/iam/apiKeys.ts
@@ -1,17 +1,19 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { api } from '../../api/client'
 import { iamQueryKeys } from './queryKeys'
 import type { ApiKey, GenerateApiKeyInput, GeneratedApiKey } from './types'
 
 /**
- * In-memory API key store. Mirrors the pattern in api.ts (members):
- * the OpenAPI spec does not yet define `/v1/iam/api-keys`, so the
- * React Query hooks read from a process-local collection until the
- * gateway lands. Hook signatures match the eventual fetch-backed
- * shapes so the swap is a one-function change.
+ * Identity & Access — API key client (AAASM-1397).
  *
- * Invariant: the `secret` field returned by generate() must NEVER be
- * persisted alongside the ApiKey record — it is the one-time reveal
- * the caller has to capture before it is gone.
+ * Production code paths call the typed `openapi-fetch` client against
+ * `/api/v1/iam/api-keys*`. The `_apiKeysInternal.set*Override` hooks are
+ * deliberate test seams that short-circuit the fetch — tests register a
+ * promise that replaces the network call without needing to mock the
+ * openapi-fetch client.
+ *
+ * Invariant: the `secret` returned by generate() and rotate() is the
+ * one-time reveal — the server never persists it.
  */
 const SEED_API_KEYS: ApiKey[] = [
   {
@@ -65,64 +67,51 @@ const SEED_API_KEYS: ApiKey[] = [
   },
 ]
 
-interface KeyStore {
-  keys: ApiKey[]
-}
-
-const keyStore: KeyStore = { keys: [...SEED_API_KEYS] }
-
+let _listOverride: (() => Promise<ApiKey[]>) | null = null
 let _generateOverride: ((input: GenerateApiKeyInput) => Promise<GeneratedApiKey>) | null = null
 let _revokeOverride: ((id: string) => Promise<void>) | null = null
-let _keySeq = 0
+let _rotateOverride: ((id: string) => Promise<GeneratedApiKey>) | null = null
+let _testSeed: readonly ApiKey[] = SEED_API_KEYS
 
-function fetchApiKeys(): Promise<ApiKey[]> {
-  return Promise.resolve([...keyStore.keys])
-}
-
-function randomSuffix(length = 24): string {
-  const alphabet = 'abcdefghjkmnpqrstuvwxyz23456789'
-  let out = ''
-  for (let i = 0; i < length; i++) {
-    out += alphabet[Math.floor(Math.random() * alphabet.length)]
+async function fetchApiKeys(): Promise<ApiKey[]> {
+  if (_listOverride) return _listOverride()
+  const { data, error } = await api.GET('/api/v1/iam/api-keys')
+  if (error || !data) {
+    throw new Error('list api keys failed')
   }
-  return out
+  return data as ApiKey[]
 }
 
-function generateApiKey(input: GenerateApiKeyInput): Promise<GeneratedApiKey> {
+async function generateApiKey(input: GenerateApiKeyInput): Promise<GeneratedApiKey> {
   if (_generateOverride) return _generateOverride(input)
-  const id = `key-gen-${++_keySeq}`
-  const prefix = `aa_live_${randomSuffix(4)}`
-  const secret = `${prefix}_${randomSuffix(32)}`
-  const nowIso = new Date().toISOString()
-  const record: ApiKey = {
-    id,
-    label: input.label,
-    prefix,
-    scopes: [...input.scopes],
-    status: 'active',
-    created_at: nowIso,
-    last_used: null,
-    // AAASM-1396 defaults — overwritten once an owner / role assignment
-    // surface exists; for now the generation flow names the implicit
-    // "self-issued" owner so the IdentityDetailCard has non-empty fields.
-    owner: 'self',
-    role: 'service:reader',
-    assigned_policies: [],
-    recent_activity: [
-      { id: `${id}-act-issue`, timestamp: nowIso, action: 'issued', target: `key issued (label ${input.label})` },
-    ],
+  const { data, error } = await api.POST('/api/v1/iam/api-keys', {
+    body: { label: input.label, scopes: input.scopes },
+  })
+  if (error || !data) {
+    throw new Error('generate api key failed')
   }
-  keyStore.keys = [record, ...keyStore.keys]
-  return Promise.resolve({ id, prefix, secret })
+  return data as GeneratedApiKey
 }
 
-function revokeApiKey(id: string): Promise<void> {
+async function revokeApiKey(id: string): Promise<void> {
   if (_revokeOverride) return _revokeOverride(id)
-  const idx = keyStore.keys.findIndex((k) => k.id === id)
-  if (idx === -1) return Promise.reject(new Error(`api key ${id} not found`))
-  const updated: ApiKey = { ...keyStore.keys[idx], status: 'revoked' }
-  keyStore.keys = [...keyStore.keys.slice(0, idx), updated, ...keyStore.keys.slice(idx + 1)]
-  return Promise.resolve()
+  const { error } = await api.POST('/api/v1/iam/api-keys/{id}/revoke', {
+    params: { path: { id } },
+  })
+  if (error) {
+    throw new Error(`revoke api key ${id} failed`)
+  }
+}
+
+async function rotateApiKey(id: string): Promise<GeneratedApiKey> {
+  if (_rotateOverride) return _rotateOverride(id)
+  const { data, error } = await api.POST('/api/v1/iam/api-keys/{id}/rotate', {
+    params: { path: { id } },
+  })
+  if (error || !data) {
+    throw new Error(`rotate api key ${id} failed`)
+  }
+  return data as GeneratedApiKey
 }
 
 export function useApiKeysQuery() {
@@ -152,25 +141,50 @@ export function useRevokeApiKeyMutation() {
   })
 }
 
+export function useRotateApiKeyMutation() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => rotateApiKey(id),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: iamQueryKeys.apiKeys() })
+    },
+  })
+}
+
+/**
+ * Test-only seams. `reset()` installs a default list override that serves
+ * the seed fixture so tests render against the same 3-entry table the
+ * gateway seeds; individual specs override generate / revoke / rotate as
+ * needed.
+ */
 export const _apiKeysInternal: {
   reset: () => void
-  snapshot: () => readonly ApiKey[]
+  setListOverride: (fn: (() => Promise<ApiKey[]>) | null) => void
   setGenerateOverride: (fn: ((input: GenerateApiKeyInput) => Promise<GeneratedApiKey>) | null) => void
   setRevokeOverride: (fn: ((id: string) => Promise<void>) | null) => void
+  setRotateOverride: (fn: ((id: string) => Promise<GeneratedApiKey>) | null) => void
+  seedSnapshot: () => readonly ApiKey[]
 } = {
   reset(): void {
-    keyStore.keys = [...SEED_API_KEYS]
+    _testSeed = SEED_API_KEYS
+    _listOverride = () => Promise.resolve([..._testSeed])
     _generateOverride = null
     _revokeOverride = null
-    _keySeq = 0
+    _rotateOverride = null
   },
-  snapshot(): readonly ApiKey[] {
-    return keyStore.keys
+  setListOverride(fn) {
+    _listOverride = fn
   },
   setGenerateOverride(fn) {
     _generateOverride = fn
   },
   setRevokeOverride(fn) {
     _revokeOverride = fn
+  },
+  setRotateOverride(fn) {
+    _rotateOverride = fn
+  },
+  seedSnapshot(): readonly ApiKey[] {
+    return _testSeed
   },
 }

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -643,6 +643,104 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProblemDetail'
+  /api/v1/iam/api-keys:
+    get:
+      tags:
+      - iam
+      summary: '`GET /api/v1/iam/api-keys` — list every API key the IAM store knows.'
+      description: |-
+        Returned in newest-first order. Active and revoked keys are both
+        included; the dashboard filters by status in its tabs.
+      operationId: list_api_keys
+      responses:
+        '200':
+          description: All API keys, newest first
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ApiKeyResponse'
+    post:
+      tags:
+      - iam
+      summary: '`POST /api/v1/iam/api-keys` — issue a new API key.'
+      description: |-
+        IAM mutations are gated as a `Global`-scope policy update — the caller
+        must hold the `OrgAdmin` role.
+
+        The response `secret` field is shown to the caller **once**; the server
+        does not persist it.
+      operationId: generate_api_key
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenerateApiKeyRequest'
+        required: true
+      responses:
+        '200':
+          description: Generated key (with one-shot secret)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneratedApiKeyResponse'
+        '403':
+          description: Caller lacks the role required to mutate IAM state
+  /api/v1/iam/api-keys/{id}/revoke:
+    post:
+      tags:
+      - iam
+      summary: '`POST /api/v1/iam/api-keys/{id}/revoke` — revoke an existing key.'
+      description: 404 if the key is unknown, 409 if it is already revoked.
+      operationId: revoke_api_key
+      parameters:
+      - name: id
+        in: path
+        description: API key id
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Key revoked
+        '403':
+          description: Caller lacks the role required to mutate IAM state
+        '404':
+          description: Unknown api key id
+        '409':
+          description: Key is already revoked
+  /api/v1/iam/api-keys/{id}/rotate:
+    post:
+      tags:
+      - iam
+      summary: |-
+        `POST /api/v1/iam/api-keys/{id}/rotate` — atomically revoke `id` and
+        issue a replacement carrying the same label, scopes, and owner.
+      description: |-
+        Returns the new key's one-shot reveal. 404 if `id` is unknown, 409 if
+        the source key is already revoked.
+      operationId: rotate_api_key
+      parameters:
+      - name: id
+        in: path
+        description: API key id to rotate
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Replacement key with one-shot secret
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneratedApiKeyResponse'
+        '403':
+          description: Caller lacks the role required to mutate IAM state
+        '404':
+          description: Unknown api key id
+        '409':
+          description: Source key is already revoked
   /api/v1/logs:
     get:
       tags:
@@ -1539,6 +1637,65 @@ components:
         timestamp:
           type: string
           description: ISO 8601 timestamp when the alert was raised.
+    ApiKeyResponse:
+      type: object
+      required:
+      - id
+      - label
+      - prefix
+      - scopes
+      - status
+      - created_at
+      - owner
+      - role
+      - assigned_policies
+      - recent_activity
+      properties:
+        assigned_policies:
+          type: array
+          items:
+            type: string
+        created_at:
+          type: string
+        id:
+          type: string
+        label:
+          type: string
+        last_used:
+          type:
+          - string
+          - 'null'
+        owner:
+          type: string
+        prefix:
+          type: string
+        recent_activity:
+          type: array
+          items:
+            $ref: '#/components/schemas/RecentActivityResponse'
+        role:
+          type: string
+        scopes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApiKeyScopeResponse'
+        status:
+          $ref: '#/components/schemas/ApiKeyStatusResponse'
+    ApiKeyScopeResponse:
+      type: string
+      description: Scopes a key may hold. Wire form matches the dashboard's TS union.
+      enum:
+      - read:members
+      - write:members
+      - read:policies
+      - write:policies
+      - read:audit
+      - admin
+    ApiKeyStatusResponse:
+      type: string
+      enum:
+      - active
+      - revoked
     ApprovalPayload:
       type: object
       description: |-
@@ -2084,6 +2241,34 @@ components:
       - violation
       - approval
       - budget
+    GenerateApiKeyRequest:
+      type: object
+      required:
+      - label
+      - scopes
+      properties:
+        label:
+          type: string
+        scopes:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApiKeyScopeResponse'
+    GeneratedApiKeyResponse:
+      type: object
+      description: |-
+        One-shot reveal shape returned by generate / rotate. `secret` MUST be
+        captured by the caller — the server does not store it.
+      required:
+      - id
+      - prefix
+      - secret
+      properties:
+        id:
+          type: string
+        prefix:
+          type: string
+        secret:
+          type: string
     GovernanceEvent:
       type: object
       description: |-
@@ -2426,6 +2611,22 @@ components:
         status: 404
         title: Not Found
         type: about:blank
+    RecentActivityResponse:
+      type: object
+      required:
+      - id
+      - timestamp
+      - action
+      - target
+      properties:
+        action:
+          type: string
+        id:
+          type: string
+        target:
+          type: string
+        timestamp:
+          type: string
     RecentEventResponse:
       type: object
       description: Summary of a recent event in the API response.
@@ -3195,3 +3396,5 @@ tags:
   description: Per-operation lifecycle actions (pause / resume / terminate)
 - name: capability
   description: Dashboard Capability Matrix — agent × resource × verb × decision view
+- name: iam
+  description: Identity & Access — API key list / generate / revoke / rotate


### PR DESCRIPTION
## Summary

AAASM-1397 — wires the full Identity & Access API key lifecycle (list / generate / revoke / **rotate**) end-to-end, from gateway store to dashboard UI.

- **`aa-gateway::iam::IamApiKeyStore`** — new in-memory, DashMap-backed store with the four lifecycle methods (10 unit tests).
- **`aa-api/v1/iam/api-keys{,/{id}/revoke,/{id}/rotate}`** — four Axum handlers gated by `PolicyWriteAuth` (Global / OrgAdmin); secret is one-shot, never persisted server-side (10 integration tests).
- **OpenAPI** — new `iam` tag, six new schemas, regenerated `openapi/v1.yaml` + dashboard `schema.d.ts`.
- **Dashboard** — `apiKeys.ts` hooks now call the typed `openapi-fetch` client; new `useRotateApiKeyMutation`; new `Rotate` button on each active row with a confirm dialog; on success the existing `RevealOnceModal` shows the replacement secret. 3 new vitest specs cover happy path, failure path, and revoked-row guard.

The seeded fixture in the gateway is byte-identical to the dashboard's previous mock, so the swap is invisible to operators looking at the existing 3-entry view.

## Test plan

- [x] `cargo nextest run -p aa-gateway -p aa-api` — **1059/1059 pass**
- [x] `pnpm exec vitest run` — **891/891 pass**
- [x] `pnpm type-check`, `pnpm lint` — clean
- [x] `cargo fmt --all`, `cargo clippy -p aa-gateway -p aa-api --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)