### PR TITLE
[AAASM-2359] ✨ (types): Add shared storage wire types in aa-core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,12 +102,15 @@ dependencies = [
 name = "aa-core"
 version = "0.0.1-alpha.4"
 dependencies = [
+ "aa-core",
  "aho-corasick",
  "async-trait",
  "cfg-if",
  "chrono",
  "criterion",
  "dirs",
+ "proptest",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -6172,8 +6175,21 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6251,6 +6267,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -12,6 +12,7 @@ async-trait  = { version = "0.1", optional = true }
 cfg-if       = "1"
 chrono       = { version = "0.4", default-features = false, features = ["clock"], optional = true }
 dirs         = { version = "6", optional = true }
+schemars     = { version = "1", optional = true }
 serde        = { version = "1", default-features = false, features = ["derive", "alloc"], optional = true }
 serde_json   = { version = "1", optional = true }
 serde_yaml   = { version = "0.9", optional = true }
@@ -23,6 +24,7 @@ default    = ["std"]
 std        = ["alloc", "dep:aho-corasick", "dep:async-trait", "dep:thiserror", "dep:chrono", "dep:dirs", "dep:serde_json", "dep:serde_yaml", "serde?/std"]
 alloc      = ["dep:sha2"]
 serde      = ["dep:serde"]
+schemars   = ["dep:schemars"]
 test-utils = []
 
 [dev-dependencies]

--- a/aa-core/Cargo.toml
+++ b/aa-core/Cargo.toml
@@ -29,7 +29,13 @@ test-utils = []
 
 [dev-dependencies]
 criterion  = { version = "0.8", features = ["html_reports"] }
+proptest   = "1"
 serde_json = "1"
+# Self dev-dependency: turns on `serde` + `schemars` for aa-core's own test
+# build so the `types::` property tests and JsonSchema derives compile and run
+# under `cargo nextest run -p aa-core` without making those features default
+# for downstream consumers.
+aa-core    = { path = ".", features = ["serde", "schemars"] }
 
 [[bench]]
 name    = "scanner_bench"

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -22,6 +22,7 @@ use crate::{AgentId, SessionId};
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum AuditEventType {
     /// A tool call was intercepted by the governance layer before execution.
     ToolCallIntercepted = 0,

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -40,6 +40,8 @@ pub mod risk_tier;
 pub mod scanner;
 pub mod time;
 pub mod topology;
+#[cfg(feature = "alloc")]
+pub mod types;
 
 pub use dev_tool::GovernanceLevel;
 pub use identity::{AgentId, SessionId};

--- a/aa-core/src/time.rs
+++ b/aa-core/src/time.rs
@@ -10,6 +10,8 @@
 /// can be used as a convenience.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schemars", schemars(transparent))]
 pub struct Timestamp(u64);
 
 impl Timestamp {

--- a/aa-core/src/types/agent_id.rs
+++ b/aa-core/src/types/agent_id.rs
@@ -103,3 +103,25 @@ impl core::fmt::Display for AgentIdParseError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for AgentIdParseError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_accepts_well_formed_id() {
+        let id = AgentId::parse("acme/billing-bot").unwrap();
+        assert_eq!(id.as_str(), "acme/billing-bot");
+        assert_eq!(id.tenant(), "acme");
+        assert_eq!(id.agent(), "billing-bot");
+    }
+
+    #[test]
+    fn parse_rejects_malformed_input_with_typed_error() {
+        assert_eq!(AgentId::parse(""), Err(AgentIdParseError::Empty));
+        assert_eq!(AgentId::parse("no-slash"), Err(AgentIdParseError::NotExactlyOneSlash));
+        assert_eq!(AgentId::parse("a/b/c"), Err(AgentIdParseError::NotExactlyOneSlash));
+        assert_eq!(AgentId::parse("/agent"), Err(AgentIdParseError::EmptyTenant));
+        assert_eq!(AgentId::parse("tenant/"), Err(AgentIdParseError::EmptyAgent));
+    }
+}

--- a/aa-core/src/types/agent_id.rs
+++ b/aa-core/src/types/agent_id.rs
@@ -125,3 +125,22 @@ mod tests {
         assert_eq!(AgentId::parse("tenant/"), Err(AgentIdParseError::EmptyAgent));
     }
 }
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_round_trip {
+    use super::AgentId;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn agent_id_round_trips(
+            tenant in "[a-z][a-z0-9-]{0,15}",
+            agent in "[a-z][a-z0-9-]{0,15}",
+        ) {
+            let original = AgentId::parse(format!("{tenant}/{agent}")).unwrap();
+            let json = serde_json::to_string(&original).unwrap();
+            let restored: AgentId = serde_json::from_str(&json).unwrap();
+            prop_assert_eq!(original, restored);
+        }
+    }
+}

--- a/aa-core/src/types/agent_id.rs
+++ b/aa-core/src/types/agent_id.rs
@@ -1,0 +1,105 @@
+//! Wire-stable agent identifier in `<tenant>/<agent>` form.
+
+use alloc::string::String;
+
+/// A storage-wire agent identifier: a validated `<tenant>/<agent>` string.
+///
+/// Unlike [`crate::identity::AgentId`] — an opaque 16-byte id used inside the
+/// runtime — this newtype is the *human-routable* identifier that storage
+/// drivers persist and round-trip. It always holds exactly one `/` separating a
+/// non-empty tenant from a non-empty agent name. Construct it through
+/// [`AgentId::parse`], which rejects malformed input with [`AgentIdParseError`].
+///
+/// # Wire format
+///
+/// Serializes transparently as a single JSON string:
+///
+/// ```json
+/// "acme/billing-bot"
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(transparent))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+#[cfg_attr(feature = "schemars", schemars(transparent))]
+pub struct AgentId(String);
+
+impl AgentId {
+    /// Parse and validate a `<tenant>/<agent>` identifier.
+    ///
+    /// Returns [`AgentIdParseError`] when the input is empty, does not contain
+    /// exactly one `/`, or has an empty tenant or agent component.
+    ///
+    /// ```
+    /// use aa_core::types::AgentId;
+    ///
+    /// let id = AgentId::parse("acme/billing-bot").unwrap();
+    /// assert_eq!(id.tenant(), "acme");
+    /// assert_eq!(id.agent(), "billing-bot");
+    /// ```
+    pub fn parse(input: impl Into<String>) -> Result<Self, AgentIdParseError> {
+        let raw = input.into();
+        if raw.is_empty() {
+            return Err(AgentIdParseError::Empty);
+        }
+        let (tenant, agent) = match raw.split_once('/') {
+            Some(pair) => pair,
+            None => return Err(AgentIdParseError::NotExactlyOneSlash),
+        };
+        if agent.contains('/') {
+            return Err(AgentIdParseError::NotExactlyOneSlash);
+        }
+        if tenant.is_empty() {
+            return Err(AgentIdParseError::EmptyTenant);
+        }
+        if agent.is_empty() {
+            return Err(AgentIdParseError::EmptyAgent);
+        }
+        Ok(Self(raw))
+    }
+
+    /// The tenant component (the text before the `/`).
+    pub fn tenant(&self) -> &str {
+        self.0.split_once('/').map_or(self.0.as_str(), |(tenant, _)| tenant)
+    }
+
+    /// The agent component (the text after the `/`).
+    pub fn agent(&self) -> &str {
+        self.0.split_once('/').map_or("", |(_, agent)| agent)
+    }
+
+    /// The full `<tenant>/<agent>` string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Error returned by [`AgentId::parse`] when the input is not a valid
+/// `<tenant>/<agent>` identifier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AgentIdParseError {
+    /// The input was empty.
+    Empty,
+    /// The input did not contain exactly one `/` separator.
+    NotExactlyOneSlash,
+    /// The tenant component (before the `/`) was empty.
+    EmptyTenant,
+    /// The agent component (after the `/`) was empty.
+    EmptyAgent,
+}
+
+impl core::fmt::Display for AgentIdParseError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let message = match self {
+            Self::Empty => "agent id must not be empty",
+            Self::NotExactlyOneSlash => "agent id must contain exactly one '/' separator",
+            Self::EmptyTenant => "agent id tenant component must not be empty",
+            Self::EmptyAgent => "agent id agent component must not be empty",
+        };
+        f.write_str(message)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for AgentIdParseError {}

--- a/aa-core/src/types/audit_event.rs
+++ b/aa-core/src/types/audit_event.rs
@@ -42,3 +42,45 @@ pub struct AuditEvent {
     /// Policy version in force when the event was recorded, if any.
     pub policy_version: Option<u64>,
 }
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_round_trip {
+    use super::AuditEvent;
+    use crate::audit::AuditEventType;
+    use crate::time::Timestamp;
+    use crate::types::AgentId;
+    use proptest::prelude::*;
+
+    fn event_type_strategy() -> impl Strategy<Value = AuditEventType> {
+        prop_oneof![
+            Just(AuditEventType::ToolCallIntercepted),
+            Just(AuditEventType::PolicyViolation),
+            Just(AuditEventType::CredentialLeakBlocked),
+            Just(AuditEventType::ApprovalGranted),
+            Just(AuditEventType::BudgetLimitExceeded),
+        ]
+    }
+
+    proptest! {
+        #[test]
+        fn audit_event_round_trips(
+            tenant in "[a-z][a-z0-9-]{0,7}",
+            agent in "[a-z][a-z0-9-]{0,7}",
+            session_id in "[A-Z0-9]{1,26}",
+            event_type in event_type_strategy(),
+            ts in any::<u64>(),
+            policy_version in proptest::option::of(any::<u64>()),
+        ) {
+            let original = AuditEvent {
+                agent_id: AgentId::parse(format!("{tenant}/{agent}")).unwrap(),
+                session_id,
+                event_type,
+                timestamp: Timestamp::from_nanos(ts),
+                policy_version,
+            };
+            let json = serde_json::to_string(&original).unwrap();
+            let restored: AuditEvent = serde_json::from_str(&json).unwrap();
+            prop_assert_eq!(original, restored);
+        }
+    }
+}

--- a/aa-core/src/types/audit_event.rs
+++ b/aa-core/src/types/audit_event.rs
@@ -1,0 +1,44 @@
+//! Metadata-only governance audit event persisted by audit sinks.
+
+use alloc::string::String;
+
+use crate::audit::AuditEventType;
+use crate::time::Timestamp;
+use crate::types::AgentId;
+
+/// A metadata-only record of a governance event.
+///
+/// An `AuditEvent` describes *that* something happened and *in what context* —
+/// it deliberately **never** carries the raw tool payload or any secret value
+/// (see Epic D / D4). `event_type` reuses the canonical
+/// [`crate::audit::AuditEventType`] so the audit wire shape cannot drift from
+/// the runtime's event taxonomy. `deny_unknown_fields` makes a field renamed on
+/// the writer side fail loudly on the reader side.
+///
+/// # Wire format
+///
+/// ```json
+/// {
+///   "agent_id": "acme/billing-bot",
+///   "session_id": "01HZX9V8…",
+///   "event_type": "PolicyViolation",
+///   "timestamp": 1717400000000000000,
+///   "policy_version": 7
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct AuditEvent {
+    /// Agent that triggered the event.
+    pub agent_id: AgentId,
+    /// Opaque session identifier the event belongs to.
+    pub session_id: String,
+    /// Category of the event, drawn from the canonical event taxonomy.
+    pub event_type: AuditEventType,
+    /// When the event occurred (nanoseconds since the Unix epoch).
+    pub timestamp: Timestamp,
+    /// Policy version in force when the event was recorded, if any.
+    pub policy_version: Option<u64>,
+}

--- a/aa-core/src/types/credential.rs
+++ b/aa-core/src/types/credential.rs
@@ -33,3 +33,23 @@ pub struct Credential {
     /// Reference to the key-encryption-key used to seal `ciphertext`.
     pub kek_ref: String,
 }
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_round_trip {
+    use super::Credential;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn credential_round_trips(
+            placeholder in r"\$\{[A-Z_]{1,20}\}",
+            ciphertext in prop::collection::vec(any::<u8>(), 0..32),
+            kek_ref in "[a-z]{1,6}://[a-z0-9/._-]{1,24}",
+        ) {
+            let original = Credential { placeholder, ciphertext, kek_ref };
+            let json = serde_json::to_string(&original).unwrap();
+            let restored: Credential = serde_json::from_str(&json).unwrap();
+            prop_assert_eq!(original, restored);
+        }
+    }
+}

--- a/aa-core/src/types/credential.rs
+++ b/aa-core/src/types/credential.rs
@@ -1,0 +1,35 @@
+//! Encrypted credential reference — never plaintext on the wire.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+/// An encrypted credential reference.
+///
+/// The plaintext secret is **never** present: a `Credential` carries only the
+/// resolver `placeholder` an agent uses in tool arguments, the opaque
+/// `ciphertext`, and the `kek_ref` identifying the key-encryption-key needed to
+/// decrypt it out-of-band. Encryption-at-rest itself is a separate workstream.
+///
+/// # Wire format
+///
+/// `ciphertext` serializes as a JSON array of byte values:
+///
+/// ```json
+/// {
+///   "placeholder": "${OPENAI_API_KEY}",
+///   "ciphertext": [186, 220, 17, 42],
+///   "kek_ref": "kms://prod/keys/api-secrets"
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct Credential {
+    /// Placeholder token the agent uses in tool args, e.g. `"${OPENAI_API_KEY}"`.
+    pub placeholder: String,
+    /// Opaque ciphertext of the secret. Never plaintext.
+    pub ciphertext: Vec<u8>,
+    /// Reference to the key-encryption-key used to seal `ciphertext`.
+    pub kek_ref: String,
+}

--- a/aa-core/src/types/mod.rs
+++ b/aa-core/src/types/mod.rs
@@ -13,10 +13,12 @@
 
 mod agent_id;
 mod audit_event;
+mod credential;
 mod policy;
 mod session_ctx;
 
 pub use agent_id::{AgentId, AgentIdParseError};
 pub use audit_event::AuditEvent;
+pub use credential::Credential;
 pub use policy::{Policy, Rule};
 pub use session_ctx::SessionCtx;

--- a/aa-core/src/types/mod.rs
+++ b/aa-core/src/types/mod.rs
@@ -12,7 +12,9 @@
 //! identifier, distinct from the opaque 16-byte [`crate::identity::AgentId`].
 
 mod agent_id;
+mod audit_event;
 mod policy;
 
 pub use agent_id::{AgentId, AgentIdParseError};
+pub use audit_event::AuditEvent;
 pub use policy::{Policy, Rule};

--- a/aa-core/src/types/mod.rs
+++ b/aa-core/src/types/mod.rs
@@ -14,7 +14,9 @@
 mod agent_id;
 mod audit_event;
 mod policy;
+mod session_ctx;
 
 pub use agent_id::{AgentId, AgentIdParseError};
 pub use audit_event::AuditEvent;
 pub use policy::{Policy, Rule};
+pub use session_ctx::SessionCtx;

--- a/aa-core/src/types/mod.rs
+++ b/aa-core/src/types/mod.rs
@@ -1,0 +1,16 @@
+//! Stable, wire-shaped types shared by every storage driver (AAASM-2355).
+//!
+//! These are the input/output types of the `aa-storage` traits. They live in
+//! `aa-core` so that the OSS Postgres driver and the Enterprise gRPC driver
+//! round-trip the *same* wire shape and never drift apart. Every type derives
+//! `serde` (under the `serde` feature) and `schemars::JsonSchema` (under the
+//! `schemars` feature) so the JSON contract is both serializable and
+//! schema-describable.
+//!
+//! The module is namespaced (`aa_core::types::*`) rather than re-exported at the
+//! crate root because [`AgentId`] here is the human-routable `<tenant>/<agent>`
+//! identifier, distinct from the opaque 16-byte [`crate::identity::AgentId`].
+
+mod agent_id;
+
+pub use agent_id::{AgentId, AgentIdParseError};

--- a/aa-core/src/types/mod.rs
+++ b/aa-core/src/types/mod.rs
@@ -12,5 +12,7 @@
 //! identifier, distinct from the opaque 16-byte [`crate::identity::AgentId`].
 
 mod agent_id;
+mod policy;
 
 pub use agent_id::{AgentId, AgentIdParseError};
+pub use policy::{Policy, Rule};

--- a/aa-core/src/types/policy.rs
+++ b/aa-core/src/types/policy.rs
@@ -1,0 +1,50 @@
+//! Versioned governance policy as persisted by storage drivers.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+/// A single allow/deny statement inside a [`Policy`].
+///
+/// # Wire format
+///
+/// ```json
+/// { "capability": "net.http", "resource": "api.example.com/*" }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct Rule {
+    /// Capability this statement governs, e.g. `"net.http"`.
+    pub capability: String,
+    /// Resource pattern the capability applies to, e.g. `"api.example.com/*"`.
+    pub resource: String,
+}
+
+/// A versioned governance policy.
+///
+/// `policy_version` is mandatory and monotonic: the L1 cache compares it to
+/// detect drift between a cached policy and the authoritative store. `deny`
+/// statements are evaluated after `allow`.
+///
+/// # Wire format
+///
+/// ```json
+/// {
+///   "policy_version": 7,
+///   "allow": [{ "capability": "net.http", "resource": "api.example.com/*" }],
+///   "deny": [{ "capability": "fs.write", "resource": "/etc/*" }]
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct Policy {
+    /// Monotonic version used by the L1 cache to detect drift.
+    pub policy_version: u64,
+    /// Statements that grant capabilities.
+    pub allow: Vec<Rule>,
+    /// Statements that revoke capabilities (evaluated after `allow`).
+    pub deny: Vec<Rule>,
+}

--- a/aa-core/src/types/policy.rs
+++ b/aa-core/src/types/policy.rs
@@ -48,3 +48,27 @@ pub struct Policy {
     /// Statements that revoke capabilities (evaluated after `allow`).
     pub deny: Vec<Rule>,
 }
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_round_trip {
+    use super::{Policy, Rule};
+    use proptest::prelude::*;
+
+    fn rule_strategy() -> impl Strategy<Value = Rule> {
+        ("[a-z.]{1,12}", "[a-z0-9.*/_-]{1,20}").prop_map(|(capability, resource)| Rule { capability, resource })
+    }
+
+    proptest! {
+        #[test]
+        fn policy_round_trips(
+            policy_version in any::<u64>(),
+            allow in prop::collection::vec(rule_strategy(), 0..4),
+            deny in prop::collection::vec(rule_strategy(), 0..4),
+        ) {
+            let original = Policy { policy_version, allow, deny };
+            let json = serde_json::to_string(&original).unwrap();
+            let restored: Policy = serde_json::from_str(&json).unwrap();
+            prop_assert_eq!(original, restored);
+        }
+    }
+}

--- a/aa-core/src/types/session_ctx.rs
+++ b/aa-core/src/types/session_ctx.rs
@@ -33,3 +33,30 @@ pub struct SessionCtx {
     /// invalid once the wall clock passes this instant.
     pub expires_at: Timestamp,
 }
+
+#[cfg(all(test, feature = "serde"))]
+mod serde_round_trip {
+    use super::SessionCtx;
+    use crate::time::Timestamp;
+    use crate::types::AgentId;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn session_ctx_round_trips(
+            tenant in "[a-z][a-z0-9-]{0,7}",
+            agent in "[a-z][a-z0-9-]{0,7}",
+            session_id in "[A-Z0-9]{1,26}",
+            expires_at in any::<u64>(),
+        ) {
+            let original = SessionCtx {
+                agent_id: AgentId::parse(format!("{tenant}/{agent}")).unwrap(),
+                session_id,
+                expires_at: Timestamp::from_nanos(expires_at),
+            };
+            let json = serde_json::to_string(&original).unwrap();
+            let restored: SessionCtx = serde_json::from_str(&json).unwrap();
+            prop_assert_eq!(original, restored);
+        }
+    }
+}

--- a/aa-core/src/types/session_ctx.rs
+++ b/aa-core/src/types/session_ctx.rs
@@ -1,0 +1,35 @@
+//! Ephemeral, TTL-bound context for one agent execution session.
+
+use alloc::string::String;
+
+use crate::time::Timestamp;
+use crate::types::AgentId;
+
+/// Context for a single agent execution session.
+///
+/// Stored by the `SessionStore` with a TTL; `expires_at` is the absolute
+/// instant past which the session is invalid, letting drivers expire entries
+/// without a separate clock round-trip.
+///
+/// # Wire format
+///
+/// ```json
+/// {
+///   "agent_id": "acme/billing-bot",
+///   "session_id": "01HZX9V8…",
+///   "expires_at": 1717400600000000000
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(deny_unknown_fields))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
+pub struct SessionCtx {
+    /// Agent that owns the session.
+    pub agent_id: AgentId,
+    /// Opaque session identifier.
+    pub session_id: String,
+    /// Absolute expiry (nanoseconds since the Unix epoch); the session is
+    /// invalid once the wall clock passes this instant.
+    pub expires_at: Timestamp,
+}


### PR DESCRIPTION
## Description

Adds the five stable, wire-shaped types that every `aa-storage` driver round-trips, so the OSS Postgres driver and the Enterprise gRPC driver share one contract and never drift. They live under `aa_core::types::*`:

| Type | Shape |
| --- | --- |
| `AgentId` | `<tenant>/<agent>` string newtype; `parse()` validates and returns the typed `AgentIdParseError` |
| `Policy` (+ `Rule`) | `{ policy_version: u64, allow: Vec<Rule>, deny: Vec<Rule> }` — version is mandatory for L1-cache drift detection |
| `AuditEvent` | metadata-only; reuses canonical `AuditEventType` + `Timestamp`; `deny_unknown_fields` |
| `SessionCtx` | `{ agent_id, session_id, expires_at }` with TTL-bound expiry |
| `Credential` | `{ placeholder, ciphertext, kek_ref }` — opaque ciphertext, never plaintext |

Each type derives `Serialize`/`Deserialize` (under `serde`) and `JsonSchema` (under `schemars`), documents its JSON wire shape in rustdoc, and has a `proptest` serde round-trip.

### Design notes

- **Namespacing:** `aa_core::identity::AgentId` already exists as an opaque 16-byte id. The new human-routable `<tenant>/<agent>` `AgentId` lives under `aa_core::types` to avoid a crate-root name collision — callers import it from `aa_core::types`.
- **Anti-drift reuse:** `AuditEvent` reuses the canonical `aa_core::audit::AuditEventType` and `aa_core::time::Timestamp` (each gains a feature-gated `JsonSchema` derive) rather than re-declaring an enum that could diverge.
- **`no_std`-friendly features:** `serde`/`schemars` derives are feature-gated; the `types` module is `alloc`-gated. A self dev-dependency (`aa-core = { path = ".", features = ["serde", "schemars"] }`) enables them for aa-core's own test build so `cargo nextest run -p aa-core types::` exercises the property tests, without forcing `schemars` onto downstream consumers' default builds.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2359 (parent Story AAASM-2355, Epic AAASM-2347)

## Testing

- [x] Unit tests added / updated
- `cargo nextest run -p aa-core types::` → 7 passed (parse accept/reject + 5 serde round-trip property tests)
- `cargo nextest run -p aa-core` → 261 passed (no regression in existing audit/time tests after the added `JsonSchema` derives)
- `cargo clippy -p aa-core --all-targets --all-features -- -D warnings` → clean
- Feature-combo builds verified: default (std), `--no-default-features --features alloc`, and pure `--no-default-features`
- `cargo doc -p aa-core --no-deps` renders the JSON examples; `cargo deny check licenses` ok

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
