### PR TITLE
[AAASM-2543] 🔧 (ci): Free disk space before Coverage llvm-cov build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,11 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
+      - name: Free disk space (reclaim runner space for llvm-cov build)
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/share/boost /opt/hostedtoolcache/CodeQL || true
+          sudo docker image prune --all --force || true
+          df -h /
       - uses: actions/checkout@v6
       - name: Checkout sibling node-sdk (for e2e_sdk_node fixtures)
         uses: actions/checkout@v6


### PR DESCRIPTION
## Description

**Rescoped after the SonarCloud CI redesign** (rebased onto current master).

Originally this PR added a free-disk step to *both* `sonar.yml` and `ci.yml` to stop the `cargo llvm-cov --workspace` builds exhausting the runner (`No space left on device`). The redesign **superseded the SonarCloud half**: `sonar.yml` was removed and SonarCloud now **reuses the Coverage job's LCOV via artifact** instead of running its own heavy build — so there's no second instrumented build to free disk for. That commit is dropped.

What remains and is still relevant: the **Coverage** job is now the **single** full-workspace `cargo llvm-cov nextest` build (and it also drives the dashboard `pnpm build` + node-sdk native binding that feed it), so it still carries the disk-exhaustion risk (seen on #873). This PR adds a "Free disk space" first step to that job — pruning `dotnet`/`android`/`ghc`/`boost`/`CodeQL` + docker images (~30 GB) before the build.

Single file now: `.github/workflows/ci.yml` (Coverage job only).

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2543

## Testing

- [x] No tests required (explain why)

CI-only change; validated `ci.yml` parses as YAML and the new step is the first step of the `coverage` job. The job's own green run on this PR is the verification.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
