### PR TITLE
[AAASM-1674] ✨ (approvals): Add expired-approvals state + WS expired handling

### DIFF
--- a/dashboard/src/features/approvals/useApprovalsStream.test.tsx
+++ b/dashboard/src/features/approvals/useApprovalsStream.test.tsx
@@ -1,0 +1,123 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MockWebSocket, resetMockWebSockets } from '../../test/mockWebSocket'
+import type { Approval } from './api'
+import { useApprovalsStream } from './useApprovalsStream'
+
+beforeEach(() => {
+  resetMockWebSockets()
+  vi.stubGlobal('WebSocket', MockWebSocket)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function makeApproval(id: string, overrides: Partial<Approval> = {}): Approval {
+  return {
+    id,
+    agent_id: 'agent-1',
+    action: 'send_email',
+    reason: 'r',
+    status: 'pending',
+    created_at: '2026-05-20T12:00:00Z',
+    expires_at: '2026-05-20T12:01:00Z',
+    routing_status: null,
+    team_id: null,
+    ...overrides,
+  }
+}
+
+function setup(initial: Approval[] = []) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  queryClient.setQueryData<Approval[]>(['approvals'], initial)
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+  const { result } = renderHook(() => useApprovalsStream(), { wrapper })
+  return { queryClient, result }
+}
+
+describe('useApprovalsStream WS handler', () => {
+  it('moves a matching active row to expired on payload.status=expired', () => {
+    const a1 = makeApproval('req-1')
+    const { queryClient } = setup([a1])
+
+    act(() => { MockWebSocket.instances[0].open() })
+    act(() => {
+      MockWebSocket.instances[0].emit({
+        event_type: 'approval',
+        agent_id: 'agent-1',
+        timestamp: '2026-05-20T12:01:00Z',
+        payload: {
+          request_id: 'req-1',
+          action: 'send_email',
+          condition_triggered: 'r',
+          status: 'expired',
+          submitted_at: 1716206400,
+          timeout_secs: 60,
+          expires_at: 1716206460,
+        },
+      })
+    })
+
+    expect(queryClient.getQueryData<Approval[]>(['approvals'])).toEqual([])
+    expect(queryClient.getQueryData<Approval[]>(['approvals', 'expired']))
+      .toEqual([{ ...a1, status: 'expired' }])
+  })
+
+  it('no-ops on expired event for an id not in the active list', () => {
+    const a1 = makeApproval('req-1')
+    const { queryClient } = setup([a1])
+
+    act(() => { MockWebSocket.instances[0].open() })
+    act(() => {
+      MockWebSocket.instances[0].emit({
+        event_type: 'approval',
+        agent_id: 'agent-1',
+        timestamp: '2026-05-20T12:01:00Z',
+        payload: {
+          request_id: 'unknown-id',
+          action: 'send_email',
+          condition_triggered: 'r',
+          status: 'expired',
+          submitted_at: 1716206400,
+          timeout_secs: 60,
+          expires_at: 1716206460,
+        },
+      })
+    })
+
+    expect(queryClient.getQueryData<Approval[]>(['approvals'])).toEqual([a1])
+    expect(queryClient.getQueryData<Approval[]>(['approvals', 'expired'])).toBeUndefined()
+  })
+
+  it('still injects pending frames into the active list (no regression)', () => {
+    const { queryClient } = setup([])
+
+    act(() => { MockWebSocket.instances[0].open() })
+    act(() => {
+      MockWebSocket.instances[0].emit({
+        event_type: 'approval',
+        agent_id: 'agent-7',
+        timestamp: '2026-05-20T12:00:00Z',
+        payload: {
+          request_id: 'req-new',
+          action: 'write_file',
+          condition_triggered: 'sensitive_path',
+          status: 'pending',
+          submitted_at: 1716206400,
+          timeout_secs: 60,
+          expires_at: 1716206460,
+        },
+      })
+    })
+
+    const active = queryClient.getQueryData<Approval[]>(['approvals'])
+    expect(active).toHaveLength(1)
+    expect(active?.[0].id).toBe('req-new')
+    expect(active?.[0].status).toBe('pending')
+  })
+})

--- a/dashboard/src/features/approvals/useApprovalsStream.ts
+++ b/dashboard/src/features/approvals/useApprovalsStream.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import type { Approval } from './api'
+import { expireApproval } from './useExpiredApprovals'
 import type { components } from '../../api/generated/schema'
 
 type GovernanceEvent = components['schemas']['GovernanceEvent']
@@ -47,6 +48,15 @@ export function useApprovalsStream(): { connected: boolean } {
           const event = JSON.parse(evt.data as string) as GovernanceEvent
           if (event.event_type !== 'approval') return
           const payload = event.payload as ApprovalPayload
+
+          // AAASM-1453 expired event — move the matching row out of the
+          // active list into the Expired section. The dispatcher silently
+          // no-ops when the id isn't in the active cache (stale event).
+          if (payload.status === 'expired') {
+            expireApproval(queryClient, payload.request_id)
+            return
+          }
+
           const incoming: Approval = {
             id: payload.request_id,
             agent_id: event.agent_id,

--- a/dashboard/src/features/approvals/useExpiredApprovals.test.tsx
+++ b/dashboard/src/features/approvals/useExpiredApprovals.test.tsx
@@ -1,0 +1,81 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { act, renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { describe, it, expect } from 'vitest'
+import type { Approval } from './api'
+import { expireApproval, useExpiredApprovals } from './useExpiredApprovals'
+
+function makeApproval(id: string): Approval {
+  return {
+    id,
+    agent_id: 'agent-1',
+    action: 'send_email',
+    reason: 'r',
+    status: 'pending',
+    created_at: '2026-05-20T12:00:00Z',
+    expires_at: '2026-05-20T12:01:00Z',
+    routing_status: null,
+    team_id: null,
+  }
+}
+
+function setup(initial: Approval[] = []) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  queryClient.setQueryData<Approval[]>(['approvals'], initial)
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  )
+  const { result } = renderHook(() => useExpiredApprovals(), { wrapper })
+  return { queryClient, result }
+}
+
+describe('useExpiredApprovals', () => {
+  it('starts with an empty expired list', () => {
+    const { result } = setup()
+    expect(result.current.expired).toEqual([])
+  })
+
+  it('moves a matching row out of the active cache and into the expired list', () => {
+    const a1 = makeApproval('a1')
+    const a2 = makeApproval('a2')
+    const { queryClient, result } = setup([a1, a2])
+
+    act(() => { result.current.expire('a1') })
+
+    expect(queryClient.getQueryData<Approval[]>(['approvals'])).toEqual([a2])
+    expect(result.current.expired).toEqual([{ ...a1, status: 'expired' }])
+  })
+
+  it('is idempotent — calling expire twice does not duplicate', () => {
+    const a1 = makeApproval('a1')
+    const { result } = setup([a1])
+
+    act(() => { result.current.expire('a1') })
+    act(() => { result.current.expire('a1') })
+
+    expect(result.current.expired).toHaveLength(1)
+  })
+
+  it('no-ops when the id is not in the active list (stale event)', () => {
+    const a1 = makeApproval('a1')
+    const { queryClient, result } = setup([a1])
+
+    act(() => { result.current.expire('not-here') })
+
+    expect(queryClient.getQueryData<Approval[]>(['approvals'])).toEqual([a1])
+    expect(result.current.expired).toEqual([])
+  })
+
+  it('module-level expireApproval works without the hook (WS handler path)', () => {
+    const a1 = makeApproval('a1')
+    const a2 = makeApproval('a2')
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    queryClient.setQueryData<Approval[]>(['approvals'], [a1, a2])
+
+    expireApproval(queryClient, 'a2')
+
+    expect(queryClient.getQueryData<Approval[]>(['approvals'])).toEqual([a1])
+    expect(queryClient.getQueryData<Approval[]>(['approvals', 'expired']))
+      .toEqual([{ ...a2, status: 'expired' }])
+  })
+})

--- a/dashboard/src/features/approvals/useExpiredApprovals.ts
+++ b/dashboard/src/features/approvals/useExpiredApprovals.ts
@@ -1,0 +1,52 @@
+import { useSyncExternalStore } from 'react'
+import { useQueryClient, type QueryClient } from '@tanstack/react-query'
+import type { Approval } from './api'
+
+const EXPIRED_KEY = ['approvals', 'expired'] as const
+const ACTIVE_KEY = ['approvals'] as const
+const EMPTY: Approval[] = []
+
+// Imperative dispatcher — usable from non-React contexts (the WS handler in
+// `useApprovalsStream`) and from React event handlers (the `onExpire` callback
+// of `ApprovalCountdown`). Both paths converge here, satisfying the parent
+// AAASM-1478 requirement that the two triggers result in the same state update.
+//
+// Removes the row from the active `['approvals']` cache and appends it (with
+// status flipped to `'expired'`) to the client-only `['approvals','expired']`
+// cache. Idempotent — calling twice with the same id does not duplicate.
+export function expireApproval(qc: QueryClient, id: string): void {
+  const active = qc.getQueryData<Approval[]>([...ACTIVE_KEY]) ?? []
+  const row = active.find((a) => a.id === id)
+  if (!row) {
+    // No-op when the WS event references a row we don't have (page-load race,
+    // already-decided row, etc.). Avoids spurious entries in the expired list.
+    return
+  }
+  qc.setQueryData<Approval[]>([...ACTIVE_KEY], active.filter((a) => a.id !== id))
+  qc.setQueryData<Approval[]>([...EXPIRED_KEY], (prev) => {
+    const existing = prev ?? []
+    if (existing.some((a) => a.id === id)) return existing
+    return [...existing, { ...row, status: 'expired' }]
+  })
+}
+
+export function useExpiredApprovals(): { expired: Approval[]; expire: (id: string) => void } {
+  const qc = useQueryClient()
+  const expiredHash = JSON.stringify(EXPIRED_KEY)
+
+  const expired = useSyncExternalStore(
+    (callback) => {
+      const unsubscribe = qc.getQueryCache().subscribe((event) => {
+        if (event.query.queryHash === expiredHash) callback()
+      })
+      return unsubscribe
+    },
+    () => qc.getQueryData<Approval[]>([...EXPIRED_KEY]) ?? EMPTY,
+    () => EMPTY,
+  )
+
+  return {
+    expired,
+    expire: (id: string) => expireApproval(qc, id),
+  }
+}


### PR DESCRIPTION
## Description

S2 of the AAASM-1478 dashboard work — auto-expire countdown + collapsible Expired section.

Adds the shared client-side state that both expiration trigger paths converge on, plus the WebSocket handler change that routes `payload.status="expired"` through it. The UI consumer (`ExpiredApprovalsSection`) lands in S3 (AAASM-1675).

### Architecture

The hook intentionally exposes both an imperative module-level dispatcher (`expireApproval(queryClient, id)`) for the WS handler — which doesn't have a hook scope — and a React-flavoured `useExpiredApprovals()` for components. Both mutate the same `['approvals', 'expired']` React-Query cache; consumers subscribe via `useSyncExternalStore` over the cache subscription so re-renders fire from either trigger.

**Commits**
1. `✨ (approvals): Add useExpiredApprovals hook + dispatcher`
2. `✅ (approvals): Add vitest for useExpiredApprovals`
3. `✨ (approvals): Route WS payload.status='expired' through expireApproval`
4. `✅ (approvals): Add vitest for WS-driven expire path`

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1674 (parent AAASM-1478)
- Builds on backend AAASM-1453 (`payload.status: "expired"`)
- Sibling PR: AAASM-1673 (#620, countdown component)

## Testing

- [x] Unit tests added (5 hook cases + 3 WS handler cases)
- [x] Regression net for existing `pending` injection path
- [x] Full suite: 948 tests pass locally (`pnpm test --run`)

## Checklist

- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean
- [x] Self-review of the diff completed
- [x] No spurious entries possible — dispatcher no-ops on unknown ids
- [x] Idempotent on repeated expire calls (covered by test)