### PR TITLE
[AAASM-2608] 📝 (docs): Tidy stale aa_core::CredentialScanner mentions in comments

### DIFF
--- a/aa-integration-tests/tests/e2e_mcp_interceptor.rs
+++ b/aa-integration-tests/tests/e2e_mcp_interceptor.rs
@@ -386,7 +386,7 @@ async fn st_q_2_mcp_read_file_home_user_is_allowed() {
 /// the proxy forwards). The mock MCP upstream is configured to reply
 /// with a result body that **embeds a synthetic OpenAI key**
 /// (`sk-test-...`). The proxy's `Interceptor::redact_response_body` runs
-/// `aa_core::CredentialScanner` against the captured response body —
+/// `aa_security::CredentialScanner` against the captured response body —
 /// the same scanner shape `aa-gateway` uses for ToolResult evaluation
 /// (AAASM-1941) — and rewrites the response with `[REDACTED:OpenAiKey]`
 /// markers in place of the raw key before forwarding to the client.
@@ -408,7 +408,7 @@ async fn st_q_3_mcp_tool_result_secret_is_redacted_before_agent_sees_it() {
     let ca = aa_proxy::tls::CaStore::load_or_create(dir.path()).await.expect("ca");
     let client_config = std::sync::Arc::new(client_trust_proxy_ca(dir.path()).await);
 
-    // Synthetic OpenAI key — built into the default `aa_core::CredentialScanner`'s
+    // Synthetic OpenAI key — built into the default `aa_security::CredentialScanner`'s
     // OpenAiKey AC pattern. The proxy's scanner catches it without any policy
     // YAML configuration; `mcp_redact_secrets.yaml` would carry the same
     // pattern explicitly if the gateway-side ToolResult flow were used.

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -206,7 +206,7 @@ impl Interceptor {
     ///
     /// Used by the AAASM-1930 MCP data path to redact upstream response
     /// bodies before they reach the client (ST-Q-3). The proxy's default
-    /// scanner carries the same `aa_core::CredentialScanner` patterns the
+    /// scanner carries the same `aa_security::CredentialScanner` patterns the
     /// gateway uses for ToolResult evaluation, so the redaction shape
     /// matches what `mcp_redact_secrets.yaml` would produce gateway-side.
     pub fn redact_response_body(&self, body: &[u8]) -> Option<Vec<u8>> {

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -377,7 +377,7 @@ impl ProxyServer {
             // MCP response path (AAASM-1930 ST-Q-3): read the upstream
             // response body-aware, run the proxy's credential scanner on
             // the body, and forward a redacted version when findings are
-            // present. The scanner is the same `aa_core::CredentialScanner`
+            // present. The scanner is the same `aa_security::CredentialScanner`
             // the gateway uses internally for ToolResult evaluation, so
             // the redaction shape matches what `mcp_redact_secrets.yaml`
             // would produce gateway-side. A future iteration could swap


### PR DESCRIPTION
## Description

Housekeeping follow-up to Story **AAASM-2567** (aa-security extraction). After the scanner moved to `aa-security` and all functional code was repointed, **four code comments** still named `aa_core::CredentialScanner`. This repoints those mentions; **comments-only, no behaviour change**.

Fixed:
- `aa-proxy/src/intercept/mod.rs:209` (`///`)
- `aa-proxy/src/proxy/mod.rs:380` (`//`)
- `aa-integration-tests/tests/e2e_mcp_interceptor.rs:389` (`///`) and `:411` (`//`)

After this, a workspace grep confirms **no `aa_core::…scanner` mentions remain anywhere outside `aa-core`'s own re-export definitions** (comments included).

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No — comments only.

## Related Issues

- Related Jira ticket: AAASM-2608 (housekeeping for AAASM-2567)

## Testing

- [x] `cargo fmt --all --check` clean; `cargo clippy --all-targets --all-features -- -D warnings` clean (no functional change).
- [x] `git grep` confirms zero residual `aa_core::…scanner` mentions outside `aa-core`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)