### PR TITLE
[AAASM-1744] ✨ (aa-gateway/storage): Add RetentionConfig + to_policy() + validation

### DIFF
--- a/aa-gateway/src/storage/mod.rs
+++ b/aa-gateway/src/storage/mod.rs
@@ -30,6 +30,7 @@ pub mod health;
 pub mod metric;
 pub mod policy;
 pub mod retention;
+pub mod retention_config;
 
 pub use agent::{AgentFilter, AgentRecord, TeamId};
 pub use audit::{AuditEvent, AuditFilter};
@@ -39,3 +40,4 @@ pub use health::{HealthStatus, RowCounts, StorageHealth};
 pub use metric::{Metric, MetricPoint, MetricQuery};
 pub use policy::{PolicyDocument, PolicyMeta, PolicyVersion};
 pub use retention::{ColdAction, RetentionPolicy, RetentionStats};
+pub use retention_config::RetentionConfig;

--- a/aa-gateway/src/storage/mod.rs
+++ b/aa-gateway/src/storage/mod.rs
@@ -40,4 +40,4 @@ pub use health::{HealthStatus, RowCounts, StorageHealth};
 pub use metric::{Metric, MetricPoint, MetricQuery};
 pub use policy::{PolicyDocument, PolicyMeta, PolicyVersion};
 pub use retention::{ColdAction, RetentionPolicy, RetentionStats};
-pub use retention_config::RetentionConfig;
+pub use retention_config::{RetentionConfig, RetentionConfigError};

--- a/aa-gateway/src/storage/retention_config.rs
+++ b/aa-gateway/src/storage/retention_config.rs
@@ -1,6 +1,6 @@
 //! Runtime configuration for the retention background task.
 
-use super::retention::ColdAction;
+use super::retention::{ColdAction, RetentionPolicy};
 
 /// Operator-configurable retention engine settings parsed from the
 /// `storage.retention` section of the gateway YAML (Story S-H wires the
@@ -21,6 +21,20 @@ pub struct RetentionConfig {
     pub archive_url: Option<String>,
     /// When true, log the work that would be performed without taking action.
     pub dry_run: bool,
+}
+
+impl RetentionConfig {
+    /// Build the [`RetentionPolicy`] descriptor the backend's
+    /// `apply_retention` expects.
+    pub fn to_policy(&self) -> RetentionPolicy {
+        RetentionPolicy {
+            hot_days: self.hot_days,
+            warm_days: self.warm_days,
+            cold_action: self.cold_action,
+            archive_url: self.archive_url.clone(),
+            dry_run: self.dry_run,
+        }
+    }
 }
 
 impl Default for RetentionConfig {

--- a/aa-gateway/src/storage/retention_config.rs
+++ b/aa-gateway/src/storage/retention_config.rs
@@ -2,6 +2,14 @@
 
 use super::retention::{ColdAction, RetentionPolicy};
 
+/// Reasons a [`RetentionConfig`] can be invalid at startup time.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum RetentionConfigError {
+    /// `cold_action == Archive` was set but no `archive_url` was provided.
+    #[error("cold_action=archive requires archive_url to be set")]
+    MissingArchiveUrl,
+}
+
 /// Operator-configurable retention engine settings parsed from the
 /// `storage.retention` section of the gateway YAML (Story S-H wires the
 /// YAML parser; S-F owns the type itself).

--- a/aa-gateway/src/storage/retention_config.rs
+++ b/aa-gateway/src/storage/retention_config.rs
@@ -32,6 +32,20 @@ pub struct RetentionConfig {
 }
 
 impl RetentionConfig {
+    /// Reject configurations that are internally inconsistent at startup
+    /// (fail-fast preferred over a silent surprise at the first cron tick).
+    ///
+    /// # Errors
+    ///
+    /// - [`RetentionConfigError::MissingArchiveUrl`] when `cold_action`
+    ///   is [`ColdAction::Archive`] but `archive_url` is `None`.
+    pub fn validate(&self) -> Result<(), RetentionConfigError> {
+        if self.cold_action == ColdAction::Archive && self.archive_url.is_none() {
+            return Err(RetentionConfigError::MissingArchiveUrl);
+        }
+        Ok(())
+    }
+
     /// Build the [`RetentionPolicy`] descriptor the backend's
     /// `apply_retention` expects.
     pub fn to_policy(&self) -> RetentionPolicy {

--- a/aa-gateway/src/storage/retention_config.rs
+++ b/aa-gateway/src/storage/retention_config.rs
@@ -73,3 +73,19 @@ impl Default for RetentionConfig {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_uses_compliance_friendly_30_90_drop_3am() {
+        let cfg = RetentionConfig::default();
+        assert_eq!(cfg.schedule, "0 3 * * *");
+        assert_eq!(cfg.hot_days, 30);
+        assert_eq!(cfg.warm_days, 90);
+        assert_eq!(cfg.cold_action, ColdAction::Drop);
+        assert_eq!(cfg.archive_url, None);
+        assert!(!cfg.dry_run);
+    }
+}

--- a/aa-gateway/src/storage/retention_config.rs
+++ b/aa-gateway/src/storage/retention_config.rs
@@ -1,0 +1,24 @@
+//! Runtime configuration for the retention background task.
+
+use super::retention::ColdAction;
+
+/// Operator-configurable retention engine settings parsed from the
+/// `storage.retention` section of the gateway YAML (Story S-H wires the
+/// YAML parser; S-F owns the type itself).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetentionConfig {
+    /// Cron schedule (UTC) on which the background task fires.
+    pub schedule: String,
+    /// Days a row stays indexed and queryable in the hot tier.
+    pub hot_days: u32,
+    /// Days a row stays in the warm tier (compressed when supported)
+    /// before the cold action runs.
+    pub warm_days: u32,
+    /// Action applied to rows older than `warm_days`.
+    pub cold_action: ColdAction,
+    /// Archive destination (e.g. `s3://bucket/path`) — required when
+    /// `cold_action == ColdAction::Archive`.
+    pub archive_url: Option<String>,
+    /// When true, log the work that would be performed without taking action.
+    pub dry_run: bool,
+}

--- a/aa-gateway/src/storage/retention_config.rs
+++ b/aa-gateway/src/storage/retention_config.rs
@@ -22,3 +22,18 @@ pub struct RetentionConfig {
     /// When true, log the work that would be performed without taking action.
     pub dry_run: bool,
 }
+
+impl Default for RetentionConfig {
+    /// Compliance-friendly defaults: hot=30d, warm=90d, cold=Drop,
+    /// schedule="0 3 * * *" (3am UTC daily), dry_run=false.
+    fn default() -> Self {
+        Self {
+            schedule: "0 3 * * *".to_string(),
+            hot_days: 30,
+            warm_days: 90,
+            cold_action: ColdAction::Drop,
+            archive_url: None,
+            dry_run: false,
+        }
+    }
+}

--- a/aa-gateway/src/storage/retention_config.rs
+++ b/aa-gateway/src/storage/retention_config.rs
@@ -88,4 +88,22 @@ mod tests {
         assert_eq!(cfg.archive_url, None);
         assert!(!cfg.dry_run);
     }
+
+    #[test]
+    fn to_policy_forwards_all_runtime_fields() {
+        let cfg = RetentionConfig {
+            schedule: "0 4 * * *".to_string(),
+            hot_days: 7,
+            warm_days: 30,
+            cold_action: ColdAction::Archive,
+            archive_url: Some("s3://bucket/aasm/".to_string()),
+            dry_run: true,
+        };
+        let policy = cfg.to_policy();
+        assert_eq!(policy.hot_days, 7);
+        assert_eq!(policy.warm_days, 30);
+        assert_eq!(policy.cold_action, ColdAction::Archive);
+        assert_eq!(policy.archive_url.as_deref(), Some("s3://bucket/aasm/"));
+        assert!(policy.dry_run);
+    }
 }

--- a/aa-gateway/src/storage/retention_config.rs
+++ b/aa-gateway/src/storage/retention_config.rs
@@ -90,6 +90,31 @@ mod tests {
     }
 
     #[test]
+    fn validate_accepts_default_config() {
+        assert!(RetentionConfig::default().validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_archive_action_without_url() {
+        let cfg = RetentionConfig {
+            cold_action: ColdAction::Archive,
+            archive_url: None,
+            ..RetentionConfig::default()
+        };
+        assert_eq!(cfg.validate(), Err(RetentionConfigError::MissingArchiveUrl));
+    }
+
+    #[test]
+    fn validate_accepts_archive_action_with_url() {
+        let cfg = RetentionConfig {
+            cold_action: ColdAction::Archive,
+            archive_url: Some("s3://example/path/".to_string()),
+            ..RetentionConfig::default()
+        };
+        assert!(cfg.validate().is_ok());
+    }
+
+    #[test]
     fn to_policy_forwards_all_runtime_fields() {
         let cfg = RetentionConfig {
             schedule: "0 4 * * *".to_string(),


### PR DESCRIPTION
## Description

Adds `RetentionConfig` — the runtime configuration backing the upcoming retention background task — together with its compliance-friendly `Default`, the `to_policy()` conversion into the action-descriptor `RetentionPolicy`, fail-fast `validate()`, and unit tests.

This is **Impl-1 of 4** under Story AAASM-1588 (E18 S-F: Retention engine). Subsequent PRs land the engine itself (`run_once`, cron-driven `start`) and the `aasm admin run-retention` CLI; see Subtasks AAASM-1745 / AAASM-1746 / AAASM-1747. Verification is AAASM-1748.

Files:

- new: `aa-gateway/src/storage/retention_config.rs`
- updated: `aa-gateway/src/storage/mod.rs` (re-exports)

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-1744 (impl subtask)
- Parent Story: AAASM-1588 (E18 S-F)
- Epic: AAASM-1569 (Epic 18)
- Related GitHub issues: —

## Testing

- [x] Unit tests added / updated — 5 new tests in `storage::retention_config::tests`
- [ ] Integration tests added / updated
- [x] Manual testing performed — `cargo test -p aa-gateway --lib storage::retention_config` green
- [ ] No tests required (explain why)

Test coverage:

- `default_uses_compliance_friendly_30_90_drop_3am` — pins `Default` values (hot=30, warm=90, cold=Drop, schedule=`0 3 * * *`, dry_run=false)
- `to_policy_forwards_all_runtime_fields` — every field on a non-default `RetentionConfig` is copied into `RetentionPolicy`
- `validate_accepts_default_config` — defaults pass `validate()`
- `validate_rejects_archive_action_without_url` — `cold_action=Archive` with `archive_url=None` returns `MissingArchiveUrl`
- `validate_accepts_archive_action_with_url` — `cold_action=Archive` with `archive_url=Some(...)` passes

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed — module-level + per-field doc comments
- [ ] All CI checks passing — pending CI run
- [x] Commits are small and follow the Gitmoji convention — 8 single-concern commits