### PR TITLE
[AAASM-2385] ✨ (aa-gateway): Reuse invalidation channel for approval push

### DIFF
--- a/aa-gateway/src/invalidation/hub.rs
+++ b/aa-gateway/src/invalidation/hub.rs
@@ -281,4 +281,25 @@ mod tests {
         assert_eq!(reconnect_a.replay[0].seq, 1);
         assert_eq!(reconnect_b.replay[0].seq, 1);
     }
+
+    #[tokio::test]
+    async fn broadcast_approval_resolved_reaches_subscriber() {
+        let hub = InvalidationHub::new();
+        let mut handle = hub.subscribe("asm-1", 0);
+
+        hub.broadcast_approval_resolved("req-42", Decision::Approved);
+
+        let event = tokio::time::timeout(Duration::from_millis(100), handle.receiver.recv())
+            .await
+            .expect("event delivered within 100 ms")
+            .expect("channel open");
+        assert_eq!(event.seq, 1);
+        match event.payload.expect("payload set") {
+            Payload::ApprovalResolved(ar) => {
+                assert_eq!(ar.request_id, "req-42");
+                assert_eq!(ar.decision(), Decision::Approved);
+            }
+            other => panic!("expected ApprovalResolved, got {other:?}"),
+        }
+    }
 }

--- a/aa-gateway/src/invalidation/hub.rs
+++ b/aa-gateway/src/invalidation/hub.rs
@@ -14,7 +14,8 @@ use std::sync::{Arc, Mutex, RwLock};
 use tokio::sync::broadcast;
 
 use aa_proto::assembly::gateway::v1::invalidation_event::Payload;
-use aa_proto::assembly::gateway::v1::{InvalidationEvent, PolicyInvalidated};
+use aa_proto::assembly::gateway::v1::{ApprovalResolved, Decision, InvalidationEvent, PolicyInvalidated};
+use aa_runtime::approval::{ApprovalDecision, ApprovalResolvedNotifier};
 
 /// Stable identifier of a subscribing Assembly instance.
 pub type AssemblyId = String;
@@ -111,16 +112,37 @@ impl InvalidationHub {
     /// [`REPLAY_RING_CAPACITY`]). An empty `agent_id` is the "invalidate all
     /// cached agents" convention used for a global policy swap.
     pub fn broadcast_policy_invalidated(&self, agent_id: impl Into<String>, policy_version: u64) {
-        let agent_id = agent_id.into();
+        self.fan_out(Payload::PolicyInvalidated(PolicyInvalidated {
+            agent_id: agent_id.into(),
+            policy_version,
+        }));
+    }
+
+    /// Fan an `ApprovalResolved` event out to every connected Assembly.
+    ///
+    /// Reuses the same push channel as [`broadcast_policy_invalidated`]: a
+    /// blocked agent that subscribed (via an `ApprovalSink`) is woken the
+    /// instant a human reviewer's verdict is recorded, instead of polling.
+    /// `request_id` identifies the resolved approval request; `decision` is
+    /// the reviewer's verdict. AAASM-2378.
+    pub fn broadcast_approval_resolved(&self, request_id: impl Into<String>, decision: Decision) {
+        self.fan_out(Payload::ApprovalResolved(ApprovalResolved {
+            request_id: request_id.into(),
+            decision: decision as i32,
+        }));
+    }
+
+    /// Fan a single payload out to every connected Assembly under each
+    /// subscriber's own monotonic sequence number, recording a copy in its
+    /// replay ring (oldest trimmed past [`REPLAY_RING_CAPACITY`]) so a
+    /// reconnecting Assembly can recover anything missed.
+    fn fan_out(&self, payload: Payload) {
         let subscribers = self.subscribers.read().expect("invalidation subscribers lock poisoned");
         for subscriber in subscribers.values() {
             let seq = subscriber.next_seq.fetch_add(1, Ordering::Relaxed);
             let event = InvalidationEvent {
                 seq,
-                payload: Some(Payload::PolicyInvalidated(PolicyInvalidated {
-                    agent_id: agent_id.clone(),
-                    policy_version,
-                })),
+                payload: Some(payload.clone()),
             };
             {
                 let mut ring = subscriber.ring.lock().expect("replay ring lock poisoned");
@@ -155,6 +177,22 @@ impl InvalidationHub {
             .read()
             .expect("invalidation subscribers lock poisoned")
             .len()
+    }
+}
+
+/// Bridges [`ApprovalQueue`](aa_runtime::approval::ApprovalQueue) resolutions to
+/// the push channel: a human verdict becomes an `ApprovalResolved` event fanned
+/// out to subscribed Assemblies. Timeouts are *not* broadcast — they are not a
+/// human response, and a blocked agent handles its own deadline locally via
+/// `ApprovalSink::wait_for_approval`. AAASM-2378.
+impl ApprovalResolvedNotifier for InvalidationHub {
+    fn notify_resolved(&self, request_id: &str, decision: &ApprovalDecision) {
+        let wire = match decision {
+            ApprovalDecision::Approved { .. } => Decision::Approved,
+            ApprovalDecision::Rejected { .. } => Decision::Denied,
+            ApprovalDecision::TimedOut { .. } => return,
+        };
+        self.broadcast_approval_resolved(request_id, wire);
     }
 }
 

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -26,7 +26,7 @@ use aa_proto::assembly::secrets::v1::secrets_service_server::SecretsServiceServe
 use aa_proto::assembly::topology::v1::topology_service_server::TopologyServiceServer;
 use tokio::sync::broadcast;
 
-use aa_runtime::approval::ApprovalQueue;
+use aa_runtime::approval::{ApprovalQueue, ApprovalResolvedNotifier};
 
 use crate::approval::clock::SystemClock;
 use crate::approval::db_escalation_scheduler::DbEscalationScheduler;
@@ -373,6 +373,11 @@ pub async fn serve_tcp(
             .map_err(|e| format!("failed to load policy: {e:?}"))?
             .with_invalidation_hub(Arc::clone(&invalidation_hub)),
     );
+    // Reuse the push channel for approval notifications: a dashboard verdict
+    // (POST /approvals/{id}/approve|reject → ApprovalQueue::decide) fans out as
+    // an `ApprovalResolved` event so blocked agents need not poll. AAASM-2378.
+    let approval_notifier: Arc<dyn ApprovalResolvedNotifier> = invalidation_hub.clone();
+    approval_queue.set_resolved_notifier(approval_notifier);
     let (audit_tx, audit_drops, initial_hash) = setup_audit("gateway", "default", storage).await?;
     let escalation_scheduler = start_escalation_scheduler();
     let db_token = CancellationToken::new();
@@ -445,6 +450,11 @@ pub async fn serve_uds(
             .map_err(|e| format!("failed to load policy: {e:?}"))?
             .with_invalidation_hub(Arc::clone(&invalidation_hub)),
     );
+    // Reuse the push channel for approval notifications: a dashboard verdict
+    // (POST /approvals/{id}/approve|reject → ApprovalQueue::decide) fans out as
+    // an `ApprovalResolved` event so blocked agents need not poll. AAASM-2378.
+    let approval_notifier: Arc<dyn ApprovalResolvedNotifier> = invalidation_hub.clone();
+    approval_queue.set_resolved_notifier(approval_notifier);
     let (audit_tx, audit_drops, initial_hash) = setup_audit("gateway", "default", storage).await?;
     let escalation_scheduler = start_escalation_scheduler();
     let db_token = CancellationToken::new();

--- a/aa-integration-tests/tests/e2e_approval_push.rs
+++ b/aa-integration-tests/tests/e2e_approval_push.rs
@@ -1,0 +1,110 @@
+//! End-to-end: a blocked agent is woken by an `ApprovalResolved` push event
+//! instead of polling (Story AAASM-2378, impl AAASM-2385).
+//!
+//! Wires the production pieces together over a loopback gRPC `InvalidationService`:
+//! the gateway [`InvalidationHub`] is installed as the [`ApprovalQueue`]'s
+//! resolved-notifier, an Assembly-side [`ApprovalSink`] subscribes over the
+//! push channel, and an agent awaits [`ApprovalSink::wait_for_approval`]. When a
+//! human verdict is recorded via [`ApprovalQueue::decide`] — the exact call the
+//! dashboard's `POST /api/v1/approvals/{id}/approve` handler makes (see
+//! `aa-api/src/routes/approvals.rs::approve_action`) — the agent's future
+//! resolves with the reviewer's `Decision`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::net::TcpListener;
+use tonic::transport::Server;
+use uuid::Uuid;
+
+use aa_core::PolicyResult;
+use aa_gateway::invalidation::{InvalidationHub, InvalidationServiceImpl};
+use aa_proto::assembly::gateway::v1::invalidation_service_server::InvalidationServiceServer;
+use aa_proto::assembly::gateway::v1::Decision;
+use aa_runtime::approval::{ApprovalDecision, ApprovalQueue, ApprovalRequest, ApprovalResolvedNotifier};
+use aa_runtime::approval_sink::ApprovalSink;
+use aa_runtime::invalidation_client::{InvalidationClient, InvalidationSink};
+
+/// Build a pending approval request with a long timeout so the queue's own
+/// auto-expiry never races the human verdict under test.
+fn pending_request(request_id: Uuid) -> ApprovalRequest {
+    ApprovalRequest {
+        request_id,
+        agent_id: "agent-approval-push".to_string(),
+        action: "tool.wire_transfer".to_string(),
+        condition_triggered: "AAASM-2378 e2e".to_string(),
+        submitted_at: 1_700_000_000,
+        timeout_secs: 300,
+        fallback: PolicyResult::Deny {
+            reason: "fallback-deny (unused on approve path)".to_string(),
+        },
+        team_id: None,
+        timeout_override_secs: None,
+        escalation_role_override: None,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn approval_push_wakes_blocked_agent() {
+    // Gateway: a hub shared between the InvalidationService and the queue's
+    // resolved-notifier, so a human verdict fans out over the push channel.
+    let hub = InvalidationHub::new();
+    let queue = ApprovalQueue::new();
+    let notifier: Arc<dyn ApprovalResolvedNotifier> = hub.clone();
+    assert!(queue.set_resolved_notifier(notifier), "notifier installs on first call");
+
+    let service = InvalidationServiceImpl::new(Arc::clone(&hub));
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind gateway");
+    let addr = listener.local_addr().expect("local_addr");
+    let server = tokio::spawn(async move {
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(InvalidationServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .expect("tonic Server::serve_with_incoming");
+    });
+    let gateway_url = format!("http://{addr}");
+
+    // Assembly: an ApprovalSink subscribes to the push channel.
+    let sink = Arc::new(ApprovalSink::new());
+    let dyn_sink: Arc<dyn InvalidationSink> = Arc::clone(&sink) as Arc<dyn InvalidationSink>;
+    let client = InvalidationClient::start(gateway_url, "asm-approval".to_string(), vec![dyn_sink]);
+
+    // Wait until the subscription is live so the broadcast actually reaches it.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while hub.subscriber_count() == 0 {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("assembly subscribed");
+
+    // The agent submits its action for approval and blocks on the push future
+    // (registered synchronously, before any verdict can race in).
+    let request_id = Uuid::new_v4();
+    let (id, _local_future) = queue.submit(pending_request(request_id));
+    let waiter = sink.wait_for_approval(id.to_string(), Duration::from_secs(5));
+
+    // The human approves via the dashboard → REST → ApprovalQueue::decide.
+    queue
+        .decide(
+            id,
+            ApprovalDecision::Approved {
+                by: "ops-1".to_string(),
+                reason: Some("approved by e2e".to_string()),
+            },
+        )
+        .expect("decide on a pending request succeeds");
+
+    // The blocked agent is woken with the reviewer's verdict over the push
+    // channel — no polling.
+    let decision = tokio::time::timeout(Duration::from_secs(2), waiter)
+        .await
+        .expect("agent woken by ApprovalResolved push within deadline");
+    assert_eq!(decision, Decision::Approved);
+    assert_eq!(sink.waiter_count(), 0, "delivered waiter is cleared");
+
+    client.abort();
+    server.abort();
+}

--- a/aa-runtime/src/approval.rs
+++ b/aa-runtime/src/approval.rs
@@ -7,7 +7,7 @@
 
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex as StdMutex};
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use std::time::SystemTime;
 
 use dashmap::DashMap;
@@ -244,6 +244,25 @@ impl std::fmt::Display for ApprovalError {
 impl std::error::Error for ApprovalError {}
 
 // ---------------------------------------------------------------------------
+// ApprovalResolvedNotifier
+// ---------------------------------------------------------------------------
+
+/// Sink notified the instant a human reviewer settles an approval request, so a
+/// blocked agent can be woken over a push channel instead of polling.
+///
+/// The gateway's invalidation hub implements this (see
+/// `aa-gateway/src/invalidation/hub.rs`) to fan an `ApprovalResolved` event out
+/// to subscribed Assemblies. Wired into an [`ApprovalQueue`] via
+/// [`ApprovalQueue::set_resolved_notifier`]; the queue invokes it from
+/// [`decide`](ApprovalQueue::decide) on every human verdict. The implementor
+/// decides which decisions to forward — timeouts are reported here too but the
+/// gateway only broadcasts genuine human verdicts (spec line 7699 / AAASM-2378).
+pub trait ApprovalResolvedNotifier: Send + Sync {
+    /// Called after `request_id` is resolved with `decision`.
+    fn notify_resolved(&self, request_id: &str, decision: &ApprovalDecision);
+}
+
+// ---------------------------------------------------------------------------
 // ApprovalQueue
 // ---------------------------------------------------------------------------
 
@@ -275,6 +294,12 @@ pub struct ApprovalQueue {
     /// Separate from `event_tx` so subscribers can distinguish submission
     /// from expiry without inspecting payload contents. AAASM-1453.
     expiry_event_tx: broadcast::Sender<ApprovalRequest>,
+    /// Optional push sink notified on every resolution (AAASM-2378). When set
+    /// (via [`set_resolved_notifier`](Self::set_resolved_notifier)), the gateway
+    /// fans an `ApprovalResolved` event out to blocked Assemblies so they need
+    /// not poll. `OnceLock` keeps the resolve hot path lock-free; the notifier
+    /// is installed once at startup.
+    resolved_notifier: OnceLock<Arc<dyn ApprovalResolvedNotifier>>,
 }
 
 /// Hash a string into a 16-byte identifier using SHA-256 truncation.
@@ -300,6 +325,7 @@ impl ApprovalQueue {
             audit_last_hash: Mutex::new([0u8; 32]),
             event_tx,
             expiry_event_tx,
+            resolved_notifier: OnceLock::new(),
         })
     }
 
@@ -320,6 +346,7 @@ impl ApprovalQueue {
             audit_last_hash: Mutex::new([0u8; 32]),
             event_tx,
             expiry_event_tx,
+            resolved_notifier: OnceLock::new(),
         })
     }
 
@@ -340,7 +367,18 @@ impl ApprovalQueue {
             audit_last_hash: Mutex::new(initial_hash),
             event_tx,
             expiry_event_tx,
+            resolved_notifier: OnceLock::new(),
         })
+    }
+
+    /// Install the push sink notified on every resolution (AAASM-2378).
+    ///
+    /// Wires the queue to the gateway's invalidation hub so a human verdict is
+    /// fanned out to blocked Assemblies as an `ApprovalResolved` event. Idempotent
+    /// per queue: the first call wins and later calls are ignored (the notifier
+    /// is installed once at startup). Returns `true` if this call installed it.
+    pub fn set_resolved_notifier(&self, notifier: Arc<dyn ApprovalResolvedNotifier>) -> bool {
+        self.resolved_notifier.set(notifier).is_ok()
     }
 
     /// Subscribe to approval request events.
@@ -656,6 +694,14 @@ impl ApprovalQueue {
             // AAASM-1453.
             if matches!(decision, ApprovalDecision::TimedOut { .. }) {
                 let _ = self.expiry_event_tx.send(req.clone());
+            }
+
+            // Wake any push subscriber (a blocked agent awaiting over the
+            // invalidation channel) before settling the local oneshot. The
+            // gateway hub forwards only genuine human verdicts as
+            // `ApprovalResolved`; timeouts are ignored there. AAASM-2378.
+            if let Some(notifier) = self.resolved_notifier.get() {
+                notifier.notify_resolved(&req.request_id.to_string(), &decision);
             }
 
             // Ignore send errors: the receiver may have been dropped (caller

--- a/aa-runtime/src/approval_sink.rs
+++ b/aa-runtime/src/approval_sink.rs
@@ -102,3 +102,47 @@ impl InvalidationSink for ApprovalSink {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn wait_resolves_when_event_arrives() {
+        let sink = ApprovalSink::new();
+        let fut = sink.wait_for_approval("r1", Duration::from_secs(5));
+        assert_eq!(sink.waiter_count(), 1);
+
+        sink.on_approval_resolved("r1", Decision::Approved);
+
+        assert_eq!(fut.await, Decision::Approved);
+        assert_eq!(sink.waiter_count(), 0, "delivered waiter is removed");
+    }
+
+    #[tokio::test]
+    async fn wait_resolves_with_denied_verdict() {
+        let sink = ApprovalSink::new();
+        let fut = sink.wait_for_approval("r1", Duration::from_secs(5));
+
+        sink.on_approval_resolved("r1", Decision::Denied);
+
+        assert_eq!(fut.await, Decision::Denied);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn wait_times_out_to_pending_not_denied() {
+        let sink = ApprovalSink::new();
+
+        let decision = sink.wait_for_approval("r1", Duration::from_millis(50)).await;
+
+        assert_eq!(decision, Decision::Pending, "timeout must not auto-deny");
+        assert_eq!(sink.waiter_count(), 0, "timed-out waiter is dropped");
+    }
+
+    #[tokio::test]
+    async fn event_without_waiter_is_dropped() {
+        let sink = ApprovalSink::new();
+        sink.on_approval_resolved("ghost", Decision::Approved);
+        assert_eq!(sink.waiter_count(), 0);
+    }
+}

--- a/aa-runtime/src/approval_sink.rs
+++ b/aa-runtime/src/approval_sink.rs
@@ -1,0 +1,104 @@
+//! Assembly-side waiter registry for `ApprovalResolved` push events
+//! (Story AAASM-2378).
+//!
+//! An agent blocked on a human approval calls [`ApprovalSink::wait_for_approval`]
+//! and awaits the returned future instead of polling the gateway. The
+//! [`ApprovalSink`] is registered as an
+//! [`InvalidationSink`](crate::invalidation_client::InvalidationSink) on the
+//! [`InvalidationClient`](crate::invalidation_client::InvalidationClient); when
+//! the gateway pushes an `ApprovalResolved` event for a request the agent is
+//! waiting on, the matching future resolves with the reviewer's [`Decision`].
+//!
+//! This reuses the existing L1 push-invalidation channel for a second event
+//! type — one stream, two consumers (spec line 7699).
+
+use std::future::Future;
+use std::sync::Arc;
+use std::time::Duration;
+
+use dashmap::DashMap;
+use tokio::sync::oneshot;
+
+use aa_proto::assembly::gateway::v1::Decision;
+
+use crate::invalidation_client::InvalidationSink;
+
+/// Registry of in-flight approval waiters keyed by `request_id`.
+///
+/// Holds one [`oneshot::Sender`] per outstanding
+/// [`wait_for_approval`](ApprovalSink::wait_for_approval) call. An incoming
+/// `ApprovalResolved` event removes the matching sender and delivers the
+/// [`Decision`], waking the awaiting future. Cheap to clone behind an `Arc`;
+/// the waiter map is shared so the [`InvalidationClient`](crate::invalidation_client::InvalidationClient)
+/// task and the awaiting agent see the same registrations.
+#[derive(Default)]
+pub struct ApprovalSink {
+    waiters: Arc<DashMap<String, oneshot::Sender<Decision>>>,
+}
+
+impl ApprovalSink {
+    /// Create an empty sink.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of approval requests currently being awaited. Primarily for
+    /// tests and metrics.
+    pub fn waiter_count(&self) -> usize {
+        self.waiters.len()
+    }
+
+    /// Subscribe to the verdict for `request_id`, returning a future that
+    /// resolves when the gateway pushes the matching `ApprovalResolved` event
+    /// or `deadline` elapses — whichever happens first.
+    ///
+    /// The waiter is registered **synchronously** on call (before the returned
+    /// future is first polled), so a verdict that races in immediately after
+    /// this returns is not lost.
+    ///
+    /// # Timeout
+    ///
+    /// On `deadline` expiry the future resolves to [`Decision::Pending`] —
+    /// **not** [`Decision::Denied`]. Callers MUST treat `Pending` as "no human
+    /// response arrived, decide locally" (e.g. apply the policy's configured
+    /// timeout fallback); it is never an implicit denial. AAASM-2378.
+    pub fn wait_for_approval(
+        &self,
+        request_id: impl Into<String>,
+        deadline: Duration,
+    ) -> impl Future<Output = Decision> {
+        let request_id = request_id.into();
+        let (tx, rx) = oneshot::channel();
+        self.waiters.insert(request_id.clone(), tx);
+        let waiters = Arc::clone(&self.waiters);
+        async move {
+            match tokio::time::timeout(deadline, rx).await {
+                // Verdict pushed before the deadline.
+                Ok(Ok(decision)) => decision,
+                // Sender dropped without a verdict (e.g. the sink was dropped) —
+                // treat as "no human response".
+                Ok(Err(_)) => Decision::Pending,
+                // Deadline elapsed: drop our registration and report Pending so
+                // the caller falls back to a local decision.
+                Err(_) => {
+                    waiters.remove(&request_id);
+                    Decision::Pending
+                }
+            }
+        }
+    }
+}
+
+impl InvalidationSink for ApprovalSink {
+    /// Approval waiters do not care about policy invalidations.
+    fn on_policy_invalidated(&self, _agent_id: &str) {}
+
+    /// Deliver `decision` to the waiter registered for `request_id`, if any.
+    /// An event with no matching waiter (already resolved, timed out, or never
+    /// registered) is dropped.
+    fn on_approval_resolved(&self, request_id: &str, decision: Decision) {
+        if let Some((_id, tx)) = self.waiters.remove(request_id) {
+            let _ = tx.send(decision);
+        }
+    }
+}

--- a/aa-runtime/src/invalidation_client.rs
+++ b/aa-runtime/src/invalidation_client.rs
@@ -14,7 +14,7 @@ use tokio::task::JoinHandle;
 
 use aa_proto::assembly::gateway::v1::invalidation_event::Payload;
 use aa_proto::assembly::gateway::v1::invalidation_service_client::InvalidationServiceClient;
-use aa_proto::assembly::gateway::v1::{subscribe_request::Kind, SubscribeInitial, SubscribeRequest};
+use aa_proto::assembly::gateway::v1::{subscribe_request::Kind, Decision, SubscribeInitial, SubscribeRequest};
 
 /// First reconnect delay; doubles on each consecutive failure.
 const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
@@ -29,6 +29,15 @@ const MAX_BACKOFF: Duration = Duration::from_secs(32);
 pub trait InvalidationSink: Send + Sync {
     /// Apply a policy invalidation for `agent_id` (empty = invalidate all).
     fn on_policy_invalidated(&self, agent_id: &str);
+
+    /// Deliver a human reviewer's verdict for the approval request
+    /// `request_id` to a blocked waiter. The default is a no-op so that
+    /// policy-only sinks (e.g. the L1 cache) need not care about the
+    /// approval-reuse half of the channel; the [`crate::approval_sink::ApprovalSink`]
+    /// overrides it to wake the matching `wait_for_approval` future. AAASM-2378.
+    fn on_approval_resolved(&self, request_id: &str, decision: Decision) {
+        let _ = (request_id, decision);
+    }
 }
 
 /// Next reconnect delay: double the current one, capped at [`MAX_BACKOFF`].
@@ -97,10 +106,19 @@ async fn subscribe_once(
 
     while let Some(event) = inbound.message().await? {
         let applied_at = Instant::now();
-        if let Some(Payload::PolicyInvalidated(policy)) = &event.payload {
-            for sink in sinks {
-                sink.on_policy_invalidated(&policy.agent_id);
+        match &event.payload {
+            Some(Payload::PolicyInvalidated(policy)) => {
+                for sink in sinks {
+                    sink.on_policy_invalidated(&policy.agent_id);
+                }
             }
+            Some(Payload::ApprovalResolved(approval)) => {
+                let decision = approval.decision();
+                for sink in sinks {
+                    sink.on_approval_resolved(&approval.request_id, decision);
+                }
+            }
+            None => {}
         }
         if event.seq > *last_seq_seen {
             *last_seq_seen = event.seq;

--- a/aa-runtime/src/lib.rs
+++ b/aa-runtime/src/lib.rs
@@ -5,6 +5,7 @@
 //! coordination, and lifecycle hooks.
 
 pub mod approval;
+pub mod approval_sink;
 pub mod config;
 pub mod correlation;
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Description

Reuses the existing L1 push-invalidation gRPC channel (AAASM-2377) to also
deliver **human approval verdicts** to blocked agents, so an agent waiting on
an approval subscribes for a push instead of polling — "one stream, two
consumers" (spec line 7699).

The wire contract was already shipped by AAASM-2377 (`proto/invalidation.proto`
defines `ApprovalResolved { request_id, decision }`, the `Decision` enum, and
the `approval_resolved` variant of the `InvalidationEvent` oneof), so this PR is
pure wiring:

- **Gateway** — `InvalidationHub::broadcast_approval_resolved` (factored a shared
  `fan_out` helper) and an `ApprovalResolvedNotifier` impl for the hub. The
  notifier is installed on the production `ApprovalQueue` in `serve_tcp`/`serve_uds`,
  so a dashboard verdict (`POST /api/v1/approvals/{id}/approve|reject` →
  `ApprovalQueue::decide`) fans an `ApprovalResolved` event out to subscribers.
  Timeouts are **not** a human verdict and are not broadcast.
- **Assembly runtime** — `InvalidationSink::on_approval_resolved` (default no-op)
  + dispatch in the subscribe loop; a new `ApprovalSink` holding a
  `DashMap<request_id, oneshot::Sender<Decision>>` exposing
  `wait_for_approval(request_id, deadline) -> Future<Decision>`. On deadline the
  future resolves to `Decision::Pending` (never `Denied`) — callers decide locally.

### Design note

The existing e2e harness (`TopologyTestEnv`) is REST-only and does not serve the
gRPC `InvalidationService`. Rather than thread `Arc<InvalidationHub>` through
`AppState` (~8 literal sites + teaching the harness gRPC), the broadcast is wired
at `ApprovalQueue::decide` — the single choke point every approval-decision path
funnels through — via a small `ApprovalResolvedNotifier` trait (defined in
`aa-runtime`, implemented for `InvalidationHub` in `aa-gateway`). No `AppState`
churn; the dashboard→REST→decide path emits the push faithfully.

## Type of Change

- [x] ✨ New feature
- [x] ♻️ Refactoring (extract `fan_out` helper)

## Breaking Changes

- [x] No

(`InvalidationSink::on_approval_resolved` is a default method; existing impls are
unaffected. New `ApprovalQueue` notifier is opt-in and off by default.)

## Related Issues

- Related Jira ticket: AAASM-2385 (Story AAASM-2378, Epic AAASM-2349)

## Testing

- [x] Unit tests added / updated — `ApprovalSink` (resolve / denied / timeout→Pending /
  no-waiter) and the hub fan-out test.
- [x] Integration tests added / updated — `e2e_approval_push`: a human verdict via
  `ApprovalQueue::decide` wakes a subscribed agent's `wait_for_approval` over the
  loopback gRPC channel with `Approved`.

```
cargo nextest run -p aa-runtime approval_sink::          # 4 passed
cargo nextest run -p aa-gateway invalidation::hub::      # incl. approval fan-out
cargo nextest run -p aa-integration-tests --test e2e_approval_push  # 1 passed
```

The timeout e2e (`Pending`) + full AC verification report ship under the
verification Subtask **AAASM-2386** (stacked PR).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc note: callers MUST treat
  `Pending` as "no human response, decide locally")
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
