### PR TITLE
[AAASM-1703] ✨ (aa-gateway): Add policy cache key derivation helper

### DIFF
--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -139,5 +139,11 @@ mod tests {
                 "hex segment must be ascii hex: {hex:?}"
             );
         }
+
+        #[test]
+        fn invalidation_pattern_matches_every_version() {
+            assert_eq!(policy_invalidation_pattern("default"), "policy:default:*");
+            assert_eq!(policy_invalidation_pattern("legacy"), "policy:legacy:*");
+        }
     }
 }

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -109,5 +109,13 @@ mod tests {
             let v2 = policy_cache_key("default", b"version-2-body");
             assert_ne!(v1, v2, "content-addressing must shift the key");
         }
+
+        #[test]
+        fn name_namespaces_the_key() {
+            let same_bytes: &[u8] = b"shared-bytes";
+            let a = policy_cache_key("default", same_bytes);
+            let b = policy_cache_key("legacy", same_bytes);
+            assert_ne!(a, b, "different names must produce different keys");
+        }
     }
 }

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -41,6 +41,28 @@ impl Default for RedisConfig {
     }
 }
 
+/// Number of hex characters retained from the SHA-256 digest when building a
+/// cache key. Sixty-four bits of entropy is overkill for collision avoidance
+/// across a single policy namespace and keeps the Redis key short.
+const POLICY_CACHE_HASH_HEX_LEN: usize = 16;
+
+/// Build the Redis key used to store a cached policy document.
+///
+/// The key is content-addressed: changing a single byte of `bytes` changes
+/// the hash slice and therefore the key, so a stale Redis entry can never
+/// serve an outdated policy document. The format is `policy:{name}:{hex}`,
+/// where `hex` is the first 16 hex characters of `sha2::Sha256(bytes)`.
+pub fn policy_cache_key(name: &str, bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(bytes);
+    let mut hex = String::with_capacity(POLICY_CACHE_HASH_HEX_LEN);
+    for byte in digest.iter().take(POLICY_CACHE_HASH_HEX_LEN / 2) {
+        use std::fmt::Write as _;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    format!("policy:{name}:{hex}")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -92,4 +92,15 @@ mod tests {
             assert_eq!(cfg.max_connections, 10);
         }
     }
+
+    mod key {
+        use super::*;
+
+        #[test]
+        fn same_inputs_yield_identical_key() {
+            let a = policy_cache_key("default", b"version-1-body");
+            let b = policy_cache_key("default", b"version-1-body");
+            assert_eq!(a, b);
+        }
+    }
 }

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -63,6 +63,16 @@ pub fn policy_cache_key(name: &str, bytes: &[u8]) -> String {
     format!("policy:{name}:{hex}")
 }
 
+/// Build the Redis `SCAN MATCH` pattern that targets every cached version of
+/// `name`, regardless of content hash.
+///
+/// Used by `PolicyCache::invalidate` (Epic-18 S-G sub-task 4) to evict every
+/// historical entry for a policy in one sweep — there is no need to know the
+/// previous content hash.
+pub fn policy_invalidation_pattern(name: &str) -> String {
+    format!("policy:{name}:*")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -102,5 +102,12 @@ mod tests {
             let b = policy_cache_key("default", b"version-1-body");
             assert_eq!(a, b);
         }
+
+        #[test]
+        fn changing_bytes_changes_key() {
+            let v1 = policy_cache_key("default", b"version-1-body");
+            let v2 = policy_cache_key("default", b"version-2-body");
+            assert_ne!(v1, v2, "content-addressing must shift the key");
+        }
     }
 }

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -117,5 +117,17 @@ mod tests {
             let b = policy_cache_key("legacy", same_bytes);
             assert_ne!(a, b, "different names must produce different keys");
         }
+
+        #[test]
+        fn hash_slice_is_sixteen_hex_chars() {
+            let key = policy_cache_key("default", b"any-body");
+            // Format is `policy:{name}:{hex}` — slice after the last colon.
+            let hex = key.rsplit(':').next().expect("key has a hex segment");
+            assert_eq!(hex.len(), 16, "expected 16 hex chars, got {hex:?}");
+            assert!(
+                hex.bytes().all(|b| b.is_ascii_hexdigit()),
+                "hex segment must be ascii hex: {hex:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Description

Second slice of Epic-18 Story S-G (`AAASM-1589`). Adds the deterministic, content-addressed cache key helpers that the Redis `PolicyCache` will use in later sub-tasks.

* `policy_cache_key(name, bytes)` → `policy:{name}:{hex}` where `hex` is the first 16 hex chars of `Sha256(bytes)`. Content-addressing guarantees that a single byte change in the policy body shifts the key, so stale Redis entries can never shadow a fresh update.
* `policy_invalidation_pattern(name)` → `policy:{name}:*`. Used by `PolicyCache::invalidate` in sub-task 4 to evict every historical version of a policy with one `SCAN MATCH`.

Stacked on top of #660 (AAASM-1699 — the cache module skeleton + `RedisConfig`). When #660 merges first the diff against master collapses to just this sub-task's changes.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1703 (sub-task) / AAASM-1589 (parent Story) / AAASM-1569 (Epic 18)

## Testing

- [x] Unit tests added (`storage::cache::tests::key::*` — five tests)
- [x] `cargo nextest run -p aa-gateway storage::cache::tests` — **7/7 passed** locally (carries 2 inherited from #660)
- [x] `cargo fmt --check` + `cargo clippy --all-targets --all-features -- -D warnings` green on every commit via lefthook pre-commit.
- [x] `cargo doc --workspace --no-deps` green via lefthook pre-push.

## Commits in this PR (7 new)

1. `✨ (aa-gateway/storage): Add policy_cache_key sha256-based helper`
2. `✅ Test policy_cache_key is deterministic`
3. `✅ Test policy_cache_key shifts on content change`
4. `✅ Test policy_cache_key namespaces by name`
5. `✅ Test policy_cache_key truncates to 16 hex chars`
6. `✨ Add policy_invalidation_pattern helper`
7. `✅ Test policy_invalidation_pattern formatting`

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing (will turn green after CI run)
- [x] Commits are small and follow the Gitmoji convention