### PR TITLE
[AAASM-2701] 🔒 (release): Sign release artifacts (cosign keyless) + installer verification + notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,45 @@ jobs:
           file "$BIN"
           "$BIN" --version
 
+      - name: Codesign + notarize aasm (macOS — gated on Apple Developer creds)
+        # Dormant until the operator sets the MACOS_SIGNING_ENABLED repo variable
+        # AND provisions the APPLE_* secrets; without them this step is skipped and
+        # the unsigned binary ships unchanged (no behaviour change). When enabled,
+        # the dist binary is Developer-ID-signed with a hardened runtime and
+        # notarized so macOS Gatekeeper accepts it. (Bare CLI Mach-O binaries can't
+        # be stapled; Gatekeeper verifies the notarization online on first run.)
+        if: ${{ runner.os == 'macOS' && vars.MACOS_SIGNING_ENABLED == 'true' }}
+        env:
+          APPLE_CERT_P12: ${{ secrets.APPLE_CERT_P12 }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          APPLE_DEVELOPER_ID: ${{ secrets.APPLE_DEVELOPER_ID }}
+          APPLE_NOTARY_KEY: ${{ secrets.APPLE_NOTARY_KEY }}
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_ISSUER: ${{ secrets.APPLE_NOTARY_ISSUER }}
+        run: |
+          set -euo pipefail
+          BIN="target/${{ matrix.target }}/dist/aasm"
+          KEYCHAIN="$RUNNER_TEMP/notary.keychain-db"
+          KEYCHAIN_PW="$(uuidgen)"
+          security create-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
+          printf '%s' "$APPLE_CERT_P12" | base64 --decode > "$RUNNER_TEMP/cert.p12"
+          security import "$RUNNER_TEMP/cert.p12" -k "$KEYCHAIN" -P "$APPLE_CERT_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PW" "$KEYCHAIN" >/dev/null
+          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+          codesign --force --options runtime --timestamp --sign "$APPLE_DEVELOPER_ID" "$BIN"
+          codesign --verify --strict --verbose=2 "$BIN"
+          ditto -c -k "$BIN" "$RUNNER_TEMP/aasm.zip"
+          printf '%s' "$APPLE_NOTARY_KEY" | base64 --decode > "$RUNNER_TEMP/notary_key.p8"
+          xcrun notarytool submit "$RUNNER_TEMP/aasm.zip" \
+            --key "$RUNNER_TEMP/notary_key.p8" \
+            --key-id "$APPLE_NOTARY_KEY_ID" \
+            --issuer "$APPLE_NOTARY_ISSUER" \
+            --wait
+          rm -f "$RUNNER_TEMP/cert.p12" "$RUNNER_TEMP/notary_key.p8" "$RUNNER_TEMP/aasm.zip"
+          security delete-keychain "$KEYCHAIN"
+
       - name: Archive binary
         shell: bash
         run: |
@@ -98,6 +137,7 @@ jobs:
     needs: build
     permissions:
       contents: write
+      id-token: write  # keyless cosign signing via GitHub OIDC
 
     steps:
       - name: Download all build artifacts
@@ -132,6 +172,26 @@ jobs:
           sha256sum aasm-*.tar.gz > SHA256SUMS
           cat SHA256SUMS
 
+      - name: Install cosign
+        if: github.event_name == 'push'
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+
+      - name: Sign SHA256SUMS with cosign (keyless)
+        if: github.event_name == 'push'
+        working-directory: artifacts
+        env:
+          COSIGN_YES: "true"
+        run: |
+          # Keyless signing via the workflow's GitHub OIDC token (Fulcio cert +
+          # Rekor transparency log). The self-contained bundle is what
+          # install-cli.sh verifies; the detached .sig/.pem are uploaded for
+          # manual / tooling convenience.
+          cosign sign-blob \
+            --bundle SHA256SUMS.cosign.bundle \
+            --output-signature SHA256SUMS.sig \
+            --output-certificate SHA256SUMS.pem \
+            SHA256SUMS
+
       - name: Upload assets to GitHub Release
         if: github.event_name == 'push'
         uses: softprops/action-gh-release@v3
@@ -139,6 +199,9 @@ jobs:
           files: |
             artifacts/aasm-*.tar.gz
             artifacts/SHA256SUMS
+            artifacts/SHA256SUMS.cosign.bundle
+            artifacts/SHA256SUMS.sig
+            artifacts/SHA256SUMS.pem
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,7 +384,7 @@ jobs:
       - name: Checkout homebrew-agent-assembly tap
         uses: actions/checkout@v6
         with:
-          repository: AI-agent-assembly/homebrew-agent-assembly
+          repository: ai-agent-assembly/homebrew-agent-assembly
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: tap
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -16,6 +16,7 @@
 
 # Usage
 
+- [Installation](installation.md)
 - [Command-Line Interface](cli.md)
 - [Dashboard](dashboard.md)
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -1,0 +1,58 @@
+# Installation
+
+## Quick install (Linux / macOS)
+
+```sh
+curl -fsSL https://tool.agent-assembly.dev | sh
+```
+
+This downloads the prebuilt `aasm` binary for your OS/architecture from the
+GitHub Release, **verifies its SHA-256 checksum and cosign signature**, and
+installs it to `~/.local/bin` (or `/usr/local/bin` if writable).
+
+Useful environment overrides:
+
+| Variable | Effect |
+|---|---|
+| `AASM_VERSION` | Install a specific release tag (default: latest) |
+| `AASM_INSTALL_DIR` | Install directory (default: `~/.local/bin`) |
+| `AASM_REQUIRE_SIGNATURE=1` | **Fail** the install unless the cosign signature is verified (requires `cosign` on PATH) |
+
+### Other channels
+
+```sh
+brew install ai-agent-assembly/tap/aasm     # Homebrew
+cargo install aa-cli                          # from crates.io
+```
+
+## Verifying the download (trust model)
+
+Every release publishes, alongside the binaries:
+
+- `SHA256SUMS` — checksums of every `aasm-*.tar.gz`.
+- `SHA256SUMS.cosign.bundle` / `.sig` / `.pem` — a **keyless cosign signature** of
+  `SHA256SUMS`, produced by the release workflow using GitHub OIDC (Sigstore
+  Fulcio certificate + Rekor transparency log — no long-lived signing key).
+
+The installer enforces **both**: it verifies the cosign signature on
+`SHA256SUMS` (when `cosign` is available, or always under
+`AASM_REQUIRE_SIGNATURE=1`), then verifies each tarball's SHA-256 against the
+now-trusted `SHA256SUMS`. Without `cosign` it warns and falls back to
+checksum-only (the checksum is always enforced).
+
+To verify manually:
+
+```sh
+cosign verify-blob \
+  --bundle SHA256SUMS.cosign.bundle \
+  --certificate-identity-regexp '^https://github.com/AI-agent-assembly/agent-assembly/\.github/workflows/release\.yml@refs/tags/v.*$' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  SHA256SUMS
+```
+
+A valid result means `SHA256SUMS` was signed by the agent-assembly release
+workflow at a tagged release — not by an attacker who swapped the file.
+
+On macOS, release binaries are Developer-ID-signed and notarized once the
+project's Apple credentials are provisioned, so Gatekeeper accepts them without
+a manual override.

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -45,7 +45,7 @@ To verify manually:
 ```sh
 cosign verify-blob \
   --bundle SHA256SUMS.cosign.bundle \
-  --certificate-identity-regexp '^https://github.com/AI-agent-assembly/agent-assembly/\.github/workflows/release\.yml@refs/tags/v.*$' \
+  --certificate-identity-regexp '^https://github.com/ai-agent-assembly/agent-assembly/\.github/workflows/release\.yml@refs/tags/v.*$' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   SHA256SUMS
 ```

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -204,4 +204,6 @@ main() {
   "${INSTALL_DIR}/${BINARY}" --version
 }
 
-main "$@"
+# Run the installer unless sourced for tests (bats sets AASM_LIB=1 to load the
+# functions without executing main).
+[ "${AASM_LIB:-0}" = "1" ] || main "$@"

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -92,6 +92,45 @@ sha256_verify() {
   say "SHA256 verified."
 }
 
+# ── cosign signature verification ─────────────────────────────────────────────
+
+# Expected signer: the agent-assembly release workflow, signed keyless via GitHub
+# OIDC (Fulcio cert + Rekor log). `(?i)` keeps the org/repo match case-insensitive.
+COSIGN_IDENTITY_RE='(?i)^https://github\.com/ai-agent-assembly/agent-assembly/\.github/workflows/release\.yml@refs/tags/v.*$'
+COSIGN_OIDC_ISSUER='https://token.actions.githubusercontent.com'
+
+verify_signature() {
+  # Verify <sums_file> against the cosign <bundle>. Honors AASM_REQUIRE_SIGNATURE:
+  # when 1, a missing cosign or missing bundle is fatal; otherwise it warns and
+  # falls back to checksum-only (the SHA-256 check below is always enforced).
+  sums_file="$1" bundle="$2"
+  require="${AASM_REQUIRE_SIGNATURE:-0}"
+
+  if [ ! -f "$bundle" ]; then
+    [ "$require" = "1" ] && err "AASM_REQUIRE_SIGNATURE=1 but this release has no cosign bundle."
+    warn "no cosign bundle for this release — skipping signature check (checksum still enforced)."
+    return 0
+  fi
+
+  if ! command -v cosign >/dev/null 2>&1; then
+    [ "$require" = "1" ] && err "AASM_REQUIRE_SIGNATURE=1 but cosign is not installed.
+  Install it: https://docs.sigstore.dev/cosign/system_config/installation/"
+    warn "cosign not installed — skipping signature verification (checksum still enforced)."
+    warn "For full supply-chain verification install cosign, or set AASM_REQUIRE_SIGNATURE=1."
+    return 0
+  fi
+
+  if cosign verify-blob \
+      --bundle "$bundle" \
+      --certificate-identity-regexp "$COSIGN_IDENTITY_RE" \
+      --certificate-oidc-issuer "$COSIGN_OIDC_ISSUER" \
+      "$sums_file" >/dev/null 2>&1; then
+    say "Cosign signature verified."
+  else
+    err "cosign signature verification FAILED for SHA256SUMS — refusing to install."
+  fi
+}
+
 # ── fetch latest release tag ──────────────────────────────────────────────────
 
 latest_release() {
@@ -121,6 +160,7 @@ main() {
   TARBALL="${BINARY}-${ARCH}-${OS}.tar.gz"
   URL="https://github.com/${REPO}/releases/download/${VERSION}/${TARBALL}"
   SUMS_URL="https://github.com/${REPO}/releases/download/${VERSION}/SHA256SUMS"
+  SIG_URL="https://github.com/${REPO}/releases/download/${VERSION}/SHA256SUMS.cosign.bundle"
 
   say "Installing ${BINARY} ${VERSION} (${ARCH}-${OS}) ..."
 
@@ -134,6 +174,11 @@ main() {
   curl -sSfL "$SUMS_URL" -o "${TMP}/SHA256SUMS" \
     || err "SHA256SUMS download failed: ${SUMS_URL}\n  Refusing to install without checksum verification."
 
+  # Best-effort fetch of the cosign bundle (releases before AAASM-2700 lack one).
+  curl -sSfL "$SIG_URL" -o "${TMP}/SHA256SUMS.cosign.bundle" 2>/dev/null || true
+
+  # Verify the signature on SHA256SUMS first, then the tarball checksum against it.
+  verify_signature "${TMP}/SHA256SUMS" "${TMP}/SHA256SUMS.cosign.bundle"
   sha256_verify "${TMP}/${TARBALL}" "${TMP}/SHA256SUMS"
 
   tar -C "$TMP" -xzf "${TMP}/${TARBALL}" "${BINARY}" \

--- a/tests/install_cli_sh.bats
+++ b/tests/install_cli_sh.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+# bats tests for scripts/install-cli.sh signature verification (AAASM-2700).
+# Run with: bats tests/install_cli_sh.bats
+# Source the installer with AASM_LIB=1 to load its functions without running main.
+
+INSTALL_CLI="$BATS_TEST_DIRNAME/../scripts/install-cli.sh"
+
+setup() {
+  STUB_DIR="$(mktemp -d)"   # empty dir → use as PATH to force a tool absent
+  TMPD="$(mktemp -d)"
+  : > "$TMPD/SHA256SUMS"
+}
+
+teardown() {
+  rm -rf "$STUB_DIR" "$TMPD"
+}
+
+@test "verify_signature: missing bundle warns and continues by default" {
+  AASM_LIB=1 . "$INSTALL_CLI"
+  run verify_signature "$TMPD/SHA256SUMS" "$TMPD/absent.bundle"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skipping signature check"* ]]
+}
+
+@test "verify_signature: missing bundle is fatal under AASM_REQUIRE_SIGNATURE=1" {
+  AASM_LIB=1 . "$INSTALL_CLI"
+  AASM_REQUIRE_SIGNATURE=1 run verify_signature "$TMPD/SHA256SUMS" "$TMPD/absent.bundle"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"no cosign bundle"* ]]
+}
+
+@test "verify_signature: bundle present but cosign absent is fatal when required" {
+  AASM_LIB=1 . "$INSTALL_CLI"
+  : > "$TMPD/present.bundle"
+  AASM_REQUIRE_SIGNATURE=1 PATH="$STUB_DIR" run verify_signature "$TMPD/SHA256SUMS" "$TMPD/present.bundle"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"cosign is not installed"* ]]
+}
+
+@test "verify_signature: bundle present, cosign absent, not required → warns and continues" {
+  AASM_LIB=1 . "$INSTALL_CLI"
+  : > "$TMPD/present.bundle"
+  PATH="$STUB_DIR" run verify_signature "$TMPD/SHA256SUMS" "$TMPD/present.bundle"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"cosign not installed"* ]]
+}


### PR DESCRIPTION
## Description

Implements **AAASM-2701** (under Story **AAASM-2700**) — makes the OSS install path a true **signed installer**. **Stacked on #987 (AAASM-2339)** — both touch `install-cli.sh`; base `master`, GitHub auto-collapses the diff once #987 merges.

**Changes:**
- **`release.yml` (publish):** cosign **keyless** `sign-blob` of `SHA256SUMS` via GitHub OIDC (`id-token: write` added) → uploads `SHA256SUMS.cosign.bundle` + `.sig` + `.pem` to the Release.
- **`release.yml` (build):** macOS `codesign` (Developer ID + hardened runtime) + `notarytool` scaffold, **gated on `vars.MACOS_SIGNING_ENABLED` + `secrets.APPLE_*`** — dormant/no-op until provisioned, so publishing is unchanged today.
- **`install-cli.sh`:** downloads the cosign bundle and `cosign verify-blob`s `SHA256SUMS` against the pinned release-workflow OIDC identity before trusting it for the checksum. Falls back to checksum-only when `cosign` is absent (always enforces the checksum); `AASM_REQUIRE_SIGNATURE=1` makes the signature mandatory. `main()` guarded so the functions are sourceable for tests.
- **`tests/install_cli_sh.bats`:** 4 cases over the signature-verification logic.
- **`docs/src/installation.md`:** install methods + the trust model (cosign identity, manual `verify-blob` command); registered in `SUMMARY.md` (mdBook builds clean).

## Type of Change

- [x] 🔒 Security / supply-chain
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No (no publishing-behaviour change without the Apple secrets; installer stays usable without cosign)

## Related Issues

- Closes AAASM-2701 (Story AAASM-2700, Epic AAASM-2225). Depends on #987 (AAASM-2339).

## Testing

- [x] `release.yml` YAML-valid (id-token + cosign steps + notarization step asserted). `install-cli.sh` `sh -n` clean; `verify_signature` loads via `AASM_LIB=1` (main not run). mdBook builds; `installation.html` renders. bats cases authored (bats not on this box; they run the pure verify logic — no network).

## Checklist

- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention
