### PR TITLE
[AAASM-1514] ✅ (aa-integration-tests): Add F116 ST-B Node.js SDK E2E fixtures and Rust harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Checkout sibling node-sdk (for e2e_sdk_node fixtures)
+        uses: actions/checkout@v4
+        with:
+          repository: AI-agent-assembly/node-sdk
+          path: node-sdk
       - name: Install protobuf compiler
         run: sudo apt-get install -y protobuf-compiler
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -144,12 +149,19 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
-          cache-dependency-path: dashboard/pnpm-lock.yaml
+          cache-dependency-path: |
+            dashboard/pnpm-lock.yaml
+            aa-integration-tests/tests/fixtures/agents/typescript/pnpm-lock.yaml
       - name: Build dashboard assets (required by aa-cli)
         working-directory: dashboard
         run: |
           pnpm install --frozen-lockfile
           pnpm build
+      - name: Symlink node-sdk for TypeScript fixture file: dependency
+        run: ln -sfn "$GITHUB_WORKSPACE/node-sdk" "$(dirname "$GITHUB_WORKSPACE")/node-sdk"
+      - name: Install TypeScript fixture dependencies (e2e_sdk_node)
+        working-directory: aa-integration-tests/tests/fixtures/agents/typescript
+        run: pnpm install --frozen-lockfile
       - name: Run tests
         # aa-ebpf requires nightly (aya-build invokes rustup run nightly) and has no
         # unit tests. Validated by the dedicated ebpf-build job.
@@ -169,6 +181,11 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v6
+      - name: Checkout sibling node-sdk (for e2e_sdk_node fixtures)
+        uses: actions/checkout@v4
+        with:
+          repository: AI-agent-assembly/node-sdk
+          path: node-sdk
       - name: Install protobuf compiler
         run: sudo apt-get install -y protobuf-compiler
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -184,12 +201,19 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
-          cache-dependency-path: dashboard/pnpm-lock.yaml
+          cache-dependency-path: |
+            dashboard/pnpm-lock.yaml
+            aa-integration-tests/tests/fixtures/agents/typescript/pnpm-lock.yaml
       - name: Build dashboard assets (required by aa-cli)
         working-directory: dashboard
         run: |
           pnpm install --frozen-lockfile
           pnpm build
+      - name: Symlink node-sdk for TypeScript fixture file: dependency
+        run: ln -sfn "$GITHUB_WORKSPACE/node-sdk" "$(dirname "$GITHUB_WORKSPACE")/node-sdk"
+      - name: Install TypeScript fixture dependencies (e2e_sdk_node)
+        working-directory: aa-integration-tests/tests/fixtures/agents/typescript
+        run: pnpm install --frozen-lockfile
       - name: Generate coverage report
         # aa-ebpf requires nightly and has no testable userspace logic — excluded.
         # aa-ffi-python requires Python dev headers for linking — excluded.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm build
-      - name: Symlink node-sdk for TypeScript fixture file: dependency
+      - name: "Symlink node-sdk for TypeScript fixture file: dependency"
         run: ln -sfn "$GITHUB_WORKSPACE/node-sdk" "$(dirname "$GITHUB_WORKSPACE")/node-sdk"
       - name: Install TypeScript fixture dependencies (e2e_sdk_node)
         working-directory: aa-integration-tests/tests/fixtures/agents/typescript
@@ -209,7 +209,7 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm build
-      - name: Symlink node-sdk for TypeScript fixture file: dependency
+      - name: "Symlink node-sdk for TypeScript fixture file: dependency"
         run: ln -sfn "$GITHUB_WORKSPACE/node-sdk" "$(dirname "$GITHUB_WORKSPACE")/node-sdk"
       - name: Install TypeScript fixture dependencies (e2e_sdk_node)
         working-directory: aa-integration-tests/tests/fixtures/agents/typescript

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,6 +4,10 @@ name: Integration tests
 # on Linux + macOS so the topology HTTP roundtrip (AAASM-1066) and the CLI
 # subcommand coverage (AAASM-1258, AAASM-1441 follow-up) are exercised on
 # both platforms before anything depending on them ships.
+#
+# Node.js SDK E2E fixtures (AAASM-1514 / F116 ST-B): TypeScript fixture scripts
+# are installed via pnpm and run in AA_SELFTEST=1 mode inside the Rust harness;
+# no running gateway or native bindings are required for the hermetic tests.
 
 on:
   push:
@@ -55,6 +59,12 @@ jobs:
           repository: AI-agent-assembly/go-sdk
           path: go-sdk
 
+      - name: Checkout sibling node-sdk
+        uses: actions/checkout@v4
+        with:
+          repository: AI-agent-assembly/node-sdk
+          path: node-sdk
+
       - name: Install protobuf compiler (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
@@ -80,6 +90,29 @@ jobs:
 
       - name: Install cargo-nextest
         uses: taiki-e/install-action@83c419a40a2e48673b2c523337e57f602dfe53c9 # cargo-nextest
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+          cache-dependency-path: aa-integration-tests/tests/fixtures/agents/typescript/pnpm-lock.yaml
+
+      - name: "Symlink node-sdk for file: dependency resolution"
+        # The TypeScript fixture package.json uses file:../../../../../../node-sdk
+        # which resolves six levels up from the typescript/ dir to the parent of
+        # GITHUB_WORKSPACE. The checkout action places node-sdk one level below
+        # GITHUB_WORKSPACE so we create a sibling symlink to bridge the gap.
+        run: ln -sfn "$GITHUB_WORKSPACE/node-sdk" "$(dirname "$GITHUB_WORKSPACE")/node-sdk"
+
+      - name: Install TypeScript fixture dependencies
+        working-directory: aa-integration-tests/tests/fixtures/agents/typescript
+        run: pnpm install --frozen-lockfile
 
       - name: Run integration tests
         env:

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -257,6 +257,7 @@ impl TopologyTestEnv {
         let trace_store = Arc::clone(&state.trace_store);
         let approval_queue = Arc::clone(&state.approval_queue);
         let budget_tracker = Arc::clone(&state.budget_tracker);
+        let ops_registry = Arc::clone(&state.ops_registry);
         let events = Arc::clone(&state.events);
         let replay_buffer = state.replay_buffer.clone();
         let next_event_id = Arc::clone(&state.next_event_id);
@@ -285,6 +286,7 @@ impl TopologyTestEnv {
             approval_queue,
             audit_dir,
             budget_tracker,
+            ops_registry,
             alert_store,
             key_store,
             events,

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -261,7 +261,6 @@ impl TopologyTestEnv {
         let events = Arc::clone(&state.events);
         let replay_buffer = state.replay_buffer.clone();
         let next_event_id = Arc::clone(&state.next_event_id);
-        let ops_registry = Arc::clone(&state.ops_registry);
 
         let port = portpicker::pick_unused_port().ok_or_else(|| anyhow::anyhow!("no free TCP port"))?;
         let addr: SocketAddr = format!("127.0.0.1:{port}").parse()?;
@@ -292,7 +291,6 @@ impl TopologyTestEnv {
             events,
             replay_buffer,
             next_event_id,
-            ops_registry,
             shutdown_tx: Some(shutdown_tx),
             server_handle: Some(server_handle),
             cleaned: false,

--- a/aa-integration-tests/tests/e2e_sdk_node.rs
+++ b/aa-integration-tests/tests/e2e_sdk_node.rs
@@ -1,0 +1,414 @@
+// F116 ST-B — Node.js SDK E2E fixture harness (AAASM-1514).
+//
+// Five hermetic selftest tests (no gateway, no native bindings) verify that
+// each TypeScript fixture script exits 0 and emits the expected JSON-line
+// contract.  Five companion tests marked `#[ignore]` cover the real
+// `initAssembly()` → gRPC-gateway path and require a running aa-gateway plus
+// native Node.js bindings; they are gated on AAASM-1514 follow-up work.
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn ts_fixtures_dir() -> PathBuf {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    PathBuf::from(manifest_dir)
+        .join("tests")
+        .join("fixtures")
+        .join("agents")
+        .join("typescript")
+}
+
+fn run_ts_script(script: &str, envs: &[(&str, &str)]) -> std::io::Result<Output> {
+    let dir = ts_fixtures_dir();
+    let mut cmd = Command::new("pnpm");
+    cmd.arg("exec").arg("tsx").arg(script);
+    cmd.current_dir(&dir);
+    for (k, v) in envs {
+        cmd.env(k, v);
+    }
+    cmd.output()
+}
+
+fn parse_events(stdout: &str) -> Vec<Value> {
+    stdout
+        .lines()
+        .filter(|l| l.trim_start().starts_with('{'))
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect()
+}
+
+fn event_of_type<'a>(events: &'a [Value], kind: &str) -> Option<&'a Value> {
+    events
+        .iter()
+        .find(|e| e.get("event").and_then(Value::as_str) == Some(kind))
+}
+
+fn assert_exit_zero(output: &Output, script: &str, stdout: &str, stderr: &str) {
+    assert!(
+        output.status.success(),
+        "{script} must exit 0 in selftest mode; got {:?}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        output.status.code(),
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Selftest tests (hermetic — no gateway, no native bindings)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn selftest_langchain_single_agent_exits_zero_and_emits_started_done() {
+    let output = run_ts_script(
+        "single_agent/langchain_agent.ts",
+        &[
+            ("AA_SELFTEST", "1"),
+            ("AA_GATEWAY_ADDR", "dummy"),
+            ("AA_AGENT_ID", "e2e-lc"),
+            ("AA_TASK", "f116-task"),
+        ],
+    )
+    .expect("spawn pnpm exec tsx single_agent/langchain_agent.ts");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_exit_zero(&output, "langchain_agent.ts", &stdout, &stderr);
+
+    let events = parse_events(&stdout);
+    let started = event_of_type(&events, "started").expect("missing 'started' event");
+    assert_eq!(started["agent_id"], "e2e-lc", "started.agent_id mismatch");
+
+    assert!(
+        event_of_type(&events, "tool_call").is_some(),
+        "missing 'tool_call' event"
+    );
+
+    let done = event_of_type(&events, "done").expect("missing 'done' event");
+    assert_eq!(done["result"], "selftest-ok", "done.result mismatch");
+}
+
+#[test]
+fn selftest_langgraph_single_agent_exits_zero_and_emits_started_done() {
+    let output = run_ts_script(
+        "single_agent/langgraph_agent.ts",
+        &[
+            ("AA_SELFTEST", "1"),
+            ("AA_GATEWAY_ADDR", "dummy"),
+            ("AA_AGENT_ID", "e2e-lg"),
+            ("AA_TASK", "f116-task"),
+        ],
+    )
+    .expect("spawn pnpm exec tsx single_agent/langgraph_agent.ts");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_exit_zero(&output, "langgraph_agent.ts", &stdout, &stderr);
+
+    let events = parse_events(&stdout);
+    let started = event_of_type(&events, "started").expect("missing 'started' event");
+    assert_eq!(started["agent_id"], "e2e-lg", "started.agent_id mismatch");
+
+    assert!(
+        event_of_type(&events, "tool_call").is_some(),
+        "missing 'tool_call' event"
+    );
+
+    let done = event_of_type(&events, "done").expect("missing 'done' event");
+    assert_eq!(done["result"], "selftest-ok", "done.result mismatch");
+}
+
+#[test]
+fn selftest_langchain_team_exits_zero_and_emits_root_and_member_started() {
+    let output = run_ts_script(
+        "agent_team/langchain_team.ts",
+        &[
+            ("AA_SELFTEST", "1"),
+            ("AA_GATEWAY_ADDR", "dummy"),
+            ("AA_AGENT_ID", "e2e-lc-root"),
+            ("AA_TASK", "f116-task"),
+        ],
+    )
+    .expect("spawn pnpm exec tsx agent_team/langchain_team.ts");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_exit_zero(&output, "langchain_team.ts", &stdout, &stderr);
+
+    let events = parse_events(&stdout);
+    let started_events: Vec<&Value> = events
+        .iter()
+        .filter(|e| e.get("event").and_then(Value::as_str) == Some("started"))
+        .collect();
+    assert_eq!(
+        started_events.len(),
+        2,
+        "expected 2 'started' events (root + member), got {}",
+        started_events.len()
+    );
+
+    let root = started_events
+        .iter()
+        .find(|e| e["agent_id"] == "e2e-lc-root")
+        .expect("missing root 'started' event");
+    assert_eq!(root["role"], "root", "root.role mismatch");
+
+    let member = started_events
+        .iter()
+        .find(|e| e["agent_id"] == "e2e-lc-root-member")
+        .expect("missing member 'started' event");
+    assert_eq!(member["role"], "member", "member.role mismatch");
+
+    let done = event_of_type(&events, "done").expect("missing 'done' event");
+    assert_eq!(done["result"], "selftest-ok", "done.result mismatch");
+}
+
+#[test]
+fn selftest_langgraph_team_exits_zero_and_emits_coordinator_and_worker_started() {
+    let output = run_ts_script(
+        "agent_team/langgraph_team.ts",
+        &[
+            ("AA_SELFTEST", "1"),
+            ("AA_GATEWAY_ADDR", "dummy"),
+            ("AA_AGENT_ID", "e2e-lg-root"),
+            ("AA_TASK", "f116-task"),
+        ],
+    )
+    .expect("spawn pnpm exec tsx agent_team/langgraph_team.ts");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_exit_zero(&output, "langgraph_team.ts", &stdout, &stderr);
+
+    let events = parse_events(&stdout);
+    let started_events: Vec<&Value> = events
+        .iter()
+        .filter(|e| e.get("event").and_then(Value::as_str) == Some("started"))
+        .collect();
+    assert_eq!(
+        started_events.len(),
+        2,
+        "expected 2 'started' events (coordinator + worker), got {}",
+        started_events.len()
+    );
+
+    let coord = started_events
+        .iter()
+        .find(|e| e["agent_id"] == "e2e-lg-root")
+        .expect("missing coordinator 'started' event");
+    assert_eq!(coord["role"], "coordinator", "coordinator.role mismatch");
+
+    let worker = started_events
+        .iter()
+        .find(|e| e["agent_id"] == "e2e-lg-root-worker")
+        .expect("missing worker 'started' event");
+    assert_eq!(worker["role"], "worker", "worker.role mismatch");
+
+    let done = event_of_type(&events, "done").expect("missing 'done' event");
+    assert_eq!(done["result"], "selftest-ok", "done.result mismatch");
+}
+
+#[test]
+fn selftest_langgraph_hierarchy_exits_zero_and_emits_root_planner_executor_started() {
+    let output = run_ts_script(
+        "root_sub_agents/langgraph_hierarchy.ts",
+        &[
+            ("AA_SELFTEST", "1"),
+            ("AA_GATEWAY_ADDR", "dummy"),
+            ("AA_AGENT_ID", "e2e-root"),
+            ("AA_TASK", "f116-task"),
+        ],
+    )
+    .expect("spawn pnpm exec tsx root_sub_agents/langgraph_hierarchy.ts");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_exit_zero(&output, "langgraph_hierarchy.ts", &stdout, &stderr);
+
+    let events = parse_events(&stdout);
+    let started_events: Vec<&Value> = events
+        .iter()
+        .filter(|e| e.get("event").and_then(Value::as_str) == Some("started"))
+        .collect();
+    assert_eq!(
+        started_events.len(),
+        3,
+        "expected 3 'started' events (root + planner + executor), got {}",
+        started_events.len()
+    );
+
+    for (id, role) in [
+        ("e2e-root", "root"),
+        ("e2e-root-planner", "planner"),
+        ("e2e-root-executor", "executor"),
+    ] {
+        let ev = started_events
+            .iter()
+            .find(|e| e["agent_id"] == id)
+            .unwrap_or_else(|| panic!("missing 'started' event for {id}"));
+        assert_eq!(ev["role"], role, "role mismatch for {id}");
+    }
+
+    let done = event_of_type(&events, "done").expect("missing 'done' event");
+    assert_eq!(done["result"], "selftest-ok", "done.result mismatch");
+}
+
+// ---------------------------------------------------------------------------
+// Real tests — require aa-gateway (gRPC) + native Node.js bindings.
+// Blocked pending AAASM-1514 follow-up: native napi-rs build in CI +
+// aa-gateway gRPC listener wired into the integration-test harness.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "requires running aa-gateway and Node.js native bindings (AAASM-1514 follow-up)"]
+fn real_langchain_single_agent_registers_with_gateway_and_emits_started_done() {
+    let addr = std::env::var("AA_GATEWAY_ADDR").unwrap_or_else(|_| "127.0.0.1:50051".to_string());
+    let output = run_ts_script(
+        "single_agent/langchain_agent.ts",
+        &[
+            ("AA_GATEWAY_ADDR", &addr),
+            ("AA_AGENT_ID", "e2e-lc-real"),
+            ("AA_TASK", "f116-task"),
+        ],
+    )
+    .expect("spawn pnpm exec tsx single_agent/langchain_agent.ts");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "langchain_agent.ts (real) must exit 0\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let events = parse_events(&stdout);
+    assert!(event_of_type(&events, "started").is_some(), "missing 'started' event");
+    assert!(event_of_type(&events, "done").is_some(), "missing 'done' event");
+}
+
+#[test]
+#[ignore = "requires running aa-gateway and Node.js native bindings (AAASM-1514 follow-up)"]
+fn real_langgraph_single_agent_registers_with_gateway_and_emits_started_done() {
+    let addr = std::env::var("AA_GATEWAY_ADDR").unwrap_or_else(|_| "127.0.0.1:50051".to_string());
+    let output = run_ts_script(
+        "single_agent/langgraph_agent.ts",
+        &[
+            ("AA_GATEWAY_ADDR", &addr),
+            ("AA_AGENT_ID", "e2e-lg-real"),
+            ("AA_TASK", "f116-task"),
+        ],
+    )
+    .expect("spawn pnpm exec tsx single_agent/langgraph_agent.ts");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "langgraph_agent.ts (real) must exit 0\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let events = parse_events(&stdout);
+    assert!(event_of_type(&events, "started").is_some(), "missing 'started' event");
+    assert!(event_of_type(&events, "done").is_some(), "missing 'done' event");
+}
+
+#[test]
+#[ignore = "requires running aa-gateway and Node.js native bindings (AAASM-1514 follow-up)"]
+fn real_langchain_team_registers_root_and_member_with_gateway() {
+    let addr = std::env::var("AA_GATEWAY_ADDR").unwrap_or_else(|_| "127.0.0.1:50051".to_string());
+    let output = run_ts_script(
+        "agent_team/langchain_team.ts",
+        &[
+            ("AA_GATEWAY_ADDR", &addr),
+            ("AA_AGENT_ID", "e2e-lc-root-real"),
+            ("AA_TASK", "f116-task"),
+        ],
+    )
+    .expect("spawn pnpm exec tsx agent_team/langchain_team.ts");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "langchain_team.ts (real) must exit 0\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let events = parse_events(&stdout);
+    let started_count = events
+        .iter()
+        .filter(|e| e.get("event").and_then(Value::as_str) == Some("started"))
+        .count();
+    assert_eq!(
+        started_count, 2,
+        "expected root + member registered (2 'started' events), got {started_count}"
+    );
+    assert!(event_of_type(&events, "done").is_some(), "missing 'done' event");
+}
+
+#[test]
+#[ignore = "requires running aa-gateway and Node.js native bindings (AAASM-1514 follow-up)"]
+fn real_langgraph_team_registers_coordinator_and_worker_with_gateway() {
+    let addr = std::env::var("AA_GATEWAY_ADDR").unwrap_or_else(|_| "127.0.0.1:50051".to_string());
+    let output = run_ts_script(
+        "agent_team/langgraph_team.ts",
+        &[
+            ("AA_GATEWAY_ADDR", &addr),
+            ("AA_AGENT_ID", "e2e-lg-root-real"),
+            ("AA_TASK", "f116-task"),
+        ],
+    )
+    .expect("spawn pnpm exec tsx agent_team/langgraph_team.ts");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "langgraph_team.ts (real) must exit 0\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let events = parse_events(&stdout);
+    let started_count = events
+        .iter()
+        .filter(|e| e.get("event").and_then(Value::as_str) == Some("started"))
+        .count();
+    assert_eq!(
+        started_count, 2,
+        "expected coordinator + worker registered (2 'started' events), got {started_count}"
+    );
+    assert!(event_of_type(&events, "done").is_some(), "missing 'done' event");
+}
+
+#[test]
+#[ignore = "requires running aa-gateway and Node.js native bindings (AAASM-1514 follow-up)"]
+fn real_langgraph_hierarchy_registers_root_planner_executor_with_gateway() {
+    let addr = std::env::var("AA_GATEWAY_ADDR").unwrap_or_else(|_| "127.0.0.1:50051".to_string());
+    let output = run_ts_script(
+        "root_sub_agents/langgraph_hierarchy.ts",
+        &[
+            ("AA_GATEWAY_ADDR", &addr),
+            ("AA_AGENT_ID", "e2e-root-real"),
+            ("AA_TASK", "f116-task"),
+        ],
+    )
+    .expect("spawn pnpm exec tsx root_sub_agents/langgraph_hierarchy.ts");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "langgraph_hierarchy.ts (real) must exit 0\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let events = parse_events(&stdout);
+    let started_count = events
+        .iter()
+        .filter(|e| e.get("event").and_then(Value::as_str) == Some("started"))
+        .count();
+    assert_eq!(
+        started_count, 3,
+        "expected root + planner + executor registered (3 'started' events), got {started_count}"
+    );
+    assert!(event_of_type(&events, "done").is_some(), "missing 'done' event");
+}

--- a/aa-integration-tests/tests/fixtures/agents/run_agents_ts.sh
+++ b/aa-integration-tests/tests/fixtures/agents/run_agents_ts.sh
@@ -1,60 +1,224 @@
 #!/usr/bin/env bash
-# run_agents_ts.sh — developer helper to run all TypeScript fixture scripts.
+# run_agents_ts.sh — developer helper to run TypeScript fixture scripts.
 #
 # Usage (selftest mode — no gateway required):
 #   bash run_agents_ts.sh
 #   bash run_agents_ts.sh --selftest
 #
-# Usage (real mode — gateway must be running):
+# Usage (filter scripts):
+#   bash run_agents_ts.sh --list
+#   bash run_agents_ts.sh --framework langchain
+#   bash run_agents_ts.sh --scenario single_agent
+#   bash run_agents_ts.sh --file "*hierarchy*"
+#
+# Usage (run options):
+#   bash run_agents_ts.sh --parallel --verbose
+#
+# Usage (real mode — supply a running gateway):
 #   AA_GATEWAY_ADDR=127.0.0.1:50051 bash run_agents_ts.sh
 #
-# The SELFTEST env-var is automatically set when AA_GATEWAY_ADDR is absent or
-# --selftest is passed, so each script emits synthetic events and exits 0
-# without contacting anything.
+# Usage (auto-start gateway from workspace build):
+#   bash run_agents_ts.sh --auto-gateway [--scenario single_agent]
+#
+# The AA_SELFTEST env-var is automatically set when AA_GATEWAY_ADDR is absent
+# and --auto-gateway is not passed, so each script emits synthetic events and
+# exits 0 without contacting anything.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TS_DIR="$SCRIPT_DIR/typescript"
 
+# ── Argument parsing ───────────────────────────────────────────────────────
 SELFTEST_FLAG=0
-for arg in "$@"; do
-  case "$arg" in
-    --selftest) SELFTEST_FLAG=1 ;;
+LIST_FLAG=0
+PARALLEL_FLAG=0
+VERBOSE_FLAG=0
+AUTO_GATEWAY_FLAG=0
+FILTER_FRAMEWORK=""
+FILTER_SCENARIO=""
+FILTER_FILE_GLOB=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --selftest)      SELFTEST_FLAG=1 ;;
+    --list)          LIST_FLAG=1 ;;
+    --parallel)      PARALLEL_FLAG=1 ;;
+    --verbose)       VERBOSE_FLAG=1 ;;
+    --auto-gateway)  AUTO_GATEWAY_FLAG=1 ;;
+    --framework)     shift; FILTER_FRAMEWORK="$1" ;;
+    --scenario)      shift; FILTER_SCENARIO="$1" ;;
+    --file)          shift; FILTER_FILE_GLOB="$1" ;;
+    -h|--help)
+      sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "error: unknown option: $1" >&2; exit 1 ;;
   esac
+  shift
 done
 
-if [[ "$SELFTEST_FLAG" -eq 1 || -z "${AA_GATEWAY_ADDR:-}" ]]; then
+# ── Script discovery ───────────────────────────────────────────────────────
+# Discover *.ts files under typescript/, excluding _shared.ts and node_modules.
+DISCOVERED=()
+while IFS= read -r -d '' f; do
+  rel="${f#$TS_DIR/}"
+  DISCOVERED+=("$rel")
+done < <(find "$TS_DIR" -name "*.ts" ! -name "_shared.ts" \
+           -not -path "*/node_modules/*" -print0 | sort -z)
+
+# ── Filtering ──────────────────────────────────────────────────────────────
+SCRIPTS=()
+for script in "${DISCOVERED[@]}"; do
+  scenario="$(dirname "$script")"
+  stem="$(basename "$script" .ts)"
+  framework="${stem%%_*}"
+
+  [[ -n "$FILTER_FRAMEWORK" && "$framework" != "$FILTER_FRAMEWORK" ]] && continue
+  [[ -n "$FILTER_SCENARIO"  && "$scenario"  != "$FILTER_SCENARIO"  ]] && continue
+  if [[ -n "$FILTER_FILE_GLOB" ]]; then
+    # shellcheck disable=SC2254
+    case "$(basename "$script")" in $FILTER_FILE_GLOB) ;; *) continue ;; esac
+  fi
+
+  SCRIPTS+=("$script")
+done
+
+if [[ "${#SCRIPTS[@]}" -eq 0 ]]; then
+  echo "[run_agents_ts] No matching scripts found." >&2
+  exit 1
+fi
+
+# ── --list ─────────────────────────────────────────────────────────────────
+if [[ "$LIST_FLAG" -eq 1 ]]; then
+  printf "  %-14s  %-24s  %s\n" "FRAMEWORK" "SCENARIO" "PATH"
+  printf "  %-14s  %-24s  %s\n" "---------" "--------" "----"
+  for script in "${SCRIPTS[@]}"; do
+    scenario="$(dirname "$script")"
+    stem="$(basename "$script" .ts)"
+    framework="${stem%%_*}"
+    printf "  %-14s  %-24s  %s\n" "$framework" "$scenario" "$script"
+  done
+  exit 0
+fi
+
+# ── --auto-gateway ─────────────────────────────────────────────────────────
+GATEWAY_PID=""
+if [[ "$AUTO_GATEWAY_FLAG" -eq 1 ]]; then
+  REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+  GATEWAY_BIN=""
+  for candidate in \
+      "$REPO_ROOT/target/debug/aa-gateway" \
+      "$REPO_ROOT/target/release/aa-gateway"; do
+    if [[ -x "$candidate" ]]; then
+      GATEWAY_BIN="$candidate"
+      break
+    fi
+  done
+
+  if [[ -z "$GATEWAY_BIN" ]]; then
+    echo "[run_agents_ts] Building aa-gateway (cargo build -p aa-gateway)..." >&2
+    (cd "$REPO_ROOT" && cargo build -p aa-gateway 2>&1) >&2
+    GATEWAY_BIN="$REPO_ROOT/target/debug/aa-gateway"
+  fi
+
+  # Write an inline allow-all policy to a temp file.
+  POLICY_FILE="$(mktemp /tmp/aa-allow-all-XXXXXX.yaml)"
+  cat > "$POLICY_FILE" <<'YAML'
+version: "1"
+global:
+  default_action: allow
+YAML
+
+  # Pick a free TCP port.
+  FREE_PORT="$(python3 -c \
+    "import socket; s=socket.socket(); s.bind(('',0)); \
+     p=s.getsockname()[1]; s.close(); print(p)")"
+
+  export AA_GATEWAY_ADDR="127.0.0.1:$FREE_PORT"
+  "$GATEWAY_BIN" --policy "$POLICY_FILE" --listen "$AA_GATEWAY_ADDR" \
+    >/tmp/aa-gateway.log 2>&1 &
+  GATEWAY_PID=$!
+  echo "[run_agents_ts] Gateway started on $AA_GATEWAY_ADDR (PID $GATEWAY_PID)"
+  sleep 1  # allow gateway to finish binding
+
+  # shellcheck disable=SC2064
+  trap "kill '$GATEWAY_PID' 2>/dev/null; rm -f '$POLICY_FILE'" EXIT
+fi
+
+# ── Selftest mode ──────────────────────────────────────────────────────────
+if [[ "$SELFTEST_FLAG" -eq 1 ]] || \
+   [[ -z "${AA_GATEWAY_ADDR:-}" && "$AUTO_GATEWAY_FLAG" -eq 0 ]]; then
   export AA_SELFTEST=1
-  export AA_GATEWAY_ADDR=dummy
+  export AA_GATEWAY_ADDR="${AA_GATEWAY_ADDR:-dummy}"
   echo "[run_agents_ts] Running in selftest mode"
 fi
 
 export AA_AGENT_ID="${AA_AGENT_ID:-e2e-dev}"
 export AA_TASK="${AA_TASK:-hello}"
 
-SCRIPTS=(
-  "single_agent/langchain_agent.ts"
-  "single_agent/langgraph_agent.ts"
-  "agent_team/langchain_team.ts"
-  "agent_team/langgraph_team.ts"
-  "root_sub_agents/langgraph_hierarchy.ts"
-)
+# ── Execution helpers ──────────────────────────────────────────────────────
+_run_one() {
+  local script="$1"
+  local scenario stem framework label
+  scenario="$(dirname "$script")"
+  stem="$(basename "$script" .ts)"
+  framework="${stem%%_*}"
+  label="[$framework / $scenario]"
 
+  if [[ "$VERBOSE_FLAG" -eq 1 ]]; then
+    echo ""
+    echo "==> $label $script"
+  else
+    echo ""
+    echo "==> $script"
+  fi
+
+  (cd "$TS_DIR" && pnpm exec tsx "$script" 2>&1)
+}
+
+# ── Run scripts ────────────────────────────────────────────────────────────
 PASS=0
 FAIL=0
 
-for script in "${SCRIPTS[@]}"; do
-  echo ""
-  echo "==> $script"
-  if (cd "$TS_DIR" && pnpm exec tsx "$script" 2>&1); then
-    echo "    [PASS]"
-    PASS=$((PASS + 1))
-  else
-    echo "    [FAIL]"
-    FAIL=$((FAIL + 1))
-  fi
-done
+if [[ "$PARALLEL_FLAG" -eq 1 ]]; then
+  TMPDIR_P="$(mktemp -d)"
+  PIDS=()
+  IDX=0
+  for script in "${SCRIPTS[@]}"; do
+    tmpout="$TMPDIR_P/$IDX.out"
+    ( _run_one "$script"; echo $? ) > "$tmpout" 2>&1 &
+    PIDS+=($!)
+    IDX=$((IDX + 1))
+  done
+
+  IDX=0
+  for script in "${SCRIPTS[@]}"; do
+    wait "${PIDS[$IDX]}" 2>/dev/null || true
+    tmpout="$TMPDIR_P/$IDX.out"
+    line_count="$(wc -l < "$tmpout")"
+    head -n $((line_count - 1)) "$tmpout"
+    rc="$(tail -n 1 "$tmpout")"
+    if [[ "$rc" -eq 0 ]]; then
+      echo "    [PASS]"
+      PASS=$((PASS + 1))
+    else
+      echo "    [FAIL]"
+      FAIL=$((FAIL + 1))
+    fi
+    IDX=$((IDX + 1))
+  done
+  rm -rf "$TMPDIR_P"
+else
+  for script in "${SCRIPTS[@]}"; do
+    if _run_one "$script"; then
+      echo "    [PASS]"
+      PASS=$((PASS + 1))
+    else
+      echo "    [FAIL]"
+      FAIL=$((FAIL + 1))
+    fi
+  done
+fi
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/aa-integration-tests/tests/fixtures/agents/run_agents_ts.sh
+++ b/aa-integration-tests/tests/fixtures/agents/run_agents_ts.sh
@@ -3,22 +3,31 @@
 #
 # Usage (selftest mode — no gateway required):
 #   bash run_agents_ts.sh
+#   bash run_agents_ts.sh --selftest
 #
 # Usage (real mode — gateway must be running):
 #   AA_GATEWAY_ADDR=127.0.0.1:50051 bash run_agents_ts.sh
 #
-# The SELFTEST env-var is automatically set when AA_GATEWAY_ADDR is absent so
-# each script emits synthetic events and exits 0 without contacting anything.
+# The SELFTEST env-var is automatically set when AA_GATEWAY_ADDR is absent or
+# --selftest is passed, so each script emits synthetic events and exits 0
+# without contacting anything.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TS_DIR="$SCRIPT_DIR/typescript"
 
-if [[ -z "${AA_GATEWAY_ADDR:-}" ]]; then
+SELFTEST_FLAG=0
+for arg in "$@"; do
+  case "$arg" in
+    --selftest) SELFTEST_FLAG=1 ;;
+  esac
+done
+
+if [[ "$SELFTEST_FLAG" -eq 1 || -z "${AA_GATEWAY_ADDR:-}" ]]; then
   export AA_SELFTEST=1
   export AA_GATEWAY_ADDR=dummy
-  echo "[run_agents_ts] No AA_GATEWAY_ADDR set — running in selftest mode"
+  echo "[run_agents_ts] Running in selftest mode"
 fi
 
 export AA_AGENT_ID="${AA_AGENT_ID:-e2e-dev}"

--- a/aa-integration-tests/tests/fixtures/agents/run_agents_ts.sh
+++ b/aa-integration-tests/tests/fixtures/agents/run_agents_ts.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# run_agents_ts.sh — developer helper to run all TypeScript fixture scripts.
+#
+# Usage (selftest mode — no gateway required):
+#   bash run_agents_ts.sh
+#
+# Usage (real mode — gateway must be running):
+#   AA_GATEWAY_ADDR=127.0.0.1:50051 bash run_agents_ts.sh
+#
+# The SELFTEST env-var is automatically set when AA_GATEWAY_ADDR is absent so
+# each script emits synthetic events and exits 0 without contacting anything.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TS_DIR="$SCRIPT_DIR/typescript"
+
+if [[ -z "${AA_GATEWAY_ADDR:-}" ]]; then
+  export AA_SELFTEST=1
+  export AA_GATEWAY_ADDR=dummy
+  echo "[run_agents_ts] No AA_GATEWAY_ADDR set — running in selftest mode"
+fi
+
+export AA_AGENT_ID="${AA_AGENT_ID:-e2e-dev}"
+export AA_TASK="${AA_TASK:-hello}"
+
+SCRIPTS=(
+  "single_agent/langchain_agent.ts"
+  "single_agent/langgraph_agent.ts"
+  "agent_team/langchain_team.ts"
+  "agent_team/langgraph_team.ts"
+  "root_sub_agents/langgraph_hierarchy.ts"
+)
+
+PASS=0
+FAIL=0
+
+for script in "${SCRIPTS[@]}"; do
+  echo ""
+  echo "==> $script"
+  if (cd "$TS_DIR" && pnpm exec tsx "$script" 2>&1); then
+    echo "    [PASS]"
+    PASS=$((PASS + 1))
+  else
+    echo "    [FAIL]"
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/aa-integration-tests/tests/fixtures/agents/typescript/_shared.ts
+++ b/aa-integration-tests/tests/fixtures/agents/typescript/_shared.ts
@@ -1,0 +1,37 @@
+// Shared helpers for TypeScript agent fixture scripts (AAASM-1514 / F116 ST-B).
+//
+// Each fixture script imports this module for standardised env-var reading and
+// structured JSON-line output. The Rust E2E harness (e2e_sdk_node.rs) and the
+// developer runner (run_agents_ts.sh) both invoke fixture scripts via:
+//
+//   AA_GATEWAY_ADDR=<host:port> AA_AGENT_ID=<id> pnpm exec tsx <script>
+//
+// Selftest mode (AA_SELFTEST=1) emits synthetic events without connecting to
+// a real gateway, so scripts can be exercised hermetically in CI.
+
+import { randomBytes } from "node:crypto";
+
+export interface AgentConfig {
+  gatewayAddr: string;
+  agentId: string;
+  task: string;
+  proxyAddr?: string; // undefined = Layer 2 inactive
+}
+
+export function loadConfig(): AgentConfig {
+  const gatewayAddr = process.env.AA_GATEWAY_ADDR;
+  if (!gatewayAddr) {
+    console.error("error: AA_GATEWAY_ADDR required");
+    process.exit(2);
+  }
+  return {
+    gatewayAddr,
+    agentId: process.env.AA_AGENT_ID ?? `e2e-${randomBytes(4).toString("hex")}`,
+    task: process.env.AA_TASK ?? "noop",
+    proxyAddr: process.env.AA_PROXY_ADDR,
+  };
+}
+
+export function emit(event: Record<string, unknown>): void {
+  console.log(JSON.stringify(event));
+}

--- a/aa-integration-tests/tests/fixtures/agents/typescript/agent_team/langchain_team.ts
+++ b/aa-integration-tests/tests/fixtures/agents/typescript/agent_team/langchain_team.ts
@@ -11,9 +11,9 @@
 //   AA_SELFTEST=1 AA_GATEWAY_ADDR=dummy pnpm exec tsx agent_team/langchain_team.ts
 
 import { loadConfig, emit, type AgentConfig } from "../_shared.js";
-import { initAssembly } from "@agent-assembly/sdk";
 
 async function runReal(cfg: AgentConfig): Promise<void> {
+  const { initAssembly } = await import("@agent-assembly/sdk");
   const rootCtx = await initAssembly({
     gatewayUrl: `http://${cfg.gatewayAddr}`,
     apiKey: "e2e-test-key",

--- a/aa-integration-tests/tests/fixtures/agents/typescript/agent_team/langchain_team.ts
+++ b/aa-integration-tests/tests/fixtures/agents/typescript/agent_team/langchain_team.ts
@@ -1,0 +1,67 @@
+// F116 ST-B — two-agent LangChain team fixture (AAASM-1514).
+//
+// Registers a root agent plus one child agent (inheriting lineage from root),
+// each invoking a LangChain tool. Verifies multi-agent registration in sdk-only
+// mode. In selftest mode emits synthetic events for hermetic CI runs.
+//
+// Invocation:
+//   AA_GATEWAY_ADDR=127.0.0.1:PORT AA_AGENT_ID=e2e-lc-root \
+//     pnpm exec tsx agent_team/langchain_team.ts
+//
+//   AA_SELFTEST=1 AA_GATEWAY_ADDR=dummy pnpm exec tsx agent_team/langchain_team.ts
+
+import { loadConfig, emit, type AgentConfig } from "../_shared.js";
+import { initAssembly } from "@agent-assembly/sdk";
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+async function runReal(cfg: AgentConfig): Promise<void> {
+  const rootCtx = await initAssembly({
+    gatewayUrl: `http://${cfg.gatewayAddr}`,
+    apiKey: "e2e-test-key",
+    agentId: cfg.agentId,
+    teamId: "f116-e2e",
+    mode: "sdk-only",
+  });
+
+  emit({ event: "started", agent_id: cfg.agentId, role: "root" });
+
+  const memberCtx = await initAssembly({
+    gatewayUrl: `http://${cfg.gatewayAddr}`,
+    apiKey: "e2e-test-key",
+    agentId: `${cfg.agentId}-member`,
+    teamId: "f116-e2e",
+    parentAgentId: cfg.agentId,
+    mode: "sdk-only",
+  });
+
+  emit({ event: "started", agent_id: `${cfg.agentId}-member`, role: "member" });
+
+  const echoTool = tool(
+    async ({ input }: { input: string }) => `echo: ${input}`,
+    {
+      name: "echo",
+      description: "Echoes the input string",
+      schema: z.object({ input: z.string() }),
+    }
+  );
+
+  const result = await echoTool.invoke({ input: cfg.task });
+  emit({ event: "tool_call", tool: "echo", input: cfg.task });
+
+  await memberCtx.shutdown();
+  await rootCtx.shutdown();
+  emit({ event: "done", result });
+}
+
+const cfg = loadConfig();
+
+if (process.env.AA_SELFTEST === "1") {
+  emit({ event: "started", agent_id: cfg.agentId, role: "root" });
+  emit({ event: "started", agent_id: `${cfg.agentId}-member`, role: "member" });
+  emit({ event: "tool_call", tool: "echo", input: cfg.task });
+  emit({ event: "done", result: "selftest-ok" });
+  process.exit(0);
+}
+
+await runReal(cfg);

--- a/aa-integration-tests/tests/fixtures/agents/typescript/agent_team/langchain_team.ts
+++ b/aa-integration-tests/tests/fixtures/agents/typescript/agent_team/langchain_team.ts
@@ -12,8 +12,6 @@
 
 import { loadConfig, emit, type AgentConfig } from "../_shared.js";
 import { initAssembly } from "@agent-assembly/sdk";
-import { tool } from "@langchain/core/tools";
-import { z } from "zod";
 
 async function runReal(cfg: AgentConfig): Promise<void> {
   const rootCtx = await initAssembly({
@@ -37,16 +35,8 @@ async function runReal(cfg: AgentConfig): Promise<void> {
 
   emit({ event: "started", agent_id: `${cfg.agentId}-member`, role: "member" });
 
-  const echoTool = tool(
-    async ({ input }: { input: string }) => `echo: ${input}`,
-    {
-      name: "echo",
-      description: "Echoes the input string",
-      schema: z.object({ input: z.string() }),
-    }
-  );
-
-  const result = await echoTool.invoke({ input: cfg.task });
+  // Simulate a LangChain team tool call.
+  const result = `team-echo: ${cfg.task}`;
   emit({ event: "tool_call", tool: "echo", input: cfg.task });
 
   await memberCtx.shutdown();

--- a/aa-integration-tests/tests/fixtures/agents/typescript/agent_team/langchain_team.ts
+++ b/aa-integration-tests/tests/fixtures/agents/typescript/agent_team/langchain_team.ts
@@ -1,8 +1,9 @@
 // F116 ST-B — two-agent LangChain team fixture (AAASM-1514).
 //
-// Registers a root agent plus one child agent (inheriting lineage from root),
-// each invoking a LangChain tool. Verifies multi-agent registration in sdk-only
-// mode. In selftest mode emits synthetic events for hermetic CI runs.
+// Registers a root agent plus one child agent (inheriting lineage from root).
+// The member agent invokes a LangChain DynamicTool. Verifies multi-agent
+// registration in sdk-only mode. In selftest mode emits synthetic events for
+// hermetic CI runs.
 //
 // Invocation:
 //   AA_GATEWAY_ADDR=127.0.0.1:PORT AA_AGENT_ID=e2e-lc-root \
@@ -11,6 +12,13 @@
 //   AA_SELFTEST=1 AA_GATEWAY_ADDR=dummy pnpm exec tsx agent_team/langchain_team.ts
 
 import { loadConfig, emit, type AgentConfig } from "../_shared.js";
+import { DynamicTool } from "@langchain/core/tools";
+
+const teamEchoTool = new DynamicTool({
+  name: "team-echo",
+  description: "Echoes a task within a team context.",
+  func: async (input: string) => `team-echo: ${input}`,
+});
 
 async function runReal(cfg: AgentConfig): Promise<void> {
   const { initAssembly } = await import("@agent-assembly/sdk");
@@ -35,9 +43,9 @@ async function runReal(cfg: AgentConfig): Promise<void> {
 
   emit({ event: "started", agent_id: `${cfg.agentId}-member`, role: "member" });
 
-  // Simulate a LangChain team tool call.
-  const result = `team-echo: ${cfg.task}`;
-  emit({ event: "tool_call", tool: "echo", input: cfg.task });
+  // Member agent invokes the LangChain tool.
+  const result = await teamEchoTool.invoke(cfg.task);
+  emit({ event: "tool_call", tool: "team-echo", input: cfg.task });
 
   await memberCtx.shutdown();
   await rootCtx.shutdown();
@@ -49,7 +57,7 @@ const cfg = loadConfig();
 if (process.env.AA_SELFTEST === "1") {
   emit({ event: "started", agent_id: cfg.agentId, role: "root" });
   emit({ event: "started", agent_id: `${cfg.agentId}-member`, role: "member" });
-  emit({ event: "tool_call", tool: "echo", input: cfg.task });
+  emit({ event: "tool_call", tool: "team-echo", input: cfg.task });
   emit({ event: "done", result: "selftest-ok" });
   process.exit(0);
 }

--- a/aa-integration-tests/tests/fixtures/agents/typescript/agent_team/langgraph_team.ts
+++ b/aa-integration-tests/tests/fixtures/agents/typescript/agent_team/langgraph_team.ts
@@ -1,0 +1,68 @@
+// F116 ST-B — two-agent LangGraph team fixture (AAASM-1514).
+//
+// Registers a root agent, then builds a LangGraph where the coordinator node
+// spins up a child assembly context (simulating agent delegation). In selftest
+// mode emits synthetic events for hermetic CI runs.
+//
+// Invocation:
+//   AA_GATEWAY_ADDR=127.0.0.1:PORT AA_AGENT_ID=e2e-lg-root \
+//     pnpm exec tsx agent_team/langgraph_team.ts
+//
+//   AA_SELFTEST=1 AA_GATEWAY_ADDR=dummy pnpm exec tsx agent_team/langgraph_team.ts
+
+import { loadConfig, emit, type AgentConfig } from "../_shared.js";
+import { initAssembly } from "@agent-assembly/sdk";
+import { StateGraph, Annotation } from "@langchain/langgraph";
+
+const StateAnnotation = Annotation.Root({
+  task: Annotation<string>(),
+  results: Annotation<string[]>({ reducer: (a, b) => [...a, ...b], default: () => [] }),
+});
+
+async function runReal(cfg: AgentConfig): Promise<void> {
+  const rootCtx = await initAssembly({
+    gatewayUrl: `http://${cfg.gatewayAddr}`,
+    apiKey: "e2e-test-key",
+    agentId: cfg.agentId,
+    teamId: "f116-e2e",
+    mode: "sdk-only",
+  });
+
+  emit({ event: "started", agent_id: cfg.agentId, role: "coordinator" });
+
+  const graph = new StateGraph(StateAnnotation)
+    .addNode("coordinator", async (state) => {
+      const workerCtx = await initAssembly({
+        gatewayUrl: `http://${cfg.gatewayAddr}`,
+        apiKey: "e2e-test-key",
+        agentId: `${cfg.agentId}-worker`,
+        teamId: "f116-e2e",
+        parentAgentId: cfg.agentId,
+        mode: "sdk-only",
+      });
+      emit({ event: "started", agent_id: `${cfg.agentId}-worker`, role: "worker" });
+      await workerCtx.shutdown();
+      return { results: [`worker: ${state.task}`] };
+    })
+    .addEdge("__start__", "coordinator")
+    .addEdge("coordinator", "__end__")
+    .compile();
+
+  const output = await graph.invoke({ task: cfg.task });
+  emit({ event: "tool_call", tool: "coordinator", input: cfg.task });
+
+  await rootCtx.shutdown();
+  emit({ event: "done", result: output.results.join(", ") });
+}
+
+const cfg = loadConfig();
+
+if (process.env.AA_SELFTEST === "1") {
+  emit({ event: "started", agent_id: cfg.agentId, role: "coordinator" });
+  emit({ event: "started", agent_id: `${cfg.agentId}-worker`, role: "worker" });
+  emit({ event: "tool_call", tool: "coordinator", input: cfg.task });
+  emit({ event: "done", result: "selftest-ok" });
+  process.exit(0);
+}
+
+await runReal(cfg);

--- a/aa-integration-tests/tests/fixtures/agents/typescript/agent_team/langgraph_team.ts
+++ b/aa-integration-tests/tests/fixtures/agents/typescript/agent_team/langgraph_team.ts
@@ -11,7 +11,6 @@
 //   AA_SELFTEST=1 AA_GATEWAY_ADDR=dummy pnpm exec tsx agent_team/langgraph_team.ts
 
 import { loadConfig, emit, type AgentConfig } from "../_shared.js";
-import { initAssembly } from "@agent-assembly/sdk";
 import { StateGraph, Annotation } from "@langchain/langgraph";
 
 const StateAnnotation = Annotation.Root({
@@ -20,6 +19,7 @@ const StateAnnotation = Annotation.Root({
 });
 
 async function runReal(cfg: AgentConfig): Promise<void> {
+  const { initAssembly } = await import("@agent-assembly/sdk");
   const rootCtx = await initAssembly({
     gatewayUrl: `http://${cfg.gatewayAddr}`,
     apiKey: "e2e-test-key",

--- a/aa-integration-tests/tests/fixtures/agents/typescript/package.json
+++ b/aa-integration-tests/tests/fixtures/agents/typescript/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "aa-agent-fixtures-typescript",
+  "version": "0.0.0",
+  "private": true,
+  "description": "TypeScript agent fixture scripts for aa-integration-tests F116 E2E tests",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@agent-assembly/sdk": "file:../../../../../../node-sdk",
+    "langchain": "^0.3.0",
+    "@langchain/core": "^0.3.0",
+    "@langchain/langgraph": "^0.2.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0",
+    "typescript": "^5.8.0",
+    "@types/node": "^24.0.0"
+  }
+}

--- a/aa-integration-tests/tests/fixtures/agents/typescript/package.json
+++ b/aa-integration-tests/tests/fixtures/agents/typescript/package.json
@@ -2,6 +2,7 @@
   "name": "aa-agent-fixtures-typescript",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "description": "TypeScript agent fixture scripts for aa-integration-tests F116 E2E tests",
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/aa-integration-tests/tests/fixtures/agents/typescript/pnpm-lock.yaml
+++ b/aa-integration-tests/tests/fixtures/agents/typescript/pnpm-lock.yaml
@@ -1,0 +1,809 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@agent-assembly/sdk':
+        specifier: file:../../../../../../node-sdk
+        version: file:../../../../../../node-sdk(@langchain/core@0.3.80(openai@5.12.2(zod@3.25.76)))
+      '@langchain/core':
+        specifier: ^0.3.0
+        version: 0.3.80(openai@5.12.2(zod@3.25.76))
+      '@langchain/langgraph':
+        specifier: ^0.2.0
+        version: 0.2.74(@langchain/core@0.3.80(openai@5.12.2(zod@3.25.76)))(zod-to-json-schema@3.25.2(zod@3.25.76))
+      langchain:
+        specifier: ^0.3.0
+        version: 0.3.37(@langchain/core@0.3.80(openai@5.12.2(zod@3.25.76)))(openai@5.12.2(zod@3.25.76))
+    devDependencies:
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.12.4
+      tsx:
+        specifier: ^4.19.0
+        version: 4.22.1
+      typescript:
+        specifier: ^5.8.0
+        version: 5.9.3
+
+packages:
+
+  '@agent-assembly/sdk@file:../../../../../../node-sdk':
+    resolution: {directory: ../../../../../../node-sdk, type: directory}
+    engines: {node: '>=18.18.0', pnpm: '>=10'}
+    peerDependencies:
+      '@langchain/core': '>=0.3.0'
+      '@openai/agents': '>=0.1.0'
+    peerDependenciesMeta:
+      '@langchain/core':
+        optional: true
+      '@openai/agents':
+        optional: true
+
+  '@cfworker/json-schema@4.1.1':
+    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
+
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@langchain/core@0.3.80':
+    resolution: {integrity: sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==}
+    engines: {node: '>=18'}
+
+  '@langchain/langgraph-checkpoint@0.0.18':
+    resolution: {integrity: sha512-IS7zJj36VgY+4pf8ZjsVuUWef7oTwt1y9ylvwu0aLuOn1d0fg05Om9DLm3v2GZ2Df6bhLV1kfWAM0IAl9O5rQQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.2.31 <0.4.0'
+
+  '@langchain/langgraph-sdk@0.0.112':
+    resolution: {integrity: sha512-/9W5HSWCqYgwma6EoOspL4BGYxGxeJP6lIquPSF4FA0JlKopaUv58ucZC3vAgdJyCgg6sorCIV/qg7SGpEcCLw==}
+    peerDependencies:
+      '@langchain/core': '>=0.2.31 <0.4.0'
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+    peerDependenciesMeta:
+      '@langchain/core':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@langchain/langgraph@0.2.74':
+    resolution: {integrity: sha512-oHpEi5sTZTPaeZX1UnzfM2OAJ21QGQrwReTV6+QnX7h8nDCBzhtipAw1cK616S+X8zpcVOjgOtJuaJhXa4mN8w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.2.36 <0.3.0 || >=0.3.40 < 0.4.0'
+      zod-to-json-schema: ^3.x
+    peerDependenciesMeta:
+      zod-to-json-schema:
+        optional: true
+
+  '@langchain/openai@0.6.17':
+    resolution: {integrity: sha512-JVSzD+FL5v/2UQxKd+ikB1h4PQOtn0VlK8nqW2kPp0fshItCv4utrjBKXC/rubBnSXoRTyonBINe8QRZ6OojVQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.3.68 <0.4.0'
+
+  '@langchain/textsplitters@0.1.0':
+    resolution: {integrity: sha512-djI4uw9rlkAb5iMhtLED+xJebDdAG935AdP4eRTB02R7OB/act55Bj9wsskhZsvuyQRpO4O1wQOp85s6T6GWmw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/core': '>=0.2.21 <0.4.0'
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@24.12.4':
+    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
+
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  console-table-printer@2.15.0:
+    resolution: {integrity: sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==}
+
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  js-tiktoken@1.0.21:
+    resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  jsonpointer@5.0.1:
+    resolution: {integrity: sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==}
+    engines: {node: '>=0.10.0'}
+
+  langchain@0.3.37:
+    resolution: {integrity: sha512-1jPsZ6xsxkcQPUvqRjvfuOLwZLLyt49hzcOK7OYAJovIkkOxd5gzK4Yw6giPUQ8g4XHyvULNlWBz+subdkcokw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@langchain/anthropic': '*'
+      '@langchain/aws': '*'
+      '@langchain/cerebras': '*'
+      '@langchain/cohere': '*'
+      '@langchain/core': '>=0.3.58 <0.4.0'
+      '@langchain/deepseek': '*'
+      '@langchain/google-genai': '*'
+      '@langchain/google-vertexai': '*'
+      '@langchain/google-vertexai-web': '*'
+      '@langchain/groq': '*'
+      '@langchain/mistralai': '*'
+      '@langchain/ollama': '*'
+      '@langchain/xai': '*'
+      axios: '*'
+      cheerio: '*'
+      handlebars: ^4.7.8
+      peggy: ^3.0.2
+      typeorm: '*'
+    peerDependenciesMeta:
+      '@langchain/anthropic':
+        optional: true
+      '@langchain/aws':
+        optional: true
+      '@langchain/cerebras':
+        optional: true
+      '@langchain/cohere':
+        optional: true
+      '@langchain/deepseek':
+        optional: true
+      '@langchain/google-genai':
+        optional: true
+      '@langchain/google-vertexai':
+        optional: true
+      '@langchain/google-vertexai-web':
+        optional: true
+      '@langchain/groq':
+        optional: true
+      '@langchain/mistralai':
+        optional: true
+      '@langchain/ollama':
+        optional: true
+      '@langchain/xai':
+        optional: true
+      axios:
+        optional: true
+      cheerio:
+        optional: true
+      handlebars:
+        optional: true
+      peggy:
+        optional: true
+      typeorm:
+        optional: true
+
+  langsmith@0.3.87:
+    resolution: {integrity: sha512-XXR1+9INH8YX96FKWc5tie0QixWz6tOqAsAKfcJyPkE0xPep+NDz0IQLR32q4bn10QK3LqD2HN6T3n6z1YLW7Q==}
+    peerDependencies:
+      '@opentelemetry/api': '*'
+      '@opentelemetry/exporter-trace-otlp-proto': '*'
+      '@opentelemetry/sdk-trace-base': '*'
+      openai: '*'
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-proto':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      openai:
+        optional: true
+
+  mustache@4.2.0:
+    resolution: {integrity: sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==}
+    hasBin: true
+
+  openai@5.12.2:
+    resolution: {integrity: sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.23.8
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
+
+  p-finally@1.0.0:
+    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
+    engines: {node: '>=4'}
+
+  p-queue@6.6.2:
+    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
+    engines: {node: '>=8'}
+
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
+  p-timeout@3.2.0:
+    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
+    engines: {node: '>=8'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  simple-wcswidth@1.1.2:
+    resolution: {integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  tsx@4.22.1:
+    resolution: {integrity: sha512-TvncJykhxAzFCk0VQZKBTClall4Pm7qXDSodb6uxi8QFa8X8mT6ABjxxsQ2opDRYxG7AzcRWXaFtruz5HJKuWg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+    hasBin: true
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@agent-assembly/sdk@file:../../../../../../node-sdk(@langchain/core@0.3.80(openai@5.12.2(zod@3.25.76)))':
+    optionalDependencies:
+      '@langchain/core': 0.3.80(openai@5.12.2(zod@3.25.76))
+
+  '@cfworker/json-schema@4.1.1': {}
+
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
+    optional: true
+
+  '@langchain/core@0.3.80(openai@5.12.2(zod@3.25.76))':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      ansi-styles: 5.2.0
+      camelcase: 6.3.0
+      decamelize: 1.2.0
+      js-tiktoken: 1.0.21
+      langsmith: 0.3.87(openai@5.12.2(zod@3.25.76))
+      mustache: 4.2.0
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 10.0.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+
+  '@langchain/langgraph-checkpoint@0.0.18(@langchain/core@0.3.80(openai@5.12.2(zod@3.25.76)))':
+    dependencies:
+      '@langchain/core': 0.3.80(openai@5.12.2(zod@3.25.76))
+      uuid: 10.0.0
+
+  '@langchain/langgraph-sdk@0.0.112(@langchain/core@0.3.80(openai@5.12.2(zod@3.25.76)))':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      p-queue: 6.6.2
+      p-retry: 4.6.2
+      uuid: 9.0.1
+    optionalDependencies:
+      '@langchain/core': 0.3.80(openai@5.12.2(zod@3.25.76))
+
+  '@langchain/langgraph@0.2.74(@langchain/core@0.3.80(openai@5.12.2(zod@3.25.76)))(zod-to-json-schema@3.25.2(zod@3.25.76))':
+    dependencies:
+      '@langchain/core': 0.3.80(openai@5.12.2(zod@3.25.76))
+      '@langchain/langgraph-checkpoint': 0.0.18(@langchain/core@0.3.80(openai@5.12.2(zod@3.25.76)))
+      '@langchain/langgraph-sdk': 0.0.112(@langchain/core@0.3.80(openai@5.12.2(zod@3.25.76)))
+      uuid: 10.0.0
+      zod: 3.25.76
+    optionalDependencies:
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@langchain/openai@0.6.17(@langchain/core@0.3.80(openai@5.12.2(zod@3.25.76)))':
+    dependencies:
+      '@langchain/core': 0.3.80(openai@5.12.2(zod@3.25.76))
+      js-tiktoken: 1.0.21
+      openai: 5.12.2(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - ws
+
+  '@langchain/textsplitters@0.1.0(@langchain/core@0.3.80(openai@5.12.2(zod@3.25.76)))':
+    dependencies:
+      '@langchain/core': 0.3.80(openai@5.12.2(zod@3.25.76))
+      js-tiktoken: 1.0.21
+
+  '@types/json-schema@7.0.15': {}
+
+  '@types/node@24.12.4':
+    dependencies:
+      undici-types: 7.16.0
+
+  '@types/retry@0.12.0': {}
+
+  '@types/uuid@10.0.0': {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
+
+  argparse@2.0.1: {}
+
+  base64-js@1.5.1: {}
+
+  camelcase@6.3.0: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  console-table-printer@2.15.0:
+    dependencies:
+      simple-wcswidth: 1.1.2
+
+  decamelize@1.2.0: {}
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
+  eventemitter3@4.0.7: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  has-flag@4.0.0: {}
+
+  js-tiktoken@1.0.21:
+    dependencies:
+      base64-js: 1.5.1
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  jsonpointer@5.0.1: {}
+
+  langchain@0.3.37(@langchain/core@0.3.80(openai@5.12.2(zod@3.25.76)))(openai@5.12.2(zod@3.25.76)):
+    dependencies:
+      '@langchain/core': 0.3.80(openai@5.12.2(zod@3.25.76))
+      '@langchain/openai': 0.6.17(@langchain/core@0.3.80(openai@5.12.2(zod@3.25.76)))
+      '@langchain/textsplitters': 0.1.0(@langchain/core@0.3.80(openai@5.12.2(zod@3.25.76)))
+      js-tiktoken: 1.0.21
+      js-yaml: 4.1.1
+      jsonpointer: 5.0.1
+      langsmith: 0.3.87(openai@5.12.2(zod@3.25.76))
+      openapi-types: 12.1.3
+      p-retry: 4.6.2
+      uuid: 10.0.0
+      yaml: 2.9.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - openai
+      - ws
+
+  langsmith@0.3.87(openai@5.12.2(zod@3.25.76)):
+    dependencies:
+      '@types/uuid': 10.0.0
+      chalk: 4.1.2
+      console-table-printer: 2.15.0
+      p-queue: 6.6.2
+      semver: 7.8.0
+      uuid: 10.0.0
+    optionalDependencies:
+      openai: 5.12.2(zod@3.25.76)
+
+  mustache@4.2.0: {}
+
+  openai@5.12.2(zod@3.25.76):
+    optionalDependencies:
+      zod: 3.25.76
+
+  openapi-types@12.1.3: {}
+
+  p-finally@1.0.0: {}
+
+  p-queue@6.6.2:
+    dependencies:
+      eventemitter3: 4.0.7
+      p-timeout: 3.2.0
+
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
+  p-timeout@3.2.0:
+    dependencies:
+      p-finally: 1.0.0
+
+  retry@0.13.1: {}
+
+  semver@7.8.0: {}
+
+  simple-wcswidth@1.1.2: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  tsx@4.22.1:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.9.3: {}
+
+  undici-types@7.16.0: {}
+
+  uuid@10.0.0: {}
+
+  uuid@9.0.1: {}
+
+  yaml@2.9.0: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod@3.25.76: {}

--- a/aa-integration-tests/tests/fixtures/agents/typescript/root_sub_agents/langgraph_hierarchy.ts
+++ b/aa-integration-tests/tests/fixtures/agents/typescript/root_sub_agents/langgraph_hierarchy.ts
@@ -11,7 +11,6 @@
 //   AA_SELFTEST=1 AA_GATEWAY_ADDR=dummy pnpm exec tsx root_sub_agents/langgraph_hierarchy.ts
 
 import { loadConfig, emit, type AgentConfig } from "../_shared.js";
-import { initAssembly } from "@agent-assembly/sdk";
 import { StateGraph, Annotation } from "@langchain/langgraph";
 
 const StateAnnotation = Annotation.Root({
@@ -23,6 +22,7 @@ const StateAnnotation = Annotation.Root({
 });
 
 async function runReal(cfg: AgentConfig): Promise<void> {
+  const { initAssembly } = await import("@agent-assembly/sdk");
   const rootCtx = await initAssembly({
     gatewayUrl: `http://${cfg.gatewayAddr}`,
     apiKey: "e2e-test-key",

--- a/aa-integration-tests/tests/fixtures/agents/typescript/root_sub_agents/langgraph_hierarchy.ts
+++ b/aa-integration-tests/tests/fixtures/agents/typescript/root_sub_agents/langgraph_hierarchy.ts
@@ -1,0 +1,86 @@
+// F116 ST-B — root + sub-agents LangGraph hierarchy fixture (AAASM-1514).
+//
+// Registers a root agent that spawns two sub-agents through a multi-level
+// LangGraph DAG. Exercises the parent→child lineage chain. In selftest mode
+// emits synthetic events for hermetic CI runs.
+//
+// Invocation:
+//   AA_GATEWAY_ADDR=127.0.0.1:PORT AA_AGENT_ID=e2e-root \
+//     pnpm exec tsx root_sub_agents/langgraph_hierarchy.ts
+//
+//   AA_SELFTEST=1 AA_GATEWAY_ADDR=dummy pnpm exec tsx root_sub_agents/langgraph_hierarchy.ts
+
+import { loadConfig, emit, type AgentConfig } from "../_shared.js";
+import { initAssembly } from "@agent-assembly/sdk";
+import { StateGraph, Annotation } from "@langchain/langgraph";
+
+const StateAnnotation = Annotation.Root({
+  task: Annotation<string>(),
+  sub_results: Annotation<string[]>({
+    reducer: (a, b) => [...a, ...b],
+    default: () => [],
+  }),
+});
+
+async function runReal(cfg: AgentConfig): Promise<void> {
+  const rootCtx = await initAssembly({
+    gatewayUrl: `http://${cfg.gatewayAddr}`,
+    apiKey: "e2e-test-key",
+    agentId: cfg.agentId,
+    teamId: "f116-e2e",
+    mode: "sdk-only",
+  });
+
+  emit({ event: "started", agent_id: cfg.agentId, role: "root" });
+
+  const graph = new StateGraph(StateAnnotation)
+    .addNode("planner", async (state) => {
+      const plannerCtx = await initAssembly({
+        gatewayUrl: `http://${cfg.gatewayAddr}`,
+        apiKey: "e2e-test-key",
+        agentId: `${cfg.agentId}-planner`,
+        teamId: "f116-e2e",
+        parentAgentId: cfg.agentId,
+        mode: "sdk-only",
+      });
+      emit({ event: "started", agent_id: `${cfg.agentId}-planner`, role: "planner" });
+      await plannerCtx.shutdown();
+      return { sub_results: [`planned: ${state.task}`] };
+    })
+    .addNode("executor", async (state) => {
+      const executorCtx = await initAssembly({
+        gatewayUrl: `http://${cfg.gatewayAddr}`,
+        apiKey: "e2e-test-key",
+        agentId: `${cfg.agentId}-executor`,
+        teamId: "f116-e2e",
+        parentAgentId: cfg.agentId,
+        mode: "sdk-only",
+      });
+      emit({ event: "started", agent_id: `${cfg.agentId}-executor`, role: "executor" });
+      await executorCtx.shutdown();
+      return { sub_results: [`executed: ${state.task}`] };
+    })
+    .addEdge("__start__", "planner")
+    .addEdge("planner", "executor")
+    .addEdge("executor", "__end__")
+    .compile();
+
+  const output = await graph.invoke({ task: cfg.task });
+  emit({ event: "tool_call", tool: "hierarchy_graph", input: cfg.task });
+
+  await rootCtx.shutdown();
+  emit({ event: "done", result: output.sub_results.join(" → ") });
+}
+
+const cfg = loadConfig();
+
+if (process.env.AA_SELFTEST === "1") {
+  emit({ event: "started", agent_id: cfg.agentId, role: "root" });
+  emit({ event: "started", agent_id: `${cfg.agentId}-planner`, role: "planner" });
+  emit({ event: "started", agent_id: `${cfg.agentId}-executor`, role: "executor" });
+  emit({ event: "tool_call", tool: "hierarchy_graph", input: cfg.task });
+  emit({ event: "done", result: "selftest-ok" });
+  process.exit(0);
+}
+
+await runReal(cfg);

--- a/aa-integration-tests/tests/fixtures/agents/typescript/single_agent/langchain_agent.ts
+++ b/aa-integration-tests/tests/fixtures/agents/typescript/single_agent/langchain_agent.ts
@@ -12,9 +12,9 @@
 //   AA_SELFTEST=1 AA_GATEWAY_ADDR=dummy pnpm exec tsx single_agent/langchain_agent.ts
 
 import { loadConfig, emit, type AgentConfig } from "../_shared.js";
-import { initAssembly } from "@agent-assembly/sdk";
 
 async function runReal(cfg: AgentConfig): Promise<void> {
+  const { initAssembly } = await import("@agent-assembly/sdk");
   const ctx = await initAssembly({
     gatewayUrl: `http://${cfg.gatewayAddr}`,
     apiKey: "e2e-test-key",

--- a/aa-integration-tests/tests/fixtures/agents/typescript/single_agent/langchain_agent.ts
+++ b/aa-integration-tests/tests/fixtures/agents/typescript/single_agent/langchain_agent.ts
@@ -13,8 +13,6 @@
 
 import { loadConfig, emit, type AgentConfig } from "../_shared.js";
 import { initAssembly } from "@agent-assembly/sdk";
-import { tool } from "@langchain/core/tools";
-import { z } from "zod";
 
 async function runReal(cfg: AgentConfig): Promise<void> {
   const ctx = await initAssembly({
@@ -27,16 +25,8 @@ async function runReal(cfg: AgentConfig): Promise<void> {
 
   emit({ event: "started", agent_id: cfg.agentId });
 
-  const echoTool = tool(
-    async ({ input }: { input: string }) => `echo: ${input}`,
-    {
-      name: "echo",
-      description: "Echoes the input string",
-      schema: z.object({ input: z.string() }),
-    }
-  );
-
-  const result = await echoTool.invoke({ input: cfg.task });
+  // Simulate a LangChain tool call (echo pattern).
+  const result = `echo: ${cfg.task}`;
   emit({ event: "tool_call", tool: "echo", input: cfg.task });
 
   await ctx.shutdown();

--- a/aa-integration-tests/tests/fixtures/agents/typescript/single_agent/langchain_agent.ts
+++ b/aa-integration-tests/tests/fixtures/agents/typescript/single_agent/langchain_agent.ts
@@ -1,0 +1,55 @@
+// F116 ST-B — single-agent LangChain fixture (AAASM-1514).
+//
+// Registers one agent via @agent-assembly/sdk, invokes a LangChain tool, then
+// shuts down. In selftest mode (AA_SELFTEST=1) skips SDK/gateway entirely and
+// emits synthetic events so the Rust harness can exercise the fixture toolchain
+// hermetically (no native bindings, no running gateway required).
+//
+// Invocation:
+//   AA_GATEWAY_ADDR=127.0.0.1:PORT AA_AGENT_ID=e2e-lc \
+//     pnpm exec tsx single_agent/langchain_agent.ts
+//
+//   AA_SELFTEST=1 AA_GATEWAY_ADDR=dummy pnpm exec tsx single_agent/langchain_agent.ts
+
+import { loadConfig, emit, type AgentConfig } from "../_shared.js";
+import { initAssembly } from "@agent-assembly/sdk";
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+async function runReal(cfg: AgentConfig): Promise<void> {
+  const ctx = await initAssembly({
+    gatewayUrl: `http://${cfg.gatewayAddr}`,
+    apiKey: "e2e-test-key",
+    agentId: cfg.agentId,
+    teamId: "f116-e2e",
+    mode: "sdk-only",
+  });
+
+  emit({ event: "started", agent_id: cfg.agentId });
+
+  const echoTool = tool(
+    async ({ input }: { input: string }) => `echo: ${input}`,
+    {
+      name: "echo",
+      description: "Echoes the input string",
+      schema: z.object({ input: z.string() }),
+    }
+  );
+
+  const result = await echoTool.invoke({ input: cfg.task });
+  emit({ event: "tool_call", tool: "echo", input: cfg.task });
+
+  await ctx.shutdown();
+  emit({ event: "done", result });
+}
+
+const cfg = loadConfig();
+
+if (process.env.AA_SELFTEST === "1") {
+  emit({ event: "started", agent_id: cfg.agentId });
+  emit({ event: "tool_call", tool: "echo", input: cfg.task });
+  emit({ event: "done", result: "selftest-ok" });
+  process.exit(0);
+}
+
+await runReal(cfg);

--- a/aa-integration-tests/tests/fixtures/agents/typescript/single_agent/langchain_agent.ts
+++ b/aa-integration-tests/tests/fixtures/agents/typescript/single_agent/langchain_agent.ts
@@ -1,8 +1,8 @@
 // F116 ST-B — single-agent LangChain fixture (AAASM-1514).
 //
-// Registers one agent via @agent-assembly/sdk, invokes a LangChain tool, then
-// shuts down. In selftest mode (AA_SELFTEST=1) skips SDK/gateway entirely and
-// emits synthetic events so the Rust harness can exercise the fixture toolchain
+// Registers one agent via @agent-assembly/sdk, invokes a LangChain DynamicTool
+// (echo pattern), then shuts down. In selftest mode (AA_SELFTEST=1) skips SDK
+// and tool execution, emitting synthetic events so the Rust harness can run
 // hermetically (no native bindings, no running gateway required).
 //
 // Invocation:
@@ -12,6 +12,13 @@
 //   AA_SELFTEST=1 AA_GATEWAY_ADDR=dummy pnpm exec tsx single_agent/langchain_agent.ts
 
 import { loadConfig, emit, type AgentConfig } from "../_shared.js";
+import { DynamicTool } from "@langchain/core/tools";
+
+const echoTool = new DynamicTool({
+  name: "echo",
+  description: "Echoes the input back.",
+  func: async (input: string) => `echo: ${input}`,
+});
 
 async function runReal(cfg: AgentConfig): Promise<void> {
   const { initAssembly } = await import("@agent-assembly/sdk");
@@ -25,8 +32,8 @@ async function runReal(cfg: AgentConfig): Promise<void> {
 
   emit({ event: "started", agent_id: cfg.agentId });
 
-  // Simulate a LangChain tool call (echo pattern).
-  const result = `echo: ${cfg.task}`;
+  // Invoke the LangChain tool.
+  const result = await echoTool.invoke(cfg.task);
   emit({ event: "tool_call", tool: "echo", input: cfg.task });
 
   await ctx.shutdown();

--- a/aa-integration-tests/tests/fixtures/agents/typescript/single_agent/langgraph_agent.ts
+++ b/aa-integration-tests/tests/fixtures/agents/typescript/single_agent/langgraph_agent.ts
@@ -1,0 +1,56 @@
+// F116 ST-B — single-agent LangGraph fixture (AAASM-1514).
+//
+// Registers one agent, builds a minimal two-node LangGraph (start → echo_node
+// → END), invokes it, then shuts down. In selftest mode emits synthetic events.
+//
+// Invocation:
+//   AA_GATEWAY_ADDR=127.0.0.1:PORT AA_AGENT_ID=e2e-lg \
+//     pnpm exec tsx single_agent/langgraph_agent.ts
+//
+//   AA_SELFTEST=1 AA_GATEWAY_ADDR=dummy pnpm exec tsx single_agent/langgraph_agent.ts
+
+import { loadConfig, emit, type AgentConfig } from "../_shared.js";
+import { initAssembly } from "@agent-assembly/sdk";
+import { StateGraph, Annotation } from "@langchain/langgraph";
+
+const StateAnnotation = Annotation.Root({
+  task: Annotation<string>(),
+  result: Annotation<string>(),
+});
+
+async function runReal(cfg: AgentConfig): Promise<void> {
+  const ctx = await initAssembly({
+    gatewayUrl: `http://${cfg.gatewayAddr}`,
+    apiKey: "e2e-test-key",
+    agentId: cfg.agentId,
+    teamId: "f116-e2e",
+    mode: "sdk-only",
+  });
+
+  emit({ event: "started", agent_id: cfg.agentId });
+
+  const graph = new StateGraph(StateAnnotation)
+    .addNode("echo_node", async (state) => ({
+      result: `echo: ${state.task}`,
+    }))
+    .addEdge("__start__", "echo_node")
+    .addEdge("echo_node", "__end__")
+    .compile();
+
+  const output = await graph.invoke({ task: cfg.task, result: "" });
+  emit({ event: "tool_call", tool: "echo_node", input: cfg.task });
+
+  await ctx.shutdown();
+  emit({ event: "done", result: output.result });
+}
+
+const cfg = loadConfig();
+
+if (process.env.AA_SELFTEST === "1") {
+  emit({ event: "started", agent_id: cfg.agentId });
+  emit({ event: "tool_call", tool: "echo_node", input: cfg.task });
+  emit({ event: "done", result: "selftest-ok" });
+  process.exit(0);
+}
+
+await runReal(cfg);

--- a/aa-integration-tests/tests/fixtures/agents/typescript/single_agent/langgraph_agent.ts
+++ b/aa-integration-tests/tests/fixtures/agents/typescript/single_agent/langgraph_agent.ts
@@ -10,7 +10,6 @@
 //   AA_SELFTEST=1 AA_GATEWAY_ADDR=dummy pnpm exec tsx single_agent/langgraph_agent.ts
 
 import { loadConfig, emit, type AgentConfig } from "../_shared.js";
-import { initAssembly } from "@agent-assembly/sdk";
 import { StateGraph, Annotation } from "@langchain/langgraph";
 
 const StateAnnotation = Annotation.Root({
@@ -19,6 +18,7 @@ const StateAnnotation = Annotation.Root({
 });
 
 async function runReal(cfg: AgentConfig): Promise<void> {
+  const { initAssembly } = await import("@agent-assembly/sdk");
   const ctx = await initAssembly({
     gatewayUrl: `http://${cfg.gatewayAddr}`,
     apiKey: "e2e-test-key",

--- a/aa-integration-tests/tests/fixtures/agents/typescript/tsconfig.json
+++ b/aa-integration-tests/tests/fixtures/agents/typescript/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Description

Implements **AAASM-1514 / F116 ST-B**: E2E Node.js SDK `initAssembly()` registration + event emission flow.

Delivers all five deliverables from the ticket AC:

1. **`aa-integration-tests/tests/e2e_sdk_node.rs`** — 5 hermetic selftest tests (pass in CI with no gateway) + 5 `#[ignore]` real-gateway tests marked for follow-up (AAASM-1514 follow-up).
2. **TypeScript fixture project** (`tests/fixtures/agents/typescript/`) — `_shared.ts` helper, `package.json` (ESM, pnpm), `tsconfig.json`, `pnpm-lock.yaml`, and 5 agent fixture scripts covering single-agent (LangChain + LangGraph), agent team, and root/sub-agent hierarchy patterns.
3. **`tests/fixtures/agents/run_agents_ts.sh`** — developer runner; supports `--selftest` flag or auto-enables selftest mode when `AA_GATEWAY_ADDR` is absent.
4. **`integration-tests.yml`** — adds node-sdk sibling checkout, pnpm v10 + Node.js 24 setup, symlink for `file:` path resolution, and TypeScript fixture install.
5. **`ci.yml`** — adds node-sdk sibling checkout, symlink, and TypeScript fixture `pnpm install` to both `test` and `coverage` jobs so `e2e_sdk_node` selftest tests run in the main CI matrix.

Each fixture script supports `AA_SELFTEST=1 AA_GATEWAY_ADDR=dummy` for hermetic CI runs that emit synthetic JSON-line events without connecting to any service.

### Node SDK shutdown contract

Fixture scripts use `initAssembly({ ..., mode: "sdk-only" })`, which returns a context object. Clean shutdown is `await ctx.shutdown()` called explicitly before `process.exit()`. In selftest mode the gateway URL is ignored and `mode: "sdk-only"` skips native binding initialisation — no napi-rs artifacts are required for hermetic CI.

For real-gateway tests (marked `#[ignore]`):
- `initAssembly()` → registers agent via gRPC
- `ctx.shutdown()` → sends deregistration event; awaiting it ensures the audit log entry lands before exit
- The `beforeExit` hook is **not** relied upon — explicit shutdown is preferred so tests can assert synchronously on deregistration

If the process exits without calling `shutdown()`, the gateway detects the stale registration via heartbeat timeout (tracked as follow-up work under AAASM-1514).

## Type of Change

- [x] New feature
- [x] Integration tests added / updated
- [x] Configuration / CI change

## Breaking Changes

No

## Related Issues

- Related Jira ticket: AAASM-1514
- Parent story: AAASM-1232 (F116 MVP acceptance)
- Epic: AAASM-1199

## Testing

- [x] 5 hermetic selftest Rust tests pass locally: `cargo nextest run -p aa-integration-tests --test e2e_sdk_node` → 5 passed, 5 skipped
- [x] All 5 TypeScript fixture scripts pass `./run_agents_ts.sh --selftest`: 5/5 pass
- [x] `pnpm typecheck` clean (zero errors)
- [x] `cargo fmt` + `cargo clippy` clean (enforced by lefthook pre-commit)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention