### PR TITLE
[AAASM-1938] 📝 (release): Draft v0.0.1-alpha.1 pre-release notes

### DIFF
--- a/docs/release/v0.0.1-alpha.1.md
+++ b/docs/release/v0.0.1-alpha.1.md
@@ -1,0 +1,57 @@
+# v0.0.1-alpha.1 — pre-release dry-run
+
+> **Operator note** — this file is the source-controlled draft of the GitHub
+> Release description for the `v0.0.1-alpha.1` tag. When you cut the tag on
+> GitHub Releases, paste the section below the **`---`** separator into the
+> "Describe this release" textarea and tick the **"Set as a pre-release"**
+> checkbox.
+
+---
+
+## v0.0.1-alpha.1 — pre-release dry-run
+
+This release exists to **dry-run the full v0.0.1 distribution pipeline** before
+cutting the v0.0.1 GA tag. Functional scope is identical to the upcoming v0.0.1
+GA — this is not a feature-bearing release.
+
+### Why pre-release
+
+- Confirms binaries, PyPI wheels, npm packages, GHCR images, and the Homebrew
+  tap update all publish correctly from a single coordinated tag push.
+- Exercises the `Smoke Test (Release Artifacts)` workflow against real
+  artifacts.
+- Surfaces any release-infrastructure bugs (Homebrew tap location, PyPI package
+  name, curl installer endpoint, GHCR tag scheme, secret configuration) in a
+  low-stakes channel before the GA tag.
+
+### Not for production use
+
+Pre-release artifacts use pre-release dist-tags on each channel — unpinned
+installs continue to resolve to the previous GA version (or skip pre-releases
+entirely):
+
+| Channel       | How to install                                                |
+| ---           | ---                                                           |
+| npm           | `npm install @agent-assembly/sdk@0.0.1-alpha.1` (or `@alpha`) |
+| PyPI          | `pip install --pre agent-assembly-python==0.0.1a1`            |
+| crates.io     | `cargo install aasm --version 0.0.1-alpha.1`                  |
+| Docker (GHCR) | `docker pull ghcr.io/agent-assembly/python:0.0.1-alpha.1`     |
+| Homebrew      | tap formula is **not** auto-updated for pre-releases          |
+
+For the GA release scope, see v0.0.1 when it is published.
+
+---
+
+## Authoring conventions for this template
+
+This document is the canonical template for **pre-release** GitHub Release
+descriptions in this project. When the v0.0.1 GA tag is cut (AAASM-1248), the
+GA release will use a separate document at `docs/release/v0.0.1.md` (or
+similar) with its own narrative — full feature list, install commands for the
+default dist-tags, link to documentation, known limitations.
+
+The horizontal-rule separator above lets `gh release create … --notes-file
+docs/release/v0.0.1-alpha.1.md` paste only the body; the operator-note header
+is kept out of the public release description.
+
+Refs: AAASM-1938


### PR DESCRIPTION
## Description

Adds `docs/release/v0.0.1-alpha.1.md` — the **source-controlled draft of
the GitHub Release description** the operator pastes into the Releases
UI when cutting `v0.0.1-alpha.1`.

Structure:

```
# Operator note (kept out of public release)
---
## Public release description (≤200 words)
… pre-release framing, channel-specific install commands …
```

The horizontal-rule separator lets `gh release create --notes-file
docs/release/v0.0.1-alpha.1.md` paste the operator note + body together
(harmless), while a manual copy/paste into the Releases UI grabs only
the body below the rule.

Establishes the canonical **template** for pre-release notes in this
project. The v0.0.1 GA release description (AAASM-1248) will use a
separate file with its own narrative (full feature list, default
dist-tags, link to documentation, known limitations).

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-1938 (sub-task of AAASM-1234, under Epic AAASM-1199)
- Related GitHub issues: n/a

## Testing

- [x] Self-review of the diff (single new file, 57 lines)
- [x] Content cross-referenced with `CHANGELOG.md` `[0.0.1-alpha.1]`
  entry (AAASM-1937 / PR #794) — install commands and framing match
- [ ] Operator-paste verification — deferred to AAASM-1939
  (alpha-1 release-notes acceptance) ahead of the actual tag cut

## Checklist

- [x] Commit is small and follows the Gitmoji convention (1 commit,
  1 new file)
- [x] Self-review of the diff completed
- [x] No Rust code changed; pre-commit / pre-push hooks skipped cleanly
- [x] CI: scoped to `docs/release/*.md` — outside any existing
  workflow's `paths:` filter, so "no checks reported" is the expected
  status
- [x] Documentation updated — this PR **is** the documentation
