### PR TITLE
[AAASM-1659] 🐛 (aa-api/alerts): Fix silence_watcher test typo (get → get_by_id)

### DIFF
--- a/aa-api/src/alerts/silence_watcher.rs
+++ b/aa-api/src/alerts/silence_watcher.rs
@@ -97,7 +97,7 @@ mod tests {
         let expired = tick(&silence_store, &alert_store, Utc::now());
         assert_eq!(expired, 1);
 
-        let restored = alert_store.get(&alert_id).unwrap();
+        let restored = alert_store.get_by_id(&alert_id).unwrap();
         assert_eq!(restored.status, "unresolved", "alert must be restored");
         assert!(restored.prior_status.is_none(), "prior_status must be cleared");
     }
@@ -122,7 +122,7 @@ mod tests {
         let expired = tick(&silence_store, &alert_store, Utc::now());
         assert_eq!(expired, 0);
 
-        let still_suppressed = alert_store.get(&alert_id).unwrap();
+        let still_suppressed = alert_store.get_by_id(&alert_id).unwrap();
         assert_eq!(still_suppressed.status, "suppressed");
     }
 


### PR DESCRIPTION
## Description

Two test sites in `aa-api/src/alerts/silence_watcher.rs` (introduced by AAASM-1646 / PR #613) call `alert_store.get(&alert_id)`. `InMemoryAlertStore` exposes `get_by_id(...)` on the `AlertStore` trait, not a bare `get(...)`. Simple typo in the test module.

`cargo clippy --workspace --all-targets --all-features --exclude aa-ebpf -- -D warnings` (CI's exact invocation) fails on every fresh master checkout with E0599, blocking **all** subsequent PRs from passing CI. Caught while picking up [AAASM-1651](https://lightning-dust-mite.atlassian.net/browse/AAASM-1651) (PR-B of AAASM-1422).

PR #613's CI somehow reported all checks green when it was merged — likely a stale-cache hit on the clippy job. Re-runs against the merged SHA reproduce the failure deterministically.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: [AAASM-1659](https://lightning-dust-mite.atlassian.net/browse/AAASM-1659) (parent: AAASM-1387; sibling: AAASM-1646 — origin of the typo)

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [x] No tests required (the fix restores the existing tests; no new tests needed)

### Local gates

| Gate | Result |
|---|---|
| `cargo clippy --workspace --all-targets --all-features --exclude aa-ebpf -- -D warnings` | ✅ |
| `cargo nextest run -p aa-api silence_watcher` | ✅ **3 / 3** |

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a — test-only)
- [ ] All CI checks passing (pending)
- [x] Commits are small and follow the Gitmoji convention

### Commits (1)

1. 🐛 `(aa-api/alerts)` Fix silence_watcher test typo (get → get_by_id)

[AAASM-1651]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1659]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ