### PR TITLE
[AAASM-2619] 🔧 (aa-runtime): Wire EnforcementConfig from RuntimeConfig

### DIFF
--- a/aa-runtime/src/config.rs
+++ b/aa-runtime/src/config.rs
@@ -746,4 +746,31 @@ mod tests {
         std::env::remove_var("AA_AGENT_ID");
         std::env::remove_var("AA_AUDIT_BUFFER_PATH");
     }
+
+    #[test]
+    fn enforcement_max_field_bytes_reads_defaults_and_rejects_zero() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AA_AGENT_ID", "agent-enf");
+
+        // Explicit non-default value is honoured.
+        std::env::set_var("AA_ENFORCEMENT_MAX_FIELD_BYTES", "4096");
+        assert_eq!(RuntimeConfig::from_env().unwrap().enforcement_max_field_bytes, 4096);
+
+        // Zero falls back to the default (a 0-byte cap would redact everything).
+        std::env::set_var("AA_ENFORCEMENT_MAX_FIELD_BYTES", "0");
+        assert_eq!(
+            RuntimeConfig::from_env().unwrap().enforcement_max_field_bytes,
+            DEFAULT_MAX_FIELD_BYTES,
+            "0 should fall back to default"
+        );
+
+        // Unset falls back to the default.
+        std::env::remove_var("AA_ENFORCEMENT_MAX_FIELD_BYTES");
+        assert_eq!(
+            RuntimeConfig::from_env().unwrap().enforcement_max_field_bytes,
+            DEFAULT_MAX_FIELD_BYTES
+        );
+
+        std::env::remove_var("AA_AGENT_ID");
+    }
 }

--- a/aa-runtime/src/config.rs
+++ b/aa-runtime/src/config.rs
@@ -2,6 +2,8 @@
 
 use std::path::PathBuf;
 
+use crate::pipeline::enforcement::DEFAULT_MAX_FIELD_BYTES;
+
 /// Configuration for the `aa-runtime` sidecar process.
 ///
 /// All fields are populated by [`RuntimeConfig::from_env`].
@@ -104,6 +106,14 @@ pub struct RuntimeConfig {
     /// `<temp-dir>/aa-audit-buffer-<agent_id>.db`. Only used when the audit
     /// publisher is enabled.
     pub audit_buffer_path: PathBuf,
+
+    /// Upper bound, in bytes, on any single secret-bearing field handed to the
+    /// runtime credential scanner. Fields larger than this are redacted whole
+    /// (fail-closed) rather than partially scanned.
+    ///
+    /// Read from `AA_ENFORCEMENT_MAX_FIELD_BYTES`. Defaults to
+    /// [`DEFAULT_MAX_FIELD_BYTES`] (64 KiB). Zero falls back to the default.
+    pub enforcement_max_field_bytes: usize,
 }
 
 impl RuntimeConfig {
@@ -132,6 +142,7 @@ impl RuntimeConfig {
     /// | `AA_CORRELATION_INTERVAL_MS` | `u64` | `1_000` |
     /// | `AA_NATS_CONFIG_PATH` | `Option<PathBuf>` | `None` (publisher disabled) |
     /// | `AA_AUDIT_BUFFER_PATH` | `PathBuf` | `<temp>/aa-audit-buffer-<agent_id>.db` |
+    /// | `AA_ENFORCEMENT_MAX_FIELD_BYTES` | `usize` | `65536` (64 KiB) |
     pub fn from_env() -> Result<Self, String> {
         let agent_id = std::env::var("AA_AGENT_ID").map_err(|_| "AA_AGENT_ID is required but not set".to_string())?;
 
@@ -216,6 +227,12 @@ impl RuntimeConfig {
             .map(PathBuf::from)
             .unwrap_or_else(|| std::env::temp_dir().join(format!("aa-audit-buffer-{agent_id}.db")));
 
+        let enforcement_max_field_bytes = std::env::var("AA_ENFORCEMENT_MAX_FIELD_BYTES")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(DEFAULT_MAX_FIELD_BYTES);
+
         Ok(Self {
             agent_id,
             worker_threads,
@@ -232,6 +249,7 @@ impl RuntimeConfig {
             correlation_interval_ms,
             nats_config_path,
             audit_buffer_path,
+            enforcement_max_field_bytes,
         })
     }
 }

--- a/aa-runtime/src/correlation/config.rs
+++ b/aa-runtime/src/correlation/config.rs
@@ -79,6 +79,7 @@ mod tests {
             correlation_interval_ms: 2_000,
             nats_config_path: None,
             audit_buffer_path: std::path::PathBuf::from("/tmp/aa-audit-buffer-test.db"),
+            enforcement_max_field_bytes: crate::pipeline::enforcement::DEFAULT_MAX_FIELD_BYTES,
         };
 
         let config = CorrelationConfig::from_runtime_config(&rc);

--- a/aa-runtime/src/ipc/server.rs
+++ b/aa-runtime/src/ipc/server.rs
@@ -640,6 +640,7 @@ mod tests {
             flush_interval: std::time::Duration::from_secs(60),
             broadcast_capacity: 64,
             agent_id: "test-agent".to_string(),
+            enforcement: crate::pipeline::enforcement::EnforcementConfig::default(),
         };
         let pipeline_metrics = Arc::new(PipelineMetrics::default());
         let (broadcast_tx, _broadcast_rx) = tokio::sync::broadcast::channel::<crate::pipeline::PipelineEvent>(64);
@@ -732,6 +733,7 @@ mod tests {
             flush_interval: std::time::Duration::from_secs(60),
             broadcast_capacity: 64,
             agent_id: "test-agent".to_string(),
+            enforcement: crate::pipeline::enforcement::EnforcementConfig::default(),
         };
         let pipeline_metrics = Arc::new(PipelineMetrics::default());
         let (broadcast_tx, _broadcast_rx) = tokio::sync::broadcast::channel::<crate::pipeline::PipelineEvent>(64);
@@ -831,6 +833,7 @@ mod tests {
             flush_interval: std::time::Duration::from_secs(60),
             broadcast_capacity: 64,
             agent_id: "test-agent".to_string(),
+            enforcement: crate::pipeline::enforcement::EnforcementConfig::default(),
         };
         let pipeline_metrics = Arc::new(PipelineMetrics::default());
         let (broadcast_tx, _broadcast_rx) = tokio::sync::broadcast::channel::<crate::pipeline::PipelineEvent>(64);

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -18,6 +18,7 @@ use aa_proto::assembly::audit::v1::audit_event::Detail;
 use aa_security::{CredentialFinding, CredentialScanner};
 
 use super::event::EnrichedEvent;
+use crate::config::RuntimeConfig;
 
 /// Default upper bound, in bytes, on a single secret-bearing field handed to
 /// the scanner. Fields larger than this are handled per [`OversizedPolicy`].
@@ -56,6 +57,21 @@ impl Default for EnforcementConfig {
     fn default() -> Self {
         Self {
             max_field_bytes: DEFAULT_MAX_FIELD_BYTES,
+            oversized_policy: OversizedPolicy::default(),
+        }
+    }
+}
+
+impl EnforcementConfig {
+    /// Build an [`EnforcementConfig`] from a [`RuntimeConfig`].
+    ///
+    /// Maps the operator-tunable per-field size cap
+    /// ([`RuntimeConfig::enforcement_max_field_bytes`]). `oversized_policy`
+    /// keeps its fail-closed [`OversizedPolicy::RedactWhole`] default — the
+    /// sole variant today — so an oversized field is never forwarded raw.
+    pub fn from_runtime_config(c: &RuntimeConfig) -> Self {
+        Self {
+            max_field_bytes: c.enforcement_max_field_bytes,
             oversized_policy: OversizedPolicy::default(),
         }
     }

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -492,4 +492,35 @@ mod tests {
         // The finding metric is labelled by kind; the raw secret never appears.
         assert!(!rendered.contains(AWS_KEY));
     }
+
+    #[test]
+    fn from_runtime_config_maps_size_cap_and_keeps_fail_closed_policy() {
+        let rc = RuntimeConfig {
+            agent_id: "test".to_string(),
+            worker_threads: 0,
+            shutdown_timeout_secs: 30,
+            ipc_max_connections: 64,
+            pipeline_input_buffer: 10_000,
+            pipeline_batch_size: 100,
+            pipeline_flush_interval_ms: 100,
+            pipeline_broadcast_capacity: 1_024,
+            metrics_addr: "0.0.0.0:8080".to_string(),
+            policy_path: None,
+            gateway_endpoint: None,
+            correlation_window_ms: 5_000,
+            correlation_interval_ms: 1_000,
+            nats_config_path: None,
+            audit_buffer_path: std::path::PathBuf::from("/tmp/aa-audit-buffer-test.db"),
+            enforcement_max_field_bytes: 4096,
+        };
+
+        let config = EnforcementConfig::from_runtime_config(&rc);
+
+        assert_eq!(config.max_field_bytes, 4096, "size cap is threaded from RuntimeConfig");
+        assert_eq!(
+            config.oversized_policy,
+            OversizedPolicy::RedactWhole,
+            "oversized policy stays fail-closed"
+        );
+    }
 }

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -38,6 +38,8 @@ pub struct PipelineConfig {
     pub broadcast_capacity: usize,
     /// Agent identity — copied from `RuntimeConfig::agent_id`.
     pub agent_id: String,
+    /// Runtime scan/redact enforcement config — derived from `RuntimeConfig`.
+    pub enforcement: enforcement::EnforcementConfig,
 }
 
 impl PipelineConfig {
@@ -49,6 +51,7 @@ impl PipelineConfig {
             flush_interval: Duration::from_millis(c.pipeline_flush_interval_ms),
             broadcast_capacity: c.pipeline_broadcast_capacity,
             agent_id: c.agent_id.clone(),
+            enforcement: enforcement::EnforcementConfig::from_runtime_config(c),
         }
     }
 }
@@ -684,6 +687,7 @@ mod tests {
             flush_interval: Duration::from_millis(200),
             broadcast_capacity: 512,
             agent_id: "test-agent".to_string(),
+            enforcement: enforcement::EnforcementConfig::default(),
         };
 
         let cloned = pipeline_config.clone();
@@ -702,6 +706,7 @@ mod tests {
             flush_interval: Duration::from_millis(flush_interval_ms),
             broadcast_capacity: 1_024,
             agent_id: "test-agent".to_string(),
+            enforcement: enforcement::EnforcementConfig::default(),
         }
     }
 

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -81,7 +81,9 @@ pub async fn run(
 
     // GATE (AAASM-2568): one precompiled scanner, constructed once and reused
     // for every event. The runtime is the authoritative scan/redact point.
-    let scanner = enforcement::RuntimeScanner::new();
+    // The size-cap / oversized policy are operator-tunable via RuntimeConfig
+    // (AAASM-2619); the fail-closed default is preserved when unset.
+    let scanner = enforcement::RuntimeScanner::with_config(config.enforcement.clone());
 
     loop {
         tokio::select! {

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -658,6 +658,7 @@ mod tests {
             correlation_interval_ms: 1_000,
             nats_config_path: None,
             audit_buffer_path: std::path::PathBuf::from("/tmp/aa-audit-buffer-test.db"),
+            enforcement_max_field_bytes: enforcement::DEFAULT_MAX_FIELD_BYTES,
         };
 
         let pipeline_config = PipelineConfig::from_runtime_config(&runtime_config);

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -1128,6 +1128,7 @@ mod tests {
             correlation_interval_ms: 1_000,
             nats_config_path,
             audit_buffer_path: std::env::temp_dir().join("aa-audit-buffer-audit-test.db"),
+            enforcement_max_field_bytes: crate::pipeline::enforcement::DEFAULT_MAX_FIELD_BYTES,
         }
     }
 

--- a/aa-runtime/tests/aaasm_2568_gate_verification.rs
+++ b/aa-runtime/tests/aaasm_2568_gate_verification.rs
@@ -15,6 +15,7 @@ use aa_proto::assembly::audit::v1::{audit_event::Detail, AuditEvent, ToolCallDet
 use aa_proto::assembly::common::v1::ActionType;
 use aa_runtime::approval::ApprovalQueue;
 use aa_runtime::ipc::{new_response_router, IpcFrame};
+use aa_runtime::pipeline::enforcement::{EnforcementConfig, OVERSIZED_MARKER};
 use aa_runtime::pipeline::{run, PipelineConfig, PipelineEvent, PipelineMetrics};
 use aa_runtime::policy::{PolicyRule, PolicyRules};
 use tokio::sync::{broadcast, mpsc};
@@ -113,4 +114,57 @@ async fn gate_redacts_on_violation_path() {
     };
     let event = drive_one(policy).await;
     assert_redacted(event);
+}
+
+/// AAASM-2619: a configured per-field size cap takes effect through `run()`.
+/// With a 16-byte cap, the secret-bearing `args_json` (well past the cap) is
+/// redacted whole (fail-closed) rather than scanned and forwarded raw —
+/// proving `AA_ENFORCEMENT_MAX_FIELD_BYTES` is wired end-to-end, not a
+/// compile-time default.
+#[tokio::test]
+async fn configured_size_cap_redacts_oversized_field_through_run() {
+    let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
+    let (broadcast_tx, mut broadcast_rx) = broadcast::channel::<PipelineEvent>(64);
+    let metrics = Arc::new(PipelineMetrics::default());
+    let token = CancellationToken::new();
+
+    // Override the 64 KiB default with a 16-byte cap.
+    let mut config = verify_config(1);
+    config.enforcement = EnforcementConfig {
+        max_field_bytes: 16,
+        ..Default::default()
+    };
+
+    tokio::spawn(run(
+        rx,
+        broadcast_tx,
+        config,
+        metrics,
+        token.clone(),
+        Arc::new(PolicyRules::default()),
+        new_response_router(),
+        ApprovalQueue::new(),
+        None,
+        Arc::new(AtomicU64::new(0)),
+    ));
+
+    // tool_call_with_secret()'s args_json is ~37 bytes, exceeding the 16-byte cap.
+    tx.send((0, IpcFrame::EventReport(tool_call_with_secret())))
+        .await
+        .expect("send event");
+    let event = tokio::time::timeout(Duration::from_millis(500), broadcast_rx.recv())
+        .await
+        .expect("timed out waiting for forwarded event")
+        .expect("broadcast error");
+    token.cancel();
+
+    let PipelineEvent::Audit(enriched) = event else {
+        panic!("expected a PipelineEvent::Audit");
+    };
+    let Some(Detail::ToolCall(tc)) = enriched.inner.detail else {
+        panic!("expected ToolCall detail");
+    };
+    let body = String::from_utf8(tc.args_json).expect("marker is utf-8");
+    assert_eq!(body, OVERSIZED_MARKER, "oversized field is redacted whole");
+    assert!(!body.contains(SECRET), "raw secret must never leave the runtime");
 }

--- a/aa-runtime/tests/aaasm_2568_gate_verification.rs
+++ b/aa-runtime/tests/aaasm_2568_gate_verification.rs
@@ -30,6 +30,7 @@ fn verify_config(batch_size: usize) -> PipelineConfig {
         flush_interval: Duration::from_millis(10_000),
         broadcast_capacity: 1_024,
         agent_id: "verify-agent".to_string(),
+        enforcement: aa_runtime::pipeline::enforcement::EnforcementConfig::default(),
     }
 }
 


### PR DESCRIPTION
## Description

Follow-up to **AAASM-2568** (runtime enforcement gate). The runtime credential scanner's per-field size cap (`EnforcementConfig::max_field_bytes`, 64 KiB) was a **compile-time default** — `pipeline::run()` built the scanner via `RuntimeScanner::new()`. This PR threads the config from `RuntimeConfig` so operators can tune the cap, and constructs `RuntimeScanner::with_config(...)` in `run()`.

What changed:
- **`RuntimeConfig`** gains an env-backed `enforcement_max_field_bytes` field (`AA_ENFORCEMENT_MAX_FIELD_BYTES`, default 64 KiB, zero → default), using the same env-as-config mechanism as every other `RuntimeConfig` field.
- **`EnforcementConfig::from_runtime_config(&RuntimeConfig)`** maps the size cap. `oversized_policy` keeps its fail-closed `RedactWhole` default — the sole variant today — so an oversized field is never forwarded raw.
- **`PipelineConfig`** (the `run()`-facing derivative of `RuntimeConfig`) carries the derived `EnforcementConfig`; `pipeline::run()` builds the scanner from it via `RuntimeScanner::with_config(...)`.

### Scope notes
- Operability enhancement; configurability was **not** a Story AC. The fail-closed default is preserved when the env var is unset.
- There is no separate "runtime TOML" for these settings — `RuntimeConfig` is entirely env-driven, so the tunable is exposed as an env var (matching the existing config surface). The `from_env` doc table is updated accordingly.
- `oversized_policy` is left as a compile-time default: `OversizedPolicy` has a single fail-closed variant, so a parser would be dead code today. Extending it is a future change when more variants exist.

## Type of Change

- [x] 🔧 Configuration / CI change
- [ ] ✨ New feature
- [ ] ♻️ Refactoring

## Breaking Changes

- [x] No

`RuntimeConfig` gains a field, but it is only constructed via `from_env` / test fixtures within `aa-runtime`; no public-API consumer breaks.

## Related Issues

- Related Jira ticket: AAASM-2619
- Relates to: AAASM-2568

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

Validation (scoped to the only affected crate, `aa-runtime`):
- `cargo nextest run -p aa-runtime` → **263 passed, 2 skipped**.
- New tests:
  - `config::tests::enforcement_max_field_bytes_reads_defaults_and_rejects_zero` — env parsing (value / zero-fallback / unset-default).
  - `pipeline::enforcement::tests::from_runtime_config_maps_size_cap_and_keeps_fail_closed_policy` — mapping keeps fail-closed policy.
  - `aaasm_2568_gate_verification::configured_size_cap_redacts_oversized_field_through_run` — **end-to-end**: drives the real pipeline with a 16-byte cap and asserts the oversized secret-bearing field is redacted whole, proving the cap is wired through `run()`.
- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check` pass (lefthook pre-commit on every commit); `cargo doc --workspace --no-deps` passes (pre-push) with no new warnings.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (env-var doc table)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)