### PR TITLE
[AAASM-1909] ✨ (aa-cli): Render storage block in aasm status + non-zero exit on DB unhealthy

### DIFF
--- a/aa-cli/src/commands/status/client.rs
+++ b/aa-cli/src/commands/status/client.rs
@@ -3,7 +3,8 @@
 use reqwest::Client;
 
 use super::models::{
-    AgentResponse, ApprovalResponse, CostResponse, HealthResponse, HealthzResponse, PaginatedResponse,
+    AdminStatusResponse, AgentResponse, ApprovalResponse, CostResponse, HealthResponse, HealthzResponse,
+    PaginatedResponse,
 };
 use crate::error::CliError;
 
@@ -37,6 +38,21 @@ impl StatusClient {
     pub async fn check_health(&self) -> Result<HealthResponse, CliError> {
         let resp = self.http.get(self.url("/api/v1/health")).send().await?;
         let body = resp.json::<HealthResponse>().await?;
+        Ok(body)
+    }
+
+    /// Fetch the storage-aware admin status block via
+    /// `GET /api/v1/admin/status` (AAASM-1591 / Epic 18 S-J).
+    ///
+    /// Returns an error when the gateway is unreachable or returns a
+    /// body the CLI cannot decode; in particular, an older gateway that
+    /// does not yet expose this route will respond with a `404` whose
+    /// non-JSON body fails decoding. Callers map both failures to a
+    /// missing storage section in `aasm status` rather than surfacing
+    /// the error directly.
+    pub async fn fetch_admin_status(&self) -> Result<AdminStatusResponse, CliError> {
+        let resp = self.http.get(self.url("/api/v1/admin/status")).send().await?;
+        let body = resp.json::<AdminStatusResponse>().await?;
         Ok(body)
     }
 

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -111,9 +111,10 @@ pub fn build_approvals_summary(approvals: &[ApprovalResponse]) -> ApprovalsSumma
 
 /// Fetch all status data from the gateway in parallel and compose a `StatusSnapshot`.
 pub async fn fetch_all(client: &StatusClient) -> StatusSnapshot {
-    let (health_result, healthz_result, agents_result, approvals_result, costs_result) = tokio::join!(
+    let (health_result, healthz_result, admin_status_result, agents_result, approvals_result, costs_result) = tokio::join!(
         client.check_health(),
         client.check_healthz(),
+        client.fetch_admin_status(),
         client.list_agents(),
         client.list_approvals(),
         client.get_costs(),
@@ -136,17 +137,19 @@ pub async fn fetch_all(client: &StatusClient) -> StatusSnapshot {
 
     let deployment = build_deployment_overview(client.base_url(), healthz_result.ok());
 
+    // AAASM-1591: surface the admin/status storage block when the
+    // gateway exposes it. A 404 / decode error from an older gateway
+    // is silently downgraded to None — the status section is omitted
+    // rather than turning the whole `aasm status` call into a failure.
+    let storage_health = admin_status_result.ok().map(|resp| resp.storage);
+
     StatusSnapshot {
         deployment,
         runtime,
         agents,
         approvals,
         budget,
-        // AAASM-1909 populates this in a follow-up commit by calling
-        // StatusClient::fetch_admin_status; today the field is always
-        // None so older gateways without /api/v1/admin/status keep
-        // working.
-        storage_health: None,
+        storage_health,
     }
 }
 

--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -142,6 +142,11 @@ pub async fn fetch_all(client: &StatusClient) -> StatusSnapshot {
         agents,
         approvals,
         budget,
+        // AAASM-1909 populates this in a follow-up commit by calling
+        // StatusClient::fetch_admin_status; today the field is always
+        // None so older gateways without /api/v1/admin/status keep
+        // working.
+        storage_health: None,
     }
 }
 

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -34,17 +34,28 @@ use models::StatusSnapshot;
 /// Compute the process exit code from a status snapshot.
 ///
 /// - `0` — all healthy
-/// - `1` — gateway is unreachable (`deployment.health == "unreachable"`) OR at
-///   least one agent has violations. Per the AAASM-1579 acceptance criteria,
-///   unreachable now maps to exit code 1 instead of the legacy exit code 2 so
-///   shell scripts can use a single non-zero check without distinguishing
-///   between failure modes.
+/// - `1` — any of:
+///     - gateway is unreachable (`deployment.health == "unreachable"`),
+///     - at least one agent has violations,
+///     - the storage health probe reports `"unavailable"` (AAASM-1591 AC:
+///       "Non-zero exit code if DB health check fails").
+///
+/// Per the AAASM-1579 acceptance criteria, all of these collapse to a
+/// single non-zero check so shell scripts don't have to distinguish
+/// between failure modes.
 pub fn compute_exit_code(snapshot: &StatusSnapshot) -> ExitCode {
     if snapshot.deployment.health == "unreachable" {
         return ExitCode::from(1);
     }
     let has_violations = snapshot.agents.iter().any(|a| a.violations_today > 0);
     if has_violations {
+        return ExitCode::from(1);
+    }
+    if snapshot
+        .storage_health
+        .as_ref()
+        .is_some_and(|s| s.health == "unavailable")
+    {
         return ExitCode::from(1);
     }
     ExitCode::SUCCESS
@@ -173,6 +184,65 @@ mod tests {
         assert_eq!(json["gateway_url"], "http://localhost:7391");
         assert_eq!(json["storage_backend"], "sqlite");
         assert_eq!(json["health"], "ok");
+    }
+
+    #[test]
+    fn exit_code_1_when_storage_health_is_unavailable() {
+        let mut snapshot = healthy_snapshot();
+        snapshot.storage_health = Some(AdminStorageHealthBlock {
+            backend: "postgres".into(),
+            path: None,
+            database_url: Some("postgresql://aasm:***@db:5432/aasm".into()),
+            health: "unavailable".into(),
+            latency_ms: 0,
+            row_counts: AdminRowCountsBlock {
+                audit_events_hot: 0,
+                agents: 0,
+                policy_versions: 0,
+            },
+            timescaledb: None,
+        });
+        assert_eq!(compute_exit_code(&snapshot), ExitCode::from(1));
+    }
+
+    #[test]
+    fn exit_code_0_when_storage_health_is_ok() {
+        let mut snapshot = healthy_snapshot();
+        snapshot.storage_health = Some(AdminStorageHealthBlock {
+            backend: "sqlite".into(),
+            path: Some("~/.aasm/local.db".into()),
+            database_url: None,
+            health: "ok".into(),
+            latency_ms: 1,
+            row_counts: AdminRowCountsBlock {
+                audit_events_hot: 47,
+                agents: 2,
+                policy_versions: 1,
+            },
+            timescaledb: None,
+        });
+        assert_eq!(compute_exit_code(&snapshot), ExitCode::SUCCESS);
+    }
+
+    #[test]
+    fn exit_code_0_when_storage_health_is_degraded() {
+        // "degraded" is reachable; it must not collapse to a non-zero
+        // exit. Only "unavailable" triggers the failure path.
+        let mut snapshot = healthy_snapshot();
+        snapshot.storage_health = Some(AdminStorageHealthBlock {
+            backend: "postgres".into(),
+            path: None,
+            database_url: Some("postgresql://aasm:***@db:5432/aasm".into()),
+            health: "degraded".into(),
+            latency_ms: 250,
+            row_counts: AdminRowCountsBlock {
+                audit_events_hot: 0,
+                agents: 0,
+                policy_versions: 0,
+            },
+            timescaledb: None,
+        });
+        assert_eq!(compute_exit_code(&snapshot), ExitCode::SUCCESS);
     }
 
     #[test]

--- a/aa-cli/src/commands/status/mod.rs
+++ b/aa-cli/src/commands/status/mod.rs
@@ -123,6 +123,7 @@ mod tests {
                 date: "2026-04-30".to_string(),
                 per_agent: vec![],
             },
+            storage_health: None,
         }
     }
 

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -352,6 +352,12 @@ pub struct StatusSnapshot {
     pub agents: Vec<AgentRow>,
     pub approvals: ApprovalsSummary,
     pub budget: BudgetRow,
+    /// Storage health block from `/api/v1/admin/status`, present when the
+    /// gateway exposes the route (AAASM-1591). Older gateways that only
+    /// serve `/healthz` leave this `None` and the storage section is
+    /// omitted from the rendered output.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_health: Option<AdminStorageHealthBlock>,
 }
 
 #[cfg(test)]

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -123,6 +123,57 @@ pub struct AdminTimescaleDbBlock {
     pub compression_ratio: f32,
 }
 
+/// Storage health block returned under `body.storage` in the
+/// `/api/v1/admin/status` response (AAASM-1591 / Epic 18 S-J).
+///
+/// Mirrors the server-side `aa_gateway::routes::admin_status::
+/// StorageHealthBlock` wire contract. Per-backend optional fields
+/// follow the same shape: `path` only on sqlite, `database_url`
+/// (already redacted by the gateway) only on postgres, `timescaledb`
+/// only when the TimescaleDB extension is active.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct AdminStorageHealthBlock {
+    /// Static backend identifier — e.g. `"sqlite"`, `"postgres"`,
+    /// `"memory"`, or `"unknown"` when the probe itself failed.
+    pub backend: String,
+    /// Local-mode SQLite file path. Present only when
+    /// `backend == "sqlite"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    /// PostgreSQL connection URL — already redacted server-side, so the
+    /// CLI never sees the raw password. Present only when
+    /// `backend == "postgres"`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub database_url: Option<String>,
+    /// Coarse health label: `"ok"`, `"degraded"`, or `"unavailable"`.
+    pub health: String,
+    /// Latency of the gateway's healthcheck probe in milliseconds.
+    pub latency_ms: u32,
+    /// Hot-tier row-count snapshot taken during the probe.
+    pub row_counts: AdminRowCountsBlock,
+    /// TimescaleDB rollup, present only when the extension is active.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timescaledb: Option<AdminTimescaleDbBlock>,
+}
+
+/// Top-level response from `GET /api/v1/admin/status`.
+///
+/// Mirrors `aa_gateway::routes::admin_status::AdminStatusBody`. The CLI
+/// only fetches and renders the `storage` block today; `mode`, `version`,
+/// and `uptime_secs` are deserialised so the response can be round-
+/// tripped if a future consumer needs them.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct AdminStatusResponse {
+    /// Deployment mode label: `"local"` or `"remote"`.
+    pub mode: String,
+    /// Gateway crate version.
+    pub version: String,
+    /// Seconds elapsed since the gateway became ready to serve traffic.
+    pub uptime_secs: u64,
+    /// Storage health block.
+    pub storage: AdminStorageHealthBlock,
+}
+
 /// Display model for the `aasm status` deployment-overview header.
 ///
 /// The serialised shape is the JSON contract for `aasm status --json` — field
@@ -429,6 +480,73 @@ mod tests {
         }"#;
         let block: AdminRowCountsBlock = serde_json::from_str(json).unwrap();
         assert_eq!(block.audit_events_hot, 1);
+    }
+
+    #[test]
+    fn admin_status_response_deserialises_postgres_with_timescaledb() {
+        let json = r#"{
+            "mode": "remote",
+            "version": "0.0.1",
+            "uptime_secs": 86400,
+            "storage": {
+                "backend": "postgres",
+                "database_url": "postgresql://aasm:***@db.internal:5432/aasm",
+                "health": "ok",
+                "latency_ms": 3,
+                "row_counts": {
+                    "audit_events_hot": 14293,
+                    "agents": 8,
+                    "policy_versions": 3
+                },
+                "timescaledb": {
+                    "enabled": true,
+                    "total_chunks": 12,
+                    "compressed_chunks": 8,
+                    "compression_ratio": 11.4
+                }
+            }
+        }"#;
+        let resp: AdminStatusResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.mode, "remote");
+        assert_eq!(resp.storage.backend, "postgres");
+        assert_eq!(resp.storage.health, "ok");
+        assert_eq!(resp.storage.latency_ms, 3);
+        assert!(resp.storage.path.is_none(), "postgres branch must omit path");
+        assert_eq!(
+            resp.storage.database_url.as_deref(),
+            Some("postgresql://aasm:***@db.internal:5432/aasm")
+        );
+        let ts = resp.storage.timescaledb.expect("timescaledb block present");
+        assert_eq!(ts.total_chunks, 12);
+        assert_eq!(ts.compressed_chunks, 8);
+    }
+
+    #[test]
+    fn admin_status_response_deserialises_sqlite_without_timescaledb() {
+        let json = r#"{
+            "mode": "local",
+            "version": "0.0.1",
+            "uptime_secs": 60,
+            "storage": {
+                "backend": "sqlite",
+                "path": "~/.aasm/local.db",
+                "health": "ok",
+                "latency_ms": 1,
+                "row_counts": {
+                    "audit_events_hot": 47,
+                    "agents": 2,
+                    "policy_versions": 1
+                }
+            }
+        }"#;
+        let resp: AdminStatusResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.storage.backend, "sqlite");
+        assert_eq!(resp.storage.path.as_deref(), Some("~/.aasm/local.db"));
+        assert!(
+            resp.storage.database_url.is_none(),
+            "sqlite branch must omit database_url"
+        );
+        assert!(resp.storage.timescaledb.is_none(), "sqlite must omit timescaledb block");
     }
 
     #[test]

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -89,6 +89,40 @@ pub struct HealthzResponse {
     pub database_url: Option<String>,
 }
 
+/// Hot-tier row-count snapshot returned inside the `/api/v1/admin/status`
+/// storage block (AAASM-1591 / Epic 18 S-J).
+///
+/// Field names mirror the server-side `aa_gateway::routes::admin_status::
+/// RowCountsBlock` wire contract verbatim. `#[serde(deny_unknown_fields)]`
+/// is intentionally omitted so future warm-/cold-tier counts can be added
+/// server-side without breaking older CLIs.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct AdminRowCountsBlock {
+    /// Audit events in the hot tier (uncompressed, queryable).
+    pub audit_events_hot: u64,
+    /// Registered agents.
+    pub agents: u64,
+    /// Total policy versions across all policy names.
+    pub policy_versions: u64,
+}
+
+/// TimescaleDB chunk + compression rollup, present in the
+/// `/api/v1/admin/status` storage block only when the PostgreSQL backend
+/// is connected to a cluster with the TimescaleDB extension installed.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct AdminTimescaleDbBlock {
+    /// Always `true` when the block is present — present-but-disabled is
+    /// reserved for a future state.
+    pub enabled: bool,
+    /// Total number of chunks across the gateway's hypertables.
+    pub total_chunks: u32,
+    /// Subset of `total_chunks` already compressed by the auto-policy.
+    pub compressed_chunks: u32,
+    /// Aggregate uncompressed/compressed size ratio as a human-friendly
+    /// float (e.g. `11.4` = 11.4× size reduction).
+    pub compression_ratio: f32,
+}
+
 /// Display model for the `aasm status` deployment-overview header.
 ///
 /// The serialised shape is the JSON contract for `aasm status --json` — field
@@ -373,6 +407,43 @@ mod tests {
             resp.database_url.as_deref(),
             Some("postgresql://user:secret@aasm-db:5432/aasm")
         );
+    }
+
+    #[test]
+    fn admin_row_counts_block_deserialises_documented_keys() {
+        let json = r#"{"audit_events_hot": 14293, "agents": 8, "policy_versions": 3}"#;
+        let block: AdminRowCountsBlock = serde_json::from_str(json).unwrap();
+        assert_eq!(block.audit_events_hot, 14_293);
+        assert_eq!(block.agents, 8);
+        assert_eq!(block.policy_versions, 3);
+    }
+
+    #[test]
+    fn admin_row_counts_block_tolerates_extra_keys() {
+        // Future warm/cold tier additions must not break older clients.
+        let json = r#"{
+            "audit_events_hot": 1,
+            "audit_events_warm": 99,
+            "agents": 1,
+            "policy_versions": 1
+        }"#;
+        let block: AdminRowCountsBlock = serde_json::from_str(json).unwrap();
+        assert_eq!(block.audit_events_hot, 1);
+    }
+
+    #[test]
+    fn admin_timescaledb_block_deserialises_documented_keys() {
+        let json = r#"{
+            "enabled": true,
+            "total_chunks": 12,
+            "compressed_chunks": 8,
+            "compression_ratio": 11.4
+        }"#;
+        let block: AdminTimescaleDbBlock = serde_json::from_str(json).unwrap();
+        assert!(block.enabled);
+        assert_eq!(block.total_chunks, 12);
+        assert_eq!(block.compressed_chunks, 8);
+        assert!((block.compression_ratio - 11.4).abs() < 0.05);
     }
 
     #[test]

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -476,6 +476,7 @@ mod tests {
                 date: "2026-04-30".to_string(),
                 per_agent: vec![],
             },
+            storage_health: None,
         };
         let json = serde_json::to_string_pretty(&snapshot).unwrap();
         assert!(json.contains("\"deployment\""));

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -97,15 +97,11 @@ pub fn format_storage_health(block: &AdminStorageHealthBlock) -> String {
     if let Some(url) = block.database_url.as_deref() {
         out.push_str(&format!("  DB:          {url}\n"));
     }
-    let (indicator, label_colored) = match block.health.as_str() {
-        "ok" => ("✓ ok".green().to_string(), "✓ ok"),
-        "degraded" => ("⚠ degraded".yellow().to_string(), "⚠ degraded"),
-        _ => ("✗ unavailable".red().to_string(), "✗ unavailable"),
+    let indicator = match block.health.as_str() {
+        "ok" => "✓ ok".green().to_string(),
+        "degraded" => "⚠ degraded".yellow().to_string(),
+        _ => "✗ unavailable".red().to_string(),
     };
-    // `label_colored` is unused as a binding but documents the bare
-    // label for readers — keep the variable name introduced for clarity
-    // without producing a warning.
-    let _ = label_colored;
     out.push_str(&format!("  DB Health:   {}  ({}ms)\n", indicator, block.latency_ms));
     out.push_str(&format!(
         "  Rows:        audit_events: {} hot\n",

--- a/aa-cli/src/commands/status/render.rs
+++ b/aa-cli/src/commands/status/render.rs
@@ -3,7 +3,9 @@
 use colored::Colorize;
 use comfy_table::{ContentArrangement, Table};
 
-use super::models::{AgentRow, ApprovalsSummary, BudgetRow, DeploymentOverview, RuntimeHealth, StatusSnapshot};
+use super::models::{
+    AdminStorageHealthBlock, AgentRow, ApprovalsSummary, BudgetRow, DeploymentOverview, RuntimeHealth, StatusSnapshot,
+};
 use crate::output::OutputFormat;
 
 /// Build the multi-line deployment-overview header block as a `String`.
@@ -75,6 +77,72 @@ pub fn format_deployment_overview(overview: &DeploymentOverview) -> String {
 /// `render_all` mirrors the other `render_*` section helpers.
 pub fn render_deployment_overview(overview: &DeploymentOverview) {
     println!("{}", format_deployment_overview(overview));
+}
+
+/// Format the Storage health section as a `String`.
+///
+/// Pure function so unit tests can assert on the exact output without
+/// capturing stdout. Layout follows the AAASM-1591 story description
+/// — `Backend` first, then per-backend identifier (`Path` on sqlite,
+/// `DB` on postgres), then health + latency, row counts, and the
+/// optional TimescaleDB line.
+pub fn format_storage_health(block: &AdminStorageHealthBlock) -> String {
+    let mut out = String::new();
+    out.push_str("STORAGE\n");
+    out.push_str("───────\n");
+    out.push_str(&format!("  Backend:     {}\n", block.backend));
+    if let Some(path) = block.path.as_deref() {
+        out.push_str(&format!("  Path:        {path}\n"));
+    }
+    if let Some(url) = block.database_url.as_deref() {
+        out.push_str(&format!("  DB:          {url}\n"));
+    }
+    let (indicator, label_colored) = match block.health.as_str() {
+        "ok" => ("✓ ok".green().to_string(), "✓ ok"),
+        "degraded" => ("⚠ degraded".yellow().to_string(), "⚠ degraded"),
+        _ => ("✗ unavailable".red().to_string(), "✗ unavailable"),
+    };
+    // `label_colored` is unused as a binding but documents the bare
+    // label for readers — keep the variable name introduced for clarity
+    // without producing a warning.
+    let _ = label_colored;
+    out.push_str(&format!("  DB Health:   {}  ({}ms)\n", indicator, block.latency_ms));
+    out.push_str(&format!(
+        "  Rows:        audit_events: {} hot\n",
+        format_count(block.row_counts.audit_events_hot)
+    ));
+    out.push_str(&format!(
+        "               agents: {}  |  policies: {}\n",
+        format_count(block.row_counts.agents),
+        format_count(block.row_counts.policy_versions)
+    ));
+    if let Some(ts) = block.timescaledb.as_ref() {
+        let ts_indicator = "✓ active".green();
+        out.push_str(&format!(
+            "  TimescaleDB: {}  ({}/{} chunks compressed, {:.1}× ratio)\n",
+            ts_indicator, ts.compressed_chunks, ts.total_chunks, ts.compression_ratio,
+        ));
+    }
+    out
+}
+
+/// Print the Storage health section to stdout.
+pub fn render_storage_health(block: &AdminStorageHealthBlock) {
+    println!("{}", format_storage_health(block));
+}
+
+/// Format a `u64` row count with thousands separators (e.g. `14_293` → `"14,293"`).
+fn format_count(n: u64) -> String {
+    let s = n.to_string();
+    let bytes = s.as_bytes();
+    let mut out = String::with_capacity(bytes.len() + bytes.len() / 3);
+    for (i, b) in bytes.iter().enumerate() {
+        if i > 0 && (bytes.len() - i) % 3 == 0 {
+            out.push(',');
+        }
+        out.push(*b as char);
+    }
+    out
 }
 
 /// Render the Runtime Health section to stdout.
@@ -262,6 +330,9 @@ pub fn render_all(snapshot: &StatusSnapshot, format: OutputFormat) {
         },
         OutputFormat::Table => {
             render_deployment_overview(&snapshot.deployment);
+            if let Some(storage_health) = snapshot.storage_health.as_ref() {
+                render_storage_health(storage_health);
+            }
             render_runtime_health(&snapshot.runtime);
             render_agents_table(&snapshot.agents);
             render_approvals_summary(&snapshot.approvals);
@@ -306,6 +377,97 @@ mod tests {
             uptime_secs: 8133,
             health: "ok".to_string(),
         }
+    }
+
+    fn sqlite_storage_block() -> AdminStorageHealthBlock {
+        use super::super::models::AdminRowCountsBlock;
+        AdminStorageHealthBlock {
+            backend: "sqlite".into(),
+            path: Some("~/.aasm/local.db".into()),
+            database_url: None,
+            health: "ok".into(),
+            latency_ms: 1,
+            row_counts: AdminRowCountsBlock {
+                audit_events_hot: 47,
+                agents: 2,
+                policy_versions: 1,
+            },
+            timescaledb: None,
+        }
+    }
+
+    fn postgres_timescale_storage_block() -> AdminStorageHealthBlock {
+        use super::super::models::{AdminRowCountsBlock, AdminTimescaleDbBlock};
+        AdminStorageHealthBlock {
+            backend: "postgres".into(),
+            path: None,
+            database_url: Some("postgresql://aasm-user:***@db.internal:5432/aasm".into()),
+            health: "ok".into(),
+            latency_ms: 3,
+            row_counts: AdminRowCountsBlock {
+                audit_events_hot: 14_293,
+                agents: 8,
+                policy_versions: 3,
+            },
+            timescaledb: Some(AdminTimescaleDbBlock {
+                enabled: true,
+                total_chunks: 12,
+                compressed_chunks: 8,
+                compression_ratio: 11.4,
+            }),
+        }
+    }
+
+    #[test]
+    fn format_storage_health_renders_sqlite_block_without_timescaledb_line() {
+        let rendered = strip_ansi(&format_storage_health(&sqlite_storage_block()));
+        assert!(rendered.starts_with("STORAGE\n"));
+        assert!(rendered.contains("  Backend:     sqlite\n"));
+        assert!(rendered.contains("  Path:        ~/.aasm/local.db\n"));
+        assert!(rendered.contains("  DB Health:   ✓ ok  (1ms)\n"));
+        assert!(rendered.contains("  Rows:        audit_events: 47 hot\n"));
+        assert!(rendered.contains("               agents: 2  |  policies: 1\n"));
+        assert!(
+            !rendered.contains("TimescaleDB"),
+            "sqlite block must not render TimescaleDB line"
+        );
+        assert!(
+            !rendered.contains("DB:"),
+            "sqlite block must not render DB: (postgres-only) line"
+        );
+    }
+
+    #[test]
+    fn format_storage_health_renders_postgres_block_with_redacted_url_and_timescaledb() {
+        let rendered = strip_ansi(&format_storage_health(&postgres_timescale_storage_block()));
+        assert!(rendered.contains("  Backend:     postgres\n"));
+        assert!(rendered.contains("  DB:          postgresql://aasm-user:***@db.internal:5432/aasm\n"));
+        // Server-side redaction means the raw password must never appear.
+        assert!(!rendered.contains("secret"));
+        assert!(rendered.contains("  DB Health:   ✓ ok  (3ms)\n"));
+        // Thousands separator on the hot count.
+        assert!(rendered.contains("  Rows:        audit_events: 14,293 hot\n"));
+        assert!(rendered.contains("  TimescaleDB: ✓ active  (8/12 chunks compressed, 11.4× ratio)\n"));
+        // Postgres branch must not render the sqlite-only Path line.
+        assert!(!rendered.contains("Path:"));
+    }
+
+    #[test]
+    fn format_storage_health_renders_unavailable_indicator() {
+        let mut block = sqlite_storage_block();
+        block.health = "unavailable".into();
+        block.latency_ms = 0;
+        let rendered = strip_ansi(&format_storage_health(&block));
+        assert!(rendered.contains("  DB Health:   ✗ unavailable  (0ms)\n"));
+    }
+
+    #[test]
+    fn format_count_inserts_thousands_separators() {
+        assert_eq!(format_count(0), "0");
+        assert_eq!(format_count(7), "7");
+        assert_eq!(format_count(1_000), "1,000");
+        assert_eq!(format_count(14_293), "14,293");
+        assert_eq!(format_count(1_234_567), "1,234,567");
     }
 
     #[test]


### PR DESCRIPTION
## Description

Client-side consumer of the `/api/v1/admin/status` route landed in AAASM-1908 / PR #762. This delivers the second half of AAASM-1591 / Epic 18 S-J.

### `aa-cli/src/commands/status/models.rs`
- New `AdminRowCountsBlock`, `AdminTimescaleDbBlock`, `AdminStorageHealthBlock`, `AdminStatusResponse` deserialise types mirroring the server-side wire contract.
- `StatusSnapshot` gains `storage_health: Option<AdminStorageHealthBlock>` — `#[serde(skip_serializing_if = "Option::is_none")]` so `--json` output stays compact when the section is absent.

### `aa-cli/src/commands/status/client.rs`
- `StatusClient::fetch_admin_status()` calls `GET /api/v1/admin/status` and decodes the response.

### `aa-cli/src/commands/status/fetch.rs`
- `fetch_all` joins the admin-status fetch into the same parallel `tokio::join!` burst. Errors (older gateway without the route, transport failure) degrade to `storage_health: None` so the existing sections still render.

### `aa-cli/src/commands/status/render.rs`
- New `format_storage_health` / `render_storage_health` builds the `STORAGE` section in the AAASM-1591 layout:
  ```
  STORAGE
  ───────
    Backend:     sqlite
    Path:        ~/.aasm/local.db
    DB Health:   ✓ ok  (1ms)
    Rows:        audit_events: 47 hot
                 agents: 2  |  policies: 1
  ```
  Postgres + TimescaleDB adds `DB:` (already-redacted URL) and `TimescaleDB: ✓ active (8/12 chunks compressed, 11.4× ratio)`.
- `render_all` calls it between the deployment overview and runtime health, gated on `storage_health.is_some()`.

### `aa-cli/src/commands/status/mod.rs`
- `compute_exit_code` joins the existing reachable / violations checks with a new rule: `storage_health.health == "unavailable"` → `ExitCode::from(1)`. `degraded` keeps a healthy exit code — it's still reachable.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No — `StatusSnapshot.storage_health` is opt-in via `Option`; older gateways without `/api/v1/admin/status` still render the prior sections verbatim.

## Related Issues

- Related Jira ticket: AAASM-1909 (subtask of AAASM-1591 / Epic AAASM-1569)
- Depends on the server route landed in AAASM-1908 / PR #762

## Testing

- [x] Unit tests added / updated — 9 new tests across `models::tests`, `render::tests`, and the `compute_exit_code` test cluster:
    - Three model deserialisation tests for the wire shape (sqlite, postgres+timescaledb, extra-key tolerance).
    - Three render golden tests covering sqlite (no TimescaleDB), postgres+Timescale (redacted URL + thousands separator + compression ratio), and the unavailable indicator.
    - Three exit-code tests pinning `unavailable → 1`, `ok → 0`, `degraded → 0`.
- [x] Integration tests added / updated — `format_count` table-driven test for the thousands separator helper.
- [x] Manual testing performed — `cargo nextest run -p aa-cli` green (566 tests, 0 skipped), `clippy --all-targets --all-features` clean.
- [ ] No tests required

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed — doc-comments on the new types + `format_storage_health` describe the wire contract and layout.
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention — 8 commits: 3 model layers, 1 snapshot field, 1 client method, 1 fetch wiring, 1 render section, 1 exit-code rule, 1 cleanup refactor.