### PR TITLE
[AAASM-1507] ✨ (aa-api): Implement ttl_seconds for expiring capability overrides

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,7 @@ dependencies = [
  "base64",
  "chrono",
  "chrono-tz",
+ "futures",
  "jsonschema",
  "jsonwebtoken",
  "libc",
@@ -320,6 +321,7 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "tokio",
+ "tokio-tungstenite",
  "uuid",
 ]
 

--- a/aa-api/src/models/capability.rs
+++ b/aa-api/src/models/capability.rs
@@ -198,6 +198,11 @@ pub struct CapabilityOverrideRequest {
     pub verb: Verb,
     /// New decision to record for that (resource, verb) pair.
     pub decision: Decision,
+    /// Optional TTL in seconds. When set, the override is automatically
+    /// reverted to the pre-override value after this duration elapses.
+    /// The endpoint returns 201 Created instead of 200 OK when TTL is provided.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttl_seconds: Option<u64>,
 }
 
 /// Response envelope for `POST /api/v1/capability/override`: the subset of
@@ -433,5 +438,19 @@ mod tests {
         assert_eq!(req.resource_id, "pg");
         assert_eq!(req.verb, Verb::Write);
         assert_eq!(req.decision, Decision::Deny);
+        assert_eq!(req.ttl_seconds, None, "ttl_seconds defaults to None when absent");
+    }
+
+    #[test]
+    fn override_request_deserializes_ttl_seconds() {
+        let raw = r#"{
+            "agentIds": ["research-bot-04"],
+            "resourceId": "pg",
+            "verb": "write",
+            "decision": "deny",
+            "ttlSeconds": 30
+        }"#;
+        let req: CapabilityOverrideRequest = serde_json::from_str(raw).unwrap();
+        assert_eq!(req.ttl_seconds, Some(30));
     }
 }

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -8,6 +8,7 @@
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -34,6 +35,16 @@ use crate::state::AppState;
 pub enum OverrideError {
     /// The request named an agent id that the store does not know about.
     UnknownAgent(String),
+}
+
+/// Pre-mutation snapshot of a single (agent, resource, verb) cell, used to
+/// restore the original decision when a TTL expires.
+#[derive(Debug, Clone)]
+struct CellSnapshot {
+    agent_id: String,
+    resource_id: String,
+    verb: Verb,
+    original: Decision,
 }
 
 /// Thread-safe holder for the dashboard Capability Matrix snapshot.
@@ -81,7 +92,15 @@ impl CapabilityStore {
     ///
     /// On success, appends one [`OverrideRecord`] to the override log so that
     /// `GET /capability/override` can list applied overrides.
-    pub async fn apply_override(&self, req: &CapabilityOverrideRequest) -> Result<Vec<CapabilityAgent>, OverrideError> {
+    ///
+    /// When `req.ttl_seconds` is `Some(n)`, a background Tokio task is spawned
+    /// that sleeps for `n` seconds then reverts the affected cells to their
+    /// pre-override decisions. The `Arc<Self>` receiver is required so the
+    /// background task can hold a reference to the store beyond the call.
+    pub async fn apply_override(
+        self: Arc<Self>,
+        req: &CapabilityOverrideRequest,
+    ) -> Result<Vec<CapabilityAgent>, OverrideError> {
         let mut matrix = self.inner.write().await;
         // Validate every requested agent_id up front so a single unknown id
         // rejects the whole request without partial mutation.
@@ -90,12 +109,26 @@ impl CapabilityStore {
                 return Err(OverrideError::UnknownAgent(id.clone()));
             }
         }
+
+        let mut snapshots: Vec<CellSnapshot> = Vec::new();
         let mut updated = Vec::with_capacity(req.agent_ids.len());
         for agent in matrix.agents.iter_mut() {
             if !req.agent_ids.contains(&agent.id) {
                 continue;
             }
             if let Some(cell) = agent.caps.get_mut(&req.resource_id) {
+                let original = match req.verb {
+                    Verb::Read => cell.read,
+                    Verb::Write => cell.write,
+                    Verb::Delete => cell.delete,
+                    Verb::Exec => cell.exec,
+                };
+                snapshots.push(CellSnapshot {
+                    agent_id: agent.id.clone(),
+                    resource_id: req.resource_id.clone(),
+                    verb: req.verb,
+                    original,
+                });
                 match req.verb {
                     Verb::Read => cell.read = req.decision,
                     Verb::Write => cell.write = req.decision,
@@ -119,7 +152,34 @@ impl CapabilityStore {
             active: true,
         };
         self.overrides.write().await.push(record);
+
+        if let Some(ttl_secs) = req.ttl_seconds {
+            let store = Arc::clone(&self);
+            tokio::spawn(async move {
+                tokio::time::sleep(Duration::from_secs(ttl_secs)).await;
+                store.revert_override(snapshots).await;
+            });
+        }
+
         Ok(updated)
+    }
+
+    /// Restore cell decisions to their pre-override values. Called by the
+    /// background TTL expiry task spawned in `apply_override`.
+    async fn revert_override(&self, snapshots: Vec<CellSnapshot>) {
+        let mut matrix = self.inner.write().await;
+        for snap in snapshots {
+            if let Some(agent) = matrix.agents.iter_mut().find(|a| a.id == snap.agent_id) {
+                if let Some(cell) = agent.caps.get_mut(&snap.resource_id) {
+                    match snap.verb {
+                        Verb::Read => cell.read = snap.original,
+                        Verb::Write => cell.write = snap.original,
+                        Verb::Delete => cell.delete = snap.original,
+                        Verb::Exec => cell.exec = snap.original,
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -151,12 +211,17 @@ pub async fn get_matrix(Extension(state): Extension<AppState>) -> (StatusCode, J
 /// uses this to drive an optimistic-UI rollback when an override fails.
 /// An unknown `agentId` rejects the request with 400 and leaves the store
 /// untouched; an unknown `resourceId` on an agent is silently skipped.
+///
+/// When `ttlSeconds` is present the override is automatically reverted after
+/// that many seconds and the response status is **201 Created**. Without a
+/// TTL the response is **200 OK** (unchanged behaviour).
 #[utoipa::path(
     post,
     path = "/api/v1/capability/override",
     request_body = CapabilityOverrideRequest,
     responses(
-        (status = 200, description = "Updated agent rows", body = CapabilityOverrideResponse),
+        (status = 200, description = "Updated agent rows (no TTL)", body = CapabilityOverrideResponse),
+        (status = 201, description = "Updated agent rows with TTL scheduled", body = CapabilityOverrideResponse),
         (status = 400, description = "Unknown agent id"),
         (status = 403, description = "Caller lacks the role required to mutate capability state")
     ),
@@ -171,8 +236,8 @@ pub async fn apply_override(
         .check_mutation(&PolicyScope::Global, MutationKind::Update)
         .map_err(OverrideHandlerError::Forbidden)?;
 
-    let updated = state
-        .capability_store
+    let has_ttl = body.ttl_seconds.is_some();
+    let updated = Arc::clone(&state.capability_store)
         .apply_override(&body)
         .await
         .map_err(|e| match e {
@@ -181,7 +246,8 @@ pub async fn apply_override(
             ),
         })?;
 
-    Ok((StatusCode::OK, Json(CapabilityOverrideResponse { updated })))
+    let status = if has_ttl { StatusCode::CREATED } else { StatusCode::OK };
+    Ok((status, Json(CapabilityOverrideResponse { updated })))
 }
 
 /// Unified error type for the override handler so 400 and 403 paths render
@@ -522,7 +588,7 @@ mod tests {
             decision: Decision::Deny,
             ttl_seconds: None,
         };
-        let updated = store.apply_override(&req).await.unwrap();
+        let updated = Arc::clone(&store).apply_override(&req).await.unwrap();
         assert_eq!(updated.len(), 1);
         assert_eq!(updated[0].id, target_agent);
         assert_eq!(updated[0].caps.get("pg").unwrap().write, Decision::Deny);
@@ -540,7 +606,7 @@ mod tests {
     #[tokio::test]
     async fn apply_override_rejects_unknown_agent() {
         let store = CapabilityStore::new_seeded();
-        let err = store
+        let err = Arc::clone(&store)
             .apply_override(&CapabilityOverrideRequest {
                 agent_ids: vec!["does-not-exist".into()],
                 resource_id: "pg".into(),
@@ -557,7 +623,7 @@ mod tests {
     async fn apply_override_skips_unknown_resource_silently() {
         let store = CapabilityStore::new_seeded();
         let target = store.snapshot().await.agents[0].id.clone();
-        let updated = store
+        let updated = Arc::clone(&store)
             .apply_override(&CapabilityOverrideRequest {
                 agent_ids: vec![target],
                 resource_id: "nonexistent-resource".into(),

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -520,6 +520,7 @@ mod tests {
             resource_id: "pg".into(),
             verb: Verb::Write,
             decision: Decision::Deny,
+            ttl_seconds: None,
         };
         let updated = store.apply_override(&req).await.unwrap();
         assert_eq!(updated.len(), 1);
@@ -545,6 +546,7 @@ mod tests {
                 resource_id: "pg".into(),
                 verb: Verb::Read,
                 decision: Decision::Allow,
+                ttl_seconds: None,
             })
             .await
             .unwrap_err();
@@ -561,6 +563,7 @@ mod tests {
                 resource_id: "nonexistent-resource".into(),
                 verb: Verb::Read,
                 decision: Decision::Deny,
+                ttl_seconds: None,
             })
             .await
             .unwrap();

--- a/aa-integration-tests/tests/api_capability.rs
+++ b/aa-integration-tests/tests/api_capability.rs
@@ -317,11 +317,6 @@ async fn capability_override_revoke_then_blocked_in_matrix() {
     );
 }
 
-/// TTL-based override expiry is not implemented — `CapabilityOverrideRequest`
-/// has no `ttl_seconds` field and `CapabilityStore` performs no time-based
-/// eviction. Once TTL support lands (AAASM follow-up), un-ignore this test and
-/// use `tokio::time::pause()` / a mock clock to avoid wallclock flakiness.
-#[ignore = "TTL override expiry not implemented; CapabilityOverrideRequest has no ttl_seconds field"]
 #[tokio::test(flavor = "multi_thread")]
 async fn capability_override_with_ttl_expires() {
     let env = TopologyTestEnv::start().await.expect("harness should start");

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -448,6 +448,10 @@ export interface paths {
          *     uses this to drive an optimistic-UI rollback when an override fails.
          *     An unknown `agentId` rejects the request with 400 and leaves the store
          *     untouched; an unknown `resourceId` on an agent is silently skipped.
+         *
+         *     When `ttlSeconds` is present the override is automatically reverted after
+         *     that many seconds and the response status is **201 Created**. Without a
+         *     TTL the response is **200 OK** (unchanged behaviour).
          */
         post: operations["apply_override"];
         delete?: never;
@@ -1351,6 +1355,13 @@ export interface components {
             decision: components["schemas"]["Decision"];
             /** @description Identifier of the resource whose cell is being overridden. */
             resourceId: string;
+            /**
+             * Format: int64
+             * @description Optional TTL in seconds. When set, the override is automatically
+             *     reverted to the pre-override value after this duration elapses.
+             *     The endpoint returns 201 Created instead of 200 OK when TTL is provided.
+             */
+            ttlSeconds?: number | null;
             /** @description Verb (read / write / delete / exec) within the cell. */
             verb: components["schemas"]["Verb"];
         };
@@ -2930,8 +2941,17 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Updated agent rows */
+            /** @description Updated agent rows (no TTL) */
             200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CapabilityOverrideResponse"];
+                };
+            };
+            /** @description Updated agent rows with TTL scheduled */
+            201: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -731,6 +731,10 @@ paths:
         uses this to drive an optimistic-UI rollback when an override fails.
         An unknown `agentId` rejects the request with 400 and leaves the store
         untouched; an unknown `resourceId` on an agent is silently skipped.
+
+        When `ttlSeconds` is present the override is automatically reverted after
+        that many seconds and the response status is **201 Created**. Without a
+        TTL the response is **200 OK** (unchanged behaviour).
       operationId: apply_override
       requestBody:
         content:
@@ -740,7 +744,13 @@ paths:
         required: true
       responses:
         '200':
-          description: Updated agent rows
+          description: Updated agent rows (no TTL)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CapabilityOverrideResponse'
+        '201':
+          description: Updated agent rows with TTL scheduled
           content:
             application/json:
               schema:
@@ -2196,6 +2206,16 @@ components:
         resourceId:
           type: string
           description: Identifier of the resource whose cell is being overridden.
+        ttlSeconds:
+          type:
+          - integer
+          - 'null'
+          format: int64
+          description: |-
+            Optional TTL in seconds. When set, the override is automatically
+            reverted to the pre-override value after this duration elapses.
+            The endpoint returns 201 Created instead of 200 OK when TTL is provided.
+          minimum: 0
         verb:
           $ref: '#/components/schemas/Verb'
           description: Verb (read / write / delete / exec) within the cell.


### PR DESCRIPTION
## What changed

Added `ttl_seconds: Option<u64>` to `CapabilityOverrideRequest` (model + serde round-trip). When the field is present the `POST /api/v1/capability/override` handler:

- captures a pre-mutation snapshot of each affected `(agent, resource, verb)` cell
- applies the override immediately
- spawns a `tokio::spawn` background task that sleeps for `ttl_seconds` then reverts each cell to its original decision via `revert_override`
- returns **201 Created** instead of 200 OK to signal the override is temporary

## Why it changed

AAASM-1507 identified a gap during AAASM-1489 review: the dashboard capability override panel supports an optional expiry duration but the API had no way to accept or honour it. This commit closes that gap.

## How to verify

```
# Run the previously-ignored integration test directly:
cargo nextest run -p aa-integration-tests capability_override_with_ttl_expires

# Full aa-api unit suite (325 tests):
cargo nextest run -p aa-api
```

The integration test (`capability_override_with_ttl_expires`) sends `"ttlSeconds": 1`, asserts the response is **201**, waits 2 s, then confirms `pg.write` for `research-bot-04` has reverted from `"deny"` back to `"approval"`.

## Commits

1. `✨ (aa-api/models)` — add `ttl_seconds` field + two serde unit tests
2. `✨ (aa-api/routes)` — `CellSnapshot`, `Arc<Self>` receiver, `revert_override`, 201 vs 200
3. `✅ (aa-integration-tests)` — remove `#[ignore]` from `capability_override_with_ttl_expires`

Closes #AAASM-1507