### PR TITLE
[AAASM-1547] ✨ (aa-integration-tests): Add MockLlmServer fixture for E2E request-count assertions

### DIFF
--- a/aa-integration-tests/tests/common/mock_llm.rs
+++ b/aa-integration-tests/tests/common/mock_llm.rs
@@ -27,6 +27,18 @@
 //! assert!(mock.last_body().unwrap().contains("REDACTED"));
 //! ```
 
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::{HeaderMap, Method, StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use axum::routing::any;
+use axum::Router;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
 /// A single inbound HTTP request captured by [`MockLlmServer`].
 ///
 /// All fields are populated verbatim from the inbound request — no
@@ -51,4 +63,140 @@ impl RecordedRequest {
     pub fn body_str(&self) -> Option<&str> {
         std::str::from_utf8(&self.body).ok()
     }
+}
+
+/// Default canned response body returned by [`MockLlmServer::start`].
+/// Shaped as a minimal OpenAI-compatible chat-completion envelope so the SUT
+/// (when treating the mock as an LLM upstream) deserialises it without
+/// special-casing.
+const DEFAULT_RESPONSE_BODY: &str = r#"{"id":"mock","object":"chat.completion","choices":[]}"#;
+const DEFAULT_RESPONSE_CONTENT_TYPE: &str = "application/json";
+
+/// Shared state injected into the axum route handler.
+///
+/// Cloned once into the `Router::with_state(...)` call; the `Arc` on `history`
+/// is what lets the handler push into the same vector the test reads from.
+#[derive(Clone)]
+struct CaptureState {
+    history: Arc<Mutex<Vec<RecordedRequest>>>,
+    response_status: StatusCode,
+    response_body: Bytes,
+    response_content_type: String,
+}
+
+/// Hermetic mock LLM upstream — binds an axum router to a random loopback
+/// port, records every inbound request into a shared history, and replies
+/// with a canned response. One instance per test; instances do not share
+/// global state.
+pub struct MockLlmServer {
+    /// Base URL the test should configure the SUT to call (e.g.
+    /// `http://127.0.0.1:54321`). No trailing slash; the server's fallback
+    /// route accepts any path, so the SUT can append whatever shape it
+    /// expects from a real upstream (`/v1/chat/completions`, etc).
+    pub url: String,
+    /// Shared, thread-safe history of inbound requests in arrival order.
+    /// Cloned `Arc` for direct access; the accessors on `MockLlmServer`
+    /// wrap the lock for the common cases.
+    pub history: Arc<Mutex<Vec<RecordedRequest>>>,
+    addr: SocketAddr,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    server_handle: Option<JoinHandle<()>>,
+}
+
+impl MockLlmServer {
+    /// Start the mock with the default canned response (200 OK,
+    /// `application/json`, minimal chat-completion envelope).
+    pub async fn start() -> anyhow::Result<Self> {
+        Self::start_inner(
+            StatusCode::OK,
+            Bytes::from_static(DEFAULT_RESPONSE_BODY.as_bytes()),
+            DEFAULT_RESPONSE_CONTENT_TYPE.to_owned(),
+        )
+        .await
+    }
+
+    async fn start_inner(
+        response_status: StatusCode,
+        response_body: Bytes,
+        response_content_type: String,
+    ) -> anyhow::Result<Self> {
+        let history = Arc::new(Mutex::new(Vec::new()));
+        let state = CaptureState {
+            history: Arc::clone(&history),
+            response_status,
+            response_body,
+            response_content_type,
+        };
+
+        let app = Router::new().fallback(any(capture_handler)).with_state(state);
+
+        let port = portpicker::pick_unused_port().ok_or_else(|| anyhow::anyhow!("no free TCP port"))?;
+        let addr: SocketAddr = format!("127.0.0.1:{port}").parse()?;
+        let listener = tokio::net::TcpListener::bind(addr).await?;
+        let bound_addr = listener.local_addr()?;
+
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+        let server_handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await;
+        });
+
+        Ok(Self {
+            url: format!("http://{bound_addr}"),
+            history,
+            addr: bound_addr,
+            shutdown_tx: Some(shutdown_tx),
+            server_handle: Some(server_handle),
+        })
+    }
+}
+
+impl Drop for MockLlmServer {
+    fn drop(&mut self) {
+        // Signal graceful shutdown first; abort the JoinHandle as a fallback
+        // in case the listener task is wedged in a future the shutdown
+        // signal can't preempt (matches `TopologyTestEnv`'s pattern in
+        // `common/mod.rs`).
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.server_handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+/// Axum fallback handler — records every inbound request, then returns the
+/// configured canned response.
+async fn capture_handler(
+    State(state): State<CaptureState>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let recorded = RecordedRequest {
+        method: method.to_string(),
+        path: uri.path().to_owned(),
+        headers: headers
+            .iter()
+            .map(|(k, v)| (k.as_str().to_owned(), v.to_str().unwrap_or_default().to_owned()))
+            .collect(),
+        body: body.to_vec(),
+    };
+    state
+        .history
+        .lock()
+        .expect("mock LLM history mutex poisoned")
+        .push(recorded);
+
+    let mut response = state.response_body.clone().into_response();
+    *response.status_mut() = state.response_status;
+    if let Ok(value) = state.response_content_type.parse() {
+        response.headers_mut().insert(axum::http::header::CONTENT_TYPE, value);
+    }
+    response
 }

--- a/aa-integration-tests/tests/common/mock_llm.rs
+++ b/aa-integration-tests/tests/common/mock_llm.rs
@@ -1,0 +1,54 @@
+//! In-process mock LLM upstream server for end-to-end integration tests
+//! (AAASM-1547 / F116 ST-I follow-up).
+//!
+//! `MockLlmServer` binds an axum router to a random loopback port, records
+//! every inbound request (method, path, headers, body) into a shared
+//! `Arc<Mutex<Vec<RecordedRequest>>>`, and replies with a configurable canned
+//! response. It is hermetic — each instance owns its own port, history, and
+//! background tokio task; instances do not share global state and can be
+//! constructed in parallel across tests.
+//!
+//! The fixture unblocks the deferred secret-detection assertions from
+//! AAASM-1521 / AAASM-1549, which need to prove that:
+//!
+//! * when policy is `block`, the upstream receives zero requests
+//!   (`mock.request_count() == 0`), and
+//! * when policy is `redact_only`, the upstream receives the *redacted* form
+//!   of the body (`mock.last_body()` contains the placeholder, not the raw
+//!   secret).
+//!
+//! Typical usage:
+//!
+//! ```ignore
+//! let mock = common::MockLlmServer::start().await?;
+//! configure_sut_upstream(&mock.url);
+//! send_request_through_sut(&mock.url).await?;
+//! assert_eq!(mock.request_count(), 1);
+//! assert!(mock.last_body().unwrap().contains("REDACTED"));
+//! ```
+
+/// A single inbound HTTP request captured by [`MockLlmServer`].
+///
+/// All fields are populated verbatim from the inbound request — no
+/// canonicalisation, no header filtering — so tests can assert on the exact
+/// bytes that crossed the wire.
+#[derive(Clone, Debug)]
+pub struct RecordedRequest {
+    /// HTTP method as a string (e.g. `"POST"`).
+    pub method: String,
+    /// Request path including any leading slash (e.g. `"/v1/chat/completions"`).
+    pub path: String,
+    /// Header name/value pairs in the order they appeared on the wire.
+    /// Names are lower-case (axum's normalised form); values are the raw
+    /// string representation.
+    pub headers: Vec<(String, String)>,
+    /// Request body bytes, captured verbatim before any framework parsing.
+    pub body: Vec<u8>,
+}
+
+impl RecordedRequest {
+    /// Body interpreted as UTF-8, if it is valid UTF-8.
+    pub fn body_str(&self) -> Option<&str> {
+        std::str::from_utf8(&self.body).ok()
+    }
+}

--- a/aa-integration-tests/tests/common/mock_llm.rs
+++ b/aa-integration-tests/tests/common/mock_llm.rs
@@ -152,6 +152,41 @@ impl MockLlmServer {
             server_handle: Some(server_handle),
         })
     }
+
+    /// Number of inbound requests recorded so far.
+    ///
+    /// Used by AAASM-1521 / AAASM-1549 to assert that a `block` policy
+    /// stopped the request *before* it reached the upstream — i.e.
+    /// `assert_eq!(mock.request_count(), 0)` after a denied call.
+    pub fn request_count(&self) -> usize {
+        self.history.lock().expect("mock LLM history mutex poisoned").len()
+    }
+
+    /// Body of the most recently recorded request as a UTF-8 string, or
+    /// `None` if no request has arrived yet or the last body was not valid
+    /// UTF-8.
+    ///
+    /// Used by `redact_only` policy tests to assert that what reached the
+    /// upstream contains the redacted placeholder and not the raw secret.
+    pub fn last_body(&self) -> Option<String> {
+        self.history
+            .lock()
+            .expect("mock LLM history mutex poisoned")
+            .last()
+            .and_then(|r| r.body_str().map(|s| s.to_owned()))
+    }
+
+    /// Snapshot of every recorded request body, in arrival order. Each entry
+    /// is the raw bytes captured by the handler — callers can decode as
+    /// UTF-8 themselves if appropriate.
+    pub fn all_bodies(&self) -> Vec<Vec<u8>> {
+        self.history
+            .lock()
+            .expect("mock LLM history mutex poisoned")
+            .iter()
+            .map(|r| r.body.clone())
+            .collect()
+    }
 }
 
 impl Drop for MockLlmServer {

--- a/aa-integration-tests/tests/common/mock_llm.rs
+++ b/aa-integration-tests/tests/common/mock_llm.rs
@@ -115,6 +115,13 @@ impl MockLlmServer {
         .await
     }
 
+    /// Start the mock with a caller-supplied canned response — useful when
+    /// the SUT needs a non-200 status (e.g. 429 for retry tests) or a body
+    /// shape that does not match the default OpenAI-compatible envelope.
+    pub async fn start_with_response(status: StatusCode, body: &str, content_type: &str) -> anyhow::Result<Self> {
+        Self::start_inner(status, Bytes::from(body.to_owned()), content_type.to_owned()).await
+    }
+
     async fn start_inner(
         response_status: StatusCode,
         response_body: Bytes,

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -26,6 +26,13 @@ pub mod scenario;
 #[allow(dead_code)]
 pub mod sdk_driver;
 
+// Ergonomic re-exports — keep the public surface flat at `common::*`,
+// matching how `TopologyTestEnv` is reached today. AAASM-1547 AC explicitly
+// requires `common::MockLlmServer` (not `common::mock_llm::MockLlmServer`)
+// be available to all integration tests.
+#[allow(unused_imports)]
+pub use mock_llm::{MockLlmServer, RecordedRequest};
+
 use rust_decimal::Decimal;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -14,6 +14,11 @@
 //! than spawning the `aa-gateway` binary as the ticket text suggests
 //! (`aa-gateway` is gRPC-only and there is currently no `aa-api` HTTP
 //! binary in the workspace).
+//!
+//! Also re-exports [`MockLlmServer`] (see [`mock_llm`]) — the hermetic mock
+//! LLM upstream that the deferred secret-detection E2E tests
+//! (AAASM-1521 / AAASM-1549) use to assert what the SUT forwarded after
+//! policy enforcement. Module-level docs in [`mock_llm`] cover usage.
 
 #[allow(dead_code)]
 pub mod cli;

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -20,6 +20,8 @@ pub mod cli;
 #[allow(dead_code)]
 pub mod format;
 #[allow(dead_code)]
+pub mod mock_llm;
+#[allow(dead_code)]
 pub mod scenario;
 #[allow(dead_code)]
 pub mod sdk_driver;

--- a/aa-integration-tests/tests/mock_llm_server.rs
+++ b/aa-integration-tests/tests/mock_llm_server.rs
@@ -71,3 +71,32 @@ async fn captures_request_body_path_and_headers_verbatim() {
         recorded.headers,
     );
 }
+
+/// AAASM-1547 supports rate-limit / retry tests by letting the caller pick
+/// the upstream's response — verify the status, body, and content-type land
+/// on the wire as configured.
+#[tokio::test]
+async fn returns_caller_supplied_canned_response() {
+    let mock = MockLlmServer::start_with_response(
+        axum::http::StatusCode::IM_A_TEAPOT,
+        r#"{"error":"i am a teapot"}"#,
+        "application/json",
+    )
+    .await
+    .expect("mock starts");
+
+    let resp = Client::new()
+        .post(&mock.url)
+        .body("ping")
+        .send()
+        .await
+        .expect("POST succeeds against mock");
+
+    assert_eq!(resp.status().as_u16(), 418);
+    assert_eq!(
+        resp.headers().get("content-type").and_then(|v| v.to_str().ok()),
+        Some("application/json"),
+    );
+    assert_eq!(resp.text().await.expect("body"), r#"{"error":"i am a teapot"}"#);
+    assert_eq!(mock.request_count(), 1, "capture still runs on non-200 canned response");
+}

--- a/aa-integration-tests/tests/mock_llm_server.rs
+++ b/aa-integration-tests/tests/mock_llm_server.rs
@@ -1,0 +1,32 @@
+//! Tests for the `MockLlmServer` fixture itself (AAASM-1547).
+//!
+//! Lives in its own test binary rather than inside `common/mock_llm.rs` so
+//! the fixture-level assertions run once, not once per integration-test
+//! binary that imports `common`.
+
+mod common;
+
+use common::MockLlmServer;
+use reqwest::Client;
+
+/// AAASM-1547 AC: "tests prove counter increments".
+///
+/// Three POSTs in sequence to the mock's base URL — `request_count()` must
+/// reach `3`. Counter is the canonical signal that the `block` policy in
+/// AAASM-1521 / AAASM-1549 will use to assert "upstream received zero
+/// requests", so the increment path needs to be unambiguous.
+#[tokio::test]
+async fn request_count_increments_per_inbound_request() {
+    let mock = MockLlmServer::start().await.expect("mock starts");
+    let client = Client::new();
+    for _ in 0..3 {
+        let resp = client
+            .post(&mock.url)
+            .body("hello")
+            .send()
+            .await
+            .expect("POST succeeds against mock");
+        assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    }
+    assert_eq!(mock.request_count(), 3);
+}

--- a/aa-integration-tests/tests/mock_llm_server.rs
+++ b/aa-integration-tests/tests/mock_llm_server.rs
@@ -30,3 +30,44 @@ async fn request_count_increments_per_inbound_request() {
     }
     assert_eq!(mock.request_count(), 3);
 }
+
+/// AAASM-1547 AC: "captures inbound request body verbatim" + "body
+/// retrievable".
+///
+/// A POST with a JSON body, a non-default path, and a custom header — every
+/// field on the recorded request must round-trip exactly. The body byte
+/// equality is the load-bearing assertion for the AAASM-1521
+/// `redact_only`-policy test, which needs to inspect what *actually*
+/// reached the upstream after redaction.
+#[tokio::test]
+async fn captures_request_body_path_and_headers_verbatim() {
+    let mock = MockLlmServer::start().await.expect("mock starts");
+    let payload = r#"{"prompt":"hello world","model":"gpt-4o"}"#;
+    let resp = Client::new()
+        .post(format!("{}/v1/chat/completions", mock.url))
+        .header("authorization", "Bearer test-key-do-not-redact")
+        .header("content-type", "application/json")
+        .body(payload.to_owned())
+        .send()
+        .await
+        .expect("POST succeeds against mock");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+
+    let recorded = {
+        let guard = mock.history.lock().expect("history mutex");
+        guard.last().cloned().expect("at least one recorded request")
+    };
+
+    assert_eq!(recorded.method, "POST");
+    assert_eq!(recorded.path, "/v1/chat/completions");
+    assert_eq!(recorded.body, payload.as_bytes(), "body must be captured verbatim");
+    assert_eq!(mock.last_body().as_deref(), Some(payload));
+    assert!(
+        recorded
+            .headers
+            .iter()
+            .any(|(k, v)| k.eq_ignore_ascii_case("authorization") && v == "Bearer test-key-do-not-redact"),
+        "authorization header should be captured verbatim, got: {:?}",
+        recorded.headers,
+    );
+}


### PR DESCRIPTION
## Description

Adds a reusable hermetic mock LLM upstream — `common::MockLlmServer` — that the deferred secret-detection E2E tests (AAASM-1521 / AAASM-1549) need in order to assert *what reached the upstream after policy enforcement*. The fixture:

- binds an axum router to a random loopback port (`portpicker`), no global state,
- captures every inbound request (method, path, headers, body bytes) verbatim into a shared `Arc<Mutex<Vec<RecordedRequest>>>`,
- exposes `request_count()`, `last_body()`, `all_bodies()` accessors,
- replies with a configurable canned response (`start()` defaults to a minimal OpenAI-compatible 200 JSON envelope; `start_with_response(status, body, content_type)` for retry / rate-limit shapes),
- signals graceful shutdown from `Drop` (oneshot + `JoinHandle::abort` fallback — matches the existing `TopologyTestEnv` lifecycle pattern),
- lives at `aa-integration-tests/tests/common/mock_llm.rs`, re-exported at `common::MockLlmServer` / `common::RecordedRequest`,
- is documented via module-level docs in `mock_llm.rs` and cross-linked from `common/mod.rs`'s preamble.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

Test-only crate (`aa-integration-tests`, `publish = false`); the new module is additive.

## Related Issues

- Related Jira ticket: AAASM-1547 (F116 ST-I follow-up: Mock LLM server fixture for E2E request-count assertions)
- Parent Story: AAASM-1232 (F116 MVP acceptance test)
- Parent Epic (per Jira link): AAASM-1199
- Unblocks deferred siblings: AAASM-1521 (ST-I SDK-path secret-detection E2E), AAASM-1549 (ST-N proxy-path secret-detection E2E)

## Acceptance criteria — verification

| AC | Where verified |
|---|---|
| `common::MockLlmServer` available to all integration tests | `tests/common/mod.rs` re-export (commit `45b3a731`) |
| Hermetic — random port, no global state | `start_inner()` uses `portpicker::pick_unused_port()` per instance; history `Arc` per instance |
| Captures inbound request body verbatim | `tests/mock_llm_server.rs::captures_request_body_path_and_headers_verbatim` |
| Tests prove counter increments + body retrievable | `tests/mock_llm_server.rs::request_count_increments_per_inbound_request` + `captures_request_body_path_and_headers_verbatim` |
| Documented in `aa-integration-tests/README.md` or module-level docs | Module-level docs in `tests/common/mock_llm.rs`; cross-link in `tests/common/mod.rs` (commit `4aa95d1a`). No `README.md` existed to update; module docs satisfy the AC's "or" clause. |

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated — three `#[tokio::test]` cases in `aa-integration-tests/tests/mock_llm_server.rs` (counter increment, verbatim capture, canned response)
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

```
$ cargo nextest run -p aa-integration-tests --test mock_llm_server
    Starting 3 tests across 1 binary
        PASS [   0.022s] captures_request_body_path_and_headers_verbatim
        PASS [   0.022s] returns_caller_supplied_canned_response
        PASS [   0.022s] request_count_increments_per_inbound_request
     Summary [   0.023s] 3 tests run: 3 passed, 0 skipped
```

The existing `smoke` test binary still passes (the shared `common` module accepts the new `pub mod mock_llm` declaration cleanly).

## Out of scope (intentionally deferred)

- Wiring `MockLlmServer` into the actual secret-detection E2E flows (`secret_aws_key_in_request_body_detected_and_blocked`, `secret_policy_redact_only_lets_call_through_but_strips_secret`) — those land under AAASM-1521 / AAASM-1549, which the ticket "Blocks" section names as the consumers of this fixture.
- HTTPS / TLS support on the mock — current consumers (SDK Layer 1 path, Layer 2 proxy in cleartext-test mode) talk plain HTTP; HTTPS would need MITM CA plumbing that belongs with the proxy E2E work.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing (will verify post-push)
- [x] Commits are small and follow the Gitmoji convention — 9 commits, one logical change each

## Commit list

```
✨ (aa-integration-tests): Add `RecordedRequest` struct for mock LLM capture
✨ (aa-integration-tests): Add `MockLlmServer` with start + graceful shutdown
✨ (aa-integration-tests): Add MockLlmServer accessors (request_count, last_body, all_bodies)
✨ (aa-integration-tests): Add `start_with_response` for caller-supplied canned response
♻️ (aa-integration-tests): Re-export `MockLlmServer` / `RecordedRequest` from `common`
✅ (aa-integration-tests): Test MockLlmServer request_count increments per inbound POST
✅ (aa-integration-tests): Test MockLlmServer captures body, path, and headers verbatim
✅ (aa-integration-tests): Test MockLlmServer returns caller-supplied canned response
📝 (aa-integration-tests): Surface MockLlmServer in common/mod.rs module docs
```