### PR TITLE
[AAASM-2018] ✨ (aa-sandbox): Add wasmtime fuel + memory store limits + wall-clock guard

### DIFF
--- a/aa-sandbox/src/error.rs
+++ b/aa-sandbox/src/error.rs
@@ -38,8 +38,28 @@ pub enum SandboxError {
     #[error("invalid WASM module: {0}")]
     InvalidWasm(String),
     /// A wasmtime-level error that does not yet have a deterministic
-    /// variant. Placeholder for the fuel / limiter mappings landing in
-    /// AAASM-2018; carries the wasmtime error's `Display` representation.
+    /// variant. Carries the wasmtime error's `Display` representation.
     #[error("wasmtime error: {0}")]
     Wasmtime(String),
+    /// The guest exhausted its wasmtime instruction-fuel budget — typically
+    /// a runaway loop. Mapped from a `Trap::OutOfFuel` wasmtime error.
+    /// (AAASM-2018 / F116 ST-W Scenario 2 — CPU half.)
+    #[error("sandbox CPU budget exhausted (fuel ran out)")]
+    CpuTimeout,
+    /// The wall-clock deadline (`SandboxLimits::wall_clock_ms`) elapsed
+    /// before the guest returned. Mapped from a wasmtime epoch-interrupt
+    /// trap fired by a watchdog thread. Distinguished from
+    /// [`SandboxError::CpuTimeout`] so audit consumers can tell whether
+    /// the kill was driven by instruction fuel (`CpuTimeout`) or by
+    /// real-time stalls in non-fuel-instrumented code paths
+    /// (`WallClockTimeout`). (AAASM-2018 / F116 ST-W Scenario 2.)
+    #[error("sandbox wall-clock deadline exceeded")]
+    WallClockTimeout,
+    /// The guest attempted to grow linear memory beyond
+    /// `SandboxLimits::memory_pages * 64 KiB`. Mapped from
+    /// [`wasmtime::ResourceLimiter::memory_growing`] returning `Err`
+    /// with the crate-internal marker error. (AAASM-2018 / F116 ST-W
+    /// Scenario 2 — memory half.)
+    #[error("sandbox memory store limit exhausted")]
+    MemoryExhausted,
 }

--- a/aa-sandbox/src/policy.rs
+++ b/aa-sandbox/src/policy.rs
@@ -1,11 +1,12 @@
-//! Sandbox policy configuration — filesystem allowlist + (in AAASM-2018)
-//! CPU/memory limits.
+//! Sandbox policy configuration — filesystem allowlist + CPU/memory limits.
 //!
 //! [`SandboxConfig`] carries the data that a single
-//! [`crate::runtime::SandboxRuntime::run_tool`] invocation needs. In this
-//! sub-task it carries only the filesystem allowlist; the
-//! `SandboxLimits { fuel, memory_pages, wall_clock_ms }` field lands in
-//! AAASM-2018 (fuel + `Store::limiter`).
+//! [`crate::runtime::SandboxRuntime::run_tool`] invocation needs:
+//!
+//! * `preopened_dirs` — WASI filesystem allowlist (AAASM-2017).
+//! * `limits` — per-invocation CPU + memory budget (AAASM-2018), fed
+//!   into wasmtime `Store::set_fuel`, `Store::limiter`, and the
+//!   wall-clock watchdog thread.
 
 use std::path::PathBuf;
 
@@ -26,6 +27,47 @@ pub struct PreopenedDir {
     pub guest_path: String,
 }
 
+/// Per-invocation CPU + memory budget for a sandboxed tool.
+///
+/// Each call to [`crate::runtime::SandboxRuntime::run_tool`] is bounded
+/// by all three of these limits independently:
+///
+/// * `fuel` exhaustion surfaces as
+///   [`crate::error::SandboxError::CpuTimeout`].
+/// * `memory_pages` exhaustion (the guest tried to grow linear memory
+///   beyond `memory_pages * 64 KiB`) surfaces as
+///   [`crate::error::SandboxError::MemoryExhausted`].
+/// * `wall_clock_ms` elapsed before the guest returned surfaces as
+///   [`crate::error::SandboxError::WallClockTimeout`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SandboxLimits {
+    /// Wasmtime instruction-fuel budget (units of `Store::set_fuel`).
+    /// One unit ≈ one instruction; runaway loops drain this quickly.
+    pub fuel: u64,
+    /// Maximum linear-memory pages the guest can grow to. One WASM page
+    /// is 64 KiB so the byte cap is `memory_pages * 65_536`.
+    pub memory_pages: u32,
+    /// Wall-clock deadline in milliseconds. Enforced by a watchdog
+    /// thread that calls `Engine::increment_epoch` after this delay; the
+    /// runtime arms `Store::set_epoch_deadline(1)` and
+    /// `epoch_deadline_trap` so the tick fires a trap.
+    pub wall_clock_ms: u64,
+}
+
+impl Default for SandboxLimits {
+    /// Safe-by-default budget. All three values are intentionally modest
+    /// so a misconfigured tool fails fast instead of running unbounded:
+    /// 10 million fuel units, 16 pages (1 MiB) of memory, 5 seconds
+    /// wall-clock.
+    fn default() -> Self {
+        Self {
+            fuel: 10_000_000,
+            memory_pages: 16,
+            wall_clock_ms: 5_000,
+        }
+    }
+}
+
 /// Sandbox configuration consumed by [`crate::runtime::SandboxRuntime`].
 ///
 /// An empty `preopened_dirs` list is the most-restrictive case: the guest
@@ -38,4 +80,8 @@ pub struct SandboxConfig {
     /// (the [`Default`]) means "no filesystem visibility" — every WASI
     /// `path_open` returns `EBADF`.
     pub preopened_dirs: Vec<PreopenedDir>,
+    /// CPU + memory + wall-clock budget. See [`SandboxLimits`] for the
+    /// per-field semantics; the [`Default`] is a safe-by-default budget
+    /// (10M fuel, 16 pages = 1 MiB memory, 5s wall-clock).
+    pub limits: SandboxLimits,
 }

--- a/aa-sandbox/src/runtime.rs
+++ b/aa-sandbox/src/runtime.rs
@@ -292,4 +292,38 @@ mod tests {
             other => panic!("expected SandboxError::FilesystemBlocked, got {:?}", other),
         }
     }
+
+    /// Hand-authored WAT fixture exercising the fuel budget. `_start`
+    /// enters an infinite WebAssembly loop (`(loop (br 0))`); every
+    /// iteration consumes ~1 unit of wasmtime instruction fuel, so a
+    /// small `SandboxLimits::fuel` budget trips `Trap::OutOfFuel`
+    /// within microseconds.
+    const RUNAWAY_LOOP_WAT: &str = r#"
+        (module
+          (func (export "_start")
+            (loop $infinite (br $infinite))
+          )
+        )
+    "#;
+
+    #[test]
+    fn run_tool_kills_runaway_loop_with_cpu_timeout() {
+        let config = SandboxConfig {
+            limits: crate::policy::SandboxLimits {
+                fuel: 1_000,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let runtime = SandboxRuntime::new(config).expect("SandboxRuntime with low fuel must construct");
+        let wasm = wat::parse_str(RUNAWAY_LOOP_WAT).expect("runaway-loop WAT fixture must parse");
+
+        let result = runtime.run_tool(&wasm, &[]);
+
+        assert!(
+            matches!(result, Err(SandboxError::CpuTimeout)),
+            "expected SandboxError::CpuTimeout, got {:?}",
+            result,
+        );
+    }
 }

--- a/aa-sandbox/src/runtime.rs
+++ b/aa-sandbox/src/runtime.rs
@@ -326,4 +326,34 @@ mod tests {
             result,
         );
     }
+
+    /// Hand-authored WAT fixture exercising the memory-store limiter.
+    /// `_start` declares a 1-page initial memory and immediately tries
+    /// to grow it by 100 pages (= 6.4 MiB), well past the default
+    /// `SandboxLimits::memory_pages = 16` (1 MiB) cap. The
+    /// `MemoryLimit` `ResourceLimiter` returns `Err(MemoryExhaustedMarker)`
+    /// for the grow, which wasmtime surfaces as a trap.
+    const MEMORY_BOMB_WAT: &str = r#"
+        (module
+          (memory (export "memory") 1)
+          (func (export "_start")
+            (drop (memory.grow (i32.const 100)))
+          )
+        )
+    "#;
+
+    #[test]
+    fn run_tool_kills_memory_bomb_with_memory_exhausted() {
+        let runtime = SandboxRuntime::new(SandboxConfig::default())
+            .expect("SandboxRuntime with default memory cap must construct");
+        let wasm = wat::parse_str(MEMORY_BOMB_WAT).expect("memory-bomb WAT fixture must parse");
+
+        let result = runtime.run_tool(&wasm, &[]);
+
+        assert!(
+            matches!(result, Err(SandboxError::MemoryExhausted)),
+            "expected SandboxError::MemoryExhausted, got {:?}",
+            result,
+        );
+    }
 }

--- a/aa-sandbox/src/runtime.rs
+++ b/aa-sandbox/src/runtime.rs
@@ -18,7 +18,7 @@
 //! Fuel + memory-store limits land in AAASM-2018; ToolRegistry dispatch +
 //! audit-event emission land in AAASM-2019.
 
-use wasmtime::{Engine, Linker, Module, Store};
+use wasmtime::{Config, Engine, Linker, Module, Store, Trap};
 use wasmtime_wasi::p1::{self, WasiP1Ctx};
 use wasmtime_wasi::{DirPerms, FilePerms, I32Exit, WasiCtx};
 
@@ -60,7 +60,9 @@ impl SandboxRuntime {
     /// practice this only happens on a programming error — duplicate
     /// import name).
     pub fn new(config: SandboxConfig) -> Result<Self, SandboxError> {
-        let engine = Engine::default();
+        let mut engine_config = Config::new();
+        engine_config.consume_fuel(true);
+        let engine = Engine::new(&engine_config).map_err(|e| SandboxError::Wasmtime(e.to_string()))?;
         let mut linker: Linker<WasiP1Ctx> = Linker::new(&engine);
         p1::add_to_linker_sync(&mut linker, |cx| cx).map_err(|e| SandboxError::Wasmtime(e.to_string()))?;
         Ok(Self { engine, linker, config })
@@ -85,9 +87,11 @@ impl SandboxRuntime {
     ///   fixtures).
     /// * [`SandboxError::InvalidWasm`] if wasmtime cannot parse/validate
     ///   the module bytes.
-    /// * [`SandboxError::Wasmtime`] for any other trap; this is the
-    ///   fallback bucket that AAASM-2018 (fuel/limiter) narrows into
-    ///   `CpuTimeout` and `MemoryExhausted`.
+    /// * [`SandboxError::CpuTimeout`] if the guest exhausts its fuel
+    ///   budget (`Trap::OutOfFuel`).
+    /// * [`SandboxError::Wasmtime`] for any other trap (further
+    ///   narrowed by `MemoryExhausted` / `WallClockTimeout` mappings
+    ///   landing on this branch).
     pub fn run_tool(&self, wasm_bytes: &[u8], _args: &[u8]) -> Result<SandboxOutput, SandboxError> {
         let module =
             Module::from_binary(&self.engine, wasm_bytes).map_err(|e| SandboxError::InvalidWasm(e.to_string()))?;
@@ -105,6 +109,9 @@ impl SandboxRuntime {
         }
         let wasi = builder.build_p1();
         let mut store = Store::new(&self.engine, wasi);
+        store
+            .set_fuel(self.config.limits.fuel)
+            .map_err(|e| SandboxError::Wasmtime(e.to_string()))?;
 
         let instance = self
             .linker
@@ -123,6 +130,8 @@ impl SandboxRuntime {
                     } else {
                         Err(SandboxError::FilesystemBlocked { errno: *code as u32 })
                     }
+                } else if matches!(trap.downcast_ref::<Trap>(), Some(Trap::OutOfFuel)) {
+                    Err(SandboxError::CpuTimeout)
                 } else {
                     Err(SandboxError::Wasmtime(trap.to_string()))
                 }

--- a/aa-sandbox/src/runtime.rs
+++ b/aa-sandbox/src/runtime.rs
@@ -18,6 +18,9 @@
 //! Fuel + memory-store limits land in AAASM-2018; ToolRegistry dispatch +
 //! audit-event emission land in AAASM-2019.
 
+use std::sync::mpsc;
+use std::time::Duration;
+
 use wasmtime::{Config, Engine, Linker, Module, ResourceLimiter, Store, Trap};
 use wasmtime_wasi::p1::{self, WasiP1Ctx};
 use wasmtime_wasi::{DirPerms, FilePerms, I32Exit, WasiCtx};
@@ -112,6 +115,7 @@ impl SandboxRuntime {
     pub fn new(config: SandboxConfig) -> Result<Self, SandboxError> {
         let mut engine_config = Config::new();
         engine_config.consume_fuel(true);
+        engine_config.epoch_interruption(true);
         let engine = Engine::new(&engine_config).map_err(|e| SandboxError::Wasmtime(e.to_string()))?;
         let mut linker: Linker<StoreState> = Linker::new(&engine);
         p1::add_to_linker_sync(&mut linker, |s| &mut s.wasi).map_err(|e| SandboxError::Wasmtime(e.to_string()))?;
@@ -166,6 +170,32 @@ impl SandboxRuntime {
         store
             .set_fuel(self.config.limits.fuel)
             .map_err(|e| SandboxError::Wasmtime(e.to_string()))?;
+        store.set_epoch_deadline(1);
+        store.epoch_deadline_trap();
+
+        // Wall-clock watchdog — spawn a thread that fires
+        // `Engine::increment_epoch` after `wall_clock_ms` unless the call
+        // completes first. `Engine::increment_epoch` ticks the global
+        // counter; since this store armed `set_epoch_deadline(1)` against
+        // the engine's current epoch + 1, that single tick trips the
+        // deadline and traps the guest with `Trap::Interrupt`.
+        //
+        // The watchdog blocks on an mpsc channel with `recv_timeout` so
+        // the main thread can wake it early — keeps fast-completing
+        // calls from paying the full `wall_clock_ms` latency.
+        let (cancel_tx, cancel_rx) = mpsc::channel::<()>();
+        let watchdog = {
+            let engine = self.engine.clone();
+            let wall_clock_ms = self.config.limits.wall_clock_ms;
+            std::thread::spawn(move || {
+                if matches!(
+                    cancel_rx.recv_timeout(Duration::from_millis(wall_clock_ms)),
+                    Err(mpsc::RecvTimeoutError::Timeout)
+                ) {
+                    engine.increment_epoch();
+                }
+            })
+        };
 
         let instance = self
             .linker
@@ -175,7 +205,15 @@ impl SandboxRuntime {
             .get_typed_func::<(), ()>(&mut store, "_start")
             .map_err(|e| SandboxError::Wasmtime(e.to_string()))?;
 
-        match start.call(&mut store, ()) {
+        let call_result = start.call(&mut store, ());
+
+        // Cancel the watchdog and reap it. Sending on the cancel channel
+        // wakes the watchdog's `recv_timeout` immediately so `join()`
+        // returns without paying the remaining `wall_clock_ms`.
+        let _ = cancel_tx.send(());
+        let _ = watchdog.join();
+
+        match call_result {
             Ok(()) => Ok(SandboxOutput { exit_code: 0 }),
             Err(trap) => {
                 if let Some(I32Exit(code)) = trap.downcast_ref::<I32Exit>() {
@@ -186,6 +224,8 @@ impl SandboxRuntime {
                     }
                 } else if matches!(trap.downcast_ref::<Trap>(), Some(Trap::OutOfFuel)) {
                     Err(SandboxError::CpuTimeout)
+                } else if matches!(trap.downcast_ref::<Trap>(), Some(Trap::Interrupt)) {
+                    Err(SandboxError::WallClockTimeout)
                 } else if trap.downcast_ref::<MemoryExhaustedMarker>().is_some() {
                     Err(SandboxError::MemoryExhausted)
                 } else {

--- a/aa-sandbox/src/runtime.rs
+++ b/aa-sandbox/src/runtime.rs
@@ -18,12 +18,62 @@
 //! Fuel + memory-store limits land in AAASM-2018; ToolRegistry dispatch +
 //! audit-event emission land in AAASM-2019.
 
-use wasmtime::{Config, Engine, Linker, Module, Store, Trap};
+use wasmtime::{Config, Engine, Linker, Module, ResourceLimiter, Store, Trap};
 use wasmtime_wasi::p1::{self, WasiP1Ctx};
 use wasmtime_wasi::{DirPerms, FilePerms, I32Exit, WasiCtx};
 
 use crate::error::SandboxError;
 use crate::policy::SandboxConfig;
+
+/// Sentinel error type the [`MemoryLimit`] [`ResourceLimiter`] returns
+/// when a `memory.grow` would exceed the configured byte cap. The
+/// runtime's call-result branch downcasts to this type to surface
+/// [`SandboxError::MemoryExhausted`].
+#[derive(Debug)]
+struct MemoryExhaustedMarker;
+
+impl std::fmt::Display for MemoryExhaustedMarker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("sandbox memory store limit exceeded")
+    }
+}
+
+impl std::error::Error for MemoryExhaustedMarker {}
+
+/// Per-store linear-memory cap enforced via [`Store::limiter`].
+///
+/// `memory_growing` denies any grow that would push the guest above
+/// `max_bytes` by returning [`MemoryExhaustedMarker`] inside the
+/// `wasmtime::Error` channel — the wasmtime runtime then surfaces that
+/// error from the call's `start.call(...)` return value, which the
+/// runtime maps to [`SandboxError::MemoryExhausted`].
+struct MemoryLimit {
+    max_bytes: usize,
+}
+
+impl ResourceLimiter for MemoryLimit {
+    fn memory_growing(&mut self, _current: usize, desired: usize, _maximum: Option<usize>) -> wasmtime::Result<bool> {
+        if desired > self.max_bytes {
+            Err(wasmtime::Error::new(MemoryExhaustedMarker))
+        } else {
+            Ok(true)
+        }
+    }
+
+    fn table_growing(&mut self, _current: usize, _desired: usize, _maximum: Option<usize>) -> wasmtime::Result<bool> {
+        Ok(true)
+    }
+}
+
+/// Per-store state combining the WASI context with the memory limiter.
+///
+/// Wraps the [`WasiP1Ctx`] previously held directly by the store; the
+/// linker's WASI projection closure now returns `&mut state.wasi`, and
+/// `Store::limiter` projects to `&mut state.limiter`.
+struct StoreState {
+    wasi: WasiP1Ctx,
+    limiter: MemoryLimit,
+}
 
 /// Successful sandboxed-tool invocation outcome.
 ///
@@ -48,7 +98,7 @@ pub struct SandboxOutput {
 /// leaks between tools.
 pub struct SandboxRuntime {
     engine: Engine,
-    linker: Linker<WasiP1Ctx>,
+    linker: Linker<StoreState>,
     config: SandboxConfig,
 }
 
@@ -63,8 +113,8 @@ impl SandboxRuntime {
         let mut engine_config = Config::new();
         engine_config.consume_fuel(true);
         let engine = Engine::new(&engine_config).map_err(|e| SandboxError::Wasmtime(e.to_string()))?;
-        let mut linker: Linker<WasiP1Ctx> = Linker::new(&engine);
-        p1::add_to_linker_sync(&mut linker, |cx| cx).map_err(|e| SandboxError::Wasmtime(e.to_string()))?;
+        let mut linker: Linker<StoreState> = Linker::new(&engine);
+        p1::add_to_linker_sync(&mut linker, |s| &mut s.wasi).map_err(|e| SandboxError::Wasmtime(e.to_string()))?;
         Ok(Self { engine, linker, config })
     }
 
@@ -108,7 +158,11 @@ impl SandboxRuntime {
                 .map_err(|e| SandboxError::Wasmtime(e.to_string()))?;
         }
         let wasi = builder.build_p1();
-        let mut store = Store::new(&self.engine, wasi);
+        let limiter = MemoryLimit {
+            max_bytes: (self.config.limits.memory_pages as usize) * 65_536,
+        };
+        let mut store = Store::new(&self.engine, StoreState { wasi, limiter });
+        store.limiter(|s| &mut s.limiter);
         store
             .set_fuel(self.config.limits.fuel)
             .map_err(|e| SandboxError::Wasmtime(e.to_string()))?;
@@ -132,6 +186,8 @@ impl SandboxRuntime {
                     }
                 } else if matches!(trap.downcast_ref::<Trap>(), Some(Trap::OutOfFuel)) {
                     Err(SandboxError::CpuTimeout)
+                } else if trap.downcast_ref::<MemoryExhaustedMarker>().is_some() {
+                    Err(SandboxError::MemoryExhausted)
                 } else {
                     Err(SandboxError::Wasmtime(trap.to_string()))
                 }


### PR DESCRIPTION
## Description

Implement the CPU + memory + wall-clock half of F116 ST-W (parent Story: AAASM-1965). Builds on the AAASM-2017 WASI runtime and adds three independently-enforced kill budgets to `aa-sandbox`:

* **CPU (fuel)** — `Engine` is now built with `Config::consume_fuel(true)`. Per call, `Store::set_fuel(self.config.limits.fuel)` is armed before `start.call`. Fuel exhaustion surfaces as `Trap::OutOfFuel` and maps to `SandboxError::CpuTimeout`.
* **Memory** — A new private `MemoryLimit` struct implements `wasmtime::ResourceLimiter`; its `memory_growing` returns a sentinel `MemoryExhaustedMarker` error when the requested grow would push the guest above `memory_pages * 64 KiB`. The runtime registers it via `Store::limiter(|s| &mut s.limiter)` per call; mapping → `SandboxError::MemoryExhausted`.
* **Wall-clock** — `Config::epoch_interruption(true)` enables epoch traps. Per call, the runtime arms `Store::set_epoch_deadline(1)` + `epoch_deadline_trap()` and spawns a watchdog thread that blocks on an mpsc channel via `recv_timeout(wall_clock_ms)`. If the channel times out, it calls `Engine::increment_epoch()` — trapping the guest with `Trap::Interrupt`. Fast-completing calls send on the cancel channel after `start.call`, so the watchdog wakes immediately and join doesn't pay the remaining `wall_clock_ms`. Mapping → `SandboxError::WallClockTimeout`.

### Type additions

* `SandboxError`: `CpuTimeout`, `WallClockTimeout`, `MemoryExhausted` (numbered after the existing `FilesystemBlocked` / `InvalidWasm` / `Wasmtime`).
* `SandboxLimits { fuel: u64, memory_pages: u32, wall_clock_ms: u64 }` with a safe-by-default `Default` (10M fuel, 16 pages = 1 MiB, 5 s wall-clock). Added to `SandboxConfig` as a `limits` field.

### Internal refactors

* `Store` state changed from `WasiP1Ctx` to `StoreState { wasi: WasiP1Ctx, limiter: MemoryLimit }` so the store can hold the per-call memory limiter alongside the WASI context. Linker projection switched from `|cx| cx` to `|s| &mut s.wasi`; `Linker<StoreState>` accordingly.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

`aa-sandbox` remains workspace-internal with no external consumers (AAASM-2019 wires the dispatch glue).

## Related Issues

- Related Jira ticket: **AAASM-2018** (sub-task of parent Story **AAASM-1965**)
- Builds on merged AAASM-2015 (#805) / AAASM-2016 (#806) / AAASM-2017 (#808)

## Testing

`cargo nextest run -p aa-sandbox` is now **3 tests, 3 passed**:

| Test | Asserts |
|---|---|
| `run_tool_blocks_path_open_outside_allowlist` (AAASM-2017) | Empty preopens + `path_open("/etc/passwd")` → `FilesystemBlocked { errno }` |
| `run_tool_kills_runaway_loop_with_cpu_timeout` (new) | Tiny fuel budget + `(loop (br 0))` → `CpuTimeout` |
| `run_tool_kills_memory_bomb_with_memory_exhausted` (new) | Default 16-page cap + `memory.grow(100)` → `MemoryExhausted` |

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required

Local validation:

```text
cargo nextest run -p aa-sandbox        # 3/3 pass
cargo clippy -p aa-sandbox -- -D warnings  # clean
cargo deny check                        # advisories ok, bans ok, licenses ok, sources ok
cargo doc -p aa-sandbox --no-deps       # clean
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (every new type / variant carries a doc-comment naming the AAASM-XXXX ticket for its scope + the wasmtime primitive it wraps)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Commit log

| Commit | Scope |
|---|---|
| `46d280bd` | ✨ (aa-sandbox/error): Add CpuTimeout / WallClockTimeout / MemoryExhausted variants |
| `09b428c3` | ✨ (aa-sandbox/policy): Add SandboxLimits with fuel + memory_pages + wall_clock_ms |
| `cd5b57d1` | ✨ (aa-sandbox/runtime): Enable consume_fuel + map Trap::OutOfFuel to CpuTimeout |
| `8ab95ece` | ✨ (aa-sandbox/runtime): Wire Store::limiter for memory cap; map to MemoryExhausted |
| `a0a9fc99` | ✨ (aa-sandbox/runtime): Wire wall-clock watchdog; map Trap::Interrupt to WallClockTimeout |
| `6d3fe8ec` | ✅ (aa-sandbox/runtime): Add WAT fixture test for runaway-loop CpuTimeout |
| `a84f8fd7` | ✅ (aa-sandbox/runtime): Add WAT fixture test for memory-bomb MemoryExhausted |