### PR TITLE
[AAASM-2626] ♻️ (aa-sdk-client): Add AssemblyClient lifecycle, event shipping + advisory preflight

### DIFF
--- a/aa-sdk-client/src/client.rs
+++ b/aa-sdk-client/src/client.rs
@@ -1,0 +1,355 @@
+//! `AssemblyClient` — the FFI-agnostic core of an Agent Assembly SDK session.
+//!
+//! Owns the lifecycle of the IPC connection to `aa-runtime` and provides the
+//! event-shipping API (`report_event` / `report_llm_call` / `report_edge` /
+//! `shutdown`) that the per-language FFI shims wrap. Every method returns a
+//! plain [`Result`]`<_, `[`SdkClientError`]`>`; there is no language-runtime
+//! (pyo3 / napi / cgo) coupling in this crate.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use crate::error::SdkClientError;
+use crate::ipc::{IpcCommand, IpcHandle};
+#[cfg(feature = "preflight")]
+use crate::preflight::Preflight;
+
+/// Handle to an active Agent Assembly session.
+///
+/// Wraps the background IPC connection to `aa-runtime`. Construct one with
+/// [`AssemblyClient::new`], report events through it, and call
+/// [`AssemblyClient::shutdown`] when done (the FFI shims tie this to their
+/// language's resource-management protocol, e.g. Python's context manager).
+pub struct AssemblyClient {
+    inner: Mutex<Option<IpcHandle>>,
+    detected_frameworks: Vec<String>,
+    #[cfg(feature = "preflight")]
+    preflight: Option<Preflight>,
+}
+
+impl AssemblyClient {
+    /// Create a client with the default advisory preflight enabled (when the
+    /// `preflight` feature is on).
+    pub fn new(ipc_handle: IpcHandle, detected_frameworks: Vec<String>) -> Self {
+        Self {
+            inner: Mutex::new(Some(ipc_handle)),
+            detected_frameworks,
+            #[cfg(feature = "preflight")]
+            preflight: Some(Preflight::new()),
+        }
+    }
+
+    /// Create a client with an explicit advisory preflight configuration.
+    ///
+    /// Pass `None` to disable local preflight (the runtime still scans
+    /// authoritatively), or `Some(preflight)` to use a custom one.
+    #[cfg(feature = "preflight")]
+    pub fn with_preflight(
+        ipc_handle: IpcHandle,
+        detected_frameworks: Vec<String>,
+        preflight: Option<Preflight>,
+    ) -> Self {
+        Self {
+            inner: Mutex::new(Some(ipc_handle)),
+            detected_frameworks,
+            preflight,
+        }
+    }
+
+    /// Apply the advisory preflight redactor to user-supplied text.
+    ///
+    /// Advisory only — the runtime re-scans every event authoritatively.
+    #[cfg(feature = "preflight")]
+    fn apply_preflight(&self, details: String) -> String {
+        match &self.preflight {
+            Some(pf) => pf.advisory_redact(details),
+            None => details,
+        }
+    }
+
+    #[cfg(not(feature = "preflight"))]
+    fn apply_preflight(&self, details: String) -> String {
+        details
+    }
+
+    /// Enqueue an already-built event onto the IPC command channel.
+    fn send(&self, event: aa_proto::assembly::audit::v1::AuditEvent) -> Result<(), SdkClientError> {
+        let guard = self.inner.lock().map_err(|_| SdkClientError::LockPoisoned)?;
+        let ipc = guard.as_ref().ok_or(SdkClientError::Shutdown)?;
+        ipc.cmd_tx
+            .blocking_send(IpcCommand::SendEvent(Box::new(event)))
+            .map_err(|_| SdkClientError::ChannelClosed)
+    }
+
+    /// Report an audit event to the runtime.
+    ///
+    /// `details` passes through the advisory preflight before shipping; the
+    /// runtime re-scans regardless.
+    pub fn report_event(&self, event_type: String, details: String) -> Result<(), SdkClientError> {
+        let safe_details = self.apply_preflight(details);
+
+        let mut labels = HashMap::new();
+        labels.insert("event_type".to_string(), event_type);
+        labels.insert("details".to_string(), safe_details);
+
+        let event = aa_proto::assembly::audit::v1::AuditEvent {
+            event_id: unique_event_id(),
+            labels,
+            ..Default::default()
+        };
+
+        self.send(event)
+    }
+
+    /// Report an LLM call to the runtime with typed metadata.
+    pub fn report_llm_call(
+        &self,
+        model: String,
+        prompt_tokens: i32,
+        completion_tokens: i32,
+        latency_ms: i64,
+        provider: &str,
+    ) -> Result<(), SdkClientError> {
+        use aa_proto::assembly::audit::v1::{audit_event, AuditEvent, LlmCallDetail};
+        use aa_proto::assembly::common::v1::ActionType;
+
+        let detail = LlmCallDetail {
+            model,
+            prompt_tokens,
+            completion_tokens,
+            latency_ms,
+            provider: provider.to_string(),
+            ..Default::default()
+        };
+
+        let event = AuditEvent {
+            event_id: unique_event_id(),
+            action_type: ActionType::LlmCall.into(),
+            detail: Some(audit_event::Detail::LlmCall(detail)),
+            ..Default::default()
+        };
+
+        self.send(event)
+    }
+
+    /// Report a directed topology edge between two agents.
+    pub fn report_edge(
+        &self,
+        source_agent_id: String,
+        target_agent_id: String,
+        edge_type: String,
+        metadata_json: Option<String>,
+    ) -> Result<(), SdkClientError> {
+        let mut labels = HashMap::new();
+        labels.insert("__aa_edge_source__".to_string(), source_agent_id);
+        labels.insert("__aa_edge_target__".to_string(), target_agent_id);
+        labels.insert("__aa_edge_type__".to_string(), edge_type);
+        if let Some(m) = metadata_json {
+            labels.insert("__aa_edge_metadata__".to_string(), m);
+        }
+
+        let event = aa_proto::assembly::audit::v1::AuditEvent {
+            event_id: unique_event_id(),
+            labels,
+            ..Default::default()
+        };
+
+        self.send(event)
+    }
+
+    /// Shut down the IPC connection and join the background thread.
+    ///
+    /// Safe to call multiple times — subsequent calls are no-ops. FFI shims
+    /// that hold a runtime lock (e.g. Python's GIL) should release it around
+    /// this call, since it blocks on the background thread join.
+    pub fn shutdown(&self) -> Result<(), SdkClientError> {
+        let mut guard = self.inner.lock().map_err(|_| SdkClientError::LockPoisoned)?;
+
+        if let Some(mut ipc) = guard.take() {
+            // Best-effort shutdown signal — the channel may already be closed.
+            let _ = ipc.cmd_tx.blocking_send(IpcCommand::Shutdown);
+
+            if let Some(thread) = ipc.thread.take() {
+                let _ = thread.join();
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Returns the list of detected AI frameworks.
+    pub fn detected_frameworks(&self) -> Vec<String> {
+        self.detected_frameworks.clone()
+    }
+}
+
+/// Generate a unique event ID string.
+fn unique_event_id() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as u64;
+    let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    format!("{:016x}-{:08x}-{:04x}", nanos, pid, seq)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::sync::mpsc;
+
+    /// Build an `AssemblyClient` backed by a test mpsc channel (no real socket).
+    fn test_client(frameworks: Vec<String>) -> (AssemblyClient, mpsc::Receiver<IpcCommand>) {
+        let (tx, rx) = mpsc::channel(16);
+        let ipc = IpcHandle {
+            cmd_tx: tx,
+            thread: None,
+        };
+        (AssemblyClient::new(ipc, frameworks), rx)
+    }
+
+    #[test]
+    fn unique_event_id_is_nonempty() {
+        assert!(!unique_event_id().is_empty());
+    }
+
+    #[test]
+    fn unique_event_id_unique() {
+        assert_ne!(unique_event_id(), unique_event_id());
+    }
+
+    #[test]
+    fn detected_frameworks_are_returned() {
+        let (client, _rx) = test_client(vec!["openai".to_string()]);
+        assert_eq!(client.detected_frameworks(), vec!["openai".to_string()]);
+    }
+
+    #[test]
+    fn report_llm_call_sends_event_with_llm_detail() {
+        use aa_proto::assembly::audit::v1::audit_event;
+
+        let (client, mut rx) = test_client(vec![]);
+        client
+            .report_llm_call("gpt-4o".to_string(), 100, 50, 1234, "openai")
+            .unwrap();
+
+        match rx.try_recv().expect("should have received a command") {
+            IpcCommand::SendEvent(event) => {
+                assert!(!event.event_id.is_empty());
+                assert_eq!(
+                    event.action_type,
+                    i32::from(aa_proto::assembly::common::v1::ActionType::LlmCall)
+                );
+                match event.detail {
+                    Some(audit_event::Detail::LlmCall(ref d)) => {
+                        assert_eq!(d.model, "gpt-4o");
+                        assert_eq!(d.prompt_tokens, 100);
+                        assert_eq!(d.completion_tokens, 50);
+                        assert_eq!(d.latency_ms, 1234);
+                        assert_eq!(d.provider, "openai");
+                    }
+                    other => panic!("expected LlmCall detail, got {:?}", other),
+                }
+            }
+            other => panic!("expected SendEvent, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn report_on_shutdown_client_returns_error() {
+        let (client, _rx) = test_client(vec![]);
+        client.shutdown().unwrap();
+        let err = client
+            .report_llm_call("gpt-4o".to_string(), 0, 0, 0, "openai")
+            .expect_err("should error on a shut-down client");
+        assert!(matches!(err, SdkClientError::Shutdown));
+    }
+
+    #[test]
+    fn report_edge_sets_edge_labels() {
+        let (client, mut rx) = test_client(vec![]);
+        client
+            .report_edge("a".into(), "b".into(), "delegates_to".into(), None)
+            .unwrap();
+
+        match rx.try_recv().expect("should receive command") {
+            IpcCommand::SendEvent(event) => {
+                assert_eq!(event.labels.get("__aa_edge_source__").unwrap(), "a");
+                assert_eq!(event.labels.get("__aa_edge_target__").unwrap(), "b");
+                assert_eq!(event.labels.get("__aa_edge_type__").unwrap(), "delegates_to");
+            }
+            other => panic!("expected SendEvent, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "preflight")]
+    #[test]
+    fn report_event_redacts_credentials_in_details() {
+        let (client, mut rx) = test_client(vec![]);
+        let secret = "sk-proj-aBcDeFgHiJkLmNoPqRsT1234567890abcdef1234567890ab";
+
+        client
+            .report_event("llm_call".into(), format!("called openai with key {secret}"))
+            .unwrap();
+
+        match rx.try_recv().expect("should receive command") {
+            IpcCommand::SendEvent(event) => {
+                let labels_str = format!("{:?}", event.labels);
+                assert!(
+                    !labels_str.contains("sk-proj-"),
+                    "details label must not contain raw credential, got: {labels_str}"
+                );
+                assert!(
+                    labels_str.contains("[REDACTED:"),
+                    "details label should contain redaction marker"
+                );
+            }
+            other => panic!("expected SendEvent, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn report_event_passes_clean_details_unchanged() {
+        let (client, mut rx) = test_client(vec![]);
+        client
+            .report_event("tool_call".into(), "searched for cats".into())
+            .unwrap();
+
+        match rx.try_recv().expect("should receive command") {
+            IpcCommand::SendEvent(event) => {
+                assert_eq!(event.labels.get("details").unwrap(), "searched for cats");
+            }
+            other => panic!("expected SendEvent, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "preflight")]
+    #[test]
+    fn report_event_with_preflight_disabled_passes_details_through() {
+        let (tx, mut rx) = mpsc::channel(16);
+        let ipc = IpcHandle {
+            cmd_tx: tx,
+            thread: None,
+        };
+        let client = AssemblyClient::with_preflight(ipc, vec![], None);
+        let secret = "sk-proj-aBcDeFgHiJkLmNoPqRsT1234567890abcdef1234567890ab";
+        let details = format!("key is {secret}");
+
+        client.report_event("llm_call".into(), details.clone()).unwrap();
+
+        match rx.try_recv().expect("should receive command") {
+            IpcCommand::SendEvent(event) => {
+                // Preflight disabled — raw credential passes through locally; the
+                // runtime still redacts it authoritatively.
+                assert_eq!(event.labels.get("details").unwrap(), &details);
+            }
+            other => panic!("expected SendEvent, got {other:?}"),
+        }
+    }
+}

--- a/aa-sdk-client/src/error.rs
+++ b/aa-sdk-client/src/error.rs
@@ -1,0 +1,34 @@
+//! Error type for the SDK client.
+
+/// Errors returned by [`AssemblyClient`](crate::client::AssemblyClient)
+/// operations.
+///
+/// The crate is FFI-agnostic, so these are plain Rust errors. The per-language
+/// shims map them onto their native exception types (e.g. the pyo3 shim
+/// converts them to `RuntimeError`).
+#[derive(Debug)]
+pub enum SdkClientError {
+    /// The client has been shut down; no further events can be reported.
+    Shutdown,
+    /// An internal lock was poisoned by a panic in another thread.
+    LockPoisoned,
+    /// The background IPC thread's command channel is closed, so the event
+    /// could not be enqueued.
+    ChannelClosed,
+}
+
+impl std::fmt::Display for SdkClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SdkClientError::Shutdown => {
+                write!(f, "AssemblyClient is shut down; cannot report events")
+            }
+            SdkClientError::LockPoisoned => write!(f, "AssemblyClient lock was poisoned"),
+            SdkClientError::ChannelClosed => {
+                write!(f, "failed to enqueue event: IPC channel is closed")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SdkClientError {}

--- a/aa-sdk-client/src/lib.rs
+++ b/aa-sdk-client/src/lib.rs
@@ -25,6 +25,7 @@
 //! - UDS transport / background IPC thread — AAASM-2625
 //! - `AssemblyClient` lifecycle, event shipping, advisory preflight — AAASM-2626
 
+pub mod client;
 pub mod codec;
 pub mod config;
 pub mod error;
@@ -32,6 +33,8 @@ pub mod ipc;
 #[cfg(feature = "preflight")]
 pub mod preflight;
 
+pub use client::AssemblyClient;
+pub use config::AssemblyConfig;
 pub use error::SdkClientError;
 #[cfg(feature = "preflight")]
 pub use preflight::Preflight;

--- a/aa-sdk-client/src/lib.rs
+++ b/aa-sdk-client/src/lib.rs
@@ -27,4 +27,7 @@
 
 pub mod codec;
 pub mod config;
+pub mod error;
 pub mod ipc;
+
+pub use error::SdkClientError;

--- a/aa-sdk-client/src/lib.rs
+++ b/aa-sdk-client/src/lib.rs
@@ -29,5 +29,9 @@ pub mod codec;
 pub mod config;
 pub mod error;
 pub mod ipc;
+#[cfg(feature = "preflight")]
+pub mod preflight;
 
 pub use error::SdkClientError;
+#[cfg(feature = "preflight")]
+pub use preflight::Preflight;

--- a/aa-sdk-client/src/preflight.rs
+++ b/aa-sdk-client/src/preflight.rs
@@ -1,0 +1,86 @@
+//! Advisory, best-effort credential preflight — **non-authoritative**.
+//!
+//! This module lets the SDK redact obvious credentials locally so an agent can
+//! *fail fast* before a secret is ever handed to the transport. It is **not** a
+//! security boundary and confers **no** authority:
+//!
+//! - The SDK is untrusted. The mandatory runtime chokepoint (`aa-runtime`,
+//!   AAASM-2568) re-scans, re-redacts, and normalizes **every** event
+//!   unconditionally, regardless of anything the SDK did or claims.
+//! - Nothing here ever sets a `clean` / `already_scanned` / pre-scanned signal
+//!   on the wire. No such marker exists, and the runtime would ignore it if it
+//!   did. Preflight only ever *removes* data (redacts); it never adds trust.
+//!
+//! The scanner is constructed once and reused, mirroring the runtime's
+//! precompiled-scanner guardrail.
+
+use aa_security::CredentialScanner;
+
+/// Advisory, best-effort local credential redactor wrapping a precompiled
+/// [`CredentialScanner`]. **Non-authoritative** — see the module docs.
+pub struct Preflight {
+    scanner: CredentialScanner,
+}
+
+impl Preflight {
+    /// Create a preflight redactor with the default credential scanner.
+    pub fn new() -> Self {
+        Self {
+            scanner: CredentialScanner::new(),
+        }
+    }
+
+    /// Create a preflight redactor from an explicit scanner configuration.
+    pub fn with_scanner(scanner: CredentialScanner) -> Self {
+        Self { scanner }
+    }
+
+    /// Best-effort redaction of credentials in `input`.
+    ///
+    /// Returns the input unchanged when no credentials are detected, otherwise
+    /// the redacted form. This is **advisory only** — the runtime re-scans
+    /// authoritatively, so a miss here is caught there. No trust marker is ever
+    /// emitted as a result of this call.
+    pub fn advisory_redact(&self, input: String) -> String {
+        let scan = self.scanner.scan(&input);
+        if scan.is_clean() {
+            input
+        } else {
+            tracing::warn!(
+                findings = scan.findings.len(),
+                "advisory preflight detected credentials; redacting locally (runtime re-scans authoritatively)"
+            );
+            scan.redact(&input)
+        }
+    }
+}
+
+impl Default for Preflight {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_input_is_returned_unchanged() {
+        let pf = Preflight::new();
+        let out = pf.advisory_redact("searched for cats".to_string());
+        assert_eq!(out, "searched for cats");
+    }
+
+    #[test]
+    fn credential_is_redacted() {
+        let pf = Preflight::new();
+        let secret = "sk-proj-aBcDeFgHiJkLmNoPqRsT1234567890abcdef1234567890ab";
+        let out = pf.advisory_redact(format!("key is {secret}"));
+        assert!(!out.contains("sk-proj-"), "raw credential must not survive, got: {out}");
+        assert!(
+            out.contains("[REDACTED:"),
+            "redacted output should carry a redaction marker"
+        );
+    }
+}


### PR DESCRIPTION
## Description

Fourth subtask of **Story AAASM-2570** (extract `aa-sdk-client`). Stacked on AAASM-2625 (transport); base is `master`.

Extracts the FFI-agnostic core of `aa-ffi-python`'s `AssemblyHandle` into a clean Rust API the per-language shims will wrap, plus the **advisory** preflight redactor. No `pyo3` / `PyResult` anywhere in the crate — every method returns `Result<_, SdkClientError>`.

- `error` — `SdkClientError` (`Shutdown` / `LockPoisoned` / `ChannelClosed`); shims map it onto native exceptions.
- `preflight` *(feature `preflight`, default on)* — `Preflight`, an **advisory, best-effort** credential redactor over a precompiled `aa_security::CredentialScanner`. Documented as **non-authoritative**: it only ever *removes* data, **never** sets a `clean`/`already_scanned`/pre-scanned marker on the wire. The runtime (AAASM-2568 gate) re-scans every event unconditionally.
- `client` — `AssemblyClient`: `report_event` / `report_llm_call` / `report_edge` / `shutdown` / `detected_frameworks`, the private `send()` enqueue path, and `unique_event_id()`. `report_event` runs `details` through the advisory preflight before shipping.

`lib.rs` re-exports `AssemblyClient`, `AssemblyConfig`, `SdkClientError`, and (under the feature) `Preflight`.

### Trust-model AC (Story)

- Preflight is advisory only: with `--no-default-features` the `aa-security` dep is dropped entirely and events still ship (runtime stays authoritative). No code path makes preflight authoritative; no trust marker is emitted — the built `AuditEvent` carries only `event_id` + `labels`/`detail`.

Commits:
- `♻️ (aa-sdk-client): Add SdkClientError result type`
- `♻️ (aa-sdk-client): Add advisory non-authoritative credential preflight`
- `♻️ (aa-sdk-client): Add AssemblyClient lifecycle and event shipping`

## Type of Change

- [x] ♻️ Refactoring

## Breaking Changes

- [x] No

New internal crate API; `aa-ffi-python` untouched (its migration is AAASM-2561).

## Related Issues

- Related Jira ticket: AAASM-2626 (subtask of AAASM-2570, Epic AAASM-2552)

## Testing

- [x] Unit tests added / updated
- [x] Manual testing performed

`cargo nextest run -p aa-sdk-client` → 23 passed (default), and `--no-default-features` → 19 passed (preflight-gated tests excluded). `cargo clippy -p aa-sdk-client --all-targets --all-features` and `--no-default-features` both clean; `cargo fmt --all --check`, `cargo deny check`, `cargo doc --workspace --no-deps` green.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention