### PR TITLE
[AAASM-2638] 🔧 (ci): Wire crate-pinnability smoke into CI + declare aa-sdk-client git-pinnable

### DIFF
--- a/.github/workflows/crate-pinnability-smoke.yml
+++ b/.github/workflows/crate-pinnability-smoke.yml
@@ -1,0 +1,63 @@
+name: Crate Pinnability Smoke
+
+# AAASM-2559 (Epic AAASM-2552 — SDK security boundary + FFI consolidation).
+#
+# Proves the four crates the thin SDK shims consume from OUTSIDE the monorepo —
+# aa-core, aa-proto, aa-security, aa-sdk-client — stay buildable as git-SHA-pinned
+# dependencies from a clean checkout outside the workspace. Guards against
+# path-coupling regressions before an external SDK repo hits them. The actual
+# build logic lives in scripts/standalone-build-smoke.sh; distribution mechanism
+# (git SHA pin) is recorded in docs/src/adr/0002-sdk-security-boundary.md.
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "aa-core/**"
+      - "aa-proto/**"
+      - "aa-security/**"
+      - "aa-sdk-client/**"
+      - "proto/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "scripts/standalone-build-smoke.sh"
+      - ".github/workflows/crate-pinnability-smoke.yml"
+  pull_request:
+    branches: [master]
+    paths:
+      - "aa-core/**"
+      - "aa-proto/**"
+      - "aa-security/**"
+      - "aa-sdk-client/**"
+      - "proto/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "scripts/standalone-build-smoke.sh"
+      - ".github/workflows/crate-pinnability-smoke.yml"
+
+# One in-flight run per ref is enough; newer pushes supersede older ones.
+concurrency:
+  group: crate-pinnability-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  # Match the rest of CI: incremental artifacts only bloat the cache here.
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  standalone-build-smoke:
+    name: Standalone build (git-SHA pin)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install protobuf compiler
+        run: sudo apt-get install -y protobuf-compiler
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Build shared crates as git-SHA-pinned external consumers
+        run: bash scripts/standalone-build-smoke.sh

--- a/aa-sdk-client/Cargo.toml
+++ b/aa-sdk-client/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "aa-sdk-client"
 version.workspace = true
-# AAASM-2559 will make the shared crates (aa-core/aa-proto/aa-security/aa-sdk-client)
-# pinnable/publishable for the external SDK repos. Held back until then.
+# Distributed to the external SDK shims as a git-SHA pin (ADR 0002 / AAASM-2559),
+# not via crates.io — so it stays `publish = false`. Git-pinnability is guarded
+# in CI by scripts/standalone-build-smoke.sh (Crate Pinnability Smoke workflow).
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -46,6 +46,10 @@
 - [Build-Time Baseline](benchmarks/build-time-baseline.md)
 - [Policy Check p99](benchmarks/policy-check-p99.md)
 
+# Development
+
+- [Consuming the Shared Crates](development/consuming-shared-crates.md)
+
 # Architecture Decision Records
 
 - [Index](adr/README.md)

--- a/docs/src/development/consuming-shared-crates.md
+++ b/docs/src/development/consuming-shared-crates.md
@@ -1,0 +1,58 @@
+# Consuming the Shared Crates
+
+The thin per-language SDK shims live in their own repositories
+(`python-sdk`, `node-sdk`) but reuse Rust crates that are developed in this
+monorepo. Four crates are consumed from **outside** the workspace:
+
+| Crate           | Role in the SDK shim                                            |
+| --------------- | -------------------------------------------------------------- |
+| `aa-core`       | wire types and traits                                          |
+| `aa-proto`      | generated protobuf / gRPC wire types                          |
+| `aa-security`   | advisory, non-authoritative credential preflight              |
+| `aa-sdk-client` | UDS transport, IPC codec, `AssemblyClient` lifecycle          |
+
+## Distribution mechanism: git SHA pin
+
+The chosen distribution mechanism is a **git SHA pin**, not a registry
+publish. The rationale (crates.io was rejected; a bare branch name does not
+resolve once a crate consumes the dependency, so a full SHA is required) is
+recorded in [ADR 0002 — SDK Security Boundary](../adr/0002-sdk-security-boundary.md).
+
+A consumer pins each crate to an exact commit:
+
+```toml
+[dependencies]
+aa-core       = { git = "https://github.com/AI-agent-assembly/agent-assembly.git", rev = "<full-40-char-sha>", package = "aa-core", features = ["serde"] }
+aa-proto      = { git = "https://github.com/AI-agent-assembly/agent-assembly.git", rev = "<full-40-char-sha>", package = "aa-proto" }
+aa-security   = { git = "https://github.com/AI-agent-assembly/agent-assembly.git", rev = "<full-40-char-sha>", package = "aa-security" }
+aa-sdk-client = { git = "https://github.com/AI-agent-assembly/agent-assembly.git", rev = "<full-40-char-sha>", package = "aa-sdk-client" }
+```
+
+Notes:
+
+- Use the **full 40-character SHA**, not a branch. `cargo`'s `rev` is a precise
+  revspec; a bare branch name fails to resolve once another crate in the graph
+  consumes the same dependency.
+- A git dependency checks out the whole repository, so workspace inheritance
+  (`version.workspace`, `[lints] workspace`, `dep = { workspace = true }`) and
+  the `proto/` sources at the workspace root resolve transparently — the
+  consumer does not need to reproduce any of it.
+- `aa-sdk-client` is `publish = false` on purpose: it is distributed only via
+  the git pin, never to crates.io.
+
+## Regression guard
+
+`scripts/standalone-build-smoke.sh` builds each of the four crates as a
+git-SHA-pinned consumer from a clean checkout of `HEAD`, outside the workspace.
+It runs in CI via the **Crate Pinnability Smoke** workflow on every pull request
+and master push that touches a shared crate, so a path-coupling regression —
+e.g. a shared crate gaining a dependency that resolves only inside the workspace
+checkout — fails CI here before an SDK repo hits it.
+
+Run it locally with:
+
+```bash
+make standalone-smoke
+# or
+bash scripts/standalone-build-smoke.sh
+```


### PR DESCRIPTION
## Description

Second implementation subtask of Story **AAASM-2559** (Epic AAASM-2552). Three granular changes:

1. **CI workflow** — `.github/workflows/crate-pinnability-smoke.yml` runs `scripts/standalone-build-smoke.sh` on pull_request + master push, path-scoped to the four shared crates, `proto/`, the script, and the workflow itself. It fails the PR if any of `aa-core`/`aa-proto`/`aa-security`/`aa-sdk-client` stops building as a git-SHA-pinned external consumer.
2. **`aa-sdk-client` pinnability** — replace the stale `publish = false` "held back until AAASM-2559" note with the actual mechanism: distributed via git-SHA pin (ADR 0002), not crates.io, so it intentionally stays `publish = false`; pinnability is now guarded by the smoke.
3. **Docs** — a new *Consuming the Shared Crates* guide (`docs/src/development/consuming-shared-crates.md`, registered in the mdBook nav) showing the concrete git-pin `[dependencies]` snippet and the regression guard.

> **Stacked on [#963](https://github.com/ai-agent-assembly/agent-assembly/pull/963)** (AAASM-2637, the smoke script). Base is `master`; the first two commits belong to #963 and drop out once it merges. Verification of all three ACs is the final subtask **AAASM-2639**.

## Type of Change

- [x] 🔧 Configuration / CI change
- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2638 (subtask of AAASM-2559, Epic AAASM-2552)

## Testing

- [x] Manual testing performed

`scripts/standalone-build-smoke.sh` passes locally (all four crates build standalone). `mdbook build` is clean. The new workflow path-trigger covers all four crate dirs + `proto/` + the script + the workflow.

- [x] No new Rust tests required (CI/tooling + docs only).

## Checklist

- [x] Code follows project style guidelines (no Rust logic changed; comment-only `Cargo.toml` edit)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention