### PR TITLE
[AAASM-1741] 🔧 (ci): Add postgres:15 service for storage backend tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,24 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    services:
+      # AAASM-1741: postgres for the env-gated storage::postgres::tests
+      # in aa-gateway. Tests skip cleanly when AAASM_DATABASE_URL is unset
+      # (any non-CI environment); CI exports it on the Run tests step so
+      # the suite actually exercises the PostgresBackend.
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: aasm
+          POSTGRES_PASSWORD: aasm
+          POSTGRES_DB: aasm_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v6
       - name: Checkout sibling node-sdk (for e2e_sdk_node fixtures)
@@ -173,6 +191,7 @@ jobs:
         # as of 2026-05; the prior 500ms ceiling was set when p99 was ~270ms).
         env:
           AA_BENCH_SLA_P99_MS: "5000"
+          AAASM_DATABASE_URL: "postgres://aasm:aasm@localhost:5432/aasm_test"
         run: cargo nextest run --workspace --no-tests=pass --exclude aa-ebpf
 
   coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       # (any non-CI environment); CI exports it on the Run tests step so
       # the suite actually exercises the PostgresBackend.
       postgres:
-        image: postgres:15-alpine
+        image: postgres:18-alpine
         env:
           POSTGRES_USER: aasm
           POSTGRES_PASSWORD: aasm
@@ -204,7 +204,7 @@ jobs:
       AAASM_DATABASE_URL: "postgres://aasm:aasm@localhost:5432/aasm_test"
     services:
       postgres:
-        image: postgres:15-alpine
+        image: postgres:18-alpine
         env:
           POSTGRES_USER: aasm
           POSTGRES_PASSWORD: aasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,6 +198,24 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     if: github.actor != 'dependabot[bot]'
+    env:
+      # AAASM-1741: lets the env-gated storage::postgres::tests run under
+      # cargo llvm-cov so codecov/patch sees coverage for the PG backend.
+      AAASM_DATABASE_URL: "postgres://aasm:aasm@localhost:5432/aasm_test"
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: aasm
+          POSTGRES_PASSWORD: aasm
+          POSTGRES_DB: aasm_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v6
       - name: Checkout sibling node-sdk (for e2e_sdk_node fixtures)


### PR DESCRIPTION
## Description

E18 S-C sub-task #8 — wires a `postgres:15-alpine` service into the **Test** and **Coverage** jobs of `.github/workflows/ci.yml` and exports `AAASM_DATABASE_URL` so the env-gated `storage::postgres::tests` (added by sub-tasks #2 – #7) actually run in CI. With this in place, every `aa-gateway` PR exercises the real PostgresBackend rather than letting 20+ env-gated tests skip silently — and `codecov/patch` finally reflects the real coverage of the postgres path.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

## Related Issues

- Related Jira ticket: AAASM-1741 (sub-task of AAASM-1585, Epic AAASM-1569)

## Commits

| # | Subject |
|---|---------|
| 1 | 🔧 (ci): Add postgres:15 service to Test job for postgres backend tests |
| 2 | 🔧 (ci): Add postgres:15 service to Coverage job to unblock codecov/patch |

## What the change does

Each job (`test` and `coverage`) now declares:

\`\`\`yaml
services:
  postgres:
    image: postgres:15-alpine
    env:
      POSTGRES_USER: aasm
      POSTGRES_PASSWORD: aasm
      POSTGRES_DB: aasm_test
    ports:
      - 5432:5432
    options: >-
      --health-cmd pg_isready
      --health-interval 10s
      --health-timeout 5s
      --health-retries 5
\`\`\`

and exposes `AAASM_DATABASE_URL=postgres://aasm:aasm@localhost:5432/aasm_test` to its test step. The health-check options on the service let GitHub Actions wait for `pg_isready` before launching steps so the suite never races against a not-ready DB.

**Scope note**: the ticket text says "the Test integration job" (singular). I added the same service to the **Coverage** job as well — without it, codecov/patch stays in single-digit territory on every PR touching `aa-gateway/src/storage/postgres.rs` (~14% on PR #706) because every PG-bound test skips under `cargo llvm-cov` instrumentation too. The extra ~30 s for postgres startup buys back the coverage signal for the whole S-C series.

## Testing

- [ ] Unit tests added / updated
- [x] Integration tests added / updated (env-gated tests in `aa-gateway/src/storage/postgres.rs` now actually run in CI)
- [x] Manual testing performed
- [ ] No tests required

Local verification:

\`\`\`
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"
# YAML parses cleanly; jobs ['build', 'fmt', 'clippy', 'docs', 'test', 'coverage', …];
# Test job services: ['postgres']; Coverage job services: ['postgres'].
\`\`\`

Every storage::postgres test has been exercised against an ephemeral `postgres:15-alpine` Docker locally over the past sub-tasks (PR #688, #695, #700, #702, #704, #706 — 22/22 passing each time), so the CI service block here is the same shape that already works.

## Checklist

- [x] Code follows project style guidelines (n/a — config only)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (inline YAML comments explain why each block exists, referencing AAASM-1741)
- [ ] All CI checks passing — pending CI run on this PR (this very PR's CI run will be the first to exercise the new postgres service end-to-end)
- [x] Commits are small and follow the Gitmoji convention

## Acceptance for this sub-task

- [x] CI matrix that previously did not exercise postgres tests now exercises them — Test + Coverage jobs both have the service.
- [x] Existing non-postgres CI jobs unaffected — only `test:` and `coverage:` jobs gain the service block; every other job (build, clippy, docs, deny, no-std, buf-lint, schema-lint, openapi-*, compat-matrix, ebpf-*, benchmark, conformance-*) is untouched.
- [x] Tests are skipped (not failed) when `AAASM_DATABASE_URL` is unset — guaranteed by the `pg_backend_or_skip()` helper that early-returns when the env var is missing; the dedicated CI Test run on this PR will be the canonical demonstration.

## Next sub-task

AAASM-1742 (E18 S-C #9) — final verification sub-task. Validates every Story AC against real PostgreSQL and produces a verification report under `verification-reports/`.