### PR TITLE
[AAASM-1649] ✅ (aa-api/tests): Integration tests for POST /alerts/silence

### DIFF
--- a/aa-api/tests/silence.rs
+++ b/aa-api/tests/silence.rs
@@ -70,6 +70,22 @@ async fn silence_returns_201_and_flips_status_to_suppressed() {
 }
 
 #[tokio::test]
+async fn silence_400_reason_too_long() {
+    let state = common::test_state();
+    let alert_id = seed_alert(&state);
+
+    let long_reason = "x".repeat(501); // 1 over the 500-char cap
+    let resp = post_silence(
+        state,
+        json!({ "alert_id": alert_id, "duration_seconds": 3600, "reason": long_reason }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = body_json(resp).await;
+    assert!(body["detail"].as_str().unwrap_or("").starts_with("reason_too_long:"));
+}
+
+#[tokio::test]
 async fn silence_400_invalid_duration_too_large() {
     let state = common::test_state();
     let alert_id = seed_alert(&state);

--- a/aa-api/tests/silence.rs
+++ b/aa-api/tests/silence.rs
@@ -68,3 +68,18 @@ async fn silence_returns_201_and_flips_status_to_suppressed() {
     assert_eq!(stored.status, "suppressed");
     assert_eq!(stored.prior_status.as_deref(), Some("unresolved"));
 }
+
+#[tokio::test]
+async fn silence_400_invalid_duration_zero() {
+    let state = common::test_state();
+    let alert_id = seed_alert(&state);
+
+    let resp = post_silence(state, json!({ "alert_id": alert_id, "duration_seconds": 0 })).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = body_json(resp).await;
+    assert!(
+        body["detail"].as_str().unwrap_or("").starts_with("invalid_duration:"),
+        "detail must carry invalid_duration code, got {:?}",
+        body["detail"]
+    );
+}

--- a/aa-api/tests/silence.rs
+++ b/aa-api/tests/silence.rs
@@ -70,6 +70,18 @@ async fn silence_returns_201_and_flips_status_to_suppressed() {
 }
 
 #[tokio::test]
+async fn silence_400_invalid_duration_too_large() {
+    let state = common::test_state();
+    let alert_id = seed_alert(&state);
+
+    // 604_801 = 1 second over the 7-day cap.
+    let resp = post_silence(state, json!({ "alert_id": alert_id, "duration_seconds": 604_801 })).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = body_json(resp).await;
+    assert!(body["detail"].as_str().unwrap_or("").starts_with("invalid_duration:"));
+}
+
+#[tokio::test]
 async fn silence_400_invalid_duration_zero() {
     let state = common::test_state();
     let alert_id = seed_alert(&state);

--- a/aa-api/tests/silence.rs
+++ b/aa-api/tests/silence.rs
@@ -70,6 +70,20 @@ async fn silence_returns_201_and_flips_status_to_suppressed() {
 }
 
 #[tokio::test]
+async fn silence_404_alert_not_found() {
+    let state = common::test_state();
+    // No alert seeded; use a syntactically valid but unrecorded ULID.
+    let resp = post_silence(
+        state,
+        json!({ "alert_id": "00000000000000000000000000", "duration_seconds": 3600 }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let body = body_json(resp).await;
+    assert!(body["detail"].as_str().unwrap_or("").starts_with("alert_not_found:"));
+}
+
+#[tokio::test]
 async fn silence_400_reason_too_long() {
     let state = common::test_state();
     let alert_id = seed_alert(&state);

--- a/aa-api/tests/silence.rs
+++ b/aa-api/tests/silence.rs
@@ -1,0 +1,70 @@
+//! Integration tests for `POST /api/v1/alerts/silence` (AAASM-1387 /
+//! AAASM-1649). Each test boots a fresh `test_state()` so they're fully
+//! isolated and parallel-safe.
+
+mod common;
+
+use aa_core::AgentId;
+use aa_gateway::budget::types::BudgetAlert;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::json;
+use tower::ServiceExt;
+
+/// Record one budget alert directly into the test env's store. Used by
+/// every test that needs an existing alert to silence.
+fn seed_alert(state: &aa_api::state::AppState) -> String {
+    state.alert_store.record(&BudgetAlert {
+        agent_id: AgentId::from_bytes([0xAB; 16]),
+        team_id: None,
+        threshold_pct: 80,
+        spent_usd: 8.0,
+        limit_usd: 10.0,
+    })
+}
+
+/// POST a JSON body to /api/v1/alerts/silence and return the response.
+async fn post_silence(state: aa_api::state::AppState, body: serde_json::Value) -> axum::http::Response<Body> {
+    let app = aa_api::server::build_app(state);
+    app.oneshot(
+        Request::builder()
+            .method("POST")
+            .uri("/api/v1/alerts/silence")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap(),
+    )
+    .await
+    .unwrap()
+}
+
+async fn body_json(response: axum::http::Response<Body>) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+#[tokio::test]
+async fn silence_returns_201_and_flips_status_to_suppressed() {
+    let state = common::test_state();
+    let alert_id = seed_alert(&state);
+
+    let resp = post_silence(
+        state.clone(),
+        json!({ "alert_id": alert_id, "duration_seconds": 3600, "reason": "maintenance" }),
+    )
+    .await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let body = body_json(resp).await;
+    assert_eq!(body["alert_id"].as_str(), Some(alert_id.as_str()));
+    assert_eq!(body["reason"].as_str(), Some("maintenance"));
+    assert_eq!(body["created_by"].as_str(), Some("__bypass__"));
+    assert_eq!(body["silence_id"].as_str().unwrap().len(), 26, "silence_id is a ULID");
+    assert!(body["starts_at"].is_string());
+    assert!(body["expires_at"].is_string());
+
+    // Follow-up GET reflects the new suppressed status + prior_status.
+    let stored = state.alert_store.get_by_id(&alert_id).unwrap();
+    assert_eq!(stored.status, "suppressed");
+    assert_eq!(stored.prior_status.as_deref(), Some("unresolved"));
+}

--- a/aa-api/tests/silence.rs
+++ b/aa-api/tests/silence.rs
@@ -70,6 +70,30 @@ async fn silence_returns_201_and_flips_status_to_suppressed() {
 }
 
 #[tokio::test]
+async fn silence_expiry_restores_prior_status() {
+    use aa_api::alerts::silence_watcher;
+    use chrono::{Duration as ChronoDuration, Utc};
+
+    let state = common::test_state();
+    let alert_id = seed_alert(&state);
+
+    // 1 s silence — must be in the past by the time we tick().
+    let resp = post_silence(state.clone(), json!({ "alert_id": alert_id, "duration_seconds": 1 })).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    assert_eq!(state.alert_store.get_by_id(&alert_id).unwrap().status, "suppressed");
+
+    // Skip clock — drive the watcher with a future `now` past expires_at.
+    // No real sleep, fully deterministic.
+    let future = Utc::now() + ChronoDuration::seconds(5);
+    let expired = silence_watcher::tick(state.silence_store.as_ref(), state.alert_store.as_ref(), future);
+    assert_eq!(expired, 1, "watcher must drain the expired silence");
+
+    let restored = state.alert_store.get_by_id(&alert_id).unwrap();
+    assert_eq!(restored.status, "unresolved", "alert must be restored to prior_status");
+    assert!(restored.prior_status.is_none(), "prior_status must be cleared");
+}
+
+#[tokio::test]
 async fn silence_409_alert_already_silenced() {
     let state = common::test_state();
     let alert_id = seed_alert(&state);

--- a/aa-api/tests/silence.rs
+++ b/aa-api/tests/silence.rs
@@ -70,6 +70,36 @@ async fn silence_returns_201_and_flips_status_to_suppressed() {
 }
 
 #[tokio::test]
+async fn silence_emits_alert_event_silence_on_bus() {
+    use aa_api::alerts::AlertEvent;
+    use std::time::Duration;
+
+    let state = common::test_state();
+    let alert_id = seed_alert(&state);
+
+    // Subscribe BEFORE the silence so the Fire event from `seed_alert`
+    // is in the past and the next event we see is the Silence one.
+    let mut rx = state.alert_store.subscribe();
+
+    let resp = post_silence(state.clone(), json!({ "alert_id": alert_id, "duration_seconds": 60 })).await;
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    let event = tokio::time::timeout(Duration::from_millis(200), rx.recv())
+        .await
+        .expect("AlertEvent::Silence must arrive within 200 ms")
+        .expect("bus must deliver an event");
+
+    match event {
+        AlertEvent::Silence(stored) => {
+            assert_eq!(stored.id, alert_id, "event carries the suppressed alert id");
+            assert_eq!(stored.status, "suppressed");
+            assert_eq!(stored.prior_status.as_deref(), Some("unresolved"));
+        }
+        other => panic!("expected AlertEvent::Silence, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn silence_expiry_restores_prior_status() {
     use aa_api::alerts::silence_watcher;
     use chrono::{Duration as ChronoDuration, Utc};

--- a/aa-api/tests/silence.rs
+++ b/aa-api/tests/silence.rs
@@ -70,6 +70,25 @@ async fn silence_returns_201_and_flips_status_to_suppressed() {
 }
 
 #[tokio::test]
+async fn silence_409_alert_already_silenced() {
+    let state = common::test_state();
+    let alert_id = seed_alert(&state);
+
+    // First silence succeeds.
+    let first = post_silence(state.clone(), json!({ "alert_id": alert_id, "duration_seconds": 3600 })).await;
+    assert_eq!(first.status(), StatusCode::CREATED);
+
+    // Second silence on the same alert while the first is still active.
+    let second = post_silence(state, json!({ "alert_id": alert_id, "duration_seconds": 3600 })).await;
+    assert_eq!(second.status(), StatusCode::CONFLICT);
+    let body = body_json(second).await;
+    assert!(body["detail"]
+        .as_str()
+        .unwrap_or("")
+        .starts_with("alert_already_silenced:"));
+}
+
+#[tokio::test]
 async fn silence_404_alert_not_found() {
     let state = common::test_state();
     // No alert seeded; use a syntactically valid but unrecorded ULID.


### PR DESCRIPTION
## Description

Subtask 6 of AAASM-1387. Adds 8 end-to-end integration tests for `POST /api/v1/alerts/silence` (the handler shipped in AAASM-1648) covering the 201 happy path, all four error paths, expiry restoration, and bus emission.

All tests boot a fresh `test_state()` so they're parallel-safe and don't share state. Auth is `AuthMode::Off` in test, so `caller.key_id = "__bypass__"` flows into the `created_by` field.

## Test cases (one commit each, per ticket contract)

| # | Test | Assertion |
|---|---|---|
| 1 | `silence_returns_201_and_flips_status_to_suppressed` | 201 + response body shape + store `status=suppressed`, `prior_status=unresolved` |
| 2 | `silence_400_invalid_duration_zero` | `duration_seconds=0` → 400 `invalid_duration:` |
| 3 | `silence_400_invalid_duration_too_large` | `duration_seconds=604_801` → 400 `invalid_duration:` |
| 4 | `silence_400_reason_too_long` | 501-char `reason` → 400 `reason_too_long:` |
| 5 | `silence_404_alert_not_found` | unknown ULID → 404 `alert_not_found:` |
| 6 | `silence_409_alert_already_silenced` | second POST during active silence → 409 `alert_already_silenced:` |
| 7 | `silence_expiry_restores_prior_status` | drives `silence_watcher::tick(now+5s)` to deterministically restore — no real sleep |
| 8 | `silence_emits_alert_event_silence_on_bus` | subscribes pre-POST, asserts `AlertEvent::Silence(stored)` arrives within 200 ms |

## Type of Change

- [x] ✅ Tests

## Breaking Changes

- [ ] Yes
- [x] No — tests only, no code changes

## Related Issues

- Related Jira ticket: [AAASM-1649](https://lightning-dust-mite.atlassian.net/browse/AAASM-1649) (sub-task of [AAASM-1387](https://lightning-dust-mite.atlassian.net/browse/AAASM-1387))

## Testing

- [x] 8 new integration tests
- [x] `cargo nextest run -p aa-api --test silence` — 8/8 passed locally
- [x] `cargo nextest run -p aa-api` — 501/501 passed locally (+8 vs prior baseline of 493)
- [x] Workspace clippy + fmt clean

## Design notes

- **No real sleep in test 7**: the silence-expiry watcher's `tick()` is a pure function accepting `now: DateTime<Utc>`, so the test drives it directly with `now + 5 s` instead of waiting on the real-time `tokio::time::sleep` inside `spawn_silence_expiry_watcher`. Fully deterministic — no CI clock-drift flakiness.
- **Bus subscription timing in test 8**: subscribes BEFORE the POST so the Fire event from `seed_alert` is in the past and the next event seen by the receiver is the Silence one. broadcast::Receiver only sees events sent after its subscribe() call.

## Commits (granular, 8 — one test per commit)

1. `✅ Add silence integration scaffolding + 201 happy-path test`
2. `✅ Test silence 400 invalid_duration (zero)`
3. `✅ Test silence 400 invalid_duration (over 7d cap)`
4. `✅ Test silence 400 reason_too_long`
5. `✅ Test silence 404 alert_not_found`
6. `✅ Test silence 409 alert_already_silenced`
7. `✅ Test silence expiry restores prior status`
8. `✅ Test silence.applied event emission on AlertStore bus`

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --workspace --all-targets`)
- [x] Self-review of the diff completed
- [x] All CI checks passing locally
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1649]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ