### PR TITLE
[AAASM-1574] 🐛 (aa-ebpf): Attach legacy unlink/rename syscall kprobes

### DIFF
--- a/aa-ebpf-probes/src/main.rs
+++ b/aa-ebpf-probes/src/main.rs
@@ -588,6 +588,19 @@ fn try_sys_rename_legacy(ctx: &ProbeContext) -> Result<u32, u32> {
     Ok(0)
 }
 
+/// kretprobe paired with [`aa_sys_rename_legacy`] — emits the event
+/// using the source path stashed by the legacy entry kprobe.
+/// Delegates to the same handler as the at-variant retprobe because
+/// both share the `RENAME_TMP` / `RENAME_ENTRY_TS` maps keyed by
+/// `pid_tgid`.
+#[kretprobe]
+pub fn aa_sys_rename_legacy_ret(ctx: RetProbeContext) -> u32 {
+    match try_sys_rename_ret(&ctx) {
+        Ok(ret) => ret,
+        Err(ret) => ret,
+    }
+}
+
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     unsafe { core::hint::unreachable_unchecked() }

--- a/aa-ebpf-probes/src/main.rs
+++ b/aa-ebpf-probes/src/main.rs
@@ -549,6 +549,45 @@ fn try_sys_rename_ret(ctx: &RetProbeContext) -> Result<u32, u32> {
     Ok(0)
 }
 
+/// kprobe on the legacy `sys_rename` — captures the source pathname
+/// from `rename(const char *oldpath, const char *newpath)`, where
+/// oldpath is the **first** syscall argument (rdi) rather than the
+/// second.
+///
+/// glibc on x86_64 routes the libc `rename()` call through `__NR_rename`
+/// (syscall 82), bypassing the `__x64_sys_renameat2` probe above; this
+/// hook covers that path. AAASM-1574.
+#[kprobe]
+pub fn aa_sys_rename_legacy(ctx: ProbeContext) -> u32 {
+    match try_sys_rename_legacy(&ctx) {
+        Ok(ret) => ret,
+        Err(ret) => ret,
+    }
+}
+
+fn try_sys_rename_legacy(ctx: &ProbeContext) -> Result<u32, u32> {
+    let (tgid, _pid) = get_pid_tgid();
+    if !should_monitor(tgid) {
+        return Ok(0);
+    }
+
+    // rename(const char *oldpath, const char *newpath) — oldpath is arg 0 (rdi).
+    let oldpath_ptr: *const u8 = syscall_pt_regs(ctx).ok_or(1u32)?.arg(0).ok_or(1u32)?;
+
+    let mut buf = [0u8; MAX_PATH_LEN];
+    unsafe {
+        let _ = bpf_probe_read_user_str_bytes(oldpath_ptr, &mut buf);
+    }
+
+    let pid_tgid = aya_ebpf::helpers::bpf_get_current_pid_tgid();
+    let _ = RENAME_TMP.insert(&pid_tgid, &buf, 0);
+
+    let entry_ts = unsafe { bpf_ktime_get_ns() };
+    let _ = RENAME_ENTRY_TS.insert(&pid_tgid, &entry_ts, 0);
+
+    Ok(0)
+}
+
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     unsafe { core::hint::unreachable_unchecked() }

--- a/aa-ebpf-probes/src/main.rs
+++ b/aa-ebpf-probes/src/main.rs
@@ -405,6 +405,44 @@ fn try_sys_unlink_ret(ctx: &RetProbeContext) -> Result<u32, u32> {
     Ok(0)
 }
 
+/// kprobe on the legacy `sys_unlink` — captures the pathname from
+/// `unlink(const char *pathname)`, where the path is the **first**
+/// syscall argument (rdi) rather than the second.
+///
+/// glibc on x86_64 routes the libc `unlink()` call through `__NR_unlink`
+/// (syscall 87), bypassing the `__x64_sys_unlinkat` probe above; this
+/// hook covers that path. AAASM-1574.
+#[kprobe]
+pub fn aa_sys_unlink_legacy(ctx: ProbeContext) -> u32 {
+    match try_sys_unlink_legacy(&ctx) {
+        Ok(ret) => ret,
+        Err(ret) => ret,
+    }
+}
+
+fn try_sys_unlink_legacy(ctx: &ProbeContext) -> Result<u32, u32> {
+    let (tgid, _pid) = get_pid_tgid();
+    if !should_monitor(tgid) {
+        return Ok(0);
+    }
+
+    // unlink(const char *pathname) — pathname is arg 0 (rdi).
+    let filename_ptr: *const u8 = syscall_pt_regs(ctx).ok_or(1u32)?.arg(0).ok_or(1u32)?;
+
+    let mut buf = [0u8; MAX_PATH_LEN];
+    unsafe {
+        let _ = bpf_probe_read_user_str_bytes(filename_ptr, &mut buf);
+    }
+
+    let pid_tgid = aya_ebpf::helpers::bpf_get_current_pid_tgid();
+    let _ = UNLINK_TMP.insert(&pid_tgid, &buf, 0);
+
+    let entry_ts = unsafe { bpf_ktime_get_ns() };
+    let _ = UNLINK_ENTRY_TS.insert(&pid_tgid, &entry_ts, 0);
+
+    Ok(0)
+}
+
 /// kprobe on `sys_renameat2` — captures the source pathname from the
 /// syscall argument, stashes it + the entry timestamp keyed by
 /// `pid_tgid`, and defers event emission to the kretprobe.

--- a/aa-ebpf-probes/src/main.rs
+++ b/aa-ebpf-probes/src/main.rs
@@ -443,6 +443,18 @@ fn try_sys_unlink_legacy(ctx: &ProbeContext) -> Result<u32, u32> {
     Ok(0)
 }
 
+/// kretprobe paired with [`aa_sys_unlink_legacy`] — emits the event
+/// using the path stashed by the legacy entry kprobe. Delegates to
+/// the same handler as the at-variant retprobe because both share the
+/// `UNLINK_TMP` / `UNLINK_ENTRY_TS` maps keyed by `pid_tgid`.
+#[kretprobe]
+pub fn aa_sys_unlink_legacy_ret(ctx: RetProbeContext) -> u32 {
+    match try_sys_unlink_ret(&ctx) {
+        Ok(ret) => ret,
+        Err(ret) => ret,
+    }
+}
+
 /// kprobe on `sys_renameat2` — captures the source pathname from the
 /// syscall argument, stashes it + the entry timestamp keyed by
 /// `pid_tgid`, and defers event emission to the kretprobe.

--- a/aa-ebpf/src/kprobe.rs
+++ b/aa-ebpf/src/kprobe.rs
@@ -60,12 +60,16 @@ impl KprobeManager {
         }
 
         // Attach all file I/O kprobe programs to their kernel functions.
+        // `aa_sys_unlink_legacy` covers the legacy `__x64_sys_unlink` entry
+        // point that glibc's `unlink()` invokes on x86_64 — bypassing the
+        // at-variant probe above. See AAASM-1574.
         let probes: &[(&str, &str)] = &[
             ("aa_sys_openat", "__x64_sys_openat"),
             ("aa_sys_openat_ret", "__x64_sys_openat"),
             ("aa_sys_read", "__x64_sys_read"),
             ("aa_sys_write", "__x64_sys_write"),
             ("aa_sys_unlink", "__x64_sys_unlinkat"),
+            ("aa_sys_unlink_legacy", "__x64_sys_unlink"),
             ("aa_sys_rename", "__x64_sys_renameat2"),
         ];
 
@@ -139,6 +143,7 @@ impl KprobeManager {
         ("aa_sys_read", "__x64_sys_read"),
         ("aa_sys_write", "__x64_sys_write"),
         ("aa_sys_unlink", "__x64_sys_unlinkat"),
+        ("aa_sys_unlink_legacy", "__x64_sys_unlink"),
         ("aa_sys_rename", "__x64_sys_renameat2"),
     ];
 }
@@ -165,7 +170,7 @@ mod tests {
     #[test]
     fn kprobe_targets_covers_all_file_io_syscalls() {
         let targets = KprobeManager::KPROBE_TARGETS;
-        assert_eq!(targets.len(), 6);
+        assert_eq!(targets.len(), 7);
 
         let prog_names: Vec<&str> = targets.iter().map(|(p, _)| *p).collect();
         assert!(prog_names.contains(&"aa_sys_openat"));
@@ -173,6 +178,7 @@ mod tests {
         assert!(prog_names.contains(&"aa_sys_read"));
         assert!(prog_names.contains(&"aa_sys_write"));
         assert!(prog_names.contains(&"aa_sys_unlink"));
+        assert!(prog_names.contains(&"aa_sys_unlink_legacy"));
         assert!(prog_names.contains(&"aa_sys_rename"));
     }
 

--- a/aa-ebpf/src/kprobe.rs
+++ b/aa-ebpf/src/kprobe.rs
@@ -60,9 +60,10 @@ impl KprobeManager {
         }
 
         // Attach all file I/O kprobe programs to their kernel functions.
-        // `aa_sys_unlink_legacy` covers the legacy `__x64_sys_unlink` entry
-        // point that glibc's `unlink()` invokes on x86_64 — bypassing the
-        // at-variant probe above. See AAASM-1574.
+        // `aa_sys_unlink_legacy` / `aa_sys_rename_legacy` cover the legacy
+        // syscall entry points that glibc on x86_64 invokes for libc
+        // `unlink()` / `rename()` — bypassing the at-variant probes
+        // above. See AAASM-1574.
         let probes: &[(&str, &str)] = &[
             ("aa_sys_openat", "__x64_sys_openat"),
             ("aa_sys_openat_ret", "__x64_sys_openat"),
@@ -71,6 +72,7 @@ impl KprobeManager {
             ("aa_sys_unlink", "__x64_sys_unlinkat"),
             ("aa_sys_unlink_legacy", "__x64_sys_unlink"),
             ("aa_sys_rename", "__x64_sys_renameat2"),
+            ("aa_sys_rename_legacy", "__x64_sys_rename"),
         ];
 
         let mut links: Vec<Box<dyn std::any::Any>> = Vec::with_capacity(probes.len());
@@ -145,6 +147,7 @@ impl KprobeManager {
         ("aa_sys_unlink", "__x64_sys_unlinkat"),
         ("aa_sys_unlink_legacy", "__x64_sys_unlink"),
         ("aa_sys_rename", "__x64_sys_renameat2"),
+        ("aa_sys_rename_legacy", "__x64_sys_rename"),
     ];
 }
 
@@ -170,7 +173,7 @@ mod tests {
     #[test]
     fn kprobe_targets_covers_all_file_io_syscalls() {
         let targets = KprobeManager::KPROBE_TARGETS;
-        assert_eq!(targets.len(), 7);
+        assert_eq!(targets.len(), 8);
 
         let prog_names: Vec<&str> = targets.iter().map(|(p, _)| *p).collect();
         assert!(prog_names.contains(&"aa_sys_openat"));
@@ -180,6 +183,7 @@ mod tests {
         assert!(prog_names.contains(&"aa_sys_unlink"));
         assert!(prog_names.contains(&"aa_sys_unlink_legacy"));
         assert!(prog_names.contains(&"aa_sys_rename"));
+        assert!(prog_names.contains(&"aa_sys_rename_legacy"));
     }
 
     #[test]

--- a/aa-integration-tests/tests/e2e_file_monitoring.rs
+++ b/aa-integration-tests/tests/e2e_file_monitoring.rs
@@ -150,6 +150,16 @@ fn load_file_io_bpf() -> Ebpf {
     attach_kprobe_pair(&mut bpf, "aa_sys_read", "aa_sys_read_ret", "__x64_sys_read");
     attach_kprobe_pair(&mut bpf, "aa_sys_write", "aa_sys_write_ret", "__x64_sys_write");
     attach_kprobe_pair(&mut bpf, "aa_sys_unlink", "aa_sys_unlink_ret", "__x64_sys_unlinkat");
+    // glibc on x86_64 routes `unlink()` through `__NR_unlink` —
+    // attach the legacy probe so the Python driver's `os.unlink(p)`
+    // call fires the unlink kretprobe via the legacy entry point.
+    // See AAASM-1574.
+    attach_kprobe_pair(
+        &mut bpf,
+        "aa_sys_unlink_legacy",
+        "aa_sys_unlink_legacy_ret",
+        "__x64_sys_unlink",
+    );
     attach_kprobe_pair(&mut bpf, "aa_sys_rename", "aa_sys_rename_ret", "__x64_sys_renameat2");
     bpf
 }

--- a/aa-integration-tests/tests/e2e_file_monitoring.rs
+++ b/aa-integration-tests/tests/e2e_file_monitoring.rs
@@ -484,7 +484,6 @@ async fn ebpf_file_read_syscall_emits_event_for_target_pid() {
 /// renameat2 today, so only the source path is asserted — see
 /// AAASM-1425 for the dual-path schema extension.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "blocked on AAASM-1574: aa-file-io probe attaches to __x64_sys_renameat2 but glibc rename() routes through __x64_sys_rename on x86_64"]
 async fn ebpf_file_rename_emits_event_with_old_path() {
     let mut bpf = load_file_io_bpf();
     let (mut rx, _events_array) = start_perf_reader(&mut bpf);

--- a/aa-integration-tests/tests/e2e_file_monitoring.rs
+++ b/aa-integration-tests/tests/e2e_file_monitoring.rs
@@ -533,7 +533,6 @@ async fn ebpf_file_rename_emits_event_with_old_path() {
 /// pid. Confirms the file is actually gone afterwards as a sanity check
 /// that the driver did the right syscall.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "blocked on AAASM-1574: aa-file-io probe attaches to __x64_sys_unlinkat but glibc unlink() routes through __x64_sys_unlink on x86_64"]
 async fn ebpf_file_unlink_emits_event_with_path() {
     let mut bpf = load_file_io_bpf();
     let (mut rx, _events_array) = start_perf_reader(&mut bpf);

--- a/aa-integration-tests/tests/e2e_file_monitoring.rs
+++ b/aa-integration-tests/tests/e2e_file_monitoring.rs
@@ -161,6 +161,16 @@ fn load_file_io_bpf() -> Ebpf {
         "__x64_sys_unlink",
     );
     attach_kprobe_pair(&mut bpf, "aa_sys_rename", "aa_sys_rename_ret", "__x64_sys_renameat2");
+    // glibc on x86_64 routes `rename()` through `__NR_rename` —
+    // attach the legacy probe so the Python driver's `os.rename(a, b)`
+    // call fires the rename kretprobe via the legacy entry point.
+    // See AAASM-1574.
+    attach_kprobe_pair(
+        &mut bpf,
+        "aa_sys_rename_legacy",
+        "aa_sys_rename_legacy_ret",
+        "__x64_sys_rename",
+    );
     bpf
 }
 

--- a/aa-integration-tests/tests/e2e_file_monitoring.rs
+++ b/aa-integration-tests/tests/e2e_file_monitoring.rs
@@ -48,35 +48,39 @@
 //!
 //! ## Test status
 //!
+//! All eight tests are enabled. See "Probe-bug history" below for the
+//! two predecessor incidents (AAASM-1552 then AAASM-1574) that
+//! previously gated this suite.
+//!
 //! | # | Name | Status |
 //! |---|------|--------|
-//! | 1 | `ebpf_file_create_emits_event_with_path_and_pid` | `#[ignore]` — AAASM-1552 |
-//! | 2 | `ebpf_file_write_syscall_emits_event_for_target_pid` | `#[ignore]` — AAASM-1552 |
-//! | 3 | `ebpf_file_read_syscall_emits_event_for_target_pid` | `#[ignore]` — AAASM-1552 |
-//! | 4 | `ebpf_file_rename_emits_event_with_old_path` | `#[ignore]` — AAASM-1552 |
-//! | 5 | `ebpf_file_unlink_emits_event_with_path` | `#[ignore]` — AAASM-1552 |
-//! | 6 | `ebpf_file_events_attributed_to_filtered_pid_only` | `#[ignore]` — AAASM-1552 |
-//! | 7 | `ebpf_pid_not_in_filter_map_produces_no_event` | enabled (root) |
-//! | 8 | `ebpf_file_event_records_path_when_openat_is_absolute` | `#[ignore]` — AAASM-1552 |
+//! | 1 | `ebpf_file_create_emits_event_with_path_and_pid` | enabled |
+//! | 2 | `ebpf_file_write_syscall_emits_event_for_target_pid` | enabled |
+//! | 3 | `ebpf_file_read_syscall_emits_event_for_target_pid` | enabled |
+//! | 4 | `ebpf_file_rename_emits_event_with_old_path` | enabled |
+//! | 5 | `ebpf_file_unlink_emits_event_with_path` | enabled |
+//! | 6 | `ebpf_file_events_attributed_to_filtered_pid_only` | enabled |
+//! | 7 | `ebpf_pid_not_in_filter_map_produces_no_event` | enabled |
+//! | 8 | `ebpf_file_event_records_path_when_openat_is_absolute` | enabled |
 //!
-//! ## Blocking probe bug — AAASM-1552
+//! ## Probe-bug history
 //!
-//! On the first three CI runs of this suite, 7 of 8 tests timed out
-//! waiting for events with the right `path`. A diagnostic dump confirmed
-//! the probe DOES fire and events DO reach userspace with correct `pid`
-//! / `tid` / `syscall` attribution — but every event has `path == ""`.
-//! Root cause: `aa-ebpf-probes::try_sys_openat` (and the matching
-//! unlink / rename probes) read `ctx.arg(1)` directly, which on any
-//! Linux kernel with `CONFIG_SYSCALL_WRAPPER=y` (default since 4.17,
-//! every modern x86_64 distro including ubuntu-latest) returns the
-//! `rsi` register of the `__x64_sys_*(struct pt_regs *regs)` wrapper —
-//! not the user's filename pointer. The probe must either deref pt_regs
-//! to extract the real syscall arg, or switch to syscall tracepoints.
+//! Two probe-side bugs previously gated this suite:
 //!
-//! Until that probe-side fix lands (tracked under AAASM-1552), the 7
-//! affected tests are `#[ignore]`'d with a referenced blocker. Test 7
-//! (`ebpf_pid_not_in_filter_map_produces_no_event`) stays enabled because it
-//! asserts the *absence* of events and is unaffected by the path bug.
+//! 1. **AAASM-1552** — `aa-ebpf-probes` read `ctx.arg(1)` directly on
+//!    `__x64_sys_*` kprobes, which on any kernel with
+//!    `CONFIG_SYSCALL_WRAPPER=y` (default since 4.17) returns the
+//!    wrapper's own register state, not the user's filename pointer.
+//!    Fixed by routing every path argument through
+//!    `syscall_pt_regs(ctx).arg(n)`. Closed.
+//! 2. **AAASM-1574** — even with the pt_regs deref fix, tests 4 and 5
+//!    timed out because glibc on x86_64 routes libc `unlink()` /
+//!    `rename()` through `__NR_unlink` / `__NR_rename` (the legacy
+//!    syscalls), which surface as `__x64_sys_unlink` / `__x64_sys_rename`
+//!    — not the at-variant probes the test was attaching to. Fixed by
+//!    adding `aa_sys_unlink_legacy` / `aa_sys_rename_legacy` probes
+//!    that read arg 0 (rdi) and attaching them alongside the at-variant
+//!    probes in [`load_file_io_bpf`]. Closed.
 //!
 //! ## Schema gaps deliberately not asserted
 //!


### PR DESCRIPTION
## Description

Fixes the bug where `aa-file-io` kprobes never fired for `os.unlink(p)` /
`os.rename(a, b)` from the Python driver, even though the at-variant
probes (`__x64_sys_unlinkat` / `__x64_sys_renameat2`) were attached and
loaded correctly.

**Root cause:** glibc on x86_64 routes the libc `unlink()` and `rename()`
calls through the legacy `__NR_unlink` (syscall 87) and `__NR_rename`
(syscall 82) entry points — `__x64_sys_unlink` and `__x64_sys_rename` —
not the at-variants we were attached to. CPython's `os.unlink` /
`os.rename` invoke those libc functions, so the at-variant probes never
fired.

**Fix (Option 1 from the ticket — smallest diff):** add two new
entry+ret kprobe pairs that read pathname/oldpath from arg 0 (rdi)
instead of arg 1 (rsi) of the legacy syscalls:

* `aa_sys_unlink_legacy` / `aa_sys_unlink_legacy_ret` → `__x64_sys_unlink`
* `aa_sys_rename_legacy` / `aa_sys_rename_legacy_ret` → `__x64_sys_rename`

Both legacy probes share the existing `UNLINK_TMP` / `RENAME_TMP` /
`*_ENTRY_TS` maps with their at-variant counterparts — the maps are
keyed by `pid_tgid` and the two entry kprobes are mutually exclusive
per syscall invocation (glibc routes through exactly one of them), so
no aliasing.

Attach tables updated in both production runtime (`aa-ebpf/src/kprobe.rs::KprobeManager`)
and the integration-test harness (`aa-integration-tests/tests/e2e_file_monitoring.rs::load_file_io_bpf`).
Tests 4 (rename) and 5 (unlink) are un-`#[ignore]`'d. Module docstring
refreshed to record the AAASM-1552 → AAASM-1574 probe-bug history.

### What is NOT in this PR

* **No userspace dedup** of legacy + at-variant events. The two entry
  kprobes hook **different kernel functions** and a single userspace
  `unlink()` / `rename()` invocation hits exactly one of them via
  `__NR_*`, so single-syscall double-fire is architecturally impossible
  on the platforms we target. The ticket text mentioned dedup as a
  cautionary belt-and-braces; we omit it to avoid drop-rate risk in
  the consumer hot path.
* **No fix for the pre-existing production gap** where
  `KprobeManager::attach` loads only entry kprobes for unlink/rename
  but not their kretprobes (so the production runtime currently emits
  zero unlink/rename events regardless of probe variant). Out of scope
  for this bug fix — separate ticket recommended.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-1574](https://lightning-dust-mite.atlassian.net/browse/AAASM-1574)
- Parent Story: [AAASM-1232](https://lightning-dust-mite.atlassian.net/browse/AAASM-1232) (F116 MVP acceptance, ST-J)
- Epic: [AAASM-1199](https://lightning-dust-mite.atlassian.net/browse/AAASM-1199)
- Predecessor that surfaced this: AAASM-1552 (PR #585) — once the SYSCALL_WRAPPER pt_regs fix landed, the wrong-attach-symbol bug became reachable.

## Testing

- [x] Unit tests added / updated — `kprobe_targets_covers_all_file_io_syscalls` bumped from 6 → 8 with presence assertions for both new legacy program names.
- [x] Integration tests added / updated — `ebpf_file_unlink_emits_event_with_path` + `ebpf_file_rename_emits_event_with_old_path` are now enabled (no `#[ignore]`); both run on the `e2e-ebpf-linux` CI job.
- [x] Manual testing performed — full `cargo nextest run -p aa-ebpf` passes locally (72/72); `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo doc --workspace --no-deps` all pass via lefthook on every commit.

eBPF programs only compile to `bpfel-unknown-none` on Linux, so the
actual probe attach against `__x64_sys_unlink` / `__x64_sys_rename`
is verified by the `e2e-ebpf-linux` CI job (Ubuntu 24.04, glibc 2.39,
sudo).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (module docstring refreshed with probe-bug history)
- [ ] All CI checks passing (awaiting CI on this PR)
- [x] Commits are small and follow the Gitmoji convention (11 commits, one per probe / per attach-table entry / per un-ignore / per docstring change)

[AAASM-1574]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ