### PR TITLE
[AAASM-2792] 🐛 (release): Revert shipped aasm to --release (dist profile breaks homebrew install)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,8 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm build
-      - name: Build aasm shipping binary (dist profile)
-        run: cargo build --profile dist --target ${{ matrix.target }} -p aa-cli
+      - name: Build aasm release binary
+        run: cargo build --release --target ${{ matrix.target }} -p aa-cli
 
       - name: Install Rosetta 2 (x86_64-apple-darwin smoke test)
         if: matrix.target == 'x86_64-apple-darwin'
@@ -74,7 +74,7 @@ jobs:
       - name: Smoke-test aasm binary (size + --version)
         shell: bash
         run: |
-          BIN="target/${{ matrix.target }}/dist/aasm"
+          BIN="target/${{ matrix.target }}/release/aasm"
           ls -lh "$BIN"
           file "$BIN"
           "$BIN" --version
@@ -96,7 +96,7 @@ jobs:
           APPLE_NOTARY_ISSUER: ${{ secrets.APPLE_NOTARY_ISSUER }}
         run: |
           set -euo pipefail
-          BIN="target/${{ matrix.target }}/dist/aasm"
+          BIN="target/${{ matrix.target }}/release/aasm"
           KEYCHAIN="$RUNNER_TEMP/notary.keychain-db"
           KEYCHAIN_PW="$(uuidgen)"
           security create-keychain -p "$KEYCHAIN_PW" "$KEYCHAIN"
@@ -122,7 +122,7 @@ jobs:
         shell: bash
         run: |
           tar -czf "aasm-${{ matrix.target }}.tar.gz" \
-            -C "target/${{ matrix.target }}/dist" aasm
+            -C "target/${{ matrix.target }}/release" aasm
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

The alpha-6 [homebrew tap PR #13](https://github.com/AI-agent-assembly/homebrew-agent-assembly/pull/13) failed its `brew install + test (macOS)` job with a silent sandbox failure:

```
==> Verifying checksum for '...--aasm-aarch64-apple-darwin.tar.gz'
✔︎ Formula aasm (0.0.1-alpha.6)
==> Installing aasm from agent-assembly/agent-assembly
##[error]Failure while executing; `sandbox-exec ... build.rb ... --verbose` exited with 1.
##[error]Process completed with exit code 1.
```

No output between `Installing aasm` and `Failure while executing`. 1.3-second elapsed. Identical pattern on a [second rerun](https://github.com/ai-agent-assembly/homebrew-agent-assembly/actions/runs/27422999812/job/81074194773) → not transient.

## Diagnosis

| Observation | Source |
|---|---|
| Every prior install/test run (8 cycles back to alpha-5) was green. PR #13 is the only failure. | tap repo workflow history |
| Same runner image (`macos-15-arm64/20260527.0100`), same brew setup action, same formula structure | both run logs |
| alpha-6 binary runs fine locally (`aasm --version` works) | local verify |
| Same Mach-O structure as alpha-5: arm64, adhoc-signed, same 6 system framework links | `codesign -dv` + `otool -L` diff |
| Successful alpha-5 case produced `cp -p …` install-block output immediately. alpha-6 produced **nothing** before the sandbox bombed | log diff |

That silent-zero-output exit is the classic SIGKILL signature from `sandbox-exec` killing the build.rb Ruby subprocess on a rule violation.

The only in-scope release-pipeline change between alpha-5 and alpha-6 that affects the shipped binary is commit [`5d833650`](https://github.com/ai-agent-assembly/agent-assembly/commit/5d833650) (`👷 (release): Build shipped aasm with --profile dist`), which flipped:

- **before**: `--release` (thin-LTO / `opt=2` / `codegen-units=16`)
- **after**: `--profile dist` (fat-LTO / `opt=z` / `codegen-units=1`)

Fat-LTO Mach-O binaries are a known class of input that occasionally trips macOS `sandbox-exec` rules.

## Fix

5 single-line edits in `.github/workflows/release.yml` reverting the build command and binary path back to `--release` / `target/<target>/release/aasm`:

- `cargo build --profile dist` → `cargo build --release`
- Smoke-test, codesign-scaffold, and archive paths all flipped `dist/` → `release/`.

The `dist`-profile size optimization is nice-to-have but cannot block the Homebrew distribution channel. Debugging the brew-sandbox interaction in detail to re-enable `--profile dist` is left for a separate follow-up.

## After merge

[PR #1022](https://github.com/AI-agent-assembly/agent-assembly/pull/1022) (AAASM-2786 alpha-7 bump) needs a rebase onto the new master so the alpha-7 tag picks up `--release`. I'll handle that.

## Test plan

- [x] Local pre-commit (cargo fmt + clippy + deny) green via lefthook
- [ ] CI green on this PR
- [ ] After merge + alpha-7 tag: homebrew tap PR's `brew install + test (macOS)` job runs green

## Refs

- alpha-6 tap PR with failure: https://github.com/AI-agent-assembly/homebrew-agent-assembly/pull/13
- Failed run logs: https://github.com/ai-agent-assembly/homebrew-agent-assembly/actions/runs/27422999812/job/81074194773
- Origin of the dist-profile switch: commit `5d833650` (AAASM-2575 follow-up)
- Blocks: [AAASM-2786 / PR #1022](https://github.com/AI-agent-assembly/agent-assembly/pull/1022) (alpha-7 release tag)
- Ticket: [AAASM-2792](https://lightning-dust-mite.atlassian.net/browse/AAASM-2792)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-2792]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ