### PR TITLE
[AAASM-1616] ✨ (alerts): Add AlertRuleStore trait + InMemoryAlertRuleStore

### DIFF
--- a/aa-api/src/alerts/rules/mod.rs
+++ b/aa-api/src/alerts/rules/mod.rs
@@ -5,4 +5,5 @@
 //! the in-memory store, the destination registry stub, and the minimum
 //! viable rule evaluator.
 
+pub mod store;
 pub mod types;

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -322,4 +322,12 @@ mod tests {
         let store = InMemoryAlertRuleStore::new();
         assert!(!store.delete("missing"));
     }
+
+    #[test]
+    fn find_by_name_returns_some_for_known_and_none_otherwise() {
+        let store = InMemoryAlertRuleStore::new();
+        store.create(rule_named("r1")).expect("create");
+        assert!(store.find_by_name("r1").is_some());
+        assert!(store.find_by_name("not-there").is_none());
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -1,0 +1,5 @@
+//! Storage backend for [`AlertRule`] records (AAASM-1386).
+//!
+//! Today the only implementation is the in-memory
+//! [`InMemoryAlertRuleStore`] — a persisted store (e.g. SQLite) is
+//! deferred per the Story's acceptance criteria.

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -261,4 +261,30 @@ mod tests {
         let names: Vec<String> = store.list(Some(false)).into_iter().map(|r| r.name).collect();
         assert_eq!(names, vec!["off".to_string()]);
     }
+
+    #[test]
+    fn update_preserves_id_and_created_at_and_bumps_updated_at() {
+        let store = InMemoryAlertRuleStore::new();
+        let created = store.create(rule_named("r1")).expect("create");
+        // Force a measurable delta so updated_at != created_at.
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let updated = store
+            .update(
+                &created.id,
+                AlertRule {
+                    threshold: 95.0,
+                    ..rule_named("r1")
+                },
+            )
+            .expect("update");
+        assert_eq!(updated.id, created.id, "id must be preserved");
+        assert_eq!(updated.created_at, created.created_at, "created_at must be preserved",);
+        assert!(
+            updated.updated_at > created.updated_at,
+            "updated_at must be bumped: {} > {}",
+            updated.updated_at,
+            created.updated_at,
+        );
+        assert_eq!(updated.threshold, 95.0);
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -247,4 +247,18 @@ mod tests {
         let names: Vec<String> = store.list(Some(true)).into_iter().map(|r| r.name).collect();
         assert_eq!(names, vec!["on".to_string()]);
     }
+
+    #[test]
+    fn list_filter_false_returns_only_disabled_rules() {
+        let store = InMemoryAlertRuleStore::new();
+        store.create(rule_named("on")).expect("on");
+        store
+            .create(AlertRule {
+                enabled: false,
+                ..rule_named("off")
+            })
+            .expect("off");
+        let names: Vec<String> = store.list(Some(false)).into_iter().map(|r| r.name).collect();
+        assert_eq!(names, vec!["off".to_string()]);
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -124,8 +124,9 @@ impl AlertRuleStore for InMemoryAlertRuleStore {
         Ok(rule)
     }
 
-    fn get(&self, _id: &str) -> Option<AlertRule> {
-        unimplemented!("AAASM-1616: get lands next")
+    fn get(&self, id: &str) -> Option<AlertRule> {
+        let rules = self.rules.read().expect("alert rule store lock poisoned");
+        rules.get(id).cloned()
     }
 
     fn list(&self, _enabled_filter: Option<bool>) -> Vec<AlertRule> {

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -287,4 +287,14 @@ mod tests {
         );
         assert_eq!(updated.threshold, 95.0);
     }
+
+    #[test]
+    fn update_returns_not_found_for_unknown_id() {
+        let store = InMemoryAlertRuleStore::new();
+        let err = store
+            .update("missing", rule_named("r1"))
+            .expect_err("unknown id must fail");
+        assert_eq!(err, AlertRuleStoreError::NotFound);
+        assert_eq!(err.error_code(), "rule_not_found");
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -158,11 +158,13 @@ impl AlertRuleStore for InMemoryAlertRuleStore {
         Ok(rule)
     }
 
-    fn delete(&self, _id: &str) -> bool {
-        unimplemented!("AAASM-1616: delete lands next")
+    fn delete(&self, id: &str) -> bool {
+        let mut rules = self.rules.write().expect("alert rule store lock poisoned");
+        rules.remove(id).is_some()
     }
 
-    fn find_by_name(&self, _name: &str) -> Option<AlertRule> {
-        unimplemented!("AAASM-1616: find_by_name lands next")
+    fn find_by_name(&self, name: &str) -> Option<AlertRule> {
+        let rules = self.rules.read().expect("alert rule store lock poisoned");
+        rules.values().find(|r| r.name == name).cloned()
     }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -168,3 +168,41 @@ impl AlertRuleStore for InMemoryAlertRuleStore {
         rules.values().find(|r| r.name == name).cloned()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alerts::rules::types::{RuleMetric, RuleOperator, RuleSeverity};
+    use std::collections::HashMap;
+
+    /// Build a rule with the given name but otherwise default values.
+    /// `id`, `created_at`, `updated_at` are left empty — the store
+    /// overwrites them on `create`.
+    fn rule_named(name: &str) -> AlertRule {
+        AlertRule {
+            id: String::new(),
+            name: name.to_string(),
+            description: format!("desc for {name}"),
+            metric: RuleMetric::BudgetSpentPct,
+            operator: RuleOperator::Gt,
+            threshold: 90.0,
+            evaluation_window_seconds: 300,
+            severity: RuleSeverity::Critical,
+            destination_ids: vec!["slack-ops".to_string()],
+            dedup_window_seconds: 600,
+            suppression_labels: HashMap::new(),
+            enabled: true,
+            created_at: String::new(),
+            updated_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn create_assigns_id_and_timestamps() {
+        let store = InMemoryAlertRuleStore::new();
+        let created = store.create(rule_named("r1")).expect("create");
+        assert!(!created.id.is_empty(), "id must be assigned");
+        assert!(!created.created_at.is_empty(), "created_at must be assigned");
+        assert_eq!(created.created_at, created.updated_at);
+    }
+}

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -141,8 +141,21 @@ impl AlertRuleStore for InMemoryAlertRuleStore {
             .collect()
     }
 
-    fn update(&self, _id: &str, _rule: AlertRule) -> Result<AlertRule, AlertRuleStoreError> {
-        unimplemented!("AAASM-1616: update lands next")
+    fn update(&self, id: &str, mut rule: AlertRule) -> Result<AlertRule, AlertRuleStoreError> {
+        let mut rules = self.rules.write().expect("alert rule store lock poisoned");
+        let existing = rules.get(id).ok_or(AlertRuleStoreError::NotFound)?;
+
+        // Reject the update when the new name collides with another
+        // rule. Same-id same-name (i.e. unchanged name) is allowed.
+        if rule.name != existing.name && rules.values().any(|r| r.id != id && r.name == rule.name) {
+            return Err(AlertRuleStoreError::NameConflict { name: rule.name });
+        }
+
+        rule.id = existing.id.clone();
+        rule.created_at = existing.created_at.clone();
+        rule.updated_at = chrono::Utc::now().to_rfc3339();
+        rules.insert(id.to_string(), rule.clone());
+        Ok(rule)
     }
 
     fn delete(&self, _id: &str) -> bool {

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -4,6 +4,9 @@
 //! [`InMemoryAlertRuleStore`] — a persisted store (e.g. SQLite) is
 //! deferred per the Story's acceptance criteria.
 
+use std::collections::HashMap;
+use std::sync::RwLock;
+
 use super::types::AlertRule;
 
 /// Errors surfaced from [`AlertRuleStore`] mutations.
@@ -78,4 +81,66 @@ pub trait AlertRuleStore: Send + Sync {
     /// [`AlertRuleStoreError::NameConflict`] before re-inserting on
     /// PUT requests that change the name.
     fn find_by_name(&self, name: &str) -> Option<AlertRule>;
+}
+
+/// Thread-safe in-memory [`AlertRuleStore`].
+///
+/// Backed by an `RwLock<HashMap<id, AlertRule>>`. Suitable for
+/// development and tests; a durable backend (e.g. SQLite) is tracked
+/// as a follow-up under AAASM-1386.
+pub struct InMemoryAlertRuleStore {
+    rules: RwLock<HashMap<String, AlertRule>>,
+}
+
+impl InMemoryAlertRuleStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self {
+            rules: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl Default for InMemoryAlertRuleStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AlertRuleStore for InMemoryAlertRuleStore {
+    fn create(&self, mut rule: AlertRule) -> Result<AlertRule, AlertRuleStoreError> {
+        let mut rules = self.rules.write().expect("alert rule store lock poisoned");
+
+        if rules.values().any(|r| r.name == rule.name) {
+            return Err(AlertRuleStoreError::NameConflict { name: rule.name });
+        }
+
+        let id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now().to_rfc3339();
+        rule.id = id.clone();
+        rule.created_at = now.clone();
+        rule.updated_at = now;
+        rules.insert(id, rule.clone());
+        Ok(rule)
+    }
+
+    fn get(&self, _id: &str) -> Option<AlertRule> {
+        unimplemented!("AAASM-1616: get lands next")
+    }
+
+    fn list(&self, _enabled_filter: Option<bool>) -> Vec<AlertRule> {
+        unimplemented!("AAASM-1616: list lands next")
+    }
+
+    fn update(&self, _id: &str, _rule: AlertRule) -> Result<AlertRule, AlertRuleStoreError> {
+        unimplemented!("AAASM-1616: update lands next")
+    }
+
+    fn delete(&self, _id: &str) -> bool {
+        unimplemented!("AAASM-1616: delete lands next")
+    }
+
+    fn find_by_name(&self, _name: &str) -> Option<AlertRule> {
+        unimplemented!("AAASM-1616: find_by_name lands next")
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -233,4 +233,18 @@ mod tests {
         names.sort();
         assert_eq!(names, vec!["a".to_string(), "b".to_string(), "c".to_string()]);
     }
+
+    #[test]
+    fn list_filter_true_returns_only_enabled_rules() {
+        let store = InMemoryAlertRuleStore::new();
+        store.create(rule_named("on")).expect("on");
+        store
+            .create(AlertRule {
+                enabled: false,
+                ..rule_named("off")
+            })
+            .expect("off");
+        let names: Vec<String> = store.list(Some(true)).into_iter().map(|r| r.name).collect();
+        assert_eq!(names, vec!["on".to_string()]);
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -129,8 +129,16 @@ impl AlertRuleStore for InMemoryAlertRuleStore {
         rules.get(id).cloned()
     }
 
-    fn list(&self, _enabled_filter: Option<bool>) -> Vec<AlertRule> {
-        unimplemented!("AAASM-1616: list lands next")
+    fn list(&self, enabled_filter: Option<bool>) -> Vec<AlertRule> {
+        let rules = self.rules.read().expect("alert rule store lock poisoned");
+        rules
+            .values()
+            .filter(|r| match enabled_filter {
+                Some(want) => r.enabled == want,
+                None => true,
+            })
+            .cloned()
+            .collect()
     }
 
     fn update(&self, _id: &str, _rule: AlertRule) -> Result<AlertRule, AlertRuleStoreError> {

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -3,3 +3,79 @@
 //! Today the only implementation is the in-memory
 //! [`InMemoryAlertRuleStore`] — a persisted store (e.g. SQLite) is
 //! deferred per the Story's acceptance criteria.
+
+use super::types::AlertRule;
+
+/// Errors surfaced from [`AlertRuleStore`] mutations.
+///
+/// Each variant maps onto a Story-defined HTTP error code that the
+/// handler in AAASM-1620 will return in the RFC 7807 response.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AlertRuleStoreError {
+    /// A rule with this `name` already exists (POST only). Maps to
+    /// 409 with `error: "rule_name_conflict"`.
+    NameConflict {
+        /// The conflicting rule name.
+        name: String,
+    },
+    /// No rule was found with the given id (GET / PUT / DELETE).
+    /// Maps to 404 with `error: "rule_not_found"`.
+    NotFound,
+}
+
+impl AlertRuleStoreError {
+    /// Stable error code returned in the RFC 7807 response.
+    pub fn error_code(&self) -> &'static str {
+        match self {
+            Self::NameConflict { .. } => "rule_name_conflict",
+            Self::NotFound => "rule_not_found",
+        }
+    }
+}
+
+impl std::fmt::Display for AlertRuleStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NameConflict { name } => write!(f, "rule name already exists: {name}"),
+            Self::NotFound => write!(f, "rule not found"),
+        }
+    }
+}
+
+impl std::error::Error for AlertRuleStoreError {}
+
+/// Read-write storage abstraction over [`AlertRule`] records.
+///
+/// Implementations must be thread-safe (`Send + Sync`).
+pub trait AlertRuleStore: Send + Sync {
+    /// Persist a new rule, returning the fully-populated record.
+    ///
+    /// The store assigns `id`, `created_at`, and `updated_at` —
+    /// callers may leave them empty on input. Returns
+    /// [`AlertRuleStoreError::NameConflict`] when `rule.name`
+    /// duplicates an existing entry.
+    fn create(&self, rule: AlertRule) -> Result<AlertRule, AlertRuleStoreError>;
+
+    /// Fetch a rule by id, or `None` if no such rule exists.
+    fn get(&self, id: &str) -> Option<AlertRule>;
+
+    /// List all rules, optionally filtering by the `enabled` flag.
+    /// `enabled_filter = None` returns every rule.
+    fn list(&self, enabled_filter: Option<bool>) -> Vec<AlertRule>;
+
+    /// Replace the rule with id `id`. The stored record's `id` and
+    /// `created_at` are preserved; the rest of the fields are taken
+    /// from `rule`; `updated_at` is bumped to now. Returns
+    /// [`AlertRuleStoreError::NotFound`] when `id` is unknown.
+    fn update(&self, id: &str, rule: AlertRule) -> Result<AlertRule, AlertRuleStoreError>;
+
+    /// Remove the rule with id `id`. Returns true when a record was
+    /// removed, false when `id` was unknown.
+    fn delete(&self, id: &str) -> bool;
+
+    /// Find a rule by exact name match, or `None` if no such rule
+    /// exists. Used by the handler to surface
+    /// [`AlertRuleStoreError::NameConflict`] before re-inserting on
+    /// PUT requests that change the name.
+    fn find_by_name(&self, name: &str) -> Option<AlertRule>;
+}

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -297,4 +297,15 @@ mod tests {
         assert_eq!(err, AlertRuleStoreError::NotFound);
         assert_eq!(err.error_code(), "rule_not_found");
     }
+
+    #[test]
+    fn update_rejects_name_conflict_with_other_rule() {
+        let store = InMemoryAlertRuleStore::new();
+        let a = store.create(rule_named("a")).expect("a");
+        store.create(rule_named("b")).expect("b");
+        let err = store
+            .update(&a.id, rule_named("b"))
+            .expect_err("renaming a -> b must collide with the existing b");
+        assert!(matches!(err, AlertRuleStoreError::NameConflict { ref name } if name == "b"));
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -308,4 +308,12 @@ mod tests {
             .expect_err("renaming a -> b must collide with the existing b");
         assert!(matches!(err, AlertRuleStoreError::NameConflict { ref name } if name == "b"));
     }
+
+    #[test]
+    fn delete_removes_existing_rule_and_returns_true() {
+        let store = InMemoryAlertRuleStore::new();
+        let created = store.create(rule_named("r1")).expect("create");
+        assert!(store.delete(&created.id), "delete must return true for known id");
+        assert!(store.get(&created.id).is_none(), "rule must be gone");
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -316,4 +316,10 @@ mod tests {
         assert!(store.delete(&created.id), "delete must return true for known id");
         assert!(store.get(&created.id).is_none(), "rule must be gone");
     }
+
+    #[test]
+    fn delete_returns_false_for_unknown_id() {
+        let store = InMemoryAlertRuleStore::new();
+        assert!(!store.delete("missing"));
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -222,4 +222,15 @@ mod tests {
         assert_eq!(store.get(&created.id).map(|r| r.name), Some("r1".to_string()));
         assert!(store.get("does-not-exist").is_none());
     }
+
+    #[test]
+    fn list_returns_all_rules_when_filter_is_none() {
+        let store = InMemoryAlertRuleStore::new();
+        store.create(rule_named("a")).expect("a");
+        store.create(rule_named("b")).expect("b");
+        store.create(rule_named("c")).expect("c");
+        let mut names: Vec<String> = store.list(None).into_iter().map(|r| r.name).collect();
+        names.sort();
+        assert_eq!(names, vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -205,4 +205,13 @@ mod tests {
         assert!(!created.created_at.is_empty(), "created_at must be assigned");
         assert_eq!(created.created_at, created.updated_at);
     }
+
+    #[test]
+    fn create_rejects_duplicate_name() {
+        let store = InMemoryAlertRuleStore::new();
+        store.create(rule_named("dup")).expect("first create");
+        let err = store.create(rule_named("dup")).expect_err("duplicate name must fail");
+        assert!(matches!(err, AlertRuleStoreError::NameConflict { ref name } if name == "dup"));
+        assert_eq!(err.error_code(), "rule_name_conflict");
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -214,4 +214,12 @@ mod tests {
         assert!(matches!(err, AlertRuleStoreError::NameConflict { ref name } if name == "dup"));
         assert_eq!(err.error_code(), "rule_name_conflict");
     }
+
+    #[test]
+    fn get_returns_some_for_known_id_and_none_otherwise() {
+        let store = InMemoryAlertRuleStore::new();
+        let created = store.create(rule_named("r1")).expect("create");
+        assert_eq!(store.get(&created.id).map(|r| r.name), Some("r1".to_string()));
+        assert!(store.get("does-not-exist").is_none());
+    }
 }


### PR DESCRIPTION
## Description

Second sub-task of **AAASM-1386** (alert-rules CRUD endpoints). Adds the
`AlertRuleStore` trait + the `InMemoryAlertRuleStore` implementation and
the `AlertRuleStoreError` enum.

The trait covers the six persistence operations the CRUD handlers in
AAASM-1620 need: `create`, `get`, `list(enabled_filter)`, `update`,
`delete`, `find_by_name`. The in-memory impl is backed by
`RwLock<HashMap<id, AlertRule>>`, assigns UUID-v4 ids + RFC 3339
timestamps on `create`, and on `update` preserves the existing
`id` + `created_at` while bumping `updated_at`.

## Depends on

- **#592** (AAASM-1615 — AlertRule domain types). PR base = `master`
  per workspace policy; the commit graph stacks AAASM-1615 ⟶ AAASM-1616
  so this PR will rebase cleanly once #592 merges.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: **AAASM-1616** (Sub-task of [AAASM-1386](https://lightning-dust-mite.atlassian.net/browse/AAASM-1386))

## Testing

- [x] Unit tests added — 12 store tests in `aa-api/src/alerts/rules/store.rs::tests`
- [x] `cargo nextest run -p aa-api --lib alerts::rules::store` → **12 / 12 passed**
- [x] `cargo clippy -p aa-api --all-targets --all-features -- -D warnings` → clean
- [x] `cargo fmt --all -- --check` → clean

### Store behavior matrix

| Behavior | Test |
|---|---|
| create assigns id + timestamps | `create_assigns_id_and_timestamps` |
| create rejects duplicate name | `create_rejects_duplicate_name` |
| get returns Some / None | `get_returns_some_for_known_id_and_none_otherwise` |
| list with no filter | `list_returns_all_rules_when_filter_is_none` |
| list filter=true | `list_filter_true_returns_only_enabled_rules` |
| list filter=false | `list_filter_false_returns_only_disabled_rules` |
| update preserves id + created_at, bumps updated_at | `update_preserves_id_and_created_at_and_bumps_updated_at` |
| update unknown id → NotFound | `update_returns_not_found_for_unknown_id` |
| update conflicting rename | `update_rejects_name_conflict_with_other_rule` |
| delete known id returns true | `delete_removes_existing_rule_and_returns_true` |
| delete unknown id returns false | `delete_returns_false_for_unknown_id` |
| find_by_name | `find_by_name_returns_some_for_known_and_none_otherwise` |

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a — new module)
- [x] All CI checks passing (local gates green; CI runs on PR)
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1386]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ