### PR TITLE
[AAASM-1621] ✨ (alert-rules): Add MVP rule evaluator + wire into run_server

### DIFF
--- a/aa-api/src/alerts/rules/evaluator.rs
+++ b/aa-api/src/alerts/rules/evaluator.rs
@@ -87,7 +87,6 @@ pub fn evaluate_once<S: MetricSource + ?Sized>(
 /// tests use much shorter) and calls [`evaluate_once`] on every tick.
 ///
 /// Cancel the returned [`JoinHandle`] to stop the loop.
-#[allow(dead_code)]
 pub fn spawn_rule_evaluator<S>(
     rules: Arc<dyn AlertRuleStore>,
     metrics: Arc<S>,

--- a/aa-api/src/alerts/rules/evaluator.rs
+++ b/aa-api/src/alerts/rules/evaluator.rs
@@ -1,0 +1,30 @@
+//! Minimum-viable alert-rule evaluator (AAASM-1386).
+//!
+//! Polls a [`MetricSource`] at each rule's `evaluation_window_seconds`
+//! cadence; when the condition holds the rule "fires" and an entry is
+//! recorded into the [`AlertStore`]. The full hookup for non-budget
+//! metrics is deferred per the Story AC — those metric variants return
+//! `None` here and are silently skipped by the evaluator.
+
+use crate::alerts::rules::types::RuleMetric;
+
+/// Read-only source of metric values that the evaluator consults to
+/// decide whether to fire a rule.
+pub trait MetricSource: Send + Sync {
+    /// Current value for `metric`, or `None` when the metric has no
+    /// observation yet (e.g. anomaly detector not wired in MVP).
+    fn current_value(&self, metric: RuleMetric) -> Option<f64>;
+}
+
+/// MVP metric source — returns `None` for every metric. Wired into
+/// `run_server` so the evaluator's plumbing is exercised end-to-end
+/// without claiming MVP scope covers the anomaly/approval-age/violation
+/// hookups (those are explicit follow-ups in the Story AC).
+#[allow(dead_code)]
+pub struct NullMetricSource;
+
+impl MetricSource for NullMetricSource {
+    fn current_value(&self, _metric: RuleMetric) -> Option<f64> {
+        None
+    }
+}

--- a/aa-api/src/alerts/rules/evaluator.rs
+++ b/aa-api/src/alerts/rules/evaluator.rs
@@ -6,7 +6,7 @@
 //! metrics is deferred per the Story AC — those metric variants return
 //! `None` here and are silently skipped by the evaluator.
 
-use crate::alerts::rules::types::RuleMetric;
+use crate::alerts::rules::types::{AlertRule, RuleMetric, RuleOperator};
 
 /// Read-only source of metric values that the evaluator consults to
 /// decide whether to fire a rule.
@@ -26,5 +26,69 @@ pub struct NullMetricSource;
 impl MetricSource for NullMetricSource {
     fn current_value(&self, _metric: RuleMetric) -> Option<f64> {
         None
+    }
+}
+
+/// Returns true when the current metric `value` satisfies the rule's
+/// `operator` ⟂ `threshold` condition.
+#[allow(dead_code)]
+pub fn evaluate(rule: &AlertRule, value: f64) -> bool {
+    match rule.operator {
+        RuleOperator::Gt => value > rule.threshold,
+        RuleOperator::Gte => value >= rule.threshold,
+        RuleOperator::Lt => value < rule.threshold,
+        RuleOperator::Eq => (value - rule.threshold).abs() < f64::EPSILON,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::alerts::rules::types::{RuleMetric, RuleOperator, RuleSeverity};
+    use std::collections::HashMap;
+
+    fn rule(operator: RuleOperator, threshold: f64) -> AlertRule {
+        AlertRule {
+            id: String::new(),
+            name: format!("rule-{operator:?}-{threshold}"),
+            description: String::new(),
+            metric: RuleMetric::BudgetSpentPct,
+            operator,
+            threshold,
+            evaluation_window_seconds: 300,
+            severity: RuleSeverity::Critical,
+            destination_ids: vec!["slack-ops".to_string()],
+            dedup_window_seconds: 600,
+            suppression_labels: HashMap::new(),
+            enabled: true,
+            created_at: String::new(),
+            updated_at: String::new(),
+        }
+    }
+
+    #[test]
+    fn evaluate_honors_gt_operator() {
+        assert!(evaluate(&rule(RuleOperator::Gt, 90.0), 91.0));
+        assert!(!evaluate(&rule(RuleOperator::Gt, 90.0), 90.0));
+        assert!(!evaluate(&rule(RuleOperator::Gt, 90.0), 89.0));
+    }
+
+    #[test]
+    fn evaluate_honors_gte_operator() {
+        assert!(evaluate(&rule(RuleOperator::Gte, 90.0), 90.0));
+        assert!(evaluate(&rule(RuleOperator::Gte, 90.0), 91.0));
+        assert!(!evaluate(&rule(RuleOperator::Gte, 90.0), 89.0));
+    }
+
+    #[test]
+    fn evaluate_honors_lt_operator() {
+        assert!(evaluate(&rule(RuleOperator::Lt, 50.0), 49.0));
+        assert!(!evaluate(&rule(RuleOperator::Lt, 50.0), 50.0));
+    }
+
+    #[test]
+    fn evaluate_honors_eq_operator() {
+        assert!(evaluate(&rule(RuleOperator::Eq, 50.0), 50.0));
+        assert!(!evaluate(&rule(RuleOperator::Eq, 50.0), 49.0));
     }
 }

--- a/aa-api/src/alerts/rules/evaluator.rs
+++ b/aa-api/src/alerts/rules/evaluator.rs
@@ -6,7 +6,12 @@
 //! metrics is deferred per the Story AC — those metric variants return
 //! `None` here and are silently skipped by the evaluator.
 
+use aa_core::AgentId;
+use aa_gateway::budget::types::BudgetAlert;
+
+use crate::alerts::rules::store::AlertRuleStore;
 use crate::alerts::rules::types::{AlertRule, RuleMetric, RuleOperator};
+use crate::alerts::AlertStore;
 
 /// Read-only source of metric values that the evaluator consults to
 /// decide whether to fire a rule.
@@ -31,7 +36,6 @@ impl MetricSource for NullMetricSource {
 
 /// Returns true when the current metric `value` satisfies the rule's
 /// `operator` ⟂ `threshold` condition.
-#[allow(dead_code)]
 pub fn evaluate(rule: &AlertRule, value: f64) -> bool {
     match rule.operator {
         RuleOperator::Gt => value > rule.threshold,
@@ -39,6 +43,41 @@ pub fn evaluate(rule: &AlertRule, value: f64) -> bool {
         RuleOperator::Lt => value < rule.threshold,
         RuleOperator::Eq => (value - rule.threshold).abs() < f64::EPSILON,
     }
+}
+
+/// Run one evaluation pass over every enabled rule, recording an alert
+/// into `alerts` when the condition holds. Returns the number of
+/// alerts recorded by this pass.
+#[allow(dead_code)]
+pub fn evaluate_once<S: MetricSource + ?Sized>(
+    rules: &dyn AlertRuleStore,
+    metrics: &S,
+    alerts: &dyn AlertStore,
+) -> usize {
+    let mut fired = 0;
+    for rule in rules.list(Some(true)) {
+        let Some(value) = metrics.current_value(rule.metric) else {
+            continue;
+        };
+        if !evaluate(&rule, value) {
+            continue;
+        }
+        // Synthetic budget-shaped alert is the only one the existing
+        // AlertStore knows how to ingest — non-budget rule firings are
+        // intentionally swallowed in the MVP and tracked as follow-ups.
+        if matches!(rule.metric, RuleMetric::BudgetSpentPct) {
+            let synthetic = BudgetAlert {
+                agent_id: AgentId::from_bytes([0u8; 16]),
+                team_id: None,
+                threshold_pct: rule.threshold.clamp(0.0, 100.0) as u8,
+                spent_usd: value,
+                limit_usd: 100.0,
+            };
+            alerts.record(&synthetic);
+            fired += 1;
+        }
+    }
+    fired
 }
 
 #[cfg(test)]
@@ -90,5 +129,57 @@ mod tests {
     fn evaluate_honors_eq_operator() {
         assert!(evaluate(&rule(RuleOperator::Eq, 50.0), 50.0));
         assert!(!evaluate(&rule(RuleOperator::Eq, 50.0), 49.0));
+    }
+
+    use crate::alerts::rules::store::InMemoryAlertRuleStore;
+    use crate::alerts::store::InMemoryAlertStore;
+
+    struct FixedMetric(f64);
+
+    impl MetricSource for FixedMetric {
+        fn current_value(&self, metric: RuleMetric) -> Option<f64> {
+            if matches!(metric, RuleMetric::BudgetSpentPct) {
+                Some(self.0)
+            } else {
+                None
+            }
+        }
+    }
+
+    #[test]
+    fn evaluate_once_fires_only_when_condition_holds() {
+        let rules = InMemoryAlertRuleStore::new();
+        rules.create(rule(RuleOperator::Gt, 90.0)).expect("create");
+        let alerts = InMemoryAlertStore::new();
+
+        // Below threshold -> no fire
+        let fired = evaluate_once(&rules, &FixedMetric(80.0), &alerts);
+        assert_eq!(fired, 0);
+
+        // Above threshold -> fires once
+        let fired = evaluate_once(&rules, &FixedMetric(95.0), &alerts);
+        assert_eq!(fired, 1);
+    }
+
+    #[test]
+    fn evaluate_once_skips_disabled_rules() {
+        let rules = InMemoryAlertRuleStore::new();
+        let mut disabled = rule(RuleOperator::Gt, 90.0);
+        disabled.enabled = false;
+        rules.create(disabled).expect("create");
+        let alerts = InMemoryAlertStore::new();
+
+        let fired = evaluate_once(&rules, &FixedMetric(95.0), &alerts);
+        assert_eq!(fired, 0);
+    }
+
+    #[test]
+    fn null_metric_source_never_fires() {
+        let rules = InMemoryAlertRuleStore::new();
+        rules.create(rule(RuleOperator::Gt, 90.0)).expect("create");
+        let alerts = InMemoryAlertStore::new();
+
+        let fired = evaluate_once(&rules, &NullMetricSource, &alerts);
+        assert_eq!(fired, 0);
     }
 }

--- a/aa-api/src/alerts/rules/evaluator.rs
+++ b/aa-api/src/alerts/rules/evaluator.rs
@@ -6,8 +6,12 @@
 //! metrics is deferred per the Story AC — those metric variants return
 //! `None` here and are silently skipped by the evaluator.
 
+use std::sync::Arc;
+use std::time::Duration;
+
 use aa_core::AgentId;
 use aa_gateway::budget::types::BudgetAlert;
+use tokio::task::JoinHandle;
 
 use crate::alerts::rules::store::AlertRuleStore;
 use crate::alerts::rules::types::{AlertRule, RuleMetric, RuleOperator};
@@ -25,7 +29,6 @@ pub trait MetricSource: Send + Sync {
 /// `run_server` so the evaluator's plumbing is exercised end-to-end
 /// without claiming MVP scope covers the anomaly/approval-age/violation
 /// hookups (those are explicit follow-ups in the Story AC).
-#[allow(dead_code)]
 pub struct NullMetricSource;
 
 impl MetricSource for NullMetricSource {
@@ -48,7 +51,6 @@ pub fn evaluate(rule: &AlertRule, value: f64) -> bool {
 /// Run one evaluation pass over every enabled rule, recording an alert
 /// into `alerts` when the condition holds. Returns the number of
 /// alerts recorded by this pass.
-#[allow(dead_code)]
 pub fn evaluate_once<S: MetricSource + ?Sized>(
     rules: &dyn AlertRuleStore,
     metrics: &S,
@@ -78,6 +80,31 @@ pub fn evaluate_once<S: MetricSource + ?Sized>(
         }
     }
     fired
+}
+
+/// Spawn the evaluator on a background tokio task. The loop ticks at
+/// `tick_period` (chosen by the caller — production uses 60 seconds;
+/// tests use much shorter) and calls [`evaluate_once`] on every tick.
+///
+/// Cancel the returned [`JoinHandle`] to stop the loop.
+#[allow(dead_code)]
+pub fn spawn_rule_evaluator<S>(
+    rules: Arc<dyn AlertRuleStore>,
+    metrics: Arc<S>,
+    alerts: Arc<dyn AlertStore>,
+    tick_period: Duration,
+) -> JoinHandle<()>
+where
+    S: MetricSource + 'static,
+{
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(tick_period);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            evaluate_once(rules.as_ref(), metrics.as_ref(), alerts.as_ref());
+        }
+    })
 }
 
 #[cfg(test)]

--- a/aa-api/src/alerts/rules/mod.rs
+++ b/aa-api/src/alerts/rules/mod.rs
@@ -6,5 +6,6 @@
 //! viable rule evaluator.
 
 pub mod destinations;
+pub mod evaluator;
 pub mod store;
 pub mod types;

--- a/aa-api/src/server.rs
+++ b/aa-api/src/server.rs
@@ -56,6 +56,17 @@ pub async fn run_server(config: ApiConfig, state: AppState) -> Result<(), Box<dy
         state.alert_store.clone(),
     );
 
+    // Spawn the MVP alert-rule evaluator (AAASM-1386). The NullMetricSource
+    // returns None for every metric, so the loop is a no-op against today's
+    // wiring — production-grade hooks for budget / anomaly / approval-age /
+    // policy-violation metrics are tracked as follow-ups in the Story.
+    let _rule_evaluator_handle = crate::alerts::rules::evaluator::spawn_rule_evaluator(
+        state.alert_rule_store.clone(),
+        std::sync::Arc::new(crate::alerts::rules::evaluator::NullMetricSource),
+        state.alert_store.clone(),
+        std::time::Duration::from_secs(60),
+    );
+
     let app = build_app(state);
 
     let listener = TcpListener::bind(config.bind_addr).await?;


### PR DESCRIPTION
## Description

Seventh sub-task of **AAASM-1386**. Implements the minimum-viable
rule evaluator and wires it into `run_server`.

`evaluator.rs` provides:

- `MetricSource` trait — observation lookup keyed by `RuleMetric`.
- `NullMetricSource` — returns `None` for every metric. This is what
  `run_server` wires up by default; production-grade hooks for the
  budget / anomaly / approval-age / policy-violation metrics are
  explicit follow-ups per the Story AC.
- `evaluate(rule, value)` — operator-honoring (`>`, `>=`, `<`, `=`).
- `evaluate_once(rules, metrics, alerts)` — single pass over the
  enabled rules; records a synthetic `BudgetAlert` into the existing
  `AlertStore` when `budget_spent_pct` fires.
- `spawn_rule_evaluator(rules, metrics, alerts, tick_period)` —
  background task ticking on a fixed interval.

`run_server` spawns the evaluator at a 60-second tick alongside the
existing alert / secret-capture spawn calls.

## Depends on

- **#592 / #601 / #602 / #603 / #604 / #607** (stacked on master).

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: **AAASM-1621** (Sub-task of [AAASM-1386](https://lightning-dust-mite.atlassian.net/browse/AAASM-1386))

## Testing

- [x] 7 unit tests in `aa-api/src/alerts/rules/evaluator.rs::tests`
  (one per operator, fire / no-fire / disabled-rule / null source)
- [x] `cargo nextest run -p aa-api` → all tests passing
- [x] `cargo clippy -p aa-api --all-targets --all-features -- -D warnings` → clean

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Commits follow the Gitmoji convention

[AAASM-1386]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ