### PR TITLE
[AAASM-2595] ✨ (dashboard): Add light/dark theme support

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -4,6 +4,25 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Agent Assembly Dashboard</title>
+    <!-- Apply the saved/OS theme before first paint to avoid a flash of the
+         wrong theme. Mirrors getInitialTheme() in src/theme/useTheme.ts. -->
+    <script>
+      (function () {
+        try {
+          var k = 'aa-dashboard-theme';
+          var s = localStorage.getItem(k);
+          var t =
+            s === 'light' || s === 'dark'
+              ? s
+              : window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
+                ? 'dark'
+                : 'light';
+          document.documentElement.setAttribute('data-theme', t);
+        } catch (e) {
+          /* no-op: theme will be applied by React on mount */
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/dashboard/src/components/AppShell.tsx
+++ b/dashboard/src/components/AppShell.tsx
@@ -7,6 +7,7 @@ import { ApprovalsBellButton } from '../features/approvals/ApprovalsBellButton'
 import { CANONICAL_ROUTES, ROUTE_GROUPS, type RouteGroup } from '../routes'
 import { TraceDrawerProvider } from './trace/TraceDrawerProvider'
 import { TraceDrawer } from './trace/TraceDrawer'
+import { ThemeToggle } from './ThemeToggle'
 import './AppShell.css'
 
 const GROUP_LABEL: Record<RouteGroup, string> = {
@@ -109,6 +110,7 @@ export function AppShell() {
           <div className="appshell__user">
             <ApprovalsBellButton />
             <span data-testid="appshell-user">{token ?? ''}</span>
+            <ThemeToggle />
             <NavLink
               to="/settings"
               className="appshell__settings-link"

--- a/dashboard/src/components/SandboxSummaryCard.css
+++ b/dashboard/src/components/SandboxSummaryCard.css
@@ -6,7 +6,7 @@
  */
 
 .sandbox-summary-card {
-  --sandbox-amber: #d97706;
+  --sandbox-amber: var(--status-warning-solid);
   --sandbox-amber-bg: rgba(217, 119, 6, 0.08);
   --sandbox-amber-border: rgba(217, 119, 6, 0.32);
 
@@ -38,7 +38,7 @@
 .sandbox-summary-card__subtitle {
   margin: 0;
   font-size: 13px;
-  color: var(--ink-3, #4b5563);
+  color: var(--ink-3);
 }
 
 .sandbox-summary-card__policy {
@@ -46,7 +46,7 @@
 }
 
 .sandbox-summary-card__window {
-  color: var(--ink-4, #6b7280);
+  color: var(--ink-4);
 }
 
 .sandbox-summary-card__counts {
@@ -73,13 +73,13 @@
 .sandbox-summary-card__label {
   margin: 0;
   font-size: 12px;
-  color: var(--ink-3, #4b5563);
+  color: var(--ink-3);
 }
 
 .sandbox-summary-card__top-rule {
   margin: 0;
   font-size: 12px;
-  color: var(--ink-3, #4b5563);
+  color: var(--ink-3);
 }
 
 .sandbox-summary-card__top-rule code {
@@ -101,7 +101,7 @@
   border: 1px solid var(--sandbox-amber-border);
   border-radius: 4px;
   background: white;
-  color: var(--ink-2, #1f2937);
+  color: var(--ink-2);
   font-size: 12px;
   font-weight: 500;
   cursor: pointer;
@@ -123,6 +123,6 @@
 }
 
 .sandbox-summary-card__btn--enforce:hover:not(:disabled) {
-  background: #b45309;
-  border-color: #b45309;
+  background: color-mix(in oklab, var(--status-warning-solid) 88%, black);
+  border-color: color-mix(in oklab, var(--status-warning-solid) 88%, black);
 }

--- a/dashboard/src/components/ThemeToggle.tsx
+++ b/dashboard/src/components/ThemeToggle.tsx
@@ -1,0 +1,34 @@
+import { useTheme } from '../theme/useTheme'
+
+/**
+ * Sun / moon button that flips the dashboard between light and dark themes.
+ * Lives in the AppShell topbar. The icon shows the theme you'll switch TO.
+ */
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme()
+  const isDark = theme === 'dark'
+
+  return (
+    <button
+      type="button"
+      className="theme-toggle"
+      data-testid="theme-toggle"
+      onClick={toggleTheme}
+      aria-label={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+      title={isDark ? 'Switch to light theme' : 'Switch to dark theme'}
+    >
+      {isDark ? (
+        // Sun — click to go light
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="4" />
+          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41" />
+        </svg>
+      ) : (
+        // Moon — click to go dark
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+        </svg>
+      )}
+    </button>
+  )
+}

--- a/dashboard/src/components/ViolationHeatmap.tsx
+++ b/dashboard/src/components/ViolationHeatmap.tsx
@@ -128,7 +128,7 @@ export function ViolationHeatmap({ nodes, maxNodes = 1000 }: Props) {
               width: 24,
               height: 14,
               background: violationColor(r * maxViolations, maxViolations),
-              border: "1px solid #ccc",
+              border: "1px solid var(--line-2)",
             }}
           />
         ))}
@@ -138,7 +138,7 @@ export function ViolationHeatmap({ nodes, maxNodes = 1000 }: Props) {
       <svg
         width={WIDTH}
         height={HEIGHT}
-        style={{ border: "1px solid #e5e7eb", borderRadius: 6, background: "#fafafa" }}
+        style={{ border: "1px solid var(--surface-card-border)", borderRadius: 6, background: "var(--surface-subtle-bg)" }}
       >
         {/* Links */}
         <g transform="translate(40,40)">
@@ -151,7 +151,7 @@ export function ViolationHeatmap({ nodes, maxNodes = 1000 }: Props) {
                 y1={link.source.y}
                 x2={link.target.x}
                 y2={link.target.y}
-                stroke="#d1d5db"
+                style={{ stroke: "var(--line-2)" }}
                 strokeWidth={1.5}
               />
             );
@@ -175,13 +175,12 @@ export function ViolationHeatmap({ nodes, maxNodes = 1000 }: Props) {
                 onMouseLeave={() => setTooltip(null)}
                 data-testid={`heatmap-node-${d.data.agent_id}`}
               >
-                <circle r={NODE_R} fill={color} stroke="#6b7280" strokeWidth={1} />
+                <circle r={NODE_R} fill={color} style={{ stroke: "var(--ink-4)" }} strokeWidth={1} />
                 <text
                   textAnchor="middle"
                   dy="0.35em"
                   fontSize={9}
-                  fill="#1f2937"
-                  style={{ pointerEvents: "none" }}
+                  style={{ fill: "var(--ink)", pointerEvents: "none" }}
                 >
                   {d.data.violation_count}
                 </text>
@@ -199,7 +198,7 @@ export function ViolationHeatmap({ nodes, maxNodes = 1000 }: Props) {
             left: tooltip.x + 60,
             top: tooltip.y + 10,
             background: "white",
-            border: "1px solid #d1d5db",
+            border: "1px solid var(--line-2)",
             borderRadius: 6,
             padding: "8px 12px",
             boxShadow: "0 2px 8px rgba(0,0,0,.15)",
@@ -229,10 +228,10 @@ export function ViolationHeatmap({ nodes, maxNodes = 1000 }: Props) {
       )}
 
       {truncated && (
-        <div style={{ marginTop: 8, fontSize: 12, color: "#6b7280" }}>
+        <div style={{ marginTop: 8, fontSize: 12, color: "var(--text-muted)" }}>
           Showing {maxNodes} of {nodes.length} agents.{" "}
           <button
-            style={{ color: "#2563eb", background: "none", border: "none", cursor: "pointer", padding: 0 }}
+            style={{ color: "var(--shell-accent)", background: "none", border: "none", cursor: "pointer", padding: 0 }}
             onClick={() => setShowAll(true)}
           >
             Show all

--- a/dashboard/src/features/iam/AccessLogPanel.css
+++ b/dashboard/src/features/iam/AccessLogPanel.css
@@ -71,12 +71,12 @@
 
 .iam-access-log-table__result--success {
   background: var(--status-success-bg, rgba(46, 160, 67, 0.15));
-  color: var(--status-success, #2ea043);
+  color: var(--status-success);
 }
 
 .iam-access-log-table__result--failure {
   background: var(--status-danger-bg, rgba(218, 54, 51, 0.15));
-  color: var(--status-danger, #da3633);
+  color: var(--status-danger);
 }
 
 .iam-access-log-table__link {

--- a/dashboard/src/pages/AgentDetailDrawer.css
+++ b/dashboard/src/pages/AgentDetailDrawer.css
@@ -417,8 +417,8 @@
   display: inline-block;
   padding: 1px 7px;
   border-radius: 999px;
-  background-color: #fef3c7;
-  color: #d97706;
+  background-color: var(--badge-amber-bg);
+  color: var(--badge-amber-text);
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.3px;

--- a/dashboard/src/pages/Settings/Settings.css
+++ b/dashboard/src/pages/Settings/Settings.css
@@ -9,7 +9,7 @@
 }
 
 .settings-page__nav {
-  border-right: 1px solid var(--color-border, #e2e2e7);
+  border-right: 1px solid var(--surface-card-border);
   padding-right: 1rem;
 }
 
@@ -18,7 +18,7 @@
   font-size: 0.95rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--color-text-muted, #6b6b76);
+  color: var(--text-muted);
 }
 
 .settings-page__nav-list {
@@ -36,7 +36,7 @@
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--color-text-muted, #6b6b76);
+  color: var(--text-muted);
 }
 
 .settings-page__nav-link {
@@ -49,11 +49,11 @@
 }
 
 .settings-page__nav-link:hover {
-  background-color: var(--color-bg-hover, #f3f3f6);
+  background-color: var(--surface-hover-bg);
 }
 
 .settings-page__nav-link--active {
-  background-color: var(--color-bg-active, #e7ecf2);
+  background-color: var(--paper-3);
   font-weight: 600;
 }
 
@@ -78,7 +78,7 @@
 }
 
 .retention-policy__field-help {
-  color: var(--color-text-muted, #6b6b76);
+  color: var(--text-muted);
   font-size: 0.85rem;
   margin: 0.25rem 0 0.5rem 0;
 }
@@ -86,7 +86,7 @@
 .retention-policy__input,
 .retention-policy__select {
   padding: 0.45rem 0.6rem;
-  border: 1px solid var(--color-border, #d4d4d8);
+  border: 1px solid var(--shell-border);
   border-radius: 4px;
   font-size: 0.95rem;
   min-width: 14rem;
@@ -94,11 +94,11 @@
 
 .retention-policy__input--error,
 .retention-policy__select--error {
-  border-color: var(--color-danger, #c54242);
+  border-color: var(--danger);
 }
 
 .retention-policy__field-error {
-  color: var(--color-danger, #c54242);
+  color: var(--danger);
   font-size: 0.85rem;
   margin-top: 0.25rem;
 }
@@ -111,17 +111,17 @@
 
 .retention-policy__button {
   padding: 0.5rem 1rem;
-  border: 1px solid var(--color-border, #d4d4d8);
+  border: 1px solid var(--shell-border);
   border-radius: 4px;
-  background-color: var(--color-bg-button, #f6f6f9);
+  background-color: var(--paper-2);
   cursor: pointer;
   font-size: 0.95rem;
 }
 
 .retention-policy__button--primary {
-  background-color: var(--color-primary, #2563eb);
+  background-color: var(--shell-accent);
   color: white;
-  border-color: var(--color-primary, #2563eb);
+  border-color: var(--shell-accent);
 }
 
 .retention-policy__button:disabled {
@@ -131,12 +131,12 @@
 
 .retention-policy__last-run {
   margin-top: 2rem;
-  border-top: 1px solid var(--color-border, #e2e2e7);
+  border-top: 1px solid var(--surface-card-border);
   padding-top: 1rem;
 }
 
 .retention-policy__last-run-empty {
-  color: var(--color-text-muted, #6b6b76);
+  color: var(--text-muted);
   font-style: italic;
 }
 
@@ -148,7 +148,7 @@
 }
 
 .retention-policy__stat-label {
-  color: var(--color-text-muted, #6b6b76);
+  color: var(--text-muted);
   font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -167,17 +167,17 @@
 }
 
 .retention-policy__status--success {
-  background-color: var(--color-bg-success, #e7f6ec);
-  color: var(--color-success, #237a3b);
+  background-color: var(--status-success-bg);
+  color: var(--ok);
 }
 
 .retention-policy__status--error {
-  background-color: var(--color-bg-danger, #faecec);
-  color: var(--color-danger, #9d2222);
+  background-color: var(--status-danger-bg);
+  color: var(--status-danger-text-strong);
 }
 
 .retention-policy__loading {
-  color: var(--color-text-muted, #6b6b76);
+  color: var(--text-muted);
   font-style: italic;
   padding: 1rem 0;
 }

--- a/dashboard/src/pages/ViolationHeatmapPage.tsx
+++ b/dashboard/src/pages/ViolationHeatmapPage.tsx
@@ -85,16 +85,16 @@ export function ViolationHeatmapPage() {
         </label>
       </div>
 
-      {status === "loading" && <p style={{ color: "#6b7280" }}>Loading…</p>}
-      {status === "error"   && <p style={{ color: "#ef4444" }}>Error: {error}</p>}
+      {status === "loading" && <p style={{ color: "var(--text-muted)" }}>Loading…</p>}
+      {status === "error"   && <p style={{ color: "var(--status-danger)" }}>Error: {error}</p>}
       {status === "success" && (
         <>
-          <p style={{ fontSize: 12, color: "#6b7280", marginBottom: 8 }}>
+          <p style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 8 }}>
             {data.nodes.length} agent{data.nodes.length !== 1 ? "s" : ""} with violations ·
             window {data.window_secs}s · generated {data.generated_at}
           </p>
           {data.nodes.length === 0 ? (
-            <p style={{ color: "#6b7280" }}>No violations recorded in this window.</p>
+            <p style={{ color: "var(--text-muted)" }}>No violations recorded in this window.</p>
           ) : (
             <ViolationHeatmap nodes={data.nodes} />
           )}

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -12,6 +12,8 @@
    ============================================================ */
 
 :root {
+  color-scheme: light;
+
   /* ── Hi-fi base palette (paper / ink / line) ─────────────── */
   --paper: #f5f4f0;
   --paper-2: #ffffff;
@@ -212,3 +214,144 @@
   --severity-medium: #eab308;
   --severity-low: #60a5fa;
 }
+
+/* ============================================================
+   Dark theme — warm-charcoal mirror of the cream/ink light theme.
+   Activated by data-theme="dark" on <html> (see src/theme/useTheme.ts);
+   mirrors design/v1/hi-fi/styles.css. The left nav rail (--shell-nav-*),
+   terminal/code panels (--term-*), and the data-viz chart palettes are
+   intentionally NOT overridden — they stay dark/identical in both modes
+   for Linear/Stripe-style visual continuity.
+   ============================================================ */
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  /* base palette */
+  --paper: #14130f;
+  --paper-2: #1c1a16;
+  --paper-3: #26231d;
+  --ink: #f0ede4;
+  --ink-2: #d8d4c7;
+  --ink-3: #aaa599;
+  --ink-4: #7a766c;
+  --ink-5: #514d44;
+  --line: #2c2924;
+  --line-2: #3a3630;
+  --line-3: #f0ede4;
+
+  /* semantic — brighter foreground, deeper tinted background */
+  --danger: #f08a82;
+  --danger-bg: #3a1a16;
+  --warn: #e6b86b;
+  --warn-bg: #382810;
+  --ok: #8ec898;
+  --ok-bg: #1b2e1e;
+  --info: #9fbef5;
+  --info-bg: #16233f;
+  --scrub: #cfa3eb;
+  --scrub-bg: #2a1838;
+
+  /* app shell — nav rail stays dark in both modes; topbar mirrors paper */
+  --shell-topbar-bg: #1c1a16;
+  --shell-topbar-border: #2c2924;
+  --shell-text-muted: #aaa599;
+  --shell-text-dim: #7a766c;
+  --shell-button-border: #3a3630;
+  --shell-button-hover-bg: #26231d;
+  --shell-error-text: #f08a82;
+
+  /* analytics / admin surfaces */
+  --surface-card: #1c1a16;
+  --surface-card-border: #2c2924;
+  --surface-subtle-bg: #14130f;
+  --surface-skeleton-base: #26231d;
+  --surface-skeleton-shimmer: #3a3630;
+  --surface-hover-bg: #26231d;
+  --form-input-border: #3a3630;
+
+  /* text scale */
+  --text-primary: #f0ede4;
+  --text-secondary: #d8d4c7;
+  --text-muted: #aaa599;
+  --text-disabled: #7a766c;
+
+  /* accent (indigo brightened for dark contrast) */
+  --accent: #818cf8;
+  --accent-hover: #6366f1;
+
+  /* tooltip */
+  --tooltip-bg: #26231d;
+  --tooltip-outline: #3a3630;
+
+  /* badge variants */
+  --badge-blue-bg: #16233f;
+  --badge-blue-text: #9fbef5;
+  --badge-blue-text-strong: #9fbef5;
+  --badge-amber-bg: #382810;
+  --badge-amber-text: #e6b86b;
+  --badge-neutral-bg: #26231d;
+  --badge-neutral-text: #aaa599;
+
+  /* shell accent/text/border + primary button inverts to a light pill */
+  --shell-accent: #9fbef5;
+  --shell-text: #f0ede4;
+  --shell-border: #2c2924;
+  --button-primary-bg: #f0ede4;
+  --button-primary-text: #14130f;
+
+  /* alert banner text on amber bg */
+  --alert-banner-text: #e6b86b;
+
+  /* IAM shell surfaces */
+  --shell-surface: #1c1a16;
+  --shell-surface-muted: #26231d;
+  --shell-surface-subtle: #14130f;
+  --shell-border-subtle: #2c2924;
+  --shell-text-strong: #d8d4c7;
+
+  /* status bg / strong-text variants */
+  --status-success-bg: #1b2e1e;
+  --status-success-text-strong: #8ec898;
+  --status-danger-bg: #3a1a16;
+  --status-danger-text-strong: #f08a82;
+  --status-danger-hover-text: #f08a82;
+
+  /* LiveOps pipeline lane fills (tinted dark) */
+  --lane-bg-default: #1c1a16;
+  --lane-bg-warn: #322a14;
+  --lane-bg-scrub: #241830;
+}
+
+/* Page surface follows the paper token so dark mode has no white gutter. */
+html, body { background: var(--paper); }
+body { color: var(--text-primary); }
+
+/* Smooth theme transition on the big surfaces only (not charts/icons). */
+body,
+.appshell__topbar,
+.appshell__content,
+.appshell__main {
+  transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+}
+
+/* ── Theme toggle (sun/moon) in the topbar ───────────────────── */
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border: 1px solid var(--shell-button-border);
+  background: var(--shell-topbar-bg);
+  color: var(--shell-text-dim);
+  border-radius: 4px;
+  cursor: pointer;
+  padding: 0;
+  transition: background-color 0.15s, border-color 0.15s, color 0.15s, transform 0.18s;
+}
+.theme-toggle:hover {
+  background: var(--shell-button-hover-bg);
+  color: var(--text-primary);
+}
+.theme-toggle:active { transform: scale(0.94); }
+.theme-toggle svg { width: 15px; height: 15px; display: block; }

--- a/dashboard/src/theme/useTheme.test.tsx
+++ b/dashboard/src/theme/useTheme.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { getInitialTheme, applyTheme, useTheme, THEME_STORAGE_KEY } from './useTheme'
+
+function mockMatchMedia(matchesDark: boolean) {
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    matches: query.includes('dark') ? matchesDark : false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals()
+  localStorage.clear()
+  document.documentElement.removeAttribute('data-theme')
+})
+
+describe('theme resolution', () => {
+  it('falls back to the OS preference when nothing is stored', () => {
+    mockMatchMedia(true)
+    expect(getInitialTheme()).toBe('dark')
+    mockMatchMedia(false)
+    expect(getInitialTheme()).toBe('light')
+  })
+
+  it('honors a stored preference over the OS setting', () => {
+    mockMatchMedia(true) // OS is dark…
+    localStorage.setItem(THEME_STORAGE_KEY, 'light')
+    expect(getInitialTheme()).toBe('light') // …but the saved choice wins
+  })
+
+  it('applyTheme sets data-theme on the document root', () => {
+    applyTheme('dark')
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+  })
+})
+
+describe('useTheme', () => {
+  it('toggles, persists the choice, and updates the document root', () => {
+    mockMatchMedia(false)
+    const { result } = renderHook(() => useTheme())
+
+    expect(result.current.theme).toBe('light')
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light')
+
+    act(() => result.current.toggleTheme())
+
+    expect(result.current.theme).toBe('dark')
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark')
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+  })
+})

--- a/dashboard/src/theme/useTheme.ts
+++ b/dashboard/src/theme/useTheme.ts
@@ -1,0 +1,88 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Light / dark theme support for the dashboard.
+ *
+ * The visual system is entirely token-driven (see src/styles.css): the active
+ * theme is selected by a `data-theme` attribute on the document root, which
+ * swaps the `:root[data-theme="dark"]` custom-property block. This module owns
+ * resolving, applying, and persisting that choice.
+ *
+ * Resolution order on first load (no explicit user choice yet):
+ *   1. a previously-saved preference in localStorage, else
+ *   2. the operating-system setting (`prefers-color-scheme`).
+ */
+
+export type Theme = 'light' | 'dark'
+
+export const THEME_STORAGE_KEY = 'aa-dashboard-theme'
+
+function prefersDark(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-color-scheme: dark)').matches
+  )
+}
+
+function readStored(): Theme | null {
+  try {
+    const v = localStorage.getItem(THEME_STORAGE_KEY)
+    return v === 'light' || v === 'dark' ? v : null
+  } catch {
+    return null
+  }
+}
+
+/** Resolve the theme to use before/at first render. */
+export function getInitialTheme(): Theme {
+  return readStored() ?? (prefersDark() ? 'dark' : 'light')
+}
+
+/** Apply a theme to the document root (idempotent). */
+export function applyTheme(theme: Theme): void {
+  if (typeof document !== 'undefined') {
+    document.documentElement.setAttribute('data-theme', theme)
+  }
+}
+
+export interface UseThemeResult {
+  theme: Theme
+  setTheme: (theme: Theme) => void
+  toggleTheme: () => void
+}
+
+export function useTheme(): UseThemeResult {
+  const [theme, setThemeState] = useState<Theme>(getInitialTheme)
+
+  // Keep the document root in sync with the active theme.
+  useEffect(() => {
+    applyTheme(theme)
+  }, [theme])
+
+  // Follow OS changes only while the user has NOT made an explicit choice.
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const onChange = (e: MediaQueryListEvent) => {
+      if (readStored() === null) setThemeState(e.matches ? 'dark' : 'light')
+    }
+    mq.addEventListener('change', onChange)
+    return () => mq.removeEventListener('change', onChange)
+  }, [])
+
+  const persist = (next: Theme) => {
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, next)
+    } catch {
+      /* storage unavailable (private mode) — theme still applies for the session */
+    }
+    setThemeState(next)
+  }
+
+  return {
+    theme,
+    setTheme: persist,
+    toggleTheme: () => persist(theme === 'dark' ? 'light' : 'dark'),
+  }
+}


### PR DESCRIPTION
## What
Adds **light / dark theme support** across the dashboard. The CSS was already fully tokenized (`src/styles.css` `:root` + `var(--…)` everywhere), so this adds the missing dark palette, a theme switch, and cleans up the last stray hardcoded colors.

## Changes
- **`styles.css`**: `color-scheme`, a `:root[data-theme="dark"]` block redefining all ~109 tokens (warm-charcoal mirror of the cream/ink light theme), smooth surface transitions, and `.theme-toggle` styles. The **left nav rail, terminal/code panels, and data-viz chart palettes intentionally stay the same in both modes** (Linear/Stripe-style continuity).
- **`src/theme/useTheme.ts`**: hook that resolves the theme (saved pref → else OS `prefers-color-scheme`), applies `data-theme` on `<html>`, persists to localStorage, and follows OS changes until the user picks.
- **`ThemeToggle`** (sun/moon) wired into the AppShell topbar.
- **`index.html`**: pre-paint inline script so there's no flash of the wrong theme.
- **Tokenized stray hardcoded colors** in Settings / SandboxSummaryCard / AgentDetailDrawer / AccessLogPanel CSS + ViolationHeatmap(.tsx) so every surface follows the theme. (Settings previously referenced undefined `--color-*` tokens and never themed at all.) The heatmap's single data-color (`#22c55e`) is left as a theme-agnostic data-viz value.

## Design source
Claude Design handoff (`agent-assembly-brief`, hi-fi); dark palette + toggle mechanism from `hi-fi/styles.css`. Default = follow OS (per product decision).

## How to verify
- Toggle in the topbar flips light⇄dark; choice persists across reloads; first load with no saved pref follows the OS.
- All pages render correctly in dark; rail + code blocks stay dark in both.
- Local: `pnpm type-check`, `pnpm lint`, `pnpm build` green; `pnpm test` = **120 files / 1034 tests pass** (incl. new `useTheme` test).

Closes AAASM-2595.