### PR TITLE
[AAASM-1646] ✨ (aa-api/alerts): Add SilenceStore + expiry watcher

### DIFF
--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -9,6 +9,7 @@ pub mod detail;
 pub mod event;
 pub mod silence;
 pub mod silence_store;
+pub mod silence_watcher;
 pub mod store;
 
 pub use event::AlertEvent;

--- a/aa-api/src/alerts/mod.rs
+++ b/aa-api/src/alerts/mod.rs
@@ -8,6 +8,7 @@ pub mod capture;
 pub mod detail;
 pub mod event;
 pub mod silence;
+pub mod silence_store;
 pub mod store;
 
 pub use event::AlertEvent;

--- a/aa-api/src/alerts/silence_store.rs
+++ b/aa-api/src/alerts/silence_store.rs
@@ -1,0 +1,190 @@
+//! In-memory store for `SilenceRecord`s and trait abstraction.
+//!
+//! The store is populated by `POST /api/v1/alerts/silence` and drained
+//! by the silence-expiry watcher (see `silence_watcher`). It holds the
+//! authoritative answer to "is this alert currently silenced?" — the
+//! route handler must consult `get_active_for_alert` before suppressing
+//! to honour the 409 `alert_already_silenced` contract.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use chrono::{DateTime, Utc};
+
+use super::silence::SilenceRecord;
+
+/// Trait for storing and querying silence records.
+///
+/// Implementations must be thread-safe (`Send + Sync`).
+pub trait SilenceStore: Send + Sync {
+    /// Insert a fresh silence record. The caller has already enforced
+    /// the 409 `alert_already_silenced` contract via
+    /// `get_active_for_alert`; this method just stores the record.
+    fn insert(&self, record: SilenceRecord);
+
+    /// Return the active silence for an alert, if any. "Active" means a
+    /// record exists *and* its `expires_at` is in the future.
+    /// `now` is passed in so tests can advance time deterministically.
+    fn get_active_for_alert(&self, alert_id: &str, now: DateTime<Utc>) -> Option<SilenceRecord>;
+
+    /// Drain and return all silence records whose `expires_at` is at or
+    /// before `now`. Called by the expiry watcher every tick — the
+    /// implementation **must** remove the returned records so a second
+    /// call with the same `now` returns an empty vec.
+    fn expire_due(&self, now: DateTime<Utc>) -> Vec<SilenceRecord>;
+}
+
+/// Hash-map backed in-memory `SilenceStore`. Keys are silence IDs;
+/// secondary lookup by `alert_id` is a linear scan over the map values,
+/// which is fine at the scale of an in-memory alert store (≤10k alerts,
+/// each with at most one active silence).
+pub struct InMemorySilenceStore {
+    records: RwLock<HashMap<String, SilenceRecord>>,
+}
+
+impl InMemorySilenceStore {
+    pub fn new() -> Self {
+        Self {
+            records: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl Default for InMemorySilenceStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SilenceStore for InMemorySilenceStore {
+    fn insert(&self, record: SilenceRecord) {
+        let mut map = self.records.write().expect("silence store lock poisoned");
+        map.insert(record.id.clone(), record);
+    }
+
+    fn get_active_for_alert(&self, alert_id: &str, now: DateTime<Utc>) -> Option<SilenceRecord> {
+        let map = self.records.read().expect("silence store lock poisoned");
+        map.values()
+            .find(|r| r.alert_id == alert_id && expires_at_after(&r.expires_at, now))
+            .cloned()
+    }
+
+    fn expire_due(&self, now: DateTime<Utc>) -> Vec<SilenceRecord> {
+        let mut map = self.records.write().expect("silence store lock poisoned");
+        let expired_ids: Vec<String> = map
+            .iter()
+            .filter(|(_, r)| !expires_at_after(&r.expires_at, now))
+            .map(|(id, _)| id.clone())
+            .collect();
+        expired_ids.into_iter().filter_map(|id| map.remove(&id)).collect()
+    }
+}
+
+/// Parse an ISO 8601 `expires_at` string and report whether the silence
+/// is still in effect at `now`. A malformed or unparseable timestamp is
+/// treated as **expired** so a broken record can't pin an alert in the
+/// `"suppressed"` state forever.
+fn expires_at_after(expires_at: &str, now: DateTime<Utc>) -> bool {
+    DateTime::parse_from_rfc3339(expires_at)
+        .map(|t| t.with_timezone(&Utc) > now)
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample(silence_id: &str, alert_id: &str, expires_at: &str) -> SilenceRecord {
+        SilenceRecord {
+            id: silence_id.to_string(),
+            alert_id: alert_id.to_string(),
+            starts_at: "2026-05-20T09:00:00Z".to_string(),
+            expires_at: expires_at.to_string(),
+            reason: None,
+            created_by: "user_test".to_string(),
+        }
+    }
+
+    fn at(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    #[test]
+    fn insert_then_get_active_returns_record() {
+        let store = InMemorySilenceStore::new();
+        store.insert(sample("sil-1", "alert-1", "2026-05-20T10:00:00Z"));
+        let now = at("2026-05-20T09:30:00Z");
+        let found = store.get_active_for_alert("alert-1", now).expect("active silence");
+        assert_eq!(found.id, "sil-1");
+    }
+
+    #[test]
+    fn get_active_returns_none_when_expired() {
+        let store = InMemorySilenceStore::new();
+        store.insert(sample("sil-1", "alert-1", "2026-05-20T09:00:00Z"));
+        let now = at("2026-05-20T09:30:00Z"); // 30 min after expiry
+        assert!(store.get_active_for_alert("alert-1", now).is_none());
+    }
+
+    #[test]
+    fn get_active_returns_none_for_unknown_alert() {
+        let store = InMemorySilenceStore::new();
+        store.insert(sample("sil-1", "alert-1", "2026-05-20T10:00:00Z"));
+        let now = at("2026-05-20T09:30:00Z");
+        assert!(store.get_active_for_alert("alert-other", now).is_none());
+    }
+
+    #[test]
+    fn get_active_picks_the_record_for_the_given_alert() {
+        let store = InMemorySilenceStore::new();
+        store.insert(sample("sil-1", "alert-1", "2026-05-20T10:00:00Z"));
+        store.insert(sample("sil-2", "alert-2", "2026-05-20T10:00:00Z"));
+        let now = at("2026-05-20T09:30:00Z");
+
+        let one = store.get_active_for_alert("alert-1", now).unwrap();
+        let two = store.get_active_for_alert("alert-2", now).unwrap();
+        assert_eq!(one.id, "sil-1");
+        assert_eq!(two.id, "sil-2");
+    }
+
+    #[test]
+    fn expire_due_removes_and_returns_past_records() {
+        let store = InMemorySilenceStore::new();
+        store.insert(sample("sil-old", "alert-1", "2026-05-20T09:00:00Z"));
+        store.insert(sample("sil-new", "alert-2", "2026-05-20T11:00:00Z"));
+        let now = at("2026-05-20T09:30:00Z");
+
+        let expired = store.expire_due(now);
+        assert_eq!(expired.len(), 1);
+        assert_eq!(expired[0].id, "sil-old");
+
+        // Active record is still there.
+        assert!(store.get_active_for_alert("alert-2", now).is_some());
+        // Expired record is gone — second call yields empty.
+        assert!(store.expire_due(now).is_empty());
+    }
+
+    #[test]
+    fn expire_due_treats_unparseable_expires_at_as_expired() {
+        let store = InMemorySilenceStore::new();
+        store.insert(sample("sil-bad", "alert-1", "not-a-timestamp"));
+        let now = at("2026-05-20T09:30:00Z");
+
+        let expired = store.expire_due(now);
+        assert_eq!(expired.len(), 1, "malformed timestamps must not pin alerts forever");
+        assert_eq!(expired[0].id, "sil-bad");
+    }
+
+    #[test]
+    fn expire_due_treats_exact_now_as_expired() {
+        // Cleanup is inclusive on the boundary — `expires_at == now` is
+        // treated as already over (the silence covered up to but not
+        // including this instant).
+        let store = InMemorySilenceStore::new();
+        store.insert(sample("sil-edge", "alert-1", "2026-05-20T09:30:00Z"));
+        let now = at("2026-05-20T09:30:00Z");
+
+        let expired = store.expire_due(now);
+        assert_eq!(expired.len(), 1);
+    }
+}

--- a/aa-api/src/alerts/silence_watcher.rs
+++ b/aa-api/src/alerts/silence_watcher.rs
@@ -1,0 +1,149 @@
+//! Background task that restores alerts when their silence expires.
+//!
+//! Runs every [`TICK_INTERVAL`] and drains expired records from the
+//! [`SilenceStore`](super::silence_store::SilenceStore), calling
+//! [`AlertStore::restore`](super::AlertStore::restore) on each so the
+//! alert returns to its pre-suppression status.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+
+use super::silence_store::SilenceStore;
+use super::AlertStore;
+
+/// Cadence of the expiry watcher. Trades off restoration latency
+/// against background-task CPU cost. 1 s is fine for human-scale
+/// silences (5 m / 1 h / 4 h / 24 h per the AAASM-1387 spec).
+pub const TICK_INTERVAL: Duration = Duration::from_secs(1);
+
+/// One pass of the expiry loop — drains all silences expired at `now`
+/// and restores the underlying alerts. Pure function (modulo store
+/// mutations) so tests can drive it without sleeping.
+///
+/// Returns the number of silences expired this tick.
+pub fn tick<S, A>(silence_store: &S, alert_store: &A, now: chrono::DateTime<Utc>) -> usize
+where
+    S: SilenceStore + ?Sized,
+    A: AlertStore + ?Sized,
+{
+    let expired = silence_store.expire_due(now);
+    let count = expired.len();
+    for record in expired {
+        // Best-effort: a silence whose alert was evicted from the ring
+        // buffer simply restores nothing — that's not an error.
+        let _ = alert_store.restore(&record.alert_id);
+    }
+    count
+}
+
+/// Spawn the expiry watcher as a tokio task.
+///
+/// The task runs until either store handle is dropped from every
+/// non-task owner (the watcher itself holds one each, so practically
+/// "until shutdown"). It uses [`tokio::time::sleep`] between ticks so
+/// the runtime can park it cleanly.
+pub fn spawn_silence_expiry_watcher(
+    silence_store: Arc<dyn SilenceStore>,
+    alert_store: Arc<dyn AlertStore>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(TICK_INTERVAL).await;
+            tick(silence_store.as_ref(), alert_store.as_ref(), Utc::now());
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use aa_core::AgentId;
+    use aa_gateway::budget::types::BudgetAlert;
+    use chrono::{Duration as ChronoDuration, Utc};
+
+    use super::*;
+    use crate::alerts::silence::SilenceRecord;
+    use crate::alerts::silence_store::InMemorySilenceStore;
+    use crate::alerts::store::InMemoryAlertStore;
+
+    fn budget_alert() -> BudgetAlert {
+        BudgetAlert {
+            agent_id: AgentId::from_bytes([0xAA; 16]),
+            team_id: None,
+            threshold_pct: 80,
+            spent_usd: 8.0,
+            limit_usd: 10.0,
+        }
+    }
+
+    #[tokio::test]
+    async fn tick_restores_alert_when_silence_expires() {
+        let alert_store = InMemoryAlertStore::new();
+        let silence_store = InMemorySilenceStore::new();
+        let alert_id = alert_store.record(&budget_alert());
+        alert_store.suppress(&alert_id).unwrap();
+
+        let expires_at = Utc::now() - ChronoDuration::seconds(1); // already expired
+        silence_store.insert(SilenceRecord {
+            id: "sil-1".to_string(),
+            alert_id: alert_id.clone(),
+            starts_at: Utc::now().to_rfc3339(),
+            expires_at: expires_at.to_rfc3339(),
+            reason: None,
+            created_by: "user_test".to_string(),
+        });
+
+        let expired = tick(&silence_store, &alert_store, Utc::now());
+        assert_eq!(expired, 1);
+
+        let restored = alert_store.get(&alert_id).unwrap();
+        assert_eq!(restored.status, "unresolved", "alert must be restored");
+        assert!(restored.prior_status.is_none(), "prior_status must be cleared");
+    }
+
+    #[tokio::test]
+    async fn tick_does_nothing_when_no_silence_is_due() {
+        let alert_store = InMemoryAlertStore::new();
+        let silence_store = InMemorySilenceStore::new();
+        let alert_id = alert_store.record(&budget_alert());
+        alert_store.suppress(&alert_id).unwrap();
+
+        let future = Utc::now() + ChronoDuration::hours(1);
+        silence_store.insert(SilenceRecord {
+            id: "sil-1".to_string(),
+            alert_id: alert_id.clone(),
+            starts_at: Utc::now().to_rfc3339(),
+            expires_at: future.to_rfc3339(),
+            reason: None,
+            created_by: "user_test".to_string(),
+        });
+
+        let expired = tick(&silence_store, &alert_store, Utc::now());
+        assert_eq!(expired, 0);
+
+        let still_suppressed = alert_store.get(&alert_id).unwrap();
+        assert_eq!(still_suppressed.status, "suppressed");
+    }
+
+    #[tokio::test]
+    async fn tick_handles_silence_for_unknown_alert_gracefully() {
+        let alert_store = InMemoryAlertStore::new();
+        let silence_store = InMemorySilenceStore::new();
+        // Silence references an alert that doesn't exist in the store
+        // (e.g. evicted from the ring buffer between create and expiry).
+        let expired_at = Utc::now() - ChronoDuration::seconds(1);
+        silence_store.insert(SilenceRecord {
+            id: "sil-orphan".to_string(),
+            alert_id: "ghost-alert-id".to_string(),
+            starts_at: Utc::now().to_rfc3339(),
+            expires_at: expired_at.to_rfc3339(),
+            reason: None,
+            created_by: "user_test".to_string(),
+        });
+
+        // Must not panic — restore returns None and we move on.
+        let expired = tick(&silence_store, &alert_store, Utc::now());
+        assert_eq!(expired, 1);
+    }
+}


### PR DESCRIPTION
## Description

Subtask 3 of AAASM-1387. Adds the in-memory store for `SilenceRecord`s and the tokio background task that restores alerts when silence windows end. Lays the groundwork for the route handler (next subtask) to be testable end-to-end including expiry restoration.

- `aa-api/src/alerts/silence_store.rs` — `SilenceStore` trait (`insert`, `get_active_for_alert`, `expire_due`) + `InMemorySilenceStore` impl backed by `RwLock<HashMap<silence_id, SilenceRecord>>`. `now: DateTime<Utc>` is taken as a parameter on the read/expire methods so tests advance time deterministically. Malformed `expires_at` strings are treated as expired so a broken record can't pin an alert in the `"suppressed"` state forever.
- `aa-api/src/alerts/silence_watcher.rs` — pure `tick(silence_store, alert_store, now) -> usize` function + `spawn_silence_expiry_watcher` tokio loop that calls `tick(Utc::now())` every `TICK_INTERVAL` (1 s). Orphan silences (alert evicted between create and expiry) are handled by `AlertStore::restore` returning `None`.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [ ] Yes
- [x] No — additive only. Two new public modules; no existing types/methods changed.

## Related Issues

- Related Jira ticket: [AAASM-1646](https://lightning-dust-mite.atlassian.net/browse/AAASM-1646) (sub-task of [AAASM-1387](https://lightning-dust-mite.atlassian.net/browse/AAASM-1387))

## Testing

- [x] Unit tests added — 7 for `silence_store` (insert/get_active/expire_due, including edge cases for unparseable timestamps and exact-boundary expiry) + 3 for `silence_watcher::tick` (happy path, no-op when not due, orphan alert)
- [x] `cargo nextest run -p aa-api` — 415/415 passed locally
- The `spawn_silence_expiry_watcher` task itself isn't unit-tested (would require tokio's `test-util` feature for paused-clock tests, which isn't in dev-deps). The pure `tick()` function covers all the logic; the spawned loop is a thin sleep/loop wrapper.

## Commits (granular, 2)

1. `✨ (aa-api/alerts): Add SilenceStore trait + InMemorySilenceStore`
2. `✨ (aa-api/alerts): Add silence-expiry watcher tokio task`

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --workspace --all-targets`)
- [x] Self-review of the diff completed
- [x] Documentation updated (struct/method docstrings)
- [x] All CI checks passing locally
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1646]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ