### PR TITLE
[AAASM-1625] ✨ (aa-api/alerts): Extend StoredAlert with optional rule_context + first_fired_at/resolved_at

### DIFF
--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -12,6 +12,8 @@ use aa_gateway::alerts::SecretAlert;
 use aa_gateway::budget::types::BudgetAlert;
 use serde::Serialize;
 
+use crate::alerts::detail::RuleContext;
+
 /// Stored representation of an alert with metadata.
 #[derive(Debug, Clone, Serialize)]
 pub struct StoredAlert {
@@ -51,6 +53,18 @@ pub struct StoredAlert {
     /// contains any byte of the original secret. `None` for budget
     /// alerts.
     pub redacted_value: Option<String>,
+    /// ISO 8601 timestamp of the first fire — mirrors `timestamp` for
+    /// budget/secret alerts and is set explicitly for rule alerts so
+    /// re-fires within a dedup window keep the original fire time.
+    pub first_fired_at: String,
+    /// ISO 8601 timestamp at which the alert was resolved. `None`
+    /// while the alert is still firing.
+    pub resolved_at: Option<String>,
+    /// Rich rule-engine context attached to alerts that came from the
+    /// rule engine. `None` for legacy budget/secret alerts. See
+    /// AAASM-1385 for the full schema.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rule_context: Option<RuleContext>,
 }
 
 /// Alert severity level derived from the budget threshold percentage.
@@ -152,7 +166,7 @@ pub fn stored_secret_alert_from(alert: &SecretAlert, id: String, timestamp: Stri
         message: build_secret_alert_message(alert),
         agent_id: format_agent_id(&alert.agent_id),
         team_id: alert.team_id.clone(),
-        timestamp,
+        timestamp: timestamp.clone(),
         threshold_pct: 0,
         spent_usd: 0.0,
         limit_usd: 0.0,
@@ -160,6 +174,9 @@ pub fn stored_secret_alert_from(alert: &SecretAlert, id: String, timestamp: Stri
         updated_at: None,
         detected_pattern_type: Some(kind.as_str().to_string()),
         redacted_value: Some(alert.redacted_label()),
+        first_fired_at: timestamp,
+        resolved_at: None,
+        rule_context: None,
     }
 }
 
@@ -172,7 +189,7 @@ pub fn stored_alert_from(alert: &BudgetAlert, id: String, timestamp: String) -> 
         message: build_alert_message(alert),
         agent_id: format_agent_id(&alert.agent_id),
         team_id: alert.team_id.clone(),
-        timestamp,
+        timestamp: timestamp.clone(),
         threshold_pct: alert.threshold_pct,
         spent_usd: alert.spent_usd,
         limit_usd: alert.limit_usd,
@@ -180,6 +197,9 @@ pub fn stored_alert_from(alert: &BudgetAlert, id: String, timestamp: String) -> 
         updated_at: None,
         detected_pattern_type: None,
         redacted_value: None,
+        first_fired_at: timestamp,
+        resolved_at: None,
+        rule_context: None,
     }
 }
 

--- a/aa-api/src/alerts/store.rs
+++ b/aa-api/src/alerts/store.rs
@@ -101,10 +101,12 @@ impl AlertStore for InMemoryAlertStore {
     fn resolve(&self, id: &str, _reason: Option<&str>) -> Option<StoredAlert> {
         let mut buf = self.alerts.write().expect("alert store lock poisoned");
         let alert = buf.iter_mut().find(|a| a.id == id)?;
-        // Idempotent: don't bump `updated_at` on subsequent resolves.
+        // Idempotent: don't bump timestamps on subsequent resolves.
         if alert.status != "resolved" {
+            let now = chrono::Utc::now().to_rfc3339();
             alert.status = "resolved".to_string();
-            alert.updated_at = Some(chrono::Utc::now().to_rfc3339());
+            alert.updated_at = Some(now.clone());
+            alert.resolved_at = Some(now);
         }
         Some(alert.clone())
     }
@@ -261,6 +263,10 @@ mod tests {
         let after = store.resolve(&id, Some("ack")).expect("known id resolves");
         assert_eq!(after.status, "resolved");
         assert!(after.updated_at.is_some());
+        assert_eq!(
+            after.resolved_at, after.updated_at,
+            "resolved_at must be set in lockstep with updated_at on the first resolve",
+        );
 
         let from_store = store.get(&id).unwrap();
         assert_eq!(from_store.status, "resolved");

--- a/aa-api/src/alerts/store.rs
+++ b/aa-api/src/alerts/store.rs
@@ -324,6 +324,29 @@ mod tests {
     }
 
     #[test]
+    fn legacy_alert_constructors_default_rule_context_to_none() {
+        let store = InMemoryAlertStore::new();
+        let budget_id = store.record(&test_alert(80));
+        let secret_id = store.record_secret(&test_secret_alert(CredentialKind::AwsAccessKey));
+
+        let budget = store.get(&budget_id).expect("budget alert");
+        let secret = store.get(&secret_id).expect("secret alert");
+
+        for stored in [&budget, &secret] {
+            assert!(
+                stored.rule_context.is_none(),
+                "legacy alerts must not carry a rule_context",
+            );
+            assert!(!stored.first_fired_at.is_empty(), "first_fired_at must be populated",);
+            assert_eq!(
+                stored.first_fired_at, stored.timestamp,
+                "first_fired_at must mirror timestamp for legacy alerts",
+            );
+            assert!(stored.resolved_at.is_none(), "resolved_at must be None pre-resolve");
+        }
+    }
+
+    #[test]
     fn record_and_record_secret_produce_distinct_ulids() {
         let store = InMemoryAlertStore::new();
         let budget_id = store.record(&test_alert(80));


### PR DESCRIPTION
## Description

Second slice of AAASM-1385. Extends the in-memory `StoredAlert` so it can carry the new rich rule-context payload alongside the legacy budget/secret alert shape.

Changes:

- `StoredAlert` gains `first_fired_at: String`, `resolved_at: Option<String>`, and `rule_context: Option<RuleContext>`. `rule_context` is `#[serde(skip_serializing_if = "Option::is_none")]` so legacy alert payloads stay byte-identical when no rule context is present.
- `stored_alert_from` and `stored_secret_alert_from` mirror `first_fired_at` from the captured `timestamp`, default `resolved_at: None` and `rule_context: None`.
- `InMemoryAlertStore::resolve` now sets `resolved_at` in lockstep with `updated_at` from a single `Utc::now()` snapshot when the alert first transitions to `"resolved"`. Idempotent on repeat calls.

## Stacked PR

This branch is stacked on **#588** ([AAASM-1624](https://lightning-dust-mite.atlassian.net/browse/AAASM-1624) — alert-detail data types). Until #588 lands, the diff against `master` includes #588's commits. Review only commits `80b3ffd8`, `ced9ee06`, `ae2d06d8`.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Legacy budget/secret alert JSON payloads are unchanged thanks to the `skip_serializing_if` on `rule_context`. New `first_fired_at` and (post-resolve) `resolved_at` fields surface in `StoredAlert` only — the public `AlertResponse` is untouched until AAASM-1628 wires the new `AlertDetailResponse`.

## Related Issues

- Related Jira ticket: [AAASM-1625](https://lightning-dust-mite.atlassian.net/browse/AAASM-1625) (sub-task of [AAASM-1385](https://lightning-dust-mite.atlassian.net/browse/AAASM-1385))

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

New AC unit test `legacy_alert_constructors_default_rule_context_to_none` asserts both constructors produce records with `rule_context: None`, non-empty `first_fired_at == timestamp`, and `resolved_at: None`. The existing `resolve_flips_status_and_sets_updated_at` is extended to also assert `resolved_at == updated_at` on first resolve.

```
cargo nextest run -p aa-api alerts::
  Summary [   0.029s] 22 tests run: 22 passed, 319 skipped
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on each new field)
- [ ] All CI checks passing (pending)
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1624]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1625]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ