### PR TITLE
[AAASM-1652] ✨ (dashboard/liveOps): Correlate ops by op_id, auto-clear overrides, 5-state model

### DIFF
--- a/dashboard/src/features/liveOps/FilterBar.tsx
+++ b/dashboard/src/features/liveOps/FilterBar.tsx
@@ -30,6 +30,7 @@ const STATUS_LABEL: Record<OperationStatus, string> = {
   pending: 'Pending',
   blocked: 'Blocked',
   completing: 'Completing',
+  terminated: 'Terminated',
 }
 
 /**

--- a/dashboard/src/features/liveOps/OperationRow.tsx
+++ b/dashboard/src/features/liveOps/OperationRow.tsx
@@ -24,6 +24,7 @@ const STATUS_LABEL: Record<OperationStatus, string> = {
   pending: 'PENDING',
   blocked: 'BLOCKED',
   completing: 'COMPLETING',
+  terminated: 'TERMINATED',
 }
 
 const OVERRIDE_LABEL: Record<OperationOverride, string> = {

--- a/dashboard/src/features/liveOps/types.ts
+++ b/dashboard/src/features/liveOps/types.ts
@@ -6,13 +6,19 @@
  * four states called out in the parent ticket's filter-bar spec.
  */
 
-export type OperationStatus = 'running' | 'pending' | 'blocked' | 'completing'
+export type OperationStatus =
+  | 'running'
+  | 'pending'
+  | 'blocked'
+  | 'completing'
+  | 'terminated'
 
 export const OPERATION_STATUSES: readonly OperationStatus[] = [
   'running',
   'pending',
   'blocked',
   'completing',
+  'terminated',
 ] as const
 
 /** Step kind inside a live-operation call stack. */

--- a/dashboard/src/features/liveOps/useLiveOpsStream.test.ts
+++ b/dashboard/src/features/liveOps/useLiveOpsStream.test.ts
@@ -361,6 +361,112 @@ describe('useLiveOpsStream', () => {
     expect(MockWebSocket.instances).toHaveLength(4)
   })
 
+  // ── AAASM-1652: ops_change event handling ──────────────────────────────
+
+  const OPS_CHANGE_EVENT = {
+    id: 100,
+    agent_id: 'support-agent',
+    event_type: 'ops_change',
+    timestamp: '2026-05-21T10:00:00Z',
+    payload: {
+      op_id: 'trace-abc:span-1',
+      state: 'running',
+      updated_at: '2026-05-21T10:00:00Z',
+    },
+  }
+
+  it('subscribes to both violation and ops_change events in the WS URL', () => {
+    renderHook(() => useLiveOpsStream(opts))
+    expect(MockWebSocket.instances[0].url).toContain('types=violation,ops_change')
+  })
+
+  it('maps ops_change events into LiveOperation rows keyed by op_id', () => {
+    const { result } = renderHook(() => useLiveOpsStream(opts))
+    act(() => {
+      MockWebSocket.instances[0].open()
+      MockWebSocket.instances[0].emit(OPS_CHANGE_EVENT)
+    })
+    expect(result.current.ops).toHaveLength(1)
+    expect(result.current.ops[0]).toMatchObject({
+      id: 'trace-abc:span-1',
+      agent: 'support-agent',
+      status: 'running',
+      startedAt: '2026-05-21T10:00:00Z',
+    })
+  })
+
+  it('merges successive ops_change events for the same op_id into one row', () => {
+    const { result } = renderHook(() => useLiveOpsStream(opts))
+    act(() => {
+      MockWebSocket.instances[0].open()
+      MockWebSocket.instances[0].emit(OPS_CHANGE_EVENT)
+      MockWebSocket.instances[0].emit({
+        ...OPS_CHANGE_EVENT,
+        id: 101,
+        payload: {
+          ...OPS_CHANGE_EVENT.payload,
+          state: 'paused',
+          updated_at: '2026-05-21T10:00:05Z',
+        },
+      })
+    })
+    expect(result.current.ops).toHaveLength(1)
+    expect(result.current.ops[0]).toMatchObject({
+      id: 'trace-abc:span-1',
+      status: 'blocked', // paused → blocked translation
+      startedAt: '2026-05-21T10:00:05Z',
+    })
+  })
+
+  it('translates gateway OpState values to dashboard OperationStatus', () => {
+    const { result } = renderHook(() => useLiveOpsStream(opts))
+    const states: Array<{ state: string; expected: string }> = [
+      { state: 'pending', expected: 'pending' },
+      { state: 'running', expected: 'running' },
+      { state: 'paused', expected: 'blocked' },
+      { state: 'completing', expected: 'completing' },
+      { state: 'terminated', expected: 'terminated' },
+    ]
+    act(() => {
+      MockWebSocket.instances[0].open()
+      states.forEach((s, i) => {
+        MockWebSocket.instances[0].emit({
+          ...OPS_CHANGE_EVENT,
+          id: 200 + i,
+          payload: { ...OPS_CHANGE_EVENT.payload, op_id: `t:${i}`, state: s.state },
+        })
+      })
+    })
+    const byId = new Map(result.current.ops.map((o) => [o.id, o.status]))
+    states.forEach((s, i) => {
+      expect(byId.get(`t:${i}`)).toBe(s.expected)
+    })
+  })
+
+  it('preserves opType / resource learned from earlier violation event when merging', () => {
+    const { result } = renderHook(() => useLiveOpsStream(opts))
+    act(() => {
+      MockWebSocket.instances[0].open()
+      // First a violation event lands the row with rich metadata (it
+      // uses the monotonic id as key — not op_id — but we override the
+      // id to match the op_id so the next ops_change event finds it).
+      MockWebSocket.instances[0].emit({
+        ...VIOLATION_EVENT,
+        id: 'trace-abc:span-1' as unknown as number,
+        payload: { ...VIOLATION_EVENT.payload, status: 'running' },
+      })
+      // Then a transition arrives via ops_change.
+      MockWebSocket.instances[0].emit(OPS_CHANGE_EVENT)
+    })
+    expect(result.current.ops).toHaveLength(1)
+    expect(result.current.ops[0]).toMatchObject({
+      id: 'trace-abc:span-1',
+      opType: 'tool_call', // from the violation event
+      resource: 'web_search', // from the violation event
+      status: 'running', // from the ops_change event
+    })
+  })
+
   it('successful open resets the backoff counter so the next close starts at initialBackoffMs', () => {
     renderHook(() => useLiveOpsStream(opts))
 

--- a/dashboard/src/features/liveOps/useLiveOpsStream.ts
+++ b/dashboard/src/features/liveOps/useLiveOpsStream.ts
@@ -68,7 +68,7 @@ function buildWsUrl(): string {
   const token =
     typeof localStorage !== 'undefined' ? localStorage.getItem('aa_token') : null
   const query = [
-    'types=violation',
+    'types=violation,ops_change',
     token ? `token=${encodeURIComponent(token)}` : '',
   ]
     .filter(Boolean)

--- a/dashboard/src/features/liveOps/useLiveOpsStream.ts
+++ b/dashboard/src/features/liveOps/useLiveOpsStream.ts
@@ -211,6 +211,25 @@ export function useLiveOpsStream({
           const op = mapEvent(parsed)
           if (!op) return
           setOps((prev) => {
+            // ops_change events use a stable `op_id` so successive
+            // transitions for the same op merge into one row. If an
+            // existing entry matches, update it in place (preserving
+            // any opType/resource learned from an earlier violation
+            // event); otherwise treat it as a new row at the head.
+            if (parsed.event_type === 'ops_change') {
+              const idx = prev.findIndex((p) => p.id === op.id)
+              if (idx >= 0) {
+                const merged: LiveOperation = {
+                  ...prev[idx]!,
+                  status: op.status,
+                  startedAt: op.startedAt,
+                  agent: op.agent,
+                }
+                const next = prev.slice()
+                next[idx] = merged
+                return next
+              }
+            }
             const next = [op, ...prev]
             return next.length > maxOps ? next.slice(0, maxOps) : next
           })

--- a/dashboard/src/features/liveOps/useLiveOpsStream.ts
+++ b/dashboard/src/features/liveOps/useLiveOpsStream.ts
@@ -7,6 +7,7 @@ type GovernanceEvent = components['schemas']['GovernanceEvent']
 type ViolationPayload = components['schemas']['ViolationPayload']
 type ViolationAuditPayload = Extract<ViolationPayload, { kind: 'audit' }>
 type WireCallStackNode = components['schemas']['CallStackNode']
+type OpsChangePayload = components['schemas']['OpsChangePayload']
 
 const CALL_STACK_KINDS: readonly CallStackNodeKind[] = ['llm', 'tool', 'result'] as const
 
@@ -80,6 +81,34 @@ function isAuditPayload(p: unknown): p is ViolationAuditPayload {
   return typeof p === 'object' && p !== null && (p as { kind?: unknown }).kind === 'audit'
 }
 
+function isOpsChangePayload(p: unknown): p is OpsChangePayload {
+  if (typeof p !== 'object' || p === null) return false
+  const obj = p as Record<string, unknown>
+  return typeof obj.op_id === 'string' && typeof obj.state === 'string'
+}
+
+/**
+ * Translate the gateway-side `OpState` wire vocabulary (`pending` /
+ * `running` / `paused` / `completing` / `terminated`) into the
+ * dashboard's `OperationStatus` vocabulary, where the operator-paused
+ * state is rendered as `blocked` (a historical naming choice from the
+ * pre-AAASM-1422 4-state model retained for backward compatibility
+ * with violation-event status fields).
+ */
+function opStateToStatus(state: string): OperationStatus {
+  switch (state) {
+    case 'paused':
+      return 'blocked'
+    case 'pending':
+    case 'running':
+    case 'completing':
+    case 'terminated':
+      return state
+    default:
+      return 'running'
+  }
+}
+
 function coerceStatus(raw: string | null | undefined): OperationStatus {
   if (raw && (OPERATION_STATUSES as readonly string[]).includes(raw)) {
     return raw as OperationStatus
@@ -88,24 +117,45 @@ function coerceStatus(raw: string | null | undefined): OperationStatus {
 }
 
 function mapEvent(event: GovernanceEvent): LiveOperation | null {
-  if (event.event_type !== 'violation') return null
-  const audit = isAuditPayload(event.payload) ? event.payload : null
-  const callStack = mapCallStack(audit?.call_stack)
-  return {
-    id: String(event.id),
-    agent: event.agent_id,
-    team: audit?.team ?? undefined,
-    opType: audit?.op_type ?? 'unknown',
-    resource: audit?.resource ?? '',
-    status: coerceStatus(audit?.status),
-    startedAt: event.timestamp,
-    latencyMs: audit?.latency_ms ?? 0,
-    ...(callStack ? { callStack } : {}),
+  if (event.event_type === 'violation') {
+    const audit = isAuditPayload(event.payload) ? event.payload : null
+    const callStack = mapCallStack(audit?.call_stack)
+    return {
+      id: String(event.id),
+      agent: event.agent_id,
+      team: audit?.team ?? undefined,
+      opType: audit?.op_type ?? 'unknown',
+      resource: audit?.resource ?? '',
+      status: coerceStatus(audit?.status),
+      startedAt: event.timestamp,
+      latencyMs: audit?.latency_ms ?? 0,
+      ...(callStack ? { callStack } : {}),
+    }
   }
+  if (event.event_type === 'ops_change') {
+    if (!isOpsChangePayload(event.payload)) return null
+    // The op_id (`"{trace_id}:{span_id}"`) is the stable identifier
+    // across the op's lifetime — keying the row map by it lets the
+    // dashboard merge successive transitions into one row instead of
+    // stacking new rows. Resource/opType are not carried on the
+    // ops_change payload by design (they live on the originating
+    // violation event); the row will inherit them from any matching
+    // earlier violation event via the merge logic below.
+    return {
+      id: event.payload.op_id,
+      agent: event.agent_id,
+      opType: 'unknown',
+      resource: '',
+      status: opStateToStatus(event.payload.state),
+      startedAt: event.payload.updated_at,
+      latencyMs: 0,
+    }
+  }
+  return null
 }
 
 // Re-export for direct unit testing of the mapper.
-export const __test__ = { mapEvent }
+export const __test__ = { mapEvent, opStateToStatus }
 
 /**
  * Subscribe to the gateway WebSocket and project violation events into a

--- a/dashboard/src/pages/LiveOpsPage.test.tsx
+++ b/dashboard/src/pages/LiveOpsPage.test.tsx
@@ -25,6 +25,12 @@ vi.mock('../features/liveOps/useLiveOpsStream', () => ({
   useLiveOpsStream: vi.fn(),
 }))
 
+vi.mock('../features/liveOps/actions', () => ({
+  pauseOp: vi.fn().mockResolvedValue(undefined),
+  resumeOp: vi.fn().mockResolvedValue(undefined),
+  terminateOp: vi.fn().mockResolvedValue(undefined),
+}))
+
 const AGENTS = [
   {
     id: 'support-agent',
@@ -172,6 +178,43 @@ describe('LiveOpsPage', () => {
     await user.click(screen.getByTestId('auto-scroll-flush'))
     expect(screen.queryByTestId('auto-scroll-flush')).toBeNull()
     expect(screen.getAllByTestId('op-row')).toHaveLength(2)
+  })
+
+  // ── AAASM-1652: 5-state model + override auto-clear ────────────────────
+
+  it('exposes all 5 lifecycle states in the status filter (incl. Terminated)', () => {
+    renderWithProviders(<LiveOpsPage />)
+    const statusFilter = screen.getByTestId('filter-status') as HTMLSelectElement
+    const labels = Array.from(statusFilter.options).map((o) => o.text)
+    expect(labels).toContain('Running')
+    expect(labels).toContain('Pending')
+    expect(labels).toContain('Blocked')
+    expect(labels).toContain('Completing')
+    expect(labels).toContain('Terminated')
+  })
+
+  it('clears terminate override when stream reports status=terminated', async () => {
+    const user = userEvent.setup()
+    mockStream({ ops: [makeOp('op-1', { status: 'running' })] })
+    const { rerender } = renderWithProviders(<LiveOpsPage />)
+
+    // Open the row-action kebab menu, click Terminate, then confirm the dialog.
+    await user.click(screen.getByTestId('row-action-trigger'))
+    await user.click(screen.getByTestId('row-action-terminate'))
+    await user.click(screen.getByTestId('confirm-dialog-confirm'))
+
+    // Optimistic override shows immediately.
+    expect(screen.getByTestId('op-row-override')).toHaveTextContent('terminating')
+
+    // Stream now reports the op as terminated; the override must auto-clear
+    // (under the pre-1422 model `terminating` only cleared on `completing`).
+    mockStream({ ops: [makeOp('op-1', { status: 'terminated' })] })
+    rerender(
+      <ToastProvider>
+        <LiveOpsPage />
+      </ToastProvider>,
+    )
+    expect(screen.queryByTestId('op-row-override')).toBeNull()
   })
 
   it('toggling auto-scroll back on clears the frozen snapshot', async () => {

--- a/dashboard/src/pages/LiveOpsPage.tsx
+++ b/dashboard/src/pages/LiveOpsPage.tsx
@@ -30,11 +30,18 @@ const OVERRIDE_VERB: Record<OperationOverride, string> = {
  * Returns true when the WS-reported `status` reflects the result the
  * optimistic `intent` was working toward. The override can be cleared
  * once the wire confirms the action took effect.
+ *
+ * `terminating` was historically matched against `completing`, which
+ * was correct under the pre-AAASM-1422 4-state model where there was
+ * no terminal `terminated` state. Now that the gateway emits a real
+ * `terminated` lifecycle state, the override clears on either: the
+ * server may briefly pass through `completing` mid-shutdown before
+ * settling on `terminated`.
  */
 function matchesIntent(status: OperationStatus, intent: OperationOverride): boolean {
   if (intent === 'pausing') return status === 'blocked'
   if (intent === 'resuming') return status === 'running'
-  return status === 'completing'
+  return status === 'completing' || status === 'terminated'
 }
 
 export function LiveOpsPage() {


### PR DESCRIPTION
## Description

PR-C of [AAASM-1422](https://lightning-dust-mite.atlassian.net/browse/AAASM-1422). Wires the dashboard to consume the `ops_change` WebSocket events introduced by PR-B ([AAASM-1651](https://lightning-dust-mite.atlassian.net/browse/AAASM-1651)) so successive lifecycle transitions for the same op merge into one Live Ops row and the optimistic row-action overrides auto-clear when the wire confirms.

Five concrete changes:

1. **`OperationStatus` gains `terminated`** — the dashboard's 4-state lifecycle was missing the gateway's terminal state. Two exhaustive `Record<OperationStatus, string>` maps (FilterBar + OperationRow) are updated in the same commit to keep bisectability.
2. **WS subscription** — `useLiveOpsStream` now subscribes to `types=violation,ops_change` instead of just `violation`.
3. **`mapEvent` extension** — adds an `ops_change` branch that translates the gateway `OpState` vocabulary (`pending|running|paused|completing|terminated`) into the dashboard `OperationStatus` vocabulary (`paused → blocked` is the only translation; the rest are identity).
4. **Merge-by-`op_id` reducer** — `setOps` now updates an existing row in place when an `ops_change` event arrives for an `op_id` already in the ring, preserving `opType`/`resource`/`team` learned from the originating violation event. New ops still prepend at the head.
5. **`matchesIntent('terminating')`** clears on both `completing` and `terminated` — under the pre-1422 4-state model the server only ever passed through `completing` (because there was no real terminal state); the 5-state model adds `terminated` as the final settling point.

### Scope boundary

PR-C only touches the dashboard's *consumption* side. The gateway still doesn't emit `ops_change` events; that's PR-H ([AAASM-1657](https://lightning-dust-mite.atlassian.net/browse/AAASM-1657)). All new tests simulate emitted events via the mock WebSocket; no live-server integration required.

### Notes on the design spec

`design/v1/live-ops.jsx` and `design/v1/hi-fi/live-ops.jsx` are pipeline-canvas animations rather than row designs; they don't prescribe a visual treatment for the new `terminated` state. The dashboard renders all states using the existing chip styling. A follow-up design-fidelity ticket can revisit specific colour/icon work for `pending` / `completing` / `terminated` chips if the design team wants.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Pure additive. Existing `violation` event handling is untouched. The WS URL gains `ops_change` to its `types=` filter; the gateway already accepts unknown filter tokens gracefully (and post-PR-B, `ops_change` is a known filter token server-side). Dashboard clients without this PR still receive only violation events because the server only emits `ops_change` once PR-H lands.

## Related Issues

- Related Jira ticket: [AAASM-1652](https://lightning-dust-mite.atlassian.net/browse/AAASM-1652) (parent: AAASM-1422)
- Depends on (already merged): [AAASM-1651](https://lightning-dust-mite.atlassian.net/browse/AAASM-1651) (PR-B — `OpsChangePayload` schema)
- Unblocks: [AAASM-1657](https://lightning-dust-mite.atlassian.net/browse/AAASM-1657) (PR-H — gateway emission) will produce events the dashboard now knows how to render

## Testing

- [x] Unit tests added / updated — 7 new vitest cases (5 in `useLiveOpsStream.test.ts`, 2 in `LiveOpsPage.test.tsx`)
- [ ] Integration tests added / updated
- [x] Manual testing performed (full local gates, see table)
- [ ] No tests required

### Local gates

| Gate | Result |
|---|---|
| `pnpm type-check` (dashboard) | ✅ |
| `pnpm lint` (dashboard) | ✅ |
| `pnpm test --run` (dashboard) | ✅ **974 / 974** across 113 files |
| `pnpm test --run src/features/liveOps/useLiveOpsStream.test.ts` | ✅ **24 / 24** (5 new + 19 existing) |
| `pnpm test --run src/pages/LiveOpsPage.test.tsx` | ✅ **13 / 13** (2 new + 11 existing) |

## Checklist

- [x] Code follows project style guidelines (`pnpm lint`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (architecture doc §7 stays accurate — payload shape unchanged from PR-B)
- [ ] All CI checks passing (pending)
- [x] Commits are small and follow the Gitmoji convention

### Commits (7 granular)

1. ✨ `(dashboard/liveOps)` Add `terminated` to OperationStatus enum
2. ✨ `(dashboard/liveOps)` Subscribe to ops_change events alongside violation
3. ✨ `(dashboard/liveOps)` Map ops_change events into LiveOperation rows
4. ✨ `(dashboard/liveOps)` Merge ops_change updates into existing row by op_id
5. ♻️ `(dashboard/LiveOpsPage)` Clear terminate override on terminated status
6. ✅ `(dashboard/liveOps)` Add vitest cases for ops_change event handling
7. ✅ `(dashboard/LiveOpsPage)` Add vitest cases for 5-state + terminate auto-clear

[AAASM-1422]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1651]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1657]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ