### PR TITLE
[AAASM-1480] 🐛 (aa-cli): Fix aasm approvals watch WS contract (path + filter value)

### DIFF
--- a/aa-cli/src/commands/approvals/client.rs
+++ b/aa-cli/src/commands/approvals/client.rs
@@ -83,7 +83,8 @@ pub async fn reject_action(ctx: &ResolvedContext, id: &str, reason: &str) -> Res
 /// Convert an HTTP(S) base URL to a WebSocket URL for the events endpoint.
 ///
 /// `http://` becomes `ws://`, `https://` becomes `wss://`.
-/// Appends `/api/v1/events?types={types}`.
+/// Appends `/api/v1/ws/events?types={types}` — matches the route mounted by
+/// `aa-api` (see `aa-api::routes::mod::v1_router` and `aa-api::ws::handler::ws_events_handler`).
 pub fn build_ws_url(base: &str, types: &str) -> Result<String, CliError> {
     let mut parsed =
         Url::parse(base).map_err(|e| CliError::Io(std::io::Error::new(std::io::ErrorKind::InvalidInput, e)))?;
@@ -98,7 +99,7 @@ pub fn build_ws_url(base: &str, types: &str) -> Result<String, CliError> {
         ))
     })?;
     let base_str = parsed.as_str().trim_end_matches('/');
-    Ok(format!("{base_str}/api/v1/events?types={types}"))
+    Ok(format!("{base_str}/api/v1/ws/events?types={types}"))
 }
 
 #[cfg(test)]
@@ -123,14 +124,14 @@ mod tests {
 
     #[test]
     fn build_ws_url_http_to_ws() {
-        let url = build_ws_url("http://localhost:8080", "approval_required").unwrap();
-        assert_eq!(url, "ws://localhost:8080/api/v1/events?types=approval_required");
+        let url = build_ws_url("http://localhost:8080", "approval").unwrap();
+        assert_eq!(url, "ws://localhost:8080/api/v1/ws/events?types=approval");
     }
 
     #[test]
     fn build_ws_url_https_to_wss() {
-        let url = build_ws_url("https://api.example.com", "approval_required").unwrap();
-        assert_eq!(url, "wss://api.example.com/api/v1/events?types=approval_required");
+        let url = build_ws_url("https://api.example.com", "approval").unwrap();
+        assert_eq!(url, "wss://api.example.com/api/v1/ws/events?types=approval");
     }
 
     #[tokio::test]

--- a/aa-cli/src/commands/approvals/watch.rs
+++ b/aa-cli/src/commands/approvals/watch.rs
@@ -30,8 +30,15 @@ pub struct WatchArgs {
 }
 
 /// Establish a WebSocket connection to the approval events endpoint.
+///
+/// The `types=approval` filter matches the snake_case wire value of
+/// `aa_api::models::EventType::Approval` — see `EventType::parse_filter`,
+/// which accepts only `"violation"`, `"approval"`, `"budget"`. Earlier
+/// revisions of this call passed `"approval_required"`, which the
+/// server silently dropped, so the WS connection succeeded but no
+/// events ever matched the filter.
 pub async fn connect_approval_ws(ctx: &ResolvedContext) -> Result<WsStream, CliError> {
-    let url = client::build_ws_url(&ctx.api_url, "approval_required")?;
+    let url = client::build_ws_url(&ctx.api_url, "approval")?;
     let (ws, _response) = tokio_tungstenite::connect_async(&url)
         .await
         .map_err(|e| CliError::Io(std::io::Error::new(std::io::ErrorKind::ConnectionRefused, e)))?;

--- a/aa-integration-tests/tests/cli_approvals.rs
+++ b/aa-integration-tests/tests/cli_approvals.rs
@@ -226,9 +226,6 @@ async fn approvals_approve_unknown_id_errors() {
 // aasm approvals watch — streaming
 // =============================================================================
 
-#[ignore = "AAASM-1480: aa-cli build_ws_url targets /api/v1/events but aa-api wires \
-            /api/v1/ws/events — WS connect 404s and the child exits immediately. \
-            Drop this #[ignore] once the WS URL contract is fixed."]
 #[tokio::test(flavor = "multi_thread")]
 async fn approvals_watch_runs_until_killed() {
     // Establishes that the `watch` subcommand wires the WebSocket connection


### PR DESCRIPTION
## Description

Fixes two bugs in `aasm approvals watch` that combined to make the subcommand unusable against any real aa-api server:

1. **Wrong path.** `aa-cli/src/commands/approvals/client.rs::build_ws_url` emitted `{base}/api/v1/events?types=…`, but `aa-api/src/routes/mod.rs` mounts the WS handler at `/ws/events` under the `/api/v1` nest — effective `/api/v1/ws/events`. The CLI was hitting the axum 404 fallback. The other two CLI WS builders (`dashboard::feed::build_ws_url`, `logs::follow::build_ws_url`) already use the correct path; this PR aligns the approvals one.
2. **Wrong filter value.** `connect_approval_ws` passed `"approval_required"`, but `aa_api::models::EventType::parse_filter` only accepts `"violation"`, `"approval"`, `"budget"` (snake_case wire form of the `EventType` enum). Unknown values silently fall through to `None`, so even with the path fix, the filter would have resolved to an empty Vec and no events would have matched.

Also drops the `#[ignore]` on `aa-integration-tests/tests/cli_approvals.rs::approvals_watch_runs_until_killed` (added in AAASM-1469 with a pointer to this ticket). That test now runs and passes.

## How verified

| Check | Result |
| --- | --- |
| `cargo nextest run -p aa-cli build_ws_url` | 9/9 pass (5 sibling builders + the 2 approvals-side tests that locked in the wrong shape — both updated) |
| `cargo nextest run -p aa-integration-tests --test cli_approvals` | **10/10 pass** (the previously-ignored watch test is now active) |
| `cargo nextest run -p aa-integration-tests --no-fail-fast` | 152/152 pass (6 skipped — unchanged) |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets --all-features -- -D warnings` | clean (per-commit via lefthook) |
| `cargo doc --workspace --no-deps` | clean (pre-push) |

## Manual repro (before fix)

```bash
./target/debug/aasm --api-url http://127.0.0.1:PORT approvals watch
# error: IO error: <upgrade error>     (CLI exits non-zero)
```

After fix: WS upgrade succeeds, prints `Watching for approval requests... (Ctrl+C to stop)`, stays connected until Ctrl+C.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-1480](https://lightning-dust-mite.atlassian.net/browse/AAASM-1480) (parent Epic: [AAASM-1258](https://lightning-dust-mite.atlassian.net/browse/AAASM-1258))
- Discovered in: PR #503 (AAASM-1469 / F121 ST-13)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Existing unit tests updated to lock in the corrected shape (no regression coverage gap)
- [x] Integration test that was `#[ignore]`'d on this bug now runs and passes
- [ ] All CI checks passing (pending CI run)

## Commit log

| SHA | Message |
| --- | --- |
| `d9b6276f` | 🐛 Fix build_ws_url path to /api/v1/ws/events |
| `58d3e3ae` | 🐛 Use 'approval' EventType in connect_approval_ws |
| `19dc3a2f` | 🔧 Drop #[ignore] on cli_approvals watch test |

[AAASM-1480]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ