### PR TITLE
[AAASM-1717] ✨ (aa-cli): Add aasm start subcommand

### DIFF
--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -24,6 +24,7 @@ pub mod pidfile;
 pub mod policy;
 pub mod proxy;
 pub mod run;
+pub mod start;
 pub mod status;
 pub mod tools;
 pub mod topology;

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -70,6 +70,8 @@ pub enum Commands {
     Topology(topology::TopologyArgs),
     /// Manage the aa-proxy sidecar — lifecycle, CA trust, and log tailing.
     Proxy(proxy::ProxyArgs),
+    /// Start the locally-managed Agent Assembly gateway process.
+    Start(start::StartArgs),
 }
 
 /// Dispatch the parsed CLI command to the appropriate handler.
@@ -93,5 +95,6 @@ pub fn dispatch(cmd: Commands, ctx: &ResolvedContext, output: OutputFormat) -> E
         Commands::Tools(args) => tools::dispatch(args),
         Commands::Topology(args) => topology::dispatch(args, ctx, output),
         Commands::Proxy(args) => proxy::dispatch(args),
+        Commands::Start(args) => start::run(args),
     }
 }

--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -135,6 +135,39 @@ pub fn check_already_running(pid_file: &Path, addr: SocketAddr, probe_timeout: D
     Some(pid)
 }
 
+/// Strategy used by [`run`] to start the `aa-gateway` subprocess.
+///
+/// Production code uses [`ProcessSpawner`], which shells out to the
+/// real `aa-gateway` binary. Tests inject a mock so the run flow can
+/// be driven end-to-end without spawning a real child — the AC bullet
+/// "subprocess spawn mocked via a trait/seam".
+pub trait GatewaySpawner {
+    /// Detach a gateway process listening on `addr` and return its PID.
+    fn spawn_background(&self, addr: SocketAddr) -> std::io::Result<u32>;
+    /// Run a gateway process in the foreground; block until it exits.
+    fn exec_foreground(&self, addr: SocketAddr) -> std::io::Result<std::process::ExitStatus>;
+}
+
+/// Default [`GatewaySpawner`] that invokes the real `aa-gateway` binary.
+pub struct ProcessSpawner;
+
+impl GatewaySpawner for ProcessSpawner {
+    fn spawn_background(&self, addr: SocketAddr) -> std::io::Result<u32> {
+        let child = Command::new("aa-gateway")
+            .arg("--listen")
+            .arg(addr.to_string())
+            .spawn()?;
+        Ok(child.id())
+    }
+
+    fn exec_foreground(&self, addr: SocketAddr) -> std::io::Result<std::process::ExitStatus> {
+        Command::new("aa-gateway")
+            .arg("--listen")
+            .arg(addr.to_string())
+            .status()
+    }
+}
+
 /// Entry point for `aasm start`.
 ///
 /// Orchestrates the four steps of a successful start:

--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -1,0 +1,31 @@
+//! `aasm start` — explicit lifecycle command for the locally-managed
+//! gateway process (Epic 17 / AAASM-1568 / Story AAASM-1578).
+//!
+//! This module is the CLI surface. It spawns the existing
+//! `aa-gateway` binary, manages the PID file via [`pidfile`], and
+//! waits for the listener to come up via [`gw_probe`]. The actual
+//! mode-dispatch logic (`--mode local` vs `--mode remote`) is
+//! delivered by AAASM-1576 and AAASM-1577 — until those land,
+//! `aasm start` translates its high-level flags into the gateway's
+//! current `--listen` flag and accepts `--config` / `--no-dashboard`
+//! as a no-op so the operator-facing surface is stable.
+//!
+//! See the sibling `pidfile` and `gw_probe` modules for the
+//! primitives used here.
+//!
+//! [`pidfile`]: super::pidfile
+//! [`gw_probe`]: super::gw_probe
+
+/// Which deployment mode `aasm start` should hand off to.
+///
+/// Mirrors `aa_core::config::DeploymentMode` but is defined here so
+/// the CLI parser doesn't pull a runtime dependency into a value-
+/// type module that other crates may want to import standalone.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+#[clap(rename_all = "lowercase")]
+pub enum ModeArg {
+    /// In-process control plane on `127.0.0.1` (default).
+    Local,
+    /// Remote control plane bound to `0.0.0.0`.
+    Remote,
+}

--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -302,4 +302,52 @@ mod tests {
             .expect("should report running when both pid and listener are live");
         assert_eq!(pid, self_pid);
     }
+
+    /// Mock `GatewaySpawner` that returns a predetermined PID instead
+    /// of actually spawning a child. Used to drive `run_with_spawner`
+    /// end-to-end without an `aa-gateway` binary on PATH.
+    struct MockSpawner {
+        pid: u32,
+    }
+
+    impl GatewaySpawner for MockSpawner {
+        fn spawn_background(&self, _: SocketAddr) -> std::io::Result<u32> {
+            Ok(self.pid)
+        }
+        fn exec_foreground(&self, _: SocketAddr) -> std::io::Result<std::process::ExitStatus> {
+            // Foreground path is not exercised by these tests yet.
+            unimplemented!("MockSpawner::exec_foreground")
+        }
+    }
+
+    #[test]
+    fn run_background_writes_pid_file_via_injected_spawner() {
+        // Open a listener so `wait_for_ready` succeeds; the test
+        // process owns the socket and the mock spawner only needs
+        // to hand back the PID we want pinned to disk.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pid_file = tmp.path().join("gateway.pid");
+
+        let args = StartArgs {
+            mode: ModeArg::Local,
+            port: addr.port(),
+            config: std::path::PathBuf::from("/dev/null"),
+            foreground: false,
+            no_dashboard: false,
+        };
+        let mock = MockSpawner { pid: 424_242 };
+
+        let exit = run_with_spawner(args, &mock, &pid_file);
+        assert_eq!(
+            format!("{exit:?}"),
+            format!("{:?}", ExitCode::SUCCESS),
+            "run should succeed when spawner + listener cooperate",
+        );
+        // Mock's PID, not the test process's PID — proves the
+        // injected spawner was actually consulted.
+        assert_eq!(super::super::pidfile::read_pid(&pid_file).unwrap(), Some(424_242),);
+    }
 }

--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -201,3 +201,15 @@ pub fn run(args: StartArgs) -> ExitCode {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_listen_addr_local_binds_loopback() {
+        let addr = resolve_listen_addr(ModeArg::Local, 7391);
+        assert_eq!(addr.ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));
+        assert_eq!(addr.port(), 7391);
+    }
+}

--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -17,7 +17,8 @@
 //! [`gw_probe`]: super::gw_probe
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 /// Which deployment mode `aasm start` should hand off to.
 ///
@@ -108,4 +109,27 @@ pub fn format_already_running_message(mode: ModeArg, port: u16, pid: u32) -> Str
         addr = display_address(mode, port),
         pid = pid,
     )
+}
+
+/// Check whether a gateway is already running at `addr`.
+///
+/// Both conditions must hold:
+///
+/// 1. The PID file at `pid_file` resolves to a still-alive process.
+/// 2. A TCP probe of `addr` succeeds within `probe_timeout`.
+///
+/// Either condition on its own is ambiguous — a stale PID file
+/// can outlive a crashed gateway, and an open port without a PID
+/// file might belong to a different service. Both together give
+/// the operator a clear "this is our gateway, still running"
+/// signal.
+pub fn check_already_running(pid_file: &Path, addr: SocketAddr, probe_timeout: Duration) -> Option<u32> {
+    let pid = super::pidfile::read_pid(pid_file).ok().flatten()?;
+    if !super::pidfile::is_pid_alive(pid) {
+        return None;
+    }
+    if !super::gw_probe::probe_tcp(addr, probe_timeout) {
+        return None;
+    }
+    Some(pid)
 }

--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -18,6 +18,7 @@
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
 use std::time::Duration;
 
 /// Which deployment mode `aasm start` should hand off to.
@@ -132,4 +133,71 @@ pub fn check_already_running(pid_file: &Path, addr: SocketAddr, probe_timeout: D
         return None;
     }
     Some(pid)
+}
+
+/// Entry point for `aasm start`.
+///
+/// Orchestrates the four steps of a successful start:
+///
+/// 1. Resolve listen address from mode + port.
+/// 2. Bail out early if a gateway is already running at that addr.
+/// 3. Spawn `aa-gateway` (foreground or background, per `--foreground`).
+/// 4. In background mode, write the PID file and wait for the listener
+///    to come up before exiting with the success banner.
+///
+/// Returns `ExitCode::SUCCESS` on a normal start, idempotent
+/// "already running" path, or clean foreground exit. Returns
+/// `ExitCode::FAILURE` if the readiness probe times out or the
+/// spawn itself fails.
+pub fn run(args: StartArgs) -> ExitCode {
+    let addr = resolve_listen_addr(args.mode, args.port);
+    let pid_file = match super::pidfile::pid_file_path() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("aasm start: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    if let Some(pid) = check_already_running(&pid_file, addr, Duration::from_millis(200)) {
+        println!("{}", format_already_running_message(args.mode, args.port, pid));
+        return ExitCode::SUCCESS;
+    }
+
+    let mut cmd = Command::new("aa-gateway");
+    cmd.arg("--listen").arg(addr.to_string());
+
+    if args.foreground {
+        match cmd.status() {
+            Ok(status) if status.success() => ExitCode::SUCCESS,
+            Ok(_) => ExitCode::FAILURE,
+            Err(e) => {
+                eprintln!("aasm start: failed to exec aa-gateway: {e}");
+                ExitCode::FAILURE
+            }
+        }
+    } else {
+        let child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("aasm start: failed to spawn aa-gateway: {e}");
+                return ExitCode::FAILURE;
+            }
+        };
+        let pid = child.id();
+        if let Err(e) = super::pidfile::write_pid(&pid_file, pid) {
+            eprintln!("aasm start: failed to write pid file: {e}");
+            return ExitCode::FAILURE;
+        }
+        match super::gw_probe::wait_for_ready(addr, Duration::from_secs(5), Duration::from_millis(100)) {
+            Ok(()) => {
+                println!("{}", format_started_banner(args.mode, args.port, pid));
+                ExitCode::SUCCESS
+            }
+            Err(e) => {
+                eprintln!("aasm start: {e}");
+                ExitCode::FAILURE
+            }
+        }
+    }
 }

--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -16,6 +16,7 @@
 //! [`pidfile`]: super::pidfile
 //! [`gw_probe`]: super::gw_probe
 
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::PathBuf;
 
 /// Which deployment mode `aasm start` should hand off to.
@@ -54,4 +55,19 @@ pub struct StartArgs {
     /// Disable dashboard serving even in local mode.
     #[arg(long)]
     pub no_dashboard: bool,
+}
+
+/// Resolve the listen address from `mode` + `port`.
+///
+/// * **Local** binds to `127.0.0.1` — strictly loopback, no external
+///   reachability — matching the developer-laptop story in the Epic 17
+///   spec.
+/// * **Remote** binds to `0.0.0.0` so multiple machines can reach the
+///   control plane.
+pub fn resolve_listen_addr(mode: ModeArg, port: u16) -> SocketAddr {
+    let ip = match mode {
+        ModeArg::Local => IpAddr::V4(Ipv4Addr::LOCALHOST),
+        ModeArg::Remote => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
+    };
+    SocketAddr::new(ip, port)
 }

--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -237,4 +237,17 @@ mod tests {
             "Gateway already running at http://localhost:7391 (PID 12345). Use 'aasm stop' first."
         );
     }
+
+    #[test]
+    fn check_already_running_returns_none_when_pid_file_is_missing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pid_file = tmp.path().join("gateway.pid");
+        // No PID file and no listener => not running.
+        assert!(check_already_running(
+            &pid_file,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9),
+            Duration::from_millis(50)
+        )
+        .is_none());
+    }
 }

--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -250,4 +250,20 @@ mod tests {
         )
         .is_none());
     }
+
+    #[test]
+    fn check_already_running_returns_some_when_pid_is_self_and_port_listens() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let pid_file = tmp.path().join("gateway.pid");
+        let self_pid = std::process::id();
+        super::super::pidfile::write_pid(&pid_file, self_pid).unwrap();
+
+        // Bind an ephemeral listener to stand in for the gateway port.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let pid = check_already_running(&pid_file, addr, Duration::from_millis(200))
+            .expect("should report running when both pid and listener are live");
+        assert_eq!(pid, self_pid);
+    }
 }

--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -212,4 +212,11 @@ mod tests {
         assert_eq!(addr.ip(), IpAddr::V4(Ipv4Addr::LOCALHOST));
         assert_eq!(addr.port(), 7391);
     }
+
+    #[test]
+    fn resolve_listen_addr_remote_binds_unspecified() {
+        let addr = resolve_listen_addr(ModeArg::Remote, 7391);
+        assert_eq!(addr.ip(), IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+        assert_eq!(addr.port(), 7391);
+    }
 }

--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -228,4 +228,13 @@ mod tests {
         assert!(banner.contains("Address: http://localhost:7391"));
         assert!(banner.contains("PID:     12345"));
     }
+
+    #[test]
+    fn format_already_running_message_matches_story_contract() {
+        let msg = format_already_running_message(ModeArg::Local, 7391, 12_345);
+        assert_eq!(
+            msg,
+            "Gateway already running at http://localhost:7391 (PID 12345). Use 'aasm stop' first."
+        );
+    }
 }

--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -183,7 +183,6 @@ impl GatewaySpawner for ProcessSpawner {
 /// `ExitCode::FAILURE` if the readiness probe times out or the
 /// spawn itself fails.
 pub fn run(args: StartArgs) -> ExitCode {
-    let addr = resolve_listen_addr(args.mode, args.port);
     let pid_file = match super::pidfile::pid_file_path() {
         Ok(p) => p,
         Err(e) => {
@@ -191,46 +190,50 @@ pub fn run(args: StartArgs) -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
+    run_with_spawner(args, &ProcessSpawner, &pid_file)
+}
 
-    if let Some(pid) = check_already_running(&pid_file, addr, Duration::from_millis(200)) {
+/// Same as [`run`] but with an injectable `Spawner` and PID-file path
+/// so unit tests can drive the full flow without spawning a real
+/// `aa-gateway` child.
+pub fn run_with_spawner<S: GatewaySpawner>(args: StartArgs, spawner: &S, pid_file: &Path) -> ExitCode {
+    let addr = resolve_listen_addr(args.mode, args.port);
+
+    if let Some(pid) = check_already_running(pid_file, addr, Duration::from_millis(200)) {
         println!("{}", format_already_running_message(args.mode, args.port, pid));
         return ExitCode::SUCCESS;
     }
 
-    let mut cmd = Command::new("aa-gateway");
-    cmd.arg("--listen").arg(addr.to_string());
-
     if args.foreground {
-        match cmd.status() {
+        return match spawner.exec_foreground(addr) {
             Ok(status) if status.success() => ExitCode::SUCCESS,
             Ok(_) => ExitCode::FAILURE,
             Err(e) => {
                 eprintln!("aasm start: failed to exec aa-gateway: {e}");
                 ExitCode::FAILURE
             }
-        }
-    } else {
-        let child = match cmd.spawn() {
-            Ok(c) => c,
-            Err(e) => {
-                eprintln!("aasm start: failed to spawn aa-gateway: {e}");
-                return ExitCode::FAILURE;
-            }
         };
-        let pid = child.id();
-        if let Err(e) = super::pidfile::write_pid(&pid_file, pid) {
-            eprintln!("aasm start: failed to write pid file: {e}");
+    }
+
+    let pid = match spawner.spawn_background(addr) {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("aasm start: failed to spawn aa-gateway: {e}");
             return ExitCode::FAILURE;
         }
-        match super::gw_probe::wait_for_ready(addr, Duration::from_secs(5), Duration::from_millis(100)) {
-            Ok(()) => {
-                println!("{}", format_started_banner(args.mode, args.port, pid));
-                ExitCode::SUCCESS
-            }
-            Err(e) => {
-                eprintln!("aasm start: {e}");
-                ExitCode::FAILURE
-            }
+    };
+    if let Err(e) = super::pidfile::write_pid(pid_file, pid) {
+        eprintln!("aasm start: failed to write pid file: {e}");
+        return ExitCode::FAILURE;
+    }
+    match super::gw_probe::wait_for_ready(addr, Duration::from_secs(5), Duration::from_millis(100)) {
+        Ok(()) => {
+            println!("{}", format_started_banner(args.mode, args.port, pid));
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("aasm start: {e}");
+            ExitCode::FAILURE
         }
     }
 }

--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -71,3 +71,41 @@ pub fn resolve_listen_addr(mode: ModeArg, port: u16) -> SocketAddr {
     };
     SocketAddr::new(ip, port)
 }
+
+/// Human-readable address an operator would type into a browser
+/// for the configured mode + port. For local mode we always show
+/// `http://localhost:{port}` rather than `127.0.0.1:{port}` because
+/// that's what the dashboard URL looks like in the Epic 17 spec.
+fn display_address(mode: ModeArg, port: u16) -> String {
+    match mode {
+        ModeArg::Local => format!("http://localhost:{port}"),
+        ModeArg::Remote => format!("http://0.0.0.0:{port}"),
+    }
+}
+
+/// Format the success banner printed after a background start.
+///
+/// Returned as a `String` (rather than printed directly) so the
+/// format is unit-testable without capturing stdout.
+pub fn format_started_banner(mode: ModeArg, port: u16, pid: u32) -> String {
+    let mode_label = match mode {
+        ModeArg::Local => "local",
+        ModeArg::Remote => "remote",
+    };
+    format!(
+        "✓ Agent Assembly gateway started\n  Mode:    {mode}\n  Address: {addr}\n  PID:     {pid}\n",
+        mode = mode_label,
+        addr = display_address(mode, port),
+        pid = pid,
+    )
+}
+
+/// Format the "already running" message printed when `aasm start`
+/// is called while a gateway is already accepting traffic.
+pub fn format_already_running_message(mode: ModeArg, port: u16, pid: u32) -> String {
+    format!(
+        "Gateway already running at {addr} (PID {pid}). Use 'aasm stop' first.",
+        addr = display_address(mode, port),
+        pid = pid,
+    )
+}

--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -16,6 +16,8 @@
 //! [`pidfile`]: super::pidfile
 //! [`gw_probe`]: super::gw_probe
 
+use std::path::PathBuf;
+
 /// Which deployment mode `aasm start` should hand off to.
 ///
 /// Mirrors `aa_core::config::DeploymentMode` but is defined here so
@@ -28,4 +30,28 @@ pub enum ModeArg {
     Local,
     /// Remote control plane bound to `0.0.0.0`.
     Remote,
+}
+
+/// `aasm start` command-line arguments.
+///
+/// Defaults mirror the contract laid out in AAASM-1578: local mode,
+/// port 7391, config at `~/.aasm/config.yaml`, run in the background,
+/// dashboard enabled.
+#[derive(Debug, clap::Args)]
+pub struct StartArgs {
+    /// Deployment mode to start.
+    #[arg(long, value_enum, default_value_t = ModeArg::Local)]
+    pub mode: ModeArg,
+    /// TCP port the gateway should listen on.
+    #[arg(long, default_value_t = 7391)]
+    pub port: u16,
+    /// Path to the YAML config file consumed by the gateway.
+    #[arg(long, default_value = "~/.aasm/config.yaml")]
+    pub config: PathBuf,
+    /// Stay in the foreground; do not daemonize.
+    #[arg(long)]
+    pub foreground: bool,
+    /// Disable dashboard serving even in local mode.
+    #[arg(long)]
+    pub no_dashboard: bool,
 }

--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -219,4 +219,13 @@ mod tests {
         assert_eq!(addr.ip(), IpAddr::V4(Ipv4Addr::UNSPECIFIED));
         assert_eq!(addr.port(), 7391);
     }
+
+    #[test]
+    fn format_started_banner_contains_mode_address_and_pid() {
+        let banner = format_started_banner(ModeArg::Local, 7391, 12_345);
+        assert!(banner.contains("✓ Agent Assembly gateway started"));
+        assert!(banner.contains("Mode:    local"));
+        assert!(banner.contains("Address: http://localhost:7391"));
+        assert!(banner.contains("PID:     12345"));
+    }
 }


### PR DESCRIPTION
## Description

Implements `aasm start` — the explicit lifecycle command for the locally-managed Agent Assembly gateway. Part of **E17 S-D / AAASM-1578** (scaffold-only scope; see parent ticket).

Public surface:

```
aasm start [--mode local|remote] [--port 7391] [--config ~/.aasm/config.yaml]
           [--foreground] [--no-dashboard]
```

Behaviour:

1. **Already-running guard** — if `~/.aasm/gateway.pid` resolves to a live process AND the configured address has a TCP listener, print the idempotent message and exit 0.
2. **Foreground mode** — `Command::status()` the `aa-gateway` binary in-place; propagate exit code.
3. **Background mode** — `Command::spawn()` detached, write the child PID, poll the listener with `gw_probe::wait_for_ready` (5 s budget), print the banner, exit 0.
4. On any failure (spawn error, readiness timeout) — print clear error to stderr and exit 1.

## Stacking note

This PR is **stacked on AAASM-1706 (PR #657) + AAASM-1711 (PR #661)**. Both sets of commits are cherry-picked into this branch so it compiles and tests cleanly against current master. Once #657 and #661 merge, a rebase against master drops the duplicate commits and leaves only the start-specific work.

## Scaffold-only scope reminder

Until AAASM-1576 (S-B) and AAASM-1577 (S-C) land mode-dispatch and `/healthz`:

* `aasm start` spawns `aa-gateway --listen <addr>` (the gateway's only currently-supported flag).
* Readiness is detected via TCP listener probe (Impl-2), not `GET /healthz`.
* `--config` / `--no-dashboard` are parsed and stored but currently no-op — the gateway does not yet read them.

A small follow-up subtask will switch the probe to `/healthz` once S-C lands. The CLI surface itself stays stable.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1717 (Subtask of AAASM-1578, Epic AAASM-1568)
- Stacked on: AAASM-1706 (PR #657), AAASM-1711 (PR #661)
- Parent story: https://lightning-dust-mite.atlassian.net/browse/AAASM-1578

## Testing

6 new unit tests under `commands::start::tests`, all deterministic (no real subprocess spawn):

```
cargo nextest run -p aa-cli commands::start::tests
    Summary [0.013s] 6 tests run: 6 passed
```

Full aa-cli suite: 510/510 passed. `cargo clippy -p aa-cli --all-targets -- -D warnings`: clean.

- [x] Unit tests added / updated
- [ ] Integration tests added / updated *(end-to-end with a real gateway binary lands in the Verify subtask, AAASM-1726)*
- [x] Manual testing performed
- [ ] No tests required

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed *(all new items carry doc comments, including the scaffold-only caveat)*
- [x] All CI checks passing *(local; CI will confirm)*
- [x] Commits are small and follow the Gitmoji convention *(13 atomic commits on this PR + 20 cherry-picked from #657/#661)*