### PR TITLE
[AAASM-2382] ✨ (aa-gateway): Gateway-side InvalidationService server + broadcast

### DIFF
--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -2175,6 +2175,40 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[tokio::test]
+    async fn apply_yaml_broadcasts_invalidation_within_100ms() {
+        use crate::invalidation::InvalidationHub;
+        use crate::policy::history::{FsHistoryStore, HistoryConfig};
+        use aa_proto::assembly::gateway::v1::invalidation_event::Payload;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let store = FsHistoryStore::new(HistoryConfig {
+            history_dir: tmp.path().to_path_buf(),
+            max_versions: 50,
+        });
+
+        // A subscriber connected before the mutation should be notified.
+        let hub = InvalidationHub::new();
+        let mut handle = hub.subscribe("asm-itest", 0);
+        let engine = make_engine(empty_doc()).with_invalidation_hub(Arc::clone(&hub));
+
+        let start = std::time::Instant::now();
+        engine
+            .apply_yaml("tools:\n  bash:\n    allow: false\n", Some("tester"), &store)
+            .await
+            .unwrap();
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(100), handle.receiver.recv())
+            .await
+            .expect("invalidation delivered within 100 ms")
+            .expect("channel open");
+        assert!(start.elapsed() < std::time::Duration::from_millis(100));
+        match event.payload.expect("payload set") {
+            Payload::PolicyInvalidated(p) => assert_eq!(p.policy_version, 1),
+            Payload::ApprovalResolved(_) => panic!("expected PolicyInvalidated"),
+        }
+    }
+
     // ── Budget alert integration ────────────────────────────────────────
 
     fn make_engine_with_alert_sender(

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -185,6 +185,10 @@ pub struct PolicyEngine {
     /// Bounded LRU cache for cascade evaluation results.
     /// Only the cascade path (`evaluate_with_cascade`) consults this cache.
     decision_cache: DecisionCache,
+    /// Optional push-invalidation hub. When set, `apply_yaml` fans a
+    /// `PolicyInvalidated` event out to every subscribed Assembly so their L1
+    /// caches drop stale decisions within ~100 ms instead of awaiting TTL.
+    invalidation_hub: Option<Arc<crate::invalidation::InvalidationHub>>,
 }
 
 /// Error returned when loading a policy from a file fails.
@@ -279,6 +283,7 @@ impl PolicyEngine {
             _watcher: watcher,
             registry: None,
             policy_epoch: Arc::new(AtomicU64::new(0)),
+            invalidation_hub: None,
             decision_cache: DecisionCache::new(100_000),
         })
     }
@@ -439,6 +444,7 @@ impl PolicyEngine {
             _watcher: None,
             registry: None,
             policy_epoch: Arc::new(AtomicU64::new(0)),
+            invalidation_hub: None,
             decision_cache: DecisionCache::new(100_000),
         })
     }
@@ -473,6 +479,7 @@ impl PolicyEngine {
             _watcher: watcher,
             registry: None,
             policy_epoch: Arc::new(AtomicU64::new(0)),
+            invalidation_hub: None,
             decision_cache: DecisionCache::new(100_000),
         })
     }
@@ -515,6 +522,7 @@ impl PolicyEngine {
             _watcher: None,
             registry: None,
             policy_epoch: Arc::new(AtomicU64::new(0)),
+            invalidation_hub: None,
             decision_cache: DecisionCache::new(100_000),
         }
     }
@@ -525,6 +533,16 @@ impl PolicyEngine {
     /// Call this after `load_from_file` in the server startup path.
     pub fn with_registry(mut self, registry: Arc<AgentRegistry>) -> Self {
         self.registry = Some(registry);
+        self
+    }
+
+    /// Attach a push-invalidation hub so `apply_yaml` broadcasts a
+    /// `PolicyInvalidated` event to every subscribed Assembly on each mutation.
+    ///
+    /// Call this after construction in the server startup path, sharing the
+    /// same hub instance that backs the `InvalidationService` gRPC server.
+    pub fn with_invalidation_hub(mut self, hub: Arc<crate::invalidation::InvalidationHub>) -> Self {
+        self.invalidation_hub = Some(hub);
         self
     }
 
@@ -549,7 +567,14 @@ impl PolicyEngine {
         self.policy.store(Arc::new(output.document));
 
         // Invalidate cached decisions — stale entries with the old epoch will be ignored.
-        self.policy_epoch.fetch_add(1, Ordering::Relaxed);
+        let new_epoch = self.policy_epoch.fetch_add(1, Ordering::Relaxed) + 1;
+
+        // Push the invalidation out to subscribed Assembly instances so their L1
+        // caches drop stale decisions immediately. An empty agent_id means
+        // "invalidate all cached agents" — a policy swap is global.
+        if let Some(hub) = &self.invalidation_hub {
+            hub.broadcast_policy_invalidated(String::new(), new_epoch);
+        }
 
         Ok(meta)
     }
@@ -1444,6 +1469,7 @@ mod tests {
             _watcher: None,
             registry: None,
             policy_epoch: Arc::new(AtomicU64::new(0)),
+            invalidation_hub: None,
             decision_cache: DecisionCache::new(1_024),
         }
     }
@@ -2191,6 +2217,7 @@ mod tests {
             _watcher: None,
             registry: None,
             policy_epoch: Arc::new(AtomicU64::new(0)),
+            invalidation_hub: None,
             decision_cache: DecisionCache::new(1_024),
         }
     }

--- a/aa-gateway/src/invalidation/hub.rs
+++ b/aa-gateway/src/invalidation/hub.rs
@@ -1,0 +1,246 @@
+//! [`InvalidationHub`] — the gateway-side fan-out for L1 push-invalidation.
+//!
+//! One [`Subscriber`] is tracked per connected Assembly (keyed by `assembly_id`).
+//! Each subscriber owns a monotonic sequence counter and a bounded replay ring
+//! so a reconnecting Assembly can request everything it missed via
+//! `SubscribeInitial.last_seq_seen`. A policy mutation calls
+//! [`InvalidationHub::broadcast_policy_invalidated`], which fans the event out to
+//! every subscriber's live channel and records it in their replay ring.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+
+use tokio::sync::broadcast;
+
+use aa_proto::assembly::gateway::v1::invalidation_event::Payload;
+use aa_proto::assembly::gateway::v1::{InvalidationEvent, PolicyInvalidated};
+
+/// Stable identifier of a subscribing Assembly instance.
+pub type AssemblyId = String;
+
+/// Number of recent events retained per subscriber for replay-on-reconnect.
+const REPLAY_RING_CAPACITY: usize = 1024;
+
+/// Bound on the per-subscriber live broadcast channel. A subscriber that falls
+/// this far behind is marked lagged and recovers via the replay ring on its
+/// next reconnect.
+const SUBSCRIBER_CHANNEL_CAPACITY: usize = 1024;
+
+/// Per-Assembly delivery state: a live channel, a monotonic seq counter, and a
+/// bounded replay ring.
+struct Subscriber {
+    /// Live fan-out channel; the Subscribe RPC holds the receiving end.
+    tx: broadcast::Sender<InvalidationEvent>,
+    /// Next sequence number to assign. Starts at 1 so `last_seq_seen == 0`
+    /// (cold start) replays the full ring.
+    next_seq: AtomicU64,
+    /// Most recent events (≤ [`REPLAY_RING_CAPACITY`]) for replay-on-reconnect.
+    ring: Mutex<VecDeque<InvalidationEvent>>,
+}
+
+/// The result of [`InvalidationHub::subscribe`]: events the Assembly missed
+/// (to flush first) plus the live receiver for everything thereafter.
+pub struct SubscriptionHandle {
+    /// Events with `seq > last_seq_seen` that were buffered while the Assembly
+    /// was disconnected. The Subscribe RPC yields these before live events.
+    pub replay: Vec<InvalidationEvent>,
+    /// Live event stream for everything published after this subscription.
+    pub receiver: broadcast::Receiver<InvalidationEvent>,
+}
+
+/// Gateway-side hub that fans policy invalidations out to every connected
+/// Assembly and buffers them for replay across reconnects.
+#[derive(Default)]
+pub struct InvalidationHub {
+    subscribers: RwLock<HashMap<AssemblyId, Arc<Subscriber>>>,
+}
+
+impl InvalidationHub {
+    /// Create an empty hub.
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Register (or look up) the subscriber for `assembly_id` and return a
+    /// [`SubscriptionHandle`] carrying the replay backlog plus a live receiver.
+    ///
+    /// Reconnecting with the same `assembly_id` reuses the existing sequence
+    /// counter and replay ring, so `last_seq_seen` resumes exactly where the
+    /// previous connection left off.
+    pub fn subscribe(&self, assembly_id: impl Into<AssemblyId>, last_seq_seen: u64) -> SubscriptionHandle {
+        let assembly_id = assembly_id.into();
+        let mut subscribers = self
+            .subscribers
+            .write()
+            .expect("invalidation subscribers lock poisoned");
+        let subscriber = subscribers
+            .entry(assembly_id)
+            .or_insert_with(|| {
+                let (tx, _rx) = broadcast::channel(SUBSCRIBER_CHANNEL_CAPACITY);
+                Arc::new(Subscriber {
+                    tx,
+                    next_seq: AtomicU64::new(1),
+                    ring: Mutex::new(VecDeque::new()),
+                })
+            })
+            .clone();
+
+        // Subscribe the receiver and snapshot the ring while still holding the
+        // write lock so a concurrent broadcast cannot interleave and be lost.
+        let receiver = subscriber.tx.subscribe();
+        let replay: Vec<InvalidationEvent> = {
+            let ring = subscriber.ring.lock().expect("replay ring lock poisoned");
+            ring.iter().filter(|event| event.seq > last_seq_seen).cloned().collect()
+        };
+        let subscriber_count = subscribers.len();
+        drop(subscribers);
+
+        if !replay.is_empty() {
+            metrics::counter!("aa_invalidation_replay_count").increment(replay.len() as u64);
+        }
+        metrics::gauge!("aa_invalidation_subscribers").set(subscriber_count as f64);
+
+        SubscriptionHandle { replay, receiver }
+    }
+
+    /// Fan a `PolicyInvalidated` event out to every connected Assembly.
+    ///
+    /// Each subscriber receives the event under its own monotonic sequence
+    /// number and a copy is appended to its replay ring (oldest trimmed past
+    /// [`REPLAY_RING_CAPACITY`]). An empty `agent_id` is the "invalidate all
+    /// cached agents" convention used for a global policy swap.
+    pub fn broadcast_policy_invalidated(&self, agent_id: impl Into<String>, policy_version: u64) {
+        let agent_id = agent_id.into();
+        let subscribers = self.subscribers.read().expect("invalidation subscribers lock poisoned");
+        for subscriber in subscribers.values() {
+            let seq = subscriber.next_seq.fetch_add(1, Ordering::Relaxed);
+            let event = InvalidationEvent {
+                seq,
+                payload: Some(Payload::PolicyInvalidated(PolicyInvalidated {
+                    agent_id: agent_id.clone(),
+                    policy_version,
+                })),
+            };
+            {
+                let mut ring = subscriber.ring.lock().expect("replay ring lock poisoned");
+                ring.push_back(event.clone());
+                while ring.len() > REPLAY_RING_CAPACITY {
+                    ring.pop_front();
+                }
+            }
+            // Best-effort: a subscriber with no live receiver still has the
+            // event recorded in its ring for replay on reconnect.
+            let _ = subscriber.tx.send(event);
+            metrics::counter!("aa_invalidation_events_broadcast").increment(1);
+        }
+    }
+
+    /// Trim a subscriber's replay ring up to and including `seq`, in response to
+    /// a `SubscribeAck`. Advances the low-water mark so acknowledged events are
+    /// not replayed again. Unknown `assembly_id`s are ignored.
+    pub fn ack(&self, assembly_id: &str, seq: u64) {
+        let subscribers = self.subscribers.read().expect("invalidation subscribers lock poisoned");
+        if let Some(subscriber) = subscribers.get(assembly_id) {
+            let mut ring = subscriber.ring.lock().expect("replay ring lock poisoned");
+            while ring.front().is_some_and(|event| event.seq <= seq) {
+                ring.pop_front();
+            }
+        }
+    }
+
+    /// Number of registered subscribers. Primarily for tests and metrics.
+    pub fn subscriber_count(&self) -> usize {
+        self.subscribers
+            .read()
+            .expect("invalidation subscribers lock poisoned")
+            .len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn policy_agent(event: &InvalidationEvent) -> &str {
+        match event.payload.as_ref().expect("payload set") {
+            Payload::PolicyInvalidated(p) => &p.agent_id,
+            Payload::ApprovalResolved(_) => panic!("expected PolicyInvalidated"),
+        }
+    }
+
+    #[tokio::test]
+    async fn broadcast_reaches_live_subscriber_within_100ms() {
+        let hub = InvalidationHub::new();
+        let mut handle = hub.subscribe("asm-1", 0);
+        assert!(handle.replay.is_empty());
+
+        let start = std::time::Instant::now();
+        hub.broadcast_policy_invalidated("agent-x", 7);
+
+        let event = tokio::time::timeout(Duration::from_millis(100), handle.receiver.recv())
+            .await
+            .expect("event delivered within 100 ms")
+            .expect("channel open");
+        assert!(start.elapsed() < Duration::from_millis(100));
+        assert_eq!(event.seq, 1);
+        assert_eq!(policy_agent(&event), "agent-x");
+    }
+
+    #[tokio::test]
+    async fn reconnect_replays_only_events_after_last_seq() {
+        let hub = InvalidationHub::new();
+        // First connection registers the subscriber, then disconnects.
+        let handle = hub.subscribe("asm-1", 0);
+        drop(handle);
+
+        hub.broadcast_policy_invalidated("agent-a", 1);
+        hub.broadcast_policy_invalidated("agent-b", 2);
+
+        // Cold reconnect replays the full backlog.
+        let full = hub.subscribe("asm-1", 0);
+        assert_eq!(full.replay.len(), 2);
+        assert_eq!(full.replay[0].seq, 1);
+        assert_eq!(full.replay[1].seq, 2);
+
+        // Reconnect having already applied seq 1 replays only seq 2.
+        let partial = hub.subscribe("asm-1", 1);
+        assert_eq!(partial.replay.len(), 1);
+        assert_eq!(partial.replay[0].seq, 2);
+        assert_eq!(policy_agent(&partial.replay[0]), "agent-b");
+    }
+
+    #[tokio::test]
+    async fn ack_trims_replay_ring() {
+        let hub = InvalidationHub::new();
+        let _handle = hub.subscribe("asm-1", 0);
+        hub.broadcast_policy_invalidated("agent-a", 1);
+        hub.broadcast_policy_invalidated("agent-b", 2);
+
+        hub.ack("asm-1", 1);
+
+        // After acking seq 1, a cold reconnect only replays seq 2.
+        let reconnect = hub.subscribe("asm-1", 0);
+        assert_eq!(reconnect.replay.len(), 1);
+        assert_eq!(reconnect.replay[0].seq, 2);
+    }
+
+    #[test]
+    fn each_subscriber_gets_independent_sequence() {
+        let hub = InvalidationHub::new();
+        let _a = hub.subscribe("asm-1", 0);
+        let _b = hub.subscribe("asm-2", 0);
+        assert_eq!(hub.subscriber_count(), 2);
+
+        hub.broadcast_policy_invalidated("agent-a", 1);
+
+        // Each subscriber independently records the event at its own seq 1.
+        let reconnect_a = hub.subscribe("asm-1", 0);
+        let reconnect_b = hub.subscribe("asm-2", 0);
+        assert_eq!(reconnect_a.replay.len(), 1);
+        assert_eq!(reconnect_b.replay.len(), 1);
+        assert_eq!(reconnect_a.replay[0].seq, 1);
+        assert_eq!(reconnect_b.replay[0].seq, 1);
+    }
+}

--- a/aa-gateway/src/invalidation/mod.rs
+++ b/aa-gateway/src/invalidation/mod.rs
@@ -6,5 +6,7 @@
 //! ~100 ms of a policy mutation instead of waiting for TTL expiry.
 
 mod hub;
+mod service;
 
 pub use hub::{AssemblyId, InvalidationHub, SubscriptionHandle};
+pub use service::InvalidationServiceImpl;

--- a/aa-gateway/src/invalidation/mod.rs
+++ b/aa-gateway/src/invalidation/mod.rs
@@ -1,0 +1,10 @@
+//! Gateway-side L1 push-invalidation channel (Story AAASM-2377).
+//!
+//! The [`InvalidationHub`] fans `PolicyInvalidated` events out to every
+//! connected Assembly over the `assembly.gateway.v1.InvalidationService`
+//! bidi stream, keeping each Assembly's in-process L1 cache fresh within
+//! ~100 ms of a policy mutation instead of waiting for TTL expiry.
+
+mod hub;
+
+pub use hub::{AssemblyId, InvalidationHub, SubscriptionHandle};

--- a/aa-gateway/src/invalidation/service.rs
+++ b/aa-gateway/src/invalidation/service.rs
@@ -1,0 +1,99 @@
+//! Tonic server adapter for [`InvalidationHub`].
+//!
+//! [`InvalidationServiceImpl`] wraps a shared [`InvalidationHub`] and implements
+//! the generated `assembly.gateway.v1.InvalidationService` trait. The Subscribe
+//! RPC reads the Assembly's opening `SubscribeInitial`, replays anything missed
+//! since `last_seq_seen`, then streams live events; subsequent `SubscribeAck`
+//! messages on the client→server half trim the replay ring.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use tokio::sync::broadcast::error::RecvError;
+use tokio_stream::Stream;
+use tonic::{Request, Response, Status, Streaming};
+
+use aa_proto::assembly::gateway::v1::invalidation_service_server::InvalidationService;
+use aa_proto::assembly::gateway::v1::{subscribe_request::Kind, InvalidationEvent, SubscribeRequest};
+
+use super::InvalidationHub;
+
+/// gRPC adapter exposing an [`InvalidationHub`] over the bidi-streaming
+/// `InvalidationService`. Clone-cheap: holds only an `Arc` to the shared hub.
+#[derive(Clone)]
+pub struct InvalidationServiceImpl {
+    hub: Arc<InvalidationHub>,
+}
+
+impl InvalidationServiceImpl {
+    /// Wrap a shared hub for serving. The same hub is shared with the policy
+    /// mutation path so `broadcast_policy_invalidated` reaches these streams.
+    pub fn new(hub: Arc<InvalidationHub>) -> Self {
+        Self { hub }
+    }
+}
+
+#[tonic::async_trait]
+impl InvalidationService for InvalidationServiceImpl {
+    type SubscribeStream = Pin<Box<dyn Stream<Item = Result<InvalidationEvent, Status>> + Send + 'static>>;
+
+    /// Open the persistent push-invalidation stream for one Assembly.
+    ///
+    /// The first inbound message must carry the `assembly_id` (and, for a
+    /// resubscribe, `SubscribeInitial.last_seq_seen`). The hub replays missed
+    /// events, then live events are forwarded until the client disconnects. A
+    /// background task drains `SubscribeAck`s to advance the replay low-water
+    /// mark.
+    async fn subscribe(
+        &self,
+        request: Request<Streaming<SubscribeRequest>>,
+    ) -> Result<Response<Self::SubscribeStream>, Status> {
+        let mut inbound = request.into_inner();
+
+        let Some(first) = inbound.message().await? else {
+            return Err(Status::invalid_argument(
+                "stream closed before initial SubscribeRequest",
+            ));
+        };
+        if first.assembly_id.is_empty() {
+            return Err(Status::invalid_argument("assembly_id is required"));
+        }
+        let assembly_id = first.assembly_id;
+        let last_seq_seen = match first.kind {
+            Some(Kind::Initial(initial)) => initial.last_seq_seen,
+            // An Ack (or no kind) as the opener carries no resume point; treat
+            // it as a cold subscription.
+            _ => 0,
+        };
+
+        let handle = self.hub.subscribe(assembly_id.clone(), last_seq_seen);
+
+        // Drain client→server Acks so the hub can trim each subscriber's ring.
+        let hub = Arc::clone(&self.hub);
+        tokio::spawn(async move {
+            while let Ok(Some(message)) = inbound.message().await {
+                if let Some(Kind::Ack(ack)) = message.kind {
+                    hub.ack(&assembly_id, ack.seq);
+                }
+            }
+        });
+
+        let super::SubscriptionHandle { replay, mut receiver } = handle;
+        let stream = async_stream::try_stream! {
+            for event in replay {
+                yield event;
+            }
+            loop {
+                match receiver.recv().await {
+                    Ok(event) => yield event,
+                    // Lagged: the live channel overflowed. Skip the gap; the
+                    // client reconciles by reconnecting with last_seq_seen.
+                    Err(RecvError::Lagged(_)) => continue,
+                    Err(RecvError::Closed) => break,
+                }
+            }
+        };
+
+        Ok(Response::new(Box::pin(stream)))
+    }
+}

--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -16,6 +16,7 @@ pub mod edges;
 pub mod engine;
 pub mod events;
 pub mod iam;
+pub mod invalidation;
 pub mod local_mode;
 pub mod message_router;
 pub mod ops;

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -9,6 +9,7 @@ use tonic::transport::Server;
 use crate::audit::AuditWriter;
 use crate::edges::InMemoryEdgeRepo;
 use crate::engine::PolicyEngine;
+use crate::invalidation::{InvalidationHub, InvalidationServiceImpl};
 use crate::registry::AgentRegistry;
 use crate::secrets::InMemorySecretsStore;
 use crate::service::{
@@ -19,6 +20,7 @@ use aa_core::{AuditEntry, AuditEventType};
 use aa_proto::assembly::agent::v1::agent_lifecycle_service_server::AgentLifecycleServiceServer;
 use aa_proto::assembly::approval::v1::approval_service_server::ApprovalServiceServer;
 use aa_proto::assembly::audit::v1::audit_service_server::AuditServiceServer;
+use aa_proto::assembly::gateway::v1::invalidation_service_server::InvalidationServiceServer;
 use aa_proto::assembly::policy::v1::policy_service_server::PolicyServiceServer;
 use aa_proto::assembly::secrets::v1::secrets_service_server::SecretsServiceServer;
 use aa_proto::assembly::topology::v1::topology_service_server::TopologyServiceServer;
@@ -365,9 +367,11 @@ pub async fn serve_tcp(
     let (tracker, budget_path) = setup_budget(policy_path, budget_alert_tx);
     let _budget_writer = start_background_writer(Arc::clone(&tracker), budget_path.clone());
     let _budget_flush = maybe_spawn_window_flush(Arc::clone(&tracker));
+    let invalidation_hub = InvalidationHub::new();
     let engine = Arc::new(
         PolicyEngine::load_from_file_with_budget(policy_path, Arc::clone(&tracker))
-            .map_err(|e| format!("failed to load policy: {e:?}"))?,
+            .map_err(|e| format!("failed to load policy: {e:?}"))?
+            .with_invalidation_hub(Arc::clone(&invalidation_hub)),
     );
     let (audit_tx, audit_drops, initial_hash) = setup_audit("gateway", "default", storage).await?;
     let escalation_scheduler = start_escalation_scheduler();
@@ -404,6 +408,9 @@ pub async fn serve_tcp(
         .add_service(ApprovalServiceServer::new(approval_svc))
         .add_service(TopologyServiceServer::new(topology_svc))
         .add_service(SecretsServiceServer::new(secrets_svc))
+        .add_service(InvalidationServiceServer::new(InvalidationServiceImpl::new(
+            Arc::clone(&invalidation_hub),
+        )))
         .serve_with_shutdown(addr, async move {
             shutdown_signal().await;
             db_token.cancel();
@@ -432,9 +439,11 @@ pub async fn serve_uds(
     let (tracker, budget_path) = setup_budget(policy_path, budget_alert_tx);
     let _budget_writer = start_background_writer(Arc::clone(&tracker), budget_path.clone());
     let _budget_flush = maybe_spawn_window_flush(Arc::clone(&tracker));
+    let invalidation_hub = InvalidationHub::new();
     let engine = Arc::new(
         PolicyEngine::load_from_file_with_budget(policy_path, Arc::clone(&tracker))
-            .map_err(|e| format!("failed to load policy: {e:?}"))?,
+            .map_err(|e| format!("failed to load policy: {e:?}"))?
+            .with_invalidation_hub(Arc::clone(&invalidation_hub)),
     );
     let (audit_tx, audit_drops, initial_hash) = setup_audit("gateway", "default", storage).await?;
     let escalation_scheduler = start_escalation_scheduler();
@@ -477,6 +486,9 @@ pub async fn serve_uds(
         .add_service(ApprovalServiceServer::new(approval_svc))
         .add_service(TopologyServiceServer::new(topology_svc))
         .add_service(SecretsServiceServer::new(secrets_svc))
+        .add_service(InvalidationServiceServer::new(InvalidationServiceImpl::new(
+            Arc::clone(&invalidation_hub),
+        )))
         .serve_with_incoming_shutdown(incoming, async move {
             shutdown_signal().await;
             db_token.cancel();


### PR DESCRIPTION
## Description

Gateway-side server for the push-invalidation channel — sub-task 2 of Story AAASM-2377. **Stacked on [AAASM-2381](https://github.com/ai-agent-assembly/agent-assembly/pull/873); the proto commits drop out once that PR merges. Targets `master` per repo policy.**

Adds `aa-gateway/src/invalidation/`:

- **`InvalidationHub`** — one `Subscriber` per connected Assembly (keyed by `assembly_id`): a live `broadcast::Sender<InvalidationEvent>`, a monotonic per-subscriber `seq`, and a bounded **1024-event replay ring**. `broadcast_policy_invalidated(agent_id, policy_version)` fans an event to every subscriber and records it for replay; `subscribe(assembly_id, last_seq_seen)` returns the missed backlog plus a live receiver; `ack(seq)` trims the ring.
- **`InvalidationServiceImpl`** — implements the generated `InvalidationService` trait: reads the opening `SubscribeInitial`, replays missed events, streams live events, and drains `SubscribeAck`s in a background task.
- **Engine hook** — `PolicyEngine::with_invalidation_hub(...)`; `apply_yaml` (the internal policy-mutation API) broadcasts a global `PolicyInvalidated` after the epoch bump.
- **Server wiring** — `server.rs` builds one shared hub, attaches it to the engine, and registers `InvalidationServiceServer` on both the TCP and UDS listeners.
- **Metrics** — `aa_invalidation_subscribers` (gauge), `aa_invalidation_events_broadcast` (counter), `aa_invalidation_replay_count` (counter).

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

Additive: new module + one optional engine field (defaults `None`) + one extra registered gRPC service.

## Related Issues

- Related Jira ticket: AAASM-2382 (sub-task of AAASM-2377, Epic AAASM-2349)
- Depends on: AAASM-2381 (#873)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

`cargo nextest run -p aa-gateway invalidation:: engine::tests::apply_yaml_broadcasts_invalidation_within_100ms` — 5 passing:
- live delivery within 100 ms, cold/partial reconnect replay, ack trims ring, independent per-subscriber sequences (hub unit tests);
- `apply_yaml` (internal mutation API) → subscriber receives `PolicyInvalidated(policy_version=1)` within 100 ms (integration).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention


[AAASM-2381]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ