### PR TITLE
[AAASM-2502] 🐛 (aa-cli): Fix flaky unit tests under parallel cargo test (env + port races)

### DIFF
--- a/aa-cli/src/commands/dashboard/pid.rs
+++ b/aa-cli/src/commands/dashboard/pid.rs
@@ -57,33 +57,29 @@ pub fn remove_pid() -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    /// Serialise tests that mutate the process-global `AA_DATA_DIR` env var
-    /// so parallel nextest threads can't race on it.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    use std::sync::MutexGuard;
 
     /// Guard that restores `AA_DATA_DIR` to its prior value on drop so tests
     /// running in the same process don't leak the env var into each other.
-    struct EnvGuard<'a> {
-        _lock: std::sync::MutexGuard<'a, ()>,
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
         prior: Option<String>,
     }
-    impl<'a> EnvGuard<'a> {
+    impl EnvGuard {
         fn set(value: &str) -> Self {
-            let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let lock = crate::test_support::env_guard();
             let prior = std::env::var("AA_DATA_DIR").ok();
             std::env::set_var("AA_DATA_DIR", value);
             Self { _lock: lock, prior }
         }
         fn unset() -> Self {
-            let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let lock = crate::test_support::env_guard();
             let prior = std::env::var("AA_DATA_DIR").ok();
             std::env::remove_var("AA_DATA_DIR");
             Self { _lock: lock, prior }
         }
     }
-    impl<'a> Drop for EnvGuard<'a> {
+    impl Drop for EnvGuard {
         fn drop(&mut self) {
             match self.prior.take() {
                 Some(v) => std::env::set_var("AA_DATA_DIR", v),

--- a/aa-cli/src/commands/gateway/pid.rs
+++ b/aa-cli/src/commands/gateway/pid.rs
@@ -72,29 +72,27 @@ pub fn is_process_alive(pid: u32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use std::sync::MutexGuard;
 
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    struct EnvGuard<'a> {
-        _lock: std::sync::MutexGuard<'a, ()>,
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
         prior: Option<String>,
     }
-    impl<'a> EnvGuard<'a> {
+    impl EnvGuard {
         fn set(value: &str) -> Self {
-            let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let lock = crate::test_support::env_guard();
             let prior = std::env::var("AA_DATA_DIR").ok();
             std::env::set_var("AA_DATA_DIR", value);
             Self { _lock: lock, prior }
         }
         fn unset() -> Self {
-            let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let lock = crate::test_support::env_guard();
             let prior = std::env::var("AA_DATA_DIR").ok();
             std::env::remove_var("AA_DATA_DIR");
             Self { _lock: lock, prior }
         }
     }
-    impl Drop for EnvGuard<'_> {
+    impl Drop for EnvGuard {
         fn drop(&mut self) {
             match self.prior.take() {
                 Some(v) => std::env::set_var("AA_DATA_DIR", v),

--- a/aa-cli/src/commands/gateway/start.rs
+++ b/aa-cli/src/commands/gateway/start.rs
@@ -253,25 +253,21 @@ pub fn wait_for_tcp(addr: &str, timeout: Duration) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use std::sync::MutexGuard;
 
-    // Serialises tests that mutate AA_POLICY to prevent race conditions when
-    // the test runner executes tests in the same binary in parallel.
-    static AA_POLICY_LOCK: Mutex<()> = Mutex::new(());
-
-    struct PolicyEnvGuard<'a> {
-        _lock: std::sync::MutexGuard<'a, ()>,
+    struct PolicyEnvGuard {
+        _lock: MutexGuard<'static, ()>,
         prior: Option<String>,
     }
-    impl<'a> PolicyEnvGuard<'a> {
+    impl PolicyEnvGuard {
         fn set(value: &str) -> Self {
-            let lock = AA_POLICY_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let lock = crate::test_support::env_guard();
             let prior = std::env::var("AA_POLICY").ok();
             std::env::set_var("AA_POLICY", value);
             Self { _lock: lock, prior }
         }
     }
-    impl Drop for PolicyEnvGuard<'_> {
+    impl Drop for PolicyEnvGuard {
         fn drop(&mut self) {
             match self.prior.take() {
                 Some(v) => std::env::set_var("AA_POLICY", v),
@@ -338,6 +334,7 @@ mod tests {
     #[test]
     fn wait_for_tcp_returns_true_when_port_is_open() {
         use std::net::TcpListener;
+        let _net = crate::test_support::net_guard();
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         let addr = format!("127.0.0.1:{port}");

--- a/aa-cli/src/commands/gateway/stop.rs
+++ b/aa-cli/src/commands/gateway/stop.rs
@@ -69,23 +69,21 @@ pub fn dispatch() -> ExitCode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use std::sync::MutexGuard;
 
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    struct EnvGuard<'a> {
-        _lock: std::sync::MutexGuard<'a, ()>,
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
         prior: Option<String>,
     }
-    impl<'a> EnvGuard<'a> {
+    impl EnvGuard {
         fn set(value: &str) -> Self {
-            let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let lock = crate::test_support::env_guard();
             let prior = std::env::var("AA_DATA_DIR").ok();
             std::env::set_var("AA_DATA_DIR", value);
             Self { _lock: lock, prior }
         }
     }
-    impl Drop for EnvGuard<'_> {
+    impl Drop for EnvGuard {
         fn drop(&mut self) {
             match self.prior.take() {
                 Some(v) => std::env::set_var("AA_DATA_DIR", v),

--- a/aa-cli/src/commands/gw_probe.rs
+++ b/aa-cli/src/commands/gw_probe.rs
@@ -62,6 +62,7 @@ mod tests {
 
     #[test]
     fn probe_tcp_returns_true_against_open_listener() {
+        let _net = crate::test_support::net_guard();
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
         assert!(probe_tcp(addr, Duration::from_millis(200)));
@@ -69,18 +70,17 @@ mod tests {
 
     #[test]
     fn probe_tcp_returns_false_when_nothing_is_listening() {
-        // Grab an ephemeral port and immediately release it. The
-        // kernel won't instantly hand the same port to another
-        // process, so the addr is reliably "nothing listens here"
-        // for the brief moment we probe it.
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let addr = listener.local_addr().unwrap();
-        drop(listener);
+        // Port 1 (tcpmux) is privileged and never has a listener in CI/dev, so
+        // connecting is reliably refused. Unlike a freed ephemeral port, the OS
+        // never hands it to a concurrent `bind(:0)`, so this is immune to the
+        // port-reuse race (matches `gateway::start`'s closed-port test).
+        let addr: SocketAddr = "127.0.0.1:1".parse().unwrap();
         assert!(!probe_tcp(addr, Duration::from_millis(200)));
     }
 
     #[test]
     fn wait_for_ready_returns_ok_when_listener_is_already_up() {
+        let _net = crate::test_support::net_guard();
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
         // 500ms budget is far more than enough; we expect the first
@@ -91,9 +91,9 @@ mod tests {
 
     #[test]
     fn wait_for_ready_returns_timeout_when_nothing_listens() {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let addr = listener.local_addr().unwrap();
-        drop(listener);
+        // `127.0.0.1:1` is reliably closed and reuse-immune — see
+        // `probe_tcp_returns_false_when_nothing_is_listening`.
+        let addr: SocketAddr = "127.0.0.1:1".parse().unwrap();
 
         let budget = Duration::from_millis(200);
         let result = wait_for_ready(addr, budget, Duration::from_millis(50));
@@ -110,6 +110,7 @@ mod tests {
 
     #[test]
     fn wait_for_ready_returns_ok_when_listener_appears_mid_wait() {
+        let _net = crate::test_support::net_guard();
         // Reserve an ephemeral port, drop the listener so nothing is
         // listening when `wait_for_ready` begins polling.
         let probe = TcpListener::bind("127.0.0.1:0").unwrap();

--- a/aa-cli/src/commands/proxy/pid.rs
+++ b/aa-cli/src/commands/proxy/pid.rs
@@ -57,31 +57,27 @@ pub fn remove_pid() -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use std::sync::MutexGuard;
 
-    /// Serialise tests that mutate the process-global `AA_DATA_DIR` env var
-    /// so parallel nextest threads can't race on it.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    struct EnvGuard<'a> {
-        _lock: std::sync::MutexGuard<'a, ()>,
+    struct EnvGuard {
+        _lock: MutexGuard<'static, ()>,
         prior: Option<String>,
     }
-    impl<'a> EnvGuard<'a> {
+    impl EnvGuard {
         fn set(value: &str) -> Self {
-            let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let lock = crate::test_support::env_guard();
             let prior = std::env::var("AA_DATA_DIR").ok();
             std::env::set_var("AA_DATA_DIR", value);
             Self { _lock: lock, prior }
         }
         fn unset() -> Self {
-            let lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let lock = crate::test_support::env_guard();
             let prior = std::env::var("AA_DATA_DIR").ok();
             std::env::remove_var("AA_DATA_DIR");
             Self { _lock: lock, prior }
         }
     }
-    impl<'a> Drop for EnvGuard<'a> {
+    impl Drop for EnvGuard {
         fn drop(&mut self) {
             match self.prior.take() {
                 Some(v) => std::env::set_var("AA_DATA_DIR", v),

--- a/aa-cli/src/commands/start.rs
+++ b/aa-cli/src/commands/start.rs
@@ -289,6 +289,7 @@ mod tests {
 
     #[test]
     fn check_already_running_returns_some_when_pid_is_self_and_port_listens() {
+        let _net = crate::test_support::net_guard();
         let tmp = tempfile::TempDir::new().unwrap();
         let pid_file = tmp.path().join("gateway.pid");
         let self_pid = std::process::id();
@@ -322,6 +323,7 @@ mod tests {
 
     #[test]
     fn run_background_writes_pid_file_via_injected_spawner() {
+        let _net = crate::test_support::net_guard();
         // Open a listener so `wait_for_ready` succeeds; the test
         // process owns the socket and the mock spawner only needs
         // to hand back the PID we want pinned to disk.

--- a/aa-cli/src/config.rs
+++ b/aa-cli/src/config.rs
@@ -178,11 +178,7 @@ pub fn resolve_context(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
-
     use super::*;
-
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     fn sample_config() -> CliConfig {
         let mut contexts = BTreeMap::new();
@@ -297,7 +293,7 @@ mod tests {
 
     #[test]
     fn resolve_dashboard_port_env_overrides_all() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = crate::test_support::env_guard();
         std::env::set_var("AASM_DASHBOARD_PORT", "9999");
         let port = resolve_dashboard_port(&CliConfig::default(), Some(5000));
         std::env::remove_var("AASM_DASHBOARD_PORT");
@@ -306,14 +302,14 @@ mod tests {
 
     #[test]
     fn resolve_dashboard_port_flag_beats_config() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = crate::test_support::env_guard();
         std::env::remove_var("AASM_DASHBOARD_PORT");
         assert_eq!(resolve_dashboard_port(&CliConfig::default(), Some(4321)), 4321);
     }
 
     #[test]
     fn resolve_dashboard_port_uses_config_default() {
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = crate::test_support::env_guard();
         std::env::remove_var("AASM_DASHBOARD_PORT");
         assert_eq!(resolve_dashboard_port(&CliConfig::default(), None), 3000);
     }

--- a/aa-cli/src/lib.rs
+++ b/aa-cli/src/lib.rs
@@ -8,6 +8,9 @@ pub mod config;
 pub mod error;
 pub mod output;
 
+#[cfg(test)]
+mod test_support;
+
 /// Agent Assembly CLI — governance gateway management tool.
 #[derive(Parser)]
 #[command(name = "aasm", version, about)]

--- a/aa-cli/src/test_support.rs
+++ b/aa-cli/src/test_support.rs
@@ -1,0 +1,35 @@
+//! Shared synchronization for `aa-cli` unit tests.
+//!
+//! The `aa-cli` unit tests run inside one process under libtest's multi-threaded
+//! harness — and so does `cargo test`, which the SonarCloud coverage job uses
+//! (unlike `cargo nextest`, which isolates each test in its own process). Several
+//! tests mutate process-global state that is unsafe to touch concurrently:
+//!
+//! - **environment variables** — the process environment is a single global
+//!   table, so concurrent `set_var`/`remove_var` from different tests race; and
+//! - **ephemeral TCP ports** — a test that frees a `bind(:0)` port can have it
+//!   immediately handed to a concurrent `bind(:0)`, breaking "nothing is
+//!   listening here" assumptions.
+//!
+//! These crate-wide locks serialize that access across every test module.
+
+use std::sync::{Mutex, MutexGuard};
+
+/// Serializes all tests that mutate a process environment variable.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Serializes all tests that bind an ephemeral (`:0`) TCP port.
+static NET_LOCK: Mutex<()> = Mutex::new(());
+
+/// Acquire the shared environment lock for the duration of the returned guard.
+///
+/// Recovers from a poisoned mutex so a single panicking test does not cascade
+/// into every later test.
+pub(crate) fn env_guard() -> MutexGuard<'static, ()> {
+    ENV_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Acquire the shared ephemeral-port lock for the duration of the returned guard.
+pub(crate) fn net_guard() -> MutexGuard<'static, ()> {
+    NET_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
+}


### PR DESCRIPTION
## Description

Fixes flaky `aa-cli` unit tests that intermittently fail the **SonarCloud coverage** step (its `cargo test --workspace` runs all tests in one process under libtest's thread pool). The dedicated `Test` job is unaffected because `cargo nextest` isolates each test in its own process.

Reproduced locally by running the `aa-cli` lib test binary with `--test-threads=16`: **~10/25 runs failed** before this change; **0/110 runs** after (60× at 16 threads + 50× at 32 threads), and `cargo nextest run -p aa-cli` stays green (583 passed).

### Root cause

1. **`AA_DATA_DIR` env race.** `commands/gateway/pid.rs`, `commands/proxy/pid.rs`, `commands/dashboard/pid.rs`, and `commands/gateway/stop.rs` each declared their *own* module-local `ENV_LOCK` but all mutate the same **process-global** `AA_DATA_DIR`. Independent locks don't serialize across modules, so `gateway::pid::write_and_read_pid_roundtrip` could read a path another module just changed → `read_pid()` returns `None`. (`config.rs`/`gateway/start.rs` mutate other env vars with the same global-environ hazard.)
2. **Ephemeral port reuse.** `gw_probe`, `start`, and `gateway/start` tests bind `127.0.0.1:0`, drop the listener, then assume the freed port stays free — but a concurrent `bind(:0)` can be handed that exact port, so the "nothing is listening" probes saw an unexpected listener.

### Fix

- New `#[cfg(test)] aa-cli/src/test_support.rs` exposing two crate-wide locks: `env_guard()` (serializes **all** env-var mutation) and `net_guard()` (serializes **all** ephemeral-port tests). Replaces the four per-module env locks with the single shared one.
- The two `gw_probe` "nothing listens" tests now probe `127.0.0.1:1` — a privileged port that is reliably closed and never handed out by `bind(:0)`, so they're deterministic and need no lock (matches the existing `gateway::start` closed-port idiom).

No production code changed — test-only. Net −13 lines.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2502
- Surfaced while rebasing AAASM-2374 (`aa-storage-sqlite-buffer`, PR #878) onto master; these tests are pre-existing master code (AAASM-1717), unrelated to that feature. Filed separately to keep the storage PRs single-concern.

## Testing

- [x] Existing tests updated (isolation only — assertions unchanged)

```
# before: ~10/25 fail   after: 0/110 fail
for i in $(seq 1 60); do <aa_cli test bin> --test-threads=16; done
for i in $(seq 1 50); do <aa_cli test bin> --test-threads=32; done
cargo nextest run -p aa-cli      # 583 passed
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
