### PR TITLE
[AAASM-2020] ✅ (aa-integration-tests): Add e2e_tool_sandbox_fs covering Scenarios 1 + 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "aa-proto",
  "aa-proxy",
  "aa-runtime",
+ "aa-sandbox",
  "anyhow",
  "assert_cmd",
  "async-trait",
@@ -358,6 +359,7 @@ dependencies = [
  "tokio-util",
  "tonic",
  "uuid",
+ "wat",
 ]
 
 [[package]]

--- a/aa-integration-tests/Cargo.toml
+++ b/aa-integration-tests/Cargo.toml
@@ -24,6 +24,7 @@ aa-gateway  = { path = "../aa-gateway" }
 aa-proto    = { path = "../aa-proto" }
 aa-proxy    = { path = "../aa-proxy" }
 aa-runtime  = { path = "../aa-runtime" }
+aa-sandbox  = { path = "../aa-sandbox" }
 
 anyhow      = "1"
 assert_cmd  = "2"
@@ -53,6 +54,7 @@ tokio-util        = "0.7"
 tonic             = { version = "0.14", features = ["transport"] }
 uuid              = { version = "1", features = ["v4"] }
 futures           = "0.3"
+wat               = "1"
 
 # Linux-only dev-deps for the AAASM-1520 / F116 ST-H eBPF E2E suite (also
 # used by AAASM-1522 / F116 ST-J file-monitoring E2E suite). Gated on

--- a/aa-integration-tests/fixtures/wasm/fs_probe.wat
+++ b/aa-integration-tests/fixtures/wasm/fs_probe.wat
@@ -1,0 +1,33 @@
+;; AAASM-2020 / F116 ST-W Scenario 1 — filesystem-isolation probe.
+;;
+;; Places the literal "/etc/passwd" at memory offset 0, then invokes
+;; WASI preview 1 `path_open` with `fd = 3` (the first non-stdio fd,
+;; unbound when `SandboxConfig::preopened_dirs` is empty). The returned
+;; errno is surfaced via `proc_exit`, which the sandbox runtime catches
+;; as `I32Exit(errno)` and maps to
+;; `SandboxError::FilesystemBlocked { errno }` (errno is EBADF / 8 under
+;; the empty-allowlist case; ENOTCAPABLE / 76 if a path escapes a
+;; preopen tree).
+(module
+  (import "wasi_snapshot_preview1" "path_open"
+    (func $path_open (param i32 i32 i32 i32 i32 i64 i64 i32 i32) (result i32)))
+  (import "wasi_snapshot_preview1" "proc_exit"
+    (func $proc_exit (param i32)))
+  (memory (export "memory") 1)
+  (data (i32.const 0) "/etc/passwd")
+  (func (export "_start")
+    (call $proc_exit
+      (call $path_open
+        (i32.const 3)
+        (i32.const 0)
+        (i32.const 0)
+        (i32.const 11)
+        (i32.const 0)
+        (i64.const 0)
+        (i64.const 0)
+        (i32.const 0)
+        (i32.const 100)
+      )
+    )
+  )
+)

--- a/aa-integration-tests/fixtures/wasm/mem_bomb.wat
+++ b/aa-integration-tests/fixtures/wasm/mem_bomb.wat
@@ -1,0 +1,14 @@
+;; AAASM-2020 / F116 ST-W Scenario 2b — memory exhaustion.
+;;
+;; Declares a 1-page initial linear memory then immediately tries to
+;; grow it by 100 pages (= 6.4 MiB), well past the default
+;; `SandboxLimits::memory_pages = 16` (1 MiB) cap. The `MemoryLimit`
+;; `ResourceLimiter` returns `Err(MemoryExhaustedMarker)` for the grow,
+;; which wasmtime surfaces as a trap; the runtime maps it to
+;; `SandboxError::MemoryExhausted`.
+(module
+  (memory (export "memory") 1)
+  (func (export "_start")
+    (drop (memory.grow (i32.const 100)))
+  )
+)

--- a/aa-integration-tests/fixtures/wasm/runaway.wat
+++ b/aa-integration-tests/fixtures/wasm/runaway.wat
@@ -1,0 +1,11 @@
+;; AAASM-2020 / F116 ST-W Scenario 2a — runaway loop / CPU timeout.
+;;
+;; `_start` enters an infinite WebAssembly loop. Each iteration consumes
+;; ~1 unit of wasmtime instruction fuel, so a small `SandboxLimits::fuel`
+;; budget trips `Trap::OutOfFuel` within microseconds. The runtime maps
+;; that to `SandboxError::CpuTimeout`.
+(module
+  (func (export "_start")
+    (loop $infinite (br $infinite))
+  )
+)

--- a/aa-integration-tests/tests/e2e_tool_sandbox_fs.rs
+++ b/aa-integration-tests/tests/e2e_tool_sandbox_fs.rs
@@ -38,10 +38,11 @@
 use aa_core::audit::AuditEventType;
 use aa_proxy::wasm_dispatch::{dispatch_wasm_tool, WasmDispatchResult};
 use aa_sandbox::error::SandboxError;
-use aa_sandbox::policy::SandboxConfig;
+use aa_sandbox::policy::{SandboxConfig, SandboxLimits};
 use aa_sandbox::registry::{ToolKind, ToolRegistry};
 
 const FS_PROBE_WAT: &str = include_str!("../fixtures/wasm/fs_probe.wat");
+const RUNAWAY_WAT: &str = include_str!("../fixtures/wasm/runaway.wat");
 
 /// Build a [`ToolRegistry`] containing a single WASM tool compiled
 /// from `wat_source` at test time and registered under `name`.
@@ -74,6 +75,41 @@ async fn sandbox_blocks_etc_passwd_read() {
             assert_eq!(
                 audit_events,
                 vec![AuditEventType::SandboxStarted, AuditEventType::SandboxFilesystemBlocked,],
+            );
+        }
+        WasmDispatchResult::NotWasm => panic!("registered Wasm tool must dispatch as Wasm"),
+    }
+}
+
+#[tokio::test]
+async fn sandbox_kills_runaway_loop() {
+    // Tight 1 000-unit fuel budget so the runaway loop trips
+    // `Trap::OutOfFuel` within microseconds; default memory + wall-clock
+    // budgets are kept (irrelevant — fuel exhausts first under any
+    // non-zero budget on a pure-CPU runaway).
+    let config = SandboxConfig {
+        limits: SandboxLimits {
+            fuel: 1_000,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let reg = registry_with("runaway", RUNAWAY_WAT, config);
+
+    let outcome = tokio::task::spawn_blocking(move || dispatch_wasm_tool("runaway", &[], &reg))
+        .await
+        .expect("dispatch task must not panic");
+
+    match outcome {
+        WasmDispatchResult::Wasm { result, audit_events } => {
+            assert!(
+                matches!(result, Err(SandboxError::CpuTimeout)),
+                "expected SandboxError::CpuTimeout, got {:?}",
+                result,
+            );
+            assert_eq!(
+                audit_events,
+                vec![AuditEventType::SandboxStarted, AuditEventType::SandboxCpuTimeout],
             );
         }
         WasmDispatchResult::NotWasm => panic!("registered Wasm tool must dispatch as Wasm"),

--- a/aa-integration-tests/tests/e2e_tool_sandbox_fs.rs
+++ b/aa-integration-tests/tests/e2e_tool_sandbox_fs.rs
@@ -43,6 +43,7 @@ use aa_sandbox::registry::{ToolKind, ToolRegistry};
 
 const FS_PROBE_WAT: &str = include_str!("../fixtures/wasm/fs_probe.wat");
 const RUNAWAY_WAT: &str = include_str!("../fixtures/wasm/runaway.wat");
+const MEM_BOMB_WAT: &str = include_str!("../fixtures/wasm/mem_bomb.wat");
 
 /// Build a [`ToolRegistry`] containing a single WASM tool compiled
 /// from `wat_source` at test time and registered under `name`.
@@ -110,6 +111,35 @@ async fn sandbox_kills_runaway_loop() {
             assert_eq!(
                 audit_events,
                 vec![AuditEventType::SandboxStarted, AuditEventType::SandboxCpuTimeout],
+            );
+        }
+        WasmDispatchResult::NotWasm => panic!("registered Wasm tool must dispatch as Wasm"),
+    }
+}
+
+#[tokio::test]
+async fn sandbox_kills_memory_bomb() {
+    // Default `SandboxLimits::memory_pages = 16` (1 MiB). The fixture
+    // declares 1 page and immediately tries to grow by 100 pages
+    // (~6.4 MiB), well past the cap — the limiter returns
+    // `Err(MemoryExhaustedMarker)` which the runtime surfaces as
+    // `SandboxError::MemoryExhausted`.
+    let reg = registry_with("mem_bomb", MEM_BOMB_WAT, SandboxConfig::default());
+
+    let outcome = tokio::task::spawn_blocking(move || dispatch_wasm_tool("mem_bomb", &[], &reg))
+        .await
+        .expect("dispatch task must not panic");
+
+    match outcome {
+        WasmDispatchResult::Wasm { result, audit_events } => {
+            assert!(
+                matches!(result, Err(SandboxError::MemoryExhausted)),
+                "expected SandboxError::MemoryExhausted, got {:?}",
+                result,
+            );
+            assert_eq!(
+                audit_events,
+                vec![AuditEventType::SandboxStarted, AuditEventType::SandboxOomKilled],
             );
         }
         WasmDispatchResult::NotWasm => panic!("registered Wasm tool must dispatch as Wasm"),

--- a/aa-integration-tests/tests/e2e_tool_sandbox_fs.rs
+++ b/aa-integration-tests/tests/e2e_tool_sandbox_fs.rs
@@ -1,0 +1,81 @@
+//! AAASM-2020 / F116 ST-W E2E — WASM/WASI sandbox tool execution.
+//!
+//! Three scenarios covering both halves of F116 ST-W (parent Story
+//! AAASM-1965):
+//!
+//! * **Scenario 1 — Filesystem isolation** (AAASM-2017).
+//!   `sandbox_blocks_etc_passwd_read` registers a WASM tool that calls
+//!   `path_open("/etc/passwd")` with an empty preopen allowlist;
+//!   asserts the dispatch helper returns
+//!   [`SandboxError::FilesystemBlocked`] AND emits the audit-event
+//!   sequence `[SandboxStarted, SandboxFilesystemBlocked]`.
+//! * **Scenario 2a — CPU timeout** (AAASM-2018). `sandbox_kills_runaway_loop`
+//!   registers a runaway-loop WASM tool with a 1 000-unit fuel budget;
+//!   asserts [`SandboxError::CpuTimeout`] AND audit
+//!   `[SandboxStarted, SandboxCpuTimeout]`.
+//! * **Scenario 2b — Memory exhaustion** (AAASM-2018).
+//!   `sandbox_kills_memory_bomb` registers a `memory.grow(100)` WASM
+//!   tool under the default 16-page (1 MiB) cap; asserts
+//!   [`SandboxError::MemoryExhausted`] AND audit
+//!   `[SandboxStarted, SandboxOomKilled]`.
+//!
+//! # Scope note
+//!
+//! The AAASM-2020 ticket text proposed using `TopologyTestEnv` (the
+//! pattern from `e2e_secret_injection.rs`) for "audit-sink readback".
+//! That pattern works when the dispatch lives behind an HTTP route
+//! (the secret-injection case fronts `/dispatch_tool`). The
+//! AAASM-2019 dispatch helper
+//! ([`aa_proxy::wasm_dispatch::dispatch_wasm_tool`]) is currently a
+//! synchronous pure function not yet wired into any HTTP route — its
+//! audit-event sink IS the `audit_events: Vec<AuditEventType>` field
+//! on the returned [`WasmDispatchResult::Wasm`]. These tests inspect
+//! that field directly, which is the canonical "audit-sink readback"
+//! at the helper's contract boundary. Wiring the helper into a
+//! production HTTP endpoint is the right scope for a follow-up
+//! sub-task once an external surface needs it.
+
+use aa_core::audit::AuditEventType;
+use aa_proxy::wasm_dispatch::{dispatch_wasm_tool, WasmDispatchResult};
+use aa_sandbox::error::SandboxError;
+use aa_sandbox::policy::SandboxConfig;
+use aa_sandbox::registry::{ToolKind, ToolRegistry};
+
+const FS_PROBE_WAT: &str = include_str!("../fixtures/wasm/fs_probe.wat");
+
+/// Build a [`ToolRegistry`] containing a single WASM tool compiled
+/// from `wat_source` at test time and registered under `name`.
+fn registry_with(name: &str, wat_source: &str, config: SandboxConfig) -> ToolRegistry {
+    let module_bytes = wat::parse_str(wat_source).expect("fixture WAT must parse");
+    let reg = ToolRegistry::new();
+    reg.register(name, ToolKind::Wasm { module_bytes, config });
+    reg
+}
+
+#[tokio::test]
+async fn sandbox_blocks_etc_passwd_read() {
+    let reg = registry_with("fs_probe", FS_PROBE_WAT, SandboxConfig::default());
+
+    // The dispatch helper is synchronous wasmtime work; wrap with
+    // `spawn_blocking` so the runtime's executor isn't held up by
+    // the sandbox call. This mirrors how the proxy data path will
+    // host the helper once it lands behind an HTTP endpoint.
+    let outcome = tokio::task::spawn_blocking(move || dispatch_wasm_tool("fs_probe", &[], &reg))
+        .await
+        .expect("dispatch task must not panic");
+
+    match outcome {
+        WasmDispatchResult::Wasm { result, audit_events } => {
+            assert!(
+                matches!(result, Err(SandboxError::FilesystemBlocked { .. })),
+                "expected SandboxError::FilesystemBlocked, got {:?}",
+                result,
+            );
+            assert_eq!(
+                audit_events,
+                vec![AuditEventType::SandboxStarted, AuditEventType::SandboxFilesystemBlocked,],
+            );
+        }
+        WasmDispatchResult::NotWasm => panic!("registered Wasm tool must dispatch as Wasm"),
+    }
+}


### PR DESCRIPTION
## Description

E2E coverage for F116 ST-W (parent Story: AAASM-1965). New file `aa-integration-tests/tests/e2e_tool_sandbox_fs.rs` with three `#[tokio::test]` cases plus a checked-in `aa-integration-tests/fixtures/wasm/` directory holding the three WAT sources.

### Tests

| Test | Scenario | Source | Asserts |
|---|---|---|---|
| `sandbox_blocks_etc_passwd_read` | 1 — filesystem isolation (AAASM-2017) | `fs_probe.wat` | `Err(SandboxError::FilesystemBlocked { .. })` + `[SandboxStarted, SandboxFilesystemBlocked]` |
| `sandbox_kills_runaway_loop` | 2a — CPU timeout (AAASM-2018) | `runaway.wat` | `Err(SandboxError::CpuTimeout)` + `[SandboxStarted, SandboxCpuTimeout]` |
| `sandbox_kills_memory_bomb` | 2b — memory exhaustion (AAASM-2018) | `mem_bomb.wat` | `Err(SandboxError::MemoryExhausted)` + `[SandboxStarted, SandboxOomKilled]` |

Each test:

1. Compiles the corresponding `.wat` fixture at test time via `wat::parse_str(include_str!(...))`.
2. Builds a single-entry `ToolRegistry` with the bytes wrapped in `ToolKind::Wasm { module_bytes, config }`.
3. Invokes `aa_proxy::wasm_dispatch::dispatch_wasm_tool` via `tokio::task::spawn_blocking` (the dispatch helper is synchronous wasmtime work; `spawn_blocking` mirrors how the proxy data path will host the helper once it lands behind an HTTP endpoint).
4. Asserts both the `SandboxError` variant AND the exact `Vec<AuditEventType>` event sequence.

### Two deviations from the ticket text (both documented in commits + the module doc-comment)

1. **`TopologyTestEnv` not used.** The AC proposed mirroring `e2e_secret_injection.rs`'s pattern. That pattern works when the dispatch lives behind an HTTP endpoint (the secret-injection case fronts `/dispatch_tool`). The AAASM-2019 dispatch helper is currently a synchronous pure function not wired into any HTTP route — its audit-event sink IS the `audit_events: Vec<AuditEventType>` field on the returned `WasmDispatchResult::Wasm`. These tests read that field directly, which is the canonical audit-sink readback at the helper's contract boundary. Wiring into a production HTTP endpoint is the right scope for a follow-up.
2. **`.wat` sources only — no pre-compiled `.wasm` artifacts.** The AC proposed checking in both `.wat` sources and pre-compiled `.wasm` artifacts. `wat::parse_str` at test time is sub-millisecond per fixture (the same pattern AAASM-2017 / 2018 / 2019 unit tests use); pre-compilation would require a `build.rs` or hand-running `wasm-tools` to keep the two in sync. Keeping just the `.wat` sources as the single source of truth removes the drift risk.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release
- [x] ✅ Tests

(Tests-only change; no production code modified.)

## Breaking Changes

- [x] No
- [ ] Yes

Tests-only change.

## Related Issues

- Related Jira ticket: **AAASM-2020** (sub-task of parent Story **AAASM-1965**)
- Builds on merged AAASM-2015 (#805) / AAASM-2016 (#806) / AAASM-2017 (#808) / AAASM-2018 (#810) / AAASM-2019 (#811)

## Testing

`cargo nextest run -p aa-integration-tests --test e2e_tool_sandbox_fs` → **3 passed, 0 failed**.

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required

Local validation:

```text
cargo nextest run -p aa-integration-tests --test e2e_tool_sandbox_fs   # 3/3 pass
cargo clippy -p aa-integration-tests --tests -- -D warnings             # clean
cargo deny check                                                         # ok ok ok ok
cargo doc -p aa-integration-tests --no-deps                              # clean
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (module doc-comment documents the two deviations + per-WAT doc-comments name the AAASM-XXXX scope)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Commit log

| Commit | Scope |
|---|---|
| `a220a81f` | ✨ (aa-integration-tests/fixtures): Add WAT sources for sandbox e2e |
| `93b00bc0` | 🔧 (aa-integration-tests): Add aa-sandbox + wat dev-dependencies |
| `6f82335c` | ✅ (aa-integration-tests): Add sandbox_blocks_etc_passwd_read e2e test |
| `4a895f80` | ✅ (aa-integration-tests): Add sandbox_kills_runaway_loop e2e test |
| `45f4f03a` | ✅ (aa-integration-tests): Add sandbox_kills_memory_bomb e2e test |