### PR TITLE
[AAASM-1907] 🐛 (aa-gateway/migrations): Enable columnstore inline in 0002 (fix migration ordering)

### DIFF
--- a/aa-gateway/migrations/postgres/0002_timescaledb_hypertables.sql
+++ b/aa-gateway/migrations/postgres/0002_timescaledb_hypertables.sql
@@ -32,9 +32,18 @@ EXCEPTION
                       acceleration and auto-compression.', SQLERRM;
 END $$;
 
--- Step 2: promote audit_events and metrics to hypertables and attach
--- compression policies. If step 1 failed silently the create_hypertable()
--- function will not exist, raising undefined_function — also caught.
+-- Step 2: promote audit_events and metrics to hypertables, enable the
+-- columnstore (TimescaleDB's storage mode that compression policies act
+-- on — required since TimescaleDB 2.18), and attach the compression
+-- policies.
+--
+-- EXCEPTION is `WHEN OTHERS` on purpose: the body can fail on plain
+-- PostgreSQL with several distinct SQLSTATEs (undefined_function from
+-- create_hypertable, invalid_parameter_value from the timescaledb.compress
+-- storage parameter, feature_not_supported for the policy call, etc.).
+-- On a TimescaleDB-enabled cluster every statement succeeds so the
+-- catch-all only fires on plain-PG paths where graceful skip is the
+-- documented intent.
 DO $$
 BEGIN
     PERFORM create_hypertable(
@@ -42,6 +51,7 @@ BEGIN
         chunk_time_interval => INTERVAL '7 days',
         if_not_exists       => TRUE
     );
+    ALTER TABLE audit_events SET (timescaledb.compress = true);
     PERFORM add_compression_policy(
         'audit_events',
         INTERVAL '30 days',
@@ -53,12 +63,13 @@ BEGIN
         chunk_time_interval => INTERVAL '1 day',
         if_not_exists       => TRUE
     );
+    ALTER TABLE metrics SET (timescaledb.compress = true);
     PERFORM add_compression_policy(
         'metrics',
         INTERVAL '7 days',
         if_not_exists => TRUE
     );
 EXCEPTION
-    WHEN undefined_function THEN
-        RAISE NOTICE 'TimescaleDB functions unavailable; hypertables not created (plain PostgreSQL fallback)';
+    WHEN OTHERS THEN
+        RAISE NOTICE 'TimescaleDB functions/parameters unavailable; hypertables not created (plain PostgreSQL fallback): %', SQLERRM;
 END $$;


### PR DESCRIPTION
## Description

Modifies `0002_timescaledb_hypertables.sql` in place to enable columnstore via `ALTER TABLE … SET (timescaledb.compress = true)` between `create_hypertable()` and `add_compression_policy()`. Also widens the EXCEPTION clause from `WHEN undefined_function` to `WHEN OTHERS`.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

Pre-v0.1.0 — no production deployments exist. The in-place edit of 0002 changes its sqlx checksum; affected DBs are all ephemeral CI containers (fresh per run) or local dev DBs (acceptable to wipe).

## Why this is needed (and why AAASM-1890 wasn't enough)

`sqlx::migrate!` runs migrations in **strict order**. AAASM-1890 (PR #758, merged) added `0003_timescaledb_compression_policies.sql` as a "follow-up" assuming 0002 would have already succeeded:

- **Plain PG**: 0002's `EXCEPTION WHEN undefined_function` caught `create_hypertable`'s missing-function error → migration recorded as applied with NOTICE → 0003 then ran cleanly. PR #758's CI hit only this path so the fix appeared to work.
- **TimescaleDB**: 0002 succeeded through `create_hypertable`, then failed at `add_compression_policy` with "columnstore not enabled" — different SQLSTATE, EXCEPTION didn't catch it. Migration 2 aborted, **migration 3 never ran**.

SD-5's `timescaledb-tests` CI job (PR #757) is the first job that actually exercised the TimescaleDB path and exposed this ordering bug.

## Fix

In `aa-gateway/migrations/postgres/0002_timescaledb_hypertables.sql`:

```sql
PERFORM create_hypertable('audit_events', 'ts', ...);
ALTER TABLE audit_events SET (timescaledb.compress = true);  -- NEW
PERFORM add_compression_policy('audit_events', INTERVAL '30 days', if_not_exists => TRUE);
-- ...same for metrics...
EXCEPTION
    WHEN OTHERS THEN
        RAISE NOTICE 'TimescaleDB functions/parameters unavailable; hypertables not created (plain PostgreSQL fallback): %', SQLERRM;
```

0003 stays in place as an idempotent no-op (every statement is `if_not_exists => TRUE` or a harmless re-set of an already-set storage parameter).

## Checksum safety

Modifying 0002 changes its sqlx-recorded checksum. Affected systems:

| Environment | Old 0002 state | Impact |
|---|---|---|
| TimescaleDB CI containers | **Never** successfully applied | None — no checksum recorded |
| Plain PG CI containers | Applied with NOTICE; ephemeral | None — fresh container each run |
| Local dev DBs | May have applied | Wipe DB (acceptable pre-v0.1.0) |
| Production | None — pre-v0.1.0 | None |

## Related Issues

- Related Jira ticket: [AAASM-1907](https://lightning-dust-mite.atlassian.net/browse/AAASM-1907) (bug subtask under [AAASM-1586](https://lightning-dust-mite.atlassian.net/browse/AAASM-1586) — Story; [AAASM-1569](https://lightning-dust-mite.atlassian.net/browse/AAASM-1569) — Epic)
- Supersedes (in effect): [AAASM-1890](https://lightning-dust-mite.atlassian.net/browse/AAASM-1890) — the 0003 file from that ticket remains as an idempotent guardrail
- Unblocks: [AAASM-1858](https://lightning-dust-mite.atlassian.net/browse/AAASM-1858) / PR #757

## Testing

- [x] Local `cargo nextest run -p aa-gateway storage::migrations` → 6/6 PASS (including testcontainer Postgres run)
- [ ] CI `Test` job (postgres:18-alpine) — graceful skip path
- [ ] After merge + rebase: SD-5's `timescaledb-tests` job exercises the TimescaleDB path end-to-end

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated — migration body comments explain the columnstore requirement and why EXCEPTION widened to WHEN OTHERS
- [ ] All CI checks passing — will validate on push
- [x] Commits are small and follow the Gitmoji convention (1 commit, single SQL file)

[AAASM-1907]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ