### PR TITLE
[AAASM-1504] ✨ (aa-api): Add matrix filter query params to GET /capability/matrix

### DIFF
--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -9,10 +9,13 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+use axum::extract::Query;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::{Extension, Json};
+use serde::Deserialize;
 use tokio::sync::RwLock;
+use utoipa::IntoParams;
 
 use aa_gateway::policy::rbac::MutationKind;
 use aa_gateway::policy::scope::PolicyScope;
@@ -123,22 +126,64 @@ impl CapabilityStore {
     }
 }
 
-/// `GET /api/v1/capability/matrix` — return the full agent × resource ×
-/// verb × decision matrix that backs the dashboard Capability Matrix page.
+/// Query parameters for `GET /api/v1/capability/matrix`.
+#[derive(Debug, Default, Deserialize, IntoParams)]
+pub struct MatrixQueryParams {
+    /// Return only the agent row whose `id` matches this value.
+    #[param(example = "research-bot-04")]
+    pub team_id: Option<String>,
+    /// Return only the resource column whose `id` matches this value, and
+    /// filter each agent's caps map to that single resource key.
+    #[param(example = "gmail")]
+    pub tool: Option<String>,
+    /// When `true`, exclude capability cells where all four verb decisions are `na`.
+    #[param(example = true)]
+    pub effective_only: Option<bool>,
+}
+
+/// `GET /api/v1/capability/matrix` — return the agent × resource × verb ×
+/// decision matrix that backs the dashboard Capability Matrix page.
 ///
-/// Returns the full snapshot — resources, agents (each with a `caps` map),
-/// policies, and sample calls — in the exact shape the dashboard's
-/// `CapabilityClient.getMatrix()` consumes.
+/// Optional filters:
+/// - `team_id` — return only the agent row whose `id` matches.
+/// - `tool` — return only the resource column whose `id` matches and filter
+///   each agent's `caps` map to that single key.
+/// - `effective_only=true` — exclude cells where all four verb decisions are `na`.
 #[utoipa::path(
     get,
     path = "/api/v1/capability/matrix",
+    params(MatrixQueryParams),
     responses(
-        (status = 200, description = "Full capability matrix snapshot", body = CapabilityMatrix)
+        (status = 200, description = "Capability matrix snapshot (filtered)", body = CapabilityMatrix)
     ),
     tag = "capability"
 )]
-pub async fn get_matrix(Extension(state): Extension<AppState>) -> (StatusCode, Json<CapabilityMatrix>) {
-    let matrix = state.capability_store.snapshot().await;
+pub async fn get_matrix(
+    Query(params): Query<MatrixQueryParams>,
+    Extension(state): Extension<AppState>,
+) -> (StatusCode, Json<CapabilityMatrix>) {
+    let mut matrix = state.capability_store.snapshot().await;
+
+    if let Some(ref tid) = params.team_id {
+        matrix.agents.retain(|a| &a.id == tid);
+    }
+
+    if let Some(ref tool) = params.tool {
+        matrix.resources.retain(|r| &r.id == tool);
+        for agent in &mut matrix.agents {
+            agent.caps.retain(|k, _| k == tool);
+        }
+    }
+
+    if params.effective_only == Some(true) {
+        use Decision::Na;
+        for agent in &mut matrix.agents {
+            agent
+                .caps
+                .retain(|_, cell| !(cell.read == Na && cell.write == Na && cell.delete == Na && cell.exec == Na));
+        }
+    }
+
     (StatusCode::OK, Json(matrix))
 }
 

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -20,8 +20,6 @@ use utoipa::IntoParams;
 use aa_gateway::policy::rbac::MutationKind;
 use aa_gateway::policy::scope::PolicyScope;
 
-use axum::extract::Query;
-
 use crate::auth::policy_auth::{PolicyAuthorizationDenied, PolicyWriteAuth};
 use crate::error::ProblemDetail;
 use crate::models::capability::{

--- a/aa-integration-tests/tests/api_capability.rs
+++ b/aa-integration-tests/tests/api_capability.rs
@@ -112,11 +112,7 @@ async fn capability_matrix_returns_seeded_data() {
     }
 }
 
-/// `?team_id=` filter is not yet implemented — `get_matrix` ignores all query
-/// parameters and always returns the full matrix. Once per-agent filtering
-/// lands, this test should be updated to assert only the requested agent row
-/// is returned.
-#[ignore = "matrix filter by team_id not implemented; full matrix returned regardless"]
+/// `?team_id=` filter returns only the agent row whose `id` matches.
 #[tokio::test(flavor = "multi_thread")]
 async fn capability_matrix_filter_by_team() {
     let env = TopologyTestEnv::start().await.expect("harness should start");
@@ -131,10 +127,8 @@ async fn capability_matrix_filter_by_team() {
     assert_eq!(agents[0]["id"], "research-bot-04");
 }
 
-/// `?tool=` filter is not yet implemented — the handler ignores the param.
-/// Once per-resource column filtering lands, this test should assert only the
-/// matching column data is included.
-#[ignore = "matrix filter by tool not implemented; full matrix returned regardless"]
+/// `?tool=` filter returns only the matching resource column and filters
+/// each agent's caps map to that single key.
 #[tokio::test(flavor = "multi_thread")]
 async fn capability_matrix_filter_by_tool() {
     let env = TopologyTestEnv::start().await.expect("harness should start");
@@ -149,9 +143,8 @@ async fn capability_matrix_filter_by_tool() {
     assert_eq!(resources[0]["id"], "gmail");
 }
 
-/// `?effective_only=true` should exclude inherited / non-effective grants once
-/// that filter lands. Currently the param is silently ignored.
-#[ignore = "effective_only filter not implemented; all grants (inherited and direct) returned"]
+/// `?effective_only=true` excludes cap cells where all four verb decisions
+/// are `na` (no effective permission).
 #[tokio::test(flavor = "multi_thread")]
 async fn capability_matrix_effective_only_excludes_inherited() {
     let env = TopologyTestEnv::start().await.expect("harness should start");
@@ -166,9 +159,7 @@ async fn capability_matrix_effective_only_excludes_inherited() {
     // Additional assertions about inherited vs effective decisions go here.
 }
 
-/// Unknown `team_id` should return 200 + empty agent list once filtering is
-/// implemented. Currently the param is ignored and the full matrix is returned.
-#[ignore = "matrix filter by team_id not implemented; full matrix returned instead of empty list"]
+/// Unknown `team_id` returns 200 with an empty agent list.
 #[tokio::test(flavor = "multi_thread")]
 async fn capability_matrix_unknown_team_returns_empty() {
     let env = TopologyTestEnv::start().await.expect("harness should start");

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -415,11 +415,13 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * `GET /api/v1/capability/matrix` — return the full agent × resource ×
-         *     verb × decision matrix that backs the dashboard Capability Matrix page.
-         * @description Returns the full snapshot — resources, agents (each with a `caps` map),
-         *     policies, and sample calls — in the exact shape the dashboard's
-         *     `CapabilityClient.getMatrix()` consumes.
+         * `GET /api/v1/capability/matrix` — return the agent × resource × verb ×
+         *     decision matrix that backs the dashboard Capability Matrix page.
+         * @description Optional filters:
+         *     - `team_id` — return only the agent row whose `id` matches.
+         *     - `tool` — return only the resource column whose `id` matches and filter
+         *       each agent's `caps` map to that single key.
+         *     - `effective_only=true` — exclude cells where all four verb decisions are `na`.
          */
         get: operations["get_matrix"];
         put?: never;
@@ -2899,14 +2901,31 @@ export interface operations {
     };
     get_matrix: {
         parameters: {
-            query?: never;
+            query?: {
+                /**
+                 * @description Return only the agent row whose `id` matches this value.
+                 * @example research-bot-04
+                 */
+                team_id?: string | null;
+                /**
+                 * @description Return only the resource column whose `id` matches this value, and
+                 *     filter each agent's caps map to that single resource key.
+                 * @example gmail
+                 */
+                tool?: string | null;
+                /**
+                 * @description When `true`, exclude capability cells where all four verb decisions are `na`.
+                 * @example true
+                 */
+                effective_only?: boolean | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;
         };
         requestBody?: never;
         responses: {
-            /** @description Full capability matrix snapshot */
+            /** @description Capability matrix snapshot (filtered) */
             200: {
                 headers: {
                     [name: string]: unknown;

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -703,16 +703,48 @@ paths:
       tags:
       - capability
       summary: |-
-        `GET /api/v1/capability/matrix` — return the full agent × resource ×
-        verb × decision matrix that backs the dashboard Capability Matrix page.
+        `GET /api/v1/capability/matrix` — return the agent × resource × verb ×
+        decision matrix that backs the dashboard Capability Matrix page.
       description: |-
-        Returns the full snapshot — resources, agents (each with a `caps` map),
-        policies, and sample calls — in the exact shape the dashboard's
-        `CapabilityClient.getMatrix()` consumes.
+        Optional filters:
+        - `team_id` — return only the agent row whose `id` matches.
+        - `tool` — return only the resource column whose `id` matches and filter
+          each agent's `caps` map to that single key.
+        - `effective_only=true` — exclude cells where all four verb decisions are `na`.
       operationId: get_matrix
+      parameters:
+      - name: team_id
+        in: query
+        description: Return only the agent row whose `id` matches this value.
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
+        example: research-bot-04
+      - name: tool
+        in: query
+        description: |-
+          Return only the resource column whose `id` matches this value, and
+          filter each agent's caps map to that single resource key.
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
+        example: gmail
+      - name: effective_only
+        in: query
+        description: When `true`, exclude capability cells where all four verb decisions are `na`.
+        required: false
+        schema:
+          type:
+          - boolean
+          - 'null'
+        example: true
       responses:
         '200':
-          description: Full capability matrix snapshot
+          description: Capability matrix snapshot (filtered)
           content:
             application/json:
               schema:


### PR DESCRIPTION
## Description

Implements `team_id`, `tool`, and `effective_only` query parameters on `GET /api/v1/capability/matrix`.

- **`team_id`** — retains only the agent row whose `id` matches the value; an unknown value returns 200 with an empty `agents` array.
- **`tool`** — retains only the matching resource column and filters each agent's `caps` map to that single key.
- **`effective_only=true`** — drops capability cells where all four verb decisions (`read`, `write`, `delete`, `exec`) are `na`, surfacing only cells with a meaningful permission.

A new `MatrixQueryParams` struct (derived `Deserialize` + `IntoParams`) carries the params; utoipa emits the query-param block into the OpenAPI spec automatically.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1504
- Related GitHub issues: #516 (AAASM-1489 — prior work that wrote and ignored these tests)

## Testing

- [x] Integration tests added / updated

Un-ignored 4 previously `#[ignore]`-marked tests in `aa-integration-tests/tests/api_capability.rs`:
- `capability_matrix_filter_by_team` — `?team_id=research-bot-04` → 1 agent row
- `capability_matrix_filter_by_tool` — `?tool=gmail` → 1 resource column
- `capability_matrix_effective_only_excludes_inherited` — `?effective_only=true` → non-empty agents
- `capability_matrix_unknown_team_returns_empty` — `?team_id=does-not-exist` → 0 agents

All 9 capability integration tests pass locally (`cargo nextest run -p aa-integration-tests --test api_capability`).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention