### PR TITLE
[AAASM-2540] ✨ (aa-storage-redis): Wire redis factories into the storage Registry + boot path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,7 @@ dependencies = [
  "aa-sandbox",
  "aa-storage",
  "aa-storage-memory",
+ "aa-storage-redis",
  "anyhow",
  "assert_cmd",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,6 +510,7 @@ version = "0.0.1-alpha.5"
 dependencies = [
  "aa-core",
  "aa-storage",
+ "aa-storage-memory",
  "async-trait",
  "deadpool-redis",
  "redis",
@@ -517,7 +518,7 @@ dependencies = [
  "serde_json",
  "testcontainers-modules",
  "tokio",
- "toml 0.8.23",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]

--- a/aa-cli/Cargo.toml
+++ b/aa-cli/Cargo.toml
@@ -28,6 +28,7 @@ aa-proxy             = { path = "../aa-proxy", version = "0.0.1-alpha.5" }
 aa-sandbox           = { path = "../aa-sandbox", version = "0.0.1-alpha.5" }
 aa-storage           = { path = "../aa-storage", version = "0.0.1-alpha.5" }
 aa-storage-memory    = { path = "../aa-storage-memory", version = "0.0.1-alpha.5" }
+aa-storage-redis     = { path = "../aa-storage-redis", version = "0.0.1-alpha.5" }
 anyhow         = "1"
 async-trait    = "0.1"
 axum           = "0.8"

--- a/aa-cli/src/commands/config/boot.rs
+++ b/aa-cli/src/commands/config/boot.rs
@@ -50,11 +50,14 @@ pub fn run(args: BootArgs) -> ExitCode {
         return ExitCode::FAILURE;
     };
 
-    // Built-in driver names, then the real in-memory driver — `register_*` is
-    // last-write-wins, so this replaces the "memory" placeholder.
+    // Built-in driver names, then the real OSS drivers — `register_*` is
+    // last-write-wins, so these replace the matching placeholders. The Redis
+    // driver only registers the L2 kinds it backs (policy / session /
+    // rate-limit); the durable kinds stay on the placeholder.
     let mut registry = Registry::new();
     aa_storage::builtin::register_builtin_drivers(&mut registry);
     aa_storage_memory::register(&mut registry);
+    aa_storage_redis::register(&mut registry);
 
     if let Err(e) = registry.validate(&storage) {
         eprintln!("error: {e}");

--- a/aa-storage-redis/Cargo.toml
+++ b/aa-storage-redis/Cargo.toml
@@ -23,12 +23,17 @@ redis = { version = "1.2", default-features = false, features = ["aio", "tokio-c
 deadpool-redis = { version = "0.23", features = ["rt_tokio_1"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# `toml` (same 0.9 pin as `aa-storage`) backs the driver-factory signatures,
+# which take the `[storage.redis]` subsection as a `toml::Value`.
+toml = "0.9"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 # Redis container for the trait-conformance suite. Re-exports `testcontainers`.
 testcontainers-modules = { version = "0.15", features = ["redis"] }
-toml = "0.8"
+# Second driver for the mixed-config registry-integration test (redis backs the
+# L2 kinds; memory backs the durable kinds).
+aa-storage-memory = { path = "../aa-storage-memory" }
 
 [lints]
 workspace = true

--- a/aa-storage-redis/src/factory.rs
+++ b/aa-storage-redis/src/factory.rs
@@ -1,0 +1,87 @@
+//! Factories that build the Redis-backed stores for the `aa-storage` driver
+//! registry.
+//!
+//! Redis backs the three high-frequency L2-cache kinds — policy, session, and
+//! rate-limit. Audit / credential / lifecycle are durable concerns the Redis
+//! driver does not implement, so [`crate::register`] registers only these three;
+//! the other kinds stay on the builtin placeholder.
+
+use std::sync::Arc;
+
+use aa_storage::factory::{PolicyStoreFactory, RateLimitCounterFactory, SessionStoreFactory};
+use aa_storage::{PolicyStore, RateLimitCounter, Result, SessionStore, StorageError};
+
+use crate::config::RedisStorageConfig;
+use crate::RedisBackend;
+
+/// Parse a `[storage.redis]` subsection into a [`RedisStorageConfig`].
+fn parse_config(config: &toml::Value) -> Result<RedisStorageConfig> {
+    config
+        .clone()
+        .try_into()
+        .map_err(|e: toml::de::Error| StorageError::Backend(format!("invalid [storage.redis] config: {e}")))
+}
+
+/// Builds a [`RedisPolicyStore`](crate::RedisPolicyStore) from `[storage.redis]`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RedisPolicyStoreFactory;
+
+impl PolicyStoreFactory for RedisPolicyStoreFactory {
+    fn build(&self, config: &toml::Value) -> Result<Arc<dyn PolicyStore>> {
+        let backend = RedisBackend::connect(&parse_config(config)?)?;
+        Ok(Arc::new(backend.policies()))
+    }
+}
+
+/// Builds a [`RedisSessionStore`](crate::RedisSessionStore) from `[storage.redis]`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RedisSessionStoreFactory;
+
+impl SessionStoreFactory for RedisSessionStoreFactory {
+    fn build(&self, config: &toml::Value) -> Result<Arc<dyn SessionStore>> {
+        let backend = RedisBackend::connect(&parse_config(config)?)?;
+        Ok(Arc::new(backend.sessions()))
+    }
+}
+
+/// Builds a [`RedisRateLimitCounter`](crate::RedisRateLimitCounter) from `[storage.redis]`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RedisRateLimitCounterFactory;
+
+impl RateLimitCounterFactory for RedisRateLimitCounterFactory {
+    fn build(&self, config: &toml::Value) -> Result<Arc<dyn RateLimitCounter>> {
+        let backend = RedisBackend::connect(&parse_config(config)?)?;
+        Ok(Arc::new(backend.rate_limiter()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn redis_section() -> toml::Value {
+        toml::from_str(
+            r#"
+url = "redis://127.0.0.1:6379"
+pool_size = 4
+tls = false
+"#,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn policy_factory_builds_from_config() {
+        assert!(RedisPolicyStoreFactory.build(&redis_section()).is_ok());
+    }
+
+    #[test]
+    fn session_factory_builds_from_config() {
+        assert!(RedisSessionStoreFactory.build(&redis_section()).is_ok());
+    }
+
+    #[test]
+    fn rate_limit_factory_builds_from_config() {
+        assert!(RedisRateLimitCounterFactory.build(&redis_section()).is_ok());
+    }
+}

--- a/aa-storage-redis/src/lib.rs
+++ b/aa-storage-redis/src/lib.rs
@@ -52,6 +52,7 @@ pub mod factory;
 mod policy;
 mod pool;
 mod rate_limit;
+mod registration;
 mod session;
 mod util;
 
@@ -60,6 +61,7 @@ pub use config::RedisStorageConfig;
 pub use policy::{RedisPolicyStore, DEFAULT_POLICY_CACHE_TTL_SECS};
 pub use pool::build_pool;
 pub use rate_limit::RedisRateLimitCounter;
+pub use registration::register;
 pub use session::{RedisSessionStore, SESSION_TTL_SECS};
 
 /// Pooled Redis connection handle, re-exported for callers that build stores

--- a/aa-storage-redis/src/lib.rs
+++ b/aa-storage-redis/src/lib.rs
@@ -48,6 +48,7 @@
 mod backend;
 mod config;
 mod error;
+pub mod factory;
 mod policy;
 mod pool;
 mod rate_limit;

--- a/aa-storage-redis/src/registration.rs
+++ b/aa-storage-redis/src/registration.rs
@@ -1,0 +1,24 @@
+//! Driver registration: announce the Redis-backed stores to an
+//! [`aa_storage::Registry`].
+
+use aa_storage::Registry;
+
+use crate::factory::{RedisPolicyStoreFactory, RedisRateLimitCounterFactory, RedisSessionStoreFactory};
+use crate::DRIVER_NAME;
+
+/// Register the Redis factories for the kinds redis backs — policy, session, and
+/// rate-limit — into `reg` under [`DRIVER_NAME`] (`"redis"`).
+///
+/// Call this from boot code *after*
+/// [`aa_storage::builtin::register_builtin_drivers`] to replace the `"redis"`
+/// placeholder for those three kinds (registration is last-write-wins).
+///
+/// Audit, credential, and lifecycle are intentionally left on the placeholder —
+/// Redis is an L2 shared cache and does not back those durable kinds, so a
+/// config that selects `redis` for them fails the boot with a clear error
+/// instead of silently using a cache as a system of record.
+pub fn register(reg: &mut Registry) {
+    reg.register_policy_store(DRIVER_NAME, Box::new(RedisPolicyStoreFactory));
+    reg.register_session_store(DRIVER_NAME, Box::new(RedisSessionStoreFactory));
+    reg.register_rate_limit_counter(DRIVER_NAME, Box::new(RedisRateLimitCounterFactory));
+}

--- a/aa-storage-redis/tests/registry_integration.rs
+++ b/aa-storage-redis/tests/registry_integration.rs
@@ -1,0 +1,55 @@
+//! Proves the Redis driver registers into `aa_storage::Registry` for the three
+//! kinds it backs, and that a mixed `[storage]` config (redis for the L2 kinds,
+//! memory for the durable kinds) validates and builds every backend.
+//!
+//! No live Redis is needed: the Redis factories build over a lazily-connected
+//! pool, so `build_*` succeeds without contacting a server. The live end-to-end
+//! boot is the verification subtask (AAASM-2541).
+
+use aa_storage::{Registry, StorageConfig};
+
+const MIXED: &str = r#"
+policy_store       = "redis"
+audit_sink         = "memory"
+session_store      = "redis"
+credential_store   = "memory"
+rate_limit_counter = "redis"
+lifecycle_store    = "memory"
+
+[redis]
+url = "redis://127.0.0.1:6379"
+pool_size = 4
+
+[memory]
+"#;
+
+fn build_registry() -> Registry {
+    let mut reg = Registry::new();
+    aa_storage::builtin::register_builtin_drivers(&mut reg);
+    aa_storage_memory::register(&mut reg);
+    aa_storage_redis::register(&mut reg);
+    reg
+}
+
+#[test]
+fn redis_registers_for_the_kinds_it_backs() {
+    let reg = build_registry();
+    assert!(reg.policy_store_names().contains(&"redis"));
+    assert!(reg.session_store_names().contains(&"redis"));
+    assert!(reg.rate_limit_counter_names().contains(&"redis"));
+}
+
+#[test]
+fn mixed_redis_memory_config_validates_and_builds_every_backend() {
+    let reg = build_registry();
+    let config: StorageConfig = toml::from_str(MIXED).expect("fixture parses");
+
+    reg.validate(&config).expect("mixed config validates");
+    reg.build_policy_store(&config).expect("policy (redis) builds");
+    reg.build_audit_sink(&config).expect("audit (memory) builds");
+    reg.build_session_store(&config).expect("session (redis) builds");
+    reg.build_credential_store(&config).expect("credential (memory) builds");
+    reg.build_rate_limit_counter(&config)
+        .expect("rate limit (redis) builds");
+    reg.build_lifecycle_store(&config).expect("lifecycle (memory) builds");
+}


### PR DESCRIPTION
## Description

Wires the **`aa-storage-redis`** driver into the storage `Registry` and the `aasm config boot` path, so an OSS operator can select `redis` for the L2 cache kinds in `agent-assembly.toml` and have it resolve to a real `RedisBackend` instead of the `NotImplemented` placeholder. Mirrors the memory driver's wiring (AAASM-2464).

- **`aa-storage-redis/src/factory.rs`** — `RedisPolicyStoreFactory` / `RedisSessionStoreFactory` / `RedisRateLimitCounterFactory` implement the `aa_storage::factory` traits for the three kinds Redis backs. Each parses the `[storage.redis]` `toml::Value` into `RedisStorageConfig` and builds the store over a lazily-connected `RedisBackend`.
- **`aa-storage-redis/src/registration.rs`** — `register(&mut Registry)` registers those three factories under `DRIVER_NAME` (`"redis"`), overriding the builtin placeholder. **Audit / credential / lifecycle are intentionally left on the placeholder** — Redis is an L2 shared cache and does not back those durable kinds, so a config selecting `redis` for them fails the boot with a clear error.
- **`aa-cli`** — adds the `aa-storage-redis` dependency and calls `aa_storage_redis::register(&mut registry)` in `commands/config/boot.rs`.
- **`toml`** becomes a normal `0.9` dependency (the factory trait signature takes `&toml::Value`, which must match `aa-storage`'s `toml`).

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

Additive registry wiring; no existing public API changes. The `aasm config boot` all-memory path is unchanged.

## Related Issues

- Related Jira ticket: AAASM-2540 (impl subtask of Story AAASM-2539, Epic AAASM-2348)

## Testing

- [x] Unit tests added / updated — per-factory build-from-`toml::Value` tests.
- [x] Integration tests added / updated — `tests/registry_integration.rs`: registers builtin + memory + redis, then validates and builds every backend of a **mixed** config (redis for policy/session/rate-limit, memory for audit/credential/lifecycle). Lazy pools → no live Redis needed.
- [x] Manual testing — `cargo nextest run -p aa-storage-redis` (13 passed, incl. the existing testcontainers conformance suite) and `-p aa-cli` config/boot tests (incl. `all_memory_config_boots_successfully`); clippy `--all-targets --all-features -D warnings`, fmt, `cargo deny`, doc all clean.
- [ ] No tests required

## Notes for reviewers

- The live end-to-end boot against a real Redis (mixed config, real op through the registry-resolved driver) is the **verification subtask AAASM-2541** (stacked PR).
- Redis backs only 3 of the 6 storage kinds by design, so a working redis deployment is a mixed config (redis L2 + a durable backend for audit/credential/lifecycle). This matches the architecture (redis = L2 cache, postgres = L3 primary).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on factories + `register`)
- [ ] All CI checks passing (pending CI)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
