### PR TITLE
[AAASM-1719] ✨ (storage): Scaffold PostgresBackend skeleton and PostgresConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5670,6 +5670,7 @@ checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
  "base64",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -5748,6 +5749,7 @@ dependencies = [
  "bitflags 2.11.1",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "digest 0.10.7",
  "dotenvy",
@@ -5790,6 +5792,7 @@ dependencies = [
  "base64",
  "bitflags 2.11.1",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -5825,6 +5828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
+ "chrono",
  "flume",
  "futures-channel",
  "futures-core",

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -41,7 +41,7 @@ strsim       = "0.11"
 humantime    = "2"
 ahash        = "0.8"
 metrics      = "0.24"
-sqlx         = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "macros", "migrate", "uuid"] }
+sqlx         = { version = "0.8", features = ["runtime-tokio-rustls", "sqlite", "postgres", "macros", "migrate", "uuid", "chrono"] }
 tokio-util   = "0.7"
 parking_lot  = "0.12"
 utoipa       = { version = "5", features = ["axum_extras"] }

--- a/aa-gateway/src/storage/mod.rs
+++ b/aa-gateway/src/storage/mod.rs
@@ -29,6 +29,8 @@ pub mod error;
 pub mod health;
 pub mod metric;
 pub mod policy;
+pub mod postgres;
+pub mod postgres_config;
 pub mod retention;
 
 pub use agent::{AgentFilter, AgentRecord, TeamId};
@@ -38,4 +40,6 @@ pub use error::{StorageError, StorageResult};
 pub use health::{HealthStatus, RowCounts, StorageHealth};
 pub use metric::{Metric, MetricPoint, MetricQuery};
 pub use policy::{PolicyDocument, PolicyMeta, PolicyVersion};
+pub use postgres::PostgresBackend;
+pub use postgres_config::PostgresConfig;
 pub use retention::{ColdAction, RetentionPolicy, RetentionStats};

--- a/aa-gateway/src/storage/postgres.rs
+++ b/aa-gateway/src/storage/postgres.rs
@@ -48,3 +48,24 @@ impl PostgresBackend {
         Ok(Self { pool })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn connect_rejects_missing_database_url() {
+        let config = PostgresConfig::default();
+        let result = PostgresBackend::connect(&config).await;
+        match result {
+            Err(StorageError::ConnectionFailed(msg)) => {
+                assert!(
+                    msg.contains("AAASM_DATABASE_URL"),
+                    "missing-URL error must mention AAASM_DATABASE_URL, got: {msg}"
+                );
+            }
+            Err(other) => panic!("expected ConnectionFailed, got {other:?}"),
+            Ok(_) => panic!("expected error when database_url is None"),
+        }
+    }
+}

--- a/aa-gateway/src/storage/postgres.rs
+++ b/aa-gateway/src/storage/postgres.rs
@@ -1,0 +1,50 @@
+//! PostgreSQL-backed implementation of [`StorageBackend`](super::backend::StorageBackend).
+//!
+//! Only the constructor lands in this sub-task (Epic 18 S-C #1). The
+//! [`StorageBackend`](super::backend::StorageBackend) trait impl is built up
+//! incrementally across sub-tasks #2 – #7.
+
+use std::time::Duration;
+
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+
+use super::error::{StorageError, StorageResult};
+use super::postgres_config::PostgresConfig;
+
+/// PostgreSQL-backed control-plane storage.
+///
+/// Created via [`PostgresBackend::connect`]. The trait surface (audit /
+/// registry / policy / metrics / lifecycle methods) is filled in by the
+/// later Epic-18 S-C sub-tasks.
+pub struct PostgresBackend {
+    // Wired into trait method implementations in E18 S-C #2 onward.
+    #[allow(dead_code)]
+    pool: PgPool,
+}
+
+impl PostgresBackend {
+    /// Open a connection pool against `config`.
+    ///
+    /// Returns [`StorageError::ConnectionFailed`] when `database_url` is
+    /// unset or the pool cannot be opened. The error message explicitly
+    /// names `AAASM_DATABASE_URL` so operators see the missing-env path
+    /// without having to dig through stack traces.
+    pub async fn connect(config: &PostgresConfig) -> StorageResult<Self> {
+        let database_url = config.database_url.as_deref().ok_or_else(|| {
+            StorageError::ConnectionFailed(
+                "AAASM_DATABASE_URL is not set and storage.postgres.database_url is not configured".into(),
+            )
+        })?;
+
+        let pool = PgPoolOptions::new()
+            .max_connections(config.max_connections)
+            .min_connections(config.min_connections)
+            .acquire_timeout(Duration::from_secs(config.connect_timeout_secs))
+            .connect(database_url)
+            .await
+            .map_err(|e| StorageError::ConnectionFailed(e.to_string()))?;
+
+        Ok(Self { pool })
+    }
+}

--- a/aa-gateway/src/storage/postgres_config.rs
+++ b/aa-gateway/src/storage/postgres_config.rs
@@ -32,3 +32,17 @@ impl Default for PostgresConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_match_spec() {
+        let cfg = PostgresConfig::default();
+        assert_eq!(cfg.database_url, None);
+        assert_eq!(cfg.max_connections, 20);
+        assert_eq!(cfg.min_connections, 2);
+        assert_eq!(cfg.connect_timeout_secs, 10);
+    }
+}

--- a/aa-gateway/src/storage/postgres_config.rs
+++ b/aa-gateway/src/storage/postgres_config.rs
@@ -1,0 +1,34 @@
+//! Connection settings consumed by [`PostgresBackend::connect`](super::postgres::PostgresBackend::connect).
+//!
+//! Lives inside `aa-gateway::storage` so the PostgreSQL backend can be wired
+//! end-to-end before Epic 18 S-H lands the unified [`StorageConfig`]. Once
+//! S-H ships, the canonical type moves to `aa-core::config` and this module
+//! is expected to re-export it.
+
+/// PostgreSQL connection settings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PostgresConfig {
+    /// Database URL (e.g. `postgres://user:pass@host:5432/db`).
+    ///
+    /// `None` means the operator did not provide one; [`PostgresBackend::connect`]
+    /// surfaces a [`StorageError::ConnectionFailed`] mentioning
+    /// `AAASM_DATABASE_URL` so the missing-config path is obvious.
+    pub database_url: Option<String>,
+    /// Upper bound on connection-pool size.
+    pub max_connections: u32,
+    /// Minimum number of warm connections kept in the pool.
+    pub min_connections: u32,
+    /// Seconds before `acquire` from the pool times out.
+    pub connect_timeout_secs: u64,
+}
+
+impl Default for PostgresConfig {
+    fn default() -> Self {
+        Self {
+            database_url: None,
+            max_connections: 20,
+            min_connections: 2,
+            connect_timeout_secs: 10,
+        }
+    }
+}


### PR DESCRIPTION
## Description

E18 S-C sub-task #1 — foundational scaffolding for the PostgreSQL `StorageBackend` implementation. Adds `PostgresConfig`, the `PostgresBackend` struct, and a `connect()` constructor that opens an `sqlx::PgPool`. No `StorageBackend` trait impl yet — those land sub-tasks #2 – #7.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

## Related Issues

- Related Jira ticket: AAASM-1719 (sub-task of AAASM-1585, Epic AAASM-1569)
- Related GitHub issues: n/a

## Commits

| # | Subject |
|---|---------|
| 1 | 🔧 (deps): Enable sqlx postgres and chrono features for aa-gateway |
| 2 | 🔧 (deps): Sync Cargo.lock for sqlx postgres + chrono features |
| 3 | ✨ (storage): Add PostgresConfig with spec defaults |
| 4 | ✨ (storage): Add PostgresBackend scaffold with connect() |
| 5 | ♻️ (storage): Re-export PostgresBackend and PostgresConfig |
| 6 | ✅ (storage): Test PostgresBackend::connect rejects missing URL |
| 7 | ✅ (storage): Test PostgresConfig defaults match spec values |

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required

Local verification:

\`\`\`
cargo nextest run -p aa-gateway storage::
  PASS storage::postgres_config::tests::defaults_match_spec
  PASS storage::postgres::tests::connect_rejects_missing_database_url
  2 tests run: 2 passed, 829 skipped

cargo clippy -p aa-gateway --all-targets --all-features -- -D warnings   # clean
cargo fmt --all -- --check                                                # clean
cargo doc -p aa-gateway --no-deps                                         # clean
\`\`\`

The full `cargo nextest run -p aa-gateway` flagged `policy_latency_test::sustained_load_p99_under_5ms` (p99 183 ms vs 15 ms target), but the test passes in isolation and is unrelated to this storage scaffold — known to be machine-load sensitive (see the existing latency-test coverage-rule stash on master).

## Checklist

- [x] Code follows project style guidelines (\`cargo fmt\`, \`cargo clippy\`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing — pending CI run on this PR
- [x] Commits are small and follow the Gitmoji convention

## Acceptance for this sub-task

- [x] \`cargo build -p aa-gateway\` green.
- [x] \`PostgresBackend::connect(None)\` returns a clear error mentioning \`AAASM_DATABASE_URL\`.
- [x] No \`sqlx::postgres::*\` imports leak outside the \`storage/\` module.

## Next sub-task

AAASM-1724 (E18 S-C #2) — initial PostgreSQL schema migration + \`migrate()\` implementation — branches off \`master\` after this PR merges.