### PR TITLE
[AAASM-1300] ✅ (ci): Add dashboard HTTP smoke test to release.yml publish job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,26 @@ jobs:
           path: artifacts/
           merge-multiple: true
 
+      - name: Smoke-test dashboard (Linux x86_64)
+        run: |
+          mkdir -p smoke-bin
+          tar -xzf artifacts/aasm-x86_64-unknown-linux-gnu.tar.gz -C smoke-bin
+          chmod +x smoke-bin/aasm
+          smoke-bin/aasm dashboard start &
+          AASM_PID=$!
+          echo "Started aasm dashboard (PID $AASM_PID), waiting for server bind..."
+          for i in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:3000/ -o /dev/null; then
+              echo "Dashboard smoke test passed (responded after ${i}s)"
+              kill "$AASM_PID" 2>/dev/null || true
+              exit 0
+            fi
+            sleep 1
+          done
+          kill "$AASM_PID" 2>/dev/null || true
+          echo "Dashboard smoke test FAILED: server did not respond within 30s"
+          exit 1
+
       - name: Generate SHA256SUMS
         run: |
           cd artifacts


### PR DESCRIPTION
## Description

Adds a **smoke-test step** to the `publish` job in `.github/workflows/release.yml` that verifies the embedded dashboard assets are functional before any release artifacts are uploaded to GitHub.

The step:
1. Extracts the `x86_64-unknown-linux-gnu` binary from the downloaded build artifact
2. Starts `aasm dashboard start` in the background
3. Polls `http://127.0.0.1:3000/` with `curl` for up to 30 s
4. Exits 0 (allowing publish to proceed) on the first HTTP 200 response
5. Exits 1 (blocking the entire publish job) if the server never responds

This gates both the SHA256SUMS generation and the GitHub Release upload — a binary with a broken or missing dashboard will never be published.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-1300
- Parent story: AAASM-1293 (Dashboard CI/CD pipeline)

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [x] No tests required (explain why)

This is a CI workflow change. The smoke test itself is the verification mechanism — it will execute on the next release tag push and fail the publish job if the dashboard binary is broken.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention