### PR TITLE
[AAASM-1250] ✨ (ci): Add smoke-test workflow + Homebrew & curl jobs

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -115,3 +115,54 @@ jobs:
             echo "::error::aasm --version mismatch — got '${got}', want '${want}'"
             exit 1
           }
+
+  smoke-curl-installer:
+    name: Smoke — curl installer
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Compute expected aasm version
+        id: expected
+        shell: bash
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if [ -n "${INPUT_VERSION}" ]; then
+            version="${INPUT_VERSION}"
+          else
+            version="${TAG#v}"
+          fi
+          if [ -z "${version}" ]; then
+            echo "::error::Could not resolve release version from event payload" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Install aasm via the curl installer
+        run: |
+          # Pipe-to-shell is the documented one-liner for this distribution
+          # channel; the installer drops `aasm` into a directory on $PATH for
+          # the current shell. Re-export common install locations so the
+          # subsequent step can find the binary regardless of which one the
+          # installer chose.
+          curl -fsSL https://get.agent-assembly.io | sh
+          {
+            echo "$HOME/.local/bin"
+            echo "$HOME/.agent-assembly/bin"
+            echo "/usr/local/bin"
+          } >> "$GITHUB_PATH"
+
+      - name: Verify aasm --version matches release tag
+        env:
+          EXPECTED: ${{ steps.expected.outputs.version }}
+        shell: bash
+        run: |
+          got=$(aasm --version)
+          want="aasm ${EXPECTED}"
+          echo "Installed: ${got}"
+          echo "Expected:  ${want}"
+          [ "${got}" = "${want}" ] || {
+            echo "::error::aasm --version mismatch — got '${got}', want '${want}'"
+            exit 1
+          }

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -68,3 +68,50 @@ jobs:
             echo "::error::aasm --version mismatch — got '${got}', want '${want}'"
             exit 1
           }
+
+  smoke-homebrew-linux:
+    name: Smoke — Homebrew (Linux x86_64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Compute expected aasm version
+        id: expected
+        shell: bash
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if [ -n "${INPUT_VERSION}" ]; then
+            version="${INPUT_VERSION}"
+          else
+            version="${TAG#v}"
+          fi
+          if [ -z "${version}" ]; then
+            echo "::error::Could not resolve release version from event payload" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Install Homebrew (Linuxbrew) on a clean Ubuntu runner
+        run: |
+          NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+          echo "/home/linuxbrew/.linuxbrew/bin" >> "$GITHUB_PATH"
+
+      - name: Install aasm via Homebrew tap
+        run: |
+          brew update
+          brew install agent-assembly/tap/aasm
+
+      - name: Verify aasm --version matches release tag
+        env:
+          EXPECTED: ${{ steps.expected.outputs.version }}
+        shell: bash
+        run: |
+          got=$(aasm --version)
+          want="aasm ${EXPECTED}"
+          echo "Installed: ${got}"
+          echo "Expected:  ${want}"
+          [ "${got}" = "${want}" ] || {
+            echo "::error::aasm --version mismatch — got '${got}', want '${want}'"
+            exit 1
+          }

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,70 @@
+name: Smoke Test (Release Artifacts)
+
+# Runs after a GitHub Release is published and verifies that every distribution
+# channel installs and runs the published artifacts on a clean runner.
+#
+# Story:    AAASM-1235 (F119 — Post-release artifact smoke test)
+# Sub-task: AAASM-1250 (Homebrew + curl installer jobs)
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version to smoke-test, without the leading 'v' (e.g. 0.0.1). Defaults to the release tag that triggered the workflow."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+# Avoid concurrent smoke runs for the same release tag.
+concurrency:
+  group: smoke-test-${{ github.event.release.tag_name || github.event.inputs.version || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  smoke-homebrew-macos:
+    name: Smoke — Homebrew (macOS ARM64)
+    runs-on: macos-14
+    timeout-minutes: 15
+    steps:
+      - name: Compute expected aasm version
+        id: expected
+        shell: bash
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if [ -n "${INPUT_VERSION}" ]; then
+            version="${INPUT_VERSION}"
+          else
+            version="${TAG#v}"
+          fi
+          if [ -z "${version}" ]; then
+            echo "::error::Could not resolve release version from event payload" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Expected aasm version: ${version}"
+
+      - name: Install aasm via Homebrew tap
+        run: |
+          brew update
+          brew install agent-assembly/tap/aasm
+
+      - name: Verify aasm --version matches release tag
+        env:
+          EXPECTED: ${{ steps.expected.outputs.version }}
+        shell: bash
+        run: |
+          got=$(aasm --version)
+          want="aasm ${EXPECTED}"
+          echo "Installed: ${got}"
+          echo "Expected:  ${want}"
+          [ "${got}" = "${want}" ] || {
+            echo "::error::aasm --version mismatch — got '${got}', want '${want}'"
+            exit 1
+          }


### PR DESCRIPTION
## Description

Adds the first half of `.github/workflows/smoke-test.yml` for Story
**AAASM-1235** (F119 — post-release artifact smoke test). The workflow
triggers on every `release: [published]` event (plus a manual
`workflow_dispatch` with an explicit `version` input for re-runs) and
ships three of the seven planned jobs in this PR:

| Job | Runner | What it verifies |
| --- | --- | --- |
| `smoke-homebrew-macos` | `macos-14` (ARM64) | `brew install agent-assembly/tap/aasm && aasm --version` prints `aasm <released-version>` |
| `smoke-homebrew-linux` | `ubuntu-latest` (x86_64) | Same flow but installs Linuxbrew non-interactively first |
| `smoke-curl-installer` | `ubuntu-latest` | `curl -fsSL https://get.agent-assembly.io \| sh && aasm --version` |

Each job resolves the expected version once (release tag → `version` with
the leading `v` stripped, or the manual-dispatch `version` input), then
asserts `aasm --version` matches `aasm <released-version>` and fails the
job with an `::error::` annotation on mismatch.

Workflow-level `permissions: issues: write` is set up front so the
failure-notification job added by **AAASM-1252** can open Issues without
needing another permissions edit.

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1250 (sub-task of AAASM-1235, under Epic AAASM-1199)
- Related GitHub issues: n/a

## Testing

- [x] **Local `actionlint` is clean** on every commit (the workflow
  parses, action references and shell quoting validate).
- [x] **`yamllint`-equivalent structure** — manual inspection confirms
  YAML keys, indentation, and the GitHub Actions schema (`on`, `jobs`,
  `permissions`, `concurrency`).
- [ ] **Runtime verification on a real release** is intentionally
  deferred to **AAASM-1253** (the verification sub-task for this Story).
  All seven smoke jobs run against the published `v0.0.1` artifacts;
  green there is the AC sign-off for both this PR and the Story.

This PR is the first of four stacked sub-task PRs:

```
AAASM-1250 (this PR) ─► AAASM-1251 (Python) ─► AAASM-1919 (npm) ─► AAASM-1252 (Docker + notify) ─► AAASM-1253 (verify)
```

Each downstream PR is branched off master and cherry-picks the prior
sub-task commits so it is independently mergeable.

## Checklist

- [x] Commits are small and follow the Gitmoji convention (3 commits:
  scaffold + macOS / Linux / curl)
- [x] Self-review of the diff completed
- [x] No `cargo`-relevant code changed; Rust pre-commit / pre-push hooks
  cleanly skipped on the YAML-only diff
- [x] All CI checks passing — none are configured to run on changes
  scoped to `.github/workflows/smoke-test.yml` (per the existing path
  filters on `ci.yml`, `dashboard-ci.yml`, etc.), so "no checks reported"
  is the expected status here
- [x] Documentation updated if behaviour changed — n/a, new workflow
