### PR TITLE
[AAASM-1861] ✨ (admin): Add retention-policy REST routes (GET / PUT / POST run)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2 0.11.0",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/aa-api/Cargo.toml
+++ b/aa-api/Cargo.toml
@@ -58,6 +58,7 @@ httpmock = "0.8"
 rstest = "0.26"
 serde_json = "1"
 sha2 = "0.11"
+tempfile = "3"
 tokio-tungstenite = "0.29"
 tower = { version = "0.5", features = ["util"] }
 

--- a/aa-api/src/models/mod.rs
+++ b/aa-api/src/models/mod.rs
@@ -4,6 +4,7 @@ pub mod alert_ws_payloads;
 pub mod capability;
 pub mod event;
 pub mod event_type;
+pub mod retention;
 pub mod topology;
 pub mod trace;
 pub mod ws_payloads;

--- a/aa-api/src/models/retention.rs
+++ b/aa-api/src/models/retention.rs
@@ -1,0 +1,101 @@
+//! DTOs for the admin retention-policy REST endpoints (AAASM-1592 S-K).
+//!
+//! These types are the wire surface between the dashboard
+//! `Settings → Storage → Retention Policy` page and the gateway. They
+//! mirror the shape of [`aa_gateway::storage::RetentionConfig`] /
+//! [`aa_gateway::storage::RetentionStats`] without coupling the HTTP
+//! layer to the gateway's internal representation.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// Cold-tier action chosen by the admin.
+///
+/// Wire-level enum kept lowercase (`drop` / `archive`) so the JSON body
+/// is identical to the YAML config key and the dashboard dropdown value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ColdActionDto {
+    /// Permanently drop rows older than the warm tier.
+    Drop,
+    /// Archive rows to the configured object store URL.
+    Archive,
+}
+
+/// Snapshot of the active retention configuration plus the most recent
+/// run's stats. Body of `GET /api/v1/admin/retention-policy`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct RetentionPolicyDocument {
+    /// Days a row stays indexed and queryable in the hot tier.
+    pub hot_days: u32,
+    /// Days a row stays in the warm tier (compressed where supported)
+    /// before the cold action runs.
+    pub warm_days: u32,
+    /// Action applied to rows older than `warm_days`.
+    pub cold_action: ColdActionDto,
+    /// Archive destination (e.g. `s3://bucket/path`). Required when
+    /// `cold_action == "archive"`; `None` otherwise.
+    pub archive_url: Option<String>,
+    /// When true, the engine logs the work it *would* perform without
+    /// taking action.
+    pub dry_run: bool,
+    /// Cron schedule (UTC) on which the background task fires. Read-only
+    /// — schedule changes still require a gateway restart.
+    pub schedule: String,
+    /// Stats from the most recent successful run. `None` when the engine
+    /// has not yet completed a pass.
+    pub last_run: Option<RetentionRunStatsDto>,
+}
+
+/// Wire representation of [`aa_gateway::storage::RetentionStats`].
+///
+/// Used both inline on [`RetentionPolicyDocument`] (`last_run`) and as
+/// the body of `POST /api/v1/admin/retention-policy/run`.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq)]
+pub struct RetentionRunStatsDto {
+    /// Timestamp (UTC) at which the run completed (ISO 8601).
+    #[schema(value_type = String)]
+    pub ran_at: DateTime<Utc>,
+    /// Rows remaining in the hot tier after the run.
+    pub hot_rows: u64,
+    /// Rows compressed into warm tier during the run.
+    pub compressed_rows: u64,
+    /// Rows archived during the run.
+    pub archived_rows: u64,
+    /// Rows dropped during the run.
+    pub dropped_rows: u64,
+    /// Bytes freed from primary storage by compression or drop.
+    pub freed_bytes: u64,
+    /// Whether the run executed in dry-run mode (logged work without
+    /// actually deleting / compressing).
+    pub dry_run: bool,
+}
+
+/// Body of `PUT /api/v1/admin/retention-policy` — partial update of the
+/// runtime retention configuration. Each field must be present; the
+/// server-side validation matches the dashboard's client-side rules
+/// (hot_days &ge; 1, warm_days &gt; hot_days, archive_url required when
+/// `cold_action == "archive"`).
+#[derive(Debug, Clone, Deserialize, Serialize, ToSchema)]
+pub struct UpdateRetentionPolicyRequest {
+    /// New value for `hot_days`. Must be &ge; 1.
+    pub hot_days: u32,
+    /// New value for `warm_days`. Must be strictly greater than `hot_days`.
+    pub warm_days: u32,
+    /// New cold-tier action.
+    pub cold_action: ColdActionDto,
+    /// Archive destination. Required when `cold_action == "archive"`;
+    /// must start with `s3://` or `gs://`.
+    #[serde(default)]
+    pub archive_url: Option<String>,
+}
+
+/// Body of `POST /api/v1/admin/retention-policy/run`.
+#[derive(Debug, Clone, Default, Deserialize, Serialize, ToSchema)]
+pub struct RunRetentionRequest {
+    /// When true, the run logs the work it *would* perform without
+    /// taking action. Defaults to `false`.
+    #[serde(default)]
+    pub dry_run: bool,
+}

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -13,10 +13,13 @@ use crate::models::capability::{
 };
 use crate::models::event::GovernanceEvent;
 use crate::models::event_type::EventType;
+use crate::models::retention::{
+    ColdActionDto, RetentionPolicyDocument, RetentionRunStatsDto, RunRetentionRequest, UpdateRetentionPolicyRequest,
+};
 use crate::models::trace::{TraceResponse, TraceSpan};
 use crate::models::ws_payloads::{ApprovalPayload, BudgetAlertPayload, EventPayload, ViolationPayload};
 use crate::routes::{
-    agents, alert_rules, alerts, approvals, audit, auth, capability, costs, destinations, edges, iam, logs, ops,
+    admin, agents, alert_rules, alerts, approvals, audit, auth, capability, costs, destinations, edges, iam, logs, ops,
     policies, topology, traces,
 };
 
@@ -52,6 +55,7 @@ use crate::routes::{
         (name = "capability", description = "Dashboard Capability Matrix — agent × resource × verb × decision view"),
         (name = "iam", description = "Identity & Access — API key list / generate / revoke / rotate"),
         (name = "audit", description = "Audit log aggregations — violation heatmaps and lineage analytics"),
+        (name = "admin", description = "Admin operations — retention policy hot-reload and on-demand run (AAASM-1592 S-K)"),
     ),
     paths(
         crate::routes::health::health,
@@ -113,6 +117,9 @@ use crate::routes::{
         iam::revoke_api_key,
         iam::rotate_api_key,
         audit::get_violations_by_lineage,
+        admin::get_retention_policy,
+        admin::update_retention_policy,
+        admin::run_retention_policy,
     ),
     components(schemas(
         crate::routes::health::HealthResponse,
@@ -214,6 +221,11 @@ use crate::routes::{
         iam::ApiKeyResponse,
         iam::GeneratedApiKeyResponse,
         iam::GenerateApiKeyRequest,
+        ColdActionDto,
+        RetentionPolicyDocument,
+        RetentionRunStatsDto,
+        RunRetentionRequest,
+        UpdateRetentionPolicyRequest,
     )),
     modifiers(&SecurityAddon, &AlertsWsSubprotocolAddon),
 )]

--- a/aa-api/src/routes/admin.rs
+++ b/aa-api/src/routes/admin.rs
@@ -14,7 +14,9 @@ use axum::Json;
 use aa_gateway::storage::{ColdAction, RetentionConfig, RetentionEngine, RetentionStats};
 
 use crate::error::ProblemDetail;
-use crate::models::retention::{ColdActionDto, RetentionPolicyDocument, RetentionRunStatsDto};
+use crate::models::retention::{
+    ColdActionDto, RetentionPolicyDocument, RetentionRunStatsDto, UpdateRetentionPolicyRequest,
+};
 use crate::state::AppState;
 
 /// Resolve the live `RetentionEngine` handle or surface a 503 to the
@@ -82,5 +84,85 @@ pub async fn get_retention_policy(
     let config = engine.current_config();
     let last_run = engine.last_run_stats();
     Ok(Json(config_to_document(&config, last_run)))
+}
+
+/// Validate the incoming DTO at the HTTP layer so callers get a
+/// field-level 400 before the gateway's `RetentionConfig::validate`
+/// runs. Mirrors the dashboard's client-side form rules.
+fn validate_update_request(req: &UpdateRetentionPolicyRequest) -> Result<(), ProblemDetail> {
+    if req.hot_days < 1 {
+        return Err(ProblemDetail::from_status(StatusCode::BAD_REQUEST)
+            .with_detail("hot_days must be >= 1")
+            .with_error_code("retention_policy_invalid_hot_days"));
+    }
+    if req.warm_days <= req.hot_days {
+        return Err(ProblemDetail::from_status(StatusCode::BAD_REQUEST)
+            .with_detail("warm_days must be strictly greater than hot_days")
+            .with_error_code("retention_policy_invalid_warm_days"));
+    }
+    if req.cold_action == ColdActionDto::Archive {
+        let url = req.archive_url.as_deref().unwrap_or("");
+        if url.is_empty() {
+            return Err(ProblemDetail::from_status(StatusCode::BAD_REQUEST)
+                .with_detail("archive_url is required when cold_action == \"archive\"")
+                .with_error_code("retention_policy_missing_archive_url"));
+        }
+        if !url.starts_with("s3://") && !url.starts_with("gs://") {
+            return Err(ProblemDetail::from_status(StatusCode::BAD_REQUEST)
+                .with_detail("archive_url must start with s3:// or gs://")
+                .with_error_code("retention_policy_invalid_archive_url"));
+        }
+    }
+    Ok(())
+}
+
+/// Build a fresh `RetentionConfig` from the live config (which carries
+/// the cron schedule we cannot change at runtime) and the validated DTO.
+fn merge_request_into_config(base: &RetentionConfig, req: &UpdateRetentionPolicyRequest) -> RetentionConfig {
+    RetentionConfig {
+        schedule: base.schedule.clone(),
+        hot_days: req.hot_days,
+        warm_days: req.warm_days,
+        cold_action: match req.cold_action {
+            ColdActionDto::Drop => ColdAction::Drop,
+            ColdActionDto::Archive => ColdAction::Archive,
+        },
+        archive_url: req.archive_url.clone(),
+        dry_run: base.dry_run,
+    }
+}
+
+/// Hot-reload the retention configuration. Returns the updated config
+/// + last-run stats so the caller can re-render the page without a
+/// follow-up GET.
+#[utoipa::path(
+    put,
+    path = "/api/v1/admin/retention-policy",
+    summary = "Hot-reload the retention policy thresholds",
+    description = "Atomically replaces the gateway's active retention configuration. Validation runs both client-side in the dashboard and server-side here; on validation failure the active config is preserved. The cron schedule is read-only at runtime — only thresholds and the cold action can be changed without a restart.",
+    request_body = UpdateRetentionPolicyRequest,
+    responses(
+        (status = 200, description = "Configuration applied; updated document returned", body = RetentionPolicyDocument),
+        (status = 400, description = "Invalid request body (validation failure)", body = ProblemDetail),
+        (status = 503, description = "Retention engine not configured", body = ProblemDetail),
+    ),
+    tag = "admin"
+)]
+pub async fn update_retention_policy(
+    Extension(state): Extension<AppState>,
+    Json(req): Json<UpdateRetentionPolicyRequest>,
+) -> Result<Json<RetentionPolicyDocument>, ProblemDetail> {
+    validate_update_request(&req)?;
+    let engine = require_engine(&state)?;
+    let current = engine.current_config();
+    let new_config = merge_request_into_config(&current, &req);
+    engine.hot_reload(new_config).map_err(|e| {
+        ProblemDetail::from_status(StatusCode::BAD_REQUEST)
+            .with_detail(e.to_string())
+            .with_error_code("retention_policy_gateway_rejected")
+    })?;
+    let applied = engine.current_config();
+    let last_run = engine.last_run_stats();
+    Ok(Json(config_to_document(&applied, last_run)))
 }
 

--- a/aa-api/src/routes/admin.rs
+++ b/aa-api/src/routes/admin.rs
@@ -15,7 +15,7 @@ use aa_gateway::storage::{ColdAction, RetentionConfig, RetentionEngine, Retentio
 
 use crate::error::ProblemDetail;
 use crate::models::retention::{
-    ColdActionDto, RetentionPolicyDocument, RetentionRunStatsDto, UpdateRetentionPolicyRequest,
+    ColdActionDto, RetentionPolicyDocument, RetentionRunStatsDto, RunRetentionRequest, UpdateRetentionPolicyRequest,
 };
 use crate::state::AppState;
 
@@ -164,5 +164,59 @@ pub async fn update_retention_policy(
     let applied = engine.current_config();
     let last_run = engine.last_run_stats();
     Ok(Json(config_to_document(&applied, last_run)))
+}
+
+/// Trigger an immediate retention pass (optionally in dry-run mode).
+#[utoipa::path(
+    post,
+    path = "/api/v1/admin/retention-policy/run",
+    summary = "Run the retention engine once immediately",
+    description = "Triggers `RetentionEngine::run_once` with the live config, optionally forcing dry-run mode for this single invocation. Returns the resulting `RetentionStats` so the dashboard's \"Last retention run\" panel can refresh inline.",
+    request_body = RunRetentionRequest,
+    responses(
+        (status = 200, description = "Run completed; stats returned", body = RetentionRunStatsDto),
+        (status = 500, description = "Backend retention pass failed", body = ProblemDetail),
+        (status = 503, description = "Retention engine not configured", body = ProblemDetail),
+    ),
+    tag = "admin"
+)]
+pub async fn run_retention_policy(
+    Extension(state): Extension<AppState>,
+    Json(req): Json<RunRetentionRequest>,
+) -> Result<Json<RetentionRunStatsDto>, ProblemDetail> {
+    let engine = require_engine(&state)?;
+    if req.dry_run {
+        // Temporarily flip dry_run on so this pass logs work without
+        // taking action. The override is itself a hot_reload, so the
+        // active config snapshot rolls forward visibly — same path as
+        // any other admin write.
+        let mut current = engine.current_config();
+        let was_dry_run = current.dry_run;
+        current.dry_run = true;
+        engine.hot_reload(current.clone()).map_err(|e| {
+            ProblemDetail::from_status(StatusCode::BAD_REQUEST)
+                .with_detail(e.to_string())
+                .with_error_code("retention_policy_dry_run_toggle_rejected")
+        })?;
+        let stats = engine.run_once().await.map_err(|e| {
+            ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR)
+                .with_detail(e.to_string())
+                .with_error_code("retention_run_failed")
+        })?;
+        // Restore the operator's dry_run preference.
+        current.dry_run = was_dry_run;
+        let _ = engine.hot_reload(current);
+        let mut dto = stats_to_dto(stats);
+        dto.dry_run = true;
+        return Ok(Json(dto));
+    }
+    let stats = engine.run_once().await.map_err(|e| {
+        ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR)
+            .with_detail(e.to_string())
+            .with_error_code("retention_run_failed")
+    })?;
+    let mut dto = stats_to_dto(stats);
+    dto.dry_run = engine.current_config().dry_run;
+    Ok(Json(dto))
 }
 

--- a/aa-api/src/routes/admin.rs
+++ b/aa-api/src/routes/admin.rs
@@ -219,4 +219,3 @@ pub async fn run_retention_policy(
     dto.dry_run = engine.current_config().dry_run;
     Ok(Json(dto))
 }
-

--- a/aa-api/src/routes/admin.rs
+++ b/aa-api/src/routes/admin.rs
@@ -1,0 +1,86 @@
+//! Admin REST routes (AAASM-1592 S-K).
+//!
+//! Mounted at `/api/v1/admin/*`. Each handler requires
+//! [`AppState::retention_engine`] to be populated; when the gateway
+//! boots without a `storage` section the field is `None` and the
+//! handlers respond with `503 Service Unavailable`.
+
+use std::sync::Arc;
+
+use axum::extract::Extension;
+use axum::http::StatusCode;
+use axum::Json;
+
+use aa_gateway::storage::{ColdAction, RetentionConfig, RetentionEngine, RetentionStats};
+
+use crate::error::ProblemDetail;
+use crate::models::retention::{ColdActionDto, RetentionPolicyDocument, RetentionRunStatsDto};
+use crate::state::AppState;
+
+/// Resolve the live `RetentionEngine` handle or surface a 503 to the
+/// caller. Used by every handler in this module.
+fn require_engine(state: &AppState) -> Result<Arc<RetentionEngine>, ProblemDetail> {
+    state.retention_engine.clone().ok_or_else(|| {
+        ProblemDetail::from_status(StatusCode::SERVICE_UNAVAILABLE)
+            .with_detail("retention engine is not configured — gateway started without a storage section")
+            .with_error_code("retention_engine_unavailable")
+    })
+}
+
+/// Convert a gateway `RetentionConfig` + last-run stats snapshot into
+/// the wire DTO.
+fn config_to_document(config: &RetentionConfig, last_run: Option<RetentionStats>) -> RetentionPolicyDocument {
+    RetentionPolicyDocument {
+        hot_days: config.hot_days,
+        warm_days: config.warm_days,
+        cold_action: match config.cold_action {
+            ColdAction::Drop => ColdActionDto::Drop,
+            ColdAction::Archive => ColdActionDto::Archive,
+        },
+        archive_url: config.archive_url.clone(),
+        dry_run: config.dry_run,
+        schedule: config.schedule.clone(),
+        last_run: last_run.map(stats_to_dto),
+    }
+}
+
+/// Map gateway `RetentionStats` onto the wire DTO.
+fn stats_to_dto(stats: RetentionStats) -> RetentionRunStatsDto {
+    // RetentionStats does not carry the dry_run flag; the caller of
+    // stats_to_dto fills it in from the policy that drove the run when
+    // it knows the answer. The Default here keeps the inline last_run
+    // panel correct for runs that the engine completed asynchronously
+    // (where we cannot recover the flag).
+    RetentionRunStatsDto {
+        ran_at: stats.ran_at,
+        hot_rows: stats.hot_rows,
+        compressed_rows: stats.compressed_rows,
+        archived_rows: stats.archived_rows,
+        dropped_rows: stats.dropped_rows,
+        freed_bytes: stats.freed_bytes,
+        dry_run: false,
+    }
+}
+
+/// Return the live retention configuration plus the most recent run's
+/// stats.
+#[utoipa::path(
+    get,
+    path = "/api/v1/admin/retention-policy",
+    summary = "Get the live retention policy + last-run stats",
+    description = "Returns the gateway's currently-active retention configuration plus the most recent successful run's statistics. The `last_run` field is `null` until the engine has completed at least one pass.",
+    responses(
+        (status = 200, description = "Current retention policy document", body = RetentionPolicyDocument),
+        (status = 503, description = "Retention engine not configured (gateway started without storage section)", body = ProblemDetail),
+    ),
+    tag = "admin"
+)]
+pub async fn get_retention_policy(
+    Extension(state): Extension<AppState>,
+) -> Result<Json<RetentionPolicyDocument>, ProblemDetail> {
+    let engine = require_engine(&state)?;
+    let config = engine.current_config();
+    let last_run = engine.last_run_stats();
+    Ok(Json(config_to_document(&config, last_run)))
+}
+

--- a/aa-api/src/routes/mod.rs
+++ b/aa-api/src/routes/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! All endpoints are nested under `/api/v1/`.
 
+pub mod admin;
 pub mod agents;
 pub mod alert_rules;
 pub mod alerts;
@@ -126,6 +127,12 @@ pub fn v1_router() -> Router {
         .route("/ops/{id}/terminate", post(ops::terminate_op))
         // Audit aggregations
         .route("/audit/violations-by-lineage", get(audit::get_violations_by_lineage))
+        // Admin — retention policy (AAASM-1592 S-K)
+        .route(
+            "/admin/retention-policy",
+            get(admin::get_retention_policy).put(admin::update_retention_policy),
+        )
+        .route("/admin/retention-policy/run", post(admin::run_retention_policy))
 }
 
 /// Fallback handler returning a 404 RFC 7807 response.

--- a/aa-api/tests/admin.rs
+++ b/aa-api/tests/admin.rs
@@ -1,0 +1,254 @@
+//! Integration tests for the admin retention-policy REST routes
+//! (AAASM-1592 S-K — AAASM-1861).
+//!
+//! Each handler under `/api/v1/admin/retention-policy*` is exercised
+//! against a real Axum router via `tower::ServiceExt::oneshot`. The
+//! happy-path cases populate `AppState.retention_engine` with a
+//! `RetentionEngine` backed by a fresh on-disk SQLite database; the
+//! unavailable / validation cases reuse `common::test_app` whose
+//! AppState defaults `retention_engine` to `None`.
+
+mod common;
+
+use std::sync::Arc;
+
+use aa_api::server::build_app;
+use aa_gateway::storage::backend::StorageBackend;
+use aa_gateway::storage::{RetentionConfig, RetentionEngine, SqliteBackend, SqliteConfig};
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::Value;
+use tower::ServiceExt;
+
+async fn build_engine() -> (Arc<RetentionEngine>, tempfile::TempDir) {
+    let tmp = tempfile::tempdir().expect("create tempdir");
+    let backend = SqliteBackend::open(&SqliteConfig {
+        path: tmp.path().join("retention-it.db"),
+    })
+    .await
+    .expect("sqlite open");
+    backend.migrate().await.expect("sqlite migrate");
+    let engine = Arc::new(RetentionEngine::new(
+        Arc::new(backend) as Arc<dyn StorageBackend>,
+        RetentionConfig::default(),
+    ));
+    (engine, tmp)
+}
+
+async fn json_body(resp: axum::response::Response) -> Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap_or_else(|e| panic!("body is not JSON: {e}; bytes={bytes:?}"))
+}
+
+#[tokio::test]
+async fn get_returns_503_when_retention_engine_is_unconfigured() {
+    let app = common::test_app();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/admin/retention-policy")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body = json_body(resp).await;
+    assert_eq!(body["status"].as_u64(), Some(503));
+    assert_eq!(body["error_code"].as_str(), Some("retention_engine_unavailable"));
+}
+
+#[tokio::test]
+async fn get_returns_current_config_with_no_last_run_initially() {
+    let (engine, _tmp) = build_engine().await;
+    let app = build_app(common::test_state_with_retention_engine(engine));
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/admin/retention-policy")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = json_body(resp).await;
+    assert_eq!(body["hot_days"].as_u64(), Some(30), "default hot_days");
+    assert_eq!(body["warm_days"].as_u64(), Some(90), "default warm_days");
+    assert_eq!(body["cold_action"].as_str(), Some("drop"));
+    assert_eq!(body["dry_run"].as_bool(), Some(false));
+    assert!(body["last_run"].is_null(), "no run yet");
+}
+
+#[tokio::test]
+async fn put_hot_reloads_config_and_returns_updated_document() {
+    let (engine, _tmp) = build_engine().await;
+    let app = build_app(common::test_state_with_retention_engine(Arc::clone(&engine)));
+
+    let req_body = serde_json::json!({
+        "hot_days": 15,
+        "warm_days": 45,
+        "cold_action": "drop",
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/v1/admin/retention-policy")
+                .header("content-type", "application/json")
+                .body(Body::from(req_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = json_body(resp).await;
+    assert_eq!(body["hot_days"].as_u64(), Some(15));
+    assert_eq!(body["warm_days"].as_u64(), Some(45));
+    assert_eq!(body["cold_action"].as_str(), Some("drop"));
+
+    // The live engine reflects the swap.
+    let live = engine.current_config();
+    assert_eq!(live.hot_days, 15);
+    assert_eq!(live.warm_days, 45);
+}
+
+#[tokio::test]
+async fn put_with_warm_days_le_hot_days_returns_400() {
+    let app = common::test_app();
+    let req_body = serde_json::json!({
+        "hot_days": 30,
+        "warm_days": 30,
+        "cold_action": "drop",
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/v1/admin/retention-policy")
+                .header("content-type", "application/json")
+                .body(Body::from(req_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = json_body(resp).await;
+    assert_eq!(body["error_code"].as_str(), Some("retention_policy_invalid_warm_days"));
+}
+
+#[tokio::test]
+async fn put_with_archive_action_missing_url_returns_400() {
+    let app = common::test_app();
+    let req_body = serde_json::json!({
+        "hot_days": 30,
+        "warm_days": 90,
+        "cold_action": "archive",
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/v1/admin/retention-policy")
+                .header("content-type", "application/json")
+                .body(Body::from(req_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = json_body(resp).await;
+    assert_eq!(
+        body["error_code"].as_str(),
+        Some("retention_policy_missing_archive_url")
+    );
+}
+
+#[tokio::test]
+async fn put_with_archive_action_bad_url_scheme_returns_400() {
+    let app = common::test_app();
+    let req_body = serde_json::json!({
+        "hot_days": 30,
+        "warm_days": 90,
+        "cold_action": "archive",
+        "archive_url": "https://example.com/bucket",
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("PUT")
+                .uri("/api/v1/admin/retention-policy")
+                .header("content-type", "application/json")
+                .body(Body::from(req_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = json_body(resp).await;
+    assert_eq!(
+        body["error_code"].as_str(),
+        Some("retention_policy_invalid_archive_url")
+    );
+}
+
+#[tokio::test]
+async fn post_run_dry_run_returns_stats_and_restores_dry_run_flag() {
+    let (engine, _tmp) = build_engine().await;
+    // Pre-condition: engine starts with dry_run=false (the default).
+    assert!(!engine.current_config().dry_run);
+
+    let app = build_app(common::test_state_with_retention_engine(Arc::clone(&engine)));
+    let req_body = serde_json::json!({ "dry_run": true });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/admin/retention-policy/run")
+                .header("content-type", "application/json")
+                .body(Body::from(req_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = json_body(resp).await;
+    assert_eq!(body["dry_run"].as_bool(), Some(true));
+    assert!(body["ran_at"].is_string(), "ran_at must be an ISO-8601 string");
+
+    // Operator's pre-existing dry_run setting must be restored.
+    assert!(
+        !engine.current_config().dry_run,
+        "ad-hoc dry-run must not leave a sticky behaviour change"
+    );
+
+    // engine.last_run_stats() is now populated.
+    assert!(engine.last_run_stats().is_some());
+}
+
+#[tokio::test]
+async fn post_run_returns_503_when_retention_engine_is_unconfigured() {
+    let app = common::test_app();
+    let req_body = serde_json::json!({ "dry_run": false });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/admin/retention-policy/run")
+                .header("content-type", "application/json")
+                .body(Body::from(req_body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+}

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -28,6 +28,7 @@ use aa_gateway::edges::InMemoryEdgeRepo;
 use aa_gateway::engine::PolicyEngine;
 use aa_gateway::policy::history::{FsHistoryStore, HistoryConfig};
 use aa_gateway::registry::AgentRegistry;
+use aa_gateway::storage::RetentionEngine;
 use aa_gateway::AuditReader;
 use aa_runtime::approval::ApprovalQueue;
 use axum::Router;
@@ -189,6 +190,16 @@ pub fn test_app() -> Router {
 pub fn test_state_with_destination_store(store: Arc<dyn aa_api::destinations::store::DestinationStore>) -> AppState {
     let mut state = test_state();
     state.destination_store = store;
+    state
+}
+
+/// Build an `AppState` whose retention_engine is populated. Used by the
+/// AAASM-1592 S-K admin route tests (`tests/admin.rs`) to drive the
+/// happy-path GET / PUT / POST behaviours.
+#[allow(dead_code)]
+pub fn test_state_with_retention_engine(engine: Arc<RetentionEngine>) -> AppState {
+    let mut state = test_state();
+    state.retention_engine = Some(engine);
     state
 }
 

--- a/aa-integration-tests/tests/api_openapi_contract.rs
+++ b/aa-integration-tests/tests/api_openapi_contract.rs
@@ -60,8 +60,8 @@ fn openapi_spec_loads_without_errors() {
     let path_count = spec["paths"].as_object().expect("spec must have a paths object").len();
 
     assert_eq!(
-        path_count, 48,
-        "openapi/v1.yaml must declare exactly 48 paths, found {path_count}"
+        path_count, 50,
+        "openapi/v1.yaml must declare exactly 50 paths, found {path_count}"
     );
 
     for schema in ["HealthResponse", "ProblemDetail", "PolicyResponse", "AlertResponse"] {
@@ -92,6 +92,8 @@ fn openapi_spec_paths_match_implemented_routes() {
     yaml_paths.sort();
 
     let mut expected: Vec<&str> = vec![
+        "/api/v1/admin/retention-policy",
+        "/api/v1/admin/retention-policy/run",
         "/api/v1/agents",
         "/api/v1/agents/{id}",
         "/api/v1/agents/{id}/budget",

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -4,6 +4,50 @@
  */
 
 export interface paths {
+    "/api/v1/admin/retention-policy": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the live retention policy + last-run stats
+         * @description Returns the gateway's currently-active retention configuration plus the most recent successful run's statistics. The `last_run` field is `null` until the engine has completed at least one pass.
+         */
+        get: operations["get_retention_policy"];
+        /**
+         * Hot-reload the retention policy thresholds
+         * @description Atomically replaces the gateway's active retention configuration. Validation runs both client-side in the dashboard and server-side here; on validation failure the active config is preserved. The cron schedule is read-only at runtime — only thresholds and the cold action can be changed without a restart.
+         */
+        put: operations["update_retention_policy"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/admin/retention-policy/run": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Run the retention engine once immediately
+         * @description Triggers `RetentionEngine::run_once` with the live config, optionally forcing dry-run mode for this single invocation. Returns the resulting `RetentionStats` so the dashboard's "Last retention run" panel can refresh inline.
+         */
+        post: operations["run_retention_policy"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/agents": {
         parameters: {
             query?: never;
@@ -1878,6 +1922,14 @@ export interface components {
             /** @description USD spent by this child on the given date (string-encoded Decimal). */
             spent_usd: string;
         };
+        /**
+         * @description Cold-tier action chosen by the admin.
+         *
+         *     Wire-level enum kept lowercase (`drop` / `archive`) so the JSON body
+         *     is identical to the YAML config key and the dashboard dropdown value.
+         * @enum {string}
+         */
+        ColdActionDto: "drop" | "archive";
         /** @description Response body for a failed test-fire (502). */
         ConnectorFailedBody: {
             /**
@@ -2474,6 +2526,81 @@ export interface components {
             /** @description Agent status before the resume operation. */
             previous_status: string;
         };
+        /**
+         * @description Snapshot of the active retention configuration plus the most recent
+         *     run's stats. Body of `GET /api/v1/admin/retention-policy`.
+         */
+        RetentionPolicyDocument: {
+            /**
+             * @description Archive destination (e.g. `s3://bucket/path`). Required when
+             *     `cold_action == "archive"`; `None` otherwise.
+             */
+            archive_url?: string | null;
+            /** @description Action applied to rows older than `warm_days`. */
+            cold_action: components["schemas"]["ColdActionDto"];
+            /**
+             * @description When true, the engine logs the work it *would* perform without
+             *     taking action.
+             */
+            dry_run: boolean;
+            /**
+             * Format: int32
+             * @description Days a row stays indexed and queryable in the hot tier.
+             */
+            hot_days: number;
+            last_run?: null | components["schemas"]["RetentionRunStatsDto"];
+            /**
+             * @description Cron schedule (UTC) on which the background task fires. Read-only
+             *     — schedule changes still require a gateway restart.
+             */
+            schedule: string;
+            /**
+             * Format: int32
+             * @description Days a row stays in the warm tier (compressed where supported)
+             *     before the cold action runs.
+             */
+            warm_days: number;
+        };
+        /**
+         * @description Wire representation of [`aa_gateway::storage::RetentionStats`].
+         *
+         *     Used both inline on [`RetentionPolicyDocument`] (`last_run`) and as
+         *     the body of `POST /api/v1/admin/retention-policy/run`.
+         */
+        RetentionRunStatsDto: {
+            /**
+             * Format: int64
+             * @description Rows archived during the run.
+             */
+            archived_rows: number;
+            /**
+             * Format: int64
+             * @description Rows compressed into warm tier during the run.
+             */
+            compressed_rows: number;
+            /**
+             * Format: int64
+             * @description Rows dropped during the run.
+             */
+            dropped_rows: number;
+            /**
+             * @description Whether the run executed in dry-run mode (logged work without
+             *     actually deleting / compressing).
+             */
+            dry_run: boolean;
+            /**
+             * Format: int64
+             * @description Bytes freed from primary storage by compression or drop.
+             */
+            freed_bytes: number;
+            /**
+             * Format: int64
+             * @description Rows remaining in the hot tier after the run.
+             */
+            hot_rows: number;
+            /** @description Timestamp (UTC) at which the run completed (ISO 8601). */
+            ran_at: string;
+        };
         /** @description One step in the routing history of an approval request. */
         RoutingHistoryEntry: {
             /** @description Whether this step was an initial routing or an escalation: `"routed"` or `"escalated"`. */
@@ -2587,6 +2714,14 @@ export interface components {
              * @description Numeric threshold the metric is compared against.
              */
             threshold: number;
+        };
+        /** @description Body of `POST /api/v1/admin/retention-policy/run`. */
+        RunRetentionRequest: {
+            /**
+             * @description When true, the run logs the work it *would* perform without
+             *     taking action. Defaults to `false`.
+             */
+            dry_run?: boolean;
         };
         /**
          * @description A representative call sample shown alongside the matrix to explain the
@@ -2957,6 +3092,32 @@ export interface components {
             name?: string | null;
         };
         /**
+         * @description Body of `PUT /api/v1/admin/retention-policy` — partial update of the
+         *     runtime retention configuration. Each field must be present; the
+         *     server-side validation matches the dashboard's client-side rules
+         *     (hot_days &ge; 1, warm_days &gt; hot_days, archive_url required when
+         *     `cold_action == "archive"`).
+         */
+        UpdateRetentionPolicyRequest: {
+            /**
+             * @description Archive destination. Required when `cold_action == "archive"`;
+             *     must start with `s3://` or `gs://`.
+             */
+            archive_url?: string | null;
+            /** @description New cold-tier action. */
+            cold_action: components["schemas"]["ColdActionDto"];
+            /**
+             * Format: int32
+             * @description New value for `hot_days`. Must be &ge; 1.
+             */
+            hot_days: number;
+            /**
+             * Format: int32
+             * @description New value for `warm_days`. Must be strictly greater than `hot_days`.
+             */
+            warm_days: number;
+        };
+        /**
          * @description Verb a capability cell scopes its decision to.
          * @enum {string}
          */
@@ -3069,6 +3230,119 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+    get_retention_policy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Current retention policy document */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RetentionPolicyDocument"];
+                };
+            };
+            /** @description Retention engine not configured (gateway started without storage section) */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+        };
+    };
+    update_retention_policy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateRetentionPolicyRequest"];
+            };
+        };
+        responses: {
+            /** @description Configuration applied; updated document returned */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RetentionPolicyDocument"];
+                };
+            };
+            /** @description Invalid request body (validation failure) */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Retention engine not configured */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+        };
+    };
+    run_retention_policy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RunRetentionRequest"];
+            };
+        };
+        responses: {
+            /** @description Run completed; stats returned */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RetentionRunStatsDto"];
+                };
+            };
+            /** @description Backend retention pass failed */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Retention engine not configured */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+        };
+    };
     list_agents: {
         parameters: {
             query?: {

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -16,6 +16,89 @@ servers:
 - url: http://localhost:7700
   description: Local development gateway
 paths:
+  /api/v1/admin/retention-policy:
+    get:
+      tags:
+      - admin
+      summary: Get the live retention policy + last-run stats
+      description: Returns the gateway's currently-active retention configuration plus the most recent successful run's statistics. The `last_run` field is `null` until the engine has completed at least one pass.
+      operationId: get_retention_policy
+      responses:
+        '200':
+          description: Current retention policy document
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetentionPolicyDocument'
+        '503':
+          description: Retention engine not configured (gateway started without storage section)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+    put:
+      tags:
+      - admin
+      summary: Hot-reload the retention policy thresholds
+      description: Atomically replaces the gateway's active retention configuration. Validation runs both client-side in the dashboard and server-side here; on validation failure the active config is preserved. The cron schedule is read-only at runtime — only thresholds and the cold action can be changed without a restart.
+      operationId: update_retention_policy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateRetentionPolicyRequest'
+        required: true
+      responses:
+        '200':
+          description: Configuration applied; updated document returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetentionPolicyDocument'
+        '400':
+          description: Invalid request body (validation failure)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '503':
+          description: Retention engine not configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+  /api/v1/admin/retention-policy/run:
+    post:
+      tags:
+      - admin
+      summary: Run the retention engine once immediately
+      description: Triggers `RetentionEngine::run_once` with the live config, optionally forcing dry-run mode for this single invocation. Returns the resulting `RetentionStats` so the dashboard's "Last retention run" panel can refresh inline.
+      operationId: run_retention_policy
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RunRetentionRequest'
+        required: true
+      responses:
+        '200':
+          description: Run completed; stats returned
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RetentionRunStatsDto'
+        '500':
+          description: Backend retention pass failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '503':
+          description: Retention engine not configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
   /api/v1/agents:
     get:
       tags:
@@ -3239,6 +3322,16 @@ components:
         spent_usd:
           type: string
           description: USD spent by this child on the given date (string-encoded Decimal).
+    ColdActionDto:
+      type: string
+      description: |-
+        Cold-tier action chosen by the admin.
+
+        Wire-level enum kept lowercase (`drop` / `archive`) so the JSON body
+        is identical to the YAML config key and the dashboard dropdown value.
+      enum:
+      - drop
+      - archive
     ConnectorFailedBody:
       type: object
       description: Response body for a failed test-fire (502).
@@ -4277,6 +4370,106 @@ components:
         previous_status:
           type: string
           description: Agent status before the resume operation.
+    RetentionPolicyDocument:
+      type: object
+      description: |-
+        Snapshot of the active retention configuration plus the most recent
+        run's stats. Body of `GET /api/v1/admin/retention-policy`.
+      required:
+      - hot_days
+      - warm_days
+      - cold_action
+      - dry_run
+      - schedule
+      properties:
+        archive_url:
+          type:
+          - string
+          - 'null'
+          description: |-
+            Archive destination (e.g. `s3://bucket/path`). Required when
+            `cold_action == "archive"`; `None` otherwise.
+        cold_action:
+          $ref: '#/components/schemas/ColdActionDto'
+          description: Action applied to rows older than `warm_days`.
+        dry_run:
+          type: boolean
+          description: |-
+            When true, the engine logs the work it *would* perform without
+            taking action.
+        hot_days:
+          type: integer
+          format: int32
+          description: Days a row stays indexed and queryable in the hot tier.
+          minimum: 0
+        last_run:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/RetentionRunStatsDto'
+            description: |-
+              Stats from the most recent successful run. `None` when the engine
+              has not yet completed a pass.
+        schedule:
+          type: string
+          description: |-
+            Cron schedule (UTC) on which the background task fires. Read-only
+            — schedule changes still require a gateway restart.
+        warm_days:
+          type: integer
+          format: int32
+          description: |-
+            Days a row stays in the warm tier (compressed where supported)
+            before the cold action runs.
+          minimum: 0
+    RetentionRunStatsDto:
+      type: object
+      description: |-
+        Wire representation of [`aa_gateway::storage::RetentionStats`].
+
+        Used both inline on [`RetentionPolicyDocument`] (`last_run`) and as
+        the body of `POST /api/v1/admin/retention-policy/run`.
+      required:
+      - ran_at
+      - hot_rows
+      - compressed_rows
+      - archived_rows
+      - dropped_rows
+      - freed_bytes
+      - dry_run
+      properties:
+        archived_rows:
+          type: integer
+          format: int64
+          description: Rows archived during the run.
+          minimum: 0
+        compressed_rows:
+          type: integer
+          format: int64
+          description: Rows compressed into warm tier during the run.
+          minimum: 0
+        dropped_rows:
+          type: integer
+          format: int64
+          description: Rows dropped during the run.
+          minimum: 0
+        dry_run:
+          type: boolean
+          description: |-
+            Whether the run executed in dry-run mode (logged work without
+            actually deleting / compressing).
+        freed_bytes:
+          type: integer
+          format: int64
+          description: Bytes freed from primary storage by compression or drop.
+          minimum: 0
+        hot_rows:
+          type: integer
+          format: int64
+          description: Rows remaining in the hot tier after the run.
+          minimum: 0
+        ran_at:
+          type: string
+          description: Timestamp (UTC) at which the run completed (ISO 8601).
     RoutingHistoryEntry:
       type: object
       description: One step in the routing history of an approval request.
@@ -4448,6 +4641,15 @@ components:
           type: number
           format: double
           description: Numeric threshold the metric is compared against.
+    RunRetentionRequest:
+      type: object
+      description: Body of `POST /api/v1/admin/retention-policy/run`.
+      properties:
+        dry_run:
+          type: boolean
+          description: |-
+            When true, the run logs the work it *would* perform without
+            taking action. Defaults to `false`.
     SampleCall:
       type: object
       description: |-
@@ -5042,6 +5244,39 @@ components:
 
         All fields are optional — supplying just `enabled` toggles dispatch
         without touching the configuration payload.
+    UpdateRetentionPolicyRequest:
+      type: object
+      description: |-
+        Body of `PUT /api/v1/admin/retention-policy` — partial update of the
+        runtime retention configuration. Each field must be present; the
+        server-side validation matches the dashboard's client-side rules
+        (hot_days &ge; 1, warm_days &gt; hot_days, archive_url required when
+        `cold_action == "archive"`).
+      required:
+      - hot_days
+      - warm_days
+      - cold_action
+      properties:
+        archive_url:
+          type:
+          - string
+          - 'null'
+          description: |-
+            Archive destination. Required when `cold_action == "archive"`;
+            must start with `s3://` or `gs://`.
+        cold_action:
+          $ref: '#/components/schemas/ColdActionDto'
+          description: New cold-tier action.
+        hot_days:
+          type: integer
+          format: int32
+          description: New value for `hot_days`. Must be &ge; 1.
+          minimum: 0
+        warm_days:
+          type: integer
+          format: int32
+          description: New value for `warm_days`. Must be strictly greater than `hot_days`.
+          minimum: 0
     Verb:
       type: string
       description: Verb a capability cell scopes its decision to.
@@ -5256,3 +5491,5 @@ tags:
   description: Identity & Access — API key list / generate / revoke / rotate
 - name: audit
   description: Audit log aggregations — violation heatmaps and lineage analytics
+- name: admin
+  description: Admin operations — retention policy hot-reload and on-demand run (AAASM-1592 S-K)


### PR DESCRIPTION
## Description

Adds the admin retention-policy REST surface that the AAASM-1592 (S-K) dashboard page consumes:

* `GET  /api/v1/admin/retention-policy` — current config + last_run stats
* `PUT  /api/v1/admin/retention-policy` — hot-reload thresholds via `RetentionEngine::hot_reload`
* `POST /api/v1/admin/retention-policy/run` — on-demand run via `RetentionEngine::run_once`, with a `dry_run` flag that is applied for the single invocation and then restored to the operator's prior setting

Every handler returns **503 Service Unavailable** when `AppState.retention_engine` is `None` (i.e. when the gateway boots without a `storage` section — production wiring lands on AAASM-1590 S-I.4).

Server-side validation mirrors the dashboard's client-side form rules so the same constraints are enforced regardless of caller:

| Field | Rule |
|---|---|
| `hot_days` | &ge; 1 |
| `warm_days` | &gt; `hot_days` |
| `archive_url` | required when `cold_action = "archive"`; must start with `s3://` or `gs://` |

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

Pure additive — three new endpoints, five new DTOs, one new utoipa tag. Existing paths untouched.

## Related Issues

- Related Jira ticket: [AAASM-1861](https://lightning-dust-mite.atlassian.net/browse/AAASM-1861) — `[3/6]` sub-ticket of [AAASM-1592](https://lightning-dust-mite.atlassian.net/browse/AAASM-1592)
- Depends on (merged): AAASM-1850 (`RetentionEngine` hot-reload primitive), AAASM-1856 (`AppState.retention_engine` slot)

## Testing

- [x] Unit / integration tests added

`aa-api/tests/admin.rs` — 8 tower::oneshot integration tests covering every handler path:

| Test | Behaviour |
|---|---|
| `get_returns_503_when_retention_engine_is_unconfigured` | GET → 503 + `retention_engine_unavailable` |
| `get_returns_current_config_with_no_last_run_initially` | GET happy path, defaults round-trip, `last_run: null` |
| `put_hot_reloads_config_and_returns_updated_document` | PUT swaps live config and returns the updated document |
| `put_with_warm_days_le_hot_days_returns_400` | Validation: `warm_days > hot_days` |
| `put_with_archive_action_missing_url_returns_400` | Validation: archive needs URL |
| `put_with_archive_action_bad_url_scheme_returns_400` | Validation: scheme prefix |
| `post_run_dry_run_returns_stats_and_restores_dry_run_flag` | Ad-hoc dry-run doesn't leave a sticky behaviour change; `last_run_stats()` populated |
| `post_run_returns_503_when_retention_engine_is_unconfigured` | POST → 503 |

All 529 aa-api tests green (+ 8 new). All 6 `aa-integration-tests::api_openapi_contract` tests green after the `path_count` bump from 48 → 50.

Local validations run: `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `npx @stoplight/spectral-cli lint openapi/v1.yaml` (no errors).

## Commits (8, GitEmoji granular)

1. ✨ (models/retention): Add admin retention-policy DTOs
2. ✨ (routes/admin): Add GET retention-policy handler
3. ✨ (routes/admin): Add PUT retention-policy handler
4. ✨ (routes/admin): Add POST retention-policy/run handler
5. ✨ (routes/admin): Mount admin routes + register in OpenAPI
6. ✨ (openapi): Regenerate v1.yaml + bump contract gate to 50 paths
7. ✨ (dashboard/codegen): Regenerate schema.d.ts for admin retention routes
8. ✅ (routes/admin): Integration tests for retention-policy routes

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --all-targets -- -D warnings`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on new handlers + DTOs; OpenAPI spec auto-generated)
- [ ] All CI checks passing — pending
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1861]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ