### PR TITLE
[AAASM-1710] ✨ (aa-gateway): Add SQLite open + parent-dir mkdir helpers in local_mode

### DIFF
--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -209,4 +209,28 @@ mod tests {
             "ensure_storage_parent should mkdir -p the parent tree"
         );
     }
+
+    /// AAASM-1576 AC #3 end-to-end at the helper level: `open_storage`
+    /// must materialise the SQLite file on disk in a fresh directory
+    /// tree, not just open a connection in memory. Uses `tempfile`
+    /// so the test is hermetic — no `~/.aasm/` writes leak from CI.
+    #[tokio::test]
+    async fn open_storage_creates_sqlite_file_in_fresh_tempdir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let db_path = tmp.path().join("nested/local.db");
+
+        // Sanity: neither the parent nor the file exist yet.
+        assert!(!db_path.parent().expect("parent").exists());
+        assert!(!db_path.exists());
+
+        let pool = open_storage(&db_path).await.expect("open_storage");
+
+        assert!(
+            db_path.is_file(),
+            "open_storage should materialise the SQLite file on disk"
+        );
+        assert!(!pool.is_closed(), "open_storage should return an open pool",);
+
+        pool.close().await;
+    }
 }

--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -8,7 +8,7 @@
 //! [`DeploymentMode::Local`]: aa_core::config::DeploymentMode::Local
 
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use axum::{routing::get, Extension, Router};
 use tokio::sync::oneshot;
@@ -89,6 +89,30 @@ pub enum LocalModeError {
 pub(crate) fn router() -> Router {
     let state = HealthzState::new("local", "sqlite");
     Router::new().route("/healthz", get(healthz)).layer(Extension(state))
+}
+
+/// Create the parent directory tree for `path` if it does not yet exist.
+///
+/// Called by [`open_storage`] before opening the SQLite file so that a
+/// developer's first `aasm start --mode local` can write to
+/// `~/.aasm/local.db` even when `~/.aasm/` doesn't exist yet — matches
+/// AAASM-1576 AC #3 (`SQLite file created at ~/.aasm/local.db on first start`).
+///
+/// `path.parent()` returning `None` or an empty path (e.g. a bare
+/// filename like `:memory:`) is a no-op success.
+///
+/// Tilde expansion is not performed here — `aa-core::config::GatewayConfig::
+/// expand_paths()` (AAASM-1691) resolves `~` upstream before this is called.
+#[allow(dead_code)] // consumed by open_storage / start_local — AAASM-1710, AAASM-1725
+pub(crate) fn ensure_storage_parent(path: &Path) -> Result<(), LocalModeError> {
+    let Some(parent) = path.parent() else { return Ok(()) };
+    if parent.as_os_str().is_empty() {
+        return Ok(());
+    }
+    std::fs::create_dir_all(parent).map_err(|source| LocalModeError::Storage {
+        path: path.to_path_buf(),
+        source: sqlx::Error::Io(source),
+    })
 }
 
 #[cfg(test)]

--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -11,6 +11,7 @@ use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 
 use axum::{routing::get, Extension, Router};
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePool};
 use tokio::sync::oneshot;
 
 use crate::routes::healthz::{healthz, HealthzState};
@@ -113,6 +114,32 @@ pub(crate) fn ensure_storage_parent(path: &Path) -> Result<(), LocalModeError> {
         path: path.to_path_buf(),
         source: sqlx::Error::Io(source),
     })
+}
+
+/// Open a SQLite connection pool backing the local control plane.
+///
+/// Calls [`ensure_storage_parent`] so `~/.aasm/` is created on first
+/// start, then opens `SqlitePool` with `create_if_missing(true)` so
+/// the SQLite file itself is materialised on the same call — the
+/// behaviour AAASM-1576 AC #3 requires (`SQLite file created at
+/// ~/.aasm/local.db on first start`).
+///
+/// Migrations are deliberately out of scope here — the durable
+/// storage layer (`E18 S-B`, AAASM-1574) owns the migration runner.
+/// Until that lands, the pool returned here is empty/schema-less; it
+/// satisfies the `/healthz` `"storage": "sqlite"` contract and lets
+/// the later sub-tasks (AAASM-1725, AAASM-1728) treat it as a real
+/// resource that must be opened and closed cleanly.
+#[allow(dead_code)] // consumed by start_local() — AAASM-1725
+pub(crate) async fn open_storage(path: &Path) -> Result<SqlitePool, LocalModeError> {
+    ensure_storage_parent(path)?;
+    let opts = SqliteConnectOptions::new().filename(path).create_if_missing(true);
+    SqlitePool::connect_with(opts)
+        .await
+        .map_err(|source| LocalModeError::Storage {
+            path: path.to_path_buf(),
+            source,
+        })
 }
 
 #[cfg(test)]

--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -188,4 +188,25 @@ mod tests {
             "uptime_secs must be present and a u64; got {body}",
         );
     }
+
+    /// Mirrors the developer's first `aasm start --mode local` —
+    /// `~/.aasm/` does not exist yet, so `ensure_storage_parent`
+    /// must `mkdir -p` the parent tree before the SQLite file can
+    /// be written. Verifies the helper creates nested missing
+    /// directories rather than only the immediate parent.
+    #[test]
+    fn ensure_storage_parent_creates_nested_directories() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let nested = tmp.path().join("a/b/c/local.db");
+
+        // Sanity: the nested parent does not exist yet.
+        assert!(!nested.parent().expect("parent").exists());
+
+        ensure_storage_parent(&nested).expect("ensure_storage_parent");
+
+        assert!(
+            nested.parent().expect("parent").is_dir(),
+            "ensure_storage_parent should mkdir -p the parent tree"
+        );
+    }
 }


### PR DESCRIPTION
## Description

Sub-task 3 of [AAASM-1576](https://lightning-dust-mite.atlassian.net/browse/AAASM-1576) (E17 S-B — Local Dev Mode). Adds the two storage helpers that satisfy AAASM-1576 AC #3 (`SQLite file created at ~/.aasm/local.db on first start`):

- `ensure_storage_parent(path) -> Result<(), LocalModeError>` — `mkdir -p` the parent directory tree.
- `open_storage(path).await -> Result<SqlitePool, LocalModeError>` — `SqliteConnectOptions::new().filename(path).create_if_missing(true)` behind the `LocalModeError` facade. Calls `ensure_storage_parent` first.

**Scope adjustment vs original Sub-task description:** the original plan included a `resolve_storage_path(&Path) -> PathBuf` that did `~`-expansion. That logic is already in `aa-core::config::GatewayConfig::expand_paths()` (delivered by [AAASM-1691](https://lightning-dust-mite.atlassian.net/browse/AAASM-1691) in S-A), so `LocalModeConfig::storage_path` is already absolute by the time `start_local()` (AAASM-1725) calls `open_storage()`. Adding a sibling `resolve_storage_path` here would duplicate that logic and risk drift. This PR therefore skips the tilde piece and ships only the on-disk pieces (`mkdir` + `SqlitePool`).

Migrations are deliberately deferred to E18 S-B ([AAASM-1574](https://lightning-dust-mite.atlassian.net/browse/AAASM-1574)). The pool returned here is schema-less for now — it satisfies the `/healthz` `"storage": "sqlite"` contract and gives `start_local()` (AAASM-1725) a real `SqlitePool` to own and `run_until_shutdown()` (AAASM-1728) a real resource to close cleanly.

Delivered in four granular commits:

1. `✨ (aa-gateway/local_mode): Add ensure_storage_parent() — create parent dir tree`
2. `✨ (aa-gateway/local_mode): Add open_storage() — SqlitePool opener with create-if-missing`
3. `✅ (aa-gateway/local_mode): Test ensure_storage_parent creates nested directories`
4. `✅ (aa-gateway/local_mode): Test open_storage creates SQLite file in fresh tempdir`

```text
$ cargo nextest run -p aa-gateway local_mode
        PASS local_mode::tests::ensure_storage_parent_creates_nested_directories
        PASS local_mode::tests::open_storage_creates_sqlite_file_in_fresh_tempdir
        PASS local_mode::tests::router_serves_healthz_with_local_mode_json
     Summary 3 tests run: 3 passed, 839 skipped
```

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Pure additive change. Two new `pub(crate)` helpers in `aa_gateway::local_mode`, no public API touched. No dependency changes — `sqlx` and `tempfile` were already present.

## Related Issues

- Related Jira ticket: [AAASM-1710](https://lightning-dust-mite.atlassian.net/browse/AAASM-1710) (this Sub-task)
- Parent Story: [AAASM-1576](https://lightning-dust-mite.atlassian.net/browse/AAASM-1576) (E17 S-B)
- Parent Epic: [AAASM-1568](https://lightning-dust-mite.atlassian.net/browse/AAASM-1568) (E17)
- Coordinates with: [AAASM-1574](https://lightning-dust-mite.atlassian.net/browse/AAASM-1574) (E18 S-B — durable SQLite backend, migrations out of scope here)

## Testing

- [x] Unit tests added / updated — two new `#[tokio::test]` / `#[test]` cases in `local_mode::tests`. Both use `tempfile::tempdir()` for hermetic on-disk checks.
- [ ] Integration tests added / updated — N/A for this helper-only Sub-task.
- [x] Manual testing performed — `cargo build -p aa-gateway`, `cargo clippy -p aa-gateway --all-targets -- -D warnings`, `cargo nextest run -p aa-gateway local_mode` all green locally.
- [ ] No tests required (explain why)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`) — lefthook fmt + clippy passed on every commit.
- [x] Self-review of the diff completed.
- [x] Documentation updated if behaviour changed — rustdoc on both new helpers explains the scope choice (tilde upstream, migrations downstream).
- [x] All CI checks passing — pending CI verification on this PR.
- [x] Commits are small and follow the Gitmoji convention — 4 commits, each scoped to one helper or one test.

## Sub-task acceptance criteria (AAASM-1710, adjusted)

- [x] `ensure_storage_parent` creates the parent directory tree (including nested missing dirs) — `ensure_storage_parent_creates_nested_directories` test.
- [x] `open_storage(tmp_path).await?` succeeds and the SQLite file exists on disk afterwards — `open_storage_creates_sqlite_file_in_fresh_tempdir` test.
- [x] `cargo nextest run -p aa-gateway local_mode::tests::ensure_storage_parent` / `local_mode::tests::open_storage` green.

The original Sub-task description had two ACs about `resolve_storage_path` (tilde expansion + identity on absolute paths). Those are deliberately not retested here because the underlying logic lives in `aa-core` and is already covered by `aa-core::config::tests` from AAASM-1691.

[AAASM-1576]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1691]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1574]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ