### PR TITLE
[AAASM-1701] ✨ (aa-gateway): Scaffold local_mode module + types

### DIFF
--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -14,6 +14,7 @@ pub mod edges;
 pub mod engine;
 pub mod events;
 pub mod iam;
+pub mod local_mode;
 pub mod message_router;
 pub mod ops;
 pub mod policy;

--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -9,6 +9,7 @@
 
 use std::net::SocketAddr;
 
+use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 
 /// Handle returned by `start_local()` once the local control plane is up.
@@ -28,4 +29,25 @@ pub struct LocalGatewayHandle {
     /// One-shot channel that signals the Axum server task to begin
     /// graceful shutdown. Hooked up by AAASM-1728's signal handler.
     pub(crate) shutdown_tx: oneshot::Sender<()>,
+}
+
+/// JSON payload returned by `GET /healthz` in local mode.
+///
+/// Documented response shape from AAASM-1576 AC #4:
+///
+/// ```json
+/// {"mode":"local","storage":"sqlite","version":"0.0.1"}
+/// ```
+///
+/// `Deserialize` is derived so the pre-flight probe in AAASM-1715 can
+/// re-parse the response and reject other servers that happen to be
+/// listening on the same port but speak a different protocol.
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HealthzResponse {
+    /// Always `"local"` when produced by this module.
+    pub mode: String,
+    /// Storage backend label — `"sqlite"` for local mode.
+    pub storage: String,
+    /// Gateway binary version (set from `CARGO_PKG_VERSION` at compile time).
+    pub version: String,
 }

--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -8,6 +8,7 @@
 //! [`DeploymentMode::Local`]: aa_core::config::DeploymentMode::Local
 
 use std::net::SocketAddr;
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
@@ -50,4 +51,46 @@ pub struct HealthzResponse {
     pub storage: String,
     /// Gateway binary version (set from `CARGO_PKG_VERSION` at compile time).
     pub version: String,
+}
+
+/// Errors that can occur while booting the local-mode control plane.
+///
+/// Each variant maps to a discrete failure mode an operator running
+/// `aasm start --mode local` (or a test calling `start_local()`
+/// directly) might hit. The `#[source]` fields preserve the original
+/// I/O / sqlx / signal error so `{:?}` and `tracing` capture the full
+/// chain.
+#[derive(Debug, thiserror::Error)]
+pub enum LocalModeError {
+    /// `TcpListener::bind` failed — port already in use by a foreign
+    /// process, permission denied, or address invalid.
+    #[error("failed to bind local gateway to {addr}: {source}")]
+    Bind {
+        /// The socket address `start_local()` tried to bind.
+        addr: String,
+        /// Underlying `std::io::Error` from `TcpListener::bind`.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Opening or migrating the SQLite database at `path` failed.
+    #[error("failed to open SQLite at {path}: {source}", path = path.display())]
+    Storage {
+        /// The resolved on-disk path the gateway tried to open.
+        path: PathBuf,
+        /// Underlying `sqlx::Error` from `SqlitePool::connect_with`.
+        #[source]
+        source: sqlx::Error,
+    },
+    /// Writing the PID file to `~/.aasm/gateway.pid` failed.
+    #[error("failed to write PID file at {path}: {source}", path = path.display())]
+    PidFile {
+        /// The PID-file path the gateway tried to write.
+        path: PathBuf,
+        /// Underlying `std::io::Error` from `std::fs::write`.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Installing the SIGTERM / SIGINT handler failed (Unix only).
+    #[error("shutdown signal handler installation failed: {0}")]
+    Signal(#[source] std::io::Error),
 }

--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -94,3 +94,38 @@ pub enum LocalModeError {
     #[error("shutdown signal handler installation failed: {0}")]
     Signal(#[source] std::io::Error),
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// AAASM-1576 AC #4: `/healthz` must return exactly
+    /// `{"mode":"local","storage":"sqlite","version":"<v>"}` —
+    /// no extra fields, no extra whitespace, lowercase values,
+    /// and the keys in the documented order.
+    #[test]
+    fn healthz_response_serialises_to_documented_shape() {
+        let resp = HealthzResponse {
+            mode: "local".to_string(),
+            storage: "sqlite".to_string(),
+            version: "0.0.1".to_string(),
+        };
+        let json = serde_json::to_string(&resp).expect("serde_json::to_string");
+        assert_eq!(json, r#"{"mode":"local","storage":"sqlite","version":"0.0.1"}"#);
+    }
+
+    /// The probe path in AAASM-1715 re-parses `/healthz` responses as
+    /// `HealthzResponse`; round-tripping the documented shape must
+    /// recover the exact same struct.
+    #[test]
+    fn healthz_response_round_trips_through_serde() {
+        let original = HealthzResponse {
+            mode: "local".to_string(),
+            storage: "sqlite".to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+        };
+        let json = serde_json::to_string(&original).expect("serialise");
+        let parsed: HealthzResponse = serde_json::from_str(&json).expect("deserialise");
+        assert_eq!(parsed, original);
+    }
+}

--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -1,0 +1,8 @@
+//! Local Dev Mode bootstrap (Epic 17 S-B, AAASM-1576).
+//!
+//! Hosts the lightweight in-process control plane the gateway runs in
+//! [`DeploymentMode::Local`]. The module is built up across the eight
+//! sub-tasks of AAASM-1576; this file currently provides only the type
+//! surface that the remaining sub-tasks layer behaviour onto.
+//!
+//! [`DeploymentMode::Local`]: aa_core::config::DeploymentMode::Local

--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -6,3 +6,26 @@
 //! surface that the remaining sub-tasks layer behaviour onto.
 //!
 //! [`DeploymentMode::Local`]: aa_core::config::DeploymentMode::Local
+
+use std::net::SocketAddr;
+
+use tokio::sync::oneshot;
+
+/// Handle returned by `start_local()` once the local control plane is up.
+///
+/// Holds the bound socket address (useful in tests that bind to port `0`
+/// to pick a free port) and the one-shot sender that drives the graceful
+/// shutdown path installed in AAASM-1728.
+///
+/// The handle is intentionally **not** `Clone` — only one caller can
+/// own the shutdown trigger at a time.
+#[allow(dead_code)] // consumed by start_local() / run_until_shutdown — AAASM-1725, AAASM-1728
+pub struct LocalGatewayHandle {
+    /// Address the local gateway is actually bound to. In normal
+    /// operation this is `127.0.0.1:{config.port}`; in tests that pass
+    /// port `0`, the resolved ephemeral port lives here.
+    pub local_addr: SocketAddr,
+    /// One-shot channel that signals the Axum server task to begin
+    /// graceful shutdown. Hooked up by AAASM-1728's signal handler.
+    pub(crate) shutdown_tx: oneshot::Sender<()>,
+}


### PR DESCRIPTION
## Description

Sub-task 1 of [AAASM-1576](https://lightning-dust-mite.atlassian.net/browse/AAASM-1576) (E17 S-B — Local Dev Mode). Establishes the `aa-gateway::local_mode` module surface that the remaining seven sub-tasks of S-B layer behaviour onto. No business logic; types only.

Delivered in five granular commits:

1. `✨ (aa-gateway): Add local_mode module scaffold + mod registration` — empty file + `pub mod local_mode;` in `lib.rs`.
2. `✨ (aa-gateway/local_mode): Add LocalGatewayHandle struct` — bound socket address + one-shot shutdown sender (consumed by AAASM-1725 / AAASM-1728; transient `#[allow(dead_code)]` until then).
3. `✨ (aa-gateway/local_mode): Add HealthzResponse serde struct` — encodes the `{mode, storage, version}` JSON shape from AAASM-1576 AC #4; `Deserialize` derived for the probe path in AAASM-1715.
4. `✨ (aa-gateway/local_mode): Add LocalModeError enum` — `Bind` / `Storage` / `PidFile` / `Signal` variants, each preserving the underlying `#[source]` error.
5. `✅ (aa-gateway/local_mode): Test HealthzResponse JSON shape` — byte-exact equality assertion + serde round-trip.

```text
cargo nextest run -p aa-gateway local_mode::tests
    Starting 2 tests across 37 binaries (829 tests skipped)
        PASS [   0.019s] aa-gateway local_mode::tests::healthz_response_round_trips_through_serde
        PASS [   0.019s] aa-gateway local_mode::tests::healthz_response_serialises_to_documented_shape
     Summary [   0.021s] 2 tests run: 2 passed, 829 skipped
```

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

Pure additive change. New module `aa_gateway::local_mode` with three types. No existing public API is touched.

## Related Issues

- Related Jira ticket: [AAASM-1701](https://lightning-dust-mite.atlassian.net/browse/AAASM-1701) (this sub-task)
- Parent Story: [AAASM-1576](https://lightning-dust-mite.atlassian.net/browse/AAASM-1576) (E17 S-B — Local Dev Mode)
- Parent Epic: [AAASM-1568](https://lightning-dust-mite.atlassian.net/browse/AAASM-1568) (Epic 17 — Gateway Deployment Architecture)
- Depends on: [AAASM-1575](https://lightning-dust-mite.atlassian.net/browse/AAASM-1575) (E17 S-A GatewayConfig — Done)

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated — two new tests in `aa-gateway::local_mode::tests` (JSON shape equality + serde round-trip).
- [ ] Integration tests added / updated — N/A for this sub-task (no behaviour yet).
- [x] Manual testing performed — `cargo build -p aa-gateway`, `cargo clippy -p aa-gateway --all-targets -- -D warnings`, `cargo nextest run -p aa-gateway local_mode::tests` all green locally.
- [ ] No tests required (explain why)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`) — lefthook fmt + clippy passed on every commit.
- [x] Self-review of the diff completed.
- [x] Documentation updated if behaviour changed — module-level doc comment + per-item rustdoc on every public type.
- [x] All CI checks passing — pending CI verification on this PR.
- [x] Commits are small and follow the Gitmoji convention — 5 commits, each scoped to one type/test.

## Sub-task acceptance criteria (AAASM-1701)

- [x] `aa-gateway/src/local_mode.rs` exists and is published via `pub mod local_mode;` in `lib.rs`.
- [x] `LocalGatewayHandle`, `HealthzResponse`, `LocalModeError` are exported from `aa_gateway::local_mode`.
- [x] `HealthzResponse` serialises to exactly `{"mode":"local","storage":"sqlite","version":"…"}` (unit test).
- [x] `cargo nextest run -p aa-gateway local_mode::tests` green.
- [x] `cargo clippy -p aa-gateway --all-targets -- -D warnings` clean.

## Note on the pre-existing flaky test

`aa-gateway::policy_latency_test::sustained_load_p99_under_5ms` is **already flaky on `master` HEAD `18065ea2`** independent of this PR (reproduced locally without these commits: p99 ~301ms vs 15ms target). Tracking under AAASM-1270 (`docs/latency_test_coverage_rule`). Not regressed by this PR.

[AAASM-1576]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1701]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ