### PR TITLE
[AAASM-1653] ✨ (aa-proto/aa-gateway): Add OpControlStream gateway→SDK return-channel

### DIFF
--- a/aa-gateway/src/ops/mod.rs
+++ b/aa-gateway/src/ops/mod.rs
@@ -17,6 +17,10 @@
 //! `OpsError::InvalidTransition`. See
 //! `docs/src/operations/ops-registry-architecture.md` for the full diagram.
 
+pub mod publisher;
+
+pub use publisher::{OpControlEnvelope, OpControlPublisher, SharedOpControlPublisher};
+
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;

--- a/aa-gateway/src/ops/publisher.rs
+++ b/aa-gateway/src/ops/publisher.rs
@@ -1,0 +1,180 @@
+//! Fan-out channel for [`crate::ops::OpsRegistry`] lifecycle transitions.
+//!
+//! `OpControlPublisher` is the gateway-side broadcast point that subscribed
+//! SDK clients (via `PolicyService::OpControlStream`, AAASM-1653) receive
+//! pause / resume / terminate signals on. PR-D ships the channel + handler;
+//! PR-H wires the [`OpsRegistry`] transitions to call [`publish`] with the
+//! matching signal.
+//!
+//! Implementation: a single `tokio::sync::broadcast` channel. Subscribers
+//! filter by `agent_id` themselves, which is cheaper than maintaining a
+//! per-agent registry of senders for low-volume signalling (pause / resume
+//! / terminate are operator-triggered, not per-action). The trade-off is
+//! that every subscriber wakes on every message — acceptable for the
+//! expected steady-state of < 100 active agents per gateway.
+//!
+//! Sequence numbers are assigned by the publisher on `publish()`, starting
+//! at 0 on construction. They reset across gateway restarts; SDK consumers
+//! treat the value as advisory dedup help, not a cross-publisher ordering
+//! guarantee.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use tokio::sync::broadcast;
+
+use aa_proto::assembly::common::v1::AgentId;
+use aa_proto::assembly::policy::v1::{OpControlMessage, OpControlSignal};
+
+/// Broadcast capacity. Sized so a momentarily-slow subscriber doesn't lag
+/// out under normal pause/resume churn. Subscribers that fall behind by
+/// more than this many messages will get `RecvError::Lagged` and skip
+/// the missed entries; the SDK reconciles via the next steady-state
+/// transition rather than replaying history.
+const CHANNEL_CAPACITY: usize = 256;
+
+/// One pre-serialised lifecycle signal addressed to a specific agent.
+///
+/// Wraps the wire-format [`OpControlMessage`] with the routing key
+/// (`agent_id`) so subscribers can filter cheaply without parsing the
+/// message body.
+#[derive(Debug, Clone)]
+pub struct OpControlEnvelope {
+    /// The agent the message is destined for. Subscribers compare this
+    /// against their own `subscribe(agent_id)` filter and drop mismatches.
+    pub agent_id: AgentId,
+    /// The wire-format message that will be forwarded to the subscriber.
+    pub message: OpControlMessage,
+}
+
+/// Broadcast publisher for op-control signals.
+///
+/// Wrap in `Arc` and clone-share between the policy service handler (which
+/// calls [`subscribe`]) and the OpsRegistry call sites (which call
+/// [`publish`] — wiring lands in PR-H).
+pub struct OpControlPublisher {
+    tx: broadcast::Sender<OpControlEnvelope>,
+    sequence: AtomicU64,
+}
+
+impl OpControlPublisher {
+    /// Create a fresh publisher with no subscribers.
+    pub fn new() -> Self {
+        let (tx, _) = broadcast::channel(CHANNEL_CAPACITY);
+        Self {
+            tx,
+            sequence: AtomicU64::new(0),
+        }
+    }
+
+    /// Subscribe to the broadcast. Returns a receiver that yields every
+    /// envelope published from now on. Subscribers must filter by
+    /// `agent_id` themselves — see [`PolicyServiceImpl::op_control_stream`].
+    ///
+    /// [`PolicyServiceImpl::op_control_stream`]: crate::service::PolicyServiceImpl
+    pub fn subscribe(&self) -> broadcast::Receiver<OpControlEnvelope> {
+        self.tx.subscribe()
+    }
+
+    /// Publish a signal addressed to an agent. Returns the assigned
+    /// sequence number. Silently succeeds when there are zero subscribers
+    /// (the message is dropped) so registry transitions don't fail just
+    /// because no SDK happens to be connected.
+    pub fn publish(&self, agent_id: AgentId, op_id: String, signal: OpControlSignal) -> u64 {
+        let sequence = self.sequence.fetch_add(1, Ordering::Relaxed);
+        let envelope = OpControlEnvelope {
+            agent_id,
+            message: OpControlMessage {
+                op_id,
+                signal: signal as i32,
+                sequence,
+            },
+        };
+        let _ = self.tx.send(envelope);
+        sequence
+    }
+
+    /// Current number of active subscribers. Useful for shedding work
+    /// when no one is listening (and for tests).
+    pub fn subscriber_count(&self) -> usize {
+        self.tx.receiver_count()
+    }
+}
+
+impl Default for OpControlPublisher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Convenience alias for the shared-ownership shape used everywhere the
+/// publisher is threaded through (`PolicyServiceImpl`, `OpsRegistry`).
+pub type SharedOpControlPublisher = Arc<OpControlPublisher>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn agent(id: &str) -> AgentId {
+        AgentId {
+            org_id: "org".into(),
+            team_id: "team".into(),
+            agent_id: id.into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn publish_with_no_subscribers_succeeds_and_drops_message() {
+        let pub_ = OpControlPublisher::new();
+        let seq = pub_.publish(agent("a1"), "trace:span".into(), OpControlSignal::Pause);
+        assert_eq!(seq, 0);
+        assert_eq!(pub_.subscriber_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn sequence_numbers_are_monotonically_increasing() {
+        let pub_ = OpControlPublisher::new();
+        let s0 = pub_.publish(agent("a1"), "o:0".into(), OpControlSignal::Pause);
+        let s1 = pub_.publish(agent("a1"), "o:1".into(), OpControlSignal::Resume);
+        let s2 = pub_.publish(agent("a1"), "o:2".into(), OpControlSignal::Terminate);
+        assert_eq!((s0, s1, s2), (0, 1, 2));
+    }
+
+    #[tokio::test]
+    async fn subscriber_receives_published_envelope() {
+        let pub_ = OpControlPublisher::new();
+        let mut rx = pub_.subscribe();
+        let seq = pub_.publish(agent("a1"), "trace:span".into(), OpControlSignal::Pause);
+
+        let envelope = rx.recv().await.unwrap();
+        assert_eq!(envelope.agent_id.agent_id, "a1");
+        assert_eq!(envelope.message.op_id, "trace:span");
+        assert_eq!(envelope.message.signal, OpControlSignal::Pause as i32);
+        assert_eq!(envelope.message.sequence, seq);
+    }
+
+    #[tokio::test]
+    async fn each_subscriber_receives_every_envelope_independently() {
+        let pub_ = OpControlPublisher::new();
+        let mut a = pub_.subscribe();
+        let mut b = pub_.subscribe();
+        pub_.publish(agent("a1"), "o:0".into(), OpControlSignal::Pause);
+
+        assert_eq!(a.recv().await.unwrap().message.op_id, "o:0");
+        assert_eq!(b.recv().await.unwrap().message.op_id, "o:0");
+    }
+
+    #[tokio::test]
+    async fn subscriber_count_tracks_active_receivers() {
+        let pub_ = OpControlPublisher::new();
+        assert_eq!(pub_.subscriber_count(), 0);
+        let r1 = pub_.subscribe();
+        assert_eq!(pub_.subscriber_count(), 1);
+        let r2 = pub_.subscribe();
+        assert_eq!(pub_.subscriber_count(), 2);
+        drop(r1);
+        assert_eq!(pub_.subscriber_count(), 1);
+        drop(r2);
+        assert_eq!(pub_.subscriber_count(), 0);
+    }
+}

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -21,7 +21,7 @@ use crate::approval::escalation::EscalationScheduler;
 use crate::approval::router::ApprovalRouter;
 use crate::approval::routing_config::RoutingConfigStore;
 use crate::engine::{DenyAction, EvaluationResult, PolicyEngine};
-use crate::ops::OpsRegistry;
+use crate::ops::{OpsRegistry, SharedOpControlPublisher};
 use crate::registry::convert::proto_agent_id_to_key;
 use crate::registry::{AgentRegistry, SuspendReason};
 use crate::service::convert;
@@ -50,6 +50,12 @@ pub struct PolicyServiceImpl {
     /// matching the pre-1422 behaviour expected by unit tests that
     /// construct the service directly.
     ops_registry: Option<Arc<OpsRegistry>>,
+    /// Optional broadcast publisher for op-control signals (AAASM-1653).
+    /// When set, the `op_control_stream` RPC subscribes here and forwards
+    /// every envelope matching the subscriber's agent_id. `None` rejects
+    /// new subscriptions with `Unavailable`. PR-H will pair this with
+    /// `OpsRegistry` transition call sites that drive `publish()`.
+    ops_publisher: Option<SharedOpControlPublisher>,
 }
 
 impl PolicyServiceImpl {
@@ -78,6 +84,7 @@ impl PolicyServiceImpl {
             last_hash: Mutex::new(initial_hash),
             secret_alert_tx: None,
             ops_registry: None,
+            ops_publisher: None,
         }
     }
 
@@ -106,6 +113,7 @@ impl PolicyServiceImpl {
             last_hash: Mutex::new(initial_hash),
             secret_alert_tx: None,
             ops_registry: None,
+            ops_publisher: None,
         }
     }
 
@@ -136,6 +144,7 @@ impl PolicyServiceImpl {
             last_hash: Mutex::new(initial_hash),
             secret_alert_tx: None,
             ops_registry: None,
+            ops_publisher: None,
         }
     }
 
@@ -171,6 +180,7 @@ impl PolicyServiceImpl {
             last_hash: Mutex::new(initial_hash),
             secret_alert_tx: None,
             ops_registry: None,
+            ops_publisher: None,
         }
     }
 
@@ -212,6 +222,20 @@ impl PolicyServiceImpl {
     /// `OpStateChanged` emission are deferred to PR-H.
     pub fn with_ops_registry(mut self, registry: Arc<OpsRegistry>) -> Self {
         self.ops_registry = Some(registry);
+        self
+    }
+
+    /// Attach an [`OpControlPublisher`] for the SDK return-channel (AAASM-1653).
+    ///
+    /// When present, [`PolicyService::op_control_stream`] subscribes to the
+    /// publisher and forwards every envelope whose `agent_id` matches the
+    /// subscriber's `OpControlSubscribeRequest.agent_id`. Without a
+    /// publisher attached, subscription requests are rejected with
+    /// `Status::unavailable("op control channel not configured")`.
+    ///
+    /// [`OpControlPublisher`]: crate::ops::OpControlPublisher
+    pub fn with_ops_publisher(mut self, publisher: SharedOpControlPublisher) -> Self {
+        self.ops_publisher = Some(publisher);
         self
     }
 

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -1,8 +1,11 @@
 //! `PolicyService` tonic trait implementation wiring gRPC RPCs to `PolicyEngine`.
 
+use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Instant, SystemTime};
+
+use tokio_stream::Stream;
 
 use tokio::sync::{broadcast, mpsc, Mutex};
 use tonic::{Request, Response, Status};
@@ -11,7 +14,10 @@ use aa_core::identity::{AgentId, SessionId};
 use aa_core::time::Timestamp;
 use aa_core::{AgentContext, AuditEntry, AuditEventType, GovernanceLevel, Lineage, Redaction};
 use aa_proto::assembly::policy::v1::policy_service_server::PolicyService;
-use aa_proto::assembly::policy::v1::{BatchCheckRequest, BatchCheckResponse, CheckActionRequest, CheckActionResponse};
+use aa_proto::assembly::policy::v1::{
+    BatchCheckRequest, BatchCheckResponse, CheckActionRequest, CheckActionResponse, OpControlMessage,
+    OpControlSubscribeRequest,
+};
 
 use aa_runtime::approval::{ApprovalQueue, ApprovalRequest};
 
@@ -847,5 +853,66 @@ impl PolicyService for PolicyServiceImpl {
         }
 
         Ok(Response::new(BatchCheckResponse { responses }))
+    }
+
+    type OpControlStreamStream = Pin<Box<dyn Stream<Item = Result<OpControlMessage, Status>> + Send + 'static>>;
+
+    /// AAASM-1653: gateway → SDK push channel for op-lifecycle signals.
+    ///
+    /// Subscribes the caller to the configured [`OpControlPublisher`] and
+    /// forwards every envelope whose `agent_id` matches the request's
+    /// `agent_id`. The stream stays open until either the client cancels
+    /// (`Closed` from the broadcast receiver) or the publisher is dropped.
+    ///
+    /// Lagged subscribers (those that fall behind the broadcast capacity)
+    /// skip the missed envelopes and continue — the SDK reconciles via
+    /// the next steady-state transition rather than replaying history.
+    ///
+    /// Returns `Status::unavailable` when no publisher is attached to the
+    /// service (tests / partial wiring), and `Status::invalid_argument`
+    /// when the request omits `agent_id`.
+    async fn op_control_stream(
+        &self,
+        request: Request<OpControlSubscribeRequest>,
+    ) -> Result<Response<Self::OpControlStreamStream>, Status> {
+        let req = request.into_inner();
+        let Some(agent_id) = req.agent_id else {
+            return Err(Status::invalid_argument("agent_id is required"));
+        };
+        let Some(publisher) = self.ops_publisher.clone() else {
+            return Err(Status::unavailable("op control channel not configured"));
+        };
+
+        let target_agent_id = agent_id.agent_id.clone();
+        let target_team_id = agent_id.team_id.clone();
+        let target_org_id = agent_id.org_id.clone();
+        let mut rx = publisher.subscribe();
+
+        let stream = async_stream::stream! {
+            loop {
+                match rx.recv().await {
+                    Ok(envelope) => {
+                        // Match on the composite id triple to avoid cross-org
+                        // / cross-team agent_id collisions.
+                        if envelope.agent_id.agent_id != target_agent_id
+                            || envelope.agent_id.team_id != target_team_id
+                            || envelope.agent_id.org_id != target_org_id
+                        {
+                            continue;
+                        }
+                        yield Ok(envelope.message);
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!(skipped = n, agent_id = %target_agent_id, "OpControlStream subscriber lagged");
+                        continue;
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        break;
+                    }
+                }
+            }
+        };
+
+        Ok(Response::new(Box::pin(stream)))
     }
 }

--- a/aa-gateway/tests/op_control_stream_test.rs
+++ b/aa-gateway/tests/op_control_stream_test.rs
@@ -1,0 +1,177 @@
+//! Integration tests for AAASM-1653: the gateway's OpControlStream
+//! server-streaming RPC subscribes to an attached `OpControlPublisher`
+//! and forwards filtered envelopes to the gRPC client.
+
+use std::io::Write;
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use std::time::Duration;
+
+use aa_gateway::ops::{OpControlPublisher, OpsRegistry, SharedOpControlPublisher};
+use aa_gateway::service::PolicyServiceImpl;
+use aa_gateway::PolicyEngine;
+use aa_proto::assembly::common::v1::AgentId as ProtoAgentId;
+use aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient;
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
+use aa_proto::assembly::policy::v1::{OpControlSignal, OpControlSubscribeRequest};
+use tokio::net::TcpListener;
+use tokio::time::timeout;
+use tonic::transport::Server;
+
+/// Start a PolicyService gRPC server with the given (optional) publisher
+/// attached, returning the bound address.
+async fn start_server(publisher: Option<SharedOpControlPublisher>) -> SocketAddr {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    writeln!(tmp, "version: \"1\"").unwrap();
+    tmp.flush().unwrap();
+
+    let (alert_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    let engine = PolicyEngine::load_from_file(tmp.path(), alert_tx).unwrap();
+    let (audit_tx, _audit_rx) = tokio::sync::mpsc::channel(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+    let mut service = PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops, [0u8; 32])
+        .with_ops_registry(Arc::new(OpsRegistry::new()));
+    if let Some(p) = publisher {
+        service = service.with_ops_publisher(p);
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let _tmp = tmp;
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(PolicyServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    addr
+}
+
+fn agent(id: &str) -> ProtoAgentId {
+    ProtoAgentId {
+        org_id: "org".into(),
+        team_id: "team".into(),
+        agent_id: id.into(),
+    }
+}
+
+#[tokio::test]
+async fn subscriber_receives_published_envelope_addressed_to_them() {
+    let publisher = Arc::new(OpControlPublisher::new());
+    let addr = start_server(Some(Arc::clone(&publisher))).await;
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let mut stream = client
+        .op_control_stream(OpControlSubscribeRequest {
+            agent_id: Some(agent("agent-7")),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    // Let the server-side subscription register before publishing.
+    for _ in 0..20 {
+        if publisher.subscriber_count() > 0 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    assert_eq!(publisher.subscriber_count(), 1, "stream should have subscribed");
+
+    publisher.publish(agent("agent-7"), "trace-1:span-1".into(), OpControlSignal::Pause);
+
+    let msg = timeout(Duration::from_secs(2), stream.message())
+        .await
+        .expect("recv did not time out")
+        .expect("stream did not error")
+        .expect("stream had a message");
+    assert_eq!(msg.op_id, "trace-1:span-1");
+    assert_eq!(msg.signal, OpControlSignal::Pause as i32);
+    assert_eq!(msg.sequence, 0);
+}
+
+#[tokio::test]
+async fn subscriber_ignores_envelopes_for_other_agents() {
+    let publisher = Arc::new(OpControlPublisher::new());
+    let addr = start_server(Some(Arc::clone(&publisher))).await;
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let mut stream = client
+        .op_control_stream(OpControlSubscribeRequest {
+            agent_id: Some(agent("agent-7")),
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    for _ in 0..20 {
+        if publisher.subscriber_count() > 0 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+
+    // Two publishes: one to a different agent (filtered out), one to the
+    // subscriber (delivered). The delivered one should arrive first since
+    // the filter just skips non-matches.
+    publisher.publish(agent("agent-other"), "trace-x:span-0".into(), OpControlSignal::Pause);
+    publisher.publish(agent("agent-7"), "trace-7:span-0".into(), OpControlSignal::Resume);
+
+    let msg = timeout(Duration::from_secs(2), stream.message())
+        .await
+        .expect("recv did not time out")
+        .unwrap()
+        .expect("stream had a message");
+    assert_eq!(msg.op_id, "trace-7:span-0");
+    assert_eq!(msg.signal, OpControlSignal::Resume as i32);
+}
+
+#[tokio::test]
+async fn missing_publisher_returns_unavailable() {
+    let addr = start_server(None).await;
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+
+    // tonic's server-streaming returns the Status on the initial response
+    // when the handler errors before yielding anything. Most clients can
+    // discover this either on the initial call or by polling the stream.
+    let initial = client
+        .op_control_stream(OpControlSubscribeRequest {
+            agent_id: Some(agent("agent-7")),
+        })
+        .await;
+    let err = match initial {
+        Err(e) => e,
+        Ok(resp) => resp
+            .into_inner()
+            .message()
+            .await
+            .expect_err("expected error from stream"),
+    };
+    assert_eq!(err.code(), tonic::Code::Unavailable);
+}
+
+#[tokio::test]
+async fn missing_agent_id_returns_invalid_argument() {
+    let publisher = Arc::new(OpControlPublisher::new());
+    let addr = start_server(Some(publisher)).await;
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+
+    let initial = client
+        .op_control_stream(OpControlSubscribeRequest { agent_id: None })
+        .await;
+    let err = match initial {
+        Err(e) => e,
+        Ok(resp) => resp
+            .into_inner()
+            .message()
+            .await
+            .expect_err("expected error from stream"),
+    };
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
+}

--- a/proto/policy.proto
+++ b/proto/policy.proto
@@ -140,3 +140,44 @@ message BatchCheckRequest {
 message BatchCheckResponse {
   repeated CheckActionResponse responses = 1;
 }
+
+// ── Op control (AAASM-1422 PR-D) ──────────────────────────────────────────────
+
+// OpControlSubscribeRequest is the unary half of OpControlStream — the SDK
+// opens the stream keyed by its own agent id; the gateway sends only the
+// messages whose op_id belongs to that agent.
+message OpControlSubscribeRequest {
+  // Composite identity of the subscribing agent. Matches the agent_id on
+  // its CheckActionRequests so the gateway can filter the broadcast.
+  assembly.common.v1.AgentId agent_id = 1;
+}
+
+// OpControlSignal classifies the lifecycle action the gateway is pushing to
+// the SDK. Mirrors the OpsRegistry transitions in aa-gateway/src/ops/mod.rs.
+enum OpControlSignal {
+  // Default — never wired; treated as a malformed message by the SDK.
+  OP_CONTROL_SIGNAL_UNSPECIFIED = 0;
+  // Operator paused the op via POST /api/v1/ops/{id}/pause. SDK should
+  // cooperatively yield at the next interruption point and block on resume.
+  OP_CONTROL_SIGNAL_PAUSE       = 1;
+  // Operator resumed the op via POST /api/v1/ops/{id}/resume. SDK unblocks.
+  OP_CONTROL_SIGNAL_RESUME      = 2;
+  // Operator (or policy deny) terminated the op. SDK fast-fails the in-flight
+  // action with an OpTerminatedError.
+  OP_CONTROL_SIGNAL_TERMINATE   = 3;
+}
+
+// OpControlMessage is one push from the gateway over the OpControlStream.
+// The SDK routes by op_id; sequence is a monotonic counter the SDK uses
+// for at-least-once delivery dedup if the channel reconnects.
+message OpControlMessage {
+  // Stable identifier of the op — "{trace_id}:{span_id}", same form the
+  // dashboard uses to key live-ops rows.
+  string          op_id    = 1;
+  // The lifecycle signal to apply.
+  OpControlSignal signal   = 2;
+  // Per-publisher monotonic sequence number. Restarts at 0 each gateway
+  // boot; SDK consumers should treat it as advisory, not as a global
+  // ordering guarantee across publishers.
+  uint64          sequence = 3;
+}

--- a/proto/policy.proto
+++ b/proto/policy.proto
@@ -17,6 +17,14 @@ service PolicyService {
   // BatchCheck pre-warms the policy cache for a set of anticipated actions.
   // Called at agent startup or when entering a new task context.
   rpc BatchCheck(BatchCheckRequest) returns (BatchCheckResponse);
+
+  // OpControlStream is the gateway → SDK push channel for op-lifecycle
+  // signals (pause / resume / terminate). The SDK opens the stream once
+  // per agent process at startup; the gateway pushes one OpControlMessage
+  // per OpsRegistry transition matching the subscriber's agent_id. See
+  // AAASM-1653 (PR-D of AAASM-1422); SDK-side consumers ship in PR-E
+  // (Python), PR-F (Node), and PR-G (Go).
+  rpc OpControlStream(OpControlSubscribeRequest) returns (stream OpControlMessage);
 }
 
 // ── Check ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

PR-D of [AAASM-1422](https://lightning-dust-mite.atlassian.net/browse/AAASM-1422). Adds the **gateway → SDK push channel** for op-lifecycle signals (pause / resume / terminate). PR-E / PR-F / PR-G (Python / Node / Go SDK consumers) will subscribe to this stream; PR-H will drive the publish call sites from `OpsRegistry` transitions.

Five concrete pieces, sequenced for bisectability:

1. **Proto messages** in `proto/policy.proto` — `OpControlSubscribeRequest`, `OpControlSignal` enum (`UNSPECIFIED / PAUSE / RESUME / TERMINATE`), `OpControlMessage { op_id, signal, sequence }`. Additive — buf breaking-check safe.
2. **`OpControlPublisher` submodule** at `aa-gateway/src/ops/publisher.rs` — wraps a `tokio::sync::broadcast` channel (capacity 256), assigns monotonic per-publisher sequence numbers, exposes `subscribe()` + `publish()`. 5 inline unit tests.
3. **`ops_publisher` field + `with_ops_publisher` builder** on `PolicyServiceImpl` — same builder pattern as `with_ops_registry`, `with_secret_alert_tx`.
4. **`OpControlStream` RPC declaration + server-streaming handler** (paired in one commit because adding the RPC to the proto requires a matching impl method, otherwise the trait is non-exhaustive). Handler filters envelopes by the composite agent id triple (`org_id + team_id + agent_id`), forwards matches to the gRPC stream, handles lagged-subscriber and channel-closed cases. Mirrors the `WatchApprovals` pattern.
5. **Integration test** in `aa-gateway/tests/op_control_stream_test.rs` — 4 cases over a real tonic server: happy-path roundtrip, cross-agent filtering, missing-publisher → `Unavailable`, missing-agent-id → `InvalidArgument`.

### Scope boundary

PR-D ships the **channel** end-to-end. It does **not**:
- Drive `publisher.publish()` from `OpsRegistry` transitions (that's PR-H — [AAASM-1657](https://lightning-dust-mite.atlassian.net/browse/AAASM-1657)).
- Add SDK-side consumers (that's PR-E / PR-F / PR-G — [AAASM-1654](https://lightning-dust-mite.atlassian.net/browse/AAASM-1654) / [-1655](https://lightning-dust-mite.atlassian.net/browse/AAASM-1655) / [-1656](https://lightning-dust-mite.atlassian.net/browse/AAASM-1656)).
- Reconnection / heartbeat / backpressure tuning beyond defaults (deferred).

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Pure additive: new proto messages, new RPC, new gateway module, new builder. The existing `PolicyServiceImpl` constructors initialise `ops_publisher: None` so call sites that don't wire the builder reject `OpControlStream` subscriptions with `Unavailable` — matches the established pattern for optional services.

## Related Issues

- Related Jira ticket: [AAASM-1653](https://lightning-dust-mite.atlassian.net/browse/AAASM-1653) (parent: AAASM-1422)
- Unblocks: [AAASM-1654](https://lightning-dust-mite.atlassian.net/browse/AAASM-1654) (PR-E python-sdk), [AAASM-1655](https://lightning-dust-mite.atlassian.net/browse/AAASM-1655) (PR-F node-sdk), [AAASM-1656](https://lightning-dust-mite.atlassian.net/browse/AAASM-1656) (PR-G go-sdk), [AAASM-1657](https://lightning-dust-mite.atlassian.net/browse/AAASM-1657) (PR-H gateway emission)

## Testing

- [x] Unit tests added / updated — 5 cases in `aa-gateway/src/ops/publisher.rs::tests`
- [x] Integration tests added / updated — 4 cases in `aa-gateway/tests/op_control_stream_test.rs`
- [x] Manual testing performed — full local gates
- [ ] No tests required

### Local gates

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | ✅ |
| `cargo clippy --workspace --all-targets --all-features --exclude aa-ebpf -- -D warnings` | ✅ |
| `cargo nextest run -p aa-gateway -p aa-api -p aa-proto -p aa-runtime` | ✅ **1549 / 1549** (2 ignored) |
| `cargo nextest run -p aa-gateway --test op_control_stream_test` | ✅ **4 / 4** |
| `cargo nextest run -p aa-gateway --lib ops::publisher::` | ✅ **5 / 5** |
| `buf lint` / `buf breaking` | n/a locally (not installed); relying on CI `Proto lint & breaking check (buf)` |

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (architecture doc §6 already calls out the proto sketch and lands the implementation)
- [ ] All CI checks passing (pending)
- [x] Commits are small and follow the Gitmoji convention

### Commits (5 granular)

1. ✨ `(aa-proto/policy)` Add OpControl proto messages for SDK return-channel
2. ✨ `(aa-gateway/ops)` Add OpControlPublisher submodule with broadcast fan-out
3. ✨ `(aa-gateway/service)` Add ops_publisher field + with_ops_publisher builder
4. ✨ `(aa-gateway/service)` Add OpControlStream RPC + server-streaming handler
5. ✅ `(aa-gateway/tests)` Add op_control_stream integration test

[AAASM-1422]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1657]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ