### PR TITLE
[AAASM-2657] 🗑️ (aa-core): Remove aa-security compat re-exports from public API

### DIFF
--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -190,13 +190,13 @@ pub struct Lineage {
 // Redaction
 // ---------------------------------------------------------------------------
 
-/// Temporary migration re-export: the redaction primitive now lives in the
-/// leaf crate `aa-security` (AAASM-2567). `AuditEntry` continues to consume it
-/// here; consumers should depend on `aa-security` directly. Gated on `std`
-/// because it holds [`CredentialFinding`](aa_security::CredentialFinding),
-/// which lives in the `std`-only `scanner` module.
+// `AuditEntry` consumes the redaction primitive from the leaf crate
+// `aa-security` (AAASM-2567); it is imported privately here and is no longer
+// re-exported from `aa-core`. Consumers depend on `aa-security` directly.
+// Gated on `std` because `Redaction` holds `aa_security::CredentialFinding`
+// values, which live in the `std`-only `scanner` module.
 #[cfg(feature = "std")]
-pub use aa_security::Redaction;
+use aa_security::Redaction;
 
 // ---------------------------------------------------------------------------
 // AuditEntry

--- a/aa-core/src/audit.rs
+++ b/aa-core/src/audit.rs
@@ -193,7 +193,7 @@ pub struct Lineage {
 /// Temporary migration re-export: the redaction primitive now lives in the
 /// leaf crate `aa-security` (AAASM-2567). `AuditEntry` continues to consume it
 /// here; consumers should depend on `aa-security` directly. Gated on `std`
-/// because it holds [`CredentialFinding`](crate::scanner::CredentialFinding),
+/// because it holds [`CredentialFinding`](aa_security::CredentialFinding),
 /// which lives in the `std`-only `scanner` module.
 #[cfg(feature = "std")]
 pub use aa_security::Redaction;
@@ -249,7 +249,7 @@ pub struct AuditEntry {
     depth: Option<u32>,
     #[cfg(feature = "std")]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Vec::is_empty", default))]
-    credential_findings: alloc::vec::Vec<crate::scanner::CredentialFinding>,
+    credential_findings: alloc::vec::Vec<aa_security::CredentialFinding>,
     #[cfg(feature = "std")]
     #[cfg_attr(feature = "serde", serde(skip_serializing_if = "Option::is_none", default))]
     redacted_payload: Option<String>,
@@ -392,7 +392,7 @@ impl AuditEntry {
     /// continue using the legacy constructors without any chain divergence.
     ///
     /// Gated on `std` because [`Redaction`] holds
-    /// [`CredentialFinding`](crate::scanner::CredentialFinding) values, which
+    /// [`CredentialFinding`](aa_security::CredentialFinding) values, which
     /// live in the `std`-only `scanner` module.
     #[cfg(feature = "std")]
     #[allow(clippy::too_many_arguments)]
@@ -537,12 +537,12 @@ impl AuditEntry {
     /// Credential / PII findings detected by the policy engine's scanner pass.
     ///
     /// Empty when the scan was clean (or when the entry was constructed via a
-    /// pre-redaction-aware code path). Each [`CredentialFinding`](crate::scanner::CredentialFinding)
+    /// pre-redaction-aware code path). Each [`CredentialFinding`](aa_security::CredentialFinding)
     /// stores only the kind, byte offset, and `[REDACTED:<kind>]` label —
     /// never the raw secret bytes.
     #[cfg(feature = "std")]
     #[inline]
-    pub fn credential_findings(&self) -> &[crate::scanner::CredentialFinding] {
+    pub fn credential_findings(&self) -> &[aa_security::CredentialFinding] {
         &self.credential_findings
     }
 
@@ -1782,7 +1782,7 @@ mod lineage_tests {
 #[cfg(all(test, feature = "std", feature = "serde"))]
 mod redaction_tests {
     use super::*;
-    use crate::scanner::CredentialScanner;
+    use aa_security::CredentialScanner;
 
     const AGENT: AgentId = AgentId::from_bytes([3u8; 16]);
     const SESSION: SessionId = SessionId::from_bytes([4u8; 16]);

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -80,9 +80,6 @@ pub use capability::{
 };
 
 #[cfg(feature = "std")]
-pub use scanner::{CredentialFinding, CredentialKind, CredentialScanner, ScanResult, ScannerConfig};
-
-#[cfg(feature = "std")]
 pub use config::{
     AgentConnectConfig, ConfigError, DeploymentMode, GatewayConfig, LocalModeConfig, RemoteModeConfig, TlsConfig,
 };

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -74,9 +74,6 @@ pub use evaluators::{DenyAllEvaluator, PermitAllEvaluator};
 #[cfg(feature = "alloc")]
 pub use audit::{AuditEntry, AuditEventType, AuditLog, AuditLogError, Lineage};
 
-#[cfg(feature = "std")]
-pub use audit::Redaction;
-
 #[cfg(feature = "alloc")]
 pub use capability::{
     action_to_capability, merge_capabilities, Capability, CapabilitySet, EffectivePermissions, PermissionSource,

--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -36,12 +36,6 @@ pub mod evaluators;
 pub mod identity;
 pub mod policy;
 pub mod risk_tier;
-/// Temporary migration re-export: the credential scanner now lives in the
-/// leaf crate `aa-security` (AAASM-2567). Consumers should depend on
-/// `aa-security` directly; this keeps `aa_core::scanner::…` paths resolving
-/// during the migration.
-#[cfg(feature = "std")]
-pub use aa_security::scanner;
 #[cfg(feature = "std")]
 pub mod storage;
 pub mod time;


### PR DESCRIPTION
## Description

Retires the **temporary** `aa-security` migration re-exports that AAASM-2567 left in `aa-core`. Now that AAASM-2604 + AAASM-2608 migrated every consumer to depend on `aa-security` directly, the compat shim is dead surface and can be removed.

Removed from `aa-core`:
- `pub use aa_security::scanner;` (the `scanner` module migration re-export + its doc comment)
- `pub use scanner::{CredentialFinding, CredentialKind, CredentialScanner, ScanResult, ScannerConfig};`
- `pub use audit::Redaction;`

In `aa-core/src/audit.rs`:
- `AuditEntry::credential_findings` field, getter and intra-doc links now reference `aa_security::CredentialFinding` directly (off the `crate::scanner` re-export).
- `pub use aa_security::Redaction;` demoted to a **private** `use aa_security::Redaction;` — `AuditEntry` still consumes it internally; it is no longer re-exported.

`aa-core` keeps its **internal** optional `std`-gated `aa-security` dependency (`AuditEntry` carries findings). Only the public re-export surface is removed.

Commits are granular (one logical change each):
1. ♻️ Repoint `AuditEntry` findings to `aa_security::CredentialFinding`
2. 🗑️ Stop re-exporting `Redaction` from `aa-core`
3. 🗑️ Drop flat scanner credential-type re-exports
4. 🗑️ Drop temporary `aa_security::scanner` module re-export

## Type of Change

- [x] ♻️ Refactoring

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No

Removes a deprecated **internal** workspace re-export only. Verified zero references to `aa_core::{scanner,CredentialScanner,CredentialFinding,CredentialKind,ScanResult,ScannerConfig,Redaction}` outside `aa-core` — in-workspace **and** across the `python-sdk` / `node-sdk` / `go-sdk` sibling repos. No runtime behaviour change.

## Related Issues

- Related Jira ticket: AAASM-2657 (impl subtask of AAASM-2614, Epic AAASM-2552)
- Related GitHub issues: n/a

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated — verification test ships in the follow-up subtask AAASM-2658 (stacked PR)
- [x] No new tests required for this commit — pure API-surface removal; existing `aa-core` suite exercises the repointed `AuditEntry` paths

Local validation (macOS):
- `cargo build --workspace` (excl. Linux-only eBPF crates) — ✅
- `cargo nextest run -p aa-core` — ✅ 212 passed
- `cargo clippy -p aa-core --all-targets --all-features -- -D warnings` — ✅
- `cargo fmt -p aa-core -- --check` — ✅
- `cargo deny check` — ✅ advisories/bans/licenses/sources ok
- `cargo doc --workspace --no-deps` (excl. eBPF) — ✅ no new warnings

> Note: the pre-push `cargo doc --workspace` hook spans the Linux-only `aa-ebpf*` crates and cannot run on a macOS dev box; full-workspace build/test/doc are covered by CI on Linux.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (doc comments de-"temporary"-fied)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-2657