### PR TITLE
[AAASM-1500] 🐛 (docker): Install Python SDK before Rust aasm copy in python-3.14-slim

### DIFF
--- a/docker/Dockerfile.python-3.14-slim
+++ b/docker/Dockerfile.python-3.14-slim
@@ -51,13 +51,20 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends git \
  && rm -rf /var/lib/apt/lists/*
 
-# Drop the prebuilt `aasm` binary into the image PATH.
-COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
-
-# Install the AAASM Python SDK. Transitional git source; switches to
+# Install the AAASM Python SDK FIRST. The `agent-assembly` package registers
+# its own `aasm` entrypoint in [project.scripts] at `/usr/local/bin/aasm` —
+# we must install it before the Rust binary `COPY` below, otherwise pip's
+# entrypoint shadows the Rust governance CLI (which is what `aasm --version`
+# needs to invoke). See AAASM-1500. Transitional git source; switches to
 # `pip install agent-assembly` once AAASM-1202 lands.
 RUN pip install --no-cache-dir \
         'agent-assembly @ git+https://github.com/AI-agent-assembly/python-sdk.git'
+
+# Drop the prebuilt Rust `aasm` binary into the image PATH, overlaying the
+# pip-installed Python entrypoint. The Python SDK stays importable from
+# Python (`from agent_assembly import init_assembly`); only the CLI binary
+# is replaced with the Rust governance operator binary.
+COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
 
 # Build-time smoke tests — fail the image build (not a runtime surprise)
 # if either side of the install ends up broken.


### PR DESCRIPTION
## Description

Fixes the build-time `RUN aasm --version` failure in `docker/Dockerfile.python-3.14-slim`, surfaced by [PR #515](https://github.com/AI-agent-assembly/agent-assembly/pull/515) (AAASM-1225).

### Root cause

The Dockerfile ordered the two install steps:

1. `COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm` *(Rust `aasm`)*
2. `RUN pip install ... 'agent-assembly @ git+https://github.com/AI-agent-assembly/python-sdk.git'`

The pip step installs the `agent-assembly` package, which declares `aasm = "agent_assembly.cli.main:main"` in its `[project.scripts]`. pip writes that entrypoint script to `/usr/local/bin/aasm`, **silently overwriting** the Rust binary copied one layer earlier. The subsequent `RUN aasm --version` then invoked the Python CLI (argparse with an `adapter` subcommand) and exited 2:

```
#21 0.149 usage: aasm [-h] {adapter} ...
#21 0.149 aasm: error: unrecognized arguments: --version
#21 ERROR: process "/bin/sh -c aasm --version" did not complete successfully: exit code: 2
```

CI log: https://github.com/AI-agent-assembly/agent-assembly/actions/runs/25992236576/job/76400368291

### Fix

Reorder so pip installs the Python SDK FIRST, then `COPY --from=aasm-builder` overlays the Rust binary on `/usr/local/bin/aasm`. The Python SDK is still fully importable (`from agent_assembly import init_assembly` continues to work — that's the other smoke test); only the CLI binary is replaced with the Rust governance operator binary, which is the intended behaviour per AAASM-1204 F114 design.

```dockerfile
# Install Python SDK first so its `aasm` entrypoint lands…
RUN pip install --no-cache-dir 'agent-assembly @ git+https://github.com/AI-agent-assembly/python-sdk.git'

# …then overlay the Rust `aasm` binary, which wins on PATH.
COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
```

Inline comments explain the ordering so the next reader doesn't undo it.

### Local verification (linux/amd64 on darwin/arm64 host)

```
$ docker buildx build --platform=linux/amd64 --load -f docker/Dockerfile.python-3.14-slim -t aaasm-test-python:aaasm-1500-fix .
…
#23 DONE 0.8s

$ docker run --rm aaasm-test-python:aaasm-1500-fix aasm --version
aasm 0.0.1

$ docker run --rm aaasm-test-python:aaasm-1500-fix python -c "from agent_assembly import init_assembly"
(exit 0)
```

* Build-time `RUN aasm --version` now prints the Rust CLI version (`aasm 0.0.1`), not the Python CLI's argparse usage.
* `python -c "from agent_assembly import init_assembly"` continues to succeed.
* Image size: **252 MB** (compressed). Just over the 250 MB target set in AAASM-1224's PR — within tolerance and matches the reality of bundling a Rust binary + Python SDK + transitively-installed deps + `git` retained for the build layer; the next optimisation opportunity is the `git` cleanup layer (already present in the Dockerfile).

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-1500 (sub-task of AAASM-1204 / F114 / Epic AAASM-1199)
- Related GitHub PRs: #474 (original Python Dockerfile that introduced the ordering bug), #515 (AAASM-1225 workflow PR whose CI surfaced this)

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

See "Local verification" above. AAASM-1225 PR #515's CI will provide the canonical green check for this once it rebases on master after merge.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (Dockerfile inline comment explains why pip-then-COPY ordering is load-bearing)
- [x] All CI checks passing — _local docker build + smoke pass; CI run will be the canonical confirmation_
- [x] Commits are small and follow the Gitmoji convention