### PR TITLE
[AAASM-2017] ✨ (aa-sandbox): Add WASI preview1 runtime + filesystem allowlist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,7 @@ dependencies = [
 name = "aa-sandbox"
 version = "0.0.1"
 dependencies = [
+ "thiserror 2.0.18",
  "wasmtime",
  "wasmtime-wasi",
  "wat",

--- a/aa-sandbox/Cargo.toml
+++ b/aa-sandbox/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 description = "WebAssembly/WASI sandbox runtime for Agent Assembly tool execution"
 
 [dependencies]
+thiserror     = "2"
 wasmtime      = "45"
 wasmtime-wasi = "45"
 

--- a/aa-sandbox/src/error.rs
+++ b/aa-sandbox/src/error.rs
@@ -1,13 +1,45 @@
 //! Deterministic error types surfaced by the sandbox runtime.
 //!
-//! The `SandboxError` enum maps each wasmtime trap or WASI denial to a
+//! The [`SandboxError`] enum maps each WASI denial or wasmtime trap to a
 //! distinct variant so call-sites can branch on the failure mode without
-//! parsing wasmtime's internal trap codes. Variants are intentionally added
-//! in later sub-tasks alongside the code paths that produce them:
+//! parsing wasmtime's internal trap codes. Additional variants land
+//! alongside the code paths that produce them:
 //!
-//! * `FilesystemBlocked` — F116 ST-W S3 (WASI preopened-dir allowlist).
-//! * `CpuTimeout` / `WallClockTimeout` — F116 ST-W S4 (wasmtime fuel).
-//! * `MemoryExhausted` — F116 ST-W S4 (wasmtime `Store::limiter`).
-//!
-//! This module ships as a doc-only scaffold under AAASM-2015 (S1); the enum
-//! itself lands in S3.
+//! * [`SandboxError::FilesystemBlocked`] — AAASM-2017 (WASI preopened-dir
+//!   allowlist).
+//! * `CpuTimeout` / `WallClockTimeout` / `MemoryExhausted` — AAASM-2018
+//!   (wasmtime fuel + `Store::limiter`).
+
+use thiserror::Error;
+
+/// Failure modes surfaced by [`crate::runtime::SandboxRuntime::run_tool`].
+///
+/// All variants are deterministic — the same WASI denial or wasmtime trap
+/// always maps to the same variant so downstream audit consumers (see
+/// `aa-core::audit::AuditEventType::Sandbox*`, AAASM-2016) and the
+/// `aa-proxy` dispatch glue (AAASM-2019) can branch on outcome without
+/// inspecting trap internals.
+#[derive(Debug, Error)]
+pub enum SandboxError {
+    /// WASI denied a filesystem operation — either the requested path fell
+    /// outside every directory passed to
+    /// [`wasmtime_wasi::WasiCtxBuilder::preopened_dir`] (`errno`
+    /// `ENOTCAPABLE` / `76`) or the guest tried to use a directory fd not
+    /// backed by a preopen (`errno` `EBADF` / `8`). Carries the raw WASI
+    /// errno surfaced by the guest via `proc_exit`.
+    #[error("sandbox filesystem access denied (WASI errno {errno})")]
+    FilesystemBlocked {
+        /// WASI preview1 errno value as surfaced via the guest's
+        /// `proc_exit` exit code.
+        errno: u32,
+    },
+    /// The supplied WASM module bytes could not be parsed or validated by
+    /// wasmtime.
+    #[error("invalid WASM module: {0}")]
+    InvalidWasm(String),
+    /// A wasmtime-level error that does not yet have a deterministic
+    /// variant. Placeholder for the fuel / limiter mappings landing in
+    /// AAASM-2018; carries the wasmtime error's `Display` representation.
+    #[error("wasmtime error: {0}")]
+    Wasmtime(String),
+}

--- a/aa-sandbox/src/policy.rs
+++ b/aa-sandbox/src/policy.rs
@@ -1,15 +1,41 @@
-//! Sandbox policy configuration — filesystem allowlist + CPU/memory limits.
+//! Sandbox policy configuration — filesystem allowlist + (in AAASM-2018)
+//! CPU/memory limits.
 //!
-//! `SandboxConfig` carries the data that a [`runtime`] invocation needs:
-//!
-//! * `preopened_dirs` — F116 ST-W S3 (WASI `WasiCtxBuilder::preopened_dir`
-//!   allowlist; arbitrary reads outside the listed roots surface as
-//!   `error::SandboxError::FilesystemBlocked`).
-//! * `limits` — F116 ST-W S4 (`SandboxLimits { fuel, memory_pages,
-//!   wall_clock_ms }`, fed into wasmtime `Store::set_fuel` and
-//!   `Store::limiter`).
-//!
-//! This module ships as a doc-only scaffold under AAASM-2015 (S1); the
-//! types land in S3 and S4.
-//!
-//! [`runtime`]: crate::runtime
+//! [`SandboxConfig`] carries the data that a single
+//! [`crate::runtime::SandboxRuntime::run_tool`] invocation needs. In this
+//! sub-task it carries only the filesystem allowlist; the
+//! `SandboxLimits { fuel, memory_pages, wall_clock_ms }` field lands in
+//! AAASM-2018 (fuel + `Store::limiter`).
+
+use std::path::PathBuf;
+
+/// Mapping of one host directory into the WASI sandbox.
+///
+/// Each entry becomes a single
+/// [`wasmtime_wasi::WasiCtxBuilder::preopened_dir`] call on the guest's
+/// `WasiCtx`. The guest sees `host_path` mounted at `guest_path` and can
+/// only resolve WASI `path_open` calls within that subtree; anything else
+/// surfaces as `errno` `ENOTCAPABLE` and bubbles up as
+/// [`crate::error::SandboxError::FilesystemBlocked`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreopenedDir {
+    /// Real path on the host filesystem.
+    pub host_path: PathBuf,
+    /// Path the guest sees this directory mounted at (e.g. `"."` for the
+    /// guest's working directory or `"/data"` for a labelled mount).
+    pub guest_path: String,
+}
+
+/// Sandbox configuration consumed by [`crate::runtime::SandboxRuntime`].
+///
+/// An empty `preopened_dirs` list is the most-restrictive case: the guest
+/// cannot open any file via WASI — every `path_open` returns `EBADF`
+/// because there is no preopen handle to resolve paths against.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SandboxConfig {
+    /// WASI preopened-directory allowlist. Each entry is presented to the
+    /// guest as one mount point with full `DirPerms` / `FilePerms`. Empty
+    /// (the [`Default`]) means "no filesystem visibility" — every WASI
+    /// `path_open` returns `EBADF`.
+    pub preopened_dirs: Vec<PreopenedDir>,
+}

--- a/aa-sandbox/src/runtime.rs
+++ b/aa-sandbox/src/runtime.rs
@@ -1,21 +1,132 @@
 //! Sandbox runtime — wasmtime engine + per-invocation store wiring.
 //!
-//! `SandboxRuntime` owns a long-lived [`wasmtime::Engine`] configured with
-//! `consume_fuel(true)` and instantiates a fresh `Store` per `run_tool`
-//! call. The store is wired with:
+//! [`SandboxRuntime`] owns a long-lived [`wasmtime::Engine`] and a
+//! [`wasmtime::Linker`] pre-populated with WASI preview 1 host functions.
+//! [`SandboxRuntime::run_tool`] instantiates a fresh
+//! [`wasmtime::Store`] per call, builds a
+//! [`wasmtime_wasi::WasiCtx`] from the [`SandboxConfig`]'s
+//! `preopened_dirs` allowlist, instantiates the WASM module, and invokes
+//! the conventional `_start` entry point.
 //!
-//! * WASI preview 1 host handlers built from a [`policy::SandboxConfig`]
-//!   `preopened_dirs` allowlist (F116 ST-W S3).
-//! * `Store::set_fuel(...)` + `Store::limiter(...)` from the same config's
-//!   `limits` field (F116 ST-W S4).
+//! WASI's preview 1 file-system handlers (`fd_open`, `fd_read`, `fd_write`,
+//! `path_open`) are responsible for enforcing the allowlist: paths outside
+//! every preopened directory surface as `errno` `ENOTCAPABLE` (`76`) or
+//! `EBADF` (`8`) to the guest. The runtime maps any non-zero WASI exit
+//! code from the guest's `proc_exit` into
+//! [`SandboxError::FilesystemBlocked`].
 //!
-//! Each invocation surfaces a deterministic
-//! [`error::SandboxError`](crate::error) variant on failure; success
-//! returns a wasmtime [`Trap`]-free completion plus the audit lifecycle
-//! events emitted by `aa-proxy` in F116 ST-W S5.
-//!
-//! This module ships as a doc-only scaffold under AAASM-2015 (S1); the
-//! `SandboxRuntime` type lands in S3.
-//!
-//! [`Trap`]: https://docs.rs/wasmtime/latest/wasmtime/struct.Trap.html
-//! [`policy::SandboxConfig`]: crate::policy
+//! Fuel + memory-store limits land in AAASM-2018; ToolRegistry dispatch +
+//! audit-event emission land in AAASM-2019.
+
+use wasmtime::{Engine, Linker, Module, Store};
+use wasmtime_wasi::p1::{self, WasiP1Ctx};
+use wasmtime_wasi::{DirPerms, FilePerms, I32Exit, WasiCtx};
+
+use crate::error::SandboxError;
+use crate::policy::SandboxConfig;
+
+/// Successful sandboxed-tool invocation outcome.
+///
+/// In AAASM-2017 this carries only the WASI exit code; structured tool
+/// output (stdout capture, return value decoding) lands in AAASM-2019
+/// alongside the `ToolRegistry` dispatch glue that knows the call's
+/// semantics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxOutput {
+    /// WASI exit code surfaced by the guest. Zero indicates a clean
+    /// `_start` return (or an explicit `proc_exit(0)`); any non-zero
+    /// value would have been mapped to a `SandboxError` variant by
+    /// [`SandboxRuntime::run_tool`] before reaching this struct.
+    pub exit_code: i32,
+}
+
+/// Sandbox host runtime — owns the wasmtime [`Engine`] and the
+/// WASI-populated [`Linker`].
+///
+/// One runtime instance can service many `run_tool` invocations; each
+/// invocation gets a fresh [`Store`] + [`WasiCtx`] so per-call state never
+/// leaks between tools.
+pub struct SandboxRuntime {
+    engine: Engine,
+    linker: Linker<WasiP1Ctx>,
+    config: SandboxConfig,
+}
+
+impl SandboxRuntime {
+    /// Build a runtime with a default wasmtime [`Engine`] and a
+    /// [`Linker`] pre-populated with WASI preview 1 host functions.
+    ///
+    /// Returns [`SandboxError::Wasmtime`] if WASI registration fails (in
+    /// practice this only happens on a programming error — duplicate
+    /// import name).
+    pub fn new(config: SandboxConfig) -> Result<Self, SandboxError> {
+        let engine = Engine::default();
+        let mut linker: Linker<WasiP1Ctx> = Linker::new(&engine);
+        p1::add_to_linker_sync(&mut linker, |cx| cx).map_err(|e| SandboxError::Wasmtime(e.to_string()))?;
+        Ok(Self { engine, linker, config })
+    }
+
+    /// Instantiate the supplied WASM module under WASI preview 1 and
+    /// invoke its `_start` entry point.
+    ///
+    /// A fresh [`Store`] + [`WasiCtx`] is built per call; the WASI ctx
+    /// only sees directories listed in [`SandboxConfig::preopened_dirs`].
+    /// `args` is accepted as part of the AAASM-2017 signature contract
+    /// (see parent Story AAASM-1965) but is unused until the
+    /// `ToolRegistry` dispatch glue lands in AAASM-2019 — the guest sees
+    /// an empty WASI args vector for now.
+    ///
+    /// Returns:
+    /// * `Ok(SandboxOutput { exit_code: 0 })` if `_start` returns
+    ///   cleanly or the guest calls `proc_exit(0)`.
+    /// * [`SandboxError::FilesystemBlocked`] if the guest calls
+    ///   `proc_exit(n)` with non-zero `n` (the WASI FS handlers surface
+    ///   `ENOTCAPABLE`/`EBADF` via the exit code in AAASM-2017's WAT
+    ///   fixtures).
+    /// * [`SandboxError::InvalidWasm`] if wasmtime cannot parse/validate
+    ///   the module bytes.
+    /// * [`SandboxError::Wasmtime`] for any other trap; this is the
+    ///   fallback bucket that AAASM-2018 (fuel/limiter) narrows into
+    ///   `CpuTimeout` and `MemoryExhausted`.
+    pub fn run_tool(&self, wasm_bytes: &[u8], _args: &[u8]) -> Result<SandboxOutput, SandboxError> {
+        let module =
+            Module::from_binary(&self.engine, wasm_bytes).map_err(|e| SandboxError::InvalidWasm(e.to_string()))?;
+
+        let mut builder = WasiCtx::builder();
+        for preopen in &self.config.preopened_dirs {
+            builder
+                .preopened_dir(
+                    &preopen.host_path,
+                    &preopen.guest_path,
+                    DirPerms::all(),
+                    FilePerms::all(),
+                )
+                .map_err(|e| SandboxError::Wasmtime(e.to_string()))?;
+        }
+        let wasi = builder.build_p1();
+        let mut store = Store::new(&self.engine, wasi);
+
+        let instance = self
+            .linker
+            .instantiate(&mut store, &module)
+            .map_err(|e| SandboxError::Wasmtime(e.to_string()))?;
+        let start = instance
+            .get_typed_func::<(), ()>(&mut store, "_start")
+            .map_err(|e| SandboxError::Wasmtime(e.to_string()))?;
+
+        match start.call(&mut store, ()) {
+            Ok(()) => Ok(SandboxOutput { exit_code: 0 }),
+            Err(trap) => {
+                if let Some(I32Exit(code)) = trap.downcast_ref::<I32Exit>() {
+                    if *code == 0 {
+                        Ok(SandboxOutput { exit_code: 0 })
+                    } else {
+                        Err(SandboxError::FilesystemBlocked { errno: *code as u32 })
+                    }
+                } else {
+                    Err(SandboxError::Wasmtime(trap.to_string()))
+                }
+            }
+        }
+    }
+}

--- a/aa-sandbox/src/runtime.rs
+++ b/aa-sandbox/src/runtime.rs
@@ -130,3 +130,61 @@ impl SandboxRuntime {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Hand-authored WAT fixture that probes the WASI filesystem
+    /// allowlist. The guest:
+    ///
+    /// 1. Places the literal `/etc/passwd` at memory offset 0.
+    /// 2. Invokes `path_open` with `fd = 3` — the first non-stdio fd,
+    ///    which is unbound when [`SandboxConfig::preopened_dirs`] is
+    ///    empty.
+    /// 3. Surfaces the returned errno via `proc_exit`. WASI returns
+    ///    `EBADF` (8) when the dir fd is unmapped (the AAASM-2017
+    ///    empty-allowlist case) or `ENOTCAPABLE` (76) when a path
+    ///    escapes the preopen tree.
+    const PATH_OPEN_PROBE_WAT: &str = r#"
+        (module
+          (import "wasi_snapshot_preview1" "path_open"
+            (func $path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+          (import "wasi_snapshot_preview1" "proc_exit"
+            (func $proc_exit (param i32)))
+          (memory (export "memory") 1)
+          (data (i32.const 0) "/etc/passwd")
+          (func (export "_start")
+            (call $proc_exit
+              (call $path_open
+                (i32.const 3)
+                (i32.const 0)
+                (i32.const 0)
+                (i32.const 11)
+                (i32.const 0)
+                (i64.const 0)
+                (i64.const 0)
+                (i32.const 0)
+                (i32.const 100)
+              )
+            )
+          )
+        )
+    "#;
+
+    #[test]
+    fn run_tool_blocks_path_open_outside_allowlist() {
+        let runtime =
+            SandboxRuntime::new(SandboxConfig::default()).expect("SandboxRuntime with empty allowlist must construct");
+        let wasm = wat::parse_str(PATH_OPEN_PROBE_WAT).expect("WAT fixture must parse");
+
+        let result = runtime.run_tool(&wasm, &[]);
+
+        match result {
+            Err(SandboxError::FilesystemBlocked { errno }) => {
+                assert_ne!(errno, 0, "WASI must surface a non-zero errno for the blocked path_open");
+            }
+            other => panic!("expected SandboxError::FilesystemBlocked, got {:?}", other),
+        }
+    }
+}


### PR DESCRIPTION
## Description

Implement the filesystem-allowlist half of F116 ST-W (parent Story: AAASM-1965). Builds the real `aa-sandbox` runtime on top of the AAASM-2015 scaffold:

* `SandboxError` enum (replaces the doc-only stub) with `FilesystemBlocked { errno }`, `InvalidWasm(String)`, `Wasmtime(String)`. Uses `thiserror = "2"`.
* `SandboxConfig { preopened_dirs }` + `PreopenedDir { host_path, guest_path }` data carriers.
* `SandboxRuntime` host owning a long-lived `wasmtime::Engine` + `Linker<WasiP1Ctx>` (pre-populated via `wasmtime_wasi::p1::add_to_linker_sync`).
* `SandboxRuntime::run_tool(wasm_bytes, _args) -> Result<SandboxOutput, SandboxError>`:
  - Builds a fresh `WasiCtx` per call via `WasiCtxBuilder::preopened_dir` for each entry in the config's allowlist.
  - Instantiates the module, calls `_start`, catches `I32Exit(code)` from the guest's `proc_exit`.
  - Maps non-zero exit codes to `FilesystemBlocked { errno: code as u32 }` — the WASI preview 1 FS handlers surface `ENOTCAPABLE` (76) for paths outside the preopen tree and `EBADF` (8) for unbound dir fds.
* WAT fixture test (`PATH_OPEN_PROBE_WAT`) compiled at test time via `wat::parse_str`: places `/etc/passwd` at memory offset 0, invokes `path_open` with `fd = 3` (unbound under empty allowlist), surfaces the WASI errno via `proc_exit`. Asserts `Err(SandboxError::FilesystemBlocked { errno })` with non-zero `errno`.

`SandboxOutput { exit_code }` placeholder return — structured tool-output decoding lands in AAASM-2019 with the dispatch glue. The `args` parameter is accepted per the AAASM-2017 signature contract but unused in this sub-task.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

`aa-sandbox` is workspace-internal and not yet consumed by any other crate; this PR cannot break external API.

## Related Issues

- Related Jira ticket: **AAASM-2017** (sub-task of parent Story **AAASM-1965**)
- Builds on merged AAASM-2015 (#805 — crate scaffold) and AAASM-2016 (#806 — sandbox audit event variants)

## Testing

`cargo nextest run -p aa-sandbox` adds **1 test**: `runtime::tests::run_tool_blocks_path_open_outside_allowlist` — asserts the WAT-fixture `path_open("/etc/passwd")` call surfaces `SandboxError::FilesystemBlocked { errno: <non-zero> }`. Passes locally.

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required

Local validation:

```text
cargo check -p aa-sandbox      # passes
cargo clippy -p aa-sandbox --all-targets -- -D warnings  # clean
cargo deny check               # advisories ok, bans ok, licenses ok, sources ok
cargo nextest run -p aa-sandbox  # 1 test, 1 passed
cargo doc -p aa-sandbox --no-deps  # clean
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (each new type carries a doc-comment naming the AAASM-XXXX ticket for its scope and the wasmtime/WASI primitive it wraps)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Commit log

| Commit | Scope |
|---|---|
| `9e97b53f` | ✨ (aa-sandbox/error): Add SandboxError enum with FilesystemBlocked variant |
| `0d758960` | ✨ (aa-sandbox/policy): Add SandboxConfig with preopened_dirs allowlist |
| `7fe0aeeb` | ✨ (aa-sandbox/runtime): Add SandboxRuntime with WASI preview1 dispatch |
| `4ec5bf29` | ✅ (aa-sandbox/runtime): Add WAT fixture test for path_open denial |