### PR TITLE
[AAASM-2375] ✅ (aa-storage-sqlite-buffer): Verify SQLite event buffer acceptance criteria

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -530,6 +530,7 @@ dependencies = [
  "async-trait",
  "dirs",
  "metrics",
+ "metrics-util",
  "rusqlite",
  "serde",
  "serde_json",
@@ -2597,6 +2598,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4286,11 +4293,15 @@ version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e56997f084e57b045edf17c3ed8ba7f9f779c670df8206dfd1c736f4c02dc4a"
 dependencies = [
+ "aho-corasick",
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
+ "indexmap 2.14.0",
  "metrics",
+ "ordered-float 5.3.0",
  "quanta",
+ "radix_trie",
  "rand 0.9.4",
  "rand_xoshiro",
  "rapidhash",
@@ -4428,6 +4439,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
 dependencies = [
  "libloading",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -4727,6 +4747,15 @@ name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -5490,6 +5519,16 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"
@@ -7190,7 +7229,7 @@ dependencies = [
  "nix",
  "num-derive",
  "num-traits",
- "ordered-float",
+ "ordered-float 4.6.0",
  "pest",
  "pest_derive",
  "phf 0.11.3",
@@ -8732,7 +8771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
- "ordered-float",
+ "ordered-float 4.6.0",
  "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",

--- a/aa-storage-sqlite-buffer/Cargo.toml
+++ b/aa-storage-sqlite-buffer/Cargo.toml
@@ -28,6 +28,9 @@ dirs = "6"
 async-trait = "0.1"
 tokio = { version = "1", features = ["macros", "rt"] }
 tempfile = "3"
+# Captures emitted metric values so the cap-eviction test can assert the exact
+# `aa_events_dropped_total` count.
+metrics-util = { version = "0.20", features = ["debugging"] }
 
 [lints]
 workspace = true

--- a/aa-storage-sqlite-buffer/tests/kill_restart.rs
+++ b/aa-storage-sqlite-buffer/tests/kill_restart.rs
@@ -1,0 +1,89 @@
+//! SIGKILL restart test (AAASM-2375): a child process enqueues events and is
+//! killed with `kill -9` (no graceful shutdown); the parent reopens the same
+//! buffer file and proves the events replay in FIFO order.
+
+mod common;
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use aa_storage_sqlite_buffer::EventBuffer;
+use common::{sample_entry, CollectingSink};
+use tempfile::tempdir;
+
+/// Env var carrying the buffer path to the child role.
+const CHILD_DB_ENV: &str = "AA_SQLITE_BUFFER_KILL_CHILD_DB";
+
+const EVENT_COUNT: u64 = 5;
+
+/// Child role: enqueue events, signal readiness, then block until SIGKILLed.
+///
+/// A no-op when `CHILD_DB_ENV` is unset, so it stays harmless in a normal run.
+#[test]
+fn child_enqueue_then_block() {
+    let Ok(db) = std::env::var(CHILD_DB_ENV) else {
+        return;
+    };
+    let buffer = EventBuffer::new(&db, 100).expect("child: open buffer");
+    for i in 0..EVENT_COUNT {
+        buffer
+            .enqueue(&sample_entry(i, &format!("event-{i}")))
+            .expect("child: enqueue");
+    }
+    // Tell the parent the events are durably written.
+    std::fs::write(format!("{db}.ready"), b"ready").expect("child: write ready file");
+    // Block until the parent kills us; sleeping avoids a busy spin.
+    loop {
+        std::thread::sleep(Duration::from_secs(3600));
+    }
+}
+
+#[tokio::test]
+async fn survives_sigkill_and_replays_in_order() {
+    let dir = tempdir().unwrap();
+    let db = dir.path().join("buffer.db");
+    let db_str = db.to_str().unwrap().to_string();
+    let ready = format!("{db_str}.ready");
+
+    // Re-invoke this same test binary, running only the child role.
+    let exe = std::env::current_exe().expect("locate test binary");
+    let mut child = Command::new(exe)
+        .args(["--exact", "child_enqueue_then_block"])
+        .env(CHILD_DB_ENV, &db_str)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn child");
+
+    // Wait for the child to finish enqueuing.
+    let start = Instant::now();
+    while !Path::new(&ready).exists() {
+        assert!(
+            start.elapsed() < Duration::from_secs(30),
+            "child never signalled readiness"
+        );
+        if let Ok(Some(status)) = child.try_wait() {
+            panic!("child exited early with {status}");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    // kill -9: terminate the child with no chance to close the DB gracefully.
+    child.kill().expect("SIGKILL child");
+    let _ = child.wait();
+
+    // Restart: reopen the file and prove the buffered events survived the kill
+    // and replay in insertion order.
+    let buffer = EventBuffer::new(&db, 100).unwrap();
+    assert_eq!(buffer.len().unwrap(), EVENT_COUNT as usize);
+
+    let sink = CollectingSink::default();
+    let flushed = buffer.drain_and_send(&sink).await.unwrap();
+    assert_eq!(flushed, EVENT_COUNT as usize);
+
+    let expected: Vec<_> = (0..EVENT_COUNT)
+        .map(|i| sample_entry(i, &format!("event-{i}")))
+        .collect();
+    assert_eq!(sink.entries(), expected, "events replay in FIFO order after kill -9");
+}

--- a/aa-storage-sqlite-buffer/tests/metrics.rs
+++ b/aa-storage-sqlite-buffer/tests/metrics.rs
@@ -1,0 +1,53 @@
+//! Verifies cap eviction is metered: the `aa_events_dropped_total` counter
+//! reflects the exact number of evicted events, alongside the buffered and
+//! flushed counters.
+
+mod common;
+
+use std::collections::HashMap;
+
+use aa_storage_sqlite_buffer::{EventBuffer, METRIC_EVENTS_BUFFERED, METRIC_EVENTS_DROPPED, METRIC_EVENTS_FLUSHED};
+use common::{sample_entry, CollectingSink};
+use metrics_util::debugging::{DebugValue, DebuggingRecorder, Snapshotter};
+use tempfile::tempdir;
+
+/// Snapshot every emitted counter into a `name -> value` map.
+fn counters(snapshotter: &Snapshotter) -> HashMap<String, u64> {
+    snapshotter
+        .snapshot()
+        .into_vec()
+        .into_iter()
+        .filter_map(|(key, _unit, _desc, value)| match value {
+            DebugValue::Counter(v) => Some((key.key().name().to_string(), v)),
+            _ => None,
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn cap_eviction_is_metered() {
+    let recorder = DebuggingRecorder::new();
+    let snapshotter = recorder.snapshotter();
+    recorder.install().expect("install debugging recorder");
+
+    let dir = tempdir().unwrap();
+    let buffer = EventBuffer::new(dir.path().join("buffer.db"), 10).unwrap();
+
+    // 15 enqueues into a cap-10 buffer evicts the 5 oldest.
+    for i in 0..15 {
+        buffer.enqueue(&sample_entry(i, &format!("event-{i}"))).unwrap();
+    }
+
+    let snap = counters(&snapshotter);
+    assert_eq!(snap.get(METRIC_EVENTS_BUFFERED).copied(), Some(15));
+    assert_eq!(snap.get(METRIC_EVENTS_DROPPED).copied(), Some(5));
+    assert_eq!(buffer.len().unwrap(), 10);
+
+    // Draining the retained 10 bumps the flushed counter by exactly 10.
+    let sink = CollectingSink::default();
+    let flushed = buffer.drain_and_send(&sink).await.unwrap();
+    assert_eq!(flushed, 10);
+
+    let snap = counters(&snapshotter);
+    assert_eq!(snap.get(METRIC_EVENTS_FLUSHED).copied(), Some(10));
+}

--- a/verification-reports/AAASM-2375.md
+++ b/verification-reports/AAASM-2375.md
@@ -1,0 +1,59 @@
+# AAASM-2375 — Verify `aa-storage-sqlite-buffer` acceptance criteria
+
+Parent Story: **AAASM-2366** · Epic: **AAASM-2348** · Implementation: **AAASM-2374** (PR #878)
+Verified against branch `v0.0.1/AAASM-2375/test/verify_sqlite_buffer` (stacked on the impl branch).
+
+## Story (AAASM-2366) acceptance criteria results
+
+| # | Acceptance criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Event-buffer module with `enqueue(event)` and `drain_and_send(sink)` | ✅ Pass | `EventBuffer::enqueue(&AuditEntry)` + `EventBuffer::drain_and_send(&dyn AuditSink)`; exercised by `tests/drain.rs::enqueues_and_drains_in_fifo_order`. |
+| 2 | `rusqlite` single-file DB at a configurable path (default `~/.local/share/agent-assembly/buffer.db`) | ✅ Pass | `EventBuffer::new(path, cap)` / `from_config`; `SqliteBufferConfig`/`default_path` join the platform data dir + `agent-assembly/buffer.db` — exactly `~/.local/share/agent-assembly/buffer.db` on Linux (XDG). |
+| 3 | WAL mode + `synchronous = NORMAL` | ✅ Pass | `tests/pragma.rs` asserts `journal_mode == "wal"` and `synchronous == 1` (NORMAL) on the live connection. |
+| 4 | Configurable cap; oldest dropped with a counter (never silent — emit a metric) | ✅ Pass | `tests/cap.rs` proves DB retains the newest 10 of 15 in order; `tests/metrics.rs` asserts `aa_events_dropped_total == 5` (and `aa_events_buffered == 15`, `aa_events_flushed_total == 10`) via a `DebuggingRecorder`. |
+| 5 | Restart test: enqueue, terminate process, restart, prove flush on reconnect | ✅ Pass | `tests/kill_restart.rs` spawns a child, enqueues 5 events, **`kill -9`** the child, then reopens the file and replays all 5; `tests/restart.rs` covers the drop/reopen variant. |
+| 6 | Drains in insertion order (FIFO) | ✅ Pass | All drain assertions compare against the exact insertion-ordered `Vec<AuditEntry>`. |
+
+## Subtask "How" checklist
+
+1. `cargo nextest run -p aa-storage-sqlite-buffer` → **8 passed, 0 failed**.
+2. Restart under a tmp dir, child `kill -9`, restart, drain, assert exact order → `kill_restart.rs` ✅.
+3. Cap test cap=10, enqueue 15, `aa_events_dropped_total == 5`, DB holds latest 10 → `cap.rs` + `metrics.rs` ✅.
+4. `PRAGMA journal_mode` / `PRAGMA synchronous` checked on the open DB → `pragma.rs` ✅.
+5. No AC failed → **no Bug subtask filed**.
+
+## Commands run
+
+```
+cargo nextest run -p aa-storage-sqlite-buffer     # 8 tests run: 8 passed, 0 skipped
+cargo test  -p aa-storage-sqlite-buffer --doc     # 2 doctests pass
+cargo fmt --all -- --check                        # clean
+cargo clippy --all-targets --all-features -- -D warnings   # clean
+cargo deny check                                  # advisories/bans/licenses/sources ok
+cargo doc -p aa-storage-sqlite-buffer --no-deps   # clean under -D warnings
+```
+
+### Tests (8 across 7 binaries)
+
+```
+kill_restart  child_enqueue_then_block                              PASS
+kill_restart  survives_sigkill_and_replays_in_order                 PASS
+restart       buffered_events_survive_restart_and_replay_in_order   PASS
+drain         enqueues_and_drains_in_fifo_order                     PASS
+drain         drain_stops_at_first_sink_failure_and_resumes_later   PASS
+cap           cap_evicts_oldest_and_retains_newest_in_order         PASS
+metrics       cap_eviction_is_metered                               PASS
+pragma        opens_in_wal_mode_with_synchronous_normal             PASS
+```
+
+## Notes on implementation choices (carried from AAASM-2374)
+
+- Uses the real contract types `AuditEntry` + `AuditSink` (the ticket text said `AuditEvent`).
+- Crate lives at the repo top-level (`aa-storage-sqlite-buffer/`); this repo has no `crates/` directory.
+- Serialization uses `serde_json` (BLOB) rather than `bincode`: `AuditEntry`'s `#[serde(skip_serializing_if)]`
+  fields cannot round-trip through bincode, which is not self-describing. Round-trip is proven by every
+  drain test comparing decoded entries for equality.
+- `rusqlite` is pinned to `0.32` so it shares `libsqlite3-sys 0.30` with `sqlx-sqlite 0.8.6`; only one crate
+  may link the native `sqlite3` library.
+
+**Verdict: all Story AAASM-2366 acceptance criteria pass.**


### PR DESCRIPTION
## Description

Verification subtask for the local SQLite event buffer (parent Story **AAASM-2366**). Stacked on the implementation branch **AAASM-2374** (PR #878) — review/merge that first; this PR's net diff narrows to the verification additions once #878 lands.

Adds the verification evidence the implementation PR did not yet carry:
- `tests/metrics.rs` — installs a `DebuggingRecorder` and asserts the exact metered counts: `aa_events_buffered == 15`, `aa_events_dropped_total == 5`, `aa_events_flushed_total == 10` for a cap-10 buffer fed 15 events. This proves the cap-eviction loss is metered, never silent.
- `tests/kill_restart.rs` — spawns a child process that enqueues 5 events, **`kill -9`** the child (no graceful shutdown), then reopens the same file and proves all 5 replay in FIFO order. This is the spec's "terminate process, restart, flush on reconnect" AC.
- `metrics-util` dev-dependency (debugging recorder).
- `verification-reports/AAASM-2375.md` — the AC-by-AC verdict.

**Result: all six Story AAASM-2366 acceptance criteria pass.** No AC failed, so no Bug subtask was filed.

## Type of Change

- [x] ✅ Tests / verification

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2375 (parent Story AAASM-2366, Epic AAASM-2348)
- Implementation PR: #878 (AAASM-2374)

## Testing

- [x] Integration tests added / updated

`cargo nextest run -p aa-storage-sqlite-buffer` — 8 tests pass:

```
kill_restart  survives_sigkill_and_replays_in_order                 PASS
kill_restart  child_enqueue_then_block                              PASS
restart       buffered_events_survive_restart_and_replay_in_order   PASS
drain         enqueues_and_drains_in_fifo_order                     PASS
drain         drain_stops_at_first_sink_failure_and_resumes_later   PASS
cap           cap_evicts_oldest_and_retains_newest_in_order         PASS
metrics       cap_eviction_is_metered                               PASS
pragma        opens_in_wal_mode_with_synchronous_normal             PASS
```

Plus 2 doctests; `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, `cargo deny check`, and `cargo doc` all clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
