### PR TITLE
[AAASM-2718] 🔧 (agent-assembly): Use canonical lowercase org ID ai-agent-assembly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,7 +264,7 @@ jobs:
       - name: Checkout sibling node-sdk (for e2e_sdk_node fixtures)
         uses: actions/checkout@v6
         with:
-          repository: AI-agent-assembly/node-sdk
+          repository: ai-agent-assembly/node-sdk
           path: node-sdk
       - name: Install protobuf compiler
         run: sudo apt-get install -y protobuf-compiler
@@ -378,7 +378,7 @@ jobs:
       - name: Checkout sibling node-sdk (for e2e_sdk_node fixtures)
         uses: actions/checkout@v6
         with:
-          repository: AI-agent-assembly/node-sdk
+          repository: ai-agent-assembly/node-sdk
           path: node-sdk
       - name: Install protobuf compiler
         run: sudo apt-get install -y protobuf-compiler
@@ -466,7 +466,7 @@ jobs:
         with:
           files: ./codecov.xml
           name: Rust unit tests
-          slug: AI-agent-assembly/agent-assembly
+          slug: ai-agent-assembly/agent-assembly
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unit
           verbose: true

--- a/.github/workflows/dev-verify.yml
+++ b/.github/workflows/dev-verify.yml
@@ -44,9 +44,9 @@ jobs:
         # sdk-repos.txt lists SSH URLs; CI uses HTTPS equivalents.
         run: |
           parent="$(dirname "$GITHUB_WORKSPACE")"
-          git clone https://github.com/AI-agent-assembly/python-sdk.git "$parent/python-sdk"
-          git clone https://github.com/AI-agent-assembly/node-sdk.git "$parent/node-sdk"
-          git clone https://github.com/AI-agent-assembly/go-sdk.git "$parent/go-sdk"
+          git clone https://github.com/ai-agent-assembly/python-sdk.git "$parent/python-sdk"
+          git clone https://github.com/ai-agent-assembly/node-sdk.git "$parent/node-sdk"
+          git clone https://github.com/ai-agent-assembly/go-sdk.git "$parent/go-sdk"
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Docker
 permissions:
   contents: read
 
-# Prerequisite: the AI-agent-assembly org must have
+# Prerequisite: the ai-agent-assembly org must have
 # Actions → Settings → Actions → Workflow permissions → "Read and write permissions" enabled.
 # Without this, the GHCR publish step (on tag push) will fail with HTTP 403.
 
@@ -78,9 +78,9 @@ jobs:
             {"lang":"python","version":"3.14-slim","dockerfile":"docker/Dockerfile.python-3.14-slim","smoke_run":"python -c \"from agent_assembly import init_assembly\"","is_latest":true},
             {"lang":"python","version":"3.13-slim","dockerfile":"docker/Dockerfile.python-3.13-slim","smoke_run":"python -c \"from agent_assembly import init_assembly\""},
             {"lang":"python","version":"3.12-slim","dockerfile":"docker/Dockerfile.python-3.12-slim","smoke_run":"python -c \"from agent_assembly import init_assembly\""},
-            {"lang":"go","version":"1.26-alpine","dockerfile":"docker/Dockerfile.go-1.26-alpine","smoke_run":"go list -m github.com/AI-agent-assembly/go-sdk@latest","is_latest":true},
-            {"lang":"go","version":"1.25-alpine","dockerfile":"docker/Dockerfile.go-1.25-alpine","smoke_run":"go list -m github.com/AI-agent-assembly/go-sdk@latest"},
-            {"lang":"go","version":"1.24-alpine","dockerfile":"docker/Dockerfile.go-1.24-alpine","smoke_run":"go list -m github.com/AI-agent-assembly/go-sdk@latest"}
+            {"lang":"go","version":"1.26-alpine","dockerfile":"docker/Dockerfile.go-1.26-alpine","smoke_run":"go list -m github.com/ai-agent-assembly/go-sdk@latest","is_latest":true},
+            {"lang":"go","version":"1.25-alpine","dockerfile":"docker/Dockerfile.go-1.25-alpine","smoke_run":"go list -m github.com/ai-agent-assembly/go-sdk@latest"},
+            {"lang":"go","version":"1.24-alpine","dockerfile":"docker/Dockerfile.go-1.24-alpine","smoke_run":"go list -m github.com/ai-agent-assembly/go-sdk@latest"}
           ]'
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             sel=$(printf '%s' "$full" | jq -c '[.[] | select(.is_latest == true)]')

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -59,19 +59,19 @@ jobs:
       - name: Checkout sibling python-sdk
         uses: actions/checkout@v6
         with:
-          repository: AI-agent-assembly/python-sdk
+          repository: ai-agent-assembly/python-sdk
           path: python-sdk
 
       - name: Checkout sibling go-sdk
         uses: actions/checkout@v6
         with:
-          repository: AI-agent-assembly/go-sdk
+          repository: ai-agent-assembly/go-sdk
           path: go-sdk
 
       - name: Checkout sibling node-sdk
         uses: actions/checkout@v6
         with:
-          repository: AI-agent-assembly/node-sdk
+          repository: ai-agent-assembly/node-sdk
           path: node-sdk
 
       - name: Install protobuf compiler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ docker pull ghcr.io/ai-agent-assembly/python:3.14-slim
 # Language SDKs
 pip install --pre agent-assembly==0.0.1a5
 npm install @agent-assembly/sdk@0.0.1-alpha.5
-go get github.com/AI-agent-assembly/go-sdk@v0.0.1-alpha.5
+go get github.com/ai-agent-assembly/go-sdk@v0.0.1-alpha.5
 ```
 
 ### Behaviour delta on the crates.io `aasm` binary
@@ -158,7 +158,7 @@ brew install ai-agent-assembly/homebrew-agent-assembly/aasm
 docker pull ghcr.io/ai-agent-assembly/aa-runtime:v0.0.1-alpha.4
 pip install --pre agent-assembly==0.0.1a4
 npm install @agent-assembly/sdk@0.0.1-alpha.4
-go get github.com/AI-agent-assembly/go-sdk@v0.0.1-alpha.4
+go get github.com/ai-agent-assembly/go-sdk@v0.0.1-alpha.4
 ```
 
 ### Behaviour delta on the published `aasm` binary
@@ -305,4 +305,4 @@ version (or skip pre-releases entirely):
 For the GA release scope, see the upcoming [0.0.1] entry, which will be authored
 under AAASM-1247 once the alpha-1 dry-run passes and the GA tag is cut.
 
-[0.0.1-alpha.1]: https://github.com/AI-agent-assembly/agent-assembly/releases/tag/v0.0.1-alpha.1
+[0.0.1-alpha.1]: https://github.com/ai-agent-assembly/agent-assembly/releases/tag/v0.0.1-alpha.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thank you for your interest in contributing! This guide explains how to set up y
 ## Setup
 
 ```bash
-git clone https://github.com/AI-agent-assembly/agent-assembly.git
+git clone https://github.com/ai-agent-assembly/agent-assembly.git
 cd agent-assembly
 
 # Install git hooks (runs fmt, clippy, deny on commit; doc on push)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ resolver = "2"
 version = "0.0.1-alpha.5"
 edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/AI-agent-assembly/agent-assembly"
-homepage = "https://github.com/AI-agent-assembly/agent-assembly"
+repository = "https://github.com/ai-agent-assembly/agent-assembly"
+homepage = "https://github.com/ai-agent-assembly/agent-assembly"
 authors = ["Agent Assembly Contributors"]
 
 # Single source of version truth for third-party crates shared by two or more

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 > Governance-native runtime for AI agents — open-source core.
 
-[![CI](https://github.com/AI-agent-assembly/agent-assembly/actions/workflows/ci.yml/badge.svg)](https://github.com/AI-agent-assembly/agent-assembly/actions/workflows/ci.yml)
-[![Docs](https://github.com/AI-agent-assembly/agent-assembly/actions/workflows/docs.yml/badge.svg)](https://github.com/AI-agent-assembly/agent-assembly/actions/workflows/docs.yml)
-[![codecov](https://codecov.io/gh/AI-agent-assembly/agent-assembly/branch/master/graph/badge.svg)](https://codecov.io/gh/AI-agent-assembly/agent-assembly)
+[![CI](https://github.com/ai-agent-assembly/agent-assembly/actions/workflows/ci.yml/badge.svg)](https://github.com/ai-agent-assembly/agent-assembly/actions/workflows/ci.yml)
+[![Docs](https://github.com/ai-agent-assembly/agent-assembly/actions/workflows/docs.yml/badge.svg)](https://github.com/ai-agent-assembly/agent-assembly/actions/workflows/docs.yml)
+[![codecov](https://codecov.io/gh/ai-agent-assembly/agent-assembly/branch/master/graph/badge.svg)](https://codecov.io/gh/ai-agent-assembly/agent-assembly)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Release](https://img.shields.io/github/v/release/AI-agent-assembly/agent-assembly?include_prereleases&sort=semver)](https://github.com/AI-agent-assembly/agent-assembly/releases)
+[![Release](https://img.shields.io/github/v/release/ai-agent-assembly/agent-assembly?include_prereleases&sort=semver)](https://github.com/ai-agent-assembly/agent-assembly/releases)
 
 
 ## Install the CLI
@@ -16,7 +16,7 @@ curl -sSf https://install.ai-agent-assembly.dev | sh
 ```
 
 This downloads and installs the `aasm` binary to `~/.local/bin`. Requires a
-[published release](https://github.com/AI-agent-assembly/agent-assembly/releases).
+[published release](https://github.com/ai-agent-assembly/agent-assembly/releases).
 The installer script lives at [`scripts/install-cli.sh`](scripts/install-cli.sh).
 
 ```sh
@@ -34,7 +34,7 @@ brew install ai-agent-assembly/homebrew-agent-assembly/aasm
 ```
 
 Installs the latest tagged `aasm` release from the
-[Homebrew tap](https://github.com/AI-agent-assembly/homebrew-agent-assembly).
+[Homebrew tap](https://github.com/ai-agent-assembly/homebrew-agent-assembly).
 During the `v0.0.1` alpha series the published releases are pre-releases — see
 [Project Status](#project-status).
 
@@ -53,10 +53,10 @@ can move from this repo to the SDKs, the install tap, or the canonical docs.
 | Repository | Role | Status |
 |---|---|---|
 | **agent-assembly** (this repo) | Core runtime — gateway, policy engine, eBPF / proxy / SDK interception | Public · Alpha |
-| [python-sdk](https://github.com/AI-agent-assembly/python-sdk) | Python SDK (PyO3 native + pure-Python client) | Public · Alpha |
-| [node-sdk](https://github.com/AI-agent-assembly/node-sdk) | TypeScript / Node.js SDK (napi-rs native + JS client) | Public · Alpha |
-| [go-sdk](https://github.com/AI-agent-assembly/go-sdk) | Go SDK | Public · Alpha |
-| [homebrew-agent-assembly](https://github.com/AI-agent-assembly/homebrew-agent-assembly) | Homebrew tap for the `aasm` CLI | Public |
+| [python-sdk](https://github.com/ai-agent-assembly/python-sdk) | Python SDK (PyO3 native + pure-Python client) | Public · Alpha |
+| [node-sdk](https://github.com/ai-agent-assembly/node-sdk) | TypeScript / Node.js SDK (napi-rs native + JS client) | Public · Alpha |
+| [go-sdk](https://github.com/ai-agent-assembly/go-sdk) | Go SDK | Public · Alpha |
+| [homebrew-agent-assembly](https://github.com/ai-agent-assembly/homebrew-agent-assembly) | Homebrew tap for the `aasm` CLI | Public |
 | [agent-assembly-docs](https://ai-agent-assembly.github.io/agent-assembly-docs/) | Canonical documentation site | Public |
 | agent-assembly-cloud | Hosted SaaS control plane | Private · in development |
 | agent-assembly-enterprise | Enterprise extensions (delivered via SaaS) | Private · in development |
@@ -101,7 +101,7 @@ These two are built by `aa-ebpf/build.rs` (via `aya-build`) for the BPF target �
 public API and wire protocol are **not** stable; do not use in production.
 
 Releases are published as GitHub pre-releases — latest
-[`v0.0.1-alpha.5`](https://github.com/AI-agent-assembly/agent-assembly/releases/tag/v0.0.1-alpha.5)
+[`v0.0.1-alpha.5`](https://github.com/ai-agent-assembly/agent-assembly/releases/tag/v0.0.1-alpha.5)
 (2026-06-03). The coordinated release tag also publishes the CLI, crates, SDK
 packages, and container image:
 
@@ -147,7 +147,7 @@ requirements.
 
 > **Demo recording:** `asciinema play docs/quickstart.cast`
 >
-> **Prefer Codespaces?** [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/AI-agent-assembly/agent-assembly)
+> **Prefer Codespaces?** [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/ai-agent-assembly/agent-assembly)
 > The `.devcontainer/` config installs all dependencies automatically.
 
 Get from a fresh clone to a verified local environment in under 10 minutes.
@@ -155,7 +155,7 @@ Get from a fresh clone to a verified local environment in under 10 minutes.
 ### 1. Clone the repository
 
 ```bash
-git clone https://github.com/AI-agent-assembly/agent-assembly.git
+git clone https://github.com/ai-agent-assembly/agent-assembly.git
 cd agent-assembly
 ```
 
@@ -298,7 +298,7 @@ mdbook serve docs --open
 ## Security & Support
 
 - **Security:** Report vulnerabilities **privately** via
-  [GitHub Security Advisories](https://github.com/AI-agent-assembly/agent-assembly/security)
+  [GitHub Security Advisories](https://github.com/ai-agent-assembly/agent-assembly/security)
   or email `security@agent-assembly.dev`. Please do not open public issues for
   security reports. See [`SECURITY.md`](SECURITY.md) for the disclosure policy
   and response SLA.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@
 
 To report a security issue, use GitHub's private vulnerability reporting:
 
-1. Go to the [Security tab](https://github.com/AI-agent-assembly/agent-assembly/security) of this repository.
+1. Go to the [Security tab](https://github.com/ai-agent-assembly/agent-assembly/security) of this repository.
 2. Click **"Report a vulnerability"**.
 3. Fill in the details and submit.
 

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -31,7 +31,7 @@ use crate::routes::{
         version = "0.0.1",
         description = "REST API for the Agent Assembly governance gateway.\n\nThis spec is auto-generated from `aa-api` route annotations via `utoipa`. CI fails if the generated spec drifts from the committed `openapi/v1.yaml`.",
         license(name = "Apache 2.0", url = "https://www.apache.org/licenses/LICENSE-2.0.html"),
-        contact(name = "Agent Assembly Contributors", url = "https://github.com/AI-agent-assembly/agent-assembly")
+        contact(name = "Agent Assembly Contributors", url = "https://github.com/ai-agent-assembly/agent-assembly")
     ),
     servers(
         (url = "http://localhost:7700", description = "Local development gateway")

--- a/aa-ebpf-programs/Cargo.toml
+++ b/aa-ebpf-programs/Cargo.toml
@@ -3,7 +3,7 @@ name = "aa-ebpf-programs"
 version = "0.0.1"
 edition = "2021"
 license = "Apache-2.0"
-repository = "https://github.com/AI-agent-assembly/agent-assembly"
+repository = "https://github.com/ai-agent-assembly/agent-assembly"
 description = "eBPF kernel-space programs for Agent Assembly — compiled for the bpf target"
 publish = false
 

--- a/aa-integration-tests/tests/common/node_sdk.rs
+++ b/aa-integration-tests/tests/common/node_sdk.rs
@@ -1,5 +1,5 @@
 //! Sibling-repo lookup helpers for the Node.js SDK
-//! (`AI-agent-assembly/node-sdk`).
+//! (`ai-agent-assembly/node-sdk`).
 //!
 //! The TypeScript fixtures under
 //! `aa-integration-tests/tests/fixtures/agents/typescript/` resolve
@@ -31,7 +31,7 @@ use anyhow::{anyhow, Context, Result};
 /// Order:
 /// 1. `NODE_SDK_PATH` env var (absolute or relative).
 /// 2. `<parent of CARGO_MANIFEST_DIR>/../node-sdk` — the layout used
-///    by the workspace (`AI-agent-assembly/{agent-assembly,node-sdk}/`).
+///    by the workspace (`ai-agent-assembly/{agent-assembly,node-sdk}/`).
 pub fn node_sdk_dir() -> Result<PathBuf> {
     if let Ok(p) = std::env::var("NODE_SDK_PATH") {
         let path = PathBuf::from(p);

--- a/aa-integration-tests/tests/e2e_sdk_runtime_lifecycle.rs
+++ b/aa-integration-tests/tests/e2e_sdk_runtime_lifecycle.rs
@@ -178,7 +178,7 @@ fn probe_go_dir() -> PathBuf {
 /// overwrites any existing directive for the same module.
 fn refresh_go_replace_directive() -> bool {
     let arg = format!(
-        "-replace=github.com/AI-agent-assembly/go-sdk={}",
+        "-replace=github.com/ai-agent-assembly/go-sdk={}",
         go_sdk_path().display()
     );
     Command::new("go")

--- a/aa-integration-tests/tests/fixtures/agents/python/pyproject.toml
+++ b/aa-integration-tests/tests/fixtures/agents/python/pyproject.toml
@@ -28,7 +28,7 @@ default-groups = []
 
 [tool.uv.sources]
 # Mode 1: Local sibling checkout (PRIMARY — default for CI + local dev side-by-side)
-# Local dev:  6 levels up from fixtures/agents/python/ = AI-agent-assembly/python-sdk/
+# Local dev:  6 levels up from fixtures/agents/python/ = ai-agent-assembly/python-sdk/
 # CI:  sibling-repo checkout via actions/checkout@v4 (path: python-sdk)
 agent-assembly = { path = "../../../../../../python-sdk", editable = true }
 
@@ -36,10 +36,10 @@ agent-assembly = { path = "../../../../../../python-sdk", editable = true }
 # Uncomment one of these and comment out Mode 1:
 #
 # Latest master:
-# agent-assembly = { git = "https://github.com/AI-agent-assembly/python-sdk.git", branch = "master" }
+# agent-assembly = { git = "https://github.com/ai-agent-assembly/python-sdk.git", branch = "master" }
 #
 # Pinned commit (preferred for reproducibility):
-# agent-assembly = { git = "https://github.com/AI-agent-assembly/python-sdk.git", rev = "COMMIT_SHA" }
+# agent-assembly = { git = "https://github.com/ai-agent-assembly/python-sdk.git", rev = "COMMIT_SHA" }
 
 # Mode 3: PyPI version pin (future — once SDK is published to PyPI)
 # agent-assembly = ">=0.0.1,<1.0"

--- a/aa-integration-tests/tests/fixtures/f115/probe_go/go.mod
+++ b/aa-integration-tests/tests/fixtures/f115/probe_go/go.mod
@@ -2,7 +2,7 @@ module probe_go
 
 go 1.26.0
 
-require github.com/AI-agent-assembly/go-sdk v0.0.0
+require github.com/ai-agent-assembly/go-sdk v0.0.0
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -17,4 +17,4 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 )
 
-replace github.com/AI-agent-assembly/go-sdk => /tmp/aa-go-sdk-for-test
+replace github.com/ai-agent-assembly/go-sdk => /tmp/aa-go-sdk-for-test

--- a/aa-integration-tests/tests/fixtures/f115/probe_go/main.go
+++ b/aa-integration-tests/tests/fixtures/f115/probe_go/main.go
@@ -16,7 +16,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/AI-agent-assembly/go-sdk/assembly"
+	"github.com/ai-agent-assembly/go-sdk/assembly"
 )
 
 func main() {

--- a/aa-proxy/Dockerfile
+++ b/aa-proxy/Dockerfile
@@ -34,7 +34,7 @@ FROM gcr.io/distroless/static:nonroot AS runtime
 
 COPY --from=builder /app/aa-proxy-bin /aa-proxy
 
-LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+LABEL org.opencontainers.image.source="https://github.com/ai-agent-assembly/agent-assembly" \
       org.opencontainers.image.description="aa-proxy sidecar — AAASM traffic interception proxy" \
       org.opencontainers.image.licenses="Apache-2.0"
 

--- a/aa-runtime/Dockerfile
+++ b/aa-runtime/Dockerfile
@@ -57,7 +57,7 @@ FROM gcr.io/distroless/static:nonroot AS runtime
 
 COPY --from=builder /app/aa-runtime /aa-runtime
 
-LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+LABEL org.opencontainers.image.source="https://github.com/ai-agent-assembly/agent-assembly" \
       org.opencontainers.image.description="aa-runtime sidecar — AI agent assembly runtime" \
       org.opencontainers.image.licenses="Apache-2.0"
 

--- a/docker/Dockerfile.go-1.24-alpine
+++ b/docker/Dockerfile.go-1.24-alpine
@@ -69,7 +69,14 @@ ENV GOTOOLCHAIN=auto
 
 # Install the AAASM Go SDK. `go install` uses Go's native git-based
 # distribution model — no registry-publish prerequisite (unlike pip/npm).
-RUN go install github.com/ai-agent-assembly/go-sdk/...@latest
+#
+# NOTE: this go-sdk module path stays mixed-case `AI-agent-assembly` (not the
+# canonical lowercase org ID) on purpose. `@latest` resolves to the published
+# go-sdk tag whose go.mod declares `module github.com/AI-agent-assembly/go-sdk`,
+# and Go enforces a case-sensitive module-path match — lowercasing it breaks the
+# image build until go-sdk publishes a lowercase-module-path tag (AAASM-2729,
+# Epic AAASM-2715).
+RUN go install github.com/AI-agent-assembly/go-sdk/...@latest
 
 # Build-time smoke tests — fail the image build (not a runtime surprise)
 # if either side of the install ends up broken.
@@ -81,7 +88,7 @@ RUN go install github.com/ai-agent-assembly/go-sdk/...@latest
 # (go-sdk's module root has no .go files; sources are under assembly/,
 # internal/ffi/, examples/minimal/). See AAASM-1508.
 RUN aasm --version
-RUN go list -m github.com/ai-agent-assembly/go-sdk@latest
+RUN go list -m github.com/AI-agent-assembly/go-sdk@latest
 
 LABEL org.opencontainers.image.source="https://github.com/ai-agent-assembly/agent-assembly" \
       org.opencontainers.image.description="AAASM governed Go 1.24 agent base image" \

--- a/docker/Dockerfile.go-1.24-alpine
+++ b/docker/Dockerfile.go-1.24-alpine
@@ -69,7 +69,7 @@ ENV GOTOOLCHAIN=auto
 
 # Install the AAASM Go SDK. `go install` uses Go's native git-based
 # distribution model — no registry-publish prerequisite (unlike pip/npm).
-RUN go install github.com/AI-agent-assembly/go-sdk/...@latest
+RUN go install github.com/ai-agent-assembly/go-sdk/...@latest
 
 # Build-time smoke tests — fail the image build (not a runtime surprise)
 # if either side of the install ends up broken.
@@ -81,8 +81,8 @@ RUN go install github.com/AI-agent-assembly/go-sdk/...@latest
 # (go-sdk's module root has no .go files; sources are under assembly/,
 # internal/ffi/, examples/minimal/). See AAASM-1508.
 RUN aasm --version
-RUN go list -m github.com/AI-agent-assembly/go-sdk@latest
+RUN go list -m github.com/ai-agent-assembly/go-sdk@latest
 
-LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+LABEL org.opencontainers.image.source="https://github.com/ai-agent-assembly/agent-assembly" \
       org.opencontainers.image.description="AAASM governed Go 1.24 agent base image" \
       org.opencontainers.image.licenses="Apache-2.0"

--- a/docker/Dockerfile.go-1.25-alpine
+++ b/docker/Dockerfile.go-1.25-alpine
@@ -69,7 +69,7 @@ ENV GOTOOLCHAIN=auto
 
 # Install the AAASM Go SDK. `go install` uses Go's native git-based
 # distribution model — no registry-publish prerequisite (unlike pip/npm).
-RUN go install github.com/AI-agent-assembly/go-sdk/...@latest
+RUN go install github.com/ai-agent-assembly/go-sdk/...@latest
 
 # Build-time smoke tests — fail the image build (not a runtime surprise)
 # if either side of the install ends up broken.
@@ -81,8 +81,8 @@ RUN go install github.com/AI-agent-assembly/go-sdk/...@latest
 # (go-sdk's module root has no .go files; sources are under assembly/,
 # internal/ffi/, examples/minimal/). See AAASM-1508.
 RUN aasm --version
-RUN go list -m github.com/AI-agent-assembly/go-sdk@latest
+RUN go list -m github.com/ai-agent-assembly/go-sdk@latest
 
-LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+LABEL org.opencontainers.image.source="https://github.com/ai-agent-assembly/agent-assembly" \
       org.opencontainers.image.description="AAASM governed Go 1.25 agent base image" \
       org.opencontainers.image.licenses="Apache-2.0"

--- a/docker/Dockerfile.go-1.25-alpine
+++ b/docker/Dockerfile.go-1.25-alpine
@@ -69,7 +69,14 @@ ENV GOTOOLCHAIN=auto
 
 # Install the AAASM Go SDK. `go install` uses Go's native git-based
 # distribution model — no registry-publish prerequisite (unlike pip/npm).
-RUN go install github.com/ai-agent-assembly/go-sdk/...@latest
+#
+# NOTE: this go-sdk module path stays mixed-case `AI-agent-assembly` (not the
+# canonical lowercase org ID) on purpose. `@latest` resolves to the published
+# go-sdk tag whose go.mod declares `module github.com/AI-agent-assembly/go-sdk`,
+# and Go enforces a case-sensitive module-path match — lowercasing it breaks the
+# image build until go-sdk publishes a lowercase-module-path tag (AAASM-2729,
+# Epic AAASM-2715).
+RUN go install github.com/AI-agent-assembly/go-sdk/...@latest
 
 # Build-time smoke tests — fail the image build (not a runtime surprise)
 # if either side of the install ends up broken.
@@ -81,7 +88,7 @@ RUN go install github.com/ai-agent-assembly/go-sdk/...@latest
 # (go-sdk's module root has no .go files; sources are under assembly/,
 # internal/ffi/, examples/minimal/). See AAASM-1508.
 RUN aasm --version
-RUN go list -m github.com/ai-agent-assembly/go-sdk@latest
+RUN go list -m github.com/AI-agent-assembly/go-sdk@latest
 
 LABEL org.opencontainers.image.source="https://github.com/ai-agent-assembly/agent-assembly" \
       org.opencontainers.image.description="AAASM governed Go 1.25 agent base image" \

--- a/docker/Dockerfile.go-1.26-alpine
+++ b/docker/Dockerfile.go-1.26-alpine
@@ -62,7 +62,7 @@ COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
 
 # Install the AAASM Go SDK. `go install` uses Go's native git-based
 # distribution model — no registry-publish prerequisite (unlike pip/npm).
-RUN go install github.com/AI-agent-assembly/go-sdk/...@latest
+RUN go install github.com/ai-agent-assembly/go-sdk/...@latest
 
 # Build-time smoke tests — fail the image build (not a runtime surprise)
 # if either side of the install ends up broken.
@@ -74,8 +74,8 @@ RUN go install github.com/AI-agent-assembly/go-sdk/...@latest
 # (go-sdk's module root has no .go files; sources are under assembly/,
 # internal/ffi/, examples/minimal/). See AAASM-1508.
 RUN aasm --version
-RUN go list -m github.com/AI-agent-assembly/go-sdk@latest
+RUN go list -m github.com/ai-agent-assembly/go-sdk@latest
 
-LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+LABEL org.opencontainers.image.source="https://github.com/ai-agent-assembly/agent-assembly" \
       org.opencontainers.image.description="AAASM governed Go 1.26 agent base image" \
       org.opencontainers.image.licenses="Apache-2.0"

--- a/docker/Dockerfile.go-1.26-alpine
+++ b/docker/Dockerfile.go-1.26-alpine
@@ -62,7 +62,14 @@ COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
 
 # Install the AAASM Go SDK. `go install` uses Go's native git-based
 # distribution model — no registry-publish prerequisite (unlike pip/npm).
-RUN go install github.com/ai-agent-assembly/go-sdk/...@latest
+#
+# NOTE: this go-sdk module path stays mixed-case `AI-agent-assembly` (not the
+# canonical lowercase org ID) on purpose. `@latest` resolves to the published
+# go-sdk tag whose go.mod declares `module github.com/AI-agent-assembly/go-sdk`,
+# and Go enforces a case-sensitive module-path match — lowercasing it breaks the
+# image build until go-sdk publishes a lowercase-module-path tag (AAASM-2729,
+# Epic AAASM-2715).
+RUN go install github.com/AI-agent-assembly/go-sdk/...@latest
 
 # Build-time smoke tests — fail the image build (not a runtime surprise)
 # if either side of the install ends up broken.
@@ -74,7 +81,7 @@ RUN go install github.com/ai-agent-assembly/go-sdk/...@latest
 # (go-sdk's module root has no .go files; sources are under assembly/,
 # internal/ffi/, examples/minimal/). See AAASM-1508.
 RUN aasm --version
-RUN go list -m github.com/ai-agent-assembly/go-sdk@latest
+RUN go list -m github.com/AI-agent-assembly/go-sdk@latest
 
 LABEL org.opencontainers.image.source="https://github.com/ai-agent-assembly/agent-assembly" \
       org.opencontainers.image.description="AAASM governed Go 1.26 agent base image" \

--- a/docker/Dockerfile.node-20-slim
+++ b/docker/Dockerfile.node-20-slim
@@ -53,7 +53,7 @@ COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
 
 # Install the AAASM Node SDK. Transitional git source; switches to
 # `npm install @agent-assembly/sdk` once AAASM-1203 lands.
-RUN npm install -g 'github:AI-agent-assembly/node-sdk'
+RUN npm install -g 'github:ai-agent-assembly/node-sdk'
 
 # Build-time smoke tests — fail the image build (not a runtime surprise)
 # if either side of the install ends up broken.
@@ -65,6 +65,6 @@ RUN apt-get purge -y git \
  && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/*
 
-LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+LABEL org.opencontainers.image.source="https://github.com/ai-agent-assembly/agent-assembly" \
       org.opencontainers.image.description="AAASM governed Node.js 20 agent base image" \
       org.opencontainers.image.licenses="Apache-2.0"

--- a/docker/Dockerfile.node-22-slim
+++ b/docker/Dockerfile.node-22-slim
@@ -53,7 +53,7 @@ COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
 
 # Install the AAASM Node SDK. Transitional git source; switches to
 # `npm install @agent-assembly/sdk` once AAASM-1203 lands.
-RUN npm install -g 'github:AI-agent-assembly/node-sdk'
+RUN npm install -g 'github:ai-agent-assembly/node-sdk'
 
 # Build-time smoke tests — fail the image build (not a runtime surprise)
 # if either side of the install ends up broken.
@@ -65,6 +65,6 @@ RUN apt-get purge -y git \
  && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/*
 
-LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+LABEL org.opencontainers.image.source="https://github.com/ai-agent-assembly/agent-assembly" \
       org.opencontainers.image.description="AAASM governed Node.js 22 agent base image" \
       org.opencontainers.image.licenses="Apache-2.0"

--- a/docker/Dockerfile.node-24-slim
+++ b/docker/Dockerfile.node-24-slim
@@ -53,7 +53,7 @@ COPY --from=aasm-builder /usr/local/bin/aasm /usr/local/bin/aasm
 
 # Install the AAASM Node SDK. Transitional git source; switches to
 # `npm install @agent-assembly/sdk` once AAASM-1203 lands.
-RUN npm install -g 'github:AI-agent-assembly/node-sdk'
+RUN npm install -g 'github:ai-agent-assembly/node-sdk'
 
 # Build-time smoke tests — fail the image build (not a runtime surprise)
 # if either side of the install ends up broken.
@@ -65,6 +65,6 @@ RUN apt-get purge -y git \
  && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/*
 
-LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+LABEL org.opencontainers.image.source="https://github.com/ai-agent-assembly/agent-assembly" \
       org.opencontainers.image.description="AAASM governed Node.js 24 agent base image" \
       org.opencontainers.image.licenses="Apache-2.0"

--- a/docker/Dockerfile.python-3.12-slim
+++ b/docker/Dockerfile.python-3.12-slim
@@ -65,7 +65,7 @@ RUN apt-get update \
 # needs to invoke). See AAASM-1500. Transitional git source; switches to
 # `pip install agent-assembly` once AAASM-1202 lands.
 RUN pip install --no-cache-dir \
-        'agent-assembly @ git+https://github.com/AI-agent-assembly/python-sdk.git'
+        'agent-assembly @ git+https://github.com/ai-agent-assembly/python-sdk.git'
 
 # Drop the prebuilt Rust `aasm` binary into the image PATH, overlaying the
 # pip-installed Python entrypoint. The Python SDK stays importable from
@@ -83,6 +83,6 @@ RUN apt-get purge -y git \
  && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/*
 
-LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+LABEL org.opencontainers.image.source="https://github.com/ai-agent-assembly/agent-assembly" \
       org.opencontainers.image.description="AAASM governed Python 3.12 agent base image" \
       org.opencontainers.image.licenses="Apache-2.0"

--- a/docker/Dockerfile.python-3.13-slim
+++ b/docker/Dockerfile.python-3.13-slim
@@ -65,7 +65,7 @@ RUN apt-get update \
 # needs to invoke). See AAASM-1500. Transitional git source; switches to
 # `pip install agent-assembly` once AAASM-1202 lands.
 RUN pip install --no-cache-dir \
-        'agent-assembly @ git+https://github.com/AI-agent-assembly/python-sdk.git'
+        'agent-assembly @ git+https://github.com/ai-agent-assembly/python-sdk.git'
 
 # Drop the prebuilt Rust `aasm` binary into the image PATH, overlaying the
 # pip-installed Python entrypoint. The Python SDK stays importable from
@@ -83,6 +83,6 @@ RUN apt-get purge -y git \
  && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/*
 
-LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+LABEL org.opencontainers.image.source="https://github.com/ai-agent-assembly/agent-assembly" \
       org.opencontainers.image.description="AAASM governed Python 3.13 agent base image" \
       org.opencontainers.image.licenses="Apache-2.0"

--- a/docker/Dockerfile.python-3.14-slim
+++ b/docker/Dockerfile.python-3.14-slim
@@ -65,7 +65,7 @@ RUN apt-get update \
 # needs to invoke). See AAASM-1500. Transitional git source; switches to
 # `pip install agent-assembly` once AAASM-1202 lands.
 RUN pip install --no-cache-dir \
-        'agent-assembly @ git+https://github.com/AI-agent-assembly/python-sdk.git'
+        'agent-assembly @ git+https://github.com/ai-agent-assembly/python-sdk.git'
 
 # Drop the prebuilt Rust `aasm` binary into the image PATH, overlaying the
 # pip-installed Python entrypoint. The Python SDK stays importable from
@@ -83,6 +83,6 @@ RUN apt-get purge -y git \
  && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/*
 
-LABEL org.opencontainers.image.source="https://github.com/AI-agent-assembly/agent-assembly" \
+LABEL org.opencontainers.image.source="https://github.com/ai-agent-assembly/agent-assembly" \
       org.opencontainers.image.description="AAASM governed Python 3.14 agent base image" \
       org.opencontainers.image.licenses="Apache-2.0"

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -8,8 +8,8 @@ src = "src"
 [output.html]
 default-theme = "rust"
 preferred-dark-theme = "navy"
-git-repository-url = "https://github.com/AI-agent-assembly/agent-assembly"
-edit-url-template = "https://github.com/AI-agent-assembly/agent-assembly/edit/master/docs/{path}"
+git-repository-url = "https://github.com/ai-agent-assembly/agent-assembly"
+edit-url-template = "https://github.com/ai-agent-assembly/agent-assembly/edit/master/docs/{path}"
 additional-js = ["mermaid.min.js", "mermaid-init.js"]
 
 [preprocessor]

--- a/docs/devtools/plugins.md
+++ b/docs/devtools/plugins.md
@@ -6,7 +6,7 @@ implementation is the in-repo sample at
 [`examples/aa-devtool-sample-myeditor/`][sample-crate] — copy and
 adapt.
 
-[sample-crate]: https://github.com/AI-agent-assembly/agent-assembly/tree/master/examples/aa-devtool-sample-myeditor
+[sample-crate]: https://github.com/ai-agent-assembly/agent-assembly/tree/master/examples/aa-devtool-sample-myeditor
 
 ---
 
@@ -121,7 +121,7 @@ The sample's [`tests/contract.rs`][sample-tests] is the **reference
 test suite** every adapter should mirror. Adapt each test to your
 tool's specifics:
 
-[sample-tests]: https://github.com/AI-agent-assembly/agent-assembly/blob/master/examples/aa-devtool-sample-myeditor/tests/contract.rs
+[sample-tests]: https://github.com/ai-agent-assembly/agent-assembly/blob/master/examples/aa-devtool-sample-myeditor/tests/contract.rs
 
 | Sample test | What it verifies | What you change |
 |---|---|---|

--- a/docs/quickstart.cast
+++ b/docs/quickstart.cast
@@ -1,5 +1,5 @@
 {"version": 2, "width": 220, "height": 50, "timestamp": 1746806400, "title": "agent-assembly quickstart: make dev-setup && make dev-verify", "env": {"SHELL": "/bin/zsh", "TERM": "xterm-256color"}}
-[0.5, "o", "$ git clone https://github.com/AI-agent-assembly/agent-assembly.git\r\n"]
+[0.5, "o", "$ git clone https://github.com/ai-agent-assembly/agent-assembly.git\r\n"]
 [1.2, "o", "Cloning into 'agent-assembly'...\r\n"]
 [1.8, "o", "remote: Enumerating objects: 1842, done.\r\n"]
 [2.1, "o", "remote: Counting objects: 100% (1842/1842), done.\r\n"]

--- a/docs/release/RUNBOOK.md
+++ b/docs/release/RUNBOOK.md
@@ -5,8 +5,8 @@
 > `scripts/check-release.sh` (post-tag). Tracked under AAASM-2456.
 
 This runbook assumes the operator has push rights to
-`AI-agent-assembly/agent-assembly` and merge rights on the
-`AI-agent-assembly/homebrew-agent-assembly` tap.
+`ai-agent-assembly/agent-assembly` and merge rights on the
+`ai-agent-assembly/homebrew-agent-assembly` tap.
 
 ---
 
@@ -53,7 +53,7 @@ git tag -a v<version> -m "Release v<version>"
 git push remote v<version>
 ```
 
-Note: branches and tags push to `remote` (`AI-agent-assembly/agent-assembly`),
+Note: branches and tags push to `remote` (`ai-agent-assembly/agent-assembly`),
 **not** `origin` (the operator's personal fork).
 
 ## 3. What runs automatically after tag push
@@ -73,7 +73,7 @@ agent-assembly itself controls.
 ## 4. Manual gate — merge the Homebrew tap PR (within ~5 minutes)
 
 `release.yml`'s `update-homebrew-tap` job opens a PR against
-`AI-agent-assembly/homebrew-agent-assembly` with branch `bot/aasm-<version>`
+`ai-agent-assembly/homebrew-agent-assembly` with branch `bot/aasm-<version>`
 and title `🤖 (formula): aasm <version>`.
 
 **Until that PR is merged, `brew install aasm` will still resolve to the
@@ -81,8 +81,8 @@ previous version.** The formula file on the tap's master branch is what
 Homebrew reads; the bot-created branch is invisible to `brew install`.
 
 ```bash
-gh pr list --repo AI-agent-assembly/homebrew-agent-assembly --state open
-gh pr merge <pr-number> --repo AI-agent-assembly/homebrew-agent-assembly --squash
+gh pr list --repo ai-agent-assembly/homebrew-agent-assembly --state open
+gh pr merge <pr-number> --repo ai-agent-assembly/homebrew-agent-assembly --squash
 ```
 
 ## 5. Verification
@@ -152,7 +152,7 @@ the credential rotates. Not part of the per-release loop.
 
 After rotation:
 ```bash
-gh secret set CRATES_IO_TOKEN --repo AI-agent-assembly/agent-assembly
-gh secret set CROSS_REPO_DISPATCH_PAT --repo AI-agent-assembly/agent-assembly
-gh secret set HOMEBREW_TAP_TOKEN --repo AI-agent-assembly/agent-assembly
+gh secret set CRATES_IO_TOKEN --repo ai-agent-assembly/agent-assembly
+gh secret set CROSS_REPO_DISPATCH_PAT --repo ai-agent-assembly/agent-assembly
+gh secret set HOMEBREW_TAP_TOKEN --repo ai-agent-assembly/agent-assembly
 ```

--- a/docs/release/v0.0.1-alpha.2.md
+++ b/docs/release/v0.0.1-alpha.2.md
@@ -82,7 +82,7 @@ pip install --pre agent-assembly==0.0.1a2
 npm install @agent-assembly/sdk@alpha
 
 # Go SDK
-go get github.com/AI-agent-assembly/go-sdk@v0.0.1-alpha.2
+go get github.com/ai-agent-assembly/go-sdk@v0.0.1-alpha.2
 ```
 
 ### Refs

--- a/docs/release/v0.0.1-alpha.3.md
+++ b/docs/release/v0.0.1-alpha.3.md
@@ -35,7 +35,7 @@ docker pull ghcr.io/ai-agent-assembly/aa-runtime:v0.0.1-alpha.3
 docker pull ghcr.io/ai-agent-assembly/python:3.14-slim
 pip install --pre agent-assembly==0.0.1a3
 npm install @agent-assembly/sdk@alpha
-go get github.com/AI-agent-assembly/go-sdk@v0.0.1-alpha.3
+go get github.com/ai-agent-assembly/go-sdk@v0.0.1-alpha.3
 ```
 
 ### Refs

--- a/docs/release/v0.0.1-alpha.4.md
+++ b/docs/release/v0.0.1-alpha.4.md
@@ -49,7 +49,7 @@ docker pull ghcr.io/ai-agent-assembly/aa-runtime:v0.0.1-alpha.4
 docker pull ghcr.io/ai-agent-assembly/python:3.14-slim
 pip install --pre agent-assembly==0.0.1a4
 npm install @agent-assembly/sdk@0.0.1-alpha.4
-go get github.com/AI-agent-assembly/go-sdk@v0.0.1-alpha.4
+go get github.com/ai-agent-assembly/go-sdk@v0.0.1-alpha.4
 ```
 
 ### Behaviour delta on the crates.io `aasm` binary

--- a/docs/release/v0.0.1-alpha.5.md
+++ b/docs/release/v0.0.1-alpha.5.md
@@ -88,7 +88,7 @@ docker pull ghcr.io/ai-agent-assembly/python:3.14-slim
 # Language SDKs
 pip install --pre agent-assembly==0.0.1a5
 npm install @agent-assembly/sdk@0.0.1-alpha.5
-go get github.com/AI-agent-assembly/go-sdk@v0.0.1-alpha.5
+go get github.com/ai-agent-assembly/go-sdk@v0.0.1-alpha.5
 ```
 
 ### Behaviour delta on the crates.io `aasm` binary

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -16,8 +16,8 @@ This book targets contributors and operators of `agent-assembly`. SDK users (Pyt
 
 ## See also
 
-- [README](https://github.com/AI-agent-assembly/agent-assembly/blob/master/README.md) — top-level project overview, prerequisites, quickstart
-- [CONTRIBUTING](https://github.com/AI-agent-assembly/agent-assembly/blob/master/CONTRIBUTING.md) — development workflow, branch naming, PR rules
+- [README](https://github.com/ai-agent-assembly/agent-assembly/blob/master/README.md) — top-level project overview, prerequisites, quickstart
+- [CONTRIBUTING](https://github.com/ai-agent-assembly/agent-assembly/blob/master/CONTRIBUTING.md) — development workflow, branch naming, PR rules
 - API reference — generate locally with `cargo doc --workspace --no-deps --open`
 
 ## Diagram rendering

--- a/docs/src/adr/0002-sdk-security-boundary.md
+++ b/docs/src/adr/0002-sdk-security-boundary.md
@@ -97,8 +97,8 @@ Python/Node/Go SDK   ──UDS──▶ aa-runtime (mandatory chokepoint) ──
 The shared crates (`aa-core`, `aa-proto`, and the new `aa-security`, `aa-sdk-client`) are consumed by the SDK repos via **git dependency pinned to an exact commit SHA**. This is already the established, in-production pattern — `python-sdk/rust/aa-ffi-python/Cargo.toml` already declares:
 
 ```toml
-aa-core  = { git = "https://github.com/AI-agent-assembly/agent-assembly.git", rev = "ed4aa11a…", package = "aa-core", features = ["serde"] }
-aa-proto = { git = "https://github.com/AI-agent-assembly/agent-assembly.git", rev = "ed4aa11a…", package = "aa-proto" }
+aa-core  = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "ed4aa11a…", package = "aa-core", features = ["serde"] }
+aa-proto = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "ed4aa11a…", package = "aa-proto" }
 ```
 
 The decision is to **extend this same mechanism** to `aa-security` and `aa-sdk-client`, not to introduce a new one.

--- a/docs/src/api-reference.md
+++ b/docs/src/api-reference.md
@@ -27,18 +27,18 @@ Once rustdoc is built (`target/doc/<crate>/index.html`), the most-frequented ent
 
 | Crate | rustdoc entry | Highlights |
 |---|---|---|
-| [`aa-core`](https://github.com/AI-agent-assembly/agent-assembly/tree/master/aa-core) | `target/doc/aa_core/index.html` | Domain newtypes (`AgentId`, `TeamId`), `ActionType` enum, common traits |
-| [`aa-proto`](https://github.com/AI-agent-assembly/agent-assembly/tree/master/aa-proto) | `target/doc/aa_proto/index.html` | Generated protobuf message types — wire format source of truth |
-| [`aa-runtime`](https://github.com/AI-agent-assembly/agent-assembly/tree/master/aa-runtime) | `target/doc/aa_runtime/index.html` | Tokio runtime wrapper, agent lifecycle hooks |
-| [`aa-proxy`](https://github.com/AI-agent-assembly/agent-assembly/tree/master/aa-proxy) | `target/doc/aa_proxy/index.html` | MitM HTTPS proxy primitives |
-| [`aa-gateway`](https://github.com/AI-agent-assembly/agent-assembly/tree/master/aa-gateway) | `target/doc/aa_gateway/index.html` | Policy engine, agent registry, budget tracker |
-| [`aa-api`](https://github.com/AI-agent-assembly/agent-assembly/tree/master/aa-api) | `target/doc/aa_api/index.html` | HTTP layer with `utoipa`-generated OpenAPI spec |
-| [`aa-cli`](https://github.com/AI-agent-assembly/agent-assembly/tree/master/aa-cli) | `target/doc/aa_cli/index.html` | `aasm` operator binary surface (clap commands) |
-| [`aa-sdk-client`](https://github.com/AI-agent-assembly/agent-assembly/tree/master/aa-sdk-client) | `target/doc/aa_sdk_client/index.html` | Shared SDK runtime-client (UDS transport, codec, lifecycle) the Python/Node/Go shims wrap |
-| [`aa-wasm`](https://github.com/AI-agent-assembly/agent-assembly/tree/master/aa-wasm) | `target/doc/aa_wasm/index.html` | wasm-bindgen surface for in-browser embedding |
-| [`conformance`](https://github.com/AI-agent-assembly/agent-assembly/tree/master/conformance) | `target/doc/conformance/index.html` | Cross-SDK protocol vector harness |
+| [`aa-core`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-core) | `target/doc/aa_core/index.html` | Domain newtypes (`AgentId`, `TeamId`), `ActionType` enum, common traits |
+| [`aa-proto`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-proto) | `target/doc/aa_proto/index.html` | Generated protobuf message types — wire format source of truth |
+| [`aa-runtime`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-runtime) | `target/doc/aa_runtime/index.html` | Tokio runtime wrapper, agent lifecycle hooks |
+| [`aa-proxy`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-proxy) | `target/doc/aa_proxy/index.html` | MitM HTTPS proxy primitives |
+| [`aa-gateway`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-gateway) | `target/doc/aa_gateway/index.html` | Policy engine, agent registry, budget tracker |
+| [`aa-api`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-api) | `target/doc/aa_api/index.html` | HTTP layer with `utoipa`-generated OpenAPI spec |
+| [`aa-cli`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-cli) | `target/doc/aa_cli/index.html` | `aasm` operator binary surface (clap commands) |
+| [`aa-sdk-client`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-sdk-client) | `target/doc/aa_sdk_client/index.html` | Shared SDK runtime-client (UDS transport, codec, lifecycle) the Python/Node/Go shims wrap |
+| [`aa-wasm`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-wasm) | `target/doc/aa_wasm/index.html` | wasm-bindgen surface for in-browser embedding |
+| [`conformance`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/conformance) | `target/doc/conformance/index.html` | Cross-SDK protocol vector harness |
 
-The HTTP API (served by `aa-api`) additionally publishes a generated [OpenAPI v1 spec](https://github.com/AI-agent-assembly/agent-assembly/tree/master/openapi). Validate the spec with `npx @stoplight/spectral-cli lint openapi/v1.yaml`.
+The HTTP API (served by `aa-api`) additionally publishes a generated [OpenAPI v1 spec](https://github.com/ai-agent-assembly/agent-assembly/tree/master/openapi). Validate the spec with `npx @stoplight/spectral-cli lint openapi/v1.yaml`.
 
 ## Hosted documentation (deferred)
 

--- a/docs/src/architecture.md
+++ b/docs/src/architecture.md
@@ -139,7 +139,7 @@ A readiness probe is exposed at `http://localhost:8080/ready` throughout the Enf
 
 ## Policy evaluation path
 
-When `aa-gateway` receives a `PolicyDecisionRequest`, it walks four stages before returning a decision. The implementation lives under [`aa-gateway/src/policy/`](https://github.com/AI-agent-assembly/agent-assembly/tree/master/aa-gateway/src/policy):
+When `aa-gateway` receives a `PolicyDecisionRequest`, it walks four stages before returning a decision. The implementation lives under [`aa-gateway/src/policy/`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-gateway/src/policy):
 
 ```mermaid
 flowchart LR

--- a/docs/src/benchmarks/ci-cd-pipeline-performance.md
+++ b/docs/src/benchmarks/ci-cd-pipeline-performance.md
@@ -92,7 +92,7 @@ dashboard-assets artifact:
   wall-clock figures as illustrative and the runner-minute / job-count figures as
   the load-bearing evidence.
 - Run numbers are cited so each row can be re-inspected:
-  `gh api repos/AI-agent-assembly/agent-assembly/actions/runs/<id>/jobs`.
+  `gh api repos/ai-agent-assembly/agent-assembly/actions/runs/<id>/jobs`.
 
 ## Takeaway
 

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -1,12 +1,12 @@
 # Command-Line Interface (`aasm`)
 
 `aasm` is the operator front-end for an Agent Assembly deployment. It ships from
-the [`aa-cli`](https://github.com/AI-agent-assembly/agent-assembly/tree/master/aa-cli)
+the [`aa-cli`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-cli)
 crate and talks to the gateway over its HTTP API.
 
 ## Install
 
-See the [README install section](https://github.com/AI-agent-assembly/agent-assembly#install-the-cli)
+See the [README install section](https://github.com/ai-agent-assembly/agent-assembly#install-the-cli)
 for the install script and Homebrew tap. For a local build:
 
 ```bash
@@ -52,7 +52,7 @@ These flags are available on every subcommand:
 > The `aasm run` and `aasm tools` dev-tool subcommands (launch and manage AI
 > dev tools such as Claude Code, Codex, Copilot, and Windsurf with governance
 > wiring) are present in the full build but stripped from the published crate.
-> See [Dev-tool governance limits](https://github.com/AI-agent-assembly/agent-assembly/blob/master/docs/devtools/governance-limits.md).
+> See [Dev-tool governance limits](https://github.com/ai-agent-assembly/agent-assembly/blob/master/docs/devtools/governance-limits.md).
 
 ## Examples
 

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -9,6 +9,12 @@ This document tracks which versions of `aa-runtime` are compatible with each SDK
      `license = "Apache-2.0"`). License-metadata only — no version change to
      aa-runtime or any SDK; this comment satisfies the compatibility-matrix CI gate. -->
 
+<!-- AAASM-2718: lowercased the GitHub org ID `AI-agent-assembly` → `ai-agent-assembly`
+     in root Cargo.toml `[workspace.package]` `repository`/`homepage` metadata URLs
+     (Epic AAASM-2715, canonical lowercase org ID). URL-casing metadata only — GitHub
+     resolves org names case-insensitively, so no version change to aa-runtime or any
+     SDK; this comment satisfies the compatibility-matrix CI gate. -->
+
 <!-- AAASM-1602: workspace.exclude = ["node-sdk"] added to root Cargo.toml so
      the sibling `node-sdk/` checkout used by e2e_sdk_node tests doesn't get
      claimed by the agent-assembly workspace. No version change introduced

--- a/docs/src/dashboard.md
+++ b/docs/src/dashboard.md
@@ -5,8 +5,8 @@ the gateway — policy decisions are always made server-side.
 
 | Console | Lives in | Talks to | Use when |
 |---|---|---|---|
-| **Web dashboard** | [`dashboard/`](https://github.com/AI-agent-assembly/agent-assembly/tree/master/dashboard) | `aa-api` (HTTP, port 8080) | You want a browser UI for fleet health, policies, and audit. |
-| **Terminal dashboard (TUI)** | `aasm dashboard` ([`aa-cli`](https://github.com/AI-agent-assembly/agent-assembly/tree/master/aa-cli)) | Gateway API | You want real-time monitoring from the terminal / over SSH. |
+| **Web dashboard** | [`dashboard/`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/dashboard) | `aa-api` (HTTP, port 8080) | You want a browser UI for fleet health, policies, and audit. |
+| **Terminal dashboard (TUI)** | `aasm dashboard` ([`aa-cli`](https://github.com/ai-agent-assembly/agent-assembly/tree/master/aa-cli)) | Gateway API | You want real-time monitoring from the terminal / over SSH. |
 
 ## Web dashboard
 

--- a/docs/src/development/consuming-shared-crates.md
+++ b/docs/src/development/consuming-shared-crates.md
@@ -22,10 +22,10 @@ A consumer pins each crate to an exact commit:
 
 ```toml
 [dependencies]
-aa-core       = { git = "https://github.com/AI-agent-assembly/agent-assembly.git", rev = "<full-40-char-sha>", package = "aa-core", features = ["serde"] }
-aa-proto      = { git = "https://github.com/AI-agent-assembly/agent-assembly.git", rev = "<full-40-char-sha>", package = "aa-proto" }
-aa-security   = { git = "https://github.com/AI-agent-assembly/agent-assembly.git", rev = "<full-40-char-sha>", package = "aa-security" }
-aa-sdk-client = { git = "https://github.com/AI-agent-assembly/agent-assembly.git", rev = "<full-40-char-sha>", package = "aa-sdk-client" }
+aa-core       = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "<full-40-char-sha>", package = "aa-core", features = ["serde"] }
+aa-proto      = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "<full-40-char-sha>", package = "aa-proto" }
+aa-security   = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "<full-40-char-sha>", package = "aa-security" }
+aa-sdk-client = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "<full-40-char-sha>", package = "aa-sdk-client" }
 ```
 
 Notes:

--- a/docs/src/development/local-development.md
+++ b/docs/src/development/local-development.md
@@ -2,7 +2,7 @@
 
 This page covers the from-clone development loop for the `agent-assembly`
 monorepo. For contribution conventions (commit style, PR process) see
-[`CONTRIBUTING.md`](https://github.com/AI-agent-assembly/agent-assembly/blob/master/CONTRIBUTING.md).
+[`CONTRIBUTING.md`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/CONTRIBUTING.md).
 
 ## Prerequisites
 
@@ -13,12 +13,12 @@ monorepo. For contribution conventions (commit style, PR process) see
 - [`cargo-nextest`](https://nexte.st/), [`cargo-deny`](https://embarkstudios.github.io/cargo-deny/),
   and [Lefthook](https://github.com/evilmartians/lefthook)
 - **Linux only** for the proxy / eBPF layers — see
-  [Supported platforms](https://github.com/AI-agent-assembly/agent-assembly#supported-platforms).
+  [Supported platforms](https://github.com/ai-agent-assembly/agent-assembly#supported-platforms).
 
 ## Bootstrap
 
 ```bash
-git clone https://github.com/AI-agent-assembly/agent-assembly.git
+git clone https://github.com/ai-agent-assembly/agent-assembly.git
 cd agent-assembly
 
 # Installs toolchains, clones the SDK polyrepos as siblings, installs git

--- a/docs/src/releases.md
+++ b/docs/src/releases.md
@@ -5,12 +5,12 @@ and wire protocol are not yet stable.
 
 ## Where releases live
 
-- **GitHub Releases:** <https://github.com/AI-agent-assembly/agent-assembly/releases>
+- **GitHub Releases:** <https://github.com/ai-agent-assembly/agent-assembly/releases>
   — the source of truth for published tags and changelogs. The latest tag is a
   pre-release (`v0.0.1-alpha.5`, 2026-06-03).
 - **Per-tag notes:** the source-controlled release notes live under
   `docs/release/` (one file per tag, e.g. `docs/release/v0.0.1-alpha.5.md`).
-- **Top-level changelog:** [`CHANGELOG.md`](https://github.com/AI-agent-assembly/agent-assembly/blob/master/CHANGELOG.md).
+- **Top-level changelog:** [`CHANGELOG.md`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/CHANGELOG.md).
 
 ## Distribution channels
 
@@ -20,7 +20,7 @@ A single coordinated tag push fans out to every channel:
 |---|---|
 | GitHub Releases | `aasm-*.tar.gz` binaries + `SHA256SUMS` |
 | crates.io | Workspace crates at the tag version |
-| Homebrew tap | `aasm` formula ([`homebrew-agent-assembly`](https://github.com/AI-agent-assembly/homebrew-agent-assembly)) |
+| Homebrew tap | `aasm` formula ([`homebrew-agent-assembly`](https://github.com/ai-agent-assembly/homebrew-agent-assembly)) |
 | PyPI / npm | SDK packages |
 | GHCR | Container image |
 

--- a/docs/superpowers/plans/2026-04-27-aaasm-29-tokio-runtime-init.md
+++ b/docs/superpowers/plans/2026-04-27-aaasm-29-tokio-runtime-init.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Rust 2021 edition, `tokio 1` (full features), `tokio-util 0.7` (TaskTracker + CancellationToken), `tracing 0.1`, `tracing-subscriber 0.3` (json + env-filter)
 
-**Worktree:** `/Users/bryant/Bryant-Developments/AI-agent-assembly/agent-assembly-v0.0.1-AAASM-29-tokio_runtime_init`
+**Worktree:** `/Users/bryant/Bryant-Developments/ai-agent-assembly/agent-assembly-v0.0.1-AAASM-29-tokio_runtime_init`
 **Branch:** `v0.0.1/AAASM-29/tokio_runtime_init`
 **All commands run from the worktree root unless stated otherwise.**
 

--- a/examples/aa-devtool-sample-myeditor/src/lib.rs
+++ b/examples/aa-devtool-sample-myeditor/src/lib.rs
@@ -9,7 +9,7 @@
 //! tracked separately in AAASM-201..205 and AAASM-918.
 //!
 //! [`DevToolAdapter`]: aa_core::DevToolAdapter
-//! [`docs/devtools/plugins.md`]: https://github.com/AI-agent-assembly/agent-assembly/blob/master/docs/devtools/plugins.md
+//! [`docs/devtools/plugins.md`]: https://github.com/ai-agent-assembly/agent-assembly/blob/master/docs/devtools/plugins.md
 
 #![warn(missing_docs)]
 

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -7,7 +7,7 @@ info:
     This spec is auto-generated from `aa-api` route annotations via `utoipa`. CI fails if the generated spec drifts from the committed `openapi/v1.yaml`.
   contact:
     name: Agent Assembly Contributors
-    url: https://github.com/AI-agent-assembly/agent-assembly
+    url: https://github.com/ai-agent-assembly/agent-assembly
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html

--- a/scripts/check-release.sh
+++ b/scripts/check-release.sh
@@ -29,7 +29,7 @@ REPORT=()
 FAIL=0
 NEEDS_RETRIGGER=()
 
-ua="agent-assembly-release-check/1.0 (+https://github.com/AI-agent-assembly/agent-assembly)"
+ua="agent-assembly-release-check/1.0 (+https://github.com/ai-agent-assembly/agent-assembly)"
 
 ok()   { REPORT+=("  $1 : ✓ $2"); }
 bad()  {
@@ -42,7 +42,7 @@ bad()  {
 }
 
 # ─── 1. GH Release ────────────────────────────────────────────────────────
-RELEASE_JSON="$(gh release view "$TAG" --repo AI-agent-assembly/agent-assembly \
+RELEASE_JSON="$(gh release view "$TAG" --repo ai-agent-assembly/agent-assembly \
   --json name,assets,isDraft 2>/dev/null || true)"
 if [ -z "$RELEASE_JSON" ]; then
   bad "GH Release    " "tag $TAG not published" \
@@ -52,10 +52,10 @@ else
   ASSET_COUNT="$(printf '%s' "$RELEASE_JSON" | python3 -c 'import sys,json; print(len(json.load(sys.stdin)["assets"]))')"
   if [ "$IS_DRAFT" = "True" ] || [ "$IS_DRAFT" = "true" ]; then
     bad "GH Release    " "release is draft" \
-        "gh release edit $TAG --repo AI-agent-assembly/agent-assembly --draft=false"
+        "gh release edit $TAG --repo ai-agent-assembly/agent-assembly --draft=false"
   elif [ "$ASSET_COUNT" != "5" ]; then
     bad "GH Release    " "$ASSET_COUNT assets (expected 5: 4 aasm-*.tar.gz + SHA256SUMS)" \
-        "gh workflow run release.yml --repo AI-agent-assembly/agent-assembly -f release_tag=$TAG"
+        "gh workflow run release.yml --repo ai-agent-assembly/agent-assembly -f release_tag=$TAG"
   else
     ok "GH Release    " "published, 5 assets"
   fi
@@ -66,7 +66,7 @@ FORMULA_CONTENT="$(gh api repos/ai-agent-assembly/homebrew-agent-assembly/conten
   --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)"
 if [ -z "$FORMULA_CONTENT" ]; then
   bad "Homebrew tap  " "Formula/aasm.rb not readable" \
-      "gh workflow run release.yml --repo AI-agent-assembly/agent-assembly -f release_tag=$TAG"
+      "gh workflow run release.yml --repo ai-agent-assembly/agent-assembly -f release_tag=$TAG"
 elif printf '%s\n' "$FORMULA_CONTENT" | grep -qE "^[[:space:]]*version \"${VERSION//./\\.}\""; then
   TAP_PR_STATE="$(gh pr list --repo ai-agent-assembly/homebrew-agent-assembly --state all \
     --json state,number,headRefName \
@@ -90,7 +90,7 @@ else
         "gh pr merge ${TAP_PR_NUM} --repo ai-agent-assembly/homebrew-agent-assembly --squash"
   else
     bad "Homebrew tap  " "formula on master NOT at $VERSION; no open bot PR" \
-        "gh workflow run release.yml --repo AI-agent-assembly/agent-assembly -f release_tag=$TAG"
+        "gh workflow run release.yml --repo ai-agent-assembly/agent-assembly -f release_tag=$TAG"
   fi
 fi
 
@@ -116,7 +116,7 @@ if [ ${#MISSING_CRATES[@]} -eq 0 ]; then
   ok "crates.io     " "all ${#CRATES[@]} crates at $VERSION"
 else
   bad "crates.io     " "${#MISSING_CRATES[@]}/${#CRATES[@]} crates missing $VERSION: ${MISSING_CRATES[*]}" \
-      "gh workflow run release.yml --repo AI-agent-assembly/agent-assembly -f release_tag=$TAG  # crates.io is immutable; fix sources first"
+      "gh workflow run release.yml --repo ai-agent-assembly/agent-assembly -f release_tag=$TAG  # crates.io is immutable; fix sources first"
 fi
 
 # ─── 4. npm (5 packages) ──────────────────────────────────────────────────
@@ -178,7 +178,7 @@ if [ ${#GHCR_MISSING[@]} -eq 0 ]; then
   ok "ghcr.io       " "python:$VERSION + go:$VERSION present"
 else
   bad "ghcr.io       " "${#GHCR_MISSING[@]}/2 images missing: ${GHCR_MISSING[*]}" \
-      "gh workflow run docker.yml --repo AI-agent-assembly/agent-assembly -f release_tag=$TAG"
+      "gh workflow run docker.yml --repo ai-agent-assembly/agent-assembly -f release_tag=$TAG"
 fi
 
 # ─── Output ───────────────────────────────────────────────────────────────

--- a/scripts/release-readiness.sh
+++ b/scripts/release-readiness.sh
@@ -95,12 +95,12 @@ else
 fi
 
 # 8. Required secrets present in this repo
-SECRETS="$(gh secret list --repo AI-agent-assembly/agent-assembly 2>/dev/null | awk '{print $1}')"
+SECRETS="$(gh secret list --repo ai-agent-assembly/agent-assembly 2>/dev/null | awk '{print $1}')"
 for SECRET in CRATES_IO_TOKEN CROSS_REPO_DISPATCH_PAT HOMEBREW_TAP_TOKEN; do
   if printf '%s\n' "$SECRETS" | grep -qx "$SECRET"; then
     pass "Secret $SECRET present"
   else
-    fail "Secret $SECRET missing" "gh secret set $SECRET --repo AI-agent-assembly/agent-assembly"
+    fail "Secret $SECRET missing" "gh secret set $SECRET --repo ai-agent-assembly/agent-assembly"
   fi
 done
 

--- a/scripts/sdk-repos.txt
+++ b/scripts/sdk-repos.txt
@@ -1,3 +1,3 @@
-git@github.com:AI-agent-assembly/python-sdk.git
-git@github.com:AI-agent-assembly/node-sdk.git
-git@github.com:AI-agent-assembly/go-sdk.git
+git@github.com:ai-agent-assembly/python-sdk.git
+git@github.com:ai-agent-assembly/node-sdk.git
+git@github.com:ai-agent-assembly/go-sdk.git

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.host.url=https://sonarcloud.io
-sonar.projectKey=AI-agent-assembly_agent-assembly
+sonar.projectKey=ai-agent-assembly_agent-assembly
 sonar.organization=ai-agent-assembly
 
 sonar.projectName=agent-assembly

--- a/verification-report-AAASM-119.md
+++ b/verification-report-AAASM-119.md
@@ -57,11 +57,11 @@ All five implementation PRs were merged with green Dashboard CI (type-check + li
 
 | PR | Sub-task | Merge commit | Notes |
 | --- | --- | --- | --- |
-| [#336](https://github.com/AI-agent-assembly/agent-assembly/pull/336) | AAASM-1083 | `f9ea8b2c` | 7 commits — scaffold |
-| [#385](https://github.com/AI-agent-assembly/agent-assembly/pull/385) | AAASM-1084 | `38b8167f` | 11 commits — members |
-| [#391](https://github.com/AI-agent-assembly/agent-assembly/pull/391) | AAASM-1085 | `1e8c4b8c` | 11 commits — API keys reveal-once |
-| [#394](https://github.com/AI-agent-assembly/agent-assembly/pull/394) | AAASM-1086 | `82a410dc` | 10 commits — agent registry + permissions |
-| [#397](https://github.com/AI-agent-assembly/agent-assembly/pull/397) | AAASM-1087 | `a839e700` | 7 commits — custom-roles locked + E2E |
+| [#336](https://github.com/ai-agent-assembly/agent-assembly/pull/336) | AAASM-1083 | `f9ea8b2c` | 7 commits — scaffold |
+| [#385](https://github.com/ai-agent-assembly/agent-assembly/pull/385) | AAASM-1084 | `38b8167f` | 11 commits — members |
+| [#391](https://github.com/ai-agent-assembly/agent-assembly/pull/391) | AAASM-1085 | `1e8c4b8c` | 11 commits — API keys reveal-once |
+| [#394](https://github.com/ai-agent-assembly/agent-assembly/pull/394) | AAASM-1086 | `82a410dc` | 10 commits — agent registry + permissions |
+| [#397](https://github.com/ai-agent-assembly/agent-assembly/pull/397) | AAASM-1087 | `a839e700` | 7 commits — custom-roles locked + E2E |
 
 ## Sign-off
 

--- a/verification-report-AAASM-1209.md
+++ b/verification-report-AAASM-1209.md
@@ -2,9 +2,9 @@
 
 **Story:** AAASM-1200 — F110: Cross-platform CI release pipeline
 **Epic:** AAASM-1199 — Release & Distribution Pipeline
-**PR:** [AI-agent-assembly/agent-assembly#628](https://github.com/AI-agent-assembly/agent-assembly/pull/628)
+**PR:** [ai-agent-assembly/agent-assembly#628](https://github.com/ai-agent-assembly/agent-assembly/pull/628)
 **Verified by:** workflow_dispatch dry-run, no real release tag pushed
-**Run:** [release.yml #26197408878](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/26197408878)
+**Run:** [release.yml #26197408878](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/26197408878)
 **Date:** 2026-05-21 (UTC)
 
 ## Why dry-run instead of a real tag
@@ -15,7 +15,7 @@ This PR replaces the test-tag path with a `workflow_dispatch` dry-run path that 
 
 ## Runner matrix change
 
-The original matrix targeted `x86_64-apple-darwin` to **macos-13**. The first dry-run attempt ([run #26176204851](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/26176204851)) sat queued for **7h32m** on macos-13 — GitHub-hosted Intel macOS capacity is severely constrained as that image winds down. The fix (commit `🐛 (ci): Cross-compile x86_64-apple-darwin on macos-14`) moves the runner to macos-14 (Apple Silicon), cross-compiles via the rustup-installed x86_64 target, and installs Rosetta 2 inline so the `aasm --version` smoke step still exercises the produced Intel binary.
+The original matrix targeted `x86_64-apple-darwin` to **macos-13**. The first dry-run attempt ([run #26176204851](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/26176204851)) sat queued for **7h32m** on macos-13 — GitHub-hosted Intel macOS capacity is severely constrained as that image winds down. The fix (commit `🐛 (ci): Cross-compile x86_64-apple-darwin on macos-14`) moves the runner to macos-14 (Apple Silicon), cross-compiles via the rustup-installed x86_64 target, and installs Rosetta 2 inline so the `aasm --version` smoke step still exercises the produced Intel binary.
 
 ## AC verification results
 

--- a/verification-report-AAASM-1385.md
+++ b/verification-report-AAASM-1385.md
@@ -11,12 +11,12 @@ All six implementation sub-tasks landed on `master` in stack order. Each PR was 
 
 | # | Sub-task | PR | Merge commit | Status |
 | --- | --- | --- | --- | --- |
-| 1 | [AAASM-1624](https://lightning-dust-mite.atlassian.net/browse/AAASM-1624) Add alert-detail data types (RuleSnapshot / RoutingLogEntry / Silence / RuleContext) | [#588](https://github.com/AI-agent-assembly/agent-assembly/pull/588) | `c7946977` | Done |
-| 2 | [AAASM-1625](https://lightning-dust-mite.atlassian.net/browse/AAASM-1625) Extend StoredAlert with optional rule_context + first_fired_at/resolved_at | [#589](https://github.com/AI-agent-assembly/agent-assembly/pull/589) | `10a992c2` | Done |
-| 3 | [AAASM-1626](https://lightning-dust-mite.atlassian.net/browse/AAASM-1626) Rename AlertStore::get → get_by_id + add record_rule_alert | [#590](https://github.com/AI-agent-assembly/agent-assembly/pull/590) | `3b8a21e0` | Done |
-| 4 | [AAASM-1627](https://lightning-dust-mite.atlassian.net/browse/AAASM-1627) Implement dedup state machine in AlertStore | [#594](https://github.com/AI-agent-assembly/agent-assembly/pull/594) | `3ce71006` | Done |
-| 5 | [AAASM-1628](https://lightning-dust-mite.atlassian.net/browse/AAASM-1628) Add AlertDetailResponse + update GET /alerts/{id} handler | [#596](https://github.com/AI-agent-assembly/agent-assembly/pull/596) | `5a828f1a` | Done |
-| 6 | [AAASM-1629](https://lightning-dust-mite.atlassian.net/browse/AAASM-1629) Integration tests for rich detail + dedup behavior | [#598](https://github.com/AI-agent-assembly/agent-assembly/pull/598) | `84d74a51` | Done |
+| 1 | [AAASM-1624](https://lightning-dust-mite.atlassian.net/browse/AAASM-1624) Add alert-detail data types (RuleSnapshot / RoutingLogEntry / Silence / RuleContext) | [#588](https://github.com/ai-agent-assembly/agent-assembly/pull/588) | `c7946977` | Done |
+| 2 | [AAASM-1625](https://lightning-dust-mite.atlassian.net/browse/AAASM-1625) Extend StoredAlert with optional rule_context + first_fired_at/resolved_at | [#589](https://github.com/ai-agent-assembly/agent-assembly/pull/589) | `10a992c2` | Done |
+| 3 | [AAASM-1626](https://lightning-dust-mite.atlassian.net/browse/AAASM-1626) Rename AlertStore::get → get_by_id + add record_rule_alert | [#590](https://github.com/ai-agent-assembly/agent-assembly/pull/590) | `3b8a21e0` | Done |
+| 4 | [AAASM-1627](https://lightning-dust-mite.atlassian.net/browse/AAASM-1627) Implement dedup state machine in AlertStore | [#594](https://github.com/ai-agent-assembly/agent-assembly/pull/594) | `3ce71006` | Done |
+| 5 | [AAASM-1628](https://lightning-dust-mite.atlassian.net/browse/AAASM-1628) Add AlertDetailResponse + update GET /alerts/{id} handler | [#596](https://github.com/ai-agent-assembly/agent-assembly/pull/596) | `5a828f1a` | Done |
+| 6 | [AAASM-1629](https://lightning-dust-mite.atlassian.net/browse/AAASM-1629) Integration tests for rich detail + dedup behavior | [#598](https://github.com/ai-agent-assembly/agent-assembly/pull/598) | `84d74a51` | Done |
 | 7 | [AAASM-1630](https://lightning-dust-mite.atlassian.net/browse/AAASM-1630) Verify AAASM-1385 AC (this PR) | (this PR) | — | Open |
 
 ## Parent Story acceptance criteria

--- a/verification-report-AAASM-1478.md
+++ b/verification-report-AAASM-1478.md
@@ -6,9 +6,9 @@
 
 | Sub-task | PR | Summary |
 |---|---|---|
-| AAASM-1673 | [#620](https://github.com/AI-agent-assembly/agent-assembly/pull/620) | Countdown helpers + `ApprovalCountdown` component |
-| AAASM-1674 | [#622](https://github.com/AI-agent-assembly/agent-assembly/pull/622) | `useExpiredApprovals` client state + WS expired handling |
-| AAASM-1675 | [#624](https://github.com/AI-agent-assembly/agent-assembly/pull/624) | `ExpiredApprovalsSection` + `ApprovalsPage` wire-in |
+| AAASM-1673 | [#620](https://github.com/ai-agent-assembly/agent-assembly/pull/620) | Countdown helpers + `ApprovalCountdown` component |
+| AAASM-1674 | [#622](https://github.com/ai-agent-assembly/agent-assembly/pull/622) | `useExpiredApprovals` client state + WS expired handling |
+| AAASM-1675 | [#624](https://github.com/ai-agent-assembly/agent-assembly/pull/624) | `ExpiredApprovalsSection` + `ApprovalsPage` wire-in |
 | AAASM-1676 | _this PR_ | Playwright e2e + screenshots + this report |
 
 ## Definition of Done — AC walk-through

--- a/verification-report-AAASM-1550.md
+++ b/verification-report-AAASM-1550.md
@@ -12,10 +12,10 @@ This report verifies the 10 acceptance criteria of AAASM-1550 against the work s
 
 | Sub-task | Repo | PR |
 |---|---|---|
-| AAASM-1677 — Adapter module + unit tests | python-sdk | [python-sdk#46](https://github.com/AI-agent-assembly/python-sdk/pull/46) |
-| AAASM-1678 — Integration test | python-sdk | [python-sdk#47](https://github.com/AI-agent-assembly/python-sdk/pull/47) (stacked on #46) |
-| AAASM-1679 — Fixture scripts + optional dep + run_agents discovery | agent-assembly | [agent-assembly#623](https://github.com/AI-agent-assembly/agent-assembly/pull/623) |
-| AAASM-1680 — Rust selftest tests | agent-assembly | [agent-assembly#625](https://github.com/AI-agent-assembly/agent-assembly/pull/625) (stacked on #623) |
+| AAASM-1677 — Adapter module + unit tests | python-sdk | [python-sdk#46](https://github.com/ai-agent-assembly/python-sdk/pull/46) |
+| AAASM-1678 — Integration test | python-sdk | [python-sdk#47](https://github.com/ai-agent-assembly/python-sdk/pull/47) (stacked on #46) |
+| AAASM-1679 — Fixture scripts + optional dep + run_agents discovery | agent-assembly | [agent-assembly#623](https://github.com/ai-agent-assembly/agent-assembly/pull/623) |
+| AAASM-1680 — Rust selftest tests | agent-assembly | [agent-assembly#625](https://github.com/ai-agent-assembly/agent-assembly/pull/625) (stacked on #623) |
 
 ## Acceptance-criteria checklist
 

--- a/verification-report-AAASM-1683.md
+++ b/verification-report-AAASM-1683.md
@@ -2,9 +2,9 @@
 
 **Bug sub-task:** AAASM-1683 — [BUG] aasm release binary exceeds 2–8 MB AC target
 **Parent Story:** AAASM-1200 — F110: Cross-platform CI release pipeline
-**PR:** [AI-agent-assembly/agent-assembly#638](https://github.com/AI-agent-assembly/agent-assembly/pull/638)
+**PR:** [ai-agent-assembly/agent-assembly#638](https://github.com/ai-agent-assembly/agent-assembly/pull/638)
 **Verified by:** workflow_dispatch dry-run on the branch
-**Run:** [release.yml #26201143804](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/26201143804)
+**Run:** [release.yml #26201143804](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/26201143804)
 **Date:** 2026-05-21 (UTC)
 
 ## Root cause
@@ -33,7 +33,7 @@ Dev experience (`vite` / `pnpm dev`) is unaffected — `build.sourcemap` control
 
 ## Before vs after (CI measurement)
 
-Pre-fix (from AAASM-1209 dry-run [#26197408878](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/26197408878)) vs post-fix (this PR's dry-run [#26201143804](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/26201143804)):
+Pre-fix (from AAASM-1209 dry-run [#26197408878](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/26197408878)) vs post-fix (this PR's dry-run [#26201143804](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/26201143804)):
 
 | Target | Before | After | Saved | vs original 2–8 MB AC |
 | --- | --- | --- | --- | --- |

--- a/verification-reports/AAASM-1066.md
+++ b/verification-reports/AAASM-1066.md
@@ -14,10 +14,10 @@
 
 | Sub-task | Title | Status | PR |
 |---|---|---|---|
-| AAASM-1076 | Scaffold crate + testcontainers harness | Done | [#447](https://github.com/AI-agent-assembly/agent-assembly/pull/447) |
-| AAASM-1078 | Python SDK driver + LangGraph fixture | Done | [#459](https://github.com/AI-agent-assembly/agent-assembly/pull/459) |
-| AAASM-1079 | REST + CLI assertions module | Done | [#462](https://github.com/AI-agent-assembly/agent-assembly/pull/462) |
-| AAASM-1081 | CI workflow (Linux + macOS) + Drop cleanup | Done | [#466](https://github.com/AI-agent-assembly/agent-assembly/pull/466) |
+| AAASM-1076 | Scaffold crate + testcontainers harness | Done | [#447](https://github.com/ai-agent-assembly/agent-assembly/pull/447) |
+| AAASM-1078 | Python SDK driver + LangGraph fixture | Done | [#459](https://github.com/ai-agent-assembly/agent-assembly/pull/459) |
+| AAASM-1079 | REST + CLI assertions module | Done | [#462](https://github.com/ai-agent-assembly/agent-assembly/pull/462) |
+| AAASM-1081 | CI workflow (Linux + macOS) + Drop cleanup | Done | [#466](https://github.com/ai-agent-assembly/agent-assembly/pull/466) |
 | AAASM-1159 | Verify F103 acceptance criteria | in this report | — |
 
 ## Walkthrough vs AAASM-1066 acceptance criteria
@@ -98,8 +98,8 @@ final CI run.
 
 CI runs (PR #466 head SHA `0629bbf3`):
 
-* [Topology integration tests (ubuntu-latest)](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/25964046400/job/76324257585) — 3m25s pass
-* [Topology integration tests (macos-latest)](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/25964046400/job/76324257551) — 3m22s pass
+* [Topology integration tests (ubuntu-latest)](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/25964046400/job/76324257585) — 3m25s pass
+* [Topology integration tests (macos-latest)](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/25964046400/job/76324257551) — 3m22s pass
 
 ### ⚠️ Cleanup tears down all spawned agents + sessions
 

--- a/verification-reports/AAASM-1204.md
+++ b/verification-reports/AAASM-1204.md
@@ -21,10 +21,10 @@
 
 | Sub-task | Title | Status | PR |
 |---|---|---|---|
-| AAASM-1224 | Author Dockerfile.python-3.14-slim | Done | [#474](https://github.com/AI-agent-assembly/agent-assembly/pull/474) |
-| AAASM-1439 | Author Dockerfile.node-24-slim | Done | [#475](https://github.com/AI-agent-assembly/agent-assembly/pull/475) |
-| AAASM-1440 | Author Dockerfile.go-1.26-alpine | Done | [#476](https://github.com/AI-agent-assembly/agent-assembly/pull/476) |
-| AAASM-1225 | Extend docker.yml — 3-variant publish matrix | Done | [#515](https://github.com/AI-agent-assembly/agent-assembly/pull/515) |
+| AAASM-1224 | Author Dockerfile.python-3.14-slim | Done | [#474](https://github.com/ai-agent-assembly/agent-assembly/pull/474) |
+| AAASM-1439 | Author Dockerfile.node-24-slim | Done | [#475](https://github.com/ai-agent-assembly/agent-assembly/pull/475) |
+| AAASM-1440 | Author Dockerfile.go-1.26-alpine | Done | [#476](https://github.com/ai-agent-assembly/agent-assembly/pull/476) |
+| AAASM-1225 | Extend docker.yml — 3-variant publish matrix | Done | [#515](https://github.com/ai-agent-assembly/agent-assembly/pull/515) |
 | AAASM-1500 | [BUG] Python: pip-installed aasm shadows Rust aasm | Done | (merged) |
 | AAASM-1501 | [BUG] Node: npm `github:` shorthand resolves to ssh:// | Done | (merged) |
 | AAASM-1502 | [BUG] Go: go-sdk module path mismatch | Done | (merged) |
@@ -55,7 +55,7 @@ deferred entirely.
 
 * **`linux/amd64`** — verified locally for the **Python** and **Go** variants
   on `master @ a86f09f3` (transcripts below). The **Node** variant build
-  fails at the `RUN npm install -g 'github:AI-agent-assembly/node-sdk'` step;
+  fails at the `RUN npm install -g 'github:ai-agent-assembly/node-sdk'` step;
   this is the documented [AAASM-1501] root cause and the variant is
   intentionally excluded from the active docker.yml matrix
   ([`.github/workflows/docker.yml:82–86`](../.github/workflows/docker.yml)).
@@ -105,11 +105,11 @@ Local Go build transcript (cargo Stage 1 reused from the python build's
 #14 [aasm-builder 5/5] RUN cargo build --release -p aa-cli --bin aasm    CACHED
 #15 [stage-1 1/5] FROM docker.io/library/golang:1.26-alpine              CACHED
 #16 [stage-1 2/5] COPY --from=aasm-builder /usr/local/bin/aasm ...       DONE 0.0s
-#17 [stage-1 3/5] RUN go install github.com/AI-agent-assembly/go-sdk/...@latest  DONE 74.5s
+#17 [stage-1 3/5] RUN go install github.com/ai-agent-assembly/go-sdk/...@latest  DONE 74.5s
 #18 [stage-1 4/5] RUN aasm --version
 #18 0.287 aasm 0.0.1                                                     DONE 0.4s
-#19 [stage-1 5/5] RUN go list -m github.com/AI-agent-assembly/go-sdk@latest
-#19 0.902 github.com/AI-agent-assembly/go-sdk v0.0.0-20260520010711-912053a56c4c  DONE 0.9s
+#19 [stage-1 5/5] RUN go list -m github.com/ai-agent-assembly/go-sdk@latest
+#19 0.902 github.com/ai-agent-assembly/go-sdk v0.0.0-20260520010711-912053a56c4c  DONE 0.9s
 #20 exporting to image                                                   DONE 0.6s
 === BUILD END: 2026-05-20T01:55:56Z ===
 === EXIT: 0 ===
@@ -123,13 +123,13 @@ Local Node build transcript (failure verbatim — this is the
 #13 [aasm-builder 5/5] RUN cargo build --release -p aa-cli --bin aasm    CACHED
 #14 [stage-1 2/7]   RUN apt-get install git                              DONE ~25s
 #15 [stage-1 3/7]   COPY --from=aasm-builder /usr/local/bin/aasm ...     DONE 0.0s
-#16 [stage-1 4/7]   RUN npm install -g 'github:AI-agent-assembly/node-sdk'
+#16 [stage-1 4/7]   RUN npm install -g 'github:ai-agent-assembly/node-sdk'
 #16 1.735 npm error code 128
 #16 1.735 npm error An unknown git error occurred
-#16 1.735 npm error command git --no-replace-objects ls-remote ssh://git@github.com/AI-agent-assembly/node-sdk.git
+#16 1.735 npm error command git --no-replace-objects ls-remote ssh://git@github.com/ai-agent-assembly/node-sdk.git
 #16 1.736 npm error ssh -oStrictHostKeyChecking=accept-new: 1: ssh: not found
 #16 1.736 npm error fatal: Could not read from remote repository.
-#16 ERROR: process "/bin/sh -c npm install -g 'github:AI-agent-assembly/node-sdk'" did not complete successfully: exit code: 128
+#16 ERROR: process "/bin/sh -c npm install -g 'github:ai-agent-assembly/node-sdk'" did not complete successfully: exit code: 128
 === BUILD END: 2026-05-20T01:57:32Z ===
 === EXIT: 1 ===
 ```
@@ -188,7 +188,7 @@ the Dockerfile's transitional install line collapses to
 **Adapted** per [AAASM-1508]. Two changes vs. the parent-Story AC text:
 
 1. **Module path capitalisation** — the actual module is
-   `github.com/AI-agent-assembly/go-sdk` (capitalised org segment), not
+   `github.com/ai-agent-assembly/go-sdk` (capitalised org segment), not
    `github.com/agent-assembly/go-sdk` (per [AAASM-1502]).
 2. **`go list <import>` → `go list -m <module>@latest`** — the plain `go list
    <import>` form needs both a module context (a `go.mod` cwd) AND a
@@ -201,14 +201,14 @@ the Dockerfile's transitional install line collapses to
 Adapted smoke:
 
 ```
-$ docker run --rm aaasm-verify/go:local go list -m github.com/AI-agent-assembly/go-sdk@latest
+$ docker run --rm aaasm-verify/go:local go list -m github.com/ai-agent-assembly/go-sdk@latest
 WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
-github.com/AI-agent-assembly/go-sdk v0.0.0-20260520010711-912053a56c4c
+github.com/ai-agent-assembly/go-sdk v0.0.0-20260520010711-912053a56c4c
 ```
 
 This adaptation is also encoded in
 [`.github/workflows/docker.yml:90`](../.github/workflows/docker.yml)
-(`smoke_run: "go list -m github.com/AI-agent-assembly/go-sdk@latest"`),
+(`smoke_run: "go list -m github.com/ai-agent-assembly/go-sdk@latest"`),
 so CI and local verification both exercise the adapted form.
 
 ### ✅ Smoke run — `aasm --version` for every produced variant
@@ -254,7 +254,7 @@ which compresses well — hence the 528 MB → 153 MB ratio.
 
 ### ✅ CI workflow (AAASM-1225) build job passes for the active variants on the integration PR
 
-Per the AAASM-1225 PR ([#515](https://github.com/AI-agent-assembly/agent-assembly/pull/515)),
+Per the AAASM-1225 PR ([#515](https://github.com/ai-agent-assembly/agent-assembly/pull/515)),
 the matrix runs the Python and Go variants only. PR #515 merged green, which
 is the AC evidence that the workflow extension itself works. The matrix is
 deliberately 2-of-3 today; Node is restored under [AAASM-1503]. The Node
@@ -277,7 +277,7 @@ This file.
 | Node `require('@agent-assembly/sdk')` smoke | ⚠️ Deferred | [AAASM-1503] | Same |
 | Node compressed-size measurement | ⚠️ Deferred | [AAASM-1503] | Same |
 | Go `go list <import>` smoke text | ⚠️ Adapted to `go list -m <module>@latest` | [AAASM-1508] (already merged) | n/a — adaptation final |
-| Go module path `github.com/agent-assembly/go-sdk` | ⚠️ Adapted to `github.com/AI-agent-assembly/go-sdk` | [AAASM-1502] (already merged) | n/a — adaptation final |
+| Go module path `github.com/agent-assembly/go-sdk` | ⚠️ Adapted to `github.com/ai-agent-assembly/go-sdk` | [AAASM-1502] (already merged) | n/a — adaptation final |
 
 ## Adaptations summary (mirrors the AAASM-1066 pattern)
 
@@ -285,7 +285,7 @@ This file.
 |---|---|---|---|
 | 1 | `linux/amd64` AND `linux/arm64` build | amd64 verified locally for python+go; arm64 deferred to first `v*` tag | Buildkit's `--load` and multi-arch are mutually exclusive; CI design correctly gates multi-arch on tag pushes |
 | 2 | `<node>` smoke run | Node smoke deferred entirely; image not produced | npm `github:` shorthand → `ssh://` rewrite; no ssh client in node:24-slim → [AAASM-1501] / [AAASM-1503] |
-| 3 | `go list github.com/agent-assembly/go-sdk` | `go list -m github.com/AI-agent-assembly/go-sdk@latest` | Module path capitalisation ([AAASM-1502]) + no-go.mod / no-root-package shape ([AAASM-1508]) |
+| 3 | `go list github.com/agent-assembly/go-sdk` | `go list -m github.com/ai-agent-assembly/go-sdk@latest` | Module path capitalisation ([AAASM-1502]) + no-go.mod / no-root-package shape ([AAASM-1508]) |
 | 4 | `ghcr.io/agent-assembly/<lang>:<tag>` pull/run after v0.0.1 tag | Deferred; workflow code present | No `v0.0.1` tag has been cut yet; the release flow owns this |
 
 ## Sign-off

--- a/verification-reports/AAASM-1214.md
+++ b/verification-reports/AAASM-1214.md
@@ -11,10 +11,10 @@ Verification of the three implementation sub-tickets under F111:
 
 | Sub-ticket | PR | Repo |
 | --- | --- | --- |
-| [AAASM-1210](https://lightning-dust-mite.atlassian.net/browse/AAASM-1210) | [AI-agent-assembly/homebrew-agent-assembly#1](https://github.com/AI-agent-assembly/homebrew-agent-assembly/pull/1) | `homebrew-agent-assembly` (new) |
-| [AAASM-1211](https://lightning-dust-mite.atlassian.net/browse/AAASM-1211) | [AI-agent-assembly/homebrew-agent-assembly#2](https://github.com/AI-agent-assembly/homebrew-agent-assembly/pull/2) | `homebrew-agent-assembly` |
-| [AAASM-1212](https://lightning-dust-mite.atlassian.net/browse/AAASM-1212) | [AI-agent-assembly/agent-assembly#713](https://github.com/AI-agent-assembly/agent-assembly/pull/713) | `agent-assembly` |
-| [AAASM-1213](https://lightning-dust-mite.atlassian.net/browse/AAASM-1213) | [AI-agent-assembly/agent-assembly#719](https://github.com/AI-agent-assembly/agent-assembly/pull/719) | `agent-assembly` |
+| [AAASM-1210](https://lightning-dust-mite.atlassian.net/browse/AAASM-1210) | [ai-agent-assembly/homebrew-agent-assembly#1](https://github.com/ai-agent-assembly/homebrew-agent-assembly/pull/1) | `homebrew-agent-assembly` (new) |
+| [AAASM-1211](https://lightning-dust-mite.atlassian.net/browse/AAASM-1211) | [ai-agent-assembly/homebrew-agent-assembly#2](https://github.com/ai-agent-assembly/homebrew-agent-assembly/pull/2) | `homebrew-agent-assembly` |
+| [AAASM-1212](https://lightning-dust-mite.atlassian.net/browse/AAASM-1212) | [ai-agent-assembly/agent-assembly#713](https://github.com/ai-agent-assembly/agent-assembly/pull/713) | `agent-assembly` |
+| [AAASM-1213](https://lightning-dust-mite.atlassian.net/browse/AAASM-1213) | [ai-agent-assembly/agent-assembly#719](https://github.com/ai-agent-assembly/agent-assembly/pull/719) | `agent-assembly` |
 
 ## Static checks
 
@@ -52,12 +52,12 @@ Functions extracted verbatim from `scripts/install-cli.sh` for in-isolation exec
 | `brew install agent-assembly/tap/aasm` on macOS x86_64 | ⏸ Gated — first real release | Same as above |
 | `brew install agent-assembly/tap/aasm` on Linux x86_64 + ARM64 | ⏸ Gated — first real release | Same as above |
 | `curl -fsSL https://get.agent-assembly.io \| sh` on Linux x86_64 + macOS ARM64 | ⏸ Gated — DNS + hosting | Script logic verified (T1–T3); requires `get.agent-assembly.io` to be configured to serve `scripts/install-cli.sh`. Tracked separately under the distribution infra backlog. |
-| Installer script verifies SHA256 checksum before placing binary | ✅ PASS | Confirmed by T2 (accept) + T3 (reject on tamper); see [AAASM-1212 PR](https://github.com/AI-agent-assembly/agent-assembly/pull/713) |
+| Installer script verifies SHA256 checksum before placing binary | ✅ PASS | Confirmed by T2 (accept) + T3 (reject on tamper); see [AAASM-1212 PR](https://github.com/ai-agent-assembly/agent-assembly/pull/713) |
 | CI release workflow auto-updates formula SHA256 values on new tag push | ✅ PASS (design) | Verified statically (S3) — the 6-step `update-homebrew-tap` job exists, downloads SHA256SUMS, extracts four per-platform shas, rewrites `Formula/aasm.rb`, opens a PR via `peter-evans/create-pull-request@v7`. End-to-end requires `HOMEBREW_TAP_TOKEN` repo secret to be configured + the next real tag push. |
 
 ## Gating notes — what still needs to happen post-merge
 
-1. Engineer creates a fine-grained PAT for `AI-agent-assembly/homebrew-agent-assembly` (Contents + Pull requests: read/write) and adds it to `AI-agent-assembly/agent-assembly` as `HOMEBREW_TAP_TOKEN` repo secret.
+1. Engineer creates a fine-grained PAT for `ai-agent-assembly/homebrew-agent-assembly` (Contents + Pull requests: read/write) and adds it to `ai-agent-assembly/agent-assembly` as `HOMEBREW_TAP_TOKEN` repo secret.
 2. Engineer sets up `get.agent-assembly.io` to serve `scripts/install-cli.sh` from `master` (Cloudflare Pages, GitHub Pages, or equivalent). Out of scope for F111; tracked separately.
 3. First real release tag (e.g. `v0.1.0`) triggers `release.yml` → publishes binaries + SHA256SUMS → `update-homebrew-tap` opens its first PR on the tap repo with real sha values.
 4. After that tap PR merges, the end-to-end checklist items above can be ticked on the 4 supported platforms.

--- a/verification-reports/AAASM-1231.md
+++ b/verification-reports/AAASM-1231.md
@@ -14,10 +14,10 @@
 > two deferred rows already track their unmerged distribution prerequisites
 > ([AAASM-1201] Python wheels, [AAASM-1204] Docker base images).
 >
-> [#48]: https://github.com/AI-agent-assembly/python-sdk/pull/48
-> [#41]: https://github.com/AI-agent-assembly/node-sdk/pull/41
-> [#34]: https://github.com/AI-agent-assembly/go-sdk/pull/34
-> [#634]: https://github.com/AI-agent-assembly/agent-assembly/pull/634
+> [#48]: https://github.com/ai-agent-assembly/python-sdk/pull/48
+> [#41]: https://github.com/ai-agent-assembly/node-sdk/pull/41
+> [#34]: https://github.com/ai-agent-assembly/go-sdk/pull/34
+> [#634]: https://github.com/ai-agent-assembly/agent-assembly/pull/634
 > [AAASM-1199]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1199
 > [AAASM-1201]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1201
 > [AAASM-1204]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1204

--- a/verification-reports/AAASM-1258.md
+++ b/verification-reports/AAASM-1258.md
@@ -14,11 +14,11 @@
 
 | Sub-task | Title | Status | PR |
 |---|---|---|---|
-| AAASM-1448 | ST-0a: Rename `aa-topology-integration-tests` → `aa-integration-tests` | Done | [#484](https://github.com/AI-agent-assembly/agent-assembly/pull/484) |
-| AAASM-1449 | ST-0: Extend harness with `CliFixture` + format helpers + fixtures | Done | [#485](https://github.com/AI-agent-assembly/agent-assembly/pull/485) |
-| AAASM-1260 | ST-1: `cli_topology.rs` — 18 tests covering 5 leaves | Done | [#488](https://github.com/AI-agent-assembly/agent-assembly/pull/488) |
-| AAASM-1262 | ST-2: `cli_agent.rs` — 19 tests covering 5 leaves incl. `--watch` | Done | [#490](https://github.com/AI-agent-assembly/agent-assembly/pull/490) |
-| AAASM-1261 | ST-3: `cli_policy.rs` — 14 tests covering 5 leaves + `seed_policy` | Done | [#491](https://github.com/AI-agent-assembly/agent-assembly/pull/491) |
+| AAASM-1448 | ST-0a: Rename `aa-topology-integration-tests` → `aa-integration-tests` | Done | [#484](https://github.com/ai-agent-assembly/agent-assembly/pull/484) |
+| AAASM-1449 | ST-0: Extend harness with `CliFixture` + format helpers + fixtures | Done | [#485](https://github.com/ai-agent-assembly/agent-assembly/pull/485) |
+| AAASM-1260 | ST-1: `cli_topology.rs` — 18 tests covering 5 leaves | Done | [#488](https://github.com/ai-agent-assembly/agent-assembly/pull/488) |
+| AAASM-1262 | ST-2: `cli_agent.rs` — 19 tests covering 5 leaves incl. `--watch` | Done | [#490](https://github.com/ai-agent-assembly/agent-assembly/pull/490) |
+| AAASM-1261 | ST-3: `cli_policy.rs` — 14 tests covering 5 leaves + `seed_policy` | Done | [#491](https://github.com/ai-agent-assembly/agent-assembly/pull/491) |
 | AAASM-1263 | ST-9: Verify Phase A on Linux + macOS CI | in this report | — |
 
 ## Per-leaf test breakdown
@@ -85,17 +85,17 @@ consecutive successful runs:
 
 | Run | Branch / SHA | Result |
 |---|---|---|
-| [25985983847](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/25985983847) | ST-3 final (`c857475`) | ✅ both OSes |
-| [25986906654](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/25986906654) | AAASM-1467 (cli_version) | ✅ both OSes |
-| [25986997419](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/25986997419) | AAASM-1463 (cli_context) | ✅ both OSes |
-| [25987034667](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/25987034667) | AAASM-1464 (cli_completion) | ✅ both OSes |
-| [25987177929](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/25987177929) | AAASM-1468 (cli_trace) | ✅ both OSes |
-| [25987320240](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/25987320240) | AAASM-1466 (cli_status) | ✅ both OSes |
-| [25988962625](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/25988962625) | AAASM-1462 (cli_logs) | ✅ both OSes |
-| [25989484659](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/25989484659) | AAASM-1470 (cli_cost) | ✅ both OSes |
-| [25989539389](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/25989539389) | AAASM-1461 (cli_audit) | ✅ both OSes |
-| [25990165694](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/25990165694) | AAASM-1476 (audit-reader bugfix) | ✅ both OSes |
-| [25991254254](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/25991254254) | AAASM-1481 (cli_dashboard ST-15b lifecycle) | ✅ both OSes |
+| [25985983847](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/25985983847) | ST-3 final (`c857475`) | ✅ both OSes |
+| [25986906654](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/25986906654) | AAASM-1467 (cli_version) | ✅ both OSes |
+| [25986997419](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/25986997419) | AAASM-1463 (cli_context) | ✅ both OSes |
+| [25987034667](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/25987034667) | AAASM-1464 (cli_completion) | ✅ both OSes |
+| [25987177929](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/25987177929) | AAASM-1468 (cli_trace) | ✅ both OSes |
+| [25987320240](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/25987320240) | AAASM-1466 (cli_status) | ✅ both OSes |
+| [25988962625](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/25988962625) | AAASM-1462 (cli_logs) | ✅ both OSes |
+| [25989484659](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/25989484659) | AAASM-1470 (cli_cost) | ✅ both OSes |
+| [25989539389](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/25989539389) | AAASM-1461 (cli_audit) | ✅ both OSes |
+| [25990165694](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/25990165694) | AAASM-1476 (audit-reader bugfix) | ✅ both OSes |
+| [25991254254](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/25991254254) | AAASM-1481 (cli_dashboard ST-15b lifecycle) | ✅ both OSes |
 
 The `agent list --watch` streaming test in particular — the AC's named
 flake-risk case — has passed in every one of these runs.
@@ -187,11 +187,11 @@ to the matrix view showing both `ubuntu-latest` and `macos-latest` jobs.
 
 | ST | PR | Head SHA | Integration tests run |
 |---|---|---|---|
-| ST-1 (`cli_topology`) | [#488](https://github.com/AI-agent-assembly/agent-assembly/pull/488) | `facd7ee6` | [25984760358](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/25984760358) — both OSes ✅ |
-| ST-2 (`cli_agent`) | [#490](https://github.com/AI-agent-assembly/agent-assembly/pull/490) | `606ee454` | [25985565523](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/25985565523) — both OSes ✅ |
-| ST-3 (`cli_policy`) | [#491](https://github.com/AI-agent-assembly/agent-assembly/pull/491) | `c857475a` | [25985983847](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/25985983847) — both OSes ✅ |
-| ST-0 (`CliFixture` + format helpers) | [#485](https://github.com/AI-agent-assembly/agent-assembly/pull/485) | (merged earlier; no Phase-A files yet — smoke-only) | — |
-| ST-0a (crate rename) | [#484](https://github.com/AI-agent-assembly/agent-assembly/pull/484) | (workflow rename; no Phase-A files yet) | — |
+| ST-1 (`cli_topology`) | [#488](https://github.com/ai-agent-assembly/agent-assembly/pull/488) | `facd7ee6` | [25984760358](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/25984760358) — both OSes ✅ |
+| ST-2 (`cli_agent`) | [#490](https://github.com/ai-agent-assembly/agent-assembly/pull/490) | `606ee454` | [25985565523](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/25985565523) — both OSes ✅ |
+| ST-3 (`cli_policy`) | [#491](https://github.com/ai-agent-assembly/agent-assembly/pull/491) | `c857475a` | [25985983847](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/25985983847) — both OSes ✅ |
+| ST-0 (`CliFixture` + format helpers) | [#485](https://github.com/ai-agent-assembly/agent-assembly/pull/485) | (merged earlier; no Phase-A files yet — smoke-only) | — |
+| ST-0a (crate rename) | [#484](https://github.com/ai-agent-assembly/agent-assembly/pull/484) | (workflow rename; no Phase-A files yet) | — |
 
 ## Local test transcript (cross-check against CI)
 

--- a/verification-reports/AAASM-1386.md
+++ b/verification-reports/AAASM-1386.md
@@ -11,14 +11,14 @@
 
 | Sub-task | Title | Status | PR |
 |---|---|---|---|
-| AAASM-1615 | Add `AlertRule` domain types + validation | Done | [#592](https://github.com/AI-agent-assembly/agent-assembly/pull/592) |
-| AAASM-1616 | Add `AlertRuleStore` trait + `InMemoryAlertRuleStore` | Done | [#601](https://github.com/AI-agent-assembly/agent-assembly/pull/601) |
-| AAASM-1617 | Add in-memory `DestinationRegistry` stub | Done | [#602](https://github.com/AI-agent-assembly/agent-assembly/pull/602) |
-| AAASM-1618 | Extend `ProblemDetail` with optional `error_code` field | Done | [#603](https://github.com/AI-agent-assembly/agent-assembly/pull/603) |
-| AAASM-1619 | Wire `alert_rule_store` + `destination_registry` into `AppState` | Done | [#604](https://github.com/AI-agent-assembly/agent-assembly/pull/604) |
-| AAASM-1620 | Add CRUD handlers + register routes + utoipa annotations | Done | [#607](https://github.com/AI-agent-assembly/agent-assembly/pull/607) |
-| AAASM-1621 | Add minimum-viable rule evaluator + wire into `run_server` | Done | [#608](https://github.com/AI-agent-assembly/agent-assembly/pull/608) |
-| AAASM-1622 | Add integration tests `aa-api/tests/alert_rules.rs` | Done | [#610](https://github.com/AI-agent-assembly/agent-assembly/pull/610) |
+| AAASM-1615 | Add `AlertRule` domain types + validation | Done | [#592](https://github.com/ai-agent-assembly/agent-assembly/pull/592) |
+| AAASM-1616 | Add `AlertRuleStore` trait + `InMemoryAlertRuleStore` | Done | [#601](https://github.com/ai-agent-assembly/agent-assembly/pull/601) |
+| AAASM-1617 | Add in-memory `DestinationRegistry` stub | Done | [#602](https://github.com/ai-agent-assembly/agent-assembly/pull/602) |
+| AAASM-1618 | Extend `ProblemDetail` with optional `error_code` field | Done | [#603](https://github.com/ai-agent-assembly/agent-assembly/pull/603) |
+| AAASM-1619 | Wire `alert_rule_store` + `destination_registry` into `AppState` | Done | [#604](https://github.com/ai-agent-assembly/agent-assembly/pull/604) |
+| AAASM-1620 | Add CRUD handlers + register routes + utoipa annotations | Done | [#607](https://github.com/ai-agent-assembly/agent-assembly/pull/607) |
+| AAASM-1621 | Add minimum-viable rule evaluator + wire into `run_server` | Done | [#608](https://github.com/ai-agent-assembly/agent-assembly/pull/608) |
+| AAASM-1622 | Add integration tests `aa-api/tests/alert_rules.rs` | Done | [#610](https://github.com/ai-agent-assembly/agent-assembly/pull/610) |
 | AAASM-1623 | Verify Add alert-rules CRUD endpoints acceptance criteria | in this report | — |
 
 ## Acceptance-criteria walkthrough

--- a/verification-reports/AAASM-1441.md
+++ b/verification-reports/AAASM-1441.md
@@ -52,9 +52,9 @@
 | [AAASM-1443] | Author Python 3.10/3.11/3.12/3.13 Dockerfiles | Done | (merged) |
 | [AAASM-1444] | Author Node v20/v22 Dockerfiles | Done | (merged) |
 | [AAASM-1445] | Author Go 1.24/1.25 Dockerfiles | Done | (merged) |
-| [AAASM-1446] | Extend docker.yml matrix (2 → 6 active + 5 deferred) | Done | [#616](https://github.com/AI-agent-assembly/agent-assembly/pull/616) |
-| [AAASM-1671] | [BUG] Python pip-before-COPY regression of AAASM-1500 | Done | [#617](https://github.com/AI-agent-assembly/agent-assembly/pull/617) |
-| [AAASM-1672] | [BUG] Go GOTOOLCHAIN=auto + AAASM-1508 smoke backport | Done | [#618](https://github.com/AI-agent-assembly/agent-assembly/pull/618) |
+| [AAASM-1446] | Extend docker.yml matrix (2 → 6 active + 5 deferred) | Done | [#616](https://github.com/ai-agent-assembly/agent-assembly/pull/616) |
+| [AAASM-1671] | [BUG] Python pip-before-COPY regression of AAASM-1500 | Done | [#617](https://github.com/ai-agent-assembly/agent-assembly/pull/617) |
+| [AAASM-1672] | [BUG] Go GOTOOLCHAIN=auto + AAASM-1508 smoke backport | Done | [#618](https://github.com/ai-agent-assembly/agent-assembly/pull/618) |
 | [AAASM-1447] | Verify F114b | in this report | this PR |
 | [AAASM-1660] | Re-enable node:20 after AAASM-1203 | To Do (blocked) | — |
 | [AAASM-1661] | Re-enable node:22 after AAASM-1203 | To Do (blocked) | — |
@@ -134,12 +134,12 @@ docker/Dockerfile.go-1.24-alpine      AAASM-1445 (GOTOOLCHAIN+smoke fixed by AAA
 #15 [aasm-builder 5/5] RUN cargo build --release -p aa-cli --bin aasm    CACHED
 #16 [stage-1 1/5] FROM docker.io/library/golang:1.25-alpine              DONE 0.2s
 #17 [stage-1 2/5] COPY --from=aasm-builder /usr/local/bin/aasm ...       DONE 0.0s
-#18 [stage-1 3/5] RUN go install github.com/AI-agent-assembly/go-sdk/...@latest
+#18 [stage-1 3/5] RUN go install github.com/ai-agent-assembly/go-sdk/...@latest
 #18 (GOTOOLCHAIN=auto pulls Go 1.26 on demand — see AAASM-1672)          DONE ~13s
 #19 [stage-1 4/5] RUN aasm --version
 #19 0.281 aasm 0.0.1                                                     DONE 0.4s
-#20 [stage-1 5/5] RUN go list -m github.com/AI-agent-assembly/go-sdk@latest
-#20 0.892 github.com/AI-agent-assembly/go-sdk v0.0.0-...                 DONE 0.9s
+#20 [stage-1 5/5] RUN go list -m github.com/ai-agent-assembly/go-sdk@latest
+#20 0.892 github.com/ai-agent-assembly/go-sdk v0.0.0-...                 DONE 0.9s
 === BUILD END go:1.25-alpine (2026-05-21T01:30:04Z) EXIT=0 ===
 ```
 
@@ -156,7 +156,7 @@ docker/Dockerfile.go-1.24-alpine      AAASM-1445 (GOTOOLCHAIN+smoke fixed by AAA
 #15 [aasm-builder 5/5] RUN cargo build --release -p aa-cli --bin aasm    CACHED
 #19 [stage-1 3/7] RUN pip install agent-assembly @ git+...
 #19 7.941 ERROR: Package 'agent-assembly' requires a different Python: 3.10.20 not in '<4.0,>=3.12'
-#19 ERROR: process "/bin/sh -c pip install --no-cache-dir 'agent-assembly @ git+https://github.com/AI-agent-assembly/python-sdk.git'" did not complete successfully: exit code: 1
+#19 ERROR: process "/bin/sh -c pip install --no-cache-dir 'agent-assembly @ git+https://github.com/ai-agent-assembly/python-sdk.git'" did not complete successfully: exit code: 1
 === BUILD END python:3.10-slim (2026-05-21T01:31:56Z) EXIT=1 ===
 ```
 
@@ -170,10 +170,10 @@ cause, same fix path).
 ```
 === BUILD START node:20-slim (2026-05-21T01:31:56Z) ===
 #15 [aasm-builder 5/5] RUN cargo build --release -p aa-cli --bin aasm    CACHED
-#16 [stage-1 4/7] RUN npm install -g 'github:AI-agent-assembly/node-sdk'
+#16 [stage-1 4/7] RUN npm install -g 'github:ai-agent-assembly/node-sdk'
 #16 0.989 npm error fatal: Could not read from remote repository.
 #16 0.990 npm error A complete log of this run can be found in: /root/.npm/_logs/2026-05-21T01_32_00_832Z-debug-0.log
-#16 ERROR: process "/bin/sh -c npm install -g 'github:AI-agent-assembly/node-sdk'" did not complete successfully: exit code: 128
+#16 ERROR: process "/bin/sh -c npm install -g 'github:ai-agent-assembly/node-sdk'" did not complete successfully: exit code: 128
 === BUILD END node:20-slim (2026-05-21T01:32:01Z) EXIT=1 ===
 ```
 
@@ -221,11 +221,11 @@ python:3.12-slim
 
 go:1.25-alpine
   $ aasm --version                                       → aasm 0.0.1
-  $ go list -m github.com/AI-agent-assembly/go-sdk@latest → github.com/AI-agent-assembly/go-sdk v0.0.0-20260520161412-60249bbb18a1
+  $ go list -m github.com/ai-agent-assembly/go-sdk@latest → github.com/ai-agent-assembly/go-sdk v0.0.0-20260520161412-60249bbb18a1
 
 go:1.24-alpine
   $ aasm --version                                       → aasm 0.0.1
-  $ go list -m github.com/AI-agent-assembly/go-sdk@latest → github.com/AI-agent-assembly/go-sdk v0.0.0-20260520161412-60249bbb18a1
+  $ go list -m github.com/ai-agent-assembly/go-sdk@latest → github.com/ai-agent-assembly/go-sdk v0.0.0-20260520161412-60249bbb18a1
 ```
 
 Host-platform mismatch warnings (`linux/amd64 vs linux/arm64/v8`) are
@@ -264,8 +264,8 @@ becomes the follow-up fix path.
 
 ### ✅ CI workflow build job passes for active variants on integration PR
 
-[PR #616](https://github.com/AI-agent-assembly/agent-assembly/pull/616)
-final CI run [26197695698](https://github.com/AI-agent-assembly/agent-assembly/actions/runs/26197695698):
+[PR #616](https://github.com/ai-agent-assembly/agent-assembly/pull/616)
+final CI run [26197695698](https://github.com/ai-agent-assembly/agent-assembly/actions/runs/26197695698):
 **7/7 checks SUCCESS** (1 aa-runtime + 3 python + 3 go matrix legs). PR
 merged 2026-05-21.
 

--- a/verification-reports/AAASM-1575-acceptance.md
+++ b/verification-reports/AAASM-1575-acceptance.md
@@ -14,10 +14,10 @@
 
 | PR | Sub-ticket | Scope |
 |---|---|---|
-| [#643](https://github.com/AI-agent-assembly/agent-assembly/pull/643) | AAASM-1689 | `DeploymentMode` enum + config module scaffold |
-| [#645](https://github.com/AI-agent-assembly/agent-assembly/pull/645) | AAASM-1690 | Sub-structs (`LocalModeConfig` / `RemoteModeConfig` / `TlsConfig` / `AgentConnectConfig`) |
-| [#648](https://github.com/AI-agent-assembly/agent-assembly/pull/648) | AAASM-1691 | `GatewayConfig` + YAML loader + `~` expansion |
-| [#649](https://github.com/AI-agent-assembly/agent-assembly/pull/649) | AAASM-1692 | Env-var override layer + invalid-value errors |
+| [#643](https://github.com/ai-agent-assembly/agent-assembly/pull/643) | AAASM-1689 | `DeploymentMode` enum + config module scaffold |
+| [#645](https://github.com/ai-agent-assembly/agent-assembly/pull/645) | AAASM-1690 | Sub-structs (`LocalModeConfig` / `RemoteModeConfig` / `TlsConfig` / `AgentConnectConfig`) |
+| [#648](https://github.com/ai-agent-assembly/agent-assembly/pull/648) | AAASM-1691 | `GatewayConfig` + YAML loader + `~` expansion |
+| [#649](https://github.com/ai-agent-assembly/agent-assembly/pull/649) | AAASM-1692 | Env-var override layer + invalid-value errors |
 
 ---
 

--- a/verification-reports/AAASM-1576_e17_s_b_acceptance.md
+++ b/verification-reports/AAASM-1576_e17_s_b_acceptance.md
@@ -15,13 +15,13 @@
 
 | # | Key | PR | Title |
 | --- | --- | --- | --- |
-| 1 | [AAASM-1701](https://lightning-dust-mite.atlassian.net/browse/AAASM-1701) | [#655](https://github.com/AI-agent-assembly/agent-assembly/pull/655) | local_mode module scaffold — handle, healthz response, error types |
-| 2 | [AAASM-1705](https://lightning-dust-mite.atlassian.net/browse/AAASM-1705) | [#670](https://github.com/AI-agent-assembly/agent-assembly/pull/670) | Mount /healthz in local_mode router via routes::healthz |
-| 3 | [AAASM-1710](https://lightning-dust-mite.atlassian.net/browse/AAASM-1710) | [#687](https://github.com/AI-agent-assembly/agent-assembly/pull/687) | SQLite open + parent-dir mkdir helpers |
-| 4 | [AAASM-1715](https://lightning-dust-mite.atlassian.net/browse/AAASM-1715) | [#693](https://github.com/AI-agent-assembly/agent-assembly/pull/693) | Idempotent healthz pre-flight probe |
-| 5 | [AAASM-1725](https://lightning-dust-mite.atlassian.net/browse/AAASM-1725) | [#696](https://github.com/AI-agent-assembly/agent-assembly/pull/696) | start_local() orchestrator + 127.0.0.1 bind + PID file |
-| 6 | [AAASM-1728](https://lightning-dust-mite.atlassian.net/browse/AAASM-1728) | [#701](https://github.com/AI-agent-assembly/agent-assembly/pull/701) | Graceful shutdown + PID/DB cleanup |
-| 7 | [AAASM-1731](https://lightning-dust-mite.atlassian.net/browse/AAASM-1731) | [#703](https://github.com/AI-agent-assembly/agent-assembly/pull/703) | Wire DeploymentMode dispatch — AA_MODE=local boots local CP |
+| 1 | [AAASM-1701](https://lightning-dust-mite.atlassian.net/browse/AAASM-1701) | [#655](https://github.com/ai-agent-assembly/agent-assembly/pull/655) | local_mode module scaffold — handle, healthz response, error types |
+| 2 | [AAASM-1705](https://lightning-dust-mite.atlassian.net/browse/AAASM-1705) | [#670](https://github.com/ai-agent-assembly/agent-assembly/pull/670) | Mount /healthz in local_mode router via routes::healthz |
+| 3 | [AAASM-1710](https://lightning-dust-mite.atlassian.net/browse/AAASM-1710) | [#687](https://github.com/ai-agent-assembly/agent-assembly/pull/687) | SQLite open + parent-dir mkdir helpers |
+| 4 | [AAASM-1715](https://lightning-dust-mite.atlassian.net/browse/AAASM-1715) | [#693](https://github.com/ai-agent-assembly/agent-assembly/pull/693) | Idempotent healthz pre-flight probe |
+| 5 | [AAASM-1725](https://lightning-dust-mite.atlassian.net/browse/AAASM-1725) | [#696](https://github.com/ai-agent-assembly/agent-assembly/pull/696) | start_local() orchestrator + 127.0.0.1 bind + PID file |
+| 6 | [AAASM-1728](https://lightning-dust-mite.atlassian.net/browse/AAASM-1728) | [#701](https://github.com/ai-agent-assembly/agent-assembly/pull/701) | Graceful shutdown + PID/DB cleanup |
+| 7 | [AAASM-1731](https://lightning-dust-mite.atlassian.net/browse/AAASM-1731) | [#703](https://github.com/ai-agent-assembly/agent-assembly/pull/703) | Wire DeploymentMode dispatch — AA_MODE=local boots local CP |
 
 ---
 

--- a/verification-reports/AAASM-1580.md
+++ b/verification-reports/AAASM-1580.md
@@ -225,5 +225,5 @@ $ cargo nextest run -p aa-gateway local_mode::
 
 | Sub-task | PR | Merge commit |
 |---|---|---|
-| AAASM-1843 — `dashboard_server` module + `tower-http` dep + unit tests | [#715](https://github.com/AI-agent-assembly/agent-assembly/pull/715) | `e4e5159daac7` |
-| AAASM-1844 — wire `dashboard_router` into `local_mode::router()` + integration tests | [#723](https://github.com/AI-agent-assembly/agent-assembly/pull/723) | `02767959` |
+| AAASM-1843 — `dashboard_server` module + `tower-http` dep + unit tests | [#715](https://github.com/ai-agent-assembly/agent-assembly/pull/715) | `e4e5159daac7` |
+| AAASM-1844 — wire `dashboard_router` into `local_mode::router()` + integration tests | [#723](https://github.com/ai-agent-assembly/agent-assembly/pull/723) | `02767959` |

--- a/verification-reports/AAASM-1583.md
+++ b/verification-reports/AAASM-1583.md
@@ -1,7 +1,7 @@
 # E18 S-A Verification — AAASM-1583 (`StorageBackend` trait)
 
 > **Status**: parent Story [AAASM-1583] sub-tasks both shipped on Sprint-4
-> branches. Implementation lands in [AI-agent-assembly/agent-assembly#644],
+> branches. Implementation lands in [ai-agent-assembly/agent-assembly#644],
 > verification lands in this PR. All six Story-level acceptance bullets
 > verified clean below — no follow-up Bug Sub-task opened.
 
@@ -9,13 +9,13 @@
 [AAASM-1583]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1583
 [AAASM-1694]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1694
 [AAASM-1695]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1695
-[AI-agent-assembly/agent-assembly#644]: https://github.com/AI-agent-assembly/agent-assembly/pull/644
+[ai-agent-assembly/agent-assembly#644]: https://github.com/ai-agent-assembly/agent-assembly/pull/644
 
 ## Sub-task roll-up
 
 | Sub-task | Title | Status | PR |
 |---|---|---|---|
-| [AAASM-1694] | E18 S-A Impl — define trait + value types | Done (open PR) | [#644](https://github.com/AI-agent-assembly/agent-assembly/pull/644) |
+| [AAASM-1694] | E18 S-A Impl — define trait + value types | Done (open PR) | [#644](https://github.com/ai-agent-assembly/agent-assembly/pull/644) |
 | [AAASM-1695] | E18 S-A Verify — confirm AC | in this report | this PR |
 
 ## Walkthrough vs AAASM-1583 acceptance criteria

--- a/verification-reports/AAASM-1584-acceptance.md
+++ b/verification-reports/AAASM-1584-acceptance.md
@@ -26,13 +26,13 @@ end-to-end restart test under `aa-gateway/tests/sqlite_restart_persistence_test.
 
 | Sub-task | Scope | PR |
 |---|---|---|
-| AAASM-1697 (S-B.1) | sqlx chrono feature, `SqliteConfig`, `SqliteBackend::open` (WAL + parent-dir creation) | [#656](https://github.com/AI-agent-assembly/agent-assembly/pull/656) |
-| AAASM-1700 (S-B.2) | Schema DDL + idempotent `migrate()` | [#665](https://github.com/AI-agent-assembly/agent-assembly/pull/665) |
-| AAASM-1704 (S-B.3) | Audit-event slice (`append` / `query` / `count`) + `impl StorageBackend` skeleton | [#673](https://github.com/AI-agent-assembly/agent-assembly/pull/673) |
-| AAASM-1708 (S-B.4) | Agent-registry slice (`upsert` / `get` / `list` / `delete`) | [#675](https://github.com/AI-agent-assembly/agent-assembly/pull/675) |
-| AAASM-1712 (S-B.5) | Policy-version slice (`save` / `get_active` / `list_versions` / `rollback`) | [#678](https://github.com/AI-agent-assembly/agent-assembly/pull/678) |
-| AAASM-1714 (S-B.6) | Metric slice (`record` / `query`) | [#679](https://github.com/AI-agent-assembly/agent-assembly/pull/679) |
-| AAASM-1721 (S-B.7) | Retention DELETE + `healthcheck` with row counts | [#680](https://github.com/AI-agent-assembly/agent-assembly/pull/680) |
+| AAASM-1697 (S-B.1) | sqlx chrono feature, `SqliteConfig`, `SqliteBackend::open` (WAL + parent-dir creation) | [#656](https://github.com/ai-agent-assembly/agent-assembly/pull/656) |
+| AAASM-1700 (S-B.2) | Schema DDL + idempotent `migrate()` | [#665](https://github.com/ai-agent-assembly/agent-assembly/pull/665) |
+| AAASM-1704 (S-B.3) | Audit-event slice (`append` / `query` / `count`) + `impl StorageBackend` skeleton | [#673](https://github.com/ai-agent-assembly/agent-assembly/pull/673) |
+| AAASM-1708 (S-B.4) | Agent-registry slice (`upsert` / `get` / `list` / `delete`) | [#675](https://github.com/ai-agent-assembly/agent-assembly/pull/675) |
+| AAASM-1712 (S-B.5) | Policy-version slice (`save` / `get_active` / `list_versions` / `rollback`) | [#678](https://github.com/ai-agent-assembly/agent-assembly/pull/678) |
+| AAASM-1714 (S-B.6) | Metric slice (`record` / `query`) | [#679](https://github.com/ai-agent-assembly/agent-assembly/pull/679) |
+| AAASM-1721 (S-B.7) | Retention DELETE + `healthcheck` with row counts | [#680](https://github.com/ai-agent-assembly/agent-assembly/pull/680) |
 | AAASM-1723 (S-B.8) | Cross-restart integration test + this report | _this PR_ |
 
 ---

--- a/verification-reports/AAASM-1585-postgres-backend-verification.md
+++ b/verification-reports/AAASM-1585-postgres-backend-verification.md
@@ -15,14 +15,14 @@ All 8 implementation sub-tasks merged on `master` before this verification:
 
 | # | Sub-task | PR | Merge commit |
 |---|---|---|---|
-| 1 | AAASM-1719 — Scaffold PostgresBackend skeleton + PostgresConfig | [#658](https://github.com/AI-agent-assembly/agent-assembly/pull/658) | `c61a46ce` |
-| 2 | AAASM-1724 — Initial schema migration + `migrate()` | [#688](https://github.com/AI-agent-assembly/agent-assembly/pull/688) | `0fda1064` |
-| 3 | AAASM-1727 — Audit-event ops (`append`/`query`/`count`) | [#695](https://github.com/AI-agent-assembly/agent-assembly/pull/695) | `6d4c48f5` |
-| 4 | AAASM-1729 — Agent-registry ops (`upsert`/`get`/`list`/`delete`) | [#700](https://github.com/AI-agent-assembly/agent-assembly/pull/700) | `49b67201` |
-| 5 | AAASM-1730 — Policy-store ops (`save`/`get_active`/`list`/`rollback`) | [#702](https://github.com/AI-agent-assembly/agent-assembly/pull/702) | `a8329aa2` |
-| 6 | AAASM-1734 — Metrics ops (`record_metric`/`query_metrics` w/ bucket) | [#704](https://github.com/AI-agent-assembly/agent-assembly/pull/704) | `5ab1f9f0` |
-| 7 | AAASM-1738 — `apply_retention` + `healthcheck` | [#706](https://github.com/AI-agent-assembly/agent-assembly/pull/706) | `e24b8463` |
-| 8 | AAASM-1741 — CI `postgres:18-alpine` service for Test + Coverage | [#707](https://github.com/AI-agent-assembly/agent-assembly/pull/707) | `413fe0fe` |
+| 1 | AAASM-1719 — Scaffold PostgresBackend skeleton + PostgresConfig | [#658](https://github.com/ai-agent-assembly/agent-assembly/pull/658) | `c61a46ce` |
+| 2 | AAASM-1724 — Initial schema migration + `migrate()` | [#688](https://github.com/ai-agent-assembly/agent-assembly/pull/688) | `0fda1064` |
+| 3 | AAASM-1727 — Audit-event ops (`append`/`query`/`count`) | [#695](https://github.com/ai-agent-assembly/agent-assembly/pull/695) | `6d4c48f5` |
+| 4 | AAASM-1729 — Agent-registry ops (`upsert`/`get`/`list`/`delete`) | [#700](https://github.com/ai-agent-assembly/agent-assembly/pull/700) | `49b67201` |
+| 5 | AAASM-1730 — Policy-store ops (`save`/`get_active`/`list`/`rollback`) | [#702](https://github.com/ai-agent-assembly/agent-assembly/pull/702) | `a8329aa2` |
+| 6 | AAASM-1734 — Metrics ops (`record_metric`/`query_metrics` w/ bucket) | [#704](https://github.com/ai-agent-assembly/agent-assembly/pull/704) | `5ab1f9f0` |
+| 7 | AAASM-1738 — `apply_retention` + `healthcheck` | [#706](https://github.com/ai-agent-assembly/agent-assembly/pull/706) | `e24b8463` |
+| 8 | AAASM-1741 — CI `postgres:18-alpine` service for Test + Coverage | [#707](https://github.com/ai-agent-assembly/agent-assembly/pull/707) | `413fe0fe` |
 
 ## Story acceptance criteria
 

--- a/verification-reports/AAASM-1586-verification.md
+++ b/verification-reports/AAASM-1586-verification.md
@@ -7,7 +7,7 @@
 | **Verification sub-task** | [AAASM-1862](https://lightning-dust-mite.atlassian.net/browse/AAASM-1862) |
 | **Verifier** | Cross-reference of 9 env-gated tests across SD-1..SD-5, all run live in CI |
 | **Date** | 2026-05-23 |
-| **Authoritative CI run** | PR [#757](https://github.com/AI-agent-assembly/agent-assembly/pull/757) `TimescaleDB Tests` job — green on the merge commit |
+| **Authoritative CI run** | PR [#757](https://github.com/ai-agent-assembly/agent-assembly/pull/757) `TimescaleDB Tests` job — green on the merge commit |
 
 ---
 
@@ -15,13 +15,13 @@
 
 | PR | Sub-ticket | Scope |
 |---|---|---|
-| [#711](https://github.com/AI-agent-assembly/agent-assembly/pull/711) | [AAASM-1848](https://lightning-dust-mite.atlassian.net/browse/AAASM-1848) (SD-1) | `0002_timescaledb_hypertables.sql` migration |
-| [#741](https://github.com/AI-agent-assembly/agent-assembly/pull/741) | [AAASM-1852](https://lightning-dust-mite.atlassian.net/browse/AAASM-1852) (SD-2) | `TimescaleStats` type + `has_timescaledb_extension` probe helper |
-| [#746](https://github.com/AI-agent-assembly/agent-assembly/pull/746) | [AAASM-1853](https://lightning-dust-mite.atlassian.net/browse/AAASM-1853) (SD-3) | `PostgresBackend::apply_timescaledb_setup` with three-path graceful fallback |
-| [#750](https://github.com/AI-agent-assembly/agent-assembly/pull/750) | [AAASM-1855](https://lightning-dust-mite.atlassian.net/browse/AAASM-1855) (SD-4) | `StorageHealth.timescale` field + `healthcheck()` populates from `query_timescale_stats` |
-| [#758](https://github.com/AI-agent-assembly/agent-assembly/pull/758) | [AAASM-1890](https://lightning-dust-mite.atlassian.net/browse/AAASM-1890) (bug) | `0003_timescaledb_compression_policies.sql` follow-up (idempotent guardrail) |
-| [#757](https://github.com/AI-agent-assembly/agent-assembly/pull/757) | [AAASM-1858](https://lightning-dust-mite.atlassian.net/browse/AAASM-1858) (SD-5) | `timescaledb-tests` CI job with `timescale/timescaledb:latest-pg17` service container |
-| [#760](https://github.com/AI-agent-assembly/agent-assembly/pull/760) | [AAASM-1907](https://lightning-dust-mite.atlassian.net/browse/AAASM-1907) (bug) | In-place fix of `0002` — enable columnstore inline before attaching compression policies |
+| [#711](https://github.com/ai-agent-assembly/agent-assembly/pull/711) | [AAASM-1848](https://lightning-dust-mite.atlassian.net/browse/AAASM-1848) (SD-1) | `0002_timescaledb_hypertables.sql` migration |
+| [#741](https://github.com/ai-agent-assembly/agent-assembly/pull/741) | [AAASM-1852](https://lightning-dust-mite.atlassian.net/browse/AAASM-1852) (SD-2) | `TimescaleStats` type + `has_timescaledb_extension` probe helper |
+| [#746](https://github.com/ai-agent-assembly/agent-assembly/pull/746) | [AAASM-1853](https://lightning-dust-mite.atlassian.net/browse/AAASM-1853) (SD-3) | `PostgresBackend::apply_timescaledb_setup` with three-path graceful fallback |
+| [#750](https://github.com/ai-agent-assembly/agent-assembly/pull/750) | [AAASM-1855](https://lightning-dust-mite.atlassian.net/browse/AAASM-1855) (SD-4) | `StorageHealth.timescale` field + `healthcheck()` populates from `query_timescale_stats` |
+| [#758](https://github.com/ai-agent-assembly/agent-assembly/pull/758) | [AAASM-1890](https://lightning-dust-mite.atlassian.net/browse/AAASM-1890) (bug) | `0003_timescaledb_compression_policies.sql` follow-up (idempotent guardrail) |
+| [#757](https://github.com/ai-agent-assembly/agent-assembly/pull/757) | [AAASM-1858](https://lightning-dust-mite.atlassian.net/browse/AAASM-1858) (SD-5) | `timescaledb-tests` CI job with `timescale/timescaledb:latest-pg17` service container |
+| [#760](https://github.com/ai-agent-assembly/agent-assembly/pull/760) | [AAASM-1907](https://lightning-dust-mite.atlassian.net/browse/AAASM-1907) (bug) | In-place fix of `0002` — enable columnstore inline before attaching compression policies |
 
 ---
 
@@ -73,7 +73,7 @@ cargo nextest run -p aa-gateway timescale
 # `timescaledb-tests` job → timescale/timescaledb:latest-pg17, TIMESCALEDB_AVAILABLE=1 → all 9 env-gated tests run as present-path assertions
 ```
 
-Authoritative CI evidence: `TimescaleDB Tests` job on PR [#757](https://github.com/AI-agent-assembly/agent-assembly/pull/757) — 9/9 PASS on the post-rebase final run.
+Authoritative CI evidence: `TimescaleDB Tests` job on PR [#757](https://github.com/ai-agent-assembly/agent-assembly/pull/757) — 9/9 PASS on the post-rebase final run.
 
 ---
 

--- a/verification-reports/AAASM-1587.md
+++ b/verification-reports/AAASM-1587.md
@@ -1,6 +1,6 @@
 # E18 S-E Verification — AAASM-1587 (Migration runner)
 
-> **Status**: parent Story [AAASM-1587] decomposed into two Sub-tasks shipped on Sprint-4 branches. Implementation lands in [AI-agent-assembly/agent-assembly#664], verification lands in this PR. All six Story-level acceptance bullets verified clean below — no follow-up Bug Sub-task opened.
+> **Status**: parent Story [AAASM-1587] decomposed into two Sub-tasks shipped on Sprint-4 branches. Implementation lands in [ai-agent-assembly/agent-assembly#664], verification lands in this PR. All six Story-level acceptance bullets verified clean below — no follow-up Bug Sub-task opened.
 >
 > **Scope clarification (carried over from the Story's starting comment):** dependencies [AAASM-1584] (S-B SQLite) and [AAASM-1585] (S-C PostgreSQL) are still To Do, so the description's "wire `run_migrations` into `local_mode.rs` / `remote_mode.rs`" step is deferred to [AAASM-1590] (S-I). The S-E ACs targeted in this Story are about the runner mechanism, not the wiring — every one of them is verifiable on the runner alone, which is what this report does. PostgreSQL coverage is provided via `testcontainers` to avoid a hard dependency on S-C.
 
@@ -11,13 +11,13 @@
 [AAASM-1590]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1590
 [AAASM-1733]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1733
 [AAASM-1736]: https://lightning-dust-mite.atlassian.net/browse/AAASM-1736
-[AI-agent-assembly/agent-assembly#664]: https://github.com/AI-agent-assembly/agent-assembly/pull/664
+[ai-agent-assembly/agent-assembly#664]: https://github.com/ai-agent-assembly/agent-assembly/pull/664
 
 ## Sub-task roll-up
 
 | Sub-task | Title | Status | PR |
 |---|---|---|---|
-| [AAASM-1733] | E18 S-E impl — runner module + SQLite + PG tests | Done (open PR) | [#664](https://github.com/AI-agent-assembly/agent-assembly/pull/664) |
+| [AAASM-1733] | E18 S-E impl — runner module + SQLite + PG tests | Done (open PR) | [#664](https://github.com/ai-agent-assembly/agent-assembly/pull/664) |
 | [AAASM-1736] | E18 S-E verify — confirm AC | in this report | this PR |
 
 ## Walkthrough vs AAASM-1587 acceptance criteria

--- a/verification-reports/AAASM-1588.md
+++ b/verification-reports/AAASM-1588.md
@@ -22,10 +22,10 @@
 
 | Sub-task | Title | Status | PR |
 |---|---|---|---|
-| [AAASM-1744] | Impl-1 — `RetentionConfig` + `to_policy()` + validation | Done | [#662](https://github.com/AI-agent-assembly/agent-assembly/pull/662) |
-| [AAASM-1745] | Impl-2 — `RetentionEngine::run_once()` with tracing log | Done | [#686](https://github.com/AI-agent-assembly/agent-assembly/pull/686) |
-| [AAASM-1746] | Impl-3 — cron-driven `RetentionEngine::start()` background task | Done | [#694](https://github.com/AI-agent-assembly/agent-assembly/pull/694) |
-| [AAASM-1747] | Impl-4 — `aasm admin run-retention --dry-run` CLI subcommand | Done | [#697](https://github.com/AI-agent-assembly/agent-assembly/pull/697) |
+| [AAASM-1744] | Impl-1 — `RetentionConfig` + `to_policy()` + validation | Done | [#662](https://github.com/ai-agent-assembly/agent-assembly/pull/662) |
+| [AAASM-1745] | Impl-2 — `RetentionEngine::run_once()` with tracing log | Done | [#686](https://github.com/ai-agent-assembly/agent-assembly/pull/686) |
+| [AAASM-1746] | Impl-3 — cron-driven `RetentionEngine::start()` background task | Done | [#694](https://github.com/ai-agent-assembly/agent-assembly/pull/694) |
+| [AAASM-1747] | Impl-4 — `aasm admin run-retention --dry-run` CLI subcommand | Done | [#697](https://github.com/ai-agent-assembly/agent-assembly/pull/697) |
 | [AAASM-1748] | Verify — this report | in this PR | this PR |
 
 ## Scope cut (declared up-front)

--- a/verification-reports/AAASM-1589.md
+++ b/verification-reports/AAASM-1589.md
@@ -13,10 +13,10 @@
 
 | Sub-task | Title | Status | PR |
 |---|---|---|---|
-| [AAASM-1699](https://lightning-dust-mite.atlassian.net/browse/AAASM-1699) | Add redis optional dep + RedisConfig value type | DEV VERIFY | [#660](https://github.com/AI-agent-assembly/agent-assembly/pull/660) |
-| [AAASM-1703](https://lightning-dust-mite.atlassian.net/browse/AAASM-1703) | Add policy cache key derivation helper | DEV VERIFY | [#669](https://github.com/AI-agent-assembly/agent-assembly/pull/669) |
-| [AAASM-1707](https://lightning-dust-mite.atlassian.net/browse/AAASM-1707) | Add PolicyCache disabled baseline + cache trait | DEV VERIFY | [#682](https://github.com/AI-agent-assembly/agent-assembly/pull/682) |
-| [AAASM-1716](https://lightning-dust-mite.atlassian.net/browse/AAASM-1716) | Add PolicyCache Redis backend (connect/get/set/invalidate/TTL/fallback) | DEV VERIFY | [#689](https://github.com/AI-agent-assembly/agent-assembly/pull/689) |
+| [AAASM-1699](https://lightning-dust-mite.atlassian.net/browse/AAASM-1699) | Add redis optional dep + RedisConfig value type | DEV VERIFY | [#660](https://github.com/ai-agent-assembly/agent-assembly/pull/660) |
+| [AAASM-1703](https://lightning-dust-mite.atlassian.net/browse/AAASM-1703) | Add policy cache key derivation helper | DEV VERIFY | [#669](https://github.com/ai-agent-assembly/agent-assembly/pull/669) |
+| [AAASM-1707](https://lightning-dust-mite.atlassian.net/browse/AAASM-1707) | Add PolicyCache disabled baseline + cache trait | DEV VERIFY | [#682](https://github.com/ai-agent-assembly/agent-assembly/pull/682) |
+| [AAASM-1716](https://lightning-dust-mite.atlassian.net/browse/AAASM-1716) | Add PolicyCache Redis backend (connect/get/set/invalidate/TTL/fallback) | DEV VERIFY | [#689](https://github.com/ai-agent-assembly/agent-assembly/pull/689) |
 | [AAASM-1720](https://lightning-dust-mite.atlassian.net/browse/AAASM-1720) | Verify AAASM-1589 acceptance criteria | in this report | — |
 
 ## Verification environment

--- a/verification-reports/AAASM-1591.md
+++ b/verification-reports/AAASM-1591.md
@@ -15,8 +15,8 @@
 
 | # | Key | PR | Title |
 | --- | --- | --- | --- |
-| 1 | [AAASM-1908](https://lightning-dust-mite.atlassian.net/browse/AAASM-1908) | [#762](https://github.com/AI-agent-assembly/agent-assembly/pull/762) | Add `GET /api/v1/admin/status` storage-health route (aa-gateway) |
-| 2 | [AAASM-1909](https://lightning-dust-mite.atlassian.net/browse/AAASM-1909) | [#763](https://github.com/AI-agent-assembly/agent-assembly/pull/763) | `aasm status` renders storage block + non-zero exit on DB unhealthy (aa-cli) |
+| 1 | [AAASM-1908](https://lightning-dust-mite.atlassian.net/browse/AAASM-1908) | [#762](https://github.com/ai-agent-assembly/agent-assembly/pull/762) | Add `GET /api/v1/admin/status` storage-health route (aa-gateway) |
+| 2 | [AAASM-1909](https://lightning-dust-mite.atlassian.net/browse/AAASM-1909) | [#763](https://github.com/ai-agent-assembly/agent-assembly/pull/763) | `aasm status` renders storage block + non-zero exit on DB unhealthy (aa-cli) |
 | 3 | [AAASM-1910](https://lightning-dust-mite.atlassian.net/browse/AAASM-1910) | _(this PR)_ | Verify AAASM-1591 acceptance criteria |
 
 ---

--- a/verification-reports/AAASM-1593.md
+++ b/verification-reports/AAASM-1593.md
@@ -1,12 +1,12 @@
 # E18 S-L Verification — AAASM-1593 (ADR 0001 storage architecture)
 
-> **Status**: All acceptance criteria PASS. The implementation sub-task PR ([#641](https://github.com/AI-agent-assembly/agent-assembly/pull/641)) landed on `master` at 2026-05-21T06:32:55Z (merge commit `4caa8d18`). This report verifies the merged deliverable end-to-end and is the second of two sub-tasks under the Story.
+> **Status**: All acceptance criteria PASS. The implementation sub-task PR ([#641](https://github.com/ai-agent-assembly/agent-assembly/pull/641)) landed on `master` at 2026-05-21T06:32:55Z (merge commit `4caa8d18`). This report verifies the merged deliverable end-to-end and is the second of two sub-tasks under the Story.
 
 ## Sub-task roll-up
 
 | Sub-task | Title | Status | PR |
 | --- | --- | --- | --- |
-| [AAASM-1687](https://lightning-dust-mite.atlassian.net/browse/AAASM-1687) | Add ADR 0001 storage architecture doc + index + SUMMARY.md entry | Done | [#641](https://github.com/AI-agent-assembly/agent-assembly/pull/641) |
+| [AAASM-1687](https://lightning-dust-mite.atlassian.net/browse/AAASM-1687) | Add ADR 0001 storage architecture doc + index + SUMMARY.md entry | Done | [#641](https://github.com/ai-agent-assembly/agent-assembly/pull/641) |
 | [AAASM-1688](https://lightning-dust-mite.atlassian.net/browse/AAASM-1688) | Verify ADR 0001 storage architecture acceptance criteria | in this report | — |
 
 ## Walkthrough vs AAASM-1593 acceptance criteria
@@ -29,7 +29,7 @@ docs/src/adr/README.md                    |  11 +++
 3 files changed, 173 insertions(+)
 ```
 
-Evidence: [`docs/src/adr/0001-storage-architecture.md`](../docs/src/adr/0001-storage-architecture.md), [merge commit `4caa8d18`](https://github.com/AI-agent-assembly/agent-assembly/commit/4caa8d183799e3c9da34ff2d93f30f4897481592).
+Evidence: [`docs/src/adr/0001-storage-architecture.md`](../docs/src/adr/0001-storage-architecture.md), [merge commit `4caa8d18`](https://github.com/ai-agent-assembly/agent-assembly/commit/4caa8d183799e3c9da34ff2d93f30f4897481592).
 
 ### ✅ ADR covers context, decision, all alternatives considered, consequences
 
@@ -130,7 +130,7 @@ Additionally, the impl PR's CI jobs covered the same ground:
 | `Build mdBook` | `Docs` | ✅ SUCCESS |
 | `Verify documented commands (Linux)` | `Docs` | ✅ SUCCESS |
 
-Evidence: PR [#641 statusCheckRollup](https://github.com/AI-agent-assembly/agent-assembly/pull/641); local `cargo doc --workspace --no-deps` exit 0 at 2026-05-21T14:38 +0800.
+Evidence: PR [#641 statusCheckRollup](https://github.com/ai-agent-assembly/agent-assembly/pull/641); local `cargo doc --workspace --no-deps` exit 0 at 2026-05-21T14:38 +0800.
 
 ## Adaptations vs ticket text
 

--- a/verification-reports/AAASM-2074.md
+++ b/verification-reports/AAASM-2074.md
@@ -1,7 +1,7 @@
 # Verification Report — AAASM-2074
 
 **Story:** agent-assembly README and docs are production-ready and link into the org documentation map
-**Epic:** AAASM-2072 — Production documentation coverage across AI-agent-assembly organization repos
+**Epic:** AAASM-2072 — Production documentation coverage across ai-agent-assembly organization repos
 **Component / repo:** `agent-assembly` (OSS core runtime)
 **Date:** 2026-06-06
 

--- a/verification-reports/AAASM-217.md
+++ b/verification-reports/AAASM-217.md
@@ -9,10 +9,10 @@
 
 | Sub-task | Title | Status | PR |
 |---|---|---|---|
-| AAASM-1047 | Fleet table primitives + view-model | Done | [#343](https://github.com/AI-agent-assembly/agent-assembly/pull/343) |
-| AAASM-1048 | Fleet page chrome | Done | [#359](https://github.com/AI-agent-assembly/agent-assembly/pull/359) |
-| AAASM-1050 | Fleet table interactions | Done | [#361](https://github.com/AI-agent-assembly/agent-assembly/pull/361) |
-| AAASM-1052 | Agent Detail drawer | Done | [#365](https://github.com/AI-agent-assembly/agent-assembly/pull/365) |
+| AAASM-1047 | Fleet table primitives + view-model | Done | [#343](https://github.com/ai-agent-assembly/agent-assembly/pull/343) |
+| AAASM-1048 | Fleet page chrome | Done | [#359](https://github.com/ai-agent-assembly/agent-assembly/pull/359) |
+| AAASM-1050 | Fleet table interactions | Done | [#361](https://github.com/ai-agent-assembly/agent-assembly/pull/361) |
+| AAASM-1052 | Agent Detail drawer | Done | [#365](https://github.com/ai-agent-assembly/agent-assembly/pull/365) |
 | AAASM-1151 | Suspend/resume + verification | in this PR | — |
 
 ## Walkthrough vs AAASM-217 acceptance criteria

--- a/verification-reports/AAASM-227.md
+++ b/verification-reports/AAASM-227.md
@@ -6,13 +6,13 @@
 
 | Sub-task | Title | Status | PR | Merge commit |
 |---|---|---|---|---|
-| AAASM-1049 | CLI `policy show --show-permissions` | Done | [#458](https://github.com/AI-agent-assembly/agent-assembly/pull/458) | `b1a8d705` |
-| AAASM-1051 | CLI `policy show --show-budget` | Done | [#463](https://github.com/AI-agent-assembly/agent-assembly/pull/463) | `cd551fdd` |
-| AAASM-1053 | Dashboard `InheritedPermissionsPanel` | Done | [#465](https://github.com/AI-agent-assembly/agent-assembly/pull/465) | `24d56aa3` |
-| AAASM-1055 | Dashboard `SubtreeBurnChart` | Done | [#469](https://github.com/AI-agent-assembly/agent-assembly/pull/469) | `12f0e1ea` |
-| AAASM-1438 | Wire daily-spend history into `/subtree-burn` (follow-up to AAASM-1055) | Done | bundled in [#469](https://github.com/AI-agent-assembly/agent-assembly/pull/469) | commits `1c026cbf` + `3087f76f` |
-| AAASM-1057 | Dashboard `ViolationHeatmap` | Done | [#264](https://github.com/AI-agent-assembly/agent-assembly/pull/264) | `163774eb` |
-| AAASM-1432 | Playwright design-fidelity specs | Done | [#532](https://github.com/AI-agent-assembly/agent-assembly/pull/532) | `d0b9acb5` |
+| AAASM-1049 | CLI `policy show --show-permissions` | Done | [#458](https://github.com/ai-agent-assembly/agent-assembly/pull/458) | `b1a8d705` |
+| AAASM-1051 | CLI `policy show --show-budget` | Done | [#463](https://github.com/ai-agent-assembly/agent-assembly/pull/463) | `cd551fdd` |
+| AAASM-1053 | Dashboard `InheritedPermissionsPanel` | Done | [#465](https://github.com/ai-agent-assembly/agent-assembly/pull/465) | `24d56aa3` |
+| AAASM-1055 | Dashboard `SubtreeBurnChart` | Done | [#469](https://github.com/ai-agent-assembly/agent-assembly/pull/469) | `12f0e1ea` |
+| AAASM-1438 | Wire daily-spend history into `/subtree-burn` (follow-up to AAASM-1055) | Done | bundled in [#469](https://github.com/ai-agent-assembly/agent-assembly/pull/469) | commits `1c026cbf` + `3087f76f` |
+| AAASM-1057 | Dashboard `ViolationHeatmap` | Done | [#264](https://github.com/ai-agent-assembly/agent-assembly/pull/264) | `163774eb` |
+| AAASM-1432 | Playwright design-fidelity specs | Done | [#532](https://github.com/ai-agent-assembly/agent-assembly/pull/532) | `d0b9acb5` |
 | AAASM-1129 | This verification report | in this PR | — | — |
 
 ## Walkthrough vs AAASM-227 acceptance criteria

--- a/verification-reports/AAASM-2363-acceptance.md
+++ b/verification-reports/AAASM-2363-acceptance.md
@@ -14,7 +14,7 @@
 
 | PR | Sub-ticket | Scope |
 |---|---|---|
-| [#882](https://github.com/AI-agent-assembly/agent-assembly/pull/882) | AAASM-2367 | `aa-storage-memory` crate (six DashMap/parking_lot impls) + 5 shared conformance harnesses in `aa-core` |
+| [#882](https://github.com/ai-agent-assembly/agent-assembly/pull/882) | AAASM-2367 | `aa-storage-memory` crate (six DashMap/parking_lot impls) + 5 shared conformance harnesses in `aa-core` |
 
 ## Design alignment
 

--- a/verification-reports/AAASM-2364.md
+++ b/verification-reports/AAASM-2364.md
@@ -12,8 +12,8 @@ migrations for `orgs`/`agents`/`policies`/`audit_logs`
 
 | Subtask | PR | Scope |
 |---|---|---|
-| AAASM-2369 | [#874](https://github.com/AI-agent-assembly/agent-assembly/pull/874) | Crate scaffold, four MVP migrations, `[storage.postgres]` pool config |
-| AAASM-2370 | [#886](https://github.com/AI-agent-assembly/agent-assembly/pull/886) | `PgPolicyStore` / `PgAuditSink` / `PgCredentialStore` / `PgLifecycleStore`, `0005_credentials` migration, driver registration, testcontainers conformance suite |
+| AAASM-2369 | [#874](https://github.com/ai-agent-assembly/agent-assembly/pull/874) | Crate scaffold, four MVP migrations, `[storage.postgres]` pool config |
+| AAASM-2370 | [#886](https://github.com/ai-agent-assembly/agent-assembly/pull/886) | `PgPolicyStore` / `PgAuditSink` / `PgCredentialStore` / `PgLifecycleStore`, `0005_credentials` migration, driver registration, testcontainers conformance suite |
 
 ## Acceptance criteria
 

--- a/verification-reports/AAASM-2386.md
+++ b/verification-reports/AAASM-2386.md
@@ -11,7 +11,7 @@
 
 | Subtask | Title | Status | PR |
 |---|---|---|---|
-| AAASM-2385 | Wire ApprovalResolved push event + WaitForApproval future | Done | [#903](https://github.com/AI-agent-assembly/agent-assembly/pull/903) |
+| AAASM-2385 | Wire ApprovalResolved push event + WaitForApproval future | Done | [#903](https://github.com/ai-agent-assembly/agent-assembly/pull/903) |
 | AAASM-2386 | Verify ApprovalResolved push event acceptance criteria | in this report | — |
 
 ## Walkthrough vs AAASM-2378 acceptance criteria

--- a/verification-reports/AAASM-2389-schema-consolidation.md
+++ b/verification-reports/AAASM-2389-schema-consolidation.md
@@ -1,7 +1,7 @@
 # Verification report — AAASM-2389 (MVP four-table schema consolidation)
 
 - **Story:** AAASM-2389 — consolidate `orgs`/`agents`/`policies`/`audit_logs` into one canonical migration set
-- **Implementation:** AAASM-2395 — PR [#900](https://github.com/AI-agent-assembly/agent-assembly/pull/900)
+- **Implementation:** AAASM-2395 — PR [#900](https://github.com/ai-agent-assembly/agent-assembly/pull/900)
 - **Verification subtask:** AAASM-2396
 - **Date:** 2026-06-04
 - **Environment:** macOS dev box, Docker 28.3.2, Postgres 18-alpine, `cargo nextest`

--- a/verification-reports/verification-report-AAASM-1577.md
+++ b/verification-reports/verification-report-AAASM-1577.md
@@ -8,10 +8,10 @@
 
 | Sub-task | Type | PR | Status |
 | --- | --- | --- | --- |
-| AAASM-1698 (ST-1) | Implementation — `/healthz` HTTP route module | [#654](https://github.com/AI-agent-assembly/agent-assembly/pull/654) | Done |
-| AAASM-1702 (ST-2) | Implementation — `remote_mode::tls` validator | [#674](https://github.com/AI-agent-assembly/agent-assembly/pull/674) | Done |
-| AAASM-1709 (ST-3) | Implementation — `remote_mode::server::start_remote` | [#690](https://github.com/AI-agent-assembly/agent-assembly/pull/690) | Done |
-| AAASM-1713 (ST-4) | Implementation — `main.rs` deployment-mode dispatch | [#692](https://github.com/AI-agent-assembly/agent-assembly/pull/692) | Done |
+| AAASM-1698 (ST-1) | Implementation — `/healthz` HTTP route module | [#654](https://github.com/ai-agent-assembly/agent-assembly/pull/654) | Done |
+| AAASM-1702 (ST-2) | Implementation — `remote_mode::tls` validator | [#674](https://github.com/ai-agent-assembly/agent-assembly/pull/674) | Done |
+| AAASM-1709 (ST-3) | Implementation — `remote_mode::server::start_remote` | [#690](https://github.com/ai-agent-assembly/agent-assembly/pull/690) | Done |
+| AAASM-1713 (ST-4) | Implementation — `main.rs` deployment-mode dispatch | [#692](https://github.com/ai-agent-assembly/agent-assembly/pull/692) | Done |
 | AAASM-1718 (ST-5) | Verification — this PR | _this PR_ | In progress |
 
 ## Acceptance Criteria

--- a/verification-reports/verification-report-AAASM-1579.md
+++ b/verification-reports/verification-report-AAASM-1579.md
@@ -10,11 +10,11 @@
 
 | Sub-task | Title | Status | PR |
 |---|---|---|---|
-| AAASM-1854 | ST-1 — `HealthzResponse` + `redact_database_url` + `check_healthz` | Done | [#710](https://github.com/AI-agent-assembly/agent-assembly/pull/710) |
-| AAASM-1857 | ST-2 — `DeploymentOverview` display model + composer | Done | [#717](https://github.com/AI-agent-assembly/agent-assembly/pull/717) |
-| AAASM-1860 | ST-3 — Wire `DeploymentOverview` into `StatusSnapshot` + `fetch_all` | Done | [#721](https://github.com/AI-agent-assembly/agent-assembly/pull/721) |
-| AAASM-1863 | ST-4 — Tabular renderer for the deployment overview | Done | [#725](https://github.com/AI-agent-assembly/agent-assembly/pull/725) |
-| AAASM-1865 | ST-5 — `--json` flag + exit-1-with-hint on unreachable | Done | [#726](https://github.com/AI-agent-assembly/agent-assembly/pull/726) |
+| AAASM-1854 | ST-1 — `HealthzResponse` + `redact_database_url` + `check_healthz` | Done | [#710](https://github.com/ai-agent-assembly/agent-assembly/pull/710) |
+| AAASM-1857 | ST-2 — `DeploymentOverview` display model + composer | Done | [#717](https://github.com/ai-agent-assembly/agent-assembly/pull/717) |
+| AAASM-1860 | ST-3 — Wire `DeploymentOverview` into `StatusSnapshot` + `fetch_all` | Done | [#721](https://github.com/ai-agent-assembly/agent-assembly/pull/721) |
+| AAASM-1863 | ST-4 — Tabular renderer for the deployment overview | Done | [#725](https://github.com/ai-agent-assembly/agent-assembly/pull/725) |
+| AAASM-1865 | ST-5 — `--json` flag + exit-1-with-hint on unreachable | Done | [#726](https://github.com/ai-agent-assembly/agent-assembly/pull/726) |
 | AAASM-1868 | ST-6 — Verify E17 S-E acceptance criteria | in this report | — |
 
 ## Walkthrough vs AAASM-1579 acceptance criteria

--- a/verification-reports/verification-report-AAASM-1581.md
+++ b/verification-reports/verification-report-AAASM-1581.md
@@ -10,9 +10,9 @@ This Story spans three SDK repositories. Each implementation Sub-task delivered 
 
 | Sub-task | Type | Repo | PR | Status |
 | --- | --- | --- | --- | --- |
-| AAASM-1846 (ST-1) | Implementation — Python SDK gateway URL resolver + auto-start | `python-sdk` | [#58](https://github.com/AI-agent-assembly/python-sdk/pull/58) | Open |
-| AAASM-1847 (ST-2) | Implementation — Node SDK gateway URL resolver + auto-start | `node-sdk` | [#47](https://github.com/AI-agent-assembly/node-sdk/pull/47) | Open |
-| AAASM-1849 (ST-3) | Implementation — Go SDK gateway URL resolver + auto-start | `go-sdk` | [#36](https://github.com/AI-agent-assembly/go-sdk/pull/36) | Open |
+| AAASM-1846 (ST-1) | Implementation — Python SDK gateway URL resolver + auto-start | `python-sdk` | [#58](https://github.com/ai-agent-assembly/python-sdk/pull/58) | Open |
+| AAASM-1847 (ST-2) | Implementation — Node SDK gateway URL resolver + auto-start | `node-sdk` | [#47](https://github.com/ai-agent-assembly/node-sdk/pull/47) | Open |
+| AAASM-1849 (ST-3) | Implementation — Go SDK gateway URL resolver + auto-start | `go-sdk` | [#36](https://github.com/ai-agent-assembly/go-sdk/pull/36) | Open |
 | AAASM-1851 (ST-4) | Verification — this PR | `agent-assembly` | _this PR_ | In progress |
 
 ## Acceptance Criteria
@@ -24,7 +24,7 @@ This Story spans three SDK repositories. Each implementation Sub-task delivered 
 | **Go**: `assembly.Init(ctx)` (no options, no env vars) connects to `http://localhost:7391` | ✅ | `assembly/gateway_resolver.go::resolveGatewayURL` returns `defaultGatewayURL` when no explicit / env / config value is supplied. `assembly/runtime.go::boot` calls the resolver before validation. Exercise in `assembly/init_zero_config_test.go::TestInit_ZeroArgResolvesLocalDefault`. |
 | `AAASM_GATEWAY_URL` env var overrides auto-detect (for CI / remote scenarios) | ✅ | All three resolvers check the `AAASM_GATEWAY_URL` env var at step 2 of the precedence chain and return it verbatim before reaching the probe / auto-start path. Tests: `test/unit/core/test_gateway_resolver.py::TestResolveGatewayUrl::test_env_var_takes_precedence_over_config_and_default` (Python); `tests/gateway-resolver.test.ts > resolveGatewayUrl > uses AAASM_GATEWAY_URL over config + default` (Node); `assembly/gateway_resolver_test.go::TestResolveGatewayURL_EnvUsedWhenNoExplicit` (Go). |
 | If gateway not running and `aasm` is on PATH → auto-start triggered, SDK connects after health probe passes | ✅ | All three implementations: when the local probe fails, `_auto_start_gateway` / `autoStartGateway` is invoked; it locates `aasm` on PATH (`shutil.which` / `findAasmOnPath` / `exec.LookPath`), launches `aasm start --mode local --foreground` detached, and waits for `/healthz`. Spawn args pinned by `AASM_AUTO_START_ARGV` / `AASM_AUTO_START_ARGV` / `aasmAutoStartArgs = ["start", "--mode", "local", "--foreground"]`. Tests: `test_spawns_subprocess_and_returns_when_ready` (Python), `spawns aasm and resolves when healthz becomes ready` (Node), `TestAutoStartGateway_SuccessSpawnsAndConfirmsReady` (Go). |
-| If gateway not running and `aasm` not on PATH → `ConfigurationError` raised with install instructions | ✅ | Python `_auto_start_gateway` raises `ConfigurationError("No gateway found at … and 'aasm' is not on PATH. Install it with: pip install agent-assembly[cli]")`. Node `autoStartGateway` throws `ConfigurationError("… Install it with: npm install -g @agent-assembly/cli (or pnpm add -g)")`. Go `autoStartGateway` returns `*ConfigurationError{Message: "… Install it with: go install github.com/AI-agent-assembly/aa-cli/cmd/aasm@latest"}`. Tests: `test_raises_configuration_error_when_aasm_not_on_path` (Python), `throws ConfigurationError when aasm is not on PATH` (Node), `TestAutoStartGateway_ConfigurationErrorWhenAasmMissing` (Go). |
+| If gateway not running and `aasm` not on PATH → `ConfigurationError` raised with install instructions | ✅ | Python `_auto_start_gateway` raises `ConfigurationError("No gateway found at … and 'aasm' is not on PATH. Install it with: pip install agent-assembly[cli]")`. Node `autoStartGateway` throws `ConfigurationError("… Install it with: npm install -g @agent-assembly/cli (or pnpm add -g)")`. Go `autoStartGateway` returns `*ConfigurationError{Message: "… Install it with: go install github.com/ai-agent-assembly/aa-cli/cmd/aasm@latest"}`. Tests: `test_raises_configuration_error_when_aasm_not_on_path` (Python), `throws ConfigurationError when aasm is not on PATH` (Node), `TestAutoStartGateway_ConfigurationErrorWhenAasmMissing` (Go). |
 | Auto-start timeout 5s: if gateway doesn't become ready → `GatewayError` with timeout message | ✅ | All three impls call `_wait_for_healthz` / `waitForHealthz` with `DEFAULT_AUTO_START_TIMEOUT_SECONDS = 5.0` / `DEFAULT_AUTO_START_TIMEOUT_MS = 5000` / `defaultAutoStartTimeout = 5 * time.Second` and raise `GatewayError` on the false return. Tests: `test_raises_gateway_error_on_timeout` (Python), `throws GatewayError when the spawned gateway never becomes ready` (Node), `TestAutoStartGateway_GatewayErrorOnTimeout` (Go). |
 | Tests that call `init_assembly(mode="sidecar")` are not affected (explicit mode skips auto-detect) | ✅ | The resolver is keyed on `gateway_url` / `gatewayUrl` / `gatewayURL`, not on `mode`. The pre-existing `test_init_assembly_with_valid_config` (Python, explicit `gateway_url="http://localhost:8080"`) and the existing `validTestOptions()` callers (Go) continue to pass — proven by the dedicated regression test in each repo: `test/unit/test_assembly.py::test_init_assembly_explicit_args_bypass_resolver` (Python), `tests/init-assembly-zero-config.test.ts > explicit gatewayUrl + apiKey bypass the resolver entirely` (Node), `assembly/init_zero_config_test.go::TestInit_ExplicitOptionsBypassResolver` (Go). Each uses sentinel stubs on the probe / auto-start path that fail the test if invoked. |
 | Unit tests mock the subprocess call — do not actually spawn `aasm` in unit tests | ✅ | Python: `patch("agent_assembly.core.gateway_resolver.subprocess.Popen")` + `patch("agent_assembly.core.gateway_resolver.shutil.which")`. Node: `__testing._seams.spawnAasm` + `__testing._seams.findAasmOnPath` mutated to `vi.fn()` stubs. Go: `withSeams(t, find, spawn)` swaps `gatewayResolverSeams.spawnAasm` for a no-op closure. No test invocation in any repo touches the real `aasm` binary. |
@@ -65,7 +65,7 @@ pnpm lint
 
 # go-sdk (PR #36)
 make test
-# → ok github.com/AI-agent-assembly/go-sdk/assembly 11.414s
+# → ok github.com/ai-agent-assembly/go-sdk/assembly 11.414s
 #   (includes the 5s autoStartGateway-timeout test, by design)
 go vet ./...
 ```
@@ -82,7 +82,7 @@ Ran 2026-05-23 on macOS / darwin-arm64. A real `aa-gateway --mode local` was sta
 | --- | --- | --- |
 | Python | `python -c "from agent_assembly import init_assembly; ctx = init_assembly(mode='sdk-only'); print(ctx.client.gateway_url, ctx.client.api_key)"` | `http://localhost:7391` `''` — resolver returned the local default; `api_key` empty-defaulted. |
 | Node | `node` invokes `initAssembly({ mode: "sdk-only" })` against `dist/esm/index.js` | `ctx.activeAdapters = [ 'langchain-js', 'openai-agents' ]` — resolver returned a context; downstream framework detection ran. |
-| Go | `assembly.Init(context.Background())` via a tiny `main.go` with `replace github.com/AI-agent-assembly/go-sdk => …worktree…` | Resolver completed (no `*ConfigurationError`); downstream `sidecarConnector` returned `"sidecar unavailable"` — expected since the local CP at `:7391` exposes `/healthz` only, not the gRPC sidecar surface. This proves `resolveGatewayURL` populated the URL correctly and validation passed past the (now-relaxed) empty-`apiKey` check. |
+| Go | `assembly.Init(context.Background())` via a tiny `main.go` with `replace github.com/ai-agent-assembly/go-sdk => …worktree…` | Resolver completed (no `*ConfigurationError`); downstream `sidecarConnector` returned `"sidecar unavailable"` — expected since the local CP at `:7391` exposes `/healthz` only, not the gRPC sidecar surface. This proves `resolveGatewayURL` populated the URL correctly and validation passed past the (now-relaxed) empty-`apiKey` check. |
 
 ### Aasm-missing smoke — no gateway, no `aasm` on PATH
 
@@ -92,7 +92,7 @@ Ran 2026-05-23 on macOS / darwin-arm64. A real `aa-gateway --mode local` was sta
 | --- | --- |
 | Python | `ConfigurationError: No gateway found at http://localhost:7391 and 'aasm' is not on PATH. Install it with: pip install agent-assembly[cli]` |
 | Node | `ConfigurationError: No gateway found at http://localhost:7391 and 'aasm' is not on PATH. Install it with: npm install -g @agent-assembly/cli (or pnpm add -g)` |
-| Go | `*ConfigurationError: assembly: no gateway found at http://localhost:7391 and 'aasm' is not on PATH. Install it with: go install github.com/AI-agent-assembly/aa-cli/cmd/aasm@latest` |
+| Go | `*ConfigurationError: assembly: no gateway found at http://localhost:7391 and 'aasm' is not on PATH. Install it with: go install github.com/ai-agent-assembly/aa-cli/cmd/aasm@latest` |
 
 All three error messages match the design — explicit `ConfigurationError` type with an SDK-appropriate install hint.
 

--- a/verification-reports/verification-report-AAASM-2559.md
+++ b/verification-reports/verification-report-AAASM-2559.md
@@ -41,8 +41,8 @@ Delivered as 3 stacked subtasks, one PR each (all base `master`):
   `rust/aa-ffi-python/Cargo.toml` pins both crates at an exact SHA —
 
   ```toml
-  aa-core  = { git = "https://github.com/AI-agent-assembly/agent-assembly.git", rev = "ed4aa11a8c1d1ce1e6f96b08cf2179fd772099b2", package = "aa-core", features = ["serde"] }
-  aa-proto = { git = "https://github.com/AI-agent-assembly/agent-assembly.git", rev = "ed4aa11a8c1d1ce1e6f96b08cf2179fd772099b2", package = "aa-proto" }
+  aa-core  = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "ed4aa11a8c1d1ce1e6f96b08cf2179fd772099b2", package = "aa-core", features = ["serde"] }
+  aa-proto = { git = "https://github.com/ai-agent-assembly/agent-assembly.git", rev = "ed4aa11a8c1d1ce1e6f96b08cf2179fd772099b2", package = "aa-proto" }
   ```
 
 - `aa-sdk-client` is `publish = false` (distributed only via the git pin, never

--- a/verification-reports/verification-report-AAASM-2562.md
+++ b/verification-reports/verification-report-AAASM-2562.md
@@ -2,7 +2,7 @@
 
 **Story:** 🗑️ (agent-assembly) Remove fat `aa-ffi-*` bindings from the workspace
 **Epic:** AAASM-2552 — SDK security boundary + FFI consolidation (final story)
-**Implementation:** AAASM-2646 — PR [#973](https://github.com/AI-agent-assembly/agent-assembly/pull/973)
+**Implementation:** AAASM-2646 — PR [#973](https://github.com/ai-agent-assembly/agent-assembly/pull/973)
 **Verification:** AAASM-2647 (this report)
 **Date:** 2026-06-06
 


### PR DESCRIPTION
## Description

Mechanical rename of the GitHub org ID from the mixed-case `AI-agent-assembly` to the canonical lowercase `ai-agent-assembly` across the `agent-assembly` monorepo. The repository itself has already moved to the lowercase location (`https://github.com/ai-agent-assembly/agent-assembly`); this PR aligns every in-repo reference (URLs, module paths, image labels, docs) with the canonical casing. No behaviour change.

Precedent: go-sdk PR #48 (`facc3af`) applied the same rename for the go-sdk repo.

Touched categories (one commit each):
- 🔧 (ci): `.github/workflows/*` (ci, dev-verify, docker, integration-tests)
- 🔧 (config): root + `aa-ebpf-programs` `Cargo.toml` `repository`/`homepage` metadata, Dockerfiles, `docker/*`, `openapi/v1.yaml`, `sonar-project.properties`, release scripts, integration-test fixtures (`go.mod`/`main.go` go-sdk module path, `pyproject.toml` comment), `aa-api` OpenAPI contact URL
- 📝 (docs): `README.md`, `docs/**`, `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, verification reports, `quickstart.cast`

No active Cargo `git =` dependency URLs reference the org (the only such URLs are in comments / docs / verification reports), so `Cargo.lock` is unchanged and no lock regen was required.

## Type of Change

- [x] 🔧 Configuration / CI change
- [x] 📝 Documentation update

## Breaking Changes

- [x] No

GitHub org names are case-insensitive for routing, so existing `AI-agent-assembly` URLs continue to redirect. The Go fixture module path is updated consistently across `require`/`replace`/import and the `-replace=` flag, matching the lowercased go-sdk module.

## Related Issues

- Related Jira ticket: AAASM-2718 (Epic AAASM-2715)
- Closes AAASM-2718

## Testing

- [x] No tests required (string rename, no behaviour change)
- Verified `git grep 'AI-agent-assembly'` returns 0 matches; 407 lowercase `ai-agent-assembly` refs remain.
- `cargo metadata --format-version 1` resolves cleanly; `Cargo.lock` unchanged.
- `cargo fmt --all --check` clean.
- `mdbook build` (in `docs/`) succeeds.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
