### PR TITLE
[AAASM-2374] ✨ (aa-storage-sqlite-buffer): Add local SQLite event buffer driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "aa-storage-sqlite-buffer"
+version = "0.0.1-alpha.5"
+dependencies = [
+ "aa-core",
+ "async-trait",
+ "dirs",
+ "metrics",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "aa-wasm"
 version = "0.0.1-alpha.5"
 dependencies = [
@@ -2698,6 +2713,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3151,6 +3178,9 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash 0.8.12",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3185,6 +3215,15 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -6027,6 +6066,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.12.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.9.1",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6744,7 +6797,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap 2.14.0",
  "log",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "aa-storage-redis",
     "aa-cache",
     "aa-storage-postgres",
+    "aa-storage-sqlite-buffer",
     "aa-proto",
     "aa-runtime",
     "aa-ebpf",

--- a/aa-storage-sqlite-buffer/Cargo.toml
+++ b/aa-storage-sqlite-buffer/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "aa-storage-sqlite-buffer"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Local in-process SQLite event buffer that survives brief gateway/queue outages and flushes audit events on reconnect"
+
+[dependencies]
+# The buffer serializes and replays the storage contract's `AuditEntry` through
+# the `AuditSink` trait, both reached from `aa-core`. `serde` is enabled so
+# `AuditEntry` can be encoded into the on-disk BLOB.
+aa-core = { path = "../aa-core", features = ["serde"] }
+# Pinned to the rusqlite line that depends on `libsqlite3-sys 0.30`, matching
+# the `sqlx-sqlite 0.8.6` already resolved for `aa-gateway`. Only one crate in
+# the workspace may link the native `sqlite3` library, so both must resolve to
+# the same `libsqlite3-sys 0.30.x`. An older rusqlite (0.31 -> libsqlite3-sys
+# 0.28) would force `sqlx` down to 0.8.0 and pull vulnerable rustls/webpki;
+# a newer one (0.33+ -> libsqlite3-sys 0.31+) breaks the `links = "sqlite3"`
+# uniqueness rule against sqlx.
+rusqlite = { version = "0.32", features = ["bundled"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+metrics = "0.24"
+dirs = "6"
+
+[dev-dependencies]
+async-trait = "0.1"
+tokio = { version = "1", features = ["macros", "rt"] }
+tempfile = "3"
+
+[lints]
+workspace = true

--- a/aa-storage-sqlite-buffer/src/buffer.rs
+++ b/aa-storage-sqlite-buffer/src/buffer.rs
@@ -1,0 +1,81 @@
+//! The on-disk SQLite event buffer.
+
+use std::path::Path;
+use std::sync::Mutex;
+
+use aa_core::storage::{Result, StorageError};
+use rusqlite::Connection;
+
+/// Map a `rusqlite` error onto the storage contract's backend variant.
+fn backend_err(err: rusqlite::Error) -> StorageError {
+    StorageError::Backend(err.to_string())
+}
+
+/// A restart-safe, FIFO event buffer backed by a single SQLite file.
+///
+/// Events are appended with [`enqueue`](EventBuffer::enqueue) while the upstream
+/// sink is unreachable and replayed in insertion order with
+/// [`drain_and_send`](EventBuffer::drain_and_send) once it recovers. The file is
+/// opened in WAL mode so buffered events survive a process restart.
+pub struct EventBuffer {
+    conn: Mutex<Connection>,
+    cap: usize,
+}
+
+impl EventBuffer {
+    /// Open (creating if absent) a buffer at `path` retaining at most `cap`
+    /// events.
+    ///
+    /// Enables WAL journaling and `synchronous = NORMAL` for a durability/perf
+    /// balance, and creates the `events` table if it does not yet exist. Parent
+    /// directories are created as needed.
+    pub fn new(path: impl AsRef<Path>, cap: usize) -> Result<Self> {
+        let path = path.as_ref();
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| StorageError::Backend(format!("create buffer directory {}: {e}", parent.display())))?;
+            }
+        }
+        let conn = Connection::open(path).map_err(backend_err)?;
+        conn.execute_batch(
+            "PRAGMA journal_mode = WAL;
+             PRAGMA synchronous = NORMAL;
+             CREATE TABLE IF NOT EXISTS events (
+                 id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                 payload     BLOB    NOT NULL,
+                 enqueued_at INTEGER NOT NULL
+             );",
+        )
+        .map_err(backend_err)?;
+        Ok(Self {
+            conn: Mutex::new(conn),
+            cap,
+        })
+    }
+
+    /// Open a buffer from operator [`SqliteBufferConfig`](crate::SqliteBufferConfig).
+    pub fn from_config(config: &crate::SqliteBufferConfig) -> Result<Self> {
+        Self::new(&config.path, config.cap)
+    }
+
+    /// The maximum number of events this buffer retains before eviction.
+    #[must_use]
+    pub fn cap(&self) -> usize {
+        self.cap
+    }
+
+    /// Number of events currently buffered.
+    pub fn len(&self) -> Result<usize> {
+        let conn = self.conn.lock().expect("event buffer mutex poisoned");
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))
+            .map_err(backend_err)?;
+        Ok(count as usize)
+    }
+
+    /// Whether the buffer currently holds no events.
+    pub fn is_empty(&self) -> Result<bool> {
+        Ok(self.len()? == 0)
+    }
+}

--- a/aa-storage-sqlite-buffer/src/buffer.rs
+++ b/aa-storage-sqlite-buffer/src/buffer.rs
@@ -2,13 +2,43 @@
 
 use std::path::Path;
 use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use aa_core::storage::{Result, StorageError};
-use rusqlite::Connection;
+use aa_core::storage::{AuditEntry, Result, StorageError};
+use rusqlite::{params, Connection};
 
 /// Map a `rusqlite` error onto the storage contract's backend variant.
 fn backend_err(err: rusqlite::Error) -> StorageError {
     StorageError::Backend(err.to_string())
+}
+
+/// Nanoseconds since the Unix epoch, saturating to `0` if the clock predates it.
+fn now_unix_nanos() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as i64)
+        .unwrap_or(0)
+}
+
+/// Delete the oldest events until at most `cap` remain, returning the count
+/// removed.
+fn prune_to_cap(conn: &Connection, cap: usize) -> Result<usize> {
+    let count: i64 = conn
+        .query_row("SELECT COUNT(*) FROM events", [], |row| row.get(0))
+        .map_err(backend_err)?;
+    let cap = cap as i64;
+    if count <= cap {
+        return Ok(0);
+    }
+    let excess = count - cap;
+    let deleted = conn
+        .execute(
+            "DELETE FROM events WHERE id IN \
+             (SELECT id FROM events ORDER BY id ASC LIMIT ?1)",
+            params![excess],
+        )
+        .map_err(backend_err)?;
+    Ok(deleted)
 }
 
 /// A restart-safe, FIFO event buffer backed by a single SQLite file.
@@ -77,5 +107,30 @@ impl EventBuffer {
     /// Whether the buffer currently holds no events.
     pub fn is_empty(&self) -> Result<bool> {
         Ok(self.len()? == 0)
+    }
+
+    /// Append `event` to the buffer.
+    ///
+    /// The entry is serialized to JSON and stored as a BLOB. When the buffer
+    /// would exceed its cap, the oldest events are evicted to make room and the
+    /// [`METRIC_EVENTS_DROPPED`](crate::METRIC_EVENTS_DROPPED) counter is bumped
+    /// by the number dropped — the loss is metered, never silent. Each accepted
+    /// event bumps [`METRIC_EVENTS_BUFFERED`](crate::METRIC_EVENTS_BUFFERED).
+    pub fn enqueue(&self, event: &AuditEntry) -> Result<()> {
+        let payload = serde_json::to_vec(event).map_err(|e| StorageError::Serialization(e.to_string()))?;
+        let enqueued_at = now_unix_nanos();
+        let conn = self.conn.lock().expect("event buffer mutex poisoned");
+        conn.execute(
+            "INSERT INTO events (payload, enqueued_at) VALUES (?1, ?2)",
+            params![payload, enqueued_at],
+        )
+        .map_err(backend_err)?;
+        metrics::counter!(crate::METRIC_EVENTS_BUFFERED).increment(1);
+
+        let dropped = prune_to_cap(&conn, self.cap)?;
+        if dropped > 0 {
+            metrics::counter!(crate::METRIC_EVENTS_DROPPED).increment(dropped as u64);
+        }
+        Ok(())
     }
 }

--- a/aa-storage-sqlite-buffer/src/buffer.rs
+++ b/aa-storage-sqlite-buffer/src/buffer.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use aa_core::storage::{AuditEntry, Result, StorageError};
-use rusqlite::{params, Connection};
+use aa_core::storage::{AuditEntry, AuditSink, Result, StorageError};
+use rusqlite::{params, Connection, OptionalExtension};
 
 /// Map a `rusqlite` error onto the storage contract's backend variant.
 fn backend_err(err: rusqlite::Error) -> StorageError {
@@ -131,6 +131,47 @@ impl EventBuffer {
         if dropped > 0 {
             metrics::counter!(crate::METRIC_EVENTS_DROPPED).increment(dropped as u64);
         }
+        Ok(())
+    }
+
+    /// Replay buffered events to `sink` in insertion (FIFO) order.
+    ///
+    /// Each event is sent and, only after the sink acknowledges it, deleted from
+    /// the buffer — so a crash mid-flush replays at-least-once rather than
+    /// losing data. Draining stops at the first sink failure (the upstream is
+    /// treated as still-unreachable), leaving the remaining events buffered for
+    /// a later retry. Returns the number of events flushed; each one bumps
+    /// [`METRIC_EVENTS_FLUSHED`](crate::METRIC_EVENTS_FLUSHED).
+    pub async fn drain_and_send(&self, sink: &dyn AuditSink) -> Result<usize> {
+        let mut flushed = 0usize;
+        while let Some((id, payload)) = self.peek_oldest()? {
+            let entry: AuditEntry =
+                serde_json::from_slice(&payload).map_err(|e| StorageError::Serialization(e.to_string()))?;
+            if sink.emit(entry).await.is_err() {
+                break;
+            }
+            self.delete(id)?;
+            flushed += 1;
+            metrics::counter!(crate::METRIC_EVENTS_FLUSHED).increment(1);
+        }
+        Ok(flushed)
+    }
+
+    /// Fetch the oldest buffered event as `(id, payload)`, if any.
+    fn peek_oldest(&self) -> Result<Option<(i64, Vec<u8>)>> {
+        let conn = self.conn.lock().expect("event buffer mutex poisoned");
+        conn.query_row("SELECT id, payload FROM events ORDER BY id ASC LIMIT 1", [], |row| {
+            Ok((row.get(0)?, row.get(1)?))
+        })
+        .optional()
+        .map_err(backend_err)
+    }
+
+    /// Delete the buffered event with the given row id.
+    fn delete(&self, id: i64) -> Result<()> {
+        let conn = self.conn.lock().expect("event buffer mutex poisoned");
+        conn.execute("DELETE FROM events WHERE id = ?1", params![id])
+            .map_err(backend_err)?;
         Ok(())
     }
 }

--- a/aa-storage-sqlite-buffer/src/buffer.rs
+++ b/aa-storage-sqlite-buffer/src/buffer.rs
@@ -95,6 +95,22 @@ impl EventBuffer {
         self.cap
     }
 
+    /// The SQLite `journal_mode` in force on this buffer's connection
+    /// (`"wal"` once opened).
+    pub fn journal_mode(&self) -> Result<String> {
+        let conn = self.conn.lock().expect("event buffer mutex poisoned");
+        conn.query_row("PRAGMA journal_mode", [], |row| row.get(0))
+            .map_err(backend_err)
+    }
+
+    /// The SQLite `synchronous` level in force on this buffer's connection
+    /// (`1` = `NORMAL`).
+    pub fn synchronous(&self) -> Result<i64> {
+        let conn = self.conn.lock().expect("event buffer mutex poisoned");
+        conn.query_row("PRAGMA synchronous", [], |row| row.get(0))
+            .map_err(backend_err)
+    }
+
     /// Number of events currently buffered.
     pub fn len(&self) -> Result<usize> {
         let conn = self.conn.lock().expect("event buffer mutex poisoned");

--- a/aa-storage-sqlite-buffer/src/config.rs
+++ b/aa-storage-sqlite-buffer/src/config.rs
@@ -1,0 +1,54 @@
+//! Configuration for the SQLite event buffer.
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+/// Default maximum number of events retained before the oldest are evicted.
+///
+/// Bounds disk use while still tolerating a multi-minute upstream outage at
+/// typical audit-event rates.
+pub const DEFAULT_CAP: usize = 10_000;
+
+/// Resolve the default buffer database path.
+///
+/// Returns the platform data directory joined with `agent-assembly/buffer.db` —
+/// `~/.local/share/agent-assembly/buffer.db` on Linux (per the XDG
+/// base-directory spec). Falls back to a relative `buffer.db` when no data
+/// directory can be determined.
+#[must_use]
+pub fn default_path() -> PathBuf {
+    dirs::data_dir()
+        .map(|dir| dir.join("agent-assembly").join("buffer.db"))
+        .unwrap_or_else(|| PathBuf::from("buffer.db"))
+}
+
+/// Operator configuration for the SQLite event buffer.
+///
+/// Deserialized from the `[storage.sqlite_buffer]` table of
+/// `agent-assembly.toml`. Both fields are optional; omitted fields fall back to
+/// [`default_path`] and [`DEFAULT_CAP`].
+///
+/// ```
+/// use aa_storage_sqlite_buffer::{SqliteBufferConfig, DEFAULT_CAP};
+///
+/// let cfg = SqliteBufferConfig::default();
+/// assert_eq!(cfg.cap, DEFAULT_CAP);
+/// ```
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct SqliteBufferConfig {
+    /// Filesystem path to the single-file SQLite buffer database.
+    pub path: PathBuf,
+    /// Maximum number of events retained before the oldest are evicted.
+    pub cap: usize,
+}
+
+impl Default for SqliteBufferConfig {
+    fn default() -> Self {
+        Self {
+            path: default_path(),
+            cap: DEFAULT_CAP,
+        }
+    }
+}

--- a/aa-storage-sqlite-buffer/src/lib.rs
+++ b/aa-storage-sqlite-buffer/src/lib.rs
@@ -26,3 +26,12 @@
 mod config;
 
 pub use config::{default_path, SqliteBufferConfig, DEFAULT_CAP};
+
+/// Counter incremented once per event accepted into the buffer.
+pub const METRIC_EVENTS_BUFFERED: &str = "aa_events_buffered";
+
+/// Counter incremented when the cap is exceeded and an oldest event is evicted.
+pub const METRIC_EVENTS_DROPPED: &str = "aa_events_dropped_total";
+
+/// Counter incremented once per event successfully flushed to the sink.
+pub const METRIC_EVENTS_FLUSHED: &str = "aa_events_flushed_total";

--- a/aa-storage-sqlite-buffer/src/lib.rs
+++ b/aa-storage-sqlite-buffer/src/lib.rs
@@ -22,3 +22,7 @@
 //! ```
 
 #![warn(missing_docs)]
+
+mod config;
+
+pub use config::{default_path, SqliteBufferConfig, DEFAULT_CAP};

--- a/aa-storage-sqlite-buffer/src/lib.rs
+++ b/aa-storage-sqlite-buffer/src/lib.rs
@@ -23,9 +23,15 @@
 
 #![warn(missing_docs)]
 
+mod buffer;
 mod config;
 
+pub use buffer::EventBuffer;
 pub use config::{default_path, SqliteBufferConfig, DEFAULT_CAP};
+
+// Re-export the storage-contract types that appear in this crate's public API
+// so callers reach the buffer and its event/sink types from a single path.
+pub use aa_core::storage::{AuditEntry, AuditSink, Result, StorageError};
 
 /// Counter incremented once per event accepted into the buffer.
 pub const METRIC_EVENTS_BUFFERED: &str = "aa_events_buffered";

--- a/aa-storage-sqlite-buffer/src/lib.rs
+++ b/aa-storage-sqlite-buffer/src/lib.rs
@@ -1,0 +1,24 @@
+//! Local in-process SQLite **event buffer** for Agent Assembly.
+//!
+//! When the upstream NATS/gateway is briefly unreachable, Assembly keeps
+//! emitting governance [`AuditEntry`](aa_core::storage::AuditEntry) records into
+//! this buffer instead of dropping them. Once the connection recovers, the
+//! buffer flushes its backlog — in insertion order — through the upstream
+//! [`AuditSink`](aa_core::storage::AuditSink). This gives Assembly **partial
+//! autonomy** so a transient outage never silently loses audit-trail data.
+//!
+//! The buffer is a single SQLite file opened in WAL mode, so a buffered event
+//! survives a process restart and is replayed on the next reconnect.
+//!
+//! ```no_run
+//! use aa_storage_sqlite_buffer::EventBuffer;
+//!
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! // Open (or create) a buffer holding at most 10_000 events.
+//! let buffer = EventBuffer::new("/var/lib/agent-assembly/buffer.db", 10_000)?;
+//! # let _ = buffer;
+//! # Ok(())
+//! # }
+//! ```
+
+#![warn(missing_docs)]

--- a/aa-storage-sqlite-buffer/src/lib.rs
+++ b/aa-storage-sqlite-buffer/src/lib.rs
@@ -1,10 +1,10 @@
 //! Local in-process SQLite **event buffer** for Agent Assembly.
 //!
 //! When the upstream NATS/gateway is briefly unreachable, Assembly keeps
-//! emitting governance [`AuditEntry`](aa_core::storage::AuditEntry) records into
-//! this buffer instead of dropping them. Once the connection recovers, the
-//! buffer flushes its backlog — in insertion order — through the upstream
-//! [`AuditSink`](aa_core::storage::AuditSink). This gives Assembly **partial
+//! emitting governance [`AuditEntry`] records into this buffer instead of
+//! dropping them. Once the connection recovers, the buffer flushes its backlog
+//! — in insertion order — through the upstream [`AuditSink`]. This gives
+//! Assembly **partial
 //! autonomy** so a transient outage never silently loses audit-trail data.
 //!
 //! The buffer is a single SQLite file opened in WAL mode, so a buffered event

--- a/aa-storage-sqlite-buffer/tests/cap.rs
+++ b/aa-storage-sqlite-buffer/tests/cap.rs
@@ -1,0 +1,31 @@
+//! Cap-enforcement (oldest-eviction) tests.
+
+mod common;
+
+use aa_storage_sqlite_buffer::EventBuffer;
+use common::{sample_entry, CollectingSink};
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn cap_evicts_oldest_and_retains_newest_in_order() {
+    let dir = tempdir().unwrap();
+    let buffer = EventBuffer::new(dir.path().join("buffer.db"), 10).unwrap();
+
+    // Enqueue 15 events into a cap-10 buffer; the 5 oldest are dropped.
+    let inputs: Vec<_> = (0..15).map(|i| sample_entry(i, &format!("event-{i}"))).collect();
+    for entry in &inputs {
+        buffer.enqueue(entry).unwrap();
+    }
+
+    assert_eq!(buffer.len().unwrap(), 10, "buffer never exceeds its cap");
+
+    // The retained events are the 10 most recent, still in FIFO order.
+    let sink = CollectingSink::default();
+    let flushed = buffer.drain_and_send(&sink).await.unwrap();
+    assert_eq!(flushed, 10);
+    assert_eq!(
+        sink.entries(),
+        inputs[5..].to_vec(),
+        "the oldest five events were evicted, newest ten retained in order"
+    );
+}

--- a/aa-storage-sqlite-buffer/tests/common/mod.rs
+++ b/aa-storage-sqlite-buffer/tests/common/mod.rs
@@ -1,0 +1,79 @@
+//! Shared test fixtures for the SQLite event-buffer integration tests.
+#![allow(dead_code)] // not every test file uses every fixture
+
+use std::sync::{Arc, Mutex};
+
+use aa_core::audit::{AuditEntry, AuditEventType};
+use aa_core::identity::{AgentId, SessionId};
+use aa_core::storage::{AuditSink, Result, StorageError};
+use async_trait::async_trait;
+
+/// Build a deterministic [`AuditEntry`] carrying `payload`, tagged with `seq`.
+pub fn sample_entry(seq: u64, payload: &str) -> AuditEntry {
+    AuditEntry::new(
+        seq,
+        1_000 + seq,
+        AuditEventType::ToolCallIntercepted,
+        AgentId::from_bytes([1u8; 16]),
+        SessionId::from_bytes([2u8; 16]),
+        payload.to_string(),
+        [0u8; 32],
+    )
+}
+
+/// An [`AuditSink`] that records every entry it receives, in order.
+#[derive(Clone, Default)]
+pub struct CollectingSink {
+    pub received: Arc<Mutex<Vec<AuditEntry>>>,
+}
+
+impl CollectingSink {
+    /// Snapshot the entries received so far.
+    pub fn entries(&self) -> Vec<AuditEntry> {
+        self.received.lock().expect("sink mutex poisoned").clone()
+    }
+}
+
+#[async_trait]
+impl AuditSink for CollectingSink {
+    async fn emit(&self, event: AuditEntry) -> Result<()> {
+        self.received.lock().expect("sink mutex poisoned").push(event);
+        Ok(())
+    }
+}
+
+/// An [`AuditSink`] that accepts the first `fail_after` entries, then fails
+/// every subsequent `emit` — modelling an upstream that goes unreachable
+/// part-way through a flush.
+#[derive(Clone)]
+pub struct FlakySink {
+    pub received: Arc<Mutex<Vec<AuditEntry>>>,
+    pub fail_after: usize,
+}
+
+impl FlakySink {
+    /// Create a sink that succeeds for the first `fail_after` emits.
+    pub fn new(fail_after: usize) -> Self {
+        Self {
+            received: Arc::new(Mutex::new(Vec::new())),
+            fail_after,
+        }
+    }
+
+    /// Snapshot the entries accepted so far.
+    pub fn entries(&self) -> Vec<AuditEntry> {
+        self.received.lock().expect("sink mutex poisoned").clone()
+    }
+}
+
+#[async_trait]
+impl AuditSink for FlakySink {
+    async fn emit(&self, event: AuditEntry) -> Result<()> {
+        let mut received = self.received.lock().expect("sink mutex poisoned");
+        if received.len() >= self.fail_after {
+            return Err(StorageError::Backend("upstream unreachable".into()));
+        }
+        received.push(event);
+        Ok(())
+    }
+}

--- a/aa-storage-sqlite-buffer/tests/drain.rs
+++ b/aa-storage-sqlite-buffer/tests/drain.rs
@@ -1,0 +1,26 @@
+//! Enqueue/drain behaviour tests for the SQLite event buffer.
+
+mod common;
+
+use aa_storage_sqlite_buffer::EventBuffer;
+use common::{sample_entry, CollectingSink};
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn enqueues_and_drains_in_fifo_order() {
+    let dir = tempdir().unwrap();
+    let buffer = EventBuffer::new(dir.path().join("buffer.db"), 100).unwrap();
+
+    let inputs: Vec<_> = (0..5).map(|i| sample_entry(i, &format!("event-{i}"))).collect();
+    for entry in &inputs {
+        buffer.enqueue(entry).unwrap();
+    }
+    assert_eq!(buffer.len().unwrap(), 5);
+
+    let sink = CollectingSink::default();
+    let flushed = buffer.drain_and_send(&sink).await.unwrap();
+
+    assert_eq!(flushed, 5);
+    assert!(buffer.is_empty().unwrap());
+    assert_eq!(sink.entries(), inputs, "events must replay in insertion order");
+}

--- a/aa-storage-sqlite-buffer/tests/drain.rs
+++ b/aa-storage-sqlite-buffer/tests/drain.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use aa_storage_sqlite_buffer::EventBuffer;
-use common::{sample_entry, CollectingSink};
+use common::{sample_entry, CollectingSink, FlakySink};
 use tempfile::tempdir;
 
 #[tokio::test]
@@ -23,4 +23,29 @@ async fn enqueues_and_drains_in_fifo_order() {
     assert_eq!(flushed, 5);
     assert!(buffer.is_empty().unwrap());
     assert_eq!(sink.entries(), inputs, "events must replay in insertion order");
+}
+
+#[tokio::test]
+async fn drain_stops_at_first_sink_failure_and_resumes_later() {
+    let dir = tempdir().unwrap();
+    let buffer = EventBuffer::new(dir.path().join("buffer.db"), 100).unwrap();
+
+    let inputs: Vec<_> = (0..5).map(|i| sample_entry(i, &format!("event-{i}"))).collect();
+    for entry in &inputs {
+        buffer.enqueue(entry).unwrap();
+    }
+
+    // The upstream accepts two events, then goes unreachable.
+    let flaky = FlakySink::new(2);
+    let flushed = buffer.drain_and_send(&flaky).await.unwrap();
+    assert_eq!(flushed, 2);
+    assert_eq!(flaky.entries(), inputs[..2].to_vec());
+    assert_eq!(buffer.len().unwrap(), 3, "unacked events stay buffered");
+
+    // The upstream recovers; the remaining events replay in FIFO order.
+    let sink = CollectingSink::default();
+    let flushed = buffer.drain_and_send(&sink).await.unwrap();
+    assert_eq!(flushed, 3);
+    assert!(buffer.is_empty().unwrap());
+    assert_eq!(sink.entries(), inputs[2..].to_vec());
 }

--- a/aa-storage-sqlite-buffer/tests/pragma.rs
+++ b/aa-storage-sqlite-buffer/tests/pragma.rs
@@ -1,0 +1,13 @@
+//! Durability-pragma tests: the buffer opens in WAL with `synchronous = NORMAL`.
+
+use aa_storage_sqlite_buffer::EventBuffer;
+use tempfile::tempdir;
+
+#[test]
+fn opens_in_wal_mode_with_synchronous_normal() {
+    let dir = tempdir().unwrap();
+    let buffer = EventBuffer::new(dir.path().join("buffer.db"), 100).unwrap();
+
+    assert_eq!(buffer.journal_mode().unwrap().to_lowercase(), "wal");
+    assert_eq!(buffer.synchronous().unwrap(), 1, "1 == synchronous NORMAL");
+}

--- a/aa-storage-sqlite-buffer/tests/restart.rs
+++ b/aa-storage-sqlite-buffer/tests/restart.rs
@@ -1,0 +1,36 @@
+//! Restart-safety test: buffered events survive dropping and reopening the
+//! buffer (the in-process analogue of a process restart) and replay in order.
+
+mod common;
+
+use aa_storage_sqlite_buffer::EventBuffer;
+use common::{sample_entry, CollectingSink};
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn buffered_events_survive_restart_and_replay_in_order() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("buffer.db");
+
+    let inputs: Vec<_> = (0..5).map(|i| sample_entry(i, &format!("event-{i}"))).collect();
+
+    // First "process": enqueue events, then drop the buffer to close the DB.
+    {
+        let buffer = EventBuffer::new(&path, 100).unwrap();
+        for entry in &inputs {
+            buffer.enqueue(entry).unwrap();
+        }
+        assert_eq!(buffer.len().unwrap(), 5);
+    } // buffer (and its SQLite connection) dropped here
+
+    // Second "process": reopen the same file and prove the events are still
+    // there, then flush them in insertion order.
+    let buffer = EventBuffer::new(&path, 100).unwrap();
+    assert_eq!(buffer.len().unwrap(), 5, "events persisted across restart");
+
+    let sink = CollectingSink::default();
+    let flushed = buffer.drain_and_send(&sink).await.unwrap();
+    assert_eq!(flushed, 5);
+    assert!(buffer.is_empty().unwrap());
+    assert_eq!(sink.entries(), inputs, "events replay in FIFO order after restart");
+}

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -25,6 +25,11 @@ This document tracks which versions of `aa-runtime` are compatible with each SDK
      the workspace version and introduces no version change to aa-runtime or any
      SDK; this comment satisfies the compatibility-matrix CI gate. -->
 
+<!-- AAASM-2374: added the `aa-storage-sqlite-buffer` crate to root Cargo.toml
+     workspace members (local SQLite event-buffer driver). It inherits the
+     workspace version and introduces no version change to aa-runtime or any
+     SDK; this comment satisfies the compatibility-matrix CI gate. -->
+
 
 ---
 


### PR DESCRIPTION
## Description

Adds the `aa-storage-sqlite-buffer` crate — a local, in-process SQLite **event buffer** that catches governance audit events while the upstream NATS/gateway is unreachable and replays them, in insertion order, once the connection recovers. This gives Assembly the **partial autonomy** described in the spec (lines 7358–7366): a transient outage never silently drops audit-trail data.

Public API (`EventBuffer`):
- `EventBuffer::new(path, cap)` — opens (creating parents) a single-file SQLite DB, enables **WAL** + `synchronous = NORMAL`, and creates the `events(id, payload, enqueued_at)` table.
- `EventBuffer::from_config(&SqliteBufferConfig)` — open from the `[storage.sqlite_buffer]` config (default path `~/.local/share/agent-assembly/buffer.db` on Linux, default cap `10_000`).
- `enqueue(&AuditEntry)` — serialises the entry to a BLOB and inserts it; when over `cap`, evicts the oldest and bumps `aa_events_dropped_total` (loss is metered, never silent). Bumps `aa_events_buffered`.
- `drain_and_send(&dyn AuditSink)` — replays buffered events FIFO, deleting each only after the sink acks (at-least-once on crash); stops at the first sink failure, leaving the rest buffered for retry. Bumps `aa_events_flushed_total`.
- Diagnostics: `len`, `is_empty`, `cap`, `journal_mode`, `synchronous`.

### Design notes / deviations from the ticket text

- **Types**: uses the real storage-contract types from `aa_core::storage` — `AuditEntry` and the `AuditSink` trait. The ticket said `AuditEvent`/`AuditSink`; the concrete type in this repo is `AuditEntry`.
- **Crate location**: the crate lives at the repo top-level (`aa-storage-sqlite-buffer/`) to match the existing flat crate layout — this repo has no `crates/` directory.
- **Serialization**: events are serialised with `serde_json` rather than `bincode`. `AuditEntry` carries `#[serde(skip_serializing_if)]` fields, which bincode (a non-self-describing format) cannot round-trip. The payload is still stored as a `BLOB`.
- **`rusqlite` pin (`0.32`)**: pinned to the line that uses `libsqlite3-sys 0.30`, matching `sqlx-sqlite 0.8.6` already in `aa-gateway`. Only one crate may link the native `sqlite3` library, so both must share one `libsqlite3-sys`. A newer rusqlite would force a downgrade/conflict. Lockfile change is purely additive — no existing dependency was downgraded, and `cargo deny check` passes (advisories/bans/licenses/sources ok).
- `docs/src/compatibility.md` carries the standard "no version change" note required by the compat-matrix CI gate when a workspace member is added.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2374 (parent Story AAASM-2366, Epic AAASM-2348)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

`cargo nextest run -p aa-storage-sqlite-buffer` — 5 tests pass:
- enqueue + FIFO drain round-trip
- drain stops at first sink failure and resumes on a later drain
- cap eviction drops the oldest and retains the newest in order
- WAL + `synchronous = NORMAL` pragmas
- restart-safe FIFO replay (buffer dropped + reopened on the same file)

Plus 2 doctests, and `cargo doc -p aa-storage-sqlite-buffer` is clean under `-D warnings`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
