### PR TITLE
[AAASM-1570] ✅ (aa-integration-tests): Add F116 ST-O scaffold

### DIFF
--- a/aa-integration-tests/tests/e2e_secret_injection.rs
+++ b/aa-integration-tests/tests/e2e_secret_injection.rs
@@ -140,3 +140,40 @@ async fn st_o_2_real_secret_absent_from_llm_traffic() {
          at least one body carries PLACEHOLDER_DB_PASSWORD or a [REDACTED:*] marker."
     );
 }
+
+// ── ST-O-3 — Raw audit JSONL contains no real value ──────────────────────────
+
+/// **ST-O-3** — The raw JSONL audit log contains zero occurrences of
+/// `REAL_DB_PASSWORD`. Audit records the placeholder name only.
+///
+/// This is the durability counterpart to ST-O-2: even after the agent
+/// process exits and the LLM transport closes, the operational record-of-
+/// truth (the audit log on disk) is provably free of the real credential.
+/// AAASM-1519 / ST-G uses the same grep-the-raw-JSONL pattern for the
+/// Secret Detection capability; ST-O-3 mirrors it for Secret Injection.
+///
+/// Setup (once AAASM-1920 ships):
+///   * Same `TopologyTestEnv` + `SecretsStore` as ST-O-1.
+///   * Reuse the env's on-disk `audit_dir`; no extra fixture required.
+///
+/// Action:
+///   * Agent dispatches `call_database` with `${DB_PASSWORD}` once.
+///
+/// Assertions:
+///   1. The audit dir contains at least one `*.jsonl` entry for this run.
+///   2. Reading every JSONL file in `audit_dir` and grepping the raw bytes
+///      for `REAL_DB_PASSWORD` returns **zero matches** — the substring must
+///      not appear in any field, including any nested args payload, header
+///      capture, or error message.
+///   3. At least one entry's args field contains `PLACEHOLDER_DB_PASSWORD`
+///      — confirming the placeholder is what was recorded, not the resolved
+///      value or an empty redaction.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "blocked on AAASM-1920: Secret Injection feature (SecretsStore + dispatch_tool + audit shape) not yet implemented"]
+async fn st_o_3_audit_log_contains_no_real_value() {
+    todo!(
+        "Wire TopologyTestEnv + SecretsStore + dispatch_tool + AuditWriter once AAASM-1920 lands. \
+         Assertions: grep every *.jsonl in env.audit_dir for REAL_DB_PASSWORD — count == 0; \
+         at least one entry's args field contains PLACEHOLDER_DB_PASSWORD."
+    );
+}

--- a/aa-integration-tests/tests/e2e_secret_injection.rs
+++ b/aa-integration-tests/tests/e2e_secret_injection.rs
@@ -102,3 +102,41 @@ async fn st_o_1_placeholder_substituted_at_dispatch() {
          (2) audit entry args field contains PLACEHOLDER_DB_PASSWORD, not REAL_DB_PASSWORD."
     );
 }
+
+// ── ST-O-2 — Real secret absent from any LLM-facing traffic ──────────────────
+
+/// **ST-O-2** — Across every LLM-bound request the agent makes during the
+/// scenario, the real secret value `REAL_DB_PASSWORD` appears **zero** times.
+/// The LLM only ever sees the placeholder `${DB_PASSWORD}` or a redacted form
+/// — never the resolved credential.
+///
+/// This is the central product guarantee of Secret Injection (`.ai/spec/
+/// about_ai-agent-assembly_born.md:7246`): the LLM's context window is
+/// provably free of the real credential, even though tool dispatches succeed
+/// against the real value.
+///
+/// Setup (once AAASM-1920 ships):
+///   * Same `TopologyTestEnv` + `SecretsStore` as ST-O-1.
+///   * A `MockLlmServer` (AAASM-1547, Done) bound as the LLM upstream so
+///     every LLM-bound request body is captured for inspection.
+///
+/// Action:
+///   * Agent runs a short scenario: a prompt round-trip to the LLM, then a
+///     `dispatch_tool` call that references `${DB_PASSWORD}`.
+///
+/// Assertions:
+///   1. `mock_llm.history()` is non-empty (the LLM was actually exercised).
+///   2. For every `RecordedRequest` in `mock_llm.history()`, the request body
+///      contains zero occurrences of `REAL_DB_PASSWORD`.
+///   3. At least one request body contains either `PLACEHOLDER_DB_PASSWORD`
+///      verbatim or a `[REDACTED:*]` marker — confirming the placeholder
+///      form (or its redaction) is what the LLM saw.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "blocked on AAASM-1920: Secret Injection feature (SecretsStore + dispatch_tool + audit shape) not yet implemented"]
+async fn st_o_2_real_secret_absent_from_llm_traffic() {
+    todo!(
+        "Wire TopologyTestEnv + SecretsStore + MockLlmServer once AAASM-1920 lands. \
+         Assertions: for every recorded LLM request body, REAL_DB_PASSWORD count == 0; \
+         at least one body carries PLACEHOLDER_DB_PASSWORD or a [REDACTED:*] marker."
+    );
+}

--- a/aa-integration-tests/tests/e2e_secret_injection.rs
+++ b/aa-integration-tests/tests/e2e_secret_injection.rs
@@ -177,3 +177,46 @@ async fn st_o_3_audit_log_contains_no_real_value() {
          at least one entry's args field contains PLACEHOLDER_DB_PASSWORD."
     );
 }
+
+// ── ST-O-4 — Unknown placeholder is an error, not a passthrough ──────────────
+
+/// **ST-O-4** — Dispatching a tool with a placeholder that is **not**
+/// registered in the `SecretsStore` must surface a structured error to the
+/// caller. The gateway must **not** silently forward the literal
+/// `${UNKNOWN_SECRET}` string through to the downstream tool.
+///
+/// This guards against a subtle failure mode: if unknown placeholders
+/// passed through silently, a typo (`${DB_PASWORD}`) would not just fail
+/// — it would mask the failure and ship the literal placeholder string to
+/// production tools, possibly trigger downstream parser errors, and rob
+/// operators of any signal that the secret never resolved.
+///
+/// Setup (once AAASM-1920 ships):
+///   * Same `TopologyTestEnv` + `SecretsStore` as ST-O-1.
+///   * The store has **no** entry for `${UNKNOWN_SECRET}`.
+///   * `MockLlmServer` bound as the downstream tool sink so we can confirm
+///     no request was forwarded.
+///
+/// Action:
+///   * Agent dispatches `call_database` with
+///     `{ "connection_string": "${UNKNOWN_SECRET}" }`.
+///
+/// Assertions:
+///   1. The `dispatch_tool` call returns an error (HTTP 4xx for the HTTP
+///      route, equivalent gRPC status for the gRPC route). The error code
+///      / reason references the unknown placeholder by name
+///      (`UNKNOWN_SECRET`).
+///   2. `mock_llm.request_count() == 0` — the downstream tool received
+///      nothing. The placeholder must not be silently forwarded.
+///   3. An audit entry exists for the failed attempt, recording the
+///      placeholder name (`${UNKNOWN_SECRET}`) and the failure reason.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "blocked on AAASM-1920: Secret Injection feature (SecretsStore + dispatch_tool + audit shape) not yet implemented"]
+async fn st_o_4_unknown_placeholder_returns_error() {
+    todo!(
+        "Wire TopologyTestEnv + SecretsStore + dispatch_tool once AAASM-1920 lands. \
+         Assertions: dispatch returns SecretInjectionError::UnknownPlaceholder {{ name: \"UNKNOWN_SECRET\" }}; \
+         mock_llm.request_count() == 0; \
+         audit entry records the placeholder name + failure reason."
+    );
+}

--- a/aa-integration-tests/tests/e2e_secret_injection.rs
+++ b/aa-integration-tests/tests/e2e_secret_injection.rs
@@ -1,0 +1,104 @@
+//! AAASM-1570 / F116 ST-O — E2E **Secret Injection** scaffold.
+//!
+//! ## What this file is — and is NOT
+//!
+//! Secret Injection is the capability described at
+//! `.ai/spec/about_ai-agent-assembly_born.md:7246`:
+//!
+//! > "Secret value 不暴露給 LLM 這個點非常重要，這其實是一個獨立的核心功能叫做
+//! > **Secret Injection** ——agent 只拿到 placeholder，Assembly 在 tool dispatch
+//! > 時才注入真實 credential，LLM 的 context window 裡永遠看不到真實 secret。"
+//!
+//! It is **distinct** from Secret Detection (ST-I / ST-N, already shipped):
+//!
+//! | Capability | Trigger | What Assembly does |
+//! |---|---|---|
+//! | Secret Detection (ST-I / ST-N) | Agent *accidentally* leaks a real secret | Redact the value in flight |
+//! | Secret Injection (this file)   | Agent *intentionally* holds a placeholder `${NAME}` | Substitute the real value at tool-dispatch time |
+//!
+//! ## Why all tests are `#[ignore]`
+//!
+//! Secret Injection has **no implementation in the workspace today** — no
+//! `SecretsStore`, no `${...}` resolver, no `dispatch_tool` route. The four
+//! tests below pin the spec contract (ST-O-1…4 acceptance criteria from
+//! AAASM-1570) so that they become runnable assertions the moment the feature
+//! lands. They are tracked under **AAASM-1920** ("Implement Secret Injection
+//! — gateway secrets store + dispatch-time substitution + audit shape"),
+//! which is linked as a *Blocks* relationship on AAASM-1570.
+//!
+//! ## Test status
+//!
+//! | # | Name | Status |
+//! |---|------|--------|
+//! | 1 | `st_o_1_placeholder_substituted_at_dispatch` | `#[ignore]` — blocked on AAASM-1920 |
+//! | 2 | `st_o_2_real_secret_absent_from_llm_traffic` | `#[ignore]` — blocked on AAASM-1920 |
+//! | 3 | `st_o_3_audit_log_contains_no_real_value`    | `#[ignore]` — blocked on AAASM-1920 |
+//! | 4 | `st_o_4_unknown_placeholder_returns_error`   | `#[ignore]` — blocked on AAASM-1920 |
+//!
+//! ## How to un-ignore
+//!
+//! When AAASM-1920 ships its `SecretsStore` + `dispatch_tool` + audit shape:
+//!
+//! 1. Wire `TopologyTestEnv::start_with_secrets_store([...])` (or equivalent
+//!    helper added by AAASM-1920) and a `MockLlmServer` for upstream capture.
+//! 2. Replace each `todo!(...)` with the real assertions described in the
+//!    function-body comments.
+//! 3. Drop the `#[ignore]` attribute on each test that the feature satisfies.
+//! 4. Verify under `cargo nextest run -p aa-integration-tests --test
+//!    e2e_secret_injection`.
+//!
+//! ## Synthetic credentials only
+//!
+//! Every secret literal below is synthetic — fabricated for test purposes.
+//! No real credentials are ever stored in this fixture.
+
+#![allow(dead_code)]
+
+mod common;
+
+// ── Synthetic credential fixtures ────────────────────────────────────────────
+
+/// Placeholder name the agent will reference. Matches the spec example at
+/// `.ai/spec/about_ai-agent-assembly_born.md:7246`.
+const PLACEHOLDER_DB_PASSWORD: &str = "${DB_PASSWORD}";
+
+/// Real secret value the gateway's `SecretsStore` will return when resolving
+/// `${DB_PASSWORD}`. Synthetic — fabricated for this test only.
+const REAL_DB_PASSWORD: &str = "real-secret-abc-DEADBEEF-0001";
+
+/// Placeholder the agent will reference that has **no** entry in the
+/// `SecretsStore`. ST-O-4 asserts this produces a structured error rather
+/// than silently passing through.
+const PLACEHOLDER_UNKNOWN: &str = "${UNKNOWN_SECRET}";
+
+// ── ST-O-1 — Placeholder substituted at dispatch ─────────────────────────────
+
+/// **ST-O-1** — Placeholder `${DB_PASSWORD}` is substituted with the real
+/// credential before the downstream tool receives the dispatch.
+///
+/// Setup (once AAASM-1920 ships):
+///   * Start `TopologyTestEnv` with a `SecretsStore` mapping
+///     `${DB_PASSWORD}` → `REAL_DB_PASSWORD`.
+///   * Register agent `secret-injection-test-agent`.
+///   * Stand up a `MockLlmServer` (AAASM-1547) as the tool sink so we can
+///     observe what the downstream tool actually received.
+///
+/// Action:
+///   * Agent dispatches `call_database` with
+///     `{ "connection_string": "${DB_PASSWORD}" }` via the new
+///     `dispatch_tool` route on `aa-api` / `aa-gateway`.
+///
+/// Assertions:
+///   1. The downstream tool sees `REAL_DB_PASSWORD` substituted in for
+///      `${DB_PASSWORD}` — `mock.last_body()` contains `REAL_DB_PASSWORD`.
+///   2. The audit entry for this dispatch records the **placeholder name**
+///      (`${DB_PASSWORD}`), not the resolved value.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "blocked on AAASM-1920: Secret Injection feature (SecretsStore + dispatch_tool + audit shape) not yet implemented"]
+async fn st_o_1_placeholder_substituted_at_dispatch() {
+    todo!(
+        "Wire TopologyTestEnv::start_with_secrets_store + dispatch_tool + AuditWriter once AAASM-1920 lands. \
+         Assertions: (1) downstream tool body contains REAL_DB_PASSWORD; \
+         (2) audit entry args field contains PLACEHOLDER_DB_PASSWORD, not REAL_DB_PASSWORD."
+    );
+}


### PR DESCRIPTION
## Description

Adds `aa-integration-tests/tests/e2e_secret_injection.rs` — the **F116 ST-O** end-to-end test target for the **Secret Injection** capability described at `.ai/spec/about_ai-agent-assembly_born.md:7246`.

Secret Injection is **distinct from Secret Detection** (ST-I / ST-N, already shipped):

| Capability | Trigger | What Assembly does |
| --- | --- | --- |
| Secret Detection (ST-I / ST-N) | Agent *accidentally* leaks a real secret | Redact the value in flight |
| Secret Injection (this scaffold) | Agent *intentionally* holds a placeholder `${NAME}` | Substitute the real value at tool-dispatch time |

Four tests pin the AAASM-1570 acceptance criteria:

| # | Name | Asserts |
|---|------|---------|
| 1 | `st_o_1_placeholder_substituted_at_dispatch` | Downstream tool receives the resolved real secret; audit records the placeholder name only |
| 2 | `st_o_2_real_secret_absent_from_llm_traffic` | Across all LLM-bound requests, the real secret appears zero times |
| 3 | `st_o_3_audit_log_contains_no_real_value` | Grep over the raw JSONL audit log finds zero occurrences of the resolved secret |
| 4 | `st_o_4_unknown_placeholder_returns_error` | An unregistered placeholder errors loudly; downstream sink receives zero requests; failure is audited |

### Why scaffold rather than implement

All four tests are `#[ignore]`'d and end in `todo!(...)` because the Secret Injection feature itself **does not exist in the workspace today** — no `SecretsStore`, no `${...}` resolver, no `dispatch_tool` route. Code search across the entire repo turned up no matches.

The feature is now tracked under **AAASM-1920** (*Implement Secret Injection — gateway secrets store + dispatch-time substitution + audit shape*), linked as a *Blocks* relationship on AAASM-1570. AAASM-1920 spans `aa-gateway`, `aa-api`, `aa-proto`, and the Python SDK — far too large to bundle into a single ST sub-task PR. The ST-O ticket explicitly anticipates this case in its own Notes section: *"If the Secret Injection feature has not yet been implemented as a standalone feature story, this test will unblock the need to create that feature ticket first."*

When AAASM-1920 ships, the next pass on this Subtask replaces each `todo!(...)` with the assertions described inline, drops the `#[ignore]` attribute, and confirms via `cargo nextest run -p aa-integration-tests --test e2e_secret_injection`.

## Type of Change

- [x] ✅ Tests (new E2E test target — scaffold only)

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-1570 (this Subtask)
- Parent Story: AAASM-1232 (F116 MVP acceptance test)
- Parent Epic: AAASM-1199
- Blocked by: AAASM-1920 (new Story — *Implement Secret Injection feature*)

## Testing

Describe the testing performed for this PR:

- [ ] Unit tests added / updated
- [x] Integration tests added / updated (4 `#[ignore]`'d ST-O tests)
- [x] Manual testing performed (see below)
- [ ] No tests required (explain why)

### Local validation

```
$ cargo check -p aa-integration-tests --tests
    Finished `dev` profile [unoptimized + debuginfo] target(s)

$ cargo clippy -p aa-integration-tests --tests -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s)

$ cargo test -p aa-integration-tests --test e2e_secret_injection -- --list
st_o_1_placeholder_substituted_at_dispatch: test
st_o_2_real_secret_absent_from_llm_traffic: test
st_o_3_audit_log_contains_no_real_value: test
st_o_4_unknown_placeholder_returns_error: test
4 tests, 0 benchmarks

$ cargo nextest run -p aa-integration-tests --test e2e_secret_injection
Summary [0.000s] 0 tests run: 0 passed, 4 skipped
```

The four `4 skipped` outcomes are the intended behaviour while AAASM-1920 is open: the scaffold compiles and is discovered by the test runner, but tests do not execute because their preconditions don't exist yet.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed *(N/A — no behaviour change; the new feature Story AAASM-1920 owns its own README)*
- [x] All CI checks passing *(will confirm after CI runs)*
- [x] Commits are small and follow the Gitmoji convention (4 commits, one per ST-O test)
