### PR TITLE
[AAASM-1566] ✨ (aa-proxy): Wire credential_action enforcement into MitM data path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,6 +350,7 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "tokio",
+ "tokio-rustls",
  "tokio-tungstenite",
  "tokio-util",
  "uuid",

--- a/aa-integration-tests/Cargo.toml
+++ b/aa-integration-tests/Cargo.toml
@@ -39,6 +39,7 @@ moka        = { version = "0.12", features = ["future"] }
 portpicker  = "0.1"
 reqwest     = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 rustls      = { version = "0.23", features = ["ring"] }
+tokio-rustls = "0.26"
 rstest      = "0.26"
 rust_decimal = "1"
 serde_json  = "1"

--- a/aa-integration-tests/tests/common/fixtures/policies/secret_block.yaml
+++ b/aa-integration-tests/tests/common/fixtures/policies/secret_block.yaml
@@ -1,0 +1,16 @@
+apiVersion: agent-assembly.dev/v1alpha1
+kind: GovernancePolicy
+metadata:
+  name: it-proxy-secret-block
+  version: "0.1.0"
+spec:
+  tools:
+    test_tool:
+      allow: true
+  data:
+    # Detection patterns are inherited from the built-in scanner; the
+    # operative knob is credential_action. `block` causes aa-proxy to
+    # return 403 to the client and never dial upstream when a secret is
+    # detected in the request body. Drives AAASM-1566's
+    # proxy_secret_block_policy_prevents_forwarding integration test.
+    credential_action: block

--- a/aa-integration-tests/tests/common/fixtures/policies/secret_redact_only.yaml
+++ b/aa-integration-tests/tests/common/fixtures/policies/secret_redact_only.yaml
@@ -1,0 +1,16 @@
+apiVersion: agent-assembly.dev/v1alpha1
+kind: GovernancePolicy
+metadata:
+  name: it-proxy-secret-redact-only
+  version: "0.1.0"
+spec:
+  tools:
+    test_tool:
+      allow: true
+  data:
+    # `redact_only` is the default — included here explicitly so a future
+    # change to the default surfaces as a diff in the fixture. aa-proxy
+    # forwards the request to upstream with secret bytes replaced by
+    # [REDACTED:<Kind>] markers. Drives AAASM-1566's
+    # proxy_aws_key_in_body_redacted_before_forwarding integration test.
+    credential_action: redact_only

--- a/aa-integration-tests/tests/e2e_policy_proxy.rs
+++ b/aa-integration-tests/tests/e2e_policy_proxy.rs
@@ -34,6 +34,7 @@ fn proxy_config(ca_dir: &std::path::Path, denied_hosts: Vec<String>) -> ProxyCon
         denied_hosts,
         skip_upstream_tls_verify: true,
         credential_action: CredentialAction::default(),
+        upstream_override: None,
     }
 }
 

--- a/aa-integration-tests/tests/e2e_policy_proxy.rs
+++ b/aa-integration-tests/tests/e2e_policy_proxy.rs
@@ -14,7 +14,7 @@ use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::broadcast;
 
-use aa_proxy::config::ProxyConfig;
+use aa_proxy::config::{CredentialAction, ProxyConfig};
 use aa_proxy::tls::CaStore;
 use aa_runtime::pipeline::PipelineEvent;
 
@@ -33,6 +33,7 @@ fn proxy_config(ca_dir: &std::path::Path, denied_hosts: Vec<String>) -> ProxyCon
         llm_only: false,
         denied_hosts,
         skip_upstream_tls_verify: true,
+        credential_action: CredentialAction::default(),
     }
 }
 

--- a/aa-integration-tests/tests/e2e_secret_interception.rs
+++ b/aa-integration-tests/tests/e2e_secret_interception.rs
@@ -338,11 +338,362 @@ fn redacted_payload_never_contains_any_raw_secret() {
     );
 }
 
-// ── Proxy-path slice (AAASM-1549 / ST-N) ─────────────────────────────────────
+// ── Proxy data-path E2E (AAASM-1566) ─────────────────────────────────────────
 //
-// The tests above drive the gateway's `PolicyEngine` (Layer 1). ST-N covers the
-// equivalent **Layer 2** scanner integration carried by `aa_proxy::Interceptor`.
-// See the file-level scope note for what this slice does and does not assert.
+// These tests drive a real `aa_proxy::proxy::ProxyServer` end-to-end: a
+// reqwest-shaped client opens a CONNECT tunnel through the proxy to an LLM
+// hostname, the proxy MitM-terminates, runs `intercept_request` against the
+// real body bytes, and applies the configured `CredentialAction`. The
+// upstream is a small TLS-terminating mock the proxy dials via the
+// `upstream_override` test knob (so we don't have to hijack DNS to redirect
+// `api.openai.com:443` to `127.0.0.1:<port>`).
+//
+// The three tests below match AAASM-1566 acceptance criteria 1:1 — see the
+// ticket body for the spec.
+
+mod proxy_data_path {
+    use std::net::SocketAddr;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    use base64::Engine as _;
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName};
+    use rustls::{ClientConfig, RootCertStore, ServerConfig};
+    use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::{TcpListener, TcpStream};
+    use tokio::sync::{broadcast, mpsc};
+    use tokio_rustls::{TlsAcceptor, TlsConnector};
+
+    use aa_proxy::audit_jsonl::ProxyAuditEntry;
+    use aa_proxy::config::{CredentialAction, ProxyConfig};
+    use aa_proxy::proxy::ProxyServer;
+    use aa_proxy::tls::CaStore;
+    use aa_runtime::pipeline::PipelineEvent;
+
+    /// LLM hostname the client CONNECTs to. `detect_api` returns
+    /// `LlmApiPattern::OpenAi`, which is what triggers the proxy's
+    /// body-inspection branch.
+    const LLM_HOSTNAME: &str = "api.openai.com";
+
+    /// Install rustls's default crypto provider exactly once per process.
+    /// Both `aws-lc-rs` and `ring` are present transitively in this
+    /// workspace, so rustls 0.23 refuses to pick one automatically — see
+    /// `project_rustls_crypto_provider`.
+    fn install_crypto_provider() {
+        use std::sync::Once;
+        static INIT: Once = Once::new();
+        INIT.call_once(|| {
+            let _ = rustls::crypto::ring::default_provider().install_default();
+        });
+    }
+
+    /// In-process TLS-terminating HTTP upstream that records inbound request
+    /// bodies and replies with a canned chat-completion envelope.
+    struct TlsCapturingUpstream {
+        addr: SocketAddr,
+        history: Arc<Mutex<Vec<Vec<u8>>>>,
+        _abort: tokio::task::AbortHandle,
+    }
+
+    impl TlsCapturingUpstream {
+        fn request_count(&self) -> usize {
+            self.history.lock().expect("history mutex poisoned").len()
+        }
+
+        fn last_body(&self) -> Option<String> {
+            self.history
+                .lock()
+                .expect("history mutex poisoned")
+                .last()
+                .and_then(|b| std::str::from_utf8(b).ok().map(String::from))
+        }
+
+        /// Start a TLS-terminating capture upstream signed by the proxy's CA.
+        ///
+        /// The certificate is signed for `LLM_HOSTNAME` so when the proxy's
+        /// client connects with `ServerName::try_from("api.openai.com")` the
+        /// server name matches the cert. Combined with the proxy's
+        /// `skip_upstream_tls_verify=true` this lets us assert end-to-end
+        /// flow without installing the test CA in the system trust store.
+        async fn start(ca: &CaStore) -> Self {
+            let ck = ca.sign_cert(LLM_HOSTNAME).expect("ca sign_cert");
+            let cert = CertificateDer::from(ck.cert_der.clone());
+            let key = PrivateKeyDer::from(PrivatePkcs8KeyDer::from(ck.key_der.clone()));
+            let server_config = ServerConfig::builder()
+                .with_no_client_auth()
+                .with_single_cert(vec![cert], key)
+                .expect("server config");
+            let acceptor = TlsAcceptor::from(Arc::new(server_config));
+
+            let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind upstream");
+            let addr = listener.local_addr().expect("local_addr");
+
+            let history: Arc<Mutex<Vec<Vec<u8>>>> = Arc::new(Mutex::new(Vec::new()));
+            let h_arc = Arc::clone(&history);
+
+            let handle = tokio::spawn(async move {
+                loop {
+                    let Ok((stream, _)) = listener.accept().await else {
+                        return;
+                    };
+                    let acceptor = acceptor.clone();
+                    let history = Arc::clone(&h_arc);
+                    tokio::spawn(async move {
+                        let Ok(mut tls) = acceptor.accept(stream).await else {
+                            return;
+                        };
+                        let mut buf: Vec<u8> = Vec::new();
+                        let mut tmp = [0u8; 4096];
+                        // Read until \r\n\r\n separator.
+                        let head_end = loop {
+                            match tls.read(&mut tmp).await {
+                                Ok(0) => return,
+                                Ok(n) => buf.extend_from_slice(&tmp[..n]),
+                                Err(_) => return,
+                            }
+                            if let Some(p) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                                break p;
+                            }
+                        };
+                        // Parse Content-Length.
+                        let head = std::str::from_utf8(&buf[..head_end]).unwrap_or("");
+                        let cl: usize = head
+                            .lines()
+                            .find_map(|line| {
+                                let lower = line.to_ascii_lowercase();
+                                lower
+                                    .strip_prefix("content-length:")
+                                    .and_then(|v| v.trim().parse().ok())
+                            })
+                            .unwrap_or(0);
+                        let body_start = head_end + 4;
+                        // Read remaining body bytes.
+                        while buf.len() < body_start + cl {
+                            match tls.read(&mut tmp).await {
+                                Ok(0) => break,
+                                Ok(n) => buf.extend_from_slice(&tmp[..n]),
+                                Err(_) => break,
+                            }
+                        }
+                        let body = buf[body_start..body_start + cl].to_vec();
+                        history.lock().expect("history mutex poisoned").push(body);
+                        let resp = b"HTTP/1.1 200 OK\r\nContent-Length: 13\r\nContent-Type: application/json\r\n\r\n{\"id\":\"mock\"}";
+                        let _ = tls.write_all(resp).await;
+                        let _ = tls.flush().await;
+                    });
+                }
+            });
+
+            Self {
+                addr,
+                history,
+                _abort: handle.abort_handle(),
+            }
+        }
+    }
+
+    /// Build a [`ClientConfig`] that trusts the proxy's per-host CA (so
+    /// `ServerName = LLM_HOSTNAME` verifies against the MitM-issued leaf cert).
+    async fn client_trust_proxy_ca(ca_dir: &std::path::Path) -> ClientConfig {
+        let pem = tokio::fs::read_to_string(ca_dir.join("ca-cert.pem"))
+            .await
+            .expect("read ca cert pem");
+        let body: String = pem.lines().filter(|l| !l.starts_with("-----")).collect();
+        let der_bytes = base64::engine::general_purpose::STANDARD
+            .decode(body)
+            .expect("decode ca pem base64");
+        let mut roots = RootCertStore::empty();
+        roots
+            .add(CertificateDer::from(der_bytes))
+            .expect("add ca cert to root store");
+        ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth()
+    }
+
+    /// Spin up a `ProxyServer` with the supplied `credential_action` and
+    /// `upstream_override`, returning the proxy's bound address plus an
+    /// abort handle and the receive channel.
+    async fn start_proxy(
+        ca_dir: &std::path::Path,
+        ca: CaStore,
+        credential_action: CredentialAction,
+        upstream_override: SocketAddr,
+        audit_jsonl_tx: Option<mpsc::Sender<ProxyAuditEntry>>,
+    ) -> (SocketAddr, broadcast::Receiver<PipelineEvent>, tokio::task::AbortHandle) {
+        let port = portpicker::pick_unused_port().expect("free port");
+        let config = ProxyConfig {
+            bind_addr: SocketAddr::from(([127, 0, 0, 1], port)),
+            ca_dir: ca_dir.to_path_buf(),
+            cert_cache_capacity: 10,
+            llm_only: false,
+            denied_hosts: Vec::new(),
+            skip_upstream_tls_verify: true,
+            credential_action,
+            upstream_override: Some(upstream_override),
+        };
+        let bind_addr = config.bind_addr;
+        let (tx, rx) = broadcast::channel(64);
+        let server = ProxyServer::new_with_audit_sink(config, ca, tx, audit_jsonl_tx);
+        let jh = tokio::spawn(async move { server.run().await.unwrap() });
+        let abort = jh.abort_handle();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            if TcpStream::connect(bind_addr).await.is_ok() {
+                break;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                panic!("proxy did not start on {bind_addr}");
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        (bind_addr, rx, abort)
+    }
+
+    /// Drive an HTTPS request through the proxy to the LLM hostname,
+    /// returning the CONNECT status line and (optionally) the inner response
+    /// status. Block-mode tests assert on the CONNECT response status line;
+    /// successful tests verify the upstream observed the call.
+    async fn send_through_proxy(
+        proxy_addr: SocketAddr,
+        client_config: Arc<ClientConfig>,
+        body: &str,
+    ) -> ProxyDriveResult {
+        let mut tcp = TcpStream::connect(proxy_addr).await.expect("connect to proxy");
+        let target_port = 443; // Arbitrary — upstream_override forwards regardless.
+        let target = format!("{LLM_HOSTNAME}:{target_port}");
+        let connect = format!("CONNECT {target} HTTP/1.1\r\nHost: {target}\r\n\r\n");
+        tcp.write_all(connect.as_bytes()).await.expect("write CONNECT");
+
+        let mut reader = BufReader::new(tcp);
+        let mut status_line = String::new();
+        reader.read_line(&mut status_line).await.expect("read connect status");
+        // Drain headers.
+        loop {
+            let mut h = String::new();
+            reader.read_line(&mut h).await.expect("read header line");
+            if h.trim().is_empty() {
+                break;
+            }
+        }
+
+        // If the proxy returned a non-200 here (e.g. CONNECT-level deny), we
+        // never get to send the inner request — caller asserts on status.
+        if !status_line.contains("200") {
+            return ProxyDriveResult {
+                connect_status: status_line,
+                inner_response: None,
+            };
+        }
+
+        // TLS-wrap the tunnel using the proxy's CA.
+        let server_name = ServerName::try_from(LLM_HOSTNAME.to_string()).expect("server name");
+        let connector = TlsConnector::from(client_config);
+        let tcp = reader.into_inner();
+        let mut tls = match connector.connect(server_name, tcp).await {
+            Ok(t) => t,
+            Err(e) => {
+                return ProxyDriveResult {
+                    connect_status: status_line,
+                    inner_response: Some(format!("TLS error: {e}")),
+                };
+            }
+        };
+
+        let req = format!(
+            "POST /v1/chat/completions HTTP/1.1\r\nHost: {LLM_HOSTNAME}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body,
+        );
+        if let Err(e) = tls.write_all(req.as_bytes()).await {
+            return ProxyDriveResult {
+                connect_status: status_line,
+                inner_response: Some(format!("write error: {e}")),
+            };
+        }
+        // Read response (best-effort) — Block path never reaches here.
+        let mut response_buf = vec![0u8; 1024];
+        let _ = tokio::time::timeout(Duration::from_secs(2), tls.read(&mut response_buf)).await;
+        let response = String::from_utf8_lossy(&response_buf)
+            .trim_end_matches('\0')
+            .to_string();
+        ProxyDriveResult {
+            connect_status: status_line,
+            inner_response: Some(response),
+        }
+    }
+
+    /// Result of driving a request through the proxy.
+    struct ProxyDriveResult {
+        /// CONNECT response status line, e.g. `"HTTP/1.1 200 Connection Established"`.
+        connect_status: String,
+        /// Inner HTTP response, or `None` when the CONNECT itself was rejected.
+        ///
+        /// Read by `proxy_secret_block_policy_prevents_forwarding` in the
+        /// next commit; allow(dead_code) for the redact-only test that does
+        /// not consume it.
+        #[allow(dead_code)]
+        inner_response: Option<String>,
+    }
+
+    // ── Test 1 — redact_only forwards [REDACTED] form, never the raw key ─
+
+    /// `TlsCapturingUpstream::last_body()` contains `[REDACTED:AwsAccessKey]`,
+    /// never the raw key. Drives AAASM-1566 acceptance criterion
+    /// `proxy_aws_key_in_body_redacted_before_forwarding`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn proxy_aws_key_in_body_redacted_before_forwarding() {
+        install_crypto_provider();
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let ca = CaStore::load_or_create(dir.path()).await.expect("ca");
+        let client_config = Arc::new(client_trust_proxy_ca(dir.path()).await);
+
+        let upstream = TlsCapturingUpstream::start(&ca).await;
+        let (proxy_addr, _rx, abort) =
+            start_proxy(dir.path(), ca, CredentialAction::RedactOnly, upstream.addr, None).await;
+
+        let body = format!(
+            r#"{{"model":"gpt-4","messages":[{{"role":"user","content":"my key is {}"}}]}}"#,
+            super::FAKE_AWS_ACCESS_KEY,
+        );
+        let result = send_through_proxy(proxy_addr, client_config, &body).await;
+        assert!(
+            result.connect_status.contains("200"),
+            "CONNECT must succeed for redact_only, got: {}",
+            result.connect_status,
+        );
+
+        // Allow the upstream a beat to capture the request.
+        for _ in 0..50 {
+            if upstream.request_count() >= 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        assert_eq!(
+            upstream.request_count(),
+            1,
+            "upstream must receive exactly one forwarded request",
+        );
+        let received = upstream.last_body().expect("upstream captured body");
+        assert!(
+            received.contains("[REDACTED:AwsAccessKey]"),
+            "forwarded body must carry the [REDACTED:AwsAccessKey] marker; got: {received}",
+        );
+        assert!(
+            !received.contains(super::FAKE_AWS_ACCESS_KEY),
+            "SECURITY INVARIANT: raw AWS key reached upstream — got: {received}",
+        );
+
+        abort.abort();
+    }
+}
+
+// ── Proxy-path scanner-only slice (AAASM-1549 / ST-N) ────────────────────────
+//
+// The mod above is the full data-path E2E. The mod below is the older
+// scanner-only slice that drives `aa_proxy::Interceptor` directly.
 
 mod proxy_path {
     use std::time::SystemTime;

--- a/aa-integration-tests/tests/e2e_secret_interception.rs
+++ b/aa-integration-tests/tests/e2e_secret_interception.rs
@@ -688,6 +688,58 @@ mod proxy_data_path {
 
         abort.abort();
     }
+
+    // ── Test 2 — block policy returns 403 and never dials upstream ───────
+
+    /// Under `CredentialAction::Block` the proxy refuses to forward a body
+    /// that contains a detected secret. Asserts both halves of the AC:
+    ///
+    /// 1. `TlsCapturingUpstream.request_count() == 0` — the proxy never
+    ///    dialled upstream.
+    /// 2. The inner HTTP response is `HTTP/1.1 403 Forbidden` (the proxy
+    ///    writes 403 to the client TLS stream after running the scanner).
+    ///
+    /// Drives AAASM-1566's `proxy_secret_block_policy_prevents_forwarding`.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn proxy_secret_block_policy_prevents_forwarding() {
+        install_crypto_provider();
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let ca = CaStore::load_or_create(dir.path()).await.expect("ca");
+        let client_config = Arc::new(client_trust_proxy_ca(dir.path()).await);
+
+        let upstream = TlsCapturingUpstream::start(&ca).await;
+        let (proxy_addr, _rx, abort) = start_proxy(dir.path(), ca, CredentialAction::Block, upstream.addr, None).await;
+
+        let body = format!(
+            r#"{{"model":"gpt-4","messages":[{{"role":"user","content":"my key is {}"}}]}}"#,
+            super::FAKE_AWS_ACCESS_KEY,
+        );
+        let result = send_through_proxy(proxy_addr, client_config, &body).await;
+
+        // CONNECT-level handshake still succeeds — the proxy only blocks
+        // after reading the inner request body inside the tunnel.
+        assert!(
+            result.connect_status.contains("200"),
+            "CONNECT must succeed (block fires inside the TLS tunnel); got: {}",
+            result.connect_status,
+        );
+
+        let inner = result.inner_response.expect("inner_response must be Some");
+        assert!(
+            inner.contains("403"),
+            "proxy must return 403 inside the tunnel under credential_action=Block; got: {inner:?}",
+        );
+
+        // Hard wait to give the upstream a chance to be (incorrectly) dialled.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        assert_eq!(
+            upstream.request_count(),
+            0,
+            "SECURITY INVARIANT: upstream must receive zero requests under Block policy",
+        );
+
+        abort.abort();
+    }
 }
 
 // ── Proxy-path scanner-only slice (AAASM-1549 / ST-N) ────────────────────────

--- a/aa-integration-tests/tests/e2e_secret_interception.rs
+++ b/aa-integration-tests/tests/e2e_secret_interception.rs
@@ -740,6 +740,92 @@ mod proxy_data_path {
 
         abort.abort();
     }
+
+    // ── Test 3 — credential_findings reach the JSONL audit ───────────────
+
+    /// Drives AAASM-1566's third AC:
+    /// `proxy_secret_redact_only_credential_findings_in_audit`.
+    ///
+    /// Wires a `JsonlWriter` to the proxy via the `audit_jsonl_tx` channel,
+    /// sends a single request with a synthetic AWS key under
+    /// `CredentialAction::RedactOnly`, then reads the JSONL off disk and
+    /// asserts:
+    ///
+    /// 1. `credential_findings` field is present in the JSONL entry.
+    /// 2. The decision is `"forwarded_redacted"`.
+    /// 3. The raw AWS key string never appears anywhere in the JSONL file
+    ///    (grep returns 0 matches).
+    #[tokio::test(flavor = "multi_thread")]
+    async fn proxy_secret_redact_only_credential_findings_in_audit() {
+        use aa_proxy::audit_jsonl::JsonlWriter;
+
+        install_crypto_provider();
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let ca = CaStore::load_or_create(dir.path()).await.expect("ca");
+        let client_config = Arc::new(client_trust_proxy_ca(dir.path()).await);
+
+        let upstream = TlsCapturingUpstream::start(&ca).await;
+
+        // Spin up the JSONL audit pipeline. The writer is owned by a
+        // background task; the proxy holds the mpsc::Sender half.
+        let jsonl_path = dir.path().join("proxy-audit.jsonl");
+        let (audit_tx, audit_rx) = mpsc::channel::<ProxyAuditEntry>(16);
+        let writer = JsonlWriter::new(&jsonl_path, audit_rx)
+            .await
+            .expect("open JSONL writer");
+        let writer_handle = tokio::spawn(writer.run());
+
+        let (proxy_addr, _rx, abort) = start_proxy(
+            dir.path(),
+            ca,
+            CredentialAction::RedactOnly,
+            upstream.addr,
+            Some(audit_tx.clone()),
+        )
+        .await;
+
+        let body = format!(
+            r#"{{"model":"gpt-4","messages":[{{"role":"user","content":"my key is {}"}}]}}"#,
+            super::FAKE_AWS_ACCESS_KEY,
+        );
+        let result = send_through_proxy(proxy_addr, client_config, &body).await;
+        assert!(
+            result.connect_status.contains("200"),
+            "CONNECT must succeed for redact_only, got: {}",
+            result.connect_status,
+        );
+
+        // Wait for the upstream to have observed the request — then the
+        // audit entry has been sent by the proxy.
+        for _ in 0..50 {
+            if upstream.request_count() >= 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // Drop the proxy's sender clone so the writer can drain and exit.
+        drop(audit_tx);
+        abort.abort();
+        // Give the writer a moment to flush — bounded by writer task join.
+        let _ = tokio::time::timeout(Duration::from_secs(2), writer_handle).await;
+
+        let on_disk = tokio::fs::read_to_string(&jsonl_path)
+            .await
+            .expect("read JSONL audit file");
+        assert!(
+            on_disk.contains("\"credential_findings\""),
+            "JSONL must carry the credential_findings field; got: {on_disk}",
+        );
+        assert!(
+            on_disk.contains("\"forwarded_redacted\""),
+            "JSONL must record decision=forwarded_redacted for redact_only path; got: {on_disk}",
+        );
+        assert!(
+            !on_disk.contains(super::FAKE_AWS_ACCESS_KEY),
+            "SECURITY INVARIANT: raw AWS key appears in audit JSONL on disk: {on_disk}",
+        );
+    }
 }
 
 // ── Proxy-path scanner-only slice (AAASM-1549 / ST-N) ────────────────────────

--- a/aa-proxy/Cargo.toml
+++ b/aa-proxy/Cargo.toml
@@ -14,7 +14,7 @@ name = "aa-proxy"
 path = "src/main.rs"
 
 [dependencies]
-aa-core = { path = "../aa-core" }
+aa-core = { path = "../aa-core", features = ["serde"] }
 aa-proto   = { path = "../aa-proto" }
 aa-runtime = { path = "../aa-runtime" }
 tokio      = { version = "1", features = ["full"] }

--- a/aa-proxy/src/audit_jsonl.rs
+++ b/aa-proxy/src/audit_jsonl.rs
@@ -1,0 +1,55 @@
+//! Proxy-side audit record for the MitM data path.
+//!
+//! [`ProxyAuditEntry`] is the small, self-contained record the proxy emits
+//! after handling one intercepted request. It carries the decision the proxy
+//! made (forward / forward-redacted / block) plus any `credential_findings`
+//! produced by the in-path scanner, but never the raw secret bytes.
+//!
+//! Layer naming note: unlike `aa-gateway::audit::AuditWriter` (which persists
+//! a hash-chained `AuditEntry`), this module is the proxy's purpose-built
+//! sink. The two records have different shapes because the proxy and the
+//! gateway observe different things; see the JSONL writer added in a later
+//! commit for how this struct reaches disk.
+
+use serde::{Deserialize, Serialize};
+
+use aa_core::CredentialFinding;
+
+/// Decision recorded for a single intercepted request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProxyAuditDecision {
+    /// Request forwarded unmodified (no findings, or policy `alert_only`).
+    Forwarded,
+    /// Request forwarded with secrets replaced by `[REDACTED:<Kind>]`
+    /// markers in the body (policy `redact_only`).
+    ForwardedRedacted,
+    /// Request blocked at the proxy; upstream never dialled (policy `block`).
+    Blocked,
+}
+
+/// A single audit record emitted by the proxy's data path.
+///
+/// `redacted_body` carries the *post-scan* body bytes (the form that was or
+/// would have been forwarded). The original raw body is never stored — only
+/// its redacted projection. `credential_findings` is the per-match metadata
+/// produced by `CredentialScanner`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProxyAuditEntry {
+    /// Wall-clock timestamp in milliseconds since the Unix epoch.
+    pub ts_ms: i64,
+    /// Agent identifier that owned the connection, when known.
+    pub agent_id: Option<String>,
+    /// Target host (no port) from the CONNECT line.
+    pub host: String,
+    /// HTTP method of the intercepted request inside the tunnel.
+    pub method: String,
+    /// Request path of the intercepted request inside the tunnel.
+    pub path: String,
+    /// What the proxy did with the request.
+    pub decision: ProxyAuditDecision,
+    /// Per-match scanner output. Empty when no secrets were detected.
+    pub credential_findings: Vec<CredentialFinding>,
+    /// Post-scan body content. `None` when the proxy bypassed the scanner.
+    pub redacted_body: Option<String>,
+}

--- a/aa-proxy/src/audit_jsonl.rs
+++ b/aa-proxy/src/audit_jsonl.rs
@@ -11,7 +11,12 @@
 //! gateway observe different things; see the JSONL writer added in a later
 //! commit for how this struct reaches disk.
 
+use std::io;
+use std::path::{Path, PathBuf};
+
 use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
+use tokio::sync::mpsc;
 
 use aa_core::CredentialFinding;
 
@@ -52,4 +57,63 @@ pub struct ProxyAuditEntry {
     pub credential_findings: Vec<CredentialFinding>,
     /// Post-scan body content. `None` when the proxy bypassed the scanner.
     pub redacted_body: Option<String>,
+}
+
+/// Append-only JSONL writer.
+///
+/// Construct with [`JsonlWriter::new`], drive with `tokio::spawn(writer.run())`.
+/// The task terminates when all senders drop and the channel closes.
+pub struct JsonlWriter {
+    receiver: mpsc::Receiver<ProxyAuditEntry>,
+    file: tokio::io::BufWriter<tokio::fs::File>,
+    path: PathBuf,
+}
+
+impl JsonlWriter {
+    /// Open `path` in append mode (creating it if missing) and bind the
+    /// supplied receiver. Parent directories must already exist.
+    pub async fn new(path: &Path, receiver: mpsc::Receiver<ProxyAuditEntry>) -> io::Result<Self> {
+        let file = tokio::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .await?;
+        Ok(Self {
+            receiver,
+            file: tokio::io::BufWriter::new(file),
+            path: path.to_path_buf(),
+        })
+    }
+
+    /// Path the writer is appending to (useful for tests).
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Background consumption loop.
+    ///
+    /// One entry per JSON line, flushed per write so external observers see
+    /// the line as soon as the proxy returns to the client. Per-entry write
+    /// failures are logged but do not stop the loop — losing one audit line
+    /// is preferable to silently halting subsequent requests.
+    pub async fn run(mut self) {
+        tracing::info!(path = %self.path.display(), "proxy audit jsonl writer started");
+        while let Some(entry) = self.receiver.recv().await {
+            if let Err(e) = self.append(&entry).await {
+                tracing::error!(error = %e, "proxy audit jsonl write failed");
+            }
+        }
+        if let Err(e) = self.file.flush().await {
+            tracing::error!(error = %e, "proxy audit jsonl final flush failed");
+        }
+        tracing::info!(path = %self.path.display(), "proxy audit jsonl writer stopped");
+    }
+
+    async fn append(&mut self, entry: &ProxyAuditEntry) -> io::Result<()> {
+        let json = serde_json::to_string(entry).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        self.file.write_all(json.as_bytes()).await?;
+        self.file.write_all(b"\n").await?;
+        self.file.flush().await?;
+        Ok(())
+    }
 }

--- a/aa-proxy/src/audit_jsonl.rs
+++ b/aa-proxy/src/audit_jsonl.rs
@@ -117,3 +117,65 @@ impl JsonlWriter {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Synthetic AWS access key from AWS public documentation. Not a real credential.
+    const FAKE_AWS_ACCESS_KEY: &str = "AKIAIOSFODNN7EXAMPLE";
+
+    /// Security invariant: the raw secret value must never appear in the
+    /// JSONL file on disk, even when the body that produced the finding
+    /// embedded the secret verbatim. Drives the AAASM-1566 acceptance
+    /// criterion "grep for the raw key against the JSONL file returns 0
+    /// matches".
+    #[tokio::test]
+    async fn audit_writer_never_writes_raw_secret() {
+        use aa_core::CredentialScanner;
+
+        let body = format!(r#"{{"k":"{FAKE_AWS_ACCESS_KEY}"}}"#);
+        let scan = CredentialScanner::new().scan(&body);
+        assert!(
+            !scan.findings.is_empty(),
+            "scanner fixture invariant — AWS key must be detected"
+        );
+        let redacted = scan.redact(&body);
+
+        let entry = ProxyAuditEntry {
+            ts_ms: 1_700_000_000_000,
+            agent_id: Some("agent-1".into()),
+            host: "api.openai.com".into(),
+            method: "POST".into(),
+            path: "/v1/chat/completions".into(),
+            decision: ProxyAuditDecision::ForwardedRedacted,
+            credential_findings: scan.findings,
+            redacted_body: Some(redacted),
+        };
+
+        let tmp = tempfile::tempdir().expect("create tempdir");
+        let path = tmp.path().join("proxy-audit.jsonl");
+        let (tx, rx) = mpsc::channel(4);
+        let writer = JsonlWriter::new(&path, rx).await.expect("open jsonl writer");
+        let handle = tokio::spawn(writer.run());
+
+        tx.send(entry).await.expect("send entry");
+        drop(tx);
+        handle.await.expect("writer task joins cleanly");
+
+        let on_disk = tokio::fs::read_to_string(&path).await.expect("read JSONL");
+        assert!(
+            !on_disk.contains(FAKE_AWS_ACCESS_KEY),
+            "SECURITY INVARIANT VIOLATED: raw secret present in proxy audit JSONL: {on_disk}",
+        );
+        assert!(
+            on_disk.contains("[REDACTED:AwsAccessKey]"),
+            "JSONL must carry the [REDACTED:AwsAccessKey] marker, got: {on_disk}",
+        );
+        assert_eq!(
+            on_disk.matches('\n').count(),
+            1,
+            "single entry must produce exactly one trailing newline: {on_disk}",
+        );
+    }
+}

--- a/aa-proxy/src/config.rs
+++ b/aa-proxy/src/config.rs
@@ -66,6 +66,16 @@ pub struct ProxyConfig {
     /// historical behaviour (the proxy forwards but the audit chain carries
     /// a redacted form).
     pub credential_action: CredentialAction,
+
+    /// Override the upstream socket address the proxy dials, regardless of
+    /// the CONNECT request's target host. Intended for integration tests
+    /// only — production deployments leave this `None` so the proxy dials
+    /// the real LLM endpoint resolved from the CONNECT line.
+    ///
+    /// When `Some`, the original hostname is still used for SNI and the
+    /// MitM certificate so the client's TLS verification continues to work
+    /// against the per-host CA chain.
+    pub upstream_override: Option<SocketAddr>,
 }
 
 impl ProxyConfig {
@@ -126,6 +136,7 @@ impl ProxyConfig {
             denied_hosts,
             skip_upstream_tls_verify,
             credential_action,
+            upstream_override: None,
         })
     }
 }

--- a/aa-proxy/src/config.rs
+++ b/aa-proxy/src/config.rs
@@ -266,4 +266,47 @@ mod tests {
         let cfg = ProxyConfig::from_env().unwrap();
         assert!(!cfg.skip_upstream_tls_verify);
     }
+
+    #[test]
+    fn from_env_credential_action_defaults_to_redact_only() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_env_vars();
+
+        let cfg = ProxyConfig::from_env().unwrap();
+        assert_eq!(cfg.credential_action, CredentialAction::RedactOnly);
+    }
+
+    #[test]
+    fn from_env_credential_action_reads_block() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_env_vars();
+        std::env::set_var("AA_PROXY_CREDENTIAL_ACTION", "block");
+
+        let cfg = ProxyConfig::from_env().unwrap();
+        assert_eq!(cfg.credential_action, CredentialAction::Block);
+    }
+
+    #[test]
+    fn from_env_credential_action_reads_alert_only_case_insensitive() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_env_vars();
+        std::env::set_var("AA_PROXY_CREDENTIAL_ACTION", "ALERT_ONLY");
+
+        let cfg = ProxyConfig::from_env().unwrap();
+        assert_eq!(cfg.credential_action, CredentialAction::AlertOnly);
+    }
+
+    #[test]
+    fn from_env_credential_action_invalid_returns_config_error() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_env_vars();
+        std::env::set_var("AA_PROXY_CREDENTIAL_ACTION", "nope");
+
+        let err = ProxyConfig::from_env().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("AA_PROXY_CREDENTIAL_ACTION"),
+            "error must name the env var, got: {msg}"
+        );
+    }
 }

--- a/aa-proxy/src/config.rs
+++ b/aa-proxy/src/config.rs
@@ -113,6 +113,11 @@ impl ProxyConfig {
             Err(_) => false,
         };
 
+        let credential_action = match std::env::var("AA_PROXY_CREDENTIAL_ACTION") {
+            Ok(val) => parse_credential_action(&val)?,
+            Err(_) => CredentialAction::default(),
+        };
+
         Ok(Self {
             bind_addr,
             ca_dir,
@@ -120,8 +125,23 @@ impl ProxyConfig {
             llm_only,
             denied_hosts,
             skip_upstream_tls_verify,
-            credential_action: CredentialAction::default(),
+            credential_action,
         })
+    }
+}
+
+/// Parse a credential action from its string representation.
+///
+/// Accepts `"block"`, `"redact_only"`, `"alert_only"` (case-insensitive).
+/// Returns [`ProxyError::Config`] for any other value.
+fn parse_credential_action(s: &str) -> Result<CredentialAction, ProxyError> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "block" => Ok(CredentialAction::Block),
+        "redact_only" => Ok(CredentialAction::RedactOnly),
+        "alert_only" => Ok(CredentialAction::AlertOnly),
+        other => Err(ProxyError::Config(format!(
+            "invalid AA_PROXY_CREDENTIAL_ACTION: {other:?} (expected block | redact_only | alert_only)"
+        ))),
     }
 }
 
@@ -141,6 +161,7 @@ mod tests {
         std::env::remove_var("AA_PROXY_LLM_ONLY");
         std::env::remove_var("AA_PROXY_DENIED_HOSTS");
         std::env::remove_var("AA_PROXY_SKIP_UPSTREAM_TLS_VERIFY");
+        std::env::remove_var("AA_PROXY_CREDENTIAL_ACTION");
     }
 
     #[test]

--- a/aa-proxy/src/config.rs
+++ b/aa-proxy/src/config.rs
@@ -5,6 +5,27 @@ use std::path::PathBuf;
 
 use crate::error::ProxyError;
 
+/// Action the proxy takes when its `CredentialScanner` produces a finding
+/// inside a flowing request body.
+///
+/// Mirrors `aa_gateway::policy::document::CredentialAction` but lives in the
+/// proxy crate so the data path can enforce policy locally without taking
+/// a dependency on the gateway. The variants and their semantics are
+/// intentionally identical so a single YAML field can drive both layers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CredentialAction {
+    /// Refuse the request: the proxy returns 403 to the client and **never**
+    /// dials upstream. The credential never leaves the host.
+    Block,
+    /// Forward a redacted form of the body upstream (default; matches the
+    /// historical behaviour from before this enum existed).
+    #[default]
+    RedactOnly,
+    /// Forward the unmodified body and raise a critical alert as a
+    /// side-effect. Documented as a deliberate downgrade for audit-only modes.
+    AlertOnly,
+}
+
 /// Runtime configuration for the proxy sidecar.
 ///
 /// All fields can be overridden via environment variables.

--- a/aa-proxy/src/config.rs
+++ b/aa-proxy/src/config.rs
@@ -58,6 +58,14 @@ pub struct ProxyConfig {
     /// never enable in production.
     /// Env: `AA_PROXY_SKIP_UPSTREAM_TLS_VERIFY` — default: `false`
     pub skip_upstream_tls_verify: bool,
+
+    /// Action to take when the in-path credential scanner detects a secret in
+    /// a flowing request body. Drives Layer 2 enforcement for LLM requests.
+    ///
+    /// Defaults to [`CredentialAction::RedactOnly`] which preserves the
+    /// historical behaviour (the proxy forwards but the audit chain carries
+    /// a redacted form).
+    pub credential_action: CredentialAction,
 }
 
 impl ProxyConfig {
@@ -112,6 +120,7 @@ impl ProxyConfig {
             llm_only,
             denied_hosts,
             skip_upstream_tls_verify,
+            credential_action: CredentialAction::default(),
         })
     }
 }

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -13,11 +13,51 @@ use aa_proto::assembly::common::v1::ActionType;
 use aa_runtime::pipeline::event::{EnrichedEvent, EventSource};
 use aa_runtime::pipeline::PipelineEvent;
 
-use aa_core::CredentialScanner;
+use aa_core::{CredentialFinding, CredentialScanner};
+use bytes::Bytes;
 
+use crate::config::CredentialAction;
 use crate::error::ProxyError;
 use crate::intercept::detect::LlmApiPattern;
 use crate::intercept::extract::{extract_anthropic, extract_cohere, extract_openai, ExtractionError, LlmFields};
+
+/// What the proxy should do with an intercepted request body after the
+/// scanner has run.
+///
+/// Returned by [`Interceptor::intercept_request`]; the data path branches on
+/// `decision` and uses `redacted_body` when applicable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VerdictDecision {
+    /// No findings — forward the original body unmodified.
+    Forward,
+    /// Findings detected and policy is `redact_only` — forward the bytes in
+    /// the `redacted_body` field instead of the original.
+    ForwardRedacted,
+    /// Findings detected and policy is `block` — return 403 to the client,
+    /// do not dial upstream.
+    Block,
+    /// Findings detected and policy is `alert_only` — forward the original
+    /// body and emit a critical alert side-effect.
+    AlertAndForward,
+}
+
+/// Output of [`Interceptor::intercept_request`].
+///
+/// Carries the policy-driven decision, the per-match scanner output (empty
+/// when clean), and the post-scan body (only populated when redaction took
+/// place). The data path consumes this to drive both upstream forwarding
+/// and audit emission.
+#[derive(Debug, Clone)]
+pub struct InterceptVerdict {
+    /// What the proxy should do with this request.
+    pub decision: VerdictDecision,
+    /// Per-match output from the credential scanner. Empty when no
+    /// credentials were detected.
+    pub findings: Vec<CredentialFinding>,
+    /// Post-scan body. `Some` only when `decision == ForwardRedacted` so the
+    /// data path can forward these bytes verbatim.
+    pub redacted_body: Option<Bytes>,
+}
 
 /// Inspects a decrypted HTTP request/response pair, decides whether it is an
 /// LLM API call, and extracts audit-relevant fields from the body.
@@ -30,6 +70,62 @@ pub struct Interceptor {
 }
 
 impl Interceptor {
+    /// Run the credential scanner against a flowing request body and decide
+    /// the data-path verdict according to the supplied [`CredentialAction`].
+    ///
+    /// Findings drive `decision`:
+    ///
+    /// * No findings → [`VerdictDecision::Forward`] (no redaction performed).
+    /// * Findings + [`CredentialAction::Block`] → [`VerdictDecision::Block`].
+    /// * Findings + [`CredentialAction::RedactOnly`] →
+    ///   [`VerdictDecision::ForwardRedacted`] with the redacted bytes
+    ///   populated.
+    /// * Findings + [`CredentialAction::AlertOnly`] →
+    ///   [`VerdictDecision::AlertAndForward`].
+    ///
+    /// When the proxy's scanner is disabled (constructed via
+    /// `with_scanner(None)`) this returns `Forward` with no findings.
+    pub fn intercept_request(&self, body: &[u8], action: CredentialAction) -> InterceptVerdict {
+        let Some(scanner) = self.scanner.as_ref() else {
+            return InterceptVerdict {
+                decision: VerdictDecision::Forward,
+                findings: Vec::new(),
+                redacted_body: None,
+            };
+        };
+
+        let text = String::from_utf8_lossy(body);
+        let scan = scanner.scan(&text);
+        if scan.is_clean() {
+            return InterceptVerdict {
+                decision: VerdictDecision::Forward,
+                findings: Vec::new(),
+                redacted_body: None,
+            };
+        }
+
+        match action {
+            CredentialAction::Block => InterceptVerdict {
+                decision: VerdictDecision::Block,
+                findings: scan.findings,
+                redacted_body: None,
+            },
+            CredentialAction::RedactOnly => {
+                let redacted = scan.redact(&text);
+                InterceptVerdict {
+                    decision: VerdictDecision::ForwardRedacted,
+                    findings: scan.findings,
+                    redacted_body: Some(Bytes::from(redacted)),
+                }
+            }
+            CredentialAction::AlertOnly => InterceptVerdict {
+                decision: VerdictDecision::AlertAndForward,
+                findings: scan.findings,
+                redacted_body: None,
+            },
+        }
+    }
+
     /// Create a new `Interceptor` with default credential scanning enabled.
     pub fn new(event_tx: broadcast::Sender<PipelineEvent>) -> Self {
         Self {

--- a/aa-proxy/src/lib.rs
+++ b/aa-proxy/src/lib.rs
@@ -17,6 +17,7 @@
 //! - **Library** (`aa_proxy::run()`): embeddable in-process for integration tests
 //!   or constrained environments where subprocess spawning is unavailable.
 
+pub mod audit_jsonl;
 pub mod config;
 pub mod error;
 pub mod intercept;

--- a/aa-proxy/src/proxy/http.rs
+++ b/aa-proxy/src/proxy/http.rs
@@ -1,0 +1,158 @@
+//! Minimal HTTP/1.1 request parsing for the proxy data path.
+//!
+//! After TLS termination the proxy needs to read the inbound request line,
+//! headers, and body off the TLS stream so the credential scanner can run
+//! against the real body bytes (and so the proxy can re-serialise with a
+//! modified body when policy is `redact_only`).
+//!
+//! Scope is intentionally small: only requests with a literal
+//! `Content-Length` header are fully supported. Requests using
+//! `Transfer-Encoding: chunked` parse the head but leave the body empty —
+//! that variant is rare for LLM POSTs and can be added when needed without
+//! breaking this API.
+
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, BufReader};
+
+use crate::error::ProxyError;
+
+/// A parsed HTTP request from the proxy's MitM tunnel.
+#[derive(Debug, Clone)]
+pub struct HttpRequest {
+    /// HTTP method (e.g. `"POST"`).
+    pub method: String,
+    /// Request target (e.g. `"/v1/chat/completions"`).
+    pub target: String,
+    /// HTTP version (e.g. `"HTTP/1.1"`).
+    pub version: String,
+    /// Header lines as `(name, value)` pairs preserving casing.
+    pub headers: Vec<(String, String)>,
+    /// Request body bytes, captured verbatim.
+    pub body: Vec<u8>,
+}
+
+impl HttpRequest {
+    /// Lookup the first header value matching `name` (case-insensitive).
+    pub fn header(&self, name: &str) -> Option<&str> {
+        self.headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(name))
+            .map(|(_, v)| v.as_str())
+    }
+}
+
+/// Read and parse an HTTP/1.1 request from `reader`.
+///
+/// Reads the request line and headers off the stream, then reads exactly
+/// `Content-Length` bytes of body. Requests without `Content-Length` and
+/// without `Transfer-Encoding: chunked` are treated as having an empty body.
+///
+/// Returns `Ok(None)` on a clean EOF before any bytes are read — that
+/// indicates the peer closed the connection between requests.
+pub async fn read_http_request<R>(reader: &mut BufReader<R>) -> Result<Option<HttpRequest>, ProxyError>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut request_line = String::new();
+    let n = reader.read_line(&mut request_line).await?;
+    if n == 0 {
+        return Ok(None);
+    }
+    let trimmed = request_line.trim_end_matches(['\r', '\n']);
+    let parts: Vec<&str> = trimmed.splitn(3, ' ').collect();
+    if parts.len() != 3 {
+        return Err(ProxyError::Config(format!("malformed HTTP request line: {trimmed:?}")));
+    }
+    let method = parts[0].to_string();
+    let target = parts[1].to_string();
+    let version = parts[2].to_string();
+
+    let mut headers: Vec<(String, String)> = Vec::new();
+    loop {
+        let mut line = String::new();
+        let n = reader.read_line(&mut line).await?;
+        if n == 0 {
+            return Err(ProxyError::Config("unexpected EOF reading headers".into()));
+        }
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            break;
+        }
+        if let Some((k, v)) = trimmed.split_once(':') {
+            headers.push((k.trim().to_string(), v.trim().to_string()));
+        } else {
+            return Err(ProxyError::Config(format!("malformed header line: {trimmed:?}")));
+        }
+    }
+
+    let content_length: usize = headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("content-length"))
+        .and_then(|(_, v)| v.parse().ok())
+        .unwrap_or(0);
+
+    let mut body = vec![0u8; content_length];
+    if content_length > 0 {
+        reader.read_exact(&mut body).await?;
+    }
+
+    Ok(Some(HttpRequest {
+        method,
+        target,
+        version,
+        headers,
+        body,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    fn make_reader(bytes: &[u8]) -> BufReader<Cursor<Vec<u8>>> {
+        BufReader::new(Cursor::new(bytes.to_vec()))
+    }
+
+    #[tokio::test]
+    async fn parses_post_with_content_length_body() {
+        let raw = b"POST /v1/chat/completions HTTP/1.1\r\n\
+                    Host: api.openai.com\r\n\
+                    Content-Type: application/json\r\n\
+                    Content-Length: 13\r\n\
+                    \r\n\
+                    {\"hello\":1}\r\n";
+        let mut reader = make_reader(raw);
+        let req = read_http_request(&mut reader).await.unwrap().expect("request present");
+        assert_eq!(req.method, "POST");
+        assert_eq!(req.target, "/v1/chat/completions");
+        assert_eq!(req.version, "HTTP/1.1");
+        assert_eq!(req.header("host"), Some("api.openai.com"));
+        assert_eq!(req.body.len(), 13);
+        assert_eq!(&req.body, b"{\"hello\":1}\r\n");
+    }
+
+    #[tokio::test]
+    async fn parses_get_with_no_body() {
+        let raw = b"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n";
+        let mut reader = make_reader(raw);
+        let req = read_http_request(&mut reader).await.unwrap().expect("request present");
+        assert_eq!(req.method, "GET");
+        assert!(req.body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn returns_none_on_clean_eof() {
+        let mut reader = make_reader(b"");
+        let req = read_http_request(&mut reader).await.unwrap();
+        assert!(req.is_none(), "EOF before request line must return None");
+    }
+
+    #[tokio::test]
+    async fn header_lookup_is_case_insensitive() {
+        let raw = b"GET / HTTP/1.1\r\nX-Custom: v\r\n\r\n";
+        let mut reader = make_reader(raw);
+        let req = read_http_request(&mut reader).await.unwrap().unwrap();
+        assert_eq!(req.header("x-custom"), Some("v"));
+        assert_eq!(req.header("X-CUSTOM"), Some("v"));
+    }
+}

--- a/aa-proxy/src/proxy/http.rs
+++ b/aa-proxy/src/proxy/http.rs
@@ -104,6 +104,38 @@ where
     }))
 }
 
+/// Re-serialise an [`HttpRequest`] with a replacement body, rewriting the
+/// `Content-Length` header to match the new body length.
+///
+/// All other headers are emitted verbatim in their original order; any
+/// existing `Content-Length` header is dropped and re-appended with the
+/// new value so the upstream sees one — and only one — accurate length.
+/// `Transfer-Encoding` is stripped to keep the framing unambiguous.
+pub fn serialize_http_request(req: &HttpRequest, new_body: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(req.body.len() + new_body.len() + 256);
+    out.extend_from_slice(req.method.as_bytes());
+    out.push(b' ');
+    out.extend_from_slice(req.target.as_bytes());
+    out.push(b' ');
+    out.extend_from_slice(req.version.as_bytes());
+    out.extend_from_slice(b"\r\n");
+
+    for (k, v) in &req.headers {
+        if k.eq_ignore_ascii_case("content-length") || k.eq_ignore_ascii_case("transfer-encoding") {
+            continue;
+        }
+        out.extend_from_slice(k.as_bytes());
+        out.extend_from_slice(b": ");
+        out.extend_from_slice(v.as_bytes());
+        out.extend_from_slice(b"\r\n");
+    }
+    out.extend_from_slice(b"Content-Length: ");
+    out.extend_from_slice(new_body.len().to_string().as_bytes());
+    out.extend_from_slice(b"\r\n\r\n");
+    out.extend_from_slice(new_body);
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -154,5 +186,47 @@ mod tests {
         let req = read_http_request(&mut reader).await.unwrap().unwrap();
         assert_eq!(req.header("x-custom"), Some("v"));
         assert_eq!(req.header("X-CUSTOM"), Some("v"));
+    }
+
+    #[tokio::test]
+    async fn serialize_rewrites_content_length_for_smaller_body() {
+        let raw = b"POST /v1/chat/completions HTTP/1.1\r\n\
+                    Host: api.openai.com\r\n\
+                    Content-Type: application/json\r\n\
+                    Content-Length: 20\r\n\
+                    \r\n\
+                    01234567890123456789";
+        let mut reader = make_reader(raw);
+        let req = read_http_request(&mut reader).await.unwrap().unwrap();
+
+        let new_body = b"short";
+        let wire = serialize_http_request(&req, new_body);
+        let text = std::str::from_utf8(&wire).unwrap();
+
+        assert!(text.starts_with("POST /v1/chat/completions HTTP/1.1\r\n"));
+        assert!(text.contains("Host: api.openai.com\r\n"));
+        assert!(text.contains("Content-Type: application/json\r\n"));
+        // Old length is dropped; only the new value appears, exactly once.
+        assert_eq!(text.matches("Content-Length: 5\r\n").count(), 1);
+        assert!(!text.contains("Content-Length: 20"));
+        // Body is the new bytes after the blank line.
+        assert!(text.ends_with("\r\n\r\nshort"));
+    }
+
+    #[tokio::test]
+    async fn serialize_drops_transfer_encoding_header() {
+        let raw = b"POST / HTTP/1.1\r\n\
+                    Host: x.example.com\r\n\
+                    Transfer-Encoding: chunked\r\n\
+                    \r\n";
+        let mut reader = make_reader(raw);
+        let req = read_http_request(&mut reader).await.unwrap().unwrap();
+        let wire = serialize_http_request(&req, b"hi");
+        let text = std::str::from_utf8(&wire).unwrap();
+        assert!(
+            !text.to_ascii_lowercase().contains("transfer-encoding"),
+            "serialized request must drop Transfer-Encoding when replacing body, got: {text}",
+        );
+        assert!(text.contains("Content-Length: 2\r\n"));
     }
 }

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -191,12 +191,19 @@ impl ProxyServer {
     }
 
     /// Dial the upstream TLS endpoint (TCP connect + ClientHello).
+    ///
+    /// Honours [`ProxyConfig::upstream_override`] when set — used by
+    /// integration tests to redirect the dial to a local mock without
+    /// hijacking DNS or modifying the client's CONNECT line.
     async fn dial_upstream_tls(
         self: &Arc<Self>,
         host: &str,
         target: &str,
     ) -> Result<tokio_rustls::client::TlsStream<TcpStream>, ProxyError> {
-        let upstream_tcp = TcpStream::connect(target).await?;
+        let upstream_tcp = match self.config.upstream_override {
+            Some(addr) => TcpStream::connect(addr).await?,
+            None => TcpStream::connect(target).await?,
+        };
         let client_config = if self.config.skip_upstream_tls_verify {
             // Integration-test-only path: skip certificate verification so tests
             // can use self-signed upstream servers without installing their CAs.

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -3,6 +3,8 @@
 //! `ProxyServer` owns the bound TCP listener, the TLS context (CA + cert cache),
 //! and the interceptor. It is the top-level runtime object of the proxy.
 
+pub mod http;
+
 use std::sync::Arc;
 use std::time::SystemTime;
 

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -22,7 +22,8 @@ use crate::config::ProxyConfig;
 use crate::error::ProxyError;
 use crate::intercept::detect::{detect_api, LlmApiPattern};
 use crate::intercept::event::ProxyEvent;
-use crate::intercept::Interceptor;
+use crate::intercept::{Interceptor, VerdictDecision};
+use crate::proxy::http::{read_http_request, serialize_http_request};
 use crate::tls::{CaStore, CertCache};
 
 /// A TLS `ServerCertVerifier` that accepts any certificate.
@@ -134,6 +135,40 @@ impl ProxyServer {
         Ok(())
     }
 
+    /// Dial the upstream TLS endpoint (TCP connect + ClientHello).
+    async fn dial_upstream_tls(
+        self: &Arc<Self>,
+        host: &str,
+        target: &str,
+    ) -> Result<tokio_rustls::client::TlsStream<TcpStream>, ProxyError> {
+        let upstream_tcp = TcpStream::connect(target).await?;
+        let client_config = if self.config.skip_upstream_tls_verify {
+            // Integration-test-only path: skip certificate verification so tests
+            // can use self-signed upstream servers without installing their CAs.
+            rustls::ClientConfig::builder()
+                .dangerous()
+                .with_custom_certificate_verifier(Arc::new(NoCertVerifier))
+                .with_no_client_auth()
+        } else {
+            let mut root_store = rustls::RootCertStore::empty();
+            let native = rustls_native_certs::load_native_certs();
+            for cert in native.certs {
+                let _ = root_store.add(cert);
+            }
+            rustls::ClientConfig::builder()
+                .with_root_certificates(root_store)
+                .with_no_client_auth()
+        };
+        let connector = TlsConnector::from(Arc::new(client_config));
+        let server_name = ServerName::try_from(host.to_string()).map_err(|e| ProxyError::Tls(e.to_string()))?;
+        let upstream_tls = connector
+            .connect(server_name, upstream_tcp)
+            .await
+            .map_err(|e| ProxyError::Tls(e.to_string()))?;
+        tracing::debug!(%host, "upstream TLS handshake complete");
+        Ok(upstream_tls)
+    }
+
     /// Handle a single accepted TCP connection.
     ///
     /// Reads the first HTTP request line to determine whether this is a
@@ -218,50 +253,84 @@ impl ProxyServer {
                 .await
                 .map_err(|e| ProxyError::Tls(e.to_string()))?;
 
-            // --- TLS client: connect to the real upstream ---
-            let upstream_tcp = TcpStream::connect(target).await?;
-            let client_config = if self.config.skip_upstream_tls_verify {
-                // Integration-test-only path: skip certificate verification so tests
-                // can use self-signed upstream servers without installing their CAs.
-                rustls::ClientConfig::builder()
-                    .dangerous()
-                    .with_custom_certificate_verifier(Arc::new(NoCertVerifier))
-                    .with_no_client_auth()
-            } else {
-                let mut root_store = rustls::RootCertStore::empty();
-                let native = rustls_native_certs::load_native_certs();
-                for cert in native.certs {
-                    let _ = root_store.add(cert);
-                }
-                rustls::ClientConfig::builder()
-                    .with_root_certificates(root_store)
-                    .with_no_client_auth()
-            };
-            let connector = TlsConnector::from(Arc::new(client_config));
-            let server_name = ServerName::try_from(host.to_string()).map_err(|e| ProxyError::Tls(e.to_string()))?;
-            let upstream_tls = connector
-                .connect(server_name, upstream_tcp)
-                .await
-                .map_err(|e| ProxyError::Tls(e.to_string()))?;
+            tracing::debug!(%host, "TLS MitM (client side) handshake complete");
 
-            tracing::debug!(%host, "TLS MitM handshake complete");
-
-            // Emit interception event for this tunnelled connection.
             let pattern = detect_api(host);
+
+            // For LLM patterns, read the inbound HTTP request inside the
+            // tunnel so the credential scanner can run against the real
+            // body bytes before any byte reaches upstream. For non-LLM
+            // patterns we fall through to a raw bidirectional copy below.
             if pattern != LlmApiPattern::Unknown {
+                let mut client_reader = BufReader::new(client_tls);
+                let Some(req) = read_http_request(&mut client_reader).await? else {
+                    // Client closed without sending a request line — nothing
+                    // to do, just return cleanly.
+                    return Ok(());
+                };
+
+                let verdict = self
+                    .interceptor
+                    .intercept_request(&req.body, self.config.credential_action);
+
+                // Emit the legacy ProxyEvent for the audit broadcast — keeps
+                // existing subscribers wired up unchanged.
                 let event = ProxyEvent {
                     agent_id: None,
                     pattern,
-                    method: "CONNECT".into(),
-                    path: format!("tunnel to {target}"),
-                    request_body: None,
+                    method: req.method.clone(),
+                    path: req.target.clone(),
+                    request_body: Some(bytes::Bytes::copy_from_slice(&req.body)),
                     response_body: None,
                     timestamp: SystemTime::now(),
                 };
                 self.interceptor.intercept(&event).await?;
+
+                if verdict.decision == VerdictDecision::Block {
+                    tracing::info!(
+                        %host,
+                        findings = verdict.findings.len(),
+                        "credential_action=Block: refusing forward, returning 403",
+                    );
+                    let mut client_tls = client_reader.into_inner();
+                    client_tls
+                        .write_all(b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n")
+                        .await?;
+                    let _ = client_tls.shutdown().await;
+                    return Ok(());
+                }
+
+                // Dial upstream only after we have decided not to block.
+                let upstream_tls = self.dial_upstream_tls(host, target).await?;
+
+                let outgoing_bytes = match verdict.decision {
+                    VerdictDecision::ForwardRedacted => {
+                        let body = verdict
+                            .redacted_body
+                            .as_deref()
+                            .expect("ForwardRedacted always carries redacted_body");
+                        serialize_http_request(&req, body)
+                    }
+                    _ => serialize_http_request(&req, &req.body),
+                };
+
+                let (mut client_read, mut client_write) = tokio::io::split(client_reader.into_inner());
+                let (mut upstream_read, mut upstream_write) = tokio::io::split(upstream_tls);
+
+                upstream_write.write_all(&outgoing_bytes).await?;
+
+                let client_to_upstream = tokio::io::copy(&mut client_read, &mut upstream_write);
+                let upstream_to_client = tokio::io::copy(&mut upstream_read, &mut client_write);
+
+                tokio::select! {
+                    r = client_to_upstream => { r?; }
+                    r = upstream_to_client => { r?; }
+                }
+                return Ok(());
             }
 
-            // Bidirectional copy between client and upstream.
+            // Non-LLM pattern: raw bidirectional copy (no body inspection).
+            let upstream_tls = self.dial_upstream_tls(host, target).await?;
             let (mut client_read, mut client_write) = tokio::io::split(client_tls);
             let (mut upstream_read, mut upstream_write) = tokio::io::split(upstream_tls);
 

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -6,24 +6,25 @@
 pub mod http;
 
 use std::sync::Arc;
-use std::time::SystemTime;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName, UnixTime};
 use rustls::{DigitallySignedStruct, ServerConfig, SignatureScheme};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, mpsc};
 use tokio_rustls::{TlsAcceptor, TlsConnector};
 
 use aa_runtime::pipeline::PipelineEvent;
 
+use crate::audit_jsonl::{ProxyAuditDecision, ProxyAuditEntry};
 use crate::config::ProxyConfig;
 use crate::error::ProxyError;
 use crate::intercept::detect::{detect_api, LlmApiPattern};
 use crate::intercept::event::ProxyEvent;
-use crate::intercept::{Interceptor, VerdictDecision};
-use crate::proxy::http::{read_http_request, serialize_http_request};
+use crate::intercept::{InterceptVerdict, Interceptor, VerdictDecision};
+use crate::proxy::http::{read_http_request, serialize_http_request, HttpRequest};
 use crate::tls::{CaStore, CertCache};
 
 /// A TLS `ServerCertVerifier` that accepts any certificate.
@@ -81,18 +82,36 @@ pub struct ProxyServer {
     ca: CaStore,
     certs: CertCache,
     interceptor: Interceptor,
+    /// Optional sink for [`ProxyAuditEntry`] records. When `Some`, the data
+    /// path emits one entry per intercepted LLM request that carried
+    /// credential findings (or that was blocked under `Block` policy).
+    /// `None` means no JSONL persistence — useful for unit tests that only
+    /// observe the broadcast event stream.
+    audit_jsonl_tx: Option<mpsc::Sender<ProxyAuditEntry>>,
 }
 
 impl ProxyServer {
-    /// Construct a `ProxyServer` from a validated config, an initialised CA,
-    /// and a broadcast sender for emitting pipeline events.
+    /// Construct a `ProxyServer` without a JSONL audit sink. The legacy
+    /// pipeline-event broadcast still fires.
     pub fn new(config: ProxyConfig, ca: CaStore, event_tx: broadcast::Sender<PipelineEvent>) -> Arc<Self> {
+        Self::new_with_audit_sink(config, ca, event_tx, None)
+    }
+
+    /// Construct a `ProxyServer` that also persists `ProxyAuditEntry`
+    /// records on `audit_jsonl_tx` (typically owned by a [`crate::audit_jsonl::JsonlWriter`]).
+    pub fn new_with_audit_sink(
+        config: ProxyConfig,
+        ca: CaStore,
+        event_tx: broadcast::Sender<PipelineEvent>,
+        audit_jsonl_tx: Option<mpsc::Sender<ProxyAuditEntry>>,
+    ) -> Arc<Self> {
         let certs = CertCache::new(config.cert_cache_capacity);
         Arc::new(Self {
             config,
             ca,
             certs,
             interceptor: Interceptor::new(event_tx),
+            audit_jsonl_tx,
         })
     }
 
@@ -133,6 +152,42 @@ impl ProxyServer {
         }
 
         Ok(())
+    }
+
+    /// Build and dispatch a [`ProxyAuditEntry`] over the configured sink.
+    ///
+    /// No-op when `audit_jsonl_tx` is `None`. `try_send` is intentional —
+    /// a slow JSONL writer must not stall the data path; a dropped entry
+    /// is preferable to back-pressuring the proxy.
+    async fn emit_audit_entry(
+        self: &Arc<Self>,
+        host: &str,
+        req: &HttpRequest,
+        verdict: &InterceptVerdict,
+        decision: ProxyAuditDecision,
+    ) {
+        let Some(tx) = self.audit_jsonl_tx.as_ref() else { return };
+        let ts_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+        let redacted_body = verdict
+            .redacted_body
+            .as_ref()
+            .and_then(|b| std::str::from_utf8(b).ok().map(|s| s.to_owned()));
+        let entry = ProxyAuditEntry {
+            ts_ms,
+            agent_id: None,
+            host: host.to_owned(),
+            method: req.method.clone(),
+            path: req.target.clone(),
+            decision,
+            credential_findings: verdict.findings.clone(),
+            redacted_body,
+        };
+        if let Err(e) = tx.try_send(entry) {
+            tracing::warn!(error = %e, "proxy audit jsonl channel full or closed, dropping entry");
+        }
     }
 
     /// Dial the upstream TLS endpoint (TCP connect + ClientHello).
@@ -292,6 +347,8 @@ impl ProxyServer {
                         findings = verdict.findings.len(),
                         "credential_action=Block: refusing forward, returning 403",
                     );
+                    self.emit_audit_entry(host, &req, &verdict, ProxyAuditDecision::Blocked)
+                        .await;
                     let mut client_tls = client_reader.into_inner();
                     client_tls
                         .write_all(b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n")
@@ -309,7 +366,18 @@ impl ProxyServer {
                             .redacted_body
                             .as_deref()
                             .expect("ForwardRedacted always carries redacted_body");
-                        serialize_http_request(&req, body)
+                        let bytes = serialize_http_request(&req, body);
+                        self.emit_audit_entry(host, &req, &verdict, ProxyAuditDecision::ForwardedRedacted)
+                            .await;
+                        bytes
+                    }
+                    VerdictDecision::AlertAndForward => {
+                        let bytes = serialize_http_request(&req, &req.body);
+                        // Emit an audit entry so operators can see the alert-mode
+                        // decision (findings are still recorded, body is not).
+                        self.emit_audit_entry(host, &req, &verdict, ProxyAuditDecision::Forwarded)
+                            .await;
+                        bytes
                     }
                     _ => serialize_http_request(&req, &req.body),
                 };

--- a/aa-proxy/tests/proxy_integration.rs
+++ b/aa-proxy/tests/proxy_integration.rs
@@ -21,6 +21,7 @@ fn test_config(ca_dir: &std::path::Path) -> ProxyConfig {
         denied_hosts: Vec::new(),
         skip_upstream_tls_verify: false,
         credential_action: CredentialAction::default(),
+        upstream_override: None,
     }
 }
 

--- a/aa-proxy/tests/proxy_integration.rs
+++ b/aa-proxy/tests/proxy_integration.rs
@@ -7,7 +7,7 @@ use tokio::net::{TcpListener, TcpStream};
 
 use tokio::sync::broadcast;
 
-use aa_proxy::config::ProxyConfig;
+use aa_proxy::config::{CredentialAction, ProxyConfig};
 use aa_proxy::tls::CaStore;
 use aa_runtime::pipeline::PipelineEvent;
 
@@ -20,6 +20,7 @@ fn test_config(ca_dir: &std::path::Path) -> ProxyConfig {
         llm_only: false,
         denied_hosts: Vec::new(),
         skip_upstream_tls_verify: false,
+        credential_action: CredentialAction::default(),
     }
 }
 


### PR DESCRIPTION
## Description

Wires `CredentialAction` (`Block | RedactOnly | AlertOnly`) into the **aa-proxy data path** so the proxy can now inspect, redact, or refuse HTTP request bodies inside its MitM TLS tunnel — closing the gap left by AAASM-1549 (ST-N detection slice).

Before this PR, the proxy's MitM data plane was a raw `tokio::io::copy` between client and upstream — no body parsing, no redaction, no credential_action enforcement. After this PR, for any host detected as an LLM API (`api.openai.com`, `api.anthropic.com`, `api.cohere.com`), the proxy:

1. Parses the inbound HTTP/1.1 request inside the TLS tunnel.
2. Runs the existing `CredentialScanner` against the real request body.
3. Branches on `ProxyConfig.credential_action`:
    * **Block** → write `403 Forbidden` to the client TLS, never dial upstream.
    * **RedactOnly** → forward the body with secrets replaced by `[REDACTED:<Kind>]` placeholders (Content-Length rewritten).
    * **AlertOnly** → forward unmodified; alert side-effect.
4. Emits a `ProxyAuditEntry` (carrying `credential_findings`) into a new JSONL audit pipeline; the raw secret never reaches disk.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

`ProxyConfig` gains three additive fields (`credential_action`, `upstream_override`, and the audit sink is set via a new `new_with_audit_sink` constructor — the legacy `new()` still works). All existing call sites updated explicitly.

## Related Issues

- Related Jira ticket: [AAASM-1566](https://lightning-dust-mite.atlassian.net/browse/AAASM-1566)
- Parent Story: [AAASM-1232](https://lightning-dust-mite.atlassian.net/browse/AAASM-1232) — F116 MVP acceptance test
- Sibling: [AAASM-1549](https://lightning-dust-mite.atlassian.net/browse/AAASM-1549) — ST-N detection slice
- Prereq landed: [AAASM-1546](https://lightning-dust-mite.atlassian.net/browse/AAASM-1546) (`CredentialAction` enum in aa-gateway), [AAASM-1547](https://lightning-dust-mite.atlassian.net/browse/AAASM-1547) (`MockLlmServer` fixture)

## Testing

Three new end-to-end integration tests in `aa-integration-tests/tests/e2e_secret_interception.rs::proxy_data_path` exercise the full data path (real `ProxyServer` + TLS-terminating capture upstream + TLS client):

| AC test | Status |
|---|---|
| `proxy_aws_key_in_body_redacted_before_forwarding` | ✅ |
| `proxy_secret_block_policy_prevents_forwarding` | ✅ |
| `proxy_secret_redact_only_credential_findings_in_audit` | ✅ |

Plus 11 new unit tests across `aa-proxy/src/`:
- 4 env-var parsing tests in `config::tests`
- 1 security-invariant test in `audit_jsonl::tests`
- 6 HTTP request parser/serializer tests in `proxy::http::tests`

No regressions: 77/77 existing aa-proxy tests still pass, including the ST-E proxy policy deny tests (`e2e_policy_proxy.rs`) and the ST-N detection slice (`e2e_secret_interception.rs::proxy_path`).

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] Manual testing performed (full `cargo nextest run -p aa-proxy` + targeted integration suites locally)
- [ ] No tests required (explain why)

## Commit decomposition

18 small commits, one logical unit each — follows the project's small-commit policy. Each commit is independently bisectable.

**Config (4 commits)** — `CredentialAction` enum, `credential_action` field on `ProxyConfig`, env-var parsing, unit tests.

**Audit JSONL (3 commits)** — `ProxyAuditEntry` struct, `JsonlWriter`, raw-secret-absence security test.

**Interceptor (1 commit)** — `InterceptVerdict { decision, findings, redacted_body }` + `intercept_request()`.

**HTTP marshalling (2 commits)** — `read_http_request()` parser, `serialize_http_request()` re-serializer with Content-Length rewrite.

**Data path (2 commits)** — replace raw `tokio::io::copy` with credential_action-aware flow, emit `ProxyAuditEntry` with `credential_findings`.

**Test infrastructure (1 commit)** — `upstream_override` test knob on `ProxyConfig` to redirect dials to a local mock without hijacking DNS.

**Fixtures (2 commits)** — `secret_block.yaml`, `secret_redact_only.yaml`.

**E2E (3 commits)** — one commit per AC test.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (all new types/fns documented; new `upstream_override` and `credential_action` fields documented inline on `ProxyConfig`)
- [x] All CI checks passing (lefthook fmt + clippy + deny + doc all green per commit)
- [x] Commits are small and follow the Gitmoji convention

[AAASM-1566]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ