### PR TITLE
[AAASM-1675] ✨ (approvals): Add ExpiredApprovalsSection + ApprovalsPage wire-in

### DIFF
--- a/dashboard/src/features/approvals/ExpiredApprovalsSection.test.tsx
+++ b/dashboard/src/features/approvals/ExpiredApprovalsSection.test.tsx
@@ -1,0 +1,64 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import type { Approval } from './api'
+import { ExpiredApprovalsSection } from './ExpiredApprovalsSection'
+
+function makeApproval(id: string): Approval {
+  return {
+    id,
+    agent_id: `agent-${id}`,
+    action: 'send_email',
+    reason: 'r',
+    status: 'expired',
+    created_at: '2026-05-20T12:00:00Z',
+    expires_at: '2026-05-20T12:01:00Z',
+    routing_status: null,
+    team_id: null,
+  }
+}
+
+describe('ExpiredApprovalsSection', () => {
+  it('renders nothing when there are no expired rows', () => {
+    const { container } = render(<ExpiredApprovalsSection rows={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders default-collapsed with a count badge', () => {
+    render(<ExpiredApprovalsSection rows={[makeApproval('a1'), makeApproval('a2')]} />)
+    expect(screen.getByTestId('expired-approvals-section')).toBeInTheDocument()
+    expect(screen.getByTestId('expired-count-badge')).toHaveTextContent('2')
+    expect(screen.queryByTestId('expired-approvals-table')).not.toBeInTheDocument()
+    expect(screen.getByTestId('expired-toggle')).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('expands the table on toggle click and shows all rows', () => {
+    render(<ExpiredApprovalsSection rows={[makeApproval('a1'), makeApproval('a2')]} />)
+    fireEvent.click(screen.getByTestId('expired-toggle'))
+    expect(screen.getByTestId('expired-approvals-table')).toBeInTheDocument()
+    expect(screen.getAllByTestId('expired-row')).toHaveLength(2)
+    expect(screen.getByTestId('expired-toggle')).toHaveAttribute('aria-expanded', 'true')
+  })
+
+  it('does not render Approve or Reject buttons in the expired table', () => {
+    render(<ExpiredApprovalsSection rows={[makeApproval('a1')]} />)
+    fireEvent.click(screen.getByTestId('expired-toggle'))
+    expect(screen.queryByTestId('approve-btn')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('reject-btn')).not.toBeInTheDocument()
+  })
+
+  it('greys out the expanded table', () => {
+    render(<ExpiredApprovalsSection rows={[makeApproval('a1')]} />)
+    fireEvent.click(screen.getByTestId('expired-toggle'))
+    const table = screen.getByTestId('expired-approvals-table') as HTMLElement
+    expect(table.style.opacity).toBe('0.65')
+    expect(table.style.color).toBe('var(--ink-3)')
+  })
+
+  it('collapses again on second toggle click', () => {
+    render(<ExpiredApprovalsSection rows={[makeApproval('a1')]} />)
+    fireEvent.click(screen.getByTestId('expired-toggle'))
+    expect(screen.getByTestId('expired-approvals-table')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('expired-toggle'))
+    expect(screen.queryByTestId('expired-approvals-table')).not.toBeInTheDocument()
+  })
+})

--- a/dashboard/src/features/approvals/ExpiredApprovalsSection.tsx
+++ b/dashboard/src/features/approvals/ExpiredApprovalsSection.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react'
+import { ApprovalRoutingBadge } from '../../components/ApprovalRoutingBadge'
+import type { Approval } from './api'
+
+interface ExpiredApprovalsSectionProps {
+  rows: Approval[]
+}
+
+export function ExpiredApprovalsSection({ rows }: ExpiredApprovalsSectionProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  if (rows.length === 0) return null
+
+  return (
+    <section data-testid="expired-approvals-section" style={{ marginTop: '1rem' }}>
+      <button
+        data-testid="expired-toggle"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((v) => !v)}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: '0.5rem',
+          width: '100%',
+          padding: '0.5rem 0.75rem',
+          background: 'var(--paper-3)',
+          border: '1px solid var(--line)',
+          borderRadius: '0.375rem',
+          cursor: 'pointer',
+          fontSize: '0.875rem',
+          color: 'var(--ink-2)',
+          textAlign: 'left',
+        }}
+      >
+        <span style={{ fontWeight: 600 }}>{expanded ? '▾' : '▸'} Expired</span>
+        <span
+          data-testid="expired-count-badge"
+          style={{
+            display: 'inline-block',
+            padding: '0 0.5rem',
+            background: 'var(--ink-4)',
+            color: 'var(--paper-2)',
+            borderRadius: '9999px',
+            fontSize: '0.75rem',
+            fontWeight: 600,
+          }}
+        >
+          {rows.length}
+        </span>
+      </button>
+
+      {expanded && (
+        <table
+          className="approvals-table"
+          data-testid="expired-approvals-table"
+          style={{ marginTop: '0.5rem', opacity: 0.65, color: 'var(--ink-3)' }}
+        >
+          <thead>
+            <tr>
+              <th>Agent</th>
+              <th>Action</th>
+              <th>Reason</th>
+              <th>Routing</th>
+              <th>Requested at</th>
+              <th>Expired at</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.id} data-testid="expired-row">
+                <td className="approvals-table__id">{row.agent_id}</td>
+                <td>{row.action}</td>
+                <td>{row.reason}</td>
+                <td>
+                  {row.routing_status
+                    ? <ApprovalRoutingBadge routingStatus={row.routing_status} />
+                    : <span className="approvals-table__unrouted">—</span>}
+                </td>
+                <td>{row.created_at}</td>
+                <td>{row.expires_at}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  )
+}

--- a/dashboard/src/pages/ApprovalsPage.test.tsx
+++ b/dashboard/src/pages/ApprovalsPage.test.tsx
@@ -1,6 +1,6 @@
 // Smoke tests for the refactored ApprovalsPage.
 // Comprehensive feature tests live in src/features/approvals/api.test.tsx.
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { act, render, screen, waitFor, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { vi } from 'vitest'
@@ -35,6 +35,23 @@ function Wrapper({ children }: { children: React.ReactNode }) {
       </ToastProvider>
     </QueryClientProvider>
   )
+}
+
+function seededWrapper(approvals: Approval[]) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  client.setQueryData<Approval[]>(['approvals'], approvals)
+  return {
+    client,
+    Wrapper({ children }: { children: React.ReactNode }) {
+      return (
+        <QueryClientProvider client={client}>
+          <ToastProvider>
+            <MemoryRouter>{children}</MemoryRouter>
+          </ToastProvider>
+        </QueryClientProvider>
+      )
+    },
+  }
 }
 
 const MOCK_APPROVAL: Approval = {
@@ -126,5 +143,39 @@ describe('ApprovalsPage', () => {
 
     fireEvent.click(screen.getByTestId('row-checkbox'))
     expect(screen.queryByTestId('approval-detail-row')).not.toBeInTheDocument()
+  })
+
+  it('moves an already-expired row to the Expired section on initial render', async () => {
+    const PAST = new Date(Date.now() - 60_000).toISOString()
+    const expiredApproval: Approval = { ...MOCK_APPROVAL, expires_at: PAST }
+    setupMocks([expiredApproval])
+    const { Wrapper: SeededWrapper, client } = seededWrapper([expiredApproval])
+
+    render(<ApprovalsPage />, { wrapper: SeededWrapper })
+
+    // The shared cache (the production source of truth for the active list)
+    // no longer contains the row; the expired cache holds it instead.
+    await waitFor(() => {
+      const active = client.getQueryData<Approval[]>(['approvals'])
+      expect(active).toEqual([])
+    })
+    expect(client.getQueryData<Approval[]>(['approvals', 'expired'])).toEqual([
+      { ...expiredApproval, status: 'expired' },
+    ])
+
+    // And the section UI reflects the same fact via its count badge.
+    expect(await screen.findByTestId('expired-count-badge')).toHaveTextContent('1')
+  })
+
+  it('reveals the expired row when the section is expanded', async () => {
+    const PAST = new Date(Date.now() - 60_000).toISOString()
+    const expiredApproval: Approval = { ...MOCK_APPROVAL, expires_at: PAST }
+    setupMocks([expiredApproval])
+    const { Wrapper: SeededWrapper } = seededWrapper([expiredApproval])
+
+    render(<ApprovalsPage />, { wrapper: SeededWrapper })
+    const toggle = await screen.findByTestId('expired-toggle')
+    act(() => { fireEvent.click(toggle) })
+    expect(screen.getAllByTestId('expired-row')).toHaveLength(1)
   })
 })

--- a/dashboard/src/pages/ApprovalsPage.tsx
+++ b/dashboard/src/pages/ApprovalsPage.tsx
@@ -13,6 +13,7 @@ import {
 import { ApprovalCountdown } from '../features/approvals/ApprovalCountdown'
 import { ApprovalDetailRow } from '../features/approvals/ApprovalDetailRow'
 import { ApprovalsFilterBar } from '../features/approvals/ApprovalsFilterBar'
+import { ExpiredApprovalsSection } from '../features/approvals/ExpiredApprovalsSection'
 import {
   EMPTY_FILTER,
   applyFilter,
@@ -130,7 +131,7 @@ export function ApprovalsPage() {
   const queryClient = useQueryClient()
   const { data: approvals, isLoading, isError, refetch } = useApprovalsQuery()
   const { connected } = useApprovalsStream()
-  const { expire } = useExpiredApprovals()
+  const { expired, expire } = useExpiredApprovals()
   const approveMutation = useApproveAction()
   const rejectMutation = useRejectAction()
   const { toast } = useToast()
@@ -387,6 +388,8 @@ export function ApprovalsPage() {
               </tbody>
             </table>
           )}
+
+          <ExpiredApprovalsSection rows={expired} />
         </>
       )}
 

--- a/dashboard/src/pages/ApprovalsPage.tsx
+++ b/dashboard/src/pages/ApprovalsPage.tsx
@@ -10,6 +10,7 @@ import {
   useRejectAction,
   type Approval,
 } from '../features/approvals/api'
+import { ApprovalCountdown } from '../features/approvals/ApprovalCountdown'
 import { ApprovalDetailRow } from '../features/approvals/ApprovalDetailRow'
 import { ApprovalsFilterBar } from '../features/approvals/ApprovalsFilterBar'
 import {
@@ -19,9 +20,10 @@ import {
   type ApprovalsFilter,
 } from '../features/approvals/filter'
 import { useApprovalsStream } from '../features/approvals/useApprovalsStream'
+import { useExpiredApprovals } from '../features/approvals/useExpiredApprovals'
 import './ApprovalsPage.css'
 
-const APPROVAL_ROW_COL_COUNT = 7
+const APPROVAL_ROW_COL_COUNT = 8
 
 // ── Reject dialog ─────────────────────────────────────────────────────────────
 
@@ -128,6 +130,7 @@ export function ApprovalsPage() {
   const queryClient = useQueryClient()
   const { data: approvals, isLoading, isError, refetch } = useApprovalsQuery()
   const { connected } = useApprovalsStream()
+  const { expire } = useExpiredApprovals()
   const approveMutation = useApproveAction()
   const rejectMutation = useRejectAction()
   const { toast } = useToast()
@@ -303,6 +306,7 @@ export function ApprovalsPage() {
                   <th>Reason</th>
                   <th>Routing</th>
                   <th>Requested at</th>
+                  <th>Expires in</th>
                   <th>Actions</th>
                 </tr>
               </thead>
@@ -310,7 +314,7 @@ export function ApprovalsPage() {
                 {isLoading
                   ? Array.from({ length: 3 }).map((_, i) => (
                     <tr key={i} data-testid="approval-row-skeleton">
-                      {Array.from({ length: 7 }).map((_, j) => (
+                      {Array.from({ length: 8 }).map((_, j) => (
                         <td key={j} style={{ padding: '8px 12px' }}>
                           <span style={{ display: 'block', height: '0.875rem', background: 'var(--line)', borderRadius: '4px' }} />
                         </td>
@@ -347,6 +351,12 @@ export function ApprovalsPage() {
                           : <span className="approvals-table__unrouted">—</span>}
                       </td>
                       <td>{row.created_at}</td>
+                      <td onClick={(e) => e.stopPropagation()}>
+                        <ApprovalCountdown
+                          expiresAt={row.expires_at}
+                          onExpire={() => expire(row.id)}
+                        />
+                      </td>
                       <td style={{ display: 'flex', gap: '0.375rem' }} onClick={(e) => e.stopPropagation()}>
                         <button
                           data-testid="approve-btn"


### PR DESCRIPTION
## Description

S3 of the AAASM-1478 dashboard work — auto-expire countdown + collapsible Expired section.

Lands the visible UI: the **Expires in** column on the pending table (renders `<ApprovalCountdown>` per row) and the collapsible **Expired** section below it (renders rows that have hit zero locally or arrived via a WS expired event).

> **Stacked PR:** this branch is stacked on `#620` (S1, AAASM-1673) and `#622` (S2, AAASM-1674). The diff currently includes those changes too; once they merge, this PR's diff will narrow to S3-only.

**Commits (in this PR, on top of S1+S2):**
1. `✨ (approvals): Add ExpiredApprovalsSection component`
2. `✅ (approvals): Add vitest for ExpiredApprovalsSection`
3. `✨ (approvals): Add Expires-in column to ApprovalsPage pending table`
4. `✨ (approvals): Render ExpiredApprovalsSection on ApprovalsPage`
5. `✅ (approvals): Add vitest covering expire-and-render in ApprovalsPage`

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No — the Approve / Reject column shifts right by one (Expires in is inserted between Requested at and Actions). Skeleton loader and `APPROVAL_ROW_COL_COUNT` updated accordingly.

## Related Issues

- Related Jira ticket: AAASM-1675 (parent AAASM-1478)
- Stacks on: #620 (AAASM-1673), #622 (AAASM-1674)

## Testing

- [x] Unit tests added: 6 cases for `ExpiredApprovalsSection`, 2 integration cases for `ApprovalsPage` covering the dual cache transition (active drained, expired populated) and the section reveal-on-click.
- [x] Full suite: 975 tests pass locally (`pnpm test --run`).

## Checklist

- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean
- [x] Self-review of the diff completed
- [x] Default-collapsed Expired section + count badge + greyed-out rows (per parent AC)
- [x] No Approve/Reject buttons in the Expired table