### PR TITLE
[AAASM-2339] 🔧 (smoke): Gate curl-installer with if: false until get.agent-assembly.io ships

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -123,6 +123,67 @@ jobs:
             exit 1
           }
 
+  smoke-curl-installer:
+    name: Smoke — curl installer
+    # AAASM-2339: get.agent-assembly.io is not provisioned yet (no DNS,
+    # no Cloudflare Worker). The job is preserved here under an unconditional
+    # `if: false` so the wiring is ready when the curl|sh install path ships;
+    # until then the job is skipped on every release and emits no signal.
+    # Deliberately kept out of `notify-on-failure`'s `needs:` list so a
+    # skipped run does not propagate to that downstream job. To re-enable:
+    # provision the endpoint, flip `if: false` to `if: true` (or drop the
+    # line), and re-add `- smoke-curl-installer` to notify-on-failure's
+    # `needs:`.
+    if: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Compute expected aasm version
+        id: expected
+        shell: bash
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "${INPUT_VERSION}" ]; then
+            version="${INPUT_VERSION#v}"
+          else
+            version="${TAG#v}"
+          fi
+          if [ -z "${version}" ]; then
+            echo "::error::Could not resolve release version from event payload" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Install aasm via the curl installer
+        run: |
+          # Pipe-to-shell is the documented one-liner for this distribution
+          # channel; the installer drops `aasm` into a directory on $PATH for
+          # the current shell. Re-export common install locations so the
+          # subsequent step can find the binary regardless of which one the
+          # installer chose.
+          curl -fsSL https://get.agent-assembly.io | sh
+          {
+            echo "$HOME/.local/bin"
+            echo "$HOME/.agent-assembly/bin"
+            echo "/usr/local/bin"
+          } >> "$GITHUB_PATH"
+
+      - name: Verify aasm --version matches release tag
+        env:
+          EXPECTED: ${{ steps.expected.outputs.version }}
+        shell: bash
+        run: |
+          got=$(aasm --version)
+          want="aasm ${EXPECTED}"
+          echo "Installed: ${got}"
+          echo "Expected:  ${want}"
+          [ "${got}" = "${want}" ] || {
+            echo "::error::aasm --version mismatch — got '${got}', want '${want}'"
+            exit 1
+          }
+
   smoke-python-pypi-import:
     name: Smoke — Python pip (import + __version__)
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -123,57 +123,6 @@ jobs:
             exit 1
           }
 
-  smoke-curl-installer:
-    name: Smoke — curl installer
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Compute expected aasm version
-        id: expected
-        shell: bash
-        env:
-          TAG: ${{ github.event.release.tag_name }}
-          INPUT_VERSION: ${{ inputs.version }}
-        run: |
-          if [ -n "${INPUT_VERSION}" ]; then
-            version="${INPUT_VERSION#v}"
-          else
-            version="${TAG#v}"
-          fi
-          if [ -z "${version}" ]; then
-            echo "::error::Could not resolve release version from event payload" >&2
-            exit 1
-          fi
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-
-      - name: Install aasm via the curl installer
-        run: |
-          # Pipe-to-shell is the documented one-liner for this distribution
-          # channel; the installer drops `aasm` into a directory on $PATH for
-          # the current shell. Re-export common install locations so the
-          # subsequent step can find the binary regardless of which one the
-          # installer chose.
-          curl -fsSL https://get.agent-assembly.io | sh
-          {
-            echo "$HOME/.local/bin"
-            echo "$HOME/.agent-assembly/bin"
-            echo "/usr/local/bin"
-          } >> "$GITHUB_PATH"
-
-      - name: Verify aasm --version matches release tag
-        env:
-          EXPECTED: ${{ steps.expected.outputs.version }}
-        shell: bash
-        run: |
-          got=$(aasm --version)
-          want="aasm ${EXPECTED}"
-          echo "Installed: ${got}"
-          echo "Expected:  ${want}"
-          [ "${got}" = "${want}" ] || {
-            echo "::error::aasm --version mismatch — got '${got}', want '${want}'"
-            exit 1
-          }
-
   smoke-python-pypi-import:
     name: Smoke — Python pip (import + __version__)
     runs-on: ubuntu-latest
@@ -378,7 +327,6 @@ jobs:
     needs:
       - smoke-homebrew-macos
       - smoke-homebrew-linux
-      - smoke-curl-installer
       - smoke-python-pypi-import
       - smoke-python-pypi-runtime
       - smoke-npm


### PR DESCRIPTION
## Description

F119 smoke-test's `Smoke — curl installer` channel runs `curl -fsSL https://get.agent-assembly.io | sh` but the endpoint doesn't exist (no DNS, no Cloudflare Worker). It failed every release dry-run.

## Decision: keep the wiring, gate it off

Initial PR (commit `ea663d95`) **deleted** the job outright (Option C from AAASM-2339's A vs B vs C trade-off). Reviewer pushback: the curl|sh install path will exist eventually (at v0.1+ when marketing matters, per the ticket), so keeping the workflow wiring in source is cheaper than deleting and re-introducing it later.

This PR therefore **gates the job off** instead of deleting it:

- Restores the original `smoke-curl-installer` job body (commit `6a60f31b`)
- Adds `if: false` so it skips on every release — zero CI minutes consumed, no DNS lookups, no errors
- Documents the re-enable recipe in a job-level comment block
- Keeps the job **out** of `notify-on-failure`'s `needs:` list so a skipped run cannot affect that downstream job

## To re-enable when the endpoint ships

1. Provision `get.agent-assembly.io` (DNS + Cloudflare Worker / static install script).
2. Flip `if: false` to `if: true` (or drop the line entirely).
3. Re-add `- smoke-curl-installer` to `notify-on-failure`'s `needs:` list.

## Changes

- `smoke-test.yml`: restore `smoke-curl-installer` under `if: false` with a re-enable-recipe comment block.
- `notify-on-failure.needs`: leave the curl entry off (a `skipped` dependency would not block notification, but skipping noise is clearer).

Smoke matrix on every release: 6 channels run, 1 channel is reported as `skipped`.

## Related

- Jira: [AAASM-2339](https://lightning-dust-mite.atlassian.net/browse/AAASM-2339)
- Resolves: AAASM-1253 curl-installer finding

— Claude Code

[AAASM-2339]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
