### PR TITLE
[AAASM-1240] ✅ (e2e): Add dashboard gateway smoke test — fleet, trace, and topology live-data views

### DIFF
--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -260,6 +260,7 @@ impl TopologyTestEnv {
         let events = Arc::clone(&state.events);
         let replay_buffer = state.replay_buffer.clone();
         let next_event_id = Arc::clone(&state.next_event_id);
+        let ops_registry = Arc::clone(&state.ops_registry);
 
         let port = portpicker::pick_unused_port().ok_or_else(|| anyhow::anyhow!("no free TCP port"))?;
         let addr: SocketAddr = format!("127.0.0.1:{port}").parse()?;
@@ -289,6 +290,7 @@ impl TopologyTestEnv {
             events,
             replay_buffer,
             next_event_id,
+            ops_registry,
             shutdown_tx: Some(shutdown_tx),
             server_handle: Some(server_handle),
             cleaned: false,
@@ -846,6 +848,7 @@ spec:
                 .build(),
             capability_store: aa_api::routes::capability::CapabilityStore::new_seeded(),
             iam_api_key_store: aa_api::routes::iam::seeded_iam_store(),
+            ops_registry: Arc::new(OpsRegistry::new()),
         },
         audit_dir,
         alert_store_handle,

--- a/dashboard/tests/e2e/dashboard-gateway-smoke.spec.ts
+++ b/dashboard/tests/e2e/dashboard-gateway-smoke.spec.ts
@@ -187,4 +187,13 @@ test.describe('Dashboard gateway smoke — live agent data renders correctly', (
     await injectToken(page)
     await mockGatewayLiveData(page)
   })
+
+  test('fleet view: agent list renders live agent rows and count from gateway', async ({ page }) => {
+    await page.goto('/agents')
+
+    await expect(page.getByTestId('fleet-page-head')).toBeVisible()
+    await expect(page.getByTestId('fleet-page-count')).toContainText(String(LIVE_AGENTS.length))
+    await expect(page.getByTestId('agent-row')).toHaveCount(LIVE_AGENTS.length)
+    await expect(page.getByTestId('fleet-row-name').first()).toContainText('support-bot')
+  })
 })

--- a/dashboard/tests/e2e/dashboard-gateway-smoke.spec.ts
+++ b/dashboard/tests/e2e/dashboard-gateway-smoke.spec.ts
@@ -158,16 +158,19 @@ async function injectToken(page: Page) {
 }
 
 async function mockGatewayLiveData(page: Page) {
-  await page.route('**/api/v1/agents', route =>
-    route.fulfill({ json: LIVE_AGENTS }),
-  )
-  await page.route(`**/api/v1/agents/${AGENT_ID}`, route =>
-    route.fulfill({ json: LIVE_AGENTS[0] }),
-  )
-  await page.route(
-    `**/api/v1/agents/${AGENT_ID}/sessions/${SESSION_ID}/trace`,
-    route => route.fulfill({ json: LIVE_TRACE_EVENTS }),
-  )
+  // Single handler for all /api/v1/agents** so that query params like
+  // `?per_page=100` on the list endpoint are caught — pattern '**/api/v1/agents'
+  // only matches the bare path and misses the query string.
+  await page.route('/api/v1/agents**', route => {
+    const url = route.request().url()
+    if (url.includes('/sessions/') && url.endsWith('/trace')) {
+      return route.fulfill({ json: LIVE_TRACE_EVENTS })
+    }
+    if (url.match(/\/api\/v1\/agents\/[^/?]+(\?|$)/)) {
+      return route.fulfill({ json: LIVE_AGENTS[0] })
+    }
+    return route.fulfill({ json: LIVE_AGENTS })
+  })
   await page.route('**/api/v1/topology', route =>
     route.fulfill({ json: LIVE_TOPOLOGY }),
   )

--- a/dashboard/tests/e2e/dashboard-gateway-smoke.spec.ts
+++ b/dashboard/tests/e2e/dashboard-gateway-smoke.spec.ts
@@ -210,4 +210,20 @@ test.describe('Dashboard gateway smoke — live agent data renders correctly', (
     await expect(page.getByTestId('trace-agent-label')).toContainText('support-bot')
     await expect(page.getByTestId('trace-event')).toHaveCount(LIVE_TRACE_EVENTS.length)
   })
+
+  test('topology view: graph renders live nodes and correct meta counts from gateway', async ({ page }) => {
+    // Vite `base: './'` workaround — same SPA-navigate pattern as trace.
+    await page.goto('/')
+    await page.evaluate(() => window.history.pushState({}, '', '/topology'))
+    await page.evaluate(() => window.dispatchEvent(new PopStateEvent('popstate')))
+
+    await page.getByTestId('topology-graph').waitFor()
+
+    const nodeCount = LIVE_TOPOLOGY.nodes.length
+    const teamCount = new Set(LIVE_TOPOLOGY.nodes.map(n => n.team)).size
+
+    await expect(page.getByTestId('topology-meta')).toContainText(`${nodeCount} agent`)
+    await expect(page.getByTestId('topology-meta')).toContainText(`${teamCount} team`)
+    await expect(page.getByTestId('topology-node')).toHaveCount(nodeCount)
+  })
 })

--- a/dashboard/tests/e2e/dashboard-gateway-smoke.spec.ts
+++ b/dashboard/tests/e2e/dashboard-gateway-smoke.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * Dashboard gateway smoke test (AAASM-1240).
+ *
+ * Verifies that the dashboard correctly retrieves live agent data from the
+ * gateway and displays it across the three primary monitoring views:
+ *   1. Fleet (agent list)  — /agents
+ *   2. Trace view          — /agents/:id/trace/:sessionId
+ *   3. Topology            — /topology
+ *
+ * Uses Playwright's page.route() to mock the gateway API, matching the
+ * project-wide pattern established in fleet.spec.ts, trace.spec.ts, and
+ * topology-design-fidelity.spec.ts.  No live gateway process is required.
+ */
+
+import { test, expect, type Page } from '@playwright/test'
+
+// ── Live-data fixtures ────────────────────────────────────────────────────────
+
+const AGENT_ID = 'live-agent-001'
+const SESSION_ID = 'live-session-abc'
+
+const LIVE_AGENTS = [
+  {
+    id: 'live-agent-001',
+    name: 'support-bot',
+    framework: 'langgraph',
+    version: '0.1.0',
+    status: 'active',
+    layer: 'sdk',
+    session_count: 12,
+    policy_violations_count: 1,
+    last_event: '2026-05-18T08:00:00Z',
+    tool_names: ['search', 'code_exec'],
+    recent_events: [],
+    recent_traces: [{ session_id: SESSION_ID }],
+    active_sessions: [],
+    metadata: { owner: 'alice' },
+    pid: null,
+  },
+  {
+    id: 'live-agent-002',
+    name: 'analytics-runner',
+    framework: 'crewai',
+    version: '0.1.0',
+    status: 'active',
+    layer: 'proxy',
+    session_count: 5,
+    policy_violations_count: 0,
+    last_event: '2026-05-18T07:30:00Z',
+    tool_names: ['query_db'],
+    recent_events: [],
+    recent_traces: [],
+    active_sessions: [],
+    metadata: { owner: 'carol' },
+    pid: null,
+  },
+  {
+    id: 'live-agent-003',
+    name: 'file-watcher',
+    framework: 'langchain',
+    version: '0.1.0',
+    status: 'idle',
+    layer: 'sdk',
+    session_count: 3,
+    policy_violations_count: 0,
+    last_event: '2026-05-18T06:00:00Z',
+    tool_names: ['file_read'],
+    recent_events: [],
+    recent_traces: [],
+    active_sessions: [],
+    metadata: {},
+    pid: null,
+  },
+]
+
+const LIVE_TRACE_EVENTS = [
+  {
+    id: 'live-evt-001',
+    timestamp: '2026-05-18T08:00:01Z',
+    type: 'llm_call',
+    agent: 'support-bot',
+    durationMs: 423,
+    payloadPreview: 'GPT-4o · summarise ticket',
+    payload: { model: 'gpt-4o', tokens: 312 },
+    severity: 'info',
+  },
+  {
+    id: 'live-evt-002',
+    timestamp: '2026-05-18T08:00:02Z',
+    type: 'tool_call',
+    agent: 'support-bot',
+    durationMs: 88,
+    payloadPreview: 'search("open tickets")',
+    payload: { tool: 'search', query: 'open tickets' },
+    severity: 'info',
+  },
+  {
+    id: 'live-evt-003',
+    timestamp: '2026-05-18T08:00:03Z',
+    type: 'policy_violation',
+    agent: 'support-bot',
+    durationMs: 5,
+    payloadPreview: 'refund > $100 — approval required',
+    payload: { action: 'process_refund', amount: 250 },
+    severity: 'critical',
+    violationReason: 'refund > $100 requires human approval',
+  },
+]
+
+const LIVE_TOPOLOGY = {
+  nodes: [
+    {
+      id: 'live-agent-001',
+      name: 'support-bot',
+      status: 'active' as const,
+      team: 'support',
+      owner: 'alice',
+      policyCount: 3,
+      budgetSpend: 4.2,
+      budgetLimit: 10,
+      framework: 'langgraph',
+      latestSessionId: SESSION_ID,
+    },
+    {
+      id: 'live-agent-002',
+      name: 'analytics-runner',
+      status: 'active' as const,
+      team: 'analytics',
+      owner: 'carol',
+      policyCount: 1,
+      budgetSpend: 1.8,
+      budgetLimit: 10,
+      framework: 'crewai',
+    },
+    {
+      id: 'live-agent-003',
+      name: 'file-watcher',
+      status: 'idle' as const,
+      team: 'support',
+      owner: 'alice',
+      policyCount: 2,
+      budgetSpend: 0.5,
+      budgetLimit: 10,
+      framework: 'langchain',
+    },
+  ],
+  edges: [
+    { source: 'live-agent-001', target: 'live-agent-003', kind: 'delegation' as const },
+  ],
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function injectToken(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('aa_token', 'e2e-smoke-token')
+  })
+}
+
+async function mockGatewayLiveData(page: Page) {
+  await page.route('**/api/v1/agents', route =>
+    route.fulfill({ json: LIVE_AGENTS }),
+  )
+  await page.route(`**/api/v1/agents/${AGENT_ID}`, route =>
+    route.fulfill({ json: LIVE_AGENTS[0] }),
+  )
+  await page.route(
+    `**/api/v1/agents/${AGENT_ID}/sessions/${SESSION_ID}/trace`,
+    route => route.fulfill({ json: LIVE_TRACE_EVENTS }),
+  )
+  await page.route('**/api/v1/topology', route =>
+    route.fulfill({ json: LIVE_TOPOLOGY }),
+  )
+  await page.route('**/api/v1/topology/nodes/*/events', route =>
+    route.fulfill({ json: [] }),
+  )
+  await page.route('**/api/v1/approvals**', route =>
+    route.fulfill({ json: [] }),
+  )
+  await page.route('**/api/v1/ws/events**', route => route.abort())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('Dashboard gateway smoke — live agent data renders correctly', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectToken(page)
+    await mockGatewayLiveData(page)
+  })
+})

--- a/dashboard/tests/e2e/dashboard-gateway-smoke.spec.ts
+++ b/dashboard/tests/e2e/dashboard-gateway-smoke.spec.ts
@@ -196,4 +196,18 @@ test.describe('Dashboard gateway smoke — live agent data renders correctly', (
     await expect(page.getByTestId('agent-row')).toHaveCount(LIVE_AGENTS.length)
     await expect(page.getByTestId('fleet-row-name').first()).toContainText('support-bot')
   })
+
+  test('trace view: event timeline renders live trace events from gateway', async ({ page }) => {
+    // Vite `base: './'` workaround — land on `/` so assets resolve, then SPA-navigate.
+    await page.goto('/')
+    await page.evaluate(
+      ([id, sessionId]) => window.history.pushState({}, '', `/agents/${id}/trace/${sessionId}`),
+      [AGENT_ID, SESSION_ID],
+    )
+    await page.evaluate(() => window.dispatchEvent(new PopStateEvent('popstate')))
+
+    await expect(page.getByTestId('trace-view')).toBeVisible()
+    await expect(page.getByTestId('trace-agent-label')).toContainText('support-bot')
+    await expect(page.getByTestId('trace-event')).toHaveCount(LIVE_TRACE_EVENTS.length)
+  })
 })


### PR DESCRIPTION
## Description

Adds a Playwright E2E smoke test (`dashboard/tests/e2e/dashboard-gateway-smoke.spec.ts`) that verifies the dashboard correctly retrieves and displays live agent data from the gateway across the three primary monitoring views: fleet (agent list), trace timeline, and topology graph.

This is the implementation of AAASM-1240 under F116 (Story AAASM-1232). The blocking dependency — `aasm gateway` CLI subcommand (AAASM-1509) — landed in PR #548, which unblocks this work.

## Type of Change

- [x] ✅ New feature (test coverage addition)

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1240
- Parent story: AAASM-1232 (F116 — Full MVP acceptance test)
- Epic: AAASM-1199 (Release & Distribution Pipeline)

## Testing

**3 new Playwright E2E smoke tests added** in `dashboard/tests/e2e/dashboard-gateway-smoke.spec.ts`:

| Test | Assertion |
|---|---|
| Fleet view | `fleet-page-count` shows `3`, `agent-row` count = 3, first row name = `support-bot` |
| Trace view | `trace-agent-label` = `support-bot`, `trace-event` count = 3 |
| Topology view | `topology-meta` = "3 agents · 2 teams", `topology-node` count = 3 |

**All 3 tests pass locally:**
```
Running 3 tests using 3 workers
  3 passed (1.1s)
```

**Full unit suite unaffected:**
```
Test Files  109 passed (109)
      Tests  940 passed (940)
```

Implementation follows the project-wide mock-gateway pattern (`page.route()`) used in `fleet.spec.ts`, `trace.spec.ts`, and `topology-design-fidelity.spec.ts`. No live gateway process is required; tests run cleanly in CI.

Key design decisions:
- Single `/api/v1/agents**` route handler (not separate per-route mocks) to correctly intercept the list endpoint which is fetched as `/api/v1/agents?per_page=100`.
- SPA `pushState` workaround for deep routes (`/trace`, `/topology`) per the established `trace.spec.ts` pattern.
- Fixture data (`LIVE_AGENTS`, `LIVE_TRACE_EVENTS`, `LIVE_TOPOLOGY`) uses realistic shapes matching the gateway API contracts.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention