### PR TITLE
[AAASM-1855] ✨ (aa-gateway/storage): healthcheck() surfaces TimescaleStats when extension is active

### DIFF
--- a/aa-gateway/src/storage/health.rs
+++ b/aa-gateway/src/storage/health.rs
@@ -1,6 +1,8 @@
 //! Storage health-report value types returned by
 //! [`StorageBackend::healthcheck`](super::StorageBackend::healthcheck).
 
+use super::timescale::TimescaleStats;
+
 /// Coarse health state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HealthStatus {
@@ -34,4 +36,9 @@ pub struct StorageHealth {
     pub latency_ms: u32,
     /// Row-count snapshot taken during the probe.
     pub row_counts: RowCounts,
+    /// TimescaleDB chunk + compression rollup for `audit_events` + `metrics`,
+    /// populated only when the PostgreSQL backend is connected to a cluster
+    /// with the `timescaledb` extension installed. `None` on SQLite and on
+    /// plain PostgreSQL deployments (Epic 18 S-D #4).
+    pub timescale: Option<TimescaleStats>,
 }

--- a/aa-gateway/src/storage/postgres.rs
+++ b/aa-gateway/src/storage/postgres.rs
@@ -911,6 +911,7 @@ impl StorageBackend for PostgresBackend {
                 agents: agents as u64,
                 policy_versions: policy_versions as u64,
             },
+            timescale: None,
         })
     }
 }

--- a/aa-gateway/src/storage/postgres.rs
+++ b/aa-gateway/src/storage/postgres.rs
@@ -1866,4 +1866,29 @@ mod tests {
             health.row_counts.audit_events,
         );
     }
+
+    /// `healthcheck()` must return `timescale: None` on a vanilla
+    /// PostgreSQL cluster where the extension is not installed.
+    /// Runs against `AAASM_DATABASE_URL` when `TIMESCALEDB_AVAILABLE != "1"`
+    /// (the existing CI `Test` job's postgres:18-alpine service).
+    #[tokio::test]
+    async fn healthcheck_reports_timescale_none_on_plain_postgres() {
+        if std::env::var("TIMESCALEDB_AVAILABLE").as_deref() == Ok("1") {
+            eprintln!(
+                "skipping plain-postgres healthcheck test: TIMESCALEDB_AVAILABLE=1 (see healthcheck_reports_timescale_stats_when_extension_active)"
+            );
+            return;
+        }
+        let Some(backend) = pg_backend_or_skip().await else {
+            return;
+        };
+        backend.migrate().await.expect("migrate");
+
+        let health = backend.healthcheck().await.expect("healthcheck");
+        assert!(
+            health.timescale.is_none(),
+            "expected timescale = None on plain PostgreSQL; got {:?}",
+            health.timescale,
+        );
+    }
 }

--- a/aa-gateway/src/storage/postgres.rs
+++ b/aa-gateway/src/storage/postgres.rs
@@ -1891,4 +1891,41 @@ mod tests {
             health.timescale,
         );
     }
+
+    /// `healthcheck()` must return `Some(TimescaleStats)` on a cluster
+    /// where the TimescaleDB extension is installed. After `migrate()`
+    /// creates the hypertables and one audit event is appended, the
+    /// rollup should report at least one chunk.
+    ///
+    /// Env-gated on `TIMESCALEDB_AVAILABLE=1`. Auto-runs once SD-5
+    /// (AAASM-1858) ships the `timescaledb-tests` CI job against the
+    /// `timescale/timescaledb:latest-pg17` service container.
+    #[tokio::test]
+    async fn healthcheck_reports_timescale_stats_when_extension_active() {
+        if std::env::var("TIMESCALEDB_AVAILABLE").as_deref() != Ok("1") {
+            eprintln!("skipping extension-present healthcheck test: TIMESCALEDB_AVAILABLE != 1");
+            return;
+        }
+        let Some(backend) = pg_backend_or_skip().await else {
+            return;
+        };
+        backend.migrate().await.expect("migrate");
+
+        // Insert one event so audit_events has at least one chunk.
+        let agent_id = fresh_agent_id();
+        backend
+            .append_audit_event(&sample_event(agent_id, now_micros()))
+            .await
+            .expect("append");
+
+        let health = backend.healthcheck().await.expect("healthcheck");
+        let stats = health
+            .timescale
+            .expect("expected Some(TimescaleStats) when TimescaleDB extension is active");
+        assert!(
+            stats.total_chunks >= 1,
+            "expected at least one chunk after inserting an audit event, got {}",
+            stats.total_chunks,
+        );
+    }
 }

--- a/aa-gateway/src/storage/postgres.rs
+++ b/aa-gateway/src/storage/postgres.rs
@@ -22,7 +22,7 @@ use super::metric::{Metric, MetricPoint, MetricQuery};
 use super::policy::{PolicyDocument, PolicyMeta, PolicyVersion};
 use super::postgres_config::PostgresConfig;
 use super::retention::{ColdAction, RetentionPolicy, RetentionStats};
-use super::timescale::has_timescaledb_extension;
+use super::timescale::{has_timescaledb_extension, query_timescale_stats};
 use aa_core::config::TimescaleConfig;
 
 /// Encode an [`AgentId`] for the `agent_id` TEXT column (canonical UUID
@@ -895,6 +895,15 @@ impl StorageBackend for PostgresBackend {
         .await
         .map_err(|e| StorageError::QueryFailed(e.to_string()))?;
 
+        // Populate optional TimescaleDB rollup when the extension is
+        // present. Probe + stats failures degrade gracefully to `None`
+        // rather than failing the entire healthcheck — observability
+        // must not block on optional metadata.
+        let timescale = match has_timescaledb_extension(&self.pool).await {
+            Ok(true) => query_timescale_stats(&self.pool).await.ok(),
+            Ok(false) | Err(_) => None,
+        };
+
         let latency_ms = u32::try_from(start.elapsed().as_millis()).unwrap_or(u32::MAX);
         let status = if latency_ms < 200 {
             HealthStatus::Ok
@@ -911,7 +920,7 @@ impl StorageBackend for PostgresBackend {
                 agents: agents as u64,
                 policy_versions: policy_versions as u64,
             },
-            timescale: None,
+            timescale,
         })
     }
 }

--- a/aa-gateway/src/storage/sqlite.rs
+++ b/aa-gateway/src/storage/sqlite.rs
@@ -735,6 +735,7 @@ impl StorageBackend for SqliteBackend {
             backend: "sqlite",
             latency_ms,
             row_counts,
+            timescale: None,
         })
     }
 }

--- a/aa-gateway/src/storage/timescale.rs
+++ b/aa-gateway/src/storage/timescale.rs
@@ -69,6 +69,47 @@ pub struct TimescaleStats {
     pub oldest_chunk_age_days: u32,
 }
 
+/// Roll up chunk counts and oldest-chunk age across the gateway's
+/// hypertables (`audit_events` + `metrics`) and return a
+/// [`TimescaleStats`] snapshot.
+///
+/// Single round-trip against `timescaledb_information.chunks`. Caller
+/// must verify the extension is present first (via
+/// [`has_timescaledb_extension`]) — querying the schema on a vanilla
+/// PostgreSQL cluster raises an undefined-table error.
+///
+/// `compression_ratio_tenths` is left at `0` for the v1 implementation.
+/// Pulling the actual ratio requires per-hypertable
+/// `hypertable_compression_stats('<table>')` calls, which differ across
+/// TimescaleDB minor versions; the SD-K dashboard ticket can layer a
+/// version-aware fetcher on top when the storage panel needs it.
+///
+/// # Errors
+///
+/// Returns [`StorageError::QueryFailed`] when the chunks rollup query
+/// fails (transport / permission / extension uninstalled).
+#[allow(dead_code)]
+pub(crate) async fn query_timescale_stats(pool: &PgPool) -> StorageResult<TimescaleStats> {
+    let (total, compressed, oldest_age_days): (i64, i64, i32) = sqlx::query_as(
+        "SELECT \
+             COUNT(*)::bigint, \
+             COUNT(*) FILTER (WHERE is_compressed)::bigint, \
+             COALESCE(EXTRACT(DAY FROM NOW() - MIN(range_start))::int, 0) \
+         FROM timescaledb_information.chunks \
+         WHERE hypertable_name IN ('audit_events', 'metrics')",
+    )
+    .fetch_one(pool)
+    .await
+    .map_err(|e| StorageError::QueryFailed(format!("timescale chunks rollup: {e}")))?;
+
+    Ok(TimescaleStats {
+        total_chunks: u32::try_from(total).unwrap_or(u32::MAX),
+        compressed_chunks: u32::try_from(compressed).unwrap_or(u32::MAX),
+        compression_ratio_tenths: 0,
+        oldest_chunk_age_days: u32::try_from(oldest_age_days).unwrap_or(0),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/aa-gateway/src/storage/timescale.rs
+++ b/aa-gateway/src/storage/timescale.rs
@@ -88,7 +88,6 @@ pub struct TimescaleStats {
 ///
 /// Returns [`StorageError::QueryFailed`] when the chunks rollup query
 /// fails (transport / permission / extension uninstalled).
-#[allow(dead_code)]
 pub(crate) async fn query_timescale_stats(pool: &PgPool) -> StorageResult<TimescaleStats> {
     let (total, compressed, oldest_age_days): (i64, i64, i32) = sqlx::query_as(
         "SELECT \

--- a/aa-gateway/tests/storage_trait_object_safety.rs
+++ b/aa-gateway/tests/storage_trait_object_safety.rs
@@ -95,6 +95,7 @@ impl StorageBackend for NoopStorage {
             backend: "noop",
             latency_ms: 0,
             row_counts: RowCounts::default(),
+            timescale: None,
         })
     }
 }
@@ -142,5 +143,6 @@ fn supporting_types_are_publicly_constructible() {
         backend: "noop",
         latency_ms: 0,
         row_counts: RowCounts::default(),
+        timescale: None,
     };
 }


### PR DESCRIPTION
## Description

Surfaces the TimescaleDB chunk + compression rollup through `StorageHealth.timescale: Option<TimescaleStats>`. PostgreSQL backend populates it via the new `query_timescale_stats` helper when the extension is installed; vanilla PG and SQLite report `None`.

This is **SD-4** of the AAASM-1586 (E18 S-D) sub-task series. Builds on SD-1 (#711, migration), SD-2 (#741, `TimescaleStats` + probe), SD-3 (#746, `apply_timescaledb_setup`).

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

Public API addition (new optional field on `StorageHealth`). Existing consumers of `StorageHealth` that don't read `timescale` are unaffected; existing struct literals were updated to include `timescale: None` in the same commit since `StorageHealth` doesn't derive `Default`.

## Related Issues

- Related Jira ticket: [AAASM-1855](https://lightning-dust-mite.atlassian.net/browse/AAASM-1855) (parent Story: [AAASM-1586](https://lightning-dust-mite.atlassian.net/browse/AAASM-1586), Epic: [AAASM-1569](https://lightning-dust-mite.atlassian.net/browse/AAASM-1569))

## Testing

- [x] Unit tests added — two tests in `postgres.rs::tests`:
  - `healthcheck_reports_timescale_none_on_plain_postgres` — runs in CI `Test` job (postgres:18-alpine); asserts `health.timescale.is_none()`
  - `healthcheck_reports_timescale_stats_when_extension_active` — env-gated on `TIMESCALEDB_AVAILABLE=1`; asserts `Some(stats)` with `total_chunks >= 1` after inserting an audit event
- [x] Existing `healthcheck_reports_ok_and_correct_row_counts` (SQLite) + `healthcheck_returns_ok_with_row_counts` (PG) still pass — `timescale: None` doesn't perturb existing assertions
- [x] Local `cargo nextest run -p aa-gateway storage::postgres::tests::healthcheck` 3/3 PASS (skip paths)
- [x] Local pre-commit (fmt + clippy `-D warnings` + rustdoc) green

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed — `StorageHealth.timescale` and `query_timescale_stats` both fully documented, including a note that `compression_ratio_tenths` is intentionally 0 in v1 (TimescaleDB version-spanning compression ratio left for the dashboard ticket)
- [ ] All CI checks passing — will validate on push
- [x] Commits are small and follow the Gitmoji convention (5 commits)

## Commit log

1. `✨ Add timescale field to StorageHealth` (combined ticket's "add field" + "Sqlite returns None" — necessarily co-temporal since `StorageHealth` has no `Default`; also touches the trait-object-safety test's noop backend literal)
2. `✨ Add query_timescale_stats helper` (transient `#[allow(dead_code)]`)
3. `♻️ PostgresBackend.healthcheck populates timescale field` (drops the `allow(dead_code)`)
4. `✅ Test healthcheck returns timescale None on plain postgres`
5. `✅ Test healthcheck reports timescale stats on timescaledb`

## Depends on

- SD-1 ([AAASM-1848](https://lightning-dust-mite.atlassian.net/browse/AAASM-1848)) — migration SQL (merged in #711)
- SD-2 ([AAASM-1852](https://lightning-dust-mite.atlassian.net/browse/AAASM-1852)) — `TimescaleStats` + probe (merged in #741)
- SD-3 ([AAASM-1853](https://lightning-dust-mite.atlassian.net/browse/AAASM-1853)) — `apply_timescaledb_setup` (merged in #746)

[AAASM-1855]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1586]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1569]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ