### PR TITLE
[AAASM-1557] ✨ (aa-gateway): Per-agent enforcement_mode override + resolution

### DIFF
--- a/aa-api/tests/agents.rs
+++ b/aa-api/tests/agents.rs
@@ -41,6 +41,7 @@ fn test_agent(id_byte: u8) -> AgentRecord {
         root_agent_id: None,
         children: Vec::new(),
         parent_key: None,
+        enforcement_mode: None,
     }
 }
 

--- a/aa-api/tests/topology.rs
+++ b/aa-api/tests/topology.rs
@@ -41,6 +41,7 @@ fn make_agent(id_byte: u8, name: &str, depth: u32, team_id: Option<&str>, parent
         root_agent_id: if depth == 0 { Some([id_byte; 16]) } else { parent_id },
         children: Vec::new(),
         parent_key: parent_id,
+        enforcement_mode: None,
     }
 }
 

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -2220,6 +2220,19 @@ mod tests {
     // ── enforcement-mode resolution (AAASM-1557) ─────────────────────────────
 
     #[test]
+    fn resolve_isolates_two_agents_under_the_same_policy() {
+        // AAASM-1557 AC: two agents share a policy, one registers in Observe,
+        // the other inherits the policy default (Enforce) — each must resolve
+        // to its own mode independently. Regression guard for any future
+        // refactor that accidentally shares state across resolve() calls.
+        let policy = aa_core::EnforcementMode::Enforce; // trusted-team policy
+        let trusted_agent = resolve_enforcement_mode(None, policy);
+        let experimental_agent = resolve_enforcement_mode(Some(aa_core::EnforcementMode::Observe), policy);
+        assert_eq!(trusted_agent, aa_core::EnforcementMode::Enforce);
+        assert_eq!(experimental_agent, aa_core::EnforcementMode::Observe);
+    }
+
+    #[test]
     fn resolve_prefers_agent_override_over_policy_default() {
         // Per-agent override is the whole point of this subtask — it must
         // win over the policy-level default. Covers all four override values

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -2216,4 +2216,17 @@ mod tests {
         assert_eq!(shadow.shadow_decision, "deny");
         assert_eq!(shadow.reason, "tool denied by policy");
     }
+
+    // ── enforcement-mode resolution (AAASM-1557) ─────────────────────────────
+
+    #[test]
+    fn resolve_falls_back_to_policy_default_when_agent_override_is_none() {
+        // An agent that registered without setting enforcement_mode inherits
+        // the policy document's posture. Most production agents take this path.
+        let resolved = resolve_enforcement_mode(None, aa_core::EnforcementMode::Observe);
+        assert_eq!(resolved, aa_core::EnforcementMode::Observe);
+
+        let resolved = resolve_enforcement_mode(None, aa_core::EnforcementMode::Enforce);
+        assert_eq!(resolved, aa_core::EnforcementMode::Enforce);
+    }
 }

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -80,6 +80,22 @@ pub struct ShadowEvent {
     pub reason: String,
 }
 
+/// Resolve the effective enforcement mode for a given agent + policy document.
+///
+/// Lookup order (first match wins):
+///
+/// 1. The agent's per-record override (set via `RegisterRequest.enforcement_mode`).
+/// 2. The policy document's `enforcement_mode` field.
+///
+/// Both inputs are `Copy` so this is a cheap pure function callable from the
+/// `CheckAction` hot path without locks or allocations.
+pub fn resolve_enforcement_mode(
+    agent_override: Option<aa_core::EnforcementMode>,
+    policy_default: aa_core::EnforcementMode,
+) -> aa_core::EnforcementMode {
+    agent_override.unwrap_or(policy_default)
+}
+
 /// Transform an [`EvaluationResult`] according to the active enforcement mode.
 ///
 /// In `Enforce` mode: returns the input unchanged with `None` shadow event.

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -2220,6 +2220,27 @@ mod tests {
     // ── enforcement-mode resolution (AAASM-1557) ─────────────────────────────
 
     #[test]
+    fn resolve_prefers_agent_override_over_policy_default() {
+        // Per-agent override is the whole point of this subtask — it must
+        // win over the policy-level default. Covers all four override values
+        // crossed with each policy default, so a regression that swaps the
+        // priority would be caught by at least one assertion.
+        for agent in [
+            aa_core::EnforcementMode::Enforce,
+            aa_core::EnforcementMode::Observe,
+            aa_core::EnforcementMode::Disabled,
+        ] {
+            for policy in [
+                aa_core::EnforcementMode::Enforce,
+                aa_core::EnforcementMode::Observe,
+                aa_core::EnforcementMode::Disabled,
+            ] {
+                assert_eq!(resolve_enforcement_mode(Some(agent), policy), agent);
+            }
+        }
+    }
+
+    #[test]
     fn resolve_falls_back_to_policy_default_when_agent_override_is_none() {
         // An agent that registered without setting enforcement_mode inherits
         // the policy document's posture. Most production agents take this path.

--- a/aa-gateway/src/registry/storage_bridge.rs
+++ b/aa-gateway/src/registry/storage_bridge.rs
@@ -119,6 +119,7 @@ pub fn storage_to_runtime(stored: StorageAgentRecord) -> RuntimeAgentRecord {
         root_agent_id: Some(*agent_id.as_bytes()),
         children: Vec::new(),
         parent_key: None,
+        enforcement_mode: None,
     }
 }
 
@@ -161,6 +162,7 @@ mod tests {
             root_agent_id: Some(agent_id),
             children: Vec::new(),
             parent_key: None,
+            enforcement_mode: None,
         }
     }
 

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -124,6 +124,13 @@ pub struct AgentRecord {
     pub children: Vec<[u8; 16]>,
     /// Registry key of the parent that spawned this agent; `None` for root agents.
     pub parent_key: Option<[u8; 16]>,
+    /// Per-agent enforcement-mode override (AAASM-1557).
+    ///
+    /// `Some(_)` means the agent registered with an explicit override that
+    /// takes precedence over the policy document's enforcement_mode field.
+    /// `None` means inherit — the resolver falls through to the policy
+    /// document and finally to `Enforce` as the server-wide default.
+    pub enforcement_mode: Option<aa_core::EnforcementMode>,
 }
 
 /// Channel sender type for pushing [`ControlCommand`]s to an agent's control stream.
@@ -883,6 +890,7 @@ mod tree_tests {
             root_agent_id: None,
             children: vec![],
             parent_key,
+            enforcement_mode: None,
         }
     }
 
@@ -1024,6 +1032,7 @@ mod lineage_tests {
             root_agent_id: None,
             children: vec![],
             parent_key,
+            enforcement_mode: None,
         }
     }
 
@@ -1163,6 +1172,7 @@ mod cascade_tests {
             root_agent_id: None,
             children: vec![],
             parent_key,
+            enforcement_mode: None,
         }
     }
 
@@ -1328,6 +1338,7 @@ mod orphan_mode_tests {
             root_agent_id: None,
             children: vec![],
             parent_key,
+            enforcement_mode: None,
         }
     }
 
@@ -1537,6 +1548,7 @@ mod cross_mode_integration {
             root_agent_id: None,
             children: vec![],
             parent_key,
+            enforcement_mode: None,
         }
     }
 
@@ -1680,6 +1692,7 @@ mod sweep_aged_agents_tests {
             root_agent_id: None,
             children: vec![],
             parent_key: None,
+            enforcement_mode: None,
         }
     }
 

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -168,6 +168,7 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
             root_agent_id,
             children: Vec::new(),
             parent_key: resolved_parent_key,
+            enforcement_mode: aa_core::EnforcementMode::from_proto_i32(req.enforcement_mode),
         };
 
         self.registry.register_persisted(record).await.map_err(|e| match e {

--- a/aa-gateway/tests/audit_integration_test.rs
+++ b/aa-gateway/tests/audit_integration_test.rs
@@ -356,6 +356,7 @@ async fn audit_service_populates_lineage_from_registry() {
             root_agent_id: Some(root_bytes),
             children: vec![],
             parent_key: None,
+            enforcement_mode: None,
         })
         .unwrap();
 

--- a/aa-gateway/tests/cascade_collect_test.rs
+++ b/aa-gateway/tests/cascade_collect_test.rs
@@ -80,6 +80,7 @@ fn register_agent(registry: &AgentRegistry, agent_id: AgentId, org_id: Option<&s
             root_agent_id: None,
             children: Vec::new(),
             parent_key: None,
+            enforcement_mode: None,
         })
         .unwrap();
 }

--- a/aa-gateway/tests/cross_team_edge_test.rs
+++ b/aa-gateway/tests/cross_team_edge_test.rs
@@ -49,6 +49,7 @@ fn make_record(n: u8, team_id: Option<&str>) -> AgentRecord {
         root_agent_id: Some([n; 16]),
         children: vec![],
         parent_key: None,
+        enforcement_mode: None,
     }
 }
 

--- a/aa-gateway/tests/lifecycle_service_test.rs
+++ b/aa-gateway/tests/lifecycle_service_test.rs
@@ -885,3 +885,47 @@ async fn root_agent_id_when_parent_unknown_returns_invalid_argument() {
         err.message()
     );
 }
+
+#[tokio::test]
+async fn register_persists_enforcement_mode_observe_override_on_agent_record() {
+    // AAASM-1557 contract: RegisterRequest.enforcement_mode = OBSERVE (proto
+    // value 2) is parsed via EnforcementMode::from_proto_i32 and stored as
+    // Some(Observe) on the AgentRecord. Resolution layer (separate test)
+    // takes care of using it; this test asserts the storage side only.
+    use aa_proto::assembly::common::v1::EnforcementMode as ProtoMode;
+
+    let (addr, registry) = start_server().await;
+    let mut client = AgentLifecycleServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let proto_id = ProtoAgentId {
+        org_id: "org-obs".into(),
+        team_id: "team-obs".into(),
+        agent_id: "experimental-agent-1".into(),
+    };
+
+    client
+        .register(RegisterRequest {
+            agent_id: Some(proto_id.clone()),
+            name: "experimental-agent".into(),
+            framework: "custom".into(),
+            version: "1.0.0".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key: test_ed25519_public_key_hex(),
+            metadata: Default::default(),
+            enforcement_mode: ProtoMode::Observe as i32,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    // Reach into the registry and confirm the override landed on the record.
+    let stored = registry
+        .list()
+        .into_iter()
+        .find(|r| r.name == "experimental-agent")
+        .expect("registered agent must be present in registry");
+    assert_eq!(stored.enforcement_mode, Some(aa_core::EnforcementMode::Observe));
+}

--- a/aa-gateway/tests/lifecycle_service_test.rs
+++ b/aa-gateway/tests/lifecycle_service_test.rs
@@ -756,6 +756,7 @@ fn aged_record_for_test(
         root_agent_id: Some(agent_key),
         children: vec![],
         parent_key: None,
+        enforcement_mode: None,
     }
 }
 

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -289,6 +289,7 @@ budget:
         root_agent_id: None,
         children: Vec::new(),
         parent_key: None,
+        enforcement_mode: None,
     };
     registry.register(record).unwrap();
 
@@ -380,6 +381,7 @@ budget:
         root_agent_id: None,
         children: Vec::new(),
         parent_key: None,
+        enforcement_mode: None,
     };
     registry.register(record).unwrap();
 
@@ -489,6 +491,7 @@ fn level_test_record(
         root_agent_id: None,
         children: Vec::new(),
         parent_key: None,
+        enforcement_mode: None,
     }
 }
 

--- a/aa-gateway/tests/registry_storage_persistence_test.rs
+++ b/aa-gateway/tests/registry_storage_persistence_test.rs
@@ -54,6 +54,7 @@ fn record(id: [u8; 16], name: &str, team_id: Option<&str>) -> AgentRecord {
         root_agent_id: Some(id),
         children: Vec::new(),
         parent_key: None,
+        enforcement_mode: None,
     }
 }
 

--- a/aa-gateway/tests/registry_test.rs
+++ b/aa-gateway/tests/registry_test.rs
@@ -39,6 +39,7 @@ fn make_record(key: [u8; 16]) -> AgentRecord {
         root_agent_id: None,
         children: Vec::new(),
         parent_key: None,
+        enforcement_mode: None,
     }
 }
 
@@ -243,6 +244,7 @@ async fn concurrent_registration_of_100_agents() {
                 root_agent_id: None,
                 children: Vec::new(),
                 parent_key: None,
+                enforcement_mode: None,
             };
             reg.register(record).unwrap();
         }));

--- a/aa-gateway/tests/topology_service_test.rs
+++ b/aa-gateway/tests/topology_service_test.rs
@@ -75,6 +75,7 @@ fn make_record(
         root_agent_id: Some(id),
         children: vec![],
         parent_key,
+        enforcement_mode: None,
     }
 }
 

--- a/aa-integration-tests/tests/api_agents.rs
+++ b/aa-integration-tests/tests/api_agents.rs
@@ -65,6 +65,7 @@ fn make_agent(id: [u8; 16]) -> AgentRecord {
         root_agent_id: None,
         children: vec![],
         parent_key: None,
+        enforcement_mode: None,
     }
 }
 

--- a/aa-integration-tests/tests/api_topology.rs
+++ b/aa-integration-tests/tests/api_topology.rs
@@ -82,6 +82,7 @@ fn make_agent(
         root_agent_id,
         children: vec![],
         parent_key,
+        enforcement_mode: None,
     }
 }
 

--- a/aa-integration-tests/tests/cli_status.rs
+++ b/aa-integration-tests/tests/cli_status.rs
@@ -212,6 +212,7 @@ async fn status_exits_1_when_agent_has_policy_violations() {
         root_agent_id: None,
         children: vec![],
         parent_key: None,
+        enforcement_mode: None,
     };
     fixture
         .env

--- a/aa-integration-tests/tests/common/cli.rs
+++ b/aa-integration-tests/tests/common/cli.rs
@@ -177,6 +177,7 @@ impl CliFixture {
             root_agent_id: None,
             children: vec![],
             parent_key: None,
+            enforcement_mode: None,
         };
 
         self.env
@@ -349,6 +350,7 @@ impl CliFixture {
             root_agent_id: Some(parent_id),
             children: vec![],
             parent_key: Some(parent_id),
+            enforcement_mode: None,
         };
         self.env
             .agent_registry

--- a/aa-integration-tests/tests/common/scenario.rs
+++ b/aa-integration-tests/tests/common/scenario.rs
@@ -104,5 +104,6 @@ fn make_record(
         root_agent_id,
         children: vec![],
         parent_key,
+        enforcement_mode: None,
     }
 }

--- a/aa-integration-tests/tests/e2e_topology.rs
+++ b/aa-integration-tests/tests/e2e_topology.rs
@@ -101,6 +101,7 @@ fn make_record(
         root_agent_id,
         children: vec![],
         parent_key,
+        enforcement_mode: None,
     }
 }
 


### PR DESCRIPTION
## Description

Subtask 4 of Story AAASM-1553. Lands the per-agent enforcement_mode override and the resolver that picks the effective mode at evaluation time.

### Changes

- `AgentRecord.enforcement_mode: Option<EnforcementMode>` — new field on the in-memory agent registry record. `None` = inherit from policy; `Some(_)` = explicit per-agent override.
- `lifecycle_service.rs::register` — reads `RegisterRequest.enforcement_mode` (proto `EnforcementMode`) via `from_proto_i32()` and stores it on the record. Proto `UNSPECIFIED` (zero) maps to `None`, preserving backward-compat for clients that don't set the field.
- `resolve_enforcement_mode(agent_override, policy_default) -> EnforcementMode` — free function in `aa-gateway::engine`. Lookup order: agent override → policy document → server-wide `Enforce`.

### Bisectability

Every existing `AgentRecord` struct literal across the workspace (registry tests, integration tests, gateway src test modules, integration-test scenario helpers) is updated in the same commit as the field addition with `enforcement_mode: None`. Workspace stays buildable at every commit.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

`RegisterRequest.enforcement_mode` was added as proto field 13 in AAASM-1555 with proto-zero default. Existing clients serialise that field as zero, which `EnforcementMode::from_proto_i32(0)` maps to `None`. Both the storage and the resolver fall back to the policy default in that case — identical to the pre-feature behaviour.

## Related Issues

- Related Jira ticket: [AAASM-1557](https://lightning-dust-mite.atlassian.net/browse/AAASM-1557)
- Stacks on [#712](https://github.com/AI-agent-assembly/agent-assembly/pull/712), [#718](https://github.com/AI-agent-assembly/agent-assembly/pull/718), [#724](https://github.com/AI-agent-assembly/agent-assembly/pull/724)

## What's in here

6 new commits on this PR:

1. ✨ Add `enforcement_mode` field to `AgentRecord` + wire from RegisterRequest (workspace bisectable: updates 16 `AgentRecord` struct literals)
2. ✨ Add `resolve_enforcement_mode` helper
3. ✅ Resolve falls back to policy default when agent override is None
4. ✅ Resolve prefers agent override over policy default (full 3×3 matrix)
5. ✅ Two agents under the same policy resolve independently
6. ✅ E2E: RegisterRequest enforcement_mode persists on AgentRecord

## Testing

```
cargo nextest run -p aa-gateway --all-features    # passes including new tests
cargo build --workspace --all-targets --all-features  # clean (excl. aa-ffi-python pyo3 link, pre-existing)
cargo clippy --workspace --all-targets --all-features -- -D warnings  # clean
```

## Out of scope for this PR

The service-layer wiring of `resolve_enforcement_mode` + `transform_for_observe_mode` + audit emission inside the `CheckAction` RPC handler is deferred to AAASM-1564 (verification integration test) so the full observe-mode flow can be tested as one piece end-to-end. The building blocks (resolver, transform, ShadowEvent, proto fields, record field) are all in place after this PR.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on new field + resolver)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1557]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ