### PR TITLE
[AAASM-1465] 🐛 (aa-cli): Rename simulate `--output` to `--output-file` to fix clap collision

### DIFF
--- a/aa-cli/src/commands/policy/simulate.rs
+++ b/aa-cli/src/commands/policy/simulate.rs
@@ -29,8 +29,11 @@ pub struct SimulateArgs {
     pub duration: Option<String>,
 
     /// Path to write the simulation report JSON.
+    ///
+    /// Named `--output-file` (not `--output`) to avoid collision with the
+    /// top-level global `--output <OutputFormat>` flag.
     #[arg(long)]
-    pub output: Option<PathBuf>,
+    pub output_file: Option<PathBuf>,
 }
 
 /// Execute the simulate command.
@@ -74,8 +77,8 @@ pub fn run(args: SimulateArgs) -> ExitCode {
 
     let report = sim_engine.run(replay.events());
 
-    // Write report to file if --output is provided.
-    if let Some(ref output_path) = args.output {
+    // Write report to file if --output-file is provided.
+    if let Some(ref output_path) = args.output_file {
         match serde_json::to_string_pretty(&report) {
             Ok(json) => {
                 if let Err(e) = std::fs::write(output_path, &json) {
@@ -138,7 +141,7 @@ mod tests {
             against: None,
             live: false,
             duration: None,
-            output: None,
+            output_file: None,
         };
         assert_eq!(run(args), ExitCode::FAILURE);
     }
@@ -150,7 +153,7 @@ mod tests {
             against: None,
             live: false,
             duration: None,
-            output: None,
+            output_file: None,
         };
         assert_eq!(run(args), ExitCode::FAILURE);
     }
@@ -183,7 +186,7 @@ spec:
             against: None,
             live: false,
             duration: None,
-            output: None,
+            output_file: None,
         };
         assert_eq!(run(args), ExitCode::FAILURE);
     }
@@ -215,7 +218,7 @@ spec:
             against: None,
             live: true,
             duration: Some("30s".to_string()),
-            output: None,
+            output_file: None,
         };
         assert_eq!(run(args), ExitCode::FAILURE);
     }

--- a/aa-integration-tests/tests/cli_policy.rs
+++ b/aa-integration-tests/tests/cli_policy.rs
@@ -334,3 +334,53 @@ async fn policy_simulate_without_against_or_live_returns_error() {
         "stderr should explain --against is required; got:\n{stderr}",
     );
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn policy_simulate_with_output_file_writes_report() {
+    let fixture = CliFixture::start().await.expect("fixture should start");
+    let policy = CliFixture::fixture_path("policies/allow_all.yaml");
+
+    // HistoricalReplay::from_file expects JSONL with {event_type, agent_id, payload}.
+    let scratch = tempfile::tempdir().expect("scratch tempdir");
+    let log_path = scratch.path().join("events.jsonl");
+    std::fs::write(
+        &log_path,
+        r#"{"event_type":"ToolCallIntercepted","agent_id":"a1","payload":"{}"}
+{"event_type":"ToolCallIntercepted","agent_id":"a2","payload":"{}"}
+"#,
+    )
+    .expect("write replay log");
+    let report_path = scratch.path().join("report.json");
+
+    let out = fixture
+        .cmd()
+        .args([
+            "policy",
+            "simulate",
+            "--policy",
+            policy.to_str().unwrap(),
+            "--against",
+            log_path.to_str().unwrap(),
+            "--output-file",
+            report_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("aasm policy simulate --output-file should execute");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "simulate should succeed for allow-all replay; stdout:\n{}\nstderr:\n{stderr}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    assert!(
+        report_path.exists(),
+        "simulate should write report to --output-file at {}",
+        report_path.display(),
+    );
+    let body = std::fs::read_to_string(&report_path).expect("read written report");
+    let parsed: Value = serde_json::from_str(&body).expect("report.json should be valid JSON");
+    assert_eq!(
+        parsed["total_events"], 2,
+        "report should account for both replayed events; got:\n{body}",
+    );
+}

--- a/aa-integration-tests/tests/cli_policy.rs
+++ b/aa-integration-tests/tests/cli_policy.rs
@@ -314,7 +314,7 @@ async fn policy_simulate_live_mode_returns_not_yet_supported() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn policy_simulate_without_against_or_live_exits_non_zero() {
+async fn policy_simulate_without_against_or_live_returns_error() {
     let fixture = CliFixture::start().await.expect("fixture should start");
     let policy = CliFixture::fixture_path("policies/allow_all.yaml");
 
@@ -323,13 +323,14 @@ async fn policy_simulate_without_against_or_live_exits_non_zero() {
         .args(["policy", "simulate", "--policy", policy.to_str().unwrap()])
         .output()
         .expect("aasm policy simulate (no --against) should execute");
-    // Same caveat as `policy_simulate_live_mode_exits_non_zero` — the
-    // user-facing "--against is required" message is hidden by a
-    // pre-existing clap-collision panic. Test only asserts non-zero
-    // exit until that bug is fixed.
+    let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
         !out.status.success(),
-        "missing --against (and not --live) should fail; stdout:\n{}",
+        "missing --against (and not --live) should fail; stdout:\n{}\nstderr:\n{stderr}",
         String::from_utf8_lossy(&out.stdout),
+    );
+    assert!(
+        stderr.contains("--against <log-file> is required"),
+        "stderr should explain --against is required; got:\n{stderr}",
     );
 }

--- a/aa-integration-tests/tests/cli_policy.rs
+++ b/aa-integration-tests/tests/cli_policy.rs
@@ -292,7 +292,7 @@ async fn policy_simulate_without_required_policy_flag_returns_error() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn policy_simulate_live_mode_exits_non_zero() {
+async fn policy_simulate_live_mode_returns_not_yet_supported() {
     let fixture = CliFixture::start().await.expect("fixture should start");
     let policy = CliFixture::fixture_path("policies/allow_all.yaml");
 
@@ -301,16 +301,15 @@ async fn policy_simulate_live_mode_exits_non_zero() {
         .args(["policy", "simulate", "--policy", policy.to_str().unwrap(), "--live"])
         .output()
         .expect("aasm policy simulate --live should execute");
-    // The handler-level error message "live simulation is not yet
-    // supported (requires AAASM-73)" is unreachable today because
-    // `policy simulate` panics on a clap arg-lookup mismatch — the
-    // subcommand's `--output <PathBuf>` flag collides with the global
-    // `--output <OutputFormat>` flag. Tracked as a separate bug;
-    // until it's fixed the only observable property is non-zero exit.
+    let stderr = String::from_utf8_lossy(&out.stderr);
     assert!(
         !out.status.success(),
-        "--live should fail; stdout:\n{}",
+        "--live should fail; stdout:\n{}\nstderr:\n{stderr}",
         String::from_utf8_lossy(&out.stdout),
+    );
+    assert!(
+        stderr.contains("live simulation is not yet supported"),
+        "stderr should explain --live is unimplemented; got:\n{stderr}",
     );
 }
 


### PR DESCRIPTION
## Description

Every invocation of `aasm policy simulate` panicked at parse-result-access time:

```
thread 'main' panicked at aa-cli/src/commands/policy/simulate.rs:33:17:
Mismatch between definition and access of `output`.
Could not downcast to std::path::PathBuf,
need to downcast to aa_cli::output::OutputFormat
```

Root cause: the top-level `aasm` CLI declares a global `--output <OutputFormat>` flag (`json`/`yaml`/`table`) on `Cli` via `clap::Parser` with `global = true`. The `policy simulate` subcommand declared its own `--output <PathBuf>` argument with the same long name — clap accepts both at parse time but mismatches at access time, panicking before the handler ever runs. Users saw a Rust backtrace instead of the actual error (e.g. `--against <log-file> is required …` or the AAASM-73 live-mode "not yet supported" message).

Picks **Option A** from the ticket: rename the field `SimulateArgs.output` → `output_file`. Since clap derives the flag long-name from the field name, the subcommand now exposes `--output-file <PathBuf>` and no longer shadows the global `--output`. Same semantics, same write logic, no UX regression.

```
$ ./target/debug/aasm policy simulate --help
…
      --output-file <OUTPUT_FILE>
          Path to write the simulation report JSON.

          Named `--output-file` (not `--output`) to avoid collision with
          the top-level global `--output <OutputFormat>` flag.
```

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [ ] No
- [x] Yes (describe below)

The CLI flag `aasm policy simulate --output <path>` no longer exists; the same semantics now live behind `--output-file <path>`. The flag has never reached a release (it's only used by `policy simulate`, which has been completely broken by the panic) — but anyone running the unreleased binary against scripts referencing `--output` will see clap's "unknown flag" error and must switch to `--output-file`. No deprecation alias is shipped because there are no real-world callers (every call previously panicked).

## Related Issues

- Related Jira ticket: [AAASM-1465](https://lightning-dust-mite.atlassian.net/browse/AAASM-1465)
- Discovered by: [AAASM-1261](https://lightning-dust-mite.atlassian.net/browse/AAASM-1261) — the two relaxed tests are tightened back up in this PR.

## Acceptance criteria

| AC | Where it's covered |
| --- | --- |
| `aasm policy simulate --policy <yaml>` no longer panics — emits "--against <log-file> is required …" | `policy_simulate_without_against_or_live_returns_error` (tightened) |
| `aasm policy simulate --policy <yaml> --live` returns the AAASM-73 "not yet supported" message | `policy_simulate_live_mode_returns_not_yet_supported` (tightened) |
| `aasm policy simulate --policy <yaml> --against <log>` succeeds end-to-end | `policy_simulate_with_output_file_writes_report` (new, exercises the full path with `--against`) |
| `aasm policy simulate --policy <yaml> --against <log> --output-file <path>` writes the report to `<path>` | `policy_simulate_with_output_file_writes_report` (new — re-reads the file and asserts `total_events == 2`) |
| AAASM-1261's two relaxed tests are tightened back up | Commits 2 + 3 below |

## Testing

- [x] Unit tests added / updated — `SimulateArgs { output_file: None }` in the four colocated unit tests in `aa-cli/src/commands/policy/simulate.rs`
- [x] Integration tests added / updated — two existing tests tightened + renamed to match the AC test names; one new positive test added
- [x] Manual testing performed — see CLI sanity output below
- [ ] No tests required (explain why)

```
$ ./target/debug/aasm policy simulate --policy …/allow_all.yaml
error: --against <log-file> is required for file-based simulation
$ echo $?  # 1

$ ./target/debug/aasm policy simulate --policy …/allow_all.yaml --live
error: live simulation is not yet supported (requires AAASM-73)
$ echo $?  # 1
```

Local validation gate:

| Command | Result |
| --- | --- |
| `cargo nextest run -p aa-integration-tests --test cli_policy` | 17 / 17 pass |
| `cargo nextest run -p aa-cli` | 493 / 493 pass |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy -p aa-cli -p aa-integration-tests --all-targets --all-features -- -D warnings` | clean |

## Commit breakdown

| Commit | Scope |
| --- | --- |
| 🐛 (aa-cli): Rename simulate `--output` to `--output-file` | Field + write site + 4 colocated unit-test constructors |
| ✅ (aa-it): Tighten policy_simulate_live test to assert AAASM-73 stderr | Existing test, renamed + stderr assertion |
| ✅ (aa-it): Tighten policy_simulate_without_against test to assert stderr | Existing test, renamed + stderr assertion |
| ✅ (aa-it): Add policy_simulate_with_output_file_writes_report test | New positive test covering AC item 4 |

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed — flag rename reflected in the field doc-comment and rustdoc
- [ ] All CI checks passing — pending CI
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1465]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ