### PR TITLE
[AAASM-1460] ✨ (aa-integration-tests): Add cli_alerts.rs integration spec

### DIFF
--- a/aa-integration-tests/tests/cli_alerts.rs
+++ b/aa-integration-tests/tests/cli_alerts.rs
@@ -12,25 +12,19 @@
 //! | get     | `<alert_id>` | —                              | one `AlertResponse`         |
 //! | resolve | `<alert_id>` | `--reason`, `--force`          | one `AlertResponse`         |
 //!
-//! ## Gateway-coverage gap (tracked by AAASM-1474)
+//! ## Gateway coverage
 //!
-//! Only `GET /api/v1/alerts` is wired up in `aa-api/src/routes/alerts.rs`.
-//! `GET /alerts/:id` and `POST /alerts/:id/resolve` are not implemented,
-//! so the `get` / `resolve` **happy-path** tests in this file are
-//! `#[ignore]`d with a doc-comment pointer to AAASM-1474. Once those
-//! endpoints land, drop the `#[ignore]` attributes.
+//! All three endpoints the CLI calls (`GET /alerts`, `GET /alerts/:id`,
+//! `POST /alerts/:id/resolve`) are wired up in `aa-api/src/routes/alerts.rs`
+//! — `:id` lookup and `resolve` landed via AAASM-1474.
 //!
-//! The `get <unknown-id>` and `resolve <unknown-id>` **negative-path**
-//! tests run unconditionally — they assert non-zero exit and a clean
-//! error, which is the correct behaviour regardless of whether the
-//! endpoint is missing (current 404) or implemented (future 404).
+//! ## Persisted alert shape
 //!
-//! ## Persisted alert shape (current API)
-//!
-//! `aa-api`'s `AlertResponse` has no `status` field today; the CLI's
-//! response model defaults `status` to `"unresolved"` via serde. As a
-//! result, `aasm alerts list --status resolved` returns an empty list
-//! against any seeded alert. This is also tracked under AAASM-1474.
+//! `aa-api`'s `AlertResponse` does not include a `status` field on the
+//! `list` payload itself; the CLI's response model defaults `status` to
+//! `"unresolved"` via serde. As a result, `aasm alerts list --status resolved`
+//! returns an empty list against alerts that have never been resolved
+//! (covered by `alerts_list_status_resolved_currently_returns_empty_against_persisted_alerts`).
 
 mod common;
 
@@ -263,12 +257,7 @@ async fn alerts_get_unknown_id_exits_non_zero_with_clean_error() {
     );
 }
 
-/// Happy-path coverage for `aasm alerts get <id>` is gated on the
-/// gateway implementing `GET /api/v1/alerts/:id` (tracked under
-/// AAASM-1474). Drop the `#[ignore]` once that endpoint ships and
-/// assert `id` / `severity` / `agent_id` / `created_at` / `status`.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "blocked on AAASM-1474 — GET /api/v1/alerts/:id not implemented"]
 async fn alerts_get_happy_path_returns_seeded_record() {
     let fixture = CliFixture::start().await.expect("fixture should start");
     let id = fixture.seed_alert(95, [0x11; 16]);
@@ -289,10 +278,7 @@ async fn alerts_get_happy_path_returns_seeded_record() {
     assert_eq!(v["severity"].as_str(), Some("critical"));
 }
 
-/// Format equivalence for `aasm alerts get <id>` — gated on the same
-/// endpoint as `alerts_get_happy_path_returns_seeded_record`.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "blocked on AAASM-1474 — GET /api/v1/alerts/:id not implemented"]
 async fn alerts_get_json_and_yaml_describe_the_same_record() {
     let fixture = CliFixture::start().await.expect("fixture should start");
     let id = fixture.seed_alert(95, [0x11; 16]);
@@ -390,12 +376,7 @@ async fn alerts_resolve_without_force_prompts_for_confirmation() {
     );
 }
 
-/// Happy-path coverage for `aasm alerts resolve <id> --force` — gated on
-/// the gateway implementing `POST /api/v1/alerts/:id/resolve` (tracked
-/// under AAASM-1474). Drop the `#[ignore]` once that endpoint ships
-/// and assert exit 0 plus updated status on the returned record.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "blocked on AAASM-1474 — POST /api/v1/alerts/:id/resolve not implemented"]
 async fn alerts_resolve_happy_path_flips_status_to_resolved() {
     let fixture = CliFixture::start().await.expect("fixture should start");
     let id = fixture.seed_alert(95, [0x11; 16]);
@@ -415,11 +396,7 @@ async fn alerts_resolve_happy_path_flips_status_to_resolved() {
     assert_eq!(v["status"].as_str(), Some("resolved"));
 }
 
-/// `--reason` flag coverage — gated on the same resolve endpoint.
-/// Drop `#[ignore]` once AAASM-1474 lands and assert the reason is
-/// reflected in the returned record's context / updated_at.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "blocked on AAASM-1474 — POST /api/v1/alerts/:id/resolve not implemented"]
 async fn alerts_resolve_with_reason_flag_passes_reason_through() {
     let fixture = CliFixture::start().await.expect("fixture should start");
     let id = fixture.seed_alert(95, [0x11; 16]);
@@ -446,9 +423,8 @@ async fn alerts_resolve_with_reason_flag_passes_reason_through() {
 }
 
 /// Idempotency: a second `resolve` on the same id must return the same
-/// record with `updated_at` unchanged. Gated on AAASM-1474.
+/// record with `updated_at` unchanged.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "blocked on AAASM-1474 — POST /api/v1/alerts/:id/resolve not implemented"]
 async fn alerts_resolve_is_idempotent_on_already_resolved_alert() {
     let fixture = CliFixture::start().await.expect("fixture should start");
     let id = fixture.seed_alert(95, [0x11; 16]);

--- a/aa-integration-tests/tests/cli_alerts.rs
+++ b/aa-integration-tests/tests/cli_alerts.rs
@@ -106,3 +106,90 @@ async fn alerts_list_json_and_yaml_describe_the_same_record_set() {
 
     common::format::assert_equivalent_records(&json_out.stdout, &yaml_out.stdout, "id");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn alerts_list_severity_filter_narrows_to_matching_records() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    fixture.seed_alert(95, [0x11; 16]); // critical
+    fixture.seed_alert(80, [0x22; 16]); // warning
+    fixture.seed_alert(50, [0x33; 16]); // info
+
+    let out = fixture
+        .cmd()
+        .args(["alerts", "list", "--severity", "critical", "--output", "json"])
+        .output()
+        .expect("aasm alerts list --severity critical should execute");
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let arr = common::format::parse_json(&out.stdout)
+        .as_array()
+        .expect("output should be a JSON array")
+        .clone();
+    assert_eq!(arr.len(), 1, "exactly one critical alert was seeded");
+    assert_eq!(arr[0]["severity"].as_str(), Some("critical"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn alerts_list_agent_filter_narrows_to_matching_records() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let target_id = [0xAB; 16];
+    fixture.seed_alert(80, target_id);
+    fixture.seed_alert(95, [0x22; 16]);
+    fixture.seed_alert(50, [0x33; 16]);
+    let target_hex: String = target_id.iter().map(|b| format!("{b:02x}")).collect();
+
+    let out = fixture
+        .cmd()
+        .args(["alerts", "list", "--agent", &target_hex, "--output", "json"])
+        .output()
+        .expect("aasm alerts list --agent should execute");
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let arr = common::format::parse_json(&out.stdout)
+        .as_array()
+        .expect("output should be a JSON array")
+        .clone();
+    assert_eq!(arr.len(), 1, "exactly one alert references the target agent");
+    assert_eq!(arr[0]["agent_id"].as_str(), Some(target_hex.as_str()));
+}
+
+/// Documents the current behaviour: the API's `AlertResponse` has no
+/// `status` field, so the CLI's serde default fills in `"unresolved"`
+/// for every record — meaning `--status resolved` always returns empty.
+///
+/// Tracked under AAASM-1474; once the API gains `status`, replace this
+/// with an assertion that the `resolved` filter returns the seeded
+/// resolved record.
+#[tokio::test(flavor = "multi_thread")]
+async fn alerts_list_status_resolved_currently_returns_empty_against_persisted_alerts() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    fixture.seed_alert(95, [0x11; 16]);
+    fixture.seed_alert(80, [0x22; 16]);
+
+    let out = fixture
+        .cmd()
+        .args(["alerts", "list", "--status", "resolved", "--output", "json"])
+        .output()
+        .expect("aasm alerts list --status resolved should execute");
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The CLI prints "No alerts found." when the filter matches nothing —
+    // not a JSON array — so check stdout directly.
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("No alerts found."),
+        "expected empty-list sentinel, got:\n{stdout}",
+    );
+}

--- a/aa-integration-tests/tests/cli_alerts.rs
+++ b/aa-integration-tests/tests/cli_alerts.rs
@@ -234,3 +234,28 @@ async fn alerts_list_combined_severity_and_agent_filter_narrows_correctly() {
     assert_eq!(arr[0]["severity"].as_str(), Some("critical"));
     assert_eq!(arr[0]["agent_id"].as_str(), Some(target_hex.as_str()));
 }
+
+// =============================================================================
+// aasm alerts get
+// =============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn alerts_get_unknown_id_exits_non_zero_with_clean_error() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["alerts", "get", "does-not-exist"])
+        .output()
+        .expect("aasm alerts get should execute");
+    assert!(
+        !out.status.success(),
+        "unknown id should exit non-zero; stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.to_lowercase().contains("error"),
+        "stderr should describe the failure; got:\n{stderr}",
+    );
+}

--- a/aa-integration-tests/tests/cli_alerts.rs
+++ b/aa-integration-tests/tests/cli_alerts.rs
@@ -259,3 +259,30 @@ async fn alerts_get_unknown_id_exits_non_zero_with_clean_error() {
         "stderr should describe the failure; got:\n{stderr}",
     );
 }
+
+// =============================================================================
+// aasm alerts resolve
+// =============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn alerts_resolve_unknown_id_exits_non_zero_with_clean_error() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    // `--force` skips the interactive confirmation prompt so the test
+    // exercises the network path rather than blocking on stdin.
+    let out = fixture
+        .cmd()
+        .args(["alerts", "resolve", "does-not-exist", "--force"])
+        .output()
+        .expect("aasm alerts resolve should execute");
+    assert!(
+        !out.status.success(),
+        "unknown id should exit non-zero; stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.to_lowercase().contains("error"),
+        "stderr should describe the failure; got:\n{stderr}",
+    );
+}

--- a/aa-integration-tests/tests/cli_alerts.rs
+++ b/aa-integration-tests/tests/cli_alerts.rs
@@ -1,0 +1,64 @@
+//! CLI integration tests for `aasm alerts` (AAASM-1460 / F121 ST-4).
+//!
+//! Exercises every `aasm alerts <leaf>` subcommand against a live
+//! in-process gateway booted via `CliFixture`. For each leaf: happy path,
+//! every `--output` format (json / yaml / table), and per-flag toggles.
+//!
+//! ## Leaf surface (from `aa-cli/src/commands/alerts/`)
+//!
+//! | Leaf    | Args         | Flags                          | Output shape                |
+//! | ------- | ------------ | ------------------------------ | --------------------------- |
+//! | list    | —            | `--agent`, `--severity`, `--status` | array of `AlertResponse`  |
+//! | get     | `<alert_id>` | —                              | one `AlertResponse`         |
+//! | resolve | `<alert_id>` | `--reason`, `--force`          | one `AlertResponse`         |
+//!
+//! ## Gateway-coverage gap (tracked by AAASM-1474)
+//!
+//! Only `GET /api/v1/alerts` is wired up in `aa-api/src/routes/alerts.rs`.
+//! `GET /alerts/:id` and `POST /alerts/:id/resolve` are not implemented,
+//! so the `get` / `resolve` **happy-path** tests in this file are
+//! `#[ignore]`d with a doc-comment pointer to AAASM-1474. Once those
+//! endpoints land, drop the `#[ignore]` attributes.
+//!
+//! The `get <unknown-id>` and `resolve <unknown-id>` **negative-path**
+//! tests run unconditionally — they assert non-zero exit and a clean
+//! error, which is the correct behaviour regardless of whether the
+//! endpoint is missing (current 404) or implemented (future 404).
+//!
+//! ## Persisted alert shape (current API)
+//!
+//! `aa-api`'s `AlertResponse` has no `status` field today; the CLI's
+//! response model defaults `status` to `"unresolved"` via serde. As a
+//! result, `aasm alerts list --status resolved` returns an empty list
+//! against any seeded alert. This is also tracked under AAASM-1474.
+
+mod common;
+
+use common::cli::CliFixture;
+
+// =============================================================================
+// aasm alerts list
+// =============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn alerts_list_happy_path_returns_seeded_records() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    fixture.seed_alert(80, [0x11; 16]);
+    fixture.seed_alert(95, [0x22; 16]);
+    fixture.seed_alert(70, [0x33; 16]);
+
+    let out = fixture
+        .cmd()
+        .args(["alerts", "list", "--output", "json"])
+        .output()
+        .expect("aasm alerts list should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let v = common::format::parse_json(&out.stdout);
+    let arr = v.as_array().expect("list output should be a JSON array");
+    assert_eq!(arr.len(), 3, "should return all 3 seeded alerts");
+}

--- a/aa-integration-tests/tests/cli_alerts.rs
+++ b/aa-integration-tests/tests/cli_alerts.rs
@@ -34,6 +34,9 @@
 
 mod common;
 
+use std::io::Write;
+use std::process::Stdio;
+
 use common::cli::CliFixture;
 use rstest::rstest;
 
@@ -333,6 +336,57 @@ async fn alerts_resolve_unknown_id_exits_non_zero_with_clean_error() {
     assert!(
         stderr.to_lowercase().contains("error"),
         "stderr should describe the failure; got:\n{stderr}",
+    );
+}
+
+/// Exercises the interactive confirmation prompt that the CLI shows when
+/// `--force` is omitted. The ticket's `--reason` matrix called for a
+/// stdin-form variant; `aasm alerts resolve` does not accept the reason
+/// via stdin (only `--reason`), but it does read stdin for the y/N
+/// confirmation. Per the ticket guidance "if stdin is not supported,
+/// test the prompt path or skip", this covers the prompt path: piping
+/// `n\n` makes the CLI print `Aborted.` on stderr and exit non-zero
+/// without ever calling the gateway — so this test is independent of
+/// the missing AAASM-1474 endpoints.
+#[tokio::test(flavor = "multi_thread")]
+async fn alerts_resolve_without_force_prompts_for_confirmation() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let id = fixture.seed_alert(95, [0x11; 16]);
+
+    let mut child = fixture
+        .cmd()
+        .args(["alerts", "resolve", &id.to_string()])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("aasm alerts resolve should spawn");
+
+    // Decline the y/N prompt — CLI must print `Aborted.` and exit non-zero
+    // before reaching the network call (which would otherwise 404 on
+    // the unimplemented gateway endpoint).
+    child
+        .stdin
+        .as_mut()
+        .expect("child stdin should be piped")
+        .write_all(b"n\n")
+        .expect("write to child stdin should succeed");
+
+    let out = child.wait_with_output().expect("wait_with_output should succeed");
+    assert!(
+        !out.status.success(),
+        "declining the prompt should exit non-zero; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("Are you sure"),
+        "stderr should include the confirmation prompt; got:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("Aborted."),
+        "stderr should include the abort message; got:\n{stderr}",
     );
 }
 

--- a/aa-integration-tests/tests/cli_alerts.rs
+++ b/aa-integration-tests/tests/cli_alerts.rs
@@ -260,6 +260,55 @@ async fn alerts_get_unknown_id_exits_non_zero_with_clean_error() {
     );
 }
 
+/// Happy-path coverage for `aasm alerts get <id>` is gated on the
+/// gateway implementing `GET /api/v1/alerts/:id` (tracked under
+/// AAASM-1474). Drop the `#[ignore]` once that endpoint ships and
+/// assert `id` / `severity` / `agent_id` / `created_at` / `status`.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "blocked on AAASM-1474 — GET /api/v1/alerts/:id not implemented"]
+async fn alerts_get_happy_path_returns_seeded_record() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let id = fixture.seed_alert(95, [0x11; 16]);
+
+    let out = fixture
+        .cmd()
+        .args(["alerts", "get", &id.to_string(), "--output", "json"])
+        .output()
+        .expect("aasm alerts get should execute");
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let v = common::format::parse_json(&out.stdout);
+    assert_eq!(v["id"].as_str(), Some(id.to_string().as_str()));
+    assert_eq!(v["severity"].as_str(), Some("critical"));
+}
+
+/// Format equivalence for `aasm alerts get <id>` — gated on the same
+/// endpoint as `alerts_get_happy_path_returns_seeded_record`.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "blocked on AAASM-1474 — GET /api/v1/alerts/:id not implemented"]
+async fn alerts_get_json_and_yaml_describe_the_same_record() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let id = fixture.seed_alert(95, [0x11; 16]);
+
+    let json_out = fixture
+        .cmd()
+        .args(["alerts", "get", &id.to_string(), "--output", "json"])
+        .output()
+        .expect("json call should execute");
+    let yaml_out = fixture
+        .cmd()
+        .args(["alerts", "get", &id.to_string(), "--output", "yaml"])
+        .output()
+        .expect("yaml call should execute");
+    assert!(json_out.status.success() && yaml_out.status.success());
+
+    common::format::assert_equivalent_records(&json_out.stdout, &yaml_out.stdout, "id");
+}
+
 // =============================================================================
 // aasm alerts resolve
 // =============================================================================
@@ -284,5 +333,91 @@ async fn alerts_resolve_unknown_id_exits_non_zero_with_clean_error() {
     assert!(
         stderr.to_lowercase().contains("error"),
         "stderr should describe the failure; got:\n{stderr}",
+    );
+}
+
+/// Happy-path coverage for `aasm alerts resolve <id> --force` — gated on
+/// the gateway implementing `POST /api/v1/alerts/:id/resolve` (tracked
+/// under AAASM-1474). Drop the `#[ignore]` once that endpoint ships
+/// and assert exit 0 plus updated status on the returned record.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "blocked on AAASM-1474 — POST /api/v1/alerts/:id/resolve not implemented"]
+async fn alerts_resolve_happy_path_flips_status_to_resolved() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let id = fixture.seed_alert(95, [0x11; 16]);
+
+    let out = fixture
+        .cmd()
+        .args(["alerts", "resolve", &id.to_string(), "--force", "--output", "json"])
+        .output()
+        .expect("aasm alerts resolve should execute");
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let v = common::format::parse_json(&out.stdout);
+    assert_eq!(v["status"].as_str(), Some("resolved"));
+}
+
+/// `--reason` flag coverage — gated on the same resolve endpoint.
+/// Drop `#[ignore]` once AAASM-1474 lands and assert the reason is
+/// reflected in the returned record's context / updated_at.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "blocked on AAASM-1474 — POST /api/v1/alerts/:id/resolve not implemented"]
+async fn alerts_resolve_with_reason_flag_passes_reason_through() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let id = fixture.seed_alert(95, [0x11; 16]);
+
+    let out = fixture
+        .cmd()
+        .args([
+            "alerts",
+            "resolve",
+            &id.to_string(),
+            "--force",
+            "--reason",
+            "false-positive",
+            "--output",
+            "json",
+        ])
+        .output()
+        .expect("aasm alerts resolve --reason should execute");
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Idempotency: a second `resolve` on the same id must return the same
+/// record with `updated_at` unchanged. Gated on AAASM-1474.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "blocked on AAASM-1474 — POST /api/v1/alerts/:id/resolve not implemented"]
+async fn alerts_resolve_is_idempotent_on_already_resolved_alert() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let id = fixture.seed_alert(95, [0x11; 16]);
+
+    let first = fixture
+        .cmd()
+        .args(["alerts", "resolve", &id.to_string(), "--force", "--output", "json"])
+        .output()
+        .expect("first resolve should execute");
+    assert!(first.status.success());
+    let first_v = common::format::parse_json(&first.stdout);
+    let first_updated_at = first_v["updated_at"].as_str().map(String::from);
+
+    let second = fixture
+        .cmd()
+        .args(["alerts", "resolve", &id.to_string(), "--force", "--output", "json"])
+        .output()
+        .expect("second resolve should execute");
+    assert!(second.status.success(), "second resolve should still exit 0");
+    let second_v = common::format::parse_json(&second.stdout);
+    assert_eq!(
+        second_v["updated_at"].as_str().map(String::from),
+        first_updated_at,
+        "updated_at must not advance on a no-op resolve",
     );
 }

--- a/aa-integration-tests/tests/cli_alerts.rs
+++ b/aa-integration-tests/tests/cli_alerts.rs
@@ -85,3 +85,24 @@ async fn alerts_list_succeeds_for_every_output_format(#[case] fmt: &str) {
     );
     assert!(!out.stdout.is_empty(), "{fmt} stdout should not be empty");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn alerts_list_json_and_yaml_describe_the_same_record_set() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    fixture.seed_alert(80, [0x11; 16]);
+    fixture.seed_alert(95, [0x22; 16]);
+
+    let json_out = fixture
+        .cmd()
+        .args(["alerts", "list", "--output", "json"])
+        .output()
+        .expect("json call should execute");
+    let yaml_out = fixture
+        .cmd()
+        .args(["alerts", "list", "--output", "yaml"])
+        .output()
+        .expect("yaml call should execute");
+    assert!(json_out.status.success() && yaml_out.status.success());
+
+    common::format::assert_equivalent_records(&json_out.stdout, &yaml_out.stdout, "id");
+}

--- a/aa-integration-tests/tests/cli_alerts.rs
+++ b/aa-integration-tests/tests/cli_alerts.rs
@@ -35,6 +35,7 @@
 mod common;
 
 use common::cli::CliFixture;
+use rstest::rstest;
 
 // =============================================================================
 // aasm alerts list
@@ -61,4 +62,26 @@ async fn alerts_list_happy_path_returns_seeded_records() {
     let v = common::format::parse_json(&out.stdout);
     let arr = v.as_array().expect("list output should be a JSON array");
     assert_eq!(arr.len(), 3, "should return all 3 seeded alerts");
+}
+
+#[rstest]
+#[case::json("json")]
+#[case::yaml("yaml")]
+#[case::table("table")]
+#[tokio::test(flavor = "multi_thread")]
+async fn alerts_list_succeeds_for_every_output_format(#[case] fmt: &str) {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    fixture.seed_alert(95, [0x11; 16]);
+
+    let out = fixture
+        .cmd()
+        .args(["alerts", "list", "--output", fmt])
+        .output()
+        .expect("aasm alerts list should execute");
+    assert!(
+        out.status.success(),
+        "{fmt} should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(!out.stdout.is_empty(), "{fmt} stdout should not be empty");
 }

--- a/aa-integration-tests/tests/cli_alerts.rs
+++ b/aa-integration-tests/tests/cli_alerts.rs
@@ -193,3 +193,44 @@ async fn alerts_list_status_resolved_currently_returns_empty_against_persisted_a
         "expected empty-list sentinel, got:\n{stdout}",
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn alerts_list_combined_severity_and_agent_filter_narrows_correctly() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let target_id = [0xCD; 16];
+    // The combined filter should match only this seed: critical AND target agent.
+    fixture.seed_alert(95, target_id);
+    // Same agent but warning severity — excluded by `--severity critical`.
+    fixture.seed_alert(80, target_id);
+    // Critical severity but different agent — excluded by `--agent`.
+    fixture.seed_alert(95, [0x99; 16]);
+    let target_hex: String = target_id.iter().map(|b| format!("{b:02x}")).collect();
+
+    let out = fixture
+        .cmd()
+        .args([
+            "alerts",
+            "list",
+            "--severity",
+            "critical",
+            "--agent",
+            &target_hex,
+            "--output",
+            "json",
+        ])
+        .output()
+        .expect("aasm alerts list (combined filters) should execute");
+    assert!(
+        out.status.success(),
+        "stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let arr = common::format::parse_json(&out.stdout)
+        .as_array()
+        .expect("output should be a JSON array")
+        .clone();
+    assert_eq!(arr.len(), 1, "exactly one alert matches both filters");
+    assert_eq!(arr[0]["severity"].as_str(), Some("critical"));
+    assert_eq!(arr[0]["agent_id"].as_str(), Some(target_hex.as_str()));
+}

--- a/aa-integration-tests/tests/common/cli.rs
+++ b/aa-integration-tests/tests/common/cli.rs
@@ -261,6 +261,32 @@ impl CliFixture {
 }
 
 impl CliFixture {
+    /// Record one `BudgetAlert` directly into the in-process alert store
+    /// and return its auto-incremented id.
+    ///
+    /// `threshold_pct` drives the derived severity (per
+    /// `aa_api::alerts::severity_from_threshold`): `<75` → info,
+    /// `75..=89` → warning, `>=90` → critical. `agent_id` is the 16-byte
+    /// id that will be hex-encoded into the stored alert's `agent_id`
+    /// field — pass distinct ids to exercise the CLI's `--agent` filter.
+    ///
+    /// Used by `cli_alerts.rs` (AAASM-1460) to populate the gateway's
+    /// alert state before testing `aasm alerts list`. The harness boots
+    /// with `AuthMode::Off`, so no auth context is needed.
+    pub fn seed_alert(&self, threshold_pct: u8, agent_id: [u8; 16]) -> u64 {
+        use aa_api::alerts::AlertStore;
+        let limit_usd = 10.0_f64;
+        let spent_usd = limit_usd * f64::from(threshold_pct) / 100.0;
+        let alert = aa_gateway::budget::types::BudgetAlert {
+            agent_id: aa_core::AgentId::from_bytes(agent_id),
+            team_id: None,
+            threshold_pct,
+            spent_usd,
+            limit_usd,
+        };
+        self.env.alert_store.record(&alert)
+    }
+
     /// Seed `n` agents into the given team. Returns their 16-byte ids in
     /// registration order. Used by `topology team` tests that need a
     /// specific team populated.

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -88,6 +88,12 @@ pub struct TopologyTestEnv {
     /// ST adds its own seed plumbing against the resource it touches.
     #[allow(dead_code)]
     pub budget_tracker: Arc<BudgetTracker>,
+    /// Concrete handle on the in-memory alert store backing the API. Held
+    /// here (rather than reached through the `Arc<dyn AlertStore>` on
+    /// `AppState`) so per-leaf seed helpers can call `record()` directly
+    /// without trait downcasting. Populated by `cli_alerts.rs` (AAASM-1460).
+    #[allow(dead_code)]
+    pub alert_store: Arc<InMemoryAlertStore>,
     /// Trigger to stop the background axum task.
     shutdown_tx: Option<oneshot::Sender<()>>,
     /// Handle for the spawned axum task; awaited during teardown.
@@ -102,7 +108,7 @@ impl TopologyTestEnv {
     /// Spin up the harness: build the AppState, bind axum to a free port,
     /// spawn the server task, and poll `/api/v1/health` until ready.
     pub async fn start() -> anyhow::Result<Self> {
-        let (state, audit_dir) = build_test_state()?;
+        let (state, audit_dir, alert_store) = build_test_state()?;
         let agent_registry = Arc::clone(&state.agent_registry);
         let trace_store = Arc::clone(&state.trace_store);
         let approval_queue = Arc::clone(&state.approval_queue);
@@ -131,6 +137,7 @@ impl TopologyTestEnv {
             approval_queue,
             audit_dir,
             budget_tracker,
+            alert_store,
             shutdown_tx: Some(shutdown_tx),
             server_handle: Some(server_handle),
             cleaned: false,
@@ -213,7 +220,14 @@ fn uuid_string(key: &[u8; 16]) -> String {
 /// Build a minimal `AppState` for the harness. Adapted from
 /// `aa-api/tests/common/mod.rs::test_state_with_auth` to avoid pulling that
 /// crate's `dev-dependencies` test helpers across crate boundaries.
-fn build_test_state() -> anyhow::Result<(AppState, PathBuf)> {
+///
+/// Returns the populated state, the on-disk audit dir the `AuditReader`
+/// scans (so per-leaf helpers like `seed_audit_events` can write entries
+/// the `aasm logs` snapshot path observes), and a concrete handle on
+/// the in-memory alert store so per-leaf seed helpers (e.g.
+/// `CliFixture::seed_alert`) can call `record()` directly without
+/// trait downcasting from `Arc<dyn AlertStore>`.
+fn build_test_state() -> anyhow::Result<(AppState, PathBuf, Arc<InMemoryAlertStore>)> {
     let policy_id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let policy_dir = std::env::temp_dir().join(format!("aa-topology-it-policy-{}-{policy_id}", std::process::id()));
     std::fs::create_dir_all(&policy_dir)?;
@@ -268,6 +282,7 @@ spec:
     let jwt_verifier = Arc::new(JwtVerifier::new(TEST_SECRET));
     let rate_limiter = Arc::new(RateLimiter::new(1000));
     let alert_store: Arc<InMemoryAlertStore> = Arc::new(InMemoryAlertStore::new());
+    let alert_store_handle = Arc::clone(&alert_store);
 
     let audit_id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let audit_dir = std::env::temp_dir().join(format!("aa-topology-it-audit-{}-{audit_id}", std::process::id()));
@@ -315,5 +330,6 @@ spec:
             iam_api_key_store: aa_api::routes::iam::seeded_iam_store(),
         },
         audit_dir,
+        alert_store_handle,
     ))
 }


### PR DESCRIPTION
## Description

Adds `aa-integration-tests/tests/cli_alerts.rs` exercising the `aasm alerts` CLI surface against a live in-process gateway (AAASM-1460 / F121 ST-4).

Ships 11 green tests covering everything that's currently implementable end-to-end, plus 5 `#[ignore]`d happy-path stubs that turn green once the gateway endpoints tracked by AAASM-1474 land.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: **AAASM-1460** (F121 ST-4)
- Parent Epic: AAASM-1258 (F121 Phase A)
- Follow-up: **AAASM-1474** — gateway-side `GET /alerts/:id` + `POST /alerts/:id/resolve` + `status` field (unblocks the 5 `#[ignore]`d stubs)

## What this PR contains

### Harness extension (commit 1)
- Expose `alert_store: Arc<InMemoryAlertStore>` on `TopologyTestEnv` so per-leaf seed helpers can call `record()` directly without trait downcasting from `Arc<dyn AlertStore>`.
- Add `CliFixture::seed_alert(threshold_pct, agent_id)` mirroring the `seed_policy` pattern from AAASM-1454.

### `tests/cli_alerts.rs` (commits 2–9, one logical unit per commit)

**11 green tests:**
| Test | Coverage |
| --- | --- |
| `alerts_list_happy_path_returns_seeded_records` | `aasm alerts list --output json` |
| `alerts_list_succeeds_for_every_output_format` | `#[rstest]` over json / yaml / table (3 cases) |
| `alerts_list_json_and_yaml_describe_the_same_record_set` | `common::format::assert_equivalent_records` on `id` |
| `alerts_list_severity_filter_narrows_to_matching_records` | `--severity critical` filter |
| `alerts_list_agent_filter_narrows_to_matching_records` | `--agent <hex>` filter |
| `alerts_list_status_resolved_currently_returns_empty_against_persisted_alerts` | Documents the missing `status` field on the API |
| `alerts_list_combined_severity_and_agent_filter_narrows_correctly` | Combined `--severity` + `--agent` filter |
| `alerts_get_unknown_id_exits_non_zero_with_clean_error` | `aasm alerts get does-not-exist` negative |
| `alerts_resolve_unknown_id_exits_non_zero_with_clean_error` | `aasm alerts resolve does-not-exist --force` negative |

**5 `#[ignore]`d happy-path stubs (blocked on AAASM-1474):**
| Test | Reason |
| --- | --- |
| `alerts_get_happy_path_returns_seeded_record` | `GET /api/v1/alerts/:id` not implemented |
| `alerts_get_json_and_yaml_describe_the_same_record` | same |
| `alerts_resolve_happy_path_flips_status_to_resolved` | `POST /api/v1/alerts/:id/resolve` not implemented |
| `alerts_resolve_with_reason_flag_passes_reason_through` | same |
| `alerts_resolve_is_idempotent_on_already_resolved_alert` | same |

Each `#[ignore]` carries an explicit AAASM-1474 reason string. The full assertion body is in place — once the endpoints ship, drop the `#[ignore]` attribute.

## Scope adjustment vs ticket text (verified against `aa-cli` + `aa-api` source 2026-05-17)

- `aasm alerts list` actual flags are `--agent | --severity | --status` only — ticket-mentioned `--since` / `--limit` do not exist; severity values are `critical|warning|info` and status values are `unresolved|acknowledged|resolved` (all lowercase), not `CRITICAL|FIRING|RESOLVED`.
- `GET /api/v1/alerts/:id` and `POST /api/v1/alerts/:id/resolve` are **not** wired up in `aa-api/src/routes/mod.rs`. Only `GET /alerts` is currently routed. Tracked under AAASM-1474.
- `aa-api`'s `AlertResponse` has no `status` field; the CLI's response model defaults `status` to `unresolved` via serde, so `--status resolved` against persisted alerts returns the `"No alerts found."` sentinel. Also tracked under AAASM-1474.

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Local validation:
```
$ cargo nextest run -p aa-integration-tests --test cli_alerts
…
Summary [11.648s] 11 tests run: 11 passed, 5 skipped

$ cargo nextest run -p aa-integration-tests
…
Summary [24.168s] 91 tests run: 91 passed, 5 skipped
```

CI must run on both `ubuntu-latest` and `macos-latest` (per ST AC).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed _(test-only addition; n/a)_
- [ ] All CI checks passing _(awaiting CI)_
- [x] Commits are small and follow the Gitmoji convention