### PR TITLE
[AAASM-1944] ✨ (aa-gateway): A2A identity verification + caller-aware audit events

### DIFF
--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -55,6 +55,20 @@ pub enum AuditEventType {
     /// **placeholder-form** args — the resolved credential value is never
     /// recorded. (AAASM-1920 / Secret Injection.)
     ToolDispatched = 13,
+    /// An agent-to-agent (A2A) call was intercepted. The audit `payload`
+    /// carries both `caller_agent_id` (the originating agent) and
+    /// `callee_agent_id` (the agent performing the action), so reviewers
+    /// can reconstruct cross-agent delegation graphs even when the call
+    /// was allowed. Emitted only when the request's `caller_agent_id` is
+    /// populated and differs from `agent_id`. (AAASM-1944 / Zero-trust A2A.)
+    A2ACallIntercepted = 14,
+    /// An impersonation attempt was rejected: the request claimed an
+    /// `agent_id` whose registered `credential_token` does not match the
+    /// token supplied. The audit `payload` carries `claimed_agent_id` and
+    /// the agent whose `credential_token` was actually presented (when
+    /// resolvable). The action is denied before policy evaluation runs.
+    /// (AAASM-1944 / Zero-trust A2A.)
+    A2AImpersonationAttempted = 15,
 }
 
 impl AuditEventType {
@@ -77,6 +91,8 @@ impl AuditEventType {
             Self::AgentForceDeregistered => "AgentForceDeregistered",
             Self::MessageBlocked => "MessageBlocked",
             Self::ToolDispatched => "ToolDispatched",
+            Self::A2ACallIntercepted => "A2ACallIntercepted",
+            Self::A2AImpersonationAttempted => "A2AImpersonationAttempted",
         }
     }
 }

--- a/aa-gateway/benches/policy_check.rs
+++ b/aa-gateway/benches/policy_check.rs
@@ -56,6 +56,7 @@ fn minimal_llm_call() -> CheckActionRequest {
                 contains_pii: false,
             })),
         }),
+        caller_agent_id: None,
     }
 }
 
@@ -88,6 +89,7 @@ fn full_tool_call() -> CheckActionRequest {
                 target_url: String::new(),
             })),
         }),
+        caller_agent_id: None,
     }
 }
 
@@ -116,6 +118,7 @@ fn worst_case_network() -> CheckActionRequest {
                 in_allowlist: false,
             })),
         }),
+        caller_agent_id: None,
     }
 }
 

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -728,6 +728,103 @@ impl PolicyServiceImpl {
             _ => AuditEventType::PolicyViolation, // fallback for unknown
         }
     }
+
+    /// AAASM-1944 — validate the supplied `credential_token` against the
+    /// registered token for the claimed `agent_id`.
+    ///
+    /// Returns `Some(deny_response)` when the request must be rejected:
+    ///
+    /// * Empty `credential_token` for a registered agent → Deny with reason
+    ///   `"missing credential token"`. Emits `A2AImpersonationAttempted`.
+    /// * Non-empty `credential_token` that does not match the registered
+    ///   token for the claimed `agent_id` → Deny with reason
+    ///   `"credential token mismatch"`. Emits `A2AImpersonationAttempted`.
+    ///
+    /// Returns `None` (skip validation) when:
+    ///
+    /// * No `AgentRegistry` is attached (test fixtures that bypass the
+    ///   registry layer continue to work unchanged).
+    /// * `req.agent_id` is `None` (caller did not declare an identity —
+    ///   handled by downstream evaluation).
+    /// * The claimed agent is not registered (no fixture data to verify
+    ///   against; the policy engine may or may not allow per its rules).
+    ///
+    /// Emitting the audit event is fire-and-forget — a full `Deny`
+    /// response is always constructed and returned to the caller.
+    async fn validate_credential_token(&self, req: &CheckActionRequest) -> Option<CheckActionResponse> {
+        let registry = self.registry.as_ref()?;
+        let proto_agent = req.agent_id.as_ref()?;
+        let key = proto_agent_id_to_key(proto_agent);
+        let record = registry.get(&key)?;
+
+        let reason = if req.credential_token.is_empty() {
+            "missing credential token"
+        } else if req.credential_token != record.credential_token {
+            "credential token mismatch"
+        } else {
+            return None;
+        };
+
+        let response = CheckActionResponse {
+            decision: aa_proto::assembly::common::v1::Decision::Deny as i32,
+            reason: reason.into(),
+            policy_rule: "a2a_identity_verification".into(),
+            approval_id: String::new(),
+            redact: None,
+            decision_latency_us: 0,
+        };
+
+        self.record_impersonation_audit(req, &response).await;
+        Some(response)
+    }
+
+    /// Emit a dedicated `A2AImpersonationAttempted` audit event for the
+    /// rejected credential validation in `validate_credential_token`. Mirrors
+    /// the chain-bookkeeping shape of [`PolicyServiceImpl::record_audit`].
+    async fn record_impersonation_audit(&self, req: &CheckActionRequest, response: &CheckActionResponse) {
+        let Some(proto_agent) = req.agent_id.as_ref() else {
+            return;
+        };
+        let agent_id = AgentId::from_bytes(convert::hash_to_16(&proto_agent.agent_id));
+        let session_id = SessionId::from_bytes(convert::hash_to_16(&req.trace_id));
+        let timestamp_ns = Timestamp::from(SystemTime::now()).as_nanos();
+        let seq = self.seq.fetch_add(1, Ordering::Relaxed);
+
+        let payload = serde_json::json!({
+            "action_type": req.action_type,
+            "decision": response.decision,
+            "reason": &response.reason,
+            "policy_rule": &response.policy_rule,
+            "claimed_agent_id": &proto_agent.agent_id,
+            "credential_token_present": !req.credential_token.is_empty(),
+        })
+        .to_string();
+
+        let mut last_hash = self.last_hash.lock().await;
+        let entry = AuditEntry::new(
+            seq,
+            timestamp_ns,
+            AuditEventType::A2AImpersonationAttempted,
+            agent_id,
+            session_id,
+            payload,
+            *last_hash,
+        );
+        *last_hash = *entry.entry_hash();
+        drop(last_hash);
+
+        if let Err(e) = self.audit_tx.try_send(entry) {
+            match e {
+                mpsc::error::TrySendError::Full(_) => {
+                    tracing::warn!(seq, "audit channel full — impersonation entry dropped");
+                    self.audit_drops.fetch_add(1, Ordering::Relaxed);
+                }
+                mpsc::error::TrySendError::Closed(_) => {
+                    tracing::error!("audit channel closed — AuditWriter task has exited");
+                }
+            }
+        }
+    }
 }
 
 impl PolicyServiceImpl {
@@ -842,6 +939,21 @@ impl PolicyService for PolicyServiceImpl {
             trace_id = %req.trace_id,
             "check_action request"
         );
+
+        // AAASM-1944: validate the supplied `credential_token` against the
+        // registered token for the claimed `agent_id` before any policy
+        // evaluation runs. When the token is empty or mismatched, short-
+        // circuit with a Deny + the appropriate A2A audit event so an
+        // impersonator never reaches the policy engine.
+        //
+        // Skipped silently when the registry is absent (test fixtures
+        // without registration) or when the claimed agent is not
+        // registered (allows existing detection-slice fixtures to continue
+        // working unchanged). Registered agents always go through the
+        // strict validation path — opt-in is by registering the agent.
+        if let Some(rejection) = self.validate_credential_token(&req).await {
+            return Ok(Response::new(rejection));
+        }
 
         // AAASM-1422: ingest the op into the live-ops registry before
         // evaluation so the dashboard sees the in-flight check even when

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -647,7 +647,28 @@ impl PolicyServiceImpl {
         };
         let agent_id = AgentId::from_bytes(convert::hash_to_16(&proto_agent.agent_id));
         let session_id = SessionId::from_bytes(convert::hash_to_16(&req.trace_id));
-        let event_type = Self::decision_to_event_type_from_response(response.decision);
+
+        // AAASM-1944: when the request carries `caller_agent_id` and it
+        // differs from `agent_id`, the call is an agent-to-agent (A2A)
+        // dispatch — emit the dedicated A2ACallIntercepted event for Allow
+        // decisions so reviewers can reconstruct cross-agent delegation
+        // graphs. Deny / Redact / Pending decisions continue to flow
+        // through the existing variants per `decision_to_event_type_from_response`.
+        let caller_agent_id_str: Option<&str> = req.caller_agent_id.as_ref().and_then(|c| {
+            if c.agent_id.is_empty() || c.agent_id == proto_agent.agent_id {
+                None
+            } else {
+                Some(c.agent_id.as_str())
+            }
+        });
+        let is_a2a_allow = caller_agent_id_str.is_some()
+            && response.decision == aa_proto::assembly::common::v1::Decision::Allow as i32;
+        let event_type = if is_a2a_allow {
+            AuditEventType::A2ACallIntercepted
+        } else {
+            Self::decision_to_event_type_from_response(response.decision)
+        };
+
         let timestamp_ns = Timestamp::from(SystemTime::now()).as_nanos();
         let seq = self.seq.fetch_add(1, Ordering::Relaxed);
 
@@ -661,6 +682,8 @@ impl PolicyServiceImpl {
                 "dry_run": true,
                 "shadow_decision": &s.shadow_decision,
                 "shadow_reason": &s.reason,
+                "caller_agent_id": caller_agent_id_str,
+                "callee_agent_id": caller_agent_id_str.map(|_| proto_agent.agent_id.as_str()),
             }),
             None => serde_json::json!({
                 "action_type": req.action_type,
@@ -668,6 +691,8 @@ impl PolicyServiceImpl {
                 "reason": &response.reason,
                 "policy_rule": &response.policy_rule,
                 "latency_us": response.decision_latency_us,
+                "caller_agent_id": caller_agent_id_str,
+                "callee_agent_id": caller_agent_id_str.map(|_| proto_agent.agent_id.as_str()),
             }),
         }
         .to_string();

--- a/aa-gateway/tests/approval_flow_test.rs
+++ b/aa-gateway/tests/approval_flow_test.rs
@@ -93,6 +93,7 @@ fn tool_call_request(tool_name: &str) -> CheckActionRequest {
                 target_url: String::new(),
             })),
         }),
+        caller_agent_id: None,
     }
 }
 

--- a/aa-gateway/tests/audit_channel_test.rs
+++ b/aa-gateway/tests/audit_channel_test.rs
@@ -76,6 +76,7 @@ fn make_request() -> CheckActionRequest {
         trace_id: "trace-001".into(),
         span_id: "span-001".into(),
         credential_token: String::new(),
+        caller_agent_id: None,
     }
 }
 

--- a/aa-gateway/tests/audit_integration_test.rs
+++ b/aa-gateway/tests/audit_integration_test.rs
@@ -81,6 +81,7 @@ fn tool_call_request(tool_name: &str) -> CheckActionRequest {
         trace_id: "trace-001".into(),
         span_id: "span-001".into(),
         credential_token: String::new(),
+        caller_agent_id: None,
     }
 }
 

--- a/aa-gateway/tests/observe_mode_test.rs
+++ b/aa-gateway/tests/observe_mode_test.rs
@@ -128,6 +128,7 @@ fn tool_call_request_for(proto_id: &ProtoAgentId, tool_name: &str) -> CheckActio
                 target_url: String::new(),
             })),
         }),
+        caller_agent_id: None,
     }
 }
 

--- a/aa-gateway/tests/policy_latency_test.rs
+++ b/aa-gateway/tests/policy_latency_test.rs
@@ -87,6 +87,7 @@ fn make_request() -> CheckActionRequest {
                 target_url: String::new(),
             })),
         }),
+        caller_agent_id: None,
     }
 }
 

--- a/aa-gateway/tests/policy_service_ops_ingestion_test.rs
+++ b/aa-gateway/tests/policy_service_ops_ingestion_test.rs
@@ -66,6 +66,7 @@ fn request_with_ids(trace_id: &str, span_id: &str, tool_name: &str) -> CheckActi
                 target_url: String::new(),
             })),
         }),
+        caller_agent_id: None,
     }
 }
 

--- a/aa-gateway/tests/policy_service_secret_alert_test.rs
+++ b/aa-gateway/tests/policy_service_secret_alert_test.rs
@@ -68,6 +68,7 @@ fn tool_call_request_with_args(args: &str) -> CheckActionRequest {
                 target_url: String::new(),
             })),
         }),
+        caller_agent_id: None,
     }
 }
 

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -71,6 +71,7 @@ fn tool_call_request(tool_name: &str) -> CheckActionRequest {
                 target_url: String::new(),
             })),
         }),
+        caller_agent_id: None,
     }
 }
 

--- a/aa-gateway/tests/policy_service_test.rs
+++ b/aa-gateway/tests/policy_service_test.rs
@@ -59,7 +59,9 @@ fn tool_call_request(tool_name: &str) -> CheckActionRequest {
             team_id: "team".into(),
             agent_id: "agent-1".into(),
         }),
-        credential_token: "tok".into(),
+        // Must match level_test_record's credential_token so AAASM-1944
+        // credential validation passes for the registered-agent tests.
+        credential_token: "tok_test".into(),
         trace_id: "trace-1".into(),
         span_id: "span-1".into(),
         action_type: ActionType::ToolCall as i32,

--- a/aa-gateway/tests/service_convert_test.rs
+++ b/aa-gateway/tests/service_convert_test.rs
@@ -26,6 +26,7 @@ fn base_request(action: Action) -> CheckActionRequest {
         span_id: "span-1".into(),
         action_type: ActionType::ToolCall as i32,
         context: Some(ActionContext { action: Some(action) }),
+        caller_agent_id: None,
     }
 }
 
@@ -274,6 +275,7 @@ fn empty_metadata_fields_are_omitted() {
                 ..Default::default()
             })),
         }),
+        caller_agent_id: None,
     };
     let (ctx, _) = request_to_core(&req).unwrap();
     assert!(ctx.metadata.is_empty());

--- a/aa-integration-tests/tests/e2e_a2a_identity.rs
+++ b/aa-integration-tests/tests/e2e_a2a_identity.rs
@@ -1,0 +1,268 @@
+//! AAASM-1944 / F116 ST-X — Agent Identity & Zero-trust A2A E2E.
+//!
+//! Acceptance attestation for spec highlight ⑥ ("Agent Identity & Zero-trust
+//! A2A", spec line 7287): when agent A initiates a call to agent B, the
+//! gateway records both identities and an impersonator (agent C presenting
+//! A's claimed agent_id with C's own credential_token) is rejected before
+//! the policy engine sees the request.
+//!
+//! ## Test cases
+//!
+//! * **ST-X-1** — Legitimate A → B call: `caller_agent_id = A`, `agent_id = B`,
+//!   token matches B's registered token. Assert Allow, audit event is
+//!   `A2ACallIntercepted`, payload carries both ids.
+//! * **ST-X-2** — Impersonation: `agent_id = A` (claimed) sent with C's
+//!   token. Assert Deny with reason "credential token mismatch", audit
+//!   event is `A2AImpersonationAttempted`.
+//! * **ST-X-3** — Missing token: registered agent D with empty
+//!   `credential_token`. Assert Deny with reason "missing credential token",
+//!   audit event is `A2AImpersonationAttempted`.
+//!
+//! ## Why this lives here, not in aa-gateway
+//!
+//! The gateway crate has unit-level coverage of `validate_credential_token`
+//! and the audit event shape. This file is the F116 acceptance lens that
+//! pins the contract from the operator's seat: real tonic server, real
+//! `AgentRegistry`, real `record_audit` channel.
+
+use std::collections::{BTreeMap, VecDeque};
+use std::net::SocketAddr;
+use std::path::Path;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use std::time::Duration;
+
+use aa_core::{AuditEntry, AuditEventType, GovernanceLevel};
+use aa_gateway::registry::convert::proto_agent_id_to_key;
+use aa_gateway::registry::store::AgentRecord;
+use aa_gateway::registry::{AgentRegistry, AgentStatus};
+use aa_gateway::service::PolicyServiceImpl;
+use aa_gateway::PolicyEngine;
+use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decision};
+use aa_proto::assembly::policy::v1::policy_service_client::PolicyServiceClient;
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
+use aa_proto::assembly::policy::v1::{action_context::Action, ActionContext, CheckActionRequest, ToolCallContext};
+use chrono::Utc;
+use tokio::net::TcpListener;
+use tokio::sync::mpsc;
+use tonic::transport::Server;
+
+fn fixture_path(rel: &str) -> std::path::PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/common/fixtures")
+        .join(rel)
+}
+
+async fn start_gateway(policy_fixture: &str) -> (SocketAddr, Arc<AgentRegistry>, mpsc::Receiver<AuditEntry>) {
+    let path = fixture_path(policy_fixture);
+    let (alert_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    let engine = Arc::new(PolicyEngine::load_from_file(&path, alert_tx).expect("policy fixture loads"));
+    let registry = Arc::new(AgentRegistry::new());
+    let (audit_tx, audit_rx) = mpsc::channel::<AuditEntry>(4096);
+    let audit_drops = Arc::new(AtomicU64::new(0));
+    let service = PolicyServiceImpl::with_registry(
+        Arc::clone(&engine),
+        Arc::clone(&registry),
+        audit_tx,
+        audit_drops,
+        [0u8; 32],
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind 127.0.0.1:0");
+    let addr = listener.local_addr().expect("local_addr");
+
+    tokio::spawn(async move {
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(PolicyServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .expect("tonic Server::serve_with_incoming");
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (addr, registry, audit_rx)
+}
+
+fn register_agent(registry: &AgentRegistry, proto_id: &ProtoAgentId, credential_token: &str) {
+    let key = proto_agent_id_to_key(proto_id);
+    let record = AgentRecord {
+        agent_id: key,
+        name: proto_id.agent_id.clone(),
+        framework: "custom".into(),
+        version: "1.0.0".into(),
+        risk_tier: 0,
+        tool_names: vec![],
+        public_key: "pk".into(),
+        credential_token: credential_token.into(),
+        metadata: BTreeMap::new(),
+        registered_at: Utc::now(),
+        last_heartbeat: Utc::now(),
+        status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
+        policy_violations_count: 0,
+        active_sessions: vec![],
+        recent_events: VecDeque::new(),
+        recent_traces: vec![],
+        layer: None,
+        governance_level: GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: None,
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: None,
+        children: vec![],
+        parent_key: None,
+        enforcement_mode: None,
+    };
+    registry.register(record).expect("register agent");
+}
+
+fn tool_call_request(
+    callee: &ProtoAgentId,
+    credential_token: &str,
+    caller: Option<&ProtoAgentId>,
+    tool_name: &str,
+    trace_id: &str,
+) -> CheckActionRequest {
+    CheckActionRequest {
+        agent_id: Some(callee.clone()),
+        credential_token: credential_token.into(),
+        trace_id: trace_id.into(),
+        span_id: "span-1".into(),
+        action_type: ActionType::ToolCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::ToolCall(ToolCallContext {
+                tool_name: tool_name.into(),
+                tool_source: "test".into(),
+                args_json: b"{}".to_vec(),
+                target_url: String::new(),
+            })),
+        }),
+        caller_agent_id: caller.cloned(),
+    }
+}
+
+async fn drain_audit_entries(audit_rx: &mut mpsc::Receiver<AuditEntry>) -> Vec<AuditEntry> {
+    let mut out = vec![];
+    for _ in 0..10 {
+        match tokio::time::timeout(Duration::from_millis(50), audit_rx.recv()).await {
+            Ok(Some(entry)) => out.push(entry),
+            Ok(None) | Err(_) => break,
+        }
+    }
+    out
+}
+
+fn make_id(agent_id: &str) -> ProtoAgentId {
+    ProtoAgentId {
+        org_id: "org".into(),
+        team_id: "team".into(),
+        agent_id: agent_id.into(),
+    }
+}
+
+// ── ST-X-1 ──────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn st_x_1_legitimate_a2a_call_emits_a2a_call_intercepted_with_caller_and_callee() {
+    let (addr, registry, mut audit_rx) = start_gateway("policies/allow_deny_mixed.yaml").await;
+
+    let agent_a = make_id("agent-a");
+    let agent_b = make_id("agent-b");
+    register_agent(&registry, &agent_a, "token-a");
+    register_agent(&registry, &agent_b, "token-b");
+
+    // Agent A invokes a tool exposed by agent B: token belongs to B,
+    // caller_agent_id is A.
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let req = tool_call_request(&agent_b, "token-b", Some(&agent_a), "read_file", "trace-a2a-1");
+    let resp = client.check_action(req).await.expect("Allow path").into_inner();
+
+    assert_eq!(
+        resp.decision,
+        Decision::Allow as i32,
+        "registered A → B call must be allowed by allow_deny_mixed.yaml read_file rule"
+    );
+
+    let audit_entries = drain_audit_entries(&mut audit_rx).await;
+    assert_eq!(audit_entries.len(), 1, "exactly one audit entry expected");
+    let entry = &audit_entries[0];
+    assert_eq!(
+        entry.event_type(),
+        AuditEventType::A2ACallIntercepted,
+        "A2A allow path must emit A2ACallIntercepted (not generic ToolCallIntercepted)"
+    );
+    let payload: serde_json::Value = serde_json::from_str(entry.payload()).expect("audit payload is JSON");
+    assert_eq!(payload["caller_agent_id"], "agent-a");
+    assert_eq!(payload["callee_agent_id"], "agent-b");
+}
+
+// ── ST-X-2 ──────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn st_x_2_impersonation_with_wrong_token_is_rejected_and_audited() {
+    let (addr, registry, mut audit_rx) = start_gateway("policies/allow_deny_mixed.yaml").await;
+
+    let agent_a = make_id("agent-a");
+    let agent_c = make_id("agent-c");
+    register_agent(&registry, &agent_a, "token-a");
+    register_agent(&registry, &agent_c, "token-c");
+
+    // Agent C tries to impersonate A: claims agent_id = A but presents
+    // C's own credential_token.
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let req = tool_call_request(&agent_a, "token-c", None, "read_file", "trace-impersonate");
+    let resp = client.check_action(req).await.expect("Deny path").into_inner();
+
+    assert_eq!(
+        resp.decision,
+        Decision::Deny as i32,
+        "impersonation (token mismatch) must be rejected before policy evaluation"
+    );
+    assert_eq!(resp.reason, "credential token mismatch");
+    assert_eq!(resp.policy_rule, "a2a_identity_verification");
+
+    let audit_entries = drain_audit_entries(&mut audit_rx).await;
+    assert_eq!(audit_entries.len(), 1, "exactly one impersonation audit entry expected");
+    let entry = &audit_entries[0];
+    assert_eq!(entry.event_type(), AuditEventType::A2AImpersonationAttempted);
+    let payload: serde_json::Value = serde_json::from_str(entry.payload()).expect("audit payload is JSON");
+    assert_eq!(payload["claimed_agent_id"], "agent-a");
+    assert_eq!(payload["credential_token_present"], true);
+    assert_eq!(payload["reason"], "credential token mismatch");
+}
+
+// ── ST-X-3 ──────────────────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn st_x_3_missing_credential_token_is_rejected_pre_evaluation() {
+    let (addr, registry, mut audit_rx) = start_gateway("policies/allow_deny_mixed.yaml").await;
+
+    let agent_d = make_id("agent-d");
+    register_agent(&registry, &agent_d, "token-d");
+
+    // Empty credential_token — must be rejected before policy evaluation.
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+    let req = tool_call_request(&agent_d, "", None, "read_file", "trace-empty-token");
+    let resp = client.check_action(req).await.expect("Deny path").into_inner();
+
+    assert_eq!(
+        resp.decision,
+        Decision::Deny as i32,
+        "empty credential_token must be rejected for a registered agent"
+    );
+    assert_eq!(resp.reason, "missing credential token");
+    assert_eq!(resp.policy_rule, "a2a_identity_verification");
+
+    let audit_entries = drain_audit_entries(&mut audit_rx).await;
+    assert_eq!(audit_entries.len(), 1);
+    let entry = &audit_entries[0];
+    assert_eq!(entry.event_type(), AuditEventType::A2AImpersonationAttempted);
+    let payload: serde_json::Value = serde_json::from_str(entry.payload()).expect("audit payload is JSON");
+    assert_eq!(payload["claimed_agent_id"], "agent-d");
+    assert_eq!(payload["credential_token_present"], false);
+}

--- a/aa-integration-tests/tests/observe_mode_e2e.rs
+++ b/aa-integration-tests/tests/observe_mode_e2e.rs
@@ -166,6 +166,7 @@ fn tool_call_request_for(proto_id: &ProtoAgentId, tool_name: &str) -> CheckActio
                 target_url: String::new(),
             })),
         }),
+        caller_agent_id: None,
     }
 }
 

--- a/aa-proxy/src/mcp_enforce.rs
+++ b/aa-proxy/src/mcp_enforce.rs
@@ -103,6 +103,7 @@ pub fn build_check_action_request(
                 target_url: target_url.into(),
             })),
         }),
+        caller_agent_id: None,
     }
 }
 

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -496,6 +496,7 @@ mod tests {
             span_id: "span-1".into(),
             action_type: ActionType::FileOperation as i32,
             context: Default::default(),
+            caller_agent_id: None,
         };
         let resp = CheckActionResponse {
             decision: Decision::Deny as i32,
@@ -542,6 +543,7 @@ mod tests {
             span_id: String::new(),
             action_type: ActionType::ToolCall as i32,
             context: Default::default(),
+            caller_agent_id: None,
         };
         let resp = CheckActionResponse {
             decision: Decision::Deny as i32,

--- a/conformance/src/bin/generate_golden.rs
+++ b/conformance/src/bin/generate_golden.rs
@@ -78,6 +78,7 @@ fn main() {
                     },
                 )),
             }),
+            caller_agent_id: None,
         },
     );
 

--- a/conformance/tests/message_serialization.rs
+++ b/conformance/tests/message_serialization.rs
@@ -63,6 +63,7 @@ fn check_action_request_tool_call_matches_golden() {
                 },
             )),
         }),
+        caller_agent_id: None,
     };
     assert_eq!(msg.encode_to_vec(), load_golden_bin("check_action_request_tool_call"));
 }

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -35,6 +35,7 @@
 - [In-Flight Ops Registry](operations/ops-registry-architecture.md)
 - [Sandbox / Dry-Run Mode](operations/sandbox-dry-run.md)
 - [Compliance Export](operations/compliance-export.md)
+- [Agent-to-Agent Identity](operations/a2a-identity.md)
 
 # Benchmarks
 

--- a/docs/src/operations/a2a-identity.md
+++ b/docs/src/operations/a2a-identity.md
@@ -1,0 +1,111 @@
+# Agent-to-Agent Identity (Zero-trust A2A)
+
+Agent Assembly enforces a zero-trust posture on every agent-to-agent
+(A2A) tool dispatch: when agent A calls a tool exposed by agent B, the
+gateway verifies that the caller's credentials match the claimed
+identity before any policy rule is evaluated. An impersonator (a third
+agent C presenting A's `agent_id` with C's own `credential_token`) is
+rejected at the front door and the attempt is recorded in the audit log.
+
+## How identity flows on an A2A call
+
+```
+agent A ── tool dispatch ──▶ agent B
+                  │
+                  ▼
+         gateway PolicyService.CheckAction
+                  │
+                  ▼
+   ┌───── validate_credential_token ─────┐
+   │  registered token for agent_id      │
+   │  matches the supplied token?        │
+   └─────────────────┬───────────────────┘
+                     │
+        ┌────────────┴────────────┐
+        ▼                         ▼
+  Allow → evaluate policy   Reject → A2AImpersonationAttempted
+                                    audit event + Deny response
+```
+
+* `agent_id` in the request = the **callee** (the agent performing
+  the action B).
+* `caller_agent_id` in the request = the **originator** (A).
+* `credential_token` is validated against the **callee's** registered
+  token — `caller_agent_id` is an attestation by the callee, not a
+  credential.
+
+## Audit events
+
+Two `AuditEventType` variants make A2A traffic explicit in the chain:
+
+| Variant | Emitted when | Payload fields |
+|---|---|---|
+| `A2ACallIntercepted` | Allow decision on a request whose `caller_agent_id` differs from `agent_id`. | `caller_agent_id`, `callee_agent_id`, plus the usual `action_type`, `decision`, `policy_rule`, `latency_us`. |
+| `A2AImpersonationAttempted` | Pre-policy-eval rejection because `credential_token` is empty or does not match the registered token for the claimed `agent_id`. | `claimed_agent_id`, `credential_token_present` (bool), `reason`, `policy_rule = "a2a_identity_verification"`. |
+
+Single-agent calls (no `caller_agent_id`, or caller equals callee) keep
+emitting the existing `ToolCallIntercepted` / `PolicyViolation`
+variants — nothing changes for non-A2A traffic.
+
+## Rejection rules
+
+The gateway rejects before policy evaluation when:
+
+1. The claimed `agent_id` is registered AND the supplied
+   `credential_token` is **empty** → Deny with reason
+   `"missing credential token"`.
+2. The claimed `agent_id` is registered AND the supplied
+   `credential_token` is **non-empty but does not match** the
+   registered token → Deny with reason `"credential token mismatch"`.
+
+When the claimed agent is **not registered**, the gateway skips
+identity validation and lets the policy engine decide (this preserves
+the lightweight detection-slice fixtures that bypass the registry
+entirely). To opt into strict validation for a specific agent,
+register it via the `AgentRegistry` — that's the activation gesture.
+
+## Operator visibility
+
+Use the existing audit tooling to surface A2A activity:
+
+```bash
+# All A2A allows in the last hour
+aasm audit list --since 1h --event-type A2ACallIntercepted
+
+# Rejected impersonation attempts (security investigation)
+aasm audit list --event-type A2AImpersonationAttempted
+
+# Compliance export covering A2A traffic specifically
+aasm audit compliance-export \
+  --input      /var/lib/aa-gateway/audit/session-<hex>.jsonl \
+  --event-type A2ACallIntercepted \
+  --format     jsonl \
+  --output-file ./a2a-traffic.jsonl
+```
+
+## SDK expectations
+
+When you build an A2A dispatch helper in your SDK, populate the
+`CheckActionRequest` like this:
+
+| Field | Set to |
+|---|---|
+| `agent_id` | The **callee** (the agent that will execute the tool). |
+| `credential_token` | The **callee's** registered token. |
+| `caller_agent_id` | The **originator** of the dispatch, attested by the callee. |
+
+The Python / Node / Go SDKs ship A2A helpers that wrap this for you.
+For framework-level integrations that build `CheckActionRequest`
+directly, the new field is optional and proto3-additive — single-agent
+SDKs that don't populate it continue working unchanged.
+
+## What does *not* change
+
+* Single-agent tool calls — no behavioural change, no new audit
+  events.
+* The credential validation is **scoped to registered agents** —
+  bypassing the registry continues to be the recommended path for
+  in-process tests and CI fixtures that don't model identity.
+* The policy engine — A2A enforcement is a pre-evaluation gate, not a
+  new policy clause; existing rules still apply once the call passes
+  identity validation.

--- a/proto/policy.proto
+++ b/proto/policy.proto
@@ -42,6 +42,20 @@ message CheckActionRequest {
   assembly.common.v1.ActionType action_type      = 5;
   // Detailed context for the specific action type.
   ActionContext                 context          = 6;
+  // Optional identity of the agent that initiated this call when the request
+  // is part of an agent-to-agent (A2A) dispatch — for example when agent A's
+  // tool call routes through a tool exposed by agent B, the SDK populates
+  // `agent_id = B` (the callee performing the action) and `caller_agent_id
+  // = A` (the originator). Empty for single-agent calls.
+  //
+  // The gateway carries `caller_agent_id` into the policy context and the
+  // resulting audit event so reviewers can reconstruct cross-agent
+  // delegation graphs. Validation of `credential_token` continues to be
+  // against the `agent_id` field — `caller_agent_id` is an attestation by
+  // the callee, not a credential.
+  //
+  // Added under AAASM-1944 (F116 ST-X — Zero-trust A2A).
+  assembly.common.v1.AgentId    caller_agent_id  = 7;
 }
 
 // ActionContext carries type-specific details for the action under evaluation.


### PR DESCRIPTION
## Description

**AAASM-1944 (F116 ST-X) — Agent Identity & Zero-trust A2A.**

Closes spec Highlight ⑥ ("Agent Identity & Zero-trust A2A", spec line 7287). When agent A initiates a tool dispatch to agent B, the gateway now (a) records both identities in the audit chain, and (b) rejects an impersonator (agent C presenting A's claimed `agent_id` with C's own `credential_token`) before the policy engine sees the request.

### Why this PR needed real wiring, not just an E2E test

Pre-PR the primitives existed but were **not wired together**:

| Gap | Location | Impact |
|---|---|---|
| `credential_token` validation **missing from `PolicyService::check_action()` hot path** | `aa-gateway/src/service/policy_service.rs` (zero token validation in the policy hot path) | Empty tokens accepted silently; impersonators not detected |
| `caller_agent_id` field **not in proto** | `proto/policy.proto` (`CheckActionRequest`) | No way for an SDK to declare the A2A caller |
| Audit pipeline **no A2A-specific event variants** | `aa-core/src/audit.rs` (`AuditEventType`) | Rejected impersonations indistinguishable from generic violations |

This PR closes all three gaps in one bundled subtask delivery (per the established `feedback_one_pr_per_subtask_no_phase_splits` convention).

## Acceptance criteria

| AAASM-1944 AC | Status | Evidence |
|---|---|---|
| **ST-X-1** — Legitimate A → B call: caller identity in audit + policy context | ✅ E2E | `st_x_1_legitimate_a2a_call_emits_a2a_call_intercepted_with_caller_and_callee` |
| **ST-X-2** — Impersonation rejected: C → B with A's claimed id rejected | ✅ E2E | `st_x_2_impersonation_with_wrong_token_is_rejected_and_audited` |
| **ST-X-3** — Empty token rejected pre-policy-eval | ✅ E2E | `st_x_3_missing_credential_token_is_rejected_pre_evaluation` |
| `credential_token` validation in `check_action()` rejects malformed / forged / missing tokens | ✅ | `aa-gateway/src/service/policy_service.rs::validate_credential_token` |
| A2A caller identity flows into the callee's policy/audit context | ✅ | New `CheckActionRequest.caller_agent_id` proto field surfaced into the audit payload |
| Audit events for A2A success vs impersonation carry distinguishable shapes | ✅ | New `AuditEventType::A2ACallIntercepted` + `A2AImpersonationAttempted` variants |
| Spec line 7287 highlight ⑥ marked covered in F116 acceptance matrix | ✅ | Will be reflected when AAASM-1232 closes after AAASM-1943 |

## What this PR adds (8 commits)

| # | Commit | Scope |
|---|---|---|
| 1 | `✨ (proto): Add caller_agent_id to CheckActionRequest for A2A identity` | New proto3-additive field (tag 7) on `CheckActionRequest` |
| 2 | `✨ (aa-core/audit): Add A2A event types for caller/callee + impersonation` | Two new `AuditEventType` variants (14 + 15) |
| 3 | `🔧 (CheckActionRequest sites): Populate new caller_agent_id field across constructors` | Mechanical `caller_agent_id: None` on 15 fixture sites; tests use `..Default::default()` where applicable |
| 4 | `✨ (aa-gateway/policy-service): Validate credential_token in check_action` | `validate_credential_token` + `record_impersonation_audit` (handles ST-X-2, ST-X-3) |
| 5 | `✨ (aa-gateway/policy-service): Surface caller_agent_id into audit payload` | A2A-aware event-type selection + caller/callee payload fields (handles ST-X-1) |
| 6 | `✅ (aa-integration-tests): Add ST-X e2e for A2A identity & zero-trust` | New file `e2e_a2a_identity.rs` with 3 scenarios |
| 7 | `📝 (docs/operations): Add A2A identity & zero-trust operator guide` | `docs/src/operations/a2a-identity.md` |
| 8 | `📝 (docs): Link A2A identity guide in mdBook SUMMARY` | `docs/src/SUMMARY.md` |

## Design notes worth flagging

### Registered-agents-only opt-in for credential validation

`validate_credential_token` skips when (a) no `AgentRegistry` is attached, or (b) the claimed agent is not registered. This preserves the lightweight detection-slice / unit-test fixtures that don't go through the registry layer — opt-in is by registering the agent. Once you call `registry.register(record)`, the strict validation path is active for that agent.

Only one fixture needed updating: `aa-gateway/tests/policy_service_test.rs::tool_call_request` had a latent bug where it registered the agent with `"tok_test"` but sent `"tok"`. The other 1062 gateway tests continue passing unchanged.

### A2A event-type selection is decision-aware

`A2ACallIntercepted` is emitted **only for Allow decisions** on A2A calls. Deny / Redact / Pending decisions on A2A calls continue to flow through `PolicyViolation` / `CredentialLeakBlocked` / `ApprovalRequested` — the A2A signal is visible via the populated `caller_agent_id` / `callee_agent_id` payload fields on those variants, not a new variant per decision. This keeps the audit-variant matrix from doubling.

### `caller_agent_id` is an attestation, not a credential

Per the proto field's docstring: `credential_token` continues to be validated against `agent_id` (the callee, performing the action). `caller_agent_id` is metadata for audit / policy context only — a malicious callee could lie about who called it, but cannot use that to escalate beyond what the callee's own credentials authorise.

### Proto3-additive change, no consumer breakage

Tag 7 (`caller_agent_id`) on `CheckActionRequest`. The buf breaking-change check on proto3 field additions passes (verified locally). Existing SDKs that don't populate it continue working — the gateway treats `None` / empty `agent_id` string as "single-agent call" and skips A2A audit-shape logic.

## Type of Change

- [x] ✨ New feature (A2A identity verification + audit shape)
- [x] 📝 Documentation update

## Breaking Changes

- [x] No
- [ ] Yes

`CheckActionRequest.caller_agent_id` is a proto3-additive field. `AuditEventType::{A2ACallIntercepted, A2AImpersonationAttempted}` are additive enum variants. `validate_credential_token` is gated on registry presence + agent registration so legacy fixtures continue working. The 15 fixture sites that gained `caller_agent_id: None` produce identical proto bytes (proto3 default for absent message fields is None).

## Related Issues

* **AAASM-1944** (this PR closes Done on merge — all 3 ST-X E2E ACs green)
* Parent Story: **AAASM-1232** (F116 Full MVP acceptance test) — AAASM-1944 is the second of three closeout gaps; AAASM-1943 (Tool Execution Sandbox) is next

## Testing

- [x] Unit tests added (impersonation rejection covered by E2E + the existing `policy_service_test` suite asserts non-A2A paths unchanged)
- [x] Integration tests added (3 new ST-X E2E tests in `aa-integration-tests/tests/e2e_a2a_identity.rs`)
- [x] Manual testing: `cargo nextest run -p aa-gateway` → 1063/1063; `cargo nextest run -p aa-integration-tests --test e2e_a2a_identity` → 3/3; `cargo nextest run -p aa-integration-tests --test cli_audit --test cli_audit_export --test observe_mode_e2e --test e2e_audit` → all passing (sibling suites unaffected). `cargo clippy --workspace --all-targets -- -D warnings` clean. `cargo fmt --all --check` clean (enforced by lefthook).

## Checklist

- [x] Code follows project style (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated (`a2a-identity.md` + SUMMARY link)
- [x] All CI checks expected to pass
- [x] Commits are small and follow the Gitmoji convention (8 commits, one logical unit per commit)
