### PR TITLE
[AAASM-2938] 📝 (docs): Add brief Examples pointer with per-SDK reference links

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -48,6 +48,7 @@
   - [Team budgets and cost](usage-guide/team-budgets.md)
   - [Observe in the dashboard](usage-guide/observe-in-dashboard.md)
   - [Choosing interception layers](usage-guide/interception-layers.md)
+  - [Runnable examples](usage-guide/examples.md)
   - [Troubleshooting](usage-guide/troubleshooting.md)
 
 # Security Model

--- a/docs/src/usage-guide/examples.md
+++ b/docs/src/usage-guide/examples.md
@@ -1,0 +1,18 @@
+# Runnable examples
+
+The pages in this guide explain *how* governance works. When you want to **run**
+it, the framework-specific, end-to-end examples live in the dedicated
+[`agent-assembly-examples`](https://github.com/ai-agent-assembly/agent-assembly-examples)
+repository rather than in this book — that keeps the runnable code versioned and
+testable on its own, while these pages stay focused on the concepts.
+
+Every example is governed by the same three-layer interception model described
+in [Choosing interception layers](interception-layers.md): a gateway as the
+brain, at least one interception layer (SDK shim, `aa-proxy` sidecar, or eBPF),
+and a policy. Pick the language you are integrating, or browse the cross-cutting
+scenarios:
+
+- **Node** — [examples-repo/node](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/node)
+- **Python** — [examples-repo/python](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/python)
+- **Go** — [examples-repo/go](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/go)
+- **Scenarios** (cross-cutting: approval-gates, audit-trace, budget-limits, policy-enforcement, sidecar-runtime) — [examples-repo/scenarios](https://github.com/ai-agent-assembly/agent-assembly-examples/tree/master/scenarios)


### PR DESCRIPTION
## Description

Adds a brief Examples pointer page to the core mdBook docs. The usage guide
previously only had conceptual pages and never pointed readers to the runnable,
framework-specific examples that live in the dedicated `agent-assembly-examples`
repository. The new page (`docs/src/usage-guide/examples.md`) is a short blurb
plus a per-language reference link list (Node, Python, Go) and a cross-cutting
Scenarios link, and is wired into `docs/src/SUMMARY.md` under the Usage Guide
section. It deliberately stays a pointer — full per-example walkthroughs remain
in each SDK's docs and the examples repo.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

Does this PR introduce any breaking changes to public APIs or behaviour?

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-2938
- Related GitHub issues: N/A

Closes AAASM-2938

## Testing

Describe the testing performed for this PR:

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [x] No tests required (explain why)

Docs-only change. Verified the new page is listed in `SUMMARY.md` (mdBook only
renders pages referenced there) and that all Markdown links are well-formed.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention