### PR TITLE
[AAASM-1671] 🐛 (docker): Reorder pip-install before COPY aasm in F114b Python Dockerfiles

### DIFF
--- a/docker/Dockerfile.python-3.10-slim
+++ b/docker/Dockerfile.python-3.10-slim
@@ -51,13 +51,20 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends git \
  && rm -rf /var/lib/apt/lists/*
 
-# Drop the prebuilt `aasm` binary into the image PATH.
-COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
-
-# Install the AAASM Python SDK. Transitional git source; switches to
+# Install the AAASM Python SDK FIRST. The `agent-assembly` package registers
+# its own `aasm` entrypoint in [project.scripts] at `/usr/local/bin/aasm` —
+# we must install it before the Rust binary `COPY` below, otherwise pip's
+# entrypoint shadows the Rust governance CLI (which is what `aasm --version`
+# needs to invoke). See AAASM-1500. Transitional git source; switches to
 # `pip install agent-assembly` once AAASM-1202 lands.
 RUN pip install --no-cache-dir \
         'agent-assembly @ git+https://github.com/AI-agent-assembly/python-sdk.git'
+
+# Drop the prebuilt Rust `aasm` binary into the image PATH, overlaying the
+# pip-installed Python entrypoint. The Python SDK stays importable from
+# Python (`from agent_assembly import init_assembly`); only the CLI binary
+# is replaced with the Rust governance operator binary.
+COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
 
 # Build-time smoke tests — fail the image build (not a runtime surprise)
 # if either side of the install ends up broken.

--- a/docker/Dockerfile.python-3.11-slim
+++ b/docker/Dockerfile.python-3.11-slim
@@ -51,13 +51,20 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends git \
  && rm -rf /var/lib/apt/lists/*
 
-# Drop the prebuilt `aasm` binary into the image PATH.
-COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
-
-# Install the AAASM Python SDK. Transitional git source; switches to
+# Install the AAASM Python SDK FIRST. The `agent-assembly` package registers
+# its own `aasm` entrypoint in [project.scripts] at `/usr/local/bin/aasm` —
+# we must install it before the Rust binary `COPY` below, otherwise pip's
+# entrypoint shadows the Rust governance CLI (which is what `aasm --version`
+# needs to invoke). See AAASM-1500. Transitional git source; switches to
 # `pip install agent-assembly` once AAASM-1202 lands.
 RUN pip install --no-cache-dir \
         'agent-assembly @ git+https://github.com/AI-agent-assembly/python-sdk.git'
+
+# Drop the prebuilt Rust `aasm` binary into the image PATH, overlaying the
+# pip-installed Python entrypoint. The Python SDK stays importable from
+# Python (`from agent_assembly import init_assembly`); only the CLI binary
+# is replaced with the Rust governance operator binary.
+COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
 
 # Build-time smoke tests — fail the image build (not a runtime surprise)
 # if either side of the install ends up broken.

--- a/docker/Dockerfile.python-3.12-slim
+++ b/docker/Dockerfile.python-3.12-slim
@@ -51,13 +51,20 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends git \
  && rm -rf /var/lib/apt/lists/*
 
-# Drop the prebuilt `aasm` binary into the image PATH.
-COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
-
-# Install the AAASM Python SDK. Transitional git source; switches to
+# Install the AAASM Python SDK FIRST. The `agent-assembly` package registers
+# its own `aasm` entrypoint in [project.scripts] at `/usr/local/bin/aasm` —
+# we must install it before the Rust binary `COPY` below, otherwise pip's
+# entrypoint shadows the Rust governance CLI (which is what `aasm --version`
+# needs to invoke). See AAASM-1500. Transitional git source; switches to
 # `pip install agent-assembly` once AAASM-1202 lands.
 RUN pip install --no-cache-dir \
         'agent-assembly @ git+https://github.com/AI-agent-assembly/python-sdk.git'
+
+# Drop the prebuilt Rust `aasm` binary into the image PATH, overlaying the
+# pip-installed Python entrypoint. The Python SDK stays importable from
+# Python (`from agent_assembly import init_assembly`); only the CLI binary
+# is replaced with the Rust governance operator binary.
+COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
 
 # Build-time smoke tests — fail the image build (not a runtime surprise)
 # if either side of the install ends up broken.

--- a/docker/Dockerfile.python-3.13-slim
+++ b/docker/Dockerfile.python-3.13-slim
@@ -51,13 +51,20 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends git \
  && rm -rf /var/lib/apt/lists/*
 
-# Drop the prebuilt `aasm` binary into the image PATH.
-COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
-
-# Install the AAASM Python SDK. Transitional git source; switches to
+# Install the AAASM Python SDK FIRST. The `agent-assembly` package registers
+# its own `aasm` entrypoint in [project.scripts] at `/usr/local/bin/aasm` —
+# we must install it before the Rust binary `COPY` below, otherwise pip's
+# entrypoint shadows the Rust governance CLI (which is what `aasm --version`
+# needs to invoke). See AAASM-1500. Transitional git source; switches to
 # `pip install agent-assembly` once AAASM-1202 lands.
 RUN pip install --no-cache-dir \
         'agent-assembly @ git+https://github.com/AI-agent-assembly/python-sdk.git'
+
+# Drop the prebuilt Rust `aasm` binary into the image PATH, overlaying the
+# pip-installed Python entrypoint. The Python SDK stays importable from
+# Python (`from agent_assembly import init_assembly`); only the CLI binary
+# is replaced with the Rust governance operator binary.
+COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
 
 # Build-time smoke tests — fail the image build (not a runtime surprise)
 # if either side of the install ends up broken.


### PR DESCRIPTION
## Description

The 4 F114b Python Dockerfiles (3.10–3.13) shipped under [AAASM-1443] were authored as near-byte-identical copies of `Dockerfile.python-3.14-slim` — but they were copied **before** AAASM-1500's `pip-install → COPY aasm` reorder landed. So all 4 broke at the build-time smoke test:

```
#20 [stage-1 5/7] RUN aasm --version
#20 0.263 usage: aasm [-h] {adapter} ...
#20 0.263 aasm: error: unrecognized arguments: --version
#20 ERROR: process "/bin/sh -c aasm --version" did not complete successfully: exit code: 2
```

Root cause: python-sdk's `pyproject.toml` declares `[project.scripts] aasm = "agent_assembly.cli.main:main"` — pip install writes a Python `aasm` script at `/usr/local/bin/aasm`. If `COPY --from=aasm-builder /usr/local/bin/aasm ...` runs **first**, pip then **overwrites** the Rust binary, leaving only the Python script — which doesn't understand `--version`.

The fix is identical to AAASM-1500's: reorder so pip install runs first, COPY aasm second.

Surfaced during F114b verification ([AAASM-1447]).

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1671 (sub-task of AAASM-1441 / Epic AAASM-1199)
- Precedent: AAASM-1500 (the same fix for python-3.14-slim, commit 368eb64d)
- Surfaced by: AAASM-1447

## Testing

Verified locally on Apple Silicon (`linux/arm64/v8` host, `linux/amd64` build via QEMU):

```
$ docker buildx build --platform=linux/amd64 --load -f docker/Dockerfile.python-3.13-slim -t aaasm-verify-1671/python-3.13-slim:local .
... (build succeeds)
$ docker run --rm aaasm-verify-1671/python-3.13-slim:local aasm --version
aasm 0.0.1
$ docker run --rm aaasm-verify-1671/python-3.13-slim:local python -c "from agent_assembly import init_assembly; print('import ok:', init_assembly.__name__)"
import ok: init_assembly
```

Both AC bullets pass: Rust `aasm --version` returns `aasm 0.0.1`, Python `from agent_assembly import init_assembly` continues to import. Same verification expected on CI for all 4 Python F114b variants.

- [ ] Unit tests added / updated (not applicable — Dockerfile reorder)
- [x] Manual testing performed (local Docker build + smoke run on python:3.13 — same one-line edit applies to 3.10/3.11/3.12)
- [ ] No tests required

## Checklist

- [x] Code follows project style guidelines (no Rust changes)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (inline comments updated to match the AAASM-1500-fixed python-3.14-slim header text)
- [ ] All CI checks passing — needs CI run
- [x] Commits are small and follow the Gitmoji convention (4 commits, one per file)

## Commit list

```
🐛 (docker): Install Python SDK before Rust aasm copy in python-3.13-slim
🐛 (docker): Install Python SDK before Rust aasm copy in python-3.12-slim
🐛 (docker): Install Python SDK before Rust aasm copy in python-3.11-slim
🐛 (docker): Install Python SDK before Rust aasm copy in python-3.10-slim
```

## Coordination note

Blocks AAASM-1446 PR #616 (matrix extension). Together with AAASM-1672 (Go GOTOOLCHAIN fix), this PR is one of two blockers for #616's CI going green.

[AAASM-1443]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1447]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ