### PR TITLE
[AAASM-1857] ✨ (aa-cli/status): Add DeploymentOverview model + composer

### DIFF
--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -220,6 +220,27 @@ mod tests {
     use super::*;
 
     #[test]
+    fn build_deployment_overview_populates_fields_from_local_sqlite_healthz() {
+        let healthz = HealthzResponse {
+            mode: "local".to_string(),
+            version: "0.0.1".to_string(),
+            storage: "sqlite".to_string(),
+            uptime_secs: 8133,
+            storage_path: Some("~/.aasm/local.db".to_string()),
+            database_url: None,
+        };
+        let overview = build_deployment_overview("http://localhost:7391", Some(healthz));
+        assert_eq!(overview.mode, "local");
+        assert_eq!(overview.gateway_url, "http://localhost:7391");
+        assert_eq!(overview.storage_backend, "sqlite");
+        assert_eq!(overview.storage_path.as_deref(), Some("~/.aasm/local.db"));
+        assert!(overview.database_url_redacted.is_none());
+        assert_eq!(overview.version, "0.0.1");
+        assert_eq!(overview.uptime_secs, 8133);
+        assert_eq!(overview.health, "ok");
+    }
+
+    #[test]
     fn build_runtime_health_reachable() {
         let resp = Some(HealthResponse {
             status: "ok".to_string(),

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -4,9 +4,50 @@ use chrono::Utc;
 
 use super::client::StatusClient;
 use super::models::{
-    AgentResponse, AgentRow, ApprovalResponse, ApprovalsSummary, BudgetRow, CostResponse, HealthResponse,
-    RuntimeHealth, StatusSnapshot,
+    redact_database_url, AgentResponse, AgentRow, ApprovalResponse, ApprovalsSummary, BudgetRow, CostResponse,
+    DeploymentOverview, HealthResponse, HealthzResponse, RuntimeHealth, StatusSnapshot,
 };
+
+/// Compose the deployment-overview display model from a `/healthz` response.
+///
+/// `gateway_url` is propagated verbatim — it is the base URL the CLI was
+/// configured to reach (typically the user's `--gateway` flag or default
+/// `http://localhost:7391`).
+///
+/// When `healthz` is `None` (the gateway did not respond), the overview is
+/// populated with `health = "unreachable"` and `mode` / `storage_backend` set
+/// to `"unknown"`. `gateway_url` is still surfaced so the operator can see
+/// what address was probed.
+///
+/// When `healthz` is `Some`, the wire response is mapped 1-to-1 with the
+/// exception of `database_url`, which is run through [`redact_database_url`]
+/// before being assigned to `database_url_redacted`. The raw wire value never
+/// reaches the display layer.
+#[allow(dead_code)]
+pub fn build_deployment_overview(gateway_url: &str, healthz: Option<HealthzResponse>) -> DeploymentOverview {
+    match healthz {
+        Some(h) => DeploymentOverview {
+            mode: h.mode,
+            gateway_url: gateway_url.to_string(),
+            storage_backend: h.storage,
+            storage_path: h.storage_path,
+            database_url_redacted: h.database_url.as_deref().map(redact_database_url),
+            version: h.version,
+            uptime_secs: h.uptime_secs,
+            health: "ok".to_string(),
+        },
+        None => DeploymentOverview {
+            mode: "unknown".to_string(),
+            gateway_url: gateway_url.to_string(),
+            storage_backend: "unknown".to_string(),
+            storage_path: None,
+            database_url_redacted: None,
+            version: String::new(),
+            uptime_secs: 0,
+            health: "unreachable".to_string(),
+        },
+    }
+}
 
 /// Convert a health API response into a display-ready `RuntimeHealth`.
 pub fn build_runtime_health(resp: Option<HealthResponse>) -> RuntimeHealth {

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -220,6 +220,19 @@ mod tests {
     use super::*;
 
     #[test]
+    fn build_deployment_overview_marks_health_unreachable_when_healthz_absent() {
+        let overview = build_deployment_overview("http://localhost:7391", None);
+        assert_eq!(overview.gateway_url, "http://localhost:7391");
+        assert_eq!(overview.health, "unreachable");
+        assert_eq!(overview.mode, "unknown");
+        assert_eq!(overview.storage_backend, "unknown");
+        assert!(overview.storage_path.is_none());
+        assert!(overview.database_url_redacted.is_none());
+        assert_eq!(overview.uptime_secs, 0);
+        assert!(overview.version.is_empty());
+    }
+
+    #[test]
     fn build_deployment_overview_redacts_database_url_for_remote_postgres() {
         let healthz = HealthzResponse {
             mode: "remote".to_string(),

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -220,6 +220,27 @@ mod tests {
     use super::*;
 
     #[test]
+    fn build_deployment_overview_redacts_database_url_for_remote_postgres() {
+        let healthz = HealthzResponse {
+            mode: "remote".to_string(),
+            version: "0.0.1".to_string(),
+            storage: "postgres".to_string(),
+            uptime_secs: 1_234_567,
+            storage_path: None,
+            database_url: Some("postgresql://aasm:secret@aasm-db:5432/aasm".to_string()),
+        };
+        let overview = build_deployment_overview("https://cp.company.internal:7391", Some(healthz));
+        assert_eq!(overview.mode, "remote");
+        assert_eq!(overview.storage_backend, "postgres");
+        assert!(overview.storage_path.is_none());
+        assert_eq!(
+            overview.database_url_redacted.as_deref(),
+            Some("postgresql://aasm:***@aasm-db:5432/aasm")
+        );
+        assert_eq!(overview.health, "ok");
+    }
+
+    #[test]
     fn build_deployment_overview_populates_fields_from_local_sqlite_healthz() {
         let healthz = HealthzResponse {
             mode: "local".to_string(),

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -89,6 +89,36 @@ pub struct HealthzResponse {
     pub database_url: Option<String>,
 }
 
+/// Display model for the `aasm status` deployment-overview header.
+///
+/// The serialised shape is the JSON contract for `aasm status --json` — field
+/// names must stay in lockstep with the AAASM-1579 story description so
+/// scripting and CI consumers can rely on them. `storage_path` and
+/// `database_url_redacted` are `Option` to allow them to be omitted in the
+/// minimum `/healthz` body case rather than emitted as `null`.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct DeploymentOverview {
+    /// Deployment mode label: `"local"` or `"remote"` (or `"unknown"` when unreachable).
+    pub mode: String,
+    /// Gateway base URL the CLI was configured to talk to.
+    pub gateway_url: String,
+    /// Storage backend label: `"sqlite"`, `"postgres"`, `"memory"`, or `"unknown"`.
+    pub storage_backend: String,
+    /// Local-mode SQLite file path, when reported by the gateway.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_path: Option<String>,
+    /// PostgreSQL connection URL with the password segment replaced by `***`,
+    /// when reported by the gateway.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub database_url_redacted: Option<String>,
+    /// Gateway crate version.
+    pub version: String,
+    /// Seconds elapsed since the gateway became ready to serve traffic.
+    pub uptime_secs: u64,
+    /// Overall health label: `"ok"` when the gateway responded, `"unreachable"` otherwise.
+    pub health: String,
+}
+
 /// Computed runtime health for display.
 #[derive(Debug, Clone, Serialize)]
 pub struct RuntimeHealth {

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -329,6 +329,30 @@ mod tests {
     }
 
     #[test]
+    fn deployment_overview_serialises_with_documented_field_names() {
+        let overview = DeploymentOverview {
+            mode: "remote".to_string(),
+            gateway_url: "https://cp.company.internal:7391".to_string(),
+            storage_backend: "postgres".to_string(),
+            storage_path: None,
+            database_url_redacted: Some("postgresql://aasm:***@aasm-db:5432/aasm".to_string()),
+            version: "0.0.1".to_string(),
+            uptime_secs: 8133,
+            health: "ok".to_string(),
+        };
+        let json = serde_json::to_value(&overview).expect("DeploymentOverview must serialise");
+        assert_eq!(json["mode"], "remote");
+        assert_eq!(json["gateway_url"], "https://cp.company.internal:7391");
+        assert_eq!(json["storage_backend"], "postgres");
+        assert_eq!(json["database_url_redacted"], "postgresql://aasm:***@aasm-db:5432/aasm");
+        assert_eq!(json["version"], "0.0.1");
+        assert_eq!(json["uptime_secs"], 8133);
+        assert_eq!(json["health"], "ok");
+        // storage_path = None must be omitted, not serialised as null.
+        assert!(json.get("storage_path").is_none(), "Option::None must be skipped");
+    }
+
+    #[test]
     fn healthz_response_deserializes_with_storage_path_and_database_url() {
         let json = r#"{
             "mode": "remote",


### PR DESCRIPTION
## Description

Display-model layer for the `aasm status` deployment-overview header. Adds:

- `DeploymentOverview` serializable struct in `aa-cli/src/commands/status/models.rs` — field names match the documented JSON shape (`mode`, `gateway_url`, `storage_backend`, `storage_path?`, `database_url_redacted?`, `version`, `uptime_secs`, `health`). `Option::None` fields are skipped from JSON, not emitted as `null`.
- `build_deployment_overview(gateway_url, Option<HealthzResponse>) -> DeploymentOverview` in `aa-cli/src/commands/status/fetch.rs` — pure function mapping wire response to display model; absent /healthz → `health = "unreachable"`; postgres `database_url` is redacted via the helper from ST-1 before reaching the display layer.

Annotated `#[allow(dead_code)]` for this PR; ST-3 wires it into `fetch_all`.

**Stacked on top of [#710](https://github.com/AI-agent-assembly/agent-assembly/pull/710) (AAASM-1854 ST-1)** via cherry-pick of those 9 commits — the duplicate commits drop automatically on rebase once #710 merges. The 6 new commits at the tip are the ST-2-specific work.

Second Sub-task of Story AAASM-1579 (E17 S-E); part of Epic AAASM-1568.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: [AAASM-1857](https://lightning-dust-mite.atlassian.net/browse/AAASM-1857) (Sub-task of [AAASM-1579](https://lightning-dust-mite.atlassian.net/browse/AAASM-1579), Epic [AAASM-1568](https://lightning-dust-mite.atlassian.net/browse/AAASM-1568))
- Stacked on: #710
- Related GitHub issues: —

## Testing

- [x] Unit tests added / updated — 4 new tests:
  - `aa-cli status::models::tests::deployment_overview_serialises_with_documented_field_names`
  - `aa-cli status::fetch::tests::build_deployment_overview_populates_fields_from_local_sqlite_healthz`
  - `aa-cli status::fetch::tests::build_deployment_overview_redacts_database_url_for_remote_postgres`
  - `aa-cli status::fetch::tests::build_deployment_overview_marks_health_unreachable_when_healthz_absent`
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Local: \`cargo nextest run -p aa-cli\` → **531 tests run: 531 passed, 0 skipped**.

## Checklist

- [x] Code follows project style guidelines (\`cargo fmt\`, \`cargo clippy\`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (doc-comments on the new items)
- [ ] All CI checks passing (will verify after push)
- [x] Commits are small and follow the Gitmoji convention (6 new commits + 9 stacked from #710)

[AAASM-1857]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ