### PR TITLE
[AAASM-2398] ✅ (sanitizer): Verify write-boundary sanitizer acceptance criteria

### DIFF
--- a/aa-gateway/tests/sanitizer_adversarial_test.rs
+++ b/aa-gateway/tests/sanitizer_adversarial_test.rs
@@ -1,0 +1,76 @@
+//! Adversarial verification for the write-boundary sanitizer
+//! (Story AAASM-2390, verification subtask AAASM-2398).
+//!
+//! Treats the sanitizer as a black box at its public boundary: feeds a
+//! maliciously-crafted event that stuffs every banned key into every nesting
+//! position, then asserts the sanitized output a handler would persist
+//! contains none of them — the boundary-level equivalent of "publish a
+//! crafted event and assert the resulting DB row has no banned field". The
+//! end-to-end NATS→Postgres path lands with the consumer (AAASM-2388).
+
+use aa_gateway::sanitizer::{sanitize, RawAuditEvent, SanitizeOutcome};
+use serde_json::{json, Value};
+
+/// Every key the sanitizer must strip, per AAASM-2390 / AAASM-2397.
+const BANNED_KEYS: &[&str] = &[
+    "prompt",
+    "completion",
+    "llm_input",
+    "llm_output",
+    "tool_payload",
+    "tool_response",
+    "tool_args",
+    "tool_result",
+    "packet_body",
+    "packet_payload",
+    "heartbeat_seq",
+];
+
+/// Recursively reports whether `key` appears anywhere in the JSON tree.
+fn contains_key_recursive(value: &Value, key: &str) -> bool {
+    match value {
+        Value::Object(map) => map.contains_key(key) || map.values().any(|v| contains_key_recursive(v, key)),
+        Value::Array(items) => items.iter().any(|v| contains_key_recursive(v, key)),
+        _ => false,
+    }
+}
+
+#[test]
+fn maliciously_crafted_event_yields_no_banned_keys() {
+    // Every banned key, placed top-level AND nested inside payload, an array,
+    // and a deeply-nested object — plus an unknown field for good measure.
+    let raw = RawAuditEvent::new(json!({
+        "kind": "tool_call",
+        "agent_id": "acme/bot",
+        "prompt": "top-level prompt",
+        "completion": "top-level completion",
+        "llm_input": "x",
+        "llm_output": "y",
+        "tool_payload": { "tool_args": ["--secret"], "nested": { "prompt": "deep" } },
+        "tool_response": { "tool_result": { "packet_body": "QkFTRTY0" } },
+        "packet_payload": "raw",
+        "heartbeat_seq": 9,
+        "payload": {
+            "events": [
+                { "prompt": "in-array prompt", "completion": "in-array completion" },
+                { "tool_payload": { "packet_payload": "deep-bytes" } }
+            ],
+            "meta": { "llm_input": "nested", "heartbeat_seq": 1 }
+        },
+        "exfiltration_attempt": "unknown field"
+    }));
+
+    let SanitizeOutcome::Audit(ev) = sanitize(raw) else {
+        panic!("a non-heartbeat event must produce an audit row");
+    };
+    let sanitized = ev.into_value();
+
+    for banned in BANNED_KEYS {
+        assert!(
+            !contains_key_recursive(&sanitized, banned),
+            "banned key `{banned}` survived sanitization: {sanitized:#}"
+        );
+    }
+    // The unknown top-level field is dropped as well.
+    assert!(!contains_key_recursive(&sanitized, "exfiltration_attempt"));
+}

--- a/aa-gateway/tests/sanitizer_adversarial_test.rs
+++ b/aa-gateway/tests/sanitizer_adversarial_test.rs
@@ -74,3 +74,20 @@ fn maliciously_crafted_event_yields_no_banned_keys() {
     // The unknown top-level field is dropped as well.
     assert!(!contains_key_recursive(&sanitized, "exfiltration_attempt"));
 }
+
+#[test]
+fn malicious_heartbeat_never_becomes_audit_row() {
+    // A heartbeat that smuggles a prompt must still route to a last-seen
+    // update, never an audit row.
+    let raw = RawAuditEvent::new(json!({
+        "kind": "heartbeat",
+        "agent_id": "acme/bot",
+        "ts": "2026-06-03T12:00:00Z",
+        "prompt": "smuggled prompt on a heartbeat",
+        "heartbeat_seq": 123,
+    }));
+    match sanitize(raw) {
+        SanitizeOutcome::Heartbeat(hb) => assert_eq!(hb.agent_id, "acme/bot"),
+        SanitizeOutcome::Audit(_) => panic!("a heartbeat must not produce an audit row"),
+    }
+}

--- a/verification-reports/AAASM-2390.md
+++ b/verification-reports/AAASM-2390.md
@@ -1,0 +1,53 @@
+# Verification Report — AAASM-2390 (Write-boundary sanitizer)
+
+- **Story:** AAASM-2390 — write-boundary sanitizer that strips raw LLM prompts, tool payloads, eBPF packets, and per-heartbeat data before any audit event hits Postgres
+- **Implementation subtask:** AAASM-2397 — PR [#883](https://github.com/ai-agent-assembly/agent-assembly/pull/883)
+- **Verification subtask:** AAASM-2398 (this report)
+- **Epic:** AAASM-2350 (Async event production + Gateway NATS consumer, Phase 1)
+- **Crate / module:** `aa-gateway::sanitizer`
+- **Date:** 2026-06-03
+
+## Scope of the implemented surface
+
+`aa-gateway::sanitizer` exposes:
+
+- `RawAuditEvent` / `SanitizedAuditEvent` newtypes over `serde_json::Value`. The sanitized inner value is private and its constructor is crate-private, so the only way to obtain a `SanitizedAuditEvent` is `sanitize()` (compile-time INSERT guard).
+- `sanitize(RawAuditEvent) -> SanitizeOutcome` returning `Audit(SanitizedAuditEvent)` or `Heartbeat(HeartbeatUpdate)`.
+- Recursive banned-key strip, unknown-top-level-key drop with the `aa_audit_dropped_unknown_field_total{field=…}` counter, and heartbeat collapse.
+
+## Acceptance criteria
+
+| # | Acceptance criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Distinct `SanitizedAuditEvent` type — INSERT accepts only this | ✅ PASS | Private inner + crate-private constructor; `sanitize` is the sole minting path (`aa-gateway/src/sanitizer/event.rs`). |
+| 2 | Drop rules cover all banned keys recursively | ✅ PASS | 11 per-key unit tests + `drops_banned_keys_nested_in_payload` + adversarial test asserting recursive absence (covers the Story's six and the subtask's expanded list as a superset). |
+| 3 | Heartbeat routes to a last-seen update, not `audit_logs` | ✅ PASS | `heartbeat_routes_to_last_seen_update` unit test + `malicious_heartbeat_never_becomes_audit_row` adversarial test. |
+| 4 | Unknown-field drops increment the metric | ✅ PASS | `drop_unknown_top_level` emits `aa_audit_dropped_unknown_field_total{field=…}`; `drops_unknown_top_level_field` asserts the drop. |
+| 5 | Proptest invariant holds for 1000 random inputs | ✅ PASS | `proptest_no_banned_keys` configured with `ProptestConfig::with_cases(1000)`. |
+
+## Commands run
+
+```
+# 1. Full sanitizer unit suite
+cargo nextest run -p aa-gateway sanitizer::
+# → 15 tests run: 15 passed
+
+# 2. Proptest invariant, 1000 cases (release)
+cargo nextest run -p aa-gateway sanitizer::sanitize::tests::proptest_no_banned_keys --release
+# → 1 test run: 1 passed (1000 cases)
+
+# 3. Adversarial integration tests (sanitizer boundary)
+cargo nextest run -p aa-gateway --test sanitizer_adversarial_test
+# → 2 tests run: 2 passed
+```
+
+> The proptest's full path is `sanitizer::sanitize::tests::proptest_no_banned_keys`; the `sanitizer::` filter from the ticket runs it together with the rest of the suite, and `proptest_no_banned_keys` selects it alone.
+
+## Notes / deviations
+
+- **End-to-end DB assertion (ticket step 3) is performed at the sanitizer boundary**, not through NATS→Postgres, because the consumer (AAASM-2388) and the `audit_logs` INSERT path do not exist yet (AAASM-2388 is To Do). The adversarial test feeds a maliciously-crafted event with every banned key — top-level, in arrays, and deeply nested — through the public `sanitize()` and asserts the persistable output contains none of them. The full publish→consume→INSERT assertion will be added with AAASM-2388.
+- The local full `aa-gateway` suite reports one unrelated failure, `policy_latency_test::sustained_load_p99_under_5ms` — a known macOS dev-box timing flake (pre-existing on `master`, green on CI Linux). It is not affected by this change.
+
+## Outcome
+
+All acceptance criteria pass. No Bug subtask filed.


### PR DESCRIPTION
## Description

Verification of the write-boundary sanitizer (Story AAASM-2390), subtask **AAASM-2398**. Adds an adversarial integration test at the sanitizer's public boundary and a verification report capturing the AC pass/fail matrix.

> **Stacked on [#883](https://github.com/ai-agent-assembly/agent-assembly/pull/883) (AAASM-2397).** Base is `master`; until #883 merges this PR's diff shows the 24 implementation commits too. The 3 commits unique to this PR are the two adversarial tests + the verification report. Rebase after #883 merges drops the duplicates.

### What's here
- `aa-gateway/tests/sanitizer_adversarial_test.rs`:
  - `maliciously_crafted_event_yields_no_banned_keys` — a crafted event stuffs **every** banned key top-level, inside arrays, and deeply nested (plus an unknown field); asserts the persistable output contains none of them.
  - `malicious_heartbeat_never_becomes_audit_row` — a heartbeat smuggling a prompt still collapses to a last-seen update, never an audit row.
- `verification-reports/AAASM-2390.md` — AC matrix, commands, and outcomes.

### AC results (all pass)
| AC | Result |
|---|---|
| Distinct `SanitizedAuditEvent`, INSERT accepts only this | ✅ |
| Drop rules cover banned keys recursively | ✅ |
| Heartbeat routes to last-seen update | ✅ |
| Unknown-field drops increment the metric | ✅ |
| Proptest invariant holds for 1000 inputs | ✅ |

### Note
The ticket's end-to-end "publish → assert DB row has none" is performed **at the sanitizer boundary** here, because the consumer + `audit_logs` INSERT path (AAASM-2388) is still To Do. The full NATS→Postgres assertion lands with AAASM-2388. No Bug subtask filed — all ACs pass.

## Type of Change

- [x] ✅ Tests / verification

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2398 (verification subtask of Story AAASM-2390, Epic AAASM-2350)
- Stacked on: AAASM-2397 / PR #883

## Testing

- [x] Integration tests added (`cargo nextest run -p aa-gateway --test sanitizer_adversarial_test` → 2 passed)
- [x] Re-ran the unit + proptest suite (`cargo nextest run -p aa-gateway sanitizer::` → 15 passed; proptest 1000 cases)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --all-targets --all-features -D warnings`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (verification report added)
- [ ] All CI checks passing (pending CI)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
