### PR TITLE
[AAASM-1922] 🐛 (aa-api): Align list_approvals response with OpenAPI contract

### DIFF
--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -145,6 +145,7 @@ use crate::routes::{
         policies::PolicyResponse,
         policies::CreatePolicyRequest,
         approvals::ApprovalResponse,
+        approvals::PaginatedApprovalResponse,
         approvals::DecideRequest,
         costs::CostSummary,
         costs::AgentCostEntry,

--- a/aa-api/src/routes/approvals.rs
+++ b/aa-api/src/routes/approvals.rs
@@ -11,7 +11,6 @@ use aa_runtime::approval::{ApprovalDecision, ApprovalError, ApprovalLookup, Pend
 use utoipa::IntoParams;
 
 use crate::error::ProblemDetail;
-use crate::pagination::PaginatedResponse;
 use crate::state::AppState;
 
 /// Query parameters for `GET /api/v1/approvals` (AAASM-1477).
@@ -195,7 +194,7 @@ fn resolved_to_response(r: ResolvedRecord) -> ApprovalResponse {
     path = "/api/v1/approvals",
     params(ListApprovalsParams),
     responses(
-        (status = 200, description = "Paginated list of approvals", body = Vec<ApprovalResponse>)
+        (status = 200, description = "Paginated list of approvals", body = PaginatedApprovalResponse)
     ),
     tag = "approvals"
 )]
@@ -237,7 +236,7 @@ pub async fn list_approvals(
 
     (
         StatusCode::OK,
-        Json(PaginatedResponse {
+        Json(PaginatedApprovalResponse {
             items,
             page: params.page(),
             per_page: params.per_page(),

--- a/aa-api/src/routes/approvals.rs
+++ b/aa-api/src/routes/approvals.rs
@@ -393,3 +393,26 @@ pub struct DecideRequest {
     /// Optional reason for the decision.
     pub reason: Option<String>,
 }
+
+/// Paginated wire-format envelope for `GET /api/v1/approvals`.
+///
+/// Mirrors the JSON shape produced by [`PaginatedResponse<ApprovalResponse>`]
+/// — `{items, page, per_page, total}` — but is declared as a concrete,
+/// non-generic type so utoipa can register it as a named component schema
+/// and downstream codegen (the dashboard `openapi-typescript` step) sees
+/// a typed envelope rather than a bare array. Introduced to close the
+/// drift between the handler's runtime body and the OpenAPI contract
+/// flagged by AAASM-1922; the other paginated list endpoints
+/// (`list_agents`, `list_alerts`, `list_policies`, `list_logs`) carry the
+/// same drift and will be addressed independently.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct PaginatedApprovalResponse {
+    /// Items in the current page.
+    pub items: Vec<ApprovalResponse>,
+    /// 1-indexed page number echoed from the request.
+    pub page: u32,
+    /// Items per page echoed from the request.
+    pub per_page: u32,
+    /// Total number of items across all pages (after filters).
+    pub total: u64,
+}

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -2375,6 +2375,38 @@ export interface components {
             /** @description Verb within the cell that was changed. */
             verb: components["schemas"]["Verb"];
         };
+        /**
+         * @description Paginated wire-format envelope for `GET /api/v1/approvals`.
+         *
+         *     Mirrors the JSON shape produced by [`PaginatedResponse<ApprovalResponse>`]
+         *     — `{items, page, per_page, total}` — but is declared as a concrete,
+         *     non-generic type so utoipa can register it as a named component schema
+         *     and downstream codegen (the dashboard `openapi-typescript` step) sees
+         *     a typed envelope rather than a bare array. Introduced to close the
+         *     drift between the handler's runtime body and the OpenAPI contract
+         *     flagged by AAASM-1922; the other paginated list endpoints
+         *     (`list_agents`, `list_alerts`, `list_policies`, `list_logs`) carry the
+         *     same drift and will be addressed independently.
+         */
+        PaginatedApprovalResponse: {
+            /** @description Items in the current page. */
+            items: components["schemas"]["ApprovalResponse"][];
+            /**
+             * Format: int32
+             * @description 1-indexed page number echoed from the request.
+             */
+            page: number;
+            /**
+             * Format: int32
+             * @description Items per page echoed from the request.
+             */
+            per_page: number;
+            /**
+             * Format: int64
+             * @description Total number of items across all pages (after filters).
+             */
+            total: number;
+        };
         /** @description Per-scope contribution to an agent's effective permissions. */
         PermissionSourceResponse: {
             /** @description Capability identifiers this scope explicitly allows. */
@@ -4370,7 +4402,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ApprovalResponse"][];
+                    "application/json": components["schemas"]["PaginatedApprovalResponse"];
                 };
             };
         };

--- a/dashboard/src/features/approvals/api.ts
+++ b/dashboard/src/features/approvals/api.ts
@@ -8,12 +8,12 @@ export type DecideRequest = components['schemas']['DecideRequest']
 export function useApprovalsQuery() {
   return useQuery({
     queryKey: ['approvals'],
-    queryFn: async () => {
+    queryFn: async (): Promise<Approval[]> => {
       const { data, error } = await api.GET('/api/v1/approvals', {
         params: { query: { per_page: 100 } },
       })
       if (error) throw new Error('Failed to fetch approvals')
-      return data ?? []
+      return data?.items ?? []
     },
   })
 }

--- a/dashboard/tests/e2e/hitl-approval.spec.ts
+++ b/dashboard/tests/e2e/hitl-approval.spec.ts
@@ -12,7 +12,7 @@
 // blocking-waiter / timeout / list-transition semantics. This file is the
 // browser-level evidence the ticket AC requests.
 
-import { test, expect, type Route } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 
 import { type FixtureHandle, killFixture, spawnFixture } from './hitl-fixture'
 
@@ -45,12 +45,10 @@ test.describe('Approvals — AAASM-1571 ST-P-5: HITL gate via real gateway', () 
     await page.route('**/api/v1/ws/events*', (route) => route.abort())
 
     // Proxy `/api/v1/**` calls to the live gateway behind the fixture.
-    // Special-cases the list endpoint: the production handler returns a
-    // `PaginatedResponse { items, total, page, per_page }` while the OpenAPI
-    // schema declares `ApprovalResponse[]` (and the dashboard consumes an
-    // array). Unwrap `items` so the dashboard renders correctly until the
-    // contract drift is fixed in a follow-up ticket.
-    await page.route('**/api/v1/**', async (route: Route) => {
+    // AAASM-1922 aligned the `list_approvals` OpenAPI body with the
+    // runtime `PaginatedApprovalResponse` envelope, so the dashboard now
+    // reads `data.items` itself — no response transform needed here.
+    await page.route('**/api/v1/**', async (route) => {
       const url = new URL(route.request().url())
       const proxiedUrl = `${baseUrl}${url.pathname}${url.search}`
       const postData = route.request().postData()
@@ -61,26 +59,6 @@ test.describe('Approvals — AAASM-1571 ST-P-5: HITL gate via real gateway', () 
         headers: route.request().headers(),
         ...(postData !== null ? { postData } : {}),
       })
-
-      const isListApprovals = url.pathname === '/api/v1/approvals' && route.request().method() === 'GET'
-      if (isListApprovals) {
-        const text = await response.text()
-        try {
-          const parsed = JSON.parse(text) as unknown
-          const items =
-            Array.isArray(parsed)
-              ? parsed
-              : (parsed as { items?: unknown[] }).items ?? []
-          await route.fulfill({
-            status: response.status(),
-            headers: { 'content-type': 'application/json' },
-            body: JSON.stringify(items),
-          })
-          return
-        } catch {
-          /* fall through to default fulfill on parse error */
-        }
-      }
 
       await route.fulfill({ response })
     })

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1048,9 +1048,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ApprovalResponse'
+                $ref: '#/components/schemas/PaginatedApprovalResponse'
   /api/v1/approvals/{id}:
     get:
       tags:
@@ -4100,6 +4098,46 @@ components:
         verb:
           $ref: '#/components/schemas/Verb'
           description: Verb within the cell that was changed.
+    PaginatedApprovalResponse:
+      type: object
+      description: |-
+        Paginated wire-format envelope for `GET /api/v1/approvals`.
+
+        Mirrors the JSON shape produced by [`PaginatedResponse<ApprovalResponse>`]
+        — `{items, page, per_page, total}` — but is declared as a concrete,
+        non-generic type so utoipa can register it as a named component schema
+        and downstream codegen (the dashboard `openapi-typescript` step) sees
+        a typed envelope rather than a bare array. Introduced to close the
+        drift between the handler's runtime body and the OpenAPI contract
+        flagged by AAASM-1922; the other paginated list endpoints
+        (`list_agents`, `list_alerts`, `list_policies`, `list_logs`) carry the
+        same drift and will be addressed independently.
+      required:
+      - items
+      - page
+      - per_page
+      - total
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/ApprovalResponse'
+          description: Items in the current page.
+        page:
+          type: integer
+          format: int32
+          description: 1-indexed page number echoed from the request.
+          minimum: 0
+        per_page:
+          type: integer
+          format: int32
+          description: Items per page echoed from the request.
+          minimum: 0
+        total:
+          type: integer
+          format: int64
+          description: Total number of items across all pages (after filters).
+          minimum: 0
     PermissionSourceResponse:
       type: object
       description: Per-scope contribution to an agent's effective permissions.


### PR DESCRIPTION
## Description

`GET /api/v1/approvals` shipped with the production handler returning `PaginatedResponse { items, total, page, per_page }` while the `#[utoipa::path]` annotation declared the response as `Vec<ApprovalResponse>`. The dashboard's generated TS type therefore disagreed with the wire format, and the AAASM-1571 Playwright spec had to paper over the gap with a one-off `page.route` items-unwrap. This PR applies Option 2 from the bug description (recommended): teach the OpenAPI contract about the envelope, regenerate the dashboard codegen, unwrap `.items` in `useApprovalsQuery`, and delete the workaround.

Touch set:

* `aa-api/src/routes/approvals.rs` — new non-generic `PaginatedApprovalResponse` schema (introduced as its own concrete type so the four other paginated handlers with the same drift — `list_agents`, `list_alerts`, `list_policies`, `list_logs` — stay untouched; they'll be fixed independently). `list_approvals` handler + `#[utoipa::path]` switch to it.
* `aa-api/src/openapi.rs` — register the new component.
* `openapi/v1.yaml` — regenerated via `cargo run -p aa-api --bin generate_openapi`.
* `dashboard/src/api/generated/schema.d.ts` — regenerated via `pnpm --dir dashboard generate:api`.
* `dashboard/src/features/approvals/api.ts` — `useApprovalsQuery` returns `data?.items ?? []`; external contract (`Approval[]`) unchanged so `ApprovalsBellButton`, `ApprovalsPage`, `useApprovalsStream` need no edits.
* `dashboard/tests/e2e/hitl-approval.spec.ts` — drop the `route.fulfill` items-unwrap and the now-unused `Route` import.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Wire format is **identical** — same `{items, page, per_page, total}` JSON the handler already returned. Only the OpenAPI declaration and the dashboard's typed consumer change.

## Related Issues

- Related Jira ticket: [AAASM-1922](https://lightning-dust-mite.atlassian.net/browse/AAASM-1922) — under [AAASM-1232](https://lightning-dust-mite.atlassian.net/browse/AAASM-1232) (F116) / [AAASM-1199](https://lightning-dust-mite.atlassian.net/browse/AAASM-1199) Epic.
- Discovered during [AAASM-1571](https://lightning-dust-mite.atlassian.net/browse/AAASM-1571) (F116 ST-P-5 HITL gate dashboard E2E).

## Testing

- [x] Unit tests added / updated — none needed; OpenAPI annotation is exercised by existing tests.
- [x] Integration tests added / updated — `cargo nextest run -p aa-integration-tests --test api_openapi_contract` **6/6 pass** (verifies path count unchanged at 51 and live responses still validate against the spec), `--test api_approvals` **12/12 pass** (handler behavior unchanged), `cargo nextest run -p aa-api` **540/540 pass**.
- [x] Manual testing performed — `pnpm --dir dashboard type-check / lint / test --run` (1030/1030 pass). Playwright `hitl-approval.spec.ts` re-run against the real `aa-api` fixture **without** the workaround — passes; screenshot evidence attached to the AAASM-1922 ticket.
- [ ] No tests required

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy` — both clean via lefthook pre-commit)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a — wire format unchanged; doc-comments added on the new schema)
- [x] All CI checks passing — see green local sweep above; CI mirror to follow
- [x] Commits are small and follow the Gitmoji convention — 7 commits, one per logical unit:
  1. `✨ (aa-api): Add PaginatedApprovalResponse schema for list_approvals`
  2. `🐛 (aa-api): Align list_approvals OpenAPI body with paginated runtime shape`
  3. `🔧 (aa-api): Register PaginatedApprovalResponse in OpenAPI components`
  4. `🔧 (openapi): Regen v1.yaml for paginated approvals response`
  5. `🔧 (dashboard): Regen schema.d.ts for paginated approvals response`
  6. `🐛 (dashboard): Unwrap items in useApprovalsQuery for paginated response`
  7. `🗑️ (dashboard): Drop HITL approvals route workaround now contract is aligned`

[AAASM-1922]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ