### PR TITLE
[AAASM-2381] ✨ (proto): Define InvalidationService push-invalidation contract

### DIFF
--- a/aa-proto/build.rs
+++ b/aa-proto/build.rs
@@ -43,6 +43,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         proto_root.join("approval.proto"),
         proto_root.join("topology.proto"),
         proto_root.join("secrets.proto"),
+        proto_root.join("invalidation.proto"),
     ];
 
     println!("cargo:rerun-if-changed={}", proto_root.display());

--- a/aa-proto/src/lib.rs
+++ b/aa-proto/src/lib.rs
@@ -16,6 +16,7 @@
 //! assembly::event::v1    — internal event bus envelope (paths ⑤ ⑥)
 //! assembly::approval::v1 — human-in-the-loop approval queue
 //! assembly::topology::v1 — agent tree, lineage, and team-member queries
+//! assembly::gateway::v1  — L1 cache push-invalidation channel
 //! ```
 
 pub mod assembly {
@@ -67,6 +68,12 @@ pub mod assembly {
     pub mod secrets {
         pub mod v1 {
             tonic::include_proto!("assembly.secrets.v1");
+        }
+    }
+
+    pub mod gateway {
+        pub mod v1 {
+            tonic::include_proto!("assembly.gateway.v1");
         }
     }
 }

--- a/proto/invalidation.proto
+++ b/proto/invalidation.proto
@@ -1,0 +1,111 @@
+syntax = "proto3";
+
+package assembly.gateway.v1;
+
+// InvalidationService is the gateway → Assembly push channel that keeps the
+// in-process L1 cache fresh without relying on TTL expiry alone.
+//
+// A revoked agent must stop executing the instant an admin mutates policy —
+// not after the L1 TTL lapses. The gateway publishes a `PolicyInvalidated`
+// event over a persistent bidi stream; every subscribed Assembly invalidates
+// the matching L1 entry within ~100 ms.
+//
+// The same stream is reserved to carry approval-result notifications
+// (`ApprovalResolved`) so blocked agents subscribe instead of poll — one
+// stream, two consumers (the approval half ships in the next Story).
+//
+// Consumed by: aa-runtime/src/invalidation_client.rs (client side)
+//              aa-gateway/src/invalidation/           (server side)
+service InvalidationService {
+  // Subscribe opens the persistent bidi stream. The Assembly sends an initial
+  // `SubscribeRequest` (with the highest sequence number it has already seen,
+  // for replay-on-reconnect) and thereafter acks delivered events; the gateway
+  // streams `InvalidationEvent`s as policy mutations occur.
+  rpc Subscribe(stream SubscribeRequest) returns (stream InvalidationEvent);
+}
+
+// ── Client → gateway ──────────────────────────────────────────────────────────
+
+// SubscribeRequest is sent by the Assembly on the client→server half of the
+// stream: once on connect (`Initial`) and then once per delivered event (`Ack`).
+message SubscribeRequest {
+  // Stable identifier of the subscribing Assembly instance. Used by the gateway
+  // to key the per-subscriber replay buffer across reconnects.
+  string assembly_id = 1;
+
+  // Exactly one of the following is set per message.
+  oneof kind {
+    // First message on a freshly opened stream. Carries the last sequence the
+    // Assembly already applied so the gateway can replay anything missed.
+    SubscribeInitial initial = 2;
+    // Steady-state acknowledgement that `seq` was applied to the L1 cache.
+    SubscribeAck     ack     = 3;
+  }
+}
+
+// SubscribeInitial is the handshake message opening (or reopening) a stream.
+message SubscribeInitial {
+  // Highest `InvalidationEvent.seq` the Assembly has already applied. The
+  // gateway replays every buffered event with a strictly greater seq. Zero on
+  // a cold start (no prior subscription).
+  uint64 last_seq_seen = 1;
+}
+
+// SubscribeAck confirms a single event was applied, letting the gateway advance
+// its per-subscriber low-water mark and trim the replay buffer.
+message SubscribeAck {
+  // Sequence number of the `InvalidationEvent` that was applied.
+  uint64 seq = 1;
+}
+
+// ── Gateway → client ──────────────────────────────────────────────────────────
+
+// InvalidationEvent is the gateway→Assembly half of the stream. Each event
+// carries a monotonically increasing per-subscriber sequence number so the
+// Assembly can detect gaps and request replay on reconnect.
+message InvalidationEvent {
+  // Monotonic, per-subscriber sequence number. Strictly increasing; gaps mean
+  // the Assembly missed events and should reconnect with `last_seq_seen`.
+  uint64 seq = 1;
+
+  // Exactly one payload is set per event.
+  oneof payload {
+    // A policy mutation invalidated the cached decision for an agent.
+    PolicyInvalidated policy_invalidated = 2;
+    // A held action was resolved by a human reviewer. Reserved here; the
+    // gateway begins broadcasting this in the approval-reuse Story.
+    ApprovalResolved  approval_resolved  = 3;
+  }
+}
+
+// PolicyInvalidated signals that the cached policy decision for `agent_id` is
+// stale and must be dropped from the L1 cache.
+message PolicyInvalidated {
+  // Agent whose cached policy decision is now stale.
+  string agent_id = 1;
+  // Monotonic policy version after the mutation (see Epic A's `policy_version`).
+  uint64 policy_version = 2;
+}
+
+// ApprovalResolved signals that a previously held action has a final decision.
+// Reserved for the approval-reuse Story; defined here so the wire contract is
+// stable before the server begins broadcasting it.
+message ApprovalResolved {
+  // Identifier of the approval request that was resolved.
+  string   request_id = 1;
+  // The reviewer's verdict.
+  Decision decision   = 2;
+}
+
+// Decision is the human reviewer's verdict on a held action, as delivered over
+// the invalidation channel's `ApprovalResolved` event.
+enum Decision {
+  // Default / unset — never sent by a conforming gateway.
+  DECISION_UNSPECIFIED = 0;
+  // The reviewer approved the held action.
+  APPROVED             = 1;
+  // The reviewer denied the held action.
+  DENIED               = 2;
+  // The request is still awaiting a reviewer verdict.
+  PENDING              = 3;
+}


### PR DESCRIPTION
## Description

Defines the gateway → Assembly **push-invalidation** wire contract — the first sub-task of Story AAASM-2377 (L1 cache freshness without a TTL race).

New `proto/invalidation.proto` declares `assembly.gateway.v1.InvalidationService` with a single persistent bidi-streaming RPC:

```proto
rpc Subscribe(stream SubscribeRequest) returns (stream InvalidationEvent);
```

- `SubscribeRequest` — `assembly_id` + `oneof { SubscribeInitial(last_seq_seen) | SubscribeAck(seq) }` for handshake-with-replay and steady-state acks.
- `InvalidationEvent` — per-subscriber `seq` + `oneof { PolicyInvalidated | ApprovalResolved }`. `ApprovalResolved` + the `Decision` enum (`DECISION_UNSPECIFIED/APPROVED/DENIED/PENDING`) are reserved on the wire now; the gateway begins broadcasting them in the next Story.

The proto is wired into `aa-proto`'s `build.rs` codegen list and re-exported as `assembly::gateway::v1` in `lib.rs`, so the server (`aa-gateway`) and client (`aa-runtime`) sub-tasks can depend on it.

> **Note on naming:** the ticket text says package `aa.gateway.v1`; this repo's every package is rooted at `assembly.*.v1` and `aa-proto/src/lib.rs` is structured under `pub mod assembly`. I used `assembly.gateway.v1` to stay consistent with that convention. The file is flat in `proto/` per the repo's documented layout (buf.yaml `DIRECTORY_SAME_PACKAGE` exception), not nested under `proto/aa/gateway/v1/`.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

Additive proto change only (new file, new package); `buf breaking` (FILE) is unaffected.

## Related Issues

- Related Jira ticket: AAASM-2381 (sub-task of AAASM-2377, Epic AAASM-2349)

## Testing

- [ ] Unit tests added / updated
- [x] No tests required (explain why)

Pure wire-contract definition — there is no behaviour to unit-test yet. Verified with `cargo check -p aa-proto`: the `assembly.gateway.v1` bindings (`InvalidationServiceServer`/`Client`, `SubscribeRequest`, `InvalidationEvent`, `Decision`) generate and compile. Server/client behaviour is tested in the AAASM-2382 / AAASM-2383 PRs.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
