### PR TITLE
[AAASM-2336] ♻️ (release): Add notify-downstream — repository_dispatch to node-sdk + python-sdk after Release publishes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,5 +285,23 @@ jobs:
           event-type: agent-assembly-release-published
           client-payload: '{"release_tag": "${{ github.ref_name }}"}'
 
-      # Future: also dispatch to python-sdk + go-sdk if they ever
-      # need to consume agent-assembly binaries the same way.
+      - name: Dispatch to python-sdk
+        # python-sdk's release-python.yml downloads `aasm-*` binaries from
+        # the agent-assembly GH Release across four runners (linux x86_64,
+        # linux aarch64, macos arm64, macos x86_64). Its current `gh release
+        # download … 2>/dev/null` swallow ships a wheel without the bundled
+        # binary on race; dispatching here is the only loud signal for that
+        # race. Companion PR on python-sdk will switch its release trigger
+        # from `push: tags` to `on: repository_dispatch` (tracked separately).
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        with:
+          token: ${{ secrets.CROSS_REPO_DISPATCH_PAT }}
+          repository: ai-agent-assembly/python-sdk
+          event-type: agent-assembly-release-published
+          client-payload: '{"release_tag": "${{ github.ref_name }}"}'
+
+      # go-sdk intentionally NOT dispatched: pure-Go module, no aasm
+      # binary consumption in its release pipeline (`goreleaser.yaml`
+      # is a check-only workflow; Go module proxy auto-indexes from
+      # git tags directly). Add a dispatch step here if that ever
+      # changes.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,3 +256,34 @@ jobs:
       packages: read
     with:
       version: ${{ github.ref_name }}
+
+  notify-downstream:
+    # Cross-repo trigger: after agent-assembly's Release object is
+    # published (binaries available on the GH Release page), fire a
+    # repository_dispatch event to the downstream SDK repos so their
+    # consume-the-binaries workflows know it's safe to run.
+    #
+    # Without this, node-sdk's release-node.yml fires on its OWN tag
+    # push (in parallel with agent-assembly's release), tries to
+    # `gh release download` aasm-*.tar.gz, and gets "release not found"
+    # because agent-assembly hasn't finished publishing yet.
+    #
+    # AAASM-2336. Supersedes the retry-with-backoff workaround in
+    # node-sdk's release-node.yml (AAASM-2328).
+    name: Notify downstream SDK repos
+    needs: publish
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Dispatch to node-sdk
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        with:
+          token: ${{ secrets.CROSS_REPO_DISPATCH_PAT }}
+          repository: ai-agent-assembly/node-sdk
+          event-type: agent-assembly-release-published
+          client-payload: '{"release_tag": "${{ github.ref_name }}"}'
+
+      # Future: also dispatch to python-sdk + go-sdk if they ever
+      # need to consume agent-assembly binaries the same way.


### PR DESCRIPTION
## Description

Replaces the AAASM-2328 retry-with-backoff workaround in node-sdk (and the silent `2>/dev/null` swallow in python-sdk) with explicit event-driven cross-repo coordination. After agent-assembly's `publish` job creates the GitHub Release, this new `notify-downstream` job fires a `repository_dispatch` event to the SDK repos so their consume-the-binaries workflows only run once the binaries are actually available on the GH Release.

## Dispatch targets

| Repo | Dispatched? | Why |
|---|---|---|
| `ai-agent-assembly/node-sdk` | ✅ | `release-node.yml` does `gh release download` on `aasm-*.tar.gz`. Was retry-with-backoff per AAASM-2328 |
| `ai-agent-assembly/python-sdk` | ✅ | `release-python.yml` does `gh release download --pattern 'aasm-*'` across four runners (linux x86_64, linux aarch64, macos arm64, macos x86_64). Current workaround swallows the failure with `2>/dev/null` and silently ships a wheel **without** the bundled aasm binary on race. Adding the dispatch is more urgent here than for node-sdk. |
| `ai-agent-assembly/go-sdk` | ❌ | Pure-Go module, no aasm binary consumption in its release pipeline. `goreleaser.yaml` is a check-only workflow; Go module proxy auto-indexes from git tags. If go-sdk ever starts consuming agent-assembly binaries, add a third dispatch step. |

## 🚨 OPERATOR PREREQUISITE

Before merging, configure secret `CROSS_REPO_DISPATCH_PAT` in `ai-agent-assembly/agent-assembly` repo settings with EITHER:

- **Classic PAT**: `repo` scope covering both `ai-agent-assembly/node-sdk` AND `ai-agent-assembly/python-sdk`
- **Fine-grained PAT** (preferred): Contents:Read, Metadata:Read, Actions:R/W, Dispatches permission on **both** node-sdk **and** python-sdk

Cannot be automated — needs operator to create the PAT.

## Companion PRs

- **node-sdk** (existing): [node-sdk#XX](https://github.com/ai-agent-assembly/node-sdk/pulls?q=AAASM-2336) — listens for the dispatch event + removes the retry loop. Both this PR and node-sdk's must merge for node-sdk's flow to work end-to-end.
- **python-sdk** (follow-up): [AAASM-2342](https://lightning-dust-mite.atlassian.net/browse/AAASM-2342) tracks switching `release-python.yml`'s trigger from `push: tags` to `on: repository_dispatch: { types: [agent-assembly-release-published] }` and dropping the silent `2>/dev/null` swallow. Until that lands, python-sdk continues firing on tag-push as today; the new dispatch is harmless on python-sdk side because `release-python.yml` doesn't yet listen for it.

## Related

- Jira: [AAASM-2336](https://lightning-dust-mite.atlassian.net/browse/AAASM-2336)
- Supersedes: AAASM-2328 workaround
- Follow-up: [AAASM-2342](https://lightning-dust-mite.atlassian.net/browse/AAASM-2342) — python-sdk repository_dispatch wiring

— Claude Code

[AAASM-2336]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[AAASM-2342]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ