### PR TITLE
[AAASM-1680] ✅ (aa-integration-tests): Add 3 Rust selftest tests for google_adk fixtures

### DIFF
--- a/aa-integration-tests/tests/e2e_sdk_python.rs
+++ b/aa-integration-tests/tests/e2e_sdk_python.rs
@@ -250,3 +250,27 @@ fn selftest_crewai_root_sub_agent_hierarchy() {
     );
     assert_eq!(events.last().unwrap()["event"], "done");
 }
+
+// ── test 11 ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn selftest_google_adk_single_agent() {
+    let out =
+        run_agent("single_agent/google_adk_agent.py", &[("AA_SELFTEST", "1")]).expect("spawn google_adk_agent.py");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "exit {:?}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        out.status.code()
+    );
+    let events = parse_events(&stdout);
+    assert!(!events.is_empty(), "expected at least one JSON event");
+    assert_eq!(events[0]["event"], "started", "first event must be 'started'");
+    assert_eq!(events[0]["framework"], "google_adk");
+    assert!(
+        events[0].get("agent_id").and_then(|v| v.as_str()).is_some(),
+        "started event must include agent_id"
+    );
+    assert_eq!(events.last().unwrap()["event"], "done", "last event must be 'done'");
+}

--- a/aa-integration-tests/tests/e2e_sdk_python.rs
+++ b/aa-integration-tests/tests/e2e_sdk_python.rs
@@ -300,3 +300,34 @@ fn selftest_google_adk_agent_team_emits_two_started_events() {
     assert_eq!(done["event"], "done");
     assert_eq!(done["agent_count"], 2, "done event must carry agent_count=2");
 }
+
+// ── test 13 ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn selftest_google_adk_root_sub_agent_hierarchy() {
+    let out = run_agent("root_sub_agents/google_adk_hierarchy.py", &[("AA_SELFTEST", "1")])
+        .expect("spawn google_adk_hierarchy.py");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "exit {:?}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        out.status.code()
+    );
+    let events = parse_events(&stdout);
+    let started: Vec<_> = events.iter().filter(|e| e["event"] == "started").collect();
+    assert_eq!(
+        started.len(),
+        2,
+        "hierarchy must emit root + child 'started' events; got {}",
+        started.len()
+    );
+    assert_eq!(started[0]["role"], "root", "first started must be root");
+    assert_eq!(started[1]["role"], "child", "second started must be child");
+    assert_eq!(started[0]["framework"], "google_adk");
+    assert!(
+        started[1].get("parent").and_then(|v| v.as_str()).is_some(),
+        "child started event must include 'parent' field"
+    );
+    assert_eq!(events.last().unwrap()["event"], "done");
+}

--- a/aa-integration-tests/tests/e2e_sdk_python.rs
+++ b/aa-integration-tests/tests/e2e_sdk_python.rs
@@ -274,3 +274,29 @@ fn selftest_google_adk_single_agent() {
     );
     assert_eq!(events.last().unwrap()["event"], "done", "last event must be 'done'");
 }
+
+// ── test 12 ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn selftest_google_adk_agent_team_emits_two_started_events() {
+    let out = run_agent("agent_team/google_adk_team.py", &[("AA_SELFTEST", "1")]).expect("spawn google_adk_team.py");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "exit {:?}\nstdout:\n{stdout}\nstderr:\n{stderr}",
+        out.status.code()
+    );
+    let events = parse_events(&stdout);
+    let started: Vec<_> = events.iter().filter(|e| e["event"] == "started").collect();
+    assert_eq!(
+        started.len(),
+        2,
+        "agent_team must emit exactly 2 'started' events; got {}",
+        started.len()
+    );
+    assert_eq!(started[0]["framework"], "google_adk");
+    let done = events.last().unwrap();
+    assert_eq!(done["event"], "done");
+    assert_eq!(done["agent_count"], 2, "done event must carry agent_count=2");
+}


### PR DESCRIPTION
## Description

Adds three Rust `#[test]` functions to `aa-integration-tests/tests/e2e_sdk_python.rs` driving the new Google ADK fixture scripts (PR #623, AAASM-1679) in selftest mode:

* `selftest_google_adk_single_agent` — asserts first event is `started` with `framework == "google_adk"` and `agent_id`; last event is `done`.
* `selftest_google_adk_agent_team_emits_two_started_events` — asserts exactly 2 `started` events and `agent_count == 2` in `done`.
* `selftest_google_adk_root_sub_agent_hierarchy` — asserts root + child `started` events with `role` + `parent` fields.

Sub-task 4 of AAASM-1550. Stacked on PR #623 (AAASM-1679) — once it merges this PR will show only the new test functions.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release
- [x] ✅ Tests

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1680 (parent: AAASM-1550, epic: AAASM-5)
- Stacked on: #623

## Testing

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required

Local run:

\`\`\`text
$ cargo nextest run -p aa-integration-tests --test e2e_sdk_python selftest_google_adk
PASS  selftest_google_adk_root_sub_agent_hierarchy            [   0.141s]
PASS  selftest_google_adk_single_agent                        [   0.141s]
PASS  selftest_google_adk_agent_team_emits_two_started_events [   0.141s]
Summary [0.142s] 3 tests run: 3 passed
\`\`\`

`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo doc --workspace --no-deps` — all green (lefthook).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [x] All CI checks passing (lefthook green)
- [x] Commits are small and follow the Gitmoji convention (one per test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)