### PR TITLE
[AAASM-2544] ✨ (invalidation): Wire HTTP policy mutation to InvalidationHub (shared-hub e2e)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,6 +42,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
+ "tonic",
  "tower",
  "tower-http",
  "tracing",

--- a/aa-api/Cargo.toml
+++ b/aa-api/Cargo.toml
@@ -62,6 +62,7 @@ serde_json = "1"
 sha2 = "0.11"
 tempfile = "3"
 tokio-tungstenite = "0.29"
+tonic = { version = "0.14", features = ["transport"] }
 tower = { version = "0.5", features = ["util"] }
 
 [lints]

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -71,7 +71,15 @@ spec:
 
     let events = Arc::new(EventBroadcast::default());
     let budget_alert_tx = events.budget_sender();
-    let policy_engine = Arc::new(PolicyEngine::load_from_file(&policy_path, budget_alert_tx).unwrap());
+    // Attach a push-invalidation hub so a policy mutation through the HTTP
+    // create_policy route (-> apply_yaml) broadcasts PolicyInvalidated. Tests
+    // that need the hub retrieve it via `policy_engine.invalidation_hub()`;
+    // with no subscribers the broadcast is a harmless no-op (AAASM-2544).
+    let policy_engine = Arc::new(
+        PolicyEngine::load_from_file(&policy_path, budget_alert_tx)
+            .unwrap()
+            .with_invalidation_hub(aa_gateway::invalidation::InvalidationHub::new()),
+    );
     let budget_tracker = Arc::new(BudgetTracker::new(
         PricingTable::default_table(),
         None,

--- a/aa-api/tests/http_policy_invalidation.rs
+++ b/aa-api/tests/http_policy_invalidation.rs
@@ -1,0 +1,96 @@
+//! End-to-end: an HTTP policy mutation drives the push-invalidation channel
+//! (Story AAASM-2377, follow-up AAASM-2544).
+//!
+//! Proves the production wiring contract: when the aa-api `create_policy` HTTP
+//! handler and the gateway `InvalidationService` share ONE hub-attached
+//! `PolicyEngine`, a real `POST /api/v1/policies` causes a subscribed Assembly's
+//! L1 cache to be invalidated within 100 ms — with no direct `apply_yaml`/hub
+//! call in the test. The composition root (which shares the hub) is the only
+//! thing a real deployment must provide; this test stands it up in-process.
+
+mod common;
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tonic::transport::Server;
+use tower::ServiceExt;
+
+use aa_gateway::invalidation::InvalidationServiceImpl;
+use aa_proto::assembly::gateway::v1::invalidation_service_server::InvalidationServiceServer;
+use aa_runtime::invalidation_client::{InvalidationClient, InvalidationSink};
+use aa_runtime::l1_cache::PolicyL1Cache;
+
+#[tokio::test]
+async fn http_policy_mutation_invalidates_subscribed_l1_within_100ms() {
+    // ── aa-api HTTP app on a hub-attached engine ────────────────────────────
+    let state = common::test_state();
+    // The composition root shares this exact hub between the HTTP engine and
+    // the gRPC InvalidationService — retrieved here via the engine getter,
+    // before `build_app` consumes the state.
+    let hub = state
+        .policy_engine
+        .invalidation_hub()
+        .expect("test_state attaches an invalidation hub");
+    let app = aa_api::server::build_app(state);
+
+    // ── Real gateway InvalidationService on the SAME hub, over loopback gRPC ─
+    let grpc = std::net::TcpListener::bind("127.0.0.1:0").expect("bind grpc port");
+    let grpc_addr = grpc.local_addr().expect("grpc local_addr");
+    drop(grpc); // free the port for tonic to bind (loopback test).
+    let service = InvalidationServiceImpl::new(Arc::clone(&hub));
+    let server = tokio::spawn(async move {
+        Server::builder()
+            .add_service(InvalidationServiceServer::new(service))
+            .serve(grpc_addr)
+            .await
+            .expect("serve InvalidationService");
+    });
+
+    // ── Assembly subscriber: L1 cache fed by the real InvalidationClient ────
+    let cache: Arc<PolicyL1Cache<bool>> = Arc::new(PolicyL1Cache::new());
+    cache.insert("agent-x", true);
+    let sink: Arc<dyn InvalidationSink> = Arc::clone(&cache) as Arc<dyn InvalidationSink>;
+    let client = InvalidationClient::start(format!("http://{grpc_addr}"), "asm-http-e2e".to_string(), vec![sink]);
+
+    // Wait until the subscriber has registered with the gateway hub.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while hub.subscriber_count() == 0 {
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    })
+    .await
+    .expect("InvalidationClient subscribed to the gateway within 5 s");
+
+    // ── Mutate policy via the real HTTP API — NOT via apply_yaml/hub directly ─
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/policies")
+        .header("content-type", "application/json")
+        .body(Body::from(
+            serde_json::json!({ "policy_yaml": "tools:\n  bash:\n    allow: false\n" }).to_string(),
+        ))
+        .expect("build create_policy request");
+    let start = Instant::now();
+    let response = app.oneshot(request).await.expect("create_policy request");
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "create_policy should return 201"
+    );
+
+    // The subscribed L1 entry must disappear within 100 ms of the HTTP mutation.
+    tokio::time::timeout(Duration::from_millis(100), async {
+        while cache.contains("agent-x") {
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+    })
+    .await
+    .expect("HTTP policy mutation invalidated the subscribed L1 within 100 ms");
+    assert!(start.elapsed() < Duration::from_millis(100));
+
+    client.abort();
+    server.abort();
+}

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -546,6 +546,15 @@ impl PolicyEngine {
         self
     }
 
+    /// Return the attached push-invalidation hub, if any.
+    ///
+    /// A composition root that builds the engine with [`Self::with_invalidation_hub`]
+    /// uses this to serve the same hub over the `InvalidationService` gRPC, so an
+    /// HTTP policy mutation (`apply_yaml`) and the subscriber stream share one hub.
+    pub fn invalidation_hub(&self) -> Option<Arc<crate::invalidation::InvalidationHub>> {
+        self.invalidation_hub.clone()
+    }
+
     /// Apply a raw YAML policy string: validate, swap into the live slot, and
     /// persist a versioned snapshot to the history store.
     ///


### PR DESCRIPTION
## Description

Closes the production gap in Story AAASM-2377: the push-invalidation channel didn't actually fire on a real policy mutation, because the broadcast trigger (`PolicyEngine::apply_yaml`) and the `InvalidationService` subscribers weren't sharing a hub.

This wires it along clean crate-responsibility lines — **no production-crate refactor, no `AppState` field churn**:

- **aa-gateway** (owns invalidation): adds `PolicyEngine::invalidation_hub()` — a read accessor symmetric with the existing `with_invalidation_hub` setter, so a composition root can retrieve the hub from an engine it built and serve the *same* hub over `InvalidationService`.
- **aa-api** (HTTP facade): unchanged in production code. `apply_yaml` already broadcasts when the engine is hub-attached; the HTTP route needs no invalidation logic.
- **The composition root** (the process that builds one hub-attached engine and serves both HTTP + `InvalidationService`) is the only missing piece — and that's **cloud's responsibility**, since OSS doesn't run aa-api in production (library + tests only).

### What this PR proves (the AC)
An `aa-api/tests/` e2e composes the existing public pieces and exercises the real path end-to-end: a real **`POST /api/v1/policies`** → `create_policy` → `apply_yaml` → shared `InvalidationHub` → real gateway `InvalidationService` (loopback gRPC) → real aa-runtime `InvalidationClient` → `PolicyL1Cache` entry evicted **within 100 ms**. No direct `apply_yaml`/hub call in the test.

### Follow-up (cloud)
The production composition root — the control-plane server building its `PolicyEngine.with_invalidation_hub(hub)` and serving `InvalidationService` on it — lands in **agent-assembly-cloud** (filed separately; OSS now provides the seam + proof).

## Type of Change

- [x] ✨ New feature (composition seam + e2e proof)

## Breaking Changes

- [x] No (additive getter + test-only changes)

## Related Issues

- Related Jira ticket: AAASM-2544 (follow-up of Story AAASM-2377, Epic AAASM-2349)

## Testing

- [x] Integration tests added / updated

`cargo nextest run -p aa-api --test http_policy_invalidation` — passes (HTTP mutation → subscriber L1 evicted <100 ms). Full `aa-api` suite re-run to confirm the `test_state` hub-attach is a no-op for existing tests.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
