### PR TITLE
[AAASM-2384] ✅ (verification): Verify gRPC push-invalidation acceptance criteria

### DIFF
--- a/aa-integration-tests/tests/e2e_invalidation_reconnect.rs
+++ b/aa-integration-tests/tests/e2e_invalidation_reconnect.rs
@@ -1,0 +1,71 @@
+//! Reconnect/replay verification for the push-invalidation channel
+//! (Story AAASM-2377, verification AAASM-2384).
+//!
+//! Proves the "no lost invalidations across a reconnect" acceptance criterion:
+//! a `PolicyInvalidated` broadcast while the Assembly is disconnected is
+//! buffered in the gateway's per-subscriber replay ring and delivered when the
+//! Assembly reconnects under the same `assembly_id` with `Resubscribe(last_seq)`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::net::TcpListener;
+use tonic::transport::Server;
+
+use aa_gateway::invalidation::{InvalidationHub, InvalidationServiceImpl};
+use aa_proto::assembly::gateway::v1::invalidation_service_server::InvalidationServiceServer;
+use aa_runtime::invalidation_client::{InvalidationClient, InvalidationSink};
+use aa_runtime::l1_cache::PolicyL1Cache;
+
+#[tokio::test]
+async fn reconnect_replays_invalidation_missed_while_disconnected() {
+    // Real gateway InvalidationService on a loopback port.
+    let hub = InvalidationHub::new();
+    let service = InvalidationServiceImpl::new(Arc::clone(&hub));
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind gateway");
+    let addr = listener.local_addr().expect("local_addr");
+    let server = tokio::spawn(async move {
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(InvalidationServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .expect("tonic Server::serve_with_incoming");
+    });
+    let gateway_url = format!("http://{addr}");
+
+    // First connection: registers subscriber "asm-r", then disconnects.
+    let cache_a: Arc<PolicyL1Cache<bool>> = Arc::new(PolicyL1Cache::new());
+    let sink_a: Arc<dyn InvalidationSink> = Arc::clone(&cache_a) as Arc<dyn InvalidationSink>;
+    let client_a = InvalidationClient::start(gateway_url.clone(), "asm-r".to_string(), vec![sink_a]);
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while hub.subscriber_count() == 0 {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("first connection subscribed");
+    client_a.abort();
+
+    // Mutation happens while "asm-r" is disconnected — buffered in the replay ring.
+    hub.broadcast_policy_invalidated("agent-x", 1);
+
+    // Reconnect under the same assembly_id with a freshly warmed cache. The
+    // client opens with last_seq_seen = 0, so the gateway replays the missed
+    // event and the entry is evicted.
+    let cache_b: Arc<PolicyL1Cache<bool>> = Arc::new(PolicyL1Cache::new());
+    cache_b.insert("agent-x", true);
+    let sink_b: Arc<dyn InvalidationSink> = Arc::clone(&cache_b) as Arc<dyn InvalidationSink>;
+    let client_b = InvalidationClient::start(gateway_url, "asm-r".to_string(), vec![sink_b]);
+
+    tokio::time::timeout(Duration::from_secs(3), async {
+        while cache_b.contains("agent-x") {
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+    })
+    .await
+    .expect("missed invalidation replayed on reconnect");
+
+    client_b.abort();
+    server.abort();
+}

--- a/verification-reports/AAASM-2384.md
+++ b/verification-reports/AAASM-2384.md
@@ -1,0 +1,67 @@
+# Verification Report — AAASM-2384
+
+**Story:** AAASM-2377 — *Persistent gRPC bidi stream that pushes policy invalidations so cache freshness isn't a TTL race*
+**Epic:** AAASM-2349 — *L1 in-process cache + Gateway push-invalidation channel*
+**Component / repo:** `agent-assembly`
+**Date:** 2026-06-03
+
+## Scope
+
+Verifies the push-invalidation channel delivered across the three implementation
+sub-tasks:
+
+| Sub-task | PR | Surface |
+|---|---|---|
+| AAASM-2381 | #873 | `proto/invalidation.proto` + `aa-proto` codegen (`assembly.gateway.v1`) |
+| AAASM-2382 | #875 | `aa-gateway/src/invalidation/` server (hub + Subscribe RPC) |
+| AAASM-2383 | #888 | `aa-runtime` `InvalidationClient` + `PolicyL1Cache` sink |
+
+## Acceptance criteria (Story AAASM-2377)
+
+| # | Criterion | Result | Evidence |
+|---|---|---|---|
+| 1 | Proto `InvalidationService` with bidi-stream `Subscribe(stream SubscribeRequest) returns (stream InvalidationEvent)` | ✅ Pass | `proto/invalidation.proto`; `cargo check -p aa-proto` generates `InvalidationServiceServer`/`Client`. Package is `assembly.gateway.v1` (repo convention) rather than the literal `aa.gateway.v1`. |
+| 2 | `InvalidationEvent` carries `oneof { PolicyInvalidated, ApprovalResolved }` | ✅ Pass | `invalidation_event::Payload` enum; `ApprovalResolved` + `Decision` reserved for the next Story. |
+| 3 | Gateway server: a `Sender<InvalidationEvent>` per connected Assembly; broadcast on policy mutation | ✅ Pass | `InvalidationHub` (per-subscriber `broadcast::Sender` + seq + replay ring); `PolicyEngine::apply_yaml` broadcasts after the epoch bump. `engine::tests::apply_yaml_broadcasts_invalidation_within_100ms`. |
+| 4 | Assembly client: reconnect with exponential backoff (1s → 32s cap) | ✅ Pass | `InvalidationClient` run loop; `invalidation_client::tests::backoff_doubles_then_caps_at_32s` asserts `1,2,4,8,16,32,32`. |
+| 5 | On reconnect, Assembly issues `Resubscribe(last_seq)`; gateway replays anything missed | ✅ Pass | Client opens with `SubscribeInitial.last_seq_seen`; hub replays `seq > last_seq_seen`. `hub::tests::reconnect_replays_only_events_after_last_seq` + e2e `reconnect_replays_invalidation_missed_while_disconnected`. |
+| 6 | Integration test: mutate policy → subscribed Assembly L1 invalidated within 100 ms | ✅ Pass | `e2e_invalidation_channel::policy_invalidation_evicts_l1_within_100ms` (real server ↔ real client over loopback gRPC). |
+
+## Commands run
+
+```
+cargo check -p aa-proto
+cargo nextest run -p aa-gateway -p aa-runtime -p aa-integration-tests invalidation
+cargo nextest run -p aa-runtime l1_cache::
+```
+
+## Results
+
+```
+9 tests run: 9 passed   (invalidation filter: aa-gateway hub ×4, engine apply_yaml ×1,
+                         aa-runtime backoff ×1, aa-integration-tests e2e ×2)
+4 tests run: 4 passed   (aa-runtime l1_cache::tests — PolicyL1Cache + sink contract)
+cargo check -p aa-proto: Finished (assembly.gateway.v1 bindings compile)
+```
+
+All green. `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -D warnings`,
+and `cargo deny check` are enforced by the lefthook pre-commit hook on every commit in the
+three implementation PRs.
+
+## Notes & limitations
+
+- **Replay durability:** the per-subscriber replay ring (1024 events) is in-memory. Reconnect
+  *to a live gateway* replays missed events (verified). A full gateway **process restart** drops
+  the ring — "no lost invalidations once both sides are up" holds for reconnects, but durable
+  cross-restart replay would need a persistent backing store (candidate follow-up, not in this
+  Story's scope).
+- **Latency metric:** `aa_invalidation_latency_seconds` records the client-side apply latency
+  (event receipt → sink dispatch); true wire latency would require a timestamp field on the
+  event, which the proto deliberately omits for now.
+- **Crate mapping:** the Assembly subscriber lives in `aa-runtime` (no `aa-assembly` crate
+  exists); the e2e tests live in `aa-integration-tests` to avoid the `aa-gateway → aa-runtime`
+  dependency cycle.
+
+## Verdict
+
+**All acceptance criteria pass.** No blocking defects found; no Bug sub-task filed.


### PR DESCRIPTION
## Description

Verification of Story AAASM-2377 (gRPC push-invalidation channel) — sub-task AAASM-2384. **Stacked on [AAASM-2383](https://github.com/ai-agent-assembly/agent-assembly/pull/888) → #875 → #873; targets `master` per repo policy.**

Adds:

1. **Reconnect/replay e2e** (`aa-integration-tests/tests/e2e_invalidation_reconnect.rs`) — broadcast a `PolicyInvalidated` while assembly `asm-r` is disconnected, reconnect under the same `assembly_id`, and assert the gateway's replay ring delivers the missed event (L1 entry evicted).
2. **Verification report** (`verification-reports/AAASM-2384.md`) — maps all six Story ACs to passing evidence, with the commands run and known limitations.

### Result: all six acceptance criteria pass

| AC | Result |
|---|---|
| Proto `InvalidationService` bidi stream | ✅ |
| `InvalidationEvent` oneof (PolicyInvalidated / ApprovalResolved reserved) | ✅ |
| Gateway per-subscriber sender + broadcast on mutation | ✅ |
| Client exponential backoff 1s→32s | ✅ |
| Resubscribe(last_seq) replay | ✅ |
| E2E invalidation < 100 ms | ✅ |

`cargo nextest run -p aa-gateway -p aa-runtime -p aa-integration-tests invalidation` → 9 passed; `aa-runtime l1_cache::` → 4 passed. No blocking defects; no Bug sub-task filed.

**Limitation noted in the report:** the 1024-event replay ring is in-memory — reconnect-to-live-gateway replay is covered; durable replay across a full gateway *process restart* would need a persistent store (candidate follow-up).

## Type of Change

- [x] ✅ Tests / verification
- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2384 (verification sub-task of AAASM-2377, Epic AAASM-2349)
- Verifies: AAASM-2381 (#873), AAASM-2382 (#875), AAASM-2383 (#888)

## Testing

- [x] Integration tests added / updated

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention


[AAASM-2383]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ