### PR TITLE
[AAASM-2095] 🐛 (ci): Set prerelease flag on GitHub Release for -alpha/-rc tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,7 @@ jobs:
             artifacts/aasm-*.tar.gz
             artifacts/SHA256SUMS
           generate_release_notes: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
 
   publish-crate:
     name: Publish to crates.io


### PR DESCRIPTION
## Description

The v0.0.1-alpha.1 dry-run on 2026-05-27 published a GitHub Release with `prerelease: false` — even though the tag explicitly carries the SemVer pre-release identifier `-alpha.1`. GitHub's "Latest" badge will point at this pre-release until a GA tag overrides it, which is misleading for downstream consumers.

The fix is a single `prerelease:` argument on the `softprops/action-gh-release@v3` step, computed from the tag shape:

```yaml
prerelease: ${{ contains(github.ref_name, '-') }}
```

`contains(github.ref_name, '-')` returns:
- `true` for any SemVer pre-release tag (`v0.0.1-alpha.1`, `v0.0.1-rc.1`, `v1.2.3-beta.4`)
- `false` for clean GA tags (`v0.0.1`, `v1.2.3`)

This matches the canonical SemVer convention where a `-` introduces the pre-release identifier.

## Out-of-scope cleanup

The existing `v0.0.1-alpha.1` Release object can be retroactively corrected via `gh release edit v0.0.1-alpha.1 --prerelease` — that's a one-shot manual ops task, not in this PR's diff.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-2095](https://lightning-dust-mite.atlassian.net/browse/AAASM-2095)
- Parent Story: [AAASM-1200](https://lightning-dust-mite.atlassian.net/browse/AAASM-1200) — F110: Cross-platform CI release pipeline
- Discovery context: v0.0.1-alpha.1 dry-run, Release URL https://github.com/AI-agent-assembly/agent-assembly/releases/tag/v0.0.1-alpha.1 (`isPrerelease: false`, should be `true`)

## Testing

- [x] `actionlint .github/workflows/release.yml` clean
- [x] Manual evaluation: `contains("v0.0.1-alpha.1", "-")` → `true`, `contains("v0.0.1", "-")` → `false`

Verification will fully close when the next release tag is pushed — observe `prerelease` flag on the resulting Release object via `gh release view <tag> --json isPrerelease`.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Commits follow Gitmoji convention

— Claude Code (Opus 4.7, 1M context)

[AAASM-2095]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ