### PR TITLE
[AAASM-1864] ✨ (registry): Write-through AgentRegistry with rehydrate-on-boot

### DIFF
--- a/aa-gateway/src/main.rs
+++ b/aa-gateway/src/main.rs
@@ -111,6 +111,13 @@ async fn run_local() -> Result<(), Box<dyn std::error::Error>> {
 
 /// Existing gRPC + policy serving path. Preserves the pre-Epic-17
 /// invocation contract `aasm-gateway --policy /path [--listen ...]`.
+///
+/// Epic 18 Story S-I.2 (AAASM-1864): the AgentRegistry is now backed by
+/// the durable SQLite [`StorageBackend`](aa_gateway::storage::StorageBackend)
+/// at `GatewayConfig.local.storage_path` (default `~/.aasm/local.db`).
+/// On boot, every previously-registered agent is replayed via
+/// `AgentRegistry::rehydrate_from_storage`; subsequent gRPC Register /
+/// Deregister calls write through to the same backend.
 async fn run_legacy_grpc(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     let policy = cli
         .policy
@@ -120,7 +127,19 @@ async fn run_legacy_grpc(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
     tracing::info!(policy = %policy.display(), "loading policy");
 
-    let registry = Arc::new(aa_gateway::AgentRegistry::new());
+    // Open the durable SQLite-backed StorageBackend, applying migrations
+    // before the gRPC service comes up. Falls back to the file path from
+    // GatewayConfig (defaults to `~/.aasm/local.db` when no config file
+    // is present) so legacy callers get persistence without changing
+    // their CLI invocation.
+    let cfg = aa_core::config::GatewayConfig::load()?;
+    let storage = aa_gateway::storage::open_sqlite_backend(&cfg.local.storage_path).await?;
+
+    let registry = Arc::new(aa_gateway::AgentRegistry::new().with_storage(storage.clone()));
+    let restored = registry.rehydrate_from_storage().await?;
+    if restored > 0 {
+        tracing::info!(restored, "rehydrated agents from durable storage");
+    }
 
     // Create the approval queue — gateway-owned, shared with the runtime via gRPC.
     let approval_queue = aa_runtime::approval::ApprovalQueue::new();

--- a/aa-gateway/src/registry/mod.rs
+++ b/aa-gateway/src/registry/mod.rs
@@ -27,6 +27,11 @@ pub enum RegistryError {
     /// A lineage validation check failed during registration.
     #[error("lineage validation failed: {0}")]
     Lineage(#[from] LineageError),
+    /// The durable [`StorageBackend`](crate::storage::StorageBackend) call
+    /// underlying `register_persisted` / `deregister_persisted` /
+    /// `rehydrate_from_storage` (Epic 18 Story S-I.2) returned an error.
+    #[error("storage backend error: {0}")]
+    Storage(#[from] crate::storage::StorageError),
 }
 
 /// Error returned when agent lineage validation fails during registration.

--- a/aa-gateway/src/registry/mod.rs
+++ b/aa-gateway/src/registry/mod.rs
@@ -7,6 +7,7 @@
 pub mod convert;
 pub mod lineage;
 pub mod orphan;
+pub mod storage_bridge;
 pub mod store;
 pub mod token;
 

--- a/aa-gateway/src/registry/storage_bridge.rs
+++ b/aa-gateway/src/registry/storage_bridge.rs
@@ -1,0 +1,199 @@
+//! Conversion between the runtime [`AgentRecord`](super::store::AgentRecord)
+//! and the durable [`storage::AgentRecord`](crate::storage::AgentRecord).
+//!
+//! The two records are intentionally different shapes (see
+//! `aa-gateway/src/storage/agent.rs` for the rationale): the registry layer
+//! owns liveness, heartbeats, and credential tokens; the storage layer
+//! persists only the durable identity / configuration fields. This module
+//! is the only place that knows how to translate between the two.
+//!
+//! Conversion runtime → storage is lossy by design: runtime-only fields
+//! (`recent_events`, `active_sessions`, `credential_token`, lineage links,
+//! …) are dropped because they are either ephemeral, security-sensitive,
+//! or reconstructible at the next agent connect. On rehydrate the inverse
+//! direction synthesises defaults for the missing runtime fields so the
+//! agent reappears in the registry as a root-level entry with status
+//! [`AgentStatus::Active`].
+//!
+//! Introduced by Epic 18 Story S-I.2 (AAASM-1864) — the registry
+//! write-through wiring that makes agent registrations durable across
+//! gateway restarts.
+
+use std::collections::VecDeque;
+
+use aa_core::identity::AgentId;
+use aa_core::GovernanceLevel;
+
+use crate::registry::AgentStatus;
+use crate::storage::AgentRecord as StorageAgentRecord;
+
+use super::store::AgentRecord as RuntimeAgentRecord;
+
+/// Metadata key used to round-trip the runtime `enforcement_mode`-equivalent
+/// flag through `storage::AgentRecord::enforcement_mode`. The runtime record
+/// has no first-class field for this today, so the storage column defaults to
+/// `"enforce"` on conversion; later Sub-tasks of Epic 18 may surface it
+/// directly on the runtime record.
+const DEFAULT_ENFORCEMENT_MODE: &str = "enforce";
+
+/// Metadata key used to carry the agent's friendly name through storage so
+/// the runtime field can be restored on rehydrate. The runtime record's
+/// `name` field has no direct column in `agent_registry`; piggy-backing on
+/// `metadata["name"]` keeps the storage schema flat.
+const METADATA_KEY_NAME: &str = "name";
+
+/// Convert a runtime [`AgentRecord`] into its durable storage equivalent.
+///
+/// Lossy — runtime-only fields are dropped. `name` is round-tripped through
+/// `metadata["name"]` so rehydrate can restore it.
+pub fn runtime_to_storage(record: &RuntimeAgentRecord) -> StorageAgentRecord {
+    let mut metadata = record.metadata.clone();
+    metadata.insert(METADATA_KEY_NAME.to_string(), record.name.clone());
+    StorageAgentRecord {
+        agent_id: AgentId::from_bytes(record.agent_id),
+        team_id: record.team_id.clone(),
+        // The runtime record has no org_id field today; storage carries
+        // None until later Sub-tasks add an explicit field or the value
+        // gets piggy-backed through metadata.
+        org_id: None,
+        metadata,
+        registered_at: record.registered_at,
+        last_seen_at: record.last_heartbeat,
+        enforcement_mode: DEFAULT_ENFORCEMENT_MODE.to_string(),
+    }
+}
+
+/// Synthesise a runtime [`AgentRecord`] from its storage row.
+///
+/// Used at boot-time rehydrate (see
+/// `AgentRegistry::rehydrate_from_storage`). Fills the runtime-only fields
+/// with defaults — restored agents reappear as root-level entries with
+/// [`AgentStatus::Active`]; their credential tokens, lineage links, and
+/// recent-event buffers do not survive a restart and are reconstructed at
+/// the next agent connect.
+pub fn storage_to_runtime(stored: StorageAgentRecord) -> RuntimeAgentRecord {
+    let StorageAgentRecord {
+        agent_id,
+        team_id,
+        org_id: _,
+        mut metadata,
+        registered_at,
+        last_seen_at,
+        enforcement_mode: _,
+    } = stored;
+
+    let name = metadata.remove(METADATA_KEY_NAME).unwrap_or_default();
+
+    RuntimeAgentRecord {
+        agent_id: *agent_id.as_bytes(),
+        name,
+        // Framework / version / public_key are not persisted today — left
+        // empty so rehydrated entries are flagged for the next connect to
+        // refresh.
+        framework: String::new(),
+        version: String::new(),
+        risk_tier: 0,
+        tool_names: Vec::new(),
+        public_key: String::new(),
+        credential_token: String::new(),
+        metadata,
+        registered_at,
+        last_heartbeat: last_seen_at,
+        status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
+        policy_violations_count: 0,
+        active_sessions: Vec::new(),
+        recent_events: VecDeque::new(),
+        recent_traces: Vec::new(),
+        layer: None,
+        governance_level: GovernanceLevel::L0Discover,
+        parent_agent_id: None,
+        team_id,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        // Restored agents reappear as roots — lineage is not persisted in
+        // this Sub-task's storage schema.
+        root_agent_id: Some(*agent_id.as_bytes()),
+        children: Vec::new(),
+        parent_key: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::collections::BTreeMap;
+
+    fn sample_runtime(agent_id: [u8; 16]) -> RuntimeAgentRecord {
+        let mut metadata = BTreeMap::new();
+        metadata.insert("env".to_string(), "staging".to_string());
+        RuntimeAgentRecord {
+            agent_id,
+            name: "demo-agent".to_string(),
+            framework: "langgraph".to_string(),
+            version: "0.1.0".to_string(),
+            risk_tier: 2,
+            tool_names: vec!["search".to_string()],
+            public_key: "pk".to_string(),
+            credential_token: "token".to_string(),
+            metadata,
+            registered_at: Utc::now(),
+            last_heartbeat: Utc::now(),
+            status: AgentStatus::Active,
+            pid: Some(1234),
+            session_count: 0,
+            last_event: None,
+            policy_violations_count: 0,
+            active_sessions: Vec::new(),
+            recent_events: VecDeque::new(),
+            recent_traces: Vec::new(),
+            layer: Some("enforced".to_string()),
+            governance_level: GovernanceLevel::L1Observe,
+            parent_agent_id: None,
+            team_id: Some("teamA".to_string()),
+            depth: 0,
+            delegation_reason: None,
+            spawned_by_tool: None,
+            root_agent_id: Some(agent_id),
+            children: Vec::new(),
+            parent_key: None,
+        }
+    }
+
+    #[test]
+    fn runtime_to_storage_preserves_durable_fields() {
+        let id = [9u8; 16];
+        let rec = sample_runtime(id);
+        let stored = runtime_to_storage(&rec);
+        assert_eq!(stored.agent_id, AgentId::from_bytes(id));
+        assert_eq!(stored.team_id.as_deref(), Some("teamA"));
+        assert_eq!(stored.metadata.get("env").map(String::as_str), Some("staging"));
+        // `name` is round-tripped via metadata so rehydrate can restore it.
+        assert_eq!(
+            stored.metadata.get(METADATA_KEY_NAME).map(String::as_str),
+            Some("demo-agent")
+        );
+        assert_eq!(stored.enforcement_mode, DEFAULT_ENFORCEMENT_MODE);
+    }
+
+    #[test]
+    fn storage_to_runtime_restores_name_and_team() {
+        let id = [7u8; 16];
+        let rec = sample_runtime(id);
+        let stored = runtime_to_storage(&rec);
+        let restored = storage_to_runtime(stored);
+        assert_eq!(restored.agent_id, id);
+        assert_eq!(restored.name, "demo-agent");
+        assert_eq!(restored.team_id.as_deref(), Some("teamA"));
+        // Rehydrate strips the synthetic `name` key from metadata.
+        assert!(!restored.metadata.contains_key(METADATA_KEY_NAME));
+        // Restored entries are roots with status Active.
+        assert!(matches!(restored.status, AgentStatus::Active));
+        assert_eq!(restored.parent_key, None);
+        assert_eq!(restored.root_agent_id, Some(id));
+    }
+}

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -1,7 +1,7 @@
 //! Agent registry store — `AgentRecord` and `AgentRegistry` backed by `DashMap`.
 
 use std::collections::{BTreeMap, VecDeque};
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use aa_core::GovernanceLevel;
 use chrono::{DateTime, Utc};
@@ -14,6 +14,7 @@ use aa_proto::assembly::agent::v1::{ControlCommand, SuspendCommand};
 
 use super::orphan::{OrphanEffect, OrphanMode};
 use super::{AgentStatus, LineageError, RegistryError, SuspendReason};
+use crate::storage::StorageBackend;
 
 /// Maximum number of recent events retained per agent.
 pub const MAX_RECENT_EVENTS: usize = 20;
@@ -150,6 +151,12 @@ pub struct AgentRegistry {
     /// Per-team maximum agent age in seconds. Agents older than this threshold
     /// are force-deregistered by `sweep_aged_agents`.
     team_max_age_secs: DashMap<String, u64>,
+    /// Optional durable [`StorageBackend`] for write-through persistence and
+    /// boot-time rehydrate. `None` means the registry is purely in-memory —
+    /// the legacy behaviour preserved for existing tests and any caller that
+    /// constructs an [`AgentRegistry::new`] without storage. Wired in by
+    /// Epic 18 Story S-I.2 (AAASM-1864).
+    storage: Option<Arc<dyn StorageBackend>>,
 }
 
 impl AgentRegistry {
@@ -162,7 +169,23 @@ impl AgentRegistry {
             registration_lock: Mutex::new(()),
             suspend_reasons: DashMap::new(),
             team_max_age_secs: DashMap::new(),
+            storage: None,
         }
+    }
+
+    /// Attach a durable [`StorageBackend`] for write-through persistence and
+    /// boot-time rehydrate. Builder-style — chains after `new()`:
+    ///
+    /// ```ignore
+    /// let registry = AgentRegistry::new().with_storage(storage_handle);
+    /// ```
+    ///
+    /// Without this call, the registry stays purely in-memory and the
+    /// `register_persisted` / `deregister_persisted` / `rehydrate_from_storage`
+    /// methods behave identically to their non-persisted counterparts.
+    pub fn with_storage(mut self, storage: Arc<dyn StorageBackend>) -> Self {
+        self.storage = Some(storage);
+        self
     }
 
     /// Configure the maximum allowed age (in seconds) for agents belonging to `team_id`.

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -341,6 +341,50 @@ impl AgentRegistry {
         Ok((record, effects))
     }
 
+    /// Replay durable storage rows back into the in-memory registry.
+    ///
+    /// Called once at gateway boot, after
+    /// [`StorageBackend::migrate`](crate::storage::StorageBackend::migrate)
+    /// runs and before any request is served. Reads every row from
+    /// `storage.list_agents(AgentFilter::default())`, converts each through
+    /// [`storage_bridge::storage_to_runtime`](super::storage_bridge::storage_to_runtime),
+    /// and calls the sync [`register`](Self::register) — restored entries
+    /// reappear as root-level agents with status
+    /// [`Active`](crate::registry::AgentStatus::Active); lineage is not
+    /// persisted in this Sub-task and the next agent connect is expected
+    /// to refresh credential tokens / parent links.
+    ///
+    /// Returns the number of agents rehydrated. A no-storage registry
+    /// returns `Ok(0)` immediately.
+    ///
+    /// Already-registered IDs (e.g. an agent that re-connected before
+    /// rehydrate finished) are logged at `tracing::warn!` and skipped —
+    /// the freshest in-memory record wins.
+    ///
+    /// Introduced by Epic 18 Story S-I.2 (AAASM-1864).
+    pub async fn rehydrate_from_storage(&self) -> Result<usize, RegistryError> {
+        let Some(storage) = self.storage.as_ref() else {
+            return Ok(0);
+        };
+        let rows = storage.list_agents(crate::storage::AgentFilter::default()).await?;
+        let mut restored = 0usize;
+        for row in rows {
+            let runtime = super::storage_bridge::storage_to_runtime(row);
+            let agent_id = runtime.agent_id;
+            match self.register(runtime) {
+                Ok(()) => restored += 1,
+                Err(RegistryError::AlreadyRegistered(_)) => {
+                    tracing::warn!(
+                        ?agent_id,
+                        "rehydrate_from_storage: agent already registered in-memory, skipping"
+                    );
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        Ok(restored)
+    }
+
     /// Deregister an agent **and** delete the durable storage row.
     ///
     /// Async wrapper around [`deregister`](Self::deregister) that, on a

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -341,6 +341,36 @@ impl AgentRegistry {
         Ok((record, effects))
     }
 
+    /// Deregister an agent **and** delete the durable storage row.
+    ///
+    /// Async wrapper around [`deregister`](Self::deregister) that, on a
+    /// successful in-memory removal, also calls
+    /// [`StorageBackend::delete_agent`](crate::storage::StorageBackend::delete_agent).
+    /// A storage [`NotFound`](crate::storage::StorageError::NotFound) result
+    /// is treated as success — the in-memory removal already happened and
+    /// best-effort cleanup is enough; any other backend error surfaces as
+    /// [`RegistryError::Storage`].
+    ///
+    /// When no storage handle is attached, behaves identically to
+    /// [`deregister`](Self::deregister).
+    ///
+    /// Introduced by Epic 18 Story S-I.2 (AAASM-1864).
+    pub async fn deregister_persisted(
+        &self,
+        agent_id: &[u8; 16],
+        mode: OrphanMode,
+    ) -> Result<(AgentRecord, Vec<OrphanEffect>), RegistryError> {
+        let (record, effects) = self.deregister(agent_id, mode)?;
+        if let Some(storage) = self.storage.as_ref() {
+            let id = aa_core::identity::AgentId::from_bytes(*agent_id);
+            match storage.delete_agent(&id).await {
+                Ok(()) | Err(crate::storage::StorageError::NotFound(_)) => {}
+                Err(err) => return Err(RegistryError::Storage(err)),
+            }
+        }
+        Ok((record, effects))
+    }
+
     /// Recursively apply `mode` to `child_key` and all its descendants.
     ///
     /// DashMap does not allow recursive locking — child keys are always collected

--- a/aa-gateway/src/registry/store.rs
+++ b/aa-gateway/src/registry/store.rs
@@ -268,6 +268,36 @@ impl AgentRegistry {
         Ok(())
     }
 
+    /// Register an agent **and** write through to durable storage.
+    ///
+    /// Async wrapper around [`register`](Self::register) that, on a
+    /// successful in-memory insert, also calls
+    /// [`StorageBackend::upsert_agent`](crate::storage::StorageBackend::upsert_agent).
+    /// If the storage write fails, the in-memory insert is rolled back so
+    /// the registry never diverges from the durable state.
+    ///
+    /// When no storage handle is attached (e.g. `AgentRegistry::new()`
+    /// without `with_storage`), behaves identically to
+    /// [`register`](Self::register).
+    ///
+    /// Introduced by Epic 18 Story S-I.2 (AAASM-1864).
+    pub async fn register_persisted(&self, record: AgentRecord) -> Result<(), RegistryError> {
+        let agent_id = record.agent_id;
+        let storage_record = self
+            .storage
+            .as_ref()
+            .map(|_| super::storage_bridge::runtime_to_storage(&record));
+        self.register(record)?;
+        if let (Some(storage), Some(durable)) = (self.storage.as_ref(), storage_record) {
+            if let Err(err) = storage.upsert_agent(durable).await {
+                // Roll back the in-memory insert so the two views stay in sync.
+                let _ = self.deregister(&agent_id, OrphanMode::Suspend);
+                return Err(RegistryError::Storage(err));
+            }
+        }
+        Ok(())
+    }
+
     /// Look up an agent by ID. Returns `None` if not found.
     pub fn get(&self, agent_id: &[u8; 16]) -> Option<AgentRecord> {
         self.agents.get(agent_id).map(|r| r.clone())

--- a/aa-gateway/src/service/lifecycle_service.rs
+++ b/aa-gateway/src/service/lifecycle_service.rs
@@ -170,7 +170,7 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
             parent_key: resolved_parent_key,
         };
 
-        self.registry.register(record).map_err(|e| match e {
+        self.registry.register_persisted(record).await.map_err(|e| match e {
             RegistryError::AlreadyRegistered(_) => Status::already_exists(e.to_string()),
             RegistryError::Lineage(LineageError::CircularDelegation { .. })
             | RegistryError::Lineage(LineageError::MaxDepthExceeded { .. }) => Status::invalid_argument(e.to_string()),
@@ -278,7 +278,8 @@ impl AgentLifecycleService for AgentLifecycleServiceImpl {
 
         let (_, effects) = self
             .registry
-            .deregister(&agent_key, OrphanMode::Suspend)
+            .deregister_persisted(&agent_key, OrphanMode::Suspend)
+            .await
             .map_err(|e| Status::not_found(e.to_string()))?;
 
         for effect in &effects {

--- a/aa-gateway/tests/registry_storage_persistence_test.rs
+++ b/aa-gateway/tests/registry_storage_persistence_test.rs
@@ -1,0 +1,145 @@
+//! End-to-end durability test for the `AgentRegistry` write-through path.
+//!
+//! Epic 18 Story S-I.2 (AAASM-1864) acceptance criterion:
+//!
+//! > Restart test: register N agents → drop registry → reopen SqliteBackend
+//! > → rehydrate → all agents present with original team_id, registered_at, name.
+//!
+//! Exercises `AgentRegistry::with_storage` + `register_persisted` +
+//! `rehydrate_from_storage` against a real on-disk SQLite file (not
+//! `:memory:`) so the test fails if a future change accidentally turns
+//! the storage write into a no-op or persists to a transient location.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::sync::Arc;
+
+use chrono::Utc;
+use tempfile::tempdir;
+
+use aa_core::GovernanceLevel;
+use aa_gateway::registry::store::{AgentRecord, AgentRegistry};
+use aa_gateway::registry::{AgentStatus, OrphanMode};
+use aa_gateway::storage::{open_sqlite_backend, StorageBackend};
+
+/// Build a minimal `AgentRecord` for testing — enough fields to register
+/// successfully without exercising lineage validation.
+fn record(id: [u8; 16], name: &str, team_id: Option<&str>) -> AgentRecord {
+    AgentRecord {
+        agent_id: id,
+        name: name.to_string(),
+        framework: "test".to_string(),
+        version: "0.0.0".to_string(),
+        risk_tier: 0,
+        tool_names: Vec::new(),
+        public_key: String::new(),
+        credential_token: String::new(),
+        metadata: BTreeMap::new(),
+        registered_at: Utc::now(),
+        last_heartbeat: Utc::now(),
+        status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
+        policy_violations_count: 0,
+        active_sessions: Vec::new(),
+        recent_events: VecDeque::new(),
+        recent_traces: Vec::new(),
+        layer: None,
+        governance_level: GovernanceLevel::L0Discover,
+        parent_agent_id: None,
+        team_id: team_id.map(str::to_string),
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: Some(id),
+        children: Vec::new(),
+        parent_key: None,
+    }
+}
+
+/// AC bullet: registered agents survive a registry restart.
+///
+/// Pattern: open a tempdir SQLite file, register three agents via the
+/// persisted path, drop the registry and backend, reopen the same file,
+/// rehydrate, and assert all three are back with the original
+/// `agent_id`, `name`, and `team_id`.
+#[tokio::test]
+async fn agents_registered_persisted_survive_registry_restart() {
+    let tmp = tempdir().expect("tempdir");
+    let db_path = tmp.path().join("registry-persistence.db");
+
+    // ── Session 1: open storage, build registry, register 3 agents.
+    let storage_1: Arc<dyn StorageBackend> = open_sqlite_backend(&db_path).await.expect("open backend");
+    let registry_1 = AgentRegistry::new().with_storage(storage_1.clone());
+    registry_1
+        .register_persisted(record([1u8; 16], "alpha", Some("teamA")))
+        .await
+        .expect("register alpha");
+    registry_1
+        .register_persisted(record([2u8; 16], "beta", Some("teamB")))
+        .await
+        .expect("register beta");
+    registry_1
+        .register_persisted(record([3u8; 16], "gamma", None))
+        .await
+        .expect("register gamma");
+
+    // Drop registry + storage handles to simulate a gateway shutdown.
+    drop(registry_1);
+    drop(storage_1);
+
+    // ── Session 2: open the same SQLite file, build a fresh registry,
+    // rehydrate, assert the three agents reappear.
+    let storage_2: Arc<dyn StorageBackend> = open_sqlite_backend(&db_path).await.expect("reopen backend");
+    let registry_2 = AgentRegistry::new().with_storage(storage_2);
+    let restored = registry_2.rehydrate_from_storage().await.expect("rehydrate");
+    assert_eq!(restored, 3, "all three persisted agents must rehydrate");
+
+    let alpha = registry_2.get(&[1u8; 16]).expect("alpha restored");
+    assert_eq!(alpha.name, "alpha");
+    assert_eq!(alpha.team_id.as_deref(), Some("teamA"));
+
+    let beta = registry_2.get(&[2u8; 16]).expect("beta restored");
+    assert_eq!(beta.name, "beta");
+    assert_eq!(beta.team_id.as_deref(), Some("teamB"));
+
+    let gamma = registry_2.get(&[3u8; 16]).expect("gamma restored");
+    assert_eq!(gamma.name, "gamma");
+    assert_eq!(gamma.team_id, None);
+}
+
+/// Deregister_persisted must clear the durable row, so a subsequent
+/// restart does NOT bring the agent back.
+#[tokio::test]
+async fn deregister_persisted_clears_storage_so_restart_skips_agent() {
+    let tmp = tempdir().expect("tempdir");
+    let db_path = tmp.path().join("registry-deregister.db");
+
+    // ── Session 1: register two agents, deregister one.
+    let storage_1: Arc<dyn StorageBackend> = open_sqlite_backend(&db_path).await.expect("open backend");
+    let registry_1 = AgentRegistry::new().with_storage(storage_1.clone());
+    registry_1
+        .register_persisted(record([4u8; 16], "keep-me", Some("teamA")))
+        .await
+        .expect("register keep-me");
+    registry_1
+        .register_persisted(record([5u8; 16], "drop-me", Some("teamA")))
+        .await
+        .expect("register drop-me");
+    registry_1
+        .deregister_persisted(&[5u8; 16], OrphanMode::Suspend)
+        .await
+        .expect("deregister drop-me");
+
+    drop(registry_1);
+    drop(storage_1);
+
+    // ── Session 2: rehydrate, expect only keep-me back.
+    let storage_2: Arc<dyn StorageBackend> = open_sqlite_backend(&db_path).await.expect("reopen backend");
+    let registry_2 = AgentRegistry::new().with_storage(storage_2);
+    let restored = registry_2.rehydrate_from_storage().await.expect("rehydrate");
+    assert_eq!(restored, 1, "only one agent must remain after deregister_persisted");
+
+    assert!(registry_2.get(&[4u8; 16]).is_some(), "keep-me must rehydrate");
+    assert!(registry_2.get(&[5u8; 16]).is_none(), "drop-me must NOT rehydrate");
+}


### PR DESCRIPTION
## Description

Epic 18 Story S-I.2 (AAASM-1864) — second of six Sub-tasks under Story AAASM-1590. Adds write-through persistence to `AgentRegistry` and rehydrates it from durable storage at boot. After this PR, an agent registered through the gRPC `Register` RPC survives a gateway restart.

### What this PR delivers

- **`aa-gateway/src/registry/storage_bridge.rs` (NEW)** — single seam translating between the runtime `AgentRecord` (rich, liveness-tracking) and the storage `AgentRecord` (durable identity slice). Lossy by design; `name` round-trips through `metadata["name"]` so rehydrate can restore it.
- **`AgentRegistry::with_storage(Arc<dyn StorageBackend>)`** — builder that opts in to durability. Without it the registry stays purely in-memory (legacy behaviour preserved for sync tests).
- **`AgentRegistry::register_persisted` (async)** — in-memory insert + `storage.upsert_agent`. Rolls back the in-memory insert on storage failure so the two views never diverge.
- **`AgentRegistry::deregister_persisted` (async)** — in-memory removal + `storage.delete_agent`. `StorageError::NotFound` is swallowed so best-effort tombstoning works.
- **`AgentRegistry::rehydrate_from_storage` (async)** — boot-time replay via `storage.list_agents(AgentFilter::default())`. Returns the number of agents restored.
- **`RegistryError::Storage(StorageError)`** — new variant so both phases return a single error type.
- **`lifecycle_service.rs`** — gRPC `Register` / `Deregister` handlers route through the persisted variants. Error mapping is unchanged.
- **`main.rs::run_legacy_grpc`** — loads `GatewayConfig`, opens `SqliteBackend` via `storage::boot::open_sqlite_backend`, attaches to `AgentRegistry`, and calls `rehydrate_from_storage` before serving. **Operator-facing change** noted below.
- **`aa-gateway/tests/registry_storage_persistence_test.rs` (NEW)** — two end-to-end restart tests against an on-disk tempdir SQLite file (not `:memory:`) covering both the persist-and-restore path and the deregister-tombstone path.

### Operator-facing change

`aasm-gateway --mode legacy-grpc` now creates `~/.aasm/local.db` on first start (or whatever `local.storage_path` resolves to in `GatewayConfig`). Existing CLI flags are unchanged and no migration is required — fresh installs get an empty database; existing installs pick up persistence on next start.

### What this PR explicitly defers

- **AppState extension** — `AppState` still carries only `storage`. The registry now has its own storage handle for write-through, which is the substantive durability work. Folding the registry handle onto `AppState` is a refactor for a later Sub-task (`AppState` consumers don't exist yet).
- **Lineage / credential token persistence** — `parent_key`, `root_agent_id`, `credential_token` are NOT persisted in this Sub-task's schema. Restored agents reappear as root-level entries with empty credential tokens; the next agent connect is expected to refresh both. Documented in `storage_bridge.rs` module docs.
- **`local_mode` / `remote_mode` registry wiring** — those entrypoints don't host the gRPC `AgentLifecycleService` today (they serve only `/healthz`). When they do, the same `with_storage` + `rehydrate` pattern from `run_legacy_grpc` applies.

## Type of Change

- [x] ✨ New feature (durable agent registry)
- [x] ♻️ Refactoring (lifecycle_service routes through persisted variants)

## Breaking Changes

- [x] No

The new `AgentRegistry::with_storage` builder is opt-in. Existing `AgentRegistry::new()` callers (sync tests in `store.rs`, anything not using `register_persisted`) keep their pure-in-memory behaviour. `RegistryError::Storage` is an additive variant; `lifecycle_service.rs`'s catch-all `_ => Status::internal(...)` arm absorbs it. The legacy-grpc operator-facing change (writes to `~/.aasm/local.db`) is documented above and matches the AC.

## Related Issues

- Jira Story: [AAASM-1590](https://lightning-dust-mite.atlassian.net/browse/AAASM-1590) (E18 S-I)
- Jira Subtask: [AAASM-1864](https://lightning-dust-mite.atlassian.net/browse/AAASM-1864) (S-I.2)
- Epic: [AAASM-1569](https://lightning-dust-mite.atlassian.net/browse/AAASM-1569) (E18 Durable Persistence Layer)
- Builds on merged sibling [AAASM-1859](https://lightning-dust-mite.atlassian.net/browse/AAASM-1859) (S-I.1) — PR #714.

## Testing

- [x] Unit tests added (`storage_bridge::tests` — 2 cases)
- [x] Integration tests added (`registry_storage_persistence_test` — 2 cases against on-disk SQLite)
- [x] `cargo nextest run -p aa-gateway` — **960/960 pass**
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean (lefthook pre-commit on every commit)
- [x] `cargo fmt --check` clean
- [x] `cargo doc --workspace --no-deps` clean (pre-push)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] All 9 commits Gitmoji-tagged, single logical change each
- [x] Branch off latest `remote/master@df64ff28`
- [x] No parallel PR for AAASM-1864 (verified via `gh pr list` + `git ls-remote`)
- [ ] All CI checks passing (will validate post-push)

[AAASM-1590]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ