### PR TITLE
[AAASM-1691] ✨ (aa-core): Add GatewayConfig + YAML loader + ~ expansion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "cfg-if",
  "chrono",
  "criterion",
+ "dirs",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -14,12 +14,13 @@ chrono       = { version = "0.4", default-features = false, features = ["clock"]
 dirs         = { version = "6", optional = true }
 serde        = { version = "1", default-features = false, features = ["derive", "alloc"], optional = true }
 serde_json   = { version = "1", optional = true }
+serde_yaml   = { version = "0.9", optional = true }
 sha2         = { version = "0.11", default-features = false, optional = true }
 thiserror    = { version = "2", optional = true }
 
 [features]
 default    = ["std"]
-std        = ["alloc", "dep:aho-corasick", "dep:async-trait", "dep:thiserror", "dep:chrono", "dep:dirs", "dep:serde_json", "serde?/std"]
+std        = ["alloc", "dep:aho-corasick", "dep:async-trait", "dep:thiserror", "dep:chrono", "dep:dirs", "dep:serde_json", "dep:serde_yaml", "serde?/std"]
 alloc      = ["dep:sha2"]
 serde      = ["dep:serde"]
 test-utils = []
@@ -27,7 +28,6 @@ test-utils = []
 [dev-dependencies]
 criterion  = { version = "0.8", features = ["html_reports"] }
 serde_json = "1"
-serde_yaml = "0.9"
 
 [[bench]]
 name    = "scanner_bench"

--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -11,6 +11,7 @@ aho-corasick = { version = "1", optional = true }
 async-trait  = { version = "0.1", optional = true }
 cfg-if       = "1"
 chrono       = { version = "0.4", default-features = false, features = ["clock"], optional = true }
+dirs         = { version = "6", optional = true }
 serde        = { version = "1", default-features = false, features = ["derive", "alloc"], optional = true }
 serde_json   = { version = "1", optional = true }
 sha2         = { version = "0.11", default-features = false, optional = true }
@@ -18,7 +19,7 @@ thiserror    = { version = "2", optional = true }
 
 [features]
 default    = ["std"]
-std        = ["alloc", "dep:aho-corasick", "dep:async-trait", "dep:thiserror", "dep:chrono", "dep:serde_json", "serde?/std"]
+std        = ["alloc", "dep:aho-corasick", "dep:async-trait", "dep:thiserror", "dep:chrono", "dep:dirs", "dep:serde_json", "serde?/std"]
 alloc      = ["dep:sha2"]
 serde      = ["dep:serde"]
 test-utils = []

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -210,13 +210,18 @@ impl GatewayConfig {
     /// no field starts with `~`. Idempotent — calling twice produces
     /// the same result as calling once.
     pub fn expand_paths(&mut self) {
-        let Some(home) = dirs::home_dir() else {
-            return;
-        };
-        self.local.storage_path = expand_tilde(&self.local.storage_path, &home);
+        if let Some(home) = dirs::home_dir() {
+            self.expand_paths_in(&home);
+        }
+    }
+
+    /// Same as [`expand_paths`](Self::expand_paths) but takes an explicit home
+    /// directory — used by tests so the assertion is independent of `$HOME`.
+    pub(crate) fn expand_paths_in(&mut self, home: &std::path::Path) {
+        self.local.storage_path = expand_tilde(&self.local.storage_path, home);
         if let Some(tls) = &mut self.remote.tls {
-            tls.cert_file = expand_tilde(&tls.cert_file, &home);
-            tls.key_file = expand_tilde(&tls.key_file, &home);
+            tls.cert_file = expand_tilde(&tls.cert_file, home);
+            tls.key_file = expand_tilde(&tls.key_file, home);
         }
     }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -202,6 +202,32 @@ impl GatewayConfig {
     }
 }
 
+impl GatewayConfig {
+    /// Expand a leading `~` in every path field to the user's home directory.
+    ///
+    /// Touches `local.storage_path` and both `remote.tls` paths.
+    /// A no-op when the home directory cannot be resolved or when
+    /// no field starts with `~`. Idempotent — calling twice produces
+    /// the same result as calling once.
+    pub fn expand_paths(&mut self) {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+        self.local.storage_path = expand_tilde(&self.local.storage_path, &home);
+        if let Some(tls) = &mut self.remote.tls {
+            tls.cert_file = expand_tilde(&tls.cert_file, &home);
+            tls.key_file = expand_tilde(&tls.key_file, &home);
+        }
+    }
+}
+
+fn expand_tilde(path: &std::path::Path, home: &std::path::Path) -> PathBuf {
+    match path.strip_prefix("~") {
+        Ok(stripped) => home.join(stripped),
+        Err(_) => path.to_path_buf(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -322,4 +322,55 @@ api_key: "secret"
         assert_eq!(cfg.gateway_url, "https://cp.company.internal:7391");
         assert_eq!(cfg.api_key.as_deref(), Some("secret"));
     }
+
+    #[test]
+    fn gateway_config_default_uses_local_mode_and_documented_defaults() {
+        let cfg = GatewayConfig::default();
+        assert_eq!(cfg.mode, DeploymentMode::Local);
+        assert_eq!(cfg.local.port, 7391);
+        assert_eq!(cfg.remote.listen_addr, SocketAddr::from(([0, 0, 0, 0], 7391)));
+        assert_eq!(cfg.agent.gateway_url, "http://localhost:7391");
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn gateway_config_from_yaml_str_parses_full_epic_example() {
+        let yaml = r#"
+mode: remote
+local:
+  port: 8080
+  dashboard: false
+  storage_path: ~/.aasm/dev.db
+remote:
+  listen_addr: "127.0.0.1:7391"
+  tls:
+    cert_file: /etc/aasm/tls.crt
+    key_file: /etc/aasm/tls.key
+  database_url: "postgres://aasm@db.internal/aasm"
+  redis_url: "redis://redis.internal:6379"
+agent:
+  gateway_url: "https://cp.company.internal:7391"
+  api_key: "secret"
+"#;
+        let cfg = GatewayConfig::from_yaml_str(yaml).expect("valid YAML should parse");
+        assert_eq!(cfg.mode, DeploymentMode::Remote);
+        assert_eq!(cfg.local.port, 8080);
+        assert!(!cfg.local.dashboard);
+        assert_eq!(cfg.remote.listen_addr, SocketAddr::from(([127, 0, 0, 1], 7391)));
+        let tls = cfg.remote.tls.expect("tls present");
+        assert_eq!(tls.cert_file, PathBuf::from("/etc/aasm/tls.crt"));
+        assert_eq!(tls.key_file, PathBuf::from("/etc/aasm/tls.key"));
+        assert_eq!(
+            cfg.remote.database_url.as_deref(),
+            Some("postgres://aasm@db.internal/aasm")
+        );
+        assert_eq!(cfg.agent.api_key.as_deref(), Some("secret"));
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn gateway_config_from_yaml_str_empty_doc_returns_default() {
+        let cfg = GatewayConfig::from_yaml_str("{}").unwrap();
+        assert_eq!(cfg, GatewayConfig::default());
+    }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -8,6 +8,23 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
+/// Errors that can occur while loading or parsing a `GatewayConfig`.
+///
+/// All variants carry enough context to be surfaced verbatim to an
+/// operator running `aasm start`; `Display` implementations come
+/// from `thiserror` so they format cleanly into log lines and CLI
+/// stderr.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    /// Failed to read the YAML config file (permission denied, or
+    /// other filesystem error other than "file not found").
+    #[error("failed to read config file: {0}")]
+    Io(#[from] std::io::Error),
+    /// The YAML payload could not be deserialised into a `GatewayConfig`.
+    #[error("failed to parse config YAML: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+}
+
 /// Which deployment topology the gateway should boot into.
 ///
 /// Selected at startup from a combination of YAML config, environment

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -373,4 +373,26 @@ agent:
         let cfg = GatewayConfig::from_yaml_str("{}").unwrap();
         assert_eq!(cfg, GatewayConfig::default());
     }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn gateway_config_load_from_missing_path_returns_default() {
+        let missing = std::env::temp_dir().join("aasm-config-does-not-exist-AAASM-1691.yaml");
+        // Make sure the test pre-condition holds even if a stale file lingers.
+        let _ = std::fs::remove_file(&missing);
+        let cfg = GatewayConfig::load_from_path(&missing).expect("missing file should not error");
+        assert_eq!(cfg, GatewayConfig::default());
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn gateway_config_load_from_existing_path_parses_yaml() {
+        let tmp_dir = std::env::temp_dir().join("aasm-config-AAASM-1691");
+        std::fs::create_dir_all(&tmp_dir).unwrap();
+        let path = tmp_dir.join("config.yaml");
+        std::fs::write(&path, "mode: remote\n").unwrap();
+        let cfg = GatewayConfig::load_from_path(&path).expect("existing file should parse");
+        assert_eq!(cfg.mode, DeploymentMode::Remote);
+        std::fs::remove_file(&path).ok();
+    }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -395,4 +395,44 @@ agent:
         assert_eq!(cfg.mode, DeploymentMode::Remote);
         std::fs::remove_file(&path).ok();
     }
+
+    #[test]
+    fn expand_paths_in_resolves_tilde_in_storage_path() {
+        let mut cfg = GatewayConfig::default();
+        let fake_home = PathBuf::from("/srv/dev/bryant");
+        cfg.expand_paths_in(&fake_home);
+        assert_eq!(cfg.local.storage_path, PathBuf::from("/srv/dev/bryant/.aasm/local.db"));
+    }
+
+    #[test]
+    fn expand_paths_in_resolves_tilde_in_tls_paths() {
+        let mut cfg = GatewayConfig::default();
+        cfg.remote.tls = Some(TlsConfig {
+            cert_file: PathBuf::from("~/secrets/tls.crt"),
+            key_file: PathBuf::from("~/secrets/tls.key"),
+        });
+        let fake_home = PathBuf::from("/srv/dev/bryant");
+        cfg.expand_paths_in(&fake_home);
+        let tls = cfg.remote.tls.unwrap();
+        assert_eq!(tls.cert_file, PathBuf::from("/srv/dev/bryant/secrets/tls.crt"));
+        assert_eq!(tls.key_file, PathBuf::from("/srv/dev/bryant/secrets/tls.key"));
+    }
+
+    #[test]
+    fn expand_paths_in_is_idempotent() {
+        let mut cfg = GatewayConfig::default();
+        let fake_home = PathBuf::from("/srv/dev/bryant");
+        cfg.expand_paths_in(&fake_home);
+        let after_first = cfg.local.storage_path.clone();
+        cfg.expand_paths_in(&fake_home);
+        assert_eq!(cfg.local.storage_path, after_first, "second call must be a no-op");
+    }
+
+    #[test]
+    fn expand_paths_in_leaves_absolute_paths_alone() {
+        let mut cfg = GatewayConfig::default();
+        cfg.local.storage_path = PathBuf::from("/var/lib/aasm.db");
+        cfg.expand_paths_in(&PathBuf::from("/srv/dev/bryant"));
+        assert_eq!(cfg.local.storage_path, PathBuf::from("/var/lib/aasm.db"));
+    }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -144,6 +144,25 @@ impl Default for AgentConnectConfig {
     }
 }
 
+/// Top-level gateway configuration loaded at startup.
+///
+/// Composes the four sub-configs and a [`DeploymentMode`] flag. All
+/// fields use `#[serde(default)]` so a minimal YAML — even an empty
+/// document — deserialises into the documented defaults.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(default))]
+pub struct GatewayConfig {
+    /// Which topology to boot — local-dev or remote control-plane.
+    pub mode: DeploymentMode,
+    /// Settings for `mode = Local`.
+    pub local: LocalModeConfig,
+    /// Settings for `mode = Remote`.
+    pub remote: RemoteModeConfig,
+    /// Settings the SDK FFI shim reads to dial the gateway.
+    pub agent: AgentConnectConfig,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -173,6 +173,20 @@ impl GatewayConfig {
     pub fn from_yaml_str(yaml: &str) -> Result<Self, ConfigError> {
         Ok(serde_yaml::from_str(yaml)?)
     }
+
+    /// Load a `GatewayConfig` from a YAML file on disk.
+    ///
+    /// A `NotFound` error returns `Self::default()` so missing
+    /// `~/.aasm/config.yaml` does not break startup. Any other I/O
+    /// error (permission denied, malformed YAML, etc.) propagates
+    /// as `ConfigError`.
+    pub fn load_from_path<P: AsRef<std::path::Path>>(path: P) -> Result<Self, ConfigError> {
+        match std::fs::read_to_string(path) {
+            Ok(yaml) => Self::from_yaml_str(&yaml),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(err) => Err(ConfigError::Io(err)),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -187,6 +187,19 @@ impl GatewayConfig {
             Err(err) => Err(ConfigError::Io(err)),
         }
     }
+
+    /// Load `GatewayConfig` from the user's `~/.aasm/config.yaml`.
+    ///
+    /// Equivalent to `load_from_path(dirs::home_dir() / ".aasm/config.yaml")`.
+    /// Falls back to `Self::default()` when the file is absent or the
+    /// home directory cannot be resolved (e.g. `$HOME` unset in a
+    /// systemd unit without `User=`).
+    pub fn load_default_path() -> Result<Self, ConfigError> {
+        let Some(home) = dirs::home_dir() else {
+            return Ok(Self::default());
+        };
+        Self::load_from_path(home.join(".aasm").join("config.yaml"))
+    }
 }
 
 #[cfg(test)]

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -163,6 +163,18 @@ pub struct GatewayConfig {
     pub agent: AgentConnectConfig,
 }
 
+#[cfg(feature = "serde")]
+impl GatewayConfig {
+    /// Parse a `GatewayConfig` from a YAML string.
+    ///
+    /// Missing fields fall back to their documented defaults thanks to
+    /// the type-level `#[serde(default)]` attribute, so an empty
+    /// document (`""` or `"{}"`) deserialises to `Self::default()`.
+    pub fn from_yaml_str(yaml: &str) -> Result<Self, ConfigError> {
+        Ok(serde_yaml::from_str(yaml)?)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -78,7 +78,9 @@ pub use capability::{
 pub use scanner::{CredentialFinding, CredentialKind, CredentialScanner, ScanResult, ScannerConfig};
 
 #[cfg(feature = "std")]
-pub use config::{AgentConnectConfig, DeploymentMode, LocalModeConfig, RemoteModeConfig, TlsConfig};
+pub use config::{
+    AgentConnectConfig, ConfigError, DeploymentMode, GatewayConfig, LocalModeConfig, RemoteModeConfig, TlsConfig,
+};
 
 pub use topology::EdgeType;
 #[cfg(all(feature = "std", feature = "test-utils"))]


### PR DESCRIPTION
## Description

Third sub-ticket of Epic 17 S-A ([AAASM-1575](https://lightning-dust-mite.atlassian.net/browse/AAASM-1575)). Composes the previous sub-structs into the top-level `GatewayConfig`, adds the YAML loader pipeline (`from_yaml_str` → `load_from_path` → `load_default_path`), and the path-expansion routine the gateway will call once at startup to resolve `~` in `storage_path` and TLS paths.

**Stacked on [#645](https://github.com/AI-agent-assembly/agent-assembly/pull/645) (AAASM-1690).** Once #645 merges, this branch's diff against master collapses to the new top-level type + loader + path expansion.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

New dependencies (`dirs`, `serde_yaml`) are gated behind the existing `std` feature.

## Related Issues

- Related Jira ticket: [AAASM-1691](https://lightning-dust-mite.atlassian.net/browse/AAASM-1691)
- Parent Story: [AAASM-1575](https://lightning-dust-mite.atlassian.net/browse/AAASM-1575)
- Parent Epic: [AAASM-1568](https://lightning-dust-mite.atlassian.net/browse/AAASM-1568)
- Stacked on: #645

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Nine new tests:

| Test | Asserts |
|---|---|
| `gateway_config_default_uses_local_mode_and_documented_defaults` | top-level Default sums to documented sub-config defaults |
| `gateway_config_from_yaml_str_parses_full_epic_example` | full Epic 17 example YAML round-trips |
| `gateway_config_from_yaml_str_empty_doc_returns_default` | empty `{}` doc → Self::default() |
| `gateway_config_load_from_missing_path_returns_default` | NotFound fallback |
| `gateway_config_load_from_existing_path_parses_yaml` | happy-path disk read |
| `expand_paths_in_resolves_tilde_in_storage_path` | `~/.aasm/local.db` expansion |
| `expand_paths_in_resolves_tilde_in_tls_paths` | TLS cert/key tilde expansion |
| `expand_paths_in_is_idempotent` | second call is a no-op |
| `expand_paths_in_leaves_absolute_paths_alone` | absolute paths untouched |

The `expand_paths_in` helper takes the home directory as a parameter — tests pass a fixed `/srv/dev/bryant` so assertions stay deterministic regardless of CI runner `$HOME`.

Local verification:

```
cargo nextest run -p aa-core --all-features  # 204 passed, 0 skipped
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all -- --check                                 # clean
```

## Commit-by-commit (13)

1. ⬆️ Add `dirs` optional dep gated by std feature
2. ⬆️ Promote `serde_yaml` to std-gated prod dep
3. ✨ Add `ConfigError` enum with Io + Yaml variants
4. ✨ Add `GatewayConfig` top-level struct with Default
5. ✨ Add `GatewayConfig::from_yaml_str` loader
6. ✨ Add `GatewayConfig::load_from_path` with NotFound fallback
7. ✨ Add `GatewayConfig::load_default_path`
8. ✨ Add `GatewayConfig::expand_paths` for `~` resolution
9. ✨ Re-export `GatewayConfig` + `ConfigError` at crate root
10. ♻️ Extract `expand_paths_in` helper for deterministic tests
11. ✅ Test `GatewayConfig` default and `from_yaml_str`
12. ✅ Test `load_from_path` NotFound fallback and parse-from-disk
13. ✅ Test `expand_paths_in` for tilde resolution

## Follow-up sub-tickets (same Story)

- AAASM-1692 — env-var override layer + invalid-value error handling
- AAASM-1693 — Story-level acceptance verification

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --all-targets --all-features`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on every new public item)
- [ ] All CI checks passing (awaiting CI)
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1575]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1691]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ