### PR TITLE
[AAASM-1689] ✨ (aa-core): Add DeploymentMode enum scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "criterion",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2 0.11.0",
  "thiserror 2.0.18",
 ]

--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -26,6 +26,7 @@ test-utils = []
 [dev-dependencies]
 criterion  = { version = "0.8", features = ["html_reports"] }
 serde_json = "1"
+serde_yaml = "0.9"
 
 [[bench]]
 name    = "scanner_bench"

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -1,0 +1,30 @@
+//! Gateway deployment-mode configuration types (Epic 17, AAASM-1568).
+//!
+//! Configuration is loaded once at startup and threaded through the
+//! application. This module is the **foundation** of Epic 17 — every
+//! other story in the Epic depends on these types to decide whether
+//! the gateway should boot in local-dev or remote-control-plane mode.
+
+/// Which deployment topology the gateway should boot into.
+///
+/// Selected at startup from a combination of YAML config, environment
+/// variables, and CLI flags. See [Epic 17 spec][epic] for the full
+/// precedence rules.
+///
+/// [epic]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1568
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+pub enum DeploymentMode {
+    /// Lightweight in-process control plane on `localhost:7391`.
+    ///
+    /// Zero-config developer experience: SQLite storage, embedded
+    /// dashboard, no network connectivity required.
+    #[default]
+    Local,
+    /// Independently-deployed control plane reached over the network.
+    ///
+    /// Agents on multiple machines all register against one gateway.
+    /// PostgreSQL storage, TLS required for production.
+    Remote,
+}

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -28,3 +28,13 @@ pub enum DeploymentMode {
     /// PostgreSQL storage, TLS required for production.
     Remote,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deployment_mode_default_is_local() {
+        assert_eq!(DeploymentMode::default(), DeploymentMode::Local);
+    }
+}

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -37,4 +37,25 @@ mod tests {
     fn deployment_mode_default_is_local() {
         assert_eq!(DeploymentMode::default(), DeploymentMode::Local);
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deployment_mode_yaml_round_trip_local() {
+        let mode: DeploymentMode = serde_yaml::from_str("local").unwrap();
+        assert_eq!(mode, DeploymentMode::Local);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deployment_mode_yaml_round_trip_remote() {
+        let mode: DeploymentMode = serde_yaml::from_str("remote").unwrap();
+        assert_eq!(mode, DeploymentMode::Remote);
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn deployment_mode_yaml_rejects_unknown_variant() {
+        let result: Result<DeploymentMode, _> = serde_yaml::from_str("foobar");
+        assert!(result.is_err(), "unknown variant should fail to deserialize");
+    }
 }

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -29,6 +29,8 @@ pub mod approval;
 pub mod audit;
 #[cfg(feature = "alloc")]
 pub mod capability;
+#[cfg(feature = "std")]
+pub mod config;
 pub mod dev_tool;
 pub mod evaluators;
 pub mod identity;
@@ -74,6 +76,9 @@ pub use capability::{
 
 #[cfg(feature = "std")]
 pub use scanner::{CredentialFinding, CredentialKind, CredentialScanner, ScanResult, ScannerConfig};
+
+#[cfg(feature = "std")]
+pub use config::DeploymentMode;
 
 pub use topology::EdgeType;
 #[cfg(all(feature = "std", feature = "test-utils"))]


### PR DESCRIPTION
## Description

Foundation commit for **Epic 17 — Gateway Deployment Architecture** ([AAASM-1568](https://lightning-dust-mite.atlassian.net/browse/AAASM-1568)) and Story S-A ([AAASM-1575](https://lightning-dust-mite.atlassian.net/browse/AAASM-1575)).

Adds a new `aa-core::config` module containing the `DeploymentMode` enum — the type every other Epic 17 story will read to decide whether the gateway boots in local-dev or remote-control-plane mode. No I/O, no env-var parsing, no top-level `GatewayConfig` yet — those land in follow-up sub-tickets so each PR stays small and bisectable.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

The new module is gated behind `feature = "std"`; downstream consumers that already enable `std` (the default) get the new public type, callers building with `default-features = false` see no surface change.

## Related Issues

- Related Jira ticket: [AAASM-1689](https://lightning-dust-mite.atlassian.net/browse/AAASM-1689)
- Parent Story: [AAASM-1575](https://lightning-dust-mite.atlassian.net/browse/AAASM-1575)
- Parent Epic: [AAASM-1568](https://lightning-dust-mite.atlassian.net/browse/AAASM-1568)

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Four tests under `aa-core::config::tests`:

| Test | Feature gate | Asserts |
|---|---|---|
| `deployment_mode_default_is_local` | always-on | `DeploymentMode::default() == Local` — locks the zero-config dev UX guarantee |
| `deployment_mode_yaml_round_trip_local` | `serde` | YAML `"local"` deserializes to `Local` |
| `deployment_mode_yaml_round_trip_remote` | `serde` | YAML `"remote"` deserializes to `Remote` |
| `deployment_mode_yaml_rejects_unknown_variant` | `serde` | `"foobar"` returns an error (groundwork for the `InvalidMode` error in AAASM-1692) |

Local verification:

```
cargo nextest run -p aa-core --all-features  # 189 passed, 0 skipped
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all -- --check                                 # clean
```

## Commit-by-commit

1. ✨ `(aa-core)` Add `DeploymentMode` enum in new config module
2. ✨ `(aa-core)` Export config module from aa-core lib
3. ✅ `(aa-core)` Add `DeploymentMode::default` test
4. ⬆️ `(aa-core)` Add `serde_yaml` dev-dependency for config tests
5. ✅ `(aa-core)` Add `DeploymentMode` serde round-trip tests
6. 🔧 `(aa-core)` Sync `Cargo.lock` with `serde_yaml` dev-dep

## Follow-up sub-tickets (same Story)

- AAASM-1690 — sub-structs (LocalModeConfig / RemoteModeConfig / TlsConfig / AgentConnectConfig)
- AAASM-1691 — `GatewayConfig` top-level + YAML loader + `~` expansion
- AAASM-1692 — env-var override layer + invalid-value error handling
- AAASM-1693 — Story-level acceptance verification

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --all-targets --all-features`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on the new enum + variants)
- [ ] All CI checks passing (awaiting CI)
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1568]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1575]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1689]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ