### PR TITLE
[AAASM-1651] ✨ (aa-api/events): Add OpsChange WS event type and OpsChangePayload

### DIFF
--- a/aa-api/src/models/event_type.rs
+++ b/aa-api/src/models/event_type.rs
@@ -28,13 +28,14 @@ impl EventType {
     /// Returns all variants when the input is empty or `None`.
     pub fn parse_filter(input: Option<&str>) -> Vec<EventType> {
         match input {
-            None | Some("") => vec![Self::Violation, Self::Approval, Self::Budget],
+            None | Some("") => vec![Self::Violation, Self::Approval, Self::Budget, Self::OpsChange],
             Some(s) => s
                 .split(',')
                 .filter_map(|t| match t.trim() {
                     "violation" => Some(Self::Violation),
                     "approval" => Some(Self::Approval),
                     "budget" => Some(Self::Budget),
+                    "ops_change" => Some(Self::OpsChange),
                     _ => None,
                 })
                 .collect(),

--- a/aa-api/src/models/event_type.rs
+++ b/aa-api/src/models/event_type.rs
@@ -16,6 +16,10 @@ pub enum EventType {
     Approval,
     /// Budget threshold alerts.
     Budget,
+    /// In-flight ops registry state transitions (AAASM-1422 PR-B).
+    /// Emitted on every `OpsRegistry` transition; payload is
+    /// [`super::ws_payloads::OpsChangePayload`].
+    OpsChange,
 }
 
 impl EventType {

--- a/aa-api/src/models/event_type.rs
+++ b/aa-api/src/models/event_type.rs
@@ -42,3 +42,43 @@ impl EventType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_filter_includes_ops_change() {
+        let result = EventType::parse_filter(None);
+        assert!(result.contains(&EventType::OpsChange));
+        assert_eq!(result.len(), 4);
+    }
+
+    #[test]
+    fn ops_change_filter_string_resolves_to_variant() {
+        assert_eq!(EventType::parse_filter(Some("ops_change")), vec![EventType::OpsChange]);
+    }
+
+    #[test]
+    fn multi_filter_keeps_order_and_includes_ops_change() {
+        let result = EventType::parse_filter(Some("violation,ops_change,budget"));
+        assert_eq!(
+            result,
+            vec![EventType::Violation, EventType::OpsChange, EventType::Budget]
+        );
+    }
+
+    #[test]
+    fn unknown_filter_token_is_dropped() {
+        assert_eq!(
+            EventType::parse_filter(Some("bogus,ops_change")),
+            vec![EventType::OpsChange]
+        );
+    }
+
+    #[test]
+    fn ops_change_variant_serializes_snake_case() {
+        let json = serde_json::to_string(&EventType::OpsChange).unwrap();
+        assert_eq!(json, "\"ops_change\"");
+    }
+}

--- a/aa-api/src/models/ws_payloads.rs
+++ b/aa-api/src/models/ws_payloads.rs
@@ -332,6 +332,7 @@ mod tests {
 /// - `"violation"` → [`ViolationPayload`]
 /// - `"approval"` → [`ApprovalPayload`]
 /// - `"budget"` → [`BudgetAlertPayload`]
+/// - `"ops_change"` → [`OpsChangePayload`]
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(untagged)]
 pub enum EventPayload {
@@ -341,4 +342,6 @@ pub enum EventPayload {
     Approval(ApprovalPayload),
     /// Budget threshold alert payload.
     Budget(BudgetAlertPayload),
+    /// In-flight ops registry state-transition payload (AAASM-1422 PR-B).
+    OpsChange(OpsChangePayload),
 }

--- a/aa-api/src/models/ws_payloads.rs
+++ b/aa-api/src/models/ws_payloads.rs
@@ -138,6 +138,39 @@ pub struct BudgetAlertPayload {
     pub limit_usd: f64,
 }
 
+/// Payload for `event_type: "ops_change"` events.
+///
+/// Emitted on every transition of an in-flight operation in the
+/// gateway-side [`aa_gateway::ops::OpsRegistry`] (AAASM-1422 PR-B).
+/// The dashboard's `useLiveOpsStream` hook correlates rows by `op_id`
+/// (composed from `trace_id:span_id`) and updates the matching row in
+/// place, so a `pause` followed by the confirming `paused` event
+/// auto-clears any optimistic override.
+///
+/// Actual emission on registry transitions ships in PR-H. PR-B only
+/// defines the payload shape so PR-C (dashboard rework) and PR-H
+/// (gateway emission) can build against a stable schema in parallel.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct OpsChangePayload {
+    /// Stable operation identifier — `"{trace_id}:{span_id}"` composed
+    /// in the gateway. The dashboard keys its row map by this value so
+    /// successive `ops_change` events for the same op merge into one
+    /// row instead of stacking.
+    pub op_id: String,
+    /// New lifecycle state after the transition. Mirrors the
+    /// `aa_gateway::ops::OpState` enum (snake_case wire format:
+    /// `pending` / `running` / `paused` / `completing` / `terminated`).
+    #[schema(value_type = String, example = "running")]
+    pub state: aa_gateway::ops::OpState,
+    /// RFC 3339 UTC timestamp of the transition. Same value as the
+    /// matching `OpRecord.updated_at` returned by the registry.
+    pub updated_at: String,
+    /// Agent that owns the operation. Mirrors `GovernanceEvent.agent_id`
+    /// so a single agent's live-ops can be filtered without joining
+    /// against the audit channel.
+    pub agent_id: String,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aa-api/src/models/ws_payloads.rs
+++ b/aa-api/src/models/ws_payloads.rs
@@ -324,6 +324,77 @@ mod tests {
         };
         assert_eq!(op_type, None);
     }
+
+    // ── OpsChangePayload — AAASM-1651 (PR-B of AAASM-1422) ────────────────
+
+    #[test]
+    fn ops_change_payload_serializes_with_snake_case_state() {
+        let payload = OpsChangePayload {
+            op_id: "trace-abc:span-1".into(),
+            state: aa_gateway::ops::OpState::Running,
+            updated_at: "2026-05-20T15:30:00Z".into(),
+            agent_id: "agent-7".into(),
+        };
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(json["op_id"], "trace-abc:span-1");
+        assert_eq!(json["state"], "running");
+        assert_eq!(json["updated_at"], "2026-05-20T15:30:00Z");
+        assert_eq!(json["agent_id"], "agent-7");
+    }
+
+    #[test]
+    fn ops_change_payload_round_trips_through_serde() {
+        let original = OpsChangePayload {
+            op_id: "t1:s2".into(),
+            state: aa_gateway::ops::OpState::Completing,
+            updated_at: "2026-05-20T16:00:00Z".into(),
+            agent_id: "agent-9".into(),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: OpsChangePayload = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.op_id, "t1:s2");
+        assert_eq!(decoded.state, aa_gateway::ops::OpState::Completing);
+    }
+
+    #[test]
+    fn ops_change_payload_accepts_all_five_op_states() {
+        // Guards against accidental gating of certain states from the wire.
+        for state in [
+            aa_gateway::ops::OpState::Pending,
+            aa_gateway::ops::OpState::Running,
+            aa_gateway::ops::OpState::Paused,
+            aa_gateway::ops::OpState::Completing,
+            aa_gateway::ops::OpState::Terminated,
+        ] {
+            let payload = OpsChangePayload {
+                op_id: "t:s".into(),
+                state,
+                updated_at: "2026-05-20T00:00:00Z".into(),
+                agent_id: "agent-1".into(),
+            };
+            let json = serde_json::to_value(&payload).unwrap();
+            assert!(json["state"].is_string(), "state serialised as string for {state:?}");
+        }
+    }
+
+    #[test]
+    fn event_payload_dispatches_ops_change_through_untagged_decode() {
+        // The untagged enum must distinguish OpsChangePayload from sibling
+        // payloads by field shape alone — op_id + state + updated_at +
+        // agent_id is the unique combination.
+        let raw = serde_json::json!({
+            "op_id": "t1:s1",
+            "state": "paused",
+            "updated_at": "2026-05-20T16:00:00Z",
+            "agent_id": "agent-3"
+        });
+        let decoded: EventPayload = serde_json::from_value(raw).unwrap();
+        let EventPayload::OpsChange(p) = decoded else {
+            panic!("expected EventPayload::OpsChange, got {decoded:?}");
+        };
+        assert_eq!(p.op_id, "t1:s1");
+        assert_eq!(p.state, aa_gateway::ops::OpState::Paused);
+    }
 }
 
 /// Discriminated union of all possible `GovernanceEvent.payload` shapes.

--- a/aa-api/src/models/ws_payloads.rs
+++ b/aa-api/src/models/ws_payloads.rs
@@ -150,6 +150,10 @@ pub struct BudgetAlertPayload {
 /// Actual emission on registry transitions ships in PR-H. PR-B only
 /// defines the payload shape so PR-C (dashboard rework) and PR-H
 /// (gateway emission) can build against a stable schema in parallel.
+///
+/// Agent attribution travels on the enclosing
+/// [`super::event::GovernanceEvent::agent_id`] — same convention as
+/// `ViolationPayload`, `ApprovalPayload`, and `BudgetAlertPayload`.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct OpsChangePayload {
     /// Stable operation identifier — `"{trace_id}:{span_id}"` composed
@@ -165,10 +169,6 @@ pub struct OpsChangePayload {
     /// RFC 3339 UTC timestamp of the transition. Same value as the
     /// matching `OpRecord.updated_at` returned by the registry.
     pub updated_at: String,
-    /// Agent that owns the operation. Mirrors `GovernanceEvent.agent_id`
-    /// so a single agent's live-ops can be filtered without joining
-    /// against the audit channel.
-    pub agent_id: String,
 }
 
 #[cfg(test)]
@@ -333,13 +333,13 @@ mod tests {
             op_id: "trace-abc:span-1".into(),
             state: aa_gateway::ops::OpState::Running,
             updated_at: "2026-05-20T15:30:00Z".into(),
-            agent_id: "agent-7".into(),
         };
         let json = serde_json::to_value(&payload).unwrap();
         assert_eq!(json["op_id"], "trace-abc:span-1");
         assert_eq!(json["state"], "running");
         assert_eq!(json["updated_at"], "2026-05-20T15:30:00Z");
-        assert_eq!(json["agent_id"], "agent-7");
+        // Agent attribution travels on the outer GovernanceEvent, not the payload.
+        assert!(!json.as_object().unwrap().contains_key("agent_id"));
     }
 
     #[test]
@@ -348,7 +348,6 @@ mod tests {
             op_id: "t1:s2".into(),
             state: aa_gateway::ops::OpState::Completing,
             updated_at: "2026-05-20T16:00:00Z".into(),
-            agent_id: "agent-9".into(),
         };
         let json = serde_json::to_string(&original).unwrap();
         let decoded: OpsChangePayload = serde_json::from_str(&json).unwrap();
@@ -370,7 +369,6 @@ mod tests {
                 op_id: "t:s".into(),
                 state,
                 updated_at: "2026-05-20T00:00:00Z".into(),
-                agent_id: "agent-1".into(),
             };
             let json = serde_json::to_value(&payload).unwrap();
             assert!(json["state"].is_string(), "state serialised as string for {state:?}");
@@ -380,13 +378,12 @@ mod tests {
     #[test]
     fn event_payload_dispatches_ops_change_through_untagged_decode() {
         // The untagged enum must distinguish OpsChangePayload from sibling
-        // payloads by field shape alone — op_id + state + updated_at +
-        // agent_id is the unique combination.
+        // payloads by field shape alone — op_id + state + updated_at is
+        // the unique combination among the four variants.
         let raw = serde_json::json!({
             "op_id": "t1:s1",
             "state": "paused",
-            "updated_at": "2026-05-20T16:00:00Z",
-            "agent_id": "agent-3"
+            "updated_at": "2026-05-20T16:00:00Z"
         });
         let decoded: EventPayload = serde_json::from_value(raw).unwrap();
         let EventPayload::OpsChange(p) = decoded else {

--- a/aa-api/tests/event_type_filter.rs
+++ b/aa-api/tests/event_type_filter.rs
@@ -5,16 +5,17 @@ use aa_api::models::EventType;
 #[test]
 fn parse_filter_none_returns_all_types() {
     let types = EventType::parse_filter(None);
-    assert_eq!(types.len(), 3);
+    assert_eq!(types.len(), 4);
     assert!(types.contains(&EventType::Violation));
     assert!(types.contains(&EventType::Approval));
     assert!(types.contains(&EventType::Budget));
+    assert!(types.contains(&EventType::OpsChange));
 }
 
 #[test]
 fn parse_filter_empty_string_returns_all_types() {
     let types = EventType::parse_filter(Some(""));
-    assert_eq!(types.len(), 3);
+    assert_eq!(types.len(), 4);
 }
 
 #[test]

--- a/aa-api/tests/ws_streaming.rs
+++ b/aa-api/tests/ws_streaming.rs
@@ -307,6 +307,7 @@ async fn ws_cli_logs_follow_integration() {
         EventType::Violation => 0,
         EventType::Approval => 1,
         EventType::Budget => 2,
+        EventType::OpsChange => 3,
     });
     assert_eq!(
         received_types,

--- a/aa-integration-tests/tests/api_ws.rs
+++ b/aa-integration-tests/tests/api_ws.rs
@@ -252,6 +252,7 @@ async fn ws_no_filter_delivers_all_event_types() {
         EventType::Violation => 0,
         EventType::Approval => 1,
         EventType::Budget => 2,
+        EventType::OpsChange => 3,
     });
     assert_eq!(
         received_types,

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -1982,14 +1982,12 @@ export interface components {
          *     Actual emission on registry transitions ships in PR-H. PR-B only
          *     defines the payload shape so PR-C (dashboard rework) and PR-H
          *     (gateway emission) can build against a stable schema in parallel.
+         *
+         *     Agent attribution travels on the enclosing
+         *     [`super::event::GovernanceEvent::agent_id`] — same convention as
+         *     `ViolationPayload`, `ApprovalPayload`, and `BudgetAlertPayload`.
          */
         OpsChangePayload: {
-            /**
-             * @description Agent that owns the operation. Mirrors `GovernanceEvent.agent_id`
-             *     so a single agent's live-ops can be filtered without joining
-             *     against the audit channel.
-             */
-            agent_id: string;
             /**
              * @description Stable operation identifier — `"{trace_id}:{span_id}"` composed
              *     in the gateway. The dashboard keys its row map by this value so

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -1798,8 +1798,9 @@ export interface components {
          *     - `"violation"` → [`ViolationPayload`]
          *     - `"approval"` → [`ApprovalPayload`]
          *     - `"budget"` → [`BudgetAlertPayload`]
+         *     - `"ops_change"` → [`OpsChangePayload`]
          */
-        EventPayload: components["schemas"]["ViolationPayload"] | components["schemas"]["ApprovalPayload"] | components["schemas"]["BudgetAlertPayload"];
+        EventPayload: components["schemas"]["ViolationPayload"] | components["schemas"]["ApprovalPayload"] | components["schemas"]["BudgetAlertPayload"] | components["schemas"]["OpsChangePayload"];
         /**
          * @description Classification of governance events for client-side filtering.
          *
@@ -1807,7 +1808,7 @@ export interface components {
          *     query parameter to receive only matching events on the WebSocket.
          * @enum {string}
          */
-        EventType: "violation" | "approval" | "budget";
+        EventType: "violation" | "approval" | "budget" | "ops_change";
         GenerateApiKeyRequest: {
             label: string;
             scopes: components["schemas"]["ApiKeyScopeResponse"][];
@@ -1968,6 +1969,47 @@ export interface components {
          * @enum {string}
          */
         OpState: "pending" | "running" | "paused" | "completing" | "terminated";
+        /**
+         * @description Payload for `event_type: "ops_change"` events.
+         *
+         *     Emitted on every transition of an in-flight operation in the
+         *     gateway-side [`aa_gateway::ops::OpsRegistry`] (AAASM-1422 PR-B).
+         *     The dashboard's `useLiveOpsStream` hook correlates rows by `op_id`
+         *     (composed from `trace_id:span_id`) and updates the matching row in
+         *     place, so a `pause` followed by the confirming `paused` event
+         *     auto-clears any optimistic override.
+         *
+         *     Actual emission on registry transitions ships in PR-H. PR-B only
+         *     defines the payload shape so PR-C (dashboard rework) and PR-H
+         *     (gateway emission) can build against a stable schema in parallel.
+         */
+        OpsChangePayload: {
+            /**
+             * @description Agent that owns the operation. Mirrors `GovernanceEvent.agent_id`
+             *     so a single agent's live-ops can be filtered without joining
+             *     against the audit channel.
+             */
+            agent_id: string;
+            /**
+             * @description Stable operation identifier — `"{trace_id}:{span_id}"` composed
+             *     in the gateway. The dashboard keys its row map by this value so
+             *     successive `ops_change` events for the same op merge into one
+             *     row instead of stacking.
+             */
+            op_id: string;
+            /**
+             * @description New lifecycle state after the transition. Mirrors the
+             *     `aa_gateway::ops::OpState` enum (snake_case wire format:
+             *     `pending` / `running` / `paused` / `completing` / `terminated`).
+             * @example running
+             */
+            state: string;
+            /**
+             * @description RFC 3339 UTC timestamp of the transition. Same value as the
+             *     matching `OpRecord.updated_at` returned by the registry.
+             */
+            updated_at: string;
+        };
         /**
          * @description A recorded capability override entry returned by
          *     `GET /api/v1/capability/override`.

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -3423,18 +3423,15 @@ components:
         Actual emission on registry transitions ships in PR-H. PR-B only
         defines the payload shape so PR-C (dashboard rework) and PR-H
         (gateway emission) can build against a stable schema in parallel.
+
+        Agent attribution travels on the enclosing
+        [`super::event::GovernanceEvent::agent_id`] — same convention as
+        `ViolationPayload`, `ApprovalPayload`, and `BudgetAlertPayload`.
       required:
       - op_id
       - state
       - updated_at
-      - agent_id
       properties:
-        agent_id:
-          type: string
-          description: |-
-            Agent that owns the operation. Mirrors `GovernanceEvent.agent_id`
-            so a single agent's live-ops can be filtered without joining
-            against the audit channel.
         op_id:
           type: string
           description: |-

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -3127,6 +3127,8 @@ components:
         description: Approval request event payload.
       - $ref: '#/components/schemas/BudgetAlertPayload'
         description: Budget threshold alert payload.
+      - $ref: '#/components/schemas/OpsChangePayload'
+        description: In-flight ops registry state-transition payload (AAASM-1422 PR-B).
       description: |-
         Discriminated union of all possible `GovernanceEvent.payload` shapes.
 
@@ -3134,6 +3136,7 @@ components:
         - `"violation"` → [`ViolationPayload`]
         - `"approval"` → [`ApprovalPayload`]
         - `"budget"` → [`BudgetAlertPayload`]
+        - `"ops_change"` → [`OpsChangePayload`]
     EventType:
       type: string
       description: |-
@@ -3145,6 +3148,7 @@ components:
       - violation
       - approval
       - budget
+      - ops_change
     GenerateApiKeyRequest:
       type: object
       required:
@@ -3404,6 +3408,52 @@ components:
       - paused
       - completing
       - terminated
+    OpsChangePayload:
+      type: object
+      description: |-
+        Payload for `event_type: "ops_change"` events.
+
+        Emitted on every transition of an in-flight operation in the
+        gateway-side [`aa_gateway::ops::OpsRegistry`] (AAASM-1422 PR-B).
+        The dashboard's `useLiveOpsStream` hook correlates rows by `op_id`
+        (composed from `trace_id:span_id`) and updates the matching row in
+        place, so a `pause` followed by the confirming `paused` event
+        auto-clears any optimistic override.
+
+        Actual emission on registry transitions ships in PR-H. PR-B only
+        defines the payload shape so PR-C (dashboard rework) and PR-H
+        (gateway emission) can build against a stable schema in parallel.
+      required:
+      - op_id
+      - state
+      - updated_at
+      - agent_id
+      properties:
+        agent_id:
+          type: string
+          description: |-
+            Agent that owns the operation. Mirrors `GovernanceEvent.agent_id`
+            so a single agent's live-ops can be filtered without joining
+            against the audit channel.
+        op_id:
+          type: string
+          description: |-
+            Stable operation identifier — `"{trace_id}:{span_id}"` composed
+            in the gateway. The dashboard keys its row map by this value so
+            successive `ops_change` events for the same op merge into one
+            row instead of stacking.
+        state:
+          type: string
+          description: |-
+            New lifecycle state after the transition. Mirrors the
+            `aa_gateway::ops::OpState` enum (snake_case wire format:
+            `pending` / `running` / `paused` / `completing` / `terminated`).
+          example: running
+        updated_at:
+          type: string
+          description: |-
+            RFC 3339 UTC timestamp of the transition. Same value as the
+            matching `OpRecord.updated_at` returned by the registry.
     OverrideRecord:
       type: object
       description: |-


### PR DESCRIPTION
## Description

PR-B of [AAASM-1422](https://lightning-dust-mite.atlassian.net/browse/AAASM-1422). Adds the WebSocket event type and typed payload schema for in-flight ops state transitions, so PR-C (dashboard id-model rework) and PR-H (gateway emission) can build against a stable wire format in parallel.

Three orthogonal pieces:

1. **`EventType::OpsChange` variant** (snake_case `ops_change`) — new fourth value alongside `Violation`/`Approval`/`Budget`. The two existing exhaustive matches on `EventType` (in `aa-api/tests/ws_streaming.rs` and `aa-integration-tests/tests/api_ws.rs` sort-by-key helpers) are updated in the same commit to keep bisectability.
2. **`OpsChangePayload`** struct — `{op_id, state, updated_at, agent_id}` with `ToSchema` so OpenAPI surfaces it. Re-uses `aa_gateway::ops::OpState` directly so the dashboard sees the same five-state enum everywhere (registry endpoints + WS payload + OpenAPI).
3. **`EventPayload::OpsChange(OpsChangePayload)` arm** in the untagged discriminated union so the generated TS types include the payload in `EventPayload`.

Plus `EventType::parse_filter` learns the `"ops_change"` filter string and includes `OpsChange` in the empty-filter default — back-compat for existing `?types=` consumers.

### Scope boundary

PR-B adds the event *type*, the *payload schema*, and the *filter parsing*. The actual emission on registry transitions ships in PR-H ([AAASM-1657](https://lightning-dust-mite.atlassian.net/browse/AAASM-1657)). I dropped the `GovernanceEvent::ops_change(...)` constructor I had originally sketched in the starting comment — adding a constructor only for one variant would be inconsistent with the existing pattern (no other variants have constructors). PR-H can construct inline.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change (OpenAPI + dashboard schema regen)
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Pure additive on the wire — existing `violation`/`approval`/`budget` events serialise identically. Default `parse_filter` now includes `OpsChange`, which means a legacy client passing no `?types=` filter will start receiving `ops_change` events once PR-H wires emission. The dashboard ignores unknown event types until PR-C handles them properly; CLI consumers similarly.

## Related Issues

- Related Jira ticket: [AAASM-1651](https://lightning-dust-mite.atlassian.net/browse/AAASM-1651) (parent: AAASM-1422)
- Dependency for: [AAASM-1652](https://lightning-dust-mite.atlassian.net/browse/AAASM-1652) (PR-C dashboard rework), [AAASM-1657](https://lightning-dust-mite.atlassian.net/browse/AAASM-1657) (PR-H emission)

## Testing

- [x] Unit tests added / updated — 9 new cases inline in `event_type.rs` and `ws_payloads.rs`
- [x] Integration tests added / updated — 2 cases in `aa-api/tests/event_type_filter.rs` updated for 4-type default
- [ ] Manual testing performed
- [ ] No tests required

### Local gates

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | ✅ |
| `cargo clippy --workspace --all-targets --all-features --exclude aa-ebpf -- -D warnings` | ✅ |
| `cargo nextest run -p aa-api` | ✅ all aa-api tests pass |
| `cargo nextest run -p aa-api --test event_type_filter` | ✅ **7 / 7** |
| `cargo nextest run -p aa-api --lib models::` (covers the 9 new unit tests) | ✅ |
| `pnpm type-check` (dashboard) | ✅ |
| `pnpm lint` (dashboard) | ✅ |
| `pnpm test --run` (dashboard) | ✅ **940 / 940** across 109 files |

### Pre-existing flake note

`aa-integration-tests::cli_proxy::proxy_logs_follow_streams_new_entries` is timing-sensitive (700ms sleep then asserts) and fails inconsistently on my local machine even against clean master. Pass in CI when scheduling is more deterministic. Not related to this PR's changes.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (architecture doc §7 already references the payload shape from PR-A)
- [ ] All CI checks passing (pending)
- [x] Commits are small and follow the Gitmoji convention

### Commits (8 granular)

1. ✨ `(aa-api/models)` Add OpsChange variant to EventType enum
2. ✨ `(aa-api/models)` Recognise "ops_change" in EventType::parse_filter
3. ✨ `(aa-api/models)` Add OpsChangePayload struct for ws_payloads
4. ✨ `(aa-api/models)` Add OpsChange variant to EventPayload union
5. ✅ `(aa-api/models)` Add unit tests for OpsChangePayload + parse_filter
6. 🔧 `(openapi)` Regenerate v1.yaml for OpsChange event variant
7. 🔧 `(dashboard/api)` Regenerate schema.d.ts for OpsChange event variant
8. ✅ `(aa-api/tests)` Update event_type_filter for 4-type default

[AAASM-1422]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1657]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ