### PR TITLE
[AAASM-1545] ✨ (alerts): Emit severity=critical alert on credential_findings

### DIFF
--- a/aa-api/src/alerts/capture.rs
+++ b/aa-api/src/alerts/capture.rs
@@ -1,9 +1,10 @@
-//! Background task that captures budget alerts from the broadcast channel.
+//! Background tasks that capture broadcasted alerts into the store.
 
 use std::sync::Arc;
 
 use tokio::sync::broadcast;
 
+use aa_gateway::alerts::SecretAlert;
 use aa_gateway::budget::types::BudgetAlert;
 
 use super::AlertStore;
@@ -31,6 +32,36 @@ pub fn spawn_alert_capture(
                 }
                 Err(broadcast::error::RecvError::Closed) => {
                     tracing::info!("budget alert broadcast channel closed, stopping capture task");
+                    break;
+                }
+            }
+        }
+    })
+}
+
+/// Spawn a background task that subscribes to the secret-detection alert
+/// broadcast channel and records each alert into the given store
+/// (AAASM-1545).
+///
+/// Same lifecycle and error handling as [`spawn_alert_capture`].
+pub fn spawn_secret_alert_capture(
+    mut rx: broadcast::Receiver<SecretAlert>,
+    store: Arc<dyn AlertStore>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(alert) => {
+                    store.record_secret(&alert);
+                }
+                Err(broadcast::error::RecvError::Lagged(count)) => {
+                    tracing::warn!(
+                        count,
+                        "secret-alert capture task lagged behind broadcast, skipped {count} alerts"
+                    );
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    tracing::info!("secret-alert broadcast channel closed, stopping capture task");
                     break;
                 }
             }

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -59,6 +59,26 @@ impl std::fmt::Display for AlertSeverity {
     }
 }
 
+/// Classification of an alert by its source signal.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AlertCategory {
+    /// Budget threshold crossed.
+    Budget,
+    /// One or more credential / sensitive-value patterns detected in an
+    /// outbound payload by the gateway's credential scanner.
+    SecretDetected,
+}
+
+impl std::fmt::Display for AlertCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AlertCategory::Budget => write!(f, "budget"),
+            AlertCategory::SecretDetected => write!(f, "secret_detected"),
+        }
+    }
+}
+
 /// Derive severity from a budget threshold percentage.
 pub fn severity_from_threshold(threshold_pct: u8) -> AlertSeverity {
     if threshold_pct >= 90 {

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -10,13 +10,16 @@ pub mod store;
 use aa_gateway::budget::types::BudgetAlert;
 use serde::Serialize;
 
-/// Stored representation of a budget alert with metadata.
+/// Stored representation of an alert with metadata.
 #[derive(Debug, Clone, Serialize)]
 pub struct StoredAlert {
     /// Auto-incremented alert identifier.
     pub id: u64,
     /// Alert severity level derived from `threshold_pct`.
     pub severity: AlertSeverity,
+    /// Source classification — `Budget` today, `SecretDetected` once
+    /// secret-detection alerts are emitted (AAASM-1545).
+    pub category: AlertCategory,
     /// Human-readable alert message.
     pub message: String,
     /// Hex-encoded agent ID that triggered the alert.
@@ -111,6 +114,7 @@ pub fn stored_alert_from(alert: &BudgetAlert, id: u64, timestamp: String) -> Sto
     StoredAlert {
         id,
         severity: severity_from_threshold(alert.threshold_pct),
+        category: AlertCategory::Budget,
         message: build_alert_message(alert),
         agent_id: format_agent_id(&alert.agent_id),
         timestamp,

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -25,6 +25,10 @@ pub struct StoredAlert {
     pub message: String,
     /// Hex-encoded agent ID that triggered the alert.
     pub agent_id: String,
+    /// Team attribution propagated from the request context. `None` for
+    /// alerts where no team was associated (e.g. legacy budget alerts
+    /// emitted without a team).
+    pub team_id: Option<String>,
     /// ISO 8601 timestamp when the alert was captured.
     pub timestamp: String,
     /// Budget threshold percentage that was crossed.
@@ -146,6 +150,7 @@ pub fn stored_secret_alert_from(alert: &SecretAlert, id: u64, timestamp: String)
         category: AlertCategory::SecretDetected,
         message: build_secret_alert_message(alert),
         agent_id: format_agent_id(&alert.agent_id),
+        team_id: alert.team_id.clone(),
         timestamp,
         threshold_pct: 0,
         spent_usd: 0.0,
@@ -165,6 +170,7 @@ pub fn stored_alert_from(alert: &BudgetAlert, id: u64, timestamp: String) -> Sto
         category: AlertCategory::Budget,
         message: build_alert_message(alert),
         agent_id: format_agent_id(&alert.agent_id),
+        team_id: alert.team_id.clone(),
         timestamp,
         threshold_pct: alert.threshold_pct,
         spent_usd: alert.spent_usd,

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -38,6 +38,13 @@ pub struct StoredAlert {
     /// ISO 8601 timestamp of the last mutation (e.g. resolve). `None`
     /// while the alert is still in its initial captured state.
     pub updated_at: Option<String>,
+    /// Primary detected credential kind for `SecretDetected` alerts
+    /// (e.g. `"AwsAccessKey"`). `None` for `Budget` alerts.
+    pub detected_pattern_type: Option<String>,
+    /// `[REDACTED:<Kind>]` label for `SecretDetected` alerts. Never
+    /// contains any byte of the original secret. `None` for budget
+    /// alerts.
+    pub redacted_value: Option<String>,
 }
 
 /// Alert severity level derived from the budget threshold percentage.
@@ -123,6 +130,8 @@ pub fn stored_alert_from(alert: &BudgetAlert, id: u64, timestamp: String) -> Sto
         limit_usd: alert.limit_usd,
         status: "unresolved".to_string(),
         updated_at: None,
+        detected_pattern_type: None,
+        redacted_value: None,
     }
 }
 

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -183,6 +183,11 @@ pub trait AlertStore: Send + Sync {
     /// Record a new budget alert, returning the assigned ID.
     fn record(&self, alert: &BudgetAlert) -> u64;
 
+    /// Record a new secret-detection alert, returning the assigned ID
+    /// (AAASM-1545). The stored alert has `severity=critical` and
+    /// `category=secret_detected`.
+    fn record_secret(&self, alert: &SecretAlert) -> u64;
+
     /// List stored alerts with pagination.
     ///
     /// Returns `(alerts, total_count)`. Results are ordered newest-first.

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -7,6 +7,7 @@
 pub mod capture;
 pub mod store;
 
+use aa_gateway::alerts::SecretAlert;
 use aa_gateway::budget::types::BudgetAlert;
 use serde::Serialize;
 
@@ -114,6 +115,46 @@ fn build_alert_message(alert: &BudgetAlert) -> String {
         alert.spent_usd,
         alert.limit_usd,
     )
+}
+
+/// Build a human-readable alert message for a [`SecretAlert`].
+fn build_secret_alert_message(alert: &SecretAlert) -> String {
+    let kind = alert.primary_kind().as_str();
+    if alert.finding_count <= 1 {
+        format!(
+            "Secret detected: agent {} attempted to send a {} value in outbound payload (redacted)",
+            format_agent_id(&alert.agent_id),
+            kind,
+        )
+    } else {
+        format!(
+            "Secret detected: agent {} attempted to send {} values ({} primary) in outbound payload (redacted)",
+            format_agent_id(&alert.agent_id),
+            alert.finding_count,
+            kind,
+        )
+    }
+}
+
+/// Convert a [`SecretAlert`] into a [`StoredAlert`] with the given ID
+/// and timestamp. Severity is always `Critical` per AAASM-1545.
+pub fn stored_secret_alert_from(alert: &SecretAlert, id: u64, timestamp: String) -> StoredAlert {
+    let kind = alert.primary_kind();
+    StoredAlert {
+        id,
+        severity: AlertSeverity::Critical,
+        category: AlertCategory::SecretDetected,
+        message: build_secret_alert_message(alert),
+        agent_id: format_agent_id(&alert.agent_id),
+        timestamp,
+        threshold_pct: 0,
+        spent_usd: 0.0,
+        limit_usd: 0.0,
+        status: "unresolved".to_string(),
+        updated_at: None,
+        detected_pattern_type: Some(kind.as_str().to_string()),
+        redacted_value: Some(alert.redacted_label()),
+    }
 }
 
 /// Convert a `BudgetAlert` into a `StoredAlert` with the given ID and timestamp.

--- a/aa-api/src/alerts/store.rs
+++ b/aa-api/src/alerts/store.rs
@@ -4,9 +4,10 @@ use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::RwLock;
 
+use aa_gateway::alerts::SecretAlert;
 use aa_gateway::budget::types::BudgetAlert;
 
-use super::{stored_alert_from, AlertStore, StoredAlert};
+use super::{stored_alert_from, stored_secret_alert_from, AlertStore, StoredAlert};
 
 /// Default maximum number of alerts retained in the ring buffer.
 const DEFAULT_CAPACITY: usize = 10_000;
@@ -48,6 +49,19 @@ impl AlertStore for InMemoryAlertStore {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let timestamp = chrono::Utc::now().to_rfc3339();
         let stored = stored_alert_from(alert, id, timestamp);
+
+        let mut buf = self.alerts.write().expect("alert store lock poisoned");
+        if buf.len() >= self.capacity {
+            buf.pop_front();
+        }
+        buf.push_back(stored);
+        id
+    }
+
+    fn record_secret(&self, alert: &SecretAlert) -> u64 {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let timestamp = chrono::Utc::now().to_rfc3339();
+        let stored = stored_secret_alert_from(alert, id, timestamp);
 
         let mut buf = self.alerts.write().expect("alert store lock poisoned");
         if buf.len() >= self.capacity {

--- a/aa-api/src/alerts/store.rs
+++ b/aa-api/src/alerts/store.rs
@@ -102,6 +102,7 @@ impl AlertStore for InMemoryAlertStore {
 mod tests {
     use super::*;
     use aa_core::AgentId;
+    use aa_core::CredentialKind;
 
     fn test_alert(threshold_pct: u8) -> BudgetAlert {
         BudgetAlert {
@@ -110,6 +111,15 @@ mod tests {
             threshold_pct,
             spent_usd: 8.0,
             limit_usd: 10.0,
+        }
+    }
+
+    fn test_secret_alert(kind: CredentialKind) -> SecretAlert {
+        SecretAlert {
+            agent_id: AgentId::from_bytes([0xAB; 16]),
+            team_id: Some("team-pioneer".to_string()),
+            kinds: vec![kind],
+            finding_count: 1,
         }
     }
 
@@ -272,5 +282,28 @@ mod tests {
         assert_eq!(id1, 1);
         assert_eq!(id2, 2);
         assert_eq!(id3, 3);
+    }
+
+    #[test]
+    fn record_secret_round_trips_critical_secret_detected() {
+        let store = InMemoryAlertStore::new();
+        let id = store.record_secret(&test_secret_alert(CredentialKind::AwsAccessKey));
+
+        let found = store.get(id).expect("recorded secret alert must be retrievable");
+        assert_eq!(found.severity, super::super::AlertSeverity::Critical);
+        assert_eq!(found.category, super::super::AlertCategory::SecretDetected);
+        assert_eq!(found.detected_pattern_type.as_deref(), Some("AwsAccessKey"));
+        assert_eq!(found.redacted_value.as_deref(), Some("[REDACTED:AwsAccessKey]"));
+        assert_eq!(found.status, "unresolved");
+    }
+
+    #[test]
+    fn record_secret_shares_id_sequence_with_record() {
+        let store = InMemoryAlertStore::new();
+        let budget_id = store.record(&test_alert(80));
+        let secret_id = store.record_secret(&test_secret_alert(CredentialKind::OpenAiKey));
+        // Both calls allocate from the same monotonic counter.
+        assert_eq!(budget_id, 1);
+        assert_eq!(secret_id, 2);
     }
 }

--- a/aa-api/src/events.rs
+++ b/aa-api/src/events.rs
@@ -4,6 +4,7 @@
 //! runtime, gateway, and proxy crates into a single struct that the API
 //! layer (and downstream WebSocket streaming) can subscribe to.
 
+use aa_gateway::alerts::SecretAlert;
 use aa_gateway::budget::types::BudgetAlert;
 use aa_runtime::approval::ApprovalRequest;
 use aa_runtime::pipeline::event::PipelineEvent;
@@ -24,6 +25,9 @@ pub struct EventBroadcast {
     /// Fires when a pending request auto-expires (AAASM-1453).
     approval_expiry_tx: broadcast::Sender<ApprovalRequest>,
     budget_tx: broadcast::Sender<BudgetAlert>,
+    /// Secret-detection alerts emitted when the gateway's credential
+    /// scanner produces a non-empty findings list (AAASM-1545).
+    secret_tx: broadcast::Sender<SecretAlert>,
 }
 
 impl EventBroadcast {
@@ -33,11 +37,13 @@ impl EventBroadcast {
         let (approval_tx, _) = broadcast::channel(capacity);
         let (approval_expiry_tx, _) = broadcast::channel(capacity);
         let (budget_tx, _) = broadcast::channel(capacity);
+        let (secret_tx, _) = broadcast::channel(capacity);
         Self {
             pipeline_tx,
             approval_tx,
             approval_expiry_tx,
             budget_tx,
+            secret_tx,
         }
     }
 
@@ -83,6 +89,16 @@ impl EventBroadcast {
     /// Get a clone of the budget alert sender.
     pub fn budget_sender(&self) -> broadcast::Sender<BudgetAlert> {
         self.budget_tx.clone()
+    }
+
+    /// Subscribe to secret-detection alerts (AAASM-1545).
+    pub fn subscribe_secret(&self) -> broadcast::Receiver<SecretAlert> {
+        self.secret_tx.subscribe()
+    }
+
+    /// Get a clone of the secret-detection alert sender (AAASM-1545).
+    pub fn secret_sender(&self) -> broadcast::Sender<SecretAlert> {
+        self.secret_tx.clone()
     }
 }
 

--- a/aa-api/src/routes/alerts.rs
+++ b/aa-api/src/routes/alerts.rs
@@ -20,6 +20,7 @@ fn alert_response_from_stored(a: StoredAlert) -> AlertResponse {
         message: a.message,
         timestamp: a.timestamp,
         agent_id: Some(a.agent_id),
+        team_id: a.team_id,
         status: a.status,
         updated_at: a.updated_at,
         detected_pattern_type: a.detected_pattern_type,
@@ -52,6 +53,10 @@ pub struct AlertResponse {
     pub timestamp: String,
     /// Agent ID that triggered the alert (if applicable).
     pub agent_id: Option<String>,
+    /// Team attribution propagated from the originating request
+    /// context. Omitted when no team was associated.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub team_id: Option<String>,
     /// Lifecycle status — `"unresolved"` on capture, `"resolved"` once
     /// the alert has been acknowledged via `POST /alerts/:id/resolve`.
     pub status: String,

--- a/aa-api/src/routes/alerts.rs
+++ b/aa-api/src/routes/alerts.rs
@@ -16,7 +16,7 @@ fn alert_response_from_stored(a: StoredAlert) -> AlertResponse {
     AlertResponse {
         id: a.id.to_string(),
         severity: a.severity.to_string(),
-        category: "budget".to_string(),
+        category: a.category.to_string(),
         message: a.message,
         timestamp: a.timestamp,
         agent_id: Some(a.agent_id),

--- a/aa-api/src/routes/alerts.rs
+++ b/aa-api/src/routes/alerts.rs
@@ -22,6 +22,8 @@ fn alert_response_from_stored(a: StoredAlert) -> AlertResponse {
         agent_id: Some(a.agent_id),
         status: a.status,
         updated_at: a.updated_at,
+        detected_pattern_type: a.detected_pattern_type,
+        redacted_value: a.redacted_value,
     }
 }
 
@@ -42,7 +44,7 @@ pub struct AlertResponse {
     pub id: String,
     /// Alert severity level (e.g. "warning", "critical").
     pub severity: String,
-    /// Alert category (e.g. "budget", "policy_violation", "anomaly").
+    /// Alert category (e.g. "budget", "secret_detected").
     pub category: String,
     /// Human-readable alert message.
     pub message: String,
@@ -56,6 +58,14 @@ pub struct AlertResponse {
     /// ISO 8601 timestamp of the last mutation (e.g. resolve). `None`
     /// while the alert is still in its initial captured state.
     pub updated_at: Option<String>,
+    /// Primary detected credential kind for `secret_detected` alerts
+    /// (e.g. `"AwsAccessKey"`). Omitted for budget alerts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detected_pattern_type: Option<String>,
+    /// `[REDACTED:<Kind>]` label for `secret_detected` alerts — never
+    /// contains the raw secret. Omitted for budget alerts.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redacted_value: Option<String>,
 }
 
 /// `GET /api/v1/alerts` — list recent governance alerts.

--- a/aa-api/src/server.rs
+++ b/aa-api/src/server.rs
@@ -45,6 +45,11 @@ pub async fn run_server(config: ApiConfig, state: AppState) -> Result<(), Box<dy
     let budget_rx = state.events.subscribe_budget();
     let _alert_capture_handle = crate::alerts::capture::spawn_alert_capture(budget_rx, state.alert_store.clone());
 
+    // Spawn background task to capture secret-detection alerts (AAASM-1545).
+    let secret_rx = state.events.subscribe_secret();
+    let _secret_alert_capture_handle =
+        crate::alerts::capture::spawn_secret_alert_capture(secret_rx, state.alert_store.clone());
+
     let app = build_app(state);
 
     let listener = TcpListener::bind(config.bind_addr).await?;

--- a/aa-api/tests/secret_alerts.rs
+++ b/aa-api/tests/secret_alerts.rs
@@ -1,0 +1,128 @@
+//! AAASM-1545 — secret-detection alerts flow from the broadcast bus
+//! into the `AlertStore` and out through `/api/v1/alerts`.
+//!
+//! These tests verify the boundary between `aa_gateway::alerts::SecretAlert`
+//! producers (PolicyService) and the public API by injecting alerts
+//! directly on `EventBroadcast::secret_sender()` — i.e. the exact path
+//! the production `spawn_secret_alert_capture` task consumes.
+//!
+//! Synthetic secret fixtures only — `AKIAIOSFODNN7EXAMPLE` is a public
+//! AWS documentation value, never a live credential.
+
+mod common;
+
+use std::time::Duration;
+
+use aa_core::{AgentId, CredentialKind};
+use aa_gateway::alerts::SecretAlert;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+const FAKE_AWS_ACCESS_KEY: &str = "AKIAIOSFODNN7EXAMPLE";
+
+fn aws_secret_alert() -> SecretAlert {
+    SecretAlert {
+        agent_id: AgentId::from_bytes([0xAB; 16]),
+        team_id: Some("team-pioneer".to_string()),
+        kinds: vec![CredentialKind::AwsAccessKey],
+        finding_count: 1,
+    }
+}
+
+#[tokio::test]
+async fn list_alerts_returns_secret_alert_after_broadcast_capture() {
+    let state = common::test_state();
+    let secret_tx = state.events.secret_sender();
+    let secret_rx = state.events.subscribe_secret();
+    let alert_store = state.alert_store.clone();
+
+    let _handle = aa_api::alerts::capture::spawn_secret_alert_capture(secret_rx, alert_store);
+
+    secret_tx.send(aws_secret_alert()).unwrap();
+
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    let app = aa_api::server::build_app(state);
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/alerts").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["total"], 1);
+
+    let items = json["items"].as_array().unwrap();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["category"], "secret_detected");
+    assert_eq!(items[0]["severity"], "critical");
+    assert_eq!(items[0]["detected_pattern_type"], "AwsAccessKey");
+    assert_eq!(items[0]["redacted_value"], "[REDACTED:AwsAccessKey]");
+    assert!(items[0]["id"].is_string());
+    assert!(items[0]["timestamp"].is_string());
+}
+
+#[tokio::test]
+async fn secret_alert_response_never_contains_raw_secret_bytes() {
+    let state = common::test_state();
+    let secret_tx = state.events.secret_sender();
+    let secret_rx = state.events.subscribe_secret();
+    let alert_store = state.alert_store.clone();
+
+    let _handle = aa_api::alerts::capture::spawn_secret_alert_capture(secret_rx, alert_store);
+
+    secret_tx.send(aws_secret_alert()).unwrap();
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    let app = aa_api::server::build_app(state);
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/alerts").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let raw = std::str::from_utf8(&body).expect("response body is UTF-8");
+    assert!(
+        !raw.contains(FAKE_AWS_ACCESS_KEY),
+        "raw secret must never appear in alert API response; body was: {raw}"
+    );
+}
+
+#[tokio::test]
+async fn get_alert_returns_secret_payload_with_critical_severity() {
+    let state = common::test_state();
+    let secret_tx = state.events.secret_sender();
+    let secret_rx = state.events.subscribe_secret();
+    let alert_store = state.alert_store.clone();
+
+    let _handle = aa_api::alerts::capture::spawn_secret_alert_capture(secret_rx, alert_store.clone());
+
+    secret_tx.send(aws_secret_alert()).unwrap();
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    // Resolve the assigned id from the store directly so the test does not
+    // depend on the global id counter starting at 1.
+    let (items, _) = alert_store.list(10, 0);
+    let id = items.first().expect("a secret alert must be recorded").id;
+
+    let app = aa_api::server::build_app(state);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/alerts/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["category"], "secret_detected");
+    assert_eq!(json["severity"], "critical");
+    assert_eq!(json["detected_pattern_type"], "AwsAccessKey");
+    assert_eq!(json["redacted_value"], "[REDACTED:AwsAccessKey]");
+}

--- a/aa-api/tests/secret_alerts.rs
+++ b/aa-api/tests/secret_alerts.rs
@@ -60,6 +60,7 @@ async fn list_alerts_returns_secret_alert_after_broadcast_capture() {
     assert_eq!(items[0]["severity"], "critical");
     assert_eq!(items[0]["detected_pattern_type"], "AwsAccessKey");
     assert_eq!(items[0]["redacted_value"], "[REDACTED:AwsAccessKey]");
+    assert_eq!(items[0]["team_id"], "team-pioneer");
     assert!(items[0]["id"].is_string());
     assert!(items[0]["timestamp"].is_string());
 }

--- a/aa-gateway/src/alerts.rs
+++ b/aa-gateway/src/alerts.rs
@@ -1,0 +1,89 @@
+//! Security alert events emitted by the gateway.
+//!
+//! Currently hosts [`SecretAlert`] — fired when the policy engine's
+//! credential scanner produces a non-empty `credential_findings` list
+//! for an outbound payload (AAASM-1545).
+//!
+//! Security invariant: this struct stores only [`CredentialKind`] tags
+//! and finding counts. The raw matched bytes never appear here and must
+//! not be added to any field.
+
+use aa_core::{AgentId, CredentialKind};
+
+/// Broadcast event raised when one or more credential / sensitive-value
+/// patterns are detected in an evaluated payload.
+///
+/// Consumers (e.g. `aa-api::alerts::capture::spawn_secret_alert_capture`)
+/// turn this into a persistent `StoredAlert` for the public alerts API.
+#[derive(Debug, Clone)]
+pub struct SecretAlert {
+    /// The agent whose outbound payload triggered the scanner.
+    pub agent_id: AgentId,
+    /// Team attribution propagated from the request context, when present.
+    pub team_id: Option<String>,
+    /// All distinct credential kinds detected in the payload, in the
+    /// order returned by the scanner pass. Always non-empty when emitted.
+    pub kinds: Vec<CredentialKind>,
+    /// Total number of credential findings produced by the scanner pass.
+    /// May exceed `kinds.len()` when the same kind matches more than once.
+    pub finding_count: usize,
+}
+
+impl SecretAlert {
+    /// The primary detected pattern kind, used as the alert's
+    /// `detected_pattern_type` in the public API. Falls back to the
+    /// generic [`CredentialKind::Custom`] only if the kinds list is
+    /// empty — which should never happen in practice since the gateway
+    /// only emits this alert when findings are non-empty.
+    pub fn primary_kind(&self) -> CredentialKind {
+        self.kinds.first().cloned().unwrap_or(CredentialKind::Custom)
+    }
+
+    /// The `[REDACTED:<Kind>]` label corresponding to `primary_kind`.
+    /// Never contains any byte of the original secret.
+    pub fn redacted_label(&self) -> String {
+        format!("[REDACTED:{}]", self.primary_kind().as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn agent() -> AgentId {
+        AgentId::from_bytes([0x42; 16])
+    }
+
+    #[test]
+    fn primary_kind_returns_first() {
+        let alert = SecretAlert {
+            agent_id: agent(),
+            team_id: None,
+            kinds: vec![CredentialKind::AwsAccessKey, CredentialKind::OpenAiKey],
+            finding_count: 2,
+        };
+        assert_eq!(alert.primary_kind(), CredentialKind::AwsAccessKey);
+    }
+
+    #[test]
+    fn redacted_label_uses_primary_kind() {
+        let alert = SecretAlert {
+            agent_id: agent(),
+            team_id: Some("team-x".to_string()),
+            kinds: vec![CredentialKind::GitHubPat],
+            finding_count: 1,
+        };
+        assert_eq!(alert.redacted_label(), "[REDACTED:GitHubPat]");
+    }
+
+    #[test]
+    fn primary_kind_falls_back_to_custom_when_empty() {
+        let alert = SecretAlert {
+            agent_id: agent(),
+            team_id: None,
+            kinds: vec![],
+            finding_count: 0,
+        };
+        assert_eq!(alert.primary_kind(), CredentialKind::Custom);
+    }
+}

--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -4,6 +4,7 @@
 //! registry, evaluates governance policies, routes enforcement decisions
 //! back to proxies and SDK shims, and writes the audit trail.
 
+pub mod alerts;
 pub mod anomaly;
 pub mod approval;
 pub mod audit;

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Instant, SystemTime};
 
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{broadcast, mpsc, Mutex};
 use tonic::{Request, Response, Status};
 
 use aa_core::identity::{AgentId, SessionId};
@@ -15,6 +15,7 @@ use aa_proto::assembly::policy::v1::{BatchCheckRequest, BatchCheckResponse, Chec
 
 use aa_runtime::approval::{ApprovalQueue, ApprovalRequest};
 
+use crate::alerts::SecretAlert;
 use crate::approval::db_escalation_scheduler::DbEscalationScheduler;
 use crate::approval::escalation::EscalationScheduler;
 use crate::approval::router::ApprovalRouter;
@@ -37,6 +38,11 @@ pub struct PolicyServiceImpl {
     audit_drops: Arc<AtomicU64>,
     seq: AtomicU64,
     last_hash: Mutex<[u8; 32]>,
+    /// Optional broadcast sender for secret-detection alerts. When set,
+    /// the service publishes a [`SecretAlert`] each time a CheckAction
+    /// produces non-empty `credential_findings` (AAASM-1545). `None`
+    /// disables emission — used by unit tests that don't need alerts.
+    secret_alert_tx: Option<broadcast::Sender<SecretAlert>>,
 }
 
 impl PolicyServiceImpl {
@@ -63,6 +69,7 @@ impl PolicyServiceImpl {
             audit_drops,
             seq: AtomicU64::new(0),
             last_hash: Mutex::new(initial_hash),
+            secret_alert_tx: None,
         }
     }
 
@@ -89,6 +96,7 @@ impl PolicyServiceImpl {
             audit_drops,
             seq: AtomicU64::new(0),
             last_hash: Mutex::new(initial_hash),
+            secret_alert_tx: None,
         }
     }
 
@@ -117,6 +125,7 @@ impl PolicyServiceImpl {
             audit_drops,
             seq: AtomicU64::new(0),
             last_hash: Mutex::new(initial_hash),
+            secret_alert_tx: None,
         }
     }
 
@@ -150,6 +159,7 @@ impl PolicyServiceImpl {
             audit_drops,
             seq: AtomicU64::new(0),
             last_hash: Mutex::new(initial_hash),
+            secret_alert_tx: None,
         }
     }
 
@@ -169,6 +179,17 @@ impl PolicyServiceImpl {
     /// `routing_status` on the in-flight approval queue entry (AC2 / AC3).
     pub fn with_router(mut self, router: Arc<ApprovalRouter>) -> Self {
         self.router = Some(router);
+        self
+    }
+
+    /// Attach a broadcast sender for secret-detection alerts (AAASM-1545).
+    ///
+    /// When present, the service publishes a [`SecretAlert`] each time a
+    /// `CheckAction` produces non-empty `credential_findings`. Callers
+    /// (e.g. `aa-api`) typically pair this with
+    /// `spawn_secret_alert_capture` to persist the alerts into the store.
+    pub fn with_secret_alert_tx(mut self, tx: broadcast::Sender<SecretAlert>) -> Self {
+        self.secret_alert_tx = Some(tx);
         self
     }
 

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -616,6 +616,51 @@ impl PolicyServiceImpl {
     }
 }
 
+impl PolicyServiceImpl {
+    /// Publish a [`SecretAlert`] when the evaluation produced one or more
+    /// credential findings and a broadcast sender is attached. The alert
+    /// carries only kind tags and counts — never any byte of the original
+    /// secret. Failure to send (no receivers) is logged at trace level
+    /// and does not propagate (AAASM-1545).
+    fn maybe_emit_secret_alert(&self, req: &CheckActionRequest, eval: &EvaluationResult) {
+        if eval.credential_findings.is_empty() {
+            return;
+        }
+        let Some(tx) = self.secret_alert_tx.as_ref() else {
+            return;
+        };
+        let Some(proto_agent) = req.agent_id.as_ref() else {
+            return;
+        };
+
+        let agent_id = AgentId::from_bytes(proto_agent_id_to_key(proto_agent));
+        let team_id = if proto_agent.team_id.is_empty() {
+            None
+        } else {
+            Some(proto_agent.team_id.clone())
+        };
+
+        // Distinct kinds (preserve first-seen order) for the alert payload.
+        let mut kinds = Vec::new();
+        for f in &eval.credential_findings {
+            if !kinds.iter().any(|k| k == &f.kind) {
+                kinds.push(f.kind.clone());
+            }
+        }
+
+        let alert = SecretAlert {
+            agent_id,
+            team_id,
+            kinds,
+            finding_count: eval.credential_findings.len(),
+        };
+
+        if let Err(err) = tx.send(alert) {
+            tracing::trace!(error = %err, "no subscribers for SecretAlert broadcast");
+        }
+    }
+}
+
 #[tonic::async_trait]
 impl PolicyService for PolicyServiceImpl {
     async fn check_action(
@@ -632,6 +677,7 @@ impl PolicyService for PolicyServiceImpl {
         );
 
         let (eval, latency_us, policy_rule) = self.evaluate_one(&req)?;
+        self.maybe_emit_secret_alert(&req, &eval);
         let deny_action = eval.deny_action;
 
         // If RequiresApproval, submit to the queue and block until decided.
@@ -672,6 +718,7 @@ impl PolicyService for PolicyServiceImpl {
 
         for req in &batch.requests {
             let (eval, latency_us, policy_rule) = self.evaluate_one(req)?;
+            self.maybe_emit_secret_alert(req, &eval);
             let deny_action = eval.deny_action;
             let resp = if let Some(approval_response) =
                 self.maybe_submit_approval(req, &eval, latency_us, &policy_rule).await

--- a/aa-gateway/tests/policy_service_secret_alert_test.rs
+++ b/aa-gateway/tests/policy_service_secret_alert_test.rs
@@ -1,0 +1,129 @@
+//! AAASM-1545 — PolicyService emits a `SecretAlert` broadcast whenever
+//! evaluating a `CheckAction` produces non-empty `credential_findings`.
+//!
+//! Calls `check_action` directly on the trait impl so the test does not
+//! need a tonic server / network port — emission happens inside the
+//! engine→service path either way.
+//!
+//! Synthetic secrets only — `AKIAIOSFODNN7EXAMPLE` is a public AWS
+//! documentation key, never a live credential.
+
+use std::io::Write;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use std::time::Duration;
+
+use aa_core::CredentialKind;
+use aa_gateway::alerts::SecretAlert;
+use aa_gateway::service::PolicyServiceImpl;
+use aa_gateway::PolicyEngine;
+use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId};
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyService;
+use aa_proto::assembly::policy::v1::{action_context::Action, ActionContext, CheckActionRequest, ToolCallContext};
+use tonic::Request;
+
+const ALLOW_TEST_TOOL_POLICY: &str = r#"
+version: "1"
+tools:
+  test_tool:
+    allow: true
+"#;
+
+const FAKE_AWS_ACCESS_KEY: &str = "AKIAIOSFODNN7EXAMPLE";
+
+fn make_service_with_secret_tx() -> (Arc<PolicyServiceImpl>, tokio::sync::broadcast::Receiver<SecretAlert>) {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", ALLOW_TEST_TOOL_POLICY).unwrap();
+    tmp.flush().unwrap();
+
+    let (budget_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    let engine = PolicyEngine::load_from_file(tmp.path(), budget_tx).unwrap();
+
+    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+
+    let (secret_tx, secret_rx) = tokio::sync::broadcast::channel::<SecretAlert>(16);
+    let service =
+        PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops, [0u8; 32]).with_secret_alert_tx(secret_tx);
+
+    (Arc::new(service), secret_rx)
+}
+
+fn tool_call_request_with_args(args: &str) -> CheckActionRequest {
+    CheckActionRequest {
+        agent_id: Some(ProtoAgentId {
+            org_id: "org".into(),
+            team_id: "team-pioneer".into(),
+            agent_id: "agent-1".into(),
+        }),
+        credential_token: "tok".into(),
+        trace_id: "trace-secret".into(),
+        span_id: "span-1".into(),
+        action_type: ActionType::ToolCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::ToolCall(ToolCallContext {
+                tool_name: "test_tool".into(),
+                tool_source: "test".into(),
+                args_json: args.as_bytes().to_vec(),
+                target_url: String::new(),
+            })),
+        }),
+    }
+}
+
+#[tokio::test]
+async fn check_action_emits_secret_alert_when_credential_findings_present() {
+    let (service, mut rx) = make_service_with_secret_tx();
+    let req = tool_call_request_with_args(FAKE_AWS_ACCESS_KEY);
+
+    service
+        .check_action(Request::new(req))
+        .await
+        .expect("check_action should succeed");
+
+    let alert = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .expect("alert must arrive within 1s")
+        .expect("broadcast channel must yield an alert");
+
+    assert!(alert.kinds.contains(&CredentialKind::AwsAccessKey));
+    assert_eq!(alert.team_id.as_deref(), Some("team-pioneer"));
+    assert!(alert.finding_count >= 1);
+}
+
+#[tokio::test]
+async fn check_action_does_not_emit_alert_when_payload_is_clean() {
+    let (service, mut rx) = make_service_with_secret_tx();
+    let req = tool_call_request_with_args(r#"{"q":"hello"}"#);
+
+    service
+        .check_action(Request::new(req))
+        .await
+        .expect("check_action should succeed");
+
+    // Short wait — no alert should arrive at all.
+    let outcome = tokio::time::timeout(Duration::from_millis(150), rx.recv()).await;
+    assert!(outcome.is_err(), "no secret alert expected for clean payload");
+}
+
+#[tokio::test]
+async fn secret_alert_payload_never_contains_raw_secret() {
+    let (service, mut rx) = make_service_with_secret_tx();
+    let req = tool_call_request_with_args(FAKE_AWS_ACCESS_KEY);
+
+    service
+        .check_action(Request::new(req))
+        .await
+        .expect("check_action should succeed");
+
+    let alert = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .expect("alert must arrive within 1s")
+        .expect("broadcast channel must yield an alert");
+
+    let serialized = format!("{alert:?}");
+    assert!(
+        !serialized.contains(FAKE_AWS_ACCESS_KEY),
+        "raw secret must never appear in the SecretAlert payload, got: {serialized}"
+    );
+}

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -1183,12 +1183,22 @@ export interface components {
         AlertResponse: {
             /** @description Agent ID that triggered the alert (if applicable). */
             agent_id?: string | null;
-            /** @description Alert category (e.g. "budget", "policy_violation", "anomaly"). */
+            /** @description Alert category (e.g. "budget", "secret_detected"). */
             category: string;
+            /**
+             * @description Primary detected credential kind for `secret_detected` alerts
+             *     (e.g. `"AwsAccessKey"`). Omitted for budget alerts.
+             */
+            detected_pattern_type?: string | null;
             /** @description Unique alert identifier. */
             id: string;
             /** @description Human-readable alert message. */
             message: string;
+            /**
+             * @description `[REDACTED:<Kind>]` label for `secret_detected` alerts — never
+             *     contains the raw secret. Omitted for budget alerts.
+             */
+            redacted_value?: string | null;
             /** @description Alert severity level (e.g. "warning", "critical"). */
             severity: string;
             /**
@@ -1196,6 +1206,11 @@ export interface components {
              *     the alert has been acknowledged via `POST /alerts/:id/resolve`.
              */
             status: string;
+            /**
+             * @description Team attribution propagated from the originating request
+             *     context. Omitted when no team was associated.
+             */
+            team_id?: string | null;
             /** @description ISO 8601 timestamp when the alert was raised. */
             timestamp: string;
             /**

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1966,13 +1966,27 @@ components:
           description: Agent ID that triggered the alert (if applicable).
         category:
           type: string
-          description: Alert category (e.g. "budget", "policy_violation", "anomaly").
+          description: Alert category (e.g. "budget", "secret_detected").
+        detected_pattern_type:
+          type:
+          - string
+          - 'null'
+          description: |-
+            Primary detected credential kind for `secret_detected` alerts
+            (e.g. `"AwsAccessKey"`). Omitted for budget alerts.
         id:
           type: string
           description: Unique alert identifier.
         message:
           type: string
           description: Human-readable alert message.
+        redacted_value:
+          type:
+          - string
+          - 'null'
+          description: |-
+            `[REDACTED:<Kind>]` label for `secret_detected` alerts — never
+            contains the raw secret. Omitted for budget alerts.
         severity:
           type: string
           description: Alert severity level (e.g. "warning", "critical").

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1995,6 +1995,13 @@ components:
           description: |-
             Lifecycle status — `"unresolved"` on capture, `"resolved"` once
             the alert has been acknowledged via `POST /alerts/:id/resolve`.
+        team_id:
+          type:
+          - string
+          - 'null'
+          description: |-
+            Team attribution propagated from the originating request
+            context. Omitted when no team was associated.
         timestamp:
           type: string
           description: ISO 8601 timestamp when the alert was raised.


### PR DESCRIPTION
## Description

Wires the missing alert-emission path for the credential scanner. When `PolicyEngine` evaluation produces non-empty `credential_findings`, `PolicyServiceImpl` now broadcasts a `SecretAlert` that the API layer captures into `AlertStore`, surfacing it through `/api/v1/alerts` with:

- `severity: "critical"`
- `category: "secret_detected"` (new — was hardcoded `"budget"`)
- `agent_id`, propagated `team_id`
- `detected_pattern_type` (e.g. `"AwsAccessKey"`)
- `redacted_value` (e.g. `"[REDACTED:AwsAccessKey]"`) — never the raw secret
- ISO-8601 `timestamp`

Closes AAASM-1545. Unblocks three deferred ST-I E2E tests under AAASM-1521.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No

Notes on additive-only surface:

- `AlertResponse` gains `detected_pattern_type` and `redacted_value` (both `Option<String>`, `#[serde(skip_serializing_if = "Option::is_none")]`) — existing budget alerts serialise byte-identically.
- `AlertCategory` is a new enum; the wire value for existing budget alerts is unchanged (`"budget"`).
- `AlertStore::record_secret` is a new trait method; existing `record` is untouched.
- `PolicyServiceImpl::with_secret_alert_tx` is opt-in via builder — every existing constructor defaults to `None` so unit tests and current production wiring keep working.

## Related Issues

- Related Jira ticket: AAASM-1545
- Parent Story: AAASM-1232 (F116 ST-I follow-up)
- Sibling deferred: AAASM-1521 (E2E secret interception)

## Implementation summary

Three-layer change matching the existing budget-alert broadcast pattern:

| Layer | Change |
|---|---|
| `aa-gateway` | New `alerts::SecretAlert` type · `PolicyServiceImpl` gains optional `secret_alert_tx` and emits in both `check_action` and `batch_check` whenever `eval.credential_findings` is non-empty |
| `aa-api` events | `EventBroadcast` gains `secret_tx` channel + `subscribe_secret()` / `secret_sender()` accessors |
| `aa-api` alerts | `StoredAlert` gains `category`, `detected_pattern_type`, `redacted_value` · `AlertResponse.category` derived from stored category · new `AlertStore::record_secret` + `spawn_secret_alert_capture` task spawned in `run_server` |

**Security invariant** held end-to-end: the payload that crosses every boundary (`SecretAlert` → `AlertStore` → `AlertResponse`) carries only `CredentialKind` tags, counts, and the `[REDACTED:Kind]` label — no raw secret bytes. Two assertions enforce this (gateway `secret_alert_payload_never_contains_raw_secret`, api `secret_alert_response_never_contains_raw_secret_bytes`).

**Production wiring TODO**: the in-process consumer that constructs `PolicyServiceImpl` for the colocated API/gateway deployment must call `.with_secret_alert_tx(state.events.secret_sender())`. That bootstrap site is not in this workspace and will be wired in the follow-up that closes the ST-I deferred tests.

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

### Coverage added by this PR

| Layer | File | Tests |
|---|---|---|
| `aa-gateway` unit | `aa-gateway/src/alerts.rs` | `primary_kind_returns_first`, `redacted_label_uses_primary_kind`, `primary_kind_falls_back_to_custom_when_empty` |
| `aa-api` unit | `aa-api/src/alerts/store.rs` | `record_secret_round_trips_critical_secret_detected`, `record_secret_shares_id_sequence_with_record` |
| `aa-gateway` integration | `aa-gateway/tests/policy_service_secret_alert_test.rs` | `check_action_emits_secret_alert_when_credential_findings_present`, `check_action_does_not_emit_alert_when_payload_is_clean`, `secret_alert_payload_never_contains_raw_secret` |
| `aa-api` integration | `aa-api/tests/secret_alerts.rs` | `list_alerts_returns_secret_alert_after_broadcast_capture`, `secret_alert_response_never_contains_raw_secret_bytes`, `get_alert_returns_secret_payload_with_critical_severity` |

All synthetic secrets — `AKIAIOSFODNN7EXAMPLE` is a public AWS-docs example; no real credentials in the diff.

### Local verification

- `cargo nextest run -p aa-gateway` → **1116/1116 passing** (includes new 3 + 3 tests)
- `cargo nextest run -p aa-api` → all alerts/secret_alerts tests passing
- `cargo nextest run -p aa-integration-tests --test e2e_secret_interception` → 6/6 passing (no regression on existing F116 ST-I detection slice)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` → clean
- `cargo fmt --all -- --check` → clean
- `cargo doc --workspace --no-deps` → clean (only pre-existing intra-doc warnings outside this diff)

Pre-existing flakes in `aa-integration-tests::cli_context::context_list_empty_prints_helpful_message` (passes when isolated) and `aa-integration-tests::e2e_sdk_node::selftest_*` (environment dependency — `tsx` from sibling node-sdk workspace) are unrelated to this change.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Commit summary

16 atomic commits, one logical unit per commit:

| # | Subject |
|---|---|
| 1 | ✨ (alerts): Add AlertCategory enum for source classification |
| 2 | ✨ (alerts): Add category field to StoredAlert defaulting to Budget |
| 3 | ♻️ (alerts): Derive AlertResponse.category from StoredAlert.category |
| 4 | ✨ (gateway-alerts): Add SecretAlert type |
| 5 | ✨ (events): Add secret_tx broadcast channel to EventBroadcast |
| 6 | ✨ (alerts): Add detected_pattern_type and redacted_value to StoredAlert |
| 7 | ✨ (alerts): Surface detected_pattern_type and redacted_value in AlertResponse |
| 8 | ✨ (alerts): Add stored_secret_alert_from constructor |
| 9 | ✨ (alerts): Add AlertStore::record_secret + InMemoryAlertStore impl |
| 10 | ✅ (alerts): Test record_secret round-trips critical secret_detected |
| 11 | ✨ (alerts): Add spawn_secret_alert_capture task |
| 12 | ✨ (policy-svc): Add secret_alert_tx field + with_secret_alert_tx builder |
| 13 | ✨ (policy-svc): Emit SecretAlert when eval.credential_findings non-empty |
| 14 | ✅ (policy-svc): Test SecretAlert emitted when credential_findings populated |
| 15 | 🔧 (api-server): Spawn secret-alert capture task on startup |
| 16 | ✅ (alerts): Integration test — secret alert flows broadcast → /api/v1/alerts |

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.7 1M-context)