### PR TITLE
[AAASM-2630] ✅ (ci): Verify schemas/openapi trigger-path fix

### DIFF
--- a/verification-reports/AAASM-2628.md
+++ b/verification-reports/AAASM-2628.md
@@ -1,0 +1,43 @@
+# AAASM-2628 — Verification: ci.yml schemas/openapi trigger-path fix
+
+Verifies Story **AAASM-2628** (close the `ci.yml` trigger gap where schemas-only
+changes never started CI). Implementation in subtask **AAASM-2629** (PR #959);
+this subtask (**AAASM-2630**) checks it against the Story acceptance criteria.
+
+## Background
+
+The gap was found during the AAASM-2599 post-merge workflow audit: `ci.yml`'s
+top-level `on.push.paths` / `on.pull_request.paths` listed only `openapi/v1.yaml`
+and omitted `schemas/**`. Because GitHub evaluates the workflow-level `paths`
+*before* any job runs, a PR touching only `schemas/**` never started `ci.yml`,
+so `schema-lint` (ajv validation of `schemas/policy/v1/policy-document.schema.json`
+and the three example policies) never ran on it. The AAASM-2599 `changes` router
+already had `schema`/`openapi` outputs, but a job-level filter cannot help if the
+workflow is never triggered.
+
+## How verified
+
+| # | Method |
+|---|--------|
+| 1 | `yaml.safe_load(ci.yml)` — parses clean. |
+| 2 | Asserted both `on.push.paths` and `on.pull_request.paths` now contain `schemas/**` and `openapi/**`, and no longer the narrow `openapi/v1.yaml`. |
+| 3 | Asserted the two single-quoted `changes`-job filter refs to `'openapi/v1.yaml'` are unchanged (the fix touches only the trigger blocks). |
+| 4 | Path-match reasoning: `schemas/policy/v1/policy-document.schema.json` and `schemas/examples/*.yaml` match `schemas/**`; the workflow now triggers and the `changes` `schema` filter (`schemas/**`) sets `schema=true` → `schema-lint` runs. |
+
+## Acceptance criteria
+
+| AC | Result | Evidence |
+|----|--------|----------|
+| A schemas-only PR triggers `ci.yml` and runs `schema-lint` | ✅ Pass | `schemas/**` added to both trigger path lists; `schema` router output already gates `schema-lint`. |
+| An openapi-only PR triggers `ci.yml` and runs the OpenAPI jobs | ✅ Pass | `openapi/v1.yaml` broadened to `openapi/**` in both trigger lists; `openapi` output gates `openapi-drift`/`openapi-lint`. |
+| No change to which jobs run for existing code PRs | ✅ Pass | Additions only broaden the trigger surface; `openapi/v1.yaml ⊂ openapi/**`, so every previously-triggering change still triggers. No filter or `if:` gate changed. |
+| `ci.yml` remains YAML-valid | ✅ Pass | `yaml.safe_load` clean. |
+
+## Outcome
+
+- All ACs **pass**. The fix is purely additive to the trigger surface — it can
+  only cause CI to run on *more* changes, never fewer, so there is no regression
+  risk to existing routing.
+- Closes the audit finding recorded on AAASM-2599. No further gaps found in the
+  trigger-path layer: every `changes`-router area filter now has a matching (or
+  superset) entry in the workflow-level `paths`.


### PR DESCRIPTION
## Description

Verification subtask for Story **AAASM-2628** (subtask **AAASM-2630**). Adds `verification-reports/AAASM-2628.md` checking the trigger-path fix in **AAASM-2629** (PR #959).

All ACs pass: both trigger blocks now include `schemas/**` + `openapi/**`, the `changes`-job filters are untouched, and the change is purely additive to the trigger surface (`openapi/v1.yaml ⊂ openapi/**`) so there is no routing regression. Stacked on PR #959 — base `master`.

## Type of Change

- [x] ✅ Tests / verification
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2630 (verify) / AAASM-2628 (story) / AAASM-2629 (impl, PR #959)

## Testing

- [x] Manual testing performed — see the report's "How verified" table.
- [x] No tests required (explain why) — verification artifact (markdown); matches no workflow path filter, so no CI runs by design.

## Checklist

- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention
