### PR TITLE
[AAASM-2651] 📝 (agent-assembly): Refresh docs left stale by the aa-ffi-* removal

### DIFF
--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -4,7 +4,7 @@ This chapter describes how `agent-assembly` is composed and how its parts intera
 
 ## Crate dependency graph
 
-The Cargo workspace declares **14 member crates** in the top-level `Cargo.toml`. Two additional eBPF crates (`aa-ebpf-probes`, `aa-ebpf-programs`) live alongside but are intentionally outside the workspace because they compile for the `bpfel-unknown-none` BPF target — they are built by `aa-ebpf/build.rs` via `aya-build`. Edges in the diagram below are derived from `path` dependencies declared in each crate's `Cargo.toml`.
+The Cargo workspace declares **29 member crates** in the top-level `Cargo.toml`; the diagram below highlights the core architectural crates (storage drivers, dev-tool adapters, and test harnesses are omitted for clarity). Two additional eBPF crates (`aa-ebpf-probes`, `aa-ebpf-programs`) live alongside but are intentionally outside the workspace because they compile for the `bpfel-unknown-none` BPF target — they are built by `aa-ebpf/build.rs` via `aya-build`. Edges in the diagram below are derived from `path` dependencies declared in each crate's `Cargo.toml`.
 
 ```mermaid
 graph TD
@@ -29,8 +29,7 @@ graph TD
     aa_api[aa-api]:::control
     aa_cli[aa-cli]:::control
 
-    aa_ffi_python[aa-ffi-python]:::ffi
-    aa_ffi_node[aa-ffi-node]:::ffi
+    aa_sdk_client[aa-sdk-client]:::ffi
     aa_ffi_go[aa-ffi-go]:::ffi
     aa_wasm[aa-wasm]:::ffi
 
@@ -49,9 +48,7 @@ graph TD
     aa_proxy --> aa_proto
     aa_proxy --> aa_runtime
 
-    aa_ffi_python --> aa_core
-    aa_ffi_python --> aa_proto
-    aa_ffi_node --> aa_core
+    aa_sdk_client --> aa_proto
     aa_wasm --> aa_core
 
     aa_gateway --> aa_core
@@ -67,7 +64,7 @@ graph TD
     conformance --> aa_proto
 ```
 
-Dashed nodes are *out-of-workspace* — they cannot be selected with `cargo -p`. `aa-ffi-go` has no Cargo dependencies on other workspace crates: it talks to the gateway over gRPC at runtime, with bindings generated from the same `proto/` source as `aa-proto`.
+Dashed nodes are *out-of-workspace* — they cannot be selected with `cargo -p`. `aa-ffi-go` has no Cargo dependencies on other workspace crates: it talks to the gateway over gRPC at runtime, with bindings generated from the same `proto/` source as `aa-proto`. `aa-sdk-client` is the shared, FFI-agnostic SDK runtime-client (UDS transport, wire codec, lifecycle, and an optional `aa-security` advisory preflight) that the per-language FFI shims wrap; the Python and Node shims now live in the sibling `python-sdk` / `node-sdk` repos and consume it via a pinned git SHA (AAASM-2560/2561), so they are no longer workspace members.
 
 ## Three-layer interception model
 
@@ -75,7 +72,7 @@ Dashed nodes are *out-of-workspace* — they cannot be selected with `cargo -p`.
 
 | Layer | Crate(s) | Where it runs | Bypass risk | Tradeoff |
 |---|---|---|---|---|
-| **1 — In-process SDK** | `aa-ffi-python`, `aa-ffi-node`, `aa-ffi-go`, `aa-wasm` | Inside the agent process | Highest (agent could skip the SDK) | Fastest path; requires SDK adoption |
+| **1 — In-process SDK** | `aa-ffi-go`, `aa-wasm` (in-workspace) + the `aa-sdk-client`-based Python/Node shims in the sibling `python-sdk` / `node-sdk` repos | Inside the agent process | Highest (agent could skip the SDK) | Fastest path; requires SDK adoption |
 | **2 — Sidecar proxy** | `aa-proxy` | Adjacent process / sidecar container | Medium (network egress only) | Catches everything routed through the proxy without code changes |
 | **3 — eBPF** | `aa-ebpf`, `aa-ebpf-common`, `aa-ebpf-probes`, `aa-ebpf-programs` | Linux kernel | Lowest (catches bypass attempts) | Linux-only; requires elevated privileges |
 

--- a/docs/src/benchmarks/BASELINE.md
+++ b/docs/src/benchmarks/BASELINE.md
@@ -15,6 +15,11 @@ Target: < 2 ms P99 per LLM call (AAASM-34 AC #6).
 
 **Verdict: PASS** — 3 orders of magnitude below the 2 ms target.
 
+> **Note (AAASM-2562):** the `aa-ffi-python` SDK-hook benchmark (`sdk_bench`) moved
+> to the `python-sdk` repo when the fat binding left this workspace — run it there
+> with `cargo bench --bench sdk_bench`. The numbers above are retained as the
+> historical 2026-04-29 baseline.
+
 ## Proxy Intercept Latency (`aa-proxy`)
 
 Target: < 5 ms P99 per intercepted request (AAASM-36 AC #5).


### PR DESCRIPTION
## Description

Follow-up to Story **AAASM-2562** (removed the fat `aa-ffi-python` / `aa-ffi-node` members — PRs #973/#974). A post-merge audit of `master` found two in-workspace docs still presenting the removed crates as live workspace members. They didn't break the mdBook build (so they passed CI), but they were factually stale. This PR corrects them.

### Changes
- **`docs/src/architecture.md`**
  - Crate-dependency mermaid graph: removed the `aa-ffi-python` / `aa-ffi-node` nodes + edges; added the `aa-sdk-client` node (`→ aa-proto`), the consolidation target the shims now wrap.
  - Corrected the prose member count **14 → 29** and clarified the diagram is a curated core view.
  - "Three-layer interception model" Layer-1 row now reads `aa-ffi-go`, `aa-wasm` (in-workspace) + the `aa-sdk-client`-based Python/Node shims in the sibling `python-sdk` / `node-sdk` repos.
- **`docs/src/benchmarks/BASELINE.md`**
  - Added a note that the `aa-ffi-python` SDK-hook bench (`sdk_bench`) moved to the `python-sdk` repo; kept the dated 2026-04-29 numbers as the historical baseline.

### Left untouched on purpose
- `docs/src/adr/0002-sdk-security-boundary.md` — immutable historical decision record.
- `docs/src/compatibility.md` matrix columns — name the SDK *products*, still valid.
- Source comments in `proto/secrets.proto` / `aa-sdk-client/src/lib.rs` — accurately describe the shims (which exist in sibling repos).

## Type of Change
- [x] 📝 Documentation update

## Breaking Changes
- [x] No

## Related Issues
- Related Jira ticket: AAASM-2651 (Epic AAASM-2552)

## Testing
- [x] No tests required (docs only)

`mdbook build` passes locally (mermaid valid, no dangling node refs); the `Build mdBook` CI job validates.

## Checklist
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing (pending CI)
- [x] Commits are small and follow the Gitmoji convention
