### PR TITLE
[AAASM-2593] ✨ (runtime): Wire AuditPublisher into aa-runtime startup

### DIFF
--- a/aa-runtime/src/config.rs
+++ b/aa-runtime/src/config.rs
@@ -88,6 +88,22 @@ pub struct RuntimeConfig {
     /// Read from `AA_CORRELATION_INTERVAL_MS`. Defaults to `1_000`.
     /// Zero falls back to the default.
     pub correlation_interval_ms: u64,
+
+    /// Path to the `agent-assembly.toml` whose `[gateway.nats]` table configures
+    /// the audit publisher.
+    ///
+    /// Read from `AA_NATS_CONFIG_PATH`.
+    /// - Not set or empty → `None` (audit publisher disabled; agent still runs)
+    /// - Non-empty string → `Some(<value>)`
+    pub nats_config_path: Option<PathBuf>,
+
+    /// Path to the local SQLite fallback buffer that holds audit events which
+    /// cannot be published while NATS is unreachable.
+    ///
+    /// Read from `AA_AUDIT_BUFFER_PATH`; defaults to
+    /// `<temp-dir>/aa-audit-buffer-<agent_id>.db`. Only used when the audit
+    /// publisher is enabled.
+    pub audit_buffer_path: PathBuf,
 }
 
 impl RuntimeConfig {
@@ -114,6 +130,8 @@ impl RuntimeConfig {
     /// | `AA_GATEWAY_ENDPOINT` | `Option<String>` | `None` |
     /// | `AA_CORRELATION_WINDOW_MS` | `u64` | `5_000` |
     /// | `AA_CORRELATION_INTERVAL_MS` | `u64` | `1_000` |
+    /// | `AA_NATS_CONFIG_PATH` | `Option<PathBuf>` | `None` (publisher disabled) |
+    /// | `AA_AUDIT_BUFFER_PATH` | `PathBuf` | `<temp>/aa-audit-buffer-<agent_id>.db` |
     pub fn from_env() -> Result<Self, String> {
         let agent_id = std::env::var("AA_AGENT_ID").map_err(|_| "AA_AGENT_ID is required but not set".to_string())?;
 
@@ -187,6 +205,17 @@ impl RuntimeConfig {
             .filter(|&n| n > 0)
             .unwrap_or(1_000);
 
+        let nats_config_path = std::env::var("AA_NATS_CONFIG_PATH")
+            .ok()
+            .filter(|v| !v.is_empty())
+            .map(PathBuf::from);
+
+        let audit_buffer_path = std::env::var("AA_AUDIT_BUFFER_PATH")
+            .ok()
+            .filter(|v| !v.is_empty())
+            .map(PathBuf::from)
+            .unwrap_or_else(|| std::env::temp_dir().join(format!("aa-audit-buffer-{agent_id}.db")));
+
         Ok(Self {
             agent_id,
             worker_threads,
@@ -201,6 +230,8 @@ impl RuntimeConfig {
             gateway_endpoint,
             correlation_window_ms,
             correlation_interval_ms,
+            nats_config_path,
+            audit_buffer_path,
         })
     }
 }

--- a/aa-runtime/src/config.rs
+++ b/aa-runtime/src/config.rs
@@ -684,4 +684,48 @@ mod tests {
         std::env::remove_var("AA_CORRELATION_WINDOW_MS");
         std::env::remove_var("AA_CORRELATION_INTERVAL_MS");
     }
+
+    #[test]
+    fn nats_config_path_set_yields_some_unset_yields_none() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AA_AGENT_ID", "agent-nats");
+
+        std::env::set_var("AA_NATS_CONFIG_PATH", "/etc/aa/agent-assembly.toml");
+        let configured = RuntimeConfig::from_env().unwrap();
+        assert_eq!(
+            configured.nats_config_path,
+            Some(PathBuf::from("/etc/aa/agent-assembly.toml"))
+        );
+
+        // Empty value ⇒ publisher disabled.
+        std::env::set_var("AA_NATS_CONFIG_PATH", "");
+        assert!(RuntimeConfig::from_env().unwrap().nats_config_path.is_none());
+
+        std::env::remove_var("AA_NATS_CONFIG_PATH");
+        assert!(RuntimeConfig::from_env().unwrap().nats_config_path.is_none());
+
+        std::env::remove_var("AA_AGENT_ID");
+    }
+
+    #[test]
+    fn audit_buffer_path_defaults_per_agent_and_honors_override() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AA_AGENT_ID", "agent-buf");
+        std::env::remove_var("AA_AUDIT_BUFFER_PATH");
+
+        let default_cfg = RuntimeConfig::from_env().unwrap();
+        assert_eq!(
+            default_cfg.audit_buffer_path,
+            std::env::temp_dir().join("aa-audit-buffer-agent-buf.db")
+        );
+
+        std::env::set_var("AA_AUDIT_BUFFER_PATH", "/var/lib/aa/buf.db");
+        assert_eq!(
+            RuntimeConfig::from_env().unwrap().audit_buffer_path,
+            PathBuf::from("/var/lib/aa/buf.db")
+        );
+
+        std::env::remove_var("AA_AGENT_ID");
+        std::env::remove_var("AA_AUDIT_BUFFER_PATH");
+    }
 }

--- a/aa-runtime/src/correlation/config.rs
+++ b/aa-runtime/src/correlation/config.rs
@@ -77,6 +77,8 @@ mod tests {
             gateway_endpoint: None,
             correlation_window_ms: 8_000,
             correlation_interval_ms: 2_000,
+            nats_config_path: None,
+            audit_buffer_path: std::path::PathBuf::from("/tmp/aa-audit-buffer-test.db"),
         };
 
         let config = CorrelationConfig::from_runtime_config(&rc);

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -648,6 +648,8 @@ mod tests {
             gateway_endpoint: None,
             correlation_window_ms: 5_000,
             correlation_interval_ms: 1_000,
+            nats_config_path: None,
+            audit_buffer_path: std::path::PathBuf::from("/tmp/aa-audit-buffer-test.db"),
         };
 
         let pipeline_config = PipelineConfig::from_runtime_config(&runtime_config);

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -1109,6 +1109,39 @@ mod tests {
             }
         }
     }
+
+    /// A minimal config for exercising the audit-publisher builder.
+    fn audit_test_config(nats_config_path: Option<std::path::PathBuf>) -> crate::config::RuntimeConfig {
+        crate::config::RuntimeConfig {
+            agent_id: "audit-test".to_string(),
+            worker_threads: 0,
+            shutdown_timeout_secs: 30,
+            ipc_max_connections: 64,
+            pipeline_input_buffer: 10_000,
+            pipeline_batch_size: 100,
+            pipeline_flush_interval_ms: 100,
+            pipeline_broadcast_capacity: 1_024,
+            metrics_addr: "0.0.0.0:8080".to_string(),
+            policy_path: None,
+            gateway_endpoint: None,
+            correlation_window_ms: 5_000,
+            correlation_interval_ms: 1_000,
+            nats_config_path,
+            audit_buffer_path: std::env::temp_dir().join("aa-audit-buffer-audit-test.db"),
+        }
+    }
+
+    #[tokio::test]
+    async fn build_audit_publisher_disabled_when_unconfigured_or_unreadable() {
+        // Unconfigured (no AA_NATS_CONFIG_PATH) ⇒ disabled, agent unaffected.
+        assert!(super::build_audit_publisher(&audit_test_config(None)).await.is_none());
+
+        // Configured but the path does not exist ⇒ disabled, no startup failure.
+        let missing = std::env::temp_dir().join("aa-nonexistent-nats-config-xyz.toml");
+        assert!(super::build_audit_publisher(&audit_test_config(Some(missing)))
+            .await
+            .is_none());
+    }
 }
 
 // ── Layer integration tests ─────────────────────────────────────────────

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -338,6 +338,88 @@ fn emit_proxy_degradation(
     let _ = broadcast_tx.send(crate::pipeline::PipelineEvent::LayerDegradation(info));
 }
 
+/// Capacity of the channel carrying governance audit entries from the approval
+/// queue to the publisher-drain task.
+const AUDIT_CHANNEL_CAPACITY: usize = 8_192;
+/// Capacity of the on-disk fallback buffer for audit events that cannot be
+/// published while NATS is unreachable.
+const AUDIT_BUFFER_CAPACITY: usize = 100_000;
+/// How often the reconnect-flush loop replays buffered audit events.
+const AUDIT_FLUSH_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Build the audit publisher when `AA_NATS_CONFIG_PATH` points at a readable
+/// config carrying a `[gateway.nats]` table.
+///
+/// Returns `None` — leaving the agent fully functional without audit publishing
+/// — when NATS is unconfigured, the config is unreadable/invalid, the buffer
+/// cannot be opened, or the initial NATS connection fails. None of these abort
+/// startup (AAASM-2547).
+async fn build_audit_publisher(
+    config: &RuntimeConfig,
+) -> Option<std::sync::Arc<crate::audit_publisher::AuditPublisher>> {
+    let path = config.nats_config_path.as_ref()?;
+    let toml = match std::fs::read_to_string(path) {
+        Ok(toml) => toml,
+        Err(err) => {
+            tracing::warn!(error = %err, path = %path.display(), "audit publisher disabled — cannot read NATS config");
+            return None;
+        }
+    };
+    let nats_config = match crate::audit_publisher::NatsConfig::from_toml_str(&toml) {
+        Ok(cfg) => cfg,
+        Err(err) => {
+            tracing::warn!(error = %err, "audit publisher disabled — invalid [gateway.nats]");
+            return None;
+        }
+    };
+    let buffer = match aa_storage_sqlite_buffer::EventBuffer::new(&config.audit_buffer_path, AUDIT_BUFFER_CAPACITY) {
+        Ok(buffer) => std::sync::Arc::new(buffer),
+        Err(err) => {
+            tracing::warn!(error = %err, path = %config.audit_buffer_path.display(), "audit publisher disabled — cannot open buffer");
+            return None;
+        }
+    };
+    let sink = match crate::audit_publisher::NatsAuditSink::connect(&nats_config).await {
+        Ok(sink) => std::sync::Arc::new(sink) as std::sync::Arc<dyn aa_core::storage::AuditSink>,
+        Err(err) => {
+            tracing::warn!(error = %err, url = %nats_config.url, "audit publisher disabled — initial NATS connect failed");
+            return None;
+        }
+    };
+    tracing::info!(url = %nats_config.url, "audit publisher enabled");
+    Some(std::sync::Arc::new(crate::audit_publisher::AuditPublisher::new(
+        sink, buffer,
+    )))
+}
+
+/// Spawn (into `tracker`) the task that drains the approval audit stream into the
+/// publisher, fire-and-forget. On cancellation it drains any already-queued
+/// entries before exiting so a graceful shutdown loses nothing.
+fn spawn_audit_drain(
+    tracker: &TaskTracker,
+    mut rx: tokio::sync::mpsc::Receiver<aa_core::storage::AuditEntry>,
+    publisher: std::sync::Arc<crate::audit_publisher::AuditPublisher>,
+    token: CancellationToken,
+) {
+    tracker.spawn(async move {
+        loop {
+            tokio::select! {
+                _ = token.cancelled() => {
+                    while let Ok(entry) = rx.try_recv() {
+                        publisher.publish(entry).await;
+                    }
+                    break;
+                }
+                maybe = rx.recv() => match maybe {
+                    Some(entry) => publisher.publish(entry).await,
+                    None => break,
+                },
+            }
+        }
+        tracing::info!("audit drain task exiting");
+    });
+}
+
 /// Start the runtime and block until graceful shutdown completes.
 ///
 /// This is the main async entry point called from `main()`. It creates the
@@ -413,8 +495,23 @@ pub async fn run(config: RuntimeConfig) {
     // Shared response router — maps connection_id → per-connection IpcResponse sender.
     let response_router = crate::ipc::new_response_router();
 
+    // Audit publisher (AAASM-2547): when [gateway.nats] is configured, the
+    // approval queue's governance AuditEntry stream is drained to NATS; when
+    // unconfigured the queue runs without audit and the agent is unaffected.
+    let audit_publisher = build_audit_publisher(&config).await;
+    let audit_flush_loop = audit_publisher
+        .as_ref()
+        .map(|publisher| std::sync::Arc::clone(publisher).spawn_reconnect_flush_loop(AUDIT_FLUSH_INTERVAL));
+
     // Shared approval queue — holds pending human-approval requests.
-    let approval_queue = crate::approval::ApprovalQueue::new();
+    let approval_queue = match &audit_publisher {
+        Some(publisher) => {
+            let (audit_tx, audit_rx) = tokio::sync::mpsc::channel(AUDIT_CHANNEL_CAPACITY);
+            spawn_audit_drain(&tracker, audit_rx, std::sync::Arc::clone(publisher), token.clone());
+            crate::approval::ApprovalQueue::with_audit(audit_tx, [0u8; 32])
+        }
+        None => crate::approval::ApprovalQueue::new(),
+    };
 
     // Clone inbound_tx for the health/metrics handler before IpcServer consumes it.
     let inbound_tx_health = inbound_tx.clone();
@@ -605,6 +702,19 @@ pub async fn run(config: RuntimeConfig) {
         );
     } else {
         tracing::info!("all tasks completed cleanly");
+    }
+
+    // AAASM-2547: stop the reconnect loop and flush any audit events that
+    // buffered while NATS was unreachable, now that the drain task has finished.
+    if let Some(handle) = audit_flush_loop {
+        handle.abort();
+    }
+    if let Some(publisher) = &audit_publisher {
+        match publisher.flush_pending().await {
+            Ok(n) if n > 0 => tracing::info!(flushed = n, "flushed buffered audit events on shutdown"),
+            Ok(_) => {}
+            Err(err) => tracing::warn!(error = %err, "failed to flush audit buffer on shutdown"),
+        }
     }
 
     tracing::info!("aa-runtime stopped");


### PR DESCRIPTION
## Description

Wires the existing `AuditPublisher` (component shipped in AAASM-2387/2391/2392) into `aa-runtime` startup so governance audit events actually flow to NATS in production — the final producer-side link of the publisher → NATS → consumer → Postgres pipeline (Epic AAASM-2350).

- **Config** (`RuntimeConfig`): `AA_NATS_CONFIG_PATH` (unset ⇒ publisher disabled) points at the `agent-assembly.toml` whose `[gateway.nats]` table configures NATS; `AA_AUDIT_BUFFER_PATH` (default `<temp>/aa-audit-buffer-<agent_id>.db`) is the SQLite fallback buffer.
- **`build_audit_publisher`**: reads the TOML → `NatsConfig::from_toml_str` → `NatsAuditSink::connect` → `EventBuffer` → `AuditPublisher`. Any failure (unreadable/invalid config, buffer open, initial connect) logs a warning and returns `None` — **never aborts startup**.
- **`run()` wiring**: when enabled, the approval queue switches to `ApprovalQueue::with_audit(tx, …)` and a tracked drain task feeds its `AuditEntry` stream to `publisher.publish`. The reconnect-flush loop is started; on shutdown it's aborted and `flush_pending()` drains any buffered events.
- **NATS-less safety**: unconfigured deployments run exactly as before (publisher disabled).

Pipeline proto-`AuditEvent` → governance `AuditEntry` conversion is intentionally out of scope (the AC's "and/or"); the approval `AuditEntry` stream is the in-scope governance source.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No — additive; unconfigured runtime behaviour is unchanged.

## Related Issues

- Related Jira ticket: AAASM-2593 (Story AAASM-2547, Epic AAASM-2350)

## Testing

- [x] Unit tests added — config env parsing (`AA_NATS_CONFIG_PATH`/`AA_AUDIT_BUFFER_PATH`); `build_audit_publisher` disabled when unconfigured/unreadable
- [x] Existing aa-runtime suite (256 tests, incl. the NATS publisher testcontainers test) green
- e2e (governance decision → message on `assembly.audit.<tenant>.<agent>`) is owned by the verification subtask **AAASM-2594**

Local: `fmt`, `clippy --workspace --all-targets --all-features --exclude aa-ebpf -D warnings`, `cargo deny`, `cargo nextest -p aa-runtime` (256 passed), `cargo doc` — all green.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
