### PR TITLE
[AAASM-1554] ✨ (aa-core): Add EnforcementMode enum and PolicyDocument field

### DIFF
--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -275,6 +275,7 @@ fn load_policy() -> PolicyDocument {
         version: 1,
         name: "default".into(),
         rules: Vec::<PolicyRule>::new(),
+        enforcement_mode: aa_core::EnforcementMode::default(),
     }
 }
 

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -43,7 +43,7 @@ pub mod topology;
 
 pub use dev_tool::GovernanceLevel;
 pub use identity::{AgentId, SessionId};
-pub use policy::{FileMode, PolicyDecision, PolicyError};
+pub use policy::{EnforcementMode, FileMode, PolicyDecision, PolicyError};
 pub use risk_tier::RiskTier;
 
 #[cfg(feature = "alloc")]

--- a/aa-core/src/policy.rs
+++ b/aa-core/src/policy.rs
@@ -329,6 +329,23 @@ mod tests {
         assert_eq!(EnforcementMode::default(), EnforcementMode::Enforce);
     }
 
+    #[cfg(feature = "serde")]
+    #[test]
+    fn enforcement_mode_serde_snake_case_round_trip() {
+        // The wire / YAML representation must use lowercase tokens — operators
+        // type `enforcement_mode: observe`, not `Observe`.
+        for (mode, expected) in [
+            (EnforcementMode::Enforce, "\"enforce\""),
+            (EnforcementMode::Observe, "\"observe\""),
+            (EnforcementMode::Disabled, "\"disabled\""),
+        ] {
+            let json = serde_json::to_string(&mode).unwrap();
+            assert_eq!(json, expected, "{mode:?} must serialise as {expected}");
+            let back: EnforcementMode = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, mode, "{expected} must deserialise back to {mode:?}");
+        }
+    }
+
     #[test]
     #[cfg(feature = "alloc")]
     fn policy_rule_field_access_clone_eq() {

--- a/aa-core/src/policy.rs
+++ b/aa-core/src/policy.rs
@@ -329,6 +329,19 @@ mod tests {
         assert_eq!(EnforcementMode::default(), EnforcementMode::Enforce);
     }
 
+    #[test]
+    fn enforcement_mode_from_proto_i32_round_trips_known_values() {
+        // The proto reserves 0 for UNSPECIFIED — it must NOT silently coerce
+        // to Enforce here; only valid 1/2/3 produce Some(_). Server-side
+        // resolution is responsible for picking a default for unspecified.
+        assert_eq!(EnforcementMode::from_proto_i32(1), Some(EnforcementMode::Enforce));
+        assert_eq!(EnforcementMode::from_proto_i32(2), Some(EnforcementMode::Observe));
+        assert_eq!(EnforcementMode::from_proto_i32(3), Some(EnforcementMode::Disabled));
+        assert_eq!(EnforcementMode::from_proto_i32(0), None);
+        assert_eq!(EnforcementMode::from_proto_i32(-1), None);
+        assert_eq!(EnforcementMode::from_proto_i32(99), None);
+    }
+
     #[cfg(feature = "serde")]
     #[test]
     fn enforcement_mode_serde_snake_case_round_trip() {

--- a/aa-core/src/policy.rs
+++ b/aa-core/src/policy.rs
@@ -324,6 +324,12 @@ mod tests {
     }
 
     #[test]
+    fn enforcement_mode_default_is_enforce() {
+        // Pre-feature semantics: omitting the mode anywhere must resolve to Enforce.
+        assert_eq!(EnforcementMode::default(), EnforcementMode::Enforce);
+    }
+
+    #[test]
     #[cfg(feature = "alloc")]
     fn policy_rule_field_access_clone_eq() {
         let rule = PolicyRule {

--- a/aa-core/src/policy.rs
+++ b/aa-core/src/policy.rs
@@ -54,6 +54,48 @@ pub enum PolicyDecision {
     RequireApproval,
 }
 
+/// Controls whether policy decisions are applied to agent actions or only observed.
+///
+/// Mirrors the proto `EnforcementMode` enum defined in `proto/policy.proto` so
+/// pure-Rust code can reason about the enforcement posture without a proto
+/// dependency.
+///
+/// | Mode       | Proto value | Effect on `Deny` / `Redact` / `Pending` / `BudgetBlock` |
+/// |------------|-------------|---------------------------------------------------------|
+/// | `Enforce`  | 1           | Decision applied; agent blocked / payload redacted.     |
+/// | `Observe`  | 2           | Decision recorded as a shadow audit event; agent proceeds. |
+/// | `Disabled` | 3           | Policy evaluation skipped entirely (test environments). |
+///
+/// `Enforce` is the default — omitting `enforcement_mode` from any
+/// policy document or registration payload leaves existing behavior unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+pub enum EnforcementMode {
+    /// Default: deny blocks, redact strips, pending halts execution.
+    #[default]
+    Enforce,
+    /// Dry-run / sandbox: decisions computed and audited; no enforcement applied.
+    Observe,
+    /// Policy evaluation disabled entirely. Only valid in hermetic test environments.
+    Disabled,
+}
+
+impl EnforcementMode {
+    /// Convert from the proto integer value (1=Enforce … 3=Disabled).
+    ///
+    /// Returns `None` for 0 (UNSPECIFIED) and any out-of-range value so callers
+    /// can fall back to a server-side default rather than silently coercing.
+    pub fn from_proto_i32(v: i32) -> Option<Self> {
+        match v {
+            1 => Some(Self::Enforce),
+            2 => Some(Self::Observe),
+            3 => Some(Self::Disabled),
+            _ => None,
+        }
+    }
+}
+
 /// A single rule inside a `PolicyDocument`.
 ///
 /// Gated on `alloc` because `action_pattern` is a `String`.

--- a/aa-core/src/policy.rs
+++ b/aa-core/src/policy.rs
@@ -125,6 +125,11 @@ pub struct PolicyDocument {
     pub name: alloc::string::String,
     /// Ordered list of rules evaluated top-to-bottom.
     pub rules: alloc::vec::Vec<PolicyRule>,
+    /// Enforcement posture for this policy. Defaults to `Enforce` when the
+    /// field is absent from the source document, preserving pre-feature
+    /// behavior for all existing policies.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub enforcement_mode: EnforcementMode,
 }
 
 /// The outcome of a `PolicyEvaluator::evaluate` call.
@@ -341,6 +346,7 @@ mod tests {
                 action_pattern: alloc::string::String::from("*"),
                 decision: PolicyDecision::Allow,
             }],
+            enforcement_mode: EnforcementMode::default(),
         };
         let cloned = doc.clone();
         assert_eq!(doc, cloned);

--- a/aa-core/src/policy.rs
+++ b/aa-core/src/policy.rs
@@ -392,6 +392,16 @@ mod tests {
         assert_eq!(doc.rules[0].decision, PolicyDecision::Allow);
     }
 
+    #[cfg(all(feature = "alloc", feature = "serde"))]
+    #[test]
+    fn policy_document_enforcement_mode_defaults_to_enforce_when_absent() {
+        // Backward compatibility: pre-feature YAML / JSON policy documents
+        // never had this field, so deserialising one must produce Enforce.
+        let yaml = "version: 1\nname: legacy-policy\nrules: []\n";
+        let doc: PolicyDocument = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(doc.enforcement_mode, EnforcementMode::Enforce);
+    }
+
     #[test]
     #[cfg(feature = "alloc")]
     fn policy_result_cross_variant_inequality() {

--- a/aa-core/src/policy.rs
+++ b/aa-core/src/policy.rs
@@ -394,6 +394,16 @@ mod tests {
 
     #[cfg(all(feature = "alloc", feature = "serde"))]
     #[test]
+    fn policy_document_enforcement_mode_parses_observe_from_yaml() {
+        // An operator-authored sandbox policy: `enforcement_mode: observe`
+        // at the document root must surface as EnforcementMode::Observe.
+        let yaml = "version: 1\nname: sandbox-policy\nenforcement_mode: observe\nrules: []\n";
+        let doc: PolicyDocument = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(doc.enforcement_mode, EnforcementMode::Observe);
+    }
+
+    #[cfg(all(feature = "alloc", feature = "serde"))]
+    #[test]
     fn policy_document_enforcement_mode_defaults_to_enforce_when_absent() {
         // Backward compatibility: pre-feature YAML / JSON policy documents
         // never had this field, so deserialising one must produce Enforce.

--- a/aa-devtool-claude-code/src/settings.rs
+++ b/aa-devtool-claude-code/src/settings.rs
@@ -82,6 +82,7 @@ mod tests {
             version: 1,
             name: "test".to_string(),
             rules,
+            enforcement_mode: aa_core::EnforcementMode::default(),
         }
     }
 

--- a/aa-devtool-codex/src/approval.rs
+++ b/aa-devtool-codex/src/approval.rs
@@ -121,6 +121,7 @@ mod tests {
                     decision: dec,
                 })
                 .collect(),
+            enforcement_mode: aa_core::EnforcementMode::default(),
         }
     }
 

--- a/aa-devtool-codex/src/sandbox.rs
+++ b/aa-devtool-codex/src/sandbox.rs
@@ -135,7 +135,7 @@ fn find_sandbox_override(policy: &PolicyDocument) -> Option<CodexSandboxMode> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aa_core::policy::{PolicyDecision, PolicyDocument, PolicyRule};
+    use aa_core::policy::{EnforcementMode, PolicyDecision, PolicyDocument, PolicyRule};
 
     fn make_policy(rules: Vec<(&str, PolicyDecision)>) -> PolicyDocument {
         PolicyDocument {
@@ -148,6 +148,7 @@ mod tests {
                     decision: dec,
                 })
                 .collect(),
+            enforcement_mode: EnforcementMode::default(),
         }
     }
 

--- a/aa-devtool-codex/tests/wrapper.rs
+++ b/aa-devtool-codex/tests/wrapper.rs
@@ -60,6 +60,7 @@ fn fixture_policy() -> PolicyDocument {
                 decision: PolicyDecision::Allow,
             },
         ],
+        enforcement_mode: aa_core::EnforcementMode::default(),
     }
 }
 
@@ -114,6 +115,7 @@ async fn apply_settings_merges_preserving_user_managed_keys() {
     let allow_policy = PolicyDocument {
         version: 1,
         name: "allow-all".into(),
+        enforcement_mode: aa_core::EnforcementMode::default(),
         rules: vec![PolicyRule {
             action_pattern: "*".into(),
             decision: PolicyDecision::Allow,

--- a/aa-devtool-copilot/src/lib.rs
+++ b/aa-devtool-copilot/src/lib.rs
@@ -442,6 +442,7 @@ mod tests {
             version: 1,
             name: "test".to_string(),
             rules: vec![],
+            enforcement_mode: aa_core::EnforcementMode::default(),
         }
     }
 
@@ -453,6 +454,7 @@ mod tests {
                 action_pattern: pattern.to_string(),
                 decision,
             }],
+            enforcement_mode: aa_core::EnforcementMode::default(),
         }
     }
 
@@ -467,6 +469,7 @@ mod tests {
                     decision: PolicyDecision::Deny,
                 })
                 .collect(),
+            enforcement_mode: aa_core::EnforcementMode::default(),
         }
     }
 
@@ -580,6 +583,7 @@ mod tests {
                     decision: PolicyDecision::Deny,
                 },
             ],
+            enforcement_mode: aa_core::EnforcementMode::default(),
         };
         let adapter = CopilotAdapter::new();
         let json = adapter.generate_managed_settings(&policy).await.unwrap();
@@ -732,6 +736,7 @@ mod tests {
                 action_pattern: "mcp_tool:filesystem:read_file".to_string(),
                 decision: PolicyDecision::RequireApproval,
             }],
+            enforcement_mode: aa_core::EnforcementMode::default(),
         };
         let adapter = CopilotAdapter::new();
         let json = adapter.generate_managed_settings(&policy).await.unwrap();

--- a/aa-devtool-windsurf/tests/contract.rs
+++ b/aa-devtool-windsurf/tests/contract.rs
@@ -89,6 +89,7 @@ async fn generate_managed_settings_returns_valid_json_with_auto_approve_false() 
         version: 1,
         name: "test-policy".into(),
         rules: vec![],
+        enforcement_mode: aa_core::EnforcementMode::default(),
     };
     let rendered = adapter().generate_managed_settings(&policy).await.expect("generate");
     let parsed: serde_json::Value = serde_json::from_str(&rendered).expect("valid json");
@@ -109,6 +110,7 @@ async fn generate_managed_settings_deny_terminal_exec_yields_empty_allowlist() {
             action_pattern: "terminal_exec".into(),
             decision: aa_core::PolicyDecision::Deny,
         }],
+        enforcement_mode: aa_core::EnforcementMode::default(),
     };
     let rendered = adapter().generate_managed_settings(&policy).await.expect("generate");
     let parsed: serde_json::Value = serde_json::from_str(&rendered).expect("valid json");
@@ -132,6 +134,7 @@ async fn generate_managed_settings_allow_terminal_command_adds_to_allowlist() {
             action_pattern: "terminal_exec:git".into(),
             decision: aa_core::PolicyDecision::Allow,
         }],
+        enforcement_mode: aa_core::EnforcementMode::default(),
     };
     let rendered = adapter().generate_managed_settings(&policy).await.expect("generate");
     let parsed: serde_json::Value = serde_json::from_str(&rendered).expect("valid json");
@@ -153,6 +156,7 @@ async fn generate_managed_settings_mcp_tool_deny_adds_to_disabled_servers() {
             action_pattern: "mcp_tool:github".into(),
             decision: aa_core::PolicyDecision::Deny,
         }],
+        enforcement_mode: aa_core::EnforcementMode::default(),
     };
     let rendered = adapter().generate_managed_settings(&policy).await.expect("generate");
     let parsed: serde_json::Value = serde_json::from_str(&rendered).expect("valid json");

--- a/aa-devtool/src/adapters/claude_code.rs
+++ b/aa-devtool/src/adapters/claude_code.rs
@@ -102,6 +102,7 @@ mod tests {
             version: 1,
             name: "test".into(),
             rules: vec![],
+            enforcement_mode: aa_core::EnforcementMode::default(),
         };
         assert!(ClaudeCodeAdapter.generate_managed_settings(&policy).await.is_err());
     }

--- a/aa-devtool/src/adapters/codex.rs
+++ b/aa-devtool/src/adapters/codex.rs
@@ -102,6 +102,7 @@ mod tests {
             version: 1,
             name: "test".into(),
             rules: vec![],
+            enforcement_mode: aa_core::EnforcementMode::default(),
         };
         assert!(CodexAdapter.generate_managed_settings(&policy).await.is_err());
     }

--- a/aa-devtool/src/adapters/copilot.rs
+++ b/aa-devtool/src/adapters/copilot.rs
@@ -112,6 +112,7 @@ mod tests {
             version: 1,
             name: "test".into(),
             rules: vec![],
+            enforcement_mode: aa_core::EnforcementMode::default(),
         };
         assert!(CopilotAdapter.generate_managed_settings(&policy).await.is_err());
     }

--- a/aa-devtool/src/adapters/windsurf.rs
+++ b/aa-devtool/src/adapters/windsurf.rs
@@ -119,6 +119,7 @@ mod tests {
             version: 1,
             name: "test".into(),
             rules: vec![],
+            enforcement_mode: aa_core::EnforcementMode::default(),
         };
         assert!(WindsurfAdapter.generate_managed_settings(&policy).await.is_err());
     }

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1650,6 +1650,7 @@ mod tests {
             version: 1,
             name: "stub".to_string(),
             rules: vec![],
+            enforcement_mode: aa_core::EnforcementMode::default(),
         };
         // PolicyEngine now also exposes an inherent `load_policy` that
         // returns a `PolicyId` (AAASM-951). Use fully-qualified syntax so
@@ -1668,6 +1669,7 @@ mod tests {
             version: 1,
             name: "stub".to_string(),
             rules: vec![],
+            enforcement_mode: aa_core::EnforcementMode::default(),
         };
         let result = engine.validate_policy(&stub);
         assert_eq!(result, Err(vec![aa_core::PolicyError::InvalidDocument]));

--- a/examples/aa-devtool-sample-myeditor/tests/contract.rs
+++ b/examples/aa-devtool-sample-myeditor/tests/contract.rs
@@ -74,6 +74,7 @@ async fn generate_managed_settings_returns_valid_json() {
         version: 1,
         name: "sample-test-policy".into(),
         rules: vec![],
+        enforcement_mode: aa_core::EnforcementMode::default(),
     };
     let rendered = adapter().generate_managed_settings(&policy).await.expect("generate");
     let parsed: serde_json::Value = serde_json::from_str(&rendered).expect("valid json");


### PR DESCRIPTION
## Description

Foundation subtask for Story AAASM-1553 (Sandbox / Dry-Run Enforcement Mode). Introduces the `EnforcementMode` enum (`Enforce` / `Observe` / `Disabled`) in `aa-core::policy` and wires it into `PolicyDocument` so YAML / JSON policy documents can carry the enforcement posture from disk through to the runtime.

All other subtasks (proto, gateway evaluator, CLI, SDKs, dashboard) depend on this type being available. Server-side behavior is unchanged in this PR — the new field defaults to `Enforce` everywhere it appears, preserving backward compatibility for every existing policy.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

`PolicyDocument` gains one field, but it is `#[serde(default)]` so every existing on-disk policy continues to deserialise identically (mode = `Enforce`). The wire format is unchanged until AAASM-1555 lands the proto enum.

## Related Issues

- Related Jira ticket: [AAASM-1554](https://lightning-dust-mite.atlassian.net/browse/AAASM-1554) (Story: [AAASM-1553](https://lightning-dust-mite.atlassian.net/browse/AAASM-1553) under Epic [AAASM-196](https://lightning-dust-mite.atlassian.net/browse/AAASM-196))

## What's in here

8 small commits, each one bisectable:

1. ✨ Add `EnforcementMode` enum to `policy` module (with `from_proto_i32` helper)
2. 🔧 Re-export `EnforcementMode` from crate root
3. ✨ Add `enforcement_mode` field to `PolicyDocument` (+ updates every existing struct literal across the workspace so the workspace stays green at HEAD)
4. ✅ `enforcement_mode_default_is_enforce`
5. ✅ `enforcement_mode_serde_snake_case_round_trip`
6. ✅ `enforcement_mode_from_proto_i32_round_trips_known_values`
7. ✅ `policy_document_enforcement_mode_defaults_to_enforce_when_absent`
8. ✅ `policy_document_enforcement_mode_parses_observe_from_yaml`

## Testing

- [x] Unit tests added / updated — 5 new tests covering the AC for this subtask
- [x] No tests required (explain why) — N/A

```
cargo nextest run -p aa-core --all-features     # 245 / 245 pass
cargo nextest run -p aa-devtool -p aa-devtool-codex \
                  -p aa-devtool-copilot -p aa-devtool-claude-code \
                  -p aa-devtool-windsurf                       # 167 / 167 pass
cargo clippy --workspace --all-targets --all-features -- -D warnings  # clean
cargo doc -p aa-core --no-deps                  # 2 pre-existing warnings, none new
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on enum + new field)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1554]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1553]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ