### PR TITLE
[AAASM-1453] ✨ (aa-api+aa-runtime): Auto-expire pending approvals + emit WS event

### DIFF
--- a/aa-api/src/events.rs
+++ b/aa-api/src/events.rs
@@ -20,6 +20,9 @@ const DEFAULT_CHANNEL_CAPACITY: usize = 256;
 pub struct EventBroadcast {
     pipeline_tx: broadcast::Sender<PipelineEvent>,
     approval_tx: broadcast::Sender<ApprovalRequest>,
+    /// Mirror of `ApprovalQueue.expiry_event_tx` for the API layer.
+    /// Fires when a pending request auto-expires (AAASM-1453).
+    approval_expiry_tx: broadcast::Sender<ApprovalRequest>,
     budget_tx: broadcast::Sender<BudgetAlert>,
 }
 
@@ -28,10 +31,12 @@ impl EventBroadcast {
     pub fn new(capacity: usize) -> Self {
         let (pipeline_tx, _) = broadcast::channel(capacity);
         let (approval_tx, _) = broadcast::channel(capacity);
+        let (approval_expiry_tx, _) = broadcast::channel(capacity);
         let (budget_tx, _) = broadcast::channel(capacity);
         Self {
             pipeline_tx,
             approval_tx,
+            approval_expiry_tx,
             budget_tx,
         }
     }
@@ -44,6 +49,15 @@ impl EventBroadcast {
     /// Subscribe to human-approval request events.
     pub fn subscribe_approvals(&self) -> broadcast::Receiver<ApprovalRequest> {
         self.approval_tx.subscribe()
+    }
+
+    /// Subscribe to approval auto-expiration events (AAASM-1453).
+    ///
+    /// Fires when a pending request's per-request timeout elapses before
+    /// any human decision arrives. The WS dispatch loop forwards these
+    /// to the client as `approval` events with `status: "expired"`.
+    pub fn subscribe_approval_expirations(&self) -> broadcast::Receiver<ApprovalRequest> {
+        self.approval_expiry_tx.subscribe()
     }
 
     /// Subscribe to budget threshold alerts.
@@ -59,6 +73,11 @@ impl EventBroadcast {
     /// Get a clone of the approval event sender.
     pub fn approval_sender(&self) -> broadcast::Sender<ApprovalRequest> {
         self.approval_tx.clone()
+    }
+
+    /// Get a clone of the approval-expiration event sender (AAASM-1453).
+    pub fn approval_expiry_sender(&self) -> broadcast::Sender<ApprovalRequest> {
+        self.approval_expiry_tx.clone()
     }
 
     /// Get a clone of the budget alert sender.

--- a/aa-api/src/models/ws_payloads.rs
+++ b/aa-api/src/models/ws_payloads.rs
@@ -90,8 +90,10 @@ pub enum ViolationPayload {
 
 /// Payload for `event_type: "approval"` events.
 ///
-/// Represents a human-in-the-loop approval request submitted by the
-/// policy engine when an action requires explicit authorisation.
+/// Represents either a freshly-submitted human-in-the-loop approval
+/// request or a status-change notification (e.g. auto-expiration). The
+/// `status` field discriminates: `"pending"` for new requests,
+/// `"expired"` for auto-expirations (AAASM-1453).
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ApprovalPayload {
     /// Unique ID for the approval request (UUID v4).
@@ -109,6 +111,17 @@ pub struct ApprovalPayload {
     /// absolute timestamp so dashboard consumers can render the
     /// auto-expire countdown without local-clock drift.
     pub expires_at: u64,
+    /// Lifecycle status — `"pending"` for newly-submitted requests
+    /// (the original event semantics) or `"expired"` when the
+    /// per-request timeout has elapsed without a human decision
+    /// (AAASM-1453). Defaults to `"pending"` for legacy producers
+    /// pre-AAASM-1453 that haven't been updated.
+    #[serde(default = "default_pending_status")]
+    pub status: String,
+}
+
+fn default_pending_status() -> String {
+    "pending".to_string()
 }
 
 /// Payload for `event_type: "budget"` events.

--- a/aa-api/src/ws/handler.rs
+++ b/aa-api/src/ws/handler.rs
@@ -87,6 +87,7 @@ async fn handle_socket(socket: WebSocket, params: WsQueryParams, state: AppState
     // Subscribe to live broadcast channels.
     let mut pipeline_rx = state.events.subscribe_pipeline();
     let mut approval_rx = state.events.subscribe_approvals();
+    let mut approval_expiry_rx = state.events.subscribe_approval_expirations();
     let mut budget_rx = state.events.subscribe_budget();
 
     let live_sender = sender.clone();
@@ -159,6 +160,23 @@ async fn handle_socket(socket: WebSocket, params: WsQueryParams, state: AppState
                     agent_id: approval_ev.agent_id.clone(),
                     payload: serde_json::to_value(EventPayload::Approval(
                         build_approval_payload(&approval_ev),
+                    ))
+                    .unwrap_or_default(),
+                    timestamp: chrono::Utc::now(),
+                })
+            }
+            Ok(expired_ev) = approval_expiry_rx.recv() => {
+                // AAASM-1453: a pending request's per-request timeout
+                // elapsed without a human decision. Propagate as an
+                // `approval` event with `status: "expired"` so the
+                // dashboard can move the row to the Expired section.
+                let id = next_id.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                Some(GovernanceEvent {
+                    id,
+                    event_type: EventType::Approval,
+                    agent_id: expired_ev.agent_id.clone(),
+                    payload: serde_json::to_value(EventPayload::Approval(
+                        build_expired_approval_payload(&expired_ev),
                     ))
                     .unwrap_or_default(),
                     timestamp: chrono::Utc::now(),
@@ -335,6 +353,22 @@ fn build_approval_payload(ev: &aa_runtime::approval::ApprovalRequest) -> Approva
         submitted_at: ev.submitted_at,
         timeout_secs: ev.timeout_secs,
         expires_at: ev.submitted_at.saturating_add(ev.timeout_secs),
+        status: "pending".to_string(),
+    }
+}
+
+/// Build a structured `ApprovalPayload` for an auto-expiration event
+/// (AAASM-1453). Carries `status: "expired"` so the dashboard can
+/// distinguish it from the original `"pending"` submission event.
+fn build_expired_approval_payload(ev: &aa_runtime::approval::ApprovalRequest) -> ApprovalPayload {
+    ApprovalPayload {
+        request_id: ev.request_id.to_string(),
+        action: ev.action.clone(),
+        condition_triggered: ev.condition_triggered.clone(),
+        submitted_at: ev.submitted_at,
+        timeout_secs: ev.timeout_secs,
+        expires_at: ev.submitted_at.saturating_add(ev.timeout_secs),
+        status: "expired".to_string(),
     }
 }
 
@@ -796,6 +830,7 @@ mod tests {
             payload.expires_at, 1_700_000_300,
             "expires_at = submitted_at + timeout_secs"
         );
+        assert_eq!(payload.status, "pending", "submission emits status=pending");
 
         // JSON-shape check — the discriminator + fields must match the
         // ApprovalPayload OpenAPI schema (no extra fields leaking through).
@@ -803,8 +838,43 @@ mod tests {
         assert_eq!(json["action"], "send_external_email");
         assert_eq!(json["timeout_secs"], 300);
         assert_eq!(json["expires_at"], 1_700_000_300_u64);
+        assert_eq!(json["status"], "pending");
         assert!(json.get("team_id").is_none(), "internal routing fields must not leak");
         assert!(json.get("fallback").is_none(), "internal routing fields must not leak");
+    }
+
+    #[test]
+    fn expired_approval_payload_carries_status_expired() {
+        // AAASM-1453: the auto-expiration path emits the same payload
+        // shape as a fresh submission but with `status: "expired"` so
+        // the dashboard can route it to the Expired section.
+        use aa_core::PolicyResult;
+        use aa_runtime::approval::ApprovalRequest;
+        use uuid::Uuid;
+
+        let request = ApprovalRequest {
+            request_id: Uuid::new_v4(),
+            agent_id: "support-agent".into(),
+            action: "send_external_email".into(),
+            condition_triggered: "outbound_email_to_unknown_domain".into(),
+            submitted_at: 1_700_000_000,
+            timeout_secs: 300,
+            fallback: PolicyResult::Allow,
+            team_id: Some("support".into()),
+            timeout_override_secs: None,
+            escalation_role_override: None,
+        };
+
+        let payload = build_expired_approval_payload(&request);
+        assert_eq!(payload.status, "expired");
+        assert_eq!(
+            payload.expires_at, 1_700_000_300,
+            "expires_at carries the original deadline so the dashboard can backfill the row"
+        );
+
+        let json = serde_json::to_value(EventPayload::Approval(payload)).unwrap();
+        assert_eq!(json["status"], "expired");
+        assert_eq!(json["expires_at"], 1_700_000_300_u64);
     }
 
     #[test]

--- a/aa-runtime/src/approval.rs
+++ b/aa-runtime/src/approval.rs
@@ -200,6 +200,11 @@ pub struct ApprovalQueue {
     audit_seq: AtomicU64,
     audit_last_hash: Mutex<[u8; 32]>,
     event_tx: broadcast::Sender<ApprovalRequest>,
+    /// Broadcast channel that fires when a pending request auto-expires
+    /// (its per-request timeout fires before any human decision arrives).
+    /// Separate from `event_tx` so subscribers can distinguish submission
+    /// from expiry without inspecting payload contents. AAASM-1453.
+    expiry_event_tx: broadcast::Sender<ApprovalRequest>,
 }
 
 /// Hash a string into a 16-byte identifier using SHA-256 truncation.
@@ -214,6 +219,7 @@ impl ApprovalQueue {
     /// Creates a new, empty queue wrapped in an [`Arc`].
     pub fn new() -> Arc<Self> {
         let (event_tx, _) = broadcast::channel(APPROVAL_EVENT_CHANNEL_CAPACITY);
+        let (expiry_event_tx, _) = broadcast::channel(APPROVAL_EVENT_CHANNEL_CAPACITY);
         Arc::new(Self {
             pending: DashMap::new(),
             routing_meta: DashMap::new(),
@@ -221,6 +227,7 @@ impl ApprovalQueue {
             audit_seq: AtomicU64::new(0),
             audit_last_hash: Mutex::new([0u8; 32]),
             event_tx,
+            expiry_event_tx,
         })
     }
 
@@ -230,6 +237,7 @@ impl ApprovalQueue {
     /// as `AuditEntry` values on the given channel.
     pub fn with_audit(audit_tx: mpsc::Sender<AuditEntry>, initial_hash: [u8; 32]) -> Arc<Self> {
         let (event_tx, _) = broadcast::channel(APPROVAL_EVENT_CHANNEL_CAPACITY);
+        let (expiry_event_tx, _) = broadcast::channel(APPROVAL_EVENT_CHANNEL_CAPACITY);
         Arc::new(Self {
             pending: DashMap::new(),
             routing_meta: DashMap::new(),
@@ -237,6 +245,7 @@ impl ApprovalQueue {
             audit_seq: AtomicU64::new(0),
             audit_last_hash: Mutex::new(initial_hash),
             event_tx,
+            expiry_event_tx,
         })
     }
 
@@ -248,6 +257,17 @@ impl ApprovalQueue {
     /// dropped.
     pub fn subscribe_events(&self) -> broadcast::Receiver<ApprovalRequest> {
         self.event_tx.subscribe()
+    }
+
+    /// Subscribe to approval auto-expiration events.
+    ///
+    /// Fires when a pending request's per-request timeout elapses before any
+    /// human decision arrives (i.e., the timer-spawned `resolve` call with
+    /// `ApprovalDecision::TimedOut`). The broadcast payload is a clone of
+    /// the original [`ApprovalRequest`]; subscribers can derive the
+    /// expired-at timestamp as `submitted_at + timeout_secs`. AAASM-1453.
+    pub fn subscribe_expirations(&self) -> broadcast::Receiver<ApprovalRequest> {
+        self.expiry_event_tx.subscribe()
     }
 
     /// Returns a snapshot of all currently pending requests.
@@ -445,6 +465,14 @@ impl ApprovalQueue {
                         }
                     }
                 }
+            }
+
+            // Broadcast auto-expiration so subscribers (WS dashboard,
+            // audit consumers) can surface the transition without polling.
+            // Ignore send errors — no subscribers means no delivery needed.
+            // AAASM-1453.
+            if matches!(decision, ApprovalDecision::TimedOut { .. }) {
+                let _ = self.expiry_event_tx.send(req.clone());
             }
 
             // Ignore send errors: the receiver may have been dropped (caller
@@ -771,6 +799,52 @@ mod tests {
 
         let decision = fut.await.expect("future should resolve after timeout");
         assert!(matches!(decision, ApprovalDecision::TimedOut { .. }));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn expiry_broadcast_fires_on_timeout() {
+        // AAASM-1453: timer-driven auto-expiration should fan out on
+        // `subscribe_expirations()` so the WS layer can surface the
+        // transition without polling.
+        let q = ApprovalQueue::new();
+        let mut expiry_rx = q.subscribe_expirations();
+        let req = make_request(5);
+        let id = req.request_id;
+        let (_rid, fut) = q.submit(req);
+
+        tokio::time::advance(std::time::Duration::from_secs(6)).await;
+        let _ = fut.await;
+
+        let broadcasted = expiry_rx.try_recv().expect("expiry broadcast should fire on TimedOut");
+        assert_eq!(broadcasted.request_id, id);
+    }
+
+    #[tokio::test]
+    async fn expiry_broadcast_does_not_fire_on_manual_decision() {
+        // Approved / Rejected resolutions must not be misclassified as
+        // auto-expirations on the new channel.
+        let q = ApprovalQueue::new();
+        let mut expiry_rx = q.subscribe_expirations();
+        let req = make_request(60);
+        let id = req.request_id;
+        let (_rid, _fut) = q.submit(req);
+
+        q.decide(
+            id,
+            ApprovalDecision::Approved {
+                by: "alice".to_string(),
+                reason: None,
+            },
+        )
+        .expect("decide should succeed");
+
+        assert!(
+            matches!(
+                expiry_rx.try_recv(),
+                Err(tokio::sync::broadcast::error::TryRecvError::Empty)
+            ),
+            "manual approval must not emit on the expiry channel"
+        );
     }
 
     #[tokio::test]

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -1053,8 +1053,10 @@ export interface components {
         /**
          * @description Payload for `event_type: "approval"` events.
          *
-         *     Represents a human-in-the-loop approval request submitted by the
-         *     policy engine when an action requires explicit authorisation.
+         *     Represents either a freshly-submitted human-in-the-loop approval
+         *     request or a status-change notification (e.g. auto-expiration). The
+         *     `status` field discriminates: `"pending"` for new requests,
+         *     `"expired"` for auto-expirations (AAASM-1453).
          */
         ApprovalPayload: {
             /** @description Human-readable description of the action awaiting approval. */
@@ -1071,6 +1073,14 @@ export interface components {
             expires_at: number;
             /** @description Unique ID for the approval request (UUID v4). */
             request_id: string;
+            /**
+             * @description Lifecycle status — `"pending"` for newly-submitted requests
+             *     (the original event semantics) or `"expired"` when the
+             *     per-request timeout has elapsed without a human decision
+             *     (AAASM-1453). Defaults to `"pending"` for legacy producers
+             *     pre-AAASM-1453 that haven't been updated.
+             */
+            status?: string;
             /**
              * Format: int64
              * @description Unix epoch timestamp (seconds) when the request was submitted.

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1701,8 +1701,10 @@ components:
       description: |-
         Payload for `event_type: "approval"` events.
 
-        Represents a human-in-the-loop approval request submitted by the
-        policy engine when an action requires explicit authorisation.
+        Represents either a freshly-submitted human-in-the-loop approval
+        request or a status-change notification (e.g. auto-expiration). The
+        `status` field discriminates: `"pending"` for new requests,
+        `"expired"` for auto-expirations (AAASM-1453).
       required:
       - request_id
       - action
@@ -1729,6 +1731,14 @@ components:
         request_id:
           type: string
           description: Unique ID for the approval request (UUID v4).
+        status:
+          type: string
+          description: |-
+            Lifecycle status — `"pending"` for newly-submitted requests
+            (the original event semantics) or `"expired"` when the
+            per-request timeout has elapsed without a human decision
+            (AAASM-1453). Defaults to `"pending"` for legacy producers
+            pre-AAASM-1453 that haven't been updated.
         submitted_at:
           type: integer
           format: int64


### PR DESCRIPTION
## Summary

Closes the read-side of the AAASM-1381 follow-up. When a pending approval's per-request timeout elapses without a human decision, the existing `tokio::spawn`ed timer in `ApprovalQueue::submit` already resolves the request via `ApprovalDecision::TimedOut { fallback }`. **This PR makes that transition observable from the outside** — both via a new broadcast channel on the queue and via a `status: "expired"` event on the WS dashboard stream.

## Scope per Option B (emit-only + status mapping)

| Commit | Scope | Path |
|---|---|---|
| ✨ | `aa-runtime`: Broadcast on auto-expiration of pending approvals | `aa-runtime/src/approval.rs` — new `expiry_event_tx` channel + `subscribe_expirations()` + emit in `resolve()` when decision is `TimedOut` |
| ✨ | `aa-api`: Add `approval_expiry` channel to `EventBroadcast` | `aa-api/src/events.rs` — mirror channel + `subscribe_approval_expirations()` + `approval_expiry_sender()` |
| ✨ | `aa-api`: `ApprovalPayload.status` + WS expiry dispatch arm | `aa-api/src/models/ws_payloads.rs` + `aa-api/src/ws/handler.rs` — new `status` field (serde default `"pending"`), new `build_expired_approval_payload` builder, third `tokio::select!` arm in the WS dispatch loop |
| 📝 | `openapi`+`dashboard`: Regenerate `v1.yaml` + `schema.d.ts` | picks up `ApprovalPayload.status` as `status?: string` (optional in TS thanks to the serde default) |

## What this does NOT change (intentional)

- **`list_approvals` REST surface** — still only returns pending requests. Auto-expired requests are dropped from the queue (as today); the dashboard maintains its own client-side "Expired" section by listening for the new WS events. Was Option A's scope; declined up-front because it would have introduced a sliding-window retention layer to `ApprovalQueue` that's not needed for the user-visible promise.
- **A separate `EventType::ApprovalExpired` variant** — reused existing `EventType::Approval` with the new `status` discriminator. Single event type, fewer schema surfaces.
- **`ApprovalDecision::Expired` variant** — the internal decision stays `TimedOut { fallback }` because all existing callers (SDKs, gateway) match on it for fallback-policy application. Expiration is a presentation-layer concept, not a decision-layer one.

## Verification

- `cargo nextest run --workspace` — **2346/2346** pass (with `AA_BENCH_SLA_P99_MS=5000` from the AAASM-1434 CI fix)
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `pnpm type-check` (dashboard) — clean
- `pnpm test --run` (dashboard) — 920/920 pass (no fixture changes needed; new TS field is optional)

## DoD check

| | |
|---|---|
| Pending approvals auto-transition to "expired" when `expires_at < now` | ✅ Existing per-request timer is the trigger; this PR makes the transition observable |
| `ApprovalResponse.status` returns `"expired"` for transitioned requests | ⏭ Out of scope under Option B — `list_approvals` still only returns pending; dashboard sees expired via WS. Documented above |
| Dashboard receives an event on auto-expire | ✅ `event_type: "approval"`, `payload.status: "expired"` |
| `ApprovalRequest.fallback` is applied | ✅ Untouched — `TimedOut { fallback }` decision still resolves the agent's future with the fallback policy |
| `cargo nextest run -p aa-api -p aa-gateway -p aa-runtime` green | ✅ |

## Follow-up

Once this lands, file a dashboard subtask under Epic AAASM-11 to add:
1. The auto-expire countdown to `ApprovalsPage` rows (uses the `expires_at` field from AAASM-1381).
2. The collapsible "Expired" section that consumes the new WS `status: "expired"` events.

That completes AAASM-1294's deferred AC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)