### PR TITLE
[AAASM-2616] ✅ (ci): Verify CI hardening

### DIFF
--- a/verification-reports/AAASM-2611.md
+++ b/verification-reports/AAASM-2611.md
@@ -1,0 +1,32 @@
+# AAASM-2611 — Verification: CI hardening
+
+Verifies Story **AAASM-2611** (least-privilege permissions + trigger/concurrency
+consistency). Implementation in subtask **AAASM-2615** (PR #950); this subtask
+(**AAASM-2616**) checks it against the Story acceptance criteria.
+
+## How verified
+
+| # | Method |
+|---|--------|
+| 1 | `yaml.safe_load` of all 9 workflows; inspected top-level `permissions` of each. |
+| 2 | Confirmed write jobs retain/gain explicit per-job permissions (audit before clamping). |
+| 3 | Confirmed `docs.yml` PR `branches` and `release.yml` `concurrency`. |
+| 4 | CI green on PR #950 (every running job succeeded under `contents: read` → nothing lost a needed permission). |
+
+## Acceptance criteria
+
+| AC | Result | Evidence |
+|----|--------|----------|
+| Every workflow declares top-level `permissions:`; write jobs explicitly elevated | ✅ Pass | All 9 have a top-level block (8 × `contents: read`; `smoke-test` keeps `contents: read, issues: write, packages: read`). Per-job write retained: `docker` build → `packages: write`; `release` `publish`/`update-homebrew-tap`/`notify-downstream` → existing per-job; **`release-status-aggregator` → added `contents: write`** (its `gh release edit`). |
+| `ci.yml` clamp is safe | ✅ Pass | Both tokens read-only (buf-setup auth; Sonar scanner reads PR context). CI green on #950. |
+| `docs.yml` PR trigger scoped to master | ✅ Pass | `pull_request.branches: [master]` added. |
+| `release.yml` has a `concurrency` block | ✅ Pass | `group: release-${{ github.ref }}`, `cancel-in-progress: false`. |
+| All workflows YAML-valid | ✅ Pass | `yaml.safe_load` clean on all 9. |
+| release permission change is tag-only | ✅ Pass (by construction) | `release.yml` runs only on `v*` tags; exercised at the next release. The aggregator's added `contents: write` preserves its `gh release edit`. |
+
+## Outcome
+
+- All ACs **pass**. The `GITHUB_TOKEN` blast radius is now least-privilege per workflow
+  without removing any permission a job actually uses (CI green on #950 confirms for the
+  PR-exercised workflows; `release.yml` verified by construction).
+- B2 (sonar `if`) was folded into AAASM-2601. No gaps found; nothing filed back to AAASM-2615.


### PR DESCRIPTION
## Description

Adds the verification report for Story **AAASM-2611** at `verification-reports/AAASM-2611.md`, confirming the CI hardening (PR #950 / AAASM-2615) satisfies each Story AC. Documentation only.

> **Stacked on #950** (which stacks on #948). Diff reduces to just this report once the parents merge. Base `master`.

Confirms all 9 workflows declare top-level `permissions:`; write jobs retain/gain per-job elevation (incl. release aggregator `contents: write`); docs `branches: [master]`; release `concurrency`; all YAML-valid; release change verified by construction (tag-only).

## Type of Change
- [x] 📝 Documentation update

## Breaking Changes
- [x] No

## Related Issues
- Related Jira ticket: AAASM-2616 (verification subtask of AAASM-2611, Epic AAASM-2551)

## Testing
- [x] No tests required (explain why)

Verification artifact over a CI-config deliverable.

## Checklist
- [x] Code follows project style guidelines — N/A for docs
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (verification artifact)
- [ ] All CI checks passing (pending CI)
- [x] Commits are small and follow the Gitmoji convention
