### PR TITLE
[AAASM-1923] ✨ (aa-gateway): Add SecretsStore trait + InMemorySecretsStore

### DIFF
--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -23,6 +23,7 @@ pub mod policy;
 pub mod registry;
 pub mod remote_mode;
 pub mod routes;
+pub mod secrets;
 pub mod server;
 pub mod service;
 pub mod simulation;

--- a/aa-gateway/src/secrets/error.rs
+++ b/aa-gateway/src/secrets/error.rs
@@ -1,0 +1,29 @@
+//! Errors returned by [`crate::secrets::SecretsStore`] CRUD operations.
+
+use thiserror::Error;
+
+/// Error returned by [`crate::secrets::SecretsStore`] CRUD operations.
+///
+/// The placeholder-resolver path has its own error type
+/// (`SecretInjectionError`, AAASM-1924) — this enum only covers
+/// failures internal to the store itself.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum SecretsError {
+    /// A `register` call was made for a placeholder name that already has
+    /// an entry. Registering the same name twice is rejected rather than
+    /// silently overwritten so operators get a signal that two callers are
+    /// racing for the same key.
+    #[error("placeholder already registered: {name}")]
+    AlreadyRegistered {
+        /// The placeholder name (no `${…}` wrapping) that was already in
+        /// the store when the duplicate `register` was attempted.
+        name: String,
+    },
+    /// A `delete` call referenced a placeholder name that is not in the
+    /// store.
+    #[error("placeholder not found: {name}")]
+    NotFound {
+        /// The placeholder name (no `${…}` wrapping) that was missing.
+        name: String,
+    },
+}

--- a/aa-gateway/src/secrets/mod.rs
+++ b/aa-gateway/src/secrets/mod.rs
@@ -20,5 +20,5 @@ pub mod store;
 pub mod types;
 
 pub use error::SecretsError;
-pub use store::SecretsStore;
+pub use store::{InMemorySecretsStore, SecretsStore};
 pub use types::Secret;

--- a/aa-gateway/src/secrets/mod.rs
+++ b/aa-gateway/src/secrets/mod.rs
@@ -1,0 +1,16 @@
+//! Gateway-side **Secret Injection** capability — placeholder registry that
+//! substitutes `${NAME}` tokens with real credential values at tool-dispatch
+//! time so the resolved value is never present in any LLM-bound request body
+//! or audit-log entry.
+//!
+//! See `aa-gateway/src/secrets/README.md` (AAASM-1929) for the threat model
+//! and the placeholder-vs-resolved audit contract.
+//!
+//! ## Distinction from Secret Detection
+//!
+//! Secret *Detection* (AAASM-1521 / 1549, already shipped) is a reactive
+//! guard against agents *accidentally* leaking real credentials. Secret
+//! *Injection* (this module, AAASM-1920) is a proactive feature: agents
+//! reference credentials *by name* and the gateway substitutes the real
+//! value at dispatch time. The two capabilities are complementary, not
+//! alternatives.

--- a/aa-gateway/src/secrets/mod.rs
+++ b/aa-gateway/src/secrets/mod.rs
@@ -16,7 +16,9 @@
 //! alternatives.
 
 pub mod error;
+pub mod store;
 pub mod types;
 
 pub use error::SecretsError;
+pub use store::SecretsStore;
 pub use types::Secret;

--- a/aa-gateway/src/secrets/mod.rs
+++ b/aa-gateway/src/secrets/mod.rs
@@ -14,3 +14,7 @@
 //! reference credentials *by name* and the gateway substitutes the real
 //! value at dispatch time. The two capabilities are complementary, not
 //! alternatives.
+
+pub mod types;
+
+pub use types::Secret;

--- a/aa-gateway/src/secrets/mod.rs
+++ b/aa-gateway/src/secrets/mod.rs
@@ -15,6 +15,8 @@
 //! value at dispatch time. The two capabilities are complementary, not
 //! alternatives.
 
+pub mod error;
 pub mod types;
 
+pub use error::SecretsError;
 pub use types::Secret;

--- a/aa-gateway/src/secrets/store.rs
+++ b/aa-gateway/src/secrets/store.rs
@@ -1,5 +1,9 @@
 //! The [`SecretsStore`] trait — gateway-side registry of placeholder →
-//! credential mappings used by Secret Injection.
+//! credential mappings used by Secret Injection — and the canonical
+//! in-memory implementation [`InMemorySecretsStore`].
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 
 use crate::secrets::{Secret, SecretsError};
 
@@ -50,4 +54,26 @@ pub trait SecretsStore: Send + Sync {
     /// Returns [`SecretsError::NotFound`] when no entry exists for `name`
     /// so callers cannot accidentally treat a no-op as a successful delete.
     fn delete(&self, name: &str) -> Result<(), SecretsError>;
+}
+
+/// In-memory [`SecretsStore`] implementation — the default for v0.0.1.
+///
+/// Backed by a single `Arc<RwLock<HashMap<String, String>>>`. Reads
+/// (`lookup`, `list`) take a read lock; writes (`register`, `delete`)
+/// take a write lock. Persistence and per-team scoping are explicit
+/// non-goals for v0.0.1 (tracked as follow-ups in `secrets/README.md`).
+///
+/// `Clone` is cheap (Arc bump) so callers can stash a handle in
+/// `AppState` and hand it to async tasks.
+#[derive(Clone, Default)]
+pub struct InMemorySecretsStore {
+    #[allow(dead_code)]
+    data: Arc<RwLock<HashMap<String, String>>>,
+}
+
+impl InMemorySecretsStore {
+    /// Builds a fresh, empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
 }

--- a/aa-gateway/src/secrets/store.rs
+++ b/aa-gateway/src/secrets/store.rs
@@ -126,4 +126,11 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(store.lookup("DB_PASSWORD").as_deref(), Some("real-secret-1"));
     }
+
+    #[test]
+    fn lookup_returns_none_for_unknown_name() {
+        let store = InMemorySecretsStore::new();
+        store.register(secret("DB_PASSWORD", "real-secret-1")).unwrap();
+        assert_eq!(store.lookup("UNKNOWN"), None);
+    }
 }

--- a/aa-gateway/src/secrets/store.rs
+++ b/aa-gateway/src/secrets/store.rs
@@ -1,0 +1,53 @@
+//! The [`SecretsStore`] trait — gateway-side registry of placeholder →
+//! credential mappings used by Secret Injection.
+
+use crate::secrets::{Secret, SecretsError};
+
+/// CRUD surface over registered placeholder secrets.
+///
+/// Implementations must be safe to share across threads — the gateway holds
+/// the store in `AppState` (`Arc<dyn SecretsStore>`) and concurrent
+/// `dispatch_tool` calls may resolve placeholders in parallel.
+///
+/// ## Method contract
+///
+/// * [`register`](SecretsStore::register) — adds a new mapping. Returns
+///   [`SecretsError::AlreadyRegistered`] if a secret with the same `name`
+///   already exists. Registration is **not** idempotent so the operator
+///   gets a signal when two callers race for the same key.
+/// * [`lookup`](SecretsStore::lookup) — returns the real value, cloned.
+///   Used by the resolver (AAASM-1924) to substitute `${NAME}` tokens.
+///   `None` means the placeholder is not registered — the resolver
+///   surfaces that as `SecretInjectionError::UnknownPlaceholder`.
+/// * [`list`](SecretsStore::list) — returns only the registered placeholder
+///   names, never the values. Intended for admin / debugging UIs.
+/// * [`delete`](SecretsStore::delete) — removes a mapping. Returns
+///   [`SecretsError::NotFound`] when the name is absent so calls are not
+///   silently no-ops.
+pub trait SecretsStore: Send + Sync {
+    /// Registers a new placeholder → credential mapping.
+    ///
+    /// Returns [`SecretsError::AlreadyRegistered`] if `secret.name` is
+    /// already present. Implementations must not silently overwrite.
+    fn register(&self, secret: Secret) -> Result<(), SecretsError>;
+
+    /// Looks up the real credential value for a placeholder name.
+    ///
+    /// `name` is the bare placeholder identifier (e.g. `DB_PASSWORD`)
+    /// without the `${…}` wrapping. Returns the cloned value, or `None`
+    /// if no entry is registered for the name.
+    fn lookup(&self, name: &str) -> Option<String>;
+
+    /// Returns every registered placeholder name, in insertion order.
+    ///
+    /// **Never** returns the real credential values. The store-wide value
+    /// surface is `lookup(name)` only — `list()` exists so admin tooling
+    /// can show what secrets are available without exposing them.
+    fn list(&self) -> Vec<String>;
+
+    /// Removes a registered placeholder.
+    ///
+    /// Returns [`SecretsError::NotFound`] when no entry exists for `name`
+    /// so callers cannot accidentally treat a no-op as a successful delete.
+    fn delete(&self, name: &str) -> Result<(), SecretsError>;
+}

--- a/aa-gateway/src/secrets/store.rs
+++ b/aa-gateway/src/secrets/store.rs
@@ -107,3 +107,23 @@ impl SecretsStore for InMemorySecretsStore {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn secret(name: &str, value: &str) -> Secret {
+        Secret {
+            name: name.to_owned(),
+            value: value.to_owned(),
+        }
+    }
+
+    #[test]
+    fn register_stores_a_new_secret() {
+        let store = InMemorySecretsStore::new();
+        let result = store.register(secret("DB_PASSWORD", "real-secret-1"));
+        assert!(result.is_ok());
+        assert_eq!(store.lookup("DB_PASSWORD").as_deref(), Some("real-secret-1"));
+    }
+}

--- a/aa-gateway/src/secrets/store.rs
+++ b/aa-gateway/src/secrets/store.rs
@@ -135,6 +135,15 @@ mod tests {
     }
 
     #[test]
+    fn delete_removes_a_registered_secret() {
+        let store = InMemorySecretsStore::new();
+        store.register(secret("DB_PASSWORD", "real-secret-1")).unwrap();
+        store.delete("DB_PASSWORD").unwrap();
+        assert_eq!(store.lookup("DB_PASSWORD"), None);
+        assert!(store.list().is_empty());
+    }
+
+    #[test]
     fn list_returns_only_names_sorted_lexicographically() {
         let store = InMemorySecretsStore::new();
         store.register(secret("STRIPE_KEY", "real-1")).unwrap();

--- a/aa-gateway/src/secrets/store.rs
+++ b/aa-gateway/src/secrets/store.rs
@@ -158,4 +158,33 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn register_duplicate_returns_already_registered() {
+        let store = InMemorySecretsStore::new();
+        store.register(secret("DB_PASSWORD", "real-secret-1")).unwrap();
+        let err = store
+            .register(secret("DB_PASSWORD", "real-secret-2"))
+            .expect_err("duplicate register must fail");
+        assert_eq!(
+            err,
+            SecretsError::AlreadyRegistered {
+                name: "DB_PASSWORD".to_owned()
+            }
+        );
+        // First registration is preserved — duplicate did not overwrite.
+        assert_eq!(store.lookup("DB_PASSWORD").as_deref(), Some("real-secret-1"));
+    }
+
+    #[test]
+    fn delete_missing_returns_not_found() {
+        let store = InMemorySecretsStore::new();
+        let err = store.delete("UNKNOWN").expect_err("delete of missing name must fail");
+        assert_eq!(
+            err,
+            SecretsError::NotFound {
+                name: "UNKNOWN".to_owned()
+            }
+        );
+    }
 }

--- a/aa-gateway/src/secrets/store.rs
+++ b/aa-gateway/src/secrets/store.rs
@@ -133,4 +133,20 @@ mod tests {
         store.register(secret("DB_PASSWORD", "real-secret-1")).unwrap();
         assert_eq!(store.lookup("UNKNOWN"), None);
     }
+
+    #[test]
+    fn list_returns_only_names_sorted_lexicographically() {
+        let store = InMemorySecretsStore::new();
+        store.register(secret("STRIPE_KEY", "real-1")).unwrap();
+        store.register(secret("DB_PASSWORD", "real-2")).unwrap();
+        store.register(secret("API_TOKEN", "real-3")).unwrap();
+        let names = store.list();
+        assert_eq!(names, vec!["API_TOKEN", "DB_PASSWORD", "STRIPE_KEY"]);
+        for value in ["real-1", "real-2", "real-3"] {
+            assert!(
+                !names.iter().any(|n| n.contains(value)),
+                "list() must never expose credential values; found {value:?}"
+            );
+        }
+    }
 }

--- a/aa-gateway/src/secrets/store.rs
+++ b/aa-gateway/src/secrets/store.rs
@@ -67,7 +67,6 @@ pub trait SecretsStore: Send + Sync {
 /// `AppState` and hand it to async tasks.
 #[derive(Clone, Default)]
 pub struct InMemorySecretsStore {
-    #[allow(dead_code)]
     data: Arc<RwLock<HashMap<String, String>>>,
 }
 
@@ -75,5 +74,36 @@ impl InMemorySecretsStore {
     /// Builds a fresh, empty store.
     pub fn new() -> Self {
         Self::default()
+    }
+}
+
+impl SecretsStore for InMemorySecretsStore {
+    fn register(&self, secret: Secret) -> Result<(), SecretsError> {
+        let mut data = self.data.write().expect("secrets store lock poisoned");
+        if data.contains_key(&secret.name) {
+            return Err(SecretsError::AlreadyRegistered { name: secret.name });
+        }
+        data.insert(secret.name, secret.value);
+        Ok(())
+    }
+
+    fn lookup(&self, name: &str) -> Option<String> {
+        let data = self.data.read().expect("secrets store lock poisoned");
+        data.get(name).cloned()
+    }
+
+    fn list(&self) -> Vec<String> {
+        let data = self.data.read().expect("secrets store lock poisoned");
+        let mut names: Vec<String> = data.keys().cloned().collect();
+        names.sort();
+        names
+    }
+
+    fn delete(&self, name: &str) -> Result<(), SecretsError> {
+        let mut data = self.data.write().expect("secrets store lock poisoned");
+        if data.remove(name).is_none() {
+            return Err(SecretsError::NotFound { name: name.to_owned() });
+        }
+        Ok(())
     }
 }

--- a/aa-gateway/src/secrets/types.rs
+++ b/aa-gateway/src/secrets/types.rs
@@ -1,0 +1,24 @@
+//! Data types backing the Secret Injection module.
+
+/// A registered secret mapping: the public **placeholder name** an agent
+/// references (e.g. `DB_PASSWORD`) → the **real credential value** the
+/// gateway substitutes in at tool-dispatch time.
+///
+/// The placeholder name is stored *without* the `${...}` syntactic wrapping
+/// (i.e. `DB_PASSWORD`, not `${DB_PASSWORD}`); the resolver wraps and
+/// unwraps it as needed when walking JSON.
+///
+/// Cloning a `Secret` clones the real value — callers that hold a `Secret`
+/// outside the `SecretsStore` are responsible for keeping it out of any
+/// LLM-bound request body or audit-log entry. See `aa-gateway/src/secrets/
+/// README.md` (AAASM-1929) for the threat-model contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Secret {
+    /// The placeholder name, without `${...}` wrapping. Conventionally
+    /// `SCREAMING_SNAKE_CASE`; validation is the resolver's responsibility,
+    /// not the store's.
+    pub name: String,
+    /// The real credential value that will replace `${name}` tokens at
+    /// dispatch time. Never logged, never serialised into audit entries.
+    pub value: String,
+}


### PR DESCRIPTION
## Description

ST1 of Story AAASM-1920 (Secret Injection). Lays the foundation for the Secret Injection feature by introducing a gateway-side registry of placeholder → credential mappings.

Adds `aa-gateway::secrets` with:

* `Secret` data type (placeholder `name` + real `value`).
* `SecretsError` for store CRUD failures (`AlreadyRegistered`, `NotFound`).
* `SecretsStore` trait — `register` / `lookup` / `list` / `delete`. `Send + Sync` so `AppState` can carry it as `Arc<dyn SecretsStore>`.
* `InMemorySecretsStore` impl backed by `Arc<RwLock<HashMap<String, String>>>`.

Contracts pinned by unit tests:

* `register` rejects duplicates with `AlreadyRegistered` (not idempotent — racing callers get a signal).
* `lookup` returns `None` for unknown names — the contract the resolver (ST2) maps to `SecretInjectionError::UnknownPlaceholder`.
* `list` returns names only, sorted lexicographically; never exposes values.
* `delete` returns `NotFound` rather than silently no-op'ing.

The follow-up ST2/ST3/ST4/ST5 PRs will consume this trait.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-1923 (Story AAASM-1920, Epic AAASM-1199)
- Related GitHub issues: —

## Testing

- [x] Unit tests added / updated — 6 tests under `aa-gateway::secrets::store::tests` (`cargo nextest run -p aa-gateway secrets::` → 6 passed).
- [ ] Integration tests added / updated — N/A; first consumer lands in ST3 (HTTP route).
- [ ] Manual testing performed
- [ ] No tests required

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (`SecretsStore` trait method contract section)
- [ ] All CI checks passing (awaiting CI)
- [x] Commits are small and follow the Gitmoji convention (11 commits, one per logical unit)