### PR TITLE
[AAASM-1657] ✨ (aa-gateway/aa-api): Real ops lifecycle enforcement end-to-end

### DIFF
--- a/aa-api/src/events.rs
+++ b/aa-api/src/events.rs
@@ -10,6 +10,23 @@ use aa_runtime::approval::ApprovalRequest;
 use aa_runtime::pipeline::event::PipelineEvent;
 use tokio::sync::broadcast;
 
+use crate::models::ws_payloads::OpsChangePayload;
+
+/// One broadcast envelope on the ops-change channel (AAASM-1657 PR-H).
+///
+/// Carries the agent attribution outside the typed `OpsChangePayload` so
+/// the WS dispatch loop can populate `GovernanceEvent.agent_id` while the
+/// payload body stays consistent with the sibling Violation / Approval /
+/// Budget payloads (which keep agent attribution on the outer event).
+#[derive(Debug, Clone)]
+pub struct OpsChangeBroadcast {
+    /// The agent the transition belongs to. Mirrors
+    /// `GovernanceEvent.agent_id` on the wire.
+    pub agent_id: String,
+    /// The typed payload for the event.
+    pub payload: OpsChangePayload,
+}
+
 /// Default channel capacity for each event broadcast.
 const DEFAULT_CHANNEL_CAPACITY: usize = 256;
 
@@ -28,6 +45,12 @@ pub struct EventBroadcast {
     /// Secret-detection alerts emitted when the gateway's credential
     /// scanner produces a non-empty findings list (AAASM-1545).
     secret_tx: broadcast::Sender<SecretAlert>,
+    /// Ops-lifecycle transitions emitted by the registry whenever an
+    /// in-flight op moves between states (AAASM-1657 PR-H). The WS
+    /// dispatch loop converts each envelope into a
+    /// `GovernanceEvent { event_type: OpsChange, ... }` so the dashboard
+    /// can apply its per-op_id row merge and override auto-clear.
+    ops_change_tx: broadcast::Sender<OpsChangeBroadcast>,
 }
 
 impl EventBroadcast {
@@ -38,12 +61,14 @@ impl EventBroadcast {
         let (approval_expiry_tx, _) = broadcast::channel(capacity);
         let (budget_tx, _) = broadcast::channel(capacity);
         let (secret_tx, _) = broadcast::channel(capacity);
+        let (ops_change_tx, _) = broadcast::channel(capacity);
         Self {
             pipeline_tx,
             approval_tx,
             approval_expiry_tx,
             budget_tx,
             secret_tx,
+            ops_change_tx,
         }
     }
 
@@ -99,6 +124,18 @@ impl EventBroadcast {
     /// Get a clone of the secret-detection alert sender (AAASM-1545).
     pub fn secret_sender(&self) -> broadcast::Sender<SecretAlert> {
         self.secret_tx.clone()
+    }
+
+    /// Subscribe to ops-lifecycle transition events (AAASM-1657 PR-H).
+    pub fn subscribe_ops_change(&self) -> broadcast::Receiver<OpsChangeBroadcast> {
+        self.ops_change_tx.subscribe()
+    }
+
+    /// Get a clone of the ops-change event sender (AAASM-1657 PR-H).
+    /// The route handlers in `routes/ops.rs` use this to publish a frame
+    /// after every successful registry transition.
+    pub fn ops_change_sender(&self) -> broadcast::Sender<OpsChangeBroadcast> {
+        self.ops_change_tx.clone()
     }
 }
 

--- a/aa-api/src/routes/ops.rs
+++ b/aa-api/src/routes/ops.rs
@@ -12,6 +12,8 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::error::ProblemDetail;
+use crate::events::OpsChangeBroadcast;
+use crate::models::ws_payloads::OpsChangePayload;
 use crate::ops::{OpRecord, OpsError};
 use crate::state::AppState;
 
@@ -40,6 +42,29 @@ fn lifecycle_ok(record: OpRecord, action: &'static str) -> impl IntoResponse {
             accepted_at: record.updated_at,
         }),
     )
+}
+
+/// AAASM-1657 PR-H: emit an `ops_change` WS event so the dashboard's
+/// `useLiveOpsStream` hook can clear the optimistic override and update
+/// the row in place. Looks up the owning `agent_id` from the registry
+/// (recorded by `OpsRegistry::ingest_with_agent` in the policy-service
+/// path); falls back to an empty string for ops registered without one
+/// (e.g. the legacy `POST /api/v1/ops` register path).
+fn emit_ops_change(state: &AppState, record: &OpRecord) {
+    let agent_id = state
+        .ops_registry
+        .agent_for(&record.op_id)
+        .map(|a| a.agent_id)
+        .unwrap_or_default();
+    let payload = OpsChangePayload {
+        op_id: record.op_id.clone(),
+        state: record.state,
+        updated_at: record.updated_at.clone(),
+    };
+    let _ = state
+        .events
+        .ops_change_sender()
+        .send(OpsChangeBroadcast { agent_id, payload });
 }
 
 fn ops_error_to_problem(err: OpsError) -> ProblemDetail {
@@ -86,11 +111,9 @@ pub async fn pause_op(
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, ProblemDetail> {
     let op_id = validate_op_id(&id)?;
-    state
-        .ops_registry
-        .pause(&op_id)
-        .map(|record| lifecycle_ok(record, "pause"))
-        .map_err(ops_error_to_problem)
+    let record = state.ops_registry.pause(&op_id).map_err(ops_error_to_problem)?;
+    emit_ops_change(&state, &record);
+    Ok(lifecycle_ok(record, "pause"))
 }
 
 /// `POST /api/v1/ops/{id}/resume` — transition a paused operation back to running.
@@ -118,11 +141,9 @@ pub async fn resume_op(
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, ProblemDetail> {
     let op_id = validate_op_id(&id)?;
-    state
-        .ops_registry
-        .resume(&op_id)
-        .map(|record| lifecycle_ok(record, "resume"))
-        .map_err(ops_error_to_problem)
+    let record = state.ops_registry.resume(&op_id).map_err(ops_error_to_problem)?;
+    emit_ops_change(&state, &record);
+    Ok(lifecycle_ok(record, "resume"))
 }
 
 /// `POST /api/v1/ops/{id}/terminate` — terminate a running or paused operation.
@@ -150,11 +171,9 @@ pub async fn terminate_op(
     Path(id): Path<String>,
 ) -> Result<impl IntoResponse, ProblemDetail> {
     let op_id = validate_op_id(&id)?;
-    state
-        .ops_registry
-        .terminate(&op_id)
-        .map(|record| lifecycle_ok(record, "terminate"))
-        .map_err(ops_error_to_problem)
+    let record = state.ops_registry.terminate(&op_id).map_err(ops_error_to_problem)?;
+    emit_ops_change(&state, &record);
+    Ok(lifecycle_ok(record, "terminate"))
 }
 
 /// `GET /api/v1/ops` — list all registered in-flight operations.

--- a/aa-api/src/server.rs
+++ b/aa-api/src/server.rs
@@ -67,6 +67,10 @@ pub async fn run_server(config: ApiConfig, state: AppState) -> Result<(), Box<dy
         std::time::Duration::from_secs(60),
     );
 
+    // Spawn background task to sweep terminal entries from the ops registry
+    // (AAASM-1657 PR-H). Default: tick every 10s, drop entries older than 60s.
+    let _ops_sweep_handle = aa_gateway::ops::spawn_sweep_task(state.ops_registry.clone());
+
     let app = build_app(state);
 
     let listener = TcpListener::bind(config.bind_addr).await?;

--- a/aa-api/src/ws/handler.rs
+++ b/aa-api/src/ws/handler.rs
@@ -5,6 +5,8 @@ use std::time::Duration;
 use crate::auth::AuthenticatedCaller;
 use crate::models::ws_payloads::{ApprovalPayload, BudgetAlertPayload, CallStackNode, EventPayload, ViolationPayload};
 use crate::models::{EventType, GovernanceEvent};
+// AAASM-1657 PR-H: the ops-change channel reuses the typed OpsChangePayload
+// shipped in PR-B (AAASM-1651).
 use crate::state::AppState;
 use crate::ws::params::WsQueryParams;
 use axum::body::Bytes;
@@ -91,6 +93,7 @@ async fn handle_socket(socket: WebSocket, params: WsQueryParams, state: AppState
     let mut approval_rx = state.events.subscribe_approvals();
     let mut approval_expiry_rx = state.events.subscribe_approval_expirations();
     let mut budget_rx = state.events.subscribe_budget();
+    let mut ops_change_rx = state.events.subscribe_ops_change();
 
     let live_sender = sender.clone();
     let ping_sender = sender.clone();
@@ -194,6 +197,20 @@ async fn handle_socket(socket: WebSocket, params: WsQueryParams, state: AppState
                         build_budget_alert_payload(&budget_ev),
                     ))
                     .unwrap_or_default(),
+                    timestamp: chrono::Utc::now(),
+                })
+            }
+            Ok(ops_ev) = ops_change_rx.recv() => {
+                // AAASM-1657 PR-H: forward operator-driven ops registry
+                // transitions to the dashboard so it can clear optimistic
+                // overrides and update the row in place by op_id.
+                let id = next_id.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                Some(GovernanceEvent {
+                    id,
+                    event_type: EventType::OpsChange,
+                    agent_id: ops_ev.agent_id,
+                    payload: serde_json::to_value(EventPayload::OpsChange(ops_ev.payload))
+                        .unwrap_or_default(),
                     timestamp: chrono::Utc::now(),
                 })
             }

--- a/aa-gateway/src/ops/mod.rs
+++ b/aa-gateway/src/ops/mod.rs
@@ -175,6 +175,16 @@ impl OpsRegistry {
         self.ops.get(op_id).map(|r| r.clone())
     }
 
+    /// Look up the owning `agent_id` for an op (AAASM-1657).
+    ///
+    /// Returns `None` for ops registered via the legacy `ingest` or
+    /// `register` paths that didn't carry an agent id. Used by the
+    /// `aa-api` route handlers when emitting `ops_change` WS events so
+    /// the dashboard's per-agent filter can target them correctly.
+    pub fn agent_for(&self, op_id: &str) -> Option<AgentId> {
+        self.agents.get(op_id).map(|a| a.clone())
+    }
+
     /// Return snapshots of all registered ops.
     pub fn list(&self) -> Vec<OpRecord> {
         self.ops.iter().map(|r| r.clone()).collect()

--- a/aa-gateway/src/ops/mod.rs
+++ b/aa-gateway/src/ops/mod.rs
@@ -21,6 +21,8 @@ pub mod publisher;
 
 pub use publisher::{OpControlEnvelope, OpControlPublisher, SharedOpControlPublisher};
 
+use aa_proto::assembly::common::v1::AgentId;
+use aa_proto::assembly::policy::v1::OpControlSignal;
 use dashmap::DashMap;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -69,6 +71,19 @@ pub enum OpsError {
 /// shard-level writes during state transitions.
 pub struct OpsRegistry {
     ops: DashMap<String, OpRecord>,
+    /// Per-op routing key for [`OpControlPublisher`] (AAASM-1657).
+    ///
+    /// Populated by [`OpsRegistry::ingest_with_agent`] so the transition
+    /// methods can address the corresponding SDK subscriber. Ops registered
+    /// via [`OpsRegistry::register`] or [`OpsRegistry::ingest`] (without an
+    /// agent id) silently skip publishing — preserving the pre-1657
+    /// behaviour for the AAASM-1525 HTTP `POST /api/v1/ops` register path
+    /// and any test fixtures that construct `OpsRegistry::new()` directly.
+    agents: DashMap<String, AgentId>,
+    /// Optional fan-out publisher for op-control signals (AAASM-1657).
+    /// Wire via [`OpsRegistry::with_publisher`]. `None` means transitions
+    /// only update local state — no SDK push happens.
+    publisher: Option<SharedOpControlPublisher>,
 }
 
 impl Default for OpsRegistry {
@@ -79,7 +94,22 @@ impl Default for OpsRegistry {
 
 impl OpsRegistry {
     pub fn new() -> Self {
-        Self { ops: DashMap::new() }
+        Self {
+            ops: DashMap::new(),
+            agents: DashMap::new(),
+            publisher: None,
+        }
+    }
+
+    /// Attach an [`OpControlPublisher`] so subsequent transitions push
+    /// the matching [`OpControlSignal`] to subscribed SDK clients.
+    ///
+    /// Only transitions on ops that were registered via
+    /// [`OpsRegistry::ingest_with_agent`] trigger a publish — without an
+    /// agent_id the publisher has nothing to route to.
+    pub fn with_publisher(mut self, publisher: SharedOpControlPublisher) -> Self {
+        self.publisher = Some(publisher);
+        self
     }
 
     /// Register a new op in the `Running` state.
@@ -118,6 +148,26 @@ impl OpsRegistry {
         };
         self.ops.insert(op_id, record.clone());
         record
+    }
+
+    /// Like [`OpsRegistry::ingest`] but also records the owning `agent_id`
+    /// so subsequent transitions can publish the matching `OpControlSignal`
+    /// to that agent's subscribed SDK stream (AAASM-1657).
+    ///
+    /// Idempotent on the op_id like `ingest`; the agent_id mapping is
+    /// inserted unconditionally (assumed stable per op_id).
+    pub fn ingest_with_agent(&self, op_id: String, agent_id: AgentId) -> OpRecord {
+        self.agents.insert(op_id.clone(), agent_id);
+        self.ingest(op_id)
+    }
+
+    /// Internal helper: publish a signal if a publisher is attached AND the
+    /// op has a recorded agent_id. Both must be present for a publish to
+    /// happen — silently no-ops otherwise.
+    fn maybe_publish(&self, op_id: &str, signal: OpControlSignal) {
+        if let (Some(pub_), Some(agent)) = (self.publisher.as_ref(), self.agents.get(op_id)) {
+            pub_.publish(agent.clone(), op_id.to_string(), signal);
+        }
     }
 
     /// Return a snapshot of the named op, or `None` if it is not registered.
@@ -161,17 +211,21 @@ impl OpsRegistry {
     /// Returns [`OpsError::InvalidTransition`] if the op is not currently
     /// `Running` (Pending / Paused / Completing / Terminated all reject).
     pub fn pause(&self, op_id: &str) -> Result<OpRecord, OpsError> {
-        let mut entry = self.ops.get_mut(op_id).ok_or(OpsError::NotFound)?;
-        match entry.state {
-            OpState::Running => {
-                entry.state = OpState::Paused;
-                entry.updated_at = chrono::Utc::now().to_rfc3339();
-                Ok(entry.clone())
+        let updated = {
+            let mut entry = self.ops.get_mut(op_id).ok_or(OpsError::NotFound)?;
+            match entry.state {
+                OpState::Running => {
+                    entry.state = OpState::Paused;
+                    entry.updated_at = chrono::Utc::now().to_rfc3339();
+                    entry.clone()
+                }
+                OpState::Pending | OpState::Paused | OpState::Completing | OpState::Terminated => {
+                    return Err(OpsError::InvalidTransition);
+                }
             }
-            OpState::Pending | OpState::Paused | OpState::Completing | OpState::Terminated => {
-                Err(OpsError::InvalidTransition)
-            }
-        }
+        };
+        self.maybe_publish(op_id, OpControlSignal::Pause);
+        Ok(updated)
     }
 
     /// Transition `Paused → Running`.
@@ -181,17 +235,21 @@ impl OpsRegistry {
     /// Returns [`OpsError::InvalidTransition`] if the op is not currently
     /// `Paused` (Pending / Running / Completing / Terminated all reject).
     pub fn resume(&self, op_id: &str) -> Result<OpRecord, OpsError> {
-        let mut entry = self.ops.get_mut(op_id).ok_or(OpsError::NotFound)?;
-        match entry.state {
-            OpState::Paused => {
-                entry.state = OpState::Running;
-                entry.updated_at = chrono::Utc::now().to_rfc3339();
-                Ok(entry.clone())
+        let updated = {
+            let mut entry = self.ops.get_mut(op_id).ok_or(OpsError::NotFound)?;
+            match entry.state {
+                OpState::Paused => {
+                    entry.state = OpState::Running;
+                    entry.updated_at = chrono::Utc::now().to_rfc3339();
+                    entry.clone()
+                }
+                OpState::Pending | OpState::Running | OpState::Completing | OpState::Terminated => {
+                    return Err(OpsError::InvalidTransition);
+                }
             }
-            OpState::Pending | OpState::Running | OpState::Completing | OpState::Terminated => {
-                Err(OpsError::InvalidTransition)
-            }
-        }
+        };
+        self.maybe_publish(op_id, OpControlSignal::Resume);
+        Ok(updated)
     }
 
     /// Transition `Running → Completing`.
@@ -227,16 +285,80 @@ impl OpsRegistry {
     ///
     /// Returns [`OpsError::NotFound`] if the ID is unknown.
     pub fn terminate(&self, op_id: &str) -> Result<OpRecord, OpsError> {
-        let mut entry = self.ops.get_mut(op_id).ok_or(OpsError::NotFound)?;
-        match entry.state {
-            OpState::Pending | OpState::Running | OpState::Paused => {
-                entry.state = OpState::Terminated;
-                entry.updated_at = chrono::Utc::now().to_rfc3339();
-                Ok(entry.clone())
+        let (updated, was_active) = {
+            let mut entry = self.ops.get_mut(op_id).ok_or(OpsError::NotFound)?;
+            match entry.state {
+                OpState::Pending | OpState::Running | OpState::Paused => {
+                    entry.state = OpState::Terminated;
+                    entry.updated_at = chrono::Utc::now().to_rfc3339();
+                    (entry.clone(), true)
+                }
+                OpState::Completing | OpState::Terminated => (entry.clone(), false),
             }
-            OpState::Completing | OpState::Terminated => Ok(entry.clone()),
+        };
+        if was_active {
+            self.maybe_publish(op_id, OpControlSignal::Terminate);
         }
+        Ok(updated)
     }
+
+    /// Sweep `Completing` and `Terminated` entries older than `ttl_seconds`.
+    ///
+    /// Returns the number of entries removed. Intended to be called on a
+    /// timer from a background tokio task (see [`spawn_sweep_task`]).
+    /// AAASM-1657: keeps the registry from growing unbounded after the
+    /// dashboard has had a chance to render the terminal state.
+    pub fn sweep(&self, ttl_seconds: i64) -> usize {
+        let now = chrono::Utc::now();
+        let mut removed = 0usize;
+        // Snapshot keys to avoid holding shards across the removal walk.
+        let keys: Vec<String> = self
+            .ops
+            .iter()
+            .filter(|r| matches!(r.state, OpState::Completing | OpState::Terminated))
+            .map(|r| r.op_id.clone())
+            .collect();
+        for op_id in keys {
+            let too_old = self
+                .ops
+                .get(&op_id)
+                .and_then(|r| chrono::DateTime::parse_from_rfc3339(&r.updated_at).ok())
+                .map(|ts| (now - ts.with_timezone(&chrono::Utc)).num_seconds() >= ttl_seconds)
+                .unwrap_or(false);
+            if too_old {
+                self.ops.remove(&op_id);
+                self.agents.remove(&op_id);
+                removed += 1;
+            }
+        }
+        removed
+    }
+}
+
+/// Spawn a background tokio task that periodically calls
+/// [`OpsRegistry::sweep`] with the configured TTL (AAASM-1657).
+///
+/// Default tick: every 10 s. Default TTL: 60 s. Returns the `JoinHandle`
+/// so the caller can `.abort()` on shutdown if desired.
+pub fn spawn_sweep_task(registry: std::sync::Arc<OpsRegistry>) -> tokio::task::JoinHandle<()> {
+    spawn_sweep_task_with(registry, std::time::Duration::from_secs(10), 60)
+}
+
+/// Test-friendly variant of [`spawn_sweep_task`] with explicit tick + TTL.
+pub fn spawn_sweep_task_with(
+    registry: std::sync::Arc<OpsRegistry>,
+    tick: std::time::Duration,
+    ttl_seconds: i64,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(tick).await;
+            let removed = registry.sweep(ttl_seconds);
+            if removed > 0 {
+                tracing::debug!(swept = removed, "OpsRegistry sweep dropped entries");
+            }
+        }
+    })
 }
 
 #[cfg(test)]
@@ -351,5 +473,123 @@ mod tests {
 
         // Completing is terminal — terminate is a no-op rather than an error.
         assert_eq!(updated.state, OpState::Completing);
+    }
+
+    // ── AAASM-1657: publisher + sweep ──────────────────────────────────────
+
+    fn agent(id: &str) -> AgentId {
+        AgentId {
+            org_id: "org".into(),
+            team_id: "team".into(),
+            agent_id: id.into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn pause_publishes_pause_signal_to_subscribed_agent() {
+        let publisher = std::sync::Arc::new(OpControlPublisher::new());
+        let registry = OpsRegistry::new().with_publisher(std::sync::Arc::clone(&publisher));
+        let mut rx = publisher.subscribe();
+
+        registry.ingest_with_agent("op-1".to_string(), agent("a1"));
+        registry.allow("op-1").unwrap();
+        registry.pause("op-1").unwrap();
+
+        let envelope = rx.recv().await.unwrap();
+        assert_eq!(envelope.message.op_id, "op-1");
+        assert_eq!(envelope.message.signal, OpControlSignal::Pause as i32);
+        assert_eq!(envelope.agent_id.agent_id, "a1");
+    }
+
+    #[tokio::test]
+    async fn resume_publishes_resume_signal() {
+        let publisher = std::sync::Arc::new(OpControlPublisher::new());
+        let registry = OpsRegistry::new().with_publisher(std::sync::Arc::clone(&publisher));
+        registry.ingest_with_agent("op-2".to_string(), agent("a1"));
+        registry.allow("op-2").unwrap();
+        registry.pause("op-2").unwrap();
+        let mut rx = publisher.subscribe();
+
+        registry.resume("op-2").unwrap();
+
+        let envelope = rx.recv().await.unwrap();
+        assert_eq!(envelope.message.signal, OpControlSignal::Resume as i32);
+    }
+
+    #[tokio::test]
+    async fn terminate_publishes_terminate_signal_only_on_active_states() {
+        let publisher = std::sync::Arc::new(OpControlPublisher::new());
+        let registry = OpsRegistry::new().with_publisher(std::sync::Arc::clone(&publisher));
+        registry.ingest_with_agent("op-3".to_string(), agent("a1"));
+        registry.allow("op-3").unwrap();
+        let mut rx = publisher.subscribe();
+
+        registry.terminate("op-3").unwrap();
+        let envelope = rx.recv().await.unwrap();
+        assert_eq!(envelope.message.signal, OpControlSignal::Terminate as i32);
+
+        // Calling terminate again on the now-Terminated op is idempotent
+        // and must NOT re-publish.
+        registry.terminate("op-3").unwrap();
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv())
+                .await
+                .is_err(),
+            "terminate on already-terminated op must not re-publish",
+        );
+    }
+
+    #[tokio::test]
+    async fn no_publish_when_op_has_no_agent_id() {
+        // An op registered via the legacy `ingest` (no agent_id) has no
+        // routing target — transitions must silently skip publishing.
+        let publisher = std::sync::Arc::new(OpControlPublisher::new());
+        let registry = OpsRegistry::new().with_publisher(std::sync::Arc::clone(&publisher));
+        let mut rx = publisher.subscribe();
+
+        registry.ingest("op-4".to_string());
+        registry.allow("op-4").unwrap();
+        registry.pause("op-4").unwrap();
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv())
+                .await
+                .is_err(),
+            "transitions on agent-less ops must not publish",
+        );
+    }
+
+    #[test]
+    fn sweep_removes_terminated_entries_older_than_ttl() {
+        let registry = OpsRegistry::new();
+        registry.register("op-old".to_string());
+        registry.terminate("op-old").unwrap();
+        // Backdate the entry by 2 minutes so the 60s TTL window passes.
+        let backdated = (chrono::Utc::now() - chrono::Duration::seconds(120)).to_rfc3339();
+        registry.ops.alter("op-old", |_, mut r| {
+            r.updated_at = backdated.clone();
+            r
+        });
+        // A second entry within the window must NOT be swept.
+        registry.register("op-fresh".to_string());
+        registry.terminate("op-fresh").unwrap();
+
+        let removed = registry.sweep(60);
+        assert_eq!(removed, 1);
+        assert!(registry.get("op-old").is_none());
+        assert!(registry.get("op-fresh").is_some());
+    }
+
+    #[test]
+    fn sweep_leaves_running_and_paused_alone() {
+        let registry = OpsRegistry::new();
+        registry.register("running".to_string());
+        registry.register("paused".to_string());
+        registry.pause("paused").unwrap();
+
+        let removed = registry.sweep(0);
+        assert_eq!(removed, 0);
+        assert!(registry.get("running").is_some());
+        assert!(registry.get("paused").is_some());
     }
 }

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -747,7 +747,16 @@ impl PolicyServiceImpl {
             return None;
         }
         let op_id = format!("{}:{}", req.trace_id, req.span_id);
-        registry.ingest(op_id.clone());
+        // AAASM-1657: thread the agent_id through to the registry so the
+        // operator-driven transitions (pause/resume/terminate) can route
+        // their OpControlSignal to the right SDK subscriber. Falls back
+        // to the agent-less `ingest` if the request omits the field
+        // (defensive — engine would reject anyway).
+        if let Some(agent_id) = req.agent_id.clone() {
+            registry.ingest_with_agent(op_id.clone(), agent_id);
+        } else {
+            registry.ingest(op_id.clone());
+        }
         Some(op_id)
     }
 
@@ -763,6 +772,18 @@ impl PolicyServiceImpl {
         };
         if let Err(err) = registry.allow(op_id) {
             tracing::trace!(op_id = %op_id, ?err, "ops_registry.allow no-op");
+        }
+    }
+
+    /// AAASM-1657: transition `Pending → Terminated` for an op the engine
+    /// just denied. Mirrors [`allow_op`] semantics — `NotFound` and
+    /// `InvalidTransition` are logged but not propagated.
+    fn terminate_op(&self, op_id: &str) {
+        let Some(registry) = self.ops_registry.as_ref() else {
+            return;
+        };
+        if let Err(err) = registry.terminate(op_id) {
+            tracing::trace!(op_id = %op_id, ?err, "ops_registry.terminate no-op");
         }
     }
 }
@@ -800,11 +821,16 @@ impl PolicyService for PolicyServiceImpl {
                 convert::eval_result_to_response(&eval, latency_us, &policy_rule)
             };
 
-        // AAASM-1422: transition Pending → Running on Allow so the registry
-        // reflects the final policy decision. Deny path is deferred to PR-H.
+        // AAASM-1422 / AAASM-1657: transition the registry op to match the
+        // final policy decision. Allow → Running, Deny → Terminated.
+        // RequiresApproval is handled by the approval queue path above and
+        // leaves the op in Pending until the operator decides.
         if let Some(op_id) = ops_op_id.as_deref() {
-            if response.decision == aa_proto::assembly::common::v1::Decision::Allow as i32 {
+            let decision = response.decision;
+            if decision == aa_proto::assembly::common::v1::Decision::Allow as i32 {
                 self.allow_op(op_id);
+            } else if decision == aa_proto::assembly::common::v1::Decision::Deny as i32 {
+                self.terminate_op(op_id);
             }
         }
 

--- a/aa-gateway/tests/ops_registry_publisher_test.rs
+++ b/aa-gateway/tests/ops_registry_publisher_test.rs
@@ -1,0 +1,105 @@
+//! End-to-end integration test for AAASM-1657 PR-H — the integration
+//! capstone. Exercises the chain:
+//!
+//!   PolicyServiceImpl(check_action ALLOW) → OpsRegistry(ingest_with_agent + allow)
+//!     → operator-driven OpsRegistry::pause/resume/terminate
+//!     → OpControlPublisher fan-out to the subscribed SDK
+//!     → registry sweep removes terminal entries after TTL
+//!
+//! The SDK side is simulated via a direct `OpControlPublisher::subscribe()`
+//! receiver (the same channel any tonic OpControlStream client would land
+//! on) — avoids standing up a gRPC server for this Rust-side test. End-to-
+//! end SDK roundtrips are covered by the per-SDK integration tests in
+//! AAASM-1654 (python), AAASM-1655 (node), and AAASM-1656 (go).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use aa_gateway::ops::{OpControlPublisher, OpState, OpsRegistry};
+use aa_proto::assembly::common::v1::AgentId;
+use aa_proto::assembly::policy::v1::OpControlSignal;
+use tokio::time::timeout;
+
+fn agent(id: &str) -> AgentId {
+    AgentId {
+        org_id: "org".into(),
+        team_id: "team".into(),
+        agent_id: id.into(),
+    }
+}
+
+#[tokio::test]
+async fn full_lifecycle_publishes_each_signal_and_sweep_removes_terminal_entry() {
+    let publisher = Arc::new(OpControlPublisher::new());
+    let registry = Arc::new(OpsRegistry::new().with_publisher(Arc::clone(&publisher)));
+    let mut rx = publisher.subscribe();
+
+    // ── 1. ingest + allow (simulates PolicyServiceImpl on Allow) ────────
+    registry.ingest_with_agent("trace-1:span-1".into(), agent("agent-7"));
+    registry.allow("trace-1:span-1").unwrap();
+    assert_eq!(registry.get("trace-1:span-1").unwrap().state, OpState::Running);
+
+    // ── 2. operator pauses ──────────────────────────────────────────────
+    registry.pause("trace-1:span-1").unwrap();
+    let env = timeout(Duration::from_secs(1), rx.recv()).await.unwrap().unwrap();
+    assert_eq!(env.message.op_id, "trace-1:span-1");
+    assert_eq!(env.message.signal, OpControlSignal::Pause as i32);
+    assert_eq!(env.agent_id.agent_id, "agent-7");
+
+    // ── 3. operator resumes ─────────────────────────────────────────────
+    registry.resume("trace-1:span-1").unwrap();
+    let env = timeout(Duration::from_secs(1), rx.recv()).await.unwrap().unwrap();
+    assert_eq!(env.message.signal, OpControlSignal::Resume as i32);
+
+    // ── 4. SDK marks the op complete ────────────────────────────────────
+    registry.complete("trace-1:span-1").unwrap();
+    assert_eq!(registry.get("trace-1:span-1").unwrap().state, OpState::Completing);
+    // No publish for complete — Completing is the SDK-initiated terminal
+    // state, not an operator signal that needs to flow back.
+
+    // ── 5. sweep removes the Completing entry after TTL elapses ─────────
+    // Use a 0-second TTL to bypass the time barrier in test (the
+    // `spawn_sweep_task_with(registry, tick, 0)` daemon would do this in
+    // prod with a real TTL; we drive the sweep manually here so the test
+    // doesn't sleep for 60s).
+    let removed = registry.sweep(0);
+    assert_eq!(removed, 1);
+    assert!(registry.get("trace-1:span-1").is_none());
+    assert!(registry.agent_for("trace-1:span-1").is_none(), "agent map also pruned");
+}
+
+#[tokio::test]
+async fn deny_path_terminates_op_and_publishes_terminate() {
+    // Mirrors what PolicyServiceImpl.terminate_op does on a Deny decision.
+    let publisher = Arc::new(OpControlPublisher::new());
+    let registry = Arc::new(OpsRegistry::new().with_publisher(Arc::clone(&publisher)));
+    let mut rx = publisher.subscribe();
+
+    registry.ingest_with_agent("trace-deny:span-0".into(), agent("agent-9"));
+    registry.terminate("trace-deny:span-0").unwrap();
+
+    let env = timeout(Duration::from_secs(1), rx.recv()).await.unwrap().unwrap();
+    assert_eq!(env.message.signal, OpControlSignal::Terminate as i32);
+    assert_eq!(env.agent_id.agent_id, "agent-9");
+    assert_eq!(registry.get("trace-deny:span-0").unwrap().state, OpState::Terminated,);
+}
+
+#[tokio::test]
+async fn sweep_preserves_active_states() {
+    let publisher = Arc::new(OpControlPublisher::new());
+    let registry = Arc::new(OpsRegistry::new().with_publisher(Arc::clone(&publisher)));
+
+    registry.ingest_with_agent("running".into(), agent("a"));
+    registry.allow("running").unwrap();
+    registry.ingest_with_agent("paused".into(), agent("b"));
+    registry.allow("paused").unwrap();
+    registry.pause("paused").unwrap();
+    registry.ingest("pending-with-no-agent".into());
+
+    // TTL 0 → would sweep anything terminal. Active states must survive.
+    let removed = registry.sweep(0);
+    assert_eq!(removed, 0);
+    assert!(registry.get("running").is_some());
+    assert!(registry.get("paused").is_some());
+    assert!(registry.get("pending-with-no-agent").is_some());
+}

--- a/aa-gateway/tests/policy_service_ops_ingestion_test.rs
+++ b/aa-gateway/tests/policy_service_ops_ingestion_test.rs
@@ -98,9 +98,10 @@ tools:
 }
 
 #[tokio::test]
-async fn check_action_deny_leaves_op_pending_until_pr_h() {
-    // Deny path doesn't yet transition the op — that's PR-H. For now we
-    // assert the Pending entry exists; PR-H will assert Terminated here.
+async fn check_action_deny_transitions_op_to_terminated() {
+    // AAASM-1657: Deny now transitions the op Pending → Terminated.
+    // (PR-A originally left the op in Pending and deferred the transition
+    // to PR-H — this test was updated when PR-H landed.)
     let registry = Arc::new(OpsRegistry::new());
     let addr = start_server_with_ops(
         r#"
@@ -123,8 +124,8 @@ tools:
     assert_eq!(resp.decision, Decision::Deny as i32);
     let record = registry
         .get("trace-deny:span-1")
-        .expect("op should still be ingested on Deny — only the transition is deferred");
-    assert_eq!(record.state, OpState::Pending);
+        .expect("op should be ingested on Deny");
+    assert_eq!(record.state, OpState::Terminated);
 }
 
 #[tokio::test]

--- a/docs/src/operations/ops-registry-architecture.md
+++ b/docs/src/operations/ops-registry-architecture.md
@@ -35,7 +35,7 @@ plan for the IPC protocol and SDK enforcement.
 | **Ingestion entry point** | `OpsRegistry::ingest(op_id) -> OpRecord` keyed by `{trace_id}:{span_id}`, idempotent | Called from `PolicyServiceImpl::check_action` *before* policy evaluation so the op appears in `Pending` state even if the policy decision takes time. |
 | **Allow transition** | `OpsRegistry::allow(op_id)`: `Pending → Running` | Called from `PolicyServiceImpl::check_action` after an `Allow` decision. |
 | **Complete transition** | `OpsRegistry::complete(op_id)`: `Running → Completing` | Drained-out terminal state; entries stay readable briefly so the dashboard can render the completion before they're swept. |
-| **Sweep policy (out of scope for PR-A)** | TBD in PR-H | Today the registry grows monotonically. Sweep / TTL is a follow-up. |
+| **Sweep policy** | Background tokio task on the registry drops `Completing` + `Terminated` entries older than **60 s**. Tick **every 10 s**. Configurable via `spawn_sweep_task_with(registry, tick, ttl_seconds)`. (AAASM-1657 PR-H) | Bounds registry memory while giving the dashboard ~10 s of grace to render the terminal state before it disappears. |
 
 ## 3 — Data model
 


### PR DESCRIPTION
## Description

PR-H of [AAASM-1422](https://lightning-dust-mite.atlassian.net/browse/AAASM-1422) — **the integration capstone**. Closes the loop between every component the previous seven PRs shipped independently:

```
PolicyServiceImpl(check_action)         ← PR-A
  → OpsRegistry.ingest_with_agent       ← (new in PR-H)
  → engine.evaluate                     (existing)
  → OpsRegistry.allow OR .terminate     ← (new Deny path in PR-H)

operator-driven HTTP                    ← AAASM-1525 / PR-A stubs
  → OpsRegistry.pause/.resume/.terminate
  → OpControlPublisher.publish          ← (new in PR-H)         → SDK consumers (PR-E/F/G)
  → ops_change WS event                 ← (new in PR-H)         → Dashboard (PR-C)

background sweep daemon                 ← (new in PR-H)
  → OpsRegistry.sweep(ttl=60s)
```

### What this PR ships

| Layer | Change | File |
|---|---|---|
| Registry → publisher wiring | `OpsRegistry::with_publisher(...)`, `ingest_with_agent(op_id, agent_id)`, `agent_for(op_id)` accessor, and a `maybe_publish` helper that fires `OpControlSignal::Pause/Resume/Terminate` from each transition when an agent_id is known | `aa-gateway/src/ops/mod.rs` |
| Sweep | `OpsRegistry::sweep(ttl_seconds)` + `spawn_sweep_task(registry)` daemon (10s tick / 60s TTL defaults) | `aa-gateway/src/ops/mod.rs` |
| Deny → Terminated | `PolicyServiceImpl::terminate_op` + `check_action` branch on `Decision::Deny`; `ingest_op` now uses `ingest_with_agent` to thread the agent_id | `aa-gateway/src/service/policy_service.rs` |
| WS broadcast | `OpsChangeBroadcast { agent_id, payload }` envelope + `ops_change_tx` channel on `EventBroadcast`, `subscribe_ops_change` / `ops_change_sender` accessors | `aa-api/src/events.rs` |
| WS dispatch | New `select!` arm builds `GovernanceEvent { event_type: OpsChange, ... }` from each envelope and applies the existing per-client type filter | `aa-api/src/ws/handler.rs` |
| Route emission | `emit_ops_change` helper called from `pause_op` / `resume_op` / `terminate_op` after each successful transition | `aa-api/src/routes/ops.rs` |
| Sweep spawn | `spawn_sweep_task(state.ops_registry.clone())` alongside the silence-watcher in `run_server` | `aa-api/src/server.rs` |
| Architecture doc | §2 "Sweep policy" updated from "TBD in PR-H" → concrete defaults | `docs/src/operations/ops-registry-architecture.md` |

### Scope boundary honoured

- New proto types or event variants — **not added** (PR-B + PR-D already shipped them).
- New dashboard logic — **not changed** (PR-C consumes `ops_change` already).
- New SDK code — **not changed** (PR-E/F/G subscribers receive the new signals automatically).
- Multi-gateway cluster coordination — **out of scope** for v0.0.1.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Pure additive: optional builder on `OpsRegistry` (no-op when not used), additive channel on `EventBroadcast`, new WS dispatch arm. Existing tests (AAASM-1525's 13 `api_ops` integration tests, the 8 `ops_lifecycle` route tests, the original 15 `ops::*` unit tests) all pass without modification. Only behavioural delta: a Deny policy decision now transitions Pending → Terminated instead of leaving the op in Pending — the AAASM-1422 PR-A test `check_action_deny_leaves_op_pending_until_pr_h` is renamed and updated to reflect the new expectation, with the rename called out in the commit message.

## Related Issues

- Related Jira ticket: [AAASM-1657](https://lightning-dust-mite.atlassian.net/browse/AAASM-1657) (parent: AAASM-1422)
- Built on (all merged):
  - [AAASM-1422](https://lightning-dust-mite.atlassian.net/browse/AAASM-1422) PR-A — `OpsRegistry` + 5-state machine
  - [AAASM-1651](https://lightning-dust-mite.atlassian.net/browse/AAASM-1651) PR-B — `OpsChangePayload` schema
  - [AAASM-1652](https://lightning-dust-mite.atlassian.net/browse/AAASM-1652) PR-C — dashboard `useLiveOpsStream`
  - [AAASM-1653](https://lightning-dust-mite.atlassian.net/browse/AAASM-1653) PR-D — `OpControlStream` + `OpControlPublisher`
  - [AAASM-1654](https://lightning-dust-mite.atlassian.net/browse/AAASM-1654) PR-E — python-sdk subscriber
  - [AAASM-1655](https://lightning-dust-mite.atlassian.net/browse/AAASM-1655) PR-F — node-sdk subscriber
  - [AAASM-1656](https://lightning-dust-mite.atlassian.net/browse/AAASM-1656) PR-G — go-sdk subscriber

After this PR merges, **all 7 sub-tasks of AAASM-1422 are Done** and the parent Task can finally close.

## Testing

- [x] Unit tests added / updated — 6 new in `aa-gateway/src/ops/mod.rs::tests` (publish on pause/resume/terminate, no-publish-when-agent-less, sweep removes terminal, sweep preserves active)
- [x] Integration tests added / updated — 3 new in `aa-gateway/tests/ops_registry_publisher_test.rs` (full lifecycle e2e, Deny→Terminate, sweep preserves active); 1 existing PR-A test updated for Deny→Terminate semantic
- [x] Manual testing performed — full local gates run
- [ ] No tests required

### Local gates (all green)

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | ✅ |
| `cargo clippy --workspace --all-targets --all-features --exclude aa-ebpf -- -D warnings` | ✅ |
| `cargo nextest run -p aa-gateway -p aa-api` | ✅ **1336 / 1336** (1 leaky, expected) |
| `cargo nextest run -p aa-gateway --test ops_registry_publisher_test` | ✅ **3 / 3** new e2e |
| `cargo nextest run -p aa-gateway --test policy_service_ops_ingestion_test` | ✅ **4 / 4** (incl. updated Deny test) |
| `cargo nextest run -p aa-integration-tests --test api_ops` | ✅ **13 / 13** (AAASM-1525 untouched) |
| `cargo nextest run -p aa-api --test ops_lifecycle` | ✅ **8 / 8** (route-level untouched) |

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated (architecture doc §2 sweep policy)
- [ ] All CI checks passing (pending)
- [x] Commits are small and follow the Gitmoji convention

### Commits (6 granular)

1. ✨ `(aa-gateway/ops)` Wire OpControlPublisher + sweep into OpsRegistry
2. ✨ `(aa-gateway/service)` Wire Deny→Terminated + agent_id thread-through
3. ✨ `(aa-api)` Emit ops_change WS events on every registry transition
4. ✨ `(aa-api)` Spawn OpsRegistry sweep task + record TTL in arch doc
5. 📝 `(docs/operations)` Replace sweep-policy TBD with PR-H defaults
6. ✅ `(aa-gateway/tests)` Add end-to-end ops_registry+publisher+sweep test

[AAASM-1422]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1657]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ