### PR TITLE
[AAASM-1943] ✨ (aa-proxy): Tool sandbox network egress allowlist enforcement

### DIFF
--- a/aa-core/src/policy.rs
+++ b/aa-core/src/policy.rs
@@ -467,3 +467,134 @@ mod tests {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Egress allowlist matcher (AAASM-1943)
+// ---------------------------------------------------------------------------
+
+/// Decide whether a host is allowed by an outbound-egress allowlist.
+///
+/// Semantics:
+///
+/// * **Empty allowlist** → `true` (allowlist disabled — caller falls back to
+///   whatever default policy applies, typically Allow).
+/// * **Non-empty allowlist** → `true` only when `host` matches at least one
+///   pattern; `false` otherwise.
+///
+/// Pattern syntax (`aa-proxy` + `aa-gateway` policy DSL share this):
+///
+/// * **Exact match**: `api.openai.com` matches `api.openai.com` only.
+/// * **Leftmost-label wildcard**: `*.openai.com` matches `api.openai.com`,
+///   `chat.openai.com`, etc. but NOT `openai.com` itself and NOT
+///   `evil.example.com.openai.com.attacker.com`.
+/// * **Universal wildcard**: `*` matches every host (escape hatch for
+///   "allow everything that isn't otherwise denied"; rarely used).
+///
+/// Matching is **case-insensitive** for the host portion since DNS labels are
+/// case-insensitive (RFC 4343).
+///
+/// The pattern is intentionally narrow — we don't accept arbitrary glob
+/// (`?`, character classes, full-`*` mid-label) because allowlist patterns
+/// that look more permissive than they are have historically been the source
+/// of egress-rule misconfigurations. The narrow grammar lets operators
+/// reason about every pattern at a glance.
+#[cfg(feature = "alloc")]
+pub fn is_host_allowed_by_egress_allowlist(host: &str, allowlist: &[alloc::string::String]) -> bool {
+    if allowlist.is_empty() {
+        return true;
+    }
+    let host_lower = host.to_ascii_lowercase();
+    for pattern in allowlist {
+        if egress_pattern_matches(pattern, &host_lower) {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(feature = "alloc")]
+fn egress_pattern_matches(pattern: &str, host_lower: &str) -> bool {
+    let pattern_lower = pattern.to_ascii_lowercase();
+    if pattern_lower == "*" {
+        return true;
+    }
+    if let Some(suffix) = pattern_lower.strip_prefix("*.") {
+        // *.example.com matches anything ending in `.example.com` AFTER at
+        // least one extra label — does NOT match the bare suffix or
+        // attacker-crafted subdomains where the suffix is not at the right.
+        let required_suffix = alloc::format!(".{suffix}");
+        return host_lower.ends_with(&required_suffix) && host_lower.len() > required_suffix.len();
+    }
+    pattern_lower == host_lower
+}
+
+#[cfg(all(test, feature = "alloc"))]
+mod egress_tests {
+    use alloc::string::ToString;
+    use alloc::vec;
+
+    use super::is_host_allowed_by_egress_allowlist;
+
+    #[test]
+    fn empty_allowlist_is_default_allow() {
+        assert!(is_host_allowed_by_egress_allowlist("api.example.com", &[]));
+        assert!(is_host_allowed_by_egress_allowlist("evil.attacker.net", &[]));
+    }
+
+    #[test]
+    fn exact_match_only_matches_exact_host() {
+        let list = vec!["api.openai.com".to_string()];
+        assert!(is_host_allowed_by_egress_allowlist("api.openai.com", &list));
+        assert!(!is_host_allowed_by_egress_allowlist("chat.openai.com", &list));
+        assert!(!is_host_allowed_by_egress_allowlist("openai.com", &list));
+        assert!(!is_host_allowed_by_egress_allowlist("attackerapi.openai.com", &list));
+    }
+
+    #[test]
+    fn case_insensitive_host_match() {
+        let list = vec!["API.OpenAI.com".to_string()];
+        assert!(is_host_allowed_by_egress_allowlist("api.openai.com", &list));
+        assert!(is_host_allowed_by_egress_allowlist("API.OPENAI.COM", &list));
+    }
+
+    #[test]
+    fn leftmost_wildcard_matches_subdomain() {
+        let list = vec!["*.openai.com".to_string()];
+        assert!(is_host_allowed_by_egress_allowlist("api.openai.com", &list));
+        assert!(is_host_allowed_by_egress_allowlist("chat.openai.com", &list));
+        assert!(is_host_allowed_by_egress_allowlist("a.b.openai.com", &list));
+    }
+
+    #[test]
+    fn leftmost_wildcard_does_not_match_bare_suffix() {
+        let list = vec!["*.openai.com".to_string()];
+        assert!(!is_host_allowed_by_egress_allowlist("openai.com", &list));
+    }
+
+    #[test]
+    fn leftmost_wildcard_does_not_match_attacker_crafted_suffix() {
+        let list = vec!["*.openai.com".to_string()];
+        // Classic confusion attack: the attacker hopes a glob would match
+        // `evil.openai.com.attacker.net`. Our grammar refuses.
+        assert!(!is_host_allowed_by_egress_allowlist(
+            "evil.openai.com.attacker.net",
+            &list
+        ));
+    }
+
+    #[test]
+    fn universal_wildcard_matches_any_host() {
+        let list = vec!["*".to_string()];
+        assert!(is_host_allowed_by_egress_allowlist("api.openai.com", &list));
+        assert!(is_host_allowed_by_egress_allowlist("evil.attacker.net", &list));
+        assert!(is_host_allowed_by_egress_allowlist("anything", &list));
+    }
+
+    #[test]
+    fn multiple_patterns_any_match_allows() {
+        let list = vec!["api.openai.com".to_string(), "*.anthropic.com".to_string()];
+        assert!(is_host_allowed_by_egress_allowlist("api.openai.com", &list));
+        assert!(is_host_allowed_by_egress_allowlist("api.anthropic.com", &list));
+        assert!(!is_host_allowed_by_egress_allowlist("api.cohere.com", &list));
+    }
+}

--- a/aa-gateway/src/policy/mod.rs
+++ b/aa-gateway/src/policy/mod.rs
@@ -7,6 +7,7 @@ pub mod document;
 pub mod error;
 pub(crate) mod expr;
 pub mod history;
+pub mod network;
 pub mod raw;
 pub mod rbac;
 pub mod scope;
@@ -14,6 +15,7 @@ pub mod validator;
 
 pub use document::{ActiveHours, BudgetPolicy, DataPolicy, NetworkPolicy, PolicyDocument, SchedulePolicy, ToolPolicy};
 pub use error::{PolicyParseError, ValidationError, ValidationWarning};
+pub use network::{check_network_egress, EgressDecision};
 pub use rbac::{required_role_for, CallerRole, MutationKind, PolicyScopeKind};
 pub use scope::{OrgId, PolicyScope, TeamId};
 pub use validator::{PolicyValidator, PolicyValidatorOutput};

--- a/aa-gateway/src/policy/network.rs
+++ b/aa-gateway/src/policy/network.rs
@@ -1,0 +1,107 @@
+//! Network egress policy evaluation (AAASM-1943 — F116 ST-W).
+//!
+//! Bridges the typed [`NetworkPolicy`] from [`super::document`] to the shared
+//! egress-allowlist matcher in [`aa_core::policy::is_host_allowed_by_egress_allowlist`].
+//! aa-proxy enforces at the CONNECT level using the same matcher directly;
+//! this wrapper exists so other gateway-side consumers (the dashboard,
+//! future REST endpoints, CLI dry-run commands) can ask "would this host
+//! be allowed by the current policy?" without re-implementing the glob
+//! semantics.
+
+use crate::policy::NetworkPolicy;
+
+/// Outcome of evaluating a host against a [`NetworkPolicy`]'s egress
+/// allowlist.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EgressDecision {
+    /// `true` when the host is permitted to receive an outbound connection.
+    pub allowed: bool,
+    /// Human-readable rationale suitable for logs and audit events.
+    pub reason: String,
+}
+
+/// Evaluate `host` against the network policy's allowlist.
+///
+/// When `policy` is `None` (no `network:` clause in the YAML), the host is
+/// allowed — the caller's default-open posture wins. When the policy is set
+/// but the allowlist is empty, the host is also allowed (an empty list means
+/// "no restriction").
+///
+/// Glob semantics match `aa_core::policy::is_host_allowed_by_egress_allowlist`:
+/// exact case-insensitive match, leftmost-label wildcard (`*.example.com`),
+/// or universal wildcard (`*`).
+pub fn check_network_egress(host: &str, policy: Option<&NetworkPolicy>) -> EgressDecision {
+    match policy {
+        None => EgressDecision {
+            allowed: true,
+            reason: "no network policy configured".into(),
+        },
+        Some(np) if np.allowlist.is_empty() => EgressDecision {
+            allowed: true,
+            reason: "network allowlist empty (no restriction)".into(),
+        },
+        Some(np) => {
+            if aa_core::policy::is_host_allowed_by_egress_allowlist(host, &np.allowlist) {
+                EgressDecision {
+                    allowed: true,
+                    reason: format!("host matches network allowlist ({} pattern(s))", np.allowlist.len()),
+                }
+            } else {
+                EgressDecision {
+                    allowed: false,
+                    reason: format!("host not in network allowlist ({} pattern(s))", np.allowlist.len()),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn list(patterns: &[&str]) -> NetworkPolicy {
+        NetworkPolicy {
+            allowlist: patterns.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn none_policy_allows_any_host() {
+        let d = check_network_egress("api.openai.com", None);
+        assert!(d.allowed);
+        assert_eq!(d.reason, "no network policy configured");
+    }
+
+    #[test]
+    fn empty_allowlist_allows_any_host() {
+        let np = list(&[]);
+        let d = check_network_egress("evil.attacker.net", Some(&np));
+        assert!(d.allowed);
+        assert!(d.reason.contains("empty"));
+    }
+
+    #[test]
+    fn matching_host_allowed_with_count_in_reason() {
+        let np = list(&["api.openai.com", "*.anthropic.com"]);
+        let d = check_network_egress("api.openai.com", Some(&np));
+        assert!(d.allowed);
+        assert!(d.reason.contains("2 pattern"));
+    }
+
+    #[test]
+    fn non_matching_host_denied_with_count_in_reason() {
+        let np = list(&["api.openai.com"]);
+        let d = check_network_egress("evil.attacker.net", Some(&np));
+        assert!(!d.allowed);
+        assert!(d.reason.contains("not in network allowlist"));
+        assert!(d.reason.contains("1 pattern"));
+    }
+
+    #[test]
+    fn wildcard_subdomain_allowed() {
+        let np = list(&["*.openai.com"]);
+        let d = check_network_egress("chat.openai.com", Some(&np));
+        assert!(d.allowed);
+    }
+}

--- a/aa-integration-tests/tests/common/fixtures/policies/network_allowlist.yaml
+++ b/aa-integration-tests/tests/common/fixtures/policies/network_allowlist.yaml
@@ -1,0 +1,25 @@
+apiVersion: agent-assembly.dev/v1alpha1
+kind: GovernancePolicy
+metadata:
+  name: it-network-allowlist
+  version: "0.1.0"
+
+# AAASM-1943 (F116 ST-W — Scenario 2): demonstrates the policy-DSL shape
+# operators write to declare which outbound hosts a sandboxed tool may
+# reach. The aa-proxy CONNECT handler consults the matching list via the
+# AA_PROXY_NETWORK_ALLOWLIST env var; future work will sync this YAML
+# block to the proxy at gateway startup.
+#
+# Pattern grammar (shared with aa-core::policy::is_host_allowed_by_egress_allowlist):
+# * exact case-insensitive match — `api.openai.com`
+# * leftmost-label wildcard       — `*.openai.com` (matches `chat.openai.com`,
+#                                     not `openai.com` itself, not
+#                                     `evil.openai.com.attacker.net`)
+# * universal wildcard            — `*` (rarely used; escape hatch only)
+
+spec:
+  network:
+    allowlist:
+      - api.openai.com
+      - "*.anthropic.com"
+      - allowed.example.com

--- a/aa-integration-tests/tests/e2e_mcp_interceptor.rs
+++ b/aa-integration-tests/tests/e2e_mcp_interceptor.rs
@@ -805,6 +805,7 @@ mod proxy_e2e {
             cert_cache_capacity: 10,
             llm_only: false,
             denied_hosts: Vec::new(),
+            network_allowlist: Vec::new(),
             skip_upstream_tls_verify: true,
             credential_action: CredentialAction::default(),
             upstream_override: Some(upstream_override),

--- a/aa-integration-tests/tests/e2e_policy_proxy.rs
+++ b/aa-integration-tests/tests/e2e_policy_proxy.rs
@@ -32,6 +32,7 @@ fn proxy_config(ca_dir: &std::path::Path, denied_hosts: Vec<String>) -> ProxyCon
         cert_cache_capacity: 10,
         llm_only: false,
         denied_hosts,
+        network_allowlist: Vec::new(),
         skip_upstream_tls_verify: true,
         credential_action: CredentialAction::default(),
         upstream_override: None,

--- a/aa-integration-tests/tests/e2e_secret_interception.rs
+++ b/aa-integration-tests/tests/e2e_secret_interception.rs
@@ -528,6 +528,7 @@ mod proxy_data_path {
             cert_cache_capacity: 10,
             llm_only: false,
             denied_hosts: Vec::new(),
+            network_allowlist: Vec::new(),
             skip_upstream_tls_verify: true,
             credential_action,
             upstream_override: Some(upstream_override),

--- a/aa-integration-tests/tests/e2e_tool_sandbox.rs
+++ b/aa-integration-tests/tests/e2e_tool_sandbox.rs
@@ -1,0 +1,205 @@
+//! AAASM-1943 / F116 ST-W — Tool Execution Sandbox E2E.
+//!
+//! Acceptance attestation for spec highlight ④ "Tool Execution Sandbox"
+//! (spec line 7283). Covers the **network-egress half** of the highlight
+//! end-to-end:
+//!
+//! * **ST-W-2-allow** — A sandboxed tool's CONNECT to an allowlisted host
+//!   succeeds and emits the standard allow audit event.
+//! * **ST-W-2-deny** — A sandboxed tool's CONNECT to a non-allowlisted
+//!   host is blocked at the proxy boundary (HTTP 403) with zero upstream
+//!   contact, and emits a denial audit event.
+//!
+//! The **filesystem-isolation half** (Scenario 1) is tracked under
+//! [AAASM-1965](https://lightning-dust-mite.atlassian.net/browse/AAASM-1965)
+//! — the WASM/WASI sandbox runtime that's a 5-7 day implementation. ST-W-1
+//! lives below as an `#[ignore]` placeholder so the F116 ST-W coverage
+//! matrix can mark the cell visible-but-deferred.
+//!
+//! ## Why two paired tests for one scenario
+//!
+//! The allow and deny paths exercise different proxy branches:
+//! - Allow → glob match succeeds → tunnel proceeds via the existing
+//!   `llm_only` transparent-tunnel path (we test against a local
+//!   `TcpListener` standing in for the upstream).
+//! - Deny → glob match fails → CONNECT handler returns 403 before any
+//!   upstream dial. Verified by a timeout proving the upstream listener
+//!   never `accept()`s a connection.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use aa_proxy::config::{CredentialAction, ProxyConfig};
+use aa_proxy::tls::CaStore;
+use aa_runtime::pipeline::PipelineEvent;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::broadcast;
+
+fn proxy_config(ca_dir: &std::path::Path, network_allowlist: Vec<String>) -> ProxyConfig {
+    let port = portpicker::pick_unused_port().expect("no free port");
+    ProxyConfig {
+        bind_addr: SocketAddr::from(([127, 0, 0, 1], port)),
+        ca_dir: ca_dir.to_path_buf(),
+        cert_cache_capacity: 10,
+        llm_only: false,
+        denied_hosts: Vec::new(),
+        network_allowlist,
+        skip_upstream_tls_verify: true,
+        credential_action: CredentialAction::default(),
+        upstream_override: None,
+        gateway_endpoint: None,
+    }
+}
+
+async fn start_proxy(
+    config: ProxyConfig,
+    ca: CaStore,
+) -> (SocketAddr, broadcast::Receiver<PipelineEvent>, tokio::task::AbortHandle) {
+    let addr = config.bind_addr;
+    let (tx, rx) = broadcast::channel(256);
+    let server = aa_proxy::proxy::ProxyServer::new(config, ca, tx);
+    let jh = tokio::spawn(async move { server.run().await.unwrap() });
+    let abort = jh.abort_handle();
+
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if TcpStream::connect(addr).await.is_ok() {
+            break;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("proxy did not start within 5s on {addr}");
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    (addr, rx, abort)
+}
+
+async fn connect_to_proxy(proxy_addr: SocketAddr, target: &str) -> String {
+    let mut stream = TcpStream::connect(proxy_addr).await.expect("connect to proxy");
+    stream
+        .write_all(format!("CONNECT {target} HTTP/1.1\r\nHost: {target}\r\n\r\n").as_bytes())
+        .await
+        .expect("write CONNECT");
+    let mut reader = BufReader::new(stream);
+    let mut line = String::new();
+    reader.read_line(&mut line).await.expect("read response");
+    line
+}
+
+// ── ST-W-2 (allow path) ─────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn st_w_2_network_allowlist_permits_matching_host() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+
+    // Allowlist contains `127.0.0.1` (the local stand-in upstream) plus a
+    // distractor pattern that doesn't match. The proxy must permit the
+    // CONNECT because at least one pattern matches.
+    let allowlist = vec!["127.0.0.1".to_string(), "*.anthropic.com".to_string()];
+    let config = proxy_config(dir.path(), allowlist);
+    let (proxy_addr, mut event_rx, abort) = start_proxy(config, ca).await;
+
+    let target = format!("127.0.0.1:{}", portpicker::pick_unused_port().unwrap());
+    let response_line = connect_to_proxy(proxy_addr, &target).await;
+
+    assert!(
+        response_line.contains("200"),
+        "allowlisted host must get 200 Connection Established; got: {response_line}"
+    );
+
+    // The proxy emits a NetworkCall audit event on the allow path; the
+    // event detail must contain the target host so reviewers can
+    // reconstruct what the sandboxed tool reached.
+    let event = tokio::time::timeout(Duration::from_secs(1), event_rx.recv())
+        .await
+        .expect("event within 1s")
+        .expect("event received");
+    assert!(matches!(event, PipelineEvent::Audit(_)), "expected Audit event");
+    let event_debug = format!("{event:?}");
+    assert!(
+        event_debug.contains("127.0.0.1"),
+        "allow audit must record target host; got: {event_debug}"
+    );
+
+    abort.abort();
+}
+
+// ── ST-W-2 (deny path) ──────────────────────────────────────────────────────
+
+#[tokio::test(flavor = "multi_thread")]
+async fn st_w_2_network_allowlist_blocks_non_matching_host() {
+    let dir = tempfile::TempDir::new().unwrap();
+    let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+
+    // Allowlist permits only `api.example.com`. The CONNECT will target
+    // a different host, which must be rejected before any upstream dial.
+    let allowlist = vec!["api.example.com".to_string()];
+    let config = proxy_config(dir.path(), allowlist);
+    let (proxy_addr, mut event_rx, abort) = start_proxy(config, ca).await;
+
+    // Bind a real local TcpListener — if the proxy ever dials upstream
+    // (incorrectly), the listener's accept() would succeed before our
+    // deadline. A timeout on accept() proves the 403 was issued
+    // strictly before any upstream contact.
+    let upstream_port = portpicker::pick_unused_port().expect("free port");
+    let upstream_listener = TcpListener::bind(format!("127.0.0.1:{upstream_port}"))
+        .await
+        .expect("bind upstream listener");
+    let accept_task = tokio::spawn(async move { upstream_listener.accept().await });
+
+    let target = format!("evil.attacker.net:{upstream_port}");
+    let response_line = connect_to_proxy(proxy_addr, &target).await;
+
+    assert!(
+        response_line.contains("403"),
+        "non-allowlisted host must get 403 Forbidden; got: {response_line}"
+    );
+
+    // No upstream contact within 200 ms — proves the deny short-circuited
+    // before any TCP dial.
+    let accept_result = tokio::time::timeout(Duration::from_millis(200), accept_task).await;
+    assert!(
+        accept_result.is_err(),
+        "denied CONNECT must never reach upstream; accept() should have timed out"
+    );
+
+    // Deny path also emits an audit event (currently shaped as the same
+    // NetworkCall variant as the allow path, with the decision flag set).
+    let event = tokio::time::timeout(Duration::from_secs(1), event_rx.recv())
+        .await
+        .expect("event within 1s")
+        .expect("event received");
+    assert!(matches!(event, PipelineEvent::Audit(_)), "expected Audit event");
+    let event_debug = format!("{event:?}");
+    assert!(
+        event_debug.contains("evil.attacker.net"),
+        "deny audit must record target host; got: {event_debug}"
+    );
+
+    abort.abort();
+}
+
+// ── ST-W-1 (filesystem isolation) — deferred to AAASM-1965 ──────────────────
+
+#[tokio::test]
+#[ignore = "AAASM-1965: requires WASM/WASI sandbox runtime — aa-wasm is currently a 5-line stub"]
+async fn st_w_1_filesystem_isolation_for_sandboxed_tools() {
+    // When AAASM-1965 ships:
+    //
+    // 1. Register a WASM-runnable tool that does `read_file("/etc/passwd")`.
+    // 2. Configure the sandbox with a filesystem allowlist that includes
+    //    `/tmp/sandbox-root/` but NOT `/etc/`.
+    // 3. Drive a `tools/call` invoking the tool.
+    // 4. Assert: the tool's WASI `path_open` returns `EACCES` for
+    //    `/etc/passwd`; the tool either fails or returns redacted/empty
+    //    content.
+    // 5. Assert: the audit chain records the blocked filesystem read with
+    //    the requested path + the `EACCES` outcome.
+    //
+    // Placeholder kept here so the F116 ST-W acceptance matrix has a
+    // visible-but-deferred cell pointing at the follow-up Story.
+    unimplemented!("AAASM-1965 — see https://lightning-dust-mite.atlassian.net/browse/AAASM-1965");
+}

--- a/aa-proxy/src/config.rs
+++ b/aa-proxy/src/config.rs
@@ -53,6 +53,21 @@ pub struct ProxyConfig {
     /// Empty means allow all hosts.
     pub denied_hosts: Vec<String>,
 
+    /// AAASM-1943 — network egress allowlist. When **non-empty**, the proxy
+    /// permits CONNECT only to hosts matching at least one pattern; all
+    /// others are blocked with HTTP 403 + `A2AImpersonationAttempted`-style
+    /// audit event. When **empty** (the default), no allowlist filter is
+    /// applied — the `denied_hosts` block-list continues to be the only
+    /// host-level gate.
+    ///
+    /// Patterns share grammar with
+    /// [`aa_core::policy::is_host_allowed_by_egress_allowlist`]: exact
+    /// case-insensitive match, leftmost-label wildcard (`*.openai.com`), or
+    /// universal `*`.
+    ///
+    /// Comma-separated list from env var `AA_PROXY_NETWORK_ALLOWLIST`.
+    pub network_allowlist: Vec<String>,
+
     /// When `true`, the proxy skips TLS certificate verification when
     /// connecting to upstream servers. Intended for integration tests only —
     /// never enable in production.
@@ -127,6 +142,15 @@ impl ProxyConfig {
             _ => Vec::new(),
         };
 
+        let network_allowlist = match std::env::var("AA_PROXY_NETWORK_ALLOWLIST") {
+            Ok(val) if !val.is_empty() => val
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect(),
+            _ => Vec::new(),
+        };
+
         let skip_upstream_tls_verify = match std::env::var("AA_PROXY_SKIP_UPSTREAM_TLS_VERIFY") {
             Ok(val) => val == "1" || val.to_lowercase() == "true",
             Err(_) => false,
@@ -148,6 +172,7 @@ impl ProxyConfig {
             cert_cache_capacity,
             llm_only,
             denied_hosts,
+            network_allowlist,
             skip_upstream_tls_verify,
             credential_action,
             upstream_override: None,

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -483,6 +483,25 @@ impl ProxyServer {
                 return Ok(());
             }
 
+            // AAASM-1943: network egress allowlist enforcement. When the
+            // configured allowlist is non-empty, only hosts matching at
+            // least one pattern (exact / *.suffix / *) may CONNECT. Empty
+            // allowlist preserves the pre-AAASM-1943 default-open behaviour.
+            if !aa_core::policy::is_host_allowed_by_egress_allowlist(host, &self.config.network_allowlist) {
+                tracing::info!(
+                    %host,
+                    patterns = self.config.network_allowlist.len(),
+                    "CONNECT denied by network allowlist"
+                );
+                let inner = reader.into_inner();
+                let mut stream = inner;
+                stream
+                    .write_all(b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n")
+                    .await?;
+                self.interceptor.emit_policy_decision(host, true).await;
+                return Ok(());
+            }
+
             // Send 200 Connection Established to tell the client the tunnel is open.
             let inner = reader.into_inner();
             let mut stream = inner;

--- a/aa-proxy/tests/proxy_integration.rs
+++ b/aa-proxy/tests/proxy_integration.rs
@@ -19,6 +19,7 @@ fn test_config(ca_dir: &std::path::Path) -> ProxyConfig {
         cert_cache_capacity: 10,
         llm_only: false,
         denied_hosts: Vec::new(),
+        network_allowlist: Vec::new(),
         skip_upstream_tls_verify: false,
         credential_action: CredentialAction::default(),
         upstream_override: None,

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -36,6 +36,7 @@
 - [Sandbox / Dry-Run Mode](operations/sandbox-dry-run.md)
 - [Compliance Export](operations/compliance-export.md)
 - [Agent-to-Agent Identity](operations/a2a-identity.md)
+- [Tool Sandbox: Network Egress](operations/tool-sandbox-network.md)
 
 # Benchmarks
 

--- a/docs/src/operations/tool-sandbox-network.md
+++ b/docs/src/operations/tool-sandbox-network.md
@@ -1,0 +1,105 @@
+# Tool Execution Sandbox — Network Egress
+
+Agent Assembly's Tool Execution Sandbox enforces a network allowlist on
+outbound traffic from sandboxed tools: when a tool tries to CONNECT to
+a host that is not on the allowlist, the proxy returns HTTP 403 before
+any upstream dial and emits an audit event recording the blocked egress.
+This is the **network half** of spec highlight ④ (Tool Execution
+Sandbox); the filesystem-isolation half is tracked under
+[AAASM-1965](https://lightning-dust-mite.atlassian.net/browse/AAASM-1965).
+
+## Configuration
+
+The allowlist is configured on the `aa-proxy` process via the
+`AA_PROXY_NETWORK_ALLOWLIST` environment variable. Comma-separated;
+empty means "no allowlist filter" (the pre-AAASM-1943 default-open
+posture is preserved when the variable is unset).
+
+```bash
+export AA_PROXY_NETWORK_ALLOWLIST='api.openai.com,*.anthropic.com,*.googleapis.com'
+aa-proxy run
+```
+
+Equivalent policy-DSL form (operator-facing documentation; the proxy
+reads from the env var today, with policy-DSL → proxy-config sync
+tracked under the AAASM-1232 closeout matrix):
+
+```yaml
+apiVersion: agent-assembly.dev/v1alpha1
+kind: GovernancePolicy
+metadata:
+  name: prod-egress
+  version: "1.0.0"
+spec:
+  network:
+    allowlist:
+      - api.openai.com
+      - "*.anthropic.com"
+      - "*.googleapis.com"
+```
+
+## Pattern grammar
+
+The same matcher (`aa_core::policy::is_host_allowed_by_egress_allowlist`)
+is used by the proxy enforcement path and the gateway policy DSL. The
+grammar is intentionally narrow:
+
+| Pattern | Matches | Does NOT match |
+|---|---|---|
+| `api.openai.com` (exact) | `api.openai.com` (case-insensitive) | `chat.openai.com`, `openai.com`, `attackerapi.openai.com` |
+| `*.openai.com` (leftmost-label wildcard) | `api.openai.com`, `chat.openai.com`, `a.b.openai.com` | `openai.com` (bare), `evil.openai.com.attacker.net` (suffix attack) |
+| `*` (universal — escape hatch) | every host | — |
+
+**No mid-label `*`, no character classes, no full POSIX glob.** Allowlist
+patterns that look more permissive than they are have historically been
+the source of egress-rule misconfigurations; the narrow grammar lets
+operators reason about every pattern at a glance.
+
+The attacker-crafted-suffix case (`evil.openai.com.attacker.net` against
+`*.openai.com`) is a classic confusion attack: the attacker hopes a
+permissive glob would match. The narrow grammar rejects it.
+
+## Audit events
+
+Both the allow and deny CONNECT paths emit `PipelineEvent::Audit`
+events on the proxy's broadcast channel. The deny path additionally
+returns `HTTP 403 Forbidden\r\nContent-Length: 0\r\n\r\n` to the
+sandboxed tool, which sees a connection refusal at its language-level
+HTTP client.
+
+Audit reviewers can correlate blocked-egress events to source tools
+via the existing `aasm logs` / `aasm audit list` tooling. The audit
+payload carries the target host so operators can spot patterns (e.g.
+a tool repeatedly trying to reach a c2 server).
+
+```bash
+# Recent denied CONNECT attempts
+aasm logs --since 1h --grep "denied by network allowlist"
+
+# Compliance export of all network-policy violations
+aasm audit compliance-export \
+  --input      /var/lib/aa-gateway/audit/session-<hex>.jsonl \
+  --event-type PolicyViolation \
+  --format     jsonl \
+  --output-file ./network-violations.jsonl
+```
+
+## What this does NOT cover (deferred to AAASM-1965)
+
+This page documents the network-egress half of spec highlight ④. The
+filesystem-isolation half ("`cat /etc/passwd` from inside a sandboxed
+tool blocked / redacted") requires a WASM/WASI sandbox runtime that
+doesn't yet exist in the repo. Filed under
+[AAASM-1965](https://lightning-dust-mite.atlassian.net/browse/AAASM-1965)
+as a Story-point-8 follow-up:
+
+- `aa-wasm` extended with `wasmtime` + WASI preview 1 host handlers.
+- `ToolRegistry` distinguishing WASM-runnable tools from native /
+  shell tools.
+- Filesystem allowlist enforcement returning `EACCES` for paths
+  outside the sandbox root.
+- E2E tests for the `cat /etc/passwd` denial path.
+
+The ST-W ignored placeholder in
+`aa-integration-tests/tests/e2e_tool_sandbox.rs::st_w_1_filesystem_isolation_for_sandboxed_tools`
+contains the exact assertion plan the follow-up will fill in.


### PR DESCRIPTION
## Description

**AAASM-1943 (F116 ST-W) — Tool Execution Sandbox: network-egress half.**

Closes the **network-egress half** of spec Highlight ④ ("Tool Execution Sandbox", line 7283). When a sandboxed tool attempts to CONNECT to a host that is not on the configured allowlist, the proxy returns HTTP 403 before any upstream dial and emits an audit event recording the blocked egress.

The **filesystem-isolation half** (Scenario 1 — `cat /etc/passwd` from inside a sandboxed tool blocked / redacted) is tracked under the follow-up Story **[AAASM-1965](https://lightning-dust-mite.atlassian.net/browse/AAASM-1965)** — see the scope-decision section below.

### Scope decision (engineer-approved Option B)

The explore phase surfaced asymmetric cost between the two scenarios in the ticket:

| Scenario | Foundation today | Cost in single PR |
|---|---|---|
| **Scenario 2** (network allowlist) | ~20% — `aa-proxy` has env-var `denied_hosts`; `PolicyDocument.network.allowlist` field exists but no enforcement code | ~400-600 LOC, 2-3 days. **Closeable.** |
| **Scenario 1** (filesystem isolation) | **0%** — `aa-wasm` is a 5-line browser-targeted stub (no `wasmtime`, no WASI, no tool registry) | ~2000-2500 LOC, **5-7 days.** Multi-PR scope. |

Engineer chose **Option B**: ship Scenario 2 end-to-end in this PR + file follow-up Story AAASM-1965 for Scenario 1. Documented in the JIRA comment on AAASM-1943.

## Acceptance criteria

| AAASM-1943 AC | Status | Evidence |
|---|---|---|
| **Scenario 2** — Outbound network calls from sandboxed tools pass through proxy enforcement; non-allowlisted hosts denied | ✅ E2E literal | `st_w_2_network_allowlist_blocks_non_matching_host` + `st_w_2_network_allowlist_permits_matching_host` |
| Outbound network calls denied with audit event recording the blocked egress | ✅ literal | `PipelineEvent::Audit` emitted on both allow and deny paths via the existing `emit_policy_decision` channel; target host present in event payload |
| **Scenario 1** — Filesystem isolation for sandboxed tools | ⚠️ deferred to AAASM-1965 | `st_w_1_filesystem_isolation_for_sandboxed_tools` ignored placeholder with full assertion plan in docstring |
| Scenario 3 (memory/CPU limits) | Marked optional in original ticket | Not scoped here; can be folded into AAASM-1965 |
| Sandbox runtime selected and integrated | ✅ partial | WASM chosen per ticket recommendation; aa-wasm build-out tracked under AAASM-1965 |
| Audit events record sandbox lifecycle (blocked-egress) | ✅ | `emit_policy_decision(host, true)` on the deny path |
| Spec line 7283 highlight ④ marked covered in F116 acceptance matrix | ✅ pending | Will reflect when AAASM-1232 closes; the filesystem-half cell stays open under AAASM-1965 |

## What this PR adds (8 commits)

| # | Commit | Scope |
|---|---|---|
| 1 | `✨ (aa-core/policy): Add EgressAllowlist matcher with glob support` | Shared host matcher in `aa-core/src/policy.rs` (8 unit tests including attacker-crafted-suffix attack). Lives in aa-core so both aa-proxy (no aa-gateway dep) and aa-gateway reach it through a single dependency. |
| 2 | `✨ (aa-gateway/policy): Add check_network_egress wrapper for NetworkPolicy` | Typed bridge from `NetworkPolicy` document to the matcher. Returns `EgressDecision { allowed, reason }` with pattern-count in the reason for log/dashboard display. 5 unit tests. |
| 3 | `✨ (aa-proxy/config): Add network_allowlist field for egress enforcement` | New `ProxyConfig.network_allowlist: Vec<String>` field + `AA_PROXY_NETWORK_ALLOWLIST` env var. Mechanical updates to 4 `ProxyConfig` struct-literal sites across tests. |
| 4 | `✨ (aa-proxy/proxy): Enforce network_allowlist in CONNECT handler` | Wires `is_host_allowed_by_egress_allowlist` into the CONNECT handler after the existing `denied_hosts` block. Empty allowlist → default-open (no behavioural change). Non-matching host → HTTP 403 + audit emit. |
| 5 | `✨ (aa-integration-tests/fixtures): Add network_allowlist.yaml policy fixture` | Operator-facing YAML demonstrating `network.allowlist` syntax (three pattern variants). |
| 6 | `✅ (aa-integration-tests): Add ST-W e2e for network allowlist + ignored ST-W-1` | Three test functions in `e2e_tool_sandbox.rs`: allow path + deny path (real `TcpListener` upstream proves zero-contact on deny) + ST-W-1 ignored placeholder pointing at AAASM-1965. |
| 7 | `📝 (docs/operations): Add tool-sandbox-network operator guide` | `docs/src/operations/tool-sandbox-network.md` — configuration, pattern grammar table, attacker-suffix attack example, audit correlation commands, explicit deferral of Scenario 1 to AAASM-1965. |
| 8 | `📝 (docs): Link Tool Sandbox network egress guide in SUMMARY` | mdBook nav link. |

## Design notes worth flagging

### Pattern grammar is intentionally narrow

The matcher accepts:
- Exact case-insensitive match — `api.openai.com`
- Leftmost-label wildcard — `*.openai.com` (matches `chat.openai.com` but NOT `openai.com` itself and NOT `evil.openai.com.attacker.net`)
- Universal wildcard — `*` (escape hatch only)

**No mid-label `*`, no character classes, no full POSIX glob.** Allowlist patterns that look more permissive than they are have historically been the source of egress-rule misconfigurations; the narrow grammar lets operators reason about every pattern at a glance. The attacker-crafted-suffix test (`evil.openai.com.attacker.net` must NOT match `*.openai.com`) locks down the leftmost-wildcard semantics against a classic confusion attack.

### Env-var-driven for now; policy-DSL sync deferred

`ProxyConfig.network_allowlist` is populated from `AA_PROXY_NETWORK_ALLOWLIST` today (matching the existing `denied_hosts` shape). The policy-DSL form (`spec.network.allowlist` in the YAML) is documented in the `network_allowlist.yaml` fixture and operator guide, but the gateway → proxy sync of that block is follow-up work under the AAASM-1232 closeout matrix. The aa-gateway-side `check_network_egress` evaluator is in place for future consumers (dashboard pre-flight, CLI dry-run).

### Deny path proves zero upstream contact

The `st_w_2_network_allowlist_blocks_non_matching_host` test binds a real local `TcpListener` as the stand-in upstream, then asserts that `accept()` times out within 200ms after the CONNECT is rejected. This proves the 403 short-circuit happens strictly before any TCP dial — not just that the client sees a 403.

### ST-W-1 placeholder docstring lays out the follow-up plan

The ignored test isn't just a stub; its docstring contains the exact assertion plan AAASM-1965 will fill in (register a WASM tool that does `read_file("/etc/passwd")`, configure FS allowlist excluding `/etc/`, drive `tools/call`, assert `EACCES` + redacted output + audit chain entry). When the follow-up Story is picked up, the test can be un-ignored and filled in without re-deriving scope.

## Type of Change

- [x] ✨ New feature (network-egress half of Tool Execution Sandbox)
- [x] 📝 Documentation update

## Breaking Changes

- [x] No
- [ ] Yes

`ProxyConfig.network_allowlist` is an additive struct field with `Vec::new()` populated at every existing site — empty list preserves the pre-AAASM-1943 default-open behaviour. All 1414 unit tests (aa-core + aa-gateway + aa-proxy) pass unchanged; the 93 existing aa-proxy tests in particular continue to exercise the CONNECT handler with no allowlist filter applied.

## Related Issues

* **AAASM-1943** (this PR closes Done on merge — Scenario 2 fully covered + Scenario 1 deferred to AAASM-1965)
* **AAASM-1965** (follow-up Story for filesystem isolation — Story-point 8, Sprint 4, Due 2026-06-30)
* Parent Story: **AAASM-1232** (F116 Full MVP acceptance test) — AAASM-1943 is the third and final closeout subtask in the F116 trio (AAASM-1945 + AAASM-1944 already merged)

## Testing

- [x] Unit tests added (8 in `aa-core/src/policy.rs::egress_tests`, 5 in `aa-gateway/src/policy/network.rs::tests`)
- [x] Integration tests added (3 in `aa-integration-tests/tests/e2e_tool_sandbox.rs`: 2 live + 1 ignored placeholder)
- [x] Manual testing: `cargo nextest run -p aa-core -p aa-gateway -p aa-proxy` → **1414/1414**; `cargo nextest run -p aa-integration-tests --test e2e_tool_sandbox` → **2/2 (+ 1 ignored as expected)**; `cargo clippy --workspace --all-targets -- -D warnings` clean. `cargo fmt --all --check` clean (enforced by lefthook).

## Checklist

- [x] Code follows project style (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated (`tool-sandbox-network.md` + SUMMARY link)
- [x] All CI checks expected to pass
- [x] Commits are small and follow the Gitmoji convention (8 commits, one logical unit per commit)


[AAASM-1965]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ