### PR TITLE
[AAASM-1472] ♻️ (aa-cli): Refactor run --dry-run short-circuit + ✅ cli_run integration tests

### DIFF
--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -246,6 +246,29 @@ fn build_child_env(handle: &RegistrationHandle, no_proxy: bool) -> HashMap<Strin
     env
 }
 
+/// Synthesize a `RegistrationHandle` for `--dry-run` without contacting the
+/// gateway. Used by the dry-run short-circuit so the planning preview works
+/// in CI runners where no AI dev tool is installed and no gateway is reachable.
+///
+/// All identity fields are prefixed `dry-run-` to make it obvious in stdout
+/// that no real registration occurred. The caller-supplied `--agent-id` /
+/// `--team-id` overrides are honored verbatim so the printed plan reflects
+/// what the live run *would* have submitted.
+fn dry_run_handle(args: &RunArgs) -> RegistrationHandle {
+    let agent_id = args
+        .agent_id
+        .clone()
+        .unwrap_or_else(|| format!("dry-run-{}", Uuid::new_v4()));
+    RegistrationHandle {
+        agent_id,
+        registration_id: format!("dry-run-{}", Uuid::new_v4()),
+        trace_id: format!("dry-run-{}", Uuid::new_v4()),
+        session_id: format!("dry-run-{}", Uuid::new_v4()),
+        proxy_addr: None,
+        team_id: args.team_id.clone(),
+    }
+}
+
 /// Construct a default policy document used until a real loader is wired in.
 fn load_policy() -> PolicyDocument {
     PolicyDocument {
@@ -378,6 +401,11 @@ async fn spawn_and_wait(cmd: std::process::Command, child_env: &HashMap<String, 
 /// Testable core of `execute`: detect, register, apply settings, spawn child.
 ///
 /// Returns the child process exit code, or 0 on `--dry-run`.
+///
+/// `--dry-run` short-circuits *before* `adapter.detect()` and
+/// `register_with_gateway()` so the planning preview works even when no AI
+/// dev tool is installed and no gateway is reachable (e.g. CI runners). The
+/// printed plan reflects what the live run *would* do with the same flags.
 pub async fn execute_with_adapters(
     args: &RunArgs,
     ctx: &ResolvedContext,
@@ -389,6 +417,17 @@ pub async fn execute_with_adapters(
             args.tool
         )
     })?;
+
+    if args.dry_run {
+        let handle = dry_run_handle(args);
+        let child_env = build_child_env(&handle, args.no_proxy);
+        let settings = "<dry-run: managed settings not generated>".to_string();
+        let mut cmd = std::process::Command::new(&args.tool);
+        cmd.args(&args.tool_args);
+        cmd.envs(&child_env);
+        print!("{}", format_dry_run_output(&handle, &settings, &cmd, &child_env));
+        return Ok(0);
+    }
 
     let info = adapter
         .detect()
@@ -411,12 +450,10 @@ pub async fn execute_with_adapters(
         .await
         .map_err(|e| anyhow::anyhow!("failed to generate managed settings: {e}"))?;
 
-    if !args.dry_run {
-        adapter
-            .apply_settings(&settings)
-            .await
-            .map_err(|e| anyhow::anyhow!("failed to apply settings: {e}"))?;
-    }
+    adapter
+        .apply_settings(&settings)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to apply settings: {e}"))?;
 
     let mut cmd = adapter
         .build_launch_command(
@@ -427,11 +464,6 @@ pub async fn execute_with_adapters(
         )
         .map_err(|e| anyhow::anyhow!("failed to build launch command: {e}"))?;
     cmd.envs(&child_env);
-
-    if args.dry_run {
-        print!("{}", format_dry_run_output(&handle, &settings, &cmd, &child_env));
-        return Ok(0);
-    }
 
     let mut guard = RegistrationGuard {
         registration_id: handle.registration_id.clone(),
@@ -923,6 +955,27 @@ mod tests {
     }
 
     // --- dry-run tests ---
+
+    #[tokio::test]
+    async fn dry_run_short_circuits_before_adapter_detect_and_gateway() {
+        // Adapter whose detect() returns None and whose other methods panic
+        // — proves --dry-run skips detect / generate_managed_settings /
+        // apply_settings / build_launch_command. The dummy ctx points at a
+        // port nothing's listening on; if --dry-run touched the gateway the
+        // POST would fail and the test would too.
+        let mut adapters: HashMap<&str, Box<dyn DevToolAdapter>> = HashMap::new();
+        adapters.insert("claude", Box::new(StubNotInstalled));
+
+        let mut args = run_args("claude");
+        args.dry_run = true;
+
+        let result = execute_with_adapters(&args, &dummy_ctx(), &adapters).await;
+        assert!(
+            result.is_ok(),
+            "--dry-run should succeed without detect() or gateway: {result:?}",
+        );
+        assert_eq!(result.unwrap(), 0, "--dry-run should exit 0");
+    }
 
     #[tokio::test]
     async fn dry_run_does_not_apply_settings() {

--- a/aa-integration-tests/tests/cli_run.rs
+++ b/aa-integration-tests/tests/cli_run.rs
@@ -1,0 +1,83 @@
+//! CLI integration tests for `aasm run` (AAASM-1472 / F121 ST-16).
+//!
+//! Exercises the `aasm run <tool> [args...]` launcher in `--dry-run` mode
+//! against the actual `aa-cli` binary. The companion refactor in
+//! `aa-cli/src/commands/run.rs::execute_with_adapters` short-circuits
+//! `--dry-run` before `adapter.detect()` and `register_with_gateway()`, so
+//! these tests work on CI runners where no AI dev tool is installed and
+//! no gateway is reachable.
+//!
+//! ## Surface vs. AC
+//!
+//! Three flag-name AC deviations (source-authoritative resolution):
+//!
+//! * AC says `--tool <name>` — source actually takes the tool as a
+//!   positional `<tool>` argument (e.g. `aasm run claude --dry-run`).
+//! * AC says `--config <path>` — no such flag exists. No fixture file
+//!   created; the per-tool `--config` custom-config test is substituted
+//!   by an `--agent-id` override test.
+//! * AC says a mutual-exclusion case (`--tool X --command Y`) — no
+//!   `--command` flag exists; this test is dropped.
+//!
+//! Net = 9 tests across help banner, missing-tool clap error, per-tool
+//! `--dry-run` (`#[rstest]` × 4), `--agent-id` override, unknown-tool
+//! error, and trailing `tool_args` echo.
+//!
+//! ## Why no `CliFixture`
+//!
+//! After the dry-run short-circuit refactor, `aasm run --dry-run` makes no
+//! HTTP calls and requires no live gateway. Tests construct the
+//! `cargo run -p aa-cli --bin aasm -- run …` command by hand.
+
+use std::process::Command;
+
+/// Build a fresh `cargo run` command for `aasm run …` invocations. Inherits
+/// the integration-test crate's cargo so the workspace lockfile is reused.
+fn aasm_cmd() -> Command {
+    let mut cmd = Command::new(env!("CARGO"));
+    cmd.args(["run", "--quiet", "-p", "aa-cli", "--bin", "aasm", "--"]);
+    cmd
+}
+
+// =============================================================================
+// aasm run --help
+// =============================================================================
+
+#[test]
+fn run_help_exits_zero_and_lists_the_four_supported_tools() {
+    let out = aasm_cmd()
+        .args(["run", "--help"])
+        .output()
+        .expect("aasm run --help should execute");
+
+    assert!(
+        out.status.success(),
+        "run --help should exit 0\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    for tool in ["claude", "codex", "copilot", "windsurf"] {
+        assert!(
+            stdout.contains(tool),
+            "run --help banner should mention `{tool}`:\n{stdout}",
+        );
+    }
+}
+
+#[test]
+fn run_without_positional_tool_fails_with_clap_usage_error() {
+    let out = aasm_cmd().arg("run").output().expect("aasm run should execute");
+
+    assert!(
+        !out.status.success(),
+        "run with no tool should fail; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("required") || stderr.contains("Usage"),
+        "stderr should surface a clap usage error:\n{stderr}",
+    );
+}

--- a/aa-integration-tests/tests/cli_run.rs
+++ b/aa-integration-tests/tests/cli_run.rs
@@ -31,6 +31,8 @@
 
 use std::process::Command;
 
+use rstest::rstest;
+
 /// Build a fresh `cargo run` command for `aasm run …` invocations. Inherits
 /// the integration-test crate's cargo so the workspace lockfile is reused.
 fn aasm_cmd() -> Command {
@@ -79,5 +81,41 @@ fn run_without_positional_tool_fails_with_clap_usage_error() {
     assert!(
         stderr.contains("required") || stderr.contains("Usage"),
         "stderr should surface a clap usage error:\n{stderr}",
+    );
+}
+
+// =============================================================================
+// aasm run <tool> --dry-run
+// =============================================================================
+
+#[rstest]
+#[case::claude("claude")]
+#[case::codex("codex")]
+#[case::copilot("copilot")]
+#[case::windsurf("windsurf")]
+fn run_dry_run_succeeds_for_every_supported_tool(#[case] tool: &str) {
+    let out = aasm_cmd()
+        .args(["run", tool, "--dry-run"])
+        .output()
+        .expect("aasm run <tool> --dry-run should execute");
+
+    assert!(
+        out.status.success(),
+        "{tool} --dry-run should exit 0; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--- aasm run dry-run ---"),
+        "{tool} --dry-run should print the dry-run banner:\n{stdout}",
+    );
+    assert!(
+        stdout.contains("--- launch command ---"),
+        "{tool} --dry-run should print the launch command section:\n{stdout}",
+    );
+    assert!(
+        stdout.contains(tool),
+        "{tool} --dry-run plan should name the tool in the launch command:\n{stdout}",
     );
 }

--- a/aa-integration-tests/tests/cli_run.rs
+++ b/aa-integration-tests/tests/cli_run.rs
@@ -119,3 +119,82 @@ fn run_dry_run_succeeds_for_every_supported_tool(#[case] tool: &str) {
         "{tool} --dry-run plan should name the tool in the launch command:\n{stdout}",
     );
 }
+
+// =============================================================================
+// aasm run <unknown>
+// =============================================================================
+
+#[test]
+fn run_unknown_tool_fails_and_lists_all_supported_tools_on_stderr() {
+    let out = aasm_cmd()
+        .args(["run", "notathing", "--dry-run"])
+        .output()
+        .expect("aasm run notathing should execute");
+
+    assert!(
+        !out.status.success(),
+        "unknown tool should fail; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("unknown tool"),
+        "stderr should announce the unknown-tool error:\n{stderr}",
+    );
+    for tool in ["claude", "codex", "copilot", "windsurf"] {
+        assert!(
+            stderr.contains(tool),
+            "stderr should list `{tool}` among supported tools:\n{stderr}",
+        );
+    }
+}
+
+// =============================================================================
+// aasm run --agent-id <id> <tool> --dry-run
+// =============================================================================
+
+#[test]
+fn run_dry_run_honors_agent_id_override() {
+    let custom_id = "cli-it-custom-agent-id";
+    let out = aasm_cmd()
+        .args(["run", "--agent-id", custom_id, "claude", "--dry-run"])
+        .output()
+        .expect("aasm run --agent-id should execute");
+
+    assert!(
+        out.status.success(),
+        "--agent-id override should not affect exit code; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains(custom_id),
+        "dry-run plan should reflect the explicit --agent-id value:\n{stdout}",
+    );
+}
+
+// =============================================================================
+// aasm run <tool> --dry-run -- <trailing tool_args>
+// =============================================================================
+
+#[test]
+fn run_dry_run_echoes_trailing_tool_args_in_launch_command() {
+    let out = aasm_cmd()
+        .args(["run", "claude", "--dry-run", "--", "--some-flag", "value"])
+        .output()
+        .expect("aasm run with trailing args should execute");
+
+    assert!(
+        out.status.success(),
+        "trailing args should not affect exit code; stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("--some-flag") && stdout.contains("value"),
+        "launch command section should echo trailing tool_args:\n{stdout}",
+    );
+}


### PR DESCRIPTION
## Description

Two-part change for F121 Phase B ST-16:

1. **Refactor** (`aa-cli/src/commands/run.rs::execute_with_adapters`) — move the `args.dry_run` branch to the top of the function, *before* `adapter.detect()` and `register_with_gateway()`. Adds `dry_run_handle()` which synthesizes a `dry-run-`-prefixed `RegistrationHandle` without contacting the gateway, and constructs a conceptual `<tool> [tool_args...]` launch command instead of calling `adapter.build_launch_command()`. After this change, `aasm run <tool> --dry-run` succeeds when no AI dev tool is installed and no gateway is reachable — required for the integration tests to run on CI.

2. **Integration tests** (`aa-integration-tests/tests/cli_run.rs`, 9 new tests) exercising the actual surface of `aasm run` in `--dry-run` mode.

## Why the refactor is needed

Before this change, `execute_with_adapters` called `adapter.detect()` (which scans PATH / npm-global for a real installed binary) and `register_with_gateway()` (HTTP POST to the gateway) *before* the dry-run short-circuit. On CI runners none of the four supported tools is installed (`PlaceholderAdapter` for claude/copilot always returns `None`; `CodexAdapter`/`WindsurfCascadeAdapter` scan PATH for binaries that aren't there), so `aasm run <tool> --dry-run` consistently errored with "X is not installed" before reaching the dry-run print. The refactor makes `--dry-run` a true parser/planning preview — the printed plan still reflects what the live run *would* submit (custom `--agent-id`, `--team-id`, trailing `tool_args`, etc.).

Adds a new unit test (`dry_run_short_circuits_before_adapter_detect_and_gateway`) that locks in the no-detect / no-gateway behavior using `StubNotInstalled` + an unreachable ctx. All 16 previously-passing unit tests still pass.

## Integration tests added (9 tests)

* `run_help_exits_zero_and_lists_the_four_supported_tools`
* `run_without_positional_tool_fails_with_clap_usage_error`
* `run_dry_run_succeeds_for_every_supported_tool` — `#[rstest]` × {claude, codex, copilot, windsurf} (4 cases)
* `run_unknown_tool_fails_and_lists_all_supported_tools_on_stderr`
* `run_dry_run_honors_agent_id_override`
* `run_dry_run_echoes_trailing_tool_args_in_launch_command`

`cli_run.rs` doesn't use `CliFixture` — after the refactor, `aasm run --dry-run` is gateway-free.

## ⚠️ Scope deviations from the AAASM-1472 description (reconciled with reporter before coding)

1. **`aasm run --tool <name>` flag does not exist.** Source takes the tool as a positional `<tool>` arg (`aasm run claude --dry-run`, not `aasm run --dry-run --tool claude`). Tests use the positional syntax.
2. **`aasm run --config <path>` flag does not exist.** No fixture file was created under `tests/common/fixtures/run/`. The AC's "custom config" test is substituted by `run_dry_run_honors_agent_id_override`, which exercises the analogous override path via the real `--agent-id` flag.
3. **`aasm run --command <…>` flag for mutual-exclusion test does not exist.** Mutual-exclusion test dropped (no source-level pair to enforce).

Net = 9 tests, same as the AC count, mapped to the surface that actually exists.

## Type of Change

- [x] ♻️ Refactoring (with behaviour clarification: `--dry-run` now works without a real installed tool or gateway)
- [x] ✅ Tests added (9 integration tests + 1 unit test)

## Breaking Changes

- [x] No — `aasm run --dry-run` now succeeds in strictly more situations than before. No previously-passing path is affected.

## Related Issues

- Related Jira ticket: [AAASM-1472](https://lightning-dust-mite.atlassian.net/browse/AAASM-1472) (parent: [AAASM-1258](https://lightning-dust-mite.atlassian.net/browse/AAASM-1258) F121)

## Testing

- [x] `cargo nextest run -p aa-cli --lib commands::run` → 17/17 pass (includes the new `dry_run_short_circuits_before_adapter_detect_and_gateway` unit test)
- [x] `cargo nextest run -p aa-integration-tests --test cli_run` → 9/9 pass
- [x] Cross-binary regression: `--test cli_run --test cli_status --test cli_topology --test cli_agent --test cli_policy` → 89/89 pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo deny check` clean

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on `execute_with_adapters` calls out the dry-run short-circuit; rustdoc on `dry_run_handle` explains the synthesized identity)
- [x] All CI checks passing (local)
- [x] Commits are small and follow the Gitmoji convention (4 commits: 1 refactor, 3 test groups)

[AAASM-1472]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ