### PR TITLE
[AAASM-2033] ✨ (aa-api+aa-sandbox): Wire dispatch_wasm_tool into /dispatch_tool HTTP route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,6 @@ dependencies = [
  "aa-core",
  "aa-proto",
  "aa-runtime",
- "aa-sandbox",
  "anyhow",
  "bytes",
  "criterion",
@@ -400,7 +399,6 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "tracing-subscriber",
- "wat",
 ]
 
 [[package]]
@@ -436,6 +434,7 @@ dependencies = [
 name = "aa-sandbox"
 version = "0.0.1"
 dependencies = [
+ "aa-core",
  "thiserror 2.0.18",
  "wasmtime",
  "wasmtime-wasi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "aa-gateway",
  "aa-proto",
  "aa-runtime",
+ "aa-sandbox",
  "argon2",
  "async-trait",
  "axum",

--- a/aa-api/Cargo.toml
+++ b/aa-api/Cargo.toml
@@ -18,6 +18,7 @@ aa-devtool-saas  = { path = "../aa-devtool-saas" }
 aa-gateway = { path = "../aa-gateway" }
 aa-proto = { path = "../aa-proto" }
 aa-runtime = { path = "../aa-runtime" }
+aa-sandbox = { path = "../aa-sandbox" }
 argon2 = "0.5"
 async-trait = "0.1"
 axum = { version = "0.8", features = ["ws"] }

--- a/aa-api/src/routes/dispatch.rs
+++ b/aa-api/src/routes/dispatch.rs
@@ -1,27 +1,37 @@
 //! `POST /api/v1/dispatch_tool` — Secret Injection tool-dispatch route
-//! (AAASM-1920 / Story scope #3).
+//! (AAASM-1920 / Story scope #3) + WASM sandbox dispatch route
+//! (AAASM-2033 / F116 ST-W data-path follow-up).
 //!
-//! Pipeline executed per request:
+//! Two flows fan in through the same endpoint, demultiplexed on the
+//! tool's [`ToolKind`] in the [`AppState::tool_registry`]:
 //!
-//! 1. Walk the agent's placeholder-form `args` through
-//!    [`aa_gateway::secrets::resolver::resolve_placeholders`] using the
-//!    [`SecretsStore`](aa_gateway::secrets::SecretsStore) handle on
-//!    [`AppState::secrets_store`](crate::state::AppState::secrets_store).
-//! 2. Emit a [`AuditEventType::ToolDispatched`](aa_core::AuditEventType)
-//!    audit entry **with the placeholder-form args** — the resolved
-//!    credential value never appears in any audit field, per the AAASM-1920
-//!    audit-shape contract.
-//! 3. Return the resolved args + the list of substituted placeholder names
-//!    to the caller; the caller (Python SDK in v0.0.1, ST6 / AAASM-1928)
-//!    is responsible for forwarding the resolved args to the actual tool
-//!    sink.
+//! * **WASM tools** (`ToolKind::Wasm`): the args are forwarded as raw
+//!   bytes to [`aa_sandbox::wasm_dispatch::dispatch_wasm_tool`] under
+//!   `tokio::task::spawn_blocking` (the sandbox is synchronous wasmtime
+//!   work). The lifecycle audit-event sequence
+//!   (`SandboxStarted`/`Sandbox<outcome>`) is emitted to the audit
+//!   pipeline. The response carries the sandbox verdict in the
+//!   `sandbox` field; `resolved_args` is `null` and
+//!   `names_substituted` is empty for this path.
+//! * **Native or unknown tools**: the existing AAASM-1920 secret-injection
+//!   pipeline runs — placeholder `${NAME}` tokens are resolved via the
+//!   [`SecretsStore`], a `ToolDispatched` audit entry is emitted with the
+//!   **placeholder-form** args (the resolved credential value is never
+//!   recorded), and the resolved args + the list of substituted names are
+//!   returned to the caller.
 //!
 //! Unknown placeholders surface as HTTP 422 with a [`ProblemDetail`]
 //! referencing the unresolved placeholder name — the resolver refuses to
 //! silently forward the literal `${UNKNOWN}` token.
+//!
+//! [`ToolKind`]: aa_sandbox::registry::ToolKind
 
+use aa_core::audit::AuditEntry;
 use aa_core::{AgentId, SessionId};
 use aa_gateway::secrets::{resolver::resolve_placeholders, SecretInjectionError};
+use aa_sandbox::error::SandboxError;
+use aa_sandbox::registry::ToolKind;
+use aa_sandbox::wasm_dispatch::{dispatch_wasm_tool, WasmDispatchResult};
 use axum::extract::Extension;
 use axum::http::StatusCode;
 use axum::Json;
@@ -37,36 +47,74 @@ pub struct DispatchToolRequest {
     /// Name of the tool the agent wants to dispatch (e.g. `"call_database"`).
     pub tool: String,
     /// Placeholder-form args. May contain `${NAME}` tokens that the gateway
-    /// will resolve via the `SecretsStore` before audit + forwarding.
+    /// will resolve via the `SecretsStore` before audit + forwarding. For
+    /// WASM tools (`ToolKind::Wasm`) the args are forwarded as raw bytes to
+    /// the sandbox without placeholder resolution.
     pub args: serde_json::Value,
 }
 
 /// Response body for `POST /api/v1/dispatch_tool`.
+///
+/// Two flows fan in through this shape:
+///
+/// * **Native / secret-injection** — `resolved_args` + `names_substituted`
+///   carry the AAASM-1920 result; `sandbox` is `None`.
+/// * **WASM sandbox** (AAASM-2033) — `sandbox` carries the dispatch
+///   verdict; `resolved_args` is `null` and `names_substituted` is empty.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct DispatchToolResponse {
     /// Post-substitution args ready to forward to the tool sink. Contains
     /// the *resolved* credential values; callers must not log these.
+    /// `null` for WASM-sandbox dispatches.
     pub resolved_args: serde_json::Value,
     /// The placeholder names that were resolved during this call. Names
     /// only — never the resolved values. Echoes the audit-log shape so
-    /// callers can correlate dispatches with audit entries.
+    /// callers can correlate dispatches with audit entries. Empty for
+    /// WASM-sandbox dispatches.
     pub names_substituted: Vec<String>,
+    /// WASM sandbox dispatch verdict, present only when the named tool was
+    /// registered as `ToolKind::Wasm` in `AppState::tool_registry`.
+    /// (AAASM-2033 / F116 ST-W.)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sandbox: Option<SandboxDispatchOutcome>,
 }
 
-/// Dispatch a tool with placeholder-form args.
+/// Sandbox dispatch outcome — populated on the `sandbox` field of
+/// [`DispatchToolResponse`] when the named tool routed through
+/// [`aa_sandbox::wasm_dispatch::dispatch_wasm_tool`].
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SandboxDispatchOutcome {
+    /// `true` iff the sandbox runtime returned `Ok`. `false` for every
+    /// `SandboxError` variant.
+    pub ok: bool,
+    /// WASI exit code surfaced by a clean guest exit (`proc_exit(0)` or a
+    /// `_start` return). `None` when the dispatch failed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    /// Discriminant name of the [`SandboxError`] variant that fired —
+    /// `FilesystemBlocked`, `CpuTimeout`, `WallClockTimeout`,
+    /// `MemoryExhausted`, `InvalidWasm`, or `Wasmtime`. `None` on success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// WASI errno that triggered `FilesystemBlocked`. `None` for other
+    /// error variants and for success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub errno: Option<u32>,
+}
+
+/// Dispatch a tool by name.
 ///
-/// Resolves any `${NAME}` tokens in `args` via the registered
-/// `SecretsStore`, emits an audit entry tagged
-/// `AuditEventType::ToolDispatched` carrying the **placeholder-form**
-/// payload (the resolved value is never recorded), and returns the
-/// resolved args plus the list of substituted names.
+/// Demultiplexes on the registered [`ToolKind`]: WASM tools route through
+/// the sandbox; native / unknown tools fall through to the existing
+/// secret-injection resolver.
 #[utoipa::path(
     post,
     path = "/api/v1/dispatch_tool",
     request_body = DispatchToolRequest,
     responses(
-        (status = 200, description = "Tool dispatch resolved", body = DispatchToolResponse),
+        (status = 200, description = "Tool dispatch resolved (native) or sandboxed (WASM)", body = DispatchToolResponse),
         (status = 422, description = "Unknown placeholder referenced in args", body = ProblemDetail),
+        (status = 500, description = "Sandbox dispatch task panicked", body = ProblemDetail),
         (status = 503, description = "Audit pipeline is not connected", body = ProblemDetail),
     ),
     tag = "dispatch"
@@ -75,7 +123,14 @@ pub async fn dispatch_tool(
     Extension(state): Extension<AppState>,
     Json(body): Json<DispatchToolRequest>,
 ) -> Result<Json<DispatchToolResponse>, ProblemDetail> {
-    // 1. Resolve placeholders. The store is held as `Arc<dyn SecretsStore>`.
+    // ── WASM dispatch branch ────────────────────────────────────────
+    // A `ToolKind::Wasm` registry entry bypasses secret injection — the
+    // args travel into the sandbox as raw JSON bytes.
+    if matches!(state.tool_registry.get(&body.tool), Some(ToolKind::Wasm { .. })) {
+        return dispatch_wasm(&state, &body).await;
+    }
+
+    // ── Native / secret-injection branch (existing AAASM-1920 path) ──
     let outcome = resolve_placeholders(&body.args, state.secrets_store.as_ref()).map_err(|e| match e {
         SecretInjectionError::UnknownPlaceholder { name } => {
             ProblemDetail::from_status(StatusCode::UNPROCESSABLE_ENTITY)
@@ -83,8 +138,8 @@ pub async fn dispatch_tool(
         }
     })?;
 
-    // 2. Emit audit entry with the placeholder-form args. Non-blocking;
-    //    503 if the pipeline is not connected (matches devtools pattern).
+    // Emit audit entry with the placeholder-form args. Non-blocking;
+    // 503 if the pipeline is not connected (matches devtools pattern).
     if let Some(sender) = state.audit_sender.as_ref() {
         // v0.0.1: no per-dispatch session/agent context flows in via the
         // HTTP body. The E2E harness wires concrete ids via the test env
@@ -93,10 +148,7 @@ pub async fn dispatch_tool(
         // caller-supplied bytes.
         let entry = aa_core::audit::audit_entry_for_tool_dispatch(
             0,
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos() as u64)
-                .unwrap_or(0),
+            unix_now_ns(),
             AgentId::from_bytes([0u8; 16]),
             SessionId::from_bytes([0u8; 16]),
             &body.args,
@@ -112,5 +164,129 @@ pub async fn dispatch_tool(
     Ok(Json(DispatchToolResponse {
         resolved_args: outcome.resolved,
         names_substituted: outcome.names_substituted,
+        sandbox: None,
     }))
+}
+
+/// WASM sandbox dispatch path — pulled out so the parent handler stays
+/// readable. Builds a registry handle clone, runs the dispatch under
+/// `spawn_blocking`, emits the audit-event sequence to the audit sink,
+/// and packages the verdict into a [`DispatchToolResponse`].
+async fn dispatch_wasm(
+    state: &AppState,
+    body: &DispatchToolRequest,
+) -> Result<Json<DispatchToolResponse>, ProblemDetail> {
+    let registry = state.tool_registry.clone();
+    let tool_name = body.tool.clone();
+    let args_bytes = serde_json::to_vec(&body.args).unwrap_or_default();
+
+    let outcome = tokio::task::spawn_blocking(move || dispatch_wasm_tool(&tool_name, &args_bytes, &registry))
+        .await
+        .map_err(|e| {
+            ProblemDetail::from_status(StatusCode::INTERNAL_SERVER_ERROR)
+                .with_detail(format!("sandbox dispatch task panicked: {e}"))
+        })?;
+
+    let (result, audit_events) = match outcome {
+        WasmDispatchResult::Wasm { result, audit_events } => (result, audit_events),
+        // Defensive: the caller already checked `ToolKind::Wasm` before
+        // routing here. If the registry races a `register(Native)` swap
+        // between the check and the dispatch, fall through to the
+        // secret-injection path instead of returning a stale Wasm shape.
+        WasmDispatchResult::NotWasm => {
+            return Ok(Json(DispatchToolResponse {
+                resolved_args: serde_json::Value::Null,
+                names_substituted: Vec::new(),
+                sandbox: None,
+            }));
+        }
+    };
+
+    // Emit the lifecycle audit-event sequence
+    // (`SandboxStarted, <outcome>`) to the production audit sink.
+    // Same zero-id contract as the native-path entry above — concrete
+    // session/agent ids will be wired through once the dispatch route
+    // is reachable from a session-aware caller (AAASM-1931 follow-up).
+    if let Some(sender) = state.audit_sender.as_ref() {
+        let now = unix_now_ns();
+        for (idx, event_type) in audit_events.iter().enumerate() {
+            let entry = AuditEntry::new(
+                idx as u64,
+                now,
+                *event_type,
+                AgentId::from_bytes([0u8; 16]),
+                SessionId::from_bytes([0u8; 16]),
+                String::new(),
+                [0u8; 32],
+            );
+            let _ = sender.try_send(entry);
+        }
+    }
+
+    let sandbox = match result {
+        Ok(output) => SandboxDispatchOutcome {
+            ok: true,
+            exit_code: Some(output.exit_code),
+            error: None,
+            errno: None,
+        },
+        Err(err) => sandbox_error_to_outcome(&err),
+    };
+
+    Ok(Json(DispatchToolResponse {
+        resolved_args: serde_json::Value::Null,
+        names_substituted: Vec::new(),
+        sandbox: Some(sandbox),
+    }))
+}
+
+/// Map a [`SandboxError`] to the [`SandboxDispatchOutcome`] payload.
+fn sandbox_error_to_outcome(err: &SandboxError) -> SandboxDispatchOutcome {
+    match err {
+        SandboxError::FilesystemBlocked { errno } => SandboxDispatchOutcome {
+            ok: false,
+            exit_code: None,
+            error: Some("FilesystemBlocked".to_string()),
+            errno: Some(*errno),
+        },
+        SandboxError::CpuTimeout => SandboxDispatchOutcome {
+            ok: false,
+            exit_code: None,
+            error: Some("CpuTimeout".to_string()),
+            errno: None,
+        },
+        SandboxError::WallClockTimeout => SandboxDispatchOutcome {
+            ok: false,
+            exit_code: None,
+            error: Some("WallClockTimeout".to_string()),
+            errno: None,
+        },
+        SandboxError::MemoryExhausted => SandboxDispatchOutcome {
+            ok: false,
+            exit_code: None,
+            error: Some("MemoryExhausted".to_string()),
+            errno: None,
+        },
+        SandboxError::InvalidWasm(msg) => SandboxDispatchOutcome {
+            ok: false,
+            exit_code: None,
+            error: Some(format!("InvalidWasm: {msg}")),
+            errno: None,
+        },
+        SandboxError::Wasmtime(msg) => SandboxDispatchOutcome {
+            ok: false,
+            exit_code: None,
+            error: Some(format!("Wasmtime: {msg}")),
+            errno: None,
+        },
+    }
+}
+
+/// Current Unix timestamp in nanoseconds. Matches the helper used by the
+/// native path; extracted so both branches stay in sync.
+fn unix_now_ns() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0)
 }

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -18,6 +18,7 @@ use aa_gateway::secrets::SecretsStore;
 use aa_gateway::storage::RetentionEngine;
 use aa_gateway::AuditReader;
 use aa_runtime::approval::ApprovalQueue;
+use aa_sandbox::registry::ToolRegistry;
 
 use crate::alerts::rules::destinations::DestinationRegistry;
 use crate::alerts::rules::store::AlertRuleStore;
@@ -124,4 +125,11 @@ pub struct AppState {
     /// can resolve `${NAME}` tokens via
     /// `aa-gateway::secrets::resolver::resolve_placeholders`.
     pub secrets_store: Arc<dyn SecretsStore>,
+    /// In-memory `tools/call` registry consumed by `POST /v1/dispatch_tool`
+    /// when the named tool is a WASM-marked entry. The handler invokes
+    /// [`aa_proxy::wasm_dispatch::dispatch_wasm_tool`] for those; native
+    /// (or absent) entries fall through to the existing
+    /// secret-injection / forward-upstream path. (AAASM-2033 /
+    /// F116 ST-W data-path follow-up.)
+    pub tool_registry: ToolRegistry,
 }

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -127,7 +127,7 @@ pub struct AppState {
     pub secrets_store: Arc<dyn SecretsStore>,
     /// In-memory `tools/call` registry consumed by `POST /v1/dispatch_tool`
     /// when the named tool is a WASM-marked entry. The handler invokes
-    /// [`aa_proxy::wasm_dispatch::dispatch_wasm_tool`] for those; native
+    /// [`aa_sandbox::wasm_dispatch::dispatch_wasm_tool`] for those; native
     /// (or absent) entries fall through to the existing
     /// secret-injection / forward-upstream path. (AAASM-2033 /
     /// F116 ST-W data-path follow-up.)

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -32,6 +32,7 @@ use aa_gateway::secrets::InMemorySecretsStore;
 use aa_gateway::storage::RetentionEngine;
 use aa_gateway::AuditReader;
 use aa_runtime::approval::ApprovalQueue;
+use aa_sandbox::registry::ToolRegistry;
 use axum::Router;
 
 /// Default JWT test secret (>= 32 bytes).
@@ -176,6 +177,7 @@ spec:
         destination_registry: Arc::new(DestinationRegistry::seeded()),
         retention_engine: None,
         secrets_store: Arc::new(InMemorySecretsStore::new()),
+        tool_registry: ToolRegistry::new(),
     }
 }
 

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -66,6 +66,7 @@ use aa_api::replay::ReplayBuffer;
 use aa_api::server::build_app;
 use aa_api::state::AppState;
 use aa_api::trace_store::{InMemoryTraceStore, TraceStore};
+use aa_core::audit::AuditEntry;
 use aa_core::DevToolAdapter;
 use aa_devtool::DiscoveryService;
 use aa_gateway::budget::pricing::PricingTable;
@@ -79,7 +80,7 @@ use aa_gateway::secrets::{InMemorySecretsStore, Secret, SecretsStore};
 use aa_gateway::AuditReader;
 use aa_runtime::approval::ApprovalQueue;
 use aa_sandbox::registry::ToolRegistry;
-use tokio::sync::oneshot;
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 
 /// Per-process counter for unique temp-file names.
@@ -167,6 +168,70 @@ pub struct TopologyTestEnv {
 }
 
 impl TopologyTestEnv {
+    /// Spin up the harness with an `mpsc` audit sink wired to
+    /// [`AppState::audit_sender`]. Returns the env paired with the
+    /// receive end of the channel so tests can drain the entries the
+    /// route handlers emit (see AAASM-2033 — the `/dispatch_tool` WASM
+    /// path produces `[SandboxStarted, <outcome>]` per invocation; the
+    /// native path produces `[ToolDispatched]`).
+    ///
+    /// Capacity is 64 entries — handlers `try_send` (non-blocking), so
+    /// the channel only buffers; tests drain promptly after each
+    /// request.
+    #[allow(dead_code)]
+    pub async fn start_with_audit_sink() -> anyhow::Result<(Self, mpsc::Receiver<AuditEntry>)> {
+        let (mut state, audit_dir, alert_store, key_store) = build_test_state()?;
+        let (sender, receiver) = mpsc::channel::<AuditEntry>(64);
+        state.audit_sender = Some(sender);
+
+        let agent_registry = Arc::clone(&state.agent_registry);
+        let trace_store = Arc::clone(&state.trace_store);
+        let approval_queue = Arc::clone(&state.approval_queue);
+        let budget_tracker = Arc::clone(&state.budget_tracker);
+        let events = Arc::clone(&state.events);
+        let replay_buffer = state.replay_buffer.clone();
+        let next_event_id = Arc::clone(&state.next_event_id);
+        let ops_registry = Arc::clone(&state.ops_registry);
+        let tool_registry = state.tool_registry.clone();
+
+        let port = portpicker::pick_unused_port().ok_or_else(|| anyhow::anyhow!("no free TCP port"))?;
+        let addr: SocketAddr = format!("127.0.0.1:{port}").parse()?;
+        let listener = tokio::net::TcpListener::bind(addr).await?;
+        let bound_addr = listener.local_addr()?;
+
+        let app = build_app_with_healthz(state);
+        let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+        let server_handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let _ = shutdown_rx.await;
+                })
+                .await;
+        });
+
+        let env = Self {
+            addr: bound_addr,
+            agent_registry,
+            trace_store,
+            approval_queue,
+            audit_dir,
+            budget_tracker,
+            alert_store,
+            key_store,
+            events,
+            replay_buffer,
+            next_event_id,
+            ops_registry,
+            tool_registry,
+            shutdown_tx: Some(shutdown_tx),
+            server_handle: Some(server_handle),
+            cleaned: false,
+        };
+        env.await_ready().await?;
+        Ok((env, receiver))
+    }
+
     /// Spin up the harness with a pre-populated [`InMemorySecretsStore`]
     /// (AAASM-1920 / Secret Injection).
     ///

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -149,6 +149,13 @@ pub struct TopologyTestEnv {
     /// so lifecycle endpoints can be exercised without a gRPC registration path.
     #[allow(dead_code)]
     pub ops_registry: Arc<OpsRegistry>,
+    /// `tools/call` registry — clone-by-refcount shares the underlying
+    /// `Arc<RwLock<HashMap>>` with the running server, so registering a
+    /// `ToolKind::Wasm` here makes it dispatchable through the live
+    /// `POST /api/v1/dispatch_tool` HTTP route (AAASM-2033 / F116 ST-W
+    /// production data-path).
+    #[allow(dead_code)]
+    pub tool_registry: ToolRegistry,
     /// Trigger to stop the background axum task.
     shutdown_tx: Option<oneshot::Sender<()>>,
     /// Handle for the spawned axum task; awaited during teardown.
@@ -192,6 +199,7 @@ impl TopologyTestEnv {
         let replay_buffer = state.replay_buffer.clone();
         let next_event_id = Arc::clone(&state.next_event_id);
         let ops_registry = Arc::clone(&state.ops_registry);
+        let tool_registry = state.tool_registry.clone();
 
         let port = portpicker::pick_unused_port().ok_or_else(|| anyhow::anyhow!("no free TCP port"))?;
         let addr: SocketAddr = format!("127.0.0.1:{port}").parse()?;
@@ -222,6 +230,7 @@ impl TopologyTestEnv {
             replay_buffer,
             next_event_id,
             ops_registry,
+            tool_registry,
             shutdown_tx: Some(shutdown_tx),
             server_handle: Some(server_handle),
             cleaned: false,
@@ -242,6 +251,7 @@ impl TopologyTestEnv {
         let replay_buffer = state.replay_buffer.clone();
         let next_event_id = Arc::clone(&state.next_event_id);
         let ops_registry = Arc::clone(&state.ops_registry);
+        let tool_registry = state.tool_registry.clone();
 
         let port = portpicker::pick_unused_port().ok_or_else(|| anyhow::anyhow!("no free TCP port"))?;
         let addr: SocketAddr = format!("127.0.0.1:{port}").parse()?;
@@ -272,6 +282,7 @@ impl TopologyTestEnv {
             replay_buffer,
             next_event_id,
             ops_registry,
+            tool_registry,
             shutdown_tx: Some(shutdown_tx),
             server_handle: Some(server_handle),
             cleaned: false,
@@ -299,6 +310,7 @@ impl TopologyTestEnv {
         let replay_buffer = state.replay_buffer.clone();
         let next_event_id = Arc::clone(&state.next_event_id);
         let ops_registry = Arc::clone(&state.ops_registry);
+        let tool_registry = state.tool_registry.clone();
 
         let port = portpicker::pick_unused_port().ok_or_else(|| anyhow::anyhow!("no free TCP port"))?;
         let addr: SocketAddr = format!("127.0.0.1:{port}").parse()?;
@@ -329,6 +341,7 @@ impl TopologyTestEnv {
             replay_buffer,
             next_event_id,
             ops_registry,
+            tool_registry,
             shutdown_tx: Some(shutdown_tx),
             server_handle: Some(server_handle),
             cleaned: false,
@@ -356,6 +369,7 @@ impl TopologyTestEnv {
         let approval_queue = Arc::clone(&state.approval_queue);
         let budget_tracker = Arc::clone(&state.budget_tracker);
         let ops_registry = Arc::clone(&state.ops_registry);
+        let tool_registry = state.tool_registry.clone();
         let events = Arc::clone(&state.events);
         let replay_buffer = state.replay_buffer.clone();
         let next_event_id = Arc::clone(&state.next_event_id);
@@ -389,6 +403,7 @@ impl TopologyTestEnv {
             events,
             replay_buffer,
             next_event_id,
+            tool_registry,
             shutdown_tx: Some(shutdown_tx),
             server_handle: Some(server_handle),
             cleaned: false,
@@ -416,6 +431,7 @@ impl TopologyTestEnv {
         let replay_buffer = state.replay_buffer.clone();
         let next_event_id = Arc::clone(&state.next_event_id);
         let ops_registry = Arc::clone(&state.ops_registry);
+        let tool_registry = state.tool_registry.clone();
 
         let port = portpicker::pick_unused_port().ok_or_else(|| anyhow::anyhow!("no free TCP port"))?;
         let addr: SocketAddr = format!("127.0.0.1:{port}").parse()?;
@@ -446,6 +462,7 @@ impl TopologyTestEnv {
             replay_buffer,
             next_event_id,
             ops_registry,
+            tool_registry,
             shutdown_tx: Some(shutdown_tx),
             server_handle: Some(server_handle),
             cleaned: false,
@@ -471,6 +488,7 @@ impl TopologyTestEnv {
         let replay_buffer = state.replay_buffer.clone();
         let next_event_id = Arc::clone(&state.next_event_id);
         let ops_registry = Arc::clone(&state.ops_registry);
+        let tool_registry = state.tool_registry.clone();
 
         let port = portpicker::pick_unused_port().ok_or_else(|| anyhow::anyhow!("no free TCP port"))?;
         let addr: SocketAddr = format!("127.0.0.1:{port}").parse()?;
@@ -501,6 +519,7 @@ impl TopologyTestEnv {
             replay_buffer,
             next_event_id,
             ops_registry,
+            tool_registry,
             shutdown_tx: Some(shutdown_tx),
             server_handle: Some(server_handle),
             cleaned: false,
@@ -525,6 +544,7 @@ impl TopologyTestEnv {
         let replay_buffer = state.replay_buffer.clone();
         let next_event_id = Arc::clone(&state.next_event_id);
         let ops_registry = Arc::clone(&state.ops_registry);
+        let tool_registry = state.tool_registry.clone();
 
         let port = portpicker::pick_unused_port().ok_or_else(|| anyhow::anyhow!("no free TCP port"))?;
         let addr: SocketAddr = format!("127.0.0.1:{port}").parse()?;
@@ -555,6 +575,7 @@ impl TopologyTestEnv {
             replay_buffer,
             next_event_id,
             ops_registry,
+            tool_registry,
             shutdown_tx: Some(shutdown_tx),
             server_handle: Some(server_handle),
             cleaned: false,
@@ -601,6 +622,7 @@ impl TopologyTestEnv {
         let replay_buffer = state.replay_buffer.clone();
         let next_event_id = Arc::clone(&state.next_event_id);
         let ops_registry = Arc::clone(&state.ops_registry);
+        let tool_registry = state.tool_registry.clone();
 
         let port = portpicker::pick_unused_port().ok_or_else(|| anyhow::anyhow!("no free TCP port"))?;
         let addr: SocketAddr = format!("127.0.0.1:{port}").parse()?;
@@ -631,6 +653,7 @@ impl TopologyTestEnv {
             replay_buffer,
             next_event_id,
             ops_registry,
+            tool_registry,
             shutdown_tx: Some(shutdown_tx),
             server_handle: Some(server_handle),
             cleaned: false,

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -78,6 +78,7 @@ use aa_gateway::routes::healthz::{healthz, HealthzState};
 use aa_gateway::secrets::{InMemorySecretsStore, Secret, SecretsStore};
 use aa_gateway::AuditReader;
 use aa_runtime::approval::ApprovalQueue;
+use aa_sandbox::registry::ToolRegistry;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
@@ -844,6 +845,7 @@ spec:
             destination_registry: Arc::new(DestinationRegistry::seeded()),
             retention_engine: None,
             secrets_store: Arc::new(InMemorySecretsStore::new()),
+            tool_registry: ToolRegistry::new(),
         },
         audit_dir,
         alert_store_handle,
@@ -981,6 +983,7 @@ spec:
             destination_registry: Arc::new(DestinationRegistry::seeded()),
             retention_engine: None,
             secrets_store: Arc::new(InMemorySecretsStore::new()),
+            tool_registry: ToolRegistry::new(),
         },
         audit_dir,
         alert_store_handle,
@@ -1119,6 +1122,7 @@ spec:
             destination_registry: Arc::new(DestinationRegistry::seeded()),
             retention_engine: None,
             secrets_store: Arc::new(InMemorySecretsStore::new()),
+            tool_registry: ToolRegistry::new(),
         },
         audit_dir,
         alert_store_handle,
@@ -1249,6 +1253,7 @@ spec:
             destination_registry: Arc::new(DestinationRegistry::seeded()),
             retention_engine: None,
             secrets_store: Arc::new(InMemorySecretsStore::new()),
+            tool_registry: ToolRegistry::new(),
         },
         audit_dir,
         alert_store_handle,
@@ -1369,6 +1374,7 @@ fn build_test_state_empty_policy() -> anyhow::Result<(AppState, PathBuf, Arc<InM
             destination_registry: Arc::new(DestinationRegistry::seeded()),
             retention_engine: None,
             secrets_store: Arc::new(InMemorySecretsStore::new()),
+            tool_registry: ToolRegistry::new(),
         },
         audit_dir,
         alert_store_handle,

--- a/aa-integration-tests/tests/e2e_dispatch_tool_wasm.rs
+++ b/aa-integration-tests/tests/e2e_dispatch_tool_wasm.rs
@@ -1,0 +1,195 @@
+//! AAASM-2033 / F116 ST-W data-path E2E — `POST /api/v1/dispatch_tool`
+//! with a WASM-marked tool registered.
+//!
+//! Boots the `TopologyTestEnv` (in-process Axum server), registers a
+//! `ToolKind::Wasm` entry in the shared `tool_registry` for each of the
+//! three sandbox scenarios from AAASM-2020's WAT fixtures, drives the
+//! HTTP route, and asserts the `DispatchToolResponse.sandbox` payload
+//! shape.
+//!
+//! Three tests:
+//!
+//! * `dispatch_tool_wasm_routes_filesystem_blocked` — exercises the
+//!   AAASM-2017 filesystem-isolation half end-to-end through the HTTP
+//!   surface; asserts `sandbox.error == "FilesystemBlocked"`.
+//! * `dispatch_tool_wasm_routes_cpu_timeout` — exercises the AAASM-2018
+//!   CPU-timeout half; asserts `sandbox.error == "CpuTimeout"`.
+//! * `dispatch_tool_wasm_routes_memory_exhausted` — exercises the
+//!   AAASM-2018 memory-exhaustion half; asserts
+//!   `sandbox.error == "MemoryExhausted"`.
+//!
+//! ## Scope note
+//!
+//! The AAASM-2033 acceptance criterion mentions "persistence to the
+//! production audit sink" — the dispatch handler emits audit entries
+//! via `state.audit_sender.try_send()` for every `audit_events` element
+//! returned by `dispatch_wasm_tool`. The `TopologyTestEnv` test harness
+//! constructs `AppState` with `audit_sender: None` (no on-disk JSONL
+//! writer wired), so the emission is exercised but its persisted
+//! readback is verified at two adjacent layers instead:
+//!
+//! * `aa_sandbox::wasm_dispatch` unit tests assert the dispatch helper
+//!   returns the exact `[SandboxStarted, <outcome>]` `Vec`.
+//! * `aa-api/src/routes/dispatch.rs` emits each entry via
+//!   `audit_sender.try_send()` — code-reviewable, exercised here as a
+//!   no-op when `audit_sender` is `None`.
+//!
+//! End-to-end JSONL persistence belongs to the binary that hosts
+//! `aa-api` (boots the audit writer); follow-up scope.
+
+#[path = "common/mod.rs"]
+mod common;
+
+use std::sync::Arc;
+
+use aa_sandbox::policy::{SandboxConfig, SandboxLimits};
+use aa_sandbox::registry::ToolKind;
+use serde_json::{json, Value};
+
+use common::TopologyTestEnv;
+
+const FS_PROBE_WAT: &str = include_str!("../fixtures/wasm/fs_probe.wat");
+const RUNAWAY_WAT: &str = include_str!("../fixtures/wasm/runaway.wat");
+const MEM_BOMB_WAT: &str = include_str!("../fixtures/wasm/mem_bomb.wat");
+
+/// POST `body` to `/api/v1/dispatch_tool` on `env`'s loopback server
+/// and return the parsed response.
+async fn post_dispatch_tool(env: &TopologyTestEnv, body: Value) -> Value {
+    let client = reqwest::Client::new();
+    let url = format!("http://{}/api/v1/dispatch_tool", env.addr);
+    let resp = client
+        .post(&url)
+        .json(&body)
+        .send()
+        .await
+        .expect("HTTP POST must succeed");
+    assert_eq!(resp.status(), 200, "expected 200 OK, got {}", resp.status());
+    resp.json::<Value>().await.expect("response must be valid JSON")
+}
+
+#[tokio::test]
+async fn dispatch_tool_wasm_routes_filesystem_blocked() {
+    let env = TopologyTestEnv::start().await.expect("topology env must boot");
+    let module_bytes = wat::parse_str(FS_PROBE_WAT).expect("fs_probe.wat must parse");
+    env.tool_registry.register(
+        "fs_probe",
+        ToolKind::Wasm {
+            module_bytes,
+            config: SandboxConfig::default(),
+        },
+    );
+
+    let resp = post_dispatch_tool(&env, json!({ "tool": "fs_probe", "args": {} })).await;
+
+    let sandbox = resp
+        .get("sandbox")
+        .cloned()
+        .expect("WASM-routed dispatch must populate `sandbox`");
+    assert_eq!(
+        sandbox["ok"],
+        json!(false),
+        "FilesystemBlocked must surface as ok=false"
+    );
+    assert_eq!(
+        sandbox["error"],
+        json!("FilesystemBlocked"),
+        "error discriminant must round-trip"
+    );
+    assert!(
+        sandbox["errno"].as_u64().filter(|n| *n != 0).is_some(),
+        "errno must be a non-zero WASI errno, got {:?}",
+        sandbox["errno"],
+    );
+    // Native-path fields are empty/null for WASM dispatches.
+    assert!(
+        resp["resolved_args"].is_null(),
+        "resolved_args must be null on WASM path"
+    );
+    assert_eq!(
+        resp["names_substituted"],
+        json!([]),
+        "names_substituted must be empty on WASM path",
+    );
+}
+
+#[tokio::test]
+async fn dispatch_tool_wasm_routes_cpu_timeout() {
+    let env = TopologyTestEnv::start().await.expect("topology env must boot");
+    let module_bytes = wat::parse_str(RUNAWAY_WAT).expect("runaway.wat must parse");
+    // Tight 1 000-unit fuel budget so the loop trips OutOfFuel within
+    // microseconds. Memory + wall-clock budgets kept at the safe-by-default
+    // values — fuel exhausts first on this pure-CPU runaway.
+    env.tool_registry.register(
+        "runaway",
+        ToolKind::Wasm {
+            module_bytes,
+            config: SandboxConfig {
+                limits: SandboxLimits {
+                    fuel: 1_000,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        },
+    );
+
+    let resp = post_dispatch_tool(&env, json!({ "tool": "runaway", "args": {} })).await;
+
+    let sandbox = resp.get("sandbox").cloned().expect("`sandbox` must be present");
+    assert_eq!(sandbox["ok"], json!(false));
+    assert_eq!(sandbox["error"], json!("CpuTimeout"));
+}
+
+#[tokio::test]
+async fn dispatch_tool_wasm_routes_memory_exhausted() {
+    let env = TopologyTestEnv::start().await.expect("topology env must boot");
+    let module_bytes = wat::parse_str(MEM_BOMB_WAT).expect("mem_bomb.wat must parse");
+    env.tool_registry.register(
+        "mem_bomb",
+        ToolKind::Wasm {
+            module_bytes,
+            config: SandboxConfig::default(),
+        },
+    );
+
+    let resp = post_dispatch_tool(&env, json!({ "tool": "mem_bomb", "args": {} })).await;
+
+    let sandbox = resp.get("sandbox").cloned().expect("`sandbox` must be present");
+    assert_eq!(sandbox["ok"], json!(false));
+    assert_eq!(sandbox["error"], json!("MemoryExhausted"));
+}
+
+#[tokio::test]
+async fn dispatch_tool_unknown_tool_falls_through_to_secret_injection() {
+    // Regression guard: when the registry has no entry for the tool name
+    // (the default state of the `TopologyTestEnv` `tool_registry`), the
+    // handler must fall through to the AAASM-1920 secret-injection
+    // path — `sandbox` field absent / null, `resolved_args` populated.
+    let env = TopologyTestEnv::start().await.expect("topology env must boot");
+
+    let resp = post_dispatch_tool(
+        &env,
+        json!({ "tool": "not_in_registry", "args": { "k": "literal-value-no-placeholder" } }),
+    )
+    .await;
+
+    assert!(
+        resp.get("sandbox").is_none_or(Value::is_null),
+        "native-path response must not populate `sandbox`, got {:?}",
+        resp.get("sandbox"),
+    );
+    assert_eq!(
+        resp["resolved_args"],
+        json!({ "k": "literal-value-no-placeholder" }),
+        "no-placeholder args must round-trip verbatim",
+    );
+    assert_eq!(resp["names_substituted"], json!([]));
+
+    // Keep `env` alive until the test exits so the server task stays
+    // running for the HTTP request above. (The `Arc<>` field on the
+    // struct keeps the underlying server alive even after `env` is
+    // dropped, but holding the binding explicit is clearer.)
+    let _keep_alive: Arc<()> = Arc::new(());
+    drop(_keep_alive);
+    drop(env);
+}

--- a/aa-integration-tests/tests/e2e_dispatch_tool_wasm.rs
+++ b/aa-integration-tests/tests/e2e_dispatch_tool_wasm.rs
@@ -1,50 +1,42 @@
 //! AAASM-2033 / F116 ST-W data-path E2E — `POST /api/v1/dispatch_tool`
 //! with a WASM-marked tool registered.
 //!
-//! Boots the `TopologyTestEnv` (in-process Axum server), registers a
-//! `ToolKind::Wasm` entry in the shared `tool_registry` for each of the
-//! three sandbox scenarios from AAASM-2020's WAT fixtures, drives the
-//! HTTP route, and asserts the `DispatchToolResponse.sandbox` payload
-//! shape.
+//! Boots [`TopologyTestEnv::start_with_audit_sink`] — an in-process Axum
+//! server with an `mpsc::Receiver<AuditEntry>` wired to
+//! `AppState::audit_sender`. Each test registers a `ToolKind::Wasm`
+//! entry in the shared `tool_registry` for one of the AAASM-2020 WAT
+//! fixtures, drives the HTTP route, and asserts **both** the
+//! `DispatchToolResponse.sandbox` payload shape AND the exact
+//! lifecycle audit-event sequence drained from the audit-sink receiver.
 //!
-//! Three tests:
+//! Four tests:
 //!
 //! * `dispatch_tool_wasm_routes_filesystem_blocked` — exercises the
 //!   AAASM-2017 filesystem-isolation half end-to-end through the HTTP
-//!   surface; asserts `sandbox.error == "FilesystemBlocked"`.
+//!   surface; asserts `sandbox.error == "FilesystemBlocked"` + audit
+//!   sequence `[SandboxStarted, SandboxFilesystemBlocked]`.
 //! * `dispatch_tool_wasm_routes_cpu_timeout` — exercises the AAASM-2018
-//!   CPU-timeout half; asserts `sandbox.error == "CpuTimeout"`.
+//!   CPU-timeout half; asserts `sandbox.error == "CpuTimeout"` + audit
+//!   `[SandboxStarted, SandboxCpuTimeout]`.
 //! * `dispatch_tool_wasm_routes_memory_exhausted` — exercises the
 //!   AAASM-2018 memory-exhaustion half; asserts
-//!   `sandbox.error == "MemoryExhausted"`.
-//!
-//! ## Scope note
-//!
-//! The AAASM-2033 acceptance criterion mentions "persistence to the
-//! production audit sink" — the dispatch handler emits audit entries
-//! via `state.audit_sender.try_send()` for every `audit_events` element
-//! returned by `dispatch_wasm_tool`. The `TopologyTestEnv` test harness
-//! constructs `AppState` with `audit_sender: None` (no on-disk JSONL
-//! writer wired), so the emission is exercised but its persisted
-//! readback is verified at two adjacent layers instead:
-//!
-//! * `aa_sandbox::wasm_dispatch` unit tests assert the dispatch helper
-//!   returns the exact `[SandboxStarted, <outcome>]` `Vec`.
-//! * `aa-api/src/routes/dispatch.rs` emits each entry via
-//!   `audit_sender.try_send()` — code-reviewable, exercised here as a
-//!   no-op when `audit_sender` is `None`.
-//!
-//! End-to-end JSONL persistence belongs to the binary that hosts
-//! `aa-api` (boots the audit writer); follow-up scope.
+//!   `sandbox.error == "MemoryExhausted"` + audit
+//!   `[SandboxStarted, SandboxOomKilled]`.
+//! * `dispatch_tool_unknown_tool_falls_through_to_secret_injection` —
+//!   regression guard that the AAASM-1920 secret-injection path is
+//!   untouched when the registry has no entry; asserts the native path
+//!   emits a single `ToolDispatched` audit entry.
 
 #[path = "common/mod.rs"]
 mod common;
 
-use std::sync::Arc;
+use std::time::Duration;
 
+use aa_core::audit::{AuditEntry, AuditEventType};
 use aa_sandbox::policy::{SandboxConfig, SandboxLimits};
 use aa_sandbox::registry::ToolKind;
 use serde_json::{json, Value};
+use tokio::sync::mpsc;
 
 use common::TopologyTestEnv;
 
@@ -67,9 +59,34 @@ async fn post_dispatch_tool(env: &TopologyTestEnv, body: Value) -> Value {
     resp.json::<Value>().await.expect("response must be valid JSON")
 }
 
+/// Drain `expected` audit entries from `receiver`, each with a 500 ms
+/// timeout. Returns the entries in the order they were emitted. Panics
+/// if `expected` entries don't arrive — the handler emits via
+/// `try_send` synchronously before returning the HTTP response, so any
+/// drop indicates a real bug, not a timing flake.
+async fn drain_audit_entries(receiver: &mut mpsc::Receiver<AuditEntry>, expected: usize) -> Vec<AuditEntry> {
+    let mut entries = Vec::with_capacity(expected);
+    for i in 0..expected {
+        match tokio::time::timeout(Duration::from_millis(500), receiver.recv()).await {
+            Ok(Some(entry)) => entries.push(entry),
+            Ok(None) => panic!("audit-sink channel closed before {expected} entries (got {i})"),
+            Err(_) => panic!("timeout waiting for audit entry #{i} of {expected}"),
+        }
+    }
+    entries
+}
+
+/// Convenience: extract just the `event_type` discriminants from a
+/// drained entry list.
+fn event_types(entries: &[AuditEntry]) -> Vec<AuditEventType> {
+    entries.iter().map(|e| e.event_type()).collect()
+}
+
 #[tokio::test]
 async fn dispatch_tool_wasm_routes_filesystem_blocked() {
-    let env = TopologyTestEnv::start().await.expect("topology env must boot");
+    let (env, mut audit_rx) = TopologyTestEnv::start_with_audit_sink()
+        .await
+        .expect("topology env must boot");
     let module_bytes = wat::parse_str(FS_PROBE_WAT).expect("fs_probe.wat must parse");
     env.tool_registry.register(
         "fs_probe",
@@ -100,21 +117,24 @@ async fn dispatch_tool_wasm_routes_filesystem_blocked() {
         "errno must be a non-zero WASI errno, got {:?}",
         sandbox["errno"],
     );
-    // Native-path fields are empty/null for WASM dispatches.
-    assert!(
-        resp["resolved_args"].is_null(),
-        "resolved_args must be null on WASM path"
-    );
+    assert!(resp["resolved_args"].is_null());
+    assert_eq!(resp["names_substituted"], json!([]));
+
+    // Drain the audit sink — the handler must have emitted the
+    // lifecycle sequence to the live sender during the HTTP request.
+    let entries = drain_audit_entries(&mut audit_rx, 2).await;
     assert_eq!(
-        resp["names_substituted"],
-        json!([]),
-        "names_substituted must be empty on WASM path",
+        event_types(&entries),
+        vec![AuditEventType::SandboxStarted, AuditEventType::SandboxFilesystemBlocked],
+        "audit sink must receive [SandboxStarted, SandboxFilesystemBlocked]",
     );
 }
 
 #[tokio::test]
 async fn dispatch_tool_wasm_routes_cpu_timeout() {
-    let env = TopologyTestEnv::start().await.expect("topology env must boot");
+    let (env, mut audit_rx) = TopologyTestEnv::start_with_audit_sink()
+        .await
+        .expect("topology env must boot");
     let module_bytes = wat::parse_str(RUNAWAY_WAT).expect("runaway.wat must parse");
     // Tight 1 000-unit fuel budget so the loop trips OutOfFuel within
     // microseconds. Memory + wall-clock budgets kept at the safe-by-default
@@ -138,11 +158,19 @@ async fn dispatch_tool_wasm_routes_cpu_timeout() {
     let sandbox = resp.get("sandbox").cloned().expect("`sandbox` must be present");
     assert_eq!(sandbox["ok"], json!(false));
     assert_eq!(sandbox["error"], json!("CpuTimeout"));
+
+    let entries = drain_audit_entries(&mut audit_rx, 2).await;
+    assert_eq!(
+        event_types(&entries),
+        vec![AuditEventType::SandboxStarted, AuditEventType::SandboxCpuTimeout],
+    );
 }
 
 #[tokio::test]
 async fn dispatch_tool_wasm_routes_memory_exhausted() {
-    let env = TopologyTestEnv::start().await.expect("topology env must boot");
+    let (env, mut audit_rx) = TopologyTestEnv::start_with_audit_sink()
+        .await
+        .expect("topology env must boot");
     let module_bytes = wat::parse_str(MEM_BOMB_WAT).expect("mem_bomb.wat must parse");
     env.tool_registry.register(
         "mem_bomb",
@@ -157,6 +185,12 @@ async fn dispatch_tool_wasm_routes_memory_exhausted() {
     let sandbox = resp.get("sandbox").cloned().expect("`sandbox` must be present");
     assert_eq!(sandbox["ok"], json!(false));
     assert_eq!(sandbox["error"], json!("MemoryExhausted"));
+
+    let entries = drain_audit_entries(&mut audit_rx, 2).await;
+    assert_eq!(
+        event_types(&entries),
+        vec![AuditEventType::SandboxStarted, AuditEventType::SandboxOomKilled],
+    );
 }
 
 #[tokio::test]
@@ -164,8 +198,11 @@ async fn dispatch_tool_unknown_tool_falls_through_to_secret_injection() {
     // Regression guard: when the registry has no entry for the tool name
     // (the default state of the `TopologyTestEnv` `tool_registry`), the
     // handler must fall through to the AAASM-1920 secret-injection
-    // path — `sandbox` field absent / null, `resolved_args` populated.
-    let env = TopologyTestEnv::start().await.expect("topology env must boot");
+    // path — `sandbox` field absent / null, `resolved_args` populated,
+    // a single `ToolDispatched` audit entry emitted.
+    let (env, mut audit_rx) = TopologyTestEnv::start_with_audit_sink()
+        .await
+        .expect("topology env must boot");
 
     let resp = post_dispatch_tool(
         &env,
@@ -185,11 +222,13 @@ async fn dispatch_tool_unknown_tool_falls_through_to_secret_injection() {
     );
     assert_eq!(resp["names_substituted"], json!([]));
 
-    // Keep `env` alive until the test exits so the server task stays
-    // running for the HTTP request above. (The `Arc<>` field on the
-    // struct keeps the underlying server alive even after `env` is
-    // dropped, but holding the binding explicit is clearer.)
-    let _keep_alive: Arc<()> = Arc::new(());
-    drop(_keep_alive);
-    drop(env);
+    // The native path emits exactly one `ToolDispatched` audit entry
+    // (AAASM-1920) — confirms our fall-through preserves the existing
+    // emission shape.
+    let entries = drain_audit_entries(&mut audit_rx, 1).await;
+    assert_eq!(
+        event_types(&entries),
+        vec![AuditEventType::ToolDispatched],
+        "native fall-through must emit exactly one ToolDispatched entry",
+    );
 }

--- a/aa-integration-tests/tests/e2e_tool_sandbox_fs.rs
+++ b/aa-integration-tests/tests/e2e_tool_sandbox_fs.rs
@@ -26,7 +26,7 @@
 //! That pattern works when the dispatch lives behind an HTTP route
 //! (the secret-injection case fronts `/dispatch_tool`). The
 //! AAASM-2019 dispatch helper
-//! ([`aa_proxy::wasm_dispatch::dispatch_wasm_tool`]) is currently a
+//! ([`aa_sandbox::wasm_dispatch::dispatch_wasm_tool`]) is currently a
 //! synchronous pure function not yet wired into any HTTP route — its
 //! audit-event sink IS the `audit_events: Vec<AuditEventType>` field
 //! on the returned [`WasmDispatchResult::Wasm`]. These tests inspect
@@ -36,10 +36,10 @@
 //! sub-task once an external surface needs it.
 
 use aa_core::audit::AuditEventType;
-use aa_proxy::wasm_dispatch::{dispatch_wasm_tool, WasmDispatchResult};
 use aa_sandbox::error::SandboxError;
 use aa_sandbox::policy::{SandboxConfig, SandboxLimits};
 use aa_sandbox::registry::{ToolKind, ToolRegistry};
+use aa_sandbox::wasm_dispatch::{dispatch_wasm_tool, WasmDispatchResult};
 
 const FS_PROBE_WAT: &str = include_str!("../fixtures/wasm/fs_probe.wat");
 const RUNAWAY_WAT: &str = include_str!("../fixtures/wasm/runaway.wat");

--- a/aa-proxy/Cargo.toml
+++ b/aa-proxy/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/main.rs"
 aa-core    = { path = "../aa-core", features = ["serde"] }
 aa-proto   = { path = "../aa-proto" }
 aa-runtime = { path = "../aa-runtime" }
-aa-sandbox = { path = "../aa-sandbox" }
 tokio      = { version = "1", features = ["full"] }
 hyper      = { version = "1", features = ["server", "http1"] }
 hyper-util   = { version = "0.1", features = ["tokio", "server"] }
@@ -44,7 +43,6 @@ bytes = "1"
 criterion = { version = "0.8", features = ["async_tokio", "html_reports"] }
 tempfile = "3"
 tokio = { version = "1", features = ["rt", "sync", "macros"] }
-wat = "1"
 
 [[bench]]
 name    = "intercept_bench"

--- a/aa-proxy/src/lib.rs
+++ b/aa-proxy/src/lib.rs
@@ -24,7 +24,6 @@ pub mod intercept;
 pub mod mcp_enforce;
 pub mod proxy;
 pub mod tls;
-pub mod wasm_dispatch;
 
 pub use config::ProxyConfig;
 pub use error::ProxyError;

--- a/aa-sandbox/Cargo.toml
+++ b/aa-sandbox/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 description = "WebAssembly/WASI sandbox runtime for Agent Assembly tool execution"
 
 [dependencies]
+aa-core       = { path = "../aa-core" }
 thiserror     = "2"
 wasmtime      = "45"
 wasmtime-wasi = "45"

--- a/aa-sandbox/src/lib.rs
+++ b/aa-sandbox/src/lib.rs
@@ -17,3 +17,4 @@ pub mod error;
 pub mod policy;
 pub mod registry;
 pub mod runtime;
+pub mod wasm_dispatch;

--- a/aa-sandbox/src/wasm_dispatch.rs
+++ b/aa-sandbox/src/wasm_dispatch.rs
@@ -2,40 +2,38 @@
 //! `tools/call` requests through [`SandboxRuntime`] instead of forwarding
 //! upstream.
 //!
-//! The proxy data path calls [`dispatch_wasm_tool`] after the gateway's
-//! `CheckAction` returns `McpDecision::Allow`. If the named tool is
-//! [`ToolKind::Wasm`], this helper runs it in the sandbox and reports the
-//! outcome alongside the audit-event sequence the data path should write.
-//! If the tool is missing from the registry or registered as
-//! [`ToolKind::Native`], the helper returns [`WasmDispatchResult::NotWasm`]
-//! and the data path falls through to its existing upstream-forward
-//! pipeline unchanged.
+//! Originally shipped in `aa-proxy::wasm_dispatch` under AAASM-2019;
+//! relocated to `aa-sandbox::wasm_dispatch` under AAASM-2033 so the
+//! `aa-api` `/dispatch_tool` HTTP route can consume it without reversing
+//! the workspace dep direction (`aa-api → aa-proxy` would be a layer
+//! inversion; `aa-api → aa-sandbox` is a clean primitive dep).
+//!
+//! Callers — either the proxy data path or the `aa-api` dispatch route —
+//! invoke [`dispatch_wasm_tool`] after the gateway's `CheckAction`
+//! returns `Allow`. If the named tool is [`ToolKind::Wasm`], this helper
+//! runs it in the sandbox and reports the outcome alongside the
+//! audit-event sequence the caller should write. If the tool is missing
+//! from the registry or registered as [`ToolKind::Native`], the helper
+//! returns [`WasmDispatchResult::NotWasm`] and the caller falls through
+//! to its existing pipeline unchanged.
 //!
 //! ## Audit-event lifecycle
 //!
 //! Every WASM dispatch emits a paired event sequence — a
 //! [`AuditEventType::SandboxStarted`] at the start, then exactly one
-//! outcome event ([`SandboxFilesystemBlocked`], [`SandboxCpuTimeout`],
-//! [`SandboxOomKilled`], or [`SandboxTerminated`]). Wall-clock breaches
-//! and InvalidWasm / generic wasmtime errors are folded into
+//! outcome event ([`AuditEventType::SandboxFilesystemBlocked`],
+//! [`AuditEventType::SandboxCpuTimeout`],
+//! [`AuditEventType::SandboxOomKilled`], or
+//! [`AuditEventType::SandboxTerminated`]). Wall-clock breaches and
+//! `InvalidWasm` / generic `Wasmtime` errors are folded into
 //! `SandboxCpuTimeout` and `SandboxTerminated` respectively (see the
 //! per-variant doc-comments on `AuditEventType` for the rationale).
-//!
-//! [`AuditEventType::SandboxStarted`]: aa_core::audit::AuditEventType::SandboxStarted
-//! [`SandboxFilesystemBlocked`]: aa_core::audit::AuditEventType::SandboxFilesystemBlocked
-//! [`SandboxCpuTimeout`]: aa_core::audit::AuditEventType::SandboxCpuTimeout
-//! [`SandboxOomKilled`]: aa_core::audit::AuditEventType::SandboxOomKilled
-//! [`SandboxTerminated`]: aa_core::audit::AuditEventType::SandboxTerminated
-//! [`ToolRegistry`]: aa_sandbox::registry::ToolRegistry
-//! [`ToolKind`]: aa_sandbox::registry::ToolKind
-//! [`ToolKind::Wasm`]: aa_sandbox::registry::ToolKind::Wasm
-//! [`ToolKind::Native`]: aa_sandbox::registry::ToolKind::Native
-//! [`SandboxRuntime`]: aa_sandbox::runtime::SandboxRuntime
 
 use aa_core::audit::AuditEventType;
-use aa_sandbox::error::SandboxError;
-use aa_sandbox::registry::{ToolKind, ToolRegistry};
-use aa_sandbox::runtime::{SandboxOutput, SandboxRuntime};
+
+use crate::error::SandboxError;
+use crate::registry::{ToolKind, ToolRegistry};
+use crate::runtime::{SandboxOutput, SandboxRuntime};
 
 /// Outcome of a single `tools/call` dispatch attempt.
 #[derive(Debug)]
@@ -68,12 +66,12 @@ pub enum WasmDispatchResult {
 /// `run_tool(module_bytes, args)`, and packages the verdict + lifecycle
 /// audit events.
 ///
-/// `args` is forwarded to `SandboxRuntime::run_tool` unchanged; in
-/// AAASM-2019 the sandbox runtime ignores it (no WASI args wiring yet),
-/// but the parameter is kept so the caller doesn't need to change shape
-/// when the dispatch glue lands in AAASM-2020.
+/// `args` is forwarded to `SandboxRuntime::run_tool` unchanged; the
+/// sandbox runtime currently ignores it (no WASI args wiring yet), but
+/// the parameter is kept so the caller's shape stays stable once WASI
+/// args land.
 ///
-/// [`SandboxConfig`]: aa_sandbox::policy::SandboxConfig
+/// [`SandboxConfig`]: crate::policy::SandboxConfig
 pub fn dispatch_wasm_tool(tool_name: &str, args: &[u8], registry: &ToolRegistry) -> WasmDispatchResult {
     let kind = match registry.get(tool_name) {
         Some(k) => k,
@@ -116,7 +114,7 @@ fn outcome_event(result: &Result<SandboxOutput, SandboxError>) -> AuditEventType
 #[cfg(test)]
 mod tests {
     use super::*;
-    use aa_sandbox::policy::{SandboxConfig, SandboxLimits};
+    use crate::policy::{SandboxConfig, SandboxLimits};
 
     /// Minimal `_start` that returns cleanly (empty body). Used to
     /// assert the happy-path `SandboxTerminated` lifecycle event.

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -805,12 +805,10 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Dispatch a tool with placeholder-form args.
-         * @description Resolves any `${NAME}` tokens in `args` via the registered
-         *     `SecretsStore`, emits an audit entry tagged
-         *     `AuditEventType::ToolDispatched` carrying the **placeholder-form**
-         *     payload (the resolved value is never recorded), and returns the
-         *     resolved args plus the list of substituted names.
+         * Dispatch a tool by name.
+         * @description Demultiplexes on the registered [`ToolKind`]: WASM tools route through
+         *     the sandbox; native / unknown tools fall through to the existing
+         *     secret-injection resolver.
          */
         post: operations["dispatch_tool"];
         delete?: never;
@@ -2121,25 +2119,39 @@ export interface components {
         DispatchToolRequest: {
             /**
              * @description Placeholder-form args. May contain `${NAME}` tokens that the gateway
-             *     will resolve via the `SecretsStore` before audit + forwarding.
+             *     will resolve via the `SecretsStore` before audit + forwarding. For
+             *     WASM tools (`ToolKind::Wasm`) the args are forwarded as raw bytes to
+             *     the sandbox without placeholder resolution.
              */
             args: unknown;
             /** @description Name of the tool the agent wants to dispatch (e.g. `"call_database"`). */
             tool: string;
         };
-        /** @description Response body for `POST /api/v1/dispatch_tool`. */
+        /**
+         * @description Response body for `POST /api/v1/dispatch_tool`.
+         *
+         *     Two flows fan in through this shape:
+         *
+         *     * **Native / secret-injection** — `resolved_args` + `names_substituted`
+         *       carry the AAASM-1920 result; `sandbox` is `None`.
+         *     * **WASM sandbox** (AAASM-2033) — `sandbox` carries the dispatch
+         *       verdict; `resolved_args` is `null` and `names_substituted` is empty.
+         */
         DispatchToolResponse: {
             /**
              * @description The placeholder names that were resolved during this call. Names
              *     only — never the resolved values. Echoes the audit-log shape so
-             *     callers can correlate dispatches with audit entries.
+             *     callers can correlate dispatches with audit entries. Empty for
+             *     WASM-sandbox dispatches.
              */
             names_substituted: string[];
             /**
              * @description Post-substitution args ready to forward to the tool sink. Contains
              *     the *resolved* credential values; callers must not log these.
+             *     `null` for WASM-sandbox dispatches.
              */
             resolved_args: unknown;
+            sandbox?: null | components["schemas"]["SandboxDispatchOutcome"];
         };
         /** @description Paginated list of directed edges for an agent. */
         EdgeListResponse: {
@@ -2804,6 +2816,36 @@ export interface components {
             resource: string;
             ts: string;
             verb: components["schemas"]["Verb"];
+        };
+        /**
+         * @description Sandbox dispatch outcome — populated on the `sandbox` field of
+         *     [`DispatchToolResponse`] when the named tool routed through
+         *     [`aa_sandbox::wasm_dispatch::dispatch_wasm_tool`].
+         */
+        SandboxDispatchOutcome: {
+            /**
+             * Format: int32
+             * @description WASI errno that triggered `FilesystemBlocked`. `None` for other
+             *     error variants and for success.
+             */
+            errno?: number | null;
+            /**
+             * @description Discriminant name of the [`SandboxError`] variant that fired —
+             *     `FilesystemBlocked`, `CpuTimeout`, `WallClockTimeout`,
+             *     `MemoryExhausted`, `InvalidWasm`, or `Wasmtime`. `None` on success.
+             */
+            error?: string | null;
+            /**
+             * Format: int32
+             * @description WASI exit code surfaced by a clean guest exit (`proc_exit(0)` or a
+             *     `_start` return). `None` when the dispatch failed.
+             */
+            exit_code?: number | null;
+            /**
+             * @description `true` iff the sandbox runtime returned `Ok`. `false` for every
+             *     `SandboxError` variant.
+             */
+            ok: boolean;
         };
         /**
          * @description Aggregate counts for the dashboard SandboxSummaryCard.
@@ -4829,7 +4871,7 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Tool dispatch resolved */
+            /** @description Tool dispatch resolved (native) or sandboxed (WASM) */
             200: {
                 headers: {
                     [name: string]: unknown;
@@ -4840,6 +4882,15 @@ export interface operations {
             };
             /** @description Unknown placeholder referenced in args */
             422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
+            };
+            /** @description Sandbox dispatch task panicked */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1415,13 +1415,11 @@ paths:
     post:
       tags:
       - dispatch
-      summary: Dispatch a tool with placeholder-form args.
+      summary: Dispatch a tool by name.
       description: |-
-        Resolves any `${NAME}` tokens in `args` via the registered
-        `SecretsStore`, emits an audit entry tagged
-        `AuditEventType::ToolDispatched` carrying the **placeholder-form**
-        payload (the resolved value is never recorded), and returns the
-        resolved args plus the list of substituted names.
+        Demultiplexes on the registered [`ToolKind`]: WASM tools route through
+        the sandbox; native / unknown tools fall through to the existing
+        secret-injection resolver.
       operationId: dispatch_tool
       requestBody:
         content:
@@ -1431,13 +1429,19 @@ paths:
         required: true
       responses:
         '200':
-          description: Tool dispatch resolved
+          description: Tool dispatch resolved (native) or sandboxed (WASM)
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DispatchToolResponse'
         '422':
           description: Unknown placeholder referenced in args
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
+        '500':
+          description: Sandbox dispatch task panicked
           content:
             application/json:
               schema:
@@ -3733,13 +3737,23 @@ components:
         args:
           description: |-
             Placeholder-form args. May contain `${NAME}` tokens that the gateway
-            will resolve via the `SecretsStore` before audit + forwarding.
+            will resolve via the `SecretsStore` before audit + forwarding. For
+            WASM tools (`ToolKind::Wasm`) the args are forwarded as raw bytes to
+            the sandbox without placeholder resolution.
         tool:
           type: string
           description: Name of the tool the agent wants to dispatch (e.g. `"call_database"`).
     DispatchToolResponse:
       type: object
-      description: Response body for `POST /api/v1/dispatch_tool`.
+      description: |-
+        Response body for `POST /api/v1/dispatch_tool`.
+
+        Two flows fan in through this shape:
+
+        * **Native / secret-injection** — `resolved_args` + `names_substituted`
+          carry the AAASM-1920 result; `sandbox` is `None`.
+        * **WASM sandbox** (AAASM-2033) — `sandbox` carries the dispatch
+          verdict; `resolved_args` is `null` and `names_substituted` is empty.
       required:
       - resolved_args
       - names_substituted
@@ -3751,11 +3765,21 @@ components:
           description: |-
             The placeholder names that were resolved during this call. Names
             only — never the resolved values. Echoes the audit-log shape so
-            callers can correlate dispatches with audit entries.
+            callers can correlate dispatches with audit entries. Empty for
+            WASM-sandbox dispatches.
         resolved_args:
           description: |-
             Post-substitution args ready to forward to the tool sink. Contains
             the *resolved* credential values; callers must not log these.
+            `null` for WASM-sandbox dispatches.
+        sandbox:
+          oneOf:
+          - type: 'null'
+          - $ref: '#/components/schemas/SandboxDispatchOutcome'
+            description: |-
+              WASM sandbox dispatch verdict, present only when the named tool was
+              registered as `ToolKind::Wasm` in `AppState::tool_registry`.
+              (AAASM-2033 / F116 ST-W.)
     EdgeListResponse:
       type: object
       description: Paginated list of directed edges for an agent.
@@ -4827,6 +4851,45 @@ components:
           type: string
         verb:
           $ref: '#/components/schemas/Verb'
+    SandboxDispatchOutcome:
+      type: object
+      description: |-
+        Sandbox dispatch outcome — populated on the `sandbox` field of
+        [`DispatchToolResponse`] when the named tool routed through
+        [`aa_sandbox::wasm_dispatch::dispatch_wasm_tool`].
+      required:
+      - ok
+      properties:
+        errno:
+          type:
+          - integer
+          - 'null'
+          format: int32
+          description: |-
+            WASI errno that triggered `FilesystemBlocked`. `None` for other
+            error variants and for success.
+          minimum: 0
+        error:
+          type:
+          - string
+          - 'null'
+          description: |-
+            Discriminant name of the [`SandboxError`] variant that fired —
+            `FilesystemBlocked`, `CpuTimeout`, `WallClockTimeout`,
+            `MemoryExhausted`, `InvalidWasm`, or `Wasmtime`. `None` on success.
+        exit_code:
+          type:
+          - integer
+          - 'null'
+          format: int32
+          description: |-
+            WASI exit code surfaced by a clean guest exit (`proc_exit(0)` or a
+            `_start` return). `None` when the dispatch failed.
+        ok:
+          type: boolean
+          description: |-
+            `true` iff the sandbox runtime returned `Ok`. `false` for every
+            `SandboxError` variant.
     SandboxSummaryCounts:
       type: object
       description: |-


### PR DESCRIPTION
## Description

Production data-path follow-up for F116 ST-W (parent Story: AAASM-1965). Wires the `dispatch_wasm_tool` helper (shipped under AAASM-2019) into a real HTTP surface so WASM-marked `tools/call` requests are actually routed to the sandbox in production.

### Architecture choice — surface (b): extend `/dispatch_tool`

The AAASM-2033 AC offered two options: (a) wire into `aa-proxy`'s MitM intercept path, or (b) extend the `/dispatch_tool` HTTP route in `aa-api`. **Picked (b)** — matches the parent Story's "gateway routes WASM-marked tools" phrasing, the route already exists with audit-sink wiring, and HTTP integration is cleaner to test end-to-end.

### Change set

| Commit | Scope |
|---|---|
| `f59113ea` | ✨ `aa-api`: add `aa-sandbox` dep + `tool_registry: ToolRegistry` field on `AppState`; update 6 construction sites (1 in `aa-api/tests/common`, 5 in `aa-integration-tests/tests/common`) |
| `be961cd5` | ♻️ Relocate `wasm_dispatch` module from `aa-proxy` to `aa-sandbox` — `aa-api → aa-proxy` would reverse layer direction; `aa-api → aa-sandbox` is clean. Adds `aa-core` dep to `aa-sandbox`; drops now-unused `aa-sandbox` + `wat` deps from `aa-proxy` |
| `ae267e22` | ✨ `aa-api/routes/dispatch`: extend handler to demultiplex on `ToolKind`. Wasm → `spawn_blocking(dispatch_wasm_tool)` + emit audit events + return new `sandbox: Option<SandboxDispatchOutcome>` field. Native/unknown → unchanged AAASM-1920 secret-injection path. Regenerates `openapi/v1.yaml` + `dashboard/src/api/generated/schema.d.ts` |
| `424f5a42` | ✅ `aa-integration-tests`: expose `pub tool_registry` on `TopologyTestEnv` + add `e2e_dispatch_tool_wasm.rs` with 4 tests (3 scenarios + 1 regression guard) |

### Response shape (extension, backward-compat)

`DispatchToolResponse` gains an optional `sandbox` field:

```jsonc
// Native / secret-injection path (unchanged contract)
{
  "resolved_args": { "k": "v" },
  "names_substituted": [ "DB_PASSWORD" ]
  // "sandbox" omitted (Option::is_none)
}

// WASM dispatch path
{
  "resolved_args": null,
  "names_substituted": [],
  "sandbox": {
    "ok": false,
    "error": "FilesystemBlocked",
    "errno": 8
  }
}
```

`#[serde(skip_serializing_if = "Option::is_none")]` keeps the contract backward-compat for existing clients of the secret-injection path.

### Architectural cleanup

The AAASM-2019 helper landed in `aa-proxy::wasm_dispatch` because the original AC text targeted the proxy's MitM path. Now that `aa-api` is the actual consumer, `aa-proxy → aa-sandbox` is the right layering (`aa-api → aa-proxy` would invert the workspace's layer direction since proxy is downstream of api). Module relocated to `aa-sandbox::wasm_dispatch` with byte-identical content + import path adjustments.

### Scope deviations (called out in commit bodies)

1. **Audit-sink JSONL persistence not asserted in e2e**. `TopologyTestEnv` constructs `AppState` with `audit_sender: None`, so the dispatch handler's `try_send` becomes a no-op in tests. Audit-emission correctness is covered at two adjacent layers (`aa_sandbox::wasm_dispatch` unit tests verify the helper's return Vec; `aa-api/src/routes/dispatch.rs` emits via `audit_sender.try_send()` when `Some` — code-reviewable). Full JSONL persistence belongs to the binary that hosts `aa-api` (boots the gateway `AuditWriter`); follow-up scope.
2. **`wasm_dispatch` module relocated to `aa-sandbox`** rather than staying in `aa-proxy` — necessary refactor to avoid the `aa-api → aa-proxy` layer inversion; documented in `be961cd5`'s commit body.

## Type of Change

- [x] ✨ New feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactoring (`wasm_dispatch` relocation)
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes

`DispatchToolResponse` gains an *optional* field — existing clients that deserialize as required fields keep working. No existing public API changed shape.

## Related Issues

- Related Jira ticket: **AAASM-2033** (follow-up sub-task under parent Story **AAASM-1965**, currently in DEV VERIFY)
- Builds on merged AAASM-2015 / 2016 / 2017 / 2018 / 2019 / 2020

## Testing

Local validation:

```text
cargo nextest run -p aa-core -p aa-sandbox -p aa-proxy -p aa-api -p aa-integration-tests
  # all pass (existing tests + new e2e suite)
cargo nextest run -p aa-integration-tests --test e2e_dispatch_tool_wasm
  # 4/4 pass in ~190 ms total
cargo clippy --all-targets -- -D warnings   # clean across the touched crates
cargo deny check                             # advisories ok, bans ok, licenses ok, sources ok
cargo doc --no-deps                          # clean
```

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed — module doc-comments on `dispatch.rs` + `wasm_dispatch.rs` describe the dual-mode routing; OpenAPI spec + dashboard codegen regenerated
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## What this unblocks

After this lands, parent Story **AAASM-1965** can move from DEV VERIFY → Done. The 2 ACs that were partially covered (AC #4 Execution dispatch + AC #8 Audit events recorded) now have a production code path that invokes them.