### PR TITLE
[AAASM-1473] ✅ (aa-integration-tests): Add cli_tools.rs integration tests

### DIFF
--- a/aa-integration-tests/tests/cli_tools.rs
+++ b/aa-integration-tests/tests/cli_tools.rs
@@ -75,3 +75,85 @@ async fn tools_list_exits_zero_and_emits_friendly_message_or_full_table() {
          column headers (TOOL/VERSION/PATH/GOVERNANCE LEVEL); got:\n{stdout}",
     );
 }
+
+// ============================================================================
+// aasm tools — help banners
+// ============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn tools_list_help_describes_purpose() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["tools", "list", "--help"])
+        .output()
+        .expect("aasm tools list --help should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // Sourced from the `/// List all discovered AI dev tools on this system.`
+    // doc-comment on `ToolsSubcommand::List` in `aa-cli/src/commands/tools.rs`.
+    assert!(
+        stdout.contains("List all discovered AI dev tools"),
+        "list-leaf help should describe its purpose; got:\n{stdout}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn tools_subcommand_help_lists_list_leaf() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["tools", "--help"])
+        .output()
+        .expect("aasm tools --help should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // The Commands section of `tools --help` enumerates available leaves;
+    // catches accidental removal/renaming of the `list` leaf.
+    let commands_section_has_list = stdout
+        .lines()
+        .skip_while(|l| !l.starts_with("Commands:"))
+        .take(10)
+        .any(|l| l.trim_start().starts_with("list "));
+    assert!(
+        commands_section_has_list,
+        "`tools --help` Commands section should enumerate the `list` leaf; got:\n{stdout}",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn tools_subcommand_help_uses_qualified_name_and_describes_group() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["tools", "--help"])
+        .output()
+        .expect("aasm tools --help should execute");
+    assert!(out.status.success(), "should exit 0");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // Catches an accidental rename of the parent subcommand (e.g.
+    // tools→devtools). Sourced from the `Usage: aasm tools …` clap line
+    // plus the parent doc-comment "List and manage AI dev tools on this
+    // system".
+    assert!(
+        stdout.contains("aasm tools"),
+        "banner should contain the qualified subcommand name 'aasm tools'; got:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("List and manage AI dev tools"),
+        "parent help should describe the group's purpose; got:\n{stdout}",
+    );
+}

--- a/aa-integration-tests/tests/cli_tools.rs
+++ b/aa-integration-tests/tests/cli_tools.rs
@@ -1,0 +1,77 @@
+//! CLI integration tests for `aasm tools` (AAASM-1473 / F121 ST-17).
+//!
+//! Covers the single shipped leaf `aasm tools list` plus the parent
+//! subcommand's help text. No gateway interaction — `tools list`
+//! discovers AI dev tools on the local filesystem. `CliFixture` is
+//! still used for harness contract uniformity across `cli_*.rs` files
+//! (per AAASM-1258 test-design rule "All tests use the shared
+//! `CliFixture` — no per-test-file gateway boot helpers"), even though
+//! the in-process gateway it boots is unused here.
+//!
+//! ## Divergence from subtask description
+//!
+//! AAASM-1473's description was drafted against a planned `--output`-aware
+//! tools surface that does not exist in `aa-cli/src/commands/tools.rs` on
+//! master:
+//!
+//! * The leaf emits a hard-coded `comfy_table` with columns
+//!   `TOOL | VERSION | PATH | GOVERNANCE LEVEL`. The global `--output`
+//!   flag is ignored — no JSON/YAML emission. Therefore the AC's
+//!   `assert_equivalent_records()`-based per-format tests are not
+//!   applicable and are not implemented here.
+//! * The list contains only *detected* tools, not the four canonical
+//!   names always. On a clean system (CI runner) the output is the
+//!   friendly message `"No AI dev tools detected on this system."`;
+//!   on a populated dev box the table appears with `ClaudeCode` /
+//!   `Codex` / `GitHubCopilot` / `Windsurf` rows (`DevToolKind` debug
+//!   format, not lowercase as the ticket assumes).
+//!
+//! Tests below tolerate both branches so the file is green on both CI
+//! (empty) and a dev-machine (populated).
+//!
+//! Adding the missing `--output` JSON/YAML support to `tools list` is a
+//! worthwhile follow-up but is production work that should land in its
+//! own ticket; out of scope here.
+
+mod common;
+
+use common::cli::CliFixture;
+
+// ============================================================================
+// aasm tools list — happy path
+// ============================================================================
+
+/// Canonical column headers emitted by `tools list` when the table branch
+/// runs (i.e. at least one tool was detected). Kept here so the assertion
+/// fails loudly if the column set changes upstream.
+const TABLE_HEADERS: [&str; 4] = ["TOOL", "VERSION", "PATH", "GOVERNANCE LEVEL"];
+
+/// Friendly message printed by `tools list` when no tools were detected.
+/// Must match the literal in `aa-cli/src/commands/tools.rs::execute_list()`.
+const EMPTY_MESSAGE: &str = "No AI dev tools detected on this system.";
+
+#[tokio::test(flavor = "multi_thread")]
+async fn tools_list_exits_zero_and_emits_friendly_message_or_full_table() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+
+    let out = fixture
+        .cmd()
+        .args(["tools", "list"])
+        .output()
+        .expect("aasm tools list should execute");
+    assert!(
+        out.status.success(),
+        "should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    let is_empty_branch = stdout.contains(EMPTY_MESSAGE);
+    let is_table_branch = TABLE_HEADERS.iter().all(|h| stdout.contains(h));
+    assert!(
+        is_empty_branch || is_table_branch,
+        "stdout must be either the empty friendly message OR the full table with all four \
+         column headers (TOOL/VERSION/PATH/GOVERNANCE LEVEL); got:\n{stdout}",
+    );
+}


### PR DESCRIPTION
## Description

Adds `aa-integration-tests/tests/cli_tools.rs` — 4 `#[tokio::test]` cases covering the single shipped `aasm tools list` leaf plus the parent subcommand's help text, written against the actual master surface.

Implements AAASM-1473 (F121 ST-17 under Story [AAASM-1258](https://lightning-dust-mite.atlassian.net/browse/AAASM-1258) → Epic [AAASM-1199](https://lightning-dust-mite.atlassian.net/browse/AAASM-1199)).

### Significant spec ↔ code divergence (test-only resolution; no production code change)

The subtask description was drafted against a planned `--output`-aware tools surface that doesn't exist in `aa-cli/src/commands/tools.rs` (165-line single file on master):

| Description says | Master actually has |
|---|---|
| `tools list` emits per-tool `{name, installed: bool, version, path}` JSON | Hard-coded `comfy_table` with columns `TOOL \| VERSION \| PATH \| GOVERNANCE LEVEL` only |
| `--output {json\|yaml\|table}` honored on `tools list` | Global `--output` flag exists on `Cli` but `execute_list()` **ignores it** — unconditionally `println!("{table}")` |
| Always lists 4 canonical tools (claude/codex/copilot/windsurf) with `installed=true/false` | Only lists **detected** tools; empty system → `"No AI dev tools detected on this system."` + exit 0 |
| 5 `#[rstest]` tests using `assert_equivalent_records()` | Not satisfiable — no JSON/YAML stream to compare |
| Tool names are lowercase `claude` / `codex` / `copilot` / `windsurf` | Source uses `DevToolKind` `{:?}` debug format: `ClaudeCode` / `Codex` / `GitHubCopilot` / `Windsurf` |

Adding the missing `--output` JSON/YAML support to `tools list` is a worthwhile follow-up but is production work that belongs in its own ticket; **not bundled here**.

See the AAASM-1473 starting-work comment for the full reconciliation and a captured snapshot of `aasm tools list` output on a populated dev box.

### Tests

| Test | What it checks |
|---|---|
| `tools_list_exits_zero_and_emits_friendly_message_or_full_table` | Exit 0; stdout matches *either* the literal empty-message *or* the table with all four canonical headers — tolerates both CI (empty) and dev-machine (populated) |
| `tools_list_help_describes_purpose` | `tools list --help` contains `"List all discovered AI dev tools"` |
| `tools_subcommand_help_lists_list_leaf` | `tools --help` Commands section enumerates the `list` leaf (catches accidental removal/rename) |
| `tools_subcommand_help_uses_qualified_name_and_describes_group` | `tools --help` contains qualified `aasm tools` token + group purpose `"List and manage AI dev tools"` |

Column-header set and friendly-message literal are extracted into module constants so an upstream rename in `execute_list()` fails the test with a self-explanatory diff.

### Commit breakdown

| Commit | Scope | Tests |
|---|---|---|
| `451ecb0a ✅ (aa-integration-tests): Add cli_tools list happy-path test` | scaffold + dual-branch-tolerant `list` happy path | 1 |
| `bcb8584d ✅ (aa-integration-tests): Add cli_tools help-banner smoke tests` | 3 help-text assertions | 3 |

## Type of Change

- [x] ✅ Tests (integration test addition)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-1473](https://lightning-dust-mite.atlassian.net/browse/AAASM-1473) (this subtask)
- Parent Story: [AAASM-1258](https://lightning-dust-mite.atlassian.net/browse/AAASM-1258) (F121 — `aasm` CLI integration tests)
- Parent Epic: [AAASM-1199](https://lightning-dust-mite.atlassian.net/browse/AAASM-1199) (Release & Distribution Pipeline)

## Testing

- [x] Integration tests added — 4 `#[tokio::test]` cases in `aa-integration-tests/tests/cli_tools.rs`
- [x] Manual testing — `cargo nextest run -p aa-integration-tests --test cli_tools` locally

### Local run summary

```
Starting 4 tests across 1 binary
        PASS [   8.923s] (1/4) tools_list_help_describes_purpose
        PASS [   8.939s] (2/4) tools_subcommand_help_lists_list_leaf
        PASS [   8.939s] (3/4) tools_subcommand_help_uses_qualified_name_and_describes_group
        PASS [   8.998s] (4/4) tools_list_exits_zero_and_emits_friendly_message_or_full_table
Summary [   8.998s] 4 tests run: 4 passed, 0 skipped
```

Verified on a populated dev box (3 of 4 canonical tools detected — `ClaudeCode` / `Codex` / `GitHubCopilot`). CI will hit the empty-branch path; the dual-branch tolerance keeps both green.

## Future follow-up (not in scope here)

Adding the missing `--output` JSON/YAML support to `tools list` so the ticket's full spec (`{name, installed, version, path}` per tool, always-listed 4 canonicals, `assert_equivalent_records()` per-format equivalence) becomes testable. Production work — file as a sibling subtask under AAASM-1258 when prioritized.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` clean per pre-commit hooks on every commit)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (module rustdoc documents the divergence + dual-branch tolerance + deferred follow-up)
- [ ] All CI checks passing (will be confirmed once GitHub Actions runs)
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1258]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1199]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1473]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ