### PR TITLE
[AAASM-1724] ✨ (storage): Add PostgreSQL initial schema and migrate()

### DIFF
--- a/aa-gateway/migrations/postgres/0001_initial.sql
+++ b/aa-gateway/migrations/postgres/0001_initial.sql
@@ -1,0 +1,59 @@
+-- E18 S-C #2 — Initial PostgreSQL schema for the gateway storage backend.
+--
+-- All DDL uses IF NOT EXISTS so the file can be replayed safely against
+-- an already-migrated database. sqlx::migrate! also tracks applied
+-- versions in _sqlx_migrations, so this file would normally only run
+-- once per database.
+--
+-- audit_events and metrics are plain tables here; E18 S-D upgrades them
+-- to TimescaleDB hypertables via a follow-up migration.
+
+-- ───────────────────────── Agent Registry ──────────────────────────────
+CREATE TABLE IF NOT EXISTS agent_registry (
+    agent_id         TEXT PRIMARY KEY,
+    team_id          TEXT,
+    org_id           TEXT,
+    metadata         JSONB NOT NULL DEFAULT '{}',
+    registered_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_seen_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    enforcement_mode TEXT NOT NULL DEFAULT 'enforce'
+);
+CREATE INDEX IF NOT EXISTS idx_registry_team ON agent_registry(team_id);
+
+-- ───────────────────────── Policy Versions ─────────────────────────────
+CREATE TABLE IF NOT EXISTS policy_versions (
+    id         BIGSERIAL PRIMARY KEY,
+    name       TEXT NOT NULL,
+    version    INT NOT NULL,
+    document   JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    is_active  BOOLEAN NOT NULL DEFAULT false,
+    UNIQUE (name, version)
+);
+
+-- ───────────────────────── Audit Events ────────────────────────────────
+-- E18 S-D will convert this table to a TimescaleDB hypertable on `ts`.
+CREATE TABLE IF NOT EXISTS audit_events (
+    ts              TIMESTAMPTZ NOT NULL,
+    event_id        UUID NOT NULL,
+    agent_id        TEXT NOT NULL,
+    team_id         TEXT,
+    action          TEXT NOT NULL,
+    decision        TEXT NOT NULL,
+    dry_run         BOOLEAN NOT NULL DEFAULT false,
+    shadow_decision TEXT,
+    matched_rule_id TEXT,
+    payload         JSONB,
+    PRIMARY KEY (ts, event_id)
+);
+CREATE INDEX IF NOT EXISTS idx_audit_agent ON audit_events(agent_id, ts DESC);
+
+-- ───────────────────────── Metrics ─────────────────────────────────────
+-- E18 S-D will convert this table to a TimescaleDB hypertable on `ts`.
+CREATE TABLE IF NOT EXISTS metrics (
+    ts       TIMESTAMPTZ NOT NULL,
+    agent_id TEXT NOT NULL,
+    metric   TEXT NOT NULL,
+    value    DOUBLE PRECISION NOT NULL,
+    labels   JSONB NOT NULL DEFAULT '{}'
+);

--- a/aa-gateway/src/storage/postgres.rs
+++ b/aa-gateway/src/storage/postgres.rs
@@ -125,4 +125,13 @@ mod tests {
             assert!(exists, "table {table} should exist after migrate()");
         }
     }
+
+    #[tokio::test]
+    async fn migrate_is_idempotent() {
+        let Some(backend) = pg_backend_or_skip().await else {
+            return;
+        };
+        backend.migrate().await.expect("first migrate");
+        backend.migrate().await.expect("second migrate should be a no-op");
+    }
 }

--- a/aa-gateway/src/storage/postgres.rs
+++ b/aa-gateway/src/storage/postgres.rs
@@ -1,8 +1,10 @@
 //! PostgreSQL-backed implementation of [`StorageBackend`](super::backend::StorageBackend).
 //!
-//! Only the constructor lands in this sub-task (Epic 18 S-C #1). The
+//! Sub-task progress: `connect()` (E18 S-C #1) and `migrate()` (E18 S-C #2)
+//! are implemented as inherent methods. The full
 //! [`StorageBackend`](super::backend::StorageBackend) trait impl is built up
-//! incrementally across sub-tasks #2 – #7.
+//! incrementally across sub-tasks #3 – #7 and consolidated into an
+//! `impl StorageBackend for PostgresBackend` block at the end.
 
 use std::time::Duration;
 

--- a/aa-gateway/src/storage/postgres.rs
+++ b/aa-gateway/src/storage/postgres.rs
@@ -18,8 +18,6 @@ use super::postgres_config::PostgresConfig;
 /// registry / policy / metrics / lifecycle methods) is filled in by the
 /// later Epic-18 S-C sub-tasks.
 pub struct PostgresBackend {
-    // Wired into trait method implementations in E18 S-C #2 onward.
-    #[allow(dead_code)]
     pool: PgPool,
 }
 
@@ -46,6 +44,22 @@ impl PostgresBackend {
             .map_err(|e| StorageError::ConnectionFailed(e.to_string()))?;
 
         Ok(Self { pool })
+    }
+
+    /// Apply the embedded `migrations/postgres/*.sql` migrations.
+    ///
+    /// Idempotent — sqlx records applied versions in `_sqlx_migrations`,
+    /// so calling this against an already-migrated database is a no-op.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError::MigrationFailed`] when any migration fails
+    /// to apply or sqlx cannot verify previously-applied versions.
+    pub async fn migrate(&self) -> StorageResult<()> {
+        sqlx::migrate!("./migrations/postgres")
+            .run(&self.pool)
+            .await
+            .map_err(|e| StorageError::MigrationFailed(e.to_string()))
     }
 }
 

--- a/aa-gateway/src/storage/postgres.rs
+++ b/aa-gateway/src/storage/postgres.rs
@@ -67,6 +67,31 @@ impl PostgresBackend {
 mod tests {
     use super::*;
 
+    /// Returns a connected backend when `AAASM_DATABASE_URL` is set, or `None`
+    /// after printing a skip notice when the env var is absent. This lets the
+    /// suite stay green on developer machines without a local PostgreSQL while
+    /// still exercising the real driver in CI.
+    async fn pg_backend_or_skip() -> Option<PostgresBackend> {
+        let url = match std::env::var("AAASM_DATABASE_URL") {
+            Ok(v) => v,
+            Err(_) => {
+                eprintln!(
+                    "skipping postgres test: AAASM_DATABASE_URL not set (CI provides this via services: postgres)"
+                );
+                return None;
+            }
+        };
+        let config = PostgresConfig {
+            database_url: Some(url),
+            ..PostgresConfig::default()
+        };
+        Some(
+            PostgresBackend::connect(&config)
+                .await
+                .expect("connect to AAASM_DATABASE_URL"),
+        )
+    }
+
     #[tokio::test]
     async fn connect_rejects_missing_database_url() {
         let config = PostgresConfig::default();
@@ -80,6 +105,24 @@ mod tests {
             }
             Err(other) => panic!("expected ConnectionFailed, got {other:?}"),
             Ok(_) => panic!("expected error when database_url is None"),
+        }
+    }
+
+    #[tokio::test]
+    async fn migrate_creates_expected_tables() {
+        let Some(backend) = pg_backend_or_skip().await else {
+            return;
+        };
+        backend.migrate().await.expect("migrate");
+
+        for table in ["agent_registry", "policy_versions", "audit_events", "metrics"] {
+            let exists: bool =
+                sqlx::query_scalar("SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_tables WHERE tablename = $1)")
+                    .bind(table)
+                    .fetch_one(&backend.pool)
+                    .await
+                    .expect("query pg_tables");
+            assert!(exists, "table {table} should exist after migrate()");
         }
     }
 }


### PR DESCRIPTION
## Description

E18 S-C sub-task #2 — adds the initial PostgreSQL schema (`agent_registry`, `policy_versions`, `audit_events`, `metrics` + their indexes) and wires `PostgresBackend::migrate()` to `sqlx::migrate!` so the gateway can stand up an empty database into a usable state on startup. The hypertable conversion for `audit_events` / `metrics` is deferred to E18 S-D as noted in the SQL comments.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

## Related Issues

- Related Jira ticket: AAASM-1724 (sub-task of AAASM-1585, Epic AAASM-1569)
- Related GitHub issues: n/a

## Commits

| # | Subject |
|---|---------|
| 1 | ✨ (storage): Add PostgreSQL initial schema migration 0001_initial |
| 2 | ✨ (storage): Implement PostgresBackend::migrate via sqlx::migrate! |
| 3 | ✅ (storage): Test PostgresBackend::migrate creates expected tables |
| 4 | ✅ (storage): Test PostgresBackend::migrate is idempotent |
| 5 | 📝 (storage): Update postgres module doc — migrate() landed in S-C #2 |

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated (env-gated on `AAASM_DATABASE_URL`)
- [x] Manual testing performed
- [ ] No tests required

Local verification — with `AAASM_DATABASE_URL` unset (default for dev machines):

\`\`\`
cargo nextest run -p aa-gateway storage::postgres::tests
  PASS connect_rejects_missing_database_url
  PASS migrate_creates_expected_tables   # printed skip notice, returned Ok
  PASS migrate_is_idempotent             # printed skip notice, returned Ok
\`\`\`

Local verification — with a real PostgreSQL 15 in Docker:

\`\`\`
docker run -d --rm --name aaasm-test-pg -e POSTGRES_USER=aasm \\
  -e POSTGRES_PASSWORD=aasm -e POSTGRES_DB=aasm_test -p 54329:5432 postgres:15-alpine

AAASM_DATABASE_URL='postgres://aasm:aasm@localhost:54329/aasm_test' \\
  cargo nextest run -p aa-gateway storage::postgres::tests
  PASS connect_rejects_missing_database_url
  PASS migrate_is_idempotent              # 129 ms — actually re-ran the migration check
  PASS migrate_creates_expected_tables    # 132 ms — actually created the tables
\`\`\`

Plus `cargo clippy -p aa-gateway --all-targets --all-features -- -D warnings` and `cargo fmt --all -- --check`: clean.

## Checklist

- [x] Code follows project style guidelines (\`cargo fmt\`, \`cargo clippy\`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (module doc bumped to reflect migrate() landing)
- [ ] All CI checks passing — pending CI run
- [x] Commits are small and follow the Gitmoji convention

## Acceptance for this sub-task

- [x] Migration applies on an empty database without errors (verified with Docker PG locally).
- [x] Re-running \`migrate()\` against an already-migrated DB is a no-op (\`migrate_is_idempotent\`).
- [x] \`cargo nextest run -p aa-gateway storage::postgres::tests\` green with PG running.
- [x] Tests are skipped gracefully when \`AAASM_DATABASE_URL\` is not set.

## Next sub-task

AAASM-1727 (E18 S-C #3) — audit-event ops (\`append_audit_event\` / \`query_audit_events\` / \`count_audit_events\`) — branches off \`master\` after this PR merges.