### PR TITLE
[AAASM-2367] ✨ (aa-storage-memory): Add in-memory storage driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "aa-storage-memory"
+version = "0.0.1-alpha.5"
+dependencies = [
+ "aa-core",
+ "aa-storage",
+ "async-trait",
+ "dashmap",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
 name = "aa-wasm"
 version = "0.0.1-alpha.5"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "aa-core",
     "aa-storage",
+    "aa-storage-memory",
     "aa-proto",
     "aa-runtime",
     "aa-ebpf",

--- a/aa-core/src/storage/conformance.rs
+++ b/aa-core/src/storage/conformance.rs
@@ -9,7 +9,10 @@
 //! meant to be called from within a `#[test]` (driven by the caller's own async
 //! runtime).
 
-use super::{AgentId, PolicyStore, StorageError};
+use super::{
+    AgentId, AuditEntry, AuditSink, CredentialStore, LifecycleStore, PolicyStore, RateLimitCounter, SessionRecord,
+    SessionStore, StorageError,
+};
 
 /// Assert that a [`PolicyStore`] implementation honors the trait contract.
 ///
@@ -42,4 +45,181 @@ pub async fn assert_policy_store_conformance(store: &dyn PolicyStore, present: &
         .invalidate(absent)
         .await
         .expect("invalidate(absent) should be idempotent");
+}
+
+/// Assert that an [`AuditSink`] implementation honors the trait contract.
+///
+/// Drives `sink` through `&dyn AuditSink` and checks that emitting an entry
+/// succeeds — the sink is append-only, so a successful `emit` is the only
+/// observable invariant the trait guarantees. Panics on failure.
+pub async fn assert_audit_sink_conformance(sink: &dyn AuditSink, event: AuditEntry) {
+    sink.emit(event).await.expect("emit should persist the entry");
+}
+
+/// Assert that a [`SessionStore`] implementation honors the trait contract.
+///
+/// Drives `store` through `&dyn SessionStore` and checks:
+///
+/// - `save` then `load` round-trips the record unchanged
+/// - `delete` removes it, after which `load` returns [`StorageError::NotFound`]
+/// - a second `delete` of the now-absent id still succeeds (idempotent)
+///
+/// `record` must use a session id the store does not already hold. Panics with a
+/// descriptive message on the first violated invariant.
+pub async fn assert_session_store_conformance(store: &dyn SessionStore, record: SessionRecord) {
+    let id = record.session_id;
+
+    store.save(record.clone()).await.expect("save(new) should succeed");
+
+    let loaded = store.load(&id).await.expect("load(present) should return the record");
+    assert_eq!(loaded, record, "loaded record should equal the saved record");
+
+    store.delete(&id).await.expect("delete(present) should succeed");
+
+    match store.load(&id).await {
+        Err(StorageError::NotFound(_)) => {}
+        other => panic!("load(deleted) should return NotFound, got {other:?}"),
+    }
+
+    store.delete(&id).await.expect("delete(absent) should be idempotent");
+}
+
+/// Assert that a [`CredentialStore`] implementation honors the trait contract.
+///
+/// Drives `store` through `&dyn CredentialStore` and checks:
+///
+/// - `put_secret` then `get_secret` round-trips the bytes unchanged
+/// - `delete_secret` removes it, after which `get_secret` returns [`StorageError::NotFound`]
+/// - a second `delete_secret` of the now-absent key still succeeds (idempotent)
+///
+/// `key` must be one the store does not already hold. Panics with a descriptive
+/// message on the first violated invariant.
+pub async fn assert_credential_store_conformance(store: &dyn CredentialStore, key: &str, value: Vec<u8>) {
+    store
+        .put_secret(key, value.clone())
+        .await
+        .expect("put_secret(new) should succeed");
+
+    let got = store
+        .get_secret(key)
+        .await
+        .expect("get_secret(present) should return the value");
+    assert_eq!(got, value, "round-tripped secret bytes should match");
+
+    store
+        .delete_secret(key)
+        .await
+        .expect("delete_secret(present) should succeed");
+
+    match store.get_secret(key).await {
+        Err(StorageError::NotFound(_)) => {}
+        other => panic!("get_secret(deleted) should return NotFound, got {other:?}"),
+    }
+
+    store
+        .delete_secret(key)
+        .await
+        .expect("delete_secret(absent) should be idempotent");
+}
+
+/// Assert that a [`RateLimitCounter`] implementation honors the trait contract.
+///
+/// Drives `counter` through `&dyn RateLimitCounter` and checks:
+///
+/// - a fresh key reads `0`
+/// - `increment` returns the accumulating window total
+/// - `current` reflects the accumulated total without modifying it
+/// - `reset` returns the counter to `0` and is idempotent
+///
+/// `key` must be one the counter has never seen. A long window is used so the
+/// assertions never race a window rollover. Panics on the first violated
+/// invariant.
+pub async fn assert_rate_limit_counter_conformance(counter: &dyn RateLimitCounter, key: &str) {
+    const WINDOW_SECS: u64 = 3600;
+
+    assert_eq!(
+        counter.current(key).await.expect("current(fresh) should succeed"),
+        0,
+        "a key that was never incremented reads 0"
+    );
+
+    assert_eq!(
+        counter
+            .increment(key, 5, WINDOW_SECS)
+            .await
+            .expect("increment should succeed"),
+        5,
+        "first increment returns the amount added"
+    );
+
+    assert_eq!(
+        counter
+            .increment(key, 3, WINDOW_SECS)
+            .await
+            .expect("increment should succeed"),
+        8,
+        "second increment accumulates within the window"
+    );
+
+    assert_eq!(
+        counter.current(key).await.expect("current should succeed"),
+        8,
+        "current reflects the accumulated total"
+    );
+
+    counter.reset(key).await.expect("reset should succeed");
+
+    assert_eq!(
+        counter.current(key).await.expect("current after reset should succeed"),
+        0,
+        "reset returns the counter to 0"
+    );
+
+    counter.reset(key).await.expect("reset(absent) should be idempotent");
+}
+
+/// Assert that a [`LifecycleStore`] implementation honors the trait contract.
+///
+/// Drives `store` through `&dyn LifecycleStore` and checks:
+///
+/// - `register` then `heartbeat` succeeds for a registered agent
+/// - `heartbeat` on an unregistered agent returns [`StorageError::NotFound`]
+/// - `deregister` removes the registration, after which `heartbeat` returns
+///   [`StorageError::NotFound`]
+/// - `deregister` is idempotent for both registered and absent agents
+///
+/// `present` is registered and deregistered by the harness; `absent` must be an
+/// agent the store never holds. Panics on the first violated invariant.
+pub async fn assert_lifecycle_store_conformance(store: &dyn LifecycleStore, present: &AgentId, absent: &AgentId) {
+    store.register(present).await.expect("register should succeed");
+
+    store
+        .heartbeat(present)
+        .await
+        .expect("heartbeat(registered) should succeed");
+
+    match store.heartbeat(absent).await {
+        Err(StorageError::NotFound(_)) => {}
+        other => panic!("heartbeat(unregistered) should return NotFound, got {other:?}"),
+    }
+
+    store
+        .deregister(present)
+        .await
+        .expect("deregister(registered) should succeed");
+
+    match store.heartbeat(present).await {
+        Err(StorageError::NotFound(_)) => {}
+        other => panic!("heartbeat(deregistered) should return NotFound, got {other:?}"),
+    }
+
+    store
+        .deregister(present)
+        .await
+        .expect("deregister(present) should be idempotent");
+
+    store
+        .deregister(absent)
+        .await
+        .expect("deregister(absent) should be idempotent");
 }

--- a/aa-storage-memory/Cargo.toml
+++ b/aa-storage-memory/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "aa-storage-memory"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "In-memory aa-storage driver (DashMap-backed) for tests and local development"
+
+[dependencies]
+aa-core = { path = "../aa-core" }
+aa-storage = { path = "../aa-storage" }
+async-trait = "0.1"
+dashmap = "6"
+parking_lot = "0.12"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }
+
+[lints]
+workspace = true

--- a/aa-storage-memory/src/audit_sink.rs
+++ b/aa-storage-memory/src/audit_sink.rs
@@ -1,0 +1,47 @@
+//! In-memory [`AuditSink`] backed by a `parking_lot::Mutex<Vec<_>>`.
+
+use std::sync::Arc;
+
+use aa_storage::{AuditEntry, AuditSink, Result};
+use async_trait::async_trait;
+use parking_lot::Mutex;
+
+/// An [`AuditSink`] that appends entries to an in-memory, unbounded buffer.
+///
+/// Intended for tests that need to assert on emitted entries. Cloning shares
+/// the same underlying buffer. The buffer is unbounded — there is no
+/// backpressure — which is acceptable for the ephemeral memory driver.
+#[derive(Clone, Default)]
+pub struct MemoryAuditSink {
+    entries: Arc<Mutex<Vec<AuditEntry>>>,
+}
+
+impl MemoryAuditSink {
+    /// Create an empty sink.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of entries currently buffered.
+    pub fn len(&self) -> usize {
+        self.entries.lock().len()
+    }
+
+    /// Whether the buffer holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.entries.lock().is_empty()
+    }
+
+    /// Remove and return all buffered entries in emit order.
+    pub fn drain(&self) -> Vec<AuditEntry> {
+        std::mem::take(&mut *self.entries.lock())
+    }
+}
+
+#[async_trait]
+impl AuditSink for MemoryAuditSink {
+    async fn emit(&self, event: AuditEntry) -> Result<()> {
+        self.entries.lock().push(event);
+        Ok(())
+    }
+}

--- a/aa-storage-memory/src/credential_store.rs
+++ b/aa-storage-memory/src/credential_store.rs
@@ -1,0 +1,41 @@
+//! In-memory [`CredentialStore`] backed by a `DashMap`.
+
+use std::sync::Arc;
+
+use aa_storage::{CredentialStore, Result, StorageError};
+use async_trait::async_trait;
+use dashmap::DashMap;
+
+/// A `DashMap`-backed [`CredentialStore`] mapping key strings to opaque secret
+/// bytes. Cloning shares the same underlying map.
+#[derive(Clone, Default)]
+pub struct MemoryCredentialStore {
+    secrets: Arc<DashMap<String, Vec<u8>>>,
+}
+
+impl MemoryCredentialStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl CredentialStore for MemoryCredentialStore {
+    async fn get_secret(&self, key: &str) -> Result<Vec<u8>> {
+        self.secrets
+            .get(key)
+            .map(|entry| entry.value().clone())
+            .ok_or_else(|| StorageError::NotFound(format!("secret {key}")))
+    }
+
+    async fn put_secret(&self, key: &str, value: Vec<u8>) -> Result<()> {
+        self.secrets.insert(key.to_owned(), value);
+        Ok(())
+    }
+
+    async fn delete_secret(&self, key: &str) -> Result<()> {
+        self.secrets.remove(key);
+        Ok(())
+    }
+}

--- a/aa-storage-memory/src/lib.rs
+++ b/aa-storage-memory/src/lib.rs
@@ -8,8 +8,10 @@ mod audit_sink;
 mod credential_store;
 mod lifecycle_store;
 mod policy_store;
+mod rate_limit_counter;
 
 pub use audit_sink::MemoryAuditSink;
 pub use credential_store::MemoryCredentialStore;
 pub use lifecycle_store::MemoryLifecycleStore;
 pub use policy_store::MemoryPolicyStore;
+pub use rate_limit_counter::MemoryRateLimitCounter;

--- a/aa-storage-memory/src/lib.rs
+++ b/aa-storage-memory/src/lib.rs
@@ -1,0 +1,5 @@
+//! In-memory `aa-storage` driver.
+//!
+//! `DashMap`- and `parking_lot`-backed implementations of the six storage
+//! traits, for unit/integration tests and local development without a real
+//! database. State is ephemeral — it lives only for the life of the process.

--- a/aa-storage-memory/src/lib.rs
+++ b/aa-storage-memory/src/lib.rs
@@ -7,7 +7,9 @@
 mod audit_sink;
 mod credential_store;
 mod lifecycle_store;
+mod policy_store;
 
 pub use audit_sink::MemoryAuditSink;
 pub use credential_store::MemoryCredentialStore;
 pub use lifecycle_store::MemoryLifecycleStore;
+pub use policy_store::MemoryPolicyStore;

--- a/aa-storage-memory/src/lib.rs
+++ b/aa-storage-memory/src/lib.rs
@@ -3,15 +3,21 @@
 //! `DashMap`- and `parking_lot`-backed implementations of the six storage
 //! traits, for unit/integration tests and local development without a real
 //! database. State is ephemeral — it lives only for the life of the process.
+//!
+//! Each store is a self-contained backend. Selecting them by name and building
+//! them from an `agent-assembly.toml` `[storage]` section is the job of the
+//! `aa-storage` driver registry (AAASM-2361) and the boot wiring, not this crate.
 
 mod audit_sink;
 mod credential_store;
 mod lifecycle_store;
 mod policy_store;
 mod rate_limit_counter;
+mod session_store;
 
 pub use audit_sink::MemoryAuditSink;
 pub use credential_store::MemoryCredentialStore;
 pub use lifecycle_store::MemoryLifecycleStore;
 pub use policy_store::MemoryPolicyStore;
 pub use rate_limit_counter::MemoryRateLimitCounter;
+pub use session_store::MemorySessionStore;

--- a/aa-storage-memory/src/lib.rs
+++ b/aa-storage-memory/src/lib.rs
@@ -3,3 +3,7 @@
 //! `DashMap`- and `parking_lot`-backed implementations of the six storage
 //! traits, for unit/integration tests and local development without a real
 //! database. State is ephemeral — it lives only for the life of the process.
+
+mod audit_sink;
+
+pub use audit_sink::MemoryAuditSink;

--- a/aa-storage-memory/src/lib.rs
+++ b/aa-storage-memory/src/lib.rs
@@ -6,6 +6,8 @@
 
 mod audit_sink;
 mod credential_store;
+mod lifecycle_store;
 
 pub use audit_sink::MemoryAuditSink;
 pub use credential_store::MemoryCredentialStore;
+pub use lifecycle_store::MemoryLifecycleStore;

--- a/aa-storage-memory/src/lib.rs
+++ b/aa-storage-memory/src/lib.rs
@@ -5,5 +5,7 @@
 //! database. State is ephemeral — it lives only for the life of the process.
 
 mod audit_sink;
+mod credential_store;
 
 pub use audit_sink::MemoryAuditSink;
+pub use credential_store::MemoryCredentialStore;

--- a/aa-storage-memory/src/lifecycle_store.rs
+++ b/aa-storage-memory/src/lifecycle_store.rs
@@ -1,0 +1,45 @@
+//! In-memory [`LifecycleStore`] backed by a `DashMap`.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use aa_storage::{AgentId, LifecycleStore, Result, StorageError};
+use async_trait::async_trait;
+use dashmap::DashMap;
+
+/// A `DashMap`-backed [`LifecycleStore`] mapping a registered agent to the
+/// instant of its last heartbeat. Cloning shares the same underlying map.
+#[derive(Clone, Default)]
+pub struct MemoryLifecycleStore {
+    agents: Arc<DashMap<[u8; 16], Instant>>,
+}
+
+impl MemoryLifecycleStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl LifecycleStore for MemoryLifecycleStore {
+    async fn register(&self, agent_id: &AgentId) -> Result<()> {
+        self.agents.insert(*agent_id.as_bytes(), Instant::now());
+        Ok(())
+    }
+
+    async fn heartbeat(&self, agent_id: &AgentId) -> Result<()> {
+        match self.agents.get_mut(agent_id.as_bytes()) {
+            Some(mut entry) => {
+                *entry = Instant::now();
+                Ok(())
+            }
+            None => Err(StorageError::NotFound(format!("agent {:?}", agent_id.as_bytes()))),
+        }
+    }
+
+    async fn deregister(&self, agent_id: &AgentId) -> Result<()> {
+        self.agents.remove(agent_id.as_bytes());
+        Ok(())
+    }
+}

--- a/aa-storage-memory/src/policy_store.rs
+++ b/aa-storage-memory/src/policy_store.rs
@@ -1,0 +1,47 @@
+//! In-memory [`PolicyStore`] backed by a `DashMap`.
+
+use std::sync::Arc;
+
+use aa_storage::{AgentId, PolicyDocument, PolicyStore, Result, StorageError};
+use async_trait::async_trait;
+use dashmap::DashMap;
+
+/// A `DashMap`-backed [`PolicyStore`] for tests and local development.
+///
+/// The store is authoritative — it holds the policies directly rather than
+/// caching a remote source — so [`invalidate`](PolicyStore::invalidate) is a
+/// no-op (there is no upstream to reload from). Cloning shares the same
+/// underlying map.
+#[derive(Clone, Default)]
+pub struct MemoryPolicyStore {
+    policies: Arc<DashMap<[u8; 16], PolicyDocument>>,
+}
+
+impl MemoryPolicyStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert or replace the policy associated with `agent_id`.
+    ///
+    /// A seed helper for tests and boot wiring; not part of the trait contract.
+    pub fn insert(&self, agent_id: &AgentId, policy: PolicyDocument) {
+        self.policies.insert(*agent_id.as_bytes(), policy);
+    }
+}
+
+#[async_trait]
+impl PolicyStore for MemoryPolicyStore {
+    async fn get_policy(&self, agent_id: &AgentId) -> Result<PolicyDocument> {
+        self.policies
+            .get(agent_id.as_bytes())
+            .map(|entry| entry.value().clone())
+            .ok_or_else(|| StorageError::NotFound(format!("policy for agent {:?}", agent_id.as_bytes())))
+    }
+
+    async fn invalidate(&self, _agent_id: &AgentId) -> Result<()> {
+        // Authoritative store: nothing is cached, so there is nothing to drop.
+        Ok(())
+    }
+}

--- a/aa-storage-memory/src/rate_limit_counter.rs
+++ b/aa-storage-memory/src/rate_limit_counter.rs
@@ -1,0 +1,66 @@
+//! In-memory [`RateLimitCounter`] backed by a `DashMap` of windowed counters.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use aa_storage::{RateLimitCounter, Result};
+use async_trait::async_trait;
+use dashmap::DashMap;
+
+/// A single key's counter and the window it is bucketed into.
+struct Window {
+    count: u64,
+    start: Instant,
+    window: Duration,
+}
+
+/// A `DashMap`-backed [`RateLimitCounter`].
+///
+/// Each key tracks a count and the wall-clock start of its current window;
+/// once the window elapses the count rolls over to zero on the next access.
+/// `DashMap`'s per-key entry lock makes the read-modify-write in
+/// [`increment`](RateLimitCounter::increment) atomic across concurrent callers.
+/// Cloning shares the same underlying map.
+#[derive(Clone, Default)]
+pub struct MemoryRateLimitCounter {
+    counters: Arc<DashMap<String, Window>>,
+}
+
+impl MemoryRateLimitCounter {
+    /// Create an empty counter set.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl RateLimitCounter for MemoryRateLimitCounter {
+    async fn increment(&self, key: &str, amount: u64, window_secs: u64) -> Result<u64> {
+        let window = Duration::from_secs(window_secs);
+        let now = Instant::now();
+        let mut entry = self.counters.entry(key.to_owned()).or_insert_with(|| Window {
+            count: 0,
+            start: now,
+            window,
+        });
+        if now.duration_since(entry.start) >= entry.window {
+            entry.count = 0;
+            entry.start = now;
+            entry.window = window;
+        }
+        entry.count = entry.count.saturating_add(amount);
+        Ok(entry.count)
+    }
+
+    async fn current(&self, key: &str) -> Result<u64> {
+        match self.counters.get(key) {
+            Some(entry) if Instant::now().duration_since(entry.start) < entry.window => Ok(entry.count),
+            _ => Ok(0),
+        }
+    }
+
+    async fn reset(&self, key: &str) -> Result<()> {
+        self.counters.remove(key);
+        Ok(())
+    }
+}

--- a/aa-storage-memory/src/session_store.rs
+++ b/aa-storage-memory/src/session_store.rs
@@ -1,0 +1,41 @@
+//! In-memory [`SessionStore`] backed by a `DashMap`.
+
+use std::sync::Arc;
+
+use aa_storage::{Result, SessionId, SessionRecord, SessionStore, StorageError};
+use async_trait::async_trait;
+use dashmap::DashMap;
+
+/// A `DashMap`-backed [`SessionStore`] keyed by session id. Cloning shares the
+/// same underlying map.
+#[derive(Clone, Default)]
+pub struct MemorySessionStore {
+    sessions: Arc<DashMap<[u8; 16], SessionRecord>>,
+}
+
+impl MemorySessionStore {
+    /// Create an empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl SessionStore for MemorySessionStore {
+    async fn save(&self, session: SessionRecord) -> Result<()> {
+        self.sessions.insert(*session.session_id.as_bytes(), session);
+        Ok(())
+    }
+
+    async fn load(&self, session_id: &SessionId) -> Result<SessionRecord> {
+        self.sessions
+            .get(session_id.as_bytes())
+            .map(|entry| entry.value().clone())
+            .ok_or_else(|| StorageError::NotFound(format!("session {:?}", session_id.as_bytes())))
+    }
+
+    async fn delete(&self, session_id: &SessionId) -> Result<()> {
+        self.sessions.remove(session_id.as_bytes());
+        Ok(())
+    }
+}

--- a/aa-storage-memory/tests/conformance.rs
+++ b/aa-storage-memory/tests/conformance.rs
@@ -3,12 +3,13 @@
 
 use aa_core::{AuditEventType, EnforcementMode};
 use aa_storage::conformance::{
-    assert_audit_sink_conformance, assert_credential_store_conformance, assert_policy_store_conformance,
-    assert_rate_limit_counter_conformance, assert_session_store_conformance,
+    assert_audit_sink_conformance, assert_credential_store_conformance, assert_lifecycle_store_conformance,
+    assert_policy_store_conformance, assert_rate_limit_counter_conformance, assert_session_store_conformance,
 };
 use aa_storage::{AgentId, AuditEntry, PolicyDocument, SessionId, SessionRecord};
 use aa_storage_memory::{
-    MemoryAuditSink, MemoryCredentialStore, MemoryPolicyStore, MemoryRateLimitCounter, MemorySessionStore,
+    MemoryAuditSink, MemoryCredentialStore, MemoryLifecycleStore, MemoryPolicyStore, MemoryRateLimitCounter,
+    MemorySessionStore,
 };
 
 fn sample_policy() -> PolicyDocument {
@@ -69,4 +70,12 @@ async fn credential_store_conformance() {
 async fn rate_limit_counter_conformance() {
     let counter = MemoryRateLimitCounter::new();
     assert_rate_limit_counter_conformance(&counter, "team-1:tokens").await;
+}
+
+#[tokio::test]
+async fn lifecycle_store_conformance() {
+    let present = AgentId::from_bytes([1; 16]);
+    let absent = AgentId::from_bytes([2; 16]);
+    let store = MemoryLifecycleStore::new();
+    assert_lifecycle_store_conformance(&store, &present, &absent).await;
 }

--- a/aa-storage-memory/tests/conformance.rs
+++ b/aa-storage-memory/tests/conformance.rs
@@ -1,10 +1,10 @@
 //! Trait-conformance suite: the shared `aa-storage` harnesses run against every
 //! memory backend through a `&dyn` reference, exercising object-safety too.
 
-use aa_core::EnforcementMode;
-use aa_storage::conformance::assert_policy_store_conformance;
-use aa_storage::{AgentId, PolicyDocument};
-use aa_storage_memory::MemoryPolicyStore;
+use aa_core::{AuditEventType, EnforcementMode};
+use aa_storage::conformance::{assert_audit_sink_conformance, assert_policy_store_conformance};
+use aa_storage::{AgentId, AuditEntry, PolicyDocument, SessionId};
+use aa_storage_memory::{MemoryAuditSink, MemoryPolicyStore};
 
 fn sample_policy() -> PolicyDocument {
     PolicyDocument {
@@ -15,6 +15,18 @@ fn sample_policy() -> PolicyDocument {
     }
 }
 
+fn sample_audit_entry() -> AuditEntry {
+    AuditEntry::new(
+        0,
+        0,
+        AuditEventType::ToolCallIntercepted,
+        AgentId::from_bytes([1; 16]),
+        SessionId::from_bytes([9; 16]),
+        "{}".to_owned(),
+        [0u8; 32],
+    )
+}
+
 #[tokio::test]
 async fn policy_store_conformance() {
     let present = AgentId::from_bytes([1; 16]);
@@ -22,4 +34,11 @@ async fn policy_store_conformance() {
     let store = MemoryPolicyStore::new();
     store.insert(&present, sample_policy());
     assert_policy_store_conformance(&store, &present, &absent).await;
+}
+
+#[tokio::test]
+async fn audit_sink_conformance() {
+    let sink = MemoryAuditSink::new();
+    assert_audit_sink_conformance(&sink, sample_audit_entry()).await;
+    assert_eq!(sink.len(), 1, "emitted entry should be buffered");
 }

--- a/aa-storage-memory/tests/conformance.rs
+++ b/aa-storage-memory/tests/conformance.rs
@@ -1,0 +1,25 @@
+//! Trait-conformance suite: the shared `aa-storage` harnesses run against every
+//! memory backend through a `&dyn` reference, exercising object-safety too.
+
+use aa_core::EnforcementMode;
+use aa_storage::conformance::assert_policy_store_conformance;
+use aa_storage::{AgentId, PolicyDocument};
+use aa_storage_memory::MemoryPolicyStore;
+
+fn sample_policy() -> PolicyDocument {
+    PolicyDocument {
+        version: 1,
+        name: "conformance".to_owned(),
+        rules: Vec::new(),
+        enforcement_mode: EnforcementMode::default(),
+    }
+}
+
+#[tokio::test]
+async fn policy_store_conformance() {
+    let present = AgentId::from_bytes([1; 16]);
+    let absent = AgentId::from_bytes([2; 16]);
+    let store = MemoryPolicyStore::new();
+    store.insert(&present, sample_policy());
+    assert_policy_store_conformance(&store, &present, &absent).await;
+}

--- a/aa-storage-memory/tests/conformance.rs
+++ b/aa-storage-memory/tests/conformance.rs
@@ -2,9 +2,11 @@
 //! memory backend through a `&dyn` reference, exercising object-safety too.
 
 use aa_core::{AuditEventType, EnforcementMode};
-use aa_storage::conformance::{assert_audit_sink_conformance, assert_policy_store_conformance};
-use aa_storage::{AgentId, AuditEntry, PolicyDocument, SessionId};
-use aa_storage_memory::{MemoryAuditSink, MemoryPolicyStore};
+use aa_storage::conformance::{
+    assert_audit_sink_conformance, assert_policy_store_conformance, assert_session_store_conformance,
+};
+use aa_storage::{AgentId, AuditEntry, PolicyDocument, SessionId, SessionRecord};
+use aa_storage_memory::{MemoryAuditSink, MemoryPolicyStore, MemorySessionStore};
 
 fn sample_policy() -> PolicyDocument {
     PolicyDocument {
@@ -41,4 +43,15 @@ async fn audit_sink_conformance() {
     let sink = MemoryAuditSink::new();
     assert_audit_sink_conformance(&sink, sample_audit_entry()).await;
     assert_eq!(sink.len(), 1, "emitted entry should be buffered");
+}
+
+#[tokio::test]
+async fn session_store_conformance() {
+    let store = MemorySessionStore::new();
+    let record = SessionRecord {
+        session_id: SessionId::from_bytes([3; 16]),
+        agent_id: AgentId::from_bytes([1; 16]),
+        started_at_ns: 42,
+    };
+    assert_session_store_conformance(&store, record).await;
 }

--- a/aa-storage-memory/tests/conformance.rs
+++ b/aa-storage-memory/tests/conformance.rs
@@ -4,10 +4,12 @@
 use aa_core::{AuditEventType, EnforcementMode};
 use aa_storage::conformance::{
     assert_audit_sink_conformance, assert_credential_store_conformance, assert_policy_store_conformance,
-    assert_session_store_conformance,
+    assert_rate_limit_counter_conformance, assert_session_store_conformance,
 };
 use aa_storage::{AgentId, AuditEntry, PolicyDocument, SessionId, SessionRecord};
-use aa_storage_memory::{MemoryAuditSink, MemoryCredentialStore, MemoryPolicyStore, MemorySessionStore};
+use aa_storage_memory::{
+    MemoryAuditSink, MemoryCredentialStore, MemoryPolicyStore, MemoryRateLimitCounter, MemorySessionStore,
+};
 
 fn sample_policy() -> PolicyDocument {
     PolicyDocument {
@@ -61,4 +63,10 @@ async fn session_store_conformance() {
 async fn credential_store_conformance() {
     let store = MemoryCredentialStore::new();
     assert_credential_store_conformance(&store, "openai/api_key", b"sk-secret".to_vec()).await;
+}
+
+#[tokio::test]
+async fn rate_limit_counter_conformance() {
+    let counter = MemoryRateLimitCounter::new();
+    assert_rate_limit_counter_conformance(&counter, "team-1:tokens").await;
 }

--- a/aa-storage-memory/tests/conformance.rs
+++ b/aa-storage-memory/tests/conformance.rs
@@ -3,10 +3,11 @@
 
 use aa_core::{AuditEventType, EnforcementMode};
 use aa_storage::conformance::{
-    assert_audit_sink_conformance, assert_policy_store_conformance, assert_session_store_conformance,
+    assert_audit_sink_conformance, assert_credential_store_conformance, assert_policy_store_conformance,
+    assert_session_store_conformance,
 };
 use aa_storage::{AgentId, AuditEntry, PolicyDocument, SessionId, SessionRecord};
-use aa_storage_memory::{MemoryAuditSink, MemoryPolicyStore, MemorySessionStore};
+use aa_storage_memory::{MemoryAuditSink, MemoryCredentialStore, MemoryPolicyStore, MemorySessionStore};
 
 fn sample_policy() -> PolicyDocument {
     PolicyDocument {
@@ -54,4 +55,10 @@ async fn session_store_conformance() {
         started_at_ns: 42,
     };
     assert_session_store_conformance(&store, record).await;
+}
+
+#[tokio::test]
+async fn credential_store_conformance() {
+    let store = MemoryCredentialStore::new();
+    assert_credential_store_conformance(&store, "openai/api_key", b"sk-secret".to_vec()).await;
 }

--- a/aa-storage-memory/tests/integration.rs
+++ b/aa-storage-memory/tests/integration.rs
@@ -1,0 +1,50 @@
+//! All-memory end-to-end check: drive the memory backends together the way an
+//! all-`"memory"` deployment would — lifecycle, policy lookup, and audit.
+
+use aa_core::{AuditEventType, EnforcementMode};
+use aa_storage::{AgentId, AuditEntry, AuditSink, LifecycleStore, PolicyDocument, PolicyStore, SessionId};
+use aa_storage_memory::{MemoryAuditSink, MemoryLifecycleStore, MemoryPolicyStore};
+
+#[tokio::test]
+async fn all_memory_lifecycle_policy_and_audit_round_trip() {
+    let agent = AgentId::from_bytes([7; 16]);
+    let session = SessionId::from_bytes([8; 16]);
+
+    // Lifecycle: register the agent and heartbeat it.
+    let lifecycle = MemoryLifecycleStore::new();
+    lifecycle.register(&agent).await.expect("register should succeed");
+    lifecycle.heartbeat(&agent).await.expect("heartbeat should succeed");
+
+    // Policy lookup: seed and resolve the agent's effective policy.
+    let policies = MemoryPolicyStore::new();
+    policies.insert(
+        &agent,
+        PolicyDocument {
+            version: 1,
+            name: "all-memory".to_owned(),
+            rules: Vec::new(),
+            enforcement_mode: EnforcementMode::default(),
+        },
+    );
+    let resolved = policies.get_policy(&agent).await.expect("policy should resolve");
+    assert_eq!(resolved.name, "all-memory");
+
+    // Audit: emit an event and drain it back.
+    let audit = MemoryAuditSink::new();
+    audit
+        .emit(AuditEntry::new(
+            0,
+            0,
+            AuditEventType::PolicyViolation,
+            agent,
+            session,
+            "{}".to_owned(),
+            [0u8; 32],
+        ))
+        .await
+        .expect("emit should succeed");
+    let drained = audit.drain();
+    assert_eq!(drained.len(), 1, "one entry should have been emitted");
+    assert_eq!(drained[0].event_type(), AuditEventType::PolicyViolation);
+    assert!(audit.is_empty(), "drain should empty the buffer");
+}

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -14,6 +14,12 @@ This document tracks which versions of `aa-runtime` are compatible with each SDK
      version and introduces no version change to aa-runtime or any SDK; this
      comment satisfies the compatibility-matrix CI gate. -->
 
+<!-- AAASM-2367: added the `aa-storage-memory` crate to root Cargo.toml
+     workspace members (in-memory storage driver for tests / local dev). It
+     inherits the workspace version and introduces no version change to
+     aa-runtime or any SDK; this comment satisfies the compatibility-matrix
+     CI gate. -->
+
 
 ---
 


### PR DESCRIPTION
## Description

Implements **AAASM-2367** — the in-memory `aa-storage` driver, the baseline backend every other driver crate (Postgres, Redis, SQLite-buffer) validates its trait-conformance suite against under Epic **AAASM-2348**.

This PR delivers:

1. **`aa-storage-memory` crate** — `DashMap`/`parking_lot`-backed `MemoryPolicyStore`, `MemoryAuditSink`, `MemorySessionStore`, `MemoryCredentialStore`, `MemoryRateLimitCounter`, `MemoryLifecycleStore`. Deps: `aa-core`, `aa-storage`, `async-trait`, `dashmap`, `parking_lot` (+ `tokio` dev-only).
2. **Conformance harness extension** — `aa_core::storage::conformance` gains `assert_*_conformance` for `AuditSink`, `SessionStore`, `CredentialStore`, `RateLimitCounter`, and `LifecycleStore`, mirroring the existing `PolicyStore` harness. Every driver now validates all six traits through a `&dyn` reference.
3. **Tests** — the six-trait conformance suite + an all-memory integration test (lifecycle register/heartbeat, seeded policy lookup, audit emit + drain).

### Design alignment

The OSS storage **driver registry** (`aa_storage::Registry`, factory traits, `StorageConfig`, `register_builtin_drivers`) is owned by **AAASM-2361 (PR #876)**, and sibling driver crates (e.g. `aa-storage-redis`, #879) ship only their concrete stores without adding a registry or self-registering. This PR follows that same pattern: it provides the six `Memory*` stores and tests them directly. Binding the driver name `"memory"` into `aa_storage::Registry` and booting from an `agent-assembly.toml` `[storage]` section is the registry/boot layer's job, tracked by follow-up subtask **AAASM-2464**.

> Note: an earlier revision of this PR introduced a separate `aa_core::storage::Registry`. That was reworked out once #876's canonical registry was found, to avoid a duplicate/conflicting registry. The branch stays on `master` (no stacking), consistent with the redis sibling.

Two deviations from the ticket text, both intentional:
- The crate lives at repo root (`aa-storage-memory/`), matching the existing `aa-storage/` convention — there is no `crates/` directory in this workspace.
- `async-trait` is a required dependency (the storage traits are `#[async_trait]`); the "minimal deps" AC is read as "no `sqlx`/`redis`/server deps".

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No — `aa-core` change is purely additive (5 new conformance fns).

## Related Issues

- Related Jira ticket: AAASM-2367 (Story AAASM-2363, Epic AAASM-2348). Follow-up: AAASM-2464.

## Testing

- [x] Unit tests added / updated — conformance harnesses exercised via the driver.
- [x] Integration tests added / updated — six-trait conformance suite + all-memory round-trip in `aa-storage-memory`.
- [x] Manual testing performed — `cargo nextest run -p aa-storage-memory -p aa-core` (268 passed), `cargo clippy --all-targets --all-features -D warnings` clean, `cargo doc --workspace --no-deps` clean for the new crate.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing (pending CI run)
- [x] Commits are small and follow the Gitmoji convention
