### PR TITLE
[AAASM-1559] ✨ (aa-cli/audit): Add --dry-run-only filter to aa audit list

### DIFF
--- a/aa-cli/src/commands/audit/export.rs
+++ b/aa-cli/src/commands/audit/export.rs
@@ -65,6 +65,11 @@ impl ExportArgs {
             since: self.since.clone(),
             until: self.until.clone(),
             limit: self.limit,
+            // `aa audit export` reads the existing live audit corpus; observe-
+            // mode shadow events are surfaced through `aa audit list
+            // --dry-run-only` instead. Leaving this off here keeps export
+            // behaviour identical to before AAASM-1559.
+            dry_run_only: false,
         }
     }
 }

--- a/aa-cli/src/commands/audit/list.rs
+++ b/aa-cli/src/commands/audit/list.rs
@@ -407,6 +407,115 @@ mod tests {
         assert!(url.contains("per_page=25"));
     }
 
+    // --- dry-run-only filter (AAASM-1559) ---
+
+    #[test]
+    fn extract_dry_run_reads_true_from_payload() {
+        // Mirrors the JSON shape that aa-gateway/policy_service.rs::record_audit
+        // produces when shadow events fire (see AAASM-1564).
+        let entry = sample_entry(
+            "ToolCallIntercepted",
+            r#"{"decision":1,"dry_run":true,"shadow_decision":"deny"}"#,
+        );
+        assert!(extract_dry_run(&entry));
+    }
+
+    #[test]
+    fn extract_dry_run_defaults_to_false_when_key_missing_or_wrong_type() {
+        // Live (non-observe) entries don't carry the key. Malformed entries
+        // must also report false rather than panic so a flaky producer
+        // doesn't drop the whole listing.
+        let live = sample_entry("PolicyViolation", r#"{"result":"deny"}"#);
+        assert!(!extract_dry_run(&live));
+
+        let wrong_type = sample_entry("ToolCallIntercepted", r#"{"dry_run":"true"}"#);
+        assert!(!extract_dry_run(&wrong_type));
+
+        let not_json = sample_entry("ToolCallIntercepted", "not even json");
+        assert!(!extract_dry_run(&not_json));
+    }
+
+    fn observe_entry() -> AuditEntry {
+        sample_entry(
+            "ToolCallIntercepted",
+            r#"{"decision":1,"dry_run":true,"shadow_decision":"deny","shadow_reason":"tool denied by policy"}"#,
+        )
+    }
+
+    fn live_entry() -> AuditEntry {
+        sample_entry("ToolCallIntercepted", r#"{"result":"allow"}"#)
+    }
+
+    #[test]
+    fn default_apply_filters_hides_dry_run_entries() {
+        // The whole point of making --dry-run-only an exclusive filter: the
+        // operator running `aa audit list` without flags must not see
+        // shadow events mixed in with their live enforcement decisions.
+        let entries = vec![live_entry(), observe_entry()];
+        let args = ListArgs {
+            agent: None,
+            action: None,
+            result: None,
+            since: None,
+            until: None,
+            limit: 50,
+            dry_run_only: false,
+        };
+        let filtered = apply_filters(&entries, &args);
+        assert_eq!(filtered.len(), 1);
+        assert!(!extract_dry_run(&filtered[0]));
+    }
+
+    #[test]
+    fn apply_filters_with_dry_run_only_keeps_only_shadow_entries() {
+        // The complementary case: --dry-run-only drops the live entries and
+        // surfaces just the would-be ones.
+        let entries = vec![live_entry(), observe_entry(), live_entry(), observe_entry()];
+        let args = ListArgs {
+            agent: None,
+            action: None,
+            result: None,
+            since: None,
+            until: None,
+            limit: 50,
+            dry_run_only: true,
+        };
+        let filtered = apply_filters(&entries, &args);
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered.iter().all(extract_dry_run));
+    }
+
+    #[test]
+    fn dry_run_only_composes_with_since_filter() {
+        // --dry-run-only + --since must compose: the time window cuts first,
+        // then the dry-run filter, so a long-tail observe-mode audit log
+        // returns only the recent shadow events.
+        let mut old_shadow = observe_entry();
+        old_shadow.timestamp = "2026-04-30T08:00:00Z".to_string();
+        let mut recent_shadow = observe_entry();
+        recent_shadow.timestamp = "2026-04-30T12:00:00Z".to_string();
+        let mut recent_live = live_entry();
+        recent_live.timestamp = "2026-04-30T12:30:00Z".to_string();
+
+        let entries = vec![old_shadow, recent_shadow.clone(), recent_live];
+        let args = ListArgs {
+            agent: None,
+            action: None,
+            result: None,
+            since: Some("2026-04-30T10:00:00Z".to_string()),
+            until: None,
+            limit: 50,
+            dry_run_only: true,
+        };
+        let filtered = apply_filters(&entries, &args);
+        assert_eq!(
+            filtered.len(),
+            1,
+            "only the recent shadow entry should survive both filters"
+        );
+        assert_eq!(filtered[0].timestamp, recent_shadow.timestamp);
+    }
+
     #[test]
     fn colorize_result_colors() {
         let allow = colorize_result("allow");

--- a/aa-cli/src/commands/audit/list.rs
+++ b/aa-cli/src/commands/audit/list.rs
@@ -37,6 +37,13 @@ pub struct ListArgs {
     /// Maximum number of entries to return.
     #[arg(long, default_value_t = 50)]
     pub limit: u32,
+
+    /// Show only sandbox / observe-mode shadow events — entries the gateway
+    /// recorded with `dry_run: true` because policy was evaluated in observe
+    /// mode (AAASM-1564). When this flag is OFF (the default), shadow events
+    /// are hidden so operators see only live enforcement decisions.
+    #[arg(long)]
+    pub dry_run_only: bool,
 }
 
 /// Build the query URL for `GET /api/v1/logs` with filter parameters.
@@ -72,6 +79,18 @@ pub fn extract_tool(entry: &AuditEntry) -> String {
         .unwrap_or_else(|| "-".to_string())
 }
 
+/// Extract the `dry_run` flag from the entry's payload JSON.
+///
+/// Returns `true` when the gateway tagged this entry as an observe-mode
+/// shadow event (AAASM-1564). Returns `false` for every other case —
+/// missing key, non-bool value, payload that isn't valid JSON.
+pub fn extract_dry_run(entry: &AuditEntry) -> bool {
+    serde_json::from_str::<serde_json::Value>(&entry.payload)
+        .ok()
+        .and_then(|v| v.get("dry_run").and_then(|d| d.as_bool()))
+        .unwrap_or(false)
+}
+
 /// Extract a policy name from the entry's payload JSON.
 pub fn extract_policy(entry: &AuditEntry) -> String {
     serde_json::from_str::<serde_json::Value>(&entry.payload)
@@ -88,7 +107,15 @@ fn matches_result_filter(entry: &AuditEntry, filter: &AuditResult) -> bool {
     }
 }
 
-/// Apply client-side filters (time range and result) to entries.
+/// Apply client-side filters (time range, result, dry-run) to entries.
+///
+/// `--dry-run-only` is an exclusive filter:
+///
+/// * OFF (default) → entries with `dry_run: true` are **hidden**, so the
+///   default `aa audit list` view shows live enforcement decisions only and
+///   doesn't get noisy as soon as anyone runs an agent under observe mode.
+/// * ON → entries with `dry_run: true` are **the only ones kept**, so an
+///   operator tuning a sandbox policy sees exactly the would-be violations.
 pub fn apply_filters(entries: &[AuditEntry], args: &ListArgs) -> Vec<AuditEntry> {
     let since = args.since.as_deref().and_then(parse_since);
     let until = args.until.as_deref().and_then(parse_until);
@@ -97,6 +124,13 @@ pub fn apply_filters(entries: &[AuditEntry], args: &ListArgs) -> Vec<AuditEntry>
         .iter()
         .filter(|e| is_within_time_range(&e.timestamp, since.as_ref(), until.as_ref()))
         .filter(|e| args.result.as_ref().map_or(true, |r| matches_result_filter(e, r)))
+        .filter(|e| {
+            if args.dry_run_only {
+                extract_dry_run(e)
+            } else {
+                !extract_dry_run(e)
+            }
+        })
         .cloned()
         .collect()
 }
@@ -282,6 +316,7 @@ mod tests {
             since: None,
             until: None,
             limit: 50,
+            dry_run_only: false,
         };
         let filtered = apply_filters(&entries, &args);
         assert_eq!(filtered.len(), 2);
@@ -301,6 +336,7 @@ mod tests {
             since: None,
             until: None,
             limit: 50,
+            dry_run_only: false,
         };
         let filtered = apply_filters(&entries, &args);
         assert_eq!(filtered.len(), 1);
@@ -322,6 +358,7 @@ mod tests {
             since: Some("2026-04-30T10:00:00Z".to_string()),
             until: None,
             limit: 50,
+            dry_run_only: false,
         };
         let filtered = apply_filters(&entries, &args);
         assert_eq!(filtered.len(), 1);
@@ -342,6 +379,7 @@ mod tests {
             since: None,
             until: None,
             limit: 50,
+            dry_run_only: false,
         };
         let url = build_url(&ctx, &args);
         assert_eq!(url, "http://localhost:8080/api/v1/logs?per_page=50&page=1");
@@ -361,6 +399,7 @@ mod tests {
             since: None,
             until: None,
             limit: 25,
+            dry_run_only: false,
         };
         let url = build_url(&ctx, &args);
         assert!(url.contains("agent_id=aa001"));

--- a/aa-cli/tests/audit_list_export.rs
+++ b/aa-cli/tests/audit_list_export.rs
@@ -60,6 +60,7 @@ async fn audit_list_returns_success_with_mock_data() {
             since: None,
             until: None,
             limit: 50,
+            dry_run_only: false,
         };
         let ctx = make_context(&uri);
         aa_cli::commands::audit::list::run(args, &ctx, aa_cli::output::OutputFormat::Table)
@@ -92,6 +93,7 @@ async fn audit_list_with_agent_filter_sends_query_param() {
             since: None,
             until: None,
             limit: 50,
+            dry_run_only: false,
         };
         let ctx = make_context(&uri);
         aa_cli::commands::audit::list::run(args, &ctx, aa_cli::output::OutputFormat::Json)
@@ -123,6 +125,7 @@ async fn audit_list_fails_on_server_error() {
             since: None,
             until: None,
             limit: 50,
+            dry_run_only: false,
         };
         let ctx = make_context(&uri);
         aa_cli::commands::audit::list::run(args, &ctx, aa_cli::output::OutputFormat::Table)


### PR DESCRIPTION
## Description

Consumer-side CLI surface for the shadow audit events that AAASM-1564 encodes into audit payloads (`dry_run: true, shadow_decision: ..., shadow_reason: ...`). Adds `--dry-run-only` to `aa audit list` with an **exclusive** semantic:

| Flag state | Behaviour |
|---|---|
| **OFF** (default) | Entries with `dry_run: true` are **hidden** — the default `aa audit list` view stays focused on live enforcement so the listing doesn't get noisy as soon as anyone runs an agent under observe mode |
| **ON** | Entries with `dry_run: true` are **the only ones kept** — surfaces exactly the would-be violations an operator needs while tuning a sandbox policy |

`extract_dry_run()` parses the `dry_run` flag out of the payload JSON (the same key `aa-gateway/src/service/policy_service.rs::record_audit` writes). The new filter goes through the existing `apply_filters()` pipeline, so `--since` / `--until` / `--result` / `--format` all compose with `--dry-run-only` for free.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

**Behavioural note:** the default view now hides observe-mode shadow events. Pre-feature audit logs had no `dry_run` key in any payload, so `extract_dry_run` returns `false` for every existing entry — the default `aa audit list` output for any pre-feature audit corpus is byte-identical to before. Only audit corpora containing observe-mode entries (which can only exist on gateways running master from #749 onward) see the new filter behaviour.

`aa audit export` keeps its pre-feature behaviour explicitly: `ExportArgs::as_list_args` sets `dry_run_only: false` with a comment pointing to `aa audit list --dry-run-only` for the shadow-event view.

## Related Issues

- Related Jira ticket: [AAASM-1559](https://lightning-dust-mite.atlassian.net/browse/AAASM-1559) (Story [AAASM-1553](https://lightning-dust-mite.atlassian.net/browse/AAASM-1553))
- Depends on: #749 (AAASM-1564) — service layer encodes `dry_run`/`shadow_decision` into the audit payload

## What's in here

2 commits:

1. ✨ Wire `--dry-run-only` end-to-end in `aa-cli/audit/list.rs` (ListArgs field + `extract_dry_run` helper + exclusive-semantic filter in `apply_filters` + 8 bisectable `ListArgs` struct-literal updates in lib + integration tests + `ExportArgs::as_list_args` comment)
2. ✅ Five unit tests covering extract-true, extract-defaults-to-false, default-hides-shadow, `--dry-run-only` keeps only shadow, `--dry-run-only` composes with `--since`

## Testing

```
cargo nextest run -p aa-cli                                              # 553 / 553 pass
cargo clippy --workspace --all-targets --all-features --exclude aa-ffi-python -- -D warnings   # clean
```

## AC checklist

- [x] `aa audit list --dry-run-only` returns only events with `dry_run: true` (`apply_filters_with_dry_run_only_keeps_only_shadow_entries`)
- [x] `--last <duration>` time filter works correctly with `--dry-run-only` — implemented as `--since <duration|iso8601>` per the existing CLI flag (`aa audit list --since 24h` is the documented form); composition tested by `dry_run_only_composes_with_since_filter`
- [x] `--format json` outputs valid JSON array per schema — the existing JSON output path runs after `apply_filters`, so the filter is transparent to `--format json` (also true for table and yaml)
- [x] Without `--dry-run-only`: live events shown, no dry-run events (`default_apply_filters_hides_dry_run_entries`)
- [x] Help text documents the flag (clap doc comment on `dry_run_only`, rendered into `aa audit list --help`)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on `extract_dry_run` + `apply_filters` + clap help text)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1559]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ