### PR TITLE
[AAASM-1853] ✨ (aa-gateway/storage): Add PostgresBackend::apply_timescaledb_setup with graceful fallback

### DIFF
--- a/aa-gateway/src/storage/postgres.rs
+++ b/aa-gateway/src/storage/postgres.rs
@@ -960,6 +960,27 @@ mod tests {
         }
     }
 
+    /// `apply_timescaledb_setup` must return `Ok(())` immediately when
+    /// `config.enabled = false`, without touching the database. Exercises
+    /// the operator-opt-out path that lets deployments disable TimescaleDB
+    /// promotion even when the extension is installed.
+    ///
+    /// Runs whenever `AAASM_DATABASE_URL` is set — no TimescaleDB needed.
+    #[tokio::test]
+    async fn apply_timescaledb_setup_skips_when_disabled() {
+        let Some(backend) = pg_backend_or_skip().await else {
+            return;
+        };
+        let disabled = TimescaleConfig {
+            enabled: false,
+            ..TimescaleConfig::default()
+        };
+        backend
+            .apply_timescaledb_setup(&disabled)
+            .await
+            .expect("apply_timescaledb_setup must return Ok when enabled = false");
+    }
+
     #[tokio::test]
     async fn migrate_creates_expected_tables() {
         let Some(backend) = pg_backend_or_skip().await else {

--- a/aa-gateway/src/storage/postgres.rs
+++ b/aa-gateway/src/storage/postgres.rs
@@ -981,6 +981,41 @@ mod tests {
             .expect("apply_timescaledb_setup must return Ok when enabled = false");
     }
 
+    /// When `enabled = true` and the TimescaleDB extension is **absent**,
+    /// `apply_timescaledb_setup` must log a warning and return `Ok(())`
+    /// rather than raising — production deployments must boot against
+    /// plain PostgreSQL without crashing on startup.
+    ///
+    /// Runs against `AAASM_DATABASE_URL` when `TIMESCALEDB_AVAILABLE != "1"`
+    /// (the existing CI `Test` job's postgres:18-alpine service).
+    #[tokio::test]
+    async fn apply_timescaledb_setup_warns_when_extension_absent() {
+        if std::env::var("TIMESCALEDB_AVAILABLE").as_deref() == Ok("1") {
+            eprintln!(
+                "skipping extension-absent test: TIMESCALEDB_AVAILABLE=1 (see apply_timescaledb_setup_succeeds_when_extension_active)"
+            );
+            return;
+        }
+        let Some(backend) = pg_backend_or_skip().await else {
+            return;
+        };
+        let enabled = TimescaleConfig::default();
+        assert!(enabled.enabled, "default must have enabled = true");
+
+        backend
+            .apply_timescaledb_setup(&enabled)
+            .await
+            .expect("apply_timescaledb_setup must return Ok via graceful fallback on plain PostgreSQL");
+
+        let present = super::super::timescale::has_timescaledb_extension(&backend.pool)
+            .await
+            .expect("probe");
+        assert!(
+            !present,
+            "this test asserts the extension-absent path; if your CI installed TimescaleDB, set TIMESCALEDB_AVAILABLE=1"
+        );
+    }
+
     #[tokio::test]
     async fn migrate_creates_expected_tables() {
         let Some(backend) = pg_backend_or_skip().await else {

--- a/aa-gateway/src/storage/postgres.rs
+++ b/aa-gateway/src/storage/postgres.rs
@@ -1016,6 +1016,39 @@ mod tests {
         );
     }
 
+    /// When `enabled = true` and the TimescaleDB extension **is** present,
+    /// `apply_timescaledb_setup` must return `Ok(())` and log at info
+    /// level — the hypertable DDL is already owned by migration 0002,
+    /// so this method only logs and returns.
+    ///
+    /// Env-gated on `TIMESCALEDB_AVAILABLE=1`; auto-runs once SD-5
+    /// (AAASM-1858) ships the `timescaledb-tests` CI job against the
+    /// `timescale/timescaledb:latest-pg17` service container.
+    #[tokio::test]
+    async fn apply_timescaledb_setup_succeeds_when_extension_active() {
+        if std::env::var("TIMESCALEDB_AVAILABLE").as_deref() != Ok("1") {
+            eprintln!("skipping extension-present test: TIMESCALEDB_AVAILABLE != 1");
+            return;
+        }
+        let Some(backend) = pg_backend_or_skip().await else {
+            return;
+        };
+
+        let present = super::super::timescale::has_timescaledb_extension(&backend.pool)
+            .await
+            .expect("probe");
+        assert!(
+            present,
+            "TIMESCALEDB_AVAILABLE=1 was set but the extension is not installed; \
+             check the docker image is timescale/timescaledb:latest-pg17"
+        );
+
+        backend
+            .apply_timescaledb_setup(&TimescaleConfig::default())
+            .await
+            .expect("apply_timescaledb_setup must return Ok when extension is active");
+    }
+
     #[tokio::test]
     async fn migrate_creates_expected_tables() {
         let Some(backend) = pg_backend_or_skip().await else {

--- a/aa-gateway/src/storage/postgres.rs
+++ b/aa-gateway/src/storage/postgres.rs
@@ -22,6 +22,7 @@ use super::metric::{Metric, MetricPoint, MetricQuery};
 use super::policy::{PolicyDocument, PolicyMeta, PolicyVersion};
 use super::postgres_config::PostgresConfig;
 use super::retention::{ColdAction, RetentionPolicy, RetentionStats};
+use super::timescale::has_timescaledb_extension;
 use aa_core::config::TimescaleConfig;
 
 /// Encode an [`AgentId`] for the `agent_id` TEXT column (canonical UUID
@@ -285,6 +286,42 @@ impl PostgresBackend {
             pool,
             timescale_config: config.timescaledb.clone(),
         })
+    }
+
+    /// Gate the TimescaleDB hypertable setup based on `config.enabled` and
+    /// the presence of the `timescaledb` extension on the cluster.
+    ///
+    /// Three paths, all returning `Ok(())`:
+    /// * `config.enabled = false` → log `info`, skip — operator opted out
+    /// * extension absent on cluster → log `warn`, skip — graceful fallback
+    /// * extension present → log `info` — the `0002_timescaledb_hypertables.sql`
+    ///   migration (S-D #1) already created the hypertables; this method
+    ///   only governs runtime gating + observability
+    ///
+    /// Called from `migrate()` after `sqlx::migrate!` runs (wired in the
+    /// next commit of this SD-3 stack).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError::QueryFailed`] only when the `pg_extension`
+    /// probe itself fails (transport / permission). The graceful-fallback
+    /// paths above never raise an error — production deployments must be
+    /// able to boot against plain PostgreSQL.
+    #[allow(dead_code)]
+    pub(crate) async fn apply_timescaledb_setup(&self, config: &TimescaleConfig) -> StorageResult<()> {
+        if !config.enabled {
+            tracing::info!("storage.postgres.timescaledb.enabled = false; skipping hypertable setup");
+            return Ok(());
+        }
+        if !has_timescaledb_extension(&self.pool).await? {
+            tracing::warn!(
+                "TimescaleDB extension not found — using standard PostgreSQL tables. \
+                 Install TimescaleDB for time-series query acceleration and auto-compression."
+            );
+            return Ok(());
+        }
+        tracing::info!("TimescaleDB extension active; hypertables governed by 0002_timescaledb_hypertables.sql");
+        Ok(())
     }
 }
 

--- a/aa-gateway/src/storage/postgres.rs
+++ b/aa-gateway/src/storage/postgres.rs
@@ -22,6 +22,7 @@ use super::metric::{Metric, MetricPoint, MetricQuery};
 use super::policy::{PolicyDocument, PolicyMeta, PolicyVersion};
 use super::postgres_config::PostgresConfig;
 use super::retention::{ColdAction, RetentionPolicy, RetentionStats};
+use aa_core::config::TimescaleConfig;
 
 /// Encode an [`AgentId`] for the `agent_id` TEXT column (canonical UUID
 /// hyphenated form). Mirrors the SQLite backend's storage shape so the
@@ -250,6 +251,12 @@ fn push_agent_where<'q>(qb: &mut sqlx::QueryBuilder<'q, sqlx::Postgres>, filter:
 /// later Epic-18 S-C sub-tasks.
 pub struct PostgresBackend {
     pool: PgPool,
+    /// TimescaleDB knobs captured from [`PostgresConfig::timescaledb`] at
+    /// connect time. Consumed by
+    /// [`PostgresBackend::apply_timescaledb_setup`] from inside `migrate()`
+    /// (wired in Epic 18 S-D #3 commit 3 — `migrate()` consumer).
+    #[allow(dead_code)]
+    timescale_config: TimescaleConfig,
 }
 
 impl PostgresBackend {
@@ -274,7 +281,10 @@ impl PostgresBackend {
             .await
             .map_err(|e| StorageError::ConnectionFailed(e.to_string()))?;
 
-        Ok(Self { pool })
+        Ok(Self {
+            pool,
+            timescale_config: config.timescaledb.clone(),
+        })
     }
 }
 

--- a/aa-gateway/src/storage/postgres.rs
+++ b/aa-gateway/src/storage/postgres.rs
@@ -254,9 +254,7 @@ pub struct PostgresBackend {
     pool: PgPool,
     /// TimescaleDB knobs captured from [`PostgresConfig::timescaledb`] at
     /// connect time. Consumed by
-    /// [`PostgresBackend::apply_timescaledb_setup`] from inside `migrate()`
-    /// (wired in Epic 18 S-D #3 commit 3 — `migrate()` consumer).
-    #[allow(dead_code)]
+    /// [`PostgresBackend::apply_timescaledb_setup`] from inside `migrate()`.
     timescale_config: TimescaleConfig,
 }
 
@@ -307,7 +305,6 @@ impl PostgresBackend {
     /// probe itself fails (transport / permission). The graceful-fallback
     /// paths above never raise an error — production deployments must be
     /// able to boot against plain PostgreSQL.
-    #[allow(dead_code)]
     pub(crate) async fn apply_timescaledb_setup(&self, config: &TimescaleConfig) -> StorageResult<()> {
         if !config.enabled {
             tracing::info!("storage.postgres.timescaledb.enabled = false; skipping hypertable setup");
@@ -327,20 +324,29 @@ impl PostgresBackend {
 
 #[async_trait]
 impl StorageBackend for PostgresBackend {
-    /// Apply the embedded `migrations/postgres/*.sql` migrations.
+    /// Apply the embedded `migrations/postgres/*.sql` migrations and
+    /// then run TimescaleDB runtime gating via
+    /// [`PostgresBackend::apply_timescaledb_setup`].
     ///
     /// Idempotent — sqlx records applied versions in `_sqlx_migrations`,
     /// so calling this against an already-migrated database is a no-op.
+    /// `apply_timescaledb_setup` is also idempotent (it only logs +
+    /// branches on extension presence; the hypertable DDL is owned by
+    /// `0002_timescaledb_hypertables.sql`, which `IF NOT EXISTS`-guards
+    /// itself).
     ///
     /// # Errors
     ///
     /// Returns [`StorageError::MigrationFailed`] when any migration fails
     /// to apply or sqlx cannot verify previously-applied versions.
+    /// Returns [`StorageError::QueryFailed`] when the extension probe in
+    /// `apply_timescaledb_setup` fails (transport / permission).
     async fn migrate(&self) -> StorageResult<()> {
         sqlx::migrate!("./migrations/postgres")
             .run(&self.pool)
             .await
-            .map_err(|e| StorageError::MigrationFailed(e.to_string()))
+            .map_err(|e| StorageError::MigrationFailed(e.to_string()))?;
+        self.apply_timescaledb_setup(&self.timescale_config).await
     }
 
     /// Persist a single audit event.

--- a/aa-gateway/src/storage/postgres_config.rs
+++ b/aa-gateway/src/storage/postgres_config.rs
@@ -5,6 +5,8 @@
 //! S-H ships, the canonical type moves to `aa-core::config` and this module
 //! is expected to re-export it.
 
+use aa_core::config::TimescaleConfig;
+
 /// PostgreSQL connection settings.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PostgresConfig {
@@ -20,6 +22,10 @@ pub struct PostgresConfig {
     pub min_connections: u32,
     /// Seconds before `acquire` from the pool times out.
     pub connect_timeout_secs: u64,
+    /// TimescaleDB-specific knobs. `enabled = false` skips the hypertable
+    /// setup step in [`PostgresBackend::apply_timescaledb_setup`] (Epic 18
+    /// S-D #3); see [`aa_core::config::TimescaleConfig`].
+    pub timescaledb: TimescaleConfig,
 }
 
 impl Default for PostgresConfig {
@@ -29,6 +35,7 @@ impl Default for PostgresConfig {
             max_connections: 20,
             min_connections: 2,
             connect_timeout_secs: 10,
+            timescaledb: TimescaleConfig::default(),
         }
     }
 }
@@ -44,5 +51,6 @@ mod tests {
         assert_eq!(cfg.max_connections, 20);
         assert_eq!(cfg.min_connections, 2);
         assert_eq!(cfg.connect_timeout_secs, 10);
+        assert!(cfg.timescaledb.enabled, "timescaledb defaults to enabled");
     }
 }


### PR DESCRIPTION
## Description

Wires `aa_core::config::TimescaleConfig` through `PostgresBackend` and adds the `apply_timescaledb_setup` method that gates runtime behaviour across three paths, all returning `Ok(())`:

- **`config.enabled = false`** → `tracing::info!`, skip — operator opted out
- **extension absent on cluster** → `tracing::warn!`, skip — graceful fallback so plain PG deployments boot cleanly
- **extension present** → `tracing::info!` — hypertables already created by `0002_timescaledb_hypertables.sql` (SD-1)

`migrate()` now invokes `apply_timescaledb_setup(&self.timescale_config)` after the sqlx migrator runs, so every backend wired via `PostgresBackend::connect(...).migrate()` gets the gating for free.

This is **SD-3** of the AAASM-1586 (E18 S-D) sub-task series. Builds on SD-1 (PR #711, merged — migration SQL) and SD-2 (PR #741, merged — `TimescaleStats` + probe helper).

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

Local `PostgresConfig` gains a new `timescaledb: TimescaleConfig` field with `Default` matching the migration's static defaults (enabled = true, chunk_interval = "7 days", compression_policy = "30 days"). Existing call sites that build `PostgresConfig::default()` get the same behaviour for free; no manual struct construction in the repo today.

## Related Issues

- Related Jira ticket: [AAASM-1853](https://lightning-dust-mite.atlassian.net/browse/AAASM-1853) (parent Story: [AAASM-1586](https://lightning-dust-mite.atlassian.net/browse/AAASM-1586), Epic: [AAASM-1569](https://lightning-dust-mite.atlassian.net/browse/AAASM-1569))

## Testing

- [x] Unit tests added — three tests in `postgres.rs::tests`, one per path:
  - `apply_timescaledb_setup_skips_when_disabled` — runs whenever `AAASM_DATABASE_URL` is set; verifies opt-out
  - `apply_timescaledb_setup_warns_when_extension_absent` — runs in CI `Test` job (postgres:18-alpine); verifies graceful fallback
  - `apply_timescaledb_setup_succeeds_when_extension_active` — env-gated on `TIMESCALEDB_AVAILABLE=1`; auto-runs once SD-5 (AAASM-1858) ships the `timescaledb-tests` CI job
- [x] Local `cargo nextest run -p aa-gateway storage::postgres::tests::apply_timescaledb` is 3/3 PASS (skip paths)
- [x] Local pre-commit (fmt + clippy `-D warnings` + rustdoc) green

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed — `migrate()` doc-comment now mentions the TimescaleDB gating call; `apply_timescaledb_setup` has full `# Errors` + path-by-path documentation
- [ ] All CI checks passing — will validate on push
- [x] Commits are small and follow the Gitmoji convention (6 commits, one per logical unit)

## Commit log

1. `♻️ Thread TimescaleConfig through PostgresBackend::connect` (+ field on local `PostgresConfig`, transient `#[allow(dead_code)]`)
2. `✨ Add apply_timescaledb_setup method on PostgresBackend` (transient `#[allow(dead_code)]`)
3. `♻️ Call apply_timescaledb_setup after migrate` (drops both `allow(dead_code)`)
4. `✅ Test apply_timescaledb_setup enabled=false skip path`
5. `✅ Test apply_timescaledb_setup extension-absent path`
6. `✅ Test apply_timescaledb_setup extension-present path`

## Depends on

- SD-1 ([AAASM-1848](https://lightning-dust-mite.atlassian.net/browse/AAASM-1848)) — migration SQL (merged in #711)
- SD-2 ([AAASM-1852](https://lightning-dust-mite.atlassian.net/browse/AAASM-1852)) — `has_timescaledb_extension` probe (merged in #741)

[AAASM-1853]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ