### PR TITLE
[AAASM-1644] ♻️ (aa-api): Switch StoredAlert.id from u64 to ULID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "ulid",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
@@ -6451,6 +6452,16 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.4",
+ "web-time",
+]
 
 [[package]]
 name = "unarray"

--- a/aa-api/Cargo.toml
+++ b/aa-api/Cargo.toml
@@ -38,6 +38,7 @@ hex = "0.4"
 moka = { version = "0.12", features = ["future"] }
 rust_decimal = { version = "1", features = ["serde-str"] }
 tokio-stream = "0.1"
+ulid = "1"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -14,8 +14,8 @@ use serde::Serialize;
 /// Stored representation of an alert with metadata.
 #[derive(Debug, Clone, Serialize)]
 pub struct StoredAlert {
-    /// Auto-incremented alert identifier.
-    pub id: u64,
+    /// Lexicographically sortable, URL-safe ULID identifier (26 chars).
+    pub id: String,
     /// Alert severity level derived from `threshold_pct`.
     pub severity: AlertSeverity,
     /// Source classification — `Budget` today, `SecretDetected` once
@@ -142,7 +142,7 @@ fn build_secret_alert_message(alert: &SecretAlert) -> String {
 
 /// Convert a [`SecretAlert`] into a [`StoredAlert`] with the given ID
 /// and timestamp. Severity is always `Critical` per AAASM-1545.
-pub fn stored_secret_alert_from(alert: &SecretAlert, id: u64, timestamp: String) -> StoredAlert {
+pub fn stored_secret_alert_from(alert: &SecretAlert, id: String, timestamp: String) -> StoredAlert {
     let kind = alert.primary_kind();
     StoredAlert {
         id,
@@ -163,7 +163,7 @@ pub fn stored_secret_alert_from(alert: &SecretAlert, id: u64, timestamp: String)
 }
 
 /// Convert a `BudgetAlert` into a `StoredAlert` with the given ID and timestamp.
-pub fn stored_alert_from(alert: &BudgetAlert, id: u64, timestamp: String) -> StoredAlert {
+pub fn stored_alert_from(alert: &BudgetAlert, id: String, timestamp: String) -> StoredAlert {
     StoredAlert {
         id,
         severity: severity_from_threshold(alert.threshold_pct),
@@ -186,27 +186,27 @@ pub fn stored_alert_from(alert: &BudgetAlert, id: u64, timestamp: String) -> Sto
 ///
 /// Implementations must be thread-safe (`Send + Sync`).
 pub trait AlertStore: Send + Sync {
-    /// Record a new budget alert, returning the assigned ID.
-    fn record(&self, alert: &BudgetAlert) -> u64;
+    /// Record a new budget alert, returning the assigned ULID.
+    fn record(&self, alert: &BudgetAlert) -> String;
 
-    /// Record a new secret-detection alert, returning the assigned ID
+    /// Record a new secret-detection alert, returning the assigned ULID
     /// (AAASM-1545). The stored alert has `severity=critical` and
     /// `category=secret_detected`.
-    fn record_secret(&self, alert: &SecretAlert) -> u64;
+    fn record_secret(&self, alert: &SecretAlert) -> String;
 
     /// List stored alerts with pagination.
     ///
     /// Returns `(alerts, total_count)`. Results are ordered newest-first.
     fn list(&self, limit: usize, offset: usize) -> (Vec<StoredAlert>, u64);
 
-    /// Retrieve a single alert by its numeric ID, or `None` if the ID is
+    /// Retrieve a single alert by its ULID, or `None` if the ID is
     /// unknown or has been evicted by the ring buffer.
-    fn get(&self, id: u64) -> Option<StoredAlert>;
+    fn get(&self, id: &str) -> Option<StoredAlert>;
 
     /// Mark an alert as resolved. Returns the post-mutation record, or
     /// `None` if the ID is unknown / evicted. Must be **idempotent** —
     /// calling `resolve` on an already-resolved alert returns the same
     /// record and does not bump `updated_at`. `_reason` is accepted for
     /// API parity but the in-memory store does not persist it.
-    fn resolve(&self, id: u64, _reason: Option<&str>) -> Option<StoredAlert>;
+    fn resolve(&self, id: &str, _reason: Option<&str>) -> Option<StoredAlert>;
 }

--- a/aa-api/src/alerts/store.rs
+++ b/aa-api/src/alerts/store.rs
@@ -1,11 +1,11 @@
 //! In-memory alert store backed by a bounded ring buffer.
 
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::RwLock;
+use std::sync::{Mutex, RwLock};
 
 use aa_gateway::alerts::SecretAlert;
 use aa_gateway::budget::types::BudgetAlert;
+use ulid::Generator;
 
 use super::{stored_alert_from, stored_secret_alert_from, AlertStore, StoredAlert};
 
@@ -19,7 +19,10 @@ const DEFAULT_CAPACITY: usize = 10_000;
 pub struct InMemoryAlertStore {
     alerts: RwLock<VecDeque<StoredAlert>>,
     capacity: usize,
-    next_id: AtomicU64,
+    /// Monotonic ULID generator. The `ulid` crate's `Generator` increments
+    /// the random portion within a single millisecond so IDs sort by
+    /// insertion order even at sub-millisecond record rates.
+    id_gen: Mutex<Generator>,
 }
 
 impl InMemoryAlertStore {
@@ -33,8 +36,17 @@ impl InMemoryAlertStore {
         Self {
             alerts: RwLock::new(VecDeque::with_capacity(capacity.min(DEFAULT_CAPACITY))),
             capacity,
-            next_id: AtomicU64::new(1),
+            id_gen: Mutex::new(Generator::new()),
         }
+    }
+
+    fn next_id(&self) -> String {
+        self.id_gen
+            .lock()
+            .expect("id generator lock poisoned")
+            .generate()
+            .expect("ULID monotonic generation overflow (impossible in normal operation)")
+            .to_string()
     }
 }
 
@@ -45,10 +57,10 @@ impl Default for InMemoryAlertStore {
 }
 
 impl AlertStore for InMemoryAlertStore {
-    fn record(&self, alert: &BudgetAlert) -> u64 {
-        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+    fn record(&self, alert: &BudgetAlert) -> String {
+        let id = self.next_id();
         let timestamp = chrono::Utc::now().to_rfc3339();
-        let stored = stored_alert_from(alert, id, timestamp);
+        let stored = stored_alert_from(alert, id.clone(), timestamp);
 
         let mut buf = self.alerts.write().expect("alert store lock poisoned");
         if buf.len() >= self.capacity {
@@ -58,10 +70,10 @@ impl AlertStore for InMemoryAlertStore {
         id
     }
 
-    fn record_secret(&self, alert: &SecretAlert) -> u64 {
-        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+    fn record_secret(&self, alert: &SecretAlert) -> String {
+        let id = self.next_id();
         let timestamp = chrono::Utc::now().to_rfc3339();
-        let stored = stored_secret_alert_from(alert, id, timestamp);
+        let stored = stored_secret_alert_from(alert, id.clone(), timestamp);
 
         let mut buf = self.alerts.write().expect("alert store lock poisoned");
         if buf.len() >= self.capacity {
@@ -81,12 +93,12 @@ impl AlertStore for InMemoryAlertStore {
         (items, total)
     }
 
-    fn get(&self, id: u64) -> Option<StoredAlert> {
+    fn get(&self, id: &str) -> Option<StoredAlert> {
         let buf = self.alerts.read().expect("alert store lock poisoned");
         buf.iter().find(|a| a.id == id).cloned()
     }
 
-    fn resolve(&self, id: u64, _reason: Option<&str>) -> Option<StoredAlert> {
+    fn resolve(&self, id: &str, _reason: Option<&str>) -> Option<StoredAlert> {
         let mut buf = self.alerts.write().expect("alert store lock poisoned");
         let alert = buf.iter_mut().find(|a| a.id == id)?;
         // Idempotent: don't bump `updated_at` on subsequent resolves.
@@ -127,67 +139,67 @@ mod tests {
     fn record_and_list_single_alert() {
         let store = InMemoryAlertStore::new();
         let id = store.record(&test_alert(80));
-        assert_eq!(id, 1);
+        assert_eq!(id.len(), 26, "ULID is always 26 chars");
 
         let (items, total) = store.list(10, 0);
         assert_eq!(total, 1);
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].id, 1);
+        assert_eq!(items[0].id, id);
         assert_eq!(items[0].threshold_pct, 80);
     }
 
     #[test]
     fn list_returns_newest_first() {
         let store = InMemoryAlertStore::new();
-        store.record(&test_alert(80));
-        store.record(&test_alert(95));
+        let id_old = store.record(&test_alert(80));
+        let id_new = store.record(&test_alert(95));
 
         let (items, total) = store.list(10, 0);
         assert_eq!(total, 2);
-        assert_eq!(items[0].id, 2); // newest
-        assert_eq!(items[1].id, 1); // oldest
+        assert_eq!(items[0].id, id_new); // newest
+        assert_eq!(items[1].id, id_old); // oldest
     }
 
     #[test]
     fn list_pagination_limit_and_offset() {
         let store = InMemoryAlertStore::new();
+        let mut ids = Vec::new();
         for i in 0..5 {
-            store.record(&test_alert(80 + i));
+            ids.push(store.record(&test_alert(80 + i)));
         }
 
-        // Page 1: limit=2, offset=0 → IDs 5, 4
+        // Page 1: limit=2, offset=0 → newest two (ids[4], ids[3])
         let (items, total) = store.list(2, 0);
         assert_eq!(total, 5);
         assert_eq!(items.len(), 2);
-        assert_eq!(items[0].id, 5);
-        assert_eq!(items[1].id, 4);
+        assert_eq!(items[0].id, ids[4]);
+        assert_eq!(items[1].id, ids[3]);
 
-        // Page 2: limit=2, offset=2 → IDs 3, 2
+        // Page 2: limit=2, offset=2 → ids[2], ids[1]
         let (items, _) = store.list(2, 2);
         assert_eq!(items.len(), 2);
-        assert_eq!(items[0].id, 3);
-        assert_eq!(items[1].id, 2);
+        assert_eq!(items[0].id, ids[2]);
+        assert_eq!(items[1].id, ids[1]);
 
-        // Page 3: limit=2, offset=4 → ID 1
+        // Page 3: limit=2, offset=4 → ids[0]
         let (items, _) = store.list(2, 4);
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0].id, 1);
+        assert_eq!(items[0].id, ids[0]);
     }
 
     #[test]
     fn capacity_evicts_oldest() {
         let store = InMemoryAlertStore::with_capacity(3);
-        store.record(&test_alert(70)); // id=1
-        store.record(&test_alert(80)); // id=2
-        store.record(&test_alert(90)); // id=3
-        store.record(&test_alert(95)); // id=4 — evicts id=1
+        let id1 = store.record(&test_alert(70));
+        let id2 = store.record(&test_alert(80));
+        let _id3 = store.record(&test_alert(90));
+        let id4 = store.record(&test_alert(95)); // evicts id1
 
         let (items, total) = store.list(10, 0);
         assert_eq!(total, 3);
-        assert_eq!(items[0].id, 4);
-        assert_eq!(items[2].id, 2);
-        // id=1 was evicted
-        assert!(!items.iter().any(|a| a.id == 1));
+        assert_eq!(items[0].id, id4); // newest
+        assert_eq!(items[2].id, id2); // oldest still retained
+        assert!(!items.iter().any(|a| a.id == id1), "id1 was evicted");
     }
 
     #[test]
@@ -217,12 +229,15 @@ mod tests {
         let store = InMemoryAlertStore::new();
         let id = store.record(&test_alert(95));
 
-        let found = store.get(id).expect("known id should return Some");
+        let found = store.get(&id).expect("known id should return Some");
         assert_eq!(found.id, id);
         assert_eq!(found.threshold_pct, 95);
         assert_eq!(found.status, "unresolved");
 
-        assert!(store.get(9_999).is_none(), "unknown id returns None");
+        assert!(
+            store.get("00000000000000000000000000").is_none(),
+            "unknown id returns None"
+        );
     }
 
     #[test]
@@ -232,22 +247,22 @@ mod tests {
         store.record(&test_alert(80));
         store.record(&test_alert(90));
 
-        assert!(store.get(id1).is_none(), "evicted id should return None");
+        assert!(store.get(&id1).is_none(), "evicted id should return None");
     }
 
     #[test]
     fn resolve_flips_status_and_sets_updated_at() {
         let store = InMemoryAlertStore::new();
         let id = store.record(&test_alert(95));
-        let before = store.get(id).unwrap();
+        let before = store.get(&id).unwrap();
         assert_eq!(before.status, "unresolved");
         assert!(before.updated_at.is_none());
 
-        let after = store.resolve(id, Some("ack")).expect("known id resolves");
+        let after = store.resolve(&id, Some("ack")).expect("known id resolves");
         assert_eq!(after.status, "resolved");
         assert!(after.updated_at.is_some());
 
-        let from_store = store.get(id).unwrap();
+        let from_store = store.get(&id).unwrap();
         assert_eq!(from_store.status, "resolved");
         assert_eq!(from_store.updated_at, after.updated_at);
     }
@@ -257,11 +272,11 @@ mod tests {
         let store = InMemoryAlertStore::new();
         let id = store.record(&test_alert(95));
 
-        let first = store.resolve(id, None).unwrap();
+        let first = store.resolve(&id, None).unwrap();
         let first_ts = first.updated_at.clone();
 
         // Second call: same record, same updated_at (no double-mutation).
-        let second = store.resolve(id, Some("again")).unwrap();
+        let second = store.resolve(&id, Some("again")).unwrap();
         assert_eq!(second.status, "resolved");
         assert_eq!(second.updated_at, first_ts);
     }
@@ -270,18 +285,23 @@ mod tests {
     fn resolve_returns_none_for_unknown_id() {
         let store = InMemoryAlertStore::new();
         store.record(&test_alert(80));
-        assert!(store.resolve(9_999, None).is_none());
+        assert!(store.resolve("00000000000000000000000000", None).is_none());
     }
 
     #[test]
-    fn ids_auto_increment() {
+    fn ids_are_unique_and_lexicographically_increasing() {
         let store = InMemoryAlertStore::new();
         let id1 = store.record(&test_alert(80));
         let id2 = store.record(&test_alert(90));
         let id3 = store.record(&test_alert(95));
-        assert_eq!(id1, 1);
-        assert_eq!(id2, 2);
-        assert_eq!(id3, 3);
+        assert_eq!(id1.len(), 26);
+        assert_eq!(id2.len(), 26);
+        assert_eq!(id3.len(), 26);
+        assert_ne!(id1, id2);
+        assert_ne!(id2, id3);
+        // ULID is lexicographically ordered by timestamp.
+        assert!(id1 < id2, "ids must sort by insertion order ({id1} < {id2})");
+        assert!(id2 < id3, "ids must sort by insertion order ({id2} < {id3})");
     }
 
     #[test]
@@ -289,7 +309,7 @@ mod tests {
         let store = InMemoryAlertStore::new();
         let id = store.record_secret(&test_secret_alert(CredentialKind::AwsAccessKey));
 
-        let found = store.get(id).expect("recorded secret alert must be retrievable");
+        let found = store.get(&id).expect("recorded secret alert must be retrievable");
         assert_eq!(found.severity, super::super::AlertSeverity::Critical);
         assert_eq!(found.category, super::super::AlertCategory::SecretDetected);
         assert_eq!(found.detected_pattern_type.as_deref(), Some("AwsAccessKey"));
@@ -298,12 +318,11 @@ mod tests {
     }
 
     #[test]
-    fn record_secret_shares_id_sequence_with_record() {
+    fn record_and_record_secret_produce_distinct_ulids() {
         let store = InMemoryAlertStore::new();
         let budget_id = store.record(&test_alert(80));
         let secret_id = store.record_secret(&test_secret_alert(CredentialKind::OpenAiKey));
-        // Both calls allocate from the same monotonic counter.
-        assert_eq!(budget_id, 1);
-        assert_eq!(secret_id, 2);
+        assert_ne!(budget_id, secret_id);
+        assert!(budget_id < secret_id, "ULIDs sort by timestamp");
     }
 }

--- a/aa-api/src/routes/alerts.rs
+++ b/aa-api/src/routes/alerts.rs
@@ -14,7 +14,7 @@ use crate::state::AppState;
 /// Convert a `StoredAlert` into the public-facing `AlertResponse` shape.
 fn alert_response_from_stored(a: StoredAlert) -> AlertResponse {
     AlertResponse {
-        id: a.id.to_string(),
+        id: a.id,
         severity: a.severity.to_string(),
         category: a.category.to_string(),
         message: a.message,
@@ -114,7 +114,7 @@ pub async fn list_alerts(
 #[utoipa::path(
     get,
     path = "/api/v1/alerts/{id}",
-    params(("id" = String, Path, description = "Numeric alert identifier")),
+    params(("id" = String, Path, description = "ULID alert identifier (26 chars)")),
     responses(
         (status = 200, description = "Alert detail", body = AlertResponse),
         (status = 404, description = "Alert not found")
@@ -125,11 +125,7 @@ pub async fn get_alert(
     Extension(state): Extension<AppState>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> Result<(StatusCode, Json<AlertResponse>), ProblemDetail> {
-    let numeric_id = id
-        .parse::<u64>()
-        .map_err(|_| ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Alert not found: {id}")))?;
-
-    let stored = state.alert_store.get(numeric_id).ok_or_else(|| {
+    let stored = state.alert_store.get(&id).ok_or_else(|| {
         ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Alert not found: {id}"))
     })?;
 
@@ -139,12 +135,12 @@ pub async fn get_alert(
 /// `POST /api/v1/alerts/:id/resolve` — mark a governance alert as resolved.
 ///
 /// Idempotent — calling against an already-resolved alert returns the same
-/// record with `updated_at` unchanged. Returns 404 if the id is unknown,
-/// evicted, or not a valid u64.
+/// record with `updated_at` unchanged. Returns 404 if the id is unknown or
+/// has been evicted from the ring buffer.
 #[utoipa::path(
     post,
     path = "/api/v1/alerts/{id}/resolve",
-    params(("id" = String, Path, description = "Numeric alert identifier")),
+    params(("id" = String, Path, description = "ULID alert identifier (26 chars)")),
     request_body(content = ResolveAlertRequest, description = "Optional resolution metadata"),
     responses(
         (status = 200, description = "Alert resolved", body = AlertResponse),
@@ -157,18 +153,11 @@ pub async fn resolve_alert(
     axum::extract::Path(id): axum::extract::Path<String>,
     body: Option<Json<ResolveAlertRequest>>,
 ) -> Result<(StatusCode, Json<AlertResponse>), ProblemDetail> {
-    let numeric_id = id
-        .parse::<u64>()
-        .map_err(|_| ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Alert not found: {id}")))?;
-
     let reason = body.and_then(|Json(req)| req.reason);
 
-    let stored = state
-        .alert_store
-        .resolve(numeric_id, reason.as_deref())
-        .ok_or_else(|| {
-            ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Alert not found: {id}"))
-        })?;
+    let stored = state.alert_store.resolve(&id, reason.as_deref()).ok_or_else(|| {
+        ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail(format!("Alert not found: {id}"))
+    })?;
 
     Ok((StatusCode::OK, Json(alert_response_from_stored(stored))))
 }

--- a/aa-api/tests/alerts.rs
+++ b/aa-api/tests/alerts.rs
@@ -162,11 +162,14 @@ async fn list_alerts_pagination_with_multiple_alerts() {
     assert_eq!(json["per_page"], 2);
     let items = json["items"].as_array().unwrap();
     assert_eq!(items.len(), 2);
-    // Newest first: IDs 5, 4
-    assert_eq!(items[0]["id"], "5");
-    assert_eq!(items[1]["id"], "4");
+    // Newest first — assert ULID format and lexicographic ordering.
+    let id0 = items[0]["id"].as_str().unwrap();
+    let id1 = items[1]["id"].as_str().unwrap();
+    assert_eq!(id0.len(), 26);
+    assert_eq!(id1.len(), 26);
+    assert!(id0 > id1, "newest-first: {id0} must sort after {id1}");
 
-    // Request page 3 with 2 items per page → should get 1 item (ID 1).
+    // Request page 3 with 2 items per page → should get 1 item (oldest).
     let response = app
         .oneshot(
             Request::builder()
@@ -181,7 +184,9 @@ async fn list_alerts_pagination_with_multiple_alerts() {
     let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     let items = json["items"].as_array().unwrap();
     assert_eq!(items.len(), 1);
-    assert_eq!(items[0]["id"], "1");
+    let oldest = items[0]["id"].as_str().unwrap();
+    assert_eq!(oldest.len(), 26);
+    assert!(oldest < id1, "page-3 entry must be older than page-1 entries");
 }
 
 // ============================================================================
@@ -227,7 +232,7 @@ async fn get_alert_returns_404_for_unknown_id() {
     let response = app
         .oneshot(
             Request::builder()
-                .uri("/api/v1/alerts/9999")
+                .uri("/api/v1/alerts/00000000000000000000000000")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -238,12 +243,12 @@ async fn get_alert_returns_404_for_unknown_id() {
 }
 
 #[tokio::test]
-async fn get_alert_returns_404_for_non_numeric_id() {
+async fn get_alert_returns_404_for_unrecognized_id() {
     let app = common::test_app();
     let response = app
         .oneshot(
             Request::builder()
-                .uri("/api/v1/alerts/not-a-number")
+                .uri("/api/v1/alerts/not-a-ulid")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -346,7 +351,7 @@ async fn resolve_alert_returns_404_for_unknown_id() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/api/v1/alerts/9999/resolve")
+                .uri("/api/v1/alerts/00000000000000000000000000/resolve")
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/aa-api/tests/secret_alerts.rs
+++ b/aa-api/tests/secret_alerts.rs
@@ -103,10 +103,9 @@ async fn get_alert_returns_secret_payload_with_critical_severity() {
     secret_tx.send(aws_secret_alert()).unwrap();
     tokio::time::sleep(Duration::from_millis(80)).await;
 
-    // Resolve the assigned id from the store directly so the test does not
-    // depend on the global id counter starting at 1.
+    // Resolve the assigned ULID from the store directly.
     let (items, _) = alert_store.list(10, 0);
-    let id = items.first().expect("a secret alert must be recorded").id;
+    let id = items.first().expect("a secret alert must be recorded").id.clone();
 
     let app = aa_api::server::build_app(state);
     let response = app

--- a/aa-integration-tests/tests/api_alerts.rs
+++ b/aa-integration-tests/tests/api_alerts.rs
@@ -45,8 +45,8 @@ use common::TopologyTestEnv;
 /// Record one budget alert directly into the test env's alert store.
 ///
 /// `threshold_pct` drives severity: `< 75` → info, `75..=89` → warning,
-/// `>= 90` → critical. Returns the auto-incremented alert id.
-fn seed_alert(env: &TopologyTestEnv, threshold_pct: u8, agent_id: [u8; 16]) -> u64 {
+/// `>= 90` → critical. Returns the assigned ULID.
+fn seed_alert(env: &TopologyTestEnv, threshold_pct: u8, agent_id: [u8; 16]) -> String {
     let limit_usd = 10.0_f64;
     let spent_usd = limit_usd * f64::from(threshold_pct) / 100.0;
     let alert = BudgetAlert {
@@ -87,8 +87,8 @@ async fn alerts_list_returns_seeded_in_recency_order() {
     let env = TopologyTestEnv::start().await.expect("harness should start");
     let client = reqwest::Client::new();
 
-    // Insertion order: info (id=1), warning (id=2), critical (id=3).
-    // Live contract: store returns newest-first, so critical must appear first.
+    // Insertion order: info, warning, critical. Live contract: store
+    // returns newest-first, so critical must appear first.
     seed_alert(&env, 50, [0x01; 16]); // info    — oldest
     seed_alert(&env, 80, [0x02; 16]); // warning
     let newest_id = seed_alert(&env, 95, [0x03; 16]); // critical — newest
@@ -106,7 +106,7 @@ async fn alerts_list_returns_seeded_in_recency_order() {
     assert_eq!(items.len(), 3, "all 3 seeded alerts should be present");
     assert_eq!(
         items[0]["id"].as_str(),
-        Some(newest_id.to_string().as_str()),
+        Some(newest_id.as_str()),
         "newest alert (id={newest_id}) must appear first",
     );
     assert_eq!(
@@ -165,7 +165,7 @@ async fn alerts_list_filter_by_status() {
     seed_alert(&env, 80, [0xBB; 16]); // stays open
 
     // Resolve one alert so the store holds both statuses.
-    env.alert_store.resolve(id1, None).expect("seeded alert must resolve");
+    env.alert_store.resolve(&id1, None).expect("seeded alert must resolve");
 
     let resp = client
         .get(format!("{}/api/v1/alerts?status=open", env.base_url()))
@@ -208,11 +208,7 @@ async fn alerts_inspect_returns_full_record() {
     assert_eq!(resp.status(), reqwest::StatusCode::OK);
     let body: serde_json::Value = resp.json().await.expect("response should parse as JSON");
 
-    assert_eq!(
-        body["id"].as_str(),
-        Some(id.to_string().as_str()),
-        "id must match the seeded alert"
-    );
+    assert_eq!(body["id"].as_str(), Some(id.as_str()), "id must match the seeded alert");
     assert_eq!(
         body["severity"].as_str(),
         Some("critical"),
@@ -246,10 +242,10 @@ async fn alerts_inspect_unknown_id_returns_404() {
     let client = reqwest::Client::new();
 
     let resp = client
-        .get(format!("{}/api/v1/alerts/999999", env.base_url()))
+        .get(format!("{}/api/v1/alerts/00000000000000000000000000", env.base_url()))
         .send()
         .await
-        .expect("GET /api/v1/alerts/999999 should reach the server");
+        .expect("GET unknown alert ULID should reach the server");
 
     assert_eq!(
         resp.status(),
@@ -351,11 +347,14 @@ async fn alerts_resolve_unknown_id_returns_404() {
     let client = reqwest::Client::new();
 
     let resp = client
-        .post(format!("{}/api/v1/alerts/999999/resolve", env.base_url()))
+        .post(format!(
+            "{}/api/v1/alerts/00000000000000000000000000/resolve",
+            env.base_url()
+        ))
         .json(&serde_json::json!({"reason": "no-op"}))
         .send()
         .await
-        .expect("POST /resolve on unknown id should reach the server");
+        .expect("POST /resolve on unknown ULID should reach the server");
 
     assert_eq!(
         resp.status(),

--- a/aa-integration-tests/tests/api_openapi_contract.rs
+++ b/aa-integration-tests/tests/api_openapi_contract.rs
@@ -27,7 +27,7 @@ use common::TopologyTestEnv;
 use reqwest::StatusCode;
 use serde_json::Value;
 
-fn seed_alert(env: &TopologyTestEnv, threshold_pct: u8, agent_id_bytes: [u8; 16]) -> u64 {
+fn seed_alert(env: &TopologyTestEnv, threshold_pct: u8, agent_id_bytes: [u8; 16]) -> String {
     let limit_usd = 10.0_f64;
     let spent_usd = limit_usd * f64::from(threshold_pct) / 100.0;
     env.alert_store.record(&BudgetAlert {
@@ -218,7 +218,7 @@ async fn openapi_spec_error_envelope_matches_for_404() {
 
     let urls = [
         format!("{}/api/v1/agents/{}", env.base_url(), "00".repeat(16)),
-        format!("{}/api/v1/alerts/99999999", env.base_url()),
+        format!("{}/api/v1/alerts/00000000000000000000000000", env.base_url()),
         format!("{}/api/v1/traces/no-such-session-contract-q", env.base_url()),
     ];
 

--- a/aa-integration-tests/tests/common/cli.rs
+++ b/aa-integration-tests/tests/common/cli.rs
@@ -273,7 +273,7 @@ impl CliFixture {
     /// Used by `cli_alerts.rs` (AAASM-1460) to populate the gateway's
     /// alert state before testing `aasm alerts list`. The harness boots
     /// with `AuthMode::Off`, so no auth context is needed.
-    pub fn seed_alert(&self, threshold_pct: u8, agent_id: [u8; 16]) -> u64 {
+    pub fn seed_alert(&self, threshold_pct: u8, agent_id: [u8; 16]) -> String {
         use aa_api::alerts::AlertStore;
         let limit_usd = 10.0_f64;
         let spent_usd = limit_usd * f64::from(threshold_pct) / 100.0;

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -266,8 +266,8 @@ export interface paths {
         /**
          * `POST /api/v1/alerts/:id/resolve` — mark a governance alert as resolved.
          * @description Idempotent — calling against an already-resolved alert returns the same
-         *     record with `updated_at` unchanged. Returns 404 if the id is unknown,
-         *     evicted, or not a valid u64.
+         *     record with `updated_at` unchanged. Returns 404 if the id is unknown or
+         *     has been evicted from the ring buffer.
          */
         post: operations["resolve_alert"];
         delete?: never;
@@ -2779,7 +2779,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description Numeric alert identifier */
+                /** @description ULID alert identifier (26 chars) */
                 id: string;
             };
             cookie?: never;
@@ -2809,7 +2809,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                /** @description Numeric alert identifier */
+                /** @description ULID alert identifier (26 chars) */
                 id: string;
             };
             cookie?: never;

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -433,7 +433,7 @@ paths:
       parameters:
       - name: id
         in: path
-        description: Numeric alert identifier
+        description: ULID alert identifier (26 chars)
         required: true
         schema:
           type: string
@@ -453,13 +453,13 @@ paths:
       summary: '`POST /api/v1/alerts/:id/resolve` — mark a governance alert as resolved.'
       description: |-
         Idempotent — calling against an already-resolved alert returns the same
-        record with `updated_at` unchanged. Returns 404 if the id is unknown,
-        evicted, or not a valid u64.
+        record with `updated_at` unchanged. Returns 404 if the id is unknown or
+        has been evicted from the ring buffer.
       operationId: resolve_alert
       parameters:
       - name: id
         in: path
-        description: Numeric alert identifier
+        description: ULID alert identifier (26 chars)
         required: true
         schema:
           type: string


### PR DESCRIPTION
## Description

Pre-req refactor for AAASM-1387 (`POST /api/v1/alerts/silence`). Switches `StoredAlert.id` from auto-incremented `u64` to ULID strings (26 chars, lexicographically sortable). Uses `ulid::Generator` so IDs sort by insertion order even within a single millisecond.

## Type of Change

- [x] ♻️ Refactoring

## Breaking Changes

- [x] Yes — `GET /api/v1/alerts/{id}` and `POST /api/v1/alerts/{id}/resolve` now accept ULID strings instead of numeric IDs. Existing clients that constructed numeric IDs will receive 404 (no client of this in-memory ring-buffer surface today).

## Related Issues

- Related Jira ticket: [AAASM-1644](https://lightning-dust-mite.atlassian.net/browse/AAASM-1644) (sub-task of [AAASM-1387](https://lightning-dust-mite.atlassian.net/browse/AAASM-1387))

## Testing

- [x] Unit tests added / updated — `aa-api/src/alerts/store.rs` (14 tests)
- [x] Integration tests added / updated — `aa-api/tests/alerts.rs`, `aa-api/tests/secret_alerts.rs`, `aa-integration-tests/tests/api_alerts.rs`, `aa-integration-tests/tests/api_openapi_contract.rs`
- [x] `cargo nextest run -p aa-api` — 333/333 passed

## Commits

1. `⬆️ (aa-api): Add ulid 1 to dependencies` — adds `ulid = "1"` to aa-api Cargo.toml; resolves to 1.2.1
2. `♻️ (aa-api): Switch StoredAlert.id from u64 to ULID` — single coupled refactor across model + trait + impl + routes + tests (the type signature is shared across all 8 touched files, so they must change atomically)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --all-targets`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed — utoipa schema descriptions reflect "ULID alert identifier (26 chars)"
- [x] All CI checks passing locally
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1644]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1387]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ