### PR TITLE
[AAASM-2582] 🔧 (ci): Build dashboard assets once and reuse via artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
         run: cargo fmt --all -- --check
 
   clippy:
-    needs: [changes]
+    needs: [changes, dashboard-assets]
     if: needs.changes.outputs.rust == 'true'
     name: Clippy lint
     runs-on: ubuntu-latest
@@ -180,19 +180,11 @@ jobs:
         with:
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - name: Download prebuilt dashboard assets (required by aa-cli)
+        uses: actions/download-artifact@v8
         with:
-          version: 10.9.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 20
-          cache: pnpm
-          cache-dependency-path: dashboard/pnpm-lock.yaml
-      - name: Build dashboard assets (required by aa-cli)
-        working-directory: dashboard
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm build
+          name: dashboard-dist-rust
+          path: dashboard/dist/
       - name: Run Clippy
         # aa-ebpf requires nightly (aya-build invokes rustup run nightly).
         # It is linted by the dedicated ebpf-build job.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
         run: cargo doc --no-deps --all-features -p aa-core
 
   test:
-    needs: [changes]
+    needs: [changes, dashboard-assets]
     if: needs.changes.outputs.rust == 'true'
     name: Test
     runs-on: ubuntu-latest
@@ -266,11 +266,11 @@ jobs:
           cache-dependency-path: |
             dashboard/pnpm-lock.yaml
             aa-integration-tests/tests/fixtures/agents/typescript/pnpm-lock.yaml
-      - name: Build dashboard assets (required by aa-cli)
-        working-directory: dashboard
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm build
+      - name: Download prebuilt dashboard assets (required by aa-cli)
+        uses: actions/download-artifact@v8
+        with:
+          name: dashboard-dist-rust
+          path: dashboard/dist/
       - name: "Symlink node-sdk for TypeScript fixture file: dependency"
         run: ln -sfn "$GITHUB_WORKSPACE/node-sdk" "$(dirname "$GITHUB_WORKSPACE")/node-sdk"
       - name: Build Node.js native binding + TS dist (e2e_sdk_node real_* tests, AAASM-1602)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
           retention-days: 1
 
   build:
-    needs: [changes]
+    needs: [changes, dashboard-assets]
     if: needs.changes.outputs.rust == 'true'
     name: Build
     runs-on: ubuntu-latest
@@ -139,19 +139,11 @@ jobs:
         run: sudo apt-get install -y mold
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - name: Download prebuilt dashboard assets (required by aa-cli)
+        uses: actions/download-artifact@v8
         with:
-          version: 10.9.0
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version: 20
-          cache: pnpm
-          cache-dependency-path: dashboard/pnpm-lock.yaml
-      - name: Build dashboard assets (required by aa-cli)
-        working-directory: dashboard
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm build
+          name: dashboard-dist-rust
+          path: dashboard/dist/
       - name: Build workspace
         # aa-ebpf requires nightly (aya-build invokes rustup run nightly).
         # It is validated by the dedicated ebpf-build job.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,7 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    needs: [changes]
+    needs: [changes, dashboard-assets]
     if: github.actor != 'dependabot[bot]' && needs.changes.outputs.rust == 'true'
     env:
       # AAASM-1741: lets the env-gated storage::postgres::tests run under
@@ -373,11 +373,11 @@ jobs:
           cache-dependency-path: |
             dashboard/pnpm-lock.yaml
             aa-integration-tests/tests/fixtures/agents/typescript/pnpm-lock.yaml
-      - name: Build dashboard assets (required by aa-cli)
-        working-directory: dashboard
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm build
+      - name: Download prebuilt dashboard assets (required by aa-cli)
+        uses: actions/download-artifact@v8
+        with:
+          name: dashboard-dist-rust
+          path: dashboard/dist/
       - name: "Symlink node-sdk for TypeScript fixture file: dependency"
         run: ln -sfn "$GITHUB_WORKSPACE/node-sdk" "$(dirname "$GITHUB_WORKSPACE")/node-sdk"
       - name: Build Node.js native binding + TS dist (e2e_sdk_node real_* tests, AAASM-1602)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,38 @@ jobs:
             ebpf:
               - 'aa-ebpf*/**'
               - '.github/workflows/ci.yml'
+  # AAASM-2582: build the dashboard assets (embedded by aa-cli's build.rs)
+  # exactly once and share them via an artifact, instead of running
+  # `pnpm install && pnpm build` in each of build/clippy/test/coverage.
+  dashboard-assets:
+    needs: [changes]
+    if: needs.changes.outputs.rust == 'true'
+    name: Build dashboard assets (shared)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dashboard
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 10.9.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: dashboard/pnpm-lock.yaml
+      - name: Build dashboard assets
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+      - name: Upload dashboard dist artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: dashboard-dist-rust
+          path: dashboard/dist/
+          retention-days: 1
+
   build:
     needs: [changes]
     if: needs.changes.outputs.rust == 'true'


### PR DESCRIPTION
## Description

The "Build dashboard assets (required by aa-cli)" step (`pnpm install --frozen-lockfile && pnpm build` in `dashboard/`) was duplicated across the `build`, `clippy`, `test`, and `coverage` jobs — rebuilt 4×. This adds a single rust-gated `dashboard-assets` producer job that builds `dashboard/dist/` once and uploads it as the `dashboard-dist-rust` artifact; the four consumers now `download-artifact` it instead.

- `build` / `clippy`: the inline pnpm build **and** their now-unused pnpm/node setup are removed (those jobs only used node for the dashboard).
- `test` / `coverage`: only the dashboard build is swapped for a download; pnpm/node setup stays because the node-sdk native binding build and the TypeScript e2e fixtures still need it.

aa-cli's `build.rs` embeds `dashboard/dist/`; the downloaded artifact is byte-identical to the previously-rebuilt assets, so there's no correctness change. This reuses the exact `upload-artifact@v7` → `download-artifact@v8` pattern already used by `dashboard-build` → `aa-cli-compat` in this file.

Subtask 4 of 5 (final implementation subtask) under Story **AAASM-2556**. Stacked on AAASM-2581 (#914); base is `master`. Six granular commits (producer + 4 consumers).

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [x] 🍀 Performance improvement
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2582 (subtask of AAASM-2556)

## Testing

- [x] No tests required (explain why)

CI-config-only. Correctness is proven by `build`/`clippy`/`test`/`coverage` going green while consuming the shared artifact (aa-cli still compiles with the embedded dashboard assets).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention