### PR TITLE
[AAASM-2606] ✅ (ci): Verify Docker/FFI PR-light split

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4
 
       - name: Set up QEMU (ARM emulation for multi-arch)
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
 
       - name: Set up Docker Buildx
@@ -120,6 +121,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4
 
       - name: Set up QEMU (ARM emulation for multi-arch)
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3  # v4.1.0
 
       - name: Set up Docker Buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,9 +61,35 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  prep:
+    name: Resolve language matrix (reduced on PR, full on tag)
+    runs-on: ubuntu-latest
+    outputs:
+      lang_matrix: ${{ steps.set.outputs.lang_matrix }}
+    steps:
+      # On pull_request, build only the `is_latest` representative per language
+      # (python 3.14, go 1.26). On tag/push, build the full version matrix.
+      - id: set
+        run: |
+          full='[
+            {"lang":"python","version":"3.14-slim","dockerfile":"docker/Dockerfile.python-3.14-slim","smoke_run":"python -c \"from agent_assembly import init_assembly\"","is_latest":true},
+            {"lang":"python","version":"3.13-slim","dockerfile":"docker/Dockerfile.python-3.13-slim","smoke_run":"python -c \"from agent_assembly import init_assembly\""},
+            {"lang":"python","version":"3.12-slim","dockerfile":"docker/Dockerfile.python-3.12-slim","smoke_run":"python -c \"from agent_assembly import init_assembly\""},
+            {"lang":"go","version":"1.26-alpine","dockerfile":"docker/Dockerfile.go-1.26-alpine","smoke_run":"go list -m github.com/AI-agent-assembly/go-sdk@latest","is_latest":true},
+            {"lang":"go","version":"1.25-alpine","dockerfile":"docker/Dockerfile.go-1.25-alpine","smoke_run":"go list -m github.com/AI-agent-assembly/go-sdk@latest"},
+            {"lang":"go","version":"1.24-alpine","dockerfile":"docker/Dockerfile.go-1.24-alpine","smoke_run":"go list -m github.com/AI-agent-assembly/go-sdk@latest"}
+          ]'
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            sel=$(printf '%s' "$full" | jq -c '[.[] | select(.is_latest == true)]')
+          else
+            sel=$(printf '%s' "$full" | jq -c '.')
+          fi
+          printf 'lang_matrix={"include":%s}\n' "$sel" >> "$GITHUB_OUTPUT"
+
   build-and-push-language-images:
     name: Build language image — ${{ matrix.lang }} (and publish on tag)
     runs-on: ubuntu-latest
+    needs: prep
     permissions:
       contents: read
       packages: write
@@ -75,47 +101,7 @@ jobs:
     # (type=gha,mode=max) deduplicates the cargo build across the matrix.
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - lang: python
-            version: "3.14-slim"
-            dockerfile: docker/Dockerfile.python-3.14-slim
-            smoke_run: "python -c \"from agent_assembly import init_assembly\""
-            # F114 latest-per-language pin — owns `python:latest` tag.
-            is_latest: true
-          - lang: python
-            version: "3.13-slim"
-            dockerfile: docker/Dockerfile.python-3.13-slim
-            smoke_run: "python -c \"from agent_assembly import init_assembly\""
-          - lang: python
-            version: "3.12-slim"
-            dockerfile: docker/Dockerfile.python-3.12-slim
-            smoke_run: "python -c \"from agent_assembly import init_assembly\""
-          # Python 3.10 / 3.11 are intentionally absent here — they were
-          # dropped from F114b scope per AAASM-1682 (Option B chosen) because
-          # python-sdk's pyproject.toml declares `requires-python = ">=3.12,<4.0"`.
-          # The 2 Dockerfiles were deleted; final Python coverage = 3.12/3.13/3.14.
-          # Node 20 / 22 / 24 are all intentionally absent here. Re-enabled
-          # by AAASM-1660 (node 20) / AAASM-1661 (node 22) / AAASM-1503
-          # (node 24) once AAASM-1203 publishes `@agent-assembly/sdk` to
-          # npm. The transitional git/tarball install paths can't produce
-          # a working image because the SDK's `dist/` and native `.node`
-          # files are gitignored — see AAASM-1501 for the full
-          # investigation. Three follow-up subtasks share one PR.
-          - lang: go
-            version: "1.26-alpine"
-            dockerfile: docker/Dockerfile.go-1.26-alpine
-            smoke_run: "go list -m github.com/AI-agent-assembly/go-sdk@latest"
-            # F114 latest-per-language pin — owns `go:latest` tag.
-            is_latest: true
-          - lang: go
-            version: "1.25-alpine"
-            dockerfile: docker/Dockerfile.go-1.25-alpine
-            smoke_run: "go list -m github.com/AI-agent-assembly/go-sdk@latest"
-          - lang: go
-            version: "1.24-alpine"
-            dockerfile: docker/Dockerfile.go-1.24-alpine
-            smoke_run: "go list -m github.com/AI-agent-assembly/go-sdk@latest"
+      matrix: ${{ fromJSON(needs.prep.outputs.lang_matrix) }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4

--- a/.github/workflows/ffi-go-staticlib.yml
+++ b/.github/workflows/ffi-go-staticlib.yml
@@ -29,21 +29,34 @@ on:
       - "!**/*.ico"
 
 jobs:
+  prep:
+    name: Resolve target matrix (linux-x86_64 on PR, full on tag/master)
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - id: set
+        run: |
+          full='[
+            {"os":"ubuntu-latest","target":"x86_64-unknown-linux-gnu"},
+            {"os":"ubuntu-latest","target":"aarch64-unknown-linux-gnu"},
+            {"os":"macos-latest","target":"x86_64-apple-darwin"},
+            {"os":"macos-latest","target":"aarch64-apple-darwin"}
+          ]'
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            sel=$(printf '%s' "$full" | jq -c '[.[] | select(.target == "x86_64-unknown-linux-gnu")]')
+          else
+            sel=$(printf '%s' "$full" | jq -c '.')
+          fi
+          printf 'matrix={"include":%s}\n' "$sel" >> "$GITHUB_OUTPUT"
+
   build-aa-ffi-go:
     name: Build aa-ffi-go (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
+    needs: prep
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-          - os: macos-latest
-            target: x86_64-apple-darwin
-          - os: macos-latest
-            target: aarch64-apple-darwin
+      matrix: ${{ fromJSON(needs.prep.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v6

--- a/verification-reports/AAASM-2600.md
+++ b/verification-reports/AAASM-2600.md
@@ -1,0 +1,37 @@
+# AAASM-2600 — Verification: Docker/FFI build-light on PR
+
+Verifies Story **AAASM-2600** (Docker/FFI PR-time build reduction).
+Implementation in subtask **AAASM-2605** (PR #945); this subtask (**AAASM-2606**)
+checks it against the Story acceptance criteria.
+
+## Scope correction (recorded during pickup)
+
+The amd64-on-PR / multi-arch-on-tag split was **already present** before this Story
+(`docker.yml` `platforms: … 'linux/amd64,linux/arm64' || 'linux/amd64'`; `push:` and
+GHCR login already tag-gated). So the implemented scope is the *remaining* PR waste:
+QEMU-step gating + PR-time matrix reduction.
+
+## How verified
+
+| # | Method |
+|---|--------|
+| 1 | `yaml.safe_load` on both workflows after the edits — parse clean; jobs = `docker`: `build-and-push` / `prep` / `build-and-push-language-images`; `ffi-go`: `prep` / `build-aa-ffi-go`. |
+| 2 | Ran the `prep` `jq` selection locally for both event types. |
+| 3 | Confirmed publish path unchanged: `push:` + GHCR login remain `if: …refs/tags/v…`. |
+
+## Acceptance criteria
+
+| AC | Result | Evidence |
+|----|--------|----------|
+| `aa-runtime` PR builds amd64-only, one version per language | ✅ Pass | `platforms` already amd64-on-PR; `Set up QEMU` now `if: …tags/v` (both jobs); `prep` `fromJSON` → PR matrix = python `3.14-slim` + go `1.26-alpine` (the `is_latest` pins). Smoke step retained. |
+| `v*` tag builds + pushes full multi-arch + full matrix | ✅ Pass | `prep` returns the full 6-entry matrix on non-PR; `platforms` → `linux/amd64,linux/arm64`; `push:`/login tag-gated (unchanged). |
+| `aa-ffi-go` PR builds only `x86_64-unknown-linux-gnu`; tag/master full 4-target | ✅ Pass | `prep` `jq select(.target=="x86_64-unknown-linux-gnu")` → 1 entry on PR; full 4 on push. Verified locally (PR→1, tag→4). |
+| No publish on PR (unchanged) | ✅ Pass | docker GHCR push/login still tag-gated; ffi-go only `upload-artifact`. |
+| Both workflows parse as valid YAML | ✅ Pass | `yaml.safe_load` clean on both. |
+| Measured PR wall-clock drop | ⏳ Post-merge | Compare a `docker`/`ffi-go`-triggering PR run before vs after: docker language images 6→2, ffi-go targets 4→1 (drops macOS ×2 + arm cross), QEMU setup removed on PR. |
+
+## Outcome
+
+- Structural ACs: **pass**; jq filtering proven locally. Wall-clock delta is observed on
+  the first post-merge PR that touches `aa-runtime`/`docker` or `aa-ffi-go`.
+- No gaps found; nothing filed back to AAASM-2605.


### PR DESCRIPTION
## Description

Adds the verification report for Story **AAASM-2600** at `verification-reports/AAASM-2600.md`, confirming the Docker/FFI PR-light change (PR #945 / AAASM-2605) satisfies each Story AC. Documentation only.

> **Stacked on #945** (which stacks on #942). Diff reduces to just this report once the parents merge. Base `master`.

Records the scope correction (amd64 split pre-existed) and confirms: QEMU tag-gated, docker language matrix PR→2/tag→6, ffi-go matrix PR→1/tag→4, publish path unchanged, both YAML valid.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2606 (verification subtask of AAASM-2600, Epic AAASM-2551)

## Testing

- [x] No tests required (explain why)

Verification artifact over a CI-config deliverable.

## Checklist

- [x] Code follows project style guidelines — N/A for docs
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (verification artifact)
- [ ] All CI checks passing (pending CI)
- [x] Commits are small and follow the Gitmoji convention
