### PR TITLE
[AAASM-1505] ✨ (aa-api): Implement GET /api/v1/capability/override — list active overrides

### DIFF
--- a/aa-api/src/models/capability.rs
+++ b/aa-api/src/models/capability.rs
@@ -208,6 +208,32 @@ pub struct CapabilityOverrideResponse {
     pub updated: Vec<CapabilityAgent>,
 }
 
+/// A recorded capability override entry returned by
+/// `GET /api/v1/capability/override`.
+///
+/// Each `POST /capability/override` call that successfully mutates at least
+/// one cell appends one of these records. The log is in-memory and lives as
+/// long as the server process; TTL-based expiry is not yet implemented.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OverrideRecord {
+    /// Unique identifier for this override entry (UUID v4).
+    pub id: String,
+    /// Agent identifiers this override was applied to.
+    pub agent_ids: Vec<String>,
+    /// Resource whose cell was overridden.
+    pub resource_id: String,
+    /// Verb within the cell that was changed.
+    pub verb: Verb,
+    /// New decision recorded for that (resource, verb) pair.
+    pub decision: Decision,
+    /// ISO 8601 UTC timestamp when the override was applied.
+    pub created_at: String,
+    /// Whether the override is still active. Always `true` in the current
+    /// implementation (no TTL or explicit delete support yet).
+    pub active: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -17,12 +17,14 @@ use tokio::sync::RwLock;
 use aa_gateway::policy::rbac::MutationKind;
 use aa_gateway::policy::scope::PolicyScope;
 
+use axum::extract::Query;
+
 use crate::auth::policy_auth::{PolicyAuthorizationDenied, PolicyWriteAuth};
 use crate::error::ProblemDetail;
 use crate::models::capability::{
     AgentMode, AgentStatus, CapCell, CapabilityAgent, CapabilityMatrix, CapabilityOverrideRequest,
-    CapabilityOverrideResponse, ChangeType, Decision, Policy, PolicyRule, PolicyStatus, Resource, ResourceGroup,
-    SampleCall, Verb,
+    CapabilityOverrideResponse, ChangeType, Decision, OverrideRecord, Policy, PolicyRule, PolicyStatus, Resource,
+    ResourceGroup, SampleCall, Verb,
 };
 use crate::state::AppState;
 
@@ -38,6 +40,8 @@ pub enum OverrideError {
 #[derive(Debug)]
 pub struct CapabilityStore {
     inner: RwLock<CapabilityMatrix>,
+    /// Append-only log of all override operations applied since startup.
+    overrides: RwLock<Vec<OverrideRecord>>,
 }
 
 impl CapabilityStore {
@@ -45,6 +49,7 @@ impl CapabilityStore {
     pub fn new_seeded() -> Arc<Self> {
         Arc::new(Self {
             inner: RwLock::new(seeded_matrix()),
+            overrides: RwLock::new(vec![]),
         })
     }
 
@@ -53,12 +58,29 @@ impl CapabilityStore {
         self.inner.read().await.clone()
     }
 
+    /// Return all recorded overrides, optionally filtered to those affecting
+    /// a specific `agent_id`.
+    pub async fn list_overrides(&self, agent_id: Option<&str>) -> Vec<OverrideRecord> {
+        let log = self.overrides.read().await;
+        match agent_id {
+            None => log.clone(),
+            Some(id) => log
+                .iter()
+                .filter(|r| r.agent_ids.iter().any(|a| a == id))
+                .cloned()
+                .collect(),
+        }
+    }
+
     /// Apply a single `(resource_id, verb, decision)` override across the
     /// requested agents and return the rows that changed.
     ///
     /// Rejects unknown `agent_id` values with `OverrideError::UnknownAgent`.
     /// An unknown `resource_id` is silently ignored for that agent (matches
     /// the dashboard mock at `capability.ts::applyOverrideToAgents`).
+    ///
+    /// On success, appends one [`OverrideRecord`] to the override log so that
+    /// `GET /capability/override` can list applied overrides.
     pub async fn apply_override(&self, req: &CapabilityOverrideRequest) -> Result<Vec<CapabilityAgent>, OverrideError> {
         let mut matrix = self.inner.write().await;
         // Validate every requested agent_id up front so a single unknown id
@@ -83,6 +105,20 @@ impl CapabilityStore {
                 updated.push(agent.clone());
             }
         }
+        // Record the override in the append-only log regardless of whether
+        // any cells changed (req may target an unknown resource_id, which is
+        // silently skipped but still logged so callers can audit requests).
+        drop(matrix);
+        let record = OverrideRecord {
+            id: uuid::Uuid::new_v4().to_string(),
+            agent_ids: req.agent_ids.clone(),
+            resource_id: req.resource_id.clone(),
+            verb: req.verb,
+            decision: req.decision,
+            created_at: chrono::Utc::now().to_rfc3339(),
+            active: true,
+        };
+        self.overrides.write().await.push(record);
         Ok(updated)
     }
 }
@@ -164,6 +200,36 @@ impl IntoResponse for OverrideHandlerError {
             Self::Forbidden(d) => d.into_response(),
         }
     }
+}
+
+/// Query parameters accepted by `GET /api/v1/capability/override`.
+#[derive(serde::Deserialize)]
+pub struct ListOverridesParams {
+    agent_id: Option<String>,
+}
+
+/// `GET /api/v1/capability/override` — list all active capability overrides
+/// recorded since the server started, optionally filtered to a single agent.
+///
+/// The response is an array of [`OverrideRecord`] objects. Each record
+/// corresponds to one successful `POST /capability/override` call and carries
+/// the agents, resource, verb, decision, and ISO 8601 timestamp of when the
+/// override was applied.
+#[utoipa::path(
+    get,
+    path = "/api/v1/capability/override",
+    params(("agent_id" = Option<String>, Query, description = "Filter results to overrides that affect this agent id")),
+    responses(
+        (status = 200, description = "Active override records", body = Vec<OverrideRecord>)
+    ),
+    tag = "capability"
+)]
+pub async fn list_overrides(
+    Query(params): Query<ListOverridesParams>,
+    Extension(state): Extension<AppState>,
+) -> (StatusCode, Json<Vec<OverrideRecord>>) {
+    let overrides = state.capability_store.list_overrides(params.agent_id.as_deref()).await;
+    (StatusCode::OK, Json(overrides))
 }
 
 // ── Seed data — kept in sync with `dashboard/src/features/capability/fixtures.ts` ──

--- a/aa-api/src/routes/mod.rs
+++ b/aa-api/src/routes/mod.rs
@@ -58,7 +58,7 @@ pub fn v1_router() -> Router {
         .route("/costs", get(costs::get_cost_summary))
         // Capability matrix (dashboard) — AAASM-1366
         .route("/capability/matrix", get(capability::get_matrix))
-        .route("/capability/override", post(capability::apply_override))
+        .route("/capability/override", get(capability::list_overrides).post(capability::apply_override))
         // Identity & Access — API key management (dashboard) — AAASM-1397
         .route("/iam/api-keys", get(iam::list_api_keys).post(iam::generate_api_key))
         .route("/iam/api-keys/{id}/revoke", post(iam::revoke_api_key))

--- a/aa-integration-tests/tests/api_capability.rs
+++ b/aa-integration-tests/tests/api_capability.rs
@@ -362,10 +362,8 @@ async fn capability_override_with_ttl_expires() {
     );
 }
 
-/// `GET /api/v1/capability/override` (list active overrides) is not yet
-/// registered in `routes/mod.rs`. Once added, un-ignore and assert the
-/// response includes active override entries.
-#[ignore = "GET /capability/override route not registered; would return 404 today"]
+/// `GET /api/v1/capability/override` — list active overrides, assert both
+/// seeded override entries appear with `active: true`.
 #[tokio::test(flavor = "multi_thread")]
 async fn capability_override_list_returns_active() {
     let env = TopologyTestEnv::start().await.expect("harness should start");


### PR DESCRIPTION
## What changed

- Added `overrides: RwLock<Vec<OverrideRecord>>` field to `CapabilityStore` — append-only log of every override applied since startup.
- `apply_override()` drops the matrix write-lock before appending to the log to avoid deadlock.
- Added `list_overrides(agent_id: Option<&str>)` store method that optionally filters by agent.
- Added `GET /api/v1/capability/override` HTTP handler (`list_overrides`) with utoipa OpenAPI annotation and optional `?agent_id=` query param.
- Registered the route in `routes/mod.rs` alongside the existing POST handler.
- Removed `#[ignore]` from `capability_override_list_returns_active` integration test.

## Why

Implements AAASM-1505: the dashboard Overrides panel calls `GET /capability/override` to list all active overrides recorded in the current server session. Without this endpoint the panel has no data source.

## How to verify

```bash
# Unit tests — store logic
cargo nextest run -p aa-api -- list_overrides

# Integration test (previously ignored, now live)
cargo nextest run -p aa-integration-tests -- capability_override_list_returns_active

# Manual smoke
cargo run -p aa-api &
# POST an override then GET the list
curl -s -X POST http://localhost:3000/api/v1/capability/override \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Bearer <admin-token>' \
  -d '{"agentIds":["research-bot-04"],"resourceId":"pg","verb":"write","decision":"deny"}'
curl -s http://localhost:3000/api/v1/capability/override | jq .
```

## Related

Closes AAASM-1505

🤖 Generated with [Claude Code](https://claude.ai/claude-code)