### PR TITLE
[AAASM-2325] 🐛 (smoke): Fix wrong org/package identifiers in smoke-test.yml

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Install aasm via Homebrew tap
         run: |
           brew update
-          brew install agent-assembly/tap/aasm
+          brew install ai-agent-assembly/agent-assembly/aasm
 
       - name: Verify aasm --version matches release tag
         env:
@@ -107,7 +107,7 @@ jobs:
       - name: Install aasm via Homebrew tap
         run: |
           brew update
-          brew install agent-assembly/tap/aasm
+          brew install ai-agent-assembly/agent-assembly/aasm
 
       - name: Verify aasm --version matches release tag
         env:
@@ -202,10 +202,10 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install agent-assembly-python[runtime] from PyPI
+      - name: Install agent-assembly from PyPI
         run: |
           python -m pip install --upgrade pip
-          pip install --no-cache-dir 'agent-assembly-python[runtime]'
+          pip install --no-cache-dir 'agent-assembly'
 
       - name: Verify agent_assembly.__version__ matches release tag
         env:
@@ -249,10 +249,10 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install agent-assembly-python[runtime] from PyPI
+      - name: Install agent-assembly from PyPI
         run: |
           python -m pip install --upgrade pip
-          pip install --no-cache-dir 'agent-assembly-python[runtime]'
+          pip install --no-cache-dir 'agent-assembly'
 
       - name: Verify the bundled aasm binary prints the release tag
         env:
@@ -326,7 +326,7 @@ jobs:
           }
 
   smoke-docker:
-    name: Smoke — Docker (ghcr.io/agent-assembly/python)
+    name: Smoke — Docker (ghcr.io/ai-agent-assembly/python)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -357,12 +357,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: echo "${GH_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
 
-      - name: Run aasm --version inside ghcr.io/agent-assembly/python
+      - name: Run aasm --version inside ghcr.io/ai-agent-assembly/python
         env:
           EXPECTED: ${{ steps.expected.outputs.version }}
         shell: bash
         run: |
-          image="ghcr.io/agent-assembly/python:${EXPECTED}"
+          image="ghcr.io/ai-agent-assembly/python:${EXPECTED}"
           got=$(docker run --rm "${image}" aasm --version)
           want="aasm ${EXPECTED}"
           echo "Image:     ${image}"


### PR DESCRIPTION
## Description
v0.0.1-alpha.3 dry-run exposed 5 of 7 smoke-test channel failures — all caused by wrong identifier strings IN `smoke-test.yml` itself (not by the channels being tested).

## Fixes (7 string replacements in 1 file)

| Line | Old | New |
|---|---|---|
| 63, 110 | `agent-assembly/tap/aasm` | `ai-agent-assembly/agent-assembly/aasm` |
| 208, 255 | `agent-assembly-python[runtime]` | `agent-assembly` |
| 329, 360, 365 | `ghcr.io/agent-assembly/python` | `ghcr.io/ai-agent-assembly/python` |

GHCR Docker fix is the PULL side of the AAASM-2093 namespace bug (the PUSH side in docker.yml was fixed; smoke-test.yml's PULL side was missed).

## Out of scope (other smoke failures, separately tracked)
- curl-installer (`get.agent-assembly.io` CDN missing) — AAASM-1253 infrastructure gap
- npm postinstall (`Cannot find module postinstall.mjs`) — AAASM-2326 packaging bug

## Verification
- `git grep "agent-assembly/tap\|agent-assembly-python\|ghcr.io/agent-assembly/" .github/workflows/smoke-test.yml` → 0 hits
- `actionlint` clean

## Related
- Jira: [AAASM-2325](https://lightning-dust-mite.atlassian.net/browse/AAASM-2325)
- Parent: [AAASM-1235](https://lightning-dust-mite.atlassian.net/browse/AAASM-1235) — F119 smoke test

— Claude Code (Opus 4.7, 1M context)

[AAASM-2325]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ