### PR TITLE
[AAASM-1518] ✅ (aa-integration-tests): E2E budget enforcement tests

### DIFF
--- a/aa-integration-tests/tests/common/fixtures/policies/budget_team_limit.yaml
+++ b/aa-integration-tests/tests/common/fixtures/policies/budget_team_limit.yaml
@@ -1,0 +1,22 @@
+apiVersion: agent-assembly.dev/v1alpha1
+kind: GovernancePolicy
+metadata:
+  name: f116-st-f-budget-team-limit
+  version: "0.1.0"
+spec:
+  rules:
+    - id: allow-default
+      effect: allow
+      match: {}
+# Reference: the team daily limit is injected at BudgetTracker construction
+# time via BudgetTracker::with_team_daily_limit(). The YAML budget stanza is
+# the policy-plane representation; integration tests use the tracker API
+# directly (same pattern as api_costs.rs).
+#
+# Equivalent policy-plane stanza (not parsed by the test harness):
+#   budgets:
+#     - scope:
+#         team: "f116-budget-it"
+#       window: "1d"
+#       limit_usd: 2.00
+#       action_on_exhaust: deny

--- a/aa-integration-tests/tests/common/fixtures/policies/budget_two_teams.yaml
+++ b/aa-integration-tests/tests/common/fixtures/policies/budget_two_teams.yaml
@@ -1,0 +1,26 @@
+apiVersion: agent-assembly.dev/v1alpha1
+kind: GovernancePolicy
+metadata:
+  name: f116-st-f-budget-two-teams
+  version: "0.1.0"
+spec:
+  rules:
+    - id: allow-default
+      effect: allow
+      match: {}
+# Reference: both teams (f116-budget-it-a and f116-budget-it-b) share the
+# same per-team cap set via BudgetTracker::with_team_daily_limit(). The
+# isolation test asserts that exhausting one team does not block the other.
+#
+# Equivalent policy-plane stanza (not parsed by the test harness):
+#   budgets:
+#     - scope:
+#         team: "f116-budget-it-a"
+#       window: "1d"
+#       limit_usd: 2.00
+#       action_on_exhaust: deny
+#     - scope:
+#         team: "f116-budget-it-b"
+#       window: "1d"
+#       limit_usd: 2.00
+#       action_on_exhaust: deny

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -24,6 +24,7 @@ pub mod scenario;
 #[allow(dead_code)]
 pub mod sdk_driver;
 
+use rust_decimal::Decimal;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicI64, AtomicU64, AtomicUsize, Ordering};
@@ -369,6 +370,60 @@ impl TopologyTestEnv {
         let approval_queue = Arc::clone(&state.approval_queue);
         let budget_tracker = Arc::clone(&state.budget_tracker);
         let key_store = Arc::clone(&state.key_store);
+        let events = Arc::clone(&state.events);
+        let replay_buffer = state.replay_buffer.clone();
+        let next_event_id = Arc::clone(&state.next_event_id);
+        let ops_registry = Arc::clone(&state.ops_registry);
+
+        let port = portpicker::pick_unused_port().ok_or_else(|| anyhow::anyhow!("no free TCP port"))?;
+        let addr: SocketAddr = format!("127.0.0.1:{port}").parse()?;
+        let listener = tokio::net::TcpListener::bind(addr).await?;
+        let bound_addr = listener.local_addr()?;
+
+        let app = build_app(state);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+        let server_handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await;
+        });
+
+        let env = Self {
+            addr: bound_addr,
+            agent_registry,
+            trace_store,
+            approval_queue,
+            audit_dir,
+            budget_tracker,
+            alert_store,
+            key_store,
+            events,
+            replay_buffer,
+            next_event_id,
+            ops_registry,
+            shutdown_tx: Some(shutdown_tx),
+            server_handle: Some(server_handle),
+            cleaned: false,
+        };
+        env.await_ready().await?;
+        Ok(env)
+    }
+
+    /// Spin up the harness with a per-team daily spend cap.
+    ///
+    /// `team_limit_usd` is passed to `BudgetTracker::with_team_daily_limit`;
+    /// the cap applies equally to every team that records spend. Used by the
+    /// budget E2E suite (AAASM-1518 / F116 ST-F).
+    #[allow(dead_code)]
+    pub async fn start_with_team_budget(team_limit_usd: Decimal) -> anyhow::Result<Self> {
+        let (state, audit_dir, alert_store, key_store) = build_test_state_with_team_budget(team_limit_usd)?;
+        let agent_registry = Arc::clone(&state.agent_registry);
+        let trace_store = Arc::clone(&state.trace_store);
+        let approval_queue = Arc::clone(&state.approval_queue);
+        let budget_tracker = Arc::clone(&state.budget_tracker);
         let events = Arc::clone(&state.events);
         let replay_buffer = state.replay_buffer.clone();
         let next_event_id = Arc::clone(&state.next_event_id);
@@ -806,6 +861,121 @@ spec:
 
     let audit_id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let audit_dir = std::env::temp_dir().join(format!("aa-auth-it-audit-{}-{audit_id}", std::process::id()));
+    std::fs::create_dir_all(&audit_dir)?;
+    let audit_reader = Arc::new(AuditReader::new(audit_dir.clone()));
+
+    Ok((
+        AppState {
+            agent_registry,
+            policy_engine,
+            budget_tracker,
+            approval_queue,
+            policy_history,
+            alert_store,
+            events,
+            replay_buffer: ReplayBuffer::new(),
+            next_event_id: Arc::new(AtomicU64::new(0)),
+            auth_config,
+            key_store,
+            rate_limiter,
+            jwt_signer,
+            jwt_verifier,
+            trace_store: Arc::new(InMemoryTraceStore::new()),
+            audit_reader,
+            startup_time: Instant::now(),
+            active_connections: Arc::new(AtomicI64::new(0)),
+            discovery: Arc::new(DiscoveryService::with_adapters(vec![])),
+            edge_repo: Arc::new(InMemoryEdgeRepo::new()),
+            topology_overview_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(1))
+                .build(),
+            topology_tree_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(5))
+                .build(),
+            topology_team_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(5))
+                .build(),
+            topology_lineage_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(5))
+                .build(),
+            topology_stats_cache: moka::future::Cache::builder()
+                .time_to_live(Duration::from_secs(10))
+                .build(),
+            capability_store: aa_api::routes::capability::CapabilityStore::new_seeded(),
+            iam_api_key_store: aa_api::routes::iam::seeded_iam_store(),
+            ops_registry: Arc::new(OpsRegistry::new()),
+        },
+        audit_dir,
+        alert_store_handle,
+        key_store_handle,
+    ))
+}
+
+/// Build a minimal `AppState` with a per-team daily spend limit applied to the
+/// `BudgetTracker`. Identical to [`build_test_state`] except the tracker is
+/// constructed with `.with_team_daily_limit(team_limit_usd)`.
+///
+/// Used by [`TopologyTestEnv::start_with_team_budget`] (AAASM-1518 / F116 ST-F).
+fn build_test_state_with_team_budget(
+    team_limit_usd: Decimal,
+) -> anyhow::Result<(AppState, PathBuf, Arc<InMemoryAlertStore>, Arc<ApiKeyStore>)> {
+    let policy_id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let policy_dir = std::env::temp_dir().join(format!("aa-budget-it-policy-{}-{policy_id}", std::process::id()));
+    std::fs::create_dir_all(&policy_dir)?;
+    let policy_path = policy_dir.join("test-policy.yaml");
+    std::fs::write(
+        &policy_path,
+        r#"
+apiVersion: agent-assembly.dev/v1alpha1
+kind: GovernancePolicy
+metadata:
+  name: budget-it-policy
+  version: "0.1.0"
+spec:
+  rules: []
+"#,
+    )?;
+
+    let events = Arc::new(EventBroadcast::default());
+    let budget_alert_tx = events.budget_sender();
+    let policy_engine = Arc::new(
+        PolicyEngine::load_from_file(&policy_path, budget_alert_tx)
+            .map_err(|e| anyhow::anyhow!("load policy: {e:?}"))?,
+    );
+    let budget_tracker = Arc::new(
+        BudgetTracker::new(PricingTable::default_table(), None, None, chrono_tz::UTC)
+            .with_team_daily_limit(team_limit_usd),
+    );
+    let approval_queue = ApprovalQueue::new();
+    let agent_registry = Arc::new(AgentRegistry::new());
+
+    let history_id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let history_dir = std::env::temp_dir().join(format!("aa-budget-it-history-{}-{history_id}", std::process::id()));
+    let policy_history = Arc::new(FsHistoryStore::new(HistoryConfig {
+        history_dir,
+        max_versions: 50,
+    }));
+
+    let auth_config = Arc::new(AuthConfig {
+        mode: AuthMode::Off,
+        jwt_secret: None,
+        api_keys_path: std::path::PathBuf::from("/dev/null"),
+        rate_limit_rpm: 1000,
+    });
+    let key_store = Arc::new(
+        ApiKeyStore::load(Path::new("/dev/null"))
+            .unwrap_or_else(|_| ApiKeyStore::load(Path::new("/nonexistent")).expect("empty key store")),
+    );
+    let key_store_handle = Arc::clone(&key_store);
+    const TEST_SECRET: &[u8] = b"budget-it-test-secret-32-bytes-long!!!!";
+    let jwt_signer = Arc::new(JwtSigner::new(TEST_SECRET));
+    let jwt_verifier = Arc::new(JwtVerifier::new(TEST_SECRET));
+    let rate_limiter = Arc::new(RateLimiter::new(1000));
+    let alert_store: Arc<InMemoryAlertStore> = Arc::new(InMemoryAlertStore::new());
+    let alert_store_handle = Arc::clone(&alert_store);
+
+    let audit_id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let audit_dir = std::env::temp_dir().join(format!("aa-budget-it-audit-{}-{audit_id}", std::process::id()));
     std::fs::create_dir_all(&audit_dir)?;
     let audit_reader = Arc::new(AuditReader::new(audit_dir.clone()));
 

--- a/aa-integration-tests/tests/e2e_budget.rs
+++ b/aa-integration-tests/tests/e2e_budget.rs
@@ -1,0 +1,269 @@
+//! AAASM-1518 / F116 ST-F — E2E budget enforcement tests.
+//!
+//! Verifies that per-team daily spend accumulates correctly across calls and
+//! that `BudgetStatus::LimitExceeded` is returned once the configured team
+//! cap is reached. The HTTP plane (`GET /api/v1/costs`) is asserted in parallel
+//! to verify the budget tracker and HTTP layer agree.
+//!
+//! ## Platform divergences vs ticket AC
+//!
+//! | AC item | Divergence | Reason |
+//! |---|---|---|
+//! | Token-count tracking (`limit_tokens: 1000`) | USD amounts via `record_raw_spend` | `BudgetTracker` tracks USD spend, not raw tokens |
+//! | Python SDK driver + mock LLM server | In-process `record_raw_spend` seeding | No HTTP route for spend ingestion; same pattern as `api_costs.rs` |
+//! | Sub-day window (`window: "5s"`) | TC-4 marked `#[ignore]` | `BudgetTracker` resets at midnight UTC only; sub-day windows not in v0.0.1 |
+//! | `BudgetExhaustedError` from SDK | `BudgetStatus::LimitExceeded` from tracker | No SDK layer in integration harness |
+//!
+//! ## Seeding strategy
+//!
+//! `env.budget_tracker.record_raw_spend(AgentId, Option<&str>, Decimal)`
+//! injects spend and returns `BudgetStatus` synchronously — the same pattern
+//! used by `api_costs.rs` (AAASM-1490 / F122 ST-I).
+
+mod common;
+
+use aa_core::AgentId;
+use aa_gateway::budget::BudgetStatus;
+use common::TopologyTestEnv;
+use rust_decimal::Decimal;
+
+// ── Agent / team IDs (distinct from topology-it and cost-it suites) ───────────
+
+const BUDGET_AGENT_A: [u8; 16] = [0xba, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01];
+const BUDGET_AGENT_B: [u8; 16] = [0xba, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x02];
+const TEAM_A: &str = "f116-budget-it-a";
+const TEAM_B: &str = "f116-budget-it-b";
+
+fn agent_hex(bytes: &[u8; 16]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+// ── TC-1: spend accumulates per-agent and per-team ────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn budget_spend_accumulates_per_agent_and_team() {
+    let env = TopologyTestEnv::start().await.expect("harness should start");
+    let agent = AgentId::from_bytes(BUDGET_AGENT_A);
+
+    for _ in 0..5 {
+        env.budget_tracker
+            .record_raw_spend(agent, Some(TEAM_A), Decimal::new(50, 2)); // 0.50 USD each
+    }
+
+    let agent_state = env
+        .budget_tracker
+        .agent_state(&agent)
+        .expect("agent state should be present after seeding");
+    assert_eq!(
+        agent_state.spent_usd,
+        Decimal::new(250, 2),
+        "agent should have 2.50 USD accumulated after 5 × 0.50 USD calls"
+    );
+
+    let team_state = env
+        .budget_tracker
+        .team_state(TEAM_A)
+        .expect("team state should be present after seeding");
+    assert_eq!(
+        team_state.spent_usd,
+        Decimal::new(250, 2),
+        "team should have 2.50 USD accumulated after 5 × 0.50 USD calls"
+    );
+
+    let body: serde_json::Value = reqwest::get(format!("{}/api/v1/costs", env.base_url()))
+        .await
+        .expect("GET /api/v1/costs")
+        .json()
+        .await
+        .expect("body as JSON");
+
+    let agents = body["per_agent"].as_array().expect("per_agent array");
+    let hex = agent_hex(&BUDGET_AGENT_A);
+    let agent_entry = agents
+        .iter()
+        .find(|e| e["agent_id"].as_str() == Some(&hex))
+        .expect("per_agent should contain the seeded agent");
+    assert_eq!(
+        agent_entry["daily_spend_usd"].as_str(),
+        Some("2.50"),
+        "HTTP per_agent daily_spend_usd should be 2.50"
+    );
+
+    let teams = body["per_team"].as_array().expect("per_team array");
+    let team_entry = teams
+        .iter()
+        .find(|e| e["team_id"].as_str() == Some(TEAM_A))
+        .expect("per_team should contain the seeded team");
+    assert_eq!(
+        team_entry["daily_spend_usd"].as_str(),
+        Some("2.50"),
+        "HTTP per_team daily_spend_usd should be 2.50"
+    );
+}
+
+// ── TC-2: limit exceeded returns LimitExceeded status ────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn budget_deny_at_exhaustion_returns_limit_exceeded() {
+    // Team daily cap: 2.00 USD.
+    let env = TopologyTestEnv::start_with_team_budget(Decimal::new(200, 2))
+        .await
+        .expect("harness should start with team budget");
+    let agent = AgentId::from_bytes(BUDGET_AGENT_A);
+
+    // 1.80 USD — within the 2.00 USD cap.
+    let status_before = env
+        .budget_tracker
+        .record_raw_spend(agent, Some(TEAM_A), Decimal::new(180, 2));
+    assert!(
+        matches!(
+            status_before,
+            BudgetStatus::WithinBudget { .. } | BudgetStatus::ThresholdAlert { .. }
+        ),
+        "1.80 USD should be within the 2.00 USD cap, got: {status_before:?}"
+    );
+
+    // Additional 0.50 USD pushes total to 2.30 — over the cap.
+    let status_over = env
+        .budget_tracker
+        .record_raw_spend(agent, Some(TEAM_A), Decimal::new(50, 2));
+    assert_eq!(
+        status_over,
+        BudgetStatus::LimitExceeded,
+        "exceeding the 2.00 USD team daily limit should return LimitExceeded"
+    );
+}
+
+// ── TC-3: enforcement is per-call — subsequent calls after exhaustion also denied
+
+#[tokio::test(flavor = "multi_thread")]
+async fn budget_exhausted_request_is_rejected_at_tracking_layer() {
+    // Team daily cap: 1.00 USD.
+    let env = TopologyTestEnv::start_with_team_budget(Decimal::new(100, 2))
+        .await
+        .expect("harness should start with team budget");
+    let agent = AgentId::from_bytes(BUDGET_AGENT_A);
+
+    // Push team over the cap in one call.
+    env.budget_tracker
+        .record_raw_spend(agent, Some(TEAM_A), Decimal::new(150, 2)); // 1.50 > 1.00
+
+    // A subsequent call must still return LimitExceeded — proving enforcement
+    // is checked on every call, not just the first one that crosses the limit.
+    let follow_up = env
+        .budget_tracker
+        .record_raw_spend(agent, Some(TEAM_A), Decimal::new(10, 2));
+    assert_eq!(
+        follow_up,
+        BudgetStatus::LimitExceeded,
+        "follow-up call after limit exceeded should still return LimitExceeded"
+    );
+
+    // The HTTP layer reflects the accumulated spend.
+    let body: serde_json::Value = reqwest::get(format!("{}/api/v1/costs", env.base_url()))
+        .await
+        .expect("GET /api/v1/costs")
+        .json()
+        .await
+        .expect("body as JSON");
+    let teams = body["per_team"].as_array().expect("per_team array");
+    let team_entry = teams
+        .iter()
+        .find(|e| e["team_id"].as_str() == Some(TEAM_A))
+        .expect("per_team should contain the seeded team");
+    let spent: Decimal = team_entry["daily_spend_usd"]
+        .as_str()
+        .expect("daily_spend_usd string")
+        .parse()
+        .expect("parseable Decimal");
+    assert!(
+        spent >= Decimal::new(150, 2),
+        "HTTP per_team spend should reflect ≥ 1.50 USD accumulated, got: {spent}"
+    );
+}
+
+// ── TC-4: sub-day window rollover (ignored — not implemented in v0.0.1) ───────
+
+/// Budget spend resets after the configured time window elapses.
+///
+/// Marked `#[ignore]` because `BudgetTracker` only resets at midnight UTC;
+/// sub-day budget windows (e.g. `window: "5s"`) are not supported in v0.0.1.
+/// Remove the `#[ignore]` and implement once a configurable flush interval is
+/// added to `BudgetTracker`.
+#[ignore]
+#[tokio::test(flavor = "multi_thread")]
+async fn budget_resets_after_daily_window() {
+    unimplemented!(
+        "sub-day budget window rollover not supported in v0.0.1 (BudgetTracker resets at midnight UTC only)"
+    );
+}
+
+// ── TC-5: per-team isolation — exhausting team A does not block team B ─────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn budget_per_team_isolation_prevents_cross_team_bleed() {
+    // Both teams share a 2.00 USD daily cap.
+    let env = TopologyTestEnv::start_with_team_budget(Decimal::new(200, 2))
+        .await
+        .expect("harness should start with team budget");
+    let agent_a = AgentId::from_bytes(BUDGET_AGENT_A);
+    let agent_b = AgentId::from_bytes(BUDGET_AGENT_B);
+
+    // Exhaust team A: 2.50 USD > 2.00 USD cap.
+    let status_a = env
+        .budget_tracker
+        .record_raw_spend(agent_a, Some(TEAM_A), Decimal::new(250, 2));
+    assert_eq!(status_a, BudgetStatus::LimitExceeded, "team A should be over its cap");
+
+    // Team B: 1.00 USD — independent cap, should be allowed.
+    let status_b = env
+        .budget_tracker
+        .record_raw_spend(agent_b, Some(TEAM_B), Decimal::new(100, 2));
+    assert!(
+        matches!(
+            status_b,
+            BudgetStatus::WithinBudget { .. } | BudgetStatus::ThresholdAlert { .. }
+        ),
+        "team B should be within budget even after team A is exhausted, got: {status_b:?}"
+    );
+}
+
+// ── TC-6: partial spend charged exactly — no rounding or double-counting ───────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn budget_partial_spend_charged_exactly() {
+    let env = TopologyTestEnv::start().await.expect("harness should start");
+    let agent = AgentId::from_bytes(BUDGET_AGENT_A);
+
+    // Seed a non-round amount: 1.37 USD.
+    env.budget_tracker
+        .record_raw_spend(agent, Some(TEAM_A), Decimal::new(137, 2));
+
+    let agent_state = env
+        .budget_tracker
+        .agent_state(&agent)
+        .expect("agent state should be present");
+    assert_eq!(
+        agent_state.spent_usd,
+        Decimal::new(137, 2),
+        "agent spend should be exactly 1.37 USD without rounding or truncation"
+    );
+
+    let body: serde_json::Value = reqwest::get(format!("{}/api/v1/costs", env.base_url()))
+        .await
+        .expect("GET /api/v1/costs")
+        .json()
+        .await
+        .expect("body as JSON");
+    let agents = body["per_agent"].as_array().expect("per_agent array");
+    let hex = agent_hex(&BUDGET_AGENT_A);
+    let entry = agents
+        .iter()
+        .find(|e| e["agent_id"].as_str() == Some(&hex))
+        .expect("per_agent should contain the seeded agent");
+    assert_eq!(
+        entry["daily_spend_usd"].as_str(),
+        Some("1.37"),
+        "HTTP per_agent daily_spend_usd should be exactly '1.37'"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `e2e_budget.rs` with **6 budget enforcement tests** (5 active + 1 `#[ignore]`) covering per-team daily spend accumulation, `LimitExceeded` enforcement, cross-team isolation, persistent denial after exhaustion, and exact decimal precision.
- Adds `TopologyTestEnv::start_with_team_budget(limit)` harness helper that wires `BudgetTracker::with_team_daily_limit` at construction time.
- Adds two reference policy YAML fixtures documenting the governance-policy representation of the team budget config.

## Platform divergences vs AC

| AC item | Divergence | Reason |
|---|---|---|
| Token-count tracking (`limit_tokens: 1000`) | USD amounts via `record_raw_spend` | `BudgetTracker` tracks USD spend, not raw token counts |
| Python SDK driver + mock LLM server | In-process `record_raw_spend` seeding | No HTTP route for spend ingestion; same pattern as `api_costs.rs` (AAASM-1490) |
| Sub-day window (`window: "5s"`) | TC-4 `#[ignore]` | `BudgetTracker` resets at midnight UTC only; sub-day windows not in v0.0.1 |
| `BudgetExhaustedError` from SDK | `BudgetStatus::LimitExceeded` from tracker | No SDK layer in integration harness |

## Budget gRPC contract note

The SDK does **not** pre-check the budget. Spend is recorded post-call via `record_raw_spend`/`record_usage`, which returns `BudgetStatus::LimitExceeded` synchronously. The policy engine (Stage 7) calls `check_daily`/`check_monthly` to gate the *next* call — enforcement is reactive (check before the next call), not pre-emptive (block before the current call reaches the LLM). This means the spend that crosses the limit *is* recorded; denial applies to the subsequent call.

## Test plan

- `cargo nextest run --test e2e_budget` → 5 passed, 1 skipped (TC-4 `#[ignore]`)
- All existing integration test suites remain green (verified locally)

Closes AAASM-1518

🤖 Generated with [Claude Code](https://claude.com/claude-code)