### PR TITLE
[AAASM-2742] 🔗 (readme): Replace unregistered install one-liner with working methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## Install the CLI
 
 ```sh
-curl -sSf https://install.ai-agent-assembly.dev | sh
+curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
 ```
 
 This downloads and installs the `aasm` binary to `~/.local/bin`. Requires a
@@ -21,11 +21,14 @@ The installer script lives at [`scripts/install-cli.sh`](scripts/install-cli.sh)
 
 ```sh
 # Pin a specific version
-AASM_VERSION=v0.1.0 curl -sSf https://install.ai-agent-assembly.dev | sh
+AASM_VERSION=v0.0.1-alpha.5 curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
 
 # Custom install directory
-AASM_INSTALL_DIR=/usr/local/bin curl -sSf https://install.ai-agent-assembly.dev | sh
+AASM_INSTALL_DIR=/usr/local/bin curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
 ```
+
+> A short hosted alias (`https://install.ai-agent-assembly.dev`) is planned but
+> not yet live — use the `raw.githubusercontent.com` URL above for now.
 
 ### Homebrew (macOS / Linux)
 

--- a/docs/src/quick-start/installation.md
+++ b/docs/src/quick-start/installation.md
@@ -21,13 +21,17 @@ The one-line installer downloads the matching pre-built tarball plus its
 the `aasm` binary:
 
 ```sh
-curl -sSf https://install.ai-agent-assembly.dev | sh
+curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
 ```
 
 By default the binary is installed to `/usr/local/bin` if that directory is
 writable, otherwise to `~/.local/bin` (always user-writable, no `sudo` needed).
 The installer script lives in the repo at
 [`scripts/install-cli.sh`](https://github.com/ai-agent-assembly/agent-assembly/blob/master/scripts/install-cli.sh).
+
+> A short hosted alias (`https://install.ai-agent-assembly.dev` — hosted install
+> script, coming soon) is planned but not yet live — use the
+> `raw.githubusercontent.com` URL above for now.
 
 If the install directory is not on your `PATH`, the script prints the line to add
 to your shell profile, for example:
@@ -42,10 +46,10 @@ The installer honors these environment variables:
 
 ```sh
 # Install a specific release tag (default: latest)
-AASM_VERSION=v0.1.0 curl -sSf https://install.ai-agent-assembly.dev | sh
+AASM_VERSION=v0.0.1-alpha.5 curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
 
 # Install to a custom directory
-AASM_INSTALL_DIR=/usr/local/bin curl -sSf https://install.ai-agent-assembly.dev | sh
+AASM_INSTALL_DIR=/usr/local/bin curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
 ```
 
 | Variable | Default | Purpose |
@@ -65,7 +69,7 @@ installer verifies that signature against the release workflow's identity before
 trusting the checksums. To make a missing/unverifiable signature fatal:
 
 ```sh
-AASM_REQUIRE_SIGNATURE=1 curl -sSf https://install.ai-agent-assembly.dev | sh
+AASM_REQUIRE_SIGNATURE=1 curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
 ```
 
 > Releases published before signing was added carry no cosign bundle; with the


### PR DESCRIPTION
## Description

The README's CLI install one-liner pointed at `https://install.ai-agent-assembly.dev`, which is **unregistered (NXDOMAIN)** — the documented `curl … | sh` command fails. This replaces it with a verified working method.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2742

## Changes

- Replace `curl -sSf https://install.ai-agent-assembly.dev | sh` (dead host) with `curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh`. The in-repo `scripts/install-cli.sh` resolves the latest GitHub Release via the API and works today (verified HTTP 200; `releases/latest` resolves).
- Update the version-pin and custom-dir examples to use the same raw-GitHub URL; pin example now uses a real tag (`v0.0.1-alpha.5`).
- Note the hosted alias `install.ai-agent-assembly.dev` as "planned but not yet live".

The Homebrew method (`brew install ai-agent-assembly/homebrew-agent-assembly/aasm`) and the Release badge were already correct and are unchanged.

## Testing

- [x] Manual verification: `install.ai-agent-assembly.dev` → NXDOMAIN; `raw.githubusercontent.com/.../scripts/install-cli.sh` → HTTP 200; Homebrew tap + `Formula/aasm.rb` exist.
- [x] No tests required (docs-only)

## Checklist

- [x] Self-review of the diff completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)