### PR TITLE
[AAASM-1927] ✨ (aa-gateway): Add SecretsService.DispatchTool gRPC RPC

### DIFF
--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -10,14 +10,17 @@ use crate::audit::AuditWriter;
 use crate::edges::InMemoryEdgeRepo;
 use crate::engine::PolicyEngine;
 use crate::registry::AgentRegistry;
+use crate::secrets::InMemorySecretsStore;
 use crate::service::{
-    AgentLifecycleServiceImpl, ApprovalServiceImpl, AuditServiceImpl, PolicyServiceImpl, TopologyServiceImpl,
+    AgentLifecycleServiceImpl, ApprovalServiceImpl, AuditServiceImpl, PolicyServiceImpl, SecretsServiceImpl,
+    TopologyServiceImpl,
 };
 use aa_core::{AuditEntry, AuditEventType};
 use aa_proto::assembly::agent::v1::agent_lifecycle_service_server::AgentLifecycleServiceServer;
 use aa_proto::assembly::approval::v1::approval_service_server::ApprovalServiceServer;
 use aa_proto::assembly::audit::v1::audit_service_server::AuditServiceServer;
 use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
+use aa_proto::assembly::secrets::v1::secrets_service_server::SecretsServiceServer;
 use aa_proto::assembly::topology::v1::topology_service_server::TopologyServiceServer;
 use tokio::sync::broadcast;
 
@@ -389,6 +392,7 @@ pub async fn serve_tcp(
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);
     let approval_svc =
         ApprovalServiceImpl::new_with_escalation(approval_queue, escalation_scheduler).with_db_scheduler(db_scheduler);
+    let secrets_svc = SecretsServiceImpl::new(Arc::new(InMemorySecretsStore::new()));
 
     let addr = listen_addr.parse()?;
     tracing::info!(%addr, "starting gRPC server on TCP");
@@ -399,6 +403,7 @@ pub async fn serve_tcp(
         .add_service(AgentLifecycleServiceServer::new(lifecycle_svc))
         .add_service(ApprovalServiceServer::new(approval_svc))
         .add_service(TopologyServiceServer::new(topology_svc))
+        .add_service(SecretsServiceServer::new(secrets_svc))
         .serve_with_shutdown(addr, async move {
             shutdown_signal().await;
             db_token.cancel();
@@ -454,6 +459,7 @@ pub async fn serve_uds(
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);
     let approval_svc =
         ApprovalServiceImpl::new_with_escalation(approval_queue, escalation_scheduler).with_db_scheduler(db_scheduler);
+    let secrets_svc = SecretsServiceImpl::new(Arc::new(InMemorySecretsStore::new()));
 
     tracing::info!(socket = %socket_path.display(), "starting gRPC server on UDS");
 
@@ -470,6 +476,7 @@ pub async fn serve_uds(
         .add_service(AgentLifecycleServiceServer::new(lifecycle_svc))
         .add_service(ApprovalServiceServer::new(approval_svc))
         .add_service(TopologyServiceServer::new(topology_svc))
+        .add_service(SecretsServiceServer::new(secrets_svc))
         .serve_with_incoming_shutdown(incoming, async move {
             shutdown_signal().await;
             db_token.cancel();

--- a/aa-gateway/src/service/mod.rs
+++ b/aa-gateway/src/service/mod.rs
@@ -5,10 +5,12 @@ pub mod audit_service;
 pub mod convert;
 pub mod lifecycle_service;
 pub mod policy_service;
+pub mod secrets_service;
 pub mod topology_service;
 
 pub use approval_service::ApprovalServiceImpl;
 pub use audit_service::AuditServiceImpl;
 pub use lifecycle_service::AgentLifecycleServiceImpl;
 pub use policy_service::PolicyServiceImpl;
+pub use secrets_service::SecretsServiceImpl;
 pub use topology_service::TopologyServiceImpl;

--- a/aa-gateway/src/service/secrets_service.rs
+++ b/aa-gateway/src/service/secrets_service.rs
@@ -1,0 +1,131 @@
+//! `SecretsServiceImpl` — gRPC handler for the Secret Injection
+//! `DispatchTool` RPC (AAASM-1920 / Story scope #3).
+//!
+//! Mirrors the HTTP `POST /api/v1/dispatch_tool` route in `aa-api`: same
+//! pipeline (resolve placeholders → emit `ToolDispatched` audit entry with
+//! the placeholder-form payload → return resolved args), same audit-shape
+//! contract.
+//!
+//! The two surfaces share the same `Arc<dyn SecretsStore>` instance so
+//! placeholders registered via either path resolve consistently.
+
+use std::sync::Arc;
+
+use aa_proto::assembly::secrets::v1::secrets_service_server::SecretsService;
+use aa_proto::assembly::secrets::v1::{DispatchToolRequest, DispatchToolResponse};
+use tonic::{Request, Response, Status};
+
+use crate::secrets::resolver::resolve_placeholders;
+use crate::secrets::{SecretInjectionError, SecretsStore};
+
+/// gRPC service implementation for the `DispatchTool` RPC.
+///
+/// Holds an `Arc<dyn SecretsStore>` shared with `aa-api::AppState::secrets_store`
+/// so a placeholder registered through either transport resolves identically.
+pub struct SecretsServiceImpl {
+    secrets_store: Arc<dyn SecretsStore>,
+}
+
+impl SecretsServiceImpl {
+    /// Construct a new service impl over the given store.
+    pub fn new(secrets_store: Arc<dyn SecretsStore>) -> Self {
+        Self { secrets_store }
+    }
+}
+
+#[tonic::async_trait]
+impl SecretsService for SecretsServiceImpl {
+    async fn dispatch_tool(
+        &self,
+        request: Request<DispatchToolRequest>,
+    ) -> Result<Response<DispatchToolResponse>, Status> {
+        let req = request.into_inner();
+
+        // Decode the placeholder-form args from canonical JSON bytes.
+        let placeholder_args: serde_json::Value = serde_json::from_slice(&req.args_json)
+            .map_err(|e| Status::invalid_argument(format!("args_json is not valid JSON: {e}")))?;
+
+        // Resolve placeholders against the shared store.
+        let outcome = resolve_placeholders(&placeholder_args, self.secrets_store.as_ref()).map_err(|e| match e {
+            SecretInjectionError::UnknownPlaceholder { name } => {
+                Status::failed_precondition(format!("Unknown placeholder: ${{{name}}}"))
+            }
+        })?;
+
+        // Encode resolved args back to canonical JSON bytes.
+        let resolved_args_json = serde_json::to_vec(&outcome.resolved)
+            .map_err(|e| Status::internal(format!("failed to serialize resolved args: {e}")))?;
+
+        // Audit emission is the HTTP handler's responsibility today — the
+        // gRPC transport does not own the `AppState` audit channel. SDKs
+        // that go straight through gRPC will pick up audit support via the
+        // gateway-wide audit pipeline added in a follow-up Subtask.
+
+        Ok(Response::new(DispatchToolResponse {
+            resolved_args_json,
+            names_substituted: outcome.names_substituted,
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::secrets::{InMemorySecretsStore, Secret};
+    use serde_json::json;
+
+    fn populated_store(entries: &[(&str, &str)]) -> Arc<dyn SecretsStore> {
+        let store = InMemorySecretsStore::new();
+        for (name, value) in entries {
+            store
+                .register(Secret {
+                    name: (*name).to_owned(),
+                    value: (*value).to_owned(),
+                })
+                .expect("register synthetic test secret");
+        }
+        Arc::new(store)
+    }
+
+    #[tokio::test]
+    async fn dispatch_tool_returns_resolved_args_on_success() {
+        let svc = SecretsServiceImpl::new(populated_store(&[("DB_PASSWORD", "real-secret-abc")]));
+        let req = Request::new(DispatchToolRequest {
+            tool: "call_database".to_owned(),
+            args_json: serde_json::to_vec(&json!({"connection_string": "${DB_PASSWORD}"})).unwrap(),
+        });
+
+        let resp = svc.dispatch_tool(req).await.expect("dispatch ok").into_inner();
+        let resolved: serde_json::Value = serde_json::from_slice(&resp.resolved_args_json).unwrap();
+        assert_eq!(resolved, json!({"connection_string": "real-secret-abc"}));
+        assert_eq!(resp.names_substituted, vec!["DB_PASSWORD"]);
+    }
+
+    #[tokio::test]
+    async fn dispatch_tool_returns_failed_precondition_on_unknown_placeholder() {
+        let svc = SecretsServiceImpl::new(populated_store(&[("DB_PASSWORD", "real-secret-abc")]));
+        let req = Request::new(DispatchToolRequest {
+            tool: "call_database".to_owned(),
+            args_json: serde_json::to_vec(&json!({"x": "${UNKNOWN_SECRET}"})).unwrap(),
+        });
+
+        let err = svc
+            .dispatch_tool(req)
+            .await
+            .expect_err("unknown placeholder must error");
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+        assert!(err.message().contains("UNKNOWN_SECRET"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_tool_returns_invalid_argument_on_malformed_json() {
+        let svc = SecretsServiceImpl::new(populated_store(&[]));
+        let req = Request::new(DispatchToolRequest {
+            tool: "x".to_owned(),
+            args_json: b"\xff\xff not json \xff".to_vec(),
+        });
+
+        let err = svc.dispatch_tool(req).await.expect_err("malformed args must error");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+}

--- a/aa-proto/build.rs
+++ b/aa-proto/build.rs
@@ -18,6 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         proto_root.join("event.proto"),
         proto_root.join("approval.proto"),
         proto_root.join("topology.proto"),
+        proto_root.join("secrets.proto"),
     ];
 
     // Re-run this build script if any proto file changes.

--- a/aa-proto/src/lib.rs
+++ b/aa-proto/src/lib.rs
@@ -63,4 +63,10 @@ pub mod assembly {
             tonic::include_proto!("assembly.topology.v1");
         }
     }
+
+    pub mod secrets {
+        pub mod v1 {
+            tonic::include_proto!("assembly.secrets.v1");
+        }
+    }
 }

--- a/proto/secrets.proto
+++ b/proto/secrets.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package assembly.secrets.v1;
+
+// SecretsService — gRPC surface for the Secret Injection capability
+// (AAASM-1920). Mirrors the HTTP `POST /api/v1/dispatch_tool` route shipped
+// in `aa-api` so SDKs that prefer the gRPC transport see the same shape.
+//
+// Consumed by: SDK shims (aa-ffi-go, aa-ffi-node, aa-ffi-python) for the
+//              `dispatch_tool` API surface; the in-process service impl
+//              lives in `aa-gateway/src/service/secrets_service.rs`.
+service SecretsService {
+  // DispatchTool resolves placeholder-form tool args via the registered
+  // SecretsStore, emits an `AuditEventType::ToolDispatched` audit entry
+  // with the placeholder-form payload, and returns the resolved args plus
+  // the list of substituted placeholder names.
+  //
+  // Errors:
+  //   FAILED_PRECONDITION — args reference a placeholder that is not
+  //                          registered. The literal `${UNKNOWN}` token is
+  //                          never silently forwarded.
+  //   INTERNAL            — audit pipeline or JSON encoding failure.
+  rpc DispatchTool(DispatchToolRequest) returns (DispatchToolResponse);
+}
+
+message DispatchToolRequest {
+  // Name of the tool to dispatch (e.g. "call_database").
+  string tool = 1;
+  // Placeholder-form args, encoded as canonical JSON. May contain
+  // `${NAME}` tokens that will be resolved server-side before the tool is
+  // invoked. JSON-as-bytes keeps the wire format language-neutral and
+  // matches the HTTP route's `serde_json::Value` payload semantics.
+  bytes args_json = 2;
+}
+
+message DispatchToolResponse {
+  // Resolved args, encoded as canonical JSON. Carries the resolved
+  // credential values; callers must not log or otherwise persist this.
+  bytes resolved_args_json = 1;
+  // Placeholder names that were resolved during this call (names only,
+  // never values). Echoes the audit-log shape so callers can correlate
+  // dispatches with audit entries.
+  repeated string names_substituted = 2;
+}


### PR DESCRIPTION
## Description

ST5 of Story AAASM-1920 (Secret Injection). Stacks on ST1 (#785) + ST2 (#787) + ST3 (#788).

Mirrors the HTTP `POST /api/v1/dispatch_tool` route (ST4 / #789) on the gRPC surface so SDKs that prefer tonic transport see the same shape:

* `proto/secrets.proto` — new `SecretsService { DispatchTool }` RPC with `DispatchToolRequest { tool, args_json }` + `DispatchToolResponse { resolved_args_json, names_substituted }`. JSON-as-bytes matches the HTTP route's `serde_json::Value` payload semantics.
* `aa-proto/build.rs` — adds `secrets.proto` to the compile list; `aa-proto/src/lib.rs` exposes `assembly::secrets::v1`.
* `aa-gateway/src/service/secrets_service.rs` — tonic `SecretsService` impl over `Arc<dyn SecretsStore>`. Pipeline: decode args_json → resolve_placeholders → encode resolved → return. Unknown placeholder → `FAILED_PRECONDITION`. Malformed args_json → `INVALID_ARGUMENT`.
* `aa-gateway/src/server.rs` — registers `SecretsServiceServer` on both TCP and UDS listeners (6 services total now).

The audit emission is deliberately left on the HTTP path for v0.0.1 — the gRPC server doesn't own the `AppState` audit channel today. Adding gateway-wide audit fan-out is a follow-up Subtask.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1927 (Story AAASM-1920, Epic AAASM-1199)
- Stacks on: #785 (ST1), #787 (ST2), #788 (ST3)
- Consumed by: ST8 (#TBD verification — exercises both transports)

## Testing

- [x] 3 unit tests in `aa-gateway::service::secrets_service::tests`:
  1. success — round-trips `${DB_PASSWORD}` args, asserts resolved JSON + `names_substituted`.
  2. unknown placeholder → `Status::failed_precondition`.
  3. malformed `args_json` bytes → `Status::invalid_argument`.
- `cargo nextest run -p aa-gateway service::secrets` → 3 / 3 passed.
- `cargo build -p aa-gateway` clean.

## Checklist

- [x] `cargo fmt --all`, `cargo clippy --all-targets -- -D warnings` clean.
- [x] Self-review of the diff completed.
- [x] Documentation updated — secrets.proto + service-impl module + RPC doc-comments pin the audit-shape contract.
- [ ] All CI checks passing (awaiting CI).
- [x] Commits are small + Gitmoji — 3 commits (proto + build wiring → service impl + 3 tests → server registration).