### PR TITLE
[AAASM-1917] ✨ (dashboard): Wire SandboxSummaryCard banner + sandbox toggle + amber badge + Playwright

### DIFF
--- a/dashboard/src/features/audit/api.test.ts
+++ b/dashboard/src/features/audit/api.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { isSandboxSummaryEmpty, type SandboxSummaryResponse } from './api'
+
+function summary(partial: Partial<SandboxSummaryResponse['counts']> = {}): SandboxSummaryResponse {
+  return {
+    counts: {
+      would_be_denies: 0,
+      would_be_redactions: 0,
+      would_be_pending_approvals: 0,
+      ...partial,
+    },
+    top_rule: null,
+    window_secs: 86_400,
+    generated_at: '2026-05-23T14:00:00Z',
+  }
+}
+
+describe('isSandboxSummaryEmpty', () => {
+  it('returns true when every would-be count is zero', () => {
+    expect(isSandboxSummaryEmpty(summary())).toBe(true)
+  })
+
+  it('returns false when any count is non-zero', () => {
+    expect(isSandboxSummaryEmpty(summary({ would_be_denies: 1 }))).toBe(false)
+    expect(isSandboxSummaryEmpty(summary({ would_be_redactions: 1 }))).toBe(false)
+    expect(isSandboxSummaryEmpty(summary({ would_be_pending_approvals: 1 }))).toBe(false)
+  })
+})

--- a/dashboard/src/features/audit/api.test.ts
+++ b/dashboard/src/features/audit/api.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { isSandboxSummaryEmpty, type SandboxSummaryResponse } from './api'
+import {
+  extractSandboxInfo,
+  isSandboxSummaryEmpty,
+  type SandboxSummaryResponse,
+} from './api'
 
 function summary(partial: Partial<SandboxSummaryResponse['counts']> = {}): SandboxSummaryResponse {
   return {
@@ -24,5 +28,32 @@ describe('isSandboxSummaryEmpty', () => {
     expect(isSandboxSummaryEmpty(summary({ would_be_denies: 1 }))).toBe(false)
     expect(isSandboxSummaryEmpty(summary({ would_be_redactions: 1 }))).toBe(false)
     expect(isSandboxSummaryEmpty(summary({ would_be_pending_approvals: 1 }))).toBe(false)
+  })
+})
+
+describe('extractSandboxInfo', () => {
+  it('returns dryRun=true and the shadow decision when payload carries them', () => {
+    const info = extractSandboxInfo('{"dry_run":true,"shadow_decision":"deny"}')
+    expect(info.dryRun).toBe(true)
+    expect(info.shadowDecision).toBe('deny')
+  })
+
+  it('returns dryRun=false when the payload omits dry_run', () => {
+    const info = extractSandboxInfo('{"decision":"Allow"}')
+    expect(info.dryRun).toBe(false)
+    expect(info.shadowDecision).toBeNull()
+  })
+
+  it('treats dry_run=false explicitly as live enforcement', () => {
+    const info = extractSandboxInfo('{"dry_run":false}')
+    expect(info.dryRun).toBe(false)
+  })
+
+  it('falls back to dryRun=false for malformed JSON', () => {
+    expect(extractSandboxInfo('not-json').dryRun).toBe(false)
+  })
+
+  it('treats empty-string shadow_decision as null', () => {
+    expect(extractSandboxInfo('{"dry_run":true,"shadow_decision":""}').shadowDecision).toBeNull()
   })
 })

--- a/dashboard/src/features/audit/api.ts
+++ b/dashboard/src/features/audit/api.ts
@@ -49,3 +49,34 @@ export function isSandboxSummaryEmpty(summary: SandboxSummaryResponse): boolean 
   const c = summary.counts
   return c.would_be_denies === 0 && c.would_be_redactions === 0 && c.would_be_pending_approvals === 0
 }
+
+/**
+ * Sandbox metadata extracted from an audit `LogEntry.payload` JSON string.
+ *
+ * The gateway writes `dry_run` / `shadow_decision` / `shadow_reason` into
+ * the payload when observe-mode suppressed a non-Allow decision (see
+ * `aa-gateway::service::policy_service::record_audit`). Live enforce rows
+ * have `dryRun: false` and `shadowDecision: null`.
+ */
+export interface SandboxPayloadInfo {
+  readonly dryRun: boolean
+  readonly shadowDecision: string | null
+}
+
+/**
+ * Parse `LogEntry.payload` (a pre-serialized JSON string) and extract the
+ * observe-mode signal. Tolerates malformed payloads and missing fields by
+ * returning a `dryRun: false` value, matching the gateway's contract that
+ * absence of the field means live enforcement.
+ */
+export function extractSandboxInfo(payload: string): SandboxPayloadInfo {
+  try {
+    const parsed = JSON.parse(payload) as Record<string, unknown>
+    const dryRun = parsed['dry_run'] === true
+    const shadow = parsed['shadow_decision']
+    const shadowDecision = typeof shadow === 'string' && shadow.length > 0 ? shadow : null
+    return { dryRun, shadowDecision }
+  } catch {
+    return { dryRun: false, shadowDecision: null }
+  }
+}

--- a/dashboard/src/features/audit/api.ts
+++ b/dashboard/src/features/audit/api.ts
@@ -1,0 +1,51 @@
+import { useQuery } from '@tanstack/react-query'
+import { api } from '../../api/client'
+import type { components } from '../../api/generated/schema'
+
+export type SandboxSummaryResponse = components['schemas']['SandboxSummaryResponse']
+export type SandboxSummaryCounts = components['schemas']['SandboxSummaryCounts']
+export type SandboxSummaryTopRule = components['schemas']['SandboxSummaryTopRule']
+
+export type SandboxWindow = '1h' | '24h' | '7d' | '30d'
+
+interface UseSandboxSummaryQueryOptions {
+  window?: SandboxWindow
+  root?: string
+}
+
+/**
+ * Fetches the global observe-mode aggregate from
+ * `GET /api/v1/audit/sandbox-summary` (AAASM-1911 / aa-api PR #767).
+ *
+ * Returns the would-be deny / redaction / pending-approval counts plus the
+ * most-frequently matched policy rule across all `dry_run: true` audit
+ * entries in the window. The endpoint is global today; per-policy scoping
+ * would need a follow-up `policy` query parameter on the API.
+ */
+export function useSandboxSummaryQuery(options: UseSandboxSummaryQueryOptions = {}) {
+  const window_ = options.window ?? '24h'
+  const root = options.root ?? undefined
+  return useQuery<SandboxSummaryResponse>({
+    queryKey: ['audit', 'sandbox-summary', window_, root ?? null],
+    queryFn: async () => {
+      const query: { window?: string; root?: string } = { window: window_ }
+      if (root) query.root = root
+      const { data, error } = await api.GET('/api/v1/audit/sandbox-summary', {
+        params: { query },
+      })
+      if (error) throw new Error('Failed to fetch sandbox summary')
+      if (!data) throw new Error('Sandbox summary response was empty')
+      return data
+    },
+  })
+}
+
+/**
+ * True when every count in the summary is zero. Callers use this to hide
+ * the SandboxSummaryCard banner when there's no observe-mode activity to
+ * surface.
+ */
+export function isSandboxSummaryEmpty(summary: SandboxSummaryResponse): boolean {
+  const c = summary.counts
+  return c.would_be_denies === 0 && c.would_be_redactions === 0 && c.would_be_pending_approvals === 0
+}

--- a/dashboard/src/pages/AgentDetailDrawer.css
+++ b/dashboard/src/pages/AgentDetailDrawer.css
@@ -392,3 +392,35 @@
   font-size: 11px;
   color: var(--ink-2);
 }
+
+/* Sandbox / observe-mode controls and badges (AAASM-1917). */
+
+.ad-events__sandbox-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 6px 0 10px;
+  font-size: 12px;
+  color: var(--ink-3);
+}
+
+.ad-events__sandbox-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+}
+
+/* Reuses the same amber as the SandboxSummaryCard so the dashboard speaks
+   with one voice about observe-mode events. */
+.ad-events__sandbox-badge {
+  display: inline-block;
+  padding: 1px 7px;
+  border-radius: 999px;
+  background-color: #fef3c7;
+  color: #d97706;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+}

--- a/dashboard/src/pages/AgentDetailPage.test.tsx
+++ b/dashboard/src/pages/AgentDetailPage.test.tsx
@@ -283,3 +283,78 @@ describe('AgentDetailPage drawer head action buttons', () => {
     expect(await screen.findByText(/Switched abc123 to shadow mode/)).toBeInTheDocument()
   })
 })
+
+describe('AgentDetailPage — sandbox events toggle + amber badge', () => {
+  const liveLog: LogEntry = {
+    ...MOCK_LOG,
+    seq: 10,
+    payload: '{"decision":"Allow"}',
+  }
+  const sandboxLog: LogEntry = {
+    ...MOCK_LOG,
+    seq: 11,
+    session_id: 'session-sandboxxx',
+    payload: '{"dry_run":true,"shadow_decision":"deny"}',
+  }
+
+  function mockWithMixedEvents() {
+    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+      mockQuery<Agent[]>({ data: [MOCK_AGENT], isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    vi.spyOn(agentsApi, 'useAgentQuery').mockReturnValue(
+      mockQuery<Agent | undefined>({ data: MOCK_AGENT, isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    vi.spyOn(agentsApi, 'useAgentEventsQuery').mockReturnValue(
+      mockQuery<LogEntry[]>({ data: [liveLog, sandboxLog], isLoading: false, isError: false }),
+    )
+    vi.spyOn(agentsApi, 'useAgentCapabilitiesQuery').mockReturnValue(
+      mockQuery<agentsApi.EffectivePermissions>({
+        data: { allow: [], deny: [], sources: [] },
+        isLoading: false,
+        isError: false,
+      }),
+    )
+  }
+
+  it('renders the amber "Would: X" badge only on dry-run rows', async () => {
+    mockWithMixedEvents()
+    renderApp('/agents/abc123')
+    await screen.findByTestId('agent-events')
+    const badges = screen.getAllByTestId('event-sandbox-badge')
+    expect(badges).toHaveLength(1)
+    expect(badges[0]).toHaveTextContent(/Would: deny/i)
+  })
+
+  it('filters the events table down to dry-run rows when the toggle is on', async () => {
+    mockWithMixedEvents()
+    renderApp('/agents/abc123')
+    expect((await screen.findAllByTestId('event-row')).length).toBe(2)
+    fireEvent.click(screen.getByTestId('agent-events-sandbox-toggle'))
+    const filtered = screen.getAllByTestId('event-row')
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0]).toHaveTextContent(/Would: deny/i)
+  })
+
+  it('hides the toggle bar entirely when there are no events at all', async () => {
+    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+      mockQuery<Agent[]>({ data: [MOCK_AGENT], isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    vi.spyOn(agentsApi, 'useAgentQuery').mockReturnValue(
+      mockQuery<Agent | undefined>({ data: MOCK_AGENT, isLoading: false, isError: false, refetch: vi.fn() }),
+    )
+    vi.spyOn(agentsApi, 'useAgentEventsQuery').mockReturnValue(
+      mockQuery<LogEntry[]>({ data: [], isLoading: false, isError: false }),
+    )
+    vi.spyOn(agentsApi, 'useAgentCapabilitiesQuery').mockReturnValue(
+      mockQuery<agentsApi.EffectivePermissions>({
+        data: { allow: [], deny: [], sources: [] },
+        isLoading: false,
+        isError: false,
+      }),
+    )
+
+    renderApp('/agents/abc123')
+    await screen.findByTestId('agent-events')
+    expect(screen.queryByTestId('agent-events-sandbox-bar')).not.toBeInTheDocument()
+  })
+})

--- a/dashboard/src/pages/AgentDetailPage.tsx
+++ b/dashboard/src/pages/AgentDetailPage.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useCallback, useMemo, useState } from 'react'
 import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import { useAgentQuery, useAgentEventsQuery, type Agent } from '../features/agents/api'
+import { extractSandboxInfo } from '../features/audit/api'
 import { useSuspendAgent, useResumeAgent } from '../features/agents/mutations'
 import { toFleetAgent } from '../features/agents/fleetTypes'
 import { Drawer } from '../components/Drawer'
@@ -181,6 +182,18 @@ export function AgentDetailPage() {
   const { data: events, isLoading: eventsLoading, isError: eventsError } = useAgentEventsQuery(id ?? '')
   const [tab, setTab] = useState<AgentDetailTab>('overview')
   const [showSuspendDialog, setShowSuspendDialog] = useState(false)
+  const [sandboxOnly, setSandboxOnly] = useState(false)
+
+  // Decorate each event row with its parsed sandbox metadata so the table
+  // can both filter (when the toggle is on) and render the amber badge
+  // without re-parsing the payload per render.
+  const decoratedEvents = useMemo(
+    () => (events ?? []).map((ev) => ({ ev, sandbox: extractSandboxInfo(ev.payload) })),
+    [events],
+  )
+  const visibleEvents = sandboxOnly
+    ? decoratedEvents.filter((row) => row.sandbox.dryRun)
+    : decoratedEvents
 
   const suspend = useSuspendAgent()
   const resume = useResumeAgent()
@@ -358,10 +371,34 @@ export function AgentDetailPage() {
                     <h2 className="ad-card__title">recent events</h2>
                     {eventsLoading && <p>Loading events…</p>}
                     {eventsError && <p style={{ color: 'var(--danger)' }}>Failed to load events.</p>}
-                    {!eventsLoading && !eventsError && (!events || events.length === 0) && (
+                    {!eventsLoading && !eventsError && decoratedEvents.length > 0 && (
+                      <div className="ad-events__sandbox-bar" data-testid="agent-events-sandbox-bar">
+                        <label className="ad-events__sandbox-toggle">
+                          <input
+                            type="checkbox"
+                            checked={sandboxOnly}
+                            onChange={(e) => setSandboxOnly(e.target.checked)}
+                            data-testid="agent-events-sandbox-toggle"
+                          />
+                          Sandbox events only
+                        </label>
+                      </div>
+                    )}
+                    {!eventsLoading && !eventsError && decoratedEvents.length === 0 && (
                       <p style={{ color: 'var(--ink-4)', fontSize: 12 }}>No events recorded for this agent.</p>
                     )}
-                    {events && events.length > 0 && (
+                    {!eventsLoading &&
+                      !eventsError &&
+                      decoratedEvents.length > 0 &&
+                      visibleEvents.length === 0 && (
+                        <p
+                          style={{ color: 'var(--ink-4)', fontSize: 12 }}
+                          data-testid="agent-events-sandbox-empty"
+                        >
+                          No sandbox events in this window.
+                        </p>
+                      )}
+                    {visibleEvents.length > 0 && (
                       <table className="ad-events">
                         <thead>
                           <tr>
@@ -371,10 +408,21 @@ export function AgentDetailPage() {
                           </tr>
                         </thead>
                         <tbody>
-                          {events.map((ev) => (
+                          {visibleEvents.map(({ ev, sandbox }) => (
                             <tr key={`${ev.seq}-${ev.session_id}`} data-testid="event-row">
                               <td>{ev.timestamp}</td>
-                              <td>{ev.event_type}</td>
+                              <td>
+                                {ev.event_type}
+                                {sandbox.dryRun ? (
+                                  <span
+                                    className="ad-events__sandbox-badge"
+                                    data-testid="event-sandbox-badge"
+                                    style={{ marginLeft: 6 }}
+                                  >
+                                    Would: {sandbox.shadowDecision ?? 'observe'}
+                                  </span>
+                                ) : null}
+                              </td>
                               <td>
                                 <code className="ad-events__code">{ev.session_id.slice(0, 12)}…</code>
                               </td>

--- a/dashboard/src/pages/PoliciesPage.test.tsx
+++ b/dashboard/src/pages/PoliciesPage.test.tsx
@@ -8,6 +8,8 @@ import { OverlayProvider } from '../components/OverlayProvider'
 import { ToastProvider } from '../components/ToastProvider'
 import * as policiesApi from '../features/policies/api'
 import type { CreatePolicyRequest, Policy } from '../features/policies/api'
+import * as auditApi from '../features/audit/api'
+import type { SandboxSummaryResponse } from '../features/audit/api'
 
 type UseCreatePolicyResult = ReturnType<typeof policiesApi.useCreatePolicy>
 
@@ -57,6 +59,24 @@ function mockPolicies(partial: Partial<UseQueryResult<Policy[], Error>>) {
   )
 }
 
+const EMPTY_SUMMARY: SandboxSummaryResponse = {
+  counts: { would_be_denies: 0, would_be_redactions: 0, would_be_pending_approvals: 0 },
+  top_rule: null,
+  window_secs: 86_400,
+  generated_at: '2026-05-23T00:00:00Z',
+}
+
+function mockSandboxSummary(
+  partial: Partial<UseQueryResult<SandboxSummaryResponse, Error>> = {},
+) {
+  const base = { data: EMPTY_SUMMARY, isLoading: false, isError: false }
+  return vi.spyOn(auditApi, 'useSandboxSummaryQuery').mockReturnValue(
+    mockQuery<SandboxSummaryResponse>(Object.assign({}, base, partial) as Partial<
+      UseQueryResult<SandboxSummaryResponse, Error>
+    >),
+  )
+}
+
 function mockMutation(partial: Partial<UseCreatePolicyResult>): UseCreatePolicyResult {
   return partial as unknown as UseCreatePolicyResult
 }
@@ -69,6 +89,13 @@ function mockCreatePolicy(
     mockMutation({ mutateAsync, isPending }),
   )
 }
+
+// All existing tests render PoliciesPage but pre-date the sandbox banner —
+// mock the new hook to a zero-state response so they don't fan out to the
+// real API and so the banner stays hidden, preserving their expectations.
+beforeEach(() => {
+  mockSandboxSummary()
+})
 
 describe('PoliciesPage — header and filter tabs', () => {
   afterEach(() => {
@@ -393,5 +420,52 @@ describe('PoliciesPage — unsaved-changes dismiss guard', () => {
       expect(screen.queryByTestId('policy-editor-overlay')).not.toBeInTheDocument(),
     )
     expect(screen.queryByTestId('confirm-dialog')).not.toBeInTheDocument()
+  })
+})
+
+describe('PoliciesPage — sandbox summary banner', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('hides the SandboxSummaryCard banner when every count is zero', () => {
+    mockPolicies({ data: [ACTIVE_POLICY], isLoading: false, isError: false, refetch: vi.fn() })
+    mockSandboxSummary() // zero-state, default
+    render(<PoliciesPage />, { wrapper: Wrapper })
+    expect(screen.queryByTestId('policies-sandbox-banner')).not.toBeInTheDocument()
+  })
+
+  it('hides the banner while the sandbox summary query is loading', () => {
+    mockPolicies({ data: [ACTIVE_POLICY], isLoading: false, isError: false, refetch: vi.fn() })
+    mockSandboxSummary({ data: undefined, isLoading: true })
+    render(<PoliciesPage />, { wrapper: Wrapper })
+    expect(screen.queryByTestId('policies-sandbox-banner')).not.toBeInTheDocument()
+  })
+
+  it('renders the banner with would-be counts and top rule when summary has activity', () => {
+    mockPolicies({ data: [ACTIVE_POLICY], isLoading: false, isError: false, refetch: vi.fn() })
+    mockSandboxSummary({
+      data: {
+        counts: {
+          would_be_denies: 7,
+          would_be_redactions: 2,
+          would_be_pending_approvals: 1,
+        },
+        top_rule: { id: 'block-secrets', count: 5 },
+        window_secs: 86_400,
+        generated_at: '2026-05-23T00:00:00Z',
+      },
+    })
+    render(<PoliciesPage />, { wrapper: Wrapper })
+
+    const banner = screen.getByTestId('policies-sandbox-banner')
+    expect(banner).toBeInTheDocument()
+    // Counts and top rule come from the SandboxSummaryCard primitive — we
+    // assert the literal numbers + rule id reached the rendered card so the
+    // API → props mapping is wired in the right order.
+    expect(banner).toHaveTextContent('7')
+    expect(banner).toHaveTextContent('2')
+    expect(banner).toHaveTextContent('1')
+    expect(banner).toHaveTextContent('block-secrets')
   })
 })

--- a/dashboard/src/pages/PoliciesPage.tsx
+++ b/dashboard/src/pages/PoliciesPage.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useMemo, useRef, useState, type MutableRefObject } from 'react'
 import { usePoliciesQuery, useCreatePolicy, type Policy } from '../features/policies/api'
+import { isSandboxSummaryEmpty, useSandboxSummaryQuery } from '../features/audit/api'
+import { SandboxSummaryCard } from '../components/SandboxSummaryCard'
 import { EmptyState, ErrorState } from '../components/states'
 import { OverlayHost } from '../components/OverlayHost'
 import { useOverlay } from '../components/useOverlay'
@@ -132,8 +134,26 @@ function PolicyRow({ policy, onEdit }: { policy: Policy; onEdit: () => void }) {
 
 export function PoliciesPage() {
   const { data: policies, isLoading, isError, refetch } = usePoliciesQuery()
+  const { data: sandboxSummary } = useSandboxSummaryQuery({ window: '24h' })
   const [filter, setFilter] = useState<FilterTab>('all')
   const { openOverlay, closeOverlay } = useOverlay('policy-editor')
+  const { toast } = useToast()
+
+  // Only surface the SandboxSummaryCard when at least one count is non-zero;
+  // operators running fully in enforce mode shouldn't see an empty card.
+  const showSandboxBanner =
+    sandboxSummary !== undefined && !isSandboxSummaryEmpty(sandboxSummary)
+
+  // The aa-api endpoint is global today (no per-policy filter), so the card
+  // carries an "All policies" label rather than a single policy name. When
+  // per-policy scoping lands on the endpoint, the label and the
+  // onEnableLiveEnforcement target can both narrow.
+  const enableLiveEnforcement = useCallback(() => {
+    toast(
+      'Open the policy you want to enforce live and set enforcement_mode: enforce',
+      'success',
+    )
+  }, [toast])
 
   // Editor publishes its dirty state into this ref so the page can decide
   // whether Esc / backdrop / Cancel should prompt for confirmation.
@@ -189,6 +209,26 @@ export function PoliciesPage() {
           + new policy
         </button>
       </header>
+
+      {showSandboxBanner && sandboxSummary ? (
+        <div className="policies-page__sandbox" data-testid="policies-sandbox-banner">
+          <SandboxSummaryCard
+            policyName="All policies"
+            windowLabel="last 24h"
+            counts={{
+              wouldBeDenies: sandboxSummary.counts.would_be_denies,
+              wouldBeRedactions: sandboxSummary.counts.would_be_redactions,
+              wouldBePendingApprovals: sandboxSummary.counts.would_be_pending_approvals,
+            }}
+            topRule={
+              sandboxSummary.top_rule
+                ? { id: sandboxSummary.top_rule.id, count: sandboxSummary.top_rule.count }
+                : undefined
+            }
+            onEnableLiveEnforcement={enableLiveEnforcement}
+          />
+        </div>
+      ) : null}
 
       <nav className="policies-tabs" role="tablist" aria-label="Filter policies">
         {FILTER_TABS.map((tab) => {

--- a/dashboard/tests/e2e/sandbox-summary.spec.ts
+++ b/dashboard/tests/e2e/sandbox-summary.spec.ts
@@ -1,0 +1,192 @@
+// E2E acceptance for AAASM-1917 (Dashboard wire-up: SandboxSummaryCard banner
+// on PoliciesPage + dry-run toggle + amber "Would: X" badge on the
+// AgentDetailPage events table).
+//
+// Walks two flows:
+//   1. /policies — stubs the new GET /api/v1/audit/sandbox-summary endpoint
+//      with a populated response and asserts the SandboxSummaryCard banner
+//      renders with the counts + top rule from the mocked payload.
+//   2. /agents/<id> — stubs /api/v1/logs to return mixed live + dry-run
+//      events and asserts (a) the amber badge appears only on the dry-run
+//      row and (b) the toggle filters the table down to dry-run rows only.
+//
+// State screenshots land in tests/__screenshots__/AAASM-1917/ for the
+// closing comment / parent Story (AAASM-1553).
+
+import { test, expect, type Page } from '@playwright/test'
+
+const SCREENSHOT_DIR = 'tests/__screenshots__/AAASM-1917'
+
+const ACTIVE_POLICY = {
+  name: 'default-policy',
+  version: '1.0.0',
+  rule_count: 5,
+  active: true,
+  policy_yaml: 'metadata:\n  name: default-policy\nrules: []\n',
+}
+
+const SANDBOX_SUMMARY_RESPONSE = {
+  counts: {
+    would_be_denies: 7,
+    would_be_redactions: 2,
+    would_be_pending_approvals: 1,
+  },
+  top_rule: { id: 'block-secrets', count: 5 },
+  window_secs: 86_400,
+  generated_at: '2026-05-23T00:00:00Z',
+}
+
+const AGENT = {
+  id: 'a'.repeat(32),
+  name: 'sandbox-test-agent',
+  framework: 'langgraph',
+  status: 'active',
+  version: '0.1.0',
+  layer: 'enforced',
+  team: 'platform',
+  mode: 'normal',
+  trust_score: 88,
+  last_seen: '2026-05-23T00:00:00Z',
+  active_sessions: [],
+  recent_traces: [],
+  policy_violations_count: 0,
+  tool_names: [],
+  metadata: {},
+  pid: null,
+}
+
+const LIVE_LOG = {
+  agent_id: AGENT.id,
+  event_type: 'ToolCallIntercepted',
+  payload: '{"decision":"Allow"}',
+  seq: 1,
+  session_id: 's'.repeat(32),
+  timestamp: '2026-05-23T00:00:01Z',
+}
+
+const SANDBOX_LOG = {
+  agent_id: AGENT.id,
+  event_type: 'ToolCallIntercepted',
+  payload: '{"dry_run":true,"shadow_decision":"deny"}',
+  seq: 2,
+  session_id: 't'.repeat(32),
+  timestamp: '2026-05-23T00:00:02Z',
+}
+
+async function injectToken(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('aa_token', 'e2e-test-token')
+  })
+}
+
+async function mockAppShell(page: Page) {
+  await page.route('**/api/v1/ws/events**', (route) => route.abort())
+  await page.route('**/api/v1/approvals**', (route) => route.fulfill({ json: [] }))
+  await page.route('**/api/v1/policies/active', (route) =>
+    route.fulfill({ status: 404, json: { detail: 'No active policy' } }),
+  )
+}
+
+test.describe('AAASM-1917 — SandboxSummaryCard banner on /policies', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectToken(page)
+    await mockAppShell(page)
+    await page.route('**/api/v1/policies', (route) => {
+      if (route.request().method() === 'GET') {
+        return route.fulfill({ json: [ACTIVE_POLICY] })
+      }
+      return route.fallback()
+    })
+    await page.route('**/api/v1/audit/sandbox-summary**', (route) =>
+      route.fulfill({ json: SANDBOX_SUMMARY_RESPONSE }),
+    )
+  })
+
+  test('renders the SandboxSummaryCard banner with counts and top rule', async ({ page }) => {
+    await page.goto('/policies')
+    await expect(page.getByTestId('policies-page')).toBeVisible()
+
+    const banner = page.getByTestId('policies-sandbox-banner')
+    await expect(banner).toBeVisible()
+    await expect(banner).toContainText('7')
+    await expect(banner).toContainText('2')
+    await expect(banner).toContainText('1')
+    await expect(banner).toContainText('block-secrets')
+
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/01-policies-sandbox-banner.png`,
+      fullPage: true,
+    })
+  })
+})
+
+test.describe('AAASM-1917 — amber Would: X badge + Sandbox events toggle on agent detail', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectToken(page)
+    await mockAppShell(page)
+    // Stub the sandbox summary so PoliciesPage doesn't error if the user
+    // navigates back; not load-bearing for these assertions.
+    await page.route('**/api/v1/audit/sandbox-summary**', (route) =>
+      route.fulfill({ json: {
+        counts: { would_be_denies: 0, would_be_redactions: 0, would_be_pending_approvals: 0 },
+        top_rule: null,
+        window_secs: 86_400,
+        generated_at: '2026-05-23T00:00:00Z',
+      } }),
+    )
+    await page.route('**/api/v1/agents**', (route) => {
+      const url = route.request().url()
+      if (url.includes(`/agents/${AGENT.id}/capabilities`)) {
+        return route.fulfill({ json: { allow: [], deny: [], sources: [] } })
+      }
+      if (url.includes(`/agents/${AGENT.id}/subtree-burn`)) {
+        return route.fulfill({ json: {
+          window: '7d',
+          total_usd: 0,
+          daily: [],
+          top_children: [],
+          generated_at: '2026-05-23T00:00:00Z',
+        } })
+      }
+      if (url.includes(`/agents/${AGENT.id}`)) {
+        return route.fulfill({ json: AGENT })
+      }
+      if (route.request().method() === 'GET') {
+        return route.fulfill({ json: [AGENT] })
+      }
+      return route.fallback()
+    })
+    await page.route('**/api/v1/logs**', (route) =>
+      route.fulfill({ json: [LIVE_LOG, SANDBOX_LOG] }),
+    )
+  })
+
+  test('amber badge renders only on the dry-run row', async ({ page }) => {
+    await page.goto(`/agents/${AGENT.id}`)
+    await expect(page.getByTestId('agent-events')).toBeVisible()
+
+    const badges = page.getByTestId('event-sandbox-badge')
+    await expect(badges).toHaveCount(1)
+    await expect(badges.first()).toContainText(/Would: deny/i)
+
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/02-amber-badge.png`,
+      fullPage: true,
+    })
+  })
+
+  test('toggle filters the events table down to dry-run rows', async ({ page }) => {
+    await page.goto(`/agents/${AGENT.id}`)
+    await expect(page.getByTestId('agent-events')).toBeVisible()
+    await expect(page.getByTestId('event-row')).toHaveCount(2)
+
+    await page.getByTestId('agent-events-sandbox-toggle').check()
+    await expect(page.getByTestId('event-row')).toHaveCount(1)
+    await expect(page.getByTestId('event-sandbox-badge')).toBeVisible()
+
+    await page.screenshot({
+      path: `${SCREENSHOT_DIR}/03-sandbox-toggle-on.png`,
+      fullPage: true,
+    })
+  })
+})


### PR DESCRIPTION
## Description

Closes the dashboard side of AAASM-1553 (Sandbox / Dry-Run Mode). Wires the `SandboxSummaryCard` primitive (AAASM-1563) and the `GET /api/v1/audit/sandbox-summary` endpoint (PR #767 / AAASM-1911) into actual operator-facing surfaces:

- **`PoliciesPage` banner** — renders the SandboxSummaryCard above the filter tabs whenever the gateway has any non-zero would-be count in the last 24h. Hidden when fully zero so enforce-only deployments stay clean.
- **`AgentDetailPage` events table** — adds a "Sandbox events only" toggle and an amber "Would: `<decision>`" badge on rows whose payload carries `dry_run: true`. Both behaviours are client-side over `LogEntry.payload` JSON — no new API call.
- **Playwright e2e spec** — visual + behavioural verification for both surfaces, screenshots into `tests/__screenshots__/AAASM-1917/`.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Closes AAASM-1917 (dashboard wire-up subtask under AAASM-1553)
- Consumes AAASM-1911 (aa-api PR #767, merged)
- Consumes AAASM-1563 (SandboxSummaryCard primitive)
- Consumes AAASM-1564 (gateway emits `dry_run` / `shadow_decision` / `shadow_reason` payload fields)

## Scope notes

- `onEnableLiveEnforcement` currently shows a toast pointing the operator to the policy editor — the YAML round-trip flow is deferred until the SandboxSummaryCard knows which policy it's anchored to. The aa-api `/audit/sandbox-summary` endpoint is global today (no `policy` filter), so per-policy rendering + per-policy enforcement-mode flips both wait on a follow-up. Captured as a comment on the ticket; no AC regression.
- "Audit-log surface" is interpreted as `AgentDetailPage`'s "recent events" section — the only tabular audit-log view in the dashboard. `ViolationHeatmapPage` is a visual heatmap, not a row table, so it's not the natural fit for the toggle.

## Testing

- [x] Unit tests added (8 new): 5 vitest cases on `extractSandboxInfo`, 3 on the `AgentDetailPage` sandbox integration
- [x] PoliciesPage tests extended with 3 new cases (zero-state hidden, loading hidden, populated banner renders counts + top rule)
- [x] Playwright e2e spec added (`tests/e2e/sandbox-summary.spec.ts`) covering both flows
- [x] `pnpm test --run` → 1014 tests / 117 files green locally
- [x] `pnpm type-check` clean
- [x] `pnpm lint` clean (0 warnings)

## Commit shape

4 granular GitEmoji commits, one logical unit each:

1. `✨ (dashboard): Add useSandboxSummaryQuery hook + isSandboxSummaryEmpty helper`
2. `✨ (dashboard): Render SandboxSummaryCard banner on PoliciesPage`
3. `✨ (dashboard): Add sandbox toggle + amber Would: X badge to agent events`
4. `✅ (dashboard): Add Playwright e2e spec for sandbox surfaces`

## Checklist

- [x] Code follows project style guidelines (Prettier via vitest setup, ESLint clean)
- [x] Self-review of the diff completed
- [x] Documentation reused from upstream components (no new docs needed; the SandboxSummaryCard primitive already documents its props)
- [ ] All CI checks passing — pending
- [x] Commits are small and follow the Gitmoji convention