### PR TITLE
[AAASM-1626] ♻️ (aa-api/alerts): Rename AlertStore::get to get_by_id + add record_rule_alert

### DIFF
--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -17,7 +17,7 @@ use aa_gateway::budget::types::BudgetAlert;
 use serde::Serialize;
 use tokio::sync::broadcast;
 
-use crate::alerts::detail::RuleContext;
+use crate::alerts::detail::{RoutingLogEntry, RuleContext, RuleSnapshot};
 
 /// Stored representation of an alert with metadata.
 #[derive(Debug, Clone, Serialize)]
@@ -219,6 +219,92 @@ pub fn stored_alert_from(alert: &BudgetAlert, id: String, timestamp: String) -> 
         first_fired_at: timestamp,
         resolved_at: None,
         rule_context: None,
+    }
+}
+
+/// Input payload for `AlertStore::record_rule_alert`.
+///
+/// Carries everything the store needs to build a `StoredAlert` with
+/// populated `rule_context`. Intentionally constructible from test
+/// fixtures and (eventually) the gateway's rule engine — the in-memory
+/// store does not own the rule lifecycle.
+#[derive(Debug, Clone)]
+pub struct RuleAlertSeed {
+    /// Agent that triggered the rule. `None` for org-scope alerts.
+    pub agent_id: Option<aa_core::AgentId>,
+    /// Team attribution. `None` when the alert is not scoped to a team.
+    pub team_id: Option<String>,
+    /// Identifier of the rule that produced the alert.
+    pub rule_id: String,
+    /// Human-readable rule name.
+    pub rule_name: String,
+    /// Snapshot of the rule definition at fire time.
+    pub rule_snapshot: RuleSnapshot,
+    /// Destinations the rule routes to (in priority order).
+    pub destination_ids: Vec<String>,
+    /// Free-form payload of the triggering event.
+    pub event_payload: serde_json::Value,
+    /// Connector-framework delivery log seeded with this fire's attempts.
+    pub routing_log: Vec<RoutingLogEntry>,
+}
+
+/// Map a rule-engine severity string to the existing `AlertSeverity` enum.
+///
+/// The spec uses `"CRITICAL"`, `"HIGH"`, `"MEDIUM"`, `"LOW"`; the existing
+/// enum only models `Critical / Warning / Info`. `HIGH` collapses into
+/// `Critical`, `MEDIUM` into `Warning`, everything else into `Info`. The
+/// original spec string is preserved on `rule_snapshot.severity` for the UI.
+pub fn severity_from_rule_string(s: &str) -> AlertSeverity {
+    match s.to_ascii_uppercase().as_str() {
+        "CRITICAL" | "HIGH" => AlertSeverity::Critical,
+        "MEDIUM" | "WARNING" => AlertSeverity::Warning,
+        _ => AlertSeverity::Info,
+    }
+}
+
+/// Build a human-readable message for a rule alert.
+fn build_rule_alert_message(seed: &RuleAlertSeed) -> String {
+    format!(
+        "Rule alert: {} ({}) fired with severity {}",
+        seed.rule_name, seed.rule_id, seed.rule_snapshot.severity,
+    )
+}
+
+/// Convert a `RuleAlertSeed` into a `StoredAlert` with populated
+/// `rule_context`. The dedup occurrence counter is seeded to 1 and
+/// `dedup_window_expires_at` is left for the store's dedup state
+/// machine to compute (AAASM-1627).
+pub fn stored_rule_alert_from(seed: &RuleAlertSeed, id: u64, timestamp: String) -> StoredAlert {
+    let agent_id_str = seed.agent_id.as_ref().map(format_agent_id).unwrap_or_default();
+    let severity = severity_from_rule_string(&seed.rule_snapshot.severity);
+    StoredAlert {
+        id,
+        severity,
+        category: AlertCategory::Rule,
+        message: build_rule_alert_message(seed),
+        agent_id: agent_id_str,
+        team_id: seed.team_id.clone(),
+        timestamp: timestamp.clone(),
+        threshold_pct: 0,
+        spent_usd: 0.0,
+        limit_usd: 0.0,
+        status: "unresolved".to_string(),
+        updated_at: None,
+        detected_pattern_type: None,
+        redacted_value: None,
+        first_fired_at: timestamp,
+        resolved_at: None,
+        rule_context: Some(RuleContext {
+            rule_id: seed.rule_id.clone(),
+            rule_name: seed.rule_name.clone(),
+            rule_snapshot: seed.rule_snapshot.clone(),
+            destination_ids: seed.destination_ids.clone(),
+            event_payload: seed.event_payload.clone(),
+            routing_log: seed.routing_log.clone(),
+            silence: None,
+            dedup_occurrence_count: 1,
+            dedup_window_expires_at: None,
+        }),
     }
 }
 

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -274,7 +274,7 @@ fn build_rule_alert_message(seed: &RuleAlertSeed) -> String {
 /// `rule_context`. The dedup occurrence counter is seeded to 1 and
 /// `dedup_window_expires_at` is left for the store's dedup state
 /// machine to compute (AAASM-1627).
-pub fn stored_rule_alert_from(seed: &RuleAlertSeed, id: u64, timestamp: String) -> StoredAlert {
+pub fn stored_rule_alert_from(seed: &RuleAlertSeed, id: String, timestamp: String) -> StoredAlert {
     let agent_id_str = seed.agent_id.as_ref().map(format_agent_id).unwrap_or_default();
     let severity = severity_from_rule_string(&seed.rule_snapshot.severity);
     StoredAlert {
@@ -289,6 +289,7 @@ pub fn stored_rule_alert_from(seed: &RuleAlertSeed, id: u64, timestamp: String) 
         spent_usd: 0.0,
         limit_usd: 0.0,
         status: "unresolved".to_string(),
+        prior_status: None,
         updated_at: None,
         detected_pattern_type: None,
         redacted_value: None,
@@ -325,7 +326,7 @@ pub trait AlertStore: Send + Sync {
     /// populated `rule_context`. Dedup state defaults to occurrence 1
     /// with no window expiry — `dedup_or_record_rule_alert` (AAASM-1627)
     /// is the dedup-aware entry point.
-    fn record_rule_alert(&self, seed: &RuleAlertSeed) -> u64;
+    fn record_rule_alert(&self, seed: &RuleAlertSeed) -> String;
 
     /// List stored alerts with pagination.
     ///

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -111,6 +111,9 @@ pub enum AlertCategory {
     /// One or more credential / sensitive-value patterns detected in an
     /// outbound payload by the gateway's credential scanner.
     SecretDetected,
+    /// Alert produced by the rule engine — carries `rule_context` with
+    /// the rule snapshot, routing log, and dedup state (AAASM-1385).
+    Rule,
 }
 
 impl std::fmt::Display for AlertCategory {
@@ -118,6 +121,7 @@ impl std::fmt::Display for AlertCategory {
         match self {
             AlertCategory::Budget => write!(f, "budget"),
             AlertCategory::SecretDetected => write!(f, "secret_detected"),
+            AlertCategory::Rule => write!(f, "rule"),
         }
     }
 }

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -237,7 +237,7 @@ pub trait AlertStore: Send + Sync {
 
     /// Retrieve a single alert by its ULID, or `None` if the ID is
     /// unknown or has been evicted by the ring buffer.
-    fn get(&self, id: &str) -> Option<StoredAlert>;
+    fn get_by_id(&self, id: &str) -> Option<StoredAlert>;
 
     /// Mark an alert as resolved. Returns the post-mutation record, or
     /// `None` if the ID is unknown / evicted. Must be **idempotent** —

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -320,6 +320,13 @@ pub trait AlertStore: Send + Sync {
     /// `category=secret_detected`.
     fn record_secret(&self, alert: &SecretAlert) -> String;
 
+    /// Record a rule-engine alert (AAASM-1385), returning the assigned
+    /// ID. The stored alert has `category: AlertCategory::Rule` and a
+    /// populated `rule_context`. Dedup state defaults to occurrence 1
+    /// with no window expiry — `dedup_or_record_rule_alert` (AAASM-1627)
+    /// is the dedup-aware entry point.
+    fn record_rule_alert(&self, seed: &RuleAlertSeed) -> u64;
+
     /// List stored alerts with pagination.
     ///
     /// Returns `(alerts, total_count)`. Results are ordered newest-first.

--- a/aa-api/src/alerts/store.rs
+++ b/aa-api/src/alerts/store.rs
@@ -113,7 +113,7 @@ impl AlertStore for InMemoryAlertStore {
         (items, total)
     }
 
-    fn get(&self, id: &str) -> Option<StoredAlert> {
+    fn get_by_id(&self, id: &str) -> Option<StoredAlert> {
         let buf = self.alerts.read().expect("alert store lock poisoned");
         buf.iter().find(|a| a.id == id).cloned()
     }
@@ -291,13 +291,13 @@ mod tests {
         let store = InMemoryAlertStore::new();
         let id = store.record(&test_alert(95));
 
-        let found = store.get(&id).expect("known id should return Some");
+        let found = store.get_by_id(&id).expect("known id should return Some");
         assert_eq!(found.id, id);
         assert_eq!(found.threshold_pct, 95);
         assert_eq!(found.status, "unresolved");
 
         assert!(
-            store.get("00000000000000000000000000").is_none(),
+            store.get_by_id("00000000000000000000000000").is_none(),
             "unknown id returns None"
         );
     }
@@ -309,14 +309,14 @@ mod tests {
         store.record(&test_alert(80));
         store.record(&test_alert(90));
 
-        assert!(store.get(&id1).is_none(), "evicted id should return None");
+        assert!(store.get_by_id(&id1).is_none(), "evicted id should return None");
     }
 
     #[test]
     fn resolve_flips_status_and_sets_updated_at() {
         let store = InMemoryAlertStore::new();
         let id = store.record(&test_alert(95));
-        let before = store.get(&id).unwrap();
+        let before = store.get_by_id(&id).unwrap();
         assert_eq!(before.status, "unresolved");
         assert!(before.updated_at.is_none());
 
@@ -328,7 +328,7 @@ mod tests {
             "resolved_at must be set in lockstep with updated_at on the first resolve",
         );
 
-        let from_store = store.get(&id).unwrap();
+        let from_store = store.get_by_id(&id).unwrap();
         assert_eq!(from_store.status, "resolved");
         assert_eq!(from_store.updated_at, after.updated_at);
     }
@@ -375,7 +375,7 @@ mod tests {
         let store = InMemoryAlertStore::new();
         let id = store.record_secret(&test_secret_alert(CredentialKind::AwsAccessKey));
 
-        let found = store.get(&id).expect("recorded secret alert must be retrievable");
+        let found = store.get_by_id(&id).expect("recorded secret alert must be retrievable");
         assert_eq!(found.severity, super::super::AlertSeverity::Critical);
         assert_eq!(found.category, super::super::AlertCategory::SecretDetected);
         assert_eq!(found.detected_pattern_type.as_deref(), Some("AwsAccessKey"));
@@ -389,8 +389,8 @@ mod tests {
         let budget_id = store.record(&test_alert(80));
         let secret_id = store.record_secret(&test_secret_alert(CredentialKind::AwsAccessKey));
 
-        let budget = store.get(&budget_id).expect("budget alert");
-        let secret = store.get(&secret_id).expect("secret alert");
+        let budget = store.get_by_id(&budget_id).expect("budget alert");
+        let secret = store.get_by_id(&secret_id).expect("secret alert");
 
         for stored in [&budget, &secret] {
             assert!(

--- a/aa-api/src/alerts/store.rs
+++ b/aa-api/src/alerts/store.rs
@@ -106,16 +106,19 @@ impl AlertStore for InMemoryAlertStore {
         id
     }
 
-    fn record_rule_alert(&self, seed: &RuleAlertSeed) -> u64 {
-        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+    fn record_rule_alert(&self, seed: &RuleAlertSeed) -> String {
+        let id = self.next_id();
         let timestamp = chrono::Utc::now().to_rfc3339();
-        let stored = stored_rule_alert_from(seed, id, timestamp);
+        let stored = stored_rule_alert_from(seed, id.clone(), timestamp);
 
-        let mut buf = self.alerts.write().expect("alert store lock poisoned");
-        if buf.len() >= self.capacity {
-            buf.pop_front();
+        {
+            let mut buf = self.alerts.write().expect("alert store lock poisoned");
+            if buf.len() >= self.capacity {
+                buf.pop_front();
+            }
+            buf.push_back(stored.clone());
         }
-        buf.push_back(stored);
+        let _ = self.event_tx.send(AlertEvent::Fire(stored));
         id
     }
 
@@ -210,6 +213,34 @@ mod tests {
             team_id: Some("team-pioneer".to_string()),
             kinds: vec![kind],
             finding_count: 1,
+        }
+    }
+
+    fn test_rule_seed() -> RuleAlertSeed {
+        use crate::alerts::detail::{RoutingLogEntry, RuleSnapshot};
+        use std::collections::BTreeMap;
+
+        RuleAlertSeed {
+            agent_id: Some(AgentId::from_bytes([0x55; 16])),
+            team_id: Some("team-platform".to_string()),
+            rule_id: "rule-budget-90".to_string(),
+            rule_name: "Budget threshold > 90%".to_string(),
+            rule_snapshot: RuleSnapshot {
+                metric: "budget_spent_pct".to_string(),
+                operator: ">".to_string(),
+                threshold: 90.0,
+                evaluation_window_seconds: 300,
+                severity: "CRITICAL".to_string(),
+                dedup_window_seconds: 600,
+                suppression_labels: BTreeMap::new(),
+            },
+            destination_ids: vec!["slack-ops".to_string()],
+            event_payload: serde_json::json!({ "metric_value": 92.3 }),
+            routing_log: vec![RoutingLogEntry {
+                destination_id: "slack-ops".to_string(),
+                delivered_at: "2026-05-13T09:12:01Z".to_string(),
+                status: "ok".to_string(),
+            }],
         }
     }
 
@@ -400,6 +431,35 @@ mod tests {
     }
 
     #[test]
+    fn record_rule_alert_round_trips_via_get_by_id() {
+        let store = InMemoryAlertStore::new();
+        let seed = test_rule_seed();
+        let id = store.record_rule_alert(&seed);
+
+        let stored = store.get_by_id(&id).expect("recorded rule alert must be retrievable");
+        assert_eq!(stored.id, id);
+        assert_eq!(stored.category, super::super::AlertCategory::Rule);
+
+        let ctx = stored.rule_context.as_ref().expect("rule_context must be populated");
+        assert_eq!(ctx.rule_id, "rule-budget-90");
+        assert_eq!(ctx.rule_name, "Budget threshold > 90%");
+        assert_eq!(ctx.dedup_occurrence_count, 1);
+        assert!(
+            ctx.dedup_window_expires_at.is_none(),
+            "dedup expiry seeded by 1626 only"
+        );
+        assert_eq!(ctx.destination_ids, vec!["slack-ops".to_string()]);
+        assert_eq!(ctx.routing_log.len(), 1);
+    }
+
+    #[test]
+    fn get_by_id_returns_none_for_unknown_rule_alert_id() {
+        let store = InMemoryAlertStore::new();
+        store.record_rule_alert(&test_rule_seed());
+        assert!(store.get_by_id("00000000000000000000000000").is_none());
+    }
+
+    #[test]
     fn legacy_alert_constructors_default_rule_context_to_none() {
         let store = InMemoryAlertStore::new();
         let budget_id = store.record(&test_alert(80));
@@ -472,7 +532,7 @@ mod tests {
         assert_eq!(suppressed.prior_status.as_deref(), Some("unresolved"));
         assert!(suppressed.updated_at.is_some());
 
-        let from_store = store.get(&id).unwrap();
+        let from_store = store.get_by_id(&id).unwrap();
         assert_eq!(from_store.status, "suppressed");
         assert_eq!(from_store.prior_status.as_deref(), Some("unresolved"));
     }

--- a/aa-api/src/alerts/store.rs
+++ b/aa-api/src/alerts/store.rs
@@ -8,7 +8,10 @@ use aa_gateway::budget::types::BudgetAlert;
 use tokio::sync::broadcast;
 use ulid::Generator;
 
-use super::{stored_alert_from, stored_secret_alert_from, AlertEvent, AlertStore, StoredAlert};
+use super::{
+    stored_alert_from, stored_rule_alert_from, stored_secret_alert_from, AlertEvent, AlertStore, RuleAlertSeed,
+    StoredAlert,
+};
 
 /// Capacity of the per-store `tokio::broadcast` channel used for the
 /// `AlertEvent` lifecycle bus. Subscribers that lag past this many
@@ -100,6 +103,19 @@ impl AlertStore for InMemoryAlertStore {
             buf.push_back(stored.clone());
         }
         let _ = self.event_tx.send(AlertEvent::Fire(stored));
+        id
+    }
+
+    fn record_rule_alert(&self, seed: &RuleAlertSeed) -> u64 {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let timestamp = chrono::Utc::now().to_rfc3339();
+        let stored = stored_rule_alert_from(seed, id, timestamp);
+
+        let mut buf = self.alerts.write().expect("alert store lock poisoned");
+        if buf.len() >= self.capacity {
+            buf.pop_front();
+        }
+        buf.push_back(stored);
         id
     }
 

--- a/aa-api/src/routes/alerts.rs
+++ b/aa-api/src/routes/alerts.rs
@@ -125,7 +125,7 @@ pub async fn get_alert(
     Extension(state): Extension<AppState>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> Result<(StatusCode, Json<AlertResponse>), ProblemDetail> {
-    let stored = state.alert_store.get(&id).ok_or_else(|| {
+    let stored = state.alert_store.get_by_id(&id).ok_or_else(|| {
         ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Alert not found: {id}"))
     })?;
 


### PR DESCRIPTION
## Description

Third slice of AAASM-1385. Two adjacent changes to `AlertStore`:

1. **Rename `get` → `get_by_id`** on the trait + in-memory impl. Updates the one production caller (`aa-api/src/routes/alerts.rs`) and the store's own unit tests. Behavior unchanged. Matches the AAASM-1385 AC verbiage verbatim.
2. **Add `record_rule_alert(seed: RuleAlertSeed) -> u64`** trait method + impl. `RuleAlertSeed` lives in `aa-api/src/alerts/mod.rs` next to the existing `BudgetAlert` / `SecretAlert` entry points and carries: agent/team scoping, rule identifier + snapshot, destinations, triggering event payload, and any routing-log entries the caller wants to seed.

Supporting changes:

- `AlertCategory::Rule` variant (serializes as `"rule"`)
- `severity_from_rule_string` mapping the spec's `CRITICAL/HIGH/MEDIUM/LOW` strings into the existing `AlertSeverity` enum
- `stored_rule_alert_from` constructor that produces a `StoredAlert` with populated `rule_context` (dedup_occurrence_count: 1, no window expiry yet — the dedup state machine in AAASM-1627 owns those)

## Stacked PR

Stacked on **#588** ([AAASM-1624](https://lightning-dust-mite.atlassian.net/browse/AAASM-1624)) and **#589** ([AAASM-1625](https://lightning-dust-mite.atlassian.net/browse/AAASM-1625)). Review only commits `4cee7757`, `54cc5d23`, `5d070892`, `80b45956`, `c1f35b79`.

## Type of Change

- [x] ✨ New feature (`record_rule_alert`, `RuleAlertSeed`, `AlertCategory::Rule`)
- [ ] 🐛 Bug fix
- [x] ♻️ Refactoring (`get` → `get_by_id` rename)
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

`AlertStore::get` was a crate-internal trait method with one production caller; rename is contained. Public HTTP / gRPC payloads are unchanged.

## Related Issues

- Related Jira ticket: [AAASM-1626](https://lightning-dust-mite.atlassian.net/browse/AAASM-1626) (sub-task of [AAASM-1385](https://lightning-dust-mite.atlassian.net/browse/AAASM-1385))

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

New tests: `record_rule_alert_round_trips_via_get_by_id`, `get_by_id_returns_none_for_unknown_rule_alert_id`. Shared `test_rule_seed()` fixture in the tests module is reused by AAASM-1627 and AAASM-1629.

```
cargo nextest run -p aa-api alerts::store::tests
  Summary [   0.030s] 17 tests run: 17 passed
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on the new trait method + types)
- [ ] All CI checks passing (pending)
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1624]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ