### PR TITLE
[AAASM-1618] ✨ (error): Extend ProblemDetail with optional error_code

### DIFF
--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -7,6 +7,7 @@
 pub mod capture;
 pub mod detail;
 pub mod event;
+pub mod rules;
 pub mod silence;
 pub mod silence_store;
 pub mod silence_watcher;

--- a/aa-api/src/alerts/rules/destinations.rs
+++ b/aa-api/src/alerts/rules/destinations.rs
@@ -1,0 +1,55 @@
+//! In-memory registry of known alert-rule destinations (AAASM-1386).
+//!
+//! The Story's `destination_ids` validation needs *some* backing source
+//! of truth. A full destination management surface (with delivery
+//! adapters per type) is out of scope for AAASM-1386; this stub ships
+//! a fixed allow-set so `destination_unknown` rejections work
+//! end-to-end. Future work can swap this for a persisted registry
+//! behind the same [`DestinationRegistryLookup`] trait.
+
+use std::collections::HashSet;
+
+use super::types::DestinationRegistryLookup;
+
+/// Seed entries returned by [`DestinationRegistry::seeded`]. Kept as a
+/// `const` so dashboard / docs can render the same allow-list without
+/// pulling in the runtime registry.
+pub const SEEDED_DESTINATIONS: &[&str] = &["slack-ops", "pagerduty-oncall", "email-team"];
+
+/// Allow-set of destination ids that alert rules may target.
+pub struct DestinationRegistry {
+    ids: HashSet<String>,
+}
+
+impl DestinationRegistry {
+    /// Empty registry — useful only in tests that want to assert
+    /// `destination_unknown` rejections without seed noise.
+    pub fn empty() -> Self {
+        Self { ids: HashSet::new() }
+    }
+
+    /// Pre-populated registry containing [`SEEDED_DESTINATIONS`].
+    pub fn seeded() -> Self {
+        Self {
+            ids: SEEDED_DESTINATIONS.iter().map(|s| (*s).to_string()).collect(),
+        }
+    }
+
+    /// Add `id` to the allow-set. Intended for tests / future
+    /// destination-management endpoints.
+    pub fn register(&mut self, id: impl Into<String>) {
+        self.ids.insert(id.into());
+    }
+}
+
+impl Default for DestinationRegistry {
+    fn default() -> Self {
+        Self::seeded()
+    }
+}
+
+impl DestinationRegistryLookup for DestinationRegistry {
+    fn contains(&self, id: &str) -> bool {
+        self.ids.contains(id)
+    }
+}

--- a/aa-api/src/alerts/rules/destinations.rs
+++ b/aa-api/src/alerts/rules/destinations.rs
@@ -80,4 +80,10 @@ mod tests {
         assert!(registry.contains("custom-webhook"));
         assert!(!registry.contains("missing"));
     }
+
+    #[test]
+    fn seeded_registry_rejects_unknown_id() {
+        let registry = DestinationRegistry::seeded();
+        assert!(!registry.contains("does-not-exist"));
+    }
 }

--- a/aa-api/src/alerts/rules/destinations.rs
+++ b/aa-api/src/alerts/rules/destinations.rs
@@ -53,3 +53,16 @@ impl DestinationRegistryLookup for DestinationRegistry {
         self.ids.contains(id)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seeded_registry_contains_every_seed_entry() {
+        let registry = DestinationRegistry::seeded();
+        for id in SEEDED_DESTINATIONS {
+            assert!(registry.contains(id), "expected seeded id {id} to be present");
+        }
+    }
+}

--- a/aa-api/src/alerts/rules/destinations.rs
+++ b/aa-api/src/alerts/rules/destinations.rs
@@ -65,4 +65,11 @@ mod tests {
             assert!(registry.contains(id), "expected seeded id {id} to be present");
         }
     }
+
+    #[test]
+    fn empty_registry_rejects_all_lookups() {
+        let registry = DestinationRegistry::empty();
+        assert!(!registry.contains("slack-ops"));
+        assert!(!registry.contains("anything"));
+    }
 }

--- a/aa-api/src/alerts/rules/destinations.rs
+++ b/aa-api/src/alerts/rules/destinations.rs
@@ -72,4 +72,12 @@ mod tests {
         assert!(!registry.contains("slack-ops"));
         assert!(!registry.contains("anything"));
     }
+
+    #[test]
+    fn register_extends_the_allow_set() {
+        let mut registry = DestinationRegistry::empty();
+        registry.register("custom-webhook");
+        assert!(registry.contains("custom-webhook"));
+        assert!(!registry.contains("missing"));
+    }
 }

--- a/aa-api/src/alerts/rules/mod.rs
+++ b/aa-api/src/alerts/rules/mod.rs
@@ -1,0 +1,6 @@
+//! Alert-rule CRUD primitives (AAASM-1386).
+//!
+//! The `/api/v1/alerts/rules` endpoints let operators author detection
+//! rules without editing YAML. This module owns the rule domain types,
+//! the in-memory store, the destination registry stub, and the minimum
+//! viable rule evaluator.

--- a/aa-api/src/alerts/rules/mod.rs
+++ b/aa-api/src/alerts/rules/mod.rs
@@ -5,5 +5,6 @@
 //! the in-memory store, the destination registry stub, and the minimum
 //! viable rule evaluator.
 
+pub mod destinations;
 pub mod store;
 pub mod types;

--- a/aa-api/src/alerts/rules/mod.rs
+++ b/aa-api/src/alerts/rules/mod.rs
@@ -4,3 +4,5 @@
 //! rules without editing YAML. This module owns the rule domain types,
 //! the in-memory store, the destination registry stub, and the minimum
 //! viable rule evaluator.
+
+pub mod types;

--- a/aa-api/src/alerts/rules/mod.rs
+++ b/aa-api/src/alerts/rules/mod.rs
@@ -5,4 +5,5 @@
 //! the in-memory store, the destination registry stub, and the minimum
 //! viable rule evaluator.
 
+pub mod store;
 pub mod types;

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -322,4 +322,12 @@ mod tests {
         let store = InMemoryAlertRuleStore::new();
         assert!(!store.delete("missing"));
     }
+
+    #[test]
+    fn find_by_name_returns_some_for_known_and_none_otherwise() {
+        let store = InMemoryAlertRuleStore::new();
+        store.create(rule_named("r1")).expect("create");
+        assert!(store.find_by_name("r1").is_some());
+        assert!(store.find_by_name("not-there").is_none());
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -1,0 +1,5 @@
+//! Storage backend for [`AlertRule`] records (AAASM-1386).
+//!
+//! Today the only implementation is the in-memory
+//! [`InMemoryAlertRuleStore`] — a persisted store (e.g. SQLite) is
+//! deferred per the Story's acceptance criteria.

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -261,4 +261,30 @@ mod tests {
         let names: Vec<String> = store.list(Some(false)).into_iter().map(|r| r.name).collect();
         assert_eq!(names, vec!["off".to_string()]);
     }
+
+    #[test]
+    fn update_preserves_id_and_created_at_and_bumps_updated_at() {
+        let store = InMemoryAlertRuleStore::new();
+        let created = store.create(rule_named("r1")).expect("create");
+        // Force a measurable delta so updated_at != created_at.
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        let updated = store
+            .update(
+                &created.id,
+                AlertRule {
+                    threshold: 95.0,
+                    ..rule_named("r1")
+                },
+            )
+            .expect("update");
+        assert_eq!(updated.id, created.id, "id must be preserved");
+        assert_eq!(updated.created_at, created.created_at, "created_at must be preserved",);
+        assert!(
+            updated.updated_at > created.updated_at,
+            "updated_at must be bumped: {} > {}",
+            updated.updated_at,
+            created.updated_at,
+        );
+        assert_eq!(updated.threshold, 95.0);
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -247,4 +247,18 @@ mod tests {
         let names: Vec<String> = store.list(Some(true)).into_iter().map(|r| r.name).collect();
         assert_eq!(names, vec!["on".to_string()]);
     }
+
+    #[test]
+    fn list_filter_false_returns_only_disabled_rules() {
+        let store = InMemoryAlertRuleStore::new();
+        store.create(rule_named("on")).expect("on");
+        store
+            .create(AlertRule {
+                enabled: false,
+                ..rule_named("off")
+            })
+            .expect("off");
+        let names: Vec<String> = store.list(Some(false)).into_iter().map(|r| r.name).collect();
+        assert_eq!(names, vec!["off".to_string()]);
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -124,8 +124,9 @@ impl AlertRuleStore for InMemoryAlertRuleStore {
         Ok(rule)
     }
 
-    fn get(&self, _id: &str) -> Option<AlertRule> {
-        unimplemented!("AAASM-1616: get lands next")
+    fn get(&self, id: &str) -> Option<AlertRule> {
+        let rules = self.rules.read().expect("alert rule store lock poisoned");
+        rules.get(id).cloned()
     }
 
     fn list(&self, _enabled_filter: Option<bool>) -> Vec<AlertRule> {

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -287,4 +287,14 @@ mod tests {
         );
         assert_eq!(updated.threshold, 95.0);
     }
+
+    #[test]
+    fn update_returns_not_found_for_unknown_id() {
+        let store = InMemoryAlertRuleStore::new();
+        let err = store
+            .update("missing", rule_named("r1"))
+            .expect_err("unknown id must fail");
+        assert_eq!(err, AlertRuleStoreError::NotFound);
+        assert_eq!(err.error_code(), "rule_not_found");
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -158,11 +158,13 @@ impl AlertRuleStore for InMemoryAlertRuleStore {
         Ok(rule)
     }
 
-    fn delete(&self, _id: &str) -> bool {
-        unimplemented!("AAASM-1616: delete lands next")
+    fn delete(&self, id: &str) -> bool {
+        let mut rules = self.rules.write().expect("alert rule store lock poisoned");
+        rules.remove(id).is_some()
     }
 
-    fn find_by_name(&self, _name: &str) -> Option<AlertRule> {
-        unimplemented!("AAASM-1616: find_by_name lands next")
+    fn find_by_name(&self, name: &str) -> Option<AlertRule> {
+        let rules = self.rules.read().expect("alert rule store lock poisoned");
+        rules.values().find(|r| r.name == name).cloned()
     }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -168,3 +168,41 @@ impl AlertRuleStore for InMemoryAlertRuleStore {
         rules.values().find(|r| r.name == name).cloned()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alerts::rules::types::{RuleMetric, RuleOperator, RuleSeverity};
+    use std::collections::HashMap;
+
+    /// Build a rule with the given name but otherwise default values.
+    /// `id`, `created_at`, `updated_at` are left empty — the store
+    /// overwrites them on `create`.
+    fn rule_named(name: &str) -> AlertRule {
+        AlertRule {
+            id: String::new(),
+            name: name.to_string(),
+            description: format!("desc for {name}"),
+            metric: RuleMetric::BudgetSpentPct,
+            operator: RuleOperator::Gt,
+            threshold: 90.0,
+            evaluation_window_seconds: 300,
+            severity: RuleSeverity::Critical,
+            destination_ids: vec!["slack-ops".to_string()],
+            dedup_window_seconds: 600,
+            suppression_labels: HashMap::new(),
+            enabled: true,
+            created_at: String::new(),
+            updated_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn create_assigns_id_and_timestamps() {
+        let store = InMemoryAlertRuleStore::new();
+        let created = store.create(rule_named("r1")).expect("create");
+        assert!(!created.id.is_empty(), "id must be assigned");
+        assert!(!created.created_at.is_empty(), "created_at must be assigned");
+        assert_eq!(created.created_at, created.updated_at);
+    }
+}

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -141,8 +141,21 @@ impl AlertRuleStore for InMemoryAlertRuleStore {
             .collect()
     }
 
-    fn update(&self, _id: &str, _rule: AlertRule) -> Result<AlertRule, AlertRuleStoreError> {
-        unimplemented!("AAASM-1616: update lands next")
+    fn update(&self, id: &str, mut rule: AlertRule) -> Result<AlertRule, AlertRuleStoreError> {
+        let mut rules = self.rules.write().expect("alert rule store lock poisoned");
+        let existing = rules.get(id).ok_or(AlertRuleStoreError::NotFound)?;
+
+        // Reject the update when the new name collides with another
+        // rule. Same-id same-name (i.e. unchanged name) is allowed.
+        if rule.name != existing.name && rules.values().any(|r| r.id != id && r.name == rule.name) {
+            return Err(AlertRuleStoreError::NameConflict { name: rule.name });
+        }
+
+        rule.id = existing.id.clone();
+        rule.created_at = existing.created_at.clone();
+        rule.updated_at = chrono::Utc::now().to_rfc3339();
+        rules.insert(id.to_string(), rule.clone());
+        Ok(rule)
     }
 
     fn delete(&self, _id: &str) -> bool {

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -4,6 +4,9 @@
 //! [`InMemoryAlertRuleStore`] — a persisted store (e.g. SQLite) is
 //! deferred per the Story's acceptance criteria.
 
+use std::collections::HashMap;
+use std::sync::RwLock;
+
 use super::types::AlertRule;
 
 /// Errors surfaced from [`AlertRuleStore`] mutations.
@@ -78,4 +81,66 @@ pub trait AlertRuleStore: Send + Sync {
     /// [`AlertRuleStoreError::NameConflict`] before re-inserting on
     /// PUT requests that change the name.
     fn find_by_name(&self, name: &str) -> Option<AlertRule>;
+}
+
+/// Thread-safe in-memory [`AlertRuleStore`].
+///
+/// Backed by an `RwLock<HashMap<id, AlertRule>>`. Suitable for
+/// development and tests; a durable backend (e.g. SQLite) is tracked
+/// as a follow-up under AAASM-1386.
+pub struct InMemoryAlertRuleStore {
+    rules: RwLock<HashMap<String, AlertRule>>,
+}
+
+impl InMemoryAlertRuleStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self {
+            rules: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl Default for InMemoryAlertRuleStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AlertRuleStore for InMemoryAlertRuleStore {
+    fn create(&self, mut rule: AlertRule) -> Result<AlertRule, AlertRuleStoreError> {
+        let mut rules = self.rules.write().expect("alert rule store lock poisoned");
+
+        if rules.values().any(|r| r.name == rule.name) {
+            return Err(AlertRuleStoreError::NameConflict { name: rule.name });
+        }
+
+        let id = uuid::Uuid::new_v4().to_string();
+        let now = chrono::Utc::now().to_rfc3339();
+        rule.id = id.clone();
+        rule.created_at = now.clone();
+        rule.updated_at = now;
+        rules.insert(id, rule.clone());
+        Ok(rule)
+    }
+
+    fn get(&self, _id: &str) -> Option<AlertRule> {
+        unimplemented!("AAASM-1616: get lands next")
+    }
+
+    fn list(&self, _enabled_filter: Option<bool>) -> Vec<AlertRule> {
+        unimplemented!("AAASM-1616: list lands next")
+    }
+
+    fn update(&self, _id: &str, _rule: AlertRule) -> Result<AlertRule, AlertRuleStoreError> {
+        unimplemented!("AAASM-1616: update lands next")
+    }
+
+    fn delete(&self, _id: &str) -> bool {
+        unimplemented!("AAASM-1616: delete lands next")
+    }
+
+    fn find_by_name(&self, _name: &str) -> Option<AlertRule> {
+        unimplemented!("AAASM-1616: find_by_name lands next")
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -233,4 +233,18 @@ mod tests {
         names.sort();
         assert_eq!(names, vec!["a".to_string(), "b".to_string(), "c".to_string()]);
     }
+
+    #[test]
+    fn list_filter_true_returns_only_enabled_rules() {
+        let store = InMemoryAlertRuleStore::new();
+        store.create(rule_named("on")).expect("on");
+        store
+            .create(AlertRule {
+                enabled: false,
+                ..rule_named("off")
+            })
+            .expect("off");
+        let names: Vec<String> = store.list(Some(true)).into_iter().map(|r| r.name).collect();
+        assert_eq!(names, vec!["on".to_string()]);
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -129,8 +129,16 @@ impl AlertRuleStore for InMemoryAlertRuleStore {
         rules.get(id).cloned()
     }
 
-    fn list(&self, _enabled_filter: Option<bool>) -> Vec<AlertRule> {
-        unimplemented!("AAASM-1616: list lands next")
+    fn list(&self, enabled_filter: Option<bool>) -> Vec<AlertRule> {
+        let rules = self.rules.read().expect("alert rule store lock poisoned");
+        rules
+            .values()
+            .filter(|r| match enabled_filter {
+                Some(want) => r.enabled == want,
+                None => true,
+            })
+            .cloned()
+            .collect()
     }
 
     fn update(&self, _id: &str, _rule: AlertRule) -> Result<AlertRule, AlertRuleStoreError> {

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -3,3 +3,79 @@
 //! Today the only implementation is the in-memory
 //! [`InMemoryAlertRuleStore`] — a persisted store (e.g. SQLite) is
 //! deferred per the Story's acceptance criteria.
+
+use super::types::AlertRule;
+
+/// Errors surfaced from [`AlertRuleStore`] mutations.
+///
+/// Each variant maps onto a Story-defined HTTP error code that the
+/// handler in AAASM-1620 will return in the RFC 7807 response.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AlertRuleStoreError {
+    /// A rule with this `name` already exists (POST only). Maps to
+    /// 409 with `error: "rule_name_conflict"`.
+    NameConflict {
+        /// The conflicting rule name.
+        name: String,
+    },
+    /// No rule was found with the given id (GET / PUT / DELETE).
+    /// Maps to 404 with `error: "rule_not_found"`.
+    NotFound,
+}
+
+impl AlertRuleStoreError {
+    /// Stable error code returned in the RFC 7807 response.
+    pub fn error_code(&self) -> &'static str {
+        match self {
+            Self::NameConflict { .. } => "rule_name_conflict",
+            Self::NotFound => "rule_not_found",
+        }
+    }
+}
+
+impl std::fmt::Display for AlertRuleStoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NameConflict { name } => write!(f, "rule name already exists: {name}"),
+            Self::NotFound => write!(f, "rule not found"),
+        }
+    }
+}
+
+impl std::error::Error for AlertRuleStoreError {}
+
+/// Read-write storage abstraction over [`AlertRule`] records.
+///
+/// Implementations must be thread-safe (`Send + Sync`).
+pub trait AlertRuleStore: Send + Sync {
+    /// Persist a new rule, returning the fully-populated record.
+    ///
+    /// The store assigns `id`, `created_at`, and `updated_at` —
+    /// callers may leave them empty on input. Returns
+    /// [`AlertRuleStoreError::NameConflict`] when `rule.name`
+    /// duplicates an existing entry.
+    fn create(&self, rule: AlertRule) -> Result<AlertRule, AlertRuleStoreError>;
+
+    /// Fetch a rule by id, or `None` if no such rule exists.
+    fn get(&self, id: &str) -> Option<AlertRule>;
+
+    /// List all rules, optionally filtering by the `enabled` flag.
+    /// `enabled_filter = None` returns every rule.
+    fn list(&self, enabled_filter: Option<bool>) -> Vec<AlertRule>;
+
+    /// Replace the rule with id `id`. The stored record's `id` and
+    /// `created_at` are preserved; the rest of the fields are taken
+    /// from `rule`; `updated_at` is bumped to now. Returns
+    /// [`AlertRuleStoreError::NotFound`] when `id` is unknown.
+    fn update(&self, id: &str, rule: AlertRule) -> Result<AlertRule, AlertRuleStoreError>;
+
+    /// Remove the rule with id `id`. Returns true when a record was
+    /// removed, false when `id` was unknown.
+    fn delete(&self, id: &str) -> bool;
+
+    /// Find a rule by exact name match, or `None` if no such rule
+    /// exists. Used by the handler to surface
+    /// [`AlertRuleStoreError::NameConflict`] before re-inserting on
+    /// PUT requests that change the name.
+    fn find_by_name(&self, name: &str) -> Option<AlertRule>;
+}

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -297,4 +297,15 @@ mod tests {
         assert_eq!(err, AlertRuleStoreError::NotFound);
         assert_eq!(err.error_code(), "rule_not_found");
     }
+
+    #[test]
+    fn update_rejects_name_conflict_with_other_rule() {
+        let store = InMemoryAlertRuleStore::new();
+        let a = store.create(rule_named("a")).expect("a");
+        store.create(rule_named("b")).expect("b");
+        let err = store
+            .update(&a.id, rule_named("b"))
+            .expect_err("renaming a -> b must collide with the existing b");
+        assert!(matches!(err, AlertRuleStoreError::NameConflict { ref name } if name == "b"));
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -308,4 +308,12 @@ mod tests {
             .expect_err("renaming a -> b must collide with the existing b");
         assert!(matches!(err, AlertRuleStoreError::NameConflict { ref name } if name == "b"));
     }
+
+    #[test]
+    fn delete_removes_existing_rule_and_returns_true() {
+        let store = InMemoryAlertRuleStore::new();
+        let created = store.create(rule_named("r1")).expect("create");
+        assert!(store.delete(&created.id), "delete must return true for known id");
+        assert!(store.get(&created.id).is_none(), "rule must be gone");
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -316,4 +316,10 @@ mod tests {
         assert!(store.delete(&created.id), "delete must return true for known id");
         assert!(store.get(&created.id).is_none(), "rule must be gone");
     }
+
+    #[test]
+    fn delete_returns_false_for_unknown_id() {
+        let store = InMemoryAlertRuleStore::new();
+        assert!(!store.delete("missing"));
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -222,4 +222,15 @@ mod tests {
         assert_eq!(store.get(&created.id).map(|r| r.name), Some("r1".to_string()));
         assert!(store.get("does-not-exist").is_none());
     }
+
+    #[test]
+    fn list_returns_all_rules_when_filter_is_none() {
+        let store = InMemoryAlertRuleStore::new();
+        store.create(rule_named("a")).expect("a");
+        store.create(rule_named("b")).expect("b");
+        store.create(rule_named("c")).expect("c");
+        let mut names: Vec<String> = store.list(None).into_iter().map(|r| r.name).collect();
+        names.sort();
+        assert_eq!(names, vec!["a".to_string(), "b".to_string(), "c".to_string()]);
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -205,4 +205,13 @@ mod tests {
         assert!(!created.created_at.is_empty(), "created_at must be assigned");
         assert_eq!(created.created_at, created.updated_at);
     }
+
+    #[test]
+    fn create_rejects_duplicate_name() {
+        let store = InMemoryAlertRuleStore::new();
+        store.create(rule_named("dup")).expect("first create");
+        let err = store.create(rule_named("dup")).expect_err("duplicate name must fail");
+        assert!(matches!(err, AlertRuleStoreError::NameConflict { ref name } if name == "dup"));
+        assert_eq!(err.error_code(), "rule_name_conflict");
+    }
 }

--- a/aa-api/src/alerts/rules/store.rs
+++ b/aa-api/src/alerts/rules/store.rs
@@ -214,4 +214,12 @@ mod tests {
         assert!(matches!(err, AlertRuleStoreError::NameConflict { ref name } if name == "dup"));
         assert_eq!(err.error_code(), "rule_name_conflict");
     }
+
+    #[test]
+    fn get_returns_some_for_known_id_and_none_otherwise() {
+        let store = InMemoryAlertRuleStore::new();
+        let created = store.create(rule_named("r1")).expect("create");
+        assert_eq!(store.get(&created.id).map(|r| r.name), Some("r1".to_string()));
+        assert!(store.get("does-not-exist").is_none());
+    }
 }

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -331,4 +331,16 @@ mod tests {
         let rule = valid_rule();
         assert_eq!(rule.validate(&registry), Ok(()));
     }
+
+    #[test]
+    fn empty_name_rejected_as_invalid_name() {
+        let registry = TestRegistry::with(&["slack-ops"]);
+        let rule = AlertRule {
+            name: String::new(),
+            ..valid_rule()
+        };
+        let err = rule.validate(&registry).expect_err("empty name must fail");
+        assert!(matches!(err, AlertRuleValidationError::InvalidName { .. }));
+        assert_eq!(err.error_code(), "invalid_name");
+    }
 }

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -42,3 +42,14 @@ pub enum RuleOperator {
     #[serde(rename = "=")]
     Eq,
 }
+
+/// Severity assigned to alerts that this rule fires. Wire form is the
+/// uppercase string matching the Story (e.g. `"CRITICAL"`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum RuleSeverity {
+    Critical,
+    High,
+    Medium,
+    Low,
+}

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -368,4 +368,17 @@ mod tests {
         assert!(matches!(err, AlertRuleValidationError::InvalidThreshold { .. }));
         assert_eq!(err.error_code(), "invalid_threshold");
     }
+
+    #[test]
+    fn budget_threshold_below_zero_rejected() {
+        let registry = TestRegistry::with(&["slack-ops"]);
+        let rule = AlertRule {
+            threshold: -1.0,
+            ..valid_rule()
+        };
+        let err = rule
+            .validate(&registry)
+            .expect_err("negative threshold must fail for budget_spent_pct");
+        assert!(matches!(err, AlertRuleValidationError::InvalidThreshold { .. }));
+    }
 }

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -1,0 +1,25 @@
+//! Alert-rule domain types and validation (AAASM-1386).
+//!
+//! Wire shape matches the Story description verbatim: see
+//! `https://lightning-dust-mite.atlassian.net/browse/AAASM-1386` for the
+//! canonical JSON example.
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// Metric a rule evaluates against. Snake-case wire form matches the
+/// Story's enum exactly so the dashboard rule-builder dropdown can map
+/// 1:1 onto these variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RuleMetric {
+    /// Percentage of the daily budget consumed (0-100).
+    BudgetSpentPct,
+    /// Anomaly score from the gateway anomaly detector. Full hookup is
+    /// deferred — see the MVP evaluator note on AAASM-1386.
+    AnomalyScore,
+    /// Age (seconds) of the oldest pending approval request.
+    ApprovalPendingAge,
+    /// Count of policy violations within the evaluation window.
+    PolicyViolationCount,
+}

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -23,3 +23,22 @@ pub enum RuleMetric {
     /// Count of policy violations within the evaluation window.
     PolicyViolationCount,
 }
+
+/// Comparison operator applied between the metric's current value and
+/// the rule's threshold. Wire form is the literal symbol (e.g. `">"`),
+/// matching the Story description.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub enum RuleOperator {
+    /// Strictly greater than.
+    #[serde(rename = ">")]
+    Gt,
+    /// Greater than or equal to.
+    #[serde(rename = ">=")]
+    Gte,
+    /// Strictly less than.
+    #[serde(rename = "<")]
+    Lt,
+    /// Equal to.
+    #[serde(rename = "=")]
+    Eq,
+}

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -343,4 +343,15 @@ mod tests {
         assert!(matches!(err, AlertRuleValidationError::InvalidName { .. }));
         assert_eq!(err.error_code(), "invalid_name");
     }
+
+    #[test]
+    fn name_over_128_chars_rejected() {
+        let registry = TestRegistry::with(&["slack-ops"]);
+        let rule = AlertRule {
+            name: "x".repeat(129),
+            ..valid_rule()
+        };
+        let err = rule.validate(&registry).expect_err("long name must fail");
+        assert!(matches!(err, AlertRuleValidationError::InvalidName { .. }));
+    }
 }

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -392,4 +392,18 @@ mod tests {
         let err = rule.validate(&registry).expect_err("NaN threshold must fail");
         assert!(matches!(err, AlertRuleValidationError::InvalidThreshold { .. }));
     }
+
+    #[test]
+    fn anomaly_threshold_negative_rejected() {
+        let registry = TestRegistry::with(&["slack-ops"]);
+        let rule = AlertRule {
+            metric: RuleMetric::AnomalyScore,
+            threshold: -0.1,
+            ..valid_rule()
+        };
+        let err = rule
+            .validate(&registry)
+            .expect_err("negative anomaly_score threshold must fail");
+        assert!(matches!(err, AlertRuleValidationError::InvalidThreshold { .. }));
+    }
 }

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -406,4 +406,19 @@ mod tests {
             .expect_err("negative anomaly_score threshold must fail");
         assert!(matches!(err, AlertRuleValidationError::InvalidThreshold { .. }));
     }
+
+    #[test]
+    fn evaluation_window_not_in_allowed_set_rejected() {
+        let registry = TestRegistry::with(&["slack-ops"]);
+        let rule = AlertRule {
+            evaluation_window_seconds: 600,
+            ..valid_rule()
+        };
+        let err = rule.validate(&registry).expect_err("600 is not in {300, 900, 3600}");
+        assert!(matches!(
+            err,
+            AlertRuleValidationError::InvalidEvaluationWindow { value: 600 }
+        ));
+        assert_eq!(err.error_code(), "invalid_evaluation_window");
+    }
 }

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -354,4 +354,18 @@ mod tests {
         let err = rule.validate(&registry).expect_err("long name must fail");
         assert!(matches!(err, AlertRuleValidationError::InvalidName { .. }));
     }
+
+    #[test]
+    fn budget_threshold_above_100_rejected() {
+        let registry = TestRegistry::with(&["slack-ops"]);
+        let rule = AlertRule {
+            threshold: 101.0,
+            ..valid_rule()
+        };
+        let err = rule
+            .validate(&registry)
+            .expect_err("threshold 101 must fail for budget_spent_pct");
+        assert!(matches!(err, AlertRuleValidationError::InvalidThreshold { .. }));
+        assert_eq!(err.error_code(), "invalid_threshold");
+    }
 }

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -421,4 +421,16 @@ mod tests {
         ));
         assert_eq!(err.error_code(), "invalid_evaluation_window");
     }
+
+    #[test]
+    fn empty_destination_ids_rejected() {
+        let registry = TestRegistry::with(&["slack-ops"]);
+        let rule = AlertRule {
+            destination_ids: Vec::new(),
+            ..valid_rule()
+        };
+        let err = rule.validate(&registry).expect_err("empty destination_ids must fail");
+        assert!(matches!(err, AlertRuleValidationError::EmptyDestinations));
+        assert_eq!(err.error_code(), "destination_unknown");
+    }
 }

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -53,3 +53,12 @@ pub enum RuleSeverity {
     Medium,
     Low,
 }
+
+/// Read-only view of the destination registry that an alert rule's
+/// `destination_ids` are validated against. Kept as a trait here so the
+/// validation logic does not depend on the concrete in-memory registry
+/// (delivered separately under AAASM-1617).
+pub trait DestinationRegistryLookup {
+    /// Returns true when `id` is a known destination.
+    fn contains(&self, id: &str) -> bool;
+}

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -184,3 +184,99 @@ impl std::fmt::Display for AlertRuleValidationError {
 }
 
 impl std::error::Error for AlertRuleValidationError {}
+
+/// Maximum name length per the Story spec ("`name` 1-128 chars").
+const NAME_MAX_LEN: usize = 128;
+
+/// Allowed `evaluation_window_seconds` values per the Story spec.
+const ALLOWED_EVAL_WINDOWS: [u32; 3] = [300, 900, 3600];
+
+impl AlertRule {
+    /// Validate the rule against the constraints enumerated in the
+    /// Story's "Validation rules" section. Returns the first failure
+    /// encountered — callers are expected to fix one issue at a time
+    /// based on the surfaced `error_code`.
+    pub fn validate<R: DestinationRegistryLookup + ?Sized>(
+        &self,
+        destinations: &R,
+    ) -> Result<(), AlertRuleValidationError> {
+        // name: 1-128 chars
+        if self.name.is_empty() {
+            return Err(AlertRuleValidationError::InvalidName {
+                reason: "name must not be empty".to_string(),
+            });
+        }
+        if self.name.chars().count() > NAME_MAX_LEN {
+            return Err(AlertRuleValidationError::InvalidName {
+                reason: format!("name must be at most {NAME_MAX_LEN} chars"),
+            });
+        }
+
+        // threshold: range per metric
+        if let Some(reason) = threshold_range_violation(self.metric, self.threshold) {
+            return Err(AlertRuleValidationError::InvalidThreshold {
+                metric: self.metric,
+                value: self.threshold,
+                reason,
+            });
+        }
+
+        // evaluation_window_seconds ∈ {300, 900, 3600}
+        if !ALLOWED_EVAL_WINDOWS.contains(&self.evaluation_window_seconds) {
+            return Err(AlertRuleValidationError::InvalidEvaluationWindow {
+                value: self.evaluation_window_seconds,
+            });
+        }
+
+        // destination_ids: non-empty + each must exist in registry
+        if self.destination_ids.is_empty() {
+            return Err(AlertRuleValidationError::EmptyDestinations);
+        }
+        for id in &self.destination_ids {
+            if !destinations.contains(id) {
+                return Err(AlertRuleValidationError::UnknownDestination { id: id.clone() });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Returns `Some(reason)` when `value` is out of the metric's allowed
+/// range, `None` when valid. Centralized so the per-metric units stay
+/// in one place.
+fn threshold_range_violation(metric: RuleMetric, value: f64) -> Option<String> {
+    if !value.is_finite() {
+        return Some("threshold must be a finite number".to_string());
+    }
+    match metric {
+        RuleMetric::BudgetSpentPct => {
+            if !(0.0..=100.0).contains(&value) {
+                Some("budget_spent_pct threshold must be in [0, 100]".to_string())
+            } else {
+                None
+            }
+        }
+        RuleMetric::AnomalyScore => {
+            if value < 0.0 {
+                Some("anomaly_score threshold must be >= 0".to_string())
+            } else {
+                None
+            }
+        }
+        RuleMetric::ApprovalPendingAge => {
+            if value < 0.0 {
+                Some("approval_pending_age threshold (seconds) must be >= 0".to_string())
+            } else {
+                None
+            }
+        }
+        RuleMetric::PolicyViolationCount => {
+            if value < 0.0 {
+                Some("policy_violation_count threshold must be >= 0".to_string())
+            } else {
+                None
+            }
+        }
+    }
+}

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -280,3 +280,55 @@ fn threshold_range_violation(metric: RuleMetric, value: f64) -> Option<String> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    /// Minimal in-test destination registry. The real seeded
+    /// implementation ships under AAASM-1617.
+    struct TestRegistry {
+        ids: HashSet<String>,
+    }
+
+    impl TestRegistry {
+        fn with(ids: &[&str]) -> Self {
+            Self {
+                ids: ids.iter().map(|s| (*s).to_string()).collect(),
+            }
+        }
+    }
+
+    impl DestinationRegistryLookup for TestRegistry {
+        fn contains(&self, id: &str) -> bool {
+            self.ids.contains(id)
+        }
+    }
+
+    fn valid_rule() -> AlertRule {
+        AlertRule {
+            id: "01HX0000000000000000000000".to_string(),
+            name: "Budget > 90%".to_string(),
+            description: "Fire CRITICAL when budget spend exceeds 90% over 5m".to_string(),
+            metric: RuleMetric::BudgetSpentPct,
+            operator: RuleOperator::Gt,
+            threshold: 90.0,
+            evaluation_window_seconds: 300,
+            severity: RuleSeverity::Critical,
+            destination_ids: vec!["slack-ops".to_string()],
+            dedup_window_seconds: 600,
+            suppression_labels: HashMap::new(),
+            enabled: true,
+            created_at: "2026-05-13T09:00:00Z".to_string(),
+            updated_at: "2026-05-13T09:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn valid_rule_passes_validation() {
+        let registry = TestRegistry::with(&["slack-ops"]);
+        let rule = valid_rule();
+        assert_eq!(rule.validate(&registry), Ok(()));
+    }
+}

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -381,4 +381,15 @@ mod tests {
             .expect_err("negative threshold must fail for budget_spent_pct");
         assert!(matches!(err, AlertRuleValidationError::InvalidThreshold { .. }));
     }
+
+    #[test]
+    fn non_finite_threshold_rejected() {
+        let registry = TestRegistry::with(&["slack-ops"]);
+        let rule = AlertRule {
+            threshold: f64::NAN,
+            ..valid_rule()
+        };
+        let err = rule.validate(&registry).expect_err("NaN threshold must fail");
+        assert!(matches!(err, AlertRuleValidationError::InvalidThreshold { .. }));
+    }
 }

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -74,6 +74,7 @@ pub trait DestinationRegistryLookup {
 /// the store will overwrite them on PUT to preserve `id` + `created_at`
 /// and bump `updated_at`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct AlertRule {
     /// Server-assigned ULID-style identifier.
     pub id: String,
@@ -460,6 +461,22 @@ mod tests {
         assert_eq!(v["metric"], "budget_spent_pct");
         assert_eq!(v["operator"], ">");
         assert_eq!(v["severity"], "CRITICAL");
+    }
+
+    #[test]
+    fn field_names_serialize_as_camel_case() {
+        let rule = valid_rule();
+        let v: serde_json::Value = serde_json::to_value(&rule).unwrap();
+        // Matches dashboard AlertRule TS interface field names (AAASM-1075).
+        assert!(v.get("evaluationWindowSeconds").is_some());
+        assert!(v.get("destinationIds").is_some());
+        assert!(v.get("dedupWindowSeconds").is_some());
+        assert!(v.get("createdAt").is_some());
+        assert!(v.get("updatedAt").is_some());
+        // Snake-case form must not appear on the wire.
+        assert!(v.get("evaluation_window_seconds").is_none());
+        assert!(v.get("destination_ids").is_none());
+        assert!(v.get("created_at").is_none());
     }
 
     #[test]

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -447,4 +447,18 @@ mod tests {
             other => panic!("expected UnknownDestination, got {other:?}"),
         }
     }
+
+    #[test]
+    fn alert_rule_round_trips_through_serde() {
+        let rule = valid_rule();
+        let json = serde_json::to_string(&rule).expect("serialize");
+        let parsed: AlertRule = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed, rule);
+
+        // Spot-check wire-form values match the Story example.
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["metric"], "budget_spent_pct");
+        assert_eq!(v["operator"], ">");
+        assert_eq!(v["severity"], "CRITICAL");
+    }
 }

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -109,3 +109,78 @@ pub struct AlertRule {
     /// RFC 3339 timestamp of the last mutation.
     pub updated_at: String,
 }
+
+/// Validation failure surfaced from [`AlertRule::validate`].
+///
+/// Each variant carries an `error_code()` matching the Story's wire
+/// contract. `invalid_metric` is not represented here because that case
+/// is caught by serde during request deserialization (the unknown
+/// `metric` string never round-trips into [`AlertRule`] in the first
+/// place); the handler in AAASM-1620 maps the serde error to a 400 with
+/// `error: "invalid_metric"`.
+///
+/// `invalid_name` and `invalid_evaluation_window` are extension codes
+/// covering the validation rules the Story's prose lists but does not
+/// label in its HTTP error table.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AlertRuleValidationError {
+    /// Name length is outside `[1, 128]` characters.
+    InvalidName {
+        /// Why the name was rejected (e.g. `"name must be 1-128 chars"`).
+        reason: String,
+    },
+    /// `threshold` is out of the metric's allowed range
+    /// (e.g. 0-100 for percentage metrics).
+    InvalidThreshold {
+        /// Metric whose unit constraint was violated.
+        metric: RuleMetric,
+        /// Submitted threshold value.
+        value: f64,
+        /// Reason the value was rejected.
+        reason: String,
+    },
+    /// `evaluation_window_seconds` is not in the allowed set
+    /// `{300, 900, 3600}`.
+    InvalidEvaluationWindow {
+        /// Submitted window value.
+        value: u32,
+    },
+    /// `destination_ids` is empty.
+    EmptyDestinations,
+    /// `destination_ids` references an id the registry does not know.
+    UnknownDestination {
+        /// The id that was rejected.
+        id: String,
+    },
+}
+
+impl AlertRuleValidationError {
+    /// Stable error code returned in the RFC 7807 response.
+    pub fn error_code(&self) -> &'static str {
+        match self {
+            Self::InvalidName { .. } => "invalid_name",
+            Self::InvalidThreshold { .. } => "invalid_threshold",
+            Self::InvalidEvaluationWindow { .. } => "invalid_evaluation_window",
+            Self::EmptyDestinations | Self::UnknownDestination { .. } => "destination_unknown",
+        }
+    }
+}
+
+impl std::fmt::Display for AlertRuleValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidName { reason } => write!(f, "invalid name: {reason}"),
+            Self::InvalidThreshold { metric, value, reason } => {
+                write!(f, "invalid threshold {value} for metric {metric:?}: {reason}")
+            }
+            Self::InvalidEvaluationWindow { value } => write!(
+                f,
+                "invalid evaluation_window_seconds {value}: must be 300, 900, or 3600",
+            ),
+            Self::EmptyDestinations => write!(f, "destination_ids must be non-empty"),
+            Self::UnknownDestination { id } => write!(f, "destination_unknown: {id}"),
+        }
+    }
+}
+
+impl std::error::Error for AlertRuleValidationError {}

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -461,4 +461,15 @@ mod tests {
         assert_eq!(v["operator"], ">");
         assert_eq!(v["severity"], "CRITICAL");
     }
+
+    #[test]
+    fn empty_suppression_labels_are_omitted_on_the_wire() {
+        let rule = valid_rule();
+        let json = serde_json::to_string(&rule).expect("serialize");
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert!(
+            v.get("suppression_labels").is_none(),
+            "empty suppression_labels should be omitted, got {v}",
+        );
+    }
 }

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -433,4 +433,18 @@ mod tests {
         assert!(matches!(err, AlertRuleValidationError::EmptyDestinations));
         assert_eq!(err.error_code(), "destination_unknown");
     }
+
+    #[test]
+    fn unknown_destination_id_rejected() {
+        let registry = TestRegistry::with(&["slack-ops"]);
+        let rule = AlertRule {
+            destination_ids: vec!["slack-ops".to_string(), "unknown-dest".to_string()],
+            ..valid_rule()
+        };
+        let err = rule.validate(&registry).expect_err("unknown destination id must fail");
+        match err {
+            AlertRuleValidationError::UnknownDestination { id } => assert_eq!(id, "unknown-dest"),
+            other => panic!("expected UnknownDestination, got {other:?}"),
+        }
+    }
 }

--- a/aa-api/src/alerts/rules/types.rs
+++ b/aa-api/src/alerts/rules/types.rs
@@ -4,6 +4,8 @@
 //! `https://lightning-dust-mite.atlassian.net/browse/AAASM-1386` for the
 //! canonical JSON example.
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
@@ -61,4 +63,49 @@ pub enum RuleSeverity {
 pub trait DestinationRegistryLookup {
     /// Returns true when `id` is a known destination.
     fn contains(&self, id: &str) -> bool;
+}
+
+/// A persisted alert rule. Same shape is used for request bodies on
+/// POST / PUT and for response bodies on GET, matching the Story
+/// description verbatim.
+///
+/// `id`, `created_at`, and `updated_at` are server-assigned; clients
+/// must omit them on POST (the in-memory store will populate them) and
+/// the store will overwrite them on PUT to preserve `id` + `created_at`
+/// and bump `updated_at`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct AlertRule {
+    /// Server-assigned ULID-style identifier.
+    pub id: String,
+    /// Human-readable rule name. Must be 1-128 characters and unique
+    /// per tenant (uniqueness is enforced at the store layer).
+    pub name: String,
+    /// Free-form description displayed in the dashboard rule list.
+    pub description: String,
+    /// Metric the rule polls.
+    pub metric: RuleMetric,
+    /// Comparison operator applied between the metric value and
+    /// [`Self::threshold`].
+    pub operator: RuleOperator,
+    /// Numeric threshold. Must be 0-100 for percentage metrics
+    /// (see [`AlertRule::validate`]).
+    pub threshold: f64,
+    /// Evaluation window in seconds — must be one of `{300, 900, 3600}`.
+    pub evaluation_window_seconds: u32,
+    /// Severity propagated to alerts emitted by this rule.
+    pub severity: RuleSeverity,
+    /// Destinations the alert is routed to. Non-empty; each id must
+    /// exist in the destination registry.
+    pub destination_ids: Vec<String>,
+    /// Window in seconds during which repeat firings are deduplicated.
+    pub dedup_window_seconds: u32,
+    /// Optional free-form `key=value` suppression labels.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub suppression_labels: HashMap<String, String>,
+    /// Whether the rule is actively evaluated.
+    pub enabled: bool,
+    /// RFC 3339 timestamp when the rule was first created.
+    pub created_at: String,
+    /// RFC 3339 timestamp of the last mutation.
+    pub updated_at: String,
 }

--- a/aa-api/src/error.rs
+++ b/aa-api/src/error.rs
@@ -65,6 +65,13 @@ impl ProblemDetail {
         self.instance = Some(instance.into());
         self
     }
+
+    /// Attach a stable machine-readable error code.
+    #[must_use]
+    pub fn with_error_code(mut self, code: &'static str) -> Self {
+        self.error_code = Some(code);
+        self
+    }
 }
 
 impl IntoResponse for ProblemDetail {

--- a/aa-api/src/error.rs
+++ b/aa-api/src/error.rs
@@ -88,3 +88,28 @@ impl IntoResponse for ProblemDetail {
             .into_response()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_code_is_omitted_when_unset() {
+        let problem = ProblemDetail::from_status(StatusCode::NOT_FOUND).with_detail("missing");
+        let v: serde_json::Value = serde_json::to_value(&problem).unwrap();
+        assert!(
+            v.get("error_code").is_none(),
+            "unset error_code must not appear on the wire"
+        );
+    }
+
+    #[test]
+    fn error_code_is_serialized_when_set() {
+        let problem = ProblemDetail::from_status(StatusCode::CONFLICT)
+            .with_detail("duplicate")
+            .with_error_code("rule_name_conflict");
+        let v: serde_json::Value = serde_json::to_value(&problem).unwrap();
+        assert_eq!(v["error_code"], "rule_name_conflict");
+        assert_eq!(v["status"], 409);
+    }
+}

--- a/aa-api/src/error.rs
+++ b/aa-api/src/error.rs
@@ -27,6 +27,16 @@ pub struct ProblemDetail {
     /// URI reference identifying the specific occurrence.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub instance: Option<String>,
+    /// Stable machine-readable error code (e.g. `"invalid_threshold"`)
+    /// for clients that need to branch on the specific failure
+    /// without parsing the human-readable `detail`. Omitted from the
+    /// wire when unset so existing endpoints stay byte-identical.
+    ///
+    /// Codes are static identifiers — `&'static str` keeps the struct
+    /// small enough that handlers returning `Result<_, ProblemDetail>`
+    /// stay under clippy's `result_large_err` threshold.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<&'static str>,
 }
 
 impl ProblemDetail {
@@ -38,6 +48,7 @@ impl ProblemDetail {
             status: status.as_u16(),
             detail: None,
             instance: None,
+            error_code: None,
         }
     }
 

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -2064,6 +2064,17 @@ export interface components {
         ProblemDetail: {
             /** @description Human-readable explanation specific to this occurrence. */
             detail?: string | null;
+            /**
+             * @description Stable machine-readable error code (e.g. `"invalid_threshold"`)
+             *     for clients that need to branch on the specific failure
+             *     without parsing the human-readable `detail`. Omitted from the
+             *     wire when unset so existing endpoints stay byte-identical.
+             *
+             *     Codes are static identifiers — `&'static str` keeps the struct
+             *     small enough that handlers returning `Result<_, ProblemDetail>`
+             *     stay under clippy's `result_large_err` threshold.
+             */
+            error_code?: string | null;
             /** @description URI reference identifying the specific occurrence. */
             instance?: string | null;
             /**

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -3574,6 +3574,19 @@ components:
           - string
           - 'null'
           description: Human-readable explanation specific to this occurrence.
+        error_code:
+          type:
+          - string
+          - 'null'
+          description: |-
+            Stable machine-readable error code (e.g. `"invalid_threshold"`)
+            for clients that need to branch on the specific failure
+            without parsing the human-readable `detail`. Omitted from the
+            wire when unset so existing endpoints stay byte-identical.
+
+            Codes are static identifiers — `&'static str` keeps the struct
+            small enough that handlers returning `Result<_, ProblemDetail>`
+            stay under clippy's `result_large_err` threshold.
         instance:
           type:
           - string


### PR DESCRIPTION
## Description

Fourth sub-task of **AAASM-1386**. Adds an optional `error_code` field to
`ProblemDetail` so the alert-rules handler in AAASM-1620 can attach the
Story-defined codes (`invalid_metric`, `invalid_threshold`,
`destination_unknown`, `rule_not_found`, `rule_name_conflict`) to RFC
7807 responses without breaking the existing wire shape.

The field uses `Option<&'static str>` (rather than `Option<String>`)
to keep `ProblemDetail` under clippy's `result_large_err` size
threshold — error codes are always static identifiers, never dynamic
strings.

## Depends on

- **#592 / #601 / #602** (stacked on master from AAASM-1615 ⟶ 1616 ⟶ 1617).

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No — additive field with `#[serde(skip_serializing_if = "Option::is_none")]`

## Related Issues

- Related Jira ticket: **AAASM-1618** (Sub-task of [AAASM-1386](https://lightning-dust-mite.atlassian.net/browse/AAASM-1386))

## Testing

- [x] 2 unit tests in `aa-api/src/error.rs::tests`
- [x] `cargo nextest run -p aa-api` → **363 / 363 passed** (full suite, including all existing tests)
- [x] `cargo clippy -p aa-api --all-targets --all-features -- -D warnings` → clean
- [x] `cargo fmt --all -- --check` → clean

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Commits follow the Gitmoji convention

[AAASM-1386]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ