### PR TITLE
[AAASM-1466] ✅ (aa-integration-tests): Add cli_status fleet-overview tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,7 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/aa-integration-tests/Cargo.toml
+++ b/aa-integration-tests/Cargo.toml
@@ -27,3 +27,4 @@ serde_json  = "1"
 serde_yaml  = "0.9"
 tempfile    = "3"
 tokio       = { version = "1", features = ["full"] }
+uuid        = { version = "1", features = ["v4"] }

--- a/aa-integration-tests/tests/cli_status.rs
+++ b/aa-integration-tests/tests/cli_status.rs
@@ -133,3 +133,32 @@ async fn status_json_and_yaml_are_structurally_equivalent() {
     assert!(json_v.get("approvals").is_some(), "json missing 'approvals' key");
     assert!(json_v.get("budget").is_some(), "json missing 'budget' key");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn status_populated_state_renders_seeded_agents_and_approvals() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agent_ids = fixture.seed_agents(3);
+    let first_agent_hex = CliFixture::hex_id(&agent_ids[0]);
+    fixture.seed_approval(&first_agent_hex, "delete_production_db");
+    fixture.seed_approval(&first_agent_hex, "wire_funds_to_external_account");
+
+    let out = fixture
+        .cmd()
+        .args(["status", "--output", "json"])
+        .output()
+        .expect("aasm status should execute");
+    assert!(
+        out.status.success(),
+        "status should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let v = parse_json(&out.stdout);
+
+    let agents = v["agents"].as_array().expect("agents should be array");
+    assert_eq!(agents.len(), 3, "3 seeded agents should appear in agents array");
+
+    let pending = v["approvals"]["pending_count"]
+        .as_u64()
+        .expect("approvals.pending_count should be a number");
+    assert_eq!(pending, 2, "2 seeded approvals should appear as pending");
+}

--- a/aa-integration-tests/tests/cli_status.rs
+++ b/aa-integration-tests/tests/cli_status.rs
@@ -1,0 +1,66 @@
+//! CLI integration tests for `aasm status` (AAASM-1466 / F121 ST-10).
+//!
+//! Exercises the `aasm status` top-level command — the kubectl-style fleet
+//! overview that aggregates runtime health, active agents, pending approvals,
+//! and budget into a single render — against a live in-process gateway booted
+//! via `CliFixture`.
+//!
+//! ## Surface vs. AC
+//!
+//! The ticket description (AAASM-1466) referenced an `aasm status --component
+//! {fleet|agents|approvals|budget}` filter and a populated-state test that
+//! seeds alerts + cost samples. Both deviate from source today:
+//!
+//! * `--component` does not exist on `StatusArgs` (`aa-cli/src/commands/status/
+//!   mod.rs` declares only `--watch`). The 5 `--component` tests are dropped;
+//!   the PR description proposes a follow-up Subtask if the flag is wanted.
+//! * The AC explicitly restricts new shared infra to **only** `seed_approval`.
+//!   The populated-state test therefore seeds agents + approvals only; alert /
+//!   cost coverage is deferred to a future Phase B ST that introduces both
+//!   helpers together.
+//!
+//! Net = 9 tests across happy path, per-output format (×3), JSON↔YAML
+//! equivalence, populated state, exit codes 1 and 2, and a `--watch` smoke.
+
+mod common;
+
+use common::cli::CliFixture;
+
+// =============================================================================
+// aasm status
+// =============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn status_happy_path_empty_gateway_exits_zero_and_renders_all_sections() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .arg("status")
+        .output()
+        .expect("aasm status should execute");
+
+    assert!(
+        out.status.success(),
+        "empty gateway should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("RUNTIME HEALTH"),
+        "missing RUNTIME HEALTH section:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("ACTIVE AGENTS"),
+        "missing ACTIVE AGENTS section:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("PENDING APPROVALS"),
+        "missing PENDING APPROVALS section:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("BUDGET STATUS"),
+        "missing BUDGET STATUS section:\n{stdout}"
+    );
+}

--- a/aa-integration-tests/tests/cli_status.rs
+++ b/aa-integration-tests/tests/cli_status.rs
@@ -25,6 +25,8 @@
 mod common;
 
 use common::cli::CliFixture;
+use common::format::{parse_json, parse_yaml};
+use rstest::rstest;
 
 // =============================================================================
 // aasm status
@@ -63,4 +65,71 @@ async fn status_happy_path_empty_gateway_exits_zero_and_renders_all_sections() {
         stdout.contains("BUDGET STATUS"),
         "missing BUDGET STATUS section:\n{stdout}"
     );
+}
+
+#[rstest]
+#[case::json("json")]
+#[case::yaml("yaml")]
+#[case::table("table")]
+#[tokio::test(flavor = "multi_thread")]
+async fn status_succeeds_for_every_output_format(#[case] fmt: &str) {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["status", "--output", fmt])
+        .output()
+        .expect("aasm status should execute");
+
+    assert!(
+        out.status.success(),
+        "{fmt} should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(!out.stdout.is_empty(), "{fmt} stdout should not be empty");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn status_json_and_yaml_are_structurally_equivalent() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let json_out = fixture
+        .cmd()
+        .args(["status", "--output", "json"])
+        .output()
+        .expect("json call should execute");
+    let yaml_out = fixture
+        .cmd()
+        .args(["status", "--output", "yaml"])
+        .output()
+        .expect("yaml call should execute");
+    assert!(json_out.status.success() && yaml_out.status.success());
+
+    // Parse both, then assert structural equality after normalizing the
+    // runtime.uptime_secs field — it counts wall-clock seconds since the
+    // gateway started and naturally drifts between the two back-to-back
+    // CLI invocations. All other section fields are deterministic given
+    // a fresh empty fixture.
+    let mut json_v = parse_json(&json_out.stdout);
+    let yaml_as_json: serde_json::Value =
+        serde_json::to_value(parse_yaml(&yaml_out.stdout)).expect("yaml should round-trip to JSON");
+    let mut yaml_v = yaml_as_json;
+    if let Some(r) = json_v.get_mut("runtime").and_then(|x| x.as_object_mut()) {
+        r.insert("uptime_secs".into(), serde_json::Value::from(0));
+    }
+    if let Some(r) = yaml_v.get_mut("runtime").and_then(|x| x.as_object_mut()) {
+        r.insert("uptime_secs".into(), serde_json::Value::from(0));
+    }
+    assert_eq!(
+        json_v,
+        yaml_v,
+        "JSON and YAML status renders should be structurally identical (uptime_secs normalized)\n\
+         json stdout:\n{}\nyaml stdout:\n{}",
+        String::from_utf8_lossy(&json_out.stdout),
+        String::from_utf8_lossy(&yaml_out.stdout),
+    );
+    assert!(json_v.get("runtime").is_some(), "json missing 'runtime' key");
+    assert!(json_v.get("agents").is_some(), "json missing 'agents' key");
+    assert!(json_v.get("approvals").is_some(), "json missing 'approvals' key");
+    assert!(json_v.get("budget").is_some(), "json missing 'budget' key");
 }

--- a/aa-integration-tests/tests/cli_status.rs
+++ b/aa-integration-tests/tests/cli_status.rs
@@ -20,12 +20,13 @@
 //!   helpers together.
 //!
 //! Net = 9 tests across happy path, per-output format (×3), JSON↔YAML
-//! equivalence, populated state, exit codes 1 and 2, and a `--watch` smoke.
+//! equivalence, populated state, exit codes 1 and 2, and `--watch` liveness.
 
 mod common;
 
 use std::collections::{BTreeMap, VecDeque};
-use std::process::Command;
+use std::process::{Command, Stdio};
+use std::time::Duration;
 
 use aa_gateway::registry::{AgentRecord, AgentStatus};
 use common::cli::CliFixture;
@@ -260,4 +261,31 @@ async fn status_exits_2_when_gateway_is_unreachable() {
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr),
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn status_watch_runs_until_killed() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let mut child = fixture
+        .cmd()
+        .args(["status", "--watch"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("aasm status --watch should spawn");
+
+    // `aasm status --watch` refreshes every 5s in an infinite loop. Stdout
+    // is block-buffered when piped, so the section-header bytes from the
+    // first render are typically lost on SIGKILL; the cli_agent.rs
+    // `agent_list_watch_runs_until_killed` test documents the same
+    // limitation. The robust signal is process longevity — proves --watch
+    // is accepted and the loop is entered without crashing.
+    std::thread::sleep(Duration::from_millis(1500));
+    assert!(
+        child.try_wait().expect("try_wait should work").is_none(),
+        "--watch should keep the process alive (not exit on its own)",
+    );
+    child.kill().expect("kill should succeed");
+    let _ = child.wait_with_output();
 }

--- a/aa-integration-tests/tests/cli_status.rs
+++ b/aa-integration-tests/tests/cli_status.rs
@@ -24,6 +24,10 @@
 
 mod common;
 
+use std::collections::{BTreeMap, VecDeque};
+use std::process::Command;
+
+use aa_gateway::registry::{AgentRecord, AgentStatus};
 use common::cli::CliFixture;
 use common::format::{parse_json, parse_yaml};
 use rstest::rstest;
@@ -161,4 +165,99 @@ async fn status_populated_state_renders_seeded_agents_and_approvals() {
         .as_u64()
         .expect("approvals.pending_count should be a number");
     assert_eq!(pending, 2, "2 seeded approvals should appear as pending");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn status_exits_1_when_agent_has_policy_violations() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    // `aasm status` exits 1 when at least one agent reports
+    // `policy_violations_count > 0`. AgentSpec doesn't expose that field
+    // (and adding it would extend shared infra beyond the AC's
+    // seed_approval allowance), so register the violation-carrying agent
+    // directly on the in-process registry.
+    let pid_bytes = std::process::id().to_le_bytes();
+    let mut id = [0u8; 16];
+    id[0..4].copy_from_slice(&pid_bytes);
+    id[4] = 0xee;
+    id[5] = 0xee;
+    let record = AgentRecord {
+        agent_id: id,
+        name: format!("violator-{:04x}", pid_bytes[0] as u16),
+        framework: "cli-it".into(),
+        version: "0.0.1".into(),
+        risk_tier: 0,
+        tool_names: vec![],
+        public_key: "deadbeef".into(),
+        credential_token: "cli-it-token".into(),
+        metadata: BTreeMap::new(),
+        registered_at: chrono::Utc::now(),
+        last_heartbeat: chrono::Utc::now(),
+        status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
+        policy_violations_count: 3,
+        active_sessions: vec![],
+        recent_events: VecDeque::new(),
+        recent_traces: vec![],
+        layer: None,
+        governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: Some("cli-it".to_string()),
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: None,
+        children: vec![],
+        parent_key: None,
+    };
+    fixture
+        .env
+        .agent_registry
+        .register(record)
+        .expect("violator agent should register");
+
+    let out = fixture
+        .cmd()
+        .arg("status")
+        .output()
+        .expect("aasm status should execute");
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "violations_today > 0 should yield exit code 1; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn status_exits_2_when_gateway_is_unreachable() {
+    // No `CliFixture::start()` — we point the CLI at a known-unbound port
+    // to exercise the unreachable-API exit code (2). Building Command by
+    // hand because `CliFixture::cmd()` always wires --api-url to the live
+    // fixture URL.
+    let mut cmd = Command::new(env!("CARGO"));
+    cmd.args([
+        "run",
+        "--quiet",
+        "-p",
+        "aa-cli",
+        "--bin",
+        "aasm",
+        "--",
+        "--api-url",
+        "http://127.0.0.1:1",
+        "status",
+    ]);
+    let out = cmd.output().expect("aasm status should execute");
+
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "unreachable gateway should yield exit code 2; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
 }

--- a/aa-integration-tests/tests/common/cli.rs
+++ b/aa-integration-tests/tests/common/cli.rs
@@ -33,8 +33,10 @@ use std::sync::atomic::{AtomicU16, Ordering};
 
 use aa_api::models::trace::TraceSpan;
 use aa_gateway::registry::{AgentRecord, AgentStatus};
+use aa_runtime::approval::{ApprovalRequest, ApprovalRequestId};
 use chrono::{Duration as ChronoDuration, Utc};
 use tempfile::TempDir;
+use uuid::Uuid;
 
 use super::TopologyTestEnv;
 
@@ -213,6 +215,41 @@ impl CliFixture {
             .and_then(|v| v.as_str())
             .map(String::from)
             .ok_or_else(|| anyhow::anyhow!("seed_policy: response missing 'name' field: {text}"))
+    }
+
+    /// Submit a pending approval request directly into the in-process
+    /// `ApprovalQueue`. Returns the assigned request id.
+    ///
+    /// Used by `cli_status.rs` (ST-10) and any future `cli_approvals.rs`
+    /// (ST-13). Direct submission is the pragmatic equivalent of the
+    /// production "policy engine triggers an approval requirement" path —
+    /// `aa-api` exposes only `/approve` and `/reject` endpoints, not a
+    /// `POST /approvals` write, so HTTP-based seeding would require
+    /// stand-up of the policy engine + runtime, which is well beyond the
+    /// scope of these CLI tests.
+    ///
+    /// The request is submitted with a 1-hour timeout so the background
+    /// auto-resolve task does not race in-test assertions; the returned
+    /// `ApprovalFuture` is dropped (the queue retains the pending entry
+    /// regardless).
+    #[allow(dead_code)]
+    pub fn seed_approval(&self, agent_id: &str, action: &str) -> ApprovalRequestId {
+        let request = ApprovalRequest {
+            request_id: Uuid::new_v4(),
+            agent_id: agent_id.to_string(),
+            action: action.to_string(),
+            condition_triggered: "cli-it-seed".to_string(),
+            submitted_at: chrono::Utc::now().timestamp() as u64,
+            timeout_secs: 3600,
+            fallback: aa_core::PolicyResult::Deny {
+                reason: "cli-it timeout".to_string(),
+            },
+            team_id: None,
+            timeout_override_secs: None,
+            escalation_role_override: None,
+        };
+        let (id, _future) = self.env.approval_queue.submit(request);
+        id
     }
 }
 

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -70,6 +70,11 @@ pub struct TopologyTestEnv {
     /// test-only equivalent (same pattern as `agent_registry`).
     #[allow(dead_code)]
     pub trace_store: Arc<dyn TraceStore>,
+    /// Shared approval queue — used by `CliFixture::seed_approval` (ST-10)
+    /// to submit pending requests that `aasm status` / `aasm approvals` then
+    /// observe via the HTTP plane.
+    #[allow(dead_code)]
+    pub approval_queue: Arc<ApprovalQueue>,
     /// Trigger to stop the background axum task.
     shutdown_tx: Option<oneshot::Sender<()>>,
     /// Handle for the spawned axum task; awaited during teardown.
@@ -87,6 +92,7 @@ impl TopologyTestEnv {
         let state = build_test_state()?;
         let agent_registry = Arc::clone(&state.agent_registry);
         let trace_store = Arc::clone(&state.trace_store);
+        let approval_queue = Arc::clone(&state.approval_queue);
 
         let port = portpicker::pick_unused_port().ok_or_else(|| anyhow::anyhow!("no free TCP port"))?;
         let addr: SocketAddr = format!("127.0.0.1:{port}").parse()?;
@@ -108,6 +114,7 @@ impl TopologyTestEnv {
             addr: bound_addr,
             agent_registry,
             trace_store,
+            approval_queue,
             shutdown_tx: Some(shutdown_tx),
             server_handle: Some(server_handle),
             cleaned: false,


### PR DESCRIPTION
## Description

Adds `aa-integration-tests/tests/cli_status.rs` — F121 Phase A ST-10. Exercises every supported surface of the `aasm status` command (the kubectl-style fleet overview that aggregates runtime health, agents, approvals, and budget into a single render) against a live in-process gateway booted via `CliFixture`.

**9 tests added:**

- `status_happy_path_empty_gateway_exits_zero_and_renders_all_sections` — empty gateway, exit 0, all four section headers (`RUNTIME HEALTH` / `ACTIVE AGENTS` / `PENDING APPROVALS` / `BUDGET STATUS`) appear in the table render.
- `status_succeeds_for_every_output_format` (`#[rstest]` ×3 — json / yaml / table) — exit 0 and non-empty stdout for each format.
- `status_json_and_yaml_are_structurally_equivalent` — parses both formats, normalizes `runtime.uptime_secs` (free-running clock), asserts structural equality of the remaining state.
- `status_populated_state_renders_seeded_agents_and_approvals` — seeds 3 agents + 2 approvals, asserts JSON output reports both counts.
- `status_exits_1_when_agent_has_policy_violations` — registers an agent with `policy_violations_count = 3`, asserts exit code 1.
- `status_exits_2_when_gateway_is_unreachable` — points the CLI at `127.0.0.1:1` with no fixture, asserts exit code 2.
- `status_watch_runs_until_killed` — spawns `--watch`, sleeps 1.5s, asserts the child is still alive (mirrors `cli_agent.rs::agent_list_watch_runs_until_killed`'s pattern, which documents that piped-stdout assertions are unreliable under SIGKILL).

**Shared-infra extension (authorized by AC):** `tests/common/cli.rs` gains `CliFixture::seed_approval(agent_id, action)`; `tests/common/mod.rs` exposes `pub approval_queue: Arc<ApprovalQueue>` on `TopologyTestEnv` so the helper can submit directly into the in-process queue. `uuid` v4 added as a dev-dep (matches the version `aa-runtime` already pins).

## ⚠️ Scope deviations from the AAASM-1466 description (reconciled with reporter before coding)

1. **`aasm status --component …` flag does not exist in source.** `StatusArgs` in `aa-cli/src/commands/status/mod.rs` declares only `--watch`. The 5 `--component {fleet|agents|approvals|budget|unknown}` tests listed in the Subtask description were dropped. A follow-up Subtask should be opened **if and only if** the `--component` filter is actually desired — at which point it becomes a Front-End / CLI feature ST, not a test ST.
2. **AC restricts new shared infra to `seed_approval` only.** The populated-state test consequently seeds agents + approvals only; alert and cost seeding (which the Subtask description also calls for) are deferred to a future Phase B ST that introduces `seed_alert` + `seed_cost_sample` together. The four section-header smoke checks in the empty-state test still confirm the zero-state alert / cost render does not crash.

Net = 9 tests (vs ~10 in the Subtask description), with full coverage of the surface that actually exists today.

## Type of Change

- [x] ✅ Tests added
- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-1466](https://lightning-dust-mite.atlassian.net/browse/AAASM-1466) (parent: [AAASM-1258](https://lightning-dust-mite.atlassian.net/browse/AAASM-1258) F121)

## Testing

- [x] Integration tests added (9 new tests in `aa-integration-tests/tests/cli_status.rs`)
- [x] All `cargo nextest run -p aa-integration-tests --test cli_status` pass locally on macOS (9/9)
- [x] Cross-binary regression check: `cargo nextest run -p aa-integration-tests --test cli_topology --test cli_agent --test cli_policy --test cli_status` → 80/80 pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo deny check` clean

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (file-level rustdoc explains scope vs. AC deviations)
- [x] All CI checks passing (local)
- [x] Commits are small and follow the Gitmoji convention (8 commits, each scoped to a single logical unit)

## Coordination

The Subtask AC warns about a potential collision with **ST-13 `cli_approvals`** which would also need `seed_approval`. ST-10 is landing first; if ST-13 is in flight, the sibling rebases on this PR.

[AAASM-1466]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ