### PR TITLE
[AAASM-2771] 🔧 (ci): Use real capital SonarCloud project key for scans

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.host.url=https://sonarcloud.io
-sonar.projectKey=ai-agent-assembly_agent-assembly
+sonar.projectKey=AI-agent-assembly_agent-assembly
 sonar.organization=ai-agent-assembly
 
 sonar.projectName=agent-assembly


### PR DESCRIPTION
## What changed

`sonar-project.properties`: restore `sonar.projectKey` to the real capital casing `AI-agent-assembly_agent-assembly`. The organization slug is left as-is (`ai-agent-assembly`, lowercase) — that is what the live SonarCloud project actually uses.

## Why

The org rename lowercased `sonar.projectKey` to `ai-agent-assembly_agent-assembly`, but the real SonarCloud project keeps the original capital key. Verified:
- `components/show?component=AI-agent-assembly_agent-assembly` returns a live project (`organization: ai-agent-assembly`, last analysed 2026-06-06).
- The quality-gate badge renders a real gate for the capital key and "not found" for the lowercase one.

The CI sonar step (`ci.yml`) passes **no** explicit `-Dsonar.projectKey`/`-Dsonar.organization` — it relies entirely on this properties file — so the lowercase key meant scans were targeting a non-existent project. This change makes the scan update the real project again. The org line needed no change.

## How to verify

On the next `master` CI run the SonarCloud scan will post results to `AI-agent-assembly_agent-assembly` (the live project), and the quality-gate badge / PR decoration will update.

Refs AAASM-2771