### PR TITLE
[AAASM-1859] ✨ (aa-gateway): Add AppState and wire StorageBackend construction at boot

### DIFF
--- a/aa-gateway/src/app_state.rs
+++ b/aa-gateway/src/app_state.rs
@@ -42,3 +42,48 @@ impl AppState {
         Self { storage }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{SqliteBackend, SqliteConfig};
+
+    /// Constructing `AppState` exposes the storage handle through the
+    /// public `storage` field — the single dependency promised by the
+    /// Story S-I acceptance criteria. The healthcheck round-trips
+    /// through the `dyn StorageBackend` vtable, proving the type
+    /// erasure is wired correctly.
+    #[tokio::test]
+    async fn app_state_holds_storage_handle() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let backend = SqliteBackend::open(&SqliteConfig {
+            path: tmp.path().join("local.db"),
+        })
+        .await
+        .expect("open backend");
+        backend.migrate().await.expect("migrate");
+        let state = AppState::new(Arc::new(backend));
+        state
+            .storage
+            .healthcheck()
+            .await
+            .expect("healthcheck round-trips through dyn StorageBackend");
+    }
+
+    /// `AppState` is `Clone`, so handlers and background tasks can
+    /// take an owned copy without forcing the gateway to hand out
+    /// `Arc<AppState>` everywhere.
+    #[tokio::test]
+    async fn app_state_is_clone() {
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let backend = SqliteBackend::open(&SqliteConfig {
+            path: tmp.path().join("local.db"),
+        })
+        .await
+        .expect("open backend");
+        let state = AppState::new(Arc::new(backend));
+        let clone = state.clone();
+        // Both clones share the same Arc<dyn StorageBackend>.
+        assert!(Arc::ptr_eq(&state.storage, &clone.storage));
+    }
+}

--- a/aa-gateway/src/app_state.rs
+++ b/aa-gateway/src/app_state.rs
@@ -1,0 +1,44 @@
+//! Gateway application state — the single owning struct for runtime
+//! dependencies shared across request handlers and background tasks.
+//!
+//! This module lands as part of Epic 18 Story S-I (AAASM-1590) and is
+//! initially small: it owns the [`StorageBackend`] handle and nothing
+//! else. Subsequent sub-tasks of the Story progressively migrate
+//! `AgentRegistry`, the audit channel, and the retention engine
+//! `JoinHandle` onto this struct so that every code path that needs
+//! durable data has one canonical place to fetch it from.
+
+use std::sync::Arc;
+
+use crate::storage::StorageBackend;
+
+/// Runtime dependencies shared across the gateway's request handlers
+/// and background tasks.
+///
+/// The struct is intentionally minimal in this Sub-task (E18 S-I.1):
+/// only the storage handle is present. Later Sub-tasks extend it with
+/// the `AgentRegistry` write-through cache (S-I.2), the audit-event
+/// pipeline (S-I.3), and the retention engine `JoinHandle` (S-I.4).
+///
+/// Cloning is cheap: every field is wrapped in `Arc`.
+#[derive(Clone)]
+pub struct AppState {
+    /// Durable storage backend. `Arc<dyn StorageBackend>` keeps the
+    /// concrete backend (SQLite locally, PostgreSQL in production)
+    /// invisible to call sites and matches the Story acceptance
+    /// criterion "`storage: Arc<dyn StorageBackend>` is the single
+    /// dependency for all data access in `AppState`".
+    pub storage: Arc<dyn StorageBackend>,
+}
+
+impl AppState {
+    /// Build a new `AppState` from an already-opened storage backend.
+    ///
+    /// Callers are expected to have invoked
+    /// [`StorageBackend::migrate`](crate::storage::StorageBackend::migrate)
+    /// on the backend before passing it in; this constructor does not
+    /// re-run migrations.
+    pub fn new(storage: Arc<dyn StorageBackend>) -> Self {
+        Self { storage }
+    }
+}

--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod alerts;
 pub mod anomaly;
+pub mod app_state;
 pub mod approval;
 pub mod audit;
 pub mod audit_reader;

--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -27,6 +27,7 @@ pub mod service;
 pub mod simulation;
 pub mod storage;
 
+pub use app_state::AppState;
 pub use audit_reader::AuditReader;
 pub use engine::{EvaluationResult, PolicyEngine, PolicyLoadError};
 pub use registry::{AgentRecord, AgentRegistry, AgentStatus};

--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -9,14 +9,16 @@
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use aa_core::config::LocalModeConfig;
 use axum::{routing::get, Extension, Router};
-use sqlx::sqlite::{SqliteConnectOptions, SqlitePool};
+use sqlx::sqlite::SqlitePool;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
 
 use crate::routes::healthz::{healthz, HealthzState};
+use crate::storage::{SqliteBackend, SqliteConfig, StorageBackend, StorageError};
 
 /// Handle returned by `start_local()` once the local control plane is up.
 ///
@@ -46,6 +48,14 @@ pub struct LocalGatewayHandle {
     pub(crate) server_task: Option<tokio::task::JoinHandle<()>>,
     /// SQLite pool to close on shutdown. `None` on the shell-handle path.
     pub(crate) pool: Option<SqlitePool>,
+    /// Type-erased storage handle constructed alongside the SQLite pool
+    /// at boot. Carried on the handle so subsequent Sub-tasks of Epic 18
+    /// Story S-I (registry write-through, audit-event durability,
+    /// retention engine) can reach the trait object from the same
+    /// lifecycle owner that already manages the pool. `None` on the
+    /// shell-handle path (probe short-circuit) where no backend was
+    /// opened.
+    pub(crate) storage: Option<Arc<dyn StorageBackend>>,
     /// PID-file path to remove on shutdown. `None` on the shell-handle
     /// path (no PID was written for that branch).
     pub(crate) pid_path: Option<PathBuf>,
@@ -89,7 +99,10 @@ impl LocalGatewayHandle {
             let _ = std::fs::remove_file(pid_path);
         }
 
-        // 4. Close the SqlitePool.
+        // 4. Close the SqlitePool. Dropping `self.storage` is left to
+        //    Drop semantics — the SqliteBackend wraps another Arc to
+        //    the same pool, so we already explicitly close the pool here.
+        drop(self.storage);
         if let Some(pool) = self.pool {
             pool.close().await;
         }
@@ -192,6 +205,23 @@ pub enum LocalModeError {
     /// Installing the SIGTERM / SIGINT handler failed (Unix only).
     #[error("shutdown signal handler installation failed: {0}")]
     Signal(#[source] std::io::Error),
+    /// The durable storage backend (`SqliteBackend::open` /
+    /// `StorageBackend::migrate`) returned an error during boot.
+    ///
+    /// Distinct from [`LocalModeError::Storage`] so the underlying
+    /// `sqlx::Error` chain stays intact in the existing variant while
+    /// this one carries the richer
+    /// [`StorageError`](crate::storage::StorageError) surface introduced
+    /// by Epic 18 Story S-I.
+    #[error("storage backend error at {path}: {source}", path = path.display())]
+    StorageBackend {
+        /// The resolved on-disk path the gateway tried to open.
+        path: PathBuf,
+        /// Underlying [`StorageError`] from
+        /// `SqliteBackend::open` / `migrate`.
+        #[source]
+        source: StorageError,
+    },
 }
 
 /// Build the local-mode Axum router skeleton.
@@ -231,29 +261,45 @@ pub(crate) fn ensure_storage_parent(path: &Path) -> Result<(), LocalModeError> {
     })
 }
 
-/// Open a SQLite connection pool backing the local control plane.
+/// Open the local-mode SQLite-backed [`StorageBackend`] and apply
+/// pending migrations.
 ///
 /// Calls [`ensure_storage_parent`] so `~/.aasm/` is created on first
-/// start, then opens `SqlitePool` with `create_if_missing(true)` so
-/// the SQLite file itself is materialised on the same call — the
-/// behaviour AAASM-1576 AC #3 requires (`SQLite file created at
-/// ~/.aasm/local.db on first start`).
+/// start, then constructs a [`SqliteBackend`] at `path` (which itself
+/// creates the file in WAL mode if absent) and runs
+/// [`StorageBackend::migrate`] to bring the schema up to date.
 ///
-/// Migrations are deliberately out of scope here — the durable
-/// storage layer (`E18 S-B`, AAASM-1574) owns the migration runner.
-/// Until that lands, the pool returned here is empty/schema-less; it
-/// satisfies the `/healthz` `"storage": "sqlite"` contract and lets
-/// the later sub-tasks (AAASM-1725, AAASM-1728) treat it as a real
-/// resource that must be opened and closed cleanly.
-pub(crate) async fn open_storage(path: &Path) -> Result<SqlitePool, LocalModeError> {
+/// Returns both the raw [`SqlitePool`] (so [`LocalGatewayHandle`] can
+/// still close it explicitly during shutdown — preserving the
+/// AAASM-1576 AC #8 guarantee that `aasm start` after a shutdown does
+/// not race against a not-yet-drained pool) and the type-erased
+/// [`Arc<dyn StorageBackend>`] consumed by the new
+/// [`crate::AppState`] introduced in Epic 18 Story S-I.1.
+///
+/// The two handles share the same underlying connection pool: every
+/// `SqlitePool` is internally `Arc<PoolInner>`, so `pool().clone()`
+/// produces a second view onto the existing pool rather than opening
+/// a second connection set.
+pub(crate) async fn open_storage(path: &Path) -> Result<(SqlitePool, Arc<dyn StorageBackend>), LocalModeError> {
     ensure_storage_parent(path)?;
-    let opts = SqliteConnectOptions::new().filename(path).create_if_missing(true);
-    SqlitePool::connect_with(opts)
+    let backend = SqliteBackend::open(&SqliteConfig {
+        path: path.to_path_buf(),
+    })
+    .await
+    .map_err(|source| LocalModeError::StorageBackend {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    backend
+        .migrate()
         .await
-        .map_err(|source| LocalModeError::Storage {
+        .map_err(|source| LocalModeError::StorageBackend {
             path: path.to_path_buf(),
             source,
-        })
+        })?;
+    let pool = backend.pool().clone();
+    let storage: Arc<dyn StorageBackend> = Arc::new(backend);
+    Ok((pool, storage))
 }
 
 /// Probe `GET http://127.0.0.1:{port}/healthz` with a 100 ms timeout.
@@ -382,14 +428,20 @@ pub(crate) async fn start_local_with_pid_path(
             shutdown_tx,
             server_task: None,
             pool: None,
+            storage: None,
             pid_path: None,
         });
     }
 
-    // 2. Storage (AAASM-1710). The pool now lives on the handle so
-    //    `LocalGatewayHandle::shutdown()` (next commit) can close it
-    //    explicitly with `pool.close().await` rather than relying on Drop.
-    let pool = open_storage(&config.storage_path).await?;
+    // 2. Storage (AAASM-1710 / AAASM-1859). `open_storage` now also
+    //    constructs the SQLite-backed `StorageBackend` and applies
+    //    pending schema migrations. The pool stays on the handle for
+    //    AAASM-1576 AC #8's explicit close-on-shutdown; the storage
+    //    Arc is carried alongside so later Sub-tasks of Epic 18
+    //    Story S-I (registry write-through, audit-event durability,
+    //    retention engine) can reach the trait object from this same
+    //    lifecycle owner.
+    let (pool, storage) = open_storage(&config.storage_path).await?;
 
     // 3. Bind 127.0.0.1:port (AC #6 — explicit Ipv4Addr::LOCALHOST,
     //    never 0.0.0.0).
@@ -429,6 +481,7 @@ pub(crate) async fn start_local_with_pid_path(
         shutdown_tx,
         server_task: Some(server_task),
         pool: Some(pool),
+        storage: Some(storage),
         pid_path: Some(pid_path.to_path_buf()),
     })
 }
@@ -514,13 +567,17 @@ mod tests {
         assert!(!db_path.parent().expect("parent").exists());
         assert!(!db_path.exists());
 
-        let pool = open_storage(&db_path).await.expect("open_storage");
+        let (pool, storage) = open_storage(&db_path).await.expect("open_storage");
 
         assert!(
             db_path.is_file(),
             "open_storage should materialise the SQLite file on disk"
         );
         assert!(!pool.is_closed(), "open_storage should return an open pool",);
+        // The companion StorageBackend handle must be a working trait
+        // object — a healthcheck round-trip exercises it through the
+        // dyn vtable.
+        storage.healthcheck().await.expect("healthcheck should succeed");
 
         pool.close().await;
     }

--- a/aa-gateway/src/remote_mode/error.rs
+++ b/aa-gateway/src/remote_mode/error.rs
@@ -12,6 +12,7 @@ use std::net::SocketAddr;
 use thiserror::Error;
 
 use super::tls::TlsError;
+use crate::storage::StorageError;
 
 /// Failures emitted by `start_remote()` and friends.
 #[derive(Debug, Error)]
@@ -49,4 +50,11 @@ pub enum GatewayError {
     /// Installing the SIGTERM / SIGINT handler failed (Unix only).
     #[error("shutdown signal handler installation failed: {0}")]
     Signal(#[source] io::Error),
+
+    /// The PostgreSQL storage backend (`PostgresBackend::connect` /
+    /// `StorageBackend::migrate`) failed during boot. Introduced by
+    /// Epic 18 Story S-I.1: the remote control plane now opens its
+    /// durable backend before binding the listener.
+    #[error("storage backend error: {0}")]
+    Storage(#[source] StorageError),
 }

--- a/aa-gateway/src/remote_mode/server.rs
+++ b/aa-gateway/src/remote_mode/server.rs
@@ -4,6 +4,7 @@
 //! design rationale; the deeper architectural context lives in
 //! AAASM-1577 / E17 S-C.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use aa_core::config::RemoteModeConfig;
@@ -14,6 +15,7 @@ use axum_server::Handle;
 use super::error::GatewayError;
 use super::tls::{self, TlsValidation};
 use crate::routes::healthz::{healthz, HealthzState};
+use crate::storage::{open_postgres_backend, PostgresConfig, StorageBackend};
 
 /// Build the remote-mode Axum router.
 ///
@@ -116,6 +118,26 @@ async fn wait_for_shutdown_signal() -> Result<(), GatewayError> {
 /// SIGTERM / SIGINT listener.
 pub async fn start_remote_with_handle(cfg: &RemoteModeConfig, handle: Handle) -> Result<(), GatewayError> {
     log_startup_banner(cfg);
+
+    // Epic 18 Story S-I.1 (AAASM-1859): when a database URL is
+    // configured, open the PostgreSQL backend and apply pending
+    // migrations before binding the listener. The handle stays in
+    // scope for the lifetime of the serve loop so the connection
+    // pool is not dropped mid-request; future Sub-tasks of the same
+    // Story pass it through AppState to handlers.
+    //
+    // When `database_url` is `None`, remote mode keeps its pre-S-I.1
+    // behaviour: no backend is opened, healthz reports `storage: memory`.
+    let _storage: Option<Arc<dyn StorageBackend>> = if let Some(url) = cfg.database_url.as_ref() {
+        let pg = PostgresConfig {
+            database_url: Some(url.clone()),
+            ..PostgresConfig::default()
+        };
+        Some(open_postgres_backend(&pg).await.map_err(GatewayError::Storage)?)
+    } else {
+        None
+    };
+
     let app = router().into_make_service();
 
     if let Some(tls_cfg) = &cfg.tls {

--- a/aa-gateway/src/storage/boot.rs
+++ b/aa-gateway/src/storage/boot.rs
@@ -1,0 +1,55 @@
+//! Storage backend bootstrap helpers.
+//!
+//! Centralises the open-then-migrate sequence each deployment mode
+//! runs at startup. Local mode opens a SQLite file at the configured
+//! path; remote mode connects to PostgreSQL. In both cases the helper
+//! returns the backend already type-erased as `Arc<dyn StorageBackend>`
+//! so call sites never depend on the concrete driver type.
+//!
+//! Introduced by Epic 18 Story S-I.1 (AAASM-1859); consumed by the
+//! Local/Remote boot paths in subsequent commits of the same Story.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use super::{PostgresBackend, PostgresConfig, SqliteBackend, SqliteConfig, StorageBackend, StorageResult};
+
+/// Open a SQLite-backed [`StorageBackend`] at `path` and apply pending
+/// schema migrations.
+///
+/// `path`'s parent directories are assumed to exist — local mode
+/// guarantees this via `ensure_storage_parent` before calling here.
+///
+/// Returns the backend already wrapped in `Arc<dyn StorageBackend>` so
+/// the caller can hand it straight to [`crate::AppState::new`].
+///
+/// # Errors
+///
+/// Surfaces any [`StorageError`](super::StorageError) raised by the
+/// underlying `SqliteBackend::open` or `migrate` calls — typically
+/// `ConnectionFailed` (bad path / permissions) or `MigrationFailed`
+/// (schema apply error).
+pub async fn open_sqlite_backend(path: &Path) -> StorageResult<Arc<dyn StorageBackend>> {
+    let backend = SqliteBackend::open(&SqliteConfig {
+        path: path.to_path_buf(),
+    })
+    .await?;
+    backend.migrate().await?;
+    Ok(Arc::new(backend))
+}
+
+/// Connect to a PostgreSQL-backed [`StorageBackend`] from `config`
+/// and apply pending schema migrations.
+///
+/// Returns the backend already wrapped in `Arc<dyn StorageBackend>`
+/// for the same reason as [`open_sqlite_backend`].
+///
+/// # Errors
+///
+/// Surfaces `ConnectionFailed` when the database is unreachable and
+/// `MigrationFailed` when the schema cannot be brought up to date.
+pub async fn open_postgres_backend(config: &PostgresConfig) -> StorageResult<Arc<dyn StorageBackend>> {
+    let backend = PostgresBackend::connect(config).await?;
+    backend.migrate().await?;
+    Ok(Arc::new(backend))
+}

--- a/aa-gateway/src/storage/mod.rs
+++ b/aa-gateway/src/storage/mod.rs
@@ -25,6 +25,7 @@
 pub mod agent;
 pub mod audit;
 pub mod backend;
+pub mod boot;
 pub mod cache;
 pub mod error;
 pub mod health;
@@ -41,6 +42,7 @@ pub mod sqlite;
 pub use agent::{AgentFilter, AgentRecord, TeamId};
 pub use audit::{AuditEvent, AuditFilter};
 pub use backend::StorageBackend;
+pub use boot::{open_postgres_backend, open_sqlite_backend};
 pub use cache::{PolicyCache, PolicyCacheLike, RedisConfig};
 pub use error::{StorageError, StorageResult};
 pub use health::{HealthStatus, RowCounts, StorageHealth};


### PR DESCRIPTION
## Description

Epic 18 Story S-I.1 (AAASM-1859) — the first of six Sub-tasks under Story AAASM-1590 (E18 S-I, "Wire StorageBackend into gateway"). Introduces `AppState` as the single runtime-dependency owner and wires the durable storage backend construction at boot in both deployment modes.

**What this PR delivers**

- New `aa_gateway::AppState` struct with `storage: Arc<dyn StorageBackend>`; `Clone`-able so handlers and background tasks can take owned copies without an outer `Arc<AppState>`.
- New `aa_gateway::storage::boot` module with `open_sqlite_backend` / `open_postgres_backend` helpers — centralises the open-then-migrate sequence and hands back the trait-erased `Arc<dyn StorageBackend>`.
- `local_mode::open_storage` now constructs `SqliteBackend` (WAL pragma + create_if_missing) and runs `StorageBackend::migrate` before returning. The function's return type became `(SqlitePool, Arc<dyn StorageBackend>)`: the pool stays for AAASM-1576 AC #8's explicit `pool.close()` on shutdown; the storage Arc rides alongside on `LocalGatewayHandle`. The two share the same underlying connection pool — no second connection set is opened.
- `remote_mode::start_remote_with_handle`: when `RemoteModeConfig.database_url` is `Some(url)`, opens `PostgresBackend` and applies pending migrations before binding. The Arc stays in scope for the lifetime of the serve loop. When `database_url` is `None`, remote mode keeps its pre-S-I.1 behaviour (no backend, `storage: memory` label).
- New error variants `LocalModeError::StorageBackend` and `GatewayError::Storage` so operators see the exact backend failure on boot.
- Unit tests for both AppState invariants (storage handle exposure + clone semantics).

**What this PR explicitly defers**

- AgentRegistry write-through to storage — Sub-task S-I.2 (AAASM-1864).
- AuditWriter dual-sink — Sub-task S-I.3 (AAASM-1867).
- RetentionEngine::start boot wiring — Sub-task S-I.4 (AAASM-1870), honours AAASM-1588 closeout follow-up #1.
- `aasm admin run-retention` CLI body — Sub-task S-I.5 (AAASM-1872), honours AAASM-1588 closeout follow-up #2.
- End-to-end restart durability verification — Sub-task AAASM-1873.
- Healthz `storage: postgres` label switch in remote mode — pending S-I.2/S-I.3 once handlers start consuming the storage handle.

## Type of Change

- [x] ✨ New feature
- [x] ♻️ Refactoring (open_storage return type)

## Breaking Changes

- [x] No

The signature change of `open_storage` is `pub(crate)`; no public API change. `LocalGatewayHandle` gains a new `pub(crate)` field — same exposure level as the existing `pool` field.

## Related Issues

- Jira Story: [AAASM-1590](https://lightning-dust-mite.atlassian.net/browse/AAASM-1590) (E18 S-I)
- Jira Subtask: [AAASM-1859](https://lightning-dust-mite.atlassian.net/browse/AAASM-1859) (S-I.1)
- Epic: [AAASM-1569](https://lightning-dust-mite.atlassian.net/browse/AAASM-1569) (E18 Durable Persistence Layer)

## Testing

- [x] Unit tests added / updated
- [x] Existing local_mode tests still green (`cargo nextest run -p aa-gateway local_mode::` — 13/13 pass)
- [x] Existing remote_mode tests still green (`cargo nextest run -p aa-gateway remote_mode::` — 6/6 pass)
- [x] New `app_state` tests green (`cargo nextest run -p aa-gateway app_state::` — 2/2 pass)
- [x] `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` clean (lefthook pre-commit hooks pass on every commit)

Pre-existing flake observation: `aa-gateway::policy_latency_test::sustained_load_p99_under_5ms` reports `p99=35ms` vs `15ms` SLA on my machine — pre-existing, unrelated to this PR, not in any code path touched here. Per memory note `project_master_integration_tests_red_2026_05_21`, master integration tests carry similar environment-sensitive noise.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] All commits Gitmoji-tagged, single logical change each
- [x] Branch off latest `remote/master@2b00b599`
- [ ] All CI checks passing (will validate post-push)

[AAASM-1590]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ