### PR TITLE
[AAASM-2370] ✨ (aa-storage-postgres): Implement PolicyStore/AuditSink/CredentialStore/LifecycleStore + testcontainers tests

### DIFF
--- a/aa-storage-postgres/migrations/0005_credentials.sql
+++ b/aa-storage-postgres/migrations/0005_credentials.sql
@@ -1,0 +1,10 @@
+-- Credentials: named secret material stored as opaque ciphertext.
+--
+-- The CredentialStore contract takes opaque bytes ("backends are expected to
+-- encrypt at rest"); this table holds them in a single `ciphertext` BYTEA
+-- column. There is deliberately NO plaintext column.
+CREATE TABLE credentials (
+    key        TEXT PRIMARY KEY,
+    ciphertext BYTEA NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/aa-storage-postgres/src/audit_sink.rs
+++ b/aa-storage-postgres/src/audit_sink.rs
@@ -1,0 +1,85 @@
+//! [`PgAuditSink`] — append-only, metadata-only audit emission against Postgres.
+
+use aa_core::audit::AuditEventType;
+use aa_storage::{AuditEntry, AuditSink, Result};
+use async_trait::async_trait;
+
+use crate::pool::PostgresPool;
+use crate::support::{agent_id_to_text, backend_err};
+
+/// Postgres-backed [`AuditSink`].
+///
+/// Each entry becomes one row in `audit_logs`. Per the "don't store" rule the
+/// table is metadata-only: the entry's `payload` is never written. The
+/// governance event-type discriminant is recorded as the action surface
+/// (`tool_name`) and a coarse posture (`decision`); `latency_ms` is left NULL
+/// because the entry carries no timing.
+#[derive(Clone)]
+pub struct PgAuditSink {
+    pool: PostgresPool,
+}
+
+impl PgAuditSink {
+    /// Build an audit sink over an existing pool.
+    pub fn new(pool: PostgresPool) -> Self {
+        Self { pool }
+    }
+}
+
+/// Coarse governance posture recorded in `audit_logs.decision`.
+fn decision_label(event_type: AuditEventType) -> &'static str {
+    match event_type {
+        AuditEventType::PolicyViolation
+        | AuditEventType::CredentialLeakBlocked
+        | AuditEventType::ApprovalDenied
+        | AuditEventType::ApprovalTimedOut
+        | AuditEventType::AgentForceDeregistered
+        | AuditEventType::MessageBlocked
+        | AuditEventType::A2AImpersonationAttempted
+        | AuditEventType::SandboxFilesystemBlocked
+        | AuditEventType::SandboxCpuTimeout
+        | AuditEventType::SandboxOomKilled
+        | AuditEventType::BudgetLimitExceeded => "deny",
+        AuditEventType::ApprovalGranted
+        | AuditEventType::ApprovalRouted
+        | AuditEventType::ToolDispatched
+        | AuditEventType::SandboxStarted
+        | AuditEventType::SandboxTerminated => "allow",
+        AuditEventType::ToolCallIntercepted
+        | AuditEventType::ApprovalRequested
+        | AuditEventType::ApprovalEscalated
+        | AuditEventType::BudgetLimitApproached
+        | AuditEventType::A2ACallIntercepted => "review",
+    }
+}
+
+#[async_trait]
+impl AuditSink for PgAuditSink {
+    async fn emit(&self, event: AuditEntry) -> Result<()> {
+        // Derive a stable row id from the entry hash so re-emitting the same
+        // entry is idempotent rather than duplicating.
+        let mut id_bytes = [0u8; 16];
+        id_bytes.copy_from_slice(&event.entry_hash()[..16]);
+        let id = uuid::Uuid::from_bytes(id_bytes);
+
+        let ns = event.timestamp_ns();
+        let ts = chrono::DateTime::from_timestamp((ns / 1_000_000_000) as i64, (ns % 1_000_000_000) as u32)
+            .unwrap_or_default();
+
+        sqlx::query(
+            "INSERT INTO audit_logs (id, agent_id, tool_name, decision, latency_ms, ts) \
+             VALUES ($1, $2, $3, $4, $5, $6) \
+             ON CONFLICT (id) DO NOTHING",
+        )
+        .bind(id)
+        .bind(agent_id_to_text(&event.agent_id()))
+        .bind(event.event_type().as_str())
+        .bind(decision_label(event.event_type()))
+        .bind(None::<i32>)
+        .bind(ts)
+        .execute(self.pool.pool())
+        .await
+        .map_err(backend_err)?;
+        Ok(())
+    }
+}

--- a/aa-storage-postgres/src/credential_store.rs
+++ b/aa-storage-postgres/src/credential_store.rs
@@ -1,0 +1,60 @@
+//! [`PgCredentialStore`] — opaque secret storage against Postgres.
+
+use aa_storage::{CredentialStore, Result, StorageError};
+use async_trait::async_trait;
+
+use crate::pool::PostgresPool;
+use crate::support::backend_err;
+
+/// Postgres-backed [`CredentialStore`]. Secrets are stored verbatim as opaque
+/// ciphertext in the `credentials.ciphertext` column; the driver never sees or
+/// stores plaintext.
+#[derive(Clone)]
+pub struct PgCredentialStore {
+    pool: PostgresPool,
+}
+
+impl PgCredentialStore {
+    /// Build a credential store over an existing pool.
+    pub fn new(pool: PostgresPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl CredentialStore for PgCredentialStore {
+    async fn get_secret(&self, key: &str) -> Result<Vec<u8>> {
+        let row: Option<(Vec<u8>,)> = sqlx::query_as("SELECT ciphertext FROM credentials WHERE key = $1")
+            .bind(key)
+            .fetch_optional(self.pool.pool())
+            .await
+            .map_err(backend_err)?;
+
+        let (ciphertext,) = row.ok_or_else(|| StorageError::NotFound(key.to_owned()))?;
+        Ok(ciphertext)
+    }
+
+    async fn put_secret(&self, key: &str, value: Vec<u8>) -> Result<()> {
+        sqlx::query(
+            "INSERT INTO credentials (key, ciphertext, updated_at) \
+             VALUES ($1, $2, now()) \
+             ON CONFLICT (key) DO UPDATE SET ciphertext = EXCLUDED.ciphertext, updated_at = now()",
+        )
+        .bind(key)
+        .bind(value)
+        .execute(self.pool.pool())
+        .await
+        .map_err(backend_err)?;
+        Ok(())
+    }
+
+    async fn delete_secret(&self, key: &str) -> Result<()> {
+        // Idempotent: deleting an absent key affects zero rows and still succeeds.
+        sqlx::query("DELETE FROM credentials WHERE key = $1")
+            .bind(key)
+            .execute(self.pool.pool())
+            .await
+            .map_err(backend_err)?;
+        Ok(())
+    }
+}

--- a/aa-storage-postgres/src/lib.rs
+++ b/aa-storage-postgres/src/lib.rs
@@ -10,6 +10,7 @@
 //! `PgLifecycleStore`) land alongside the connection-pool wrapper; this module
 //! re-exports the public surface a caller needs to wire the driver up.
 
+pub mod audit_sink;
 pub mod config;
 pub mod credential_store;
 pub mod lifecycle_store;
@@ -17,6 +18,7 @@ pub mod policy_store;
 pub mod pool;
 pub mod support;
 
+pub use audit_sink::PgAuditSink;
 pub use config::PostgresPoolConfig;
 pub use credential_store::PgCredentialStore;
 pub use lifecycle_store::PgLifecycleStore;

--- a/aa-storage-postgres/src/lib.rs
+++ b/aa-storage-postgres/src/lib.rs
@@ -24,3 +24,17 @@ pub use credential_store::PgCredentialStore;
 pub use lifecycle_store::PgLifecycleStore;
 pub use policy_store::PgPolicyStore;
 pub use pool::{PostgresPool, MIGRATOR};
+
+/// The name this driver registers under in the storage registry. An operator
+/// selects it with `backend = "postgres"` (or `[storage.postgres]`).
+pub const NAME: &str = "postgres";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn driver_registers_as_postgres() {
+        assert_eq!(NAME, "postgres");
+    }
+}

--- a/aa-storage-postgres/src/lib.rs
+++ b/aa-storage-postgres/src/lib.rs
@@ -11,8 +11,10 @@
 //! re-exports the public surface a caller needs to wire the driver up.
 
 pub mod config;
+pub mod lifecycle_store;
 pub mod pool;
 pub mod support;
 
 pub use config::PostgresPoolConfig;
+pub use lifecycle_store::PgLifecycleStore;
 pub use pool::{PostgresPool, MIGRATOR};

--- a/aa-storage-postgres/src/lib.rs
+++ b/aa-storage-postgres/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod config;
 pub mod pool;
+pub mod support;
 
 pub use config::PostgresPoolConfig;
 pub use pool::{PostgresPool, MIGRATOR};

--- a/aa-storage-postgres/src/lib.rs
+++ b/aa-storage-postgres/src/lib.rs
@@ -11,12 +11,14 @@
 //! re-exports the public surface a caller needs to wire the driver up.
 
 pub mod config;
+pub mod credential_store;
 pub mod lifecycle_store;
 pub mod policy_store;
 pub mod pool;
 pub mod support;
 
 pub use config::PostgresPoolConfig;
+pub use credential_store::PgCredentialStore;
 pub use lifecycle_store::PgLifecycleStore;
 pub use policy_store::PgPolicyStore;
 pub use pool::{PostgresPool, MIGRATOR};

--- a/aa-storage-postgres/src/lib.rs
+++ b/aa-storage-postgres/src/lib.rs
@@ -12,9 +12,11 @@
 
 pub mod config;
 pub mod lifecycle_store;
+pub mod policy_store;
 pub mod pool;
 pub mod support;
 
 pub use config::PostgresPoolConfig;
 pub use lifecycle_store::PgLifecycleStore;
+pub use policy_store::PgPolicyStore;
 pub use pool::{PostgresPool, MIGRATOR};

--- a/aa-storage-postgres/src/lifecycle_store.rs
+++ b/aa-storage-postgres/src/lifecycle_store.rs
@@ -1,0 +1,63 @@
+//! [`PgLifecycleStore`] — agent register / heartbeat / deregister against Postgres.
+
+use aa_storage::{AgentId, LifecycleStore, Result, StorageError};
+use async_trait::async_trait;
+
+use crate::pool::PostgresPool;
+use crate::support::{agent_id_to_text, backend_err};
+
+/// Postgres-backed [`LifecycleStore`]. Liveness is tracked in the `agents`
+/// table's `status` and `last_heartbeat` columns.
+#[derive(Clone)]
+pub struct PgLifecycleStore {
+    pool: PostgresPool,
+}
+
+impl PgLifecycleStore {
+    /// Build a lifecycle store over an existing pool.
+    pub fn new(pool: PostgresPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl LifecycleStore for PgLifecycleStore {
+    async fn register(&self, agent_id: &AgentId) -> Result<()> {
+        // Upsert so a re-registration overwrites a stale row's status/heartbeat.
+        sqlx::query(
+            "INSERT INTO agents (id, status, registered_at, last_heartbeat) \
+             VALUES ($1, 'registered', now(), now()) \
+             ON CONFLICT (id) DO UPDATE SET status = 'registered', last_heartbeat = now()",
+        )
+        .bind(agent_id_to_text(agent_id))
+        .execute(self.pool.pool())
+        .await
+        .map_err(backend_err)?;
+        Ok(())
+    }
+
+    async fn heartbeat(&self, agent_id: &AgentId) -> Result<()> {
+        let id = agent_id_to_text(agent_id);
+        let result = sqlx::query("UPDATE agents SET last_heartbeat = now() WHERE id = $1")
+            .bind(&id)
+            .execute(self.pool.pool())
+            .await
+            .map_err(backend_err)?;
+
+        if result.rows_affected() == 0 {
+            return Err(StorageError::NotFound(id));
+        }
+        Ok(())
+    }
+
+    async fn deregister(&self, agent_id: &AgentId) -> Result<()> {
+        // Idempotent: marking an absent agent offline affects zero rows and
+        // still succeeds.
+        sqlx::query("UPDATE agents SET status = 'deregistered' WHERE id = $1")
+            .bind(agent_id_to_text(agent_id))
+            .execute(self.pool.pool())
+            .await
+            .map_err(backend_err)?;
+        Ok(())
+    }
+}

--- a/aa-storage-postgres/src/policy_store.rs
+++ b/aa-storage-postgres/src/policy_store.rs
@@ -1,0 +1,45 @@
+//! [`PgPolicyStore`] — read-side policy access against Postgres.
+
+use aa_storage::{AgentId, PolicyDocument, PolicyStore, Result, StorageError};
+use async_trait::async_trait;
+
+use crate::pool::PostgresPool;
+use crate::support::{agent_id_to_text, backend_err};
+
+/// Postgres-backed [`PolicyStore`]. Reads the highest-versioned policy row for
+/// an agent and deserializes its JSONB `body` into a [`PolicyDocument`].
+#[derive(Clone)]
+pub struct PgPolicyStore {
+    pool: PostgresPool,
+}
+
+impl PgPolicyStore {
+    /// Build a policy store over an existing pool.
+    pub fn new(pool: PostgresPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl PolicyStore for PgPolicyStore {
+    async fn get_policy(&self, agent_id: &AgentId) -> Result<PolicyDocument> {
+        let id = agent_id_to_text(agent_id);
+        let row: Option<(serde_json::Value,)> = sqlx::query_as(
+            "SELECT body FROM policies WHERE agent_id = $1 \
+             ORDER BY policy_version DESC LIMIT 1",
+        )
+        .bind(&id)
+        .fetch_optional(self.pool.pool())
+        .await
+        .map_err(backend_err)?;
+
+        let (body,) = row.ok_or(StorageError::NotFound(id))?;
+        serde_json::from_value(body).map_err(|e| StorageError::Serialization(e.to_string()))
+    }
+
+    async fn invalidate(&self, _agent_id: &AgentId) -> Result<()> {
+        // No-op: this driver holds no in-process cache, so reads already hit the
+        // source of truth. The L2 cache layer (Epic C) owns invalidation.
+        Ok(())
+    }
+}

--- a/aa-storage-postgres/src/support.rs
+++ b/aa-storage-postgres/src/support.rs
@@ -1,0 +1,15 @@
+//! Shared helpers for the trait implementations: id encoding and error mapping.
+
+use aa_storage::{AgentId, StorageError};
+
+/// Encode an [`AgentId`] for a `TEXT` agent-id column as its canonical
+/// hyphenated UUID string (the same encoding the gateway driver uses).
+pub fn agent_id_to_text(id: &AgentId) -> String {
+    uuid::Uuid::from_bytes(*id.as_bytes()).to_string()
+}
+
+/// Map an sqlx error to [`StorageError::Backend`] — the catch-all for a backend
+/// that was reachable but failed the operation.
+pub fn backend_err(err: sqlx::Error) -> StorageError {
+    StorageError::Backend(err.to_string())
+}

--- a/aa-storage-postgres/tests/conformance_pg.rs
+++ b/aa-storage-postgres/tests/conformance_pg.rs
@@ -2,8 +2,10 @@
 //! via `testcontainers-modules`. Each test spins up its own fresh Postgres 18
 //! container, so the cases are isolated and require Docker to run.
 
-use aa_storage::{AgentId, LifecycleStore, StorageError};
-use aa_storage_postgres::{PgLifecycleStore, PostgresPool, PostgresPoolConfig};
+use aa_core::EnforcementMode;
+use aa_storage::conformance::assert_policy_store_conformance;
+use aa_storage::{AgentId, LifecycleStore, PolicyDocument, StorageError};
+use aa_storage_postgres::{PgLifecycleStore, PgPolicyStore, PostgresPool, PostgresPoolConfig};
 use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use testcontainers_modules::testcontainers::{ContainerAsync, ImageExt};
@@ -90,4 +92,39 @@ async fn lifecycle_register_heartbeat_deregister() {
         .deregister(&absent)
         .await
         .expect("deregister(absent) is idempotent");
+}
+
+#[tokio::test]
+async fn policy_store_satisfies_conformance() {
+    let (_pg, pool) = setup_pg().await;
+
+    let present = AgentId::from_bytes([1u8; 16]);
+    let absent = AgentId::from_bytes([2u8; 16]);
+
+    // Seed: the policies FK requires the agent row, so register it first, then
+    // insert one policy version for the present agent.
+    PgLifecycleStore::new(pool.clone())
+        .register(&present)
+        .await
+        .expect("register present agent");
+
+    let doc = PolicyDocument {
+        version: 1,
+        name: "test".to_owned(),
+        rules: Vec::new(),
+        enforcement_mode: EnforcementMode::default(),
+    };
+    let body = serde_json::to_value(&doc).expect("serialize policy");
+    let agent_text = uuid::Uuid::from_bytes(*present.as_bytes()).to_string();
+    sqlx::query("INSERT INTO policies (agent_id, policy_version, body) VALUES ($1, $2, $3)")
+        .bind(&agent_text)
+        .bind(1_i64)
+        .bind(body)
+        .execute(pool.pool())
+        .await
+        .expect("seed policy row");
+
+    let store = PgPolicyStore::new(pool.clone());
+    // Coerces to `&dyn PolicyStore`, exercising object-safety too.
+    assert_policy_store_conformance(&store, &present, &absent).await;
 }

--- a/aa-storage-postgres/tests/conformance_pg.rs
+++ b/aa-storage-postgres/tests/conformance_pg.rs
@@ -2,7 +2,8 @@
 //! via `testcontainers-modules`. Each test spins up its own fresh Postgres 18
 //! container, so the cases are isolated and require Docker to run.
 
-use aa_storage_postgres::{PostgresPool, PostgresPoolConfig};
+use aa_storage::{AgentId, LifecycleStore, StorageError};
+use aa_storage_postgres::{PgLifecycleStore, PostgresPool, PostgresPoolConfig};
 use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use testcontainers_modules::testcontainers::{ContainerAsync, ImageExt};
@@ -64,4 +65,29 @@ async fn migrations_apply_cleanly_and_audit_logs_is_metadata_only() {
             "audit_logs must not contain a {forbidden} column"
         );
     }
+}
+
+#[tokio::test]
+async fn lifecycle_register_heartbeat_deregister() {
+    let (_pg, pool) = setup_pg().await;
+    let store = PgLifecycleStore::new(pool.clone());
+
+    let present = AgentId::from_bytes([7u8; 16]);
+    let absent = AgentId::from_bytes([9u8; 16]);
+
+    store.register(&present).await.expect("register");
+    // Re-registration overwrites the stale row without error.
+    store.register(&present).await.expect("re-register is idempotent");
+    store.heartbeat(&present).await.expect("heartbeat present");
+
+    match store.heartbeat(&absent).await {
+        Err(StorageError::NotFound(_)) => {}
+        other => panic!("heartbeat(absent) should be NotFound, got {other:?}"),
+    }
+
+    store.deregister(&present).await.expect("deregister");
+    store
+        .deregister(&absent)
+        .await
+        .expect("deregister(absent) is idempotent");
 }

--- a/aa-storage-postgres/tests/conformance_pg.rs
+++ b/aa-storage-postgres/tests/conformance_pg.rs
@@ -4,8 +4,8 @@
 
 use aa_core::EnforcementMode;
 use aa_storage::conformance::assert_policy_store_conformance;
-use aa_storage::{AgentId, LifecycleStore, PolicyDocument, StorageError};
-use aa_storage_postgres::{PgLifecycleStore, PgPolicyStore, PostgresPool, PostgresPoolConfig};
+use aa_storage::{AgentId, CredentialStore, LifecycleStore, PolicyDocument, StorageError};
+use aa_storage_postgres::{PgCredentialStore, PgLifecycleStore, PgPolicyStore, PostgresPool, PostgresPoolConfig};
 use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use testcontainers_modules::testcontainers::{ContainerAsync, ImageExt};
@@ -127,4 +127,30 @@ async fn policy_store_satisfies_conformance() {
     let store = PgPolicyStore::new(pool.clone());
     // Coerces to `&dyn PolicyStore`, exercising object-safety too.
     assert_policy_store_conformance(&store, &present, &absent).await;
+}
+
+#[tokio::test]
+async fn credential_store_secret_roundtrip() {
+    let (_pg, pool) = setup_pg().await;
+    let store = PgCredentialStore::new(pool.clone());
+
+    let key = "openai/api_key";
+    match store.get_secret(key).await {
+        Err(StorageError::NotFound(_)) => {}
+        other => panic!("get_secret(absent) should be NotFound, got {other:?}"),
+    }
+
+    store.put_secret(key, b"ciphertext-bytes".to_vec()).await.expect("put");
+    assert_eq!(store.get_secret(key).await.expect("get"), b"ciphertext-bytes");
+
+    // put overwrites.
+    store.put_secret(key, b"rotated".to_vec()).await.expect("overwrite");
+    assert_eq!(store.get_secret(key).await.expect("get rotated"), b"rotated");
+
+    store.delete_secret(key).await.expect("delete");
+    store.delete_secret(key).await.expect("delete(absent) is idempotent");
+    match store.get_secret(key).await {
+        Err(StorageError::NotFound(_)) => {}
+        other => panic!("get_secret after delete should be NotFound, got {other:?}"),
+    }
 }

--- a/aa-storage-postgres/tests/conformance_pg.rs
+++ b/aa-storage-postgres/tests/conformance_pg.rs
@@ -1,0 +1,67 @@
+//! Trait-conformance tests for the Postgres driver, run against a real Postgres
+//! via `testcontainers-modules`. Each test spins up its own fresh Postgres 18
+//! container, so the cases are isolated and require Docker to run.
+
+use aa_storage_postgres::{PostgresPool, PostgresPoolConfig};
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use testcontainers_modules::testcontainers::{ContainerAsync, ImageExt};
+
+/// Start a fresh Postgres 18 container, connect a pool, and run migrations.
+///
+/// Returns the container guard (kept alive for the test's duration) alongside
+/// the migrated pool.
+async fn setup_pg() -> (ContainerAsync<Postgres>, PostgresPool) {
+    let container = Postgres::default()
+        .with_db_name("aasm")
+        .with_user("aasm")
+        .with_password("secret")
+        .with_tag("18-alpine")
+        .start()
+        .await
+        .expect("start postgres testcontainer (is Docker running?)");
+
+    let host = container.get_host().await.expect("container host");
+    let port = container.get_host_port_ipv4(5432).await.expect("container port");
+    let url = format!("postgres://aasm:secret@{host}:{port}/aasm");
+
+    let pool = PostgresPool::connect(&PostgresPoolConfig {
+        url,
+        max_connections: 5,
+        statement_timeout_ms: 0,
+    })
+    .await
+    .expect("connect pool");
+    pool.migrate().await.expect("run migrations");
+
+    (container, pool)
+}
+
+#[tokio::test]
+async fn migrations_apply_cleanly_and_audit_logs_is_metadata_only() {
+    let (_pg, pool) = setup_pg().await;
+
+    // Every migrated table exists after a fresh migrate().
+    for table in ["orgs", "agents", "policies", "audit_logs", "credentials"] {
+        let exists: bool =
+            sqlx::query_scalar("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = $1)")
+                .bind(table)
+                .fetch_one(pool.pool())
+                .await
+                .expect("query table existence");
+        assert!(exists, "table {table} should exist after migrations");
+    }
+
+    // audit_logs must carry no payload/prompt/body column (spec line 7551).
+    let columns: Vec<String> =
+        sqlx::query_scalar("SELECT column_name FROM information_schema.columns WHERE table_name = 'audit_logs'")
+            .fetch_all(pool.pool())
+            .await
+            .expect("query audit_logs columns");
+    for forbidden in ["payload", "prompt", "body"] {
+        assert!(
+            !columns.iter().any(|c| c == forbidden),
+            "audit_logs must not contain a {forbidden} column"
+        );
+    }
+}

--- a/aa-storage-postgres/tests/conformance_pg.rs
+++ b/aa-storage-postgres/tests/conformance_pg.rs
@@ -5,7 +5,9 @@
 use aa_core::EnforcementMode;
 use aa_storage::conformance::assert_policy_store_conformance;
 use aa_storage::{AgentId, CredentialStore, LifecycleStore, PolicyDocument, StorageError};
-use aa_storage_postgres::{PgCredentialStore, PgLifecycleStore, PgPolicyStore, PostgresPool, PostgresPoolConfig};
+use aa_storage_postgres::{
+    PgAuditSink, PgCredentialStore, PgLifecycleStore, PgPolicyStore, PostgresPool, PostgresPoolConfig,
+};
 use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
 use testcontainers_modules::testcontainers::{ContainerAsync, ImageExt};
@@ -153,4 +155,45 @@ async fn credential_store_secret_roundtrip() {
         Err(StorageError::NotFound(_)) => {}
         other => panic!("get_secret after delete should be NotFound, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn audit_sink_writes_metadata_only_row() {
+    use aa_core::audit::{AuditEntry, AuditEventType};
+    use aa_storage::{AuditSink, SessionId};
+
+    let (_pg, pool) = setup_pg().await;
+    let sink = PgAuditSink::new(pool.clone());
+
+    let agent = AgentId::from_bytes([3u8; 16]);
+    let session = SessionId::from_bytes([4u8; 16]);
+    let entry = AuditEntry::new(
+        0,
+        1_700_000_000_000_000_000,
+        AuditEventType::ToolDispatched,
+        agent,
+        session,
+        // A payload carrying a secret — the sink must NOT persist it.
+        r#"{"tool":"shell","secret":"should-not-be-stored"}"#.to_owned(),
+        [0u8; 32],
+    );
+
+    sink.emit(entry).await.expect("emit");
+
+    let agent_text = uuid::Uuid::from_bytes(*agent.as_bytes()).to_string();
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM audit_logs WHERE agent_id = $1")
+        .bind(&agent_text)
+        .fetch_one(pool.pool())
+        .await
+        .expect("count audit rows");
+    assert_eq!(count, 1, "emit should write exactly one audit row");
+
+    let (tool_name, decision): (String, String) =
+        sqlx::query_as("SELECT tool_name, decision FROM audit_logs WHERE agent_id = $1")
+            .bind(&agent_text)
+            .fetch_one(pool.pool())
+            .await
+            .expect("fetch audit row");
+    assert_eq!(tool_name, "ToolDispatched");
+    assert_eq!(decision, "allow");
 }


### PR DESCRIPTION
## Description

Implements the `aa_core::storage` trait contract for the **`aa-storage-postgres`** driver and proves it against a real Postgres via `testcontainers-modules`. **Stacked on [#874](https://github.com/AI-agent-assembly/agent-assembly/pull/874) (AAASM-2369)** — review/merge that first; this PR's diff resolves to just the trait impls + tests once #874 lands.

Trait implementations (all over the migrated schema from #874, plus a new `credentials` table):
- **`PgPolicyStore`** — `get_policy` reads the highest-versioned `policies` row and deserializes its JSONB body into a `PolicyDocument` (NotFound when absent); `invalidate` is a no-op (no in-process cache here).
- **`PgAuditSink`** — `emit` writes one metadata-only `audit_logs` row: stable id from the entry hash, agent id, event-type discriminant as `tool_name`, a coarse `allow`/`deny`/`review` posture as `decision`, entry timestamp. The payload is never persisted (spec line 7551); idempotent via `ON CONFLICT DO NOTHING`.
- **`PgCredentialStore`** — `get`/`put`/`delete` over a new `credentials` table storing opaque ciphertext only (no plaintext column).
- **`PgLifecycleStore`** — `register` (upsert), `heartbeat` (UPDATE last_heartbeat, NotFound when unregistered), `deregister` (idempotent).

Also:
- New migration `0005_credentials.sql` (backs `PgCredentialStore`).
- `NAME = "postgres"` driver identifier + unit test.
- Shared `support` helpers: `agent_id_to_text` (canonical UUID string) + `backend_err`.
- `tests/conformance_pg.rs`: a per-test fresh Postgres 18 container (builder order `db_name → user → password → tag`), migrations applied before each test. Covers the migrations/metadata-only schema check, lifecycle, the `assert_policy_store_conformance` harness, the credential roundtrip, and the audit metadata-only emit.

## Type of Change

- [x] ✨ New feature
- [x] ✅ Tests

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2370 (subtask of Story AAASM-2364, Epic AAASM-2348)
- Stacked on AAASM-2369 (#874)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [x] Manual testing performed

`cargo nextest run -p aa-storage-postgres` runs the full conformance suite against a real Postgres 18 testcontainer (Docker required). `cargo clippy --all-targets -- -D warnings` clean; `cargo deny check` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
