### PR TITLE
[AAASM-1941] ✨ (aa-gateway): ToolResult policy evaluation — FieldRef::ToolResult + proto + response-side flow

### DIFF
--- a/aa-api/src/ws/handler.rs
+++ b/aa-api/src/ws/handler.rs
@@ -353,6 +353,7 @@ fn action_type_label(raw: i32) -> Option<String> {
         ActionType::NetworkCall => "network",
         ActionType::ProcessExec => "process",
         ActionType::AgentSpawn => "spawn",
+        ActionType::ToolResult => "tool_result",
         ActionType::ActionUnspecified => return None,
     };
     Some(label.to_string())

--- a/aa-core/src/capability.rs
+++ b/aa-core/src/capability.rs
@@ -134,6 +134,7 @@ pub fn action_to_capability(action: &crate::GovernanceAction) -> Option<Capabili
     // mappings here to avoid silent policy bypasses.
     match action {
         GovernanceAction::ToolCall { name, .. } => Some(Capability::McpTool(name.clone())),
+        GovernanceAction::ToolResult { tool_name, .. } => Some(Capability::McpTool(tool_name.clone())),
         GovernanceAction::FileAccess {
             mode: FileMode::Read, ..
         } => Some(Capability::FileRead),

--- a/aa-core/src/policy.rs
+++ b/aa-core/src/policy.rs
@@ -167,6 +167,19 @@ pub enum GovernanceAction {
         /// Pre-serialized JSON arguments passed to the tool.
         args: ArgsJson,
     },
+    /// Result returned by a tool invocation, evaluated on the response path
+    /// before the result is forwarded back to the agent.
+    ///
+    /// Carries the same shape as `ToolCall.args` — a pre-serialized JSON
+    /// string — so the policy engine can apply JSON-pointer-addressed
+    /// predicates (e.g. `tool_result.foo`) and credential-pattern scans
+    /// against the body the upstream tool emitted.
+    ToolResult {
+        /// Registered name of the tool that produced the result.
+        tool_name: alloc::string::String,
+        /// Pre-serialized JSON body of the tool's response.
+        result: ArgsJson,
+    },
     /// Read or write access to a file path.
     FileAccess {
         /// Absolute or relative path of the file being accessed.

--- a/aa-core/src/policy.rs
+++ b/aa-core/src/policy.rs
@@ -274,6 +274,21 @@ mod tests {
     }
 
     #[test]
+    #[cfg(all(feature = "alloc", feature = "serde"))]
+    fn governance_action_tool_result_serde_round_trip() {
+        // The audit pipeline serialises every GovernanceAction it sees; if the
+        // new variant fails to round-trip through serde, downstream audit
+        // entries silently lose response-side actions.
+        let action = GovernanceAction::ToolResult {
+            tool_name: alloc::string::String::from("read_file"),
+            result: alloc::string::String::from("{\"contents\":\"sk-test-abc\"}"),
+        };
+        let encoded = serde_json::to_string(&action).expect("serialize");
+        let decoded: GovernanceAction = serde_json::from_str(&encoded).expect("deserialize");
+        assert_eq!(decoded, action);
+    }
+
+    #[test]
     #[cfg(feature = "alloc")]
     fn governance_action_file_access() {
         let action = GovernanceAction::FileAccess {

--- a/aa-core/src/policy.rs
+++ b/aa-core/src/policy.rs
@@ -265,6 +265,16 @@ mod tests {
 
     #[test]
     #[cfg(feature = "alloc")]
+    fn governance_action_tool_result() {
+        let action = GovernanceAction::ToolResult {
+            tool_name: alloc::string::String::from("list_files"),
+            result: alloc::string::String::from("{\"entries\":[\"a.txt\"]}"),
+        };
+        assert_eq!(action.clone(), action);
+    }
+
+    #[test]
+    #[cfg(feature = "alloc")]
     fn governance_action_file_access() {
         let action = GovernanceAction::FileAccess {
             path: alloc::string::String::from("/etc/passwd"),

--- a/aa-gateway/src/engine/cache.rs
+++ b/aa-gateway/src/engine/cache.rs
@@ -48,6 +48,10 @@ fn action_discriminant(action: &aa_core::GovernanceAction) -> u64 {
             "tool".hash(&mut h);
             name.hash(&mut h);
         }
+        aa_core::GovernanceAction::ToolResult { tool_name, .. } => {
+            "tool_result".hash(&mut h);
+            tool_name.hash(&mut h);
+        }
         aa_core::GovernanceAction::NetworkRequest { url, method } => {
             "net".hash(&mut h);
             url.hash(&mut h);

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -554,6 +554,7 @@ impl PolicyEngine {
         // to redact the payload once; the redacted text propagates — the original is dropped.
         let text = match action {
             aa_core::GovernanceAction::ToolCall { args, .. } => args.as_str(),
+            aa_core::GovernanceAction::ToolResult { .. } => "",
             aa_core::GovernanceAction::FileAccess { path, .. } => path.as_str(),
             aa_core::GovernanceAction::NetworkRequest { url, .. } => url.as_str(),
             aa_core::GovernanceAction::ProcessExec { command } => command.as_str(),
@@ -769,6 +770,7 @@ impl PolicyEngine {
         // Stage 6 — Credential scan: accumulate custom patterns from all cascade docs.
         let text = match action {
             aa_core::GovernanceAction::ToolCall { args, .. } => args.as_str(),
+            aa_core::GovernanceAction::ToolResult { .. } => "",
             aa_core::GovernanceAction::FileAccess { path, .. } => path.as_str(),
             aa_core::GovernanceAction::NetworkRequest { url, .. } => url.as_str(),
             aa_core::GovernanceAction::ProcessExec { command } => command.as_str(),

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -554,7 +554,7 @@ impl PolicyEngine {
         // to redact the payload once; the redacted text propagates — the original is dropped.
         let text = match action {
             aa_core::GovernanceAction::ToolCall { args, .. } => args.as_str(),
-            aa_core::GovernanceAction::ToolResult { .. } => "",
+            aa_core::GovernanceAction::ToolResult { result, .. } => result.as_str(),
             aa_core::GovernanceAction::FileAccess { path, .. } => path.as_str(),
             aa_core::GovernanceAction::NetworkRequest { url, .. } => url.as_str(),
             aa_core::GovernanceAction::ProcessExec { command } => command.as_str(),
@@ -770,7 +770,7 @@ impl PolicyEngine {
         // Stage 6 — Credential scan: accumulate custom patterns from all cascade docs.
         let text = match action {
             aa_core::GovernanceAction::ToolCall { args, .. } => args.as_str(),
-            aa_core::GovernanceAction::ToolResult { .. } => "",
+            aa_core::GovernanceAction::ToolResult { result, .. } => result.as_str(),
             aa_core::GovernanceAction::FileAccess { path, .. } => path.as_str(),
             aa_core::GovernanceAction::NetworkRequest { url, .. } => url.as_str(),
             aa_core::GovernanceAction::ProcessExec { command } => command.as_str(),

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -2385,6 +2385,18 @@ mod tests {
     }
 
     #[test]
+    fn tool_result_numeric_comparison_against_json_number() {
+        // Numeric ops (`>`, `>=`, `<`, `<=`, ==, !=) work against JSON
+        // numbers — mirror of args.<key>'s numeric path so policies can
+        // gate on response-side numeric fields (counts, sizes, scores).
+        let action = tool_result_with_body("score", r#"{"score": 95}"#);
+        assert!(evaluate("tool_result.score > 90", &action, None, None));
+        assert!(evaluate("tool_result.score <= 95", &action, None, None));
+        assert!(!evaluate("tool_result.score < 50", &action, None, None));
+        assert!(evaluate("tool_result.score == 95", &action, None, None));
+    }
+
+    #[test]
     fn tool_result_predicate_against_non_toolresult_action_is_no_match() {
         // A ToolCall / FileAccess / NetworkRequest / ProcessExec action carries
         // no `result` payload; tool_result predicates must surface as no-match

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -2355,4 +2355,31 @@ mod tests {
         let action = tool_result_with_body("ping", r#"{"ok": true}"#);
         assert!(evaluate(r#"tool_result starts_with "{""#, &action, None, None));
     }
+
+    #[test]
+    fn tool_result_predicate_against_non_toolresult_action_is_no_match() {
+        // A ToolCall / FileAccess / NetworkRequest / ProcessExec action carries
+        // no `result` payload; tool_result predicates must surface as no-match
+        // so policies don't leak across request/response sides. The same shape
+        // applies to the bare `tool_result` whole-body predicate.
+        assert!(!evaluate(
+            r#"tool_result.contents == "hello""#,
+            &tool("read_file"),
+            None,
+            None,
+        ));
+        assert!(!evaluate(
+            r#"tool_result contains "sk-""#,
+            &file("/etc/passwd"),
+            None,
+            None
+        ));
+        assert!(!evaluate(
+            r#"tool_result.api_key starts_with "sk-""#,
+            &network("https://example.com", "GET"),
+            None,
+            None,
+        ));
+        assert!(!evaluate(r#"tool_result contains "x""#, &process("ls"), None, None));
+    }
 }

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -1204,6 +1204,12 @@ pub(crate) fn validate_variables(expr: &str) -> Result<(), crate::policy::error:
         if name.starts_with("args.") && name.len() > "args.".len() {
             continue;
         }
+        // Same shape applies to `tool_result.<key>` (response-side
+        // FieldRef::ToolResult) and the bare `tool_result` shorthand
+        // (FieldRef::ToolResultWhole) — neither sits in a static list.
+        if name == "tool_result" || (name.starts_with("tool_result.") && name.len() > "tool_result.".len()) {
+            continue;
+        }
         if !KNOWN_VARIABLES.contains(&name.as_str()) {
             let suggestion = suggest_variable(&name).map(str::to_owned);
             let available = KNOWN_VARIABLES.iter().map(|s| s.to_string()).collect();

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -2357,6 +2357,20 @@ mod tests {
     }
 
     #[test]
+    fn tool_result_missing_key_is_null_safe_no_match() {
+        // The pointer fails to resolve — predicate must be no-match, NOT
+        // fail-safe true.
+        let action = tool_result_with_body("read_file", r#"{"other": "value"}"#);
+        assert!(!evaluate(r#"tool_result.contents == "hello""#, &action, None, None,));
+        assert!(!evaluate(
+            r#"tool_result.contents starts_with "h""#,
+            &action,
+            None,
+            None,
+        ));
+    }
+
+    #[test]
     fn tool_result_predicate_against_non_toolresult_action_is_no_match() {
         // A ToolCall / FileAccess / NetworkRequest / ProcessExec action carries
         // no `result` payload; tool_result predicates must surface as no-match

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -2323,4 +2323,16 @@ mod tests {
         let action = tool_result_with_body("read_file", r#"{"contents": "key=sk-abc123"}"#);
         assert!(evaluate(r#"tool_result.contents contains "sk-""#, &action, None, None));
     }
+
+    #[test]
+    fn tool_result_walks_nested_json_pointer() {
+        // `tool_result.payload.api_key` → JSON pointer "/payload/api_key".
+        let action = tool_result_with_body("http_fetch", r#"{"payload": {"api_key": "sk-test-xyz"}}"#);
+        assert!(evaluate(
+            r#"tool_result.payload.api_key starts_with "sk-""#,
+            &action,
+            None,
+            None,
+        ));
+    }
 }

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -2315,4 +2315,12 @@ mod tests {
         let action = tool_result_with_body("read_file", r#"{"contents": "hello"}"#);
         assert!(evaluate(r#"tool_result.contents == "hello""#, &action, None, None));
     }
+
+    #[test]
+    fn tool_result_field_contains_matches_substring_in_leaf() {
+        // The ST-Q-3 acceptance criterion's predicate shape — a credential
+        // pattern fragment inside a nested string field.
+        let action = tool_result_with_body("read_file", r#"{"contents": "key=sk-abc123"}"#);
+        assert!(evaluate(r#"tool_result.contents contains "sk-""#, &action, None, None));
+    }
 }

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -109,6 +109,18 @@ enum FieldRef {
     /// evaluator; null-safe no-match when the pointer cannot resolve or the
     /// `args` payload is not valid JSON.
     ToolArg(String),
+    /// `tool_result.<key>` / `tool_result.<key>.<nested>` — walks the `result`
+    /// JSON body on a `GovernanceAction::ToolResult` via the carried
+    /// JSON-pointer path. Mirrors `ToolArg`'s null-safety contract: non-
+    /// `ToolResult` actions, malformed `result` JSON, and unresolved
+    /// pointers all surface as no-match (false).
+    ToolResult(String),
+    /// Bare `tool_result` (no dotted path) — treats the entire serialised
+    /// `result` body of a `GovernanceAction::ToolResult` as one string for
+    /// regex-style `contains` / `starts_with` matches. Lets policies write
+    /// `tool_result contains "sk-"` without committing to a specific JSON
+    /// field shape, useful when the response body's schema is unknown.
+    ToolResultWhole,
 }
 
 #[derive(Debug, PartialEq)]

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -2371,6 +2371,20 @@ mod tests {
     }
 
     #[test]
+    fn tool_result_malformed_json_is_null_safe_no_match() {
+        // A result body that doesn't parse as JSON (default empty string,
+        // truncated, etc.) is no-match for dotted predicates — but the bare
+        // `tool_result contains "..."` still matches the raw bytes because
+        // it never parses the body.
+        let empty = tool_result_with_body("read_file", "");
+        assert!(!evaluate(r#"tool_result.contents == "hello""#, &empty, None, None,));
+
+        let garbage = tool_result_with_body("read_file", "{not valid json");
+        assert!(!evaluate(r#"tool_result.contents == "hello""#, &garbage, None, None,));
+        assert!(evaluate(r#"tool_result contains "not valid""#, &garbage, None, None));
+    }
+
+    #[test]
     fn tool_result_predicate_against_non_toolresult_action_is_no_match() {
         // A ToolCall / FileAccess / NetworkRequest / ProcessExec action carries
         // no `result` payload; tool_result predicates must surface as no-match

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -2297,4 +2297,22 @@ mod tests {
             None,
         ));
     }
+
+    // ── FieldRef::ToolResult — tool_result.<key> + bare tool_result tests ───
+
+    /// Build a `ToolResult` action against a known `tool_name` whose `result`
+    /// is a JSON-encoded body — used by the response-side predicate tests
+    /// below.
+    fn tool_result_with_body(tool_name: &str, body: &str) -> GovernanceAction {
+        GovernanceAction::ToolResult {
+            tool_name: tool_name.to_string(),
+            result: body.to_string(),
+        }
+    }
+
+    #[test]
+    fn tool_result_field_eq_matches_string_leaf() {
+        let action = tool_result_with_body("read_file", r#"{"contents": "hello"}"#);
+        assert!(evaluate(r#"tool_result.contents == "hello""#, &action, None, None));
+    }
 }

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -503,6 +503,114 @@ fn eval_clause_safe(
         };
     }
 
+    // `tool_result.<key>` — JSON-pointer walk into the ToolResult's `result`
+    // payload, and the bare `tool_result` shorthand for matching the whole
+    // serialised body. Mirrors `args.<key>`'s null-safety contract: non-
+    // `ToolResult` actions, unparseable result JSON, and unresolved pointers
+    // all surface as no-match. The bare `tool_result` arm only accepts
+    // `contains` / `starts_with` against a string literal (regex-style
+    // pattern matching on the full body); equality / numeric / list ops
+    // don't have a sensible whole-body interpretation and fall through to
+    // false.
+    if matches!(field, FieldRef::ToolResult(_) | FieldRef::ToolResultWhole) {
+        let result_str = match action {
+            GovernanceAction::ToolResult { result, .. } => result.as_str(),
+            _ => return false,
+        };
+        if let FieldRef::ToolResultWhole = field {
+            let lit = match literal {
+                LiteralVal::Str(s) => s.as_str(),
+                _ => return false,
+            };
+            return match op {
+                OpKind::Contains => result_str.contains(lit),
+                OpKind::StartsWith => result_str.starts_with(lit),
+                _ => false,
+            };
+        }
+        let pointer = match field {
+            FieldRef::ToolResult(p) => p,
+            _ => unreachable!(),
+        };
+        let result_value: serde_json::Value = match serde_json::from_str(result_str) {
+            Ok(v) => v,
+            Err(_) => return false,
+        };
+        let resolved = match result_value.pointer(pointer) {
+            Some(v) => v,
+            None => return false,
+        };
+        return match op {
+            OpKind::Eq | OpKind::Ne => match (resolved, literal) {
+                (serde_json::Value::String(s), LiteralVal::Str(lit)) => {
+                    if matches!(op, OpKind::Eq) {
+                        s == lit
+                    } else {
+                        s != lit
+                    }
+                }
+                (serde_json::Value::Number(n), LiteralVal::Num(lit)) => match n.as_f64() {
+                    Some(v) => {
+                        if matches!(op, OpKind::Eq) {
+                            (v - *lit).abs() < f64::EPSILON
+                        } else {
+                            (v - *lit).abs() >= f64::EPSILON
+                        }
+                    }
+                    None => false,
+                },
+                _ => false,
+            },
+            OpKind::Contains | OpKind::StartsWith => {
+                let value = match resolved.as_str() {
+                    Some(s) => s,
+                    None => return false,
+                };
+                let lit = match literal {
+                    LiteralVal::Str(s) => s.as_str(),
+                    _ => return false,
+                };
+                if matches!(op, OpKind::Contains) {
+                    value.contains(lit)
+                } else {
+                    value.starts_with(lit)
+                }
+            }
+            OpKind::In | OpKind::NotIn => {
+                let value = match resolved.as_str() {
+                    Some(s) => s,
+                    None => return false,
+                };
+                let list = match literal {
+                    LiteralVal::StrList(items) => items,
+                    _ => return false,
+                };
+                if matches!(op, OpKind::In) {
+                    list.iter().any(|item| item == value)
+                } else {
+                    list.iter().all(|item| item != value)
+                }
+            }
+            OpKind::Gt | OpKind::Gte | OpKind::Lt | OpKind::Lte => {
+                let lhs = match resolved.as_f64() {
+                    Some(n) => n,
+                    None => return false,
+                };
+                let rhs = match literal {
+                    LiteralVal::Num(n) => *n,
+                    _ => return false,
+                };
+                match op {
+                    OpKind::Gt => lhs > rhs,
+                    OpKind::Gte => lhs >= rhs,
+                    OpKind::Lt => lhs < rhs,
+                    OpKind::Lte => lhs <= rhs,
+                    _ => unreachable!(),
+                }
+            }
+        };
+    }
+
     // `args.<key>` — JSON-pointer walk into the ToolCall's args payload.
     //
     // Null-safe at every step: non-ToolCall actions, unparseable args JSON,

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -9,6 +9,8 @@
 //! combinator := "AND" | "OR"
 //! field      := "tool" | "path" | "url" | "method" | "command"
 //!             | "args." dotted_path        # walks ToolCall.args JSON
+//!             | "tool_result." dotted_path # walks ToolResult.result JSON
+//!             | "tool_result"              # whole ToolResult.result body
 //!             | (other identifiers — see KNOWN_VARIABLES)
 //! op         := "==" | "!=" | ">" | ">=" | "<" | "<=" | "contains" | "starts_with"
 //!             | "in" | "not_in"
@@ -25,6 +27,21 @@
 //! resolved numeric leaves accept `== != > >= < <=`. Non-`ToolCall`
 //! actions, malformed `args` JSON, and unresolved pointers all surface
 //! as no-match (false) — never fail-safe-true.
+//!
+//! ## `tool_result.<key>` predicates (response side)
+//!
+//! Response-side mirror of `args.<key>`: identifiers prefixed with
+//! `tool_result.` walk the JSON body on a
+//! [`GovernanceAction::ToolResult`]'s `result` field via the same
+//! JSON-pointer translation (`tool_result.foo` → `/foo`,
+//! `tool_result.payload.api_key` → `/payload/api_key`). Op coverage
+//! and null-safety match `args.<key>` exactly.
+//!
+//! The bare identifier `tool_result` (no dotted suffix) is a special
+//! shorthand that treats the entire serialised `result` body as one
+//! string. Only `contains` / `starts_with` against a string literal
+//! are meaningful here — useful for regex-style pattern matches like
+//! `tool_result contains "sk-"` when the body schema is unknown.
 //!
 //! **Fail-safe**: any parse/tokenization error returns `true`
 //! (triggers RequiresApproval — the safe default).

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -303,6 +303,24 @@ fn tokenize(expr: &str) -> Option<Vec<Token>> {
                 continue;
             }
 
+            // `tool_result.<key>` / `tool_result.<key>.<nested>` — response-side
+            // mirror of `args.<key>`. Resolves to `FieldRef::ToolResult(pointer)`
+            // when a dotted path follows; the bare `tool_result` (no path) maps
+            // to `FieldRef::ToolResultWhole` so policies can match the entire
+            // serialised response as one string.
+            if let Some(rest) = word.strip_prefix("tool_result.") {
+                if rest.is_empty() {
+                    return None;
+                }
+                let pointer = format!("/{}", rest.replace('.', "/"));
+                tokens.push(Token::Field(FieldRef::ToolResult(pointer)));
+                continue;
+            }
+            if word == "tool_result" {
+                tokens.push(Token::Field(FieldRef::ToolResultWhole));
+                continue;
+            }
+
             let token = match word.as_str() {
                 "AND" => Token::And,
                 "OR" => Token::Or,

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -2335,4 +2335,24 @@ mod tests {
             None,
         ));
     }
+
+    #[test]
+    fn bare_tool_result_contains_pattern_in_whole_body() {
+        // The ST-Q-3 shorthand: `tool_result contains "sk-"` matches against
+        // the entire serialised result body — useful when the schema is
+        // unknown but the secret prefix is.
+        let action = tool_result_with_body(
+            "search",
+            r#"{"items": [{"snippet": "leaked key: sk-test-123 in log"}]}"#,
+        );
+        assert!(evaluate(r#"tool_result contains "sk-""#, &action, None, None));
+    }
+
+    #[test]
+    fn bare_tool_result_starts_with_against_whole_body() {
+        // Whole-body starts_with is rarer but sometimes useful — e.g. asserting
+        // a response is JSON-shaped (`{...}`) before any further predicate runs.
+        let action = tool_result_with_body("ping", r#"{"ok": true}"#);
+        assert!(evaluate(r#"tool_result starts_with "{""#, &action, None, None));
+    }
 }

--- a/aa-gateway/src/service/convert.rs
+++ b/aa-gateway/src/service/convert.rs
@@ -92,6 +92,10 @@ pub fn request_to_core(req: &CheckActionRequest) -> Result<(AgentContext, Govern
             name: tc.tool_name.clone(),
             args: String::from_utf8_lossy(&tc.args_json).into_owned(),
         },
+        Action::ToolResult(tr) => GovernanceAction::ToolResult {
+            tool_name: tr.tool_name.clone(),
+            result: String::from_utf8_lossy(&tr.result_json).into_owned(),
+        },
         Action::FileOp(fo) => {
             let mode = match fo.operation.as_str() {
                 "read" => FileMode::Read,

--- a/aa-gateway/src/simulation/engine.rs
+++ b/aa-gateway/src/simulation/engine.rs
@@ -128,6 +128,7 @@ impl SimulationEngine {
 fn action_summary(action: &GovernanceAction) -> String {
     match action {
         GovernanceAction::ToolCall { name, .. } => format!("tool:{name}"),
+        GovernanceAction::ToolResult { tool_name, .. } => format!("tool_result:{tool_name}"),
         GovernanceAction::FileAccess { path, mode } => format!("file:{mode:?}:{path}"),
         GovernanceAction::NetworkRequest { url, method, .. } => format!("net:{method}:{url}"),
         GovernanceAction::ProcessExec { command, .. } => format!("exec:{command}"),

--- a/aa-integration-tests/tests/common/fixtures/policies/mcp_redact_secrets.yaml
+++ b/aa-integration-tests/tests/common/fixtures/policies/mcp_redact_secrets.yaml
@@ -1,0 +1,19 @@
+apiVersion: agent-assembly.dev/v1alpha1
+kind: GovernancePolicy
+metadata:
+  name: it-mcp-redact-secrets
+  version: "0.1.0"
+spec:
+  tools:
+    test_tool:
+      allow: true
+  data:
+    # AAASM-1941 / ST-Q-3 fixture: detect OpenAI keys (sk-[A-Za-z0-9]+) in
+    # the response body of a tool call. `credential_action: redact_only`
+    # keeps the action Allow but populates `redacted_payload` so the
+    # response-side CheckAction maps to Decision::Redact with
+    # RedactInstructions — i.e. the upstream secret is rewritten before
+    # the agent ever sees it.
+    credential_action: redact_only
+    sensitive_patterns:
+      - "sk-[A-Za-z0-9-]+"

--- a/aa-integration-tests/tests/e2e_mcp_redact.rs
+++ b/aa-integration-tests/tests/e2e_mcp_redact.rs
@@ -1,0 +1,137 @@
+//! F116 ST-Q Part 2 — gateway-level coverage of the response-side
+//! `GovernanceAction::ToolResult` path.
+//!
+//! Loads the `mcp_redact_secrets.yaml` fixture, evaluates a `ToolResult`
+//! action whose `result` body embeds a synthetic OpenAI key, and asserts:
+//!
+//! 1. The credential scanner (Stage 6 of `PolicyEngine::evaluate`) detects
+//!    the key in the response body — `credential_findings` is non-empty.
+//! 2. `redacted_payload` is `Some(_)` and the raw secret is replaced by a
+//!    `[REDACTED:…]` marker.
+//! 3. The full original secret never appears in `redacted_payload`.
+//! 4. Routing the `EvaluationResult` through
+//!    `aa_gateway::service::convert::eval_result_to_response` yields
+//!    `Decision::Redact` carrying a `RedactInstructions { rules: [..] }`
+//!    payload — the contract the proxy + AAASM-1930 ST-Q-3 hook into.
+//!
+//! Full proxy E2E (an MCP server returning a real `sk-…` key over the
+//! wire, intercepted by `aa-proxy`, and the agent receiving the redacted
+//! response) lands in AAASM-1930.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use aa_core::identity::{AgentId, SessionId};
+use aa_core::time::Timestamp;
+use aa_core::{AgentContext, GovernanceAction, GovernanceLevel, PolicyResult};
+use aa_gateway::service::convert::eval_result_to_response;
+use aa_gateway::{EvaluationResult, PolicyEngine};
+use aa_proto::assembly::common::v1::Decision;
+
+/// Synthetic OpenAI key — uses the documented `sk-test-` prefix so no real
+/// secret material ever lives in this fixture.
+const FAKE_OPENAI_KEY: &str = "sk-test-AbCdEf1234567890ABCDEF1234567890ABCDEF1234567890";
+
+fn fixture_path(rel: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/common/fixtures")
+        .join(rel)
+}
+
+fn make_ctx(agent_bytes: [u8; 16]) -> AgentContext {
+    AgentContext {
+        agent_id: AgentId::from_bytes(agent_bytes),
+        session_id: SessionId::from_bytes([0xAAu8; 16]),
+        pid: 1,
+        started_at: Timestamp::from_nanos(0),
+        metadata: BTreeMap::new(),
+        governance_level: GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: None,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: None,
+    }
+}
+
+fn make_engine() -> PolicyEngine {
+    let path = fixture_path("policies/mcp_redact_secrets.yaml");
+    let (tx, _rx) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    PolicyEngine::load_from_file(&path, tx).expect("mcp_redact_secrets.yaml must load cleanly")
+}
+
+fn tool_result_with_body(tool_name: &str, body: &str) -> GovernanceAction {
+    GovernanceAction::ToolResult {
+        tool_name: tool_name.to_string(),
+        result: body.to_string(),
+    }
+}
+
+fn evaluate(action: &GovernanceAction, agent_seed: u8) -> EvaluationResult {
+    let engine = make_engine();
+    let ctx = make_ctx([agent_seed; 16]);
+    engine.evaluate(&ctx, action)
+}
+
+#[test]
+fn tool_result_with_openai_key_is_redacted_and_surfaces_redact_instructions() {
+    // The MCP server "returned" a response body that embeds an OpenAI key.
+    let body = format!(r#"{{"items":[{{"snippet":"leaked: {FAKE_OPENAI_KEY}"}}]}}"#);
+    let action = tool_result_with_body("search", &body);
+
+    let result = evaluate(&action, 0x11);
+
+    // Stage 6 must catch the key — credential_findings non-empty.
+    assert!(
+        !result.credential_findings.is_empty(),
+        "expected the credential scanner to flag the OpenAI key, got no findings"
+    );
+
+    // The raw secret must NEVER survive in the redacted payload.
+    let redacted = result
+        .redacted_payload
+        .as_deref()
+        .expect("credential_action=redact_only must produce a redacted_payload when findings are non-empty");
+    assert!(
+        !redacted.contains(FAKE_OPENAI_KEY),
+        "raw OpenAI key leaked into redacted_payload: {redacted}"
+    );
+
+    // The decision stays Allow at the engine level — Stage 6 redacts in-memory.
+    // It's the convert.rs mapping (eval_result_to_response) that promotes a
+    // findings + redacted_payload combination to Decision::Redact on the wire.
+    assert_eq!(
+        result.decision,
+        PolicyResult::Allow,
+        "engine decision should remain Allow; convert.rs handles Decision::Redact mapping"
+    );
+
+    let response = eval_result_to_response(&result, 0, "data_pattern_scan");
+    assert_eq!(
+        response.decision,
+        Decision::Redact as i32,
+        "credential_findings + redacted_payload must map to Decision::Redact"
+    );
+    let redact = response.redact.expect("Decision::Redact must carry RedactInstructions");
+    assert!(
+        !redact.rules.is_empty(),
+        "RedactInstructions must list at least one rule, got {:?}",
+        redact.rules
+    );
+
+    // The full key must not leak through the proto response either — neither
+    // the rule's field_path nor its replacement string should carry it.
+    for rule in &redact.rules {
+        assert!(
+            !rule.field_path.contains(FAKE_OPENAI_KEY),
+            "raw secret leaked into rule.field_path: {}",
+            rule.field_path
+        );
+        assert!(
+            !rule.replacement.contains(FAKE_OPENAI_KEY),
+            "raw secret leaked into rule.replacement: {}",
+            rule.replacement
+        );
+    }
+}

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -57,6 +57,9 @@ enum ActionType {
   PROCESS_EXEC       = 5;
   // Spawn a child agent.
   AGENT_SPAWN        = 6;
+  // Result body returned by a tool invocation — evaluated on the response
+  // path so policies can redact secrets in the body before the agent sees it.
+  TOOL_RESULT        = 7;
 }
 
 // ── Risk tier ─────────────────────────────────────────────────────────────────

--- a/proto/policy.proto
+++ b/proto/policy.proto
@@ -53,6 +53,7 @@ message ActionContext {
     FileOpContext      file_op      = 3;
     NetworkCallContext network_call = 4;
     ProcessExecContext process_exec = 5;
+    ToolResultContext  tool_result  = 6;
   }
 }
 
@@ -76,6 +77,26 @@ message ToolCallContext {
   bytes  args_json   = 3;
   // Target URL if the tool makes an HTTP request.
   string target_url  = 4;
+}
+
+// ToolResultContext carries the response body emitted by a tool invocation.
+// Sent by the proxy on the response path so the policy engine can match
+// patterns / JSON-pointer paths against the body before the agent receives it
+// and surface RedactInstructions to rewrite matched substrings in flight.
+message ToolResultContext {
+  // Registered tool name (e.g. "web_search", "run_python") — matches the
+  // tool_name of the originating ToolCallContext when the proxy issues a
+  // second CheckAction on the response.
+  string tool_name   = 1;
+  // Source system ("mcp", "langchain", "function").
+  string tool_source = 2;
+  // JSON-encoded response body. Policy clauses reference fields via
+  // `tool_result.<dotted_path>`; bare `tool_result` walks the whole body
+  // as one string for regex-style pattern matches.
+  bytes  result_json = 3;
+  // Source URL the response came from (the upstream endpoint that produced
+  // it). Empty when the proxy could not attribute a URL.
+  string source_url  = 4;
 }
 
 // FileOpContext carries details about a filesystem operation.


### PR DESCRIPTION
## Description

Response-side complement to AAASM-1940 (`FieldRef::ToolArg`, request-side). Adds the `GovernanceAction::ToolResult` action shape end-to-end so the policy engine can match patterns against the body returned by a tool call and surface `Decision::Redact` + `RedactInstructions` before the response reaches the agent. This unblocks AAASM-1930's ST-Q-3 acceptance criterion (`redact_if tool_result contains_pattern "(sk-[a-zA-Z0-9]+)"`).

Six logical slices, mirroring the ticket's Part A–F structure:

- **A — aa-core**: new `GovernanceAction::ToolResult { tool_name, result }` variant + serde round-trip + clone tests.
- **B — proto**: `ActionType::TOOL_RESULT = 7` in `common.proto` (note: ticket said `= 6` but that slot is `AGENT_SPAWN`); `ToolResultContext { tool_name, tool_source, result_json, source_url }` message + `ActionContext.action` oneof variant (`tool_result = 6`) in `policy.proto`. Prost regenerates automatically via `aa-proto/build.rs`.
- **C — `aa-gateway/src/policy/expr.rs`**: `FieldRef::ToolResult(JsonPath)` for dotted-path predicates + `FieldRef::ToolResultWhole` for the bare `tool_result` shorthand; lexer recognises both; `validate_variables` skips both; evaluator branch mirrors `ToolArg`'s null-safety (non-`ToolResult` actions, malformed JSON, unresolved pointers all surface as no-match).
- **D — `aa-gateway/src/service/convert.rs`**: maps `ActionContext::tool_result` → `GovernanceAction::ToolResult`. Also touches `aa-api/src/ws/handler.rs` ActionType label so the dashboard ws stream can identify response-side ops (unavoidable downstream of the proto enum).
- **E — integration test**: `aa-integration-tests/tests/common/fixtures/policies/mcp_redact_secrets.yaml` + `aa-integration-tests/tests/e2e_mcp_redact.rs` — loads the fixture, evaluates a `ToolResult` action whose body embeds a synthetic OpenAI key, and asserts the engine produces `credential_findings` + a `redacted_payload`, then `eval_result_to_response` promotes the EvaluationResult to `Decision::Redact` with `RedactInstructions`.
- **F — DSL docs**: module doc on `expr.rs` documents `tool_result.<dotted_path>` + bare `tool_result` shorthand.

Engine wiring: `Stage 6 credential scan` in `aa-gateway/src/engine/mod.rs` now reads `ToolResult { result }` instead of the temporary empty stub introduced with the variant, so existing `data.sensitive_patterns` policies automatically apply to response bodies the same way they apply to `ToolCall.args`.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No

The new variant is purely additive on the wire format. Existing `ToolCall` / `FileAccess` / `NetworkRequest` / `ProcessExec` / `SendMessage` flows are unchanged. The aa-api ws handler now recognises `tool_result` as an extra op-type label — no consumers ship before this PR.

## Related Issues

- Related Jira ticket: [AAASM-1941](https://lightning-dust-mite.atlassian.net/browse/AAASM-1941)
- Parent Story: [AAASM-1232](https://lightning-dust-mite.atlassian.net/browse/AAASM-1232) (F116 — Full MVP acceptance test)
- Sibling (Done): [AAASM-1940](https://lightning-dust-mite.atlassian.net/browse/AAASM-1940) — request-side `FieldRef::ToolArg`, PR #797
- Blocks: AAASM-1930 ST-Q-3 acceptance criterion (full proxy E2E)

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] Manual testing performed

**aa-core**: 2 new tests (`governance_action_tool_result` clone equality, `governance_action_tool_result_serde_round_trip`).

**aa-gateway**: 8 new tests covering the predicate evaluator, lexer, and validator:
- `tool_result_field_eq_matches_string_leaf`
- `tool_result_field_contains_matches_substring_in_leaf`
- `tool_result_walks_nested_json_pointer`
- `bare_tool_result_contains_pattern_in_whole_body` + `bare_tool_result_starts_with_against_whole_body`
- `tool_result_missing_key_is_null_safe_no_match`
- `tool_result_malformed_json_is_null_safe_no_match`
- `tool_result_numeric_comparison_against_json_number`
- `tool_result_predicate_against_non_toolresult_action_is_no_match`

**aa-integration-tests**: 1 new gateway-level e2e test (`e2e_mcp_redact::tool_result_with_openai_key_is_redacted_and_surfaces_redact_instructions`) loading `mcp_redact_secrets.yaml`.

Local validation run on this branch:

- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo nextest run -p aa-core -p aa-gateway -p aa-proto` — **1308 passed, 0 failed**.
- `cargo nextest run -p aa-integration-tests --test e2e_mcp_redact --test e2e_secret_interception --test e2e_policy_sdk` — **18 passed, 0 failed** (no regression in the AAASM-1521 secret-interception suite or AAASM-1940 args predicates).

Workspace-wide `cargo nextest run --workspace` has 5 `e2e_sdk_node::selftest_lang*` failures that **reproduce identically on `remote/master` @ 1e0ec8a2** with no diff applied — pre-existing on master, not caused by this PR.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (DSL grammar doc in `expr.rs`)
- [ ] All CI checks passing (will track after push)
- [x] Commits are small and follow the Gitmoji convention (21 commits, ≈1 commit per logical change)


[AAASM-1941]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ