### PR TITLE
[AAASM-2959] 🐛 (release): Sync Cargo.lock when bumping SDK FFI pins

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -544,6 +544,21 @@ jobs:
           done
           git -C . diff -- native/aa-ffi-python/Cargo.toml || true
 
+      - name: Regenerate native/aa-ffi-python/Cargo.lock for the new pins
+        shell: bash
+        env:
+          NEW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          cd sdk
+          # AAASM-2959: re-resolve the lock so it matches the just-rewritten
+          # Cargo.toml revs. python pins all three shared crates, so update all
+          # three to NEW_SHA together. This only re-resolves the lock (no
+          # compile), so cargo alone suffices.
+          cargo update --manifest-path native/aa-ffi-python/Cargo.toml \
+            -p aa-core -p aa-proto -p aa-sdk-client --precise "${NEW_SHA}"
+          git -C . diff -- native/aa-ffi-python/Cargo.lock || true
+
       - name: Open SDK pin-bump PR via peter-evans/create-pull-request
         uses: peter-evans/create-pull-request@v8
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -462,6 +462,21 @@ jobs:
             || { echo "::error::aa-sdk-client rev rewrite produced unexpected result"; exit 1; }
           git -C . diff -- native/aa-ffi-node/Cargo.toml || true
 
+      - name: Regenerate native/aa-ffi-node/Cargo.lock for the new pin
+        shell: bash
+        env:
+          NEW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          cd sdk
+          # AAASM-2959: re-resolve the lock so it matches the just-rewritten
+          # Cargo.toml rev. node pins only aa-sdk-client; its transitive
+          # aa-core/aa-proto from the same git source update with it. This only
+          # re-resolves the lock (no compile), so cargo alone suffices.
+          cargo update --manifest-path native/aa-ffi-node/Cargo.toml \
+            -p aa-sdk-client --precise "${NEW_SHA}"
+          git -C . diff -- native/aa-ffi-node/Cargo.lock || true
+
       - name: Open SDK pin-bump PR via peter-evans/create-pull-request
         uses: peter-evans/create-pull-request@v8
         with:


### PR DESCRIPTION
## Description

`release.yml` jobs `update-node-sdk-ffi-pin` and `update-python-sdk-ffi-pin` rewrite the `rev = "<sha>"` git-SHA pin(s) in `native/aa-ffi-*/Cargo.toml` on each release and open a bot PR, but never regenerated the sibling `native/aa-ffi-*/Cargo.lock`. The bot PR therefore landed with `Cargo.toml` pointing at the new core commit while `Cargo.lock` still recorded the old one — inconsistent committed state (not build-breaking today only because the SDK builds do not use `--locked`).

This adds a `cargo update` step in each job, after the rev-rewrite step and before the `peter-evans/create-pull-request` step, that re-resolves only the lock (no compile) using the same `NEW_SHA` env var the rewrite already computed:

- node job: `cargo update --manifest-path native/aa-ffi-node/Cargo.toml -p aa-sdk-client --precise "$NEW_SHA"` (node pins only `aa-sdk-client`; transitive `aa-core`/`aa-proto` from the same git source update with it).
- python job: `cargo update --manifest-path native/aa-ffi-python/Cargo.toml -p aa-core -p aa-proto -p aa-sdk-client --precise "$NEW_SHA"` (python pins all three).

`peter-evans/create-pull-request` has no `add-paths` restriction in either job, so the regenerated `Cargo.lock` is auto-committed into the bot PR alongside the manifest — no path config change needed.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2959
- Refs AAASM-2959

## Testing

- [x] No tests required (explain why)

`cargo update` only re-resolves the lock and needs no special toolchain. The workflow change was validated with `actionlint .github/workflows/release.yml` (no new findings; the only warning is a pre-existing SC2046 at line 97, outside this diff) and a YAML parse. The rewrite logic, PR title/body, and other jobs are untouched.

## Checklist

- [x] Self-review of the diff completed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
