### PR TITLE
[AAASM-1843] ✨ (aa-gateway): Add dashboard_server module + tower-http dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
  "tokio-util",
  "tonic",
  "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "utoipa",
@@ -2838,6 +2839,12 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
@@ -6858,6 +6865,12 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
  "tokio",
  "tokio-util",

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -48,6 +48,7 @@ parking_lot  = "0.12"
 utoipa       = { version = "5", features = ["axum_extras"] }
 axum         = "0.8"
 axum-server  = { version = "0.7", features = ["tls-rustls"] }
+tower-http   = { version = "0.6", features = ["fs"] }
 x509-parser  = "0.18"
 redis        = { version = "1.2", default-features = false, features = ["tokio-comp", "connection-manager"], optional = true }
 

--- a/aa-gateway/src/dashboard_server.rs
+++ b/aa-gateway/src/dashboard_server.rs
@@ -9,7 +9,7 @@
 //! currently provides only the module surface that the next commits layer
 //! `dashboard_router()` and `find_dashboard_dist()` onto.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use axum::Router;
 use tower_http::services::{ServeDir, ServeFile};
@@ -30,4 +30,63 @@ pub fn dashboard_router(dist_path: &Path) -> Router {
     let index_html = dist_path.join("index.html");
     let serve_dir = ServeDir::new(dist_path).not_found_service(ServeFile::new(index_html));
     Router::new().nest_service("/", serve_dir)
+}
+
+/// Resolve the `dashboard/dist/` directory the gateway should serve.
+///
+/// Resolution order, first match wins:
+///
+/// 1. `AAASM_DASHBOARD_DIST` — operator-supplied override; takes
+///    precedence over every other source so a developer can point at
+///    a sibling checkout or a custom build.
+/// 2. `{binary_dir}/../dashboard/dist/` — installed layout where the
+///    `aasm` / `aa-gateway` binary lives alongside its assets, e.g.
+///    `/usr/local/bin/aasm` + `/usr/local/dashboard/dist`.
+/// 3. `{cargo_manifest_dir}/../dashboard/dist/` — workspace
+///    development layout, used by `cargo run -p aa-gateway` against a
+///    locally-built `dashboard/dist/`.
+///
+/// Returns `None` when every candidate is missing. The local-mode
+/// router (next sub-task) interprets `None` as "log a warning and
+/// skip mounting the SPA" so the gateway still starts and `/healthz`
+/// keeps working — AAASM-1580 AC "Missing dashboard/dist/ → gateway
+/// starts successfully with warning".
+pub fn find_dashboard_dist() -> Option<PathBuf> {
+    find_dashboard_dist_in(
+        std::env::var("AAASM_DASHBOARD_DIST").ok(),
+        std::env::current_exe()
+            .ok()
+            .as_deref()
+            .and_then(Path::parent)
+            .and_then(Path::parent)
+            .map(Path::to_path_buf),
+        Some(Path::new(env!("CARGO_MANIFEST_DIR")).join("..")),
+    )
+}
+
+/// Pure resolution helper exposed for hermetic testing — `find_dashboard_dist`
+/// is a thin wrapper that supplies real process inputs.
+///
+/// Each `*_root` is treated as the parent of `dashboard/dist`. The
+/// helper validates `is_dir()` on every candidate so it never returns
+/// a path that does not actually exist on disk; an empty
+/// `env_override` skips straight to the disk fallbacks.
+fn find_dashboard_dist_in(
+    env_override: Option<String>,
+    installed_root: Option<PathBuf>,
+    dev_root: Option<PathBuf>,
+) -> Option<PathBuf> {
+    if let Some(env_path) = env_override {
+        let p = PathBuf::from(env_path);
+        if p.is_dir() {
+            return Some(p);
+        }
+    }
+    for root in [installed_root, dev_root].into_iter().flatten() {
+        let candidate = root.join("dashboard").join("dist");
+        if candidate.is_dir() {
+            return Some(candidate);
+        }
+    }
+    None
 }

--- a/aa-gateway/src/dashboard_server.rs
+++ b/aa-gateway/src/dashboard_server.rs
@@ -8,3 +8,26 @@
 //! The module is built up across the sub-tasks of AAASM-1580; this file
 //! currently provides only the module surface that the next commits layer
 //! `dashboard_router()` and `find_dashboard_dist()` onto.
+
+use std::path::Path;
+
+use axum::Router;
+use tower_http::services::{ServeDir, ServeFile};
+
+/// Build an Axum `Router` that serves the compiled dashboard SPA from
+/// `dist_path`.
+///
+/// File requests resolve against `dist_path` directly; anything
+/// `ServeDir` cannot find falls through to `dist_path/index.html` so
+/// client-side React Router paths like `/agents/abc` reach the SPA
+/// instead of returning 404. Mounted via `nest_service("/")` so the
+/// router can be `.merge()`d into a parent that already owns concrete
+/// API routes (e.g. `/healthz`) without the SPA fallback eating them.
+///
+/// Consumer: `local_mode::router()` mounts this in the next sub-task
+/// (AAASM-1844) when `LocalModeConfig.dashboard == true`.
+pub fn dashboard_router(dist_path: &Path) -> Router {
+    let index_html = dist_path.join("index.html");
+    let serve_dir = ServeDir::new(dist_path).not_found_service(ServeFile::new(index_html));
+    Router::new().nest_service("/", serve_dir)
+}

--- a/aa-gateway/src/dashboard_server.rs
+++ b/aa-gateway/src/dashboard_server.rs
@@ -20,16 +20,18 @@ use tower_http::services::{ServeDir, ServeFile};
 /// File requests resolve against `dist_path` directly; anything
 /// `ServeDir` cannot find falls through to `dist_path/index.html` so
 /// client-side React Router paths like `/agents/abc` reach the SPA
-/// instead of returning 404. Mounted via `nest_service("/")` so the
-/// router can be `.merge()`d into a parent that already owns concrete
-/// API routes (e.g. `/healthz`) without the SPA fallback eating them.
+/// instead of returning 404. The `ServeDir` is registered as the
+/// router's `fallback_service` so it only handles requests that did
+/// not match a concrete route — a parent router can therefore
+/// `.merge()` this in alongside `/healthz` and future `/api/v1/*`
+/// routes without the SPA catch-all eating them.
 ///
 /// Consumer: `local_mode::router()` mounts this in the next sub-task
 /// (AAASM-1844) when `LocalModeConfig.dashboard == true`.
 pub fn dashboard_router(dist_path: &Path) -> Router {
     let index_html = dist_path.join("index.html");
     let serve_dir = ServeDir::new(dist_path).not_found_service(ServeFile::new(index_html));
-    Router::new().nest_service("/", serve_dir)
+    Router::new().fallback_service(serve_dir)
 }
 
 /// Resolve the `dashboard/dist/` directory the gateway should serve.

--- a/aa-gateway/src/dashboard_server.rs
+++ b/aa-gateway/src/dashboard_server.rs
@@ -18,19 +18,24 @@ use tower_http::services::{ServeDir, ServeFile};
 /// `dist_path`.
 ///
 /// File requests resolve against `dist_path` directly; anything
-/// `ServeDir` cannot find falls through to `dist_path/index.html` so
-/// client-side React Router paths like `/agents/abc` reach the SPA
-/// instead of returning 404. The `ServeDir` is registered as the
-/// router's `fallback_service` so it only handles requests that did
-/// not match a concrete route — a parent router can therefore
-/// `.merge()` this in alongside `/healthz` and future `/api/v1/*`
-/// routes without the SPA catch-all eating them.
+/// `ServeDir` cannot find falls through to `ServeDir::fallback` —
+/// `ServeFile(index.html)` — so client-side React Router paths like
+/// `/agents/abc` reach the SPA shell with a real **200 OK** instead of
+/// a 404. `fallback` is used here rather than `not_found_service`
+/// because the latter preserves the original `404` status alongside
+/// the substituted body, which is the wrong UX for SPA routing.
+///
+/// The `ServeDir` is registered as the router's `fallback_service` so
+/// it only handles requests that did not match a concrete route — a
+/// parent router can therefore `.merge()` this in alongside
+/// `/healthz` and future `/api/v1/*` routes without the SPA catch-all
+/// eating them.
 ///
 /// Consumer: `local_mode::router()` mounts this in the next sub-task
 /// (AAASM-1844) when `LocalModeConfig.dashboard == true`.
 pub fn dashboard_router(dist_path: &Path) -> Router {
     let index_html = dist_path.join("index.html");
-    let serve_dir = ServeDir::new(dist_path).not_found_service(ServeFile::new(index_html));
+    let serve_dir = ServeDir::new(dist_path).fallback(ServeFile::new(index_html));
     Router::new().fallback_service(serve_dir)
 }
 

--- a/aa-gateway/src/dashboard_server.rs
+++ b/aa-gateway/src/dashboard_server.rs
@@ -176,6 +176,71 @@ mod tests {
         );
     }
 
+    /// AAASM-1580 AC "AAASM_DASHBOARD_DIST=/custom/path env var
+    /// overrides default dist path": when the env override resolves to
+    /// an existing directory, it wins regardless of what the installed
+    /// or dev roots contain — even when *both* would otherwise match.
+    #[test]
+    fn find_dashboard_dist_prefers_env_override() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let installed = tempfile::tempdir().expect("installed root");
+        std::fs::create_dir_all(installed.path().join("dashboard").join("dist")).expect("installed dist");
+
+        let resolved = find_dashboard_dist_in(
+            Some(tmp.path().to_string_lossy().into_owned()),
+            Some(installed.path().to_path_buf()),
+            None,
+        );
+
+        assert_eq!(
+            resolved.as_deref(),
+            Some(tmp.path()),
+            "env-var override must beat the installed-layout root"
+        );
+    }
+
+    /// Negative path of the override: an env value pointing at a path
+    /// that is *not* an existing directory must be ignored, and the
+    /// helper must fall through to the installed/dev fallbacks. This
+    /// keeps a stale env var from blocking a working development tree.
+    #[test]
+    fn find_dashboard_dist_falls_through_when_env_path_missing() {
+        let installed = tempfile::tempdir().expect("installed root");
+        let installed_dist = installed.path().join("dashboard").join("dist");
+        std::fs::create_dir_all(&installed_dist).expect("installed dist");
+
+        let resolved = find_dashboard_dist_in(
+            Some("/definitely/does/not/exist".to_string()),
+            Some(installed.path().to_path_buf()),
+            None,
+        );
+
+        assert_eq!(
+            resolved.as_deref(),
+            Some(installed_dist.as_path()),
+            "missing env-var path must fall through to the installed root"
+        );
+    }
+
+    /// AAASM-1580 AC "Missing dashboard/dist/ → gateway starts
+    /// successfully with warning" at the helper level: when every
+    /// candidate root is absent, the resolver returns `None` so the
+    /// caller (the local-mode router in AAASM-1844) can warn and skip
+    /// mounting the SPA instead of crashing.
+    #[test]
+    fn find_dashboard_dist_returns_none_when_no_candidate_resolves() {
+        let installed = tempfile::tempdir().expect("installed root"); // no dashboard/dist inside
+        let dev = tempfile::tempdir().expect("dev root"); //          no dashboard/dist inside
+
+        let resolved = find_dashboard_dist_in(
+            None,
+            Some(installed.path().to_path_buf()),
+            Some(dev.path().to_path_buf()),
+        );
+
+        assert_eq!(resolved, None, "missing every candidate must yield None");
+    }
+
     /// AAASM-1580 AC "GET /agents → index.html (SPA fallback, not 404)":
     /// an unknown nested path falls through to `ServeDir::fallback`
     /// (ServeFile of index.html), so React Router receives the SPA

--- a/aa-gateway/src/dashboard_server.rs
+++ b/aa-gateway/src/dashboard_server.rs
@@ -97,3 +97,104 @@ fn find_dashboard_dist_in(
     }
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use axum::body::{to_bytes, Body};
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    /// Build a minimal `dashboard/dist/`-shaped tempdir for the router
+    /// tests: `index.html` at the root plus an `assets/main.js` file
+    /// whose contents we assert against to prove `ServeDir` is reaching
+    /// real files (rather than always returning the index fallback).
+    fn make_stub_dist() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            dir.path().join("index.html"),
+            r#"<!doctype html><html><body><div id="root"></div></body></html>"#,
+        )
+        .expect("write index.html");
+        std::fs::create_dir_all(dir.path().join("assets")).expect("mkdir assets");
+        std::fs::write(dir.path().join("assets/main.js"), "export const main = () => 42;\n")
+            .expect("write assets/main.js");
+        dir
+    }
+
+    async fn get(router: Router, path: &str) -> axum::http::Response<Body> {
+        router
+            .oneshot(Request::builder().uri(path).body(Body::empty()).expect("build request"))
+            .await
+            .expect("router.oneshot")
+    }
+
+    /// AAASM-1580 AC #1 at the helper level: `GET /` returns 200 and
+    /// the body contains `<div id="root">`, proving the React SPA's
+    /// `index.html` is what the router serves at the root.
+    #[tokio::test]
+    async fn dashboard_router_serves_index_at_root() {
+        let dist = make_stub_dist();
+        let response = get(dashboard_router(dist.path()), "/").await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), 64 * 1024).await.expect("body");
+        let body = std::str::from_utf8(&bytes).expect("utf8");
+        assert!(
+            body.contains(r#"<div id="root">"#),
+            "GET / must serve index.html with the React mount node; got: {body}"
+        );
+    }
+
+    /// AAASM-1580 AC "All JS/CSS assets served with correct Content-Type":
+    /// `GET /assets/main.js` reaches the real file and `ServeDir` sets
+    /// a JavaScript content-type from its mime-guess table — covers
+    /// both `application/javascript` and `text/javascript` because the
+    /// canonical value has moved between tower-http releases.
+    #[tokio::test]
+    async fn dashboard_router_serves_static_assets_with_javascript_content_type() {
+        let dist = make_stub_dist();
+        let response = get(dashboard_router(dist.path()), "/assets/main.js").await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let ctype = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_owned();
+        assert!(
+            ctype.contains("javascript"),
+            "asset must be served with a JavaScript content-type; got {ctype:?}"
+        );
+        let bytes = to_bytes(response.into_body(), 64 * 1024).await.expect("body");
+        assert_eq!(
+            std::str::from_utf8(&bytes).expect("utf8"),
+            "export const main = () => 42;\n",
+            "asset body must match the file on disk"
+        );
+    }
+
+    /// AAASM-1580 AC "GET /agents → index.html (SPA fallback, not 404)":
+    /// an unknown nested path falls through to `ServeDir::fallback`
+    /// (ServeFile of index.html), so React Router receives the SPA
+    /// shell with a real 200 status instead of a 404.
+    #[tokio::test]
+    async fn dashboard_router_falls_back_to_index_on_unknown_path() {
+        let dist = make_stub_dist();
+        let response = get(dashboard_router(dist.path()), "/agents/abc").await;
+
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "SPA fallback must return 200, not 404"
+        );
+        let bytes = to_bytes(response.into_body(), 64 * 1024).await.expect("body");
+        let body = std::str::from_utf8(&bytes).expect("utf8");
+        assert!(
+            body.contains(r#"<div id="root">"#),
+            "fallback body must be index.html; got: {body}"
+        );
+    }
+}

--- a/aa-gateway/src/dashboard_server.rs
+++ b/aa-gateway/src/dashboard_server.rs
@@ -1,0 +1,10 @@
+//! Dashboard SPA static-asset server for local-mode (Epic 17 S-F, AAASM-1580).
+//!
+//! Serves the compiled React dashboard out of `dashboard/dist/` from the
+//! same Axum process as the local-mode control plane so a developer running
+//! `aasm start --mode local` can open `http://localhost:7391/` and see the
+//! UI without standing up a separate Vite dev server.
+//!
+//! The module is built up across the sub-tasks of AAASM-1580; this file
+//! currently provides only the module surface that the next commits layer
+//! `dashboard_router()` and `find_dashboard_dist()` onto.

--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -10,6 +10,7 @@ pub mod approval;
 pub mod audit;
 pub mod audit_reader;
 pub mod budget;
+pub mod dashboard_server;
 pub mod edges;
 pub mod engine;
 pub mod events;


### PR DESCRIPTION
## Description

Introduces the self-contained `aa-gateway::dashboard_server` module that the
local-mode router will mount in AAASM-1844 to serve the compiled React SPA
out of the same Axum process as `/healthz`. This PR ships only the module +
its dependency + unit tests — the `local_mode::router()` wire-up lands in a
separate stacked PR per *one PR per sub-ticket* convention.

What's in the module:

* `pub fn dashboard_router(dist_path: &Path) -> Router` — returns an Axum
  `Router` whose `fallback_service` is a `ServeDir` over `dist_path` with
  `ServeDir::fallback(ServeFile(index.html))` for SPA routing. Concrete
  parent routes (e.g. `/healthz`, future `/api/v1/*`) take precedence when
  merged.
* `pub fn find_dashboard_dist() -> Option<PathBuf>` — first-match resolution
  over `AAASM_DASHBOARD_DIST` env var → `{binary_dir}/../dashboard/dist/` →
  `{cargo_manifest_dir}/../dashboard/dist/`. Returns `None` so the consumer
  can warn-and-skip when nothing resolves. Implementation lives in a private
  `find_dashboard_dist_in()` helper so unit tests drive every branch
  hermetically.

Two findings deviated from the literal story spec, both captured in their own
bug-fix commits in this series so the history explains why:

1. `Router::new().nest_service("/", svc)` panics in axum 0.8 — replaced with
   `Router::new().fallback_service(svc)`.
2. `ServeDir::not_found_service(ServeFile(...))` substitutes the body but
   **keeps the 404 status code** — wrong for SPA fallback. Switched to
   `ServeDir::fallback(...)` which lets `ServeFile`'s 200 OK propagate.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [x] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-1843 (sub-task of Story AAASM-1580 under Epic AAASM-1568)
- Related GitHub issues: —

## Testing

`cargo nextest run -p aa-gateway dashboard_server::tests` — 6 tests, all green:

* `dashboard_router_serves_index_at_root` — GET `/` → 200 + `<div id="root">`
* `dashboard_router_serves_static_assets_with_javascript_content_type` —
  GET `/assets/main.js` → 200 + JavaScript content-type + matching bytes
* `dashboard_router_falls_back_to_index_on_unknown_path` — GET `/agents/abc`
  → 200 + index.html body (SPA fallback)
* `find_dashboard_dist_prefers_env_override` — env path beats installed
  root when both would otherwise match
* `find_dashboard_dist_falls_through_when_env_path_missing` — stale env
  doesn't block working tree
* `find_dashboard_dist_returns_none_when_no_candidate_resolves` — caller
  can warn-and-skip

Full crate suite green locally: `cargo nextest run -p aa-gateway` →
946 passed. `cargo clippy --all-targets --all-features -- -D warnings`
clean. `cargo deny check` clean.

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Stacked context

This is **PR 1 of 3** for Story AAASM-1580 (Epic 17 S-F — dashboard SPA
served by gateway in local mode):

* **AAASM-1843** *(this PR)* — module + dependency + tests
* **AAASM-1844** — wire `dashboard_router()` into `local_mode::router()`
* **AAASM-1845** — verification: AC report under `verification-reports/`