### PR TITLE
[AAASM-1860] ✨ (aa-cli/status): Wire DeploymentOverview into StatusSnapshot

### DIFF
--- a/aa-cli/src/commands/status/client.rs
+++ b/aa-cli/src/commands/status/client.rs
@@ -47,7 +47,6 @@ impl StatusClient {
     /// `aa-gateway::routes::healthz::healthz` regardless of deployment mode.
     /// Returns an error when the gateway is unreachable or returns a body the
     /// client cannot decode; callers map that to `health = "unreachable"`.
-    #[allow(dead_code)]
     pub async fn check_healthz(&self) -> Result<HealthzResponse, CliError> {
         let resp = self.http.get(self.url("/healthz")).send().await?;
         let body = resp.json::<HealthzResponse>().await?;

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -134,7 +134,10 @@ pub async fn fetch_all(client: &StatusClient) -> StatusSnapshot {
         },
     };
 
+    let deployment = build_deployment_overview(client.base_url(), None);
+
     StatusSnapshot {
+        deployment,
         runtime,
         agents,
         approvals,

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -23,7 +23,6 @@ use super::models::{
 /// exception of `database_url`, which is run through [`redact_database_url`]
 /// before being assigned to `database_url_redacted`. The raw wire value never
 /// reaches the display layer.
-#[allow(dead_code)]
 pub fn build_deployment_overview(gateway_url: &str, healthz: Option<HealthzResponse>) -> DeploymentOverview {
     match healthz {
         Some(h) => DeploymentOverview {

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -112,8 +112,9 @@ pub fn build_approvals_summary(approvals: &[ApprovalResponse]) -> ApprovalsSumma
 
 /// Fetch all status data from the gateway in parallel and compose a `StatusSnapshot`.
 pub async fn fetch_all(client: &StatusClient) -> StatusSnapshot {
-    let (health_result, agents_result, approvals_result, costs_result) = tokio::join!(
+    let (health_result, healthz_result, agents_result, approvals_result, costs_result) = tokio::join!(
         client.check_health(),
+        client.check_healthz(),
         client.list_agents(),
         client.list_approvals(),
         client.get_costs(),
@@ -134,7 +135,7 @@ pub async fn fetch_all(client: &StatusClient) -> StatusSnapshot {
         },
     };
 
-    let deployment = build_deployment_overview(client.base_url(), None);
+    let deployment = build_deployment_overview(client.base_url(), healthz_result.ok());
 
     StatusSnapshot {
         deployment,

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -63,6 +63,16 @@ mod tests {
 
     fn healthy_snapshot() -> StatusSnapshot {
         StatusSnapshot {
+            deployment: DeploymentOverview {
+                mode: "local".to_string(),
+                gateway_url: "http://localhost:7391".to_string(),
+                storage_backend: "sqlite".to_string(),
+                storage_path: Some("~/.aasm/local.db".to_string()),
+                database_url_redacted: None,
+                version: "0.0.1".to_string(),
+                uptime_secs: 3600,
+                health: "ok".to_string(),
+            },
             runtime: RuntimeHealth {
                 reachable: true,
                 status: "ok".to_string(),

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -261,6 +261,8 @@ pub struct PaginatedResponse<T> {
 /// Complete status snapshot combining all sections.
 #[derive(Debug, Clone, Serialize)]
 pub struct StatusSnapshot {
+    /// Deployment-overview header: mode, gateway URL, storage backend, version, uptime, health.
+    pub deployment: DeploymentOverview,
     pub runtime: RuntimeHealth,
     pub agents: Vec<AgentRow>,
     pub approvals: ApprovalsSummary,

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -318,6 +318,9 @@ mod tests {
             },
         };
         let json = serde_json::to_string_pretty(&snapshot).unwrap();
+        assert!(json.contains("\"deployment\""));
+        assert!(json.contains("\"gateway_url\""));
+        assert!(json.contains("\"storage_backend\""));
         assert!(json.contains("\"runtime\""));
         assert!(json.contains("\"agents\""));
         assert!(json.contains("\"approvals\""));

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -284,7 +284,18 @@ mod tests {
 
     #[test]
     fn render_status_json_contains_all_keys() {
+        use super::super::models::DeploymentOverview;
         let snapshot = StatusSnapshot {
+            deployment: DeploymentOverview {
+                mode: "local".to_string(),
+                gateway_url: "http://localhost:7391".to_string(),
+                storage_backend: "sqlite".to_string(),
+                storage_path: None,
+                database_url_redacted: None,
+                version: "0.0.1".to_string(),
+                uptime_secs: 120,
+                health: "ok".to_string(),
+            },
             runtime: RuntimeHealth {
                 reachable: true,
                 status: "ok".to_string(),


### PR DESCRIPTION
## Description

Snapshot-level integration of the deployment overview. Changes:

- `StatusSnapshot` gains a `deployment: DeploymentOverview` field (first/top of the struct so it serialises first in JSON).
- `fetch_all` adds `client.check_healthz()` to its `tokio::join!` and feeds the result through `build_deployment_overview(client.base_url(), healthz_result.ok())` into the snapshot — health=`"unreachable"` when the gateway is offline.
- Existing fixtures (`mod.rs healthy_snapshot`, `render.rs render_status_json_contains_all_keys`) updated to satisfy the new mandatory field.
- Dead-code allow attributes on `check_healthz` and `build_deployment_overview` removed now that both are live consumers.
- Extended `render_status_json_contains_all_keys` to assert the new top-level JSON keys (`deployment`, `gateway_url`, `storage_backend`).

**Stacked on [#710](https://github.com/AI-agent-assembly/agent-assembly/pull/710) (AAASM-1854 ST-1) and [#717](https://github.com/AI-agent-assembly/agent-assembly/pull/717) (AAASM-1857 ST-2)** via cherry-pick — dependency commits drop automatically on rebase as the parent PRs merge. The 5 net new commits at the tip are ST-3.

Third Sub-task of Story AAASM-1579 (E17 S-E); part of Epic AAASM-1568.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Internal struct shape change to `StatusSnapshot` — `aa-cli` is the only consumer, no public API impact.

## Related Issues

- Related Jira ticket: [AAASM-1860](https://lightning-dust-mite.atlassian.net/browse/AAASM-1860) (Sub-task of [AAASM-1579](https://lightning-dust-mite.atlassian.net/browse/AAASM-1579), Epic [AAASM-1568](https://lightning-dust-mite.atlassian.net/browse/AAASM-1568))
- Stacked on: #710, #717
- Related GitHub issues: —

## Testing

- [x] Unit tests added / updated — extended `render_status_json_contains_all_keys` to cover the new top-level keys; updated `healthy_snapshot` fixture so existing exit-code tests continue to pass.
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Local: \`cargo nextest run -p aa-cli\` → **531 tests run: 531 passed, 0 skipped**.

## Checklist

- [x] Code follows project style guidelines (\`cargo fmt\`, \`cargo clippy\`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (doc-comment on new struct field)
- [ ] All CI checks passing (will verify after push)
- [x] Commits are small and follow the Gitmoji convention (5 new commits + stacked dependencies)

[AAASM-1860]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ