### PR TITLE
[AAASM-2093] 🐛 (ci): Fix GHCR namespace for language images in docker.yml

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -151,8 +151,8 @@ jobs:
           # parent Story's "`:latest` per language still routes to the F114
           # variant" AC bullet. See AAASM-1446.
           tags: |
-            ghcr.io/agent-assembly/${{ matrix.lang }}:${{ matrix.version }}
-            ${{ matrix.is_latest && format('ghcr.io/agent-assembly/{0}:latest', matrix.lang) || '' }}
+            ghcr.io/ai-agent-assembly/${{ matrix.lang }}:${{ matrix.version }}
+            ${{ matrix.is_latest && format('ghcr.io/ai-agent-assembly/{0}:latest', matrix.lang) || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -163,7 +163,7 @@ jobs:
       - name: Smoke run (PR only)
         if: github.event_name == 'pull_request'
         env:
-          IMAGE: ghcr.io/agent-assembly/${{ matrix.lang }}:${{ matrix.version }}
+          IMAGE: ghcr.io/ai-agent-assembly/${{ matrix.lang }}:${{ matrix.version }}
           SMOKE_RUN: ${{ matrix.smoke_run }}
         run: |
           docker run --rm "$IMAGE" aasm --version


### PR DESCRIPTION
## Description

The language-image matrix in `docker.yml` (python:3.12-slim, 3.13-slim, 3.14-slim, go:1.24-alpine, 1.25-alpine, 1.26-alpine) was pushing to `ghcr.io/agent-assembly/...` — a namespace that does **not** exist on GHCR. The org's actual GHCR namespace is `ghcr.io/ai-agent-assembly/...`, which the same workflow's `aa-runtime` job at line 58 already uses correctly.

The discrepancy was surfaced by the v0.0.1-alpha.1 dry-run on 2026-05-27: all 6 language-image jobs in run `26483450432` failed with:

```
ERROR: failed to build: failed to solve: failed to push
  ghcr.io/agent-assembly/python:3.13-slim:
  denied: not_found: owner not found
```

Renaming the org from `AI-agent-assembly` → `ai-agent-assembly` (cosmetic case-only rename) does **not** fix this — GitHub org names are case-insensitive and GHCR was already normalizing to lowercase. The bug is the missing `ai-` prefix in the workflow.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: [AAASM-2093](https://lightning-dust-mite.atlassian.net/browse/AAASM-2093)
- Parent Story: [AAASM-1204](https://lightning-dust-mite.atlassian.net/browse/AAASM-1204) — F114: Docker base images
- Discovery context: v0.0.1-alpha.1 dry-run (run id 26483450432)

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed — `git grep "ghcr.io/agent-assembly/" .github/workflows/docker.yml` returns 0 matches after the fix
- [x] `actionlint .github/workflows/docker.yml` clean
- [ ] No tests required (explain why)

Verification will fully close when the next release tag is pushed and the `Build language image — python/go` matrix jobs succeed.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (none needed — internal CI fix)
- [ ] All CI checks passing (will verify once CI completes)
- [x] Commits are small and follow the Gitmoji convention

## Note on follow-up Docker work

The same matrix only tags by language-version (`:3.12-slim`) and never by release version (`:0.0.1-alpha.1`). The F119 `smoke-docker` job expects `:0.0.1-alpha.1`. That tag-scheme gap is tracked separately under AAASM-1253 finding #4 — not in this PR's scope.

— Claude Code (Opus 4.7, 1M context)

[AAASM-2093]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ