### PR TITLE
[AAASM-1702] ✨ (aa-gateway): Add remote_mode::tls validator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rust_decimal",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -5219,6 +5220,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "notify",
  "parking_lot",
  "proptest",
+ "rcgen",
  "regex",
  "reqwest 0.12.28",
  "rust_decimal",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,6 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rust_decimal",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -5223,15 +5222,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,7 @@ dependencies = [
  "strsim",
  "tempfile",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "tracing-subscriber",
  "utoipa",
  "uuid",
+ "x509-parser",
 ]
 
 [[package]]

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -56,6 +56,7 @@ tempfile     = "3"
 tokio-stream = "0.1"
 insta        = "1"
 tower        = { version = "0.5", features = ["util"] }
+rcgen        = { version = "0.14", features = ["pem"] }
 
 [[bin]]
 name = "aa-gateway"

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -47,6 +47,7 @@ parking_lot  = "0.12"
 utoipa       = { version = "5", features = ["axum_extras"] }
 axum         = "0.8"
 rustls-pemfile = "2"
+x509-parser  = "0.18"
 
 [dev-dependencies]
 criterion    = { version = "0.8", features = ["async_tokio"] }

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -46,7 +46,6 @@ tokio-util   = "0.7"
 parking_lot  = "0.12"
 utoipa       = { version = "5", features = ["axum_extras"] }
 axum         = "0.8"
-rustls-pemfile = "2"
 x509-parser  = "0.18"
 
 [dev-dependencies]

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -57,6 +57,7 @@ tokio-stream = "0.1"
 insta        = "1"
 tower        = { version = "0.5", features = ["util"] }
 rcgen        = { version = "0.14", features = ["pem"] }
+time         = "0.3"
 
 [[bin]]
 name = "aa-gateway"

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -46,6 +46,7 @@ tokio-util   = "0.7"
 parking_lot  = "0.12"
 utoipa       = { version = "5", features = ["axum_extras"] }
 axum         = "0.8"
+rustls-pemfile = "2"
 
 [dev-dependencies]
 criterion    = { version = "0.8", features = ["async_tokio"] }

--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -19,6 +19,7 @@ pub mod message_router;
 pub mod ops;
 pub mod policy;
 pub mod registry;
+pub mod remote_mode;
 pub mod routes;
 pub mod server;
 pub mod service;

--- a/aa-gateway/src/remote_mode/mod.rs
+++ b/aa-gateway/src/remote_mode/mod.rs
@@ -1,0 +1,13 @@
+//! Remote Control-Plane mode runtime for `aa-gateway`.
+//!
+//! Bootstrap function and pre-flight checks invoked when `AA_MODE=remote`.
+//! See AAASM-1577 (E17 S-C) for the design rationale: the gateway starts
+//! as a multi-machine server binding `0.0.0.0:PORT` over plain HTTP or
+//! optional TLS, exposes `/healthz`, and drains on SIGTERM.
+//!
+//! Submodules:
+//!
+//! - [`tls`] — pre-flight cert / key validation (AAASM-1702 / ST-2)
+//! - `server` — listener bootstrap (AAASM-1709 / ST-3, lands next)
+
+pub mod tls;

--- a/aa-gateway/src/remote_mode/tls.rs
+++ b/aa-gateway/src/remote_mode/tls.rs
@@ -237,4 +237,16 @@ mod tests {
             other => panic!("expected KeyFileMissing, got {other:?}"),
         }
     }
+
+    #[test]
+    fn errors_when_cert_is_not_pem() {
+        let (_real_cert, key) = issue_cert_with_validity(-1, 365);
+        // Junk bytes that pass existence + read checks but fail PEM parse.
+        let junk = b"this is not a PEM-wrapped X.509 cert".to_vec();
+        let (_dir, cfg) = write_pair(&junk, &key);
+        match validate(&cfg).expect_err("expected error") {
+            TlsError::CertParse(_) => {}
+            other => panic!("expected CertParse, got {other:?}"),
+        }
+    }
 }

--- a/aa-gateway/src/remote_mode/tls.rs
+++ b/aa-gateway/src/remote_mode/tls.rs
@@ -135,3 +135,48 @@ pub enum TlsError {
     #[error("failed to parse TLS cert as PEM x509: {0}")]
     CertParse(String),
 }
+
+#[cfg(test)]
+mod tests {
+    use rcgen::{CertificateParams, KeyPair};
+    use tempfile::TempDir;
+    use time::{Duration as TimeDuration, OffsetDateTime};
+
+    use super::*;
+
+    /// Generate a self-signed cert with custom validity offsets (in days
+    /// from `now`). Returns the PEM bytes for cert and key.
+    fn issue_cert_with_validity(not_before_days: i64, not_after_days: i64) -> (Vec<u8>, Vec<u8>) {
+        let now = OffsetDateTime::now_utc();
+        let mut params = CertificateParams::new(vec!["test.example".to_string()]).expect("params");
+        params.not_before = now + TimeDuration::days(not_before_days);
+        params.not_after = now + TimeDuration::days(not_after_days);
+
+        let key_pair = KeyPair::generate().expect("key_pair");
+        let cert = params.self_signed(&key_pair).expect("self-signed");
+        (cert.pem().into_bytes(), key_pair.serialize_pem().into_bytes())
+    }
+
+    /// Write cert + key PEM bytes into a temp dir, returning a [`TlsConfig`]
+    /// pointing at the written paths. The `TempDir` is returned so the caller
+    /// can keep it alive for the duration of the test (Drop deletes the files).
+    fn write_pair(cert_pem: &[u8], key_pem: &[u8]) -> (TempDir, TlsConfig) {
+        let dir = TempDir::new().expect("tempdir");
+        let cert_path = dir.path().join("cert.pem");
+        let key_path = dir.path().join("key.pem");
+        fs::write(&cert_path, cert_pem).expect("write cert");
+        fs::write(&key_path, key_pem).expect("write key");
+        let cfg = TlsConfig {
+            cert_file: cert_path,
+            key_file: key_path,
+        };
+        (dir, cfg)
+    }
+
+    #[test]
+    fn returns_ok_for_fresh_year_long_cert() {
+        let (cert, key) = issue_cert_with_validity(-1, 365);
+        let (_dir, cfg) = write_pair(&cert, &key);
+        assert_eq!(validate(&cfg).expect("validate"), TlsValidation::Ok);
+    }
+}

--- a/aa-gateway/src/remote_mode/tls.rs
+++ b/aa-gateway/src/remote_mode/tls.rs
@@ -1,0 +1,3 @@
+//! Pre-flight TLS validation for Remote Control-Plane Mode.
+//!
+//! Contents are added in subsequent commits for AAASM-1702.

--- a/aa-gateway/src/remote_mode/tls.rs
+++ b/aa-gateway/src/remote_mode/tls.rs
@@ -9,6 +9,29 @@ use std::path::PathBuf;
 
 use thiserror::Error;
 
+/// Outcome of a successful [`validate`] call — the cert parsed, but
+/// classification distinguishes "fine" from soft warnings about its
+/// remaining lifetime.
+///
+/// The caller decides whether `ExpiringSoon` and `Expired` produce
+/// log lines or hard startup errors; this type only reports.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TlsValidation {
+    /// Cert parsed and is not within 30 days of expiry.
+    Ok,
+    /// Cert parsed but expires within 30 days. Operator should rotate.
+    ExpiringSoon {
+        /// Whole days remaining until `notAfter`.
+        days_until_expiry: i64,
+    },
+    /// Cert parsed but `notAfter` is already in the past. The gateway
+    /// can still start, but new TLS clients will reject the chain.
+    Expired {
+        /// Whole days since `notAfter`.
+        expired_days_ago: i64,
+    },
+}
+
 /// Hard failures that should stop gateway startup in remote-mode TLS.
 ///
 /// The variant carries enough context (paths, parse messages) for the

--- a/aa-gateway/src/remote_mode/tls.rs
+++ b/aa-gateway/src/remote_mode/tls.rs
@@ -1,3 +1,40 @@
 //! Pre-flight TLS validation for Remote Control-Plane Mode.
 //!
-//! Contents are added in subsequent commits for AAASM-1702.
+//! The gateway calls [`validate`] before binding the listener so any
+//! cert / key misconfiguration produces a fast, clearly-attributed
+//! startup error rather than a runtime TLS handshake failure that
+//! shows up only when the first client tries to connect.
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+/// Hard failures that should stop gateway startup in remote-mode TLS.
+///
+/// The variant carries enough context (paths, parse messages) for the
+/// startup log line to point an operator at exactly the file or field
+/// that needs fixing.
+#[derive(Debug, Error)]
+pub enum TlsError {
+    /// The configured `cert_file` path does not exist on disk.
+    #[error("TLS cert_file not found: {0}")]
+    CertFileMissing(PathBuf),
+
+    /// The configured `key_file` path does not exist on disk.
+    #[error("TLS key_file not found: {0}")]
+    KeyFileMissing(PathBuf),
+
+    /// I/O error reading cert or key file (e.g. permission denied).
+    #[error("failed to read TLS file {path}: {source}")]
+    Io {
+        /// File the gateway tried to read.
+        path: PathBuf,
+        /// Underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The cert file does not parse as PEM-encoded X.509.
+    #[error("failed to parse TLS cert as PEM x509: {0}")]
+    CertParse(String),
+}

--- a/aa-gateway/src/remote_mode/tls.rs
+++ b/aa-gateway/src/remote_mode/tls.rs
@@ -179,4 +179,23 @@ mod tests {
         let (_dir, cfg) = write_pair(&cert, &key);
         assert_eq!(validate(&cfg).expect("validate"), TlsValidation::Ok);
     }
+
+    #[test]
+    fn flags_expiring_soon_within_30_days() {
+        let (cert, key) = issue_cert_with_validity(-1, 10);
+        let (_dir, cfg) = write_pair(&cert, &key);
+        let result = validate(&cfg).expect("validate");
+        match result {
+            TlsValidation::ExpiringSoon { days_until_expiry } => {
+                // Allow a one-day slack on each side — UTC midnight rollover
+                // between cert issue and validate() could shift the bucket
+                // by one full day on a slow CI runner.
+                assert!(
+                    (9..=10).contains(&days_until_expiry),
+                    "expected days_until_expiry in 9..=10, got {days_until_expiry}"
+                );
+            }
+            other => panic!("expected ExpiringSoon, got {other:?}"),
+        }
+    }
 }

--- a/aa-gateway/src/remote_mode/tls.rs
+++ b/aa-gateway/src/remote_mode/tls.rs
@@ -6,12 +6,12 @@
 //! shows up only when the first client tries to connect.
 
 use std::fs;
-use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use aa_core::config::TlsConfig;
 use thiserror::Error;
+use x509_parser::pem::Pem;
 
 /// Outcome of a successful [`validate`] call — the cert parsed, but
 /// classification distinguishes "fine" from soft warnings about its
@@ -69,14 +69,13 @@ pub fn validate(cfg: &TlsConfig) -> Result<TlsValidation, TlsError> {
     // parsing happens in axum-server::tls_rustls when ST-3 binds.
     let _key_bytes = read_file(&cfg.key_file)?;
 
-    let mut reader = BufReader::new(cert_bytes.as_slice());
-    let leaf_der = rustls_pemfile::certs(&mut reader)
+    let leaf_pem = Pem::iter_from_buffer(&cert_bytes)
         .next()
-        .ok_or_else(|| TlsError::CertParse("no certificate found in PEM".to_string()))?
+        .ok_or_else(|| TlsError::CertParse("no PEM block in cert file".to_string()))?
         .map_err(|e| TlsError::CertParse(format!("pem decode: {e}")))?;
-
-    let (_, x509) =
-        x509_parser::parse_x509_certificate(&leaf_der).map_err(|e| TlsError::CertParse(format!("x509 decode: {e}")))?;
+    let x509 = leaf_pem
+        .parse_x509()
+        .map_err(|e| TlsError::CertParse(format!("x509 decode: {e}")))?;
 
     let not_after_secs = x509.validity().not_after.timestamp();
     let now_secs = SystemTime::now()

--- a/aa-gateway/src/remote_mode/tls.rs
+++ b/aa-gateway/src/remote_mode/tls.rs
@@ -215,4 +215,26 @@ mod tests {
             other => panic!("expected Expired, got {other:?}"),
         }
     }
+
+    #[test]
+    fn errors_when_cert_file_missing() {
+        let (cert, key) = issue_cert_with_validity(-1, 365);
+        let (dir, mut cfg) = write_pair(&cert, &key);
+        cfg.cert_file = dir.path().join("does-not-exist.pem");
+        match validate(&cfg).expect_err("expected error") {
+            TlsError::CertFileMissing(path) => assert_eq!(path, cfg.cert_file),
+            other => panic!("expected CertFileMissing, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn errors_when_key_file_missing() {
+        let (cert, key) = issue_cert_with_validity(-1, 365);
+        let (dir, mut cfg) = write_pair(&cert, &key);
+        cfg.key_file = dir.path().join("missing-key.pem");
+        match validate(&cfg).expect_err("expected error") {
+            TlsError::KeyFileMissing(path) => assert_eq!(path, cfg.key_file),
+            other => panic!("expected KeyFileMissing, got {other:?}"),
+        }
+    }
 }

--- a/aa-gateway/src/remote_mode/tls.rs
+++ b/aa-gateway/src/remote_mode/tls.rs
@@ -198,4 +198,21 @@ mod tests {
             other => panic!("expected ExpiringSoon, got {other:?}"),
         }
     }
+
+    #[test]
+    fn flags_expired_for_past_not_after() {
+        // not_before 100 days ago, not_after 7 days ago.
+        let (cert, key) = issue_cert_with_validity(-100, -7);
+        let (_dir, cfg) = write_pair(&cert, &key);
+        let result = validate(&cfg).expect("validate");
+        match result {
+            TlsValidation::Expired { expired_days_ago } => {
+                assert!(
+                    (6..=7).contains(&expired_days_ago),
+                    "expected expired_days_ago in 6..=7, got {expired_days_ago}"
+                );
+            }
+            other => panic!("expected Expired, got {other:?}"),
+        }
+    }
 }

--- a/aa-gateway/src/remote_mode/tls.rs
+++ b/aa-gateway/src/remote_mode/tls.rs
@@ -5,8 +5,12 @@
 //! startup error rather than a runtime TLS handshake failure that
 //! shows up only when the first client tries to connect.
 
-use std::path::PathBuf;
+use std::fs;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
+use aa_core::config::TlsConfig;
 use thiserror::Error;
 
 /// Outcome of a successful [`validate`] call — the cert parsed, but
@@ -30,6 +34,76 @@ pub enum TlsValidation {
         /// Whole days since `notAfter`.
         expired_days_ago: i64,
     },
+}
+
+/// Threshold below which a cert is reported as `ExpiringSoon`.
+const EXPIRING_SOON_DAYS: i64 = 30;
+
+/// Seconds in one day, used to convert between Unix-epoch seconds and
+/// whole-day deltas.
+const SECONDS_PER_DAY: i64 = 86_400;
+
+/// Validate a [`TlsConfig`] before binding the listener.
+///
+/// Steps, in order:
+///
+/// 1. `cert_file` and `key_file` exist on disk.
+/// 2. Both files are readable (open + read into memory).
+/// 3. The cert file decodes as PEM-wrapped X.509.
+/// 4. The leaf cert's `notAfter` is classified — `Ok` /
+///    `ExpiringSoon` (≤ 30 days) / `Expired` (in the past).
+///
+/// Returns `Err(TlsError)` for hard failures the gateway must surface
+/// before binding. Returns `Ok(TlsValidation::*)` when the cert parsed,
+/// leaving log-vs-fail policy for expiry warnings to the caller.
+pub fn validate(cfg: &TlsConfig) -> Result<TlsValidation, TlsError> {
+    if !cfg.cert_file.exists() {
+        return Err(TlsError::CertFileMissing(cfg.cert_file.clone()));
+    }
+    if !cfg.key_file.exists() {
+        return Err(TlsError::KeyFileMissing(cfg.key_file.clone()));
+    }
+
+    let cert_bytes = read_file(&cfg.cert_file)?;
+    // Key file is read purely as a readability check — handshake-time
+    // parsing happens in axum-server::tls_rustls when ST-3 binds.
+    let _key_bytes = read_file(&cfg.key_file)?;
+
+    let mut reader = BufReader::new(cert_bytes.as_slice());
+    let leaf_der = rustls_pemfile::certs(&mut reader)
+        .next()
+        .ok_or_else(|| TlsError::CertParse("no certificate found in PEM".to_string()))?
+        .map_err(|e| TlsError::CertParse(format!("pem decode: {e}")))?;
+
+    let (_, x509) =
+        x509_parser::parse_x509_certificate(&leaf_der).map_err(|e| TlsError::CertParse(format!("x509 decode: {e}")))?;
+
+    let not_after_secs = x509.validity().not_after.timestamp();
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+
+    let days_until = (not_after_secs - now_secs) / SECONDS_PER_DAY;
+
+    if days_until < 0 {
+        Ok(TlsValidation::Expired {
+            expired_days_ago: -days_until,
+        })
+    } else if days_until <= EXPIRING_SOON_DAYS {
+        Ok(TlsValidation::ExpiringSoon {
+            days_until_expiry: days_until,
+        })
+    } else {
+        Ok(TlsValidation::Ok)
+    }
+}
+
+fn read_file(path: &Path) -> Result<Vec<u8>, TlsError> {
+    fs::read(path).map_err(|source| TlsError::Io {
+        path: path.to_path_buf(),
+        source,
+    })
 }
 
 /// Hard failures that should stop gateway startup in remote-mode TLS.


### PR DESCRIPTION
## Description

Pre-flight TLS validation for Remote CP Mode (AAASM-1577 / E17 S-C). When `RemoteModeConfig.tls` is set, the gateway calls `remote_mode::tls::validate(&cfg)` before binding the listener so any cert/key misconfiguration causes a fast, clearly-attributed startup error instead of a runtime TLS handshake failure.

Adds:

- `aa-gateway/src/remote_mode/mod.rs` — new module declaration (`pub mod tls;`)
- `aa-gateway/src/remote_mode/tls.rs` — `TlsError` enum, `TlsValidation` enum, `validate()` function
- `aa-gateway/src/lib.rs` — `pub mod remote_mode;`
- `aa-gateway/Cargo.toml` — `x509-parser = "0.18"` dep, `rcgen` + `time` dev-deps for cert fixtures
- 6 unit tests under `remote_mode::tls::tests`

The validator:

1. Checks `cert_file` and `key_file` exist on disk
2. Reads both into memory (catches permission errors)
3. PEM-parses the cert (via `x509_parser::pem::Pem`)
4. Classifies `notAfter` against now:
   - `Ok` — more than 30 days remaining
   - `ExpiringSoon { days_until_expiry }` — within 30 days
   - `Expired { expired_days_ago }` — past `notAfter`
5. Returns `Err(TlsError::*)` for hard failures (file missing, I/O error, bad PEM)

Key file is only read as a readability probe — handshake-time parsing belongs to `axum-server::tls_rustls` when ST-3 (AAASM-1709) wires up the listener.

### Note on supply chain

Initially planned to use `rustls-pemfile`, but `RUSTSEC-2025-0134` flagged it as unmaintained. The implementation uses `x509-parser`'s built-in PEM parsing instead — same crate that already extracts `notAfter`, so no new dep. Captured in the last commit (`♻️ Swap PEM parser to x509-parser`).

Out of scope for this PR (separate Sub-tasks):

- HTTP/HTTPS listener bind + axum-server wiring (AAASM-1709 / ST-3)
- `main.rs` mode dispatch (AAASM-1713 / ST-4)
- Story-level acceptance verification (AAASM-1718 / ST-5)

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1702 (Sub-task of AAASM-1577 under Epic AAASM-1568)

## Testing

- [x] Unit tests added — 6 tests under `aa-gateway remote_mode::tls::tests`
- [x] Manual testing — `cargo nextest run -p aa-gateway remote_mode::tls` green

```
$ cargo nextest run -p aa-gateway remote_mode::tls
        PASS remote_mode::tls::tests::returns_ok_for_fresh_year_long_cert
        PASS remote_mode::tls::tests::flags_expiring_soon_within_30_days
        PASS remote_mode::tls::tests::flags_expired_for_past_not_after
        PASS remote_mode::tls::tests::errors_when_cert_file_missing
        PASS remote_mode::tls::tests::errors_when_key_file_missing
        PASS remote_mode::tls::tests::errors_when_cert_is_not_pem
     Summary 6 tests run: 6 passed, 832 skipped
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated (rustdoc on new types)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention