### PR TITLE
[AAASM-2586] 🔒 (aa-runtime): Wire enforcement stage into pipeline before forward/audit

### DIFF
--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -76,6 +76,10 @@ pub async fn run(
     let mut ticker = tokio::time::interval(config.flush_interval);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
+    // GATE (AAASM-2568): one precompiled scanner, constructed once and reused
+    // for every event. The runtime is the authoritative scan/redact point.
+    let scanner = enforcement::RuntimeScanner::new();
+
     loop {
         tokio::select! {
             biased;
@@ -91,7 +95,11 @@ pub async fn run(
             Some((connection_id, frame)) = rx.recv() => {
                 match frame {
                     IpcFrame::EventReport(event) => {
-                        let enriched = enrich(event, &config.agent_id, connection_id, &seq);
+                        let mut enriched = enrich(event, &config.agent_id, connection_id, &seq);
+                        // GATE: scan + redact + normalize before any forward or
+                        // audit, on every path. Unconditional — no SDK signal can
+                        // skip this.
+                        scanner.enforce(&mut enriched);
                         tracing::debug!(sequence_number = enriched.sequence_number, connection_id, "event enriched");
                         metrics.record_processed(1);
                         ::metrics::counter!("aa_events_received_total").increment(1);

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -1444,4 +1444,69 @@ mod tests {
 
         token.cancel();
     }
+
+    // -----------------------------------------------------------------------
+    // GATE: runtime enforcement runs before forward/audit on every path
+    // (AAASM-2568)
+    // -----------------------------------------------------------------------
+
+    /// An AWS access-key id the credential scanner detects via the `AKIA` literal.
+    const GATE_SECRET: &str = "AKIAIOSFODNN7EXAMPLE";
+
+    /// A ToolCall `AuditEvent` whose `args_json` embeds [`GATE_SECRET`].
+    fn tool_call_with_secret() -> AuditEvent {
+        use aa_proto::assembly::audit::v1::ToolCallDetail;
+        AuditEvent {
+            action_type: ActionType::ToolCall as i32,
+            detail: Some(Detail::ToolCall(ToolCallDetail {
+                args_json: format!(r#"{{"api_key": "{GATE_SECRET}"}}"#).into_bytes(),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }
+    }
+
+    /// Assert an audited pipeline event's `args_json` was redacted, not raw.
+    fn assert_args_redacted(event: PipelineEvent) {
+        let enriched = unwrap_audit(event);
+        let Some(Detail::ToolCall(tc)) = enriched.inner.detail else {
+            panic!("expected ToolCall detail");
+        };
+        let body = String::from_utf8(tc.args_json).expect("redacted text is utf-8");
+        assert!(!body.contains(GATE_SECRET), "raw secret must not leave the runtime");
+        assert!(body.contains("[REDACTED:"), "redaction marker present");
+    }
+
+    #[tokio::test]
+    async fn secret_is_redacted_on_batch_path() {
+        let config = test_config(1, 10_000); // flush at size 1; interval won't fire
+        let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
+        let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<PipelineEvent>(64);
+        let metrics = Arc::new(PipelineMetrics::default());
+        let token = CancellationToken::new();
+
+        tokio::spawn(run(
+            rx,
+            broadcast_tx,
+            config,
+            metrics.clone(),
+            token.clone(),
+            Arc::new(PolicyRules::default()),
+            crate::ipc::new_response_router(),
+            crate::approval::ApprovalQueue::new(),
+            None,
+            Arc::new(AtomicU64::new(0)),
+        ));
+
+        tx.send((0, IpcFrame::EventReport(tool_call_with_secret())))
+            .await
+            .unwrap();
+
+        let event = tokio::time::timeout(Duration::from_millis(500), broadcast_rx.recv())
+            .await
+            .expect("timed out waiting for batched event")
+            .expect("broadcast error");
+        assert_args_redacted(event);
+        token.cancel();
+    }
 }

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -1509,4 +1509,51 @@ mod tests {
         assert_args_redacted(event);
         token.cancel();
     }
+
+    #[tokio::test]
+    async fn secret_is_redacted_on_violation_path() {
+        use crate::policy::{PolicyRule, PolicyRules};
+
+        // batch_size=100, long interval — only the violation should arrive,
+        // exercising the immediate-broadcast path.
+        let config = test_config(100, 10_000);
+        let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
+        let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<PipelineEvent>(64);
+        let metrics = Arc::new(PipelineMetrics::default());
+        let token = CancellationToken::new();
+
+        // A rule blocking TOOL_CALL actions routes the secret-bearing event
+        // onto the violation broadcast path instead of the batch.
+        let policy = PolicyRules {
+            rules: vec![PolicyRule {
+                name: "block-tools".to_string(),
+                blocked_actions: vec!["TOOL_CALL".to_string()],
+                ..Default::default()
+            }],
+        };
+
+        tokio::spawn(run(
+            rx,
+            broadcast_tx,
+            config,
+            metrics.clone(),
+            token.clone(),
+            Arc::new(policy),
+            crate::ipc::new_response_router(),
+            crate::approval::ApprovalQueue::new(),
+            None,
+            Arc::new(AtomicU64::new(0)),
+        ));
+
+        tx.send((0, IpcFrame::EventReport(tool_call_with_secret())))
+            .await
+            .unwrap();
+
+        let event = tokio::time::timeout(Duration::from_millis(500), broadcast_rx.recv())
+            .await
+            .expect("timed out waiting for violation event")
+            .expect("broadcast error");
+        assert_args_redacted(event);
+        token.cancel();
+    }
 }


### PR DESCRIPTION
## Description

Third and final implementation subtask for the **\[GATE\]** Story AAASM-2568 (Epic AAASM-2552). **This is the gate landing.** **Stacked on #926 → #924** — merge those first; this PR's diff narrows to just the wiring once they land.

Wires the enforcement stage into the live pipeline:

- Constructs **one** `RuntimeScanner` at pipeline start (precompiled, reused for every event).
- Calls `enforce(&mut enriched)` **unconditionally** on every `EventReport`, **before** `is_policy_violation` — so the pipeline becomes `enrich → enforce(scan/redact/normalize) → policy → forward/batch`.
- Because the call sits before the branch, **both** the immediate violation-broadcast path and the batch path forward only redacted events.
- There is no SDK `clean`/`already_scanned` field on the wire and no code path that skips the scan.

> Scanner construction is intentionally inside `run()` (one instance per pipeline task, reused per event) rather than threaded through the 14 call sites — the smallest change that satisfies the "precompiled, constructed once, reused" guardrail. Plumbing `EnforcementConfig` from `RuntimeConfig` is a deliberate follow-up; the 64 KiB default cap applies.

## Type of Change

- [x] 🔒 Security (new enforcement)
- [x] ♻️ Refactoring

## Breaking Changes

- [x] No (internal pipeline behaviour; wire format unchanged)

## Related Issues

- Related Jira ticket: AAASM-2586 (subtask of AAASM-2568, Epic AAASM-2552)
- Stacked on: #926 (AAASM-2585), #924 (AAASM-2584)

## Testing

- [x] Unit tests added / updated

`secret_is_redacted_on_batch_path` and `secret_is_redacted_on_violation_path` spin up the real `run()` task and assert the forwarded event carries `[REDACTED:*]` on both paths. `cargo nextest run -p aa-runtime` → 256 passed.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
