### PR TITLE
[AAASM-1713] ✨ (aa-gateway): Wire main.rs deployment-mode dispatch

### DIFF
--- a/aa-gateway/src/main.rs
+++ b/aa-gateway/src/main.rs
@@ -156,4 +156,14 @@ mod tests {
         let resolved = resolve_mode(None, |_| None).expect("resolve");
         assert_eq!(resolved, Mode::LegacyGrpc);
     }
+
+    #[test]
+    fn rejects_invalid_aa_mode_value() {
+        let err = resolve_mode(None, env_with("foobar")).expect_err("expected error");
+        assert!(err.contains("foobar"), "error must echo the invalid value: {err}");
+        assert!(
+            err.contains("legacy-grpc") && err.contains("local") && err.contains("remote"),
+            "error must list valid modes: {err}"
+        );
+    }
 }

--- a/aa-gateway/src/main.rs
+++ b/aa-gateway/src/main.rs
@@ -129,3 +129,19 @@ async fn run_remote() -> Result<(), Box<dyn std::error::Error>> {
     aa_gateway::remote_mode::start_remote(&cfg.remote).await?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a closure that pretends `AA_MODE` is set to `value`.
+    fn env_with(value: &'static str) -> impl Fn(&str) -> Option<String> {
+        move |k| (k == "AA_MODE").then(|| value.to_string())
+    }
+
+    #[test]
+    fn cli_flag_overrides_env() {
+        let resolved = resolve_mode(Some(Mode::Remote), env_with("local")).expect("resolve");
+        assert_eq!(resolved, Mode::Remote);
+    }
+}

--- a/aa-gateway/src/main.rs
+++ b/aa-gateway/src/main.rs
@@ -81,8 +81,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cli = Cli::parse();
 
-    let _mode = resolve_mode(cli.mode, |k| std::env::var(k).ok())?;
+    let mode = resolve_mode(cli.mode, |k| std::env::var(k).ok())?;
 
+    match mode {
+        Mode::LegacyGrpc => run_legacy_grpc(cli).await,
+        Mode::Local => Err("Local Dev Mode bootstrap (E17 S-B / AAASM-1576) is not yet implemented".into()),
+        Mode::Remote => run_remote().await,
+    }
+}
+
+/// Existing gRPC + policy serving path. Preserves the pre-Epic-17
+/// invocation contract `aasm-gateway --policy /path [--listen ...]`.
+async fn run_legacy_grpc(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     let policy = cli
         .policy
         .as_ref()
@@ -108,4 +118,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         aa_gateway::server::serve_tcp(&policy, &cli.listen, registry, approval_queue, budget_alert_tx).await
     }
+}
+
+/// Remote Control-Plane Mode entry: load the persisted `GatewayConfig`
+/// (YAML + env overrides) and hand its `remote` section to
+/// `aa_gateway::remote_mode::start_remote`. Blocks until SIGTERM /
+/// SIGINT triggers graceful drain.
+async fn run_remote() -> Result<(), Box<dyn std::error::Error>> {
+    let cfg = aa_core::config::GatewayConfig::load()?;
+    aa_gateway::remote_mode::start_remote(&cfg.remote).await?;
+    Ok(())
 }

--- a/aa-gateway/src/main.rs
+++ b/aa-gateway/src/main.rs
@@ -3,16 +3,43 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use tracing_subscriber::EnvFilter;
+
+/// Deployment topology selected at boot.
+///
+/// `LegacyGrpc` preserves the gRPC + policy YAML flow the binary has
+/// always exposed and is the default until `--mode` or `AA_MODE` says
+/// otherwise. `Local` and `Remote` map onto the Epic 17 deployment
+/// modes from `aa_core::config::DeploymentMode`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+enum Mode {
+    /// Existing gRPC + policy server entry — default for backwards
+    /// compatibility while AAASM-1577 and AAASM-1576 land.
+    LegacyGrpc,
+    /// Local Dev Mode (AAASM-1576 / E17 S-B). Bootstrap is not yet
+    /// wired — selecting this mode exits with a clear error pointing
+    /// at the tracking Sub-task.
+    Local,
+    /// Remote Control-Plane Mode (AAASM-1577 / E17 S-C). Drives the
+    /// `aa_gateway::remote_mode::start_remote` entrypoint.
+    Remote,
+}
 
 /// Agent Assembly governance gateway — gRPC policy evaluation server.
 #[derive(Parser)]
 #[command(name = "aa-gateway", version, about)]
 struct Cli {
-    /// Path to the policy YAML file.
+    /// Deployment mode. Overrides the `AA_MODE` environment variable.
+    /// Default — when neither flag nor env are set — is `legacy-grpc`.
+    #[arg(long, value_enum)]
+    mode: Option<Mode>,
+
+    /// Path to the policy YAML file. Required by `legacy-grpc`; ignored by
+    /// `remote` and `local` modes.
     #[arg(long)]
-    policy: PathBuf,
+    policy: Option<PathBuf>,
 
     /// TCP listen address (e.g. "127.0.0.1:50051").
     #[arg(long, default_value = "127.0.0.1:50051")]
@@ -31,7 +58,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let cli = Cli::parse();
 
-    tracing::info!(policy = %cli.policy.display(), "loading policy");
+    let policy = cli
+        .policy
+        .as_ref()
+        .ok_or("--policy is required in legacy-grpc mode")?
+        .clone();
+
+    tracing::info!(policy = %policy.display(), "loading policy");
 
     let registry = Arc::new(aa_gateway::AgentRegistry::new());
 
@@ -46,8 +79,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _webhook_handle = aa_gateway::events::startup::maybe_spawn_webhook(&approval_queue, budget_alert_rx);
 
     if let Some(socket_path) = &cli.socket {
-        aa_gateway::server::serve_uds(&cli.policy, socket_path, registry, approval_queue, budget_alert_tx).await
+        aa_gateway::server::serve_uds(&policy, socket_path, registry, approval_queue, budget_alert_tx).await
     } else {
-        aa_gateway::server::serve_tcp(&cli.policy, &cli.listen, registry, approval_queue, budget_alert_tx).await
+        aa_gateway::server::serve_tcp(&policy, &cli.listen, registry, approval_queue, budget_alert_tx).await
     }
 }

--- a/aa-gateway/src/main.rs
+++ b/aa-gateway/src/main.rs
@@ -150,4 +150,10 @@ mod tests {
         let resolved = resolve_mode(None, env_with("remote")).expect("resolve");
         assert_eq!(resolved, Mode::Remote);
     }
+
+    #[test]
+    fn defaults_to_legacy_grpc() {
+        let resolved = resolve_mode(None, |_| None).expect("resolve");
+        assert_eq!(resolved, Mode::LegacyGrpc);
+    }
 }

--- a/aa-gateway/src/main.rs
+++ b/aa-gateway/src/main.rs
@@ -144,4 +144,10 @@ mod tests {
         let resolved = resolve_mode(Some(Mode::Remote), env_with("local")).expect("resolve");
         assert_eq!(resolved, Mode::Remote);
     }
+
+    #[test]
+    fn falls_back_to_aa_mode_env() {
+        let resolved = resolve_mode(None, env_with("remote")).expect("resolve");
+        assert_eq!(resolved, Mode::Remote);
+    }
 }

--- a/aa-gateway/src/main.rs
+++ b/aa-gateway/src/main.rs
@@ -27,6 +27,29 @@ enum Mode {
     Remote,
 }
 
+/// Resolve the active deployment mode using the documented precedence:
+/// explicit `--mode` flag > `AA_MODE` environment variable > default
+/// (`Mode::LegacyGrpc`).
+///
+/// `env_lookup` is parameterised so unit tests can inject a stub
+/// without poisoning the real process environment.
+fn resolve_mode(cli_mode: Option<Mode>, env_lookup: impl Fn(&str) -> Option<String>) -> Result<Mode, String> {
+    if let Some(m) = cli_mode {
+        return Ok(m);
+    }
+    if let Some(raw) = env_lookup("AA_MODE") {
+        return match raw.to_ascii_lowercase().as_str() {
+            "legacy-grpc" => Ok(Mode::LegacyGrpc),
+            "local" => Ok(Mode::Local),
+            "remote" => Ok(Mode::Remote),
+            other => Err(format!(
+                "invalid AA_MODE={other:?} — expected one of: legacy-grpc, local, remote"
+            )),
+        };
+    }
+    Ok(Mode::LegacyGrpc)
+}
+
 /// Agent Assembly governance gateway — gRPC policy evaluation server.
 #[derive(Parser)]
 #[command(name = "aa-gateway", version, about)]
@@ -57,6 +80,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .init();
 
     let cli = Cli::parse();
+
+    let _mode = resolve_mode(cli.mode, |k| std::env::var(k).ok())?;
 
     let policy = cli
         .policy


### PR DESCRIPTION
## Description

Wires the gateway binary entrypoint to AAASM-1709's `remote_mode::start_remote` (and surfaces a clear "not yet implemented" error for local mode until AAASM-1576 lands). Existing `legacy-grpc` invocations are unchanged.

### Behaviour

```
aa-gateway --policy policies/dev.yaml                    # ← legacy gRPC path (default)
aa-gateway --policy policies/dev.yaml --mode legacy-grpc # ← same
aa-gateway --mode remote                                  # ← AAASM-1709 path
AA_MODE=remote aa-gateway                                 # ← same via env
aa-gateway --mode local                                   # ← error: "Local Dev Mode... not yet implemented"
AA_MODE=foobar aa-gateway                                 # ← error: "invalid AA_MODE=\"foobar\"..."
```

### Adds

- `aa-gateway/src/main.rs`:
  - `Mode` enum (`LegacyGrpc` / `Local` / `Remote`) — clap `ValueEnum`, kebab-case
  - `Cli::mode: Option<Mode>` + `Cli::policy: Option<PathBuf>` (was required; legacy-grpc still asserts at runtime)
  - `resolve_mode(cli_mode, env_lookup) -> Result<Mode, String>` — pure function, CLI > env > default
  - `run_legacy_grpc(cli)` — existing gRPC + policy path moved into a function
  - `run_remote()` — loads `aa_core::config::GatewayConfig::load()` and drives `aa_gateway::remote_mode::start_remote`
- `aa-gateway/src/main.rs` (test module) — 4 unit tests

### Out of scope

- `aasm start` orchestration (AAASM-1578 / ST-D)
- Local-mode `start_local` (AAASM-1576 / S-B)
- Binary-process integration test — covered by ST-3's `tests/remote_mode_http.rs` (which already proves `start_remote` binds /healthz over HTTP). Adding a subprocess-spawn test on top would be high-friction for low marginal coverage; ST-5 verification will provide the end-to-end signal

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No — `aa-gateway --policy <path> [--listen ...]` invocations are byte-identical to before

## Related Issues

- Related Jira ticket: AAASM-1713 (Sub-task of AAASM-1577 under Epic AAASM-1568)

## Testing

- [x] Unit tests added — 4 tests under `aa-gateway::bin/aa-gateway tests`
- [x] Manual testing — `cargo nextest run -p aa-gateway --bin aa-gateway` green

```
$ cargo nextest run -p aa-gateway --bin aa-gateway
        PASS aa-gateway::bin/aa-gateway tests::cli_flag_overrides_env
        PASS aa-gateway::bin/aa-gateway tests::falls_back_to_aa_mode_env
        PASS aa-gateway::bin/aa-gateway tests::defaults_to_legacy_grpc
        PASS aa-gateway::bin/aa-gateway tests::rejects_invalid_aa_mode_value
     Summary 4 tests run: 4 passed, 0 skipped
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated (rustdoc on Mode + resolve_mode + run_legacy_grpc + run_remote)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention