### PR TITLE
[AAASM-1694] ✨ (storage): Define StorageBackend trait and supporting value types

### DIFF
--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -21,6 +21,7 @@ pub mod registry;
 pub mod server;
 pub mod service;
 pub mod simulation;
+pub mod storage;
 
 pub use audit_reader::AuditReader;
 pub use engine::{EvaluationResult, PolicyEngine, PolicyLoadError};

--- a/aa-gateway/src/storage/agent.rs
+++ b/aa-gateway/src/storage/agent.rs
@@ -1,0 +1,52 @@
+//! Agent-registry storage value types — slim records for persistence.
+//!
+//! These are deliberately distinct from the richer
+//! [`crate::registry::store::AgentRecord`] runtime state: the registry layer
+//! owns liveness, heartbeats, and credential tokens; the storage layer
+//! persists only the durable identity / configuration fields. Conversion
+//! between the two happens at the wiring layer (Epic 18 S-I).
+
+use std::collections::BTreeMap;
+
+use aa_core::identity::AgentId;
+use chrono::{DateTime, Utc};
+
+/// Team identifier used by the storage layer.
+///
+/// Kept as a type alias for now so existing `String` team_ids in the gateway
+/// can be passed through unchanged. May be replaced with a newtype later.
+pub type TeamId = String;
+
+/// Storage-layer agent record — the durable shape of a registered agent.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentRecord {
+    /// Stable agent identifier.
+    pub agent_id: AgentId,
+    /// Owning team, if assigned.
+    pub team_id: Option<TeamId>,
+    /// Owning org, if assigned.
+    pub org_id: Option<String>,
+    /// Arbitrary metadata (k/v).
+    pub metadata: BTreeMap<String, String>,
+    /// Initial registration timestamp (UTC).
+    pub registered_at: DateTime<Utc>,
+    /// Last time the agent was observed (UTC).
+    pub last_seen_at: DateTime<Utc>,
+    /// Enforcement mode — `"enforce"`, `"shadow"`, `"observe"`, etc.
+    pub enforcement_mode: String,
+}
+
+/// Filter applied to agent-registry queries.
+#[derive(Debug, Clone, Default)]
+pub struct AgentFilter {
+    /// Restrict to agents owned by this team.
+    pub team_id: Option<TeamId>,
+    /// Restrict to agents owned by this org.
+    pub org_id: Option<String>,
+    /// Substring match on agent metadata `name` key.
+    pub name_contains: Option<String>,
+    /// Maximum number of agents to return.
+    pub limit: Option<u32>,
+    /// Offset into the result set.
+    pub offset: Option<u32>,
+}

--- a/aa-gateway/src/storage/audit.rs
+++ b/aa-gateway/src/storage/audit.rs
@@ -1,0 +1,55 @@
+//! Audit-event storage value types — record + query filter.
+
+use aa_core::identity::AgentId;
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
+
+use super::agent::TeamId;
+
+/// Storage-layer audit event — the persisted shape of a policy / tool-call decision.
+///
+/// Kept distinct from [`aa_core::audit::AuditEntry`] (the in-memory enrichment
+/// shape used by the runtime audit pipeline). `AuditEvent` mirrors the columns
+/// the spec defines for the `audit_events` hypertable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditEvent {
+    /// Event timestamp (UTC).
+    pub ts: DateTime<Utc>,
+    /// Stable event identifier.
+    pub event_id: Uuid,
+    /// Agent the event was attributed to.
+    pub agent_id: AgentId,
+    /// Owning team, when known.
+    pub team_id: Option<TeamId>,
+    /// Action label (e.g. `"tool_call"`, `"policy_decision"`).
+    pub action: String,
+    /// Decision label (e.g. `"allow"`, `"deny"`, `"shadow"`).
+    pub decision: String,
+    /// True if the decision was produced in dry-run / shadow mode.
+    pub dry_run: bool,
+    /// Decision the gateway would have made in real mode, when `dry_run` is true.
+    pub shadow_decision: Option<String>,
+    /// Identifier of the policy rule that matched, if any.
+    pub matched_rule_id: Option<String>,
+    /// Free-form JSON payload (wire-protocol record, redactions, lineage…).
+    pub payload: Option<serde_json::Value>,
+}
+
+/// Filter applied to audit-event queries.
+#[derive(Debug, Clone, Default)]
+pub struct AuditFilter {
+    /// Restrict to events for this agent.
+    pub agent_id: Option<AgentId>,
+    /// Restrict to events for this team.
+    pub team_id: Option<TeamId>,
+    /// Inclusive lower bound (UTC).
+    pub from: Option<DateTime<Utc>>,
+    /// Exclusive upper bound (UTC).
+    pub to: Option<DateTime<Utc>>,
+    /// When true, only dry-run events are returned.
+    pub dry_run_only: bool,
+    /// Maximum number of events to return.
+    pub limit: Option<u32>,
+    /// Offset into the result set (for paging).
+    pub offset: Option<u32>,
+}

--- a/aa-gateway/src/storage/backend.rs
+++ b/aa-gateway/src/storage/backend.rs
@@ -1,0 +1,168 @@
+//! Async trait abstracting persistence for the gateway control plane.
+
+use async_trait::async_trait;
+
+use aa_core::identity::AgentId;
+
+use super::agent::{AgentFilter, AgentRecord};
+use super::audit::{AuditEvent, AuditFilter};
+use super::error::StorageResult;
+use super::health::StorageHealth;
+use super::metric::{Metric, MetricPoint, MetricQuery};
+use super::policy::{PolicyDocument, PolicyMeta, PolicyVersion};
+use super::retention::{RetentionPolicy, RetentionStats};
+
+/// Persistence contract used by the gateway runtime.
+///
+/// Concrete implementations land in later Epic-18 stories:
+///
+/// - SQLite backend — Epic 18 S-B
+/// - PostgreSQL backend — Epic 18 S-C
+///
+/// Business logic must only depend on this trait. Importing a database
+/// driver (`sqlx`, `rusqlite`, …) anywhere outside the `storage` module is
+/// prohibited by the parent Story's acceptance criteria.
+#[async_trait]
+pub trait StorageBackend: Send + Sync + 'static {
+    /// Append a single audit event.
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::QueryFailed`](super::StorageError::QueryFailed)
+    ///   when the backend rejects the write.
+    /// - [`StorageError::ConnectionFailed`](super::StorageError::ConnectionFailed)
+    ///   when the connection is lost.
+    async fn append_audit_event(&self, event: &AuditEvent) -> StorageResult<()>;
+
+    /// Return audit events matching `filter`, ordered by timestamp descending.
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::QueryFailed`](super::StorageError::QueryFailed)
+    ///   when the filter is invalid for the backend or the query fails.
+    async fn query_audit_events(&self, filter: AuditFilter) -> StorageResult<Vec<AuditEvent>>;
+
+    /// Return the number of audit events matching `filter`.
+    ///
+    /// # Errors
+    ///
+    /// Same conditions as [`query_audit_events`](Self::query_audit_events).
+    async fn count_audit_events(&self, filter: AuditFilter) -> StorageResult<u64>;
+
+    /// Insert or update an agent record.
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::Conflict`](super::StorageError::Conflict)
+    ///   when an optimistic-concurrency check fails.
+    /// - [`StorageError::QueryFailed`](super::StorageError::QueryFailed)
+    ///   on backend failure.
+    async fn upsert_agent(&self, record: AgentRecord) -> StorageResult<()>;
+
+    /// Return the agent record for `id`, if registered.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Ok(None)` for unknown ids; only backend failure surfaces
+    /// as [`StorageError::QueryFailed`](super::StorageError::QueryFailed) /
+    /// [`StorageError::ConnectionFailed`](super::StorageError::ConnectionFailed).
+    async fn get_agent(&self, id: &AgentId) -> StorageResult<Option<AgentRecord>>;
+
+    /// Return all agent records matching `filter`, paged per the filter limits.
+    ///
+    /// # Errors
+    ///
+    /// As [`query_audit_events`](Self::query_audit_events).
+    async fn list_agents(&self, filter: AgentFilter) -> StorageResult<Vec<AgentRecord>>;
+
+    /// Remove the agent record for `id`.
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::NotFound`](super::StorageError::NotFound)
+    ///   when no record matches.
+    async fn delete_agent(&self, id: &AgentId) -> StorageResult<()>;
+
+    /// Save a new policy version. Returns the assigned [`PolicyVersion`].
+    ///
+    /// The freshly-saved version is not automatically marked active;
+    /// callers must use [`rollback_policy`](Self::rollback_policy) to
+    /// activate a specific version.
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::Conflict`](super::StorageError::Conflict)
+    ///   if a same-name, same-content version already exists and the
+    ///   backend rejects the duplicate.
+    async fn save_policy(&self, doc: PolicyDocument) -> StorageResult<PolicyVersion>;
+
+    /// Return the currently-active version of `name`, if any.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Ok(None)` for unknown names; only backend failure surfaces
+    /// as a [`StorageError`](super::StorageError).
+    async fn get_active_policy(&self, name: &str) -> StorageResult<Option<PolicyDocument>>;
+
+    /// List all stored versions of `name` (metadata only).
+    ///
+    /// # Errors
+    ///
+    /// As [`query_audit_events`](Self::query_audit_events). An unknown name
+    /// returns `Ok(vec![])`.
+    async fn list_policy_versions(&self, name: &str) -> StorageResult<Vec<PolicyMeta>>;
+
+    /// Mark `version` of `name` as the active version.
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::NotFound`](super::StorageError::NotFound)
+    ///   if `(name, version)` does not exist.
+    async fn rollback_policy(&self, name: &str, version: u32) -> StorageResult<()>;
+
+    /// Record a single metric sample.
+    ///
+    /// # Errors
+    ///
+    /// As [`append_audit_event`](Self::append_audit_event).
+    async fn record_metric(&self, m: Metric) -> StorageResult<()>;
+
+    /// Return metric points matching `q`.
+    ///
+    /// # Errors
+    ///
+    /// As [`query_audit_events`](Self::query_audit_events).
+    async fn query_metrics(&self, q: MetricQuery) -> StorageResult<Vec<MetricPoint>>;
+
+    /// Run any pending schema migrations.
+    ///
+    /// Must be idempotent — calling on an already-migrated database is a
+    /// no-op.
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::MigrationFailed`](super::StorageError::MigrationFailed)
+    ///   when a migration fails to apply or verify.
+    async fn migrate(&self) -> StorageResult<()>;
+
+    /// Apply `policy` to existing data: compress warm-tier rows, archive or
+    /// drop cold-tier rows.
+    ///
+    /// When `policy.dry_run == true`, return statistics for the actions
+    /// that *would* be taken without performing them.
+    ///
+    /// # Errors
+    ///
+    /// - [`StorageError::RetentionError`](super::StorageError::RetentionError)
+    ///   on a non-fatal retention failure.
+    /// - [`StorageError::QueryFailed`](super::StorageError::QueryFailed)
+    ///   on backend failure during the run.
+    async fn apply_retention(&self, policy: &RetentionPolicy) -> StorageResult<RetentionStats>;
+
+    /// Probe backend liveness, latency, and current row counts.
+    ///
+    /// A degraded but reachable backend returns `Ok` with
+    /// `StorageHealth.status = HealthStatus::Degraded` rather than an
+    /// error. Errors only when the probe itself fails.
+    async fn healthcheck(&self) -> StorageResult<StorageHealth>;
+}

--- a/aa-gateway/src/storage/error.rs
+++ b/aa-gateway/src/storage/error.rs
@@ -1,0 +1,31 @@
+//! Failure modes returned by every [`StorageBackend`](super::StorageBackend) operation.
+
+/// Result alias used across the storage layer.
+pub type StorageResult<T> = Result<T, StorageError>;
+
+/// Errors any storage backend may return.
+///
+/// Variants are intentionally broad so concrete backends (`sqlx`, `rusqlite`, …)
+/// can map their driver-specific errors into one of these without leaking
+/// driver types into the trait surface.
+#[derive(Debug, thiserror::Error)]
+pub enum StorageError {
+    /// Backend connection could not be established or was lost mid-operation.
+    #[error("connection failed: {0}")]
+    ConnectionFailed(String),
+    /// Query execution failed at the backend.
+    #[error("query failed: {0}")]
+    QueryFailed(String),
+    /// Schema migration failed to apply or verify.
+    #[error("migration failed: {0}")]
+    MigrationFailed(String),
+    /// Requested record does not exist.
+    #[error("record not found: {0}")]
+    NotFound(String),
+    /// Uniqueness, version, or optimistic-concurrency conflict.
+    #[error("conflict: {0}")]
+    Conflict(String),
+    /// Retention-policy enforcement encountered a non-fatal error.
+    #[error("retention error: {0}")]
+    RetentionError(String),
+}

--- a/aa-gateway/src/storage/health.rs
+++ b/aa-gateway/src/storage/health.rs
@@ -1,0 +1,37 @@
+//! Storage health-report value types returned by
+//! [`StorageBackend::healthcheck`](super::StorageBackend::healthcheck).
+
+/// Coarse health state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HealthStatus {
+    /// Backend is reachable and responsive within expected latency.
+    Ok,
+    /// Backend is reachable but degraded — slow queries or partial features.
+    Degraded,
+    /// Backend is unreachable or returning errors.
+    Unavailable,
+}
+
+/// Row-count snapshot across top-level storage entities.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RowCounts {
+    /// Total number of audit events stored across all tiers.
+    pub audit_events: u64,
+    /// Number of registered agents.
+    pub agents: u64,
+    /// Number of stored policy versions across all policy names.
+    pub policy_versions: u64,
+}
+
+/// Aggregate health report.
+#[derive(Debug, Clone)]
+pub struct StorageHealth {
+    /// Overall status.
+    pub status: HealthStatus,
+    /// Static backend identifier — e.g. `"sqlite"`, `"postgres"`.
+    pub backend: &'static str,
+    /// Latency of the healthcheck probe in milliseconds.
+    pub latency_ms: u32,
+    /// Row-count snapshot taken during the probe.
+    pub row_counts: RowCounts,
+}

--- a/aa-gateway/src/storage/metric.rs
+++ b/aa-gateway/src/storage/metric.rs
@@ -1,0 +1,47 @@
+//! Metric storage value types — sample record, query, and result point.
+
+use std::collections::BTreeMap;
+
+use aa_core::identity::AgentId;
+use chrono::{DateTime, Utc};
+
+/// A single metric sample that may be persisted to storage.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Metric {
+    /// Sample timestamp (UTC).
+    pub ts: DateTime<Utc>,
+    /// Agent the metric is attributed to.
+    pub agent_id: AgentId,
+    /// Metric name (e.g. `"tokens_used"`, `"events_per_sec"`, `"cost_usd"`).
+    pub metric: String,
+    /// Numeric sample value.
+    pub value: f64,
+    /// Free-form labels for slicing (e.g. provider, model, tool).
+    pub labels: BTreeMap<String, String>,
+}
+
+/// Query parameters for fetching metric points.
+#[derive(Debug, Clone, Default)]
+pub struct MetricQuery {
+    /// Restrict to this agent.
+    pub agent_id: Option<AgentId>,
+    /// Restrict to this metric name.
+    pub metric: Option<String>,
+    /// Inclusive lower bound (UTC).
+    pub from: Option<DateTime<Utc>>,
+    /// Exclusive upper bound (UTC).
+    pub to: Option<DateTime<Utc>>,
+    /// Optional aggregation bucket (e.g. `"1 minute"`, `"1 hour"`).
+    pub bucket: Option<String>,
+    /// Maximum number of points to return.
+    pub limit: Option<u32>,
+}
+
+/// A single metric data point returned by [`MetricQuery`].
+#[derive(Debug, Clone, PartialEq)]
+pub struct MetricPoint {
+    /// Bucket timestamp (UTC). For raw samples this is the sample's `ts`.
+    pub ts: DateTime<Utc>,
+    /// Aggregated or raw value at this timestamp.
+    pub value: f64,
+}

--- a/aa-gateway/src/storage/mod.rs
+++ b/aa-gateway/src/storage/mod.rs
@@ -1,10 +1,30 @@
 //! Storage backend abstraction for the gateway control plane.
 //!
-//! Submodules are added incrementally under
-//! [AAASM-1694](https://lightning-dust-mite.atlassian.net/browse/AAASM-1694).
+//! This module owns the [`StorageBackend`] trait — the single point of
+//! contact between the gateway's business logic and any persistent data
+//! store. The trait is intentionally driver-agnostic: importing a database
+//! driver (`sqlx`, `rusqlite`, `redis`, …) anywhere outside the `storage`
+//! module is prohibited (Epic 18, Story S-A acceptance criterion).
+//!
+//! Concrete implementations land in subsequent Epic-18 stories:
+//!
+//! - SQLite backend — Epic 18 S-B
+//! - PostgreSQL backend (with TimescaleDB hypertables) — Epic 18 S-C / S-D
+//! - Migration runner — Epic 18 S-E
+//! - Retention engine — Epic 18 S-F
+//! - Redis cache — Epic 18 S-G
+//! - Wire-up into the gateway, replacing in-memory stores — Epic 18 S-I
+//!
+//! ## Value-type ownership
+//!
+//! The storage layer defines its own value types ([`AuditEvent`],
+//! [`AgentRecord`], [`PolicyVersion`], …) rather than reusing the gateway's
+//! richer runtime structs. Keeping the two sides separate prevents the
+//! storage schema from drifting whenever a runtime type grows new fields.
 
 pub mod agent;
 pub mod audit;
+pub mod backend;
 pub mod error;
 pub mod health;
 pub mod metric;
@@ -13,6 +33,7 @@ pub mod retention;
 
 pub use agent::{AgentFilter, AgentRecord, TeamId};
 pub use audit::{AuditEvent, AuditFilter};
+pub use backend::StorageBackend;
 pub use error::{StorageError, StorageResult};
 pub use health::{HealthStatus, RowCounts, StorageHealth};
 pub use metric::{Metric, MetricPoint, MetricQuery};

--- a/aa-gateway/src/storage/mod.rs
+++ b/aa-gateway/src/storage/mod.rs
@@ -2,3 +2,7 @@
 //!
 //! Submodules are added incrementally under
 //! [AAASM-1694](https://lightning-dust-mite.atlassian.net/browse/AAASM-1694).
+
+pub mod error;
+
+pub use error::{StorageError, StorageResult};

--- a/aa-gateway/src/storage/mod.rs
+++ b/aa-gateway/src/storage/mod.rs
@@ -3,8 +3,10 @@
 //! Submodules are added incrementally under
 //! [AAASM-1694](https://lightning-dust-mite.atlassian.net/browse/AAASM-1694).
 
+pub mod agent;
 pub mod error;
 pub mod health;
 
+pub use agent::{AgentFilter, AgentRecord, TeamId};
 pub use error::{StorageError, StorageResult};
 pub use health::{HealthStatus, RowCounts, StorageHealth};

--- a/aa-gateway/src/storage/mod.rs
+++ b/aa-gateway/src/storage/mod.rs
@@ -1,0 +1,4 @@
+//! Storage backend abstraction for the gateway control plane.
+//!
+//! Submodules are added incrementally under
+//! [AAASM-1694](https://lightning-dust-mite.atlassian.net/browse/AAASM-1694).

--- a/aa-gateway/src/storage/mod.rs
+++ b/aa-gateway/src/storage/mod.rs
@@ -4,5 +4,7 @@
 //! [AAASM-1694](https://lightning-dust-mite.atlassian.net/browse/AAASM-1694).
 
 pub mod error;
+pub mod health;
 
 pub use error::{StorageError, StorageResult};
+pub use health::{HealthStatus, RowCounts, StorageHealth};

--- a/aa-gateway/src/storage/mod.rs
+++ b/aa-gateway/src/storage/mod.rs
@@ -4,9 +4,11 @@
 //! [AAASM-1694](https://lightning-dust-mite.atlassian.net/browse/AAASM-1694).
 
 pub mod agent;
+pub mod audit;
 pub mod error;
 pub mod health;
 
 pub use agent::{AgentFilter, AgentRecord, TeamId};
+pub use audit::{AuditEvent, AuditFilter};
 pub use error::{StorageError, StorageResult};
 pub use health::{HealthStatus, RowCounts, StorageHealth};

--- a/aa-gateway/src/storage/mod.rs
+++ b/aa-gateway/src/storage/mod.rs
@@ -9,6 +9,7 @@ pub mod error;
 pub mod health;
 pub mod metric;
 pub mod policy;
+pub mod retention;
 
 pub use agent::{AgentFilter, AgentRecord, TeamId};
 pub use audit::{AuditEvent, AuditFilter};
@@ -16,3 +17,4 @@ pub use error::{StorageError, StorageResult};
 pub use health::{HealthStatus, RowCounts, StorageHealth};
 pub use metric::{Metric, MetricPoint, MetricQuery};
 pub use policy::{PolicyDocument, PolicyMeta, PolicyVersion};
+pub use retention::{ColdAction, RetentionPolicy, RetentionStats};

--- a/aa-gateway/src/storage/mod.rs
+++ b/aa-gateway/src/storage/mod.rs
@@ -8,9 +8,11 @@ pub mod audit;
 pub mod error;
 pub mod health;
 pub mod metric;
+pub mod policy;
 
 pub use agent::{AgentFilter, AgentRecord, TeamId};
 pub use audit::{AuditEvent, AuditFilter};
 pub use error::{StorageError, StorageResult};
 pub use health::{HealthStatus, RowCounts, StorageHealth};
 pub use metric::{Metric, MetricPoint, MetricQuery};
+pub use policy::{PolicyDocument, PolicyMeta, PolicyVersion};

--- a/aa-gateway/src/storage/mod.rs
+++ b/aa-gateway/src/storage/mod.rs
@@ -7,8 +7,10 @@ pub mod agent;
 pub mod audit;
 pub mod error;
 pub mod health;
+pub mod metric;
 
 pub use agent::{AgentFilter, AgentRecord, TeamId};
 pub use audit::{AuditEvent, AuditFilter};
 pub use error::{StorageError, StorageResult};
 pub use health::{HealthStatus, RowCounts, StorageHealth};
+pub use metric::{Metric, MetricPoint, MetricQuery};

--- a/aa-gateway/src/storage/policy.rs
+++ b/aa-gateway/src/storage/policy.rs
@@ -1,0 +1,39 @@
+//! Policy storage value types — input document, stored version, and metadata.
+
+use chrono::{DateTime, Utc};
+
+/// Lightweight metadata for a stored policy version (no document body).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolicyMeta {
+    /// Policy name (unique key).
+    pub name: String,
+    /// Monotonic version number assigned by the backend on insert.
+    pub version: u32,
+    /// When this version was persisted (UTC).
+    pub created_at: DateTime<Utc>,
+    /// True if this version is currently active.
+    pub is_active: bool,
+}
+
+/// Input shape for saving a new policy.
+///
+/// Storage-layer counterpart of the runtime
+/// [`crate::policy::document::PolicyDocument`]: this type holds just the name
+/// and the raw document bytes (YAML or JSON, as authored) so the storage
+/// layer never has to parse policy semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolicyDocument {
+    /// Policy name.
+    pub name: String,
+    /// Raw document bytes — YAML or JSON, exactly as authored.
+    pub bytes: Vec<u8>,
+}
+
+/// Persisted policy version — metadata plus the document body.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolicyVersion {
+    /// Metadata (name, version, created_at, is_active).
+    pub meta: PolicyMeta,
+    /// Document body persisted alongside the metadata.
+    pub document: PolicyDocument,
+}

--- a/aa-gateway/src/storage/retention.rs
+++ b/aa-gateway/src/storage/retention.rs
@@ -1,0 +1,47 @@
+//! Retention-policy descriptor + applied-result statistics.
+
+use chrono::{DateTime, Utc};
+
+/// Action taken on cold-tier rows once they exceed `warm_days`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColdAction {
+    /// Archive rows to an external store (e.g. S3).
+    Archive,
+    /// Drop rows permanently.
+    Drop,
+}
+
+/// Operator-configurable retention policy applied by
+/// [`StorageBackend::apply_retention`](super::StorageBackend::apply_retention).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetentionPolicy {
+    /// Number of days a row stays indexed and queryable in hot tier.
+    pub hot_days: u32,
+    /// Number of days a row stays in warm tier (compressed) before cold action.
+    pub warm_days: u32,
+    /// Action to take on rows older than `warm_days`.
+    pub cold_action: ColdAction,
+    /// Archive URL (e.g. `s3://bucket/path`) — required when
+    /// `cold_action == ColdAction::Archive`.
+    pub archive_url: Option<String>,
+    /// When true, log the work that would be performed without taking action.
+    pub dry_run: bool,
+}
+
+/// Outcome of a single
+/// [`apply_retention`](super::StorageBackend::apply_retention) invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetentionStats {
+    /// Rows in hot tier after the run.
+    pub hot_rows: u64,
+    /// Rows compressed into warm tier during the run.
+    pub compressed_rows: u64,
+    /// Rows archived during the run.
+    pub archived_rows: u64,
+    /// Rows dropped during the run.
+    pub dropped_rows: u64,
+    /// Bytes freed from primary storage as a result of compression / drop.
+    pub freed_bytes: u64,
+    /// Timestamp at which the run completed.
+    pub ran_at: DateTime<Utc>,
+}


### PR DESCRIPTION
## Description

First Story of [AAASM-1569 (Epic 18: Durable Persistence Layer)](https://lightning-dust-mite.atlassian.net/browse/AAASM-1569). Lands the `StorageBackend` trait and its supporting value types in a fresh `aa-gateway::storage` module. No database driver code — concrete SQLite (S-B) and PostgreSQL (S-C) implementations are separate Stories under the same Epic.

The module is organised into eight files:

| File | Contents |
|---|---|
| `mod.rs` | Module root + public re-exports (no driver imports) |
| `error.rs` | `StorageError` (`thiserror`) + `StorageResult<T>` |
| `health.rs` | `HealthStatus`, `RowCounts`, `StorageHealth` |
| `agent.rs` | Storage-layer `AgentRecord`, `AgentFilter`, `TeamId` |
| `audit.rs` | Storage-layer `AuditEvent`, `AuditFilter` |
| `metric.rs` | `Metric`, `MetricQuery`, `MetricPoint` |
| `policy.rs` | `PolicyDocument`, `PolicyMeta`, `PolicyVersion` |
| `retention.rs` | `ColdAction`, `RetentionPolicy`, `RetentionStats` |
| `backend.rs` | `#[async_trait] pub trait StorageBackend` with rustdoc on every method |

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

The new `aa_gateway::storage` module is purely additive. Existing in-memory `audit_store.rs` and `registry::store::AgentRecord` are untouched — those are replaced in a later Story (E18 S-I, AAASM-1590).

## Related Issues

- Related Jira ticket: [AAASM-1694](https://lightning-dust-mite.atlassian.net/browse/AAASM-1694) (Impl sub-task of [AAASM-1583](https://lightning-dust-mite.atlassian.net/browse/AAASM-1583), under [AAASM-1569 Epic 18](https://lightning-dust-mite.atlassian.net/browse/AAASM-1569))
- Verification follow-up: [AAASM-1695](https://lightning-dust-mite.atlassian.net/browse/AAASM-1695) (separate PR per workspace one-PR-per-subtask policy)

## Testing

Describe the testing performed for this PR:

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [x] No tests required (explain why)

This PR delivers a trait abstraction with no behaviour. Concrete impls (S-B SQLite, S-C PostgreSQL) carry the unit + integration tests for their backend semantics. The dyn-safety / public-surface tests for the trait itself ship in the verification sub-task PR [AAASM-1695].

Pre-push validation:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean (lefthook pre-commit ran on every commit)
- `cargo check -p aa-gateway` — clean
- `cargo doc -p aa-gateway --no-deps` — clean (pre-push hook); 18 pre-existing warnings in `registry/`, none in `storage/`
- `grep -rE 'use (sqlx|rusqlite|postgres|redis|tokio_postgres)' aa-gateway/src/storage/` — no matches (AC: no DB-driver imports)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (every trait method has rustdoc; module-level docs added)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention (9 commits, one per module file)

[AAASM-1694]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ