### PR TITLE
[AAASM-1508] 🐛 (docker): Use `go list -m` for go-sdk smoke in go-1.26-alpine

### DIFF
--- a/docker/Dockerfile.go-1.26-alpine
+++ b/docker/Dockerfile.go-1.26-alpine
@@ -59,8 +59,15 @@ RUN go install github.com/AI-agent-assembly/go-sdk/...@latest
 
 # Build-time smoke tests — fail the image build (not a runtime surprise)
 # if either side of the install ends up broken.
+#
+# `go list -m <module>@latest` is a self-contained query against GOPROXY:
+# it doesn't need a local go.mod (works from `/`), and it asserts the
+# module is resolvable. The plain `go list <import>` form needs both a
+# module context AND a package at the import path — neither holds here
+# (go-sdk's module root has no .go files; sources are under assembly/,
+# internal/ffi/, examples/minimal/). See AAASM-1508.
 RUN aasm --version
-RUN go list github.com/AI-agent-assembly/go-sdk
+RUN go list -m github.com/AI-agent-assembly/go-sdk@latest
 
 LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
       org.opencontainers.image.description="AAASM governed Go 1.26 agent base image" \


### PR DESCRIPTION
## Description

Fixes the build-time smoke failure exposed by AAASM-1225 [PR #515](https://github.com/AI-agent-assembly/agent-assembly/pull/515)'s re-run after the AAASM-1502 path-rename PRs merged:

```
#21 [stage-1 5/5] RUN go list github.com/AI-agent-assembly/go-sdk
#21 0.051 no required module provides package github.com/AI-agent-assembly/go-sdk:
         go.mod file not found in current directory or any parent directory
#21 ERROR: process did not complete successfully: exit code: 1
```

CI log: https://github.com/AI-agent-assembly/agent-assembly/actions/runs/26007958360/job/76442885777

### Root cause — two stacked issues

1. **`go list <import>` needs a Go module context.** The Dockerfile runs the smoke from `/` (default WORKDIR), which has no `go.mod`. The earlier `RUN go install ...@latest` worked because `...@latest` is a self-contained module query; `go list <import>` is not.
2. **The go-sdk module ROOT has no Go package.** Sources live under `assembly/`, `internal/ffi/`, `examples/minimal/`. Even with a module context, `go list github.com/AI-agent-assembly/go-sdk` would fail with "no Go files in …".

The AC's original smoke form was structurally wrong from inception; it only surfaced now because the AAASM-1502 module-path mismatch failed before this step on every previous run.

### Fix

Switch to module-resolution form:

```diff
- RUN go list github.com/AI-agent-assembly/go-sdk
+ RUN go list -m github.com/AI-agent-assembly/go-sdk@latest
```

`go list -m <module>@latest` is a self-contained GOPROXY module query — works from any CWD with no local `go.mod`, asserts the module is resolvable, and is what the AC actually meant.

### Local verification

```
$ docker buildx build --platform=linux/amd64 --load -f docker/Dockerfile.go-1.26-alpine .
…
#20 DONE 0.5s

$ docker run --rm aaasm-test-go:aaasm-1508-fix aasm --version
aasm 0.0.1

$ docker run --rm aaasm-test-go:aaasm-1508-fix go list -m github.com/AI-agent-assembly/go-sdk@latest
github.com/AI-agent-assembly/go-sdk v0.0.0-20260518005601-4ccda102d172
```

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-1508 (sub-task of AAASM-1204 / F114 / Epic AAASM-1199)
- Related GitHub PRs: #476 (introduced the smoke line), #526 (AAASM-1502 path rename — fixed half the bug), #515 (AAASM-1225 workflow PR whose CI re-run exposed this)

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed (docker buildx + docker run; see above)
- [ ] No tests required (explain why)

PR #515 will re-run after this lands + rebase, providing the canonical CI confirmation.

## Pairs with a commit on PR #515

The workflow's `smoke_run` for the `go` matrix entry also references the old form. Will push a coordinated commit on PR #515 to update it after this merges (or in the same review cycle).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy` — n/a, Dockerfile-only)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (inline comment explains why `-m … @latest` form)
- [x] All CI checks passing — _local docker build + smoke pass; no path-filter CI fires on a docker/** change today_
- [x] Commits are small and follow the Gitmoji convention