### PR TITLE
[AAASM-1251] ✨ (ci): Add Python pip [runtime] smoke jobs

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -213,3 +213,50 @@ jobs:
             echo "::error::agent_assembly.__version__ mismatch — got '${got}', want '${want}'"
             exit 1
           }
+
+  smoke-python-pypi-runtime:
+    name: Smoke — Python pip (aasm --version via [runtime] extra)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Compute expected aasm version
+        id: expected
+        shell: bash
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if [ -n "${INPUT_VERSION}" ]; then
+            version="${INPUT_VERSION}"
+          else
+            version="${TAG#v}"
+          fi
+          if [ -z "${version}" ]; then
+            echo "::error::Could not resolve release version from event payload" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python 3.12 on a clean runner
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install agent-assembly-python[runtime] from PyPI
+        run: |
+          python -m pip install --upgrade pip
+          pip install --no-cache-dir 'agent-assembly-python[runtime]'
+
+      - name: Verify the bundled aasm binary prints the release tag
+        env:
+          EXPECTED: ${{ steps.expected.outputs.version }}
+        shell: bash
+        run: |
+          got=$(aasm --version)
+          want="aasm ${EXPECTED}"
+          echo "Installed: ${got}"
+          echo "Expected:  ${want}"
+          [ "${got}" = "${want}" ] || {
+            echo "::error::aasm --version mismatch — got '${got}', want '${want}'"
+            exit 1
+          }

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -166,3 +166,50 @@ jobs:
             echo "::error::aasm --version mismatch — got '${got}', want '${want}'"
             exit 1
           }
+
+  smoke-python-pypi-import:
+    name: Smoke — Python pip (import + __version__)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Compute expected aasm version
+        id: expected
+        shell: bash
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if [ -n "${INPUT_VERSION}" ]; then
+            version="${INPUT_VERSION}"
+          else
+            version="${TAG#v}"
+          fi
+          if [ -z "${version}" ]; then
+            echo "::error::Could not resolve release version from event payload" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Python 3.12 on a clean runner
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install agent-assembly-python[runtime] from PyPI
+        run: |
+          python -m pip install --upgrade pip
+          pip install --no-cache-dir 'agent-assembly-python[runtime]'
+
+      - name: Verify agent_assembly.__version__ matches release tag
+        env:
+          EXPECTED: ${{ steps.expected.outputs.version }}
+        shell: bash
+        run: |
+          got=$(python -c "import agent_assembly; print(agent_assembly.__version__)")
+          want="${EXPECTED}"
+          echo "Installed: ${got}"
+          echo "Expected:  ${want}"
+          [ "${got}" = "${want}" ] || {
+            echo "::error::agent_assembly.__version__ mismatch — got '${got}', want '${want}'"
+            exit 1
+          }


### PR DESCRIPTION
## Description

Adds the two Python smoke jobs from the F119 matrix to
`.github/workflows/smoke-test.yml`. **Stacks on
[#773](https://github.com/AI-agent-assembly/agent-assembly/pull/773)
(AAASM-1250)** — branched off master + cherry-picked the three commits
from that PR so this branch lints and runs standalone; once #773
merges, a rebase against master will drop the cherry-picked commits
cleanly.

New jobs in this PR:

| Job | Verifies |
| --- | --- |
| `smoke-python-pypi-import` | `pip install agent-assembly-python[runtime]` then `python -c "import agent_assembly; print(agent_assembly.__version__)"` prints the released version |
| `smoke-python-pypi-runtime` | Same install, then `aasm --version` prints `aasm <released-version>` (proves the `[runtime]` extra bundles the native binary on the venv's PATH) |

Both jobs:

* run on a fresh `ubuntu-latest` runner with no pre-installed tools,
* set up Python 3.12 via `actions/setup-python@v6` (matches the version
  already used by `.github/workflows/dev-verify.yml`),
* use `pip install --no-cache-dir` so a stale runner-image cache cannot
  hide a real publish failure,
* resolve the expected release version from the same release-tag /
  `workflow_dispatch.version` source as the Homebrew + curl jobs.

The install command is taken verbatim from the F119 acceptance matrix
on AAASM-1235 (`pip install agent-assembly-python[runtime]`). If the
package on PyPI is published under a different name at v0.0.1 release
time, AAASM-1253 (the verification sub-task) will surface that.

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1251 (sub-task of AAASM-1235, under Epic AAASM-1199)
- Stacks on: #773 (AAASM-1250)
- Related GitHub issues: n/a

## Testing

- [x] `actionlint .github/workflows/smoke-test.yml` clean on every commit
- [x] Self-review of the diff completed — only the two new jobs are
  added; the three jobs cherry-picked from #773 are unchanged
- [ ] Runtime verification on a real release is the job of AAASM-1253;
  all seven smoke jobs are exercised together against published v0.0.1
  artifacts

## Checklist

- [x] Commits are small and follow the Gitmoji convention (2 new
  commits on top of the 3 cherry-picked from #773 — one per smoke job)
- [x] Self-review of the diff completed
- [x] No Rust code changed; pre-commit / pre-push hooks cleanly skipped
  on the YAML-only diff
- [x] CI: "no checks reported" is the expected status here (no workflow
  has a path filter that matches `smoke-test.yml`)
- [x] Documentation updated if behaviour changed — n/a
