### PR TITLE
[AAASM-1485] ✅ (aa-integration-tests): Add api_auth.rs integration tests for /api/v1/auth/token

### DIFF
--- a/aa-api/src/auth/api_key.rs
+++ b/aa-api/src/auth/api_key.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use argon2::password_hash::SaltString;
 use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier};
+use dashmap::DashMap;
 use rand::RngExt as _;
 use rand_core::OsRng;
 use serde::{Deserialize, Serialize};
@@ -96,6 +97,8 @@ pub struct ApiKeyEntry {
 /// In-memory store of API key entries loaded from a JSON file.
 pub struct ApiKeyStore {
     entries: Vec<ApiKeyEntry>,
+    /// Runtime-revoked key IDs; checked during every `validate_detailed` call.
+    revoked_ids: DashMap<String, ()>,
 }
 
 impl ApiKeyStore {
@@ -104,21 +107,53 @@ impl ApiKeyStore {
     /// Returns an empty store if the file does not exist.
     pub fn load(path: &Path) -> Result<Self, ApiKeyError> {
         if !path.exists() {
-            return Ok(Self { entries: Vec::new() });
+            return Ok(Self {
+                entries: Vec::new(),
+                revoked_ids: DashMap::new(),
+            });
         }
 
         let content = std::fs::read_to_string(path).map_err(|e| ApiKeyError::Io(e.to_string()))?;
         let entries: Vec<ApiKeyEntry> =
             serde_json::from_str(&content).map_err(|e| ApiKeyError::ParseError(e.to_string()))?;
-        Ok(Self { entries })
+        Ok(Self {
+            entries,
+            revoked_ids: DashMap::new(),
+        })
+    }
+
+    /// Mark a key ID as revoked; subsequent `validate_detailed` calls for that
+    /// key will return `Err(KeyNotValid::Revoked)`.
+    pub fn revoke(&self, key_id: &str) {
+        self.revoked_ids.insert(key_id.to_string(), ());
+    }
+
+    /// Validate a raw API key and distinguish *revoked* from *not-found*.
+    ///
+    /// Returns `Ok(&ApiKeyEntry)` on success, `Err(KeyNotValid::Revoked)` if the
+    /// key exists but has been revoked, or `Err(KeyNotValid::NotFound)` for any
+    /// other failure (parse error, wrong hash, unknown key).
+    pub fn validate_detailed(&self, raw_key: &str) -> Result<&ApiKeyEntry, KeyNotValid> {
+        let key = ApiKey::parse(raw_key).map_err(|_| KeyNotValid::NotFound)?;
+        match self.entries.iter().find(|entry| key.verify(&entry.key_hash)) {
+            None => Err(KeyNotValid::NotFound),
+            Some(entry) => {
+                if self.revoked_ids.contains_key(&entry.id) {
+                    Err(KeyNotValid::Revoked)
+                } else {
+                    Ok(entry)
+                }
+            }
+        }
     }
 
     /// Validate a raw API key string against stored entries.
     ///
     /// Returns the matching entry if the key is valid, or `None` if no match.
+    /// Use [`validate_detailed`](Self::validate_detailed) when the caller needs
+    /// to distinguish revoked keys from unknown keys.
     pub fn validate(&self, raw_key: &str) -> Option<&ApiKeyEntry> {
-        let key = ApiKey::parse(raw_key).ok()?;
-        self.entries.iter().find(|entry| key.verify(&entry.key_hash))
+        self.validate_detailed(raw_key).ok()
     }
 
     /// Return the number of stored entries.
@@ -245,7 +280,10 @@ mod tests {
             created_at: 1700000000,
             label: Some("test key".to_string()),
         };
-        let store = ApiKeyStore { entries: vec![entry] };
+        let store = ApiKeyStore {
+            entries: vec![entry],
+            revoked_ids: DashMap::new(),
+        };
 
         let result = store.validate(key.as_str());
         assert!(result.is_some());
@@ -264,7 +302,10 @@ mod tests {
             created_at: 1700000000,
             label: None,
         };
-        let store = ApiKeyStore { entries: vec![entry] };
+        let store = ApiKeyStore {
+            entries: vec![entry],
+            revoked_ids: DashMap::new(),
+        };
 
         let result = store.validate(key2.as_str());
         assert!(result.is_none());

--- a/aa-api/src/auth/api_key.rs
+++ b/aa-api/src/auth/api_key.rs
@@ -132,6 +132,15 @@ impl ApiKeyStore {
     }
 }
 
+/// Reason a key lookup failed during authentication.
+#[derive(Debug)]
+pub enum KeyNotValid {
+    /// No entry matched the supplied raw key.
+    NotFound,
+    /// The key exists but has been revoked.
+    Revoked,
+}
+
 /// Errors related to API key operations.
 #[derive(Debug, Error)]
 pub enum ApiKeyError {

--- a/aa-api/src/auth/mod.rs
+++ b/aa-api/src/auth/mod.rs
@@ -18,7 +18,7 @@ use axum::http::request::Parts;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 
-use self::api_key::ApiKeyStore;
+use self::api_key::{ApiKeyStore, KeyNotValid};
 use self::config::{AuthConfig, AuthMode};
 use self::jwt::JwtVerifier;
 use self::rate_limit::RateLimiter;
@@ -137,9 +137,15 @@ where
                 .get::<Arc<ApiKeyStore>>()
                 .expect("ApiKeyStore extension missing");
 
-            let entry = key_store
-                .validate(token)
-                .ok_or_else(|| AuthError::InvalidToken("invalid API key".into()))?;
+            let entry = match key_store.validate_detailed(token) {
+                Ok(e) => e,
+                Err(KeyNotValid::Revoked) => {
+                    return Err(AuthError::InvalidToken("revoked API key".into()));
+                }
+                Err(KeyNotValid::NotFound) => {
+                    return Err(AuthError::InvalidToken("invalid API key".into()));
+                }
+            };
 
             AuthenticatedCaller {
                 key_id: entry.id.clone(),

--- a/aa-integration-tests/tests/api_auth.rs
+++ b/aa-integration-tests/tests/api_auth.rs
@@ -170,3 +170,37 @@ async fn auth_token_with_revoked_key_returns_401() {
         "error detail must mention 'revoked'; got: {detail}"
     );
 }
+
+// ─── rate limit ──────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn auth_token_rate_limit_applies_per_api_key() {
+    let (plaintext, entry) = common::make_api_key("key-1", vec![Scope::Read]);
+    // Set rate limit to 5 requests per minute so it is easily triggered in tests.
+    let env = common::TopologyTestEnv::start_with_auth(&[entry], 5).await.unwrap();
+
+    let client = reqwest::Client::new();
+    let mut statuses = Vec::new();
+    for _ in 0..10 {
+        let resp = client
+            .post(format!("{}/api/v1/auth/token", env.base_url()))
+            .bearer_auth(&plaintext)
+            .json(&serde_json::json!({}))
+            .send()
+            .await
+            .unwrap();
+        statuses.push(resp.status());
+    }
+
+    let ok_count = statuses.iter().filter(|s| **s == StatusCode::OK).count();
+    let rate_limited = statuses.contains(&StatusCode::TOO_MANY_REQUESTS);
+
+    assert!(
+        ok_count >= 1,
+        "at least one request should succeed before the limit kicks in"
+    );
+    assert!(
+        rate_limited,
+        "some requests must be rate-limited (429) when limit is 5 rpm"
+    );
+}

--- a/aa-integration-tests/tests/api_auth.rs
+++ b/aa-integration-tests/tests/api_auth.rs
@@ -103,3 +103,70 @@ async fn auth_token_with_scoped_api_key_returns_scoped_jwt() {
         "JWT scope must match the API key's scopes"
     );
 }
+
+// ─── error paths ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn auth_token_with_unknown_api_key_returns_401() {
+    let (plaintext, entry) = common::make_api_key("key-1", vec![Scope::Read]);
+    let env = common::TopologyTestEnv::start_with_auth(&[entry], 1000).await.unwrap();
+
+    // Generate a fresh key that was never registered in the store.
+    let (unknown_plaintext, _) = common::make_api_key("key-unknown", vec![Scope::Read]);
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/api/v1/auth/token", env.base_url()))
+        .bearer_auth(&unknown_plaintext)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    // Suppress unused-variable warning; plaintext kept to make the store non-empty.
+    let _ = plaintext;
+}
+
+#[tokio::test]
+async fn auth_token_without_auth_header_returns_401() {
+    let (_, entry) = common::make_api_key("key-1", vec![Scope::Read]);
+    let env = common::TopologyTestEnv::start_with_auth(&[entry], 1000).await.unwrap();
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/api/v1/auth/token", env.base_url()))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn auth_token_with_revoked_key_returns_401() {
+    let (plaintext, entry) = common::make_api_key("key-1", vec![Scope::Read]);
+    let env = common::TopologyTestEnv::start_with_auth(&[entry], 1000).await.unwrap();
+
+    // Revoke the key via the shared Arc before making the request.
+    env.key_store.revoke("key-1");
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/api/v1/auth/token", env.base_url()))
+        .bearer_auth(&plaintext)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let detail = body["detail"].as_str().unwrap_or("");
+    assert!(
+        detail.contains("revoked"),
+        "error detail must mention 'revoked'; got: {detail}"
+    );
+}

--- a/aa-integration-tests/tests/api_auth.rs
+++ b/aa-integration-tests/tests/api_auth.rs
@@ -1,0 +1,105 @@
+//! AAASM-1485 / F122 ST-D — live-gateway integration tests for
+//! `POST /api/v1/auth/token` (JWT issuance from API key credentials).
+//!
+//! All tests spin up a real `TopologyTestEnv` with `AuthMode::On` via
+//! `start_with_auth()`, make HTTP calls with `reqwest`, and assert on the
+//! actual HTTP response — nothing is mocked.
+//!
+//! ## Divergence note
+//!
+//! The JIRA ticket was drafted against a `{api_key, secret}` request body
+//! design. The implemented endpoint instead authenticates via the
+//! `Authorization: Bearer <aa_key>` header with an optional `{"scopes":[…]}`
+//! body. Tests match the actual implementation.
+
+mod common;
+
+use aa_api::auth::jwt::JwtVerifier;
+use aa_api::auth::scope::Scope;
+use reqwest::StatusCode;
+
+// ─── happy path ──────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn auth_token_with_valid_api_key_returns_jwt() {
+    let (plaintext, entry) = common::make_api_key("key-1", vec![Scope::Read, Scope::Write]);
+    let env = common::TopologyTestEnv::start_with_auth(&[entry], 1000).await.unwrap();
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/api/v1/auth/token", env.base_url()))
+        .bearer_auth(&plaintext)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let token = body["token"].as_str().expect("response must have 'token' string");
+    assert!(!token.is_empty(), "token must be non-empty");
+    assert!(body["expires_at"].is_u64(), "response must have 'expires_at' as u64");
+    assert!(body["scopes"].is_array(), "response must have 'scopes' as array");
+}
+
+#[tokio::test]
+async fn auth_token_jwt_is_well_formed() {
+    let (plaintext, entry) = common::make_api_key("key-1", vec![Scope::Read, Scope::Write]);
+    let env = common::TopologyTestEnv::start_with_auth(&[entry], 1000).await.unwrap();
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/api/v1/auth/token", env.base_url()))
+        .bearer_auth(&plaintext)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let token_str = body["token"].as_str().expect("response must have 'token' string");
+
+    let verifier = JwtVerifier::new(common::AUTH_IT_JWT_SECRET);
+    let claims = verifier
+        .verify(token_str)
+        .expect("JWT must verify with the test secret");
+
+    assert!(!claims.sub.is_empty(), "JWT payload must have non-empty 'sub'");
+    assert!(claims.exp > 0, "JWT payload must have positive 'exp'");
+    assert!(claims.iat > 0, "JWT payload must have positive 'iat'");
+    assert!(!claims.scope.is_empty(), "JWT payload must have non-empty 'scope'");
+}
+
+#[tokio::test]
+async fn auth_token_with_scoped_api_key_returns_scoped_jwt() {
+    let (plaintext, entry) = common::make_api_key("key-1", vec![Scope::Read]);
+    let env = common::TopologyTestEnv::start_with_auth(&[entry], 1000).await.unwrap();
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/api/v1/auth/token", env.base_url()))
+        .bearer_auth(&plaintext)
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    let token_str = body["token"].as_str().expect("response must have 'token' string");
+
+    let verifier = JwtVerifier::new(common::AUTH_IT_JWT_SECRET);
+    let claims = verifier
+        .verify(token_str)
+        .expect("JWT must verify with the test secret");
+
+    assert_eq!(
+        claims.scope,
+        vec![Scope::Read],
+        "JWT scope must match the API key's scopes"
+    );
+}

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -94,6 +94,11 @@ pub struct TopologyTestEnv {
     /// without trait downcasting. Populated by `cli_alerts.rs` (AAASM-1460).
     #[allow(dead_code)]
     pub alert_store: Arc<InMemoryAlertStore>,
+    /// Shared API key store — same Arc the running server holds.
+    /// Auth integration tests (AAASM-1485) call `key_store.revoke()` here
+    /// to exercise the revocation path without restarting the server.
+    #[allow(dead_code)]
+    pub key_store: Arc<ApiKeyStore>,
     /// Trigger to stop the background axum task.
     shutdown_tx: Option<oneshot::Sender<()>>,
     /// Handle for the spawned axum task; awaited during teardown.
@@ -108,7 +113,7 @@ impl TopologyTestEnv {
     /// Spin up the harness: build the AppState, bind axum to a free port,
     /// spawn the server task, and poll `/api/v1/health` until ready.
     pub async fn start() -> anyhow::Result<Self> {
-        let (state, audit_dir, alert_store) = build_test_state()?;
+        let (state, audit_dir, alert_store, key_store) = build_test_state()?;
         let agent_registry = Arc::clone(&state.agent_registry);
         let trace_store = Arc::clone(&state.trace_store);
         let approval_queue = Arc::clone(&state.approval_queue);
@@ -138,6 +143,7 @@ impl TopologyTestEnv {
             audit_dir,
             budget_tracker,
             alert_store,
+            key_store,
             shutdown_tx: Some(shutdown_tx),
             server_handle: Some(server_handle),
             cleaned: false,
@@ -221,13 +227,10 @@ fn uuid_string(key: &[u8; 16]) -> String {
 /// `aa-api/tests/common/mod.rs::test_state_with_auth` to avoid pulling that
 /// crate's `dev-dependencies` test helpers across crate boundaries.
 ///
-/// Returns the populated state, the on-disk audit dir the `AuditReader`
-/// scans (so per-leaf helpers like `seed_audit_events` can write entries
-/// the `aasm logs` snapshot path observes), and a concrete handle on
-/// the in-memory alert store so per-leaf seed helpers (e.g.
-/// `CliFixture::seed_alert`) can call `record()` directly without
-/// trait downcasting from `Arc<dyn AlertStore>`.
-fn build_test_state() -> anyhow::Result<(AppState, PathBuf, Arc<InMemoryAlertStore>)> {
+/// Returns the populated state, the on-disk audit dir, a concrete handle on
+/// the in-memory alert store, and the key store Arc so callers can mutate it
+/// (e.g. call `revoke()`) after construction.
+fn build_test_state() -> anyhow::Result<(AppState, PathBuf, Arc<InMemoryAlertStore>, Arc<ApiKeyStore>)> {
     let policy_id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let policy_dir = std::env::temp_dir().join(format!("aa-topology-it-policy-{}-{policy_id}", std::process::id()));
     std::fs::create_dir_all(&policy_dir)?;
@@ -277,6 +280,7 @@ spec:
         ApiKeyStore::load(Path::new("/dev/null"))
             .unwrap_or_else(|_| ApiKeyStore::load(Path::new("/nonexistent")).expect("empty key store")),
     );
+    let key_store_handle = Arc::clone(&key_store);
     const TEST_SECRET: &[u8] = b"topology-it-test-secret-32-bytes-long-padding";
     let jwt_signer = Arc::new(JwtSigner::new(TEST_SECRET));
     let jwt_verifier = Arc::new(JwtVerifier::new(TEST_SECRET));
@@ -331,5 +335,6 @@ spec:
         },
         audit_dir,
         alert_store_handle,
+        key_store_handle,
     ))
 }

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -31,7 +31,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use aa_api::alerts::store::InMemoryAlertStore;
-use aa_api::auth::api_key::ApiKeyStore;
+use aa_api::auth::api_key::{ApiKey, ApiKeyEntry, ApiKeyStore};
 use aa_api::auth::config::{AuthConfig, AuthMode};
 use aa_api::auth::jwt::{JwtSigner, JwtVerifier};
 use aa_api::auth::rate_limit::RateLimiter;
@@ -114,6 +114,55 @@ impl TopologyTestEnv {
     /// spawn the server task, and poll `/api/v1/health` until ready.
     pub async fn start() -> anyhow::Result<Self> {
         let (state, audit_dir, alert_store, key_store) = build_test_state()?;
+        let agent_registry = Arc::clone(&state.agent_registry);
+        let trace_store = Arc::clone(&state.trace_store);
+        let approval_queue = Arc::clone(&state.approval_queue);
+        let budget_tracker = Arc::clone(&state.budget_tracker);
+
+        let port = portpicker::pick_unused_port().ok_or_else(|| anyhow::anyhow!("no free TCP port"))?;
+        let addr: SocketAddr = format!("127.0.0.1:{port}").parse()?;
+        let listener = tokio::net::TcpListener::bind(addr).await?;
+        let bound_addr = listener.local_addr()?;
+
+        let app = build_app(state);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+        let server_handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await;
+        });
+
+        let env = Self {
+            addr: bound_addr,
+            agent_registry,
+            trace_store,
+            approval_queue,
+            audit_dir,
+            budget_tracker,
+            alert_store,
+            key_store,
+            shutdown_tx: Some(shutdown_tx),
+            server_handle: Some(server_handle),
+            cleaned: false,
+        };
+        env.await_ready().await?;
+        Ok(env)
+    }
+
+    /// Spin up the harness with authentication enabled.
+    ///
+    /// `entries` are pre-seeded into the `ApiKeyStore`; `rate_limit_rpm` caps
+    /// per-key request rate for this environment (use a small value for the
+    /// rate-limit smoke test only).
+    ///
+    /// **Coordination point (AAASM-1485)**: ST-R will reuse this builder.
+    /// Whichever ST opens first adds it here; the other rebases.
+    #[allow(dead_code)]
+    pub async fn start_with_auth(entries: &[ApiKeyEntry], rate_limit_rpm: u32) -> anyhow::Result<Self> {
+        let (state, audit_dir, alert_store, key_store) = build_test_state_with_auth(entries, rate_limit_rpm)?;
         let agent_registry = Arc::clone(&state.agent_registry);
         let trace_store = Arc::clone(&state.trace_store);
         let approval_queue = Arc::clone(&state.approval_queue);
@@ -337,4 +386,147 @@ spec:
         alert_store_handle,
         key_store_handle,
     ))
+}
+
+/// JWT secret used by `start_with_auth` — exposed so tests can decode tokens.
+pub const AUTH_IT_JWT_SECRET: &[u8] = b"auth-it-test-secret-32-bytes-long!!";
+
+/// Build a minimal `AppState` with authentication enabled and pre-seeded API keys.
+///
+/// Used by `TopologyTestEnv::start_with_auth` (AAASM-1485 / F122 ST-D).
+fn build_test_state_with_auth(
+    entries: &[ApiKeyEntry],
+    rate_limit_rpm: u32,
+) -> anyhow::Result<(AppState, PathBuf, Arc<InMemoryAlertStore>, Arc<ApiKeyStore>)> {
+    let policy_id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let policy_dir = std::env::temp_dir().join(format!("aa-auth-it-policy-{}-{policy_id}", std::process::id()));
+    std::fs::create_dir_all(&policy_dir)?;
+    let policy_path = policy_dir.join("test-policy.yaml");
+    std::fs::write(
+        &policy_path,
+        r#"
+apiVersion: agent-assembly.dev/v1alpha1
+kind: GovernancePolicy
+metadata:
+  name: auth-it-policy
+  version: "0.1.0"
+spec:
+  rules: []
+"#,
+    )?;
+
+    let events = Arc::new(EventBroadcast::default());
+    let budget_alert_tx = events.budget_sender();
+    let policy_engine = Arc::new(
+        PolicyEngine::load_from_file(&policy_path, budget_alert_tx)
+            .map_err(|e| anyhow::anyhow!("load policy: {e:?}"))?,
+    );
+    let budget_tracker = Arc::new(BudgetTracker::new(
+        PricingTable::default_table(),
+        None,
+        None,
+        chrono_tz::UTC,
+    ));
+    let approval_queue = ApprovalQueue::new();
+    let agent_registry = Arc::new(AgentRegistry::new());
+
+    let history_id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let history_dir = std::env::temp_dir().join(format!("aa-auth-it-history-{}-{history_id}", std::process::id()));
+    let policy_history = Arc::new(FsHistoryStore::new(HistoryConfig {
+        history_dir,
+        max_versions: 50,
+    }));
+
+    let auth_config = Arc::new(AuthConfig {
+        mode: AuthMode::On,
+        jwt_secret: Some(AUTH_IT_JWT_SECRET.to_vec()),
+        api_keys_path: std::path::PathBuf::from("/dev/null"),
+        rate_limit_rpm,
+    });
+
+    let key_store = if entries.is_empty() {
+        Arc::new(
+            ApiKeyStore::load(Path::new("/dev/null"))
+                .unwrap_or_else(|_| ApiKeyStore::load(Path::new("/nonexistent")).expect("empty key store")),
+        )
+    } else {
+        let id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let tmp = std::env::temp_dir().join(format!("aa-auth-it-keys-{}-{id}.json", std::process::id()));
+        let json = serde_json::to_string(entries).unwrap();
+        std::fs::write(&tmp, &json).unwrap();
+        Arc::new(ApiKeyStore::load(&tmp).unwrap())
+    };
+    let key_store_handle = Arc::clone(&key_store);
+
+    let jwt_signer = Arc::new(JwtSigner::new(AUTH_IT_JWT_SECRET));
+    let jwt_verifier = Arc::new(JwtVerifier::new(AUTH_IT_JWT_SECRET));
+    let rate_limiter = Arc::new(RateLimiter::new(rate_limit_rpm));
+    let alert_store: Arc<InMemoryAlertStore> = Arc::new(InMemoryAlertStore::new());
+    let alert_store_handle = Arc::clone(&alert_store);
+
+    let audit_id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let audit_dir = std::env::temp_dir().join(format!("aa-auth-it-audit-{}-{audit_id}", std::process::id()));
+    std::fs::create_dir_all(&audit_dir)?;
+    let audit_reader = Arc::new(AuditReader::new(audit_dir.clone()));
+
+    Ok((
+        AppState {
+            agent_registry,
+            policy_engine,
+            budget_tracker,
+            approval_queue,
+            policy_history,
+            alert_store,
+            events,
+            replay_buffer: ReplayBuffer::new(),
+            next_event_id: Arc::new(AtomicU64::new(0)),
+            auth_config,
+            key_store,
+            rate_limiter,
+            jwt_signer,
+            jwt_verifier,
+            trace_store: Arc::new(InMemoryTraceStore::new()),
+            audit_reader,
+            startup_time: Instant::now(),
+            active_connections: Arc::new(AtomicI64::new(0)),
+            discovery: Arc::new(DiscoveryService::with_adapters(vec![])),
+            edge_repo: Arc::new(InMemoryEdgeRepo::new()),
+            topology_overview_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(1))
+                .build(),
+            topology_tree_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(5))
+                .build(),
+            topology_team_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(5))
+                .build(),
+            topology_lineage_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(5))
+                .build(),
+            topology_stats_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(10))
+                .build(),
+            capability_store: aa_api::routes::capability::CapabilityStore::new_seeded(),
+            iam_api_key_store: aa_api::routes::iam::seeded_iam_store(),
+        },
+        audit_dir,
+        alert_store_handle,
+        key_store_handle,
+    ))
+}
+
+/// Generate a test API key, returning (plaintext, `ApiKeyEntry`).
+///
+/// The entry can be passed to `TopologyTestEnv::start_with_auth`.
+pub fn make_api_key(id: &str, scopes: Vec<aa_api::auth::scope::Scope>) -> (String, ApiKeyEntry) {
+    let key = ApiKey::generate();
+    let hash = key.hash().expect("hashing should succeed");
+    let entry = ApiKeyEntry {
+        id: id.to_string(),
+        key_hash: hash,
+        scopes,
+        created_at: 1_700_000_000,
+        label: Some(format!("test key {id}")),
+    };
+    (key.as_str().to_string(), entry)
 }


### PR DESCRIPTION
## Description

Implements the 7 live-gateway HTTP integration tests required by AAASM-1485 (F122 ST-D) for `POST /api/v1/auth/token`.

All tests spin up a real `TopologyTestEnv` with `AuthMode::On` via the new `start_with_auth()` builder, send real HTTP requests through `reqwest`, and assert on the actual HTTP response — no mocking.

**Supporting infrastructure added alongside the tests:**

- `ApiKeyStore` gains a `DashMap`-backed `revoked_ids` set, a `revoke()` method, and `validate_detailed()` that distinguishes `Revoked` from `NotFound`. `validate()` is updated to delegate to it.
- `AuthenticatedCaller` extractor uses `validate_detailed()` so revoked keys produce a `"revoked API key"` error message distinct from `"invalid API key"`.
- `TopologyTestEnv` gains a public `key_store: Arc<ApiKeyStore>` field so tests can call `revoke()` on the live server's store mid-test.
- New helpers in `common/mod.rs`: `start_with_auth()`, `build_test_state_with_auth()`, `make_api_key()`, `AUTH_IT_JWT_SECRET`.

**Divergence from ticket AC:** The JIRA ticket was drafted against a `{api_key, secret}` body design. The implemented endpoint authenticates via `Authorization: Bearer <aa_key>` header with an optional `{"scopes":[…]}` body. Tests match the actual implementation.

## Type of Change

- [x] ✅ Integration tests added

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1485
- Parent story: AAASM-1259
- Epic: AAASM-1199

## Testing

- [x] Integration tests added / updated

**Tests added (`aa-integration-tests/tests/api_auth.rs`):**

Happy path:
1. `auth_token_with_valid_api_key_returns_jwt` — 200 + `{token, expires_at, scopes}` shape
2. `auth_token_jwt_is_well_formed` — JWT verified with `JwtVerifier`; `sub`/`exp`/`iat`/`scope` all present
3. `auth_token_with_scoped_api_key_returns_scoped_jwt` — JWT scope matches key grant

Error paths:
4. `auth_token_with_unknown_api_key_returns_401` — unregistered key → 401
5. `auth_token_without_auth_header_returns_401` — no Authorization header → 401
6. `auth_token_with_revoked_key_returns_401` — revoked key → 401 + detail contains "revoked"

Rate limit:
7. `auth_token_rate_limit_applies_per_api_key` — 10 requests at 5 rpm → mix of 200 and 429

All 7 tests pass locally (`cargo nextest run --test api_auth`: 7 passed, 0 skipped).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention