### PR TITLE
[AAASM-2361] ✨ (storage): Add [storage] schema, driver registry, and aasm config validate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,7 @@ dependencies = [
  "aa-gateway",
  "aa-proxy",
  "aa-sandbox",
+ "aa-storage",
  "anyhow",
  "assert_cmd",
  "async-trait",
@@ -93,6 +94,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
+ "toml 0.9.12+spec-1.1.0",
  "url",
  "uuid",
  "wiremock",
@@ -451,7 +453,10 @@ version = "0.0.1-alpha.5"
 dependencies = [
  "aa-core",
  "async-trait",
+ "serde",
+ "thiserror 2.0.18",
  "tokio",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -26,6 +26,7 @@ aa-devtool-windsurf  = { path = "../aa-devtool-windsurf", version = "0.0.1-alpha
 aa-gateway           = { path = "../aa-gateway", version = "0.0.1-alpha.5" }
 aa-proxy             = { path = "../aa-proxy", version = "0.0.1-alpha.5" }
 aa-sandbox           = { path = "../aa-sandbox", version = "0.0.1-alpha.5" }
+aa-storage           = { path = "../aa-storage", version = "0.0.1-alpha.5" }
 anyhow         = "1"
 async-trait    = "0.1"
 axum           = "0.8"
@@ -53,6 +54,7 @@ serde_yaml     = "0.9"
 thiserror      = "2"
 tokio          = { version = "1", features = ["full"] }
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-native-roots"] }
+toml           = "0.9"
 url            = "2"
 uuid           = { version = "1", features = ["serde", "v4"] }
 

--- a/aa-cli/src/commands/config/mod.rs
+++ b/aa-cli/src/commands/config/mod.rs
@@ -1,0 +1,28 @@
+//! Runtime configuration subcommands (`aasm config ...`).
+
+use std::process::ExitCode;
+
+use clap::{Args, Subcommand};
+
+pub mod validate;
+
+/// Arguments for the `aasm config` subcommand group.
+#[derive(Args)]
+pub struct ConfigArgs {
+    #[command(subcommand)]
+    pub command: ConfigCommands,
+}
+
+/// Available config subcommands.
+#[derive(Subcommand)]
+pub enum ConfigCommands {
+    /// Validate an `agent-assembly.toml` file (currently the `[storage]` section).
+    Validate(validate::ValidateArgs),
+}
+
+/// Dispatch a config subcommand.
+pub fn dispatch(args: ConfigArgs) -> ExitCode {
+    match args.command {
+        ConfigCommands::Validate(val_args) => validate::run(val_args),
+    }
+}

--- a/aa-cli/src/commands/config/validate.rs
+++ b/aa-cli/src/commands/config/validate.rs
@@ -1,0 +1,64 @@
+//! `aasm config validate` — local validation of `agent-assembly.toml`.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use aa_storage::{Registry, StorageConfig};
+use clap::Args;
+use serde::Deserialize;
+
+/// Arguments for `aasm config validate`.
+#[derive(Args)]
+pub struct ValidateArgs {
+    /// Path to the `agent-assembly.toml` file to validate.
+    pub file: PathBuf,
+}
+
+/// Minimal view of `agent-assembly.toml` covering the sections this command
+/// validates. Unknown sections are ignored.
+#[derive(Deserialize)]
+struct RuntimeConfig {
+    storage: Option<StorageConfig>,
+}
+
+/// Execute `aasm config validate`.
+///
+/// Parses the TOML file and resolves every `[storage]` driver name against the
+/// built-in driver registry. Exits 0 when valid; 1 with the error on stderr
+/// otherwise.
+pub fn run(args: ValidateArgs) -> ExitCode {
+    let contents = match std::fs::read_to_string(&args.file) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: failed to read {}: {e}", args.file.display());
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let config: RuntimeConfig = match toml::from_str(&contents) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: invalid TOML in {}: {e}", args.file.display());
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let Some(storage) = config.storage else {
+        eprintln!("error: {} has no [storage] section", args.file.display());
+        return ExitCode::FAILURE;
+    };
+
+    let mut registry = Registry::new();
+    aa_storage::builtin::register_builtin_drivers(&mut registry);
+
+    match registry.validate(&storage) {
+        Ok(()) => {
+            println!("Config is valid: {}", args.file.display());
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}

--- a/aa-cli/src/commands/config/validate.rs
+++ b/aa-cli/src/commands/config/validate.rs
@@ -62,3 +62,44 @@ pub fn run(args: ValidateArgs) -> ExitCode {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture(name: &str) -> PathBuf {
+        PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures")).join(name)
+    }
+
+    #[test]
+    fn valid_config_exits_success() {
+        let args = ValidateArgs {
+            file: fixture("storage_valid.toml"),
+        };
+        assert_eq!(run(args), ExitCode::SUCCESS);
+    }
+
+    #[test]
+    fn unknown_driver_exits_failure() {
+        let args = ValidateArgs {
+            file: fixture("storage_unknown_driver.toml"),
+        };
+        assert_eq!(run(args), ExitCode::FAILURE);
+    }
+
+    #[test]
+    fn missing_subsection_exits_failure() {
+        let args = ValidateArgs {
+            file: fixture("storage_missing_subsection.toml"),
+        };
+        assert_eq!(run(args), ExitCode::FAILURE);
+    }
+
+    #[test]
+    fn missing_file_exits_failure() {
+        let args = ValidateArgs {
+            file: PathBuf::from("/tmp/nonexistent-agent-assembly-config-xyz.toml"),
+        };
+        assert_eq!(run(args), ExitCode::FAILURE);
+    }
+}

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod approvals;
 pub mod audit;
 pub mod budget;
 pub mod completion;
+pub mod config;
 pub mod context;
 pub mod cost;
 pub mod dashboard;
@@ -55,6 +56,8 @@ pub enum Commands {
     Policy(policy::PolicyArgs),
     /// Manage named API contexts (connection profiles).
     Context(context::ContextArgs),
+    /// Validate an `agent-assembly.toml` runtime configuration file.
+    Config(config::ConfigArgs),
     /// Generate shell completion scripts.
     Completion(completion::CompletionArgs),
     /// Show fleet health, agents, approvals, and budget at a glance.
@@ -101,6 +104,7 @@ pub fn dispatch(cmd: Commands, ctx: &ResolvedContext, output: OutputFormat) -> E
         Commands::Logs(args) => logs::dispatch(args, ctx),
         Commands::Policy(args) => policy::dispatch(args, ctx, output),
         Commands::Context(args) => context::dispatch(args),
+        Commands::Config(args) => config::dispatch(args),
         Commands::Completion(args) => completion::run(args),
         Commands::Status(args) => status::dispatch(args, ctx, output),
         Commands::Version => version::run(ctx, output),

--- a/aa-cli/tests/fixtures/storage_missing_subsection.toml
+++ b/aa-cli/tests/fixtures/storage_missing_subsection.toml
@@ -1,0 +1,12 @@
+# Fixture: `policy_store = "redis"` names a registered driver, but there is no
+# [storage.redis] subsection. Validation fails with MissingDriverSection.
+[storage]
+policy_store       = "redis"
+audit_sink         = "postgres"
+session_store      = "redis"
+credential_store   = "postgres"
+rate_limit_counter = "redis"
+lifecycle_store    = "postgres"
+
+[storage.postgres]
+url = "postgresql://localhost:5432/assembly"

--- a/aa-cli/tests/fixtures/storage_unknown_driver.toml
+++ b/aa-cli/tests/fixtures/storage_unknown_driver.toml
@@ -1,0 +1,19 @@
+# Fixture: `policy_store` names a driver that is not registered. Even though a
+# [storage.mongodb] subsection is present, validation fails with UnknownDriver
+# and lists the valid driver names.
+[storage]
+policy_store       = "mongodb"
+audit_sink         = "postgres"
+session_store      = "redis"
+credential_store   = "postgres"
+rate_limit_counter = "redis"
+lifecycle_store    = "postgres"
+
+[storage.mongodb]
+url = "mongodb://localhost:27017"
+
+[storage.redis]
+url = "redis://localhost:6379"
+
+[storage.postgres]
+url = "postgresql://localhost:5432/assembly"

--- a/aa-cli/tests/fixtures/storage_valid.toml
+++ b/aa-cli/tests/fixtures/storage_valid.toml
@@ -1,0 +1,15 @@
+# Fixture: every storage kind selects a registered driver and supplies its
+# per-driver subsection. `aasm config validate` exits 0.
+[storage]
+policy_store       = "redis"
+audit_sink         = "postgres"
+session_store      = "redis"
+credential_store   = "postgres"
+rate_limit_counter = "redis"
+lifecycle_store    = "postgres"
+
+[storage.redis]
+url = "redis://localhost:6379"
+
+[storage.postgres]
+url = "postgresql://localhost:5432/assembly"

--- a/aa-storage/Cargo.toml
+++ b/aa-storage/Cargo.toml
@@ -8,9 +8,13 @@ description = "Storage trait abstraction (pure interface) for the Agent Assembly
 
 [dependencies]
 # Facade crate: the storage traits live in `aa-core::storage` and are re-exported
-# here. Only `aa-core` is needed at build time; `async-trait` is a dev-dep used by
-# the conformance test's example implementation.
-aa-core = { path = "../aa-core" }
+# here. `serde`/`toml` back the `[storage]` config schema + driver registry; the
+# crate stays a pure interface (no `sqlx`/`redis`/`tonic` backend dependency).
+# `async-trait` is a dev-dep used by the conformance test's example implementation.
+aa-core   = { path = "../aa-core" }
+serde     = { version = "1", features = ["derive"] }
+thiserror = "2"
+toml      = "0.9"
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/aa-storage/src/builtin.rs
+++ b/aa-storage/src/builtin.rs
@@ -1,0 +1,93 @@
+//! Placeholder registration of the OSS driver names.
+//!
+//! The concrete OSS backends (`memory`, `redis`, `postgres`) ship in Epic B and
+//! will register their own real factories from their own crates. Until then,
+//! [`register_builtin_drivers`] registers those names with a stub factory so the
+//! config loader recognizes them (and `aasm config validate` reports the correct
+//! set of valid names), while attempting to *build* one returns a clear
+//! "not yet implemented" error.
+
+use std::sync::Arc;
+
+use crate::factory::{
+    AuditSinkFactory, CredentialStoreFactory, LifecycleStoreFactory, PolicyStoreFactory, RateLimitCounterFactory,
+    SessionStoreFactory,
+};
+use crate::{
+    AuditSink, CredentialStore, LifecycleStore, PolicyStore, RateLimitCounter, Registry, Result, SessionStore,
+    StorageError,
+};
+
+/// The OSS driver names the loader recognizes ahead of their Epic B impls.
+const BUILTIN_DRIVERS: [&str; 3] = ["memory", "postgres", "redis"];
+
+/// A factory stand-in for an OSS driver whose backend is not implemented yet.
+///
+/// Registering it makes the driver *name* resolvable (so config validation
+/// passes and lists it among the valid names), but building it returns
+/// [`StorageError::Backend`] explaining the backend lands in Epic B.
+struct NotImplemented {
+    driver: &'static str,
+}
+
+impl NotImplemented {
+    fn unimplemented<T>(&self) -> Result<T> {
+        Err(StorageError::Backend(format!(
+            "storage driver {:?} is not implemented yet (ships in Epic B)",
+            self.driver
+        )))
+    }
+}
+
+impl PolicyStoreFactory for NotImplemented {
+    fn build(&self, _config: &toml::Value) -> Result<Arc<dyn PolicyStore>> {
+        self.unimplemented()
+    }
+}
+
+impl AuditSinkFactory for NotImplemented {
+    fn build(&self, _config: &toml::Value) -> Result<Arc<dyn AuditSink>> {
+        self.unimplemented()
+    }
+}
+
+impl SessionStoreFactory for NotImplemented {
+    fn build(&self, _config: &toml::Value) -> Result<Arc<dyn SessionStore>> {
+        self.unimplemented()
+    }
+}
+
+impl CredentialStoreFactory for NotImplemented {
+    fn build(&self, _config: &toml::Value) -> Result<Arc<dyn CredentialStore>> {
+        self.unimplemented()
+    }
+}
+
+impl RateLimitCounterFactory for NotImplemented {
+    fn build(&self, _config: &toml::Value) -> Result<Arc<dyn RateLimitCounter>> {
+        self.unimplemented()
+    }
+}
+
+impl LifecycleStoreFactory for NotImplemented {
+    fn build(&self, _config: &toml::Value) -> Result<Arc<dyn LifecycleStore>> {
+        self.unimplemented()
+    }
+}
+
+/// Register the placeholder OSS drivers (`memory`, `redis`, `postgres`) for
+/// every storage kind.
+///
+/// This is the manual `register_drivers()`-at-boot hook the design calls for;
+/// Epic B replaces each placeholder with the real driver crate's `register`
+/// call.
+pub fn register_builtin_drivers(registry: &mut Registry) {
+    for driver in BUILTIN_DRIVERS {
+        registry.register_policy_store(driver, Box::new(NotImplemented { driver }));
+        registry.register_audit_sink(driver, Box::new(NotImplemented { driver }));
+        registry.register_session_store(driver, Box::new(NotImplemented { driver }));
+        registry.register_credential_store(driver, Box::new(NotImplemented { driver }));
+        registry.register_rate_limit_counter(driver, Box::new(NotImplemented { driver }));
+        registry.register_lifecycle_store(driver, Box::new(NotImplemented { driver }));
+    }
+}

--- a/aa-storage/src/config.rs
+++ b/aa-storage/src/config.rs
@@ -1,0 +1,60 @@
+//! [`StorageConfig`] — the `[storage]` section of `agent-assembly.toml`.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::DriverName;
+
+/// The `[storage]` section: which driver backs each storage kind, plus the
+/// per-driver connection subsections.
+///
+/// ```toml
+/// [storage]
+/// policy_store       = "redis"
+/// audit_sink         = "postgres"
+/// session_store      = "redis"
+/// credential_store   = "postgres"
+/// rate_limit_counter = "redis"
+/// lifecycle_store    = "postgres"
+///
+/// [storage.redis]
+/// url = "redis://localhost:6379"
+///
+/// [storage.postgres]
+/// url = "postgresql://localhost:5432/assembly"
+/// ```
+///
+/// The six driver-kind keys select a backend by [`DriverName`]; every other key
+/// under `[storage]` is a `[storage.<name>]` table captured into [`drivers`]
+/// and handed verbatim to that driver's factory.
+///
+/// [`drivers`]: StorageConfig::drivers
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageConfig {
+    /// Driver backing the [`PolicyStore`](crate::PolicyStore).
+    pub policy_store: DriverName,
+    /// Driver backing the [`AuditSink`](crate::AuditSink).
+    pub audit_sink: DriverName,
+    /// Driver backing the [`SessionStore`](crate::SessionStore).
+    pub session_store: DriverName,
+    /// Driver backing the [`CredentialStore`](crate::CredentialStore).
+    pub credential_store: DriverName,
+    /// Driver backing the [`RateLimitCounter`](crate::RateLimitCounter).
+    pub rate_limit_counter: DriverName,
+    /// Driver backing the [`LifecycleStore`](crate::LifecycleStore).
+    pub lifecycle_store: DriverName,
+    /// Per-driver `[storage.<name>]` subsections, keyed by driver name.
+    ///
+    /// Each value is the raw TOML table for that driver; the driver's own
+    /// factory parses the keys it needs.
+    #[serde(flatten)]
+    pub drivers: HashMap<DriverName, toml::Value>,
+}
+
+impl StorageConfig {
+    /// Return the `[storage.<name>]` subsection for `name`, if present.
+    pub fn driver_section(&self, name: &DriverName) -> Option<&toml::Value> {
+        self.drivers.get(name)
+    }
+}

--- a/aa-storage/src/driver_name.rs
+++ b/aa-storage/src/driver_name.rs
@@ -1,0 +1,54 @@
+//! [`DriverName`] — the string identifier that selects a storage backend.
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Name of a storage driver as written in `agent-assembly.toml`
+/// (e.g. `"redis"`, `"postgres"`, `"memory"`).
+///
+/// A `DriverName` is the key the [`Registry`](crate::Registry) resolves to a
+/// concrete backend factory, and also the key of the per-driver
+/// `[storage.<name>]` subsection. It is a thin, transparent newtype over
+/// [`String`] so it deserializes directly from a TOML string and can be used as
+/// a map key.
+///
+/// ```
+/// use aa_storage::DriverName;
+///
+/// let name = DriverName::new("redis");
+/// assert_eq!(name.as_str(), "redis");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct DriverName(String);
+
+impl DriverName {
+    /// Create a `DriverName` from anything string-like.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+
+    /// Borrow the underlying driver name as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for DriverName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for DriverName {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+impl From<String> for DriverName {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}

--- a/aa-storage/src/error.rs
+++ b/aa-storage/src/error.rs
@@ -1,0 +1,42 @@
+//! [`ConfigError`] — failures raised while resolving storage drivers from config.
+
+/// Error returned when a `[storage]` configuration cannot be resolved against
+/// the driver [`Registry`](crate::Registry).
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ConfigError {
+    /// A driver name in `[storage]` is not registered for its kind.
+    ///
+    /// `available` lists every driver name registered for `kind`, so the
+    /// operator can see the valid choices in the error message.
+    #[error("unknown {kind} driver {name:?}; available drivers: [{}]", available.join(", "))]
+    UnknownDriver {
+        /// The storage-kind key that named the driver (e.g. `"policy_store"`).
+        kind: &'static str,
+        /// The unrecognized driver name from the config.
+        name: String,
+        /// Driver names registered for this kind, in sorted order.
+        available: Vec<String>,
+    },
+
+    /// A driver was named but its `[storage.<name>]` subsection is missing.
+    #[error("driver {name:?} (selected for {kind}) has no [storage.{name}] subsection")]
+    MissingDriverSection {
+        /// The storage-kind key that named the driver.
+        kind: &'static str,
+        /// The driver name whose subsection is absent.
+        name: String,
+    },
+
+    /// The driver's factory failed to build the backend from its subsection.
+    #[error("failed to build {kind} driver {name:?}: {source}")]
+    Build {
+        /// The storage-kind key that named the driver.
+        kind: &'static str,
+        /// The driver name being built.
+        name: String,
+        /// The underlying backend error.
+        #[source]
+        source: crate::StorageError,
+    },
+}

--- a/aa-storage/src/factory.rs
+++ b/aa-storage/src/factory.rs
@@ -1,0 +1,46 @@
+//! Factory traits that build a storage backend from its TOML subsection.
+//!
+//! A driver crate implements the factory for each storage kind it provides and
+//! registers it on the [`Registry`](crate::Registry). The loader then calls the
+//! factory with the driver's `[storage.<name>]` subsection (as a
+//! [`toml::Value`]) to construct the trait object.
+
+use std::sync::Arc;
+
+use crate::{AuditSink, CredentialStore, LifecycleStore, PolicyStore, RateLimitCounter, Result, SessionStore};
+
+/// Builds a [`PolicyStore`] from its `[storage.<name>]` TOML subsection.
+pub trait PolicyStoreFactory: Send + Sync {
+    /// Construct the policy-store backend from its config subsection.
+    fn build(&self, config: &toml::Value) -> Result<Arc<dyn PolicyStore>>;
+}
+
+/// Builds an [`AuditSink`] from its `[storage.<name>]` TOML subsection.
+pub trait AuditSinkFactory: Send + Sync {
+    /// Construct the audit-sink backend from its config subsection.
+    fn build(&self, config: &toml::Value) -> Result<Arc<dyn AuditSink>>;
+}
+
+/// Builds a [`SessionStore`] from its `[storage.<name>]` TOML subsection.
+pub trait SessionStoreFactory: Send + Sync {
+    /// Construct the session-store backend from its config subsection.
+    fn build(&self, config: &toml::Value) -> Result<Arc<dyn SessionStore>>;
+}
+
+/// Builds a [`CredentialStore`] from its `[storage.<name>]` TOML subsection.
+pub trait CredentialStoreFactory: Send + Sync {
+    /// Construct the credential-store backend from its config subsection.
+    fn build(&self, config: &toml::Value) -> Result<Arc<dyn CredentialStore>>;
+}
+
+/// Builds a [`RateLimitCounter`] from its `[storage.<name>]` TOML subsection.
+pub trait RateLimitCounterFactory: Send + Sync {
+    /// Construct the rate-limit-counter backend from its config subsection.
+    fn build(&self, config: &toml::Value) -> Result<Arc<dyn RateLimitCounter>>;
+}
+
+/// Builds a [`LifecycleStore`] from its `[storage.<name>]` TOML subsection.
+pub trait LifecycleStoreFactory: Send + Sync {
+    /// Construct the lifecycle-store backend from its config subsection.
+    fn build(&self, config: &toml::Value) -> Result<Arc<dyn LifecycleStore>>;
+}

--- a/aa-storage/src/lib.rs
+++ b/aa-storage/src/lib.rs
@@ -28,3 +28,16 @@
 #![warn(missing_docs)]
 
 pub use aa_core::storage::*;
+
+pub mod builtin;
+pub mod factory;
+
+mod config;
+mod driver_name;
+mod error;
+mod registry;
+
+pub use config::StorageConfig;
+pub use driver_name::DriverName;
+pub use error::ConfigError;
+pub use registry::Registry;

--- a/aa-storage/src/registry.rs
+++ b/aa-storage/src/registry.rs
@@ -236,3 +236,172 @@ impl Registry {
             })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::factory::{
+        AuditSinkFactory, CredentialStoreFactory, LifecycleStoreFactory, RateLimitCounterFactory, SessionStoreFactory,
+    };
+    use crate::{AgentId, PolicyDocument, StorageError};
+
+    /// A policy store that exists only so a factory has something to return.
+    struct FakePolicyStore;
+
+    #[async_trait::async_trait]
+    impl PolicyStore for FakePolicyStore {
+        async fn get_policy(&self, _agent_id: &AgentId) -> crate::Result<PolicyDocument> {
+            Err(StorageError::NotFound("fake".into()))
+        }
+        async fn invalidate(&self, _agent_id: &AgentId) -> crate::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// One factory registerable for every kind. Only the policy-store build is
+    /// exercised; the other kinds only need to be *present* for `validate`.
+    struct FakeFactory;
+
+    impl PolicyStoreFactory for FakeFactory {
+        fn build(&self, _config: &toml::Value) -> crate::Result<Arc<dyn PolicyStore>> {
+            Ok(Arc::new(FakePolicyStore))
+        }
+    }
+    macro_rules! unused_factory {
+        ($trait:ident, $store:ident) => {
+            impl $trait for FakeFactory {
+                fn build(&self, _config: &toml::Value) -> crate::Result<Arc<dyn crate::$store>> {
+                    Err(StorageError::Backend("unused in tests".into()))
+                }
+            }
+        };
+    }
+    unused_factory!(AuditSinkFactory, AuditSink);
+    unused_factory!(SessionStoreFactory, SessionStore);
+    unused_factory!(CredentialStoreFactory, CredentialStore);
+    unused_factory!(RateLimitCounterFactory, RateLimitCounter);
+    unused_factory!(LifecycleStoreFactory, LifecycleStore);
+
+    /// Registry with the `"memory"` driver registered for every kind.
+    fn registry_with_memory() -> Registry {
+        let mut r = Registry::new();
+        r.register_policy_store("memory", Box::new(FakeFactory));
+        r.register_audit_sink("memory", Box::new(FakeFactory));
+        r.register_session_store("memory", Box::new(FakeFactory));
+        r.register_credential_store("memory", Box::new(FakeFactory));
+        r.register_rate_limit_counter("memory", Box::new(FakeFactory));
+        r.register_lifecycle_store("memory", Box::new(FakeFactory));
+        r
+    }
+
+    fn parse(toml_str: &str) -> StorageConfig {
+        toml::from_str(toml_str).expect("fixture parses")
+    }
+
+    const VALID: &str = r#"
+policy_store       = "memory"
+audit_sink         = "memory"
+session_store      = "memory"
+credential_store   = "memory"
+rate_limit_counter = "memory"
+lifecycle_store    = "memory"
+
+[memory]
+flush_every = 100
+"#;
+
+    const UNKNOWN_DRIVER: &str = r#"
+policy_store       = "mongodb"
+audit_sink         = "memory"
+session_store      = "memory"
+credential_store   = "memory"
+rate_limit_counter = "memory"
+lifecycle_store    = "memory"
+
+[memory]
+flush_every = 100
+
+[mongodb]
+url = "mongodb://localhost"
+"#;
+
+    const MISSING_SUBSECTION: &str = r#"
+policy_store       = "memory"
+audit_sink         = "memory"
+session_store      = "memory"
+credential_store   = "memory"
+rate_limit_counter = "memory"
+lifecycle_store    = "memory"
+"#;
+
+    #[test]
+    fn storage_section_flattens_known_keys_and_subsections() {
+        let config = parse(VALID);
+        assert_eq!(config.policy_store.as_str(), "memory");
+        assert_eq!(config.lifecycle_store.as_str(), "memory");
+        // The `[memory]` table is captured as a per-driver subsection.
+        assert!(config.driver_section(&DriverName::new("memory")).is_some());
+    }
+
+    #[test]
+    fn valid_combination_passes_validate_and_builds() {
+        let registry = registry_with_memory();
+        let config = parse(VALID);
+        assert!(registry.validate(&config).is_ok());
+        assert!(registry.build_policy_store(&config).is_ok());
+    }
+
+    #[test]
+    fn unknown_driver_reports_kind_name_and_available() {
+        let registry = registry_with_memory();
+        let config = parse(UNKNOWN_DRIVER);
+        let err = registry.validate(&config).unwrap_err();
+        match err {
+            ConfigError::UnknownDriver { kind, name, available } => {
+                assert_eq!(kind, "policy_store");
+                assert_eq!(name, "mongodb");
+                assert_eq!(available, vec!["memory".to_string()]);
+            }
+            other => panic!("expected UnknownDriver, got {other:?}"),
+        }
+        // The valid names appear in the rendered error message.
+        let rendered = registry.validate(&config).unwrap_err().to_string();
+        assert!(rendered.contains("memory"), "error lists valid names: {rendered}");
+    }
+
+    #[test]
+    fn missing_per_driver_subsection_is_rejected() {
+        let registry = registry_with_memory();
+        let config = parse(MISSING_SUBSECTION);
+        let err = registry.validate(&config).unwrap_err();
+        assert!(
+            matches!(err, ConfigError::MissingDriverSection { ref name, .. } if name == "memory"),
+            "expected MissingDriverSection, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn builtin_registry_accepts_known_oss_driver_names() {
+        let mut registry = Registry::new();
+        crate::builtin::register_builtin_drivers(&mut registry);
+        let config = parse(
+            r#"
+policy_store       = "redis"
+audit_sink         = "postgres"
+session_store      = "redis"
+credential_store   = "postgres"
+rate_limit_counter = "redis"
+lifecycle_store    = "postgres"
+
+[redis]
+url = "redis://localhost:6379"
+
+[postgres]
+url = "postgresql://localhost:5432/assembly"
+"#,
+        );
+        assert!(registry.validate(&config).is_ok());
+        // But building a not-yet-implemented backend surfaces a clear error.
+        assert!(registry.build_policy_store(&config).is_err());
+    }
+}

--- a/aa-storage/src/registry.rs
+++ b/aa-storage/src/registry.rs
@@ -1,0 +1,238 @@
+//! [`Registry`] — maps driver names to backend factories and resolves a
+//! [`StorageConfig`] into concrete stores.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use crate::factory::{
+    AuditSinkFactory, CredentialStoreFactory, LifecycleStoreFactory, PolicyStoreFactory, RateLimitCounterFactory,
+    SessionStoreFactory,
+};
+use crate::{
+    AuditSink, ConfigError, CredentialStore, DriverName, LifecycleStore, PolicyStore, RateLimitCounter, SessionStore,
+    StorageConfig,
+};
+
+/// Registry of storage-driver factories, keyed by [`DriverName`] per kind.
+///
+/// Each driver crate calls the `register_*` methods (typically from a single
+/// `register(&mut Registry)` entry point) to make its backends selectable by
+/// name. The loader then uses [`validate`](Registry::validate) to check a
+/// [`StorageConfig`] and the `build_*` methods to instantiate the chosen stores.
+#[derive(Default)]
+pub struct Registry {
+    policy_stores: BTreeMap<DriverName, Box<dyn PolicyStoreFactory>>,
+    audit_sinks: BTreeMap<DriverName, Box<dyn AuditSinkFactory>>,
+    session_stores: BTreeMap<DriverName, Box<dyn SessionStoreFactory>>,
+    credential_stores: BTreeMap<DriverName, Box<dyn CredentialStoreFactory>>,
+    rate_limit_counters: BTreeMap<DriverName, Box<dyn RateLimitCounterFactory>>,
+    lifecycle_stores: BTreeMap<DriverName, Box<dyn LifecycleStoreFactory>>,
+}
+
+impl Registry {
+    /// Create an empty registry with no drivers registered.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a policy-store driver under `name`.
+    pub fn register_policy_store(&mut self, name: impl Into<DriverName>, factory: Box<dyn PolicyStoreFactory>) {
+        self.policy_stores.insert(name.into(), factory);
+    }
+
+    /// Register an audit-sink driver under `name`.
+    pub fn register_audit_sink(&mut self, name: impl Into<DriverName>, factory: Box<dyn AuditSinkFactory>) {
+        self.audit_sinks.insert(name.into(), factory);
+    }
+
+    /// Register a session-store driver under `name`.
+    pub fn register_session_store(&mut self, name: impl Into<DriverName>, factory: Box<dyn SessionStoreFactory>) {
+        self.session_stores.insert(name.into(), factory);
+    }
+
+    /// Register a credential-store driver under `name`.
+    pub fn register_credential_store(&mut self, name: impl Into<DriverName>, factory: Box<dyn CredentialStoreFactory>) {
+        self.credential_stores.insert(name.into(), factory);
+    }
+
+    /// Register a rate-limit-counter driver under `name`.
+    pub fn register_rate_limit_counter(
+        &mut self,
+        name: impl Into<DriverName>,
+        factory: Box<dyn RateLimitCounterFactory>,
+    ) {
+        self.rate_limit_counters.insert(name.into(), factory);
+    }
+
+    /// Register a lifecycle-store driver under `name`.
+    pub fn register_lifecycle_store(&mut self, name: impl Into<DriverName>, factory: Box<dyn LifecycleStoreFactory>) {
+        self.lifecycle_stores.insert(name.into(), factory);
+    }
+
+    /// Names of all registered policy-store drivers, sorted.
+    pub fn policy_store_names(&self) -> Vec<&str> {
+        self.policy_stores.keys().map(DriverName::as_str).collect()
+    }
+
+    /// Names of all registered audit-sink drivers, sorted.
+    pub fn audit_sink_names(&self) -> Vec<&str> {
+        self.audit_sinks.keys().map(DriverName::as_str).collect()
+    }
+
+    /// Names of all registered session-store drivers, sorted.
+    pub fn session_store_names(&self) -> Vec<&str> {
+        self.session_stores.keys().map(DriverName::as_str).collect()
+    }
+
+    /// Names of all registered credential-store drivers, sorted.
+    pub fn credential_store_names(&self) -> Vec<&str> {
+        self.credential_stores.keys().map(DriverName::as_str).collect()
+    }
+
+    /// Names of all registered rate-limit-counter drivers, sorted.
+    pub fn rate_limit_counter_names(&self) -> Vec<&str> {
+        self.rate_limit_counters.keys().map(DriverName::as_str).collect()
+    }
+
+    /// Names of all registered lifecycle-store drivers, sorted.
+    pub fn lifecycle_store_names(&self) -> Vec<&str> {
+        self.lifecycle_stores.keys().map(DriverName::as_str).collect()
+    }
+
+    /// Check that `name` is registered in `factories` and that `config` carries
+    /// its `[storage.<name>]` subsection.
+    fn check<F: ?Sized>(
+        kind: &'static str,
+        name: &DriverName,
+        factories: &BTreeMap<DriverName, Box<F>>,
+        config: &StorageConfig,
+    ) -> Result<(), ConfigError> {
+        if !factories.contains_key(name) {
+            return Err(ConfigError::UnknownDriver {
+                kind,
+                name: name.to_string(),
+                available: factories.keys().map(DriverName::to_string).collect(),
+            });
+        }
+        if config.driver_section(name).is_none() {
+            return Err(ConfigError::MissingDriverSection {
+                kind,
+                name: name.to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    /// Check every driver named in `config` is registered and has a subsection.
+    ///
+    /// Returns the first [`ConfigError`] encountered. This is the entry point
+    /// behind `aasm config validate`.
+    pub fn validate(&self, config: &StorageConfig) -> Result<(), ConfigError> {
+        Self::check("policy_store", &config.policy_store, &self.policy_stores, config)?;
+        Self::check("audit_sink", &config.audit_sink, &self.audit_sinks, config)?;
+        Self::check("session_store", &config.session_store, &self.session_stores, config)?;
+        Self::check(
+            "credential_store",
+            &config.credential_store,
+            &self.credential_stores,
+            config,
+        )?;
+        Self::check(
+            "rate_limit_counter",
+            &config.rate_limit_counter,
+            &self.rate_limit_counters,
+            config,
+        )?;
+        Self::check(
+            "lifecycle_store",
+            &config.lifecycle_store,
+            &self.lifecycle_stores,
+            config,
+        )?;
+        Ok(())
+    }
+
+    /// Build the configured [`PolicyStore`].
+    pub fn build_policy_store(&self, config: &StorageConfig) -> Result<Arc<dyn PolicyStore>, ConfigError> {
+        let name = &config.policy_store;
+        Self::check("policy_store", name, &self.policy_stores, config)?;
+        let section = config.driver_section(name).expect("subsection checked by `check`");
+        self.policy_stores[name]
+            .build(section)
+            .map_err(|source| ConfigError::Build {
+                kind: "policy_store",
+                name: name.to_string(),
+                source,
+            })
+    }
+
+    /// Build the configured [`AuditSink`].
+    pub fn build_audit_sink(&self, config: &StorageConfig) -> Result<Arc<dyn AuditSink>, ConfigError> {
+        let name = &config.audit_sink;
+        Self::check("audit_sink", name, &self.audit_sinks, config)?;
+        let section = config.driver_section(name).expect("subsection checked by `check`");
+        self.audit_sinks[name]
+            .build(section)
+            .map_err(|source| ConfigError::Build {
+                kind: "audit_sink",
+                name: name.to_string(),
+                source,
+            })
+    }
+
+    /// Build the configured [`SessionStore`].
+    pub fn build_session_store(&self, config: &StorageConfig) -> Result<Arc<dyn SessionStore>, ConfigError> {
+        let name = &config.session_store;
+        Self::check("session_store", name, &self.session_stores, config)?;
+        let section = config.driver_section(name).expect("subsection checked by `check`");
+        self.session_stores[name]
+            .build(section)
+            .map_err(|source| ConfigError::Build {
+                kind: "session_store",
+                name: name.to_string(),
+                source,
+            })
+    }
+
+    /// Build the configured [`CredentialStore`].
+    pub fn build_credential_store(&self, config: &StorageConfig) -> Result<Arc<dyn CredentialStore>, ConfigError> {
+        let name = &config.credential_store;
+        Self::check("credential_store", name, &self.credential_stores, config)?;
+        let section = config.driver_section(name).expect("subsection checked by `check`");
+        self.credential_stores[name]
+            .build(section)
+            .map_err(|source| ConfigError::Build {
+                kind: "credential_store",
+                name: name.to_string(),
+                source,
+            })
+    }
+
+    /// Build the configured [`RateLimitCounter`].
+    pub fn build_rate_limit_counter(&self, config: &StorageConfig) -> Result<Arc<dyn RateLimitCounter>, ConfigError> {
+        let name = &config.rate_limit_counter;
+        Self::check("rate_limit_counter", name, &self.rate_limit_counters, config)?;
+        let section = config.driver_section(name).expect("subsection checked by `check`");
+        self.rate_limit_counters[name]
+            .build(section)
+            .map_err(|source| ConfigError::Build {
+                kind: "rate_limit_counter",
+                name: name.to_string(),
+                source,
+            })
+    }
+
+    /// Build the configured [`LifecycleStore`].
+    pub fn build_lifecycle_store(&self, config: &StorageConfig) -> Result<Arc<dyn LifecycleStore>, ConfigError> {
+        let name = &config.lifecycle_store;
+        Self::check("lifecycle_store", name, &self.lifecycle_stores, config)?;
+        let section = config.driver_section(name).expect("subsection checked by `check`");
+        self.lifecycle_stores[name]
+            .build(section)
+            .map_err(|source| ConfigError::Build {
+                kind: "lifecycle_store",
+                name: name.to_string(),
+                source,
+            })
+    }
+}

--- a/agent-assembly.toml.example
+++ b/agent-assembly.toml.example
@@ -1,0 +1,28 @@
+# agent-assembly.toml — example runtime configuration
+#
+# Validate a copy of this file with:
+#
+#     aasm config validate agent-assembly.toml
+#
+# ---------------------------------------------------------------------------
+# [storage] — persistence backend selection
+# ---------------------------------------------------------------------------
+# Each storage kind picks a driver *by name*. The runtime resolves the name to
+# a registered backend at boot, so you can switch Redis -> Postgres -> memory
+# without recompiling Assembly. The OSS driver names are `memory`, `redis`, and
+# `postgres` (their backends ship in a later milestone).
+[storage]
+policy_store       = "redis"
+audit_sink         = "postgres"
+session_store      = "redis"
+credential_store   = "postgres"
+rate_limit_counter = "redis"
+lifecycle_store    = "postgres"
+
+# Per-driver connection settings live under `[storage.<driver-name>]`. Provide a
+# subsection for every driver named above; each driver parses the keys it needs.
+[storage.redis]
+url = "redis://localhost:6379"
+
+[storage.postgres]
+url = "postgresql://localhost:5432/assembly"


### PR DESCRIPTION
## Description

Implements the storage **driver-selection** layer for Story AAASM-2356 (Epic AAASM-2347): operators choose `policy_store` / `audit_sink` / … drivers in `agent-assembly.toml`, and the runtime resolves them by name through a registry — no recompile to swap backends.

Since there is no `aa-config` crate (and no runtime config struct yet), the schema, registry, factory traits, and error live in **`aa-storage`** — the natural home for "the storage contract + how to pick a driver". The crate stays a pure interface (adds only `serde`/`toml`/`thiserror`; no `sqlx`/`redis`/`tonic`), and no new workspace member is introduced.

What landed:
- `aa-storage`: `DriverName`, `StorageConfig` (six driver-kind keys + flattened `HashMap<DriverName, toml::Value>` of per-driver `[storage.<name>]` subsections), six `*Factory` traits returning `Arc<dyn _>`, a `Registry` with `register_*` / `validate` / `build_*`, and `ConfigError::UnknownDriver { kind, name, available }` (+ `MissingDriverSection`, `Build`).
- `register_builtin_drivers()` registers the planned OSS names (`memory`/`redis`/`postgres`) so the loader recognizes them and lists them as valid; *building* one returns a clear "not implemented (Epic B)" error.
- `aa-cli`: `aasm config validate <file>` surfaces the typed error and exit code.
- `agent-assembly.toml.example` documents the `[storage]` schema.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2361 (Story AAASM-2356, Epic AAASM-2347)

## Testing

- [x] Unit tests added / updated
- [x] Manual testing performed

`cargo nextest run -p aa-storage` (8 passed) covers the three fixture cases — valid combination validates + builds, unknown driver reports kind/name/available, missing `[storage.<name>]` subsection is rejected — plus `register_builtin_drivers` accepting the known OSS names. `cargo nextest run -p aa-cli` config tests (4 passed) drive `aasm config validate` over committed fixtures. Manual run against the example + fixtures:

```
$ aasm config validate agent-assembly.toml.example
Config is valid: agent-assembly.toml.example
$ aasm config validate aa-cli/tests/fixtures/storage_unknown_driver.toml
error: unknown policy_store driver "mongodb"; available drivers: [memory, postgres, redis]
$ aasm config validate aa-cli/tests/fixtures/storage_missing_subsection.toml
error: driver "redis" (selected for policy_store) has no [storage.redis] subsection
```

## Out of scope

- Concrete driver implementations (Epic B) and enterprise `driver = "gateway"` (Epic E).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
