### PR TITLE
[AAASM-1601] ✅ (aa-integration-tests): Binary gateway spawn + audit-chain restart fixture

### DIFF
--- a/aa-gateway/src/main.rs
+++ b/aa-gateway/src/main.rs
@@ -74,6 +74,13 @@ struct Cli {
     /// Unix domain socket path. When set, takes precedence over --listen.
     #[arg(long)]
     socket: Option<PathBuf>,
+
+    /// Audit log directory. Equivalent to setting the `AA_AUDIT_DIR`
+    /// environment variable; primarily intended for integration test
+    /// isolation (AAASM-1601). Falls back to `dirs::data_dir()/aa/audit`
+    /// when neither the flag nor the env var is set.
+    #[arg(long)]
+    audit_dir: Option<PathBuf>,
 }
 
 #[tokio::main]
@@ -83,6 +90,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .init();
 
     let cli = Cli::parse();
+
+    // `--audit-dir` is a thin alias for the env var so the spawned
+    // gateway picks it up through `default_audit_dir()` (AAASM-1601).
+    if let Some(ref dir) = cli.audit_dir {
+        std::env::set_var("AA_AUDIT_DIR", dir);
+    }
 
     let mode = resolve_mode(cli.mode, |k| std::env::var(k).ok())?;
 

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -31,8 +31,21 @@ use crate::budget::persistence::{default_budget_path, load_from_disk, save_to_di
 use crate::budget::{BudgetAlert, BudgetTracker};
 use tokio_util::sync::CancellationToken;
 
-/// Default audit directory relative to the system data directory (`~/.aa/audit`).
+/// Default audit directory.
+///
+/// Resolves in this order:
+/// 1. `AA_AUDIT_DIR` environment variable, when set (used by integration
+///    tests that need per-test audit isolation — AAASM-1601).
+/// 2. `dirs::data_dir()/aa/audit` (e.g. `~/.local/share/aa/audit` on
+///    Linux, `~/Library/Application Support/aa/audit` on macOS).
+/// 3. `./aa/audit` if neither the env var nor a system data dir is
+///    available.
 fn default_audit_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("AA_AUDIT_DIR") {
+        if !dir.is_empty() {
+            return PathBuf::from(dir);
+        }
+    }
     dirs::data_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join("aa")

--- a/aa-integration-tests/tests/common/binary_gateway.rs
+++ b/aa-integration-tests/tests/common/binary_gateway.rs
@@ -17,8 +17,6 @@
 //!    introduced under AAASM-1601) redirects the audit JSONL to a
 //!    per-test directory so multiple tests don't clobber each other.
 
-#![allow(dead_code)]
-
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};

--- a/aa-integration-tests/tests/common/binary_gateway.rs
+++ b/aa-integration-tests/tests/common/binary_gateway.rs
@@ -1,0 +1,168 @@
+//! Out-of-process gateway fixture for tests that need a real
+//! `aa-gateway` binary (e.g. AAASM-1601's
+//! `audit_chain_survives_gateway_restart`).
+//!
+//! Unlike `TopologyTestEnv` (which boots an in-process Axum router for
+//! the HTTP plane), `BinaryGateway` spawns the actual `aa-gateway` Rust
+//! binary so we can exercise process-boundary behaviours: hash-chain
+//! resumption via `AuditWriter::read_last_hash`, SIGTERM graceful
+//! drain, restart durability.
+//!
+//! Isolation is achieved via two environment hooks:
+//!
+//! 1. `HOME` is pointed at a per-test temp directory so the gateway's
+//!    SQLite-backed `local.storage_path` and `budget.json` land
+//!    outside the engineer's real `~/.aasm` / `~/.aa` dirs.
+//! 2. `AA_AUDIT_DIR` (or the equivalent `--audit-dir` CLI flag, also
+//!    introduced under AAASM-1601) redirects the audit JSONL to a
+//!    per-test directory so multiple tests don't clobber each other.
+
+#![allow(dead_code)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, Context, Result};
+
+/// Handle to a spawned `aa-gateway` subprocess.
+///
+/// The `Drop` impl unconditionally kills the child if it is still alive,
+/// so test panics never leave dangling gateways. For clean shutdown
+/// (e.g. between spawn / respawn cycles), call
+/// [`Self::sigterm_and_wait`] explicitly.
+pub struct BinaryGateway {
+    child: Option<Child>,
+    listen_addr: String,
+    audit_dir: PathBuf,
+    home_dir: PathBuf,
+    policy_path: PathBuf,
+}
+
+impl BinaryGateway {
+    /// Spawn `aa-gateway --policy ... --listen ... --audit-dir ...`
+    /// with `HOME` and `AA_AUDIT_DIR` pointed at the supplied per-test
+    /// temp directories, then wait until the gRPC listener accepts a
+    /// TCP connection (≤ 30 s).
+    pub fn spawn(audit_dir: PathBuf, home_dir: PathBuf, policy_path: PathBuf, listen_addr: String) -> Result<Self> {
+        let bin = locate_gateway_binary().context("locating aa-gateway binary for BinaryGateway::spawn")?;
+        let child = Command::new(&bin)
+            .arg("--policy")
+            .arg(&policy_path)
+            .arg("--listen")
+            .arg(&listen_addr)
+            .arg("--audit-dir")
+            .arg(&audit_dir)
+            .env("HOME", &home_dir)
+            .env("AA_AUDIT_DIR", &audit_dir)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .with_context(|| format!("spawning {} failed", bin.display()))?;
+        let gw = Self {
+            child: Some(child),
+            listen_addr,
+            audit_dir,
+            home_dir,
+            policy_path,
+        };
+        gw.await_ready(Duration::from_secs(30))?;
+        Ok(gw)
+    }
+
+    /// Return the TCP listen address (`"127.0.0.1:<port>"`).
+    pub fn listen_addr(&self) -> &str {
+        &self.listen_addr
+    }
+
+    /// Return the configured audit directory.
+    pub fn audit_dir(&self) -> &Path {
+        &self.audit_dir
+    }
+
+    /// Process ID of the live child, if any.
+    pub fn pid(&self) -> Option<u32> {
+        self.child.as_ref().map(|c| c.id())
+    }
+
+    fn await_ready(&self, timeout: Duration) -> Result<()> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if std::net::TcpStream::connect_timeout(
+                &self.listen_addr.parse().context("parsing listen addr")?,
+                Duration::from_millis(200),
+            )
+            .is_ok()
+            {
+                return Ok(());
+            }
+            if Instant::now() > deadline {
+                return Err(anyhow!(
+                    "aa-gateway at {} did not start accepting connections within {timeout:?}",
+                    self.listen_addr,
+                ));
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+}
+
+impl Drop for BinaryGateway {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            // Try a graceful kill (SIGKILL via std), then reap — never
+            // panic in Drop so test failures still produce a clean
+            // teardown.
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+/// Locate the `aa-gateway` binary on disk.
+///
+/// Looks in this order: `target/debug/aa-gateway`, `target/release/aa-gateway`
+/// (resolved relative to the current `CARGO_MANIFEST_DIR`'s workspace root),
+/// `$PATH`, `$HOME/.cargo/bin/aa-gateway`. Returns an error when nothing is
+/// found so the test can either skip or trigger a `cargo build -p aa-gateway`.
+fn locate_gateway_binary() -> Result<PathBuf> {
+    // Workspace target dir first — this is what `cargo nextest run --workspace`
+    // produces and matches the CI Integration tests job's layout.
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").context("CARGO_MANIFEST_DIR not set")?;
+    let workspace_root = Path::new(&manifest).parent().context("manifest has no parent")?;
+    for profile in ["debug", "release"] {
+        let candidate = workspace_root.join("target").join(profile).join("aa-gateway");
+        if is_executable(&candidate) {
+            return Ok(candidate);
+        }
+    }
+    // `$PATH` fallback (used by engineers who `cargo install`-ed the binary).
+    if let Ok(path_var) = std::env::var("PATH") {
+        for dir in path_var.split(':') {
+            let candidate = Path::new(dir).join("aa-gateway");
+            if is_executable(&candidate) {
+                return Ok(candidate);
+            }
+        }
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        let candidate = PathBuf::from(home).join(".cargo").join("bin").join("aa-gateway");
+        if is_executable(&candidate) {
+            return Ok(candidate);
+        }
+    }
+    Err(anyhow!(
+        "aa-gateway binary not found — run `cargo build -p aa-gateway` first or include it in CI's build step"
+    ))
+}
+
+#[cfg(unix)]
+fn is_executable(path: &Path) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+    path.metadata().is_ok_and(|m| m.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(not(unix))]
+fn is_executable(path: &Path) -> bool {
+    path.exists()
+}

--- a/aa-integration-tests/tests/common/binary_gateway.rs
+++ b/aa-integration-tests/tests/common/binary_gateway.rs
@@ -85,6 +85,51 @@ impl BinaryGateway {
         self.child.as_ref().map(|c| c.id())
     }
 
+    /// Send `SIGTERM` to the child and wait for graceful exit (≤ `timeout`).
+    ///
+    /// Hard-kills the child via `Child::kill()` if it has not exited
+    /// within the timeout — prevents the test from hanging when the
+    /// gateway gets stuck in a shutdown handler. Returns an error in
+    /// the hard-kill case so the test can decide whether to fail.
+    ///
+    /// On non-Unix platforms (effectively only Windows) falls back to
+    /// the std `Child::kill()` non-graceful path; the audit-chain
+    /// scenario this fixture exists for runs on Linux + macOS only.
+    pub fn sigterm_and_wait(&mut self, timeout: Duration) -> Result<()> {
+        let Some(mut child) = self.child.take() else {
+            return Ok(());
+        };
+        #[cfg(unix)]
+        {
+            let pid = child.id();
+            // SAFETY: `pid` is a valid PID we own — std::process::Child guarantees
+            // it has not been reaped yet (Self::take() is exclusive).
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGTERM);
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = child.kill();
+        }
+        let deadline = Instant::now() + timeout;
+        loop {
+            match child.try_wait()? {
+                Some(_status) => return Ok(()),
+                None => {
+                    if Instant::now() > deadline {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        return Err(anyhow!(
+                            "aa-gateway did not exit within {timeout:?} of SIGTERM; SIGKILL'd as a safety net",
+                        ));
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+            }
+        }
+    }
+
     fn await_ready(&self, timeout: Duration) -> Result<()> {
         let deadline = Instant::now() + timeout;
         loop {

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -21,6 +21,8 @@
 //! policy enforcement. Module-level docs in [`mock_llm`] cover usage.
 
 #[allow(dead_code)]
+pub mod binary_gateway;
+#[allow(dead_code)]
 pub mod cli;
 #[allow(dead_code)]
 pub mod format;

--- a/aa-integration-tests/tests/e2e_audit.rs
+++ b/aa-integration-tests/tests/e2e_audit.rs
@@ -13,11 +13,13 @@
 //! | 4 | `audit_entries_are_in_chronological_order` | enabled |
 //! | 5 | `audit_hash_chain_validates_against_known_good` | enabled |
 //! | 6 | `audit_chain_break_detected_when_entry_modified` | enabled |
-//! | 7 | `audit_chain_survives_gateway_restart` | `#[ignore]` — requires binary spawn |
+//! | 7 | `audit_chain_survives_gateway_restart` | enabled via `BinaryGateway` (AAASM-1601) |
 //!
 //! Tests 1-2 are scaffolded with `#[ignore]` pending AAASM-237 (the HTTP path
-//! in `aa-api` does not yet wire `AuditWriter` into handlers). Test 7 requires
-//! a binary gateway spawn + SIGTERM/restart fixture not yet available.
+//! in `aa-api` does not yet wire `AuditWriter` into handlers). Test 7 spawns
+//! the real `aa-gateway` binary via `common::binary_gateway::BinaryGateway`
+//! (AAASM-1601) and verifies the JSONL hash chain remains intact across a
+//! SIGTERM + respawn cycle.
 
 mod common;
 
@@ -241,17 +243,148 @@ async fn audit_chain_break_detected_when_entry_modified() {
 }
 
 // =============================================================================
-// Test 7 — restart persistence (blocked)
+// Test 7 — restart persistence (AAASM-1601)
 // =============================================================================
 
-/// After a gateway restart the chain must still validate: `AuditWriter`
-/// resumes from `read_last_hash` so the chain links across the restart
-/// boundary without a gap.
+/// After an `aa-gateway` process restart the chain must still validate:
+/// `AuditWriter::new` resumes from `read_last_hash` so the chain links
+/// across the restart boundary without a gap.
 ///
-/// Blocked: requires spawning the `aa-gateway` binary, sending SIGTERM, and
-/// restarting — infrastructure not yet available in the integration harness.
+/// Verifies that:
+/// 1. A spawned `aa-gateway` binary, given a pre-seeded JSONL file,
+///    boots cleanly and does **not** truncate or corrupt the file.
+/// 2. The post-spawn `read_last_hash` returns the expected hash from
+///    the seeded entries (the gateway picks up where the seed left off).
+/// 3. SIGTERM produces a clean shutdown.
+/// 4. A second spawn against the **same** audit dir replays
+///    `read_last_hash` correctly.
+/// 5. Final `verify_chain` shows an unbroken chain.
+///
+/// What this test does **not** yet exercise: gateway-internal audit
+/// writes between the spawns. The HTTP path is not yet wired into
+/// `AuditWriter` (AAASM-237); once that lands, this test should be
+/// extended to drive entries via the API between SIGTERM and respawn,
+/// then assert the new entries' `prev_hash` chains off the seed.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "blocked on AAASM-1601: binary gateway spawn + SIGTERM/restart test infrastructure not yet available"]
-async fn audit_chain_survives_gateway_restart() {
-    todo!("implement once binary-spawn harness is available")
+async fn audit_chain_survives_gateway_restart() -> anyhow::Result<()> {
+    use std::time::Duration;
+
+    use common::binary_gateway::BinaryGateway;
+
+    // Skip cleanly when the binary isn't on disk — matches the
+    // `cli_gateway.rs` pattern so engineers running just one test
+    // crate get a clear hint instead of a confusing failure.
+    if !workspace_gateway_binary_locatable() {
+        eprintln!("skip: aa-gateway binary not found — run `cargo build -p aa-gateway` first");
+        return Ok(());
+    }
+
+    // ── Setup: per-test temp dirs ───────────────────────────────────
+    let audit_tmp = tempdir()?;
+    let home_tmp = tempdir()?;
+    let policy_tmp = tempdir()?;
+
+    let audit_dir = audit_tmp.path().to_path_buf();
+    let home_dir = home_tmp.path().to_path_buf();
+    let policy_path = policy_tmp.path().join("policy.yaml");
+    std::fs::write(
+        &policy_path,
+        "apiVersion: agent-assembly.dev/v1alpha1\nkind: GovernancePolicy\nspec:\n  rules: []\n",
+    )?;
+
+    // ── Seed: 3 valid chained audit entries on disk. ────────────────
+    // The seeded path matches the gateway's `audit_file_path` convention
+    // (`{audit_dir}/{agent_id}-{session_id}.jsonl`) with `agent_id="gateway"`
+    // and `session_id="default"` per `setup_audit("gateway", "default", ...)`
+    // in `aa-gateway/src/server.rs`.
+    let audit_file = audit_dir.join("gateway-default.jsonl");
+    let seeded = make_chain(3);
+    write_jsonl(&audit_file, &seeded);
+    let seeded_last_hash = *seeded[2].entry_hash();
+
+    // ── Phase 1: spawn gateway 1, verify it doesn't corrupt the file ──
+    let listen1 = format!("127.0.0.1:{}", free_port());
+    let mut gw1 = BinaryGateway::spawn(
+        audit_dir.clone(),
+        home_dir.clone(),
+        policy_path.clone(),
+        listen1.clone(),
+    )
+    .map_err(|e| anyhow::anyhow!("spawning gateway 1: {e}"))?;
+
+    let observed_during_gw1 = AuditWriter::read_last_hash(&audit_file).await?.unwrap_or([0u8; 32]);
+    assert_eq!(
+        observed_during_gw1, seeded_last_hash,
+        "post-spawn last_hash must match the seed — gateway 1 must not corrupt the chain",
+    );
+
+    gw1.sigterm_and_wait(Duration::from_secs(10))
+        .map_err(|e| anyhow::anyhow!("SIGTERM gateway 1: {e}"))?;
+
+    // ── Phase 2: spawn gateway 2 on a different port, same audit dir ──
+    let listen2 = format!("127.0.0.1:{}", free_port());
+    let mut gw2 = BinaryGateway::spawn(audit_dir.clone(), home_dir.clone(), policy_path.clone(), listen2)
+        .map_err(|e| anyhow::anyhow!("spawning gateway 2: {e}"))?;
+
+    let observed_after_restart = AuditWriter::read_last_hash(&audit_file).await?.unwrap_or([0u8; 32]);
+    assert_eq!(
+        observed_after_restart, seeded_last_hash,
+        "post-restart last_hash must still match the seed — chain survives the SIGTERM + respawn boundary",
+    );
+
+    gw2.sigterm_and_wait(Duration::from_secs(10))
+        .map_err(|e| anyhow::anyhow!("SIGTERM gateway 2: {e}"))?;
+
+    // ── Phase 3: end-to-end chain validation ────────────────────────
+    let result = AuditWriter::verify_chain(&audit_file).await?;
+    assert!(
+        result.is_valid,
+        "chain must remain valid across spawn + SIGTERM + respawn + SIGTERM cycle; first_invalid = {:?}",
+        result.first_invalid,
+    );
+    Ok(())
+}
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind 127.0.0.1:0")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
+/// Mirror `binary_gateway::locate_gateway_binary`'s discovery contract so
+/// the test skips cleanly when the binary is absent (rather than panicking
+/// inside `BinaryGateway::spawn`).
+fn workspace_gateway_binary_locatable() -> bool {
+    #[cfg(unix)]
+    fn runnable(p: &Path) -> bool {
+        use std::os::unix::fs::PermissionsExt;
+        p.metadata().is_ok_and(|m| m.permissions().mode() & 0o111 != 0)
+    }
+    #[cfg(not(unix))]
+    fn runnable(p: &Path) -> bool {
+        p.exists()
+    }
+    let manifest = match std::env::var("CARGO_MANIFEST_DIR") {
+        Ok(d) => d,
+        Err(_) => return false,
+    };
+    let root = match Path::new(&manifest).parent() {
+        Some(r) => r,
+        None => return false,
+    };
+    for profile in ["debug", "release"] {
+        if runnable(&root.join("target").join(profile).join("aa-gateway")) {
+            return true;
+        }
+    }
+    if let Ok(path_var) = std::env::var("PATH") {
+        for d in path_var.split(':') {
+            if runnable(&Path::new(d).join("aa-gateway")) {
+                return true;
+            }
+        }
+    }
+    false
 }


### PR DESCRIPTION
## Description

Adds the test infrastructure required to un-ignore `audit_chain_survives_gateway_restart` in `aa-integration-tests/tests/e2e_audit.rs:254` — the only F116 ST-G test still gated on infrastructure (per the `#[ignore]` audit in AAASM-1241).

Two surfaces:

1. **Gateway-side, minimal**: `default_audit_dir()` now reads `AA_AUDIT_DIR` env var first; a new `--audit-dir <PATH>` CLI flag on `aa-gateway` sets that env var as an operator-facing alias. Default behaviour (no env, no flag) is unchanged — falls back to `dirs::data_dir()/aa/audit`.

2. **Test-side, new fixture**: `aa-integration-tests/tests/common/binary_gateway.rs` introduces `BinaryGateway`: a Drop-safe wrapper around a spawned `aa-gateway` subprocess that pins `HOME` + `AA_AUDIT_DIR` to per-test temp dirs, polls the TCP listener until ready, and exposes `sigterm_and_wait(timeout)` for graceful shutdown. Panics during a test never leave dangling gateway processes — Drop hard-kills the child if cleanup wasn't explicit.

The new test seeds 3 valid chain entries on disk, spawns gateway 1, asserts `read_last_hash` matches the seed, SIGTERMs, spawns gateway 2 on a different port, repeats the assertion, SIGTERMs, then runs end-to-end `verify_chain`.

What this PR does **not** address: gateway-internal audit writes (HTTP path → AuditWriter) — still gated on AAASM-237. Once that lands, the test should be extended to drive writes between the spawn boundaries and assert the new entries' `prev_hash` chains off the seed.

## Type of Change

- [x] ✨ New feature (test infrastructure + small CLI/env surface on `aa-gateway`)
- [x] ✅ Tests

## Breaking Changes

- [x] No

`AA_AUDIT_DIR` and `--audit-dir` are both opt-in; behaviour for callers who set neither is unchanged.

## Related Issues

- Related Jira ticket: AAASM-1601 (F116 ST-G follow-up under AAASM-1232)
- Parent verification ST: AAASM-1241
- Follow-up: AAASM-237 (HTTP path → AuditWriter wiring) — once it lands the test can be extended to verify gateway-side writes across the restart boundary.

## Testing

- [x] Integration tests added — un-ignored `audit_chain_survives_gateway_restart`; skip path (binary missing) mirrors `cli_gateway.rs::gateway_binary_available`.
- [x] `cargo build -p aa-gateway && cargo nextest run -p aa-integration-tests --test e2e_audit` → 5/5 enabled tests passed (2 still `#[ignore]`-pending-AAASM-237).
- [x] `cargo nextest run -p aa-gateway` → 1017/1017 passed.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed — rustdoc on `default_audit_dir`, `--audit-dir`, and the new `BinaryGateway` type; test header table refreshed.
- [x] All CI checks passing (pending push)
- [x] Commits are small and follow the Gitmoji convention (6 commits — see `git log master..HEAD`)