### PR TITLE
[AAASM-1698] ✨ (aa-gateway): Add /healthz HTTP route module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,7 @@ dependencies = [
  "arc-swap",
  "async-stream",
  "async-trait",
+ "axum",
  "chrono",
  "chrono-tz",
  "clap",

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -45,6 +45,7 @@ sqlx         = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", 
 tokio-util   = "0.7"
 parking_lot  = "0.12"
 utoipa       = { version = "5", features = ["axum_extras"] }
+axum         = "0.8"
 
 [dev-dependencies]
 criterion    = { version = "0.8", features = ["async_tokio"] }

--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -18,6 +18,7 @@ pub mod message_router;
 pub mod ops;
 pub mod policy;
 pub mod registry;
+pub mod routes;
 pub mod server;
 pub mod service;
 pub mod simulation;

--- a/aa-gateway/src/routes/healthz.rs
+++ b/aa-gateway/src/routes/healthz.rs
@@ -8,6 +8,7 @@
 
 use std::time::Instant;
 
+use axum::{Extension, Json};
 use serde::Serialize;
 
 /// Process-wide state required by [`healthz`] to compute its response.
@@ -57,4 +58,19 @@ pub struct HealthzBody {
     pub storage: String,
     /// Seconds elapsed since the gateway became ready to serve traffic.
     pub uptime_secs: u64,
+}
+
+/// `GET /healthz` — process-liveness probe.
+///
+/// Always returns `200 OK` with [`HealthzBody`] as long as the gateway
+/// process is responding to HTTP. A 200 here does **not** imply the
+/// database or any downstream subsystem is healthy — `/api/v1/admin/status`
+/// reports the deeper readiness signal (delivered by AAASM-1474).
+pub async fn healthz(Extension(state): Extension<HealthzState>) -> Json<HealthzBody> {
+    Json(HealthzBody {
+        mode: state.mode.to_string(),
+        version: state.version.to_string(),
+        storage: state.storage.to_string(),
+        uptime_secs: state.started_at.elapsed().as_secs(),
+    })
 }

--- a/aa-gateway/src/routes/healthz.rs
+++ b/aa-gateway/src/routes/healthz.rs
@@ -74,3 +74,23 @@ pub async fn healthz(Extension(state): Extension<HealthzState>) -> Json<HealthzB
         uptime_secs: state.started_at.elapsed().as_secs(),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn body_serialises_to_documented_shape() {
+        let body = HealthzBody {
+            mode: "remote".into(),
+            version: "0.0.1".into(),
+            storage: "memory".into(),
+            uptime_secs: 7,
+        };
+        let json = serde_json::to_value(&body).expect("HealthzBody must serialise");
+        assert_eq!(json["mode"], "remote");
+        assert_eq!(json["version"], "0.0.1");
+        assert_eq!(json["storage"], "memory");
+        assert_eq!(json["uptime_secs"], 7);
+    }
+}

--- a/aa-gateway/src/routes/healthz.rs
+++ b/aa-gateway/src/routes/healthz.rs
@@ -8,6 +8,8 @@
 
 use std::time::Instant;
 
+use serde::Serialize;
+
 /// Process-wide state required by [`healthz`] to compute its response.
 ///
 /// Constructed once at gateway startup and threaded into Axum as an
@@ -38,4 +40,21 @@ impl HealthzState {
             started_at: Instant::now(),
         }
     }
+}
+
+/// JSON body returned by `GET /healthz`.
+///
+/// Field names are stable wire contract — load balancers, the `aasm
+/// status` CLI, and the dashboard parse this shape. Do not rename
+/// without a coordinated client update.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct HealthzBody {
+    /// Deployment mode label: `"local"` or `"remote"`.
+    pub mode: String,
+    /// Gateway crate version.
+    pub version: String,
+    /// Storage backend label.
+    pub storage: String,
+    /// Seconds elapsed since the gateway became ready to serve traffic.
+    pub uptime_secs: u64,
 }

--- a/aa-gateway/src/routes/healthz.rs
+++ b/aa-gateway/src/routes/healthz.rs
@@ -1,3 +1,41 @@
 //! `GET /healthz` — gateway process-liveness probe.
 //!
-//! Contents are added in subsequent commits for AAASM-1698.
+//! Returns `200 OK` whenever the gateway process is responsive. The
+//! response is intentionally cheap to compute — no DB queries, no
+//! downstream subsystem checks — so the endpoint can be hit by
+//! load-balancer health probes at high frequency without affecting
+//! request-path latency.
+
+use std::time::Instant;
+
+/// Process-wide state required by [`healthz`] to compute its response.
+///
+/// Constructed once at gateway startup and threaded into Axum as an
+/// `Extension`. Cloning is cheap — `mode`, `version`, and `storage`
+/// are `'static` string slices and `started_at` is a `Copy` `Instant`.
+#[derive(Clone, Debug)]
+pub struct HealthzState {
+    /// Deployment mode label: `"local"` or `"remote"`.
+    pub mode: &'static str,
+    /// Storage backend label: `"sqlite"`, `"postgres"`, or `"memory"`.
+    pub storage: &'static str,
+    /// Gateway crate version (from `CARGO_PKG_VERSION`).
+    pub version: &'static str,
+    /// Wall-clock instant the gateway became ready to serve traffic.
+    pub started_at: Instant,
+}
+
+impl HealthzState {
+    /// Build state for a freshly-started gateway. `mode` and `storage`
+    /// are the labels reported in the response body; `started_at` is
+    /// captured at construction time and drives the `uptime_secs`
+    /// field of [`super::healthz`]'s response.
+    pub fn new(mode: &'static str, storage: &'static str) -> Self {
+        Self {
+            mode,
+            storage,
+            version: env!("CARGO_PKG_VERSION"),
+            started_at: Instant::now(),
+        }
+    }
+}

--- a/aa-gateway/src/routes/healthz.rs
+++ b/aa-gateway/src/routes/healthz.rs
@@ -1,0 +1,3 @@
+//! `GET /healthz` — gateway process-liveness probe.
+//!
+//! Contents are added in subsequent commits for AAASM-1698.

--- a/aa-gateway/src/routes/healthz.rs
+++ b/aa-gateway/src/routes/healthz.rs
@@ -93,4 +93,13 @@ mod tests {
         assert_eq!(json["storage"], "memory");
         assert_eq!(json["uptime_secs"], 7);
     }
+
+    #[tokio::test]
+    async fn handler_returns_documented_body() {
+        let state = HealthzState::new("remote", "memory");
+        let Json(body) = healthz(Extension(state)).await;
+        assert_eq!(body.mode, "remote");
+        assert_eq!(body.storage, "memory");
+        assert_eq!(body.version, env!("CARGO_PKG_VERSION"));
+    }
 }

--- a/aa-gateway/src/routes/healthz.rs
+++ b/aa-gateway/src/routes/healthz.rs
@@ -77,6 +77,8 @@ pub async fn healthz(Extension(state): Extension<HealthzState>) -> Json<HealthzB
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
 
     #[test]
@@ -101,5 +103,30 @@ mod tests {
         assert_eq!(body.mode, "remote");
         assert_eq!(body.storage, "memory");
         assert_eq!(body.version, env!("CARGO_PKG_VERSION"));
+    }
+
+    #[tokio::test]
+    async fn uptime_secs_is_monotonic_non_negative() {
+        // Build state with a started_at 5 seconds in the past so uptime is
+        // deterministic without needing tokio::time::sleep on the test path.
+        let state = HealthzState {
+            mode: "remote",
+            storage: "memory",
+            version: "0.0.1",
+            started_at: Instant::now() - Duration::from_secs(5),
+        };
+        let Json(first) = healthz(Extension(state.clone())).await;
+        let Json(second) = healthz(Extension(state)).await;
+        assert!(
+            first.uptime_secs >= 5,
+            "expected uptime ≥ 5s after backdating started_at, got {}",
+            first.uptime_secs
+        );
+        assert!(
+            second.uptime_secs >= first.uptime_secs,
+            "uptime must be monotonic non-decreasing: {} -> {}",
+            first.uptime_secs,
+            second.uptime_secs
+        );
     }
 }

--- a/aa-gateway/src/routes/mod.rs
+++ b/aa-gateway/src/routes/mod.rs
@@ -1,0 +1,9 @@
+//! HTTP routes served by `aa-gateway`.
+//!
+//! In remote mode, the gateway exposes a small set of process-liveness
+//! and admin endpoints over Axum. The full agent-control surface lives
+//! in the sibling `aa-api` crate; this module only owns routes that
+//! must be reachable even when `aa-api` is not mounted (today: just
+//! `/healthz`).
+
+pub mod healthz;


### PR DESCRIPTION
## Description

Introduces the `/healthz` HTTP liveness route in `aa-gateway` — the foundational module for the Remote CP Mode work landing under [AAASM-1577](https://lightning-dust-mite.atlassian.net/browse/AAASM-1577) (E17 S-C).

Adds:

- `aa-gateway/src/routes/mod.rs` — new `routes` module declaration
- `aa-gateway/src/routes/healthz.rs` — `HealthzState`, `HealthzBody`, and the `healthz` Axum handler
- `aa-gateway/Cargo.toml` — `axum = "0.8"` dependency (same pin as `aa-api`)
- 3 unit tests under `routes::healthz::tests`

The handler is intentionally cheap — no DB queries, no subsystem checks — so load balancers can probe it at high frequency. A 200 from `/healthz` does **not** imply downstream subsystem health; `/api/v1/admin/status` reports the deeper readiness signal.

Out of scope for this PR (separate Sub-tasks):

- TLS validator (AAASM-1702 / ST-2)
- `start_remote()` server bootstrap (AAASM-1709 / ST-3)
- `main.rs` mode dispatch (AAASM-1713 / ST-4)
- Story-level acceptance verification (AAASM-1718 / ST-5)

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1698 (Sub-task of AAASM-1577 under Epic AAASM-1568)
- Related GitHub issues: —

## Testing

- [x] Unit tests added — 3 tests under `aa-gateway routes::healthz::tests`
- [x] Manual testing — `cargo nextest run -p aa-gateway routes::healthz` green

```
$ cargo nextest run -p aa-gateway routes::healthz
        PASS routes::healthz::tests::body_serialises_to_documented_shape
        PASS routes::healthz::tests::handler_returns_documented_body
        PASS routes::healthz::tests::uptime_secs_is_monotonic_non_negative
     Summary 3 tests run: 3 passed, 829 skipped
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on new types)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1577]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ