### PR TITLE
[AAASM-1919] ✨ (ci): Add npm @agent-assembly/sdk smoke job

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -260,3 +260,60 @@ jobs:
             echo "::error::aasm --version mismatch — got '${got}', want '${want}'"
             exit 1
           }
+
+  smoke-npm:
+    name: Smoke — npm (@agent-assembly/sdk install + require)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Compute expected aasm version
+        id: expected
+        shell: bash
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if [ -n "${INPUT_VERSION}" ]; then
+            version="${INPUT_VERSION}"
+          else
+            version="${TAG#v}"
+          fi
+          if [ -z "${version}" ]; then
+            echo "::error::Could not resolve release version from event payload" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Node.js 20 LTS on a clean runner
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Install @agent-assembly/sdk from the public npm registry
+        run: |
+          # Smoke test runs from /tmp on a fresh runner so that no
+          # repo-local package.json can shadow the install.
+          mkdir -p /tmp/aa-npm-smoke
+          cd /tmp/aa-npm-smoke
+          npm init -y >/dev/null
+          npm install --no-audit --no-fund @agent-assembly/sdk
+
+      - name: Verify the package loads via require() without throwing
+        run: |
+          cd /tmp/aa-npm-smoke
+          node -e "require('@agent-assembly/sdk')"
+
+      - name: Verify installed package version matches release tag
+        env:
+          EXPECTED: ${{ steps.expected.outputs.version }}
+        shell: bash
+        run: |
+          cd /tmp/aa-npm-smoke
+          got=$(node -p "require('@agent-assembly/sdk/package.json').version")
+          want="${EXPECTED}"
+          echo "Installed: ${got}"
+          echo "Expected:  ${want}"
+          [ "${got}" = "${want}" ] || {
+            echo "::error::@agent-assembly/sdk version mismatch — got '${got}', want '${want}'"
+            exit 1
+          }


### PR DESCRIPTION
## Description

Adds the npm channel smoke job to `.github/workflows/smoke-test.yml`.
**Stacks on
[#773](https://github.com/AI-agent-assembly/agent-assembly/pull/773)
(AAASM-1250) and
[#775](https://github.com/AI-agent-assembly/agent-assembly/pull/775)
(AAASM-1251)** — branched off master and cherry-picked the 5 commits
from those two PRs so this branch runs `actionlint` clean as a
standalone. When #773 + #775 merge, a rebase against master will drop
the cherry-picked commits.

New job in this PR (single commit):

| Job | Verifies |
| --- | --- |
| `smoke-npm` | `npm install @agent-assembly/sdk && node -e "require('@agent-assembly/sdk')"` exits 0; package.json `version` field equals the released version |

The job:

* runs on a fresh `ubuntu-latest` runner with no pre-installed tools,
* sets up Node.js 20 LTS via `actions/setup-node@v6`,
* `cd`s into `/tmp/aa-npm-smoke` and `npm init -y`s a throwaway project
  so no repo-local `package.json` shadows the install,
* installs `@agent-assembly/sdk` from the public npm registry
  (`--no-audit --no-fund` to keep output tight),
* runs `node -e "require('@agent-assembly/sdk')"` — the AC's literal
  smoke step,
* additionally cross-checks `require('@agent-assembly/sdk/package.json').version`
  against the release tag, so a successful `require()` on a stale
  registry mirror cannot quietly mask a publish miss.

End-user install uses `npm` even though the workspace itself standardises
on pnpm: `npm install` is the canonical install path for
`@agent-assembly/sdk` consumers, so the smoke test follows the AC
verbatim.

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1919 (sub-task of AAASM-1235, under Epic AAASM-1199)
- Stacks on: #773 (AAASM-1250), #775 (AAASM-1251)
- Related GitHub issues: n/a

## Testing

- [x] `actionlint .github/workflows/smoke-test.yml` clean
- [x] Self-review of the diff completed — only one new job added; the
  five jobs cherry-picked from #773 / #775 are unchanged
- [ ] Runtime verification on a real release is the job of AAASM-1253;
  all seven smoke jobs are exercised together against published v0.0.1
  artifacts

## Checklist

- [x] Commits are small and follow the Gitmoji convention (1 new commit
  on top of 5 cherry-picked from #773 + #775)
- [x] Self-review of the diff completed
- [x] No Rust code changed; pre-commit / pre-push hooks cleanly skipped
  on the YAML-only diff
- [x] CI: "no checks reported" is the expected status here
- [x] Documentation updated if behaviour changed — n/a
