### PR TITLE
[AAASM-1461] ✅ (aa-integration-tests): Add cli_audit.rs F121 ST-5 integration tests

### DIFF
--- a/aa-integration-tests/tests/cli_audit.rs
+++ b/aa-integration-tests/tests/cli_audit.rs
@@ -252,6 +252,68 @@ async fn audit_list_since_filter_excludes_events_before_cutoff() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn audit_list_until_filter_excludes_events_after_cutoff() {
+    use std::io::Write as _;
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agent_id = AgentId::from_bytes([0xb5; 16]);
+    let session_id = SessionId::from_bytes([0xed; 16]);
+
+    let now_ns = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock should be after Unix epoch")
+        .as_nanos() as u64;
+
+    // Genesis = 24h old (before cutoff, kept); second = now-5s (after cutoff, dropped).
+    let old = AuditEntry::new(
+        0,
+        now_ns.saturating_sub(24 * NANOS_PER_HOUR),
+        AuditEventType::ToolCallIntercepted,
+        agent_id,
+        session_id,
+        r#"{"tool":"old","result":"allow","policy":"default"}"#.into(),
+        [0u8; 32],
+    );
+    let new_entry = AuditEntry::new(
+        1,
+        now_ns.saturating_sub(5 * 1_000_000_000),
+        AuditEventType::ToolCallIntercepted,
+        agent_id,
+        session_id,
+        r#"{"tool":"new","result":"allow","policy":"default"}"#.into(),
+        *old.entry_hash(),
+    );
+    let path = fixture.env.audit_dir.join("until-filter.jsonl");
+    let mut f = std::fs::File::create(&path).expect("create until-filter.jsonl");
+    writeln!(f, "{}", serde_json::to_string(&old).unwrap()).unwrap();
+    writeln!(f, "{}", serde_json::to_string(&new_entry).unwrap()).unwrap();
+    drop(f);
+
+    let cutoff = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+    let out = fixture
+        .cmd()
+        .args(["--output", "json", "audit", "list", "--until", &cutoff])
+        .output()
+        .expect("aasm audit list --until should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let parsed = common::format::parse_json(&out.stdout);
+    let arr = parsed.as_array().expect("json stdout should be an array");
+    assert_eq!(
+        arr.len(),
+        1,
+        "--until 1h-ago should keep only the 24h-old entry; got:\n{parsed:#}"
+    );
+    let payload = arr[0].get("payload").and_then(|v| v.as_str()).unwrap_or_default();
+    assert!(
+        payload.contains("\"tool\":\"old\""),
+        "remaining entry should be the older one; got payload {payload}"
+    );
+}
+
 // =============================================================================
 // aasm audit export
 // =============================================================================

--- a/aa-integration-tests/tests/cli_audit.rs
+++ b/aa-integration-tests/tests/cli_audit.rs
@@ -341,6 +341,80 @@ async fn audit_list_limit_caps_returned_rows() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn audit_list_combined_filters_narrow_correctly() {
+    use std::io::Write as _;
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agent_keep: [u8; 16] = [0xc1; 16];
+    let agent_drop: [u8; 16] = [0xc2; 16];
+
+    // Recent (within `--since 1h`) PolicyViolation events for the kept agent.
+    fixture
+        .seed_audit_events(3, agent_keep, AuditEventType::PolicyViolation)
+        .expect("seed kept-agent violations");
+    // Same agent, different action — should drop on `--action`.
+    fixture
+        .seed_audit_events(2, agent_keep, AuditEventType::ToolCallIntercepted)
+        .expect("seed kept-agent tool calls");
+    // Different agent, same action — should drop on `--agent`.
+    fixture
+        .seed_audit_events(2, agent_drop, AuditEventType::PolicyViolation)
+        .expect("seed dropped-agent violations");
+
+    // Old PolicyViolation for kept agent — should drop on `--since 1h`.
+    let now_ns = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock should be after Unix epoch")
+        .as_nanos() as u64;
+    let stale = AuditEntry::new(
+        0,
+        now_ns.saturating_sub(24 * NANOS_PER_HOUR),
+        AuditEventType::PolicyViolation,
+        AgentId::from_bytes(agent_keep),
+        SessionId::from_bytes([0xec; 16]),
+        r#"{"tool":"old","result":"deny","policy":"deny-rm"}"#.into(),
+        [0u8; 32],
+    );
+    let stale_path = fixture.env.audit_dir.join("combined-stale.jsonl");
+    let mut f = std::fs::File::create(&stale_path).expect("create combined-stale.jsonl");
+    writeln!(f, "{}", serde_json::to_string(&stale).unwrap()).unwrap();
+    drop(f);
+
+    let keep_hex = CliFixture::hex_id(&agent_keep);
+    let out = fixture
+        .cmd()
+        .args([
+            "--output",
+            "json",
+            "audit",
+            "list",
+            "--agent",
+            &keep_hex,
+            "--action",
+            "PolicyViolation",
+            "--since",
+            "1h",
+        ])
+        .output()
+        .expect("aasm audit list combined filters should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let parsed = common::format::parse_json(&out.stdout);
+    let arr = parsed.as_array().expect("json stdout should be an array");
+    assert_eq!(
+        arr.len(),
+        3,
+        "combined filters should keep only recent kept-agent PolicyViolation events; got:\n{parsed:#}"
+    );
+    for e in arr {
+        assert_eq!(e.get("agent_id").and_then(|v| v.as_str()), Some(keep_hex.as_str()));
+        assert_eq!(e.get("event_type").and_then(|v| v.as_str()), Some("PolicyViolation"));
+    }
+}
+
 // =============================================================================
 // aasm audit export
 // =============================================================================

--- a/aa-integration-tests/tests/cli_audit.rs
+++ b/aa-integration-tests/tests/cli_audit.rs
@@ -568,3 +568,46 @@ async fn audit_verify_chain_returns_success_for_valid_chain() {
         "stdout should report \"OK — 5 entries verified\"; got:\n{stdout}"
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn audit_verify_chain_returns_failure_for_tampered_chain() {
+    use std::io::Write as _;
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let dir = tempfile::tempdir().expect("tempdir for tampered chain");
+    let path = dir.path().join("tampered.jsonl");
+
+    let entries = make_valid_chain(3);
+    // Replace entry[1] with a forged copy that keeps the original
+    // `previous_hash` and seq but mutates payload + event_type so
+    // entry_hash diverges, breaking integrity at that entry index.
+    let bad_entry = AuditEntry::new(
+        entries[1].seq(),
+        entries[1].timestamp_ns(),
+        AuditEventType::PolicyViolation,
+        entries[1].agent_id(),
+        entries[1].session_id(),
+        "TAMPERED".to_string(),
+        *entries[1].previous_hash(),
+    );
+    let mut f = std::fs::File::create(&path).expect("create tampered.jsonl");
+    writeln!(f, "{}", serde_json::to_string(&entries[0]).unwrap()).unwrap();
+    writeln!(f, "{}", serde_json::to_string(&bad_entry).unwrap()).unwrap();
+    writeln!(f, "{}", serde_json::to_string(&entries[2]).unwrap()).unwrap();
+    drop(f);
+
+    let out = fixture
+        .cmd()
+        .args(["audit", "verify-chain", path.to_str().expect("utf-8 path")])
+        .output()
+        .expect("aasm audit verify-chain should execute");
+    assert!(!out.status.success(), "tampered chain should exit non-zero");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(stderr.contains("FAIL"), "stderr should announce FAIL; got:\n{stderr}");
+    // entry[1] is byte-swapped → integrity check fails at entry index 2
+    // (the third entry's `previous_hash` no longer matches the forged
+    // entry's `entry_hash`).
+    assert!(
+        stderr.contains("entry 2"),
+        "stderr should name the broken entry index; got:\n{stderr}"
+    );
+}

--- a/aa-integration-tests/tests/cli_audit.rs
+++ b/aa-integration-tests/tests/cli_audit.rs
@@ -22,6 +22,7 @@ mod common;
 
 use aa_core::audit::AuditEventType;
 use common::cli::CliFixture;
+use rstest::rstest;
 
 // =============================================================================
 // aasm audit list
@@ -57,6 +58,31 @@ async fn audit_list_happy_path_renders_table_with_seeded_events() {
         "event_type row missing; got:\n{stdout}"
     );
     assert!(stdout.contains("bash"), "seeded tool name missing; got:\n{stdout}");
+}
+
+#[rstest]
+#[case::json("json")]
+#[case::yaml("yaml")]
+#[case::table("table")]
+#[tokio::test(flavor = "multi_thread")]
+async fn audit_list_succeeds_for_every_output_format(#[case] fmt: &str) {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agent: [u8; 16] = [0xa2; 16];
+    fixture
+        .seed_audit_events(3, agent, AuditEventType::ToolCallIntercepted)
+        .expect("seed_audit_events");
+
+    let out = fixture
+        .cmd()
+        .args(["--output", fmt, "audit", "list"])
+        .output()
+        .expect("aasm audit list should execute");
+    assert!(
+        out.status.success(),
+        "{fmt} should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(!out.stdout.is_empty(), "{fmt} stdout should not be empty");
 }
 
 // =============================================================================

--- a/aa-integration-tests/tests/cli_audit.rs
+++ b/aa-integration-tests/tests/cli_audit.rs
@@ -151,6 +151,39 @@ async fn audit_list_agent_filter_narrows_to_one_agent() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn audit_list_action_filter_narrows_to_one_event_type() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agent: [u8; 16] = [0xb3; 16];
+    fixture
+        .seed_audit_events(2, agent, AuditEventType::ToolCallIntercepted)
+        .expect("seed tool-call events");
+    fixture
+        .seed_audit_events(3, agent, AuditEventType::PolicyViolation)
+        .expect("seed policy-violation events");
+
+    let out = fixture
+        .cmd()
+        .args(["--output", "json", "audit", "list", "--action", "PolicyViolation"])
+        .output()
+        .expect("aasm audit list --action should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let entries = common::format::parse_json(&out.stdout);
+    let arr = entries.as_array().expect("json stdout should be an array");
+    assert_eq!(
+        arr.len(),
+        3,
+        "should return only the 3 PolicyViolation events; got:\n{entries:#}"
+    );
+    for e in arr {
+        assert_eq!(e.get("event_type").and_then(|v| v.as_str()), Some("PolicyViolation"));
+    }
+}
+
 // =============================================================================
 // aasm audit export
 // =============================================================================

--- a/aa-integration-tests/tests/cli_audit.rs
+++ b/aa-integration-tests/tests/cli_audit.rs
@@ -511,3 +511,60 @@ async fn audit_export_writes_valid_csv_to_temp_file() {
 // =============================================================================
 // aasm audit verify-chain
 // =============================================================================
+
+/// Build a valid hash-linked `AuditEntry` chain of `n` entries rooted at
+/// the `[0u8; 32]` genesis hash. Returned in order, ready to serialize
+/// one-per-line into a JSONL file.
+fn make_valid_chain(n: u64) -> Vec<AuditEntry> {
+    let agent = AgentId::from_bytes([0x91; 16]);
+    let session = SessionId::from_bytes([0x92; 16]);
+    let mut entries = Vec::with_capacity(n as usize);
+    let mut prev_hash = [0u8; 32];
+    for seq in 0..n {
+        let entry = AuditEntry::new(
+            seq,
+            1_700_000_000_000_000_000 + seq * 1_000_000_000,
+            AuditEventType::ToolCallIntercepted,
+            agent,
+            session,
+            format!(r#"{{"tool":"bash","result":"allow","policy":"default","seq":{seq}}}"#),
+            prev_hash,
+        );
+        prev_hash = *entry.entry_hash();
+        entries.push(entry);
+    }
+    entries
+}
+
+/// Write the given entries one-per-line as JSONL to `path`.
+fn write_jsonl(path: &std::path::Path, entries: &[AuditEntry]) {
+    use std::io::Write as _;
+    let mut f = std::fs::File::create(path).expect("create chain jsonl");
+    for e in entries {
+        writeln!(f, "{}", serde_json::to_string(e).expect("serialize entry")).expect("write entry line");
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn audit_verify_chain_returns_success_for_valid_chain() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let dir = tempfile::tempdir().expect("tempdir for chain file");
+    let path = dir.path().join("valid.jsonl");
+    write_jsonl(&path, &make_valid_chain(5));
+
+    let out = fixture
+        .cmd()
+        .args(["audit", "verify-chain", path.to_str().expect("utf-8 path")])
+        .output()
+        .expect("aasm audit verify-chain should execute");
+    assert!(
+        out.status.success(),
+        "valid chain should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("OK") && stdout.contains("5 entries verified"),
+        "stdout should report \"OK — 5 entries verified\"; got:\n{stdout}"
+    );
+}

--- a/aa-integration-tests/tests/cli_audit.rs
+++ b/aa-integration-tests/tests/cli_audit.rs
@@ -85,6 +85,31 @@ async fn audit_list_succeeds_for_every_output_format(#[case] fmt: &str) {
     assert!(!out.stdout.is_empty(), "{fmt} stdout should not be empty");
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn audit_list_json_and_yaml_describe_equivalent_records() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agent: [u8; 16] = [0xa3; 16];
+    fixture
+        .seed_audit_events(4, agent, AuditEventType::ToolCallIntercepted)
+        .expect("seed_audit_events");
+
+    let json_out = fixture
+        .cmd()
+        .args(["--output", "json", "audit", "list"])
+        .output()
+        .expect("aasm audit list --output json should execute");
+    assert!(json_out.status.success(), "json case should exit 0");
+
+    let yaml_out = fixture
+        .cmd()
+        .args(["--output", "yaml", "audit", "list"])
+        .output()
+        .expect("aasm audit list --output yaml should execute");
+    assert!(yaml_out.status.success(), "yaml case should exit 0");
+
+    common::format::assert_equivalent_records(&json_out.stdout, &yaml_out.stdout, "agent_id");
+}
+
 // =============================================================================
 // aasm audit export
 // =============================================================================

--- a/aa-integration-tests/tests/cli_audit.rs
+++ b/aa-integration-tests/tests/cli_audit.rs
@@ -21,8 +21,14 @@
 mod common;
 
 use aa_core::audit::AuditEventType;
+use aa_core::identity::SessionId;
+use aa_core::{AgentId, AuditEntry};
 use common::cli::CliFixture;
 use rstest::rstest;
+
+/// Nanoseconds in one hour — used by the `--since` / `--until` filter
+/// tests to position seeded events on either side of an absolute cutoff.
+const NANOS_PER_HOUR: u64 = 3_600 * 1_000_000_000;
 
 // =============================================================================
 // aasm audit list
@@ -182,6 +188,68 @@ async fn audit_list_action_filter_narrows_to_one_event_type() {
     for e in arr {
         assert_eq!(e.get("event_type").and_then(|v| v.as_str()), Some("PolicyViolation"));
     }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn audit_list_since_filter_excludes_events_before_cutoff() {
+    use std::io::Write as _;
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agent_id = AgentId::from_bytes([0xb4; 16]);
+    let session_id = SessionId::from_bytes([0xee; 16]);
+
+    let now_ns = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock should be after Unix epoch")
+        .as_nanos() as u64;
+
+    // Genesis entry is ~24h old (well outside `--since 1h`) so the filter
+    // must drop it; the second entry is ~5s old (inside the window).
+    let old = AuditEntry::new(
+        0,
+        now_ns.saturating_sub(24 * NANOS_PER_HOUR),
+        AuditEventType::ToolCallIntercepted,
+        agent_id,
+        session_id,
+        r#"{"tool":"old","result":"allow","policy":"default"}"#.into(),
+        [0u8; 32],
+    );
+    let new_entry = AuditEntry::new(
+        1,
+        now_ns.saturating_sub(5 * 1_000_000_000),
+        AuditEventType::ToolCallIntercepted,
+        agent_id,
+        session_id,
+        r#"{"tool":"new","result":"allow","policy":"default"}"#.into(),
+        *old.entry_hash(),
+    );
+    let path = fixture.env.audit_dir.join("since-filter.jsonl");
+    let mut f = std::fs::File::create(&path).expect("create since-filter.jsonl");
+    writeln!(f, "{}", serde_json::to_string(&old).unwrap()).unwrap();
+    writeln!(f, "{}", serde_json::to_string(&new_entry).unwrap()).unwrap();
+    drop(f);
+
+    let out = fixture
+        .cmd()
+        .args(["--output", "json", "audit", "list", "--since", "1h"])
+        .output()
+        .expect("aasm audit list --since should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let parsed = common::format::parse_json(&out.stdout);
+    let arr = parsed.as_array().expect("json stdout should be an array");
+    assert_eq!(
+        arr.len(),
+        1,
+        "--since 1h should exclude the 24h-old entry and keep only the recent one; got:\n{parsed:#}"
+    );
+    let payload = arr[0].get("payload").and_then(|v| v.as_str()).unwrap_or_default();
+    assert!(
+        payload.contains("\"tool\":\"new\""),
+        "remaining entry should be the recent one; got payload {payload}"
+    );
 }
 
 // =============================================================================

--- a/aa-integration-tests/tests/cli_audit.rs
+++ b/aa-integration-tests/tests/cli_audit.rs
@@ -110,6 +110,47 @@ async fn audit_list_json_and_yaml_describe_equivalent_records() {
     common::format::assert_equivalent_records(&json_out.stdout, &yaml_out.stdout, "agent_id");
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn audit_list_agent_filter_narrows_to_one_agent() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agent_keep: [u8; 16] = [0xb1; 16];
+    let agent_drop: [u8; 16] = [0xb2; 16];
+    fixture
+        .seed_audit_events(2, agent_keep, AuditEventType::ToolCallIntercepted)
+        .expect("seed agent_keep");
+    fixture
+        .seed_audit_events(3, agent_drop, AuditEventType::ToolCallIntercepted)
+        .expect("seed agent_drop");
+
+    let keep_hex = CliFixture::hex_id(&agent_keep);
+    let drop_hex = CliFixture::hex_id(&agent_drop);
+    let out = fixture
+        .cmd()
+        .args(["--output", "json", "audit", "list", "--agent", &keep_hex])
+        .output()
+        .expect("aasm audit list --agent should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let entries = common::format::parse_json(&out.stdout);
+    let arr = entries.as_array().expect("json stdout should be an array");
+    assert_eq!(
+        arr.len(),
+        2,
+        "should return only the 2 events for agent_keep; got:\n{entries:#}"
+    );
+    for e in arr {
+        assert_eq!(e.get("agent_id").and_then(|v| v.as_str()), Some(keep_hex.as_str()));
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        !stdout.contains(&drop_hex),
+        "agent_drop events should not leak through; got:\n{stdout}"
+    );
+}
+
 // =============================================================================
 // aasm audit export
 // =============================================================================

--- a/aa-integration-tests/tests/cli_audit.rs
+++ b/aa-integration-tests/tests/cli_audit.rs
@@ -419,6 +419,50 @@ async fn audit_list_combined_filters_narrow_correctly() {
 // aasm audit export
 // =============================================================================
 
+/// `aasm audit export --format json --output <file>` should write a
+/// valid JSON array to the given TempDir file.
+///
+/// **Currently `#[ignore]`'d**: `aasm audit export` is unusable today because
+/// the CLI declares two flags that share the clap id `"output"` —
+/// a top-level global `--output: OutputFormat` (`aa-cli/src/lib.rs:19-21`)
+/// AND a leaf-level `audit export --output: Option<String>`
+/// (`aa-cli/src/commands/audit/export.rs:23-25`). Every invocation of
+/// `audit export`, with or without `--output` on the command line, panics
+/// inside clap with "Mismatch between definition and access of `output`."
+/// Re-enable this test once the collision is resolved (rename the leaf flag
+/// to e.g. `--out` or give it a distinct `id`). Filed as a follow-up
+/// bug subtask under AAASM-1258.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "AAASM-1258 bug subtask: clap id collision on --output between global Cli and audit::ExportArgs"]
+async fn audit_export_writes_valid_json_array_to_temp_file() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agent: [u8; 16] = [0xd1; 16];
+    fixture
+        .seed_audit_events(4, agent, AuditEventType::ToolCallIntercepted)
+        .expect("seed events");
+
+    let tmp = tempfile::tempdir().expect("tempdir for export target");
+    let out_path = tmp.path().join("audit.json");
+    let out_arg = out_path.to_string_lossy().to_string();
+    let out = fixture
+        .cmd()
+        .args(["audit", "export", "--format", "json", "--output", &out_arg])
+        .output()
+        .expect("aasm audit export should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(out_path.exists(), "export file should exist at {out_path:?}");
+
+    let body = std::fs::read(&out_path).expect("read exported json");
+    assert!(!body.is_empty(), "exported file should not be empty");
+    let parsed = common::format::parse_json(&body);
+    let arr = parsed.as_array().expect("exported json should be an array");
+    assert_eq!(arr.len(), 4, "should export all 4 seeded entries; got:\n{parsed:#}");
+}
+
 // =============================================================================
 // aasm audit verify-chain
 // =============================================================================

--- a/aa-integration-tests/tests/cli_audit.rs
+++ b/aa-integration-tests/tests/cli_audit.rs
@@ -20,9 +20,44 @@
 
 mod common;
 
+use aa_core::audit::AuditEventType;
+use common::cli::CliFixture;
+
 // =============================================================================
 // aasm audit list
 // =============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn audit_list_happy_path_renders_table_with_seeded_events() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agent: [u8; 16] = [0xa1; 16];
+    fixture
+        .seed_audit_events(5, agent, AuditEventType::ToolCallIntercepted)
+        .expect("seed_audit_events should succeed");
+
+    let out = fixture
+        .cmd()
+        .args(["audit", "list"])
+        .output()
+        .expect("aasm audit list should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("TIMESTAMP"),
+        "table header missing TIMESTAMP; got:\n{stdout}"
+    );
+    assert!(stdout.contains("ACTION"), "table header missing ACTION; got:\n{stdout}");
+    assert!(
+        stdout.contains("ToolCallIntercepted"),
+        "event_type row missing; got:\n{stdout}"
+    );
+    assert!(stdout.contains("bash"), "seeded tool name missing; got:\n{stdout}");
+}
 
 // =============================================================================
 // aasm audit export

--- a/aa-integration-tests/tests/cli_audit.rs
+++ b/aa-integration-tests/tests/cli_audit.rs
@@ -463,6 +463,51 @@ async fn audit_export_writes_valid_json_array_to_temp_file() {
     assert_eq!(arr.len(), 4, "should export all 4 seeded entries; got:\n{parsed:#}");
 }
 
+/// `aasm audit export --format csv --output <file>` should write a CSV
+/// file with the documented header row plus one data row per seeded
+/// event.
+///
+/// **Currently `#[ignore]`'d** for the same `--output` clap id collision
+/// documented on `audit_export_writes_valid_json_array_to_temp_file`.
+/// Re-enable alongside that test when the bug subtask lands.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "AAASM-1258 bug subtask: clap id collision on --output between global Cli and audit::ExportArgs"]
+async fn audit_export_writes_valid_csv_to_temp_file() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agent: [u8; 16] = [0xd2; 16];
+    fixture
+        .seed_audit_events(3, agent, AuditEventType::ToolCallIntercepted)
+        .expect("seed events");
+
+    let tmp = tempfile::tempdir().expect("tempdir for export target");
+    let out_path = tmp.path().join("audit.csv");
+    let out_arg = out_path.to_string_lossy().to_string();
+    let out = fixture
+        .cmd()
+        .args(["audit", "export", "--format", "csv", "--output", &out_arg])
+        .output()
+        .expect("aasm audit export should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(out_path.exists(), "export file should exist at {out_path:?}");
+
+    let body = std::fs::read_to_string(&out_path).expect("read exported csv");
+    let lines: Vec<&str> = body.lines().collect();
+    assert!(
+        lines[0].starts_with("timestamp,agent_id,session_id,event_type,tool,result,policy"),
+        "CSV should start with the documented header row; got first line:\n{}",
+        lines[0],
+    );
+    assert!(
+        lines.len() >= 4,
+        "CSV should have header + at least 3 data rows; got {} lines:\n{body}",
+        lines.len(),
+    );
+}
+
 // =============================================================================
 // aasm audit verify-chain
 // =============================================================================

--- a/aa-integration-tests/tests/cli_audit.rs
+++ b/aa-integration-tests/tests/cli_audit.rs
@@ -611,3 +611,35 @@ async fn audit_verify_chain_returns_failure_for_tampered_chain() {
         "stderr should name the broken entry index; got:\n{stderr}"
     );
 }
+
+/// `aasm audit verify-chain <nonexistent>` should exit non-zero with an
+/// I/O error on stderr.
+///
+/// **Deviation from the AC text** ("stderr names the missing path"): the
+/// real CLI wraps the underlying `std::io::Error` directly via
+/// `eprintln!("error: {e}")`, and `io::Error` from `File::open` does not
+/// carry the path by default. So the actual stderr is shaped like
+/// `error: No such file or directory (os error 2)` without the filename.
+/// This test asserts the achievable invariants (non-zero exit + the
+/// "error:" prefix). If a future commit teaches the CLI to wrap the
+/// error with `Context::with_context(|| path.display())`, tighten this
+/// test to also assert the path appears.
+#[tokio::test(flavor = "multi_thread")]
+async fn audit_verify_chain_returns_failure_for_missing_file() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let dir = tempfile::tempdir().expect("tempdir for missing-file path");
+    let path = dir.path().join("does-not-exist.jsonl");
+    assert!(!path.exists(), "precondition: target path must not exist");
+
+    let out = fixture
+        .cmd()
+        .args(["audit", "verify-chain", path.to_str().expect("utf-8 path")])
+        .output()
+        .expect("aasm audit verify-chain should execute");
+    assert!(!out.status.success(), "missing chain file should exit non-zero");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.starts_with("error:"),
+        "stderr should be prefixed with `error:`; got:\n{stderr}"
+    );
+}

--- a/aa-integration-tests/tests/cli_audit.rs
+++ b/aa-integration-tests/tests/cli_audit.rs
@@ -54,6 +54,7 @@ async fn audit_list_happy_path_renders_table_with_seeded_events() {
         String::from_utf8_lossy(&out.stderr),
     );
     let stdout = String::from_utf8_lossy(&out.stdout);
+    let agent_hex = CliFixture::hex_id(&agent);
     assert!(
         stdout.contains("TIMESTAMP"),
         "table header missing TIMESTAMP; got:\n{stdout}"
@@ -61,9 +62,12 @@ async fn audit_list_happy_path_renders_table_with_seeded_events() {
     assert!(stdout.contains("ACTION"), "table header missing ACTION; got:\n{stdout}");
     assert!(
         stdout.contains("ToolCallIntercepted"),
-        "event_type row missing; got:\n{stdout}"
+        "seeded event_type row missing; got:\n{stdout}"
     );
-    assert!(stdout.contains("bash"), "seeded tool name missing; got:\n{stdout}");
+    assert!(
+        stdout.contains(&agent_hex),
+        "seeded agent_id missing from stdout; got:\n{stdout}"
+    );
 }
 
 #[rstest]

--- a/aa-integration-tests/tests/cli_audit.rs
+++ b/aa-integration-tests/tests/cli_audit.rs
@@ -314,6 +314,33 @@ async fn audit_list_until_filter_excludes_events_after_cutoff() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn audit_list_limit_caps_returned_rows() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let agent: [u8; 16] = [0xb6; 16];
+    fixture
+        .seed_audit_events(10, agent, AuditEventType::ToolCallIntercepted)
+        .expect("seed 10 events");
+
+    let out = fixture
+        .cmd()
+        .args(["--output", "json", "audit", "list", "--limit", "3"])
+        .output()
+        .expect("aasm audit list --limit should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let parsed = common::format::parse_json(&out.stdout);
+    let arr = parsed.as_array().expect("json stdout should be an array");
+    assert_eq!(
+        arr.len(),
+        3,
+        "--limit 3 should cap returned entries even when 10 were seeded; got:\n{parsed:#}"
+    );
+}
+
 // =============================================================================
 // aasm audit export
 // =============================================================================

--- a/aa-integration-tests/tests/cli_audit.rs
+++ b/aa-integration-tests/tests/cli_audit.rs
@@ -1,0 +1,33 @@
+//! CLI integration tests for `aasm audit` (AAASM-1461 / F121 ST-5).
+//!
+//! Exercises every `aasm audit <leaf>` subcommand against a live in-process
+//! gateway booted via `CliFixture`. Two leaves (`list`, `export`) hit the
+//! gateway via `GET /api/v1/logs`; the third (`verify-chain`) is
+//! filesystem-only and reads a JSONL file via [`aa_gateway::audit::AuditWriter::verify_chain`].
+//!
+//! ## Leaf surface (from `aa-cli/src/commands/audit/`)
+//!
+//! | Leaf         | Args                                                   | Backend                                              | Notes |
+//! | ------------ | ------------------------------------------------------ | ---------------------------------------------------- | ----- |
+//! | list         | `--agent --action --result --since --until --limit`     | `GET /api/v1/logs`                                   | Honors global `--output {table,json,yaml}` |
+//! | export       | `--format {csv,json} --output <file> --compliance ...` | `GET /api/v1/logs`                                   | Writes to stdout when `--output` is absent |
+//! | verify-chain | positional `<path>`                                    | local JSONL file via `AuditWriter::verify_chain`     | Stdout `OK — N entries verified` on success; stderr `FAIL — hash chain broken at entry N` on tampered |
+//!
+//! Audit events surface through `/api/v1/logs` by reading JSONL files from
+//! the harness's `audit_dir`. The `seed_audit_events` helper (added in this
+//! file's companion `common/cli.rs` commit) writes `aa_core::AuditEntry`
+//! lines into that dir so the real `AuditReader` picks them up.
+
+mod common;
+
+// =============================================================================
+// aasm audit list
+// =============================================================================
+
+// =============================================================================
+// aasm audit export
+// =============================================================================
+
+// =============================================================================
+// aasm audit verify-chain
+// =============================================================================


### PR DESCRIPTION
## Description

Adds `aa-integration-tests/tests/cli_audit.rs` — F121 Phase A ST-5 of the `aasm` CLI integration test suite (AAASM-1461 under AAASM-1258). Covers every leaf of `aasm audit` end-to-end against the live in-process gateway booted by `CliFixture`, matching the pattern of `cli_topology.rs` / `cli_agent.rs` / `cli_policy.rs`.

**16 tests, 14 active + 2 ignored** (the 2 ignored ones exist as production-ready test bodies blocked on a pre-existing CLI bug — see Notes).

| Leaf | Tests | Pattern |
|---|---|---|
| `audit list` | 9 (happy path, rstest formats, json/yaml record-equivalence, `--agent`, `--action`, `--since`, `--until`, `--limit`, combined filters) | Seeds `aa_core::AuditEntry` JSONL into the harness audit dir → `GET /api/v1/logs` returns them |
| `audit export` | 2 (`--format json` + `--format csv` into TempDir file) — **`#[ignore]`'d** | See Notes |
| `audit verify-chain` | 3 (valid chain, tampered chain, missing file) | Builds chain programmatically in TempDir via `AuditEntry::new` |

## Type of Change

- [x] ✅ Tests (integration tests)

## Breaking Changes

- [x] No

`tests/common/mod.rs` adds a `pub audit_dir: PathBuf` field on `TopologyTestEnv` and `tests/common/cli.rs` adds a leaf-specific `seed_audit_events()` helper, matching the established \"each downstream sub-task adds the seed helpers it needs\" pattern called out in `cli.rs`'s own doc comment. No shared-infra extension beyond that.

## Related Issues

- Related Jira ticket: AAASM-1461 (under AAASM-1258 / F121 Phase A)

## Commit history (16 small, bisectable commits)

1. `✅ Add cli_audit.rs skeleton`
2. `🔧 Expose audit_dir on TopologyTestEnv`
3. `✨ Add seed_audit_events on CliFixture`
4. `✅ Add audit_list happy-path test`
5. `✅ Add audit_list output-format rstest`
6. `✅ Assert audit_list json/yaml equivalence`
7. `✅ Add audit_list --agent filter test`
8. `✅ Add audit_list --action filter test`
9. `✅ Add audit_list --since filter test`
10. `✅ Add audit_list --until filter test`
11. `✅ Add audit_list --limit pagination test`
12. `✅ Add audit_list combined-filter test`
13. `✅ Add audit_export json test (ignored — CLI bug)`
14. `✅ Add audit_export csv test (ignored — CLI bug)`
15. `✅ Add audit_verify_chain happy-path test`
16. `✅ Add audit_verify_chain tampered-chain test`
17. `✅ Add audit_verify_chain missing-file test`

## Testing

- [x] Integration tests added (`aa-integration-tests/tests/cli_audit.rs`)
- [x] `cargo nextest run -p aa-integration-tests --test cli_audit` → **14 passed, 2 skipped** locally
- [x] Full crate run `cargo nextest run -p aa-integration-tests` → **94 passed, 2 skipped** (no regression from `TopologyTestEnv::audit_dir` exposure)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy -p aa-integration-tests --tests --all-features -- -D warnings` clean
- [x] Pre-commit hooks (fmt + clippy + doc) ran green on every commit

## Notes (deviations from the ticket spec)

**Real `aasm audit` flag surface vs ticket text:**
- `audit list` accepts `--agent --action --result --since --until --limit`; `--output` is the global flag (not leaf-level). Tests pass `--output` before the subcommand.
- `audit export` is `--output <file>` (a file path), NOT `--output-dir <dir>` as the ticket described. Tests write into `TempDir.path().join(\"audit.{json,csv}\")` once the underlying CLI bug is unblocked.
- `verify-chain` reads `aa_core::AuditEntry` JSONL via `AuditWriter::verify_chain`. Stdout-on-success is `OK — N entries verified`; stderr-on-tampered is `FAIL — hash chain broken at entry N`. Tests assert exit code + match on the entry **index**, not field name (impl reports index).

**Audit chain fixtures**: `tests/common/fixtures/audit/chain_valid.jsonl` + `chain_tampered.jsonl` use a custom (`event_id`/`prev_hash`/`hash`) shape that does **not** deserialize as `aa_core::AuditEntry` — they were placeholder fixtures. To stay on green, the verify-chain tests build their chains programmatically in `TempDir` (mirroring `aa-cli/src/commands/audit/verify_chain.rs::tests::make_chain`). The on-disk fixtures can be regenerated in a follow-up if anyone wants them runnable from outside the test binary.

**`#[ignore]`'d export tests**: `aasm audit export` is currently unusable because the CLI declares `Cli::output: OutputFormat` (global) AND `ExportArgs::output: Option<String>` (leaf) on the same clap id `\"output\"`, so every invocation panics inside the matches downcast regardless of whether `--output` is passed on the command line. Both export tests carry their final shape and an `#[ignore = \"AAASM-1258 bug subtask: clap id collision...\"]` so they auto-enable when the bug is fixed. A bug subtask under AAASM-1258 will be filed.

**`verify-chain` missing-path AC**: AC said \"stderr names the missing path\". `std::io::Error` from `File::open` does not include the filename by default, and the CLI's `eprintln!(\"error: {e}\")` doesn't add path context. Test asserts the achievable invariants (non-zero exit + `error:` prefix); doc-comment notes how to tighten the assertion if a future commit adds path context to the error.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (no behaviour change; tests only)
- [x] All CI checks passing locally
- [x] Commits are small and follow the Gitmoji convention