### PR TITLE
[AAASM-2386] ✅ (aa-integration-tests): Verify approval-push acceptance criteria

### DIFF
--- a/aa-integration-tests/tests/e2e_approval_push_timeout.rs
+++ b/aa-integration-tests/tests/e2e_approval_push_timeout.rs
@@ -1,0 +1,69 @@
+//! End-to-end verification of the approval-push timeout policy
+//! (Story AAASM-2378, verification AAASM-2386).
+//!
+//! An agent subscribes to the push channel and awaits a verdict that never
+//! arrives. When the caller-specified deadline elapses, the future must resolve
+//! to [`Decision::Pending`] — **not** `Denied`: a timeout is "no human response,
+//! decide locally", never an implicit denial. This complements the happy-path
+//! `e2e_approval_push` test (impl AAASM-2385) which covers the approve path.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::net::TcpListener;
+use tonic::transport::Server;
+
+use aa_gateway::invalidation::{InvalidationHub, InvalidationServiceImpl};
+use aa_proto::assembly::gateway::v1::invalidation_service_server::InvalidationServiceServer;
+use aa_proto::assembly::gateway::v1::Decision;
+use aa_runtime::approval_sink::ApprovalSink;
+use aa_runtime::invalidation_client::{InvalidationClient, InvalidationSink};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn approval_push_timeout_resolves_pending_not_denied() {
+    // Gateway push channel on a loopback port (no verdict will ever be sent).
+    let hub = InvalidationHub::new();
+    let service = InvalidationServiceImpl::new(Arc::clone(&hub));
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind gateway");
+    let addr = listener.local_addr().expect("local_addr");
+    let server = tokio::spawn(async move {
+        let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+        Server::builder()
+            .add_service(InvalidationServiceServer::new(service))
+            .serve_with_incoming(incoming)
+            .await
+            .expect("tonic Server::serve_with_incoming");
+    });
+    let gateway_url = format!("http://{addr}");
+
+    // Assembly subscribes to the channel.
+    let sink = Arc::new(ApprovalSink::new());
+    let dyn_sink: Arc<dyn InvalidationSink> = Arc::clone(&sink) as Arc<dyn InvalidationSink>;
+    let client = InvalidationClient::start(gateway_url, "asm-timeout".to_string(), vec![dyn_sink]);
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while hub.subscriber_count() == 0 {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("assembly subscribed");
+
+    // The agent blocks on a verdict with a 100 ms deadline; no human responds.
+    let started = Instant::now();
+    let decision = sink.wait_for_approval("r1", Duration::from_millis(100)).await;
+    let elapsed = started.elapsed();
+
+    // Resolves Pending (the timeout fallback), never Denied, and only after the
+    // deadline — the caller, not the channel, decides what Pending means.
+    assert_eq!(decision, Decision::Pending, "timeout must not auto-deny");
+    assert_ne!(decision, Decision::Denied);
+    assert!(
+        elapsed >= Duration::from_millis(100),
+        "must wait the full deadline before giving up, waited {elapsed:?}"
+    );
+    assert_eq!(sink.waiter_count(), 0, "timed-out waiter is dropped");
+
+    client.abort();
+    server.abort();
+}

--- a/verification-reports/AAASM-2386.md
+++ b/verification-reports/AAASM-2386.md
@@ -1,0 +1,114 @@
+# AAASM-2378 Verification — AAASM-2386 (Approval-result push reuse)
+
+> **Status**: All Story AAASM-2378 acceptance criteria are met. The push
+> channel built in AAASM-2377 now also carries human approval verdicts, so an
+> agent blocked on an approval subscribes for an `ApprovalResolved` event
+> instead of polling. Implementation landed under AAASM-2385 (PR #903); this
+> Subtask adds the timeout end-to-end test and this report. **No Bug Subtask
+> opened.**
+
+## Subtask roll-up
+
+| Subtask | Title | Status | PR |
+|---|---|---|---|
+| AAASM-2385 | Wire ApprovalResolved push event + WaitForApproval future | Done | [#903](https://github.com/AI-agent-assembly/agent-assembly/pull/903) |
+| AAASM-2386 | Verify ApprovalResolved push event acceptance criteria | in this report | — |
+
+## Walkthrough vs AAASM-2378 acceptance criteria
+
+### ✅ Proto adds `ApprovalResolved { request_id, decision }` to the `InvalidationEvent` oneof
+
+Already shipped by the previous Story (AAASM-2377): `proto/invalidation.proto`
+defines the `ApprovalResolved` message (`request_id: string`, `decision: Decision`),
+the `Decision` enum (`DECISION_UNSPECIFIED / APPROVED / DENIED / PENDING`), and
+the `approval_resolved` arm of the `InvalidationEvent` `oneof payload`.
+
+Evidence: [`proto/invalidation.proto:72-111`](../proto/invalidation.proto)
+(generated as `aa_proto::assembly::gateway::v1::{ApprovalResolved, Decision}`).
+
+### ✅ Gateway emits `ApprovalResolved` to subscribed Assemblies when the human responds via the dashboard
+
+The dashboard verdict path is `POST /api/v1/approvals/{id}/approve|reject`
+→ `ApprovalQueue::decide` → `resolve`. On every settled request the queue
+notifies an installed `ApprovalResolvedNotifier`; `InvalidationHub` implements it
+and fans an `ApprovalResolved` event out to subscribers via
+`broadcast_approval_resolved`. A timeout is **not** a human verdict and is **not**
+broadcast (the hub impl returns early for `TimedOut`). The notifier is installed
+on the production queue in both `serve_tcp` and `serve_uds`.
+
+Evidence:
+* `aa-api/src/routes/approvals.rs::approve_action` / `reject_action` → `state.approval_queue.decide(...)`.
+* `aa-runtime/src/approval.rs` — `ApprovalResolvedNotifier`, `set_resolved_notifier`, notify call in `resolve`.
+* `aa-gateway/src/invalidation/hub.rs` — `broadcast_approval_resolved` + `impl ApprovalResolvedNotifier for InvalidationHub`.
+* `aa-gateway/src/server.rs` — `approval_queue.set_resolved_notifier(...)` in `serve_tcp` + `serve_uds`.
+
+Design note: the broadcast is wired at `ApprovalQueue::decide` (the single choke
+point every approval-decision path funnels through) rather than threaded through
+`AppState`, because the REST e2e harness `TopologyTestEnv` is REST-only and does
+not serve the gRPC `InvalidationService` (`aa-integration-tests/tests/common/mod.rs:15`).
+The end-to-end tests drive `ApprovalQueue::decide` directly — the exact call the
+REST handler makes — over a real loopback gRPC channel.
+
+### ✅ Assembly runtime exposes `wait_for_approval(request_id) -> Future<Decision>` that resolves when the matching event arrives
+
+`ApprovalSink` (an `InvalidationSink`) holds a
+`DashMap<request_id, oneshot::Sender<Decision>>`. `wait_for_approval` registers a
+oneshot **synchronously** on call and returns a future that resolves when the
+matching `ApprovalResolved` event is dispatched to `on_approval_resolved`.
+
+Evidence: `aa-runtime/src/approval_sink.rs`; dispatch in
+`aa-runtime/src/invalidation_client.rs::subscribe_once` (the `ApprovalResolved`
+arm). Covered by the happy-path e2e (below) and unit tests
+`wait_resolves_when_event_arrives`, `wait_resolves_with_denied_verdict`.
+
+### ✅ Timeout policy: caller-specified deadline; on timeout the `Future` resolves to `Decision::Pending` (do not auto-deny)
+
+`wait_for_approval` awaits with `tokio::time::timeout(deadline, …)`; on expiry it
+drops its registration and resolves to `Decision::Pending` — never `Denied`. The
+rustdoc states callers MUST treat `Pending` as "no human response, decide locally".
+
+Evidence: `aa-runtime/src/approval_sink.rs::wait_for_approval`; unit test
+`wait_times_out_to_pending_not_denied` (`-p aa-runtime`); end-to-end test
+`approval_push_timeout_resolves_pending_not_denied`
+(`aa-integration-tests/tests/e2e_approval_push_timeout.rs`), which also asserts the
+future does **not** resolve before the 100 ms deadline.
+
+### ✅ Integration test: dashboard approves request; the agent's `wait_for_approval` resolves with `Approved`
+
+`aa-integration-tests/tests/e2e_approval_push.rs::approval_push_wakes_blocked_agent`:
+over a loopback gRPC `InvalidationService`, an `ApprovalSink` subscribes and an
+agent awaits `wait_for_approval`; a verdict via `ApprovalQueue::decide` (the call
+`POST /approvals/{id}/approve` makes) fans out as `ApprovalResolved` and resolves
+the agent's future with `Approved` — no polling.
+
+## Test evidence
+
+```text
+cargo nextest run -p aa-runtime approval_sink::
+    4 passed  (wait_resolves_when_event_arrives, wait_resolves_with_denied_verdict,
+               wait_times_out_to_pending_not_denied, event_without_waiter_is_dropped)
+
+cargo nextest run -p aa-gateway invalidation::hub::
+    incl. broadcast_approval_resolved_reaches_subscriber — passed
+
+cargo nextest run -p aa-integration-tests --test e2e_approval_push --test e2e_approval_push_timeout
+    approval_push_wakes_blocked_agent                  PASS
+    approval_push_timeout_resolves_pending_not_denied  PASS
+```
+
+Local quality gates green on the AAASM-2385 branch: `cargo fmt --all -- --check`,
+`cargo clippy --all-targets --all-features -- -D warnings`, `cargo deny check`,
+`cargo doc --workspace --no-deps`.
+
+## Out-of-scope confirmations (per Story)
+
+* Approval **workflow business logic** — untouched; only the resolution → push
+  wiring was added.
+* Approval **persistence** — unchanged (the in-memory `ApprovalQueue` resolved
+  history is pre-existing).
+* **Dashboard UI** for emitting approvals — untouched; the existing REST surface
+  is reused.
+
+## Conclusion
+
+All five acceptance criteria pass. No defects found; **no Bug Subtask filed**.


### PR DESCRIPTION
## Description

Verification Subtask for Story **AAASM-2378** (approval-result push reuse). Adds
the timeout end-to-end test and a written report walking each acceptance
criterion to its implementation + test evidence. The implementation ships in the
parent Subtask **AAASM-2385** (PR #903); this PR is **stacked on that branch** —
its own changes are the last two commits (timeout e2e + report). Merge after #903.

- **Timeout e2e** — `e2e_approval_push_timeout.rs`: an agent subscribes and awaits
  a verdict that never arrives; on the 100 ms deadline `wait_for_approval` resolves
  to `Decision::Pending` (asserted **not** `Denied`) and only **after** the deadline.
- **Report** — `verification-reports/AAASM-2386.md`: all five ACs pass; **no Bug
  Subtask filed**.

## Type of Change

- [x] ✅ Tests
- [x] 📝 Documentation update (verification report)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2386 (verifies Story AAASM-2378; depends on AAASM-2385 / PR #903)

## Testing

- [x] Integration tests added / updated

```
cargo nextest run -p aa-runtime approval_sink::                       # 4 passed
cargo nextest run -p aa-gateway invalidation::hub::                   # 5 passed
cargo nextest run -p aa-integration-tests --test e2e_approval_push \
                                          --test e2e_approval_push_timeout  # 2 passed
```

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

> **Note:** this is a stacked PR; the diff currently includes AAASM-2385's commits
> and will narrow to its own two commits once #903 merges into `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
