### PR TITLE
[AAASM-1564] ✨ (aa-gateway): Wire observe mode end-to-end + 4 ST-SANDBOX integration tests

### DIFF
--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -26,7 +26,9 @@ use crate::approval::db_escalation_scheduler::DbEscalationScheduler;
 use crate::approval::escalation::EscalationScheduler;
 use crate::approval::router::ApprovalRouter;
 use crate::approval::routing_config::RoutingConfigStore;
-use crate::engine::{DenyAction, EvaluationResult, PolicyEngine};
+use crate::engine::{
+    resolve_enforcement_mode, transform_for_observe_mode, DenyAction, EvaluationResult, PolicyEngine, ShadowEvent,
+};
 use crate::ops::{OpsRegistry, SharedOpControlPublisher};
 use crate::registry::convert::proto_agent_id_to_key;
 use crate::registry::{AgentRegistry, SuspendReason};
@@ -243,6 +245,21 @@ impl PolicyServiceImpl {
     pub fn with_ops_publisher(mut self, publisher: SharedOpControlPublisher) -> Self {
         self.ops_publisher = Some(publisher);
         self
+    }
+
+    /// Look up the per-agent `enforcement_mode` override for the request's agent.
+    ///
+    /// Returns `Some(_)` when the request's agent is registered AND its record
+    /// carries an explicit override; `None` in every other case (no registry
+    /// attached, agent unregistered, agent registered with no override). The
+    /// resolver in [`crate::engine::resolve_enforcement_mode`] treats `None` as
+    /// "inherit from policy default", so an unknown / unregistered agent
+    /// transparently falls back to live enforcement.
+    fn lookup_agent_enforcement_override(&self, req: &CheckActionRequest) -> Option<aa_core::EnforcementMode> {
+        let registry = self.registry.as_ref()?;
+        let proto_agent = req.agent_id.as_ref()?;
+        let agent_key = proto_agent_id_to_key(proto_agent);
+        registry.get(&agent_key)?.enforcement_mode
     }
 
     /// Evaluate a single request against the engine, returning the raw
@@ -612,7 +629,18 @@ impl PolicyServiceImpl {
     /// Build an `AuditEntry` from a request and evaluation result, then fire-and-forget
     /// via `try_send`. Maintains the hash chain by reading and updating `last_hash`.
     /// Never blocks the caller beyond the brief mutex acquisition.
-    async fn record_audit(&self, req: &CheckActionRequest, response: &CheckActionResponse, eval: &EvaluationResult) {
+    ///
+    /// When `shadow` is `Some`, observe-mode evaluation suppressed a non-Allow
+    /// decision; the payload carries `dry_run: true` plus the original
+    /// `shadow_decision` and matched rule so the audit reader can render the
+    /// would-be event distinctly from live enforcement records.
+    async fn record_audit(
+        &self,
+        req: &CheckActionRequest,
+        response: &CheckActionResponse,
+        eval: &EvaluationResult,
+        shadow: Option<&ShadowEvent>,
+    ) {
         let proto_agent = match req.agent_id.as_ref() {
             Some(a) => a,
             None => return, // No agent identity — cannot construct entry.
@@ -623,13 +651,25 @@ impl PolicyServiceImpl {
         let timestamp_ns = Timestamp::from(SystemTime::now()).as_nanos();
         let seq = self.seq.fetch_add(1, Ordering::Relaxed);
 
-        let payload = serde_json::json!({
-            "action_type": req.action_type,
-            "decision": response.decision,
-            "reason": &response.reason,
-            "policy_rule": &response.policy_rule,
-            "latency_us": response.decision_latency_us,
-        })
+        let payload = match shadow {
+            Some(s) => serde_json::json!({
+                "action_type": req.action_type,
+                "decision": response.decision,
+                "reason": &response.reason,
+                "policy_rule": &response.policy_rule,
+                "latency_us": response.decision_latency_us,
+                "dry_run": true,
+                "shadow_decision": &s.shadow_decision,
+                "shadow_reason": &s.reason,
+            }),
+            None => serde_json::json!({
+                "action_type": req.action_type,
+                "decision": response.decision,
+                "reason": &response.reason,
+                "policy_rule": &response.policy_rule,
+                "latency_us": response.decision_latency_us,
+            }),
+        }
         .to_string();
 
         let mut last_hash = self.last_hash.lock().await;
@@ -811,6 +851,15 @@ impl PolicyService for PolicyServiceImpl {
 
         let (eval, latency_us, policy_rule) = self.evaluate_one(&req)?;
         self.maybe_emit_secret_alert(&req, &eval);
+
+        // AAASM-1564: apply observe-mode transform before the response is
+        // constructed. Resolution order is agent override → policy default
+        // (Enforce). When the transform returns a ShadowEvent, the decision
+        // has been rewritten to Allow and the shadow metadata flows into
+        // record_audit so the audit log captures the would-be decision.
+        let agent_override = self.lookup_agent_enforcement_override(&req);
+        let effective_mode = resolve_enforcement_mode(agent_override, aa_core::EnforcementMode::Enforce);
+        let (eval, shadow_event) = transform_for_observe_mode(eval, effective_mode);
         let deny_action = eval.deny_action;
 
         // If RequiresApproval, submit to the queue and block until decided.
@@ -853,7 +902,7 @@ impl PolicyService for PolicyServiceImpl {
         self.maybe_suspend_agent(&req, deny_action).await;
 
         // Fire-and-forget audit entry — never blocks the response.
-        self.record_audit(&req, &response, &eval).await;
+        self.record_audit(&req, &response, &eval, shadow_event.as_ref()).await;
 
         Ok(Response::new(response))
     }
@@ -865,7 +914,15 @@ impl PolicyService for PolicyServiceImpl {
         for req in &batch.requests {
             let (eval, latency_us, policy_rule) = self.evaluate_one(req)?;
             self.maybe_emit_secret_alert(req, &eval);
+
+            // AAASM-1564: same observe-mode transform as check_action above,
+            // applied per-request inside the batch so each request honours its
+            // agent's mode independently.
+            let agent_override = self.lookup_agent_enforcement_override(req);
+            let effective_mode = resolve_enforcement_mode(agent_override, aa_core::EnforcementMode::Enforce);
+            let (eval, shadow_event) = transform_for_observe_mode(eval, effective_mode);
             let deny_action = eval.deny_action;
+
             let resp = if let Some(approval_response) =
                 self.maybe_submit_approval(req, &eval, latency_us, &policy_rule).await
             {
@@ -874,7 +931,7 @@ impl PolicyService for PolicyServiceImpl {
                 convert::eval_result_to_response(&eval, latency_us, &policy_rule)
             };
             self.maybe_suspend_agent(req, deny_action).await;
-            self.record_audit(req, &resp, &eval).await;
+            self.record_audit(req, &resp, &eval, shadow_event.as_ref()).await;
             responses.push(resp);
         }
 

--- a/aa-gateway/tests/observe_mode_test.rs
+++ b/aa-gateway/tests/observe_mode_test.rs
@@ -1,0 +1,200 @@
+//! AAASM-1564 — end-to-end verification of observe-mode enforcement.
+//!
+//! Validates the contract laid out across AAASM-1554..AAASM-1557 actually fires
+//! on the gRPC request path:
+//!
+//! * ST-SANDBOX-1 — Observe + deny rule → response is Allow, audit log carries
+//!   a `dry_run: true` shadow event.
+//! * ST-SANDBOX-2 — Observe + allow → response is Allow, no shadow metadata.
+//! * ST-SANDBOX-3 — Enforce + deny → response is Deny (regression guard).
+//! * ST-SANDBOX-4 — Per-agent override wins; two agents under the same deny
+//!   policy resolve to different decisions based on their record's mode.
+
+use std::io::Write;
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+
+use aa_core::{AuditEntry, GovernanceLevel};
+use aa_gateway::registry::convert::proto_agent_id_to_key;
+use aa_gateway::registry::store::AgentRecord;
+use aa_gateway::registry::{AgentRegistry, AgentStatus};
+use aa_gateway::service::PolicyServiceImpl;
+use aa_gateway::PolicyEngine;
+use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decision};
+use aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient;
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
+use aa_proto::assembly::policy::v1::{action_context::Action, ActionContext, CheckActionRequest, ToolCallContext};
+use chrono::Utc;
+use std::collections::{BTreeMap, VecDeque};
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+use tonic::transport::Server;
+
+/// Start a PolicyService gRPC server with an attached AgentRegistry and a
+/// caller-owned audit receiver. The receiver is the contract surface the
+/// observe-mode tests inspect — every `record_audit` call lands here.
+async fn start_server_with_audit_rx(policy_yaml: &str) -> (SocketAddr, Arc<AgentRegistry>, mpsc::Receiver<AuditEntry>) {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", policy_yaml).unwrap();
+    tmp.flush().unwrap();
+
+    let (alert_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    let engine = Arc::new(PolicyEngine::load_from_file(tmp.path(), alert_tx).unwrap());
+    let registry = Arc::new(AgentRegistry::new());
+    let (audit_tx, audit_rx) = mpsc::channel(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+    let service = PolicyServiceImpl::with_registry(
+        Arc::clone(&engine),
+        Arc::clone(&registry),
+        audit_tx,
+        audit_drops,
+        [0u8; 32],
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        let _tmp = tmp;
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(PolicyServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (addr, registry, audit_rx)
+}
+
+/// Construct an `AgentRecord` carrying `enforcement_mode` and register it.
+fn register_agent_with_mode(
+    registry: &AgentRegistry,
+    agent_name: &str,
+    proto_id: &ProtoAgentId,
+    mode: Option<aa_core::EnforcementMode>,
+) {
+    let key = proto_agent_id_to_key(proto_id);
+    let record = AgentRecord {
+        agent_id: key,
+        name: agent_name.into(),
+        framework: "custom".into(),
+        version: "1.0.0".into(),
+        risk_tier: 0,
+        tool_names: vec![],
+        public_key: "pk".into(),
+        credential_token: "tok".into(),
+        metadata: BTreeMap::new(),
+        registered_at: Utc::now(),
+        last_heartbeat: Utc::now(),
+        status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
+        policy_violations_count: 0,
+        active_sessions: vec![],
+        recent_events: VecDeque::new(),
+        recent_traces: vec![],
+        layer: None,
+        governance_level: GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: None,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: None,
+        children: vec![],
+        parent_key: None,
+        enforcement_mode: mode,
+    };
+    registry.register(record).unwrap();
+}
+
+fn tool_call_request_for(proto_id: &ProtoAgentId, tool_name: &str) -> CheckActionRequest {
+    CheckActionRequest {
+        agent_id: Some(proto_id.clone()),
+        credential_token: "tok".into(),
+        trace_id: format!("trace-{tool_name}"),
+        span_id: "span-1".into(),
+        action_type: ActionType::ToolCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::ToolCall(ToolCallContext {
+                tool_name: tool_name.into(),
+                tool_source: "test".into(),
+                args_json: b"{}".to_vec(),
+                target_url: String::new(),
+            })),
+        }),
+    }
+}
+
+/// Drain audit entries with a short bounded wait — `record_audit` is
+/// fire-and-forget so the entry may not arrive synchronously with the
+/// CheckAction response.
+async fn drain_audit_entries(audit_rx: &mut mpsc::Receiver<AuditEntry>) -> Vec<AuditEntry> {
+    let mut out = vec![];
+    for _ in 0..10 {
+        match tokio::time::timeout(Duration::from_millis(50), audit_rx.recv()).await {
+            Ok(Some(entry)) => out.push(entry),
+            Ok(None) | Err(_) => break,
+        }
+    }
+    out
+}
+
+const DENY_BASH_POLICY: &str = r#"
+version: "1"
+tools:
+  bash:
+    allow: false
+"#;
+
+#[tokio::test]
+async fn st_sandbox_1_observe_mode_with_deny_rule_returns_allow_and_dry_run_audit() {
+    // The core ST contract: an agent registered with enforcement_mode = OBSERVE
+    // hits a deny rule, the gateway returns Allow (agent NOT blocked), and the
+    // audit log records exactly one entry tagged dry_run = true with
+    // shadow_decision = "deny".
+    let (addr, registry, mut audit_rx) = start_server_with_audit_rx(DENY_BASH_POLICY).await;
+
+    let proto_id = ProtoAgentId {
+        org_id: "org".into(),
+        team_id: "team".into(),
+        agent_id: "observe-agent".into(),
+    };
+    register_agent_with_mode(
+        &registry,
+        "observe-agent",
+        &proto_id,
+        Some(aa_core::EnforcementMode::Observe),
+    );
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let resp = client
+        .check_action(tool_call_request_for(&proto_id, "bash"))
+        .await
+        .unwrap()
+        .into_inner();
+
+    // ⚠️ Agent is NOT blocked even though the policy says deny.
+    assert_eq!(
+        resp.decision,
+        Decision::Allow as i32,
+        "observe mode must rewrite Deny → Allow on the response"
+    );
+
+    // Shadow audit event was emitted.
+    let entries = drain_audit_entries(&mut audit_rx).await;
+    assert_eq!(
+        entries.len(),
+        1,
+        "exactly one audit entry expected, got {}",
+        entries.len()
+    );
+    let payload: serde_json::Value = serde_json::from_str(entries[0].payload()).expect("payload is valid JSON");
+    assert_eq!(payload["dry_run"], serde_json::Value::Bool(true));
+    assert_eq!(payload["shadow_decision"], "deny");
+}

--- a/aa-gateway/tests/observe_mode_test.rs
+++ b/aa-gateway/tests/observe_mode_test.rs
@@ -242,3 +242,40 @@ tools:
     );
     assert!(payload.get("shadow_decision").is_none());
 }
+
+#[tokio::test]
+async fn st_sandbox_3_enforce_mode_with_deny_rule_still_blocks_agent() {
+    // Regression guard: an agent without any per-agent override (or registered
+    // with Enforce) hitting a deny policy must still be blocked. If anyone
+    // ever flips the default in resolve_enforcement_mode this test catches it.
+    let (addr, registry, mut audit_rx) = start_server_with_audit_rx(DENY_BASH_POLICY).await;
+
+    let proto_id = ProtoAgentId {
+        org_id: "org".into(),
+        team_id: "team".into(),
+        agent_id: "enforce-agent".into(),
+    };
+    register_agent_with_mode(&registry, "enforce-agent", &proto_id, None);
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let resp = client
+        .check_action(tool_call_request_for(&proto_id, "bash"))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(
+        resp.decision,
+        Decision::Deny as i32,
+        "enforce mode must still block deny rules — regression in {:?}",
+        resp.reason
+    );
+
+    // Audit entry must be a normal Deny record, NOT a shadow event.
+    let entries = drain_audit_entries(&mut audit_rx).await;
+    assert_eq!(entries.len(), 1);
+    let payload: serde_json::Value = serde_json::from_str(entries[0].payload()).expect("payload is valid JSON");
+    assert!(
+        payload.get("dry_run").is_none(),
+        "enforce-mode audit entry must not carry dry_run"
+    );
+}

--- a/aa-gateway/tests/observe_mode_test.rs
+++ b/aa-gateway/tests/observe_mode_test.rs
@@ -279,3 +279,54 @@ async fn st_sandbox_3_enforce_mode_with_deny_rule_still_blocks_agent() {
         "enforce-mode audit entry must not carry dry_run"
     );
 }
+
+#[tokio::test]
+async fn st_sandbox_4_per_agent_override_isolates_two_agents_under_one_policy() {
+    // Per-agent override AC: two agents share the same deny policy. One
+    // registers with EnforcementMode::Observe (experimental), the other
+    // without an override (trusted, defaults to Enforce). Each must resolve
+    // to its own mode independently on the request path.
+    let (addr, registry, _audit_rx) = start_server_with_audit_rx(DENY_BASH_POLICY).await;
+
+    let experimental_id = ProtoAgentId {
+        org_id: "org".into(),
+        team_id: "team".into(),
+        agent_id: "experimental-agent".into(),
+    };
+    let trusted_id = ProtoAgentId {
+        org_id: "org".into(),
+        team_id: "team".into(),
+        agent_id: "trusted-agent".into(),
+    };
+    register_agent_with_mode(
+        &registry,
+        "experimental-agent",
+        &experimental_id,
+        Some(aa_core::EnforcementMode::Observe),
+    );
+    register_agent_with_mode(&registry, "trusted-agent", &trusted_id, None);
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let experimental_resp = client
+        .check_action(tool_call_request_for(&experimental_id, "bash"))
+        .await
+        .unwrap()
+        .into_inner();
+    let trusted_resp = client
+        .check_action(tool_call_request_for(&trusted_id, "bash"))
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(
+        experimental_resp.decision,
+        Decision::Allow as i32,
+        "experimental agent in observe mode must proceed",
+    );
+    assert_eq!(
+        trusted_resp.decision,
+        Decision::Deny as i32,
+        "trusted agent under same policy must still be blocked — got reason {:?}",
+        trusted_resp.reason,
+    );
+}

--- a/aa-gateway/tests/observe_mode_test.rs
+++ b/aa-gateway/tests/observe_mode_test.rs
@@ -198,3 +198,47 @@ async fn st_sandbox_1_observe_mode_with_deny_rule_returns_allow_and_dry_run_audi
     assert_eq!(payload["dry_run"], serde_json::Value::Bool(true));
     assert_eq!(payload["shadow_decision"], "deny");
 }
+
+#[tokio::test]
+async fn st_sandbox_2_observe_mode_with_allow_decision_emits_no_shadow_metadata() {
+    // Observe mode must NOT fabricate shadow events for already-Allow
+    // decisions — otherwise audit-log shadow volume would mirror all traffic
+    // instead of just would-be violations. The response is Allow either way;
+    // the discriminator is whether `dry_run` appears in the audit payload.
+    let allow_policy = r#"
+version: "1"
+tools:
+  web_search:
+    allow: true
+"#;
+    let (addr, registry, mut audit_rx) = start_server_with_audit_rx(allow_policy).await;
+
+    let proto_id = ProtoAgentId {
+        org_id: "org".into(),
+        team_id: "team".into(),
+        agent_id: "observe-clean-agent".into(),
+    };
+    register_agent_with_mode(
+        &registry,
+        "observe-clean-agent",
+        &proto_id,
+        Some(aa_core::EnforcementMode::Observe),
+    );
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let resp = client
+        .check_action(tool_call_request_for(&proto_id, "web_search"))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(resp.decision, Decision::Allow as i32);
+
+    let entries = drain_audit_entries(&mut audit_rx).await;
+    assert_eq!(entries.len(), 1);
+    let payload: serde_json::Value = serde_json::from_str(entries[0].payload()).expect("payload is valid JSON");
+    assert!(
+        payload.get("dry_run").is_none(),
+        "Allow decisions in observe mode must NOT include dry_run in the audit payload, got: {payload}"
+    );
+    assert!(payload.get("shadow_decision").is_none());
+}


### PR DESCRIPTION
## Description

The keystone subtask for Story AAASM-1553. Two things land here:

1. **Service-layer wiring** that connects the engine primitives shipped in [#724](https://github.com/AI-agent-assembly/agent-assembly/pull/724) (transform) and [#729](https://github.com/AI-agent-assembly/agent-assembly/pull/729) (resolver + record field) to the gRPC `CheckAction` and `BatchCheck` hot paths. Before this PR, even an operator who set the agent's `enforcement_mode` to `OBSERVE` would still get live enforcement — the building blocks existed but nothing called them.

2. **4 end-to-end integration tests** (ST-SANDBOX-1..4) that prove the contract is honoured at the wire level.

## What changed in `aa-gateway/src/service/policy_service.rs`

- New helper `lookup_agent_enforcement_override(req) -> Option<EnforcementMode>` — reads the per-agent override off the registered `AgentRecord`. Returns `None` for missing-registry / unknown-agent / no-explicit-override cases, which the resolver treats as "inherit from policy default".
- `check_action` and `batch_check` now apply, between `evaluate_one()` and the response builder:
  ```rust
  let agent_override = self.lookup_agent_enforcement_override(req);
  let mode = resolve_enforcement_mode(agent_override, EnforcementMode::Enforce);
  let (eval, shadow) = transform_for_observe_mode(eval, mode);
  ```
- `record_audit` now takes `Option<&ShadowEvent>` and adds `dry_run: true`, `shadow_decision`, `shadow_reason` to the audit-payload JSON when present. Hash chain + event-type mapping unchanged for enforce-mode traffic.

## ST-SANDBOX integration tests

`aa-gateway/tests/observe_mode_test.rs` — 4 tests covering the AC matrix:

| Test | Setup | Asserts |
|---|---|---|
| ST-SANDBOX-1 | Agent registered with `Observe`, policy denies tool | Response = `Allow`; exactly one audit entry with `dry_run: true, shadow_decision: "deny"` |
| ST-SANDBOX-2 | Agent registered with `Observe`, policy allows tool | Response = `Allow`; audit entry has NO `dry_run` field |
| ST-SANDBOX-3 | Agent registered without override, policy denies tool | Response = `Deny` (regression guard); audit entry has no `dry_run` |
| ST-SANDBOX-4 | Two agents (`Observe` + no override) under same deny policy | `Observe` agent → Allow; no-override agent → Deny |

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

`record_audit`'s signature gained a parameter (`shadow: Option<&ShadowEvent>`); it's private so no public API impact. Every caller path with no observed override produces byte-identical audit entries to before. The wiring is a no-op for any request whose agent isn't registered or registered without an override.

## Related Issues

- Related Jira ticket: [AAASM-1564](https://lightning-dust-mite.atlassian.net/browse/AAASM-1564) (Story: [AAASM-1553](https://lightning-dust-mite.atlassian.net/browse/AAASM-1553))
- Depends on (already merged): #712, #718, #724, #729

## What's in here

6 commits:

1. ✨ Wire observe-mode end-to-end in `CheckAction` and `BatchCheck` (helper + transform call + record_audit extension)
2. ✅ ST-SANDBOX-1 — observe + deny → Allow with dry_run audit (includes test helpers)
3. ✅ ST-SANDBOX-2 — observe + Allow → no shadow metadata
4. ✅ ST-SANDBOX-3 — enforce + deny → still blocks (regression guard)
5. ✅ ST-SANDBOX-4 — per-agent override isolates two agents under one policy

## Testing

- [x] Unit tests added (4 ST-SANDBOX integration tests)
- [x] Integration tests added (same 4 — they run against a real tonic server + registry)

```
cargo nextest run -p aa-gateway --all-features              # 992 / 992 pass
cargo nextest run -p aa-gateway --test observe_mode_test    # 4 / 4 pass
cargo clippy --workspace --all-targets --all-features --exclude aa-ffi-python -- -D warnings  # clean
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on the new helper + the extended `record_audit`)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention