### PR TITLE
[AAASM-1544] ✨ (aa-gateway): Wire credential_findings into audit log entries

### DIFF
--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -251,6 +251,8 @@ impl AuditEntry {
             &previous_hash,
             &payload,
             &Lineage::default(),
+            #[cfg(feature = "std")]
+            &Redaction::default(),
         );
         Self {
             seq,
@@ -300,6 +302,8 @@ impl AuditEntry {
             &previous_hash,
             &payload,
             &lineage,
+            #[cfg(feature = "std")]
+            &Redaction::default(),
         );
         Self {
             seq,
@@ -452,6 +456,11 @@ impl AuditEntry {
             spawned_by_tool: self.spawned_by_tool.clone(),
             depth: self.depth,
         };
+        #[cfg(feature = "std")]
+        let redaction = Redaction {
+            credential_findings: self.credential_findings.clone(),
+            redacted_payload: self.redacted_payload.clone(),
+        };
         let expected = Self::compute_hash(
             self.seq,
             self.timestamp_ns,
@@ -461,6 +470,8 @@ impl AuditEntry {
             &self.previous_hash,
             &self.payload,
             &lineage,
+            #[cfg(feature = "std")]
+            &redaction,
         );
         expected == self.entry_hash
     }
@@ -474,6 +485,9 @@ impl AuditEntry {
     /// Field order and encoding are fixed — see [`AuditEntry::new`] for the
     /// documented byte sequence. Lineage fields append only when `Some`;
     /// when all lineage fields are `None`, output equals the pre-AAASM-934 hash exactly.
+    /// Redaction bytes append only when `redaction != Redaction::default()`;
+    /// the default value (empty findings + `None` payload) contributes 0 bytes,
+    /// so existing chains verify unchanged.
     #[allow(clippy::too_many_arguments)]
     fn compute_hash(
         seq: u64,
@@ -484,6 +498,7 @@ impl AuditEntry {
         previous_hash: &[u8; 32],
         payload: &str,
         lineage: &Lineage,
+        #[cfg(feature = "std")] redaction: &Redaction,
     ) -> [u8; 32] {
         let mut hasher = Sha256::new();
         hasher.update(seq.to_be_bytes());
@@ -515,6 +530,26 @@ impl AuditEntry {
         }
         if let Some(d) = lineage.depth {
             hasher.update(d.to_be_bytes());
+        }
+        // Redaction — append only when non-default; empty Vec + None contributes 0 bytes
+        // so entries constructed via new() / new_with_lineage() hash exactly as before.
+        #[cfg(feature = "std")]
+        {
+            if !redaction.credential_findings.is_empty() || redaction.redacted_payload.is_some() {
+                hasher.update((redaction.credential_findings.len() as u32).to_be_bytes());
+                for finding in &redaction.credential_findings {
+                    hasher.update((finding.offset as u64).to_be_bytes());
+                    hasher.update((finding.matched.len() as u32).to_be_bytes());
+                    hasher.update(finding.matched.as_bytes());
+                }
+                if let Some(s) = &redaction.redacted_payload {
+                    hasher.update([1u8]);
+                    hasher.update((s.len() as u32).to_be_bytes());
+                    hasher.update(s.as_bytes());
+                } else {
+                    hasher.update([0u8]);
+                }
+            }
         }
         hasher.finalize().into()
     }

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -193,6 +193,12 @@ pub struct AuditEntry {
     spawned_by_tool: Option<String>,
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
     depth: Option<u32>,
+    #[cfg(feature = "std")]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty", default))]
+    credential_findings: alloc::vec::Vec<crate::scanner::CredentialFinding>,
+    #[cfg(feature = "std")]
+    #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
+    redacted_payload: Option<String>,
 }
 
 impl AuditEntry {
@@ -261,6 +267,10 @@ impl AuditEntry {
             delegation_reason: None,
             spawned_by_tool: None,
             depth: None,
+            #[cfg(feature = "std")]
+            credential_findings: alloc::vec::Vec::new(),
+            #[cfg(feature = "std")]
+            redacted_payload: None,
         }
     }
 
@@ -306,6 +316,10 @@ impl AuditEntry {
             delegation_reason: lineage.delegation_reason,
             spawned_by_tool: lineage.spawned_by_tool,
             depth: lineage.depth,
+            #[cfg(feature = "std")]
+            credential_findings: alloc::vec::Vec::new(),
+            #[cfg(feature = "std")]
+            redacted_payload: None,
         }
     }
 
@@ -395,6 +409,29 @@ impl AuditEntry {
     #[inline]
     pub fn depth(&self) -> Option<u32> {
         self.depth
+    }
+
+    /// Credential / PII findings detected by the policy engine's scanner pass.
+    ///
+    /// Empty when the scan was clean (or when the entry was constructed via a
+    /// pre-redaction-aware code path). Each [`CredentialFinding`](crate::scanner::CredentialFinding)
+    /// stores only the kind, byte offset, and `[REDACTED:<kind>]` label —
+    /// never the raw secret bytes.
+    #[cfg(feature = "std")]
+    #[inline]
+    pub fn credential_findings(&self) -> &[crate::scanner::CredentialFinding] {
+        &self.credential_findings
+    }
+
+    /// Redacted version of the action payload, if the scanner produced findings.
+    ///
+    /// `None` when the scan was clean. When `Some`, every detected secret has
+    /// been replaced with its `[REDACTED:<kind>]` label so the audit trail
+    /// itself never leaks the raw secret.
+    #[cfg(feature = "std")]
+    #[inline]
+    pub fn redacted_payload(&self) -> Option<&str> {
+        self.redacted_payload.as_deref()
     }
 
     // -----------------------------------------------------------------------

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -1577,3 +1577,102 @@ mod lineage_tests {
         assert_eq!(log.len(), 2);
     }
 }
+
+#[cfg(all(test, feature = "std", feature = "serde"))]
+mod redaction_tests {
+    use super::*;
+    use crate::scanner::CredentialScanner;
+
+    const AGENT: AgentId = AgentId::from_bytes([3u8; 16]);
+    const SESSION: SessionId = SessionId::from_bytes([4u8; 16]);
+
+    /// Synthetic AWS access key from AWS public documentation. Not a real credential.
+    const FAKE_AWS_ACCESS_KEY: &str = "AKIAIOSFODNN7EXAMPLE";
+
+    fn build_redaction_for_fake_secret() -> Redaction {
+        let scanner = CredentialScanner::new();
+        let scan = scanner.scan(FAKE_AWS_ACCESS_KEY);
+        assert!(
+            !scan.findings.is_empty(),
+            "scanner must detect the synthetic AWS access key — fixture invariant",
+        );
+        let redacted = scan.redact(FAKE_AWS_ACCESS_KEY);
+        Redaction {
+            credential_findings: scan.findings,
+            redacted_payload: Some(redacted),
+        }
+    }
+
+    #[test]
+    fn audit_entry_with_redaction_never_serializes_the_raw_secret() {
+        let redaction = build_redaction_for_fake_secret();
+        // Decision metadata only — no raw secret bytes in the audit payload itself.
+        let payload = String::from(r#"{"action_type":"tool_call","decision":"redact"}"#);
+        let entry = AuditEntry::new_with_lineage_and_redaction(
+            0,
+            1_700_000_000_000_000_000,
+            AuditEventType::CredentialLeakBlocked,
+            AGENT,
+            SESSION,
+            payload,
+            [0u8; 32],
+            Lineage::default(),
+            redaction,
+        );
+
+        let serialized = serde_json::to_string(&entry).expect("AuditEntry must serialize");
+
+        // Primary security invariant: the raw secret bytes never appear in the
+        // serialized AuditEntry — neither in `payload`, nor in `credential_findings`,
+        // nor in `redacted_payload`.
+        assert!(
+            !serialized.contains(FAKE_AWS_ACCESS_KEY),
+            "SECURITY INVARIANT VIOLATED: raw secret appears in serialized AuditEntry: {serialized}",
+        );
+
+        // Secondary sanity check: the redaction label IS present, proving findings were attached.
+        assert!(
+            serialized.contains("[REDACTED:AwsAccessKey]"),
+            "serialized AuditEntry must carry the [REDACTED:AwsAccessKey] label, got: {serialized}",
+        );
+
+        // Tamper-evidence holds: the entry validates against its recorded hash.
+        assert!(
+            entry.verify_integrity(),
+            "verify_integrity must pass on a freshly constructed redacted entry",
+        );
+    }
+
+    #[test]
+    fn redaction_default_preserves_legacy_hash() {
+        // new() and new_with_lineage_and_redaction(_, _, ..., Redaction::default())
+        // must produce identical entry_hash for the same base fields. This guarantees
+        // the existing audit chain on disk continues to verify after this PR lands.
+        let payload = String::from(r#"{"tool":"bash"}"#);
+        let legacy = AuditEntry::new(
+            0,
+            1_700_000_000_000_000_000,
+            AuditEventType::ToolCallIntercepted,
+            AGENT,
+            SESSION,
+            payload.clone(),
+            [0u8; 32],
+        );
+        let with_default_redaction = AuditEntry::new_with_lineage_and_redaction(
+            0,
+            1_700_000_000_000_000_000,
+            AuditEventType::ToolCallIntercepted,
+            AGENT,
+            SESSION,
+            payload,
+            [0u8; 32],
+            Lineage::default(),
+            Redaction::default(),
+        );
+        assert_eq!(
+            legacy.entry_hash(),
+            with_default_redaction.entry_hash(),
+            "Redaction::default() must contribute 0 bytes to the hash so legacy chains keep verifying",
+        );
+    }
+}

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -108,6 +108,46 @@ pub struct Lineage {
 }
 
 // ---------------------------------------------------------------------------
+// Redaction
+// ---------------------------------------------------------------------------
+
+/// Optional credential-redaction artefacts attached to an [`AuditEntry`].
+///
+/// Populated when the gateway's policy engine ran the credential scanner
+/// (Stage 6 of `PolicyEngine::evaluate`) and produced at least one finding.
+/// Both fields default to empty / `None`, matching the legacy code path that
+/// constructs entries without scanner output. `Redaction::default()` passed
+/// to [`AuditEntry::new_with_lineage_and_redaction`] produces a hash
+/// identical to [`AuditEntry::new_with_lineage`] with the same base fields,
+/// preserving backward compatibility.
+///
+/// ## Security invariant
+///
+/// Neither field stores the raw secret value. `credential_findings` holds
+/// only the [`CredentialKind`](crate::scanner::CredentialKind), byte offset,
+/// and the `[REDACTED:<kind>]` label (`CredentialFinding`'s `end` field is
+/// `#[serde(skip)]`). `redacted_payload` holds the sanitised payload returned
+/// by `ScanResult::redact` where every match has been replaced with its
+/// `[REDACTED:<kind>]` label.
+///
+/// ## Feature gating
+///
+/// Gated on `std` because [`CredentialFinding`](crate::scanner::CredentialFinding)
+/// lives in the `std`-only `scanner` module. `no_std + alloc` builds compile
+/// `AuditEntry` without redaction support.
+#[cfg(feature = "std")]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Redaction {
+    /// All credential / PII findings detected by the scanner. Empty when the
+    /// scanner found nothing.
+    pub credential_findings: alloc::vec::Vec<crate::scanner::CredentialFinding>,
+    /// The redacted version of the action payload (raw secret bytes replaced
+    /// with `[REDACTED:<kind>]` labels). `None` when no findings were produced.
+    pub redacted_payload: Option<alloc::string::String>,
+}
+
+// ---------------------------------------------------------------------------
 // AuditEntry
 // ---------------------------------------------------------------------------
 

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -327,6 +327,61 @@ impl AuditEntry {
         }
     }
 
+    /// Create a new [`AuditEntry`] carrying both lineage data and credential
+    /// scanner output, computing `entry_hash` over all tamper-meaningful fields.
+    ///
+    /// When `redaction == Redaction::default()` (empty findings + `None` payload),
+    /// the resulting `entry_hash` is identical to [`AuditEntry::new_with_lineage`]
+    /// with the same base fields — so callers that don't have scanner data can
+    /// continue using the legacy constructors without any chain divergence.
+    ///
+    /// Gated on `std` because [`Redaction`] holds
+    /// [`CredentialFinding`](crate::scanner::CredentialFinding) values, which
+    /// live in the `std`-only `scanner` module.
+    #[cfg(feature = "std")]
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_lineage_and_redaction(
+        seq: u64,
+        timestamp_ns: u64,
+        event_type: AuditEventType,
+        agent_id: AgentId,
+        session_id: SessionId,
+        payload: String,
+        previous_hash: [u8; 32],
+        lineage: Lineage,
+        redaction: Redaction,
+    ) -> Self {
+        let entry_hash = Self::compute_hash(
+            seq,
+            timestamp_ns,
+            &event_type,
+            &agent_id,
+            &session_id,
+            &previous_hash,
+            &payload,
+            &lineage,
+            &redaction,
+        );
+        Self {
+            seq,
+            timestamp_ns,
+            event_type,
+            agent_id,
+            session_id,
+            payload,
+            previous_hash,
+            entry_hash,
+            root_agent_id: lineage.root_agent_id,
+            parent_agent_id: lineage.parent_agent_id,
+            team_id: lineage.team_id,
+            delegation_reason: lineage.delegation_reason,
+            spawned_by_tool: lineage.spawned_by_tool,
+            depth: lineage.depth,
+            credential_findings: redaction.credential_findings,
+            redacted_payload: redaction.redacted_payload,
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Getters
     // -----------------------------------------------------------------------

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -64,6 +64,9 @@ pub use evaluators::{DenyAllEvaluator, PermitAllEvaluator};
 #[cfg(feature = "alloc")]
 pub use audit::{AuditEntry, AuditEventType, AuditLog, AuditLogError, Lineage};
 
+#[cfg(feature = "std")]
+pub use audit::Redaction;
+
 #[cfg(feature = "alloc")]
 pub use capability::{
     action_to_capability, merge_capabilities, Capability, CapabilitySet, EffectivePermissions, PermissionSource,

--- a/aa-gateway/src/audit.rs
+++ b/aa-gateway/src/audit.rs
@@ -183,3 +183,66 @@ pub enum AuditError {
     #[error("JSON deserialization error at line {line}: {source}")]
     Deserialize { line: u64, source: serde_json::Error },
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aa_core::{AgentId, AuditEventType, CredentialScanner, Lineage, Redaction, SessionId};
+
+    /// Synthetic AWS access key from AWS public documentation. Not a real credential.
+    const FAKE_AWS_ACCESS_KEY: &str = "AKIAIOSFODNN7EXAMPLE";
+
+    #[tokio::test]
+    async fn audit_writer_jsonl_never_contains_raw_secret() {
+        let scanner = CredentialScanner::new();
+        let scan = scanner.scan(FAKE_AWS_ACCESS_KEY);
+        assert!(
+            !scan.findings.is_empty(),
+            "scanner fixture invariant — must detect AWS key"
+        );
+        let redacted_payload = scan.redact(FAKE_AWS_ACCESS_KEY);
+        let redaction = Redaction {
+            credential_findings: scan.findings,
+            redacted_payload: Some(redacted_payload),
+        };
+
+        let entry = AuditEntry::new_with_lineage_and_redaction(
+            0,
+            1_700_000_000_000_000_000,
+            AuditEventType::CredentialLeakBlocked,
+            AgentId::from_bytes([5u8; 16]),
+            SessionId::from_bytes([6u8; 16]),
+            r#"{"action_type":"tool_call","decision":"redact"}"#.to_string(),
+            [0u8; 32],
+            Lineage::default(),
+            redaction,
+        );
+
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let (tx, rx) = mpsc::channel(4);
+        let writer = AuditWriter::new(tmp.path().to_path_buf(), "agent-test", "session-test", rx)
+            .await
+            .expect("construct AuditWriter");
+        let path = writer.path.clone();
+        let handle = tokio::spawn(writer.run());
+
+        tx.send(entry).await.expect("send entry to writer");
+        drop(tx);
+        handle.await.expect("writer task joins cleanly");
+
+        let on_disk = tokio::fs::read_to_string(&path).await.expect("read JSONL");
+
+        assert!(
+            !on_disk.contains(FAKE_AWS_ACCESS_KEY),
+            "SECURITY INVARIANT VIOLATED: raw secret present in audit JSONL on disk: {on_disk}",
+        );
+        assert!(
+            on_disk.contains("[REDACTED:AwsAccessKey]"),
+            "audit JSONL must carry the [REDACTED:AwsAccessKey] label, got: {on_disk}",
+        );
+
+        let verify = AuditWriter::verify_chain(&path).await.expect("verify_chain runs");
+        assert!(verify.is_valid, "single redacted entry must verify cleanly");
+        assert_eq!(verify.entries_checked, 1);
+    }
+}

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -9,7 +9,7 @@ use tonic::{Request, Response, Status};
 
 use aa_core::identity::{AgentId, SessionId};
 use aa_core::time::Timestamp;
-use aa_core::{AgentContext, AuditEntry, AuditEventType, GovernanceLevel};
+use aa_core::{AgentContext, AuditEntry, AuditEventType, GovernanceLevel, Lineage, Redaction};
 use aa_proto::assembly::policy::v1::policy_service_server::PolicyService;
 use aa_proto::assembly::policy::v1::{BatchCheckRequest, BatchCheckResponse, CheckActionRequest, CheckActionResponse};
 
@@ -539,7 +539,7 @@ impl PolicyServiceImpl {
     /// Build an `AuditEntry` from a request and evaluation result, then fire-and-forget
     /// via `try_send`. Maintains the hash chain by reading and updating `last_hash`.
     /// Never blocks the caller beyond the brief mutex acquisition.
-    async fn record_audit(&self, req: &CheckActionRequest, response: &CheckActionResponse) {
+    async fn record_audit(&self, req: &CheckActionRequest, response: &CheckActionResponse, eval: &EvaluationResult) {
         let proto_agent = match req.agent_id.as_ref() {
             Some(a) => a,
             None => return, // No agent identity — cannot construct entry.
@@ -561,7 +561,29 @@ impl PolicyServiceImpl {
 
         let mut last_hash = self.last_hash.lock().await;
 
-        let entry = AuditEntry::new(seq, timestamp_ns, event_type, agent_id, session_id, payload, *last_hash);
+        // When the credential scanner produced findings, attach them (and the
+        // redacted payload) to the audit entry via the redaction-aware constructor.
+        // Both fields carry the [REDACTED:<kind>] form only — the raw secret bytes
+        // never reach the audit pipeline.
+        let entry = if eval.credential_findings.is_empty() {
+            AuditEntry::new(seq, timestamp_ns, event_type, agent_id, session_id, payload, *last_hash)
+        } else {
+            let redaction = Redaction {
+                credential_findings: eval.credential_findings.clone(),
+                redacted_payload: eval.redacted_payload.clone(),
+            };
+            AuditEntry::new_with_lineage_and_redaction(
+                seq,
+                timestamp_ns,
+                event_type,
+                agent_id,
+                session_id,
+                payload,
+                *last_hash,
+                Lineage::default(),
+                redaction,
+            )
+        };
 
         // Update the chain head before sending — even if try_send fails (the entry
         // is dropped), we advance the chain so subsequent entries don't duplicate
@@ -640,7 +662,7 @@ impl PolicyService for PolicyServiceImpl {
         self.maybe_suspend_agent(&req, deny_action).await;
 
         // Fire-and-forget audit entry — never blocks the response.
-        self.record_audit(&req, &response).await;
+        self.record_audit(&req, &response, &eval).await;
 
         Ok(Response::new(response))
     }
@@ -660,7 +682,7 @@ impl PolicyService for PolicyServiceImpl {
                 convert::eval_result_to_response(&eval, latency_us, &policy_rule)
             };
             self.maybe_suspend_agent(req, deny_action).await;
-            self.record_audit(req, &resp).await;
+            self.record_audit(req, &resp, &eval).await;
             responses.push(resp);
         }
 


### PR DESCRIPTION
## Description

When `PolicyEngine::evaluate()` produces a non-empty `credential_findings` set (Stage 6 of `engine::evaluate`), the corresponding audit log entry now carries:

* `credential_findings: Vec<CredentialFinding>` — kind, byte offset, `[REDACTED:<kind>]` label (the `end` field is `#[serde(skip)]`)
* `redacted_payload: String` — same sanitised content the gateway returns over gRPC

The raw secret value is **never** stored, hashed, or serialised — only the `[REDACTED:<kind>]` form is. Hash-chain backward compatibility is preserved: `Redaction::default()` (empty findings + `None` payload) contributes 0 bytes to the SHA-256 input, so any pre-existing audit JSONL chain on disk continues to verify after this PR lands.

Changes:

* `aa-core/src/audit.rs` — new `Redaction` struct; new `AuditEntry::new_with_lineage_and_redaction` constructor; extended `compute_hash` to fold in non-default redaction bytes; getters `credential_findings()` / `redacted_payload()`; serde gating + skip-empty/None for back-compat.
* `aa-gateway/src/service/policy_service.rs` — `record_audit` now takes `&EvaluationResult`. When `eval.credential_findings.is_empty()`, the legacy `AuditEntry::new` path is used (unchanged byte-for-byte). Otherwise, the new redaction-aware constructor wires findings + redacted payload into the chain.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No — `Redaction::default()` produces a hash identical to the pre-PR `new()` / `new_with_lineage()` output, so existing chains continue to verify.

## Related Issues

- Related Jira ticket: AAASM-1544 (parent Story AAASM-1232)
- Unblocks the deferred E2E test from AAASM-1521: `secret_redacted_in_audit_log`

## Testing

Two new unit tests in `aa-core/src/audit.rs::redaction_tests`:

* `audit_entry_with_redaction_never_serializes_the_raw_secret` — uses a synthetic AWS access key (`AKIAIOSFODNN7EXAMPLE`, from AWS public docs — not a real credential), serialises an `AuditEntry` carrying scanner-produced `Redaction`, asserts the raw secret is **absent** from the JSON and that the `[REDACTED:AwsAccessKey]` label **is** present. Also asserts `verify_integrity()` passes on the redacted entry.
* `redaction_default_preserves_legacy_hash` — proves `AuditEntry::new(...)` and `AuditEntry::new_with_lineage_and_redaction(..., Redaction::default())` produce identical `entry_hash`, so pre-existing on-disk audit chains keep verifying.

Both tests are gated on `feature = "serde"`, which the workspace test run enables via aa-gateway's feature unification (verified locally — both tests appear in `cargo nextest run --workspace --no-tests=pass --exclude aa-ebpf` output).

Local validation:

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p aa-core -p aa-gateway --all-targets -- -D warnings` — clean
- [x] `cargo nextest run -p aa-core -p aa-gateway` — 959 tests pass
- [x] `cargo nextest run --workspace --no-tests=pass --exclude aa-ebpf` — redaction tests confirmed running
- [x] Unit tests added
- [ ] Integration tests added / updated — none required; this is a struct-level data-flow change
- [x] No tests required for the legacy hash path (default `Redaction` is byte-identical)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed — module-level rustdoc on `Redaction` documents the security invariant and feature gating
- [ ] All CI checks passing — will be verified after push
- [x] Commits are small and follow the Gitmoji convention (6 commits, one logical unit each)