### PR TITLE
[AAASM-2587] ✅ (aa-runtime): Verify aa-runtime enforcement gate acceptance criteria

### DIFF
--- a/aa-runtime/tests/aaasm_2568_gate_verification.rs
+++ b/aa-runtime/tests/aaasm_2568_gate_verification.rs
@@ -1,0 +1,99 @@
+//! AAASM-2568 verification — the `aa-runtime` enforcement gate cannot be bypassed.
+//!
+//! Drives the public [`aa_runtime::pipeline::run`] loop end-to-end and proves the
+//! Story acceptance criteria: every inbound event is scanned + redacted before it
+//! is forwarded/audited, on **both** the batch path and the violation path, and
+//! the raw secret never leaves the runtime regardless of SDK behaviour.
+//!
+//! See `verification-reports/verification-report-AAASM-2568.md`.
+
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+use std::time::Duration;
+
+use aa_proto::assembly::audit::v1::{audit_event::Detail, AuditEvent, ToolCallDetail};
+use aa_proto::assembly::common::v1::ActionType;
+use aa_runtime::approval::ApprovalQueue;
+use aa_runtime::ipc::{new_response_router, IpcFrame};
+use aa_runtime::pipeline::{run, PipelineConfig, PipelineEvent, PipelineMetrics};
+use aa_runtime::policy::PolicyRules;
+use tokio::sync::{broadcast, mpsc};
+use tokio_util::sync::CancellationToken;
+
+/// An AWS access-key id the credential scanner detects via the `AKIA` literal.
+const SECRET: &str = "AKIAIOSFODNN7EXAMPLE";
+
+fn verify_config(batch_size: usize) -> PipelineConfig {
+    PipelineConfig {
+        input_buffer: 1_024,
+        batch_size,
+        flush_interval: Duration::from_millis(10_000),
+        broadcast_capacity: 1_024,
+        agent_id: "verify-agent".to_string(),
+    }
+}
+
+/// A ToolCall `AuditEvent` whose `args_json` embeds [`SECRET`].
+fn tool_call_with_secret() -> AuditEvent {
+    AuditEvent {
+        action_type: ActionType::ToolCall as i32,
+        detail: Some(Detail::ToolCall(ToolCallDetail {
+            args_json: format!(r#"{{"api_key": "{SECRET}"}}"#).into_bytes(),
+            ..Default::default()
+        })),
+        ..Default::default()
+    }
+}
+
+/// Assert that a forwarded pipeline event's `args_json` is redacted, not raw.
+fn assert_redacted(event: PipelineEvent) {
+    let PipelineEvent::Audit(enriched) = event else {
+        panic!("expected a PipelineEvent::Audit");
+    };
+    let Some(Detail::ToolCall(tc)) = enriched.inner.detail else {
+        panic!("expected ToolCall detail");
+    };
+    let body = String::from_utf8(tc.args_json).expect("redacted text is utf-8");
+    assert!(!body.contains(SECRET), "raw secret must never leave the runtime");
+    assert!(body.contains("[REDACTED:"), "redaction marker present");
+}
+
+/// Spin up the real pipeline with `policy`, push one secret-bearing ToolCall,
+/// and return the single forwarded event.
+async fn drive_one(policy: PolicyRules) -> PipelineEvent {
+    let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
+    let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<PipelineEvent>(64);
+    let metrics = Arc::new(PipelineMetrics::default());
+    let token = CancellationToken::new();
+
+    tokio::spawn(run(
+        rx,
+        broadcast_tx,
+        verify_config(1),
+        metrics,
+        token.clone(),
+        Arc::new(policy),
+        new_response_router(),
+        ApprovalQueue::new(),
+        None,
+        Arc::new(AtomicU64::new(0)),
+    ));
+
+    tx.send((0, IpcFrame::EventReport(tool_call_with_secret())))
+        .await
+        .expect("send event");
+    let event = tokio::time::timeout(Duration::from_millis(500), broadcast_rx.recv())
+        .await
+        .expect("timed out waiting for forwarded event")
+        .expect("broadcast error");
+    token.cancel();
+    event
+}
+
+/// AC: every inbound event is scanned + redacted before forward/audit on the
+/// normal (batch) path — no policy rules, so the event is batched then flushed.
+#[tokio::test]
+async fn gate_redacts_on_batch_path() {
+    let event = drive_one(PolicyRules::default()).await;
+    assert_redacted(event);
+}

--- a/aa-runtime/tests/aaasm_2568_gate_verification.rs
+++ b/aa-runtime/tests/aaasm_2568_gate_verification.rs
@@ -16,7 +16,7 @@ use aa_proto::assembly::common::v1::ActionType;
 use aa_runtime::approval::ApprovalQueue;
 use aa_runtime::ipc::{new_response_router, IpcFrame};
 use aa_runtime::pipeline::{run, PipelineConfig, PipelineEvent, PipelineMetrics};
-use aa_runtime::policy::PolicyRules;
+use aa_runtime::policy::{PolicyRule, PolicyRules};
 use tokio::sync::{broadcast, mpsc};
 use tokio_util::sync::CancellationToken;
 
@@ -95,5 +95,21 @@ async fn drive_one(policy: PolicyRules) -> PipelineEvent {
 #[tokio::test]
 async fn gate_redacts_on_batch_path() {
     let event = drive_one(PolicyRules::default()).await;
+    assert_redacted(event);
+}
+
+/// AC: redaction also happens on the violation path. A rule blocking `TOOL_CALL`
+/// routes the secret-bearing event onto the immediate broadcast path, which must
+/// still be redacted — the gate is independent of the forwarding decision.
+#[tokio::test]
+async fn gate_redacts_on_violation_path() {
+    let policy = PolicyRules {
+        rules: vec![PolicyRule {
+            name: "block-tools".to_string(),
+            blocked_actions: vec!["TOOL_CALL".to_string()],
+            ..Default::default()
+        }],
+    };
+    let event = drive_one(policy).await;
     assert_redacted(event);
 }

--- a/verification-reports/verification-report-AAASM-2568.md
+++ b/verification-reports/verification-report-AAASM-2568.md
@@ -1,0 +1,64 @@
+# Verification Report — AAASM-2568
+
+**Story:** 🔒 (agent-assembly) `aa-runtime` authoritative scan/redact/normalize enforcement stage **\[GATE\]**
+**Epic:** AAASM-2552 — SDK security boundary + FFI consolidation (runtime is the enforcement authority)
+**Component / repo:** `agent-assembly` (Rust monorepo)
+**Verified at:** ST-4 (AAASM-2587), stacked on AAASM-2584 → AAASM-2585 → AAASM-2586.
+
+## Summary
+
+`aa-runtime` is now the authoritative scan/redact/normalize enforcement point. A
+single precompiled `RuntimeScanner` runs **unconditionally** on every inbound
+event, mutating the allowlisted secret-bearing fields in place **before** the
+event is forwarded or audited — on both the batch path and the immediate
+violation-broadcast path. No SDK-supplied signal can shorten or skip this work.
+
+Full `aa-runtime` suite: **258 passed, 2 skipped** (`cargo nextest run -p aa-runtime`).
+
+## Implementation map
+
+| Subtask | PR | What |
+|---|---|---|
+| AAASM-2584 | #924 | `aa-runtime/src/pipeline/enforcement.rs` — `EnforcementConfig`, `OversizedPolicy`, `EnforcementOutcome`, `RuntimeScanner` (one precompiled `aa_core::CredentialScanner`), `enforce()` over the field allowlist |
+| AAASM-2585 | #926 | `emit_metrics()` — latency / payload-size / finding-count / oversized |
+| AAASM-2586 | #927 | Wired into `pipeline::run()` before `is_policy_violation`, covering both forward paths |
+| AAASM-2587 | (this) | End-to-end verification suite + this report |
+
+## Acceptance criteria → evidence
+
+### AC1 — Every inbound event is scanned + redacted + normalized at the runtime **before** forward/audit, independent of SDK behaviour
+
+- Wiring: `aa-runtime/src/pipeline/mod.rs` — `RuntimeScanner` is built once before the loop and `scanner.enforce(&mut enriched)` is called in the `IpcFrame::EventReport` arm **before** `is_policy_violation` and before any `broadcast_tx.send` / batch push. Pipeline order is `enrich → enforce(scan/redact/normalize) → is_policy_violation → forward/batch`.
+- Field allowlist (`enforcement.rs::scan_detail`): `tool_call.args_json` (bytes→UTF-8 normalize) + `error_message`, `file_op.path`, `process.command` + `args[]`. Non-secret-bearing details (`LlmCall`/`Network`/`Violation`/`Approval`) are matched explicitly and skipped.
+- Tests: `enforcement::tests::{tool_call_args_json_secret_is_redacted_in_place, tool_call_error_message_secret_is_redacted, file_op_path_secret_is_redacted, process_command_and_args_secrets_are_redacted}` (unit) and `aaasm_2568_gate_verification::gate_redacts_on_batch_path` (end-to-end through `run()`).
+
+### AC2 — Raw secrets never leave the runtime (not forwarded, not audited), proven by the bypass suite
+
+- `aa-runtime/tests/aaasm_2568_gate_verification.rs` drives the real `run()` loop and asserts the forwarded `PipelineEvent` carries `[REDACTED:*]` and **never** the raw secret, on:
+  - the **batch path** — `gate_redacts_on_batch_path`
+  - the **violation path** — `gate_redacts_on_violation_path`
+- Unit-level: `oversized_field_is_redacted_whole_fail_closed` proves a secret hidden past the size cap is dropped (fail-closed), never forwarded raw.
+
+### AC3 — No code path lets an SDK-supplied flag skip scanning
+
+- The wire `AuditEvent` (`proto/audit.proto`) has **no** `clean` / `already_scanned` / pre-scanned field — `grep -ci 'already_scanned\|clean' proto/audit.proto` → `0`.
+- `enforce()` takes no such parameter and is called unconditionally; `scan_detail` has no early-out keyed on event content. Reuse across events is covered by `enforcement::tests::one_scanner_redacts_across_multiple_events`.
+
+### AC4 — Scan-latency / payload-size / finding-count metrics emitted; p99 within budget (or revised budget documented)
+
+- `enforcement.rs::emit_metrics` emits on every `enforce()`:
+  - `aa_runtime_scan_latency_seconds` (histogram, measured around scan+redact only)
+  - `aa_runtime_scan_payload_bytes` (histogram)
+  - `aa_runtime_scan_findings_total{kind}` (counter, labelled by `CredentialKind` — never the raw secret)
+  - `aa_runtime_scan_oversized_total` (counter)
+- Test: `enforcement::tests::enforce_emits_scan_metrics` installs a local Prometheus recorder and asserts the families render while the raw secret never appears in the exposition.
+- **Latency budget:** the scan is an O(n) Aho-Corasick pass over a size-capped (64 KiB default) field set; the `aa_runtime_scan_latency_seconds` histogram makes the real distribution observable in deployment. No regression to the existing pipeline latency tests was observed. The policy-latency SLA continues to be governed by the gateway's `policy_latency_test`; if field-scan latency is later shown to approach the budget, the cap (`EnforcementConfig::max_field_bytes`) is the documented tuning knob.
+
+### AC5 — Gateway sanitizer retained as backstop
+
+- `aa-gateway/src/sanitizer/{mod,event,rules,sanitize}.rs` are unchanged by this Story — the banned-key write-side backstop remains in place. This work adds a layer at the runtime; it removes nothing.
+
+## Notes
+
+- The scanner is sourced from `aa_core::CredentialScanner` (already an `aa-runtime` dependency). When AAASM-2567 extracts `aa-security`, the import swaps `aa_core` → `aa-security` with no behavioural change.
+- This Story is **the gate**: Stories 6–9 (AAASM-2570/2560/2561/2562) — any removal or thinning of SDK-side scanning — may now proceed.


### PR DESCRIPTION
## Description

Verification subtask (final) for the **\[GATE\]** Story AAASM-2568 (Epic AAASM-2552). **Stacked on #927 → #926 → #924** — merge those first; this PR's diff narrows to the verification test + report once they land.

- Adds `aa-runtime/tests/aaasm_2568_gate_verification.rs` — an end-to-end integration test that drives the public `pipeline::run()` loop and asserts a secret-bearing ToolCall is redacted before forward on **both** the batch path (`gate_redacts_on_batch_path`) and the violation path (`gate_redacts_on_violation_path`).
- Adds `verification-reports/verification-report-AAASM-2568.md` mapping each Story AC → evidence (tests, file refs, run output).

### AC coverage (see report)
- Scan + redact before forward/audit, both paths ✔
- Raw secrets never leave the runtime ✔ (asserted end-to-end)
- No SDK skip flag exists (`grep` of `proto/audit.proto` for `clean`/`already_scanned` → 0) ✔
- Latency / payload-size / finding-count / oversized metrics emitted ✔
- Gateway sanitizer retained (untouched) ✔

`cargo nextest run -p aa-runtime` → **258 passed, 2 skipped**.

## Type of Change

- [x] ✅ Tests
- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2587 (verification subtask of AAASM-2568, Epic AAASM-2552)
- Stacked on: #927 (AAASM-2586), #926 (AAASM-2585), #924 (AAASM-2584)

## Testing

- [x] Integration tests added / updated

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
