### PR TITLE
[AAASM-1488] ✅ (aa-integration-tests): Add api_approvals.rs — 12 HITL live-gateway tests

### DIFF
--- a/aa-api/src/routes/approvals.rs
+++ b/aa-api/src/routes/approvals.rs
@@ -352,9 +352,13 @@ pub async fn reject_action(
     let uuid = Uuid::parse_str(&id)
         .map_err(|_| ProblemDetail::from_status(StatusCode::BAD_REQUEST).with_detail(format!("Invalid UUID: {id}")))?;
 
+    let reason = body.reason.filter(|r| !r.trim().is_empty()).ok_or_else(|| {
+        ProblemDetail::from_status(StatusCode::BAD_REQUEST).with_detail("Rejection requires a non-empty reason")
+    })?;
+
     let decision = ApprovalDecision::Rejected {
         by: body.by.unwrap_or_else(|| "api".to_string()),
-        reason: body.reason.unwrap_or_else(|| "rejected via API".to_string()),
+        reason,
     };
 
     state.approval_queue.decide(uuid, decision).map_err(|e| match e {

--- a/aa-api/src/routes/approvals.rs
+++ b/aa-api/src/routes/approvals.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use aa_runtime::approval::{ApprovalDecision, ApprovalLookup, PendingApprovalRequest, ResolvedRecord};
+use aa_runtime::approval::{ApprovalDecision, ApprovalError, ApprovalLookup, PendingApprovalRequest, ResolvedRecord};
 use utoipa::IntoParams;
 
 use crate::error::ProblemDetail;
@@ -307,8 +307,12 @@ pub async fn approve_action(
         reason: body.reason,
     };
 
-    state.approval_queue.decide(uuid, decision).map_err(|_| {
-        ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Approval request not found: {id}"))
+    state.approval_queue.decide(uuid, decision).map_err(|e| match e {
+        ApprovalError::AlreadyDecided => ProblemDetail::from_status(StatusCode::CONFLICT)
+            .with_detail(format!("Approval request has already been decided: {id}")),
+        ApprovalError::NotFound => {
+            ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Approval request not found: {id}"))
+        }
     })?;
 
     Ok((
@@ -353,8 +357,12 @@ pub async fn reject_action(
         reason: body.reason.unwrap_or_else(|| "rejected via API".to_string()),
     };
 
-    state.approval_queue.decide(uuid, decision).map_err(|_| {
-        ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Approval request not found: {id}"))
+    state.approval_queue.decide(uuid, decision).map_err(|e| match e {
+        ApprovalError::AlreadyDecided => ProblemDetail::from_status(StatusCode::CONFLICT)
+            .with_detail(format!("Approval request has already been decided: {id}")),
+        ApprovalError::NotFound => {
+            ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Approval request not found: {id}"))
+        }
     })?;
 
     Ok((

--- a/aa-integration-tests/tests/api_approvals.rs
+++ b/aa-integration-tests/tests/api_approvals.rs
@@ -1,0 +1,378 @@
+//! Live-gateway HTTP integration tests for `/api/v1/approvals/*` (AAASM-1488 / F122 ST-G).
+//!
+//! Exercises the HITL approval workflow end-to-end via a real running
+//! `TopologyTestEnv` and `reqwest` HTTP calls. State is seeded directly
+//! through `env.approval_queue` — no mocking.
+//!
+//! Test matrix:
+//! - List ×3: empty, pending-only default, agent filter
+//! - Inspect ×2: full request shape, unknown id 404
+//! - Approve ×3: happy path + state update, already-decided 409, unknown 404
+//! - Reject ×3: with reason 200, without reason 400, after approve 409
+//! - Expiry ×1: timed-out request appears in `?status=timed_out`
+
+mod common;
+
+use std::time::Duration;
+
+use aa_core::PolicyResult;
+use aa_runtime::approval::{ApprovalDecision, ApprovalRequest};
+use common::TopologyTestEnv;
+use uuid::Uuid;
+
+fn make_approval(agent_id: &str, action: &str) -> ApprovalRequest {
+    ApprovalRequest {
+        request_id: Uuid::new_v4(),
+        agent_id: agent_id.to_string(),
+        action: action.to_string(),
+        condition_triggered: "f122-approvals-it".to_string(),
+        submitted_at: 1_700_000_000,
+        timeout_secs: 3600,
+        fallback: PolicyResult::Deny {
+            reason: "timed out".to_string(),
+        },
+        team_id: None,
+        timeout_override_secs: None,
+        escalation_role_override: None,
+    }
+}
+
+// =============================================================================
+// List (3 tests)
+// =============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn approvals_list_empty_returns_200_and_empty_array() {
+    let env = TopologyTestEnv::start().await.expect("harness should start");
+    let client = reqwest::Client::new();
+
+    let resp = client
+        .get(format!("{}/api/v1/approvals", env.base_url()))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(resp.status(), 200);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(json["total"], 0);
+    assert!(json["items"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn approvals_list_pending_only_by_default() {
+    let env = TopologyTestEnv::start().await.expect("harness should start");
+    let client = reqwest::Client::new();
+
+    let pending_req = make_approval("f122-approvals-it-list-pending", "tool.invoke");
+    let pending_id = pending_req.request_id;
+    env.approval_queue.submit(pending_req);
+
+    // Seed a second request and approve it immediately so it leaves the pending queue.
+    let approved_req = make_approval("f122-approvals-it-list-approved", "tool.invoke");
+    let approved_id = approved_req.request_id;
+    env.approval_queue.submit(approved_req);
+    env.approval_queue
+        .decide(
+            approved_id,
+            ApprovalDecision::Approved {
+                by: "f122-approvals-it-approver".to_string(),
+                reason: None,
+            },
+        )
+        .expect("decide should succeed");
+
+    let resp = client
+        .get(format!("{}/api/v1/approvals", env.base_url()))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(resp.status(), 200);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(json["total"], 1, "default list must return only pending");
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["id"], pending_id.to_string());
+    assert_eq!(items[0]["status"], "pending");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn approvals_list_filter_by_agent() {
+    let env = TopologyTestEnv::start().await.expect("harness should start");
+    let client = reqwest::Client::new();
+
+    let req_a = make_approval("f122-approvals-it-alice", "tool.invoke");
+    let id_a = req_a.request_id;
+    env.approval_queue.submit(req_a);
+
+    let req_b = make_approval("f122-approvals-it-bob", "tool.invoke");
+    env.approval_queue.submit(req_b);
+
+    let resp = client
+        .get(format!(
+            "{}/api/v1/approvals?agent=f122-approvals-it-alice",
+            env.base_url()
+        ))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(resp.status(), 200);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(json["total"], 1, "agent filter must narrow to alice only");
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items[0]["id"], id_a.to_string());
+    assert_eq!(items[0]["agent_id"], "f122-approvals-it-alice");
+}
+
+// =============================================================================
+// Inspect (2 tests)
+// =============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn approvals_inspect_returns_full_request() {
+    let env = TopologyTestEnv::start().await.expect("harness should start");
+    let client = reqwest::Client::new();
+
+    let req = make_approval("f122-approvals-it-inspect-agent", "sensitive.action");
+    let id = req.request_id;
+    env.approval_queue.submit(req);
+
+    let resp = client
+        .get(format!("{}/api/v1/approvals/{id}", env.base_url()))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(resp.status(), 200);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(json["id"], id.to_string());
+    assert_eq!(json["agent_id"], "f122-approvals-it-inspect-agent");
+    assert_eq!(json["action"], "sensitive.action");
+    assert_eq!(json["status"], "pending");
+    assert!(
+        !json["created_at"].as_str().unwrap_or("").is_empty(),
+        "created_at must be present"
+    );
+    assert!(
+        !json["expires_at"].as_str().unwrap_or("").is_empty(),
+        "expires_at must be present for pending"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn approvals_inspect_unknown_id_returns_404() {
+    let env = TopologyTestEnv::start().await.expect("harness should start");
+    let client = reqwest::Client::new();
+
+    let fake_id = Uuid::new_v4();
+    let resp = client
+        .get(format!("{}/api/v1/approvals/{fake_id}", env.base_url()))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(resp.status(), 404);
+}
+
+// =============================================================================
+// Approve (3 tests)
+// =============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn approvals_approve_pending_returns_200_and_updates_state() {
+    let env = TopologyTestEnv::start().await.expect("harness should start");
+    let client = reqwest::Client::new();
+
+    let req = make_approval("f122-approvals-it-approve-agent", "delete.action");
+    let id = req.request_id;
+    env.approval_queue.submit(req);
+
+    let resp = client
+        .post(format!("{}/api/v1/approvals/{id}/approve", env.base_url()))
+        .json(&serde_json::json!({"by": "f122-approvals-it-approver", "reason": "ok"}))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(resp.status(), 200);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(json["status"], "approved");
+
+    // Subsequent GET must show approved (moved from pending to resolved history).
+    let inspect = client
+        .get(format!("{}/api/v1/approvals/{id}", env.base_url()))
+        .send()
+        .await
+        .expect("inspect request should succeed");
+    assert_eq!(inspect.status(), 200);
+    let inspect_json: serde_json::Value = inspect.json().await.unwrap();
+    assert_eq!(inspect_json["status"], "approved");
+    assert_eq!(inspect_json["id"], id.to_string());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn approvals_approve_already_decided_returns_409() {
+    let env = TopologyTestEnv::start().await.expect("harness should start");
+    let client = reqwest::Client::new();
+
+    let req = make_approval("f122-approvals-it-double-approve-agent", "action");
+    let id = req.request_id;
+    env.approval_queue.submit(req);
+
+    // Pre-approve via the queue directly (first decision).
+    env.approval_queue
+        .decide(
+            id,
+            ApprovalDecision::Approved {
+                by: "f122-approvals-it-first".to_string(),
+                reason: None,
+            },
+        )
+        .expect("first decide should succeed");
+
+    // Second approve attempt via HTTP must return 409 Conflict.
+    let resp = client
+        .post(format!("{}/api/v1/approvals/{id}/approve", env.base_url()))
+        .json(&serde_json::json!({"by": "f122-approvals-it-second"}))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(resp.status(), 409);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("already been decided"),
+        "error body should mention current state: {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn approvals_approve_unknown_id_returns_404() {
+    let env = TopologyTestEnv::start().await.expect("harness should start");
+    let client = reqwest::Client::new();
+
+    let fake_id = Uuid::new_v4();
+    let resp = client
+        .post(format!("{}/api/v1/approvals/{fake_id}/approve", env.base_url()))
+        .json(&serde_json::json!({"by": "f122-approvals-it-approver"}))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(resp.status(), 404);
+}
+
+// =============================================================================
+// Reject (3 tests)
+// =============================================================================
+
+#[tokio::test(flavor = "multi_thread")]
+async fn approvals_reject_with_reason_returns_200() {
+    let env = TopologyTestEnv::start().await.expect("harness should start");
+    let client = reqwest::Client::new();
+
+    let req = make_approval("f122-approvals-it-reject-agent", "dangerous.action");
+    let id = req.request_id;
+    env.approval_queue.submit(req);
+
+    let resp = client
+        .post(format!("{}/api/v1/approvals/{id}/reject", env.base_url()))
+        .json(&serde_json::json!({"by": "f122-approvals-it-reviewer", "reason": "violates policy X"}))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(resp.status(), 200);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(json["status"], "rejected");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn approvals_reject_without_reason_returns_400() {
+    let env = TopologyTestEnv::start().await.expect("harness should start");
+    let client = reqwest::Client::new();
+
+    let req = make_approval("f122-approvals-it-reject-no-reason-agent", "action");
+    let id = req.request_id;
+    env.approval_queue.submit(req);
+
+    let resp = client
+        .post(format!("{}/api/v1/approvals/{id}/reject", env.base_url()))
+        .json(&serde_json::json!({}))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(resp.status(), 400);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("reason"),
+        "error body should mention missing reason: {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn approvals_reject_after_approve_returns_409() {
+    let env = TopologyTestEnv::start().await.expect("harness should start");
+    let client = reqwest::Client::new();
+
+    let req = make_approval("f122-approvals-it-reject-after-approve-agent", "action");
+    let id = req.request_id;
+    env.approval_queue.submit(req);
+
+    let approve_resp = client
+        .post(format!("{}/api/v1/approvals/{id}/approve", env.base_url()))
+        .json(&serde_json::json!({"by": "f122-approvals-it-approver"}))
+        .send()
+        .await
+        .expect("approve request should succeed");
+    assert_eq!(approve_resp.status(), 200);
+
+    // Reject after approve is a terminal-state violation — must return 409.
+    let reject_resp = client
+        .post(format!("{}/api/v1/approvals/{id}/reject", env.base_url()))
+        .json(&serde_json::json!({"reason": "changed mind"}))
+        .send()
+        .await
+        .expect("reject request should succeed");
+
+    assert_eq!(reject_resp.status(), 409);
+}
+
+// =============================================================================
+// Expiry (1 test)
+// =============================================================================
+
+// Seeds a request with a 1-second timeout, waits 1.5 s for the ApprovalQueue's
+// internal tokio timer to fire, then asserts the request appears under
+// `?status=timed_out`. The 50 ms ordering sleep mentioned in the subtask is
+// absorbed into the 1.5 s wait here; no additional sleep needed.
+#[tokio::test(flavor = "multi_thread")]
+async fn approvals_expired_request_listed_with_status_timed_out() {
+    let env = TopologyTestEnv::start().await.expect("harness should start");
+    let client = reqwest::Client::new();
+
+    let mut req = make_approval("f122-approvals-it-expiry-agent", "expire.action");
+    req.timeout_secs = 1;
+    let id = req.request_id;
+    env.approval_queue.submit(req);
+
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    let resp = client
+        .get(format!("{}/api/v1/approvals?status=timed_out", env.base_url()))
+        .send()
+        .await
+        .expect("request should succeed");
+
+    assert_eq!(resp.status(), 200);
+    let json: serde_json::Value = resp.json().await.unwrap();
+    assert!(
+        json["total"].as_u64().unwrap_or(0) >= 1,
+        "timed_out list should contain at least one entry"
+    );
+    let items = json["items"].as_array().unwrap();
+    let found = items.iter().any(|item| item["id"] == id.to_string());
+    assert!(found, "expired request {id} must appear in timed_out list");
+}

--- a/aa-runtime/src/approval.rs
+++ b/aa-runtime/src/approval.rs
@@ -225,14 +225,18 @@ pub enum ApprovalDecision {
 /// Errors returned by [`ApprovalQueue::decide`].
 #[derive(Debug, PartialEq, Eq)]
 pub enum ApprovalError {
-    /// No pending request exists for the given ID (already resolved or never submitted).
+    /// No pending request exists for the given ID and it is not in the resolved history.
     NotFound,
+    /// The request has already been decided (approved, rejected, or timed out).
+    /// Distinct from `NotFound` so callers can return 409 Conflict rather than 404.
+    AlreadyDecided,
 }
 
 impl std::fmt::Display for ApprovalError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::NotFound => write!(f, "approval request not found"),
+            Self::AlreadyDecided => write!(f, "approval request has already been decided"),
         }
     }
 }
@@ -504,11 +508,24 @@ impl ApprovalQueue {
 
     /// Apply an [`ApprovalDecision`] to the request identified by `id`.
     ///
-    /// Returns `Err(ApprovalError::NotFound)` if no pending request exists for
-    /// `id` (already resolved, timed out, or never submitted).
+    /// Returns:
+    /// - `Ok(())` — decision applied successfully.
+    /// - `Err(ApprovalError::AlreadyDecided)` — the request exists in the
+    ///   resolved history (already approved, rejected, or timed out).
+    /// - `Err(ApprovalError::NotFound)` — the id is unknown (never submitted
+    ///   or evicted from the bounded resolved history).
     pub fn decide(&self, id: ApprovalRequestId, decision: ApprovalDecision) -> Result<(), ApprovalError> {
         if self.resolve(id, decision) {
-            Ok(())
+            return Ok(());
+        }
+        // Distinguish "already decided" (in resolved history) from "never submitted".
+        let in_history = self
+            .resolved_history
+            .lock()
+            .map(|g| g.iter().any(|r| r.request_id == id))
+            .unwrap_or(false);
+        if in_history {
+            Err(ApprovalError::AlreadyDecided)
         } else {
             Err(ApprovalError::NotFound)
         }
@@ -930,7 +947,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn decide_after_resolve_returns_not_found() {
+    async fn decide_after_resolve_returns_already_decided() {
         let q = ApprovalQueue::new();
         let req = make_request(60);
         let id = req.request_id;
@@ -952,7 +969,7 @@ mod tests {
                 reason: "too late".to_string(),
             },
         );
-        assert_eq!(result, Err(ApprovalError::NotFound));
+        assert_eq!(result, Err(ApprovalError::AlreadyDecided));
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
## Description

Adds `aa-integration-tests/tests/api_approvals.rs` — 12 live-gateway HTTP integration tests for the `/api/v1/approvals/*` HITL workflow (AAASM-1488 / F122 ST-G). All tests boot a real `TopologyTestEnv` and issue actual HTTP calls via `reqwest`; no mocking.

To support two test cases that exercised missing API semantics, this PR also extends `aa-runtime` and `aa-api`:

- **`aa-runtime`**: Added `ApprovalError::AlreadyDecided` — `decide` now distinguishes a re-decision on a resolved request from a completely unknown id.
- **`aa-api`**: `approve_action` / `reject_action` map `AlreadyDecided` → 409 Conflict (previously both mapped to 404).
- **`aa-api`**: `reject_action` now validates that `reason` is present and non-empty (returns 400 Bad Request); rejection is a governance action and requires a documented rationale.

### Test matrix

| Group | Tests |
|---|---|
| List | `approvals_list_empty_returns_200_and_empty_array`, `approvals_list_pending_only_by_default`, `approvals_list_filter_by_agent` |
| Inspect | `approvals_inspect_returns_full_request`, `approvals_inspect_unknown_id_returns_404` |
| Approve | `approvals_approve_pending_returns_200_and_updates_state`, `approvals_approve_already_decided_returns_409`, `approvals_approve_unknown_id_returns_404` |
| Reject | `approvals_reject_with_reason_returns_200`, `approvals_reject_without_reason_returns_400`, `approvals_reject_after_approve_returns_409` |
| Expiry | `approvals_expired_request_listed_with_status_timed_out` |

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [ ] No
- [x] Yes (describe below)

`POST /api/v1/approvals/{id}/reject` now returns 400 if `reason` is absent or empty. Previously it silently defaulted to `"rejected via API"`. CLI tests that reject via `aasm approvals reject <id> --reason <text>` are unaffected; the CLI always provides a reason.

`ApprovalError::AlreadyDecided` is a new public variant — downstream crates that match exhaustively on `ApprovalError` will need to add a branch.

## Related Issues

- Related Jira ticket: AAASM-1488 (Subtask) / AAASM-1259 (Story) / AAASM-1199 (Epic)

## Testing

- [x] Integration tests added / updated
- [x] Unit tests added / updated (updated `decide_after_resolve_returns_already_decided` in `aa-runtime`)

**Local validation**: `cargo check --workspace`, `cargo clippy --all-targets`, and `cargo fmt` all pass. `cargo nextest run` is blocked locally by a pre-existing `sqlx --check-cfg` link-stage issue on this macOS host (unrelated to these changes — existing `cli_approvals` tests have the same failure). CI validates actual execution.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention