### PR TITLE
[AAASM-2621] 🔧 (ci): Fine-grain ci.yml router + add CI Success gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,10 @@ jobs:
       rust: ${{ steps.filter.outputs.rust }}
       dashboard: ${{ steps.filter.outputs.dashboard }}
       ebpf: ${{ steps.filter.outputs.ebpf }}
+      proto: ${{ steps.filter.outputs.proto }}
+      schema: ${{ steps.filter.outputs.schema }}
+      openapi: ${{ steps.filter.outputs.openapi }}
+      storage: ${{ steps.filter.outputs.storage }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v4.0.1
@@ -85,6 +89,26 @@ jobs:
               - 'dashboard/**'
               - 'openapi/v1.yaml'
               - 'sonar-project.properties'
+              - '.github/workflows/ci.yml'
+            # AAASM-2599: fine-grained filters so single-purpose validators run
+            # only when their own inputs change (each is a strict subset of the
+            # broad `rust` set above, so this can never lose coverage). Always
+            # include this workflow so editing CI re-runs everything.
+            proto:
+              - 'proto/**'
+              - 'aa-proto/**'
+              - '.github/workflows/ci.yml'
+            schema:
+              - 'schemas/**'
+              - '.github/workflows/ci.yml'
+            openapi:
+              - 'aa-api/**'
+              - 'openapi/**'
+              - '.spectral.yaml'
+              - '.github/workflows/ci.yml'
+            storage:
+              - 'aa-gateway/**'
+              - 'aa-storage*/**'
               - '.github/workflows/ci.yml'
             # AAASM-2580: gate the slow eBPF --release jobs (fat-LTO BPF build +
             # bpf-linker compile) so they only run when eBPF code — or this

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,7 +487,7 @@ jobs:
   # major; pg17 is the latest published tag as of 2026-05.
   timescaledb-tests:
     needs: [changes]
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.storage == 'true'
     name: TimescaleDB Tests
     runs-on: ubuntu-latest
     services:
@@ -524,7 +524,7 @@ jobs:
 
   migration-drift-check:
     needs: [changes]
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.storage == 'true'
     name: Migration drift check
     runs-on: ubuntu-latest
     steps:
@@ -581,7 +581,7 @@ jobs:
 
   buf-lint:
     needs: [changes]
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.proto == 'true'
     name: Proto lint & breaking check (buf)
     runs-on: ubuntu-latest
     steps:
@@ -607,7 +607,7 @@ jobs:
 
   schema-lint:
     needs: [changes]
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.schema == 'true'
     name: Schema lint & validation (ajv)
     runs-on: ubuntu-latest
     steps:
@@ -633,7 +633,7 @@ jobs:
 
   openapi-drift:
     needs: [changes]
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.openapi == 'true'
     name: OpenAPI spec drift check
     runs-on: ubuntu-latest
     steps:
@@ -649,7 +649,7 @@ jobs:
 
   openapi-lint:
     needs: [changes]
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.openapi == 'true'
     name: OpenAPI spec lint (Spectral)
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1209,6 +1209,60 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
+  # AAASM-2599: single aggregate gate that succeeds only when every functional
+  # CI job passed or was intentionally skipped (path-routed). This is the one
+  # status to make a required check in branch protection — it stays green for
+  # PRs that legitimately skip whole areas, yet fails if any job failed or was
+  # cancelled. Quality/acceptance jobs (coverage, sonar) are deliberately NOT
+  # gated here: their failures are advisory and must not block merge.
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - changes
+      - dashboard-assets
+      - build
+      - fmt
+      - clippy
+      - docs
+      - test
+      - timescaledb-tests
+      - migration-drift-check
+      - deny
+      - no-std
+      - buf-lint
+      - schema-lint
+      - openapi-drift
+      - openapi-lint
+      - compat-matrix-check
+      - ebpf-build
+      - e2e-ebpf-linux
+      - benchmark
+      - conformance
+      - conformance-python
+      - conformance-node
+      - conformance-go
+      - dashboard-typecheck
+      - dashboard-build
+      - dashboard-test
+      - dashboard-codegen-drift
+      - aa-cli-compat
+    steps:
+      - name: Verify no required job failed or was cancelled
+        run: |
+          results="${{ join(needs.*.result, ' ') }}"
+          echo "Job results: $results"
+          for r in $results; do
+            case "$r" in
+              failure|cancelled)
+                echo "::error::A required CI job concluded with '$r'"
+                exit 1
+                ;;
+            esac
+          done
+          echo "All required CI jobs passed or were intentionally skipped."
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Description

Fine-grains the `agent-assembly` CI router and adds a single aggregate gate so the path-routed workflow stays compact yet always-correct (AAASM-2599, impl subtask AAASM-2621).

**Router** — adds four narrow `dorny/paths-filter` outputs to the `changes` job on top of the existing `rust`/`dashboard`/`ebpf` set:

| Output | Paths |
|---|---|
| `proto` | `proto/**`, `aa-proto/**`, `.github/workflows/ci.yml` |
| `schema` | `schemas/**`, `.github/workflows/ci.yml` |
| `openapi` | `aa-api/**`, `openapi/**`, `.spectral.yaml`, `.github/workflows/ci.yml` |
| `storage` | `aa-gateway/**`, `aa-storage*/**`, `.github/workflows/ci.yml` |

Each new filter matches a **strict subset** of the broad `rust` filter, so narrowing a validator onto it can never lose coverage.

**Re-gating** — six single-purpose validators now run only when their own inputs change:

- `buf-lint` → `proto`
- `schema-lint` → `schema`
- `openapi-drift`, `openapi-lint` → `openapi`
- `timescaledb-tests`, `migration-drift-check` → `storage`

Behavioural Rust jobs (`build`, `test`, `clippy`, `docs`, `conformance*`, `no-std`, `deny`, `compat-matrix-check`, …) **stay on the broad `rust` output** — they exercise the whole workspace, so narrowing them would risk missing coverage. The win: an `aa-cli`-only PR no longer drags in the proto/schema/openapi checks or the slow Postgres testcontainer jobs.

**CI Success gate** — new `ci-success` job that `needs` every functional job, runs with `if: always()`, and fails only if any concluded `failure` or `cancelled` (skipped/success pass). This collapses the path-routed matrix into one stable status that is green even when a PR legitimately skips whole areas — the single status to make a required check in branch protection. `coverage` and `sonar` are intentionally excluded so their advisory failures never block merge.

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2621 (impl) / AAASM-2599 (story)

## Testing

- [x] Manual testing performed — YAML validated with `yaml.safe_load`; gate `needs` asserted to cover every job except `ci-success`/`coverage`/`sonar` (28 needs / 31 jobs); narrow filters confirmed to be subsets of the `rust` filter.
- [x] No tests required (explain why) — config-only workflow change; behaviour is observed by the running PR's own check set.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (inline workflow comments)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
