### PR TITLE
[AAASM-1452] 🔧 (ci): Set AA_BENCH_SLA_P99_MS=1500 on Benchmark latency SLA step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,6 +432,15 @@ jobs:
           cargo bench -p aa-ffi-python --bench sdk_bench
           cargo bench -p aa-proxy --bench intercept_bench
       - name: Run latency SLA test (5s burst)
+        # AAASM-1452: shared GitHub-hosted runners exhibit noisy-neighbour
+        # tail latency that breaches the test's bare-metal 15ms default
+        # (observed p99 spikes to 733ms+ even on the dedicated Benchmark
+        # job under steal-time contention). 1500ms absorbs the runner
+        # variance while still surfacing any real ≥100× regression. The
+        # 5ms bare-metal target stays enforced by the test name; only the
+        # SLA assertion is relaxed.
+        env:
+          AA_BENCH_SLA_P99_MS: "1500"
         run: cargo test -p aa-gateway --test policy_latency_test -- --nocapture
 
   conformance:


### PR DESCRIPTION
## Description

Fixes the recurring CI flake in `aa-gateway::policy_latency_test::sustained_load_p99_under_5ms` on the **Benchmark** job by setting `AA_BENCH_SLA_P99_MS: 1500` on that step's env block.

### Diagnosis

The ticket originally proposed bumping the env var on the workspace `Test` job — but inspection of `.github/workflows/ci.yml` shows it's already set there at `5000` (line 163, with an explanatory comment). The remaining flake is on the **dedicated Benchmark job** (line 418-435), which runs `policy_latency_test` without any env override and therefore falls through to the test's bare-metal default of 15 ms (defined at `aa-gateway/tests/policy_latency_test.rs:39`).

Recent symptom observed on AAASM-1474 PR #502 — the Benchmark job failed once with the same shape as #484/#488 (p99 ≥ 733 ms), passed cleanly on rerun. Pure CI-runner noise.

### Why 1500 ms

* **5 ms** — bare-metal target enforced by the test name and the operator-facing SLO. Unchanged.
* **15 ms** — the test's hardcoded fallback default. Way too tight for shared CI.
* **500 ms** — the value the ticket text quotes; was the Test job's prior value (already bumped to 5000 ms in a previous fix).
* **1500 ms** — chosen here. 100× over bare-metal, ≥2× over observed worst-case CI p99 (733 ms), well under the Test job's 5000 ms (which sees much heavier concurrent load).

A real ≥100× regression in the policy engine would still trip the assertion — only the runner-noise breach is absorbed.

### Acceptance criteria

| AC | Status |
|---|---|
| `.github/workflows/ci.yml` — `AA_BENCH_SLA_P99_MS` env var set | ✅ Met (Benchmark job; Test job was already 5000) |
| Reasoning documented in a workflow comment | ✅ Met (7-line block citing AAASM-1452 + observation data) |
| Verify CI stays green | Will run on this PR; if it goes green first try after a known-flaky-test step exists, that's evidence of the fix |
| Optional follow-up nightly bare-metal job | Out of scope — flagged in commit message + this PR description |

## Type of Change

- [ ] ✅ Test
- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No  *(CI-only)*
- [ ] Yes

## Related Issues

- Closes: **AAASM-1452** (Fix flake in `policy_latency_test::sustained_load_p99_under_5ms`)
- Observed on: **AAASM-1474 PR #502**, AAASM-1258 PR #484, AAASM-1260 PR #488

## Testing

CI-only change. The fix is exercised by this PR's CI run — if the Benchmark job goes green first try (no rerun), that's the validation.

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed *(workflow YAML lint via PR CI)*
- [x] No tests required *(CI configuration)*

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated *(7-line inline comment block in ci.yml)*
- [ ] All CI checks passing *(awaiting CI run on this PR)*
- [x] Single atomic commit per ticket guidance
