### PR TITLE
[AAASM-1930] ✨ (aa-proxy): MCP enforcement helpers + ProxyConfig gateway endpoint (foundation)

### DIFF
--- a/aa-integration-tests/tests/e2e_policy_proxy.rs
+++ b/aa-integration-tests/tests/e2e_policy_proxy.rs
@@ -35,6 +35,7 @@ fn proxy_config(ca_dir: &std::path::Path, denied_hosts: Vec<String>) -> ProxyCon
         skip_upstream_tls_verify: true,
         credential_action: CredentialAction::default(),
         upstream_override: None,
+        gateway_endpoint: None,
     }
 }
 

--- a/aa-integration-tests/tests/e2e_secret_interception.rs
+++ b/aa-integration-tests/tests/e2e_secret_interception.rs
@@ -531,6 +531,7 @@ mod proxy_data_path {
             skip_upstream_tls_verify: true,
             credential_action,
             upstream_override: Some(upstream_override),
+            gateway_endpoint: None,
         };
         let bind_addr = config.bind_addr;
         let (tx, rx) = broadcast::channel(64);

--- a/aa-proxy/src/config.rs
+++ b/aa-proxy/src/config.rs
@@ -188,6 +188,7 @@ mod tests {
         std::env::remove_var("AA_PROXY_DENIED_HOSTS");
         std::env::remove_var("AA_PROXY_SKIP_UPSTREAM_TLS_VERIFY");
         std::env::remove_var("AA_PROXY_CREDENTIAL_ACTION");
+        std::env::remove_var("AA_PROXY_GATEWAY_ENDPOINT");
     }
 
     #[test]
@@ -334,5 +335,37 @@ mod tests {
             msg.contains("AA_PROXY_CREDENTIAL_ACTION"),
             "error must name the env var, got: {msg}"
         );
+    }
+
+    #[test]
+    fn from_env_gateway_endpoint_defaults_to_none() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_env_vars();
+
+        let cfg = ProxyConfig::from_env().unwrap();
+        assert_eq!(cfg.gateway_endpoint, None);
+    }
+
+    #[test]
+    fn from_env_reads_gateway_endpoint() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_env_vars();
+        std::env::set_var("AA_PROXY_GATEWAY_ENDPOINT", "http://127.0.0.1:50051");
+
+        let cfg = ProxyConfig::from_env().unwrap();
+        assert_eq!(cfg.gateway_endpoint.as_deref(), Some("http://127.0.0.1:50051"));
+    }
+
+    #[test]
+    fn from_env_gateway_endpoint_empty_string_is_none() {
+        // Empty AA_PROXY_GATEWAY_ENDPOINT must be treated as "unset" so
+        // operators can disable MCP forwarding by clearing the variable
+        // without unsetting it (matches the AA_PROXY_DENIED_HOSTS pattern).
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_env_vars();
+        std::env::set_var("AA_PROXY_GATEWAY_ENDPOINT", "");
+
+        let cfg = ProxyConfig::from_env().unwrap();
+        assert_eq!(cfg.gateway_endpoint, None);
     }
 }

--- a/aa-proxy/src/config.rs
+++ b/aa-proxy/src/config.rs
@@ -76,6 +76,15 @@ pub struct ProxyConfig {
     /// MitM certificate so the client's TLS verification continues to work
     /// against the per-host CA chain.
     pub upstream_override: Option<SocketAddr>,
+
+    /// Endpoint of the `aa-gateway` PolicyService gRPC server. When `Some`,
+    /// the proxy connects on startup and forwards MCP `tools/call` bodies
+    /// to the gateway for structured policy evaluation (AAASM-1930). When
+    /// `None`, MCP enforcement is disabled and bodies pass through to the
+    /// existing credential-scanner data path unchanged.
+    ///
+    /// Env: `AA_PROXY_GATEWAY_ENDPOINT` — e.g. `http://127.0.0.1:50051`.
+    pub gateway_endpoint: Option<String>,
 }
 
 impl ProxyConfig {
@@ -128,6 +137,11 @@ impl ProxyConfig {
             Err(_) => CredentialAction::default(),
         };
 
+        let gateway_endpoint = match std::env::var("AA_PROXY_GATEWAY_ENDPOINT") {
+            Ok(val) if !val.is_empty() => Some(val),
+            _ => None,
+        };
+
         Ok(Self {
             bind_addr,
             ca_dir,
@@ -137,6 +151,7 @@ impl ProxyConfig {
             skip_upstream_tls_verify,
             credential_action,
             upstream_override: None,
+            gateway_endpoint,
         })
     }
 }

--- a/aa-proxy/src/lib.rs
+++ b/aa-proxy/src/lib.rs
@@ -21,6 +21,7 @@ pub mod audit_jsonl;
 pub mod config;
 pub mod error;
 pub mod intercept;
+pub mod mcp_enforce;
 pub mod proxy;
 pub mod tls;
 

--- a/aa-proxy/src/mcp_enforce.rs
+++ b/aa-proxy/src/mcp_enforce.rs
@@ -162,4 +162,82 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_slice(&tool.args_json).expect("args_json must be valid JSON");
         assert_eq!(parsed, json!({ "path": "/etc/passwd" }));
     }
+
+    fn response_with(decision: Decision, reason: &str) -> CheckActionResponse {
+        CheckActionResponse {
+            decision: decision as i32,
+            reason: reason.into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn decision_allow_maps_to_mcp_allow() {
+        let resp = response_with(Decision::Allow, "ok");
+        assert_eq!(decision_from_response(&resp), McpDecision::Allow);
+    }
+
+    #[test]
+    fn decision_deny_maps_to_mcp_deny_with_reason() {
+        let resp = response_with(Decision::Deny, "tool_name read_file blocked on /etc paths");
+        match decision_from_response(&resp) {
+            McpDecision::Deny { reason } => {
+                assert_eq!(reason, "tool_name read_file blocked on /etc paths");
+            }
+            other => panic!("expected Deny, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decision_redact_maps_to_mcp_redact_with_instructions() {
+        let resp = CheckActionResponse {
+            decision: Decision::Redact as i32,
+            redact: Some(RedactInstructions::default()),
+            ..Default::default()
+        };
+        assert!(matches!(decision_from_response(&resp), McpDecision::Redact { .. }));
+    }
+
+    #[test]
+    fn decision_pending_downgrades_to_deny_at_proxy_layer() {
+        // The proxy cannot block on a human approval queue inside the MitM
+        // tunnel, so PENDING must surface as a wire-level Deny.
+        let mut resp = response_with(Decision::Pending, "");
+        resp.approval_id = "queue-7".into();
+        match decision_from_response(&resp) {
+            McpDecision::Deny { reason } => {
+                assert!(
+                    reason.contains("queue-7") || reason.contains("PENDING"),
+                    "deny reason should explain the downgrade, got: {reason}",
+                );
+            }
+            other => panic!("expected Deny, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decision_unspecified_downgrades_to_deny() {
+        let resp = response_with(Decision::Unspecified, "");
+        assert!(matches!(decision_from_response(&resp), McpDecision::Deny { .. }));
+    }
+
+    #[test]
+    fn unknown_decision_code_downgrades_to_deny() {
+        // Out-of-range proto enum value (e.g. a future Decision variant the
+        // proxy was compiled before) must still surface as Deny rather than
+        // panic.
+        let resp = CheckActionResponse {
+            decision: 9999,
+            ..Default::default()
+        };
+        match decision_from_response(&resp) {
+            McpDecision::Deny { reason } => {
+                assert!(
+                    reason.contains("9999"),
+                    "reason should name the unknown code, got: {reason}"
+                );
+            }
+            other => panic!("expected Deny, got {other:?}"),
+        }
+    }
 }

--- a/aa-proxy/src/mcp_enforce.rs
+++ b/aa-proxy/src/mcp_enforce.rs
@@ -1,0 +1,130 @@
+//! MCP `tools/call` policy enforcement against the `aa-gateway` PolicyService.
+//!
+//! This module is the bridge between the proxy's MCP detection primitive
+//! (`intercept::mcp::parse_mcp_request`) and the gateway's existing
+//! `PolicyService.CheckAction` gRPC RPC.
+//!
+//! Flow:
+//!
+//! ```text
+//!   client TLS  ──→  parse_mcp_request(body)  ──→  Some(McpToolCall)
+//!                                                       │
+//!                                                       ▼
+//!                                       build_check_action_request(...)
+//!                                                       │
+//!                                                       ▼
+//!                                       GatewayClient::check_action
+//!                                                       │
+//!                                                       ▼
+//!                                       decision_from_response(...)
+//!                                                       │
+//!                                                       ▼
+//!                                       McpDecision::{Allow,Deny,Redact}
+//! ```
+//!
+//! See AAASM-1930.
+
+use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decision};
+use aa_proto::assembly::policy::v1::{
+    action_context::Action, ActionContext, CheckActionRequest, CheckActionResponse, RedactInstructions, ToolCallContext,
+};
+
+use crate::intercept::mcp::McpToolCall;
+
+/// Tool-source label written into `ToolCallContext.tool_source` for every
+/// MCP call evaluated by this module. Matches the convention already used
+/// in `aa-gateway/tests/edge_langgraph_test.rs` fixtures.
+pub const MCP_TOOL_SOURCE: &str = "mcp";
+
+/// Synthetic `agent_id` the proxy uses when forwarding MCP calls without
+/// having registered an agent identity. The proxy is intentionally
+/// agent-agnostic at Layer 2 — the gateway evaluates the ToolCallContext
+/// directly. Used because `CheckActionRequest.agent_id` is a required
+/// field on the proto.
+const PROXY_AGENT_ID: &str = "aa-proxy";
+
+/// Top-level decision the proxy data path branches on after a gateway
+/// `CheckAction` response. Maps the proto `Decision` enum onto the
+/// proxy's wire-level enforcement choices.
+#[derive(Debug, Clone, PartialEq)]
+pub enum McpDecision {
+    /// Forward the original `tools/call` envelope to the upstream MCP server.
+    Allow,
+    /// Refuse the call: the proxy writes a JSON-RPC 2.0 error envelope back
+    /// to the client and never dials upstream. `reason` is copied from the
+    /// gateway response so the client sees the policy rule that fired.
+    Deny { reason: String },
+    /// Forward the call, but rewrite matching fields in the upstream
+    /// response before returning it to the client. `instructions` carries
+    /// the field-path / replacement rules from the gateway.
+    Redact { instructions: RedactInstructions },
+}
+
+/// Build a `CheckActionRequest` from a parsed MCP call ready to send over
+/// the `PolicyService.CheckAction` gRPC RPC.
+///
+/// * `tool_name` / `arguments` come from [`McpToolCall`].
+/// * `target_url` is the upstream MCP server URL — empty string when the
+///   proxy has no host context to attach.
+/// * `trace_id` / `span_id` are propagated for distributed-tracing
+///   correlation; the proxy may pass empty strings when no parent trace
+///   is available.
+pub fn build_check_action_request(
+    call: &McpToolCall,
+    target_url: &str,
+    trace_id: &str,
+    span_id: &str,
+) -> CheckActionRequest {
+    // Serialise arguments back to JSON bytes for `ToolCallContext.args_json`.
+    // Failure here is "synthesise an empty payload" rather than propagate —
+    // an arguments value that round-trips serde once cannot round-trip
+    // serde twice without a programming bug, and an empty args_json still
+    // lets the policy engine match against `tool_name` alone.
+    let args_json = serde_json::to_vec(&call.arguments).unwrap_or_default();
+    CheckActionRequest {
+        agent_id: Some(ProtoAgentId {
+            org_id: String::new(),
+            team_id: String::new(),
+            agent_id: PROXY_AGENT_ID.into(),
+        }),
+        credential_token: String::new(),
+        trace_id: trace_id.into(),
+        span_id: span_id.into(),
+        action_type: ActionType::ToolCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::ToolCall(ToolCallContext {
+                tool_name: call.tool_name.clone(),
+                tool_source: MCP_TOOL_SOURCE.into(),
+                args_json,
+                target_url: target_url.into(),
+            })),
+        }),
+    }
+}
+
+/// Convert a `CheckActionResponse` into an [`McpDecision`].
+///
+/// `Decision::Pending` and `Decision::Unspecified` map to `Deny` with a
+/// reason explaining the conservative downgrade — the proxy cannot block
+/// on a human approval queue inside the MitM tunnel, so any non-deterministic
+/// verdict is treated as a refusal at this layer.
+pub fn decision_from_response(response: &CheckActionResponse) -> McpDecision {
+    match Decision::try_from(response.decision) {
+        Ok(Decision::Allow) => McpDecision::Allow,
+        Ok(Decision::Deny) => McpDecision::Deny {
+            reason: response.reason.clone(),
+        },
+        Ok(Decision::Redact) => McpDecision::Redact {
+            instructions: response.redact.clone().unwrap_or_default(),
+        },
+        Ok(Decision::Pending) => McpDecision::Deny {
+            reason: format!(
+                "policy returned PENDING (approval queue {:?}) — proxy cannot block on human approval",
+                response.approval_id,
+            ),
+        },
+        Ok(Decision::Unspecified) | Err(_) => McpDecision::Deny {
+            reason: format!("unrecognised policy decision code {}", response.decision),
+        },
+    }
+}

--- a/aa-proxy/src/mcp_enforce.rs
+++ b/aa-proxy/src/mcp_enforce.rs
@@ -128,3 +128,38 @@ pub fn decision_from_response(response: &CheckActionResponse) -> McpDecision {
         },
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn sample_call() -> McpToolCall {
+        McpToolCall {
+            tool_name: "read_file".into(),
+            arguments: json!({ "path": "/etc/passwd" }),
+        }
+    }
+
+    #[test]
+    fn build_request_populates_tool_call_context_fields() {
+        let call = sample_call();
+        let req = build_check_action_request(&call, "https://mcp.example.com/tools", "trace-abc", "span-1");
+
+        assert_eq!(req.action_type, ActionType::ToolCall as i32);
+        assert_eq!(req.trace_id, "trace-abc");
+        assert_eq!(req.span_id, "span-1");
+
+        let action = req.context.expect("context").action.expect("action");
+        let tool = match action {
+            Action::ToolCall(t) => t,
+            other => panic!("expected ToolCall action, got {other:?}"),
+        };
+        assert_eq!(tool.tool_name, "read_file");
+        assert_eq!(tool.tool_source, MCP_TOOL_SOURCE);
+        assert_eq!(tool.target_url, "https://mcp.example.com/tools");
+        // args_json round-trips back to the original Value.
+        let parsed: serde_json::Value = serde_json::from_slice(&tool.args_json).expect("args_json must be valid JSON");
+        assert_eq!(parsed, json!({ "path": "/etc/passwd" }));
+    }
+}

--- a/aa-proxy/tests/proxy_integration.rs
+++ b/aa-proxy/tests/proxy_integration.rs
@@ -22,6 +22,7 @@ fn test_config(ca_dir: &std::path::Path) -> ProxyConfig {
         skip_upstream_tls_verify: false,
         credential_action: CredentialAction::default(),
         upstream_override: None,
+        gateway_endpoint: None,
     }
 }
 


### PR DESCRIPTION
## Description

F116 ST-Q follow-up (AAASM-1930) — **foundation PR for MCP interceptor data-path**.

Per the split decision recorded in AAASM-1930's comment thread (and the
sibling subtask **AAASM-1940** carrying the gateway policy DSL extension),
this PR delivers the bridge primitive between AAASM-1572's
`parse_mcp_request` parser and `aa-runtime`'s existing `GatewayClient` —
without yet wiring it into the proxy MitM data path.

**What this PR adds (5 commits, additive only):**

1. `ProxyConfig.gateway_endpoint: Option<String>` (env: `AA_PROXY_GATEWAY_ENDPOINT`) — points at the `aa-gateway` PolicyService gRPC server. Defaults to `None` (preserves existing credential-scanner-only behaviour).
2. `aa-proxy/src/mcp_enforce.rs` — a new helper module with:
   * `build_check_action_request(call, target_url, trace_id, span_id) → CheckActionRequest` — converts a parsed `McpToolCall` into a `CheckActionRequest` carrying `ToolCallContext { tool_name, tool_source: "mcp", args_json, target_url }`, ready for `PolicyService.CheckAction` over gRPC.
   * `McpDecision` enum — the proxy's wire-level outcomes: `Allow` / `Deny { reason }` / `Redact { instructions }`.
   * `decision_from_response(response) → McpDecision` — maps the proto `Decision` enum onto `McpDecision`, conservatively downgrading `PENDING` and `UNSPECIFIED` to `Deny` (the proxy can't park bytes on a human approval queue inside the MitM tunnel).
3. 10 unit tests (3 env-var tests for `gateway_endpoint`, 1 request-builder test, 6 decision-mapper tests covering Allow / Deny / Redact / Pending / Unspecified / unknown-code).
4. Existing `ProxyConfig` literals in `proxy_integration`, `e2e_secret_interception`, and `e2e_policy_proxy` test files updated with `gateway_endpoint: None` — no behavioural change to those tests.

**What this PR does NOT do (carried by AAASM-1930's follow-up commits + AAASM-1940):**

* No proxy data-path wiring — `parse_mcp_request` is not yet called from `ProxyServer::handle_connection`. No gateway-client instance held by `ProxyServer`. No MCP detection branch in the MitM tunnel.
* No JSON-RPC error envelope writer for the Deny path.
* No response-side `tool_result` redaction.
* No mock MCP server fixture or MCP policy YAMLs in `aa-integration-tests/`.
* No un-ignoring of `e2e_mcp_interceptor.rs`'s ST-Q-1..5 `#[ignore]` placeholders.

**Scope blocker that drove the split:**

Mid-implementation I found that `aa-gateway`'s policy expression DSL has no `FieldRef` for `ToolCall.args.*` or for the upstream `tool_result.*` body. Only `tool` (the name) is matchable on a `ToolCall` action. The ST-Q-1 (`deny if tool_name == "read_file" and args.path starts_with "/etc"`) and ST-Q-3 (`redact_if tool_result contains_pattern …`) ACs both rely on field references the DSL doesn't expose today. AAASM-1940 is filed to add `FieldRef::ToolArg(JsonPath)` and `FieldRef::ToolResult(JsonPath)`; AAASM-1930 resumes against the extended DSL once that lands.

## Type of Change

- [x] ✨ New feature (`aa_proxy::mcp_enforce` module + `ProxyConfig.gateway_endpoint`)
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

`ProxyConfig` gains a new field. Every existing test constructor was updated
in the same commit that added the field. No external callers ship; nothing
runtime-visible changes when the default value is left at `None`.

## Related Issues

* Parent subtask: **AAASM-1930** (this PR — foundation)
* Sibling subtask filed: **AAASM-1940** (gateway policy DSL extension — `FieldRef::ToolArg` and `FieldRef::ToolResult`)
* Parent Story: **AAASM-1232** (F116 Full MVP acceptance test)
* Detection-slice precedent: AAASM-1572 (Done, PR #786) → introduced `aa-proxy::intercept::mcp::parse_mcp_request` and the `e2e_mcp_interceptor.rs::st_q_*` `#[ignore]` placeholders this PR's helpers will eventually drive.

## Testing

- [x] Unit tests added (10 new in `aa-proxy/src/config.rs` and `aa-proxy/src/mcp_enforce.rs`)
- [ ] Integration tests added / updated (none — no data-path wiring in this PR)
- [x] Manual testing performed: `cargo test -p aa-proxy --lib` → 87 passed / 0 failed; `cargo clippy -p aa-proxy --all-targets -- -D warnings` clean.
- [ ] No tests required (explain why)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (`mcp_enforce` module docstring + flow diagram; `gateway_endpoint` docstring on `ProxyConfig`)
- [x] All CI checks passing (local pre-commit hook clean on every commit)
- [x] Commits are small and follow the Gitmoji convention (5 commits, one per logical unit — config field, env-var tests, helper module, builder test, decision-mapper tests)
