### PR TITLE
[AAASM-2612] 🔧 (ci): Gate coverage/Sonar/benchmark to push-master or label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -860,7 +860,7 @@ jobs:
     name: Benchmark
     runs-on: ubuntu-latest
     needs: [changes, build]
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.rust == 'true' && (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-benchmark'))
     steps:
       - uses: actions/checkout@v6
       - name: Install protobuf compiler

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,7 +318,7 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     needs: [changes, dashboard-assets]
-    if: github.actor != 'dependabot[bot]' && needs.changes.outputs.rust == 'true'
+    if: github.actor != 'dependabot[bot]' && needs.changes.outputs.rust == 'true' && (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-coverage'))
     env:
       # AAASM-1741: lets the env-gated storage::postgres::tests run under
       # cargo llvm-cov so codecov/patch sees coverage for the PG backend.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1110,7 +1110,7 @@ jobs:
   sonar:
     name: SonarCloud analysis
     needs: [changes, coverage, dashboard-test]
-    if: ${{ !cancelled() && needs.changes.result == 'success' && github.actor != 'dependabot[bot]' }}
+    if: ${{ !cancelled() && needs.changes.result == 'success' && github.actor != 'dependabot[bot]' && (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-coverage')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Description

Moves the acceptance-cost CI jobs off the routine-PR hot-path. Story **AAASM-2601** (Epic AAASM-2551). CI config only.

- **`coverage`** + **`sonar`** now run on `push: master` (post-merge trend) and on PRs **only when labelled `run-coverage`**.
- **`benchmark`** now runs on `push: master` and on PRs **only when labelled `run-benchmark`** (it was running on every rust PR; absolute-latency benches are runner-dependent/noisy).
- Disk-space guard + all existing logic retained — only the job `if:` gates changed.

**Safe to skip:** `master` has **no required status checks** (review-required only), so skipping these on a routine PR does **not** wedge merges. This very PR (unlabelled) demonstrates it — `Coverage`/`SonarCloud analysis`/`Benchmark` should show **skipped**.

To get diff-coverage / a benchmark on demand, add the `run-coverage` / `run-benchmark` label to a PR.

## Type of Change
- [x] 🔧 Configuration / CI change

## Breaking Changes
- [x] No

## Related Issues
- Related Jira ticket: AAASM-2612 (impl subtask of AAASM-2601, Epic AAASM-2551)

## Testing
- [x] No tests required (explain why)

CI-config-only; `if:` gating. The master/label paths preserve coverage trend + on-demand diff coverage.

## Checklist
- [x] Code follows project style guidelines — N/A (`*.rs` hooks skipped)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (documented in ticket + PR)
- [ ] All CI checks passing (pending CI)
- [x] Commits are small and follow the Gitmoji convention
