### PR TITLE
[AAASM-2346] 🐛 (release): Add --allow-dirty to cargo workspaces publish for _embedded staging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,6 +272,7 @@ jobs:
             --from-git \
             --no-git-push \
             --yes \
+            --allow-dirty \
             --token "$CARGO_REGISTRY_TOKEN"
 
   update-homebrew-tap:


### PR DESCRIPTION
## Description

`v0.0.1-alpha.4` release pipeline's `publish-crates` job failed at `cargo publish -p aa-proto` with:

```
error: 18 files in the working directory contain changes that were not yet committed into git:

aa-proto/_embedded/proto/agent.proto
aa-proto/_embedded/proto/approval.proto
aa-proto/_embedded/proto/audit.proto
aa-proto/_embedded/proto/buf.yaml
[…]

to proceed despite this and include the uncommitted changes, pass the `--allow-dirty` flag
error: unable to publish package aa-proto
```

## Root cause

`aa-proto/build.rs` mirrors `proto/` → `aa-proto/_embedded/proto/` at build time, so the proto files end up inside the published crate tarball. Those files are intentionally NOT git-tracked (they're derived from the source `proto/` tree and regenerated on every build). `cargo publish` refuses a dirty tree by default; `cargo workspaces publish` doesn't pass `--allow-dirty` through automatically.

The same situation applies to the other staging steps that precede `publish-crates`:
- `aa-ebpf/_embedded/aa-ebpf-probes/` (cp + sed rewrite)
- `aa-cli/_embedded/dashboard/dist/` (pnpm build + cp)
- Temporary edits `.ci/strip-for-publish.sh` makes to `aa-cli/Cargo.toml` + `src/commands/mod.rs` to drop the held-back dev-tool surface

All four of those dirtiness sources are deliberate pre-publish state. `--allow-dirty` just tells `cargo publish` to accept them.

## Fix

One-line diff:

```diff
 cargo workspaces publish \
   --from-git \
   --no-git-push \
   --yes \
+  --allow-dirty \
   --token "$CARGO_REGISTRY_TOKEN"
```

## Operator gate (already addressed)

The crates.io account behind `CRATES_IO_TOKEN` (mapped to env var `CARGO_REGISTRY_TOKEN` per cargo's convention — secret name in GH is `CRATES_IO_TOKEN`, env var name cargo expects is `CARGO_REGISTRY_TOKEN`) needed email verification. Original failure was a 400 Bad Request: `"A verified email address is required to publish crates to crates.io"`. Operator confirmed the email is now verified.

## Recovery path

1. Merge this PR.
2. Re-run failed jobs on existing Release run [26854864681](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/26854864681), OR re-trigger via `workflow_dispatch` against the existing `v0.0.1-alpha.4` tag.
3. `publish-crates` should now succeed and land all 9 crates on crates.io for the first time. Verified locally that no `v0.0.1-alpha.4` artifacts exist on crates.io yet (curl returns 404 for aa-core / aa-proto / aa-runtime / aa-cli / aa-gateway).

**No new git tag needed.**

## Companion fixes for the same v0.0.1-alpha.4 release failure

- [node-sdk#67](https://github.com/ai-agent-assembly/node-sdk/pull/67) — lowercase `repository.url` in `package.json` for npm sigstore provenance match (AAASM-2344)
- [python-sdk#74](https://github.com/ai-agent-assembly/python-sdk/pull/74) — three bugs in `release-python.yml` Stage step (AAASM-2345)

All three repos need their fix PRs merged before re-triggering the SDK release workflows via `workflow_dispatch`.

## Related

- Jira: [AAASM-2346](https://lightning-dust-mite.atlassian.net/browse/AAASM-2346)
- Parent Story: [AAASM-1200](https://lightning-dust-mite.atlassian.net/browse/AAASM-1200) (F110 release pipeline)
- Failed run: https://github.com/ai-agent-assembly/agent-assembly/actions/runs/26854864681

— Claude Code


[AAASM-2346]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ