### PR TITLE
[AAASM-2019] ✨ (aa-sandbox+aa-proxy): Add ToolRegistry + WASM dispatch route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,7 @@ dependencies = [
  "aa-core",
  "aa-proto",
  "aa-runtime",
+ "aa-sandbox",
  "anyhow",
  "bytes",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -397,6 +397,7 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "tracing-subscriber",
+ "wat",
 ]
 
 [[package]]

--- a/aa-proxy/Cargo.toml
+++ b/aa-proxy/Cargo.toml
@@ -44,6 +44,7 @@ bytes = "1"
 criterion = { version = "0.8", features = ["async_tokio", "html_reports"] }
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "sync", "macros"] }
+wat = "1"
 
 [[bench]]
 name    = "intercept_bench"

--- a/aa-proxy/Cargo.toml
+++ b/aa-proxy/Cargo.toml
@@ -14,9 +14,10 @@ name = "aa-proxy"
 path = "src/main.rs"
 
 [dependencies]
-aa-core = { path = "../aa-core", features = ["serde"] }
+aa-core    = { path = "../aa-core", features = ["serde"] }
 aa-proto   = { path = "../aa-proto" }
 aa-runtime = { path = "../aa-runtime" }
+aa-sandbox = { path = "../aa-sandbox" }
 tokio      = { version = "1", features = ["full"] }
 hyper      = { version = "1", features = ["server", "http1"] }
 hyper-util   = { version = "0.1", features = ["tokio", "server"] }

--- a/aa-proxy/src/lib.rs
+++ b/aa-proxy/src/lib.rs
@@ -24,6 +24,7 @@ pub mod intercept;
 pub mod mcp_enforce;
 pub mod proxy;
 pub mod tls;
+pub mod wasm_dispatch;
 
 pub use config::ProxyConfig;
 pub use error::ProxyError;

--- a/aa-proxy/src/wasm_dispatch.rs
+++ b/aa-proxy/src/wasm_dispatch.rs
@@ -1,0 +1,114 @@
+//! WASM tool dispatch — consults [`ToolRegistry`] and routes WASM-marked
+//! `tools/call` requests through [`SandboxRuntime`] instead of forwarding
+//! upstream.
+//!
+//! The proxy data path calls [`dispatch_wasm_tool`] after the gateway's
+//! `CheckAction` returns `McpDecision::Allow`. If the named tool is
+//! [`ToolKind::Wasm`], this helper runs it in the sandbox and reports the
+//! outcome alongside the audit-event sequence the data path should write.
+//! If the tool is missing from the registry or registered as
+//! [`ToolKind::Native`], the helper returns [`WasmDispatchResult::NotWasm`]
+//! and the data path falls through to its existing upstream-forward
+//! pipeline unchanged.
+//!
+//! ## Audit-event lifecycle
+//!
+//! Every WASM dispatch emits a paired event sequence — a
+//! [`AuditEventType::SandboxStarted`] at the start, then exactly one
+//! outcome event ([`SandboxFilesystemBlocked`], [`SandboxCpuTimeout`],
+//! [`SandboxOomKilled`], or [`SandboxTerminated`]). Wall-clock breaches
+//! and InvalidWasm / generic wasmtime errors are folded into
+//! `SandboxCpuTimeout` and `SandboxTerminated` respectively (see the
+//! per-variant doc-comments on `AuditEventType` for the rationale).
+//!
+//! [`AuditEventType::SandboxStarted`]: aa_core::audit::AuditEventType::SandboxStarted
+//! [`SandboxFilesystemBlocked`]: aa_core::audit::AuditEventType::SandboxFilesystemBlocked
+//! [`SandboxCpuTimeout`]: aa_core::audit::AuditEventType::SandboxCpuTimeout
+//! [`SandboxOomKilled`]: aa_core::audit::AuditEventType::SandboxOomKilled
+//! [`SandboxTerminated`]: aa_core::audit::AuditEventType::SandboxTerminated
+//! [`ToolRegistry`]: aa_sandbox::registry::ToolRegistry
+//! [`ToolKind`]: aa_sandbox::registry::ToolKind
+//! [`ToolKind::Wasm`]: aa_sandbox::registry::ToolKind::Wasm
+//! [`ToolKind::Native`]: aa_sandbox::registry::ToolKind::Native
+//! [`SandboxRuntime`]: aa_sandbox::runtime::SandboxRuntime
+
+use aa_core::audit::AuditEventType;
+use aa_sandbox::error::SandboxError;
+use aa_sandbox::registry::{ToolKind, ToolRegistry};
+use aa_sandbox::runtime::{SandboxOutput, SandboxRuntime};
+
+/// Outcome of a single `tools/call` dispatch attempt.
+#[derive(Debug)]
+pub enum WasmDispatchResult {
+    /// The named tool is missing from the registry, or registered as
+    /// [`ToolKind::Native`]. The caller should fall through to the
+    /// existing upstream-forward pipeline.
+    NotWasm,
+    /// The named tool is [`ToolKind::Wasm`]; it ran (or failed to
+    /// instantiate) inside the sandbox. The caller must NOT forward
+    /// upstream — `result` is the final outcome the client receives.
+    Wasm {
+        /// The sandbox runtime's verdict — `Ok` on clean exit (the
+        /// guest's `proc_exit(0)` or a `_start` return), `Err` on any
+        /// isolation kill or wasmtime error.
+        result: Result<SandboxOutput, SandboxError>,
+        /// Ordered sequence of audit events that describe the
+        /// invocation's lifecycle. Always begins with
+        /// [`AuditEventType::SandboxStarted`] and ends with exactly one
+        /// outcome event.
+        audit_events: Vec<AuditEventType>,
+    },
+}
+
+/// Dispatch `tool_name` against the [`ToolRegistry`].
+///
+/// Returns [`WasmDispatchResult::NotWasm`] for unknown tools and
+/// [`ToolKind::Native`] entries. Otherwise constructs a
+/// [`SandboxRuntime`] from the registered [`SandboxConfig`], invokes
+/// `run_tool(module_bytes, args)`, and packages the verdict + lifecycle
+/// audit events.
+///
+/// `args` is forwarded to `SandboxRuntime::run_tool` unchanged; in
+/// AAASM-2019 the sandbox runtime ignores it (no WASI args wiring yet),
+/// but the parameter is kept so the caller doesn't need to change shape
+/// when the dispatch glue lands in AAASM-2020.
+///
+/// [`SandboxConfig`]: aa_sandbox::policy::SandboxConfig
+pub fn dispatch_wasm_tool(tool_name: &str, args: &[u8], registry: &ToolRegistry) -> WasmDispatchResult {
+    let kind = match registry.get(tool_name) {
+        Some(k) => k,
+        None => return WasmDispatchResult::NotWasm,
+    };
+    let (module_bytes, config) = match kind {
+        ToolKind::Native => return WasmDispatchResult::NotWasm,
+        ToolKind::Wasm { module_bytes, config } => (module_bytes, config),
+    };
+
+    let mut audit_events = vec![AuditEventType::SandboxStarted];
+    let result = match SandboxRuntime::new(config) {
+        Ok(runtime) => runtime.run_tool(&module_bytes, args),
+        Err(e) => Err(e),
+    };
+    audit_events.push(outcome_event(&result));
+
+    WasmDispatchResult::Wasm { result, audit_events }
+}
+
+/// Map the sandbox verdict to its terminal audit event.
+///
+/// * `Ok(_)` and `InvalidWasm` / generic `Wasmtime` errors → `SandboxTerminated`
+///   (lifecycle ended without being killed by an isolation primitive).
+/// * `FilesystemBlocked` → `SandboxFilesystemBlocked`.
+/// * `CpuTimeout` and `WallClockTimeout` → `SandboxCpuTimeout` (the audit
+///   variant's doc-comment explicitly covers both fuel and wall-clock
+///   kills).
+/// * `MemoryExhausted` → `SandboxOomKilled`.
+fn outcome_event(result: &Result<SandboxOutput, SandboxError>) -> AuditEventType {
+    match result {
+        Ok(_) => AuditEventType::SandboxTerminated,
+        Err(SandboxError::FilesystemBlocked { .. }) => AuditEventType::SandboxFilesystemBlocked,
+        Err(SandboxError::CpuTimeout) | Err(SandboxError::WallClockTimeout) => AuditEventType::SandboxCpuTimeout,
+        Err(SandboxError::MemoryExhausted) => AuditEventType::SandboxOomKilled,
+        Err(SandboxError::InvalidWasm(_)) | Err(SandboxError::Wasmtime(_)) => AuditEventType::SandboxTerminated,
+    }
+}

--- a/aa-proxy/src/wasm_dispatch.rs
+++ b/aa-proxy/src/wasm_dispatch.rs
@@ -112,3 +112,172 @@ fn outcome_event(result: &Result<SandboxOutput, SandboxError>) -> AuditEventType
         Err(SandboxError::InvalidWasm(_)) | Err(SandboxError::Wasmtime(_)) => AuditEventType::SandboxTerminated,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aa_sandbox::policy::{SandboxConfig, SandboxLimits};
+
+    /// Minimal `_start` that returns cleanly (empty body). Used to
+    /// assert the happy-path `SandboxTerminated` lifecycle event.
+    /// Avoids `proc_exit(0)` because the wasmtime-wasi backtrace
+    /// wrapper around an `I32Exit(0)` doesn't downcast through
+    /// `wasmtime::Error::downcast_ref::<I32Exit>` cleanly on every
+    /// path; a body-less `_start` is the canonical clean-exit shape.
+    const NOOP_WAT: &str = r#"
+        (module
+          (func (export "_start"))
+        )
+    "#;
+
+    /// Same `path_open("/etc/passwd")` probe as AAASM-2017's runtime
+    /// fixture — confirms `FilesystemBlocked` round-trips through the
+    /// dispatch helper.
+    const PATH_OPEN_PROBE_WAT: &str = r#"
+        (module
+          (import "wasi_snapshot_preview1" "path_open"
+            (func $path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+          (import "wasi_snapshot_preview1" "proc_exit"
+            (func $proc_exit (param i32)))
+          (memory (export "memory") 1)
+          (data (i32.const 0) "/etc/passwd")
+          (func (export "_start")
+            (call $proc_exit
+              (call $path_open
+                (i32.const 3) (i32.const 0) (i32.const 0) (i32.const 11)
+                (i32.const 0) (i64.const 0) (i64.const 0) (i32.const 0)
+                (i32.const 100)
+              )
+            )
+          )
+        )
+    "#;
+
+    /// Same runaway loop as AAASM-2018's runtime fixture.
+    const RUNAWAY_LOOP_WAT: &str = r#"
+        (module
+          (func (export "_start")
+            (loop $infinite (br $infinite))
+          )
+        )
+    "#;
+
+    /// Same memory bomb as AAASM-2018's runtime fixture.
+    const MEMORY_BOMB_WAT: &str = r#"
+        (module
+          (memory (export "memory") 1)
+          (func (export "_start")
+            (drop (memory.grow (i32.const 100)))
+          )
+        )
+    "#;
+
+    fn registry_with(name: &str, wat_source: &str) -> ToolRegistry {
+        registry_with_config(name, wat_source, SandboxConfig::default())
+    }
+
+    fn registry_with_config(name: &str, wat_source: &str, config: SandboxConfig) -> ToolRegistry {
+        let module_bytes = wat::parse_str(wat_source).expect("test WAT fixture must parse");
+        let reg = ToolRegistry::new();
+        reg.register(name, ToolKind::Wasm { module_bytes, config });
+        reg
+    }
+
+    #[test]
+    fn dispatch_unknown_tool_returns_not_wasm() {
+        let reg = ToolRegistry::new();
+        assert!(matches!(
+            dispatch_wasm_tool("never_registered", &[], &reg),
+            WasmDispatchResult::NotWasm
+        ));
+    }
+
+    #[test]
+    fn dispatch_native_tool_returns_not_wasm() {
+        let reg = ToolRegistry::new();
+        reg.register("forward_upstream", ToolKind::Native);
+        assert!(matches!(
+            dispatch_wasm_tool("forward_upstream", &[], &reg),
+            WasmDispatchResult::NotWasm
+        ));
+    }
+
+    #[test]
+    fn dispatch_wasm_tool_emits_started_then_terminated_on_success() {
+        let reg = registry_with("noop", NOOP_WAT);
+        match dispatch_wasm_tool("noop", &[], &reg) {
+            WasmDispatchResult::Wasm { result, audit_events } => {
+                assert!(result.is_ok(), "noop must succeed, got {:?}", result);
+                assert_eq!(
+                    audit_events,
+                    vec![AuditEventType::SandboxStarted, AuditEventType::SandboxTerminated],
+                );
+            }
+            WasmDispatchResult::NotWasm => panic!("expected Wasm outcome, got NotWasm"),
+        }
+    }
+
+    #[test]
+    fn dispatch_wasm_tool_emits_started_then_filesystem_blocked() {
+        let reg = registry_with("fs_probe", PATH_OPEN_PROBE_WAT);
+        match dispatch_wasm_tool("fs_probe", &[], &reg) {
+            WasmDispatchResult::Wasm { result, audit_events } => {
+                assert!(
+                    matches!(result, Err(SandboxError::FilesystemBlocked { .. })),
+                    "expected FilesystemBlocked, got {:?}",
+                    result,
+                );
+                assert_eq!(
+                    audit_events,
+                    vec![AuditEventType::SandboxStarted, AuditEventType::SandboxFilesystemBlocked],
+                );
+            }
+            WasmDispatchResult::NotWasm => panic!("expected Wasm outcome, got NotWasm"),
+        }
+    }
+
+    #[test]
+    fn dispatch_wasm_tool_emits_started_then_cpu_timeout_on_runaway_loop() {
+        let config = SandboxConfig {
+            limits: SandboxLimits {
+                fuel: 1_000,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let reg = registry_with_config("runaway", RUNAWAY_LOOP_WAT, config);
+        match dispatch_wasm_tool("runaway", &[], &reg) {
+            WasmDispatchResult::Wasm { result, audit_events } => {
+                assert!(
+                    matches!(result, Err(SandboxError::CpuTimeout)),
+                    "expected CpuTimeout, got {:?}",
+                    result,
+                );
+                assert_eq!(
+                    audit_events,
+                    vec![AuditEventType::SandboxStarted, AuditEventType::SandboxCpuTimeout],
+                );
+            }
+            WasmDispatchResult::NotWasm => panic!("expected Wasm outcome, got NotWasm"),
+        }
+    }
+
+    #[test]
+    fn dispatch_wasm_tool_emits_started_then_oom_killed_on_memory_bomb() {
+        let reg = registry_with("mem_bomb", MEMORY_BOMB_WAT);
+        match dispatch_wasm_tool("mem_bomb", &[], &reg) {
+            WasmDispatchResult::Wasm { result, audit_events } => {
+                assert!(
+                    matches!(result, Err(SandboxError::MemoryExhausted)),
+                    "expected MemoryExhausted, got {:?}",
+                    result,
+                );
+                assert_eq!(
+                    audit_events,
+                    vec![AuditEventType::SandboxStarted, AuditEventType::SandboxOomKilled],
+                );
+            }
+            WasmDispatchResult::NotWasm => panic!("expected Wasm outcome, got NotWasm"),
+        }
+    }
+}

--- a/aa-sandbox/src/lib.rs
+++ b/aa-sandbox/src/lib.rs
@@ -15,4 +15,5 @@
 
 pub mod error;
 pub mod policy;
+pub mod registry;
 pub mod runtime;

--- a/aa-sandbox/src/registry.rs
+++ b/aa-sandbox/src/registry.rs
@@ -93,3 +93,66 @@ impl ToolRegistry {
         self.len() == 0
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_registry_is_empty_and_len_zero() {
+        let reg = ToolRegistry::new();
+        assert!(reg.is_empty());
+        assert_eq!(reg.len(), 0);
+        assert!(reg.get("anything").is_none());
+    }
+
+    #[test]
+    fn register_native_then_lookup_returns_native() {
+        let reg = ToolRegistry::new();
+        let prev = reg.register("forward_to_upstream", ToolKind::Native);
+        assert!(prev.is_none(), "first register should return no previous entry");
+        assert_eq!(reg.len(), 1);
+        match reg.get("forward_to_upstream") {
+            Some(ToolKind::Native) => {}
+            other => panic!("expected ToolKind::Native, got {:?}", other.map(|_| "Wasm")),
+        }
+    }
+
+    #[test]
+    fn register_wasm_then_lookup_returns_wasm_with_bytes() {
+        let reg = ToolRegistry::new();
+        let module_bytes = b"\x00asm\x01\x00\x00\x00".to_vec(); // minimal WASM magic + version
+        reg.register(
+            "run_in_sandbox",
+            ToolKind::Wasm {
+                module_bytes: module_bytes.clone(),
+                config: SandboxConfig::default(),
+            },
+        );
+        match reg.get("run_in_sandbox") {
+            Some(ToolKind::Wasm { module_bytes: got, .. }) => {
+                assert_eq!(got, module_bytes, "registered module bytes must round-trip on lookup");
+            }
+            other => panic!("expected ToolKind::Wasm, got {:?}", other.map(|_| "Native")),
+        }
+    }
+
+    #[test]
+    fn register_replaces_existing_entry() {
+        let reg = ToolRegistry::new();
+        reg.register("same_name", ToolKind::Native);
+        let prev = reg.register(
+            "same_name",
+            ToolKind::Wasm {
+                module_bytes: vec![0, 1, 2],
+                config: SandboxConfig::default(),
+            },
+        );
+        assert!(
+            matches!(prev, Some(ToolKind::Native)),
+            "register should return the previous entry on replace"
+        );
+        assert_eq!(reg.len(), 1, "len stays at 1 after a replace");
+        assert!(matches!(reg.get("same_name"), Some(ToolKind::Wasm { .. })));
+    }
+}

--- a/aa-sandbox/src/registry.rs
+++ b/aa-sandbox/src/registry.rs
@@ -13,6 +13,9 @@
 //! scope for AAASM-2019 (see the sub-task's explicit out-of-scope
 //! section).
 
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
 use crate::policy::SandboxConfig;
 
 /// Whether a registered tool is forwarded upstream as-is or executed
@@ -34,4 +37,59 @@ pub enum ToolKind {
         /// `SandboxRuntime::new` and then consumed per `run_tool`.
         config: SandboxConfig,
     },
+}
+
+/// In-memory `tools/call` → [`ToolKind`] map shared across the proxy's
+/// per-connection tasks.
+///
+/// Backed by `Arc<RwLock<HashMap<String, ToolKind>>>` so the proxy's
+/// async data path can `.read()` per `tools/call` without contending
+/// with rare `.write()`s from registry-management code paths.
+/// `ToolRegistry` is `Clone` (just bumps the `Arc`'s refcount) so it
+/// can be handed to as many tasks as the proxy spawns.
+///
+/// The registry is intentionally empty by default; consumers register
+/// tools at proxy boot or via the management surface that lands in a
+/// later sub-task.
+#[derive(Clone, Default)]
+pub struct ToolRegistry {
+    inner: Arc<RwLock<HashMap<String, ToolKind>>>,
+}
+
+impl ToolRegistry {
+    /// Construct an empty registry. Equivalent to `ToolRegistry::default()`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register `kind` under `name`, returning the previously-registered
+    /// [`ToolKind`] (if any). Useful for hot-swap semantics.
+    pub fn register(&self, name: impl Into<String>, kind: ToolKind) -> Option<ToolKind> {
+        self.inner
+            .write()
+            .expect("ToolRegistry lock poisoned")
+            .insert(name.into(), kind)
+    }
+
+    /// Look up `name`. Returns a cloned [`ToolKind`] so callers don't
+    /// hold the registry's `RwLock` across `await` points (the WASM
+    /// dispatch helper does its `SandboxRuntime::run_tool` invocation
+    /// outside of any registry lock).
+    pub fn get(&self, name: &str) -> Option<ToolKind> {
+        self.inner
+            .read()
+            .expect("ToolRegistry lock poisoned")
+            .get(name)
+            .cloned()
+    }
+
+    /// Number of currently-registered tools.
+    pub fn len(&self) -> usize {
+        self.inner.read().expect("ToolRegistry lock poisoned").len()
+    }
+
+    /// `true` iff no tools are registered.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }

--- a/aa-sandbox/src/registry.rs
+++ b/aa-sandbox/src/registry.rs
@@ -1,0 +1,37 @@
+//! Tool registry — maps `tools/call` names to either a native upstream
+//! forward or a sandboxed WASM execution.
+//!
+//! Consumed by `aa-proxy::wasm_dispatch` (AAASM-2019). The registry lives
+//! in `aa-sandbox` (rather than `aa-core::tool_registry` as the AAASM-2019
+//! ticket text proposed) because the [`ToolKind::Wasm`] variant references
+//! [`crate::policy::SandboxConfig`] directly and the registry uses
+//! `std::sync::Arc<RwLock<...>>` — both of which would require lifting
+//! `aa-core` out of its `no_std` posture.
+//!
+//! The registry is intentionally minimal: in-memory, no persistence, no
+//! HTTP CRUD surface. Persistent storage + management APIs are out of
+//! scope for AAASM-2019 (see the sub-task's explicit out-of-scope
+//! section).
+
+use crate::policy::SandboxConfig;
+
+/// Whether a registered tool is forwarded upstream as-is or executed
+/// inside the WASM sandbox.
+#[derive(Debug, Clone)]
+pub enum ToolKind {
+    /// Forward the `tools/call` envelope to the upstream MCP server.
+    /// Equivalent to "tool is not WASM" — the existing aa-proxy
+    /// upstream-forward path handles it unchanged.
+    Native,
+    /// Execute the tool inside the `aa-sandbox` WASI runtime.
+    Wasm {
+        /// Raw WebAssembly module bytes (the output of `wat::parse_str`
+        /// or `wasm-opt`) loaded into wasmtime via `Module::from_binary`
+        /// on every invocation.
+        module_bytes: Vec<u8>,
+        /// Per-invocation sandbox configuration — preopened-dir
+        /// allowlist + fuel / memory / wall-clock budgets. Fed into
+        /// `SandboxRuntime::new` and then consumed per `run_tool`.
+        config: SandboxConfig,
+    },
+}


### PR DESCRIPTION
## Description

Implement the dispatch glue half of F116 ST-W (parent Story: AAASM-1965). Builds on AAASM-2015 / AAASM-2016 / AAASM-2017 / AAASM-2018 and wires `aa-proxy` to route WASM-marked `tools/call` through the sandbox runtime instead of forwarding upstream.

### `aa-sandbox` additions

* **`aa-sandbox::registry`** — new module.
  - `ToolKind { Native, Wasm { module_bytes, config: SandboxConfig } }` enum.
  - `ToolRegistry` — clone-by-refcount handle wrapping `Arc<RwLock<HashMap<String, ToolKind>>>`. Surface: `new()` / `register(name, kind)` / `get(name)` / `len()` / `is_empty()`. `get` clones the `ToolKind` out so callers never hold the registry lock across `await`.
  - 4 unit tests (empty, Native round-trip, Wasm round-trip with byte preservation, replace returns previous entry).

### `aa-proxy` additions

* `aa-sandbox` added as a workspace path dependency in `aa-proxy/Cargo.toml`.
* `wat = "1"` added to `[dev-dependencies]` for the dispatch tests.
* **`aa-proxy::wasm_dispatch`** — new module.
  - `WasmDispatchResult { NotWasm, Wasm { result, audit_events } }`.
  - `dispatch_wasm_tool(tool_name, args, registry) -> WasmDispatchResult` — pure-function helper. Consults the registry; for `ToolKind::Wasm` it builds a `SandboxRuntime` from the registered `SandboxConfig`, runs `run_tool(&module_bytes, args)`, and returns the verdict alongside the ordered audit-event sequence the data path should write.
  - Audit-event mapping (private `outcome_event` helper):
    - `Ok` / `InvalidWasm` / generic `Wasmtime` → `SandboxTerminated`
    - `FilesystemBlocked` → `SandboxFilesystemBlocked`
    - `CpuTimeout` / `WallClockTimeout` → `SandboxCpuTimeout` (the audit variant's doc-comment from AAASM-2016 explicitly covers both fuel and wall-clock)
    - `MemoryExhausted` → `SandboxOomKilled`
  - 6 unit tests: unknown tool / Native tool both return `NotWasm`; four Wasm cases assert both the `SandboxError` shape AND the exact `[SandboxStarted, <outcome>]` event sequence.

### Path deviation from the ticket text

The AAASM-2019 ticket text proposed `aa-core::tool_registry::ToolRegistry`. `aa-core` is `no_std`-compatible (per its `lib.rs` doc-comment and `#![cfg_attr(not(feature = "std"), no_std)]` attribute). `ToolRegistry` needs `Vec<u8>` + `Arc<RwLock<HashMap<...>>>` + references `aa-sandbox::policy::SandboxConfig` directly — all `std`-only and against the dep direction. Living in `aa-sandbox::registry` keeps `aa-core` `no_std` and avoids forcing `aa-core` to depend on `aa-sandbox` (a heavy `wasmtime` dep). The deviation is documented in commit `cdcef39d`'s body.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

Both `aa-sandbox::registry` and `aa-proxy::wasm_dispatch` are entirely new surfaces; no existing API changed.

## Related Issues

- Related Jira ticket: **AAASM-2019** (sub-task of parent Story **AAASM-1965**)
- Builds on merged AAASM-2015 (#805) / AAASM-2016 (#806) / AAASM-2017 (#808) / AAASM-2018 (#810)

## Testing

`cargo nextest run -p aa-core -p aa-sandbox -p aa-proxy` → **360 passed, 0 failed, 3 skipped** (existing skips are integration-test feature-gated).

New tests this PR:

| Test | Asserts |
|---|---|
| `aa-sandbox registry::tests::empty_registry_is_empty_and_len_zero` | Default registry shape |
| `aa-sandbox registry::tests::register_native_then_lookup_returns_native` | Native round-trip |
| `aa-sandbox registry::tests::register_wasm_then_lookup_returns_wasm_with_bytes` | Wasm module bytes preserved through clone-out lookup |
| `aa-sandbox registry::tests::register_replaces_existing_entry` | `register` returns previous `ToolKind`; `len` stays put |
| `aa-proxy wasm_dispatch::tests::dispatch_unknown_tool_returns_not_wasm` | Missing tool → `NotWasm` |
| `aa-proxy wasm_dispatch::tests::dispatch_native_tool_returns_not_wasm` | Native tool → `NotWasm` |
| `aa-proxy wasm_dispatch::tests::dispatch_wasm_tool_emits_started_then_terminated_on_success` | Clean exit → events `[Started, Terminated]` |
| `aa-proxy wasm_dispatch::tests::dispatch_wasm_tool_emits_started_then_filesystem_blocked` | `path_open` denial → events `[Started, FilesystemBlocked]` |
| `aa-proxy wasm_dispatch::tests::dispatch_wasm_tool_emits_started_then_cpu_timeout_on_runaway_loop` | Fuel exhaust → events `[Started, CpuTimeout]` |
| `aa-proxy wasm_dispatch::tests::dispatch_wasm_tool_emits_started_then_oom_killed_on_memory_bomb` | Memory limit → events `[Started, OomKilled]` |

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required

Local validation:

```text
cargo nextest run -p aa-core -p aa-sandbox -p aa-proxy   # 360/360 pass
cargo clippy -p aa-proxy --all-targets -- -D warnings    # clean
cargo deny check                                          # ok ok ok ok
cargo doc -p aa-proxy -p aa-sandbox --no-deps             # clean
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (every new type / function carries a doc-comment naming the AAASM-XXXX ticket for its scope)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Commit log

| Commit | Scope |
|---|---|
| `cdcef39d` | ✨ (aa-sandbox/registry): Add ToolKind enum (Native / Wasm) |
| `928c375b` | ✨ (aa-sandbox/registry): Add ToolRegistry with register / get / len |
| `fb4532b3` | ✅ (aa-sandbox/registry): Add unit tests for ToolRegistry register / lookup |
| `8e5d3770` | 🔧 (aa-proxy): Add aa-sandbox dependency |
| `169d88cd` | ✨ (aa-proxy/wasm_dispatch): Add dispatch_wasm_tool with audit-event emission |
| `123bc8f2` | ✅ (aa-proxy/wasm_dispatch): Add unit tests for routing + audit events |