### PR TITLE
[AAASM-1622] ✅ (alert-rules): Add integration tests for /api/v1/alerts/rules

### DIFF
--- a/aa-api/tests/alert_rules.rs
+++ b/aa-api/tests/alert_rules.rs
@@ -1,0 +1,63 @@
+//! Integration tests for `/api/v1/alerts/rules` (AAASM-1386).
+
+mod common;
+
+use axum::body::Body;
+use axum::http::Request;
+use serde_json::json;
+
+#[allow(dead_code)]
+fn valid_rule_body() -> serde_json::Value {
+    json!({
+        "name": "Budget > 90%",
+        "description": "Fire CRITICAL when budget spend exceeds 90%",
+        "metric": "budget_spent_pct",
+        "operator": ">",
+        "threshold": 90,
+        "evaluationWindowSeconds": 300,
+        "severity": "CRITICAL",
+        "destinationIds": ["slack-ops"],
+        "dedupWindowSeconds": 600,
+        "enabled": true
+    })
+}
+
+#[allow(dead_code)]
+async fn read_json(response: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+#[allow(dead_code)]
+fn post(uri: &str, body: serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+#[allow(dead_code)]
+fn put(uri: &str, body: serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .method("PUT")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+#[allow(dead_code)]
+fn delete(uri: &str) -> Request<Body> {
+    Request::builder()
+        .method("DELETE")
+        .uri(uri)
+        .body(Body::empty())
+        .unwrap()
+}
+
+#[allow(dead_code)]
+fn get(uri: &str) -> Request<Body> {
+    Request::builder().uri(uri).body(Body::empty()).unwrap()
+}

--- a/aa-api/tests/alert_rules.rs
+++ b/aa-api/tests/alert_rules.rs
@@ -126,3 +126,14 @@ async fn full_crud_round_trip() {
     let problem = read_json(response).await;
     assert_eq!(problem["error_code"], "rule_not_found");
 }
+
+#[tokio::test]
+async fn create_with_unknown_metric_returns_invalid_metric() {
+    let app = common::test_app();
+    let mut body = valid_rule_body();
+    body["metric"] = json!("not_a_real_metric");
+    let response = app.oneshot(post("/api/v1/alerts/rules", body)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let problem = read_json(response).await;
+    assert_eq!(problem["error_code"], "invalid_metric");
+}

--- a/aa-api/tests/alert_rules.rs
+++ b/aa-api/tests/alert_rules.rs
@@ -3,10 +3,10 @@
 mod common;
 
 use axum::body::Body;
-use axum::http::Request;
+use axum::http::{Request, StatusCode};
 use serde_json::json;
+use tower::ServiceExt;
 
-#[allow(dead_code)]
 fn valid_rule_body() -> serde_json::Value {
     json!({
         "name": "Budget > 90%",
@@ -22,13 +22,11 @@ fn valid_rule_body() -> serde_json::Value {
     })
 }
 
-#[allow(dead_code)]
 async fn read_json(response: axum::response::Response) -> serde_json::Value {
     let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
     serde_json::from_slice(&bytes).unwrap()
 }
 
-#[allow(dead_code)]
 fn post(uri: &str, body: serde_json::Value) -> Request<Body> {
     Request::builder()
         .method("POST")
@@ -38,7 +36,6 @@ fn post(uri: &str, body: serde_json::Value) -> Request<Body> {
         .unwrap()
 }
 
-#[allow(dead_code)]
 fn put(uri: &str, body: serde_json::Value) -> Request<Body> {
     Request::builder()
         .method("PUT")
@@ -48,7 +45,6 @@ fn put(uri: &str, body: serde_json::Value) -> Request<Body> {
         .unwrap()
 }
 
-#[allow(dead_code)]
 fn delete(uri: &str) -> Request<Body> {
     Request::builder()
         .method("DELETE")
@@ -57,7 +53,76 @@ fn delete(uri: &str) -> Request<Body> {
         .unwrap()
 }
 
-#[allow(dead_code)]
 fn get(uri: &str) -> Request<Body> {
     Request::builder().uri(uri).body(Body::empty()).unwrap()
+}
+
+#[tokio::test]
+async fn full_crud_round_trip() {
+    let app = common::test_app();
+
+    // POST → 201 + assigned id/timestamps
+    let response = app
+        .clone()
+        .oneshot(post("/api/v1/alerts/rules", valid_rule_body()))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let created = read_json(response).await;
+    let id = created["id"].as_str().expect("id assigned").to_string();
+    assert!(!id.is_empty());
+    assert!(!created["createdAt"].as_str().unwrap().is_empty());
+    let original_created_at = created["createdAt"].as_str().unwrap().to_string();
+
+    // GET list contains the rule (bare array, matching dashboard hooks
+    // from AAASM-1075)
+    let response = app.clone().oneshot(get("/api/v1/alerts/rules")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let list = read_json(response).await;
+    let arr = list.as_array().expect("list response must be a JSON array");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["id"], id);
+
+    // GET by id → 200
+    let response = app
+        .clone()
+        .oneshot(get(&format!("/api/v1/alerts/rules/{id}")))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // PUT → 200 with bumped updatedAt + preserved createdAt
+    // sleep a tick so updatedAt is observably different
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    let mut updated_body = valid_rule_body();
+    updated_body["threshold"] = json!(95);
+    let response = app
+        .clone()
+        .oneshot(put(&format!("/api/v1/alerts/rules/{id}"), updated_body))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let updated = read_json(response).await;
+    assert_eq!(updated["id"], id);
+    assert_eq!(updated["createdAt"], original_created_at);
+    assert_ne!(updated["updatedAt"], original_created_at);
+    assert_eq!(updated["threshold"], 95.0);
+
+    // DELETE → 204
+    let response = app
+        .clone()
+        .oneshot(delete(&format!("/api/v1/alerts/rules/{id}")))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+    // GET after delete → 404
+    let response = app
+        .clone()
+        .oneshot(get(&format!("/api/v1/alerts/rules/{id}")))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let problem = read_json(response).await;
+    assert_eq!(problem["error_code"], "rule_not_found");
 }

--- a/aa-api/tests/alert_rules.rs
+++ b/aa-api/tests/alert_rules.rs
@@ -159,3 +159,12 @@ async fn create_with_unknown_destination_returns_destination_unknown() {
     let problem = read_json(response).await;
     assert_eq!(problem["error_code"], "destination_unknown");
 }
+
+#[tokio::test]
+async fn get_unknown_id_returns_rule_not_found() {
+    let app = common::test_app();
+    let response = app.oneshot(get("/api/v1/alerts/rules/no-such-id")).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let problem = read_json(response).await;
+    assert_eq!(problem["error_code"], "rule_not_found");
+}

--- a/aa-api/tests/alert_rules.rs
+++ b/aa-api/tests/alert_rules.rs
@@ -137,3 +137,14 @@ async fn create_with_unknown_metric_returns_invalid_metric() {
     let problem = read_json(response).await;
     assert_eq!(problem["error_code"], "invalid_metric");
 }
+
+#[tokio::test]
+async fn create_with_out_of_range_threshold_returns_invalid_threshold() {
+    let app = common::test_app();
+    let mut body = valid_rule_body();
+    body["threshold"] = json!(200);
+    let response = app.oneshot(post("/api/v1/alerts/rules", body)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let problem = read_json(response).await;
+    assert_eq!(problem["error_code"], "invalid_threshold");
+}

--- a/aa-api/tests/alert_rules.rs
+++ b/aa-api/tests/alert_rules.rs
@@ -168,3 +168,22 @@ async fn get_unknown_id_returns_rule_not_found() {
     let problem = read_json(response).await;
     assert_eq!(problem["error_code"], "rule_not_found");
 }
+
+#[tokio::test]
+async fn create_with_duplicate_name_returns_rule_name_conflict() {
+    let app = common::test_app();
+    let response = app
+        .clone()
+        .oneshot(post("/api/v1/alerts/rules", valid_rule_body()))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let response = app
+        .oneshot(post("/api/v1/alerts/rules", valid_rule_body()))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let problem = read_json(response).await;
+    assert_eq!(problem["error_code"], "rule_name_conflict");
+}

--- a/aa-api/tests/alert_rules.rs
+++ b/aa-api/tests/alert_rules.rs
@@ -148,3 +148,14 @@ async fn create_with_out_of_range_threshold_returns_invalid_threshold() {
     let problem = read_json(response).await;
     assert_eq!(problem["error_code"], "invalid_threshold");
 }
+
+#[tokio::test]
+async fn create_with_unknown_destination_returns_destination_unknown() {
+    let app = common::test_app();
+    let mut body = valid_rule_body();
+    body["destinationIds"] = json!(["does-not-exist"]);
+    let response = app.oneshot(post("/api/v1/alerts/rules", body)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let problem = read_json(response).await;
+    assert_eq!(problem["error_code"], "destination_unknown");
+}

--- a/aa-api/tests/alert_rules.rs
+++ b/aa-api/tests/alert_rules.rs
@@ -187,3 +187,33 @@ async fn create_with_duplicate_name_returns_rule_name_conflict() {
     let problem = read_json(response).await;
     assert_eq!(problem["error_code"], "rule_name_conflict");
 }
+
+#[tokio::test]
+async fn list_filters_by_enabled_query() {
+    let app = common::test_app();
+
+    let mut a = valid_rule_body();
+    a["name"] = json!("on");
+    app.clone().oneshot(post("/api/v1/alerts/rules", a)).await.unwrap();
+
+    let mut b = valid_rule_body();
+    b["name"] = json!("off");
+    b["enabled"] = json!(false);
+    app.clone().oneshot(post("/api/v1/alerts/rules", b)).await.unwrap();
+
+    let response = app
+        .clone()
+        .oneshot(get("/api/v1/alerts/rules?enabled=true"))
+        .await
+        .unwrap();
+    let list = read_json(response).await;
+    let arr = list.as_array().expect("list response must be a JSON array");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["name"], "on");
+
+    let response = app.oneshot(get("/api/v1/alerts/rules?enabled=false")).await.unwrap();
+    let list = read_json(response).await;
+    let arr = list.as_array().expect("list response must be a JSON array");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["name"], "off");
+}


### PR DESCRIPTION
## Description

Eighth sub-task of **AAASM-1386**. Adds the end-to-end integration tests
under `aa-api/tests/alert_rules.rs` covering the Story AC matrix.

| Behavior | Test |
|---|---|
| POST → GET list → GET id → PUT → DELETE | `full_crud_round_trip` |
| 400 `invalid_metric` | `create_with_unknown_metric_returns_invalid_metric` |
| 400 `invalid_threshold` | `create_with_out_of_range_threshold_returns_invalid_threshold` |
| 400 `destination_unknown` | `create_with_unknown_destination_returns_destination_unknown` |
| 404 `rule_not_found` | `get_unknown_id_returns_rule_not_found` |
| 409 `rule_name_conflict` | `create_with_duplicate_name_returns_rule_name_conflict` |
| `?enabled=true|false` | `list_filters_by_enabled_query` |

`full_crud_round_trip` also asserts the PUT contract — `id` and
`created_at` preserved, `updated_at` bumped — and that GET-after-DELETE
surfaces `rule_not_found`.

## Depends on

- **#592 / #601 / #602 / #603 / #604 / #607 / #608** (stacked on master).

## Type of Change

- [x] ✅ Tests

## Testing

- [x] `cargo nextest run -p aa-api --test alert_rules` → **7 / 7 passed**
- [x] `cargo clippy -p aa-api --all-targets --all-features -- -D warnings` → clean
- [x] `cargo fmt --all -- --check` → clean

## Checklist

- [x] Tests added
- [x] Self-review completed
- [x] Commits follow the Gitmoji convention