### PR TITLE
[AAASM-2016] ✨ (aa-core/audit): Add Sandbox lifecycle event variants

### DIFF
--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -88,6 +88,13 @@ pub enum AuditEventType {
     /// `WasiCtxBuilder::preopened_dir`. (AAASM-1965 / F116 ST-W,
     /// Scenario 1 — filesystem isolation.)
     SandboxFilesystemBlocked = 17,
+    /// A sandboxed tool was killed because its wasmtime instruction-fuel
+    /// budget (or wall-clock guard) was exhausted. Surfaced by
+    /// `aa-sandbox::runtime` when `Store::set_fuel` drains to zero or
+    /// the wall-clock watcher fires, mapping to
+    /// `SandboxError::CpuTimeout` / `SandboxError::WallClockTimeout`.
+    /// (AAASM-1965 / F116 ST-W, Scenario 2 — runaway-loop kill.)
+    SandboxCpuTimeout = 18,
 }
 
 impl AuditEventType {
@@ -114,6 +121,7 @@ impl AuditEventType {
             Self::A2AImpersonationAttempted => "A2AImpersonationAttempted",
             Self::SandboxStarted => "SandboxStarted",
             Self::SandboxFilesystemBlocked => "SandboxFilesystemBlocked",
+            Self::SandboxCpuTimeout => "SandboxCpuTimeout",
         }
     }
 }
@@ -986,6 +994,7 @@ mod tests {
             AuditEventType::SandboxFilesystemBlocked.as_str(),
             "SandboxFilesystemBlocked"
         );
+        assert_eq!(AuditEventType::SandboxCpuTimeout.as_str(), "SandboxCpuTimeout");
     }
 
     #[test]
@@ -1004,6 +1013,7 @@ mod tests {
         assert_eq!(AuditEventType::ToolDispatched as u32, 13);
         assert_eq!(AuditEventType::SandboxStarted as u32, 16);
         assert_eq!(AuditEventType::SandboxFilesystemBlocked as u32, 17);
+        assert_eq!(AuditEventType::SandboxCpuTimeout as u32, 18);
     }
 
     #[test]
@@ -1023,6 +1033,7 @@ mod tests {
             AuditEventType::ToolDispatched,
             AuditEventType::SandboxStarted,
             AuditEventType::SandboxFilesystemBlocked,
+            AuditEventType::SandboxCpuTimeout,
         ];
         for i in 0..variants.len() {
             for j in (i + 1)..variants.len() {

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -105,6 +105,12 @@ pub enum AuditEventType {
     ///
     /// [`SandboxCpuTimeout`]: Self::SandboxCpuTimeout
     SandboxOomKilled = 19,
+    /// A sandboxed tool invocation completed without being killed by
+    /// any isolation primitive. Emitted by `aa-sandbox::runtime`
+    /// regardless of whether the tool returned a logical success or a
+    /// tool-defined error — this variant marks lifecycle completion,
+    /// not outcome semantics. (AAASM-1965 / F116 ST-W.)
+    SandboxTerminated = 20,
 }
 
 impl AuditEventType {
@@ -133,6 +139,7 @@ impl AuditEventType {
             Self::SandboxFilesystemBlocked => "SandboxFilesystemBlocked",
             Self::SandboxCpuTimeout => "SandboxCpuTimeout",
             Self::SandboxOomKilled => "SandboxOomKilled",
+            Self::SandboxTerminated => "SandboxTerminated",
         }
     }
 }
@@ -1007,6 +1014,7 @@ mod tests {
         );
         assert_eq!(AuditEventType::SandboxCpuTimeout.as_str(), "SandboxCpuTimeout");
         assert_eq!(AuditEventType::SandboxOomKilled.as_str(), "SandboxOomKilled");
+        assert_eq!(AuditEventType::SandboxTerminated.as_str(), "SandboxTerminated");
     }
 
     #[test]
@@ -1027,6 +1035,7 @@ mod tests {
         assert_eq!(AuditEventType::SandboxFilesystemBlocked as u32, 17);
         assert_eq!(AuditEventType::SandboxCpuTimeout as u32, 18);
         assert_eq!(AuditEventType::SandboxOomKilled as u32, 19);
+        assert_eq!(AuditEventType::SandboxTerminated as u32, 20);
     }
 
     #[test]
@@ -1048,6 +1057,7 @@ mod tests {
             AuditEventType::SandboxFilesystemBlocked,
             AuditEventType::SandboxCpuTimeout,
             AuditEventType::SandboxOomKilled,
+            AuditEventType::SandboxTerminated,
         ];
         for i in 0..variants.len() {
             for j in (i + 1)..variants.len() {

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -95,6 +95,16 @@ pub enum AuditEventType {
     /// `SandboxError::CpuTimeout` / `SandboxError::WallClockTimeout`.
     /// (AAASM-1965 / F116 ST-W, Scenario 2 — runaway-loop kill.)
     SandboxCpuTimeout = 18,
+    /// A sandboxed tool was killed because wasmtime's `Store::limiter`
+    /// rejected a memory-growth request that would exceed the
+    /// configured `memory_pages` ceiling. Surfaced by
+    /// `aa-sandbox::runtime` mapping to `SandboxError::MemoryExhausted`.
+    /// Distinguished from [`SandboxCpuTimeout`] so audit consumers can
+    /// tell whether the host pressure was instruction-fuel or memory
+    /// pages. (AAASM-1965 / F116 ST-W, Scenario 2 — memory-bomb kill.)
+    ///
+    /// [`SandboxCpuTimeout`]: Self::SandboxCpuTimeout
+    SandboxOomKilled = 19,
 }
 
 impl AuditEventType {
@@ -122,6 +132,7 @@ impl AuditEventType {
             Self::SandboxStarted => "SandboxStarted",
             Self::SandboxFilesystemBlocked => "SandboxFilesystemBlocked",
             Self::SandboxCpuTimeout => "SandboxCpuTimeout",
+            Self::SandboxOomKilled => "SandboxOomKilled",
         }
     }
 }
@@ -995,6 +1006,7 @@ mod tests {
             "SandboxFilesystemBlocked"
         );
         assert_eq!(AuditEventType::SandboxCpuTimeout.as_str(), "SandboxCpuTimeout");
+        assert_eq!(AuditEventType::SandboxOomKilled.as_str(), "SandboxOomKilled");
     }
 
     #[test]
@@ -1014,6 +1026,7 @@ mod tests {
         assert_eq!(AuditEventType::SandboxStarted as u32, 16);
         assert_eq!(AuditEventType::SandboxFilesystemBlocked as u32, 17);
         assert_eq!(AuditEventType::SandboxCpuTimeout as u32, 18);
+        assert_eq!(AuditEventType::SandboxOomKilled as u32, 19);
     }
 
     #[test]
@@ -1034,6 +1047,7 @@ mod tests {
             AuditEventType::SandboxStarted,
             AuditEventType::SandboxFilesystemBlocked,
             AuditEventType::SandboxCpuTimeout,
+            AuditEventType::SandboxOomKilled,
         ];
         for i in 0..variants.len() {
             for j in (i + 1)..variants.len() {

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -1237,6 +1237,42 @@ mod tests {
         assert!(!s.contains("bash"));
     }
 
+    #[test]
+    fn display_round_trips_sandbox_event_names() {
+        // For each Sandbox* lifecycle variant introduced under AAASM-1965,
+        // assert that AuditEntry's Display surfaces the variant's `as_str()`
+        // label verbatim. Auditors grep the JSONL log by these tokens.
+        let sandbox_events = [
+            (AuditEventType::SandboxStarted, "event=SandboxStarted]"),
+            (
+                AuditEventType::SandboxFilesystemBlocked,
+                "event=SandboxFilesystemBlocked]",
+            ),
+            (AuditEventType::SandboxCpuTimeout, "event=SandboxCpuTimeout]"),
+            (AuditEventType::SandboxOomKilled, "event=SandboxOomKilled]"),
+            (AuditEventType::SandboxTerminated, "event=SandboxTerminated]"),
+        ];
+        for (event_type, expected_tail) in sandbox_events {
+            let entry = AuditEntry::new(
+                0,
+                1_714_222_134_000_000_000,
+                event_type,
+                AgentId::from_bytes(AGENT_BYTES),
+                SessionId::from_bytes(SESSION_BYTES),
+                alloc::string::String::from("{}"),
+                GENESIS_HASH,
+            );
+            let rendered = alloc::format!("{}", entry);
+            assert!(
+                rendered.ends_with(expected_tail),
+                "Display for {:?} should end with `{}` but was `{}`",
+                event_type,
+                expected_tail,
+                rendered,
+            );
+        }
+    }
+
     // --- AuditLog helpers ---
 
     fn make_log() -> AuditLog {

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -81,6 +81,13 @@ pub enum AuditEventType {
     /// [`SandboxCpuTimeout`]: Self::SandboxCpuTimeout
     /// [`SandboxOomKilled`]: Self::SandboxOomKilled
     SandboxStarted = 16,
+    /// A sandboxed tool attempted to read or write outside the WASI
+    /// preopened-dir allowlist. Surfaced by `aa-sandbox::runtime` when
+    /// `path_open` (or another `fd_*` host call) returns `EACCES`
+    /// because the requested path is not under any directory passed to
+    /// `WasiCtxBuilder::preopened_dir`. (AAASM-1965 / F116 ST-W,
+    /// Scenario 1 — filesystem isolation.)
+    SandboxFilesystemBlocked = 17,
 }
 
 impl AuditEventType {
@@ -106,6 +113,7 @@ impl AuditEventType {
             Self::A2ACallIntercepted => "A2ACallIntercepted",
             Self::A2AImpersonationAttempted => "A2AImpersonationAttempted",
             Self::SandboxStarted => "SandboxStarted",
+            Self::SandboxFilesystemBlocked => "SandboxFilesystemBlocked",
         }
     }
 }
@@ -974,6 +982,10 @@ mod tests {
         assert_eq!(AuditEventType::ApprovalEscalated.as_str(), "ApprovalEscalated");
         assert_eq!(AuditEventType::ToolDispatched.as_str(), "ToolDispatched");
         assert_eq!(AuditEventType::SandboxStarted.as_str(), "SandboxStarted");
+        assert_eq!(
+            AuditEventType::SandboxFilesystemBlocked.as_str(),
+            "SandboxFilesystemBlocked"
+        );
     }
 
     #[test]
@@ -991,6 +1003,7 @@ mod tests {
         assert_eq!(AuditEventType::ApprovalEscalated as u32, 10);
         assert_eq!(AuditEventType::ToolDispatched as u32, 13);
         assert_eq!(AuditEventType::SandboxStarted as u32, 16);
+        assert_eq!(AuditEventType::SandboxFilesystemBlocked as u32, 17);
     }
 
     #[test]
@@ -1009,6 +1022,7 @@ mod tests {
             AuditEventType::ApprovalEscalated,
             AuditEventType::ToolDispatched,
             AuditEventType::SandboxStarted,
+            AuditEventType::SandboxFilesystemBlocked,
         ];
         for i in 0..variants.len() {
             for j in (i + 1)..variants.len() {

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -69,6 +69,18 @@ pub enum AuditEventType {
     /// resolvable). The action is denied before policy evaluation runs.
     /// (AAASM-1944 / Zero-trust A2A.)
     A2AImpersonationAttempted = 15,
+    /// A sandboxed (WASM/WASI) tool invocation has begun. Emitted by
+    /// `aa-proxy` immediately before handing the parsed `tools/call`
+    /// envelope to the `aa-sandbox` runtime for execution. Marks the
+    /// start of the lifecycle terminated by [`SandboxTerminated`],
+    /// [`SandboxFilesystemBlocked`], [`SandboxCpuTimeout`], or
+    /// [`SandboxOomKilled`]. (AAASM-1965 / F116 ST-W.)
+    ///
+    /// [`SandboxTerminated`]: Self::SandboxTerminated
+    /// [`SandboxFilesystemBlocked`]: Self::SandboxFilesystemBlocked
+    /// [`SandboxCpuTimeout`]: Self::SandboxCpuTimeout
+    /// [`SandboxOomKilled`]: Self::SandboxOomKilled
+    SandboxStarted = 16,
 }
 
 impl AuditEventType {
@@ -93,6 +105,7 @@ impl AuditEventType {
             Self::ToolDispatched => "ToolDispatched",
             Self::A2ACallIntercepted => "A2ACallIntercepted",
             Self::A2AImpersonationAttempted => "A2AImpersonationAttempted",
+            Self::SandboxStarted => "SandboxStarted",
         }
     }
 }
@@ -960,6 +973,7 @@ mod tests {
         assert_eq!(AuditEventType::ApprovalRouted.as_str(), "ApprovalRouted");
         assert_eq!(AuditEventType::ApprovalEscalated.as_str(), "ApprovalEscalated");
         assert_eq!(AuditEventType::ToolDispatched.as_str(), "ToolDispatched");
+        assert_eq!(AuditEventType::SandboxStarted.as_str(), "SandboxStarted");
     }
 
     #[test]
@@ -976,6 +990,7 @@ mod tests {
         assert_eq!(AuditEventType::ApprovalRouted as u32, 9);
         assert_eq!(AuditEventType::ApprovalEscalated as u32, 10);
         assert_eq!(AuditEventType::ToolDispatched as u32, 13);
+        assert_eq!(AuditEventType::SandboxStarted as u32, 16);
     }
 
     #[test]
@@ -993,6 +1008,7 @@ mod tests {
             AuditEventType::ApprovalRouted,
             AuditEventType::ApprovalEscalated,
             AuditEventType::ToolDispatched,
+            AuditEventType::SandboxStarted,
         ];
         for i in 0..variants.len() {
             for j in (i + 1)..variants.len() {


### PR DESCRIPTION
## Description

Extend `aa-core::audit::AuditEventType` with the five lifecycle event variants the `aa-sandbox` runtime will emit under F116 ST-W (parent Story: AAASM-1965, "Tool Execution Sandbox — filesystem isolation + CPU/memory limits half").

**Pure data-type change** — no consumer wiring in this PR. `aa-proxy`'s dispatch glue lands in S5 (AAASM-2019), the `aa-sandbox` runtime that triggers the events lands in S3 (AAASM-2017) and S4 (AAASM-2018).

### Variants

| Discriminant | Variant | Triggered by |
|---|---|---|
| `16` | `SandboxStarted` | `aa-proxy` before handing `tools/call` to the sandbox runtime |
| `17` | `SandboxFilesystemBlocked` | WASI `path_open` denied because target is outside the `preopened_dir` allowlist |
| `18` | `SandboxCpuTimeout` | wasmtime `Store::set_fuel` budget exhausted (or wall-clock guard fired) |
| `19` | `SandboxOomKilled` | wasmtime `Store::limiter` rejected memory growth past `memory_pages` cap |
| `20` | `SandboxTerminated` | invocation completed without being killed by any isolation primitive |

### Discriminant numbering note

The ticket description originally proposed 14..=18. The A2A variants from AAASM-1944 (Zero-trust A2A) landed at 14, 15 between Story drafting and S2 pickup, so this PR slots Sandbox events into the next free range — **16..=20**. Each commit's body calls out the chosen discriminant. No protocol-version bump needed since the enum is open-ended.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

The enum has `#[repr(u32)]` and is extended additively — existing serialized audit entries are unaffected.

## Related Issues

- Related Jira ticket: **AAASM-2016** (sub-task of parent Story **AAASM-1965**)
- Related GitHub issues: n/a

## Testing

`aa-core/src/audit.rs`'s existing test module extended in lock-step with each variant addition (variant→str round-trip + discriminant + pairwise distinctness). A new dedicated test `display_round_trips_sandbox_event_names` builds an `AuditEntry` per Sandbox variant and asserts the formatted output ends with `event=<VariantName>]` — the exact suffix grep tooling consumes off the JSONL log.

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required

Local validation:

```text
cargo nextest run -p aa-core    # 207 tests, 207 passed, 0 skipped
cargo clippy -p aa-core --all-targets --all-features -- -D warnings  # clean
cargo fmt -p aa-core -- --check  # clean
cargo doc -p aa-core --no-deps   # clean
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (each variant carries a doc-comment pinning the wasmtime/WASI primitive that triggers it)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention (one variant per commit + one test commit)

## Commit log

| Commit | Scope |
|---|---|
| `c4d077ea` | ✨ (aa-core/audit): Add SandboxStarted variant (=16) |
| `aae6717c` | ✨ (aa-core/audit): Add SandboxFilesystemBlocked variant (=17) |
| `47908a54` | ✨ (aa-core/audit): Add SandboxCpuTimeout variant (=18) |
| `618f26f5` | ✨ (aa-core/audit): Add SandboxOomKilled variant (=19) |
| `7bc343ce` | ✨ (aa-core/audit): Add SandboxTerminated variant (=20) |
| `4415bb9c` | ✅ (aa-core/audit): Add Display round-trip test for sandbox events |