### PR TITLE
🔧 (dependabot): Ignore broken time 0.3.48 (incompatible with rcgen 0.14.8)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,16 @@ updates:
     commit-message:
       prefix: "⬆"
     open-pull-requests-limit: 10
+    ignore:
+      # time 0.3.48 introduced an E0119 trait-coherence conflict that breaks
+      # rcgen 0.14.8 (our pinned cert-gen dep, used by aa-gateway/aa-proxy):
+      #   error[E0119]: conflicting implementations of trait `From<…HourBase>`
+      # No fixable combination exists yet — 0.3.48 is the latest `time` and
+      # 0.14.8 is the latest published `rcgen` (no 0.14.9 / 0.15). Skip this
+      # one broken release; a later `time` (0.3.49+) or an `rcgen` fix will
+      # re-enable the bump automatically. See PR #1026.
+      - dependency-name: "time"
+        versions: ["0.3.48"]
 
   # ── Dashboard (pnpm) ─────────────────────────────────────────────────────
   # React + TypeScript frontend scaffold located in dashboard/, managed with


### PR DESCRIPTION
## What

Adds a Dependabot `ignore` for **`time` version `0.3.48`** in the cargo entry of `.github/dependabot.yml`, so Dependabot stops re-opening the broken bump (#1026) on its daily schedule.

## Why

`time 0.3.48` introduced an `E0119` trait-coherence regression that fails to compile **`rcgen 0.14.8`** — our pinned cert-generation dependency (used by `aa-gateway` + `aa-proxy`):

```
error[E0119]: conflicting implementations of trait `From<…HourBase>` …
   --> rcgen-0.14.8/src/lib.rs:359:1
error: could not compile `rcgen` due to 2 previous errors
```

There is **no fixable version combination** today: `0.3.48` is the latest `time` (no `0.3.49+`), and `0.14.8` is the latest published `rcgen` (no `0.14.9`, no `0.15`). So the bump cannot go green while it's adopted — the only working state is keeping `time` at `0.3.47` (green on `master`). This is an upstream incompatibility, not our code.

Ignoring **only the specific `0.3.48` release** means Dependabot will automatically re-propose `time` once a compatible version ships (a later `time`, or an `rcgen` fix) — we don't lose future updates.

## How to verify

`.github/dependabot.yml` parses as valid YAML; the cargo entry now carries:
```yaml
    ignore:
      - dependency-name: "time"
        versions: ["0.3.48"]
```

## Related

- Closes the recurrence of #1026 (which is being closed as unmergeable). Refs #1026.
