### PR TITLE
[AAASM-2827] 🐛 (docs): Rebuild archive subpaths from git tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -125,14 +125,15 @@ jobs:
             echo "channel=latest" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Restore previously published versions
+      - name: Fetch prior live versions.json
+        # AAASM-2752 + AAASM-2827: the live manifest is the only place that
+        # carries the moving channel targets (pre-release -> vX.Y.Z-pre).
+        # archived[] is rebuilt from git tags in the next step so a missing
+        # or truncated prior manifest is no longer a permanent loss.
         if: github.event_name != 'pull_request'
         id: restore
         continue-on-error: true
         run: |
-          # Aggregate existing published versions so we never wipe old
-          # version subpaths. We pull the live Pages site root; if the site
-          # does not exist yet (first deploy) this is a no-op.
           base_url="https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY##*/}"
           echo "Fetching existing versions.json from ${base_url}/versions.json"
           if curl -fsSL "${base_url}/versions.json" -o prior-versions.json; then
@@ -142,6 +143,86 @@ jobs:
             echo "prior_versions=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Rebuild every release tag's docs subpath from git
+        # AAASM-2827: the previous design mirrored prior subpaths from the
+        # live Pages site with `wget -r`, which silently lost versions when
+        # the mirror failed and only worked if the prior deploy was itself
+        # whole. Rebuild every archived release directly from its git tag
+        # instead — git is the source of truth, and this loop is idempotent
+        # and self-healing: if a prior release never published docs (e.g.
+        # because its Release workflow failed), it is recovered on the next
+        # successful deploy.
+        if: github.event_name != 'pull_request'
+        env:
+          VERSION: ${{ steps.docver.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p _site
+
+          # Enumerate every release tag (vX.Y.Z[-pre]) reachable in the
+          # repository. The workflow's checkout uses fetch-depth: 0 so all
+          # tags are local.
+          mapfile -t TAGS < <(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' | sort)
+          : > extra-archived.txt
+
+          # Workspace for tag worktrees. We use git worktree (cheaper than
+          # a fresh clone per tag) and tear each one down after use.
+          BUILD_ROOT="$(mktemp -d)"
+          trap 'rm -rf "$BUILD_ROOT" || true' EXIT
+
+          for tag in "${TAGS[@]}"; do
+            # Skip the tag being cut this run; the freshly built docs/book
+            # is placed in _site/$VERSION below by the assemble step.
+            if [ "$tag" = "$VERSION" ]; then
+              echo "$tag" >> extra-archived.txt
+              continue
+            fi
+
+            # Already restored from the artifact upload of a prior step?
+            # (Defensive — no current step pre-populates _site, but this
+            # keeps the loop idempotent if one is added later.)
+            if [ -f "_site/$tag/index.html" ]; then
+              echo "Skipping $tag (already present in _site)"
+              echo "$tag" >> extra-archived.txt
+              continue
+            fi
+
+            workdir="$BUILD_ROOT/$tag"
+            echo "::group::Rebuild $tag"
+            # `git worktree add --detach` checks out the tag's tree without
+            # touching the current branch state. A tag whose docs/ subtree
+            # is missing or whose mdBook config has drifted past this
+            # workflow's mdbook version is logged and skipped — its subpath
+            # will fall back to the prior live mirror (if any) or 404.
+            if ! git worktree add --detach "$workdir" "$tag" >/dev/null 2>&1; then
+              echo "::warning::Could not check out $tag; skipping."
+              echo "::endgroup::"
+              continue
+            fi
+            if [ ! -f "$workdir/docs/book.toml" ]; then
+              echo "::warning::$tag has no docs/book.toml; skipping."
+              git worktree remove --force "$workdir" >/dev/null 2>&1 || true
+              echo "::endgroup::"
+              continue
+            fi
+            if ! mdbook build "$workdir/docs"; then
+              echo "::warning::mdbook build failed for $tag; skipping."
+              git worktree remove --force "$workdir" >/dev/null 2>&1 || true
+              echo "::endgroup::"
+              continue
+            fi
+            mkdir -p "_site/$tag"
+            cp -R "$workdir/docs/book/." "_site/$tag/"
+            git worktree remove --force "$workdir" >/dev/null 2>&1 || true
+            echo "$tag" >> extra-archived.txt
+            echo "::endgroup::"
+          done
+
+          echo "Rebuilt archive subpaths:"
+          find _site -maxdepth 1 -mindepth 1 -type d | sort
+          echo "extra-archived.txt:"
+          cat extra-archived.txt
+
       - name: Assemble versioned Pages site
         if: github.event_name != 'pull_request'
         env:
@@ -149,46 +230,24 @@ jobs:
           CHANNEL: ${{ steps.docver.outputs.channel }}
         run: |
           set -euo pipefail
-          base_url="https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY##*/}"
 
           mkdir -p _site
-          # 1. Mirror existing published subpaths so they survive this deploy
-          #    (deploy-pages replaces the whole site with the artifact). We
-          #    union the prior channel targets + archived ids.
-          if [ -f prior-versions.json ]; then
-            python3 - <<'PYIDS' > prior-ids.txt
-          import json
-          d = json.load(open("prior-versions.json"))
-          ids = set()
-          for c in d.get("channels", []):
-              if isinstance(c, dict) and c.get("target"):
-                  ids.add(c["target"])
-          for a in d.get("archived", []):
-              if isinstance(a, dict) and a.get("id"):
-                  ids.add(a["id"])
-          print(" ".join(sorted(ids)))
-          PYIDS
-            for v in $(cat prior-ids.txt); do
-              if [ "$v" = "$VERSION" ]; then continue; fi
-              echo "Restoring existing version subpath: $v"
-              mkdir -p "_site/$v"
-              wget -q -e robots=off -np -r -nH --cut-dirs=1 -P "_site" "${base_url}/${v}/" \
-                || echo "WARN: could not mirror ${v}; it re-publishes from its own tag run."
-            done
-          fi
 
-          # 2. Place the freshly built book at the target version subpath.
+          # 1. Place the freshly built book at the target version subpath.
+          #    Archive subpaths for all *other* release tags were already
+          #    materialised by the rebuild step above.
           rm -rf "_site/$VERSION"
           mkdir -p "_site/$VERSION"
           cp -R docs/book/. "_site/$VERSION/"
 
-          # 3. Recompute versions.json via the testable channel module
+          # 2. Recompute versions.json via the testable channel module
           #    (docs/ci/channels.py), which applies the pre-release semver
-          #    gate: the pre-release channel is emitted only when the newest
-          #    pre-release strictly leads the newest stable release.
+          #    gate and unions extra-archived.txt (written by the rebuild
+          #    step) into archived[]. AAASM-2827: this makes archived[]
+          #    self-healing against a missing/truncated prior manifest.
           python3 docs/ci/build_versions.py "$VERSION" "$CHANNEL" _site/versions.json
 
-          # 4. Root redirect (stable -> pre-release -> latest, resolved client-side).
+          # 3. Root redirect (stable -> pre-release -> latest, resolved client-side).
           cp docs/site-root-index.html _site/index.html
 
           echo "Assembled _site:"; find _site -maxdepth 2 -type d | sort

--- a/docs/ci/build_versions.py
+++ b/docs/ci/build_versions.py
@@ -2,10 +2,13 @@
 
 Usage:  python3 docs/ci/build_versions.py <VERSION> <CHANNEL> <OUTPUT>
 
-Reads the prior live manifest from ``prior-versions.json`` (if present) and the
-committed source manifest from ``docs/versions.json`` (if present), computes the
-published manifest via :func:`channels.compute_versions` (which applies the
-pre-release semver gate), and writes it to ``<OUTPUT>``.
+Reads the prior live manifest from ``prior-versions.json`` (if present), the
+committed source manifest from ``docs/versions.json`` (if present), and an
+optional ``extra-archived.txt`` (one tag per line; AAASM-2827) listing every
+git tag the workflow has rebuilt into a versioned subpath this run. Computes
+the published manifest via :func:`channels.compute_versions` (which applies
+the pre-release semver gate and unions ``extra_archived`` into ``archived[]``)
+and writes it to ``<OUTPUT>``.
 """
 
 from __future__ import annotations
@@ -31,12 +34,38 @@ def _load(path: str) -> Manifest | None:
     return loaded if isinstance(loaded, dict) else None
 
 
+def _load_extra_archived(path: str) -> list[str]:
+    """Read a newline-separated list of version tags, dropping blanks/comments.
+
+    Returns an empty list if the file is missing; ``channels.compute_versions``
+    drops non-version strings, so a malformed file is degraded silently rather
+    than failing the deploy.
+    """
+    file = Path(path)
+    if not file.exists():
+        return []
+    tags: list[str] = []
+    for raw in file.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        tags.append(line)
+    return tags
+
+
 def main(argv: list[str]) -> None:
     """Recompute versions.json for one docs cut and write it to ``argv[3]``."""
     version, channel, output = argv[1], argv[2], argv[3]
     prior = _load("prior-versions.json")
     source = _load("docs/versions.json")
-    out = compute_versions(version, channel, prior=prior, source=source)
+    extra_archived = _load_extra_archived("extra-archived.txt")
+    out = compute_versions(
+        version,
+        channel,
+        prior=prior,
+        source=source,
+        extra_archived=extra_archived,
+    )
     Path(output).write_text(json.dumps(out, indent=2))
     print("versions.json:", json.dumps(out))
 

--- a/docs/ci/channels.py
+++ b/docs/ci/channels.py
@@ -168,6 +168,7 @@ def compute_versions(
     channel: str,
     prior: Manifest | None = None,
     source: Manifest | None = None,
+    extra_archived: list[str] | None = None,
 ) -> dict[str, list[dict[str, str]]]:
     """Compute the published ``versions.json`` document for one docs cut.
 
@@ -183,6 +184,13 @@ def compute_versions(
         ``None`` on first deploy.
     source:
         The committed ``docs/versions.json`` source manifest, or ``None``.
+    extra_archived:
+        Additional version ids to seed into ``archived[]`` (e.g. the full list
+        of release git tags reachable at the time of the cut). The workflow
+        rebuilds a versioned subpath for every git tag on every deploy, so
+        ``extra_archived`` makes ``versions.json`` self-healing against a
+        prior live manifest that has lost entries (AAASM-2827). Unrecognised
+        version strings are dropped silently.
 
     Returns a dict ``{"channels": [...], "archived": [...]}`` with channels in
     display order (latest, pre-release, stable) and archived newest-first. The
@@ -216,6 +224,15 @@ def compute_versions(
                         "target": c["target"],
                     },
                 )
+
+    # Seed extra archived entries supplied by the workflow (typically the full
+    # list of release git tags). This is the authoritative source of truth: if
+    # the prior live manifest lost an entry but its tag still exists in git,
+    # this restores it on the next cut.
+    if extra_archived:
+        for tag in extra_archived:
+            if isinstance(tag, str) and parse_version(tag) is not None:
+                archived.setdefault(tag, {"id": tag, "title": tag})
 
     # Always guarantee a latest channel.
     channels.setdefault(

--- a/docs/ci/test_channels.py
+++ b/docs/ci/test_channels.py
@@ -146,5 +146,62 @@ class ChannelGateScenarioTests(unittest.TestCase):
         self.assertNotIn("stable", chans)
 
 
+class ExtraArchivedSeedingTests(unittest.TestCase):
+    """Regression: AAASM-2827.
+
+    The live ``versions.json`` lost prior tags after a sequence of failed
+    releases meant earlier docs cuts never ran. The next successful cut then
+    inherited the truncated ``archived[]`` and the loss became permanent.
+
+    The fix: callers pass the full list of release git tags as
+    ``extra_archived`` so ``archived[]`` is reconstituted from the
+    authoritative source (git) on every deploy.
+    """
+
+    def test_extra_archived_restores_missing_tags(self) -> None:
+        # Reproduce the live state at the time of AAASM-2827: prior manifest
+        # has only v0.0.1-alpha.8 archived, but git tags v0.0.1-alpha.4..8
+        # all exist and are now rebuilt by the workflow.
+        prior = _prior(
+            pre_release="v0.0.1-alpha.8",
+            archived=["v0.0.1-alpha.8"],
+        )
+        tags = [
+            "v0.0.1-alpha.4",
+            "v0.0.1-alpha.5",
+            "v0.0.1-alpha.6",
+            "v0.0.1-alpha.7",
+            "v0.0.1-alpha.8",
+        ]
+        doc = compute_versions(
+            "latest", "latest", prior=prior, extra_archived=tags
+        )
+        ids = _archived_ids(doc)
+        for tag in tags:
+            self.assertIn(tag, ids)
+        # Newest-first ordering — the bumped tag heads the list.
+        self.assertEqual(ids[0], "v0.0.1-alpha.8")
+
+    def test_extra_archived_drops_non_version_strings(self) -> None:
+        # ``latest`` is the live latest-channel target and must never enter
+        # archived[]; ``not-a-version`` is a guard against garbled input.
+        doc = compute_versions(
+            "latest",
+            "latest",
+            extra_archived=["latest", "not-a-version", "v0.1.0"],
+        )
+        ids = _archived_ids(doc)
+        self.assertEqual(ids, ["v0.1.0"])
+
+    def test_extra_archived_idempotent_with_prior(self) -> None:
+        # An entry already present in prior is not duplicated when also
+        # supplied via extra_archived.
+        prior = _prior(archived=["v0.1.0"])
+        doc = compute_versions(
+            "latest", "latest", prior=prior, extra_archived=["v0.1.0", "v0.2.0"]
+        )
+        self.assertEqual(_archived_ids(doc), ["v0.2.0", "v0.1.0"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

The mdBook docs site at `https://ai-agent-assembly.github.io/agent-assembly/` was losing previously-archived release snapshots on each deploy. Live `versions.json` contained only the most recent tag (`v0.0.1-alpha.8`); `/v0.0.1-alpha.4/` .. `/v0.0.1-alpha.7/` all returned 404 even though the tags exist in git.

## Root cause

Two compounding failures in `.github/workflows/docs.yml` and `docs/ci/`:

1. **Brittle mirror restore.** The `Restore previously published versions` step mirrored prior versioned subpaths from the live Pages site with `wget -q -e robots=off -np -r -nH --cut-dirs=1 …`. When `wget -r` exits non-zero (partial mirror, intermittent 404 on a sub-asset), the step logged `WARN: could not mirror <tag>` and silently dropped the subpath. The next deploy's only restore input is the live site itself, so a single drop is permanent.

2. **`workflow_run` gating on Release `success`.** `docs.yml` is triggered by `workflow_run: workflows: ["Release"]` and gated on `github.event.workflow_run.conclusion == 'success'`. Releases for `v0.0.1-alpha.4`/`.5`/`.6`/`.7` all failed (build/publish issues unrelated to docs), so docs.yml was `skipped` for each — no subpath was ever published, no archived entry was ever added, and the next deploy had nothing to mirror.

`alpha.8` was the first successful Release whose docs ran end-to-end, so it appeared in `archived[]` alone.

## Fix

Stop trusting the live site as the source of truth for archived subpaths. Use git tags.

- **New workflow step `Rebuild every release tag's docs subpath from git`** enumerates `git tag --list 'v[0-9]*.[0-9]*.[0-9]*'`, `git worktree add --detach`s each tag, runs `mdbook build` against its `docs/` subtree, and copies the result to `_site/<tag>/`. Tags whose tree no longer builds with the workflow's mdbook version are logged with `::warning::` and skipped — they never block the deploy.
- **`compute_versions` gains an `extra_archived` parameter** (`docs/ci/channels.py`). The workflow writes the list of successfully-rebuilt tags to `extra-archived.txt`; `build_versions.py` reads it and feeds it to `compute_versions`, which unions it into `archived[]`. `parse_version` filters non-version strings so e.g. `"latest"` never lands in `archived[]`.
- **The `wget -r` mirror loop is removed** from `Assemble versioned Pages site`. The rebuild step has already materialised every archive subpath.
- **The prior-versions.json fetch is kept** (renamed to `Fetch prior live versions.json`) because it still carries the moving channel targets (`pre-release → v0.0.1-alpha.X`) that aren't recoverable from git tags alone.

## Backfill

No manual backfill needed. The next master-push docs deploy will rebuild `v0.0.1-alpha.4` through `v0.0.1-alpha.8` from git tags automatically. All five tags ship `docs/book.toml` + a buildable `docs/src/SUMMARY.md` (verified locally).

## Commits (atomic)

1. `✨ (docs): Add extra_archived seed to compute_versions` — channel module surface change with no caller wiring.
2. `✅ (docs): Add regression tests for extra_archived seeding` — covers the exact live-state scenario plus two edge cases (non-version filter, idempotency with prior).
3. `🔧 (docs): Read extra-archived.txt in build_versions.py` — wire the CLI driver through the new surface.
4. `🐛 (docs-ci): Rebuild every release tag's docs subpath from git` — workflow change: drop `wget -r`, add the tag rebuild loop.

## Test plan

- [x] `python3 docs/ci/test_channels.py` — all 12 tests pass (9 prior + 3 new).
- [x] CLI smoke-test: prior=`{latest, pre-release→alpha.8, archived=[alpha.8]}`, `extra-archived.txt`=alpha.4..8 + `latest` + `not-a-version` → `archived[]` = `[alpha.8, alpha.7, alpha.6, alpha.5, alpha.4]` newest-first, `latest`/`not-a-version` dropped.
- [x] CLI smoke-test: no `extra-archived.txt` present → output unchanged from pre-fix behaviour.
- [x] `actionlint .github/workflows/docs.yml` clean (with and without shellcheck).
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docs.yml'))"` parses; `jobs` and step count intact.
- [ ] On merge: docs deploy logs should show 5 `::group::Rebuild v0.0.1-alpha.X` groups and `extra-archived.txt` listing all 5 tags. Final `versions.json` `archived[]` should contain all 5.
- [ ] Post-deploy: `curl -sI https://ai-agent-assembly.github.io/agent-assembly/v0.0.1-alpha.5/` returns 200.

Closes AAASM-2827.

🤖 Generated with [Claude Code](https://claude.com/claude-code)