### PR TITLE
[AAASM-1672] 🐛 (docker): Fix F114b Go Dockerfiles — GOTOOLCHAIN=auto + AAASM-1508 smoke backport

### DIFF
--- a/docker/Dockerfile.go-1.24-alpine
+++ b/docker/Dockerfile.go-1.24-alpine
@@ -53,14 +53,28 @@ FROM golang:1.24-alpine
 # Drop the prebuilt `aasm` binary into the image PATH.
 COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
 
+# go-sdk's go.mod declares `go 1.26.0`; the golang:1.24-alpine base image
+# ships a 1.24 toolchain. GOTOOLCHAIN=auto lets `go install` fetch the
+# required 1.26 toolchain on demand, matching the "courtesy buffer"
+# semantics of this F114b variant (host stays on Go 1.24, AAASM-managed
+# go-sdk install transparently uses 1.26). See AAASM-1672.
+ENV GOTOOLCHAIN=auto
+
 # Install the AAASM Go SDK. `go install` uses Go's native git-based
 # distribution model — no registry-publish prerequisite (unlike pip/npm).
 RUN go install github.com/AI-agent-assembly/go-sdk/...@latest
 
 # Build-time smoke tests — fail the image build (not a runtime surprise)
 # if either side of the install ends up broken.
+#
+# `go list -m <module>@latest` is a self-contained query against GOPROXY:
+# it doesn't need a local go.mod (works from `/`), and it asserts the
+# module is resolvable. The plain `go list <import>` form needs both a
+# module context AND a package at the import path — neither holds here
+# (go-sdk's module root has no .go files; sources are under assembly/,
+# internal/ffi/, examples/minimal/). See AAASM-1508.
 RUN aasm --version
-RUN go list github.com/agent-assembly/go-sdk
+RUN go list -m github.com/AI-agent-assembly/go-sdk@latest
 
 LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
       org.opencontainers.image.description="AAASM governed Go 1.24 agent base image" \

--- a/docker/Dockerfile.go-1.25-alpine
+++ b/docker/Dockerfile.go-1.25-alpine
@@ -53,14 +53,28 @@ FROM golang:1.25-alpine
 # Drop the prebuilt `aasm` binary into the image PATH.
 COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
 
+# go-sdk's go.mod declares `go 1.26.0`; the golang:1.25-alpine base image
+# ships a 1.25 toolchain. GOTOOLCHAIN=auto lets `go install` fetch the
+# required 1.26 toolchain on demand, matching the "courtesy buffer"
+# semantics of this F114b variant (host stays on Go 1.25, AAASM-managed
+# go-sdk install transparently uses 1.26). See AAASM-1672.
+ENV GOTOOLCHAIN=auto
+
 # Install the AAASM Go SDK. `go install` uses Go's native git-based
 # distribution model — no registry-publish prerequisite (unlike pip/npm).
 RUN go install github.com/AI-agent-assembly/go-sdk/...@latest
 
 # Build-time smoke tests — fail the image build (not a runtime surprise)
 # if either side of the install ends up broken.
+#
+# `go list -m <module>@latest` is a self-contained query against GOPROXY:
+# it doesn't need a local go.mod (works from `/`), and it asserts the
+# module is resolvable. The plain `go list <import>` form needs both a
+# module context AND a package at the import path — neither holds here
+# (go-sdk's module root has no .go files; sources are under assembly/,
+# internal/ffi/, examples/minimal/). See AAASM-1508.
 RUN aasm --version
-RUN go list github.com/agent-assembly/go-sdk
+RUN go list -m github.com/AI-agent-assembly/go-sdk@latest
 
 LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
       org.opencontainers.image.description="AAASM governed Go 1.25 agent base image" \


### PR DESCRIPTION
## Description

The 2 F114b Go Dockerfiles (`docker/Dockerfile.go-1.24-alpine`, `docker/Dockerfile.go-1.25-alpine`) shipped under [AAASM-1445] don't build today. Two co-dependent root causes:

### 1. go-sdk requires Go ≥1.26 (set in go-sdk commit 05d19c5 for govulncheck CVE GO-2026-4971)

```
#18 [stage-1 3/5] RUN go install github.com/AI-agent-assembly/go-sdk/...@latest
#18 5.213 go: github.com/AI-agent-assembly/go-sdk@v0.0.0-20260520010711-912053a56c4c requires go >= 1.26.0 (running go 1.25.10; GOTOOLCHAIN=local)
#18 ERROR: process "/bin/sh -c go install github.com/AI-agent-assembly/go-sdk/...@latest" did not complete successfully: exit code: 1
```

The `golang:1.24-alpine` / `golang:1.25-alpine` base images ship older toolchains; the alpine default `GOTOOLCHAIN=local` blocks on-demand 1.26 download.

Fix: `ENV GOTOOLCHAIN=auto` before the `go install` line. Lets Go fetch 1.26 transparently. Preserves the parent Story's "courtesy buffer" semantics — host base stays on Go 1.24/1.25, AAASM-managed go-sdk install transparently uses 1.26.

### 2. Build-time smoke line is pre-AAASM-1508

The 1.24/1.25 Dockerfiles inherited `RUN go list github.com/agent-assembly/go-sdk` — the same broken form that AAASM-1508 fixed for the F114 Go 1.26 variant. Wrong module-path case (`agent-assembly` should be `AI-agent-assembly`) **and** needs a `go.mod` cwd which doesn't exist at `/`.

Fix: backport the AAASM-1508 form already in `docker/Dockerfile.go-1.26-alpine`: `RUN go list -m github.com/AI-agent-assembly/go-sdk@latest`.

Both fixes ship per file because either fix alone leaves the build broken: GOTOOLCHAIN=auto on its own still fails at the broken smoke line; smoke-line fix alone still fails at `go install`.

Surfaced during F114b verification ([AAASM-1447]).

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1672 (sub-task of AAASM-1441 / Epic AAASM-1199)
- Precedent: AAASM-1508 (the smoke-line fix in go-1.26-alpine)
- Trigger: go-sdk commit 05d19c5 (Go 1.26 toolchain bump)
- Original ship: AAASM-1445 (Dockerfiles shipped before either fix)
- Surfaced by: AAASM-1447

## Testing

Verified locally on Apple Silicon (`linux/arm64/v8` host, `linux/amd64` build via QEMU):

```
$ docker buildx build --platform=linux/amd64 --load -f docker/Dockerfile.go-1.25-alpine -t aaasm-verify-1672/go-1.25-alpine:local .
... (build succeeds — GOTOOLCHAIN=auto pulls Go 1.26)
$ docker run --rm aaasm-verify-1672/go-1.25-alpine:local aasm --version
aasm 0.0.1
$ docker run --rm aaasm-verify-1672/go-1.25-alpine:local go list -m github.com/AI-agent-assembly/go-sdk@latest
github.com/AI-agent-assembly/go-sdk v0.0.0-20260520010711-912053a56c4c
```

Both AC bullets pass. Same one-edit applies to 1.24 (verified by inspection — the only difference between 1.24 and 1.25 in this diff is the FROM line + image-description label).

- [x] Manual testing performed (local Docker build + smoke run on go:1.25)
- [ ] No tests required

## Checklist

- [x] Code follows project style guidelines (no Rust changes)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (inline comments added for both GOTOOLCHAIN and AAASM-1508 rationale)
- [ ] All CI checks passing — needs CI run
- [x] Commits are small and follow the Gitmoji convention (2 commits, one per file)

## Commit list

```
🐛 (docker): Fix go-1.25-alpine — GOTOOLCHAIN=auto + AAASM-1508 smoke line
🐛 (docker): Fix go-1.24-alpine — GOTOOLCHAIN=auto + AAASM-1508 smoke line
```

## Coordination note

Together with AAASM-1671 (Python pip-order fix, PR #617), this PR unblocks AAASM-1446 PR #616's CI. The matrix-extension PR re-runs green once both 1671 + 1672 merge.

[AAASM-1445]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1447]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ