### PR TITLE
[AAASM-2362] 📝 (verification): Verify storage TOML loader acceptance criteria

### DIFF
--- a/verification-reports/AAASM-2362.md
+++ b/verification-reports/AAASM-2362.md
@@ -1,0 +1,90 @@
+# Verification Report — AAASM-2362
+
+**Story:** AAASM-2356 — *As an OSS operator, I want to pick storage drivers from `agent-assembly.toml` so I switch backends without recompiling*
+**Epic:** AAASM-2347 — Storage trait abstraction (`aa-storage`)
+**Implementation PR:** [#876](https://github.com/ai-agent-assembly/agent-assembly/pull/876) (`v0.0.1/AAASM-2361/feat/storage_toml_loader`)
+**Component / repo:** `agent-assembly`
+**Date:** 2026-06-03
+
+## Scope
+
+Verify the acceptance criteria of the parent Story against the implementation in
+AAASM-2361. Driver implementations (Epic B) and the enterprise `gateway` driver
+(Epic E) are explicitly out of scope; the loader resolves driver *names* against
+a registry seeded with the planned OSS placeholders (`memory`, `redis`,
+`postgres`).
+
+## How verified
+
+```
+cargo nextest run -p aa-storage
+cargo nextest run -p aa-cli -E 'test(config::validate)'
+cargo test -p aa-storage --doc
+./target/debug/aasm config validate <fixture>
+```
+
+Fixtures live at `aa-cli/tests/fixtures/{storage_valid,storage_unknown_driver,storage_missing_subsection}.toml`; the canonical valid example is `agent-assembly.toml.example` at the repo root.
+
+## Acceptance criteria
+
+| # | Criterion | Result | Evidence |
+|---|-----------|--------|----------|
+| 1 | `[storage]` section accepts all six driver-kind keys | ✅ PASS | `StorageConfig` has `policy_store`, `audit_sink`, `session_store`, `credential_store`, `rate_limit_counter`, `lifecycle_store`; `storage_section_flattens_known_keys_and_subsections` parses them. |
+| 2 | Per-driver `[storage.<name>]` subsection parses | ✅ PASS | `#[serde(flatten)] drivers: HashMap<DriverName, toml::Value>` captures every `[storage.<name>]` table; asserted in the same test and in the valid fixture run below. |
+| 3 | Unknown driver name → `UnknownDriver` listing valid names | ✅ PASS | `unknown_driver_reports_kind_name_and_available`; CLI run prints `available drivers: [memory, postgres, redis]`. |
+| 4 | Each fixture TOML round-trips through the loader | ✅ PASS | `valid_config_exits_success`, `unknown_driver_exits_failure`, `missing_subsection_exits_failure` drive the three fixtures through `aasm config validate`. |
+| 5 | `aasm config validate` surfaces the error verbatim | ✅ PASS | Manual runs below; the `ConfigError` `Display` string is printed to stderr unchanged with exit code 1. |
+| 6 | `agent-assembly.toml.example` parses cleanly | ✅ PASS | `aasm config validate agent-assembly.toml.example` → `Config is valid` (exit 0). |
+
+## Test output
+
+### `cargo nextest run -p aa-storage` — 8 passed
+
+```
+PASS registry::tests::storage_section_flattens_known_keys_and_subsections
+PASS registry::tests::valid_combination_passes_validate_and_builds
+PASS registry::tests::unknown_driver_reports_kind_name_and_available
+PASS registry::tests::missing_per_driver_subsection_is_rejected
+PASS registry::tests::builtin_registry_accepts_known_oss_driver_names
+PASS ::conformance memory_policy_store_satisfies_conformance
+PASS ::object_safety all_six_storage_traits_are_object_safe_via_aa_core_storage_path
+PASS ::object_safety all_six_storage_traits_are_object_safe_via_aa_storage_path
+Summary: 8 tests run: 8 passed, 0 skipped
+```
+
+### `cargo nextest run -p aa-cli -E 'test(config::validate)'` — 4 passed
+
+```
+PASS commands::config::validate::tests::valid_config_exits_success
+PASS commands::config::validate::tests::unknown_driver_exits_failure
+PASS commands::config::validate::tests::missing_subsection_exits_failure
+PASS commands::config::validate::tests::missing_file_exits_failure
+Summary: 4 tests run: 4 passed, 579 skipped
+```
+
+### `cargo test -p aa-storage --doc` — 2 passed
+
+```
+test aa-storage/src/lib.rs - (line 24) ... ok
+test aa-storage/src/driver_name.rs - driver_name::DriverName (line 16) ... ok
+test result: ok. 2 passed; 0 failed
+```
+
+### `aasm config validate` — manual runs
+
+```
+$ aasm config validate agent-assembly.toml.example
+Config is valid: agent-assembly.toml.example          # exit 0
+
+$ aasm config validate aa-cli/tests/fixtures/storage_unknown_driver.toml
+error: unknown policy_store driver "mongodb"; available drivers: [memory, postgres, redis]   # exit 1
+
+$ aasm config validate aa-cli/tests/fixtures/storage_missing_subsection.toml
+error: driver "redis" (selected for policy_store) has no [storage.redis] subsection           # exit 1
+```
+
+## Conclusion
+
+All six acceptance criteria of AAASM-2356 are met. No defects found; **no Bug
+Subtask filed.** Recommend merging PR #876 and closing the Story once both
+subtasks are Done.


### PR DESCRIPTION
## Description

Verification report for Story **AAASM-2356** (storage driver selection from `agent-assembly.toml`), covering the implementation in AAASM-2361 / PR #876. Adds a single file, `verification-reports/AAASM-2362.md`.

All six acceptance criteria **PASS**:
1. `[storage]` accepts all six driver-kind keys.
2. Per-driver `[storage.<name>]` subsections parse.
3. Unknown driver → `UnknownDriver` listing valid names.
4. Each fixture TOML round-trips through the loader.
5. `aasm config validate` surfaces the error verbatim (exit 1).
6. `agent-assembly.toml.example` validates cleanly (exit 0).

Evidence: `aa-storage` 8 tests, `aa-cli` config 4 tests, doctests 2 — all green — plus manual `aasm config validate` runs on the example and both error fixtures. No defects found; no Bug Subtask filed.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2362 (verification of Story AAASM-2356)
- Verifies: PR #876

## Testing

- [x] No tests required (explain why)

This PR adds only a verification report (Markdown); the verified tests live in PR #876. No CI workflow path filter matches `verification-reports/**`, so "no checks reported" is expected.

## Checklist

- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention
