### PR TITLE
[AAASM-1462] ✅ (aa-integration-tests): Add cli_logs.rs CLI integration tests

### DIFF
--- a/aa-integration-tests/tests/cli_logs.rs
+++ b/aa-integration-tests/tests/cli_logs.rs
@@ -33,6 +33,9 @@
 
 mod common;
 
+use std::process::Stdio;
+use std::time::Duration;
+
 use aa_core::audit::AuditEventType;
 use common::cli::CliFixture;
 use rstest::rstest;
@@ -288,6 +291,49 @@ async fn logs_combined_filters_narrow_correctly() {
     for e in &entries {
         assert_eq!(e["agent_id"], agent_a_hex);
     }
+}
+
+// =============================================================================
+// aasm logs --follow (streaming mode)
+// =============================================================================
+
+// Follows the cli_agent.rs `--watch` precedent (cli_agent.rs:155-179): spawn
+// the streaming command, give it ~1.5 s to connect to the WS endpoint and
+// enter its event loop, assert it stays alive (didn't exit on its own with
+// an error), then SIGTERM and `wait_with_output()` so no zombie leaks
+// between tests. We deliberately do not assert on stdout-event count — Rust
+// stdout is block-buffered to pipes and the in-flight bytes are lost on
+// SIGKILL, which is why cli_agent.rs documents the strict-count assertion as
+// flaky. The 3 s ticket-AC budget is preserved (we cap at 1.5 s + tear-down).
+#[tokio::test(flavor = "multi_thread")]
+async fn logs_follow_runs_until_killed() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let mut child = fixture
+        .cmd()
+        .args(["logs", "--follow", "--output", "json"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("aasm logs --follow should spawn");
+
+    // Let the WebSocket connect and the stream loop enter — cli_agent.rs uses
+    // the same 1500 ms budget for `--watch`.
+    std::thread::sleep(Duration::from_millis(1500));
+    let alive = child.try_wait().expect("try_wait should work").is_none();
+    if !alive {
+        let out = child.wait_with_output().unwrap_or_else(|_| std::process::Output {
+            status: std::process::ExitStatus::default(),
+            stdout: vec![],
+            stderr: vec![],
+        });
+        panic!(
+            "--follow exited prematurely; stderr:\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    child.kill().expect("kill should succeed");
+    let _ = child.wait_with_output();
 }
 
 #[ignore = "blocked by AAASM-1476 — aa-gateway audit_reader::parse_event_type expects CamelCase but CLI sends snake_case"]

--- a/aa-integration-tests/tests/cli_logs.rs
+++ b/aa-integration-tests/tests/cli_logs.rs
@@ -170,6 +170,42 @@ async fn logs_type_filter_smoke_accepts_flag_and_returns_matching() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn logs_since_filter_only_returns_recent() {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agent = fixture.seed_agents(1)[0];
+
+    let now_ns = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64;
+    let two_hours_ns: u64 = 2 * 60 * 60 * 1_000_000_000;
+    // 2 events in the past (2 h ago) — should be excluded by --since 30m.
+    for i in 0..2 {
+        fixture
+            .seed_audit_event(now_ns - two_hours_ns + i, agent, AuditEventType::PolicyViolation, "old")
+            .expect("seed old should succeed");
+    }
+    // 3 events in the last few seconds — should be included.
+    for i in 0..3 {
+        fixture
+            .seed_audit_event(
+                now_ns - (3 - i) * 1_000_000_000,
+                agent,
+                AuditEventType::PolicyViolation,
+                "new",
+            )
+            .expect("seed new should succeed");
+    }
+
+    let out = fixture
+        .cmd()
+        .args(["logs", "--since", "30m", "--output", "json"])
+        .output()
+        .expect("aasm logs --since should execute");
+    assert!(out.status.success());
+    let entries = parse_jsonl(&out.stdout);
+    assert_eq!(entries.len(), 3, "only the 3 recent events should pass --since 30m");
+}
+
 #[ignore = "blocked by AAASM-1476 — aa-gateway audit_reader::parse_event_type expects CamelCase but CLI sends snake_case"]
 #[tokio::test(flavor = "multi_thread")]
 async fn logs_type_filter_only_returns_matching() {

--- a/aa-integration-tests/tests/cli_logs.rs
+++ b/aa-integration-tests/tests/cli_logs.rs
@@ -104,3 +104,29 @@ async fn logs_succeeds_for_every_output_format(#[case] fmt: &str) {
     );
     assert!(!out.stdout.is_empty(), "{fmt} stdout should not be empty");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn logs_agent_filter_only_returns_matching() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agents = fixture.seed_agents(2);
+    let (agent_a, agent_b) = (agents[0], agents[1]);
+    fixture
+        .seed_audit_events(3, agent_a, AuditEventType::PolicyViolation)
+        .expect("seed A should succeed");
+    fixture
+        .seed_audit_events(2, agent_b, AuditEventType::PolicyViolation)
+        .expect("seed B should succeed");
+
+    let agent_a_hex = CliFixture::hex_id(&agent_a);
+    let out = fixture
+        .cmd()
+        .args(["logs", "--agent", &agent_a_hex, "--output", "json"])
+        .output()
+        .expect("aasm logs --agent should execute");
+    assert!(out.status.success());
+    let entries = parse_jsonl(&out.stdout);
+    assert_eq!(entries.len(), 3, "only agent_a events expected");
+    for e in &entries {
+        assert_eq!(e["agent_id"], agent_a_hex, "stray non-matching event in stdout");
+    }
+}

--- a/aa-integration-tests/tests/cli_logs.rs
+++ b/aa-integration-tests/tests/cli_logs.rs
@@ -144,7 +144,7 @@ async fn logs_agent_filter_only_returns_matching() {
 // The smoke test below pins the surface that works today (flag is accepted,
 // CLI exits 0, the violation events at minimum come back). The strict
 // filter-correctness assertion is `#[ignore]`d until the underlying bug is
-// fixed — tracked as a sub-task under AAASM-1258.
+// fixed — tracked as AAASM-1476 (sub-task under AAASM-1258).
 #[tokio::test(flavor = "multi_thread")]
 async fn logs_type_filter_smoke_accepts_flag_and_returns_matching() {
     let fixture = CliFixture::start().await.expect("fixture should start");
@@ -170,7 +170,7 @@ async fn logs_type_filter_smoke_accepts_flag_and_returns_matching() {
     );
 }
 
-#[ignore = "blocked by aa-gateway audit-reader event_type parse mismatch — see follow-up bug under AAASM-1258"]
+#[ignore = "blocked by AAASM-1476 — aa-gateway audit_reader::parse_event_type expects CamelCase but CLI sends snake_case"]
 #[tokio::test(flavor = "multi_thread")]
 async fn logs_type_filter_only_returns_matching() {
     let fixture = CliFixture::start().await.expect("fixture should start");

--- a/aa-integration-tests/tests/cli_logs.rs
+++ b/aa-integration-tests/tests/cli_logs.rs
@@ -206,6 +206,24 @@ async fn logs_since_filter_only_returns_recent() {
     assert_eq!(entries.len(), 3, "only the 3 recent events should pass --since 30m");
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn logs_limit_caps_returned_entries() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agent = fixture.seed_agents(1)[0];
+    fixture
+        .seed_audit_events(10, agent, AuditEventType::PolicyViolation)
+        .expect("seed 10 should succeed");
+
+    let out = fixture
+        .cmd()
+        .args(["logs", "--limit", "3", "--output", "json"])
+        .output()
+        .expect("aasm logs --limit should execute");
+    assert!(out.status.success());
+    let entries = parse_jsonl(&out.stdout);
+    assert_eq!(entries.len(), 3, "--limit 3 should cap output to 3 entries");
+}
+
 #[ignore = "blocked by AAASM-1476 — aa-gateway audit_reader::parse_event_type expects CamelCase but CLI sends snake_case"]
 #[tokio::test(flavor = "multi_thread")]
 async fn logs_type_filter_only_returns_matching() {

--- a/aa-integration-tests/tests/cli_logs.rs
+++ b/aa-integration-tests/tests/cli_logs.rs
@@ -224,6 +224,72 @@ async fn logs_limit_caps_returned_entries() {
     assert_eq!(entries.len(), 3, "--limit 3 should cap output to 3 entries");
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn logs_combined_filters_narrow_correctly() {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agents = fixture.seed_agents(2);
+    let (agent_a, agent_b) = (agents[0], agents[1]);
+
+    let now_ns = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos() as u64;
+    let two_hours_ns: u64 = 2 * 60 * 60 * 1_000_000_000;
+    // Agent A: 2 old (2 h ago) + 3 recent.
+    for i in 0..2 {
+        fixture
+            .seed_audit_event(
+                now_ns - two_hours_ns + i,
+                agent_a,
+                AuditEventType::PolicyViolation,
+                "a-old",
+            )
+            .unwrap();
+    }
+    for i in 0..3 {
+        fixture
+            .seed_audit_event(
+                now_ns - (3 - i) * 1_000_000_000,
+                agent_a,
+                AuditEventType::PolicyViolation,
+                "a-new",
+            )
+            .unwrap();
+    }
+    // Agent B: 2 recent — should be excluded by --agent <A>.
+    fixture
+        .seed_audit_events(2, agent_b, AuditEventType::PolicyViolation)
+        .unwrap();
+
+    let agent_a_hex = CliFixture::hex_id(&agent_a);
+    // `--type violation` is included for matrix coverage; per AAASM-1476 it
+    // is a no-op against the audit reader, so the binding filters here are
+    // `--agent` (server-side) and `--since` (client-side trim).
+    let out = fixture
+        .cmd()
+        .args([
+            "logs",
+            "--agent",
+            &agent_a_hex,
+            "--type",
+            "violation",
+            "--since",
+            "30m",
+            "--output",
+            "json",
+        ])
+        .output()
+        .expect("aasm logs combined filters should execute");
+    assert!(out.status.success());
+    let entries = parse_jsonl(&out.stdout);
+    assert_eq!(
+        entries.len(),
+        3,
+        "agent A + last 30 minutes should match the 3 recent A-violations"
+    );
+    for e in &entries {
+        assert_eq!(e["agent_id"], agent_a_hex);
+    }
+}
+
 #[ignore = "blocked by AAASM-1476 — aa-gateway audit_reader::parse_event_type expects CamelCase but CLI sends snake_case"]
 #[tokio::test(flavor = "multi_thread")]
 async fn logs_type_filter_only_returns_matching() {

--- a/aa-integration-tests/tests/cli_logs.rs
+++ b/aa-integration-tests/tests/cli_logs.rs
@@ -1,0 +1,75 @@
+//! CLI integration tests for `aasm logs` (AAASM-1462 / F121 ST-6).
+//!
+//! Covers the snapshot path (`aasm logs`) backed by `GET /api/v1/logs`, the
+//! per-`--output` format matrix, every supported filter flag, a combined-filter
+//! scenario, and a `--follow` streaming-alive smoke test.
+//!
+//! ## Leaf surface (from `aa-cli/src/commands/logs/`)
+//!
+//! | Flag         | Notes                                                                  |
+//! | ---          | ---                                                                    |
+//! | `--follow` / `-f` | Switches dispatch to the WebSocket follow path.                   |
+//! | `--agent`    | Hex-encoded agent ID; forwarded as `?agent_id=...` to the REST query.  |
+//! | `--type`     | Event-type filter (`violation` / `approval` / `budget`).               |
+//! | `--since`    | Duration shorthand (`30m`, `2h`, `1d`) or ISO 8601; client-side cut.   |
+//! | `--until`    | ISO 8601 only; client-side cut.                                        |
+//! | `--limit`    | `per_page` for the REST query (default 50).                            |
+//! | `--no-color` | Disables ANSI color in plain-text output.                              |
+//! | `--output`   | `json` branches to `format_log_json`; everything else falls through    |
+//! |              | to `format_log_line` — so `yaml` currently renders the same plain-text |
+//! |              | output as `table`.                                                     |
+//!
+//! ## Divergence notes from the ticket text (AAASM-1462)
+//!
+//! * Ticket mentions a `--level` flag and a `--component` flag — neither
+//!   exists in the CLI. The closest surface is `--type`, which is what these
+//!   tests exercise; `--component` has no analogue so the test for it is
+//!   omitted (the ticket itself disclaimed this with "verify at impl time").
+//! * Ticket asks the `--follow` test to assert `≥7 events on stdout within
+//!   3s, then SIGTERM`. The established cli_agent.rs `--watch` precedent
+//!   documents that stdout-count assertions under SIGKILL are unreliable
+//!   because Rust's stdout is block-buffered to pipes. This file adopts the
+//!   same "process-stays-alive" assertion (cli_agent.rs:155-179).
+
+mod common;
+
+use aa_core::audit::AuditEventType;
+use common::cli::CliFixture;
+use serde_json::Value;
+
+/// Parse newline-delimited JSON from `aasm logs --output json`.
+fn parse_jsonl(stdout: &[u8]) -> Vec<Value> {
+    std::str::from_utf8(stdout)
+        .expect("stdout is utf-8")
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| serde_json::from_str::<Value>(l).expect("each stdout line is a JSON object"))
+        .collect()
+}
+
+// =============================================================================
+// aasm logs (snapshot mode)
+// =============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn logs_happy_path_returns_seeded_events() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agent = fixture.seed_agents(1)[0];
+    fixture
+        .seed_audit_events(5, agent, AuditEventType::PolicyViolation)
+        .expect("seed should succeed");
+
+    let out = fixture
+        .cmd()
+        .args(["logs", "--output", "json"])
+        .output()
+        .expect("aasm logs should execute");
+    assert!(
+        out.status.success(),
+        "aasm logs should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let entries = parse_jsonl(&out.stdout);
+    assert_eq!(entries.len(), 5, "5 seeded events expected in stdout");
+}

--- a/aa-integration-tests/tests/cli_logs.rs
+++ b/aa-integration-tests/tests/cli_logs.rs
@@ -35,6 +35,7 @@ mod common;
 
 use aa_core::audit::AuditEventType;
 use common::cli::CliFixture;
+use rstest::rstest;
 use serde_json::Value;
 
 /// Parse newline-delimited JSON from `aasm logs --output json`.
@@ -72,4 +73,34 @@ async fn logs_happy_path_returns_seeded_events() {
     );
     let entries = parse_jsonl(&out.stdout);
     assert_eq!(entries.len(), 5, "5 seeded events expected in stdout");
+}
+
+// NOTE on `--output yaml`: `aa-cli/src/commands/logs/fetch.rs` only branches
+// on `Json` vs. text — yaml is parsed by clap but renders the same plain-text
+// shape as `table`. The format test below parametrizes all three so the matrix
+// matches the ticket AC; it asserts on exit + non-empty stdout rather than on
+// format-specific structure because yaml/table share the same renderer today.
+#[rstest]
+#[case::json("json")]
+#[case::yaml("yaml")]
+#[case::table("table")]
+#[tokio::test(flavor = "multi_thread")]
+async fn logs_succeeds_for_every_output_format(#[case] fmt: &str) {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agent = fixture.seed_agents(1)[0];
+    fixture
+        .seed_audit_events(2, agent, AuditEventType::PolicyViolation)
+        .expect("seed should succeed");
+
+    let out = fixture
+        .cmd()
+        .args(["logs", "--output", fmt])
+        .output()
+        .expect("aasm logs should execute");
+    assert!(
+        out.status.success(),
+        "{fmt} should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(!out.stdout.is_empty(), "{fmt} stdout should not be empty");
 }

--- a/aa-integration-tests/tests/cli_logs.rs
+++ b/aa-integration-tests/tests/cli_logs.rs
@@ -130,3 +130,70 @@ async fn logs_agent_filter_only_returns_matching() {
         assert_eq!(e["agent_id"], agent_a_hex, "stray non-matching event in stdout");
     }
 }
+
+// The `--type` filter has a pre-existing CLI↔API contract mismatch:
+//   • `aasm logs --type violation` sends `?event_type=violation` (snake_case
+//     wire form via `LogEventType::as_api_str()`).
+//   • `aa-gateway`'s `AuditReader::list` parses event_type via a match table
+//     keyed on CamelCase variant names (`"PolicyViolation"`, …). Anything
+//     else falls through to `None` → filter is silently dropped → every
+//     event is returned.
+// Verified empirically while writing this file: 3 violations + 2 approvals
+// seeded, `--type violation` returns all 5 instead of 3.
+//
+// The smoke test below pins the surface that works today (flag is accepted,
+// CLI exits 0, the violation events at minimum come back). The strict
+// filter-correctness assertion is `#[ignore]`d until the underlying bug is
+// fixed — tracked as a sub-task under AAASM-1258.
+#[tokio::test(flavor = "multi_thread")]
+async fn logs_type_filter_smoke_accepts_flag_and_returns_matching() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agent = fixture.seed_agents(1)[0];
+    fixture
+        .seed_audit_events(3, agent, AuditEventType::PolicyViolation)
+        .expect("seed violations should succeed");
+    fixture
+        .seed_audit_events(2, agent, AuditEventType::ApprovalGranted)
+        .expect("seed approvals should succeed");
+
+    let out = fixture
+        .cmd()
+        .args(["logs", "--type", "violation", "--output", "json"])
+        .output()
+        .expect("aasm logs --type should execute");
+    assert!(out.status.success(), "--type should be accepted by clap");
+    let entries = parse_jsonl(&out.stdout);
+    let violations = entries.iter().filter(|e| e["event_type"] == "PolicyViolation").count();
+    assert!(
+        violations >= 3,
+        "at minimum the 3 seeded violation events should appear (got {violations})"
+    );
+}
+
+#[ignore = "blocked by aa-gateway audit-reader event_type parse mismatch — see follow-up bug under AAASM-1258"]
+#[tokio::test(flavor = "multi_thread")]
+async fn logs_type_filter_only_returns_matching() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agent = fixture.seed_agents(1)[0];
+    fixture
+        .seed_audit_events(3, agent, AuditEventType::PolicyViolation)
+        .expect("seed violations should succeed");
+    fixture
+        .seed_audit_events(2, agent, AuditEventType::ApprovalGranted)
+        .expect("seed approvals should succeed");
+
+    let out = fixture
+        .cmd()
+        .args(["logs", "--type", "violation", "--output", "json"])
+        .output()
+        .expect("aasm logs --type should execute");
+    assert!(out.status.success());
+    let entries = parse_jsonl(&out.stdout);
+    assert_eq!(entries.len(), 3, "only PolicyViolation events expected");
+    for e in &entries {
+        assert_eq!(
+            e["event_type"], "PolicyViolation",
+            "stray non-violation event in stdout"
+        );
+    }
+}

--- a/aa-integration-tests/tests/common/cli.rs
+++ b/aa-integration-tests/tests/common/cli.rs
@@ -27,11 +27,16 @@
 //!   spawns an independent runtime that gets dropped between tests).
 
 use std::collections::{BTreeMap, VecDeque};
+use std::fs::OpenOptions;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::atomic::{AtomicU16, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use aa_api::models::trace::TraceSpan;
+use aa_core::audit::AuditEventType;
+use aa_core::{AgentId, AuditEntry, SessionId};
 use aa_gateway::registry::{AgentRecord, AgentStatus};
 use aa_runtime::approval::{ApprovalRequest, ApprovalRequestId};
 use chrono::{Duration as ChronoDuration, Utc};
@@ -352,5 +357,54 @@ impl CliFixture {
                 .record_span(session_id, agent_id, span)
                 .expect("seed_trace_session: record_span should succeed");
         }
+    }
+}
+
+impl CliFixture {
+    /// Append one audit entry to the per-fixture JSONL file in
+    /// [`TopologyTestEnv::audit_dir`]. Lets per-leaf tests control timestamp,
+    /// agent, and event type independently — used by `cli_logs.rs` filter
+    /// tests where `seed_audit_events` (bulk-stride helper below) is too
+    /// coarse.
+    pub fn seed_audit_event(
+        &self,
+        timestamp_ns: u64,
+        agent_id: [u8; 16],
+        event_type: AuditEventType,
+        payload: &str,
+    ) -> anyhow::Result<()> {
+        let entry = AuditEntry::new(
+            0,
+            timestamp_ns,
+            event_type,
+            AgentId::from_bytes(agent_id),
+            SessionId::from_bytes([0u8; 16]),
+            payload.to_string(),
+            [0u8; 32],
+        );
+        let line = serde_json::to_string(&entry)?;
+        let path = self.env.audit_dir.join("seed.jsonl");
+        let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
+        file.write_all(line.as_bytes())?;
+        file.write_all(b"\n")?;
+        Ok(())
+    }
+
+    /// Seed `n` audit entries for `agent_id` with `event_type`, timestamps
+    /// spaced one second apart ending at "now". Returns the nanosecond
+    /// timestamp of the oldest entry so the caller can build `--since`
+    /// boundaries relative to it.
+    pub fn seed_audit_events(&self, n: usize, agent_id: [u8; 16], event_type: AuditEventType) -> anyhow::Result<u64> {
+        // Pin "now" against UNIX_EPOCH so all entries share a stable base;
+        // back off by `n` seconds so the newest entry lands within the last
+        // second (keeps `--since 1h` happy without needing system clock games).
+        let now_ns = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos() as u64;
+        let stride_ns: u64 = Duration::from_secs(1).as_nanos() as u64;
+        let oldest_ns = now_ns - stride_ns * n as u64;
+        for i in 0..n {
+            let ts = oldest_ns + stride_ns * i as u64;
+            self.seed_audit_event(ts, agent_id, event_type, &format!("seed-{i}"))?;
+        }
+        Ok(oldest_ns)
     }
 }

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -25,7 +25,7 @@ pub mod scenario;
 pub mod sdk_driver;
 
 use std::net::SocketAddr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicI64, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -75,6 +75,10 @@ pub struct TopologyTestEnv {
     /// observe via the HTTP plane.
     #[allow(dead_code)]
     pub approval_queue: Arc<ApprovalQueue>,
+    /// On-disk JSONL audit directory the harness's `AuditReader` scans.
+    /// Exposed so per-leaf seed helpers (e.g. `CliFixture::seed_audit_events`)
+    /// can write entries that the `aasm logs` snapshot path observes.
+    pub audit_dir: PathBuf,
     /// Trigger to stop the background axum task.
     shutdown_tx: Option<oneshot::Sender<()>>,
     /// Handle for the spawned axum task; awaited during teardown.
@@ -89,7 +93,7 @@ impl TopologyTestEnv {
     /// Spin up the harness: build the AppState, bind axum to a free port,
     /// spawn the server task, and poll `/api/v1/health` until ready.
     pub async fn start() -> anyhow::Result<Self> {
-        let state = build_test_state()?;
+        let (state, audit_dir) = build_test_state()?;
         let agent_registry = Arc::clone(&state.agent_registry);
         let trace_store = Arc::clone(&state.trace_store);
         let approval_queue = Arc::clone(&state.approval_queue);
@@ -115,6 +119,7 @@ impl TopologyTestEnv {
             agent_registry,
             trace_store,
             approval_queue,
+            audit_dir,
             shutdown_tx: Some(shutdown_tx),
             server_handle: Some(server_handle),
             cleaned: false,
@@ -197,7 +202,7 @@ fn uuid_string(key: &[u8; 16]) -> String {
 /// Build a minimal `AppState` for the harness. Adapted from
 /// `aa-api/tests/common/mod.rs::test_state_with_auth` to avoid pulling that
 /// crate's `dev-dependencies` test helpers across crate boundaries.
-fn build_test_state() -> anyhow::Result<AppState> {
+fn build_test_state() -> anyhow::Result<(AppState, PathBuf)> {
     let policy_id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let policy_dir = std::env::temp_dir().join(format!("aa-topology-it-policy-{}-{policy_id}", std::process::id()));
     std::fs::create_dir_all(&policy_dir)?;
@@ -256,45 +261,48 @@ spec:
     let audit_id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let audit_dir = std::env::temp_dir().join(format!("aa-topology-it-audit-{}-{audit_id}", std::process::id()));
     std::fs::create_dir_all(&audit_dir)?;
-    let audit_reader = Arc::new(AuditReader::new(audit_dir));
+    let audit_reader = Arc::new(AuditReader::new(audit_dir.clone()));
 
-    Ok(AppState {
-        agent_registry,
-        policy_engine,
-        budget_tracker,
-        approval_queue,
-        policy_history,
-        alert_store,
-        events,
-        replay_buffer: ReplayBuffer::new(),
-        next_event_id: Arc::new(AtomicU64::new(0)),
-        auth_config,
-        key_store,
-        rate_limiter,
-        jwt_signer,
-        jwt_verifier,
-        trace_store: Arc::new(InMemoryTraceStore::new()),
-        audit_reader,
-        startup_time: Instant::now(),
-        active_connections: Arc::new(AtomicI64::new(0)),
-        discovery: Arc::new(DiscoveryService::with_adapters(vec![])),
-        edge_repo: Arc::new(InMemoryEdgeRepo::new()),
-        topology_overview_cache: moka::future::Cache::builder()
-            .time_to_live(Duration::from_secs(1))
-            .build(),
-        topology_tree_cache: moka::future::Cache::builder()
-            .time_to_live(Duration::from_secs(5))
-            .build(),
-        topology_team_cache: moka::future::Cache::builder()
-            .time_to_live(Duration::from_secs(5))
-            .build(),
-        topology_lineage_cache: moka::future::Cache::builder()
-            .time_to_live(Duration::from_secs(5))
-            .build(),
-        topology_stats_cache: moka::future::Cache::builder()
-            .time_to_live(Duration::from_secs(10))
-            .build(),
-        capability_store: aa_api::routes::capability::CapabilityStore::new_seeded(),
-        iam_api_key_store: aa_api::routes::iam::seeded_iam_store(),
-    })
+    Ok((
+        AppState {
+            agent_registry,
+            policy_engine,
+            budget_tracker,
+            approval_queue,
+            policy_history,
+            alert_store,
+            events,
+            replay_buffer: ReplayBuffer::new(),
+            next_event_id: Arc::new(AtomicU64::new(0)),
+            auth_config,
+            key_store,
+            rate_limiter,
+            jwt_signer,
+            jwt_verifier,
+            trace_store: Arc::new(InMemoryTraceStore::new()),
+            audit_reader,
+            startup_time: Instant::now(),
+            active_connections: Arc::new(AtomicI64::new(0)),
+            discovery: Arc::new(DiscoveryService::with_adapters(vec![])),
+            edge_repo: Arc::new(InMemoryEdgeRepo::new()),
+            topology_overview_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(1))
+                .build(),
+            topology_tree_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(5))
+                .build(),
+            topology_team_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(5))
+                .build(),
+            topology_lineage_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(5))
+                .build(),
+            topology_stats_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(10))
+                .build(),
+            capability_store: aa_api::routes::capability::CapabilityStore::new_seeded(),
+            iam_api_key_store: aa_api::routes::iam::seeded_iam_store(),
+        },
+        audit_dir,
+    ))
 }


### PR DESCRIPTION
## Description

Adds `aa-integration-tests/tests/cli_logs.rs` — F121 ST-6 CLI integration coverage for `aasm logs` (snapshot + `--follow` streaming). Closes the per-leaf gap left by the renamed `aa-integration-tests` crate (AAASM-1258 → AAASM-1462 sub-task).

The PR contains 10 active tests (1 file × 10 cases) plus 1 `#[ignore]`d test that pins a bug surfaced during implementation (filed as AAASM-1476).

| Test                                                                      | Notes                                       |
| ---                                                                       | ---                                         |
| `logs_happy_path_returns_seeded_events`                                   | 5 seeded events → 5 entries on stdout       |
| `logs_succeeds_for_every_output_format` (rstest × json/yaml/table)         | 3 cases                                     |
| `logs_agent_filter_only_returns_matching`                                 | server-side `?agent_id=…` filter            |
| `logs_type_filter_smoke_accepts_flag_and_returns_matching`                | smoke (filter is no-op — AAASM-1476)        |
| `logs_type_filter_only_returns_matching`                                  | `#[ignore]` until AAASM-1476 fixed          |
| `logs_since_filter_only_returns_recent`                                   | client-side `is_within_time_range` cut      |
| `logs_limit_caps_returned_entries`                                        | `per_page` REST param                       |
| `logs_combined_filters_narrow_correctly`                                  | `--agent` + `--type` + `--since`            |
| `logs_follow_runs_until_killed`                                           | spawn-and-kill (cli_agent.rs `--watch` pattern) |

Two shared-harness extensions land alongside the test file:

* `TopologyTestEnv::audit_dir: PathBuf` — bubbles the per-test JSONL audit directory out of `build_test_state` so per-leaf seeders can write entries the harness's `AuditReader` will observe.
* `CliFixture::seed_audit_events` + `seed_audit_event` — bulk-stride and one-shot writers that serialise valid `AuditEntry` rows into the env's audit_dir. Matches the per-sub-task seeder pattern ST-3 used for `seed_policy`.

## Type of Change

- [x] ✨ New feature (test coverage)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1462 (parent AAASM-1258); follow-up bug filed as AAASM-1476.

## Testing

- [x] Integration tests added (this PR is the tests)
- [x] Local run: `cargo nextest run -p aa-integration-tests --test cli_logs` — 10 passed, 1 skipped.
- [x] Full crate: `cargo nextest run -p aa-integration-tests` — 90 passed, 1 skipped (no regressions in topology / agent / policy / smoke).
- [x] Flake check: `cli_logs` run 10× in a row, all green.

## Scope adjustments vs. ticket text (AAASM-1462)

Three discrepancies between the ticket AC and the actual `aasm logs` CLI surface, all documented in the file's module preamble:

1. **`--level` flag does not exist.** Real flag is `--type {violation|approval|budget}`. The "severity filter" test became a `--type` filter test.
2. **`--component` flag does not exist.** Ticket disclaimed this with "verify at impl time" — the test was dropped.
3. **`--output yaml` falls back to plain text** — `fetch.rs` only branches on `Json` vs. text. The format-matrix test still parametrizes all three so the matrix matches the AC; it asserts on exit + non-empty stdout rather than format-specific shape.

Plus one bug discovered empirically while writing the `--type` filter test (now AAASM-1476):

4. **`--type` filter is a no-op end-to-end.** CLI sends snake_case (`?event_type=violation`); `aa-gateway`'s `AuditReader::list` parses on CamelCase variant names (`"PolicyViolation"`) and silently drops unrecognised strings. Two tests are included: a smoke test that pins today's accept-and-ignore behaviour (passes today), and a strict assertion test marked `#[ignore]` with a pointer to AAASM-1476.

The `--follow` test uses the cli_agent.rs `--watch` precedent (assert process stays alive ~1.5s, kill cleanly) rather than the ticket's "≥7 events on stdout" pattern — cli_agent.rs documents that stdout-count assertions under SIGKILL are unreliable because Rust stdout is block-buffered to pipes.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy` — lefthook pre-commit verified each commit)
- [x] Self-review of the diff completed
- [x] No documentation changes needed (no behaviour change in product code)
- [x] All CI checks expected passing (full local nextest run green)
- [x] Commits are small and follow the Gitmoji convention (11 commits, one logical unit per commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)