### PR TITLE
[AAASM-1398] ✨ (iam): Add Filterable Access Log tab

### DIFF
--- a/dashboard/src/features/iam/AccessLogFilterBar.css
+++ b/dashboard/src/features/iam/AccessLogFilterBar.css
@@ -1,0 +1,34 @@
+.iam-access-log-filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid var(--shell-border-subtle);
+  margin-bottom: 0.75rem;
+}
+
+.iam-access-log-filter-bar__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 12rem;
+}
+
+.iam-access-log-filter-bar__label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--shell-text-muted);
+}
+
+.iam-access-log-filter-bar__select,
+.iam-access-log-filter-bar__date {
+  font-size: 0.85rem;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid var(--shell-border-subtle);
+  border-radius: 0.25rem;
+  background: var(--shell-surface);
+  color: var(--shell-text);
+}

--- a/dashboard/src/features/iam/AccessLogFilterBar.test.tsx
+++ b/dashboard/src/features/iam/AccessLogFilterBar.test.tsx
@@ -1,0 +1,105 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { AccessLogFilterBar } from './AccessLogFilterBar'
+import type { AccessLogFilter } from './accessLog'
+
+const IDENTITIES = ['alice@example.com', 'gateway-ci', 'observability-exporter']
+
+describe('AccessLogFilterBar (AAASM-1398)', () => {
+  it('renders the three required controls inside the filter bar', () => {
+    render(
+      <AccessLogFilterBar identities={IDENTITIES} value={{}} onChange={vi.fn()} />,
+    )
+    expect(screen.getByTestId('access-log-filter-bar')).toBeInTheDocument()
+    expect(screen.getByTestId('access-log-filter-identity')).toBeInTheDocument()
+    expect(screen.getByTestId('access-log-filter-event-type')).toBeInTheDocument()
+    expect(screen.getByTestId('access-log-filter-time-range')).toBeInTheDocument()
+    // Custom date inputs only show up when 'custom' is selected.
+    expect(screen.queryByTestId('access-log-filter-custom-from')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('access-log-filter-custom-to')).not.toBeInTheDocument()
+  })
+
+  it('changing identity emits onChange with the new identity', async () => {
+    const onChange = vi.fn<(next: AccessLogFilter) => void>()
+    render(
+      <AccessLogFilterBar identities={IDENTITIES} value={{}} onChange={onChange} />,
+    )
+    await userEvent.selectOptions(
+      screen.getByTestId('access-log-filter-identity'),
+      'gateway-ci',
+    )
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ identity: 'gateway-ci' }),
+    )
+  })
+
+  it('selecting the empty identity option clears the identity filter to null', async () => {
+    const onChange = vi.fn<(next: AccessLogFilter) => void>()
+    render(
+      <AccessLogFilterBar
+        identities={IDENTITIES}
+        value={{ identity: 'gateway-ci' }}
+        onChange={onChange}
+      />,
+    )
+    await userEvent.selectOptions(
+      screen.getByTestId('access-log-filter-identity'),
+      '',
+    )
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ identity: null }),
+    )
+  })
+
+  it('changing event type emits onChange with the typed event_type value', async () => {
+    const onChange = vi.fn<(next: AccessLogFilter) => void>()
+    render(
+      <AccessLogFilterBar identities={IDENTITIES} value={{}} onChange={onChange} />,
+    )
+    await userEvent.selectOptions(
+      screen.getByTestId('access-log-filter-event-type'),
+      'key_rotate',
+    )
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: 'key_rotate' }),
+    )
+  })
+
+  it('selecting custom time range reveals from / to date inputs', async () => {
+    const onChange = vi.fn<(next: AccessLogFilter) => void>()
+    function Harness() {
+      return (
+        <AccessLogFilterBar
+          identities={IDENTITIES}
+          value={{ timeRange: { kind: 'custom', from: '2026-05-10', to: '2026-05-17' } }}
+          onChange={onChange}
+        />
+      )
+    }
+    render(<Harness />)
+    expect(screen.getByTestId('access-log-filter-custom-from')).toBeInTheDocument()
+    expect(screen.getByTestId('access-log-filter-custom-to')).toBeInTheDocument()
+  })
+
+  it('selecting custom from "Any time" defaults the range to last 7 days', async () => {
+    const onChange = vi.fn<(next: AccessLogFilter) => void>()
+    render(
+      <AccessLogFilterBar identities={IDENTITIES} value={{}} onChange={onChange} />,
+    )
+    await userEvent.selectOptions(
+      screen.getByTestId('access-log-filter-time-range'),
+      'custom',
+    )
+    expect(onChange).toHaveBeenCalledTimes(1)
+    const next = onChange.mock.calls[0][0]
+    expect(next.timeRange).toMatchObject({ kind: 'custom' })
+    // The defaulted from/to span ~7 days.
+    if (next.timeRange?.kind !== 'custom') throw new Error('expected custom')
+    const fromMs = new Date(next.timeRange.from).getTime()
+    const toMs = new Date(next.timeRange.to).getTime()
+    const days = (toMs - fromMs) / (24 * 60 * 60 * 1000)
+    expect(days).toBeGreaterThanOrEqual(6.5)
+    expect(days).toBeLessThanOrEqual(7.5)
+  })
+})

--- a/dashboard/src/features/iam/AccessLogFilterBar.tsx
+++ b/dashboard/src/features/iam/AccessLogFilterBar.tsx
@@ -1,0 +1,170 @@
+import {
+  ACCESS_LOG_EVENT_TYPES,
+  type AccessLogEventType,
+  type AccessLogFilter,
+  type AccessLogTimeRange,
+} from './accessLog'
+import './AccessLogFilterBar.css'
+
+const EVENT_TYPE_LABELS: Record<AccessLogEventType, string> = {
+  login: 'Login',
+  logout: 'Logout',
+  policy_change: 'Policy change',
+  key_rotate: 'Key rotation',
+  member_invite: 'Member invite',
+  permission_grant: 'Permission grant',
+}
+
+const TIME_RANGE_OPTIONS = ['24h', '7d', '30d', 'custom'] as const
+type TimeRangeOption = (typeof TIME_RANGE_OPTIONS)[number]
+
+const TIME_RANGE_LABELS: Record<TimeRangeOption, string> = {
+  '24h': 'Last 24 hours',
+  '7d': 'Last 7 days',
+  '30d': 'Last 30 days',
+  custom: 'Custom range',
+}
+
+export interface AccessLogFilterBarProps {
+  /** Candidate identity values for the identity select — usually the union
+   *  of member emails and active service-key labels. */
+  identities: readonly string[]
+  value: AccessLogFilter
+  onChange: (next: AccessLogFilter) => void
+}
+
+function readTimeRangeKind(range: AccessLogTimeRange | undefined): TimeRangeOption | '' {
+  if (!range) return ''
+  return range.kind
+}
+
+export function AccessLogFilterBar({
+  identities,
+  value,
+  onChange,
+}: AccessLogFilterBarProps) {
+  const currentTimeKind = readTimeRangeKind(value.timeRange)
+  const isCustom = value.timeRange?.kind === 'custom'
+
+  return (
+    <div className="iam-access-log-filter-bar" data-testid="access-log-filter-bar">
+      <label className="iam-access-log-filter-bar__field">
+        <span className="iam-access-log-filter-bar__label">Identity</span>
+        <select
+          className="iam-access-log-filter-bar__select"
+          data-testid="access-log-filter-identity"
+          value={value.identity ?? ''}
+          onChange={(e) => {
+            const raw = e.target.value
+            onChange({ ...value, identity: raw === '' ? null : raw })
+          }}
+        >
+          <option value="">All identities</option>
+          {identities.map((id) => (
+            <option key={id} value={id}>
+              {id}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="iam-access-log-filter-bar__field">
+        <span className="iam-access-log-filter-bar__label">Event type</span>
+        <select
+          className="iam-access-log-filter-bar__select"
+          data-testid="access-log-filter-event-type"
+          value={value.eventType ?? ''}
+          onChange={(e) => {
+            const raw = e.target.value
+            onChange({
+              ...value,
+              eventType: raw === '' ? null : (raw as AccessLogEventType),
+            })
+          }}
+        >
+          <option value="">All event types</option>
+          {ACCESS_LOG_EVENT_TYPES.map((t) => (
+            <option key={t} value={t}>
+              {EVENT_TYPE_LABELS[t]}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="iam-access-log-filter-bar__field">
+        <span className="iam-access-log-filter-bar__label">Time range</span>
+        <select
+          className="iam-access-log-filter-bar__select"
+          data-testid="access-log-filter-time-range"
+          value={currentTimeKind}
+          onChange={(e) => {
+            const raw = e.target.value as TimeRangeOption | ''
+            if (raw === '') {
+              onChange({ ...value, timeRange: undefined })
+              return
+            }
+            if (raw === 'custom') {
+              // Default the custom range to the last 7 days so the inputs
+              // open populated rather than empty (empty dates would render
+              // the table as "no rows" until the user picks both ends).
+              const to = new Date().toISOString().slice(0, 10)
+              const from = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+                .toISOString()
+                .slice(0, 10)
+              onChange({ ...value, timeRange: { kind: 'custom', from, to } })
+              return
+            }
+            onChange({ ...value, timeRange: { kind: raw } })
+          }}
+        >
+          <option value="">Any time</option>
+          {TIME_RANGE_OPTIONS.map((opt) => (
+            <option key={opt} value={opt}>
+              {TIME_RANGE_LABELS[opt]}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {isCustom && value.timeRange?.kind === 'custom' && (
+        <>
+          <label className="iam-access-log-filter-bar__field">
+            <span className="iam-access-log-filter-bar__label">From</span>
+            <input
+              type="date"
+              className="iam-access-log-filter-bar__date"
+              data-testid="access-log-filter-custom-from"
+              // <input type="date"> emits YYYY-MM-DD; we keep that as the
+              // stored representation in the filter and the data layer
+              // does an ISO string comparison.
+              value={value.timeRange.from.slice(0, 10)}
+              onChange={(e) => {
+                if (value.timeRange?.kind !== 'custom') return
+                onChange({
+                  ...value,
+                  timeRange: { ...value.timeRange, from: e.target.value },
+                })
+              }}
+            />
+          </label>
+          <label className="iam-access-log-filter-bar__field">
+            <span className="iam-access-log-filter-bar__label">To</span>
+            <input
+              type="date"
+              className="iam-access-log-filter-bar__date"
+              data-testid="access-log-filter-custom-to"
+              value={value.timeRange.to.slice(0, 10)}
+              onChange={(e) => {
+                if (value.timeRange?.kind !== 'custom') return
+                onChange({
+                  ...value,
+                  timeRange: { ...value.timeRange, to: e.target.value },
+                })
+              }}
+            />
+          </label>
+        </>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/features/iam/AccessLogPanel.css
+++ b/dashboard/src/features/iam/AccessLogPanel.css
@@ -1,0 +1,116 @@
+.iam-access-log-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.iam-access-log-panel__intro {
+  margin: 0 0 0.5rem;
+  color: var(--shell-text-muted);
+  font-size: 0.85rem;
+}
+
+.iam-access-log-panel__loading,
+.iam-access-log-panel__empty {
+  padding: 1.5rem 0;
+  text-align: center;
+  color: var(--shell-text-muted);
+}
+
+.iam-access-log-panel__error {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: var(--status-danger-hover-text);
+  padding: 0.75rem 0;
+}
+
+.iam-access-log-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.iam-access-log-table th,
+.iam-access-log-table td {
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid var(--shell-border-subtle);
+}
+
+.iam-access-log-table th {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--shell-text-muted);
+}
+
+.iam-access-log-table__mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
+  font-size: 0.8rem;
+}
+
+.iam-access-log-table__row {
+  cursor: pointer;
+}
+
+.iam-access-log-table__row:hover {
+  background: var(--shell-surface-subtle);
+}
+
+.iam-access-log-table__result {
+  display: inline-block;
+  padding: 1px 6px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 0.25rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.iam-access-log-table__result--success {
+  background: var(--status-success-bg, rgba(46, 160, 67, 0.15));
+  color: var(--status-success, #2ea043);
+}
+
+.iam-access-log-table__result--failure {
+  background: var(--status-danger-bg, rgba(218, 54, 51, 0.15));
+  color: var(--status-danger, #da3633);
+}
+
+.iam-access-log-table__link {
+  color: var(--shell-accent);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+
+.iam-access-log-table__link:hover {
+  text-decoration: underline;
+}
+
+.iam-access-log-panel__pagination {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  justify-content: flex-end;
+  padding: 0.75rem 0;
+  font-size: 0.85rem;
+  color: var(--shell-text-muted);
+}
+
+.iam-access-log-panel__pagination button {
+  padding: 0.25rem 0.6rem;
+  border: 1px solid var(--shell-border-subtle);
+  border-radius: 0.25rem;
+  background: transparent;
+  color: var(--shell-text);
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.iam-access-log-panel__pagination button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/dashboard/src/features/iam/AccessLogPanel.test.tsx
+++ b/dashboard/src/features/iam/AccessLogPanel.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { AccessLogPanel } from './AccessLogPanel'
+import { _accessLogInternal, type AccessLogEvent } from './accessLog'
+
+function LocationDisplay() {
+  const location = useLocation()
+  return <div data-testid="location-display">{location.pathname}</div>
+}
+
+function Harness() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={['/identity?tab=access-log']}>
+        <Routes>
+          <Route
+            path="/identity"
+            element={
+              <>
+                <AccessLogPanel />
+                <LocationDisplay />
+              </>
+            }
+          />
+          <Route path="/audit/event/:id" element={<LocationDisplay />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+function makeEvent(over: Partial<AccessLogEvent>, hoursAgo: number): AccessLogEvent {
+  return {
+    id: 'evt-x',
+    timestamp: new Date(Date.now() - hoursAgo * 60 * 60 * 1000).toISOString(),
+    identity: 'alice@agent-assembly.dev',
+    event_type: 'login',
+    target: 'dashboard',
+    result: 'success',
+    source_ip: '10.0.0.1',
+    ...over,
+  }
+}
+
+describe('AccessLogPanel (AAASM-1398)', () => {
+  beforeEach(() => {
+    _accessLogInternal.reset()
+  })
+
+  it('renders the iam-panel-access-log section with seeded rows', async () => {
+    render(<Harness />)
+    await waitFor(() => {
+      expect(screen.getByTestId('iam-panel-access-log')).toBeInTheDocument()
+    })
+    // The default seed has 10 events — all should appear on page 1.
+    await waitFor(() => {
+      expect(screen.getByTestId('access-log-row-evt-1')).toBeInTheDocument()
+      expect(screen.getByTestId('access-log-row-evt-10')).toBeInTheDocument()
+    })
+  })
+
+  it('shows the empty state when the filter narrows to zero rows', async () => {
+    _accessLogInternal.setFetchOverride(() => Promise.resolve([]))
+    render(<Harness />)
+    expect(await screen.findByTestId('access-log-empty')).toBeInTheDocument()
+    expect(screen.queryByTestId('access-log-table')).not.toBeInTheDocument()
+  })
+
+  it('changing the event-type filter narrows visible rows', async () => {
+    render(<Harness />)
+    // Wait for the seed to render first.
+    await screen.findByTestId('access-log-row-evt-1')
+
+    await userEvent.selectOptions(
+      screen.getByTestId('access-log-filter-event-type'),
+      'key_rotate',
+    )
+
+    await waitFor(() => {
+      // Only key_rotate events remain — login / policy_change / etc. drop.
+      expect(screen.queryByTestId('access-log-row-evt-1')).not.toBeInTheDocument()
+    })
+    // evt-3 and evt-9 are the two key_rotate seed events.
+    expect(screen.getByTestId('access-log-row-evt-3')).toBeInTheDocument()
+    expect(screen.getByTestId('access-log-row-evt-9')).toBeInTheDocument()
+  })
+
+  it('changing the identity filter narrows visible rows', async () => {
+    render(<Harness />)
+    await screen.findByTestId('access-log-row-evt-1')
+
+    // Identity selector reads its options from the members + api-keys
+    // queries. Both seed identities exist as options once those queries
+    // resolve.
+    await waitFor(() => {
+      const select = screen.getByTestId('access-log-filter-identity') as HTMLSelectElement
+      const optionValues = Array.from(select.options).map((o) => o.value)
+      expect(optionValues).toContain('gateway-ci')
+    })
+
+    await userEvent.selectOptions(
+      screen.getByTestId('access-log-filter-identity'),
+      'gateway-ci',
+    )
+
+    await waitFor(() => {
+      // evt-3 is the only gateway-ci event in the seed.
+      expect(screen.getByTestId('access-log-row-evt-3')).toBeInTheDocument()
+      expect(screen.queryByTestId('access-log-row-evt-1')).not.toBeInTheDocument()
+    })
+  })
+
+  it('each row carries a stable /audit/event/<id> cross-link (AC #11)', async () => {
+    render(<Harness />)
+    const row = await screen.findByTestId('access-log-row-evt-1')
+    const link = within(row).getByTestId('access-log-row-link-evt-1')
+    expect(link).toHaveAttribute('href', '/audit/event/evt-1')
+  })
+
+  it('clicking a row navigates to /audit/event/<id>', async () => {
+    render(<Harness />)
+    const row = await screen.findByTestId('access-log-row-evt-1')
+
+    await userEvent.click(row)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('location-display')).toHaveTextContent(
+        '/audit/event/evt-1',
+      )
+    })
+  })
+
+  it('pagination prev/next moves the visible window when rows exceed page size', async () => {
+    // Override the fetcher with 15 fake rows so we get exactly two pages.
+    const many = Array.from({ length: 15 }, (_, i) =>
+      makeEvent({ id: `many-${i + 1}` }, i),
+    )
+    _accessLogInternal.setFetchOverride(() => Promise.resolve(many))
+
+    render(<Harness />)
+    await screen.findByTestId('access-log-row-many-1')
+
+    // Page 1 of 2, prev disabled, next enabled.
+    expect(screen.getByTestId('access-log-page-indicator')).toHaveTextContent(
+      'Page 1 of 2',
+    )
+    expect(screen.getByTestId('access-log-pagination-prev')).toBeDisabled()
+    expect(screen.getByTestId('access-log-pagination-next')).not.toBeDisabled()
+    // Page 1 holds many-1..many-10; many-11 is not yet visible.
+    expect(screen.getByTestId('access-log-row-many-10')).toBeInTheDocument()
+    expect(screen.queryByTestId('access-log-row-many-11')).not.toBeInTheDocument()
+
+    await userEvent.click(screen.getByTestId('access-log-pagination-next'))
+
+    expect(screen.getByTestId('access-log-page-indicator')).toHaveTextContent(
+      'Page 2 of 2',
+    )
+    expect(screen.getByTestId('access-log-pagination-next')).toBeDisabled()
+    expect(screen.getByTestId('access-log-pagination-prev')).not.toBeDisabled()
+    expect(screen.getByTestId('access-log-row-many-11')).toBeInTheDocument()
+    expect(screen.queryByTestId('access-log-row-many-1')).not.toBeInTheDocument()
+  })
+})

--- a/dashboard/src/features/iam/AccessLogPanel.tsx
+++ b/dashboard/src/features/iam/AccessLogPanel.tsx
@@ -1,0 +1,188 @@
+import { useMemo, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import {
+  useAccessLogQuery,
+  type AccessLogEvent,
+  type AccessLogEventType,
+  type AccessLogFilter,
+} from './accessLog'
+import { useMembersQuery } from './api'
+import { useApiKeysQuery } from './apiKeys'
+import { AccessLogFilterBar } from './AccessLogFilterBar'
+import './AccessLogPanel.css'
+
+const PAGE_SIZE = 10
+
+const EVENT_TYPE_LABELS: Record<AccessLogEventType, string> = {
+  login: 'Login',
+  logout: 'Logout',
+  policy_change: 'Policy change',
+  key_rotate: 'Key rotation',
+  member_invite: 'Member invite',
+  permission_grant: 'Permission grant',
+}
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toISOString().slice(0, 16).replace('T', ' ')
+}
+
+function auditEventHref(eventId: string): string {
+  // AAASM-1398 — verbatim path-segment from the AC. The /audit page is
+  // currently a ComingSoon route; the link is intentionally stable so the
+  // audit page (next sprint) can claim `/audit/event/:id` directly.
+  return `/audit/event/${eventId}`
+}
+
+export function AccessLogPanel() {
+  const [filter, setFilter] = useState<AccessLogFilter>({})
+  const [page, setPage] = useState(0)
+  const navigate = useNavigate()
+
+  const { data: events, isLoading, isError, refetch } = useAccessLogQuery(filter)
+  // Identity candidates feed the filter bar — union of member emails (page 1
+  // with a generous page size so the demo seed shows up in full) and active
+  // service-key labels. Service keys lacking a label fall back to prefix.
+  const { data: membersPage } = useMembersQuery(1, 100)
+  const { data: apiKeys } = useApiKeysQuery()
+  const identities = useMemo<string[]>(() => {
+    const memberEmails = membersPage?.items.map((m) => m.email) ?? []
+    const keyLabels =
+      apiKeys?.filter((k) => k.status === 'active').map((k) => k.label ?? k.prefix) ?? []
+    return Array.from(new Set([...memberEmails, ...keyLabels])).sort()
+  }, [membersPage, apiKeys])
+
+  const rows = events ?? []
+  const totalPages = Math.max(1, Math.ceil(rows.length / PAGE_SIZE))
+  const safePage = Math.min(page, totalPages - 1)
+  const pageRows = rows.slice(safePage * PAGE_SIZE, (safePage + 1) * PAGE_SIZE)
+
+  function handleFilterChange(next: AccessLogFilter) {
+    setFilter(next)
+    // Reset to the first page when the filter changes — otherwise narrowing
+    // a filter while on page 3 leaves the user looking at an empty window.
+    setPage(0)
+  }
+
+  if (isError) {
+    return (
+      <section className="iam-access-log-panel" data-testid="iam-panel-access-log">
+        <h2>Access Log</h2>
+        <div className="iam-access-log-panel__error" data-testid="access-log-error">
+          <span>Failed to load access log.</span>
+          <button type="button" onClick={() => void refetch()}>
+            Retry
+          </button>
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    <section className="iam-access-log-panel" data-testid="iam-panel-access-log">
+      <h2>Access Log</h2>
+      <p className="iam-access-log-panel__intro">
+        Identity-scoped audit events. Each row links to the corresponding entry
+        on the full audit log.
+      </p>
+
+      <AccessLogFilterBar
+        identities={identities}
+        value={filter}
+        onChange={handleFilterChange}
+      />
+
+      {isLoading && (
+        <div className="iam-access-log-panel__loading" data-testid="access-log-loading">
+          Loading…
+        </div>
+      )}
+
+      {!isLoading && rows.length === 0 && (
+        <div className="iam-access-log-panel__empty" data-testid="access-log-empty">
+          No access-log events match the current filter.
+        </div>
+      )}
+
+      {!isLoading && rows.length > 0 && (
+        <>
+          <table className="iam-access-log-table" data-testid="access-log-table">
+            <thead>
+              <tr>
+                <th>Timestamp</th>
+                <th>Identity</th>
+                <th>Event type</th>
+                <th>Target</th>
+                <th>Result</th>
+                <th>Source IP</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {pageRows.map((row: AccessLogEvent) => (
+                <tr
+                  key={row.id}
+                  data-testid={`access-log-row-${row.id}`}
+                  className="iam-access-log-table__row"
+                  onClick={() => navigate(auditEventHref(row.id))}
+                >
+                  <td className="iam-access-log-table__mono">
+                    {formatTimestamp(row.timestamp)}
+                  </td>
+                  <td>{row.identity}</td>
+                  <td>{EVENT_TYPE_LABELS[row.event_type]}</td>
+                  <td className="iam-access-log-table__mono">{row.target}</td>
+                  <td>
+                    <span
+                      className={`iam-access-log-table__result iam-access-log-table__result--${row.result}`}
+                    >
+                      {row.result}
+                    </span>
+                  </td>
+                  <td className="iam-access-log-table__mono">{row.source_ip}</td>
+                  <td>
+                    <Link
+                      to={auditEventHref(row.id)}
+                      className="iam-access-log-table__link"
+                      data-testid={`access-log-row-link-${row.id}`}
+                      // Don't double-fire navigate(): row onClick already
+                      // routes; the Link is here so the href is discoverable
+                      // to keyboard / screen-reader users and to the e2e
+                      // assertion that the AC #11 cross-link path is stable.
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      View →
+                    </Link>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          <div className="iam-access-log-panel__pagination">
+            <button
+              type="button"
+              data-testid="access-log-pagination-prev"
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={safePage === 0}
+            >
+              ← Previous
+            </button>
+            <span data-testid="access-log-page-indicator">
+              Page {safePage + 1} of {totalPages}
+            </span>
+            <button
+              type="button"
+              data-testid="access-log-pagination-next"
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={safePage >= totalPages - 1}
+            >
+              Next →
+            </button>
+          </div>
+        </>
+      )}
+    </section>
+  )
+}

--- a/dashboard/src/features/iam/accessLog.test.tsx
+++ b/dashboard/src/features/iam/accessLog.test.tsx
@@ -56,13 +56,13 @@ describe('accessLog seed + filter (AAASM-1398)', () => {
 
   it('identity filter narrows rows to that identity only', async () => {
     const { result } = renderHook(
-      () => useAccessLogQuery({ identity: 'alice@example.com' }),
+      () => useAccessLogQuery({ identity: 'alice@agent-assembly.dev' }),
       { wrapper: makeWrapper() },
     )
     await waitFor(() => expect(result.current.data).toBeDefined())
     const data = result.current.data as AccessLogEvent[]
     expect(data.length).toBeGreaterThan(0)
-    for (const e of data) expect(e.identity).toBe('alice@example.com')
+    for (const e of data) expect(e.identity).toBe('alice@agent-assembly.dev')
   })
 
   it('eventType filter narrows rows to that type only', async () => {

--- a/dashboard/src/features/iam/accessLog.test.tsx
+++ b/dashboard/src/features/iam/accessLog.test.tsx
@@ -1,0 +1,114 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  ACCESS_LOG_EVENT_TYPES,
+  _accessLogInternal,
+  useAccessLogQuery,
+  type AccessLogEvent,
+  type AccessLogEventType,
+} from './accessLog'
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  }
+}
+
+describe('accessLog seed + filter (AAASM-1398)', () => {
+  beforeEach(() => {
+    _accessLogInternal.reset()
+  })
+
+  it('exports the full event-type vocabulary', () => {
+    // The filter bar in C2 reads ACCESS_LOG_EVENT_TYPES to populate its select.
+    expect(ACCESS_LOG_EVENT_TYPES).toEqual([
+      'login',
+      'logout',
+      'policy_change',
+      'key_rotate',
+      'member_invite',
+      'permission_grant',
+    ])
+  })
+
+  it('seeds 10 events covering every event type at least once', () => {
+    const seen = new Set<AccessLogEventType>(
+      _accessLogInternal.snapshot().map((e) => e.event_type),
+    )
+    expect(_accessLogInternal.snapshot()).toHaveLength(10)
+    for (const t of ACCESS_LOG_EVENT_TYPES) {
+      expect(seen.has(t)).toBe(true)
+    }
+  })
+
+  it('useAccessLogQuery({}) returns the full seed, newest-first', async () => {
+    const { result } = renderHook(() => useAccessLogQuery({}), { wrapper: makeWrapper() })
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    const data = result.current.data as AccessLogEvent[]
+    expect(data).toHaveLength(10)
+    // Sorted reverse-chron: first event is the most recent.
+    for (let i = 1; i < data.length; i++) {
+      expect(data[i - 1].timestamp >= data[i].timestamp).toBe(true)
+    }
+  })
+
+  it('identity filter narrows rows to that identity only', async () => {
+    const { result } = renderHook(
+      () => useAccessLogQuery({ identity: 'alice@example.com' }),
+      { wrapper: makeWrapper() },
+    )
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    const data = result.current.data as AccessLogEvent[]
+    expect(data.length).toBeGreaterThan(0)
+    for (const e of data) expect(e.identity).toBe('alice@example.com')
+  })
+
+  it('eventType filter narrows rows to that type only', async () => {
+    const { result } = renderHook(
+      () => useAccessLogQuery({ eventType: 'key_rotate' }),
+      { wrapper: makeWrapper() },
+    )
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    const data = result.current.data as AccessLogEvent[]
+    expect(data.length).toBeGreaterThan(0)
+    for (const e of data) expect(e.event_type).toBe('key_rotate')
+  })
+
+  it('timeRange 24h excludes events older than 24 hours', async () => {
+    const { result } = renderHook(
+      () => useAccessLogQuery({ timeRange: { kind: '24h' } }),
+      { wrapper: makeWrapper() },
+    )
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    const data = result.current.data as AccessLogEvent[]
+    const cutoff = Date.now() - 24 * 60 * 60 * 1000
+    for (const e of data) {
+      expect(new Date(e.timestamp).getTime()).toBeGreaterThanOrEqual(cutoff)
+    }
+    // The seed includes events at -1h, -3h, -6h, -20h (in-range) and
+    // -48h+ (out-of-range), so a 24-hour cutoff must drop at least one row.
+    expect(data.length).toBeLessThan(10)
+  })
+
+  it('setFetchOverride swaps the source (proves the eventual fetch swap is one-function)', async () => {
+    _accessLogInternal.setFetchOverride(() =>
+      Promise.resolve([
+        {
+          id: 'override-1',
+          timestamp: new Date().toISOString(),
+          identity: 'overridden',
+          event_type: 'login',
+          target: 'gateway',
+          result: 'success',
+          source_ip: '1.2.3.4',
+        },
+      ]),
+    )
+    const { result } = renderHook(() => useAccessLogQuery({}), { wrapper: makeWrapper() })
+    await waitFor(() => expect(result.current.data).toBeDefined())
+    expect(result.current.data).toHaveLength(1)
+    expect(result.current.data?.[0].id).toBe('override-1')
+  })
+})

--- a/dashboard/src/features/iam/accessLog.ts
+++ b/dashboard/src/features/iam/accessLog.ts
@@ -1,0 +1,231 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query'
+import { iamQueryKeys } from './queryKeys'
+
+/**
+ * Access Log data layer (AAASM-1398).
+ *
+ * Until the OpenAPI surface for `/api/v1/audit/...` lands with the
+ * identity-scoped filter we need, the panel reads from a process-local
+ * seed via the same in-memory + override-seam pattern used by
+ * `apiKeys.ts` and `api.ts` (members). Hook signature is built around
+ * the eventual server filter so the swap is a one-function change.
+ */
+
+export type AccessLogEventType =
+  | 'login'
+  | 'logout'
+  | 'policy_change'
+  | 'key_rotate'
+  | 'member_invite'
+  | 'permission_grant'
+
+export const ACCESS_LOG_EVENT_TYPES: readonly AccessLogEventType[] = [
+  'login',
+  'logout',
+  'policy_change',
+  'key_rotate',
+  'member_invite',
+  'permission_grant',
+] as const
+
+export interface AccessLogEvent {
+  readonly id: string
+  /** ISO-8601 UTC timestamp. */
+  readonly timestamp: string
+  /** Member email or service-key label that performed the action. */
+  readonly identity: string
+  readonly event_type: AccessLogEventType
+  /** Free-form target description — e.g. `role:service:admin`, `key:gateway-ci`. */
+  readonly target: string
+  readonly result: 'success' | 'failure'
+  /** IPv4 / IPv6 source address; placeholder for v1 seed data. */
+  readonly source_ip: string
+}
+
+export type AccessLogTimeRange =
+  | { readonly kind: '24h' | '7d' | '30d' }
+  | { readonly kind: 'custom'; readonly from: string; readonly to: string }
+
+export interface AccessLogFilter {
+  readonly identity?: string | null
+  readonly eventType?: AccessLogEventType | null
+  readonly timeRange?: AccessLogTimeRange
+}
+
+// Fixed "now" the seed timestamps are anchored to. The default useQuery call
+// applies the time-range filter relative to *real* `Date.now()` at fetch
+// time, so seed events stay in-range as long as they're authored close to
+// today. The seed below uses live `new Date()` arithmetic at module-load —
+// adequate for the dashboard demo seed pattern (mirrors apiKeys.ts).
+const NOW = new Date()
+
+function isoMinusHours(hours: number): string {
+  return new Date(NOW.getTime() - hours * 60 * 60 * 1000).toISOString()
+}
+
+const SEED_ACCESS_LOG: AccessLogEvent[] = [
+  {
+    id: 'evt-1',
+    timestamp: isoMinusHours(1),
+    identity: 'alice@example.com',
+    event_type: 'login',
+    target: 'dashboard',
+    result: 'success',
+    source_ip: '10.0.0.42',
+  },
+  {
+    id: 'evt-2',
+    timestamp: isoMinusHours(3),
+    identity: 'alice@example.com',
+    event_type: 'policy_change',
+    target: 'policy:read-only-baseline',
+    result: 'success',
+    source_ip: '10.0.0.42',
+  },
+  {
+    id: 'evt-3',
+    timestamp: isoMinusHours(6),
+    identity: 'gateway-ci',
+    event_type: 'key_rotate',
+    target: 'key:gateway-ci',
+    result: 'success',
+    source_ip: '10.0.0.7',
+  },
+  {
+    id: 'evt-4',
+    timestamp: isoMinusHours(20),
+    identity: 'carol@example.com',
+    event_type: 'member_invite',
+    target: 'invite:dave@example.com',
+    result: 'success',
+    source_ip: '10.0.0.51',
+  },
+  {
+    id: 'evt-5',
+    timestamp: isoMinusHours(48),
+    identity: 'carol@example.com',
+    event_type: 'permission_grant',
+    target: 'role:service:observer',
+    result: 'success',
+    source_ip: '10.0.0.51',
+  },
+  {
+    id: 'evt-6',
+    timestamp: isoMinusHours(72),
+    identity: 'observability-exporter',
+    event_type: 'login',
+    target: 'gateway',
+    result: 'failure',
+    source_ip: '10.0.0.99',
+  },
+  {
+    id: 'evt-7',
+    timestamp: isoMinusHours(120),
+    identity: 'bob@example.com',
+    event_type: 'policy_change',
+    target: 'policy:admin-baseline',
+    result: 'failure',
+    source_ip: '10.0.0.8',
+  },
+  {
+    id: 'evt-8',
+    timestamp: isoMinusHours(168),
+    identity: 'bob@example.com',
+    event_type: 'logout',
+    target: 'dashboard',
+    result: 'success',
+    source_ip: '10.0.0.8',
+  },
+  {
+    id: 'evt-9',
+    timestamp: isoMinusHours(360),
+    identity: 'alice@example.com',
+    event_type: 'key_rotate',
+    target: 'key:retired-runner',
+    result: 'success',
+    source_ip: '10.0.0.42',
+  },
+  {
+    id: 'evt-10',
+    timestamp: isoMinusHours(720),
+    identity: 'retired-runner',
+    event_type: 'login',
+    target: 'gateway',
+    result: 'failure',
+    source_ip: '10.0.0.250',
+  },
+]
+
+interface EventStore {
+  events: AccessLogEvent[]
+}
+
+const eventStore: EventStore = { events: [...SEED_ACCESS_LOG] }
+
+let _fetchOverride: ((filter: AccessLogFilter) => Promise<AccessLogEvent[]>) | null = null
+
+function timeRangeCutoffIso(range: AccessLogTimeRange | undefined): string | null {
+  if (!range) return null
+  if (range.kind === '24h') return new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+  if (range.kind === '7d') return new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString()
+  if (range.kind === '30d') return new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
+  return null
+}
+
+/**
+ * In-process filter applied to the seed. Mirrors the eventual server
+ * contract: identity exact match, event-type exact match, time-range
+ * cutoff (custom = inclusive from/to range, presets = "since N ago").
+ */
+function applyFilter(events: readonly AccessLogEvent[], filter: AccessLogFilter): AccessLogEvent[] {
+  let out = events.slice()
+  if (filter.identity) {
+    out = out.filter((e) => e.identity === filter.identity)
+  }
+  if (filter.eventType) {
+    out = out.filter((e) => e.event_type === filter.eventType)
+  }
+  if (filter.timeRange?.kind === 'custom') {
+    const { from, to } = filter.timeRange
+    out = out.filter((e) => e.timestamp >= from && e.timestamp <= to)
+  } else {
+    const cutoff = timeRangeCutoffIso(filter.timeRange)
+    if (cutoff) out = out.filter((e) => e.timestamp >= cutoff)
+  }
+  // Newest first — the AC's "paginated table" expects natural reverse-chron order.
+  out.sort((a, b) => (a.timestamp < b.timestamp ? 1 : -1))
+  return out
+}
+
+function fetchAccessLog(filter: AccessLogFilter): Promise<AccessLogEvent[]> {
+  if (_fetchOverride) return _fetchOverride(filter)
+  return Promise.resolve(applyFilter(eventStore.events, filter))
+}
+
+export function useAccessLogQuery(
+  filter: AccessLogFilter,
+): UseQueryResult<AccessLogEvent[]> {
+  return useQuery({
+    queryKey: iamQueryKeys.accessLog(filter as object),
+    queryFn: () => fetchAccessLog(filter),
+  })
+}
+
+export const _accessLogInternal: {
+  reset: () => void
+  snapshot: () => readonly AccessLogEvent[]
+  setFetchOverride: (
+    fn: ((filter: AccessLogFilter) => Promise<AccessLogEvent[]>) | null,
+  ) => void
+} = {
+  reset(): void {
+    eventStore.events = [...SEED_ACCESS_LOG]
+    _fetchOverride = null
+  },
+  snapshot(): readonly AccessLogEvent[] {
+    return eventStore.events
+  },
+  setFetchOverride(fn) {
+    _fetchOverride = fn
+  },
+}

--- a/dashboard/src/features/iam/accessLog.ts
+++ b/dashboard/src/features/iam/accessLog.ts
@@ -67,7 +67,7 @@ const SEED_ACCESS_LOG: AccessLogEvent[] = [
   {
     id: 'evt-1',
     timestamp: isoMinusHours(1),
-    identity: 'alice@example.com',
+    identity: 'alice@agent-assembly.dev',
     event_type: 'login',
     target: 'dashboard',
     result: 'success',
@@ -76,7 +76,7 @@ const SEED_ACCESS_LOG: AccessLogEvent[] = [
   {
     id: 'evt-2',
     timestamp: isoMinusHours(3),
-    identity: 'alice@example.com',
+    identity: 'alice@agent-assembly.dev',
     event_type: 'policy_change',
     target: 'policy:read-only-baseline',
     result: 'success',
@@ -94,7 +94,7 @@ const SEED_ACCESS_LOG: AccessLogEvent[] = [
   {
     id: 'evt-4',
     timestamp: isoMinusHours(20),
-    identity: 'carol@example.com',
+    identity: 'carol@agent-assembly.dev',
     event_type: 'member_invite',
     target: 'invite:dave@example.com',
     result: 'success',
@@ -103,7 +103,7 @@ const SEED_ACCESS_LOG: AccessLogEvent[] = [
   {
     id: 'evt-5',
     timestamp: isoMinusHours(48),
-    identity: 'carol@example.com',
+    identity: 'carol@agent-assembly.dev',
     event_type: 'permission_grant',
     target: 'role:service:observer',
     result: 'success',
@@ -121,7 +121,7 @@ const SEED_ACCESS_LOG: AccessLogEvent[] = [
   {
     id: 'evt-7',
     timestamp: isoMinusHours(120),
-    identity: 'bob@example.com',
+    identity: 'bob@agent-assembly.dev',
     event_type: 'policy_change',
     target: 'policy:admin-baseline',
     result: 'failure',
@@ -130,7 +130,7 @@ const SEED_ACCESS_LOG: AccessLogEvent[] = [
   {
     id: 'evt-8',
     timestamp: isoMinusHours(168),
-    identity: 'bob@example.com',
+    identity: 'bob@agent-assembly.dev',
     event_type: 'logout',
     target: 'dashboard',
     result: 'success',
@@ -139,7 +139,7 @@ const SEED_ACCESS_LOG: AccessLogEvent[] = [
   {
     id: 'evt-9',
     timestamp: isoMinusHours(360),
-    identity: 'alice@example.com',
+    identity: 'alice@agent-assembly.dev',
     event_type: 'key_rotate',
     target: 'key:retired-runner',
     result: 'success',

--- a/dashboard/src/features/iam/queryKeys.ts
+++ b/dashboard/src/features/iam/queryKeys.ts
@@ -7,4 +7,8 @@ export const iamQueryKeys = {
   agents: () => [...iamQueryKeys.all, 'agents'] as const,
   agentPermissions: (agentId: string) =>
     [...iamQueryKeys.agents(), agentId, 'permissions'] as const,
+  // AAASM-1398 — Access Log tab query keys. Carrying the filter object
+  // in the key so React Query can cache one entry per filter shape.
+  accessLog: (filter: object) =>
+    [...iamQueryKeys.all, 'access-log', filter] as const,
 } as const

--- a/dashboard/src/pages/IdentityPage.test.tsx
+++ b/dashboard/src/pages/IdentityPage.test.tsx
@@ -85,4 +85,17 @@ describe('IdentityPage', () => {
     const link = screen.getByTestId('iam-audit-link')
     expect(link).toHaveAttribute('href', '/audit')
   })
+
+  it('renders the AccessLogPanel (not the placeholder) on ?tab=access-log', async () => {
+    renderAt(['/identity?tab=access-log'])
+    expect(screen.getByTestId('iam-tab-access-log')).toHaveAttribute('aria-selected', 'true')
+    // The placeholder body text from TabPlaceholder must NOT render — the
+    // real panel takes over. Both share `iam-panel-access-log` as the
+    // section testid, so we discriminate on the panel's heading + an
+    // element only the real panel renders (the filter bar).
+    expect(await screen.findByTestId('access-log-filter-bar')).toBeInTheDocument()
+    expect(
+      screen.queryByText(/Content for the Access Log tab lands in a follow-up/i),
+    ).not.toBeInTheDocument()
+  })
 })

--- a/dashboard/src/pages/IdentityPage.tsx
+++ b/dashboard/src/pages/IdentityPage.tsx
@@ -2,6 +2,7 @@ import { Link, useSearchParams } from 'react-router-dom'
 import { MembersPanel } from '../features/iam/MembersPanel'
 import { ServiceIdentitiesPanel } from '../features/iam/ServiceIdentitiesPanel'
 import { RolesPermissionsPanel } from '../features/iam/RolesPermissionsPanel'
+import { AccessLogPanel } from '../features/iam/AccessLogPanel'
 import { IAM_DEFAULT_TAB, IAM_TAB_KEYS, IAM_TAB_LABELS, parseIamTab, type IamTabKey } from '../features/iam/tabs'
 import './IdentityPage.css'
 
@@ -20,6 +21,7 @@ function ActiveTabContent({ tab }: { tab: IamTabKey }) {
   if (tab === 'members') return <MembersPanel />
   if (tab === 'services') return <ServiceIdentitiesPanel />
   if (tab === 'roles') return <RolesPermissionsPanel />
+  if (tab === 'access-log') return <AccessLogPanel />
   return <TabPlaceholder tab={tab} />
 }
 

--- a/dashboard/tests/e2e/iam-access-log.spec.ts
+++ b/dashboard/tests/e2e/iam-access-log.spec.ts
@@ -1,0 +1,124 @@
+// Story-level Playwright e2e for AAASM-1398 — Filterable Access Log tab.
+//
+// Drives the real `/identity?tab=access-log` page in Chromium and walks the
+// AC: panel renders → filter narrows rows → custom time range narrows
+// further → each row carries a stable `/audit/event/<id>` cross-link →
+// the existing header cross-link (AAASM-1160 partial AC #11) is intact.
+//
+// Click-through to /audit/event/<id> is intentionally NOT exercised. The
+// /audit route is still a ComingSoon page (`/audit/event/:id` doesn't
+// route to a real page until the Audit Log Story lands next sprint), so
+// the cross-link contract is verified via href assertions only.
+
+import { test, expect, type Page } from '@playwright/test'
+
+async function injectToken(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('aa_token', 'e2e-test-token')
+  })
+}
+
+async function stubShellProbes(page: Page) {
+  await page.route('**/api/v1/ws/events**', (route) => route.abort())
+  await page.route('**/api/v1/approvals**', (route) => route.fulfill({ json: [] }))
+  await page.route('**/api/v1/policies/active', (route) =>
+    route.fulfill({ status: 404, json: { detail: 'No active policy' } }),
+  )
+  await page.route('**/api/v1/policies', (route) =>
+    route.request().method() === 'GET' ? route.fulfill({ json: [] }) : route.fallback(),
+  )
+}
+
+test.describe('Identity & Access — Access Log tab (AAASM-1398)', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectToken(page)
+    await stubShellProbes(page)
+  })
+
+  test('Access Log tab renders the filterable panel with seeded rows', async ({
+    page,
+  }) => {
+    await page.goto('/identity?tab=access-log')
+
+    await expect(page.getByTestId('identity-page')).toBeVisible()
+    await expect(page.getByTestId('iam-tab-access-log')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+    await expect(page.getByTestId('iam-panel-access-log')).toBeVisible()
+    await expect(page.getByTestId('access-log-filter-bar')).toBeVisible()
+    await expect(page.getByTestId('access-log-table')).toBeVisible()
+
+    // The default seed has 10 events; all sit on page 1.
+    const rows = page.locator('[data-testid^="access-log-row-evt-"]')
+    await expect(rows).toHaveCount(10)
+    await expect(page.getByTestId('access-log-page-indicator')).toHaveText(
+      'Page 1 of 1',
+    )
+  })
+
+  test('Event-type filter narrows rows to that type only', async ({ page }) => {
+    await page.goto('/identity?tab=access-log')
+    await expect(page.getByTestId('access-log-row-evt-1')).toBeVisible()
+
+    await page
+      .getByTestId('access-log-filter-event-type')
+      .selectOption('key_rotate')
+
+    // Seed has exactly two key_rotate events: evt-3 and evt-9.
+    const rows = page.locator('[data-testid^="access-log-row-evt-"]')
+    await expect(rows).toHaveCount(2)
+    await expect(page.getByTestId('access-log-row-evt-3')).toBeVisible()
+    await expect(page.getByTestId('access-log-row-evt-9')).toBeVisible()
+    await expect(page.getByTestId('access-log-row-evt-1')).toHaveCount(0)
+  })
+
+  test('Custom time range reveals from/to date inputs and narrows rows', async ({
+    page,
+  }) => {
+    await page.goto('/identity?tab=access-log')
+    await expect(page.getByTestId('access-log-row-evt-1')).toBeVisible()
+
+    await page
+      .getByTestId('access-log-filter-time-range')
+      .selectOption('custom')
+
+    await expect(page.getByTestId('access-log-filter-custom-from')).toBeVisible()
+    await expect(page.getByTestId('access-log-filter-custom-to')).toBeVisible()
+
+    // Set the from to today and the to to today — should drop most rows.
+    const today = new Date().toISOString().slice(0, 10)
+    await page.getByTestId('access-log-filter-custom-from').fill(today)
+    await page.getByTestId('access-log-filter-custom-to').fill(today)
+
+    // evt-1 (-1h) typically falls on "today"; older events drop.
+    // We assert visible row count is at most a few (down from 10).
+    const rows = page.locator('[data-testid^="access-log-row-evt-"]')
+    await expect.poll(async () => await rows.count(), { timeout: 5_000 }).toBeLessThan(10)
+  })
+
+  test('Each row exposes a stable /audit/event/<id> cross-link', async ({
+    page,
+  }) => {
+    await page.goto('/identity?tab=access-log')
+    const link = page.getByTestId('access-log-row-link-evt-1')
+    await expect(link).toBeVisible()
+    await expect(link).toHaveAttribute('href', '/audit/event/evt-1')
+
+    // Sanity-check a second row to prove the link template is per-row, not
+    // hard-coded.
+    await expect(page.getByTestId('access-log-row-link-evt-3')).toHaveAttribute(
+      'href',
+      '/audit/event/evt-3',
+    )
+  })
+
+  test('Header "View full audit log" link is still present (AAASM-1160 AC #11)', async ({
+    page,
+  }) => {
+    await page.goto('/identity?tab=access-log')
+    const header = page.getByTestId('iam-audit-link')
+    await expect(header).toBeVisible()
+    await expect(header).toHaveAttribute('href', '/audit')
+  })
+})


### PR DESCRIPTION
## Summary

Implements the **Filterable Access Log tab** on the Identity & Access page
([AAASM-1398](https://lightning-dust-mite.atlassian.net/browse/AAASM-1398)),
replacing the AAASM-1083 placeholder. This is the last open sub-task under
the AAASM-119 Story (RBAC + service identity + authz governance UI); closing
it completes AC #11 (the per-row `/audit/event/<id>` cross-link that
AAASM-1160 verification had flagged ⚠ partial).

## Commits (5 atomic)

| # | SHA | What |
|---|---|---|
| C1 | `e793f9d6` | ✨ `accessLog.ts` — types + 10-event seed + `useAccessLogQuery` + `_accessLogInternal` override seam |
| C2 | `eeb3dd0c` | ✨ `AccessLogFilterBar.tsx` — identity + event-type + time-range controls (24h / 7d / 30d / custom) |
| C3 | `2c433351` | ✨ `AccessLogPanel.tsx` — paginated table + per-row `/audit/event/<id>` Link; seed identity emails aligned to members roster |
| C4 | `19875fe6` | 🔧 `IdentityPage.tsx` — `ActiveTabContent` returns `<AccessLogPanel />` on `?tab=access-log` |
| C5 | `f8e6aa55` | ✅ `tests/e2e/iam-access-log.spec.ts` — 5 Playwright cases drive the panel in Chromium |

## AC coverage

| AC | Where it's satisfied |
|---|---|
| `<AccessLogPanel>` reads identity-scoped events via `useAccessLogQuery({identity, eventType, timeRange})` | `accessLog.ts:205-212` |
| Filter bar — identity selector | `AccessLogFilterBar.tsx:57-78`, options populated by `useMembersQuery` + active `useApiKeysQuery` in `AccessLogPanel.tsx:39-49` |
| Filter bar — event-type selector | `AccessLogFilterBar.tsx:80-103` (6 typed values via `ACCESS_LOG_EVENT_TYPES`) |
| Filter bar — time range (24h / 7d / 30d / custom) | `AccessLogFilterBar.tsx:105-134`; custom reveals from/to date inputs at `:140-176` |
| Paginated table — columns: timestamp · identity · event type · target · result · source IP | `AccessLogPanel.tsx:105-149`, page size 10, prev/next + indicator at `:151-172` |
| Per-row cross-link to `/audit/event/<id>` | `AccessLogPanel.tsx:31-35` (path-segment, verbatim AC wording) + `:135-148` (Link + row click) |
| testids `iam-panel-access-log`, `access-log-filter-bar`, `access-log-row-<id>` | All present in source + asserted in unit + e2e specs |
| Vitest: filter inputs narrow rows; row click navigates to audit page | `AccessLogPanel.test.tsx` cases 3/4 (filter narrowing) + 6 (row click) |

## Local validation

- `pnpm type-check` — clean
- `pnpm lint` — clean
- `pnpm test --run` — **917/917** passing across 107 files (20 new tests: 7 accessLog + 6 filter bar + 7 panel + 1 IdentityPage wire)
- `pnpm exec playwright test iam-access-log --project=chromium` — **5/5** passing in 1.4s

## Per-row click target — why `/audit/event/<id>` and why no e2e click-through

The AC names `/audit/event/{id}` verbatim. The current `/audit` route in `App.tsx`
is a `ComingSoon` page (the dedicated Audit Log Story lands next sprint), so
`/audit/event/<id>` won't resolve to a real page until then. The link contract
is implemented faithfully but **not** clicked in the e2e — both the vitest case
(`MemoryRouter`) and the Playwright case assert `link.href === '/audit/event/<id>'`
instead. The next-sprint Audit Log page can claim `/audit/event/:id` directly
without any change on this side.

## OpenAPI gap

`/api/v1/audit/...` is still not in the OpenAPI surface, so the panel reads
from an in-memory seed via the same `_<feature>Internal.setFetchOverride`
pattern used by `apiKeys.ts` and `api.ts` (members). When the gateway
endpoint lands, swapping `fetchAccessLog` for a fetch call is a one-function
change; the React Query hook + filter contract + component wiring stay
unchanged.

Closes AAASM-1398.

[AAASM-1398]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ