### PR TITLE
[AAASM-2581] 🔧 (ci): Install mold + select it via target-scoped RUSTFLAGS on heavy Rust jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,10 +143,15 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Clippy lint
     runs-on: ubuntu-latest
+    env:
+      # AAASM-2581: select mold for host-target links only.
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
     steps:
       - uses: actions/checkout@v6
       - name: Install protobuf compiler
         run: sudo apt-get install -y protobuf-compiler
+      - name: Install mold linker
+        run: sudo apt-get install -y mold
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,10 +94,17 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Build
     runs-on: ubuntu-latest
+    env:
+      # AAASM-2581: select mold for host-target links only. Cross targets
+      # (bpfel/wasm32/thumbv7) keep their own linkers — this is per-target,
+      # not a global RUSTFLAGS, on purpose.
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
     steps:
       - uses: actions/checkout@v6
       - name: Install protobuf compiler
         run: sudo apt-get install -y protobuf-compiler
+      - name: Install mold linker
+        run: sudo apt-get install -y mold
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,8 @@ jobs:
       # AAASM-1741: lets the env-gated storage::postgres::tests run under
       # cargo llvm-cov so codecov/patch sees coverage for the PG backend.
       AAASM_DATABASE_URL: "postgres://aasm:aasm@localhost:5432/aasm_test"
+      # AAASM-2581: select mold for host-target links only.
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
     services:
       postgres:
         image: postgres:18-alpine
@@ -324,6 +326,8 @@ jobs:
           path: node-sdk
       - name: Install protobuf compiler
         run: sudo apt-get install -y protobuf-compiler
+      - name: Install mold linker
+        run: sudo apt-get install -y mold
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: llvm-tools-preview

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,17 @@ jobs:
         run: sudo apt-get install -y protobuf-compiler
       - name: Install mold linker
         run: sudo apt-get install -y mold
+      - name: Free up runner disk space
+        # AAASM-2581: selecting mold changes the rust-cache key (it hashes
+        # RUSTFLAGS), so the first run rebuilds the workspace cold. The Test
+        # job is the heaviest disk consumer (cold target/ + nextest archive +
+        # node_modules + node-sdk native build + postgres testcontainer image)
+        # and, unlike Coverage, never frees target/. Reclaim ~25 GB of
+        # preinstalled toolchains we don't use so the cold build fits.
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/.ghcup /opt/hostedtoolcache/CodeQL
+          df -h /
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install cargo-nextest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,9 @@ jobs:
     if: needs.changes.outputs.rust == 'true'
     name: Test
     runs-on: ubuntu-latest
+    env:
+      # AAASM-2581: select mold for host-target links only.
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
     services:
       # AAASM-1741: postgres for the env-gated storage::postgres::tests
       # in aa-gateway. Tests skip cleanly when AAASM_DATABASE_URL is unset
@@ -220,6 +223,8 @@ jobs:
           path: node-sdk
       - name: Install protobuf compiler
         run: sudo apt-get install -y protobuf-compiler
+      - name: Install mold linker
+        run: sudo apt-get install -y mold
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - name: Install cargo-nextest


### PR DESCRIPTION
## Description

Link is the serial tail of every Rust job. This installs `mold` and selects it for **host-target links only** on the four heaviest native compile jobs: `build`, `clippy`, `test`, `coverage`.

Selection is via the per-target env var `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS: "-C link-arg=-fuse-ld=mold"` — deliberately **not** a global `RUSTFLAGS`, so the `bpfel-unknown-none` (eBPF), `wasm32-unknown-unknown`, and `thumbv7em-none-eabihf` cross-targets keep their own linkers (`bpf-linker` / `rust-lld`) untouched. ubuntu-latest ships gcc ≥ 12 which understands `-fuse-ld=mold`, and the apt `mold` package provides `ld.mold`.

Self-contained: does not depend on the `.cargo/config.toml` mold/lld config owned by AAASM-2554 (that Story handles local-dev linker selection).

Subtask 3 of 5 under Story **AAASM-2556**. Stacked on AAASM-2580 (#913); base is `master`. One commit per job (build, clippy, test, coverage).

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [x] 🍀 Performance improvement
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2581 (subtask of AAASM-2556)

## Testing

- [x] No tests required (explain why)

CI-config-only. Correctness is proven by build/clippy/test/coverage going green with mold as the host linker; cross-target jobs are unaffected by construction (per-target env scoping).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention