### PR TITLE
[AAASM-2888] 📝 (skill): Restructure homebrew-tap-merge to Agent Skills spec (EXAMPLES + bundled script)

### DIFF
--- a/.claude/skills/homebrew-tap-merge/EXAMPLES.md
+++ b/.claude/skills/homebrew-tap-merge/EXAMPLES.md
@@ -1,0 +1,79 @@
+# EXAMPLES — homebrew-tap-merge
+
+A full end-to-end walk-through of the skill's 4-step plan against a real
+release. Use this to see what each step looks like in practice, including the
+AAASM-2871 stale-master rebase path. The lean plan lives in
+[SKILL.md](SKILL.md).
+
+## Contents
+
+- [Worked example — alpha-9 (2026-06-14)](#worked-example--alpha-9-2026-06-14)
+  - [Step 1 — Scope check](#step-1--scope-check)
+  - [Step 2 — Cross-verify 4 sha256s](#step-2--cross-verify-4-sha256s)
+  - [Step 3 — Detect stale-master + server-side rebase](#step-3--detect-stale-master--server-side-rebase)
+  - [Step 4 — Wait for CI re-run + merge](#step-4--wait-for-ci-re-run--merge)
+
+## Worked example — alpha-9 (2026-06-14)
+
+PR [#16](https://github.com/ai-agent-assembly/homebrew-agent-assembly/pull/16)
+on `ai-agent-assembly/homebrew-agent-assembly`, titled `🤖 (formula): aasm
+0.0.1-alpha.9`, opened by the release-bot at 2026-06-13 18:09 UTC after the
+upstream `v0.0.1-alpha.9` tag push triggered `release.yml`'s
+`update-homebrew-tap` job.
+
+**Initial state**: `brew install + test (macOS)` check RED with the
+AAASM-2871 silent `sandbox-exec` SIGKILL fingerprint (PR was based on a
+pre-`HOMEBREW_NO_REQUIRE_TAP_TRUST=1` master tip).
+
+### Step 1 — Scope check
+
+```bash
+gh pr view 16 --repo ai-agent-assembly/homebrew-agent-assembly \
+  --json files,additions,deletions
+# → single file Formula/aasm.rb, ~5 additions, ~5 deletions  ✓
+```
+
+### Step 2 — Cross-verify 4 sha256s
+
+```bash
+.claude/skills/homebrew-tap-merge/scripts/verify-tap-sha256.sh v0.0.1-alpha.9 16
+# OK: all 4 sha256 entries match upstream SHA256SUMS for v0.0.1-alpha.9.
+```
+
+The four sha256 values pinned in the PR diff (also present in upstream
+`SHA256SUMS`):
+
+| Platform                       | sha256 (alpha-9)                                                   |
+|--------------------------------|--------------------------------------------------------------------|
+| `aarch64-apple-darwin`         | `1e08c94b…` (darwin-arm)                                           |
+| `x86_64-apple-darwin`          | `047e0cb5…` (darwin-intel)                                         |
+| `aarch64-unknown-linux-gnu`    | `95b7f7ca…` (linux-arm)                                            |
+| `x86_64-unknown-linux-gnu`     | `311be632…` (linux-x64)                                            |
+
+### Step 3 — Detect stale-master + server-side rebase
+
+```bash
+gh pr view 16 --repo ai-agent-assembly/homebrew-agent-assembly \
+  --json mergeStateStatus
+# → "BEHIND"
+
+gh api -X PUT \
+  /repos/ai-agent-assembly/homebrew-agent-assembly/pulls/16/update-branch \
+  -f update_method=rebase
+```
+
+This pulls in the `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` env applied to the tap's
+`brew install + test` workflow on master, so the CI re-run no longer trips
+the AAASM-2871 sandbox quirk.
+
+### Step 4 — Wait for CI re-run + merge
+
+```bash
+# brew install + test (macOS) goes green; the success log contains:
+#   Pouring … Cellar/aasm/0.0.1-alpha.9: 3 files, 21.5MB, built in 1 second
+
+gh pr merge 16 --repo ai-agent-assembly/homebrew-agent-assembly --squash
+```
+
+Verifies the AAASM-2871 workaround is active in workflow env, then squashes
+in the formula bump.

--- a/.claude/skills/homebrew-tap-merge/SKILL.md
+++ b/.claude/skills/homebrew-tap-merge/SKILL.md
@@ -48,6 +48,26 @@ red in `scripts/check-release.sh` output.
 - Upstream `agent-assembly` release for the same tag is published.
 - `SHA256SUMS` asset exists on the upstream release.
 
+## How to use
+
+Invoke from a shell or via the slash command:
+
+```text
+/homebrew-tap-merge <PR_NUMBER>
+```
+
+Example: `/homebrew-tap-merge 16` — verify + merge tap PR #16 for
+`aasm 0.0.1-alpha.9`.
+
+**Required inputs**:
+
+- `<PR_NUMBER>` — the bot PR number on
+  `ai-agent-assembly/homebrew-agent-assembly`. Resolve with
+  `gh pr list --repo ai-agent-assembly/homebrew-agent-assembly --state open`.
+- Upstream `agent-assembly` release for the matching tag must already be
+  published with the `SHA256SUMS` asset attached (the helper script
+  `scripts/verify-tap-sha256.sh` downloads this).
+
 ## Do Not Assume
 - Do not assume the 4 sha256 lines in `Formula/aasm.rb` are correct — verify
   every one against the upstream `SHA256SUMS` asset.
@@ -70,16 +90,25 @@ Expected: single file `Formula/aasm.rb`, ~5 additions and ~5 deletions
 
 ### 2. Cross-verify all 4 sha256 lines vs upstream
 
+Run the helper:
+
+```bash
+./scripts/verify-tap-sha256.sh <tag> [<pr>]
+# e.g. ./scripts/verify-tap-sha256.sh v0.0.1-alpha.9 16
+```
+
+Exits 0 iff all 4 sha256s in the formula match the upstream `SHA256SUMS`
+asset (one per platform — `aarch64-apple-darwin`, `x86_64-apple-darwin`,
+`aarch64-unknown-linux-gnu`, `x86_64-unknown-linux-gnu`). Non-zero exit
+prints a mismatch table — **escalate; do not merge**.
+
+For ad-hoc inspection, the equivalent manual flow is:
+
 ```bash
 gh release download <tag> -A SHA256SUMS \
   --repo ai-agent-assembly/agent-assembly --dir /tmp/aasm-<tag>
 gh pr diff <n> --repo ai-agent-assembly/homebrew-agent-assembly
 ```
-
-For each of the 4 `sha256 "<hash>"` lines in the diff (one per platform —
-`aarch64-apple-darwin`, `x86_64-apple-darwin`, `aarch64-unknown-linux-gnu`,
-`x86_64-unknown-linux-gnu`), confirm the hash matches the corresponding row
-in `/tmp/aasm-<tag>/SHA256SUMS`. Mismatch → escalate; do not merge.
 
 ### 3. Handle red `brew install + test (macOS)` check
 

--- a/.claude/skills/homebrew-tap-merge/SKILL.md
+++ b/.claude/skills/homebrew-tap-merge/SKILL.md
@@ -153,6 +153,71 @@ gh pr merge <n> --repo ai-agent-assembly/homebrew-agent-assembly --squash
 
 Use the tap's configured strategy (squash, per `docs/release/RUNBOOK.md`).
 
+## Worked example — alpha-9 (2026-06-14)
+
+PR [#16](https://github.com/ai-agent-assembly/homebrew-agent-assembly/pull/16)
+on `ai-agent-assembly/homebrew-agent-assembly`, titled `🤖 (formula): aasm
+0.0.1-alpha.9`, opened by the release-bot at 2026-06-13 18:09 UTC after the
+upstream `v0.0.1-alpha.9` tag push triggered `release.yml`'s
+`update-homebrew-tap` job.
+
+**Initial state**: `brew install + test (macOS)` check RED with the
+AAASM-2871 silent `sandbox-exec` SIGKILL fingerprint (PR was based on a
+pre-`HOMEBREW_NO_REQUIRE_TAP_TRUST=1` master tip).
+
+**Step 1 — Scope check**:
+
+```bash
+gh pr view 16 --repo ai-agent-assembly/homebrew-agent-assembly \
+  --json files,additions,deletions
+# → single file Formula/aasm.rb, ~5 additions, ~5 deletions  ✓
+```
+
+**Step 2 — Cross-verify 4 sha256s**:
+
+```bash
+./scripts/verify-tap-sha256.sh v0.0.1-alpha.9 16
+# OK: all 4 sha256 entries match upstream SHA256SUMS for v0.0.1-alpha.9.
+```
+
+The four sha256 values pinned in the PR diff (also present in upstream
+`SHA256SUMS`):
+
+| Platform                       | sha256 (alpha-9)                                                   |
+|--------------------------------|--------------------------------------------------------------------|
+| `aarch64-apple-darwin`         | `1e08c94b…` (darwin-arm)                                           |
+| `x86_64-apple-darwin`          | `047e0cb5…` (darwin-intel)                                         |
+| `aarch64-unknown-linux-gnu`    | `95b7f7ca…` (linux-arm)                                            |
+| `x86_64-unknown-linux-gnu`     | `311be632…` (linux-x64)                                            |
+
+**Step 3 — Detect stale-master + server-side rebase**:
+
+```bash
+gh pr view 16 --repo ai-agent-assembly/homebrew-agent-assembly \
+  --json mergeStateStatus
+# → "BEHIND"
+
+gh api -X PUT \
+  /repos/ai-agent-assembly/homebrew-agent-assembly/pulls/16/update-branch \
+  -f update_method=rebase
+```
+
+This pulls in the `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` env applied to the tap's
+`brew install + test` workflow on master, so the CI re-run no longer trips
+the AAASM-2871 sandbox quirk.
+
+**Step 4 — Wait for CI re-run + merge**:
+
+```bash
+# brew install + test (macOS) goes green; the success log contains:
+#   Pouring … Cellar/aasm/0.0.1-alpha.9: 3 files, 21.5MB, built in 1 second
+
+gh pr merge 16 --repo ai-agent-assembly/homebrew-agent-assembly --squash
+```
+
+Verifies the AAASM-2871 workaround is active in workflow env, then squashes
+in the formula bump.
+
 ## Post-conditions
 - Tap `master` branch's `Formula/aasm.rb` has the new version + 4 sha256s.
 - `brew install aasm` (on a fresh `brew update`) now resolves to the new

--- a/.claude/skills/homebrew-tap-merge/SKILL.md
+++ b/.claude/skills/homebrew-tap-merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: homebrew-tap-merge
-description: Verify + merge the auto-opened homebrew-agent-assembly bot PR for a new agent-assembly release.
+description: Verify and merge the bot PR that release.yml auto-opens on homebrew-agent-assembly for a new agent-assembly release. Use when a bot/aasm-<version> PR is open on the Homebrew tap and needs sha256 cross-verification against the upstream SHA256SUMS, a stale-master server-side rebase, or the AAASM-2871 macOS-CI tap-trust workaround before it can be merged.
 ---
 
 # SKILL.md — homebrew-tap-merge

--- a/.claude/skills/homebrew-tap-merge/SKILL.md
+++ b/.claude/skills/homebrew-tap-merge/SKILL.md
@@ -17,6 +17,26 @@ The skill lives in `agent-assembly` because the `homebrew-agent-assembly` tap
 repo has no Jira component; the skill is logically owned by the upstream that
 publishes to it.
 
+## When to use
+
+Invoke this skill when `agent-assembly`'s `release.yml` has finished its
+`update-homebrew-tap` job and a `bot/aasm-<version>` PR is now open on
+`ai-agent-assembly/homebrew-agent-assembly`, and the operator (or
+`release-watch`) wants to verify the bot diff and merge it so `brew install
+aasm` picks up the new release.
+
+## When NOT to use
+
+- **Tap PR not yet open** — `release.yml` hasn't finished `update-homebrew-tap`
+  yet. Wait for the upstream release workflow rather than opening a manual PR.
+- **Tap PR has manual edits beyond the bot's diff** — anything outside the
+  version line + 4 sha256 lines is out of scope for this skill. Escalate; do
+  not auto-merge a hand-edited formula.
+- **AAASM-2871 (Homebrew/brew#22719) is patched upstream** — if the tap's
+  `brew install + test` workflow no longer needs `HOMEBREW_NO_REQUIRE_TAP_TRUST=1`,
+  the stale-master rebase shortcut may no longer be required; re-evaluate the
+  step 3 branch before relying on this skill verbatim.
+
 ## Type
 Command-like. Invoked manually after a release tag is pushed, or by
 `release-watch` / `/release-preparation` when the Homebrew channel is still

--- a/.claude/skills/homebrew-tap-merge/SKILL.md
+++ b/.claude/skills/homebrew-tap-merge/SKILL.md
@@ -227,6 +227,26 @@ in the formula bump.
   `scripts/check-release.sh v<version>`) to confirm the Homebrew row goes
   green.
 
+## What's expected when done
+
+When this skill completes successfully, all of the following must hold:
+
+- Tap `master`'s `Formula/aasm.rb` shows the new `version "<X>"` line and
+  the 4 sha256s that match upstream `SHA256SUMS` for the corresponding tag.
+- The bot PR is **closed and merged** (squash), not just approved.
+- The operator can immediately follow up with
+  `/release-validate-channels v<X>` and see the Homebrew row report ✓.
+
+Quick verification command from any shell with `gh` configured:
+
+```bash
+gh api /repos/ai-agent-assembly/homebrew-agent-assembly/contents/Formula/aasm.rb \
+  -H "Accept: application/vnd.github.raw" | grep -E "^  version |^      sha256"
+```
+
+The output should print one `version "<X>"` line and four `sha256 "<hash>"`
+lines matching the upstream release.
+
 ## AAASM-2871 quirk (live until Homebrew/brew#22719 ships)
 
 The `brew install + test (macOS)` check requires

--- a/.claude/skills/homebrew-tap-merge/SKILL.md
+++ b/.claude/skills/homebrew-tap-merge/SKILL.md
@@ -247,6 +247,25 @@ gh api /repos/ai-agent-assembly/homebrew-agent-assembly/contents/Formula/aasm.rb
 The output should print one `version "<X>"` line and four `sha256 "<hash>"`
 lines matching the upstream release.
 
+## What's auto-handled (do NOT manually run)
+
+These steps are owned by the release pipeline or are explicitly forbidden
+inside this skill — do not attempt them manually:
+
+- **Opening the bot PR** — handled by `release.yml`'s `update-homebrew-tap`
+  job, triggered on every `agent-assembly` tag push. Wait for it; do not
+  hand-open a tap PR.
+- **Editing `Formula/aasm.rb` by hand** — never. Any manual edit will be
+  undone by the next bot rebase, and a mismatched sha256 indicates a real
+  release-artifact problem upstream (escalate, do not "fix" the formula).
+- **`brew update-bottles` / `brew bottle …`** — not part of this tap's
+  lifecycle. The tap installs from binary tarballs (no bottle DSL); there
+  is nothing to bottle here.
+- **Local `git push --force` to the bot branch** — use the server-side
+  `gh api … /pulls/<n>/update-branch -f update_method=rebase` pattern from
+  step 3. The classifier blocks local force-push to active PRs without
+  explicit auth, and a force-push would also break the bot's audit trail.
+
 ## AAASM-2871 quirk (live until Homebrew/brew#22719 ships)
 
 The `brew install + test (macOS)` check requires

--- a/.claude/skills/homebrew-tap-merge/SKILL.md
+++ b/.claude/skills/homebrew-tap-merge/SKILL.md
@@ -6,75 +6,41 @@ description: Verify + merge the auto-opened homebrew-agent-assembly bot PR for a
 # SKILL.md — homebrew-tap-merge
 
 ## Purpose
-Codify the bot-PR-to-merge flow on the `ai-agent-assembly/homebrew-agent-assembly`
-tap. After each `agent-assembly` release, the `update-homebrew-tap` job in
-`release.yml` (see `docs/release/RUNBOOK.md` § "Manual gate — merge the
-Homebrew tap PR") opens a `bot/aasm-<version>` PR that updates `Formula/aasm.rb`
-with the new version + 4 SHA256 sums. Merging is mechanically simple but has
-gotchas worth codifying — this skill owns that flow.
 
-The skill lives in `agent-assembly` because the `homebrew-agent-assembly` tap
-repo has no Jira component; the skill is logically owned by the upstream that
-publishes to it.
+After each `agent-assembly` release, `release.yml`'s `update-homebrew-tap` job
+opens a `bot/aasm-<version>` PR on `ai-agent-assembly/homebrew-agent-assembly`
+that bumps `Formula/aasm.rb` (version line + 4 SHA256 sums). This skill owns the
+verify-and-merge flow for that PR so `brew install aasm` picks up the release.
+
+The skill lives in `agent-assembly` because the tap repo has no Jira component;
+it is logically owned by the upstream that publishes to it.
 
 ## When to use
 
-Invoke this skill when `agent-assembly`'s `release.yml` has finished its
-`update-homebrew-tap` job and a `bot/aasm-<version>` PR is now open on
-`ai-agent-assembly/homebrew-agent-assembly`, and the operator (or
-`release-watch`) wants to verify the bot diff and merge it so `brew install
-aasm` picks up the new release.
+Invoke when `release.yml`'s `update-homebrew-tap` job has finished and a
+`bot/aasm-<version>` PR is open on `ai-agent-assembly/homebrew-agent-assembly`,
+and the operator (or `release-watch`) wants to verify the bot diff and merge it.
 
 ## When NOT to use
 
-- **Tap PR not yet open** — `release.yml` hasn't finished `update-homebrew-tap`
-  yet. Wait for the upstream release workflow rather than opening a manual PR.
+- **Tap PR not yet open** — wait for `release.yml`; do not hand-open a PR.
 - **Tap PR has manual edits beyond the bot's diff** — anything outside the
-  version line + 4 sha256 lines is out of scope for this skill. Escalate; do
-  not auto-merge a hand-edited formula.
-- **AAASM-2871 (Homebrew/brew#22719) is patched upstream** — if the tap's
-  `brew install + test` workflow no longer needs `HOMEBREW_NO_REQUIRE_TAP_TRUST=1`,
-  the stale-master rebase shortcut may no longer be required; re-evaluate the
-  step 3 branch before relying on this skill verbatim.
-
-## Type
-Command-like. Invoked manually after a release tag is pushed, or by
-`release-watch` / `/release-preparation` when the Homebrew channel is still
-red in `scripts/check-release.sh` output.
-
-## Pre-conditions
-- Bot PR number provided (resolve via
-  `gh pr list --repo ai-agent-assembly/homebrew-agent-assembly --state open`).
-- Upstream `agent-assembly` release for the same tag is published.
-- `SHA256SUMS` asset exists on the upstream release.
+  version line + 4 sha256 lines is out of scope. Escalate; do not auto-merge a
+  hand-edited formula.
+- **AAASM-2871 (Homebrew/brew#22719) is patched upstream** — if the tap's `brew
+  install + test` workflow no longer needs `HOMEBREW_NO_REQUIRE_TAP_TRUST=1`,
+  the step-3 rebase shortcut may no longer be required; re-evaluate.
 
 ## How to use
-
-Invoke from a shell or via the slash command:
 
 ```text
 /homebrew-tap-merge <PR_NUMBER>
 ```
 
-Example: `/homebrew-tap-merge 16` — verify + merge tap PR #16 for
-`aasm 0.0.1-alpha.9`.
-
-**Required inputs**:
-
-- `<PR_NUMBER>` — the bot PR number on
-  `ai-agent-assembly/homebrew-agent-assembly`. Resolve with
-  `gh pr list --repo ai-agent-assembly/homebrew-agent-assembly --state open`.
-- Upstream `agent-assembly` release for the matching tag must already be
-  published with the `SHA256SUMS` asset attached (the helper script
-  `scripts/verify-tap-sha256.sh` downloads this).
-
-## Do Not Assume
-- Do not assume the 4 sha256 lines in `Formula/aasm.rb` are correct — verify
-  every one against the upstream `SHA256SUMS` asset.
-- Do not assume a red `brew install + test (macOS)` check is a real failure
-  — check if the PR is on a stale master first (see step 3 below).
-- Do not assume Homebrew/brew#22719 has shipped — the AAASM-2871 quirk is
-  still live as of this skill's authoring.
+Example: `/homebrew-tap-merge 16`. Resolve the PR number with
+`gh pr list --repo ai-agent-assembly/homebrew-agent-assembly --state open`. The
+matching upstream `agent-assembly` release must already be published with its
+`SHA256SUMS` asset attached.
 
 ## Executable plan
 
@@ -85,43 +51,30 @@ gh pr view <n> --repo ai-agent-assembly/homebrew-agent-assembly \
   --json files,additions,deletions
 ```
 
-Expected: single file `Formula/aasm.rb`, ~5 additions and ~5 deletions
-(version line + 4 sha256 lines). Reject anything broader as out-of-scope.
+Expected: single file `Formula/aasm.rb`, ~5 additions and ~5 deletions. Reject
+anything broader as out-of-scope.
 
 ### 2. Cross-verify all 4 sha256 lines vs upstream
 
-Run the helper:
-
 ```bash
-./scripts/verify-tap-sha256.sh <tag> [<pr>]
-# e.g. ./scripts/verify-tap-sha256.sh v0.0.1-alpha.9 16
+.claude/skills/homebrew-tap-merge/scripts/verify-tap-sha256.sh <tag> [<pr>]
+# e.g. .claude/skills/homebrew-tap-merge/scripts/verify-tap-sha256.sh v0.0.1-alpha.9 16
 ```
 
-Exits 0 iff all 4 sha256s in the formula match the upstream `SHA256SUMS`
-asset (one per platform — `aarch64-apple-darwin`, `x86_64-apple-darwin`,
-`aarch64-unknown-linux-gnu`, `x86_64-unknown-linux-gnu`). Non-zero exit
-prints a mismatch table — **escalate; do not merge**.
-
-For ad-hoc inspection, the equivalent manual flow is:
-
-```bash
-gh release download <tag> -A SHA256SUMS \
-  --repo ai-agent-assembly/agent-assembly --dir /tmp/aasm-<tag>
-gh pr diff <n> --repo ai-agent-assembly/homebrew-agent-assembly
-```
+Exits 0 iff all 4 sha256s match the upstream `SHA256SUMS` asset (one per
+platform: `aarch64-apple-darwin`, `x86_64-apple-darwin`,
+`aarch64-unknown-linux-gnu`, `x86_64-unknown-linux-gnu`). Non-zero exit prints a
+mismatch table — **escalate; do not merge**.
 
 ### 3. Handle red `brew install + test (macOS)` check
-
-Check whether the PR is on stale master:
 
 ```bash
 gh pr view <n> --repo ai-agent-assembly/homebrew-agent-assembly \
   --json baseRefOid,mergeable,mergeStateStatus
 ```
 
-- **If `mergeStateStatus` is `BEHIND` or the base SHA is older than master's tip**
-  — trigger a server-side rebase (avoids local force-push, works through the
-  classifier):
+- If `mergeStateStatus` is `BEHIND` (stale master), trigger a **server-side**
+  rebase (no local force-push):
 
   ```bash
   gh api -X PUT \
@@ -129,19 +82,10 @@ gh pr view <n> --repo ai-agent-assembly/homebrew-agent-assembly \
     -f update_method=rebase
   ```
 
-  The endpoint takes an optional `expected_head_sha` for safety. Wait for CI
-  to re-run, then re-evaluate.
+  Wait for CI to re-run, then re-evaluate. See the AAASM-2871 note below.
 
-- **If the PR is up to date** — surface the failure log:
-
-  ```bash
-  gh run view --repo ai-agent-assembly/homebrew-agent-assembly \
-    --job <id> --log-failed
-  ```
-
-  Look for the AAASM-2871 fingerprint: `sandbox-exec` exits with status 1
-  silently inside the `brew install + test` step. See memory entry
-  `project_homebrew_tap_sandbox_kills_install` for full context.
+- If the PR is up to date, surface the failure log with
+  `gh run view --repo ai-agent-assembly/homebrew-agent-assembly --job <id> --log-failed`.
 
 ### 4. Merge
 
@@ -151,153 +95,36 @@ Once CI is green and sha256s are verified:
 gh pr merge <n> --repo ai-agent-assembly/homebrew-agent-assembly --squash
 ```
 
-Use the tap's configured strategy (squash, per `docs/release/RUNBOOK.md`).
-
-## Worked example — alpha-9 (2026-06-14)
-
-PR [#16](https://github.com/ai-agent-assembly/homebrew-agent-assembly/pull/16)
-on `ai-agent-assembly/homebrew-agent-assembly`, titled `🤖 (formula): aasm
-0.0.1-alpha.9`, opened by the release-bot at 2026-06-13 18:09 UTC after the
-upstream `v0.0.1-alpha.9` tag push triggered `release.yml`'s
-`update-homebrew-tap` job.
-
-**Initial state**: `brew install + test (macOS)` check RED with the
-AAASM-2871 silent `sandbox-exec` SIGKILL fingerprint (PR was based on a
-pre-`HOMEBREW_NO_REQUIRE_TAP_TRUST=1` master tip).
-
-**Step 1 — Scope check**:
-
-```bash
-gh pr view 16 --repo ai-agent-assembly/homebrew-agent-assembly \
-  --json files,additions,deletions
-# → single file Formula/aasm.rb, ~5 additions, ~5 deletions  ✓
-```
-
-**Step 2 — Cross-verify 4 sha256s**:
-
-```bash
-./scripts/verify-tap-sha256.sh v0.0.1-alpha.9 16
-# OK: all 4 sha256 entries match upstream SHA256SUMS for v0.0.1-alpha.9.
-```
-
-The four sha256 values pinned in the PR diff (also present in upstream
-`SHA256SUMS`):
-
-| Platform                       | sha256 (alpha-9)                                                   |
-|--------------------------------|--------------------------------------------------------------------|
-| `aarch64-apple-darwin`         | `1e08c94b…` (darwin-arm)                                           |
-| `x86_64-apple-darwin`          | `047e0cb5…` (darwin-intel)                                         |
-| `aarch64-unknown-linux-gnu`    | `95b7f7ca…` (linux-arm)                                            |
-| `x86_64-unknown-linux-gnu`     | `311be632…` (linux-x64)                                            |
-
-**Step 3 — Detect stale-master + server-side rebase**:
-
-```bash
-gh pr view 16 --repo ai-agent-assembly/homebrew-agent-assembly \
-  --json mergeStateStatus
-# → "BEHIND"
-
-gh api -X PUT \
-  /repos/ai-agent-assembly/homebrew-agent-assembly/pulls/16/update-branch \
-  -f update_method=rebase
-```
-
-This pulls in the `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` env applied to the tap's
-`brew install + test` workflow on master, so the CI re-run no longer trips
-the AAASM-2871 sandbox quirk.
-
-**Step 4 — Wait for CI re-run + merge**:
-
-```bash
-# brew install + test (macOS) goes green; the success log contains:
-#   Pouring … Cellar/aasm/0.0.1-alpha.9: 3 files, 21.5MB, built in 1 second
-
-gh pr merge 16 --repo ai-agent-assembly/homebrew-agent-assembly --squash
-```
-
-Verifies the AAASM-2871 workaround is active in workflow env, then squashes
-in the formula bump.
-
-## Post-conditions
-- Tap `master` branch's `Formula/aasm.rb` has the new version + 4 sha256s.
-- `brew install aasm` (on a fresh `brew update`) now resolves to the new
-  version. Until the merge happens, `brew install aasm` still resolves to
-  the previous version — the bot branch is invisible to `brew install`.
-- Suggest follow-up: invoke `/release-validate-channels` (or re-run
-  `scripts/check-release.sh v<version>`) to confirm the Homebrew row goes
-  green.
-
-## What's expected when done
-
-When this skill completes successfully, all of the following must hold:
-
-- Tap `master`'s `Formula/aasm.rb` shows the new `version "<X>"` line and
-  the 4 sha256s that match upstream `SHA256SUMS` for the corresponding tag.
-- The bot PR is **closed and merged** (squash), not just approved.
-- The operator can immediately follow up with
-  `/release-validate-channels v<X>` and see the Homebrew row report ✓.
-
-Quick verification command from any shell with `gh` configured:
-
-```bash
-gh api /repos/ai-agent-assembly/homebrew-agent-assembly/contents/Formula/aasm.rb \
-  -H "Accept: application/vnd.github.raw" | grep -E "^  version |^      sha256"
-```
-
-The output should print one `version "<X>"` line and four `sha256 "<hash>"`
-lines matching the upstream release.
-
-## What's auto-handled (do NOT manually run)
-
-These steps are owned by the release pipeline or are explicitly forbidden
-inside this skill — do not attempt them manually:
-
-- **Opening the bot PR** — handled by `release.yml`'s `update-homebrew-tap`
-  job, triggered on every `agent-assembly` tag push. Wait for it; do not
-  hand-open a tap PR.
-- **Editing `Formula/aasm.rb` by hand** — never. Any manual edit will be
-  undone by the next bot rebase, and a mismatched sha256 indicates a real
-  release-artifact problem upstream (escalate, do not "fix" the formula).
-- **`brew update-bottles` / `brew bottle …`** — not part of this tap's
-  lifecycle. The tap installs from binary tarballs (no bottle DSL); there
-  is nothing to bottle here.
-- **Local `git push --force` to the bot branch** — use the server-side
-  `gh api … /pulls/<n>/update-branch -f update_method=rebase` pattern from
-  step 3. The classifier blocks local force-push to active PRs without
-  explicit auth, and a force-push would also break the bot's audit trail.
-
 ## AAASM-2871 quirk (live until Homebrew/brew#22719 ships)
 
-The `brew install + test (macOS)` check requires
-`HOMEBREW_NO_REQUIRE_TAP_TRUST=1` in the workflow env. If a bot PR pre-dates
-this fix being applied to the tap's CI workflow, it needs a rebase against
-master first (step 3 above). Once Homebrew/brew#22719 ships and the workaround
-is removed, this requirement can be dropped from this skill.
+The tap's `brew install + test (macOS)` check needs
+`HOMEBREW_NO_REQUIRE_TAP_TRUST=1` in the workflow env. A bot PR on stale master
+predates that fix and fails with a silent `sandbox-exec` SIGKILL — the step-3
+server-side rebase pulls in the env and clears it. Limit to one rebase attempt
+before escalating. Background: memory entry
+`project_homebrew_tap_sandbox_kills_install`.
 
-## Output
+## Do NOT (auto-handled or forbidden)
 
-Report the merge with:
+- **Opening the bot PR** — owned by `release.yml`'s `update-homebrew-tap` job.
+- **Editing `Formula/aasm.rb` by hand** — never. A mismatched sha256 means a
+  real upstream release-artifact problem; escalate, do not "fix" the formula.
+- **Local `git push --force` to the bot branch** — use the server-side
+  `update-branch` API (step 3); force-push breaks the bot's audit trail.
+- **Merging past a red `brew install + test` check** — users hit the same
+  failure on `brew install`.
 
-```
-### Homebrew tap merge
-- PR #<n> — verified 4 sha256s vs upstream SHA256SUMS — merged via squash
-- Follow-up: re-run scripts/check-release.sh v<version> to confirm Homebrew row
-```
+## Post-conditions
 
-## Safe-Fix Guidance
-- Do not edit `Formula/aasm.rb` by hand to "fix" a mismatched sha256 — the
-  upstream release artifact is the source of truth; if hashes don't match,
-  the release tarball or the bot is broken, not the formula. Escalate.
-- Do not bypass a red `brew install + test (macOS)` check by merging anyway
-  — Homebrew users will hit the same failure on `brew install`.
-- Do not local-rebase + force-push the bot branch; use the server-side
-  `update-branch` API call to keep the audit trail clean.
-- Limit to one rebase attempt before escalating — repeated failures indicate
-  a real formula or release-artifact problem.
+- Tap `master`'s `Formula/aasm.rb` has the new version + 4 verified sha256s.
+- The bot PR is **closed and merged** (squash), not just approved.
+- Follow up with `/release-validate-channels v<version>` (or re-run
+  `scripts/check-release.sh v<version>`) and confirm the Homebrew row goes green.
 
-## Cross-links
-- `docs/release/RUNBOOK.md` § "Manual gate — merge the Homebrew tap PR"
-- `.github/workflows/release.yml` § `update-homebrew-tap` job (the producer
-  of these PRs)
-- Memory entry `project_homebrew_tap_sandbox_kills_install` (AAASM-2871
-  background)
+## Detailed references
+
+- [EXAMPLES.md](EXAMPLES.md) — full worked alpha-9 walk-through of all 4 steps,
+  including the stale-master rebase path and the verified sha256 table.
+- `scripts/verify-tap-sha256.sh` — the step-2 cross-verification helper.
+- `docs/release/RUNBOOK.md` § "Manual gate — merge the Homebrew tap PR".
+- `.github/workflows/release.yml` § `update-homebrew-tap` job (PR producer).

--- a/.claude/skills/homebrew-tap-merge/scripts/verify-tap-sha256.sh
+++ b/.claude/skills/homebrew-tap-merge/scripts/verify-tap-sha256.sh
@@ -5,7 +5,7 @@
 # AAASM-2888 — extracted from .claude/skills/homebrew-tap-merge/SKILL.md step 2.
 #
 # Usage:
-#   scripts/verify-tap-sha256.sh <tag> [<pr>]
+#   .claude/skills/homebrew-tap-merge/scripts/verify-tap-sha256.sh <tag> [<pr>]
 #
 #   <tag>  Upstream agent-assembly tag (e.g. v0.0.1-alpha.9).
 #   <pr>   Optional tap PR number. If given, the formula content is fetched

--- a/scripts/verify-tap-sha256.sh
+++ b/scripts/verify-tap-sha256.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Cross-verify the 4 sha256 lines in homebrew-agent-assembly's Formula/aasm.rb
+# against the upstream agent-assembly release's SHA256SUMS asset.
+#
+# AAASM-2888 — extracted from .claude/skills/homebrew-tap-merge/SKILL.md step 2.
+#
+# Usage:
+#   scripts/verify-tap-sha256.sh <tag> [<pr>]
+#
+#   <tag>  Upstream agent-assembly tag (e.g. v0.0.1-alpha.9).
+#   <pr>   Optional tap PR number. If given, the formula content is fetched
+#          from the PR head; otherwise from tap master.
+#
+# Exits 0 iff all 4 sha256s match. Non-zero on mismatch or fetch failure,
+# printing a table of (platform, formula sha256, release sha256, match).
+
+set -uo pipefail
+
+UPSTREAM_REPO="ai-agent-assembly/agent-assembly"
+TAP_REPO="ai-agent-assembly/homebrew-agent-assembly"
+
+if [ $# -lt 1 ] || [ $# -gt 2 ]; then
+  echo "Usage: $0 <tag> [<pr>]" >&2
+  echo "  e.g. $0 v0.0.1-alpha.9 16" >&2
+  exit 2
+fi
+
+TAG="$1"
+PR="${2:-}"
+
+WORK_DIR="$(mktemp -d -t aasm-tap-sha256-XXXXXX)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# ─── 1. Fetch upstream SHA256SUMS ─────────────────────────────────────────
+if ! gh release download "$TAG" -A SHA256SUMS \
+    --repo "$UPSTREAM_REPO" --dir "$WORK_DIR" >/dev/null 2>&1; then
+  echo "ERROR: could not download SHA256SUMS for $TAG from $UPSTREAM_REPO" >&2
+  exit 1
+fi
+
+SHA_FILE="$WORK_DIR/SHA256SUMS"
+if [ ! -s "$SHA_FILE" ]; then
+  echo "ERROR: SHA256SUMS asset empty or missing for $TAG" >&2
+  exit 1
+fi
+
+# ─── 2. Fetch Formula/aasm.rb ─────────────────────────────────────────────
+FORMULA_FILE="$WORK_DIR/aasm.rb"
+if [ -n "$PR" ]; then
+  HEAD_REF="$(gh pr view "$PR" --repo "$TAP_REPO" --json headRefOid \
+    -q .headRefOid 2>/dev/null || true)"
+  if [ -z "$HEAD_REF" ]; then
+    echo "ERROR: could not resolve head SHA of PR #$PR on $TAP_REPO" >&2
+    exit 1
+  fi
+  if ! gh api "/repos/$TAP_REPO/contents/Formula/aasm.rb?ref=$HEAD_REF" \
+      -H "Accept: application/vnd.github.raw" >"$FORMULA_FILE" 2>/dev/null; then
+    echo "ERROR: could not fetch Formula/aasm.rb at PR #$PR head" >&2
+    exit 1
+  fi
+else
+  if ! gh api "/repos/$TAP_REPO/contents/Formula/aasm.rb" \
+      -H "Accept: application/vnd.github.raw" >"$FORMULA_FILE" 2>/dev/null; then
+    echo "ERROR: could not fetch Formula/aasm.rb from $TAP_REPO master" >&2
+    exit 1
+  fi
+fi
+
+# ─── 3. Pair platforms to (formula sha, release sha) ──────────────────────
+# Map: formula platform identifier (substring) → release asset filename.
+PLATFORMS=(
+  "aarch64-apple-darwin|aasm-${TAG}-aarch64-apple-darwin.tar.gz"
+  "x86_64-apple-darwin|aasm-${TAG}-x86_64-apple-darwin.tar.gz"
+  "aarch64-unknown-linux-gnu|aasm-${TAG}-aarch64-unknown-linux-gnu.tar.gz"
+  "x86_64-unknown-linux-gnu|aasm-${TAG}-x86_64-unknown-linux-gnu.tar.gz"
+)
+
+# Extract: every `sha256 "<hash>"` line in formula, in order.
+mapfile -t FORMULA_SHAS < <(grep -Eo 'sha256[[:space:]]+"[0-9a-f]{64}"' "$FORMULA_FILE" \
+  | grep -Eo '[0-9a-f]{64}')
+
+if [ "${#FORMULA_SHAS[@]}" -ne 4 ]; then
+  echo "ERROR: expected 4 sha256 entries in Formula/aasm.rb, found ${#FORMULA_SHAS[@]}" >&2
+  exit 1
+fi
+
+mismatches=0
+rows=()
+rows+=("PLATFORM|FORMULA|RELEASE|MATCH")
+i=0
+for entry in "${PLATFORMS[@]}"; do
+  platform="${entry%%|*}"
+  asset="${entry##*|}"
+  fsh="${FORMULA_SHAS[$i]}"
+  rsh="$(awk -v a="$asset" '$2 == a {print $1}' "$SHA_FILE")"
+  if [ -z "$rsh" ]; then
+    # try basename match if SHA256SUMS uses ./asset prefix
+    rsh="$(awk -v a="./$asset" '$2 == a {print $1}' "$SHA_FILE")"
+  fi
+  if [ -z "$rsh" ]; then
+    rows+=("$platform|$fsh|<missing>|✗")
+    mismatches=$((mismatches + 1))
+  elif [ "$fsh" = "$rsh" ]; then
+    rows+=("$platform|$fsh|$rsh|✓")
+  else
+    rows+=("$platform|$fsh|$rsh|✗")
+    mismatches=$((mismatches + 1))
+  fi
+  i=$((i + 1))
+done
+
+# ─── 4. Report ────────────────────────────────────────────────────────────
+printf '%s\n' "${rows[@]}" | column -t -s '|'
+
+if [ "$mismatches" -gt 0 ]; then
+  echo
+  echo "FAIL: $mismatches of 4 sha256 entries do not match upstream SHA256SUMS." >&2
+  exit 1
+fi
+
+echo
+echo "OK: all 4 sha256 entries match upstream SHA256SUMS for $TAG."
+exit 0


### PR DESCRIPTION
## Description

Restructure the `homebrew-tap-merge` skill to the Anthropic Agent Skills spec (progressive disclosure). No behavioural change to the documented flow — this is a documentation/layout refactor of the skill itself.

- **Level 1 (frontmatter)**: rewrote `description` to state *what* + *when* in the third person (354 chars, ≤ 1024) so the skill is discoverable by the dispatcher (names the `bot/aasm-<version>` PR, sha256 cross-verification, stale-master rebase, and the AAASM-2871 macOS-CI tap-trust workaround).
- **Level 2 (SKILL.md)**: slimmed from 303 → 130 lines (< 200 target). Lean overview keeps Purpose, When to use / NOT, How to use, a concise 4-step plan, a brief AAASM-2871 note, a consolidated "Do NOT" callout, Post-conditions, and a `## Detailed references` section linking one level deep.
- **Level 3 (bundled resources)**:
  - `EXAMPLES.md` — the full worked alpha-9 walk-through moved out of SKILL.md (with a `## Contents` TOC, one-level-deep links).
  - `scripts/verify-tap-sha256.sh` — `git mv`d from repo-root `scripts/` into the skill dir, executable bit preserved.

## Type of Change

- [x] 📝 Documentation update
- [x] ♻️ Refactoring

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2888

## Testing

- [x] No tests required (explain why)

Documentation/skill-layout-only change. Validated: `wc -l SKILL.md` = 130 (< 200); bundled `scripts/verify-tap-sha256.sh` exists and is executable; repo-root copy removed; `EXAMPLES.md` present with no content lost; links are one level deep; frontmatter `description` = 354 chars (≤ 1024).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention