### PR TITLE
[AAASM-2357] ✨ (aa-storage): Add pure-interface storage trait crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,7 @@ dependencies = [
  "aa-core",
  "async-trait",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aa-storage"
+version = "0.0.1-alpha.4"
+dependencies = [
+ "aa-core",
+ "async-trait",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "aa-wasm"
 version = "0.0.1-alpha.4"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "aa-core",
+    "aa-storage",
     "aa-proto",
     "aa-runtime",
     "aa-ebpf",

--- a/aa-storage/Cargo.toml
+++ b/aa-storage/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "aa-storage"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Storage trait abstraction (pure interface) for the Agent Assembly persistence layer"
+
+[dependencies]
+aa-core      = { path = "../aa-core" }
+async-trait  = "0.1"
+thiserror    = "2"
+
+[lints]
+workspace = true

--- a/aa-storage/Cargo.toml
+++ b/aa-storage/Cargo.toml
@@ -11,5 +11,8 @@ aa-core      = { path = "../aa-core" }
 async-trait  = "0.1"
 thiserror    = "2"
 
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }
+
 [lints]
 workspace = true

--- a/aa-storage/src/audit_sink.rs
+++ b/aa-storage/src/audit_sink.rs
@@ -1,0 +1,37 @@
+//! [`AuditSink`] — append-only emission of audit entries.
+
+use crate::{AuditEntry, Result};
+use async_trait::async_trait;
+
+/// Append-only sink for governance [`AuditEntry`] records.
+///
+/// Every governance decision produces one entry. The sink is write-only from the
+/// runtime's perspective: it persists entries in order so the hash-chained audit
+/// log stays verifiable. Backends may batch or buffer internally, but
+/// [`emit`](AuditSink::emit) must not reorder entries relative to the calls.
+///
+/// # Example
+///
+/// ```
+/// use aa_storage::{AuditEntry, AuditSink, Result};
+/// use async_trait::async_trait;
+///
+/// /// A sink that discards every entry (useful as a test double).
+/// struct NullAuditSink;
+///
+/// #[async_trait]
+/// impl AuditSink for NullAuditSink {
+///     async fn emit(&self, _event: AuditEntry) -> Result<()> {
+///         Ok(())
+///     }
+/// }
+/// ```
+#[async_trait]
+pub trait AuditSink: Send + Sync {
+    /// Persist a single audit entry.
+    ///
+    /// Takes ownership of `event` because the sink is the entry's final
+    /// destination. Returns [`StorageError::Backend`](crate::StorageError::Backend)
+    /// when the entry could not be durably recorded.
+    async fn emit(&self, event: AuditEntry) -> Result<()>;
+}

--- a/aa-storage/src/conformance.rs
+++ b/aa-storage/src/conformance.rs
@@ -1,0 +1,45 @@
+//! Reusable trait-conformance harness for driver crates.
+//!
+//! Downstream backend crates (Epic B: Postgres, Redis, memory; Epic E: the
+//! Enterprise gateway driver) import this module to prove their implementation
+//! honors the trait contract, exercising it through a `&dyn` reference so
+//! object-safety is checked at the same time.
+//!
+//! The harness functions panic on the first violated invariant, so they are
+//! meant to be called from within a `#[test]` (driven by the caller's own async
+//! runtime).
+
+use crate::{AgentId, PolicyStore, StorageError};
+
+/// Assert that a [`PolicyStore`] implementation honors the trait contract.
+///
+/// Drives `store` through `&dyn PolicyStore` and checks:
+///
+/// - `get_policy(present)` resolves to a policy
+/// - `get_policy(absent)` returns [`StorageError::NotFound`]
+/// - `invalidate(present)` succeeds
+/// - `invalidate(absent)` succeeds (invalidation is idempotent)
+///
+/// `present` must be an agent the store has a policy for; `absent` must be one it
+/// does not. Panics with a descriptive message on the first violated invariant.
+pub async fn assert_policy_store_conformance(store: &dyn PolicyStore, present: &AgentId, absent: &AgentId) {
+    store
+        .get_policy(present)
+        .await
+        .expect("get_policy(present) should resolve to a policy");
+
+    match store.get_policy(absent).await {
+        Err(StorageError::NotFound(_)) => {}
+        other => panic!("get_policy(absent) should return NotFound, got {other:?}"),
+    }
+
+    store
+        .invalidate(present)
+        .await
+        .expect("invalidate(present) should succeed");
+
+    store
+        .invalidate(absent)
+        .await
+        .expect("invalidate(absent) should be idempotent");
+}

--- a/aa-storage/src/credential_store.rs
+++ b/aa-storage/src/credential_store.rs
@@ -1,0 +1,53 @@
+//! [`CredentialStore`] — storage for named secret material.
+
+use crate::Result;
+use async_trait::async_trait;
+use std::vec::Vec;
+
+/// Stores and retrieves named secret material as opaque bytes.
+///
+/// Keys are caller-defined names (for example `"openai/api_key"`); values are
+/// opaque byte strings so the contract stays agnostic to the secret's encoding.
+/// Backends are expected to encrypt at rest; this trait only defines the access
+/// contract, not the protection mechanism.
+///
+/// # Example
+///
+/// ```
+/// use aa_storage::{CredentialStore, Result, StorageError};
+/// use async_trait::async_trait;
+///
+/// /// A store that holds no secrets.
+/// struct EmptyCredentialStore;
+///
+/// #[async_trait]
+/// impl CredentialStore for EmptyCredentialStore {
+///     async fn get_secret(&self, key: &str) -> Result<Vec<u8>> {
+///         Err(StorageError::NotFound(key.to_owned()))
+///     }
+///
+///     async fn put_secret(&self, _key: &str, _value: Vec<u8>) -> Result<()> {
+///         Ok(())
+///     }
+///
+///     async fn delete_secret(&self, _key: &str) -> Result<()> {
+///         Ok(())
+///     }
+/// }
+/// ```
+#[async_trait]
+pub trait CredentialStore: Send + Sync {
+    /// Return the secret bytes stored under `key`.
+    ///
+    /// Returns [`StorageError::NotFound`](crate::StorageError::NotFound) when no
+    /// secret exists for the key.
+    async fn get_secret(&self, key: &str) -> Result<Vec<u8>>;
+
+    /// Store `value` under `key`, overwriting any existing secret.
+    async fn put_secret(&self, key: &str, value: Vec<u8>) -> Result<()>;
+
+    /// Delete the secret stored under `key`.
+    ///
+    /// Idempotent: deleting an absent key succeeds.
+    async fn delete_secret(&self, key: &str) -> Result<()>;
+}

--- a/aa-storage/src/error.rs
+++ b/aa-storage/src/error.rs
@@ -1,0 +1,33 @@
+//! Error type shared by every storage trait.
+
+use std::string::String;
+
+/// Failure modes common to all storage backends.
+///
+/// Backends map their native errors (a `sqlx::Error`, a `redis::RedisError`, a
+/// `tonic::Status`, …) onto these variants so callers never depend on a concrete
+/// backend's error type. The string payloads carry backend-specific detail for
+/// logging without leaking the backend's types into this crate's public API.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum StorageError {
+    /// The requested entity does not exist in the backend.
+    #[error("storage entity not found: {0}")]
+    NotFound(String),
+
+    /// The backend is unreachable or returned a transport/connection failure.
+    #[error("storage backend unavailable: {0}")]
+    Backend(String),
+
+    /// Stored bytes could not be encoded to or decoded from the domain type.
+    #[error("storage serialization error: {0}")]
+    Serialization(String),
+
+    /// The write conflicts with existing state (optimistic-concurrency or
+    /// uniqueness violation).
+    #[error("storage conflict: {0}")]
+    Conflict(String),
+}
+
+/// Convenience alias for results returned by storage trait methods.
+pub type Result<T> = core::result::Result<T, StorageError>;

--- a/aa-storage/src/lib.rs
+++ b/aa-storage/src/lib.rs
@@ -12,9 +12,11 @@
 
 #![warn(missing_docs)]
 
+mod audit_sink;
 mod error;
 mod policy_store;
 
+pub use audit_sink::AuditSink;
 pub use error::{Result, StorageError};
 pub use policy_store::PolicyStore;
 

--- a/aa-storage/src/lib.rs
+++ b/aa-storage/src/lib.rs
@@ -15,10 +15,12 @@
 mod audit_sink;
 mod error;
 mod policy_store;
+mod session_store;
 
 pub use audit_sink::AuditSink;
 pub use error::{Result, StorageError};
 pub use policy_store::PolicyStore;
+pub use session_store::SessionRecord;
 
 // Re-export the shared `aa-core` domain types the traits reference so call sites
 // import the storage contract and its types from a single path (`aa_storage::*`).

--- a/aa-storage/src/lib.rs
+++ b/aa-storage/src/lib.rs
@@ -13,11 +13,13 @@
 #![warn(missing_docs)]
 
 mod audit_sink;
+mod credential_store;
 mod error;
 mod policy_store;
 mod session_store;
 
 pub use audit_sink::AuditSink;
+pub use credential_store::CredentialStore;
 pub use error::{Result, StorageError};
 pub use policy_store::PolicyStore;
 pub use session_store::{SessionRecord, SessionStore};

--- a/aa-storage/src/lib.rs
+++ b/aa-storage/src/lib.rs
@@ -11,3 +11,7 @@
 //! changes any caller code.
 
 #![warn(missing_docs)]
+
+mod error;
+
+pub use error::{Result, StorageError};

--- a/aa-storage/src/lib.rs
+++ b/aa-storage/src/lib.rs
@@ -9,6 +9,28 @@
 //! The OSS Postgres/Redis/memory drivers and the Enterprise gateway driver all
 //! implement the same contract, so swapping the persistence backend never
 //! changes any caller code.
+//!
+//! # Traits
+//!
+//! - [`PolicyStore`] — fetch and invalidate an agent's effective policy
+//! - [`AuditSink`] — append-only emission of audit entries
+//! - [`SessionStore`] — persist, load, and delete per-execution session records
+//! - [`CredentialStore`] — store and retrieve named secret material
+//! - [`RateLimitCounter`] — read-modify-write counters for rate limiting
+//! - [`LifecycleStore`] — agent register / heartbeat / deregister bookkeeping
+//!
+//! Every method returns [`Result`], whose error is the backend-agnostic
+//! [`StorageError`].
+//!
+//! # Single import path
+//!
+//! Callers import the traits and the shared domain types they reference from one
+//! place — this crate re-exports [`AgentId`], [`SessionId`], [`PolicyDocument`],
+//! and [`AuditEntry`] from `aa-core`:
+//!
+//! ```
+//! use aa_storage::{AgentId, AuditSink, PolicyDocument, PolicyStore};
+//! ```
 
 #![warn(missing_docs)]
 

--- a/aa-storage/src/lib.rs
+++ b/aa-storage/src/lib.rs
@@ -1,0 +1,13 @@
+//! Storage trait abstraction for the Agent Assembly persistence layer.
+//!
+//! This crate is a **pure interface**: it defines the narrow storage traits that
+//! every persistence backend implements, and it carries no concrete backend
+//! dependency (no `sqlx`, no `redis`, no `tonic`). Its only dependencies are
+//! `async-trait`, `thiserror`, and the shared domain types re-exported from
+//! `aa-core`.
+//!
+//! The OSS Postgres/Redis/memory drivers and the Enterprise gateway driver all
+//! implement the same contract, so swapping the persistence backend never
+//! changes any caller code.
+
+#![warn(missing_docs)]

--- a/aa-storage/src/lib.rs
+++ b/aa-storage/src/lib.rs
@@ -13,8 +13,10 @@
 #![warn(missing_docs)]
 
 mod error;
+mod policy_store;
 
 pub use error::{Result, StorageError};
+pub use policy_store::PolicyStore;
 
 // Re-export the shared `aa-core` domain types the traits reference so call sites
 // import the storage contract and its types from a single path (`aa_storage::*`).

--- a/aa-storage/src/lib.rs
+++ b/aa-storage/src/lib.rs
@@ -16,12 +16,14 @@ mod audit_sink;
 mod credential_store;
 mod error;
 mod policy_store;
+mod rate_limit_counter;
 mod session_store;
 
 pub use audit_sink::AuditSink;
 pub use credential_store::CredentialStore;
 pub use error::{Result, StorageError};
 pub use policy_store::PolicyStore;
+pub use rate_limit_counter::RateLimitCounter;
 pub use session_store::{SessionRecord, SessionStore};
 
 // Re-export the shared `aa-core` domain types the traits reference so call sites

--- a/aa-storage/src/lib.rs
+++ b/aa-storage/src/lib.rs
@@ -15,6 +15,7 @@
 mod audit_sink;
 mod credential_store;
 mod error;
+mod lifecycle_store;
 mod policy_store;
 mod rate_limit_counter;
 mod session_store;
@@ -22,6 +23,7 @@ mod session_store;
 pub use audit_sink::AuditSink;
 pub use credential_store::CredentialStore;
 pub use error::{Result, StorageError};
+pub use lifecycle_store::LifecycleStore;
 pub use policy_store::PolicyStore;
 pub use rate_limit_counter::RateLimitCounter;
 pub use session_store::{SessionRecord, SessionStore};

--- a/aa-storage/src/lib.rs
+++ b/aa-storage/src/lib.rs
@@ -20,7 +20,7 @@ mod session_store;
 pub use audit_sink::AuditSink;
 pub use error::{Result, StorageError};
 pub use policy_store::PolicyStore;
-pub use session_store::SessionRecord;
+pub use session_store::{SessionRecord, SessionStore};
 
 // Re-export the shared `aa-core` domain types the traits reference so call sites
 // import the storage contract and its types from a single path (`aa_storage::*`).

--- a/aa-storage/src/lib.rs
+++ b/aa-storage/src/lib.rs
@@ -15,3 +15,7 @@
 mod error;
 
 pub use error::{Result, StorageError};
+
+// Re-export the shared `aa-core` domain types the traits reference so call sites
+// import the storage contract and its types from a single path (`aa_storage::*`).
+pub use aa_core::{AgentId, AuditEntry, PolicyDocument, SessionId};

--- a/aa-storage/src/lib.rs
+++ b/aa-storage/src/lib.rs
@@ -35,6 +35,7 @@
 #![warn(missing_docs)]
 
 mod audit_sink;
+pub mod conformance;
 mod credential_store;
 mod error;
 mod lifecycle_store;

--- a/aa-storage/src/lifecycle_store.rs
+++ b/aa-storage/src/lifecycle_store.rs
@@ -1,0 +1,54 @@
+//! [`LifecycleStore`] — agent register / heartbeat / deregister bookkeeping.
+
+use crate::{AgentId, Result};
+use async_trait::async_trait;
+
+/// Tracks agent liveness through register, heartbeat, and deregister.
+///
+/// The runtime [`register`](LifecycleStore::register)s an agent when it comes
+/// online, sends periodic [`heartbeat`](LifecycleStore::heartbeat)s while it runs,
+/// and [`deregister`](LifecycleStore::deregister)s it on clean shutdown. Backends
+/// use the heartbeat timestamp to expire agents that stopped reporting.
+///
+/// # Example
+///
+/// ```
+/// use aa_storage::{AgentId, LifecycleStore, Result};
+/// use async_trait::async_trait;
+///
+/// /// A store that accepts all lifecycle transitions and persists nothing.
+/// struct NullLifecycleStore;
+///
+/// #[async_trait]
+/// impl LifecycleStore for NullLifecycleStore {
+///     async fn register(&self, _agent_id: &AgentId) -> Result<()> {
+///         Ok(())
+///     }
+///
+///     async fn heartbeat(&self, _agent_id: &AgentId) -> Result<()> {
+///         Ok(())
+///     }
+///
+///     async fn deregister(&self, _agent_id: &AgentId) -> Result<()> {
+///         Ok(())
+///     }
+/// }
+/// ```
+#[async_trait]
+pub trait LifecycleStore: Send + Sync {
+    /// Record that `agent_id` is now online.
+    ///
+    /// Overwrites any stale registration for the same agent.
+    async fn register(&self, agent_id: &AgentId) -> Result<()>;
+
+    /// Refresh the liveness timestamp for `agent_id`.
+    ///
+    /// Returns [`StorageError::NotFound`](crate::StorageError::NotFound) when the
+    /// agent is not currently registered.
+    async fn heartbeat(&self, agent_id: &AgentId) -> Result<()>;
+
+    /// Record that `agent_id` has gone offline.
+    ///
+    /// Idempotent: deregistering an agent that is not registered succeeds.
+    async fn deregister(&self, agent_id: &AgentId) -> Result<()>;
+}

--- a/aa-storage/src/policy_store.rs
+++ b/aa-storage/src/policy_store.rs
@@ -1,0 +1,46 @@
+//! [`PolicyStore`] — read-side access to an agent's effective policy.
+
+use crate::{AgentId, PolicyDocument, Result};
+use async_trait::async_trait;
+
+/// Fetches and invalidates the effective [`PolicyDocument`] for an agent.
+///
+/// The runtime calls [`get_policy`](PolicyStore::get_policy) on the hot path
+/// before evaluating an action, so backends are expected to serve from a fast
+/// store (or a cache wrapper layered on top — see Epic C). When a policy changes,
+/// [`invalidate`](PolicyStore::invalidate) drops any cached copy so the next read
+/// reloads from the source of truth.
+///
+/// # Example
+///
+/// ```
+/// use aa_storage::{AgentId, PolicyDocument, PolicyStore, Result, StorageError};
+/// use async_trait::async_trait;
+///
+/// /// A backend that has no policy for any agent.
+/// struct EmptyPolicyStore;
+///
+/// #[async_trait]
+/// impl PolicyStore for EmptyPolicyStore {
+///     async fn get_policy(&self, agent_id: &AgentId) -> Result<PolicyDocument> {
+///         Err(StorageError::NotFound(format!("{:?}", agent_id.as_bytes())))
+///     }
+///
+///     async fn invalidate(&self, _agent_id: &AgentId) -> Result<()> {
+///         Ok(())
+///     }
+/// }
+/// ```
+#[async_trait]
+pub trait PolicyStore: Send + Sync {
+    /// Return the effective policy for `agent_id`.
+    ///
+    /// Returns [`StorageError::NotFound`](crate::StorageError::NotFound) when the
+    /// agent has no policy on record.
+    async fn get_policy(&self, agent_id: &AgentId) -> Result<PolicyDocument>;
+
+    /// Drop any cached policy for `agent_id` so the next read reloads it.
+    ///
+    /// Idempotent: invalidating an agent with no cached entry succeeds.
+    async fn invalidate(&self, agent_id: &AgentId) -> Result<()>;
+}

--- a/aa-storage/src/rate_limit_counter.rs
+++ b/aa-storage/src/rate_limit_counter.rs
@@ -1,0 +1,56 @@
+//! [`RateLimitCounter`] — read-modify-write counters for rate limiting.
+
+use crate::Result;
+use async_trait::async_trait;
+
+/// Atomic counters keyed by an arbitrary string, used for rate limiting.
+///
+/// The defining operation is [`increment`](RateLimitCounter::increment): it must
+/// apply the read-modify-write **atomically** so two concurrent callers can never
+/// observe or commit the same pre-increment value. Counters are scoped to a
+/// fixed-length window; `window_secs` lets the backend bucket and expire counts
+/// without the caller tracking wall-clock time.
+///
+/// # Example
+///
+/// ```
+/// use aa_storage::{RateLimitCounter, Result};
+/// use async_trait::async_trait;
+///
+/// /// A counter that always reports a single hit (a stand-in for a real backend).
+/// struct AlwaysOne;
+///
+/// #[async_trait]
+/// impl RateLimitCounter for AlwaysOne {
+///     async fn increment(&self, _key: &str, _amount: u64, _window_secs: u64) -> Result<u64> {
+///         Ok(1)
+///     }
+///
+///     async fn current(&self, _key: &str) -> Result<u64> {
+///         Ok(1)
+///     }
+///
+///     async fn reset(&self, _key: &str) -> Result<()> {
+///         Ok(())
+///     }
+/// }
+/// ```
+#[async_trait]
+pub trait RateLimitCounter: Send + Sync {
+    /// Atomically add `amount` to the counter for `key` within the window of
+    /// length `window_secs`, returning the new total for the current window.
+    ///
+    /// The read-modify-write is atomic with respect to concurrent callers.
+    async fn increment(&self, key: &str, amount: u64, window_secs: u64) -> Result<u64>;
+
+    /// Return the current total for `key` without modifying it.
+    ///
+    /// Returns `0` for a key that has never been incremented (or whose window
+    /// has expired).
+    async fn current(&self, key: &str) -> Result<u64>;
+
+    /// Reset the counter for `key` back to zero.
+    ///
+    /// Idempotent: resetting an absent key succeeds.
+    async fn reset(&self, key: &str) -> Result<()>;
+}

--- a/aa-storage/src/session_store.rs
+++ b/aa-storage/src/session_store.rs
@@ -1,6 +1,7 @@
 //! [`SessionStore`] — persistence for per-execution session records.
 
-use crate::{AgentId, SessionId};
+use crate::{AgentId, Result, SessionId};
+use async_trait::async_trait;
 
 /// A persisted record of a single agent execution session.
 ///
@@ -15,4 +16,51 @@ pub struct SessionRecord {
     pub agent_id: AgentId,
     /// Wall-clock start time of the session, in nanoseconds since the Unix epoch.
     pub started_at_ns: u64,
+}
+
+/// Persists, loads, and deletes [`SessionRecord`]s.
+///
+/// The runtime saves a record when a session starts, loads it to resume
+/// governance context, and deletes it when the session ends.
+///
+/// # Example
+///
+/// ```
+/// use aa_storage::{Result, SessionRecord, SessionStore, StorageError};
+/// use aa_storage::SessionId;
+/// use async_trait::async_trait;
+///
+/// /// A store that holds no sessions.
+/// struct EmptySessionStore;
+///
+/// #[async_trait]
+/// impl SessionStore for EmptySessionStore {
+///     async fn save(&self, _session: SessionRecord) -> Result<()> {
+///         Ok(())
+///     }
+///
+///     async fn load(&self, session_id: &SessionId) -> Result<SessionRecord> {
+///         Err(StorageError::NotFound(format!("{:?}", session_id.as_bytes())))
+///     }
+///
+///     async fn delete(&self, _session_id: &SessionId) -> Result<()> {
+///         Ok(())
+///     }
+/// }
+/// ```
+#[async_trait]
+pub trait SessionStore: Send + Sync {
+    /// Persist `session`, overwriting any record with the same session id.
+    async fn save(&self, session: SessionRecord) -> Result<()>;
+
+    /// Load the record for `session_id`.
+    ///
+    /// Returns [`StorageError::NotFound`](crate::StorageError::NotFound) when no
+    /// record exists for the id.
+    async fn load(&self, session_id: &SessionId) -> Result<SessionRecord>;
+
+    /// Delete the record for `session_id`.
+    ///
+    /// Idempotent: deleting an absent session succeeds.
+    async fn delete(&self, session_id: &SessionId) -> Result<()>;
 }

--- a/aa-storage/src/session_store.rs
+++ b/aa-storage/src/session_store.rs
@@ -1,0 +1,18 @@
+//! [`SessionStore`] — persistence for per-execution session records.
+
+use crate::{AgentId, SessionId};
+
+/// A persisted record of a single agent execution session.
+///
+/// One record is created per execution run and ties together all governance
+/// events within that run. Backends key the record by its
+/// [`session_id`](SessionRecord::session_id).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionRecord {
+    /// Stable identifier for this execution run.
+    pub session_id: SessionId,
+    /// The agent that owns this session.
+    pub agent_id: AgentId,
+    /// Wall-clock start time of the session, in nanoseconds since the Unix epoch.
+    pub started_at_ns: u64,
+}

--- a/aa-storage/tests/conformance.rs
+++ b/aa-storage/tests/conformance.rs
@@ -1,0 +1,50 @@
+//! Integration test proving the conformance harness runs against a real
+//! `PolicyStore` implementation, driven through a `dyn` reference.
+
+use std::collections::HashMap;
+
+use aa_core::EnforcementMode;
+use aa_storage::conformance::assert_policy_store_conformance;
+use aa_storage::{AgentId, PolicyDocument, PolicyStore, Result, StorageError};
+use async_trait::async_trait;
+
+/// Minimal in-memory `PolicyStore` used only to exercise the conformance harness.
+struct MemoryPolicyStore {
+    policies: HashMap<[u8; 16], PolicyDocument>,
+}
+
+#[async_trait]
+impl PolicyStore for MemoryPolicyStore {
+    async fn get_policy(&self, agent_id: &AgentId) -> Result<PolicyDocument> {
+        self.policies
+            .get(agent_id.as_bytes())
+            .cloned()
+            .ok_or_else(|| StorageError::NotFound(format!("{:?}", agent_id.as_bytes())))
+    }
+
+    async fn invalidate(&self, _agent_id: &AgentId) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn memory_policy_store_satisfies_conformance() {
+    let present = AgentId::from_bytes([1; 16]);
+    let absent = AgentId::from_bytes([2; 16]);
+
+    let mut policies = HashMap::new();
+    policies.insert(
+        *present.as_bytes(),
+        PolicyDocument {
+            version: 1,
+            name: "test".to_owned(),
+            rules: Vec::new(),
+            enforcement_mode: EnforcementMode::default(),
+        },
+    );
+
+    let store = MemoryPolicyStore { policies };
+
+    // Coerces to `&dyn PolicyStore` at the call site, exercising object-safety.
+    assert_policy_store_conformance(&store, &present, &absent).await;
+}

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -9,6 +9,11 @@ This document tracks which versions of `aa-runtime` are compatible with each SDK
      claimed by the agent-assembly workspace. No version change introduced
      by that PR; this comment satisfies the compatibility-matrix CI gate. -->
 
+<!-- AAASM-2357: added the `aa-storage` crate to root Cargo.toml workspace
+     members (pure-interface storage trait crate). It inherits the workspace
+     version and introduces no version change to aa-runtime or any SDK; this
+     comment satisfies the compatibility-matrix CI gate. -->
+
 
 ---
 


### PR DESCRIPTION
## Description

Adds the **`aa-storage`** crate — the pure-interface storage contract that every persistence backend (OSS Postgres/Redis/memory, Enterprise gateway driver) implements, so swapping the backend never changes caller code. This is the load-bearing trait surface for the whole persistence roadmap (Epic AAASM-2347).

The crate depends only on `async-trait`, `thiserror`, and the shared domain types re-exported from `aa-core` — no `sqlx`, `redis`, or `tonic`.

Six traits, each with a runnable rustdoc example:

| Trait | Contract |
|---|---|
| `PolicyStore` | `get_policy(&AgentId) -> PolicyDocument`, `invalidate(&AgentId)` |
| `AuditSink` | `emit(AuditEntry)` — append-only, order-preserving |
| `SessionStore` | `save`/`load`/`delete` over `SessionRecord` |
| `CredentialStore` | `get`/`put`/`delete` named secret bytes |
| `RateLimitCounter` | atomic `increment` (read-modify-write) + `current`/`reset` |
| `LifecycleStore` | `register`/`heartbeat`/`deregister` |

Also ships a reusable `conformance` harness (`assert_policy_store_conformance(&dyn PolicyStore, …)`) that downstream driver crates import to prove conformance, plus an integration test that runs it against an in-crate in-memory `PolicyStore`.

### ⚠️ Layering note (deliverable #10 — `aa_core::storage::*`)

The Story asks both that the traits use **concrete** `aa-core` types *and* that they be re-exported at `aa_core::storage::*`. Those two together form a Cargo dependency **cycle** (`aa-storage → aa-core → aa-storage`) and cannot compile. Confirmed with the reporter: we point the dependency **`aa-storage → aa-core`** (keeping the concrete signatures the downstream drivers need) and deliver the single-import-path goal via **`aa_storage::*`** (the crate re-exports `AgentId`, `SessionId`, `PolicyDocument`, `AuditEntry`). The `aa_core::storage::*` re-export is recorded as an infeasible-by-cycle finding and tracked in the verification subtask **AAASM-2358** rather than patched silently.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2357 (parent Story AAASM-2354, Epic AAASM-2347)

## Testing

- [x] Unit tests added / updated — 7 rustdoc examples + 1 conformance integration test
- [x] Integration tests added / updated — `tests/conformance.rs`
- Local: `cargo test -p aa-storage` (1 + 7 pass), `cargo clippy -p aa-storage --all-targets -- -D warnings` clean, `cargo deny check` ok, `cargo doc -p aa-storage --no-deps` renders all six trait pages, `cargo check --workspace` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
