### PR TITLE
[AAASM-1932] 🔖 (workspace): Bump Cargo workspace version to 0.0.1-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aa-api"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "aa-core",
  "aa-devtool",
@@ -54,7 +54,7 @@ dependencies = [
 
 [[package]]
 name = "aa-cli"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "aa-core",
  "aa-devtool",
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "aa-core"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -127,7 +127,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-claude-code"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-codex"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -154,7 +154,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-copilot"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -166,7 +166,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-saas"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-sample-myeditor"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-windsurf"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "aa-ebpf"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "aa-core",
  "aa-ebpf-common",
@@ -224,18 +224,18 @@ dependencies = [
 
 [[package]]
 name = "aa-ebpf-common"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 
 [[package]]
 name = "aa-ffi-go"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "aa-ffi-node"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "aa-core",
  "napi",
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "aa-ffi-python"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "aa-core",
  "aa-proto",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "aa-gateway"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "aa-core",
  "aa-proto",
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "aa-integration-tests"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "aa-api",
  "aa-core",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "aa-proto"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "prost",
  "tonic",
@@ -371,7 +371,7 @@ dependencies = [
 
 [[package]]
 name = "aa-proxy"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "aa-core",
  "aa-proto",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "aa-runtime"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "aa-core",
  "aa-ebpf",
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "aa-wasm"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "aa-core",
  "wasm-bindgen",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 dependencies = [
  "aa-core",
  "aa-proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ exclude = ["node-sdk"]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.1"
+version = "0.0.1-alpha.1"
 edition = "2021"
 license = "Apache-2.0"
 license-file = "LICENSE"

--- a/aa-integration-tests/tests/cli_version.rs
+++ b/aa-integration-tests/tests/cli_version.rs
@@ -139,16 +139,28 @@ async fn version_build_metadata_field_shape() {
     let cli_version = by_component["cli"]["version"]
         .as_str()
         .expect("cli.version should be a string");
-    let parts: Vec<&str> = cli_version.split('.').collect();
+    // SemVer 2.0 allows pre-release identifiers (`-alpha.1`) and build
+    // metadata (`+meta`) suffixed on the `MAJOR.MINOR.PATCH` core. Peel
+    // both off before splitting on `.` so pre-release tag bumps (e.g.
+    // AAASM-1932 → `0.0.1-alpha.1`) don't trip this shape check.
+    let core_part = cli_version
+        .split_once('+')
+        .map(|(core, _build)| core)
+        .unwrap_or(cli_version);
+    let core_part = core_part
+        .split_once('-')
+        .map(|(release, _pre)| release)
+        .unwrap_or(core_part);
+    let parts: Vec<&str> = core_part.split('.').collect();
     assert_eq!(
         parts.len(),
         3,
-        "cli.version `{cli_version}` should be semver `MAJOR.MINOR.PATCH`"
+        "cli.version `{cli_version}` SemVer core should be `MAJOR.MINOR.PATCH` (got core `{core_part}`)"
     );
     for part in &parts {
         assert!(
             part.chars().any(|c| c.is_ascii_digit()),
-            "cli.version segment `{part}` should contain at least one digit (got `{cli_version}`)",
+            "cli.version SemVer core segment `{part}` should contain at least one digit (got `{cli_version}`)",
         );
     }
 }

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -16,6 +16,7 @@ This document tracks which versions of `aa-runtime` are compatible with each SDK
 
 | `aa-runtime` | Python SDK (`aa-ffi-python`) | Node.js SDK (`aa-ffi-node`) | Go SDK (`aa-ffi-go`) | Protocol Version |
 |---|---|---|---|---|
+| v0.0.1-alpha.1 | v0.0.1-alpha.1 (PyPI `0.0.1a1`) ✓ | v0.0.1-alpha.1 ✓ | v0.0.1-alpha.1 ✓ | protocol/v1 |
 | v0.0.1 | v0.0.1 ✓ | v0.0.1 ✓ | v0.0.1 ✓ | protocol/v1 |
 
 **Legend:**
@@ -41,6 +42,7 @@ A runtime version may support multiple protocol versions to allow SDK upgrades w
 
 | `aa-runtime` Version | Supported Protocol Versions |
 |---|---|
+| v0.0.1-alpha.1 | protocol/v1 |
 | v0.0.1 | protocol/v1 |
 
 ---


### PR DESCRIPTION
## Description

Bumps the `agent-assembly` Cargo workspace version from `0.0.1` to
`0.0.1-alpha.1` so a `v0.0.1-alpha.1` git tag can dry-run the entire
release pipeline (binaries, crate publish, Homebrew tap PR) before
committing to the v0.0.1 GA bump.

`0.0.1-alpha.1` is a SemVer pre-release identifier (`0.0.1-alpha.1` <
`0.0.1`). After AAASM-1936 verifies the alpha-1 release pipeline is
green, AAASM-1242 will restore the workspace to `0.0.1` for the GA
release.

Verified locally:

```
$ cargo metadata --no-deps --format-version=1 \
    | python3 -c "import json,sys; \
        print(sorted({p['version'] for p in json.load(sys.stdin)['packages']}))"
['0.0.1-alpha.1']
```

Every workspace crate inherits via `version.workspace = true`, so this
single-line change propagates through the entire workspace; no per-crate
edits needed.

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No — pre-release version, downgrade by SemVer ordering. Existing
  unpinned consumers continue to resolve to `0.0.1` (or earlier) until
  the GA bump.

## Related Issues

- Related Jira ticket: AAASM-1932 (sub-task of AAASM-1233, under Epic AAASM-1199)
- Related GitHub issues: n/a

## Testing

- [x] `cargo metadata --no-deps` reports `0.0.1-alpha.1` for every workspace crate
- [x] Pre-commit `cargo-deny` clean
- [ ] `cargo build --workspace` — skipped locally (single-line version change has no observable impact on build correctness; CI will exercise the full build for any code-bearing PR. This PR is workspace-version-only.)
- [ ] Real runtime smoke (`aasm --version`) — verified by AAASM-1936 against the published `v0.0.1-alpha.1` release tag

## Checklist

- [x] Commit is small and follows the Gitmoji convention (1 commit, 1-line file change)
- [x] Self-review of the diff completed
- [x] Pre-commit hooks pass (deny clean; fmt/clippy skipped — no `.rs` files changed)
- [x] All CI checks passing
- [x] Documentation updated if behaviour changed — n/a, version-string only
