### PR TITLE
[AAASM-1252] ✨ (ci): Add Docker smoke job + failure notification

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -366,3 +366,57 @@ jobs:
             echo "::error::Container aasm --version mismatch for ${image} — got '${got}', want '${want}'"
             exit 1
           }
+
+  notify-on-failure:
+    name: Open Issue when a smoke job fails
+    needs:
+      - smoke-homebrew-macos
+      - smoke-homebrew-linux
+      - smoke-curl-installer
+      - smoke-python-pypi-import
+      - smoke-python-pypi-runtime
+      - smoke-npm
+      - smoke-docker
+    # Fire only when the workflow is genuinely broken — `failure()` covers
+    # any failed `needs:` job; the `release` event guard avoids dispatching
+    # notifications during manual `workflow_dispatch` reruns.
+    if: failure() && github.event_name == 'release'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open an Issue with the list of failed smoke jobs
+        uses: actions/github-script@v7
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        with:
+          script: |
+            const tag = context.payload?.release?.tag_name
+              || context.payload?.release?.name
+              || context.ref;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const needs = JSON.parse(process.env.NEEDS_JSON);
+            const failedLines = Object.entries(needs)
+              .filter(([, j]) => j.result !== 'success' && j.result !== 'skipped')
+              .map(([k, j]) => `- \`${k}\` — **${j.result}**`)
+              .join('\n');
+            const title = `Smoke test failed for release ${tag}`;
+            const body = [
+              `The post-release smoke test workflow failed for release **${tag}**.`,
+              '',
+              '## Failed jobs',
+              failedLines || '_(no individual job result was non-success — the workflow itself failed)_',
+              '',
+              `Workflow run: ${runUrl}`,
+              '',
+              '_Opened automatically by the `Smoke Test (Release Artifacts)` workflow on failure (AAASM-1252)._',
+            ].join('\n');
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['ci', 'release', 'smoke-test-failure'],
+            });

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -19,6 +19,7 @@ on:
 permissions:
   contents: read
   issues: write
+  packages: read
 
 # Avoid concurrent smoke runs for the same release tag.
 concurrency:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -318,3 +318,51 @@ jobs:
             echo "::error::@agent-assembly/sdk version mismatch — got '${got}', want '${want}'"
             exit 1
           }
+
+  smoke-docker:
+    name: Smoke — Docker (ghcr.io/agent-assembly/python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Compute expected aasm version
+        id: expected
+        shell: bash
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+        run: |
+          if [ -n "${INPUT_VERSION}" ]; then
+            version="${INPUT_VERSION}"
+          else
+            version="${TAG#v}"
+          fi
+          if [ -z "${version}" ]; then
+            echo "::error::Could not resolve release version from event payload" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GitHub Container Registry
+        # GITHUB_TOKEN gets packages:read from the workflow-level
+        # permission grant; this works for both public and private
+        # tags so the workflow doesn't have to change if visibility
+        # ever flips.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: echo "${GH_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
+
+      - name: Run aasm --version inside ghcr.io/agent-assembly/python
+        env:
+          EXPECTED: ${{ steps.expected.outputs.version }}
+        shell: bash
+        run: |
+          image="ghcr.io/agent-assembly/python:${EXPECTED}"
+          got=$(docker run --rm "${image}" aasm --version)
+          want="aasm ${EXPECTED}"
+          echo "Image:     ${image}"
+          echo "Installed: ${got}"
+          echo "Expected:  ${want}"
+          [ "${got}" = "${want}" ] || {
+            echo "::error::Container aasm --version mismatch for ${image} — got '${got}', want '${want}'"
+            exit 1
+          }


### PR DESCRIPTION
## Description

Completes the F119 smoke-test workflow. **Stacks on
[#773](https://github.com/AI-agent-assembly/agent-assembly/pull/773)
(AAASM-1250),
[#775](https://github.com/AI-agent-assembly/agent-assembly/pull/775)
(AAASM-1251), and
[#776](https://github.com/AI-agent-assembly/agent-assembly/pull/776)
(AAASM-1919)** — branched off master and cherry-picked the 6 commits
from those PRs so this branch lints and runs standalone. Rebasing
against master once those merge will drop the cherry-picked commits.

New commits in this PR:

| Commit | What it adds |
| --- | --- |
| 🔧 (ci): Grant smoke-test workflow `packages: read` for GHCR pulls | Workflow-level permission bump so `GITHUB_TOKEN` can `docker login ghcr.io` |
| ✨ (ci): Add `smoke-docker` job | The 7th smoke job — `docker run ghcr.io/agent-assembly/python:${VERSION} aasm --version` |
| ✨ (ci): Add `notify-on-failure` job | `actions/github-script@v7` opens an Issue titled `Smoke test failed for release <tag>` listing the failed jobs + workflow-run URL when any of the 7 smoke jobs fails on a `release: published` run |

`notify-on-failure`:

* `needs:` all seven smoke jobs.
* `if: failure() && github.event_name == 'release'` — fires only on
  real release-triggered runs, not on manual `workflow_dispatch` reruns
  the operator does while debugging.
* Job-level `permissions: { contents: read, issues: write }` keeps the
  notify job's blast radius explicit in addition to the workflow-level
  grant.
* The created Issue is labelled `ci`, `release`, `smoke-test-failure`
  so the team can filter `is:open label:smoke-test-failure` after any
  release.

## Acceptance criteria coverage (F119, AAASM-1235)

| AC | Where it's satisfied |
| --- | --- |
| `smoke-test.yml` workflow created and triggers on release `published` event | First commit of #773 (`on: release: types: [published]`) |
| All 7 smoke test jobs pass for v0.0.1 release | Verified by AAASM-1253 against the live v0.0.1 release |
| Workflow result is reported as a commit status on the release tag | GitHub Actions reports per-workflow check runs on the release-tag commit automatically — no extra wiring needed |
| Any smoke test failure sends a notification (GitHub issue or comment on the release) | `notify-on-failure` job in this PR |

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1252 (sub-task of AAASM-1235, under Epic AAASM-1199)
- Stacks on: #773 (AAASM-1250), #775 (AAASM-1251), #776 (AAASM-1919)
- Related GitHub issues: n/a

## Testing

- [x] `actionlint .github/workflows/smoke-test.yml` clean on every commit
- [x] Self-review of the diff completed — three new commits, six
  cherry-picked from the dep PRs left untouched
- [ ] Runtime verification is the job of AAASM-1253; all 7 smoke jobs +
  notify wiring are exercised together against published v0.0.1
  artifacts

## Checklist

- [x] Commits are small and follow the Gitmoji convention (3 new
  commits — permissions bump, smoke-docker, notify-on-failure)
- [x] Self-review of the diff completed
- [x] No Rust code changed; pre-commit / pre-push hooks cleanly skipped
- [x] CI: "no checks reported" is the expected status here
- [x] Documentation updated if behaviour changed — n/a
