### PR TITLE
[AAASM-1937] 📝 (changelog): Add [0.0.1-alpha.1] pre-release entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to **AI Agent Assembly** are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.0.1-alpha.1] — 2026-05-25 (pre-release)
+
+> **Not for production use.** This is the first pre-release of AI Agent Assembly,
+> published to **dry-run the full v0.0.1 distribution pipeline** before cutting the
+> v0.0.1 GA tag. Functional scope is identical to the upcoming v0.0.1 GA — this
+> release does not add features beyond what GA will ship.
+
+### Pre-release purpose
+
+- Verify the cross-repo release workflows (`agent-assembly`, `python-sdk`,
+  `node-sdk`, `go-sdk`) function end-to-end before cutting v0.0.1.
+- Exercise the F119 smoke-test workflow (`.github/workflows/smoke-test.yml`)
+  against real published artifacts.
+- Surface any release-infrastructure bugs (Homebrew tap location, PyPI package
+  name, curl installer endpoint, GHCR tag scheme, secret configuration) in a
+  low-stakes channel before the GA release.
+
+### Channel-specific dist-tag behaviour
+
+Pre-release artifacts publish only under pre-release tags on each channel, so
+unpinned `npm install` / `pip install` continue to resolve to the previous GA
+version (or skip pre-releases entirely):
+
+| Channel       | How to install the alpha-1 explicitly                         |
+| ---           | ---                                                           |
+| npm           | `npm install @agent-assembly/sdk@0.0.1-alpha.1` (or `@alpha`) |
+| PyPI          | `pip install --pre agent-assembly-python==0.0.1a1`            |
+| crates.io     | `cargo install aasm --version 0.0.1-alpha.1`                  |
+| Docker (GHCR) | `docker pull ghcr.io/agent-assembly/python:0.0.1-alpha.1`     |
+| Homebrew      | tap formula not auto-updated on pre-releases                  |
+
+For the GA release scope, see the upcoming [0.0.1] entry, which will be authored
+under AAASM-1247 once the alpha-1 dry-run passes and the GA tag is cut.
+
+[0.0.1-alpha.1]: https://github.com/AI-agent-assembly/agent-assembly/releases/tag/v0.0.1-alpha.1


### PR DESCRIPTION
## Description

Creates `CHANGELOG.md` in the `agent-assembly` repo root following the
[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format and seeds
it with a `[0.0.1-alpha.1]` pre-release entry.

The entry:

- Frames the alpha-1 release as a **dry-run of the v0.0.1 distribution
  pipeline**, not a feature-bearing release.
- Documents channel-specific install commands (npm `@alpha` dist-tag,
  PyPI `--pre`, cargo `--version`, Docker tag, Homebrew note).
- Leaves a placeholder reference to the upcoming `[0.0.1]` GA entry
  (authored later under AAASM-1247).

After the alpha-1 dry-run passes and v0.0.1 GA is cut, AAASM-1247 will
add the full GA entry **above** the alpha-1 section (Keep a Changelog
reverse-chronological order). The alpha-1 entry stays in the file for
historical traceability.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1937 (sub-task of AAASM-1234, under Epic AAASM-1199)
- Related GitHub issues: n/a

## Testing

- [x] Self-review of the diff (single new file, 42 lines)
- [x] Conforms to Keep a Changelog 1.1.0 structure (heading levels,
  date format, dist-tag table)
- [ ] Live alpha-1 publish verification — deferred to AAASM-1939
  (alpha-1 release-notes acceptance) and AAASM-1936 (alpha-1
  release-pipeline verification)

## Checklist

- [x] Commit is small and follows the Gitmoji convention (1 commit,
  1 new file)
- [x] Self-review of the diff completed
- [x] No Rust code changed; pre-commit / pre-push hooks skipped cleanly
- [x] CI: scoped to `CHANGELOG.md` — outside any existing workflow's
  `paths:` filter, so "no checks reported" is the expected status
- [x] Documentation updated — this PR **is** the documentation
