### PR TITLE
[AAASM-2457] ♻️ (smoke): Drop SDK-asserting jobs from agent-assembly + add cargo install aasm smoke

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -184,10 +184,10 @@ jobs:
             exit 1
           }
 
-  smoke-python-pypi-import:
-    name: Smoke — Python pip (import + __version__)
+  smoke-cargo-install:
+    name: Smoke — cargo install aasm (crates.io)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - name: Compute expected aasm version
         id: expected
@@ -207,78 +207,16 @@ jobs:
           fi
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Python 3.12 on a clean runner
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      - name: Install agent-assembly from PyPI
+      - name: Install aasm from crates.io
         env:
           VERSION: ${{ steps.expected.outputs.version }}
         run: |
-          python -m pip install --upgrade pip
-          # AAASM-2455: pin to the just-published prerelease so we don't resolve
-          # to the bogus PyPI 0.0.2 squat (AAASM-2454). PEP-440 form:
-          # 0.0.1-alpha.N → 0.0.1aN.
-          pep440="${VERSION//-alpha./a}"
-          pip install --no-cache-dir --pre "agent-assembly==${pep440}"
+          cargo install aasm --version "${VERSION}" --locked
 
-      - name: Verify agent_assembly.__version__ matches release tag
-        env:
-          EXPECTED: ${{ steps.expected.outputs.version }}
-        shell: bash
-        run: |
-          got=$(python -c "import agent_assembly; print(agent_assembly.__version__)")
-          want="${EXPECTED}"
-          echo "Installed: ${got}"
-          echo "Expected:  ${want}"
-          [ "${got}" = "${want}" ] || {
-            echo "::error::agent_assembly.__version__ mismatch — got '${got}', want '${want}'"
-            exit 1
-          }
-
-  smoke-python-pypi-runtime:
-    name: Smoke — Python pip (aasm --version via [runtime] extra)
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Compute expected aasm version
-        id: expected
-        shell: bash
-        env:
-          TAG: ${{ github.event.release.tag_name }}
-          INPUT_VERSION: ${{ inputs.version }}
-        run: |
-          if [ -n "${INPUT_VERSION}" ]; then
-            version="${INPUT_VERSION#v}"
-          else
-            version="${TAG#v}"
-          fi
-          if [ -z "${version}" ]; then
-            echo "::error::Could not resolve release version from event payload" >&2
-            exit 1
-          fi
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Python 3.12 on a clean runner
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Install agent-assembly[runtime] from PyPI
-        env:
-          VERSION: ${{ steps.expected.outputs.version }}
-        run: |
-          python -m pip install --upgrade pip
-          # AAASM-2455: pin to the just-published prerelease + add [runtime]
-          # extra so the bundled aasm sidecar is installed (this is what
-          # `aasm --version` below expects to find). The job name promised
-          # the extra but the previous install command was missing it.
-          # PEP-440 form: 0.0.1-alpha.N → 0.0.1aN.
-          pep440="${VERSION//-alpha./a}"
-          pip install --no-cache-dir --pre "agent-assembly[runtime]==${pep440}"
-
-      - name: Verify the bundled aasm binary prints the release tag
+      - name: Verify aasm --version matches release tag
         env:
           EXPECTED: ${{ steps.expected.outputs.version }}
         shell: bash
@@ -289,63 +227,6 @@ jobs:
           echo "Expected:  ${want}"
           [ "${got}" = "${want}" ] || {
             echo "::error::aasm --version mismatch — got '${got}', want '${want}'"
-            exit 1
-          }
-
-  smoke-npm:
-    name: Smoke — npm (@agent-assembly/sdk install + require)
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - name: Compute expected aasm version
-        id: expected
-        shell: bash
-        env:
-          TAG: ${{ github.event.release.tag_name }}
-          INPUT_VERSION: ${{ inputs.version }}
-        run: |
-          if [ -n "${INPUT_VERSION}" ]; then
-            version="${INPUT_VERSION#v}"
-          else
-            version="${TAG#v}"
-          fi
-          if [ -z "${version}" ]; then
-            echo "::error::Could not resolve release version from event payload" >&2
-            exit 1
-          fi
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
-
-      - name: Set up Node.js 20 LTS on a clean runner
-        uses: actions/setup-node@v6
-        with:
-          node-version: "20"
-
-      - name: Install @agent-assembly/sdk from the public npm registry
-        run: |
-          # Smoke test runs from /tmp on a fresh runner so that no
-          # repo-local package.json can shadow the install.
-          mkdir -p /tmp/aa-npm-smoke
-          cd /tmp/aa-npm-smoke
-          npm init -y >/dev/null
-          npm install --no-audit --no-fund @agent-assembly/sdk
-
-      - name: Verify the package loads via require() without throwing
-        run: |
-          cd /tmp/aa-npm-smoke
-          node -e "require('@agent-assembly/sdk')"
-
-      - name: Verify installed package version matches release tag
-        env:
-          EXPECTED: ${{ steps.expected.outputs.version }}
-        shell: bash
-        run: |
-          cd /tmp/aa-npm-smoke
-          got=$(node -p "require('@agent-assembly/sdk/package.json').version")
-          want="${EXPECTED}"
-          echo "Installed: ${got}"
-          echo "Expected:  ${want}"
-          [ "${got}" = "${want}" ] || {
-            echo "::error::@agent-assembly/sdk version mismatch — got '${got}', want '${want}'"
             exit 1
           }
 
@@ -402,9 +283,7 @@ jobs:
     needs:
       - smoke-homebrew-macos
       - smoke-homebrew-linux
-      - smoke-python-pypi-import
-      - smoke-python-pypi-runtime
-      - smoke-npm
+      - smoke-cargo-install
       - smoke-docker
     # Fire only when the workflow is genuinely broken — `failure()` covers
     # any failed `needs:` job; the `release` event guard avoids dispatching


### PR DESCRIPTION
## Description

agent-assembly's `smoke-test.yml` was asserting on downstream SDK packages (`@agent-assembly/sdk` on npm, `agent-assembly[runtime]` on PyPI) under the false assumption that SDK versions track the agent-assembly tag 1:1. That coupling caused three problems:

1. **Semantic** — node-sdk and python-sdk are free to release on their own cadence. A pure-JS bugfix on node-sdk should not require an agent-assembly release; asserting `npm install @agent-assembly/sdk` version == agent-assembly tag bakes a wrong premise into the release verdict.
2. **Operational** — these jobs run inside agent-assembly's `release.yml` smoke-test phase, BEFORE the cross-repo `repository_dispatch` fan-out has finished publishing on npm + PyPI. They race the SDK publish workflows and fail even on a healthy coordinated release. Bug 8 from the AAASM-2454 investigation.
3. **Coverage gap** — the only release path that smoke never touched was `cargo install aasm` (the AAASM-2340 crates.io publish). That's an agent-assembly-published artifact and belongs here.

## Changes

| Before | After |
|---|---|
| 7 smoke jobs: `smoke-homebrew-macos`, `smoke-homebrew-linux`, `smoke-curl-installer` (gated off), `smoke-python-pypi-import`, `smoke-python-pypi-runtime`, `smoke-npm`, `smoke-docker` | 5 smoke jobs: `smoke-homebrew-macos`, `smoke-homebrew-linux`, `smoke-curl-installer` (gated off), **`smoke-cargo-install`** ← new, `smoke-docker` |
| `notify-on-failure.needs:` lists 6 entries | `notify-on-failure.needs:` lists 4 entries (removed 3 SDK, added cargo) |

**Net diff:** -117 deletions, +10 insertions across `smoke-test.yml`. Single file changed.

### `smoke-cargo-install` job

Validates the AAASM-2340 install path that had no prior smoke coverage:

```yaml
smoke-cargo-install:
  name: Smoke — cargo install aasm (crates.io)
  runs-on: ubuntu-latest
  timeout-minutes: 30
  steps:
    - …compute expected version from release tag…
    - uses: dtolnay/rust-toolchain@…  # stable
    - run: cargo install aasm --version "${VERSION}" --locked
    - run: |
        got=$(aasm --version)
        want="aasm ${EXPECTED}"
        [ "${got}" = "${want}" ] || { echo "::error::mismatch"; exit 1; }
```

30-minute timeout because the first `cargo install` on a clean runner has to compile aa-cli + transitive deps (wasmtime included).

## What this means for SDK quality

SDK quality stays on the SDK repos' own CI, which already runs on every PR. agent-assembly's release smoke now only asserts on artifacts that agent-assembly itself publishes:

* Homebrew formula (`brew install`)
* ghcr.io Docker images (`docker run`)
* crates.io aasm install path (`cargo install aasm`)
* (curl|sh installer — gated off until `get.agent-assembly.io` is provisioned)

## Supersedes

* **[PR #848](https://github.com/ai-agent-assembly/agent-assembly/pull/848) (AAASM-2455 — pin pip install version)** becomes moot once this PR lands, because the pip smoke jobs it was pinning are deleted entirely. Recommend closing #848 as superseded if this lands first; alternatively merge #848 first and this PR will cleanly delete the now-pinned code.

## Companion items

* AAASM-2454 — investigation of PyPI 0.0.2 squat (still open; orthogonal to this PR — agent-assembly's smoke no longer touches PyPI either way)
* AAASM-2456 / PR #849 — release-readiness.sh already has the anti-recurrence check for naked `pip install agent-assembly` lines

## Related

- Jira: [AAASM-2457](https://lightning-dust-mite.atlassian.net/browse/AAASM-2457)
- Parent Story: [AAASM-1235](https://lightning-dust-mite.atlassian.net/browse/AAASM-1235) (F119 post-release smoke test)

— Claude Code


[AAASM-2457]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ