### PR TITLE
[AAASM-1848] ✨ (aa-gateway/migrations): Add TimescaleDB hypertable migration

### DIFF
--- a/aa-gateway/migrations/postgres/0002_timescaledb_hypertables.sql
+++ b/aa-gateway/migrations/postgres/0002_timescaledb_hypertables.sql
@@ -1,0 +1,64 @@
+-- E18 S-D #1 — Promote audit_events and metrics to TimescaleDB hypertables.
+--
+-- TimescaleDB is a PostgreSQL extension that transparently partitions
+-- time-series tables into time-ordered chunks. Queries that filter by `ts`
+-- only scan the relevant chunks (10–100× faster than full-table scans on
+-- the un-promoted tables), and the auto-compression policy shrinks chunks
+-- older than the configured threshold (10–20× space savings).
+--
+-- This migration is **graceful** when the TimescaleDB extension is not
+-- installed in the cluster: both DO blocks swallow the relevant SQLSTATE
+-- codes and emit a NOTICE instead of failing. Plain PostgreSQL deployments
+-- keep using the standard tables defined in 0001_initial.sql with no
+-- runtime difference beyond the unused indexes.
+--
+-- The hypertable settings here intentionally match the static defaults in
+-- `aa-core::config::TimescaleConfig` (chunk_interval: 7 days for audit,
+-- 1 day for metrics; compression policy: 30 days for audit, 7 days for
+-- metrics). Operators who tune those config values must apply matching
+-- ALTER statements out-of-band — sqlx migrations are versioned and
+-- immutable once applied.
+
+-- Step 1: try to install the extension. On a plain PostgreSQL cluster the
+-- control file is missing and CREATE EXTENSION raises feature_not_supported
+-- (or undefined_file); we catch both so the migration succeeds anyway.
+DO $$
+BEGIN
+    CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE NOTICE 'TimescaleDB extension not available (%): skipping hypertable setup. \
+                      Install the TimescaleDB extension for time-series query \
+                      acceleration and auto-compression.', SQLERRM;
+END $$;
+
+-- Step 2: promote audit_events and metrics to hypertables and attach
+-- compression policies. If step 1 failed silently the create_hypertable()
+-- function will not exist, raising undefined_function — also caught.
+DO $$
+BEGIN
+    PERFORM create_hypertable(
+        'audit_events', 'ts',
+        chunk_time_interval => INTERVAL '7 days',
+        if_not_exists       => TRUE
+    );
+    PERFORM add_compression_policy(
+        'audit_events',
+        INTERVAL '30 days',
+        if_not_exists => TRUE
+    );
+
+    PERFORM create_hypertable(
+        'metrics', 'ts',
+        chunk_time_interval => INTERVAL '1 day',
+        if_not_exists       => TRUE
+    );
+    PERFORM add_compression_policy(
+        'metrics',
+        INTERVAL '7 days',
+        if_not_exists => TRUE
+    );
+EXCEPTION
+    WHEN undefined_function THEN
+        RAISE NOTICE 'TimescaleDB functions unavailable; hypertables not created (plain PostgreSQL fallback)';
+END $$;

--- a/aa-gateway/src/storage/postgres.rs
+++ b/aa-gateway/src/storage/postgres.rs
@@ -934,6 +934,53 @@ mod tests {
         backend.migrate().await.expect("second migrate should be a no-op");
     }
 
+    /// Migration 0002 must apply cleanly on a plain PostgreSQL cluster that
+    /// has no TimescaleDB extension installed — both DO blocks in the
+    /// migration swallow the relevant SQLSTATE codes and emit NOTICEs.
+    /// Verifies the graceful-fallback path so that production deployments
+    /// without the extension do not fail at startup.
+    ///
+    /// Runs only when `AAASM_DATABASE_URL` points at a vanilla PostgreSQL
+    /// instance, i.e. `TIMESCALEDB_AVAILABLE` is not set to `1`. The CI
+    /// `Test` job (postgres:18-alpine service) exercises this path.
+    #[tokio::test]
+    async fn migrate_0002_succeeds_when_timescaledb_extension_absent() {
+        if std::env::var("TIMESCALEDB_AVAILABLE").as_deref() == Ok("1") {
+            eprintln!(
+                "skipping plain-postgres test: TIMESCALEDB_AVAILABLE=1 (see migrate_0002_creates_hypertables_when_timescaledb_active for the present-path test)"
+            );
+            return;
+        }
+        let Some(backend) = pg_backend_or_skip().await else {
+            return;
+        };
+        backend
+            .migrate()
+            .await
+            .expect("migrate must not fail on plain PostgreSQL");
+
+        let has_extension: bool =
+            sqlx::query_scalar("SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb')")
+                .fetch_one(&backend.pool)
+                .await
+                .expect("query pg_extension");
+        assert!(
+            !has_extension,
+            "this test asserts the extension-absent path; if your CI installed TimescaleDB, set TIMESCALEDB_AVAILABLE=1"
+        );
+
+        let hypertable_schema_present: bool = sqlx::query_scalar(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = '_timescaledb_internal')",
+        )
+        .fetch_one(&backend.pool)
+        .await
+        .expect("query information_schema.schemata");
+        assert!(
+            !hypertable_schema_present,
+            "TimescaleDB internal schema must NOT exist when extension is absent"
+        );
+    }
+
     /// Mint a fresh, unique [`AgentId`] so every test can scope its
     /// inserts and assertions against an isolated key — necessary because
     /// the audit_events table is shared across all postgres tests when

--- a/aa-gateway/src/storage/postgres.rs
+++ b/aa-gateway/src/storage/postgres.rs
@@ -981,6 +981,54 @@ mod tests {
         );
     }
 
+    /// Migration 0002 must promote `audit_events` and `metrics` to
+    /// TimescaleDB hypertables when the extension is available. Exercises
+    /// the present-path: hypertable rows appear in
+    /// `timescaledb_information.hypertables` for both tables.
+    ///
+    /// Runs only when `TIMESCALEDB_AVAILABLE=1` is set — the CI
+    /// `timescaledb-tests` job (AAASM-1858 / SD-5) wires this against the
+    /// `timescale/timescaledb:latest-pg17` service container.
+    #[tokio::test]
+    async fn migrate_0002_creates_hypertables_when_timescaledb_active() {
+        if std::env::var("TIMESCALEDB_AVAILABLE").as_deref() != Ok("1") {
+            eprintln!(
+                "skipping timescaledb present-path test: TIMESCALEDB_AVAILABLE != 1 (set to 1 when AAASM_DATABASE_URL points at a TimescaleDB-enabled instance)"
+            );
+            return;
+        }
+        let Some(backend) = pg_backend_or_skip().await else {
+            return;
+        };
+        backend
+            .migrate()
+            .await
+            .expect("migrate must not fail on a TimescaleDB-enabled PostgreSQL");
+
+        let has_extension: bool =
+            sqlx::query_scalar("SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb')")
+                .fetch_one(&backend.pool)
+                .await
+                .expect("query pg_extension");
+        assert!(
+            has_extension,
+            "TIMESCALEDB_AVAILABLE=1 was set but the timescaledb extension is not installed; \
+             check the docker image is timescale/timescaledb:latest-pg17"
+        );
+
+        let hypertable_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM timescaledb_information.hypertables \
+             WHERE hypertable_name IN ('audit_events', 'metrics')",
+        )
+        .fetch_one(&backend.pool)
+        .await
+        .expect("query timescaledb_information.hypertables");
+        assert_eq!(
+            hypertable_count, 2,
+            "expected both audit_events and metrics to be promoted to hypertables, found {hypertable_count}"
+        );
+    }
+
     /// Mint a fresh, unique [`AgentId`] so every test can scope its
     /// inserts and assertions against an isolated key — necessary because
     /// the audit_events table is shared across all postgres tests when


### PR DESCRIPTION
## Description

Adds the PostgreSQL-only migration `0002_timescaledb_hypertables.sql` that promotes `audit_events` and `metrics` to TimescaleDB hypertables with auto-compression. The migration is **graceful**: on a plain PostgreSQL cluster the two `DO $$` blocks swallow the missing-extension SQLSTATE codes and emit `NOTICE`s; on a TimescaleDB-enabled cluster the hypertables are created with the chunk intervals + compression policies that match `aa-core::TimescaleConfig` defaults.

Story decomposition for AAASM-1586 (E18 S-D). This is sub-task **SD-1** of 5 (impl) + 1 (verify).

| Setting | audit_events | metrics |
|---|---|---|
| Chunk interval | 7 days | 1 day |
| Compression policy threshold | 30 days | 7 days |

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

This migration is **additive** — plain PG deployments are unaffected (graceful fallback); TimescaleDB deployments gain hypertable + compression.

## Related Issues

- Related Jira ticket: [AAASM-1848](https://lightning-dust-mite.atlassian.net/browse/AAASM-1848) (parent Story: [AAASM-1586](https://lightning-dust-mite.atlassian.net/browse/AAASM-1586), Epic: [AAASM-1569](https://lightning-dust-mite.atlassian.net/browse/AAASM-1569))

## Testing

- [x] Unit tests added — two new tests in `aa-gateway/src/storage/postgres.rs::tests`:
  - `migrate_0002_succeeds_when_timescaledb_extension_absent` — runs on the existing `Test` job's `postgres:18-alpine` service. Asserts migrate succeeds, no `timescaledb` row in `pg_extension`, no `_timescaledb_internal` schema. Skips when `TIMESCALEDB_AVAILABLE=1`.
  - `migrate_0002_creates_hypertables_when_timescaledb_active` — env-gated on `TIMESCALEDB_AVAILABLE=1`. Asserts hypertables for both tables are listed in `timescaledb_information.hypertables`. Wired by SD-5 (AAASM-1858) which adds the `timescaledb-tests` CI job.
- [x] All existing `aa-gateway storage::migrations` tests pass locally (6/6 green, including the `Postgres::default()` testcontainer test).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed — migration file header explains the graceful-fallback contract
- [ ] All CI checks passing — will validate on push
- [x] Commits are small and follow the Gitmoji convention (3 commits, one per logical unit)

## Commit log

1. `✨ (aa-gateway/migrations): Add 0002_timescaledb_hypertables.sql`
2. `✅ (aa-gateway/storage): Test 0002 migration on plain postgres`
3. `✅ (aa-gateway/storage): Test 0002 migration on timescaledb container`

[AAASM-1848]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1586]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ