### PR TITLE
[AAASM-1506] ✨ (aa-api): Implement DELETE /capability/override/{id} — revoke override

### DIFF
--- a/aa-api/src/models/capability.rs
+++ b/aa-api/src/models/capability.rs
@@ -205,11 +205,14 @@ pub struct CapabilityOverrideRequest {
     pub ttl_seconds: Option<u64>,
 }
 
-/// Response envelope for `POST /api/v1/capability/override`: the subset of
-/// agent rows that actually changed (matches `OverrideResponse` in the
-/// dashboard's TypeScript mock).
+/// Response envelope for `POST /api/v1/capability/override`: the stable UUID
+/// assigned to this override (use it to `DELETE /capability/override/{id}`)
+/// plus the subset of agent rows that actually changed.
 #[derive(Debug, Clone, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct CapabilityOverrideResponse {
+    /// Stable UUID for this override; pass to `DELETE /capability/override/{id}` to revert.
+    pub override_id: String,
     pub updated: Vec<CapabilityAgent>,
 }
 
@@ -419,8 +422,12 @@ mod tests {
 
     #[test]
     fn override_response_serializes_updated_array() {
-        let resp = CapabilityOverrideResponse { updated: vec![] };
+        let resp = CapabilityOverrideResponse {
+            override_id: "test-id".into(),
+            updated: vec![],
+        };
         let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["overrideId"], "test-id");
         assert!(json["updated"].is_array());
         assert_eq!(json["updated"].as_array().unwrap().len(), 0);
     }

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -85,6 +85,7 @@ use crate::routes::{
         ops::terminate_op,
         capability::get_matrix,
         capability::apply_override,
+        capability::revoke_override,
         iam::list_api_keys,
         iam::generate_api_key,
         iam::revoke_api_key,

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -84,6 +84,7 @@ use crate::routes::{
         ops::resume_op,
         ops::terminate_op,
         capability::get_matrix,
+        capability::list_overrides,
         capability::apply_override,
         capability::revoke_override,
         iam::list_api_keys,

--- a/aa-api/src/routes/capability.rs
+++ b/aa-api/src/routes/capability.rs
@@ -10,6 +10,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use axum::extract::Path;
 use axum::extract::Query;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
@@ -17,6 +18,7 @@ use axum::{Extension, Json};
 use serde::Deserialize;
 use tokio::sync::RwLock;
 use utoipa::IntoParams;
+use uuid::Uuid;
 
 use aa_gateway::policy::rbac::MutationKind;
 use aa_gateway::policy::scope::PolicyScope;
@@ -48,12 +50,34 @@ struct CellSnapshot {
     original: Decision,
 }
 
-/// Thread-safe holder for the dashboard Capability Matrix snapshot.
+/// Reasons a revoke request can fail.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RevokeOverrideError {
+    /// No active override with the supplied id exists.
+    NotFound,
+}
+
+/// Per-agent revert record — tracks the pre-override cell value so
+/// `DELETE /capability/override/{id}` can restore each cell individually.
+#[derive(Debug, Clone)]
+struct RevertRecord {
+    override_id: String,
+    agent_id: String,
+    resource_id: String,
+    verb: Verb,
+    prev_decision: Decision,
+}
+
+/// Thread-safe holder for the dashboard Capability Matrix snapshot, the
+/// append-only override log (for `GET /capability/override`), and the
+/// per-agent revert records (for `DELETE /capability/override/{id}`).
 #[derive(Debug)]
 pub struct CapabilityStore {
     inner: RwLock<CapabilityMatrix>,
     /// Append-only log of all override operations applied since startup.
     overrides: RwLock<Vec<OverrideRecord>>,
+    /// Per-agent pre-override cell values used to revert on DELETE.
+    revert_records: RwLock<Vec<RevertRecord>>,
 }
 
 impl CapabilityStore {
@@ -62,6 +86,7 @@ impl CapabilityStore {
         Arc::new(Self {
             inner: RwLock::new(seeded_matrix()),
             overrides: RwLock::new(vec![]),
+            revert_records: RwLock::new(Vec::new()),
         })
     }
 
@@ -85,14 +110,16 @@ impl CapabilityStore {
     }
 
     /// Apply a single `(resource_id, verb, decision)` override across the
-    /// requested agents and return the rows that changed.
+    /// requested agents.  Returns a stable UUID for the override plus the
+    /// agent rows that actually changed.
     ///
     /// Rejects unknown `agent_id` values with `OverrideError::UnknownAgent`.
     /// An unknown `resource_id` is silently ignored for that agent (matches
     /// the dashboard mock at `capability.ts::applyOverrideToAgents`).
     ///
-    /// On success, appends one [`OverrideRecord`] to the override log so that
-    /// `GET /capability/override` can list applied overrides.
+    /// On success, appends one [`OverrideRecord`] to the override log so
+    /// `GET /capability/override` can list applied overrides, and records
+    /// per-agent revert data so `DELETE /capability/override/{id}` can undo.
     ///
     /// When `req.ttl_seconds` is `Some(n)`, a background Tokio task is spawned
     /// that sleeps for `n` seconds then reverts the affected cells to their
@@ -101,50 +128,62 @@ impl CapabilityStore {
     pub async fn apply_override(
         self: Arc<Self>,
         req: &CapabilityOverrideRequest,
-    ) -> Result<Vec<CapabilityAgent>, OverrideError> {
-        let mut matrix = self.inner.write().await;
-        // Validate every requested agent_id up front so a single unknown id
-        // rejects the whole request without partial mutation.
-        for id in &req.agent_ids {
-            if !matrix.agents.iter().any(|a| &a.id == id) {
-                return Err(OverrideError::UnknownAgent(id.clone()));
-            }
-        }
-
-        let mut snapshots: Vec<CellSnapshot> = Vec::new();
-        let mut updated = Vec::with_capacity(req.agent_ids.len());
-        for agent in matrix.agents.iter_mut() {
-            if !req.agent_ids.contains(&agent.id) {
-                continue;
-            }
-            if let Some(cell) = agent.caps.get_mut(&req.resource_id) {
-                let original = match req.verb {
-                    Verb::Read => cell.read,
-                    Verb::Write => cell.write,
-                    Verb::Delete => cell.delete,
-                    Verb::Exec => cell.exec,
-                };
-                snapshots.push(CellSnapshot {
-                    agent_id: agent.id.clone(),
-                    resource_id: req.resource_id.clone(),
-                    verb: req.verb,
-                    original,
-                });
-                match req.verb {
-                    Verb::Read => cell.read = req.decision,
-                    Verb::Write => cell.write = req.decision,
-                    Verb::Delete => cell.delete = req.decision,
-                    Verb::Exec => cell.exec = req.decision,
+    ) -> Result<(String, Vec<CapabilityAgent>), OverrideError> {
+        let override_id = Uuid::new_v4().to_string();
+        let (updated, revert_items, snapshots) = {
+            let mut matrix = self.inner.write().await;
+            // Validate every requested agent_id up front so a single unknown id
+            // rejects the whole request without partial mutation.
+            for id in &req.agent_ids {
+                if !matrix.agents.iter().any(|a| &a.id == id) {
+                    return Err(OverrideError::UnknownAgent(id.clone()));
                 }
-                updated.push(agent.clone());
             }
-        }
-        // Record the override in the append-only log regardless of whether
-        // any cells changed (req may target an unknown resource_id, which is
-        // silently skipped but still logged so callers can audit requests).
-        drop(matrix);
-        let record = OverrideRecord {
-            id: uuid::Uuid::new_v4().to_string(),
+
+            let mut updated = Vec::with_capacity(req.agent_ids.len());
+            let mut revert_items: Vec<RevertRecord> = Vec::new();
+            let mut snapshots: Vec<CellSnapshot> = Vec::new();
+            for agent in matrix.agents.iter_mut() {
+                if !req.agent_ids.contains(&agent.id) {
+                    continue;
+                }
+                if let Some(cell) = agent.caps.get_mut(&req.resource_id) {
+                    let prev_decision = match req.verb {
+                        Verb::Read => cell.read,
+                        Verb::Write => cell.write,
+                        Verb::Delete => cell.delete,
+                        Verb::Exec => cell.exec,
+                    };
+                    revert_items.push(RevertRecord {
+                        override_id: override_id.clone(),
+                        agent_id: agent.id.clone(),
+                        resource_id: req.resource_id.clone(),
+                        verb: req.verb,
+                        prev_decision,
+                    });
+                    snapshots.push(CellSnapshot {
+                        agent_id: agent.id.clone(),
+                        resource_id: req.resource_id.clone(),
+                        verb: req.verb,
+                        original: prev_decision,
+                    });
+                    match req.verb {
+                        Verb::Read => cell.read = req.decision,
+                        Verb::Write => cell.write = req.decision,
+                        Verb::Delete => cell.delete = req.decision,
+                        Verb::Exec => cell.exec = req.decision,
+                    }
+                    updated.push(agent.clone());
+                }
+            }
+            (updated, revert_items, snapshots)
+        };
+        // Persist revert records for DELETE support.
+        self.revert_records.write().await.extend(revert_items);
+        // Append to the override log regardless of whether any cells changed
+        // (unknown resource_id is silently skipped but still logged).
+        let log_entry = OverrideRecord {
+            id: override_id.clone(),
             agent_ids: req.agent_ids.clone(),
             resource_id: req.resource_id.clone(),
             verb: req.verb,
@@ -152,7 +191,7 @@ impl CapabilityStore {
             created_at: chrono::Utc::now().to_rfc3339(),
             active: true,
         };
-        self.overrides.write().await.push(record);
+        self.overrides.write().await.push(log_entry);
 
         if let Some(ttl_secs) = req.ttl_seconds {
             let store = Arc::clone(&self);
@@ -162,7 +201,49 @@ impl CapabilityStore {
             });
         }
 
-        Ok(updated)
+        Ok((override_id, updated))
+    }
+
+    /// Revert all cell changes made by the override identified by `id`,
+    /// remove its revert records, and mark the log entry as inactive.
+    ///
+    /// Returns `RevokeOverrideError::NotFound` when no active override with
+    /// that id exists.
+    pub async fn revoke_override(&self, id: &str) -> Result<(), RevokeOverrideError> {
+        let records: Vec<RevertRecord> = self
+            .revert_records
+            .read()
+            .await
+            .iter()
+            .filter(|r| r.override_id == id)
+            .cloned()
+            .collect();
+        if records.is_empty() {
+            return Err(RevokeOverrideError::NotFound);
+        }
+        {
+            let mut matrix = self.inner.write().await;
+            for record in &records {
+                if let Some(agent) = matrix.agents.iter_mut().find(|a| a.id == record.agent_id) {
+                    if let Some(cell) = agent.caps.get_mut(&record.resource_id) {
+                        match record.verb {
+                            Verb::Read => cell.read = record.prev_decision,
+                            Verb::Write => cell.write = record.prev_decision,
+                            Verb::Delete => cell.delete = record.prev_decision,
+                            Verb::Exec => cell.exec = record.prev_decision,
+                        }
+                    }
+                }
+            }
+        }
+        self.revert_records.write().await.retain(|r| r.override_id != id);
+        // Mark the log entry inactive so GET /capability/override reflects the revocation.
+        for entry in self.overrides.write().await.iter_mut() {
+            if entry.id == id {
+                entry.active = false;
+            }
+        }
+        Ok(())
     }
 
     /// Restore cell decisions to their pre-override values. Called by the
@@ -280,7 +361,7 @@ pub async fn apply_override(
         .map_err(OverrideHandlerError::Forbidden)?;
 
     let has_ttl = body.ttl_seconds.is_some();
-    let updated = Arc::clone(&state.capability_store)
+    let (override_id, updated) = Arc::clone(&state.capability_store)
         .apply_override(&body)
         .await
         .map_err(|e| match e {
@@ -290,7 +371,7 @@ pub async fn apply_override(
         })?;
 
     let status = if has_ttl { StatusCode::CREATED } else { StatusCode::OK };
-    Ok((status, Json(CapabilityOverrideResponse { updated })))
+    Ok((status, Json(CapabilityOverrideResponse { override_id, updated })))
 }
 
 /// Unified error type for the override handler so 400 and 403 paths render
@@ -339,6 +420,34 @@ pub async fn list_overrides(
 ) -> (StatusCode, Json<Vec<OverrideRecord>>) {
     let overrides = state.capability_store.list_overrides(params.agent_id.as_deref()).await;
     (StatusCode::OK, Json(overrides))
+}
+
+/// `DELETE /api/v1/capability/override/{id}` — revert a previously applied
+/// capability override, restoring each affected cell to its pre-override value.
+///
+/// Returns 204 No Content on success.  Returns 404 when no active override
+/// with the supplied `id` exists (either it was never created or has already
+/// been revoked).
+#[utoipa::path(
+    delete,
+    path = "/api/v1/capability/override/{id}",
+    params(
+        ("id" = String, Path, description = "UUID of the override to revoke")
+    ),
+    responses(
+        (status = 204, description = "Override revoked; cells restored to base policy"),
+        (status = 404, description = "No active override with this id", body = ProblemDetail)
+    ),
+    tag = "capability"
+)]
+pub async fn revoke_override(Extension(state): Extension<AppState>, Path(id): Path<String>) -> impl IntoResponse {
+    match state.capability_store.revoke_override(&id).await {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(RevokeOverrideError::NotFound) => ProblemDetail::from_status(StatusCode::NOT_FOUND)
+            .with_detail(format!("No active override with id: {id}"))
+            .with_instance(format!("/api/v1/capability/override/{id}"))
+            .into_response(),
+    }
 }
 
 // ── Seed data — kept in sync with `dashboard/src/features/capability/fixtures.ts` ──
@@ -631,7 +740,7 @@ mod tests {
             decision: Decision::Deny,
             ttl_seconds: None,
         };
-        let updated = Arc::clone(&store).apply_override(&req).await.unwrap();
+        let (_override_id, updated) = Arc::clone(&store).apply_override(&req).await.unwrap();
         assert_eq!(updated.len(), 1);
         assert_eq!(updated[0].id, target_agent);
         assert_eq!(updated[0].caps.get("pg").unwrap().write, Decision::Deny);
@@ -666,7 +775,7 @@ mod tests {
     async fn apply_override_skips_unknown_resource_silently() {
         let store = CapabilityStore::new_seeded();
         let target = store.snapshot().await.agents[0].id.clone();
-        let updated = Arc::clone(&store)
+        let (_override_id, updated) = Arc::clone(&store)
             .apply_override(&CapabilityOverrideRequest {
                 agent_ids: vec![target],
                 resource_id: "nonexistent-resource".into(),

--- a/aa-api/src/routes/mod.rs
+++ b/aa-api/src/routes/mod.rs
@@ -20,7 +20,7 @@ pub mod tools;
 pub mod topology;
 pub mod traces;
 
-use axum::routing::{get, post};
+use axum::routing::{delete, get, post};
 use axum::Router;
 
 use crate::error::ProblemDetail;
@@ -59,6 +59,7 @@ pub fn v1_router() -> Router {
         // Capability matrix (dashboard) — AAASM-1366
         .route("/capability/matrix", get(capability::get_matrix))
         .route("/capability/override", get(capability::list_overrides).post(capability::apply_override))
+        .route("/capability/override/{id}", delete(capability::revoke_override))
         // Identity & Access — API key management (dashboard) — AAASM-1397
         .route("/iam/api-keys", get(iam::list_api_keys).post(iam::generate_api_key))
         .route("/iam/api-keys/{id}/revoke", post(iam::revoke_api_key))

--- a/aa-integration-tests/tests/api_capability.rs
+++ b/aa-integration-tests/tests/api_capability.rs
@@ -5,20 +5,13 @@
 //! `CapabilityStore::new_seeded()` as the fixture baseline. Auth is `Off` so
 //! all RBAC checks pass without a token.
 //!
-//! ## Route surface discovered from `aa-api/src/routes/capability.rs`
-//!
-//! The module exposes exactly **2 handlers** (not 10 as the ticket description
-//! estimates — the description was written before the implementation settled):
+//! ## Route surface for `aa-api/src/routes/capability.rs`
 //!
 //! | Method | Path | Handler |
 //! |--------|------|---------|
-//! | GET    | `/api/v1/capability/matrix`   | `get_matrix`     |
-//! | POST   | `/api/v1/capability/override` | `apply_override` |
-//!
-//! Filter query params (`team_id`, `tool`, `effective_only`), GET list of
-//! overrides, and DELETE override-by-id are **not yet implemented**. Tests for
-//! those features are marked `#[ignore]` with a note pointing to the relevant
-//! gap; they should be un-ignored once the handlers land.
+//! | GET    | `/api/v1/capability/matrix`        | `get_matrix`      |
+//! | POST   | `/api/v1/capability/override`      | `apply_override`  |
+//! | DELETE | `/api/v1/capability/override/{id}` | `revoke_override` |
 
 mod common;
 
@@ -384,9 +377,7 @@ async fn capability_override_list_returns_active() {
     }
 }
 
-/// `DELETE /api/v1/capability/override/{id}` is not yet registered. Once
-/// added, un-ignore and verify the matrix reverts after deletion.
-#[ignore = "DELETE /capability/override/{id} route not registered; would return 404 today"]
+/// `DELETE /api/v1/capability/override/{id}` reverts the cell and returns 204.
 #[tokio::test(flavor = "multi_thread")]
 async fn capability_override_delete_removes_from_matrix() {
     let env = TopologyTestEnv::start().await.expect("harness should start");
@@ -403,7 +394,7 @@ async fn capability_override_delete_removes_from_matrix() {
         }),
     )
     .await;
-    assert_eq!(create_resp.status(), StatusCode::CREATED);
+    assert_eq!(create_resp.status(), StatusCode::OK);
     let create_body: Value = create_resp.json().await.unwrap();
     let override_id = create_body["overrideId"]
         .as_str()

--- a/aa-integration-tests/tests/api_openapi_contract.rs
+++ b/aa-integration-tests/tests/api_openapi_contract.rs
@@ -45,7 +45,7 @@ fn load_spec() -> Value {
     serde_yaml::from_str(&yaml).expect("openapi/v1.yaml must be valid YAML")
 }
 
-// ── TC-1: spec file loads and has 39 paths ───────────────────────────────────
+// ── TC-1: spec file loads and has 40 paths ───────────────────────────────────
 
 #[test]
 fn openapi_spec_loads_without_errors() {
@@ -60,8 +60,8 @@ fn openapi_spec_loads_without_errors() {
     let path_count = spec["paths"].as_object().expect("spec must have a paths object").len();
 
     assert_eq!(
-        path_count, 39,
-        "openapi/v1.yaml must declare exactly 39 paths, found {path_count}"
+        path_count, 40,
+        "openapi/v1.yaml must declare exactly 40 paths, found {path_count}"
     );
 
     for schema in ["HealthResponse", "ProblemDetail", "PolicyResponse", "AlertResponse"] {
@@ -112,6 +112,7 @@ fn openapi_spec_paths_match_implemented_routes() {
         "/api/v1/auth/token",
         "/api/v1/capability/matrix",
         "/api/v1/capability/override",
+        "/api/v1/capability/override/{id}",
         "/api/v1/costs",
         "/api/v1/health",
         "/api/v1/iam/api-keys",

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -439,7 +439,15 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /**
+         * `GET /api/v1/capability/override` — list all active capability overrides
+         *     recorded since the server started, optionally filtered to a single agent.
+         * @description The response is an array of [`OverrideRecord`] objects. Each record
+         *     corresponds to one successful `POST /capability/override` call and carries
+         *     the agents, resource, verb, decision, and ISO 8601 timestamp of when the
+         *     override was applied.
+         */
+        get: operations["list_overrides"];
         put?: never;
         /**
          * `POST /api/v1/capability/override` — apply a capability override across
@@ -1658,6 +1666,33 @@ export interface components {
             action: string;
             /** @description Operation id from the URL path. */
             op_id: string;
+        };
+        /**
+         * @description A recorded capability override entry returned by
+         *     `GET /api/v1/capability/override`.
+         *
+         *     Each `POST /capability/override` call that successfully mutates at least
+         *     one cell appends one of these records. The log is in-memory and lives as
+         *     long as the server process; TTL-based expiry is not yet implemented.
+         */
+        OverrideRecord: {
+            /**
+             * @description Whether the override is still active. Always `true` in the current
+             *     implementation (no TTL or explicit delete support yet).
+             */
+            active: boolean;
+            /** @description Agent identifiers this override was applied to. */
+            agentIds: string[];
+            /** @description ISO 8601 UTC timestamp when the override was applied. */
+            createdAt: string;
+            /** @description New decision recorded for that (resource, verb) pair. */
+            decision: components["schemas"]["Decision"];
+            /** @description Unique identifier for this override entry (UUID v4). */
+            id: string;
+            /** @description Resource whose cell was overridden. */
+            resourceId: string;
+            /** @description Verb within the cell that was changed. */
+            verb: components["schemas"]["Verb"];
         };
         /** @description Per-scope contribution to an agent's effective permissions. */
         PermissionSourceResponse: {
@@ -2968,6 +3003,29 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CapabilityMatrix"];
+                };
+            };
+        };
+    };
+    list_overrides: {
+        parameters: {
+            query?: {
+                /** @description Filter results to overrides that affect this agent id */
+                agent_id?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Active override records */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OverrideRecord"][];
                 };
             };
         };

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -462,6 +462,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/capability/override/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * `DELETE /api/v1/capability/override/{id}` — revert a previously applied
+         *     capability override, restoring each affected cell to its pre-override value.
+         * @description Returns 204 No Content on success.  Returns 404 when no active override
+         *     with the supplied `id` exists (either it was never created or has already
+         *     been revoked).
+         */
+        delete: operations["revoke_override"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/costs": {
         parameters: {
             query?: never;
@@ -1368,11 +1391,13 @@ export interface components {
             verb: components["schemas"]["Verb"];
         };
         /**
-         * @description Response envelope for `POST /api/v1/capability/override`: the subset of
-         *     agent rows that actually changed (matches `OverrideResponse` in the
-         *     dashboard's TypeScript mock).
+         * @description Response envelope for `POST /api/v1/capability/override`: the stable UUID
+         *     assigned to this override (use it to `DELETE /capability/override/{id}`)
+         *     plus the subset of agent rows that actually changed.
          */
         CapabilityOverrideResponse: {
+            /** @description Stable UUID for this override; pass to `DELETE /capability/override/{id}` to revert. */
+            overrideId: string;
             updated: components["schemas"]["CapabilityAgent"][];
         };
         /**
@@ -2991,6 +3016,36 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    revoke_override: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the override to revoke */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Override revoked; cells restored to base policy */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description No active override with this id */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
             };
         };
     };

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -791,6 +791,34 @@ paths:
           description: Unknown agent id
         '403':
           description: Caller lacks the role required to mutate capability state
+  /api/v1/capability/override/{id}:
+    delete:
+      tags:
+      - capability
+      summary: |-
+        `DELETE /api/v1/capability/override/{id}` — revert a previously applied
+        capability override, restoring each affected cell to its pre-override value.
+      description: |-
+        Returns 204 No Content on success.  Returns 404 when no active override
+        with the supplied `id` exists (either it was never created or has already
+        been revoked).
+      operationId: revoke_override
+      parameters:
+      - name: id
+        in: path
+        description: UUID of the override to revoke
+        required: true
+        schema:
+          type: string
+      responses:
+        '204':
+          description: Override revoked; cells restored to base policy
+        '404':
+          description: No active override with this id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
   /api/v1/costs:
     get:
       tags:
@@ -2254,12 +2282,16 @@ components:
     CapabilityOverrideResponse:
       type: object
       description: |-
-        Response envelope for `POST /api/v1/capability/override`: the subset of
-        agent rows that actually changed (matches `OverrideResponse` in the
-        dashboard's TypeScript mock).
+        Response envelope for `POST /api/v1/capability/override`: the stable UUID
+        assigned to this override (use it to `DELETE /capability/override/{id}`)
+        plus the subset of agent rows that actually changed.
       required:
+      - overrideId
       - updated
       properties:
+        overrideId:
+          type: string
+          description: Stable UUID for this override; pass to `DELETE /capability/override/{id}` to revert.
         updated:
           type: array
           items:

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -750,6 +750,34 @@ paths:
               schema:
                 $ref: '#/components/schemas/CapabilityMatrix'
   /api/v1/capability/override:
+    get:
+      tags:
+      - capability
+      summary: |-
+        `GET /api/v1/capability/override` — list all active capability overrides
+        recorded since the server started, optionally filtered to a single agent.
+      description: |-
+        The response is an array of [`OverrideRecord`] objects. Each record
+        corresponds to one successful `POST /capability/override` call and carries
+        the agents, resource, verb, decision, and ISO 8601 timestamp of when the
+        override was applied.
+      operationId: list_overrides
+      parameters:
+      - name: agent_id
+        in: query
+        description: Filter results to overrides that affect this agent id
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: Active override records
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/OverrideRecord'
     post:
       tags:
       - capability
@@ -2742,6 +2770,49 @@ components:
         op_id:
           type: string
           description: Operation id from the URL path.
+    OverrideRecord:
+      type: object
+      description: |-
+        A recorded capability override entry returned by
+        `GET /api/v1/capability/override`.
+
+        Each `POST /capability/override` call that successfully mutates at least
+        one cell appends one of these records. The log is in-memory and lives as
+        long as the server process; TTL-based expiry is not yet implemented.
+      required:
+      - id
+      - agentIds
+      - resourceId
+      - verb
+      - decision
+      - createdAt
+      - active
+      properties:
+        active:
+          type: boolean
+          description: |-
+            Whether the override is still active. Always `true` in the current
+            implementation (no TTL or explicit delete support yet).
+        agentIds:
+          type: array
+          items:
+            type: string
+          description: Agent identifiers this override was applied to.
+        createdAt:
+          type: string
+          description: ISO 8601 UTC timestamp when the override was applied.
+        decision:
+          $ref: '#/components/schemas/Decision'
+          description: New decision recorded for that (resource, verb) pair.
+        id:
+          type: string
+          description: Unique identifier for this override entry (UUID v4).
+        resourceId:
+          type: string
+          description: Resource whose cell was overridden.
+        verb:
+          $ref: '#/components/schemas/Verb'
+          description: Verb within the cell that was changed.
     PermissionSourceResponse:
       type: object
       description: Per-scope contribution to an agent's effective permissions.


### PR DESCRIPTION
## What changed

Implements `DELETE /api/v1/capability/override/{id}` — the revoke endpoint that was discovered as missing during AAASM-1489 testing and tracked in AAASM-1506.

Key changes:
- **`CapabilityOverrideResponse`** gains a stable `override_id: String` (wire: `overrideId`) so POST callers receive a UUID they can later pass to DELETE
- **`CapabilityStore`** now tracks applied overrides via `OverrideRecord` (captures pre-override cell decision per agent/resource/verb tuple)
- **`apply_override` store method** returns `(String, Vec<CapabilityAgent>)` — UUID + changed rows
- **`revoke_override` store method** restores all affected cells to their pre-override decisions and removes the records
- **`revoke_override` HTTP handler** returns 204 on success, 404 (ProblemDetail) when the id is unknown
- **Route registered** at `DELETE /capability/override/{id}` in `v1_router()`
- **OpenAPI path added** via `utoipa::path(delete, ...)` annotation + entry in `openapi.rs`
- **Integration test `capability_override_delete_removes_from_matrix`** un-ignored and verified passing; POST status assertion corrected from 201 → 200

## Why it changed

AAASM-1489 surfaced that `POST /capability/override` had no corresponding revoke path, leaving the UI unable to roll back overrides. AAASM-1506 tracks the implementation of the missing DELETE endpoint.

## How to verify

```
cargo nextest run -p aa-integration-tests --test api_capability
# All 6 tests must pass (previously 5 passed + 1 ignored)
```

Manual smoke test:
1. `POST /api/v1/capability/override` with `{ "agentIds": ["research-bot-04"], "resourceId": "pg", "verb": "write", "decision": "deny" }` → captures `overrideId`
2. `GET /api/v1/capability/matrix` → `agents[research-bot-04].caps.pg.write == "deny"`
3. `DELETE /api/v1/capability/override/{overrideId}` → 204
4. `GET /api/v1/capability/matrix` → `agents[research-bot-04].caps.pg.write == "approval"` (seeded value restored)
5. `DELETE /api/v1/capability/override/{overrideId}` (repeat) → 404

Closes #AAASM-1506

🤖 Generated with [Claude Code](https://claude.com/claude-code)