### PR TITLE
[AAASM-1716] ✨ (aa-gateway): Add PolicyCache Redis backend with TTL + startup fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,6 +959,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5068,11 +5077,14 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72d32a1ac9123f0d84fda64bfc02a271d9868483162dd2d9099b5c362ece064c"
 dependencies = [
+ "arc-swap",
  "arcstr",
  "async-lock",
+ "backon",
  "bytes",
  "cfg-if",
  "combine",
+ "futures-channel",
  "futures-util",
  "itoa",
  "percent-encoding",

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -48,7 +48,7 @@ utoipa       = { version = "5", features = ["axum_extras"] }
 axum         = "0.8"
 axum-server  = { version = "0.7", features = ["tls-rustls"] }
 x509-parser  = "0.18"
-redis        = { version = "1.2", default-features = false, features = ["tokio-comp"], optional = true }
+redis        = { version = "1.2", default-features = false, features = ["tokio-comp", "connection-manager"], optional = true }
 
 [dev-dependencies]
 criterion    = { version = "0.8", features = ["async_tokio"] }

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -54,6 +54,7 @@ redis        = { version = "1.2", default-features = false, features = ["tokio-c
 criterion    = { version = "0.8", features = ["async_tokio"] }
 proptest     = "1"
 tempfile     = "3"
+tokio        = { version = "1", features = ["test-util", "macros", "rt-multi-thread"] }
 tokio-stream = "0.1"
 insta        = "1"
 tower        = { version = "0.5", features = ["util"] }

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -548,5 +548,23 @@ mod tests {
                 Err(err) => assert!(matches!(err, StorageError::ConnectionFailed(_))),
             }
         }
+
+        #[tokio::test]
+        async fn from_config_async_falls_back_to_disabled_on_bad_url() {
+            // `127.0.0.1:1` is reserved and consistently refuses connections,
+            // which exercises the runtime-failure branch — not the URL-parse
+            // branch.
+            let config = RedisConfig {
+                enabled: true,
+                url: Some("redis://127.0.0.1:1".into()),
+                ..RedisConfig::default()
+            };
+            let cache = PolicyCache::from_config_async(&config).await;
+            assert!(
+                matches!(cache, PolicyCache::Disabled),
+                "connect failure must fall back to Disabled, not panic"
+            );
+            assert!(!cache.is_enabled());
+        }
     }
 }

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -504,5 +504,18 @@ mod tests {
             cache.invalidate("default").await;
             assert!(cache.get("default").await.is_none());
         }
+
+        #[tokio::test(start_paused = true)]
+        async fn entry_expires_after_ttl() {
+            use tokio::time::Duration;
+            let cache = StubPolicyCache::new(30);
+            cache.set(&doc("default", b"v1-body")).await;
+            assert!(cache.get("default").await.is_some());
+            tokio::time::advance(Duration::from_secs(31)).await;
+            assert!(
+                cache.get("default").await.is_none(),
+                "entry must expire once ttl_secs elapses"
+            );
+        }
     }
 }

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -1,18 +1,18 @@
 //! Optional Redis-backed policy cache for the gateway.
 //!
-//! This module ships in stages across Epic-18 Story S-G:
-//!
-//! - First commit: the [`RedisConfig`] value type and the OFF default posture.
-//! - Second commit: content-addressed cache key derivation.
-//! - This commit: the [`PolicyCacheLike`] trait + [`PolicyCache`] enum,
-//!   shipped with the `Disabled` no-op variant only.
-//! - Final commit: the Redis-backed variant of [`PolicyCache`].
+//! The cache ships under the `redis-cache` Cargo feature. With the feature
+//! off the gateway still compiles and runs against [`PolicyCache::Disabled`],
+//! a no-op implementation that lets the rest of the codebase write
+//! cache-aware code unconditionally.
 //!
 //! The cache is **off by default** — the gateway should always be runnable
 //! without a Redis process. Production deployments opt in by setting
 //! `storage.redis.enabled = true` and providing a reachable URL.
 
 use async_trait::async_trait;
+
+#[cfg(feature = "redis-cache")]
+use redis::aio::ConnectionManager;
 
 use super::policy::PolicyDocument;
 
@@ -165,6 +165,18 @@ pub fn policy_cache_key(name: &str, bytes: &[u8]) -> String {
 /// previous content hash.
 pub fn policy_invalidation_pattern(name: &str) -> String {
     format!("policy:{name}:*")
+}
+
+/// Redis-backed policy cache.
+///
+/// Only available with the `redis-cache` Cargo feature. The struct holds a
+/// cloneable [`ConnectionManager`] (the redis-rs multiplexed handle) and the
+/// per-entry TTL pulled from [`RedisConfig::policy_cache_ttl_secs`].
+#[cfg(feature = "redis-cache")]
+#[allow(dead_code)] // fields consumed by `connect` + `PolicyCacheLike` impls in the next commits
+pub struct RedisPolicyCache {
+    conn: ConnectionManager,
+    ttl_secs: u64,
 }
 
 #[cfg(test)]

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -55,6 +55,9 @@ pub enum PolicyCache {
     /// No-op cache — `get` always returns `None`, `set` and `invalidate`
     /// are no-ops, `is_enabled` returns `false`.
     Disabled,
+    /// Redis-backed cache. Only available with the `redis-cache` feature.
+    #[cfg(feature = "redis-cache")]
+    Redis(RedisPolicyCache),
 }
 
 #[async_trait]
@@ -62,24 +65,32 @@ impl PolicyCacheLike for PolicyCache {
     async fn get(&self, _name: &str) -> Option<PolicyDocument> {
         match self {
             Self::Disabled => None,
+            #[cfg(feature = "redis-cache")]
+            Self::Redis(cache) => cache.get(_name).await,
         }
     }
 
     async fn set(&self, _doc: &PolicyDocument) {
         match self {
             Self::Disabled => {}
+            #[cfg(feature = "redis-cache")]
+            Self::Redis(cache) => cache.set(_doc).await,
         }
     }
 
     async fn invalidate(&self, _name: &str) {
         match self {
             Self::Disabled => {}
+            #[cfg(feature = "redis-cache")]
+            Self::Redis(cache) => cache.invalidate(_name).await,
         }
     }
 
     fn is_enabled(&self) -> bool {
         match self {
             Self::Disabled => false,
+            #[cfg(feature = "redis-cache")]
+            Self::Redis(_) => true,
         }
     }
 }

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -169,6 +169,17 @@ pub fn policy_invalidation_pattern(name: &str) -> String {
     format!("policy:{name}:*")
 }
 
+/// Direct Redis key under which the currently-active cached document for
+/// `name` lives.
+///
+/// The active-key scheme uses `policy:{name}` (no hash suffix) so `get`,
+/// `set`, and `invalidate` all operate on a single, deterministic key. The
+/// content-hash helpers above remain available as building blocks for any
+/// future multi-version cache scheme.
+pub fn active_policy_key(name: &str) -> String {
+    format!("policy:{name}")
+}
+
 /// Redis-backed policy cache.
 ///
 /// Only available with the `redis-cache` Cargo feature. The struct holds a
@@ -214,9 +225,15 @@ impl RedisPolicyCache {
 #[cfg(feature = "redis-cache")]
 #[async_trait]
 impl PolicyCacheLike for RedisPolicyCache {
-    async fn get(&self, _name: &str) -> Option<PolicyDocument> {
-        // Filled in by the next commit (SCAN+GET).
-        None
+    async fn get(&self, name: &str) -> Option<PolicyDocument> {
+        use redis::AsyncCommands;
+        let mut conn = self.conn.clone();
+        let key = active_policy_key(name);
+        let bytes: redis::RedisResult<Option<Vec<u8>>> = conn.get(&key).await;
+        bytes.ok().flatten().map(|b| PolicyDocument {
+            name: name.into(),
+            bytes: b,
+        })
     }
 
     async fn set(&self, _doc: &PolicyDocument) {

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -175,7 +175,7 @@ pub fn policy_invalidation_pattern(name: &str) -> String {
 /// cloneable [`ConnectionManager`] (the redis-rs multiplexed handle) and the
 /// per-entry TTL pulled from [`RedisConfig::policy_cache_ttl_secs`].
 #[cfg(feature = "redis-cache")]
-#[allow(dead_code)] // `conn` is consumed by the `PolicyCacheLike` impl added next.
+#[allow(dead_code)] // `conn` and `ttl_secs` are wired up by the next get/set commits.
 pub struct RedisPolicyCache {
     conn: ConnectionManager,
     ttl_secs: u64,
@@ -208,6 +208,27 @@ impl RedisPolicyCache {
     #[cfg(test)]
     pub fn ttl_secs(&self) -> u64 {
         self.ttl_secs
+    }
+}
+
+#[cfg(feature = "redis-cache")]
+#[async_trait]
+impl PolicyCacheLike for RedisPolicyCache {
+    async fn get(&self, _name: &str) -> Option<PolicyDocument> {
+        // Filled in by the next commit (SCAN+GET).
+        None
+    }
+
+    async fn set(&self, _doc: &PolicyDocument) {
+        // Filled in by a following commit (invalidate-then-SETEX).
+    }
+
+    async fn invalidate(&self, _name: &str) {
+        // Filled in by a following commit (SCAN+DEL).
+    }
+
+    fn is_enabled(&self) -> bool {
+        true
     }
 }
 

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -14,6 +14,8 @@ use async_trait::async_trait;
 #[cfg(feature = "redis-cache")]
 use redis::aio::ConnectionManager;
 
+#[cfg(feature = "redis-cache")]
+use super::error::{StorageError, StorageResult};
 use super::policy::PolicyDocument;
 
 /// Behaviour every policy cache implementation must provide.
@@ -173,10 +175,40 @@ pub fn policy_invalidation_pattern(name: &str) -> String {
 /// cloneable [`ConnectionManager`] (the redis-rs multiplexed handle) and the
 /// per-entry TTL pulled from [`RedisConfig::policy_cache_ttl_secs`].
 #[cfg(feature = "redis-cache")]
-#[allow(dead_code)] // fields consumed by `connect` + `PolicyCacheLike` impls in the next commits
+#[allow(dead_code)] // `conn` is consumed by the `PolicyCacheLike` impl added next.
 pub struct RedisPolicyCache {
     conn: ConnectionManager,
     ttl_secs: u64,
+}
+
+#[cfg(feature = "redis-cache")]
+impl RedisPolicyCache {
+    /// Establish a Redis connection from `config` and wrap it in a
+    /// [`ConnectionManager`].
+    ///
+    /// Returns [`StorageError::ConnectionFailed`] when `config.url` is `None`
+    /// or the URL cannot be parsed, and when the connection manager cannot
+    /// complete its initial handshake.
+    pub async fn connect(config: &RedisConfig) -> StorageResult<Self> {
+        let url = config.url.as_deref().ok_or_else(|| {
+            StorageError::ConnectionFailed("storage.redis.url is required when redis.enabled = true".into())
+        })?;
+        let client = redis::Client::open(url).map_err(|e| StorageError::ConnectionFailed(e.to_string()))?;
+        let conn = client
+            .get_connection_manager()
+            .await
+            .map_err(|e| StorageError::ConnectionFailed(e.to_string()))?;
+        Ok(Self {
+            conn,
+            ttl_secs: config.policy_cache_ttl_secs,
+        })
+    }
+
+    /// Expose the configured TTL — useful in tests and for debug introspection.
+    #[cfg(test)]
+    pub fn ttl_secs(&self) -> u64 {
+        self.ttl_secs
+    }
 }
 
 #[cfg(test)]

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -496,5 +496,13 @@ mod tests {
             assert_eq!(fetched.bytes, b"v1-body".to_vec());
             assert!(cache.is_enabled());
         }
+
+        #[tokio::test]
+        async fn invalidate_evicts_entry() {
+            let cache = StubPolicyCache::new(30);
+            cache.set(&doc("default", b"v1-body")).await;
+            cache.invalidate("default").await;
+            assert!(cache.get("default").await.is_none());
+        }
     }
 }

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -236,8 +236,17 @@ impl PolicyCacheLike for RedisPolicyCache {
         })
     }
 
-    async fn set(&self, _doc: &PolicyDocument) {
-        // Filled in by a following commit (invalidate-then-SETEX).
+    async fn set(&self, doc: &PolicyDocument) {
+        use redis::AsyncCommands;
+        let mut conn = self.conn.clone();
+        let key = active_policy_key(&doc.name);
+        // SET with EX (TTL in seconds). Best-effort — driver errors are
+        // logged at debug and otherwise swallowed; callers still see a
+        // consistent view through the authoritative store on cache miss.
+        let result: redis::RedisResult<()> = conn.set_ex(&key, &doc.bytes, self.ttl_secs).await;
+        if let Err(err) = result {
+            tracing::debug!(error = %err, key = %key, "redis policy cache set failed");
+        }
     }
 
     async fn invalidate(&self, _name: &str) {

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -421,4 +421,80 @@ mod tests {
             assert!(!cache.is_enabled());
         }
     }
+
+    /// HashMap-backed [`PolicyCacheLike`] stub used to exercise the trait
+    /// contract without a live Redis server. Honours TTL via
+    /// `tokio::time::Instant` so tests can fast-forward through
+    /// `tokio::time::advance` instead of sleeping.
+    mod stub {
+        use super::*;
+        use std::collections::HashMap;
+        use std::sync::Mutex;
+        use tokio::time::{Duration, Instant};
+
+        pub struct StubPolicyCache {
+            ttl: Duration,
+            store: Mutex<HashMap<String, (Vec<u8>, Instant)>>,
+        }
+
+        impl StubPolicyCache {
+            pub fn new(ttl_secs: u64) -> Self {
+                Self {
+                    ttl: Duration::from_secs(ttl_secs),
+                    store: Mutex::new(HashMap::new()),
+                }
+            }
+        }
+
+        #[async_trait]
+        impl PolicyCacheLike for StubPolicyCache {
+            async fn get(&self, name: &str) -> Option<PolicyDocument> {
+                let guard = self.store.lock().expect("stub lock");
+                let (bytes, expires_at) = guard.get(name)?;
+                if *expires_at <= Instant::now() {
+                    return None;
+                }
+                Some(PolicyDocument {
+                    name: name.into(),
+                    bytes: bytes.clone(),
+                })
+            }
+
+            async fn set(&self, doc: &PolicyDocument) {
+                let mut guard = self.store.lock().expect("stub lock");
+                guard.insert(doc.name.clone(), (doc.bytes.clone(), Instant::now() + self.ttl));
+            }
+
+            async fn invalidate(&self, name: &str) {
+                let mut guard = self.store.lock().expect("stub lock");
+                guard.remove(name);
+            }
+
+            fn is_enabled(&self) -> bool {
+                true
+            }
+        }
+    }
+
+    mod contract {
+        use super::stub::StubPolicyCache;
+        use super::*;
+
+        fn doc(name: &str, body: &[u8]) -> PolicyDocument {
+            PolicyDocument {
+                name: name.into(),
+                bytes: body.to_vec(),
+            }
+        }
+
+        #[tokio::test]
+        async fn round_trip_set_then_get() {
+            let cache = StubPolicyCache::new(30);
+            cache.set(&doc("default", b"v1-body")).await;
+            let fetched = cache.get("default").await.expect("cached entry present");
+            assert_eq!(fetched.name, "default");
+            assert_eq!(fetched.bytes, b"v1-body".to_vec());
+            assert!(cache.is_enabled());
+        }
+    }
 }

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -535,5 +535,18 @@ mod tests {
                 Err(err) => assert!(matches!(err, StorageError::ConnectionFailed(_))),
             }
         }
+
+        #[tokio::test]
+        async fn connect_with_malformed_url_returns_connection_failed() {
+            let config = RedisConfig {
+                enabled: true,
+                url: Some("not-a-redis-url".into()),
+                ..RedisConfig::default()
+            };
+            match RedisPolicyCache::connect(&config).await {
+                Ok(_) => panic!("malformed URL must surface as ConnectionFailed"),
+                Err(err) => assert!(matches!(err, StorageError::ConnectionFailed(_))),
+            }
+        }
     }
 }

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -186,7 +186,6 @@ pub fn active_policy_key(name: &str) -> String {
 /// cloneable [`ConnectionManager`] (the redis-rs multiplexed handle) and the
 /// per-entry TTL pulled from [`RedisConfig::policy_cache_ttl_secs`].
 #[cfg(feature = "redis-cache")]
-#[allow(dead_code)] // `conn` and `ttl_secs` are wired up by the next get/set commits.
 pub struct RedisPolicyCache {
     conn: ConnectionManager,
     ttl_secs: u64,

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -248,8 +248,14 @@ impl PolicyCacheLike for RedisPolicyCache {
         }
     }
 
-    async fn invalidate(&self, _name: &str) {
-        // Filled in by a following commit (SCAN+DEL).
+    async fn invalidate(&self, name: &str) {
+        use redis::AsyncCommands;
+        let mut conn = self.conn.clone();
+        let key = active_policy_key(name);
+        let result: redis::RedisResult<()> = conn.del(&key).await;
+        if let Err(err) = result {
+            tracing::debug!(error = %err, key = %key, "redis policy cache invalidate failed");
+        }
     }
 
     fn is_enabled(&self) -> bool {

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -518,4 +518,22 @@ mod tests {
             );
         }
     }
+
+    #[cfg(feature = "redis-cache")]
+    mod redis_backend {
+        use super::*;
+
+        #[tokio::test]
+        async fn connect_with_none_url_returns_connection_failed() {
+            let config = RedisConfig {
+                enabled: true,
+                url: None,
+                ..RedisConfig::default()
+            };
+            match RedisPolicyCache::connect(&config).await {
+                Ok(_) => panic!("None URL must surface as ConnectionFailed"),
+                Err(err) => assert!(matches!(err, StorageError::ConnectionFailed(_))),
+            }
+        }
+    }
 }

--- a/aa-gateway/src/storage/cache.rs
+++ b/aa-gateway/src/storage/cache.rs
@@ -103,18 +103,56 @@ impl Default for PolicyCache {
 }
 
 impl PolicyCache {
-    /// Build a cache handle from `config`. When `config.enabled` is `false`
-    /// (the default), this returns [`PolicyCache::Disabled`] without
-    /// touching Redis. The `enabled = true` branch lands in Epic-18 S-G
-    /// sub-task 4.
+    /// Build a cache handle from `config` without touching the network.
+    ///
+    /// When `config.enabled` is `false` (the default), this returns
+    /// [`PolicyCache::Disabled`]. When `enabled = true` and the
+    /// `redis-cache` feature is on, the synchronous `from_config` cannot
+    /// run async I/O — callers should use [`PolicyCache::from_config_async`]
+    /// to attempt the Redis connection. The sync constructor here still
+    /// returns `Disabled` for the enabled case, matching the safe posture
+    /// callers see if they forget to switch to the async constructor.
     pub fn from_config(config: &RedisConfig) -> Self {
         if !config.enabled {
             return Self::Disabled;
         }
-        // TODO(AAASM-1716, S-G sub-task 4): attempt the Redis connection.
-        // Until then, treat enabled-but-unimplemented as Disabled so the
-        // gateway never tries to talk to a non-existent backend.
+        // The enabled branch requires async I/O — see `from_config_async`.
         Self::Disabled
+    }
+
+    /// Build a cache handle, attempting the Redis connection when enabled.
+    ///
+    /// * `config.enabled = false` → returns [`PolicyCache::Disabled`].
+    /// * `config.enabled = true` and the `redis-cache` feature is on → tries
+    ///   to open a [`RedisPolicyCache`]. On connection failure, logs a
+    ///   `tracing::warn!` and returns [`PolicyCache::Disabled`] so the
+    ///   gateway can still serve requests via the authoritative store.
+    /// * `config.enabled = true` and the feature is off → logs a warning
+    ///   and returns [`PolicyCache::Disabled`].
+    pub async fn from_config_async(config: &RedisConfig) -> Self {
+        if !config.enabled {
+            return Self::Disabled;
+        }
+        #[cfg(feature = "redis-cache")]
+        {
+            match RedisPolicyCache::connect(config).await {
+                Ok(cache) => Self::Redis(cache),
+                Err(err) => {
+                    tracing::warn!(
+                        error = %err,
+                        "redis policy cache connect failed — falling back to disabled cache"
+                    );
+                    Self::Disabled
+                }
+            }
+        }
+        #[cfg(not(feature = "redis-cache"))]
+        {
+            tracing::warn!(
+                "storage.redis.enabled = true but the `redis-cache` feature is not compiled in; falling back to disabled cache"
+            );
+            Self::Disabled
+        }
     }
 }
 


### PR DESCRIPTION
## Description

Fourth slice of Epic-18 Story S-G (`AAASM-1589`). Implements the Redis-backed policy cache and the startup-warning fallback path.

* `RedisPolicyCache` struct (feature-gated under `redis-cache`) wraps a cloneable `redis::aio::ConnectionManager` plus the per-entry TTL from `RedisConfig`.
* `RedisPolicyCache::connect` validates `config.url`, opens a `redis::Client`, builds a `ConnectionManager`, and maps every driver error to `StorageError::ConnectionFailed`.
* `PolicyCacheLike` implementation: `get` via `GET policy:{name}`, `set` via `SET … EX ttl_secs`, `invalidate` via `DEL`. All driver errors on writes are logged at `debug` and swallowed — the cache is a hint, never a correctness gate.
* New `PolicyCache::Redis(RedisPolicyCache)` enum variant + match-arm wiring, all cfg-gated.
* New `PolicyCache::from_config_async` runs the connection attempt when `enabled = true`; on failure it logs `tracing::warn!` and falls back to `PolicyCache::Disabled` (Story AC #4).
* `aa-gateway/Cargo.toml` adds the `connection-manager` redis feature (required for `ConnectionManager`) and adds `tokio` to dev-dependencies with `test-util` for simulated-time tests.

Stacked on top of #682 (AAASM-1707).

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Jira: AAASM-1716 / AAASM-1589 / AAASM-1569

## Testing

- [x] **17/17** cache tests pass with `--features redis-cache` (6 new in this PR + 11 carried).
- [x] `cargo build -p aa-gateway` (default features, no `redis` crate compiled in) green.
- [x] `cargo build -p aa-gateway --features redis-cache` green.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` green per commit via lefthook pre-commit.
- [x] `cargo doc --workspace --no-deps` green via lefthook pre-push.
- New tests added in this PR:
  * `contract::round_trip_set_then_get`, `::invalidate_evicts_entry`, `::entry_expires_after_ttl` — HashMap-backed stub honours the `PolicyCacheLike` contract (TTL via `tokio::time::advance`, no real Redis).
  * `redis_backend::connect_with_none_url_returns_connection_failed`, `::connect_with_malformed_url_returns_connection_failed`, `::from_config_async_falls_back_to_disabled_on_bad_url`.

## Commits in this PR (17 new)

1. `🔧 Enable redis connection-manager feature`
2. `✨ Add RedisPolicyCache struct under redis-cache feature`
3. `✨ Add RedisPolicyCache::connect`
4. `✨ Add PolicyCacheLike impl skeleton for RedisPolicyCache`
5. `✨ Implement RedisPolicyCache::get via GET active_policy_key`
6. `✨ Implement RedisPolicyCache::set via SET EX`
7. `♻️ Lift transient allow(dead_code) on RedisPolicyCache`
8. `✨ Implement RedisPolicyCache::invalidate via DEL`
9. `✨ Wire PolicyCache::Redis variant into match arms`
10. `✨ Add PolicyCache::from_config_async with Redis fallback`
11. `⬆️ Add tokio dev-dependency with test-util feature`
12. `✅ Add StubPolicyCache + round-trip contract test`
13. `✅ Test invalidate evicts cached entry`
14. `✅ Test cache entry expires after configured TTL`
15. `✅ Test connect with None URL returns ConnectionFailed`
16. `✅ Test connect with malformed URL returns ConnectionFailed`
17. `✅ Test from_config_async falls back to Disabled on bad URL`

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing (will turn green after CI run)
- [x] Commits are small and follow the Gitmoji convention