### PR TITLE
[AAASM-1463] ✅ (aa-integration-tests): Add cli_context.rs integration tests

### DIFF
--- a/aa-integration-tests/tests/cli_context.rs
+++ b/aa-integration-tests/tests/cli_context.rs
@@ -338,3 +338,114 @@ async fn context_set_replaces_existing_context_url() {
         "list should not retain the old URL after replacement; got:\n{stdout}",
     );
 }
+
+// ============================================================================
+// aasm context use
+// ============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn context_use_switches_default_to_named_context() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let home = TempDir::new().expect("tempdir for HOME");
+
+    // `a` becomes default (first), `b` does not.
+    for (name, url) in [("a", "http://a:8080"), ("b", "http://b:8080")] {
+        let out = fixture
+            .cmd()
+            .env("HOME", home.path())
+            .args(["context", "set", name, "--api-url", url])
+            .output()
+            .expect("seed set");
+        assert!(out.status.success(), "seed set should succeed");
+    }
+
+    let used = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args(["context", "use", "b"])
+        .output()
+        .expect("use");
+    assert!(
+        used.status.success(),
+        "use should succeed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&used.stdout),
+        String::from_utf8_lossy(&used.stderr),
+    );
+
+    let list = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args(["context", "list"])
+        .output()
+        .expect("list");
+    assert!(list.status.success(), "list should succeed");
+    let stdout = String::from_utf8_lossy(&list.stdout);
+    let b_line = stdout
+        .lines()
+        .find(|l| l.trim_start().starts_with("b"))
+        .unwrap_or_else(|| panic!("missing 'b' line in:\n{stdout}"));
+    assert!(
+        b_line.contains(" *"),
+        "after `use b`, b should be default; got: {b_line:?}"
+    );
+    let a_line = stdout
+        .lines()
+        .find(|l| l.trim_start().starts_with("a"))
+        .unwrap_or_else(|| panic!("missing 'a' line in:\n{stdout}"));
+    assert!(
+        !a_line.contains(" *"),
+        "after `use b`, a should no longer be default; got: {a_line:?}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn context_use_unknown_name_exits_non_zero_and_says_not_found() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let home = TempDir::new().expect("tempdir for HOME");
+
+    // Seed at least one known context so the failure path is "unknown name",
+    // not "no contexts at all".
+    let seed = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args(["context", "set", "known", "--api-url", "http://known:8080"])
+        .output()
+        .expect("seed set");
+    assert!(seed.status.success(), "seed should succeed");
+
+    let out = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args(["context", "use", "missing"])
+        .output()
+        .expect("use");
+    assert!(
+        !out.status.success(),
+        "use on unknown name should exit non-zero\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("not found"),
+        "stderr should mention 'not found'; got:\n{stderr}",
+    );
+
+    // Default unchanged.
+    let list = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args(["context", "list"])
+        .output()
+        .expect("list");
+    assert!(list.status.success(), "list should succeed");
+    let stdout = String::from_utf8_lossy(&list.stdout);
+    let known_line = stdout
+        .lines()
+        .find(|l| l.trim_start().starts_with("known"))
+        .unwrap_or_else(|| panic!("missing 'known' line in:\n{stdout}"));
+    assert!(
+        known_line.contains(" *"),
+        "default should still be 'known' after failed use; got: {known_line:?}",
+    );
+}

--- a/aa-integration-tests/tests/cli_context.rs
+++ b/aa-integration-tests/tests/cli_context.rs
@@ -449,3 +449,103 @@ async fn context_use_unknown_name_exits_non_zero_and_says_not_found() {
         "default should still be 'known' after failed use; got: {known_line:?}",
     );
 }
+
+// ============================================================================
+// Round-trip + $HOME isolation
+// ============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn context_set_then_list_round_trips_full_values() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let home = TempDir::new().expect("tempdir for HOME");
+
+    let set = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args([
+            "context",
+            "set",
+            "rt",
+            "--api-url",
+            "https://rt.example.com:9443",
+            "--api-key",
+            "rt-token",
+        ])
+        .output()
+        .expect("set");
+    assert!(set.status.success(), "set should succeed");
+
+    let list = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args(["context", "list"])
+        .output()
+        .expect("list");
+    assert!(list.status.success(), "list should succeed");
+    let stdout = String::from_utf8_lossy(&list.stdout);
+    assert!(
+        stdout.contains("rt"),
+        "round-trip: list missing context name 'rt':\n{stdout}"
+    );
+    assert!(
+        stdout.contains("https://rt.example.com:9443"),
+        "round-trip: list missing api_url:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("(key set)"),
+        "round-trip: list should annotate '(key set)':\n{stdout}",
+    );
+    // Key MUST NOT appear in plaintext stdout — defense against accidental
+    // print regressions.
+    assert!(
+        !stdout.contains("rt-token"),
+        "round-trip: secret key must not leak to stdout:\n{stdout}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn context_set_does_not_touch_real_home_dot_aa() {
+    // Snapshot the real $HOME/.aa/config.yaml (if any) before the test. If
+    // HOME isolation works, this content is identical after.
+    let real_home = std::env::var_os("HOME").expect("HOME should be set in test process");
+    let real_cfg = std::path::Path::new(&real_home).join(".aa/config.yaml");
+    let before = std::fs::read_to_string(&real_cfg).ok();
+
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let home = TempDir::new().expect("tempdir for HOME");
+
+    let out = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args([
+            "context",
+            "set",
+            "iso",
+            "--api-url",
+            "http://iso.test:8080",
+            "--api-key",
+            "iso-key",
+        ])
+        .output()
+        .expect("set");
+    assert!(out.status.success(), "set should succeed");
+
+    let after = std::fs::read_to_string(&real_cfg).ok();
+    assert_eq!(
+        before, after,
+        "real $HOME/.aa/config.yaml content changed across the test; HOME isolation is broken",
+    );
+
+    // Per-test HOME tempdir actually received the write — proves the
+    // before/after equality above is meaningful (not a no-op `set`).
+    let tmp_cfg = home.path().join(".aa/config.yaml");
+    assert!(
+        tmp_cfg.exists(),
+        "tempdir HOME/.aa/config.yaml should exist after `set`",
+    );
+    let raw = std::fs::read_to_string(&tmp_cfg).expect("read tempdir config.yaml");
+    assert!(
+        raw.contains("iso"),
+        "tempdir config.yaml should contain the 'iso' context; got:\n{raw}",
+    );
+}

--- a/aa-integration-tests/tests/cli_context.rs
+++ b/aa-integration-tests/tests/cli_context.rs
@@ -1,0 +1,155 @@
+//! CLI integration tests for `aasm context` (AAASM-1463 / F121 follow-up).
+//!
+//! Exercises the three real `context` leaves shipped in master: `list`,
+//! `set <NAME>`, and `use <NAME>`. Backed purely by the local config file
+//! at `~/.aa/config.yaml`; no gateway calls — the in-process gateway that
+//! `CliFixture::start()` boots sits idle for these tests, but the fixture
+//! is used anyway to keep the harness contract uniform across cli_*.rs
+//! files (per AAASM-1258 test-design rule "All tests use the shared
+//! `CliFixture` — no per-test-file gateway boot helpers").
+//!
+//! ## Divergence from subtask description
+//!
+//! The AAASM-1463 description was drafted against a *planned* context
+//! surface (`show` leaf, `--gateway-url`/`--token` flags, `--output` json
+//! format, config at `~/.aasm/config.toml`). Master ships `list`/`set`/
+//! `use` with positional `<NAME>` + `--api-url`/`--api-key`, plain-text
+//! output only, config at `~/.aa/config.yaml`. Tests are written against
+//! the real surface; see the AAASM-1463 starting-work comment for the
+//! full reconciliation.
+//!
+//! ## $HOME isolation
+//!
+//! `aa_cli::config::config_dir()` calls `dirs::home_dir()`, which on Unix
+//! reads `$HOME`. Each test injects `HOME=<tempfile::TempDir>` on the
+//! `Command` so config writes land inside the tempdir and disappear when
+//! the test ends. The shared `CliFixture::cmd()` does not set `HOME`
+//! (it only sets `AA_DATA_DIR`); per-test override here keeps the
+//! isolation pattern contained to this file.
+//!
+//! ## Leaf surface (from `aa-cli/src/commands/context.rs`)
+//!
+//! | Leaf | Args | Backend | Notes |
+//! | --- | --- | --- | --- |
+//! | `list` | — | filesystem (`~/.aa/config.yaml`) | prints `<name>[ *]  <url>[ (key set)]` per line; empty config → "No contexts configured." |
+//! | `set` | `<NAME> --api-url <U> [--api-key <K>]` | filesystem | first inserted context becomes default; re-`set` of an existing name replaces both URL and key |
+//! | `use` | `<NAME>` | filesystem | switches default; non-zero exit when name absent |
+
+mod common;
+
+use common::cli::CliFixture;
+use tempfile::TempDir;
+
+// ============================================================================
+// aasm context list
+// ============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn context_list_empty_prints_helpful_message() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let home = TempDir::new().expect("tempdir for HOME");
+
+    let out = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args(["context", "list"])
+        .output()
+        .expect("aasm context list should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("No contexts configured"),
+        "empty list should print helpful message; got:\n{stdout}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn context_list_with_two_contexts_shows_both_names_and_urls() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let home = TempDir::new().expect("tempdir for HOME");
+
+    // Seed via the CLI itself — exercises real `set` writes.
+    for (name, url) in [
+        ("prod", "https://prod.example.com"),
+        ("staging", "https://staging.example.com"),
+    ] {
+        let out = fixture
+            .cmd()
+            .env("HOME", home.path())
+            .args(["context", "set", name, "--api-url", url])
+            .output()
+            .expect("aasm context set should execute");
+        assert!(out.status.success(), "seed `set {name}` should succeed");
+    }
+
+    let out = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args(["context", "list"])
+        .output()
+        .expect("aasm context list should execute");
+    assert!(out.status.success(), "list should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("prod"), "list missing 'prod' line; got:\n{stdout}");
+    assert!(
+        stdout.contains("staging"),
+        "list missing 'staging' line; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("https://prod.example.com"),
+        "list missing prod URL; got:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("https://staging.example.com"),
+        "list missing staging URL; got:\n{stdout}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn context_list_marks_default_with_asterisk_and_others_without() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let home = TempDir::new().expect("tempdir for HOME");
+
+    // First `set` becomes the default (asserted in detail by
+    // `context_set_first_context_becomes_default`); second does not.
+    for (name, url) in [("first-default", "http://one:8080"), ("other", "http://two:8080")] {
+        let out = fixture
+            .cmd()
+            .env("HOME", home.path())
+            .args(["context", "set", name, "--api-url", url])
+            .output()
+            .expect("seed set");
+        assert!(out.status.success(), "seed `set {name}` should succeed");
+    }
+
+    let out = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args(["context", "list"])
+        .output()
+        .expect("list");
+    assert!(out.status.success(), "list should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    let default_line = stdout
+        .lines()
+        .find(|l| l.trim_start().starts_with("first-default"))
+        .unwrap_or_else(|| panic!("missing 'first-default' line in:\n{stdout}"));
+    assert!(
+        default_line.contains(" *"),
+        "default context line should contain ' *' marker; got: {default_line:?}",
+    );
+    let other_line = stdout
+        .lines()
+        .find(|l| l.trim_start().starts_with("other"))
+        .unwrap_or_else(|| panic!("missing 'other' line in:\n{stdout}"));
+    assert!(
+        !other_line.contains(" *"),
+        "non-default context line should not have ' *' marker; got: {other_line:?}",
+    );
+}

--- a/aa-integration-tests/tests/cli_context.rs
+++ b/aa-integration-tests/tests/cli_context.rs
@@ -153,3 +153,188 @@ async fn context_list_marks_default_with_asterisk_and_others_without() {
         "non-default context line should not have ' *' marker; got: {other_line:?}",
     );
 }
+
+// ============================================================================
+// aasm context set
+// ============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn context_set_creates_config_file_and_prints_save_message() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let home = TempDir::new().expect("tempdir for HOME");
+
+    let out = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args(["context", "set", "local", "--api-url", "http://localhost:8080"])
+        .output()
+        .expect("aasm context set should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("'local'"),
+        "save message should quote the context name; got:\n{stdout}",
+    );
+
+    let cfg_path = home.path().join(".aa/config.yaml");
+    assert!(cfg_path.exists(), "set should create ~/.aa/config.yaml under HOME");
+    let raw = std::fs::read_to_string(&cfg_path).expect("read config.yaml");
+    assert!(
+        raw.contains("local"),
+        "config.yaml should contain context name; got:\n{raw}"
+    );
+    assert!(
+        raw.contains("http://localhost:8080"),
+        "config.yaml should contain api_url; got:\n{raw}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn context_set_first_context_becomes_default() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let home = TempDir::new().expect("tempdir for HOME");
+
+    let out = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args(["context", "set", "first", "--api-url", "http://first:8080"])
+        .output()
+        .expect("set");
+    assert!(out.status.success(), "set should succeed");
+
+    let list = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args(["context", "list"])
+        .output()
+        .expect("list");
+    assert!(list.status.success(), "list should succeed");
+    let stdout = String::from_utf8_lossy(&list.stdout);
+    let line = stdout
+        .lines()
+        .find(|l| l.trim_start().starts_with("first"))
+        .unwrap_or_else(|| panic!("missing 'first' line in:\n{stdout}"));
+    assert!(
+        line.contains(" *"),
+        "first context inserted should be marked default; got: {line:?}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn context_set_with_api_key_marks_key_set_in_list() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let home = TempDir::new().expect("tempdir for HOME");
+
+    let out = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args([
+            "context",
+            "set",
+            "withkey",
+            "--api-url",
+            "https://api.example.com",
+            "--api-key",
+            "secret-token-abc",
+        ])
+        .output()
+        .expect("set");
+    assert!(out.status.success(), "set should succeed");
+
+    let list = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args(["context", "list"])
+        .output()
+        .expect("list");
+    assert!(list.status.success(), "list should succeed");
+    let stdout = String::from_utf8_lossy(&list.stdout);
+    let line = stdout
+        .lines()
+        .find(|l| l.trim_start().starts_with("withkey"))
+        .unwrap_or_else(|| panic!("missing 'withkey' line in:\n{stdout}"));
+    assert!(
+        line.contains("(key set)"),
+        "list should annotate '(key set)' when --api-key was set; got: {line:?}",
+    );
+    assert!(
+        !stdout.contains("secret-token-abc"),
+        "list must NOT print the secret token in stdout; got:\n{stdout}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn context_set_without_api_key_omits_key_set_marker() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let home = TempDir::new().expect("tempdir for HOME");
+
+    let out = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args(["context", "set", "nokey", "--api-url", "http://nokey:8080"])
+        .output()
+        .expect("set");
+    assert!(out.status.success(), "set should succeed");
+
+    let list = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args(["context", "list"])
+        .output()
+        .expect("list");
+    assert!(list.status.success(), "list should succeed");
+    let stdout = String::from_utf8_lossy(&list.stdout);
+    let line = stdout
+        .lines()
+        .find(|l| l.trim_start().starts_with("nokey"))
+        .unwrap_or_else(|| panic!("missing 'nokey' line in:\n{stdout}"));
+    assert!(
+        !line.contains("(key set)"),
+        "list should omit '(key set)' when --api-key was absent; got: {line:?}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn context_set_replaces_existing_context_url() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let home = TempDir::new().expect("tempdir for HOME");
+
+    // Initial value.
+    let first = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args(["context", "set", "dev", "--api-url", "http://old:1111"])
+        .output()
+        .expect("first set");
+    assert!(first.status.success(), "first set should succeed");
+    // Re-set replaces.
+    let second = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args(["context", "set", "dev", "--api-url", "http://new:2222"])
+        .output()
+        .expect("second set");
+    assert!(second.status.success(), "second set should succeed");
+
+    let list = fixture
+        .cmd()
+        .env("HOME", home.path())
+        .args(["context", "list"])
+        .output()
+        .expect("list");
+    assert!(list.status.success(), "list should succeed");
+    let stdout = String::from_utf8_lossy(&list.stdout);
+    assert!(
+        stdout.contains("http://new:2222"),
+        "list should reflect the replaced URL; got:\n{stdout}",
+    );
+    assert!(
+        !stdout.contains("http://old:1111"),
+        "list should not retain the old URL after replacement; got:\n{stdout}",
+    );
+}


### PR DESCRIPTION
## Description

Adds `aa-integration-tests/tests/cli_context.rs` — 12 `#[tokio::test]` cases covering all three `aasm context` leaves (`list`, `set`, `use`) shipped in master, plus a `set→list` round-trip and a `$HOME` isolation sanity check.

Implements AAASM-1463 (F121 follow-up under Story [AAASM-1258](https://lightning-dust-mite.atlassian.net/browse/AAASM-1258) → Epic [AAASM-1199](https://lightning-dust-mite.atlassian.net/browse/AAASM-1199)).

### Spec divergence (documented in JIRA + module-level doc)

The AAASM-1463 description was drafted against a *planned* `context` surface (`show` leaf, `--gateway-url`/`--token` flags, `--output` json format, config at `~/.aasm/config.toml`). Master ships:

| Description says | Actual surface |
|---|---|
| `aasm context show` | `aasm context list` (and `aasm context use <NAME>` — a third real leaf) |
| `set --name X --gateway-url U --token T` | `set <NAME>` (positional) `--api-url <U>` `--api-key <K>` |
| `--output {json\|yaml\|table}` on `show` | No `--output` flag — context leaves `println!` plain text |
| `~/.aasm/config.toml` | `~/.aa/config.yaml` (via `dirs::home_dir()`) |

Tests are written against the real surface and explicitly cover the third (`use`) leaf the description omits. See the AAASM-1463 starting-work comment for the reconciliation.

### `$HOME` isolation

`CliFixture::cmd()` already pre-wires `AA_DATA_DIR` but does not set `HOME`. Each test in this file injects `HOME=<tempfile::TempDir>` on the `Command` so config writes land in the tempdir and disappear when the test ends. No new shared infrastructure introduced — the override stays scoped to this file per the subtask AC ("No new shared infrastructure introduced.").

### Commit breakdown

Mirrors the per-leaf commit pattern used by the cli_policy.rs / cli_agent.rs landings under this Story:

| Commit | Scope | Tests |
|---|---|---|
| `✅ (aa-integration-tests): Add cli_context list tests` | scaffold + `list` leaf | 3 |
| `✅ (aa-integration-tests): Add cli_context set tests` | `set` leaf (with/without `--api-key`, replacement, first-becomes-default) | 5 |
| `✅ (aa-integration-tests): Add cli_context use tests` | `use` leaf (happy + unknown-name) | 2 |
| `✅ (aa-integration-tests): Add cli_context round-trip and HOME isolation tests` | cross-leaf | 2 |

## Type of Change

- [x] ✅ Tests (integration test addition)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-1463](https://lightning-dust-mite.atlassian.net/browse/AAASM-1463) (this subtask)
- Parent Story: [AAASM-1258](https://lightning-dust-mite.atlassian.net/browse/AAASM-1258) (F121 — `aasm` CLI integration tests)
- Parent Epic: [AAASM-1199](https://lightning-dust-mite.atlassian.net/browse/AAASM-1199) (Release & Distribution Pipeline)

## Testing

- [x] Integration tests added — 12 `#[tokio::test]` cases in `aa-integration-tests/tests/cli_context.rs`
- [x] Manual testing performed — full suite executed locally via `cargo nextest run -p aa-integration-tests --test cli_context`

### Local run summary

```
Starting 12 tests across 1 binary
... (all 12) PASS ...
Summary [112.480s] 12 tests run: 12 passed (12 slow), 0 skipped
```

Per-test runtime is dominated by the `CliFixture::start()` gateway boot + multiple `cargo run -p aa-cli` invocations — same shape as the cli_policy.rs / cli_agent.rs landings.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` clean per pre-commit hooks on every commit)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (file-level rustdoc documents leaf surface + divergence + HOME isolation rationale)
- [ ] All CI checks passing (will be confirmed once GitHub Actions runs)
- [x] Commits are small and follow the Gitmoji convention (one commit per leaf)

[AAASM-1258]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1199]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1463]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ