### PR TITLE
[AAASM-2379] ✨ (aa-cache): Add DashMap L1 cache wrapper with TTL + stampede protection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aa-cache"
+version = "0.0.1-alpha.5"
+dependencies = [
+ "aa-core",
+ "async-trait",
+ "dashmap",
+ "tokio",
+]
+
+[[package]]
 name = "aa-cli"
 version = "0.0.1-alpha.5"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,8 +57,10 @@ dependencies = [
 name = "aa-cache"
 version = "0.0.1-alpha.5"
 dependencies = [
+ "aa-cache",
  "aa-core",
  "async-trait",
+ "criterion",
  "dashmap",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "aa-core",
     "aa-storage",
+    "aa-cache",
     "aa-proto",
     "aa-runtime",
     "aa-ebpf",

--- a/aa-cache/Cargo.toml
+++ b/aa-cache/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "aa-cache"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "In-process L1 cache wrapper (DashMap + TTL + stampede protection) for the Agent Assembly storage traits"
+
+[dependencies]
+aa-core = { path = "../aa-core" }
+async-trait = "0.1"
+dashmap = "6"
+tokio = { version = "1", features = ["sync"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+
+[features]
+# Exposes the in-memory `MemoryPolicyStore` test/bench double. Off by default so
+# downstream consumers never pull the test scaffolding; enabled for this crate's
+# own benches via the self dev-dependency below.
+test-utils = ["tokio/time"]
+
+[lints]
+workspace = true

--- a/aa-cache/Cargo.toml
+++ b/aa-cache/Cargo.toml
@@ -13,13 +13,21 @@ dashmap = "6"
 tokio = { version = "1", features = ["sync"] }
 
 [dev-dependencies]
+criterion = { version = "0.8", features = ["async_tokio"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+# Self dev-dependency: turns on `test-utils` for this crate's own bench build so
+# `MemoryPolicyStore` is available, without exposing it to downstream consumers.
+aa-cache = { path = ".", features = ["test-utils"] }
 
 [features]
 # Exposes the in-memory `MemoryPolicyStore` test/bench double. Off by default so
 # downstream consumers never pull the test scaffolding; enabled for this crate's
 # own benches via the self dev-dependency below.
 test-utils = ["tokio/time"]
+
+[[bench]]
+name = "l1_hit"
+harness = false
 
 [lints]
 workspace = true

--- a/aa-cache/benches/l1_hit.rs
+++ b/aa-cache/benches/l1_hit.rs
@@ -1,0 +1,46 @@
+//! Criterion benchmark: L1 cache hit latency vs the raw store (AAASM-2379).
+//!
+//! `l1_hit_warm` measures a warm `L1Cache` hit — the tool-call critical path —
+//! and must land in the sub-microsecond range. `raw_memory_store` is the
+//! baseline: the same `MemoryPolicyStore::get_policy` the cache fronts, shown
+//! alongside so the cache's per-call cost is visible against the unwrapped store.
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use aa_cache::testing::{sample_policy, MemoryPolicyStore};
+use aa_cache::L1Cache;
+use aa_core::storage::{AgentId, PolicyStore};
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn bench_l1_hit(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+    let id = AgentId::from_bytes([7; 16]);
+
+    // Warm the L1 cache: one load, after which every `get` is an in-memory hit.
+    let cache = L1Cache::new(
+        MemoryPolicyStore::with_policy(id, sample_policy(1)),
+        Duration::from_secs(3600),
+    );
+    rt.block_on(async { cache.get(id).await.expect("warm load") });
+
+    // Raw baseline store, fronted by no cache.
+    let raw = MemoryPolicyStore::with_policy(id, sample_policy(1));
+
+    let mut group = c.benchmark_group("l1_cache");
+    group.bench_function("l1_hit_warm", |b| {
+        b.to_async(&rt)
+            .iter(|| async { black_box(cache.get(black_box(id)).await.expect("hit")) });
+    });
+    group.bench_function("raw_memory_store", |b| {
+        b.to_async(&rt)
+            .iter(|| async { black_box(raw.get_policy(black_box(&id)).await.expect("present")) });
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench_l1_hit);
+criterion_main!(benches);

--- a/aa-cache/src/cached_value.rs
+++ b/aa-cache/src/cached_value.rs
@@ -1,0 +1,32 @@
+//! [`CachedValue`] — a cache entry tagged with its insertion instant.
+
+use std::time::{Duration, Instant};
+
+/// A value stored in the L1 cache together with the [`Instant`] it was inserted.
+///
+/// The insertion time drives TTL expiry: an entry older than the cache's
+/// configured TTL is treated as a miss, forcing a reload from the wrapped store.
+#[derive(Debug, Clone)]
+pub struct CachedValue<V> {
+    /// The cached value.
+    pub value: V,
+    /// When this entry was inserted.
+    pub inserted_at: Instant,
+}
+
+impl<V> CachedValue<V> {
+    /// Wrap `value`, stamping it with the current instant.
+    #[must_use]
+    pub fn new(value: V) -> Self {
+        Self {
+            value,
+            inserted_at: Instant::now(),
+        }
+    }
+
+    /// Return `true` once the entry's age has reached or exceeded `ttl`.
+    #[must_use]
+    pub fn is_expired(&self, ttl: Duration) -> bool {
+        self.inserted_at.elapsed() >= ttl
+    }
+}

--- a/aa-cache/src/l1.rs
+++ b/aa-cache/src/l1.rs
@@ -179,4 +179,25 @@ mod tests {
         cache.get(id).await.expect("policy present");
         assert_eq!(cache.inner().call_count(), 2);
     }
+
+    #[tokio::test]
+    async fn invalidate_evicts_the_cached_entry() {
+        let id = agent(3);
+        let store = MemoryPolicyStore::with_policy(id, sample_policy(1));
+        let cache = L1Cache::new(store, Duration::from_secs(60));
+
+        cache.get(id).await.expect("policy present");
+        assert_eq!(cache.len(), 1);
+
+        // Invalidate removes the entry and reports it was present.
+        assert!(cache.invalidate(&id));
+        assert_eq!(cache.len(), 0);
+
+        // Invalidating the now-absent key reports nothing was removed.
+        assert!(!cache.invalidate(&id));
+
+        // The next get is a fresh miss that reloads from the store.
+        cache.get(id).await.expect("policy present");
+        assert_eq!(cache.inner().call_count(), 2);
+    }
 }

--- a/aa-cache/src/l1.rs
+++ b/aa-cache/src/l1.rs
@@ -133,3 +133,35 @@ impl<S: CacheSource> L1Cache<S> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use aa_core::storage::AgentId;
+
+    use crate::testing::{sample_policy, MemoryPolicyStore};
+    use crate::L1Cache;
+
+    fn agent(seed: u8) -> AgentId {
+        AgentId::from_bytes([seed; 16])
+    }
+
+    #[tokio::test]
+    async fn miss_populates_then_serves_from_cache() {
+        let id = agent(1);
+        let store = MemoryPolicyStore::with_policy(id, sample_policy(1));
+        let cache = L1Cache::new(store, Duration::from_secs(60));
+
+        // First get is a miss: hits the store and populates the cache.
+        let first = cache.get(id).await.expect("policy present");
+        assert_eq!(first.version, 1);
+        assert_eq!(cache.inner().call_count(), 1);
+        assert_eq!(cache.len(), 1);
+
+        // Second get is a hit: served from memory, the store is not touched again.
+        let second = cache.get(id).await.expect("policy present");
+        assert_eq!(second.version, 1);
+        assert_eq!(cache.inner().call_count(), 1);
+    }
+}

--- a/aa-cache/src/l1.rs
+++ b/aa-cache/src/l1.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use aa_core::storage::Result;
+use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
+use tokio::sync::Notify;
 
 use crate::cached_value::CachedValue;
 use crate::source::CacheSource;
@@ -13,10 +15,13 @@ use crate::source::CacheSource;
 ///
 /// `get` serves fresh keys from memory and falls back to the wrapped store on a
 /// miss or once an entry's TTL elapses, repopulating the cache on the way out
-/// (cache-aside).
+/// (cache-aside). Concurrent misses for the same key collapse to a single
+/// `load` call (stampede protection), so a burst of cold lookups never fans out
+/// into N backend round-trips.
 pub struct L1Cache<S: CacheSource> {
     inner: S,
     entries: Arc<DashMap<S::Key, CachedValue<S::Value>>>,
+    inflight: Arc<DashMap<S::Key, Arc<Notify>>>,
     ttl: Duration,
 }
 
@@ -26,6 +31,7 @@ impl<S: CacheSource> L1Cache<S> {
         Self {
             inner,
             entries: Arc::new(DashMap::new()),
+            inflight: Arc::new(DashMap::new()),
             ttl,
         }
     }
@@ -49,12 +55,54 @@ impl<S: CacheSource> L1Cache<S> {
     ///
     /// Cache-aside: a hit clones out of the `DashMap`; a miss (or an expired
     /// entry) loads from the wrapped store, populates the cache, and returns.
+    ///
+    /// Stampede protection: the first caller to miss a key becomes the *leader*
+    /// and performs the single `load`; concurrent callers become *followers*,
+    /// wait on a shared [`Notify`], then re-read the now-populated cache. The
+    /// inner store therefore sees exactly one call per key per miss window.
     pub async fn get(&self, key: S::Key) -> Result<S::Value> {
-        if let Some(value) = self.fresh(&key) {
-            return Ok(value);
+        loop {
+            // Fast path: a fresh cache hit needs no coordination.
+            if let Some(value) = self.fresh(&key) {
+                return Ok(value);
+            }
+
+            // Miss: claim leadership for this key, or grab the in-flight signal.
+            let follower = match self.inflight.entry(key.clone()) {
+                Entry::Vacant(slot) => {
+                    slot.insert(Arc::new(Notify::new()));
+                    None
+                }
+                Entry::Occupied(slot) => Some(slot.get().clone()),
+            };
+
+            match follower {
+                // Leader: load once, populate, then wake every waiter.
+                None => {
+                    let result = self.inner.load(&key).await;
+                    if let Ok(ref value) = result {
+                        self.entries.insert(key.clone(), CachedValue::new(value.clone()));
+                    }
+                    if let Some((_, notify)) = self.inflight.remove(&key) {
+                        notify.notify_waiters();
+                    }
+                    return result;
+                }
+                // Follower: wait for the leader, then retry the loop.
+                Some(notify) => {
+                    let waiter = notify.notified();
+                    tokio::pin!(waiter);
+                    // Register before re-checking the cache so the leader's
+                    // notification can't be missed (tokio::sync::Notify pattern):
+                    // the leader always populates `entries` before notifying, so
+                    // either the re-check sees the value or the wait is woken.
+                    waiter.as_mut().enable();
+                    if let Some(value) = self.fresh(&key) {
+                        return Ok(value);
+                    }
+                    waiter.await;
+                }
+            }
         }
-        let value = self.inner.load(&key).await?;
-        self.entries.insert(key, CachedValue::new(value.clone()));
-        Ok(value)
     }
 }

--- a/aa-cache/src/l1.rs
+++ b/aa-cache/src/l1.rs
@@ -200,4 +200,29 @@ mod tests {
         cache.get(id).await.expect("policy present");
         assert_eq!(cache.inner().call_count(), 2);
     }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_misses_collapse_to_one_load() {
+        use std::sync::Arc;
+
+        let id = agent(4);
+        // A 50ms inner delay holds the leader long enough for all followers to
+        // pile up behind it before it finishes loading.
+        let store = MemoryPolicyStore::with_policy(id, sample_policy(7)).with_delay(Duration::from_millis(50));
+        let cache = Arc::new(L1Cache::new(store, Duration::from_secs(60)));
+
+        // Fire 100 concurrent gets for the same cold key.
+        let mut handles = Vec::with_capacity(100);
+        for _ in 0..100 {
+            let cache = Arc::clone(&cache);
+            handles.push(tokio::spawn(async move { cache.get(id).await }));
+        }
+        for handle in handles {
+            let policy = handle.await.expect("task joined").expect("policy present");
+            assert_eq!(policy.version, 7);
+        }
+
+        // Every miss collapsed onto a single inner load.
+        assert_eq!(cache.inner().call_count(), 1);
+    }
 }

--- a/aa-cache/src/l1.rs
+++ b/aa-cache/src/l1.rs
@@ -1,0 +1,60 @@
+//! [`L1Cache`] — a `DashMap`-backed, TTL'd, cache-aside wrapper over a store.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use aa_core::storage::Result;
+use dashmap::DashMap;
+
+use crate::cached_value::CachedValue;
+use crate::source::CacheSource;
+
+/// In-process L1 cache that fronts a [`CacheSource`] with a [`DashMap`].
+///
+/// `get` serves fresh keys from memory and falls back to the wrapped store on a
+/// miss or once an entry's TTL elapses, repopulating the cache on the way out
+/// (cache-aside).
+pub struct L1Cache<S: CacheSource> {
+    inner: S,
+    entries: Arc<DashMap<S::Key, CachedValue<S::Value>>>,
+    ttl: Duration,
+}
+
+impl<S: CacheSource> L1Cache<S> {
+    /// Wrap `inner`, expiring cached entries `ttl` after insertion.
+    pub fn new(inner: S, ttl: Duration) -> Self {
+        Self {
+            inner,
+            entries: Arc::new(DashMap::new()),
+            ttl,
+        }
+    }
+
+    /// Borrow the wrapped store.
+    pub fn inner(&self) -> &S {
+        &self.inner
+    }
+
+    /// Return a fresh (non-expired) cached value for `key`, if present.
+    fn fresh(&self, key: &S::Key) -> Option<S::Value> {
+        let entry = self.entries.get(key)?;
+        if entry.is_expired(self.ttl) {
+            None
+        } else {
+            Some(entry.value.clone())
+        }
+    }
+
+    /// Fetch the value for `key`, serving from cache when fresh.
+    ///
+    /// Cache-aside: a hit clones out of the `DashMap`; a miss (or an expired
+    /// entry) loads from the wrapped store, populates the cache, and returns.
+    pub async fn get(&self, key: S::Key) -> Result<S::Value> {
+        if let Some(value) = self.fresh(&key) {
+            return Ok(value);
+        }
+        let value = self.inner.load(&key).await?;
+        self.entries.insert(key, CachedValue::new(value.clone()));
+        Ok(value)
+    }
+}

--- a/aa-cache/src/l1.rs
+++ b/aa-cache/src/l1.rs
@@ -41,6 +41,15 @@ impl<S: CacheSource> L1Cache<S> {
         &self.inner
     }
 
+    /// Drop the cached entry for `key`; returns whether one was present.
+    ///
+    /// This is the hook the Epic C push-invalidation channel calls when the
+    /// Gateway reports that an agent's policy changed: the next `get` reloads
+    /// from the source of truth rather than serving a stale entry.
+    pub fn invalidate(&self, key: &S::Key) -> bool {
+        self.entries.remove(key).is_some()
+    }
+
     /// Return a fresh (non-expired) cached value for `key`, if present.
     fn fresh(&self, key: &S::Key) -> Option<S::Value> {
         let entry = self.entries.get(key)?;

--- a/aa-cache/src/l1.rs
+++ b/aa-cache/src/l1.rs
@@ -41,6 +41,24 @@ impl<S: CacheSource> L1Cache<S> {
         &self.inner
     }
 
+    /// Number of entries currently held (including any past their TTL but not
+    /// yet evicted). Intended for diagnostics, not control flow.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the cache holds no entries.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Drop every cached entry.
+    pub fn clear(&self) {
+        self.entries.clear();
+    }
+
     /// Drop the cached entry for `key`; returns whether one was present.
     ///
     /// This is the hook the Epic C push-invalidation channel calls when the

--- a/aa-cache/src/l1.rs
+++ b/aa-cache/src/l1.rs
@@ -164,4 +164,19 @@ mod tests {
         assert_eq!(second.version, 1);
         assert_eq!(cache.inner().call_count(), 1);
     }
+
+    #[tokio::test]
+    async fn expired_entry_is_treated_as_a_miss() {
+        let id = agent(2);
+        let store = MemoryPolicyStore::with_policy(id, sample_policy(1));
+        let cache = L1Cache::new(store, Duration::from_millis(20));
+
+        cache.get(id).await.expect("policy present");
+        assert_eq!(cache.inner().call_count(), 1);
+
+        // Let the entry age past its TTL; the next get must reload from the store.
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        cache.get(id).await.expect("policy present");
+        assert_eq!(cache.inner().call_count(), 2);
+    }
 }

--- a/aa-cache/src/lib.rs
+++ b/aa-cache/src/lib.rs
@@ -12,3 +12,7 @@
 //!
 //! Invalidation (this is what the Epic C push-invalidation channel will call)
 //! is provided by [`L1Cache::invalidate`].
+
+mod cached_value;
+
+pub use cached_value::CachedValue;

--- a/aa-cache/src/lib.rs
+++ b/aa-cache/src/lib.rs
@@ -17,6 +17,9 @@ mod cached_value;
 mod l1;
 mod source;
 
+#[cfg(any(test, feature = "test-utils"))]
+pub mod testing;
+
 pub use cached_value::CachedValue;
 pub use l1::L1Cache;
 pub use source::CacheSource;

--- a/aa-cache/src/lib.rs
+++ b/aa-cache/src/lib.rs
@@ -14,5 +14,7 @@
 //! is provided by [`L1Cache::invalidate`].
 
 mod cached_value;
+mod source;
 
 pub use cached_value::CachedValue;
+pub use source::CacheSource;

--- a/aa-cache/src/lib.rs
+++ b/aa-cache/src/lib.rs
@@ -14,7 +14,9 @@
 //! is provided by [`L1Cache::invalidate`].
 
 mod cached_value;
+mod l1;
 mod source;
 
 pub use cached_value::CachedValue;
+pub use l1::L1Cache;
 pub use source::CacheSource;

--- a/aa-cache/src/lib.rs
+++ b/aa-cache/src/lib.rs
@@ -1,0 +1,14 @@
+//! In-process **L1 cache** for the Agent Assembly storage layer.
+//!
+//! Policy is queried on the tool-call critical path, so a backend round-trip
+//! (Postgres or Gateway) per call is too expensive. [`L1Cache`] wraps any store
+//! behind an in-process [`DashMap`](dashmap::DashMap) with a configurable TTL and
+//! per-key stampede protection, so hot lookups hit memory and never cross the
+//! network.
+//!
+//! The wrapped store is abstracted by the [`CacheSource`] trait, which is
+//! blanket-implemented for [`aa_core::storage::PolicyStore`]; the cache itself is
+//! agnostic to which store it fronts.
+//!
+//! Invalidation (this is what the Epic C push-invalidation channel will call)
+//! is provided by [`L1Cache::invalidate`].

--- a/aa-cache/src/source.rs
+++ b/aa-cache/src/source.rs
@@ -2,7 +2,7 @@
 
 use std::hash::Hash;
 
-use aa_core::storage::Result;
+use aa_core::storage::{AgentId, PolicyDocument, PolicyStore, Result};
 use async_trait::async_trait;
 
 /// The backing store an [`L1Cache`](crate::L1Cache) fronts.
@@ -21,4 +21,16 @@ pub trait CacheSource: Send + Sync {
 
     /// Load the value for `key` from the underlying store.
     async fn load(&self, key: &Self::Key) -> Result<Self::Value>;
+}
+
+/// Every [`PolicyStore`] is a [`CacheSource`] keyed by [`AgentId`] returning a
+/// [`PolicyDocument`], so `L1Cache<P>` fronts any policy backend directly.
+#[async_trait]
+impl<P: PolicyStore> CacheSource for P {
+    type Key = AgentId;
+    type Value = PolicyDocument;
+
+    async fn load(&self, key: &AgentId) -> Result<PolicyDocument> {
+        self.get_policy(key).await
+    }
 }

--- a/aa-cache/src/source.rs
+++ b/aa-cache/src/source.rs
@@ -1,0 +1,24 @@
+//! [`CacheSource`] — the store an [`L1Cache`](crate::L1Cache) loads from on a miss.
+
+use std::hash::Hash;
+
+use aa_core::storage::Result;
+use async_trait::async_trait;
+
+/// The backing store an [`L1Cache`](crate::L1Cache) fronts.
+///
+/// Abstracts "load the value for a key" so the cache is generic over any store —
+/// `PolicyStore`, `SessionStore`, `CredentialStore`, … — without depending on a
+/// concrete one. The associated [`Key`](CacheSource::Key) and
+/// [`Value`](CacheSource::Value) become the cache's key and cached value types.
+#[async_trait]
+pub trait CacheSource: Send + Sync {
+    /// The key the source is addressed by; also the cache key.
+    type Key: Eq + Hash + Clone + Send + Sync;
+
+    /// The value the source returns; cloned out of the cache on a hit.
+    type Value: Clone + Send + Sync;
+
+    /// Load the value for `key` from the underlying store.
+    async fn load(&self, key: &Self::Key) -> Result<Self::Value>;
+}

--- a/aa-cache/src/testing.rs
+++ b/aa-cache/src/testing.rs
@@ -1,0 +1,88 @@
+//! In-memory test/bench doubles for the storage traits.
+//!
+//! Gated behind the `test-utils` feature (and always available under `cfg(test)`)
+//! so production builds never pull the scaffolding.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use aa_core::policy::EnforcementMode;
+use aa_core::storage::{AgentId, PolicyDocument, PolicyStore, Result, StorageError};
+use async_trait::async_trait;
+
+/// Build a throwaway [`PolicyDocument`] with the given schema version.
+#[must_use]
+pub fn sample_policy(version: u32) -> PolicyDocument {
+    PolicyDocument {
+        version,
+        name: "sample".to_owned(),
+        rules: Vec::new(),
+        enforcement_mode: EnforcementMode::default(),
+    }
+}
+
+/// An in-memory [`PolicyStore`] for tests and benchmarks.
+///
+/// Counts `get_policy` calls (so stampede tests can assert "exactly one inner
+/// call") and supports an artificial per-call delay (to widen the stampede
+/// window deterministically).
+#[derive(Default)]
+pub struct MemoryPolicyStore {
+    policies: HashMap<[u8; 16], PolicyDocument>,
+    calls: AtomicUsize,
+    delay: Option<Duration>,
+}
+
+impl MemoryPolicyStore {
+    /// An empty store with no policies and no artificial delay.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A store seeded with a single `agent_id -> policy` mapping.
+    #[must_use]
+    pub fn with_policy(agent_id: AgentId, policy: PolicyDocument) -> Self {
+        let mut store = Self::new();
+        store.insert(agent_id, policy);
+        store
+    }
+
+    /// Seed or overwrite the policy for `agent_id`.
+    pub fn insert(&mut self, agent_id: AgentId, policy: PolicyDocument) {
+        self.policies.insert(*agent_id.as_bytes(), policy);
+    }
+
+    /// Make every `get_policy` sleep `delay` before returning, widening the
+    /// window in which concurrent callers pile up behind the cache leader.
+    #[must_use]
+    pub fn with_delay(mut self, delay: Duration) -> Self {
+        self.delay = Some(delay);
+        self
+    }
+
+    /// Number of `get_policy` calls served so far.
+    #[must_use]
+    pub fn call_count(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl PolicyStore for MemoryPolicyStore {
+    async fn get_policy(&self, agent_id: &AgentId) -> Result<PolicyDocument> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        if let Some(delay) = self.delay {
+            tokio::time::sleep(delay).await;
+        }
+        self.policies
+            .get(agent_id.as_bytes())
+            .cloned()
+            .ok_or_else(|| StorageError::NotFound(format!("{:?}", agent_id.as_bytes())))
+    }
+
+    async fn invalidate(&self, _agent_id: &AgentId) -> Result<()> {
+        Ok(())
+    }
+}

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -14,6 +14,11 @@ This document tracks which versions of `aa-runtime` are compatible with each SDK
      version and introduces no version change to aa-runtime or any SDK; this
      comment satisfies the compatibility-matrix CI gate. -->
 
+<!-- AAASM-2379: added the `aa-cache` crate to root Cargo.toml workspace
+     members (in-process L1 cache wrapper over the storage traits). It inherits
+     the workspace version and introduces no version change to aa-runtime or any
+     SDK; this comment satisfies the compatibility-matrix CI gate. -->
+
 
 ---
 


### PR DESCRIPTION
## Description

Adds a new `aa-cache` crate with `L1Cache<S>`, an in-process L1 cache wrapper over the storage traits. Policy is queried on every tool call, so a backend round-trip per call is too expensive; `L1Cache` serves hot keys from an in-process `DashMap` with a configurable TTL and per-key stampede protection, never crossing the network on a hit.

Implements subtask **AAASM-2379** of Story **AAASM-2376** (Epic **AAASM-2349** — L1 in-process cache + Gateway push-invalidation channel).

Design:
- `CacheSource` trait abstracts the wrapped store (associated `Key`/`Value` + async `load`); blanket-implemented for every `PolicyStore` (keyed by `AgentId`, value `PolicyDocument`), so `L1Cache<MemoryPolicyStore>` works directly.
- `CachedValue<V>` tags each entry with its insertion `Instant`; `is_expired(ttl)` drives expiry.
- `L1Cache<S>` holds `Arc<DashMap<K, CachedValue<V>>>` + a TTL + an `Arc<DashMap<K, Arc<tokio::sync::Notify>>>` of in-flight loads.
  - `get` — cache-aside; a fresh hit clones out of the map, a miss/expiry loads from the store and repopulates.
  - Stampede protection — the first caller to miss becomes the leader and performs the one `load`; concurrent callers wait on the shared `Notify` and re-read the populated cache, so the inner store sees exactly one call per miss window.
  - `invalidate(key) -> bool` — the hook the Epic C push-invalidation channel will call.
  - `len`/`is_empty`/`clear` diagnostics.
- `testing::MemoryPolicyStore` (feature `test-utils`) — a counting `PolicyStore` double used by the unit tests and the benchmark.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

Adds a new workspace member only; inherits the workspace version and changes no published version (compatibility-matrix note added).

## Related Issues

- Related Jira ticket: AAASM-2379 (Story AAASM-2376, Epic AAASM-2349)

## Testing

- [x] Unit tests added / updated
- [x] No tests required (explain why) — N/A

`cargo nextest run -p aa-cache` (4 tests, all passing):
- `miss_populates_then_serves_from_cache` — cache-aside populate + hit
- `expired_entry_is_treated_as_a_miss` — TTL expiry reloads
- `invalidate_evicts_the_cached_entry` — invalidate semantics
- `concurrent_misses_collapse_to_one_load` — 100 concurrent misses → exactly 1 inner load

`cargo bench -p aa-cache --bench l1_hit` — warm L1 hit median **~0.2 µs** (target < 1 µs), shown against the raw `MemoryPolicyStore::get_policy` baseline.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
