### PR TITLE
[AAASM-1693] ✅ (aa-core): Verify E17 S-A GatewayConfig acceptance

### DIFF
--- a/aa-core/tests/config_acceptance.rs
+++ b/aa-core/tests/config_acceptance.rs
@@ -1,0 +1,164 @@
+//! Story-level acceptance spec for E17 S-A (AAASM-1575).
+//!
+//! Exercises the full GatewayConfig precedence chain through the
+//! public crate surface — no `pub(crate)` shortcuts — once all four
+//! implementation sub-tickets (AAASM-1689..1692) have landed. Each
+//! `#[test]` ticks one of the eight AC bullets from the Story.
+//!
+//! Gated behind `feature = "serde"` because every meaningful AC
+//! exercises the YAML loader; running `cargo nextest run -p aa-core
+//! --all-features` enables it.
+
+#![cfg(feature = "serde")]
+
+use std::path::PathBuf;
+
+use aa_core::config::{ConfigError, DeploymentMode, GatewayConfig};
+
+/// AC #1 — `DeploymentMode` reachable via `aa_core::config::DeploymentMode`.
+#[test]
+fn ac_1_deployment_mode_exported_from_config_module() {
+    let _: DeploymentMode = DeploymentMode::Local;
+    let _: DeploymentMode = DeploymentMode::Remote;
+}
+
+/// AC #2 — full Epic-17 sample YAML round-trips through `from_yaml_str`.
+#[test]
+fn ac_2_full_epic_example_yaml_round_trips() {
+    let yaml = r#"
+mode: remote
+local:
+  port: 7391
+  dashboard: true
+  storage_path: ~/.aasm/local.db
+remote:
+  listen_addr: "0.0.0.0:7391"
+  tls:
+    cert_file: /etc/aasm/tls.crt
+    key_file: /etc/aasm/tls.key
+  database_url: "postgres://aasm@db.internal/aasm"
+  redis_url: "redis://redis.internal:6379"
+agent:
+  gateway_url: "http://localhost:7391"
+  api_key: "secret"
+"#;
+    let cfg = GatewayConfig::from_yaml_str(yaml).expect("Epic example YAML must parse");
+    assert_eq!(cfg.mode, DeploymentMode::Remote);
+    assert!(cfg.remote.tls.is_some());
+    assert!(cfg.remote.database_url.is_some());
+}
+
+/// AC #3 — missing YAML file at `load_from_path` returns defaults, no error.
+#[test]
+fn ac_3_missing_yaml_file_returns_default() {
+    let missing = std::env::temp_dir().join("aasm-config-AAASM-1693-missing.yaml");
+    let _ = std::fs::remove_file(&missing);
+    let cfg = GatewayConfig::load_from_path(&missing).expect("NotFound must not error");
+    assert_eq!(cfg, GatewayConfig::default());
+}
+
+/// AC #4 — `AA_MODE=remote` env var overrides `mode: local` in the YAML.
+#[test]
+fn ac_4_aa_mode_env_overrides_yaml_mode() {
+    let mut cfg = GatewayConfig::from_yaml_str("mode: local").unwrap();
+    assert_eq!(cfg.mode, DeploymentMode::Local, "precondition: YAML wins to start");
+    // Use the public method through a scoped temp env-var set / unset to
+    // exercise the exact code path the gateway will run at boot.
+    let restore = ScopedEnv::set("AA_MODE", "remote");
+    cfg.apply_env_overrides().expect("env override should succeed");
+    drop(restore);
+    assert_eq!(cfg.mode, DeploymentMode::Remote);
+}
+
+/// AC #5 — `AAASM_DATABASE_URL` env var overrides `remote.database_url`.
+#[test]
+fn ac_5_aasm_database_url_env_overrides_yaml_value() {
+    let yaml = r#"
+remote:
+  database_url: "postgres://yaml-default/aasm"
+"#;
+    let mut cfg = GatewayConfig::from_yaml_str(yaml).unwrap();
+    assert_eq!(cfg.remote.database_url.as_deref(), Some("postgres://yaml-default/aasm"));
+    let restore = ScopedEnv::set("AAASM_DATABASE_URL", "postgres://env-override/aasm");
+    cfg.apply_env_overrides().unwrap();
+    drop(restore);
+    assert_eq!(cfg.remote.database_url.as_deref(), Some("postgres://env-override/aasm"));
+}
+
+/// AC #6 — `~` in `storage_path` expanded to the real home directory.
+#[test]
+fn ac_6_tilde_in_storage_path_expanded_to_real_home() {
+    let mut cfg = GatewayConfig::default();
+    assert_eq!(cfg.local.storage_path, PathBuf::from("~/.aasm/local.db"));
+    cfg.expand_paths();
+    // dirs::home_dir() must be set on every supported CI runner; if it isn't,
+    // expand_paths is a no-op and the assertion below still holds (the path
+    // simply stays raw). We assert non-emptiness either way to prove the
+    // call did not error and the field is still a valid PathBuf.
+    let expanded = cfg.local.storage_path.to_string_lossy();
+    if let Some(home) = dirs::home_dir() {
+        let expected = home.join(".aasm").join("local.db");
+        assert_eq!(cfg.local.storage_path, expected, "expanded path should match real home");
+    }
+    assert!(!expanded.is_empty(), "storage_path must remain a valid PathBuf");
+}
+
+/// AC #7 — Invalid `AA_MODE` returns a clear error containing both
+/// `AA_MODE` and the bad value.
+#[test]
+fn ac_7_invalid_aa_mode_returns_clear_error() {
+    let mut cfg = GatewayConfig::default();
+    let restore = ScopedEnv::set("AA_MODE", "foobar");
+    let err = cfg.apply_env_overrides().expect_err("AA_MODE=foobar must Err");
+    drop(restore);
+    let msg = format!("{err}");
+    assert!(matches!(err, ConfigError::InvalidMode { ref raw } if raw == "foobar"));
+    assert!(msg.contains("AA_MODE"), "message must name the var: {msg}");
+    assert!(msg.contains("foobar"), "message must include the value: {msg}");
+}
+
+/// AC #8 (partial) — the whole crate test surface stays green.
+///
+/// The full assertion is `cargo nextest run -p aa-core --all-features` in CI;
+/// this placeholder makes the AC visible in the integration spec and ensures
+/// the spec file itself contributes a passing test even when run alone.
+#[test]
+fn ac_8_crate_suite_smoke() {
+    // Sanity-check: defaults survive a no-op load attempt against a fake path.
+    let cfg = GatewayConfig::load_from_path("/tmp/aasm-config-does-not-exist-AAASM-1693.yaml").unwrap();
+    assert_eq!(cfg, GatewayConfig::default());
+}
+
+/// Tiny RAII guard for env-var manipulation in the AC tests.
+///
+/// `apply_env_overrides()` reads from `std::env::var`, which is process-global.
+/// Restoring the prior value when the guard drops keeps tests independent
+/// (nextest may still serialise them — that's fine; correctness here doesn't
+/// depend on parallelism).
+struct ScopedEnv {
+    key: &'static str,
+    prior: Option<String>,
+}
+
+impl ScopedEnv {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prior = std::env::var(key).ok();
+        // SAFETY: tests run in this process; we restore on drop. Other parallel
+        // tests in this binary do not read these specific env vars.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+        Self { key, prior }
+    }
+}
+
+impl Drop for ScopedEnv {
+    fn drop(&mut self) {
+        unsafe {
+            match &self.prior {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}

--- a/verification-reports/AAASM-1575-acceptance.md
+++ b/verification-reports/AAASM-1575-acceptance.md
@@ -1,0 +1,91 @@
+# AAASM-1575 — E17 S-A Acceptance Verification
+
+| | |
+|---|---|
+| **Story** | [AAASM-1575](https://lightning-dust-mite.atlassian.net/browse/AAASM-1575) — GatewayConfig deployment mode config schema |
+| **Epic** | [AAASM-1568](https://lightning-dust-mite.atlassian.net/browse/AAASM-1568) — Gateway Deployment Architecture |
+| **Verifier** | Automated via `aa-core/tests/config_acceptance.rs` |
+| **Date** | 2026-05-21 |
+| **Commit** | This PR's HEAD |
+
+---
+
+## Implementation PRs verified
+
+| PR | Sub-ticket | Scope |
+|---|---|---|
+| [#643](https://github.com/AI-agent-assembly/agent-assembly/pull/643) | AAASM-1689 | `DeploymentMode` enum + config module scaffold |
+| [#645](https://github.com/AI-agent-assembly/agent-assembly/pull/645) | AAASM-1690 | Sub-structs (`LocalModeConfig` / `RemoteModeConfig` / `TlsConfig` / `AgentConnectConfig`) |
+| [#648](https://github.com/AI-agent-assembly/agent-assembly/pull/648) | AAASM-1691 | `GatewayConfig` + YAML loader + `~` expansion |
+| [#649](https://github.com/AI-agent-assembly/agent-assembly/pull/649) | AAASM-1692 | Env-var override layer + invalid-value errors |
+
+---
+
+## AC bullets
+
+| # | Bullet | Test | Status |
+|---|---|---|---|
+| 1 | `DeploymentMode` enum exported from `aa-core::config` | `ac_1_deployment_mode_exported_from_config_module` | ✅ PASS |
+| 2 | `GatewayConfig` can be deserialised from a valid YAML string via `serde_yaml` | `ac_2_full_epic_example_yaml_round_trips` | ✅ PASS |
+| 3 | Missing YAML file → defaults used; no error | `ac_3_missing_yaml_file_returns_default` | ✅ PASS |
+| 4 | `AA_MODE=remote` env var overrides `mode: local` in the YAML | `ac_4_aa_mode_env_overrides_yaml_mode` | ✅ PASS |
+| 5 | `AAASM_DATABASE_URL` env var overrides `remote.database_url` in YAML | `ac_5_aasm_database_url_env_overrides_yaml_value` | ✅ PASS |
+| 6 | `~` in `storage_path` expanded to the actual home directory | `ac_6_tilde_in_storage_path_expanded_to_real_home` | ✅ PASS |
+| 7 | Invalid `AA_MODE` value (`AA_MODE=foobar`) → startup fails with clear error message | `ac_7_invalid_aa_mode_returns_clear_error` | ✅ PASS |
+| 8 | `cargo nextest run -p aa-core config::tests` green | `cargo nextest run -p aa-core --all-features` — 219 passed, 0 skipped | ✅ PASS |
+
+All 8 bullets verified.
+
+---
+
+## Verification commands
+
+```bash
+cd agent-assembly
+cargo nextest run -p aa-core --all-features          # 219 passed, 0 skipped
+cargo clippy --all-targets --all-features -- -D warnings  # clean
+cargo fmt --all -- --check                            # clean
+```
+
+Output (truncated to the summary line):
+
+```
+Summary [0.157s] 219 tests run: 219 passed, 0 skipped
+```
+
+---
+
+## Deviations from the Story description
+
+None blocking.
+
+Two minor adjustments worth noting for the record:
+
+1. **`expand_paths` helper split.** The Story description specifies a single
+   `expand_paths(&mut self)` method. The implementation in AAASM-1691 ships
+   that method plus a `pub(crate) expand_paths_in(&mut self, home: &Path)`
+   helper used by the unit tests to inject a fixed home directory so
+   assertions stay deterministic across CI runners with different `$HOME`
+   values. The public API matches the Story exactly.
+2. **`apply_env_overrides_with` injection.** Similar story for the env-var
+   layer — the public `apply_env_overrides()` matches the Story signature.
+   An internal `pub(crate) apply_env_overrides_with(get_env: impl Fn)` lets
+   tests pass a HashMap-backed mock environment instead of mutating process
+   env vars in parallel.
+
+Neither change adds new public surface; both are testability refinements.
+
+---
+
+## Follow-up bugs / sub-tasks
+
+None filed. All 8 AC bullets pass on first run against the merged sub-tickets.
+
+---
+
+## Next steps
+
+- Land #649 (AAASM-1692) → #648 → #645 → #643 in stacked-PR order, then merge
+  this verification PR.
+- Close AAASM-1689..1693 → AAASM-1575 → consider parent Epic AAASM-1568 ready
+  for the next Story (S-B local-mode bootstrap).


### PR DESCRIPTION
## Description

**Final sub-ticket** of Epic 17 S-A ([AAASM-1575](https://lightning-dust-mite.atlassian.net/browse/AAASM-1575)). Adds a story-level integration spec at `aa-core/tests/config_acceptance.rs` that ticks all 8 AC bullets through the public crate surface, plus a `verification-reports/AAASM-1575-acceptance.md` summarising the result.

**Stacked on [#649](https://github.com/AI-agent-assembly/agent-assembly/pull/649) (AAASM-1692).** Verifies the cumulative behaviour of all four implementation PRs (#643 → #645 → #648 → #649) end-to-end. Should land last in the stack.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release
- [x] ✅ Tests / acceptance verification

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: [AAASM-1693](https://lightning-dust-mite.atlassian.net/browse/AAASM-1693)
- Parent Story: [AAASM-1575](https://lightning-dust-mite.atlassian.net/browse/AAASM-1575)
- Parent Epic: [AAASM-1568](https://lightning-dust-mite.atlassian.net/browse/AAASM-1568)
- Verifies: #643, #645, #648, #649

## Testing

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Eight integration tests, one per AC bullet:

| # | AC | Test |
|---|---|---|
| 1 | `DeploymentMode` exported from `aa-core::config` | `ac_1_deployment_mode_exported_from_config_module` |
| 2 | `GatewayConfig` deserialises from valid YAML | `ac_2_full_epic_example_yaml_round_trips` |
| 3 | Missing YAML file → defaults | `ac_3_missing_yaml_file_returns_default` |
| 4 | `AA_MODE=remote` overrides YAML | `ac_4_aa_mode_env_overrides_yaml_mode` |
| 5 | `AAASM_DATABASE_URL` overrides YAML | `ac_5_aasm_database_url_env_overrides_yaml_value` |
| 6 | `~` expanded to home directory | `ac_6_tilde_in_storage_path_expanded_to_real_home` |
| 7 | Invalid `AA_MODE` → clear error | `ac_7_invalid_aa_mode_returns_clear_error` |
| 8 | Crate suite green | `ac_8_crate_suite_smoke` + `cargo nextest run --all-features` |

All eight pass against the cumulative stack:

```
cargo nextest run -p aa-core --all-features  # 219 passed, 0 skipped
cargo clippy --all-targets --all-features -- -D warnings  # clean
cargo fmt --all -- --check                                 # clean
```

The integration spec uses the public API only (no `pub(crate)` shortcuts) and a tiny `ScopedEnv` RAII guard for safe process-env mutations in AC 4, 5, 7.

## Verification report

`verification-reports/AAASM-1575-acceptance.md` — full AC → test mapping table, the two non-blocking testability refinements (`expand_paths_in`, `apply_env_overrides_with`), and the recommended merge order.

## Commit-by-commit (2)

1. ✅ `(aa-core)` Add `config_acceptance` integration spec for E17 S-A
2. 📝 `(verification)` Add `AAASM-1575` E17 S-A acceptance report

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --all-targets --all-features`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (verification report)
- [ ] All CI checks passing (awaiting CI)
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1575]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1693]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1575]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ