### PR TITLE
[AAASM-2395] ✨ (aa-storage-postgres): Consolidate MVP schema + gateway migration drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,6 +432,25 @@ jobs:
           TIMESCALEDB_AVAILABLE: "1"
         run: cargo nextest run -p aa-gateway timescale
 
+  migration-drift-check:
+    needs: [changes]
+    if: needs.changes.outputs.rust == 'true'
+    name: Migration drift check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install protobuf compiler
+        run: sudo apt-get install -y protobuf-compiler
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@83c419a40a2e48673b2c523337e57f602dfe53c9 # cargo-nextest
+      - name: Run gateway migration drift test
+        # Boots a throwaway Postgres (testcontainers) and applies the
+        # aa-storage-postgres MIGRATOR through the gateway. Fails if the
+        # canonical MVP migrations no longer apply cleanly or audit_logs drifts.
+        run: cargo nextest run -p aa-gateway -E 'binary(migration_boot)'
+
   deny:
     needs: [changes]
     if: needs.changes.outputs.rust == 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,7 @@ dependencies = [
  "aa-core",
  "aa-proto",
  "aa-runtime",
+ "aa-storage-postgres",
  "ahash 0.8.12",
  "arc-swap",
  "async-stream",

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -53,6 +53,10 @@ x509-parser  = "0.18"
 redis        = { version = "1.2", default-features = false, features = ["tokio-comp", "connection-manager"], optional = true }
 
 [dev-dependencies]
+# Path-only (the driver is publish=false). The migration-drift test runs the
+# driver's own embedded MIGRATOR so the gateway can never drift from the
+# canonical MVP schema (AAASM-2389).
+aa-storage-postgres = { path = "../aa-storage-postgres" }
 criterion    = { version = "0.8", features = ["async_tokio"] }
 proptest     = "1"
 tempfile     = "3"

--- a/aa-gateway/tests/migration_boot.rs
+++ b/aa-gateway/tests/migration_boot.rs
@@ -1,0 +1,92 @@
+//! Migration drift gate (AAASM-2389).
+//!
+//! The async Gateway consumer and the OSS Postgres driver must agree on the MVP
+//! schema. Rather than copy migration files, the gateway boots the **driver's**
+//! embedded [`aa_storage_postgres::MIGRATOR`] against a fresh Postgres 18 and
+//! asserts the canonical four-table shape. If a migration file changes such that
+//! it no longer applies cleanly — or the `audit_logs` contract drifts — this
+//! test (and the `migration-drift-check` CI job that runs it) fails.
+//!
+//! Requires Docker: each run spins its own throwaway Postgres container.
+
+use aa_storage_postgres::{PostgresPool, PostgresPoolConfig};
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use testcontainers_modules::testcontainers::ImageExt;
+
+/// Boot a fresh Postgres 18 and apply the driver's embedded migrations through
+/// the same `PostgresPool::migrate` path a gateway uses at startup.
+#[tokio::test]
+async fn gateway_boots_driver_migrations_on_fresh_postgres() {
+    let container = Postgres::default()
+        .with_db_name("aasm")
+        .with_user("aasm")
+        .with_password("secret")
+        .with_tag("18-alpine")
+        .start()
+        .await
+        .expect("start postgres testcontainer (is Docker running?)");
+
+    let host = container.get_host().await.expect("container host");
+    let port = container.get_host_port_ipv4(5432).await.expect("container port");
+    let url = format!("postgres://aasm:secret@{host}:{port}/aasm");
+
+    let pool = PostgresPool::connect(&PostgresPoolConfig {
+        url,
+        max_connections: 5,
+        statement_timeout_ms: 0,
+    })
+    .await
+    .expect("connect pool");
+
+    // The drift gate: applying the driver's MIGRATOR must succeed.
+    pool.migrate().await.expect("driver migrations apply cleanly");
+
+    // The canonical MVP four tables (+ credentials) all exist.
+    for table in ["orgs", "agents", "policies", "audit_logs", "credentials"] {
+        let exists: bool =
+            sqlx::query_scalar("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = $1)")
+                .bind(table)
+                .fetch_one(pool.pool())
+                .await
+                .expect("query table existence");
+        assert!(exists, "table {table} must exist after the driver migrations");
+    }
+
+    // audit_logs.event_id is the idempotency key: present and NOT NULL.
+    let event_id_nullable: Option<String> = sqlx::query_scalar(
+        "SELECT is_nullable FROM information_schema.columns \
+         WHERE table_name = 'audit_logs' AND column_name = 'event_id'",
+    )
+    .fetch_optional(pool.pool())
+    .await
+    .expect("query audit_logs.event_id");
+    assert_eq!(
+        event_id_nullable.as_deref(),
+        Some("NO"),
+        "audit_logs.event_id must exist and be NOT NULL"
+    );
+
+    // Metadata-only: no payload/body/prompt/completion column ever lands.
+    let columns: Vec<String> =
+        sqlx::query_scalar("SELECT column_name FROM information_schema.columns WHERE table_name = 'audit_logs'")
+            .fetch_all(pool.pool())
+            .await
+            .expect("query audit_logs columns");
+    for forbidden in ["payload", "body", "prompt", "completion"] {
+        assert!(
+            !columns.iter().any(|c| c == forbidden),
+            "audit_logs must not contain a {forbidden} column"
+        );
+    }
+
+    // The dashboard query index survives migration.
+    let has_index: bool = sqlx::query_scalar(
+        "SELECT EXISTS (SELECT 1 FROM pg_indexes \
+         WHERE tablename = 'audit_logs' AND indexname = 'idx_audit_logs_agent_ts')",
+    )
+    .fetch_one(pool.pool())
+    .await
+    .expect("query audit_logs indexes");
+    assert!(has_index, "idx_audit_logs_agent_ts must exist after migrations");
+}

--- a/aa-storage-postgres/README.md
+++ b/aa-storage-postgres/README.md
@@ -1,0 +1,48 @@
+# aa-storage-postgres
+
+PostgreSQL storage driver (L3 primary) for the Agent Assembly persistence layer.
+Implements the `aa-storage` traits (`LifecycleStore`, `PolicyStore`, `AuditSink`,
+`CredentialStore`) over a `sqlx` connection pool.
+
+## Canonical migration set
+
+`migrations/` in this crate is the **single source of truth** for the Phase 1 MVP
+four-table schema:
+
+| File | Table | Notes |
+|---|---|---|
+| `0001_orgs.sql` | `orgs` | Top-level tenant boundary |
+| `0002_agents.sql` | `agents` | Liveness bookkeeping (`id` = canonical `AgentId` text) |
+| `0003_policies.sql` | `policies` | Versioned effective policy documents |
+| `0004_audit_logs.sql` | `audit_logs` | Metadata-only; `event_id UUID PRIMARY KEY` is the idempotency key |
+| `0005_credentials.sql` | `credentials` | Opaque ciphertext at rest |
+
+`audit_logs` is deliberately **metadata-only** (spec line 7551): it has no
+`payload`/`body`/`prompt`/`completion` column. The `event_id` UUID is `UNIQUE NOT
+NULL`, so a retried publish collapses to one row
+(`INSERT … ON CONFLICT (event_id) DO NOTHING`).
+
+The migrations are embedded at compile time and exposed as
+[`aa_storage_postgres::MIGRATOR`](src/pool.rs); call
+[`PostgresPool::migrate`](src/pool.rs) once on startup to apply them.
+
+## For the Gateway team
+
+**Do not copy these files.** `aa-gateway` must run the **same** migration set,
+not a duplicate, so the async consumer and the OSS driver never drift. Depend on
+this crate and run its embedded migrator:
+
+```rust
+// In aa-gateway, against a fresh Postgres:
+aa_storage_postgres::MIGRATOR.run(&pool).await?;
+// or, via the pool wrapper that calls the same MIGRATOR:
+aa_storage_postgres::PostgresPool::connect(&cfg).await?.migrate().await?;
+```
+
+`aa-gateway/tests/migration_boot.rs` exercises exactly this against a fresh
+Postgres 18, and the `migration-drift-check` CI job runs it on every change to
+`aa-storage-*` or the gateway — a failed migration apply fails the build.
+
+> `aa-gateway/migrations/postgres/` is a **separate** schema
+> (`audit_events` + TimescaleDB hypertables, Epic F) and is unrelated to this
+> canonical MVP set.

--- a/aa-storage-postgres/migrations/0004_audit_logs.sql
+++ b/aa-storage-postgres/migrations/0004_audit_logs.sql
@@ -4,8 +4,13 @@
 -- request body — only the metadata needed to answer "who did what, and what did
 -- governance decide". There is deliberately no foreign key on `agent_id`: the
 -- append-only sink must never fail because an agent row is absent or expired.
+--
+-- `event_id` is the idempotency key: a UUID derived from the event's content
+-- hash. PRIMARY KEY makes it UNIQUE NOT NULL, so a retried publish collapses to
+-- a single row (`INSERT … ON CONFLICT (event_id) DO NOTHING`) and the async
+-- Gateway consumer never double-inserts.
 CREATE TABLE audit_logs (
-    id         UUID PRIMARY KEY,
+    event_id   UUID PRIMARY KEY,
     agent_id   TEXT NOT NULL,
     tool_name  TEXT NOT NULL,
     decision   TEXT NOT NULL,

--- a/aa-storage-postgres/src/audit_sink.rs
+++ b/aa-storage-postgres/src/audit_sink.rs
@@ -56,22 +56,23 @@ fn decision_label(event_type: AuditEventType) -> &'static str {
 #[async_trait]
 impl AuditSink for PgAuditSink {
     async fn emit(&self, event: AuditEntry) -> Result<()> {
-        // Derive a stable row id from the entry hash so re-emitting the same
-        // entry is idempotent rather than duplicating.
-        let mut id_bytes = [0u8; 16];
-        id_bytes.copy_from_slice(&event.entry_hash()[..16]);
-        let id = uuid::Uuid::from_bytes(id_bytes);
+        // Derive a stable event_id from the entry hash so re-emitting the same
+        // entry is idempotent rather than duplicating: the UNIQUE event_id key
+        // makes `ON CONFLICT` collapse a retried publish to a single row.
+        let mut event_id_bytes = [0u8; 16];
+        event_id_bytes.copy_from_slice(&event.entry_hash()[..16]);
+        let event_id = uuid::Uuid::from_bytes(event_id_bytes);
 
         let ns = event.timestamp_ns();
         let ts = chrono::DateTime::from_timestamp((ns / 1_000_000_000) as i64, (ns % 1_000_000_000) as u32)
             .unwrap_or_default();
 
         sqlx::query(
-            "INSERT INTO audit_logs (id, agent_id, tool_name, decision, latency_ms, ts) \
+            "INSERT INTO audit_logs (event_id, agent_id, tool_name, decision, latency_ms, ts) \
              VALUES ($1, $2, $3, $4, $5, $6) \
-             ON CONFLICT (id) DO NOTHING",
+             ON CONFLICT (event_id) DO NOTHING",
         )
-        .bind(id)
+        .bind(event_id)
         .bind(agent_id_to_text(&event.agent_id()))
         .bind(event.event_type().as_str())
         .bind(decision_label(event.event_type()))

--- a/aa-storage-postgres/tests/conformance_pg.rs
+++ b/aa-storage-postgres/tests/conformance_pg.rs
@@ -57,18 +57,29 @@ async fn migrations_apply_cleanly_and_audit_logs_is_metadata_only() {
         assert!(exists, "table {table} should exist after migrations");
     }
 
-    // audit_logs must carry no payload/prompt/body column (spec line 7551).
+    // audit_logs must carry no payload/body/prompt/completion column (spec line 7551).
     let columns: Vec<String> =
         sqlx::query_scalar("SELECT column_name FROM information_schema.columns WHERE table_name = 'audit_logs'")
             .fetch_all(pool.pool())
             .await
             .expect("query audit_logs columns");
-    for forbidden in ["payload", "prompt", "body"] {
+    for forbidden in ["payload", "body", "prompt", "completion"] {
         assert!(
             !columns.iter().any(|c| c == forbidden),
             "audit_logs must not contain a {forbidden} column"
         );
     }
+
+    // The dashboard reads audit_logs by (agent_id, ts DESC); that covering
+    // index must survive a fresh migrate() (AAASM-2389 AC).
+    let has_index: bool = sqlx::query_scalar(
+        "SELECT EXISTS (SELECT 1 FROM pg_indexes \
+         WHERE tablename = 'audit_logs' AND indexname = 'idx_audit_logs_agent_ts')",
+    )
+    .fetch_one(pool.pool())
+    .await
+    .expect("query audit_logs indexes");
+    assert!(has_index, "idx_audit_logs_agent_ts must exist after migrations");
 }
 
 #[tokio::test]

--- a/aa-storage-postgres/tests/conformance_pg.rs
+++ b/aa-storage-postgres/tests/conformance_pg.rs
@@ -208,3 +208,39 @@ async fn audit_sink_writes_metadata_only_row() {
     assert_eq!(tool_name, "ToolDispatched");
     assert_eq!(decision, "allow");
 }
+
+#[tokio::test]
+async fn audit_sink_dedups_repeated_emit_on_event_id() {
+    use aa_core::audit::{AuditEntry, AuditEventType};
+    use aa_storage::{AuditSink, SessionId};
+
+    let (_pg, pool) = setup_pg().await;
+    let sink = PgAuditSink::new(pool.clone());
+
+    let agent = AgentId::from_bytes([5u8; 16]);
+    let session = SessionId::from_bytes([6u8; 16]);
+    // Re-emitting an identical entry yields the same content hash → same
+    // event_id → the UNIQUE key collapses the retry to one row.
+    let make_entry = || {
+        AuditEntry::new(
+            0,
+            1_700_000_000_000_000_000,
+            AuditEventType::ToolDispatched,
+            agent,
+            session,
+            r#"{"tool":"shell"}"#.to_owned(),
+            [0u8; 32],
+        )
+    };
+
+    sink.emit(make_entry()).await.expect("first emit");
+    sink.emit(make_entry()).await.expect("retried emit is idempotent");
+
+    let agent_text = uuid::Uuid::from_bytes(*agent.as_bytes()).to_string();
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM audit_logs WHERE agent_id = $1")
+        .bind(&agent_text)
+        .fetch_one(pool.pool())
+        .await
+        .expect("count audit rows");
+    assert_eq!(count, 1, "duplicate event_id must not double-insert");
+}


### PR DESCRIPTION
## Description

Consolidate the MVP four-table schema (`orgs`/`agents`/`policies`/`audit_logs`) into a single canonical migration set and add a cross-component drift gate between the OSS Postgres driver and the Gateway.

- **Canonical set confirmed.** `aa-storage-postgres/migrations/` is the single source of truth. The Gateway's `aa-gateway/migrations/postgres/*` is a *separate* schema (`audit_events` + TimescaleDB hypertables, Epic F) — **not** a duplicate of the four MVP tables, so nothing was removed. A new `aa-storage-postgres/README.md` documents this and points the Gateway team at the driver `MIGRATOR`.
- **`audit_logs.event_id`.** Rekeyed `audit_logs` on `event_id UUID PRIMARY KEY` (UNIQUE + NOT NULL) — the idempotency key the async consumer dedups on. `PgAuditSink` now inserts `ON CONFLICT (event_id) DO NOTHING`.
- **No duplicate copy.** A new `aa-gateway/tests/migration_boot.rs` runs the **driver's** embedded `MIGRATOR` (via a `path` dev-dependency) against a fresh Postgres 18 — proving the Gateway uses the same migrations, not a copy.
- **CI drift gate.** New `migration-drift-check` job runs that boot test; a migration that no longer applies cleanly (or an `audit_logs` drift) fails CI.
- **Metadata-only enforced.** Tests assert `audit_logs` has no `payload`/`body`/`prompt`/`completion` column and that the `(agent_id, ts DESC)` index survives migration.

## Type of Change

- [x] ✨ New feature
- [x] ♻️ Refactoring
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

`aa-storage-postgres` is `publish = false` and not yet deployed; the `id`→`event_id` rekey has no external consumers (the sink is the only writer).

## Related Issues

- Related Jira ticket: AAASM-2395 (parent Story AAASM-2389, Epic AAASM-2350)

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

Validated locally (Docker):
- `cargo nextest run -p aa-storage-postgres` — 9 passed (incl. new `audit_sink_dedups_repeated_emit_on_event_id` and strengthened migration assertions).
- `cargo nextest run -p aa-gateway -E 'binary(migration_boot)'` — 1 passed.
- `cargo fmt --all --check`, `cargo clippy -p aa-storage-postgres -p aa-gateway --all-targets -- -D warnings`, `cargo deny check` — all clean.

> Note: the verification subtask AAASM-2396 should filter the gateway test with `-E 'binary(migration_boot)'` (a bare positional matches only the test-name segment in this nextest version).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
