### PR TITLE
[AAASM-1446] ✨ (ci/docker): Extend language-images matrix with F114b Python/Go variants

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -83,6 +83,10 @@ jobs:
             version: "3.13-slim"
             dockerfile: docker/Dockerfile.python-3.13-slim
             smoke_run: "python -c \"from agent_assembly import init_assembly\""
+          - lang: python
+            version: "3.12-slim"
+            dockerfile: docker/Dockerfile.python-3.12-slim
+            smoke_run: "python -c \"from agent_assembly import init_assembly\""
           # Node 24 is intentionally absent here. Re-enabled by AAASM-1503
           # once AAASM-1203 publishes `@agent-assembly/sdk` to npm. The
           # transitional git/tarball install paths can't produce a working

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -88,14 +88,12 @@ jobs:
             version: "3.12-slim"
             dockerfile: docker/Dockerfile.python-3.12-slim
             smoke_run: "python -c \"from agent_assembly import init_assembly\""
-          - lang: python
-            version: "3.11-slim"
-            dockerfile: docker/Dockerfile.python-3.11-slim
-            smoke_run: "python -c \"from agent_assembly import init_assembly\""
-          - lang: python
-            version: "3.10-slim"
-            dockerfile: docker/Dockerfile.python-3.10-slim
-            smoke_run: "python -c \"from agent_assembly import init_assembly\""
+          # Python 3.10 / 3.11 are intentionally absent here — see AAASM-1682.
+          # python-sdk's pyproject.toml declares `requires-python = ">=3.12,<4.0"`,
+          # so pip refuses to install `agent-assembly` on these older runtimes.
+          # The Dockerfiles ship in-tree (no CI cost) and the matrix entries will
+          # return once AAASM-1682 lands (either by relaxing the SDK's
+          # requires-python floor, or by formally dropping 3.10/3.11 from scope).
           # Node 20 / 22 / 24 are all intentionally absent here. Re-enabled
           # by AAASM-1660 (node 20) / AAASM-1661 (node 22) / AAASM-1503
           # (node 24) once AAASM-1203 publishes `@agent-assembly/sdk` to

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -91,6 +91,10 @@ jobs:
             version: "3.11-slim"
             dockerfile: docker/Dockerfile.python-3.11-slim
             smoke_run: "python -c \"from agent_assembly import init_assembly\""
+          - lang: python
+            version: "3.10-slim"
+            dockerfile: docker/Dockerfile.python-3.10-slim
+            smoke_run: "python -c \"from agent_assembly import init_assembly\""
           # Node 24 is intentionally absent here. Re-enabled by AAASM-1503
           # once AAASM-1203 publishes `@agent-assembly/sdk` to npm. The
           # transitional git/tarball install paths can't produce a working

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -95,11 +95,13 @@ jobs:
             version: "3.10-slim"
             dockerfile: docker/Dockerfile.python-3.10-slim
             smoke_run: "python -c \"from agent_assembly import init_assembly\""
-          # Node 24 is intentionally absent here. Re-enabled by AAASM-1503
-          # once AAASM-1203 publishes `@agent-assembly/sdk` to npm. The
-          # transitional git/tarball install paths can't produce a working
-          # image because the SDK's `dist/` and native `.node` files are
-          # gitignored — see AAASM-1501 for the full investigation.
+          # Node 20 / 22 / 24 are all intentionally absent here. Re-enabled
+          # by AAASM-1660 (node 20) / AAASM-1661 (node 22) / AAASM-1503
+          # (node 24) once AAASM-1203 publishes `@agent-assembly/sdk` to
+          # npm. The transitional git/tarball install paths can't produce
+          # a working image because the SDK's `dist/` and native `.node`
+          # files are gitignored — see AAASM-1501 for the full
+          # investigation. Three follow-up subtasks share one PR.
           - lang: go
             version: "1.26-alpine"
             dockerfile: docker/Dockerfile.go-1.26-alpine

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -80,6 +80,8 @@ jobs:
             version: "3.14-slim"
             dockerfile: docker/Dockerfile.python-3.14-slim
             smoke_run: "python -c \"from agent_assembly import init_assembly\""
+            # F114 latest-per-language pin — owns `python:latest` tag.
+            is_latest: true
           - lang: python
             version: "3.13-slim"
             dockerfile: docker/Dockerfile.python-3.13-slim
@@ -105,6 +107,8 @@ jobs:
             version: "1.26-alpine"
             dockerfile: docker/Dockerfile.go-1.26-alpine
             smoke_run: "go list -m github.com/AI-agent-assembly/go-sdk@latest"
+            # F114 latest-per-language pin — owns `go:latest` tag.
+            is_latest: true
           - lang: go
             version: "1.25-alpine"
             dockerfile: docker/Dockerfile.go-1.25-alpine
@@ -143,9 +147,14 @@ jobs:
           platforms: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
           load: ${{ github.event_name == 'pull_request' }}
+          # The `:latest` tag is only pushed by matrix entries flagged with
+          # `is_latest: true` (the F114 pin per language). Without this gate,
+          # every F114b leg would race to overwrite `:latest`, defeating the
+          # parent Story's "`:latest` per language still routes to the F114
+          # variant" AC bullet. See AAASM-1446.
           tags: |
             ghcr.io/agent-assembly/${{ matrix.lang }}:${{ matrix.version }}
-            ghcr.io/agent-assembly/${{ matrix.lang }}:latest
+            ${{ matrix.is_latest && format('ghcr.io/agent-assembly/{0}:latest', matrix.lang) || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -106,6 +106,10 @@ jobs:
             version: "1.26-alpine"
             dockerfile: docker/Dockerfile.go-1.26-alpine
             smoke_run: "go list -m github.com/AI-agent-assembly/go-sdk@latest"
+          - lang: go
+            version: "1.25-alpine"
+            dockerfile: docker/Dockerfile.go-1.25-alpine
+            smoke_run: "go list -m github.com/AI-agent-assembly/go-sdk@latest"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -110,6 +110,10 @@ jobs:
             version: "1.25-alpine"
             dockerfile: docker/Dockerfile.go-1.25-alpine
             smoke_run: "go list -m github.com/AI-agent-assembly/go-sdk@latest"
+          - lang: go
+            version: "1.24-alpine"
+            dockerfile: docker/Dockerfile.go-1.24-alpine
+            smoke_run: "go list -m github.com/AI-agent-assembly/go-sdk@latest"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -87,6 +87,10 @@ jobs:
             version: "3.12-slim"
             dockerfile: docker/Dockerfile.python-3.12-slim
             smoke_run: "python -c \"from agent_assembly import init_assembly\""
+          - lang: python
+            version: "3.11-slim"
+            dockerfile: docker/Dockerfile.python-3.11-slim
+            smoke_run: "python -c \"from agent_assembly import init_assembly\""
           # Node 24 is intentionally absent here. Re-enabled by AAASM-1503
           # once AAASM-1203 publishes `@agent-assembly/sdk` to npm. The
           # transitional git/tarball install paths can't produce a working

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,10 +67,11 @@ jobs:
       contents: read
       packages: write
 
-    # Matrix mirrors AAASM-1204 (F114) — latest-per-language Phase 1 set.
-    # Each entry feeds a single Dockerfile from docker/ plus its language-specific
-    # smoke command. The aasm-builder stage is identical across all three, so
-    # GHA cache (type=gha,mode=max) deduplicates the cargo build across entries.
+    # Matrix covers AAASM-1204 (F114, Phase 1: latest per language) + AAASM-1441
+    # (F114b, Phase 2: extended-version variants). Each entry feeds a single
+    # Dockerfile from docker/ plus its language-specific smoke command. The
+    # aasm-builder stage is identical across every entry, so GHA cache
+    # (type=gha,mode=max) deduplicates the cargo build across the matrix.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,6 +79,10 @@ jobs:
             version: "3.14-slim"
             dockerfile: docker/Dockerfile.python-3.14-slim
             smoke_run: "python -c \"from agent_assembly import init_assembly\""
+          - lang: python
+            version: "3.13-slim"
+            dockerfile: docker/Dockerfile.python-3.13-slim
+            smoke_run: "python -c \"from agent_assembly import init_assembly\""
           # Node 24 is intentionally absent here. Re-enabled by AAASM-1503
           # once AAASM-1203 publishes `@agent-assembly/sdk` to npm. The
           # transitional git/tarball install paths can't produce a working


### PR DESCRIPTION
## Description

Extends the `build-and-push-language-images` matrix in `.github/workflows/docker.yml` with the F114b extended-version Dockerfile variants shipped under AAASM-1443 + AAASM-1445. Matrix grows from **2 → 6 active entries**:

| Lang | Added | Active in matrix | Deferred |
|---|---|---|---|
| Python | 3.12, 3.13 | 3.12 / 3.13 / 3.14 (3) | 3.10, 3.11 — AAASM-1682 |
| Node | — | — (3 deferred — AAASM-1503 / AAASM-1660 / AAASM-1661) | — |
| Go | 1.24, 1.25 | 1.24 / 1.25 / 1.26 (3) | — |

Also gates the `:latest` tag push so only the F114 latest-per-language pin (python:3.14, go:1.26) overwrites `<lang>:latest` on `v*` tag pushes — closes the parent Story's "`:latest` per language still routes to the F114 variant" AC bullet that the prior 2-entry matrix didn't surface.

**Scope deviation from ticket plan:** the ticket says "matrix 3 → 11". The actual state today is:

* **Node (3 deferred)** — Node 20/22/24 share the AAASM-1203 npm-publish blocker. Tracked under AAASM-1660 / AAASM-1661 / AAASM-1503.
* **Python 3.10 / 3.11 (2 deferred)** — surfaced during this PR's first CI run: `python-sdk/pyproject.toml` declares `requires-python = ">=3.12,<4.0"`, so pip refuses to install `agent-assembly` on these older runtimes. Tracked under **AAASM-1682**.

Final matrix: **6 active entries** + **5 deferred Dockerfiles parked in-tree**.

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1446 (sub-task of AAASM-1441 / Epic AAASM-1199)
- Bug subtasks surfaced + filed during this PR's CI run: AAASM-1671 (Python pip-order, fixed in #617), AAASM-1672 (Go GOTOOLCHAIN + smoke backport, fixed in #618), AAASM-1682 (Python 3.10/3.11 requires-python conflict)
- Follow-up Jira tickets filed: AAASM-1660 (Node 20), AAASM-1661 (Node 22)
- Related Jira tickets (deferred): AAASM-1503, AAASM-1203, AAASM-1682

## Testing

- [x] `python3 -c "import yaml; ..."` parses the workflow YAML cleanly; matrix has exactly 6 entries; `is_latest` set on python:3.14 + go:1.26 only.
- [x] Every active entry's `dockerfile:` path exists on `master` (post-AAASM-1671/1672 fix).
- [x] CI build job passes for all 6 active matrix legs (7/7 checks green after the is_latest gate commit).
- [ ] First `v*` tag push will exercise the `:latest` gate end-to-end — deferred to release flow per AAASM-1204.md pattern.

## Checklist

- [x] Code follows project style guidelines (no Rust changes; YAML formatting matches existing matrix)
- [x] Self-review of the diff completed
- [x] Documentation updated (matrix-header comment + Node-deferred comment + new Python-deferred comment + `:latest` gate rationale)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention (10 commits)

## Commit list

```
✨ (ci/docker): Add python:3.13-slim variant to language-images matrix
✨ (ci/docker): Add python:3.12-slim variant to language-images matrix
✨ (ci/docker): Add python:3.11-slim variant to language-images matrix
✨ (ci/docker): Add python:3.10-slim variant to language-images matrix
📝 (ci/docker): Note Node 20/22 deferred alongside Node 24 in matrix comment
✨ (ci/docker): Add go:1.25-alpine variant to language-images matrix
✨ (ci/docker): Add go:1.24-alpine variant to language-images matrix
📝 (ci/docker): Refresh matrix header comment for F114b extension
🗑️ (ci/docker): Defer python:3.10/3.11 matrix entries pending AAASM-1682
🔧 (ci/docker): Gate `:latest` tag to F114-pinned matrix entries via is_latest flag
```