### PR TITLE
[AAASM-2763] ✨ (docs): agent-assembly README badges (state at a glance, with logos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 
 > Governance-native runtime for AI agents — open-source core.
 
-[![CI](https://github.com/ai-agent-assembly/agent-assembly/actions/workflows/ci.yml/badge.svg)](https://github.com/ai-agent-assembly/agent-assembly/actions/workflows/ci.yml)
-[![Docs](https://github.com/ai-agent-assembly/agent-assembly/actions/workflows/docs.yml/badge.svg)](https://github.com/ai-agent-assembly/agent-assembly/actions/workflows/docs.yml)
-[![codecov](https://codecov.io/gh/ai-agent-assembly/agent-assembly/branch/master/graph/badge.svg)](https://codecov.io/gh/ai-agent-assembly/agent-assembly)
-[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Release](https://img.shields.io/github/v/release/ai-agent-assembly/agent-assembly?include_prereleases&sort=semver)](https://github.com/ai-agent-assembly/agent-assembly/releases)
+[![CI](https://img.shields.io/github/actions/workflow/status/ai-agent-assembly/agent-assembly/ci.yml?branch=master&logo=githubactions&logoColor=white&label=CI)](https://github.com/ai-agent-assembly/agent-assembly/actions/workflows/ci.yml)
+[![Docs](https://img.shields.io/github/actions/workflow/status/ai-agent-assembly/agent-assembly/docs.yml?branch=master&logo=githubactions&logoColor=white&label=docs)](https://github.com/ai-agent-assembly/agent-assembly/actions/workflows/docs.yml)
+[![Release](https://img.shields.io/badge/release-v0.0.1--alpha.5-3b82f6?logo=github)](https://github.com/ai-agent-assembly/agent-assembly/releases)
+[![Coverage](https://img.shields.io/codecov/c/github/ai-agent-assembly/agent-assembly?logo=codecov&logoColor=white)](https://codecov.io/gh/ai-agent-assembly/agent-assembly)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](LICENSE)
+[![Rust](https://img.shields.io/badge/rust-%E2%89%A51.75-orange?logo=rust)](https://www.rust-lang.org)
+[![Style](https://img.shields.io/badge/style-rustfmt-000?logo=rust)](https://github.com/rust-lang/rustfmt)
+[![Lints](https://img.shields.io/badge/lints-clippy-blue?logo=rust)](https://github.com/rust-lang/rust-clippy)
 
 
 ## Install the CLI

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Docs](https://img.shields.io/github/actions/workflow/status/ai-agent-assembly/agent-assembly/docs.yml?branch=master&logo=githubactions&logoColor=white&label=docs)](https://github.com/ai-agent-assembly/agent-assembly/actions/workflows/docs.yml)
 [![Release](https://img.shields.io/badge/release-v0.0.1--alpha.5-3b82f6?logo=github)](https://github.com/ai-agent-assembly/agent-assembly/releases)
 [![Coverage](https://img.shields.io/codecov/c/github/ai-agent-assembly/agent-assembly?logo=codecov&logoColor=white)](https://codecov.io/gh/ai-agent-assembly/agent-assembly)
+[![Quality Gate](https://img.shields.io/sonar/quality_gate/AI-agent-assembly_agent-assembly?server=https%3A%2F%2Fsonarcloud.io&logo=sonarcloud)](https://sonarcloud.io/project/overview?id=AI-agent-assembly_agent-assembly)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue?logo=apache)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-%E2%89%A51.75-orange?logo=rust)](https://www.rust-lang.org)
 [![Style](https://img.shields.io/badge/style-rustfmt-000?logo=rust)](https://github.com/rust-lang/rustfmt)


### PR DESCRIPTION
## Description

Replaces the badge block at the top of `README.md` with a single, consistently ordered, logo'd badge strip that conveys project state at a glance. Every badge carries a `?logo=...` and links to the relevant page. Each badge URL was curl-verified to render a real value before inclusion.

Badge set (in order):

| Badge | Renders | Logo |
|---|---|---|
| CI | `CI: passing` | githubactions |
| Docs | `docs: passing` | githubactions |
| Release | `release: v0.0.1-alpha.5` | github |
| Coverage | `coverage: 78%` | codecov |
| Quality Gate | `quality gate: failed` | sonarcloud |
| License | `license: Apache-2.0` | apache |
| Rust | `rust: ≥1.75` | rust |
| Style | `style: rustfmt` | rust |
| Lints | `lints: clippy` | rust |

Notable choices:
- CI/Docs use the shields.io `github/actions/workflow/status` endpoint (`logo=githubactions`) instead of the plain GitHub badge so they carry a logo.
- Release uses a **static** `img.shields.io/badge` pinned to the current latest tag (`v0.0.1-alpha.5`) rather than the rate-limit-flaky live `github/v/release` badge.

### SonarCloud quality-gate badge — now ADDED (correct capital key)

The badge was previously omitted because the project key `ai-agent-assembly_agent-assembly` (lowercase, as in `sonar-project.properties`) returned `component or metric not found`. The SonarCloud project actually exists under the **original capital casing** `AI-agent-assembly_agent-assembly` (capital `AI-`) — the documented casing exception for this org. The Quality Gate badge has been added using that correct capital key, placed right after the Coverage badge:

```
[![Quality Gate](https://img.shields.io/sonar/quality_gate/AI-agent-assembly_agent-assembly?server=https%3A%2F%2Fsonarcloud.io&logo=sonarcloud)](https://sonarcloud.io/project/overview?id=AI-agent-assembly_agent-assembly)
```

`curl -sL` confirms it renders a real value: `quality gate: failed` (not "not found").

> **Separate bug (not fixed here):** `sonar-project.properties` still carries the WRONG lowercase key `ai-agent-assembly_agent-assembly`, which does not match the real capital-cased SonarCloud project. The CI scan may be pushing analysis to a wrong/shadow project. This warrants its own ticket and verification of the CI scan flow; it is intentionally left untouched in this docs-only PR.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2763

## Testing

- [x] Manual testing performed — each badge URL was `curl`'d and its SVG `aria-label` confirmed to render a real value (not an error) before inclusion.
