### PR TITLE
[AAASM-2383] ✨ (aa-runtime): Assembly InvalidationClient + L1 cache sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -439,6 +439,7 @@ dependencies = [
  "sha2 0.11.0",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "tonic",

--- a/aa-integration-tests/tests/e2e_invalidation_channel.rs
+++ b/aa-integration-tests/tests/e2e_invalidation_channel.rs
@@ -1,0 +1,70 @@
+//! End-to-end test for the gRPC push-invalidation channel (Story AAASM-2377).
+//!
+//! Wires the real gateway-side `InvalidationServiceImpl` to the real
+//! Assembly-side `InvalidationClient` over a loopback gRPC connection and
+//! asserts that a policy invalidation evicts the subscribed L1 cache entry
+//! within 100 ms — the security-critical bound that closes the TTL-race window.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::net::TcpListener;
+use tonic::transport::Server;
+
+use aa_gateway::invalidation::{InvalidationHub, InvalidationServiceImpl};
+use aa_proto::assembly::gateway::v1::invalidation_service_server::InvalidationServiceServer;
+use aa_runtime::invalidation_client::{InvalidationClient, InvalidationSink};
+use aa_runtime::l1_cache::PolicyL1Cache;
+
+#[tokio::test]
+async fn policy_invalidation_evicts_l1_within_100ms() {
+    // ── Real gateway InvalidationService on a loopback port ──────────────────
+    let hub = InvalidationHub::new();
+    let service = InvalidationServiceImpl::new(Arc::clone(&hub));
+    // Bind before spawning so the socket is already listening when the client
+    // dials — connections queue even before `serve_with_incoming` runs.
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind gateway");
+    let addr = listener.local_addr().expect("local_addr");
+    let server = tokio::spawn(async move {
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(InvalidationServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .expect("tonic Server::serve_with_incoming");
+    });
+
+    // ── Assembly-side L1 cache, warm with two agents, subscribed to the channel
+    let cache: Arc<PolicyL1Cache<bool>> = Arc::new(PolicyL1Cache::new());
+    cache.insert("agent-x", true);
+    cache.insert("agent-y", true);
+    let sink: Arc<dyn InvalidationSink> = Arc::clone(&cache) as Arc<dyn InvalidationSink>;
+    let client = InvalidationClient::start(format!("http://{addr}"), "asm-e2e".to_string(), vec![sink]);
+
+    // Wait until the subscriber has registered with the gateway.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while hub.subscriber_count() == 0 {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("client subscribed to gateway within 5 s");
+
+    // ── Mutate policy → gateway pushes a targeted invalidation for agent-x ────
+    let start = Instant::now();
+    hub.broadcast_policy_invalidated("agent-x", 1);
+
+    tokio::time::timeout(Duration::from_millis(100), async {
+        while cache.contains("agent-x") {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("agent-x evicted from L1 within 100 ms");
+
+    assert!(start.elapsed() < Duration::from_millis(100));
+    assert!(cache.contains("agent-y"), "unrelated agent-y must stay cached");
+
+    client.abort();
+    server.abort();
+}

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -28,6 +28,7 @@ sha2                        = "0.11"
 serde_json                  = "1"
 toml                        = "1.1"
 tokio                       = { version = "1", features = ["full"] }
+tokio-stream                = "0.1"
 tokio-util                  = { version = "0.7", features = ["rt"] }
 tonic                       = { version = "0.14", features = ["transport"] }
 tracing                     = "0.1"

--- a/aa-runtime/src/invalidation_client.rs
+++ b/aa-runtime/src/invalidation_client.rs
@@ -7,6 +7,20 @@
 //! reconnects with exponential backoff — resuming from `last_seq_seen` so the
 //! gateway replays anything missed while disconnected.
 
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::task::JoinHandle;
+
+use aa_proto::assembly::gateway::v1::invalidation_event::Payload;
+use aa_proto::assembly::gateway::v1::invalidation_service_client::InvalidationServiceClient;
+use aa_proto::assembly::gateway::v1::{subscribe_request::Kind, SubscribeInitial, SubscribeRequest};
+
+/// First reconnect delay; doubles on each consecutive failure.
+const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+/// Upper bound on the reconnect delay (1s → 2 → 4 → … → 32s cap).
+const MAX_BACKOFF: Duration = Duration::from_secs(32);
+
 /// A consumer of policy-invalidation events delivered over the push channel.
 ///
 /// The canonical implementor is an in-process L1 cache, which drops the cached
@@ -15,4 +29,84 @@
 pub trait InvalidationSink: Send + Sync {
     /// Apply a policy invalidation for `agent_id` (empty = invalidate all).
     fn on_policy_invalidated(&self, agent_id: &str);
+}
+
+/// Next reconnect delay: double the current one, capped at [`MAX_BACKOFF`].
+fn next_backoff(current: Duration) -> Duration {
+    (current * 2).min(MAX_BACKOFF)
+}
+
+/// Background subscriber that keeps the registered [`InvalidationSink`]s fresh
+/// from the gateway's push-invalidation stream.
+pub struct InvalidationClient;
+
+impl InvalidationClient {
+    /// Spawn the subscribe loop on the Tokio runtime and return its handle.
+    ///
+    /// The task reconnects forever with exponential backoff; abort the returned
+    /// [`JoinHandle`] to stop it. `assembly_id` keys the gateway's per-subscriber
+    /// replay buffer so reconnects resume from the last applied sequence.
+    pub fn start(gateway_url: String, assembly_id: String, sinks: Vec<Arc<dyn InvalidationSink>>) -> JoinHandle<()> {
+        tokio::spawn(async move { run(gateway_url, assembly_id, sinks).await })
+    }
+}
+
+/// Reconnect loop: subscribe, apply events, and on disconnect back off
+/// exponentially before resubscribing from `last_seq_seen`.
+async fn run(gateway_url: String, assembly_id: String, sinks: Vec<Arc<dyn InvalidationSink>>) {
+    let mut backoff = INITIAL_BACKOFF;
+    let mut last_seq_seen: u64 = 0;
+    loop {
+        match subscribe_once(&gateway_url, &assembly_id, &mut last_seq_seen, &sinks).await {
+            // The gateway closed the stream cleanly — reconnect promptly.
+            Ok(()) => backoff = INITIAL_BACKOFF,
+            Err(err) => {
+                metrics::counter!("aa_invalidation_reconnects_total").increment(1);
+                tracing::warn!(
+                    error = %err,
+                    backoff_secs = backoff.as_secs(),
+                    last_seq_seen,
+                    "invalidation stream dropped; reconnecting after backoff"
+                );
+                tokio::time::sleep(backoff).await;
+                backoff = next_backoff(backoff);
+            }
+        }
+    }
+}
+
+/// Open one Subscribe stream and apply events until it ends or errors.
+///
+/// `last_seq_seen` is advanced as events arrive (even if the stream later
+/// errors), so the next reconnect replays only what was genuinely missed.
+async fn subscribe_once(
+    gateway_url: &str,
+    assembly_id: &str,
+    last_seq_seen: &mut u64,
+    sinks: &[Arc<dyn InvalidationSink>],
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let mut client = InvalidationServiceClient::connect(gateway_url.to_owned()).await?;
+    let initial = SubscribeRequest {
+        assembly_id: assembly_id.to_owned(),
+        kind: Some(Kind::Initial(SubscribeInitial {
+            last_seq_seen: *last_seq_seen,
+        })),
+    };
+    let response = client.subscribe(tokio_stream::once(initial)).await?;
+    let mut inbound = response.into_inner();
+
+    while let Some(event) = inbound.message().await? {
+        let applied_at = Instant::now();
+        if let Some(Payload::PolicyInvalidated(policy)) = &event.payload {
+            for sink in sinks {
+                sink.on_policy_invalidated(&policy.agent_id);
+            }
+        }
+        if event.seq > *last_seq_seen {
+            *last_seq_seen = event.seq;
+        }
+        metrics::histogram!("aa_invalidation_latency_seconds").record(applied_at.elapsed().as_secs_f64());
+    }
+
+    Ok(())
 }

--- a/aa-runtime/src/invalidation_client.rs
+++ b/aa-runtime/src/invalidation_client.rs
@@ -110,3 +110,18 @@ async fn subscribe_once(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backoff_doubles_then_caps_at_32s() {
+        // 1s → 2 → 4 → 8 → 16 → 32 → 32 (capped).
+        let schedule: Vec<u64> = std::iter::successors(Some(INITIAL_BACKOFF), |&d| Some(next_backoff(d)))
+            .take(7)
+            .map(|d| d.as_secs())
+            .collect();
+        assert_eq!(schedule, vec![1, 2, 4, 8, 16, 32, 32]);
+    }
+}

--- a/aa-runtime/src/invalidation_client.rs
+++ b/aa-runtime/src/invalidation_client.rs
@@ -1,0 +1,18 @@
+//! Assembly-side subscriber for the gateway's L1 push-invalidation channel
+//! (Story AAASM-2377).
+//!
+//! [`InvalidationClient`] opens the `assembly.gateway.v1.InvalidationService`
+//! Subscribe stream, applies each `PolicyInvalidated` event to the registered
+//! [`InvalidationSink`]s (e.g. the [`crate::l1_cache::PolicyL1Cache`]), and
+//! reconnects with exponential backoff — resuming from `last_seq_seen` so the
+//! gateway replays anything missed while disconnected.
+
+/// A consumer of policy-invalidation events delivered over the push channel.
+///
+/// The canonical implementor is an in-process L1 cache, which drops the cached
+/// decision for the named agent. An empty `agent_id` is the "invalidate all
+/// cached agents" convention the gateway uses for a global policy swap.
+pub trait InvalidationSink: Send + Sync {
+    /// Apply a policy invalidation for `agent_id` (empty = invalidate all).
+    fn on_policy_invalidated(&self, agent_id: &str);
+}

--- a/aa-runtime/src/l1_cache.rs
+++ b/aa-runtime/src/l1_cache.rs
@@ -77,3 +77,53 @@ impl<V: Send + Sync> InvalidationSink for PolicyL1Cache<V> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_and_get_roundtrip() {
+        let cache: PolicyL1Cache<bool> = PolicyL1Cache::new();
+        cache.insert("agent-a", true);
+        assert_eq!(cache.get("agent-a"), Some(true));
+        assert!(cache.contains("agent-a"));
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn invalidate_drops_only_the_named_entry() {
+        let cache: PolicyL1Cache<u8> = PolicyL1Cache::new();
+        cache.insert("agent-a", 1);
+        cache.insert("agent-b", 2);
+
+        cache.invalidate("agent-a");
+
+        assert!(!cache.contains("agent-a"));
+        assert_eq!(cache.get("agent-b"), Some(2));
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn sink_named_agent_invalidates_one() {
+        let cache: PolicyL1Cache<u8> = PolicyL1Cache::new();
+        cache.insert("agent-a", 1);
+        cache.insert("agent-b", 2);
+
+        cache.on_policy_invalidated("agent-a");
+
+        assert!(!cache.contains("agent-a"));
+        assert!(cache.contains("agent-b"));
+    }
+
+    #[test]
+    fn sink_empty_agent_invalidates_all() {
+        let cache: PolicyL1Cache<u8> = PolicyL1Cache::new();
+        cache.insert("agent-a", 1);
+        cache.insert("agent-b", 2);
+
+        cache.on_policy_invalidated("");
+
+        assert!(cache.is_empty());
+    }
+}

--- a/aa-runtime/src/l1_cache.rs
+++ b/aa-runtime/src/l1_cache.rs
@@ -1,0 +1,79 @@
+//! In-process L1 policy cache, kept fresh by gateway push-invalidation.
+//!
+//! [`PolicyL1Cache`] is a `DashMap`-backed cache keyed by `agent_id`. It serves
+//! cached policy decisions off the tool-call hot path and implements
+//! [`InvalidationSink`] so the [`crate::invalidation_client::InvalidationClient`]
+//! can evict a stale entry the moment the gateway pushes a `PolicyInvalidated`
+//! — closing the TTL-race window where a revoked agent keeps executing.
+
+use dashmap::DashMap;
+
+use crate::invalidation_client::InvalidationSink;
+
+/// A `DashMap`-backed L1 cache of per-agent values (e.g. policy decisions),
+/// invalidated on demand by the push-invalidation subscriber.
+pub struct PolicyL1Cache<V> {
+    entries: DashMap<String, V>,
+}
+
+impl<V> Default for PolicyL1Cache<V> {
+    fn default() -> Self {
+        Self {
+            entries: DashMap::new(),
+        }
+    }
+}
+
+impl<V> PolicyL1Cache<V> {
+    /// Create an empty cache.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert or replace the cached value for `agent_id`.
+    pub fn insert(&self, agent_id: impl Into<String>, value: V) {
+        self.entries.insert(agent_id.into(), value);
+    }
+
+    /// Drop the cached value for `agent_id`, if present.
+    pub fn invalidate(&self, agent_id: &str) {
+        self.entries.remove(agent_id);
+    }
+
+    /// Drop every cached value — used for a global policy swap.
+    pub fn invalidate_all(&self) {
+        self.entries.clear();
+    }
+
+    /// Whether a value is currently cached for `agent_id`.
+    pub fn contains(&self, agent_id: &str) -> bool {
+        self.entries.contains_key(agent_id)
+    }
+
+    /// Number of cached entries.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the cache holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+}
+
+impl<V: Clone> PolicyL1Cache<V> {
+    /// Return a clone of the cached value for `agent_id`, if present.
+    pub fn get(&self, agent_id: &str) -> Option<V> {
+        self.entries.get(agent_id).map(|entry| entry.value().clone())
+    }
+}
+
+impl<V: Send + Sync> InvalidationSink for PolicyL1Cache<V> {
+    fn on_policy_invalidated(&self, agent_id: &str) {
+        if agent_id.is_empty() {
+            self.invalidate_all();
+        } else {
+            self.invalidate(agent_id);
+        }
+    }
+}

--- a/aa-runtime/src/lib.rs
+++ b/aa-runtime/src/lib.rs
@@ -13,6 +13,7 @@ pub mod gateway_client;
 pub mod health;
 pub mod invalidation_client;
 pub mod ipc;
+pub mod l1_cache;
 pub mod layer;
 pub mod lifecycle;
 pub mod pipeline;

--- a/aa-runtime/src/lib.rs
+++ b/aa-runtime/src/lib.rs
@@ -11,6 +11,7 @@ pub mod correlation;
 pub mod ebpf_bridge;
 pub mod gateway_client;
 pub mod health;
+pub mod invalidation_client;
 pub mod ipc;
 pub mod layer;
 pub mod lifecycle;


### PR DESCRIPTION
## Description

Assembly-side subscriber for the push-invalidation channel — sub-task 3 of Story AAASM-2377. **Stacked on [AAASM-2382](https://github.com/ai-agent-assembly/agent-assembly/pull/875) (which is stacked on #873); the upstream commits drop out as those PRs merge. Targets `master` per repo policy.**

> **Crate note:** the ticket says `aa-assembly/src/invalidation_client.rs`, but there is no `aa-assembly` crate — the Assembly runtime is **`aa-runtime`** (it already hosts `gateway_client.rs`). Implemented there. `aa-gateway` depends on `aa-runtime`, so the end-to-end test (which needs the real server) lives in **`aa-integration-tests`** to avoid a dependency cycle.

Adds:

- **`InvalidationSink`** trait — `on_policy_invalidated(agent_id)`; empty `agent_id` = invalidate all.
- **`PolicyL1Cache<V>`** (`aa-runtime/src/l1_cache.rs`) — `DashMap`-backed L1 cache keyed by `agent_id` (`insert`/`get`/`invalidate`/`invalidate_all`), implementing `InvalidationSink`.
- **`InvalidationClient::start(gateway_url, assembly_id, sinks)`** — spawns a Tokio task that opens the Subscribe stream, applies each `PolicyInvalidated` to the sinks, and on disconnect backs off exponentially **1s → 2 → 4 → … → 32s cap**, resubscribing with `last_seq_seen` so the gateway replays anything missed.
- **Metrics** — `aa_invalidation_reconnects_total` (counter), `aa_invalidation_latency_seconds` (apply-latency histogram).
- Added `tokio-stream` to `aa-runtime` (already the workspace streaming primitive) for the client-streaming request.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2383 (sub-task of AAASM-2377, Epic AAASM-2349)
- Depends on: AAASM-2382 (#875), AAASM-2381 (#873)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

- `aa-runtime`: PolicyL1Cache insert/invalidate + sink contract (named drops one, empty clears all); `next_backoff` schedule `1,2,4,8,16,32,32`.
- `aa-integration-tests/e2e_invalidation_channel`: real gateway `InvalidationServiceImpl` ↔ real `InvalidationClient` over loopback gRPC — broadcast `PolicyInvalidated(agent-x)` evicts the L1 entry within **100 ms** while `agent-y` stays cached. All green.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention


[AAASM-2382]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ