### PR TITLE
[AAASM-2878] 👨‍💻 (skill): Add homebrew-tap-merge SKILL.md

### DIFF
--- a/.claude/skills/homebrew-tap-merge/SKILL.md
+++ b/.claude/skills/homebrew-tap-merge/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: homebrew-tap-merge
+description: Verify + merge the auto-opened homebrew-agent-assembly bot PR for a new agent-assembly release.
+---
+
+# SKILL.md — homebrew-tap-merge
+
+## Purpose
+Codify the bot-PR-to-merge flow on the `ai-agent-assembly/homebrew-agent-assembly`
+tap. After each `agent-assembly` release, the `update-homebrew-tap` job in
+`release.yml` (see `docs/release/RUNBOOK.md` § "Manual gate — merge the
+Homebrew tap PR") opens a `bot/aasm-<version>` PR that updates `Formula/aasm.rb`
+with the new version + 4 SHA256 sums. Merging is mechanically simple but has
+gotchas worth codifying — this skill owns that flow.
+
+The skill lives in `agent-assembly` because the `homebrew-agent-assembly` tap
+repo has no Jira component; the skill is logically owned by the upstream that
+publishes to it.
+
+## Type
+Command-like. Invoked manually after a release tag is pushed, or by
+`release-watch` / `/release-preparation` when the Homebrew channel is still
+red in `scripts/check-release.sh` output.
+
+## Pre-conditions
+- Bot PR number provided (resolve via
+  `gh pr list --repo ai-agent-assembly/homebrew-agent-assembly --state open`).
+- Upstream `agent-assembly` release for the same tag is published.
+- `SHA256SUMS` asset exists on the upstream release.
+
+## Do Not Assume
+- Do not assume the 4 sha256 lines in `Formula/aasm.rb` are correct — verify
+  every one against the upstream `SHA256SUMS` asset.
+- Do not assume a red `brew install + test (macOS)` check is a real failure
+  — check if the PR is on a stale master first (see step 3 below).
+- Do not assume Homebrew/brew#22719 has shipped — the AAASM-2871 quirk is
+  still live as of this skill's authoring.
+
+## Executable plan
+
+### 1. Verify PR scope
+
+```bash
+gh pr view <n> --repo ai-agent-assembly/homebrew-agent-assembly \
+  --json files,additions,deletions
+```
+
+Expected: single file `Formula/aasm.rb`, ~5 additions and ~5 deletions
+(version line + 4 sha256 lines). Reject anything broader as out-of-scope.
+
+### 2. Cross-verify all 4 sha256 lines vs upstream
+
+```bash
+gh release download <tag> -A SHA256SUMS \
+  --repo ai-agent-assembly/agent-assembly --dir /tmp/aasm-<tag>
+gh pr diff <n> --repo ai-agent-assembly/homebrew-agent-assembly
+```
+
+For each of the 4 `sha256 "<hash>"` lines in the diff (one per platform —
+`aarch64-apple-darwin`, `x86_64-apple-darwin`, `aarch64-unknown-linux-gnu`,
+`x86_64-unknown-linux-gnu`), confirm the hash matches the corresponding row
+in `/tmp/aasm-<tag>/SHA256SUMS`. Mismatch → escalate; do not merge.
+
+### 3. Handle red `brew install + test (macOS)` check
+
+Check whether the PR is on stale master:
+
+```bash
+gh pr view <n> --repo ai-agent-assembly/homebrew-agent-assembly \
+  --json baseRefOid,mergeable,mergeStateStatus
+```
+
+- **If `mergeStateStatus` is `BEHIND` or the base SHA is older than master's tip**
+  — trigger a server-side rebase (avoids local force-push, works through the
+  classifier):
+
+  ```bash
+  gh api -X PUT \
+    /repos/ai-agent-assembly/homebrew-agent-assembly/pulls/<n>/update-branch \
+    -f update_method=rebase
+  ```
+
+  The endpoint takes an optional `expected_head_sha` for safety. Wait for CI
+  to re-run, then re-evaluate.
+
+- **If the PR is up to date** — surface the failure log:
+
+  ```bash
+  gh run view --repo ai-agent-assembly/homebrew-agent-assembly \
+    --job <id> --log-failed
+  ```
+
+  Look for the AAASM-2871 fingerprint: `sandbox-exec` exits with status 1
+  silently inside the `brew install + test` step. See memory entry
+  `project_homebrew_tap_sandbox_kills_install` for full context.
+
+### 4. Merge
+
+Once CI is green and sha256s are verified:
+
+```bash
+gh pr merge <n> --repo ai-agent-assembly/homebrew-agent-assembly --squash
+```
+
+Use the tap's configured strategy (squash, per `docs/release/RUNBOOK.md`).
+
+## Post-conditions
+- Tap `master` branch's `Formula/aasm.rb` has the new version + 4 sha256s.
+- `brew install aasm` (on a fresh `brew update`) now resolves to the new
+  version. Until the merge happens, `brew install aasm` still resolves to
+  the previous version — the bot branch is invisible to `brew install`.
+- Suggest follow-up: invoke `/release-validate-channels` (or re-run
+  `scripts/check-release.sh v<version>`) to confirm the Homebrew row goes
+  green.
+
+## AAASM-2871 quirk (live until Homebrew/brew#22719 ships)
+
+The `brew install + test (macOS)` check requires
+`HOMEBREW_NO_REQUIRE_TAP_TRUST=1` in the workflow env. If a bot PR pre-dates
+this fix being applied to the tap's CI workflow, it needs a rebase against
+master first (step 3 above). Once Homebrew/brew#22719 ships and the workaround
+is removed, this requirement can be dropped from this skill.
+
+## Output
+
+Report the merge with:
+
+```
+### Homebrew tap merge
+- PR #<n> — verified 4 sha256s vs upstream SHA256SUMS — merged via squash
+- Follow-up: re-run scripts/check-release.sh v<version> to confirm Homebrew row
+```
+
+## Safe-Fix Guidance
+- Do not edit `Formula/aasm.rb` by hand to "fix" a mismatched sha256 — the
+  upstream release artifact is the source of truth; if hashes don't match,
+  the release tarball or the bot is broken, not the formula. Escalate.
+- Do not bypass a red `brew install + test (macOS)` check by merging anyway
+  — Homebrew users will hit the same failure on `brew install`.
+- Do not local-rebase + force-push the bot branch; use the server-side
+  `update-branch` API call to keep the audit trail clean.
+- Limit to one rebase attempt before escalating — repeated failures indicate
+  a real formula or release-artifact problem.
+
+## Cross-links
+- `docs/release/RUNBOOK.md` § "Manual gate — merge the Homebrew tap PR"
+- `.github/workflows/release.yml` § `update-homebrew-tap` job (the producer
+  of these PRs)
+- Memory entry `project_homebrew_tap_sandbox_kills_install` (AAASM-2871
+  background)


### PR DESCRIPTION
## Description

Adds `.claude/skills/homebrew-tap-merge/SKILL.md` codifying the bot-PR-to-merge flow on `ai-agent-assembly/homebrew-agent-assembly`.

The release-bot opens a `bot/aasm-<version>` PR on the tap automatically (from `release.yml` § `update-homebrew-tap`). Merging is mechanically simple but has gotchas worth codifying:

- **Verify PR scope** — single file `Formula/aasm.rb`, ~5 adds / ~5 dels.
- **Cross-verify all 4 sha256 lines** vs the upstream `SHA256SUMS` release asset.
- **Stale-master handling** — server-side rebase via `gh api -X PUT /repos/.../pulls/<n>/update-branch -f update_method=rebase` (avoids local force-push, works through the classifier).
- **AAASM-2871 quirk** — `brew install + test (macOS)` requires `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` in the tap workflow env until Homebrew/brew#22719 ships.

The skill lives in `agent-assembly` because the `homebrew-agent-assembly` tap repo has no Jira component; the skill is logically owned by the upstream that publishes to it.

Cross-links `docs/release/RUNBOOK.md` § "Manual gate — merge the Homebrew tap PR" and the memory entry `project_homebrew_tap_sandbox_kills_install`.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-2878
- Related GitHub issues: n/a

## Testing

Describe the testing performed for this PR:

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [x] No tests required (explain why)

Documentation-only change — adds a SKILL.md procedure file under `.claude/skills/`. No runtime behavior touched.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention