### PR TITLE
[AAASM-1521] ✅ (aa-integration-tests): Add F116 ST-I E2E secret-detection tests

### DIFF
--- a/aa-integration-tests/tests/common/fixtures/README.md
+++ b/aa-integration-tests/tests/common/fixtures/README.md
@@ -11,8 +11,10 @@ Static fixture files consumed by the CLI integration tests under
 | File | Used by | Purpose |
 | --- | --- | --- |
 | `allow_all.yaml` | `cli_policy.rs` ST-3 happy-path tests | Minimal valid policy with empty rule set |
+| `allow_deny_mixed.yaml` | `e2e_policy_sdk.rs` F116 ST-D | `websearch` denied, `read_file` allowed |
 | `deny_websearch.yaml` | `cli_policy.rs` ST-3 deny-path tests | Single deny rule for the `WebSearch` tool |
 | `invalid.yaml` | `cli_policy.rs` ST-3 `policy validate` negative-path | Malformed YAML — missing required keys + wrong types |
+| `secret_detection_patterns.yaml` | `e2e_secret_interception.rs` F116 ST-I | Allows `test_tool`; adds a custom `MYCO-SECRET-*` regex to `data.sensitive_patterns` for the credential scanner |
 
 ## `audit/`
 

--- a/aa-integration-tests/tests/common/fixtures/policies/secret_detection_patterns.yaml
+++ b/aa-integration-tests/tests/common/fixtures/policies/secret_detection_patterns.yaml
@@ -1,0 +1,12 @@
+apiVersion: agent-assembly.dev/v1alpha1
+kind: GovernancePolicy
+metadata:
+  name: it-secret-detection-patterns
+  version: "0.1.0"
+spec:
+  tools:
+    test_tool:
+      allow: true
+  data:
+    sensitive_patterns:
+      - "MYCO-SECRET-[A-Za-z0-9]+"

--- a/aa-integration-tests/tests/e2e_secret_interception.rs
+++ b/aa-integration-tests/tests/e2e_secret_interception.rs
@@ -248,3 +248,68 @@ fn short_high_entropy_string_does_not_trigger_scanner() {
 
     assert_clean(&result);
 }
+
+// ── Test 6 — Critical security assertion: raw secrets never in redacted output
+
+#[test]
+fn redacted_payload_never_contains_any_raw_secret() {
+    // Combine four independent secrets in one payload so a single evaluation
+    // exercises the multi-finding redaction path. The flagship security
+    // invariant for this ST: even one byte of an original secret leaking
+    // through is a hard failure.
+    //
+    // The scanner runs four passes (AC literal, digit sequences, emails,
+    // high-entropy). Overlapping findings between passes can produce
+    // garbled [REDACTED:Kind] labels in the output — see the engine's
+    // `ScanResult::redact()` for reverse-offset replacement semantics.
+    // That is acceptable: the redaction primitive's only contract is that
+    // raw secret bytes are removed. Asserting on specific label shapes
+    // under overlap would be brittle, so this test asserts only the
+    // security invariant.
+    let payload = format!(
+        r#"{{
+            "aws": "{FAKE_AWS_ACCESS_KEY}",
+            "openai": "{FAKE_OPENAI_KEY}",
+            "github": "{FAKE_GITHUB_PAT}",
+            "custom": "{FAKE_CUSTOM_TOKEN}"
+        }}"#
+    );
+    let action = tool_call_with_args(&payload);
+    let result = evaluate(&action, 0xA6);
+
+    assert_eq!(
+        result.decision,
+        PolicyResult::Allow,
+        "scanner-only detection must not deny",
+    );
+    assert!(
+        result.credential_findings.len() >= 4,
+        "expected at least one finding per embedded secret (>=4); got {:?}",
+        result.credential_findings,
+    );
+
+    let redacted = result
+        .redacted_payload
+        .expect("multi-secret payload must produce a redacted output");
+
+    // Primary security invariant: NO raw secret string appears in the redacted output.
+    for (label, raw) in [
+        ("AWS access key", FAKE_AWS_ACCESS_KEY),
+        ("OpenAI key", FAKE_OPENAI_KEY),
+        ("GitHub PAT", FAKE_GITHUB_PAT),
+        ("custom token", FAKE_CUSTOM_TOKEN),
+    ] {
+        assert!(
+            !redacted.contains(raw),
+            "SECURITY INVARIANT VIOLATED: {label} appears in redacted payload — value would leak to downstream audit / alert / upstream",
+        );
+    }
+
+    // Sanity check: at least one redaction marker was emitted somewhere in the
+    // output. The specific kind / count is not asserted because overlapping
+    // findings can collapse adjacent markers under the current redact() logic.
+    assert!(
+        redacted.contains("[REDACTED:"),
+        "redacted payload must contain at least one [REDACTED:Kind] marker, got: {redacted}",
+    );
+}

--- a/aa-integration-tests/tests/e2e_secret_interception.rs
+++ b/aa-integration-tests/tests/e2e_secret_interception.rs
@@ -1,0 +1,172 @@
+//! F116 ST-I — E2E secret-value interception (detection slice).
+//!
+//! Exercises the live credential scanner inside `aa_gateway::PolicyEngine` by
+//! evaluating governance actions whose `args` payload embeds a synthetic API
+//! key, GitHub PAT, OpenAI key, or a custom policy-defined pattern. Asserts:
+//!
+//! 1. The decision stays `Allow` (the scanner redacts in-memory, it does not
+//!    deny on its own — see `aa-gateway/src/engine/mod.rs:471` Stage 6).
+//! 2. `credential_findings` is non-empty and carries the expected
+//!    `CredentialKind`.
+//! 3. `redacted_payload` is `Some(_)` and contains the `[REDACTED:<kind>]`
+//!    label.
+//! 4. The full original secret never appears in `redacted_payload`.
+//!
+//! ## Scope
+//!
+//! This file ships the **detection-only** slice of the original 8-test ST.
+//! The remaining tests in the ST require runtime features that are not yet
+//! implemented (audit-log emission of credential findings, alert emission
+//! with severity=critical, policy action modes `block` / `redact_only`,
+//! mock LLM upstream). See AAASM-1544 / 1545 / 1546 / 1547 for the follow-up
+//! work; the corresponding tests will be added in a second PR once those
+//! runtime features land.
+//!
+//! ## Synthetic secrets only
+//!
+//! Every secret value below is synthetic — from AWS public-docs examples
+//! (`AKIAIOSFODNN7EXAMPLE`), from prefixes documented as test-only
+//! (`sk-test-`), or manually-fabricated padding (`ghp_0000…`). No real
+//! secrets are stored in this fixture.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use aa_core::identity::{AgentId, SessionId};
+use aa_core::time::Timestamp;
+use aa_core::{AgentContext, CredentialKind, GovernanceAction, GovernanceLevel, PolicyResult};
+use aa_gateway::{EvaluationResult, PolicyEngine};
+
+// ── Synthetic secret fixtures ────────────────────────────────────────────────
+
+/// AWS access key ID from AWS public documentation. Synthetic.
+const FAKE_AWS_ACCESS_KEY: &str = "AKIAIOSFODNN7EXAMPLE";
+
+/// GitHub personal access token prefix + zero-padding. Synthetic.
+#[allow(dead_code)] // wired in by the GitHub PAT detection test commit
+const FAKE_GITHUB_PAT: &str = "ghp_0000000000000000000000000000000000";
+
+/// OpenAI key with the documented `sk-test-` test prefix. Synthetic.
+#[allow(dead_code)] // wired in by the OpenAI key detection test commit
+const FAKE_OPENAI_KEY: &str = "sk-test-AbCdEf1234567890ABCDEF1234567890ABCDEF1234567890";
+
+/// Custom-pattern token shaped to match `MYCO-SECRET-[A-Za-z0-9]+`.
+#[allow(dead_code)] // wired in by the custom-regex detection test commit
+const FAKE_CUSTOM_TOKEN: &str = "MYCO-SECRET-DEADBEEFCAFE0001";
+
+/// Below the `GenericHighEntropy` length floor (20 chars) — must not trip the
+/// scanner. 12 alphanumeric characters with no built-in prefix match.
+#[allow(dead_code)] // wired in by the no-false-positive test commit
+const SHORT_HIGH_ENTROPY: &str = "abc123def456";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Resolve a fixture path relative to this crate's manifest root.
+fn fixture_path(rel: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/common/fixtures")
+        .join(rel)
+}
+
+/// Build a minimal `AgentContext` for tests. The 16-byte agent ID seed is
+/// passed in so each test can produce a distinct, deterministic identity.
+fn make_ctx(agent_bytes: [u8; 16]) -> AgentContext {
+    AgentContext {
+        agent_id: AgentId::from_bytes(agent_bytes),
+        session_id: SessionId::from_bytes([0xAAu8; 16]),
+        pid: 1,
+        started_at: Timestamp::from_nanos(0),
+        metadata: BTreeMap::new(),
+        governance_level: GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: None,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: None,
+    }
+}
+
+/// Construct a `PolicyEngine` from the F116 ST-I secret-detection fixture.
+fn make_engine() -> PolicyEngine {
+    let path = fixture_path("policies/secret_detection_patterns.yaml");
+    let (tx, _rx) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    PolicyEngine::load_from_file(&path, tx).expect("secret_detection_patterns.yaml must load cleanly")
+}
+
+/// Build a `ToolCall` action against the policy-allowed `test_tool` whose
+/// `args` payload is the supplied string. Stage 6 of `evaluate()` scans the
+/// `args` field; see `aa-gateway/src/engine/mod.rs:478`.
+fn tool_call_with_args(args: impl Into<String>) -> GovernanceAction {
+    GovernanceAction::ToolCall {
+        name: "test_tool".to_string(),
+        args: args.into(),
+    }
+}
+
+/// Evaluate `action` with a fresh engine and a deterministic agent identity.
+fn evaluate(action: &GovernanceAction, agent_seed: u8) -> EvaluationResult {
+    let engine = make_engine();
+    let ctx = make_ctx([agent_seed; 16]);
+    engine.evaluate(&ctx, action)
+}
+
+/// Helper for the no-false-positive expectations: asserts `Allow` and clean
+/// scan output. Used by the negative-path test below.
+#[allow(dead_code)] // wired in by the no-false-positive test commit
+fn assert_clean(result: &EvaluationResult) {
+    assert_eq!(result.decision, PolicyResult::Allow, "clean payload must yield Allow");
+    assert!(
+        result.credential_findings.is_empty(),
+        "clean payload must produce no credential findings, got {:?}",
+        result.credential_findings,
+    );
+    assert!(
+        result.redacted_payload.is_none(),
+        "clean payload must leave redacted_payload as None",
+    );
+}
+
+/// Helper for the positive-path expectations: asserts a single finding of the
+/// expected `CredentialKind` and a non-None `redacted_payload`. Used by every
+/// detection test below.
+fn assert_detected(result: &EvaluationResult, expected: CredentialKind) {
+    assert_eq!(
+        result.decision,
+        PolicyResult::Allow,
+        "scanner-only detection must not deny — decision should remain Allow",
+    );
+    assert!(
+        result.credential_findings.iter().any(|f| f.kind == expected),
+        "expected at least one finding of kind {:?}, got {:?}",
+        expected,
+        result.credential_findings,
+    );
+    assert!(
+        result.redacted_payload.is_some(),
+        "detection must populate redacted_payload",
+    );
+}
+
+// ── Test 1 — AWS access key in tool args ─────────────────────────────────────
+
+#[test]
+fn aws_access_key_in_tool_args_is_detected_and_redacted() {
+    let payload = format!(r#"{{"data":"my access key is {FAKE_AWS_ACCESS_KEY}, rotate soon"}}"#);
+    let action = tool_call_with_args(&payload);
+    let result = evaluate(&action, 0xA1);
+
+    assert_detected(&result, CredentialKind::AwsAccessKey);
+
+    let redacted = result
+        .redacted_payload
+        .expect("AWS access key must produce a redacted payload");
+    assert!(
+        redacted.contains("[REDACTED:AwsAccessKey]"),
+        "redacted payload must carry the [REDACTED:AwsAccessKey] label, got: {redacted}",
+    );
+    assert!(
+        !redacted.contains(FAKE_AWS_ACCESS_KEY),
+        "redacted payload must not retain the original AWS access key",
+    );
+}

--- a/aa-integration-tests/tests/e2e_secret_interception.rs
+++ b/aa-integration-tests/tests/e2e_secret_interception.rs
@@ -43,7 +43,6 @@ use aa_gateway::{EvaluationResult, PolicyEngine};
 const FAKE_AWS_ACCESS_KEY: &str = "AKIAIOSFODNN7EXAMPLE";
 
 /// GitHub personal access token prefix + zero-padding. Synthetic.
-#[allow(dead_code)] // wired in by the GitHub PAT detection test commit
 const FAKE_GITHUB_PAT: &str = "ghp_0000000000000000000000000000000000";
 
 /// OpenAI key with the documented `sk-test-` test prefix. Synthetic.
@@ -168,5 +167,28 @@ fn aws_access_key_in_tool_args_is_detected_and_redacted() {
     assert!(
         !redacted.contains(FAKE_AWS_ACCESS_KEY),
         "redacted payload must not retain the original AWS access key",
+    );
+}
+
+// ── Test 2 — GitHub personal access token in tool args ───────────────────────
+
+#[test]
+fn github_pat_in_tool_args_is_detected_and_redacted() {
+    let payload = format!(r#"{{"headers":{{"X-Auth":"Bearer {FAKE_GITHUB_PAT}"}}}}"#);
+    let action = tool_call_with_args(&payload);
+    let result = evaluate(&action, 0xA2);
+
+    assert_detected(&result, CredentialKind::GitHubPat);
+
+    let redacted = result
+        .redacted_payload
+        .expect("GitHub PAT must produce a redacted payload");
+    assert!(
+        redacted.contains("[REDACTED:GitHubPat]"),
+        "redacted payload must carry the [REDACTED:GitHubPat] label, got: {redacted}",
+    );
+    assert!(
+        !redacted.contains(FAKE_GITHUB_PAT),
+        "redacted payload must not retain the original GitHub PAT",
     );
 }

--- a/aa-integration-tests/tests/e2e_secret_interception.rs
+++ b/aa-integration-tests/tests/e2e_secret_interception.rs
@@ -53,7 +53,6 @@ const FAKE_CUSTOM_TOKEN: &str = "MYCO-SECRET-DEADBEEFCAFE0001";
 
 /// Below the `GenericHighEntropy` length floor (20 chars) — must not trip the
 /// scanner. 12 alphanumeric characters with no built-in prefix match.
-#[allow(dead_code)] // wired in by the no-false-positive test commit
 const SHORT_HIGH_ENTROPY: &str = "abc123def456";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -110,7 +109,6 @@ fn evaluate(action: &GovernanceAction, agent_seed: u8) -> EvaluationResult {
 
 /// Helper for the no-false-positive expectations: asserts `Allow` and clean
 /// scan output. Used by the negative-path test below.
-#[allow(dead_code)] // wired in by the no-false-positive test commit
 fn assert_clean(result: &EvaluationResult) {
     assert_eq!(result.decision, PolicyResult::Allow, "clean payload must yield Allow");
     assert!(
@@ -235,4 +233,18 @@ fn custom_sensitive_pattern_in_tool_args_is_detected_and_redacted() {
         !redacted.contains(FAKE_CUSTOM_TOKEN),
         "redacted payload must not retain the original custom token",
     );
+}
+
+// ── Test 5 — No false positive on short high-entropy string ──────────────────
+
+#[test]
+fn short_high_entropy_string_does_not_trigger_scanner() {
+    // 12 alphanumeric characters: no AC-literal prefix matches, and the value
+    // is below the 20-byte length floor enforced for `GenericHighEntropy`.
+    // This guards against alert fatigue (AAASM-1521 acceptance criterion).
+    let payload = format!(r#"{{"id":"{SHORT_HIGH_ENTROPY}"}}"#);
+    let action = tool_call_with_args(&payload);
+    let result = evaluate(&action, 0xA5);
+
+    assert_clean(&result);
 }

--- a/aa-integration-tests/tests/e2e_secret_interception.rs
+++ b/aa-integration-tests/tests/e2e_secret_interception.rs
@@ -49,7 +49,6 @@ const FAKE_GITHUB_PAT: &str = "ghp_0000000000000000000000000000000000";
 const FAKE_OPENAI_KEY: &str = "sk-test-AbCdEf1234567890ABCDEF1234567890ABCDEF1234567890";
 
 /// Custom-pattern token shaped to match `MYCO-SECRET-[A-Za-z0-9]+`.
-#[allow(dead_code)] // wired in by the custom-regex detection test commit
 const FAKE_CUSTOM_TOKEN: &str = "MYCO-SECRET-DEADBEEFCAFE0001";
 
 /// Below the `GenericHighEntropy` length floor (20 chars) — must not trip the
@@ -212,5 +211,28 @@ fn openai_key_in_tool_args_is_detected_and_redacted() {
     assert!(
         !redacted.contains(FAKE_OPENAI_KEY),
         "redacted payload must not retain the original OpenAI key",
+    );
+}
+
+// ── Test 4 — Policy-defined custom regex in tool args ────────────────────────
+
+#[test]
+fn custom_sensitive_pattern_in_tool_args_is_detected_and_redacted() {
+    let payload = format!(r#"{{"data":"internal token = {FAKE_CUSTOM_TOKEN}"}}"#);
+    let action = tool_call_with_args(&payload);
+    let result = evaluate(&action, 0xA4);
+
+    assert_detected(&result, CredentialKind::Custom);
+
+    let redacted = result
+        .redacted_payload
+        .expect("custom-regex match must produce a redacted payload");
+    assert!(
+        redacted.contains("[REDACTED:Custom]"),
+        "redacted payload must carry the [REDACTED:Custom] label, got: {redacted}",
+    );
+    assert!(
+        !redacted.contains(FAKE_CUSTOM_TOKEN),
+        "redacted payload must not retain the original custom token",
     );
 }

--- a/aa-integration-tests/tests/e2e_secret_interception.rs
+++ b/aa-integration-tests/tests/e2e_secret_interception.rs
@@ -46,7 +46,6 @@ const FAKE_AWS_ACCESS_KEY: &str = "AKIAIOSFODNN7EXAMPLE";
 const FAKE_GITHUB_PAT: &str = "ghp_0000000000000000000000000000000000";
 
 /// OpenAI key with the documented `sk-test-` test prefix. Synthetic.
-#[allow(dead_code)] // wired in by the OpenAI key detection test commit
 const FAKE_OPENAI_KEY: &str = "sk-test-AbCdEf1234567890ABCDEF1234567890ABCDEF1234567890";
 
 /// Custom-pattern token shaped to match `MYCO-SECRET-[A-Za-z0-9]+`.
@@ -190,5 +189,28 @@ fn github_pat_in_tool_args_is_detected_and_redacted() {
     assert!(
         !redacted.contains(FAKE_GITHUB_PAT),
         "redacted payload must not retain the original GitHub PAT",
+    );
+}
+
+// ── Test 3 — OpenAI key in tool args ─────────────────────────────────────────
+
+#[test]
+fn openai_key_in_tool_args_is_detected_and_redacted() {
+    let payload = format!(r#"{{"messages":[{{"role":"user","content":"my key is {FAKE_OPENAI_KEY}"}}]}}"#);
+    let action = tool_call_with_args(&payload);
+    let result = evaluate(&action, 0xA3);
+
+    assert_detected(&result, CredentialKind::OpenAiKey);
+
+    let redacted = result
+        .redacted_payload
+        .expect("OpenAI key must produce a redacted payload");
+    assert!(
+        redacted.contains("[REDACTED:OpenAiKey]"),
+        "redacted payload must carry the [REDACTED:OpenAiKey] label, got: {redacted}",
+    );
+    assert!(
+        !redacted.contains(FAKE_OPENAI_KEY),
+        "redacted payload must not retain the original OpenAI key",
     );
 }


### PR DESCRIPTION
## Description

Adds the **detection-only slice** of F116 ST-I — six end-to-end integration tests in `aa-integration-tests/tests/e2e_secret_interception.rs` that exercise the live credential scanner inside `aa_gateway::PolicyEngine` against:

- AWS access keys (`AKIA…`)
- GitHub personal access tokens (`ghp_…`)
- OpenAI keys (`sk-test-…`)
- Policy-defined custom regex (`data.sensitive_patterns`)
- Short high-entropy strings (no-false-positive guard)
- A multi-secret payload — the **critical security invariant** that no raw secret string ever appears in `EvaluationResult.redacted_payload`

All test secrets are synthetic — AWS public-docs examples, zero-padded `ghp_` strings, the documented `sk-test-` test prefix, and a fabricated `MYCO-SECRET-*` token. No real secrets in fixtures.

### Scope — and what is deferred

The original AAASM-1521 ticket described 8 tests covering (a) detection, (b) audit-log redacted-pattern emission, (c) alert emission with severity=critical, (d) policy action modes `block` / `redact_only`, and (e) mock LLM upstream request-count assertions.

A pre-flight runtime audit found that **(a) detection is fully wired** (`aa-core/src/scanner.rs`, `aa-gateway/src/engine/mod.rs:471–534` Stage 6, `aa-gateway/src/service/convert.rs:147–166`) but **(b)–(e) are not implemented in the runtime yet**. Per AAASM-1521 comment from 2026-05-19, this PR ships only the detection-only tests; the runtime gaps are tracked in four new sub-tickets under AAASM-1232:

- **AAASM-1544** — Emit `credential_findings` to audit log
- **AAASM-1545** — Emit alert (severity=critical) on credential findings
- **AAASM-1546** — Policy action enum: `block | redact_only | alert_only`
- **AAASM-1547** — Mock LLM server fixture

A follow-up PR will add the remaining 4 tests once those land.

## Type of Change

- [x] ✨ New feature (integration test coverage of an existing runtime feature)
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: [AAASM-1521](https://lightning-dust-mite.atlassian.net/browse/AAASM-1521) (Subtask)
- Parent Story: [AAASM-1232](https://lightning-dust-mite.atlassian.net/browse/AAASM-1232) (F116 MVP acceptance test)
- Follow-up Subtasks unblocking the remaining 4 tests: AAASM-1544, AAASM-1545, AAASM-1546, AAASM-1547

## Testing

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [x] Manual testing performed (`cargo nextest run -p aa-integration-tests` → 441 passed locally)
- [ ] No tests required (explain why)

Local validation:

```
cargo nextest run -p aa-integration-tests --test e2e_secret_interception
  → 6 passed, 0 skipped
cargo nextest run -p aa-integration-tests
  → 441 passed, 5 skipped (pre-existing)
cargo fmt --all -- --check                                # clean
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo doc --workspace --no-deps                           # clean
```

### Security review — synthetic secrets only

Every secret value in this PR is one of:

| Value | Source |
|---|---|
| `AKIAIOSFODNN7EXAMPLE` | AWS public docs example |
| `ghp_0000…0` | manually fabricated zero-padding |
| `sk-test-AbCdEf…` | OpenAI documented test-only prefix |
| `MYCO-SECRET-DEADBEEFCAFE0001` | fabricated, matches policy custom regex |
| `abc123def456` (no-false-positive decoy) | manually fabricated, below scanner length floor |

Reviewer: please confirm.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (fixture README catalog row added)
- [x] All CI checks passing locally (will re-verify on CI)
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1521]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ