### PR TITLE
[AAASM-2455] 🐛 (smoke): Pin pip install to PEP-440 prerelease + restore [runtime] extra

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -213,9 +213,15 @@ jobs:
           python-version: "3.12"
 
       - name: Install agent-assembly from PyPI
+        env:
+          VERSION: ${{ steps.expected.outputs.version }}
         run: |
           python -m pip install --upgrade pip
-          pip install --no-cache-dir 'agent-assembly'
+          # AAASM-2455: pin to the just-published prerelease so we don't resolve
+          # to the bogus PyPI 0.0.2 squat (AAASM-2454). PEP-440 form:
+          # 0.0.1-alpha.N → 0.0.1aN.
+          pep440="${VERSION//-alpha./a}"
+          pip install --no-cache-dir --pre "agent-assembly==${pep440}"
 
       - name: Verify agent_assembly.__version__ matches release tag
         env:
@@ -259,10 +265,18 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install agent-assembly from PyPI
+      - name: Install agent-assembly[runtime] from PyPI
+        env:
+          VERSION: ${{ steps.expected.outputs.version }}
         run: |
           python -m pip install --upgrade pip
-          pip install --no-cache-dir 'agent-assembly'
+          # AAASM-2455: pin to the just-published prerelease + add [runtime]
+          # extra so the bundled aasm sidecar is installed (this is what
+          # `aasm --version` below expects to find). The job name promised
+          # the extra but the previous install command was missing it.
+          # PEP-440 form: 0.0.1-alpha.N → 0.0.1aN.
+          pep440="${VERSION//-alpha./a}"
+          pip install --no-cache-dir --pre "agent-assembly[runtime]==${pep440}"
 
       - name: Verify the bundled aasm binary prints the release tag
         env:


### PR DESCRIPTION
## Description

The v0.0.1-alpha.4 release pipeline's two pip smoke jobs both failed:

```
smoke-python-pypi-import:  got '0.0.1a2', want '0.0.1-alpha.4'
smoke-python-pypi-runtime: aasm: error: unrecognized arguments: --version
```

Both ran `pip install --no-cache-dir 'agent-assembly'` (no `--pre`, no version pin). pip resolved the latest non-prerelease version, which is PyPI's `agent-assembly==0.0.2` — a long-standing squat with internal `__version__ == "0.0.1a2"` (investigation tracked under [AAASM-2454](https://lightning-dust-mite.atlassian.net/browse/AAASM-2454)). That bogus version was returned for every smoke run regardless of which release tag was being verified.

## Fix

Both jobs now:

* Add `--pre` and `==${pep440-version}` to pin to the exact just-published prerelease.
* Convert the release tag to PEP-440 with bash parameter expansion: `${VERSION//-alpha./a}` → `0.0.1-alpha.N` becomes `0.0.1aN`.

Also fixes a separate bug on `smoke-python-pypi-runtime`: the job name advertised `[runtime]` extra but the install command was bare `agent-assembly`. Restored the extra so the bundled aasm sidecar (which the `aasm --version` verify step depends on) actually installs.

## After this lands

* Re-trigger of `release-python.yml` against `v0.0.1-alpha.4` (after [PR #74](https://github.com/ai-agent-assembly/python-sdk/pull/74) merges) publishes `agent-assembly==0.0.1a4` to PyPI
* These smoke jobs assert against `0.0.1a4` (correctly pinned) instead of the bogus `0.0.2`
* Smoke jobs go green

This fix is independent of [AAASM-2454](https://lightning-dust-mite.atlassian.net/browse/AAASM-2454)'s yank decision — pinning correctly defeats the squat whether or not `0.0.2` stays on PyPI.

## Related

* Jira: [AAASM-2455](https://lightning-dust-mite.atlassian.net/browse/AAASM-2455)
* Companion Group 1 fixes: [agent-assembly#846](https://github.com/ai-agent-assembly/agent-assembly/pull/846) (AAASM-2346), [node-sdk#67](https://github.com/ai-agent-assembly/node-sdk/pull/67) (AAASM-2344), [python-sdk#74](https://github.com/ai-agent-assembly/python-sdk/pull/74) (AAASM-2345)
* PyPI 0.0.2 squat investigation: [AAASM-2454](https://lightning-dust-mite.atlassian.net/browse/AAASM-2454)

— Claude Code


[AAASM-2454]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-2454]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ