### PR TITLE
[AAASM-1381] ✨ (aa-api): Add expires_at to ApprovalResponse + ApprovalPayload

### DIFF
--- a/aa-api/src/models/ws_payloads.rs
+++ b/aa-api/src/models/ws_payloads.rs
@@ -104,6 +104,11 @@ pub struct ApprovalPayload {
     pub submitted_at: u64,
     /// Seconds before the request times out.
     pub timeout_secs: u64,
+    /// Unix epoch timestamp (seconds) at which the request expires
+    /// (`submitted_at + timeout_secs`). Provided as a pre-computed
+    /// absolute timestamp so dashboard consumers can render the
+    /// auto-expire countdown without local-clock drift.
+    pub expires_at: u64,
 }
 
 /// Payload for `event_type: "budget"` events.

--- a/aa-api/src/routes/approvals.rs
+++ b/aa-api/src/routes/approvals.rs
@@ -63,6 +63,12 @@ pub struct ApprovalResponse {
     pub status: String,
     /// ISO 8601 timestamp when the request was created.
     pub created_at: String,
+    /// ISO 8601 timestamp at which the pending request expires
+    /// (`created_at` + the governing `approval_timeout_secs`). The
+    /// dashboard renders a countdown from this value. Empty string on
+    /// post-decision (`approved` / `rejected`) responses where
+    /// expiration is no longer meaningful.
+    pub expires_at: String,
     /// Structured routing metadata. Absent until the router has processed the request.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub routing_status: Option<RoutingStatusInfo>,
@@ -121,6 +127,9 @@ pub async fn list_approvals(
                 created_at: chrono::DateTime::from_timestamp(p.submitted_at as i64, 0)
                     .map(|dt| dt.to_rfc3339())
                     .unwrap_or_default(),
+                expires_at: chrono::DateTime::from_timestamp(p.submitted_at.saturating_add(p.timeout_secs) as i64, 0)
+                    .map(|dt| dt.to_rfc3339())
+                    .unwrap_or_default(),
                 routing_status,
                 team_id: p.team_id,
             }
@@ -177,6 +186,7 @@ pub async fn approve_action(
             reason: String::new(),
             status: "approved".to_string(),
             created_at: String::new(),
+            expires_at: String::new(),
             routing_status: None,
             team_id: None,
         }),
@@ -222,6 +232,7 @@ pub async fn reject_action(
             reason: String::new(),
             status: "rejected".to_string(),
             created_at: String::new(),
+            expires_at: String::new(),
             routing_status: None,
             team_id: None,
         }),

--- a/aa-api/src/ws/handler.rs
+++ b/aa-api/src/ws/handler.rs
@@ -334,6 +334,7 @@ fn build_approval_payload(ev: &aa_runtime::approval::ApprovalRequest) -> Approva
         condition_triggered: ev.condition_triggered.clone(),
         submitted_at: ev.submitted_at,
         timeout_secs: ev.timeout_secs,
+        expires_at: ev.submitted_at.saturating_add(ev.timeout_secs),
     }
 }
 
@@ -791,12 +792,17 @@ mod tests {
         assert_eq!(payload.condition_triggered, "outbound_email_to_unknown_domain");
         assert_eq!(payload.submitted_at, 1_700_000_000);
         assert_eq!(payload.timeout_secs, 300);
+        assert_eq!(
+            payload.expires_at, 1_700_000_300,
+            "expires_at = submitted_at + timeout_secs"
+        );
 
         // JSON-shape check — the discriminator + fields must match the
         // ApprovalPayload OpenAPI schema (no extra fields leaking through).
         let json = serde_json::to_value(EventPayload::Approval(payload)).unwrap();
         assert_eq!(json["action"], "send_external_email");
         assert_eq!(json["timeout_secs"], 300);
+        assert_eq!(json["expires_at"], 1_700_000_300_u64);
         assert!(json.get("team_id").is_none(), "internal routing fields must not leak");
         assert!(json.get("fallback").is_none(), "internal routing fields must not leak");
     }

--- a/aa-api/tests/approvals.rs
+++ b/aa-api/tests/approvals.rs
@@ -68,6 +68,10 @@ async fn list_approvals_returns_pending_requests() {
     assert_eq!(items[0]["id"], expected_id);
     assert_eq!(items[0]["agent_id"], "test-agent");
     assert_eq!(items[0]["status"], "pending");
+    // `created_at` = submitted_at = 1_700_000_000 → RFC 3339 → 2023-11-14T22:13:20+00:00
+    // `expires_at` = submitted_at + timeout_secs (600) = 1_700_000_600 → 22:23:20+00:00
+    assert_eq!(items[0]["created_at"], "2023-11-14T22:13:20+00:00");
+    assert_eq!(items[0]["expires_at"], "2023-11-14T22:23:20+00:00");
 }
 
 #[tokio::test]

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -970,6 +970,14 @@ export interface components {
             action: string;
             /** @description Policy condition that triggered this request. */
             condition_triggered: string;
+            /**
+             * Format: int64
+             * @description Unix epoch timestamp (seconds) at which the request expires
+             *     (`submitted_at + timeout_secs`). Provided as a pre-computed
+             *     absolute timestamp so dashboard consumers can render the
+             *     auto-expire countdown without local-clock drift.
+             */
+            expires_at: number;
             /** @description Unique ID for the approval request (UUID v4). */
             request_id: string;
             /**
@@ -991,6 +999,14 @@ export interface components {
             agent_id: string;
             /** @description ISO 8601 timestamp when the request was created. */
             created_at: string;
+            /**
+             * @description ISO 8601 timestamp at which the pending request expires
+             *     (`created_at` + the governing `approval_timeout_secs`). The
+             *     dashboard renders a countdown from this value. Empty string on
+             *     post-decision (`approved` / `rejected`) responses where
+             *     expiration is no longer meaningful.
+             */
+            expires_at: string;
             /** @description Unique approval request identifier. */
             id: string;
             /** @description Human-readable reason for the approval request. */

--- a/dashboard/src/features/approvals/ApprovalsBellButton.test.tsx
+++ b/dashboard/src/features/approvals/ApprovalsBellButton.test.tsx
@@ -22,7 +22,9 @@ function Wrapper({ children }: { children: React.ReactNode }) {
 
 const MOCK_APPROVAL: Approval = {
   id: 'a1', agent_id: 'agent-1', action: 'send_email', reason: 'r',
-  status: 'pending', created_at: '2026-05-13T00:00:00Z', routing_status: null, team_id: null,
+  status: 'pending', created_at: '2026-05-13T00:00:00Z',
+  expires_at: '2026-05-13T01:00:00Z',
+  routing_status: null, team_id: null,
 }
 
 afterEach(() => { vi.restoreAllMocks() })

--- a/dashboard/src/features/approvals/api.test.tsx
+++ b/dashboard/src/features/approvals/api.test.tsx
@@ -68,6 +68,7 @@ const MOCK_APPROVAL: Approval = {
   reason: 'requires elevated permission',
   status: 'pending',
   created_at: '2026-05-12T10:00:00Z',
+  expires_at: '2026-05-12T11:00:00Z',
   routing_status: null,
   team_id: null,
 }
@@ -79,6 +80,7 @@ const MOCK_APPROVAL_2: Approval = {
   reason: 'blocked by egress policy',
   status: 'pending',
   created_at: '2026-05-12T10:05:00Z',
+  expires_at: '2026-05-12T11:05:00Z',
   routing_status: null,
   team_id: null,
 }
@@ -175,6 +177,7 @@ describe('ApprovalsPage', () => {
         condition_triggered: 'blocked by shell policy',
         submitted_at: 1715513200,
         timeout_secs: 300,
+        expires_at: 1715513500,
       },
     }
 

--- a/dashboard/src/features/approvals/filter.test.ts
+++ b/dashboard/src/features/approvals/filter.test.ts
@@ -4,11 +4,11 @@ import type { Approval } from './api'
 
 const APPROVALS: Approval[] = [
   // age 15 min → high
-  { id: '1', agent_id: 'a1', team_id: 't1', action: 'send_email', reason: 'r', status: 'pending', created_at: '2026-05-13T12:45:00Z', routing_status: null },
+  { id: '1', agent_id: 'a1', team_id: 't1', action: 'send_email', reason: 'r', status: 'pending', created_at: '2026-05-13T12:45:00Z', expires_at: '2026-05-13T13:45:00Z', routing_status: null },
   // age 3 h → medium
-  { id: '2', agent_id: 'a2', team_id: 't1', action: 'exec_shell',  reason: 'r', status: 'pending', created_at: '2026-05-13T10:00:00Z', routing_status: null },
+  { id: '2', agent_id: 'a2', team_id: 't1', action: 'exec_shell',  reason: 'r', status: 'pending', created_at: '2026-05-13T10:00:00Z', expires_at: '2026-05-13T11:00:00Z', routing_status: null },
   // age 25 h → low
-  { id: '3', agent_id: 'a1', team_id: 't2', action: 'write_file',  reason: 'r', status: 'pending', created_at: '2026-05-12T12:00:00Z', routing_status: null },
+  { id: '3', agent_id: 'a1', team_id: 't2', action: 'write_file',  reason: 'r', status: 'pending', created_at: '2026-05-12T12:00:00Z', expires_at: '2026-05-12T13:00:00Z', routing_status: null },
 ]
 
 const NOW = new Date('2026-05-13T13:00:00Z').getTime()

--- a/dashboard/src/features/approvals/useApprovalsStream.ts
+++ b/dashboard/src/features/approvals/useApprovalsStream.ts
@@ -54,6 +54,9 @@ export function useApprovalsStream(): { connected: boolean } {
             reason: payload.condition_triggered,
             status: 'pending',
             created_at: event.timestamp,
+            // WS `expires_at` is unix seconds; the REST shape uses RFC 3339,
+            // so convert to ISO 8601 for consistency with the cached list view.
+            expires_at: new Date(payload.expires_at * 1000).toISOString(),
             routing_status: null,
             team_id: null,
           }

--- a/dashboard/src/pages/ApprovalsPage.test.tsx
+++ b/dashboard/src/pages/ApprovalsPage.test.tsx
@@ -40,7 +40,9 @@ function Wrapper({ children }: { children: React.ReactNode }) {
 const MOCK_APPROVAL: Approval = {
   id: 'a1b2c3d4', agent_id: 'agent-001', action: 'send_email',
   reason: 'external comms', status: 'pending',
-  created_at: '2026-05-10T00:00:00Z', routing_status: null, team_id: null,
+  created_at: '2026-05-10T00:00:00Z',
+  expires_at: '2026-05-10T01:00:00Z',
+  routing_status: null, team_id: null,
 }
 
 afterEach(() => { vi.restoreAllMocks() })

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1552,6 +1552,7 @@ components:
       - condition_triggered
       - submitted_at
       - timeout_secs
+      - expires_at
       properties:
         action:
           type: string
@@ -1559,6 +1560,15 @@ components:
         condition_triggered:
           type: string
           description: Policy condition that triggered this request.
+        expires_at:
+          type: integer
+          format: int64
+          description: |-
+            Unix epoch timestamp (seconds) at which the request expires
+            (`submitted_at + timeout_secs`). Provided as a pre-computed
+            absolute timestamp so dashboard consumers can render the
+            auto-expire countdown without local-clock drift.
+          minimum: 0
         request_id:
           type: string
           description: Unique ID for the approval request (UUID v4).
@@ -1582,6 +1592,7 @@ components:
       - reason
       - status
       - created_at
+      - expires_at
       properties:
         action:
           type: string
@@ -1592,6 +1603,14 @@ components:
         created_at:
           type: string
           description: ISO 8601 timestamp when the request was created.
+        expires_at:
+          type: string
+          description: |-
+            ISO 8601 timestamp at which the pending request expires
+            (`created_at` + the governing `approval_timeout_secs`). The
+            dashboard renders a countdown from this value. Empty string on
+            post-decision (`approved` / `rejected`) responses where
+            expiration is no longer meaningful.
         id:
           type: string
           description: Unique approval request identifier.


### PR DESCRIPTION
## Summary

Adds an `expires_at` field to both surfaces of the approvals data path so the dashboard (AAASM-1294) can render its auto-expire countdown deterministically — without local-clock drift.

- **REST** (`ApprovalResponse`): `expires_at: String` in RFC 3339, mirroring the existing `created_at: String`.
- **WS event** (`ApprovalPayload`): `expires_at: u64` (unix seconds), mirroring sibling fields `submitted_at: u64` / `timeout_secs: u64`.

Both are computed as `submitted_at + timeout_secs` (`PendingApprovalRequest.timeout_secs` is the already-resolved value with any per-policy override applied upstream, sourced from `approval_timeout_secs` config which defaults to 300).

## Scope per AAASM-1381 ticket

| Commit | Scope | Path |
|---|---|---|
| ✨ | `aa-api`: Add `expires_at` (RFC 3339) to `ApprovalResponse` + wire `list_approvals` | `aa-api/src/routes/approvals.rs` + `aa-api/tests/approvals.rs` |
| ✨ | `aa-api`: Add `expires_at` to `ApprovalPayload` WebSocket event | `aa-api/src/models/ws_payloads.rs` + `aa-api/src/ws/handler.rs` |
| 📝 | `openapi`: Regenerate `v1.yaml` from utoipa annotations | `openapi/v1.yaml` |

### Out of scope (filed as follow-up)

- **Scope item 4** (ticket): "Backend should auto-transition pending approvals to `expired` when `expires_at < now` (separate from this UI work)" — deferred per the ticket's own parenthetical and filed as a separate Task. This PR is the **read-side data-model fix** (field addition + serialization); the auto-transition is a behavioural change in `ApprovalQueue` (background task or on-read scan, plus the `expired` status variant + emit semantics) worth its own diff.

### Scope-item-2 ("Default TTL value sourced from config") status

Already in place pre-PR. `aa-gateway/src/policy/document.rs` exposes `approval_timeout_secs: u32` (defaults to 300, set by validator). The policy engine wires it into `ApprovalRequest.timeout_secs` via `PolicyDecision::RequireApproval { timeout_secs }`. `PendingApprovalRequest.timeout_secs` is the already-resolved value — no new config knob needed.

## Verification

- `cargo nextest run -p aa-api` — **282/282** pass (includes the updated `list_approvals_returns_pending_requests` REST test with RFC 3339 assertion + the updated `approval_event_maps_to_governance_event_correctly` WS handler test).
- `cargo fmt --all -- --check` — clean.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- `cargo run -p aa-api --bin generate_openapi` — regenerated `openapi/v1.yaml` matches utoipa annotations (committed).
- `AA_BENCH_SLA_P99_MS=5000 cargo nextest run -p aa-gateway --test policy_latency_test` — passes locally with CI's env var (untouched by this PR, but proves the workspace test stays green under CI conditions).

## DoD check

| | |
|---|---|
| `expires_at: string` on `ApprovalResponse` (Rust + utoipa + openapi yaml) | ✅ RFC 3339 |
| `expires_at` on `ApprovalPayload` (WebSocket events) | ✅ unix seconds u64 |
| Default TTL value sourced from `aa-gateway` config | ✅ Already in place pre-PR (`approval_timeout_secs`, default 300) |
| Regenerated `openapi/v1.yaml` from utoipa annotations + committed | ✅ |
| Backend auto-transition pending → expired | ⏭ Filed as follow-up (AAASM-1452, the analogue of the ticket's scope item #4) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)