### PR TITLE
[AAASM-2883] ✨ (release.yml): Auto-PR SDK source-pin bumps on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -485,6 +485,77 @@ jobs:
             Upstream tag: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}
             Source workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
+  update-python-sdk-ffi-pin:
+    # AAASM-2883: after every tag push, open a PR on python-sdk that bumps
+    # all three git-SHA pins (`aa-core`, `aa-proto`, `aa-sdk-client`) in
+    # `rust/aa-ffi-python/Cargo.toml` to the exact commit this release
+    # was cut from. Per ADR 0002 / AAASM-2559 the three pins MUST share a
+    # single SHA so cargo resolves one checkout of the agent-assembly
+    # workspace; this job rewrites all three together. Mirrors
+    # update-node-sdk-ffi-pin (and ultimately update-homebrew-tap).
+    name: Update python-sdk aa-ffi-python pin
+    runs-on: ubuntu-latest
+    needs: publish
+    if: github.event_name == 'push'
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout python-sdk
+        uses: actions/checkout@v6
+        with:
+          repository: ai-agent-assembly/python-sdk
+          token: ${{ secrets.PYTHON_SDK_BOT_TOKEN }}
+          path: sdk
+
+      - name: Rewrite rust/aa-ffi-python/Cargo.toml git-SHA pins
+        shell: bash
+        env:
+          NEW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          cd sdk
+          # Rewrite the rev for each of the three shared crates. The host
+          # casing varies (`AI-agent-assembly` vs `ai-agent-assembly`) across
+          # historical edits, so the regex tolerates `[^"]*` for the URL.
+          for crate in aa-core aa-proto aa-sdk-client; do
+            sed -i -E "s|(${crate} = \{ git = \"[^\"]*\", rev = )\"[0-9a-f]{40}\"|\\1\"${NEW_SHA}\"|" \
+              rust/aa-ffi-python/Cargo.toml
+          done
+          # All three pins must now point at NEW_SHA (ADR 0002 / AAASM-2559).
+          for crate in aa-core aa-proto aa-sdk-client; do
+            grep -q "^${crate} = .*rev = \"${NEW_SHA}\"" rust/aa-ffi-python/Cargo.toml \
+              || { echo "::error::${crate} rev rewrite produced unexpected result"; exit 1; }
+          done
+          git -C . diff -- rust/aa-ffi-python/Cargo.toml || true
+
+      - name: Open SDK pin-bump PR via peter-evans/create-pull-request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          path: sdk
+          token: ${{ secrets.PYTHON_SDK_BOT_TOKEN }}
+          branch: bot/aa-ffi-pin-${{ github.ref_name }}
+          base: master
+          delete-branch: true
+          commit-message: "🤖 (aa-ffi-python): Bump aa-core/aa-proto/aa-sdk-client pin to ${{ github.ref_name }}"
+          title: "🤖 (aa-ffi-python): Bump aa-core/aa-proto/aa-sdk-client pin to ${{ github.ref_name }}"
+          body: |
+            Auto-bump the three shared git-SHA pins (`aa-core`, `aa-proto`,
+            `aa-sdk-client`) in `rust/aa-ffi-python/Cargo.toml` to track
+            agent-assembly release `${{ github.ref_name }}` (commit
+            `${{ github.sha }}`).
+
+            Per ADR 0002 / AAASM-2559 the three pins must share one SHA so
+            cargo resolves a single checkout of the agent-assembly workspace.
+
+            Why: without this PR, the SDK source pin drifts behind the
+            published agent-assembly binaries (AAASM-2880 observed an 8-day
+            drift behind alpha-9). Merging this PR on `python-sdk` realigns
+            the native shim with the matching upstream tag.
+
+            Upstream tag: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+            Source workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
   notify-downstream:
     # Cross-repo trigger: after agent-assembly's Release object is
     # published (binaries available on the GH Release page), fire a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,6 +423,68 @@ jobs:
 
             Source workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
+  update-node-sdk-ffi-pin:
+    # AAASM-2883: after every tag push, open a PR on node-sdk that bumps
+    # native/aa-ffi-node/Cargo.toml's `aa-sdk-client` git-SHA pin to the
+    # exact commit this release was cut from. Without this, the SDK pin
+    # drifts behind the published binaries (AAASM-2880 observed an 8-day
+    # drift behind alpha-9) because the manual bump step on the SDK side
+    # gets forgotten. The PR is opened by the bot and reviewed/merged on
+    # node-sdk; this workflow only proposes it.
+    name: Update node-sdk aa-ffi-node pin
+    runs-on: ubuntu-latest
+    needs: publish
+    if: github.event_name == 'push'
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout node-sdk
+        uses: actions/checkout@v6
+        with:
+          repository: ai-agent-assembly/node-sdk
+          token: ${{ secrets.NODE_SDK_BOT_TOKEN }}
+          path: sdk
+
+      - name: Rewrite native/aa-ffi-node/Cargo.toml aa-sdk-client rev
+        shell: bash
+        env:
+          NEW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          cd sdk
+          # Match the literal `aa-sdk-client = { git = "...", rev = "<40-hex>"`
+          # prefix and rewrite only the rev value. We don't need to know the
+          # old SHA ahead of time; the regex anchors on the surrounding tokens.
+          sed -i -E 's|(aa-sdk-client = \{ git = "[^"]*", rev = )"[0-9a-f]{40}"|\1"'"${NEW_SHA}"'"|' \
+            native/aa-ffi-node/Cargo.toml
+          grep -q "rev = \"${NEW_SHA}\"" native/aa-ffi-node/Cargo.toml \
+            || { echo "::error::aa-sdk-client rev rewrite produced unexpected result"; exit 1; }
+          git -C . diff -- native/aa-ffi-node/Cargo.toml || true
+
+      - name: Open SDK pin-bump PR via peter-evans/create-pull-request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          path: sdk
+          token: ${{ secrets.NODE_SDK_BOT_TOKEN }}
+          branch: bot/aa-ffi-pin-${{ github.ref_name }}
+          base: master
+          delete-branch: true
+          commit-message: "🤖 (aa-ffi-node): Bump aa-sdk-client pin to ${{ github.ref_name }}"
+          title: "🤖 (aa-ffi-node): Bump aa-sdk-client pin to ${{ github.ref_name }}"
+          body: |
+            Auto-bump `aa-sdk-client` git-SHA pin in `native/aa-ffi-node/Cargo.toml`
+            to track agent-assembly release `${{ github.ref_name }}` (commit
+            `${{ github.sha }}`).
+
+            Why: without this PR, the SDK source pin drifts behind the published
+            agent-assembly binaries (AAASM-2880 observed an 8-day drift behind
+            alpha-9). Merging this PR on `node-sdk` realigns the native shim
+            with the matching upstream tag.
+
+            Upstream tag: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+            Source workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
   notify-downstream:
     # Cross-repo trigger: after agent-assembly's Release object is
     # published (binaries available on the GH Release page), fire a

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -488,7 +488,7 @@ jobs:
   update-python-sdk-ffi-pin:
     # AAASM-2883: after every tag push, open a PR on python-sdk that bumps
     # all three git-SHA pins (`aa-core`, `aa-proto`, `aa-sdk-client`) in
-    # `rust/aa-ffi-python/Cargo.toml` to the exact commit this release
+    # `native/aa-ffi-python/Cargo.toml` to the exact commit this release
     # was cut from. Per ADR 0002 / AAASM-2559 the three pins MUST share a
     # single SHA so cargo resolves one checkout of the agent-assembly
     # workspace; this job rewrites all three together. Mirrors
@@ -508,7 +508,7 @@ jobs:
           token: ${{ secrets.PYTHON_SDK_BOT_TOKEN }}
           path: sdk
 
-      - name: Rewrite rust/aa-ffi-python/Cargo.toml git-SHA pins
+      - name: Rewrite native/aa-ffi-python/Cargo.toml git-SHA pins
         shell: bash
         env:
           NEW_SHA: ${{ github.sha }}
@@ -520,14 +520,14 @@ jobs:
           # historical edits, so the regex tolerates `[^"]*` for the URL.
           for crate in aa-core aa-proto aa-sdk-client; do
             sed -i -E "s|(${crate} = \{ git = \"[^\"]*\", rev = )\"[0-9a-f]{40}\"|\\1\"${NEW_SHA}\"|" \
-              rust/aa-ffi-python/Cargo.toml
+              native/aa-ffi-python/Cargo.toml
           done
           # All three pins must now point at NEW_SHA (ADR 0002 / AAASM-2559).
           for crate in aa-core aa-proto aa-sdk-client; do
-            grep -q "^${crate} = .*rev = \"${NEW_SHA}\"" rust/aa-ffi-python/Cargo.toml \
+            grep -q "^${crate} = .*rev = \"${NEW_SHA}\"" native/aa-ffi-python/Cargo.toml \
               || { echo "::error::${crate} rev rewrite produced unexpected result"; exit 1; }
           done
-          git -C . diff -- rust/aa-ffi-python/Cargo.toml || true
+          git -C . diff -- native/aa-ffi-python/Cargo.toml || true
 
       - name: Open SDK pin-bump PR via peter-evans/create-pull-request
         uses: peter-evans/create-pull-request@v8
@@ -541,7 +541,7 @@ jobs:
           title: "🤖 (aa-ffi-python): Bump aa-core/aa-proto/aa-sdk-client pin to ${{ github.ref_name }}"
           body: |
             Auto-bump the three shared git-SHA pins (`aa-core`, `aa-proto`,
-            `aa-sdk-client`) in `rust/aa-ffi-python/Cargo.toml` to track
+            `aa-sdk-client`) in `native/aa-ffi-python/Cargo.toml` to track
             agent-assembly release `${{ github.ref_name }}` (commit
             `${{ github.sha }}`).
 


### PR DESCRIPTION
## Description

Adds two new jobs to \`.github/workflows/release.yml\` that fire after every tag push to open auto-PRs against the SDK repos, bumping their FFI git-SHA source pins to the exact commit the release was cut from. Mirrors the existing \`update-homebrew-tap\` job pattern.

- **\`update-node-sdk-ffi-pin\`** — sed-rewrites the \`aa-sdk-client\` \`rev = "<sha>"\` in \`native/aa-ffi-node/Cargo.toml\` and opens a PR on \`AI-agent-assembly/node-sdk\` via \`peter-evans/create-pull-request@v8\` (token: \`NODE_SDK_BOT_TOKEN\`).
- **\`update-python-sdk-ffi-pin\`** — sed-rewrites all three shared git-SHA pins (\`aa-core\`, \`aa-proto\`, \`aa-sdk-client\`) in \`rust/aa-ffi-python/Cargo.toml\` to one SHA per ADR 0002 / AAASM-2559, then opens a PR on \`AI-agent-assembly/python-sdk\` (token: \`PYTHON_SDK_BOT_TOKEN\`).

Both jobs gate on \`needs: publish\` and \`if: github.event_name == 'push'\` so they only run on real tag pushes, not \`workflow_dispatch\`. Neither is added to \`release-status-aggregator\`'s \`needs:\` — they're purely additive so an SDK bot-token misconfig can't poison the existing release status report.

## Type of Change

- [x] ✨ New feature
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2883 (parent: AAASM-2880 — the alpha-9 SDK pin drifted 8 days behind the binary release because the manual remember-to-bump step failed)
- Related GitHub issues: n/a

## Owner action required before this is functional

The two new repo secrets must be configured on \`ai-agent-assembly/agent-assembly\`:

- \`NODE_SDK_BOT_TOKEN\` — fine-grained PAT or GitHub App token with \`contents: write\` + \`pull-requests: write\` on \`AI-agent-assembly/node-sdk\`.
- \`PYTHON_SDK_BOT_TOKEN\` — same scopes on \`AI-agent-assembly/python-sdk\`.

Without these, \`peter-evans/create-pull-request@v8\` will fail to push the bot branch. The jobs are still safe to merge ahead of the secret config; they'll simply no-op until the secrets exist.

## Testing

- [x] \`actionlint .github/workflows/release.yml\` — only the unrelated pre-existing SC2046 warning at line 97 (codesign step, untouched).
- [x] Both \`sed\` regexes dry-run against the actual SDK \`Cargo.toml\` files via Ubuntu 24.04 docker (GNU sed) — all four guards (\`grep -q\`) pass, all three python-sdk pins flip together to one SHA.
- [ ] End-to-end test (real tag push opening real bot PRs) — **not possible from a PR**; runs the first time a tag is pushed after merge. Precedent: \`update-homebrew-tap\` was validated the same way (\`actionlint\` + post-merge tag push).

## Checklist

- [x] Code follows project style guidelines (\`cargo fmt\`, \`cargo clippy\` — n/a, YAML-only)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (in-job comments explain the why)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention (2 commits — one per SDK job for review clarity)

## Precedent

The two jobs are structural copies of the existing \`update-homebrew-tap\` job (lines 345–424 of \`release.yml\` on master): same triggers, same \`peter-evans/create-pull-request@v8\` action, same \`bot/aa-ffi-pin-<tag>\` branch naming (mirrors \`bot/aasm-<version>\`), same body template.