### PR TITLE
[AAASM-1464] ✅ (aa-integration-tests): cli_completion.rs — 6 tests (4 shells + 2 negative) (F121 ST-8)

### DIFF
--- a/aa-integration-tests/tests/cli_completion.rs
+++ b/aa-integration-tests/tests/cli_completion.rs
@@ -35,6 +35,7 @@ use rstest::rstest;
 /// | `powershell` | `Register-ArgumentCompleter`    | PowerShell completer API    |
 #[rstest]
 #[case::bash("bash", "_aasm()")]
+#[case::zsh("zsh", "#compdef aasm")]
 #[tokio::test(flavor = "multi_thread")]
 async fn completion_emits_shell_specific_marker(#[case] shell: &str, #[case] marker: &str) {
     let fixture = CliFixture::start().await.expect("fixture should start");

--- a/aa-integration-tests/tests/cli_completion.rs
+++ b/aa-integration-tests/tests/cli_completion.rs
@@ -60,3 +60,32 @@ async fn completion_emits_shell_specific_marker(#[case] shell: &str, #[case] mar
         "shell={shell}: stdout should contain shell-specific marker {marker:?}\nstdout:\n{stdout}",
     );
 }
+
+// =============================================================================
+// aasm completion <shell> — negative paths
+// =============================================================================
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn completion_unknown_shell_errors_and_lists_supported_shells() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["completion", "bogus-shell"])
+        .output()
+        .expect("aasm completion bogus-shell should execute");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        !out.status.success(),
+        "should exit non-zero for unknown shell\nstdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    for shell in ["bash", "zsh", "fish", "powershell"] {
+        assert!(
+            stderr.contains(shell),
+            "stderr should name supported shell {shell:?}\nstderr:\n{stderr}",
+        );
+    }
+}

--- a/aa-integration-tests/tests/cli_completion.rs
+++ b/aa-integration-tests/tests/cli_completion.rs
@@ -89,3 +89,30 @@ async fn completion_unknown_shell_errors_and_lists_supported_shells() {
         );
     }
 }
+
+#[rstest]
+#[tokio::test(flavor = "multi_thread")]
+async fn completion_missing_shell_arg_errors_with_clap_usage() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["completion"])
+        .output()
+        .expect("aasm completion (no shell arg) should execute");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        !out.status.success(),
+        "should exit non-zero when <SHELL> is missing\nstdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("<SHELL>"),
+        "stderr should mention the missing <SHELL> argument\nstderr:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("Usage:"),
+        "stderr should include the clap usage hint\nstderr:\n{stderr}",
+    );
+}

--- a/aa-integration-tests/tests/cli_completion.rs
+++ b/aa-integration-tests/tests/cli_completion.rs
@@ -36,6 +36,7 @@ use rstest::rstest;
 #[rstest]
 #[case::bash("bash", "_aasm()")]
 #[case::zsh("zsh", "#compdef aasm")]
+#[case::fish("fish", "__fish_aasm_global_optspecs")]
 #[tokio::test(flavor = "multi_thread")]
 async fn completion_emits_shell_specific_marker(#[case] shell: &str, #[case] marker: &str) {
     let fixture = CliFixture::start().await.expect("fixture should start");

--- a/aa-integration-tests/tests/cli_completion.rs
+++ b/aa-integration-tests/tests/cli_completion.rs
@@ -1,0 +1,59 @@
+//! CLI integration tests for `aasm completion` (AAASM-1464 / F121 ST-8).
+//!
+//! Exercises every supported shell of `aasm completion <shell>` plus the
+//! two documented negative paths. Each happy-path case asserts a
+//! shell-specific marker so accidental output crosswiring (e.g. a zsh
+//! script emitted for `completion bash`) is caught.
+//!
+//! ## Leaf surface (from `aa-cli/src/commands/completion.rs`)
+//!
+//! `completion` takes a single positional `<SHELL>` argument typed as
+//! `clap_complete::Shell` (variants: `Bash`, `Elvish`, `Fish`,
+//! `PowerShell`, `Zsh`). Output is written to stdout via
+//! `clap_complete::generate`. No gateway interaction is performed.
+//!
+//! Per the ST-8 acceptance criteria the tests reuse `CliFixture::cmd()`
+//! unchanged — no new shared infrastructure is introduced.
+
+mod common;
+
+use common::cli::CliFixture;
+use rstest::rstest;
+
+// =============================================================================
+// aasm completion <shell> — happy path
+// =============================================================================
+
+/// Shell-specific markers chosen to be both stable across `clap_complete`
+/// versions and unique to one shell's completion grammar.
+///
+/// | Shell        | Marker                          | Why it's unique             |
+/// | ------------ | ------------------------------- | --------------------------- |
+/// | `bash`       | `_aasm()`                       | bash function declaration   |
+/// | `zsh`        | `#compdef aasm`                 | zsh compdef header          |
+/// | `fish`       | `__fish_aasm_global_optspecs`   | fish optspec helper         |
+/// | `powershell` | `Register-ArgumentCompleter`    | PowerShell completer API    |
+#[rstest]
+#[case::bash("bash", "_aasm()")]
+#[tokio::test(flavor = "multi_thread")]
+async fn completion_emits_shell_specific_marker(#[case] shell: &str, #[case] marker: &str) {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["completion", shell])
+        .output()
+        .expect("aasm completion should execute");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        out.status.success(),
+        "shell={shell}: should exit 0\nstdout:\n{stdout}\nstderr:\n{stderr}",
+    );
+    assert!(!out.stdout.is_empty(), "shell={shell}: stdout should be non-empty",);
+    assert!(
+        stdout.contains(marker),
+        "shell={shell}: stdout should contain shell-specific marker {marker:?}\nstdout:\n{stdout}",
+    );
+}

--- a/aa-integration-tests/tests/cli_completion.rs
+++ b/aa-integration-tests/tests/cli_completion.rs
@@ -37,6 +37,7 @@ use rstest::rstest;
 #[case::bash("bash", "_aasm()")]
 #[case::zsh("zsh", "#compdef aasm")]
 #[case::fish("fish", "__fish_aasm_global_optspecs")]
+#[case::powershell("powershell", "Register-ArgumentCompleter")]
 #[tokio::test(flavor = "multi_thread")]
 async fn completion_emits_shell_specific_marker(#[case] shell: &str, #[case] marker: &str) {
     let fixture = CliFixture::start().await.expect("fixture should start");


### PR DESCRIPTION
## Description

Adds `aa-integration-tests/tests/cli_completion.rs` — the F121 ST-8 surface (AAASM-1464). Covers every supported shell of `aasm completion <shell>` plus both documented negative paths.

**Coverage:** 6 tests, 1 binary, no new shared infrastructure.

| Test | Asserts |
| --- | --- |
| `completion_emits_shell_specific_marker::case_1_bash` | exit 0 + stdout contains `_aasm()` |
| `completion_emits_shell_specific_marker::case_2_zsh` | exit 0 + stdout contains `#compdef aasm` |
| `completion_emits_shell_specific_marker::case_3_fish` | exit 0 + stdout contains `__fish_aasm_global_optspecs` |
| `completion_emits_shell_specific_marker::case_4_powershell` | exit 0 + stdout contains `Register-ArgumentCompleter` |
| `completion_unknown_shell_errors_and_lists_supported_shells` | non-zero exit + stderr names `bash` / `zsh` / `fish` / `powershell` |
| `completion_missing_shell_arg_errors_with_clap_usage` | non-zero exit + stderr contains `<SHELL>` and `Usage:` |

Each happy-path case asserts a **shell-specific marker** so accidental output crosswiring (e.g. a zsh script emitted for `completion bash`) is caught. Markers chosen to be both stable across `clap_complete` versions and grammatically unique to one shell.

Reuses `CliFixture::cmd()` from AAASM-1449 (ST-0) — per the AC, no new shared infrastructure introduced.

## Type of Change

- [x] ✅ Tests added / updated

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-1464](https://lightning-dust-mite.atlassian.net/browse/AAASM-1464) (parent Epic: [AAASM-1258](https://lightning-dust-mite.atlassian.net/browse/AAASM-1258))
- Related GitHub PRs: #485 (ST-0 harness), #488 (ST-1), #490 (ST-2), #491 (ST-3)

## Testing

- [x] Integration tests added — 6 `#[rstest]` tests, all green locally on macOS
- [x] Full `aa-integration-tests` crate run: 86/86 passed (was 80; +6 new)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p aa-integration-tests --tests --all-features -- -D warnings` clean
- [x] `cargo doc -p aa-integration-tests --no-deps` clean

CI on Linux will provide the cross-platform coverage required by the ST-8 AC.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (N/A — test-only)
- [ ] All CI checks passing (pending CI run)
- [x] Commits are small and follow the Gitmoji convention (6 commits, one per leaf — bash / zsh / fish / powershell / unknown-shell / missing-arg)

## Acceptance Criteria mapping (from AAASM-1464)

- [x] `tests/cli_completion.rs` exists with 6 `#[rstest]` tests (4 happy + 2 negative), all green locally (Linux pending CI)
- [x] Each per-shell test asserts a shell-specific marker, not just non-empty stdout
- [x] Negative tests assert both non-zero exit AND a stderr message naming the supported shells (unknown-shell test names all 4; missing-arg test asserts clap usage)
- [x] No new shared infrastructure introduced

[AAASM-1464]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ