### PR TITLE
[AAASM-2775] 🐛 (release): Fix strip-for-publish leak of audit-consumer through aa-integration-tests

### DIFF
--- a/.ci/strip-for-publish.sh
+++ b/.ci/strip-for-publish.sh
@@ -50,6 +50,10 @@ MARKED_FILES=(
     "${REPO_ROOT}/aa-gateway/Cargo.toml"
     "${REPO_ROOT}/aa-gateway/src/lib.rs"
     "${REPO_ROOT}/aa-gateway/src/main.rs"
+    # AAASM-2775: aa-integration-tests forwards a feature to aa-gateway's stripped
+    # audit-consumer feature. Without this strip, cargo-workspaces resolution
+    # fails at publish time on the dangling feature reference (alpha-6 release).
+    "${REPO_ROOT}/aa-integration-tests/Cargo.toml"
 )
 
 # ---- Files to delete outright (they consume held-back deps) ----

--- a/aa-integration-tests/Cargo.toml
+++ b/aa-integration-tests/Cargo.toml
@@ -21,7 +21,15 @@ integration-test = []
 # `tests/audit_consumer_verify.rs` (Docker-backed: NATS JetStream + Postgres).
 #
 # Usage: cargo nextest run -p aa-integration-tests --features audit-consumer --test audit_consumer_verify
+#
+# AAASM-2775: wrapped in strip-for-publish markers so the published workspace
+# graph does not reference `aa-gateway/audit-consumer` (which is itself stripped
+# from aa-gateway/Cargo.toml at publish time, AAASM-2388). aa-integration-tests
+# is `publish = false`, but cargo-workspaces walks the full workspace dep graph
+# during publish and resolution fails on the dangling feature reference.
+# strip-for-publish:begin audit-consumer
 audit-consumer = ["aa-gateway/audit-consumer"]
+# strip-for-publish:end audit-consumer
 
 # AAASM-2594: e2e verification of the aa-runtime audit-publisher startup wiring.
 # Gates `tests/audit_publisher_startup_verify.rs` (Docker-backed: NATS JetStream).


### PR DESCRIPTION
## Summary

The alpha-6 release (AAASM-2767 / tag `v0.0.1-alpha.6`) succeeded on **4 of 5 channels** (GH Release, Homebrew tap PR #13, npm `@agent-assembly/sdk@0.0.1-alpha.6` + 4 sub-packages, PyPI `agent-assembly==0.0.1a6`, Go module proxy `go-sdk@v0.0.1-alpha.5`) but failed at `publish-crates` on crates.io with a cargo resolver error:

```
error: failed to select a version for `aa-gateway`.
    ... required by package `aa-integration-tests v0.0.1-alpha.6`
versions that meet the requirements `*` (locked to 0.0.1-alpha.6) are: 0.0.1-alpha.6

package `aa-integration-tests` depends on `aa-gateway` with feature `audit-consumer`
but `aa-gateway` does not have that feature.
help: available features: default, redis-cache
```

Run: https://github.com/ai-agent-assembly/agent-assembly/actions/runs/27422337419/job/81053203724

## Root cause

[AAASM-2388](https://lightning-dust-mite.atlassian.net/browse/AAASM-2388) wrapped the gateway NATS audit-consumer feature in `strip-for-publish:begin audit-consumer` / `:end audit-consumer` markers in `aa-gateway/Cargo.toml` and added it to `MARKED_FILES` in `.ci/strip-for-publish.sh`. But the **matching feature forward** in `aa-integration-tests/Cargo.toml`:

```toml
audit-consumer = ["aa-gateway/audit-consumer"]
```

was never wrapped, and `aa-integration-tests/Cargo.toml` was never added to `MARKED_FILES`.

`aa-integration-tests` is `publish = false` so cargo doesn't try to upload it, but **cargo-workspaces walks the full workspace dependency graph during the publish run** and resolution fails on the dangling feature reference.

The latent bug stayed hidden until alpha-6:
- Pre-alpha-5 publishes failed at the dirty-tree check (AAASM-2346).
- alpha-5 publishes failed at the `aa-ebpf` source-mutation guard (AAASM-2463).
- Both exit **before** the workspace resolver runs.
- AAASM-2463's `--no-verify` fix in alpha-6 finally let publishes get past the verify guard and surfaced this next-layer issue.

## Fix

1. `aa-integration-tests/Cargo.toml` — wrap `audit-consumer = ["aa-gateway/audit-consumer"]` in `# strip-for-publish:begin audit-consumer` / `# strip-for-publish:end audit-consumer` markers.
2. `.ci/strip-for-publish.sh` — add `aa-integration-tests/Cargo.toml` to `MARKED_FILES`.

12 inserts across 2 files; no other touches.

## Local verification

```
$ bash .ci/strip-for-publish.sh
AAASM-2340 strip-for-publish: scrubbing held-back surface for crates.io publish
  ...
  ✓ aa-cli compiles cleanly without dev-tool surface
  ✓ aa-gateway compiles cleanly without audit-consumer surface

$ cargo metadata --format-version 1 --no-deps  # post-strip
✓ workspace resolves (no missing-feature error)
```

The cargo dry-run `cargo publish -p aa-gateway --dry-run --no-verify` then fails on a different (expected) error: `aa-core@0.0.1-alpha.6` not on crates.io — which is correct, because during a real `cargo workspaces publish` run aa-core publishes first in topological order.

## After merge

Tag `v0.0.1-alpha.7` to retry the crates.io publish path. The four already-green channels (GH Release, Homebrew, npm, PyPI, Go module proxy) carry forward from alpha-6; the new tag's release.yml will simply re-publish them at alpha.7 alongside.

## Test plan

- [x] Local pre-commit (cargo fmt + clippy + deny) green via lefthook
- [x] Local strip-for-publish.sh + cargo metadata green
- [ ] CI green on this PR (Test + Build + Coverage + SonarCloud + compat-matrix)
- [ ] Tag `v0.0.1-alpha.7` after merge → release.yml `publish-crates` succeeds for all 9 publishable crates

## Refs

- alpha-6 release run: https://github.com/ai-agent-assembly/agent-assembly/actions/runs/27422337419
- Origin: [AAASM-2388](https://lightning-dust-mite.atlassian.net/browse/AAASM-2388) (NATS AuditPublisher in aa-runtime)
- Predecessor recovery: [AAASM-2463](https://lightning-dust-mite.atlassian.net/browse/AAASM-2463) (alpha-5 → alpha-6 `--no-verify` fix)
- Ticket: [AAASM-2775](https://lightning-dust-mite.atlassian.net/browse/AAASM-2775)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-2388]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-2388]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ