### PR TITLE
[AAASM-1467] ✅ (aa-integration-tests): Add cli_version integration tests

### DIFF
--- a/aa-integration-tests/tests/cli_version.rs
+++ b/aa-integration-tests/tests/cli_version.rs
@@ -25,6 +25,7 @@
 mod common;
 
 use common::cli::CliFixture;
+use rstest::rstest;
 
 // =============================================================================
 // aasm version
@@ -55,4 +56,25 @@ async fn version_happy_path_reports_cli_and_gateway_rows() {
         stdout.contains("gateway"),
         "stdout should mention the `gateway` row\nstdout:\n{stdout}",
     );
+}
+
+#[rstest]
+#[case::json("json")]
+#[case::yaml("yaml")]
+#[case::table("table")]
+#[tokio::test(flavor = "multi_thread")]
+async fn version_succeeds_for_every_output_format(#[case] fmt: &str) {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["version", "--output", fmt])
+        .output()
+        .expect("aasm version should execute");
+    assert!(
+        out.status.success(),
+        "{fmt} should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(!out.stdout.is_empty(), "{fmt} stdout should not be empty");
 }

--- a/aa-integration-tests/tests/cli_version.rs
+++ b/aa-integration-tests/tests/cli_version.rs
@@ -25,6 +25,7 @@
 mod common;
 
 use common::cli::CliFixture;
+use common::format::assert_equivalent_records;
 use rstest::rstest;
 
 // =============================================================================
@@ -77,4 +78,29 @@ async fn version_succeeds_for_every_output_format(#[case] fmt: &str) {
         String::from_utf8_lossy(&out.stderr),
     );
     assert!(!out.stdout.is_empty(), "{fmt} stdout should not be empty");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn version_json_and_yaml_describe_equivalent_records() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let json_out = fixture
+        .cmd()
+        .args(["version", "--output", "json"])
+        .output()
+        .expect("aasm version --output json should execute");
+    assert!(json_out.status.success(), "json variant should exit 0");
+
+    let yaml_out = fixture
+        .cmd()
+        .args(["version", "--output", "yaml"])
+        .output()
+        .expect("aasm version --output yaml should execute");
+    assert!(yaml_out.status.success(), "yaml variant should exit 0");
+
+    // `version` emits a flat array keyed by `component`; equivalence asserts
+    // both formats describe the same {cli, gateway, api} record set. Per-row
+    // `status` is reachability-dependent and excluded by the helper (it
+    // compares only the `component` id field).
+    assert_equivalent_records(&json_out.stdout, &yaml_out.stdout, "component");
 }

--- a/aa-integration-tests/tests/cli_version.rs
+++ b/aa-integration-tests/tests/cli_version.rs
@@ -25,7 +25,7 @@
 mod common;
 
 use common::cli::CliFixture;
-use common::format::assert_equivalent_records;
+use common::format::{assert_equivalent_records, parse_json};
 use rstest::rstest;
 
 // =============================================================================
@@ -103,4 +103,52 @@ async fn version_json_and_yaml_describe_equivalent_records() {
     // `status` is reachability-dependent and excluded by the helper (it
     // compares only the `component` id field).
     assert_equivalent_records(&json_out.stdout, &yaml_out.stdout, "component");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn version_build_metadata_field_shape() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["version", "--output", "json"])
+        .output()
+        .expect("aasm version --output json should execute");
+    assert!(out.status.success(), "should exit 0");
+
+    let v = parse_json(&out.stdout);
+    let rows = v.as_array().expect("version output should be a JSON array");
+    let by_component: std::collections::HashMap<&str, &serde_json::Value> = rows
+        .iter()
+        .filter_map(|row| row.get("component").and_then(|c| c.as_str()).map(|c| (c, row)))
+        .collect();
+
+    for component in ["cli", "gateway", "api"] {
+        let row = by_component
+            .get(component)
+            .unwrap_or_else(|| panic!("expected `{component}` row in version output\nstdout:\n{v}"));
+        assert!(row.get("version").is_some(), "`{component}` row should have `version`");
+        assert!(row.get("status").is_some(), "`{component}` row should have `status`");
+    }
+
+    // The CLI row is always populated from `CARGO_PKG_VERSION` at build time
+    // and must be a non-empty semver-shaped string regardless of gateway
+    // reachability. Tolerates the "build without git context" case the AC
+    // calls out — the CLI does not currently emit `commit`/`build_date`
+    // fields, so this is the version-string shape we can assert today.
+    let cli_version = by_component["cli"]["version"]
+        .as_str()
+        .expect("cli.version should be a string");
+    let parts: Vec<&str> = cli_version.split('.').collect();
+    assert_eq!(
+        parts.len(),
+        3,
+        "cli.version `{cli_version}` should be semver `MAJOR.MINOR.PATCH`"
+    );
+    for part in &parts {
+        assert!(
+            part.chars().any(|c| c.is_ascii_digit()),
+            "cli.version segment `{part}` should contain at least one digit (got `{cli_version}`)",
+        );
+    }
 }

--- a/aa-integration-tests/tests/cli_version.rs
+++ b/aa-integration-tests/tests/cli_version.rs
@@ -1,0 +1,58 @@
+//! CLI integration tests for `aasm version` (AAASM-1467 / F121 ST-11).
+//!
+//! Exercises the top-level `aasm version` command against a live in-process
+//! gateway booted via [`CliFixture`], plus one degraded path (gateway
+//! unreachable) using a stand-alone command pointed at a freshly-reserved-
+//! and-released TCP port. Output shape per `aa-cli/src/commands/version.rs`
+//! is a flat `Vec<VersionRow>` of `{component, version, status}` for the
+//! three components `cli`, `gateway`, `api`.
+//!
+//! ## Leaf surface (from `aa-cli/src/commands/version.rs`)
+//!
+//! | Leaf | Args | Flags | Output shape |
+//! | --- | --- | --- | --- |
+//! | version | — | `--output` (inherited from root) | array of three rows (cli, gateway, api) |
+//!
+//! ## AC vs implementation
+//!
+//! AAASM-1467 originally described a nested JSON shape with `commit` and
+//! `build_date` metadata. The implementation does not currently expose
+//! those fields — the build-metadata test instead asserts the shape of
+//! what the CLI actually emits (semver `version` on the `cli` row, presence
+//! of all three component rows). Adding `commit` / `build_date` is a
+//! CLI-surface change and out of scope for this ST.
+
+mod common;
+
+use common::cli::CliFixture;
+
+// =============================================================================
+// aasm version
+// =============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn version_happy_path_reports_cli_and_gateway_rows() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["version"])
+        .output()
+        .expect("aasm version should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("cli"),
+        "stdout should mention the `cli` row\nstdout:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("gateway"),
+        "stdout should mention the `gateway` row\nstdout:\n{stdout}",
+    );
+}

--- a/aa-integration-tests/tests/cli_version.rs
+++ b/aa-integration-tests/tests/cli_version.rs
@@ -152,3 +152,60 @@ async fn version_build_metadata_field_shape() {
         );
     }
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn version_gateway_unreachable_degrades_gracefully() {
+    // Reserve a free port, then immediately release it. The kernel won't
+    // reassign it within the few seconds the test runs, so any connection
+    // to the URL will fast-refuse and `aasm version` should still exit 0
+    // with the gateway / api rows marked `unreachable`.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("test should be able to bind to ephemeral port");
+    let port = listener.local_addr().expect("listener should have a local addr").port();
+    drop(listener);
+    let dead_url = format!("http://127.0.0.1:{port}");
+
+    let out = std::process::Command::new(env!("CARGO"))
+        .args([
+            "run",
+            "--quiet",
+            "-p",
+            "aa-cli",
+            "--bin",
+            "aasm",
+            "--",
+            "--api-url",
+            &dead_url,
+            "version",
+            "--output",
+            "json",
+        ])
+        .output()
+        .expect("aasm version should execute even against a dead gateway");
+    assert!(
+        out.status.success(),
+        "version should exit 0 even when the gateway is unreachable\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let v = parse_json(&out.stdout);
+    let rows = v.as_array().expect("version output should be a JSON array");
+    let gateway_row = rows
+        .iter()
+        .find(|row| row.get("component").and_then(|c| c.as_str()) == Some("gateway"))
+        .expect("gateway row should be present");
+    assert_eq!(
+        gateway_row["status"].as_str(),
+        Some("unreachable"),
+        "gateway row should report `unreachable` status\nrow:\n{gateway_row}",
+    );
+    let api_row = rows
+        .iter()
+        .find(|row| row.get("component").and_then(|c| c.as_str()) == Some("api"))
+        .expect("api row should be present");
+    assert_eq!(
+        api_row["status"].as_str(),
+        Some("unreachable"),
+        "api row should report `unreachable` status\nrow:\n{api_row}",
+    );
+}


### PR DESCRIPTION
## Description

Adds `aa-integration-tests/tests/cli_version.rs` — integration tests for the
top-level `aasm version` command against a live in-process gateway booted
via `CliFixture` (the AAASM-1066 / F121 ST-0 harness), plus one degraded
path (gateway unreachable) that uses a stand-alone command pointed at a
freshly-reserved-and-released TCP port.

Five `#[rstest]`/`#[tokio::test]` test functions (seven test cases after
parametrization):

1. `version_happy_path_reports_cli_and_gateway_rows` — default table
   output, exit 0, stdout mentions `cli` and `gateway` rows.
2. `version_succeeds_for_every_output_format` — `#[rstest]` over
   `json` / `yaml` / `table`; each format exits 0 with non-empty stdout.
3. `version_json_and_yaml_describe_equivalent_records` —
   `assert_equivalent_records(.., \"component\")` for cross-format
   equivalence (excludes per-row `status` which is reachability-dependent,
   per AC).
4. `version_build_metadata_field_shape` — JSON output contains rows for
   `cli`, `gateway`, and `api`; every row has `version` + `status` fields;
   the build-time-populated `cli.version` matches `MAJOR.MINOR.PATCH`.
5. `version_gateway_unreachable_degrades_gracefully` — reserves an
   ephemeral port, drops the listener, invokes `aasm version` against the
   freed port. Asserts exit 0 + `gateway` / `api` rows report
   `status == \"unreachable\"`.

## AC vs implementation note

AAASM-1467's original spec described a nested JSON shape with
`{cli: {version, commit, build_date}, gateway: {…}}`. The current CLI
(`aa-cli/src/commands/version.rs`) emits a **flat** `Vec<VersionRow>` of
`{component, version, status}` for `cli` / `gateway` / `api` — no
`commit` / `build_date` fields. The build-metadata test is therefore
re-scoped to assert the shape of the fields the implementation actually
emits (semver `version` on the `cli` row, presence of all three component
rows). Adding `commit` / `build_date` would be a CLI-surface change and is
out of scope for this ST.

## Type of Change

- [x] ✨ New feature (test coverage; no production code change)
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1467 (parent Story AAASM-1258)
- Related GitHub issues: —

## Testing

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

```
cargo nextest run -p aa-integration-tests --test cli_version
Starting 7 tests across 1 binary
    PASS [  23.717s] (1/7) aa-integration-tests::cli_version version_succeeds_for_every_output_format::case_2_yaml
    PASS [  23.762s] (2/7) aa-integration-tests::cli_version version_gateway_unreachable_degrades_gracefully
    PASS [  23.767s] (3/7) aa-integration-tests::cli_version version_succeeds_for_every_output_format::case_3_table
    PASS [  23.767s] (4/7) aa-integration-tests::cli_version version_build_metadata_field_shape
    PASS [  23.767s] (5/7) aa-integration-tests::cli_version version_happy_path_reports_cli_and_gateway_rows
    PASS [  23.767s] (6/7) aa-integration-tests::cli_version version_succeeds_for_every_output_format::case_1_json
    PASS [  29.116s] (7/7) aa-integration-tests::cli_version version_json_and_yaml_describe_equivalent_records
 Summary [  29.116s] 7 tests run: 7 passed, 0 skipped
```

CI will run the same suite on Linux + macOS (AC).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed — N/A
- [ ] All CI checks passing — _pending CI_
- [x] Commits are small and follow the Gitmoji convention (5 commits, one per test fn)