### PR TITLE
[AAASM-2627] ✅ (aa-sdk-client): Verify aa-sdk-client acceptance criteria

### DIFF
--- a/aa-sdk-client/tests/advisory_preflight_no_marker.rs
+++ b/aa-sdk-client/tests/advisory_preflight_no_marker.rs
@@ -1,0 +1,54 @@
+//! AAASM-2570 acceptance: the advisory preflight redacts credentials locally,
+//! but **never** emits a trust marker on the wire. The runtime re-scans every
+//! event unconditionally; nothing the SDK does may shorten that work.
+#![cfg(feature = "preflight")]
+
+use aa_sdk_client::ipc::{IpcCommand, IpcHandle};
+use aa_sdk_client::AssemblyClient;
+use tokio::sync::mpsc;
+
+#[test]
+fn advisory_preflight_redacts_and_emits_no_trust_marker() {
+    let (tx, mut rx) = mpsc::channel(8);
+    let client = AssemblyClient::new(
+        IpcHandle {
+            cmd_tx: tx,
+            thread: None,
+        },
+        vec![],
+    );
+    let secret = "sk-proj-aBcDeFgHiJkLmNoPqRsT1234567890abcdef1234567890ab";
+
+    client
+        .report_event("llm_call".into(), format!("called openai with key {secret}"))
+        .unwrap();
+
+    match rx.try_recv().expect("event should have been enqueued") {
+        IpcCommand::SendEvent(event) => {
+            // Advisory redaction happened locally.
+            let details = event.labels.get("details").expect("details label present");
+            assert!(!details.contains("sk-proj-"), "raw credential leaked: {details}");
+            assert!(details.contains("[REDACTED:"), "expected redaction marker in details");
+
+            // No `clean` / `already_scanned` / pre-scanned signal is ever placed
+            // on the wire.
+            for marker in [
+                "clean",
+                "scanned",
+                "already_scanned",
+                "preflight",
+                "__aa_scanned__",
+                "__aa_clean__",
+            ] {
+                assert!(
+                    !event.labels.contains_key(marker),
+                    "unexpected SDK trust marker on the wire: {marker}"
+                );
+            }
+
+            // Only the two expected labels exist — no extra metadata smuggled in.
+            assert_eq!(event.labels.len(), 2, "unexpected extra labels: {:?}", event.labels);
+        }
+        other => panic!("expected SendEvent, got {other:?}"),
+    }
+}

--- a/aa-sdk-client/tests/lifecycle_e2e.rs
+++ b/aa-sdk-client/tests/lifecycle_e2e.rs
@@ -1,0 +1,72 @@
+//! AAASM-2570 acceptance: `AssemblyClient` drives a full session against a mock
+//! `UnixListener` "runtime" — connect → heartbeat → report event → shutdown.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use aa_sdk_client::codec::{TAG_ACK, TAG_EVENT_REPORT, TAG_HEARTBEAT};
+use aa_sdk_client::ipc::spawn_ipc_thread;
+use aa_sdk_client::AssemblyClient;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixListener;
+
+/// Read a prost varint length prefix from `reader`.
+async fn read_varint<R: AsyncReadExt + Unpin>(reader: &mut R) -> usize {
+    let mut result: u64 = 0;
+    let mut shift = 0u32;
+    loop {
+        let byte = reader.read_u8().await.unwrap();
+        result |= ((byte & 0x7F) as u64) << shift;
+        if byte & 0x80 == 0 {
+            break;
+        }
+        shift += 7;
+    }
+    result as usize
+}
+
+#[tokio::test]
+async fn client_ships_event_to_mock_runtime_and_shuts_down() {
+    let socket_path = format!("/tmp/aa-sdk-client-e2e-{}.sock", std::process::id());
+    let _ = std::fs::remove_file(&socket_path);
+    let listener = UnixListener::bind(&socket_path).unwrap();
+
+    let ipc = spawn_ipc_thread(PathBuf::from(&socket_path)).unwrap();
+    let client = Arc::new(AssemblyClient::new(ipc, vec!["openai".to_string()]));
+    assert_eq!(client.detected_frameworks(), vec!["openai".to_string()]);
+
+    let (stream, _) = listener.accept().await.unwrap();
+    let (mut reader, mut writer) = tokio::io::split(stream);
+
+    // 1. Heartbeat handshake.
+    assert_eq!(reader.read_u8().await.unwrap(), TAG_HEARTBEAT);
+    writer.write_all(&[TAG_ACK, 0x00]).await.unwrap();
+    writer.flush().await.unwrap();
+
+    // 2. Report an event. `report_event` issues a blocking send, so it must run
+    //    off the async runtime thread.
+    let ship = {
+        let c = Arc::clone(&client);
+        tokio::task::spawn_blocking(move || c.report_event("tool_call".into(), "searched for cats".into()))
+    };
+
+    // 3. Server reads the event-report frame (tag + length-delimited payload) and acks.
+    assert_eq!(reader.read_u8().await.unwrap(), TAG_EVENT_REPORT);
+    let len = read_varint(&mut reader).await;
+    let mut buf = vec![0u8; len];
+    reader.read_exact(&mut buf).await.unwrap();
+    assert!(!buf.is_empty(), "event report payload should be non-empty");
+    writer.write_all(&[TAG_ACK, 0x00]).await.unwrap();
+    writer.flush().await.unwrap();
+
+    ship.await.unwrap().expect("report_event should succeed");
+
+    // 4. Shutdown joins the background thread — also off the runtime.
+    let c = Arc::clone(&client);
+    tokio::task::spawn_blocking(move || c.shutdown())
+        .await
+        .unwrap()
+        .expect("shutdown should succeed");
+
+    let _ = std::fs::remove_file(&socket_path);
+}

--- a/aa-sdk-client/tests/preflight_disabled_passthrough.rs
+++ b/aa-sdk-client/tests/preflight_disabled_passthrough.rs
@@ -1,0 +1,36 @@
+//! AAASM-2570 acceptance: preflight is advisory and optional. Disabling it lets
+//! raw text pass through locally (the runtime still scans authoritatively) and
+//! even then no trust marker is added to the event.
+#![cfg(feature = "preflight")]
+
+use aa_sdk_client::ipc::{IpcCommand, IpcHandle};
+use aa_sdk_client::AssemblyClient;
+use tokio::sync::mpsc;
+
+#[test]
+fn preflight_disabled_passes_text_through_without_marker() {
+    let (tx, mut rx) = mpsc::channel(8);
+    let client = AssemblyClient::with_preflight(
+        IpcHandle {
+            cmd_tx: tx,
+            thread: None,
+        },
+        vec![],
+        None,
+    );
+    let secret = "sk-proj-aBcDeFgHiJkLmNoPqRsT1234567890abcdef1234567890ab";
+    let details = format!("key is {secret}");
+
+    client.report_event("llm_call".into(), details.clone()).unwrap();
+
+    match rx.try_recv().expect("event should have been enqueued") {
+        IpcCommand::SendEvent(event) => {
+            // Local preflight off ⇒ raw text passes through unchanged here; the
+            // runtime is responsible for the authoritative scan/redact.
+            assert_eq!(event.labels.get("details").unwrap(), &details);
+            // Still no trust marker added.
+            assert_eq!(event.labels.len(), 2, "unexpected extra labels: {:?}", event.labels);
+        }
+        other => panic!("expected SendEvent, got {other:?}"),
+    }
+}

--- a/verification-reports/verification-report-AAASM-2570.md
+++ b/verification-reports/verification-report-AAASM-2570.md
@@ -1,0 +1,102 @@
+# Verification Report — AAASM-2570
+
+**Story:** ♻️ (agent-assembly) Extract `aa-sdk-client` (UDS/proto/lifecycle/event shipping + advisory preflight)
+**Epic:** AAASM-2552 — SDK security boundary + FFI consolidation (Story 6 of 9)
+**Component / repo:** `agent-assembly`
+**Date:** 2026-06-06
+
+## Summary
+
+Created a new workspace crate, `aa-sdk-client`, as the single, FFI-agnostic home
+for the SDK runtime-client logic that was previously reimplemented per language
+(1,357 lines in `aa-ffi-python`; a separate 178-line reimplementation in
+`node-sdk`). The crate owns the UDS transport, the IPC wire codec, the
+`AssemblyClient` lifecycle, and event capture/shipping, plus an **advisory,
+non-authoritative** credential preflight.
+
+The work was delivered as 5 stacked subtasks, one PR each (all base `master`):
+
+| Subtask | PR | Scope |
+|---|---|---|
+| AAASM-2623 | #954 | Scaffold the crate (manifest, lib root, workspace member, compat-matrix doc) |
+| AAASM-2624 | #955 | Port socket config + IPC wire codec |
+| AAASM-2625 | #956 | Port UDS transport / background IPC thread |
+| AAASM-2626 | #957 | `AssemblyClient` lifecycle + event shipping + advisory preflight |
+| AAASM-2627 | (this) | Acceptance tests + this report |
+
+This change is **purely additive**. `aa-ffi-python` is untouched; rewiring the
+Python/Node shims onto `aa-sdk-client` (and removing their duplicate copies) is
+deliberately deferred to Stories 7–9 (AAASM-2560 / AAASM-2561 / AAASM-2562), per
+the Epic's boundary-first gating. The runtime-enforcement gate (AAASM-2568) and
+the `aa-security` extraction (AAASM-2567) are both already merged, so this
+extraction was unblocked.
+
+## Acceptance criteria
+
+### AC1 — `aa-sdk-client` is the single implementation of the SDK transport/codec/lifecycle
+
+**Met (as the canonical implementation).** The crate now contains the complete,
+language-agnostic runtime-client: `config` (socket resolution), `codec` (wire
+protocol, byte-compatible with `aa-runtime`'s codec), `ipc` (UDS background
+thread), and `client` (`AssemblyClient` lifecycle + event shipping). The public
+API (`AssemblyClient`, `AssemblyConfig`, `SdkClientError`, `Preflight`) is a
+clean, `pyo3`/`napi`/`cgo`-free surface ready for thin shims to wrap. The actual
+migration of the existing shims onto this crate is tracked by AAASM-2561 (Python)
+/ AAASM-2560 (Node) / AAASM-2562 (remove fat bindings) — until those land the old
+copies coexist, by design.
+
+### AC2 — Preflight is advisory only; no path makes it authoritative and no trust marker is emitted
+
+**Met.**
+- `preflight.rs` is documented as non-authoritative and only ever *removes* data
+  (redacts); it never adds a `clean` / `already_scanned` / pre-scanned signal.
+- The `preflight` cargo feature (default on) gates the entire `aa-security`
+  dependency: `--no-default-features` drops it and events still ship, proving the
+  runtime — not the SDK — is the authority.
+- Test `advisory_preflight_redacts_and_emits_no_trust_marker`
+  (`tests/advisory_preflight_no_marker.rs`) asserts the shipped `AuditEvent`
+  carries exactly two labels (`event_type`, `details`) and none of
+  `clean` / `scanned` / `already_scanned` / `preflight` / `__aa_scanned__` /
+  `__aa_clean__`.
+- Test `preflight_disabled_passes_text_through_without_marker`
+  (`tests/preflight_disabled_passthrough.rs`) confirms that with preflight
+  disabled raw text passes through locally and still no marker is attached.
+
+### AC3 — The crate builds standalone and is ready for the thin Node/Python shims to depend on
+
+**Met (in-workspace).** `cargo build -p aa-sdk-client` and
+`cargo build -p aa-sdk-client --no-default-features` both succeed. The crate
+exposes a minimal, FFI-agnostic Rust API returning `Result<_, SdkClientError>`
+(no language-runtime coupling), which is exactly what the shims wrap. Making the
+crate consumable from an **external** checkout (git-SHA pin / publish) is the
+separate Story AAASM-2559.
+
+## Tests
+
+`cargo nextest run -p aa-sdk-client`
+
+- Default features: **26 passed, 0 skipped** (incl. 3 integration tests).
+- `--no-default-features`: **20 passed, 0 skipped** (preflight-gated tests excluded; the e2e lifecycle test still runs).
+
+Integration tests (`aa-sdk-client/tests/`):
+
+| File | Asserts |
+|---|---|
+| `advisory_preflight_no_marker.rs` | redaction happens locally; no trust marker on the wire; only expected labels present |
+| `preflight_disabled_passthrough.rs` | preflight optional; disabled ⇒ raw passes through locally, still no marker |
+| `lifecycle_e2e.rs` | full session vs a mock `UnixListener`: connect → heartbeat → report event → shutdown |
+
+## Quality gates
+
+- `cargo fmt --all -- --check` — clean
+- `cargo clippy -p aa-sdk-client --all-targets --all-features -- -D warnings` — clean
+- `cargo clippy -p aa-sdk-client --all-targets --no-default-features -- -D warnings` — clean
+- `cargo deny check` — advisories / bans / licenses / sources ok
+- `cargo doc --workspace --no-deps` — builds
+- `compat-matrix-check` — satisfied via the `docs/src/compatibility.md` row added in AAASM-2623
+
+## Follow-ups (out of scope here)
+
+- AAASM-2559 — make the shared crates pinnable/publishable for external SDK repos.
+- AAASM-2560 / AAASM-2561 — thin Node / Python shims on `aa-sdk-client`.
+- AAASM-2562 — remove the fat `aa-ffi-*` runtime-client copies from the workspace.


### PR DESCRIPTION
## Description

Final subtask of **Story AAASM-2570** (extract `aa-sdk-client`). Stacked on AAASM-2626; base is `master`. Proves the Story's acceptance criteria with integration tests and a verification report.

Integration tests (`aa-sdk-client/tests/`):
- `advisory_preflight_no_marker.rs` — the advisory preflight redacts credentials locally **and** the shipped `AuditEvent` carries no `clean`/`already_scanned`/pre-scanned marker (only the two expected labels). Proves preflight is non-authoritative.
- `preflight_disabled_passthrough.rs` — preflight is optional: disabled ⇒ raw text passes through locally (runtime stays authoritative), still no marker added.
- `lifecycle_e2e.rs` — `AssemblyClient` drives a full session against a mock `UnixListener` runtime: connect → heartbeat → report event → shutdown.

Plus `verification-reports/verification-report-AAASM-2570.md` mapping each Story AC and the follow-up shim migration (AAASM-2559/2560/2561/2562).

Commits:
- `✅ (aa-sdk-client): Add advisory-preflight no-trust-marker acceptance test`
- `✅ (aa-sdk-client): Add preflight-disabled passthrough acceptance test`
- `✅ (aa-sdk-client): Add end-to-end mock-runtime lifecycle test`
- `📝 (docs): Add AAASM-2570 verification report`

## Type of Change

- [x] ♻️ Refactoring (verification of)
- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2627 (subtask of AAASM-2570, Epic AAASM-2552)

## Testing

- [x] Integration tests added / updated
- [x] Manual testing performed

`cargo nextest run -p aa-sdk-client` → 26 passed (default, incl. 3 integration); `--no-default-features` → 20 passed (e2e runs, preflight-gated tests excluded). `cargo clippy -p aa-sdk-client --all-targets` (both feature modes), `cargo fmt --all --check`, `cargo deny check`, `cargo doc --workspace --no-deps` all green.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention