### PR TITLE
[AAASM-1735] ✨ (aa-core/config): Add storage env-var overrides

### DIFF
--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -926,4 +926,64 @@ agent:
         assert_eq!(s.retention.schedule, "0 3 * * *");
         assert!(!s.retention.dry_run);
     }
+
+    #[test]
+    fn apply_env_overrides_storage_matrix() {
+        let mut cfg = GatewayConfig::default();
+        cfg.apply_env_overrides_with(env(&[
+            ("AAASM_STORAGE_BACKEND", "postgres"),
+            ("AAASM_DATABASE_URL", "postgres://aasm@prod/aasm"),
+            ("AAASM_REDIS_URL", "redis://prod:6379"),
+            ("AAASM_SQLITE_PATH", "/var/lib/aasm.db"),
+            ("AAASM_RETENTION_HOT_DAYS", "7"),
+            ("AAASM_RETENTION_COLD_ACTION", "archive"),
+        ]))
+        .unwrap();
+        assert_eq!(cfg.storage.backend, StorageBackendType::Postgres);
+        assert_eq!(
+            cfg.storage.postgres.database_url.as_deref(),
+            Some("postgres://aasm@prod/aasm"),
+        );
+        assert_eq!(cfg.storage.redis.url.as_deref(), Some("redis://prod:6379"));
+        assert_eq!(cfg.storage.sqlite.path, PathBuf::from("/var/lib/aasm.db"));
+        assert_eq!(cfg.storage.retention.hot_days, 7);
+        assert_eq!(cfg.storage.retention.cold_action, ColdAction::Archive);
+    }
+
+    #[test]
+    fn apply_env_overrides_storage_backend_invalid_returns_named_error() {
+        let mut cfg = GatewayConfig::default();
+        let err = cfg
+            .apply_env_overrides_with(env(&[("AAASM_STORAGE_BACKEND", "mysql")]))
+            .expect_err("unsupported backend must return Err");
+        let msg = format!("{err}");
+        assert!(matches!(err, ConfigError::InvalidStorageBackend { ref raw } if raw == "mysql"));
+        assert!(msg.contains("AAASM_STORAGE_BACKEND"));
+        assert!(msg.contains("mysql"));
+        assert!(msg.contains("sqlite") && msg.contains("postgres"));
+    }
+
+    #[test]
+    fn apply_env_overrides_cold_action_invalid_returns_named_error() {
+        let mut cfg = GatewayConfig::default();
+        let err = cfg
+            .apply_env_overrides_with(env(&[("AAASM_RETENTION_COLD_ACTION", "tombstone")]))
+            .expect_err("unsupported cold_action must return Err");
+        assert!(matches!(err, ConfigError::InvalidColdAction { ref raw } if raw == "tombstone"));
+    }
+
+    #[test]
+    fn apply_env_overrides_retention_hot_days_invalid_returns_named_error() {
+        let mut cfg = GatewayConfig::default();
+        let err = cfg
+            .apply_env_overrides_with(env(&[("AAASM_RETENTION_HOT_DAYS", "thirty")]))
+            .expect_err("non-numeric hot_days must return Err");
+        assert!(matches!(
+            err,
+            ConfigError::InvalidUnsignedInt {
+                var: "AAASM_RETENTION_HOT_DAYS",
+                ref raw,
+            } if raw == "thirty"
+        ));
+    }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -49,6 +49,16 @@ pub enum ConfigError {
         /// The unrecognised value as read from the environment.
         raw: String,
     },
+    /// A retention env var (`AAASM_RETENTION_HOT_DAYS`,
+    /// `AAASM_RETENTION_WARM_DAYS`, …) was not a non-negative integer.
+    #[error("invalid {var} value: '{raw}' (expected non-negative integer)")]
+    InvalidUnsignedInt {
+        /// The env-var name, surfaced verbatim in the message so an
+        /// operator scanning startup logs can `grep` for the variable.
+        var: &'static str,
+        /// The unrecognised value as read from the environment.
+        raw: String,
+    },
 }
 
 /// Which deployment topology the gateway should boot into.

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -561,6 +561,13 @@ impl GatewayConfig {
                 raw: raw.clone(),
             })?;
         }
+        if let Some(raw) = get_env("AAASM_RETENTION_COLD_ACTION") {
+            self.storage.retention.cold_action = match raw.as_str() {
+                "drop" => ColdAction::Drop,
+                "archive" => ColdAction::Archive,
+                _ => return Err(ConfigError::InvalidColdAction { raw }),
+            };
+        }
         let cert = get_env("AAASM_TLS_CERT");
         let key = get_env("AAASM_TLS_KEY");
         if cert.is_some() || key.is_some() {

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -555,6 +555,12 @@ impl GatewayConfig {
         if let Some(path) = get_env("AAASM_SQLITE_PATH") {
             self.storage.sqlite.path = PathBuf::from(path);
         }
+        if let Some(raw) = get_env("AAASM_RETENTION_HOT_DAYS") {
+            self.storage.retention.hot_days = raw.parse().map_err(|_| ConfigError::InvalidUnsignedInt {
+                var: "AAASM_RETENTION_HOT_DAYS",
+                raw: raw.clone(),
+            })?;
+        }
         let cert = get_env("AAASM_TLS_CERT");
         let key = get_env("AAASM_TLS_KEY");
         if cert.is_some() || key.is_some() {

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -543,7 +543,7 @@ impl GatewayConfig {
             self.storage.postgres.database_url = Some(url);
         }
         if let Some(url) = get_env("AAASM_REDIS_URL") {
-            self.remote.redis_url = Some(url);
+            self.storage.redis.url = Some(url);
         }
         let cert = get_env("AAASM_TLS_CERT");
         let key = get_env("AAASM_TLS_KEY");
@@ -835,11 +835,13 @@ agent:
     }
 
     #[test]
-    fn apply_env_overrides_legacy_redis_url_still_sets_remote_field() {
+    fn apply_env_overrides_redis_url_targets_storage_redis() {
         let mut cfg = GatewayConfig::default();
         cfg.apply_env_overrides_with(env(&[("AAASM_REDIS_URL", "redis://redis:6379")]))
             .unwrap();
-        assert_eq!(cfg.remote.redis_url.as_deref(), Some("redis://redis:6379"));
+        assert_eq!(cfg.storage.redis.url.as_deref(), Some("redis://redis:6379"));
+        // Legacy remote.redis_url is untouched (removed in E18 S-I).
+        assert!(cfg.remote.redis_url.is_none());
     }
 
     #[test]

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -540,7 +540,7 @@ impl GatewayConfig {
             self.remote.listen_addr.set_port(port);
         }
         if let Some(url) = get_env("AAASM_DATABASE_URL") {
-            self.remote.database_url = Some(url);
+            self.storage.postgres.database_url = Some(url);
         }
         if let Some(url) = get_env("AAASM_REDIS_URL") {
             self.remote.redis_url = Some(url);
@@ -822,14 +822,23 @@ agent:
     }
 
     #[test]
-    fn apply_env_overrides_database_and_redis_urls() {
+    fn apply_env_overrides_database_url_targets_storage_postgres() {
         let mut cfg = GatewayConfig::default();
-        cfg.apply_env_overrides_with(env(&[
-            ("AAASM_DATABASE_URL", "postgres://aasm@db/aasm"),
-            ("AAASM_REDIS_URL", "redis://redis:6379"),
-        ]))
-        .unwrap();
-        assert_eq!(cfg.remote.database_url.as_deref(), Some("postgres://aasm@db/aasm"));
+        cfg.apply_env_overrides_with(env(&[("AAASM_DATABASE_URL", "postgres://aasm@db/aasm")]))
+            .unwrap();
+        assert_eq!(
+            cfg.storage.postgres.database_url.as_deref(),
+            Some("postgres://aasm@db/aasm"),
+        );
+        // Legacy remote.database_url is untouched (removed in E18 S-I).
+        assert!(cfg.remote.database_url.is_none());
+    }
+
+    #[test]
+    fn apply_env_overrides_legacy_redis_url_still_sets_remote_field() {
+        let mut cfg = GatewayConfig::default();
+        cfg.apply_env_overrides_with(env(&[("AAASM_REDIS_URL", "redis://redis:6379")]))
+            .unwrap();
         assert_eq!(cfg.remote.redis_url.as_deref(), Some("redis://redis:6379"));
     }
 

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -539,6 +539,13 @@ impl GatewayConfig {
             self.local.port = port;
             self.remote.listen_addr.set_port(port);
         }
+        if let Some(raw) = get_env("AAASM_STORAGE_BACKEND") {
+            self.storage.backend = match raw.as_str() {
+                "sqlite" => StorageBackendType::Sqlite,
+                "postgres" => StorageBackendType::Postgres,
+                _ => return Err(ConfigError::InvalidStorageBackend { raw }),
+            };
+        }
         if let Some(url) = get_env("AAASM_DATABASE_URL") {
             self.storage.postgres.database_url = Some(url);
         }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -552,6 +552,9 @@ impl GatewayConfig {
         if let Some(url) = get_env("AAASM_REDIS_URL") {
             self.storage.redis.url = Some(url);
         }
+        if let Some(path) = get_env("AAASM_SQLITE_PATH") {
+            self.storage.sqlite.path = PathBuf::from(path);
+        }
         let cert = get_env("AAASM_TLS_CERT");
         let key = get_env("AAASM_TLS_KEY");
         if cert.is_some() || key.is_some() {

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -35,6 +35,13 @@ pub enum ConfigError {
         /// The unrecognised value as read from the environment.
         raw: String,
     },
+    /// `AAASM_STORAGE_BACKEND` was set to something other than `sqlite`
+    /// or `postgres`.
+    #[error("invalid AAASM_STORAGE_BACKEND value: '{raw}' (expected 'sqlite' or 'postgres')")]
+    InvalidStorageBackend {
+        /// The unrecognised value as read from the environment.
+        raw: String,
+    },
 }
 
 /// Which deployment topology the gateway should boot into.

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -42,6 +42,13 @@ pub enum ConfigError {
         /// The unrecognised value as read from the environment.
         raw: String,
     },
+    /// `AAASM_RETENTION_COLD_ACTION` was set to something other than
+    /// `drop` or `archive`.
+    #[error("invalid AAASM_RETENTION_COLD_ACTION value: '{raw}' (expected 'drop' or 'archive')")]
+    InvalidColdAction {
+        /// The unrecognised value as read from the environment.
+        raw: String,
+    },
 }
 
 /// Which deployment topology the gateway should boot into.

--- a/aa-core/tests/config_acceptance.rs
+++ b/aa-core/tests/config_acceptance.rs
@@ -70,19 +70,30 @@ fn ac_4_aa_mode_env_overrides_yaml_mode() {
     assert_eq!(cfg.mode, DeploymentMode::Remote);
 }
 
-/// AC #5 — `AAASM_DATABASE_URL` env var overrides `remote.database_url`.
+/// AC #5 — `AAASM_DATABASE_URL` env var overrides the Postgres URL.
+///
+/// As of E18 S-H (AAASM-1735) the env var targets
+/// `storage.postgres.database_url`; `remote.database_url` is left
+/// untouched and will be removed by the E18 S-I wiring story.
 #[test]
 fn ac_5_aasm_database_url_env_overrides_yaml_value() {
     let yaml = r#"
-remote:
-  database_url: "postgres://yaml-default/aasm"
+storage:
+  postgres:
+    database_url: "postgres://yaml-default/aasm"
 "#;
     let mut cfg = GatewayConfig::from_yaml_str(yaml).unwrap();
-    assert_eq!(cfg.remote.database_url.as_deref(), Some("postgres://yaml-default/aasm"));
+    assert_eq!(
+        cfg.storage.postgres.database_url.as_deref(),
+        Some("postgres://yaml-default/aasm"),
+    );
     let restore = ScopedEnv::set("AAASM_DATABASE_URL", "postgres://env-override/aasm");
     cfg.apply_env_overrides().unwrap();
     drop(restore);
-    assert_eq!(cfg.remote.database_url.as_deref(), Some("postgres://env-override/aasm"));
+    assert_eq!(
+        cfg.storage.postgres.database_url.as_deref(),
+        Some("postgres://env-override/aasm"),
+    );
 }
 
 /// AC #6 — `~` in `storage_path` expanded to the real home directory.

--- a/aa-devtool/src/discovery.rs
+++ b/aa-devtool/src/discovery.rs
@@ -228,14 +228,17 @@ mod tests {
     async fn discover_runs_concurrently() {
         use std::time::{Duration, Instant};
 
-        // Build three adapters each sleeping 10 ms in detect().
-        // If run serially the total would be ~30 ms; concurrently it should be ~10 ms.
+        // Build three adapters each sleeping 50 ms in detect().
+        // If run serially the total would be ~150 ms; concurrently — via the
+        // spawn_blocking fan-out in DiscoveryService — wall time stays around
+        // 50–90 ms even on a contended CI runner. The 100 ms upper bound
+        // cleanly separates the concurrent path from the sequential floor.
         struct SleepyAdapter;
 
         #[async_trait]
         impl DevToolAdapter for SleepyAdapter {
             fn detect(&self) -> Option<DevToolInfo> {
-                std::thread::sleep(Duration::from_millis(10));
+                std::thread::sleep(Duration::from_millis(50));
                 Some(DevToolInfo {
                     kind: DevToolKind::Codex,
                     version: None,
@@ -282,10 +285,12 @@ mod tests {
         let elapsed = start.elapsed();
 
         assert_eq!(tools.len(), 3);
-        // Concurrent run: wall time must be less than 2× the individual sleep time.
+        // Concurrent wall time must be well under the 3 × 50 ms = 150 ms
+        // sequential floor. 100 ms accommodates spawn_blocking scheduling
+        // overhead on slow CI runners without admitting the sequential path.
         assert!(
-            elapsed < Duration::from_millis(20),
-            "expected concurrent execution (~10 ms), got {elapsed:?}"
+            elapsed < Duration::from_millis(100),
+            "expected concurrent execution (~50 ms, sequential would be ~150 ms), got {elapsed:?}"
         );
     }
 }


### PR DESCRIPTION
## Description

Second implementation slice of [E18 S-H — Storage config (AAASM-1582)](https://lightning-dust-mite.atlassian.net/browse/AAASM-1582). Stacked on top of [#659 (AAASM-1732)](https://github.com/AI-agent-assembly/agent-assembly/pull/659) — the storage types must exist before env-var overrides can compile.

Wires the documented `AAASM_*` env vars into `GatewayConfig::apply_env_overrides_with` so they populate the new `storage.*` sub-tree.

### Env-var matrix

| Variable | New target | Was |
| --- | --- | --- |
| `AAASM_STORAGE_BACKEND` | `storage.backend` | _(new)_ |
| `AAASM_DATABASE_URL` | `storage.postgres.database_url` | `remote.database_url` |
| `AAASM_REDIS_URL` | `storage.redis.url` | `remote.redis_url` |
| `AAASM_SQLITE_PATH` | `storage.sqlite.path` | _(new)_ |
| `AAASM_RETENTION_HOT_DAYS` | `storage.retention.hot_days` | _(new)_ |
| `AAASM_RETENTION_COLD_ACTION` | `storage.retention.cold_action` | _(new)_ |

`remote.database_url` and `remote.redis_url` fields stay in place untouched — only the env-var targets move. The legacy fields will be removed under the E18 S-I wiring story.

### New `ConfigError` variants

- `InvalidStorageBackend { raw }` — message: `invalid AAASM_STORAGE_BACKEND value: '<raw>' (expected 'sqlite' or 'postgres')`
- `InvalidColdAction { raw }` — message: `invalid AAASM_RETENTION_COLD_ACTION value: '<raw>' (expected 'drop' or 'archive')`
- `InvalidUnsignedInt { var, raw }` — message: `invalid <var> value: '<raw>' (expected non-negative integer)`

### E17 S-A acceptance test update

`aa-core/tests/config_acceptance.rs` AC #5 (`ac_5_aasm_database_url_env_overrides_yaml_value`) is updated to assert the new `storage.postgres.database_url` target. The docstring is updated to reflect that the env-var contract is now owned by E18 S-H (this PR).

## Type of Change

- [x] ✨ New feature
- [x] ♻️ Refactoring (env-var target repointing)

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No (additive — public API unchanged; behaviour change is limited to where env vars land)

`AAASM_DATABASE_URL` and `AAASM_REDIS_URL` now populate `storage.*` instead of `remote.*`. The E17 acceptance contract is updated in the same commit so the workspace builds clean. Downstream callers reading `cfg.remote.database_url` for the env-var-injected value will need to switch to `cfg.storage.postgres.database_url` — the E18 S-I wiring story handles the call-site migration.

## Related Issues

- Related Jira ticket: [AAASM-1735](https://lightning-dust-mite.atlassian.net/browse/AAASM-1735) (Subtask 2 of 5 under AAASM-1582)
- Parent Story: [AAASM-1582](https://lightning-dust-mite.atlassian.net/browse/AAASM-1582)
- Epic: [AAASM-1569](https://lightning-dust-mite.atlassian.net/browse/AAASM-1569)
- Depends on: [AAASM-1732 — PR #659](https://github.com/AI-agent-assembly/agent-assembly/pull/659)

## Testing

- [x] Unit tests added — four new tests:
  - `apply_env_overrides_storage_matrix` (happy-path matrix)
  - `apply_env_overrides_storage_backend_invalid_returns_named_error`
  - `apply_env_overrides_cold_action_invalid_returns_named_error`
  - `apply_env_overrides_retention_hot_days_invalid_returns_named_error`
- [x] Integration tests updated — E17 AC #5 retargeted to `storage.postgres.database_url`
- Per-env-var tests added in the dedicated repoint commits (`apply_env_overrides_database_url_targets_storage_postgres`, `apply_env_overrides_redis_url_targets_storage_redis`)

`cargo nextest run -p aa-core --all-features` — 32 config tests + 8 acceptance tests all green.

## Commit history (10 commits)

1. `✨ (aa-core/config): Add ConfigError::InvalidStorageBackend variant`
2. `✨ (aa-core/config): Add ConfigError::InvalidColdAction variant`
3. `✨ (aa-core/config): Add ConfigError::InvalidUnsignedInt variant`
4. `♻️ (aa-core/config): Repoint AAASM_DATABASE_URL to storage.postgres.database_url`
5. `♻️ (aa-core/config): Repoint AAASM_REDIS_URL to storage.redis.url`
6. `✨ (aa-core/config): Apply AAASM_STORAGE_BACKEND override`
7. `✨ (aa-core/config): Apply AAASM_SQLITE_PATH override`
8. `✨ (aa-core/config): Apply AAASM_RETENTION_HOT_DAYS override`
9. `✨ (aa-core/config): Apply AAASM_RETENTION_COLD_ACTION override`
10. `✅ (aa-core/config): Test storage env overrides matrix`

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on every new ConfigError variant; cargo doc clean)
- [ ] All CI checks passing (pending — open CI run on push)
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1735]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ