### PR TITLE
[AAASM-1690] ✨ (aa-core): Add config sub-structs

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,2 +1,12 @@
 extends:
   - spectral:oas
+rules:
+  # Spectral 6.16's `duplicated-entry-in-enum` rule walks `$..[?(@.enum)]`
+  # via nimma and crashes with "Cannot read properties of null (reading
+  # 'enum')" against our `openapi: 3.1.0` spec — utoipa emits the
+  # type-array nullable form (`type: [string, "null"]`) for any
+  # `Option<T>`, and nimma's compiled JSONPath treats the `type` array as
+  # a candidate node and dereferences `.enum` on a null. Disable the rule
+  # until Spectral ships a 3.1-aware traversal; utoipa never emits
+  # duplicate enum entries anyway.
+  duplicated-entry-in-enum: off

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -5,6 +5,7 @@
 //! other story in the Epic depends on these types to decide whether
 //! the gateway should boot in local-dev or remote-control-plane mode.
 
+use std::net::SocketAddr;
 use std::path::PathBuf;
 
 /// Which deployment topology the gateway should boot into.
@@ -70,6 +71,36 @@ pub struct TlsConfig {
     pub cert_file: PathBuf,
     /// PEM-encoded private key matching `cert_file`.
     pub key_file: PathBuf,
+}
+
+/// Configuration for the network-reachable **remote** control plane.
+///
+/// Defaults bind to `0.0.0.0:7391` with no TLS and no database —
+/// production callers must explicitly configure `tls` and
+/// `database_url` before serving real traffic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(default))]
+pub struct RemoteModeConfig {
+    /// Address the gateway binds to. Default: `0.0.0.0:7391`.
+    pub listen_addr: SocketAddr,
+    /// TLS cert / key paths. `None` disables TLS (development only).
+    pub tls: Option<TlsConfig>,
+    /// PostgreSQL connection URL. `None` falls back to in-memory storage.
+    pub database_url: Option<String>,
+    /// Optional Redis URL used by the rate-limit and pub/sub subsystems.
+    pub redis_url: Option<String>,
+}
+
+impl Default for RemoteModeConfig {
+    fn default() -> Self {
+        Self {
+            listen_addr: SocketAddr::from(([0, 0, 0, 0], 7391)),
+            tls: None,
+            database_url: None,
+            redis_url: None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -153,4 +153,24 @@ mod tests {
             "storage_path should fall back to default"
         );
     }
+
+    #[test]
+    fn remote_mode_config_default_binds_all_interfaces() {
+        let cfg = RemoteModeConfig::default();
+        assert_eq!(cfg.listen_addr, SocketAddr::from(([0, 0, 0, 0], 7391)));
+        assert!(cfg.tls.is_none(), "tls should be opt-in, never on by default");
+        assert!(cfg.database_url.is_none());
+        assert!(cfg.redis_url.is_none());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn remote_mode_config_yaml_overrides_database_keeps_other_defaults() {
+        let yaml = r#"database_url: "postgres://aasm@db.internal/aasm""#;
+        let cfg: RemoteModeConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.database_url.as_deref(), Some("postgres://aasm@db.internal/aasm"));
+        assert_eq!(cfg.listen_addr, SocketAddr::from(([0, 0, 0, 0], 7391)));
+        assert!(cfg.tls.is_none());
+        assert!(cfg.redis_url.is_none());
+    }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -87,4 +87,12 @@ mod tests {
         let result: Result<DeploymentMode, _> = serde_yaml::from_str("foobar");
         assert!(result.is_err(), "unknown variant should fail to deserialize");
     }
+
+    #[test]
+    fn local_mode_config_default_matches_spec() {
+        let cfg = LocalModeConfig::default();
+        assert_eq!(cfg.port, 7391);
+        assert!(cfg.dashboard);
+        assert_eq!(cfg.storage_path, PathBuf::from("~/.aasm/local.db"));
+    }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -197,4 +197,23 @@ mod tests {
         assert!(cfg.tls.is_none());
         assert!(cfg.redis_url.is_none());
     }
+
+    #[test]
+    fn agent_connect_config_default_points_at_localhost() {
+        let cfg = AgentConnectConfig::default();
+        assert_eq!(cfg.gateway_url, "http://localhost:7391");
+        assert!(cfg.api_key.is_none());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn agent_connect_config_yaml_round_trip() {
+        let yaml = r#"
+gateway_url: "https://cp.company.internal:7391"
+api_key: "secret"
+"#;
+        let cfg: AgentConnectConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(cfg.gateway_url, "https://cp.company.internal:7391");
+        assert_eq!(cfg.api_key.as_deref(), Some("secret"));
+    }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -5,6 +5,8 @@
 //! other story in the Epic depends on these types to decide whether
 //! the gateway should boot in local-dev or remote-control-plane mode.
 
+use std::path::PathBuf;
+
 /// Which deployment topology the gateway should boot into.
 ///
 /// Selected at startup from a combination of YAML config, environment
@@ -27,6 +29,33 @@ pub enum DeploymentMode {
     /// Agents on multiple machines all register against one gateway.
     /// PostgreSQL storage, TLS required for production.
     Remote,
+}
+
+/// Configuration for the in-process **local-dev** control plane.
+///
+/// All fields default to the zero-config developer values documented
+/// in the Epic 17 spec. `storage_path` is stored raw; `~` is expanded
+/// later by `GatewayConfig::expand_paths()` (added in AAASM-1691).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(default))]
+pub struct LocalModeConfig {
+    /// TCP port the local gateway listens on. Default: `7391`.
+    pub port: u16,
+    /// Whether to serve the dashboard SPA at the same address. Default: `true`.
+    pub dashboard: bool,
+    /// SQLite database path. Default: `~/.aasm/local.db` (un-expanded).
+    pub storage_path: PathBuf,
+}
+
+impl Default for LocalModeConfig {
+    fn default() -> Self {
+        Self {
+            port: 7391,
+            dashboard: true,
+            storage_path: PathBuf::from("~/.aasm/local.db"),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -95,4 +95,17 @@ mod tests {
         assert!(cfg.dashboard);
         assert_eq!(cfg.storage_path, PathBuf::from("~/.aasm/local.db"));
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn local_mode_config_yaml_overrides_port_keeps_other_defaults() {
+        let cfg: LocalModeConfig = serde_yaml::from_str("port: 8080").unwrap();
+        assert_eq!(cfg.port, 8080);
+        assert!(cfg.dashboard, "dashboard should fall back to default");
+        assert_eq!(
+            cfg.storage_path,
+            PathBuf::from("~/.aasm/local.db"),
+            "storage_path should fall back to default"
+        );
+    }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -103,6 +103,30 @@ impl Default for RemoteModeConfig {
     }
 }
 
+/// Agent-side connection settings (used by the SDK FFI shims, not the gateway).
+///
+/// `gateway_url` is the address the SDK calls into. `api_key` is the
+/// optional bearer token surface for authenticated SaaS deployments;
+/// in local mode it is typically `None`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(default))]
+pub struct AgentConnectConfig {
+    /// Where the SDK connects. Default: `http://localhost:7391`.
+    pub gateway_url: String,
+    /// Optional API key for authenticated control planes.
+    pub api_key: Option<String>,
+}
+
+impl Default for AgentConnectConfig {
+    fn default() -> Self {
+        Self {
+            gateway_url: String::from("http://localhost:7391"),
+            api_key: None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -58,6 +58,20 @@ impl Default for LocalModeConfig {
     }
 }
 
+/// TLS material for the remote control plane listener.
+///
+/// `None` on `RemoteModeConfig::tls` disables TLS (development only).
+/// Production deployments must supply both files; paths are stored raw
+/// and expanded by `GatewayConfig::expand_paths()` (AAASM-1691).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct TlsConfig {
+    /// PEM-encoded certificate chain.
+    pub cert_file: PathBuf,
+    /// PEM-encoded private key matching `cert_file`.
+    pub key_file: PathBuf,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -78,7 +78,7 @@ pub use capability::{
 pub use scanner::{CredentialFinding, CredentialKind, CredentialScanner, ScanResult, ScannerConfig};
 
 #[cfg(feature = "std")]
-pub use config::DeploymentMode;
+pub use config::{AgentConnectConfig, DeploymentMode, LocalModeConfig, RemoteModeConfig, TlsConfig};
 
 pub use topology::EdgeType;
 #[cfg(all(feature = "std", feature = "test-utils"))]


### PR DESCRIPTION
## Description

Second sub-ticket of Epic 17 S-A ([AAASM-1575](https://lightning-dust-mite.atlassian.net/browse/AAASM-1575)). Adds the four sub-config structs that the upcoming `GatewayConfig` top-level type will compose:

| Struct | Default | Purpose |
|---|---|---|
| `LocalModeConfig` | port 7391 / dashboard on / `~/.aasm/local.db` | local-dev gateway settings |
| `TlsConfig` | _none — opt-in_ | PEM cert/key paths for remote mode |
| `RemoteModeConfig` | bind `0.0.0.0:7391`, TLS off, no DB | remote control-plane settings |
| `AgentConnectConfig` | `http://localhost:7391`, no api_key | client-side SDK dial-out |

All four use `#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]` matching the convention in `policy.rs` / `audit.rs`. Type-level `#[serde(default)]` plus a `Default` impl gives the documented "partial YAML → other fields fall back" semantics the Epic spec calls for.

**Stacked on [#643](https://github.com/AI-agent-assembly/agent-assembly/pull/643) (AAASM-1689).** Once #643 merges, this branch's diff against master collapses to just the new structs + tests.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

All new types are additive and gated behind `feature = "std"`.

## Related Issues

- Related Jira ticket: [AAASM-1690](https://lightning-dust-mite.atlassian.net/browse/AAASM-1690)
- Parent Story: [AAASM-1575](https://lightning-dust-mite.atlassian.net/browse/AAASM-1575)
- Parent Epic: [AAASM-1568](https://lightning-dust-mite.atlassian.net/browse/AAASM-1568)
- Stacked on: #643

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Six new tests under `aa-core::config::tests`:

| Test | Asserts |
|---|---|
| `local_mode_config_default_matches_spec` | port=7391, dashboard=true, storage_path raw |
| `local_mode_config_yaml_overrides_port_keeps_other_defaults` | partial YAML → `#[serde(default)]` semantics |
| `remote_mode_config_default_binds_all_interfaces` | 0.0.0.0:7391, TLS off, no DBs |
| `remote_mode_config_yaml_overrides_database_keeps_other_defaults` | partial YAML for remote |
| `agent_connect_config_default_points_at_localhost` | localhost UX guarantee |
| `agent_connect_config_yaml_round_trip` | full HTTPS + api_key round-trip |

Local verification:

```
cargo nextest run -p aa-core --all-features  # 195 passed, 0 skipped
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all -- --check                                 # clean
```

## Commit-by-commit

1. ✨ `(aa-core)` Add `LocalModeConfig` struct with documented defaults
2. ✅ `(aa-core)` Add `LocalModeConfig::default` test
3. ✅ `(aa-core)` Test `LocalModeConfig` YAML overrides keep other defaults
4. ✨ `(aa-core)` Add `TlsConfig` struct for remote-mode TLS material
5. ✨ `(aa-core)` Add `RemoteModeConfig` struct with documented defaults
6. ✅ `(aa-core)` Test `RemoteModeConfig` defaults and partial YAML override
7. ✨ `(aa-core)` Add `AgentConnectConfig` struct with documented defaults
8. ✅ `(aa-core)` Test `AgentConnectConfig` defaults and YAML round-trip
9. ✨ `(aa-core)` Re-export config sub-structs at the crate root

## Follow-up sub-tickets (same Story)

- AAASM-1691 — `GatewayConfig` top-level + YAML loader + `~` expansion
- AAASM-1692 — env-var override layer + invalid-value error handling
- AAASM-1693 — Story-level acceptance verification

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --all-targets --all-features`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on every new struct + field)
- [ ] All CI checks passing (awaiting CI)
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1575]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1690]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ