### PR TITLE
[AAASM-1502] 🐛 (docker): Use renamed go-sdk module path in go-1.26-alpine smoke

### DIFF
--- a/docker/Dockerfile.go-1.26-alpine
+++ b/docker/Dockerfile.go-1.26-alpine
@@ -60,7 +60,7 @@ RUN go install github.com/AI-agent-assembly/go-sdk/...@latest
 # Build-time smoke tests — fail the image build (not a runtime surprise)
 # if either side of the install ends up broken.
 RUN aasm --version
-RUN go list github.com/agent-assembly/go-sdk
+RUN go list github.com/AI-agent-assembly/go-sdk
 
 LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
       org.opencontainers.image.description="AAASM governed Go 1.26 agent base image" \


### PR DESCRIPTION
## Description

Updates the smoke `RUN go list` in `docker/Dockerfile.go-1.26-alpine` (line 63) to reference the renamed `go-sdk` module path. This is the agent-assembly side of the cross-repo fix opened in [AAASM-1502](https://lightning-dust-mite.atlassian.net/browse/AAASM-1502); the upstream rename is [go-sdk #31](https://github.com/AI-agent-assembly/go-sdk/pull/31).

### Diff

```diff
- RUN go list github.com/agent-assembly/go-sdk
+ RUN go list github.com/AI-agent-assembly/go-sdk
```

The `go install ...@latest` step one line above already uses the new path (it always did — `go install` resolves via the GitHub URL, which is `AI-agent-assembly/go-sdk`). The smoke `go list` was the half that was left at the old path and that's what surfaced the mismatch in [PR #515](https://github.com/AI-agent-assembly/agent-assembly/pull/515) (AAASM-1225).

### Merge dependency

This PR's CI cannot pass until [go-sdk #31](https://github.com/AI-agent-assembly/go-sdk/pull/31) merges and the renamed module is live on GOPROXY. The `Dockerfile.go-1.26-alpine` build is invoked by:

* AAASM-1225 PR #515 → `build-and-push-language-images` matrix `go` leg
* AAASM-1226 → local verification

Local docker build wasn't run against this branch (would fail until go-sdk #31 merges and GOPROXY indexes the new path). Verification will be the CI run on this PR after go-sdk #31 lands and after rebasing master.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-1502 (sub-task of AAASM-1204 / F114 / Epic AAASM-1199)
- Related GitHub PRs: AI-agent-assembly/go-sdk#31 (upstream rename, must merge first), #476 (original Go Dockerfile that introduced the smoke path), #515 (AAASM-1225 workflow PR whose CI surfaced this)

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

Manual verification:
* go-sdk PR #31 build/vet/test all green inside `golang:1.26-alpine` (see PR #31 description).
* The path on this line aligns with go-sdk's renamed `go.mod` module declaration.
* This PR's Dockerfile CI run will be the canonical confirmation post-go-sdk#31 merge.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy` — no Rust changes here, lefthook pre-commit ran clean)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a — single string change)
- [ ] All CI checks passing — _pending: blocks on go-sdk#31 merging first_
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1502]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ