### PR TITLE
[AAASM-1930] ✨ (aa-proxy): MCP data-path Phase B-1 — handle_connection enforcement wiring

### DIFF
--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -24,7 +24,9 @@ use crate::config::ProxyConfig;
 use crate::error::ProxyError;
 use crate::intercept::detect::{detect_api, LlmApiPattern};
 use crate::intercept::event::ProxyEvent;
+use crate::intercept::mcp::parse_mcp_request;
 use crate::intercept::{InterceptVerdict, Interceptor, VerdictDecision};
+use crate::mcp_enforce::{evaluate_mcp_call, McpDecision};
 use crate::proxy::http::{read_http_request, serialize_http_request, HttpRequest};
 use crate::tls::{CaStore, CertCache};
 
@@ -71,6 +73,16 @@ impl ServerCertVerifier for NoCertVerifier {
             .signature_verification_algorithms
             .supported_schemes()
     }
+}
+
+/// Build a JSON-RPC 2.0 error response body carrying the policy reason.
+///
+/// `id` is fixed at `null` because the proxy denies before parsing the
+/// inbound envelope's `id` field — most MCP clients accept a null id on
+/// errors emitted by a transport-layer interceptor.
+fn build_jsonrpc_error_response(code: i32, message: &str) -> String {
+    let msg_json = serde_json::to_string(message).unwrap_or_else(|_| "\"policy deny\"".into());
+    format!(r#"{{"jsonrpc":"2.0","id":null,"error":{{"code":{code},"message":{msg_json}}}}}"#)
 }
 
 /// The running proxy server.
@@ -264,6 +276,95 @@ impl ProxyServer {
         Ok(upstream_tls)
     }
 
+    /// Non-LLM, gateway-aware data path: read the HTTP request inside the
+    /// MitM TLS tunnel, try to parse it as an MCP `tools/call` envelope, and
+    /// either enforce the gateway's decision on the wire or forward the
+    /// body transparently.
+    ///
+    /// Branches:
+    ///
+    /// * **MCP detected, gateway returns `Allow` or `Redact`** — forward the
+    ///   original body to upstream and continue bidirectional copy.
+    ///   (`Redact` is logged and forwarded as `Allow` for now — response-side
+    ///   rewriting lands in AAASM-1941.)
+    /// * **MCP detected, gateway returns `Deny`** — write a JSON-RPC 2.0
+    ///   error envelope to the client TLS stream, do not dial upstream.
+    /// * **MCP detected, gateway RPC failed** — log the error, fall through
+    ///   to transparent forward. Soft-degradation matches `aa-runtime`'s
+    ///   policy.
+    /// * **Body is not MCP** — transparently forward what was read plus the
+    ///   remaining stream.
+    async fn handle_non_llm_with_gateway(
+        self: &Arc<Self>,
+        client_tls: tokio_rustls::server::TlsStream<TcpStream>,
+        gateway: &Arc<Mutex<GatewayClient>>,
+        host: &str,
+        target: &str,
+    ) -> Result<(), ProxyError> {
+        let mut client_reader = BufReader::new(client_tls);
+        let Some(req) = read_http_request(&mut client_reader).await? else {
+            return Ok(());
+        };
+
+        // MCP detection.
+        if let Some(call) = parse_mcp_request(&req.body) {
+            let target_url = format!("https://{host}{path}", path = req.target);
+            match evaluate_mcp_call(gateway, &call, &target_url, "", "").await {
+                Ok(McpDecision::Allow) | Ok(McpDecision::Redact { .. }) => {
+                    tracing::info!(
+                        tool_name = %call.tool_name,
+                        %host,
+                        "MCP call allowed by gateway, forwarding to upstream",
+                    );
+                    // fall through to forward
+                }
+                Ok(McpDecision::Deny { reason }) => {
+                    tracing::info!(
+                        tool_name = %call.tool_name,
+                        %host,
+                        %reason,
+                        "MCP call denied by gateway, returning JSON-RPC error envelope",
+                    );
+                    let body = build_jsonrpc_error_response(-32000, &reason);
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(),
+                        body,
+                    );
+                    let mut client_tls = client_reader.into_inner();
+                    client_tls.write_all(resp.as_bytes()).await?;
+                    let _ = client_tls.shutdown().await;
+                    return Ok(());
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        tool_name = %call.tool_name,
+                        %host,
+                        error = %e,
+                        "gateway CheckAction failed, forwarding without enforcement",
+                    );
+                    // fall through to forward
+                }
+            }
+        }
+
+        // Not MCP (or RPC failed) — forward the consumed body plus the
+        // remaining stream transparently.
+        let upstream_tls = self.dial_upstream_tls(host, target).await?;
+        let outgoing = serialize_http_request(&req, &req.body);
+        let (mut client_read, mut client_write) = tokio::io::split(client_reader.into_inner());
+        let (mut upstream_read, mut upstream_write) = tokio::io::split(upstream_tls);
+        upstream_write.write_all(&outgoing).await?;
+
+        let client_to_upstream = tokio::io::copy(&mut client_read, &mut upstream_write);
+        let upstream_to_client = tokio::io::copy(&mut upstream_read, &mut client_write);
+        tokio::select! {
+            r = client_to_upstream => { r?; }
+            r = upstream_to_client => { r?; }
+        }
+        Ok(())
+    }
+
     /// Handle a single accepted TCP connection.
     ///
     /// Reads the first HTTP request line to determine whether this is a
@@ -437,17 +538,33 @@ impl ProxyServer {
                 return Ok(());
             }
 
-            // Non-LLM pattern: raw bidirectional copy (no body inspection).
-            let upstream_tls = self.dial_upstream_tls(host, target).await?;
-            let (mut client_read, mut client_write) = tokio::io::split(client_tls);
-            let (mut upstream_read, mut upstream_write) = tokio::io::split(upstream_tls);
+            // Non-LLM pattern.
+            //
+            // When a gateway client is configured, attempt MCP detection
+            // on the inbound HTTPS request body: a JSON-RPC 2.0 `tools/call`
+            // envelope is dispatched to the gateway PolicyService and
+            // enforced on the wire (Deny → JSON-RPC error envelope, Allow →
+            // forward, Redact → forward unchanged until AAASM-1941 lands
+            // response-side rewriting). Non-MCP bodies fall through to a
+            // transparent forward of the bytes we've already read.
+            //
+            // When no gateway is configured, preserve the historical raw
+            // bidirectional copy (no body inspection at all).
+            if let Some(gateway) = self.gateway_client.get() {
+                self.handle_non_llm_with_gateway(client_tls, gateway, host, target)
+                    .await?;
+            } else {
+                let upstream_tls = self.dial_upstream_tls(host, target).await?;
+                let (mut client_read, mut client_write) = tokio::io::split(client_tls);
+                let (mut upstream_read, mut upstream_write) = tokio::io::split(upstream_tls);
 
-            let client_to_upstream = tokio::io::copy(&mut client_read, &mut upstream_write);
-            let upstream_to_client = tokio::io::copy(&mut upstream_read, &mut client_write);
+                let client_to_upstream = tokio::io::copy(&mut client_read, &mut upstream_write);
+                let upstream_to_client = tokio::io::copy(&mut upstream_read, &mut client_write);
 
-            tokio::select! {
-                r = client_to_upstream => { r?; }
-                r = upstream_to_client => { r?; }
+                tokio::select! {
+                    r = client_to_upstream => { r?; }
+                    r = upstream_to_client => { r?; }
+                }
             }
 
             Ok(())


### PR DESCRIPTION
## Description

**AAASM-1930 Phase B-1 — proxy data-path MCP wiring (1 commit, no integration tests yet).**

This is the third PR under AAASM-1930. Prior PRs in this chain:

* [#786|https://github.com/AI-agent-assembly/agent-assembly/pull/786] (AAASM-1572 detection slice) — `parse_mcp_request` parser primitive + ST-Q `#[ignore]` placeholders.
* [#796|https://github.com/AI-agent-assembly/agent-assembly/pull/796] (AAASM-1930 foundation) — `ProxyConfig.gateway_endpoint` + `mcp_enforce` module (`build_check_action_request`, `McpDecision`, `decision_from_response`).
* [#797|https://github.com/AI-agent-assembly/agent-assembly/pull/797] (AAASM-1940 Part 1) — Policy DSL `FieldRef::ToolArg(JsonPath)` for `args.<key>` predicates.
* [#798|https://github.com/AI-agent-assembly/agent-assembly/pull/798] (AAASM-1930 Phase A) — `ProxyServer.gateway_client` field + connect-on-startup + `evaluate_mcp_call` helper.

**This PR finally activates MCP enforcement on the proxy's hot data path.** When `gateway_client` is `Some` (configured + connected) the non-LLM TLS-tunnel branch in `ProxyServer::handle_connection` becomes body-aware: it reads the inbound HTTPS request, runs `parse_mcp_request`, and dispatches to `evaluate_mcp_call` on a match.

**What integration tests this PR does NOT have (yet):**

* No mock MCP server fixture under `aa-integration-tests/tests/common/`.
* No MCP policy YAML fixtures (`mcp_deny_etc_paths.yaml`, `mcp_allowlist.yaml`).
* `e2e_mcp_interceptor.rs::st_q_*` placeholders remain `#[ignore]`d.

All of the above land in the next PR under AAASM-1930 (Phase B-2). Splitting because:

1. The data-path refactor is contained and reviewable on its own (+126 / -9 lines in one file).
2. The integration-test infrastructure is genuinely substantial (mock MCP server matches `TlsCapturingUpstream` from `e2e_secret_interception.rs` — ~80 LoC; spinning up a real `PolicyService` follows the `observe_mode_e2e.rs::start_gateway_with_policy_fixture` pattern; the 4 un-ignored tests each carry ~50 LoC of assertions). That's its own PR-sized chunk.
3. The existing aa-proxy lib suite (84/0) still passes — no regressions verified.

## What this PR adds (1 commit)

`✨ (aa-proxy): Wire MCP enforcement into non-LLM data-path branch`

| Area | Change |
|---|---|
| `proxy/mod.rs` imports | `intercept::mcp::parse_mcp_request`, `mcp_enforce::{evaluate_mcp_call, McpDecision}` brought into the module. |
| `build_jsonrpc_error_response(code, message)` | Free function in `proxy/mod.rs` that produces a JSON-RPC 2.0 error body for the Deny path: `{"jsonrpc":"2.0","id":null,"error":{"code":-32000,"message":<reason>}}`. `id` is fixed at `null` because the proxy denies before parsing the inbound envelope's `id` — most MCP clients accept this for transport-layer errors. |
| `ProxyServer::handle_non_llm_with_gateway` method | The new body-aware non-LLM data path. Reads the HTTPS request inside the MitM tunnel, calls `parse_mcp_request`, dispatches to `evaluate_mcp_call`, and branches on `McpDecision`. |
| `handle_connection` non-LLM branch | Conditionally calls `handle_non_llm_with_gateway` when `gateway_client.get()` is `Some`; otherwise preserves the existing raw `tokio::io::copy` path verbatim. |

### Decision branch behaviour

* `McpDecision::Allow` → forward the original `tools/call` envelope to upstream + bidirectional copy.
* `McpDecision::Redact { .. }` → logged + forwarded as Allow for now. Response-side rewriting is blocked on **AAASM-1941** (`FieldRef::ToolResult` + proto + response-side `CheckAction` flow). The Redact code path is wired but treated as a permissive Allow until that work lands.
* `McpDecision::Deny { reason }` → write a `HTTP/1.1 200 OK` response inside the TLS tunnel carrying the JSON-RPC error body. Do not dial upstream. Client receives a transport-success / application-error response, matching the MCP-over-HTTPS convention.
* Gateway RPC failure → log a `warn!` with the error, fall through to transparent forward. Soft-degradation matches `aa-runtime`'s missing-gateway policy.
* Body is not MCP → transparently forward the consumed body plus the remaining stream.

### Backwards compatibility

* `gateway_client` defaults to empty `OnceCell` (no connection ever attempted) when `ProxyConfig.gateway_endpoint` is `None`.
* When the OnceCell is empty, `handle_connection` takes the existing raw-copy path — **zero behavioural change** for the existing test suite. Verified: `cargo test -p aa-proxy --lib` → **84 passed / 0 failed / 3 ignored** at HEAD.

### Why the integration tests aren't here yet

The mock-server / un-ignore work needs:

1. A `TlsCapturingMcpUpstream` fixture (~80 LoC modelled on `TlsCapturingUpstream`) — TLS-terminating, captures inbound JSON-RPC bodies, replies with a canned tool-result envelope.
2. A `start_gateway_with_mcp_policy(yaml)` helper modelled on `observe_mode_e2e.rs::start_gateway_with_policy_fixture` — boots a real `PolicyService` gRPC server backed by a YAML policy.
3. Two policy YAML fixtures (`mcp_deny_etc_paths.yaml`, `mcp_allowlist.yaml`).
4. Wire ST-Q-1, ST-Q-2, ST-Q-4, ST-Q-5 through the proxy + mock upstream + gateway and assert wire-level + audit shapes.

That's a substantial chunk on its own (~300+ LoC of integration plumbing + 4 tests). Keeping it in its own PR keeps review focused.

## Type of Change

- [x] ✨ New feature (proxy data-path enforcement for MCP)
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

The new branch is gated entirely behind `gateway_client.get().is_some()` — when `ProxyConfig.gateway_endpoint` is unset (the default), the proxy takes the existing raw-copy path verbatim. No public API change.

## Related Issues

* This subtask (in progress): **AAASM-1930** (will not close until Phase B-2 PR merges and ST-Q-1/2/4/5 are passing).
* Blocks ST-Q-3 only: **AAASM-1941** (`FieldRef::ToolResult` + proto + response-side flow).
* Parent Story: **AAASM-1232**.
* Prior PRs in the chain: #786, #796, #797, #798.

## Testing

- [ ] Unit tests added / updated — none in this PR. The new code paths are integration-test territory and that work lands in Phase B-2.
- [ ] Integration tests added / updated — see "Why the integration tests aren't here yet" above.
- [x] Manual testing: `cargo test -p aa-proxy --lib` → **84/0**; `cargo clippy -p aa-proxy --lib -- -D warnings` clean. The existing `e2e_secret_interception.rs::proxy_data_path` integration tests will continue to exercise the non-MCP path under the unchanged `ProxyConfig` literals (`gateway_endpoint: None`).
- [ ] No tests required (explain why) — see above.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (method docstring covers all four decision branches + soft-degradation policy)
- [x] All CI checks expected to pass (modulo the codecov/patch acceptance gap — same shape as PR #798: new code without callers/tests in this PR)
- [x] Commits small + Gitmoji
