### PR TITLE
[AAASM-2632] 🔧 (ci): Reduce integration-tests.yml to macOS-only

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,10 +3,16 @@ name: Integration tests
 permissions:
   contents: read
 
-# End-to-end integration test suite. Runs the `aa-integration-tests` crate
-# on Linux + macOS so the topology HTTP roundtrip (AAASM-1066) and the CLI
-# subcommand coverage (AAASM-1258, AAASM-1441 follow-up) are exercised on
-# both platforms before anything depending on them ships.
+# End-to-end integration test suite (macOS leg). Runs the `aa-integration-tests`
+# crate on macOS so the topology HTTP roundtrip (AAASM-1066) and the CLI
+# subcommand coverage (AAASM-1258, AAASM-1441 follow-up) are exercised on a
+# non-Linux platform before anything depending on them ships.
+#
+# AAASM-2631: the Linux leg was dropped — ci.yml's `test` job already runs the
+# whole workspace (incl. aa-integration-tests) on ubuntu-latest for every rust
+# PR, so running it serially here too was pure duplication. The tests bind
+# ephemeral ports (TcpListener::bind 127.0.0.1:0) and pass concurrently in
+# `test`, so the Linux coverage is fully retained there.
 #
 # Node.js SDK E2E fixtures (AAASM-1514 / F116 ST-B): TypeScript fixture scripts
 # are installed via pnpm and run in AA_SELFTEST=1 mode inside the Rust harness;
@@ -44,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [macos-latest]
 
     steps:
       - name: Checkout agent-assembly
@@ -68,12 +74,7 @@ jobs:
           repository: AI-agent-assembly/node-sdk
           path: node-sdk
 
-      - name: Install protobuf compiler (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
-
-      - name: Install protobuf compiler (macOS)
-        if: matrix.os == 'macos-latest'
+      - name: Install protobuf compiler
         run: brew install protobuf
 
       - uses: actions/setup-python@v6


### PR DESCRIPTION
## Description

Removes the redundant Linux execution of the `aa-integration-tests` suite (subtask **AAASM-2632**, found during the AAASM-2628 audit).

The crate was running **twice on Linux** per PR: once parallel in `ci.yml`'s `test` job (`--workspace` includes it) and once serially here on `ubuntu-latest`. The tests bind **ephemeral ports** (`TcpListener::bind("127.0.0.1:0")`) and already pass **concurrently** in `test`, so the serial Linux run was pure duplication — not a correctness safeguard.

**Change:** drop the `ubuntu-latest` matrix leg (and its now-dead Linux protoc step) from `integration-tests.yml`; macOS remains the workflow's unique coverage. **No change to `ci.yml`** — Linux integration coverage is fully retained by its `test` job, on the broader `rust` trigger surface.

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2632 (impl) / AAASM-2631 (story) / found during AAASM-2628 audit

## Testing

- [x] Manual testing performed — `yaml.safe_load` clean; asserted matrix is `[macos-latest]` and no `if: matrix.os == 'ubuntu-latest'` steps remain; confirmed `ci.yml`'s `test` still runs `--workspace` (no `--exclude aa-integration-tests`), so Linux coverage is retained.
- [x] No tests required (explain why) — CI-config-only change.

## Checklist

- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention
