### PR TITLE
[AAASM-1854] ✨ (aa-cli/status): Add /healthz client + DB URL redaction helper

### DIFF
--- a/aa-cli/src/commands/status/client.rs
+++ b/aa-cli/src/commands/status/client.rs
@@ -2,7 +2,9 @@
 
 use reqwest::Client;
 
-use super::models::{AgentResponse, ApprovalResponse, CostResponse, HealthResponse, PaginatedResponse};
+use super::models::{
+    AgentResponse, ApprovalResponse, CostResponse, HealthResponse, HealthzResponse, PaginatedResponse,
+};
 use crate::error::CliError;
 
 /// Client for making status-related API requests.
@@ -35,6 +37,20 @@ impl StatusClient {
     pub async fn check_health(&self) -> Result<HealthResponse, CliError> {
         let resp = self.http.get(self.url("/api/v1/health")).send().await?;
         let body = resp.json::<HealthResponse>().await?;
+        Ok(body)
+    }
+
+    /// Fetch the lightweight gateway liveness probe via `GET /healthz`.
+    ///
+    /// Backs the deployment-overview section of `aasm status` — surfaces the
+    /// `mode`, `version`, `storage`, and `uptime_secs` fields published by
+    /// `aa-gateway::routes::healthz::healthz` regardless of deployment mode.
+    /// Returns an error when the gateway is unreachable or returns a body the
+    /// client cannot decode; callers map that to `health = "unreachable"`.
+    #[allow(dead_code)]
+    pub async fn check_healthz(&self) -> Result<HealthzResponse, CliError> {
+        let resp = self.http.get(self.url("/healthz")).send().await?;
+        let body = resp.json::<HealthzResponse>().await?;
         Ok(body)
     }
 

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -20,6 +20,44 @@ pub struct HealthResponse {
     pub pipeline_lag_ms: u64,
 }
 
+/// Redact the password component of a database connection URL.
+///
+/// Replaces the password segment of the userinfo portion of an authority-bearing
+/// URL with `***`. Used by the `aasm status` deployment overview so a postgres
+/// `database_url` can be displayed without leaking the credential.
+///
+/// Returns the input unchanged when:
+/// * the input is not a `scheme://...` URL,
+/// * the authority contains no `user:pass@` userinfo, or
+/// * the userinfo contains a username only (no `:password`).
+///
+/// The split point between userinfo and host is the rightmost `@` inside the
+/// authority — tolerating an `@` inside the password is intentional, since
+/// well-formed URLs percent-encode any such occurrence.
+pub fn redact_database_url(url: &str) -> String {
+    let Some(scheme_end) = url.find("://") else {
+        return url.to_string();
+    };
+    let authority_start = scheme_end + 3;
+    let authority_end = url[authority_start..]
+        .find(['/', '?', '#'])
+        .map(|i| authority_start + i)
+        .unwrap_or(url.len());
+    let authority = &url[authority_start..authority_end];
+
+    let Some(at_idx) = authority.rfind('@') else {
+        return url.to_string();
+    };
+    let userinfo = &authority[..at_idx];
+    let Some(colon_idx) = userinfo.find(':') else {
+        return url.to_string();
+    };
+
+    let user = &userinfo[..colon_idx];
+    let host_and_rest = &url[authority_start + at_idx..];
+    format!("{}://{}:***{}", &url[..scheme_end], user, host_and_rest)
+}
+
 /// API response from `GET /healthz` — the lightweight gateway liveness probe.
 ///
 /// Mirrors the wire contract published by `aa-gateway::routes::healthz::HealthzBody`

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -274,6 +274,12 @@ mod tests {
     }
 
     #[test]
+    fn redact_database_url_replaces_postgres_password() {
+        let redacted = redact_database_url("postgresql://aasm:secret@aasm-db:5432/aasm");
+        assert_eq!(redacted, "postgresql://aasm:***@aasm-db:5432/aasm");
+    }
+
+    #[test]
     fn healthz_response_deserializes_with_storage_path_and_database_url() {
         let json = r#"{
             "mode": "remote",

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -280,6 +280,12 @@ mod tests {
     }
 
     #[test]
+    fn redact_database_url_leaves_no_password_url_unchanged() {
+        let input = "postgresql://aasm@aasm-db:5432/aasm";
+        assert_eq!(redact_database_url(input), input);
+    }
+
+    #[test]
     fn healthz_response_deserializes_with_storage_path_and_database_url() {
         let json = r#"{
             "mode": "remote",

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -236,6 +236,27 @@ mod tests {
     }
 
     #[test]
+    fn healthz_response_deserializes_with_storage_path_and_database_url() {
+        let json = r#"{
+            "mode": "remote",
+            "version": "0.0.1",
+            "storage": "postgres",
+            "uptime_secs": 8133,
+            "storage_path": "~/.aasm/local.db",
+            "database_url": "postgresql://user:secret@aasm-db:5432/aasm"
+        }"#;
+        let resp: HealthzResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.mode, "remote");
+        assert_eq!(resp.storage, "postgres");
+        assert_eq!(resp.uptime_secs, 8133);
+        assert_eq!(resp.storage_path.as_deref(), Some("~/.aasm/local.db"));
+        assert_eq!(
+            resp.database_url.as_deref(),
+            Some("postgresql://user:secret@aasm-db:5432/aasm")
+        );
+    }
+
+    #[test]
     fn agent_response_deserializes() {
         let json = r#"{
             "id": "abc123",

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -224,6 +224,18 @@ mod tests {
     }
 
     #[test]
+    fn healthz_response_deserializes_minimal_body() {
+        let json = r#"{"mode":"local","version":"0.0.1","storage":"sqlite","uptime_secs":0}"#;
+        let resp: HealthzResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.mode, "local");
+        assert_eq!(resp.version, "0.0.1");
+        assert_eq!(resp.storage, "sqlite");
+        assert_eq!(resp.uptime_secs, 0);
+        assert!(resp.storage_path.is_none());
+        assert!(resp.database_url.is_none());
+    }
+
+    #[test]
     fn agent_response_deserializes() {
         let json = r#"{
             "id": "abc123",

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -292,6 +292,13 @@ mod tests {
     }
 
     #[test]
+    fn redact_database_url_leaves_malformed_input_unchanged() {
+        for input in ["~/.aasm/local.db", "not-a-url", "://no-scheme", ""] {
+            assert_eq!(redact_database_url(input), input, "input: {input:?}");
+        }
+    }
+
+    #[test]
     fn healthz_response_deserializes_with_storage_path_and_database_url() {
         let json = r#"{
             "mode": "remote",

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -286,6 +286,12 @@ mod tests {
     }
 
     #[test]
+    fn redact_database_url_leaves_sqlite_url_unchanged() {
+        let input = "sqlite:///home/dev/.aasm/local.db";
+        assert_eq!(redact_database_url(input), input);
+    }
+
+    #[test]
     fn healthz_response_deserializes_with_storage_path_and_database_url() {
         let json = r#"{
             "mode": "remote",

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -20,6 +20,37 @@ pub struct HealthResponse {
     pub pipeline_lag_ms: u64,
 }
 
+/// API response from `GET /healthz` — the lightweight gateway liveness probe.
+///
+/// Mirrors the wire contract published by `aa-gateway::routes::healthz::HealthzBody`
+/// (landed under AAASM-1577 ST-1). Field names are part of that contract — do
+/// not rename without a coordinated server-side update.
+///
+/// `storage_path` and `database_url` are reserved for the richer
+/// `GET /api/v1/admin/status` response (AAASM-1474) and remain `None` when the
+/// gateway exposes only the minimum `/healthz` body; the `aasm status`
+/// deployment overview opportunistically surfaces them when present.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct HealthzResponse {
+    /// Deployment mode label: `"local"` or `"remote"`.
+    pub mode: String,
+    /// Gateway crate version.
+    pub version: String,
+    /// Storage backend label: `"sqlite"`, `"postgres"`, or `"memory"`.
+    pub storage: String,
+    /// Seconds elapsed since the gateway became ready to serve traffic.
+    pub uptime_secs: u64,
+    /// Local-mode SQLite file path, when reported.
+    #[serde(default)]
+    pub storage_path: Option<String>,
+    /// Raw PostgreSQL connection URL, when reported.
+    ///
+    /// Password redaction is applied by the display-layer composer, not here —
+    /// this model preserves the wire shape the gateway sent.
+    #[serde(default)]
+    pub database_url: Option<String>,
+}
+
 /// Computed runtime health for display.
 #[derive(Debug, Clone, Serialize)]
 pub struct RuntimeHealth {


### PR DESCRIPTION
## Description

Input-side wiring for the new `aasm status` deployment-overview header. Adds:

- `HealthzResponse` deserialize struct mirroring `aa-gateway::routes::healthz::HealthzBody` (with forward-compat optional `storage_path` / `database_url` fields used by later sub-tasks).
- Pure `redact_database_url(url: &str) -> String` helper — replaces the password segment of a `scheme://user:pass@host/...` URL with `***`. Returns input unchanged for sqlite paths, no-password URLs, and any malformed inputs.
- `StatusClient::check_healthz()` — `GET {base}/healthz` returning `HealthzResponse`.

No render/dispatch changes here — ST-2..ST-5 plug into this. `check_healthz` is annotated `#[allow(dead_code)]` in this commit and is removed by ST-3 when `fetch_all` starts calling it.

First Sub-task of Story AAASM-1579 (E17 S-E: \`aasm status\` deployment overview); part of Epic AAASM-1568 (Epic 17: Gateway Deployment Architecture).

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: [AAASM-1854](https://lightning-dust-mite.atlassian.net/browse/AAASM-1854) (Sub-task of [AAASM-1579](https://lightning-dust-mite.atlassian.net/browse/AAASM-1579), Epic [AAASM-1568](https://lightning-dust-mite.atlassian.net/browse/AAASM-1568))
- Related GitHub issues: —

## Testing

- [x] Unit tests added / updated — 6 new tests under `aa-cli/src/commands/status/models.rs`:
  - `healthz_response_deserializes_minimal_body`
  - `healthz_response_deserializes_with_storage_path_and_database_url`
  - `redact_database_url_replaces_postgres_password`
  - `redact_database_url_leaves_no_password_url_unchanged`
  - `redact_database_url_leaves_sqlite_url_unchanged`
  - `redact_database_url_leaves_malformed_input_unchanged`
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Local: \`cargo nextest run -p aa-cli\` → **527 tests run: 527 passed, 0 skipped**.

## Checklist

- [x] Code follows project style guidelines (\`cargo fmt\`, \`cargo clippy\`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (doc-comments on the new public items)
- [ ] All CI checks passing (will verify after push)
- [x] Commits are small and follow the Gitmoji convention (9 commits, one per struct / helper / test)

[AAASM-1854]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ