### PR TITLE
[AAASM-1546] ✨ (policy): Add credential_action enum (block | redact_only | alert_only)

### DIFF
--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -26,7 +26,7 @@ use crate::budget::BudgetTracker;
 
 use crate::engine::decision::{merge_decisions, PolicyDecision};
 use crate::engine::scope_index::ScopeIndex;
-use crate::policy::document::ActionOnExceed;
+use crate::policy::document::{ActionOnExceed, CredentialAction};
 use crate::policy::{PolicyDocument, PolicyValidator};
 use crate::registry::AgentRegistry;
 
@@ -490,6 +490,22 @@ impl PolicyEngine {
             for m in re.find_iter(text) {
                 all_findings.push(aa_core::CredentialFinding::from_regex_match(m.start(), m.end()));
             }
+        }
+
+        let credential_action = policy.data.as_ref().map(|d| d.credential_action).unwrap_or_default();
+
+        // Hard-block path: a finding with `credential_action: block` short-circuits
+        // every downstream stage so the payload never reaches the LLM in any form.
+        if credential_action == CredentialAction::Block && !all_findings.is_empty() {
+            all_findings.sort_by_key(|f| f.offset);
+            return EvaluationResult {
+                decision: aa_core::PolicyResult::Deny {
+                    reason: "credential detected".into(),
+                },
+                redacted_payload: None,
+                credential_findings: all_findings,
+                deny_action: None,
+            };
         }
 
         let (redacted_payload, credential_findings) = if all_findings.is_empty() {

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1343,6 +1343,28 @@ mod tests {
     }
 
     #[test]
+    fn data_pattern_blocks_when_credential_action_is_block() {
+        let mut doc = empty_doc();
+        doc.data = Some(DataPolicy {
+            sensitive_patterns: vec![r"password=\w+".to_string()],
+            credential_action: CredentialAction::Block,
+        });
+        let engine = make_engine(doc);
+        let ctx = make_ctx();
+        let action = tool_call("any", "password=secret");
+        let result = engine.evaluate(&ctx, &action);
+        assert_eq!(
+            result.decision,
+            PolicyResult::Deny {
+                reason: "credential detected".into(),
+            }
+        );
+        assert!(!result.credential_findings.is_empty());
+        // Block must never produce a redacted form — the payload is rejected outright.
+        assert!(result.redacted_payload.is_none());
+    }
+
+    #[test]
     fn budget_denies_when_exceeded() {
         let mut doc = empty_doc();
         doc.budget = Some(BudgetPolicy {

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1365,6 +1365,23 @@ mod tests {
     }
 
     #[test]
+    fn data_pattern_forwards_when_credential_action_is_alert_only() {
+        let mut doc = empty_doc();
+        doc.data = Some(DataPolicy {
+            sensitive_patterns: vec![r"password=\w+".to_string()],
+            credential_action: CredentialAction::AlertOnly,
+        });
+        let engine = make_engine(doc);
+        let ctx = make_ctx();
+        let action = tool_call("any", "password=secret");
+        let result = engine.evaluate(&ctx, &action);
+        assert_eq!(result.decision, PolicyResult::Allow);
+        assert!(!result.credential_findings.is_empty());
+        // Alert-only mode forwards the payload unmodified — no redacted form is set.
+        assert!(result.redacted_payload.is_none());
+    }
+
+    #[test]
     fn budget_denies_when_exceeded() {
         let mut doc = empty_doc();
         doc.budget = Some(BudgetPolicy {

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -709,19 +709,52 @@ impl PolicyEngine {
                 }
             }
         }
+
+        // Most-restrictive-wins across the cascade: Block > RedactOnly > AlertOnly.
+        // Docs without a `data` section don't vote — RedactOnly remains the default.
+        let credential_action = cascade
+            .iter()
+            .filter_map(|d| d.data.as_ref().map(|dp| dp.credential_action))
+            .max_by_key(|a| match a {
+                CredentialAction::Block => 2,
+                CredentialAction::RedactOnly => 1,
+                CredentialAction::AlertOnly => 0,
+            })
+            .unwrap_or_default();
+
+        if credential_action == CredentialAction::Block && !all_findings.is_empty() {
+            all_findings.sort_by_key(|f| f.offset);
+            return EvaluationResult {
+                decision: aa_core::PolicyResult::Deny {
+                    reason: "credential detected".into(),
+                },
+                redacted_payload: None,
+                credential_findings: all_findings,
+                deny_action: None,
+            };
+        }
+
         let (redacted_payload, credential_findings) = if all_findings.is_empty() {
             (None, vec![])
         } else {
             all_findings.sort_by_key(|f| f.offset);
-            let merged = aa_core::ScanResult {
-                findings: all_findings.clone(),
-            };
-            let redacted = merged.redact(text);
             tracing::warn!(
                 finding_count = all_findings.len(),
                 "DataLeakEvent emission pending AAASM-31 EnrichedEvent::DataLeak variant"
             );
-            (Some(redacted), all_findings)
+            if credential_action == CredentialAction::AlertOnly {
+                tracing::warn!(
+                    finding_count = all_findings.len(),
+                    "credential_action=alert_only: alert emission pending AAASM-1545"
+                );
+                (None, all_findings)
+            } else {
+                let merged = aa_core::ScanResult {
+                    findings: all_findings.clone(),
+                };
+                let redacted = merged.redact(text);
+                (Some(redacted), all_findings)
+            }
         };
 
         // Stage 7 — Budget: check against all cascade docs' budget configs.

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -513,10 +513,6 @@ impl PolicyEngine {
         } else {
             // Sort by offset for deterministic redaction order.
             all_findings.sort_by_key(|f| f.offset);
-            let merged = aa_core::ScanResult {
-                findings: all_findings.clone(),
-            };
-            let redacted = merged.redact(text);
             // TODO(AAASM-31): wrap in EnrichedEvent::DataLeak(DataLeakEvent { ... }) and
             // send on the broadcast_tx once AAASM-31 adds the DataLeak variant to EnrichedEvent.
             // DataLeakEvent fields are available here:
@@ -530,7 +526,21 @@ impl PolicyEngine {
                 finding_count = all_findings.len(),
                 "DataLeakEvent emission pending AAASM-31 EnrichedEvent::DataLeak variant"
             );
-            (Some(redacted), all_findings)
+            if credential_action == CredentialAction::AlertOnly {
+                // Forward the unmodified payload upstream; alert side-effect emission
+                // is wired by sibling subtask AAASM-1545.
+                tracing::warn!(
+                    finding_count = all_findings.len(),
+                    "credential_action=alert_only: alert emission pending AAASM-1545"
+                );
+                (None, all_findings)
+            } else {
+                let merged = aa_core::ScanResult {
+                    findings: all_findings.clone(),
+                };
+                let redacted = merged.redact(text);
+                (Some(redacted), all_findings)
+            }
         };
 
         // Stage 7 — Budget check (monthly first, then daily).

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1005,8 +1005,8 @@ impl aa_core::PolicyEvaluator for PolicyEngine {
 mod tests {
     use super::*;
     use crate::policy::document::{
-        ActionOnExceed, ActiveHours, BudgetPolicy, DataPolicy, NetworkPolicy, PolicyDocument, SchedulePolicy,
-        ToolPolicy,
+        ActionOnExceed, ActiveHours, BudgetPolicy, CredentialAction, DataPolicy, NetworkPolicy, PolicyDocument,
+        SchedulePolicy, ToolPolicy,
     };
     use aa_core::{
         identity::{AgentId, SessionId},
@@ -1301,6 +1301,7 @@ mod tests {
         let mut doc = empty_doc();
         doc.data = Some(DataPolicy {
             sensitive_patterns: vec![r"password=\w+".to_string()],
+            credential_action: CredentialAction::default(),
         });
         let engine = make_engine(doc);
         let ctx = make_ctx();
@@ -1504,6 +1505,7 @@ mod tests {
         );
         doc.data = Some(DataPolicy {
             sensitive_patterns: vec![".*".to_string()],
+            credential_action: CredentialAction::default(),
         });
         let engine = make_engine(doc);
         let ctx = make_ctx();
@@ -1618,6 +1620,7 @@ mod tests {
         let mut doc = empty_doc();
         doc.data = Some(DataPolicy {
             sensitive_patterns: vec![r"api_key=[A-Za-z0-9]+".to_string()],
+            credential_action: CredentialAction::default(),
         });
         let engine = make_engine(doc);
         let ctx = make_ctx();

--- a/aa-gateway/src/policy/document.rs
+++ b/aa-gateway/src/policy/document.rs
@@ -71,6 +71,10 @@ pub enum CredentialAction {
 pub struct DataPolicy {
     /// Compiled regex patterns for PII / credential detection.
     pub sensitive_patterns: Vec<String>,
+    /// Action to take when the scanner produces a finding. Defaults to
+    /// [`CredentialAction::RedactOnly`] so policies that omit the field
+    /// keep the historical behaviour.
+    pub credential_action: CredentialAction,
 }
 
 /// Per-policy approval escalation overrides.

--- a/aa-gateway/src/policy/document.rs
+++ b/aa-gateway/src/policy/document.rs
@@ -50,6 +50,22 @@ pub struct BudgetPolicy {
     pub action_on_exceed: ActionOnExceed,
 }
 
+/// Action to take when the credential / sensitive-data scanner produces
+/// a finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CredentialAction {
+    /// Refuse the action: engine returns `Deny` with reason
+    /// `"credential detected"`; upstream never receives the payload.
+    Block,
+    /// Forward a redacted form of the payload upstream (default; preserves
+    /// the historical behaviour from before this enum existed).
+    #[default]
+    RedactOnly,
+    /// Forward the unmodified payload and raise an alert side-effect.
+    /// Documented as a deliberate downgrade for low-risk audit-only modes.
+    AlertOnly,
+}
+
 /// Validated data / PII policy.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DataPolicy {
@@ -150,5 +166,10 @@ mod tests {
         };
         assert!(tp.allow);
         assert!(tp.limit_per_hour.is_none());
+    }
+
+    #[test]
+    fn credential_action_default_is_redact_only() {
+        assert_eq!(CredentialAction::default(), CredentialAction::RedactOnly);
     }
 }

--- a/aa-gateway/src/policy/raw.rs
+++ b/aa-gateway/src/policy/raw.rs
@@ -59,6 +59,9 @@ pub struct RawBudgetPolicy {
 pub struct RawDataPolicy {
     /// Regex patterns for PII / credential detection.
     pub sensitive_patterns: Option<Vec<String>>,
+    /// Action taken on a finding: `"block"`, `"redact_only"` (default),
+    /// or `"alert_only"`. Validated into a [`crate::policy::document::CredentialAction`].
+    pub credential_action: Option<String>,
     /// Unknown keys captured for warning emission.
     #[serde(flatten)]
     pub unknown: HashMap<String, serde_yaml::Value>,
@@ -303,6 +306,13 @@ mod tests {
         let yaml = "{}\n";
         let raw: RawDataPolicy = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(raw.sensitive_patterns, None);
+    }
+
+    #[test]
+    fn raw_data_deserializes_credential_action() {
+        let yaml = "credential_action: block\n";
+        let raw: RawDataPolicy = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(raw.credential_action.as_deref(), Some("block"));
     }
 
     // ── RawToolPolicy ───────────────────────────────────────────────────────

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -557,6 +557,14 @@ mod tests {
         assert_eq!(dp.sensitive_patterns.len(), 1);
     }
 
+    #[test]
+    fn data_credential_action_block_parses() {
+        let yaml = "data:\n  credential_action: block\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        let dp = out.document.data.unwrap();
+        assert_eq!(dp.credential_action, CredentialAction::Block);
+    }
+
     // ── Budget validation ───────────────────────────────────────────────────
 
     #[test]

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -308,9 +308,22 @@ impl PolicyValidator {
             }
         }
 
+        let credential_action = match raw.credential_action.as_deref() {
+            None | Some("redact_only") => CredentialAction::RedactOnly,
+            Some("block") => CredentialAction::Block,
+            Some("alert_only") => CredentialAction::AlertOnly,
+            Some(other) => {
+                errors.push(ValidationError::new(
+                    "data.credential_action",
+                    format!("must be 'block', 'redact_only', or 'alert_only', got '{}'", other),
+                ));
+                CredentialAction::RedactOnly
+            }
+        };
+
         Some(DataPolicy {
             sensitive_patterns: patterns,
-            credential_action: CredentialAction::default(),
+            credential_action,
         })
     }
 

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 
 use crate::policy::{
     document::{
-        ActionOnExceed, ActiveHours, ApprovalPolicy, BudgetPolicy, DataPolicy, NetworkPolicy, PolicyDocument,
-        SchedulePolicy, ToolPolicy,
+        ActionOnExceed, ActiveHours, ApprovalPolicy, BudgetPolicy, CredentialAction, DataPolicy, NetworkPolicy,
+        PolicyDocument, SchedulePolicy, ToolPolicy,
     },
     error::{ValidationError, ValidationWarning},
     raw::{GovernancePolicyEnvelope, RawPolicyDocument},
@@ -310,6 +310,7 @@ impl PolicyValidator {
 
         Some(DataPolicy {
             sensitive_patterns: patterns,
+            credential_action: CredentialAction::default(),
         })
     }
 

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -573,6 +573,15 @@ mod tests {
         assert_eq!(dp.credential_action, CredentialAction::AlertOnly);
     }
 
+    #[test]
+    fn data_credential_action_invalid_value_is_an_error() {
+        let yaml = "data:\n  credential_action: not_a_real_mode\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err());
+        let errs = result.unwrap_err();
+        assert!(errs.iter().any(|e| e.field == "data.credential_action"));
+    }
+
     // ── Budget validation ───────────────────────────────────────────────────
 
     #[test]

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -565,6 +565,14 @@ mod tests {
         assert_eq!(dp.credential_action, CredentialAction::Block);
     }
 
+    #[test]
+    fn data_credential_action_alert_only_parses() {
+        let yaml = "data:\n  credential_action: alert_only\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        let dp = out.document.data.unwrap();
+        assert_eq!(dp.credential_action, CredentialAction::AlertOnly);
+    }
+
     // ── Budget validation ───────────────────────────────────────────────────
 
     #[test]

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -405,4 +405,20 @@ mod tests {
         assert_eq!(resp.reason, "credential detected");
         assert!(resp.redact.is_none());
     }
+
+    #[test]
+    fn eval_with_allow_and_findings_but_no_redacted_payload_maps_to_allow() {
+        // credential_action: alert_only → engine returns Allow + findings but
+        // leaves redacted_payload = None. The wire response must be
+        // Decision::Allow so the payload is forwarded unmodified.
+        let eval = EvaluationResult {
+            decision: PolicyResult::Allow,
+            redacted_payload: None,
+            credential_findings: vec![aa_core::CredentialFinding::from_regex_match(0, 4)],
+            deny_action: None,
+        };
+        let resp = eval_result_to_response(&eval, 0, "");
+        assert_eq!(resp.decision, Decision::Allow as i32);
+        assert!(resp.redact.is_none());
+    }
 }

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -387,4 +387,22 @@ mod tests {
         assert_eq!(proto.team_id, "");
         assert_eq!(proto.routing_status, "no_team_id");
     }
+
+    #[test]
+    fn eval_with_deny_and_findings_maps_to_decision_deny() {
+        // credential_action: block → engine returns Deny *and* findings populated.
+        // The wire response must still be Decision::Deny — no Redact instructions.
+        let eval = EvaluationResult {
+            decision: PolicyResult::Deny {
+                reason: "credential detected".into(),
+            },
+            redacted_payload: None,
+            credential_findings: vec![aa_core::CredentialFinding::from_regex_match(0, 4)],
+            deny_action: None,
+        };
+        let resp = eval_result_to_response(&eval, 0, "data_pattern_scan");
+        assert_eq!(resp.decision, Decision::Deny as i32);
+        assert_eq!(resp.reason, "credential detected");
+        assert!(resp.redact.is_none());
+    }
 }

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -142,11 +142,32 @@ pub fn request_to_core(req: &CheckActionRequest) -> Result<(AgentContext, Govern
 /// `latency_us` is the measured evaluation wall time in microseconds.
 /// `policy_rule` is the identifier of the rule that triggered (empty for Allow).
 ///
-/// When the engine detected credential/PII findings and produced a redacted payload,
-/// the response uses `Decision::Redact` with the redacted field paths.
+/// Mapping rules:
+/// * `decision == Deny` → `Decision::Deny` (covers `credential_action: block`,
+///   which short-circuits with findings *and* a Deny verdict).
+/// * findings non-empty *and* `redacted_payload.is_some()` →
+///   `Decision::Redact` (covers `credential_action: redact_only`).
+/// * findings non-empty *and* `redacted_payload.is_none()` →
+///   `Decision::Allow` (covers `credential_action: alert_only`, where the
+///   payload is forwarded unmodified; the alert side-effect is wired
+///   separately).
+/// * everything else falls through to the underlying `PolicyResult`.
 pub fn eval_result_to_response(eval: &EvaluationResult, latency_us: i64, policy_rule: &str) -> CheckActionResponse {
-    // If the scanner produced redaction findings, return REDACT with instructions.
-    if !eval.credential_findings.is_empty() {
+    // Deny short-circuits everything, including the findings-driven Redact path,
+    // so `credential_action: block` returns a hard Deny even though findings exist.
+    if let PolicyResult::Deny { reason } = &eval.decision {
+        return CheckActionResponse {
+            decision: Decision::Deny as i32,
+            reason: reason.clone(),
+            policy_rule: policy_rule.to_string(),
+            approval_id: String::new(),
+            redact: None,
+            decision_latency_us: latency_us,
+        };
+    }
+
+    // Findings + redacted payload → Redact instructions.
+    if !eval.credential_findings.is_empty() && eval.redacted_payload.is_some() {
         let rules: Vec<RedactRule> = eval
             .credential_findings
             .iter()
@@ -174,14 +195,7 @@ pub fn eval_result_to_response(eval: &EvaluationResult, latency_us: i64, policy_
             redact: None,
             decision_latency_us: latency_us,
         },
-        PolicyResult::Deny { reason } => CheckActionResponse {
-            decision: Decision::Deny as i32,
-            reason: reason.clone(),
-            policy_rule: policy_rule.to_string(),
-            approval_id: String::new(),
-            redact: None,
-            decision_latency_us: latency_us,
-        },
+        PolicyResult::Deny { .. } => unreachable!("Deny is handled by the short-circuit above"),
         PolicyResult::RequiresApproval { .. } => {
             panic!(
                 "RequiresApproval must be handled before conversion — \

--- a/aa-gateway/tests/cascade_credential_action_test.rs
+++ b/aa-gateway/tests/cascade_credential_action_test.rs
@@ -1,0 +1,99 @@
+//! Cascade test for credential_action most-restrictive-wins (AAASM-1546).
+//!
+//! When two cascade docs disagree on `credential_action`, the engine must pick
+//! the strictest mode (Block > RedactOnly > AlertOnly). A Block in any doc
+//! short-circuits the scan with `Deny { "credential detected" }` and never
+//! produces a redacted payload.
+
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::io::Write;
+
+use aa_core::identity::{AgentId, SessionId};
+use aa_core::{AgentContext, GovernanceAction, GovernanceLevel, PolicyResult};
+use aa_gateway::engine::PolicyEngine;
+use aa_gateway::policy::document::{CredentialAction, DataPolicy, PolicyDocument};
+use aa_gateway::policy::scope::PolicyScope;
+
+fn make_engine() -> PolicyEngine {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    writeln!(tmp, "version: \"1\"").unwrap();
+    tmp.flush().unwrap();
+    let (alert_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    PolicyEngine::load_from_file(tmp.path(), alert_tx).unwrap()
+}
+
+fn data_doc(scope: PolicyScope, pattern: &str, action: CredentialAction) -> PolicyDocument {
+    PolicyDocument {
+        name: None,
+        policy_version: None,
+        version: None,
+        scope,
+        network: None,
+        schedule: None,
+        budget: None,
+        data: Some(DataPolicy {
+            sensitive_patterns: vec![pattern.to_string()],
+            credential_action: action,
+        }),
+        approval_timeout_secs: 300,
+        approval_policy: None,
+        tools: HashMap::new(),
+        capabilities: None,
+    }
+}
+
+fn make_ctx(id: u8) -> AgentContext {
+    AgentContext {
+        agent_id: AgentId::from_bytes([id; 16]),
+        session_id: SessionId::from_bytes([0u8; 16]),
+        pid: 0,
+        started_at: aa_core::time::Timestamp::from_nanos(0),
+        metadata: BTreeMap::new(),
+        governance_level: GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: None,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: None,
+    }
+}
+
+fn tool_action(args: &str) -> GovernanceAction {
+    GovernanceAction::ToolCall {
+        name: "leak".to_string(),
+        args: args.to_string(),
+    }
+}
+
+#[test]
+fn cascade_block_in_any_doc_wins_over_redact_only() {
+    let agent_id = AgentId::from_bytes([7u8; 16]);
+    let mut engine = make_engine();
+    // Global says redact_only; Agent says block. Block must win.
+    engine.load_policy(data_doc(
+        PolicyScope::Global,
+        r"password=\w+",
+        CredentialAction::RedactOnly,
+    ));
+    engine.load_policy(data_doc(
+        PolicyScope::Agent(agent_id),
+        r"password=\w+",
+        CredentialAction::Block,
+    ));
+
+    let ctx = make_ctx(7);
+    let action = tool_action("password=hunter2");
+    let result = engine.evaluate(&ctx, &action);
+
+    assert_eq!(
+        result.decision,
+        PolicyResult::Deny {
+            reason: "credential detected".into(),
+        }
+    );
+    assert!(!result.credential_findings.is_empty());
+    // Block must never produce a redacted payload — the request is rejected outright.
+    assert!(result.redacted_payload.is_none());
+}


### PR DESCRIPTION
## Description

Adds a configurable `credential_action` to `data:` in policy YAML so operators can choose what happens when the credential scanner produces a finding.

| Mode          | Wire decision           | redacted_payload | Behaviour                                                       |
|---------------|-------------------------|------------------|-----------------------------------------------------------------|
| `block`       | `Decision::Deny`        | `None`           | Hard reject; payload never reaches the LLM, no redacted form.   |
| `redact_only` | `Decision::Redact`      | `Some(redacted)` | **Default** — historical behaviour preserved.                   |
| `alert_only`  | `Decision::Allow`       | `None`           | Forward unmodified; alert side-effect keyed to AAASM-1545.      |

Wiring threads through `RawDataPolicy` → `validator` → `DataPolicy` → `PolicyEngine` (both `evaluate_primary` and `evaluate_with_cascade`, where most-restrictive-wins ordering is `Block > RedactOnly > AlertOnly`) → `eval_result_to_response`.

`redact_only` is the default, so any existing YAML that omits the field keeps its current behaviour — fully back-compatible.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-1546](https://lightning-dust-mite.atlassian.net/browse/AAASM-1546) — F116 ST-I follow-up
- Parent Story: [AAASM-1232](https://lightning-dust-mite.atlassian.net/browse/AAASM-1232) (F116 MVP acceptance)
- Epic: [AAASM-1199](https://lightning-dust-mite.atlassian.net/browse/AAASM-1199)
- Unblocks the deferred secret-detection E2E tests in [AAASM-1521](https://lightning-dust-mite.atlassian.net/browse/AAASM-1521): `secret_aws_key_in_request_body_detected_and_blocked` and `secret_policy_redact_only_lets_call_through_but_strips_secret`.
- Sibling follow-ups still pending: [AAASM-1545](https://lightning-dust-mite.atlassian.net/browse/AAASM-1545) (alert emission for `alert_only`), [AAASM-1544](https://lightning-dust-mite.atlassian.net/browse/AAASM-1544) (audit-log propagation).

## Testing

- [x] Unit tests added (8 new tests across `policy/raw.rs`, `policy/document.rs`, `policy/validator.rs`, `engine/mod.rs`, `service/convert.rs`)
- [x] Integration test added (`aa-gateway/tests/cascade_credential_action_test.rs` — cascade most-restrictive-wins)
- [x] Full `cargo nextest run -p aa-gateway` green: **787 tests run: 787 passed**
- [x] `cargo clippy -p aa-gateway --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo doc -p aa-gateway --no-deps` only emits pre-existing warnings (none from this change)

### Acceptance criteria (from AAASM-1546)

- [x] `DataPolicy` gains `credential_action: CredentialAction` (defaulting to `RedactOnly` for back-compat)
- [x] Engine respects the action: `block` → `Decision::Deny`, `redact_only` → `Decision::Redact`, `alert_only` → `Decision::Allow` (+ TODO alert keyed to AAASM-1545)
- [x] YAML validator accepts the new field
- [x] Unit tests cover all three modes
- [x] No breaking change for existing YAML without the field

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated where behaviour changed (doc comments on `CredentialAction`, `DataPolicy.credential_action`, `RawDataPolicy.credential_action`, `eval_result_to_response`)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention (16 commits, each one logical unit)

[AAASM-1546]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ