### PR TITLE
[AAASM-1262] ✅ (aa-integration-tests): cli_agent.rs — 19 tests covering 5 leaves incl. --watch (F121 ST-2)

### DIFF
--- a/aa-integration-tests/tests/cli_agent.rs
+++ b/aa-integration-tests/tests/cli_agent.rs
@@ -178,3 +178,70 @@ async fn agent_list_watch_runs_until_killed() {
     child.kill().expect("kill should succeed");
     let _ = child.wait_with_output();
 }
+
+// =============================================================================
+// aasm agent inspect
+// =============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_inspect_happy_path_returns_single_agent() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let ids = fixture.seed_agents(1);
+    let hex = CliFixture::hex_id(&ids[0]);
+
+    let out = fixture
+        .cmd()
+        .args(["agent", "inspect", &hex, "--output", "json"])
+        .output()
+        .expect("aasm agent inspect should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let v: Value = serde_json::from_slice(&out.stdout).expect("stdout is JSON");
+    // AgentResponse uses field name `id` (not `agent_id`); see
+    // aa-api/src/routes/agents.rs::AgentResponse.
+    assert_eq!(v.get("id").and_then(Value::as_str), Some(hex.as_str()));
+}
+
+#[rstest]
+#[case::json("json")]
+#[case::yaml("yaml")]
+#[case::table("table")]
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_inspect_succeeds_for_every_output_format(#[case] fmt: &str) {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let ids = fixture.seed_agents(1);
+    let hex = CliFixture::hex_id(&ids[0]);
+
+    let out = fixture
+        .cmd()
+        .args(["agent", "inspect", &hex, "--output", fmt])
+        .output()
+        .expect("aasm agent inspect should execute");
+    assert!(
+        out.status.success(),
+        "{fmt} should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(!out.stdout.is_empty(), "{fmt} stdout should not be empty");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_inspect_missing_agent_returns_error() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let bogus = "ffffffffffffffffffffffffffffffff";
+
+    let out = fixture
+        .cmd()
+        .args(["agent", "inspect", bogus])
+        .output()
+        .expect("aasm agent inspect should execute");
+    assert!(
+        !out.status.success(),
+        "unknown agent should fail; stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+}

--- a/aa-integration-tests/tests/cli_agent.rs
+++ b/aa-integration-tests/tests/cli_agent.rs
@@ -1,0 +1,180 @@
+//! CLI integration tests for `aasm agent` (AAASM-1262 / F121 Phase A ST-2).
+//!
+//! Exercises every `aasm agent <leaf>` subcommand against a live in-process
+//! gateway booted via `CliFixture`. For each leaf: happy path, every
+//! `--output` format, per-flag toggles, and (for `agent list`) the `--watch`
+//! streaming mode using the spawn-and-kill pattern documented in the
+//! parent Story.
+//!
+//! ## Leaf surface (from `aa-cli/src/commands/agent/`)
+//!
+//! | Leaf | Args | Flags | Endpoint | Confirmation |
+//! | --- | --- | --- | --- | --- |
+//! | list    | —             | `--status`, `--framework`, `--watch` | GET `/api/v1/agents`              | n/a |
+//! | inspect | `<agent_id>`  | —                                    | GET `/api/v1/agents/{id}`         | n/a |
+//! | kill    | `<agent_id>`  | `--force`                            | DELETE `/api/v1/agents/{id}`      | stdin prompt unless `--force` |
+//! | suspend | `<agent_id>`  | `--reason` (required), `--force`     | POST `/api/v1/agents/{id}/suspend` | stdin prompt unless `--force` |
+//! | resume  | `<agent_id>`  | —                                    | POST `/api/v1/agents/{id}/resume`  | n/a |
+//!
+//! Critical for non-TTY testing: `Command::output()` invokes the binary
+//! with no TTY on stdin, so kill/suspend prompts auto-fail without
+//! `--force`. The "happy path" mutation tests below always pass `--force`.
+
+mod common;
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use aa_gateway::registry::{AgentStatus, SuspendReason};
+use common::cli::{AgentSpec, CliFixture};
+use rstest::rstest;
+use serde_json::Value;
+
+// =============================================================================
+// aasm agent list
+// =============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_list_happy_path_returns_seeded_agents() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    fixture.seed_agents(3);
+
+    let out = fixture
+        .cmd()
+        .args(["agent", "list", "--output", "json"])
+        .output()
+        .expect("aasm agent list should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let v: Value = serde_json::from_slice(&out.stdout).expect("stdout is JSON");
+    let items = v.as_array().expect("stdout is array");
+    assert_eq!(items.len(), 3, "3 seeded agents expected");
+}
+
+#[rstest]
+#[case::json("json")]
+#[case::yaml("yaml")]
+#[case::table("table")]
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_list_succeeds_for_every_output_format(#[case] fmt: &str) {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    fixture.seed_agents(2);
+
+    let out = fixture
+        .cmd()
+        .args(["agent", "list", "--output", fmt])
+        .output()
+        .expect("aasm agent list should execute");
+    assert!(
+        out.status.success(),
+        "{fmt} should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(!out.stdout.is_empty(), "{fmt} stdout should not be empty");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_list_status_filter_only_returns_matching() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    fixture.seed_agents(2);
+    fixture.seed_agent_with(AgentSpec {
+        status: Some(AgentStatus::Suspended(SuspendReason::Manual)),
+        ..AgentSpec::default()
+    });
+
+    // CLI filter uses full Debug-formatted status string (`format!("{:?}", ...)`
+    // in record_to_response), and the comparison is eq_ignore_ascii_case — so
+    // "Suspended(Manual)" matches a Suspended(Manual) agent but not just
+    // "suspended". See aa-api/src/routes/agents.rs::record_to_response.
+    let out = fixture
+        .cmd()
+        .args(["agent", "list", "--status", "Suspended(Manual)", "--output", "json"])
+        .output()
+        .expect("aasm agent list --status should execute");
+    assert!(out.status.success());
+    let v: Value = serde_json::from_slice(&out.stdout).expect("stdout is JSON");
+    let items = v.as_array().expect("stdout is array");
+    assert_eq!(items.len(), 1, "only 1 suspended agent expected");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_list_framework_filter_only_returns_matching() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    fixture.seed_agents(2); // default framework "cli-it"
+    fixture.seed_agent_with(AgentSpec {
+        framework: Some("other-fw".into()),
+        ..AgentSpec::default()
+    });
+
+    let out = fixture
+        .cmd()
+        .args(["agent", "list", "--framework", "other-fw", "--output", "json"])
+        .output()
+        .expect("aasm agent list --framework should execute");
+    assert!(out.status.success());
+    let v: Value = serde_json::from_slice(&out.stdout).expect("stdout is JSON");
+    let items = v.as_array().expect("stdout is array");
+    assert_eq!(items.len(), 1, "only 1 other-fw agent expected");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_list_status_and_framework_combination_intersects() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    fixture.seed_agents(2); // active + cli-it
+    fixture.seed_agent_with(AgentSpec {
+        status: Some(AgentStatus::Suspended(SuspendReason::Manual)),
+        framework: Some("other-fw".into()),
+        ..AgentSpec::default()
+    });
+
+    let out = fixture
+        .cmd()
+        .args([
+            "agent",
+            "list",
+            "--status",
+            "Suspended(Manual)",
+            "--framework",
+            "other-fw",
+            "--output",
+            "json",
+        ])
+        .output()
+        .expect("aasm agent list --status --framework should execute");
+    assert!(out.status.success());
+    let v: Value = serde_json::from_slice(&out.stdout).expect("stdout is JSON");
+    let items = v.as_array().expect("stdout is array");
+    assert_eq!(items.len(), 1, "intersection should yield 1 agent");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_list_watch_runs_until_killed() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    fixture.seed_agents(2);
+
+    let mut child = fixture
+        .cmd()
+        .args(["agent", "list", "--watch", "--output", "json"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("aasm agent list --watch should spawn");
+
+    // --watch refreshes every 2s in an infinite loop; let it run briefly.
+    // Note: refresh-count assertion via stdout is unreliable when piped —
+    // Rust's stdout is block-buffered to pipes and the in-flight bytes are
+    // lost on SIGKILL. So we just verify the process stays alive and exits
+    // cleanly when killed — proves the --watch flag is accepted and enters
+    // the loop without crashing.
+    std::thread::sleep(Duration::from_millis(1500));
+    assert!(
+        child.try_wait().expect("try_wait should work").is_none(),
+        "--watch should keep the process alive (not exit on its own)",
+    );
+    child.kill().expect("kill should succeed");
+    let _ = child.wait_with_output();
+}

--- a/aa-integration-tests/tests/cli_agent.rs
+++ b/aa-integration-tests/tests/cli_agent.rs
@@ -305,3 +305,110 @@ async fn agent_kill_missing_agent_returns_error() {
         String::from_utf8_lossy(&out.stdout),
     );
 }
+
+// =============================================================================
+// aasm agent suspend
+// =============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_suspend_with_reason_and_force_succeeds() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let ids = fixture.seed_agents(1);
+    let hex = CliFixture::hex_id(&ids[0]);
+
+    let out = fixture
+        .cmd()
+        .args([
+            "agent",
+            "suspend",
+            &hex,
+            "--reason",
+            "policy violation",
+            "--force",
+            "--output",
+            "json",
+        ])
+        .output()
+        .expect("aasm agent suspend should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let v: Value = serde_json::from_slice(&out.stdout).expect("stdout is JSON");
+    assert_eq!(v.get("agent_id").and_then(Value::as_str), Some(hex.as_str()),);
+    // Gateway formats AgentStatus via `format!("{:?}", ...)` so suspend
+    // returns the full Debug form including the reason variant.
+    assert_eq!(v.get("new_status").and_then(Value::as_str), Some("Suspended(Manual)"),);
+}
+
+#[rstest]
+#[case::json("json")]
+#[case::yaml("yaml")]
+#[case::table("table")]
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_suspend_succeeds_for_every_output_format(#[case] fmt: &str) {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let ids = fixture.seed_agents(1);
+    let hex = CliFixture::hex_id(&ids[0]);
+
+    let out = fixture
+        .cmd()
+        .args([
+            "agent", "suspend", &hex, "--reason", "fmt test", "--force", "--output", fmt,
+        ])
+        .output()
+        .expect("aasm agent suspend should execute");
+    assert!(
+        out.status.success(),
+        "{fmt} should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(!out.stdout.is_empty(), "{fmt} stdout should not be empty");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_suspend_without_reason_returns_error() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let ids = fixture.seed_agents(1);
+    let hex = CliFixture::hex_id(&ids[0]);
+
+    let out = fixture
+        .cmd()
+        .args(["agent", "suspend", &hex, "--force"])
+        .output()
+        .expect("aasm agent suspend --force (no --reason) should execute");
+    assert!(
+        !out.status.success(),
+        "missing --reason should fail (clap-enforced); stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_suspend_then_inspect_shows_suspended_status() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let ids = fixture.seed_agents(1);
+    let hex = CliFixture::hex_id(&ids[0]);
+
+    let suspend = fixture
+        .cmd()
+        .args(["agent", "suspend", &hex, "--reason", "round-trip", "--force"])
+        .output()
+        .expect("suspend should execute");
+    assert!(suspend.status.success());
+
+    let inspect = fixture
+        .cmd()
+        .args(["agent", "inspect", &hex, "--output", "json"])
+        .output()
+        .expect("inspect should execute");
+    assert!(inspect.status.success());
+    let v: Value = serde_json::from_slice(&inspect.stdout).expect("inspect stdout is JSON");
+    assert_eq!(
+        v.get("status").and_then(Value::as_str),
+        Some("Suspended(Manual)"),
+        "agent status should be Suspended(Manual) after suspend",
+    );
+}

--- a/aa-integration-tests/tests/cli_agent.rs
+++ b/aa-integration-tests/tests/cli_agent.rs
@@ -245,3 +245,63 @@ async fn agent_inspect_missing_agent_returns_error() {
         String::from_utf8_lossy(&out.stdout),
     );
 }
+
+// =============================================================================
+// aasm agent kill
+// =============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_kill_with_force_succeeds() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let ids = fixture.seed_agents(1);
+    let hex = CliFixture::hex_id(&ids[0]);
+
+    let out = fixture
+        .cmd()
+        .args(["agent", "kill", &hex, "--force"])
+        .output()
+        .expect("aasm agent kill --force should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_kill_without_force_aborts_on_non_tty_stdin() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let ids = fixture.seed_agents(1);
+    let hex = CliFixture::hex_id(&ids[0]);
+
+    // Command::output() = no TTY on stdin → prompt read_line returns "",
+    // confirmation fails, exit non-zero. Documents the safety property.
+    let out = fixture
+        .cmd()
+        .args(["agent", "kill", &hex])
+        .output()
+        .expect("aasm agent kill (no --force) should execute");
+    assert!(
+        !out.status.success(),
+        "without --force on non-TTY stdin should abort; stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_kill_missing_agent_returns_error() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let bogus = "ffffffffffffffffffffffffffffffff";
+
+    let out = fixture
+        .cmd()
+        .args(["agent", "kill", bogus, "--force"])
+        .output()
+        .expect("aasm agent kill --force should execute");
+    assert!(
+        !out.status.success(),
+        "unknown agent should fail; stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+}

--- a/aa-integration-tests/tests/cli_agent.rs
+++ b/aa-integration-tests/tests/cli_agent.rs
@@ -412,3 +412,84 @@ async fn agent_suspend_then_inspect_shows_suspended_status() {
         "agent status should be Suspended(Manual) after suspend",
     );
 }
+
+// =============================================================================
+// aasm agent resume
+// =============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_resume_happy_path_succeeds() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let id = fixture.seed_agent_with(AgentSpec {
+        status: Some(AgentStatus::Suspended(SuspendReason::Manual)),
+        ..AgentSpec::default()
+    });
+    let hex = CliFixture::hex_id(&id);
+
+    let out = fixture
+        .cmd()
+        .args(["agent", "resume", &hex, "--output", "json"])
+        .output()
+        .expect("aasm agent resume should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let v: Value = serde_json::from_slice(&out.stdout).expect("stdout is JSON");
+    assert_eq!(v.get("new_status").and_then(Value::as_str), Some("Active"));
+}
+
+#[rstest]
+#[case::json("json")]
+#[case::yaml("yaml")]
+#[case::table("table")]
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_resume_succeeds_for_every_output_format(#[case] fmt: &str) {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let id = fixture.seed_agent_with(AgentSpec {
+        status: Some(AgentStatus::Suspended(SuspendReason::Manual)),
+        ..AgentSpec::default()
+    });
+    let hex = CliFixture::hex_id(&id);
+
+    let out = fixture
+        .cmd()
+        .args(["agent", "resume", &hex, "--output", fmt])
+        .output()
+        .expect("aasm agent resume should execute");
+    assert!(
+        out.status.success(),
+        "{fmt} should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(!out.stdout.is_empty(), "{fmt} stdout should not be empty");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn agent_suspend_then_resume_round_trip_returns_to_active() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let ids = fixture.seed_agents(1);
+    let hex = CliFixture::hex_id(&ids[0]);
+
+    let suspend = fixture
+        .cmd()
+        .args(["agent", "suspend", &hex, "--reason", "test", "--force"])
+        .output()
+        .expect("suspend should execute");
+    assert!(suspend.status.success());
+
+    let resume = fixture
+        .cmd()
+        .args(["agent", "resume", &hex, "--output", "json"])
+        .output()
+        .expect("resume should execute");
+    assert!(resume.status.success());
+    let v: Value = serde_json::from_slice(&resume.stdout).expect("resume stdout is JSON");
+    assert_eq!(
+        v.get("previous_status").and_then(Value::as_str),
+        Some("Suspended(Manual)"),
+    );
+    assert_eq!(v.get("new_status").and_then(Value::as_str), Some("Active"));
+}


### PR DESCRIPTION
## Summary

Phase A ST-2 of AAASM-1258 (F121) — integration tests for every `aasm agent` leaf: list / inspect / kill / suspend / resume + `--watch` streaming smoke. **5 granular commits, 19 test fns / 27 actual cases.**

## Leaves covered

| Leaf | Args | Tests | rstest cases | Notable |
|---|---|---|---|---|
| `agent list` | — | 6 | +2 (format ×3) | `--watch` streaming smoke; filter combination test |
| `agent inspect` | `<agent_id>` | 3 | +2 | missing-agent error path |
| `agent kill` | `<agent_id>` | 3 | — | confirms safety: aborts on non-TTY stdin without `--force` |
| `agent suspend` | `<agent_id>` | 4 | +2 | suspend→inspect round-trip |
| `agent resume` | `<agent_id>` | 3 | +2 | suspend→resume round-trip |
| **Total** | | **19 fns** | **27 cases** | |

## Commits (5 — per-leaf granularity)

| # | SHA | Subject |
|---|---|---|
| 1 | `544a9815` | ✅ Add cli_agent list tests |
| 2 | `0621e005` | ✅ Add cli_agent inspect tests |
| 3 | `378e639f` | ✅ Add cli_agent kill tests |
| 4 | `f6812e91` | ✅ Add cli_agent suspend tests |
| 5 | `606ee454` | ✅ Add cli_agent resume tests |

No new harness extensions needed — ST-1's `seed_team_members` / `seed_parent_child` weren't required, and `AgentSpec` already supports status / framework via `seed_agent_with`.

## Discoveries worth recording

Three behaviors discovered while writing assertions — all documented inline + in commit messages:

1. **`AgentResponse.id`, not `agent_id`** — the inspect/list endpoint uses field `id` for the hex UUID. (Suspend/Resume responses use `agent_id` because they're distinct types.)
2. **`--status` filter requires the full Debug-formatted string** — gateway emits status via `format!(\"{:?}\", AgentStatus)`, so a Manual-reason suspended agent has status string `\"Suspended(Manual)\"`. Filter is `eq_ignore_ascii_case` strict equality — you must pass `--status \"Suspended(Manual)\"`, not `--status suspended`.
3. **Kill/suspend prompt safely aborts on non-TTY stdin** — without `--force`, the CLI reads from stdin; when stdin is piped (as in `Command::output()`), the read returns empty and confirmation fails. Tests deliberately exercise this path to document the safety property.

## `--watch` test pattern caveat

The `agent_list_watch_runs_until_killed` test is intentionally a **liveness check** rather than a refresh-count assertion. Rust's stdout is block-buffered when piped, so bytes the CLI emits via `print!`/`println!` sit in the kernel buffer until full or explicit flush — and `Child::kill()` (SIGKILL) terminates before flushing. We assert: process spawns, stays alive for 1.5s (proves `--watch` enters the infinite loop), and can be killed cleanly.

## Test plan

```text
$ cargo nextest run -p aa-integration-tests --test cli_agent
  27 tests run: 27 passed (1 leaky), 0 skipped

$ cargo nextest run -p aa-integration-tests
  64 tests run: 64 passed (1 leaky), 0 skipped
  (5 AAASM-1066 + 4 ST-0 + 28 ST-1 cli_topology + 27 new cli_agent)
```

lefthook fmt + clippy + deny green on every commit. The "1 leaky" is the cargo-run-aasm subprocess pattern noted in ST-1 — harmless.

## AC coverage vs AAASM-1262

| AC | Status |
|---|---|
| One new file `aa-integration-tests/tests/cli_agent.rs` | ✅ |
| Covers list / inspect / kill / suspend / resume | ✅ all 5 leaves |
| Each leaf has happy + per-`--output` format tests | ✅ |
| Includes `--watch` streaming test | ✅ liveness-style; documented caveat |
| Suspend→inspect round-trip + suspend→resume round-trip | ✅ both present |
| Independent of ST-1 (different new file) | ✅ |

## Related

* Parent: AAASM-1258 (F121 Phase A)
* Builds on: AAASM-1449 ST-0 (CliFixture)
* Parallel to: AAASM-1261 ST-3 (cli_policy.rs)
* Unblocks: AAASM-1263 ST-9 (verify Phase A) once ST-3 also lands
* Epic: AAASM-1199