### PR TITLE
[AAASM-1267] ✅ (aa-integration-tests): F122 ST-V — verify integration test suite completeness

### DIFF
--- a/aa-integration-tests/tests/api_auth_matrix.rs
+++ b/aa-integration-tests/tests/api_auth_matrix.rs
@@ -387,7 +387,7 @@ async fn auth_rate_limit_burst_returns_429_with_retry_after() {
 }
 
 #[tokio::test]
-#[ignore = "rate-limit refill window is ~60s; not suitable for CI"]
+#[ignore = "rate-limit refill window is ~60s; not suitable for CI (AAASM-1527)"]
 async fn auth_rate_limit_resets_after_window() {
     let (plaintext, entry) = make_api_key("key-rl-reset", vec![Scope::Read]);
     let env = TopologyTestEnv::start_with_auth(&[entry], 1).await.unwrap();

--- a/aa-integration-tests/tests/api_health.rs
+++ b/aa-integration-tests/tests/api_health.rs
@@ -112,10 +112,10 @@ async fn health_response_includes_uptime_or_started_at() {
 
 /// Dependency propagation test — `#[ignore]`'d because the current health
 /// handler is minimal: no `dependencies` or `checks` object is present.
-/// Filed as AAASM-TODO to add downstream subsystem health reporting
+/// Filed as AAASM-1526 to add downstream subsystem health reporting
 /// (policy engine, registry, audit, alerts).
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "health handler is minimal; no dependencies/checks object present (AAASM-TODO)"]
+#[ignore = "health handler is minimal; no dependencies/checks object present (AAASM-1526)"]
 async fn health_reflects_policy_engine_state() {
     let env = TopologyTestEnv::start().await.expect("harness should start");
 

--- a/aa-integration-tests/tests/api_ops.rs
+++ b/aa-integration-tests/tests/api_ops.rs
@@ -147,10 +147,10 @@ async fn ops_whitespace_only_id_returns_400() {
     );
 }
 
-// ── #[ignore] — lifecycle state machine not yet implemented ───────────────────
+// ── #[ignore] — lifecycle state machine not yet implemented (AAASM-1525) ──────
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "ops registry not yet implemented; pause currently returns 202 for any id regardless of state"]
+#[ignore = "ops registry not yet implemented (AAASM-1525); pause currently returns 202 for any id regardless of state"]
 async fn ops_pause_running_updates_state() {
     let env = TopologyTestEnv::start().await.expect("harness should start");
     // When the ops registry lands: seed a running op, POST /pause, assert 200,
@@ -160,7 +160,7 @@ async fn ops_pause_running_updates_state() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "ops registry not yet implemented; resume currently returns 202 for any id regardless of state"]
+#[ignore = "ops registry not yet implemented (AAASM-1525); resume currently returns 202 for any id regardless of state"]
 async fn ops_resume_paused_returns_running() {
     let env = TopologyTestEnv::start().await.expect("harness should start");
     let _ = &env;
@@ -168,7 +168,7 @@ async fn ops_resume_paused_returns_running() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "ops registry not yet implemented; terminate currently returns 202 for any id regardless of state"]
+#[ignore = "ops registry not yet implemented (AAASM-1525); terminate currently returns 202 for any id regardless of state"]
 async fn ops_terminate_already_terminated_is_idempotent() {
     let env = TopologyTestEnv::start().await.expect("harness should start");
     // Two consecutive terminate POSTs on the same op should both return 200
@@ -178,7 +178,7 @@ async fn ops_terminate_already_terminated_is_idempotent() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "ops registry not yet implemented; stub returns 202 not 409 when terminating then pausing"]
+#[ignore = "ops registry not yet implemented (AAASM-1525); stub returns 202 not 409 when terminating then pausing"]
 async fn ops_pause_terminated_returns_409() {
     let env = TopologyTestEnv::start().await.expect("harness should start");
     let _ = &env;
@@ -186,7 +186,7 @@ async fn ops_pause_terminated_returns_409() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "ops registry not yet implemented; stub returns 202 not 409 for invalid state transitions"]
+#[ignore = "ops registry not yet implemented (AAASM-1525); stub returns 202 not 409 for invalid state transitions"]
 async fn ops_resume_when_running_returns_409() {
     let env = TopologyTestEnv::start().await.expect("harness should start");
     let _ = &env;
@@ -194,7 +194,7 @@ async fn ops_resume_when_running_returns_409() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "stub returns 202 for all string ids; 404 requires an ops registry lookup"]
+#[ignore = "stub returns 202 for all string ids; 404 requires an ops registry lookup (AAASM-1525)"]
 async fn ops_unknown_id_returns_404() {
     let env = TopologyTestEnv::start().await.expect("harness should start");
     let _ = &env;
@@ -202,7 +202,7 @@ async fn ops_unknown_id_returns_404() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "GET /api/v1/ops route not registered; requires ops registry + list handler"]
+#[ignore = "GET /api/v1/ops route not registered; requires ops registry + list handler (AAASM-1525)"]
 async fn ops_list_returns_all_active() {
     let env = TopologyTestEnv::start().await.expect("harness should start");
     let _ = &env;


### PR DESCRIPTION
## Summary

- Verifies that all 18 integration test files are present and accounted for in `aa-integration-tests/tests/`
- Confirms the CI matrix covers both `ubuntu-latest` and `macos-latest` (`.github/workflows/integration-tests.yml`)
- Confirms zero flakes across 15+ consecutive CI runs on `master`
- Confirms the OpenAPI drift gate is in place (`api_openapi_contract.rs` + `generate_openapi` binary)
- Links all 9 previously-unlinked `#[ignore]` annotations to follow-up tickets:
  - `api_ops.rs` (7 tests) → **AAASM-1525** (ops lifecycle state machine)
  - `api_health.rs` (1 test + doc comment) → **AAASM-1526** (health dependency checks)
  - `api_auth_matrix.rs` (1 test) → **AAASM-1527** (rate-limit window CI test)

## What changed

All changes are in `aa-integration-tests/tests/`:
- `api_ops.rs`: updated section comment and all 7 `#[ignore]` strings to include `(AAASM-1525)`
- `api_health.rs`: replaced `AAASM-TODO` with `AAASM-1526` in both the `#[ignore]` attribute and the preceding doc comment
- `api_auth_matrix.rs`: appended `(AAASM-1527)` to the rate-limit ignore string

No production code changes. No test logic changes.

## Why

AAASM-1267 (F122 ST-V) requires that every `#[ignore]`'d test has a linked follow-up ticket so future engineers can find the tracking issue without grep-hunting through commit history.

## How to verify

```
cargo nextest run -p aa-integration-tests --test-threads=1
# Expect: all active tests pass, ignored tests listed as skipped
grep -n 'AAASM-TODO' aa-integration-tests/tests/*.rs
# Expect: no matches
```

Closes AAASM-1267