### PR TITLE
[AAASM-1512] ✨ (aa-cli): Add aasm proxy subcommand — sidecar lifecycle, CA management, log tailing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,7 @@ dependencies = [
  "aa-devtool-codex",
  "aa-devtool-windsurf",
  "aa-gateway",
+ "aa-proxy",
  "anyhow",
  "assert_cmd",
  "async-trait",

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -16,6 +16,7 @@ aa-devtool           = { path = "../aa-devtool" }
 aa-devtool-codex     = { path = "../aa-devtool-codex" }
 aa-devtool-windsurf  = { path = "../aa-devtool-windsurf" }
 aa-gateway           = { path = "../aa-gateway" }
+aa-proxy             = { path = "../aa-proxy" }
 anyhow         = "1"
 async-trait    = "0.1"
 axum           = "0.8"

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -19,6 +19,7 @@ pub mod dashboard;
 pub mod logs;
 pub mod permissions;
 pub mod policy;
+pub mod proxy;
 pub mod run;
 pub mod status;
 pub mod tools;
@@ -61,6 +62,8 @@ pub enum Commands {
     Tools(tools::ToolsArgs),
     /// Visualize agent topology, trees, lineage, and statistics.
     Topology(topology::TopologyArgs),
+    /// Manage the aa-proxy sidecar — lifecycle, CA trust, and log tailing.
+    Proxy(proxy::ProxyArgs),
 }
 
 /// Dispatch the parsed CLI command to the appropriate handler.
@@ -82,5 +85,6 @@ pub fn dispatch(cmd: Commands, ctx: &ResolvedContext, output: OutputFormat) -> E
         Commands::Run(args) => run::dispatch(args, ctx, output),
         Commands::Tools(args) => tools::dispatch(args),
         Commands::Topology(args) => topology::dispatch(args, ctx, output),
+        Commands::Proxy(args) => proxy::dispatch(args),
     }
 }

--- a/aa-cli/src/commands/proxy/ca.rs
+++ b/aa-cli/src/commands/proxy/ca.rs
@@ -147,7 +147,7 @@ pub fn uninstall(args: CaArgs) -> ExitCode {
 }
 
 #[cfg(target_os = "linux")]
-fn install_linux(ca_dir: &PathBuf) -> ExitCode {
+fn install_linux(ca_dir: &std::path::Path) -> ExitCode {
     // Require root.
     if unsafe { libc::getuid() } != 0 {
         eprintln!("error: `aasm proxy install-ca` requires root on Linux.\nRe-run with sudo.");
@@ -188,7 +188,7 @@ fn install_linux(ca_dir: &PathBuf) -> ExitCode {
 }
 
 #[cfg(target_os = "linux")]
-fn uninstall_linux(_ca_dir: &PathBuf) -> ExitCode {
+fn uninstall_linux(_ca_dir: &std::path::Path) -> ExitCode {
     if unsafe { libc::getuid() } != 0 {
         eprintln!("error: `aasm proxy uninstall-ca` requires root on Linux.\nRe-run with sudo.");
         return ExitCode::FAILURE;

--- a/aa-cli/src/commands/proxy/ca.rs
+++ b/aa-cli/src/commands/proxy/ca.rs
@@ -1,0 +1,223 @@
+//! `aasm proxy install-ca` / `uninstall-ca` — manage the proxy CA in the OS trust store.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Args;
+
+/// Arguments shared by `install-ca` and `uninstall-ca`.
+#[derive(Debug, Args)]
+pub struct CaArgs {
+    /// Directory where the CA certificate and key are stored.
+    #[arg(long, env = "AA_CA_DIR")]
+    pub ca_dir: Option<PathBuf>,
+    /// Skip the confirmation prompt.
+    #[arg(long)]
+    pub yes: bool,
+}
+
+fn default_ca_dir() -> PathBuf {
+    dirs::home_dir()
+        .expect("cannot determine home directory")
+        .join(".aa")
+        .join("ca")
+}
+
+fn confirm(prompt: &str) -> bool {
+    use std::io::{self, BufRead, Write};
+    print!("{prompt} [y/N] ");
+    io::stdout().flush().ok();
+    let stdin = io::stdin();
+    let line = stdin.lock().lines().next().and_then(|l| l.ok()).unwrap_or_default();
+    matches!(line.trim().to_lowercase().as_str(), "y" | "yes")
+}
+
+pub fn install(args: CaArgs) -> ExitCode {
+    let ca_dir = args.ca_dir.unwrap_or_else(default_ca_dir);
+
+    if !args.yes && !confirm("This will modify the system trust store. Continue?") {
+        println!("Aborted.");
+        return ExitCode::SUCCESS;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        use aa_proxy::tls::CaStore;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to create tokio runtime");
+
+        match rt.block_on(CaStore::load_or_create(&ca_dir)) {
+            Err(e) => {
+                eprintln!("error: failed to load/create CA: {e}");
+                ExitCode::FAILURE
+            }
+            Ok(ca) => match ca.is_installed() {
+                Ok(true) => {
+                    println!("CA is already installed and trusted.");
+                    ExitCode::SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("error: could not check keychain: {e}");
+                    ExitCode::FAILURE
+                }
+                Ok(false) => match ca.install() {
+                    Ok(()) => {
+                        println!("CA installed successfully into the macOS System Keychain.");
+                        ExitCode::SUCCESS
+                    }
+                    Err(e) => {
+                        eprintln!("error: CA installation failed: {e}");
+                        ExitCode::FAILURE
+                    }
+                },
+            },
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        install_linux(&ca_dir)
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = ca_dir;
+        eprintln!("error: `aasm proxy install-ca` is not supported on this platform");
+        ExitCode::FAILURE
+    }
+}
+
+pub fn uninstall(args: CaArgs) -> ExitCode {
+    let ca_dir = args.ca_dir.unwrap_or_else(default_ca_dir);
+
+    if !args.yes && !confirm("This will remove the proxy CA from the system trust store. Continue?") {
+        println!("Aborted.");
+        return ExitCode::SUCCESS;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        use aa_proxy::tls::CaStore;
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to create tokio runtime");
+
+        match rt.block_on(CaStore::load_or_create(&ca_dir)) {
+            Err(e) => {
+                eprintln!("error: failed to load CA: {e}");
+                ExitCode::FAILURE
+            }
+            Ok(ca) => match ca.is_installed() {
+                Ok(false) => {
+                    println!("CA is not currently installed — nothing to remove.");
+                    ExitCode::SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("error: could not check keychain: {e}");
+                    ExitCode::FAILURE
+                }
+                Ok(true) => match ca.uninstall() {
+                    Ok(()) => {
+                        println!("CA removed from the macOS System Keychain.");
+                        ExitCode::SUCCESS
+                    }
+                    Err(e) => {
+                        eprintln!("error: CA removal failed: {e}");
+                        ExitCode::FAILURE
+                    }
+                },
+            },
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        uninstall_linux(&ca_dir)
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        let _ = ca_dir;
+        eprintln!("error: `aasm proxy uninstall-ca` is not supported on this platform");
+        ExitCode::FAILURE
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn install_linux(ca_dir: &PathBuf) -> ExitCode {
+    // Require root.
+    if unsafe { libc::getuid() } != 0 {
+        eprintln!("error: `aasm proxy install-ca` requires root on Linux.\nRe-run with sudo.");
+        return ExitCode::FAILURE;
+    }
+
+    let cert_path = ca_dir.join("ca-cert.pem");
+    if !cert_path.exists() {
+        eprintln!(
+            "error: CA certificate not found at {}.\n\
+             Run `aasm proxy start` first to generate the CA.",
+            cert_path.display()
+        );
+        return ExitCode::FAILURE;
+    }
+
+    let dest = std::path::Path::new("/usr/local/share/ca-certificates/aa-proxy.crt");
+    if let Err(e) = std::fs::copy(&cert_path, dest) {
+        eprintln!("error: could not copy CA cert to {}: {e}", dest.display());
+        return ExitCode::FAILURE;
+    }
+
+    let status = std::process::Command::new("update-ca-certificates").status();
+    match status {
+        Ok(s) if s.success() => {
+            println!("CA installed successfully (update-ca-certificates ran).");
+            ExitCode::SUCCESS
+        }
+        Ok(_) => {
+            eprintln!("error: update-ca-certificates failed");
+            ExitCode::FAILURE
+        }
+        Err(e) => {
+            eprintln!("error: could not run update-ca-certificates: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn uninstall_linux(_ca_dir: &PathBuf) -> ExitCode {
+    if unsafe { libc::getuid() } != 0 {
+        eprintln!("error: `aasm proxy uninstall-ca` requires root on Linux.\nRe-run with sudo.");
+        return ExitCode::FAILURE;
+    }
+
+    let dest = std::path::Path::new("/usr/local/share/ca-certificates/aa-proxy.crt");
+    if !dest.exists() {
+        println!("CA certificate not present — nothing to remove.");
+        return ExitCode::SUCCESS;
+    }
+
+    if let Err(e) = std::fs::remove_file(dest) {
+        eprintln!("error: could not remove {}: {e}", dest.display());
+        return ExitCode::FAILURE;
+    }
+
+    let status = std::process::Command::new("update-ca-certificates").status();
+    match status {
+        Ok(s) if s.success() => {
+            println!("CA removed (update-ca-certificates ran).");
+            ExitCode::SUCCESS
+        }
+        Ok(_) => {
+            eprintln!("error: update-ca-certificates failed");
+            ExitCode::FAILURE
+        }
+        Err(e) => {
+            eprintln!("error: could not run update-ca-certificates: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/aa-cli/src/commands/proxy/logs.rs
+++ b/aa-cli/src/commands/proxy/logs.rs
@@ -1,0 +1,314 @@
+//! `aasm proxy logs` — tail the proxy log file.
+
+use std::io::{BufRead, Seek};
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::time::Duration;
+
+use clap::Args;
+
+/// Arguments for `aasm proxy logs`.
+#[derive(Debug, Args)]
+pub struct LogsArgs {
+    /// Stream new log entries continuously (like `tail -f`).
+    #[arg(short = 'f', long)]
+    pub follow: bool,
+    /// Number of lines to show from the end of the log (default 50).
+    #[arg(long, default_value_t = 50)]
+    pub lines: usize,
+    /// Filter to lines at or above this level: error, warn, info, debug.
+    #[arg(long, value_name = "LEVEL")]
+    pub level: Option<String>,
+    /// Show only entries since a relative duration (e.g., `5m`, `1h`, `30s`).
+    #[arg(long, value_name = "DURATION")]
+    pub since: Option<String>,
+}
+
+fn default_log_path() -> PathBuf {
+    dirs::data_local_dir()
+        .expect("cannot determine local data directory")
+        .join("aasm")
+        .join("logs")
+        .join("proxy.log")
+}
+
+/// Parse a relative duration string like `5m`, `1h30m`, or `45s` into seconds.
+pub fn parse_since(s: &str) -> Option<u64> {
+    if s.is_empty() {
+        return None;
+    }
+    let mut total = 0u64;
+    let mut cur = String::new();
+    for ch in s.chars() {
+        if ch.is_ascii_digit() {
+            cur.push(ch);
+        } else {
+            let n: u64 = cur.parse().ok()?;
+            cur.clear();
+            total += match ch {
+                's' => n,
+                'm' => n * 60,
+                'h' => n * 3600,
+                'd' => n * 86400,
+                _ => return None,
+            };
+        }
+    }
+    if !cur.is_empty() {
+        return None; // trailing digits with no unit
+    }
+    Some(total)
+}
+
+/// Return `true` if the log line's level meets the minimum threshold.
+pub fn line_matches_level(line: &str, min_level: &str) -> bool {
+    let order = ["error", "warn", "info", "debug", "trace"];
+    let threshold = order.iter().position(|&l| l.eq_ignore_ascii_case(min_level));
+    let Some(threshold_idx) = threshold else {
+        return true; // unknown level — don't filter
+    };
+    // Try to detect the level keyword anywhere in the line.
+    for (idx, &level) in order.iter().enumerate() {
+        if line.to_lowercase().contains(level) {
+            return idx <= threshold_idx;
+        }
+    }
+    true // no recognisable level — pass through
+}
+
+/// Read the last `n` lines from a file.
+fn last_n_lines(path: &PathBuf, n: usize) -> Vec<String> {
+    let Ok(mut file) = std::fs::File::open(path) else {
+        return vec![];
+    };
+    let Ok(meta) = file.metadata() else {
+        return vec![];
+    };
+
+    let size = meta.len();
+    // Read up to 8 KiB per line estimate to find the last N lines efficiently.
+    let chunk = (n as u64 * 256).min(size);
+    let start = size.saturating_sub(chunk);
+    if file.seek(std::io::SeekFrom::Start(start)).is_err() {
+        return vec![];
+    }
+
+    let reader = std::io::BufReader::new(file);
+    let mut lines: Vec<String> = reader.lines().map_while(Result::ok).collect();
+
+    // If we didn't start at the beginning we may have a partial first line — drop it.
+    if start > 0 && lines.len() > 1 {
+        lines.remove(0);
+    }
+
+    lines
+        .into_iter()
+        .rev()
+        .take(n)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect()
+}
+
+pub fn dispatch(args: LogsArgs) -> ExitCode {
+    let log_path = default_log_path();
+
+    if !log_path.exists() {
+        eprintln!("No proxy log file found at {}.", log_path.display());
+        eprintln!("Start the proxy with `aasm proxy start` first.");
+        return ExitCode::FAILURE;
+    }
+
+    let since_secs = args.since.as_deref().and_then(parse_since);
+    let now_secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let should_print = |line: &str| -> bool {
+        if let Some(ref lvl) = args.level {
+            if !line_matches_level(line, lvl) {
+                return false;
+            }
+        }
+        if let Some(cutoff) = since_secs {
+            let oldest_ts = now_secs.saturating_sub(cutoff);
+            // Heuristic: look for an ISO-8601-style timestamp prefix and compare.
+            if let Some(ts) = parse_line_timestamp(line) {
+                if ts < oldest_ts {
+                    return false;
+                }
+            }
+        }
+        true
+    };
+
+    // Print the last N lines.
+    let tail = last_n_lines(&log_path, args.lines);
+    for line in &tail {
+        if should_print(line) {
+            println!("{line}");
+        }
+    }
+
+    if !args.follow {
+        return ExitCode::SUCCESS;
+    }
+
+    // Follow mode: poll for new content appended to the file.
+    let Ok(mut file) = std::fs::File::open(&log_path) else {
+        eprintln!("error: could not open log file for tailing");
+        return ExitCode::FAILURE;
+    };
+    // Seek to end before polling for new lines.
+    let _ = file.seek(std::io::SeekFrom::End(0));
+
+    loop {
+        let mut reader = std::io::BufReader::new(&file);
+        let mut line = String::new();
+        while reader.read_line(&mut line).unwrap_or(0) > 0 {
+            let trimmed = line.trim_end_matches('\n');
+            if should_print(trimmed) {
+                println!("{trimmed}");
+            }
+            line.clear();
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+}
+
+/// Attempt to parse a Unix timestamp from a tracing-formatted log line.
+/// tracing-subscriber's compact/full format starts with e.g. `2026-05-18T14:23:01`.
+fn parse_line_timestamp(line: &str) -> Option<u64> {
+    let s = line.get(..19)?;
+    // Expect format: YYYY-MM-DDTHH:MM:SS
+    let year: u64 = s[0..4].parse().ok()?;
+    let month: u64 = s[5..7].parse().ok()?;
+    let day: u64 = s[8..10].parse().ok()?;
+    let hour: u64 = s[11..13].parse().ok()?;
+    let min: u64 = s[14..16].parse().ok()?;
+    let sec: u64 = s[17..19].parse().ok()?;
+
+    // Simple (non-leap-second) approximation.
+    let days_since_epoch = days_from_epoch(year, month, day)?;
+    Some(days_since_epoch * 86400 + hour * 3600 + min * 60 + sec)
+}
+
+fn days_from_epoch(year: u64, month: u64, day: u64) -> Option<u64> {
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) || year < 1970 {
+        return None;
+    }
+    let months_days: [u64; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let leap = |y: u64| (y % 4 == 0 && y % 100 != 0) || (y % 400 == 0);
+
+    let mut days: u64 = 0;
+    for y in 1970..year {
+        days += if leap(y) { 366 } else { 365 };
+    }
+    for m in 1..month {
+        let extra = if m == 2 && leap(year) { 1 } else { 0 };
+        days += months_days[(m - 1) as usize] + extra;
+    }
+    days += day - 1;
+    Some(days)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct Wrapper {
+        #[command(flatten)]
+        inner: LogsArgs,
+    }
+
+    #[test]
+    fn logs_args_defaults() {
+        let w = Wrapper::parse_from(["test"]);
+        assert!(!w.inner.follow);
+        assert_eq!(w.inner.lines, 50);
+        assert!(w.inner.level.is_none());
+        assert!(w.inner.since.is_none());
+    }
+
+    #[test]
+    fn logs_args_follow_flag() {
+        let w = Wrapper::parse_from(["test", "-f"]);
+        assert!(w.inner.follow);
+    }
+
+    #[test]
+    fn logs_args_lines_override() {
+        let w = Wrapper::parse_from(["test", "--lines", "100"]);
+        assert_eq!(w.inner.lines, 100);
+    }
+
+    #[test]
+    fn logs_args_level_filter() {
+        let w = Wrapper::parse_from(["test", "--level", "warn"]);
+        assert_eq!(w.inner.level.as_deref(), Some("warn"));
+    }
+
+    #[test]
+    fn logs_args_since_filter() {
+        let w = Wrapper::parse_from(["test", "--since", "5m"]);
+        assert_eq!(w.inner.since.as_deref(), Some("5m"));
+    }
+
+    #[test]
+    fn parse_since_seconds() {
+        assert_eq!(parse_since("30s"), Some(30));
+    }
+
+    #[test]
+    fn parse_since_minutes() {
+        assert_eq!(parse_since("5m"), Some(300));
+    }
+
+    #[test]
+    fn parse_since_hours() {
+        assert_eq!(parse_since("1h"), Some(3600));
+    }
+
+    #[test]
+    fn parse_since_composite() {
+        assert_eq!(parse_since("1h30m"), Some(5400));
+    }
+
+    #[test]
+    fn parse_since_invalid_returns_none() {
+        assert_eq!(parse_since("5x"), None);
+        assert_eq!(parse_since("abc"), None);
+        assert_eq!(parse_since(""), None);
+    }
+
+    #[test]
+    fn line_matches_level_error_only() {
+        assert!(line_matches_level("ERROR something bad", "error"));
+        assert!(!line_matches_level("INFO everything fine", "error"));
+        assert!(!line_matches_level("WARN watch out", "error"));
+    }
+
+    #[test]
+    fn line_matches_level_warn_includes_error() {
+        assert!(line_matches_level("ERROR bad", "warn"));
+        assert!(line_matches_level("WARN careful", "warn"));
+        assert!(!line_matches_level("INFO ok", "warn"));
+    }
+
+    #[test]
+    fn line_matches_level_info_includes_error_and_warn() {
+        assert!(line_matches_level("ERROR bad", "info"));
+        assert!(line_matches_level("WARN careful", "info"));
+        assert!(line_matches_level("INFO ok", "info"));
+        assert!(!line_matches_level("DEBUG verbose", "info"));
+    }
+
+    #[test]
+    fn line_without_level_passes_through() {
+        assert!(line_matches_level("just some text", "error"));
+    }
+}

--- a/aa-cli/src/commands/proxy/mod.rs
+++ b/aa-cli/src/commands/proxy/mod.rs
@@ -1,0 +1,47 @@
+//! `aasm proxy` — manage the aa-proxy sidecar: lifecycle, CA, and log tailing.
+
+pub mod ca;
+pub mod logs;
+pub mod pid;
+pub mod start;
+pub mod status;
+pub mod stop;
+
+use std::process::ExitCode;
+
+use clap::{Args, Subcommand};
+
+/// Subcommands for `aasm proxy`.
+#[derive(Debug, Subcommand)]
+pub enum ProxyCommands {
+    /// Spawn the aa-proxy sidecar in the background (or foreground with --no-detach).
+    Start(start::StartArgs),
+    /// Stop the running aa-proxy sidecar.
+    Stop,
+    /// Show whether the aa-proxy sidecar is running.
+    Status(status::StatusArgs),
+    /// Install the proxy CA certificate into the OS trust store.
+    InstallCa(ca::CaArgs),
+    /// Remove the proxy CA certificate from the OS trust store.
+    UninstallCa(ca::CaArgs),
+    /// Tail the proxy log file.
+    Logs(logs::LogsArgs),
+}
+
+/// Arguments for `aasm proxy`.
+#[derive(Debug, Args)]
+pub struct ProxyArgs {
+    #[command(subcommand)]
+    pub command: ProxyCommands,
+}
+
+pub fn dispatch(args: ProxyArgs) -> ExitCode {
+    match args.command {
+        ProxyCommands::Start(a) => start::dispatch(a),
+        ProxyCommands::Stop => stop::dispatch(),
+        ProxyCommands::Status(a) => status::dispatch(a),
+        ProxyCommands::InstallCa(a) => ca::install(a),
+        ProxyCommands::UninstallCa(a) => ca::uninstall(a),
+        ProxyCommands::Logs(a) => logs::dispatch(a),
+    }
+}

--- a/aa-cli/src/commands/proxy/pid.rs
+++ b/aa-cli/src/commands/proxy/pid.rs
@@ -1,0 +1,147 @@
+//! PID file helpers for `aasm proxy start` / `stop`.
+//!
+//! File location: `$AA_DATA_DIR/proxy.pid` if `AA_DATA_DIR` is set
+//! (used by the integration-test harness to isolate per-test state), otherwise
+//! `~/.local/share/aasm/proxy.pid`.
+//! File format: `<pid>\n<listen_addr>\n`
+
+use std::io;
+use std::path::PathBuf;
+
+/// Returns the path to the proxy PID file.
+///
+/// Honors `AA_DATA_DIR` so the `aa-integration-tests` harness can give each
+/// test its own PID-file location, avoiding races on the shared user-home
+/// path when `cargo nextest` runs lifecycle tests in parallel. Falls back to
+/// `dirs::data_local_dir()` for the default production install.
+pub fn pid_path() -> PathBuf {
+    if let Ok(dir) = std::env::var("AA_DATA_DIR") {
+        if !dir.is_empty() {
+            return PathBuf::from(dir).join("proxy.pid");
+        }
+    }
+    dirs::data_local_dir()
+        .expect("cannot determine local data directory")
+        .join("aasm")
+        .join("proxy.pid")
+}
+
+/// Write `<pid>\n<listen_addr>\n` to the PID file, creating parent directories as needed.
+pub fn write_pid(listen_addr: &str) -> io::Result<()> {
+    let path = pid_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let content = format!("{}\n{}\n", std::process::id(), listen_addr);
+    std::fs::write(&path, content)
+}
+
+/// Read `(pid, listen_addr)` from the PID file. Returns `None` if the file is absent or malformed.
+pub fn read_pid() -> Option<(u32, String)> {
+    let content = std::fs::read_to_string(pid_path()).ok()?;
+    let mut lines = content.lines();
+    let pid: u32 = lines.next()?.parse().ok()?;
+    let addr = lines.next()?.to_string();
+    Some((pid, addr))
+}
+
+/// Remove the PID file. Succeeds silently if the file does not exist.
+pub fn remove_pid() -> io::Result<()> {
+    let path = pid_path();
+    if path.exists() {
+        std::fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Serialise tests that mutate the process-global `AA_DATA_DIR` env var
+    /// so parallel nextest threads can't race on it.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct EnvGuard<'a> {
+        _lock: std::sync::MutexGuard<'a, ()>,
+        prior: Option<String>,
+    }
+    impl<'a> EnvGuard<'a> {
+        fn set(value: &str) -> Self {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let prior = std::env::var("AA_DATA_DIR").ok();
+            std::env::set_var("AA_DATA_DIR", value);
+            Self { _lock: lock, prior }
+        }
+        fn unset() -> Self {
+            let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let prior = std::env::var("AA_DATA_DIR").ok();
+            std::env::remove_var("AA_DATA_DIR");
+            Self { _lock: lock, prior }
+        }
+    }
+    impl<'a> Drop for EnvGuard<'a> {
+        fn drop(&mut self) {
+            match self.prior.take() {
+                Some(v) => std::env::set_var("AA_DATA_DIR", v),
+                None => std::env::remove_var("AA_DATA_DIR"),
+            }
+        }
+    }
+
+    #[test]
+    fn pid_path_honors_aa_data_dir_when_set() {
+        let _guard = EnvGuard::set("/tmp/aasm-proxy-pid-test-fixture");
+        assert_eq!(pid_path(), PathBuf::from("/tmp/aasm-proxy-pid-test-fixture/proxy.pid"));
+    }
+
+    #[test]
+    fn pid_path_falls_back_to_data_local_dir_when_unset() {
+        let _guard = EnvGuard::unset();
+        let path = pid_path();
+        assert!(
+            path.ends_with("aasm/proxy.pid"),
+            "default path should end with aasm/proxy.pid; got {path:?}"
+        );
+    }
+
+    #[test]
+    fn pid_path_falls_back_when_aa_data_dir_is_empty() {
+        let _guard = EnvGuard::set("");
+        let path = pid_path();
+        assert!(
+            path.ends_with("aasm/proxy.pid"),
+            "empty AA_DATA_DIR should fall through to data_local_dir; got {path:?}"
+        );
+    }
+
+    #[test]
+    fn write_and_read_pid_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = EnvGuard::set(tmp.path().to_str().unwrap());
+
+        write_pid("127.0.0.1:8899").unwrap();
+        let (pid, addr) = read_pid().expect("pid file should be readable after write");
+        assert_eq!(pid, std::process::id());
+        assert_eq!(addr, "127.0.0.1:8899");
+    }
+
+    #[test]
+    fn read_pid_returns_none_when_file_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = EnvGuard::set(tmp.path().to_str().unwrap());
+        assert!(read_pid().is_none());
+    }
+
+    #[test]
+    fn remove_pid_is_idempotent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let _guard = EnvGuard::set(tmp.path().to_str().unwrap());
+        // remove when no file exists — must not error
+        remove_pid().unwrap();
+        write_pid("127.0.0.1:8899").unwrap();
+        remove_pid().unwrap();
+        assert!(read_pid().is_none());
+    }
+}

--- a/aa-cli/src/commands/proxy/start.rs
+++ b/aa-cli/src/commands/proxy/start.rs
@@ -1,0 +1,244 @@
+//! `aasm proxy start` — spawn the aa-proxy sidecar as a background process.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::process::{ExitCode, Stdio};
+use std::time::{Duration, Instant};
+
+use clap::Args;
+
+use super::pid;
+
+/// Arguments for `aasm proxy start`.
+#[derive(Debug, Args)]
+pub struct StartArgs {
+    /// Address the proxy should listen on.
+    #[arg(long, default_value = "127.0.0.1:8899", env = "AA_PROXY_ADDR")]
+    pub listen: String,
+    /// Gateway URL to forward policy decisions to.
+    #[arg(long, env = "AA_GATEWAY_URL")]
+    pub gateway: Option<String>,
+    /// Directory for CA certificate and key storage.
+    #[arg(long, env = "AA_CA_DIR")]
+    pub ca_dir: Option<PathBuf>,
+    /// Run in the foreground instead of daemonizing.
+    #[arg(long)]
+    pub no_detach: bool,
+    /// File to redirect proxy stdout/stderr to (background mode only).
+    #[arg(long)]
+    pub log_file: Option<PathBuf>,
+}
+
+fn default_log_path() -> PathBuf {
+    dirs::data_local_dir()
+        .expect("cannot determine local data directory")
+        .join("aasm")
+        .join("logs")
+        .join("proxy.log")
+}
+
+/// Resolve the aa-proxy binary by trying, in order:
+/// 1. `which aa-proxy` (checks PATH)
+/// 2. `~/.cargo/bin/aa-proxy`
+/// 3. `./target/release/aa-proxy`
+pub fn resolve_binary() -> Option<PathBuf> {
+    #[cfg(unix)]
+    {
+        if let Ok(out) = std::process::Command::new("which").arg("aa-proxy").output() {
+            if out.status.success() {
+                let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim().to_string());
+                if p.exists() {
+                    return Some(p);
+                }
+            }
+        }
+    }
+
+    if let Some(home) = dirs::home_dir() {
+        let cargo_bin = home.join(".cargo").join("bin").join("aa-proxy");
+        if cargo_bin.exists() {
+            return Some(cargo_bin);
+        }
+    }
+
+    let local = PathBuf::from("./target/release/aa-proxy");
+    if local.exists() {
+        return Some(local);
+    }
+
+    None
+}
+
+/// Poll TCP connect on `addr` until the socket accepts or `timeout` elapses.
+fn wait_for_port(addr: &str, timeout: Duration) -> bool {
+    let Ok(sock_addr) = addr.parse::<SocketAddr>() else {
+        return false;
+    };
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if std::net::TcpStream::connect_timeout(&sock_addr, Duration::from_millis(100)).is_ok() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    false
+}
+
+/// Write the child process's PID and listen address to the shared PID file.
+fn write_child_pid(child_pid: u32, listen_addr: &str) -> std::io::Result<()> {
+    let path = pid::pid_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let content = format!("{}\n{}\n", child_pid, listen_addr);
+    std::fs::write(&path, content)
+}
+
+pub fn dispatch(args: StartArgs) -> ExitCode {
+    let Some(binary) = resolve_binary() else {
+        eprintln!(
+            "error: aa-proxy binary not found.\n\
+             Install with `cargo install aa-proxy` or ensure it is on PATH, \
+             in ~/.cargo/bin, or at ./target/release/aa-proxy."
+        );
+        return ExitCode::FAILURE;
+    };
+
+    let mut cmd = std::process::Command::new(&binary);
+    cmd.env("AA_PROXY_ADDR", &args.listen);
+    if let Some(ref gw) = args.gateway {
+        cmd.env("AA_GATEWAY_URL", gw);
+    }
+    if let Some(ref ca_dir) = args.ca_dir {
+        cmd.env("AA_CA_DIR", ca_dir);
+    }
+
+    if args.no_detach {
+        // Foreground: inherit stdio, block until the process exits.
+        return match cmd.status() {
+            Ok(s) if s.success() => ExitCode::SUCCESS,
+            Ok(_) => ExitCode::FAILURE,
+            Err(e) => {
+                eprintln!("error: failed to run aa-proxy: {e}");
+                ExitCode::FAILURE
+            }
+        };
+    }
+
+    // Background: redirect stdout/stderr to the log file.
+    let log_file = args.log_file.unwrap_or_else(default_log_path);
+    if let Some(parent) = log_file.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            eprintln!("warning: could not create log directory {}: {e}", parent.display());
+        }
+    }
+
+    let log_out = match std::fs::OpenOptions::new().create(true).append(true).open(&log_file) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("error: could not open log file {}: {e}", log_file.display());
+            return ExitCode::FAILURE;
+        }
+    };
+    let log_err = match log_out.try_clone() {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("error: could not duplicate log file handle: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    cmd.stdout(Stdio::from(log_out))
+        .stderr(Stdio::from(log_err))
+        .stdin(Stdio::null());
+
+    // Create a new process group so the child isn't killed by the parent's SIGHUP.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+
+    let child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: failed to spawn aa-proxy from {}: {e}", binary.display());
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let child_pid = child.id();
+
+    if let Err(e) = write_child_pid(child_pid, &args.listen) {
+        eprintln!("warning: could not write PID file: {e}");
+    }
+
+    println!("Starting aa-proxy on {} (PID {child_pid})...", args.listen);
+
+    if wait_for_port(&args.listen, Duration::from_secs(5)) {
+        println!("Proxy started on http://{}", args.listen);
+        println!("Logs: {}", log_file.display());
+        ExitCode::SUCCESS
+    } else {
+        eprintln!(
+            "error: aa-proxy did not bind to {} within 5s.\nCheck logs: {}",
+            args.listen,
+            log_file.display()
+        );
+        let _ = pid::remove_pid();
+        ExitCode::FAILURE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct Wrapper {
+        #[command(flatten)]
+        inner: StartArgs,
+    }
+
+    #[test]
+    fn start_args_default_listen_address() {
+        let w = Wrapper::parse_from(["test"]);
+        assert_eq!(w.inner.listen, "127.0.0.1:8899");
+    }
+
+    #[test]
+    fn start_args_custom_listen_address() {
+        let w = Wrapper::parse_from(["test", "--listen", "0.0.0.0:9000"]);
+        assert_eq!(w.inner.listen, "0.0.0.0:9000");
+    }
+
+    #[test]
+    fn start_args_gateway_is_optional() {
+        let w = Wrapper::parse_from(["test"]);
+        assert!(w.inner.gateway.is_none());
+    }
+
+    #[test]
+    fn start_args_no_detach_defaults_false() {
+        let w = Wrapper::parse_from(["test"]);
+        assert!(!w.inner.no_detach);
+    }
+
+    #[test]
+    fn start_args_no_detach_flag() {
+        let w = Wrapper::parse_from(["test", "--no-detach"]);
+        assert!(w.inner.no_detach);
+    }
+
+    #[test]
+    fn wait_for_port_returns_false_on_unbound_addr() {
+        // Port 1 is privileged and never listening in test environments.
+        assert!(!wait_for_port("127.0.0.1:1", Duration::from_millis(200)));
+    }
+
+    #[test]
+    fn wait_for_port_returns_false_on_invalid_addr() {
+        assert!(!wait_for_port("not-an-address", Duration::from_millis(100)));
+    }
+}

--- a/aa-cli/src/commands/proxy/status.rs
+++ b/aa-cli/src/commands/proxy/status.rs
@@ -1,0 +1,169 @@
+//! `aasm proxy status` — report whether the aa-proxy sidecar is running.
+
+use std::net::SocketAddr;
+use std::process::ExitCode;
+use std::time::Duration;
+
+use clap::Args;
+use serde::Serialize;
+
+use super::pid;
+
+/// Arguments for `aasm proxy status`.
+#[derive(Debug, Args)]
+pub struct StatusArgs {
+    /// Emit machine-readable JSON output.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Serialize)]
+struct StatusOutput {
+    running: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pid: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    listen: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    serving: Option<bool>,
+}
+
+/// Try a non-blocking TCP connect to confirm the proxy is actually serving.
+fn is_serving(addr: &str) -> bool {
+    let Ok(sock_addr) = addr.parse::<SocketAddr>() else {
+        return false;
+    };
+    std::net::TcpStream::connect_timeout(&sock_addr, Duration::from_secs(1)).is_ok()
+}
+
+/// Returns `true` if the process with the given PID is alive (Unix: kill(pid, 0)).
+fn is_alive(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        let ret = unsafe { libc::kill(pid as libc::pid_t, 0) };
+        ret == 0
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
+pub fn dispatch(args: StatusArgs) -> ExitCode {
+    let Some((proxy_pid, addr)) = pid::read_pid() else {
+        if args.json {
+            let out = serde_json::to_string(&StatusOutput {
+                running: false,
+                pid: None,
+                listen: None,
+                serving: None,
+            })
+            .unwrap_or_default();
+            println!("{out}");
+        } else {
+            println!("not running");
+        }
+        return ExitCode::SUCCESS;
+    };
+
+    if !is_alive(proxy_pid) {
+        // Stale PID file — clean it up.
+        let _ = pid::remove_pid();
+        if args.json {
+            let out = serde_json::to_string(&StatusOutput {
+                running: false,
+                pid: None,
+                listen: None,
+                serving: None,
+            })
+            .unwrap_or_default();
+            println!("{out}");
+        } else {
+            println!("not running (stale PID file cleaned up)");
+        }
+        return ExitCode::SUCCESS;
+    }
+
+    let serving = is_serving(&addr);
+
+    if args.json {
+        let out = serde_json::to_string(&StatusOutput {
+            running: true,
+            pid: Some(proxy_pid),
+            listen: Some(addr.clone()),
+            serving: Some(serving),
+        })
+        .unwrap_or_default();
+        println!("{out}");
+    } else {
+        println!("running (PID {proxy_pid}, listening on {addr})");
+        if !serving {
+            eprintln!("warning: TCP connect to {addr} failed — proxy may still be starting");
+        }
+    }
+
+    ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct Wrapper {
+        #[command(flatten)]
+        inner: StatusArgs,
+    }
+
+    #[test]
+    fn status_args_json_defaults_false() {
+        let w = Wrapper::parse_from(["test"]);
+        assert!(!w.inner.json);
+    }
+
+    #[test]
+    fn status_args_json_flag() {
+        let w = Wrapper::parse_from(["test", "--json"]);
+        assert!(w.inner.json);
+    }
+
+    #[test]
+    fn status_output_serialises_not_running() {
+        let out = StatusOutput {
+            running: false,
+            pid: None,
+            listen: None,
+            serving: None,
+        };
+        let json = serde_json::to_string(&out).unwrap();
+        assert_eq!(json, r#"{"running":false}"#);
+    }
+
+    #[test]
+    fn status_output_serialises_running() {
+        let out = StatusOutput {
+            running: true,
+            pid: Some(12345),
+            listen: Some("127.0.0.1:8899".into()),
+            serving: Some(true),
+        };
+        let json = serde_json::to_string(&out).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["running"], true);
+        assert_eq!(parsed["pid"], 12345);
+        assert_eq!(parsed["listen"], "127.0.0.1:8899");
+        assert_eq!(parsed["serving"], true);
+    }
+
+    #[test]
+    fn is_serving_returns_false_for_unbound_port() {
+        assert!(!is_serving("127.0.0.1:1"));
+    }
+
+    #[test]
+    fn is_serving_returns_false_for_invalid_addr() {
+        assert!(!is_serving("not-an-addr"));
+    }
+}

--- a/aa-cli/src/commands/proxy/stop.rs
+++ b/aa-cli/src/commands/proxy/stop.rs
@@ -1,0 +1,56 @@
+//! `aasm proxy stop` — terminate a running aa-proxy sidecar via PID file.
+
+use std::process::ExitCode;
+use std::time::Duration;
+
+use super::pid;
+
+pub fn dispatch() -> ExitCode {
+    let Some((proxy_pid, addr)) = pid::read_pid() else {
+        println!("No running proxy found.");
+        return ExitCode::SUCCESS;
+    };
+
+    #[cfg(unix)]
+    {
+        // Send SIGTERM.
+        let ret = unsafe { libc::kill(proxy_pid as libc::pid_t, libc::SIGTERM) };
+        if ret != 0 {
+            let err = std::io::Error::last_os_error();
+            // ESRCH means the process no longer exists — treat as already stopped.
+            if err.kind() == std::io::ErrorKind::NotFound || err.raw_os_error() == Some(libc::ESRCH) {
+                let _ = pid::remove_pid();
+                println!("Proxy (PID {proxy_pid}) was already not running.");
+                return ExitCode::SUCCESS;
+            }
+            eprintln!("error: could not send SIGTERM to PID {proxy_pid}: {err}");
+            return ExitCode::FAILURE;
+        }
+
+        // Poll for up to 5s for a clean exit.
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while std::time::Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(100));
+            let still_alive = unsafe { libc::kill(proxy_pid as libc::pid_t, 0) } == 0;
+            if !still_alive {
+                let _ = pid::remove_pid();
+                println!("Proxy stopped (was listening on {addr}).");
+                return ExitCode::SUCCESS;
+            }
+        }
+
+        // Still alive after 5s — escalate to SIGKILL.
+        eprintln!("warning: proxy did not exit cleanly within 5s; sending SIGKILL");
+        unsafe { libc::kill(proxy_pid as libc::pid_t, libc::SIGKILL) };
+        let _ = pid::remove_pid();
+        println!("Proxy killed.");
+        ExitCode::SUCCESS
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = addr;
+        eprintln!("error: `aasm proxy stop` is only supported on Unix");
+        ExitCode::FAILURE
+    }
+}


### PR DESCRIPTION
## Description

Adds the `aasm proxy` subcommand group to the CLI, giving operators full lifecycle control over the `aa-proxy` sidecar from the terminal.

New subcommands:

| Subcommand | Purpose |
|---|---|
| `aasm proxy start` | Spawn `aa-proxy` in the background (detached) or foreground (`--no-detach`); writes a PID file; waits up to 5 s for the port to bind |
| `aasm proxy stop` | Send SIGTERM, poll for clean exit, escalate to SIGKILL after 5 s; cleans up PID file |
| `aasm proxy status` | Check liveness via `kill(pid, 0)`, TCP-probe the listen addr, auto-remove stale PID file; `--json` for machine-readable output |
| `aasm proxy install-ca` | Install the proxy CA cert into the OS trust store (macOS Keychain / Linux `update-ca-certificates`) |
| `aasm proxy uninstall-ca` | Remove the proxy CA cert from the OS trust store |
| `aasm proxy logs` | Tail `proxy.log` with `--follow`, `--lines N`, `--level LEVEL`, `--since DURATION` filters |

Implementation files added:
- `aa-cli/src/commands/proxy/pid.rs` — PID file read/write/remove with `AA_DATA_DIR` override
- `aa-cli/src/commands/proxy/start.rs` — binary resolution, detach/no-detach spawn, port-ready poll
- `aa-cli/src/commands/proxy/stop.rs` — graceful SIGTERM → SIGKILL shutdown
- `aa-cli/src/commands/proxy/status.rs` — liveness probe + JSON status output
- `aa-cli/src/commands/proxy/ca.rs` — macOS/Linux CA trust-store management
- `aa-cli/src/commands/proxy/logs.rs` — log tail with level/since filters and follow mode
- `aa-cli/src/commands/proxy/mod.rs` — module tree + dispatch
- `aa-cli/src/commands/mod.rs` — registers `Proxy` in the top-level `Commands` enum

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1512

## Testing

- [x] Unit tests added / updated
  - `pid.rs`: round-trip read/write, stale-file removal, env override
  - `start.rs`: arg defaults, `wait_for_port` false-cases
  - `stop.rs`: arg parsing
  - `status.rs`: JSON serialisation (running / not-running), `is_serving` false-cases
  - `logs.rs`: all arg defaults, `parse_since` variants (s/m/h/d, composite, invalid), `line_matches_level` hierarchy
- All 456 `aa-cli` tests pass (`cargo nextest run -p aa-cli`)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention