### PR TITLE
[AAASM-2393] ✨ (aa-gateway): NATS JetStream audit consumer worker

### DIFF
--- a/.ci/strip-for-publish.sh
+++ b/.ci/strip-for-publish.sh
@@ -45,6 +45,11 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 MARKED_FILES=(
     "${REPO_ROOT}/aa-cli/Cargo.toml"
     "${REPO_ROOT}/aa-cli/src/commands/mod.rs"
+    # AAASM-2388: gateway NATS audit consumer (async-nats + publish=false
+    # aa-storage-postgres). Removed so the published gateway has no held-back deps.
+    "${REPO_ROOT}/aa-gateway/Cargo.toml"
+    "${REPO_ROOT}/aa-gateway/src/lib.rs"
+    "${REPO_ROOT}/aa-gateway/src/main.rs"
 )
 
 # ---- Files to delete outright (they consume held-back deps) ----
@@ -53,21 +58,25 @@ DELETED_FILES=(
     "${REPO_ROOT}/aa-cli/src/commands/tools.rs"
     "${REPO_ROOT}/aa-cli/tests/run_command.rs"
     "${REPO_ROOT}/aa-integration-tests/tests/cli_run.rs"
+    # AAASM-2388: the audit consumer module + its integration test.
+    "${REPO_ROOT}/aa-gateway/src/audit_consumer.rs"
+    "${REPO_ROOT}/aa-gateway/tests/audit_consumer_e2e.rs"
 )
 
-# Strip region. Uses awk to drop lines from
-# `strip-for-publish:begin <region>` through `strip-for-publish:end <region>`
-# inclusive. Lines are matched anywhere on the line (not just column 0) so
-# both Rust `// ...` and TOML `# ...` comment styles work.
+# Strip region. Uses awk to drop lines from any
+# `strip-for-publish:begin <region>` through its matching
+# `strip-for-publish:end <region>` (inclusive), regardless of region name, so a
+# single file may carry several independently-named regions. Lines are matched
+# anywhere on the line (not just column 0) so both Rust `// ...` and TOML
+# `# ...` comment styles work.
 strip_regions() {
     local file="$1"
-    local region="devtool"
     local tmp
     tmp="$(mktemp)"
-    awk -v r="$region" '
+    awk '
         BEGIN { in_region = 0 }
-        index($0, "strip-for-publish:begin " r) > 0 { in_region = 1; next }
-        index($0, "strip-for-publish:end " r) > 0   { in_region = 0; next }
+        index($0, "strip-for-publish:begin ") > 0 { in_region = 1; next }
+        index($0, "strip-for-publish:end ") > 0   { in_region = 0; next }
         in_region == 0 { print }
     ' "$file" > "$tmp"
     mv "$tmp" "$file"
@@ -98,3 +107,9 @@ echo ""
 echo "AAASM-2340 strip-for-publish: verifying aa-cli still builds after strip"
 ( cd "$REPO_ROOT" && cargo check -p aa-cli ) >/dev/null
 echo "  ✓ aa-cli compiles cleanly without dev-tool surface"
+
+# AAASM-2388: aa-gateway must still compile without the audit-consumer surface.
+echo ""
+echo "AAASM-2388 strip-for-publish: verifying aa-gateway still builds after strip"
+( cd "$REPO_ROOT" && cargo check -p aa-gateway ) >/dev/null
+echo "  ✓ aa-gateway compiles cleanly without audit-consumer surface"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,7 @@ dependencies = [
  "aa-storage-postgres",
  "ahash 0.8.12",
  "arc-swap",
+ "async-nats",
  "async-stream",
  "async-trait",
  "axum",

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -51,6 +51,14 @@ axum-server  = { version = "0.8", features = ["tls-rustls"] }
 tower-http   = { version = "0.6", features = ["fs"] }
 x509-parser  = "0.18"
 redis        = { version = "1.2", default-features = false, features = ["tokio-comp", "connection-manager"], optional = true }
+# strip-for-publish:begin audit-consumer
+# AAASM-2388: gateway-side NATS JetStream audit consumer. Held back from the
+# crates.io publish set — aa-storage-postgres is `publish = false`, so cargo
+# would reject the published gateway for depending on it. This whole block is
+# removed by .ci/strip-for-publish.sh before `cargo workspaces publish`.
+async-nats   = { version = "0.49", optional = true }
+aa-storage-postgres = { path = "../aa-storage-postgres", optional = true }
+# strip-for-publish:end audit-consumer
 
 [dev-dependencies]
 # Path-only (the driver is publish=false). The migration-drift test runs the
@@ -66,7 +74,7 @@ insta        = "1"
 tower        = { version = "0.5", features = ["util"] }
 rcgen        = { version = "0.14", features = ["pem"] }
 time         = "0.3"
-testcontainers-modules = { version = "0.15", features = ["postgres"] }
+testcontainers-modules = { version = "0.15", features = ["postgres", "nats"] }
 rustls       = "0.23"
 
 [features]
@@ -75,6 +83,11 @@ default = []
 # Off by default — the gateway runs with `PolicyCache::Disabled` unless a
 # downstream binary explicitly enables this feature.
 redis-cache = ["dep:redis"]
+# strip-for-publish:begin audit-consumer
+# AAASM-2388: gateway-internal NATS->Postgres audit consumer worker. Default
+# OFF; enabled in dev/CI via `--all-features`. Stripped before crates.io publish.
+audit-consumer = ["dep:async-nats", "dep:aa-storage-postgres"]
+# strip-for-publish:end audit-consumer
 
 [[bin]]
 name = "aa-gateway"

--- a/aa-gateway/src/audit_consumer.rs
+++ b/aa-gateway/src/audit_consumer.rs
@@ -157,6 +157,22 @@ impl AuditConsumerHandle {
     }
 }
 
+/// Boot-wiring convenience: build a config from the environment and spawn the
+/// consumer, returning `None` when it is not configured (env vars unset).
+///
+/// A startup failure is logged and returns `None` rather than propagating, so a
+/// misconfigured consumer never prevents the gateway from serving.
+pub async fn spawn_from_env() -> Option<AuditConsumerHandle> {
+    let config = AuditConsumerConfig::from_env()?;
+    match spawn(config, CancellationToken::new()).await {
+        Ok(handle) => Some(handle),
+        Err(err) => {
+            tracing::warn!(error = %err, "audit consumer disabled — failed to start");
+            None
+        }
+    }
+}
+
 /// Connect to NATS and Postgres, ensure the stream/consumer exist, and spawn
 /// the producer + DB-writer tasks. Returns once both are running.
 pub async fn spawn(

--- a/aa-gateway/src/audit_consumer.rs
+++ b/aa-gateway/src/audit_consumer.rs
@@ -414,3 +414,106 @@ fn parse_ts(value: &Value) -> Option<DateTime<Utc>> {
         _ => None,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// RFC 3339 string parsed straight to a `DateTime<Utc>` for comparisons.
+    fn utc(rfc3339: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(rfc3339).unwrap().with_timezone(&Utc)
+    }
+
+    /// Sanitize a JSON object into an audit event, panicking on a heartbeat.
+    fn audit_event(value: Value) -> SanitizedAuditEvent {
+        match sanitize(RawAuditEvent::new(value)) {
+            SanitizeOutcome::Audit(event) => event,
+            SanitizeOutcome::Heartbeat(_) => panic!("expected an audit event, got a heartbeat"),
+        }
+    }
+
+    #[test]
+    fn record_uses_event_id_as_primary_key() {
+        let id = "550e8400-e29b-41d4-a716-446655440000";
+        let record = audit_log_record(&audit_event(json!({
+            "kind": "tool_call",
+            "event_id": id,
+            "agent_id": "acme/bot",
+            "action": "fs.read",
+            "decision": "deny",
+            "ts": "2026-06-04T12:00:00Z",
+        })));
+        assert_eq!(record.id, Uuid::parse_str(id).unwrap());
+        assert_eq!(record.agent_id, "acme/bot");
+        assert_eq!(record.tool_name, "fs.read");
+        assert_eq!(record.decision, "deny");
+        assert!(record.latency_ms.is_none());
+        assert_eq!(record.ts, utc("2026-06-04T12:00:00Z"));
+    }
+
+    #[test]
+    fn record_falls_back_to_event_type_and_review() {
+        // No `action` → tool_name uses event_type; no `decision` → "review".
+        let record = audit_log_record(&audit_event(json!({
+            "kind": "tool_call",
+            "event_id": "550e8400-e29b-41d4-a716-446655440000",
+            "agent_id": "acme/bot",
+            "event_type": "tool_call_intercepted",
+        })));
+        assert_eq!(record.tool_name, "tool_call_intercepted");
+        assert_eq!(record.decision, "review");
+    }
+
+    #[test]
+    fn record_tool_name_unknown_without_action_or_event_type() {
+        let record = audit_log_record(&audit_event(json!({
+            "kind": "tool_call",
+            "event_id": "550e8400-e29b-41d4-a716-446655440000",
+            "agent_id": "acme/bot",
+        })));
+        assert_eq!(record.tool_name, "unknown");
+    }
+
+    #[test]
+    fn missing_event_id_falls_back_to_stable_content_hash() {
+        // Same body → same id (retries dedupe); different body → different id.
+        let a = json!({"kind": "tool_call", "agent_id": "acme/bot", "action": "fs.read"});
+        let b = json!({"kind": "tool_call", "agent_id": "acme/other", "action": "fs.read"});
+        assert_eq!(extract_event_id(&a), extract_event_id(&a));
+        assert_ne!(extract_event_id(&a), extract_event_id(&b));
+    }
+
+    #[test]
+    fn invalid_event_id_falls_back_deterministically() {
+        let value = json!({"event_id": "not-a-uuid", "agent_id": "acme/bot"});
+        assert_eq!(extract_event_id(&value), extract_event_id(&value));
+    }
+
+    #[test]
+    fn parse_ts_accepts_rfc3339_and_epochs() {
+        assert_eq!(
+            parse_ts(&json!("2026-06-04T12:00:00Z")).unwrap(),
+            utc("2026-06-04T12:00:00Z")
+        );
+        assert_eq!(
+            parse_ts(&json!(1_000_000_000_i64)).unwrap(),
+            DateTime::from_timestamp(1_000_000_000, 0).unwrap()
+        );
+        assert_eq!(
+            parse_ts(&json!(1_700_000_000_000_i64)).unwrap(),
+            DateTime::from_timestamp_millis(1_700_000_000_000).unwrap()
+        );
+        assert!(parse_ts(&Value::Null).is_none());
+        assert!(parse_ts(&json!("not a date")).is_none());
+    }
+
+    #[test]
+    fn extract_ts_prefers_ts_then_timestamp() {
+        assert_eq!(
+            extract_ts(&json!({"timestamp": "2026-01-01T00:00:00Z"})).unwrap(),
+            utc("2026-01-01T00:00:00Z")
+        );
+        assert!(extract_ts(&json!({"agent_id": "x"})).is_none());
+    }
+}

--- a/aa-gateway/src/audit_consumer.rs
+++ b/aa-gateway/src/audit_consumer.rs
@@ -1,0 +1,400 @@
+//! Gateway-side NATS JetStream audit-event consumer (AAASM-2388).
+//!
+//! Phase 1 keeps the audit consumer *inside* the gateway as a pair of Tokio
+//! tasks rather than a separate deployable (spec line 7460). A **producer**
+//! task drains the `assembly.audit.>` JetStream subject and hands each message
+//! to a bounded [`mpsc`] channel; a **DB-writer** task pulls from that channel,
+//! runs the write-boundary [`sanitize`] pass, and persists the result through
+//! `aa-storage-postgres`.
+//!
+//! The design decisions:
+//!
+//! * **Idempotency.** A normal event becomes an [`AuditLogRecord`] whose `id`
+//!   is the event's own `event_id`, so the table's `ON CONFLICT (id) DO NOTHING`
+//!   primary key deduplicates retries. A conflict bumps
+//!   `aa_audit_duplicates_total`.
+//! * **At-least-once.** The JetStream pull-consumer uses explicit ack; a message
+//!   is acked only after its DB write succeeds. A failed write is left un-acked
+//!   so NATS redelivers it after `ack_wait`.
+//! * **Backpressure.** The channel is bounded. When it is full the producer uses
+//!   `try_send` and, on `Full`, drops the message *un-acked* — NATS redelivers
+//!   later once the writer has caught up — and bumps a backpressure counter. The
+//!   in-flight depth is exposed as `aa_audit_consumer_channel_depth`.
+//! * **Graceful shutdown.** Cancelling the [`CancellationToken`] stops the
+//!   producer, which drops its channel sender; the writer then drains the
+//!   remaining messages and exits.
+//!
+//! This module is compiled only under the `audit-consumer` feature, which pulls
+//! the held-back `async-nats` + `aa-storage-postgres` dependencies.
+
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use aa_storage_postgres::{AuditLogRecord, PgAuditSink, PgLifecycleStore, PostgresPool, PostgresPoolConfig};
+use async_nats::jetstream::{self, consumer};
+use chrono::{DateTime, Utc};
+use serde_json::Value;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio_stream::StreamExt;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use crate::sanitizer::{sanitize, RawAuditEvent, SanitizeOutcome, SanitizedAuditEvent};
+
+/// Wildcard subject every audit event is published under.
+const SUBJECT: &str = "assembly.audit.>";
+/// JetStream stream that captures the audit subject.
+const STREAM_NAME: &str = "AUDIT";
+/// Durable pull-consumer name, so restarts resume where they left off.
+const DURABLE_NAME: &str = "aa-gateway-audit-consumer";
+/// Default bound on the producer→writer channel (spec/AC: 8192).
+const DEFAULT_CHANNEL_CAPACITY: usize = 8192;
+/// How long an un-acked message waits before JetStream redelivers it.
+const ACK_WAIT: Duration = Duration::from_secs(30);
+
+/// Counter: events INSERTed for the first time.
+const METRIC_INSERTED: &str = "aa_audit_consumer_inserted_total";
+/// Counter: events whose `event_id` already existed (ON CONFLICT matched).
+const METRIC_DUPLICATES: &str = "aa_audit_duplicates_total";
+/// Counter: heartbeat events collapsed into a last-seen update.
+const METRIC_HEARTBEATS: &str = "aa_audit_consumer_heartbeats_total";
+/// Counter: messages dropped un-acked because the channel was full.
+const METRIC_BACKPRESSURE: &str = "aa_audit_consumer_backpressure_total";
+/// Counter: messages left un-acked because the DB write failed.
+const METRIC_WRITE_ERRORS: &str = "aa_audit_consumer_write_errors_total";
+/// Gauge: current in-flight depth of the producer→writer channel.
+const METRIC_CHANNEL_DEPTH: &str = "aa_audit_consumer_channel_depth";
+
+/// Stable namespace for deriving an id when an event omits a parseable
+/// `event_id`, so identical bodies still collide on the primary key.
+const EVENT_ID_NAMESPACE: Uuid = Uuid::from_u128(0x6161_6173_6d32_3338_3861_7564_6974_6964);
+
+/// A durable JetStream pull-consumer over the audit subject.
+type PullConsumer = consumer::Consumer<consumer::pull::Config>;
+
+/// Runtime configuration for the audit consumer.
+#[derive(Debug, Clone)]
+pub struct AuditConsumerConfig {
+    /// NATS server URL (e.g. `nats://127.0.0.1:4222`).
+    pub nats_url: String,
+    /// Postgres connection settings for the audit sink.
+    pub postgres: PostgresPoolConfig,
+    /// Bound on the producer→writer channel.
+    pub channel_capacity: usize,
+    /// JetStream stream name.
+    pub stream_name: String,
+    /// Durable consumer name.
+    pub durable_name: String,
+    /// Subject to subscribe to.
+    pub subject: String,
+}
+
+impl AuditConsumerConfig {
+    /// Build a config with default stream/subject/capacity for the given
+    /// NATS URL and Postgres settings.
+    pub fn new(nats_url: impl Into<String>, postgres: PostgresPoolConfig) -> Self {
+        Self {
+            nats_url: nats_url.into(),
+            postgres,
+            channel_capacity: DEFAULT_CHANNEL_CAPACITY,
+            stream_name: STREAM_NAME.to_string(),
+            durable_name: DURABLE_NAME.to_string(),
+            subject: SUBJECT.to_string(),
+        }
+    }
+
+    /// Build a config from the environment, returning `None` (consumer
+    /// disabled) when either `AA_AUDIT_NATS_URL` or `AA_AUDIT_POSTGRES_URL` is
+    /// unset.
+    pub fn from_env() -> Option<Self> {
+        let nats_url = std::env::var("AA_AUDIT_NATS_URL").ok()?;
+        let pg_url = std::env::var("AA_AUDIT_POSTGRES_URL").ok()?;
+        let postgres = PostgresPoolConfig {
+            url: pg_url,
+            ..Default::default()
+        };
+        Some(Self::new(nats_url, postgres))
+    }
+}
+
+/// Errors that can occur while bringing the consumer up.
+#[derive(Debug, thiserror::Error)]
+pub enum AuditConsumerError {
+    /// Opening the Postgres pool failed.
+    #[error("postgres connection failed: {0}")]
+    Postgres(#[source] sqlx::Error),
+    /// Applying the embedded migrations failed.
+    #[error("postgres migration failed: {0}")]
+    Migrate(#[source] sqlx::migrate::MigrateError),
+    /// Connecting to NATS failed.
+    #[error("NATS connect failed: {0}")]
+    NatsConnect(#[source] async_nats::ConnectError),
+    /// Creating/binding the JetStream stream or consumer failed.
+    #[error("JetStream setup failed: {0}")]
+    JetStream(String),
+}
+
+/// Handle to the running consumer: cancel via the token and await both tasks.
+pub struct AuditConsumerHandle {
+    producer: JoinHandle<()>,
+    writer: JoinHandle<()>,
+    shutdown: CancellationToken,
+}
+
+impl AuditConsumerHandle {
+    /// The shutdown token; cancelling it drains and stops the consumer.
+    pub fn shutdown_token(&self) -> CancellationToken {
+        self.shutdown.clone()
+    }
+
+    /// Signal shutdown and wait for the producer and writer to finish draining.
+    pub async fn shutdown(self) {
+        self.shutdown.cancel();
+        let _ = self.producer.await;
+        let _ = self.writer.await;
+    }
+}
+
+/// Connect to NATS and Postgres, ensure the stream/consumer exist, and spawn
+/// the producer + DB-writer tasks. Returns once both are running.
+pub async fn spawn(
+    config: AuditConsumerConfig,
+    shutdown: CancellationToken,
+) -> Result<AuditConsumerHandle, AuditConsumerError> {
+    let pool = PostgresPool::connect(&config.postgres)
+        .await
+        .map_err(AuditConsumerError::Postgres)?;
+    pool.migrate().await.map_err(AuditConsumerError::Migrate)?;
+    let sink = PgAuditSink::new(pool.clone());
+    let lifecycle = PgLifecycleStore::new(pool);
+
+    let client = async_nats::connect(&config.nats_url)
+        .await
+        .map_err(AuditConsumerError::NatsConnect)?;
+    let js = jetstream::new(client);
+    let stream = js
+        .get_or_create_stream(jetstream::stream::Config {
+            name: config.stream_name.clone(),
+            subjects: vec![config.subject.clone()],
+            ..Default::default()
+        })
+        .await
+        .map_err(|e| AuditConsumerError::JetStream(e.to_string()))?;
+    let consumer = stream
+        .get_or_create_consumer(
+            &config.durable_name,
+            consumer::pull::Config {
+                durable_name: Some(config.durable_name.clone()),
+                ack_policy: consumer::AckPolicy::Explicit,
+                ack_wait: ACK_WAIT,
+                ..Default::default()
+            },
+        )
+        .await
+        .map_err(|e| AuditConsumerError::JetStream(e.to_string()))?;
+
+    let (tx, rx) = mpsc::channel::<jetstream::Message>(config.channel_capacity);
+    let depth = Arc::new(AtomicI64::new(0));
+
+    let producer = tokio::spawn(run_producer(consumer, tx, Arc::clone(&depth), shutdown.clone()));
+    let writer = tokio::spawn(run_writer(rx, sink, lifecycle, depth));
+
+    tracing::info!(
+        subject = %config.subject,
+        stream = %config.stream_name,
+        "audit consumer started"
+    );
+    Ok(AuditConsumerHandle {
+        producer,
+        writer,
+        shutdown,
+    })
+}
+
+/// Producer task: pull from JetStream and `try_send` into the bounded channel.
+///
+/// A full channel drops the message un-acked (NATS redelivers after `ack_wait`),
+/// applying backpressure without blocking the pull loop. Cancellation or a
+/// closed channel stops the loop; dropping `tx` then signals the writer to
+/// drain and exit.
+async fn run_producer(
+    consumer: PullConsumer,
+    tx: mpsc::Sender<jetstream::Message>,
+    depth: Arc<AtomicI64>,
+    shutdown: CancellationToken,
+) {
+    let mut messages = match consumer.messages().await {
+        Ok(messages) => messages,
+        Err(err) => {
+            tracing::error!(%err, "audit consumer: failed to open JetStream message stream");
+            return;
+        }
+    };
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = shutdown.cancelled() => {
+                tracing::info!("audit consumer: shutdown signalled, stopping producer");
+                break;
+            }
+            next = messages.next() => match next {
+                Some(Ok(message)) => match tx.try_send(message) {
+                    Ok(()) => {
+                        let depth_now = depth.fetch_add(1, Ordering::Relaxed) + 1;
+                        metrics::gauge!(METRIC_CHANNEL_DEPTH).set(depth_now as f64);
+                    }
+                    Err(mpsc::error::TrySendError::Full(_message)) => {
+                        // Leave un-acked: JetStream redelivers after ack_wait
+                        // once the writer drains the channel.
+                        metrics::counter!(METRIC_BACKPRESSURE).increment(1);
+                    }
+                    Err(mpsc::error::TrySendError::Closed(_message)) => {
+                        tracing::warn!("audit consumer: writer channel closed, stopping producer");
+                        break;
+                    }
+                },
+                Some(Err(err)) => {
+                    tracing::warn!(%err, "audit consumer: error pulling message");
+                }
+                None => {
+                    tracing::info!("audit consumer: JetStream message stream ended");
+                    break;
+                }
+            },
+        }
+    }
+}
+
+/// DB-writer task: sanitize each message, persist it, and ack on success.
+///
+/// Exits when the channel is closed (producer gone) after draining every
+/// buffered message.
+async fn run_writer(
+    mut rx: mpsc::Receiver<jetstream::Message>,
+    sink: PgAuditSink,
+    lifecycle: PgLifecycleStore,
+    depth: Arc<AtomicI64>,
+) {
+    while let Some(message) = rx.recv().await {
+        let depth_now = depth.fetch_sub(1, Ordering::Relaxed) - 1;
+        metrics::gauge!(METRIC_CHANNEL_DEPTH).set(depth_now.max(0) as f64);
+
+        match process_message(&message, &sink, &lifecycle).await {
+            Ok(()) => {
+                if let Err(err) = message.ack().await {
+                    tracing::warn!(%err, "audit consumer: ack failed after successful write");
+                }
+            }
+            Err(err) => {
+                // Do not ack — JetStream redelivers after ack_wait.
+                metrics::counter!(METRIC_WRITE_ERRORS).increment(1);
+                tracing::warn!(%err, "audit consumer: write failed, leaving message un-acked");
+            }
+        }
+    }
+    tracing::info!("audit consumer: channel drained, writer exiting");
+}
+
+/// Errors raised while processing a single message (before ack).
+#[derive(Debug, thiserror::Error)]
+enum ProcessError {
+    /// The message payload was not valid JSON.
+    #[error("decode failed: {0}")]
+    Decode(#[source] serde_json::Error),
+    /// The storage write failed.
+    #[error("storage write failed: {0}")]
+    Storage(String),
+}
+
+/// Decode → sanitize → persist one message. Audit events INSERT a row;
+/// heartbeats collapse into a last-seen touch.
+async fn process_message(
+    message: &jetstream::Message,
+    sink: &PgAuditSink,
+    lifecycle: &PgLifecycleStore,
+) -> Result<(), ProcessError> {
+    let value: Value = serde_json::from_slice(&message.payload).map_err(ProcessError::Decode)?;
+    match sanitize(RawAuditEvent::new(value)) {
+        SanitizeOutcome::Audit(event) => {
+            let record = audit_log_record(&event);
+            let inserted = sink
+                .insert_audit_log(&record)
+                .await
+                .map_err(|e| ProcessError::Storage(e.to_string()))?;
+            if inserted {
+                metrics::counter!(METRIC_INSERTED).increment(1);
+            } else {
+                metrics::counter!(METRIC_DUPLICATES).increment(1);
+            }
+            Ok(())
+        }
+        SanitizeOutcome::Heartbeat(heartbeat) => {
+            let ts = parse_ts(&heartbeat.last_heartbeat_at);
+            lifecycle
+                .touch_last_heartbeat(&heartbeat.agent_id, ts)
+                .await
+                .map_err(|e| ProcessError::Storage(e.to_string()))?;
+            metrics::counter!(METRIC_HEARTBEATS).increment(1);
+            Ok(())
+        }
+    }
+}
+
+/// Map a sanitized audit event onto the `audit_logs` columns, using its
+/// `event_id` as the primary key for idempotency.
+fn audit_log_record(event: &SanitizedAuditEvent) -> AuditLogRecord {
+    let value = event.as_value();
+    AuditLogRecord {
+        id: extract_event_id(value),
+        agent_id: string_field(value, "agent_id").unwrap_or_default(),
+        tool_name: string_field(value, "action")
+            .or_else(|| string_field(value, "event_type"))
+            .unwrap_or_else(|| "unknown".to_string()),
+        decision: string_field(value, "decision").unwrap_or_else(|| "review".to_string()),
+        latency_ms: None,
+        ts: extract_ts(value).unwrap_or_else(Utc::now),
+    }
+}
+
+/// Read a parseable `event_id`, falling back to a deterministic v5 UUID over
+/// the event body so malformed senders still dedupe by content.
+fn extract_event_id(value: &Value) -> Uuid {
+    if let Some(id) = value
+        .get("event_id")
+        .and_then(Value::as_str)
+        .and_then(|s| Uuid::parse_str(s).ok())
+    {
+        return id;
+    }
+    let bytes = serde_json::to_vec(value).unwrap_or_default();
+    Uuid::new_v5(&EVENT_ID_NAMESPACE, &bytes)
+}
+
+/// Borrow a top-level string field as an owned `String`.
+fn string_field(value: &Value, key: &str) -> Option<String> {
+    value.get(key).and_then(Value::as_str).map(str::to_string)
+}
+
+/// Resolve the event timestamp from `ts` or `timestamp`.
+fn extract_ts(value: &Value) -> Option<DateTime<Utc>> {
+    value.get("ts").or_else(|| value.get("timestamp")).and_then(parse_ts)
+}
+
+/// Parse a timestamp value: RFC 3339 string, or epoch seconds/milliseconds.
+fn parse_ts(value: &Value) -> Option<DateTime<Utc>> {
+    match value {
+        Value::String(s) => DateTime::parse_from_rfc3339(s).ok().map(|dt| dt.with_timezone(&Utc)),
+        Value::Number(number) => {
+            let raw = number.as_i64()?;
+            if raw >= 1_000_000_000_000 {
+                DateTime::from_timestamp_millis(raw)
+            } else {
+                DateTime::from_timestamp(raw, 0)
+            }
+        }
+        _ => None,
+    }
+}

--- a/aa-gateway/src/audit_consumer.rs
+++ b/aa-gateway/src/audit_consumer.rs
@@ -364,7 +364,7 @@ async fn process_message(
 fn audit_log_record(event: &SanitizedAuditEvent) -> AuditLogRecord {
     let value = event.as_value();
     AuditLogRecord {
-        id: extract_event_id(value),
+        event_id: extract_event_id(value),
         agent_id: string_field(value, "agent_id").unwrap_or_default(),
         tool_name: string_field(value, "action")
             .or_else(|| string_field(value, "event_type"))
@@ -444,7 +444,7 @@ mod tests {
             "decision": "deny",
             "ts": "2026-06-04T12:00:00Z",
         })));
-        assert_eq!(record.id, Uuid::parse_str(id).unwrap());
+        assert_eq!(record.event_id, Uuid::parse_str(id).unwrap());
         assert_eq!(record.agent_id, "acme/bot");
         assert_eq!(record.tool_name, "fs.read");
         assert_eq!(record.decision, "deny");

--- a/aa-gateway/src/lib.rs
+++ b/aa-gateway/src/lib.rs
@@ -9,6 +9,12 @@ pub mod anomaly;
 pub mod app_state;
 pub mod approval;
 pub mod audit;
+// strip-for-publish:begin audit-consumer
+// AAASM-2388: gateway-internal NATS->Postgres audit consumer. Compiled only
+// under the `audit-consumer` feature (held back from crates.io publish).
+#[cfg(feature = "audit-consumer")]
+pub mod audit_consumer;
+// strip-for-publish:end audit-consumer
 pub mod audit_reader;
 pub mod budget;
 pub mod dashboard_server;

--- a/aa-gateway/src/main.rs
+++ b/aa-gateway/src/main.rs
@@ -195,7 +195,14 @@ async fn run_legacy_grpc(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     // Optionally spawn the webhook delivery loop (reads AA_WEBHOOK_URL).
     let _webhook_handle = aa_gateway::events::startup::maybe_spawn_webhook(&approval_queue, budget_alert_rx);
 
-    if let Some(socket_path) = &cli.socket {
+    // strip-for-publish:begin audit-consumer
+    // AAASM-2388: spawn the NATS->Postgres audit consumer when configured via
+    // AA_AUDIT_NATS_URL + AA_AUDIT_POSTGRES_URL. Drained after serve returns.
+    #[cfg(feature = "audit-consumer")]
+    let audit_consumer = aa_gateway::audit_consumer::spawn_from_env().await;
+    // strip-for-publish:end audit-consumer
+
+    let serve_result = if let Some(socket_path) = &cli.socket {
         aa_gateway::server::serve_uds(
             &policy,
             socket_path,
@@ -215,7 +222,17 @@ async fn run_legacy_grpc(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             Some(storage),
         )
         .await
+    };
+
+    // strip-for-publish:begin audit-consumer
+    // Graceful drain: stop pulling, flush the channel into Postgres, then exit.
+    #[cfg(feature = "audit-consumer")]
+    if let Some(handle) = audit_consumer {
+        handle.shutdown().await;
     }
+    // strip-for-publish:end audit-consumer
+
+    serve_result
 }
 
 /// Remote Control-Plane Mode entry: load the persisted `GatewayConfig`

--- a/aa-gateway/tests/audit_consumer_e2e.rs
+++ b/aa-gateway/tests/audit_consumer_e2e.rs
@@ -1,0 +1,135 @@
+//! End-to-end test for the gateway NATS→Postgres audit consumer (AAASM-2388).
+//!
+//! Spins up real NATS (JetStream) and Postgres containers via testcontainers,
+//! publishes events to `assembly.audit.>`, runs the consumer, and asserts that
+//! every event lands in `audit_logs` and that duplicate `event_id`s collapse to
+//! a single row (idempotency).
+//!
+//! Requires Docker. Compiled only under the `audit-consumer` feature; the
+//! sustained 50k-events/sec throughput benchmark lives in the verification
+//! subtask (AAASM-2394).
+#![cfg(feature = "audit-consumer")]
+
+use std::time::Duration;
+
+use aa_gateway::audit_consumer::{spawn, AuditConsumerConfig};
+use aa_storage_postgres::PostgresPoolConfig;
+use serde_json::json;
+use testcontainers_modules::nats::{Nats, NatsServerCmd};
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use testcontainers_modules::testcontainers::ImageExt;
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+/// Number of distinct events published in the "all land" phase.
+const EVENT_COUNT: usize = 1000;
+/// Times the single duplicate event is republished.
+const DUPLICATE_REPUBLISHES: usize = 50;
+
+/// Count rows currently in `audit_logs`.
+async fn count_rows(pool: &sqlx::PgPool) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT count(*) FROM audit_logs")
+        .fetch_one(pool)
+        .await
+        .expect("count query")
+}
+
+/// Poll `audit_logs` until it holds at least `target` rows or we give up.
+async fn wait_for_count(pool: &sqlx::PgPool, target: i64) -> i64 {
+    for _ in 0..150 {
+        let count = count_rows(pool).await;
+        if count >= target {
+            return count;
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    count_rows(pool).await
+}
+
+/// Publish one JSON audit event to the audit subject and wait for its ack.
+async fn publish_event(js: &async_nats::jetstream::Context, event: &serde_json::Value) {
+    let payload = serde_json::to_vec(event).expect("serialize event");
+    js.publish("assembly.audit.acme.bot", payload.into())
+        .await
+        .expect("publish")
+        .await
+        .expect("pub-ack");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn consumer_drains_all_events_and_dedupes_by_event_id() {
+    // ---- Bring up NATS (JetStream) + Postgres -----------------------------
+    let pg = Postgres::default().start().await.expect("start postgres");
+    let pg_port = pg.get_host_port_ipv4(5432).await.expect("pg port");
+    let pg_url = format!("postgres://postgres:postgres@127.0.0.1:{pg_port}/postgres");
+
+    let nats_cmd = NatsServerCmd::default().with_jetstream();
+    let nats = Nats::default().with_cmd(&nats_cmd).start().await.expect("start nats");
+    let nats_port = nats.get_host_port_ipv4(4222).await.expect("nats port");
+    let nats_url = format!("nats://127.0.0.1:{nats_port}");
+
+    // ---- Start the consumer (creates the stream + durable consumer) -------
+    let config = AuditConsumerConfig::new(
+        nats_url.clone(),
+        PostgresPoolConfig {
+            url: pg_url.clone(),
+            ..Default::default()
+        },
+    );
+    let shutdown = CancellationToken::new();
+    let handle = spawn(config, shutdown.clone()).await.expect("spawn consumer");
+
+    // ---- Publish EVENT_COUNT distinct events ------------------------------
+    let client = async_nats::connect(&nats_url).await.expect("nats connect");
+    let js = async_nats::jetstream::new(client);
+    for _ in 0..EVENT_COUNT {
+        publish_event(
+            &js,
+            &json!({
+                "event_id": Uuid::new_v4().to_string(),
+                "kind": "tool_call",
+                "agent_id": "acme/bot",
+                "action": "fs.read",
+                "decision": "allow",
+                "ts": "2026-06-04T12:00:00Z",
+            }),
+        )
+        .await;
+    }
+
+    // Every distinct event must land exactly once.
+    let landed = wait_for_count(&pool(&pg_url).await, EVENT_COUNT as i64).await;
+    assert_eq!(
+        landed, EVENT_COUNT as i64,
+        "all published events should land in audit_logs"
+    );
+
+    // ---- Idempotency: republish ONE event_id many times -------------------
+    let duplicate = json!({
+        "event_id": Uuid::new_v4().to_string(),
+        "kind": "tool_call",
+        "agent_id": "acme/bot",
+        "action": "fs.write",
+        "decision": "deny",
+        "ts": "2026-06-04T12:34:56Z",
+    });
+    for _ in 0..DUPLICATE_REPUBLISHES {
+        publish_event(&js, &duplicate).await;
+    }
+
+    // The duplicate adds exactly one row regardless of how often it is sent.
+    let after_dupes = wait_for_count(&pool(&pg_url).await, EVENT_COUNT as i64 + 1).await;
+    assert_eq!(
+        after_dupes,
+        EVENT_COUNT as i64 + 1,
+        "duplicate event_id must collapse to a single audit_logs row"
+    );
+
+    handle.shutdown().await;
+}
+
+/// Open a throwaway pool for assertions.
+async fn pool(url: &str) -> sqlx::PgPool {
+    sqlx::PgPool::connect(url).await.expect("connect for assertions")
+}

--- a/aa-storage-postgres/src/audit_sink.rs
+++ b/aa-storage-postgres/src/audit_sink.rs
@@ -3,9 +3,34 @@
 use aa_core::audit::AuditEventType;
 use aa_storage::{AuditEntry, AuditSink, Result};
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use uuid::Uuid;
 
 use crate::pool::PostgresPool;
 use crate::support::{agent_id_to_text, backend_err};
+
+/// A fully-resolved `audit_logs` row, ready to INSERT verbatim.
+///
+/// Unlike [`AuditEntry`] — which the sink hashes into a row — this carries the
+/// columns directly. The async audit consumer (AAASM-2388) builds one from a
+/// sanitized event, using the event's own `event_id` as [`id`](Self::id) so
+/// that the table's `ON CONFLICT (id) DO NOTHING` primary key doubles as
+/// event-id idempotency without a schema change.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuditLogRecord {
+    /// Primary key. Set to the event's `event_id` for idempotent inserts.
+    pub id: Uuid,
+    /// Canonical agent identifier (stored verbatim in the `TEXT` column).
+    pub agent_id: String,
+    /// Action surface recorded in `tool_name`.
+    pub tool_name: String,
+    /// Coarse governance posture recorded in `decision`.
+    pub decision: String,
+    /// Optional decision latency; `None` leaves the column NULL.
+    pub latency_ms: Option<i32>,
+    /// Event timestamp.
+    pub ts: DateTime<Utc>,
+}
 
 /// Postgres-backed [`AuditSink`].
 ///

--- a/aa-storage-postgres/src/audit_sink.rs
+++ b/aa-storage-postgres/src/audit_sink.rs
@@ -13,13 +13,13 @@ use crate::support::{agent_id_to_text, backend_err};
 ///
 /// Unlike [`AuditEntry`] — which the sink hashes into a row — this carries the
 /// columns directly. The async audit consumer (AAASM-2388) builds one from a
-/// sanitized event, using the event's own `event_id` as [`id`](Self::id) so
-/// that the table's `ON CONFLICT (id) DO NOTHING` primary key doubles as
-/// event-id idempotency without a schema change.
+/// sanitized event, carrying the event's own `event_id` as the
+/// [`event_id`](Self::event_id) primary key so that `ON CONFLICT (event_id)
+/// DO NOTHING` gives idempotency on retried publishes.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AuditLogRecord {
-    /// Primary key. Set to the event's `event_id` for idempotent inserts.
-    pub id: Uuid,
+    /// Primary key — the event's `event_id`, the idempotency key.
+    pub event_id: Uuid,
     /// Canonical agent identifier (stored verbatim in the `TEXT` column).
     pub agent_id: String,
     /// Action surface recorded in `tool_name`.
@@ -53,16 +53,16 @@ impl PgAuditSink {
     /// INSERT a pre-resolved [`AuditLogRecord`], deduplicating on its primary key.
     ///
     /// Returns `Ok(true)` when a new row was written and `Ok(false)` when the
-    /// `id` already existed (`ON CONFLICT (id) DO NOTHING` matched zero rows).
-    /// The async audit consumer uses the boolean to count duplicates without a
-    /// second round-trip.
+    /// `event_id` already existed (`ON CONFLICT (event_id) DO NOTHING` matched
+    /// zero rows). The async audit consumer uses the boolean to count duplicates
+    /// without a second round-trip.
     pub async fn insert_audit_log(&self, record: &AuditLogRecord) -> Result<bool> {
         let result = sqlx::query(
-            "INSERT INTO audit_logs (id, agent_id, tool_name, decision, latency_ms, ts) \
+            "INSERT INTO audit_logs (event_id, agent_id, tool_name, decision, latency_ms, ts) \
              VALUES ($1, $2, $3, $4, $5, $6) \
-             ON CONFLICT (id) DO NOTHING",
+             ON CONFLICT (event_id) DO NOTHING",
         )
-        .bind(record.id)
+        .bind(record.event_id)
         .bind(&record.agent_id)
         .bind(&record.tool_name)
         .bind(&record.decision)

--- a/aa-storage-postgres/src/audit_sink.rs
+++ b/aa-storage-postgres/src/audit_sink.rs
@@ -49,6 +49,30 @@ impl PgAuditSink {
     pub fn new(pool: PostgresPool) -> Self {
         Self { pool }
     }
+
+    /// INSERT a pre-resolved [`AuditLogRecord`], deduplicating on its primary key.
+    ///
+    /// Returns `Ok(true)` when a new row was written and `Ok(false)` when the
+    /// `id` already existed (`ON CONFLICT (id) DO NOTHING` matched zero rows).
+    /// The async audit consumer uses the boolean to count duplicates without a
+    /// second round-trip.
+    pub async fn insert_audit_log(&self, record: &AuditLogRecord) -> Result<bool> {
+        let result = sqlx::query(
+            "INSERT INTO audit_logs (id, agent_id, tool_name, decision, latency_ms, ts) \
+             VALUES ($1, $2, $3, $4, $5, $6) \
+             ON CONFLICT (id) DO NOTHING",
+        )
+        .bind(record.id)
+        .bind(&record.agent_id)
+        .bind(&record.tool_name)
+        .bind(&record.decision)
+        .bind(record.latency_ms)
+        .bind(record.ts)
+        .execute(self.pool.pool())
+        .await
+        .map_err(backend_err)?;
+        Ok(result.rows_affected() == 1)
+    }
 }
 
 /// Coarse governance posture recorded in `audit_logs.decision`.

--- a/aa-storage-postgres/src/lib.rs
+++ b/aa-storage-postgres/src/lib.rs
@@ -18,7 +18,7 @@ pub mod policy_store;
 pub mod pool;
 pub mod support;
 
-pub use audit_sink::PgAuditSink;
+pub use audit_sink::{AuditLogRecord, PgAuditSink};
 pub use config::PostgresPoolConfig;
 pub use credential_store::PgCredentialStore;
 pub use lifecycle_store::PgLifecycleStore;

--- a/aa-storage-postgres/src/lifecycle_store.rs
+++ b/aa-storage-postgres/src/lifecycle_store.rs
@@ -2,6 +2,7 @@
 
 use aa_storage::{AgentId, LifecycleStore, Result, StorageError};
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 
 use crate::pool::PostgresPool;
 use crate::support::{agent_id_to_text, backend_err};
@@ -17,6 +18,24 @@ impl PgLifecycleStore {
     /// Build a lifecycle store over an existing pool.
     pub fn new(pool: PostgresPool) -> Self {
         Self { pool }
+    }
+
+    /// Record a heartbeat "last seen" for a raw agent-id string without
+    /// requiring the agent row to exist.
+    ///
+    /// The async audit consumer (AAASM-2388) collapses heartbeat events into
+    /// this call. Unlike [`LifecycleStore::heartbeat`], an unknown `agent_id`
+    /// is a no-op (zero rows) rather than a [`StorageError::NotFound`] — a
+    /// heartbeat must never fail the consumer's ack path. `ts` falls back to
+    /// `now()` when the event carried no timestamp.
+    pub async fn touch_last_heartbeat(&self, agent_id: &str, ts: Option<DateTime<Utc>>) -> Result<()> {
+        sqlx::query("UPDATE agents SET last_heartbeat = COALESCE($2, now()) WHERE id = $1")
+            .bind(agent_id)
+            .bind(ts)
+            .execute(self.pool.pool())
+            .await
+            .map_err(backend_err)?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Description

Phase 1 of the async audit pipeline (Epic AAASM-2350): a gateway-side NATS JetStream consumer that drains the `assembly.audit.>` subject into Postgres `audit_logs` with idempotency, backpressure, and graceful drain.

A **producer** task pulls from a durable JetStream pull-consumer and `try_send`s each message into a bounded `tokio::sync::mpsc` channel; a **DB-writer** task runs the merged write-boundary `sanitize()` pass, persists the result via `aa-storage-postgres`, and acks only after a successful write. Heartbeats collapse to an `agents.last_heartbeat` touch.

Because `aa-gateway` is a published crate and `aa-storage-postgres` is `publish = false`, the consumer (and its `async-nats` + `aa-storage-postgres` deps) live behind a default-OFF `audit-consumer` cargo feature whose surface is wrapped in `strip-for-publish` markers — the same pattern `aa-cli` uses for its held-back deps. The published gateway is unchanged.

### Key behaviours (Story ACs)
- ✅ One worker spawned, subscribed to `assembly.audit.>` (wildcard)
- ✅ Per message: deserialize → `sanitize()` → INSERT via `aa-storage-postgres`
- ✅ Idempotency: `audit_logs.event_id` PRIMARY KEY + `ON CONFLICT (event_id) DO NOTHING`; conflicts bump `aa_audit_duplicates_total`
- ✅ Backpressure: bounded `mpsc::channel(8192)`; full ⇒ message left un-acked for redelivery; in-flight depth exposed as `aa_audit_consumer_channel_depth`
- ✅ At-least-once: JetStream pull-consumer, explicit ack after the DB write
- ✅ Graceful shutdown via `CancellationToken` (drain channel before exit)

The sustained **50k events/sec** throughput benchmark is owned by the verification subtask **AAASM-2394** (per its own AC); this PR's integration test asserts correctness.

## Type of Change

- [x] ✨ New feature
- [x] 🔧 Configuration / CI change (strip-for-publish)

## Breaking Changes

- [x] No

The consumer is behind a default-OFF feature; the published gateway and default build are unchanged.

## Related Issues

- Related Jira ticket: AAASM-2393 (Story AAASM-2388, Epic AAASM-2350)

## Testing

- [x] Unit tests added / updated — `event_id`/field mapping, deterministic fallback, RFC 3339 / epoch timestamp parsing
- [x] Integration tests added / updated — testcontainers NATS (JetStream) + Postgres: 1000 events all land; a repeated `event_id` collapses to one row
- [x] Manual testing performed — `strip-for-publish.sh` dry-run verified both `aa-cli` and `aa-gateway` compile after stripping the held-back surface

Validation run locally: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --all-features --exclude aa-ebpf -D warnings`, `cargo deny check`, `cargo nextest run -p aa-gateway -p aa-storage-postgres` (1101 passed), feature-gated unit + integration tests (Docker), `cargo doc --workspace --no-deps`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
