### PR TITLE
[AAASM-2602] 🔧 (ci): Add concurrency cancellation to all PR-triggered workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1133,3 +1133,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/dev-verify.yml
+++ b/.github/workflows/dev-verify.yml
@@ -78,3 +78,7 @@ jobs:
 
       - name: Run dev-verify
         run: make dev-verify
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -168,3 +168,7 @@ jobs:
         run: |
           docker run --rm "$IMAGE" aasm --version
           docker run --rm "$IMAGE" sh -c "$SMOKE_RUN"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -77,3 +77,7 @@ jobs:
 
       - name: Verify api-reference.md rustdoc command
         run: cargo doc --workspace --no-deps --exclude aa-ebpf
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ffi-go-staticlib.yml
+++ b/.github/workflows/ffi-go-staticlib.yml
@@ -81,3 +81,7 @@ jobs:
         with:
           name: aa-ffi-go-${{ matrix.target }}
           path: dist/${{ matrix.target }}/libaa_ffi_go.a
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/integration-bypass-permissions.yml
+++ b/.github/workflows/integration-bypass-permissions.yml
@@ -90,3 +90,7 @@ jobs:
             -f ci/integration/bypass-permissions/docker-compose.yml \
             -p aaasm-bypass-test \
             down --volumes --remove-orphans || true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -142,3 +142,7 @@ jobs:
             **/*.log
           if-no-files-found: ignore
           retention-days: 7
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Description

Adds a top-level `concurrency` block to every **PR-triggered** workflow so a newer commit on a PR cancels the superseded in-flight run, while `master`/tag runs always run to completion. Story **AAASM-2598** (Epic AAASM-2551). CI config only.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Applied to: `ci.yml`, `docker.yml`, `ffi-go-staticlib.yml`, `integration-tests.yml`, `integration-bypass-permissions.yml`, `dev-verify.yml`, `docs.yml` (one commit each). `release.yml` is left untouched (tag-only, must never cancel); `smoke-test.yml` already had a `concurrency` block.

All 7 files validated to parse as YAML with a well-formed `concurrency` mapping.

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2602 (impl subtask of AAASM-2598, Epic AAASM-2551)

## Testing

- [x] No tests required (explain why)

CI-config change. `cancel-in-progress` is gated to `pull_request`, so `master`/tag pipelines are unaffected. Behavioural confirmation (a second push cancels the first run) is verified post-merge in AAASM-2603.

## Checklist

- [x] Code follows project style guidelines — N/A (`*.rs` hooks skipped on workflow edits)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (CI behaviour documented in the ticket)
- [ ] All CI checks passing (pending CI)
- [x] Commits are small and follow the Gitmoji convention
