### PR TITLE
[AAASM-1865] ✨ (aa-cli/status): Add --json flag and exit-1-with-hint on unreachable

### DIFF
--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -61,7 +61,17 @@ pub fn dispatch(args: StatusArgs, ctx: &ResolvedContext, output: OutputFormat) -
             ExitCode::SUCCESS
         } else {
             let snapshot = fetch::fetch_all(&api_client).await;
-            render::render_all(&snapshot, output);
+            if args.json {
+                match serde_json::to_string_pretty(&snapshot.deployment) {
+                    Ok(json) => println!("{json}"),
+                    Err(e) => eprintln!("error serializing deployment overview to JSON: {e}"),
+                }
+            } else {
+                render::render_all(&snapshot, output);
+            }
+            if snapshot.deployment.health == "unreachable" {
+                eprintln!("Error: gateway is not running. Start it with: aasm start");
+            }
             compute_exit_code(&snapshot)
         }
     })

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -34,11 +34,14 @@ use models::StatusSnapshot;
 /// Compute the process exit code from a status snapshot.
 ///
 /// - `0` — all healthy
-/// - `1` — at least one agent has violations
-/// - `2` — runtime API is unreachable
+/// - `1` — gateway is unreachable (`deployment.health == "unreachable"`) OR at
+///   least one agent has violations. Per the AAASM-1579 acceptance criteria,
+///   unreachable now maps to exit code 1 instead of the legacy exit code 2 so
+///   shell scripts can use a single non-zero check without distinguishing
+///   between failure modes.
 pub fn compute_exit_code(snapshot: &StatusSnapshot) -> ExitCode {
-    if !snapshot.runtime.reachable {
-        return ExitCode::from(2);
+    if snapshot.deployment.health == "unreachable" {
+        return ExitCode::from(1);
     }
     let has_violations = snapshot.agents.iter().any(|a| a.violations_today > 0);
     if has_violations {
@@ -127,17 +130,17 @@ mod tests {
     }
 
     #[test]
-    fn exit_code_2_when_unreachable() {
+    fn exit_code_1_when_deployment_unreachable() {
         let mut snapshot = healthy_snapshot();
-        snapshot.runtime.reachable = false;
-        assert_eq!(compute_exit_code(&snapshot), ExitCode::from(2));
+        snapshot.deployment.health = "unreachable".to_string();
+        assert_eq!(compute_exit_code(&snapshot), ExitCode::from(1));
     }
 
     #[test]
-    fn exit_code_2_takes_precedence_over_violations() {
+    fn exit_code_1_when_deployment_unreachable_with_violations() {
         let mut snapshot = healthy_snapshot();
-        snapshot.runtime.reachable = false;
+        snapshot.deployment.health = "unreachable".to_string();
         snapshot.agents[0].violations_today = 5;
-        assert_eq!(compute_exit_code(&snapshot), ExitCode::from(2));
+        assert_eq!(compute_exit_code(&snapshot), ExitCode::from(1));
     }
 }

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -19,6 +19,14 @@ pub struct StatusArgs {
     /// Auto-refresh the status display every 5 seconds.
     #[arg(long)]
     pub watch: bool,
+
+    /// Print only the deployment-overview header as machine-readable JSON.
+    ///
+    /// Intended for scripting and CI integrations — the documented shape is
+    /// the JSON contract published in the AAASM-1579 story description.
+    /// Distinct from `--output json`, which serialises the full status snapshot.
+    #[arg(long)]
+    pub json: bool,
 }
 
 use models::StatusSnapshot;

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -147,6 +147,34 @@ mod tests {
     }
 
     #[test]
+    fn json_flag_output_contains_documented_top_level_keys() {
+        // The --json flag emits snapshot.deployment alone via
+        // serde_json::to_string_pretty — verify the resulting shape matches
+        // the AAASM-1579 documented contract.
+        let snapshot = healthy_snapshot();
+        let json: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string_pretty(&snapshot.deployment).expect("serialise deployment"))
+                .expect("parse deployment JSON");
+        for required_key in [
+            "mode",
+            "gateway_url",
+            "storage_backend",
+            "version",
+            "uptime_secs",
+            "health",
+        ] {
+            assert!(
+                json.get(required_key).is_some(),
+                "missing top-level key {required_key:?}"
+            );
+        }
+        assert_eq!(json["mode"], "local");
+        assert_eq!(json["gateway_url"], "http://localhost:7391");
+        assert_eq!(json["storage_backend"], "sqlite");
+        assert_eq!(json["health"], "ok");
+    }
+
+    #[test]
     fn exit_code_1_when_deployment_unreachable_with_violations() {
         let mut snapshot = healthy_snapshot();
         snapshot.deployment.health = "unreachable".to_string();

--- a/aa-integration-tests/tests/cli_status.rs
+++ b/aa-integration-tests/tests/cli_status.rs
@@ -235,11 +235,12 @@ async fn status_exits_1_when_agent_has_policy_violations() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn status_exits_2_when_gateway_is_unreachable() {
+async fn status_exits_1_with_hint_when_gateway_is_unreachable() {
     // No `CliFixture::start()` — we point the CLI at a known-unbound port
-    // to exercise the unreachable-API exit code (2). Building Command by
-    // hand because `CliFixture::cmd()` always wires --api-url to the live
-    // fixture URL.
+    // to exercise the unreachable-gateway behaviour. Per AAASM-1579 AC the
+    // CLI now exits 1 (was 2) and writes a documented hint to stderr.
+    // Building Command by hand because `CliFixture::cmd()` always wires
+    // --api-url to the live fixture URL.
     let mut cmd = Command::new(env!("CARGO"));
     cmd.args([
         "run",
@@ -254,13 +255,17 @@ async fn status_exits_2_when_gateway_is_unreachable() {
         "status",
     ]);
     let out = cmd.output().expect("aasm status should execute");
+    let stderr = String::from_utf8_lossy(&out.stderr);
 
     assert_eq!(
         out.status.code(),
-        Some(2),
-        "unreachable gateway should yield exit code 2; stdout:\n{}\nstderr:\n{}",
+        Some(1),
+        "unreachable gateway should yield exit code 1; stdout:\n{}\nstderr:\n{stderr}",
         String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        stderr.contains("Error: gateway is not running. Start it with: aasm start"),
+        "unreachable gateway should print the documented stderr hint; stderr:\n{stderr}",
     );
 }
 

--- a/aa-integration-tests/tests/cli_status.rs
+++ b/aa-integration-tests/tests/cli_status.rs
@@ -111,19 +111,22 @@ async fn status_json_and_yaml_are_structurally_equivalent() {
     assert!(json_out.status.success() && yaml_out.status.success());
 
     // Parse both, then assert structural equality after normalizing the
-    // runtime.uptime_secs field — it counts wall-clock seconds since the
-    // gateway started and naturally drifts between the two back-to-back
-    // CLI invocations. All other section fields are deterministic given
-    // a fresh empty fixture.
+    // wall-clock uptime fields (`runtime.uptime_secs` and
+    // `deployment.uptime_secs`) — they count seconds since the gateway
+    // started and naturally drift between the two back-to-back CLI
+    // invocations. All other section fields are deterministic given a
+    // fresh empty fixture.
     let mut json_v = parse_json(&json_out.stdout);
     let yaml_as_json: serde_json::Value =
         serde_json::to_value(parse_yaml(&yaml_out.stdout)).expect("yaml should round-trip to JSON");
     let mut yaml_v = yaml_as_json;
-    if let Some(r) = json_v.get_mut("runtime").and_then(|x| x.as_object_mut()) {
-        r.insert("uptime_secs".into(), serde_json::Value::from(0));
-    }
-    if let Some(r) = yaml_v.get_mut("runtime").and_then(|x| x.as_object_mut()) {
-        r.insert("uptime_secs".into(), serde_json::Value::from(0));
+    for v in [&mut json_v, &mut yaml_v] {
+        if let Some(r) = v.get_mut("runtime").and_then(|x| x.as_object_mut()) {
+            r.insert("uptime_secs".into(), serde_json::Value::from(0));
+        }
+        if let Some(d) = v.get_mut("deployment").and_then(|x| x.as_object_mut()) {
+            d.insert("uptime_secs".into(), serde_json::Value::from(0));
+        }
     }
     assert_eq!(
         json_v,

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -68,6 +68,7 @@ use aa_gateway::edges::InMemoryEdgeRepo;
 use aa_gateway::engine::PolicyEngine;
 use aa_gateway::policy::history::{FsHistoryStore, HistoryConfig};
 use aa_gateway::registry::{AgentRegistry, OrphanMode};
+use aa_gateway::routes::healthz::{healthz, HealthzState};
 use aa_gateway::AuditReader;
 use aa_runtime::approval::ApprovalQueue;
 use tokio::sync::oneshot;
@@ -169,7 +170,7 @@ impl TopologyTestEnv {
         let listener = tokio::net::TcpListener::bind(addr).await?;
         let bound_addr = listener.local_addr()?;
 
-        let app = build_app(state);
+        let app = build_app_with_healthz(state);
         let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
 
         let server_handle = tokio::spawn(async move {
@@ -226,7 +227,7 @@ impl TopologyTestEnv {
         let listener = tokio::net::TcpListener::bind(addr).await?;
         let bound_addr = listener.local_addr()?;
 
-        let app = build_app(state);
+        let app = build_app_with_healthz(state);
         let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
 
         let server_handle = tokio::spawn(async move {
@@ -286,7 +287,7 @@ impl TopologyTestEnv {
         let listener = tokio::net::TcpListener::bind(addr).await?;
         let bound_addr = listener.local_addr()?;
 
-        let app = build_app(state);
+        let app = build_app_with_healthz(state);
         let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
 
         let server_handle = tokio::spawn(async move {
@@ -343,7 +344,7 @@ impl TopologyTestEnv {
         let listener = tokio::net::TcpListener::bind(addr).await?;
         let bound_addr = listener.local_addr()?;
 
-        let app = build_app(state);
+        let app = build_app_with_healthz(state);
         let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
 
         let server_handle = tokio::spawn(async move {
@@ -398,7 +399,7 @@ impl TopologyTestEnv {
         let listener = tokio::net::TcpListener::bind(addr).await?;
         let bound_addr = listener.local_addr()?;
 
-        let app = build_app(state);
+        let app = build_app_with_healthz(state);
         let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
 
         let server_handle = tokio::spawn(async move {
@@ -452,7 +453,7 @@ impl TopologyTestEnv {
         let listener = tokio::net::TcpListener::bind(addr).await?;
         let bound_addr = listener.local_addr()?;
 
-        let app = build_app(state);
+        let app = build_app_with_healthz(state);
         let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
 
         let server_handle = tokio::spawn(async move {
@@ -556,6 +557,22 @@ fn uuid_string(key: &[u8; 16]) -> String {
 }
 
 /// Build a minimal `AppState` for the harness. Adapted from
+/// Build the in-process test app and bolt the gateway's `/healthz` route on top.
+///
+/// `aa_api::server::build_app` exposes the `/api/v1/*` surface; in production
+/// the `/healthz` liveness probe lives in `aa-gateway` (`aa_gateway::routes::
+/// healthz`). The CLI consumes both — `aasm status` derives its deployment-
+/// overview / exit-code behaviour from `/healthz`, so the test fixture must
+/// serve it too. Mounts with neutral labels (`mode = "local"`, `storage = "memory"`)
+/// matching the in-memory `AppState` the fixture actually builds.
+fn build_app_with_healthz(state: AppState) -> axum::Router {
+    use axum::routing::get;
+    use axum::Extension;
+    build_app(state)
+        .route("/healthz", get(healthz))
+        .layer(Extension(HealthzState::new("local", "memory")))
+}
+
 /// `aa-api/tests/common/mod.rs::test_state_with_auth` to avoid pulling that
 /// crate's `dev-dependencies` test helpers across crate boundaries.
 ///


### PR DESCRIPTION
## Description

Final CLI surface for the `aasm status` deployment overview. Changes:

- `StatusArgs` gains a `#[arg(long)] pub json: bool` flag. Documented as the scripting/CI shortcut that emits **only** the deployment overview JSON shape from the AAASM-1579 story (distinct from `--output json` which serialises the full snapshot).
- `dispatch` branches on `args.json`: when set, prints `serde_json::to_string_pretty(&snapshot.deployment)` and skips the Table/YAML/JSON snapshot rendering; otherwise calls `render_all` as before.
- After rendering (in either path), if `snapshot.deployment.health == "unreachable"`, dispatch writes `Error: gateway is not running. Start it with: aasm start` to **stderr** so scripts pick up the actionable hint alongside the exit code.
- `compute_exit_code` rewritten to key off `snapshot.deployment.health` instead of `snapshot.runtime.reachable`. Unreachable now returns `ExitCode::from(1)` (previously 2) per the AAASM-1579 AC. Violations behaviour unchanged.
- Existing `exit_code_2_*` tests renamed to `exit_code_1_when_deployment_unreachable*` and re-aimed at the new contract.

**Stacked on [#710](https://github.com/AI-agent-assembly/agent-assembly/pull/710) → [#717](https://github.com/AI-agent-assembly/agent-assembly/pull/717) → [#721](https://github.com/AI-agent-assembly/agent-assembly/pull/721) → [#725](https://github.com/AI-agent-assembly/agent-assembly/pull/725)** via cherry-pick — dependency commits drop on rebase as parents merge. The 4 net new commits at the tip are ST-5.

Fifth (and final implementation) Sub-task of Story AAASM-1579 (E17 S-E); part of Epic AAASM-1568. ST-6 follows with the verification report.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring (compute_exit_code semantics changed — see Breaking Changes)
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [ ] No
- [x] Yes (describe below)

**`aasm status` exit code 2** (gateway runtime unreachable) is now **exit code 1**, matching the AAASM-1579 AC. Shell scripts that distinguished between `2` (unreachable) and `1` (violations) need updating, though the simpler `[ "$exit" -ne 0 ]` check is unaffected.

## Related Issues

- Related Jira ticket: [AAASM-1865](https://lightning-dust-mite.atlassian.net/browse/AAASM-1865) (Sub-task of [AAASM-1579](https://lightning-dust-mite.atlassian.net/browse/AAASM-1579), Epic [AAASM-1568](https://lightning-dust-mite.atlassian.net/browse/AAASM-1568))
- Stacked on: #710, #717, #721, #725
- Related GitHub issues: —

## Testing

- [x] Unit tests added / updated — 1 new test, 2 renamed/re-aimed:
  - `aa-cli status::tests::json_flag_output_contains_documented_top_level_keys` (new)
  - `aa-cli status::tests::exit_code_1_when_deployment_unreachable` (renamed from `exit_code_2_when_unreachable`)
  - `aa-cli status::tests::exit_code_1_when_deployment_unreachable_with_violations` (renamed from `exit_code_2_takes_precedence_over_violations`)
- [ ] Integration tests added / updated
- [ ] Manual testing performed (will be exercised by ST-6 verification)
- [ ] No tests required (explain why)

Local: \`cargo nextest run -p aa-cli\` → **535 tests run: 535 passed, 0 skipped**.

## Checklist

- [x] Code follows project style guidelines (\`cargo fmt\`, \`cargo clippy\`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (compute_exit_code doc-comment updated; --json flag has user-facing doc)
- [ ] All CI checks passing (will verify after push)
- [x] Commits are small and follow the Gitmoji convention (4 new commits + stacked dependencies)

[AAASM-1865]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ