### PR TITLE
[AAASM-2464] ✨ (storage): Wire all-memory agent-assembly.toml boot + register memory driver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,7 @@ dependencies = [
  "aa-proxy",
  "aa-sandbox",
  "aa-storage",
+ "aa-storage-memory",
  "anyhow",
  "assert_cmd",
  "async-trait",
@@ -469,6 +470,7 @@ dependencies = [
  "dashmap",
  "parking_lot",
  "tokio",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -27,6 +27,7 @@ aa-gateway           = { path = "../aa-gateway", version = "0.0.1-alpha.5" }
 aa-proxy             = { path = "../aa-proxy", version = "0.0.1-alpha.5" }
 aa-sandbox           = { path = "../aa-sandbox", version = "0.0.1-alpha.5" }
 aa-storage           = { path = "../aa-storage", version = "0.0.1-alpha.5" }
+aa-storage-memory    = { path = "../aa-storage-memory", version = "0.0.1-alpha.5" }
 anyhow         = "1"
 async-trait    = "0.1"
 axum           = "0.8"

--- a/aa-cli/src/commands/config/boot.rs
+++ b/aa-cli/src/commands/config/boot.rs
@@ -1,0 +1,122 @@
+//! `aasm config boot` — build the storage backends declared in
+//! `agent-assembly.toml` and serve a sample policy lookup, proving the config
+//! wires up end-to-end. Smoke-tests an all-`"memory"` (or any) deployment.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use aa_storage::{AgentId, Registry, StorageConfig, StorageError};
+use clap::Args;
+use serde::Deserialize;
+
+/// Arguments for `aasm config boot`.
+#[derive(Args)]
+pub struct BootArgs {
+    /// Path to the `agent-assembly.toml` file to boot from.
+    pub file: PathBuf,
+}
+
+/// Minimal view of `agent-assembly.toml` covering the sections this command
+/// reads. Unknown sections are ignored.
+#[derive(Deserialize)]
+struct RuntimeConfig {
+    storage: Option<StorageConfig>,
+}
+
+/// Execute `aasm config boot`.
+///
+/// Resolves every `[storage]` driver through the registry (built-in driver
+/// names plus the real in-memory driver), builds each backend, and performs a
+/// sample policy lookup. Exits 0 on success; 1 with the error on stderr.
+pub fn run(args: BootArgs) -> ExitCode {
+    let contents = match std::fs::read_to_string(&args.file) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: failed to read {}: {e}", args.file.display());
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let config: RuntimeConfig = match toml::from_str(&contents) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: invalid TOML in {}: {e}", args.file.display());
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let Some(storage) = config.storage else {
+        eprintln!("error: {} has no [storage] section", args.file.display());
+        return ExitCode::FAILURE;
+    };
+
+    // Built-in driver names, then the real in-memory driver — `register_*` is
+    // last-write-wins, so this replaces the "memory" placeholder.
+    let mut registry = Registry::new();
+    aa_storage::builtin::register_builtin_drivers(&mut registry);
+    aa_storage_memory::register(&mut registry);
+
+    if let Err(e) = registry.validate(&storage) {
+        eprintln!("error: {e}");
+        return ExitCode::FAILURE;
+    }
+
+    let policy_store = match registry.build_policy_store(&storage) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    // Build the remaining five backends so a misconfigured kind fails the boot.
+    let others = [
+        ("audit_sink", registry.build_audit_sink(&storage).map(drop)),
+        ("session_store", registry.build_session_store(&storage).map(drop)),
+        ("credential_store", registry.build_credential_store(&storage).map(drop)),
+        (
+            "rate_limit_counter",
+            registry.build_rate_limit_counter(&storage).map(drop),
+        ),
+        ("lifecycle_store", registry.build_lifecycle_store(&storage).map(drop)),
+    ];
+    for (kind, result) in others {
+        if let Err(e) = result {
+            eprintln!("error: failed to build {kind}: {e}");
+            return ExitCode::FAILURE;
+        }
+    }
+
+    // Serve a sample policy lookup end-to-end (config commands run outside a
+    // runtime, so build a small one for the async trait call).
+    let agent = AgentId::from_bytes([0u8; 16]);
+    let runtime = match tokio::runtime::Builder::new_current_thread().enable_all().build() {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("error: failed to start runtime: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let lookup = runtime.block_on(policy_store.get_policy(&agent));
+
+    println!("Booted storage from {}", args.file.display());
+    println!("  policy_store       = {}", storage.policy_store);
+    println!("  audit_sink         = {}", storage.audit_sink);
+    println!("  session_store      = {}", storage.session_store);
+    println!("  credential_store   = {}", storage.credential_store);
+    println!("  rate_limit_counter = {}", storage.rate_limit_counter);
+    println!("  lifecycle_store    = {}", storage.lifecycle_store);
+
+    let agent_hex = hex::encode(agent.as_bytes());
+    match lookup {
+        Ok(policy) => println!("  policy lookup for agent {agent_hex}: found policy {:?}", policy.name),
+        Err(StorageError::NotFound(_)) => {
+            println!("  policy lookup for agent {agent_hex}: no policy on record (empty store)")
+        }
+        Err(e) => {
+            eprintln!("error: policy lookup failed: {e}");
+            return ExitCode::FAILURE;
+        }
+    }
+
+    ExitCode::SUCCESS
+}

--- a/aa-cli/src/commands/config/boot.rs
+++ b/aa-cli/src/commands/config/boot.rs
@@ -120,3 +120,28 @@ pub fn run(args: BootArgs) -> ExitCode {
 
     ExitCode::SUCCESS
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture(name: &str) -> PathBuf {
+        PathBuf::from(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures")).join(name)
+    }
+
+    #[test]
+    fn all_memory_config_boots_successfully() {
+        let args = BootArgs {
+            file: fixture("storage_all_memory.toml"),
+        };
+        assert_eq!(run(args), ExitCode::SUCCESS);
+    }
+
+    #[test]
+    fn missing_file_exits_failure() {
+        let args = BootArgs {
+            file: PathBuf::from("/tmp/nonexistent-aaasm-boot-xyz.toml"),
+        };
+        assert_eq!(run(args), ExitCode::FAILURE);
+    }
+}

--- a/aa-cli/src/commands/config/mod.rs
+++ b/aa-cli/src/commands/config/mod.rs
@@ -4,6 +4,7 @@ use std::process::ExitCode;
 
 use clap::{Args, Subcommand};
 
+pub mod boot;
 pub mod validate;
 
 /// Arguments for the `aasm config` subcommand group.
@@ -18,11 +19,14 @@ pub struct ConfigArgs {
 pub enum ConfigCommands {
     /// Validate an `agent-assembly.toml` file (currently the `[storage]` section).
     Validate(validate::ValidateArgs),
+    /// Build the `[storage]` backends from an `agent-assembly.toml` and run a sample policy lookup.
+    Boot(boot::BootArgs),
 }
 
 /// Dispatch a config subcommand.
 pub fn dispatch(args: ConfigArgs) -> ExitCode {
     match args.command {
         ConfigCommands::Validate(val_args) => validate::run(val_args),
+        ConfigCommands::Boot(boot_args) => boot::run(boot_args),
     }
 }

--- a/aa-cli/tests/fixtures/storage_all_memory.toml
+++ b/aa-cli/tests/fixtures/storage_all_memory.toml
@@ -1,0 +1,12 @@
+# Fixture: every storage kind uses the in-memory driver. `aasm config boot`
+# builds all six backends and serves a sample policy lookup; exits 0.
+[storage]
+policy_store       = "memory"
+audit_sink         = "memory"
+session_store      = "memory"
+credential_store   = "memory"
+rate_limit_counter = "memory"
+lifecycle_store    = "memory"
+
+# The in-memory driver needs no connection settings.
+[storage.memory]

--- a/aa-storage-memory/Cargo.toml
+++ b/aa-storage-memory/Cargo.toml
@@ -12,6 +12,9 @@ aa-storage = { path = "../aa-storage" }
 async-trait = "0.1"
 dashmap = "6"
 parking_lot = "0.12"
+# `toml` (same 0.9 pin as `aa-storage`) backs the driver-factory signatures,
+# which take the `[storage.memory]` subsection as a `toml::Value`.
+toml = "0.9"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/aa-storage-memory/src/factory.rs
+++ b/aa-storage-memory/src/factory.rs
@@ -1,0 +1,79 @@
+//! Factories that build the in-memory backends for the `aa-storage` driver
+//! registry.
+//!
+//! The memory driver needs no connection settings, so every factory ignores its
+//! `[storage.memory]` TOML subsection and returns a fresh, empty store. They are
+//! registered under the driver name `"memory"` by [`crate::register`].
+
+use std::sync::Arc;
+
+use aa_storage::factory::{
+    AuditSinkFactory, CredentialStoreFactory, LifecycleStoreFactory, PolicyStoreFactory, RateLimitCounterFactory,
+    SessionStoreFactory,
+};
+use aa_storage::{AuditSink, CredentialStore, LifecycleStore, PolicyStore, RateLimitCounter, Result, SessionStore};
+
+use crate::{
+    MemoryAuditSink, MemoryCredentialStore, MemoryLifecycleStore, MemoryPolicyStore, MemoryRateLimitCounter,
+    MemorySessionStore,
+};
+
+/// Builds a [`MemoryPolicyStore`](crate::MemoryPolicyStore).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MemoryPolicyStoreFactory;
+
+impl PolicyStoreFactory for MemoryPolicyStoreFactory {
+    fn build(&self, _config: &toml::Value) -> Result<Arc<dyn PolicyStore>> {
+        Ok(Arc::new(MemoryPolicyStore::new()))
+    }
+}
+
+/// Builds a [`MemoryAuditSink`](crate::MemoryAuditSink).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MemoryAuditSinkFactory;
+
+impl AuditSinkFactory for MemoryAuditSinkFactory {
+    fn build(&self, _config: &toml::Value) -> Result<Arc<dyn AuditSink>> {
+        Ok(Arc::new(MemoryAuditSink::new()))
+    }
+}
+
+/// Builds a [`MemorySessionStore`](crate::MemorySessionStore).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MemorySessionStoreFactory;
+
+impl SessionStoreFactory for MemorySessionStoreFactory {
+    fn build(&self, _config: &toml::Value) -> Result<Arc<dyn SessionStore>> {
+        Ok(Arc::new(MemorySessionStore::new()))
+    }
+}
+
+/// Builds a [`MemoryCredentialStore`](crate::MemoryCredentialStore).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MemoryCredentialStoreFactory;
+
+impl CredentialStoreFactory for MemoryCredentialStoreFactory {
+    fn build(&self, _config: &toml::Value) -> Result<Arc<dyn CredentialStore>> {
+        Ok(Arc::new(MemoryCredentialStore::new()))
+    }
+}
+
+/// Builds a [`MemoryRateLimitCounter`](crate::MemoryRateLimitCounter).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MemoryRateLimitCounterFactory;
+
+impl RateLimitCounterFactory for MemoryRateLimitCounterFactory {
+    fn build(&self, _config: &toml::Value) -> Result<Arc<dyn RateLimitCounter>> {
+        Ok(Arc::new(MemoryRateLimitCounter::new()))
+    }
+}
+
+/// Builds a [`MemoryLifecycleStore`](crate::MemoryLifecycleStore).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MemoryLifecycleStoreFactory;
+
+impl LifecycleStoreFactory for MemoryLifecycleStoreFactory {
+    fn build(&self, _config: &toml::Value) -> Result<Arc<dyn LifecycleStore>> {
+        Ok(Arc::new(MemoryLifecycleStore::new()))
+    }
+}

--- a/aa-storage-memory/src/lib.rs
+++ b/aa-storage-memory/src/lib.rs
@@ -4,15 +4,23 @@
 //! traits, for unit/integration tests and local development without a real
 //! database. State is ephemeral — it lives only for the life of the process.
 //!
-//! Each store is a self-contained backend. Selecting them by name and building
-//! them from an `agent-assembly.toml` `[storage]` section is the job of the
-//! `aa-storage` driver registry (AAASM-2361) and the boot wiring, not this crate.
+//! # Driver registration
+//!
+//! Call [`register`] from boot code to announce all six backends to an
+//! [`aa_storage::Registry`] under [`DRIVER_NAME`] (`"memory"`), so an
+//! `agent-assembly.toml` `[storage]` section can select them by name. The
+//! per-kind [`factory`] types build a store from its `[storage.memory]`
+//! subsection (which the memory driver ignores — it needs no connection
+//! settings).
+
+pub mod factory;
 
 mod audit_sink;
 mod credential_store;
 mod lifecycle_store;
 mod policy_store;
 mod rate_limit_counter;
+mod registration;
 mod session_store;
 
 pub use audit_sink::MemoryAuditSink;
@@ -20,4 +28,5 @@ pub use credential_store::MemoryCredentialStore;
 pub use lifecycle_store::MemoryLifecycleStore;
 pub use policy_store::MemoryPolicyStore;
 pub use rate_limit_counter::MemoryRateLimitCounter;
+pub use registration::{register, DRIVER_NAME};
 pub use session_store::MemorySessionStore;

--- a/aa-storage-memory/src/registration.rs
+++ b/aa-storage-memory/src/registration.rs
@@ -1,0 +1,27 @@
+//! Driver registration: announce the memory backends to an [`aa_storage::Registry`].
+
+use aa_storage::Registry;
+
+use crate::factory::{
+    MemoryAuditSinkFactory, MemoryCredentialStoreFactory, MemoryLifecycleStoreFactory, MemoryPolicyStoreFactory,
+    MemoryRateLimitCounterFactory, MemorySessionStoreFactory,
+};
+
+/// The name the memory driver registers all six storage backends under.
+pub const DRIVER_NAME: &str = "memory";
+
+/// Register the in-memory factories for all six storage kinds into `reg` under
+/// [`DRIVER_NAME`].
+///
+/// Call this from boot code *after*
+/// [`aa_storage::builtin::register_builtin_drivers`] to replace the `"memory"`
+/// placeholder with the real backends — `register_*` is last-write-wins, so the
+/// real factory overrides the not-yet-implemented stub.
+pub fn register(reg: &mut Registry) {
+    reg.register_policy_store(DRIVER_NAME, Box::new(MemoryPolicyStoreFactory));
+    reg.register_audit_sink(DRIVER_NAME, Box::new(MemoryAuditSinkFactory));
+    reg.register_session_store(DRIVER_NAME, Box::new(MemorySessionStoreFactory));
+    reg.register_credential_store(DRIVER_NAME, Box::new(MemoryCredentialStoreFactory));
+    reg.register_rate_limit_counter(DRIVER_NAME, Box::new(MemoryRateLimitCounterFactory));
+    reg.register_lifecycle_store(DRIVER_NAME, Box::new(MemoryLifecycleStoreFactory));
+}

--- a/aa-storage-memory/tests/registry_integration.rs
+++ b/aa-storage-memory/tests/registry_integration.rs
@@ -1,0 +1,52 @@
+//! Proves the memory driver registers into `aa_storage::Registry` and that an
+//! all-`"memory"` `[storage]` config validates and builds every backend.
+
+use aa_storage::{Registry, StorageConfig};
+
+const ALL_MEMORY: &str = r#"
+policy_store       = "memory"
+audit_sink         = "memory"
+session_store      = "memory"
+credential_store   = "memory"
+rate_limit_counter = "memory"
+lifecycle_store    = "memory"
+
+[memory]
+"#;
+
+fn all_memory_config() -> StorageConfig {
+    toml::from_str(ALL_MEMORY).expect("fixture parses")
+}
+
+#[test]
+fn register_makes_memory_resolvable_for_all_kinds() {
+    let mut reg = Registry::new();
+    aa_storage_memory::register(&mut reg);
+
+    for names in [
+        reg.policy_store_names(),
+        reg.audit_sink_names(),
+        reg.session_store_names(),
+        reg.credential_store_names(),
+        reg.rate_limit_counter_names(),
+        reg.lifecycle_store_names(),
+    ] {
+        assert!(names.contains(&"memory"), "memory should be registered for every kind");
+    }
+}
+
+#[test]
+fn all_memory_config_validates_and_builds_every_backend() {
+    let mut reg = Registry::new();
+    aa_storage_memory::register(&mut reg);
+    let config = all_memory_config();
+
+    reg.validate(&config).expect("all-memory config validates");
+    reg.build_policy_store(&config).expect("policy store builds");
+    reg.build_audit_sink(&config).expect("audit sink builds");
+    reg.build_session_store(&config).expect("session store builds");
+    reg.build_credential_store(&config).expect("credential store builds");
+    reg.build_rate_limit_counter(&config)
+        .expect("rate limit counter builds");
+    reg.build_lifecycle_store(&config).expect("lifecycle store builds");
+}


### PR DESCRIPTION
## Description

Implements **AAASM-2464** — the registry/boot wiring that completes the two deferred ACs of Story **AAASM-2363** (in-memory driver): **AC2** (register the driver as `"memory"`) and **AC5** (all-memory `agent-assembly.toml` boots end-to-end and serves a policy lookup). Now unblocked since **#876** (the `aa_storage::Registry`/`StorageConfig` loader) merged to `master`.

Delivers:

1. **Memory driver factories + `register()` (AC2)** — `aa-storage-memory` gains six `Memory*`-building factory structs (impl `aa_storage::factory::*`) and `register(&mut Registry)` + `DRIVER_NAME = "memory"`. Boot code calls it *after* `register_builtin_drivers` to replace the `"memory"` `NotImplemented` placeholder with the real backends (last-write-wins). Adds `toml` (same 0.9 pin as `aa-storage`) for the factory signatures.
2. **`aasm config boot <file>` command (AC5)** — loads `agent-assembly.toml`, registers built-in + the real memory driver, validates, builds all six `[storage]` backends, and serves a sample policy lookup. Sibling to `aasm config validate`.
3. **Tests + fixture** — registry register/build integration test in `aa-storage-memory`; an all-memory fixture + boot end-to-end tests in `aa-cli`.

### Real run (the all-memory boot, end-to-end)

```
$ aasm config boot aa-cli/tests/fixtures/storage_all_memory.toml
Booted storage from aa-cli/tests/fixtures/storage_all_memory.toml
  policy_store       = memory
  audit_sink         = memory
  session_store      = memory
  credential_store   = memory
  rate_limit_counter = memory
  lifecycle_store    = memory
  policy lookup for agent 00000000000000000000000000000000: no policy on record (empty store)
$ echo $?
0
```

The lookup returns `NotFound` because a fresh memory `PolicyStore` is empty (policies are seeded by the gateway, not config) — that is the store correctly *serving* the lookup; the full config → registry → build → query path works.

### Design notes

- The real driver registration lives in the **boot layer** (`aa-cli`, which depends on both `aa-storage` and `aa-storage-memory`) because `aa-storage` cannot depend on the driver crates. `builtin.rs` keeps the `"memory"` placeholder for crates that don't pull in the driver.
- Scope is the in-memory path only; Postgres/Redis/SQLite drivers are separate Epic stories and still resolve to their `NotImplemented` placeholders.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No — additive (new factories/command; `aa-cli` gains an `aa-storage-memory` dep).

## Related Issues

- Related Jira ticket: AAASM-2464 (completes deferred ACs of Story AAASM-2363, Epic AAASM-2348).

## Testing

- [x] Unit/integration tests added — `aa-storage-memory` register/build test; `aa-cli` boot end-to-end + missing-file tests.
- [x] Manual testing performed — `aasm config boot` on the all-memory fixture (output above, exit 0); `cargo nextest -p aa-storage-memory -p aa-cli` → **594 passed**; `cargo clippy --all-targets --all-features -D warnings` clean; `cargo deny check` clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing (pending CI run)
- [x] Commits are small and follow the Gitmoji convention
