### PR TITLE
[AAASM-2103] 🔧 (release): Bump agent-assembly workspace to 0.0.1-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to **AI Agent Assembly** are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.1-alpha.2] — 2026-05-28 (pre-release)
+
+> **Not for production use.** Second pre-release in the v0.0.1 dry-run series.
+> Continues exercising the release CD pipeline while verifying the 6
+> release-infra fixes that landed since alpha-1.
+
+### Release-infra fixes verified by this tag
+
+* **AAASM-2093** — `docker.yml` language images now push to the correct
+  `ghcr.io/ai-agent-assembly/` namespace (was `ghcr.io/agent-assembly/`,
+  which caused `denied: not_found: owner not found`).
+* **AAASM-2094** — `aa-cli/Cargo.toml` workspace path-deps now carry
+  explicit `version` literals so `cargo publish -p aa-cli` passes
+  manifest verification (the deeper crates.io dep-resolution issue is
+  tracked separately; the publish job will still fail at that step).
+* **AAASM-2095** — `release.yml` now sets `prerelease: true` on the
+  GitHub Release object for SemVer pre-release tags (`-alpha.*`,
+  `-rc.*`).
+* **AAASM-2096** — F119 smoke-test now chains off `release.yml` via
+  `workflow_call` instead of `release: published` (which was blocked
+  by the GITHUB_TOKEN downstream-trigger restriction).
+* **AAASM-2097** (node-sdk) — `pnpm publish` now derives the npm
+  dist-tag from the SemVer pre-release identifier (`--tag alpha` for
+  `-alpha.*`, `--tag rc` for `-rc.*`, etc.) instead of hardcoded
+  `--tag alpha`.
+* **AAASM-2098** (node-sdk) — `pnpm-lock.yaml` no longer drifts when
+  the workspace version bumps; `optionalDependencies` use the
+  `workspace:*` protocol.
+
+### What remains unfixed (still expected to surface on alpha-2)
+
+* **crates.io publish** — still fails at dep resolution (internal
+  crates not on crates.io). Architectural decision under AAASM-1200.
+* **F119 smoke-test channel jobs** — the 6 AAASM-1253 findings (PyPI
+  name, curl endpoint, Docker tag scheme, Homebrew tap GA, smoke-test
+  PyPI name, curl pipefail) are still pending.
+
+### Install
+
+```bash
+cargo install aasm --version 0.0.1-alpha.2
+brew install ai-agent-assembly/homebrew-agent-assembly/aasm  # version-pinned to alpha.2 via tap formula
+docker pull ghcr.io/ai-agent-assembly/aa-runtime:v0.0.1-alpha.2
+```
+
+### Refs
+
+* Verify ticket: `AAASM-2107` — alpha-2 cross-repo release verification
+* Predecessor: `AAASM-1936` — alpha-1 release-pipeline verification
+
+---
+
 ## [0.0.1-alpha.1] — 2026-05-25 (pre-release)
 
 > **Not for production use.** This is the first pre-release of AI Agent Assembly,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aa-api"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aa-core",
  "aa-devtool",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "aa-cli"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aa-core",
  "aa-devtool",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "aa-core"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-claude-code"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-codex"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-copilot"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-saas"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-sample-myeditor"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-windsurf"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "aa-ebpf"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aa-core",
  "aa-ebpf-common",
@@ -226,18 +226,18 @@ dependencies = [
 
 [[package]]
 name = "aa-ebpf-common"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 
 [[package]]
 name = "aa-ffi-go"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "aa-ffi-node"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aa-core",
  "napi",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "aa-ffi-python"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aa-core",
  "aa-proto",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "aa-gateway"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aa-core",
  "aa-proto",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "aa-integration-tests"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aa-api",
  "aa-core",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "aa-proto"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "prost",
  "tonic",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "aa-proxy"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aa-core",
  "aa-proto",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "aa-runtime"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aa-core",
  "aa-ebpf",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "aa-sandbox"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aa-core",
  "thiserror 2.0.18",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "aa-wasm"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aa-core",
  "wasm-bindgen",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 dependencies = [
  "aa-core",
  "aa-proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ exclude = ["node-sdk"]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.1-alpha.1"
+version = "0.0.1-alpha.2"
 edition = "2021"
 license = "Apache-2.0"
 license-file = "LICENSE"

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -11,12 +11,12 @@ name = "aasm"
 path = "src/main.rs"
 
 [dependencies]
-aa-core              = { path = "../aa-core", version = "0.0.1-alpha.1" }
-aa-devtool           = { path = "../aa-devtool", version = "0.0.1-alpha.1" }
-aa-devtool-codex     = { path = "../aa-devtool-codex", version = "0.0.1-alpha.1" }
-aa-devtool-windsurf  = { path = "../aa-devtool-windsurf", version = "0.0.1-alpha.1" }
-aa-gateway           = { path = "../aa-gateway", version = "0.0.1-alpha.1" }
-aa-proxy             = { path = "../aa-proxy", version = "0.0.1-alpha.1" }
+aa-core              = { path = "../aa-core", version = "0.0.1-alpha.2" }
+aa-devtool           = { path = "../aa-devtool", version = "0.0.1-alpha.2" }
+aa-devtool-codex     = { path = "../aa-devtool-codex", version = "0.0.1-alpha.2" }
+aa-devtool-windsurf  = { path = "../aa-devtool-windsurf", version = "0.0.1-alpha.2" }
+aa-gateway           = { path = "../aa-gateway", version = "0.0.1-alpha.2" }
+aa-proxy             = { path = "../aa-proxy", version = "0.0.1-alpha.2" }
 anyhow         = "1"
 async-trait    = "0.1"
 axum           = "0.8"

--- a/docs/release/v0.0.1-alpha.2.md
+++ b/docs/release/v0.0.1-alpha.2.md
@@ -1,0 +1,94 @@
+# v0.0.1-alpha.2 — pre-release dry-run continuation
+
+> **Operator note** — this file is the source-controlled draft of the GitHub
+> Release description for the `v0.0.1-alpha.2` tag. When you cut the tag on
+> GitHub Releases, paste the section below the **`---`** separator into the
+> "Describe this release" textarea. The `prerelease: true` flag is now applied
+> automatically by `release.yml` (AAASM-2095), so you no longer need to tick the
+> **"Set as a pre-release"** checkbox manually.
+
+---
+
+## v0.0.1-alpha.2 — pre-release dry-run continuation
+
+Second pre-release in the v0.0.1 dry-run series. Continues exercising the
+release CD pipeline while verifying the 6 release-infra fixes that landed since
+alpha-1. Functional scope is identical to alpha-1 — this is not a feature-bearing
+release.
+
+### Why a second pre-release
+
+The alpha-1 dry-run surfaced 6 distinct release-infra bugs that have since been
+fixed. Alpha-2 verifies those fixes by exercising the same pipeline with the
+new code path:
+
+- **Docker matrix** — language-image jobs (python/go × 3 versions each) push to
+  the correct `ghcr.io/ai-agent-assembly/` namespace (was `ghcr.io/agent-assembly/`
+  pre-fix, which produced `denied: not_found: owner not found`).
+- **GitHub Release object** — `prerelease: true` is set automatically for
+  SemVer pre-release tags via `softprops/action-gh-release@v3 prerelease:`.
+- **F119 smoke-test chain** — `smoke-test.yml` now runs as a `workflow_call`
+  child of `release.yml` instead of relying on the broken `release: published`
+  event chain.
+- **aa-cli manifest verification** — `cargo publish -p aa-cli` no longer trips
+  on missing `version` requirements in workspace path-deps.
+- **node-sdk pre-release publish** — `pnpm publish` now derives `--tag <id>`
+  from the SemVer pre-release identifier instead of hardcoded `alpha`.
+- **node-sdk lockfile** — `pnpm-lock.yaml` no longer drifts on workspace
+  version bumps; `optionalDependencies` use `workspace:*`.
+
+### Known issues that will still surface on alpha-2
+
+These are tracked separately and will not be fixed by this release:
+
+1. **crates.io publish** — `cargo publish -p aa-cli` advances past manifest
+   verification but still fails at dep resolution because the 6 internal crates
+   (`aa-core`, `aa-devtool`, `aa-devtool-codex`, `aa-devtool-windsurf`,
+   `aa-gateway`, `aa-proxy`) are not on crates.io. Architectural decision
+   pending — either publish all internal crates in topological order, or drop
+   crates.io as a distribution channel for `aasm`. Binary distribution via
+   GitHub Releases + Homebrew tap remains the recommended install path.
+
+2. **F119 smoke-test channel jobs** — the 6 outstanding AAASM-1253 findings
+   (PyPI package name mismatch, curl-installer endpoint, Docker `:0.0.1-alpha.*`
+   tag scheme, Homebrew tap GA status, smoke-test PyPI install name, curl
+   pipefail) will still surface as failed channel jobs. The smoke-test
+   *workflow* now fires correctly (AAASM-2096); the *channels* themselves still
+   need work.
+
+### Install (pre-release dist-tags)
+
+```bash
+# Rust (cargo) — see AAASM-1200 follow-up; crates.io publish still gated
+cargo install aasm --version 0.0.1-alpha.2  # currently fails — use the binary tarball instead
+
+# Homebrew tap
+brew install ai-agent-assembly/homebrew-agent-assembly/aasm  # tap formula auto-updates
+
+# Direct binary download
+curl -L https://github.com/ai-agent-assembly/agent-assembly/releases/download/v0.0.1-alpha.2/aasm-aarch64-apple-darwin.tar.gz | tar xz
+
+# Docker (aa-runtime)
+docker pull ghcr.io/ai-agent-assembly/aa-runtime:v0.0.1-alpha.2
+
+# Language-specific runtime images (now using corrected namespace)
+docker pull ghcr.io/ai-agent-assembly/python:3.14-slim
+docker pull ghcr.io/ai-agent-assembly/go:1.26-alpine
+
+# Python SDK
+pip install --pre agent-assembly==0.0.1a2
+
+# Node.js SDK (now correctly resolves via @alpha dist-tag)
+npm install @agent-assembly/sdk@alpha
+
+# Go SDK
+go get github.com/AI-agent-assembly/go-sdk@v0.0.1-alpha.2
+```
+
+### Refs
+
+- Epic   `AAASM-1199` — Release & Distribution Pipeline
+- Story  `AAASM-1234` — F118 release-trigger
+- Verify `AAASM-2107` — alpha-2 cross-repo release verification
+- Predecessor: `AAASM-1936` — alpha-1 release-pipeline verification
+- Sibling release docs: `docs/release/v0.0.1-alpha.1.md`

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -17,6 +17,7 @@ This document tracks which versions of `aa-runtime` are compatible with each SDK
 | `aa-runtime` | Python SDK (`aa-ffi-python`) | Node.js SDK (`aa-ffi-node`) | Go SDK (`aa-ffi-go`) | Protocol Version |
 |---|---|---|---|---|
 | v0.0.1-alpha.1 | v0.0.1-alpha.1 (PyPI `0.0.1a1`) ✓ | v0.0.1-alpha.1 ✓ | v0.0.1-alpha.1 ✓ | protocol/v1 |
+| v0.0.1-alpha.2 | v0.0.1-alpha.2 (PyPI `0.0.1a2`) ✓ | v0.0.1-alpha.2 ✓ | v0.0.1-alpha.2 ✓ | protocol/v1 |
 | v0.0.1 | v0.0.1 ✓ | v0.0.1 ✓ | v0.0.1 ✓ | protocol/v1 |
 
 **Legend:**
@@ -43,6 +44,7 @@ A runtime version may support multiple protocol versions to allow SDK upgrades w
 | `aa-runtime` Version | Supported Protocol Versions |
 |---|---|
 | v0.0.1-alpha.1 | protocol/v1 |
+| v0.0.1-alpha.2 | protocol/v1 |
 | v0.0.1 | protocol/v1 |
 
 ---


### PR DESCRIPTION
## Description

Bump `agent-assembly` workspace from `0.0.1-alpha.1` → `0.0.1-alpha.2` for the cross-repo alpha-2 pre-release dry-run. Verifies the 4 release-infra fixes that landed since alpha-1:

- **AAASM-2093** — Docker GHCR namespace (`ai-agent-assembly/`, was `agent-assembly/`)
- **AAASM-2094** — aa-cli path-deps carry explicit `version` literals
- **AAASM-2095** — `softprops/action-gh-release@v3` sets `prerelease: true` for SemVer pre-release tags
- **AAASM-2096** — F119 smoke-test chains off `release.yml` via `workflow_call`

## Diff

| File | Change |
|---|---|
| `Cargo.toml` | `[workspace.package] version` → `"0.0.1-alpha.2"` |
| `Cargo.lock` | Regenerated by `cargo build --workspace` |
| `aa-cli/Cargo.toml` | 6 path-dep `version` literals bumped (tech-debt tracked under AAASM-2100) |
| `CHANGELOG.md` | New `[0.0.1-alpha.2]` section |
| `docs/release/v0.0.1-alpha.2.md` | **New** — operator-note header + release body |
| `docs/src/compatibility.md` | `v0.0.1-alpha.2` row added to both tables |

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Jira ticket: [AAASM-2103](https://lightning-dust-mite.atlassian.net/browse/AAASM-2103)
- Parent Story: [AAASM-1234](https://lightning-dust-mite.atlassian.net/browse/AAASM-1234) — F118: Release-trigger
- Epic: [AAASM-1199](https://lightning-dust-mite.atlassian.net/browse/AAASM-1199) — Release & Distribution Pipeline

## Testing

- [x] `cargo build --workspace` → exit 0
- [x] `cargo nextest run -p aa-integration-tests --test cli_version` → 7/7 passing (the alpha-1 SemVer-tolerant fix handles `-alpha.2`)
- [x] `cargo publish -p aa-cli --dry-run --allow-dirty` → advances past manifest verification (the deeper crates.io dep-resolution failure is expected, not a regression — see AAASM-2094 caveat)

## What's still expected to fail on alpha-2 tag-push

1. **agent-assembly `Publish to crates.io` job** — still fails at dep resolution. Architectural decision under AAASM-1200.
2. **F119 smoke-test channel jobs** — the 6 outstanding AAASM-1253 findings (PyPI name, curl endpoint, Docker tag scheme, Homebrew tap GA, smoke-test PyPI name, curl pipefail).

These are tracked separately and out of scope for this bump.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Commits follow Gitmoji convention

— Claude Code (Opus 4.7, 1M context)

[AAASM-2103]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ