### PR TITLE
[AAASM-1563] ✨ (dashboard): Add SandboxSummaryCard presentational component

### DIFF
--- a/dashboard/src/components/SandboxSummaryCard.css
+++ b/dashboard/src/components/SandboxSummaryCard.css
@@ -1,0 +1,128 @@
+/* AAASM-1563 — Sandbox Summary Card
+ *
+ * Amber palette intentionally contrasts with the dashboard's red (live-deny)
+ * and green (live-allow) tokens so an operator can immediately distinguish
+ * "would-be" / observe-mode aggregates from live enforcement data.
+ */
+
+.sandbox-summary-card {
+  --sandbox-amber: #d97706;
+  --sandbox-amber-bg: rgba(217, 119, 6, 0.08);
+  --sandbox-amber-border: rgba(217, 119, 6, 0.32);
+
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border: 1px solid var(--sandbox-amber-border);
+  border-left: 4px solid var(--sandbox-amber);
+  border-radius: 6px;
+  background: var(--sandbox-amber-bg);
+}
+
+.sandbox-summary-card__head {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sandbox-summary-card__title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--sandbox-amber);
+}
+
+.sandbox-summary-card__subtitle {
+  margin: 0;
+  font-size: 13px;
+  color: var(--ink-3, #4b5563);
+}
+
+.sandbox-summary-card__policy {
+  font-weight: 600;
+}
+
+.sandbox-summary-card__window {
+  color: var(--ink-4, #6b7280);
+}
+
+.sandbox-summary-card__counts {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 8px;
+  margin: 4px 0;
+}
+
+.sandbox-summary-card__row {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sandbox-summary-card__count {
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: var(--sandbox-amber);
+}
+
+.sandbox-summary-card__label {
+  margin: 0;
+  font-size: 12px;
+  color: var(--ink-3, #4b5563);
+}
+
+.sandbox-summary-card__top-rule {
+  margin: 0;
+  font-size: 12px;
+  color: var(--ink-3, #4b5563);
+}
+
+.sandbox-summary-card__top-rule code {
+  padding: 1px 4px;
+  border-radius: 3px;
+  background: rgba(0, 0, 0, 0.04);
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 11px;
+}
+
+.sandbox-summary-card__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.sandbox-summary-card__btn {
+  padding: 6px 12px;
+  border: 1px solid var(--sandbox-amber-border);
+  border-radius: 4px;
+  background: white;
+  color: var(--ink-2, #1f2937);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.sandbox-summary-card__btn:hover:not(:disabled) {
+  background: var(--sandbox-amber-bg);
+}
+
+.sandbox-summary-card__btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.sandbox-summary-card__btn--enforce {
+  background: var(--sandbox-amber);
+  border-color: var(--sandbox-amber);
+  color: white;
+}
+
+.sandbox-summary-card__btn--enforce:hover:not(:disabled) {
+  background: #b45309;
+  border-color: #b45309;
+}

--- a/dashboard/src/components/SandboxSummaryCard.test.tsx
+++ b/dashboard/src/components/SandboxSummaryCard.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SandboxSummaryCard } from './SandboxSummaryCard'
+
+const baseCounts = {
+  wouldBeDenies: 47,
+  wouldBeRedactions: 12,
+  wouldBePendingApprovals: 3,
+}
+
+describe('SandboxSummaryCard', () => {
+  it('renders the policy name + default window label in the header', () => {
+    render(<SandboxSummaryCard policyName="coding-team-sandbox" counts={baseCounts} />)
+
+    const card = screen.getByTestId('sandbox-summary-card')
+    expect(within(card).getByRole('heading', { name: /sandbox summary/i })).toBeInTheDocument()
+    expect(within(card).getByText('coding-team-sandbox')).toBeInTheDocument()
+    expect(within(card).getByText(/last 24h/)).toBeInTheDocument()
+  })
+
+  it('honours a custom window label when provided', () => {
+    render(
+      <SandboxSummaryCard
+        policyName="team-alpha"
+        windowLabel="last 7d"
+        counts={baseCounts}
+      />,
+    )
+    expect(screen.getByText(/last 7d/)).toBeInTheDocument()
+  })
+
+  it('renders each would-be count under the matching label', () => {
+    render(<SandboxSummaryCard policyName="p" counts={baseCounts} />)
+
+    expect(within(screen.getByTestId('would-be-denies')).getByText('47')).toBeInTheDocument()
+    expect(within(screen.getByTestId('would-be-redactions')).getByText('12')).toBeInTheDocument()
+    expect(within(screen.getByTestId('would-be-pending-approvals')).getByText('3')).toBeInTheDocument()
+  })
+
+  it('omits the top-rule line when topRule is undefined', () => {
+    render(<SandboxSummaryCard policyName="p" counts={baseCounts} />)
+    expect(screen.queryByTestId('top-rule')).not.toBeInTheDocument()
+  })
+
+  it('renders the top-rule line with id and count when provided', () => {
+    render(
+      <SandboxSummaryCard
+        policyName="p"
+        counts={baseCounts}
+        topRule={{ id: 'block-bash-rm-rf', count: 31 }}
+      />,
+    )
+    const line = screen.getByTestId('top-rule')
+    expect(line).toHaveTextContent('Top matched rule')
+    expect(within(line).getByText('block-bash-rm-rf')).toBeInTheDocument()
+    expect(line).toHaveTextContent('31×')
+  })
+
+  it('disables every action button when no handlers are supplied', () => {
+    render(<SandboxSummaryCard policyName="p" counts={baseCounts} />)
+
+    expect(screen.getByRole('button', { name: /view all events/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /export csv/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /enable live enforcement/i })).toBeDisabled()
+  })
+
+  it('fires the respective callback when each enabled action button is clicked', async () => {
+    const user = userEvent.setup()
+    const onView = vi.fn()
+    const onExport = vi.fn()
+    const onEnforce = vi.fn()
+
+    render(
+      <SandboxSummaryCard
+        policyName="p"
+        counts={baseCounts}
+        onViewAllEvents={onView}
+        onExportCsv={onExport}
+        onEnableLiveEnforcement={onEnforce}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /view all events/i }))
+    await user.click(screen.getByRole('button', { name: /export csv/i }))
+    await user.click(screen.getByRole('button', { name: /enable live enforcement/i }))
+
+    expect(onView).toHaveBeenCalledTimes(1)
+    expect(onExport).toHaveBeenCalledTimes(1)
+    expect(onEnforce).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders a zero count without crashing or hiding the row', () => {
+    // Guard against an "empty state masquerading as nothing happened" — even
+    // when every count is zero the card should render the three rows so
+    // operators see that observe mode IS active for the window.
+    render(
+      <SandboxSummaryCard
+        policyName="p"
+        counts={{ wouldBeDenies: 0, wouldBeRedactions: 0, wouldBePendingApprovals: 0 }}
+      />,
+    )
+    expect(within(screen.getByTestId('would-be-denies')).getByText('0')).toBeInTheDocument()
+    expect(within(screen.getByTestId('would-be-redactions')).getByText('0')).toBeInTheDocument()
+    expect(within(screen.getByTestId('would-be-pending-approvals')).getByText('0')).toBeInTheDocument()
+  })
+})

--- a/dashboard/src/components/SandboxSummaryCard.tsx
+++ b/dashboard/src/components/SandboxSummaryCard.tsx
@@ -1,0 +1,145 @@
+import type { MouseEvent } from 'react'
+import './SandboxSummaryCard.css'
+
+/**
+ * Aggregate counts for the policy's sandbox (observe-mode) window.
+ *
+ * Each count is the number of shadow audit events the gateway recorded
+ * with `dry_run: true` (see AAASM-1564) over the configured window —
+ * what *would* have happened under live enforcement.
+ */
+export interface SandboxSummaryCounts {
+  wouldBeDenies: number
+  wouldBeRedactions: number
+  wouldBePendingApprovals: number
+}
+
+/**
+ * Most-frequent matched rule across the shadow events in the window,
+ * surfaced so operators can see at a glance which rule is generating
+ * the bulk of would-be violations.
+ */
+export interface SandboxSummaryTopRule {
+  /** Rule identifier as recorded in `shadow_decision.matched_rule_id`. */
+  id: string
+  /** Number of shadow events that matched this rule in the window. */
+  count: number
+}
+
+export interface SandboxSummaryCardProps {
+  /** Policy name surfaced in the card title. */
+  readonly policyName: string
+  /** Window label, e.g. `'last 24h'`. Free-form so callers can swap units. */
+  readonly windowLabel?: string
+  /** Counts to render in the breakdown. */
+  readonly counts: SandboxSummaryCounts
+  /** Optional top-rule line. Omits when `undefined`. */
+  readonly topRule?: SandboxSummaryTopRule
+  /** Fires when the operator clicks "View all events". */
+  readonly onViewAllEvents?: () => void
+  /** Fires when the operator clicks "Export CSV". */
+  readonly onExportCsv?: () => void
+  /**
+   * Fires when the operator clicks "Enable live enforcement →".
+   * Callers should open a confirmation modal before issuing the
+   * `enforcement_mode: enforce` policy update.
+   */
+  readonly onEnableLiveEnforcement?: () => void
+}
+
+/**
+ * Read-only summary card for the per-policy sandbox / observe-mode window.
+ *
+ * Renders the three would-be-decision counts (denies / redactions /
+ * pending approvals), an optional top-matched-rule line, and three
+ * action buttons. The component is purely presentational — all counts,
+ * the top rule, and the click handlers come from the caller so the
+ * card can be reused on any page that has access to an aggregated
+ * `dry_run: true` count.
+ *
+ * AAASM-1563. The data-source plumbing (`aa-api` aggregation endpoint
+ * + dashboard fetcher) lands in a follow-up subtask; this PR ships
+ * the primitive only.
+ */
+export function SandboxSummaryCard({
+  policyName,
+  windowLabel = 'last 24h',
+  counts,
+  topRule,
+  onViewAllEvents,
+  onExportCsv,
+  onEnableLiveEnforcement,
+}: SandboxSummaryCardProps) {
+  function handleClick(handler: (() => void) | undefined) {
+    return (event: MouseEvent<HTMLButtonElement>) => {
+      event.preventDefault()
+      handler?.()
+    }
+  }
+
+  return (
+    <section
+      className="sandbox-summary-card"
+      data-testid="sandbox-summary-card"
+      aria-labelledby="sandbox-summary-card-title"
+    >
+      <header className="sandbox-summary-card__head">
+        <h2 id="sandbox-summary-card-title" className="sandbox-summary-card__title">
+          Sandbox Summary
+        </h2>
+        <p className="sandbox-summary-card__subtitle">
+          <span className="sandbox-summary-card__policy">{policyName}</span>
+          <span className="sandbox-summary-card__window"> ({windowLabel})</span>
+        </p>
+      </header>
+
+      <dl className="sandbox-summary-card__counts">
+        <div className="sandbox-summary-card__row" data-testid="would-be-denies">
+          <dt className="sandbox-summary-card__count">{counts.wouldBeDenies}</dt>
+          <dd className="sandbox-summary-card__label">Would-be denies</dd>
+        </div>
+        <div className="sandbox-summary-card__row" data-testid="would-be-redactions">
+          <dt className="sandbox-summary-card__count">{counts.wouldBeRedactions}</dt>
+          <dd className="sandbox-summary-card__label">Would-be redactions</dd>
+        </div>
+        <div className="sandbox-summary-card__row" data-testid="would-be-pending-approvals">
+          <dt className="sandbox-summary-card__count">{counts.wouldBePendingApprovals}</dt>
+          <dd className="sandbox-summary-card__label">Would-be pending approvals</dd>
+        </div>
+      </dl>
+
+      {topRule && (
+        <p className="sandbox-summary-card__top-rule" data-testid="top-rule">
+          Top matched rule: <code>{topRule.id}</code> ({topRule.count}×)
+        </p>
+      )}
+
+      <div className="sandbox-summary-card__actions">
+        <button
+          type="button"
+          className="sandbox-summary-card__btn"
+          onClick={handleClick(onViewAllEvents)}
+          disabled={!onViewAllEvents}
+        >
+          View all events
+        </button>
+        <button
+          type="button"
+          className="sandbox-summary-card__btn"
+          onClick={handleClick(onExportCsv)}
+          disabled={!onExportCsv}
+        >
+          Export CSV
+        </button>
+        <button
+          type="button"
+          className="sandbox-summary-card__btn sandbox-summary-card__btn--enforce"
+          onClick={handleClick(onEnableLiveEnforcement)}
+          disabled={!onEnableLiveEnforcement}
+        >
+          Enable live enforcement →
+        </button>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Description

Standalone, read-only React component for AAASM-1563. Renders the per-policy observe-mode (sandbox) window summary:

```
┌─ SANDBOX SUMMARY ────────────────────────────────┐
│ coding-team-sandbox (last 24h)                    │
│                                                   │
│  47        12         3                           │
│  Would-be  Would-be   Would-be                    │
│  denies    redactions pending approvals           │
│                                                   │
│  Top matched rule: block-bash-rm-rf (31×)         │
│                                                   │
│  [View all events]  [Export CSV]  [Enable live →] │
└───────────────────────────────────────────────────┘
```

Purely presentational — every count, the top rule, and every click handler come from the caller as props. Buttons auto-disable when no handler is supplied so callers can wire surfaces incrementally.

The amber palette intentionally contrasts with the dashboard's red (live-deny) and green (live-allow) tokens so an operator can immediately distinguish "would-be" / observe-mode aggregates from live enforcement data.

## Scoped down from the original AC (rationale)

`aa-api` doesn't yet surface the `dry_run` / `shadow_decision` / `shadow_reason` fields that AAASM-1564 added to the internal audit pipeline. `grep enforcement_mode openapi/v1.yaml` returns no matches. That blocks:

| Original AC bullet | Blocker |
|---|---|
| Audit-log toggle shows/hides dry-run events | No tabular audit-log page in the dashboard; per-agent event table doesn't carry `dry_run` via API |
| Dry-run rows render amber "Would: X" badge | API doesn't carry the field |
| Sandbox Summary card on Policy detail (wire-up) | No aggregate-counts API to fetch from |
| "Enable live enforcement" button (action) | No policy-update endpoint accepting `enforcement_mode: enforce` |
| Playwright visual test for badge | Depends on the badge actually rendering, which depends on the data |

User-approved decision: ship the **presentational primitive** here so the component is testable / reviewable / styleable today, and file a follow-up subtask for the `aa-api` work + wire-up + audit-log integration.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

The component is new and unused — nothing in the dashboard imports it yet. Wire-up lands in a follow-up.

## Related Issues

- Related Jira ticket: [AAASM-1563](https://lightning-dust-mite.atlassian.net/browse/AAASM-1563) (Story [AAASM-1553](https://lightning-dust-mite.atlassian.net/browse/AAASM-1553))
- Depends on (already merged): AAASM-1564 (gateway emits the `dry_run` payload field in the audit pipeline)
- **Will file a follow-up subtask** under AAASM-1553 for the `aa-api` surface + dashboard wire-up

## What's in here

1 commit:

1. ✨ New `SandboxSummaryCard` component (TSX + scoped CSS) + 8 vitest unit tests covering header / counts rendering / top-rule conditional / buttons all-disabled-when-no-handlers / each handler fires / zero counts render

## Testing

```
pnpm test --run                # 1001 / 1001 pass (8 new + 993 existing)
pnpm type-check                # clean
pnpm lint                      # clean
```

## Checklist

- [x] Code follows project style guidelines (`pnpm lint`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (JSDoc on every exported symbol + scope-down rationale in the ticket comment)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1563]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ