### PR TITLE
[AAASM-2094] 🐛 (aa-cli): Add version requirement to workspace path-deps

### DIFF
--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -11,12 +11,12 @@ name = "aasm"
 path = "src/main.rs"
 
 [dependencies]
-aa-core              = { path = "../aa-core" }
-aa-devtool           = { path = "../aa-devtool" }
-aa-devtool-codex     = { path = "../aa-devtool-codex" }
-aa-devtool-windsurf  = { path = "../aa-devtool-windsurf" }
-aa-gateway           = { path = "../aa-gateway" }
-aa-proxy             = { path = "../aa-proxy" }
+aa-core              = { path = "../aa-core", version = "0.0.1-alpha.1" }
+aa-devtool           = { path = "../aa-devtool", version = "0.0.1-alpha.1" }
+aa-devtool-codex     = { path = "../aa-devtool-codex", version = "0.0.1-alpha.1" }
+aa-devtool-windsurf  = { path = "../aa-devtool-windsurf", version = "0.0.1-alpha.1" }
+aa-gateway           = { path = "../aa-gateway", version = "0.0.1-alpha.1" }
+aa-proxy             = { path = "../aa-proxy", version = "0.0.1-alpha.1" }
 anyhow         = "1"
 async-trait    = "0.1"
 axum           = "0.8"


### PR DESCRIPTION
## Description

`cargo publish -p aa-cli` failed on the v0.0.1-alpha.1 dry-run with:

```
error: failed to verify manifest at `aa-cli/Cargo.toml`

Caused by:
  all dependencies must have a version requirement specified when publishing.
  the `path` specification will be removed from the dependency declaration.
```

cargo-publish strips the `path` field when uploading to crates.io and needs a `version` constraint to resolve the dep on the registry. The 6 internal workspace path-deps in `aa-cli/Cargo.toml` (aa-core, aa-devtool, aa-devtool-codex, aa-devtool-windsurf, aa-gateway, aa-proxy) had only `path = "..."` with no `version`.

Each path-dep now has `version = "0.0.1-alpha.1"` alongside the `path`. cargo prefers the local path during development; the version field is only consulted by cargo-publish.

## ⚠️ This is necessary but not sufficient

After this fix, the dry-run advances past manifest verification to a deeper failure:

```
error: failed to prepare local package for uploading
Caused by:
  no matching package named `aa-core` found
  location searched: crates.io index
```

The 6 internal crates aa-cli depends on are not published to crates.io — only aa-cli itself is being published by `release.yml`. To make `cargo publish -p aa-cli` work end-to-end, one of the following architectural decisions is needed:

1. **Publish all internal crates to crates.io in topological order** before aa-cli — would require significant `release.yml` work and lock all six crates' public APIs.
2. **Drop crates.io as a distribution channel for aa-cli** — relies on binary distribution (already working): GitHub Releases tarballs + Homebrew tap + future curl-installer.

That decision belongs to the parent Story (AAASM-1200) — out of scope for this bug. I'll file a follow-up ticket once the decision is made.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-2094](https://lightning-dust-mite.atlassian.net/browse/AAASM-2094)
- Parent Story: [AAASM-1200](https://lightning-dust-mite.atlassian.net/browse/AAASM-1200) — F110: Cross-platform CI release pipeline
- Discovery context: v0.0.1-alpha.1 dry-run, release.yml run 26483450422, job 77986193926

## Testing

- [x] Manual testing: `cargo publish -p aa-cli --dry-run --allow-dirty` advances past manifest verification (which it could not before).
- [x] `cargo fmt` / `cargo clippy` / lefthook pre-commit hooks clean.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Commits follow Gitmoji convention

— Claude Code (Opus 4.7, 1M context)

[AAASM-2094]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ