### PR TITLE
[AAASM-2358] ✅ (aa-storage): Verify trait crate acceptance criteria

### DIFF
--- a/aa-storage/tests/object_safety.rs
+++ b/aa-storage/tests/object_safety.rs
@@ -1,0 +1,25 @@
+//! AAASM-2358 verification: every storage trait is object-safe and reachable
+//! from the single import path.
+//!
+//! The parent Story's AC asks for the traits at `aa_core::storage::*`. That
+//! re-export is infeasible: `aa-storage` depends on `aa-core` for the concrete
+//! shared types, so re-exporting the traits back from `aa-core` would create a
+//! Cargo dependency cycle (`aa-storage -> aa-core -> aa-storage`). The single
+//! import path is therefore `aa_storage::*`, which this test exercises. See the
+//! verification report and the Bug subtask filed under AAASM-2354.
+
+use aa_storage::{AuditSink, CredentialStore, LifecycleStore, PolicyStore, RateLimitCounter, SessionStore};
+
+#[test]
+fn all_six_storage_traits_are_object_safe_via_single_import_path() {
+    // Each binding compiles only if the trait is object-safe and reachable from
+    // the `aa_storage::*` import path. The successful build is the assertion; the
+    // values stay `None` because a real trait object would need a concrete
+    // backend.
+    let _policy: Option<Box<dyn PolicyStore>> = None;
+    let _audit: Option<Box<dyn AuditSink>> = None;
+    let _session: Option<Box<dyn SessionStore>> = None;
+    let _credential: Option<Box<dyn CredentialStore>> = None;
+    let _rate: Option<Box<dyn RateLimitCounter>> = None;
+    let _lifecycle: Option<Box<dyn LifecycleStore>> = None;
+}

--- a/verification-reports/AAASM-2358.md
+++ b/verification-reports/AAASM-2358.md
@@ -1,0 +1,48 @@
+# AAASM-2358 — Verify `aa-storage` trait crate acceptance criteria
+
+Parent Story: **AAASM-2354** · Epic: **AAASM-2347** · Implementation: **AAASM-2357** (PR #851)
+Verified against branch `v0.0.1/AAASM-2358/test/verify_aa_storage_acs` (stacked on the impl branch).
+
+## Acceptance criteria results
+
+| # | Acceptance criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | `aa-storage` compiles standalone with **no backend dependencies** | ✅ Pass | `cargo tree -p aa-storage -e normal` shows only `aa-core`, `async-trait`, `thiserror` as direct deps. No `sqlx`, `redis`, or `tonic`. |
+| 2 | All six traits documented with rustdoc examples + runnable conformance stub | ✅ Pass | 7 doctests pass (`cargo test -p aa-storage --doc`); `conformance::assert_policy_store_conformance` + `tests/conformance.rs` run green. |
+| 3 | `cargo deny check` passes | ✅ Pass | `advisories ok, bans ok, licenses ok, sources ok`. |
+| 4 | Re-exported under `aa_core::storage::*` so call sites import from one path | ⚠️ **Infeasible — see finding** | Cargo dependency cycle; single import path delivered via `aa_storage::*` instead. Bug subtask filed. |
+| 5 | Trait-conformance stub can be parameterized by a `dyn PolicyStore` | ✅ Pass | `tests/conformance.rs` passes `&MemoryPolicyStore` as `&dyn PolicyStore`; `tests/object_safety.rs` constructs `Box<dyn _>` for all six traits. |
+
+## Commands run
+
+```
+cargo check -p aa-storage                              # clean
+cargo deny check                                       # advisories/bans/licenses/sources ok
+cargo test -p aa-storage                               # 1 conformance + 1 object-safety + 7 doctests pass
+cargo doc -p aa-storage --no-deps                      # renders six trait pages
+cargo tree -p aa-storage -e normal                     # only aa-core/async-trait/thiserror direct
+```
+
+`target/doc/aa_storage/` renders all six trait pages:
+`trait.PolicyStore.html`, `trait.AuditSink.html`, `trait.SessionStore.html`,
+`trait.CredentialStore.html`, `trait.RateLimitCounter.html`, `trait.LifecycleStore.html`.
+
+## Finding — AC #4 `aa_core::storage::*` re-export is infeasible (Cargo cycle)
+
+The traits use the **concrete** shared types from `aa-core` (`get_policy(&AgentId) -> PolicyDocument`,
+`emit(AuditEntry)`, …), so `aa-storage` must depend on `aa-core`. Re-exporting the traits back out of
+`aa-core` as `aa_core::storage::*` would make `aa-core` depend on `aa-storage`, forming a cycle
+`aa-storage → aa-core → aa-storage`, which Cargo rejects.
+
+This is a contradiction inside the Story's own ACs (concrete-types vs. re-export-from-aa-core), not an
+implementation defect. The single-import-path intent is satisfied via **`aa_storage::*`**, which
+re-exports `AgentId`, `SessionId`, `PolicyDocument`, and `AuditEntry` alongside the six traits, so call
+sites import the contract and its types from one path. The chosen layering keeps the concrete signatures
+the downstream Postgres/Redis/Enterprise drivers (Epic B/E) need.
+
+Filed as a Bug subtask under AAASM-2354 per this ticket's instruction #4 (do not patch silently).
+
+## Conclusion
+
+All implementable ACs pass. The lone exception (AC #4) is infeasible-by-cycle and recorded as a Bug
+subtask with the agreed resolution (`aa_storage::*` as the single import path). No code defects found.


### PR DESCRIPTION
## Description

Verifies the acceptance criteria for the `aa-storage` trait crate (parent Story **AAASM-2354**, implemented in **AAASM-2357** / PR #851). Stacked on the impl branch — once #851 merges, rebasing this branch on `master` drops the impl commits.

Adds two things:

1. **`aa-storage/tests/object_safety.rs`** — proves all six storage traits are object-safe and reachable from the single `aa_storage::*` import path by constructing `Box<dyn Trait>` for each.
2. **`verification-reports/AAASM-2358.md`** — AC-by-AC results.

### AC results

| # | AC | Result |
|---|---|---|
| 1 | No backend deps (`cargo tree` → only `aa-core`/`async-trait`/`thiserror`) | ✅ |
| 2 | Six traits documented + runnable conformance stub | ✅ (7 doctests + conformance test) |
| 3 | `cargo deny check` passes | ✅ |
| 4 | Re-export under `aa_core::storage::*` | ⚠️ Infeasible (Cargo cycle) — see finding |
| 5 | Conformance stub parameterizable by `dyn PolicyStore` | ✅ |

### Finding (AC #4)

`aa_core::storage::*` is mutually exclusive with the concrete-types AC: it would require `aa-core → aa-storage` while `aa-storage` already depends on `aa-core`, forming a Cargo cycle. Single import path delivered via `aa_storage::*` instead. Filed as Bug subtask **AAASM-2458** under the Story (not patched silently, per this ticket's instruction #4).

## Type of Change

- [x] ✅ Tests / verification
- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2358 (parent Story AAASM-2354, Epic AAASM-2347)
- Finding: AAASM-2458

## Testing

- [x] Integration tests added / updated — `tests/object_safety.rs`
- Local: `cargo test -p aa-storage` (object-safety + conformance + 7 doctests pass), `cargo clippy -p aa-storage --all-targets -- -D warnings` clean, `cargo deny check` ok, `cargo doc -p aa-storage --no-deps` renders six trait pages.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
