### PR TITLE
[AAASM-1739] ✨ (aa-core/config): Add StorageConfig validation

### DIFF
--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -59,6 +59,10 @@ pub enum ConfigError {
         /// The unrecognised value as read from the environment.
         raw: String,
     },
+    /// `storage.retention.cold_action = archive` was selected but no
+    /// `archive_url` was supplied (in YAML or via env var).
+    #[error("archive_url is required when cold_action is archive")]
+    ArchiveUrlRequired,
 }
 
 /// Which deployment topology the gateway should boot into.

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -1052,4 +1052,31 @@ agent:
         cfg.storage.retention.archive_url = Some("s3://aasm-archive/".into());
         cfg.validate().expect("archive + url must validate");
     }
+
+    #[test]
+    fn validate_warm_days_must_be_greater_than_hot_days() {
+        let mut cfg = GatewayConfig::default();
+        cfg.storage.retention.hot_days = 60;
+        cfg.storage.retention.warm_days = 30; // < hot_days
+        let err = cfg.validate().expect_err("warm_days <= hot_days must fail");
+        assert!(matches!(
+            err,
+            ConfigError::WarmDaysNotGreaterThanHotDays { hot: 60, warm: 30 }
+        ));
+        assert_eq!(format!("{err}"), "warm_days (30) must be greater than hot_days (60)",);
+    }
+
+    #[test]
+    fn validate_warm_days_equal_to_hot_days_also_fails() {
+        let mut cfg = GatewayConfig::default();
+        cfg.storage.retention.hot_days = 30;
+        cfg.storage.retention.warm_days = 30; // == hot_days
+        let err = cfg
+            .validate()
+            .expect_err("warm_days == hot_days must fail (strict inequality)");
+        assert!(matches!(
+            err,
+            ConfigError::WarmDaysNotGreaterThanHotDays { hot: 30, warm: 30 }
+        ));
+    }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -1032,4 +1032,24 @@ agent:
             } if raw == "thirty"
         ));
     }
+
+    #[test]
+    fn validate_archive_without_url_fails_with_documented_message() {
+        let mut cfg = GatewayConfig::default();
+        cfg.storage.retention.cold_action = ColdAction::Archive;
+        cfg.storage.retention.archive_url = None;
+        let err = cfg
+            .validate()
+            .expect_err("cold_action = Archive without archive_url must fail");
+        assert!(matches!(err, ConfigError::ArchiveUrlRequired));
+        assert_eq!(format!("{err}"), "archive_url is required when cold_action is archive",);
+    }
+
+    #[test]
+    fn validate_archive_with_url_passes() {
+        let mut cfg = GatewayConfig::default();
+        cfg.storage.retention.cold_action = ColdAction::Archive;
+        cfg.storage.retention.archive_url = Some("s3://aasm-archive/".into());
+        cfg.validate().expect("archive + url must validate");
+    }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -599,6 +599,36 @@ impl GatewayConfig {
     }
 }
 
+impl GatewayConfig {
+    /// Validate the fully-loaded config — call this **after**
+    /// [`expand_paths`](Self::expand_paths) and
+    /// [`apply_env_overrides`](Self::apply_env_overrides) so values
+    /// coming in from env vars are included in the checks.
+    ///
+    /// Currently enforces two storage-retention invariants from
+    /// E18 S-H (AAASM-1582):
+    ///
+    /// * `storage.retention.cold_action = archive` requires
+    ///   `storage.retention.archive_url` to be set (in YAML or by
+    ///   env var) — returns [`ConfigError::ArchiveUrlRequired`].
+    /// * `storage.retention.warm_days` must be strictly greater than
+    ///   `storage.retention.hot_days` — returns
+    ///   [`ConfigError::WarmDaysNotGreaterThanHotDays`].
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        let r = &self.storage.retention;
+        if r.cold_action == ColdAction::Archive && r.archive_url.is_none() {
+            return Err(ConfigError::ArchiveUrlRequired);
+        }
+        if r.warm_days <= r.hot_days {
+            return Err(ConfigError::WarmDaysNotGreaterThanHotDays {
+                hot: r.hot_days,
+                warm: r.warm_days,
+            });
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -480,14 +480,17 @@ impl GatewayConfig {
     }
 
     /// One-shot loader for `aasm start` and the gateway bootstrap path:
-    /// read `~/.aasm/config.yaml`, expand `~` in path fields, then apply
-    /// the `AA_MODE` / `AAASM_*` env-var overrides.
+    /// read `~/.aasm/config.yaml`, expand `~` in path fields, apply the
+    /// `AA_MODE` / `AAASM_*` env-var overrides, and finally
+    /// [`validate`](Self::validate) the result.
     ///
-    /// Returns the same `ConfigError` variants as the underlying steps.
+    /// Returns the same `ConfigError` variants as the underlying steps,
+    /// plus the validation errors from E18 S-H (AAASM-1739).
     pub fn load() -> Result<Self, ConfigError> {
         let mut cfg = Self::load_default_path()?;
         cfg.expand_paths();
         cfg.apply_env_overrides()?;
+        cfg.validate()?;
         Ok(cfg)
     }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -63,6 +63,15 @@ pub enum ConfigError {
     /// `archive_url` was supplied (in YAML or via env var).
     #[error("archive_url is required when cold_action is archive")]
     ArchiveUrlRequired,
+    /// `storage.retention.warm_days` was less than or equal to
+    /// `hot_days` — the warm tier must extend past the hot tier.
+    #[error("warm_days ({warm}) must be greater than hot_days ({hot})")]
+    WarmDaysNotGreaterThanHotDays {
+        /// The configured `hot_days` value (for the operator-facing message).
+        hot: u32,
+        /// The configured `warm_days` value.
+        warm: u32,
+    },
 }
 
 /// Which deployment topology the gateway should boot into.


### PR DESCRIPTION
## Description

Third implementation slice of [E18 S-H — Storage config (AAASM-1582)](https://lightning-dust-mite.atlassian.net/browse/AAASM-1582). Stacked on [#663 (AAASM-1735)](https://github.com/AI-agent-assembly/agent-assembly/pull/663), which is itself on [#659 (AAASM-1732)](https://github.com/AI-agent-assembly/agent-assembly/pull/659).

Adds startup-time validation so misconfigurations fail fast with the operator-facing messages spelled out verbatim in the Story AC.

### New `ConfigError` variants

- `ArchiveUrlRequired` — message: `archive_url is required when cold_action is archive`
- `WarmDaysNotGreaterThanHotDays { hot, warm }` — message: `warm_days ({warm}) must be greater than hot_days ({hot})`

### New entry point

- `GatewayConfig::validate(&self) -> Result<(), ConfigError>` — pure-logic check exposed as a `pub` method.
- `load()` calls `validate()` after `expand_paths()` and `apply_env_overrides()`, so `aasm start` exits with the documented error before binding any sockets.
- `from_yaml_str` deliberately does **not** auto-validate — keeps the parse path pure for callers (tests, dashboard hot-reload preview) that want the raw structure.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No (additive — `validate()` is a new method; `load()` gains one extra failure mode that was previously a runtime crash)

## Related Issues

- Related Jira ticket: [AAASM-1739](https://lightning-dust-mite.atlassian.net/browse/AAASM-1739) (Subtask 3 of 5 under AAASM-1582)
- Parent Story: [AAASM-1582](https://lightning-dust-mite.atlassian.net/browse/AAASM-1582)
- Epic: [AAASM-1569](https://lightning-dust-mite.atlassian.net/browse/AAASM-1569)
- Depends on: [#663](https://github.com/AI-agent-assembly/agent-assembly/pull/663) → [#659](https://github.com/AI-agent-assembly/agent-assembly/pull/659)

## Testing

- [x] Unit tests added — four new tests covering both rules + edge cases:
  - `validate_archive_without_url_fails_with_documented_message` (asserts on the literal AC error string)
  - `validate_archive_with_url_passes`
  - `validate_warm_days_must_be_greater_than_hot_days`
  - `validate_warm_days_equal_to_hot_days_also_fails` (strict-inequality edge case)

`cargo nextest run -p aa-core --all-features` — **229 tests pass**.

## Commit history (6 commits)

1. `✨ (aa-core/config): Add ConfigError::ArchiveUrlRequired variant`
2. `✨ (aa-core/config): Add ConfigError::WarmDaysNotGreaterThanHotDays variant`
3. `✨ (aa-core/config): Add GatewayConfig::validate()`
4. `♻️ (aa-core/config): Call validate() from load()`
5. `✅ (aa-core/config): Test archive_url required when cold_action=archive`
6. `✅ (aa-core/config): Test warm_days must be greater than hot_days`

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on every new `ConfigError` variant + on `validate()` itself; `cargo doc --no-deps` clean)
- [ ] All CI checks passing (pending — open CI run on push)
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1739]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ