### PR TITLE
[AAASM-1213] ✨ (release): Auto-update Homebrew tap formula on every tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,3 +204,20 @@ jobs:
           repository: AI-agent-assembly/homebrew-agent-assembly
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: tap
+
+      - name: Rewrite Formula/aasm.rb with new version + shas
+        shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          DARWIN_ARM: ${{ steps.shas.outputs.darwin_arm }}
+          DARWIN_INTEL: ${{ steps.shas.outputs.darwin_intel }}
+          LINUX_ARM: ${{ steps.shas.outputs.linux_arm }}
+          LINUX_INTEL: ${{ steps.shas.outputs.linux_intel }}
+        run: |
+          cd tap
+          sed -i "s|version \".*\"|version \"${VERSION}\"|" Formula/aasm.rb
+          sed -i "/aasm-aarch64-apple-darwin\.tar\.gz/{n;s|sha256 \"[^\"]*\"|sha256 \"${DARWIN_ARM}\"|}" Formula/aasm.rb
+          sed -i "/aasm-x86_64-apple-darwin\.tar\.gz/{n;s|sha256 \"[^\"]*\"|sha256 \"${DARWIN_INTEL}\"|}" Formula/aasm.rb
+          sed -i "/aasm-aarch64-unknown-linux-gnu\.tar\.gz/{n;s|sha256 \"[^\"]*\"|sha256 \"${LINUX_ARM}\"|}" Formula/aasm.rb
+          sed -i "/aasm-x86_64-unknown-linux-gnu\.tar\.gz/{n;s|sha256 \"[^\"]*\"|sha256 \"${LINUX_INTEL}\"|}" Formula/aasm.rb
+          git -C . diff -- Formula/aasm.rb || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,3 +188,12 @@ jobs:
             echo "linux_arm=$(awk '$2=="aasm-aarch64-unknown-linux-gnu.tar.gz"{print $1}' SHA256SUMS)"
             echo "linux_intel=$(awk '$2=="aasm-x86_64-unknown-linux-gnu.tar.gz"{print $1}' SHA256SUMS)"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Extract release version from tag
+        id: version
+        shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          # github.ref_name is the tag (e.g. v0.0.1); strip the leading "v".
+          echo "version=${REF_NAME#v}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,3 +221,21 @@ jobs:
           sed -i "/aasm-aarch64-unknown-linux-gnu\.tar\.gz/{n;s|sha256 \"[^\"]*\"|sha256 \"${LINUX_ARM}\"|}" Formula/aasm.rb
           sed -i "/aasm-x86_64-unknown-linux-gnu\.tar\.gz/{n;s|sha256 \"[^\"]*\"|sha256 \"${LINUX_INTEL}\"|}" Formula/aasm.rb
           git -C . diff -- Formula/aasm.rb || true
+
+      - name: Open tap PR via peter-evans/create-pull-request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          path: tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          branch: bot/aasm-${{ steps.version.outputs.version }}
+          base: master
+          delete-branch: true
+          commit-message: "🤖 (formula): Update aasm to ${{ steps.version.outputs.version }}"
+          title: "🤖 (formula): aasm ${{ steps.version.outputs.version }}"
+          body: |
+            Auto-update from agent-assembly release `${{ github.ref_name }}`.
+
+            Bumps `version` and refreshes the four per-platform `sha256` values in
+            `Formula/aasm.rb` from the `SHA256SUMS` published with the release.
+
+            Source workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,3 +158,18 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
         run: cargo publish -p aa-cli
+
+  update-homebrew-tap:
+    name: Update Homebrew tap formula
+    runs-on: ubuntu-latest
+    needs: publish
+    if: github.event_name == 'push'
+    permissions:
+      contents: read
+
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: artifacts/
+          merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,3 +173,18 @@ jobs:
         with:
           path: artifacts/
           merge-multiple: true
+
+      - name: Extract per-platform sha256
+        id: shas
+        shell: bash
+        run: |
+          cd artifacts
+          if [ ! -f SHA256SUMS ]; then
+            sha256sum aasm-*.tar.gz > SHA256SUMS
+          fi
+          {
+            echo "darwin_arm=$(awk '$2=="aasm-aarch64-apple-darwin.tar.gz"{print $1}' SHA256SUMS)"
+            echo "darwin_intel=$(awk '$2=="aasm-x86_64-apple-darwin.tar.gz"{print $1}' SHA256SUMS)"
+            echo "linux_arm=$(awk '$2=="aasm-aarch64-unknown-linux-gnu.tar.gz"{print $1}' SHA256SUMS)"
+            echo "linux_intel=$(awk '$2=="aasm-x86_64-unknown-linux-gnu.tar.gz"{print $1}' SHA256SUMS)"
+          } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,3 +197,10 @@ jobs:
         run: |
           # github.ref_name is the tag (e.g. v0.0.1); strip the leading "v".
           echo "version=${REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout homebrew-agent-assembly tap
+        uses: actions/checkout@v6
+        with:
+          repository: AI-agent-assembly/homebrew-agent-assembly
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: tap


### PR DESCRIPTION
## Description

Adds a new `update-homebrew-tap` job to `.github/workflows/release.yml` that, on every tag push, opens an automated PR against `AI-agent-assembly/homebrew-agent-assembly` updating `Formula/aasm.rb` so users get the latest `aasm` via `brew install agent-assembly/agent-assembly/aasm` immediately after a release.

Built as 6 small commits, each adding one step to the new job:

| # | Commit |
| - | - |
| 1 | `✨ (release): Add update-homebrew-tap job stub with artifact download` |
| 2 | `✨ (release): Extract per-platform sha256 outputs from SHA256SUMS` |
| 3 | `✨ (release): Extract release version from tag ref` |
| 4 | `✨ (release): Checkout homebrew-agent-assembly with HOMEBREW_TAP_TOKEN` |
| 5 | `✨ (release): Rewrite Formula/aasm.rb with new version + shas via sed` |
| 6 | `✨ (release): Open tap PR via peter-evans/create-pull-request` |

## Required new secret — `HOMEBREW_TAP_TOKEN`

This workflow will **silently no-op (or fail) until** a repository secret named `HOMEBREW_TAP_TOKEN` is configured at:

> `https://github.com/AI-agent-assembly/agent-assembly/settings/secrets/actions`

Recommended: a fine-grained PAT scoped to **only** `AI-agent-assembly/homebrew-agent-assembly` with:

- **Contents**: Read and write
- **Pull requests**: Read and write

The token is used both for `actions/checkout` (clone) and `peter-evans/create-pull-request` (push branch + open PR). It is **not** added in this PR — the engineer must create and add the PAT before the next tag.

## Behaviour after merge + secret

```
git tag v0.1.0 && git push remote v0.1.0
  → Release workflow runs
  → publish job uploads aasm-*.tar.gz + SHA256SUMS to GitHub Release
  → update-homebrew-tap job:
    - downloads SHA256SUMS, extracts 4 platform shas
    - clones tap repo
    - rewrites Formula/aasm.rb (version: "0.1.0" + 4 sha256 lines)
    - opens PR on tap: `🤖 (formula): aasm 0.1.0` on branch bot/aasm-0.1.0
```

## Security review (workflow injection)

All GitHub-context values used in `run:` blocks (`github.ref_name`, step outputs) flow through `env:` rather than being interpolated directly. The step outputs (`darwin_arm`, `darwin_intel`, `linux_arm`, `linux_intel`) are SHA-256 hex strings generated by `sha256sum` from our own build artifacts — no external user input touches a shell.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: [AAASM-1213](https://lightning-dust-mite.atlassian.net/browse/AAASM-1213)
- Parent Story: [AAASM-1201](https://lightning-dust-mite.atlassian.net/browse/AAASM-1201)
- Companion sub-tickets: AAASM-1210 (tap scaffold), AAASM-1211 (`Formula/aasm.rb`), AAASM-1212 (curl installer SHA256 verify)
- Downstream tap PR(s) will land at `AI-agent-assembly/homebrew-agent-assembly/pull/<n>`

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed (YAML parsed OK, `jobs:` keys verified: build, publish, publish-crate, update-homebrew-tap)
- [ ] No tests required (explain why)

Full end-to-end requires a tag push with `HOMEBREW_TAP_TOKEN` configured — first observable run will be at the next release. AAASM-1214 covers the e2e checklist.

## Checklist

- [x] Code follows project style guidelines (YAML parse OK)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (PR body documents the new secret)
- [ ] All CI checks passing (pending)
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1213]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ