### PR TITLE
[AAASM-2580] 🔧 (ci): Path-gate eBPF --release jobs behind a dedicated changes filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -601,7 +601,8 @@ jobs:
 
   ebpf-build:
     needs: [changes]
-    if: needs.changes.outputs.rust == 'true'
+    # AAASM-2580: only run when aa-ebpf* (or this workflow) changed.
+    if: needs.changes.outputs.ebpf == 'true'
     name: eBPF probes build (Linux nightly)
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -682,7 +682,8 @@ jobs:
 
   e2e-ebpf-linux:
     needs: [changes]
-    if: needs.changes.outputs.rust == 'true'
+    # AAASM-2580: only run when aa-ebpf* (or this workflow) changed.
+    if: needs.changes.outputs.ebpf == 'true'
     # AAASM-1520 / F116 ST-H — Layer 3 (eBPF) end-to-end interception suite.
     # Linux-only, runs as root for CAP_BPF + CAP_PERFMON; the test source is
     # `#[cfg(all(target_os = "linux", feature = "integration-test"))]` so it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
     outputs:
       rust: ${{ steps.filter.outputs.rust }}
       dashboard: ${{ steps.filter.outputs.dashboard }}
+      ebpf: ${{ steps.filter.outputs.ebpf }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v4.0.1
@@ -81,6 +82,12 @@ jobs:
               - 'dashboard/**'
               - 'openapi/v1.yaml'
               - 'sonar-project.properties'
+              - '.github/workflows/ci.yml'
+            # AAASM-2580: gate the slow eBPF --release jobs (fat-LTO BPF build +
+            # bpf-linker compile) so they only run when eBPF code — or this
+            # workflow — actually changes. Non-eBPF PRs skip them.
+            ebpf:
+              - 'aa-ebpf*/**'
               - '.github/workflows/ci.yml'
   build:
     needs: [changes]


### PR DESCRIPTION
## Description

Adds a dedicated `ebpf` change-detection filter to the `changes` job and switches the two slow eBPF `--release` jobs — `ebpf-build` (Linux nightly) and `e2e-ebpf-linux` (Layer 3 e2e) — from the broad `rust` gate to it. PRs that don't touch `aa-ebpf*` (or this workflow) now skip the fat-LTO BPF build + `bpf-linker` compile entirely.

The `ebpf` filter intentionally includes `.github/workflows/ci.yml` so edits to the eBPF jobs themselves still validate — which is why the eBPF jobs **do** run on this PR.

Subtask 2 of 5 under Story **AAASM-2556**. Stacked on AAASM-2579 (#909); base is `master`.

Three granular commits:
1. add `ebpf` output + filter to the `changes` job
2. gate `ebpf-build` on it
3. gate `e2e-ebpf-linux` on it

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [x] 🍀 Performance improvement
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2580 (subtask of AAASM-2556)

## Testing

- [x] No tests required (explain why)

CI-config-only. The eBPF jobs run green on this PR (the workflow file is in the `ebpf` filter); the *skip* behavior on non-eBPF PRs is verified under AAASM-2583.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention