### PR TITLE
[AAASM-2573] 🔧 (scripts): Add build-time baseline harness + recorded baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ SHELL := /bin/bash
 .DEFAULT_GOAL := help
 
 .PHONY: help dev-setup install-tools clone-sdks install-hooks build-workspace \
-        test dev-verify smoke-python smoke-node smoke-go gateway-health \
-        demo-record
+        build-baseline test dev-verify smoke-python smoke-node smoke-go \
+        gateway-health demo-record
 
 ## dev-setup: Bootstrap the full local development environment (install tools, clone SDKs, install hooks, build)
 dev-setup: install-tools clone-sdks install-hooks build-workspace
@@ -105,6 +105,10 @@ gateway-health:
 ## build-workspace: Build the Cargo workspace (excludes eBPF crates requiring nightly)
 build-workspace:
 	@cargo build --workspace --exclude aa-ebpf
+
+## build-baseline: Record a build-time baseline (cold/warm/test + cargo tree -d) into target/build-baseline/
+build-baseline:
+	@bash scripts/build-baseline.sh
 
 ## install-hooks: Install git pre-commit hooks via pre-commit
 install-hooks:

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -43,6 +43,7 @@
 # Benchmarks
 
 - [Baseline](benchmarks/BASELINE.md)
+- [Build-Time Baseline](benchmarks/build-time-baseline.md)
 - [Policy Check p99](benchmarks/policy-check-p99.md)
 
 # Architecture Decision Records

--- a/docs/src/benchmarks/build-time-baseline.md
+++ b/docs/src/benchmarks/build-time-baseline.md
@@ -110,7 +110,48 @@ shift run-to-run with build parallelism, but this set is stable.
 | 3 | `rand`, `rand_core`, `getrandom` |
 | 2 | `winnow`, `webpki-roots`, `wast`, `wasm-encoder`, `untrusted`, `toml`, `toml_datetime`, `thiserror-impl`, … |
 
-The full report is archived at `target/build-baseline/cargo-tree-dups.txt`.
+The complete set of multi-version packages — the committed dedup baseline for
+AAASM-2555 to diff against — follows. The full `cargo tree -d` report (with the
+inverted dependent trees) is also archived at
+`target/build-baseline/cargo-tree-dups.txt` for the dependency paths.
+
+```text
+block-buffer        v0.10.4  v0.12.0
+const-oid           v0.9.6   v0.10.2
+convert_case        v0.10.0  v0.11.0
+cpufeatures         v0.2.17  v0.3.0
+crypto-common       v0.1.7   v0.2.1
+deadpool            v0.12.3  v0.13.0
+deadpool-runtime    v0.1.4   v0.3.1
+digest              v0.10.7  v0.11.3
+fixedbitset         v0.4.2   v0.5.7
+foldhash            v0.1.5   v0.2.0
+getrandom           v0.2.17  v0.3.4   v0.4.2
+hashbrown           v0.14.5  v0.15.5  v0.16.1  v0.17.1
+hashlink            v0.9.1   v0.10.0
+hmac                v0.12.1  v0.13.0
+itertools           v0.13.0  v0.14.0
+lru                 v0.16.4  v0.18.0
+petgraph            v0.6.5   v0.8.3
+phf                 v0.11.3  v0.12.1
+phf_shared          v0.11.3  v0.12.1
+rand                v0.8.6   v0.9.4   v0.10.1
+rand_chacha         v0.3.1   v0.9.0
+rand_core           v0.6.4   v0.9.5   v0.10.1
+reqwest             v0.12.28 v0.13.3
+sha2                v0.10.9  v0.11.0
+similar             v2.7.0   v3.1.1
+thiserror           v1.0.69  v2.0.18
+thiserror-impl      v1.0.69  v2.0.18
+toml                v0.9.12  v1.1.2
+toml_datetime       v0.7.5   v1.1.1
+untrusted           v0.7.1   v0.9.0
+wasm-encoder        v0.248.0 v0.251.0
+wast                v35.0.2  v251.0.0
+webpki-roots        v0.26.11 v1.0.7
+winnow              v0.7.15  v1.0.2
+```
+
 AAASM-2555 should re-run `cargo tree -d` after centralizing
 `[workspace.dependencies]` and confirm this count drops.
 

--- a/docs/src/benchmarks/build-time-baseline.md
+++ b/docs/src/benchmarks/build-time-baseline.md
@@ -28,8 +28,15 @@ report) under `target/build-baseline/` (gitignored):
 |---|---|---|
 | 1 | Cold build | `cargo clean` then `cargo build --workspace --timings` |
 | 2 | Warm rebuild | `touch aa-cli/src/main.rs` then `cargo build --workspace` |
-| 3 | Test build+run | `cargo nextest run --workspace` |
+| 3 | Test build | `cargo nextest run --workspace --no-run` (compile only) |
 | 4 | Duplicate deps | `cargo tree -d` |
+
+Measurement 3 deliberately compiles the test binaries **without running**
+them: the build-time signal the profile/linker/dedup Stories move is the
+**compile** cost, whereas the full suite's run wall-clock is dominated by
+Docker-backed integration tests and is sensitive to timing flakes. Set
+`BUILD_BASELINE_RUN_TESTS=1` to additionally run the full suite
+(`--no-fail-fast`) and record its build+run wall-clock.
 
 ### Why `aa-ebpf` is excluded
 

--- a/docs/src/benchmarks/build-time-baseline.md
+++ b/docs/src/benchmarks/build-time-baseline.md
@@ -1,0 +1,62 @@
+# Build-Time Baseline
+
+Before/after harness for **Epic AAASM-2551** (_Rust build & compile-time
+performance_). This page records the **build-time** baseline established by
+Story **AAASM-2557** so the profile (AAASM-2553), dev/linker (AAASM-2554),
+dependency-dedup (AAASM-2555), and CI (AAASM-2556) Stories can each quote a
+measured before/after against the **same** harness.
+
+> This is distinct from [Baseline](BASELINE.md), which records **runtime**
+> (`cargo bench`) numbers. This page measures how long the workspace takes to
+> **compile**, not how fast it runs.
+
+## Harness
+
+Run the full capture with:
+
+```bash
+make build-baseline          # wraps scripts/build-baseline.sh
+# or
+bash scripts/build-baseline.sh
+```
+
+The harness records four measurements and archives the raw outputs (logs, the
+`cargo build --timings` HTML, the top-crate extraction, and the `cargo tree -d`
+report) under `target/build-baseline/` (gitignored):
+
+| # | Measurement | Command |
+|---|---|---|
+| 1 | Cold build | `cargo clean` then `cargo build --workspace --timings` |
+| 2 | Warm rebuild | `touch aa-cli/src/main.rs` then `cargo build --workspace` |
+| 3 | Test build+run | `cargo nextest run --workspace` |
+| 4 | Duplicate deps | `cargo tree -d` |
+
+### Why `aa-ebpf` is excluded
+
+`aa-ebpf` requires a nightly toolchain plus `bpf-linker`, so the workspace's own
+`make build-workspace` and `make test` targets build with `--exclude aa-ebpf`.
+The baseline mirrors that to measure the build path developers and the
+non-eBPF CI jobs actually hit. Pass `BUILD_BASELINE_INCLUDE_EBPF=1` to include
+it on a nightly-capable host. Other tunables: `BUILD_BASELINE_WARM_FILE`,
+`BUILD_BASELINE_TOP_N`, `BUILD_BASELINE_OUT` (see the script header).
+
+### Reproducibility notes
+
+- Wall-clock is whole-second resolution from the shell; expect a few percent
+  run-to-run variance, especially for the link-bound warm rebuild.
+- Numbers are machine-specific. Always compare a before/after **pair captured on
+  the same machine** — never an absolute number against a different host.
+- The third-party registry cache (`~/.cargo`) is shared, so the cold build
+  measures compile + link time, not crate download time.
+
+## Recorded baseline
+
+<!-- AAASM-2573: measured numbers are recorded in the measurement commit. -->
+
+## Acceptance-criteria mapping (AAASM-2557)
+
+| Acceptance criterion | Evidence |
+|---|---|
+| Baseline numbers for cold build, warm rebuild, and test build+run recorded | "Recorded baseline" → wall-clock table |
+| `cargo build --timings` HTML identifies the top 5 longest-compiling crates | "Recorded baseline" → top-crates table (`target/build-baseline/cargo-timing.html`) |
+| `cargo tree -d` attached as the dedup baseline for AAASM-2555 | "Recorded baseline" → duplicate-dependency table (`target/build-baseline/cargo-tree-dups.txt`) |

--- a/docs/src/benchmarks/build-time-baseline.md
+++ b/docs/src/benchmarks/build-time-baseline.md
@@ -58,12 +58,78 @@ it on a nightly-capable host. Other tunables: `BUILD_BASELINE_WARM_FILE`,
 
 ## Recorded baseline
 
-<!-- AAASM-2573: measured numbers are recorded in the measurement commit. -->
+Captured **2026-06-05** on Apple M-series (arm64, 16 logical CPUs, 128 GB),
+macOS Darwin 25.4.0, `cargo 1.95.0`, `cargo-nextest 0.9.133`, default
+`[profile.dev]` and `[profile.release]` (i.e. the pre-Epic configuration).
+
+| Measurement | Wall-clock |
+|---|---|
+| Cold build (`cargo build --workspace --timings`) | **124 s** |
+| Warm rebuild (touch `aa-cli/src/main.rs`, relink) | **5 s** |
+| Test build (`cargo nextest run --workspace --no-run`) | **396 s** |
+| Packages built in >1 version (`cargo tree -d`) | **34** |
+| Distinct duplicate `(name, version)` build units | **105** |
+
+> Local wall-clock is noisy: across three runs the cold build measured
+> 91–211 s on this machine (background load / thermal). Treat these as the
+> local order-of-magnitude; the Epic's per-Story before/after pairs must be
+> captured on the same idle machine, and CI numbers are authoritative.
+
+### Top longest-compiling crates
+
+From the archived `cargo build --timings` HTML
+(`target/build-baseline/cargo-timing.html`), summing each crate's units
+(build-script + lib + codegen):
+
+| Rank | Compile (s) | Crate |
+|---|---|---|
+| 1 | 63.6 | `aws-lc-sys` 0.40.0 |
+| 2 | 35.2 | `wasmtime` 45.0.0 |
+| 3 | 33.7 | `cranelift-codegen` 0.132.0 |
+| 4 | 29.8 | `rustls` 0.23.40 |
+| 5 | 25.3 | `object` 0.39.1 |
+| 6 | 25.2 | `libsqlite3-sys` 0.30.1 |
+| 7 | 23.1 | `asn1-rs` 0.7.1 |
+| 8 | 22.9 | `thiserror` 1.0.69 |
+| 9 | 21.0 | `rustix` 1.1.4 |
+| 10 | 21.0 | `wasmtime-internal-jit-debug` 45.0.0 |
+
+The long poles are the **WebAssembly** stack (`wasmtime`, `cranelift-codegen`,
+`wasmtime-internal-jit-debug` — pulled by `aa-wasm`) and **crypto/TLS**
+(`aws-lc-sys`, `rustls`), confirming the Epic's hypothesis. Per-crate seconds
+shift run-to-run with build parallelism, but this set is stable.
+
+### Duplicate dependencies (dedup baseline for AAASM-2555)
+
+`cargo tree -d` reports **34 packages built in more than one version**
+(105 distinct `(name, version)` units). The worst offenders:
+
+| Versions | Package |
+|---|---|
+| 4 | `hashbrown` |
+| 3 | `rand`, `rand_core`, `getrandom` |
+| 2 | `winnow`, `webpki-roots`, `wast`, `wasm-encoder`, `untrusted`, `toml`, `toml_datetime`, `thiserror-impl`, … |
+
+The full report is archived at `target/build-baseline/cargo-tree-dups.txt`.
+AAASM-2555 should re-run `cargo tree -d` after centralizing
+`[workspace.dependencies]` and confirm this count drops.
+
+### Full test build+run (context)
+
+The default harness records test **compile** time only, because the full
+suite's run wall-clock is dominated by integration-test execution rather than
+the build. For reference, one `BUILD_BASELINE_RUN_TESTS=1` capture on the same
+machine measured **3452 s** end-to-end build+run — of which the run phase was
+`Summary [2546 s] 3764 tests run: 3744 passed (228 slow, 4 leaky), 20 failed`.
+The 20 failures are local timing-sensitive integration assertions (e.g. the
+`aa-api` L1-invalidation 100 ms check) and do not affect compile time. This
+number is here for completeness; the profile/linker/dedup Stories should be
+judged against the **compile** rows above, not this run-dominated figure.
 
 ## Acceptance-criteria mapping (AAASM-2557)
 
 | Acceptance criterion | Evidence |
 |---|---|
-| Baseline numbers for cold build, warm rebuild, and test build+run recorded | "Recorded baseline" → wall-clock table |
-| `cargo build --timings` HTML identifies the top 5 longest-compiling crates | "Recorded baseline" → top-crates table (`target/build-baseline/cargo-timing.html`) |
-| `cargo tree -d` attached as the dedup baseline for AAASM-2555 | "Recorded baseline" → duplicate-dependency table (`target/build-baseline/cargo-tree-dups.txt`) |
+| Baseline numbers for cold build, warm rebuild, and test build+run recorded | "Recorded baseline" → wall-clock table (cold/warm/test-build) + "Full test build+run (context)" |
+| `cargo build --timings` HTML identifies the top 5 longest-compiling crates | "Top longest-compiling crates" table (`target/build-baseline/cargo-timing.html`) |
+| `cargo tree -d` attached as the dedup baseline for AAASM-2555 | "Duplicate dependencies" table (`target/build-baseline/cargo-tree-dups.txt`) |

--- a/scripts/build-baseline.sh
+++ b/scripts/build-baseline.sh
@@ -121,17 +121,32 @@ else
   echo "(warm rebuild skipped: $WARM_FILE not found)" >"$WARM_LOG"
 fi
 
-# --- 3. Test build + run wall-clock ---------------------------------------
-# `--no-fail-fast` so a single flaky/slow test (e.g. a timing-sensitive
-# integration assertion) does not truncate the wall-clock — the baseline must
-# reflect compiling every test binary plus running the whole suite, matching
-# what CI does. Test failures are expected to leave the number unchanged.
-TEST_LOG="$OUT/nextest.log"
-echo ">>> test build+run: $CARGO nextest run --workspace ${EXCLUDE[*]} --no-fail-fast"
-TEST_START=$SECONDS
-$CARGO nextest run --workspace "${EXCLUDE[@]}" --no-fail-fast >"$TEST_LOG" 2>&1
-TEST_REAL=$(( SECONDS - TEST_START ))
-echo "    test build+run: ${TEST_REAL}s  (log: $TEST_LOG)"
+# --- 3a. Test-binary build (compile only) ---------------------------------
+# This is the build-time signal for the test path: `--no-run` compiles every
+# test binary without executing any test, so it is deterministic and free of
+# Docker / timing-flake noise — exactly the cost the profile, linker, and
+# dedup Stories move.
+TESTBUILD_LOG="$OUT/nextest-build.log"
+echo ">>> test build (compile only): $CARGO nextest run --workspace ${EXCLUDE[*]} --no-run"
+TESTBUILD_START=$SECONDS
+$CARGO nextest run --workspace "${EXCLUDE[@]}" --no-run >"$TESTBUILD_LOG" 2>&1
+TESTBUILD_REAL=$(( SECONDS - TESTBUILD_START ))
+echo "    test build: ${TESTBUILD_REAL}s  (log: $TESTBUILD_LOG)"
+
+# --- 3b. Test build+run (opt-in) ------------------------------------------
+# The full suite run is dominated by Docker-backed integration tests, not
+# compilation, so it is OFF by default. Enable with BUILD_BASELINE_RUN_TESTS=1.
+# `--no-fail-fast` keeps a single flaky test from truncating the wall-clock.
+# Because 3a already compiled the test binaries, this measures the run cost.
+TEST_REAL=""
+if [ "${BUILD_BASELINE_RUN_TESTS:-0}" = "1" ]; then
+  TEST_LOG="$OUT/nextest-run.log"
+  echo ">>> test run: $CARGO nextest run --workspace ${EXCLUDE[*]} --no-fail-fast"
+  TEST_START=$SECONDS
+  $CARGO nextest run --workspace "${EXCLUDE[@]}" --no-fail-fast >"$TEST_LOG" 2>&1
+  TEST_REAL=$(( SECONDS - TEST_START ))
+  echo "    test run: ${TEST_REAL}s  (log: $TEST_LOG)"
+fi
 
 # --- 4. Duplicate-dependency report ---------------------------------------
 DUPS_LOG="$OUT/cargo-tree-dups.txt"
@@ -160,7 +175,10 @@ SUMMARY="$OUT/summary.md"
   echo "|---|---|"
   echo "| Cold build (\`build --workspace --timings\`) | ${COLD_REAL}s |"
   echo "| Warm rebuild (touch \`${WARM_FILE}\`) | ${WARM_REAL:-n/a}s |"
-  echo "| Test build+run (\`nextest run --workspace\`) | ${TEST_REAL}s |"
+  echo "| Test build (\`nextest run --no-run\`) | ${TESTBUILD_REAL}s |"
+  if [ -n "$TEST_REAL" ]; then
+    echo "| Test run (\`nextest run --no-fail-fast\`) | ${TEST_REAL}s |"
+  fi
   echo "| Packages built in >1 version (\`cargo tree -d\`) | ${DUP_PKGS_MULTIVER} |"
   echo "| Distinct duplicate (name, version) units | ${DUP_UNIT_COUNT} |"
 } >"$SUMMARY"

--- a/scripts/build-baseline.sh
+++ b/scripts/build-baseline.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Build-time baseline harness for the agent-assembly Cargo workspace.
+# AAASM-2557 (Epic AAASM-2551 — Rust build & compile-time performance).
+#
+# Usage: bash scripts/build-baseline.sh
+#
+# Captures a reproducible before/after build-time profile so the
+# profile / linker / dedup / CI Stories (AAASM-2553/2554/2555/2556) can be
+# re-measured against the same harness. Four measurements are taken:
+#
+#   1. Cold build      — cargo clean, then `cargo build --workspace --timings`.
+#   2. Warm rebuild    — touch one leaf source file, then rebuild (link-bound).
+#   3. Test build+run  — `cargo nextest run --workspace` wall-clock.
+#   4. Duplicate deps  — `cargo tree -d` duplicate-version report.
+#
+# Raw outputs (logs, timing HTML, top-crate extraction, tree -d) are written
+# to target/build-baseline/ (gitignored). Re-run on any commit to compare.
+#
+# Environment overrides:
+#   CARGO                       cargo binary (default: cargo)
+#   BUILD_BASELINE_OUT          output dir (default: target/build-baseline)
+#   BUILD_BASELINE_WARM_FILE    file to touch for the warm rebuild
+#                               (default: aa-cli/src/main.rs)
+#   BUILD_BASELINE_INCLUDE_EBPF set to 1 to drop the `--exclude aa-ebpf` guard
+#                               (aa-ebpf needs a nightly toolchain + bpf-linker;
+#                               excluded by default to match `make build-workspace`)
+#   BUILD_BASELINE_TOP_N        crates listed in the top-crates report (default: 10)
+
+set -uo pipefail
+
+CARGO="${CARGO:-cargo}"
+OUT="${BUILD_BASELINE_OUT:-target/build-baseline}"
+WARM_FILE="${BUILD_BASELINE_WARM_FILE:-aa-cli/src/main.rs}"
+TOP_N="${BUILD_BASELINE_TOP_N:-10}"
+
+# aa-ebpf requires a nightly toolchain + bpf-linker; the workspace's own
+# `make build-workspace` / `make test` exclude it, so the baseline does too.
+EXCLUDE=(--exclude aa-ebpf)
+if [ "${BUILD_BASELINE_INCLUDE_EBPF:-0}" = "1" ]; then
+  EXCLUDE=()
+fi
+
+# Resolve to the repository root regardless of the caller's cwd.
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT" || exit 1
+mkdir -p "$OUT"
+
+echo "=== agent-assembly build-time baseline ==="
+echo "root:    $ROOT"
+echo "cargo:   $($CARGO --version)"
+echo "host:    $(uname -srm)"
+echo "exclude: ${EXCLUDE[*]:-<none>}"
+echo "out:     $OUT"
+echo
+
+# --- 1. Cold build (clean tree) -------------------------------------------
+echo ">>> cargo clean"
+$CARGO clean
+mkdir -p "$OUT"  # `cargo clean` wipes target/, including a pre-created $OUT
+COLD_LOG="$OUT/cold-build.log"
+echo ">>> cold build: $CARGO build --workspace ${EXCLUDE[*]} --timings"
+COLD_START=$SECONDS
+$CARGO build --workspace "${EXCLUDE[@]}" --timings >"$COLD_LOG" 2>&1
+COLD_REAL=$(( SECONDS - COLD_START ))
+echo "    cold build: ${COLD_REAL}s  (log: $COLD_LOG)"
+
+# Archive the generated --timings HTML next to the rest of the baseline
+# (pick the most recently modified one without parsing `ls`).
+TIMING_HTML=""
+for f in target/cargo-timings/cargo-timing-*.html; do
+  [ -e "$f" ] || continue
+  if [ -z "$TIMING_HTML" ] || [ "$f" -nt "$TIMING_HTML" ]; then
+    TIMING_HTML="$f"
+  fi
+done
+if [ -n "$TIMING_HTML" ]; then
+  cp "$TIMING_HTML" "$OUT/cargo-timing.html"
+  echo "    timings:    $OUT/cargo-timing.html"
+fi
+
+# --- top-N longest-compiling crates from the timings HTML ------------------
+TOP_LOG="$OUT/top-crates.txt"
+if [ -n "$TIMING_HTML" ] && command -v python3 >/dev/null 2>&1; then
+  python3 - "$OUT/cargo-timing.html" "$TOP_N" >"$TOP_LOG" <<'PY'
+import json, re, sys
+html = open(sys.argv[1], encoding="utf-8", errors="replace").read()
+top_n = int(sys.argv[2])
+# cargo embeds the per-unit timing data as JSON objects carrying both a
+# "name" and a "duration" key; pull them out tolerantly of the surrounding JS.
+units = {}
+for m in re.finditer(r'\{[^{}]*?"duration":[0-9.]+[^{}]*?\}', html):
+    try:
+        o = json.loads(m.group(0))
+    except Exception:
+        continue
+    if "name" in o and "duration" in o:
+        # A crate may compile twice (lib + test/bench); keep the largest unit.
+        key = "%s %s" % (o.get("name"), o.get("version", ""))
+        units[key] = max(units.get(key, 0.0), float(o["duration"]))
+ranked = sorted(units.items(), key=lambda kv: kv[1], reverse=True)[:top_n]
+print("rank  duration(s)  crate")
+for i, (name, dur) in enumerate(ranked, 1):
+    print("%4d  %11.1f  %s" % (i, dur, name.strip()))
+PY
+  echo "    top crates: $TOP_LOG"
+else
+  echo "(top-crate extraction skipped: no timings HTML or python3)" >"$TOP_LOG"
+fi
+
+# --- 2. Warm incremental rebuild (one-line / mtime touch) ------------------
+WARM_LOG="$OUT/warm-rebuild.log"
+if [ -f "$WARM_FILE" ]; then
+  touch "$WARM_FILE"
+  echo ">>> warm rebuild after touching $WARM_FILE"
+  WARM_START=$SECONDS
+  $CARGO build --workspace "${EXCLUDE[@]}" >"$WARM_LOG" 2>&1
+  WARM_REAL=$(( SECONDS - WARM_START ))
+  echo "    warm rebuild: ${WARM_REAL}s  (log: $WARM_LOG)"
+else
+  WARM_REAL=""
+  echo "(warm rebuild skipped: $WARM_FILE not found)" >"$WARM_LOG"
+fi
+
+# --- 3. Test build + run wall-clock ---------------------------------------
+TEST_LOG="$OUT/nextest.log"
+echo ">>> test build+run: $CARGO nextest run --workspace ${EXCLUDE[*]}"
+TEST_START=$SECONDS
+$CARGO nextest run --workspace "${EXCLUDE[@]}" >"$TEST_LOG" 2>&1
+TEST_REAL=$(( SECONDS - TEST_START ))
+echo "    test build+run: ${TEST_REAL}s  (log: $TEST_LOG)"
+
+# --- 4. Duplicate-dependency report ---------------------------------------
+DUPS_LOG="$OUT/cargo-tree-dups.txt"
+echo ">>> cargo tree -d (duplicate versions)"
+$CARGO tree -d >"$DUPS_LOG" 2>&1 || true
+DUP_COUNT="$(grep -cE '^[a-zA-Z0-9_-]+ v[0-9]' "$DUPS_LOG" 2>/dev/null || echo 0)"
+echo "    duplicate roots: ${DUP_COUNT}  (report: $DUPS_LOG)"
+
+# --- Summary ---------------------------------------------------------------
+SUMMARY="$OUT/summary.md"
+{
+  echo "# Build-time baseline — raw run"
+  echo
+  echo "- host: \`$(uname -srm)\`"
+  echo "- cargo: \`$($CARGO --version)\`"
+  echo "- exclude: \`${EXCLUDE[*]:-<none>}\`"
+  echo
+  echo "| Measurement | Wall-clock |"
+  echo "|---|---|"
+  echo "| Cold build (\`build --workspace --timings\`) | ${COLD_REAL}s |"
+  echo "| Warm rebuild (touch \`${WARM_FILE}\`) | ${WARM_REAL:-n/a}s |"
+  echo "| Test build+run (\`nextest run --workspace\`) | ${TEST_REAL}s |"
+  echo "| \`cargo tree -d\` duplicate roots | ${DUP_COUNT} |"
+} >"$SUMMARY"
+
+echo
+echo "=== done — summary written to $SUMMARY ==="
+cat "$SUMMARY"

--- a/scripts/build-baseline.sh
+++ b/scripts/build-baseline.sh
@@ -82,22 +82,22 @@ fi
 TOP_LOG="$OUT/top-crates.txt"
 if [ -n "$TIMING_HTML" ] && command -v python3 >/dev/null 2>&1; then
   python3 - "$OUT/cargo-timing.html" "$TOP_N" >"$TOP_LOG" <<'PY'
-import json, re, sys
+import json, sys
 html = open(sys.argv[1], encoding="utf-8", errors="replace").read()
 top_n = int(sys.argv[2])
-# cargo embeds the per-unit timing data as JSON objects carrying both a
-# "name" and a "duration" key; pull them out tolerantly of the surrounding JS.
-units = {}
-for m in re.finditer(r'\{[^{}]*?"duration":[0-9.]+[^{}]*?\}', html):
-    try:
-        o = json.loads(m.group(0))
-    except Exception:
-        continue
-    if "name" in o and "duration" in o:
-        # A crate may compile twice (lib + test/bench); keep the largest unit.
-        key = "%s %s" % (o.get("name"), o.get("version", ""))
-        units[key] = max(units.get(key, 0.0), float(o["duration"]))
-ranked = sorted(units.items(), key=lambda kv: kv[1], reverse=True)[:top_n]
+# cargo embeds the per-unit timing data as a pretty-printed JSON array
+# assigned to `const UNIT_DATA = [ ... ];`. Slice that array out and parse it.
+seg = html.split("const UNIT_DATA", 1)[1]
+seg = seg.split("\nconst ", 1)[0]
+arr = seg[seg.index("["): seg.rindex("]") + 1]
+data = json.loads(arr)
+# A crate compiles as several units (build-script, lib, codegen); sum them
+# per (name, version) to get the crate's total wall-clock compile cost.
+agg = {}
+for o in data:
+    key = "%s %s" % (o.get("name"), o.get("version", ""))
+    agg[key] = agg.get(key, 0.0) + float(o.get("duration", 0.0))
+ranked = sorted(agg.items(), key=lambda kv: kv[1], reverse=True)[:top_n]
 print("rank  duration(s)  crate")
 for i, (name, dur) in enumerate(ranked, 1):
     print("%4d  %11.1f  %s" % (i, dur, name.strip()))
@@ -133,8 +133,15 @@ echo "    test build+run: ${TEST_REAL}s  (log: $TEST_LOG)"
 DUPS_LOG="$OUT/cargo-tree-dups.txt"
 echo ">>> cargo tree -d (duplicate versions)"
 $CARGO tree -d >"$DUPS_LOG" 2>&1 || true
-DUP_COUNT="$(grep -cE '^[a-zA-Z0-9_-]+ v[0-9]' "$DUPS_LOG" 2>/dev/null || echo 0)"
-echo "    duplicate roots: ${DUP_COUNT}  (report: $DUPS_LOG)"
+# Column-0 lines are the duplicate-group headers ("<name> v<ver>"); the
+# indented lines below each are the dependents. The headline metric is the
+# number of packages that appear with MORE THAN ONE version — those are the
+# crates compiled twice (what AAASM-2555's dedup targets). Same-version repeats
+# (feature/dep-kind splits) compile once, so they are not counted.
+DUP_PAIRS="$(grep -E '^[A-Za-z0-9][A-Za-z0-9_+.-]* v[0-9]' "$DUPS_LOG" | awk '{print $1, $2}' | sort -u)"
+DUP_PKGS_MULTIVER="$(printf '%s\n' "$DUP_PAIRS" | awk 'NF{c[$1]++} END{n=0; for(k in c) if(c[k]>1) n++; print n+0}')"
+DUP_UNIT_COUNT="$(printf '%s\n' "$DUP_PAIRS" | awk 'NF' | wc -l | tr -d ' ')"
+echo "    packages with >1 version: ${DUP_PKGS_MULTIVER}  (distinct duplicate units: ${DUP_UNIT_COUNT}; report: $DUPS_LOG)"
 
 # --- Summary ---------------------------------------------------------------
 SUMMARY="$OUT/summary.md"
@@ -150,7 +157,8 @@ SUMMARY="$OUT/summary.md"
   echo "| Cold build (\`build --workspace --timings\`) | ${COLD_REAL}s |"
   echo "| Warm rebuild (touch \`${WARM_FILE}\`) | ${WARM_REAL:-n/a}s |"
   echo "| Test build+run (\`nextest run --workspace\`) | ${TEST_REAL}s |"
-  echo "| \`cargo tree -d\` duplicate roots | ${DUP_COUNT} |"
+  echo "| Packages built in >1 version (\`cargo tree -d\`) | ${DUP_PKGS_MULTIVER} |"
+  echo "| Distinct duplicate (name, version) units | ${DUP_UNIT_COUNT} |"
 } >"$SUMMARY"
 
 echo

--- a/scripts/build-baseline.sh
+++ b/scripts/build-baseline.sh
@@ -122,10 +122,14 @@ else
 fi
 
 # --- 3. Test build + run wall-clock ---------------------------------------
+# `--no-fail-fast` so a single flaky/slow test (e.g. a timing-sensitive
+# integration assertion) does not truncate the wall-clock — the baseline must
+# reflect compiling every test binary plus running the whole suite, matching
+# what CI does. Test failures are expected to leave the number unchanged.
 TEST_LOG="$OUT/nextest.log"
-echo ">>> test build+run: $CARGO nextest run --workspace ${EXCLUDE[*]}"
+echo ">>> test build+run: $CARGO nextest run --workspace ${EXCLUDE[*]} --no-fail-fast"
 TEST_START=$SECONDS
-$CARGO nextest run --workspace "${EXCLUDE[@]}" >"$TEST_LOG" 2>&1
+$CARGO nextest run --workspace "${EXCLUDE[@]}" --no-fail-fast >"$TEST_LOG" 2>&1
 TEST_REAL=$(( SECONDS - TEST_START ))
 echo "    test build+run: ${TEST_REAL}s  (log: $TEST_LOG)"
 


### PR DESCRIPTION
## Description

Implements **AAASM-2573** (implementation subtask of Story **AAASM-2557** —
_Establish build-time baseline_, under Epic **AAASM-2551** _Rust build &
compile-time performance_).

Adds a reusable, measurement-only build-time harness and records the pre-Epic
baseline so the profile (AAASM-2553), dev/linker (AAASM-2554), dependency-dedup
(AAASM-2555), and CI (AAASM-2556) Stories can each quote a before/after against
the **same** harness.

- `scripts/build-baseline.sh` — `cargo clean` + cold `cargo build --workspace --timings`,
  warm rebuild (touch a leaf source, relink), test-binary build (`nextest --no-run`),
  and `cargo tree -d`; archives logs, the timings HTML, top-crate extraction, and the
  duplicate report under `target/build-baseline/` (gitignored). Full suite run is opt-in
  (`BUILD_BASELINE_RUN_TESTS=1`) since it is dominated by integration-test runtime.
- `make build-baseline` — convenience wrapper.
- `docs/src/benchmarks/build-time-baseline.md` (+ `SUMMARY.md` link) — methodology and the
  recorded baseline.

### Recorded baseline (macOS arm64, 2026-06-05, pre-Epic config)

| Measurement | Wall-clock |
|---|---|
| Cold build (`build --workspace --timings`) | 124 s |
| Warm rebuild (touch `aa-cli/src/main.rs`) | 5 s |
| Test build (`nextest run --no-run`) | 396 s |
| Packages built in >1 version (`cargo tree -d`) | 34 |

Top long poles: `aws-lc-sys`, `wasmtime`/`cranelift-codegen`, `rustls`,
`libsqlite3-sys` — i.e. the WASM + crypto stacks, confirming the Epic hypothesis.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

No product or profile/config change — this Story is measurement-only.

## Related Issues

- Related Jira ticket: AAASM-2573 (Story AAASM-2557, Epic AAASM-2551)
- Related GitHub issues: n/a

## Testing

Describe the testing performed for this PR:

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

Harness was run end-to-end three times (cold-build variance 91–211 s noted in the
doc); shellcheck-clean; markdownlint-clean; no Rust/product code changed.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
