### PR TITLE
[AAASM-1241] ✅ (aa-integration-tests): Link 4 #[ignore] markers to tracked follow-up tickets

### DIFF
--- a/aa-integration-tests/tests/e2e_audit.rs
+++ b/aa-integration-tests/tests/e2e_audit.rs
@@ -251,7 +251,7 @@ async fn audit_chain_break_detected_when_entry_modified() {
 /// Blocked: requires spawning the `aa-gateway` binary, sending SIGTERM, and
 /// restarting — infrastructure not yet available in the integration harness.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "requires binary gateway spawn + SIGTERM/restart infrastructure"]
+#[ignore = "blocked on AAASM-1601: binary gateway spawn + SIGTERM/restart test infrastructure not yet available"]
 async fn audit_chain_survives_gateway_restart() {
     todo!("implement once binary-spawn harness is available")
 }

--- a/aa-integration-tests/tests/e2e_budget.rs
+++ b/aa-integration-tests/tests/e2e_budget.rs
@@ -190,7 +190,7 @@ async fn budget_exhausted_request_is_rejected_at_tracking_layer() {
 /// sub-day budget windows (e.g. `window: "5s"`) are not supported in v0.0.1.
 /// Remove the `#[ignore]` and implement once a configurable flush interval is
 /// added to `BudgetTracker`.
-#[ignore]
+#[ignore = "blocked on AAASM-1600: BudgetTracker sub-day window flush interval not implemented"]
 #[tokio::test(flavor = "multi_thread")]
 async fn budget_resets_after_daily_window() {
     unimplemented!(

--- a/aa-integration-tests/tests/e2e_sdk_node.rs
+++ b/aa-integration-tests/tests/e2e_sdk_node.rs
@@ -263,7 +263,7 @@ fn selftest_langgraph_hierarchy_exits_zero_and_emits_root_planner_executor_start
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "requires running aa-gateway and Node.js native bindings (AAASM-1514 follow-up)"]
+#[ignore = "blocked on AAASM-1602: live-gateway + Node.js native-binding test fixture not yet available"]
 fn real_langchain_single_agent_registers_with_gateway_and_emits_started_done() {
     let addr = std::env::var("AA_GATEWAY_ADDR").unwrap_or_else(|_| "127.0.0.1:50051".to_string());
     let output = run_ts_script(
@@ -289,7 +289,7 @@ fn real_langchain_single_agent_registers_with_gateway_and_emits_started_done() {
 }
 
 #[test]
-#[ignore = "requires running aa-gateway and Node.js native bindings (AAASM-1514 follow-up)"]
+#[ignore = "blocked on AAASM-1602: live-gateway + Node.js native-binding test fixture not yet available"]
 fn real_langgraph_single_agent_registers_with_gateway_and_emits_started_done() {
     let addr = std::env::var("AA_GATEWAY_ADDR").unwrap_or_else(|_| "127.0.0.1:50051".to_string());
     let output = run_ts_script(
@@ -315,7 +315,7 @@ fn real_langgraph_single_agent_registers_with_gateway_and_emits_started_done() {
 }
 
 #[test]
-#[ignore = "requires running aa-gateway and Node.js native bindings (AAASM-1514 follow-up)"]
+#[ignore = "blocked on AAASM-1602: live-gateway + Node.js native-binding test fixture not yet available"]
 fn real_langchain_team_registers_root_and_member_with_gateway() {
     let addr = std::env::var("AA_GATEWAY_ADDR").unwrap_or_else(|_| "127.0.0.1:50051".to_string());
     let output = run_ts_script(
@@ -348,7 +348,7 @@ fn real_langchain_team_registers_root_and_member_with_gateway() {
 }
 
 #[test]
-#[ignore = "requires running aa-gateway and Node.js native bindings (AAASM-1514 follow-up)"]
+#[ignore = "blocked on AAASM-1602: live-gateway + Node.js native-binding test fixture not yet available"]
 fn real_langgraph_team_registers_coordinator_and_worker_with_gateway() {
     let addr = std::env::var("AA_GATEWAY_ADDR").unwrap_or_else(|_| "127.0.0.1:50051".to_string());
     let output = run_ts_script(
@@ -381,7 +381,7 @@ fn real_langgraph_team_registers_coordinator_and_worker_with_gateway() {
 }
 
 #[test]
-#[ignore = "requires running aa-gateway and Node.js native bindings (AAASM-1514 follow-up)"]
+#[ignore = "blocked on AAASM-1602: live-gateway + Node.js native-binding test fixture not yet available"]
 fn real_langgraph_hierarchy_registers_root_planner_executor_with_gateway() {
     let addr = std::env::var("AA_GATEWAY_ADDR").unwrap_or_else(|_| "127.0.0.1:50051".to_string());
     let output = run_ts_script(

--- a/aa-integration-tests/tests/e2e_topology.rs
+++ b/aa-integration-tests/tests/e2e_topology.rs
@@ -406,7 +406,7 @@ async fn policy_requires_approval_for_spawn_child_at_depth_two() {
 ///
 /// Marked `#[ignore]` because `AgentRegistry` does not yet implement
 /// re-parenting. Unblock by implementing `AgentRegistry::reparent`.
-#[ignore = "re-parenting not implemented in AgentRegistry (follow-up ticket pending)"]
+#[ignore = "blocked on AAASM-1599: AgentRegistry::reparent not implemented"]
 #[tokio::test(flavor = "multi_thread")]
 async fn policy_evaluates_against_current_topology_after_reparent() {
     let env = TopologyTestEnv::start().await.expect("harness should start");


### PR DESCRIPTION
## Description

Clears AAASM-1241 AC #4 ("No undocumented `#[ignore]` tests remain unintentionally — enumerate every `#[ignore]` and verify it has a linked follow-up").

The F116 `#[ignore]` audit during ST-V verification found 4 violation clusters where ignored tests either had no ticket reference, no reason string, or pointed at a now-Done ticket. Filed 4 new sub-tickets under AAASM-1232 to track the underlying work, and this PR updates each `#[ignore]` reason string to reference the right one:

| File:line | Before | After |
|---|---|---|
| `e2e_topology.rs:409` | `#[ignore = "re-parenting not implemented in AgentRegistry (follow-up ticket pending)"]` | `#[ignore = "blocked on AAASM-1599: ..."]` |
| `e2e_budget.rs:193` | `#[ignore]` (bare attribute) | `#[ignore = "blocked on AAASM-1600: ..."]` |
| `e2e_audit.rs:254` | `#[ignore = "requires binary gateway spawn + SIGTERM/restart infrastructure"]` | `#[ignore = "blocked on AAASM-1601: ..."]` |
| `e2e_sdk_node.rs:266,292,318,351,384` (×5) | `#[ignore = "... (AAASM-1514 follow-up)"]` (stale ref to Done ticket) | `#[ignore = "blocked on AAASM-1602: ..."]` |

After merge, every F116 `#[ignore]` marker references a tracked, open ticket:

| Ignored test | Tracked under |
|---|---|
| `e2e_audit.rs:78, 96` | AAASM-237 |
| `e2e_audit.rs:254` | **AAASM-1601** (this PR) |
| `e2e_budget.rs:193` | **AAASM-1600** (this PR) |
| `e2e_ebpf.rs:246` | AAASM-1567 |
| `e2e_file_monitoring.rs:467, 516` | AAASM-1574 |
| `e2e_sdk_node.rs:266, 292, 318, 351, 384` | **AAASM-1602** (this PR) |
| `e2e_topology.rs:409` | **AAASM-1599** (this PR) |

No test behavior changes — every test that was ignored is still ignored. The only diff is the reason string in the attribute.

## Type of Change

- [x] ✅ Tests (documentation-style metadata update in test attributes)

## Breaking Changes

- [x] No — `cargo nextest run -p aa-integration-tests` produces an identical pass/skip set before and after.

## Related Issues

- AAASM-1241 (parent — F116 ST-V verification)
- Newly filed follow-ups: AAASM-1599, AAASM-1600, AAASM-1601, AAASM-1602
- AAASM-1232 (F116 story)

## Testing

- [x] No tests required — strictly metadata update; lefthook fmt/clippy clean on every commit. CI will confirm `Integration tests (ubuntu-latest) + (macos-latest)` and `e2e — Layer 3 eBPF (Linux)` keep their existing pass/skip set.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] All commits small (one per file) and follow the Gitmoji convention
- [ ] All CI checks passing — to be confirmed on this PR