### PR TITLE
[AAASM-1692] ✨ (aa-core): Add env-var override layer + invalid-value errors

### DIFF
--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -269,6 +269,11 @@ impl GatewayConfig {
                 _ => return Err(ConfigError::InvalidMode { raw }),
             };
         }
+        if let Some(raw) = get_env("AAASM_GATEWAY_PORT") {
+            let port: u16 = raw.parse().map_err(|_| ConfigError::InvalidPort { raw: raw.clone() })?;
+            self.local.port = port;
+            self.remote.listen_addr.set_port(port);
+        }
         Ok(())
     }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -245,6 +245,34 @@ fn expand_tilde(path: &std::path::Path, home: &std::path::Path) -> PathBuf {
     }
 }
 
+impl GatewayConfig {
+    /// Apply the documented `AA_MODE` / `AAASM_*` environment variables
+    /// on top of `self`, overriding any fields they set.
+    ///
+    /// Returns `ConfigError::InvalidMode` / `ConfigError::InvalidPort`
+    /// when an env var has been set to a value that cannot be parsed.
+    pub fn apply_env_overrides(&mut self) -> Result<(), ConfigError> {
+        self.apply_env_overrides_with(|key| std::env::var(key).ok())
+    }
+
+    /// Same as [`apply_env_overrides`](Self::apply_env_overrides) but reads env
+    /// vars through the supplied closure. Used by tests to inject a mock
+    /// environment without touching process-global state.
+    pub(crate) fn apply_env_overrides_with<F>(&mut self, get_env: F) -> Result<(), ConfigError>
+    where
+        F: Fn(&str) -> Option<String>,
+    {
+        if let Some(raw) = get_env("AA_MODE") {
+            self.mode = match raw.as_str() {
+                "local" => DeploymentMode::Local,
+                "remote" => DeploymentMode::Remote,
+                _ => return Err(ConfigError::InvalidMode { raw }),
+            };
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -579,4 +579,33 @@ agent:
         assert_eq!(cfg.remote.database_url.as_deref(), Some("postgres://aasm@db/aasm"));
         assert_eq!(cfg.remote.redis_url.as_deref(), Some("redis://redis:6379"));
     }
+
+    #[test]
+    fn apply_env_overrides_tls_creates_config_when_yaml_omitted_it() {
+        let mut cfg = GatewayConfig::default();
+        assert!(cfg.remote.tls.is_none(), "precondition: TLS off by default");
+        cfg.apply_env_overrides_with(env(&[
+            ("AAASM_TLS_CERT", "/etc/aasm/tls.crt"),
+            ("AAASM_TLS_KEY", "/etc/aasm/tls.key"),
+        ]))
+        .unwrap();
+        let tls = cfg.remote.tls.expect("TLS env vars must create TlsConfig");
+        assert_eq!(tls.cert_file, PathBuf::from("/etc/aasm/tls.crt"));
+        assert_eq!(tls.key_file, PathBuf::from("/etc/aasm/tls.key"));
+    }
+
+    #[test]
+    fn apply_env_overrides_tls_patches_existing_config_asymmetrically() {
+        let mut cfg = GatewayConfig::default();
+        cfg.remote.tls = Some(TlsConfig {
+            cert_file: PathBuf::from("/old/tls.crt"),
+            key_file: PathBuf::from("/old/tls.key"),
+        });
+        // Only AAASM_TLS_CERT set — key should keep its old path.
+        cfg.apply_env_overrides_with(env(&[("AAASM_TLS_CERT", "/new/tls.crt")]))
+            .unwrap();
+        let tls = cfg.remote.tls.expect("tls preserved");
+        assert_eq!(tls.cert_file, PathBuf::from("/new/tls.crt"));
+        assert_eq!(tls.key_file, PathBuf::from("/old/tls.key"), "key untouched");
+    }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -212,6 +212,18 @@ impl GatewayConfig {
         };
         Self::load_from_path(home.join(".aasm").join("config.yaml"))
     }
+
+    /// One-shot loader for `aasm start` and the gateway bootstrap path:
+    /// read `~/.aasm/config.yaml`, expand `~` in path fields, then apply
+    /// the `AA_MODE` / `AAASM_*` env-var overrides.
+    ///
+    /// Returns the same `ConfigError` variants as the underlying steps.
+    pub fn load() -> Result<Self, ConfigError> {
+        let mut cfg = Self::load_default_path()?;
+        cfg.expand_paths();
+        cfg.apply_env_overrides()?;
+        Ok(cfg)
+    }
 }
 
 impl GatewayConfig {

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -567,4 +567,16 @@ agent:
         assert!(msg.contains("AAASM_GATEWAY_PORT"));
         assert!(msg.contains("not-a-number"));
     }
+
+    #[test]
+    fn apply_env_overrides_database_and_redis_urls() {
+        let mut cfg = GatewayConfig::default();
+        cfg.apply_env_overrides_with(env(&[
+            ("AAASM_DATABASE_URL", "postgres://aasm@db/aasm"),
+            ("AAASM_REDIS_URL", "redis://redis:6379"),
+        ]))
+        .unwrap();
+        assert_eq!(cfg.remote.database_url.as_deref(), Some("postgres://aasm@db/aasm"));
+        assert_eq!(cfg.remote.redis_url.as_deref(), Some("redis://redis:6379"));
+    }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -544,4 +544,27 @@ agent:
         assert!(msg.contains("AA_MODE"), "message should name the var: {msg}");
         assert!(msg.contains("foobar"), "message should include the value: {msg}");
     }
+
+    #[test]
+    fn apply_env_overrides_port_updates_local_and_remote() {
+        let mut cfg = GatewayConfig::default();
+        cfg.apply_env_overrides_with(env(&[("AAASM_GATEWAY_PORT", "8080")]))
+            .unwrap();
+        assert_eq!(cfg.local.port, 8080);
+        assert_eq!(cfg.remote.listen_addr.port(), 8080);
+        // The bind address (only the port should change) keeps 0.0.0.0.
+        assert_eq!(cfg.remote.listen_addr.ip().to_string(), "0.0.0.0");
+    }
+
+    #[test]
+    fn apply_env_overrides_port_invalid_returns_named_error() {
+        let mut cfg = GatewayConfig::default();
+        let err = cfg
+            .apply_env_overrides_with(env(&[("AAASM_GATEWAY_PORT", "not-a-number")]))
+            .expect_err("non-numeric port must return Err");
+        let msg = format!("{err}");
+        assert!(matches!(err, ConfigError::InvalidPort { ref raw } if raw == "not-a-number"));
+        assert!(msg.contains("AAASM_GATEWAY_PORT"));
+        assert!(msg.contains("not-a-number"));
+    }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -23,6 +23,18 @@ pub enum ConfigError {
     /// The YAML payload could not be deserialised into a `GatewayConfig`.
     #[error("failed to parse config YAML: {0}")]
     Yaml(#[from] serde_yaml::Error),
+    /// `AA_MODE` was set to something other than `local` or `remote`.
+    #[error("invalid AA_MODE value: '{raw}' (expected 'local' or 'remote')")]
+    InvalidMode {
+        /// The unrecognised value as read from the environment.
+        raw: String,
+    },
+    /// `AAASM_GATEWAY_PORT` was not a valid `u16`.
+    #[error("invalid AAASM_GATEWAY_PORT value: '{raw}' (expected u16)")]
+    InvalidPort {
+        /// The unrecognised value as read from the environment.
+        raw: String,
+    },
 }
 
 /// Which deployment topology the gateway should boot into.

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -512,4 +512,36 @@ agent:
         cfg.expand_paths_in(&PathBuf::from("/srv/dev/bryant"));
         assert_eq!(cfg.local.storage_path, PathBuf::from("/var/lib/aasm.db"));
     }
+
+    /// Helper for env-override tests — builds a closure backed by a
+    /// `HashMap`. Keeps test bodies short without bumping into the
+    /// borrow checker when mapping `&[(&str, &str)]` over `&str` keys.
+    fn env(pairs: &[(&str, &str)]) -> impl Fn(&str) -> Option<String> {
+        let map: std::collections::HashMap<String, String> = pairs
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        move |key| map.get(key).cloned()
+    }
+
+    #[test]
+    fn apply_env_overrides_aa_mode_remote_promotes_mode() {
+        let mut cfg = GatewayConfig::default();
+        cfg.apply_env_overrides_with(env(&[("AA_MODE", "remote")])).unwrap();
+        assert_eq!(cfg.mode, DeploymentMode::Remote);
+    }
+
+    #[test]
+    fn apply_env_overrides_aa_mode_invalid_returns_named_error() {
+        let mut cfg = GatewayConfig::default();
+        let err = cfg
+            .apply_env_overrides_with(env(&[("AA_MODE", "foobar")]))
+            .expect_err("invalid value must return Err");
+        // The message must include both the env-var name and the bad value
+        // so operators can grep startup logs.
+        let msg = format!("{err}");
+        assert!(matches!(err, ConfigError::InvalidMode { ref raw } if raw == "foobar"));
+        assert!(msg.contains("AA_MODE"), "message should name the var: {msg}");
+        assert!(msg.contains("foobar"), "message should include the value: {msg}");
+    }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -274,6 +274,12 @@ impl GatewayConfig {
             self.local.port = port;
             self.remote.listen_addr.set_port(port);
         }
+        if let Some(url) = get_env("AAASM_DATABASE_URL") {
+            self.remote.database_url = Some(url);
+        }
+        if let Some(url) = get_env("AAASM_REDIS_URL") {
+            self.remote.redis_url = Some(url);
+        }
         Ok(())
     }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -280,6 +280,20 @@ impl GatewayConfig {
         if let Some(url) = get_env("AAASM_REDIS_URL") {
             self.remote.redis_url = Some(url);
         }
+        let cert = get_env("AAASM_TLS_CERT");
+        let key = get_env("AAASM_TLS_KEY");
+        if cert.is_some() || key.is_some() {
+            let tls = self.remote.tls.get_or_insert(TlsConfig {
+                cert_file: PathBuf::new(),
+                key_file: PathBuf::new(),
+            });
+            if let Some(path) = cert {
+                tls.cert_file = PathBuf::from(path);
+            }
+            if let Some(path) = key {
+                tls.key_file = PathBuf::from(path);
+            }
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
## Description

Fourth and final **implementation** sub-ticket of Epic 17 S-A ([AAASM-1575](https://lightning-dust-mite.atlassian.net/browse/AAASM-1575)). Adds the env-var override layer that finishes the configuration precedence chain (defaults → YAML → env → CLI).

### Variables wired up

| Env var | Field | Error on bad value |
|---|---|---|
| `AA_MODE` | `mode` (Local/Remote) | `ConfigError::InvalidMode` |
| `AAASM_GATEWAY_PORT` | `local.port` AND port of `remote.listen_addr` | `ConfigError::InvalidPort` |
| `AAASM_DATABASE_URL` | `remote.database_url` | — |
| `AAASM_REDIS_URL` | `remote.redis_url` | — |
| `AAASM_TLS_CERT` | `remote.tls.cert_file` (creates `TlsConfig` if `None`) | — |
| `AAASM_TLS_KEY` | `remote.tls.key_file` (creates `TlsConfig` if `None`) | — |

### Plus the one-shot loader

`GatewayConfig::load()` chains the three pieces from this Story:
1. `load_default_path()` — read `~/.aasm/config.yaml`, missing → defaults
2. `expand_paths()` — resolve `~` in `storage_path` / TLS paths
3. `apply_env_overrides()` — apply the six env vars above

This is the entry point aa-gateway main() and `aasm start` will call.

### Testability

`apply_env_overrides_with(get_env: impl Fn(&str) -> Option<String>)` lets tests pass a closure-backed mock env (a `HashMap`-of-fixed-pairs helper named `env()` keeps the test bodies short). The public `apply_env_overrides()` is a thin wrapper that reads `std::env::var`. Tests never touch process-global env state, so they run safely under nextest's parallel executor.

**Stacked on [#648](https://github.com/AI-agent-assembly/agent-assembly/pull/648) (AAASM-1691).** Once #648 merges, this branch's diff against master collapses to just the new error variants + override layer + tests.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

`ConfigError` gains two new variants (`InvalidMode`, `InvalidPort`). The enum is `#[non_exhaustive]`-style consumed only via `match` over public variants, so adding more is forward-compatible — but downstream callers that `match` on it should add the new arms.

## Related Issues

- Related Jira ticket: [AAASM-1692](https://lightning-dust-mite.atlassian.net/browse/AAASM-1692)
- Parent Story: [AAASM-1575](https://lightning-dust-mite.atlassian.net/browse/AAASM-1575)
- Parent Epic: [AAASM-1568](https://lightning-dust-mite.atlassian.net/browse/AAASM-1568)
- Stacked on: #648

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Seven new tests under `aa-core::config::tests`:

| Test | Asserts |
|---|---|
| `apply_env_overrides_aa_mode_remote_promotes_mode` | AA_MODE=remote flips mode |
| `apply_env_overrides_aa_mode_invalid_returns_named_error` | AA_MODE=foobar → InvalidMode with `AA_MODE` and `foobar` in message |
| `apply_env_overrides_port_updates_local_and_remote` | 8080 patches both local.port and remote.listen_addr port; bind IP untouched |
| `apply_env_overrides_port_invalid_returns_named_error` | non-numeric → InvalidPort |
| `apply_env_overrides_database_and_redis_urls` | both URL vars round-trip |
| `apply_env_overrides_tls_creates_config_when_yaml_omitted_it` | cert+key envs create a fresh TlsConfig |
| `apply_env_overrides_tls_patches_existing_config_asymmetrically` | only-cert env keeps existing key_file |

Local verification:

```
cargo nextest run -p aa-core --all-features  # 211 passed, 0 skipped
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all -- --check                                 # clean
```

## Commit-by-commit (10)

1. ✨ Extend `ConfigError` with `InvalidMode` + `InvalidPort`
2. ✨ Add `apply_env_overrides` with `AA_MODE` handling
3. ✨ Add `AAASM_GATEWAY_PORT` env override
4. ✨ Add `AAASM_DATABASE_URL` + `AAASM_REDIS_URL` overrides
5. ✨ Add `AAASM_TLS_CERT` + `AAASM_TLS_KEY` env overrides
6. ✨ Add `GatewayConfig::load` convenience method
7. ✅ Test `AA_MODE` env override happy and invalid paths
8. ✅ Test `AAASM_GATEWAY_PORT` happy path and invalid value
9. ✅ Test `AAASM_DATABASE_URL` + `AAASM_REDIS_URL` overrides
10. ✅ Test TLS env vars create and asymmetrically patch `TlsConfig`

## Next sub-ticket (same Story)

- AAASM-1693 — Story-level acceptance verification (runs once 1689..1692 are merged)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --all-targets --all-features`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on every new public item)
- [ ] All CI checks passing (awaiting CI)
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1575]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1692]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ