### PR TITLE
[AAASM-2463] 🐛 (release): Add --no-verify to publish + remove smoke-test from release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -273,6 +273,7 @@ jobs:
             --no-git-push \
             --yes \
             --allow-dirty \
+            --no-verify \
             --token "$CARGO_REGISTRY_TOKEN"
 
   update-homebrew-tap:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -357,22 +357,6 @@ jobs:
 
             Source workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-  smoke-test:
-    # Run the 7-channel smoke test after the GitHub Release publishes.
-    # The default `release: published` event-chain doesn't fire when
-    # softprops/action-gh-release creates the Release under GITHUB_TOKEN,
-    # so call smoke-test.yml directly via workflow_call instead.
-    name: Smoke test published artifacts
-    needs: publish
-    if: github.event_name == 'push'
-    uses: ./.github/workflows/smoke-test.yml
-    permissions:
-      contents: read
-      issues: write
-      packages: read
-    with:
-      version: ${{ github.ref_name }}
-
   notify-downstream:
     # Cross-repo trigger: after agent-assembly's Release object is
     # published (binaries available on the GH Release page), fire a
@@ -429,7 +413,7 @@ jobs:
     # aggregator runs even when an upstream job failed (the whole point
     # is to see which channels are red).
     name: Release status aggregator
-    needs: [publish-crates, update-homebrew-tap, notify-downstream, smoke-test]
+    needs: [publish-crates, update-homebrew-tap, notify-downstream]
     if: always() && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

Two bugs surfaced on the v0.0.1-alpha.5 release. Single PR fixes both.

## Bug 1 — `cargo publish --verify` trips on aa-ebpf's build.rs

`cargo workspaces publish` runs `cargo publish --verify` per crate. For `aa-ebpf`, the verify step extracts the tarball and runs `cargo build`, which triggers `aa-ebpf/build.rs`. The build script renames the staged `Cargo.toml.embedded` → `Cargo.toml` inside the extracted tarball (the AAASM-2340 trick to bypass nested-package detection on the publish side). cargo refuses the publish:

```
error: failed to verify package tarball
Caused by:
  Source directory was modified by build.rs during cargo publish.
  Build scripts should not modify anything outside of OUT_DIR.
  Added:   …/aa-ebpf-0.0.1-alpha.5/_embedded/aa-ebpf-probes/Cargo.toml
  Removed: …/aa-ebpf-0.0.1-alpha.5/_embedded/aa-ebpf-probes/Cargo.toml.embedded

To proceed despite this, pass the `--no-verify` flag.
error: unable to publish package aa-ebpf
```

Topo order broke at aa-ebpf on alpha-5: aa-core / aa-proto / aa-ebpf-common landed, then the 6 downstream crates (aa-ebpf / aa-runtime / aa-proxy / aa-sandbox / aa-gateway / aa-cli) failed.

**Fix:** add ``--no-verify`` to `cargo workspaces publish`. The workspace is already built + tested in CI before tagging — publish-time verify is redundant.

## Bug 2 — `smoke-test` raced publishes inside release.yml

`smoke-test` job had `needs: publish` (same level as `publish-crates`, `update-homebrew-tap`, `notify-downstream`). So smoke ran **in parallel** with the publishes it was meant to smoke-test:

- `smoke-cargo-install` raced `publish-crates` → `cargo install aasm` failed
- `smoke-homebrew-*` raced the manual tap PR merge → wrong version resolved
- `smoke-docker` raced docker.yml (separate workflow) → image not yet pushed

Per user direction: **remove `smoke-test` job from release.yml entirely** for this phase. Re-introducing it later with correct `needs:` ordering is a separate concern.

## Changes

- `release.yml` `cargo workspaces publish` → adds `--no-verify` flag
- `release.yml` → deletes the `smoke-test:` job (16 lines)
- `release.yml` → drops `smoke-test` from `release-status-aggregator.needs:` list

Net diff: **−17 / +2** on `.github/workflows/release.yml`.

## Recovery for alpha-5

alpha-5 partially-published: aa-core, aa-proto, aa-ebpf-common at `0.0.1-alpha.5`. The 6 remaining crates are NOT on crates.io.

After this PR merges, a new tag (alpha-6) will cleanly publish all 9 crates.

## Related

- Jira: [AAASM-2463](https://lightning-dust-mite.atlassian.net/browse/AAASM-2463)
- AAASM-2340 — `_embedded/` staging trick that this PR makes compatible with `cargo publish`
- AAASM-2346 — `--allow-dirty` flag (this PR adds `--no-verify` alongside)

— Claude Code

[AAASM-2463]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ