### PR TITLE
[AAASM-1645] ✨ (aa-api/alerts): Add Silence types + AlertStore suppress/restore + AlertEvent bus

### DIFF
--- a/aa-api/src/alerts/event.rs
+++ b/aa-api/src/alerts/event.rs
@@ -1,0 +1,24 @@
+//! Lifecycle event published by the `AlertStore` broadcast bus.
+//!
+//! Subscribers (notably the `GET /api/v1/alerts/ws` WebSocket handler
+//! in AAASM-1389) receive these events whenever an alert's state
+//! transitions — fire, resolve, or silence. Each variant carries the
+//! `StoredAlert` snapshot at the moment of the transition.
+
+use super::StoredAlert;
+
+/// A single alert-lifecycle transition.
+#[derive(Debug, Clone)]
+pub enum AlertEvent {
+    /// A new alert was recorded into the store (budget threshold crossed
+    /// or secret-detection finding).
+    Fire(StoredAlert),
+    /// An existing alert was acknowledged via
+    /// `POST /api/v1/alerts/{id}/resolve` and flipped from
+    /// `unresolved` to `resolved`.
+    Resolve(StoredAlert),
+    /// An existing alert was suppressed by a fresh silence applied via
+    /// `POST /api/v1/alerts/silence`. The snapshot's `status` field is
+    /// `"suppressed"`; `prior_status` carries the pre-suppression state.
+    Silence(StoredAlert),
+}

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -15,6 +15,7 @@ pub use event::AlertEvent;
 use aa_gateway::alerts::SecretAlert;
 use aa_gateway::budget::types::BudgetAlert;
 use serde::Serialize;
+use tokio::sync::broadcast;
 
 use crate::alerts::detail::RuleContext;
 
@@ -244,4 +245,11 @@ pub trait AlertStore: Send + Sync {
     /// record and does not bump `updated_at`. `_reason` is accepted for
     /// API parity but the in-memory store does not persist it.
     fn resolve(&self, id: &str, _reason: Option<&str>) -> Option<StoredAlert>;
+
+    /// Subscribe to the lifecycle event bus. Each mutation
+    /// (`record`/`record_secret` → `Fire`, `resolve` → `Resolve`,
+    /// `suppress` → `Silence`) publishes one [`AlertEvent`] carrying
+    /// a snapshot of the post-mutation alert. Implementations that
+    /// don't emit events should still return a live receiver.
+    fn subscribe(&self) -> broadcast::Receiver<AlertEvent>;
 }

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -252,4 +252,19 @@ pub trait AlertStore: Send + Sync {
     /// a snapshot of the post-mutation alert. Implementations that
     /// don't emit events should still return a live receiver.
     fn subscribe(&self) -> broadcast::Receiver<AlertEvent>;
+
+    /// Suppress an alert — flip its status to `"suppressed"` and capture
+    /// the prior status in `prior_status` so the silence-expiry watcher
+    /// can restore it later.
+    ///
+    /// Returns the post-mutation record on success, or `None` when:
+    /// * the ID is unknown or evicted from the ring buffer, **or**
+    /// * the alert is already `"suppressed"` (defensive — the route
+    ///   handler is expected to catch double-suppression at the
+    ///   `SilenceStore` layer and return 409 `alert_already_silenced`
+    ///   before reaching this method).
+    ///
+    /// On success an `AlertEvent::Silence(snapshot)` is published on the
+    /// bus.
+    fn suppress(&self, id: &str) -> Option<StoredAlert>;
 }

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -267,4 +267,18 @@ pub trait AlertStore: Send + Sync {
     /// On success an `AlertEvent::Silence(snapshot)` is published on the
     /// bus.
     fn suppress(&self, id: &str) -> Option<StoredAlert>;
+
+    /// Restore a previously-suppressed alert to its `prior_status`.
+    /// Called by the silence-expiry watcher (AAASM-1646) when a silence
+    /// window ends, or by an explicit DELETE silence path.
+    ///
+    /// Returns the post-mutation record on success, or `None` when:
+    /// * the ID is unknown or evicted, **or**
+    /// * the alert is not currently `"suppressed"` (nothing to restore).
+    ///
+    /// If `prior_status` is missing (shouldn't happen, but defensive),
+    /// the alert is restored to `"unresolved"`. The expiry watcher
+    /// composes the appropriate bus event itself based on the restored
+    /// status; this method publishes no event.
+    fn restore(&self, id: &str) -> Option<StoredAlert>;
 }

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -42,8 +42,16 @@ pub struct StoredAlert {
     /// Configured daily limit in USD.
     pub limit_usd: f64,
     /// Lifecycle status — `"unresolved"` on capture, flipped to
-    /// `"resolved"` once `AlertStore::resolve` is called.
+    /// `"resolved"` once `AlertStore::resolve` is called, or
+    /// `"suppressed"` while an active silence covers the alert
+    /// (AAASM-1645).
     pub status: String,
+    /// Status the alert held immediately before being suppressed
+    /// (AAASM-1645). Populated only while `status == "suppressed"`;
+    /// the expiry watcher reads it to know whether to restore the
+    /// alert to `"unresolved"` or `"resolved"`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prior_status: Option<String>,
     /// ISO 8601 timestamp of the last mutation (e.g. resolve). `None`
     /// while the alert is still in its initial captured state.
     pub updated_at: Option<String>,
@@ -172,6 +180,7 @@ pub fn stored_secret_alert_from(alert: &SecretAlert, id: String, timestamp: Stri
         spent_usd: 0.0,
         limit_usd: 0.0,
         status: "unresolved".to_string(),
+        prior_status: None,
         updated_at: None,
         detected_pattern_type: Some(kind.as_str().to_string()),
         redacted_value: Some(alert.redacted_label()),
@@ -195,6 +204,7 @@ pub fn stored_alert_from(alert: &BudgetAlert, id: String, timestamp: String) -> 
         spent_usd: alert.spent_usd,
         limit_usd: alert.limit_usd,
         status: "unresolved".to_string(),
+        prior_status: None,
         updated_at: None,
         detected_pattern_type: None,
         redacted_value: None,

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -6,8 +6,11 @@
 
 pub mod capture;
 pub mod detail;
+pub mod event;
 pub mod silence;
 pub mod store;
+
+pub use event::AlertEvent;
 
 use aa_gateway::alerts::SecretAlert;
 use aa_gateway::budget::types::BudgetAlert;

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod capture;
 pub mod detail;
+pub mod silence;
 pub mod store;
 
 use aa_gateway::alerts::SecretAlert;

--- a/aa-api/src/alerts/silence.rs
+++ b/aa-api/src/alerts/silence.rs
@@ -1,0 +1,104 @@
+//! Silence record domain type for the `POST /api/v1/alerts/silence` endpoint.
+//!
+//! `SilenceRecord` is the in-memory representation kept by `SilenceStore`
+//! and returned in the 201 response body. The slimmer
+//! [`super::detail::Silence`] embedded view (id + expires_at + reason)
+//! is projected from this record when an alert detail payload includes
+//! its active silence.
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use super::detail;
+
+/// Full silence record kept in `SilenceStore` and returned by
+/// `POST /api/v1/alerts/silence`.
+///
+/// The struct is exposed via `utoipa::ToSchema` so the OpenAPI spec can
+/// reference it as the 201 response body for the silence endpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct SilenceRecord {
+    /// ULID identifier of the silence record itself (26 chars).
+    pub id: String,
+    /// ULID of the alert this silence is attached to.
+    pub alert_id: String,
+    /// ISO 8601 timestamp at which the silence took effect (typically
+    /// when the operator submitted the request).
+    pub starts_at: String,
+    /// ISO 8601 timestamp at which the silence expires. After this,
+    /// the alert is restored to its prior status by the expiry watcher.
+    pub expires_at: String,
+    /// Optional free-text reason captured at silence creation time
+    /// (max 500 chars enforced by the route handler).
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub reason: Option<String>,
+    /// Stable identifier of the principal that created the silence —
+    /// resolved from the API key / JWT auth context by the handler.
+    pub created_by: String,
+}
+
+impl From<&SilenceRecord> for detail::Silence {
+    /// Project a full silence record into the slim embedded view used by
+    /// `RuleContext.silence` in `GET /api/v1/alerts/{id}`.
+    fn from(record: &SilenceRecord) -> Self {
+        detail::Silence {
+            id: record.id.clone(),
+            expires_at: record.expires_at.clone(),
+            reason: record.reason.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_record() -> SilenceRecord {
+        SilenceRecord {
+            id: "01KS1HQA40000000000000ABCD".to_string(),
+            alert_id: "01KS1HQA00000000000000ZZZZ".to_string(),
+            starts_at: "2026-05-20T09:30:00Z".to_string(),
+            expires_at: "2026-05-20T10:30:00Z".to_string(),
+            reason: Some("Known maintenance window".to_string()),
+            created_by: "user_abc123".to_string(),
+        }
+    }
+
+    #[test]
+    fn serializes_all_fields_when_reason_present() {
+        let json = serde_json::to_string(&sample_record()).unwrap();
+        assert!(json.contains("\"id\":\"01KS1HQA40000000000000ABCD\""));
+        assert!(json.contains("\"alert_id\":\"01KS1HQA00000000000000ZZZZ\""));
+        assert!(json.contains("\"starts_at\":\"2026-05-20T09:30:00Z\""));
+        assert!(json.contains("\"expires_at\":\"2026-05-20T10:30:00Z\""));
+        assert!(json.contains("\"reason\":\"Known maintenance window\""));
+        assert!(json.contains("\"created_by\":\"user_abc123\""));
+    }
+
+    #[test]
+    fn omits_reason_when_none() {
+        let record = SilenceRecord {
+            reason: None,
+            ..sample_record()
+        };
+        let json = serde_json::to_string(&record).unwrap();
+        assert!(!json.contains("\"reason\""), "reason must be omitted when None");
+    }
+
+    #[test]
+    fn round_trips_through_serde() {
+        let record = sample_record();
+        let json = serde_json::to_string(&record).unwrap();
+        let parsed: SilenceRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, record);
+    }
+
+    #[test]
+    fn projects_to_detail_silence_view() {
+        let record = sample_record();
+        let view: detail::Silence = (&record).into();
+        assert_eq!(view.id, record.id);
+        assert_eq!(view.expires_at, record.expires_at);
+        assert_eq!(view.reason, record.reason);
+    }
+}

--- a/aa-api/src/alerts/store.rs
+++ b/aa-api/src/alerts/store.rs
@@ -141,6 +141,23 @@ impl AlertStore for InMemoryAlertStore {
     fn subscribe(&self) -> broadcast::Receiver<AlertEvent> {
         self.event_tx.subscribe()
     }
+
+    fn suppress(&self, id: &str) -> Option<StoredAlert> {
+        let snapshot = {
+            let mut buf = self.alerts.write().expect("alert store lock poisoned");
+            let alert = buf.iter_mut().find(|a| a.id == id)?;
+            if alert.status == "suppressed" {
+                // Defensive: refuse to overwrite an existing prior_status.
+                return None;
+            }
+            alert.prior_status = Some(alert.status.clone());
+            alert.status = "suppressed".to_string();
+            alert.updated_at = Some(chrono::Utc::now().to_rfc3339());
+            alert.clone()
+        };
+        let _ = self.event_tx.send(AlertEvent::Silence(snapshot.clone()));
+        Some(snapshot)
+    }
 }
 
 #[cfg(test)]

--- a/aa-api/src/alerts/store.rs
+++ b/aa-api/src/alerts/store.rs
@@ -414,4 +414,131 @@ mod tests {
         assert_ne!(budget_id, secret_id);
         assert!(budget_id < secret_id, "ULIDs sort by timestamp");
     }
+
+    // ─── AlertEvent bus (AAASM-1645) ─────────────────────────────────────────
+
+    #[tokio::test]
+    async fn subscribe_receives_fire_on_record() {
+        let store = InMemoryAlertStore::new();
+        let mut rx = store.subscribe();
+        let id = store.record(&test_alert(80));
+        match rx.recv().await.expect("event must arrive") {
+            AlertEvent::Fire(stored) => assert_eq!(stored.id, id),
+            other => panic!("expected Fire, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn subscribe_receives_resolve_only_on_state_change() {
+        let store = InMemoryAlertStore::new();
+        let id = store.record(&test_alert(80));
+        let mut rx = store.subscribe();
+        store.resolve(&id, None).unwrap();
+        match rx.recv().await.expect("first resolve emits") {
+            AlertEvent::Resolve(stored) => assert_eq!(stored.status, "resolved"),
+            other => panic!("expected Resolve, got {other:?}"),
+        }
+        // Second (idempotent) resolve must not emit a second event.
+        store.resolve(&id, None).unwrap();
+        let res = tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await;
+        assert!(res.is_err(), "no event should arrive on idempotent re-resolve");
+    }
+
+    // ─── suppress / restore (AAASM-1645) ─────────────────────────────────────
+
+    #[test]
+    fn suppress_flips_status_and_saves_prior_status() {
+        let store = InMemoryAlertStore::new();
+        let id = store.record(&test_alert(80));
+
+        let suppressed = store.suppress(&id).expect("suppress must succeed");
+        assert_eq!(suppressed.status, "suppressed");
+        assert_eq!(suppressed.prior_status.as_deref(), Some("unresolved"));
+        assert!(suppressed.updated_at.is_some());
+
+        let from_store = store.get(&id).unwrap();
+        assert_eq!(from_store.status, "suppressed");
+        assert_eq!(from_store.prior_status.as_deref(), Some("unresolved"));
+    }
+
+    #[test]
+    fn suppress_preserves_resolved_as_prior_status() {
+        let store = InMemoryAlertStore::new();
+        let id = store.record(&test_alert(95));
+        store.resolve(&id, None).unwrap();
+
+        let suppressed = store.suppress(&id).expect("suppress must succeed");
+        assert_eq!(suppressed.status, "suppressed");
+        assert_eq!(suppressed.prior_status.as_deref(), Some("resolved"));
+    }
+
+    #[test]
+    fn suppress_returns_none_for_unknown_id() {
+        let store = InMemoryAlertStore::new();
+        store.record(&test_alert(80));
+        assert!(store.suppress("00000000000000000000000000").is_none());
+    }
+
+    #[test]
+    fn suppress_returns_none_when_already_suppressed() {
+        let store = InMemoryAlertStore::new();
+        let id = store.record(&test_alert(80));
+        store.suppress(&id).expect("first suppress succeeds");
+
+        // Second suppress must refuse so prior_status isn't overwritten.
+        assert!(store.suppress(&id).is_none(), "double-suppress must return None");
+    }
+
+    #[tokio::test]
+    async fn suppress_publishes_silence_event() {
+        let store = InMemoryAlertStore::new();
+        let id = store.record(&test_alert(95));
+        let mut rx = store.subscribe();
+        store.suppress(&id).unwrap();
+        match rx.recv().await.expect("silence event must arrive") {
+            AlertEvent::Silence(stored) => {
+                assert_eq!(stored.id, id);
+                assert_eq!(stored.status, "suppressed");
+                assert_eq!(stored.prior_status.as_deref(), Some("unresolved"));
+            }
+            other => panic!("expected Silence, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn restore_returns_alert_to_prior_status() {
+        let store = InMemoryAlertStore::new();
+        let id = store.record(&test_alert(80));
+        store.suppress(&id).unwrap();
+
+        let restored = store.restore(&id).expect("restore must succeed");
+        assert_eq!(restored.status, "unresolved");
+        assert!(restored.prior_status.is_none(), "prior_status must be cleared");
+    }
+
+    #[test]
+    fn restore_returns_to_resolved_when_that_was_prior_status() {
+        let store = InMemoryAlertStore::new();
+        let id = store.record(&test_alert(95));
+        store.resolve(&id, None).unwrap();
+        store.suppress(&id).unwrap();
+
+        let restored = store.restore(&id).unwrap();
+        assert_eq!(restored.status, "resolved");
+        assert!(restored.prior_status.is_none());
+    }
+
+    #[test]
+    fn restore_returns_none_when_not_suppressed() {
+        let store = InMemoryAlertStore::new();
+        let id = store.record(&test_alert(80));
+        // Alert is "unresolved", not "suppressed" — restore must refuse.
+        assert!(store.restore(&id).is_none());
+    }
+
+    #[test]
+    fn restore_returns_none_for_unknown_id() {
+        let store = InMemoryAlertStore::new();
+        assert!(store.restore("00000000000000000000000000").is_none());
+    }
 }

--- a/aa-api/src/alerts/store.rs
+++ b/aa-api/src/alerts/store.rs
@@ -158,6 +158,18 @@ impl AlertStore for InMemoryAlertStore {
         let _ = self.event_tx.send(AlertEvent::Silence(snapshot.clone()));
         Some(snapshot)
     }
+
+    fn restore(&self, id: &str) -> Option<StoredAlert> {
+        let mut buf = self.alerts.write().expect("alert store lock poisoned");
+        let alert = buf.iter_mut().find(|a| a.id == id)?;
+        if alert.status != "suppressed" {
+            return None; // not currently under a silence
+        }
+        let prior = alert.prior_status.take().unwrap_or_else(|| "unresolved".to_string());
+        alert.status = prior;
+        alert.updated_at = Some(chrono::Utc::now().to_rfc3339());
+        Some(alert.clone())
+    }
 }
 
 #[cfg(test)]

--- a/aa-api/src/alerts/store.rs
+++ b/aa-api/src/alerts/store.rs
@@ -5,9 +5,16 @@ use std::sync::{Mutex, RwLock};
 
 use aa_gateway::alerts::SecretAlert;
 use aa_gateway::budget::types::BudgetAlert;
+use tokio::sync::broadcast;
 use ulid::Generator;
 
-use super::{stored_alert_from, stored_secret_alert_from, AlertStore, StoredAlert};
+use super::{stored_alert_from, stored_secret_alert_from, AlertEvent, AlertStore, StoredAlert};
+
+/// Capacity of the per-store `tokio::broadcast` channel used for the
+/// `AlertEvent` lifecycle bus. Subscribers that lag past this many
+/// pending events get a `RecvError::Lagged` and must reconcile state
+/// from the store directly.
+const EVENT_CHANNEL_CAPACITY: usize = 256;
 
 /// Default maximum number of alerts retained in the ring buffer.
 const DEFAULT_CAPACITY: usize = 10_000;
@@ -23,6 +30,10 @@ pub struct InMemoryAlertStore {
     /// the random portion within a single millisecond so IDs sort by
     /// insertion order even at sub-millisecond record rates.
     id_gen: Mutex<Generator>,
+    /// Lifecycle event sender. Retained on `self` so the bus stays open
+    /// even when no subscriber is currently attached — late subscribers
+    /// receive events from the moment of their `subscribe()` call.
+    event_tx: broadcast::Sender<AlertEvent>,
 }
 
 impl InMemoryAlertStore {
@@ -33,10 +44,12 @@ impl InMemoryAlertStore {
 
     /// Create a new store with the given maximum capacity.
     pub fn with_capacity(capacity: usize) -> Self {
+        let (event_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
         Self {
             alerts: RwLock::new(VecDeque::with_capacity(capacity.min(DEFAULT_CAPACITY))),
             capacity,
             id_gen: Mutex::new(Generator::new()),
+            event_tx,
         }
     }
 
@@ -62,11 +75,15 @@ impl AlertStore for InMemoryAlertStore {
         let timestamp = chrono::Utc::now().to_rfc3339();
         let stored = stored_alert_from(alert, id.clone(), timestamp);
 
-        let mut buf = self.alerts.write().expect("alert store lock poisoned");
-        if buf.len() >= self.capacity {
-            buf.pop_front();
+        {
+            let mut buf = self.alerts.write().expect("alert store lock poisoned");
+            if buf.len() >= self.capacity {
+                buf.pop_front();
+            }
+            buf.push_back(stored.clone());
         }
-        buf.push_back(stored);
+        // Best-effort publish; ignore `SendError` when no subscriber is attached.
+        let _ = self.event_tx.send(AlertEvent::Fire(stored));
         id
     }
 
@@ -75,11 +92,14 @@ impl AlertStore for InMemoryAlertStore {
         let timestamp = chrono::Utc::now().to_rfc3339();
         let stored = stored_secret_alert_from(alert, id.clone(), timestamp);
 
-        let mut buf = self.alerts.write().expect("alert store lock poisoned");
-        if buf.len() >= self.capacity {
-            buf.pop_front();
+        {
+            let mut buf = self.alerts.write().expect("alert store lock poisoned");
+            if buf.len() >= self.capacity {
+                buf.pop_front();
+            }
+            buf.push_back(stored.clone());
         }
-        buf.push_back(stored);
+        let _ = self.event_tx.send(AlertEvent::Fire(stored));
         id
     }
 
@@ -99,16 +119,27 @@ impl AlertStore for InMemoryAlertStore {
     }
 
     fn resolve(&self, id: &str, _reason: Option<&str>) -> Option<StoredAlert> {
-        let mut buf = self.alerts.write().expect("alert store lock poisoned");
-        let alert = buf.iter_mut().find(|a| a.id == id)?;
-        // Idempotent: don't bump timestamps on subsequent resolves.
-        if alert.status != "resolved" {
-            let now = chrono::Utc::now().to_rfc3339();
-            alert.status = "resolved".to_string();
-            alert.updated_at = Some(now.clone());
-            alert.resolved_at = Some(now);
+        let (snapshot, was_mutation) = {
+            let mut buf = self.alerts.write().expect("alert store lock poisoned");
+            let alert = buf.iter_mut().find(|a| a.id == id)?;
+            // Idempotent: don't bump timestamps on subsequent resolves.
+            let mutated = alert.status != "resolved";
+            if mutated {
+                let now = chrono::Utc::now().to_rfc3339();
+                alert.status = "resolved".to_string();
+                alert.updated_at = Some(now.clone());
+                alert.resolved_at = Some(now);
+            }
+            (alert.clone(), mutated)
+        };
+        if was_mutation {
+            let _ = self.event_tx.send(AlertEvent::Resolve(snapshot.clone()));
         }
-        Some(alert.clone())
+        Some(snapshot)
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<AlertEvent> {
+        self.event_tx.subscribe()
     }
 }
 


### PR DESCRIPTION
## Description

Subtask 2 of AAASM-1387 (POST /alerts/silence). Lays down the domain types and `AlertStore` mutations the upcoming `SilenceStore` and route handler will depend on.

- New `SilenceRecord` struct (full POST response shape: id, alert_id, starts_at, expires_at, reason, created_by) in `aa-api/src/alerts/silence.rs`; projects to the existing slim `detail::Silence` view.
- New `AlertEvent { Fire, Resolve, Silence }` enum in `aa-api/src/alerts/event.rs`.
- `AlertStore::subscribe()` returns a `tokio::broadcast::Receiver<AlertEvent>`; `InMemoryAlertStore` carries the sender. `record`/`record_secret` → `Fire`; `resolve` → `Resolve` (only on actual state change).
- `AlertStore::suppress(id)` — flips status to `"suppressed"`, captures prior status, emits `Silence`. Defensive `None` on double-suppress.
- `AlertStore::restore(id)` — reverts to `prior_status`, clears it. No event from this method (the upcoming silence-expiry watcher composes its own event).
- `StoredAlert.prior_status: Option<String>` field added (skipped in JSON when None).

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [ ] No
- [x] Yes (additive) — `AlertStore` trait gains three new methods (`subscribe`, `suppress`, `restore`). Any external impls of `AlertStore` (there are none in this repo) would need to add them.

## Related Issues

- Related Jira ticket: [AAASM-1645](https://lightning-dust-mite.atlassian.net/browse/AAASM-1645) (sub-task of [AAASM-1387](https://lightning-dust-mite.atlassian.net/browse/AAASM-1387))

## Testing

- [x] Unit tests added / updated — `aa-api/src/alerts/store.rs` gains 11 new tests for suppress/restore/bus; `aa-api/src/alerts/silence.rs` ships 4 tests for SilenceRecord serde + projection
- [x] No integration tests added (no public-facing endpoint yet — route handler ships in AAASM-1648)
- [x] `cargo nextest run -p aa-api` — 373/373 passed locally (12 new vs prior baseline)

## Commits (granular, 7)

1. `✨ (aa-api/alerts): Add SilenceRecord domain type`
2. `✨ (aa-api/alerts): Add prior_status field to StoredAlert`
3. `✨ (aa-api/alerts): Add AlertEvent enum for lifecycle bus`
4. `✨ (aa-api/alerts): Add AlertStore subscribe() + Fire/Resolve emission`
5. `✨ (aa-api/alerts): Add AlertStore::suppress with prior_status tracking`
6. `✨ (aa-api/alerts): Add AlertStore::restore to revert suppression`
7. `✅ (aa-api/alerts): Unit tests for suppress/restore + bus delivery`

## Coordination

PR #591 (AAASM-1389 WS Story, currently DIRTY) drafted its own `AlertEvent` enum in `aa-api/src/alerts/event.rs`. After this lands, that PR needs a rebase to drop the duplicate and consume this canonical bus.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --workspace --all-targets`)
- [x] Self-review of the diff completed
- [x] Documentation updated (struct/method docstrings)
- [x] All CI checks passing locally
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1645]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ