### PR TITLE
[AAASM-1930] ✨ (aa-proxy): MCP data-path Phase A — gateway client wiring on ProxyServer

### DIFF
--- a/aa-proxy/src/mcp_enforce.rs
+++ b/aa-proxy/src/mcp_enforce.rs
@@ -24,10 +24,14 @@
 //!
 //! See AAASM-1930.
 
+use std::sync::Arc;
+
 use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decision};
 use aa_proto::assembly::policy::v1::{
     action_context::Action, ActionContext, CheckActionRequest, CheckActionResponse, RedactInstructions, ToolCallContext,
 };
+use aa_runtime::gateway_client::GatewayClient;
+use tokio::sync::Mutex;
 
 use crate::intercept::mcp::McpToolCall;
 
@@ -127,6 +131,38 @@ pub fn decision_from_response(response: &CheckActionResponse) -> McpDecision {
             reason: format!("unrecognised policy decision code {}", response.decision),
         },
     }
+}
+
+/// End-to-end evaluation: build a `CheckActionRequest` from the parsed MCP
+/// call, forward it over the supplied gateway client, and surface the
+/// resulting [`McpDecision`].
+///
+/// The proxy's data path holds the gateway client inside an
+/// `Arc<Mutex<GatewayClient>>` (the tonic-generated client's `check_action`
+/// is `&mut self`-keyed). This helper takes the same shape and serialises
+/// the RPC behind the mutex — concurrent connection tasks queue up briefly
+/// rather than sharing a connection lock-free.
+///
+/// Wraps the gateway's `tonic::Status` in an `anyhow::Error` (with the
+/// status code preserved in the message) so callers can `?`-propagate
+/// alongside other proxy data-path errors without taking a direct tonic
+/// dependency.
+pub async fn evaluate_mcp_call(
+    gateway: &Arc<Mutex<GatewayClient>>,
+    call: &McpToolCall,
+    target_url: &str,
+    trace_id: &str,
+    span_id: &str,
+) -> anyhow::Result<McpDecision> {
+    let request = build_check_action_request(call, target_url, trace_id, span_id);
+    let response = {
+        let mut client = gateway.lock().await;
+        client
+            .check_action(request)
+            .await
+            .map_err(|e| anyhow::anyhow!("PolicyService.CheckAction failed: {e}"))?
+    };
+    Ok(decision_from_response(&response))
 }
 
 #[cfg(test)]

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -13,9 +13,10 @@ use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, Serve
 use rustls::{DigitallySignedStruct, ServerConfig, SignatureScheme};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::{broadcast, mpsc, Mutex, OnceCell};
 use tokio_rustls::{TlsAcceptor, TlsConnector};
 
+use aa_runtime::gateway_client::GatewayClient;
 use aa_runtime::pipeline::PipelineEvent;
 
 use crate::audit_jsonl::{ProxyAuditDecision, ProxyAuditEntry};
@@ -88,6 +89,15 @@ pub struct ProxyServer {
     /// `None` means no JSONL persistence — useful for unit tests that only
     /// observe the broadcast event stream.
     audit_jsonl_tx: Option<mpsc::Sender<ProxyAuditEntry>>,
+    /// Lazily-initialised gRPC client for the `aa-gateway` PolicyService.
+    /// Populated at startup by [`ProxyServer::run`] when
+    /// [`ProxyConfig::gateway_endpoint`] is `Some`; stays empty otherwise.
+    ///
+    /// The inner `Mutex` serialises concurrent `check_action` RPCs from
+    /// connection tasks — the underlying tonic client is `&mut self`-keyed.
+    /// The outer `OnceCell` lets the connect step run inside `run()`'s
+    /// async context without requiring an async constructor.
+    gateway_client: OnceCell<Arc<Mutex<GatewayClient>>>,
 }
 
 impl ProxyServer {
@@ -112,6 +122,7 @@ impl ProxyServer {
             certs,
             interceptor: Interceptor::new(event_tx),
             audit_jsonl_tx,
+            gateway_client: OnceCell::new(),
         })
     }
 
@@ -120,6 +131,28 @@ impl ProxyServer {
     /// This future runs until the process is killed or an unrecoverable error
     /// occurs. It is called from [`crate::run`].
     pub async fn run(self: &Arc<Self>) -> Result<(), ProxyError> {
+        // Best-effort connect to the gateway when an endpoint is configured.
+        // A connection failure here is logged but does not fail startup —
+        // MCP enforcement simply stays disabled and the proxy continues to
+        // serve the credential-scanner path. This matches `aa-runtime`'s
+        // policy that a missing gateway is a soft degradation, not a fatal
+        // error.
+        if let Some(endpoint) = &self.config.gateway_endpoint {
+            match GatewayClient::connect(endpoint).await {
+                Ok(client) => {
+                    let _ = self.gateway_client.set(Arc::new(Mutex::new(client)));
+                    tracing::info!(%endpoint, "connected to aa-gateway PolicyService for MCP enforcement");
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        %endpoint,
+                        error = %e,
+                        "failed to connect to aa-gateway; MCP enforcement disabled",
+                    );
+                }
+            }
+        }
+
         let listener = TcpListener::bind(self.config.bind_addr).await?;
         tracing::info!(addr = %self.config.bind_addr, "proxy listening");
 


### PR DESCRIPTION
## Description

**AAASM-1930 second PR — Phase A (infrastructure, no data-path wiring yet).**

This is the second PR under AAASM-1930. The [first PR (#796)|https://github.com/AI-agent-assembly/agent-assembly/pull/796] added the `parse_mcp_request` primitive and the `mcp_enforce::build_check_action_request` / `decision_from_response` helpers. **This PR adds the connection plumbing those helpers need — but it does not yet wire MCP detection into the proxy's hot data path.**

The next PR under AAASM-1930 (Phase B) will:
* Add the MCP detection branch in `ProxyServer::handle_connection` that takes precedence over the existing raw-copy non-LLM path when a gateway is configured.
* Wire `McpDecision::Deny` → JSON-RPC 2.0 error envelope writer to the client TLS stream.
* Emit structured `ToolCall` audit events.
* Add the mock MCP server fixture under `aa-integration-tests/tests/common/` (modelled on `TlsCapturingUpstream` from `e2e_secret_interception.rs::proxy_data_path`).
* Add `mcp_deny_etc_paths.yaml` + `mcp_allowlist.yaml` policy fixtures.
* Un-ignore `st_q_1`, `st_q_2`, `st_q_4`, `st_q_5` with real wire-level + audit assertions.

ST-Q-3 (`tool_result` redaction) stays `#[ignore]`d throughout — it's blocked on **AAASM-1941** (Part 2 of the policy DSL extension).

## What this PR adds

| # | Commit | Scope |
|---|---|---|
| 1 | `✨ Hold GatewayClient on ProxyServer + connect on startup` | New `gateway_client: OnceCell<Arc<Mutex<GatewayClient>>>` field on `ProxyServer`. `run()` best-effort connects to `config.gateway_endpoint` before entering the accept loop. Connection failures are logged but non-fatal — the proxy continues to serve the credential-scanner path. |
| 2 | `✨ Add evaluate_mcp_call end-to-end helper in mcp_enforce` | Composes `build_check_action_request` + `GatewayClient::check_action` + `decision_from_response` into one async helper that takes `&Arc<Mutex<GatewayClient>>` (matching the shape ProxyServer holds) and returns `anyhow::Result<McpDecision>`. The mutex is locked only for the RPC duration. |

## Design notes worth flagging

### `OnceCell<Arc<Mutex<GatewayClient>>>` shape

The tonic-generated `PolicyServiceClient::check_action` is `&mut self`-keyed, so concurrent connection tasks need either a per-task client clone or a shared mutex. I chose the shared-mutex shape (matching `aa-runtime/src/pipeline/mod.rs::gateway_client: Option<Arc<Mutex<GatewayClient>>>`) — the mutex is only held for the duration of one RPC, so contention is bounded.

The outer `OnceCell` lets the async connect step run inside `ProxyServer::run`'s async context without requiring an async constructor — keeping `ProxyServer::new` and `new_with_audit_sink` non-async preserves the existing test plumbing.

### Soft-degradation on connect failure

If `config.gateway_endpoint` is set but the gateway is unreachable, the proxy logs a warning and continues to serve the existing credential-scanner-only path. This matches `aa-runtime`'s policy (`gateway_client: Option<…>`) that a missing gateway is a soft degradation, not a fatal error. The downside: MCP traffic silently passes through without policy evaluation. The next PR's `handle_connection` change will need to decide whether to fail-safe-deny in that mode; for now no MCP detection runs at all so the question is moot.

### `anyhow::Result` over `tonic::Status`

`evaluate_mcp_call` wraps the gateway's `tonic::Status` in `anyhow::Error` (with the message preserved) so callers can `?`-propagate alongside other proxy data-path errors without `aa-proxy` taking a direct `tonic` dependency.

## What this PR does NOT do

* **No proxy data-path wiring** — `parse_mcp_request` is still not called from inside any TLS tunnel. Configuring `gateway_endpoint` today gives you a connected gateway client with zero usage.
* No JSON-RPC error envelope writer.
* No structured `ToolCall` audit emission.
* No mock MCP server fixture or MCP policy YAMLs.
* No un-ignoring of `e2e_mcp_interceptor.rs::st_q_*` placeholders.

All of the above land in AAASM-1930's third PR (Phase B), which will be opened against the same subtask once this Phase A merges.

## Type of Change

- [x] ✨ New feature (infrastructure preparation for MCP enforcement)
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

`ProxyServer` gains a new internal field. No public API change. Existing constructors (`new`, `new_with_audit_sink`) take no extra arguments. No behavioural change when `config.gateway_endpoint` is `None` (the default).

## Related Issues

* This subtask (in progress): **AAASM-1930** (will not close until Phase B PR merges and ST-Q-1/2/4/5 are passing)
* Sibling subtask (To Do, blocks ST-Q-3): **AAASM-1941** (Part 2 — `FieldRef::ToolResult` + proto changes + response-side flow)
* Earlier under same Story: AAASM-1572 (Done, PR #786), AAASM-1940 (Done, PR #797), this subtask's first PR #796 (Done)
* Parent Story: **AAASM-1232**

## Testing

- [ ] Unit tests added / updated — none in this PR. `evaluate_mcp_call` exercises the gRPC RPC which needs an integration-style test against a running `PolicyService`. The integration test lands in Phase B's `e2e_mcp_interceptor.rs::st_q_1` etc.
- [ ] Integration tests added / updated — see above.
- [x] Manual testing: `cargo test -p aa-proxy --lib` → 87 passed / 0 failed (existing 80 + 7 from prior PR #796 mcp_enforce tests, unchanged). `cargo clippy -p aa-proxy --all-targets -- -D warnings` clean.
- [ ] No tests required (explain why) — see above.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (module + field docstrings explain the OnceCell shape, the soft-degradation policy, and the Phase B plan)
- [x] All CI checks expected to pass
- [x] Commits small + Gitmoji
