### PR TITLE
[AAASM-1572] ✅ (aa-proxy): F116 ST-Q MCP interceptor detection slice

### DIFF
--- a/aa-integration-tests/tests/e2e_mcp_interceptor.rs
+++ b/aa-integration-tests/tests/e2e_mcp_interceptor.rs
@@ -93,3 +93,36 @@ fn parser_extracts_tool_name_and_path_for_allow_match() {
         Some("/home/user/file.txt"),
     );
 }
+
+/// ST-Q detection — deeply nested `arguments` objects survive parsing intact.
+/// Real-world MCP tools use structured config blocks (e.g. an HTTP fetch tool
+/// with `arguments.request.headers.authorization`). The policy engine walks
+/// these via `FieldRef::Tool` + JSON-path predicates; the parser must hand
+/// the full sub-tree to the engine unchanged.
+#[test]
+fn parser_preserves_nested_arguments_object() {
+    let body = br#"{
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/call",
+        "params": {
+            "name": "http_fetch",
+            "arguments": {
+                "request": {
+                    "method": "GET",
+                    "headers": { "authorization": "Bearer placeholder" },
+                    "config": { "timeout_ms": 30000 }
+                }
+            }
+        }
+    }"#;
+    let call = parse_mcp_request(body).expect("MCP tools/call with nested args must parse");
+    assert_eq!(call.tool_name, "http_fetch");
+    assert_eq!(
+        call.arguments
+            .pointer("/request/config/timeout_ms")
+            .and_then(|v| v.as_u64()),
+        Some(30000),
+        "JSON pointer walk through nested arguments must succeed for policy predicates",
+    );
+}

--- a/aa-integration-tests/tests/e2e_mcp_interceptor.rs
+++ b/aa-integration-tests/tests/e2e_mcp_interceptor.rs
@@ -39,10 +39,6 @@
 use aa_proxy::intercept::mcp::parse_mcp_request;
 
 /// OpenAI key with the documented `sk-test-` test prefix. Synthetic.
-///
-/// Consumed by the raw-secret-absence invariant test added in a later commit
-/// in this PR; allow(dead_code) until that test lands.
-#[allow(dead_code)]
 const FAKE_OPENAI_KEY: &str = "sk-test-AbCdEf1234567890ABCDEF1234567890ABCDEF1234567890";
 
 // ── Detection slice ──────────────────────────────────────────────────────────
@@ -161,5 +157,63 @@ fn parser_rejects_non_mcp_json_traffic_seen_by_proxy() {
     assert!(
         parse_mcp_request(generic).is_none(),
         "generic JSON must not match an MCP rule"
+    );
+}
+
+/// ST-Q detection — raw-secret-absence security invariant on the parser.
+///
+/// The parser is **not** a redactor — that's AAASM-1930's response-side job.
+/// What the parser MUST guarantee is that it does not become a side-channel:
+/// the secret bytes must live exactly in the structured `arguments` value
+/// where the policy engine can match against them, and nowhere else (no copy
+/// in `tool_name`, no leak via `Debug` formatting outside the arguments).
+///
+/// AAASM-1930's ST-Q-3 will assert the data-path-side redaction (raw key
+/// absent from the response bytes returned to the agent). This test locks
+/// down the parser-side prerequisite: the parser hands a faithful
+/// `arguments` to the engine without smearing the secret across other
+/// fields.
+#[test]
+fn parser_does_not_leak_secret_bytes_outside_arguments_value() {
+    let body = format!(
+        r#"{{
+            "jsonrpc": "2.0",
+            "id": 4,
+            "method": "tools/call",
+            "params": {{
+                "name": "submit_context",
+                "arguments": {{ "context": "user said {FAKE_OPENAI_KEY}" }}
+            }}
+        }}"#
+    );
+    let call = parse_mcp_request(body.as_bytes()).expect("MCP body with secret in args must parse");
+
+    // (1) tool_name carries only the tool name — never spills the secret.
+    assert_eq!(call.tool_name, "submit_context");
+    assert!(
+        !call.tool_name.contains(FAKE_OPENAI_KEY),
+        "tool_name must never carry argument bytes",
+    );
+
+    // (2) The secret IS present in the structured arguments value — that's
+    //     where the gateway's redaction predicate (AAASM-1930) will find and
+    //     replace it on the response path.
+    let context = call
+        .arguments
+        .get("context")
+        .and_then(|v| v.as_str())
+        .expect("arguments.context must be a string");
+    assert!(
+        context.contains(FAKE_OPENAI_KEY),
+        "secret must be present in arguments so the policy engine can match it",
+    );
+
+    // (3) The secret must NOT appear in any non-arguments serialised view of
+    //     the parsed struct (a regression here would mean a future change
+    //     accidentally added a Display impl or log line that leaks the key).
+    let debug_repr = format!("{:?}", call.tool_name);
+    assert!(
+        !debug_repr.contains(FAKE_OPENAI_KEY),
+        "Debug of tool_name must not leak the secret — got {debug_repr}",
     );
 }

--- a/aa-integration-tests/tests/e2e_mcp_interceptor.rs
+++ b/aa-integration-tests/tests/e2e_mcp_interceptor.rs
@@ -290,3 +290,16 @@ fn st_q_3_mcp_tool_result_secret_is_redacted_before_agent_sees_it() {
 fn st_q_4_mcp_tool_name_outside_allowlist_is_denied() {
     todo!("AAASM-1930: install mcp_allowlist.yaml, drive tools/call execute_bash, assert deny")
 }
+
+/// ST-Q-5 — All four behaviours above work with NO SDK installed.
+///
+/// Validates the framework-agnostic Layer 2 contract that motivates the
+/// MCP interceptor's design (spec lines 452–453 / 7243). The driver in
+/// AAASM-1930 will skip `init_assembly()` and connect a raw client through
+/// the proxy; deny / allow / redact / allowlist must all behave identically
+/// to the SDK-installed cases above.
+#[ignore = "AAASM-1930: requires aa-proxy MCP data-path wiring"]
+#[test]
+fn st_q_5_mcp_interception_works_without_sdk_installed() {
+    todo!("AAASM-1930: drive without init_assembly(), assert ST-Q-1..4 behaviours all hold")
+}

--- a/aa-integration-tests/tests/e2e_mcp_interceptor.rs
+++ b/aa-integration-tests/tests/e2e_mcp_interceptor.rs
@@ -275,3 +275,18 @@ fn st_q_2_mcp_read_file_home_user_is_allowed() {
 fn st_q_3_mcp_tool_result_secret_is_redacted_before_agent_sees_it() {
     todo!("AAASM-1930: install mcp_redact_secrets.yaml, drive a tool whose result carries sk-...")
 }
+
+/// ST-Q-4 — MCP tool name outside the allowlist is denied.
+///
+/// AAASM-1930 will assert:
+///
+/// 1. With `deny if tool_name not in [read_file, write_file]`, a
+///    `tools/call` for `execute_bash` is denied at the proxy.
+/// 2. The upstream MCP server's `request_count() == 0`.
+/// 3. The emitted audit event carries `tool_name == "execute_bash"`,
+///    `decision == Deny` with the allowlist reason.
+#[ignore = "AAASM-1930: requires aa-proxy MCP data-path wiring"]
+#[test]
+fn st_q_4_mcp_tool_name_outside_allowlist_is_denied() {
+    todo!("AAASM-1930: install mcp_allowlist.yaml, drive tools/call execute_bash, assert deny")
+}

--- a/aa-integration-tests/tests/e2e_mcp_interceptor.rs
+++ b/aa-integration-tests/tests/e2e_mcp_interceptor.rs
@@ -259,3 +259,19 @@ fn st_q_1_mcp_read_file_etc_passwd_is_denied() {
 fn st_q_2_mcp_read_file_home_user_is_allowed() {
     todo!("AAASM-1930: drive the allowed path and assert upstream forward + Allow audit event")
 }
+
+/// ST-Q-3 — MCP tool result containing a secret is redacted before the
+/// agent sees it.
+///
+/// AAASM-1930 will assert:
+///
+/// 1. The agent's view of the upstream response has the secret pattern
+///    replaced with `[REDACTED:OpenAiKey]` (or equivalent redaction marker).
+/// 2. The raw secret value appears nowhere in the bytes the agent receives.
+/// 3. The emitted audit event has `credential_findings` populated and
+///    `decision == Redact`.
+#[ignore = "AAASM-1930: requires aa-proxy MCP data-path wiring"]
+#[test]
+fn st_q_3_mcp_tool_result_secret_is_redacted_before_agent_sees_it() {
+    todo!("AAASM-1930: install mcp_redact_secrets.yaml, drive a tool whose result carries sk-...")
+}

--- a/aa-integration-tests/tests/e2e_mcp_interceptor.rs
+++ b/aa-integration-tests/tests/e2e_mcp_interceptor.rs
@@ -243,3 +243,19 @@ fn parser_does_not_leak_secret_bytes_outside_arguments_value() {
 fn st_q_1_mcp_read_file_etc_passwd_is_denied() {
     todo!("AAASM-1930: drive a JSON-RPC tools/call through ProxyServer with mcp_deny_etc_paths.yaml")
 }
+
+/// ST-Q-2 — MCP `read_file /home/user/file.txt` is allowed.
+///
+/// AAASM-1930 will assert:
+///
+/// 1. The proxy forwards the original JSON-RPC envelope unchanged to the
+///    upstream mock MCP server (`request_count() == 1`,
+///    `last_call().tool_name == "read_file"`).
+/// 2. The agent receives the upstream's result envelope intact.
+/// 3. The emitted audit event carries `tool_name == "read_file"`,
+///    `decision == Allow`.
+#[ignore = "AAASM-1930: requires aa-proxy MCP data-path wiring"]
+#[test]
+fn st_q_2_mcp_read_file_home_user_is_allowed() {
+    todo!("AAASM-1930: drive the allowed path and assert upstream forward + Allow audit event")
+}

--- a/aa-integration-tests/tests/e2e_mcp_interceptor.rs
+++ b/aa-integration-tests/tests/e2e_mcp_interceptor.rs
@@ -70,3 +70,26 @@ fn parser_extracts_tool_name_and_path_for_deny_match() {
         "policy engine needs arguments.path to evaluate `starts_with \"/etc\"` predicates",
     );
 }
+
+/// ST-Q detection — the parser surfaces an allowed path (one that does NOT
+/// match the deny rule's `starts_with "/etc"` predicate) just like a denied
+/// one. The primitive is policy-agnostic; ST-Q-2 in AAASM-1930 will assert
+/// that the gateway evaluates this body as `Allow` and forwards upstream.
+#[test]
+fn parser_extracts_tool_name_and_path_for_allow_match() {
+    let body = br#"{
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {
+            "name": "read_file",
+            "arguments": { "path": "/home/user/file.txt" }
+        }
+    }"#;
+    let call = parse_mcp_request(body).expect("MCP tools/call body must parse");
+    assert_eq!(call.tool_name, "read_file");
+    assert_eq!(
+        call.arguments.get("path").and_then(|v| v.as_str()),
+        Some("/home/user/file.txt"),
+    );
+}

--- a/aa-integration-tests/tests/e2e_mcp_interceptor.rs
+++ b/aa-integration-tests/tests/e2e_mcp_interceptor.rs
@@ -126,3 +126,40 @@ fn parser_preserves_nested_arguments_object() {
         "JSON pointer walk through nested arguments must succeed for policy predicates",
     );
 }
+
+/// ST-Q detection — non-MCP JSON traffic flowing through the proxy must be
+/// rejected by `parse_mcp_request`. Critical invariant: the proxy data path
+/// (AAASM-1930) will call this primitive on every body it sees in the MitM
+/// tunnel; if an OpenAI chat-completions body or any plain JSON object
+/// matched, the policy engine would evaluate MCP rules against arbitrary
+/// LLM traffic.
+#[test]
+fn parser_rejects_non_mcp_json_traffic_seen_by_proxy() {
+    // OpenAI chat-completions body — the proxy sees this on every LLM call.
+    let openai = br#"{
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "hi"}]
+    }"#;
+    assert!(
+        parse_mcp_request(openai).is_none(),
+        "OpenAI body must not match an MCP rule"
+    );
+
+    // Anthropic body — same risk.
+    let anthropic = br#"{
+        "model": "claude-3-opus-20240229",
+        "max_tokens": 1024,
+        "messages": [{"role": "user", "content": "hi"}]
+    }"#;
+    assert!(
+        parse_mcp_request(anthropic).is_none(),
+        "Anthropic body must not match an MCP rule",
+    );
+
+    // Plain JSON object with no MCP envelope — generic webhook traffic etc.
+    let generic = br#"{"event": "ping", "ts": 1700000000}"#;
+    assert!(
+        parse_mcp_request(generic).is_none(),
+        "generic JSON must not match an MCP rule"
+    );
+}

--- a/aa-integration-tests/tests/e2e_mcp_interceptor.rs
+++ b/aa-integration-tests/tests/e2e_mcp_interceptor.rs
@@ -1,0 +1,72 @@
+//! F116 ST-Q — E2E MCP interceptor (detection slice).
+//!
+//! Exercises the new `aa_proxy::intercept::mcp::parse_mcp_request` primitive
+//! against MCP-shaped JSON-RPC 2.0 `tools/call` request bodies and asserts:
+//!
+//! 1. The structured `tool_name` and `arguments` fields the policy engine
+//!    needs (`FieldRef::Tool` / `ToolCallContext.args_json`) are extracted
+//!    correctly from the wire shape the proxy will see in production.
+//! 2. Non-MCP JSON traffic flowing through the proxy is rejected so the
+//!    policy engine never matches an MCP rule against an arbitrary body.
+//! 3. The raw bytes of a payload that contains a secret are never retained
+//!    in the parsed `McpToolCall` outside the structured `arguments` value
+//!    (security invariant — the data-path follow-up will add redaction on
+//!    the response side, but the parser must not be a side-channel today).
+//!
+//! ## Scope
+//!
+//! This file ships the **detection-only** slice of the original 5-test ST-Q.
+//! The remaining E2E tests (ST-Q-1 through ST-Q-5) require runtime features
+//! that are not yet implemented in `aa-proxy`:
+//!
+//! * Detection inside the MitM TLS tunnel (proxy must recognise an MCP body
+//!   and branch into the MCP path).
+//! * A gateway client in `aa-proxy` to send a `PolicyEvaluationRequest`
+//!   carrying `ToolCallContext { tool_name, args_json, tool_source: "mcp" }`.
+//! * Enforcement on the wire — JSON-RPC error envelope for `deny`, result
+//!   mutation for `redact`, passthrough for `allow`.
+//! * Structured `ToolCall` audit emission with `tool_name`, `args_json`,
+//!   `decision` — not the raw `NetworkCall` body bytes.
+//!
+//! See **AAASM-1930** for the data-path follow-up; the ST-Q-1..5 placeholders
+//! at the end of this file are marked `#[ignore]` until that work lands.
+//!
+//! ## Synthetic secrets only
+//!
+//! Every secret value below is synthetic — from prefixes documented as
+//! test-only (`sk-test-`). No real secrets are stored in this fixture.
+
+use aa_proxy::intercept::mcp::parse_mcp_request;
+
+/// OpenAI key with the documented `sk-test-` test prefix. Synthetic.
+///
+/// Consumed by the raw-secret-absence invariant test added in a later commit
+/// in this PR; allow(dead_code) until that test lands.
+#[allow(dead_code)]
+const FAKE_OPENAI_KEY: &str = "sk-test-AbCdEf1234567890ABCDEF1234567890ABCDEF1234567890";
+
+// ── Detection slice ──────────────────────────────────────────────────────────
+
+/// ST-Q detection — the parser extracts `tool_name == "read_file"` and the
+/// nested `arguments.path == "/etc/passwd"` from a canonical MCP `tools/call`
+/// request body. This is the structured-field primitive the data-path
+/// follow-up (AAASM-1930) will feed into `PolicyEvaluationRequest`.
+#[test]
+fn parser_extracts_tool_name_and_path_for_deny_match() {
+    let body = br#"{
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "read_file",
+            "arguments": { "path": "/etc/passwd" }
+        }
+    }"#;
+    let call = parse_mcp_request(body).expect("MCP tools/call body must parse");
+    assert_eq!(call.tool_name, "read_file");
+    assert_eq!(
+        call.arguments.get("path").and_then(|v| v.as_str()),
+        Some("/etc/passwd"),
+        "policy engine needs arguments.path to evaluate `starts_with \"/etc\"` predicates",
+    );
+}

--- a/aa-integration-tests/tests/e2e_mcp_interceptor.rs
+++ b/aa-integration-tests/tests/e2e_mcp_interceptor.rs
@@ -217,3 +217,29 @@ fn parser_does_not_leak_secret_bytes_outside_arguments_value() {
         "Debug of tool_name must not leak the secret — got {debug_repr}",
     );
 }
+
+// ── ST-Q-1..5 E2E placeholders (pending AAASM-1930) ─────────────────────────
+//
+// The five tests below mirror the ST-Q acceptance criteria 1:1. They are
+// `#[ignore]` because the proxy data path does not yet recognise MCP traffic,
+// has no gateway client, and cannot enforce allow/deny/redact on the wire.
+// Each test's docstring records the exact assertion AAASM-1930 will make
+// against a real running `ProxyServer` + mock MCP upstream, so when the
+// data-path work lands the engineer can replace `todo!()` with the
+// implementation and remove `#[ignore]`.
+
+/// ST-Q-1 — MCP `read_file /etc/passwd` is denied at the proxy.
+///
+/// AAASM-1930 will assert:
+///
+/// 1. The proxy returns a JSON-RPC 2.0 error envelope to the client
+///    (`error.code = -32000`, message carries the policy reason).
+/// 2. The upstream mock MCP server's `request_count() == 0` — the deny fires
+///    at the proxy, the call is never passed through.
+/// 3. The emitted `PipelineEvent::Audit` carries a structured `ToolCall`
+///    detail with `tool_name == "read_file"`, `decision == Deny`.
+#[ignore = "AAASM-1930: requires aa-proxy MCP data-path wiring"]
+#[test]
+fn st_q_1_mcp_read_file_etc_passwd_is_denied() {
+    todo!("AAASM-1930: drive a JSON-RPC tools/call through ProxyServer with mcp_deny_etc_paths.yaml")
+}

--- a/aa-proxy/src/intercept/mcp.rs
+++ b/aa-proxy/src/intercept/mcp.rs
@@ -164,4 +164,21 @@ mod tests {
         assert!(parse_mcp_request(b"{\"jsonrpc\":\"2.0\",\"method\":").is_none());
         assert!(parse_mcp_request(b"").is_none());
     }
+
+    #[test]
+    fn missing_arguments_defaults_to_json_null() {
+        // Tools that take no arguments (e.g. `tools/call` for a
+        // `list_workspace_files` no-arg tool) omit the `arguments` field
+        // entirely. The parser must accept these and surface
+        // `arguments == Value::Null` so callers can treat it uniformly.
+        let body = br#"{
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": "ping" }
+        }"#;
+        let call = parse_mcp_request(body).expect("missing arguments must still parse");
+        assert_eq!(call.tool_name, "ping");
+        assert_eq!(call.arguments, serde_json::Value::Null);
+    }
 }

--- a/aa-proxy/src/intercept/mcp.rs
+++ b/aa-proxy/src/intercept/mcp.rs
@@ -127,4 +127,17 @@ mod tests {
         }"#;
         assert!(parse_mcp_request(body).is_none());
     }
+
+    #[test]
+    fn returns_none_when_jsonrpc_version_is_wrong_or_missing() {
+        // Wrong version — JSON-RPC 1.0 or unspecified MUST be rejected so a
+        // legacy non-MCP payload cannot accidentally be matched.
+        let wrong_version = br#"{"jsonrpc":"1.0","id":1,"method":"tools/call","params":{"name":"x"}}"#;
+        assert!(parse_mcp_request(wrong_version).is_none());
+
+        // Missing entirely — non-MCP JSON-shaped traffic flowing through the
+        // proxy must not produce a false-positive McpToolCall.
+        let no_version = br#"{"id":1,"method":"tools/call","params":{"name":"x"}}"#;
+        assert!(parse_mcp_request(no_version).is_none());
+    }
 }

--- a/aa-proxy/src/intercept/mcp.rs
+++ b/aa-proxy/src/intercept/mcp.rs
@@ -92,3 +92,25 @@ pub fn parse_mcp_request(body: &[u8]) -> Option<McpToolCall> {
         arguments: params.arguments,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn extracts_tool_name_and_arguments_from_tools_call() {
+        let body = br#"{
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "read_file",
+                "arguments": { "path": "/etc/passwd" }
+            }
+        }"#;
+        let call = parse_mcp_request(body).expect("valid tools/call must parse");
+        assert_eq!(call.tool_name, "read_file");
+        assert_eq!(call.arguments, json!({ "path": "/etc/passwd" }));
+    }
+}

--- a/aa-proxy/src/intercept/mcp.rs
+++ b/aa-proxy/src/intercept/mcp.rs
@@ -154,4 +154,14 @@ mod tests {
         }"#;
         assert!(parse_mcp_request(body).is_none());
     }
+
+    #[test]
+    fn returns_none_on_malformed_json() {
+        // Garbage bytes, truncated envelopes, and non-JSON traffic must all
+        // surface as `None` instead of panicking — the proxy data path will
+        // see plenty of non-MCP HTTPS bodies in production.
+        assert!(parse_mcp_request(b"not json at all").is_none());
+        assert!(parse_mcp_request(b"{\"jsonrpc\":\"2.0\",\"method\":").is_none());
+        assert!(parse_mcp_request(b"").is_none());
+    }
 }

--- a/aa-proxy/src/intercept/mcp.rs
+++ b/aa-proxy/src/intercept/mcp.rs
@@ -113,4 +113,18 @@ mod tests {
         assert_eq!(call.tool_name, "read_file");
         assert_eq!(call.arguments, json!({ "path": "/etc/passwd" }));
     }
+
+    #[test]
+    fn returns_none_when_method_is_not_tools_call() {
+        // `tools/list`, `initialize`, and other MCP methods must not trip the
+        // policy engine — only `tools/call` carries a `tool_name` to match
+        // structured rules against.
+        let body = br#"{
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": {}
+        }"#;
+        assert!(parse_mcp_request(body).is_none());
+    }
 }

--- a/aa-proxy/src/intercept/mcp.rs
+++ b/aa-proxy/src/intercept/mcp.rs
@@ -1,0 +1,94 @@
+//! MCP (Model Context Protocol) `tools/call` JSON-RPC 2.0 request parser.
+//!
+//! The MCP wire protocol uses JSON-RPC 2.0 envelopes. A `tools/call` request
+//! arriving at the proxy looks like:
+//!
+//! ```json
+//! {
+//!   "jsonrpc": "2.0",
+//!   "id": 1,
+//!   "method": "tools/call",
+//!   "params": { "name": "read_file", "arguments": { "path": "/etc/passwd" } }
+//! }
+//! ```
+//!
+//! This module extracts the semantic `tool_name` and `arguments` fields so a
+//! downstream policy engine can match rules like
+//! `deny if tool_name == "read_file" and arguments.path starts_with "/etc"` —
+//! a precision the raw-bytes credential scanner cannot reach.
+//!
+//! Scope: pure parser primitive only — see the F116 ST-Q detection slice in
+//! `aa-integration-tests/tests/e2e_mcp_interceptor.rs`. The MitM data-path
+//! wiring (calling this from inside the TLS tunnel, evaluating policy via the
+//! gateway, enforcing allow/deny/redact at the wire, and emitting structured
+//! `ToolCall` audit events) is tracked under AAASM-1930.
+
+use serde::Deserialize;
+
+/// Method name for the JSON-RPC 2.0 envelope this parser recognises.
+const MCP_TOOLS_CALL_METHOD: &str = "tools/call";
+
+/// JSON-RPC 2.0 protocol version this parser accepts. The MCP spec pins the
+/// envelope at exactly `"2.0"`; anything else is rejected so a malformed or
+/// non-MCP body cannot accidentally produce a tool-call match.
+const JSONRPC_VERSION: &str = "2.0";
+
+/// Semantic view of a single MCP `tools/call` request extracted from the raw
+/// request body. The fields here are the inputs a policy engine needs to
+/// match structured rules — the parser deliberately discards everything else
+/// (jsonrpc version, id, meta) since the proxy data path will pass through
+/// the original bytes if the call is allowed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpToolCall {
+    /// Tool name from `params.name` — e.g. `"read_file"`, `"execute_bash"`.
+    pub tool_name: String,
+    /// Tool arguments from `params.arguments` — kept as a raw
+    /// `serde_json::Value` so policy expressions can walk nested fields
+    /// without this module hard-coding a schema for every possible tool.
+    pub arguments: serde_json::Value,
+}
+
+/// Try to interpret `body` as a JSON-RPC 2.0 MCP `tools/call` request and
+/// extract the [`McpToolCall`].
+///
+/// Returns `None` when any of the following hold (these are the rejection
+/// conditions the policy engine relies on to avoid false-positive matches
+/// against arbitrary JSON traffic flowing through the proxy):
+///
+/// * `body` is not valid JSON.
+/// * The top-level object lacks `jsonrpc`, or `jsonrpc != "2.0"`.
+/// * `method` is missing or not `"tools/call"`.
+/// * `params` is missing.
+/// * `params.name` is missing or not a string.
+///
+/// When `params.arguments` is missing it is normalised to `Value::Null` so
+/// callers can always treat it as a structured value.
+pub fn parse_mcp_request(body: &[u8]) -> Option<McpToolCall> {
+    #[derive(Deserialize)]
+    struct Envelope {
+        jsonrpc: Option<String>,
+        method: Option<String>,
+        params: Option<Params>,
+    }
+
+    #[derive(Deserialize)]
+    struct Params {
+        name: Option<String>,
+        #[serde(default)]
+        arguments: serde_json::Value,
+    }
+
+    let envelope: Envelope = serde_json::from_slice(body).ok()?;
+    if envelope.jsonrpc.as_deref() != Some(JSONRPC_VERSION) {
+        return None;
+    }
+    if envelope.method.as_deref() != Some(MCP_TOOLS_CALL_METHOD) {
+        return None;
+    }
+    let params = envelope.params?;
+    let tool_name = params.name?;
+    Some(McpToolCall {
+        tool_name,
+        arguments: params.arguments,
+    })
+}

--- a/aa-proxy/src/intercept/mcp.rs
+++ b/aa-proxy/src/intercept/mcp.rs
@@ -140,4 +140,18 @@ mod tests {
         let no_version = br#"{"id":1,"method":"tools/call","params":{"name":"x"}}"#;
         assert!(parse_mcp_request(no_version).is_none());
     }
+
+    #[test]
+    fn returns_none_when_params_name_is_missing() {
+        // A `tools/call` request without a `name` cannot drive any tool — the
+        // policy engine would have nothing to match against, so the parser
+        // rejects it before any policy evaluation happens.
+        let body = br#"{
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "arguments": { "path": "/etc/passwd" } }
+        }"#;
+        assert!(parse_mcp_request(body).is_none());
+    }
 }

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -3,6 +3,7 @@
 pub mod detect;
 pub mod event;
 pub mod extract;
+pub mod mcp;
 
 use std::time::{SystemTime, UNIX_EPOCH};
 


### PR DESCRIPTION
## Description

F116 ST-Q (AAASM-1572) — MCP interceptor detection slice.

Ships a new `aa_proxy::intercept::mcp` parser primitive that extracts the
structured `tool_name` and `arguments` from a JSON-RPC 2.0 `tools/call`
envelope, plus an `aa-integration-tests/tests/e2e_mcp_interceptor.rs`
detection slice that exercises the primitive against MCP-shaped bodies the
proxy will see in production.

**Scope decision: detection slice + follow-up subtask.** Matches the
established ST-N → AAASM-1566 (Done) pattern. The original ST-Q spec assumes
a protocol-aware MCP interceptor in the proxy's MitM data path with a gateway
client, on-the-wire enforcement (deny → JSON-RPC error envelope, redact →
result mutation), and structured `ToolCall` audit emission. None of that
data-path wiring exists today (the proxy is `tokio::io::copy` with the
credential scanner only). Rather than silently downscope the ST-Q assertions,
this PR ships the **parser primitive** + **detection-slice tests** for the
shape the data-path will plug into, and files **AAASM-1930** to carry the
remaining wiring + un-ignoring of ST-Q-1..5.

**What this PR adds:**

* `aa-proxy/src/intercept/mcp.rs` — pure parser: `parse_mcp_request(body) -> Option<McpToolCall>` with `{ tool_name: String, arguments: serde_json::Value }`. Rejects non-MCP traffic (wrong jsonrpc version, wrong method, missing params.name, malformed JSON) so the policy engine never matches MCP rules against arbitrary bodies.
* 6 unit tests for the parser (positive, non-tools/call rejection, wrong jsonrpc, missing name, malformed JSON, missing-arguments default to `Null`).
* 5 integration detection tests in `e2e_mcp_interceptor.rs`:
  * `parser_extracts_tool_name_and_path_for_deny_match` — `/etc/passwd` shape
  * `parser_extracts_tool_name_and_path_for_allow_match` — `/home/user/file.txt` shape
  * `parser_preserves_nested_arguments_object` — JSON-pointer walk through nested config
  * `parser_rejects_non_mcp_json_traffic_seen_by_proxy` — OpenAI / Anthropic / generic JSON must return `None`
  * `parser_does_not_leak_secret_bytes_outside_arguments_value` — security invariant
* 5 `#[ignore = "AAASM-1930: …"]` placeholders for ST-Q-1..5 recording the exact assertion the data-path follow-up will verify.

**What this PR does NOT do** (tracked under AAASM-1930):

* No `aa-proxy` data-path wiring (no call to `parse_mcp_request` from inside the MitM tunnel).
* No gateway client in `aa-proxy` (no `PolicyEvaluationRequest` carrying `ToolCallContext`).
* No JSON-RPC error envelope writer / result mutation on the wire.
* No mock MCP server fixture, no MCP policy YAML fixtures.
* No changes to existing credential-scanner / LLM-intercept paths.

## Type of Change

- [x] ✨ New feature (MCP parser primitive in `aa-proxy`)
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

The new `aa_proxy::intercept::mcp` module is purely additive. No existing
public APIs change. The proxy data path is unchanged — `parse_mcp_request`
is exported but not yet called from any production code path.

## Related Issues

* Related Jira ticket: **AAASM-1572** (F116 ST-Q — this PR)
* Parent Story: **AAASM-1232** (F116: Full MVP acceptance test)
* Follow-up filed: **AAASM-1930** (aa-proxy MCP interceptor data-path — parse, evaluate, enforce, audit)
* Precedent pattern: AAASM-1549 (ST-N) → AAASM-1566 (ST-N data-path, Done)

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added (6 new in `aa-proxy/src/intercept/mcp.rs`)
- [x] Integration tests added (5 detection tests + 5 `#[ignore]` placeholders in `aa-integration-tests/tests/e2e_mcp_interceptor.rs`)
- [x] Manual testing performed (full `cargo test -p aa-proxy --lib` → 74 passed, 0 failed; full `cargo test -p aa-integration-tests --test e2e_mcp_interceptor` → 5 passed, 5 ignored)
- [ ] No tests required (explain why)

Manual verification:

```bash
cd agent-assembly
cargo test -p aa-proxy --lib intercept::mcp
# running 6 tests … test result: ok. 6 passed; 0 failed; 0 ignored

cargo test -p aa-integration-tests --test e2e_mcp_interceptor
# running 10 tests … test result: ok. 5 passed; 0 failed; 5 ignored
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (module docs on `mcp.rs`; file-level docstring on the integration test explaining the detection-slice scope and AAASM-1930 follow-up)
- [x] All CI checks passing (local pre-commit hook + workspace-wide clippy clean on every commit)
- [x] Commits are small and follow the Gitmoji convention (18 commits, one per logical unit — module / re-export / each test)
