### PR TITLE
[AAASM-1471] ✅ (aa-integration-tests): Add cli_dashboard.rs --help smoke tests

### DIFF
--- a/aa-integration-tests/tests/cli_dashboard.rs
+++ b/aa-integration-tests/tests/cli_dashboard.rs
@@ -1,0 +1,79 @@
+//! CLI integration tests for `aasm dashboard` (AAASM-1471 / F121 ST-15).
+//!
+//! Smoke-only: the dashboard is a TUI that requires a live TTY, and we
+//! don't ship a virtual-terminal harness in v0.0.1. These tests exercise
+//! the `--help` path only — the clap parser must accept the subcommand
+//! plus its global flag siblings and render a usable banner.
+//!
+//! No actual TUI is ever launched. No gateway HTTP traffic. `CliFixture`
+//! is still used for harness contract uniformity across `cli_*.rs` files
+//! (per AAASM-1258 test-design rule "All tests use the shared
+//! `CliFixture` — no per-test-file gateway boot helpers"), even though
+//! the in-process gateway it boots is unused here.
+//!
+//! ## Divergence from subtask description
+//!
+//! AAASM-1471's description calls the global override flag `--gateway-url`;
+//! master ships it as `--api-url` (declared on the top-level `Cli` struct
+//! at `aa-cli/src/lib.rs` with `global = true`). The clap-parser-smoke
+//! test uses `--api-url` accordingly. Everything else (banner text,
+//! `--output` global flag) matches the description verbatim.
+//!
+//! ## Future follow-up (not in scope)
+//!
+//! Full TUI interaction testing (key navigation, dialog rendering, feed
+//! updates) requires a `vte`-style virtual-terminal harness. The parent
+//! Story's "Out of scope" section explicitly defers this; no follow-up
+//! sub-ticket is filed here.
+
+mod common;
+
+use common::cli::CliFixture;
+
+// ============================================================================
+// aasm dashboard --help — banner-content tests
+// ============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dashboard_help_exits_zero_and_describes_tui() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["dashboard", "--help"])
+        .output()
+        .expect("aasm dashboard --help should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Open an interactive TUI dashboard"),
+        "banner should describe the TUI; got:\n{stdout}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dashboard_subcommand_name_appears_in_banner() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["dashboard", "--help"])
+        .output()
+        .expect("aasm dashboard --help should execute");
+    assert!(out.status.success(), "should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // Catches an accidental rename of the subcommand (e.g. dashboard→ui).
+    // The Usage line is `Usage: aasm dashboard [OPTIONS] [COMMAND]`, so
+    // asserting on the qualified `aasm dashboard` token is precise enough
+    // to fail loudly if the leaf is renamed without also being unique
+    // enough to false-positive against an unrelated mention.
+    assert!(
+        stdout.contains("aasm dashboard"),
+        "banner should contain the qualified subcommand name 'aasm dashboard'; got:\n{stdout}",
+    );
+}

--- a/aa-integration-tests/tests/cli_dashboard.rs
+++ b/aa-integration-tests/tests/cli_dashboard.rs
@@ -77,3 +77,45 @@ async fn dashboard_subcommand_name_appears_in_banner() {
         "banner should contain the qualified subcommand name 'aasm dashboard'; got:\n{stdout}",
     );
 }
+
+// ============================================================================
+// aasm dashboard --help — clap parser smoke for global flags
+// ============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dashboard_help_accepts_global_api_url_flag() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    // Global `--api-url` is declared on the top-level `Cli` struct with
+    // `global = true`, so clap must accept it next to any subcommand
+    // including `dashboard --help`. The flag value is irrelevant to
+    // `--help`; this just verifies clap doesn't choke.
+    let out = fixture
+        .cmd()
+        .args(["dashboard", "--help", "--api-url", "http://x"])
+        .output()
+        .expect("aasm dashboard --help --api-url … should execute");
+    assert!(
+        out.status.success(),
+        "clap should accept global --api-url next to dashboard --help\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn dashboard_help_accepts_global_output_format_flag() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["dashboard", "--help", "--output", "json"])
+        .output()
+        .expect("aasm dashboard --help --output json should execute");
+    assert!(
+        out.status.success(),
+        "clap should accept global --output next to dashboard --help\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}


### PR DESCRIPTION
## Description

Adds `aa-integration-tests/tests/cli_dashboard.rs` — 4 `#[tokio::test]` cases that smoke-test `aasm dashboard --help` without ever launching the TUI.

Implements AAASM-1471 (F121 ST-15 under Story [AAASM-1258](https://lightning-dust-mite.atlassian.net/browse/AAASM-1258) → Epic [AAASM-1199](https://lightning-dust-mite.atlassian.net/browse/AAASM-1199)).

### Why smoke-only

The dashboard is a TUI that needs a live TTY. CI runners don't have one, and a vte-style virtual-terminal harness is overkill for v0.0.1. The parent Story's "Out of scope" section explicitly defers full TUI interaction testing; no follow-up sub-ticket is filed here. These tests verify the clap parser surface only.

### Tests

| Test | What it checks |
|---|---|
| `dashboard_help_exits_zero_and_describes_tui` | `--help` exits 0, banner contains `Open an interactive TUI dashboard` |
| `dashboard_subcommand_name_appears_in_banner` | Banner includes the qualified `aasm dashboard` token — catches an accidental subcommand rename |
| `dashboard_help_accepts_global_api_url_flag` | clap accepts global `--api-url http://x` next to `dashboard --help` |
| `dashboard_help_accepts_global_output_format_flag` | clap accepts global `--output json` next to `dashboard --help` |

### Spec divergence (documented in JIRA + module rustdoc)

| Description says | Master ships |
|---|---|
| Global `--gateway-url` flag | Global flag is `--api-url` (declared on `Cli` struct with `global = true` at `aa-cli/src/lib.rs`) |
| (else matches) | Banner text + `--output {table\|json\|yaml}` global flag match the description verbatim |

See the AAASM-1471 starting-work comment for the captured `--help` banner that informed every assertion in this file.

### Commit breakdown

| Commit | Scope | Tests |
|---|---|---|
| `8e3eb925 ✅ (aa-integration-tests): Add cli_dashboard banner-content smoke tests` | scaffold + banner assertions | 2 |
| `785d37f3 ✅ (aa-integration-tests): Add cli_dashboard parser-smoke tests for global flags` | clap parser smoke for `--api-url`/`--output` | 2 |

## Type of Change

- [x] ✅ Tests (integration test addition)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-1471](https://lightning-dust-mite.atlassian.net/browse/AAASM-1471) (this subtask)
- Parent Story: [AAASM-1258](https://lightning-dust-mite.atlassian.net/browse/AAASM-1258) (F121 — `aasm` CLI integration tests)
- Parent Epic: [AAASM-1199](https://lightning-dust-mite.atlassian.net/browse/AAASM-1199) (Release & Distribution Pipeline)

## Testing

- [x] Integration tests added — 4 `#[tokio::test]` cases in `aa-integration-tests/tests/cli_dashboard.rs`
- [x] Manual testing performed — `cargo nextest run -p aa-integration-tests --test cli_dashboard` locally

### Local run summary

```
Starting 4 tests across 1 binary
        PASS [  12.290s] (1/4) dashboard_subcommand_name_appears_in_banner
        PASS [  12.309s] (2/4) dashboard_help_accepts_global_output_format_flag
        PASS [  12.309s] (3/4) dashboard_help_accepts_global_api_url_flag
        PASS [  12.309s] (4/4) dashboard_help_exits_zero_and_describes_tui
Summary [  12.309s] 4 tests run: 4 passed, 0 skipped
```

Fast because `--help` is offline — no gateway HTTP traffic.

## Future follow-up (deferred per parent Story's Out-of-scope section)

Full TUI interaction testing (keyboard navigation, dialog rendering, feed updates) would require a virtual-terminal harness (e.g. `vte`). Not in scope for v0.0.1; not creating a sub-ticket here.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` clean per pre-commit hooks on every commit)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (module rustdoc documents smoke-only scope, divergence, deferred TUI testing)
- [ ] All CI checks passing (will be confirmed once GitHub Actions runs)
- [x] Commits are small and follow the Gitmoji convention (one commit per test grouping)

[AAASM-1258]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1199]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1471]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ