### PR TITLE
[AAASM-1866] ✨ (settings): Add Retention Policy admin page + Settings shell

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -20,6 +20,12 @@ import { IdentityPage } from './pages/IdentityPage'
 import { TeamDetailPage } from './pages/TeamDetailPage'
 import { TeamsPage } from './pages/TeamsPage'
 import { ViolationHeatmapPage } from './pages/ViolationHeatmapPage'
+import {
+  SettingsLayout,
+  SettingsGeneralPlaceholder,
+  SettingsApiKeysPlaceholder,
+} from './pages/Settings'
+import { RetentionPolicyPage } from './pages/Settings/RetentionPolicy'
 
 function App() {
   return (
@@ -62,6 +68,14 @@ function App() {
 
             {/* ── First-run onboarding wizard (AAASM-1351) ────────────────── */}
             <Route path="/onboarding" element={<OnboardingPage />} />
+
+            {/* ── Settings — AAASM-1592 S-K ─────────────────────────────── */}
+            <Route path="/settings" element={<SettingsLayout />}>
+              <Route index element={<SettingsGeneralPlaceholder />} />
+              <Route path="general" element={<SettingsGeneralPlaceholder />} />
+              <Route path="api-keys" element={<SettingsApiKeysPlaceholder />} />
+              <Route path="storage/retention" element={<RetentionPolicyPage />} />
+            </Route>
           </Route>
         </Route>
         <Route path="*" element={<NotFoundPage />} />

--- a/dashboard/src/api/retention.ts
+++ b/dashboard/src/api/retention.ts
@@ -1,0 +1,51 @@
+// Retention-policy admin API client (AAASM-1592 S-K).
+//
+// Thin wrapper around the codegen'd openapi-fetch client. Surfaces the
+// three retention-policy operations as named functions so the page
+// component never touches `api.GET / api.PUT / api.POST` directly.
+
+import { api } from "./client";
+import type { components } from "./generated/schema";
+
+export type RetentionPolicyDocument = components["schemas"]["RetentionPolicyDocument"];
+export type UpdateRetentionPolicyRequest = components["schemas"]["UpdateRetentionPolicyRequest"];
+export type RetentionRunStatsDto = components["schemas"]["RetentionRunStatsDto"];
+export type ColdActionDto = components["schemas"]["ColdActionDto"];
+
+export interface RetentionPolicyClient {
+  get(): Promise<RetentionPolicyDocument>;
+  update(req: UpdateRetentionPolicyRequest): Promise<RetentionPolicyDocument>;
+  run(dryRun: boolean): Promise<RetentionRunStatsDto>;
+}
+
+export function createRetentionPolicyClient(): RetentionPolicyClient {
+  return {
+    async get() {
+      const { data, error } = await api.GET("/api/v1/admin/retention-policy");
+      if (error || !data) {
+        throw new Error(`retention policy GET failed: ${JSON.stringify(error ?? "no data")}`);
+      }
+      return data;
+    },
+    async update(req) {
+      const { data, error } = await api.PUT("/api/v1/admin/retention-policy", {
+        body: req,
+      });
+      if (error || !data) {
+        throw new Error(`retention policy PUT failed: ${JSON.stringify(error ?? "no data")}`);
+      }
+      return data;
+    },
+    async run(dryRun) {
+      const { data, error } = await api.POST("/api/v1/admin/retention-policy/run", {
+        body: { dry_run: dryRun },
+      });
+      if (error || !data) {
+        throw new Error(`retention policy run failed: ${JSON.stringify(error ?? "no data")}`);
+      }
+      return data;
+    },
+  };
+}
+
+export const retentionPolicyClient: RetentionPolicyClient = createRetentionPolicyClient();

--- a/dashboard/src/components/AppShell.css
+++ b/dashboard/src/components/AppShell.css
@@ -123,6 +123,22 @@
   background: var(--shell-button-hover-bg);
 }
 
+.appshell__settings-link {
+  margin-left: 0.75rem;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: 0.25rem;
+  border: 1px solid var(--shell-button-border);
+  background: none;
+  cursor: pointer;
+  color: var(--shell-text-dim);
+  text-decoration: none;
+}
+
+.appshell__settings-link:hover {
+  background: var(--shell-button-hover-bg);
+}
+
 .appshell__content {
   flex: 1;
   overflow: auto;

--- a/dashboard/src/components/AppShell.tsx
+++ b/dashboard/src/components/AppShell.tsx
@@ -109,6 +109,14 @@ export function AppShell() {
           <div className="appshell__user">
             <ApprovalsBellButton />
             <span data-testid="appshell-user">{token ?? ''}</span>
+            <NavLink
+              to="/settings"
+              className="appshell__settings-link"
+              data-testid="topbar-settings-link"
+              aria-label="Settings"
+            >
+              ⚙ Settings
+            </NavLink>
             <button
               className="appshell__logout"
               data-testid="logout-btn"

--- a/dashboard/src/pages/Settings/RetentionPolicy.test.tsx
+++ b/dashboard/src/pages/Settings/RetentionPolicy.test.tsx
@@ -1,0 +1,246 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { RetentionPolicyPage } from './RetentionPolicy'
+import type {
+  RetentionPolicyClient,
+  RetentionPolicyDocument,
+  RetentionRunStatsDto,
+  UpdateRetentionPolicyRequest,
+} from '../../api/retention'
+
+function makeDoc(overrides: Partial<RetentionPolicyDocument> = {}): RetentionPolicyDocument {
+  return {
+    hot_days: 30,
+    warm_days: 90,
+    cold_action: 'drop',
+    archive_url: null,
+    dry_run: false,
+    schedule: '0 0 3 * * *',
+    last_run: null,
+    ...overrides,
+  }
+}
+
+function makeStats(overrides: Partial<RetentionRunStatsDto> = {}): RetentionRunStatsDto {
+  return {
+    ran_at: '2026-05-20T03:00:12Z',
+    hot_rows: 1234,
+    compressed_rows: 1452,
+    archived_rows: 0,
+    dropped_rows: 388,
+    freed_bytes: 127 * 1024 * 1024,
+    dry_run: false,
+    ...overrides,
+  }
+}
+
+interface FakeClientOptions {
+  initialDoc?: RetentionPolicyDocument
+  updateError?: string
+  runError?: string
+  runResult?: RetentionRunStatsDto
+}
+
+interface FakeClient extends RetentionPolicyClient {
+  calls: {
+    get: number
+    update: UpdateRetentionPolicyRequest[]
+    run: boolean[]
+  }
+}
+
+function makeFakeClient(options: FakeClientOptions = {}): FakeClient {
+  const initialDoc = options.initialDoc ?? makeDoc()
+  let currentDoc = initialDoc
+  const calls = { get: 0, update: [] as UpdateRetentionPolicyRequest[], run: [] as boolean[] }
+  return {
+    calls,
+    async get() {
+      calls.get += 1
+      return structuredClone(currentDoc)
+    },
+    async update(req) {
+      calls.update.push(req)
+      if (options.updateError) throw new Error(options.updateError)
+      currentDoc = {
+        ...currentDoc,
+        hot_days: req.hot_days,
+        warm_days: req.warm_days,
+        cold_action: req.cold_action,
+        archive_url: req.archive_url ?? null,
+      }
+      return structuredClone(currentDoc)
+    },
+    async run(dryRun) {
+      calls.run.push(dryRun)
+      if (options.runError) throw new Error(options.runError)
+      const stats = options.runResult ?? makeStats({ dry_run: dryRun })
+      currentDoc = { ...currentDoc, last_run: stats }
+      return structuredClone(stats)
+    },
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('RetentionPolicyPage', () => {
+  it('renders the loading state then the current config', async () => {
+    const client = makeFakeClient({ initialDoc: makeDoc({ hot_days: 15, warm_days: 60 }) })
+    render(<RetentionPolicyPage client={client} />)
+
+    expect(screen.getByTestId('retention-policy-loading')).toBeInTheDocument()
+
+    const hotInput = await screen.findByTestId<HTMLInputElement>('retention-policy-hot-days')
+    expect(hotInput.value).toBe('15')
+    const warmInput = screen.getByTestId<HTMLInputElement>('retention-policy-warm-days')
+    expect(warmInput.value).toBe('60')
+    expect(client.calls.get).toBe(1)
+  })
+
+  it('shows the empty-state when there is no last run', async () => {
+    const client = makeFakeClient()
+    render(<RetentionPolicyPage client={client} />)
+
+    expect(await screen.findByTestId('retention-policy-last-run-empty')).toBeInTheDocument()
+  })
+
+  it('shows last-run stats when the GET response carries them', async () => {
+    const client = makeFakeClient({
+      initialDoc: makeDoc({ last_run: makeStats({ hot_rows: 5_000, dropped_rows: 200 }) }),
+    })
+    render(<RetentionPolicyPage client={client} />)
+
+    expect(await screen.findByTestId('retention-policy-stat-hot')).toHaveTextContent('5,000')
+    expect(screen.getByTestId('retention-policy-stat-dropped')).toHaveTextContent('200')
+    expect(screen.queryByTestId('retention-policy-last-run-empty')).toBeNull()
+  })
+
+  it('disables Save and shows the warm_days <= hot_days error when invalid', async () => {
+    const user = userEvent.setup()
+    const client = makeFakeClient()
+    render(<RetentionPolicyPage client={client} />)
+
+    const warmInput = await screen.findByTestId<HTMLInputElement>('retention-policy-warm-days')
+    await user.clear(warmInput)
+    await user.type(warmInput, '30')
+
+    expect(screen.getByTestId('retention-policy-warm-days-error')).toBeInTheDocument()
+    expect(screen.getByTestId<HTMLButtonElement>('retention-policy-save')).toBeDisabled()
+  })
+
+  it('shows the archive_url required error when cold_action switches to archive', async () => {
+    const user = userEvent.setup()
+    const client = makeFakeClient()
+    render(<RetentionPolicyPage client={client} />)
+
+    const select = await screen.findByTestId<HTMLSelectElement>('retention-policy-cold-action')
+    await user.selectOptions(select, 'archive')
+
+    expect(screen.getByTestId('retention-policy-archive-field')).toBeInTheDocument()
+    expect(screen.getByTestId('retention-policy-archive-url-error')).toHaveTextContent(
+      /required when cold_action is "archive"/,
+    )
+    expect(screen.getByTestId<HTMLButtonElement>('retention-policy-save')).toBeDisabled()
+  })
+
+  it('rejects archive_url values that lack a s3:// or gs:// prefix', async () => {
+    const user = userEvent.setup()
+    const client = makeFakeClient()
+    render(<RetentionPolicyPage client={client} />)
+
+    const select = await screen.findByTestId<HTMLSelectElement>('retention-policy-cold-action')
+    await user.selectOptions(select, 'archive')
+
+    const urlInput = await screen.findByTestId<HTMLInputElement>('retention-policy-archive-url')
+    await user.type(urlInput, 'https://example.com/bucket')
+
+    expect(screen.getByTestId('retention-policy-archive-url-error')).toHaveTextContent(/s3:\/\/ or gs:\/\//)
+    expect(screen.getByTestId<HTMLButtonElement>('retention-policy-save')).toBeDisabled()
+  })
+
+  it('Save Changes fires PUT with the edited values and renders a success status', async () => {
+    const user = userEvent.setup()
+    const client = makeFakeClient()
+    render(<RetentionPolicyPage client={client} />)
+
+    const hotInput = await screen.findByTestId<HTMLInputElement>('retention-policy-hot-days')
+    await user.clear(hotInput)
+    await user.type(hotInput, '15')
+
+    const saveBtn = screen.getByTestId<HTMLButtonElement>('retention-policy-save')
+    expect(saveBtn).not.toBeDisabled()
+    await user.click(saveBtn)
+
+    await waitFor(() => {
+      expect(client.calls.update.length).toBe(1)
+    })
+    expect(client.calls.update[0]?.hot_days).toBe(15)
+    expect(client.calls.update[0]?.warm_days).toBe(90)
+    expect(client.calls.update[0]?.cold_action).toBe('drop')
+
+    await waitFor(() => {
+      expect(screen.getByTestId('retention-policy-status').textContent).toMatch(/updated/i)
+    })
+  })
+
+  it('renders an error status when Save fails', async () => {
+    const user = userEvent.setup()
+    const client = makeFakeClient({ updateError: 'gateway rejected' })
+    render(<RetentionPolicyPage client={client} />)
+
+    const saveBtn = await screen.findByTestId<HTMLButtonElement>('retention-policy-save')
+    await user.click(saveBtn)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('retention-policy-status').textContent).toMatch(/Save failed/i)
+    })
+  })
+
+  it('Run Now (Dry Run) calls run(true) and renders the returned stats', async () => {
+    const user = userEvent.setup()
+    const client = makeFakeClient({ runResult: makeStats({ hot_rows: 9_999, dry_run: true }) })
+    render(<RetentionPolicyPage client={client} />)
+
+    const dryRunBtn = await screen.findByTestId<HTMLButtonElement>('retention-policy-dry-run')
+    await user.click(dryRunBtn)
+
+    await waitFor(() => {
+      expect(client.calls.run).toEqual([true])
+    })
+    expect(await screen.findByTestId('retention-policy-stat-hot')).toHaveTextContent('9,999')
+    expect(screen.getByTestId('retention-policy-last-run-dry-run-tag')).toBeInTheDocument()
+  })
+
+  it('Run Now (non-dry) calls run(false)', async () => {
+    const user = userEvent.setup()
+    const client = makeFakeClient()
+    render(<RetentionPolicyPage client={client} />)
+
+    const runBtn = await screen.findByTestId<HTMLButtonElement>('retention-policy-run')
+    await user.click(runBtn)
+
+    await waitFor(() => {
+      expect(client.calls.run).toEqual([false])
+    })
+  })
+
+  it('shows a load error when GET fails', async () => {
+    const client: RetentionPolicyClient = {
+      async get() {
+        throw new Error('boom')
+      },
+      async update() {
+        throw new Error('unreachable')
+      },
+      async run() {
+        throw new Error('unreachable')
+      },
+    }
+    render(<RetentionPolicyPage client={client} />)
+
+    expect(await screen.findByTestId('retention-policy-load-error')).toHaveTextContent(/boom/)
+  })
+})

--- a/dashboard/src/pages/Settings/RetentionPolicy.tsx
+++ b/dashboard/src/pages/Settings/RetentionPolicy.tsx
@@ -1,0 +1,368 @@
+// Settings → Storage → Retention Policy page (AAASM-1592 S-K).
+//
+// Implements the layout in the parent story description:
+//   * Hot tier / Warm tier number inputs
+//   * Cold tier action dropdown (Drop / Archive)
+//   * Archive URL input (shown only when cold action = Archive)
+//   * Save Changes / Run Now (Dry Run) / Run Now action buttons
+//   * Last retention run summary panel
+//
+// Client-side validation runs synchronously on every render; the
+// server-side validation in aa-api enforces the same rules so a stale
+// client cannot bypass them.
+
+import { useEffect, useMemo, useState } from 'react'
+import {
+  retentionPolicyClient,
+  type ColdActionDto,
+  type RetentionPolicyDocument,
+  type RetentionRunStatsDto,
+  type UpdateRetentionPolicyRequest,
+} from '../../api/retention'
+
+interface FormErrors {
+  hot_days?: string
+  warm_days?: string
+  archive_url?: string
+}
+
+function validate(req: UpdateRetentionPolicyRequest): FormErrors {
+  const errors: FormErrors = {}
+  if (!Number.isFinite(req.hot_days) || req.hot_days < 1) {
+    errors.hot_days = 'hot_days must be ≥ 1'
+  }
+  if (!Number.isFinite(req.warm_days) || req.warm_days <= req.hot_days) {
+    errors.warm_days = 'warm_days must be strictly greater than hot_days'
+  }
+  if (req.cold_action === 'archive') {
+    const url = (req.archive_url ?? '').trim()
+    if (!url) {
+      errors.archive_url = 'archive_url is required when cold_action is "archive"'
+    } else if (!/^s3:\/\//.test(url) && !/^gs:\/\//.test(url)) {
+      errors.archive_url = 'archive_url must start with s3:// or gs://'
+    }
+  }
+  return errors
+}
+
+function docToFormState(doc: RetentionPolicyDocument): UpdateRetentionPolicyRequest {
+  return {
+    hot_days: doc.hot_days,
+    warm_days: doc.warm_days,
+    cold_action: doc.cold_action,
+    archive_url: doc.archive_url ?? '',
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+  return `${(bytes / 1024 / 1024 / 1024).toFixed(2)} GB`
+}
+
+interface RetentionPolicyPageProps {
+  /** Test seam — defaults to the live `retentionPolicyClient`. */
+  client?: typeof retentionPolicyClient
+}
+
+export function RetentionPolicyPage({ client = retentionPolicyClient }: RetentionPolicyPageProps = {}) {
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [doc, setDoc] = useState<RetentionPolicyDocument | null>(null)
+  const [form, setForm] = useState<UpdateRetentionPolicyRequest | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [running, setRunning] = useState(false)
+  const [statusMsg, setStatusMsg] = useState<{ kind: 'success' | 'error'; text: string } | null>(null)
+  const [lastRun, setLastRun] = useState<RetentionRunStatsDto | null>(null)
+
+  // Initial load
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    client
+      .get()
+      .then((d) => {
+        if (cancelled) return
+        setDoc(d)
+        setForm(docToFormState(d))
+        setLastRun(d.last_run ?? null)
+        setLoadError(null)
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return
+        setLoadError(String(e))
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [client])
+
+  const errors = useMemo(() => (form ? validate(form) : {}), [form])
+  const hasErrors = Object.keys(errors).length > 0
+
+  function updateField<K extends keyof UpdateRetentionPolicyRequest>(
+    key: K,
+    value: UpdateRetentionPolicyRequest[K],
+  ) {
+    setForm((prev) => (prev ? { ...prev, [key]: value } : prev))
+    setStatusMsg(null)
+  }
+
+  async function handleSave() {
+    if (!form || hasErrors) return
+    setSaving(true)
+    setStatusMsg(null)
+    try {
+      const body: UpdateRetentionPolicyRequest = {
+        hot_days: form.hot_days,
+        warm_days: form.warm_days,
+        cold_action: form.cold_action,
+        archive_url: form.cold_action === 'archive' ? (form.archive_url ?? '').trim() : null,
+      }
+      const updated = await client.update(body)
+      setDoc(updated)
+      setForm(docToFormState(updated))
+      setLastRun(updated.last_run ?? null)
+      setStatusMsg({ kind: 'success', text: 'Retention policy updated.' })
+    } catch (e: unknown) {
+      setStatusMsg({ kind: 'error', text: `Save failed: ${String(e)}` })
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleRun(dryRun: boolean) {
+    setRunning(true)
+    setStatusMsg(null)
+    try {
+      const stats = await client.run(dryRun)
+      setLastRun(stats)
+      setStatusMsg({
+        kind: 'success',
+        text: dryRun ? 'Dry run complete.' : 'Retention run complete.',
+      })
+    } catch (e: unknown) {
+      setStatusMsg({ kind: 'error', text: `Run failed: ${String(e)}` })
+    } finally {
+      setRunning(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <section className="retention-policy" data-testid="retention-policy-page">
+        <h1>Retention Policy</h1>
+        <div className="retention-policy__loading" data-testid="retention-policy-loading">
+          Loading current retention policy…
+        </div>
+      </section>
+    )
+  }
+
+  if (loadError || !form || !doc) {
+    return (
+      <section className="retention-policy" data-testid="retention-policy-page">
+        <h1>Retention Policy</h1>
+        <div
+          className="retention-policy__status retention-policy__status--error"
+          data-testid="retention-policy-load-error"
+        >
+          Could not load retention policy: {loadError ?? 'unknown error'}
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    <section className="retention-policy" data-testid="retention-policy-page">
+      <h1>Retention Policy</h1>
+      <p>
+        Audit and metric rows are partitioned into <strong>hot</strong>, <strong>warm</strong>, and <strong>cold</strong>{' '}
+        tiers. Hot rows stay indexed for fast queries; warm rows are compressed where the backend supports it; cold rows
+        are dropped or archived to an object store. Changes apply immediately — the gateway does not need a restart.
+      </p>
+
+      <div className="retention-policy__field">
+        <label htmlFor="hot_days" className="retention-policy__field-label">
+          Hot tier (days)
+        </label>
+        <p className="retention-policy__field-help">Fully indexed, fast queries.</p>
+        <input
+          id="hot_days"
+          name="hot_days"
+          type="number"
+          min={1}
+          className={`retention-policy__input${errors.hot_days ? ' retention-policy__input--error' : ''}`}
+          value={form.hot_days}
+          onChange={(e) => updateField('hot_days', Number(e.target.value))}
+          data-testid="retention-policy-hot-days"
+          aria-invalid={Boolean(errors.hot_days)}
+        />
+        {errors.hot_days && (
+          <div className="retention-policy__field-error" data-testid="retention-policy-hot-days-error">
+            {errors.hot_days}
+          </div>
+        )}
+      </div>
+
+      <div className="retention-policy__field">
+        <label htmlFor="warm_days" className="retention-policy__field-label">
+          Warm tier (days)
+        </label>
+        <p className="retention-policy__field-help">Compressed, slower queries. Must be greater than hot tier.</p>
+        <input
+          id="warm_days"
+          name="warm_days"
+          type="number"
+          min={1}
+          className={`retention-policy__input${errors.warm_days ? ' retention-policy__input--error' : ''}`}
+          value={form.warm_days}
+          onChange={(e) => updateField('warm_days', Number(e.target.value))}
+          data-testid="retention-policy-warm-days"
+          aria-invalid={Boolean(errors.warm_days)}
+        />
+        {errors.warm_days && (
+          <div className="retention-policy__field-error" data-testid="retention-policy-warm-days-error">
+            {errors.warm_days}
+          </div>
+        )}
+      </div>
+
+      <div className="retention-policy__field">
+        <label htmlFor="cold_action" className="retention-policy__field-label">
+          Cold tier action
+        </label>
+        <select
+          id="cold_action"
+          name="cold_action"
+          className="retention-policy__select"
+          value={form.cold_action}
+          onChange={(e) => updateField('cold_action', e.target.value as ColdActionDto)}
+          data-testid="retention-policy-cold-action"
+        >
+          <option value="drop">Drop</option>
+          <option value="archive">Archive to S3</option>
+        </select>
+      </div>
+
+      {form.cold_action === 'archive' && (
+        <div className="retention-policy__field" data-testid="retention-policy-archive-field">
+          <label htmlFor="archive_url" className="retention-policy__field-label">
+            Archive URL
+          </label>
+          <p className="retention-policy__field-help">Must start with s3:// or gs://</p>
+          <input
+            id="archive_url"
+            name="archive_url"
+            type="text"
+            className={`retention-policy__input${errors.archive_url ? ' retention-policy__input--error' : ''}`}
+            value={form.archive_url ?? ''}
+            onChange={(e) => updateField('archive_url', e.target.value)}
+            placeholder="s3://my-bucket/aasm-archive/"
+            data-testid="retention-policy-archive-url"
+            aria-invalid={Boolean(errors.archive_url)}
+          />
+          {errors.archive_url && (
+            <div className="retention-policy__field-error" data-testid="retention-policy-archive-url-error">
+              {errors.archive_url}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div className="retention-policy__actions">
+        <button
+          type="button"
+          className="retention-policy__button retention-policy__button--primary"
+          onClick={handleSave}
+          disabled={hasErrors || saving || running}
+          data-testid="retention-policy-save"
+        >
+          {saving ? 'Saving…' : 'Save Changes'}
+        </button>
+        <button
+          type="button"
+          className="retention-policy__button"
+          onClick={() => handleRun(true)}
+          disabled={saving || running}
+          data-testid="retention-policy-dry-run"
+        >
+          {running ? 'Running…' : 'Run Now (Dry Run)'}
+        </button>
+        <button
+          type="button"
+          className="retention-policy__button"
+          onClick={() => handleRun(false)}
+          disabled={saving || running}
+          data-testid="retention-policy-run"
+        >
+          {running ? 'Running…' : 'Run Now'}
+        </button>
+      </div>
+
+      {statusMsg && (
+        <div
+          className={`retention-policy__status retention-policy__status--${statusMsg.kind}`}
+          data-testid="retention-policy-status"
+          role={statusMsg.kind === 'error' ? 'alert' : 'status'}
+        >
+          {statusMsg.text}
+        </div>
+      )}
+
+      <div className="retention-policy__last-run" data-testid="retention-policy-last-run">
+        <h2>Last retention run</h2>
+        {lastRun ? (
+          <>
+            <p>
+              Ran at: <strong>{new Date(lastRun.ran_at).toUTCString()}</strong>
+              {lastRun.dry_run && (
+                <span data-testid="retention-policy-last-run-dry-run-tag"> (dry run)</span>
+              )}
+            </p>
+            <div className="retention-policy__stat-grid">
+              <div>
+                <div className="retention-policy__stat-label">Hot rows</div>
+                <div className="retention-policy__stat-value" data-testid="retention-policy-stat-hot">
+                  {lastRun.hot_rows.toLocaleString()}
+                </div>
+              </div>
+              <div>
+                <div className="retention-policy__stat-label">Compressed</div>
+                <div className="retention-policy__stat-value" data-testid="retention-policy-stat-compressed">
+                  {lastRun.compressed_rows.toLocaleString()}
+                </div>
+              </div>
+              <div>
+                <div className="retention-policy__stat-label">Archived</div>
+                <div className="retention-policy__stat-value" data-testid="retention-policy-stat-archived">
+                  {lastRun.archived_rows.toLocaleString()}
+                </div>
+              </div>
+              <div>
+                <div className="retention-policy__stat-label">Dropped</div>
+                <div className="retention-policy__stat-value" data-testid="retention-policy-stat-dropped">
+                  {lastRun.dropped_rows.toLocaleString()}
+                </div>
+              </div>
+              <div>
+                <div className="retention-policy__stat-label">Freed</div>
+                <div className="retention-policy__stat-value" data-testid="retention-policy-stat-freed">
+                  {formatBytes(lastRun.freed_bytes)}
+                </div>
+              </div>
+            </div>
+          </>
+        ) : (
+          <p className="retention-policy__last-run-empty" data-testid="retention-policy-last-run-empty">
+            No retention run has completed yet.
+          </p>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/dashboard/src/pages/Settings/RetentionPolicy.tsx
+++ b/dashboard/src/pages/Settings/RetentionPolicy.tsx
@@ -76,10 +76,12 @@ export function RetentionPolicyPage({ client = retentionPolicyClient }: Retentio
   const [statusMsg, setStatusMsg] = useState<{ kind: 'success' | 'error'; text: string } | null>(null)
   const [lastRun, setLastRun] = useState<RetentionRunStatsDto | null>(null)
 
-  // Initial load
+  // Initial load. `loading` starts true (initial state) so the loading
+  // panel renders before this effect resolves. We intentionally do not
+  // set it back to true on client-prop changes — the live singleton
+  // never changes mid-mount; tests re-mount the component to swap.
   useEffect(() => {
     let cancelled = false
-    setLoading(true)
     client
       .get()
       .then((d) => {

--- a/dashboard/src/pages/Settings/Settings.css
+++ b/dashboard/src/pages/Settings/Settings.css
@@ -1,0 +1,183 @@
+/* Settings shell — two-column layout with a fixed-width left nav. */
+
+.settings-page {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  min-height: calc(100vh - 4rem);
+}
+
+.settings-page__nav {
+  border-right: 1px solid var(--color-border, #e2e2e7);
+  padding-right: 1rem;
+}
+
+.settings-page__nav-title {
+  margin: 0 0 1rem 0;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted, #6b6b76);
+}
+
+.settings-page__nav-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.settings-page__nav-list li + li {
+  margin-top: 0.25rem;
+}
+
+.settings-page__nav-section {
+  margin: 1rem 0 0.25rem 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-muted, #6b6b76);
+}
+
+.settings-page__nav-link {
+  display: block;
+  padding: 0.4rem 0.6rem;
+  color: inherit;
+  text-decoration: none;
+  border-radius: 4px;
+  font-size: 0.95rem;
+}
+
+.settings-page__nav-link:hover {
+  background-color: var(--color-bg-hover, #f3f3f6);
+}
+
+.settings-page__nav-link--active {
+  background-color: var(--color-bg-active, #e7ecf2);
+  font-weight: 600;
+}
+
+.settings-page__panel {
+  padding: 0 0.5rem;
+}
+
+/* Retention Policy page — form layout. */
+
+.retention-policy {
+  max-width: 640px;
+}
+
+.retention-policy__field {
+  margin-bottom: 1.25rem;
+}
+
+.retention-policy__field-label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.retention-policy__field-help {
+  color: var(--color-text-muted, #6b6b76);
+  font-size: 0.85rem;
+  margin: 0.25rem 0 0.5rem 0;
+}
+
+.retention-policy__input,
+.retention-policy__select {
+  padding: 0.45rem 0.6rem;
+  border: 1px solid var(--color-border, #d4d4d8);
+  border-radius: 4px;
+  font-size: 0.95rem;
+  min-width: 14rem;
+}
+
+.retention-policy__input--error,
+.retention-policy__select--error {
+  border-color: var(--color-danger, #c54242);
+}
+
+.retention-policy__field-error {
+  color: var(--color-danger, #c54242);
+  font-size: 0.85rem;
+  margin-top: 0.25rem;
+}
+
+.retention-policy__actions {
+  display: flex;
+  gap: 0.75rem;
+  margin: 1.5rem 0;
+}
+
+.retention-policy__button {
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--color-border, #d4d4d8);
+  border-radius: 4px;
+  background-color: var(--color-bg-button, #f6f6f9);
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+.retention-policy__button--primary {
+  background-color: var(--color-primary, #2563eb);
+  color: white;
+  border-color: var(--color-primary, #2563eb);
+}
+
+.retention-policy__button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.retention-policy__last-run {
+  margin-top: 2rem;
+  border-top: 1px solid var(--color-border, #e2e2e7);
+  padding-top: 1rem;
+}
+
+.retention-policy__last-run-empty {
+  color: var(--color-text-muted, #6b6b76);
+  font-style: italic;
+}
+
+.retention-policy__stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.5rem 1.5rem;
+  margin-top: 0.5rem;
+}
+
+.retention-policy__stat-label {
+  color: var(--color-text-muted, #6b6b76);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.retention-policy__stat-value {
+  font-variant-numeric: tabular-nums;
+  font-size: 1rem;
+}
+
+.retention-policy__status {
+  margin: 1rem 0;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  font-size: 0.9rem;
+}
+
+.retention-policy__status--success {
+  background-color: var(--color-bg-success, #e7f6ec);
+  color: var(--color-success, #237a3b);
+}
+
+.retention-policy__status--error {
+  background-color: var(--color-bg-danger, #faecec);
+  color: var(--color-danger, #9d2222);
+}
+
+.retention-policy__loading {
+  color: var(--color-text-muted, #6b6b76);
+  font-style: italic;
+  padding: 1rem 0;
+}

--- a/dashboard/src/pages/Settings/index.tsx
+++ b/dashboard/src/pages/Settings/index.tsx
@@ -1,0 +1,82 @@
+// Settings shell — left-rail sub-navigation rendering the active child
+// route in the main panel. Currently surfaces the Storage → Retention
+// Policy entry (AAASM-1592 S-K); General and API Keys are placeholders
+// for future sub-tickets so the IA shape is complete on landing.
+
+import { NavLink, Outlet } from 'react-router-dom'
+import './Settings.css'
+
+interface SettingsNavEntry {
+  id: string
+  label: string
+  to: string
+  section?: string
+}
+
+const SETTINGS_NAV: SettingsNavEntry[] = [
+  { id: 'general', label: 'General', to: '/settings/general' },
+  { id: 'api-keys', label: 'API Keys', to: '/settings/api-keys' },
+  {
+    id: 'storage-retention',
+    label: 'Retention Policy',
+    to: '/settings/storage/retention',
+    section: 'Storage',
+  },
+]
+
+export function SettingsLayout() {
+  return (
+    <main className="settings-page" data-testid="settings-page">
+      <aside className="settings-page__nav" data-testid="settings-nav">
+        <h2 className="settings-page__nav-title">Settings</h2>
+        <ul className="settings-page__nav-list">
+          {SETTINGS_NAV.map((entry) => (
+            <li key={entry.id}>
+              {entry.section && (
+                <div
+                  className="settings-page__nav-section"
+                  data-testid={`settings-nav-section-${entry.section.toLowerCase()}`}
+                >
+                  {entry.section}
+                </div>
+              )}
+              <NavLink
+                to={entry.to}
+                className={({ isActive }) =>
+                  `settings-page__nav-link${isActive ? ' settings-page__nav-link--active' : ''}`
+                }
+                data-testid={`settings-nav-link-${entry.id}`}
+              >
+                {entry.label}
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      </aside>
+      <section className="settings-page__panel">
+        <Outlet />
+      </section>
+    </main>
+  )
+}
+
+export function SettingsGeneralPlaceholder() {
+  return (
+    <section data-testid="settings-general-placeholder">
+      <h1>General</h1>
+      <p>General workspace settings land in a follow-up sub-ticket.</p>
+    </section>
+  )
+}
+
+export function SettingsApiKeysPlaceholder() {
+  return (
+    <section data-testid="settings-api-keys-placeholder">
+      <h1>API Keys</h1>
+      <p>
+        API key management already lives at <NavLink to="/identity">Identity</NavLink>; a Settings-scoped redirect
+        consolidates the entry-point in a follow-up sub-ticket.
+      </p>
+    </section>
+  )
+}


### PR DESCRIPTION
## Description

Ships the dashboard surface for the AAASM-1592 (E18 S-K) admin REST endpoints landed in AAASM-1861:

* New top-level **Settings** shell at `/settings` with a left-rail sub-nav (General / API Keys placeholders + a Storage section)
* New **Retention Policy** page at `/settings/storage/retention` consuming the codegen'd OpenAPI types
* New `⚙ Settings` link in the AppShell topbar so the page is reachable from anywhere

The Retention Policy page implements the exact layout in the story description: hot / warm number inputs, cold tier dropdown (Drop / Archive to S3), conditional Archive URL input, three action buttons (Save Changes / Run Now (Dry Run) / Run Now), and a "Last retention run" panel.

Client-side validation enforces the same rules as the gateway:

| Field | Rule |
|---|---|
| `hot_days` | &ge; 1 |
| `warm_days` | &gt; `hot_days` |
| `archive_url` | required when `cold_action = "archive"`; must start with `s3://` or `gs://` |

Save is disabled while invalid; all buttons are disabled mid-request. Success / error after every action surfaces in a coloured status banner.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

Pure additive — new routes, new components, no changes to existing pages.

## Related Issues

- Related Jira ticket: [AAASM-1866](https://lightning-dust-mite.atlassian.net/browse/AAASM-1866) — `[4/6]` sub-ticket of [AAASM-1592](https://lightning-dust-mite.atlassian.net/browse/AAASM-1592)
- Depends on (merged): AAASM-1861 (admin REST endpoints + codegen schema)

## Testing

- [x] Unit tests added

`dashboard/src/pages/Settings/RetentionPolicy.test.tsx` — 11 vitest cases via a fake `RetentionPolicyClient` injected through a test seam:

| Test | Behaviour |
|---|---|
| `renders the loading state then the current config` | GET happy path → loaded values match |
| `shows the empty-state when there is no last run` | `last_run: null` initial state |
| `shows last-run stats when the GET response carries them` | Stats panel populated on mount |
| `disables Save and shows the warm_days <= hot_days error when invalid` | Validation: warm_days |
| `shows the archive_url required error when cold_action switches to archive` | Validation: archive missing URL |
| `rejects archive_url values that lack a s3:// or gs:// prefix` | Validation: scheme prefix |
| `Save Changes fires PUT with the edited values and renders a success status` | PUT happy path |
| `renders an error status when Save fails` | PUT error path |
| `Run Now (Dry Run) calls run(true) and renders the returned stats` | POST dry-run + stats refresh |
| `Run Now (non-dry) calls run(false)` | POST non-dry |
| `shows a load error when GET fails` | Initial-load failure mode |

**Local validation**:
- `pnpm --dir dashboard test --run` — **993/993** tests pass (115 test files, includes 11 new)
- `pnpm --dir dashboard type-check` — clean
- `pnpm --dir dashboard lint` — clean (zero warnings, `--max-warnings 0`)

## Commits (6, GitEmoji granular)

1. ✨ (api/retention): Add retention-policy admin client wrapper
2. ✨ (pages/Settings): Add Settings shell with left-rail sub-nav
3. ✨ (pages/Settings): Add RetentionPolicy page with form + actions
4. ✨ (App): Mount /settings routes
5. ✅ (pages/Settings): Unit tests for RetentionPolicyPage
6. ✨ (AppShell): Add Settings link to topbar user area

## Checklist

- [x] Code follows project style guidelines (`pnpm lint`, `pnpm type-check`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (page-level + section-level explanatory copy)
- [ ] All CI checks passing — pending
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1866]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ