### PR TITLE
[AAASM-2637] ✨ (ci): Add standalone-build smoke for shared SDK crates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 
 .PHONY: help dev-setup install-tools clone-sdks install-hooks build-workspace \
         build-baseline test dev-verify smoke-python smoke-node smoke-go \
-        gateway-health demo-record
+        standalone-smoke gateway-health demo-record
 
 ## dev-setup: Bootstrap the full local development environment (install tools, clone SDKs, install hooks, build)
 dev-setup: install-tools clone-sdks install-hooks build-workspace
@@ -109,6 +109,10 @@ build-workspace:
 ## build-baseline: Record a build-time baseline (cold/warm/test + cargo tree -d) into target/build-baseline/
 build-baseline:
 	@bash scripts/build-baseline.sh
+
+## standalone-smoke: Build the shared SDK crates as git-SHA-pinned external consumers (AAASM-2559)
+standalone-smoke:
+	@bash scripts/standalone-build-smoke.sh
 
 ## install-hooks: Install git pre-commit hooks via pre-commit
 install-hooks:

--- a/scripts/standalone-build-smoke.sh
+++ b/scripts/standalone-build-smoke.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Standalone-build smoke for the shared SDK crates.
+# AAASM-2559 (Epic AAASM-2552 — SDK security boundary + FFI consolidation).
+#
+# Usage: bash scripts/standalone-build-smoke.sh [crate ...]
+#
+# The thin per-language SDK shims (python-sdk, node-sdk) consume four crates
+# from OUTSIDE this monorepo via a git SHA pin — the distribution mechanism
+# chosen in ADR 0002 (docs/src/adr/0002-sdk-security-boundary.md). Inside the
+# workspace these crates resolve through `path` deps and workspace inheritance
+# (`version.workspace`, `[lints] workspace`, `dep = { workspace = true }`), none
+# of which an external consumer sees directly. This script proves each crate is
+# still buildable as a git-SHA-pinned dependency from a throwaway consumer that
+# lives outside the workspace, catching path-coupling regressions before an SDK
+# repo hits them.
+#
+# How it works, per crate:
+#   1. Clone the repo at the current HEAD into a temp dir (committed files only —
+#      a clean checkout, exactly what `cargo` fetches for a git dependency).
+#   2. Generate a tiny external consumer crate (its own workspace) in a second
+#      temp dir, depending on the crate via `{ git = "file://<clone>", rev = <sha> }`.
+#   3. `cargo build` the consumer and assert it succeeds.
+#
+# The four crates and why they ship outside the workspace:
+#   aa-core        wire types / traits consumed by the shims
+#   aa-proto       generated protobuf/gRPC wire types
+#   aa-security    advisory (non-authoritative) credential preflight
+#   aa-sdk-client  UDS transport + AssemblyClient lifecycle
+#
+# Environment overrides:
+#   CARGO                 cargo binary (default: cargo)
+#   STANDALONE_SMOKE_OUT  temp working dir (default: a fresh mktemp -d, removed on exit)
+#
+# Exits 0 only when every crate builds standalone; non-zero otherwise.
+# Requires: git, cargo, and protoc on PATH (aa-proto's build.rs invokes protoc).
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CARGO="${CARGO:-cargo}"
+
+# Default crate set = the four shared crates the SDK shims pin externally.
+# An explicit argument list overrides it (handy for debugging one crate).
+if [[ "$#" -gt 0 ]]; then
+    CRATES=("$@")
+else
+    CRATES=(aa-core aa-proto aa-security aa-sdk-client)
+fi
+
+if [[ -n "${STANDALONE_SMOKE_OUT:-}" ]]; then
+    WORKDIR="${STANDALONE_SMOKE_OUT}"
+    mkdir -p "${WORKDIR}"
+    KEEP_WORKDIR=1
+else
+    WORKDIR="$(mktemp -d)"
+    KEEP_WORKDIR=0
+fi
+# shellcheck disable=SC2329  # invoked indirectly via the EXIT trap below
+cleanup() { [[ "${KEEP_WORKDIR}" -eq 0 ]] && rm -rf "${WORKDIR}"; }
+trap cleanup EXIT
+
+# Share one target dir across the per-crate consumers so common dependencies
+# (aa-proto, aa-security, tokio, prost, ...) compile once instead of N times.
+export CARGO_TARGET_DIR="${WORKDIR}/target"
+
+command -v protoc >/dev/null 2>&1 || {
+    echo "::error::protoc not found on PATH — aa-proto's build.rs needs it" >&2
+    exit 1
+}
+
+SHA="$(git -C "${REPO_ROOT}" rev-parse HEAD)"
+
+# A clean clone of HEAD: cargo fetches a git dependency from committed objects
+# only, so building against this clone reproduces exactly what an external
+# consumer sees — uncommitted working-tree files never leak in.
+CLONE="${WORKDIR}/agent-assembly-clean"
+echo "AAASM-2559 standalone-build smoke"
+echo "  repo:  ${REPO_ROOT}"
+echo "  HEAD:  ${SHA}"
+echo "  crates: ${CRATES[*]}"
+echo ""
+echo "==> Cloning a clean checkout of HEAD ..."
+git clone --quiet --no-hardlinks "${REPO_ROOT}" "${CLONE}"
+# Pin HEAD onto a named branch so cargo's `rev =` resolution always finds it,
+# even when HEAD is a detached PR-merge commit on CI.
+git -C "${CLONE}" checkout --quiet -B standalone-smoke-pin "${SHA}"
+GIT_URL="file://${CLONE}"
+
+failures=()
+for crate in "${CRATES[@]}"; do
+    echo ""
+    echo "==> ${crate}: building as a git-SHA-pinned external consumer"
+    consumer="${WORKDIR}/consume-${crate}"
+    mkdir -p "${consumer}/src"
+    cat > "${consumer}/Cargo.toml" <<EOF
+[package]
+name = "consume-${crate}"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+# Detach from any ancestor workspace: this consumer stands in for an external
+# SDK repo and must resolve ${crate} purely through the git pin below.
+[workspace]
+
+[dependencies]
+${crate} = { git = "${GIT_URL}", rev = "${SHA}", package = "${crate}" }
+EOF
+    echo "// Pulling ${crate} in as a dependency is enough to force a full build of it." \
+        > "${consumer}/src/lib.rs"
+
+    if ( cd "${consumer}" && "${CARGO}" build --quiet ); then
+        echo "    ✓ ${crate} builds standalone (git pin, outside the workspace)"
+    else
+        echo "    ✗ ${crate} FAILED to build as a git-SHA-pinned dependency" >&2
+        failures+=("${crate}")
+    fi
+done
+
+echo ""
+if [[ "${#failures[@]}" -eq 0 ]]; then
+    echo "✓ all ${#CRATES[@]} shared crates build standalone at ${SHA}"
+    exit 0
+fi
+echo "::error::standalone build failed for: ${failures[*]}" >&2
+exit 1


### PR DESCRIPTION
## Description

First implementation subtask of Story **AAASM-2559** (make the shared crates pinnable for the external SDK repos; Epic AAASM-2552).

Adds `scripts/standalone-build-smoke.sh` (+ a `make standalone-smoke` target). For each of the four crates the thin SDK shims consume from outside the monorepo — `aa-core`, `aa-proto`, `aa-security`, `aa-sdk-client` — the script:

1. clones the repo at the current HEAD into a temp dir (committed files only — a clean checkout, exactly what `cargo` fetches for a git dependency);
2. generates a throwaway consumer crate (its own workspace, outside the agent-assembly workspace) depending on the crate via `{ git = "file://<clone>", rev = <sha>, package = <crate> }`;
3. `cargo build`s the consumer and asserts success.

This reproduces the **git-SHA pin** distribution mechanism chosen in ADR 0002 (`docs/src/adr/0002-sdk-security-boundary.md`) and catches path-coupling regressions — e.g. a shared crate gaining a dependency that resolves only inside the workspace checkout — before an SDK repo hits them.

CI wiring of this script and the `aa-sdk-client` pinnability declaration are the next subtask (**AAASM-2638**); end-to-end verification is **AAASM-2639**.

## Type of Change

- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2637 (subtask of AAASM-2559, Epic AAASM-2552)

## Testing

- [x] Manual testing performed

Ran locally against HEAD — all four crates build standalone as git-SHA-pinned external consumers:

```
==> aa-core:        ✓ builds standalone (git pin, outside the workspace)
==> aa-proto:       ✓ builds standalone (git pin, outside the workspace)
==> aa-security:    ✓ builds standalone (git pin, outside the workspace)
==> aa-sdk-client:  ✓ builds standalone (git pin, outside the workspace)
✓ all 4 shared crates build standalone at <sha>   (~25s)
```

- [x] No new Rust tests required (this is a CI/tooling shell script; it *is* the test).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy` — no Rust changed; `shellcheck` clean)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (script is self-documenting; consumer-facing docs land in AAASM-2638)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention