### PR TITLE
[AAASM-2634] ✅ (conformance): Encoded/nested payload bypass-resistance tests for the credential scanner

### DIFF
--- a/conformance/tests/credential_detection.rs
+++ b/conformance/tests/credential_detection.rs
@@ -141,3 +141,24 @@ fn unknown_key_secret_is_redacted() {
         "value under an unknown key must still be redacted"
     );
 }
+
+/// A GitHub PAT — detected via the `ghp_` literal pattern.
+const GH_PAT: &str = "ghp_0123456789abcdefABCDEF0123456789abcd";
+
+#[test]
+fn embedded_in_surrounding_text_is_redacted() {
+    let sc = scanner();
+    // Concatenated mid-string into a URL query, not a tidy "token" field.
+    let input = format!("https://api.example.com/v1/do?session=abc123&pat={GH_PAT}&retries=3");
+
+    let result = sc.scan(&input);
+    assert!(
+        !result.is_clean(),
+        "a secret embedded in surrounding text must be detected"
+    );
+    let redacted = result.redact(&input);
+    assert!(
+        !redacted.contains(GH_PAT),
+        "secret embedded mid-string must be redacted whole"
+    );
+}

--- a/conformance/tests/credential_detection.rs
+++ b/conformance/tests/credential_detection.rs
@@ -122,3 +122,22 @@ fn nested_json_secret_is_redacted() {
         "raw secret must not survive redaction even when deeply nested"
     );
 }
+
+#[test]
+fn unknown_key_secret_is_redacted() {
+    let sc = scanner();
+    // A field name no banned-key list would ever target. Content scanning still
+    // catches the value — position under an arbitrary key confers no immunity.
+    let input = serde_json::json!({
+        "totally_made_up_field_xyz": AWS_KEY
+    })
+    .to_string();
+
+    let result = sc.scan(&input);
+    assert!(!result.is_clean(), "a secret under an unknown key must be detected");
+    let redacted = result.redact(&input);
+    assert!(
+        !redacted.contains(AWS_KEY),
+        "value under an unknown key must still be redacted"
+    );
+}

--- a/conformance/tests/credential_detection.rs
+++ b/conformance/tests/credential_detection.rs
@@ -88,3 +88,37 @@ fn all_vectors_redact_correctly() {
         );
     }
 }
+
+// ── SDK-bypass resistance: encoded / nested payloads (AAASM-2634 / Story AAASM-2569 case 3) ──
+//
+// The gateway's banned-key sanitizer strips *known key names*; it never inspects
+// values hidden under unknown keys, deep nesting, or arbitrary surrounding text.
+// The `CredentialScanner` that `aa-runtime` runs authoritatively is content-based,
+// so position / nesting / key-name confers no immunity. These tests assert
+// **raw-secret-absence** after `redact()` — the secret substring never survives —
+// rather than finding-count or label equality, per the known scanner-overlap quirk
+// where a single secret can match several detectors.
+
+/// An AWS access-key id — detected via the `AKIA` literal pattern.
+const AWS_KEY: &str = "AKIAIOSFODNN7EXAMPLE";
+
+#[test]
+fn nested_json_secret_is_redacted() {
+    let sc = scanner();
+    // A secret buried four objects deep: a key-based strip never reaches it.
+    let input = serde_json::json!({
+        "a": { "b": { "c": { "credential": AWS_KEY } } }
+    })
+    .to_string();
+
+    let result = sc.scan(&input);
+    assert!(
+        !result.is_clean(),
+        "a secret nested deep in JSON must still be detected"
+    );
+    let redacted = result.redact(&input);
+    assert!(
+        !redacted.contains(AWS_KEY),
+        "raw secret must not survive redaction even when deeply nested"
+    );
+}

--- a/conformance/tests/credential_detection.rs
+++ b/conformance/tests/credential_detection.rs
@@ -162,3 +162,23 @@ fn embedded_in_surrounding_text_is_redacted() {
         "secret embedded mid-string must be redacted whole"
     );
 }
+
+#[test]
+fn multiple_nested_secrets_all_redacted() {
+    let sc = scanner();
+    // Two distinct secrets in an array of differently-shaped objects: every raw
+    // value must be gone, regardless of how many detectors each one trips.
+    let input = serde_json::json!({
+        "outer": [
+            { "k": AWS_KEY },
+            { "nested": { "deep": GH_PAT } }
+        ]
+    })
+    .to_string();
+
+    let result = sc.scan(&input);
+    assert!(!result.is_clean(), "multiple nested secrets must be detected");
+    let redacted = result.redact(&input);
+    assert!(!redacted.contains(AWS_KEY), "first nested secret must be redacted");
+    assert!(!redacted.contains(GH_PAT), "second nested secret must be redacted");
+}


### PR DESCRIPTION
## Description

Adds **primitive-level SDK-bypass-resistance tests** to `conformance/tests/credential_detection.rs`, proving the `CredentialScanner` that `aa-runtime` runs authoritatively catches secrets hidden by **nesting / unknown keys / surrounding text** — exactly the payloads a key-name-based "banned-key strip" would miss.

This is the conformance/primitive half of Story **AAASM-2569** case 3 (encoded / nested payload). The runtime-boundary cases (1–5) land in the sibling subtask **AAASM-2635**.

Four new tests, each asserting **raw-secret-absence** after `ScanResult::redact()` (the secret substring never survives) rather than finding-count or label equality — per the known scanner-overlap quirk where one secret trips several detectors:

- `nested_json_secret_is_redacted` — secret buried four objects deep.
- `unknown_key_secret_is_redacted` — secret under an arbitrary field name no banned-key list targets.
- `embedded_in_surrounding_text_is_redacted` — PAT concatenated mid-string into a URL query.
- `multiple_nested_secrets_all_redacted` — two distinct secrets across an array of objects; every raw value must be gone.

## Type of Change

- [x] ✅ Tests

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2634 (subtask of Story AAASM-2569, Epic AAASM-2552)

## Testing

- [x] Integration tests added / updated
- Local: `cargo nextest run -p conformance` → **46 passed, 0 skipped** (42 existing + 4 new).
- `cargo fmt --all --check` + `cargo clippy --all-targets --all-features -D warnings` clean (pre-commit hooks).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a — tests only)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
