### PR TITLE
[AAASM-2339] 🔧 (infra): Provision the curl install endpoint (tool.agent-assembly.dev)

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -125,16 +125,12 @@ jobs:
 
   smoke-curl-installer:
     name: Smoke — curl installer
-    # AAASM-2339: get.agent-assembly.io is not provisioned yet (no DNS,
-    # no Cloudflare Worker). The job is preserved here under an unconditional
-    # `if: false` so the wiring is ready when the curl|sh install path ships;
-    # until then the job is skipped on every release and emits no signal.
-    # Deliberately kept out of `notify-on-failure`'s `needs:` list so a
-    # skipped run does not propagate to that downstream job. To re-enable:
-    # provision the endpoint, flip `if: false` to `if: true` (or drop the
-    # line), and re-add `- smoke-curl-installer` to notify-on-failure's
-    # `needs:`.
-    if: false
+    # AAASM-2339: the install endpoint (tool.agent-assembly.dev) is served by the
+    # Cloudflare Worker in infra/install-endpoint/. This job is gated on the
+    # `INSTALL_ENDPOINT_LIVE` repo variable so it runs once the Worker is deployed
+    # and the variable is set to `true` — skipped otherwise, so there is no
+    # false-red on releases cut before the endpoint goes live.
+    if: ${{ vars.INSTALL_ENDPOINT_LIVE == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -163,7 +159,7 @@ jobs:
           # the current shell. Re-export common install locations so the
           # subsequent step can find the binary regardless of which one the
           # installer chose.
-          curl -fsSL https://get.agent-assembly.io | sh
+          curl -fsSL https://tool.agent-assembly.dev | sh
           {
             echo "$HOME/.local/bin"
             echo "$HOME/.agent-assembly/bin"
@@ -285,6 +281,7 @@ jobs:
       - smoke-homebrew-linux
       - smoke-cargo-install
       - smoke-docker
+      - smoke-curl-installer
     # Fire only when the workflow is genuinely broken — `failure()` covers
     # any failed `needs:` job; the `release` event guard avoids dispatching
     # notifications during manual `workflow_dispatch` reruns.

--- a/infra/install-endpoint/README.md
+++ b/infra/install-endpoint/README.md
@@ -37,7 +37,7 @@ The `smoke-curl-installer` job in `.github/workflows/smoke-test.yml` is gated on
 repo variable so it only runs once the endpoint is live:
 
 ```sh
-gh variable set INSTALL_ENDPOINT_LIVE --body true --repo AI-agent-assembly/agent-assembly
+gh variable set INSTALL_ENDPOINT_LIVE --body true --repo ai-agent-assembly/agent-assembly
 ```
 
 Until that variable is `true`, the job is skipped (no false-red on releases).

--- a/infra/install-endpoint/README.md
+++ b/infra/install-endpoint/README.md
@@ -1,0 +1,55 @@
+# aasm install endpoint
+
+Cloudflare Worker that serves [`scripts/install-cli.sh`](../../scripts/install-cli.sh)
+at **`https://tool.agent-assembly.dev`**, powering the one-line installer:
+
+```sh
+curl -fsSL https://tool.agent-assembly.dev | sh
+```
+
+The `.dev` TLD is HSTS-preloaded (HTTPS-only), so the endpoint can never be served
+over plaintext `http`. The Worker fetches the install script from a pinned ref
+(`SCRIPT_REF`) and serves it verbatim; the installer then downloads the release
+binary and verifies its **SHA-256 checksum + cosign signature** (AAASM-2700).
+
+## Deploy (one-time, operator)
+
+Prerequisites: a Cloudflare account with the **`agent-assembly.dev`** zone added,
+and [`wrangler`](https://developers.cloudflare.com/workers/wrangler/) installed
+(`npm i -g wrangler`).
+
+```sh
+cd infra/install-endpoint
+wrangler login
+wrangler deploy          # provisions the Worker + the tool.agent-assembly.dev custom domain
+```
+
+Verify:
+
+```sh
+curl -fsSL https://tool.agent-assembly.dev | head -5     # should print the install script
+curl -fsS  https://tool.agent-assembly.dev/healthz       # -> ok
+```
+
+## Enable the release smoke test
+
+The `smoke-curl-installer` job in `.github/workflows/smoke-test.yml` is gated on a
+repo variable so it only runs once the endpoint is live:
+
+```sh
+gh variable set INSTALL_ENDPOINT_LIVE --body true --repo AI-agent-assembly/agent-assembly
+```
+
+Until that variable is `true`, the job is skipped (no false-red on releases).
+
+## Pinning the served script
+
+For an immutable, auditable installer, pin `SCRIPT_REF` in `wrangler.toml` to a
+release tag and re-deploy:
+
+```toml
+[vars]
+SCRIPT_REF = "v0.0.1"
+```
+
+`master` (the default) always serves the latest reviewed installer.

--- a/infra/install-endpoint/src/worker.js
+++ b/infra/install-endpoint/src/worker.js
@@ -1,0 +1,64 @@
+// Cloudflare Worker — the aasm install endpoint (AAASM-2339).
+//
+// Serves `scripts/install-cli.sh` from the agent-assembly repo at
+// https://tool.agent-assembly.dev so users can run:
+//
+//   curl -fsSL https://tool.agent-assembly.dev | sh
+//
+// The `.dev` TLD is HSTS-preloaded (HTTPS-only), so this endpoint can never be
+// reached over plaintext http. The script is fetched from a pinned ref
+// (SCRIPT_REF) and served verbatim; the installer itself then downloads the
+// release binary and verifies its checksum + cosign signature (AAASM-2700).
+
+const DEFAULT_REPO = "AI-agent-assembly/agent-assembly";
+const DEFAULT_REF = "master";
+const SCRIPT_PATH = "scripts/install-cli.sh";
+
+export default {
+  async fetch(request, env, ctx) {
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("method not allowed\n", {
+        status: 405,
+        headers: { Allow: "GET, HEAD", "content-type": "text/plain; charset=utf-8" },
+      });
+    }
+
+    const url = new URL(request.url);
+    if (url.pathname === "/healthz") {
+      return new Response("ok\n", {
+        status: 200,
+        headers: { "content-type": "text/plain; charset=utf-8" },
+      });
+    }
+
+    const repo = env.SCRIPT_REPO || DEFAULT_REPO;
+    const ref = env.SCRIPT_REF || DEFAULT_REF;
+    const src = `https://raw.githubusercontent.com/${repo}/${ref}/${SCRIPT_PATH}`;
+
+    // Serve from the edge cache to avoid hammering raw.githubusercontent.com.
+    const cache = caches.default;
+    const cached = await cache.match(request);
+    if (cached) return cached;
+
+    const upstream = await fetch(src, { cf: { cacheTtl: 300, cacheEverything: true } });
+    if (!upstream.ok) {
+      return new Response(`error: could not fetch install script (HTTP ${upstream.status})\n`, {
+        status: 502,
+        headers: { "content-type": "text/plain; charset=utf-8" },
+      });
+    }
+
+    const body = await upstream.text();
+    const resp = new Response(body, {
+      status: 200,
+      headers: {
+        "content-type": "text/x-shellscript; charset=utf-8",
+        "cache-control": "public, max-age=300",
+        "x-content-type-options": "nosniff",
+        "x-install-source": src,
+      },
+    });
+    ctx.waitUntil(cache.put(request, resp.clone()));
+    return resp;
+  },
+};

--- a/infra/install-endpoint/src/worker.js
+++ b/infra/install-endpoint/src/worker.js
@@ -10,7 +10,7 @@
 // (SCRIPT_REF) and served verbatim; the installer itself then downloads the
 // release binary and verifies its checksum + cosign signature (AAASM-2700).
 
-const DEFAULT_REPO = "AI-agent-assembly/agent-assembly";
+const DEFAULT_REPO = "ai-agent-assembly/agent-assembly";
 const DEFAULT_REF = "master";
 const SCRIPT_PATH = "scripts/install-cli.sh";
 

--- a/infra/install-endpoint/wrangler.toml
+++ b/infra/install-endpoint/wrangler.toml
@@ -15,5 +15,5 @@ routes = [
 #   SCRIPT_REF = "v0.0.1"   → freeze the installer to a release tag (recommended
 #                             once releases are cut, so the served script is
 #                             immutable and auditable).
-SCRIPT_REPO = "AI-agent-assembly/agent-assembly"
+SCRIPT_REPO = "ai-agent-assembly/agent-assembly"
 SCRIPT_REF = "master"

--- a/infra/install-endpoint/wrangler.toml
+++ b/infra/install-endpoint/wrangler.toml
@@ -1,0 +1,19 @@
+name = "aasm-install-endpoint"
+main = "src/worker.js"
+compatibility_date = "2026-05-01"
+
+# Bind the Worker to the install one-liner host. Requires the `agent-assembly.dev`
+# zone to exist in this Cloudflare account. `custom_domain = true` provisions and
+# manages the DNS + cert for tool.agent-assembly.dev automatically on first deploy.
+routes = [
+  { pattern = "tool.agent-assembly.dev", custom_domain = true },
+]
+
+[vars]
+# Source repo + ref the install script is served from.
+#   SCRIPT_REF = "master"   → always serves the latest reviewed installer.
+#   SCRIPT_REF = "v0.0.1"   → freeze the installer to a release tag (recommended
+#                             once releases are cut, so the served script is
+#                             immutable and auditable).
+SCRIPT_REPO = "AI-agent-assembly/agent-assembly"
+SCRIPT_REF = "master"

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -3,7 +3,7 @@
 # Usage: curl -fsSL https://tool.agent-assembly.dev | sh
 #
 # Detects the host OS and CPU architecture, downloads the matching
-# pre-built tarball plus its SHA256SUMS file from the AI-agent-assembly
+# pre-built tarball plus its SHA256SUMS file from the ai-agent-assembly
 # GitHub Release, verifies the tarball's SHA-256 against SHA256SUMS, and
 # extracts the binary into ${AASM_INSTALL_DIR}. The install aborts if
 # the checksum cannot be downloaded or does not match.
@@ -14,7 +14,7 @@
 #   AASM_NO_MODIFY_PATH  Set to 1 to skip PATH modification hint
 set -eu
 
-REPO="AI-agent-assembly/agent-assembly"
+REPO="ai-agent-assembly/agent-assembly"
 BINARY="aasm"
 VERSION="${AASM_VERSION:-}"
 # INSTALL_DIR is resolved in main() after pick_install_dir is in scope.

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # One-line installer for the aasm CLI.
-# Usage: curl -fsSL https://get.agent-assembly.io | sh
+# Usage: curl -fsSL https://tool.agent-assembly.dev | sh
 #
 # Detects the host OS and CPU architecture, downloads the matching
 # pre-built tarball plus its SHA256SUMS file from the AI-agent-assembly


### PR DESCRIPTION
## Description

Implements **AAASM-2339** with **Option A (Cloudflare Worker)** — provisions the install endpoint so `curl -fsSL https://tool.agent-assembly.dev | sh` works (operator chose to provision rather than drop the curl channel; canonical domain `tool.agent-assembly.dev`, an HTTPS-only `.dev` TLD).

**What's added/changed:**
- `infra/install-endpoint/` — a Cloudflare Worker (`src/worker.js` + `wrangler.toml`) that serves `scripts/install-cli.sh` from a pinned ref (`SCRIPT_REF`, default `master`) with `text/x-shellscript` + edge caching + a `/healthz` probe; plus a deploy **runbook** (`README.md`).
- `scripts/install-cli.sh` — installer one-liner comment now points at `tool.agent-assembly.dev`.
- `.github/workflows/smoke-test.yml` — re-enabled the `smoke-curl-installer` job (was `if: false`), now **gated on the `INSTALL_ENDPOINT_LIVE` repo variable** and targeting the new domain; re-added it to `notify-on-failure`'s `needs`.

**Owner one-time action (not code):** `wrangler deploy` from `infra/install-endpoint/` (needs the `agent-assembly.dev` Cloudflare zone), then `gh variable set INSTALL_ENDPOINT_LIVE --body true`. Until then the smoke job skips (no false-red). The decision deviates from the ticket's earlier "Option C / drop it" recommendation per operator direction.

## Type of Change

- [x] 🔧 Configuration / CI change
- [x] ✨ New feature (install endpoint)

## Breaking Changes

- [x] No

## Related Issues

- Closes AAASM-2339 (under Story AAASM-1235)

## Testing

- [x] Manual: `wrangler.toml` parses (tomllib), `worker.js` passes `node --check`, `smoke-test.yml` YAML-valid with the gated `if:` + notify `needs` asserted. The smoke job is skip-until-live by design (private endpoint not yet deployed).
- [x] No tests required beyond the above — infra/config + script-comment change.

## Checklist

- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention
