### PR TITLE
[AAASM-2900] 🐛 (release-readiness): Gate the SDK bot-token secrets in check 8

### DIFF
--- a/docs/release/RUNBOOK.md
+++ b/docs/release/RUNBOOK.md
@@ -184,8 +184,9 @@ the credential rotates. Not part of the per-release loop.
   publish fails with "OTP required".
 - **PAT rotation.** `CRATES_IO_TOKEN`, `CROSS_REPO_DISPATCH_PAT`,
   `HOMEBREW_TAP_TOKEN` expire on the cadence configured at the GitHub /
-  crates.io side. `release-readiness.sh` check 8 verifies all three exist
-  in the repo; it does not verify they're still valid.
+  crates.io side. `release-readiness.sh` check 8 verifies all five required
+  secrets exist (these three plus the two SDK FFI-pin bot tokens below);
+  it does not verify they're still valid.
 - **SDK FFI-pin bot tokens.** `NODE_SDK_BOT_TOKEN` and `PYTHON_SDK_BOT_TOKEN`
   are required by the `update-node-sdk-ffi-pin` / `update-python-sdk-ffi-pin`
   jobs (section 3) to open the source-pin bump PRs. Without them the jobs fail

--- a/scripts/release-readiness.sh
+++ b/scripts/release-readiness.sh
@@ -96,7 +96,8 @@ fi
 
 # 8. Required secrets present in this repo
 SECRETS="$(gh secret list --repo ai-agent-assembly/agent-assembly 2>/dev/null | awk '{print $1}')"
-for SECRET in CRATES_IO_TOKEN CROSS_REPO_DISPATCH_PAT HOMEBREW_TAP_TOKEN; do
+for SECRET in CRATES_IO_TOKEN CROSS_REPO_DISPATCH_PAT HOMEBREW_TAP_TOKEN \
+              NODE_SDK_BOT_TOKEN PYTHON_SDK_BOT_TOKEN; do
   if printf '%s\n' "$SECRETS" | grep -qx "$SECRET"; then
     pass "Secret $SECRET present"
   else


### PR DESCRIPTION
## Description

`scripts/release-readiness.sh` **check 8** ("Required secrets present") only verified `CRATES_IO_TOKEN`, `CROSS_REPO_DISPATCH_PAT`, `HOMEBREW_TAP_TOKEN` — **not** the two bot tokens added by AAASM-2883 (`NODE_SDK_BOT_TOKEN`, `PYTHON_SDK_BOT_TOKEN`) that the `update-node-sdk-ffi-pin` / `update-python-sdk-ffi-pin` jobs need to open the source-pin bump PRs.

**Impact:** the readiness pre-flight gave a *false green* when the bot tokens were missing — an operator could pass the gate, cut a tag, and have the FFI-pin auto-bump jobs fail silently with `peter-evans/create-pull-request` "no token".

**Fix (2 commits):**
1. `scripts/release-readiness.sh` — add the two tokens to check 8's secret list. The existing pass/fail loop already prints the correct `gh secret set <name> …` remediation per missing secret, so no other change is needed.
2. `docs/release/RUNBOOK.md` §8 — correct the wording "check 8 verifies all three exist" → "all five required secrets (these three plus the two SDK FFI-pin bot tokens below)".

**Verification:** ran the updated check-8 loop against the live repo secrets — all 5 report present (the two bot tokens were configured by the owner under AAASM-2898 at 2026-06-14 07:07 UTC). `bash -n` clean.

## Type of Change

- [x] 🐛 Bug fix
- [x] 📝 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Pre-flight check only; adds two assertions to an existing loop. No runtime/API/build behavior changes.

## Related Issues

- Related Jira ticket: AAASM-2900 (parent Story AAASM-2894 — SDK pin-bump automation rollout)
- Context: AAASM-2880 / AAASM-2883 (the FFI-pin auto-bump jobs + secrets these gate)

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [x] No tests required (pre-flight script assertion; exercised manually against live secrets)

Manual verification:
- `bash -n scripts/release-readiness.sh` → clean.
- Ran the exact check-8 loop against `gh secret list` for `ai-agent-assembly/agent-assembly` → all 5 secrets (`CRATES_IO_TOKEN`, `CROSS_REPO_DISPATCH_PAT`, `HOMEBREW_TAP_TOKEN`, `NODE_SDK_BOT_TOKEN`, `PYTHON_SDK_BOT_TOKEN`) report present.

## Checklist

- [x] Two atomic GitEmoji commits (script fix + doc wording)
- [x] Branch base: `master` (against `remote`)
- [x] Diff scoped to `scripts/release-readiness.sh` + `docs/release/RUNBOOK.md`