### PR TITLE
[AAASM-1705] ✨ (aa-gateway): Mount /healthz in local_mode router via routes::healthz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tonic",
+ "tower",
  "tracing",
  "tracing-subscriber",
  "utoipa",

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -53,6 +53,7 @@ proptest     = "1"
 tempfile     = "3"
 tokio-stream = "0.1"
 insta        = "1"
+tower        = { version = "0.5", features = ["util"] }
 
 [[bin]]
 name = "aa-gateway"

--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -90,3 +90,51 @@ pub(crate) fn router() -> Router {
     let state = HealthzState::new("local", "sqlite");
     Router::new().route("/healthz", get(healthz)).layer(Extension(state))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use axum::body::{to_bytes, Body};
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    /// AAASM-1576 AC #4, driven through the router built by `router()`:
+    /// `GET /healthz` returns 200 with `application/json` content-type and
+    /// a body whose `mode`, `storage`, and `version` fields carry the
+    /// local-mode labels. The `uptime_secs` field is asserted to be
+    /// present (guards against a regression that would drop the field
+    /// from `HealthzBody`).
+    #[tokio::test]
+    async fn router_serves_healthz_with_local_mode_json() {
+        let app = router();
+        let request = Request::builder()
+            .uri("/healthz")
+            .body(Body::empty())
+            .expect("build request");
+
+        let response = app.oneshot(request).await.expect("router.oneshot");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let ctype = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default();
+        assert!(
+            ctype.starts_with("application/json"),
+            "expected application/json, got {ctype}"
+        );
+
+        let bytes = to_bytes(response.into_body(), 8 * 1024).await.expect("read body");
+        let body: serde_json::Value = serde_json::from_slice(&bytes).expect("parse json");
+
+        assert_eq!(body["mode"], "local", "mode label");
+        assert_eq!(body["storage"], "sqlite", "storage label");
+        assert_eq!(body["version"], env!("CARGO_PKG_VERSION"), "crate version");
+        assert!(
+            body["uptime_secs"].is_u64(),
+            "uptime_secs must be present and a u64; got {body}",
+        );
+    }
+}

--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -10,7 +10,6 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
-use serde::{Deserialize, Serialize};
 use tokio::sync::oneshot;
 
 /// Handle returned by `start_local()` once the local control plane is up.
@@ -30,27 +29,6 @@ pub struct LocalGatewayHandle {
     /// One-shot channel that signals the Axum server task to begin
     /// graceful shutdown. Hooked up by AAASM-1728's signal handler.
     pub(crate) shutdown_tx: oneshot::Sender<()>,
-}
-
-/// JSON payload returned by `GET /healthz` in local mode.
-///
-/// Documented response shape from AAASM-1576 AC #4:
-///
-/// ```json
-/// {"mode":"local","storage":"sqlite","version":"0.0.1"}
-/// ```
-///
-/// `Deserialize` is derived so the pre-flight probe in AAASM-1715 can
-/// re-parse the response and reject other servers that happen to be
-/// listening on the same port but speak a different protocol.
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct HealthzResponse {
-    /// Always `"local"` when produced by this module.
-    pub mode: String,
-    /// Storage backend label — `"sqlite"` for local mode.
-    pub storage: String,
-    /// Gateway binary version (set from `CARGO_PKG_VERSION` at compile time).
-    pub version: String,
 }
 
 /// Errors that can occur while booting the local-mode control plane.
@@ -93,39 +71,4 @@ pub enum LocalModeError {
     /// Installing the SIGTERM / SIGINT handler failed (Unix only).
     #[error("shutdown signal handler installation failed: {0}")]
     Signal(#[source] std::io::Error),
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// AAASM-1576 AC #4: `/healthz` must return exactly
-    /// `{"mode":"local","storage":"sqlite","version":"<v>"}` —
-    /// no extra fields, no extra whitespace, lowercase values,
-    /// and the keys in the documented order.
-    #[test]
-    fn healthz_response_serialises_to_documented_shape() {
-        let resp = HealthzResponse {
-            mode: "local".to_string(),
-            storage: "sqlite".to_string(),
-            version: "0.0.1".to_string(),
-        };
-        let json = serde_json::to_string(&resp).expect("serde_json::to_string");
-        assert_eq!(json, r#"{"mode":"local","storage":"sqlite","version":"0.0.1"}"#);
-    }
-
-    /// The probe path in AAASM-1715 re-parses `/healthz` responses as
-    /// `HealthzResponse`; round-tripping the documented shape must
-    /// recover the exact same struct.
-    #[test]
-    fn healthz_response_round_trips_through_serde() {
-        let original = HealthzResponse {
-            mode: "local".to_string(),
-            storage: "sqlite".to_string(),
-            version: env!("CARGO_PKG_VERSION").to_string(),
-        };
-        let json = serde_json::to_string(&original).expect("serialise");
-        let parsed: HealthzResponse = serde_json::from_str(&json).expect("deserialise");
-        assert_eq!(parsed, original);
-    }
 }

--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -10,7 +10,10 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
 
+use axum::{routing::get, Extension, Router};
 use tokio::sync::oneshot;
+
+use crate::routes::healthz::{healthz, HealthzState};
 
 /// Handle returned by `start_local()` once the local control plane is up.
 ///
@@ -71,4 +74,19 @@ pub enum LocalModeError {
     /// Installing the SIGTERM / SIGINT handler failed (Unix only).
     #[error("shutdown signal handler installation failed: {0}")]
     Signal(#[source] std::io::Error),
+}
+
+/// Build the local-mode Axum router skeleton.
+///
+/// Mounts only `/healthz` for now via [`crate::routes::healthz::healthz`];
+/// later sub-tasks (dashboard SPA in AAASM-1580, API routes wired by
+/// AAASM-1731) merge into this same router.
+///
+/// The `Extension(HealthzState::new("local", "sqlite"))` layer supplies
+/// the labels the shared `/healthz` handler reads, so the response body
+/// carries `mode: "local"` and `storage: "sqlite"` per AAASM-1576 AC #4.
+#[allow(dead_code)] // consumed by start_local() — AAASM-1725
+pub(crate) fn router() -> Router {
+    let state = HealthzState::new("local", "sqlite");
+    Router::new().route("/healthz", get(healthz)).layer(Extension(state))
 }


### PR DESCRIPTION
## Description

Sub-task 2 of [AAASM-1576](https://lightning-dust-mite.atlassian.net/browse/AAASM-1576) (E17 S-B — Local Dev Mode).

**Scope adjustment from original Sub-task plan:** between AAASM-1701 merging and this Sub-task starting, [PR #654](https://github.com/AI-agent-assembly/agent-assembly/pull/654) ([AAASM-1698](https://lightning-dust-mite.atlassian.net/browse/AAASM-1698), sibling of E17 S-C) merged `aa-gateway/src/routes/healthz.rs` — a `/healthz` handler whose `HealthzBody` is explicitly labelled the **stable wire contract** for both modes (load balancers, `aasm status`, dashboard all parse it). `HealthzBody { mode, version, storage, uptime_secs }` is a superset of the shape AAASM-1576 AC #4 asks for.

To avoid two competing healthz response types in the gateway, this PR:

1. **Drops** the `HealthzResponse` placeholder added in AAASM-1701 + its two tests — superseded.
2. **Composes** a local-mode `router()` that mounts the existing `routes::healthz::healthz` with `Extension(HealthzState::new("local", "sqlite"))`, so the shared handler reports the local-mode labels.
3. **Adds** a `tower::ServiceExt::oneshot` integration test that drives the router end-to-end (status, Content-Type, body shape).

Result: AAASM-1576 AC #4 is now satisfied via the single stable wire contract that the rest of the platform parses.

Delivered in four granular commits:

1. `♻️ (aa-gateway/local_mode): Drop HealthzResponse — superseded by routes::healthz::HealthzBody`
2. `✨ (aa-gateway/local_mode): Add router() builder mounting /healthz via routes::healthz`
3. `🔧 (aa-gateway): Add tower (util) dev-dependency for axum oneshot router tests`
4. `✅ (aa-gateway/local_mode): Test local router serves /healthz with local-mode JSON`

```text
$ cargo nextest run -p aa-gateway local_mode
        PASS local_mode::tests::router_serves_healthz_with_local_mode_json
     Summary 1 test run: 1 passed, 832 skipped
```

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

The dropped `HealthzResponse` was only introduced in AAASM-1701 and never exposed beyond the `local_mode` module — no external callers. Net public surface in `aa_gateway::local_mode`: `LocalGatewayHandle`, `LocalModeError`, plus the now-`pub(crate)` `router()` helper.

## Related Issues

- Related Jira ticket: [AAASM-1705](https://lightning-dust-mite.atlassian.net/browse/AAASM-1705) (this Sub-task)
- Parent Story: [AAASM-1576](https://lightning-dust-mite.atlassian.net/browse/AAASM-1576) (E17 S-B)
- Parent Epic: [AAASM-1568](https://lightning-dust-mite.atlassian.net/browse/AAASM-1568) (E17)
- Sibling reuse: [AAASM-1698](https://lightning-dust-mite.atlassian.net/browse/AAASM-1698) (`routes::healthz` source of truth)

## Testing

- [x] Unit tests added / updated — new `local_mode::tests::router_serves_healthz_with_local_mode_json` driving the router via `tower::ServiceExt::oneshot`.
- [ ] Integration tests added / updated — N/A (no separate `aa-integration-tests` change).
- [x] Manual testing performed — `cargo build -p aa-gateway`, `cargo clippy -p aa-gateway --all-targets -- -D warnings`, `cargo nextest run -p aa-gateway local_mode` all green locally.
- [ ] No tests required (explain why)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`) — lefthook fmt + clippy passed on every commit.
- [x] Self-review of the diff completed.
- [x] Documentation updated if behaviour changed — rustdoc on the new `router()` helper explains the `HealthzState` layering choice.
- [x] All CI checks passing — pending CI verification on this PR.
- [x] Commits are small and follow the Gitmoji convention — 4 commits, each scoped to one type/dep/test.

## Sub-task acceptance criteria (AAASM-1705, adjusted)

- [x] `GET /healthz` (via `tower::ServiceExt::oneshot`) returns 200 with `Content-Type: application/json`.
- [x] Response body carries `mode == "local"`, `storage == "sqlite"`, `version == CARGO_PKG_VERSION` (the three AAASM-1576 AC #4 fields). Also carries `uptime_secs` from the shared `HealthzBody` contract — guarded by the new test.
- [x] Handler is `async` and does **not** perform blocking I/O (`routes::healthz::healthz` is plain `async`).
- [x] `cargo nextest run -p aa-gateway local_mode` green.

The original Sub-task description said the body should be byte-exact `{"mode":"local","storage":"sqlite","version":"…"}`. Because we now reuse the shared `HealthzBody`, the body also includes `uptime_secs` (non-deterministic). The test asserts the three required fields by value and the additional field by presence/type — which is the right contract guard given the shared shape.

[AAASM-1576]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1698]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1705]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ