### PR TITLE
[AAASM-2023] ✨ (aa-gateway): Multi-document policy cascade loader (unblocks ST-org-4)

### DIFF
--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -521,7 +521,25 @@ impl PolicyEngine {
     /// single-policy pipeline (`evaluate_primary`) when no scoped policies are
     /// present, preserving full backward compatibility.
     pub fn evaluate(&self, ctx: &aa_core::AgentContext, action: &aa_core::GovernanceAction) -> EvaluationResult {
-        let cascade = self.collect_cascade(&ctx.agent_id);
+        // AAASM-2023 — resolve lineage from ctx FIRST (convert.rs already
+        // deposits proto.org_id / proto.team_id into ctx.metadata) before
+        // falling back to a registry lookup. The registry-keyed-by-composite
+        // path doesn't match `ctx.agent_id` (which is hashed from just the
+        // agent_id string), so without this preference org-scoped cascades
+        // would never see the agent's org_id.
+        let ctx_lineage = crate::registry::Lineage {
+            org_id: ctx.metadata.get("org_id").cloned(),
+            team_id: ctx.team_id.clone().or_else(|| ctx.metadata.get("team_id").cloned()),
+        };
+        let lineage = if ctx_lineage.org_id.is_some() || ctx_lineage.team_id.is_some() {
+            ctx_lineage
+        } else {
+            self.registry
+                .as_ref()
+                .and_then(|r| r.lineage(ctx.agent_id.as_bytes()))
+                .unwrap_or_default()
+        };
+        let cascade = self.collect_cascade_with_lineage(&ctx.agent_id, &lineage);
 
         // Backward-compat: no scoped policies loaded → use primary policy only.
         if cascade.is_empty() {
@@ -1213,13 +1231,29 @@ impl PolicyEngine {
     /// narrowest. Policies within the same scope appear in their load order
     /// (insertion order in `ScopeIndex`).
     pub fn collect_cascade(&self, agent_id: &aa_core::identity::AgentId) -> Vec<Arc<PolicyDocument>> {
-        use crate::policy::scope::PolicyScope;
-
         let lineage = self
             .registry
             .as_ref()
             .and_then(|r| r.lineage(agent_id.as_bytes()))
             .unwrap_or_default();
+        self.collect_cascade_with_lineage(agent_id, &lineage)
+    }
+
+    /// AAASM-2023 — variant of [`Self::collect_cascade`] that takes a
+    /// pre-resolved [`crate::registry::Lineage`] hint instead of looking
+    /// it up via the attached registry.
+    ///
+    /// Used by [`Self::evaluate`] which can resolve the lineage from the
+    /// `AgentContext` (where convert.rs already deposits `org_id` /
+    /// `team_id` in `metadata`) without needing the registry to be
+    /// queryable by `ctx.agent_id` — a key shape that doesn't match the
+    /// registry's composite `{org_id, team_id, agent_id}` hash today.
+    pub fn collect_cascade_with_lineage(
+        &self,
+        agent_id: &aa_core::identity::AgentId,
+        lineage: &crate::registry::Lineage,
+    ) -> Vec<Arc<PolicyDocument>> {
+        use crate::policy::scope::PolicyScope;
 
         let mut cascade = Vec::new();
 

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -263,6 +263,146 @@ impl PolicyEngine {
         })
     }
 
+    /// AAASM-2023 — Load **multiple** policy documents from every `*.yaml`
+    /// file in a directory and populate the `scope_index` cascade.
+    ///
+    /// Each YAML file is parsed independently and inserted into the
+    /// `scope_index` keyed by its `scope` field (`Global` / `Org(...)` /
+    /// `Team(...)` / `Agent(...)`). At evaluation time, the cascade
+    /// collector at `evaluate()` walks the scopes for the calling agent's
+    /// lineage and merges every matching document — which finally lets
+    /// `scope: org:<id>` policies fire ONLY for agents in that org
+    /// (closes the gateway-side gap that AAASM-2008 ST-org-4 surfaced).
+    ///
+    /// ## Semantics
+    ///
+    /// * Files are loaded in alphabetical filename order (deterministic).
+    /// * The first Global-scoped document found supplies the budget and
+    ///   data-pattern config; if no Global-scoped document is present,
+    ///   budget limits default to None and the data-pattern set is empty.
+    /// * Files that fail to parse abort the entire load — the caller gets
+    ///   a `PolicyParseError` for the first bad file. (Partial loads would
+    ///   be a worse failure mode than the loud abort.)
+    /// * The `policy: ArcSwap<Arc<PolicyDocument>>` primary field is set
+    ///   to the first Global-scoped document (or a fresh default when
+    ///   none is present). With a non-empty `scope_index`, `evaluate()`
+    ///   routes through `evaluate_with_cascade` and the primary slot is
+    ///   only consulted by callers that bypass the cascade path.
+    /// * No filesystem watcher is attached — the watcher today is
+    ///   single-file. Hot-reload across multiple files is a separate
+    ///   concern; for now the cascade is static-at-load.
+    ///
+    /// ## Example
+    ///
+    /// ```text
+    /// policies/
+    /// ├── 000-global-allow-all.yaml   # scope: global (or omitted)
+    /// ├── 100-org-acme-deny-bash.yaml # scope: org:acme
+    /// └── 200-team-platform.yaml      # scope: team:platform
+    /// ```
+    ///
+    /// Loading this directory gives every agent in `acme/platform` the
+    /// Global rules + the org-acme deny + the team-platform rules.
+    /// Agents in other orgs see only the Global rules.
+    pub fn load_cascade_from_dir(
+        dir: &Path,
+        budget_alert_tx: tokio::sync::broadcast::Sender<crate::budget::BudgetAlert>,
+    ) -> Result<Self, PolicyLoadError> {
+        // Collect *.yaml entries in alphabetical order so the cascade is
+        // deterministic across runs and filesystems with different
+        // dir-iteration orders.
+        let mut entries: Vec<std::path::PathBuf> = std::fs::read_dir(dir)
+            .map_err(PolicyLoadError::Io)?
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("yaml"))
+            .collect();
+        entries.sort();
+
+        let mut scope_index = ScopeIndex::new();
+        let mut primary: Option<PolicyDocument> = None;
+        let mut compiled_patterns = Vec::new();
+        let mut budget_tz = chrono_tz::UTC;
+        let mut daily_limit: Option<rust_decimal::Decimal> = None;
+        let mut monthly_limit: Option<rust_decimal::Decimal> = None;
+
+        for path in &entries {
+            let yaml = std::fs::read_to_string(path).map_err(PolicyLoadError::Io)?;
+            let output = PolicyValidator::from_yaml(&yaml).map_err(PolicyLoadError::Validation)?;
+            let doc = output.document;
+
+            // First Global-scoped document supplies budget + sensitive-pattern config.
+            if matches!(doc.scope, crate::policy::scope::PolicyScope::Global) && primary.is_none() {
+                compiled_patterns = doc
+                    .data
+                    .as_ref()
+                    .map(|dp| {
+                        dp.sensitive_patterns
+                            .iter()
+                            .filter_map(|p| regex::Regex::new(p).ok())
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                budget_tz = doc
+                    .budget
+                    .as_ref()
+                    .and_then(|bp| bp.timezone.as_deref())
+                    .and_then(|s| s.parse::<chrono_tz::Tz>().ok())
+                    .unwrap_or(chrono_tz::UTC);
+                daily_limit = doc
+                    .budget
+                    .as_ref()
+                    .and_then(|bp| bp.daily_limit_usd)
+                    .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
+                monthly_limit = doc
+                    .budget
+                    .as_ref()
+                    .and_then(|bp| bp.monthly_limit_usd)
+                    .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
+                primary = Some(doc.clone());
+            }
+
+            scope_index.insert(doc);
+        }
+
+        let budget = Arc::new(BudgetTracker::new_with_alert_sender(
+            crate::budget::PricingTable::default_table(),
+            daily_limit,
+            monthly_limit,
+            budget_tz,
+            budget_alert_tx,
+        ));
+
+        let primary_doc = primary.unwrap_or_else(|| PolicyDocument {
+            name: None,
+            policy_version: None,
+            version: None,
+            scope: crate::policy::scope::PolicyScope::Global,
+            network: None,
+            schedule: None,
+            budget: None,
+            data: None,
+            approval_timeout_secs: 300,
+            approval_policy: None,
+            tools: std::collections::HashMap::new(),
+            capabilities: None,
+        });
+        let policy_arc = Arc::new(ArcSwap::new(Arc::new(primary_doc)));
+
+        Ok(PolicyEngine {
+            policy: policy_arc,
+            scanner: aa_core::CredentialScanner::new(),
+            compiled_patterns,
+            rate_state: DashMap::new(),
+            budget,
+            scope_index,
+            _watcher: None,
+            registry: None,
+            policy_epoch: Arc::new(AtomicU64::new(0)),
+            decision_cache: DecisionCache::new(100_000),
+        })
+    }
+
     /// Load a policy from a YAML file using a pre-built budget tracker.
     ///
     /// Use this when restoring budget state from disk — the caller constructs

--- a/aa-integration-tests/tests/common/fixtures/policies/org_cascade/000-global-allow-all.yaml
+++ b/aa-integration-tests/tests/common/fixtures/policies/org_cascade/000-global-allow-all.yaml
@@ -1,0 +1,14 @@
+apiVersion: agent-assembly.dev/v1alpha1
+kind: GovernancePolicy
+metadata:
+  name: it-cascade-global-allow-all
+  version: "0.1.0"
+
+# AAASM-2023 ST-org-4 cascade fixture — Global-scoped default policy
+# layered under the org-alpha-scoped deny in 100-org-alpha-deny-bash.yaml.
+# Empty rules list = allow-by-default for any tool the agent invokes
+# unless a higher-precedence document in the cascade denies it.
+#
+# Default scope is `global` when the field is absent.
+spec:
+  tools: {}

--- a/aa-integration-tests/tests/common/fixtures/policies/org_cascade/100-org-alpha-deny-bash.yaml
+++ b/aa-integration-tests/tests/common/fixtures/policies/org_cascade/100-org-alpha-deny-bash.yaml
@@ -1,0 +1,20 @@
+apiVersion: agent-assembly.dev/v1alpha1
+kind: GovernancePolicy
+metadata:
+  name: it-cascade-org-alpha-deny-bash
+  version: "0.1.0"
+
+# AAASM-2023 ST-org-4 cascade fixture — Org-scoped policy layered ON TOP of
+# the Global default in 000-global-allow-all.yaml. Fires only for agents
+# whose `lineage.org_id == "org-alpha"`; agents in any other org fall
+# through to the Global default (allow).
+#
+# Mirrors aa-integration-tests/tests/common/fixtures/policies/org_scoped_deny_bash.yaml
+# but lives under the cascade directory so load_cascade_from_dir picks it
+# up alongside the Global default.
+scope: org:org-alpha
+
+spec:
+  tools:
+    bash:
+      allow: false

--- a/aa-integration-tests/tests/common/fixtures/policies/org_cascade/100-org-alpha-deny-bash.yaml
+++ b/aa-integration-tests/tests/common/fixtures/policies/org_cascade/100-org-alpha-deny-bash.yaml
@@ -9,12 +9,11 @@ metadata:
 # whose `lineage.org_id == "org-alpha"`; agents in any other org fall
 # through to the Global default (allow).
 #
-# Mirrors aa-integration-tests/tests/common/fixtures/policies/org_scoped_deny_bash.yaml
-# but lives under the cascade directory so load_cascade_from_dir picks it
-# up alongside the Global default.
-scope: org:org-alpha
-
+# Note: `scope` lives INSIDE `spec:` for envelope-format documents — the
+# validator deserializes the `spec` value as the RawPolicyDocument, so
+# `scope:` at the outer envelope level is silently ignored.
 spec:
+  scope: org:org-alpha
   tools:
     bash:
       allow: false

--- a/aa-integration-tests/tests/e2e_org_isolation.rs
+++ b/aa-integration-tests/tests/e2e_org_isolation.rs
@@ -56,17 +56,37 @@ fn fixture_path(rel: &str) -> std::path::PathBuf {
 async fn start_gateway(policy_fixture: &str) -> (SocketAddr, Arc<AgentRegistry>, mpsc::Receiver<AuditEntry>) {
     let path = fixture_path(policy_fixture);
     let (alert_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
-    let engine = Arc::new(PolicyEngine::load_from_file(&path, alert_tx).expect("policy fixture loads"));
+    let engine_inner = PolicyEngine::load_from_file(&path, alert_tx).expect("policy fixture loads");
+    spawn_gateway_with_engine_builder(engine_inner).await
+}
+
+/// AAASM-2023 — companion helper that loads a directory of YAML documents
+/// via `PolicyEngine::load_cascade_from_dir`. Used by the org-scoped ST-org-4
+/// test where the gateway needs both a Global default and an Org-scoped rule.
+async fn start_gateway_with_cascade_dir(
+    policy_dir: &str,
+) -> (SocketAddr, Arc<AgentRegistry>, mpsc::Receiver<AuditEntry>) {
+    let path = fixture_path(policy_dir);
+    let (alert_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    let engine_inner = PolicyEngine::load_cascade_from_dir(&path, alert_tx).expect("cascade fixture loads");
+    spawn_gateway_with_engine_builder(engine_inner).await
+}
+
+/// Build the registry first, attach it to the engine via `with_registry`
+/// (so `collect_cascade` can resolve `lineage.org_id`), then wire the gRPC
+/// server. Returns the bound addr + registry handle + audit receiver.
+async fn spawn_gateway_with_engine_builder(
+    engine_inner: PolicyEngine,
+) -> (SocketAddr, Arc<AgentRegistry>, mpsc::Receiver<AuditEntry>) {
     let registry = Arc::new(AgentRegistry::new());
+    // AAASM-2023 — engine.with_registry is the key step: collect_cascade
+    // walks `self.registry.lineage(agent_id)` for org/team scoping; without
+    // it the cascade is collapsed to Global-only and org-scoped policies
+    // never fire even when scope_index has them registered.
+    let engine = Arc::new(engine_inner.with_registry(Arc::clone(&registry)));
     let (audit_tx, audit_rx) = mpsc::channel::<AuditEntry>(4096);
     let audit_drops = Arc::new(AtomicU64::new(0));
-    let service = PolicyServiceImpl::with_registry(
-        Arc::clone(&engine),
-        Arc::clone(&registry),
-        audit_tx,
-        audit_drops,
-        [0u8; 32],
-    );
+    let service = PolicyServiceImpl::with_registry(engine, Arc::clone(&registry), audit_tx, audit_drops, [0u8; 32]);
 
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind 127.0.0.1:0");
     let addr = listener.local_addr().expect("local_addr");
@@ -261,28 +281,53 @@ async fn st_org_3_cross_org_budget_isolation() {
 // ── ST-org-4 ────────────────────────────────────────────────────────────────
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[ignore = "AAASM-2023: PolicyEngine::load_from_file does not populate the scope_index, so org-scoped \
-    policies route through evaluate_primary and apply globally. The engine's scope_index cascade \
-    DOES handle PolicyScope::Org correctly (covered by aa-gateway/tests/cascade_merge_test.rs), but \
-    exercising it E2E here requires a multi-document loader — filed as a follow-up subtask"]
 async fn st_org_4_policy_with_org_scope_fires_only_for_matching_org() {
-    // When AAASM-2023 ships a `PolicyEngine::load_cascade_from_dir(...)` or
-    // equivalent multi-document loader, this test will:
+    // AAASM-2023 un-ignored this test. Uses the new
+    // `PolicyEngine::load_cascade_from_dir` to load TWO policy documents
+    // from a single directory:
     //
-    // 1. Load TWO policy documents: a Global allow-all + an
-    //    org-alpha-scoped deny-bash (org_scoped_deny_bash.yaml fixture).
-    // 2. Register agents in org-alpha and org-beta.
-    // 3. Drive `bash` from each agent.
-    // 4. Assert: org-alpha → Deny (org-scoped rule fires); org-beta →
-    //    Allow (org-scoped rule does NOT fire — lineage.org_id filters it
-    //    out of the cascade).
+    //   policies/org_cascade/
+    //   ├── 000-global-allow-all.yaml   (scope: global, empty tools)
+    //   └── 100-org-alpha-deny-bash.yaml (scope: org:org-alpha, deny bash)
     //
-    // The pure-logic equivalent (cascade evaluator + PolicyScope::Org
-    // filtering) is already unit-tested in
-    // aa-gateway/tests/cascade_merge_test.rs::cascade_merge_org_team_agent.
-    // This E2E test is the F116 acceptance lens; un-ignored when AAASM-2023
-    // wires the gateway-side multi-document loader.
-    unimplemented!("AAASM-2023 — gateway multi-document cascade loader");
+    // Cascade collector at engine/mod.rs:1083-1116 walks the scopes for
+    // each agent's lineage. Org-alpha agents include the org-alpha
+    // document → bash is denied. Org-beta agents don't include it →
+    // bash falls through to the Global allow-all default.
+    let (addr, registry, _audit_rx) = start_gateway_with_cascade_dir("policies/org_cascade").await;
+
+    let alpha = id("org-alpha", "team", "agent-a");
+    let beta = id("org-beta", "team", "agent-b");
+    register_agent(&registry, &alpha, "tok-alpha");
+    register_agent(&registry, &beta, "tok-beta");
+
+    let mut client = PolicyServiceClient::connect(format!("http://{addr}")).await.unwrap();
+
+    // bash from org-alpha → Deny (the org-scoped policy fires).
+    let alpha_resp = client
+        .check_action(tool_call(&alpha, "tok-alpha", "bash", "t-alpha"))
+        .await
+        .expect("alpha bash")
+        .into_inner();
+    assert_eq!(
+        alpha_resp.decision,
+        Decision::Deny as i32,
+        "org-alpha bash must be denied by the org-scoped policy (cascade includes org-alpha doc)"
+    );
+
+    // bash from org-beta → Allow (cascade for org-beta only includes the
+    // Global allow-all default; the org-alpha-scoped doc is filtered out
+    // by lineage.org_id mismatch).
+    let beta_resp = client
+        .check_action(tool_call(&beta, "tok-beta", "bash", "t-beta"))
+        .await
+        .expect("beta bash")
+        .into_inner();
+    assert_eq!(
+        beta_resp.decision,
+        Decision::Allow as i32,
+        "org-beta bash must pass through — the org-alpha-scoped policy must not fire"
+    );
 }
 
 // ── ST-org-5 ────────────────────────────────────────────────────────────────

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -38,6 +38,7 @@
 - [Agent-to-Agent Identity](operations/a2a-identity.md)
 - [Tool Sandbox: Network Egress](operations/tool-sandbox-network.md)
 - [Org-Tier Isolation](operations/org-isolation.md)
+- [Multi-Document Policy Cascade](operations/policy-cascade-loader.md)
 
 # Benchmarks
 

--- a/docs/src/operations/policy-cascade-loader.md
+++ b/docs/src/operations/policy-cascade-loader.md
@@ -1,0 +1,141 @@
+# Multi-Document Policy Cascade
+
+`PolicyEngine::load_cascade_from_dir(dir)` loads every `*.yaml` file in a
+directory and populates the gateway's `scope_index` so each document
+cascades by its declared scope (`Global` / `Org(<id>)` / `Team(<id>)` /
+`Agent(<id>)`). This unlocks org-scoped, team-scoped, and agent-scoped
+policy rules in the runtime evaluation path — a capability that
+`load_from_file` (single-document) does not provide.
+
+## When to use
+
+* **Multi-tenant deployments** where each org needs its own deny/allow
+  overrides on top of a Global baseline.
+* **Team-level guardrails** layered on top of the org's rules
+  (e.g. "platform team can use bash, but support cannot").
+* **Per-agent escape hatches** for a single high-risk agent that needs
+  a narrower allowlist than its team's default.
+
+Single-policy deployments should continue using `load_from_file` — the
+cascade adds zero value when there's only one document.
+
+## Directory layout
+
+```
+policies/
+├── 000-global-allow-all.yaml      # scope: global (or omitted)
+├── 100-org-acme-deny-bash.yaml    # spec.scope: org:acme
+├── 200-team-platform.yaml         # spec.scope: team:platform
+└── 300-agent-research-bot.yaml    # spec.scope: agent:<UUID>
+```
+
+Filename prefixes are convention only — the loader sorts alphabetically
+so the cascade order is deterministic across filesystems. Use numeric
+prefixes to make precedence visually obvious.
+
+## Scope field placement (gotcha)
+
+When using the envelope format (`apiVersion` / `kind` / `metadata` /
+`spec`), the `scope:` field MUST live inside `spec:`, not at the outer
+envelope level:
+
+```yaml
+# CORRECT — scope inside spec
+apiVersion: agent-assembly.dev/v1alpha1
+kind: GovernancePolicy
+metadata:
+  name: org-acme-deny-bash
+spec:
+  scope: org:acme
+  tools:
+    bash:
+      allow: false
+
+# WRONG — scope at envelope level is SILENTLY IGNORED
+apiVersion: agent-assembly.dev/v1alpha1
+kind: GovernancePolicy
+metadata:
+  name: org-acme-deny-bash
+scope: org:acme         # ← will be ignored; document defaults to Global
+spec:
+  tools:
+    bash:
+      allow: false
+```
+
+The validator's envelope parser deserializes `spec`'s value as a
+`RawPolicyDocument` — outer-level keys outside the envelope frame are
+silently dropped. Always put `scope:` inside `spec:`.
+
+## How the cascade is collected
+
+At evaluation time, the gateway walks scopes from broadest to narrowest
+for the calling agent's lineage:
+
+1. **Global** — every Global-scoped document.
+2. **Org** — documents matching the agent's `lineage.org_id`. The org
+   is resolved from `ctx.metadata["org_id"]` (populated by the SDK's
+   proto `AgentId.org_id`).
+3. **Team** — documents matching the agent's `lineage.team_id`.
+4. **Agent** — documents matching the agent's `lineage.agent_id`.
+
+Each level **augments** the cascade — Global rules still apply for
+agents in org-acme; the org-acme rules are added on top. The decision
+merger (`merge_decisions`) resolves conflicts with narrower scopes
+winning (Agent > Team > Org > Global).
+
+## How `org_id` flows from request to cascade
+
+The cascade's filtering by `lineage.org_id` works through two paths:
+
+1. **From request context** — `convert.rs::request_to_core` deposits
+   `proto.org_id` into `ctx.metadata["org_id"]`. `PolicyEngine::evaluate`
+   reads this first and uses it as the lineage hint. This is the
+   primary path.
+2. **From registry fallback** — when `ctx.metadata["org_id"]` is empty
+   (e.g. for traffic that doesn't go through the SDK's identity
+   plumbing), the engine falls back to `registry.lineage(agent_id)`.
+
+The primary path is what makes `scope: org:<id>` work end-to-end: every
+SDK call that populates `AgentId.org_id` lands in the right org's
+cascade automatically.
+
+## Programmatic loading
+
+For tests or programmatic setups that don't use a directory:
+
+```rust
+use aa_gateway::PolicyEngine;
+use tokio::sync::broadcast;
+
+let (alert_tx, _) = broadcast::channel(64);
+let engine = PolicyEngine::load_cascade_from_dir(
+    std::path::Path::new("/etc/aa-gateway/policies/"),
+    alert_tx,
+)?;
+```
+
+The loader returns the same `PolicyEngine` type as `load_from_file`,
+so it drops into existing service wiring without code changes.
+
+## Caveats
+
+* **No filesystem watcher** — the cascade is static at load. Hot-reload
+  across multiple files is a separate concern; restart the gateway to
+  pick up changes.
+* **First Global doc supplies budget config** — alphabetical order
+  determines which Global document's `budget:` block sets daily /
+  monthly limits and `data.sensitive_patterns`. If two Global docs
+  disagree on budget, the alphabetically-first one wins.
+* **Parse failures abort the whole load** — partial loads would be a
+  worse failure mode than the loud abort; the caller gets a
+  `PolicyParseError` for the first bad file.
+
+## Related
+
+* AAASM-2008 — Org-tier isolation (closes the audit / topology /
+  credential surfaces; deferred the policy-scope half to this ticket).
+* `aa-gateway/tests/cascade_merge_test.rs` — pure-logic unit tests of
+  the cascade evaluator (independent of the loader).
+* `aa-integration-tests/tests/e2e_org_isolation.rs::st_org_4_*` — the
+  E2E test that exercises this loader against a real gateway.


### PR DESCRIPTION
## Description

**AAASM-2023 — Multi-document policy cascade loader.** Closes the deferred ST-org-4 scenario from AAASM-2008's follow-up trail by wiring the gateway-side multi-document load path so `scope: org:<id>` policies route through `evaluate_with_cascade` and fire only for agents in the matching org.

## Acceptance criteria

| AC | Status | Evidence |
|---|---|---|
| Multi-document loader exposed | ✅ | `PolicyEngine::load_cascade_from_dir(dir, alert_tx)` |
| ST-org-4 un-ignored and green | ✅ | `st_org_4_policy_with_org_scope_fires_only_for_matching_org` — org-alpha → Deny on bash, org-beta → Allow |
| No regression on single-file `load_from_file` | ✅ | 1068/1068 aa-gateway tests pass unchanged |
| Operator documentation | ✅ | `docs/src/operations/policy-cascade-loader.md` + SUMMARY link |

## Commits (5)

1. `✨ (aa-gateway/engine): Add load_cascade_from_dir multi-document loader`
2. `✨ (aa-integration-tests/fixtures): Add org_cascade fixture directory`
3. `✨ (aa-gateway/engine): Resolve cascade lineage from AgentContext first`
4. `✅ (aa-integration-tests): Un-ignore ST-org-4 with multi-document cascade loader`
5. `📝 (docs/operations): Add multi-document cascade loader guide + SUMMARY link`

## Design notes

### Two bugs uncovered (and fixed) during ST-org-4 un-ignore

**Bug 1 — Scope field placement.** The validator's envelope parser deserializes `spec`'s value as `RawPolicyDocument`. Outer-level keys (siblings of `metadata` and `spec`) are silently dropped. The first iteration of `100-org-alpha-deny-bash.yaml` placed `scope: org:org-alpha` at the outer level → it was ignored and the doc loaded as Global, applying the bash deny to every agent regardless of org. Fixed by moving `scope:` inside `spec:` and documenting the gotcha in the operator guide.

**Bug 2 — Cascade lineage resolution.** `collect_cascade(ctx.agent_id)` looked up the registry by `ctx.agent_id.as_bytes()`, but the registry stores agents at `proto_agent_id_to_key(proto)` — a composite hash of `{org_id, team_id, agent_id}`. `ctx.agent_id` is hashed from just the `agent_id` STRING per `convert.rs::hash_to_16`. The two key shapes never match, so the registry lookup always failed → cascade collapsed to Global-only → org-scoped policies never fired.

Fix: `PolicyEngine::evaluate` now resolves the cascade lineage from `ctx.metadata` FIRST (`convert.rs` already deposits proto's `org_id` and `team_id` there), falling back to the registry lookup only when the ctx-derived lineage is empty. A new public helper `collect_cascade_with_lineage(agent_id, &Lineage)` takes pre-resolved lineage; the existing `collect_cascade(agent_id)` stays as a thin wrapper for backwards compat with `cascade_collect_test.rs` and other external callers.

### Operator-friendly directory layout

`load_cascade_from_dir` reads every `*.yaml` in a directory and inserts each as a scope-indexed document. Files load in alphabetical filename order so precedence is deterministic. The first Global-scoped document supplies budget config + sensitive patterns (mirrors `load_from_file`'s single-doc behaviour). Parse failures abort the whole load — partial loads would be a worse failure mode than the loud abort.

### No filesystem watcher

The cascade is static at load. Hot-reload across multiple files is a separate concern; operators restart the gateway to pick up changes. The single-file watcher in `load_from_file` remains in place for single-doc deployments.

## Type of Change

- [x] ✨ New feature (multi-document cascade loader)
- [x] 🐛 Bug fix (cascade lineage resolution from ctx)
- [x] 📝 Documentation update

## Breaking Changes

- [x] No

`load_cascade_from_dir` is a new constructor; `load_from_file` and `load_from_file_with_budget` are unchanged. `collect_cascade(agent_id)` retains its existing signature; new `collect_cascade_with_lineage` is additive. 1068 aa-gateway tests pass unchanged.

## Related Issues

* **AAASM-2023** (this PR closes Done on merge)
* **AAASM-2008** (deferred this scope item)
* Logical parent: **AAASM-1232** (F116 MVP acceptance, Done)

## Testing

- [x] `cargo nextest run -p aa-gateway` → **1068/1068**
- [x] `cargo nextest run -p aa-integration-tests --test e2e_org_isolation` → **4/4 live + 1 ignored as expected** (ST-org-3 still gated by AAASM-2022)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean (enforced by lefthook)

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated
- [x] All CI checks expected to pass
- [x] Commits are small and follow the Gitmoji convention (5 commits)
