### PR TITLE
[AAASM-2391] ✨ (aa-runtime): Add NATS AuditPublisher with SQLite buffer fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,12 +428,17 @@ dependencies = [
  "aa-core",
  "aa-ebpf",
  "aa-proto",
+ "aa-storage-sqlite-buffer",
+ "async-nats",
+ "async-trait",
  "axum",
  "bitflags 2.12.1",
+ "bytes",
  "dashmap",
  "libc",
  "metrics",
  "metrics-exporter-prometheus",
+ "metrics-util",
  "prost",
  "serde",
  "serde_json",
@@ -836,6 +841,42 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-nats"
+version = "0.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "407486109ea5cfdf53fde05f46996dadf0547518a4d49f050d25f405ae31ed2d"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-util",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "pin-project",
+ "portable-atomic",
+ "rand 0.10.1",
+ "regex",
+ "ring",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "serde",
+ "serde_json",
+ "serde_nanos",
+ "serde_repr",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "tryhard",
+ "url",
 ]
 
 [[package]]
@@ -2548,6 +2589,7 @@ dependencies = [
  "ed25519",
  "serde",
  "sha2 0.10.9",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -4464,6 +4506,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "nkeys"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879011babc47a1c7fdf5a935ae3cfe94f34645ca0cac1c7f6424b36fc743d1bf"
+dependencies = [
+ "data-encoding",
+ "ed25519",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "log",
+ "rand 0.8.6",
+ "signatory",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4513,6 +4570,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nuid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
+dependencies = [
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -6501,6 +6567,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_nanos"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93142f0367a4cc53ae0fead1bcda39e85beccfad3dcd717656cacab94b12985"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6681,6 +6756,18 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signatory"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
+dependencies = [
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "zeroize",
 ]
 
 [[package]]
@@ -7478,6 +7565,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "httparse",
+ "rand 0.8.6",
+ "ring",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7761,6 +7869,16 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tryhard"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "tungstenite"

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -14,7 +14,7 @@ default = []
 integration-test = []
 
 [dependencies]
-aa-core                     = { path = "../aa-core", version = "0.0.1-alpha.5" }
+aa-core                     = { path = "../aa-core", version = "0.0.1-alpha.5", features = ["serde"] }
 aa-proto                    = { path = "../aa-proto", version = "0.0.1-alpha.5" }
 aa-storage-sqlite-buffer    = { path = "../aa-storage-sqlite-buffer", version = "0.0.1-alpha.5" }
 async-nats                  = "0.49"

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -16,8 +16,12 @@ integration-test = []
 [dependencies]
 aa-core                     = { path = "../aa-core", version = "0.0.1-alpha.5" }
 aa-proto                    = { path = "../aa-proto", version = "0.0.1-alpha.5" }
+aa-storage-sqlite-buffer    = { path = "../aa-storage-sqlite-buffer", version = "0.0.1-alpha.5" }
+async-nats                  = "0.49"
+async-trait                 = "0.1"
 axum                        = "0.8"
 bitflags                    = "2"
+bytes                       = "1"
 dashmap                     = "6"
 uuid                        = { version = "1", features = ["v4"] }
 metrics                     = "0.24"
@@ -43,6 +47,9 @@ libc    = "0.2"
 tempfile = "3"
 tokio = { version = "1", features = ["test-util"] }
 tower = { version = "0.5", features = ["util"] }
+# Captures emitted metric values so the audit-publisher metric tests can assert
+# the exact counter values recorded by `metrics::counter!`.
+metrics-util = { version = "0.20", features = ["debugging"] }
 
 [lints]
 workspace = true

--- a/aa-runtime/src/audit_publisher/config.rs
+++ b/aa-runtime/src/audit_publisher/config.rs
@@ -66,3 +66,34 @@ impl Default for NatsConfig {
         }
     }
 }
+
+/// The `[gateway]` table, holding the nested `nats` configuration.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct GatewaySection {
+    nats: NatsConfig,
+}
+
+/// Document root used to reach `[gateway.nats]` from a full
+/// `agent-assembly.toml`.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+struct ConfigRoot {
+    gateway: GatewaySection,
+}
+
+impl NatsConfig {
+    /// Parse the `[gateway.nats]` table out of an `agent-assembly.toml` document.
+    ///
+    /// A document with neither `[gateway]` nor `[gateway.nats]` yields the
+    /// [`Default`] configuration, so callers can pass the whole config file
+    /// unconditionally.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying [`toml::de::Error`] when the document is not valid
+    /// TOML or the `[gateway.nats]` table has a type-incompatible value.
+    pub fn from_toml_str(toml: &str) -> Result<Self, toml::de::Error> {
+        Ok(toml::from_str::<ConfigRoot>(toml)?.gateway.nats)
+    }
+}

--- a/aa-runtime/src/audit_publisher/config.rs
+++ b/aa-runtime/src/audit_publisher/config.rs
@@ -97,3 +97,33 @@ impl NatsConfig {
         Ok(toml::from_str::<ConfigRoot>(toml)?.gateway.nats)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_full_gateway_nats_table() {
+        let toml = r#"
+            [gateway.nats]
+            url = "tls://nats.example.com:4222"
+            token = "s3cr3t"
+            max_inflight = 4096
+
+            [gateway.nats.tls]
+            ca = "/etc/aa/ca.pem"
+            cert = "/etc/aa/client.pem"
+            key = "/etc/aa/client.key"
+        "#;
+
+        let cfg = NatsConfig::from_toml_str(toml).expect("valid config");
+
+        assert_eq!(cfg.url, "tls://nats.example.com:4222");
+        assert_eq!(cfg.token.as_deref(), Some("s3cr3t"));
+        assert_eq!(cfg.max_inflight, 4096);
+        let tls = cfg.tls.expect("tls table present");
+        assert_eq!(tls.ca, Some(PathBuf::from("/etc/aa/ca.pem")));
+        assert_eq!(tls.cert, Some(PathBuf::from("/etc/aa/client.pem")));
+        assert_eq!(tls.key, Some(PathBuf::from("/etc/aa/client.key")));
+    }
+}

--- a/aa-runtime/src/audit_publisher/config.rs
+++ b/aa-runtime/src/audit_publisher/config.rs
@@ -1,0 +1,68 @@
+//! Operator configuration for the NATS audit publisher.
+//!
+//! Deserialized from the `[gateway.nats]` table of `agent-assembly.toml`.
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+/// Default NATS server URL when `[gateway.nats] url` is omitted.
+pub const DEFAULT_URL: &str = "nats://127.0.0.1:4222";
+
+/// Default cap on in-flight (unacknowledged) publishes when `max_inflight` is
+/// omitted.
+pub const DEFAULT_MAX_INFLIGHT: usize = 1_024;
+
+/// TLS material for the NATS connection, configured under `[gateway.nats.tls]`.
+///
+/// All three paths are optional: provide `ca` to trust a private server
+/// certificate, and `cert` + `key` together for mutual-TLS client
+/// authentication.
+#[derive(Debug, Clone, Default, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct NatsTlsConfig {
+    /// Path to a PEM bundle of root certificates used to verify the server.
+    pub ca: Option<PathBuf>,
+    /// Path to the client certificate (PEM) for mutual TLS.
+    pub cert: Option<PathBuf>,
+    /// Path to the client private key (PEM) for mutual TLS.
+    pub key: Option<PathBuf>,
+}
+
+/// Connection settings for the Assembly-side NATS audit publisher.
+///
+/// Deserialized from the `[gateway.nats]` table; every field is optional and
+/// falls back to a sensible default so a bare `[gateway.nats]` (or no table at
+/// all) still yields a usable local-development configuration.
+///
+/// ```
+/// use aa_runtime::audit_publisher::NatsConfig;
+///
+/// let cfg = NatsConfig::default();
+/// assert_eq!(cfg.url, "nats://127.0.0.1:4222");
+/// assert!(cfg.token.is_none());
+/// assert!(cfg.tls.is_none());
+/// ```
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct NatsConfig {
+    /// NATS server URL (e.g. `nats://host:4222` or `tls://host:4222`).
+    pub url: String,
+    /// Bearer token presented to the server for authentication.
+    pub token: Option<String>,
+    /// TLS material; `None` leaves the connection plaintext.
+    pub tls: Option<NatsTlsConfig>,
+    /// Upper bound on concurrently in-flight publishes.
+    pub max_inflight: usize,
+}
+
+impl Default for NatsConfig {
+    fn default() -> Self {
+        Self {
+            url: DEFAULT_URL.to_string(),
+            token: None,
+            tls: None,
+            max_inflight: DEFAULT_MAX_INFLIGHT,
+        }
+    }
+}

--- a/aa-runtime/src/audit_publisher/config.rs
+++ b/aa-runtime/src/audit_publisher/config.rs
@@ -126,4 +126,16 @@ mod tests {
         assert_eq!(tls.cert, Some(PathBuf::from("/etc/aa/client.pem")));
         assert_eq!(tls.key, Some(PathBuf::from("/etc/aa/client.key")));
     }
+
+    #[test]
+    fn falls_back_to_defaults_when_table_absent() {
+        // A config document with an unrelated table and no [gateway.nats].
+        let cfg = NatsConfig::from_toml_str("[storage]\naudit_sink = \"postgres\"\n").expect("valid config");
+
+        assert_eq!(cfg, NatsConfig::default());
+        assert_eq!(cfg.url, DEFAULT_URL);
+        assert_eq!(cfg.max_inflight, DEFAULT_MAX_INFLIGHT);
+        assert!(cfg.token.is_none());
+        assert!(cfg.tls.is_none());
+    }
 }

--- a/aa-runtime/src/audit_publisher/config.rs
+++ b/aa-runtime/src/audit_publisher/config.rs
@@ -96,6 +96,43 @@ impl NatsConfig {
     pub fn from_toml_str(toml: &str) -> Result<Self, toml::de::Error> {
         Ok(toml::from_str::<ConfigRoot>(toml)?.gateway.nats)
     }
+
+    /// Build the [`async_nats::ConnectOptions`] described by this configuration.
+    ///
+    /// Applies the bearer token when set and, when a `[gateway.nats.tls]` table
+    /// is present, requires TLS and installs the configured root certificate
+    /// and (for mutual TLS) the client certificate/key. `max_inflight` caps the
+    /// client's internal channel capacity.
+    ///
+    /// Enabling TLS requires a process-wide `rustls` crypto provider to be
+    /// installed by the host binary before [`connect`](Self::connect) is called.
+    #[must_use]
+    pub fn connect_options(&self) -> async_nats::ConnectOptions {
+        let mut opts = async_nats::ConnectOptions::new().client_capacity(self.max_inflight.max(1));
+        if let Some(token) = &self.token {
+            opts = opts.token(token.clone());
+        }
+        if let Some(tls) = &self.tls {
+            opts = opts.require_tls(true);
+            if let Some(ca) = &tls.ca {
+                opts = opts.add_root_certificates(ca.clone());
+            }
+            if let (Some(cert), Some(key)) = (&tls.cert, &tls.key) {
+                opts = opts.add_client_certificate(cert.clone(), key.clone());
+            }
+        }
+        opts
+    }
+
+    /// Connect to the configured NATS server using [`connect_options`](Self::connect_options).
+    ///
+    /// # Errors
+    ///
+    /// Returns the [`async_nats::ConnectError`] when the initial connection
+    /// cannot be established.
+    pub async fn connect(&self) -> Result<async_nats::Client, async_nats::ConnectError> {
+        self.connect_options().connect(self.url.clone()).await
+    }
 }
 
 #[cfg(test)]

--- a/aa-runtime/src/audit_publisher/mod.rs
+++ b/aa-runtime/src/audit_publisher/mod.rs
@@ -1,0 +1,26 @@
+//! Assembly-side audit-event publisher.
+//!
+//! The [`AuditPublisher`] fires governance [`AuditEntry`](aa_core::storage::AuditEntry)
+//! records at a NATS subject and returns control to the agent immediately, so
+//! the tool-call critical path never blocks on the gateway's database writes
+//! (spec line 7349). When the NATS connection is down, events spill into the
+//! local SQLite [`EventBuffer`](aa_storage_sqlite_buffer::EventBuffer) instead
+//! of being dropped, and a background loop flushes the backlog in FIFO order
+//! once the connection recovers.
+//!
+//! NATS is the Phase 1 backend (spec line 7457); the publisher is the only
+//! Assembly-side component that knows about it, so swapping in Kafka later does
+//! not touch the agent-facing API.
+
+/// Counter incremented once per event accepted by the NATS sink.
+pub const METRIC_PUBLISHED: &str = "aa_audit_published_total";
+
+/// Counter incremented once per failed publish attempt (the event is then
+/// routed to the buffer).
+pub const METRIC_PUBLISH_ERRORS: &str = "aa_audit_publish_errors_total";
+
+/// Counter incremented once per event diverted to the SQLite fallback buffer.
+pub const METRIC_BUFFERED: &str = "aa_audit_buffered_total";
+
+/// Counter incremented once per buffered event replayed to NATS on reconnect.
+pub const METRIC_FLUSHED: &str = "aa_audit_flushed_total";

--- a/aa-runtime/src/audit_publisher/mod.rs
+++ b/aa-runtime/src/audit_publisher/mod.rs
@@ -13,8 +13,10 @@
 //! not touch the agent-facing API.
 
 mod config;
+mod subject;
 
 pub use config::{NatsConfig, NatsTlsConfig, DEFAULT_MAX_INFLIGHT, DEFAULT_URL};
+pub use subject::subject_for;
 
 /// Counter incremented once per event accepted by the NATS sink.
 pub const METRIC_PUBLISHED: &str = "aa_audit_published_total";

--- a/aa-runtime/src/audit_publisher/mod.rs
+++ b/aa-runtime/src/audit_publisher/mod.rs
@@ -13,10 +13,12 @@
 //! not touch the agent-facing API.
 
 mod config;
+mod publisher;
 mod sink;
 mod subject;
 
 pub use config::{NatsConfig, NatsTlsConfig, DEFAULT_MAX_INFLIGHT, DEFAULT_URL};
+pub use publisher::AuditPublisher;
 pub use sink::NatsAuditSink;
 pub use subject::subject_for;
 

--- a/aa-runtime/src/audit_publisher/mod.rs
+++ b/aa-runtime/src/audit_publisher/mod.rs
@@ -12,6 +12,10 @@
 //! Assembly-side component that knows about it, so swapping in Kafka later does
 //! not touch the agent-facing API.
 
+mod config;
+
+pub use config::{NatsConfig, NatsTlsConfig, DEFAULT_MAX_INFLIGHT, DEFAULT_URL};
+
 /// Counter incremented once per event accepted by the NATS sink.
 pub const METRIC_PUBLISHED: &str = "aa_audit_published_total";
 

--- a/aa-runtime/src/audit_publisher/mod.rs
+++ b/aa-runtime/src/audit_publisher/mod.rs
@@ -13,9 +13,11 @@
 //! not touch the agent-facing API.
 
 mod config;
+mod sink;
 mod subject;
 
 pub use config::{NatsConfig, NatsTlsConfig, DEFAULT_MAX_INFLIGHT, DEFAULT_URL};
+pub use sink::NatsAuditSink;
 pub use subject::subject_for;
 
 /// Counter incremented once per event accepted by the NATS sink.

--- a/aa-runtime/src/audit_publisher/publisher.rs
+++ b/aa-runtime/src/audit_publisher/publisher.rs
@@ -1,11 +1,13 @@
 //! The fire-and-forget [`AuditPublisher`] with offline buffering.
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use aa_core::storage::{AuditEntry, AuditSink, Result};
 use aa_storage_sqlite_buffer::EventBuffer;
+use tokio::task::JoinHandle;
 
-use super::{METRIC_BUFFERED, METRIC_PUBLISHED, METRIC_PUBLISH_ERRORS};
+use super::{METRIC_BUFFERED, METRIC_FLUSHED, METRIC_PUBLISHED, METRIC_PUBLISH_ERRORS};
 
 /// Publishes audit events to a NATS [`AuditSink`] and, when that sink fails,
 /// diverts them to a local SQLite [`EventBuffer`] instead of blocking the agent.
@@ -52,5 +54,45 @@ impl AuditPublisher {
     /// Propagates any error from the underlying buffer query.
     pub fn buffered_len(&self) -> Result<usize> {
         self.buffer.len()
+    }
+
+    /// Replay any buffered events to the sink in FIFO order, returning the count
+    /// flushed.
+    ///
+    /// Draining stops at the first sink failure (the connection is treated as
+    /// still down), leaving the remainder buffered for a later attempt. Each
+    /// replayed event bumps `aa_audit_flushed_total`.
+    ///
+    /// # Errors
+    ///
+    /// Propagates buffer read/decode errors; a sink failure is not an error
+    /// here — it simply ends the drain early.
+    pub async fn flush_pending(&self) -> Result<usize> {
+        if self.buffer.is_empty()? {
+            return Ok(0);
+        }
+        let flushed = self.buffer.drain_and_send(&*self.sink).await?;
+        if flushed > 0 {
+            metrics::counter!(METRIC_FLUSHED).increment(flushed as u64);
+        }
+        Ok(flushed)
+    }
+
+    /// Spawn a background task that periodically flushes the buffer, draining it
+    /// once the NATS connection recovers.
+    ///
+    /// The task ticks every `interval` and calls [`flush_pending`](Self::flush_pending);
+    /// abort the returned [`JoinHandle`] to stop it.
+    #[must_use]
+    pub fn spawn_reconnect_flush_loop(self: Arc<Self>, interval: Duration) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            loop {
+                ticker.tick().await;
+                if let Err(err) = self.flush_pending().await {
+                    tracing::warn!(error = %err, "audit buffer flush failed");
+                }
+            }
+        })
     }
 }

--- a/aa-runtime/src/audit_publisher/publisher.rs
+++ b/aa-runtime/src/audit_publisher/publisher.rs
@@ -96,3 +96,79 @@ impl AuditPublisher {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Mutex;
+
+    use aa_core::audit::{AuditEntry, AuditEventType};
+    use aa_core::storage::StorageError;
+    use aa_core::{AgentId, SessionId};
+    use async_trait::async_trait;
+    use tempfile::TempDir;
+
+    /// An in-memory [`AuditSink`] whose connectivity can be toggled. It records
+    /// every accepted entry so tests can assert FIFO replay order.
+    struct FakeSink {
+        up: AtomicBool,
+        captured: Mutex<Vec<AuditEntry>>,
+    }
+
+    impl FakeSink {
+        fn new(up: bool) -> Self {
+            Self {
+                up: AtomicBool::new(up),
+                captured: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn captured_seqs(&self) -> Vec<u64> {
+            self.captured.lock().unwrap().iter().map(AuditEntry::seq).collect()
+        }
+    }
+
+    #[async_trait]
+    impl AuditSink for FakeSink {
+        async fn emit(&self, event: AuditEntry) -> Result<()> {
+            if !self.up.load(Ordering::SeqCst) {
+                return Err(StorageError::Backend("fake sink down".to_string()));
+            }
+            self.captured.lock().unwrap().push(event);
+            Ok(())
+        }
+    }
+
+    /// Build a distinct audit entry tagged with `seq`.
+    fn entry(seq: u64) -> AuditEntry {
+        AuditEntry::new(
+            seq,
+            seq,
+            AuditEventType::ToolCallIntercepted,
+            AgentId::from_bytes([0u8; 16]),
+            SessionId::from_bytes([0u8; 16]),
+            format!("{{\"seq\":{seq}}}"),
+            [0u8; 32],
+        )
+    }
+
+    /// Create a fresh on-disk buffer in a temp dir (returned so it outlives the buffer).
+    fn new_buffer() -> (TempDir, Arc<EventBuffer>) {
+        let dir = TempDir::new().expect("temp dir");
+        let buffer = EventBuffer::new(dir.path().join("buffer.db"), 10_000).expect("open buffer");
+        (dir, Arc::new(buffer))
+    }
+
+    #[tokio::test]
+    async fn publish_succeeds_when_sink_up() {
+        let (_dir, buffer) = new_buffer();
+        let sink = Arc::new(FakeSink::new(true));
+        let publisher = AuditPublisher::new(sink.clone(), buffer.clone());
+
+        publisher.publish(entry(1)).await;
+
+        assert_eq!(sink.captured_seqs(), vec![1]);
+        assert_eq!(publisher.buffered_len().unwrap(), 0, "nothing should be buffered");
+    }
+}

--- a/aa-runtime/src/audit_publisher/publisher.rs
+++ b/aa-runtime/src/audit_publisher/publisher.rs
@@ -124,6 +124,10 @@ mod tests {
             }
         }
 
+        fn set_up(&self, up: bool) {
+            self.up.store(up, Ordering::SeqCst);
+        }
+
         fn captured_seqs(&self) -> Vec<u64> {
             self.captured.lock().unwrap().iter().map(AuditEntry::seq).collect()
         }
@@ -183,5 +187,26 @@ mod tests {
 
         assert!(sink.captured_seqs().is_empty(), "sink is down, nothing delivered");
         assert_eq!(publisher.buffered_len().unwrap(), 2, "both events buffered");
+    }
+
+    #[tokio::test]
+    async fn reconnect_drains_buffer_in_fifo_order() {
+        let (_dir, buffer) = new_buffer();
+        let sink = Arc::new(FakeSink::new(false));
+        let publisher = AuditPublisher::new(sink.clone(), buffer.clone());
+
+        // Sink down: three events accumulate in the buffer.
+        for seq in 1..=3 {
+            publisher.publish(entry(seq)).await;
+        }
+        assert_eq!(publisher.buffered_len().unwrap(), 3);
+
+        // Reconnect and flush: the backlog drains in insertion order.
+        sink.set_up(true);
+        let flushed = publisher.flush_pending().await.unwrap();
+
+        assert_eq!(flushed, 3);
+        assert_eq!(publisher.buffered_len().unwrap(), 0, "buffer fully drained");
+        assert_eq!(sink.captured_seqs(), vec![1, 2, 3], "replayed in FIFO order");
     }
 }

--- a/aa-runtime/src/audit_publisher/publisher.rs
+++ b/aa-runtime/src/audit_publisher/publisher.rs
@@ -171,4 +171,17 @@ mod tests {
         assert_eq!(sink.captured_seqs(), vec![1]);
         assert_eq!(publisher.buffered_len().unwrap(), 0, "nothing should be buffered");
     }
+
+    #[tokio::test]
+    async fn buffers_when_sink_down() {
+        let (_dir, buffer) = new_buffer();
+        let sink = Arc::new(FakeSink::new(false));
+        let publisher = AuditPublisher::new(sink.clone(), buffer.clone());
+
+        publisher.publish(entry(1)).await;
+        publisher.publish(entry(2)).await;
+
+        assert!(sink.captured_seqs().is_empty(), "sink is down, nothing delivered");
+        assert_eq!(publisher.buffered_len().unwrap(), 2, "both events buffered");
+    }
 }

--- a/aa-runtime/src/audit_publisher/publisher.rs
+++ b/aa-runtime/src/audit_publisher/publisher.rs
@@ -1,0 +1,56 @@
+//! The fire-and-forget [`AuditPublisher`] with offline buffering.
+
+use std::sync::Arc;
+
+use aa_core::storage::{AuditEntry, AuditSink, Result};
+use aa_storage_sqlite_buffer::EventBuffer;
+
+use super::{METRIC_BUFFERED, METRIC_PUBLISHED, METRIC_PUBLISH_ERRORS};
+
+/// Publishes audit events to a NATS [`AuditSink`] and, when that sink fails,
+/// diverts them to a local SQLite [`EventBuffer`] instead of blocking the agent.
+///
+/// The sink is held behind a trait object so the publisher can be exercised
+/// with an in-memory fake in unit tests and a real
+/// [`NatsAuditSink`](super::NatsAuditSink) in production.
+pub struct AuditPublisher {
+    sink: Arc<dyn AuditSink>,
+    buffer: Arc<EventBuffer>,
+}
+
+impl AuditPublisher {
+    /// Build a publisher over an audit `sink` and the SQLite fallback `buffer`.
+    #[must_use]
+    pub fn new(sink: Arc<dyn AuditSink>, buffer: Arc<EventBuffer>) -> Self {
+        Self { sink, buffer }
+    }
+
+    /// Publish `entry`, fire-and-forget.
+    ///
+    /// Tries the sink first; on any sink error the entry is appended to the
+    /// buffer. This never returns an error to the caller, so the agent's
+    /// critical path is never blocked by audit production. Each outcome bumps
+    /// the matching `aa_audit_*` counter.
+    pub async fn publish(&self, entry: AuditEntry) {
+        match self.sink.emit(entry.clone()).await {
+            Ok(()) => {
+                metrics::counter!(METRIC_PUBLISHED).increment(1);
+            }
+            Err(_) => {
+                metrics::counter!(METRIC_PUBLISH_ERRORS).increment(1);
+                if self.buffer.enqueue(&entry).is_ok() {
+                    metrics::counter!(METRIC_BUFFERED).increment(1);
+                }
+            }
+        }
+    }
+
+    /// Number of events currently held in the fallback buffer.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from the underlying buffer query.
+    pub fn buffered_len(&self) -> Result<usize> {
+        self.buffer.len()
+    }
+}

--- a/aa-runtime/src/audit_publisher/publisher.rs
+++ b/aa-runtime/src/audit_publisher/publisher.rs
@@ -209,4 +209,46 @@ mod tests {
         assert_eq!(publisher.buffered_len().unwrap(), 0, "buffer fully drained");
         assert_eq!(sink.captured_seqs(), vec![1, 2, 3], "replayed in FIFO order");
     }
+
+    #[test]
+    fn records_all_four_audit_metrics() {
+        use metrics_util::debugging::DebuggingRecorder;
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        // Drive one of each outcome (published, error+buffered, flushed) under a
+        // thread-local recorder so the assertions never race a global one.
+        metrics::with_local_recorder(&recorder, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                let (_dir, buffer) = new_buffer();
+                let sink = Arc::new(FakeSink::new(true));
+                let publisher = AuditPublisher::new(sink.clone(), buffer.clone());
+
+                publisher.publish(entry(1)).await; // -> published
+                sink.set_up(false);
+                publisher.publish(entry(2)).await; // -> publish error + buffered
+                sink.set_up(true);
+                publisher.flush_pending().await.unwrap(); // -> flushed
+            });
+        });
+
+        let names: Vec<String> = snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .map(|(key, _, _, _)| key.key().name().to_string())
+            .collect();
+
+        for expected in [METRIC_PUBLISHED, METRIC_PUBLISH_ERRORS, METRIC_BUFFERED, METRIC_FLUSHED] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "missing metric {expected}; got {names:?}"
+            );
+        }
+    }
 }

--- a/aa-runtime/src/audit_publisher/sink.rs
+++ b/aa-runtime/src/audit_publisher/sink.rs
@@ -1,0 +1,61 @@
+//! NATS-backed [`AuditSink`] implementation.
+
+use aa_core::storage::{AuditEntry, AuditSink, Result, StorageError};
+use async_trait::async_trait;
+
+use super::config::NatsConfig;
+use super::subject::subject_for;
+
+/// An [`AuditSink`] that publishes each entry to its
+/// `assembly.audit.<tenant>.<agent>` subject over NATS.
+///
+/// The sink serializes the entry to JSON and publishes it fire-and-forget. When
+/// the underlying connection is not established, [`emit`](AuditSink::emit)
+/// returns a [`StorageError::Backend`] so the caller can divert the event to
+/// the local buffer instead of blocking on a dead connection.
+pub struct NatsAuditSink {
+    client: async_nats::Client,
+}
+
+impl NatsAuditSink {
+    /// Wrap an already-connected NATS client.
+    #[must_use]
+    pub fn new(client: async_nats::Client) -> Self {
+        Self { client }
+    }
+
+    /// Connect to the server described by `config` and wrap the client.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError::Backend`] when the initial connection fails.
+    pub async fn connect(config: &NatsConfig) -> Result<Self> {
+        let client = config
+            .connect()
+            .await
+            .map_err(|e| StorageError::Backend(e.to_string()))?;
+        Ok(Self::new(client))
+    }
+
+    /// Whether the wrapped client currently has an established connection.
+    #[must_use]
+    pub fn is_connected(&self) -> bool {
+        self.client.connection_state() == async_nats::connection::State::Connected
+    }
+}
+
+#[async_trait]
+impl AuditSink for NatsAuditSink {
+    async fn emit(&self, event: AuditEntry) -> Result<()> {
+        if !self.is_connected() {
+            return Err(StorageError::Backend("nats connection is not established".to_string()));
+        }
+        let subject = subject_for(&event);
+        let payload = serde_json::to_vec(&event).map_err(|e| StorageError::Serialization(e.to_string()))?;
+        self.client
+            .publish(subject, payload.into())
+            .await
+            .map_err(|e| StorageError::Backend(e.to_string()))?;
+        Ok(())
+    }
+}

--- a/aa-runtime/src/audit_publisher/subject.rs
+++ b/aa-runtime/src/audit_publisher/subject.rs
@@ -83,4 +83,11 @@ mod tests {
             format!("assembly.audit.acme_corp_eu.{expected_agent}")
         );
     }
+
+    #[test]
+    fn falls_back_to_team_id_when_org_absent() {
+        let entry = entry_with(None, Some("payments"));
+        let expected_agent = uuid::Uuid::from_bytes(AGENT_BYTES);
+        assert_eq!(subject_for(&entry), format!("assembly.audit.payments.{expected_agent}"));
+    }
 }

--- a/aa-runtime/src/audit_publisher/subject.rs
+++ b/aa-runtime/src/audit_publisher/subject.rs
@@ -1,0 +1,40 @@
+//! Derivation of the NATS subject an audit entry is published to.
+
+use aa_core::storage::AuditEntry;
+
+/// Subject prefix shared by every audit event.
+const SUBJECT_PREFIX: &str = "assembly.audit";
+
+/// Token used when a tenant identifier is unavailable on the entry.
+const UNKNOWN_TENANT: &str = "default";
+
+/// Build the NATS subject `assembly.audit.<tenant>.<agent>` for `entry`.
+///
+/// `<tenant>` is the entry's org id, falling back to its team id, then to
+/// `default`. `<agent>` is the agent id rendered as a hyphenated UUID. The
+/// tenant token is sanitized so the subject contains only subject-safe
+/// characters — NATS forbids whitespace and reserves `.`, `*`, and `>`.
+pub fn subject_for(entry: &AuditEntry) -> String {
+    let tenant = entry
+        .org_id()
+        .or_else(|| entry.team_id())
+        .map(sanitize_token)
+        .filter(|token| !token.is_empty())
+        .unwrap_or_else(|| UNKNOWN_TENANT.to_string());
+    let agent = uuid::Uuid::from_bytes(*entry.agent_id().as_bytes());
+    format!("{SUBJECT_PREFIX}.{tenant}.{agent}")
+}
+
+/// Replace every character outside `[A-Za-z0-9_-]` with `_` so the result is a
+/// single valid NATS subject token.
+fn sanitize_token(raw: &str) -> String {
+    raw.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}

--- a/aa-runtime/src/audit_publisher/subject.rs
+++ b/aa-runtime/src/audit_publisher/subject.rs
@@ -72,4 +72,15 @@ mod tests {
         let expected_agent = uuid::Uuid::from_bytes(AGENT_BYTES);
         assert_eq!(subject_for(&entry), format!("assembly.audit.default.{expected_agent}"));
     }
+
+    #[test]
+    fn prefers_org_id_and_sanitizes_unsafe_chars() {
+        // org_id wins over team_id; the space and dot are not subject-safe.
+        let entry = entry_with(Some("acme corp.eu"), Some("payments"));
+        let expected_agent = uuid::Uuid::from_bytes(AGENT_BYTES);
+        assert_eq!(
+            subject_for(&entry),
+            format!("assembly.audit.acme_corp_eu.{expected_agent}")
+        );
+    }
 }

--- a/aa-runtime/src/audit_publisher/subject.rs
+++ b/aa-runtime/src/audit_publisher/subject.rs
@@ -38,3 +38,38 @@ fn sanitize_token(raw: &str) -> String {
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aa_core::audit::{AuditEventType, Lineage};
+    use aa_core::{AgentId, SessionId};
+
+    const AGENT_BYTES: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+
+    /// Build an audit entry carrying the given optional org/team lineage.
+    fn entry_with(org: Option<&str>, team: Option<&str>) -> AuditEntry {
+        let lineage = Lineage {
+            org_id: org.map(str::to_string),
+            team_id: team.map(str::to_string),
+            ..Lineage::default()
+        };
+        AuditEntry::new_with_lineage(
+            1,
+            0,
+            AuditEventType::ToolCallIntercepted,
+            AgentId::from_bytes(AGENT_BYTES),
+            SessionId::from_bytes(AGENT_BYTES),
+            "{}".to_string(),
+            [0u8; 32],
+            lineage,
+        )
+    }
+
+    #[test]
+    fn defaults_tenant_and_renders_agent_uuid() {
+        let entry = entry_with(None, None);
+        let expected_agent = uuid::Uuid::from_bytes(AGENT_BYTES);
+        assert_eq!(subject_for(&entry), format!("assembly.audit.default.{expected_agent}"));
+    }
+}

--- a/aa-runtime/src/lib.rs
+++ b/aa-runtime/src/lib.rs
@@ -5,6 +5,7 @@
 //! coordination, and lifecycle hooks.
 
 pub mod approval;
+pub mod audit_publisher;
 pub mod config;
 pub mod correlation;
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Description

Adds the Assembly-side **`AuditPublisher`** for Epic AAASM-2350 (Phase 1 async event production). The publisher fires governance audit events at a NATS subject and returns to the agent immediately; when NATS is unreachable, events spill into the local SQLite buffer (AAASM-2366) and a background loop replays them in FIFO order on reconnect — so the tool-call critical path never blocks on the gateway (spec line 7349).

Landed in **`aa-runtime`** (the Assembly runtime; there is no `aa-assembly` crate in the workspace) under `aa-runtime/src/audit_publisher/`:

- **`NatsConfig` / `NatsTlsConfig`** — deserialized from the `[gateway.nats]` table of `agent-assembly.toml` (`url`, `token`, `tls.{ca,cert,key}`, `max_inflight`); builds `async_nats::ConnectOptions` (token + require_tls + root/client certs + client capacity).
- **`subject_for`** — maps an entry to `assembly.audit.<tenant>.<agent>`; tenant resolves `org_id → team_id → default` (sanitized to subject-safe characters), agent is the `agent_id` as a hyphenated UUID.
- **`NatsAuditSink`** — implements `aa_core::storage::AuditSink`, publishing entries as JSON; returns a `Backend` error when the connection is not established so callers fall back to the buffer.
- **`AuditPublisher`** — `publish()` is fire-and-forget (tries the sink, falls back to `buffer.enqueue`, never errors back); `flush_pending` / `spawn_reconnect_flush_loop` drain the buffer in FIFO order.
- **Metrics** — `aa_audit_published_total`, `aa_audit_publish_errors_total`, `aa_audit_buffered_total`, `aa_audit_flushed_total`.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2391 (Story AAASM-2387, Epic AAASM-2350)

## Testing

- [x] Unit tests added / updated

`cargo nextest run -p aa-runtime` (239 passed) + `cargo test -p aa-runtime --doc`:

- config: full `[gateway.nats]` table parsing (incl. TLS) + default fallback
- subject: default tenant + agent UUID, org-id priority + sanitization, team-id fallback
- publisher: publish succeeds when sink up; events buffer when sink down; reconnect drains buffer in FIFO order; all four `aa_audit_*` metrics recorded

> The testcontainers-based NATS integration test (publish 1000 → kill NATS → publish 100 → restart → assert 1100 land) is the **AAASM-2392** verification subtask, shipping in a follow-up PR stacked on this branch.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
