### PR TITLE
[AAASM-1600] ✨ (aa-gateway/budget): Configurable sub-day flush interval

### DIFF
--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -10,8 +10,8 @@ pub use pricing::{PricingEntry, PricingLoadError, PricingTable};
 
 pub mod persistence;
 pub use persistence::{
-    default_budget_path, load_from_disk, save_to_disk_atomic, start_background_writer, PersistedAgentEntry,
-    PersistedBudget, PersistenceError,
+    default_budget_path, load_from_disk, save_to_disk_atomic, start_background_writer, start_window_flush_task,
+    PersistedAgentEntry, PersistedBudget, PersistenceError,
 };
 
 pub mod tracker;

--- a/aa-gateway/src/budget/mod.rs
+++ b/aa-gateway/src/budget/mod.rs
@@ -3,7 +3,7 @@
 //! Entry point: [`tracker::BudgetTracker::record_usage`].
 
 pub mod types;
-pub use types::{BudgetAlert, BudgetState, BudgetStatus, Model, Provider};
+pub use types::{BudgetAlert, BudgetState, BudgetStatus, BudgetWindow, Model, Provider};
 
 pub mod pricing;
 pub use pricing::{PricingEntry, PricingLoadError, PricingTable};

--- a/aa-gateway/src/budget/persistence.rs
+++ b/aa-gateway/src/budget/persistence.rs
@@ -89,6 +89,31 @@ pub fn start_background_writer(
     })
 }
 
+/// Spawn a tokio task that calls `tracker.flush_window()` every `interval`.
+///
+/// Required when the tracker is configured with
+/// [`crate::budget::BudgetWindow::Duration`] so sub-day rollovers take
+/// effect even when no spend event has fired in the interval — dashboard
+/// reads see a zeroed accumulator immediately after the window elapses.
+/// Callers using the default `Daily` window can skip this task; the
+/// lazy reset in `record_cost` is sufficient.
+pub fn start_window_flush_task(
+    tracker: std::sync::Arc<crate::budget::tracker::BudgetTracker>,
+    interval: std::time::Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut tick = tokio::time::interval(interval);
+        // First tick fires immediately; skip it so the loop body runs at
+        // `interval` boundaries instead of t=0 (which would race with any
+        // record_cost call that arrives just after spawn).
+        tick.tick().await;
+        loop {
+            tick.tick().await;
+            tracker.flush_window();
+        }
+    })
+}
+
 /// Encode an `AgentId` as a 32-char lowercase hex string.
 pub fn agent_id_to_hex(id: &aa_core::AgentId) -> String {
     id.as_bytes().iter().map(|b| format!("{:02x}", b)).collect()

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -821,6 +821,7 @@ mod tests {
             date: today,
             month: today.year() as u32 * 100 + today.month(),
             monthly_spent_usd: None,
+            last_reset_at: None,
         };
         let persisted = PersistedBudget {
             per_agent: vec![PersistedAgentEntry {

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -12,7 +12,7 @@ use rust_decimal::prelude::ToPrimitive;
 
 use crate::budget::{
     pricing::PricingTable,
-    types::{BudgetAlert, BudgetState, BudgetStatus},
+    types::{BudgetAlert, BudgetState, BudgetStatus, BudgetWindow},
 };
 
 /// Per-agent daily limit entry stored in `BudgetTracker::agent_limits`.
@@ -80,6 +80,9 @@ pub struct BudgetTracker {
     pub(crate) spend_history: DashMap<AgentId, std::collections::BTreeMap<chrono::NaiveDate, Decimal>>,
     alert_tx: broadcast::Sender<BudgetAlert>,
     timezone: chrono_tz::Tz,
+    /// Rollover strategy. Defaults to [`BudgetWindow::Daily`]; override via
+    /// [`BudgetTracker::with_window`] to enable sub-day rollover (AAASM-1600).
+    window: BudgetWindow,
 }
 
 impl BudgetTracker {
@@ -119,6 +122,7 @@ impl BudgetTracker {
             spend_history: DashMap::new(),
             alert_tx,
             timezone,
+            window: BudgetWindow::Daily,
         }
     }
 
@@ -193,7 +197,22 @@ impl BudgetTracker {
             spend_history: DashMap::new(),
             alert_tx,
             timezone,
+            window: BudgetWindow::Daily,
         }
+    }
+
+    /// Override the rollover strategy. Defaults to [`BudgetWindow::Daily`] —
+    /// callers that need sub-day rollover (test fixtures, short-cycle staging)
+    /// pass `BudgetWindow::Duration(...)`.
+    pub fn with_window(mut self, window: BudgetWindow) -> Self {
+        self.window = window;
+        self
+    }
+
+    /// Return the currently-configured rollover strategy.
+    #[allow(dead_code)]
+    pub fn window(&self) -> BudgetWindow {
+        self.window
     }
 
     /// Return an `Arc` wrapping the per-ancestor `parking_lot::Mutex`, creating it if absent.

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -626,6 +626,28 @@ impl BudgetTracker {
             .unwrap_or_else(|_| BudgetState::new_for_date(today_in_tz(self.timezone)))
     }
 
+    /// Re-evaluate the window-aware reset against every per-agent, per-team,
+    /// and global state. Used by the periodic flush task so sub-day rollovers
+    /// take effect even when no `record_cost` call has fired in the interval —
+    /// e.g. so dashboard reads see a zeroed accumulator the moment the window
+    /// elapses.
+    ///
+    /// No-op for [`BudgetWindow::Daily`] when the calendar date hasn't rolled
+    /// over (each state's `maybe_reset_window` short-circuits on the same-day
+    /// path).
+    pub fn flush_window(&self) {
+        let now = chrono::Utc::now();
+        for mut entry in self.per_agent.iter_mut() {
+            entry.maybe_reset_window(now, self.window, self.timezone);
+        }
+        for mut entry in self.team_budgets.iter_mut() {
+            entry.maybe_reset_window(now, self.window, self.timezone);
+        }
+        if let Ok(mut g) = self.global.lock() {
+            g.maybe_reset_window(now, self.window, self.timezone);
+        }
+    }
+
     /// Snapshot the full tracker state for disk persistence.
     pub fn snapshot(&self) -> crate::budget::persistence::PersistedBudget {
         let per_agent = self

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -276,7 +276,7 @@ impl BudgetTracker {
     /// per-action cost is not yet known and only a limit check is needed.
     pub fn check_daily(&self, agent_id: &AgentId, limit: Decimal) -> bool {
         if let Some(mut entry) = self.per_agent.get_mut(agent_id) {
-            entry.maybe_reset(today_in_tz(self.timezone));
+            entry.maybe_reset_window(chrono::Utc::now(), self.window, self.timezone);
             entry.spent_usd >= limit
         } else {
             false
@@ -289,7 +289,7 @@ impl BudgetTracker {
     /// current month in the configured timezone.
     pub fn check_monthly(&self, agent_id: &AgentId, limit: Decimal) -> bool {
         if let Some(mut entry) = self.per_agent.get_mut(agent_id) {
-            entry.maybe_reset(today_in_tz(self.timezone));
+            entry.maybe_reset_window(chrono::Utc::now(), self.window, self.timezone);
             entry.monthly_spent_usd.map(|m| m >= limit).unwrap_or(false)
         } else {
             false
@@ -349,12 +349,15 @@ impl BudgetTracker {
     /// and [`record_raw_spend`](Self::record_raw_spend).
     fn record_cost(&self, agent_id: AgentId, team_id: Option<&str>, cost: Decimal) -> BudgetStatus {
         let has_monthly = self.monthly_limit_usd.is_some() || self.team_monthly_limit_usd.is_some();
+        let now = chrono::Utc::now();
         let today = today_in_tz(self.timezone);
+        let window = self.window;
+        let tz = self.timezone;
 
         self.per_agent
             .entry(agent_id)
             .and_modify(|s| {
-                s.maybe_reset(today);
+                s.maybe_reset_window(now, window, tz);
                 s.spent_usd += cost;
                 if let Some(m) = s.monthly_spent_usd.as_mut() {
                     *m += cost;
@@ -365,6 +368,9 @@ impl BudgetTracker {
                 s.spent_usd += cost;
                 if has_monthly {
                     s.monthly_spent_usd = Some(cost);
+                }
+                if matches!(window, BudgetWindow::Duration(_)) {
+                    s.last_reset_at = Some(now);
                 }
                 s
             });
@@ -384,17 +390,20 @@ impl BudgetTracker {
             self.team_budgets
                 .entry(tid.to_string())
                 .and_modify(|s| {
-                    s.maybe_reset(today_in_tz(self.timezone));
+                    s.maybe_reset_window(now, window, tz);
                     s.spent_usd += cost;
                     if let Some(m) = s.monthly_spent_usd.as_mut() {
                         *m += cost;
                     }
                 })
                 .or_insert_with(|| {
-                    let mut s = BudgetState::new_for_date(today_in_tz(self.timezone));
+                    let mut s = BudgetState::new_for_date(today);
                     s.spent_usd += cost;
                     if has_monthly {
                         s.monthly_spent_usd = Some(cost);
+                    }
+                    if matches!(window, BudgetWindow::Duration(_)) {
+                        s.last_reset_at = Some(now);
                     }
                     s
                 });
@@ -430,7 +439,7 @@ impl BudgetTracker {
             .unwrap_or((cost, None));
 
         if let Ok(mut g) = self.global.lock() {
-            g.maybe_reset(today_in_tz(self.timezone));
+            g.maybe_reset_window(now, window, tz);
             g.spent_usd += cost;
         }
 
@@ -465,7 +474,7 @@ impl BudgetTracker {
         amount: Decimal,
     ) -> Result<(), crate::budget::types::BudgetError> {
         use crate::budget::types::{BudgetError, BudgetKind};
-        let today = today_in_tz(self.timezone);
+        let now = chrono::Utc::now();
         for &ancestor_bytes in ancestors {
             let ancestor_id = AgentId::from_bytes(ancestor_bytes);
             if let Some(limit) = self.resolve_limit(&ancestor_id, BudgetKind::Daily) {
@@ -474,7 +483,7 @@ impl BudgetTracker {
                     .get(&ancestor_id)
                     .map(|s| {
                         let mut copy = s.clone();
-                        copy.maybe_reset(today);
+                        copy.maybe_reset_window(now, self.window, self.timezone);
                         copy.spent_usd
                     })
                     .unwrap_or(Decimal::ZERO);
@@ -515,16 +524,22 @@ impl BudgetTracker {
         self.preflight_ancestors(ancestors, amount)?;
 
         // Phase 2: commit — record spend on the agent and every ancestor.
+        let now = chrono::Utc::now();
         let today = today_in_tz(self.timezone);
+        let window = self.window;
+        let tz = self.timezone;
         self.per_agent
             .entry(agent_id)
             .and_modify(|s| {
-                s.maybe_reset(today);
+                s.maybe_reset_window(now, window, tz);
                 s.spent_usd += amount;
             })
             .or_insert_with(|| {
                 let mut s = BudgetState::new_for_date(today);
                 s.spent_usd = amount;
+                if matches!(window, BudgetWindow::Duration(_)) {
+                    s.last_reset_at = Some(now);
+                }
                 s
             });
         for &ancestor_bytes in ancestors {
@@ -532,12 +547,15 @@ impl BudgetTracker {
             self.per_agent
                 .entry(ancestor_id)
                 .and_modify(|s| {
-                    s.maybe_reset(today);
+                    s.maybe_reset_window(now, window, tz);
                     s.spent_usd += amount;
                 })
                 .or_insert_with(|| {
                     let mut s = BudgetState::new_for_date(today);
                     s.spent_usd = amount;
+                    if matches!(window, BudgetWindow::Duration(_)) {
+                        s.last_reset_at = Some(now);
+                    }
                     s
                 });
         }
@@ -550,7 +568,7 @@ impl BudgetTracker {
     /// `descendants` should be the slice returned by `AgentRegistry::descendants_of(agent_id)`.
     /// This is a read-only snapshot — it does not mutate any state.
     pub fn subtree_spend(&self, agent_id: &AgentId, descendants: &[[u8; 16]]) -> crate::budget::types::SubtreeSpend {
-        let today = today_in_tz(self.timezone);
+        let now = chrono::Utc::now();
         let mut total_usd = Decimal::ZERO;
         let mut agents_counted = 0usize;
 
@@ -559,7 +577,7 @@ impl BudgetTracker {
             let aid = AgentId::from_bytes(id_bytes);
             if let Some(state) = self.per_agent.get(&aid) {
                 let mut copy = state.clone();
-                copy.maybe_reset(today);
+                copy.maybe_reset_window(now, self.window, self.timezone);
                 if copy.spent_usd > Decimal::ZERO {
                     total_usd += copy.spent_usd;
                     agents_counted += 1;

--- a/aa-gateway/src/budget/types.rs
+++ b/aa-gateway/src/budget/types.rs
@@ -151,6 +151,51 @@ impl BudgetState {
             self.date = today;
         }
     }
+
+    /// Window-aware reset.
+    ///
+    /// For [`BudgetWindow::Daily`] this is equivalent to [`maybe_reset`] using
+    /// the calendar date of `now` in the supplied timezone.
+    ///
+    /// For [`BudgetWindow::Duration`] the daily accumulator is zeroed each time
+    /// `now - last_reset_at >= interval`. On the first call under a fresh state
+    /// `last_reset_at` is `None`, so we seed the anchor without zeroing —
+    /// existing spend (loaded from disk) is preserved across the upgrade path.
+    pub fn maybe_reset_window(&mut self, now: chrono::DateTime<chrono::Utc>, window: BudgetWindow, tz: chrono_tz::Tz) {
+        match window {
+            BudgetWindow::Daily => {
+                self.maybe_reset(now.with_timezone(&tz).date_naive());
+            }
+            BudgetWindow::Duration(interval) => {
+                let today = now.with_timezone(&tz).date_naive();
+                let current_month = Self::month_tag(today);
+                if current_month != self.month {
+                    self.monthly_spent_usd = self.monthly_spent_usd.map(|_| rust_decimal::Decimal::ZERO);
+                    self.month = current_month;
+                }
+                match self.last_reset_at {
+                    None => {
+                        // Seed the anchor on first observation under the
+                        // Duration window. Existing `spent_usd` (legacy or
+                        // mid-window) stays as-is — the rollover triggers only
+                        // once we have a baseline.
+                        self.last_reset_at = Some(now);
+                    }
+                    Some(anchor) => {
+                        let elapsed = now
+                            .signed_duration_since(anchor)
+                            .to_std()
+                            .unwrap_or(std::time::Duration::ZERO);
+                        if elapsed >= interval {
+                            self.spent_usd = rust_decimal::Decimal::ZERO;
+                            self.last_reset_at = Some(now);
+                            self.date = today;
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Aggregate spend summary for an agent and its entire descendant subtree.

--- a/aa-gateway/src/budget/types.rs
+++ b/aa-gateway/src/budget/types.rs
@@ -100,6 +100,14 @@ pub struct BudgetState {
     /// Total USD spent this calendar month. `None` when monthly tracking is unused.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub monthly_spent_usd: Option<rust_decimal::Decimal>,
+    /// Wall-clock instant of the last sub-day reset.
+    ///
+    /// `None` preserves the historical date-only reset path (and the
+    /// back-compat for `budget.json` files written before AAASM-1600);
+    /// `Some(t)` is populated by [`maybe_reset_window`] when the tracker
+    /// is configured with [`BudgetWindow::Duration`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_reset_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl BudgetState {
@@ -116,6 +124,7 @@ impl BudgetState {
             date,
             month: Self::month_tag(date),
             monthly_spent_usd: None,
+            last_reset_at: None,
         }
     }
 
@@ -126,6 +135,7 @@ impl BudgetState {
             date,
             month: Self::month_tag(date),
             monthly_spent_usd: None,
+            last_reset_at: None,
         }
     }
 
@@ -233,6 +243,7 @@ mod tests {
             date: yesterday,
             month: BudgetState::month_tag(yesterday),
             monthly_spent_usd: None,
+            last_reset_at: None,
         };
         state.maybe_reset(Utc::now().date_naive());
         assert_eq!(state.spent_usd, Decimal::ZERO);
@@ -250,6 +261,7 @@ mod tests {
             date: today,
             month: BudgetState::month_tag(today),
             monthly_spent_usd: None,
+            last_reset_at: None,
         };
         state.maybe_reset(Utc::now().date_naive());
         assert_eq!(state.spent_usd, amount);
@@ -265,6 +277,7 @@ mod tests {
             date: jan1,
             month: BudgetState::month_tag(jan1),
             monthly_spent_usd: None,
+            last_reset_at: None,
         };
         // Inject a specific "today" that is after state.date
         let injected_today = NaiveDate::from_ymd_opt(2024, 1, 2).unwrap();
@@ -283,6 +296,7 @@ mod tests {
             date: jan31,
             month: BudgetState::month_tag(jan31),
             monthly_spent_usd: Some(Decimal::new(10000, 2)), // 100.00
+            last_reset_at: None,
         };
         let feb1 = NaiveDate::from_ymd_opt(2024, 2, 1).unwrap();
         state.maybe_reset(feb1);
@@ -303,6 +317,7 @@ mod tests {
             date: jan1,
             month: BudgetState::month_tag(jan1),
             monthly_spent_usd: Some(monthly),
+            last_reset_at: None,
         };
         let jan2 = NaiveDate::from_ymd_opt(2024, 1, 2).unwrap();
         state.maybe_reset(jan2);
@@ -322,6 +337,7 @@ mod tests {
             date: dec31,
             month: BudgetState::month_tag(dec31),
             monthly_spent_usd: None,
+            last_reset_at: None,
         };
         let jan1 = NaiveDate::from_ymd_opt(2025, 1, 1).unwrap();
         state.maybe_reset(jan1);

--- a/aa-gateway/src/budget/types.rs
+++ b/aa-gateway/src/budget/types.rs
@@ -42,6 +42,26 @@ pub enum BudgetKind {
     Global,
 }
 
+/// Rollover strategy for [`super::tracker::BudgetTracker`].
+///
+/// `Daily` (the default) zeroes accumulated spend at the calendar-day
+/// boundary in the tracker's configured timezone — historical behaviour
+/// preserved for every existing deployment.
+///
+/// `Duration` zeroes accumulated spend every elapsed wall-clock interval —
+/// driven by [`BudgetState::last_reset_at`]. Intended for test fixtures and
+/// short-cycle staging environments that need sub-day rollover (e.g. a
+/// 200 ms window for the `budget_resets_after_daily_window` integration
+/// test gated by AAASM-1600).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BudgetWindow {
+    /// Reset at midnight in the configured timezone.
+    #[default]
+    Daily,
+    /// Reset every `interval` of wall-clock time.
+    Duration(std::time::Duration),
+}
+
 /// Error returned by [`super::tracker::BudgetTracker::check_and_decrement`].
 #[derive(Debug, Clone, PartialEq, thiserror::Error)]
 pub enum BudgetError {

--- a/aa-gateway/src/budget/types.rs
+++ b/aa-gateway/src/budget/types.rs
@@ -421,4 +421,78 @@ mod tests {
         assert_eq!(alert.threshold_pct, 80);
         assert!((alert.spent_usd - 8.0).abs() < f64::EPSILON);
     }
+
+    #[test]
+    fn maybe_reset_window_daily_matches_maybe_reset() {
+        use chrono::Utc;
+        use rust_decimal::Decimal;
+        let yesterday = Utc::now().date_naive() - chrono::Duration::days(1);
+        let mut a = BudgetState::new_for_date(yesterday);
+        a.spent_usd = Decimal::new(500, 2);
+        let mut b = a.clone();
+        a.maybe_reset(Utc::now().date_naive());
+        b.maybe_reset_window(Utc::now(), BudgetWindow::Daily, chrono_tz::UTC);
+        assert_eq!(a.spent_usd, b.spent_usd);
+        assert_eq!(a.date, b.date);
+    }
+
+    #[test]
+    fn maybe_reset_window_duration_seeds_anchor_without_zeroing() {
+        use chrono::Utc;
+        use rust_decimal::Decimal;
+        let mut state = BudgetState::new_today();
+        state.spent_usd = Decimal::new(500, 2);
+        let before = state.spent_usd;
+        let now = Utc::now();
+        state.maybe_reset_window(
+            now,
+            BudgetWindow::Duration(std::time::Duration::from_secs(60)),
+            chrono_tz::UTC,
+        );
+        // First observation under Duration: anchor seeded, spend preserved.
+        assert_eq!(state.spent_usd, before);
+        assert_eq!(state.last_reset_at, Some(now));
+    }
+
+    #[test]
+    fn maybe_reset_window_duration_keeps_spend_inside_interval() {
+        use chrono::Utc;
+        use rust_decimal::Decimal;
+        let now = Utc::now();
+        let mut state = BudgetState::new_today();
+        state.spent_usd = Decimal::new(250, 2);
+        state.last_reset_at = Some(now);
+        // 100 ms later — well inside the 5 s window.
+        state.maybe_reset_window(
+            now + chrono::Duration::milliseconds(100),
+            BudgetWindow::Duration(std::time::Duration::from_secs(5)),
+            chrono_tz::UTC,
+        );
+        assert_eq!(state.spent_usd, Decimal::new(250, 2));
+        assert_eq!(state.last_reset_at, Some(now));
+    }
+
+    #[test]
+    fn maybe_reset_window_duration_zeroes_after_interval() {
+        use chrono::Utc;
+        use rust_decimal::Decimal;
+        let now = Utc::now();
+        let mut state = BudgetState::new_today();
+        state.spent_usd = Decimal::new(250, 2);
+        state.last_reset_at = Some(now);
+        // 200 ms later — well past the 100 ms window.
+        let later = now + chrono::Duration::milliseconds(200);
+        state.maybe_reset_window(
+            later,
+            BudgetWindow::Duration(std::time::Duration::from_millis(100)),
+            chrono_tz::UTC,
+        );
+        assert_eq!(state.spent_usd, Decimal::ZERO);
+        assert_eq!(state.last_reset_at, Some(later));
+    }
+
+    #[test]
+    fn budget_window_default_is_daily() {
+        assert_eq!(BudgetWindow::default(), BudgetWindow::Daily);
+    }
 }

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1500,6 +1500,7 @@ mod tests {
             monthly_limit_usd: None,
             timezone: None,
             action_on_exceed: ActionOnExceed::default(),
+            window: None,
         });
         let engine = make_engine(doc);
         let ctx = make_ctx();
@@ -1523,6 +1524,7 @@ mod tests {
             monthly_limit_usd: Some(5.0),
             timezone: None,
             action_on_exceed: ActionOnExceed::default(),
+            window: None,
         });
         let engine = make_engine(doc);
         let ctx = make_ctx();
@@ -1546,6 +1548,7 @@ mod tests {
             monthly_limit_usd: Some(10.0),
             timezone: None,
             action_on_exceed: ActionOnExceed::default(),
+            window: None,
         });
         let engine = make_engine(doc);
         let ctx = make_ctx();
@@ -1564,6 +1567,7 @@ mod tests {
             monthly_limit_usd: Some(5.0),
             timezone: None,
             action_on_exceed: ActionOnExceed::default(),
+            window: None,
         });
         let engine = make_engine(doc);
         let ctx = make_ctx();
@@ -1588,6 +1592,7 @@ mod tests {
             monthly_limit_usd: None,
             timezone: None,
             action_on_exceed: ActionOnExceed::Deny,
+            window: None,
         });
         let engine = make_engine(doc);
         let ctx = make_ctx();
@@ -1611,6 +1616,7 @@ mod tests {
             monthly_limit_usd: None,
             timezone: None,
             action_on_exceed: ActionOnExceed::Suspend,
+            window: None,
         });
         let engine = make_engine(doc);
         let ctx = make_ctx();
@@ -1634,6 +1640,7 @@ mod tests {
             monthly_limit_usd: Some(5.0),
             timezone: None,
             action_on_exceed: ActionOnExceed::Suspend,
+            window: None,
         });
         let engine = make_engine(doc);
         let ctx = make_ctx();
@@ -1657,6 +1664,7 @@ mod tests {
             monthly_limit_usd: None,
             timezone: None,
             action_on_exceed: ActionOnExceed::Deny,
+            window: None,
         });
         let engine = make_engine(doc);
         let ctx = make_ctx();
@@ -1960,6 +1968,7 @@ mod tests {
             monthly_limit_usd: None,
             timezone: None,
             action_on_exceed: ActionOnExceed::default(),
+            window: None,
         });
         let engine = make_engine_with_alert_sender(doc, alert_tx);
         let ctx = make_ctx();
@@ -1981,6 +1990,7 @@ mod tests {
             monthly_limit_usd: None,
             timezone: None,
             action_on_exceed: ActionOnExceed::default(),
+            window: None,
         });
         let engine = make_engine(doc);
         let ctx = make_ctx();

--- a/aa-gateway/src/policy/document.rs
+++ b/aa-gateway/src/policy/document.rs
@@ -48,6 +48,10 @@ pub struct BudgetPolicy {
     pub timezone: Option<String>,
     /// Action when budget is exceeded: deny individual requests or suspend agent.
     pub action_on_exceed: ActionOnExceed,
+    /// Optional sub-day rollover window parsed from the YAML `window:` field.
+    /// `None` preserves the historical calendar-day rollover behaviour.
+    /// AAASM-1600.
+    pub window: Option<std::time::Duration>,
 }
 
 /// Action to take when the credential / sensitive-data scanner produces

--- a/aa-gateway/src/policy/raw.rs
+++ b/aa-gateway/src/policy/raw.rs
@@ -49,6 +49,10 @@ pub struct RawBudgetPolicy {
     pub timezone: Option<String>,
     /// Action when budget is exceeded: `"deny"` (default) or `"suspend"`.
     pub action_on_exceed: Option<String>,
+    /// Optional sub-day rollover window expressed as a humantime duration
+    /// (e.g. `"5s"`, `"30m"`, `"1h30m"`). When absent the tracker rolls at the
+    /// calendar-day boundary (the historical default). AAASM-1600.
+    pub window: Option<String>,
     /// Unknown keys captured for warning emission.
     #[serde(flatten)]
     pub unknown: HashMap<String, serde_yaml::Value>,

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -284,11 +284,35 @@ impl PolicyValidator {
             }
         };
 
+        // Validate sub-day window if provided (AAASM-1600). Parses
+        // humantime strings; rejects zero-or-negative or unparseable values.
+        let window = match raw.window.as_deref() {
+            None => None,
+            Some(s) => match humantime::parse_duration(s) {
+                Ok(d) if d.is_zero() => {
+                    errors.push(ValidationError::new(
+                        "budget.window",
+                        "must be a positive duration (e.g. '5s', '30m', '1h')",
+                    ));
+                    None
+                }
+                Ok(d) => Some(d),
+                Err(e) => {
+                    errors.push(ValidationError::new(
+                        "budget.window",
+                        format!("'{s}' is not a valid humantime duration: {e}"),
+                    ));
+                    None
+                }
+            },
+        };
+
         Some(BudgetPolicy {
             daily_limit_usd: raw.daily_limit_usd,
             monthly_limit_usd: raw.monthly_limit_usd,
             timezone: raw.timezone,
             action_on_exceed,
+            window,
         })
     }
 

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -94,9 +94,10 @@ fn setup_budget(policy_path: &Path, budget_alert_tx: broadcast::Sender<BudgetAle
         }
     });
 
-    // Extract limits from the policy YAML so the tracker enforces them.
+    // Extract limits and rollover window from the policy YAML so the tracker
+    // enforces them.
     let yaml = std::fs::read_to_string(policy_path).unwrap_or_default();
-    let (daily_limit, monthly_limit) = if let Ok(output) = crate::policy::PolicyValidator::from_yaml(&yaml) {
+    let (daily_limit, monthly_limit, window) = if let Ok(output) = crate::policy::PolicyValidator::from_yaml(&yaml) {
         let daily = output
             .document
             .budget
@@ -109,18 +110,27 @@ fn setup_budget(policy_path: &Path, budget_alert_tx: broadcast::Sender<BudgetAle
             .as_ref()
             .and_then(|bp| bp.monthly_limit_usd)
             .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
-        (daily, monthly)
+        let window = output.document.budget.as_ref().and_then(|bp| bp.window);
+        (daily, monthly, window)
     } else {
-        (None, None)
+        (None, None, None)
     };
 
-    let tracker = Arc::new(BudgetTracker::with_state_and_alert_sender(
+    let mut tracker = BudgetTracker::with_state_and_alert_sender(
         crate::budget::PricingTable::default_table(),
         daily_limit,
         monthly_limit,
         persisted,
         budget_alert_tx,
-    ));
+    );
+    if let Some(d) = window {
+        tracker = tracker.with_window(crate::budget::BudgetWindow::Duration(d));
+        tracing::info!(
+            window_ms = d.as_millis() as u64,
+            "budget sub-day rollover window configured"
+        );
+    }
+    let tracker = Arc::new(tracker);
 
     tracing::info!(path = %budget_path.display(), "budget state loaded");
 

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -27,8 +27,10 @@ use crate::approval::clock::SystemClock;
 use crate::approval::db_escalation_scheduler::DbEscalationScheduler;
 use crate::approval::escalation::EscalationScheduler;
 use crate::approval::NoopAuditSink;
-use crate::budget::persistence::{default_budget_path, load_from_disk, save_to_disk_atomic, start_background_writer};
-use crate::budget::{BudgetAlert, BudgetTracker};
+use crate::budget::persistence::{
+    default_budget_path, load_from_disk, save_to_disk_atomic, start_background_writer, start_window_flush_task,
+};
+use crate::budget::{BudgetAlert, BudgetTracker, BudgetWindow};
 use tokio_util::sync::CancellationToken;
 
 /// Default audit directory relative to the system data directory (`~/.aa/audit`).
@@ -135,6 +137,24 @@ fn setup_budget(policy_path: &Path, budget_alert_tx: broadcast::Sender<BudgetAle
     tracing::info!(path = %budget_path.display(), "budget state loaded");
 
     (tracker, budget_path)
+}
+
+/// Spawn a periodic flush task when the tracker is configured with a
+/// sub-day rollover window; return `None` for the default `Daily` window
+/// (lazy reset in `record_cost` is sufficient there). The returned handle
+/// is kept alive by the caller so the task is dropped on gateway shutdown.
+fn maybe_spawn_window_flush(tracker: Arc<BudgetTracker>) -> Option<tokio::task::JoinHandle<()>> {
+    match tracker.window() {
+        BudgetWindow::Daily => None,
+        BudgetWindow::Duration(interval) => {
+            // Tick at roughly one-quarter of the configured window so the
+            // background flush is reactive without busy-spinning. Floor at
+            // 50 ms — anything shorter is the test-fixture domain and the
+            // lazy reset in `record_cost` covers it.
+            let flush_interval = std::cmp::max(interval / 4, std::time::Duration::from_millis(50));
+            Some(start_window_flush_task(tracker, flush_interval))
+        }
+    }
 }
 
 /// Spawn the [`EscalationScheduler`] background task and return the `Arc<EscalationScheduler>`.
@@ -328,6 +348,7 @@ pub async fn serve_tcp(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (tracker, budget_path) = setup_budget(policy_path, budget_alert_tx);
     let _budget_writer = start_background_writer(Arc::clone(&tracker), budget_path.clone());
+    let _budget_flush = maybe_spawn_window_flush(Arc::clone(&tracker));
     let engine = Arc::new(
         PolicyEngine::load_from_file_with_budget(policy_path, Arc::clone(&tracker))
             .map_err(|e| format!("failed to load policy: {e:?}"))?,
@@ -392,6 +413,7 @@ pub async fn serve_uds(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (tracker, budget_path) = setup_budget(policy_path, budget_alert_tx);
     let _budget_writer = start_background_writer(Arc::clone(&tracker), budget_path.clone());
+    let _budget_flush = maybe_spawn_window_flush(Arc::clone(&tracker));
     let engine = Arc::new(
         PolicyEngine::load_from_file_with_budget(policy_path, Arc::clone(&tracker))
             .map_err(|e| format!("failed to load policy: {e:?}"))?,

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -438,7 +438,83 @@ impl TopologyTestEnv {
     /// budget E2E suite (AAASM-1518 / F116 ST-F).
     #[allow(dead_code)]
     pub async fn start_with_team_budget(team_limit_usd: Decimal) -> anyhow::Result<Self> {
-        let (state, audit_dir, alert_store, key_store) = build_test_state_with_team_budget(team_limit_usd)?;
+        let (state, audit_dir, alert_store, key_store) = build_test_state_with_team_budget(team_limit_usd, None)?;
+        let agent_registry = Arc::clone(&state.agent_registry);
+        let trace_store = Arc::clone(&state.trace_store);
+        let approval_queue = Arc::clone(&state.approval_queue);
+        let budget_tracker = Arc::clone(&state.budget_tracker);
+        let events = Arc::clone(&state.events);
+        let replay_buffer = state.replay_buffer.clone();
+        let next_event_id = Arc::clone(&state.next_event_id);
+        let ops_registry = Arc::clone(&state.ops_registry);
+
+        let port = portpicker::pick_unused_port().ok_or_else(|| anyhow::anyhow!("no free TCP port"))?;
+        let addr: SocketAddr = format!("127.0.0.1:{port}").parse()?;
+        let listener = tokio::net::TcpListener::bind(addr).await?;
+        let bound_addr = listener.local_addr()?;
+
+        let app = build_app_with_healthz(state);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+        let server_handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await;
+        });
+
+        let env = Self {
+            addr: bound_addr,
+            agent_registry,
+            trace_store,
+            approval_queue,
+            audit_dir,
+            budget_tracker,
+            alert_store,
+            key_store,
+            events,
+            replay_buffer,
+            next_event_id,
+            ops_registry,
+            shutdown_tx: Some(shutdown_tx),
+            server_handle: Some(server_handle),
+            cleaned: false,
+        };
+        env.await_ready().await?;
+        Ok(env)
+    }
+
+    /// Start a harness whose `BudgetTracker` uses a sub-day rollover window.
+    ///
+    /// `team_limit_usd` is passed to `BudgetTracker::with_team_daily_limit`;
+    /// `window` is passed to `BudgetTracker::with_window(BudgetWindow::Duration)`
+    /// and a periodic flush task is spawned in-process so reads between
+    /// `record_*` calls see the rollover. Used by AAASM-1600 to validate
+    /// the F116 ST-F `budget_resets_after_daily_window` integration test.
+    #[allow(dead_code)]
+    pub async fn start_with_team_budget_window(
+        team_limit_usd: Decimal,
+        window: std::time::Duration,
+    ) -> anyhow::Result<Self> {
+        let (state, audit_dir, alert_store, key_store) =
+            build_test_state_with_team_budget(team_limit_usd, Some(window))?;
+        // Spawn the periodic flush task at one-quarter of the configured
+        // window so sub-day rollovers are visible to dashboard reads even
+        // when no `record_*` event fires in the interval — mirrors the
+        // gateway's `maybe_spawn_window_flush` cadence.
+        let flush_interval = std::cmp::max(window / 4, std::time::Duration::from_millis(20));
+        let _flush_handle = tokio::spawn({
+            let tracker = Arc::clone(&state.budget_tracker);
+            async move {
+                let mut tick = tokio::time::interval(flush_interval);
+                tick.tick().await;
+                loop {
+                    tick.tick().await;
+                    tracker.flush_window();
+                }
+            }
+        });
         let agent_registry = Arc::clone(&state.agent_registry);
         let trace_store = Arc::clone(&state.trace_store);
         let approval_queue = Arc::clone(&state.approval_queue);
@@ -972,11 +1048,15 @@ spec:
 
 /// Build a minimal `AppState` with a per-team daily spend limit applied to the
 /// `BudgetTracker`. Identical to [`build_test_state`] except the tracker is
-/// constructed with `.with_team_daily_limit(team_limit_usd)`.
+/// constructed with `.with_team_daily_limit(team_limit_usd)`. When `window`
+/// is `Some(_)`, the tracker is also configured with
+/// `BudgetWindow::Duration(...)` for sub-day rollover (AAASM-1600).
 ///
-/// Used by [`TopologyTestEnv::start_with_team_budget`] (AAASM-1518 / F116 ST-F).
+/// Used by [`TopologyTestEnv::start_with_team_budget`] (AAASM-1518 / F116 ST-F)
+/// and [`TopologyTestEnv::start_with_team_budget_window`] (AAASM-1600).
 fn build_test_state_with_team_budget(
     team_limit_usd: Decimal,
+    window: Option<std::time::Duration>,
 ) -> anyhow::Result<(AppState, PathBuf, Arc<InMemoryAlertStore>, Arc<ApiKeyStore>)> {
     let policy_id = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
     let policy_dir = std::env::temp_dir().join(format!("aa-budget-it-policy-{}-{policy_id}", std::process::id()));
@@ -1001,10 +1081,12 @@ spec:
         PolicyEngine::load_from_file(&policy_path, budget_alert_tx)
             .map_err(|e| anyhow::anyhow!("load policy: {e:?}"))?,
     );
-    let budget_tracker = Arc::new(
-        BudgetTracker::new(PricingTable::default_table(), None, None, chrono_tz::UTC)
-            .with_team_daily_limit(team_limit_usd),
-    );
+    let mut tracker = BudgetTracker::new(PricingTable::default_table(), None, None, chrono_tz::UTC)
+        .with_team_daily_limit(team_limit_usd);
+    if let Some(d) = window {
+        tracker = tracker.with_window(aa_gateway::budget::BudgetWindow::Duration(d));
+    }
+    let budget_tracker = Arc::new(tracker);
     let approval_queue = ApprovalQueue::new();
     let agent_registry = Arc::new(AgentRegistry::new());
 

--- a/aa-integration-tests/tests/e2e_budget.rs
+++ b/aa-integration-tests/tests/e2e_budget.rs
@@ -11,7 +11,7 @@
 //! |---|---|---|
 //! | Token-count tracking (`limit_tokens: 1000`) | USD amounts via `record_raw_spend` | `BudgetTracker` tracks USD spend, not raw tokens |
 //! | Python SDK driver + mock LLM server | In-process `record_raw_spend` seeding | No HTTP route for spend ingestion; same pattern as `api_costs.rs` |
-//! | Sub-day window (`window: "5s"`) | TC-4 marked `#[ignore]` | `BudgetTracker` resets at midnight UTC only; sub-day windows not in v0.0.1 |
+//! | Sub-day window (`window: "5s"`) | TC-4 exercised at 150 ms via `start_with_team_budget_window` | `BudgetTracker` supports sub-day rollover as of AAASM-1600; the integration test uses a 150 ms window to keep the suite fast |
 //! | `BudgetExhaustedError` from SDK | `BudgetStatus::LimitExceeded` from tracker | No SDK layer in integration harness |
 //!
 //! ## Seeding strategy
@@ -182,19 +182,64 @@ async fn budget_exhausted_request_is_rejected_at_tracking_layer() {
     );
 }
 
-// ── TC-4: sub-day window rollover (ignored — not implemented in v0.0.1) ───────
+// ── TC-4: sub-day window rollover (AAASM-1600) ────────────────────────────────
 
-/// Budget spend resets after the configured time window elapses.
+/// Budget spend resets after the configured sub-day window elapses.
 ///
-/// Marked `#[ignore]` because `BudgetTracker` only resets at midnight UTC;
-/// sub-day budget windows (e.g. `window: "5s"`) are not supported in v0.0.1.
-/// Remove the `#[ignore]` and implement once a configurable flush interval is
-/// added to `BudgetTracker`.
-#[ignore = "blocked on AAASM-1600: BudgetTracker sub-day window flush interval not implemented"]
+/// Exercises `BudgetWindow::Duration` end-to-end: pre-window spend
+/// accumulates, the wall-clock window elapses, post-window spend reflects
+/// only the new amount (proof the previous accumulator was zeroed by
+/// `maybe_reset_window` on the next `record_*` call). Uses a 150 ms window
+/// so the assertion fires in under a second of suite time.
 #[tokio::test(flavor = "multi_thread")]
 async fn budget_resets_after_daily_window() {
-    unimplemented!(
-        "sub-day budget window rollover not supported in v0.0.1 (BudgetTracker resets at midnight UTC only)"
+    use std::time::Duration as StdDuration;
+    let window = StdDuration::from_millis(150);
+    let env = TopologyTestEnv::start_with_team_budget_window(Decimal::new(500, 2), window)
+        .await
+        .expect("harness should start with sub-day budget window");
+    let agent = AgentId::from_bytes(BUDGET_AGENT_A);
+
+    // Pre-window: record some spend; assert it accumulated.
+    env.budget_tracker
+        .record_raw_spend(agent, Some(TEAM_A), Decimal::new(200, 2)); // 2.00 USD
+    let before = env
+        .budget_tracker
+        .team_state(TEAM_A)
+        .expect("team state present after first spend");
+    assert_eq!(
+        before.spent_usd,
+        Decimal::new(200, 2),
+        "team should accumulate 2.00 USD before window elapses"
+    );
+
+    // Sleep past the window. The periodic flush task also runs; either it
+    // or the lazy reset on the next `record_raw_spend` will zero the
+    // accumulator — the assertion below works regardless of which fires
+    // first.
+    tokio::time::sleep(window + StdDuration::from_millis(100)).await;
+
+    // Post-window: a fresh spend triggers the window-aware reset, so the
+    // total reflects only the new amount.
+    let status = env
+        .budget_tracker
+        .record_raw_spend(agent, Some(TEAM_A), Decimal::new(75, 2)); // 0.75 USD
+    let after = env
+        .budget_tracker
+        .team_state(TEAM_A)
+        .expect("team state present after window-elapsed spend");
+    assert_eq!(
+        after.spent_usd,
+        Decimal::new(75, 2),
+        "spend must zero and re-accumulate from the post-window record once the {} ms window elapses",
+        window.as_millis()
+    );
+    assert!(
+        matches!(
+            status,
+            BudgetStatus::WithinBudget { .. } | BudgetStatus::ThresholdAlert { .. }
+        ),
+        "0.75 USD spend after reset should be well within the 5.00 USD cap, got: {status:?}"
     );
 }
 


### PR DESCRIPTION
## Description

Adds a configurable sub-day rollover window to `BudgetTracker` so the F116 ST-F `budget_resets_after_daily_window` integration test can run (today's tracker resets only at midnight UTC, which is impractical to exercise in a CI suite).

Design:
- New `BudgetWindow` enum (`Daily | Duration(std::time::Duration)`), defaults to `Daily` — no behavioural change for existing deployments.
- New `BudgetState::last_reset_at: Option<DateTime<Utc>>` field (back-compat via `#[serde(default)]`), populated only when the tracker is in `Duration` mode.
- New `BudgetState::maybe_reset_window` routing path: delegates to the legacy `maybe_reset` for `Daily`, anchors + zeroes on elapsed-interval for `Duration`.
- All reset call sites in `BudgetTracker` (`record_cost`, `check_daily`, `check_monthly`, `preflight_ancestors`, `check_and_decrement` Phase 2, `subtree_spend`) now route through `maybe_reset_window`.
- New `BudgetTracker::flush_window()` + `start_window_flush_task` so dashboard reads see fresh state even between record events.
- New `budget.window: "5s"` policy YAML field, validated via `humantime::parse_duration` into `BudgetPolicy.window: Option<Duration>`.
- Gateway server reads the field in `setup_budget` and spawns a periodic flush task at `interval / 4` cadence (50 ms floor) when configured.
- New `TopologyTestEnv::start_with_team_budget_window(cap, window)` test fixture for integration coverage.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

`BudgetWindow::Daily` is the default; persisted `budget.json` files from before AAASM-1600 deserialize unchanged (back-compat exercised by `load_from_disk_backward_compat_missing_monthly_fields` and the new field's serde default).

## Related Issues

- Related Jira ticket: AAASM-1600 (F116 ST-F follow-up under AAASM-1232)
- Parent verification ST: AAASM-1241

## Testing

- [x] Unit tests added — 5 new cases in `aa-gateway/src/budget/types.rs::tests` covering `maybe_reset_window` (Daily parity, anchor seeding, sub-window no-op, post-interval rollover, default).
- [x] Integration tests added — un-ignored `budget_resets_after_daily_window` in `aa-integration-tests/tests/e2e_budget.rs:193`, now running against a 150 ms window via `start_with_team_budget_window`.
- [x] Full regression sweep: `cargo nextest run -p aa-gateway` → 1022/1022 passed.
- [x] `cargo nextest run -p aa-integration-tests --test e2e_budget` → 6/6 passed.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on new types/methods + tracing log)
- [x] All CI checks passing (pending push)
- [x] Commits are small and follow the Gitmoji convention (14 commits — see `git log master..HEAD`)