### PR TITLE
[AAASM-2743] 🚀 (docs-ci): Publish core mdBook to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,8 @@ name: Docs
 
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
 on:
   pull_request:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,6 +60,19 @@ jobs:
         with:
           path: docs/book
 
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name == 'push'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
   verify-commands:
     name: Verify documented commands (Linux)
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,12 +54,11 @@ jobs:
       - name: Build book
         run: mdbook build docs
 
-      - name: Upload book artifact
-        uses: actions/upload-artifact@v7
+      - name: Upload Pages artifact
+        if: github.event_name == 'push'
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: agent-assembly-book
-          path: docs/book/
-          retention-days: 7
+          path: docs/book
 
   verify-commands:
     name: Verify documented commands (Linux)


### PR DESCRIPTION
## Description

Wires the `Docs` workflow to publish the branded core mdBook to GitHub Pages. On `push` to `master`, the built book (`docs/book`) is uploaded via `actions/upload-pages-artifact@v3` and deployed by a new `deploy` job using `actions/deploy-pages@v4`, landing at https://ai-agent-assembly.github.io/agent-assembly/. PR builds still run `mdbook build` for validation but do **not** deploy. The `verify-commands` job is unchanged.

Granular changes:
- Add `pages: write` + `id-token: write` to the top-level `permissions` block.
- Swap the transient `actions/upload-artifact` step for `actions/upload-pages-artifact@v3`, gated to `push` events.
- Add a `deploy` job (`needs: build`, `github-pages` environment, push-only) running `actions/deploy-pages@v4`.

## Type of Change

- [x] 🔧 Configuration / CI change
- [x] 🚀 Release

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2743 (Epic AAASM-2741)

Closes AAASM-2743

## Testing

- [x] Manual testing performed
- [x] No tests required (explain why)

`cd docs && mdbook build` passes locally (output to `docs/book`, matching the deploy path). `actionlint` passes clean on `docs.yml`. CI deploy verified via workflow structure; the live Pages publish runs on merge to `master`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
