### PR TITLE
[AAASM-2397] ✨ (sanitizer): Add write-boundary audit-event sanitizer

### DIFF
--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -23,6 +23,7 @@ pub mod policy;
 pub mod registry;
 pub mod remote_mode;
 pub mod routes;
+pub mod sanitizer;
 pub mod secrets;
 pub mod server;
 pub mod service;

--- a/aa-gateway/src/sanitizer/event.rs
+++ b/aa-gateway/src/sanitizer/event.rs
@@ -1,10 +1,6 @@
 //! Newtypes that mark the trust boundary between raw inbound audit events and
 //! the sanitized form the storage layer is allowed to persist.
 
-// Accessors are consumed once `sanitize` is wired up; introduced here with the
-// types they belong to.
-#![allow(dead_code)]
-
 use serde_json::Value;
 
 /// An audit event exactly as received off the wire (NATS subject

--- a/aa-gateway/src/sanitizer/event.rs
+++ b/aa-gateway/src/sanitizer/event.rs
@@ -62,3 +62,25 @@ impl SanitizedAuditEvent {
         self.0
     }
 }
+
+/// A collapsed heartbeat. Per-beat records are never stored; instead a
+/// heartbeat event becomes a single "last seen at" update on the agent row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeartbeatUpdate {
+    /// Agent the heartbeat belongs to (empty when the event omitted it).
+    pub agent_id: String,
+    /// Heartbeat timestamp as carried by the event, left as the raw JSON
+    /// scalar (`Null` when absent) so the storage layer owns parsing and may
+    /// fall back to `now()`.
+    pub last_heartbeat_at: Value,
+}
+
+/// The result of sanitizing a raw audit event — either an audit row to INSERT
+/// or a heartbeat to collapse into an agent "last seen" update.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SanitizeOutcome {
+    /// A normal event: write this sanitized row to `audit_logs`.
+    Audit(SanitizedAuditEvent),
+    /// A heartbeat: update `agents.last_heartbeat` instead of inserting a row.
+    Heartbeat(HeartbeatUpdate),
+}

--- a/aa-gateway/src/sanitizer/event.rs
+++ b/aa-gateway/src/sanitizer/event.rs
@@ -1,0 +1,35 @@
+//! Newtypes that mark the trust boundary between raw inbound audit events and
+//! the sanitized form the storage layer is allowed to persist.
+
+// Accessors are consumed once `sanitize` is wired up; introduced here with the
+// types they belong to.
+#![allow(dead_code)]
+
+use serde_json::Value;
+
+/// An audit event exactly as received off the wire (NATS subject
+/// `assembly.audit.>`), before any field-drop rules are applied.
+///
+/// Carries whatever an upstream SDK or proxy chose to emit — including fields
+/// we must never persist. The only way to turn one into something the storage
+/// layer accepts is [`sanitize`](super::sanitize).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawAuditEvent(Value);
+
+impl RawAuditEvent {
+    /// Wraps a decoded JSON value as a raw, untrusted audit event.
+    pub fn new(value: Value) -> Self {
+        Self(value)
+    }
+
+    /// Consumes the wrapper, yielding the underlying JSON value.
+    pub(crate) fn into_value(self) -> Value {
+        self.0
+    }
+}
+
+impl From<Value> for RawAuditEvent {
+    fn from(value: Value) -> Self {
+        Self::new(value)
+    }
+}

--- a/aa-gateway/src/sanitizer/event.rs
+++ b/aa-gateway/src/sanitizer/event.rs
@@ -33,3 +33,32 @@ impl From<Value> for RawAuditEvent {
         Self::new(value)
     }
 }
+
+/// An audit event that has passed the write-boundary sanitizer: guaranteed to
+/// contain none of the banned keys at any depth and only vetted top-level
+/// metadata.
+///
+/// The inner value is private and the constructor is crate-private, so the
+/// **only** way to obtain one is [`sanitize`](super::sanitize). Postgres
+/// handlers accept this type and nothing else, which makes "raw events never
+/// get INSERTed" a compile-time guarantee rather than a convention.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SanitizedAuditEvent(Value);
+
+impl SanitizedAuditEvent {
+    /// Mints the sanitized wrapper. Crate-private on purpose: only the
+    /// sanitizer may vouch that a value is safe to persist.
+    pub(crate) fn new(value: Value) -> Self {
+        Self(value)
+    }
+
+    /// Borrows the sanitized JSON value for persistence.
+    pub fn as_value(&self) -> &Value {
+        &self.0
+    }
+
+    /// Consumes the wrapper, yielding the sanitized JSON value.
+    pub fn into_value(self) -> Value {
+        self.0
+    }
+}

--- a/aa-gateway/src/sanitizer/mod.rs
+++ b/aa-gateway/src/sanitizer/mod.rs
@@ -13,4 +13,7 @@
 //! them so a newly-emitting sender is noticed), and collapses heartbeats into a
 //! single "last seen" update instead of a per-beat row.
 
+mod event;
 mod rules;
+
+pub use event::RawAuditEvent;

--- a/aa-gateway/src/sanitizer/mod.rs
+++ b/aa-gateway/src/sanitizer/mod.rs
@@ -15,5 +15,6 @@
 
 mod event;
 mod rules;
+mod sanitize;
 
 pub use event::{HeartbeatUpdate, RawAuditEvent, SanitizeOutcome, SanitizedAuditEvent};

--- a/aa-gateway/src/sanitizer/mod.rs
+++ b/aa-gateway/src/sanitizer/mod.rs
@@ -18,3 +18,4 @@ mod rules;
 mod sanitize;
 
 pub use event::{HeartbeatUpdate, RawAuditEvent, SanitizeOutcome, SanitizedAuditEvent};
+pub use sanitize::sanitize;

--- a/aa-gateway/src/sanitizer/mod.rs
+++ b/aa-gateway/src/sanitizer/mod.rs
@@ -16,4 +16,4 @@
 mod event;
 mod rules;
 
-pub use event::RawAuditEvent;
+pub use event::{RawAuditEvent, SanitizedAuditEvent};

--- a/aa-gateway/src/sanitizer/mod.rs
+++ b/aa-gateway/src/sanitizer/mod.rs
@@ -16,4 +16,4 @@
 mod event;
 mod rules;
 
-pub use event::{RawAuditEvent, SanitizedAuditEvent};
+pub use event::{HeartbeatUpdate, RawAuditEvent, SanitizeOutcome, SanitizedAuditEvent};

--- a/aa-gateway/src/sanitizer/mod.rs
+++ b/aa-gateway/src/sanitizer/mod.rs
@@ -1,0 +1,16 @@
+//! Write-boundary sanitizer (AAASM-2390 / AAASM-2397).
+//!
+//! Every audit event the Gateway consumer is about to persist passes through
+//! [`sanitize`] first. The sanitizer is the *boundary* line of defense:
+//! regardless of what an upstream SDK or proxy emits, the four classes of
+//! "never store" data — raw LLM prompts/completions, full tool-call payloads,
+//! eBPF packet bodies, and per-heartbeat sequence records — are dropped before
+//! anything reaches `audit_logs`.
+//!
+//! The sender is the first line of defense; this module is the last. It never
+//! trusts the inbound shape: it operates on the untyped JSON tree as received,
+//! strips banned keys recursively, drops unknown top-level fields (counting
+//! them so a newly-emitting sender is noticed), and collapses heartbeats into a
+//! single "last seen" update instead of a per-beat row.
+
+mod rules;

--- a/aa-gateway/src/sanitizer/rules.rs
+++ b/aa-gateway/src/sanitizer/rules.rs
@@ -26,7 +26,40 @@ pub(crate) const BANNED_KEYS: &[&str] = &[
     "heartbeat_seq",
 ];
 
+/// Top-level metadata keys the sanitizer keeps. Mirrors the `audit_events`
+/// columns plus the event-routing fields a sender may set (`kind`,
+/// `event_type`, `session_id`, `org_id`, `timestamp`, `policy_version`). The
+/// `payload` container is kept — its dangerous contents are removed by the
+/// recursive [`BANNED_KEYS`] pass, not by dropping the whole object.
+///
+/// Anything else at the top level is dropped and counted via
+/// `aa_audit_dropped_unknown_field_total`, so we notice when a sender starts
+/// emitting a field we have not vetted.
+pub(crate) const ALLOWED_TOP_LEVEL_KEYS: &[&str] = &[
+    "event_id",
+    "ts",
+    "timestamp",
+    "agent_id",
+    "team_id",
+    "org_id",
+    "session_id",
+    "kind",
+    "event_type",
+    "action",
+    "decision",
+    "dry_run",
+    "shadow_decision",
+    "matched_rule_id",
+    "policy_version",
+    "payload",
+];
+
 /// Returns `true` if `key` is on the recursive banned list.
 pub(crate) fn is_banned(key: &str) -> bool {
     BANNED_KEYS.contains(&key)
+}
+
+/// Returns `true` if `key` is an allowed top-level metadata key.
+pub(crate) fn is_allowed_top_level(key: &str) -> bool {
+    ALLOWED_TOP_LEVEL_KEYS.contains(&key)
 }

--- a/aa-gateway/src/sanitizer/rules.rs
+++ b/aa-gateway/src/sanitizer/rules.rs
@@ -1,9 +1,5 @@
 //! Field-classification rule sets for the write-boundary sanitizer.
 
-// Consumed by `sanitize` once the entrypoint is wired up; until then the rule
-// sets are introduced ahead of their first caller.
-#![allow(dead_code)]
-
 /// Keys whose values are **never** persisted. Stripped recursively at every
 /// depth of the event tree before an audit row is constructed.
 ///

--- a/aa-gateway/src/sanitizer/rules.rs
+++ b/aa-gateway/src/sanitizer/rules.rs
@@ -1,0 +1,32 @@
+//! Field-classification rule sets for the write-boundary sanitizer.
+
+// Consumed by `sanitize` once the entrypoint is wired up; until then the rule
+// sets are introduced ahead of their first caller.
+#![allow(dead_code)]
+
+/// Keys whose values are **never** persisted. Stripped recursively at every
+/// depth of the event tree before an audit row is constructed.
+///
+/// This is the union of the spec's "確定不用存" (must NOT store) list
+/// (spec lines 7551–7572) and the expanded observability-payload keys called
+/// out in AAASM-2397: raw LLM prompt / completion, full tool-call payloads,
+/// eBPF packet bodies, and the per-heartbeat sequence counter. A superset is
+/// deliberate — defense-in-depth means erring toward dropping.
+pub(crate) const BANNED_KEYS: &[&str] = &[
+    "prompt",
+    "completion",
+    "llm_input",
+    "llm_output",
+    "tool_payload",
+    "tool_response",
+    "tool_args",
+    "tool_result",
+    "packet_body",
+    "packet_payload",
+    "heartbeat_seq",
+];
+
+/// Returns `true` if `key` is on the recursive banned list.
+pub(crate) fn is_banned(key: &str) -> bool {
+    BANNED_KEYS.contains(&key)
+}

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -159,4 +159,14 @@ mod tests {
         }));
         assert!(!contains_key_recursive(&audit_value(raw), "llm_output"));
     }
+
+    #[test]
+    fn drops_tool_payload_field() {
+        let raw = RawAuditEvent::new(json!({
+            "kind": "tool_call",
+            "agent_id": "acme/bot",
+            "tool_payload": { "args": { "path": "/etc/passwd" } },
+        }));
+        assert!(!contains_key_recursive(&audit_value(raw), "tool_payload"));
+    }
 }

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -247,4 +247,21 @@ mod tests {
         assert!(!contains_key_recursive(&out, "prompt"));
         assert!(!contains_key_recursive(&out, "completion"));
     }
+
+    #[test]
+    fn heartbeat_routes_to_last_seen_update() {
+        let raw = RawAuditEvent::new(json!({
+            "kind": "heartbeat",
+            "agent_id": "acme/bot",
+            "ts": "2026-06-03T00:00:00Z",
+            "heartbeat_seq": 7,
+        }));
+        match sanitize(raw) {
+            SanitizeOutcome::Heartbeat(hb) => {
+                assert_eq!(hb.agent_id, "acme/bot");
+                assert_eq!(hb.last_heartbeat_at, json!("2026-06-03T00:00:00Z"));
+            }
+            SanitizeOutcome::Audit(_) => panic!("heartbeat must not become an audit row"),
+        }
+    }
 }

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -179,4 +179,14 @@ mod tests {
         }));
         assert!(!contains_key_recursive(&audit_value(raw), "tool_response"));
     }
+
+    #[test]
+    fn drops_tool_args_field() {
+        let raw = RawAuditEvent::new(json!({
+            "kind": "tool_call",
+            "agent_id": "acme/bot",
+            "tool_args": ["--token", "sekret"],
+        }));
+        assert!(!contains_key_recursive(&audit_value(raw), "tool_args"));
+    }
 }

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -209,4 +209,14 @@ mod tests {
         }));
         assert!(!contains_key_recursive(&audit_value(raw), "packet_body"));
     }
+
+    #[test]
+    fn drops_packet_payload_field() {
+        let raw = RawAuditEvent::new(json!({
+            "kind": "tool_call",
+            "agent_id": "acme/bot",
+            "packet_payload": "raw-packet-bytes",
+        }));
+        assert!(!contains_key_recursive(&audit_value(raw), "packet_payload"));
+    }
 }

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -219,4 +219,14 @@ mod tests {
         }));
         assert!(!contains_key_recursive(&audit_value(raw), "packet_payload"));
     }
+
+    #[test]
+    fn drops_heartbeat_seq_field() {
+        let raw = RawAuditEvent::new(json!({
+            "kind": "tool_call",
+            "agent_id": "acme/bot",
+            "heartbeat_seq": 42,
+        }));
+        assert!(!contains_key_recursive(&audit_value(raw), "heartbeat_seq"));
+    }
 }

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -95,3 +95,38 @@ pub fn sanitize(raw: RawAuditEvent) -> SanitizeOutcome {
 
     SanitizeOutcome::Audit(SanitizedAuditEvent::new(value))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize;
+    use crate::sanitizer::{RawAuditEvent, SanitizeOutcome};
+    use serde_json::{json, Value};
+
+    /// Recursively reports whether `key` appears anywhere in the JSON tree.
+    fn contains_key_recursive(value: &Value, key: &str) -> bool {
+        match value {
+            Value::Object(map) => map.contains_key(key) || map.values().any(|v| contains_key_recursive(v, key)),
+            Value::Array(items) => items.iter().any(|v| contains_key_recursive(v, key)),
+            _ => false,
+        }
+    }
+
+    /// Sanitizes `raw`, asserting it produced an audit row, and returns the
+    /// sanitized JSON for inspection.
+    fn audit_value(raw: RawAuditEvent) -> Value {
+        match sanitize(raw) {
+            SanitizeOutcome::Audit(ev) => ev.into_value(),
+            other => panic!("expected Audit outcome, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn drops_prompt_field() {
+        let raw = RawAuditEvent::new(json!({
+            "kind": "tool_call",
+            "agent_id": "acme/bot",
+            "prompt": "the raw system prompt",
+        }));
+        assert!(!contains_key_recursive(&audit_value(raw), "prompt"));
+    }
+}

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -229,4 +229,22 @@ mod tests {
         }));
         assert!(!contains_key_recursive(&audit_value(raw), "heartbeat_seq"));
     }
+
+    #[test]
+    fn drops_banned_keys_nested_in_payload() {
+        let raw = RawAuditEvent::new(json!({
+            "kind": "tool_call",
+            "agent_id": "acme/bot",
+            "payload": {
+                "tool_call": { "prompt": "nested secret prompt" },
+                "steps": [{ "completion": "deep completion" }],
+            },
+        }));
+        let out = audit_value(raw);
+        // The vetted `payload` container survives...
+        assert!(contains_key_recursive(&out, "payload"));
+        // ...but banned keys nested anywhere inside it are gone.
+        assert!(!contains_key_recursive(&out, "prompt"));
+        assert!(!contains_key_recursive(&out, "completion"));
+    }
 }

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -264,4 +264,18 @@ mod tests {
             SanitizeOutcome::Audit(_) => panic!("heartbeat must not become an audit row"),
         }
     }
+
+    #[test]
+    fn drops_unknown_top_level_field() {
+        let raw = RawAuditEvent::new(json!({
+            "kind": "tool_call",
+            "agent_id": "acme/bot",
+            "mystery_field": "who put this here",
+        }));
+        let out = audit_value(raw);
+        // The unvetted key is dropped (and counted via the metric)...
+        assert!(!contains_key_recursive(&out, "mystery_field"));
+        // ...while vetted metadata is retained.
+        assert!(contains_key_recursive(&out, "agent_id"));
+    }
 }

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -169,4 +169,14 @@ mod tests {
         }));
         assert!(!contains_key_recursive(&audit_value(raw), "tool_payload"));
     }
+
+    #[test]
+    fn drops_tool_response_field() {
+        let raw = RawAuditEvent::new(json!({
+            "kind": "tool_call",
+            "agent_id": "acme/bot",
+            "tool_response": { "body": "tool stdout bytes" },
+        }));
+        assert!(!contains_key_recursive(&audit_value(raw), "tool_response"));
+    }
 }

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -1,0 +1,28 @@
+//! The write-boundary sanitizer entrypoint and its field-drop helpers.
+
+// Helpers are wired together by `sanitize` in this same module; each is
+// introduced just ahead of its caller.
+#![allow(dead_code)]
+
+use serde_json::Value;
+
+use super::rules;
+
+/// Recursively removes every [`rules::BANNED_KEYS`] entry from a JSON value,
+/// descending into nested objects and array elements. Mutates in place.
+fn strip_banned_keys(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            map.retain(|key, _| !rules::is_banned(key));
+            for child in map.values_mut() {
+                strip_banned_keys(child);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                strip_banned_keys(item);
+            }
+        }
+        _ => {}
+    }
+}

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -26,3 +26,21 @@ fn strip_banned_keys(value: &mut Value) {
         _ => {}
     }
 }
+
+/// Drops any top-level key that is not vetted metadata, emitting
+/// `aa_audit_dropped_unknown_field_total{field=<name>}` once per dropped key.
+///
+/// Must run *after* [`strip_banned_keys`] so that known-bad keys are already
+/// gone and the counter only fires for genuinely unexpected fields — the
+/// signal that a sender has started emitting something new.
+fn drop_unknown_top_level(map: &mut serde_json::Map<String, Value>) {
+    let unknown: Vec<String> = map
+        .keys()
+        .filter(|key| !rules::is_allowed_top_level(key))
+        .cloned()
+        .collect();
+    for field in unknown {
+        map.remove(&field);
+        metrics::counter!("aa_audit_dropped_unknown_field_total", "field" => field).increment(1);
+    }
+}

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -129,4 +129,14 @@ mod tests {
         }));
         assert!(!contains_key_recursive(&audit_value(raw), "prompt"));
     }
+
+    #[test]
+    fn drops_completion_field() {
+        let raw = RawAuditEvent::new(json!({
+            "kind": "tool_call",
+            "agent_id": "acme/bot",
+            "completion": "the model completion text",
+        }));
+        assert!(!contains_key_recursive(&audit_value(raw), "completion"));
+    }
 }

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -6,7 +6,11 @@
 
 use serde_json::Value;
 
+use super::event::HeartbeatUpdate;
 use super::rules;
+
+/// The `kind` discriminant that marks a heartbeat event.
+const HEARTBEAT_KIND: &str = "heartbeat";
 
 /// Recursively removes every [`rules::BANNED_KEYS`] entry from a JSON value,
 /// descending into nested objects and array elements. Mutates in place.
@@ -42,5 +46,32 @@ fn drop_unknown_top_level(map: &mut serde_json::Map<String, Value>) {
     for field in unknown {
         map.remove(&field);
         metrics::counter!("aa_audit_dropped_unknown_field_total", "field" => field).increment(1);
+    }
+}
+
+/// Returns `true` when the event's top-level `kind` is `"heartbeat"`.
+fn is_heartbeat(value: &Value) -> bool {
+    value.get("kind").and_then(Value::as_str) == Some(HEARTBEAT_KIND)
+}
+
+/// Collapses a heartbeat event into a single agent "last seen" update.
+///
+/// Missing fields degrade gracefully: an absent agent id becomes the empty
+/// string and an absent timestamp becomes `Value::Null`, leaving the storage
+/// layer free to default to `now()`.
+fn collapse_heartbeat(value: &Value) -> HeartbeatUpdate {
+    let agent_id = value
+        .get("agent_id")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let last_heartbeat_at = value
+        .get("ts")
+        .or_else(|| value.get("timestamp"))
+        .cloned()
+        .unwrap_or(Value::Null);
+    HeartbeatUpdate {
+        agent_id,
+        last_heartbeat_at,
     }
 }

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -189,4 +189,14 @@ mod tests {
         }));
         assert!(!contains_key_recursive(&audit_value(raw), "tool_args"));
     }
+
+    #[test]
+    fn drops_tool_result_field() {
+        let raw = RawAuditEvent::new(json!({
+            "kind": "tool_call",
+            "agent_id": "acme/bot",
+            "tool_result": { "stdout": "result bytes" },
+        }));
+        assert!(!contains_key_recursive(&audit_value(raw), "tool_result"));
+    }
 }

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -100,6 +100,7 @@ pub fn sanitize(raw: RawAuditEvent) -> SanitizeOutcome {
 mod tests {
     use super::sanitize;
     use crate::sanitizer::{RawAuditEvent, SanitizeOutcome};
+    use proptest::prelude::*;
     use serde_json::{json, Value};
 
     /// Recursively reports whether `key` appears anywhere in the JSON tree.
@@ -277,5 +278,46 @@ mod tests {
         assert!(!contains_key_recursive(&out, "mystery_field"));
         // ...while vetted metadata is retained.
         assert!(contains_key_recursive(&out, "agent_id"));
+    }
+
+    /// Generates object keys, biased toward the banned set so the invariant is
+    /// actually exercised rather than almost never hitting a banned key.
+    fn key_strategy() -> impl Strategy<Value = String> {
+        prop_oneof![
+            proptest::sample::select(crate::sanitizer::rules::BANNED_KEYS).prop_map(String::from),
+            "[a-z_]{1,12}",
+        ]
+    }
+
+    /// Generates an arbitrary, possibly deeply-nested `serde_json::Value`.
+    fn arb_json() -> impl Strategy<Value = Value> {
+        let leaf = prop_oneof![
+            Just(Value::Null),
+            any::<bool>().prop_map(Value::Bool),
+            any::<i64>().prop_map(|n| Value::Number(n.into())),
+            ".*".prop_map(Value::String),
+        ];
+        leaf.prop_recursive(4, 64, 8, |inner| {
+            prop_oneof![
+                prop::collection::vec(inner.clone(), 0..8).prop_map(Value::Array),
+                prop::collection::vec((key_strategy(), inner), 0..8)
+                    .prop_map(|pairs| Value::Object(pairs.into_iter().collect())),
+            ]
+        })
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1000))]
+
+        /// The core invariant: no banned key survives anywhere in the tree of a
+        /// sanitized audit event, for any random input.
+        #[test]
+        fn proptest_no_banned_keys(value in arb_json()) {
+            if let SanitizeOutcome::Audit(ev) = sanitize(RawAuditEvent::new(value)) {
+                for banned in crate::sanitizer::rules::BANNED_KEYS {
+                    prop_assert!(!contains_key_recursive(ev.as_value(), banned));
+                }
+            }
+        }
     }
 }

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -1,12 +1,8 @@
 //! The write-boundary sanitizer entrypoint and its field-drop helpers.
 
-// Helpers are wired together by `sanitize` in this same module; each is
-// introduced just ahead of its caller.
-#![allow(dead_code)]
-
 use serde_json::Value;
 
-use super::event::HeartbeatUpdate;
+use super::event::{HeartbeatUpdate, RawAuditEvent, SanitizeOutcome, SanitizedAuditEvent};
 use super::rules;
 
 /// The `kind` discriminant that marks a heartbeat event.
@@ -74,4 +70,28 @@ fn collapse_heartbeat(value: &Value) -> HeartbeatUpdate {
         agent_id,
         last_heartbeat_at,
     }
+}
+
+/// Sanitizes a raw inbound audit event at the Gateway write boundary.
+///
+/// Heartbeats collapse to a [`HeartbeatUpdate`]; every other event has its
+/// banned keys stripped recursively and its unknown top-level fields dropped,
+/// then is wrapped as a [`SanitizedAuditEvent`] ready to INSERT. This is the
+/// single entrypoint the consumer (AAASM-2388) calls before persisting.
+pub fn sanitize(raw: RawAuditEvent) -> SanitizeOutcome {
+    let mut value = raw.into_value();
+
+    // Heartbeats never become audit rows — collapse to a last-seen update.
+    if is_heartbeat(&value) {
+        return SanitizeOutcome::Heartbeat(collapse_heartbeat(&value));
+    }
+
+    // Defense-in-depth: drop never-store keys at every depth first, so the
+    // unknown-field accounting only sees genuinely unexpected keys.
+    strip_banned_keys(&mut value);
+    if let Value::Object(map) = &mut value {
+        drop_unknown_top_level(map);
+    }
+
+    SanitizeOutcome::Audit(SanitizedAuditEvent::new(value))
 }

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -149,4 +149,14 @@ mod tests {
         }));
         assert!(!contains_key_recursive(&audit_value(raw), "llm_input"));
     }
+
+    #[test]
+    fn drops_llm_output_field() {
+        let raw = RawAuditEvent::new(json!({
+            "kind": "tool_call",
+            "agent_id": "acme/bot",
+            "llm_output": "raw llm output text",
+        }));
+        assert!(!contains_key_recursive(&audit_value(raw), "llm_output"));
+    }
 }

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -199,4 +199,14 @@ mod tests {
         }));
         assert!(!contains_key_recursive(&audit_value(raw), "tool_result"));
     }
+
+    #[test]
+    fn drops_packet_body_field() {
+        let raw = RawAuditEvent::new(json!({
+            "kind": "tool_call",
+            "agent_id": "acme/bot",
+            "packet_body": "QkFTRTY0UEFDS0VU",
+        }));
+        assert!(!contains_key_recursive(&audit_value(raw), "packet_body"));
+    }
 }

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -139,4 +139,14 @@ mod tests {
         }));
         assert!(!contains_key_recursive(&audit_value(raw), "completion"));
     }
+
+    #[test]
+    fn drops_llm_input_field() {
+        let raw = RawAuditEvent::new(json!({
+            "kind": "tool_call",
+            "agent_id": "acme/bot",
+            "llm_input": "raw llm input prompt",
+        }));
+        assert!(!contains_key_recursive(&audit_value(raw), "llm_input"));
+    }
 }


### PR DESCRIPTION
## Description

Implements the **write-boundary sanitizer** (Story AAASM-2390, Epic AAASM-2350 Phase 1) in a new `aa-gateway::sanitizer` module. Every audit event the Gateway is about to persist passes through `sanitize()` first: the four classes of "never store" data — raw LLM prompts/completions, full tool-call payloads, eBPF packet bodies, and per-heartbeat records — are dropped before anything can reach `audit_logs`, **no matter what an upstream SDK or proxy emits**.

### What's here
- **`RawAuditEvent` / `SanitizedAuditEvent`** newtypes over `serde_json::Value`. `SanitizedAuditEvent`'s inner value is private and its constructor is crate-private, so the **only** way to mint one is `sanitize()` — making "raw events never reach the INSERT" a compile-time guarantee (Postgres handlers accept only `SanitizedAuditEvent`).
- **`sanitize(RawAuditEvent) -> SanitizeOutcome`** — recursively strips banned keys at every depth, drops unknown top-level keys (counting them), and returns either an `Audit(SanitizedAuditEvent)` row or a `Heartbeat(HeartbeatUpdate)`.
- **`BANNED_KEYS`** (recursive drop-list): `prompt`, `completion`, `llm_input`, `llm_output`, `tool_payload`, `tool_response`, `tool_args`, `tool_result`, `packet_body`, `packet_payload`, `heartbeat_seq`.
- **Heartbeat collapse**: `kind == "heartbeat"` routes to an `agents.last_heartbeat` update instead of an `audit_logs` row.
- **Unknown-field accounting**: top-level keys outside the vetted allow-list are dropped and counted via `aa_audit_dropped_unknown_field_total{field=…}`.

### Design notes (refinements over the literal subtask wording)
1. **Untyped JSON, not the typed `AuditEvent`.** The banned keys are not fields of `aa_core::AuditEvent` (which is `#[serde(deny_unknown_fields)]`). Since the Story requires dropping them regardless of what an upstream emits, the sanitizer operates on the raw JSON tree received off the NATS subject — that is the only shape that can carry the disallowed data.
2. **`sanitize` returns `SanitizeOutcome`**, not bare `SanitizedAuditEvent`, so heartbeat routing (AC #3) is expressible from the return type. `SanitizedAuditEvent` is still the only persistable type — it's the `Audit` variant's payload.
3. **Banned-key set is a superset** (union of the Story's six and the subtask's expanded list) — defense-in-depth errs toward dropping.
4. **Deliverable #8 (consumer calls `sanitize` before INSERT) is out of scope here**: the consumer (AAASM-2388) is still To Do. This PR ships the self-contained, fully-tested `sanitize()` API that AAASM-2388 will call.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2397 (subtask of Story AAASM-2390, Epic AAASM-2350)

## Testing

- [x] Unit tests added / updated
- [x] No integration tests required here (the DB INSERT path lands with the consumer, AAASM-2388; an adversarial end-to-end check is the verification subtask AAASM-2398)

15 tests, all passing (`cargo nextest run -p aa-gateway sanitizer::`):
- One drop-rule test per banned key (11) asserting the key is absent recursively.
- Nested-in-`payload` recursion test.
- Heartbeat-routing test.
- Unknown-top-level-field drop test.
- `proptest_no_banned_keys` invariant over **1000** random nested JSON inputs (keys biased toward the banned set).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --all-targets --all-features -D warnings` — enforced per-commit by lefthook)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (module + item rustdoc; no sanitizer doc warnings)
- [ ] All CI checks passing (pending CI)
- [x] Commits are small and follow the Gitmoji convention (24 commits, one logical unit each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
