### PR TITLE
[AAASM-2579] 🔧 (ci): Pin CARGO_INCREMENTAL=0 at workflow env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # AAASM-2579: incremental artifacts bloat the rust-cache and give no
+  # benefit on cold CI runners; pin off uniformly across every Rust job.
+  CARGO_INCREMENTAL: 0
 
 jobs:
   changes:


### PR DESCRIPTION
## Description

Pins `CARGO_INCREMENTAL: 0` at the workflow-level `env:` block in `.github/workflows/ci.yml`. Incremental compilation artifacts bloat the `Swatinem/rust-cache` and give no benefit on cold CI runners; setting it once at the workflow level applies uniformly to every Rust job — including the ones that do not use `rust-cache` (e.g. `aa-cli-compat`).

First of five stacked subtasks under Story **AAASM-2556** (Epic AAASM-2551, CI build-pipeline speedups).

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [x] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2579 (subtask of AAASM-2556)

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [x] No tests required (explain why)

CI-config-only change. Correctness is proven by the workflow itself going green; behavior of every job is unchanged (incremental is already effectively off under `rust-cache`, this just makes it explicit and uniform).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention