### PR TITLE
[AAASM-2022] ✨ (aa-gateway/budget): Wire explicit Org-tier budget enforcement

### DIFF
--- a/aa-gateway/src/budget/rollup.rs
+++ b/aa-gateway/src/budget/rollup.rs
@@ -145,7 +145,7 @@ mod tests {
     fn tracker_with_spend(seed: &[(AgentId, Option<&str>, Decimal)]) -> BudgetTracker {
         let tracker = BudgetTracker::new(PricingTable::default_table(), None, None, chrono_tz::UTC);
         for (agent_id, team_id, amount) in seed {
-            tracker.record_raw_spend(*agent_id, *team_id, *amount);
+            tracker.record_raw_spend(*agent_id, *team_id, None, *amount);
         }
         tracker
     }

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -153,6 +153,20 @@ impl BudgetTracker {
         self
     }
 
+    /// AAASM-2022 — Set the per-org daily spend limit in USD. Enforced in
+    /// `record_cost` for every org independently of how teams within the
+    /// org are named.
+    pub fn with_org_daily_limit(mut self, limit: Decimal) -> Self {
+        self.org_daily_limit_usd = Some(limit);
+        self
+    }
+
+    /// AAASM-2022 — Set the per-org monthly spend limit in USD.
+    pub fn with_org_monthly_limit(mut self, limit: Decimal) -> Self {
+        self.org_monthly_limit_usd = Some(limit);
+        self
+    }
+
     /// Register a per-agent daily and/or monthly spend cap.
     ///
     /// Used by `check_and_decrement` to validate per-agent limits before committing
@@ -687,6 +701,13 @@ impl BudgetTracker {
     /// Return the current spend state for a specific team, or `None` if the team has no spend.
     pub fn team_state(&self, team_id: &str) -> Option<BudgetState> {
         self.team_budgets.get(team_id).map(|s| s.clone())
+    }
+
+    /// AAASM-2022 — Return the current spend state for a specific
+    /// organisation, or `None` if the org has no recorded spend. Mirrors
+    /// [`team_state`](Self::team_state) at the multi-tenancy tier.
+    pub fn org_state(&self, org_id: &str) -> Option<BudgetState> {
+        self.org_budgets.get(org_id).map(|s| s.clone())
     }
 
     /// Return the current spend state for a specific agent, or `None` if the

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -60,6 +60,12 @@ pub struct BudgetTracker {
     pub(crate) per_agent: DashMap<AgentId, BudgetState>,
     /// Per-team daily/monthly spend rollup. `pub(crate)` for test date manipulation.
     pub(crate) team_budgets: DashMap<String, BudgetState>,
+    /// AAASM-2022 — Per-org daily/monthly spend rollup. Mirrors `team_budgets`
+    /// at the multi-tenancy tier so an org's agents share a single spend
+    /// envelope independent of how teams are named across orgs. Used by
+    /// `record_cost` for org-tier enforcement and by `org_state` for read-back.
+    #[allow(dead_code)] // consumed by record_cost in the next commit
+    pub(crate) org_budgets: DashMap<String, BudgetState>,
     pub(crate) global: Mutex<BudgetState>,
     pricing: PricingTable,
     daily_limit_usd: Option<Decimal>,
@@ -68,6 +74,15 @@ pub struct BudgetTracker {
     team_daily_limit_usd: Option<Decimal>,
     /// Per-team monthly spend limit. Applied to each team independently.
     team_monthly_limit_usd: Option<Decimal>,
+    /// AAASM-2022 — Per-org daily spend limit. Applied to each org
+    /// independently. `None` leaves the org tier unconstrained (only
+    /// per-agent / per-team / global limits enforce in that case).
+    #[allow(dead_code)] // consumed by record_cost in the next commit
+    org_daily_limit_usd: Option<Decimal>,
+    /// AAASM-2022 — Per-org monthly spend limit. Applied to each org
+    /// independently.
+    #[allow(dead_code)] // consumed by record_cost in the next commit
+    org_monthly_limit_usd: Option<Decimal>,
     /// Per-agent daily/monthly limits set via [`BudgetTracker::with_agent_limit`].
     pub(crate) agent_limits: DashMap<AgentId, AgentLimit>,
     /// Per-ancestor mutex used to serialise concurrent check_and_decrement calls
@@ -111,12 +126,15 @@ impl BudgetTracker {
         Self {
             per_agent: DashMap::new(),
             team_budgets: DashMap::new(),
+            org_budgets: DashMap::new(),
             global: Mutex::new(BudgetState::new_for_date(today_in_tz(timezone))),
             pricing,
             daily_limit_usd,
             monthly_limit_usd,
             team_daily_limit_usd: None,
             team_monthly_limit_usd: None,
+            org_daily_limit_usd: None,
+            org_monthly_limit_usd: None,
             agent_limits: DashMap::new(),
             parent_locks: DashMap::new(),
             spend_history: DashMap::new(),
@@ -186,12 +204,19 @@ impl BudgetTracker {
         Self {
             per_agent,
             team_budgets,
+            // AAASM-2022 — Org-tier budgets are not yet persisted; restore as
+            // empty until the persistence schema grows an `org_budgets` field.
+            // A clean restart re-accumulates from zero rather than carrying
+            // stale data across schema bumps.
+            org_budgets: DashMap::new(),
             global: Mutex::new(initial.global),
             pricing,
             daily_limit_usd,
             monthly_limit_usd,
             team_daily_limit_usd: None,
             team_monthly_limit_usd: None,
+            org_daily_limit_usd: None,
+            org_monthly_limit_usd: None,
             agent_limits: DashMap::new(),
             parent_locks: DashMap::new(),
             spend_history: DashMap::new(),

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -64,7 +64,6 @@ pub struct BudgetTracker {
     /// at the multi-tenancy tier so an org's agents share a single spend
     /// envelope independent of how teams are named across orgs. Used by
     /// `record_cost` for org-tier enforcement and by `org_state` for read-back.
-    #[allow(dead_code)] // consumed by record_cost in the next commit
     pub(crate) org_budgets: DashMap<String, BudgetState>,
     pub(crate) global: Mutex<BudgetState>,
     pricing: PricingTable,
@@ -77,11 +76,9 @@ pub struct BudgetTracker {
     /// AAASM-2022 — Per-org daily spend limit. Applied to each org
     /// independently. `None` leaves the org tier unconstrained (only
     /// per-agent / per-team / global limits enforce in that case).
-    #[allow(dead_code)] // consumed by record_cost in the next commit
     org_daily_limit_usd: Option<Decimal>,
     /// AAASM-2022 — Per-org monthly spend limit. Applied to each org
     /// independently.
-    #[allow(dead_code)] // consumed by record_cost in the next commit
     org_monthly_limit_usd: Option<Decimal>,
     /// Per-agent daily/monthly limits set via [`BudgetTracker::with_agent_limit`].
     pub(crate) agent_limits: DashMap<AgentId, AgentLimit>,
@@ -329,23 +326,32 @@ impl BudgetTracker {
     /// rather than raw token counts.
     ///
     /// Fires 80%/95% threshold alerts on the broadcast channel and updates the
-    /// global and team spend accumulators. Returns the resulting [`BudgetStatus`].
-    pub fn record_raw_spend(&self, agent_id: AgentId, team_id: Option<&str>, amount_usd: Decimal) -> BudgetStatus {
-        self.record_cost(agent_id, team_id, amount_usd)
+    /// global, team, and (AAASM-2022) org spend accumulators. Returns the
+    /// resulting [`BudgetStatus`].
+    pub fn record_raw_spend(
+        &self,
+        agent_id: AgentId,
+        team_id: Option<&str>,
+        org_id: Option<&str>,
+        amount_usd: Decimal,
+    ) -> BudgetStatus {
+        self.record_cost(agent_id, team_id, org_id, amount_usd)
     }
 
     /// Record token usage and return the resulting [`BudgetStatus`].
+    #[allow(clippy::too_many_arguments)] // multi-tenancy tier adds org_id; lineage chain is structural
     pub fn record_usage(
         &self,
         agent_id: AgentId,
         team_id: Option<&str>,
+        org_id: Option<&str>,
         provider: crate::budget::types::Provider,
         model: crate::budget::types::Model,
         input_tokens: u64,
         output_tokens: u64,
     ) -> BudgetStatus {
         let cost = self.pricing.cost_usd(provider, model, input_tokens, output_tokens);
-        self.record_cost(agent_id, team_id, cost)
+        self.record_cost(agent_id, team_id, org_id, cost)
     }
 
     /// Compute status for `spent` against `limit`, emit a [`BudgetAlert`] on the broadcast
@@ -372,8 +378,21 @@ impl BudgetTracker {
 
     /// Shared cost-recording logic used by both [`record_usage`](Self::record_usage)
     /// and [`record_raw_spend`](Self::record_raw_spend).
-    fn record_cost(&self, agent_id: AgentId, team_id: Option<&str>, cost: Decimal) -> BudgetStatus {
-        let has_monthly = self.monthly_limit_usd.is_some() || self.team_monthly_limit_usd.is_some();
+    ///
+    /// AAASM-2022 — accepts `org_id` so the spend can be rolled up into
+    /// `org_budgets` for explicit Org-tier enforcement. When `org_id` is
+    /// `None`, the org tier is skipped (existing single-org or untenanted
+    /// deployments preserve their behaviour).
+    fn record_cost(
+        &self,
+        agent_id: AgentId,
+        team_id: Option<&str>,
+        org_id: Option<&str>,
+        cost: Decimal,
+    ) -> BudgetStatus {
+        let has_monthly = self.monthly_limit_usd.is_some()
+            || self.team_monthly_limit_usd.is_some()
+            || self.org_monthly_limit_usd.is_some();
         let now = chrono::Utc::now();
         let today = today_in_tz(self.timezone);
         let window = self.window;
@@ -450,6 +469,54 @@ impl BudgetTracker {
                 if let Some(team_state) = self.team_budgets.get(tid) {
                     let status =
                         self.check_limit_and_alert(agent_id, Some(tid), team_state.spent_usd, team_daily_limit);
+                    if status == BudgetStatus::LimitExceeded {
+                        return BudgetStatus::LimitExceeded;
+                    }
+                }
+            }
+        }
+
+        // AAASM-2022 — Org-tier rollup + enforcement. Mirrors the team block:
+        // accumulate per-org spend into `org_budgets`, then enforce the
+        // monthly limit (precedes daily by convention).
+        if let Some(oid) = org_id {
+            self.org_budgets
+                .entry(oid.to_string())
+                .and_modify(|s| {
+                    s.maybe_reset_window(now, window, tz);
+                    s.spent_usd += cost;
+                    if let Some(m) = s.monthly_spent_usd.as_mut() {
+                        *m += cost;
+                    }
+                })
+                .or_insert_with(|| {
+                    let mut s = BudgetState::new_for_date(today);
+                    s.spent_usd += cost;
+                    if has_monthly {
+                        s.monthly_spent_usd = Some(cost);
+                    }
+                    if matches!(window, BudgetWindow::Duration(_)) {
+                        s.last_reset_at = Some(now);
+                    }
+                    s
+                });
+
+            // Check org monthly limit and emit alert.
+            if let Some(org_monthly_limit) = self.org_monthly_limit_usd {
+                if let Some(org_state) = self.org_budgets.get(oid) {
+                    if let Some(org_monthly) = org_state.monthly_spent_usd {
+                        let status = self.check_limit_and_alert(agent_id, None, org_monthly, org_monthly_limit);
+                        if status == BudgetStatus::LimitExceeded {
+                            return BudgetStatus::LimitExceeded;
+                        }
+                    }
+                }
+            }
+
+            // Check org daily limit and emit alert.
+            if let Some(org_daily_limit) = self.org_daily_limit_usd {
+                if let Some(org_state) = self.org_budgets.get(oid) {
+                    let status = self.check_limit_and_alert(agent_id, None, org_state.spent_usd, org_daily_limit);
                     if status == BudgetStatus::LimitExceeded {
                         return BudgetStatus::LimitExceeded;
                     }
@@ -763,8 +830,8 @@ mod tests {
     fn agent_spend_history_records_todays_spend() {
         let t = new_tracker();
         let aid = AgentId::from_bytes([0xAA; 16]);
-        t.record_raw_spend(aid, None, Decimal::new(125, 2));
-        t.record_raw_spend(aid, None, Decimal::new(375, 2));
+        t.record_raw_spend(aid, None, None, Decimal::new(125, 2));
+        t.record_raw_spend(aid, None, None, Decimal::new(375, 2));
 
         let history = t.agent_spend_history(&aid, 1);
         assert_eq!(history.len(), 1);
@@ -775,7 +842,7 @@ mod tests {
     fn agent_spend_history_zero_days_returns_empty_vec() {
         let t = new_tracker();
         let aid = AgentId::from_bytes([0xAA; 16]);
-        t.record_raw_spend(aid, None, Decimal::ONE);
+        t.record_raw_spend(aid, None, None, Decimal::ONE);
         assert!(t.agent_spend_history(&aid, 0).is_empty());
     }
 
@@ -852,7 +919,7 @@ mod tests {
     fn record_usage_no_limit_returns_within_budget() {
         use crate::budget::types::{BudgetStatus, Model, Provider};
         let t = new_tracker();
-        let s = t.record_usage(agent(1), None, Provider::OpenAi, Model::Gpt4o, 100, 100);
+        let s = t.record_usage(agent(1), None, None, Provider::OpenAi, Model::Gpt4o, 100, 100);
         assert!(matches!(s, BudgetStatus::WithinBudget { .. }));
     }
 
@@ -861,7 +928,7 @@ mod tests {
         use crate::budget::types::{BudgetStatus, Model, Provider};
         // GPT-4o: 100k input=$0.50 + 40k output=$0.60 = $1.10 > $1.00 limit
         let t = tracker_with_limit("1.00");
-        let s = t.record_usage(agent(2), None, Provider::OpenAi, Model::Gpt4o, 100_000, 40_000);
+        let s = t.record_usage(agent(2), None, None, Provider::OpenAi, Model::Gpt4o, 100_000, 40_000);
         assert_eq!(s, BudgetStatus::LimitExceeded);
     }
 
@@ -870,7 +937,7 @@ mod tests {
         use crate::budget::types::{BudgetStatus, Model, Provider};
         // 100k input=$0.50 + 20k output=$0.30 = $0.80 = 80% of $1.00
         let t = tracker_with_limit("1.00");
-        let s = t.record_usage(agent(3), None, Provider::OpenAi, Model::Gpt4o, 100_000, 20_000);
+        let s = t.record_usage(agent(3), None, None, Provider::OpenAi, Model::Gpt4o, 100_000, 20_000);
         assert_eq!(s, BudgetStatus::ThresholdAlert { pct: 80 });
     }
 
@@ -879,12 +946,12 @@ mod tests {
         use crate::budget::types::{BudgetStatus, Model, Provider};
         let t = tracker_with_limit("1.00");
         let id = agent(4);
-        t.record_usage(id, None, Provider::OpenAi, Model::Gpt4o, 100_000, 30_000); // $0.95
+        t.record_usage(id, None, None, Provider::OpenAi, Model::Gpt4o, 100_000, 30_000); // $0.95
         t.per_agent.alter(&id, |_, mut s| {
             s.date = chrono::Utc::now().date_naive() - chrono::Duration::days(1);
             s
         });
-        let s = t.record_usage(id, None, Provider::OpenAi, Model::Gpt4o, 100, 0);
+        let s = t.record_usage(id, None, None, Provider::OpenAi, Model::Gpt4o, 100, 0);
         assert!(matches!(s, BudgetStatus::WithinBudget { .. }));
     }
 
@@ -927,7 +994,7 @@ mod tests {
         use crate::budget::types::{Model, Provider};
         let t = new_tracker();
         let id = agent(7);
-        t.record_usage(id, None, Provider::OpenAi, Model::Gpt4o, 1_000, 0);
+        t.record_usage(id, None, None, Provider::OpenAi, Model::Gpt4o, 1_000, 0);
         let snap = t.snapshot();
         assert_eq!(snap.per_agent.len(), 1);
         assert_eq!(snap.global.spent_usd, snap.per_agent[0].state.spent_usd);
@@ -937,8 +1004,8 @@ mod tests {
     fn global_state_accumulates_all_agents() {
         use crate::budget::types::{Model, Provider};
         let t = new_tracker();
-        t.record_usage(agent(5), None, Provider::OpenAi, Model::Gpt4o, 1_000, 0); // $0.005
-        t.record_usage(agent(6), None, Provider::OpenAi, Model::Gpt4o, 1_000, 0); // $0.005
+        t.record_usage(agent(5), None, None, Provider::OpenAi, Model::Gpt4o, 1_000, 0); // $0.005
+        t.record_usage(agent(6), None, None, Provider::OpenAi, Model::Gpt4o, 1_000, 0); // $0.005
         let g = t.global_state();
         let expected: Decimal = "0.010".parse().unwrap();
         assert_eq!(g.spent_usd, expected);
@@ -953,15 +1020,15 @@ mod tests {
         let t = BudgetTracker::new(PricingTable::default_table(), Some("1.00".parse().unwrap()), None, tz);
         let id = agent(10);
         // First call — establishes the agent entry
-        t.record_usage(id, None, Provider::OpenAi, Model::Gpt4o, 100_000, 30_000); // $0.95
-                                                                                   // Backdate the agent entry by 1 day in the Tokyo timezone
+        t.record_usage(id, None, None, Provider::OpenAi, Model::Gpt4o, 100_000, 30_000); // $0.95
+                                                                                         // Backdate the agent entry by 1 day in the Tokyo timezone
         let yesterday_tokyo = today_in_tz(tz) - chrono::Duration::days(1);
         t.per_agent.alter(&id, |_, mut s| {
             s.date = yesterday_tokyo;
             s
         });
         // Next call should reset (yesterday < today in Tokyo)
-        let s = t.record_usage(id, None, Provider::OpenAi, Model::Gpt4o, 100, 0);
+        let s = t.record_usage(id, None, None, Provider::OpenAi, Model::Gpt4o, 100, 0);
         assert!(
             matches!(s, BudgetStatus::WithinBudget { .. }),
             "Expected reset after Tokyo midnight, got: {:?}",
@@ -983,7 +1050,7 @@ mod tests {
         use crate::budget::types::{BudgetStatus, Model, Provider};
         // Monthly limit $1.00. GPT-4o: 100k input=$0.50 + 40k output=$0.60 = $1.10 > $1.00
         let t = tracker_with_monthly_limit("1.00");
-        let s = t.record_usage(agent(20), None, Provider::OpenAi, Model::Gpt4o, 100_000, 40_000);
+        let s = t.record_usage(agent(20), None, None, Provider::OpenAi, Model::Gpt4o, 100_000, 40_000);
         assert_eq!(s, BudgetStatus::LimitExceeded);
     }
 
@@ -992,7 +1059,7 @@ mod tests {
         use crate::budget::types::{BudgetStatus, Model, Provider};
         // Monthly limit $10.00. Small usage should be within budget.
         let t = tracker_with_monthly_limit("10.00");
-        let s = t.record_usage(agent(21), None, Provider::OpenAi, Model::Gpt4o, 1_000, 0);
+        let s = t.record_usage(agent(21), None, None, Provider::OpenAi, Model::Gpt4o, 1_000, 0);
         assert!(matches!(s, BudgetStatus::WithinBudget { .. }));
     }
 
@@ -1003,14 +1070,14 @@ mod tests {
         let t = tracker_with_monthly_limit("1.00");
         let id = agent(22);
         // Day 1: $0.50 (100k input)
-        t.record_usage(id, None, Provider::OpenAi, Model::Gpt4o, 100_000, 0);
+        t.record_usage(id, None, None, Provider::OpenAi, Model::Gpt4o, 100_000, 0);
         // Backdate the entry by 1 day — daily resets, monthly stays
         t.per_agent.alter(&id, |_, mut s| {
             s.date = chrono::Utc::now().date_naive() - chrono::Duration::days(1);
             s
         });
         // Day 2: another $0.60 (40k output) — total monthly $1.10 > $1.00
-        let s = t.record_usage(id, None, Provider::OpenAi, Model::Gpt4o, 0, 40_000);
+        let s = t.record_usage(id, None, None, Provider::OpenAi, Model::Gpt4o, 0, 40_000);
         assert_eq!(s, BudgetStatus::LimitExceeded);
     }
 
@@ -1021,7 +1088,7 @@ mod tests {
         let t = tracker_with_monthly_limit("1.00");
         let id = agent(23);
         // Record $0.95
-        t.record_usage(id, None, Provider::OpenAi, Model::Gpt4o, 100_000, 30_000);
+        t.record_usage(id, None, None, Provider::OpenAi, Model::Gpt4o, 100_000, 30_000);
         // Backdate to last month — both daily and monthly should reset
         let last_month = chrono::Utc::now().date_naive() - chrono::Duration::days(32);
         t.per_agent.alter(&id, |_, mut s| {
@@ -1030,7 +1097,7 @@ mod tests {
             s
         });
         // New usage should start fresh — well within budget
-        let s = t.record_usage(id, None, Provider::OpenAi, Model::Gpt4o, 100, 0);
+        let s = t.record_usage(id, None, None, Provider::OpenAi, Model::Gpt4o, 100, 0);
         assert!(
             matches!(s, BudgetStatus::WithinBudget { .. }),
             "Expected within budget after monthly reset, got: {:?}",
@@ -1050,7 +1117,7 @@ mod tests {
     fn check_daily_returns_true_when_exceeded() {
         let t = tracker_with_limit("1.00");
         let id = agent(31);
-        t.record_raw_spend(id, None, "1.00".parse().unwrap());
+        t.record_raw_spend(id, None, None, "1.00".parse().unwrap());
         assert!(t.check_daily(&id, "1.00".parse().unwrap()));
     }
 
@@ -1064,7 +1131,7 @@ mod tests {
     fn check_monthly_returns_true_when_exceeded() {
         let t = tracker_with_monthly_limit("5.00");
         let id = agent(33);
-        t.record_raw_spend(id, None, "5.00".parse().unwrap());
+        t.record_raw_spend(id, None, None, "5.00".parse().unwrap());
         assert!(t.check_monthly(&id, "5.00".parse().unwrap()));
     }
 
@@ -1072,8 +1139,8 @@ mod tests {
     fn record_raw_spend_accumulates() {
         let t = tracker_with_limit("10.00");
         let id = agent(34);
-        t.record_raw_spend(id, None, "3.00".parse().unwrap());
-        t.record_raw_spend(id, None, "4.00".parse().unwrap());
+        t.record_raw_spend(id, None, None, "3.00".parse().unwrap());
+        t.record_raw_spend(id, None, None, "4.00".parse().unwrap());
         // 7.00 >= 7.00
         assert!(t.check_daily(&id, "7.00".parse().unwrap()));
         // 7.00 < 8.00
@@ -1086,7 +1153,7 @@ mod tests {
         let mut rx = t.subscribe_alerts();
         let id = agent(35);
         // 8.00 / 10.00 = 80%
-        t.record_raw_spend(id, None, "8.00".parse().unwrap());
+        t.record_raw_spend(id, None, None, "8.00".parse().unwrap());
         let alert = rx.try_recv().expect("expected 80% alert");
         assert_eq!(alert.threshold_pct, 80);
         assert_eq!(alert.agent_id, id);
@@ -1098,7 +1165,7 @@ mod tests {
         let mut rx = t.subscribe_alerts();
         let id = agent(36);
         // 9.50 / 10.00 = 95%
-        t.record_raw_spend(id, None, "9.50".parse().unwrap());
+        t.record_raw_spend(id, None, None, "9.50".parse().unwrap());
         let alert = rx.try_recv().expect("expected 95% alert");
         assert_eq!(alert.threshold_pct, 95);
     }
@@ -1114,7 +1181,7 @@ mod tests {
             tx,
         );
         let id = agent(37);
-        t.record_raw_spend(id, None, "8.00".parse().unwrap());
+        t.record_raw_spend(id, None, None, "8.00".parse().unwrap());
         let alert = rx.try_recv().expect("alert should arrive on external channel");
         assert_eq!(alert.threshold_pct, 80);
     }
@@ -1125,7 +1192,7 @@ mod tests {
     fn check_daily_exact_limit_is_exceeded() {
         let t = tracker_with_limit("1.00");
         let id = agent(40);
-        t.record_raw_spend(id, None, "1.00".parse().unwrap());
+        t.record_raw_spend(id, None, None, "1.00".parse().unwrap());
         // 1.00 >= 1.00 is true (not strictly greater)
         assert!(t.check_daily(&id, "1.00".parse().unwrap()));
     }
@@ -1134,7 +1201,7 @@ mod tests {
     fn check_daily_resets_on_new_date() {
         let t = tracker_with_limit("1.00");
         let id = agent(41);
-        t.record_raw_spend(id, None, "0.90".parse().unwrap());
+        t.record_raw_spend(id, None, None, "0.90".parse().unwrap());
         // Backdate the entry to yesterday
         t.per_agent.alter(&id, |_, mut s| {
             s.date = chrono::Utc::now().date_naive() - chrono::Duration::days(1);
@@ -1148,8 +1215,8 @@ mod tests {
     fn check_monthly_accumulates_raw_spend() {
         let t = tracker_with_monthly_limit("7.00");
         let id = agent(42);
-        t.record_raw_spend(id, None, "3.00".parse().unwrap());
-        t.record_raw_spend(id, None, "4.00".parse().unwrap());
+        t.record_raw_spend(id, None, None, "3.00".parse().unwrap());
+        t.record_raw_spend(id, None, None, "4.00".parse().unwrap());
         // 7.00 >= 7.00
         assert!(t.check_monthly(&id, "7.00".parse().unwrap()));
         // 7.00 < 8.00
@@ -1161,7 +1228,7 @@ mod tests {
         use chrono::Datelike;
         let t = tracker_with_monthly_limit("5.00");
         let id = agent(43);
-        t.record_raw_spend(id, None, "5.00".parse().unwrap());
+        t.record_raw_spend(id, None, None, "5.00".parse().unwrap());
         // Backdate to last month
         let last_month = chrono::Utc::now().date_naive() - chrono::Duration::days(32);
         t.per_agent.alter(&id, |_, mut s| {
@@ -1190,7 +1257,7 @@ mod tests {
         let t = tracker_with_team_daily_limit("5.00");
         let id = agent(50);
         // Spend $5.00 — exactly at limit
-        let status = t.record_raw_spend(id, Some("team-alpha"), "5.00".parse().unwrap());
+        let status = t.record_raw_spend(id, Some("team-alpha"), None, "5.00".parse().unwrap());
         assert_eq!(status, BudgetStatus::LimitExceeded);
     }
 
@@ -1198,7 +1265,7 @@ mod tests {
     fn team_daily_limit_not_exceeded_before_threshold() {
         let t = tracker_with_team_daily_limit("10.00");
         let id = agent(51);
-        let status = t.record_raw_spend(id, Some("team-alpha"), "3.00".parse().unwrap());
+        let status = t.record_raw_spend(id, Some("team-alpha"), None, "3.00".parse().unwrap());
         assert!(matches!(status, BudgetStatus::WithinBudget { .. }));
     }
 
@@ -1208,9 +1275,9 @@ mod tests {
         let id_a = agent(52);
         let id_b = agent(53);
         // Agent A spends $3.00
-        t.record_raw_spend(id_a, Some("team-beta"), "3.00".parse().unwrap());
+        t.record_raw_spend(id_a, Some("team-beta"), None, "3.00".parse().unwrap());
         // Agent B spends $2.00 — pushes team total to $5.00 (exactly at limit)
-        let status = t.record_raw_spend(id_b, Some("team-beta"), "2.00".parse().unwrap());
+        let status = t.record_raw_spend(id_b, Some("team-beta"), None, "2.00".parse().unwrap());
         assert_eq!(status, BudgetStatus::LimitExceeded);
     }
 
@@ -1218,7 +1285,7 @@ mod tests {
     fn team_monthly_limit_exceeded_blocks() {
         let t = tracker_with_team_monthly_limit("10.00");
         let id = agent(54);
-        let status = t.record_raw_spend(id, Some("team-gamma"), "10.00".parse().unwrap());
+        let status = t.record_raw_spend(id, Some("team-gamma"), None, "10.00".parse().unwrap());
         assert_eq!(status, BudgetStatus::LimitExceeded);
     }
 
@@ -1227,7 +1294,7 @@ mod tests {
         let t = tracker_with_team_daily_limit("1.00");
         let id = agent(55);
         // No team_id — team limit should not apply
-        let status = t.record_raw_spend(id, None, "100.00".parse().unwrap());
+        let status = t.record_raw_spend(id, None, None, "100.00".parse().unwrap());
         assert!(matches!(status, BudgetStatus::WithinBudget { .. }));
     }
 
@@ -1239,7 +1306,7 @@ mod tests {
         let mut rx = t.subscribe_alerts();
         let id = agent(60);
         // 8.00 / 10.00 = 80%
-        t.record_raw_spend(id, Some("team-delta"), "8.00".parse().unwrap());
+        t.record_raw_spend(id, Some("team-delta"), None, "8.00".parse().unwrap());
         let alert = rx.try_recv().expect("expected 80% team alert");
         assert_eq!(alert.threshold_pct, 80);
         assert_eq!(alert.team_id.as_deref(), Some("team-delta"));
@@ -1251,7 +1318,7 @@ mod tests {
         let mut rx = t.subscribe_alerts();
         let id = agent(61);
         // 9.50 / 10.00 = 95%
-        t.record_raw_spend(id, Some("team-epsilon"), "9.50".parse().unwrap());
+        t.record_raw_spend(id, Some("team-epsilon"), None, "9.50".parse().unwrap());
         let alert = rx.try_recv().expect("expected 95% team alert");
         assert_eq!(alert.threshold_pct, 95);
         assert_eq!(alert.team_id.as_deref(), Some("team-epsilon"));
@@ -1374,7 +1441,7 @@ mod tests {
     fn subtree_spend_leaf_agent_equals_own_spend() {
         let t = new_tracker();
         let id = agent(80);
-        t.record_raw_spend(id, None, "3.00".parse().unwrap());
+        t.record_raw_spend(id, None, None, "3.00".parse().unwrap());
         let result = t.subtree_spend(&id, &[]);
         assert_eq!(result.usd, "3.00".parse::<Decimal>().unwrap());
         assert_eq!(result.agents_counted, 1);
@@ -1395,7 +1462,7 @@ mod tests {
         // Record $1 each for every node.
         let one: Decimal = "1.00".parse().unwrap();
         for &a in &[root, child_a, child_b, gc1, gc2, gc3, gc4] {
-            t.record_raw_spend(a, None, one);
+            t.record_raw_spend(a, None, None, one);
         }
 
         let descendants = [
@@ -1521,7 +1588,7 @@ mod tests {
         let t = tracker_with_team_monthly_limit("10.00");
         let mut rx = t.subscribe_alerts();
         let id = agent(62);
-        t.record_raw_spend(id, Some("team-zeta"), "8.00".parse().unwrap());
+        t.record_raw_spend(id, Some("team-zeta"), None, "8.00".parse().unwrap());
         let alert = rx.try_recv().expect("expected 80% monthly team alert");
         assert_eq!(alert.threshold_pct, 80);
         assert_eq!(alert.team_id.as_deref(), Some("team-zeta"));

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1678,6 +1678,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: Some(1.0),
             monthly_limit_usd: None,
+            org_daily_limit_usd: None,
+            org_monthly_limit_usd: None,
             timezone: None,
             action_on_exceed: ActionOnExceed::default(),
             window: None,
@@ -1702,6 +1704,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: None,
             monthly_limit_usd: Some(5.0),
+            org_daily_limit_usd: None,
+            org_monthly_limit_usd: None,
             timezone: None,
             action_on_exceed: ActionOnExceed::default(),
             window: None,
@@ -1726,6 +1730,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: None,
             monthly_limit_usd: Some(10.0),
+            org_daily_limit_usd: None,
+            org_monthly_limit_usd: None,
             timezone: None,
             action_on_exceed: ActionOnExceed::default(),
             window: None,
@@ -1745,6 +1751,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: Some(2.0),
             monthly_limit_usd: Some(5.0),
+            org_daily_limit_usd: None,
+            org_monthly_limit_usd: None,
             timezone: None,
             action_on_exceed: ActionOnExceed::default(),
             window: None,
@@ -1770,6 +1778,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: Some(1.0),
             monthly_limit_usd: None,
+            org_daily_limit_usd: None,
+            org_monthly_limit_usd: None,
             timezone: None,
             action_on_exceed: ActionOnExceed::Deny,
             window: None,
@@ -1794,6 +1804,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: Some(1.0),
             monthly_limit_usd: None,
+            org_daily_limit_usd: None,
+            org_monthly_limit_usd: None,
             timezone: None,
             action_on_exceed: ActionOnExceed::Suspend,
             window: None,
@@ -1818,6 +1830,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: None,
             monthly_limit_usd: Some(5.0),
+            org_daily_limit_usd: None,
+            org_monthly_limit_usd: None,
             timezone: None,
             action_on_exceed: ActionOnExceed::Suspend,
             window: None,
@@ -1842,6 +1856,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: Some(10.0),
             monthly_limit_usd: None,
+            org_daily_limit_usd: None,
+            org_monthly_limit_usd: None,
             timezone: None,
             action_on_exceed: ActionOnExceed::Deny,
             window: None,
@@ -2146,6 +2162,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: Some(10.0),
             monthly_limit_usd: None,
+            org_daily_limit_usd: None,
+            org_monthly_limit_usd: None,
             timezone: None,
             action_on_exceed: ActionOnExceed::default(),
             window: None,
@@ -2168,6 +2186,8 @@ mod tests {
         doc.budget = Some(BudgetPolicy {
             daily_limit_usd: Some(1.0),
             monthly_limit_usd: None,
+            org_daily_limit_usd: None,
+            org_monthly_limit_usd: None,
             timezone: None,
             action_on_exceed: ActionOnExceed::default(),
             window: None,

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -240,13 +240,33 @@ impl PolicyEngine {
             .as_ref()
             .and_then(|bp| bp.monthly_limit_usd)
             .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
-        let budget = Arc::new(BudgetTracker::new_with_alert_sender(
+        // AAASM-2022 — Lift org-tier limits from BudgetPolicy into the tracker.
+        let org_daily_limit = output
+            .document
+            .budget
+            .as_ref()
+            .and_then(|bp| bp.org_daily_limit_usd)
+            .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
+        let org_monthly_limit = output
+            .document
+            .budget
+            .as_ref()
+            .and_then(|bp| bp.org_monthly_limit_usd)
+            .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
+        let mut budget_tracker = BudgetTracker::new_with_alert_sender(
             crate::budget::PricingTable::default_table(),
             daily_limit,
             monthly_limit,
             budget_tz,
             budget_alert_tx,
-        ));
+        );
+        if let Some(limit) = org_daily_limit {
+            budget_tracker = budget_tracker.with_org_daily_limit(limit);
+        }
+        if let Some(limit) = org_monthly_limit {
+            budget_tracker = budget_tracker.with_org_monthly_limit(limit);
+        }
+        let budget = Arc::new(budget_tracker);
         let policy_arc = Arc::new(ArcSwap::new(Arc::new(output.document)));
         let watcher = crate::engine::watcher::start_watcher(path, policy_arc.clone()).ok();
         Ok(PolicyEngine {
@@ -325,6 +345,9 @@ impl PolicyEngine {
         let mut budget_tz = chrono_tz::UTC;
         let mut daily_limit: Option<rust_decimal::Decimal> = None;
         let mut monthly_limit: Option<rust_decimal::Decimal> = None;
+        // AAASM-2022 — Org-tier limits from the Global-scoped doc.
+        let mut org_daily_limit: Option<rust_decimal::Decimal> = None;
+        let mut org_monthly_limit: Option<rust_decimal::Decimal> = None;
 
         for path in &entries {
             let yaml = std::fs::read_to_string(path).map_err(PolicyLoadError::Io)?;
@@ -359,19 +382,36 @@ impl PolicyEngine {
                     .as_ref()
                     .and_then(|bp| bp.monthly_limit_usd)
                     .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
+                org_daily_limit = doc
+                    .budget
+                    .as_ref()
+                    .and_then(|bp| bp.org_daily_limit_usd)
+                    .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
+                org_monthly_limit = doc
+                    .budget
+                    .as_ref()
+                    .and_then(|bp| bp.org_monthly_limit_usd)
+                    .and_then(|v| rust_decimal::Decimal::try_from(v).ok());
                 primary = Some(doc.clone());
             }
 
             scope_index.insert(doc);
         }
 
-        let budget = Arc::new(BudgetTracker::new_with_alert_sender(
+        let mut budget_tracker = BudgetTracker::new_with_alert_sender(
             crate::budget::PricingTable::default_table(),
             daily_limit,
             monthly_limit,
             budget_tz,
             budget_alert_tx,
-        ));
+        );
+        if let Some(limit) = org_daily_limit {
+            budget_tracker = budget_tracker.with_org_daily_limit(limit);
+        }
+        if let Some(limit) = org_monthly_limit {
+            budget_tracker = budget_tracker.with_org_monthly_limit(limit);
+        }
+        let budget = Arc::new(budget_tracker);
 
         let primary_doc = primary.unwrap_or_else(|| PolicyDocument {
             name: None,

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1097,8 +1097,12 @@ impl PolicyEngine {
     /// tracker's `record_raw_spend`, which fires 80%/95% threshold alerts.
     pub fn record_spend(&self, ctx: &aa_core::AgentContext, amount_usd: f64) {
         if let Ok(amount) = rust_decimal::Decimal::try_from(amount_usd) {
+            // AAASM-2022 — thread `org_id` from ctx.metadata so the spend
+            // rolls up into the Org tier's budget envelope. Falls back to
+            // None when convert.rs didn't populate the metadata key.
+            let org_id = ctx.metadata.get("org_id").map(String::as_str);
             self.budget
-                .record_raw_spend(ctx.agent_id, ctx.team_id.as_deref(), amount);
+                .record_raw_spend(ctx.agent_id, ctx.team_id.as_deref(), org_id, amount);
         }
     }
 

--- a/aa-gateway/src/policy/document.rs
+++ b/aa-gateway/src/policy/document.rs
@@ -44,6 +44,13 @@ pub struct BudgetPolicy {
     pub daily_limit_usd: Option<f64>,
     /// Maximum USD spend per calendar month; `None` means no limit.
     pub monthly_limit_usd: Option<f64>,
+    /// AAASM-2022 — Maximum USD spend per calendar day, per organisation.
+    /// Enforced independently of `daily_limit_usd` (which is the global cap).
+    /// `None` means no per-org daily limit.
+    pub org_daily_limit_usd: Option<f64>,
+    /// AAASM-2022 — Maximum USD spend per calendar month, per organisation.
+    /// `None` means no per-org monthly limit.
+    pub org_monthly_limit_usd: Option<f64>,
     /// IANA timezone for daily/monthly reset boundary. `None` means UTC.
     pub timezone: Option<String>,
     /// Action when budget is exceeded: deny individual requests or suspend agent.

--- a/aa-gateway/src/policy/raw.rs
+++ b/aa-gateway/src/policy/raw.rs
@@ -45,6 +45,12 @@ pub struct RawBudgetPolicy {
     pub daily_limit_usd: Option<f64>,
     /// Maximum USD spend per calendar month; `None` means no limit.
     pub monthly_limit_usd: Option<f64>,
+    /// AAASM-2022 — Maximum USD spend per calendar day, per organisation.
+    /// `None` means no per-org daily limit.
+    pub org_daily_limit_usd: Option<f64>,
+    /// AAASM-2022 — Maximum USD spend per calendar month, per organisation.
+    /// `None` means no per-org monthly limit.
+    pub org_monthly_limit_usd: Option<f64>,
     /// Optional IANA timezone for daily/monthly reset boundary. Defaults to UTC if absent.
     pub timezone: Option<String>,
     /// Action when budget is exceeded: `"deny"` (default) or `"suspend"`.

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -261,6 +261,33 @@ impl PolicyValidator {
             }
         }
 
+        // AAASM-2022 — Per-org limits use the same validation rules as the
+        // global limits: positive, and monthly >= daily.
+        if let Some(limit) = raw.org_daily_limit_usd {
+            if limit <= 0.0 {
+                errors.push(ValidationError::new(
+                    "budget.org_daily_limit_usd",
+                    "must be greater than 0",
+                ));
+            }
+        }
+        if let Some(limit) = raw.org_monthly_limit_usd {
+            if limit <= 0.0 {
+                errors.push(ValidationError::new(
+                    "budget.org_monthly_limit_usd",
+                    "must be greater than 0",
+                ));
+            }
+            if let Some(daily) = raw.org_daily_limit_usd {
+                if limit < daily {
+                    errors.push(ValidationError::new(
+                        "budget.org_monthly_limit_usd",
+                        "must be >= org_daily_limit_usd",
+                    ));
+                }
+            }
+        }
+
         // Validate timezone string if provided
         if let Some(tz_str) = &raw.timezone {
             if tz_str.parse::<chrono_tz::Tz>().is_err() {
@@ -310,6 +337,8 @@ impl PolicyValidator {
         Some(BudgetPolicy {
             daily_limit_usd: raw.daily_limit_usd,
             monthly_limit_usd: raw.monthly_limit_usd,
+            org_daily_limit_usd: raw.org_daily_limit_usd,
+            org_monthly_limit_usd: raw.org_monthly_limit_usd,
             timezone: raw.timezone,
             action_on_exceed,
             window,

--- a/aa-gateway/tests/budget_persistence_test.rs
+++ b/aa-gateway/tests/budget_persistence_test.rs
@@ -32,7 +32,7 @@ fn round_trip_preserves_spend() {
         alert_tx.clone(),
     );
     let agent = test_agent_id();
-    tracker.record_raw_spend(agent, None, Decimal::from_str("42.50").unwrap());
+    tracker.record_raw_spend(agent, None, None, Decimal::from_str("42.50").unwrap());
 
     // 2. Snapshot and persist.
     let snapshot = tracker.snapshot();
@@ -74,7 +74,7 @@ fn restored_tracker_accumulates_further_spend() {
         alert_tx.clone(),
     );
     let agent = test_agent_id();
-    tracker.record_raw_spend(agent, None, Decimal::from_str("10.00").unwrap());
+    tracker.record_raw_spend(agent, None, None, Decimal::from_str("10.00").unwrap());
 
     let snapshot = tracker.snapshot();
     save_to_disk_atomic(&path, &snapshot).unwrap();
@@ -89,7 +89,7 @@ fn restored_tracker_accumulates_further_spend() {
     ));
 
     // Record more spend on the restored tracker.
-    restored.record_raw_spend(agent, None, Decimal::from_str("5.00").unwrap());
+    restored.record_raw_spend(agent, None, None, Decimal::from_str("5.00").unwrap());
 
     let final_snapshot = restored.snapshot();
     assert_eq!(

--- a/aa-gateway/tests/team_budget_test.rs
+++ b/aa-gateway/tests/team_budget_test.rs
@@ -31,7 +31,7 @@ fn base_tracker() -> BudgetTracker {
 fn record_usage_accumulates_in_team_budgets() {
     let t = base_tracker();
     let id = agent(1);
-    t.record_usage(id, Some("team-a"), Provider::OpenAi, Model::Gpt4o, 1_000, 0);
+    t.record_usage(id, Some("team-a"), None, Provider::OpenAi, Model::Gpt4o, 1_000, 0);
     let state = t
         .team_state("team-a")
         .expect("team-a must have a state after record_usage");
@@ -43,7 +43,7 @@ fn record_usage_accumulates_in_team_budgets() {
 fn record_raw_spend_accumulates_in_team_budgets() {
     let t = base_tracker();
     let id = agent(2);
-    t.record_raw_spend(id, Some("team-b"), Decimal::from_str("7.50").unwrap());
+    t.record_raw_spend(id, Some("team-b"), None, Decimal::from_str("7.50").unwrap());
     let state = t
         .team_state("team-b")
         .expect("team-b must have a state after record_raw_spend");
@@ -57,13 +57,13 @@ fn team_limit_blocks_second_agent_when_team_total_exceeded() {
     let agent_a = agent(10);
     let agent_b = agent(11);
     // Agent A spends $3.00 — within budget
-    let s1 = t.record_raw_spend(agent_a, Some("shared-team"), Decimal::from_str("3.00").unwrap());
+    let s1 = t.record_raw_spend(agent_a, Some("shared-team"), None, Decimal::from_str("3.00").unwrap());
     assert!(
         matches!(s1, BudgetStatus::WithinBudget { .. }),
         "agent_a should be within budget"
     );
     // Agent B spends $2.00 — pushes team total to $5.00 (exactly at limit)
-    let s2 = t.record_raw_spend(agent_b, Some("shared-team"), Decimal::from_str("2.00").unwrap());
+    let s2 = t.record_raw_spend(agent_b, Some("shared-team"), None, Decimal::from_str("2.00").unwrap());
     assert_eq!(s2, BudgetStatus::LimitExceeded, "team limit must block agent_b");
 }
 
@@ -71,7 +71,7 @@ fn team_limit_blocks_second_agent_when_team_total_exceeded() {
 #[test]
 fn individual_agent_below_team_limit_is_not_blocked() {
     let t = base_tracker().with_team_daily_limit(Decimal::from_str("10.00").unwrap());
-    let s = t.record_raw_spend(agent(12), Some("solo-team"), Decimal::from_str("3.00").unwrap());
+    let s = t.record_raw_spend(agent(12), Some("solo-team"), None, Decimal::from_str("3.00").unwrap());
     assert!(matches!(s, BudgetStatus::WithinBudget { .. }));
 }
 
@@ -83,7 +83,7 @@ fn budget_alert_fires_at_80_pct_of_team_daily_limit() {
         .with_team_daily_limit(Decimal::from_str("10.00").unwrap());
 
     // 8.00 / 10.00 = 80%
-    t.record_raw_spend(agent(20), Some("alert-team"), Decimal::from_str("8.00").unwrap());
+    t.record_raw_spend(agent(20), Some("alert-team"), None, Decimal::from_str("8.00").unwrap());
     let alert = alert_rx.try_recv().expect("expected 80% alert");
     assert_eq!(alert.threshold_pct, 80);
     assert_eq!(alert.team_id.as_deref(), Some("alert-team"));
@@ -97,7 +97,12 @@ fn budget_alert_fires_at_95_pct_of_team_daily_limit() {
         .with_team_daily_limit(Decimal::from_str("10.00").unwrap());
 
     // 9.50 / 10.00 = 95%
-    t.record_raw_spend(agent(21), Some("alert-team-95"), Decimal::from_str("9.50").unwrap());
+    t.record_raw_spend(
+        agent(21),
+        Some("alert-team-95"),
+        None,
+        Decimal::from_str("9.50").unwrap(),
+    );
     let alert = alert_rx.try_recv().expect("expected 95% alert");
     assert_eq!(alert.threshold_pct, 95);
     assert_eq!(alert.team_id.as_deref(), Some("alert-team-95"));
@@ -110,7 +115,12 @@ fn team_budget_persists_through_snapshot_round_trip() {
     let path = dir.path().join("budget.json");
 
     let t = base_tracker();
-    t.record_raw_spend(agent(30), Some("persist-team"), Decimal::from_str("4.20").unwrap());
+    t.record_raw_spend(
+        agent(30),
+        Some("persist-team"),
+        None,
+        Decimal::from_str("4.20").unwrap(),
+    );
 
     let snap = t.snapshot();
     assert!(
@@ -133,8 +143,8 @@ fn team_daily_spend_resets_on_date_advance() {
     let id = agent(31);
 
     // Spend at limit — subsequent calls should be blocked
-    t.record_raw_spend(id, Some("reset-team"), Decimal::from_str("5.00").unwrap());
-    let before = t.record_raw_spend(agent(32), Some("reset-team"), Decimal::from_str("0.01").unwrap());
+    t.record_raw_spend(id, Some("reset-team"), None, Decimal::from_str("5.00").unwrap());
+    let before = t.record_raw_spend(agent(32), Some("reset-team"), None, Decimal::from_str("0.01").unwrap());
     assert_eq!(before, BudgetStatus::LimitExceeded, "should be blocked before reset");
 
     // Take snapshot, backdate the team entry by 1 day, restore into a new tracker
@@ -146,7 +156,7 @@ fn team_daily_spend_resets_on_date_advance() {
         .with_team_daily_limit(Decimal::from_str("5.00").unwrap());
 
     // After date advance, team spend resets — new call should be within budget
-    let s = restored.record_raw_spend(agent(33), Some("reset-team"), Decimal::from_str("1.00").unwrap());
+    let s = restored.record_raw_spend(agent(33), Some("reset-team"), None, Decimal::from_str("1.00").unwrap());
     assert!(
         matches!(s, BudgetStatus::WithinBudget { .. }),
         "team spend must reset after date advance"

--- a/aa-integration-tests/tests/api_agents.rs
+++ b/aa-integration-tests/tests/api_agents.rs
@@ -184,7 +184,7 @@ async fn agents_budget_returns_snapshot() {
 
     let agent_core_id = aa_core::identity::AgentId::from_bytes(id);
     env.budget_tracker
-        .record_raw_spend(agent_core_id, Some(TEAM), rust_decimal::Decimal::from(5));
+        .record_raw_spend(agent_core_id, Some(TEAM), None, rust_decimal::Decimal::from(5));
 
     let client = reqwest::Client::new();
     let resp = client

--- a/aa-integration-tests/tests/api_costs.rs
+++ b/aa-integration-tests/tests/api_costs.rs
@@ -22,7 +22,7 @@
 //! ## Seeding strategy
 //!
 //! The gateway exposes no HTTP route for recording spend, so tests seed
-//! `env.budget_tracker.record_raw_spend(AgentId, Option<&str>, Decimal)`
+//! `env.budget_tracker.record_raw_spend(AgentId, Option<&str>, None, Decimal)`
 //! directly — the same pattern used for `agent_registry` and `trace_store`.
 //!
 //! ## No query-param filtering
@@ -140,6 +140,7 @@ async fn costs_global_date_field_is_iso_date_string() {
     env.budget_tracker.record_raw_spend(
         AgentId::from_bytes(AGENT_A_BYTES),
         Some(TEAM_ID),
+        None,
         Decimal::new(100, 2), // 1.00 USD
     );
 
@@ -166,6 +167,7 @@ async fn costs_per_agent_entry_has_date_field_in_iso_format() {
     env.budget_tracker.record_raw_spend(
         AgentId::from_bytes(AGENT_A_BYTES),
         Some(TEAM_ID),
+        None,
         Decimal::new(250, 2), // 2.50 USD
     );
 
@@ -195,6 +197,7 @@ async fn costs_per_team_entry_has_date_field_in_iso_format() {
     env.budget_tracker.record_raw_spend(
         AgentId::from_bytes(AGENT_A_BYTES),
         Some(TEAM_ID),
+        None,
         Decimal::new(300, 2), // 3.00 USD
     );
 
@@ -227,6 +230,7 @@ async fn costs_reflects_seeded_per_agent_spend() {
     env.budget_tracker.record_raw_spend(
         agent_id,
         Some(TEAM_ID),
+        None,
         Decimal::new(475, 2), // 4.75 USD
     );
 
@@ -257,11 +261,13 @@ async fn costs_reflects_seeded_per_team_spend_and_sorted_order() {
     env.budget_tracker.record_raw_spend(
         AgentId::from_bytes(AGENT_B_BYTES),
         Some(TEAM_ID_B),
+        None,
         Decimal::new(600, 2), // 6.00 USD
     );
     env.budget_tracker.record_raw_spend(
         AgentId::from_bytes(AGENT_A_BYTES),
         Some(TEAM_ID),
+        None,
         Decimal::new(200, 2), // 2.00 USD
     );
 
@@ -315,10 +321,18 @@ async fn costs_global_spend_accumulates_across_agents() {
     let env = TopologyTestEnv::start().await.expect("harness should start");
 
     // Agent A: 3.25 USD; Agent B: 1.75 USD → total 5.00 USD.
-    env.budget_tracker
-        .record_raw_spend(AgentId::from_bytes(AGENT_A_BYTES), Some(TEAM_ID), Decimal::new(325, 2));
-    env.budget_tracker
-        .record_raw_spend(AgentId::from_bytes(AGENT_B_BYTES), Some(TEAM_ID), Decimal::new(175, 2));
+    env.budget_tracker.record_raw_spend(
+        AgentId::from_bytes(AGENT_A_BYTES),
+        Some(TEAM_ID),
+        None,
+        Decimal::new(325, 2),
+    );
+    env.budget_tracker.record_raw_spend(
+        AgentId::from_bytes(AGENT_B_BYTES),
+        Some(TEAM_ID),
+        None,
+        Decimal::new(175, 2),
+    );
 
     let body: serde_json::Value = reqwest::get(format!("{}/api/v1/costs", env.base_url()))
         .await

--- a/aa-integration-tests/tests/common/cli.rs
+++ b/aa-integration-tests/tests/common/cli.rs
@@ -404,7 +404,9 @@ impl CliFixture {
     pub fn seed_cost_sample(&self, agent_id: [u8; 16], team_id: Option<&str>, usd: &str) {
         let amount = Decimal::from_str(usd).expect("seed_cost_sample: invalid USD amount");
         let agent_id = AgentId::from_bytes(agent_id);
-        self.env.budget_tracker.record_raw_spend(agent_id, team_id, amount);
+        self.env
+            .budget_tracker
+            .record_raw_spend(agent_id, team_id, None, amount);
     }
 }
 

--- a/aa-integration-tests/tests/e2e_budget.rs
+++ b/aa-integration-tests/tests/e2e_budget.rs
@@ -16,7 +16,7 @@
 //!
 //! ## Seeding strategy
 //!
-//! `env.budget_tracker.record_raw_spend(AgentId, Option<&str>, Decimal)`
+//! `env.budget_tracker.record_raw_spend(AgentId, Option<&str>, None, Decimal)`
 //! injects spend and returns `BudgetStatus` synchronously — the same pattern
 //! used by `api_costs.rs` (AAASM-1490 / F122 ST-I).
 
@@ -47,7 +47,7 @@ async fn budget_spend_accumulates_per_agent_and_team() {
 
     for _ in 0..5 {
         env.budget_tracker
-            .record_raw_spend(agent, Some(TEAM_A), Decimal::new(50, 2)); // 0.50 USD each
+            .record_raw_spend(agent, Some(TEAM_A), None, Decimal::new(50, 2)); // 0.50 USD each
     }
 
     let agent_state = env
@@ -114,7 +114,7 @@ async fn budget_deny_at_exhaustion_returns_limit_exceeded() {
     // 1.80 USD — within the 2.00 USD cap.
     let status_before = env
         .budget_tracker
-        .record_raw_spend(agent, Some(TEAM_A), Decimal::new(180, 2));
+        .record_raw_spend(agent, Some(TEAM_A), None, Decimal::new(180, 2));
     assert!(
         matches!(
             status_before,
@@ -126,7 +126,7 @@ async fn budget_deny_at_exhaustion_returns_limit_exceeded() {
     // Additional 0.50 USD pushes total to 2.30 — over the cap.
     let status_over = env
         .budget_tracker
-        .record_raw_spend(agent, Some(TEAM_A), Decimal::new(50, 2));
+        .record_raw_spend(agent, Some(TEAM_A), None, Decimal::new(50, 2));
     assert_eq!(
         status_over,
         BudgetStatus::LimitExceeded,
@@ -146,13 +146,13 @@ async fn budget_exhausted_request_is_rejected_at_tracking_layer() {
 
     // Push team over the cap in one call.
     env.budget_tracker
-        .record_raw_spend(agent, Some(TEAM_A), Decimal::new(150, 2)); // 1.50 > 1.00
+        .record_raw_spend(agent, Some(TEAM_A), None, Decimal::new(150, 2)); // 1.50 > 1.00
 
     // A subsequent call must still return LimitExceeded — proving enforcement
     // is checked on every call, not just the first one that crosses the limit.
     let follow_up = env
         .budget_tracker
-        .record_raw_spend(agent, Some(TEAM_A), Decimal::new(10, 2));
+        .record_raw_spend(agent, Some(TEAM_A), None, Decimal::new(10, 2));
     assert_eq!(
         follow_up,
         BudgetStatus::LimitExceeded,
@@ -202,7 +202,7 @@ async fn budget_resets_after_daily_window() {
 
     // Pre-window: record some spend; assert it accumulated.
     env.budget_tracker
-        .record_raw_spend(agent, Some(TEAM_A), Decimal::new(200, 2)); // 2.00 USD
+        .record_raw_spend(agent, Some(TEAM_A), None, Decimal::new(200, 2)); // 2.00 USD
     let before = env
         .budget_tracker
         .team_state(TEAM_A)
@@ -223,7 +223,7 @@ async fn budget_resets_after_daily_window() {
     // total reflects only the new amount.
     let status = env
         .budget_tracker
-        .record_raw_spend(agent, Some(TEAM_A), Decimal::new(75, 2)); // 0.75 USD
+        .record_raw_spend(agent, Some(TEAM_A), None, Decimal::new(75, 2)); // 0.75 USD
     let after = env
         .budget_tracker
         .team_state(TEAM_A)
@@ -257,13 +257,13 @@ async fn budget_per_team_isolation_prevents_cross_team_bleed() {
     // Exhaust team A: 2.50 USD > 2.00 USD cap.
     let status_a = env
         .budget_tracker
-        .record_raw_spend(agent_a, Some(TEAM_A), Decimal::new(250, 2));
+        .record_raw_spend(agent_a, Some(TEAM_A), None, Decimal::new(250, 2));
     assert_eq!(status_a, BudgetStatus::LimitExceeded, "team A should be over its cap");
 
     // Team B: 1.00 USD — independent cap, should be allowed.
     let status_b = env
         .budget_tracker
-        .record_raw_spend(agent_b, Some(TEAM_B), Decimal::new(100, 2));
+        .record_raw_spend(agent_b, Some(TEAM_B), None, Decimal::new(100, 2));
     assert!(
         matches!(
             status_b,
@@ -282,7 +282,7 @@ async fn budget_partial_spend_charged_exactly() {
 
     // Seed a non-round amount: 1.37 USD.
     env.budget_tracker
-        .record_raw_spend(agent, Some(TEAM_A), Decimal::new(137, 2));
+        .record_raw_spend(agent, Some(TEAM_A), None, Decimal::new(137, 2));
 
     let agent_state = env
         .budget_tracker

--- a/aa-integration-tests/tests/e2e_org_isolation.rs
+++ b/aa-integration-tests/tests/e2e_org_isolation.rs
@@ -13,10 +13,11 @@
 //!   tenant.
 //! * **ST-org-2** — Cross-org topology isolation: registry's
 //!   `org_members(oid)` returns only that org's agents.
-//! * **ST-org-3** — Cross-org budget isolation (ignored placeholder):
-//!   `BudgetTracker` is keyed by `team_id` today; an Org-explicit
-//!   tier requires `org_budgets` plumbing — filed as a follow-up
-//!   subtask after this PR opens.
+//! * **ST-org-3** — Cross-org budget isolation: `BudgetTracker` now holds an
+//!   `org_budgets` map plus `with_org_daily_limit` / `with_org_monthly_limit`
+//!   builders (AAASM-2022). Two orgs sharing the same per-org cap prove
+//!   isolation: spending in org-alpha exhausts its envelope without affecting
+//!   org-beta.
 //! * **ST-org-4** — Org-scoped policy evaluation: a policy with
 //!   `scope: org:org-alpha` fires only for org-alpha agents; org-beta
 //!   agents fall through to the cascade default.
@@ -260,22 +261,62 @@ async fn st_org_2_registry_org_members_scopes_topology_by_org() {
 
 // ── ST-org-3 ────────────────────────────────────────────────────────────────
 
-#[tokio::test]
-#[ignore = "AAASM-2022: explicit Org-tier budget tracking — BudgetTracker keys by team_id today; \
-    cross-org isolation works for non-pathological setups (orgs with distinct team_ids) but the \
-    AC asks for an explicit Org tier that this PR does not wire"]
-async fn st_org_3_cross_org_budget_isolation() {
-    // When AAASM-2022 ships:
+#[test]
+fn st_org_3_cross_org_budget_isolation() {
+    // AAASM-2022 — exercises the Org tier on `BudgetTracker` directly.
     //
-    // 1. Configure org-alpha with a daily budget of $1 and org-beta with $10.
-    // 2. Drive enough cost-bearing actions from an org-alpha agent to exhaust
-    //    its $1 budget.
-    // 3. Assert org-alpha agents now hit budget-exceeded denies.
-    // 4. Assert org-beta agents continue accepting (org-isolation; their
-    //    budget was not affected by org-alpha's exhaustion).
-    // 5. Assert the budget-exceeded audit events for org-alpha do not appear
-    //    in a `/api/v1/logs?org_id=org-beta` query.
-    unimplemented!("AAASM-2022 — explicit Org-tier budget enforcement");
+    // The check_action gRPC surface does not transport `cost_usd`, and there
+    // is no production HTTP route for spend ingestion (same caveat documented
+    // by the F116 ST-F suite in `e2e_budget.rs`). Driving the tracker
+    // in-process gives the strongest assertion of the tier's semantics
+    // without papering over the missing transport layer.
+    use aa_core::AgentId;
+    use aa_gateway::budget::pricing::PricingTable;
+    use aa_gateway::budget::tracker::BudgetTracker;
+    use aa_gateway::budget::types::BudgetStatus;
+    use rust_decimal::Decimal;
+    use std::str::FromStr;
+
+    let cap = Decimal::from_str("1.00").expect("cap parses");
+    let tracker =
+        BudgetTracker::new(PricingTable::default_table(), None, None, chrono_tz::UTC).with_org_daily_limit(cap);
+
+    let agent_alpha = AgentId::from_bytes([0xAA; 16]);
+    let agent_beta = AgentId::from_bytes([0xBB; 16]);
+
+    // org-alpha consumes the full envelope in two transactions.
+    let first = tracker.record_raw_spend(agent_alpha, None, Some("org-alpha"), Decimal::from_str("0.60").unwrap());
+    assert!(
+        matches!(first, BudgetStatus::WithinBudget { .. }),
+        "first org-alpha spend must be within budget, got {first:?}"
+    );
+
+    // Pushing org-alpha to the cap exactly trips the Org daily limit.
+    let exhaust = tracker.record_raw_spend(agent_alpha, None, Some("org-alpha"), Decimal::from_str("0.40").unwrap());
+    assert_eq!(
+        exhaust,
+        BudgetStatus::LimitExceeded,
+        "org-alpha must trip its $1.00 daily envelope at exactly $1.00",
+    );
+
+    // org-beta has its own envelope — spending after org-alpha exhausted
+    // must NOT be affected.
+    let beta = tracker.record_raw_spend(agent_beta, None, Some("org-beta"), Decimal::from_str("0.50").unwrap());
+    assert!(
+        matches!(beta, BudgetStatus::WithinBudget { .. }),
+        "org-beta must remain within budget despite org-alpha exhaustion, got {beta:?}"
+    );
+
+    // Tracker reports each org's spend independently.
+    let alpha_state = tracker.org_state("org-alpha").expect("org-alpha must have a state");
+    assert_eq!(alpha_state.spent_usd, cap, "org-alpha spend = $1.00");
+
+    let beta_state = tracker.org_state("org-beta").expect("org-beta must have a state");
+    assert_eq!(
+        beta_state.spent_usd,
+        Decimal::from_str("0.50").unwrap(),
+        "org-beta spend = $0.50, isolated from org-alpha",
+    );
 }
 
 // ── ST-org-4 ────────────────────────────────────────────────────────────────

--- a/docs/src/operations/org-isolation.md
+++ b/docs/src/operations/org-isolation.md
@@ -16,7 +16,7 @@ gateway enforces the following invariants:
 | Topology | `GET /api/v1/topology/overview?org_id=X` returns only X's agents. The registry maintains an `org_index` secondary index for O(members) lookup. |
 | Credential validation | An agent registered in Org A presenting its valid token but claiming `agent_id.org_id = "B"` is rejected with `A2AImpersonationAttempted`. The registry's credential reverse-index catches cross-org reuse before any policy evaluation. |
 | Policy scope | A policy with `scope: org:<id>` cascades only for agents in that org. (Requires the multi-document loader from [AAASM-2023](https://lightning-dust-mite.atlassian.net/browse/AAASM-2023) — partial today.) |
-| Budget | Per-team budget isolation provides implicit Org-tier isolation when each Org uses distinct team_ids. Explicit Org-tier budget tracking is tracked under [AAASM-2022](https://lightning-dust-mite.atlassian.net/browse/AAASM-2022). |
+| Budget | Every Org owns an independent spend envelope on the `BudgetTracker.org_budgets` map. `record_cost` rolls each charge into the agent's `org_id` and enforces `org_daily_limit_usd` / `org_monthly_limit_usd` set via policy YAML or the `with_org_*_limit` builders. Exhausting one Org's envelope never affects another. |
 
 ## How to set up multi-tenancy
 
@@ -90,17 +90,58 @@ When an agent in Org A presents its credential but claims `agent_id.org_id =
 A reviewer searching `aasm audit list --event-type A2AImpersonationAttempted`
 sees these attempts grouped by the org the attacker tried to claim.
 
+## Configuring Org-tier budget limits
+
+Operator-facing knobs live in the `budget:` section of any Global-scoped
+policy document:
+
+```yaml
+budget:
+  daily_limit_usd:        10000.0   # global cap across all orgs
+  monthly_limit_usd:      250000.0
+  org_daily_limit_usd:    1000.0    # AAASM-2022 — per-org daily cap
+  org_monthly_limit_usd:  25000.0   # AAASM-2022 — per-org monthly cap
+  timezone: "UTC"
+  action_on_exceed: deny
+```
+
+Semantics:
+
+* `org_daily_limit_usd` / `org_monthly_limit_usd` are **uniform per-Org**
+  caps — the same envelope applies to every Org that records spend.
+  Cross-Org isolation comes from the tracker maintaining an independent
+  `BudgetState` per `org_id`, not from per-Org-customised limits.
+* Enforcement order in `record_cost` is **global → org → team → agent**,
+  monthly checked before daily within each tier. The first tier that
+  exceeds returns `BudgetStatus::LimitExceeded` and the deny is recorded.
+* Limits enter the tracker via `with_org_daily_limit` /
+  `with_org_monthly_limit` builders during policy load. Restoring from
+  persisted snapshot preserves limits via the same path — the
+  `org_budgets` map is empty on first restore until the migration in
+  AAASM-2022 follow-up lands.
+
+### Observing per-Org spend
+
+```rust
+// In-process accessor:
+let alpha = budget.org_state("acme").map(|s| s.spent_usd);
+```
+
+The dashboard / CLI surfaces for `aasm budget status --org <id>` are
+queued under [AAASM-1232](https://lightning-dust-mite.atlassian.net/browse/AAASM-1232)
+follow-up subtasks.
+
 ## Known gaps
 
-* **Org-tier budget**: explicit Org-tier limits not yet wired —
-  [AAASM-2022](https://lightning-dust-mite.atlassian.net/browse/AAASM-2022).
 * **Org-scoped policy E2E**: `PolicyEngine::load_from_file` doesn't
   populate the scope_index, so `scope: org:<id>` policies need a
   multi-document loader — [AAASM-2023](https://lightning-dust-mite.atlassian.net/browse/AAASM-2023).
 * **Topology endpoints beyond `overview`**: tree / team / lineage /
   stats accept the `org_id` query param but currently ignore it.
+* **Persistence schema for Org-tier spend**: the on-disk snapshot does
+  not yet carry the `org_budgets` map; a restored tracker starts with
+  empty Org state.
 
-These are all carry-overs from the F116 Org-tier isolation acceptance
-work (AAASM-2008). The headline scenarios — audit isolation, topology
-overview scoping, cross-org credential rejection — ship complete in
-AAASM-2008.
+The headline scenarios — audit isolation, topology overview scoping,
+cross-org credential rejection (AAASM-2008), and cross-org budget
+envelope isolation (AAASM-2022) — ship complete.


### PR DESCRIPTION
## Description

AAASM-2022 — wire an explicit **Org tier** into `BudgetTracker`, closing the
last F116 follow-up from the AAASM-2008 closeout audit.

The Org tier sits between the existing **Global** and **Team** tiers, so
`record_cost` now enforces `global → org → team → agent`, monthly preceding
daily within each tier. Two orgs sharing the same per-Org cap spend
independently — exhausting one envelope no longer affects the other.

### Surface additions

| Layer | Change |
|---|---|
| `BudgetTracker` | `org_budgets: DashMap<String, BudgetState>` + `org_daily_limit_usd` / `org_monthly_limit_usd` fields |
| Builders | `with_org_daily_limit(Decimal)`, `with_org_monthly_limit(Decimal)` |
| Reads | `org_state(org_id) -> Option<BudgetState>` (mirrors `team_state`) |
| Recorders | `record_cost`, `record_raw_spend`, `record_usage` gain `org_id: Option<&str>` |
| `BudgetPolicy` YAML | `org_daily_limit_usd` / `org_monthly_limit_usd` (validated like global twins) |
| `PolicyEngine::load_from_file` | Lifts org limits from YAML into the tracker via the new builders |
| Engine `record_spend` | Threads `org_id` from `ctx.metadata` populated by `convert.rs` |

### Commits

| # | Commit | Scope |
|---|---|---|
| 1 | `60f9378b` | `BudgetTracker` fields |
| 2 | `ad421ba6` | `record_*` signature + org enforcement in `record_cost` |
| 3 | `f55deb60` | builders + `org_state` accessor |
| 4 | `b253a034` | `BudgetPolicy` YAML schema |
| 5 | `f7f07b54` | `PolicyEngine` wires YAML → tracker |
| 6 | `039469b8` | ST-org-3 E2E un-ignored |
| 7 | `e53bc554` | `docs/operations/org-isolation.md` |

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] Yes — `BudgetTracker::record_cost`, `record_raw_spend`, `record_usage`
  gain a new third positional `org_id: Option<&str>` argument. All in-tree
  callers updated in this PR; this is a gateway-internal API with no
  external consumers.

## Related Issues

- Related Jira ticket: [AAASM-2022](https://lightning-dust-mite.atlassian.net/browse/AAASM-2022)
- Parent Story: [AAASM-1232](https://lightning-dust-mite.atlassian.net/browse/AAASM-1232)
- Acceptance attestation context: AAASM-2008 (F116 ST-L closeout audit)

## Testing

- [x] Unit tests added / updated — 1068 `aa-gateway` tests still green
- [x] Integration tests added / updated — ST-org-3 (`e2e_org_isolation.rs`)
      un-ignored and asserts cross-org isolation: org-alpha exhausts its $1.00
      envelope while org-beta keeps spending at $0.50 unaffected; `org_state`
      reports each tenant's spend independently. ST-org-1/2/4/5 still pass.
- [x] Pre-commit hooks pass — `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo doc`.

Suite snapshot before push:

```
Summary [  91.127s] 1456/1645 tests run: 1455 passed (2 leaky), 1 failed, 9 skipped
FAIL [   1.721s] (1441/1645) aa-integration-tests::cli_proxy proxy_logs_follow_streams_new_entries
```

The single failure (`proxy_logs_follow_streams_new_entries`) reproduces on
`remote/master` cleanly — pre-existing flake, unrelated to AAASM-2022.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated (`docs/src/operations/org-isolation.md`)
- [x] Commits are small and follow the Gitmoji convention (7 atomic commits)


[AAASM-2022]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ