### PR TITLE
[AAASM-1673] ✨ (approvals): Add countdown helpers + ApprovalCountdown component

### DIFF
--- a/dashboard/src/features/approvals/ApprovalCountdown.test.tsx
+++ b/dashboard/src/features/approvals/ApprovalCountdown.test.tsx
@@ -1,0 +1,93 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest'
+import { ApprovalCountdown } from './ApprovalCountdown'
+
+const FIXED_NOW = new Date('2026-05-20T12:00:00Z').getTime()
+
+function plus(ms: number): string {
+  return new Date(FIXED_NOW + ms).toISOString()
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(FIXED_NOW)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('ApprovalCountdown', () => {
+  it('renders mm:ss with low-tier colour when remaining > 5min', () => {
+    render(<ApprovalCountdown expiresAt={plus(10 * 60 * 1000)} />)
+    const el = screen.getByTestId('approval-countdown')
+    expect(el).toHaveTextContent('10:00')
+    expect(el.getAttribute('data-tier')).toBe('low')
+    expect((el as HTMLElement).style.color).toBe('var(--ink-3)')
+  })
+
+  it('renders medium-tier colour when 1min <= remaining < 5min', () => {
+    render(<ApprovalCountdown expiresAt={plus(3 * 60 * 1000)} />)
+    const el = screen.getByTestId('approval-countdown')
+    expect(el.getAttribute('data-tier')).toBe('medium')
+    expect((el as HTMLElement).style.color).toBe('var(--warn)')
+  })
+
+  it('renders high-tier colour when remaining < 1min', () => {
+    render(<ApprovalCountdown expiresAt={plus(30 * 1000)} />)
+    const el = screen.getByTestId('approval-countdown')
+    expect(el).toHaveTextContent('00:30')
+    expect(el.getAttribute('data-tier')).toBe('high')
+    expect((el as HTMLElement).style.color).toBe('var(--danger)')
+  })
+
+  it('ticks every 10s while remaining > 60s', () => {
+    render(<ApprovalCountdown expiresAt={plus(2 * 60 * 1000)} />)
+    expect(screen.getByTestId('approval-countdown')).toHaveTextContent('02:00')
+
+    // After 9s, no tick has fired yet.
+    act(() => { vi.advanceTimersByTime(9_000) })
+    expect(screen.getByTestId('approval-countdown')).toHaveTextContent('02:00')
+
+    // At 10s, the slow timer fires.
+    act(() => { vi.advanceTimersByTime(1_000) })
+    expect(screen.getByTestId('approval-countdown')).toHaveTextContent('01:50')
+  })
+
+  it('switches to 1s cadence once remaining drops below 60s', () => {
+    render(<ApprovalCountdown expiresAt={plus(65 * 1000)} />)
+    // First slow tick at 10s — drops to 55s remaining, fast cadence engages.
+    act(() => { vi.advanceTimersByTime(10_000) })
+    expect(screen.getByTestId('approval-countdown')).toHaveTextContent('00:55')
+
+    // From now on, tick every 1s.
+    act(() => { vi.advanceTimersByTime(1_000) })
+    expect(screen.getByTestId('approval-countdown')).toHaveTextContent('00:54')
+    act(() => { vi.advanceTimersByTime(1_000) })
+    expect(screen.getByTestId('approval-countdown')).toHaveTextContent('00:53')
+  })
+
+  it('fires onExpire exactly once when remaining reaches zero', () => {
+    const onExpire = vi.fn()
+    render(<ApprovalCountdown expiresAt={plus(2_000)} onExpire={onExpire} />)
+
+    // Two 1s ticks bring remaining to zero. Stepping per-tick lets React
+    // re-render between firings so the next setTimeout is installed.
+    act(() => { vi.advanceTimersByTime(1_000) })
+    act(() => { vi.advanceTimersByTime(1_000) })
+    expect(screen.getByTestId('approval-countdown')).toHaveTextContent('00:00')
+    expect(onExpire).toHaveBeenCalledTimes(1)
+
+    // Subsequent ticks are no-ops; no timers remain, but the once-only
+    // guard would still prevent a duplicate call if any fired.
+    act(() => { vi.advanceTimersByTime(10_000) })
+    expect(onExpire).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires onExpire immediately for an already-expired timestamp', () => {
+    const onExpire = vi.fn()
+    render(<ApprovalCountdown expiresAt={plus(-5_000)} onExpire={onExpire} />)
+    expect(onExpire).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('approval-countdown')).toHaveTextContent('00:00')
+  })
+})

--- a/dashboard/src/features/approvals/ApprovalCountdown.tsx
+++ b/dashboard/src/features/approvals/ApprovalCountdown.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef, useState } from 'react'
+import { formatCountdown, getCountdownTier, getRemainingMs } from './urgency'
+
+const TICK_FAST_MS = 1_000
+const TICK_SLOW_MS = 10_000
+const FAST_THRESHOLD_MS = 60_000
+
+const TIER_COLOR: Record<ReturnType<typeof getCountdownTier>, string> = {
+  high: 'var(--danger)',
+  medium: 'var(--warn)',
+  low: 'var(--ink-3)',
+}
+
+interface ApprovalCountdownProps {
+  expiresAt: string
+  onExpire?: () => void
+}
+
+export function ApprovalCountdown({ expiresAt, onExpire }: ApprovalCountdownProps) {
+  const [now, setNow] = useState(() => Date.now())
+  const firedRef = useRef(false)
+  const remainingMs = getRemainingMs(expiresAt, now)
+
+  useEffect(() => {
+    firedRef.current = false
+  }, [expiresAt])
+
+  useEffect(() => {
+    if (remainingMs > 0) return
+    if (firedRef.current) return
+    firedRef.current = true
+    onExpire?.()
+  }, [remainingMs, onExpire])
+
+  useEffect(() => {
+    if (remainingMs === 0) return
+    const period = remainingMs < FAST_THRESHOLD_MS ? TICK_FAST_MS : TICK_SLOW_MS
+    const timer = setTimeout(() => setNow(Date.now()), period)
+    return () => clearTimeout(timer)
+  }, [remainingMs])
+
+  const tier = getCountdownTier(remainingMs)
+  return (
+    <span
+      data-testid="approval-countdown"
+      data-tier={tier}
+      style={{ color: TIER_COLOR[tier], fontVariantNumeric: 'tabular-nums' }}
+    >
+      {formatCountdown(remainingMs)}
+    </span>
+  )
+}

--- a/dashboard/src/features/approvals/urgency.test.ts
+++ b/dashboard/src/features/approvals/urgency.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import {
+  formatCountdown,
+  getCountdownTier,
+  getRemainingMs,
+  getUrgency,
+} from './urgency'
+
+const NOW = new Date('2026-05-20T12:00:00Z').getTime()
+
+describe('getUrgency', () => {
+  it('returns high for <1h old', () => {
+    expect(getUrgency('2026-05-20T11:30:00Z', NOW)).toBe('high')
+  })
+
+  it('returns medium for 1–6h old', () => {
+    expect(getUrgency('2026-05-20T09:00:00Z', NOW)).toBe('medium')
+  })
+
+  it('returns low for >=6h old', () => {
+    expect(getUrgency('2026-05-20T05:00:00Z', NOW)).toBe('low')
+  })
+})
+
+describe('getRemainingMs', () => {
+  it('returns positive ms when expiry is in the future', () => {
+    expect(getRemainingMs('2026-05-20T12:00:30Z', NOW)).toBe(30_000)
+  })
+
+  it('clamps to 0 when expiry is in the past', () => {
+    expect(getRemainingMs('2026-05-20T11:59:00Z', NOW)).toBe(0)
+  })
+
+  it('returns 0 for an unparseable timestamp', () => {
+    expect(getRemainingMs('not-a-date', NOW)).toBe(0)
+  })
+})
+
+describe('getCountdownTier', () => {
+  it('returns high for <60s remaining', () => {
+    expect(getCountdownTier(59_999)).toBe('high')
+    expect(getCountdownTier(0)).toBe('high')
+  })
+
+  it('returns medium for 1–5min remaining', () => {
+    expect(getCountdownTier(60_000)).toBe('medium')
+    expect(getCountdownTier(4 * 60 * 1000)).toBe('medium')
+  })
+
+  it('returns low for >=5min remaining', () => {
+    expect(getCountdownTier(5 * 60 * 1000)).toBe('low')
+    expect(getCountdownTier(60 * 60 * 1000)).toBe('low')
+  })
+})
+
+describe('formatCountdown', () => {
+  it('formats mm:ss under 1h', () => {
+    expect(formatCountdown(0)).toBe('00:00')
+    expect(formatCountdown(9 * 1000)).toBe('00:09')
+    expect(formatCountdown(65 * 1000)).toBe('01:05')
+    expect(formatCountdown(59 * 60 * 1000 + 59 * 1000)).toBe('59:59')
+  })
+
+  it('formats Xh Ym at or above 1h', () => {
+    expect(formatCountdown(60 * 60 * 1000)).toBe('1h 0m')
+    expect(formatCountdown(2 * 60 * 60 * 1000 + 15 * 60 * 1000)).toBe('2h 15m')
+  })
+
+  it('clamps negative input to 00:00', () => {
+    expect(formatCountdown(-5_000)).toBe('00:00')
+  })
+})

--- a/dashboard/src/features/approvals/urgency.ts
+++ b/dashboard/src/features/approvals/urgency.ts
@@ -9,3 +9,36 @@ export function getUrgency(createdAt: string, now: number = Date.now()): Urgency
   if (ageMs < SIX_HOURS_MS) return 'medium'
   return 'low'
 }
+
+// Countdown helpers — time-remaining-until-expiry. Distinct from `getUrgency`
+// (age-since-creation): the parent AAASM-1478 spec reuses the red/orange/gray
+// visual tiers but inverts the meaning (low remaining → high severity).
+
+export type CountdownTier = Urgency
+
+const ONE_MINUTE_MS = 60 * 1000
+const FIVE_MINUTES_MS = 5 * ONE_MINUTE_MS
+
+export function getRemainingMs(expiresAt: string, now: number = Date.now()): number {
+  const target = new Date(expiresAt).getTime()
+  if (Number.isNaN(target)) return 0
+  return Math.max(0, target - now)
+}
+
+export function getCountdownTier(remainingMs: number): CountdownTier {
+  if (remainingMs < ONE_MINUTE_MS) return 'high'
+  if (remainingMs < FIVE_MINUTES_MS) return 'medium'
+  return 'low'
+}
+
+export function formatCountdown(remainingMs: number): string {
+  const totalSecs = Math.max(0, Math.floor(remainingMs / 1000))
+  if (totalSecs < ONE_HOUR_MS / 1000) {
+    const m = Math.floor(totalSecs / 60)
+    const s = totalSecs % 60
+    return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`
+  }
+  const h = Math.floor(totalSecs / 3600)
+  const m = Math.floor((totalSecs % 3600) / 60)
+  return `${h}h ${m}m`
+}


### PR DESCRIPTION
## Description

S1 of the AAASM-1478 dashboard work — auto-expire countdown + collapsible Expired section.

Adds the time-remaining utility functions and the presentational `ApprovalCountdown` component. **No `ApprovalsPage` wiring** in this PR — that lands in S3 (AAASM-1675) after the client-state hook from S2 (AAASM-1674).

**Commits**
1. `✨ (approvals): Add countdown helpers in urgency.ts` — `getRemainingMs`, `getCountdownTier`, `formatCountdown`, and a `CountdownTier` alias.
2. `✅ (approvals): Add vitest for countdown helpers` — boundary cases at 60s and 5min, `mm:ss` / `Xh Ym` formatting, negative-input clamp.
3. `✨ (approvals): Add ApprovalCountdown component` — renders with tier colour, dual-cadence ticking, `onExpire` once-only.
4. `✅ (approvals): Add vitest for ApprovalCountdown` — 7 cases covering tier colour, slow-and-fast cadence, expire callback.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1673 (parent AAASM-1478)
- Backend deps already shipped: AAASM-1381 (REST `expires_at`), AAASM-1453 (WS expired event)

## Testing

- [x] Unit tests added (12 helper cases + 7 component cases)
- [ ] Integration tests added — N/A for S1; lands in S3 wire-in PR
- [x] Manual testing performed — verified `pnpm type-check`, `pnpm lint`, `pnpm test --run` all green (959 tests pass)

## Checklist

- [x] Code follows project style guidelines (`pnpm lint`, `pnpm type-check`)
- [x] Self-review of the diff completed
- [x] No behaviour change to existing exports — `getUrgency` untouched
- [x] All commits are small and follow the Gitmoji convention