### PR TITLE
[AAASM-2312] 🔧 (release): Bump agent-assembly workspace to 0.0.1-alpha.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to **AI Agent Assembly** are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.1-alpha.3] — 2026-06-01 (pre-release)
+
+> **Not for production use.** Third pre-release in the v0.0.1 dry-run
+> series. Verifies the 3 release-infra fixes that landed since alpha-2.
+
+### Release-infra fixes verified by this tag
+
+* **AAASM-2188 (PR #832)** — Docker matrix parallel cargo cache race
+  (`File exists (os error 17)` when unpacking same crate concurrently).
+  Fixed by per-Dockerfile cache `id` + `sharing=locked` on all 6
+  language Dockerfiles.
+* **AAASM-2189 (python-sdk#68)** — `Release Python SDK` maturin wheel
+  builds missing protoc. Fixed by downloading official protoc 32.1
+  binary in `before-script-linux` with SHA256 verification + retry.
+* **AAASM-2190 (node-sdk#59)** — `release.yml` `pnpm publish` E402
+  for scoped package. Fixed by adding `--access public`.
+
+### Still unfixed (separately tracked, not blocking this dry-run)
+
+* `Publish to crates.io` — AAASM-2094 deeper issue (internal crates
+  not on crates.io). Architectural decision pending under AAASM-1200.
+* `node-sdk release-node` cross-repo race (release not found).
+* `smoke-test.yml` Docker pull uses old namespace.
+* 6× AAASM-1253 smoke-test findings.
+
+### Install
+
+```bash
+cargo install aasm --version 0.0.1-alpha.3
+brew install ai-agent-assembly/homebrew-agent-assembly/aasm
+docker pull ghcr.io/ai-agent-assembly/aa-runtime:v0.0.1-alpha.3
+```
+
+### Refs
+
+* Verify: `AAASM-2316`
+* Predecessor: `AAASM-2107` (alpha-2)
+
+---
+
 ## [0.0.1-alpha.2] — 2026-05-28 (pre-release)
 
 > **Not for production use.** Second pre-release in the v0.0.1 dry-run series.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aa-api"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aa-core",
  "aa-devtool",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "aa-cli"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aa-core",
  "aa-devtool",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "aa-core"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aho-corasick",
  "async-trait",
@@ -116,7 +116,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -129,7 +129,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-claude-code"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -143,7 +143,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-codex"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-copilot"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -168,7 +168,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-saas"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-sample-myeditor"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "aa-devtool-windsurf"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aa-core",
  "async-trait",
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "aa-ebpf"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aa-core",
  "aa-ebpf-common",
@@ -226,18 +226,18 @@ dependencies = [
 
 [[package]]
 name = "aa-ebpf-common"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 
 [[package]]
 name = "aa-ffi-go"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "aa-ffi-node"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aa-core",
  "napi",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "aa-ffi-python"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aa-core",
  "aa-proto",
@@ -260,7 +260,7 @@ dependencies = [
 
 [[package]]
 name = "aa-gateway"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aa-core",
  "aa-proto",
@@ -319,7 +319,7 @@ dependencies = [
 
 [[package]]
 name = "aa-integration-tests"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aa-api",
  "aa-core",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "aa-proto"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "prost",
  "tonic",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "aa-proxy"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aa-core",
  "aa-proto",
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "aa-runtime"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aa-core",
  "aa-ebpf",
@@ -432,7 +432,7 @@ dependencies = [
 
 [[package]]
 name = "aa-sandbox"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aa-core",
  "thiserror 2.0.18",
@@ -443,7 +443,7 @@ dependencies = [
 
 [[package]]
 name = "aa-wasm"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aa-core",
  "wasm-bindgen",
@@ -1624,7 +1624,7 @@ dependencies = [
 
 [[package]]
 name = "conformance"
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 dependencies = [
  "aa-core",
  "aa-proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ exclude = ["node-sdk"]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.1-alpha.2"
+version = "0.0.1-alpha.3"
 edition = "2021"
 license = "Apache-2.0"
 license-file = "LICENSE"

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -11,12 +11,12 @@ name = "aasm"
 path = "src/main.rs"
 
 [dependencies]
-aa-core              = { path = "../aa-core", version = "0.0.1-alpha.2" }
-aa-devtool           = { path = "../aa-devtool", version = "0.0.1-alpha.2" }
-aa-devtool-codex     = { path = "../aa-devtool-codex", version = "0.0.1-alpha.2" }
-aa-devtool-windsurf  = { path = "../aa-devtool-windsurf", version = "0.0.1-alpha.2" }
-aa-gateway           = { path = "../aa-gateway", version = "0.0.1-alpha.2" }
-aa-proxy             = { path = "../aa-proxy", version = "0.0.1-alpha.2" }
+aa-core              = { path = "../aa-core", version = "0.0.1-alpha.3" }
+aa-devtool           = { path = "../aa-devtool", version = "0.0.1-alpha.3" }
+aa-devtool-codex     = { path = "../aa-devtool-codex", version = "0.0.1-alpha.3" }
+aa-devtool-windsurf  = { path = "../aa-devtool-windsurf", version = "0.0.1-alpha.3" }
+aa-gateway           = { path = "../aa-gateway", version = "0.0.1-alpha.3" }
+aa-proxy             = { path = "../aa-proxy", version = "0.0.1-alpha.3" }
 anyhow         = "1"
 async-trait    = "0.1"
 axum           = "0.8"

--- a/docs/release/v0.0.1-alpha.3.md
+++ b/docs/release/v0.0.1-alpha.3.md
@@ -1,0 +1,45 @@
+# v0.0.1-alpha.3 — release-infra fixes verification
+
+> **Operator note** — this file is the source-controlled draft of the
+> GitHub Release description for the `v0.0.1-alpha.3` tag. The
+> `prerelease: true` flag is now applied automatically by `release.yml`
+> (AAASM-2095, verified in alpha-2).
+
+---
+
+## v0.0.1-alpha.3 — release-infra fixes verification
+
+Third pre-release in the v0.0.1 dry-run series. Verifies that the 3
+release-infra fixes that landed since alpha-2 actually work in real
+release CD (not just locally).
+
+### Fixes verified by this tag
+
+- **AAASM-2188** — Docker matrix parallel cargo cache race
+- **AAASM-2189** — maturin protoc + SHA256 hardening
+- **AAASM-2190** — node-sdk `--access public` for scoped npm publish
+
+### Known issues still surfacing on this dry-run (tracked separately)
+
+- `Publish to crates.io` — AAASM-2094 deeper issue
+- `node-sdk release-node` — cross-repo race ("release not found")
+- `smoke-docker` — smoke-test.yml uses old `ghcr.io/agent-assembly/`
+- 6× AAASM-1253 smoke-test channel findings
+
+### Install (pre-release dist-tags)
+
+```bash
+brew install ai-agent-assembly/homebrew-agent-assembly/aasm
+curl -L https://github.com/ai-agent-assembly/agent-assembly/releases/download/v0.0.1-alpha.3/aasm-aarch64-apple-darwin.tar.gz | tar xz
+docker pull ghcr.io/ai-agent-assembly/aa-runtime:v0.0.1-alpha.3
+docker pull ghcr.io/ai-agent-assembly/python:3.14-slim
+pip install --pre agent-assembly==0.0.1a3
+npm install @agent-assembly/sdk@alpha
+go get github.com/AI-agent-assembly/go-sdk@v0.0.1-alpha.3
+```
+
+### Refs
+
+- Epic `AAASM-1199` — Release & Distribution Pipeline
+- Story `AAASM-1234` — F118 release-trigger
+- Verify `AAASM-2316` — alpha-3 cross-repo release verification

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -18,6 +18,7 @@ This document tracks which versions of `aa-runtime` are compatible with each SDK
 |---|---|---|---|---|
 | v0.0.1-alpha.1 | v0.0.1-alpha.1 (PyPI `0.0.1a1`) ✓ | v0.0.1-alpha.1 ✓ | v0.0.1-alpha.1 ✓ | protocol/v1 |
 | v0.0.1-alpha.2 | v0.0.1-alpha.2 (PyPI `0.0.1a2`) ✓ | v0.0.1-alpha.2 ✓ | v0.0.1-alpha.2 ✓ | protocol/v1 |
+| v0.0.1-alpha.3 | v0.0.1-alpha.3 (PyPI `0.0.1a3`) ✓ | v0.0.1-alpha.3 ✓ | v0.0.1-alpha.3 ✓ | protocol/v1 |
 | v0.0.1 | v0.0.1 ✓ | v0.0.1 ✓ | v0.0.1 ✓ | protocol/v1 |
 
 **Legend:**
@@ -45,6 +46,7 @@ A runtime version may support multiple protocol versions to allow SDK upgrades w
 |---|---|
 | v0.0.1-alpha.1 | protocol/v1 |
 | v0.0.1-alpha.2 | protocol/v1 |
+| v0.0.1-alpha.3 | protocol/v1 |
 | v0.0.1 | protocol/v1 |
 
 ---


### PR DESCRIPTION
## Description

Third pre-release in the v0.0.1 dry-run series. Verifies the 3 release-infra fixes that landed since alpha-2:
- AAASM-2188 (PR #832) — Docker matrix cargo cache race
- AAASM-2189 (python-sdk#68) — maturin protoc + SHA256 hardening
- AAASM-2190 (node-sdk#59) — pnpm publish --access public

## Files updated

| File | Change |
|---|---|
| `Cargo.toml` | workspace version → "0.0.1-alpha.3" |
| `Cargo.lock` | Regenerated by `cargo build --workspace` |
| `aa-cli/Cargo.toml` | 6 path-dep version literals bumped (AAASM-2100 debt) |
| `CHANGELOG.md` | New [0.0.1-alpha.3] section |
| `docs/release/v0.0.1-alpha.3.md` | New release-notes file |
| `docs/src/compatibility.md` | Alpha-3 rows in both tables |

## Related Issues
- Jira: [AAASM-2312](https://lightning-dust-mite.atlassian.net/browse/AAASM-2312)
- Parent: [AAASM-1234](https://lightning-dust-mite.atlassian.net/browse/AAASM-1234)
- Epic: [AAASM-1199](https://lightning-dust-mite.atlassian.net/browse/AAASM-1199)

## Testing

- [x] `cargo build --workspace` clean (regenerated Cargo.lock)
- [x] `cargo nextest -p aa-integration-tests --test cli_version` → 7/7 passing
- [x] `cargo publish -p aa-cli --dry-run` advances past manifest verification (deeper dep-resolution failure expected per AAASM-2094)

— Claude Code (Opus 4.7, 1M context)

[AAASM-2312]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1234]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-1199]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ