### PR TITLE
[AAASM-1617] ✨ (alerts): Add in-memory DestinationRegistry stub

### DIFF
--- a/aa-api/src/alerts/rules/destinations.rs
+++ b/aa-api/src/alerts/rules/destinations.rs
@@ -1,0 +1,55 @@
+//! In-memory registry of known alert-rule destinations (AAASM-1386).
+//!
+//! The Story's `destination_ids` validation needs *some* backing source
+//! of truth. A full destination management surface (with delivery
+//! adapters per type) is out of scope for AAASM-1386; this stub ships
+//! a fixed allow-set so `destination_unknown` rejections work
+//! end-to-end. Future work can swap this for a persisted registry
+//! behind the same [`DestinationRegistryLookup`] trait.
+
+use std::collections::HashSet;
+
+use super::types::DestinationRegistryLookup;
+
+/// Seed entries returned by [`DestinationRegistry::seeded`]. Kept as a
+/// `const` so dashboard / docs can render the same allow-list without
+/// pulling in the runtime registry.
+pub const SEEDED_DESTINATIONS: &[&str] = &["slack-ops", "pagerduty-oncall", "email-team"];
+
+/// Allow-set of destination ids that alert rules may target.
+pub struct DestinationRegistry {
+    ids: HashSet<String>,
+}
+
+impl DestinationRegistry {
+    /// Empty registry — useful only in tests that want to assert
+    /// `destination_unknown` rejections without seed noise.
+    pub fn empty() -> Self {
+        Self { ids: HashSet::new() }
+    }
+
+    /// Pre-populated registry containing [`SEEDED_DESTINATIONS`].
+    pub fn seeded() -> Self {
+        Self {
+            ids: SEEDED_DESTINATIONS.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    /// Add `id` to the allow-set. Intended for tests / future
+    /// destination-management endpoints.
+    pub fn register(&mut self, id: impl Into<String>) {
+        self.ids.insert(id.into());
+    }
+}
+
+impl Default for DestinationRegistry {
+    fn default() -> Self {
+        Self::seeded()
+    }
+}
+
+impl DestinationRegistryLookup for DestinationRegistry {
+    fn contains(&self, id: &str) -> bool {
+        self.ids.contains(id)
+    }
+}

--- a/aa-api/src/alerts/rules/destinations.rs
+++ b/aa-api/src/alerts/rules/destinations.rs
@@ -80,4 +80,10 @@ mod tests {
         assert!(registry.contains("custom-webhook"));
         assert!(!registry.contains("missing"));
     }
+
+    #[test]
+    fn seeded_registry_rejects_unknown_id() {
+        let registry = DestinationRegistry::seeded();
+        assert!(!registry.contains("does-not-exist"));
+    }
 }

--- a/aa-api/src/alerts/rules/destinations.rs
+++ b/aa-api/src/alerts/rules/destinations.rs
@@ -53,3 +53,16 @@ impl DestinationRegistryLookup for DestinationRegistry {
         self.ids.contains(id)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seeded_registry_contains_every_seed_entry() {
+        let registry = DestinationRegistry::seeded();
+        for id in SEEDED_DESTINATIONS {
+            assert!(registry.contains(id), "expected seeded id {id} to be present");
+        }
+    }
+}

--- a/aa-api/src/alerts/rules/destinations.rs
+++ b/aa-api/src/alerts/rules/destinations.rs
@@ -65,4 +65,11 @@ mod tests {
             assert!(registry.contains(id), "expected seeded id {id} to be present");
         }
     }
+
+    #[test]
+    fn empty_registry_rejects_all_lookups() {
+        let registry = DestinationRegistry::empty();
+        assert!(!registry.contains("slack-ops"));
+        assert!(!registry.contains("anything"));
+    }
 }

--- a/aa-api/src/alerts/rules/destinations.rs
+++ b/aa-api/src/alerts/rules/destinations.rs
@@ -72,4 +72,12 @@ mod tests {
         assert!(!registry.contains("slack-ops"));
         assert!(!registry.contains("anything"));
     }
+
+    #[test]
+    fn register_extends_the_allow_set() {
+        let mut registry = DestinationRegistry::empty();
+        registry.register("custom-webhook");
+        assert!(registry.contains("custom-webhook"));
+        assert!(!registry.contains("missing"));
+    }
 }

--- a/aa-api/src/alerts/rules/mod.rs
+++ b/aa-api/src/alerts/rules/mod.rs
@@ -5,5 +5,6 @@
 //! the in-memory store, the destination registry stub, and the minimum
 //! viable rule evaluator.
 
+pub mod destinations;
 pub mod store;
 pub mod types;


### PR DESCRIPTION
## Description

Third sub-task of **AAASM-1386**. Adds an in-memory `DestinationRegistry`
backing the `destination_unknown` validation rule. Seeded with three
defaults (`slack-ops`, `pagerduty-oncall`, `email-team`); `register()`
lets future destination-management endpoints (or tests) extend the
allow-set. Implements the `DestinationRegistryLookup` trait introduced
under AAASM-1615 so `AlertRule::validate` consumes it directly.

A full destination-management surface (delivery adapters, persisted
storage) is intentionally out of scope per the Story.

## Depends on

- **#592** (AAASM-1615 — types) — needed for `DestinationRegistryLookup`.
- **#601** (AAASM-1616 — store) — chained on the same worktree to keep
  the commit graph linear; will rebase cleanly once #592 / #601 merge.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: **AAASM-1617** (Sub-task of [AAASM-1386](https://lightning-dust-mite.atlassian.net/browse/AAASM-1386))

## Testing

- [x] 4 unit tests in `aa-api/src/alerts/rules/destinations.rs::tests`
- [x] `cargo nextest run -p aa-api --lib alerts::rules::destinations` → **4 / 4 passed**
- [x] `cargo clippy -p aa-api --all-targets --all-features -- -D warnings` → clean
- [x] `cargo fmt --all -- --check` → clean

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Commits follow the Gitmoji convention

[AAASM-1386]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ