### PR TITLE
[AAASM-1745] ✨ (aa-gateway/storage): Add RetentionEngine::run_once() with tracing log

### DIFF
--- a/aa-gateway/src/storage/mod.rs
+++ b/aa-gateway/src/storage/mod.rs
@@ -33,6 +33,7 @@ pub mod postgres;
 pub mod postgres_config;
 pub mod retention;
 pub mod retention_config;
+pub mod retention_engine;
 pub mod sqlite;
 
 pub use agent::{AgentFilter, AgentRecord, TeamId};
@@ -46,4 +47,5 @@ pub use postgres::PostgresBackend;
 pub use postgres_config::PostgresConfig;
 pub use retention::{ColdAction, RetentionPolicy, RetentionStats};
 pub use retention_config::{RetentionConfig, RetentionConfigError};
+pub use retention_engine::RetentionEngine;
 pub use sqlite::{SqliteBackend, SqliteConfig};

--- a/aa-gateway/src/storage/retention_engine.rs
+++ b/aa-gateway/src/storage/retention_engine.rs
@@ -175,4 +175,15 @@ mod tests {
             .expect("apply_retention should have been called");
         assert_eq!(captured, config.to_policy());
     }
+
+    #[tokio::test]
+    async fn run_once_returns_stats_from_backend_unchanged() {
+        let canned = canned_stats();
+        let backend = Arc::new(FakeBackend::new(canned.clone()));
+        let engine = RetentionEngine::new(backend, RetentionConfig::default());
+
+        let stats = engine.run_once().await.expect("run_once should succeed");
+
+        assert_eq!(stats, canned);
+    }
 }

--- a/aa-gateway/src/storage/retention_engine.rs
+++ b/aa-gateway/src/storage/retention_engine.rs
@@ -1,0 +1,18 @@
+//! Background retention engine — orchestrates periodic invocations of
+//! [`StorageBackend::apply_retention`](super::StorageBackend::apply_retention).
+//!
+//! Story S-F. The engine itself is a thin orchestrator; backend-specific
+//! semantics (TimescaleDB compression, S3 archive, plain DELETE) live in
+//! each [`StorageBackend`] implementation.
+
+use std::sync::Arc;
+
+use super::backend::StorageBackend;
+use super::retention_config::RetentionConfig;
+
+/// Owns the periodic retention task lifecycle.
+#[allow(dead_code)] // fields read by the constructor + run_once landing in subsequent commits
+pub struct RetentionEngine {
+    backend: Arc<dyn StorageBackend>,
+    config: RetentionConfig,
+}

--- a/aa-gateway/src/storage/retention_engine.rs
+++ b/aa-gateway/src/storage/retention_engine.rs
@@ -40,6 +40,17 @@ impl RetentionEngine {
     /// [`apply_retention`](StorageBackend::apply_retention).
     pub async fn run_once(&self) -> StorageResult<RetentionStats> {
         let policy = self.config.to_policy();
-        self.backend.apply_retention(&policy).await
+        let stats = self.backend.apply_retention(&policy).await?;
+        tracing::info!(
+            dry_run = policy.dry_run,
+            hot_rows = stats.hot_rows,
+            compressed_rows = stats.compressed_rows,
+            archived_rows = stats.archived_rows,
+            dropped_rows = stats.dropped_rows,
+            freed_bytes = stats.freed_bytes,
+            ran_at = %stats.ran_at,
+            "retention run complete",
+        );
+        Ok(stats)
     }
 }

--- a/aa-gateway/src/storage/retention_engine.rs
+++ b/aa-gateway/src/storage/retention_engine.rs
@@ -65,23 +65,30 @@ mod tests {
     use super::*;
     use crate::storage::{
         AgentFilter, AgentRecord, AuditEvent, AuditFilter, ColdAction, Metric, MetricPoint, MetricQuery,
-        PolicyDocument, PolicyMeta, PolicyVersion, RetentionPolicy, StorageHealth,
+        PolicyDocument, PolicyMeta, PolicyVersion, RetentionPolicy, StorageError, StorageHealth,
     };
     use aa_core::identity::AgentId;
 
     /// `StorageBackend` test double that records the
-    /// [`RetentionPolicy`] handed to `apply_retention` and returns canned
-    /// [`RetentionStats`]. Every other trait method is unreachable in this
-    /// module's tests and panics if called.
+    /// [`RetentionPolicy`] handed to `apply_retention` and returns either
+    /// canned [`RetentionStats`] or a configured error. Every other trait
+    /// method is unreachable in this module's tests and panics if called.
     struct FakeBackend {
-        canned: RetentionStats,
+        outcome: Mutex<Option<StorageResult<RetentionStats>>>,
         captured: Mutex<Option<RetentionPolicy>>,
     }
 
     impl FakeBackend {
         fn new(canned: RetentionStats) -> Self {
             Self {
-                canned,
+                outcome: Mutex::new(Some(Ok(canned))),
+                captured: Mutex::new(None),
+            }
+        }
+
+        fn failing(error: StorageError) -> Self {
+            Self {
+                outcome: Mutex::new(Some(Err(error))),
                 captured: Mutex::new(None),
             }
         }
@@ -95,7 +102,11 @@ mod tests {
     impl StorageBackend for FakeBackend {
         async fn apply_retention(&self, policy: &RetentionPolicy) -> StorageResult<RetentionStats> {
             *self.captured.lock().unwrap() = Some(policy.clone());
-            Ok(self.canned.clone())
+            self.outcome
+                .lock()
+                .unwrap()
+                .take()
+                .expect("FakeBackend::apply_retention fired more than once in a single test")
         }
         async fn append_audit_event(&self, _: &AuditEvent) -> StorageResult<()> {
             unreachable!()
@@ -203,5 +214,16 @@ mod tests {
         let stats = engine.run_once().await.expect("run_once should succeed");
 
         assert_eq!(stats, canned);
+    }
+
+    #[tokio::test]
+    async fn run_once_surfaces_backend_error() {
+        let backend = Arc::new(FakeBackend::failing(StorageError::RetentionError(
+            "simulated S3 archive timeout".to_string(),
+        )));
+        let engine = RetentionEngine::new(backend, RetentionConfig::default());
+
+        let err = engine.run_once().await.expect_err("backend error must surface");
+        assert!(matches!(err, StorageError::RetentionError(ref msg) if msg.contains("S3 archive timeout")));
     }
 }

--- a/aa-gateway/src/storage/retention_engine.rs
+++ b/aa-gateway/src/storage/retention_engine.rs
@@ -11,8 +11,17 @@ use super::backend::StorageBackend;
 use super::retention_config::RetentionConfig;
 
 /// Owns the periodic retention task lifecycle.
-#[allow(dead_code)] // fields read by the constructor + run_once landing in subsequent commits
+#[allow(dead_code)] // fields read by run_once landing in the next commit
 pub struct RetentionEngine {
     backend: Arc<dyn StorageBackend>,
     config: RetentionConfig,
+}
+
+impl RetentionEngine {
+    /// Build an engine that, when driven, calls
+    /// [`apply_retention`](StorageBackend::apply_retention) on `backend`
+    /// using the policy derived from `config`.
+    pub fn new(backend: Arc<dyn StorageBackend>, config: RetentionConfig) -> Self {
+        Self { backend, config }
+    }
 }

--- a/aa-gateway/src/storage/retention_engine.rs
+++ b/aa-gateway/src/storage/retention_engine.rs
@@ -177,6 +177,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn run_once_propagates_dry_run_flag_to_policy() {
+        let backend = Arc::new(FakeBackend::new(canned_stats()));
+        let config = RetentionConfig {
+            dry_run: true,
+            ..RetentionConfig::default()
+        };
+        let engine = RetentionEngine::new(backend.clone(), config);
+
+        engine.run_once().await.expect("run_once should succeed");
+
+        let captured = backend.captured_policy().unwrap();
+        assert!(
+            captured.dry_run,
+            "dry_run must round-trip from RetentionConfig through to_policy and into the backend"
+        );
+    }
+
+    #[tokio::test]
     async fn run_once_returns_stats_from_backend_unchanged() {
         let canned = canned_stats();
         let backend = Arc::new(FakeBackend::new(canned.clone()));

--- a/aa-gateway/src/storage/retention_engine.rs
+++ b/aa-gateway/src/storage/retention_engine.rs
@@ -8,10 +8,11 @@
 use std::sync::Arc;
 
 use super::backend::StorageBackend;
+use super::error::StorageResult;
+use super::retention::RetentionStats;
 use super::retention_config::RetentionConfig;
 
 /// Owns the periodic retention task lifecycle.
-#[allow(dead_code)] // fields read by run_once landing in the next commit
 pub struct RetentionEngine {
     backend: Arc<dyn StorageBackend>,
     config: RetentionConfig,
@@ -23,5 +24,22 @@ impl RetentionEngine {
     /// using the policy derived from `config`.
     pub fn new(backend: Arc<dyn StorageBackend>, config: RetentionConfig) -> Self {
         Self { backend, config }
+    }
+
+    /// Run one retention pass: build the [`RetentionPolicy`](super::RetentionPolicy)
+    /// from `self.config`, hand it to the backend, and return the
+    /// resulting [`RetentionStats`].
+    ///
+    /// The cron-driven background loop (next commit) invokes this once per
+    /// scheduled tick; operators can also invoke it manually via
+    /// `aasm admin run-retention`.
+    ///
+    /// # Errors
+    ///
+    /// Surfaces any [`StorageError`](super::StorageError) returned by
+    /// [`apply_retention`](StorageBackend::apply_retention).
+    pub async fn run_once(&self) -> StorageResult<RetentionStats> {
+        let policy = self.config.to_policy();
+        self.backend.apply_retention(&policy).await
     }
 }

--- a/aa-gateway/src/storage/retention_engine.rs
+++ b/aa-gateway/src/storage/retention_engine.rs
@@ -54,3 +54,125 @@ impl RetentionEngine {
         Ok(stats)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use async_trait::async_trait;
+    use chrono::{TimeZone, Utc};
+
+    use super::*;
+    use crate::storage::{
+        AgentFilter, AgentRecord, AuditEvent, AuditFilter, ColdAction, Metric, MetricPoint, MetricQuery,
+        PolicyDocument, PolicyMeta, PolicyVersion, RetentionPolicy, StorageHealth,
+    };
+    use aa_core::identity::AgentId;
+
+    /// `StorageBackend` test double that records the
+    /// [`RetentionPolicy`] handed to `apply_retention` and returns canned
+    /// [`RetentionStats`]. Every other trait method is unreachable in this
+    /// module's tests and panics if called.
+    struct FakeBackend {
+        canned: RetentionStats,
+        captured: Mutex<Option<RetentionPolicy>>,
+    }
+
+    impl FakeBackend {
+        fn new(canned: RetentionStats) -> Self {
+            Self {
+                canned,
+                captured: Mutex::new(None),
+            }
+        }
+
+        fn captured_policy(&self) -> Option<RetentionPolicy> {
+            self.captured.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl StorageBackend for FakeBackend {
+        async fn apply_retention(&self, policy: &RetentionPolicy) -> StorageResult<RetentionStats> {
+            *self.captured.lock().unwrap() = Some(policy.clone());
+            Ok(self.canned.clone())
+        }
+        async fn append_audit_event(&self, _: &AuditEvent) -> StorageResult<()> {
+            unreachable!()
+        }
+        async fn query_audit_events(&self, _: AuditFilter) -> StorageResult<Vec<AuditEvent>> {
+            unreachable!()
+        }
+        async fn count_audit_events(&self, _: AuditFilter) -> StorageResult<u64> {
+            unreachable!()
+        }
+        async fn upsert_agent(&self, _: AgentRecord) -> StorageResult<()> {
+            unreachable!()
+        }
+        async fn get_agent(&self, _: &AgentId) -> StorageResult<Option<AgentRecord>> {
+            unreachable!()
+        }
+        async fn list_agents(&self, _: AgentFilter) -> StorageResult<Vec<AgentRecord>> {
+            unreachable!()
+        }
+        async fn delete_agent(&self, _: &AgentId) -> StorageResult<()> {
+            unreachable!()
+        }
+        async fn save_policy(&self, _: PolicyDocument) -> StorageResult<PolicyVersion> {
+            unreachable!()
+        }
+        async fn get_active_policy(&self, _: &str) -> StorageResult<Option<PolicyDocument>> {
+            unreachable!()
+        }
+        async fn list_policy_versions(&self, _: &str) -> StorageResult<Vec<PolicyMeta>> {
+            unreachable!()
+        }
+        async fn rollback_policy(&self, _: &str, _: u32) -> StorageResult<()> {
+            unreachable!()
+        }
+        async fn record_metric(&self, _: Metric) -> StorageResult<()> {
+            unreachable!()
+        }
+        async fn query_metrics(&self, _: MetricQuery) -> StorageResult<Vec<MetricPoint>> {
+            unreachable!()
+        }
+        async fn migrate(&self) -> StorageResult<()> {
+            unreachable!()
+        }
+        async fn healthcheck(&self) -> StorageResult<StorageHealth> {
+            unreachable!()
+        }
+    }
+
+    fn canned_stats() -> RetentionStats {
+        RetentionStats {
+            hot_rows: 100,
+            compressed_rows: 50,
+            archived_rows: 20,
+            dropped_rows: 10,
+            freed_bytes: 4096,
+            ran_at: Utc.with_ymd_and_hms(2026, 5, 22, 3, 0, 0).unwrap(),
+        }
+    }
+
+    #[tokio::test]
+    async fn run_once_invokes_apply_retention_with_policy_from_config() {
+        let backend = Arc::new(FakeBackend::new(canned_stats()));
+        let config = RetentionConfig {
+            hot_days: 7,
+            warm_days: 30,
+            cold_action: ColdAction::Archive,
+            archive_url: Some("s3://b/".to_string()),
+            dry_run: true,
+            ..RetentionConfig::default()
+        };
+        let engine = RetentionEngine::new(backend.clone(), config.clone());
+
+        engine.run_once().await.expect("run_once should succeed");
+
+        let captured = backend
+            .captured_policy()
+            .expect("apply_retention should have been called");
+        assert_eq!(captured, config.to_policy());
+    }
+}


### PR DESCRIPTION
## Description

Adds the orchestrator half of Story S-F: `RetentionEngine::new(backend, config)` plus an async `run_once() -> StorageResult<RetentionStats>` that derives the policy from `RetentionConfig::to_policy()`, calls `StorageBackend::apply_retention`, and emits a structured `tracing::info` log capturing every `RetentionStats` field (hot/compressed/archived/dropped row counts, bytes freed, run timestamp, dry_run flag).

This is **Impl-2 of 4** under Story AAASM-1588 (E18 S-F: Retention engine). Builds on Impl-1 (#662 / AAASM-1744, already merged). Remaining: AAASM-1746 (cron-driven `start()`), AAASM-1747 (`aasm admin run-retention` CLI), AAASM-1748 (verification).

Files:

- new: `aa-gateway/src/storage/retention_engine.rs`
- updated: `aa-gateway/src/storage/mod.rs` (re-export `RetentionEngine`)

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-1745 (impl subtask)
- Parent Story: AAASM-1588 (E18 S-F)
- Epic: AAASM-1569 (Epic 18)
- Depends on (merged): AAASM-1744 / PR #662
- Related GitHub issues: —

## Testing

- [x] Unit tests added / updated — 4 new tests in `storage::retention_engine::tests`
- [ ] Integration tests added / updated
- [x] Manual testing performed — `cargo nextest run -p aa-gateway storage::retention` runs 9/9 green (5 from Impl-1 + 4 new here)

Engine-side coverage of parent Story acceptance criteria:

- `run_once_invokes_apply_retention_with_policy_from_config` — the policy reaching the backend matches `config.to_policy()`
- `run_once_returns_stats_from_backend_unchanged` — engine forwards `RetentionStats` verbatim (AC #3, engine side)
- `run_once_propagates_dry_run_flag_to_policy` — `dry_run` flag round-trips through to the backend (AC #2, engine side)
- `run_once_surfaces_backend_error` — `StorageError::RetentionError` from the backend propagates out of `run_once`

`FakeBackend` is an in-module `StorageBackend` test double: `apply_retention` captures the policy and returns either canned `RetentionStats` or a primed `StorageError`; every other trait method is `unreachable!()`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy -D warnings`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed — module + per-method doc comments
- [ ] All CI checks passing — pending CI run
- [x] Commits are small and follow the Gitmoji convention — 8 single-concern commits