### PR TITLE
[AAASM-2797] 🐛 (release): Add version="0.0.1-alpha.7" to storage/cache crate path-deps

### DIFF
--- a/aa-cache/Cargo.toml
+++ b/aa-cache/Cargo.toml
@@ -7,7 +7,7 @@ repository.workspace = true
 description = "In-process L1 cache wrapper (DashMap + TTL + stampede protection) for the Agent Assembly storage traits"
 
 [dependencies]
-aa-core = { path = "../aa-core" }
+aa-core = { path = "../aa-core", version = "0.0.1-alpha.7" }
 async-trait = { workspace = true }
 dashmap = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }

--- a/aa-storage-memory/Cargo.toml
+++ b/aa-storage-memory/Cargo.toml
@@ -7,8 +7,8 @@ repository.workspace = true
 description = "In-memory aa-storage driver (DashMap-backed) for tests and local development"
 
 [dependencies]
-aa-core = { path = "../aa-core" }
-aa-storage = { path = "../aa-storage" }
+aa-core = { path = "../aa-core", version = "0.0.1-alpha.7" }
+aa-storage = { path = "../aa-storage", version = "0.0.1-alpha.7" }
 async-trait = { workspace = true }
 dashmap = { workspace = true }
 parking_lot = { workspace = true }

--- a/aa-storage-redis/Cargo.toml
+++ b/aa-storage-redis/Cargo.toml
@@ -9,11 +9,11 @@ description = "Redis L2 shared-cache storage driver (SessionStore, RateLimitCoun
 [dependencies]
 # Trait contract — the storage traits live in `aa-core::storage` and are
 # re-exported verbatim by the `aa-storage` facade.
-aa-storage = { path = "../aa-storage" }
+aa-storage = { path = "../aa-storage", version = "0.0.1-alpha.7" }
 # Pulled in only to enable `aa-core`'s `serde` feature so `PolicyDocument`
 # (re-exported through `aa-storage`) gains `Serialize`/`Deserialize`, which the
 # JSON-backed `RedisPolicyStore` needs. No `aa-core` items are named directly.
-aa-core = { path = "../aa-core", features = ["serde"] }
+aa-core = { path = "../aa-core", version = "0.0.1-alpha.7", features = ["serde"] }
 
 async-trait = { workspace = true }
 # `redis = 1.2` matches the workspace pin. `tokio-rustls-comp` backs the
@@ -33,7 +33,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 testcontainers-modules = { workspace = true, features = ["redis"] }
 # Second driver for the mixed-config registry-integration test (redis backs the
 # L2 kinds; memory backs the durable kinds).
-aa-storage-memory = { path = "../aa-storage-memory" }
+aa-storage-memory = { path = "../aa-storage-memory", version = "0.0.1-alpha.7" }
 
 [lints]
 workspace = true

--- a/aa-storage-sqlite-buffer/Cargo.toml
+++ b/aa-storage-sqlite-buffer/Cargo.toml
@@ -10,7 +10,7 @@ description = "Local in-process SQLite event buffer that survives brief gateway/
 # The buffer serializes and replays the storage contract's `AuditEntry` through
 # the `AuditSink` trait, both reached from `aa-core`. `serde` is enabled so
 # `AuditEntry` can be encoded into the on-disk BLOB.
-aa-core = { path = "../aa-core", features = ["serde"] }
+aa-core = { path = "../aa-core", version = "0.0.1-alpha.7", features = ["serde"] }
 # Pinned to the rusqlite line that depends on `libsqlite3-sys 0.30`, matching
 # the `sqlx-sqlite 0.8.6` already resolved for `aa-gateway`. Only one crate in
 # the workspace may link the native `sqlite3` library, so both must resolve to

--- a/aa-storage/Cargo.toml
+++ b/aa-storage/Cargo.toml
@@ -11,7 +11,7 @@ description = "Storage trait abstraction (pure interface) for the Agent Assembly
 # here. `serde`/`toml` back the `[storage]` config schema + driver registry; the
 # crate stays a pure interface (no `sqlx`/`redis`/`tonic` backend dependency).
 # `async-trait` is a dev-dep used by the conformance test's example implementation.
-aa-core   = { path = "../aa-core" }
+aa-core   = { path = "../aa-core", version = "0.0.1-alpha.7" }
 serde     = { workspace = true }
 thiserror = { workspace = true }
 toml      = { workspace = true }


### PR DESCRIPTION
## Summary

The alpha-7 release (AAASM-2786, tag `v0.0.1-alpha.7`) had `publish-crates` die after publishing only `aa-core@0.0.1-alpha.7`:

```
error: failed to verify manifest at aa-storage/Cargo.toml
Caused by:
  all dependencies must have a version requirement specified when publishing.
  the `path` specification will be removed from the dependency declaration.
error: unable to publish package aa-storage
```

Run: https://github.com/ai-agent-assembly/agent-assembly/actions/runs/27431248533/job/81083489941

cargo refuses to publish a crate that has path-deps without `version = "..."` literals — it can't substitute a published version for the path-dep in the uploaded tarball.

## Affected crates (5 publishable, 8 path-deps)

| Crate | Path-deps that need a `version` literal |
|---|---|
| `aa-storage` | `aa-core` |
| `aa-storage-memory` | `aa-core`, `aa-storage` |
| `aa-storage-redis` | `aa-storage`, `aa-core`, `aa-storage-memory` |
| `aa-storage-sqlite-buffer` | `aa-core` |
| `aa-cache` | `aa-core` |

These 5 crates were added between alpha-3 and alpha-5 (AAASM-2458, 2367, 2372, 2374, 2379) but the alpha-3 → alpha-6 publish cycles all died at earlier blockers (dirty-tree check, `cargo publish --verify`, audit-consumer feature ref). The strict path-dep version requirement was never reached, so this latent bug never surfaced — until AAASM-2775 + AAASM-2792 got past all earlier blockers in alpha-7.

## Fix

Pattern matches existing publishable crates (`aa-gateway`, `aa-runtime`, etc.):

```diff
-aa-core   = { path = "../aa-core" }
+aa-core   = { path = "../aa-core", version = "0.0.1-alpha.7" }
```

8 single-line edits across 5 Cargo.toml files. `cargo metadata --format-version 1 --no-deps` resolves cleanly after the edit.

## After merge

Bump to `v0.0.1-alpha.8` (separate ticket) and re-tag to retry `publish-crates`. The other 5 channels from alpha-7 (GH Release, ghcr.io images, Homebrew tap formula, npm + 3/4 PyPI wheels) re-publish at alpha-8 alongside their existing rows.

## Multi-layer chain status

| Cycle | Publish-crates blocker | Fix |
|---|---|---|
| pre-alpha-5 | dirty-tree check | AAASM-2346 (`--allow-dirty`) |
| alpha-5 | `cargo publish --verify` source-mutation guard | AAASM-2463 (`--no-verify`) |
| alpha-6 | workspace resolver — `audit-consumer` ref leak | AAASM-2775 |
| **alpha-7** | **storage/cache crates' path-deps missing `version=`** | **AAASM-2797 (this PR)** |
| alpha-8 | (expected to be clean) | — |

## Test plan

- [x] `cargo metadata --format-version 1 --no-deps` resolves cleanly
- [x] Local pre-commit (cargo fmt + clippy + deny) green via lefthook
- [ ] CI green on this PR
- [ ] After merge + alpha-8 tag: `publish-crates` succeeds for all 9 publishable crates (aa-core, aa-proto, aa-ebpf-common, aa-ebpf, aa-runtime, aa-proxy, aa-sandbox, aa-gateway, aa-cli) AND the 5 storage/cache crates published here (aa-storage, aa-storage-memory, aa-storage-redis, aa-storage-sqlite-buffer, aa-cache) — total 14 crates landing on crates.io at alpha-8.

Wait — that 14-crate count is more than the 9 I said earlier. Let me verify in a follow-up review whether the 5 storage crates are actually intended to be published (no `publish = false` is currently set), or whether the intent is `publish = false` since they're newer storage primitives.

## Refs

- alpha-7 release run: https://github.com/ai-agent-assembly/agent-assembly/actions/runs/27431248533
- Predecessor: AAASM-2786 (alpha-7 bump)
- Multi-layer chain: AAASM-2346 → AAASM-2463 → AAASM-2775 → **AAASM-2797**
- Ticket: [AAASM-2797](https://lightning-dust-mite.atlassian.net/browse/AAASM-2797)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-2797]: https://lightning-dust-mite.atlassian.net/browse/AAASM-2797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ