### PR TITLE
[AAASM-1551] 🐛 (ci): Skip selftest_* tests in sonar.yml llvm-cov coverage step

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -79,11 +79,16 @@ jobs:
         # (`--all-features` activates them but `--exclude aa-ebpf` means the
         # BPF object never gets built, so `Ebpf::load` trips on empty bytes).
         # The dedicated `e2e-ebpf-linux` job in ci.yml is authoritative.
+        #
+        # The `selftest_*` tests in aa-integration-tests/tests/e2e_sdk_node.rs
+        # spawn `pnpm exec tsx` and require a live Node SDK dev environment.
+        # pnpm/Node.js are not installed before this step (AAASM-1551).
         run: |
           cargo llvm-cov --no-report --all-features --workspace \
             --exclude aa-ebpf --exclude aa-ffi-python --exclude aa-devtool-claude-code \
             -- --skip sustained_load_p99_under_5ms --skip all_layers_run_independently \
-               --skip auth_rate_limit_resets_after_window --skip ebpf_
+               --skip auth_rate_limit_resets_after_window --skip ebpf_ \
+               --skip selftest_
           cargo llvm-cov --no-report -p aa-devtool-claude-code
           cargo llvm-cov --no-run --lcov --output-path lcov.info
 


### PR DESCRIPTION
## Description

Adds `--skip selftest_` to the `cargo llvm-cov` skip list in the **Generate coverage report** step of `sonar.yml`.

The 5 `selftest_*` tests in `aa-integration-tests/tests/e2e_sdk_node.rs` unconditionally invoke `pnpm exec tsx …` to exercise the Node SDK. In the SonarCloud environment, `pnpm` / Node.js are not available at the point the coverage step runs — they are only installed later as a conditional fallback for TypeScript coverage. This causes `cargo llvm-cov` to exit non-zero, preventing `lcov.info` from being generated and breaking every SonarCloud run on any PR that touches `aa-*/**` or `dashboard/**`.

The fix is a one-line addition consistent with the existing skip patterns for timing-sensitive tests (`sustained_load_p99_under_5ms`, etc.) and environment-constrained tests (`ebpf_`). The `selftest_*` tests continue to run and pass in the main CI job (`ci.yml`) where Node.js is available.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-1551
- Reference failing CI run: https://github.com/AI-agent-assembly/agent-assembly/actions/runs/26083113766/job/76689392471?pr=576

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [x] No tests required (explain why)

CI YAML change only — correctness verified by the SonarCloud job passing on this PR. The `selftest_*` tests themselves are unchanged and will continue to be exercised in `ci.yml`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention