### PR TITLE
[AAASM-2620] 🐛 (aa-runtime): Make non_matching_action_stays_in_batch deterministic

### DIFF
--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -975,7 +975,7 @@ mod tests {
         token.cancel();
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn non_matching_action_stays_in_batch() {
         use crate::policy::{PolicyRule, PolicyRules};
         use aa_proto::assembly::common::v1::ActionType;
@@ -1009,9 +1009,10 @@ mod tests {
             Arc::new(AtomicU64::new(0)),
         ));
 
-        // Yield briefly so the pipeline's interval fires its immediate first tick
-        // (tokio::time::interval ticks once immediately on creation).
-        tokio::time::sleep(Duration::from_millis(10)).await;
+        // `tokio::time::interval` fires an immediate first tick on creation. With the
+        // clock paused, let the run loop start and absorb that empty flush before we
+        // send the event, so the first tick cannot race ahead and flush our event.
+        tokio::task::yield_now().await;
 
         // Build a TOOL_CALL event — not blocked by the policy
         let event = AuditEvent {
@@ -1020,11 +1021,17 @@ mod tests {
         };
         tx.send((0, IpcFrame::EventReport(event))).await.unwrap();
 
-        // Should NOT arrive before the flush interval (100ms timeout)
-        let result = tokio::time::timeout(Duration::from_millis(100), broadcast_rx.recv()).await;
+        // Wait until the run loop has enqueued the event into the batch.
+        while metrics.processed() == 0 {
+            tokio::task::yield_now().await;
+        }
+
+        // Advancing virtual time by less than the flush interval must NOT flush the
+        // batch — the non-matching event has to stay batched.
+        tokio::time::advance(Duration::from_millis(100)).await;
         assert!(
-            result.is_err(),
-            "non-matching event should stay in batch, not arrive immediately"
+            broadcast_rx.try_recv().is_err(),
+            "non-matching event should stay in batch, not arrive before flush interval"
         );
 
         token.cancel();


### PR DESCRIPTION
## Description

`aa-runtime pipeline::tests::non_matching_action_stays_in_batch` was flaky under the `Coverage` (llvm-cov) job. The test is a negative-within-timeout assertion: it sent a non-matching event and asserted nothing arrived within 100 ms. It relied on a wall-clock `sleep(10ms)` to absorb the immediate first tick that `tokio::time::interval` fires on creation. Under llvm-cov's slower execution the first tick could slip past the 10 ms sleep and flush the batched event inside the 100 ms window → false failure.

This makes the test deterministic by removing all wall-clock dependence:

- Runs the test under a paused clock (`#[tokio::test(start_paused = true)]`).
- Yields once so the run loop starts and absorbs the interval's immediate first (empty) tick **before** the event is sent — the tick can no longer race ahead and flush the event.
- Waits (via `metrics.processed()`) until the event is actually enqueued into the batch.
- Advances virtual time by 100 ms (well under the 10 s flush interval) and asserts the batch did not flush.

No production code changed — test-only.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2620
- Related GitHub issues: surfaced during #927 (AAASM-2568)

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [x] Manual testing performed

Verification:

- `cargo nextest run -p aa-runtime pipeline::tests::non_matching_action_stays_in_batch` — ran 5× consecutively, all PASS.
- `cargo nextest run -p aa-runtime pipeline::tests` — 26 passed.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p aa-runtime --all-targets --all-features -- -D warnings` — clean.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a — test-only)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
