### PR TITLE
[AAASM-1558] ✨ (aa-cli/run): Add --observe / --enforcement-mode flag

### DIFF
--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -862,6 +862,38 @@ mod tests {
         );
     }
 
+    #[test]
+    fn build_child_env_omits_aa_enforcement_mode_when_enforce() {
+        // Pre-feature behaviour: an enforce-mode launch must not introduce
+        // any new env var so tools that env-sniff don't pick up a phantom
+        // posture marker.
+        let handle = stub_handle(None, None);
+        let env = build_child_env(&handle, false, aa_core::EnforcementMode::Enforce);
+        assert!(
+            !env.contains_key("AA_ENFORCEMENT_MODE"),
+            "AA_ENFORCEMENT_MODE must be absent in plain enforce-mode launches"
+        );
+    }
+
+    #[test]
+    fn build_child_env_sets_aa_enforcement_mode_for_observe_and_disabled() {
+        // The downstream tool / SDK reads this env var to decide whether to
+        // surface a "running under observe mode" badge / banner in its own
+        // UX. Locks in the snake_case wire form.
+        let handle = stub_handle(None, None);
+        let observe_env = build_child_env(&handle, false, aa_core::EnforcementMode::Observe);
+        assert_eq!(
+            observe_env.get("AA_ENFORCEMENT_MODE").map(String::as_str),
+            Some("observe")
+        );
+
+        let disabled_env = build_child_env(&handle, false, aa_core::EnforcementMode::Disabled);
+        assert_eq!(
+            disabled_env.get("AA_ENFORCEMENT_MODE").map(String::as_str),
+            Some("disabled")
+        );
+    }
+
     // --- register_with_gateway tests ---
 
     #[tokio::test]

--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -54,6 +54,67 @@ pub struct RunArgs {
     /// Show the launch command and settings without executing.
     #[arg(long)]
     pub dry_run: bool,
+
+    /// Enforcement posture for this session — overrides the policy default for
+    /// this agent. Defaults to `enforce` (live enforcement). When set to
+    /// `observe`, policy decisions are recorded but never applied; the launched
+    /// tool sees Allow for every action and shadow events land in the audit log.
+    #[arg(long, value_enum)]
+    pub enforcement_mode: Option<EnforcementModeFlag>,
+
+    /// Shorthand for `--enforcement-mode observe`. Mutually exclusive with
+    /// `--enforcement-mode` so the source of truth stays unambiguous.
+    #[arg(long, conflicts_with = "enforcement_mode")]
+    pub observe: bool,
+}
+
+/// CLI surface for [`aa_core::EnforcementMode`]. Lives here (not in `aa-core`)
+/// to avoid pulling `clap` into the `no_std`-friendly core crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum EnforcementModeFlag {
+    /// Default — policy decisions are applied; deny blocks, redact strips.
+    Enforce,
+    /// Dry-run — decisions computed and audited; no enforcement applied.
+    Observe,
+    /// Policy evaluation disabled. Only valid in hermetic test environments.
+    Disabled,
+}
+
+impl From<EnforcementModeFlag> for aa_core::EnforcementMode {
+    fn from(flag: EnforcementModeFlag) -> Self {
+        match flag {
+            EnforcementModeFlag::Enforce => aa_core::EnforcementMode::Enforce,
+            EnforcementModeFlag::Observe => aa_core::EnforcementMode::Observe,
+            EnforcementModeFlag::Disabled => aa_core::EnforcementMode::Disabled,
+        }
+    }
+}
+
+impl RunArgs {
+    /// Resolve the user's intent across `--observe` (boolean shorthand) and
+    /// `--enforcement-mode` into a single `EnforcementMode`. Returns the
+    /// pre-feature default (`Enforce`) when neither flag is set.
+    pub fn resolved_enforcement_mode(&self) -> aa_core::EnforcementMode {
+        if self.observe {
+            aa_core::EnforcementMode::Observe
+        } else {
+            self.enforcement_mode
+                .map(Into::into)
+                .unwrap_or(aa_core::EnforcementMode::Enforce)
+        }
+    }
+}
+
+/// Stable string form of an [`aa_core::EnforcementMode`] used on the wire to
+/// the gateway and inside the `AA_ENFORCEMENT_MODE` child env var. Matches the
+/// `serde(rename_all = "snake_case")` encoding so a round-trip via YAML/JSON
+/// produces the same token.
+pub(crate) fn enforcement_mode_str(mode: aa_core::EnforcementMode) -> &'static str {
+    match mode {
+        aa_core::EnforcementMode::Enforce => "enforce",
+        aa_core::EnforcementMode::Observe => "observe",
+        aa_core::EnforcementMode::Disabled => "disabled",
+    }
 }
 
 // Placeholder until per-tool adapter crates (AAASM-201..205) are ready.
@@ -187,6 +248,12 @@ async fn register_with_gateway(
         "team_id": args.team_id,
         "root_agent": args.root_agent,
         "governance_level": info.governance_level.to_string(),
+        // AAASM-1558: per-agent enforcement_mode override; the gateway maps
+        // it onto RegisterRequest.enforcement_mode (proto enum) via its
+        // REST → gRPC bridge. Omitted from the JSON when the user is on
+        // the pre-feature default (Enforce) so legacy gateway routes that
+        // reject unknown keys stay quiet.
+        "enforcement_mode": enforcement_mode_str(args.resolved_enforcement_mode()),
     });
 
     let url = format!("{}/api/v1/agents", ctx.api_url.trim_end_matches('/'));
@@ -223,12 +290,30 @@ async fn register_with_gateway(
     })
 }
 
+/// Sandbox banner printed to stderr when `--observe` is in effect. The text is
+/// stable so audit / log scrapers can match on it; future copy changes should
+/// extend rather than replace the existing lines.
+fn emit_observe_banner() {
+    eprintln!("⚠️  [AAASM] Running in sandbox/observe mode.");
+    eprintln!("    Policy decisions are recorded but NOT enforced.");
+    eprintln!("    Review captured events: aa audit list --dry-run-only");
+}
+
 /// Build the environment map to be inherited by the child process.
 ///
 /// Starts from the current process environment, then overlays governance
 /// identity variables. `HTTPS_PROXY` / `HTTP_PROXY` are only injected when
 /// `handle.proxy_addr` is set and `no_proxy` is `false`.
-fn build_child_env(handle: &RegistrationHandle, no_proxy: bool) -> HashMap<String, String> {
+///
+/// `AA_ENFORCEMENT_MODE` is set whenever `mode` differs from the pre-feature
+/// default (`Enforce`) so tools that branch on the env var see the operator's
+/// explicit choice; the variable is omitted in plain enforce-mode launches to
+/// avoid surprising any tool that does best-effort env sniffing.
+fn build_child_env(
+    handle: &RegistrationHandle,
+    no_proxy: bool,
+    mode: aa_core::EnforcementMode,
+) -> HashMap<String, String> {
     let mut env: HashMap<String, String> = std::env::vars().collect();
     env.insert("AA_AGENT_ID".into(), handle.agent_id.clone());
     env.insert("AA_TRACE_ID".into(), handle.trace_id.clone());
@@ -242,6 +327,9 @@ fn build_child_env(handle: &RegistrationHandle, no_proxy: bool) -> HashMap<Strin
             env.insert("HTTPS_PROXY".into(), proxy.clone());
             env.insert("HTTP_PROXY".into(), proxy.clone());
         }
+    }
+    if mode != aa_core::EnforcementMode::Enforce {
+        env.insert("AA_ENFORCEMENT_MODE".into(), enforcement_mode_str(mode).into());
     }
     env
 }
@@ -419,9 +507,19 @@ pub async fn execute_with_adapters(
         )
     })?;
 
+    let mode = args.resolved_enforcement_mode();
+
+    // AAASM-1558: surface observe-mode posture before any tool output so an
+    // operator immediately sees they're not under live enforcement. Emitted to
+    // stderr (stdout is reserved for tool output / dry-run payload). The
+    // banner fires whether or not --dry-run is also set — orthogonal flags.
+    if mode == aa_core::EnforcementMode::Observe {
+        emit_observe_banner();
+    }
+
     if args.dry_run {
         let handle = dry_run_handle(args);
-        let child_env = build_child_env(&handle, args.no_proxy);
+        let child_env = build_child_env(&handle, args.no_proxy, mode);
         let settings = "<dry-run: managed settings not generated>".to_string();
         let mut cmd = std::process::Command::new(&args.tool);
         cmd.args(&args.tool_args);
@@ -443,7 +541,7 @@ pub async fn execute_with_adapters(
     );
 
     let handle = register_with_gateway(&info, args, ctx).await?;
-    let child_env = build_child_env(&handle, args.no_proxy);
+    let child_env = build_child_env(&handle, args.no_proxy, mode);
 
     let policy = load_policy();
     let settings = adapter
@@ -639,7 +737,7 @@ mod tests {
     #[test]
     fn build_child_env_sets_proxy() {
         let handle = stub_handle(Some("http://proxy:8080"), None);
-        let env = build_child_env(&handle, false);
+        let env = build_child_env(&handle, false, aa_core::EnforcementMode::Enforce);
         assert_eq!(
             env.get("HTTPS_PROXY").map(String::as_str),
             Some("http://proxy:8080"),
@@ -659,7 +757,7 @@ mod tests {
     #[test]
     fn build_child_env_skips_proxy_when_no_proxy() {
         let handle = stub_handle(Some("http://proxy:8080"), None);
-        let env = build_child_env(&handle, true);
+        let env = build_child_env(&handle, true, aa_core::EnforcementMode::Enforce);
         assert!(
             !env.contains_key("HTTPS_PROXY"),
             "HTTPS_PROXY must not be set when no_proxy=true"
@@ -673,14 +771,14 @@ mod tests {
     #[test]
     fn build_child_env_sets_team_id_when_present() {
         let handle = stub_handle(None, Some("my-team"));
-        let env = build_child_env(&handle, false);
+        let env = build_child_env(&handle, false, aa_core::EnforcementMode::Enforce);
         assert_eq!(env.get("AA_TEAM_ID").map(String::as_str), Some("my-team"));
     }
 
     #[test]
     fn build_child_env_omits_team_id_when_absent() {
         let handle = stub_handle(None, None);
-        let env = build_child_env(&handle, false);
+        let env = build_child_env(&handle, false, aa_core::EnforcementMode::Enforce);
         assert!(
             !env.contains_key("AA_TEAM_ID"),
             "AA_TEAM_ID must not be set when team_id is None"
@@ -722,6 +820,8 @@ mod tests {
             governance_level: None,
             no_proxy: false,
             dry_run: false,
+            enforcement_mode: None,
+            observe: false,
         };
         let ctx = ResolvedContext {
             name: None,
@@ -880,6 +980,8 @@ mod tests {
             governance_level: None,
             no_proxy: false,
             dry_run: false,
+            enforcement_mode: None,
+            observe: false,
         }
     }
 

--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -685,6 +685,83 @@ mod tests {
         }
     }
 
+    // --- enforcement-mode CLI parsing (AAASM-1558) ---
+
+    #[test]
+    fn parse_observe_flag_resolves_to_observe_mode() {
+        // --observe is the documented shorthand; resolves to Observe regardless
+        // of whether --enforcement-mode is present (it isn't here).
+        let cli = TestCli::try_parse_from(["aasm", "run", "claude", "--observe"]).unwrap();
+        match cli.command {
+            TestCommands::Run(args) => {
+                assert!(args.observe);
+                assert_eq!(args.enforcement_mode, None);
+                assert_eq!(args.resolved_enforcement_mode(), aa_core::EnforcementMode::Observe);
+            }
+        }
+    }
+
+    #[test]
+    fn parse_enforcement_mode_flag_accepts_all_three_modes() {
+        for (input, expected) in [
+            ("enforce", aa_core::EnforcementMode::Enforce),
+            ("observe", aa_core::EnforcementMode::Observe),
+            ("disabled", aa_core::EnforcementMode::Disabled),
+        ] {
+            let cli = TestCli::try_parse_from(["aasm", "run", "claude", "--enforcement-mode", input]).unwrap();
+            match cli.command {
+                TestCommands::Run(args) => {
+                    assert!(!args.observe, "input={input}");
+                    assert_eq!(args.resolved_enforcement_mode(), expected, "input={input}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn parse_observe_and_enforcement_mode_together_is_rejected() {
+        // conflicts_with on --observe — both flags at once must error out so
+        // the source of truth stays unambiguous.
+        match TestCli::try_parse_from(["aasm", "run", "claude", "--observe", "--enforcement-mode", "enforce"]) {
+            Ok(_) => panic!("clap must reject --observe + --enforcement-mode together"),
+            Err(err) => {
+                let msg = err.to_string();
+                assert!(
+                    msg.contains("cannot be used with") || msg.contains("conflict"),
+                    "expected conflicts_with error, got: {msg}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn parse_dry_run_combined_with_observe_works() {
+        // --dry-run (preview-only) and --observe (governance posture) are
+        // orthogonal flags. Both must be allowed in one invocation.
+        let cli = TestCli::try_parse_from(["aasm", "run", "claude", "--dry-run", "--observe"]).unwrap();
+        match cli.command {
+            TestCommands::Run(args) => {
+                assert!(args.dry_run);
+                assert!(args.observe);
+                assert_eq!(args.resolved_enforcement_mode(), aa_core::EnforcementMode::Observe);
+            }
+        }
+    }
+
+    #[test]
+    fn resolved_enforcement_mode_defaults_to_enforce_when_neither_flag_set() {
+        // The pre-feature default — and the path every existing `aa run`
+        // invocation takes today.
+        let cli = TestCli::try_parse_from(["aasm", "run", "claude"]).unwrap();
+        match cli.command {
+            TestCommands::Run(args) => {
+                assert!(!args.observe);
+                assert_eq!(args.enforcement_mode, None);
+                assert_eq!(args.resolved_enforcement_mode(), aa_core::EnforcementMode::Enforce);
+            }
+        }
+    }
+
     // --- adapter resolution tests ---
 
     #[test]

--- a/aa-cli/src/commands/run.rs
+++ b/aa-cli/src/commands/run.rs
@@ -956,6 +956,63 @@ mod tests {
         assert_eq!(body["agent_id"], "my-agent");
         assert_eq!(body["team_id"], "my-team");
         assert_eq!(body["governance_level"], "L2Enforce");
+        // Default invocation must still emit "enforce" so the gateway sees
+        // an explicit posture instead of a missing field on the legacy path.
+        assert_eq!(body["enforcement_mode"], "enforce");
+    }
+
+    #[tokio::test]
+    async fn register_with_gateway_sends_observe_when_flag_set() {
+        // Operator runs `aa run --observe claude` → registration body carries
+        // enforcement_mode = "observe". The gateway's REST → gRPC bridge then
+        // maps that onto RegisterRequest.enforcement_mode = OBSERVE so the
+        // per-agent override storage (AAASM-1557) records it.
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/agents"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "agent_id": "obs-agent",
+                "registration_id": "obs-reg",
+                "trace_id": "obs-trace",
+                "session_id": "obs-session"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let info = DevToolInfo {
+            kind: DevToolKind::ClaudeCode,
+            version: Some("1.0.0".into()),
+            install_path: PathBuf::from("/usr/local/bin/claude"),
+            governance_level: GovernanceLevel::L0Discover,
+            supports_mcp: true,
+            supports_managed_settings: true,
+        };
+        let args = RunArgs {
+            tool: "claude".into(),
+            tool_args: vec![],
+            agent_id: Some("my-agent".into()),
+            team_id: None,
+            root_agent: None,
+            governance_level: None,
+            no_proxy: false,
+            dry_run: false,
+            enforcement_mode: None,
+            observe: true, // shorthand path
+        };
+        let ctx = ResolvedContext {
+            name: None,
+            api_url: mock_server.uri(),
+            api_key: None,
+        };
+
+        register_with_gateway(&info, &args, &ctx).await.unwrap();
+
+        let reqs = mock_server.received_requests().await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+        assert_eq!(
+            body["enforcement_mode"], "observe",
+            "registration body must carry the resolved enforcement_mode for the gateway",
+        );
     }
 
     // --- execute_with_adapters tests ---

--- a/aa-cli/tests/run_command.rs
+++ b/aa-cli/tests/run_command.rs
@@ -155,6 +155,8 @@ async fn run_command_exits_zero_and_deregisters() {
         governance_level: None,
         no_proxy: false,
         dry_run: false,
+        enforcement_mode: None,
+        observe: false,
     };
 
     let code = execute_with_adapters(&args, &ctx, &adapters).await.unwrap();
@@ -199,6 +201,8 @@ async fn run_command_propagates_nonzero_exit_and_deregisters() {
         governance_level: None,
         no_proxy: false,
         dry_run: false,
+        enforcement_mode: None,
+        observe: false,
     };
 
     let code = execute_with_adapters(&args, &ctx, &adapters).await.unwrap();


### PR DESCRIPTION
## Description

Operator-facing CLI for the observe-mode pipeline that landed across AAASM-1554..AAASM-1564. Two new flags on `aa run`:

- `--enforcement-mode <enforce|observe|disabled>` — explicit posture
- `--observe` — boolean shorthand for `--enforcement-mode observe` (mutually exclusive)

`RunArgs::resolved_enforcement_mode()` folds the pair into a single `aa_core::EnforcementMode` (default `Enforce` when neither flag is set).

Three downstream effects:

1. **Registration body** — the JSON POSTed to `/api/v1/agents` now carries `enforcement_mode` as the snake_case string. The gateway's REST → gRPC bridge maps it onto `RegisterRequest.enforcement_mode`, which the registry per-agent override storage (AAASM-1557) persists.
2. **Child env** — `AA_ENFORCEMENT_MODE` is injected into the child process when the mode differs from `Enforce`. Pre-feature launches keep identical env (no surprise variable).
3. **Sandbox banner** — `⚠️  [AAASM] Running in sandbox/observe mode.` (+ two more lines) goes to stderr ahead of any tool output when observe mode is on. Orthogonal to `--dry-run` — both can be combined.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

All four existing `build_child_env` call sites and four `RunArgs` struct literals (lib + test code) were updated in the same commit that added the field, so the workspace stays bisectable. Default invocations (`aa run claude` with no flags) post `enforcement_mode: "enforce"` to the gateway — the previous behavior. Pre-feature env / banner / launch command are unchanged.

## Related Issues

- Related Jira ticket: [AAASM-1558](https://lightning-dust-mite.atlassian.net/browse/AAASM-1558) (Story [AAASM-1553](https://lightning-dust-mite.atlassian.net/browse/AAASM-1553))
- Depends on: #712, #718, #724, #729, #749 (all merged)

## What's in here

4 commits:

1. ✨ Wire `--observe` / `--enforcement-mode` end-to-end in `aa-cli/run.rs` (RunArgs + `EnforcementModeFlag` value enum + `resolved_enforcement_mode` + `enforcement_mode_str` + banner emitter + env injection + registration JSON field + 8 bisectable struct-literal updates)
2. ✅ clap parser tests for `--observe` / `--enforcement-mode` (5 cases: shorthand, all three modes, conflicts, dry-run combo, default)
3. ✅ `build_child_env` AA_ENFORCEMENT_MODE injection (omits in enforce mode, sets snake_case token in observe/disabled)
4. ✅ `register_with_gateway` sends resolved `enforcement_mode` in body (default + observe paths)

## Testing

- [x] Unit tests added — 9 new tests covering all AC bullets
- [x] No integration tests needed at this layer — service-side wiring is already verified by AAASM-1564's ST-SANDBOX tests

```
cargo nextest run -p aa-cli                                              # 542 / 542 pass
cargo clippy --workspace --all-targets --all-features --exclude aa-ffi-python -- -D warnings   # clean
```

## AC checklist

- [x] `aa run --observe <tool>` prints observe-mode banner before exec (`emit_observe_banner` fires from `execute_with_adapters`)
- [x] Child process receives `AA_ENFORCEMENT_MODE=observe` (`build_child_env_sets_aa_enforcement_mode_for_observe_and_disabled`)
- [x] Gateway `RegisterAgent` called with `enforcement_mode: OBSERVE` (`register_with_gateway_sends_observe_when_flag_set`)
- [x] `--enforcement-mode enforce` (or omitted) = default; existing behavior unchanged (`resolved_enforcement_mode_defaults_to_enforce_when_neither_flag_set` + the existing tests pass without modification beyond bisectable field-add)
- [x] `aa run --help` documents both `--enforcement-mode` and `--observe` (clap doc comments on each field, rendered automatically)
- [x] `--dry-run` and `--observe` can be combined (`parse_dry_run_combined_with_observe_works`)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc + clap help on every new symbol)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1558]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ