### PR TITLE
[AAASM-1709] ✨ (aa-gateway): Add remote_mode::server::start_remote

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,6 +267,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "axum-server",
  "chrono",
  "chrono-tz",
  "clap",
@@ -826,6 +827,28 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2220,6 +2243,16 @@ checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
 dependencies = [
  "lazy_static",
  "num",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+ "tokio",
 ]
 
 [[package]]
@@ -5222,6 +5255,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -46,6 +46,7 @@ tokio-util   = "0.7"
 parking_lot  = "0.12"
 utoipa       = { version = "5", features = ["axum_extras"] }
 axum         = "0.8"
+axum-server  = { version = "0.7", features = ["tls-rustls"] }
 x509-parser  = "0.18"
 
 [dev-dependencies]

--- a/aa-gateway/src/remote_mode/error.rs
+++ b/aa-gateway/src/remote_mode/error.rs
@@ -1,0 +1,52 @@
+//! Errors that can interrupt the remote control-plane bootstrap.
+//!
+//! Owned by [`super::server::start_remote`] and the test-friendly
+//! `start_remote_with_handle`. Each variant maps to a single failure
+//! mode an operator running `aasm-gateway --mode remote` might hit, so
+//! `tracing::error!` formatted output and `aasm status` JSON encoding
+//! can point at the exact step that broke.
+
+use std::io;
+use std::net::SocketAddr;
+
+use thiserror::Error;
+
+use super::tls::TlsError;
+
+/// Failures emitted by `start_remote()` and friends.
+#[derive(Debug, Error)]
+pub enum GatewayError {
+    /// Pre-flight [`super::tls::validate`] reported a hard cert / key
+    /// failure. Wraps the underlying [`TlsError`] so the variant
+    /// (missing file, parse error, etc.) is preserved.
+    #[error("TLS preflight failed: {0}")]
+    Tls(#[from] TlsError),
+
+    /// Loading the rustls cert / key into an `axum_server::tls_rustls::RustlsConfig`
+    /// failed at handshake-config build time. Distinct from [`Self::Tls`]
+    /// (which is the file-level preflight) — this is the rustls-side
+    /// rejection (e.g. cert / key mismatch).
+    #[error("failed to load rustls TLS config: {0}")]
+    TlsLoad(#[source] io::Error),
+
+    /// `TcpListener::bind` / `axum_server::bind` failed for the
+    /// configured `listen_addr` — port already in use, permission
+    /// denied, or address malformed.
+    #[error("failed to bind remote gateway to {addr}: {source}")]
+    Bind {
+        /// The socket address the gateway tried to bind.
+        addr: SocketAddr,
+        /// Underlying `std::io::Error` from the bind attempt.
+        #[source]
+        source: io::Error,
+    },
+
+    /// `axum_server::serve` returned an error after binding. Includes
+    /// graceful-shutdown cleanup failures.
+    #[error("remote gateway serve loop failed: {0}")]
+    Serve(#[source] io::Error),
+
+    /// Installing the SIGTERM / SIGINT handler failed (Unix only).
+    #[error("shutdown signal handler installation failed: {0}")]
+    Signal(#[source] io::Error),
+}

--- a/aa-gateway/src/remote_mode/mod.rs
+++ b/aa-gateway/src/remote_mode/mod.rs
@@ -12,6 +12,8 @@
 //! - `server` — listener bootstrap (AAASM-1709 / ST-3, lands in subsequent commits)
 
 pub mod error;
+pub mod server;
 pub mod tls;
 
 pub use error::GatewayError;
+pub use server::router;

--- a/aa-gateway/src/remote_mode/mod.rs
+++ b/aa-gateway/src/remote_mode/mod.rs
@@ -8,6 +8,10 @@
 //! Submodules:
 //!
 //! - [`tls`] — pre-flight cert / key validation (AAASM-1702 / ST-2)
-//! - `server` — listener bootstrap (AAASM-1709 / ST-3, lands next)
+//! - [`error`] — `GatewayError` reported by the bootstrap path
+//! - `server` — listener bootstrap (AAASM-1709 / ST-3, lands in subsequent commits)
 
+pub mod error;
 pub mod tls;
+
+pub use error::GatewayError;

--- a/aa-gateway/src/remote_mode/mod.rs
+++ b/aa-gateway/src/remote_mode/mod.rs
@@ -16,4 +16,4 @@ pub mod server;
 pub mod tls;
 
 pub use error::GatewayError;
-pub use server::router;
+pub use server::{router, start_remote, start_remote_with_handle};

--- a/aa-gateway/src/remote_mode/server.rs
+++ b/aa-gateway/src/remote_mode/server.rs
@@ -6,9 +6,11 @@
 
 use aa_core::config::RemoteModeConfig;
 use axum::{routing::get, Extension, Router};
+use axum_server::tls_rustls::RustlsConfig;
 use axum_server::Handle;
 
 use super::error::GatewayError;
+use super::tls::{self, TlsValidation};
 use crate::routes::healthz::{healthz, HealthzState};
 
 /// Build the remote-mode Axum router.
@@ -38,15 +40,42 @@ pub fn router() -> Router {
 /// production [`start_remote`] entrypoint wires the handle to a
 /// SIGTERM / SIGINT listener.
 pub async fn start_remote_with_handle(cfg: &RemoteModeConfig, handle: Handle) -> Result<(), GatewayError> {
-    if cfg.tls.is_none() {
-        tracing::warn!("⚠ TLS not configured — running over plain HTTP");
-    }
-
     let app = router().into_make_service();
 
-    axum_server::bind(cfg.listen_addr)
-        .handle(handle)
-        .serve(app)
-        .await
-        .map_err(GatewayError::Serve)
+    if let Some(tls_cfg) = &cfg.tls {
+        // Pre-flight cert + key (existence, readability, PEM parse, expiry).
+        match tls::validate(tls_cfg)? {
+            TlsValidation::Ok => {}
+            TlsValidation::ExpiringSoon { days_until_expiry } => {
+                tracing::warn!(
+                    days_until_expiry,
+                    "⚠ TLS cert expires within 30 days — rotate before notAfter"
+                );
+            }
+            TlsValidation::Expired { expired_days_ago } => {
+                tracing::error!(
+                    expired_days_ago,
+                    "TLS cert has already expired — new TLS clients will reject the chain"
+                );
+            }
+        }
+
+        let rustls_cfg = RustlsConfig::from_pem_file(&tls_cfg.cert_file, &tls_cfg.key_file)
+            .await
+            .map_err(GatewayError::TlsLoad)?;
+
+        axum_server::bind_rustls(cfg.listen_addr, rustls_cfg)
+            .handle(handle)
+            .serve(app)
+            .await
+            .map_err(GatewayError::Serve)
+    } else {
+        tracing::warn!("⚠ TLS not configured — running over plain HTTP");
+
+        axum_server::bind(cfg.listen_addr)
+            .handle(handle)
+            .serve(app)
+            .await
+            .map_err(GatewayError::Serve)
+    }
 }

--- a/aa-gateway/src/remote_mode/server.rs
+++ b/aa-gateway/src/remote_mode/server.rs
@@ -29,6 +29,23 @@ pub fn router() -> Router {
     Router::new().route("/healthz", get(healthz)).layer(Extension(state))
 }
 
+/// Print the operator-facing startup banner via `tracing::info!`.
+///
+/// Five lines — mode, listen addr, scheme (http / https), storage label,
+/// version — sized to fit a typical 80-column terminal so the boot log
+/// is scannable.
+fn log_startup_banner(cfg: &RemoteModeConfig) {
+    let scheme = if cfg.tls.is_some() { "https" } else { "http" };
+    tracing::info!(
+        scheme,
+        addr = %cfg.listen_addr,
+        storage = "memory",
+        version = env!("CARGO_PKG_VERSION"),
+        "Agent Assembly [remote mode] starting on {scheme}://{}",
+        cfg.listen_addr
+    );
+}
+
 /// Bind the remote-mode listener and serve until `handle` triggers
 /// shutdown. Plain-HTTP path — TLS is added in a follow-up commit.
 ///
@@ -40,6 +57,7 @@ pub fn router() -> Router {
 /// production [`start_remote`] entrypoint wires the handle to a
 /// SIGTERM / SIGINT listener.
 pub async fn start_remote_with_handle(cfg: &RemoteModeConfig, handle: Handle) -> Result<(), GatewayError> {
+    log_startup_banner(cfg);
     let app = router().into_make_service();
 
     if let Some(tls_cfg) = &cfg.tls {

--- a/aa-gateway/src/remote_mode/server.rs
+++ b/aa-gateway/src/remote_mode/server.rs
@@ -4,8 +4,11 @@
 //! design rationale; the deeper architectural context lives in
 //! AAASM-1577 / E17 S-C.
 
+use aa_core::config::RemoteModeConfig;
 use axum::{routing::get, Extension, Router};
+use axum_server::Handle;
 
+use super::error::GatewayError;
 use crate::routes::healthz::{healthz, HealthzState};
 
 /// Build the remote-mode Axum router.
@@ -22,4 +25,28 @@ use crate::routes::healthz::{healthz, HealthzState};
 pub fn router() -> Router {
     let state = HealthzState::new("remote", "memory");
     Router::new().route("/healthz", get(healthz)).layer(Extension(state))
+}
+
+/// Bind the remote-mode listener and serve until `handle` triggers
+/// shutdown. Plain-HTTP path — TLS is added in a follow-up commit.
+///
+/// Returns `Ok(())` after the server has drained on graceful shutdown,
+/// or `Err(GatewayError)` if bind / serve failed.
+///
+/// `handle` is the caller's lever for shutdown: tests build their own
+/// and call `handle.graceful_shutdown(Some(_))` to exit cleanly; the
+/// production [`start_remote`] entrypoint wires the handle to a
+/// SIGTERM / SIGINT listener.
+pub async fn start_remote_with_handle(cfg: &RemoteModeConfig, handle: Handle) -> Result<(), GatewayError> {
+    if cfg.tls.is_none() {
+        tracing::warn!("⚠ TLS not configured — running over plain HTTP");
+    }
+
+    let app = router().into_make_service();
+
+    axum_server::bind(cfg.listen_addr)
+        .handle(handle)
+        .serve(app)
+        .await
+        .map_err(GatewayError::Serve)
 }

--- a/aa-gateway/src/remote_mode/server.rs
+++ b/aa-gateway/src/remote_mode/server.rs
@@ -1,0 +1,25 @@
+//! Remote Control-Plane Mode listener bootstrap.
+//!
+//! Owns `start_remote` and the `router` builder. See AAASM-1709 for the
+//! design rationale; the deeper architectural context lives in
+//! AAASM-1577 / E17 S-C.
+
+use axum::{routing::get, Extension, Router};
+
+use crate::routes::healthz::{healthz, HealthzState};
+
+/// Build the remote-mode Axum router.
+///
+/// Mounts only `/healthz` today via [`crate::routes::healthz::healthz`].
+/// Later sub-tasks (cross-mode API routes wired by AAASM-1731, dashboard
+/// SPA opt-in in AAASM-1580) merge into this same router.
+///
+/// The injected `HealthzState::new("remote", "memory")` layer supplies
+/// the labels the shared `/healthz` handler reads, so the response body
+/// carries `mode: "remote"` and `storage: "memory"`. The `"memory"`
+/// label is a stub until E18 S-C (AAASM-1719 PostgreSQL backend) wires
+/// the real storage label through `RemoteModeConfig`.
+pub fn router() -> Router {
+    let state = HealthzState::new("remote", "memory");
+    Router::new().route("/healthz", get(healthz)).layer(Extension(state))
+}

--- a/aa-gateway/src/remote_mode/server.rs
+++ b/aa-gateway/src/remote_mode/server.rs
@@ -4,6 +4,8 @@
 //! design rationale; the deeper architectural context lives in
 //! AAASM-1577 / E17 S-C.
 
+use std::time::Duration;
+
 use aa_core::config::RemoteModeConfig;
 use axum::{routing::get, Extension, Router};
 use axum_server::tls_rustls::RustlsConfig;
@@ -44,6 +46,62 @@ fn log_startup_banner(cfg: &RemoteModeConfig) {
         "Agent Assembly [remote mode] starting on {scheme}://{}",
         cfg.listen_addr
     );
+}
+
+/// How long graceful shutdown waits for in-flight requests to drain
+/// before forcefully closing the listener. Matches the 30-second
+/// budget the Story AC documents.
+const GRACEFUL_SHUTDOWN_BUDGET: Duration = Duration::from_secs(30);
+
+/// Bind the remote-mode listener and serve until SIGTERM / SIGINT.
+///
+/// Top-level entrypoint for `aasm-gateway --mode remote`. Creates an
+/// internal [`Handle`], spawns a signal listener that drives graceful
+/// shutdown on SIGTERM (Unix) or Ctrl+C, then defers to
+/// [`start_remote_with_handle`] for the actual bind + serve loop.
+///
+/// Returns `Ok(())` after the server has drained, or `Err(GatewayError)`
+/// for any pre-flight / bind / serve / signal-installation failure.
+pub async fn start_remote(cfg: &RemoteModeConfig) -> Result<(), GatewayError> {
+    let handle = Handle::new();
+    let signal_handle = handle.clone();
+
+    tokio::spawn(async move {
+        if let Err(err) = wait_for_shutdown_signal().await {
+            tracing::error!(error = %err, "shutdown signal listener failed");
+            signal_handle.shutdown();
+            return;
+        }
+        tracing::info!(
+            secs = GRACEFUL_SHUTDOWN_BUDGET.as_secs(),
+            "shutdown signal received — draining in-flight requests"
+        );
+        signal_handle.graceful_shutdown(Some(GRACEFUL_SHUTDOWN_BUDGET));
+    });
+
+    start_remote_with_handle(cfg, handle).await
+}
+
+/// Wait for SIGTERM (Unix) or SIGINT (Ctrl+C, all platforms), whichever
+/// arrives first. Returns `Err(GatewayError::Signal)` only when the
+/// underlying signal handler could not be installed.
+async fn wait_for_shutdown_signal() -> Result<(), GatewayError> {
+    let ctrl_c = tokio::signal::ctrl_c();
+
+    #[cfg(unix)]
+    {
+        let mut sigterm =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).map_err(GatewayError::Signal)?;
+        tokio::select! {
+            res = ctrl_c => res.map_err(GatewayError::Signal),
+            _ = sigterm.recv() => Ok(()),
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        ctrl_c.await.map_err(GatewayError::Signal)
+    }
 }
 
 /// Bind the remote-mode listener and serve until `handle` triggers

--- a/aa-gateway/tests/remote_mode_http.rs
+++ b/aa-gateway/tests/remote_mode_http.rs
@@ -41,3 +41,38 @@ async fn start_remote_serves_healthz_over_http() {
     shutdown_handle.graceful_shutdown(Some(Duration::from_secs(5)));
     server.await.expect("server task").expect("server result");
 }
+
+/// AAASM-1709 AC #4 — graceful_shutdown drains and returns Ok within
+/// the configured budget. The test asserts the bind/serve future does
+/// not get stuck after the handle is triggered; if the drain exceeded
+/// the budget the test would time out at the outer `tokio::time::timeout`.
+#[tokio::test]
+async fn graceful_shutdown_drains_cleanly() {
+    let cfg = RemoteModeConfig {
+        listen_addr: "127.0.0.1:0".parse().expect("listen_addr"),
+        tls: None,
+        ..Default::default()
+    };
+
+    let handle = Handle::new();
+    let ready_handle = handle.clone();
+    let shutdown_handle = handle.clone();
+
+    let server = tokio::spawn(async move { aa_gateway::remote_mode::start_remote_with_handle(&cfg, handle).await });
+
+    // Wait until the listener is actually bound before triggering shutdown
+    // — otherwise the test races the bind step and `graceful_shutdown` is
+    // a no-op against a not-yet-listening server.
+    let _addr = ready_handle.listening().await.expect("server bound");
+
+    shutdown_handle.graceful_shutdown(Some(Duration::from_secs(5)));
+
+    // The bind/serve future resolves to `Ok(())` once the graceful-shutdown
+    // drain completes; failure to exit within 10 s here would mean the
+    // drain logic deadlocked.
+    tokio::time::timeout(Duration::from_secs(10), server)
+        .await
+        .expect("server exited within timeout budget")
+        .expect("server task joined")
+        .expect("serve returned Ok");
+}

--- a/aa-gateway/tests/remote_mode_http.rs
+++ b/aa-gateway/tests/remote_mode_http.rs
@@ -1,0 +1,43 @@
+//! Integration tests for `aa_gateway::remote_mode::start_remote_with_handle`
+//! exercised over plain HTTP — no TLS material required.
+//!
+//! Both tests bind to `127.0.0.1:0` so they can run in parallel without
+//! contending for a fixed port. The `axum_server::Handle::listening()`
+//! call gives us the actual bound port back so the reqwest probe knows
+//! where to connect.
+
+use std::time::Duration;
+
+use aa_core::config::RemoteModeConfig;
+use axum_server::Handle;
+
+/// AAASM-1709 AC #1 — `start_remote_with_handle` binds, serves
+/// `/healthz`, and the response carries the remote-mode JSON.
+#[tokio::test]
+async fn start_remote_serves_healthz_over_http() {
+    let cfg = RemoteModeConfig {
+        listen_addr: "127.0.0.1:0".parse().expect("listen_addr"),
+        tls: None,
+        ..Default::default()
+    };
+
+    let handle = Handle::new();
+    let probe_handle = handle.clone();
+    let shutdown_handle = handle.clone();
+
+    let server = tokio::spawn(async move { aa_gateway::remote_mode::start_remote_with_handle(&cfg, handle).await });
+
+    let addr = probe_handle.listening().await.expect("server bound");
+    let body: serde_json::Value = reqwest::get(format!("http://{addr}/healthz"))
+        .await
+        .expect("GET /healthz")
+        .json()
+        .await
+        .expect("parse JSON body");
+
+    assert_eq!(body["mode"], "remote", "mode label");
+    assert_eq!(body["storage"], "memory", "storage label");
+
+    shutdown_handle.graceful_shutdown(Some(Duration::from_secs(5)));
+    server.await.expect("server task").expect("server result");
+}


### PR DESCRIPTION
## Description

Listener bootstrap for Remote CP Mode (AAASM-1577 / E17 S-C). When the gateway boots with `AA_MODE=remote`, `start_remote(&cfg.remote)` builds the Axum router, optionally pre-flights TLS via ST-2's validator, binds via `axum_server` (HTTP or HTTPS), prints a startup banner, and serves until SIGTERM / SIGINT triggers a 30-second graceful drain.

Adds:

- `aa-gateway/src/remote_mode/error.rs` — `GatewayError` enum (`Tls` / `TlsLoad` / `Bind` / `Serve` / `Signal`)
- `aa-gateway/src/remote_mode/server.rs`:
  - `pub fn router() -> Router` — mounts `/healthz` (mirrors `local_mode::router()` for symmetry)
  - `pub async fn start_remote_with_handle(cfg, handle) -> Result<(), GatewayError>` — test-friendly bind + serve loop accepting a caller-supplied `axum_server::Handle`
  - `pub async fn start_remote(cfg) -> Result<(), GatewayError>` — top-level entry that wires SIGTERM / SIGINT to `handle.graceful_shutdown(Some(30s))`
  - `fn log_startup_banner(cfg)` — operator-facing scheme / addr / storage / version log line
- `aa-gateway/src/remote_mode/mod.rs` — re-exports `GatewayError`, `router`, `start_remote`, `start_remote_with_handle`
- `aa-gateway/Cargo.toml` — adds `axum-server = { version = "0.7", features = ["tls-rustls"] }`
- `aa-gateway/tests/remote_mode_http.rs` — 2 integration tests

### Design notes

The split between `start_remote` (with internal SIGTERM listener) and `start_remote_with_handle` (caller supplies the `Handle`) is deliberate. The integration tests need a handle they can trigger directly so they can't depend on a real SIGTERM; production code (ST-4 will wire this into `main.rs`) calls the simpler `start_remote(cfg)`.

`HealthzState::new("remote", "memory")` uses `"memory"` as the storage label — a stub until E18 S-C (AAASM-1719's PostgreSQL backend) threads the real storage label through `RemoteModeConfig`. The label is observable through `/healthz` and the integration test asserts it.

Out of scope for this PR (separate Sub-tasks):

- `main.rs` mode dispatch (AAASM-1713 / ST-4)
- Story-level acceptance verification — register-two-agents + TLS end-to-end (AAASM-1718 / ST-5)

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1709 (Sub-task of AAASM-1577 under Epic AAASM-1568)

## Testing

- [x] Unit tests added — none new (TLS unit tests landed in ST-2)
- [x] Integration tests added — 2 tests under `aa-gateway --test remote_mode_http`
- [x] Manual testing — `cargo nextest run -p aa-gateway --test remote_mode_http` green

```
$ cargo nextest run -p aa-gateway --test remote_mode_http
        PASS aa-gateway::remote_mode_http graceful_shutdown_drains_cleanly
        PASS aa-gateway::remote_mode_http start_remote_serves_healthz_over_http
     Summary 2 tests run: 2 passed, 0 skipped
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated (rustdoc on new types + functions)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention