### PR TITLE
[AAASM-1872] ✨ (aa-cli): Wire admin run-retention to live POST /api/v1/admin/retention-policy/run

### DIFF
--- a/aa-cli/src/commands/admin/mod.rs
+++ b/aa-cli/src/commands/admin/mod.rs
@@ -10,6 +10,9 @@ use std::process::ExitCode;
 
 use clap::{Args, Subcommand};
 
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
+
 /// Subcommands for `aasm admin`.
 #[derive(Debug, Subcommand)]
 pub enum AdminCommands {
@@ -25,9 +28,13 @@ pub struct AdminArgs {
 }
 
 /// Dispatch an `aasm admin` subcommand.
-pub fn dispatch(args: AdminArgs) -> ExitCode {
+///
+/// `ctx` and `output` were threaded through in Epic 18 Story S-I.5
+/// (AAASM-1872) so admin subcommands can reach the gateway via the
+/// shared HTTP client and respect the global `--output` selection.
+pub fn dispatch(args: AdminArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
     match args.command {
-        AdminCommands::RunRetention(a) => retention::dispatch(a),
+        AdminCommands::RunRetention(a) => retention::dispatch(a, ctx, output),
     }
 }
 

--- a/aa-cli/src/commands/admin/retention.rs
+++ b/aa-cli/src/commands/admin/retention.rs
@@ -9,6 +9,9 @@ use std::process::ExitCode;
 
 use clap::Args;
 
+use crate::config::ResolvedContext;
+use crate::output::OutputFormat;
+
 /// Arguments for `aasm admin run-retention`.
 #[derive(Debug, Args)]
 pub struct RunRetentionArgs {
@@ -19,7 +22,11 @@ pub struct RunRetentionArgs {
 }
 
 /// Dispatch `aasm admin run-retention [--dry-run]`.
-pub fn dispatch(_args: RunRetentionArgs) -> ExitCode {
+///
+/// `ctx` and `output` were threaded through in this commit for Epic 18
+/// Story S-I.5 (AAASM-1872); the live transport wire-up that consumes
+/// them lands in the next commit.
+pub fn dispatch(_args: RunRetentionArgs, _ctx: &ResolvedContext, _output: OutputFormat) -> ExitCode {
     eprintln!(
         "aasm admin run-retention: gateway admin transport not yet wired \
          (tracked under AAASM-1590 / Story S-I). The retention engine \

--- a/aa-cli/src/commands/admin/retention.rs
+++ b/aa-cli/src/commands/admin/retention.rs
@@ -1,14 +1,18 @@
-//! `aasm admin run-retention` — manually trigger one retention pass.
+//! `aasm admin run-retention` — manually trigger one retention pass
+//! against the running gateway.
 //!
-//! Until the gateway admin transport from Story S-I (AAASM-1590) lands,
-//! this subcommand parses its arguments and prints a clear stub message
-//! pointing at the in-flight wiring ticket; it exits 0 so end-to-end CI
-//! that exercises CLI help / arg parsing stays green.
+//! Posts to `POST /api/v1/admin/retention-policy/run` and prints the
+//! returned `RetentionRunStatsDto` to stdout. The transport landed in
+//! Epic 18 Story S-I.5 (AAASM-1872) — the matching aa-api handler,
+//! OpenAPI registration, and dashboard codegen were already in place
+//! from sibling stories AAASM-1850 / AAASM-1856 / AAASM-1861.
 
 use std::process::ExitCode;
 
 use clap::Args;
+use serde::{Deserialize, Serialize};
 
+use crate::client::post_json;
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
 
@@ -21,18 +25,58 @@ pub struct RunRetentionArgs {
     pub dry_run: bool,
 }
 
+/// Request body sent to `POST /api/v1/admin/retention-policy/run`.
+///
+/// Mirrors `aa_api::models::retention::RunRetentionRequest`. Kept local
+/// to aa-cli so the CLI does not depend on the aa-api crate, matching
+/// the convention used elsewhere (e.g. `budget.rs`, `permissions.rs`).
+#[derive(Debug, Serialize)]
+struct RunRetentionRequest {
+    dry_run: bool,
+}
+
+/// Response body returned by `POST /api/v1/admin/retention-policy/run`.
+///
+/// Mirrors `aa_api::models::retention::RetentionRunStatsDto`.
+#[derive(Debug, Deserialize, Serialize)]
+struct RetentionRunStatsDto {
+    ran_at: String,
+    hot_rows: u64,
+    compressed_rows: u64,
+    archived_rows: u64,
+    dropped_rows: u64,
+    freed_bytes: u64,
+    dry_run: bool,
+}
+
+const ENDPOINT: &str = "/api/v1/admin/retention-policy/run";
+
 /// Dispatch `aasm admin run-retention [--dry-run]`.
 ///
-/// `ctx` and `output` were threaded through in this commit for Epic 18
-/// Story S-I.5 (AAASM-1872); the live transport wire-up that consumes
-/// them lands in the next commit.
-pub fn dispatch(_args: RunRetentionArgs, _ctx: &ResolvedContext, _output: OutputFormat) -> ExitCode {
-    eprintln!(
-        "aasm admin run-retention: gateway admin transport not yet wired \
-         (tracked under AAASM-1590 / Story S-I). The retention engine \
-         (Story S-F) is in place; once the admin transport lands this \
-         subcommand will trigger a manual retention pass against the \
-         running gateway."
-    );
+/// Honours `OutputFormat::Yaml` if selected; defaults to pretty JSON.
+/// Exits with `ExitCode::SUCCESS` on a successful pass, or
+/// `ExitCode::FAILURE` when the gateway is unreachable or returns a
+/// non-2xx status — the reqwest / HTTP error chain is printed to
+/// stderr so an operator running `aasm admin run-retention` can see
+/// exactly why the call failed.
+pub fn dispatch(args: RunRetentionArgs, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
+    let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
+    let req = RunRetentionRequest { dry_run: args.dry_run };
+    let stats: RetentionRunStatsDto = match rt.block_on(post_json(ctx, ENDPOINT, &req)) {
+        Ok(stats) => stats,
+        Err(err) => {
+            eprintln!("aasm admin run-retention: {err}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let rendered = match output {
+        OutputFormat::Yaml => serde_yaml::to_string(&stats).expect("serialize stats as YAML"),
+        // Table format on a single-record response is the same as JSON
+        // pretty-print for now; the dashboard renders the same shape.
+        OutputFormat::Table | OutputFormat::Json => {
+            serde_json::to_string_pretty(&stats).expect("serialize stats as JSON")
+        }
+    };
+    println!("{rendered}");
     ExitCode::SUCCESS
 }

--- a/aa-cli/src/commands/admin/retention.rs
+++ b/aa-cli/src/commands/admin/retention.rs
@@ -80,3 +80,56 @@ pub fn dispatch(args: RunRetentionArgs, ctx: &ResolvedContext, output: OutputFor
     println!("{rendered}");
     ExitCode::SUCCESS
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the wire shape sent to `POST /api/v1/admin/retention-policy/run`.
+    /// The OpenAPI spec + the aa-api `RunRetentionRequest` deserializer
+    /// both expect a single field named exactly `dry_run`.
+    #[test]
+    fn request_serializes_dry_run_true() {
+        let body = serde_json::to_value(RunRetentionRequest { dry_run: true }).expect("serialize");
+        assert_eq!(body, serde_json::json!({"dry_run": true}));
+    }
+
+    /// Default flag → `dry_run: false` on the wire.
+    #[test]
+    fn request_serializes_dry_run_false() {
+        let body = serde_json::to_value(RunRetentionRequest { dry_run: false }).expect("serialize");
+        assert_eq!(body, serde_json::json!({"dry_run": false}));
+    }
+
+    /// Pins the response shape we deserialize from the gateway.
+    /// Mirrors the aa-api `RetentionRunStatsDto` exactly so a future
+    /// rename / field addition surfaces here.
+    #[test]
+    fn response_deserializes_full_stats() {
+        let payload = serde_json::json!({
+            "ran_at": "2026-05-23T12:34:56Z",
+            "hot_rows": 100,
+            "compressed_rows": 20,
+            "archived_rows": 5,
+            "dropped_rows": 3,
+            "freed_bytes": 4096,
+            "dry_run": false
+        });
+        let stats: RetentionRunStatsDto = serde_json::from_value(payload).expect("deserialize");
+        assert_eq!(stats.ran_at, "2026-05-23T12:34:56Z");
+        assert_eq!(stats.hot_rows, 100);
+        assert_eq!(stats.compressed_rows, 20);
+        assert_eq!(stats.archived_rows, 5);
+        assert_eq!(stats.dropped_rows, 3);
+        assert_eq!(stats.freed_bytes, 4096);
+        assert!(!stats.dry_run);
+    }
+
+    /// The endpoint path the CLI POSTs to must match what the aa-api
+    /// router mounts (`aa-api/src/routes/mod.rs`) and what
+    /// `openapi/v1.yaml` advertises.
+    #[test]
+    fn endpoint_matches_openapi_path() {
+        assert_eq!(ENDPOINT, "/api/v1/admin/retention-policy/run");
+    }
+}

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -83,7 +83,7 @@ pub enum Commands {
 /// Dispatch the parsed CLI command to the appropriate handler.
 pub fn dispatch(cmd: Commands, ctx: &ResolvedContext, output: OutputFormat) -> ExitCode {
     match cmd {
-        Commands::Admin(args) => admin::dispatch(args),
+        Commands::Admin(args) => admin::dispatch(args, ctx, output),
         Commands::Agent(args) => agent::dispatch(args, ctx, output),
         Commands::Alerts(args) => alerts::dispatch(args, ctx, output),
         Commands::Audit(args) => audit::dispatch(args, ctx, output),

--- a/aa-cli/tests/admin_run_retention.rs
+++ b/aa-cli/tests/admin_run_retention.rs
@@ -1,32 +1,139 @@
-//! End-to-end test for `aasm admin run-retention` — AAASM-1747.
+//! End-to-end test for `aasm admin run-retention` — Epic 18 Story S-I.5
+//! (AAASM-1872).
 //!
-//! Until the gateway admin transport (AAASM-1590) lands, the subcommand
-//! is a stub that prints a pointer at the in-flight wiring ticket and
-//! exits 0. These tests pin both the exit-code contract (success so help
-//! / arg-parsing CI stays green) and the stub-message contract (so the
-//! pointer to S-I is reliably surfaced).
+//! The subcommand POSTs to `/api/v1/admin/retention-policy/run` on the
+//! configured gateway and prints the returned `RetentionRunStatsDto`.
+//! These tests drive that path against a wiremock server so the wire
+//! contract — endpoint, request body, response shape, exit codes — is
+//! pinned independently of any running aa-api binary.
 
-use assert_cmd::Command;
+use std::process::ExitCode;
 
-#[test]
-fn admin_run_retention_dry_run_exits_success() {
-    Command::cargo_bin("aasm")
-        .expect("aasm binary must build")
-        .args(["admin", "run-retention", "--dry-run"])
-        .assert()
-        .success();
+use wiremock::matchers::{body_json, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use aa_cli::commands::admin::retention::{dispatch, RunRetentionArgs};
+use aa_cli::config::ResolvedContext;
+use aa_cli::output::OutputFormat;
+
+fn make_context(api_url: &str) -> ResolvedContext {
+    ResolvedContext {
+        name: None,
+        api_url: api_url.to_string(),
+        api_key: None,
+    }
 }
 
-#[test]
-fn admin_run_retention_stub_message_points_at_aaasm_1590() {
-    let output = Command::cargo_bin("aasm")
-        .expect("aasm binary must build")
-        .args(["admin", "run-retention"])
-        .output()
-        .expect("aasm must run");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("AAASM-1590"),
-        "stub message must point operators at the in-flight wiring ticket, got: {stderr}"
+fn sample_stats_json() -> serde_json::Value {
+    serde_json::json!({
+        "ran_at": "2026-05-23T12:34:56Z",
+        "hot_rows": 100,
+        "compressed_rows": 20,
+        "archived_rows": 5,
+        "dropped_rows": 3,
+        "freed_bytes": 4096,
+        "dry_run": false
+    })
+}
+
+/// Default invocation (no `--dry-run`) POSTs `{"dry_run": false}` and
+/// exits SUCCESS when the gateway returns a valid stats JSON.
+#[tokio::test]
+async fn run_retention_default_posts_dry_run_false_and_succeeds() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/admin/retention-policy/run"))
+        .and(body_json(serde_json::json!({"dry_run": false})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sample_stats_json()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let result = std::thread::spawn(move || {
+        let ctx = make_context(&uri);
+        dispatch(RunRetentionArgs { dry_run: false }, &ctx, OutputFormat::Table)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+}
+
+/// `--dry-run` puts `{"dry_run": true}` on the wire.
+#[tokio::test]
+async fn run_retention_dry_run_flag_flows_to_request_body() {
+    let server = MockServer::start().await;
+
+    let mut dry_run_stats = sample_stats_json();
+    dry_run_stats["dry_run"] = serde_json::Value::Bool(true);
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/admin/retention-policy/run"))
+        .and(body_json(serde_json::json!({"dry_run": true})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(dry_run_stats))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let result = std::thread::spawn(move || {
+        let ctx = make_context(&uri);
+        dispatch(RunRetentionArgs { dry_run: true }, &ctx, OutputFormat::Json)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
+}
+
+/// Connect-refused (unreachable gateway) surfaces as `ExitCode::FAILURE`.
+/// Points the CLI at a port that has no listener — the request errors
+/// out at connection time and the dispatcher must NOT silently exit 0.
+#[tokio::test]
+async fn run_retention_unreachable_gateway_returns_failure() {
+    // Bind ourselves to grab a free port, then drop the listener so the
+    // port is definitively closed before the CLI dials.
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral");
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+
+    let uri = format!("http://127.0.0.1:{port}");
+    let result = std::thread::spawn(move || {
+        let ctx = make_context(&uri);
+        dispatch(RunRetentionArgs { dry_run: false }, &ctx, OutputFormat::Table)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(
+        result,
+        ExitCode::FAILURE,
+        "connect-refused must surface as ExitCode::FAILURE, not silent success"
     );
+}
+
+/// `--output yaml` renders the response as YAML; the wire contract is
+/// unchanged.
+#[tokio::test]
+async fn run_retention_respects_yaml_output_selector() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/admin/retention-policy/run"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sample_stats_json()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let uri = server.uri();
+    let result = std::thread::spawn(move || {
+        let ctx = make_context(&uri);
+        dispatch(RunRetentionArgs { dry_run: false }, &ctx, OutputFormat::Yaml)
+    })
+    .join()
+    .unwrap();
+
+    assert_eq!(result, ExitCode::SUCCESS);
 }


### PR DESCRIPTION
## Description

Epic 18 Story S-I.5 (AAASM-1872) — fifth of six Sub-tasks under Story AAASM-1590. Honours **AAASM-1588 closeout comment 12531 follow-up #2** end-to-end: `aasm admin run-retention` is now a live operator command that posts to the gateway's admin endpoint and prints the returned `RetentionRunStatsDto`.

### Scope discovery — most of the spec was already done

When I started this Subtask, I expected to add the aa-api handler, register it in OpenAPI, regenerate `openapi/v1.yaml` and `dashboard/src/api/generated/schema.d.ts`, and bump the `api_openapi_contract.rs` integration test. **All of those were already in place** on master, landed by sibling Stories AAASM-1850 / AAASM-1856 / AAASM-1861:

| Spec deliverable | State on master before this PR |
|---|---|
| `aa-api/src/handlers/admin.rs` → `run_retention_policy` | ✅ Implemented, utoipa-annotated, calls `engine.run_once().await` |
| Router registration `POST /admin/retention-policy/run` | ✅ Mounted in `aa-api/src/routes/mod.rs` |
| `openapi/v1.yaml` includes the path | ✅ Present |
| `dashboard/src/api/generated/schema.d.ts` includes the path | ✅ Present |
| `api_openapi_contract.rs` lists the path | ✅ Already listed |
| Models `RunRetentionRequest`, `RetentionRunStatsDto` | ✅ Defined |

This PR's actual delivery is narrow: connect the CLI placeholder to the existing endpoint.

### What this PR delivers

- **`aa-cli/src/commands/admin/mod.rs`** — `dispatch` signature grows `(args, ctx, output)` to match the established pattern from `alerts::dispatch` etc. Caller in `commands::mod` updated.
- **`aa-cli/src/commands/admin/retention.rs`** — placeholder body replaced with a live HTTP POST through the shared `client::post_json`. Request body `RunRetentionRequest { dry_run }`, response body `RetentionRunStatsDto`. Output respects the global `--output` selector: YAML when selected, pretty JSON otherwise. Exit `SUCCESS` on 2xx, `FAILURE` (with stderr message) on connect refused / HTTP error / parse failure.
- **`aa-cli/src/commands/admin/retention.rs::tests`** (NEW unit tests) — pin the local DTOs against the OpenAPI wire shape: `dry_run` field name in the request, every field of `RetentionRunStatsDto` in the response, endpoint path matches what the router mounts.
- **`aa-cli/tests/admin_run_retention.rs`** (REWRITTEN integration tests) — 4 wiremock-driven tests covering the live wire contract: default invocation, `--dry-run` flag, connect-refused failure, YAML output selector. The pre-existing stub-message tests are gone (their assertions are now false).

### Mapping to Subtask AC

| AC | Verification |
|---|---|
| `aasm admin run-retention` (and `--dry-run`) prints `RetentionStats` JSON | `run_retention_default_posts_dry_run_false_and_succeeds` + `run_retention_dry_run_flag_flows_to_request_body` wiremock tests |
| Exit 0 on success | Above tests assert `ExitCode::SUCCESS` |
| Non-zero with clear message if gateway unreachable | `run_retention_unreachable_gateway_returns_failure` asserts `ExitCode::FAILURE` against a bind-and-drop port |
| OpenAPI spec drift + dashboard codegen drift CI green | No regeneration needed — predecessor PRs already covered both |
| Cross-reference comment on AAASM-1588 follow-up #2 | Will be posted at closeout |

### What this PR explicitly defers

- **Gateway-level end-to-end test** (CLI → real running aa-api server → SqliteBackend) — covered at the AAASM-1873 verification Sub-task. The wiremock pattern here pins the CLI's wire contract; the verification Sub-task asserts the live integration.
- **`Table` output format dedicated rendering** — for a single-record `RetentionRunStatsDto`, table-style rendering would just print key:value pairs identical to JSON. `OutputFormat::Table` is treated the same as `OutputFormat::Json` for now (pretty JSON). The dashboard already parses the identical shape.

## Type of Change

- [x] ✨ New feature (CLI live transport for admin run-retention)
- [x] ♻️ Refactoring (`admin::dispatch` signature growth)

## Breaking Changes

- [x] No

`admin::dispatch` is internal to aa-cli; only `commands::mod` calls it. The CLI's user-facing surface (the `aasm admin run-retention [--dry-run]` invocation) is unchanged. The output shape is now JSON of the real `RetentionRunStatsDto` instead of a stub stderr message, which is the intent of the Subtask.

## Related Issues

- Jira Story: [AAASM-1590](https://lightning-dust-mite.atlassian.net/browse/AAASM-1590) (E18 S-I)
- Jira Subtask: [AAASM-1872](https://lightning-dust-mite.atlassian.net/browse/AAASM-1872) (S-I.5)
- Honours: [AAASM-1588](https://lightning-dust-mite.atlassian.net/browse/AAASM-1588) closeout comment 12531 follow-up #2
- Epic: [AAASM-1569](https://lightning-dust-mite.atlassian.net/browse/AAASM-1569)
- Builds on the HTTP-side scaffolding from AAASM-1850 / AAASM-1856 / AAASM-1861 and the runtime engine from AAASM-1870 / AAASM-1588.

## Testing

- [x] Unit tests added (`commands::admin::retention::tests` — 4 cases pinning wire shape + endpoint)
- [x] Integration tests rewritten (`tests/admin_run_retention.rs` — 4 wiremock cases pinning live transport)
- [x] `cargo nextest run -p aa-cli` — **540/540 pass**
- [x] `cargo nextest run -p aa-gateway` — **992/992 pass**
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean (lefthook pre-commit on every commit)
- [x] `cargo fmt --check` clean
- [x] `cargo doc --workspace --no-deps` clean (pre-push)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] 4 GitEmoji-tagged commits, single logical change each
- [x] Branch off latest `remote/master@ae8eac41`
- [x] No parallel PR for AAASM-1872 (verified via `gh pr list` + `git ls-remote`)
- [ ] All CI checks passing (will validate post-push)

[AAASM-1590]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ