### PR TITLE
[AAASM-1470] ✅ (aa-integration-tests): Add cli_cost integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "portpicker",
  "reqwest",
  "rstest 0.23.0",
+ "rust_decimal",
  "serde_json",
  "serde_yaml",
  "tempfile",

--- a/aa-integration-tests/Cargo.toml
+++ b/aa-integration-tests/Cargo.toml
@@ -23,6 +23,7 @@ moka        = { version = "0.12", features = ["future"] }
 portpicker  = "0.1"
 reqwest     = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 rstest      = "0.23"
+rust_decimal = "1"
 serde_json  = "1"
 serde_yaml  = "0.9"
 tempfile    = "3"

--- a/aa-integration-tests/tests/cli_cost.rs
+++ b/aa-integration-tests/tests/cli_cost.rs
@@ -27,6 +27,7 @@
 mod common;
 
 use common::cli::CliFixture;
+use rstest::rstest;
 
 // =============================================================================
 // aasm cost summary
@@ -57,4 +58,25 @@ async fn cost_summary_happy_path_renders_daily_spend() {
         stdout.contains("Daily spend"),
         "stdout should mention `Daily spend` for the default --period today\nstdout:\n{stdout}",
     );
+}
+
+#[rstest]
+#[case::json("json")]
+#[case::yaml("yaml")]
+#[case::table("table")]
+#[tokio::test(flavor = "multi_thread")]
+async fn cost_summary_succeeds_for_every_output_format(#[case] fmt: &str) {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["cost", "summary", "--output", fmt])
+        .output()
+        .expect("aasm cost summary should execute");
+    assert!(
+        out.status.success(),
+        "{fmt} should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(!out.stdout.is_empty(), "{fmt} stdout should not be empty");
 }

--- a/aa-integration-tests/tests/cli_cost.rs
+++ b/aa-integration-tests/tests/cli_cost.rs
@@ -216,3 +216,26 @@ async fn cost_forecast_succeeds_for_every_output_format(#[case] fmt: &str) {
     );
     assert!(!out.stdout.is_empty(), "{fmt} stdout should not be empty");
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cost_forecast_json_and_yaml_describe_equivalent_object() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let json_out = fixture
+        .cmd()
+        .args(["cost", "forecast", "--output", "json"])
+        .output()
+        .expect("aasm cost forecast --output json should execute");
+    assert!(json_out.status.success(), "json variant should exit 0");
+
+    let yaml_out = fixture
+        .cmd()
+        .args(["cost", "forecast", "--output", "yaml"])
+        .output()
+        .expect("aasm cost forecast --output yaml should execute");
+    assert!(yaml_out.status.success(), "yaml variant should exit 0");
+
+    // `cost forecast` emits a single `CostForecastDisplay` object (not a
+    // collection), so structural object-equality is the right check.
+    assert_equivalent_objects(&json_out.stdout, &yaml_out.stdout);
+}

--- a/aa-integration-tests/tests/cli_cost.rs
+++ b/aa-integration-tests/tests/cli_cost.rs
@@ -27,7 +27,7 @@
 mod common;
 
 use common::cli::CliFixture;
-use common::format::assert_equivalent_objects;
+use common::format::{assert_equivalent_objects, parse_json};
 use rstest::rstest;
 
 // =============================================================================
@@ -238,4 +238,73 @@ async fn cost_forecast_json_and_yaml_describe_equivalent_object() {
     // `cost forecast` emits a single `CostForecastDisplay` object (not a
     // collection), so structural object-equality is the right check.
     assert_equivalent_objects(&json_out.stdout, &yaml_out.stdout);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cost_forecast_structural_assertion_after_seed() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    // Seed enough spend that the projection is non-trivial. We never assert
+    // exact projected numbers (per AC: "Do NOT assert exact numbers — the
+    // forecasting algorithm may evolve") — only structural properties.
+    let agent_id = fixture.seed_agents(1)[0];
+    fixture.seed_cost_sample(agent_id, Some("topology-it"), "12.34");
+
+    let out = fixture
+        .cmd()
+        .args(["cost", "forecast", "--output", "json"])
+        .output()
+        .expect("aasm cost forecast --output json should execute");
+    assert!(out.status.success(), "should exit 0");
+
+    let v = parse_json(&out.stdout);
+
+    for field in [
+        "date",
+        "day_of_month",
+        "days_in_month",
+        "current_daily_spend",
+        "projected_monthly_spend",
+    ] {
+        assert!(
+            v.get(field).is_some(),
+            "forecast output should expose `{field}` field\nstdout:\n{v}",
+        );
+    }
+
+    let day_of_month = v["day_of_month"].as_u64().expect("day_of_month should be an integer");
+    let days_in_month = v["days_in_month"].as_u64().expect("days_in_month should be an integer");
+    assert!(
+        (1..=31).contains(&day_of_month),
+        "day_of_month should be 1..=31, got {day_of_month}",
+    );
+    assert!(
+        (28..=31).contains(&days_in_month),
+        "days_in_month should be 28..=31, got {days_in_month}",
+    );
+
+    let projected: f64 = v["projected_monthly_spend"]
+        .as_str()
+        .expect("projected_monthly_spend should be a string")
+        .parse()
+        .expect("projected_monthly_spend should parse as f64");
+    let current: f64 = v["current_daily_spend"]
+        .as_str()
+        .expect("current_daily_spend should be a string")
+        .parse()
+        .expect("current_daily_spend should parse as f64");
+    assert!(
+        projected >= 0.0,
+        "projected_monthly_spend should be non-negative, got {projected}"
+    );
+    assert!(
+        current >= 0.0,
+        "current_daily_spend should be non-negative, got {current}"
+    );
+    // Trivial sanity: projection over a full month should be at least the
+    // single-day spend (algorithm-agnostic — anything less means a bug).
+    assert!(
+        projected >= current,
+        "projected_monthly_spend ({projected}) should not be smaller than current_daily_spend ({current})",
+    );
 }

--- a/aa-integration-tests/tests/cli_cost.rs
+++ b/aa-integration-tests/tests/cli_cost.rs
@@ -104,3 +104,30 @@ async fn cost_summary_json_and_yaml_describe_equivalent_object() {
     // collection), so structural object-equality is the right check here.
     assert_equivalent_objects(&json_out.stdout, &yaml_out.stdout);
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cost_summary_period_month_switches_rendered_label() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["cost", "summary", "--period", "month"])
+        .output()
+        .expect("aasm cost summary --period month should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Monthly spend"),
+        "--period month should render `Monthly spend` instead of `Daily spend`\nstdout:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("COST SUMMARY (Monthly)"),
+        "section header should carry the period label\nstdout:\n{stdout}",
+    );
+}

--- a/aa-integration-tests/tests/cli_cost.rs
+++ b/aa-integration-tests/tests/cli_cost.rs
@@ -131,3 +131,36 @@ async fn cost_summary_period_month_switches_rendered_label() {
         "section header should carry the period label\nstdout:\n{stdout}",
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cost_summary_group_by_agent_renders_per_agent_table_after_seed() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    // Seed one agent with $8.10 of spend so the per-agent table has at
+    // least one row to render. Without seeded spend, `render_agent_table`
+    // is skipped (early-return on empty `per_agent`).
+    let agent_id = fixture.seed_agents(1)[0];
+    fixture.seed_cost_sample(agent_id, Some("topology-it"), "8.10");
+
+    let out = fixture
+        .cmd()
+        .args(["cost", "summary", "--group-by", "agent"])
+        .output()
+        .expect("aasm cost summary --group-by agent should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("AGENT_ID"),
+        "--group-by agent should render the per-agent table header `AGENT_ID`\nstdout:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("DAILY_SPEND"),
+        "per-agent table should include `DAILY_SPEND` column\nstdout:\n{stdout}",
+    );
+}

--- a/aa-integration-tests/tests/cli_cost.rs
+++ b/aa-integration-tests/tests/cli_cost.rs
@@ -164,3 +164,34 @@ async fn cost_summary_group_by_agent_renders_per_agent_table_after_seed() {
         "per-agent table should include `DAILY_SPEND` column\nstdout:\n{stdout}",
     );
 }
+
+// =============================================================================
+// aasm cost forecast
+// =============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cost_forecast_happy_path_renders_projection() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["cost", "forecast"])
+        .output()
+        .expect("aasm cost forecast should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("COST FORECAST"),
+        "stdout should contain the section header\nstdout:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("Projected monthly"),
+        "stdout should mention `Projected monthly` label\nstdout:\n{stdout}",
+    );
+}

--- a/aa-integration-tests/tests/cli_cost.rs
+++ b/aa-integration-tests/tests/cli_cost.rs
@@ -1,0 +1,60 @@
+//! CLI integration tests for `aasm cost` (AAASM-1470 / F121 ST-14).
+//!
+//! Exercises the `cost summary` and `cost forecast` leaves against a live
+//! in-process gateway booted via [`CliFixture`]. Spend state is seeded
+//! directly into the gateway's `BudgetTracker` via
+//! [`CliFixture::seed_cost_sample`] — the gateway exposes no HTTP route
+//! for recording cost samples, so direct insertion is the test-only
+//! equivalent (same pattern as registry + trace-store seeding).
+//!
+//! ## Leaf surface (from `aa-cli/src/commands/cost/`)
+//!
+//! | Leaf | Args | Flags | Output shape |
+//! | --- | --- | --- | --- |
+//! | summary | — | `--period {today,month}`, `--group-by agent` | nested `CostSummaryDisplay` |
+//! | forecast | — | _(none)_ | nested `CostForecastDisplay` |
+//!
+//! ## AC vs implementation
+//!
+//! AAASM-1470 originally described flags `--team`, `--since`, `--until`,
+//! `--horizon` that do not exist in the current `aa-cli` cost surface,
+//! and a `seed_cost_sample` helper that had to be added by this ST. The
+//! tests here cover what the CLI actually exposes today: `--period`,
+//! `--group-by agent`, structural forecast assertions, and cross-format
+//! equivalence. Missing flags would be CLI-surface changes outside the
+//! scope of an integration-test ST.
+
+mod common;
+
+use common::cli::CliFixture;
+
+// =============================================================================
+// aasm cost summary
+// =============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cost_summary_happy_path_renders_daily_spend() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["cost", "summary"])
+        .output()
+        .expect("aasm cost summary should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("COST SUMMARY"),
+        "stdout should contain the section header\nstdout:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("Daily spend"),
+        "stdout should mention `Daily spend` for the default --period today\nstdout:\n{stdout}",
+    );
+}

--- a/aa-integration-tests/tests/cli_cost.rs
+++ b/aa-integration-tests/tests/cli_cost.rs
@@ -27,6 +27,7 @@
 mod common;
 
 use common::cli::CliFixture;
+use common::format::assert_equivalent_objects;
 use rstest::rstest;
 
 // =============================================================================
@@ -79,4 +80,27 @@ async fn cost_summary_succeeds_for_every_output_format(#[case] fmt: &str) {
         String::from_utf8_lossy(&out.stderr),
     );
     assert!(!out.stdout.is_empty(), "{fmt} stdout should not be empty");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn cost_summary_json_and_yaml_describe_equivalent_object() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let json_out = fixture
+        .cmd()
+        .args(["cost", "summary", "--output", "json"])
+        .output()
+        .expect("aasm cost summary --output json should execute");
+    assert!(json_out.status.success(), "json variant should exit 0");
+
+    let yaml_out = fixture
+        .cmd()
+        .args(["cost", "summary", "--output", "yaml"])
+        .output()
+        .expect("aasm cost summary --output yaml should execute");
+    assert!(yaml_out.status.success(), "yaml variant should exit 0");
+
+    // `cost summary` emits a single `CostSummaryDisplay` object (not a
+    // collection), so structural object-equality is the right check here.
+    assert_equivalent_objects(&json_out.stdout, &yaml_out.stdout);
 }

--- a/aa-integration-tests/tests/cli_cost.rs
+++ b/aa-integration-tests/tests/cli_cost.rs
@@ -195,3 +195,24 @@ async fn cost_forecast_happy_path_renders_projection() {
         "stdout should mention `Projected monthly` label\nstdout:\n{stdout}",
     );
 }
+
+#[rstest]
+#[case::json("json")]
+#[case::yaml("yaml")]
+#[case::table("table")]
+#[tokio::test(flavor = "multi_thread")]
+async fn cost_forecast_succeeds_for_every_output_format(#[case] fmt: &str) {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["cost", "forecast", "--output", fmt])
+        .output()
+        .expect("aasm cost forecast should execute");
+    assert!(
+        out.status.success(),
+        "{fmt} should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(!out.stdout.is_empty(), "{fmt} stdout should not be empty");
+}

--- a/aa-integration-tests/tests/common/cli.rs
+++ b/aa-integration-tests/tests/common/cli.rs
@@ -31,6 +31,7 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::str::FromStr;
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -40,6 +41,7 @@ use aa_core::{AgentId, AuditEntry, SessionId};
 use aa_gateway::registry::{AgentRecord, AgentStatus};
 use aa_runtime::approval::{ApprovalRequest, ApprovalRequestId};
 use chrono::{Duration as ChronoDuration, Utc};
+use rust_decimal::Decimal;
 use tempfile::TempDir;
 use uuid::Uuid;
 
@@ -357,6 +359,22 @@ impl CliFixture {
                 .record_span(session_id, agent_id, span)
                 .expect("seed_trace_session: record_span should succeed");
         }
+    }
+
+    /// Seed one cost sample for the given agent (and optionally its team)
+    /// into the shared `BudgetTracker`. The amount is parsed as a decimal
+    /// USD string (e.g. `"8.10"`) so callers can express precise figures
+    /// without floating-point round-tripping.
+    ///
+    /// Used by `cli_cost.rs` (AAASM-1470 / F121 ST-14) to populate spend
+    /// state before invoking `aasm cost summary` / `cost forecast`. The
+    /// gateway exposes no HTTP route for recording cost samples, so direct
+    /// insertion is the test-only equivalent — same pattern as
+    /// `seed_agent_with` (registry) and `seed_trace_session` (trace store).
+    pub fn seed_cost_sample(&self, agent_id: [u8; 16], team_id: Option<&str>, usd: &str) {
+        let amount = Decimal::from_str(usd).expect("seed_cost_sample: invalid USD amount");
+        let agent_id = AgentId::from_bytes(agent_id);
+        self.env.budget_tracker.record_raw_spend(agent_id, team_id, amount);
     }
 }
 

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -79,6 +79,15 @@ pub struct TopologyTestEnv {
     /// Exposed so per-leaf seed helpers (e.g. `CliFixture::seed_audit_events`)
     /// can write entries that the `aasm logs` snapshot path observes.
     pub audit_dir: PathBuf,
+    /// Shared budget tracker. Exposed so the `aasm cost` CLI integration
+    /// tests (AAASM-1470 / ST-14) can seed per-agent / per-team spend
+    /// directly via `BudgetTracker::record_raw_spend` — the gateway exposes
+    /// no HTTP route for recording cost samples, so direct insertion is
+    /// the test-only equivalent (same pattern as `agent_registry` and
+    /// `trace_store`). Matches the ST-0 design note that downstream cost
+    /// ST adds its own seed plumbing against the resource it touches.
+    #[allow(dead_code)]
+    pub budget_tracker: Arc<BudgetTracker>,
     /// Trigger to stop the background axum task.
     shutdown_tx: Option<oneshot::Sender<()>>,
     /// Handle for the spawned axum task; awaited during teardown.
@@ -97,6 +106,7 @@ impl TopologyTestEnv {
         let agent_registry = Arc::clone(&state.agent_registry);
         let trace_store = Arc::clone(&state.trace_store);
         let approval_queue = Arc::clone(&state.approval_queue);
+        let budget_tracker = Arc::clone(&state.budget_tracker);
 
         let port = portpicker::pick_unused_port().ok_or_else(|| anyhow::anyhow!("no free TCP port"))?;
         let addr: SocketAddr = format!("127.0.0.1:{port}").parse()?;
@@ -120,6 +130,7 @@ impl TopologyTestEnv {
             trace_store,
             approval_queue,
             audit_dir,
+            budget_tracker,
             shutdown_tx: Some(shutdown_tx),
             server_handle: Some(server_handle),
             cleaned: false,


### PR DESCRIPTION
## Description

Adds `aa-integration-tests/tests/cli_cost.rs` — integration tests for the
two leaves of `aasm cost` (`summary` and `forecast`) against a live
in-process gateway booted via `CliFixture`, plus the cost-seed plumbing
required to seed spend state (the gateway exposes no HTTP route for
recording cost samples).

### Test fns (9 fns, 13 parametrized cases)

**`aasm cost summary`**

1. `cost_summary_happy_path_renders_daily_spend` — default `--period today`, table output, `COST SUMMARY` + `Daily spend` headers present.
2. `cost_summary_succeeds_for_every_output_format` — `#[rstest]` over `json` / `yaml` / `table`; each format exits 0.
3. `cost_summary_json_and_yaml_describe_equivalent_object` — `assert_equivalent_objects` for cross-format structural equivalence (single-object endpoint, not a collection).
4. `cost_summary_period_month_switches_rendered_label` — `--period month` flips `Daily spend` → `Monthly spend` and the section header to `COST SUMMARY (Monthly)`.
5. `cost_summary_group_by_agent_renders_per_agent_table_after_seed` — seeds one agent + one cost sample via the new `seed_cost_sample` helper, asserts the `AGENT_ID` / `DAILY_SPEND` table columns render.

**`aasm cost forecast`**

6. `cost_forecast_happy_path_renders_projection` — table output, `COST FORECAST` + `Projected monthly` labels present.
7. `cost_forecast_succeeds_for_every_output_format` — `#[rstest]` over json/yaml/table.
8. `cost_forecast_json_and_yaml_describe_equivalent_object` — `assert_equivalent_objects` equivalence.
9. `cost_forecast_structural_assertion_after_seed` — seeds spend; asserts only structural properties (per AC: never assert exact projected numbers): all expected schema fields present, `day_of_month ∈ 1..=31`, `days_in_month ∈ 28..=31`, both `current_daily_spend` and `projected_monthly_spend` are non-negative, projected ≥ current_daily.

### Cost-seed plumbing (separate infrastructure commit)

* `pub budget_tracker: Arc<BudgetTracker>` exposed on `TopologyTestEnv`, plumbed through `start()` (same pattern as the existing `agent_registry` / `trace_store` fields).
* `CliFixture::seed_cost_sample(agent_id, team_id, usd)` drives `BudgetTracker::record_raw_spend` directly. USD takes a string (`"8.10"`) so callers avoid float round-trip drift.
* `rust_decimal` added as a dev-dep so the helper can parse the USD string into a `Decimal`.
* Aligned with the ST-0 design note that downstream per-resource STs add their own seed plumbing (same pattern as AAASM-1468's trace-store seed).

## AC re-scope note

The ticket's AC was written against a `cost` CLI surface that does not match the current implementation. Confirmed by walking `aa-cli/src/commands/cost/{mod,summary,forecast}.rs` and `aa-api/src/routes/costs.rs`.

| AC test category | Actual surface | Adapted |
| --- | --- | --- |
| `summary --team <id>` filter | `--team` does not exist | Replaced with `--group-by agent` |
| `summary --since 7d` / `--until <ts>` | Neither flag exists; `GET /api/v1/costs` takes no params | Dropped; added `--period today/month` instead |
| `summary --team --since --until` combined | n/a | Dropped |
| `forecast --horizon 7d/30d` | `ForecastArgs {}` is empty | Dropped horizon-specific tests |
| Negative path `summary --team <unknown>` | n/a | Dropped |
| `assert_equivalent_records()` per AC | Single-object output, not a collection | Used `assert_equivalent_objects` instead |

The missing flags would be CLI-surface changes, outside the scope of an integration-test ST.

## Type of Change

- [x] ✨ New feature (test coverage + minimal test-only seed plumbing)
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade — _new dev-dep only: `rust_decimal`_
- [ ] 🚀 Release

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1470 (parent Story AAASM-1258)

## Testing

- [x] Integration tests added
- [x] All passing locally

```
cargo nextest run -p aa-integration-tests --test cli_cost
Starting 13 tests across 1 binary
... 13 PASS
Summary [  17.064s] 13 tests run: 13 passed, 0 skipped
```

## Checklist

- [x] `cargo fmt`, `cargo clippy` clean
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed — N/A
- [ ] All CI checks passing — _pending CI_
- [x] Commits are small and follow the Gitmoji convention (10 commits: 1 infra + 9 test fns; one logical unit per commit)