### PR TITLE
[AAASM-1476] 🐛 (aa-gateway): Accept snake_case categories in audit_reader event-type filter

### DIFF
--- a/aa-gateway/src/audit_reader.rs
+++ b/aa-gateway/src/audit_reader.rs
@@ -42,7 +42,7 @@ impl AuditReader {
 
         // Parse filter values once.
         let agent_filter: Option<AgentId> = agent_id.and_then(parse_agent_id);
-        let event_filter: Option<AuditEventType> = event_type.and_then(parse_event_type);
+        let event_filter: Option<Vec<AuditEventType>> = event_type.and_then(parse_event_type);
 
         // Apply filters.
         if agent_filter.is_some() || event_filter.is_some() {
@@ -52,8 +52,8 @@ impl AuditReader {
                         return false;
                     }
                 }
-                if let Some(et) = &event_filter {
-                    if entry.event_type() != *et {
+                if let Some(types) = &event_filter {
+                    if !types.contains(&entry.event_type()) {
                         return false;
                     }
                 }
@@ -116,18 +116,45 @@ fn parse_agent_id(s: &str) -> Option<AgentId> {
     Some(AgentId::from_bytes(arr))
 }
 
-/// Parse an event type string (e.g. `"PolicyViolation"`) into an [`AuditEventType`].
-fn parse_event_type(s: &str) -> Option<AuditEventType> {
+/// Parse an event-type filter string into the set of [`AuditEventType`] variants it matches.
+///
+/// Accepts two wire forms so both API consumers stay supported:
+///
+/// * **CamelCase variant name** (e.g. `"PolicyViolation"`, `"ApprovalGranted"`) →
+///   matches that single variant. Used by callers that already know which
+///   exact variant they want.
+/// * **snake_case category** (e.g. `"violation"`, `"approval"`, `"budget"`) →
+///   matches the whole family of related variants. Used by `aasm logs --type`,
+///   whose `LogEventType::as_api_str` emits these.
+///
+/// Returns `None` for unrecognised strings so the caller drops the filter
+/// rather than silently filtering against nothing.
+fn parse_event_type(s: &str) -> Option<Vec<AuditEventType>> {
+    use AuditEventType::*;
     match s {
-        "ToolCallIntercepted" => Some(AuditEventType::ToolCallIntercepted),
-        "PolicyViolation" => Some(AuditEventType::PolicyViolation),
-        "CredentialLeakBlocked" => Some(AuditEventType::CredentialLeakBlocked),
-        "ApprovalRequested" => Some(AuditEventType::ApprovalRequested),
-        "ApprovalGranted" => Some(AuditEventType::ApprovalGranted),
-        "ApprovalDenied" => Some(AuditEventType::ApprovalDenied),
-        "BudgetLimitApproached" => Some(AuditEventType::BudgetLimitApproached),
-        "BudgetLimitExceeded" => Some(AuditEventType::BudgetLimitExceeded),
-        "ApprovalTimedOut" => Some(AuditEventType::ApprovalTimedOut),
+        // CamelCase variant names (1:1).
+        "ToolCallIntercepted" => Some(vec![ToolCallIntercepted]),
+        "PolicyViolation" => Some(vec![PolicyViolation]),
+        "CredentialLeakBlocked" => Some(vec![CredentialLeakBlocked]),
+        "ApprovalRequested" => Some(vec![ApprovalRequested]),
+        "ApprovalGranted" => Some(vec![ApprovalGranted]),
+        "ApprovalDenied" => Some(vec![ApprovalDenied]),
+        "ApprovalTimedOut" => Some(vec![ApprovalTimedOut]),
+        "BudgetLimitApproached" => Some(vec![BudgetLimitApproached]),
+        "BudgetLimitExceeded" => Some(vec![BudgetLimitExceeded]),
+
+        // snake_case categories (1:N) — matches `aasm logs --type` wire form.
+        "violation" => Some(vec![PolicyViolation]),
+        "approval" => Some(vec![
+            ApprovalRequested,
+            ApprovalGranted,
+            ApprovalDenied,
+            ApprovalTimedOut,
+            ApprovalRouted,
+            ApprovalEscalated,
+        ]),
+        "budget" => Some(vec![BudgetLimitApproached, BudgetLimitExceeded]),
+
         _ => None,
     }
 }

--- a/aa-gateway/src/audit_reader.rs
+++ b/aa-gateway/src/audit_reader.rs
@@ -158,3 +158,51 @@ fn parse_event_type(s: &str) -> Option<Vec<AuditEventType>> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use AuditEventType::*;
+
+    #[test]
+    fn camel_case_variant_name_yields_singleton() {
+        assert_eq!(parse_event_type("PolicyViolation"), Some(vec![PolicyViolation]));
+        assert_eq!(parse_event_type("ApprovalGranted"), Some(vec![ApprovalGranted]));
+        assert_eq!(parse_event_type("BudgetLimitExceeded"), Some(vec![BudgetLimitExceeded]));
+    }
+
+    #[test]
+    fn snake_case_violation_matches_policy_violation() {
+        assert_eq!(parse_event_type("violation"), Some(vec![PolicyViolation]));
+    }
+
+    #[test]
+    fn snake_case_approval_matches_full_approval_family() {
+        let variants = parse_event_type("approval").expect("approval should parse");
+        for v in [
+            ApprovalRequested,
+            ApprovalGranted,
+            ApprovalDenied,
+            ApprovalTimedOut,
+            ApprovalRouted,
+            ApprovalEscalated,
+        ] {
+            assert!(variants.contains(&v), "expected {v:?} in `approval` family");
+        }
+        assert_eq!(variants.len(), 6, "approval should match exactly six variants");
+    }
+
+    #[test]
+    fn snake_case_budget_matches_both_budget_variants() {
+        let variants = parse_event_type("budget").expect("budget should parse");
+        assert!(variants.contains(&BudgetLimitApproached));
+        assert!(variants.contains(&BudgetLimitExceeded));
+        assert_eq!(variants.len(), 2);
+    }
+
+    #[test]
+    fn unknown_string_returns_none() {
+        assert_eq!(parse_event_type("garbage"), None);
+        assert_eq!(parse_event_type(""), None);
+    }
+}

--- a/aa-integration-tests/tests/cli_logs.rs
+++ b/aa-integration-tests/tests/cli_logs.rs
@@ -134,45 +134,6 @@ async fn logs_agent_filter_only_returns_matching() {
     }
 }
 
-// The `--type` filter has a pre-existing CLI↔API contract mismatch:
-//   • `aasm logs --type violation` sends `?event_type=violation` (snake_case
-//     wire form via `LogEventType::as_api_str()`).
-//   • `aa-gateway`'s `AuditReader::list` parses event_type via a match table
-//     keyed on CamelCase variant names (`"PolicyViolation"`, …). Anything
-//     else falls through to `None` → filter is silently dropped → every
-//     event is returned.
-// Verified empirically while writing this file: 3 violations + 2 approvals
-// seeded, `--type violation` returns all 5 instead of 3.
-//
-// The smoke test below pins the surface that works today (flag is accepted,
-// CLI exits 0, the violation events at minimum come back). The strict
-// filter-correctness assertion is `#[ignore]`d until the underlying bug is
-// fixed — tracked as AAASM-1476 (sub-task under AAASM-1258).
-#[tokio::test(flavor = "multi_thread")]
-async fn logs_type_filter_smoke_accepts_flag_and_returns_matching() {
-    let fixture = CliFixture::start().await.expect("fixture should start");
-    let agent = fixture.seed_agents(1)[0];
-    fixture
-        .seed_audit_events(3, agent, AuditEventType::PolicyViolation)
-        .expect("seed violations should succeed");
-    fixture
-        .seed_audit_events(2, agent, AuditEventType::ApprovalGranted)
-        .expect("seed approvals should succeed");
-
-    let out = fixture
-        .cmd()
-        .args(["logs", "--type", "violation", "--output", "json"])
-        .output()
-        .expect("aasm logs --type should execute");
-    assert!(out.status.success(), "--type should be accepted by clap");
-    let entries = parse_jsonl(&out.stdout);
-    let violations = entries.iter().filter(|e| e["event_type"] == "PolicyViolation").count();
-    assert!(
-        violations >= 3,
-        "at minimum the 3 seeded violation events should appear (got {violations})"
-    );
-}
-
 #[tokio::test(flavor = "multi_thread")]
 async fn logs_since_filter_only_returns_recent() {
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -336,7 +297,6 @@ async fn logs_follow_runs_until_killed() {
     let _ = child.wait_with_output();
 }
 
-#[ignore = "blocked by AAASM-1476 — aa-gateway audit_reader::parse_event_type expects CamelCase but CLI sends snake_case"]
 #[tokio::test(flavor = "multi_thread")]
 async fn logs_type_filter_only_returns_matching() {
     let fixture = CliFixture::start().await.expect("fixture should start");


### PR DESCRIPTION
## Description

Fixes the CLI ↔ API contract mismatch surfaced during AAASM-1462: `aasm logs --type violation` (and `--type approval` / `--type budget`) silently returned every audit event because the gateway's `AuditReader::parse_event_type` only recognised CamelCase variant names (`"PolicyViolation"`, `"ApprovalGranted"`, …) while the CLI emits the snake_case category form (`"violation"`, `"approval"`, `"budget"`) via `LogEventType::as_api_str`.

Going with **option (1)** from the bug description: widen the gateway-side parser to accept both wire forms. `parse_event_type` now returns `Option<Vec<AuditEventType>>` — CamelCase strings still produce a singleton vec (backwards-compatible), while snake_case categories produce the full family they represent. The filter step in `AuditReader::list` switches from equality to membership.

| snake_case | variants matched |
| --- | --- |
| `violation` | `PolicyViolation` |
| `approval` | `ApprovalRequested`, `ApprovalGranted`, `ApprovalDenied`, `ApprovalTimedOut`, `ApprovalRouted`, `ApprovalEscalated` |
| `budget` | `BudgetLimitApproached`, `BudgetLimitExceeded` |

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No (CamelCase callers keep the same behaviour; snake_case callers now work where they previously silently no-op'd)

## Related Issues

- Related Jira ticket: AAASM-1476 (sub-task under AAASM-1258); originally discovered during AAASM-1462.

## Testing

- [x] Unit tests added (5 new tests in `aa-gateway/src/audit_reader.rs::tests` — CamelCase singletons, the three snake_case categories, and an unknown-string negative case).
- [x] Integration test un-`#[ignore]`d (`cli_logs::logs_type_filter_only_returns_matching` was `#[ignore]`'d behind this bug; it now passes end-to-end). The smoke test that was wrapped around the workaround is dropped — the strict assertion supersedes it.
- [x] Local validation:
  - `cargo nextest run -p aa-gateway audit_reader` → 5/5 pass
  - `cargo nextest run -p aa-integration-tests --test cli_logs` → **10/10 pass, 0 skipped** (was 10 passed + 1 skipped before the fix)
  - `cargo nextest run -p aa-gateway -p aa-api -p aa-integration-tests` → 1171/1172 pass + 1 known flake in `cli_topology` that passes in isolation (unrelated — touches no audit/event_type code)

## Acceptance criteria verification

| AC | Status |
| --- | --- |
| `cli_logs::logs_type_filter_only_returns_matching` passes | ✓ (was `#[ignore]`'d; now in the active test set) |
| No other `--type` consumer regresses | ✓ — only the dashboard hits `/api/v1/logs`, and that call passes `agent_id` only (`dashboard/src/features/agents/api.ts:75`); aa-api has no `event_type` filter test |
| `aa-gateway` unit tests added for the new wire form | ✓ (5 tests in `audit_reader::tests`) |
| Remove `#[ignore]` and surrounding bug-explainer comment | ✓ (also drops the workaround smoke test) |

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy` — lefthook pre-commit verified each commit)
- [x] Self-review of the diff completed
- [x] No new dependencies
- [x] All CI checks expected passing
- [x] Commits are small and follow the Gitmoji convention (3 commits, one logical unit per commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)