### PR TITLE
[AAASM-2604] ♻️ (aa-runtime): Repoint enforcement scanner onto aa-security directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,6 +441,7 @@ dependencies = [
  "aa-core",
  "aa-ebpf",
  "aa-proto",
+ "aa-security",
  "aa-storage-sqlite-buffer",
  "async-nats",
  "async-trait",

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -15,6 +15,7 @@ integration-test = []
 
 [dependencies]
 aa-core                     = { path = "../aa-core", version = "0.0.1-alpha.5", features = ["serde"] }
+aa-security                 = { path = "../aa-security", version = "0.0.1-alpha.5", features = ["serde"] }
 aa-proto                    = { path = "../aa-proto", version = "0.0.1-alpha.5" }
 aa-storage-sqlite-buffer    = { path = "../aa-storage-sqlite-buffer", version = "0.0.1-alpha.5" }
 async-nats                  = { workspace = true }

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -9,13 +9,13 @@
 //! This module is the standalone enforcement primitive. Wiring it into the
 //! pipeline `run()` loop lands in AAASM-2586.
 //!
-//! The scanner / redaction primitives are sourced from [`aa_core`] today; they
-//! move to `aa-security` under AAASM-2567, which is an import-only change here.
+//! The scanner / redaction primitives are sourced from the dedicated
+//! [`aa_security`] leaf crate (extracted out of `aa-core` under AAASM-2567).
 
 use std::time::{Duration, Instant};
 
-use aa_core::{CredentialFinding, CredentialScanner};
 use aa_proto::assembly::audit::v1::audit_event::Detail;
+use aa_security::{CredentialFinding, CredentialScanner};
 
 use super::event::EnrichedEvent;
 
@@ -227,7 +227,7 @@ impl RuntimeScanner {
 /// Emit scan observability metrics for one [`RuntimeScanner::enforce`] call.
 ///
 /// Latency is measured around the scan + redact work only. The finding
-/// counter is labelled by [`aa_core::CredentialKind`] and never carries the
+/// counter is labelled by [`aa_security::CredentialKind`] and never carries the
 /// raw secret. Emitted on every call, including clean and no-detail events.
 fn emit_metrics(outcome: &EnforcementOutcome, elapsed: Duration) {
     ::metrics::histogram!("aa_runtime_scan_latency_seconds").record(elapsed.as_secs_f64());


### PR DESCRIPTION
## Description

Follow-up subtask of Story **AAASM-2567** (Epic **AAASM-2552**) to complete **AC2** for `aa-runtime`.

`aa-runtime` became a scanner consumer *after* the original consumer-repoint subtask (AAASM-2591) was scoped — the parallel runtime-enforcement work (AAASM-2568, `aa-runtime/src/pipeline/enforcement.rs`) was added against the **temporary `aa_core` scanner re-export**, with a documented plan to "swap to aa-security when 2567 lands". 2567 has landed; this is that swap. A workspace-wide audit confirmed `aa-runtime` was the **only** crate still riding the re-export.

### Change
- `enforcement.rs` — `use aa_core::{CredentialFinding, CredentialScanner}` → `use aa_security::{…}`; updated the `CredentialKind` and module-level doc links to `aa_security`.
- `aa-runtime/Cargo.toml` — added `aa-security = { path = "../aa-security", version = "0.0.1-alpha.5", features = ["serde"] }` (direct dependency).

> **Coordination:** `enforcement.rs` is also touched by **AAASM-2586** (under AAASM-2568), currently In Progress. This change is intentionally minimal (one import, two doc links, one Cargo.toml line) to keep the conflict surface tiny.

## Type of Change

- [x] ♻️ Refactoring

## Breaking Changes

- [x] No — same types, sourced directly from `aa-security` instead of via the transparent `aa-core` re-export.

## Related Issues

- Related Jira ticket: AAASM-2604 (subtask of AAASM-2567, Epic AAASM-2552)

## Testing

- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean (workspace).
- [x] `cargo nextest run -p aa-runtime --lib` → 253 passed, 2 skipped (incl. `pipeline::enforcement::tests`).
- [x] `cargo deny check` clean; `cargo fmt --all --check` clean; `cargo doc -p aa-runtime` resolves the updated links.
- [x] Audit: no functional `aa_core::{CredentialScanner,…}` usage remains anywhere in `aa-runtime`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)