### PR TITLE
[AAASM-1708] ✨ (storage::sqlite): Implement agent-registry trait methods

### DIFF
--- a/aa-gateway/src/storage/sqlite.rs
+++ b/aa-gateway/src/storage/sqlite.rs
@@ -257,6 +257,80 @@ fn push_audit_where<'q>(qb: &mut sqlx::QueryBuilder<'q, sqlx::Sqlite>, filter: &
     }
 }
 
+/// Decode a single `agent_registry` row into an [`AgentRecord`].
+///
+/// Maps TEXT timestamps back to `DateTime<Utc>` and TEXT JSON metadata
+/// back to a `BTreeMap<String, String>`.
+fn row_to_agent_record(row: &sqlx::sqlite::SqliteRow) -> StorageResult<AgentRecord> {
+    use sqlx::Row;
+
+    let agent_id_text: String = row
+        .try_get("agent_id")
+        .map_err(|e| StorageError::QueryFailed(format!("agent_id column: {e}")))?;
+    let agent_id = agent_id_from_text(&agent_id_text)?;
+
+    let metadata_text: String = row
+        .try_get("metadata")
+        .map_err(|e| StorageError::QueryFailed(format!("metadata column: {e}")))?;
+    let metadata: std::collections::BTreeMap<String, String> =
+        serde_json::from_str(&metadata_text).map_err(|e| StorageError::QueryFailed(format!("metadata parse: {e}")))?;
+
+    let registered_at: String = row
+        .try_get("registered_at")
+        .map_err(|e| StorageError::QueryFailed(format!("registered_at column: {e}")))?;
+    let registered_at = chrono::DateTime::parse_from_rfc3339(&registered_at)
+        .map_err(|e| StorageError::QueryFailed(format!("registered_at parse: {e}")))?
+        .with_timezone(&chrono::Utc);
+
+    let last_seen_at: String = row
+        .try_get("last_seen_at")
+        .map_err(|e| StorageError::QueryFailed(format!("last_seen_at column: {e}")))?;
+    let last_seen_at = chrono::DateTime::parse_from_rfc3339(&last_seen_at)
+        .map_err(|e| StorageError::QueryFailed(format!("last_seen_at parse: {e}")))?
+        .with_timezone(&chrono::Utc);
+
+    Ok(AgentRecord {
+        agent_id,
+        team_id: row
+            .try_get("team_id")
+            .map_err(|e| StorageError::QueryFailed(format!("team_id column: {e}")))?,
+        org_id: row
+            .try_get("org_id")
+            .map_err(|e| StorageError::QueryFailed(format!("org_id column: {e}")))?,
+        metadata,
+        registered_at,
+        last_seen_at,
+        enforcement_mode: row
+            .try_get("enforcement_mode")
+            .map_err(|e| StorageError::QueryFailed(format!("enforcement_mode column: {e}")))?,
+    })
+}
+
+/// Push the agent-registry WHERE clause derived from `filter` into `qb`.
+///
+/// Uses SQLite's JSON1 `json_extract` to perform the substring match on
+/// the metadata `name` key. Pushes nothing for an empty filter.
+fn push_agent_where<'q>(qb: &mut sqlx::QueryBuilder<'q, sqlx::Sqlite>, filter: &'q AgentFilter) {
+    let mut started = false;
+    let mut connective = move |qb: &mut sqlx::QueryBuilder<'q, sqlx::Sqlite>| {
+        qb.push(if started { " AND " } else { " WHERE " });
+        started = true;
+    };
+    if let Some(team_id) = filter.team_id.as_ref() {
+        connective(qb);
+        qb.push("team_id = ").push_bind(team_id.clone());
+    }
+    if let Some(org_id) = filter.org_id.as_ref() {
+        connective(qb);
+        qb.push("org_id = ").push_bind(org_id.clone());
+    }
+    if let Some(name_contains) = filter.name_contains.as_ref() {
+        connective(qb);
+        qb.push("json_extract(metadata, '$.name') LIKE ")
+            .push_bind(format!("%{name_contains}%"));
+    }
+}
+
 /// Trait wiring. Concrete method bodies for each slice land in their own
 /// Epic-18 S-B sub-task; until then the unimplemented slices return
 /// `todo!("AAASM-…")` so the workspace compiles.
@@ -323,20 +397,70 @@ impl StorageBackend for SqliteBackend {
         u64::try_from(count).map_err(|e| StorageError::QueryFailed(format!("count overflow: {e}")))
     }
 
-    async fn upsert_agent(&self, _record: AgentRecord) -> StorageResult<()> {
-        todo!("AAASM-1708: upsert_agent")
+    async fn upsert_agent(&self, record: AgentRecord) -> StorageResult<()> {
+        let metadata_text = serde_json::to_string(&record.metadata)
+            .map_err(|e| StorageError::QueryFailed(format!("metadata serialize: {e}")))?;
+        sqlx::query(
+            "INSERT OR REPLACE INTO agent_registry \
+             (agent_id, team_id, org_id, metadata, registered_at, last_seen_at, enforcement_mode) \
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(agent_id_to_text(&record.agent_id))
+        .bind(record.team_id)
+        .bind(record.org_id)
+        .bind(metadata_text)
+        .bind(record.registered_at.to_rfc3339())
+        .bind(record.last_seen_at.to_rfc3339())
+        .bind(record.enforcement_mode)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| StorageError::QueryFailed(e.to_string()))?;
+        Ok(())
     }
 
-    async fn get_agent(&self, _id: &AgentId) -> StorageResult<Option<AgentRecord>> {
-        todo!("AAASM-1708: get_agent")
+    async fn get_agent(&self, id: &AgentId) -> StorageResult<Option<AgentRecord>> {
+        let row = sqlx::query(
+            "SELECT agent_id, team_id, org_id, metadata, registered_at, last_seen_at, enforcement_mode \
+             FROM agent_registry WHERE agent_id = ?",
+        )
+        .bind(agent_id_to_text(id))
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| StorageError::QueryFailed(e.to_string()))?;
+        row.as_ref().map(row_to_agent_record).transpose()
     }
 
-    async fn list_agents(&self, _filter: AgentFilter) -> StorageResult<Vec<AgentRecord>> {
-        todo!("AAASM-1708: list_agents")
+    async fn list_agents(&self, filter: AgentFilter) -> StorageResult<Vec<AgentRecord>> {
+        let mut qb = sqlx::QueryBuilder::<sqlx::Sqlite>::new(
+            "SELECT agent_id, team_id, org_id, metadata, registered_at, last_seen_at, \
+             enforcement_mode FROM agent_registry",
+        );
+        push_agent_where(&mut qb, &filter);
+        qb.push(" ORDER BY agent_id");
+        if let Some(limit) = filter.limit {
+            qb.push(" LIMIT ").push_bind(i64::from(limit));
+            if let Some(offset) = filter.offset {
+                qb.push(" OFFSET ").push_bind(i64::from(offset));
+            }
+        }
+        let rows = qb
+            .build()
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| StorageError::QueryFailed(e.to_string()))?;
+        rows.iter().map(row_to_agent_record).collect()
     }
 
-    async fn delete_agent(&self, _id: &AgentId) -> StorageResult<()> {
-        todo!("AAASM-1708: delete_agent")
+    async fn delete_agent(&self, id: &AgentId) -> StorageResult<()> {
+        let result = sqlx::query("DELETE FROM agent_registry WHERE agent_id = ?")
+            .bind(agent_id_to_text(id))
+            .execute(&self.pool)
+            .await
+            .map_err(|e| StorageError::QueryFailed(e.to_string()))?;
+        if result.rows_affected() == 0 {
+            return Err(StorageError::NotFound(agent_id_to_text(id)));
+        }
+        Ok(())
     }
 
     async fn save_policy(&self, _doc: PolicyDocument) -> StorageResult<PolicyVersion> {

--- a/aa-gateway/src/storage/sqlite.rs
+++ b/aa-gateway/src/storage/sqlite.rs
@@ -791,4 +791,117 @@ mod tests {
             .expect("query scoped");
         assert_eq!(scoped, scoped_rows.len() as u64);
     }
+
+    fn sample_agent(seed: u8, team: &str, org: &str, name: &str) -> AgentRecord {
+        let mut metadata = std::collections::BTreeMap::new();
+        metadata.insert("name".to_owned(), name.to_owned());
+        let ts = chrono::DateTime::parse_from_rfc3339("2026-05-21T09:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        AgentRecord {
+            agent_id: AgentId::from_bytes([seed; 16]),
+            team_id: Some(team.to_owned()),
+            org_id: Some(org.to_owned()),
+            metadata,
+            registered_at: ts,
+            last_seen_at: ts,
+            enforcement_mode: "enforce".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn agent_upsert_is_idempotent_and_updates_existing_row() {
+        let (_tmp, backend) = open_temp_backend().await;
+        backend.migrate().await.expect("migrate");
+        let mut rec = sample_agent(7, "team-x", "org-1", "Alpha");
+        backend.upsert_agent(rec.clone()).await.expect("first upsert");
+
+        // Update last_seen_at and re-upsert; row count must stay at 1
+        // and the new last_seen_at must be visible.
+        let later = chrono::DateTime::parse_from_rfc3339("2026-05-21T12:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        rec.last_seen_at = later;
+        backend.upsert_agent(rec.clone()).await.expect("second upsert");
+
+        let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM agent_registry")
+            .fetch_one(backend.pool())
+            .await
+            .expect("count");
+        assert_eq!(count, 1, "upsert should not duplicate the row");
+
+        let fetched = backend.get_agent(&rec.agent_id).await.expect("get").expect("present");
+        assert_eq!(fetched.last_seen_at, later);
+    }
+
+    #[tokio::test]
+    async fn agent_get_returns_none_for_unknown_id() {
+        let (_tmp, backend) = open_temp_backend().await;
+        backend.migrate().await.expect("migrate");
+        let missing = AgentId::from_bytes([0xff; 16]);
+        assert!(backend.get_agent(&missing).await.expect("get").is_none());
+    }
+
+    #[tokio::test]
+    async fn agent_list_filters_by_team_org_and_name_substring() {
+        let (_tmp, backend) = open_temp_backend().await;
+        backend.migrate().await.expect("migrate");
+        for rec in [
+            sample_agent(1, "team-x", "org-1", "Alpha"),
+            sample_agent(2, "team-x", "org-2", "Bravo"),
+            sample_agent(3, "team-y", "org-1", "Alpha-prime"),
+        ] {
+            backend.upsert_agent(rec).await.expect("seed");
+        }
+
+        let team_x = backend
+            .list_agents(AgentFilter {
+                team_id: Some("team-x".into()),
+                ..AgentFilter::default()
+            })
+            .await
+            .expect("by team");
+        assert_eq!(team_x.len(), 2);
+
+        let org_1 = backend
+            .list_agents(AgentFilter {
+                org_id: Some("org-1".into()),
+                ..AgentFilter::default()
+            })
+            .await
+            .expect("by org");
+        assert_eq!(org_1.len(), 2);
+
+        let named_alpha = backend
+            .list_agents(AgentFilter {
+                name_contains: Some("Alpha".into()),
+                ..AgentFilter::default()
+            })
+            .await
+            .expect("by name substring");
+        assert_eq!(named_alpha.len(), 2);
+        assert!(named_alpha
+            .iter()
+            .all(|r| r.metadata.get("name").unwrap().contains("Alpha")));
+    }
+
+    #[tokio::test]
+    async fn agent_delete_removes_row_and_second_delete_returns_not_found() {
+        let (_tmp, backend) = open_temp_backend().await;
+        backend.migrate().await.expect("migrate");
+        let rec = sample_agent(9, "team-x", "org-1", "Bravo");
+        backend.upsert_agent(rec.clone()).await.expect("seed");
+
+        backend.delete_agent(&rec.agent_id).await.expect("first delete");
+        assert!(
+            backend.get_agent(&rec.agent_id).await.expect("get").is_none(),
+            "row should be removed"
+        );
+
+        let err = backend
+            .delete_agent(&rec.agent_id)
+            .await
+            .expect_err("second delete must report NotFound");
+        assert!(matches!(err, StorageError::NotFound(_)));
+    }
 }


### PR DESCRIPTION
## Description

Fourth sub-task of **Story AAASM-1584 (E18 S-B: SQLite StorageBackend)**. Stacks on top of S-B.3 (#673). Replaces the four agent-registry `todo!()` stubs with real implementations:

- `upsert_agent` — `INSERT OR REPLACE`; metadata serialized to JSON TEXT.
- `get_agent` — `fetch_optional` + row decoder; returns `Option<AgentRecord>`.
- `list_agents` — `QueryBuilder` SELECT with dynamic WHERE (team_id / org_id / name_contains via SQLite JSON1 `json_extract`), `ORDER BY agent_id`, optional LIMIT/OFFSET.
- `delete_agent` — DELETE; `rows_affected == 0 → StorageError::NotFound`.

Plus the slice-shared `row_to_agent_record` decoder and `push_agent_where` clause builder.

> **Note on PR base:** Branch cut from `v0.0.1/AAASM-1704/feat/storage_sqlite_audit_events` (S-B.3). PR base remains `master`.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: **AAASM-1708** (sub-task of AAASM-1584, under Epic AAASM-1569)
- Stacked on: #673 (AAASM-1704) → #665 (AAASM-1700) → #656 (AAASM-1697)

## Testing

- [x] Unit + integration tests added
  - `agent_upsert_is_idempotent_and_updates_existing_row`
  - `agent_get_returns_none_for_unknown_id`
  - `agent_list_filters_by_team_org_and_name_substring`
  - `agent_delete_removes_row_and_second_delete_returns_not_found`
- [x] Manual testing performed (`cargo nextest run -p aa-gateway storage::sqlite` — 12/12 passed)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --all-targets -- -D warnings`)
- [x] Self-review of the diff completed
- [x] Documentation updated
- [x] All CI checks passing (pending CI on push)
- [x] Commits are small and follow the Gitmoji convention (2 commits — implementations + AC tests)