### PR TITLE
[AAASM-2605] 🔧 (ci): Docker/FFI build-light on PR (QEMU tag-gate + matrix reduction)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4
 
       - name: Set up QEMU (ARM emulation for multi-arch)
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
 
       - name: Set up Docker Buildx
@@ -120,6 +121,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4
 
       - name: Set up QEMU (ARM emulation for multi-arch)
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
 
       - name: Set up Docker Buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,9 +61,35 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  prep:
+    name: Resolve language matrix (reduced on PR, full on tag)
+    runs-on: ubuntu-latest
+    outputs:
+      lang_matrix: ${{ steps.set.outputs.lang_matrix }}
+    steps:
+      # On pull_request, build only the `is_latest` representative per language
+      # (python 3.14, go 1.26). On tag/push, build the full version matrix.
+      - id: set
+        run: |
+          full='[
+            {"lang":"python","version":"3.14-slim","dockerfile":"docker/Dockerfile.python-3.14-slim","smoke_run":"python -c \"from agent_assembly import init_assembly\"","is_latest":true},
+            {"lang":"python","version":"3.13-slim","dockerfile":"docker/Dockerfile.python-3.13-slim","smoke_run":"python -c \"from agent_assembly import init_assembly\""},
+            {"lang":"python","version":"3.12-slim","dockerfile":"docker/Dockerfile.python-3.12-slim","smoke_run":"python -c \"from agent_assembly import init_assembly\""},
+            {"lang":"go","version":"1.26-alpine","dockerfile":"docker/Dockerfile.go-1.26-alpine","smoke_run":"go list -m github.com/AI-agent-assembly/go-sdk@latest","is_latest":true},
+            {"lang":"go","version":"1.25-alpine","dockerfile":"docker/Dockerfile.go-1.25-alpine","smoke_run":"go list -m github.com/AI-agent-assembly/go-sdk@latest"},
+            {"lang":"go","version":"1.24-alpine","dockerfile":"docker/Dockerfile.go-1.24-alpine","smoke_run":"go list -m github.com/AI-agent-assembly/go-sdk@latest"}
+          ]'
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            sel=$(printf '%s' "$full" | jq -c '[.[] | select(.is_latest == true)]')
+          else
+            sel=$(printf '%s' "$full" | jq -c '.')
+          fi
+          printf 'lang_matrix={"include":%s}\n' "$sel" >> "$GITHUB_OUTPUT"
+
   build-and-push-language-images:
     name: Build language image — ${{ matrix.lang }} (and publish on tag)
     runs-on: ubuntu-latest
+    needs: prep
     permissions:
       contents: read
       packages: write
@@ -75,47 +101,7 @@ jobs:
     # (type=gha,mode=max) deduplicates the cargo build across the matrix.
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - lang: python
-            version: "3.14-slim"
-            dockerfile: docker/Dockerfile.python-3.14-slim
-            smoke_run: "python -c \"from agent_assembly import init_assembly\""
-            # F114 latest-per-language pin — owns `python:latest` tag.
-            is_latest: true
-          - lang: python
-            version: "3.13-slim"
-            dockerfile: docker/Dockerfile.python-3.13-slim
-            smoke_run: "python -c \"from agent_assembly import init_assembly\""
-          - lang: python
-            version: "3.12-slim"
-            dockerfile: docker/Dockerfile.python-3.12-slim
-            smoke_run: "python -c \"from agent_assembly import init_assembly\""
-          # Python 3.10 / 3.11 are intentionally absent here — they were
-          # dropped from F114b scope per AAASM-1682 (Option B chosen) because
-          # python-sdk's pyproject.toml declares `requires-python = ">=3.12,<4.0"`.
-          # The 2 Dockerfiles were deleted; final Python coverage = 3.12/3.13/3.14.
-          # Node 20 / 22 / 24 are all intentionally absent here. Re-enabled
-          # by AAASM-1660 (node 20) / AAASM-1661 (node 22) / AAASM-1503
-          # (node 24) once AAASM-1203 publishes `@agent-assembly/sdk` to
-          # npm. The transitional git/tarball install paths can't produce
-          # a working image because the SDK's `dist/` and native `.node`
-          # files are gitignored — see AAASM-1501 for the full
-          # investigation. Three follow-up subtasks share one PR.
-          - lang: go
-            version: "1.26-alpine"
-            dockerfile: docker/Dockerfile.go-1.26-alpine
-            smoke_run: "go list -m github.com/AI-agent-assembly/go-sdk@latest"
-            # F114 latest-per-language pin — owns `go:latest` tag.
-            is_latest: true
-          - lang: go
-            version: "1.25-alpine"
-            dockerfile: docker/Dockerfile.go-1.25-alpine
-            smoke_run: "go list -m github.com/AI-agent-assembly/go-sdk@latest"
-          - lang: go
-            version: "1.24-alpine"
-            dockerfile: docker/Dockerfile.go-1.24-alpine
-            smoke_run: "go list -m github.com/AI-agent-assembly/go-sdk@latest"
+      matrix: ${{ fromJSON(needs.prep.outputs.lang_matrix) }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4

--- a/.github/workflows/ffi-go-staticlib.yml
+++ b/.github/workflows/ffi-go-staticlib.yml
@@ -29,21 +29,34 @@ on:
       - "!**/*.ico"
 
 jobs:
+  prep:
+    name: Resolve target matrix (linux-x86_64 on PR, full on tag/master)
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - id: set
+        run: |
+          full='[
+            {"os":"ubuntu-latest","target":"x86_64-unknown-linux-gnu"},
+            {"os":"ubuntu-latest","target":"aarch64-unknown-linux-gnu"},
+            {"os":"macos-latest","target":"x86_64-apple-darwin"},
+            {"os":"macos-latest","target":"aarch64-apple-darwin"}
+          ]'
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            sel=$(printf '%s' "$full" | jq -c '[.[] | select(.target == "x86_64-unknown-linux-gnu")]')
+          else
+            sel=$(printf '%s' "$full" | jq -c '.')
+          fi
+          printf 'matrix={"include":%s}\n' "$sel" >> "$GITHUB_OUTPUT"
+
   build-aa-ffi-go:
     name: Build aa-ffi-go (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    needs: prep
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-          - os: macos-latest
-            target: x86_64-apple-darwin
-          - os: macos-latest
-            target: aarch64-apple-darwin
+      matrix: ${{ fromJSON(needs.prep.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Description

Reduces Docker/FFI **PR build cost** while keeping the full multi-arch build + publish on tags untouched. Story **AAASM-2600** (Epic AAASM-2551). CI config only.

> **Scope note:** the amd64-on-PR / multi-arch-on-tag split already existed (`docker.yml` `platforms:` + tag-gated `push:`/login). This PR addresses the *remaining* PR waste:

1. **Gate `Set up QEMU` to tag builds only** (both docker jobs) — pointless for amd64-only PR builds.
2. **Reduce the docker language matrix on PR** — a `prep` job emits a `fromJSON` matrix: `is_latest`-only (python 3.14, go 1.26) on `pull_request`, the full 6-version matrix on tag/push.
3. **Reduce the `ffi-go` target matrix on PR** — `x86_64-unknown-linux-gnu` only on `pull_request`; full 4-target matrix (linux x86_64/aarch64 + darwin x86_64/aarch64) on tag/master.

No change to publishing: GHCR `push:`/login stay tag-gated; ffi-go still uploads artifacts. Both workflows validated to parse; the `prep` `jq` filtering was verified locally (docker PR→2/tag→6; ffi-go PR→1/tag→4).

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2605 (impl subtask of AAASM-2600, Epic AAASM-2551)

## Testing

- [x] No tests required (explain why)

CI-config change. The tag/release path (full matrix + publish) is unchanged; only the `pull_request` matrix is reduced. **Stacked on #942** (AAASM-2598) — both touch `docker.yml`/`ffi-go`; the concurrency commits drop once #942 merges.

## Checklist

- [x] Code follows project style guidelines — N/A (`*.rs` hooks skipped)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (CI behaviour documented in the ticket)
- [ ] All CI checks passing (pending CI)
- [x] Commits are small and follow the Gitmoji convention
