### PR TITLE
[AAASM-2653] 📝 (docs): Expand mdBook docs coverage and fix navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,10 @@ mdbook serve docs --open
 | [Introduction](docs/src/README.md) | Book overview and audience |
 | [Architecture Overview](docs/src/architecture.md) | Crate dependency graph, three-layer interception, IPC, sidecar lifecycle, policy evaluation |
 | [API Reference](docs/src/api-reference.md) | rustdoc generation flow and per-crate API surface map |
+| [Command-Line Interface](docs/src/cli.md) | `aasm` global flags, command groups, and examples |
+| [Dashboard](docs/src/dashboard.md) | Web console and terminal (TUI) governance dashboards |
+| [Local Development](docs/src/development/local-development.md) | From-clone setup, everyday build/test loop, git hooks |
+| [Releases](docs/src/releases.md) | Release state, distribution channels, and process |
 | [Compatibility Matrix](docs/src/compatibility.md) | Which `aa-runtime` versions work with which SDK versions |
 | [Versioning Policy](docs/src/versioning.md) | Protocol semver rules, breaking-change classification, deprecation lifecycle |
 | [Protocol Changelog](docs/src/protocol/CHANGELOG.md) | Wire-protocol change log |

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -54,6 +54,7 @@
 
 # Development
 
+- [Local Development](development/local-development.md)
 - [Consuming the Shared Crates](development/consuming-shared-crates.md)
 
 # Architecture Decision Records

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -22,6 +22,7 @@
 # Governance
 
 - [L0–L3 Capability Matrix](governance/capability-matrix.md)
+- [Policy RBAC Role Matrix](policy-rbac.md)
 
 # Protocol
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -17,6 +17,7 @@
 # Usage
 
 - [Command-Line Interface](cli.md)
+- [Dashboard](dashboard.md)
 
 # Governance
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -14,6 +14,10 @@
 - [Overview](architecture.md)
 - [API Reference](api-reference.md)
 
+# Usage
+
+- [Command-Line Interface](cli.md)
+
 # Governance
 
 - [L0–L3 Capability Matrix](governance/capability-matrix.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -45,6 +45,10 @@
 - [Org-Tier Isolation](operations/org-isolation.md)
 - [Multi-Document Policy Cascade](operations/policy-cascade-loader.md)
 
+# Releases
+
+- [Releases](releases.md)
+
 # Benchmarks
 
 - [Baseline](benchmarks/BASELINE.md)

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -1,0 +1,73 @@
+# Command-Line Interface (`aasm`)
+
+`aasm` is the operator front-end for an Agent Assembly deployment. It ships from
+the [`aa-cli`](https://github.com/AI-agent-assembly/agent-assembly/tree/master/aa-cli)
+crate and talks to the gateway over its HTTP API.
+
+## Install
+
+See the [README install section](https://github.com/AI-agent-assembly/agent-assembly#install-the-cli)
+for the install script and Homebrew tap. For a local build:
+
+```bash
+cargo build -p aa-cli
+./target/debug/aasm --help
+```
+
+## Global flags
+
+These flags are available on every subcommand:
+
+| Flag | Description |
+|---|---|
+| `--context <name>` | Named context (connection profile) from `~/.aa/config.yaml`. |
+| `--api-url <url>` | Override the gateway API URL (takes precedence over the context). |
+| `--api-key <key>` | Override the API key (takes precedence over the context). |
+| `--output <fmt>` | Output format for `list`/`get` commands — `table` (default), `json`, … |
+
+## Command groups
+
+| Command | Purpose |
+|---|---|
+| `aasm status` | Fleet health, agents, approvals, and budget at a glance. |
+| `aasm topology` | Visualize agent topology, trees, lineage, and statistics. |
+| `aasm agent` | Manage monitored agent processes. |
+| `aasm policy` | Manage governance policies. |
+| `aasm alerts` | Manage governance alerts. |
+| `aasm approvals` | Manage human-in-the-loop approval requests. |
+| `aasm audit` | Query audit-log entries and export compliance reports. |
+| `aasm logs` | Query and stream audit-log events. |
+| `aasm trace` | Visualize a session trace (tree or timeline). |
+| `aasm cost` | Query cost summary and forecast spending. |
+| `aasm dashboard` | Open the interactive TUI dashboard (see [Dashboard](dashboard.md)). |
+| `aasm gateway` | Manage the `aa-gateway` governance daemon. |
+| `aasm proxy` | Manage the `aa-proxy` sidecar — lifecycle, CA trust, log tailing. |
+| `aasm start` / `aasm stop` | Start / stop the locally-managed gateway process. |
+| `aasm sandbox` | Run a WebAssembly tool inside the sandbox (fs / CPU / memory / wall-clock isolation). |
+| `aasm config` | Validate an `agent-assembly.toml` runtime configuration file. |
+| `aasm context` | Manage named API contexts (connection profiles). |
+| `aasm completion` | Generate shell-completion scripts. |
+| `aasm version` | Show CLI and gateway version information. |
+
+> The `aasm run` and `aasm tools` dev-tool subcommands (launch and manage AI
+> dev tools such as Claude Code, Codex, Copilot, and Windsurf with governance
+> wiring) are present in the full build but stripped from the published crate.
+> See [Dev-tool governance limits](https://github.com/AI-agent-assembly/agent-assembly/blob/master/docs/devtools/governance-limits.md).
+
+## Examples
+
+```bash
+# Inspect the agent topology as JSON
+aasm --output json topology overview
+
+# Validate a runtime config file before boot
+aasm config validate ./agent-assembly.toml
+
+# Run the gateway against a bundled reference policy
+cargo run -p aa-gateway -- --policy policy-examples/low-risk.yaml
+
+# Open the live TUI dashboard against a named context
+aasm --context staging dashboard
+```
+
+Every command supports `--help` for the full flag set, e.g. `aasm policy --help`.

--- a/docs/src/dashboard.md
+++ b/docs/src/dashboard.md
@@ -1,0 +1,43 @@
+# Dashboard
+
+Agent Assembly ships two governance consoles. Both are read/observe surfaces over
+the gateway — policy decisions are always made server-side.
+
+| Console | Lives in | Talks to | Use when |
+|---|---|---|---|
+| **Web dashboard** | [`dashboard/`](https://github.com/AI-agent-assembly/agent-assembly/tree/master/dashboard) | `aa-api` (HTTP, port 8080) | You want a browser UI for fleet health, policies, and audit. |
+| **Terminal dashboard (TUI)** | `aasm dashboard` ([`aa-cli`](https://github.com/AI-agent-assembly/agent-assembly/tree/master/aa-cli)) | Gateway API | You want real-time monitoring from the terminal / over SSH. |
+
+## Web dashboard
+
+The community web UI is built with **Vite + React 19 + TypeScript**. It proxies
+`/api/*` to `aa-api` on port 8080.
+
+```bash
+cd dashboard
+pnpm install
+
+# Dev server at http://localhost:3000, proxying /api/* to http://localhost:8080
+pnpm dev
+
+pnpm type-check   # type-check without emitting
+pnpm lint         # lint
+pnpm test         # unit tests (Vitest)
+pnpm build        # production build → dist/
+```
+
+Requirements: Node.js ≥ 20 and pnpm ≥ 10. Start a gateway + `aa-api` first so
+the `/api/*` proxy has a backend (see [CLI](cli.md) and the README quickstart).
+
+## Terminal dashboard (TUI)
+
+```bash
+# Interactive TUI against the default context
+aasm dashboard
+
+# Against a named connection profile
+aasm --context staging dashboard
+```
+
+The TUI renders fleet health, agents, approvals, and budget, refreshing in real
+time. For a one-shot non-interactive snapshot use [`aasm status`](cli.md).

--- a/docs/src/development/local-development.md
+++ b/docs/src/development/local-development.md
@@ -1,0 +1,62 @@
+# Local Development
+
+This page covers the from-clone development loop for the `agent-assembly`
+monorepo. For contribution conventions (commit style, PR process) see
+[`CONTRIBUTING.md`](https://github.com/AI-agent-assembly/agent-assembly/blob/master/CONTRIBUTING.md).
+
+## Prerequisites
+
+- Rust stable (≥ 1.75) via [rustup](https://rustup.rs/)
+- `protoc` — Protocol Buffers compiler (`brew install protobuf` /
+  `apt-get install protobuf-compiler`); required by the `aa-proto` and
+  `aa-gateway` build scripts
+- [`cargo-nextest`](https://nexte.st/), [`cargo-deny`](https://embarkstudios.github.io/cargo-deny/),
+  and [Lefthook](https://github.com/evilmartians/lefthook)
+- **Linux only** for the proxy / eBPF layers — see
+  [Supported platforms](https://github.com/AI-agent-assembly/agent-assembly#supported-platforms).
+
+## Bootstrap
+
+```bash
+git clone https://github.com/AI-agent-assembly/agent-assembly.git
+cd agent-assembly
+
+# Installs toolchains, clones the SDK polyrepos as siblings, installs git
+# hooks, and builds the workspace.
+make dev-setup
+
+# Smoke-tests each SDK repo in parallel, then checks gateway health.
+make dev-verify
+```
+
+## Everyday loop
+
+```bash
+cargo build --workspace --exclude aa-ebpf   # build (skip the BPF-target crate off Linux)
+cargo nextest run --workspace               # full test suite
+cargo nextest run -p aa-core                # one crate
+cargo fmt --all                             # format
+cargo clippy --all-targets -- -D warnings   # lint
+cargo deny check                            # dependency / license audit
+```
+
+The eBPF crates compile with a target-specific toolchain; on non-Linux hosts
+`cargo check -p aa-ebpf` is sufficient.
+
+## Git hooks
+
+Hooks are managed by [Lefthook](https://github.com/evilmartians/lefthook)
+(`lefthook.toml`). Install them once with `lefthook install`. The **pre-commit**
+hook runs `fmt`, `clippy`, and `deny` scoped by file glob; the **pre-push** hook
+runs `cargo doc --workspace --no-deps`.
+
+## Running locally
+
+Point the gateway at a bundled reference policy and connect a sidecar:
+
+```bash
+cargo run -p aa-gateway -- --policy policy-examples/low-risk.yaml
+```
+
+See the [CLI](../cli.md) page for `aasm` operator commands and the README
+"Running with Docker Compose" section for the sidecar stack.

--- a/docs/src/releases.md
+++ b/docs/src/releases.md
@@ -1,0 +1,32 @@
+# Releases
+
+`agent-assembly` is in the **`v0.0.1` alpha pre-release series**. The public API
+and wire protocol are not yet stable.
+
+## Where releases live
+
+- **GitHub Releases:** <https://github.com/AI-agent-assembly/agent-assembly/releases>
+  — the source of truth for published tags and changelogs. The latest tag is a
+  pre-release (`v0.0.1-alpha.5`, 2026-06-03).
+- **Per-tag notes:** the source-controlled release notes live under
+  `docs/release/` (one file per tag, e.g. `docs/release/v0.0.1-alpha.5.md`).
+- **Top-level changelog:** [`CHANGELOG.md`](https://github.com/AI-agent-assembly/agent-assembly/blob/master/CHANGELOG.md).
+
+## Distribution channels
+
+A single coordinated tag push fans out to every channel:
+
+| Channel | Artifact |
+|---|---|
+| GitHub Releases | `aasm-*.tar.gz` binaries + `SHA256SUMS` |
+| crates.io | Workspace crates at the tag version |
+| Homebrew tap | `aasm` formula ([`homebrew-agent-assembly`](https://github.com/AI-agent-assembly/homebrew-agent-assembly)) |
+| PyPI / npm | SDK packages |
+| GHCR | Container image |
+
+## Release process
+
+The mechanics (version bump, tag, changelog, multi-channel publish) are driven
+by the automated release workflow. Operators follow the pre-tag checklist in the
+release runbook at `docs/release/RUNBOOK.md`. See also the
+[Versioning Policy](versioning.md) and [Compatibility Matrix](compatibility.md).


### PR DESCRIPTION
## Description

Closes the mdBook documentation-coverage gaps for the `agent-assembly` core runtime and fixes navigation so every in-`src` page is reachable from `SUMMARY.md` (Story AAASM-2074, Epic AAASM-2072). Documentation-only change.

> **Stacked on #979** (AAASM-2652, README). Per repo convention this PR targets `master`; until #979 merges its 8 README commits also appear here. After #979 merges this branch will be rebased onto `master`, leaving only the 6 docs commits below.

This sub-task's commits:
- **CLI usage page** (`docs/src/cli.md`) — `aasm` global flags, command groups (sourced from the real `Commands` enum), and examples; new **Usage** section in `SUMMARY.md`.
- **Dashboard page** (`docs/src/dashboard.md`) — web console (Vite/React/`aa-api`) and terminal TUI (`aasm dashboard`).
- **Local Development page** (`docs/src/development/local-development.md`) — from-clone setup (`make dev-setup`/`dev-verify`), everyday loop, git hooks.
- **Releases page** (`docs/src/releases.md`) — release state, distribution channels, process; new **Releases** section.
- **Orphan fix** — wired the previously-unreachable `policy-rbac.md` into `SUMMARY.md` under Governance.
- **README** — listed the four new pages in the Documentation chapter table.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2653 (sub-task of AAASM-2074, Epic AAASM-2072)
- Related GitHub issues: N/A

## Testing

- [x] Manual testing performed
- [x] No tests required (explain why)

`mdbook build docs` succeeds after every commit (mdBook 0.5.2 + mermaid 0.17.0, matching CI). Zero in-`src` orphan pages remain. Relative-link scan over `docs/src` + `README` (82 links) is clean for all new/edited pages; one pre-existing broken link in `migration/template.md` (`../../conformance/vectors/`) is untouched here and noted for the verification sub-task **AAASM-2654**.

## Checklist

- [x] Code follows project style guidelines — N/A, Markdown only
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
