### PR TITLE
[AAASM-2199] 📝 (readme): Link agent-assembly-examples from agent-assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ dev-verify passed (22s total)
 - [SDK repositories](#ecosystem) — Python, Node.js, and Go SDK guides
 - [Architecture Overview](docs/src/architecture.md) — three-layer interception model
 - [Policy examples](policy-examples/) — reference governance policies
-- [Runnable examples](https://github.com/AI-agent-assembly/agent-assembly-examples) — learn the runtime, CLI, and policy behavior by running small, framework-specific examples for Python, Node.js/TypeScript, Go, policy enforcement, approvals, audit, trace, and runtime workflows
+- [Runnable examples](https://github.com/ai-agent-assembly/agent-assembly-examples) — learn the runtime, CLI, and policy behavior by running small, framework-specific examples for Python, Node.js/TypeScript, Go, policy enforcement, approvals, audit, trace, and runtime workflows
 
 ## Running with Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ dev-verify passed (22s total)
 - [SDK repositories](#ecosystem) — Python, Node.js, and Go SDK guides
 - [Architecture Overview](docs/src/architecture.md) — three-layer interception model
 - [Policy examples](policy-examples/) — reference governance policies
+- [Runnable examples](https://github.com/AI-agent-assembly/agent-assembly-examples) — learn the runtime, CLI, and policy behavior by running small, framework-specific examples for Python, Node.js/TypeScript, Go, policy enforcement, approvals, audit, trace, and runtime workflows
 
 ## Running with Docker Compose
 


### PR DESCRIPTION
## Description

Add a **Runnable examples** entry to the Quickstart "Next steps" list in `README.md`, linking the [agent-assembly-examples](https://github.com/AI-agent-assembly/agent-assembly-examples) repo so readers can learn the runtime, CLI, and policy behavior by running small, framework-specific examples.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2199

## Testing

- [x] No tests required (README link addition only; no code or behavior change).

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a)
- [x] Commits are small and follow the Gitmoji convention