### PR TITLE
[AAASM-1852] ✨ (aa-gateway/storage): Add TimescaleStats type + extension probe helper

### DIFF
--- a/aa-gateway/src/storage/mod.rs
+++ b/aa-gateway/src/storage/mod.rs
@@ -38,6 +38,7 @@ pub mod retention;
 pub mod retention_config;
 pub mod retention_engine;
 pub mod sqlite;
+pub mod timescale;
 
 pub use agent::{AgentFilter, AgentRecord, TeamId};
 pub use audit::{AuditEvent, AuditFilter};
@@ -54,3 +55,4 @@ pub use retention::{ColdAction, RetentionPolicy, RetentionStats};
 pub use retention_config::{RetentionConfig, RetentionConfigError};
 pub use retention_engine::RetentionEngine;
 pub use sqlite::{SqliteBackend, SqliteConfig};
+pub use timescale::TimescaleStats;

--- a/aa-gateway/src/storage/timescale.rs
+++ b/aa-gateway/src/storage/timescale.rs
@@ -16,6 +16,32 @@
 //! the two concerns independently versioned.
 
 use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+
+use super::error::{StorageError, StorageResult};
+
+/// Returns `true` when the TimescaleDB extension is installed on the
+/// PostgreSQL cluster behind `pool`, `false` otherwise.
+///
+/// The check is a single round-trip against `pg_extension` and is safe
+/// to call on any PostgreSQL cluster — vanilla PG returns `false`,
+/// TimescaleDB-enabled PG returns `true`. Callers in
+/// `PostgresBackend::apply_timescaledb_setup` (S-D #3) and
+/// `PostgresBackend::healthcheck` (S-D #4) use this to branch between
+/// the plain-table and hypertable code paths.
+///
+/// # Errors
+///
+/// Returns [`StorageError::QueryFailed`] when the query against
+/// `pg_extension` cannot execute (transport failure, permission denied,
+/// etc.). Treat the failure as "extension status unknown" — the caller
+/// typically downgrades to the no-TimescaleDB code path.
+pub async fn has_timescaledb_extension(pool: &PgPool) -> StorageResult<bool> {
+    sqlx::query_scalar::<_, bool>("SELECT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'timescaledb')")
+        .fetch_one(pool)
+        .await
+        .map_err(|e| StorageError::QueryFailed(format!("pg_extension probe: {e}")))
+}
 
 /// Snapshot of TimescaleDB chunk and compression state for the gateway's
 /// hypertables (`audit_events` + `metrics`), surfaced through

--- a/aa-gateway/src/storage/timescale.rs
+++ b/aa-gateway/src/storage/timescale.rs
@@ -68,3 +68,56 @@ pub struct TimescaleStats {
     /// no chunks exist yet.
     pub oldest_chunk_age_days: u32,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::postgres::PgPoolOptions;
+
+    /// Build a pool against `AAASM_DATABASE_URL`, or return `None` after
+    /// printing a skip notice. Mirrors `postgres::tests::pg_backend_or_skip`
+    /// but works directly with a `PgPool` since the probe helper does not
+    /// need a full `PostgresBackend`.
+    async fn pool_or_skip() -> Option<PgPool> {
+        let url = match std::env::var("AAASM_DATABASE_URL") {
+            Ok(v) => v,
+            Err(_) => {
+                eprintln!(
+                    "skipping postgres test: AAASM_DATABASE_URL not set (CI provides this via services: postgres)"
+                );
+                return None;
+            }
+        };
+        Some(
+            PgPoolOptions::new()
+                .max_connections(2)
+                .connect(&url)
+                .await
+                .expect("connect to AAASM_DATABASE_URL"),
+        )
+    }
+
+    /// `has_timescaledb_extension` must return `false` against a plain
+    /// PostgreSQL cluster — `pg_extension` has no `timescaledb` row.
+    /// Exercises the false branch via the existing `Test` CI job
+    /// (postgres:18-alpine service).
+    #[tokio::test]
+    async fn probe_returns_false_on_plain_postgres() {
+        if std::env::var("TIMESCALEDB_AVAILABLE").as_deref() == Ok("1") {
+            eprintln!(
+                "skipping plain-postgres probe test: TIMESCALEDB_AVAILABLE=1 (see probe_returns_true_on_timescaledb)"
+            );
+            return;
+        }
+        let Some(pool) = pool_or_skip().await else {
+            return;
+        };
+        let present = has_timescaledb_extension(&pool)
+            .await
+            .expect("probe must succeed on plain PostgreSQL");
+        assert!(
+            !present,
+            "expected probe to report false on plain PostgreSQL; if your CI installed TimescaleDB, set TIMESCALEDB_AVAILABLE=1"
+        );
+    }
+}

--- a/aa-gateway/src/storage/timescale.rs
+++ b/aa-gateway/src/storage/timescale.rs
@@ -1,0 +1,44 @@
+//! TimescaleDB observability and capability detection for the gateway's
+//! PostgreSQL backend.
+//!
+//! The TimescaleDB extension is **optional**: the gateway runs against
+//! vanilla PostgreSQL as well. This module owns the small surface that
+//! lets the rest of the storage layer answer two questions at runtime:
+//!
+//! 1. "Is the TimescaleDB extension installed on the connected cluster?"
+//!    → [`has_timescaledb_extension`] (Epic 18 S-D #3 — `PostgresBackend::apply_timescaledb_setup`)
+//! 2. "If yes, what's the current hypertable + compression state?"
+//!    → [`TimescaleStats`] returned from `healthcheck()` (Epic 18 S-D #4)
+//!
+//! The module **deliberately does not** create or drop hypertables — that
+//! DDL lives in the `0002_timescaledb_hypertables.sql` migration (S-D #1).
+//! Keeping schema mutation in migrations and observability in Rust keeps
+//! the two concerns independently versioned.
+
+use serde::{Deserialize, Serialize};
+
+/// Snapshot of TimescaleDB chunk and compression state for the gateway's
+/// hypertables (`audit_events` + `metrics`), surfaced through
+/// [`StorageHealth::timescale`](super::health::StorageHealth) when the
+/// extension is active. `None` on plain PostgreSQL.
+///
+/// All fields are aggregated across both hypertables; per-table breakdown
+/// is intentionally out of scope for v1 — the dashboard's storage panel
+/// only needs the rollup.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct TimescaleStats {
+    /// Total number of chunks across the gateway's hypertables.
+    pub total_chunks: u32,
+    /// Subset of `total_chunks` that have been compressed by the
+    /// auto-compression policy.
+    pub compressed_chunks: u32,
+    /// Aggregate `uncompressed_bytes / compressed_bytes` ratio expressed
+    /// in tenths of a unit (e.g. `124` = 12.4× size reduction).
+    ///
+    /// Stored as an integer to keep the type `Eq + Hash`; readers
+    /// reconstruct the float with `compression_ratio_tenths as f32 / 10.0`.
+    pub compression_ratio_tenths: u32,
+    /// Age in days of the oldest chunk across both hypertables. `0` when
+    /// no chunks exist yet.
+    pub oldest_chunk_age_days: u32,
+}

--- a/aa-gateway/src/storage/timescale.rs
+++ b/aa-gateway/src/storage/timescale.rs
@@ -120,4 +120,29 @@ mod tests {
             "expected probe to report false on plain PostgreSQL; if your CI installed TimescaleDB, set TIMESCALEDB_AVAILABLE=1"
         );
     }
+
+    /// `has_timescaledb_extension` must return `true` against a
+    /// TimescaleDB-enabled cluster. Env-gated on `TIMESCALEDB_AVAILABLE=1`;
+    /// the CI `timescaledb-tests` job (AAASM-1858 / SD-5) wires this
+    /// against the `timescale/timescaledb:latest-pg17` service container.
+    #[tokio::test]
+    async fn probe_returns_true_on_timescaledb() {
+        if std::env::var("TIMESCALEDB_AVAILABLE").as_deref() != Ok("1") {
+            eprintln!(
+                "skipping timescaledb probe test: TIMESCALEDB_AVAILABLE != 1 (set it to 1 when AAASM_DATABASE_URL points at a TimescaleDB-enabled instance)"
+            );
+            return;
+        }
+        let Some(pool) = pool_or_skip().await else {
+            return;
+        };
+        let present = has_timescaledb_extension(&pool)
+            .await
+            .expect("probe must succeed on a TimescaleDB-enabled PostgreSQL");
+        assert!(
+            present,
+            "TIMESCALEDB_AVAILABLE=1 was set but the extension is not installed; \
+             check the docker image is timescale/timescaledb:latest-pg17"
+        );
+    }
 }


### PR DESCRIPTION
## Description

Introduces `aa-gateway/src/storage/timescale.rs` — the new module that owns TimescaleDB observability and capability detection for the PostgreSQL backend. Ships two pieces:

1. **`TimescaleStats`** — value type snapshotting hypertable chunk count, compressed chunk count, aggregate compression ratio (in tenths so the type stays `Eq + Hash`), and oldest chunk age. Re-exported from `storage::mod`. Designed for `StorageHealth.timescale: Option<TimescaleStats>` (SD-4 wires it).
2. **`has_timescaledb_extension(pool: &PgPool) -> StorageResult<bool>`** — single-round-trip async probe of `pg_extension`. Used by SD-3 (`apply_timescaledb_setup`) and SD-4 (`healthcheck`) to branch between plain-PG and TimescaleDB code paths.

This is **SD-2** of the AAASM-1586 (E18 S-D) sub-task series. Builds on SD-1 (PR #711, merged).

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-1852](https://lightning-dust-mite.atlassian.net/browse/AAASM-1852) (parent Story: [AAASM-1586](https://lightning-dust-mite.atlassian.net/browse/AAASM-1586), Epic: [AAASM-1569](https://lightning-dust-mite.atlassian.net/browse/AAASM-1569))

## Testing

- [x] Unit tests added — two tests in `timescale.rs::tests`:
  - `probe_returns_false_on_plain_postgres` — runs in the `Test` CI job (postgres:18-alpine service); asserts the probe reports `false`. Skips when `TIMESCALEDB_AVAILABLE=1`.
  - `probe_returns_true_on_timescaledb` — env-gated on `TIMESCALEDB_AVAILABLE=1`; auto-runs once SD-5 (AAASM-1858) ships the `timescaledb-tests` CI job.
- [x] Local `cargo nextest run -p aa-gateway storage::timescale` is 2/2 PASS (skip-path; tests early-return without `AAASM_DATABASE_URL` set locally).
- [x] Local `cargo check -p aa-gateway --tests` clean; lefthook fmt + clippy + rustdoc all green per pre-commit.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed — module-level docstring explains the two-question scope; both items have doc-comments with `# Errors` blocks
- [ ] All CI checks passing — will validate on push
- [x] Commits are small and follow the Gitmoji convention (4 commits, one per logical unit)

## Commit log

1. `✨ (aa-gateway/storage): Add TimescaleStats struct in timescale module`
2. `✨ (aa-gateway/storage): Add has_timescaledb_extension probe helper`
3. `✅ (aa-gateway/storage): Test extension probe on plain postgres`
4. `✅ (aa-gateway/storage): Test extension probe on timescaledb container`

## Depends on

SD-1 (AAASM-1848) — merged in PR #711. No code dependency, but the `0002_timescaledb_hypertables.sql` migration is what causes the extension to be loaded on the TimescaleDB image used by SD-5's CI job.

[AAASM-1852]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1586]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ