### PR TITLE
[AAASM-2618] ✅ (aa-runtime): Add runtime-side scan-stage p99 latency assertion

### DIFF
--- a/aa-runtime/tests/scan_latency_test.rs
+++ b/aa-runtime/tests/scan_latency_test.rs
@@ -12,9 +12,12 @@
 //! shared CI runners, and `AA_BENCH_ITERS` overrides the per-fixture iteration
 //! count for fuller local validation.
 
-use std::time::Duration;
+use std::hint::black_box;
+use std::time::{Duration, Instant};
 
-use aa_runtime::pipeline::enforcement::DEFAULT_MAX_FIELD_BYTES;
+use aa_proto::assembly::audit::v1::{audit_event::Detail, AuditEvent, ToolCallDetail};
+use aa_runtime::pipeline::enforcement::{RuntimeScanner, DEFAULT_MAX_FIELD_BYTES};
+use aa_runtime::pipeline::{EnrichedEvent, EventSource};
 
 /// The latency at the given percentile (`pct` in `0.0..=100.0`) of an
 /// already-sorted slice. Mirrors the gateway `policy_latency_test` helper so the
@@ -91,4 +94,109 @@ fn fixtures_cover_representative_sizes() {
         near_cap.len() < DEFAULT_MAX_FIELD_BYTES,
         "near_cap fixture must stay under the {DEFAULT_MAX_FIELD_BYTES}-byte cap"
     );
+}
+
+/// Runtime-specific p99 budget for one `RuntimeScanner::enforce()` call over the
+/// representative fixtures. The scan is a pure in-process aho-corasick pass plus
+/// redaction — a small fraction of the gateway's policy-latency budget.
+///
+/// The budget is profile-aware because `cargo test` defaults to a debug build,
+/// where the scanner runs ~100x slower than the optimized binary the runtime
+/// actually ships:
+///
+/// * **release** — `5ms`, the representative budget. Measured p99 is ~0.4ms, so
+///   this leaves ~12x headroom for shared-runner scheduling jitter.
+/// * **debug** — `50ms`, a loose ceiling that still trips on a catastrophic
+///   regression (e.g. an accidental per-event scanner rebuild or an O(n^2)
+///   scan) without flaking under parallel test execution.
+///
+/// An explicit `AA_BENCH_SLA_P99_MS` always wins — set it to `5` on bare-metal /
+/// nightly runs for a tight check regardless of profile.
+fn sla_p99() -> Duration {
+    if let Some(ms) = std::env::var("AA_BENCH_SLA_P99_MS").ok().and_then(|v| v.parse().ok()) {
+        return Duration::from_millis(ms);
+    }
+    let default_ms = if cfg!(debug_assertions) { 50 } else { 5 };
+    Duration::from_millis(default_ms)
+}
+
+/// Per-fixture iteration count. Defaults small enough for CI; override with
+/// `AA_BENCH_ITERS` for fuller local / nightly validation.
+fn iterations() -> usize {
+    std::env::var("AA_BENCH_ITERS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(2_000)
+}
+
+/// Wrap `args_json` in a fresh ToolCall [`EnrichedEvent`] with throwaway metadata.
+fn tool_call_event(args_json: Vec<u8>) -> EnrichedEvent {
+    EnrichedEvent {
+        inner: AuditEvent {
+            detail: Some(Detail::ToolCall(ToolCallDetail {
+                args_json,
+                ..Default::default()
+            })),
+            ..Default::default()
+        },
+        received_at_ms: 0,
+        source: EventSource::Sdk,
+        agent_id: "bench-agent".to_string(),
+        connection_id: 0,
+        sequence_number: 0,
+    }
+}
+
+#[test]
+fn enforce_scan_p99_within_budget() {
+    let scanner = RuntimeScanner::new();
+    let iters = iterations();
+    let mut latencies: Vec<Duration> = Vec::with_capacity(iters * FIXTURE_SIZES.len());
+
+    for (_, size) in FIXTURE_SIZES {
+        let payload = args_json_payload(*size);
+
+        // Warm up so first-touch page faults / cache misses don't skew the tail.
+        for _ in 0..64 {
+            let mut event = tool_call_event(payload.clone());
+            black_box(scanner.enforce(&mut event));
+        }
+
+        for _ in 0..iters {
+            // Rebuild from the original (still-secret-bearing) payload each call
+            // so every measured scan does the full find + redact work. Event
+            // construction is deliberately outside the timed region.
+            let mut event = tool_call_event(payload.clone());
+            let started = Instant::now();
+            let outcome = scanner.enforce(&mut event);
+            latencies.push(started.elapsed());
+            // The seeded credential must be found, proving the redaction path
+            // (not a no-op clean scan) is what we are measuring.
+            assert!(!outcome.is_clean(), "seeded credential must be redacted");
+        }
+    }
+
+    latencies.sort();
+    let total = latencies.len();
+    let p50 = percentile(&latencies, 50.0);
+    let p95 = percentile(&latencies, 95.0);
+    let p99 = percentile(&latencies, 99.0);
+    let p999 = percentile(&latencies, 99.9);
+    let max = latencies[total - 1];
+
+    eprintln!();
+    eprintln!("=== RuntimeScanner::enforce() Scan-Latency Test ===");
+    eprintln!("  Fixtures:    {FIXTURE_SIZES:?}");
+    eprintln!("  Iters/size:  {iters}");
+    eprintln!("  Total scans: {total}");
+    eprintln!();
+    eprintln!("  p50:  {p50:>10.3?}");
+    eprintln!("  p95:  {p95:>10.3?}");
+    eprintln!("  p99:  {p99:>10.3?}");
+    eprintln!("  p999: {p999:>10.3?}");
+    eprintln!("  max:  {max:>10.3?}");
+    eprintln!();
+
+    let sla = sla_p99();
+    assert!(p99 < sla, "scan p99 latency {p99:?} exceeds budget (target: {sla:?})");
 }

--- a/aa-runtime/tests/scan_latency_test.rs
+++ b/aa-runtime/tests/scan_latency_test.rs
@@ -1,0 +1,36 @@
+//! Runtime-side scan-stage latency test (AAASM-2618).
+//!
+//! Hardens AAASM-2568 AC4 ("scan-latency metrics emitted; p99 within budget,
+//! or budget documented"). The enforcement stage already emits the
+//! `aa_runtime_scan_latency_seconds` histogram; this test adds the missing
+//! runtime-side assertion that [`RuntimeScanner::enforce`] p99 stays within an
+//! agreed scan budget across representative `tool_call.args_json` sizes,
+//! including a fixture near the 64 KiB field cap.
+//!
+//! Reuses the `AA_BENCH_*` env-var convention from the gateway's
+//! `policy_latency_test`: `AA_BENCH_SLA_P99_MS` overrides the budget on noisy /
+//! shared CI runners, and `AA_BENCH_ITERS` overrides the per-fixture iteration
+//! count for fuller local validation.
+
+use std::time::Duration;
+
+/// The latency at the given percentile (`pct` in `0.0..=100.0`) of an
+/// already-sorted slice. Mirrors the gateway `policy_latency_test` helper so the
+/// two latency suites report percentiles identically.
+fn percentile(sorted: &[Duration], pct: f64) -> Duration {
+    let idx = ((sorted.len() as f64) * pct / 100.0).ceil() as usize;
+    sorted[idx.min(sorted.len() - 1)]
+}
+
+#[test]
+fn percentile_picks_expected_rank() {
+    // 1ms, 2ms, ..., 100ms already sorted (sorted[i] == (i + 1) ms).
+    let sorted: Vec<Duration> = (1..=100).map(Duration::from_millis).collect();
+
+    // ceil(100 * 50/100) == 50 -> sorted[50] == 51ms.
+    assert_eq!(percentile(&sorted, 50.0), Duration::from_millis(51));
+    // ceil(100 * 99/100) == 99 -> sorted[99] == 100ms.
+    assert_eq!(percentile(&sorted, 99.0), Duration::from_millis(100));
+    // The top percentile clamps to the final (max) element, never out of bounds.
+    assert_eq!(percentile(&sorted, 100.0), Duration::from_millis(100));
+}

--- a/aa-runtime/tests/scan_latency_test.rs
+++ b/aa-runtime/tests/scan_latency_test.rs
@@ -14,6 +14,8 @@
 
 use std::time::Duration;
 
+use aa_runtime::pipeline::enforcement::DEFAULT_MAX_FIELD_BYTES;
+
 /// The latency at the given percentile (`pct` in `0.0..=100.0`) of an
 /// already-sorted slice. Mirrors the gateway `policy_latency_test` helper so the
 /// two latency suites report percentiles identically.
@@ -33,4 +35,60 @@ fn percentile_picks_expected_rank() {
     assert_eq!(percentile(&sorted, 99.0), Duration::from_millis(100));
     // The top percentile clamps to the final (max) element, never out of bounds.
     assert_eq!(percentile(&sorted, 100.0), Duration::from_millis(100));
+}
+
+/// An AWS access-key id the credential scanner detects via the `AKIA` literal —
+/// embedded in every fixture so the redaction path (not just the clean path) is
+/// exercised by the latency measurement.
+const AWS_KEY: &str = "AKIAIOSFODNN7EXAMPLE";
+
+/// The representative `tool_call.args_json` sizes the latency test sweeps.
+///
+/// `near_cap` deliberately sits just under [`DEFAULT_MAX_FIELD_BYTES`] (64 KiB)
+/// so the field is scanned in full rather than redacted-whole as oversized —
+/// this is the worst-case scan cost the budget must cover.
+const FIXTURE_SIZES: &[(&str, usize)] = &[("small", 256), ("medium", 4 * 1024), ("near_cap", 60 * 1024)];
+
+/// Build a realistic `tool_call.args_json` byte payload of roughly
+/// `target_bytes`: a JSON envelope padded with benign filler text and seeded
+/// with a single [`AWS_KEY`] so the scanner finds and redacts one credential.
+fn args_json_payload(target_bytes: usize) -> Vec<u8> {
+    // ~64-byte benign block resembling tool arguments.
+    const FILLER: &str = "lorem ipsum dolor sit amet consectetur adipiscing elit sed do; ";
+    let prefix = format!(r#"{{"api_key":"{AWS_KEY}","note":""#);
+    let suffix = r#""}"#;
+
+    let mut payload = String::with_capacity(target_bytes + FILLER.len());
+    payload.push_str(&prefix);
+    while payload.len() + suffix.len() < target_bytes {
+        payload.push_str(FILLER);
+    }
+    payload.push_str(suffix);
+    payload.into_bytes()
+}
+
+#[test]
+fn fixtures_cover_representative_sizes() {
+    for (name, target) in FIXTURE_SIZES {
+        let payload = args_json_payload(*target);
+        // Each payload lands at roughly its target size and carries the secret.
+        assert!(
+            payload.len() >= *target,
+            "{name} fixture ({}) under target {target}",
+            payload.len()
+        );
+        assert!(
+            payload.windows(AWS_KEY.len()).any(|w| w == AWS_KEY.as_bytes()),
+            "{name} fixture must embed the credential to exercise redaction"
+        );
+    }
+
+    // The near-cap fixture must be scanned in full: large, but under the cap so
+    // it is not short-circuited by the oversized-field path.
+    let near_cap = args_json_payload(60 * 1024);
+    assert!(near_cap.len() > 32 * 1024, "near_cap fixture should be large");
+    assert!(
+        near_cap.len() < DEFAULT_MAX_FIELD_BYTES,
+        "near_cap fixture must stay under the {DEFAULT_MAX_FIELD_BYTES}-byte cap"
+    );
 }

--- a/verification-reports/AAASM-2618.md
+++ b/verification-reports/AAASM-2618.md
@@ -1,0 +1,102 @@
+# Verification Report — AAASM-2618
+
+**Task:** ✅ (aa-runtime): Add runtime-side p99 latency assertion/bench for the scan stage
+**Follow-up of:** AAASM-2568 AC4 ("scan-latency metrics emitted; p99 within budget, or budget documented")
+**Branch:** `v0.0.1/AAASM-2618/test/runtime_scan_p99` (base `master`)
+
+---
+
+## Context
+
+The authoritative enforcement stage (`aa-runtime/src/pipeline/enforcement.rs`,
+`RuntimeScanner::enforce`) already emits the `aa_runtime_scan_latency_seconds`
+histogram, but there was **no runtime-side test asserting the scan + redact
+p99** — AC4 of AAASM-2568 was satisfied only by the gateway's
+`policy_latency_test` and a documented budget. This task adds the missing
+runtime-side assertion and records the measured budget.
+
+## Change
+
+A focused latency test at `aa-runtime/tests/scan_latency_test.rs`:
+
+- Sweeps `RuntimeScanner::enforce()` over representative `tool_call.args_json`
+  payloads — `small` (256 B), `medium` (4 KiB), and `near_cap` (60 KiB, just
+  under the 64 KiB `DEFAULT_MAX_FIELD_BYTES` field cap so the field is scanned
+  in full rather than redacted-whole as oversized). Each fixture embeds a real
+  credential so the **redaction** path is measured, not a clean no-op scan.
+- Records per-call wall-clock latency, sorts, and computes p50/p95/p99/p999/max.
+- **Asserts p99 stays within a profile-aware budget** (see below).
+- Reuses the gateway's `AA_BENCH_*` env-var convention:
+  - `AA_BENCH_SLA_P99_MS` — override the p99 budget (always wins over the default).
+  - `AA_BENCH_ITERS` — per-fixture iteration count (default 2 000).
+
+Three `#[test]`s ship: `percentile_picks_expected_rank` (helper),
+`fixtures_cover_representative_sizes` (fixture/size guard incl. the near-cap
+bound), and `enforce_scan_p99_within_budget` (the assertion).
+
+## Budget rationale
+
+The scan is a pure in-process aho-corasick pass plus redaction — a small
+fraction of the gateway's policy-latency budget. The budget is **profile-aware**
+because `cargo test` defaults to a debug build where the scanner runs ~100×
+slower than the optimized binary the runtime actually ships:
+
+| Profile | Default budget | Measured p99 | Headroom |
+|---|---|---|---|
+| `--release` | **5 ms** | ~0.37 ms | ~13× |
+| debug (default) | **50 ms** | ~2.3 ms | ~21× |
+
+The debug ceiling is loose by design: it still trips on a catastrophic
+regression (e.g. an accidental per-event scanner rebuild, or an O(n²) scan)
+without flaking under parallel test execution. Set `AA_BENCH_SLA_P99_MS=5` on
+bare-metal / nightly runs for a tight check regardless of profile.
+
+## Measured results
+
+**Environment:** Apple M3 Max, 16 cores, 128 GB, macOS 26.4.1 (Darwin 25.4.0),
+rustc 1.95.0. 2 000 iterations × 3 fixtures = 6 000 scans, machine otherwise idle.
+
+Release (`cargo test -p aa-runtime --release --test scan_latency_test`):
+
+```
+  p50:    22.709µs
+  p95:   340.875µs
+  p99:   367.625µs
+  p999:  472.625µs
+  max:   784.667µs
+```
+
+Debug (`cargo test -p aa-runtime --test scan_latency_test`):
+
+```
+  p50:   183.875µs
+  p95:     2.246ms
+  p99:     2.334ms
+  p999:    2.992ms
+  max:     7.905ms
+```
+
+The p50/p95 figures are the stable signal; the far tail (p999/max) is dominated
+by OS scheduling jitter and grows sharply when the host is contended — hence the
+generous, overridable p99 ceiling rather than a tight per-call SLA.
+
+## Verification
+
+```
+$ cargo test -p aa-runtime --test scan_latency_test
+test percentile_picks_expected_rank ... ok
+test fixtures_cover_representative_sizes ... ok
+test enforce_scan_p99_within_budget ... ok
+test result: ok. 3 passed; 0 failed
+
+$ cargo clippy -p aa-runtime --test scan_latency_test -- -D warnings
+Finished — no warnings
+
+$ cargo fmt --check    # clean
+```
+
+## Scope
+
+Hardens AC4 coverage of AAASM-2568. The metric + documented budget already
+satisfied the AC; this adds the executable assertion and records the
+runtime-specific numbers above.


### PR DESCRIPTION
## Description

Hardens **AAASM-2568 AC4** ("scan-latency metrics emitted; p99 within budget, or budget documented") by adding the missing runtime-side latency assertion for the authoritative scan stage.

`RuntimeScanner::enforce()` already emits the `aa_runtime_scan_latency_seconds` histogram, but nothing asserted its p99 — we relied on the gateway's `policy_latency_test` plus a documented budget. This PR adds a focused test at `aa-runtime/tests/scan_latency_test.rs` that:

- Sweeps `enforce()` over representative `tool_call.args_json` payloads — `small` (256 B), `medium` (4 KiB), and `near_cap` (60 KiB, just under the 64 KiB `DEFAULT_MAX_FIELD_BYTES` cap so the field is scanned in full), each seeded with a real credential so the **redaction** path is measured.
- Records per-call latency, computes p50/p95/p99/p999/max, and **asserts p99 within a profile-aware budget** (5 ms release / 50 ms debug; explicit `AA_BENCH_SLA_P99_MS` always wins).
- Reuses the gateway's `AA_BENCH_*` convention (`AA_BENCH_SLA_P99_MS`, `AA_BENCH_ITERS`).

Measured (Apple M3 Max, idle): release p99 **~0.37 ms**, debug p99 **~2.3 ms**. Full numbers + budget rationale in `verification-reports/AAASM-2618.md`.

## Type of Change

- [x] ✅ Tests
- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2618 (follow-up of AAASM-2568)

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [x] Integration tests added / updated

```
$ cargo test -p aa-runtime --test scan_latency_test
test percentile_picks_expected_rank ... ok
test fixtures_cover_representative_sizes ... ok
test enforce_scan_p99_within_budget ... ok
test result: ok. 3 passed; 0 failed
```

- `cargo clippy -p aa-runtime --test scan_latency_test -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- pre-push `cargo doc --workspace --no-deps` — passed

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
