### PR TITLE
[AAASM-1647] ✨ (aa-api): Wire SilenceStore into AppState + spawn watcher

### DIFF
--- a/aa-api/src/alerts/silence_watcher.rs
+++ b/aa-api/src/alerts/silence_watcher.rs
@@ -97,7 +97,7 @@ mod tests {
         let expired = tick(&silence_store, &alert_store, Utc::now());
         assert_eq!(expired, 1);
 
-        let restored = alert_store.get(&alert_id).unwrap();
+        let restored = alert_store.get_by_id(&alert_id).unwrap();
         assert_eq!(restored.status, "unresolved", "alert must be restored");
         assert!(restored.prior_status.is_none(), "prior_status must be cleared");
     }
@@ -122,7 +122,7 @@ mod tests {
         let expired = tick(&silence_store, &alert_store, Utc::now());
         assert_eq!(expired, 0);
 
-        let still_suppressed = alert_store.get(&alert_id).unwrap();
+        let still_suppressed = alert_store.get_by_id(&alert_id).unwrap();
         assert_eq!(still_suppressed.status, "suppressed");
     }
 

--- a/aa-api/src/server.rs
+++ b/aa-api/src/server.rs
@@ -50,6 +50,12 @@ pub async fn run_server(config: ApiConfig, state: AppState) -> Result<(), Box<dy
     let _secret_alert_capture_handle =
         crate::alerts::capture::spawn_secret_alert_capture(secret_rx, state.alert_store.clone());
 
+    // Spawn background task to restore alerts when their silence expires (AAASM-1646 / AAASM-1647).
+    let _silence_expiry_handle = crate::alerts::silence_watcher::spawn_silence_expiry_watcher(
+        state.silence_store.clone(),
+        state.alert_store.clone(),
+    );
+
     let app = build_app(state);
 
     let listener = TcpListener::bind(config.bind_addr).await?;

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -17,6 +17,7 @@ use aa_gateway::registry::AgentRegistry;
 use aa_gateway::AuditReader;
 use aa_runtime::approval::ApprovalQueue;
 
+use crate::alerts::silence_store::SilenceStore;
 use crate::alerts::AlertStore;
 use crate::auth::api_key::ApiKeyStore;
 use crate::auth::config::AuthConfig;
@@ -45,6 +46,10 @@ pub struct AppState {
     pub policy_history: Arc<dyn PolicyHistoryStore>,
     /// Persistent alert store for budget alerts.
     pub alert_store: Arc<dyn AlertStore>,
+    /// In-memory store for active alert silences. Populated by
+    /// `POST /api/v1/alerts/silence` and drained by the silence-expiry
+    /// watcher spawned in `run_server` (AAASM-1646 / AAASM-1647).
+    pub silence_store: Arc<dyn SilenceStore>,
     /// Unified event broadcast bus for streaming to clients.
     pub events: Arc<EventBroadcast>,
     /// Circular replay buffer for reconnecting WebSocket clients.

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicI64, AtomicU64, AtomicUsize};
 use std::sync::Arc;
 use std::time::Instant;
 
+use aa_api::alerts::silence_store::InMemorySilenceStore;
 use aa_api::alerts::store::InMemoryAlertStore;
 use aa_api::auth::api_key::{ApiKey, ApiKeyEntry, ApiKeyStore};
 use aa_api::auth::config::{AuthConfig, AuthMode};
@@ -117,6 +118,7 @@ spec:
     let jwt_verifier = Arc::new(JwtVerifier::new(secret));
     let rate_limiter = Arc::new(RateLimiter::new(rpm));
     let alert_store: Arc<InMemoryAlertStore> = Arc::new(InMemoryAlertStore::new());
+    let silence_store: Arc<InMemorySilenceStore> = Arc::new(InMemorySilenceStore::new());
 
     let audit_id = TEMP_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let audit_dir = std::env::temp_dir().join(format!("aa-api-test-audit-{}-{audit_id}", std::process::id()));
@@ -130,6 +132,7 @@ spec:
         approval_queue,
         policy_history,
         alert_store,
+        silence_store,
         events,
         replay_buffer: ReplayBuffer::new(),
         next_event_id: Arc::new(AtomicU64::new(0)),

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -45,6 +45,7 @@ use std::sync::atomic::{AtomicI64, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use aa_api::alerts::silence_store::InMemorySilenceStore;
 use aa_api::alerts::store::InMemoryAlertStore;
 use aa_api::auth::api_key::{ApiKey, ApiKeyEntry, ApiKeyStore};
 use aa_api::auth::config::{AuthConfig, AuthMode};
@@ -615,6 +616,7 @@ spec:
     let jwt_verifier = Arc::new(JwtVerifier::new(TEST_SECRET));
     let rate_limiter = Arc::new(RateLimiter::new(1000));
     let alert_store: Arc<InMemoryAlertStore> = Arc::new(InMemoryAlertStore::new());
+    let silence_store: Arc<InMemorySilenceStore> = Arc::new(InMemorySilenceStore::new());
     let alert_store_handle = Arc::clone(&alert_store);
 
     let audit_id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -630,6 +632,7 @@ spec:
             approval_queue,
             policy_history,
             alert_store,
+            silence_store,
             events,
             replay_buffer: ReplayBuffer::new(),
             next_event_id: Arc::new(AtomicU64::new(0)),
@@ -746,6 +749,7 @@ spec:
     let jwt_verifier = Arc::new(JwtVerifier::new(AUTH_IT_JWT_SECRET));
     let rate_limiter = Arc::new(RateLimiter::new(rate_limit_rpm));
     let alert_store: Arc<InMemoryAlertStore> = Arc::new(InMemoryAlertStore::new());
+    let silence_store: Arc<InMemorySilenceStore> = Arc::new(InMemorySilenceStore::new());
     let alert_store_handle = Arc::clone(&alert_store);
 
     let audit_id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -761,6 +765,7 @@ spec:
             approval_queue,
             policy_history,
             alert_store,
+            silence_store,
             events,
             replay_buffer: ReplayBuffer::new(),
             next_event_id: Arc::new(AtomicU64::new(0)),
@@ -878,6 +883,7 @@ spec:
     let jwt_verifier = Arc::new(JwtVerifier::new(AUTH_IT_JWT_SECRET));
     let rate_limiter = Arc::new(RateLimiter::new_with_window(rate_limit_rpm, rate_limit_window_secs));
     let alert_store: Arc<InMemoryAlertStore> = Arc::new(InMemoryAlertStore::new());
+    let silence_store: Arc<InMemorySilenceStore> = Arc::new(InMemorySilenceStore::new());
     let alert_store_handle = Arc::clone(&alert_store);
 
     let audit_id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -893,6 +899,7 @@ spec:
             approval_queue,
             policy_history,
             alert_store,
+            silence_store,
             events,
             replay_buffer: ReplayBuffer::new(),
             next_event_id: Arc::new(AtomicU64::new(0)),
@@ -996,6 +1003,7 @@ spec:
     let jwt_verifier = Arc::new(JwtVerifier::new(TEST_SECRET));
     let rate_limiter = Arc::new(RateLimiter::new(1000));
     let alert_store: Arc<InMemoryAlertStore> = Arc::new(InMemoryAlertStore::new());
+    let silence_store: Arc<InMemorySilenceStore> = Arc::new(InMemorySilenceStore::new());
     let alert_store_handle = Arc::clone(&alert_store);
 
     let audit_id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -1011,6 +1019,7 @@ spec:
             approval_queue,
             policy_history,
             alert_store,
+            silence_store,
             events,
             replay_buffer: ReplayBuffer::new(),
             next_event_id: Arc::new(AtomicU64::new(0)),
@@ -1110,6 +1119,7 @@ fn build_test_state_empty_policy() -> anyhow::Result<(AppState, PathBuf, Arc<InM
     let jwt_verifier = Arc::new(JwtVerifier::new(TEST_SECRET));
     let rate_limiter = Arc::new(RateLimiter::new(1000));
     let alert_store: Arc<InMemoryAlertStore> = Arc::new(InMemoryAlertStore::new());
+    let silence_store: Arc<InMemorySilenceStore> = Arc::new(InMemorySilenceStore::new());
     let alert_store_handle = Arc::clone(&alert_store);
 
     let audit_id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
@@ -1125,6 +1135,7 @@ fn build_test_state_empty_policy() -> anyhow::Result<(AppState, PathBuf, Arc<InM
             approval_queue,
             policy_history,
             alert_store,
+            silence_store,
             events,
             replay_buffer: ReplayBuffer::new(),
             next_event_id: Arc::new(AtomicU64::new(0)),


### PR DESCRIPTION
## Description

Subtask 4 of AAASM-1387. Plumbs the `SilenceStore` from AAASM-1646 into the shared `AppState` so the upcoming `POST /api/v1/alerts/silence` handler (AAASM-1648) can reach it, and spawns the silence-expiry watcher inside `run_server` against the same handle.

Also includes a small hotfix for a pre-existing master breakage: PR #590 (AAASM-1626) renamed `AlertStore::get` → `get_by_id` and merged between PR #613 (silence_watcher) being authored and merged — GitHub didn't catch the semantic conflict because no file was touched on both sides. The watcher tests still called `.get()`, breaking `cargo nextest run -p aa-api` on master. Fixed as commit 1 of this PR.

## Type of Change

- [x] ✨ New feature (AppState wiring)
- [x] 🐛 Bug fix (master hotfix for AlertStore rename)

## Breaking Changes

- [x] No — `AppState` gains one new public field. All callers are test scaffolding inside this repo, updated atomically in the same commit.

## Related Issues

- Related Jira ticket: [AAASM-1647](https://lightning-dust-mite.atlassian.net/browse/AAASM-1647) (sub-task of [AAASM-1387](https://lightning-dust-mite.atlassian.net/browse/AAASM-1387))
- Caused by: [AAASM-1626](https://lightning-dust-mite.atlassian.net/browse/AAASM-1626) / PR #590 (semantic conflict not caught by GitHub)

## Testing

- [x] No new tests in this subtask — wiring only. Behavior verified by the silence_watcher tests carried in from AAASM-1646 (now passing again after the hotfix).
- [x] `cargo nextest run -p aa-api` — 417/417 passed locally
- [x] Workspace clippy / fmt / doc check — clean

## Commits (granular, 3)

1. `🐛 (aa-api/alerts): Fix silence_watcher tests broken by AlertStore rename` — master hotfix
2. `✨ (aa-api/state): Add silence_store to AppState` — new field + test scaffolding (1 site in `aa-api/tests/common`, 5 sites in `aa-integration-tests/tests/common`)
3. `✨ (aa-api/server): Spawn silence-expiry watcher on server start`

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --workspace --all-targets`)
- [x] Self-review of the diff completed
- [x] Documentation updated (docstrings on the new field + watcher spawn site)
- [x] All CI checks passing locally
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1647]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ