### PR TITLE
[AAASM-2392] ✅ (aa-runtime): Verify AuditPublisher AC with NATS reconnect integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
+ "testcontainers-modules",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -50,6 +50,9 @@ tower = { version = "0.5", features = ["util"] }
 # Captures emitted metric values so the audit-publisher metric tests can assert
 # the exact counter values recorded by `metrics::counter!`.
 metrics-util = { version = "0.20", features = ["debugging"] }
+# Real NATS server for the audit-publisher reconnect integration test. Requires
+# Docker; re-exports the `testcontainers` core runner.
+testcontainers-modules = { version = "0.15", features = ["nats"] }
 
 [lints]
 workspace = true

--- a/aa-runtime/tests/audit_publisher_nats.rs
+++ b/aa-runtime/tests/audit_publisher_nats.rs
@@ -1,0 +1,168 @@
+//! Reconnect integration test for the Assembly-side audit publisher
+//! (AAASM-2392, verifying AAASM-2387).
+//!
+//! Runs against a real NATS server via `testcontainers-modules`, so it requires
+//! Docker. The test proves the AAASM-2387 acceptance criteria end-to-end:
+//! events publish over `async-nats` while the server is up, divert to the
+//! SQLite buffer during an outage, and replay in FIFO order once the server
+//! returns — with nothing lost across the restart.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use aa_core::audit::{AuditEntry, AuditEventType};
+use aa_core::{AgentId, SessionId};
+use aa_runtime::audit_publisher::{AuditPublisher, NatsAuditSink, NatsConfig};
+use aa_storage_sqlite_buffer::EventBuffer;
+use tempfile::TempDir;
+use testcontainers_modules::nats::Nats;
+use testcontainers_modules::testcontainers::core::IntoContainerPort;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use testcontainers_modules::testcontainers::{ContainerAsync, ImageExt};
+use tokio_stream::StreamExt;
+
+/// Reserve an ephemeral host port, then release it so a container can bind it.
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local addr")
+        .port()
+}
+
+/// Start a NATS container with its client port pinned to `host_port`, so a
+/// restart is reachable at the same address the publisher already knows.
+async fn start_nats(host_port: u16) -> ContainerAsync<Nats> {
+    Nats::default()
+        .with_mapped_port(host_port, 4222.tcp())
+        .start()
+        .await
+        .expect("start nats testcontainer (is Docker running?)")
+}
+
+/// Build a distinct audit entry tagged with `seq`.
+fn entry(seq: u64) -> AuditEntry {
+    AuditEntry::new(
+        seq,
+        seq,
+        AuditEventType::ToolCallIntercepted,
+        AgentId::from_bytes([7u8; 16]),
+        SessionId::from_bytes([9u8; 16]),
+        format!("{{\"seq\":{seq}}}"),
+        [0u8; 32],
+    )
+}
+
+/// Subscribe a fresh client to every audit subject. The client is returned
+/// alongside the subscription so it outlives the borrow.
+async fn subscribe(url: &str) -> (async_nats::Client, async_nats::Subscriber) {
+    let client = async_nats::connect(url).await.expect("subscriber connect");
+    let sub = client
+        .subscribe("assembly.audit.>")
+        .await
+        .expect("subscribe to audit subjects");
+    (client, sub)
+}
+
+/// Collect up to `n` decoded `seq` values from `sub`, stopping early on timeout.
+async fn collect_seqs(sub: &mut async_nats::Subscriber, n: usize, timeout: Duration) -> Vec<u64> {
+    let mut seqs = Vec::with_capacity(n);
+    let deadline = Instant::now() + timeout;
+    while seqs.len() < n {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, sub.next()).await {
+            Ok(Some(msg)) => {
+                let decoded: AuditEntry = serde_json::from_slice(&msg.payload).expect("decode audit entry");
+                seqs.push(decoded.seq());
+            }
+            _ => break,
+        }
+    }
+    seqs
+}
+
+/// Poll the sink's connection state until it matches `want` or the timeout
+/// elapses; returns whether the desired state was reached.
+async fn wait_for_connection(sink: &NatsAuditSink, want: bool, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if sink.is_connected() == want {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    sink.is_connected() == want
+}
+
+#[tokio::test]
+async fn buffers_during_outage_and_replays_all_on_reconnect() {
+    let host_port = free_port();
+    let url = format!("nats://127.0.0.1:{host_port}");
+    let tmp = TempDir::new().expect("temp dir");
+    let buffer = Arc::new(EventBuffer::new(tmp.path().join("buffer.db"), 100_000).expect("open buffer"));
+
+    // --- Phase 1: NATS up — publish 1000 events, all delivered. ---
+    let nats1 = start_nats(host_port).await;
+    let sink = Arc::new(
+        NatsAuditSink::connect(&NatsConfig {
+            url: url.clone(),
+            ..Default::default()
+        })
+        .await
+        .expect("connect publisher"),
+    );
+    let publisher = AuditPublisher::new(sink.clone(), buffer.clone());
+    assert!(wait_for_connection(&sink, true, Duration::from_secs(10)).await);
+
+    let (_sub_client1, mut sub1) = subscribe(&url).await;
+    for seq in 0..1000 {
+        publisher.publish(entry(seq)).await;
+    }
+    let got1 = collect_seqs(&mut sub1, 1000, Duration::from_secs(30)).await;
+    assert_eq!(got1.len(), 1000, "all 1000 events delivered while NATS is up");
+    assert_eq!(publisher.buffered_len().unwrap(), 0, "nothing buffered while up");
+
+    // --- Phase 2: NATS down — publish 100 more, all buffered, never blocking. ---
+    nats1.rm().await.expect("remove nats1");
+    assert!(
+        wait_for_connection(&sink, false, Duration::from_secs(30)).await,
+        "publisher should observe the disconnect"
+    );
+    for seq in 1000..1100 {
+        publisher.publish(entry(seq)).await;
+    }
+    assert_eq!(
+        publisher.buffered_len().unwrap(),
+        100,
+        "all 100 events buffered during the outage"
+    );
+
+    // --- Phase 3: NATS restarts on the same port — reconnect, flush in FIFO. ---
+    let _nats2 = start_nats(host_port).await;
+    assert!(
+        wait_for_connection(&sink, true, Duration::from_secs(60)).await,
+        "publisher should reconnect to the restarted server"
+    );
+    let (_sub_client2, mut sub2) = subscribe(&url).await;
+
+    let flushed = publisher.flush_pending().await.expect("flush buffered events");
+    assert_eq!(flushed, 100, "all buffered events flushed on reconnect");
+    assert_eq!(publisher.buffered_len().unwrap(), 0, "buffer fully drained");
+
+    let got2 = collect_seqs(&mut sub2, 100, Duration::from_secs(30)).await;
+    assert_eq!(
+        got2,
+        (1000..1100).collect::<Vec<u64>>(),
+        "buffered events replayed in FIFO order"
+    );
+
+    // 1000 (pre-outage) + 100 (replayed) = 1100 events land across the restart.
+    assert_eq!(
+        got1.len() + got2.len(),
+        1100,
+        "zero acked events lost across the restart"
+    );
+}

--- a/aa-runtime/tests/audit_publisher_nats.rs
+++ b/aa-runtime/tests/audit_publisher_nats.rs
@@ -55,12 +55,17 @@ fn entry(seq: u64) -> AuditEntry {
 
 /// Subscribe a fresh client to every audit subject. The client is returned
 /// alongside the subscription so it outlives the borrow.
+///
+/// Flushes after subscribing so the `SUB` is registered server-side before the
+/// caller starts publishing — otherwise early messages can race ahead of the
+/// subscription and be missed.
 async fn subscribe(url: &str) -> (async_nats::Client, async_nats::Subscriber) {
     let client = async_nats::connect(url).await.expect("subscriber connect");
     let sub = client
         .subscribe("assembly.audit.>")
         .await
         .expect("subscribe to audit subjects");
+    client.flush().await.expect("flush subscription to server");
     (client, sub)
 }
 

--- a/verification-reports/AAASM-2392.md
+++ b/verification-reports/AAASM-2392.md
@@ -1,0 +1,51 @@
+# AAASM-2392 — AuditPublisher + SQLite-buffer fallback acceptance verification
+
+**Story:** AAASM-2387 — *As an Assembly runtime, I want to publish audit events to NATS so the agent critical path doesn't wait on the gateway*
+**Epic:** AAASM-2350 — *Async event production + Gateway NATS consumer (Phase 1)*
+**Implementation:** AAASM-2391 (PR #902)
+**Verified against:** `aa-runtime` @ branch `v0.0.1/AAASM-2392/test/verify_audit_publisher` (stacked on the AAASM-2391 branch)
+
+## Scope note
+
+The Story description names crate `aa-assembly`; no such crate exists in the
+workspace. The Assembly runtime is **`aa-runtime`**, so the publisher lives at
+`aa-runtime/src/audit_publisher/` and is verified with `-p aa-runtime`. The
+ticket's `aasm metrics` check is covered by the metric-snapshot unit test.
+
+## Acceptance criteria
+
+| # | Criterion (AAASM-2387 / 2392) | Status | Evidence |
+|---|---|---|---|
+| 1 | `AuditPublisher` wraps the `async-nats` client; subject `assembly.audit.<tenant>.<agent>` | ✅ | `NatsAuditSink` wraps `async_nats::Client`; `subject::subject_for` builds the subject. Unit tests `audit_publisher::subject::tests::*` (default tenant + agent UUID, org priority + sanitization, team fallback). Live subjects observed by the integration test's `assembly.audit.>` subscriber. |
+| 2 | TLS + token auth configurable via `[gateway.nats]` in `agent-assembly.toml` | ✅ | `NatsConfig`/`NatsTlsConfig` + `from_toml_str`; `connect_options` applies `token`, `require_tls`, root + client certs. Unit tests `config::tests::parses_full_gateway_nats_table` (url + token + tls.{ca,cert,key} + max_inflight) and `falls_back_to_defaults_when_table_absent`. |
+| 3 | NATS down → events go to the SQLite buffer; never blocks the agent | ✅ | `AuditPublisher::publish` is fire-and-forget and returns `()`; on sink error it `buffer.enqueue`s. Unit test `publisher::tests::buffers_when_sink_down`; integration test buffers 100 events during a real server outage (`buffered_len() == 100`). |
+| 4 | On reconnect, the buffer flushes in FIFO order | ✅ | `flush_pending` → `EventBuffer::drain_and_send`; `spawn_reconnect_flush_loop` runs it on an interval. Unit test `publisher::tests::reconnect_drains_buffer_in_fifo_order`; integration test replays the 100 buffered events as `seq 1000..1100` **in order** after a same-port restart. |
+| 5 | Metrics `aa_audit_published_total`, `aa_audit_publish_errors_total`, `aa_audit_buffered_total` (+ `aa_audit_flushed_total`) | ✅ | Constants in `audit_publisher/mod.rs`; emitted in `publish`/`flush_pending`. Unit test `publisher::tests::records_all_four_audit_metrics` asserts all four names present via a scoped `DebuggingRecorder`. |
+
+## How it was run
+
+### Unit + doc tests
+```
+cargo nextest run -p aa-runtime          # 239 passed, 2 skipped
+cargo test -p aa-runtime --doc           # 1 passed (NatsConfig example)
+cargo clippy -p aa-runtime --all-targets --all-features -- -D warnings   # clean
+cargo deny check                         # advisories/bans/licenses/sources ok
+```
+
+### Reconnect integration test (Docker required)
+```
+cargo test -p aa-runtime --test audit_publisher_nats -- --nocapture
+# test result: ok. 1 passed; finished in 227.30s
+```
+
+`tests/audit_publisher_nats.rs::buffers_during_outage_and_replays_all_on_reconnect`
+exercises the end-to-end path against a real `nats:2.10` container:
+
+1. **Up** — publish 1000 events; a `assembly.audit.>` subscriber receives all 1000; buffer empty.
+2. **Down** — stop the container; the publisher observes the disconnect; publish 100 more → all 100 land in the SQLite buffer (publish never errors).
+3. **Restart** — start NATS again on the **same mapped host port**; the client auto-reconnects; `flush_pending` drains all 100; a fresh subscriber receives them as `seq 1000..1100` in FIFO order.
+4. **Total** — 1000 + 100 = **1100** events delivered across the restart; zero acked events lost.
+
+## Result
+
+**All five acceptance criteria pass.** No bugs found; no Bug Subtask filed.


### PR DESCRIPTION
## Description

Verification subtask for Story AAASM-2387 — proves the **`AuditPublisher`** (shipped in AAASM-2391, PR #902) meets every acceptance criterion.

> **Stacked on #902.** This branch is cut from the AAASM-2391 branch, so the diff includes its commits until #902 merges; the AAASM-2392-specific additions are the last three commits (testcontainers dev-dep, the integration test, and this report). Base branch is `master`.

Adds an end-to-end **NATS reconnect integration test** (`aa-runtime/tests/audit_publisher_nats.rs`) against a real `nats:2.10` container via `testcontainers-modules`, plus a verification report at `verification-reports/AAASM-2392.md`.

The test pins the NATS client port to a fixed host port so a restart is reachable at the same address, then:

1. **Up** — publish 1000 events; a `assembly.audit.>` subscriber receives all 1000; buffer empty.
2. **Down** — stop the container; the publisher observes the disconnect; publish 100 more → all buffered (`publish` never errors).
3. **Restart** — start NATS on the same port; the client auto-reconnects; `flush_pending` drains all 100 and a fresh subscriber receives them as `seq 1000..1100` in FIFO order.
4. **Total** — 1000 + 100 = **1100** delivered across the restart; zero acked events lost.

## Type of Change

- [x] ✅ Tests / verification

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2392 (verifies AAASM-2387, Epic AAASM-2350)

## Testing

- [x] Integration tests added / updated

```
cargo nextest run -p aa-runtime                                   # 239 passed
cargo test -p aa-runtime --doc                                    # 1 passed
cargo test -p aa-runtime --test audit_publisher_nats -- --nocapture
#   test result: ok. 1 passed; finished in 227.30s   (real Docker NATS)
cargo clippy -p aa-runtime --all-targets --all-features -- -D warnings   # clean
cargo deny check                                                  # clean
```

All five acceptance criteria pass; no Bug Subtask required.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
