### PR TITLE
[AAASM-1715] ✨ (aa-gateway): Add idempotent healthz pre-flight probe

### DIFF
--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -327,4 +327,40 @@ mod tests {
 
         assert!(alive, "probe must report alive against a real local-mode /healthz");
     }
+
+    /// AAASM-1576 AC #2 guard: when *some other* HTTP server is
+    /// listening on port 7391 — say a developer's static-asset server
+    /// or a stale process from a different product — `probe_running`
+    /// must return `false`. Otherwise `start_local()` would falsely
+    /// reuse a foreign process and the gateway would silently fail to
+    /// come up.
+    ///
+    /// Spins up a tiny axum router that responds 200 OK with
+    /// `{"foo":"bar"}` (missing every documented `HealthzBody` field)
+    /// and asserts the probe rejects it.
+    #[tokio::test]
+    async fn probe_running_returns_false_on_body_shape_mismatch() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ephemeral port");
+        let port = listener.local_addr().expect("local_addr").port();
+
+        async fn foreign_handler() -> axum::Json<serde_json::Value> {
+            axum::Json(serde_json::json!({"foo": "bar"}))
+        }
+        let foreign_app = Router::new().route("/healthz", get(foreign_handler));
+
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, foreign_app).await;
+        });
+
+        let alive = probe_running(port).await;
+
+        server.abort();
+
+        assert!(
+            !alive,
+            "probe must reject foreign /healthz responses missing HealthzBody fields"
+        );
+    }
 }

--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -274,4 +274,31 @@ mod tests {
 
         pool.close().await;
     }
+
+    /// AAASM-1576 AC #2 negative path: when no gateway is listening,
+    /// `probe_running` must return `false` (so `start_local()` proceeds
+    /// with auto-start) — within the documented 100 ms timeout, never
+    /// hanging or panicking.
+    ///
+    /// Pattern: bind a TcpListener to grab a fresh ephemeral port, then
+    /// drop it before probing — the kernel returns ECONNREFUSED on the
+    /// next connect attempt, exercising the connection-refused path.
+    #[tokio::test]
+    async fn probe_running_returns_false_on_connection_refused() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ephemeral port");
+        let port = listener.local_addr().expect("local_addr").port();
+        drop(listener);
+
+        let start = std::time::Instant::now();
+        let alive = probe_running(port).await;
+        let elapsed = start.elapsed();
+
+        assert!(!alive, "probe must report dead when port is closed");
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "probe should fail fast on connection refused; took {elapsed:?}"
+        );
+    }
 }

--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -142,6 +142,47 @@ pub(crate) async fn open_storage(path: &Path) -> Result<SqlitePool, LocalModeErr
         })
 }
 
+/// Probe `GET http://127.0.0.1:{port}/healthz` with a 100 ms timeout.
+///
+/// Used as the auto-start idempotency check by `start_local()` (AAASM-1725):
+/// if a previous gateway is already serving on the port, the call short-
+/// circuits and we reuse the existing process rather than failing to bind.
+/// Matches AAASM-1576 AC #2 ("If port 7391 is already in use by a running
+/// AASM gateway, auto-start is skipped").
+///
+/// Returns:
+/// * `true`  — a running gateway responded 200 OK and the body carries a
+///   `HealthzBody`-compatible shape (string `mode`, `version`, `storage`).
+/// * `false` — connection refused, request timeout, non-200 response, or
+///   unexpected body shape. The probe never panics; every error path maps
+///   to `false` so callers can treat it as a boolean.
+///
+/// The body-shape check guards against falsely identifying *foreign*
+/// services that happen to be listening on the port (e.g. a developer
+/// running a different HTTP server on 7391) as a healthy AASM gateway.
+#[allow(dead_code)] // consumed by start_local() — AAASM-1725
+pub(crate) async fn probe_running(port: u16) -> bool {
+    let url = format!("http://127.0.0.1:{port}/healthz");
+    let Ok(client) = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_millis(100))
+        .build()
+    else {
+        return false;
+    };
+    let Ok(resp) = client.get(&url).send().await else {
+        return false;
+    };
+    if !resp.status().is_success() {
+        return false;
+    }
+    let Ok(body) = resp.json::<serde_json::Value>().await else {
+        return false;
+    };
+    body.get("mode").and_then(|v| v.as_str()).is_some()
+        && body.get("storage").and_then(|v| v.as_str()).is_some()
+        && body.get("version").and_then(|v| v.as_str()).is_some()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -301,4 +301,30 @@ mod tests {
             "probe should fail fast on connection refused; took {elapsed:?}"
         );
     }
+
+    /// AAASM-1576 AC #2 positive path: when a real local-mode gateway is
+    /// serving on the port, `probe_running` must return `true` so
+    /// `start_local()` short-circuits and reuses the existing process.
+    ///
+    /// Spins up the actual `router()` (which mounts `routes::healthz`
+    /// with `HealthzState::new("local", "sqlite")`) on an ephemeral
+    /// port via `axum::serve`, then probes it. The server task is
+    /// aborted on the way out to keep the test hermetic.
+    #[tokio::test]
+    async fn probe_running_returns_true_against_local_mode_router() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind ephemeral port");
+        let port = listener.local_addr().expect("local_addr").port();
+
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, router()).await;
+        });
+
+        let alive = probe_running(port).await;
+
+        server.abort();
+
+        assert!(alive, "probe must report alive against a real local-mode /healthz");
+    }
 }


### PR DESCRIPTION
## Description

Sub-task 4 of [AAASM-1576](https://lightning-dust-mite.atlassian.net/browse/AAASM-1576) (E17 S-B — Local Dev Mode). Adds `probe_running(port: u16) -> bool` — the auto-start idempotency check that `start_local()` (AAASM-1725) will call before binding.

`probe_running` performs a `GET http://127.0.0.1:{port}/healthz` with a 100 ms timeout and returns:

| Server state                              | `probe_running` |
| ---                                       | ---             |
| no listener (ECONNREFUSED)                | `false`         |
| local-mode `/healthz` on the port         | `true`          |
| 200 with foreign body shape on the port   | `false`         |

Delivers AAASM-1576 AC #2 (*"If port 7391 is already in use by a running AASM gateway, auto-start is skipped (idempotent)"*).

**Scope adjustment vs original Sub-task description:**

1. The original AC referenced parsing `HealthzResponse` — that type was removed in AAASM-1705 and superseded by the shared `routes::healthz::HealthzBody` from AAASM-1698. The probe now parses into `serde_json::Value` and checks for the three documented label fields (`mode`, `storage`, `version` as strings). Going through `Value` avoids adding `Deserialize` to the stable `HealthzBody` wire-contract type.
2. The original plan had a `🔧 Add reqwest dep` commit — `reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }` is already a direct dep of `aa-gateway`, so that commit was moot and is omitted.

Delivered in four granular commits:

1. `✨ (aa-gateway/local_mode): Add probe_running() healthz pre-flight check`
2. `✅ (aa-gateway/local_mode): Test probe_running returns false on connection refused`
3. `✅ (aa-gateway/local_mode): Test probe_running returns true against local-mode router`
4. `✅ (aa-gateway/local_mode): Test probe_running returns false on body shape mismatch`

```text
$ cargo nextest run -p aa-gateway -E 'test(probe_running)'
        PASS local_mode::tests::probe_running_returns_false_on_connection_refused
        PASS local_mode::tests::probe_running_returns_true_against_local_mode_router
        PASS local_mode::tests::probe_running_returns_false_on_body_shape_mismatch
     Summary 3 tests run: 3 passed, 865 skipped
```

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Pure additive change. One new `pub(crate)` helper in `aa_gateway::local_mode`, three new test cases. No public API touched, no dependency changes.

## Related Issues

- Related Jira ticket: [AAASM-1715](https://lightning-dust-mite.atlassian.net/browse/AAASM-1715) (this Sub-task)
- Parent Story: [AAASM-1576](https://lightning-dust-mite.atlassian.net/browse/AAASM-1576) (E17 S-B)
- Parent Epic: [AAASM-1568](https://lightning-dust-mite.atlassian.net/browse/AAASM-1568) (E17)
- Reuses: [AAASM-1698](https://lightning-dust-mite.atlassian.net/browse/AAASM-1698) (`HealthzBody` wire contract)

## Testing

- [x] Unit tests added / updated — three new `#[tokio::test]` cases covering the probe's full truth table (connection-refused, alive local-mode router, foreign body shape).
- [ ] Integration tests added / updated — N/A for this helper-only Sub-task.
- [x] Manual testing performed — `cargo build -p aa-gateway`, `cargo clippy -p aa-gateway --all-targets -- -D warnings`, `cargo nextest run -p aa-gateway -E 'test(probe_running)'` all green locally.
- [ ] No tests required (explain why)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`) — lefthook fmt + clippy passed on every commit.
- [x] Self-review of the diff completed.
- [x] Documentation updated if behaviour changed — rustdoc on `probe_running` documents the return-value contract and the body-shape guard rationale.
- [x] All CI checks passing — pending CI verification on this PR.
- [x] Commits are small and follow the Gitmoji convention — 4 commits, one helper + one test per commit.

## Sub-task acceptance criteria (AAASM-1715, adjusted)

- [x] `probe_running(port)` returns `false` when nothing listens on the port (connection refused), within the documented timeout window — `probe_running_returns_false_on_connection_refused` (asserts < 500 ms).
- [x] `probe_running(port)` returns `true` when a test server on the port responds 200 with valid `HealthzBody` JSON — `probe_running_returns_true_against_local_mode_router` (uses the real `router()` from AAASM-1705).
- [x] `probe_running(port)` returns `false` when something listens but returns 200 with an unexpected body shape — `probe_running_returns_false_on_body_shape_mismatch` (foreign axum router returning `{"foo":"bar"}`).
- [x] No panic on DNS / connection / timeout errors — every error path maps to `false` via `let Ok(...) else { return false }`.
- [x] `cargo nextest run -p aa-gateway -E 'test(probe_running)'` green.

## Notes for downstream sub-tasks

AAASM-1725's `start_local()` will call `probe_running(config.port).await` before `TcpListener::bind` — if it returns `true`, short-circuit and return an existing handle; otherwise proceed to bind and start the Axum server.

[AAASM-1576]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1715]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ