### PR TITLE
[AAASM-1850] ✨ (retention_engine): Add hot_reload primitive for AAASM-1592 admin REST

### DIFF
--- a/aa-gateway/src/storage/retention_engine.rs
+++ b/aa-gateway/src/storage/retention_engine.rs
@@ -482,4 +482,15 @@ mod tests {
 
         assert!(engine.last_run_stats().is_none());
     }
+
+    #[tokio::test]
+    async fn last_run_stats_populated_after_run_once() {
+        let canned = canned_stats();
+        let backend = Arc::new(FakeBackend::new(canned.clone()));
+        let engine = RetentionEngine::new(backend, RetentionConfig::default());
+
+        engine.run_once().await.expect("run_once should succeed");
+
+        assert_eq!(engine.last_run_stats(), Some(canned));
+    }
 }

--- a/aa-gateway/src/storage/retention_engine.rs
+++ b/aa-gateway/src/storage/retention_engine.rs
@@ -418,4 +418,19 @@ mod tests {
 
         assert_eq!(engine.current_config(), config);
     }
+
+    #[tokio::test]
+    async fn hot_reload_swaps_active_config_observed_by_current_config() {
+        let backend = Arc::new(FakeBackend::new(canned_stats()));
+        let engine = RetentionEngine::new(backend, RetentionConfig::default());
+
+        let new_config = RetentionConfig {
+            hot_days: 15,
+            warm_days: 60,
+            ..RetentionConfig::default()
+        };
+        engine.hot_reload(new_config.clone()).expect("valid config must swap");
+
+        assert_eq!(engine.current_config(), new_config);
+    }
 }

--- a/aa-gateway/src/storage/retention_engine.rs
+++ b/aa-gateway/src/storage/retention_engine.rs
@@ -49,6 +49,35 @@ impl RetentionEngine {
         RetentionConfig::clone(&self.config.load())
     }
 
+    /// Atomically replace the active retention configuration.
+    ///
+    /// Called by the admin REST `PUT /api/v1/admin/retention-policy` handler.
+    /// The new config is validated first (delegating to
+    /// [`RetentionConfig::validate`]); on validation failure the active
+    /// config is left untouched. On success, subsequent [`run_once`] calls
+    /// observe the new thresholds; the cron schedule captured by
+    /// [`start`](Self::start) is not affected — schedule changes still
+    /// require a restart.
+    ///
+    /// # Errors
+    ///
+    /// - Any [`RetentionConfigError`] from
+    ///   [`RetentionConfig::validate`] (missing archive_url, invalid
+    ///   schedule). The active config is preserved when an error is
+    ///   returned.
+    pub fn hot_reload(&self, new_config: RetentionConfig) -> Result<(), RetentionConfigError> {
+        new_config.validate()?;
+        tracing::info!(
+            hot_days = new_config.hot_days,
+            warm_days = new_config.warm_days,
+            cold_action = ?new_config.cold_action,
+            dry_run = new_config.dry_run,
+            "retention config hot-reloaded",
+        );
+        self.config.store(Arc::new(new_config));
+        Ok(())
+    }
+
     /// Run one retention pass: build the [`RetentionPolicy`](super::RetentionPolicy)
     /// from `self.config`, hand it to the backend, and return the
     /// resulting [`RetentionStats`].

--- a/aa-gateway/src/storage/retention_engine.rs
+++ b/aa-gateway/src/storage/retention_engine.rs
@@ -38,6 +38,17 @@ impl RetentionEngine {
         }
     }
 
+    /// Return a snapshot of the active retention configuration.
+    ///
+    /// The admin REST API uses this for `GET /api/v1/admin/retention-policy`
+    /// and to render the current values back to the caller after a successful
+    /// `PUT`. The returned value is a clone, decoupled from any subsequent
+    /// [`hot_reload`](Self::hot_reload) so the caller can hold it without
+    /// blocking writers.
+    pub fn current_config(&self) -> RetentionConfig {
+        RetentionConfig::clone(&self.config.load())
+    }
+
     /// Run one retention pass: build the [`RetentionPolicy`](super::RetentionPolicy)
     /// from `self.config`, hand it to the backend, and return the
     /// resulting [`RetentionStats`].

--- a/aa-gateway/src/storage/retention_engine.rs
+++ b/aa-gateway/src/storage/retention_engine.rs
@@ -474,4 +474,12 @@ mod tests {
             "active config must be untouched after a rejected hot_reload"
         );
     }
+
+    #[tokio::test]
+    async fn last_run_stats_is_none_before_first_run_once() {
+        let backend = Arc::new(FakeBackend::new(canned_stats()));
+        let engine = RetentionEngine::new(backend, RetentionConfig::default());
+
+        assert!(engine.last_run_stats().is_none());
+    }
 }

--- a/aa-gateway/src/storage/retention_engine.rs
+++ b/aa-gateway/src/storage/retention_engine.rs
@@ -7,6 +7,7 @@
 
 use std::sync::Arc;
 
+use arc_swap::ArcSwap;
 use chrono::Utc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -19,7 +20,11 @@ use super::retention_config::{RetentionConfig, RetentionConfigError};
 /// Owns the periodic retention task lifecycle.
 pub struct RetentionEngine {
     backend: Arc<dyn StorageBackend>,
-    config: RetentionConfig,
+    /// Active retention configuration. Held behind an [`ArcSwap`] so the
+    /// admin REST API (Story S-K) can hot-reload thresholds at runtime
+    /// without restarting the gateway, while concurrent `run_once` calls
+    /// see a stable snapshot for the duration of one pass.
+    config: Arc<ArcSwap<RetentionConfig>>,
 }
 
 impl RetentionEngine {
@@ -27,7 +32,10 @@ impl RetentionEngine {
     /// [`apply_retention`](StorageBackend::apply_retention) on `backend`
     /// using the policy derived from `config`.
     pub fn new(backend: Arc<dyn StorageBackend>, config: RetentionConfig) -> Self {
-        Self { backend, config }
+        Self {
+            backend,
+            config: Arc::new(ArcSwap::from_pointee(config)),
+        }
     }
 
     /// Run one retention pass: build the [`RetentionPolicy`](super::RetentionPolicy)
@@ -43,7 +51,7 @@ impl RetentionEngine {
     /// Surfaces any [`StorageError`](super::StorageError) returned by
     /// [`apply_retention`](StorageBackend::apply_retention).
     pub async fn run_once(&self) -> StorageResult<RetentionStats> {
-        let policy = self.config.to_policy();
+        let policy = self.config.load().to_policy();
         let stats = self.backend.apply_retention(&policy).await?;
         tracing::info!(
             dry_run = policy.dry_run,
@@ -73,7 +81,7 @@ impl RetentionEngine {
     ///   this case — fail-fast at startup rather than panic at the first
     ///   tick.
     pub fn start(self: Arc<Self>, shutdown: CancellationToken) -> Result<JoinHandle<()>, RetentionConfigError> {
-        let schedule = self.config.parsed_schedule()?;
+        let schedule = self.config.load().parsed_schedule()?;
         Ok(tokio::spawn(async move {
             loop {
                 let Some(next) = schedule.upcoming(Utc).next() else {

--- a/aa-gateway/src/storage/retention_engine.rs
+++ b/aa-gateway/src/storage/retention_engine.rs
@@ -453,4 +453,25 @@ mod tests {
             .expect("apply_retention should have been called");
         assert_eq!(captured, new_config.to_policy());
     }
+
+    #[tokio::test]
+    async fn hot_reload_validation_failure_preserves_active_config() {
+        let backend = Arc::new(FakeBackend::new(canned_stats()));
+        let initial = RetentionConfig::default();
+        let engine = RetentionEngine::new(backend, initial.clone());
+
+        // archive without archive_url fails RetentionConfig::validate
+        let invalid = RetentionConfig {
+            cold_action: ColdAction::Archive,
+            archive_url: None,
+            ..RetentionConfig::default()
+        };
+        let err = engine.hot_reload(invalid).expect_err("invalid config must be rejected");
+        assert_eq!(err, RetentionConfigError::MissingArchiveUrl);
+        assert_eq!(
+            engine.current_config(),
+            initial,
+            "active config must be untouched after a rejected hot_reload"
+        );
+    }
 }

--- a/aa-gateway/src/storage/retention_engine.rs
+++ b/aa-gateway/src/storage/retention_engine.rs
@@ -433,4 +433,24 @@ mod tests {
 
         assert_eq!(engine.current_config(), new_config);
     }
+
+    #[tokio::test]
+    async fn hot_reload_is_visible_to_subsequent_run_once() {
+        let backend = Arc::new(FakeBackend::new(canned_stats()));
+        let engine = RetentionEngine::new(backend.clone(), RetentionConfig::default());
+
+        let new_config = RetentionConfig {
+            hot_days: 7,
+            warm_days: 14,
+            dry_run: true,
+            ..RetentionConfig::default()
+        };
+        engine.hot_reload(new_config.clone()).expect("valid config must swap");
+        engine.run_once().await.expect("run_once should succeed");
+
+        let captured = backend
+            .captured_policy()
+            .expect("apply_retention should have been called");
+        assert_eq!(captured, new_config.to_policy());
+    }
 }

--- a/aa-gateway/src/storage/retention_engine.rs
+++ b/aa-gateway/src/storage/retention_engine.rs
@@ -402,4 +402,20 @@ mod tests {
             .expect_err("invalid schedule must return Err, not panic");
         assert!(matches!(err, RetentionConfigError::InvalidSchedule { .. }));
     }
+
+    #[tokio::test]
+    async fn current_config_returns_constructor_value() {
+        let backend = Arc::new(FakeBackend::new(canned_stats()));
+        let config = RetentionConfig {
+            hot_days: 7,
+            warm_days: 21,
+            cold_action: ColdAction::Archive,
+            archive_url: Some("s3://bucket/a/".to_string()),
+            dry_run: true,
+            ..RetentionConfig::default()
+        };
+        let engine = RetentionEngine::new(backend, config.clone());
+
+        assert_eq!(engine.current_config(), config);
+    }
 }

--- a/aa-gateway/src/storage/retention_engine.rs
+++ b/aa-gateway/src/storage/retention_engine.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use chrono::Utc;
+use parking_lot::RwLock;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -25,6 +26,11 @@ pub struct RetentionEngine {
     /// without restarting the gateway, while concurrent `run_once` calls
     /// see a stable snapshot for the duration of one pass.
     config: Arc<ArcSwap<RetentionConfig>>,
+    /// Stats from the most recent successful [`run_once`]. `None` until
+    /// the engine has completed at least one pass. Surfaced by
+    /// [`last_run_stats`](Self::last_run_stats) for the admin GET handler
+    /// "Last retention run" panel.
+    last_run_stats: Arc<RwLock<Option<RetentionStats>>>,
 }
 
 impl RetentionEngine {
@@ -35,6 +41,7 @@ impl RetentionEngine {
         Self {
             backend,
             config: Arc::new(ArcSwap::from_pointee(config)),
+            last_run_stats: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -103,7 +110,17 @@ impl RetentionEngine {
             ran_at = %stats.ran_at,
             "retention run complete",
         );
+        *self.last_run_stats.write() = Some(stats.clone());
         Ok(stats)
+    }
+
+    /// Stats from the most recent successful [`run_once`], or `None` if
+    /// the engine has not completed a run yet.
+    ///
+    /// Powers the "Last retention run" panel on the dashboard admin UI
+    /// (AAASM-1592 S-K).
+    pub fn last_run_stats(&self) -> Option<RetentionStats> {
+        self.last_run_stats.read().clone()
     }
 
     /// Spawn the background retention task. Returns a [`JoinHandle`] for


### PR DESCRIPTION
## Description

Adds the building blocks the AAASM-1592 (E18 S-K) admin REST handlers need: a hot-reloadable `RetentionConfig` inside `RetentionEngine`, plus accessors to read the current config and the most recent run's stats.

Concretely:
- `RetentionEngine.config` is now held behind `Arc<ArcSwap<RetentionConfig>>` so config can be swapped at runtime without restarting the gateway.
- New `current_config()` — snapshot of the active config (clone — caller-safe).
- New `hot_reload(new_config)` — validates via `RetentionConfig::validate`, then atomically swaps. On validation error the active config is left untouched.
- New `last_run_stats()` — `Option<RetentionStats>` from the most recent successful `run_once`. `None` until the first run.
- `run_once` writes its result through to the holder so the dashboard's "Last retention run" panel can render the latest stats.

Schedule changes remain out of scope — the cron schedule captured by `start()` is fixed for the task's lifetime; only thresholds (`hot_days`, `warm_days`, `cold_action`, `archive_url`, `dry_run`) are hot-reloadable. Schedule changes still require a restart.

## Type of Change

- [x] ✨ New feature
- [x] ♻️ Refactoring (internal: `config` field type change, no public API churn beyond new methods)

## Breaking Changes

- [x] No

`RetentionEngine::new` keeps the same signature. All previously existing methods (`run_once`, `start`) work as before. The internal `config` field type changed from `RetentionConfig` to `Arc<ArcSwap<RetentionConfig>>` but that field was already private.

## Related Issues

- Related Jira ticket: [AAASM-1850](https://lightning-dust-mite.atlassian.net/browse/AAASM-1850) — `[1/6]` sub-ticket of [AAASM-1592](https://lightning-dust-mite.atlassian.net/browse/AAASM-1592) (E18 S-K Dashboard Retention Policy admin UI)
- Epic: [AAASM-1569](https://lightning-dust-mite.atlassian.net/browse/AAASM-1569) — Durable Persistence Layer

## Testing

- [x] Unit tests added / updated

6 new unit tests in `aa-gateway/src/storage/retention_engine.rs`:

1. `current_config_returns_constructor_value` — read-back after `new`
2. `hot_reload_swaps_active_config_observed_by_current_config` — basic swap
3. `hot_reload_is_visible_to_subsequent_run_once` — `FakeBackend` captures the new policy
4. `hot_reload_validation_failure_preserves_active_config` — `MissingArchiveUrl` rejects without partial swap
5. `last_run_stats_is_none_before_first_run_once` — empty-state boundary
6. `last_run_stats_populated_after_run_once` — happy-path write-through

All 20 `storage::retention*` tests green locally (existing 13 + new 7-count when counting both `retention_config` and `retention_engine` modules).

### Known unrelated local failure

`aa-gateway::policy_latency_test::sustained_load_p99_under_5ms` fails on the macOS dev box (p99 23–149ms vs 15ms SLA target) — also fails on `remote/master` HEAD `2b00b599`, so this is a pre-existing benchmark flake sensitive to host load, not something this PR introduces. CI Linux runners pass.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --all-targets -- -D warnings`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on new methods)
- [ ] All CI checks passing — pending
- [x] Commits are small and follow the Gitmoji convention (10 commits: 1 refactor, 3 new methods, 6 tests — one test per commit)

[AAASM-1850]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ