### PR TITLE
[AAASM-2858] 📝 (release): Cross-link SDK runbooks for SDK-only hotfix path

### DIFF
--- a/docs/release/RUNBOOK.md
+++ b/docs/release/RUNBOOK.md
@@ -132,6 +132,20 @@ publishes. This is a coordination signal, not a gate. If an SDK publish
 fails, the SDK's own follow-up release fixes it independently — the
 `agent-assembly` tag is unaffected.
 
+### SDK-only hotfixes — do not cut an agent-assembly tag
+
+When an operator is asked to ship a fix that lives **only** in a Python
+or TypeScript SDK surface (no change to the `aasm` binary, no change to
+a shared Rust crate), do **not** cut a fresh `agent-assembly` tag for it.
+Cutting an agent-assembly tag triggers crates.io publishes, ghcr.io image
+builds, and a Homebrew tap PR — all wasted work for a fix that touches
+none of those artifacts. Instead, dispatch the SDK's own release workflow
+in SDK-only hotfix mode and reuse the existing `agent-assembly` tag as
+`binary_source_tag`. See `node-sdk/docs/release/RUNBOOK.md` section 2 and
+`python-sdk/docs/release/RUNBOOK.md` section 2 for the per-SDK procedure,
+including the `.N` (semver) vs `.postN` (PEP 440) version-naming
+asymmetry between the two ecosystems.
+
 ## 8. Operator gates — one-time-per-environment setup
 
 These must be set up once, before the first release, and again whenever


### PR DESCRIPTION
## Description

Adds a new "### SDK-only hotfixes — do not cut an agent-assembly tag" subsection at the end of section 7 (`Decoupling note — SDK versions are not required to match`) of `docs/release/RUNBOOK.md`. The new subsection points operators at the per-SDK runbooks landed in parallel from this same ticket (in `ai-agent-assembly/node-sdk` and `ai-agent-assembly/python-sdk`) when they're asked to ship a fix that lives only in a Python or TypeScript SDK surface.

The intent is to discourage operators from accidentally cutting a fresh `agent-assembly` tag — which would trigger crates.io publishes, ghcr.io image builds, and a Homebrew tap PR — for a fix that touches none of those artifacts. The cross-link explicitly references each SDK runbook's section 2 ("SDK-only hotfix mode") and calls out the `.N` (semver) vs `.postN` (PEP 440) version-naming asymmetry between the two ecosystems so the operator picks the right spelling on the first try.

Placed at the end of the existing decoupling-note section because that's the natural home for "the SDKs don't move in lock-step with agent-assembly" guidance.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-2858 (subtask of Story AAASM-2851 — decouple SDK releases from agent-assembly core)
- Related GitHub issues: parallel runbook PRs opened from this ticket in `ai-agent-assembly/node-sdk` and `ai-agent-assembly/python-sdk`

## Testing

Describe the testing performed for this PR:

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

Manual verification:

- Visual inspection of rendered markdown — the new `###` subsection sits naturally under `## 7. Decoupling note` and doesn't disrupt the existing numbered-section flow because it's a sub-heading not a new top-level section.
- Pre-commit hooks (lefthook) ran clean — clippy/fmt/deny all skip with "no matching staged files" because the diff is markdown-only.
- Pre-push (`cargo doc`) skipped via `LEFTHOOK=0` on macOS — the project memory documents this pattern for docs-only commits on macOS where the eBPF crates can't cargo-doc.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

## Acceptance criteria coverage (from AAASM-2858)

- [x] AC3: agent-assembly runbook gets a 3–5 sentence cross-link paragraph pointing at SDK runbooks. (The new subsection is 6 sentences across 11 wrapped lines — slightly over the "3–5 sentence" guide-rail because the version-naming asymmetry note costs an extra sentence; happy to trim if preferred.)
- [x] AC4: PR bases `master`.
- [x] Single granular commit, `📝 (release):` scope.