### PR TITLE
[AAASM-1619] ✨ (state): Wire alert_rule_store + destination_registry into AppState

### DIFF
--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -17,6 +17,8 @@ use aa_gateway::registry::AgentRegistry;
 use aa_gateway::AuditReader;
 use aa_runtime::approval::ApprovalQueue;
 
+use crate::alerts::rules::destinations::DestinationRegistry;
+use crate::alerts::rules::store::AlertRuleStore;
 use crate::alerts::silence_store::SilenceStore;
 use crate::alerts::AlertStore;
 use crate::auth::api_key::ApiKeyStore;
@@ -107,4 +109,8 @@ pub struct AppState {
     /// (AAASM-924). 5-minute TTL by default. Shared across requests so
     /// the resolver backend is hit at most once per TTL window per key.
     pub saas_secret_cache: Arc<crate::routes::devtools::secret_cache::SecretCache>,
+    /// Alert-rule CRUD store (AAASM-1386).
+    pub alert_rule_store: Arc<dyn AlertRuleStore>,
+    /// Allow-set of destinations alert rules may target (AAASM-1386).
+    pub destination_registry: Arc<DestinationRegistry>,
 }

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -5,6 +5,8 @@ use std::sync::atomic::{AtomicI64, AtomicU64, AtomicUsize};
 use std::sync::Arc;
 use std::time::Instant;
 
+use aa_api::alerts::rules::destinations::DestinationRegistry;
+use aa_api::alerts::rules::store::InMemoryAlertRuleStore;
 use aa_api::alerts::silence_store::InMemorySilenceStore;
 use aa_api::alerts::store::InMemoryAlertStore;
 use aa_api::auth::api_key::{ApiKey, ApiKeyEntry, ApiKeyStore};
@@ -168,6 +170,8 @@ spec:
         destination_store: Arc::new(InMemoryDestinationStore::new(Arc::new(NoopRuleReferenceChecker))),
         audit_sender: None,
         saas_secret_cache: Arc::new(aa_api::routes::devtools::secret_cache::SecretCache::new()),
+        alert_rule_store: Arc::new(InMemoryAlertRuleStore::new()),
+        destination_registry: Arc::new(DestinationRegistry::seeded()),
     }
 }
 

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -45,6 +45,8 @@ use std::sync::atomic::{AtomicI64, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use aa_api::alerts::rules::destinations::DestinationRegistry;
+use aa_api::alerts::rules::store::InMemoryAlertRuleStore;
 use aa_api::alerts::silence_store::InMemorySilenceStore;
 use aa_api::alerts::store::InMemoryAlertStore;
 use aa_api::auth::api_key::{ApiKey, ApiKeyEntry, ApiKeyStore};
@@ -668,6 +670,8 @@ spec:
             destination_store: Arc::new(InMemoryDestinationStore::new(Arc::new(NoopRuleReferenceChecker))),
             audit_sender: None,
             saas_secret_cache: Arc::new(aa_api::routes::devtools::secret_cache::SecretCache::new()),
+            alert_rule_store: Arc::new(InMemoryAlertRuleStore::new()),
+            destination_registry: Arc::new(DestinationRegistry::seeded()),
         },
         audit_dir,
         alert_store_handle,
@@ -801,6 +805,8 @@ spec:
             destination_store: Arc::new(InMemoryDestinationStore::new(Arc::new(NoopRuleReferenceChecker))),
             audit_sender: None,
             saas_secret_cache: Arc::new(aa_api::routes::devtools::secret_cache::SecretCache::new()),
+            alert_rule_store: Arc::new(InMemoryAlertRuleStore::new()),
+            destination_registry: Arc::new(DestinationRegistry::seeded()),
         },
         audit_dir,
         alert_store_handle,
@@ -935,6 +941,8 @@ spec:
             destination_store: Arc::new(InMemoryDestinationStore::new(Arc::new(NoopRuleReferenceChecker))),
             audit_sender: None,
             saas_secret_cache: Arc::new(aa_api::routes::devtools::secret_cache::SecretCache::new()),
+            alert_rule_store: Arc::new(InMemoryAlertRuleStore::new()),
+            destination_registry: Arc::new(DestinationRegistry::seeded()),
         },
         audit_dir,
         alert_store_handle,
@@ -1055,6 +1063,8 @@ spec:
             destination_store: Arc::new(InMemoryDestinationStore::new(Arc::new(NoopRuleReferenceChecker))),
             audit_sender: None,
             saas_secret_cache: Arc::new(aa_api::routes::devtools::secret_cache::SecretCache::new()),
+            alert_rule_store: Arc::new(InMemoryAlertRuleStore::new()),
+            destination_registry: Arc::new(DestinationRegistry::seeded()),
         },
         audit_dir,
         alert_store_handle,
@@ -1171,6 +1181,8 @@ fn build_test_state_empty_policy() -> anyhow::Result<(AppState, PathBuf, Arc<InM
             destination_store: Arc::new(InMemoryDestinationStore::new(Arc::new(NoopRuleReferenceChecker))),
             audit_sender: None,
             saas_secret_cache: Arc::new(aa_api::routes::devtools::secret_cache::SecretCache::new()),
+            alert_rule_store: Arc::new(InMemoryAlertRuleStore::new()),
+            destination_registry: Arc::new(DestinationRegistry::seeded()),
         },
         audit_dir,
         alert_store_handle,


### PR DESCRIPTION
## Description

Fifth sub-task of **AAASM-1386**. Threads the two new singletons added by
AAASM-1615 / AAASM-1616 / AAASM-1617 through `AppState` so the CRUD
handlers in AAASM-1620 can reach them via `Extension<AppState>`:

- `alert_rule_store: Arc<dyn AlertRuleStore>` (defaults to
  `InMemoryAlertRuleStore::new()`).
- `destination_registry: Arc<DestinationRegistry>` (defaults to
  `DestinationRegistry::seeded()` — slack-ops, pagerduty-oncall,
  email-team).

All `AppState` constructors in the workspace get the new fields in the
same commit to keep the repo bisectable: `aa-api/tests/common/mod.rs`
plus five sites under `aa-integration-tests/tests/common/mod.rs`.

## Depends on

- **#592 / #601 / #602 / #603** (stacked on master from
  AAASM-1615 ⟶ 1616 ⟶ 1617 ⟶ 1618).

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No — additive fields with defaults supplied at every construction site.

## Related Issues

- Related Jira ticket: **AAASM-1619** (Sub-task of [AAASM-1386](https://lightning-dust-mite.atlassian.net/browse/AAASM-1386))

## Testing

- [x] `cargo nextest run -p aa-api -p aa-gateway` → **1157 / 1157 passed**
- [x] `cargo clippy --all-targets --all-features -- -D warnings` → clean

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed

[AAASM-1386]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ