### PR TITLE
[AAASM-1740] ✨ (aa-core/config): Auto-select storage.backend by mode and expand ~ in sqlite.path

### DIFF
--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -1139,4 +1139,16 @@ agent:
             ConfigError::WarmDaysNotGreaterThanHotDays { hot: 30, warm: 30 }
         ));
     }
+
+    #[test]
+    fn resolve_storage_backend_defaults_to_sqlite_in_local_mode() {
+        // Default mode is already Local; backend_explicit stays false
+        // since it's only flipped via YAML peek or AAASM_STORAGE_BACKEND.
+        let mut cfg = GatewayConfig {
+            mode: DeploymentMode::Local,
+            ..GatewayConfig::default()
+        };
+        cfg.resolve_storage_backend();
+        assert_eq!(cfg.storage.backend, StorageBackendType::Sqlite);
+    }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -1151,4 +1151,29 @@ agent:
         cfg.resolve_storage_backend();
         assert_eq!(cfg.storage.backend, StorageBackendType::Sqlite);
     }
+
+    #[test]
+    fn resolve_storage_backend_defaults_to_postgres_in_remote_mode() {
+        let mut cfg = GatewayConfig {
+            mode: DeploymentMode::Remote,
+            ..GatewayConfig::default()
+        };
+        cfg.resolve_storage_backend();
+        assert_eq!(cfg.storage.backend, StorageBackendType::Postgres);
+    }
+
+    #[test]
+    fn resolve_storage_backend_respects_explicit_choice() {
+        // Operator pinned sqlite in remote mode (e.g. in-process test
+        // runner pointed at the remote API surface) — resolver must
+        // leave it alone.
+        let mut cfg = GatewayConfig {
+            mode: DeploymentMode::Remote,
+            ..GatewayConfig::default()
+        };
+        cfg.storage.backend = StorageBackendType::Sqlite;
+        cfg.storage.backend_explicit = true;
+        cfg.resolve_storage_backend();
+        assert_eq!(cfg.storage.backend, StorageBackendType::Sqlite);
+    }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -677,10 +677,11 @@ impl GatewayConfig {
     /// * `mode: Local` → `storage.backend = Sqlite`
     /// * `mode: Remote` → `storage.backend = Postgres`
     ///
-    /// No-op when [`StorageConfig::backend_explicit`] is `true` — an
-    /// operator's explicit choice always wins, including the odd-but-
-    /// valid `mode: remote` + `storage.backend: sqlite` combo (an
-    /// in-memory test runner pointed at the remote API surface).
+    /// No-op when the operator explicitly set `storage.backend` in
+    /// YAML or via `AAASM_STORAGE_BACKEND` — their choice always wins,
+    /// including the odd-but-valid `mode: remote` + `storage.backend:
+    /// sqlite` combo (an in-memory test runner pointed at the remote
+    /// API surface).
     pub fn resolve_storage_backend(&mut self) {
         if self.storage.backend_explicit {
             return;

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -1176,4 +1176,13 @@ agent:
         cfg.resolve_storage_backend();
         assert_eq!(cfg.storage.backend, StorageBackendType::Sqlite);
     }
+
+    #[test]
+    fn expand_paths_in_resolves_tilde_in_storage_sqlite_path() {
+        let mut cfg = GatewayConfig::default();
+        assert_eq!(cfg.storage.sqlite.path, PathBuf::from("~/.aasm/local.db"));
+        let fake_home = PathBuf::from("/srv/dev/bryant");
+        cfg.expand_paths_in(&fake_home);
+        assert_eq!(cfg.storage.sqlite.path, PathBuf::from("/srv/dev/bryant/.aasm/local.db"),);
+    }
 }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -509,6 +509,7 @@ impl GatewayConfig {
         let mut cfg = Self::load_default_path()?;
         cfg.expand_paths();
         cfg.apply_env_overrides()?;
+        cfg.resolve_storage_backend();
         cfg.validate()?;
         Ok(cfg)
     }

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -418,6 +418,17 @@ pub struct StorageConfig {
     pub redis: RedisConfig,
     /// Hot / warm / cold audit-event lifecycle policy.
     pub retention: RetentionConfig,
+    /// Internal marker — `true` iff `backend` was explicitly set in
+    /// YAML or via the `AAASM_STORAGE_BACKEND` env var. When `false`,
+    /// `GatewayConfig::resolve_storage_backend` infers the value from
+    /// the deployment mode (Local → Sqlite, Remote → Postgres).
+    ///
+    /// Marked `#[serde(skip)]` so it never appears in YAML and never
+    /// shows up in serialized output. Always `false` on
+    /// `Self::default()` and immediately after deserialization;
+    /// `from_yaml_str` patches it via a single-pass YAML peek.
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub(crate) backend_explicit: bool,
 }
 
 /// Top-level gateway configuration loaded at startup.
@@ -448,8 +459,16 @@ impl GatewayConfig {
     /// Missing fields fall back to their documented defaults thanks to
     /// the type-level `#[serde(default)]` attribute, so an empty
     /// document (`""` or `"{}"`) deserialises to `Self::default()`.
+    ///
+    /// In addition to the structural parse, this peeks at the raw YAML
+    /// to determine whether `storage.backend` was set explicitly — used
+    /// by `resolve_storage_backend` (AAASM-1740) to know when to infer
+    /// the value from the deployment mode rather than overwrite an
+    /// operator-supplied choice.
     pub fn from_yaml_str(yaml: &str) -> Result<Self, ConfigError> {
-        Ok(serde_yaml::from_str(yaml)?)
+        let mut cfg: Self = serde_yaml::from_str(yaml)?;
+        cfg.storage.backend_explicit = yaml_has_storage_backend(yaml);
+        Ok(cfg)
     }
 
     /// Load a `GatewayConfig` from a YAML file on disk.
@@ -524,6 +543,20 @@ fn expand_tilde(path: &std::path::Path, home: &std::path::Path) -> PathBuf {
         Ok(stripped) => home.join(stripped),
         Err(_) => path.to_path_buf(),
     }
+}
+
+/// Peek at raw YAML to determine whether `storage.backend` was set
+/// explicitly. Returns `false` for invalid YAML — `from_yaml_str` will
+/// surface that as a `ConfigError::Yaml` further up the call chain.
+#[cfg(feature = "serde")]
+fn yaml_has_storage_backend(yaml: &str) -> bool {
+    let Ok(value) = serde_yaml::from_str::<serde_yaml::Value>(yaml) else {
+        return false;
+    };
+    value
+        .get("storage")
+        .and_then(|storage| storage.get("backend"))
+        .is_some()
 }
 
 impl GatewayConfig {

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -532,6 +532,7 @@ impl GatewayConfig {
     /// directory — used by tests so the assertion is independent of `$HOME`.
     pub(crate) fn expand_paths_in(&mut self, home: &std::path::Path) {
         self.local.storage_path = expand_tilde(&self.local.storage_path, home);
+        self.storage.sqlite.path = expand_tilde(&self.storage.sqlite.path, home);
         if let Some(tls) = &mut self.remote.tls {
             tls.cert_file = expand_tilde(&tls.cert_file, home);
             tls.key_file = expand_tilde(&tls.key_file, home);

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -594,6 +594,9 @@ impl GatewayConfig {
                 "postgres" => StorageBackendType::Postgres,
                 _ => return Err(ConfigError::InvalidStorageBackend { raw }),
             };
+            // An explicit env-var choice counts as "set by operator" —
+            // resolve_storage_backend must not overwrite it.
+            self.storage.backend_explicit = true;
         }
         if let Some(url) = get_env("AAASM_DATABASE_URL") {
             self.storage.postgres.database_url = Some(url);
@@ -662,6 +665,28 @@ impl GatewayConfig {
             });
         }
         Ok(())
+    }
+}
+
+impl GatewayConfig {
+    /// Infer `storage.backend` from `mode` when it was not explicitly
+    /// set in YAML or via the `AAASM_STORAGE_BACKEND` env var.
+    ///
+    /// * `mode: Local` → `storage.backend = Sqlite`
+    /// * `mode: Remote` → `storage.backend = Postgres`
+    ///
+    /// No-op when [`StorageConfig::backend_explicit`] is `true` — an
+    /// operator's explicit choice always wins, including the odd-but-
+    /// valid `mode: remote` + `storage.backend: sqlite` combo (an
+    /// in-memory test runner pointed at the remote API surface).
+    pub fn resolve_storage_backend(&mut self) {
+        if self.storage.backend_explicit {
+            return;
+        }
+        self.storage.backend = match self.mode {
+            DeploymentMode::Local => StorageBackendType::Sqlite,
+            DeploymentMode::Remote => StorageBackendType::Postgres,
+        };
     }
 }
 


### PR DESCRIPTION
## Description

Fourth implementation slice of [E18 S-H — Storage config (AAASM-1582)](https://lightning-dust-mite.atlassian.net/browse/AAASM-1582). Stacked on [#666 (AAASM-1739)](https://github.com/AI-agent-assembly/agent-assembly/pull/666) → [#663 (AAASM-1735)](https://github.com/AI-agent-assembly/agent-assembly/pull/663) → [#659 (AAASM-1732)](https://github.com/AI-agent-assembly/agent-assembly/pull/659).

Closes out the last two AC bullets that the implementation Subtasks own:

### A. Auto-select `storage.backend` by deployment `mode`

When `storage.backend` is **not explicitly set** in YAML or via the `AAASM_STORAGE_BACKEND` env var:

- `mode: local` → `storage.backend: sqlite`
- `mode: remote` → `storage.backend: postgres`

Public API stays `pub backend: StorageBackendType` (non-optional). Explicitness is tracked via a `pub(crate) backend_explicit: bool` field with `#[serde(skip)]`, populated by:

- `from_yaml_str` — single-pass YAML peek (`yaml_has_storage_backend`) that checks whether the raw document contains `storage.backend`.
- `apply_env_overrides_with` — marks `true` when `AAASM_STORAGE_BACKEND` is present.

`GatewayConfig::resolve_storage_backend(&mut self)` is the public entry point. It's no-op when `backend_explicit = true`, so an operator's explicit `mode: remote` + `storage.backend: sqlite` is preserved (tested under `resolve_storage_backend_respects_explicit_choice`).

`load()` now runs: `expand_paths → apply_env_overrides → resolve_storage_backend → validate`.

### B. Expand `~` in `storage.sqlite.path`

Extends the existing `expand_paths_in()` with a single line — same `expand_tilde` helper as `local.storage_path` and `remote.tls.*`. Idempotent.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No (additive — new pub method, new internal field; `StorageConfig` PartialEq still works because `backend_explicit = false` for both `Default::default()` and empty YAML)

## Related Issues

- Related Jira ticket: [AAASM-1740](https://lightning-dust-mite.atlassian.net/browse/AAASM-1740) (Subtask 4 of 5 under AAASM-1582)
- Parent Story: [AAASM-1582](https://lightning-dust-mite.atlassian.net/browse/AAASM-1582)
- Epic: [AAASM-1569](https://lightning-dust-mite.atlassian.net/browse/AAASM-1569)
- Depends on: [#666](https://github.com/AI-agent-assembly/agent-assembly/pull/666) → [#663](https://github.com/AI-agent-assembly/agent-assembly/pull/663) → [#659](https://github.com/AI-agent-assembly/agent-assembly/pull/659)

## Testing

- [x] Unit tests added:
  - `resolve_storage_backend_defaults_to_sqlite_in_local_mode`
  - `resolve_storage_backend_defaults_to_postgres_in_remote_mode`
  - `resolve_storage_backend_respects_explicit_choice` (the explicit-set guard)
  - `expand_paths_in_resolves_tilde_in_storage_sqlite_path`

`cargo nextest run -p aa-core --all-features` — **233 tests pass**.

## Commit history (7 commits)

1. `✨ (aa-core/config): Mark whether storage.backend came from YAML`
2. `✨ (aa-core/config): Resolve storage backend from deployment mode`
3. `♻️ (aa-core/config): Call resolve_storage_backend from load()`
4. `♻️ (aa-core/config): Expand ~ in storage.sqlite.path`
5. `✅ (aa-core/config): Test backend defaults to sqlite in local mode`
6. `✅ (aa-core/config): Test backend defaults to postgres in remote mode`
7. `✅ (aa-core/config): Test ~ expansion in sqlite.path`

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on `resolve_storage_backend`, `backend_explicit`, `from_yaml_str`, `yaml_has_storage_backend`)
- [ ] All CI checks passing (pending — open CI run on push)
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1740]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ