### PR TITLE
[AAASM-421] ✨ (aa-cli): aasm docs export — CLI reference auto-generation

### DIFF
--- a/.github/workflows/cli-reference.yml
+++ b/.github/workflows/cli-reference.yml
@@ -1,0 +1,59 @@
+name: CLI Reference
+
+# AAASM-421: the `docs/cli/` reference is auto-generated from the live `clap`
+# command tree by `aasm docs export`. This job runs `aasm docs export --check`
+# on every PR so a change to a `clap` definition that forgets to regenerate the
+# committed reference fails the build instead of silently drifting.
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - "aa-cli/**"
+      - "docs/cli/**"
+      - ".github/workflows/cli-reference.yml"
+  push:
+    branches: [master]
+    paths:
+      - "aa-cli/**"
+      - "docs/cli/**"
+      - ".github/workflows/cli-reference.yml"
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  check:
+    name: Verify docs/cli is up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install system dependencies (protoc, pkg-config, libssl-dev)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler pkg-config libssl-dev
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build aasm
+        run: cargo build -p aa-cli
+
+      - name: Verify CLI reference is current
+        # Non-zero exit (with the list of stale files) when a clap definition
+        # changed but `docs/cli/` was not regenerated. Fix locally with:
+        #   cargo run -p aa-cli -- docs export --format markdown --out docs/cli/
+        run: ./target/debug/aasm docs export --check --out docs/cli/
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/aa-cli/src/commands/docs/export.rs
+++ b/aa-cli/src/commands/docs/export.rs
@@ -1,0 +1,475 @@
+//! `aasm docs export` — auto-generate the CLI reference from the live `clap`
+//! command tree.
+//!
+//! The renderer walks the `clap::Command` returned by [`crate::Cli::command()`]
+//! — never a hand-maintained list — so the emitted Markdown can never drift
+//! from the actual CLI surface. Each command (the root plus every subcommand,
+//! recursively) becomes one Markdown file under the output directory:
+//!
+//! * the root `aasm` command  → `aasm.md`
+//! * `aasm agent`             → `aasm-agent.md`
+//! * `aasm agent create`      → `aasm-agent-create.md`
+//!
+//! Every file carries a stable anchor id derived from the command path
+//! (`#cmd-aasm-agent-create`) so external docs can deep-link to a command and
+//! keep working across regenerations.
+//!
+//! `--check` re-renders into memory and compares against the on-disk tree,
+//! returning a non-zero exit code when they differ. This is what the CI job
+//! runs to keep `docs/cli/` honest.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use clap::builder::StyledStr;
+use clap::{Args, Command, CommandFactory};
+
+/// Arguments for `aasm docs export`.
+#[derive(Args)]
+#[command(after_help = "\
+Examples:
+  aasm docs export
+  aasm docs export --format markdown --out docs/cli/
+  aasm docs export --check")]
+pub struct ExportArgs {
+    /// Output format for the generated reference (only `markdown` today).
+    #[arg(long, value_enum, default_value_t = DocsFormat::Markdown)]
+    pub format: DocsFormat,
+
+    /// Directory to write the generated reference into.
+    #[arg(long, default_value = "docs/cli/")]
+    pub out: PathBuf,
+
+    /// Verify the on-disk reference is up to date instead of writing it.
+    ///
+    /// Re-renders the CLI tree in memory and compares it against the files in
+    /// `--out`. Exits non-zero (and lists the stale paths) when they differ,
+    /// without modifying anything. Used by CI to block PRs that change a
+    /// `clap` definition without regenerating `docs/cli/`.
+    #[arg(long)]
+    pub check: bool,
+}
+
+/// Output format for `aasm docs export`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, clap::ValueEnum)]
+pub enum DocsFormat {
+    /// One Markdown file per command.
+    Markdown,
+}
+
+/// Run `aasm docs export`.
+pub fn run(args: ExportArgs) -> ExitCode {
+    // `format` is currently single-valued; the flag exists so the acceptance
+    // contract (`--format markdown`) is explicit and future formats slot in
+    // here without a breaking CLI change.
+    let DocsFormat::Markdown = args.format;
+
+    let root = crate::Cli::command();
+    let pages = render_all(&root);
+
+    if args.check {
+        check(&args.out, &pages)
+    } else {
+        write(&args.out, &pages)
+    }
+}
+
+/// A single rendered reference page: its on-disk file name and Markdown body.
+struct Page {
+    /// File name relative to the output directory (e.g. `aasm-agent-create.md`).
+    file_name: String,
+    /// Rendered Markdown contents.
+    body: String,
+}
+
+/// Walk the live command tree and render every command to a [`Page`].
+///
+/// Results are keyed and sorted by file name so the output (and any `--check`
+/// diff) is deterministic regardless of `clap`'s subcommand ordering.
+fn render_all(root: &Command) -> Vec<Page> {
+    let mut pages: BTreeMap<String, Page> = BTreeMap::new();
+    walk(root, &[], &mut pages);
+    pages.into_values().collect()
+}
+
+/// Recursively visit `cmd` and each of its subcommands.
+///
+/// `ancestors` is the slice of command names from the root down to (but not
+/// including) `cmd`; the full path is `ancestors + [cmd.get_name()]`.
+fn walk(cmd: &Command, ancestors: &[String], pages: &mut BTreeMap<String, Page>) {
+    let mut path: Vec<String> = ancestors.to_vec();
+    path.push(cmd.get_name().to_string());
+
+    let file_name = format!("{}.md", path.join("-"));
+    let body = render_command(cmd, &path);
+    pages.insert(file_name.clone(), Page { file_name, body });
+
+    for sub in cmd.get_subcommands() {
+        // `clap`'s built-in `help` pseudo-subcommand is not a real command and
+        // would render an empty, confusing page — skip it.
+        if sub.get_name() == "help" {
+            continue;
+        }
+        walk(sub, &path, pages);
+    }
+}
+
+/// Render one command's Markdown page given its full command path.
+fn render_command(cmd: &Command, path: &[String]) -> String {
+    let full = path.join(" ");
+    let anchor = anchor_id(path);
+    let mut out = String::new();
+
+    // Title + stable anchor for durable cross-links.
+    out.push_str(&format!("# `{full}`\n\n"));
+    out.push_str(&format!("<a id=\"{anchor}\"></a>\n\n"));
+
+    // Synopsis — the command's about/long-about text.
+    if let Some(about) = cmd.get_long_about().or_else(|| cmd.get_about()).map(styled_to_string) {
+        let about = about.trim();
+        if !about.is_empty() {
+            out.push_str(&format!("{about}\n\n"));
+        }
+    }
+
+    // Usage — reuse clap's own rendered usage string for accuracy.
+    out.push_str("## Synopsis\n\n");
+    out.push_str("```text\n");
+    out.push_str(render_usage(cmd, path).trim_end());
+    out.push('\n');
+    out.push_str("```\n\n");
+
+    // Options table — every argument the command accepts.
+    let args: Vec<&clap::Arg> = cmd.get_arguments().collect();
+    if !args.is_empty() {
+        out.push_str("## Options\n\n");
+        out.push_str("| Option | Value | Description |\n");
+        out.push_str("|--------|-------|-------------|\n");
+        for arg in &args {
+            out.push_str(&render_arg_row(arg));
+        }
+        out.push('\n');
+    }
+
+    // Subcommands — link to each child page by its stable anchor.
+    let subs: Vec<&Command> = cmd.get_subcommands().filter(|s| s.get_name() != "help").collect();
+    if !subs.is_empty() {
+        out.push_str("## Subcommands\n\n");
+        out.push_str("| Command | Description |\n");
+        out.push_str("|---------|-------------|\n");
+        for sub in &subs {
+            let mut sub_path = path.to_vec();
+            sub_path.push(sub.get_name().to_string());
+            let sub_full = sub_path.join(" ");
+            let sub_file = format!("{}.md", sub_path.join("-"));
+            let sub_anchor = anchor_id(&sub_path);
+            let desc = sub
+                .get_about()
+                .map(styled_to_string)
+                .unwrap_or_default()
+                .replace('\n', " ");
+            out.push_str(&format!(
+                "| [`{sub_full}`]({sub_file}#{sub_anchor}) | {} |\n",
+                escape_cell(&desc)
+            ));
+        }
+        out.push('\n');
+    }
+
+    // Examples — surfaced from `#[command(after_help = …)]`.
+    if let Some(after) = cmd
+        .get_after_long_help()
+        .or_else(|| cmd.get_after_help())
+        .map(styled_to_string)
+    {
+        let after = after.trim();
+        if !after.is_empty() {
+            out.push_str("## Examples\n\n");
+            // after_help conventionally already reads "Examples:\n  <cmd>".
+            // Drop a leading "Examples:" line to avoid a doubled heading, then
+            // render the remainder as a fenced block.
+            let body = after
+                .strip_prefix("Examples:")
+                .unwrap_or(after)
+                .trim_start_matches('\n');
+            out.push_str("```text\n");
+            out.push_str(body.trim_end());
+            out.push('\n');
+            out.push_str("```\n\n");
+        }
+    }
+
+    out
+}
+
+/// Build the stable anchor id for a command path: `cmd-aasm-agent-create`.
+fn anchor_id(path: &[String]) -> String {
+    format!("cmd-{}", path.join("-"))
+}
+
+/// Render one option as a Markdown table row.
+fn render_arg_row(arg: &clap::Arg) -> String {
+    // Flag column: `--long`, `-s`, or a positional `<NAME>`.
+    let flag = if let Some(long) = arg.get_long() {
+        match arg.get_short() {
+            Some(short) => format!("`-{short}`, `--{long}`"),
+            None => format!("`--{long}`"),
+        }
+    } else if let Some(short) = arg.get_short() {
+        format!("`-{short}`")
+    } else {
+        format!("`<{}>`", arg.get_id().as_str().to_uppercase())
+    };
+
+    // Value column: placeholder + enumerated possible values when present.
+    let value = if matches!(
+        arg.get_action(),
+        clap::ArgAction::SetTrue | clap::ArgAction::SetFalse | clap::ArgAction::Help | clap::ArgAction::Version
+    ) {
+        String::new()
+    } else {
+        let placeholder = arg
+            .get_value_names()
+            .map(|names| names.iter().map(|n| format!("`<{n}>`")).collect::<Vec<_>>().join(" "))
+            .unwrap_or_default();
+        let possible: Vec<String> = arg
+            .get_possible_values()
+            .iter()
+            .map(|p| format!("`{}`", p.get_name()))
+            .collect();
+        if possible.is_empty() {
+            placeholder
+        } else if placeholder.is_empty() {
+            possible.join(", ")
+        } else {
+            format!("{placeholder} ({})", possible.join(", "))
+        }
+    };
+
+    // Description column: help text + default value + required marker.
+    let mut desc = arg
+        .get_long_help()
+        .or_else(|| arg.get_help())
+        .map(styled_to_string)
+        .unwrap_or_default()
+        .replace('\n', " ");
+    let defaults: Vec<String> = arg
+        .get_default_values()
+        .iter()
+        .map(|v| v.to_string_lossy().into_owned())
+        .collect();
+    if !defaults.is_empty() {
+        desc.push_str(&format!(" [default: {}]", defaults.join(", ")));
+    }
+    if arg.is_required_set() {
+        desc.push_str(" *(required)*");
+    }
+
+    format!(
+        "| {} | {} | {} |\n",
+        escape_cell(&flag),
+        escape_cell(&value),
+        escape_cell(desc.trim())
+    )
+}
+
+/// Render clap's own usage string for a command, prefixed with the full path.
+fn render_usage(cmd: &Command, path: &[String]) -> String {
+    // `render_usage` yields e.g. "Usage: list [OPTIONS]" using the leaf name;
+    // rewrite the leaf to the full path so the synopsis is copy-pasteable.
+    let usage = styled_to_string(&cmd.clone().render_usage());
+    let leaf = cmd.get_name();
+    let full = path.join(" ");
+    usage.replacen(&format!("Usage: {leaf}"), &format!("Usage: {full}"), 1)
+}
+
+/// Flatten a clap [`StyledStr`] to plain text (ANSI styling stripped).
+fn styled_to_string(s: &StyledStr) -> String {
+    s.to_string()
+}
+
+/// Escape Markdown table-cell-breaking characters.
+fn escape_cell(s: &str) -> String {
+    s.replace('|', "\\|")
+}
+
+/// Write every page to `out_dir`, creating it if necessary.
+fn write(out_dir: &Path, pages: &[Page]) -> ExitCode {
+    if let Err(e) = std::fs::create_dir_all(out_dir) {
+        eprintln!("error: failed to create {}: {e}", out_dir.display());
+        return ExitCode::FAILURE;
+    }
+    for page in pages {
+        let path = out_dir.join(&page.file_name);
+        if let Err(e) = std::fs::write(&path, &page.body) {
+            eprintln!("error: failed to write {}: {e}", path.display());
+            return ExitCode::FAILURE;
+        }
+    }
+    println!("wrote {} CLI reference file(s) to {}", pages.len(), out_dir.display());
+    ExitCode::SUCCESS
+}
+
+/// Compare the on-disk reference against the freshly rendered pages.
+///
+/// Returns [`ExitCode::SUCCESS`] only when every page matches byte-for-byte and
+/// no extra/orphaned files exist in `out_dir`.
+fn check(out_dir: &Path, pages: &[Page]) -> ExitCode {
+    let mut stale: Vec<String> = Vec::new();
+
+    let expected: std::collections::BTreeSet<&str> = pages.iter().map(|p| p.file_name.as_str()).collect();
+
+    for page in pages {
+        let path = out_dir.join(&page.file_name);
+        match std::fs::read_to_string(&path) {
+            Ok(on_disk) if on_disk == page.body => {}
+            Ok(_) => stale.push(format!("{} (out of date)", path.display())),
+            Err(_) => stale.push(format!("{} (missing)", path.display())),
+        }
+    }
+
+    // Catch orphaned files — a command was removed but its page lingers.
+    if let Ok(entries) = std::fs::read_dir(out_dir) {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name.ends_with(".md") && !expected.contains(name.as_ref()) {
+                stale.push(format!("{} (orphaned)", entry.path().display()));
+            }
+        }
+    }
+
+    if stale.is_empty() {
+        println!("CLI reference in {} is up to date", out_dir.display());
+        ExitCode::SUCCESS
+    } else {
+        eprintln!(
+            "error: CLI reference in {} is stale; run `aasm docs export` to regenerate:",
+            out_dir.display()
+        );
+        for s in &stale {
+            eprintln!("  - {s}");
+        }
+        ExitCode::FAILURE
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rendered() -> Vec<Page> {
+        render_all(&crate::Cli::command())
+    }
+
+    #[test]
+    fn renders_a_page_for_the_root_command() {
+        let pages = rendered();
+        assert!(pages.iter().any(|p| p.file_name == "aasm.md"));
+    }
+
+    #[test]
+    fn renders_a_page_per_nested_subcommand() {
+        let pages = rendered();
+        // `aasm agent list` is a known three-level command.
+        assert!(
+            pages.iter().any(|p| p.file_name == "aasm-agent-list.md"),
+            "expected a page for `aasm agent list`"
+        );
+    }
+
+    #[test]
+    fn does_not_emit_a_page_for_clap_help_pseudo_command() {
+        let pages = rendered();
+        assert!(
+            !pages.iter().any(|p| p.file_name.contains("-help.md")),
+            "the built-in `help` subcommand must not get its own page"
+        );
+    }
+
+    #[test]
+    fn anchor_id_is_stable_and_path_derived() {
+        assert_eq!(
+            anchor_id(&["aasm".to_string(), "agent".to_string(), "create".to_string()]),
+            "cmd-aasm-agent-create"
+        );
+    }
+
+    #[test]
+    fn page_contains_its_stable_anchor() {
+        let pages = rendered();
+        let agent = pages
+            .iter()
+            .find(|p| p.file_name == "aasm-agent.md")
+            .expect("agent page");
+        assert!(agent.body.contains("<a id=\"cmd-aasm-agent\"></a>"));
+    }
+
+    #[test]
+    fn page_has_synopsis_and_options_sections() {
+        let pages = rendered();
+        let root = pages.iter().find(|p| p.file_name == "aasm.md").expect("root page");
+        assert!(root.body.contains("## Synopsis"));
+        assert!(root.body.contains("## Options"));
+        assert!(root.body.contains("## Subcommands"));
+    }
+
+    #[test]
+    fn examples_are_surfaced_from_after_help() {
+        let pages = rendered();
+        // `aasm docs export` itself declares an after_help Examples block.
+        let export = pages
+            .iter()
+            .find(|p| p.file_name == "aasm-docs-export.md")
+            .expect("docs export page");
+        assert!(export.body.contains("## Examples"));
+        assert!(export.body.contains("aasm docs export --check"));
+    }
+
+    #[test]
+    fn subcommand_links_use_stable_anchors() {
+        let pages = rendered();
+        let agent = pages
+            .iter()
+            .find(|p| p.file_name == "aasm-agent.md")
+            .expect("agent page");
+        assert!(agent.body.contains("aasm-agent-list.md#cmd-aasm-agent-list"));
+    }
+
+    #[test]
+    fn check_passes_against_freshly_written_pages() {
+        let dir = tempfile::tempdir().unwrap();
+        let pages = rendered();
+        assert_eq!(write(dir.path(), &pages), ExitCode::SUCCESS);
+        assert_eq!(check(dir.path(), &pages), ExitCode::SUCCESS);
+    }
+
+    #[test]
+    fn check_fails_when_a_page_is_modified() {
+        let dir = tempfile::tempdir().unwrap();
+        let pages = rendered();
+        write(dir.path(), &pages);
+        // Corrupt one file to simulate a drifted clap definition.
+        std::fs::write(dir.path().join("aasm.md"), "stale").unwrap();
+        assert_eq!(check(dir.path(), &pages), ExitCode::FAILURE);
+    }
+
+    #[test]
+    fn check_fails_when_a_page_is_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let pages = rendered();
+        write(dir.path(), &pages);
+        std::fs::remove_file(dir.path().join("aasm.md")).unwrap();
+        assert_eq!(check(dir.path(), &pages), ExitCode::FAILURE);
+    }
+
+    #[test]
+    fn check_fails_on_orphaned_page() {
+        let dir = tempfile::tempdir().unwrap();
+        let pages = rendered();
+        write(dir.path(), &pages);
+        std::fs::write(dir.path().join("aasm-ghost.md"), "orphan").unwrap();
+        assert_eq!(check(dir.path(), &pages), ExitCode::FAILURE);
+    }
+}

--- a/aa-cli/src/commands/docs/mod.rs
+++ b/aa-cli/src/commands/docs/mod.rs
@@ -1,0 +1,28 @@
+//! `aasm docs` — generate documentation from the live CLI definition.
+
+use std::process::ExitCode;
+
+use clap::{Args, Subcommand};
+
+pub mod export;
+
+/// Arguments for the `aasm docs` subcommand group.
+#[derive(Args)]
+pub struct DocsArgs {
+    #[command(subcommand)]
+    pub command: DocsCommands,
+}
+
+/// Available `aasm docs` subcommands.
+#[derive(Subcommand)]
+pub enum DocsCommands {
+    /// Export the CLI reference, one Markdown file per command.
+    Export(export::ExportArgs),
+}
+
+/// Dispatch a `docs` subcommand.
+pub fn dispatch(args: DocsArgs) -> ExitCode {
+    match args.command {
+        DocsCommands::Export(export_args) => export::run(export_args),
+    }
+}

--- a/aa-cli/src/commands/mod.rs
+++ b/aa-cli/src/commands/mod.rs
@@ -18,6 +18,7 @@ pub mod config;
 pub mod context;
 pub mod cost;
 pub mod dashboard;
+pub mod docs;
 pub mod gateway;
 pub mod gw_probe;
 pub mod logs;
@@ -60,6 +61,8 @@ pub enum Commands {
     Config(config::ConfigArgs),
     /// Generate shell completion scripts.
     Completion(completion::CompletionArgs),
+    /// Generate documentation from the live CLI definition.
+    Docs(docs::DocsArgs),
     /// Show fleet health, agents, approvals, and budget at a glance.
     Status(status::StatusArgs),
     /// Show CLI and gateway version information.
@@ -106,6 +109,7 @@ pub fn dispatch(cmd: Commands, ctx: &ResolvedContext, output: OutputFormat) -> E
         Commands::Context(args) => context::dispatch(args),
         Commands::Config(args) => config::dispatch(args),
         Commands::Completion(args) => completion::run(args),
+        Commands::Docs(args) => docs::dispatch(args),
         Commands::Status(args) => status::dispatch(args, ctx, output),
         Commands::Version => version::run(ctx, output),
         Commands::Trace(args) => trace::dispatch(args, ctx, output),

--- a/docs/cli/aasm-admin-run-retention.md
+++ b/docs/cli/aasm-admin-run-retention.md
@@ -1,0 +1,18 @@
+# `aasm admin run-retention`
+
+<a id="cmd-aasm-admin-run-retention"></a>
+
+Trigger one manual retention pass against the running gateway
+
+## Synopsis
+
+```text
+Usage: aasm admin run-retention [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--dry-run` |  | Run in dry-run mode — log what would be retained/dropped without taking any action |
+

--- a/docs/cli/aasm-admin.md
+++ b/docs/cli/aasm-admin.md
@@ -1,0 +1,18 @@
+# `aasm admin`
+
+<a id="cmd-aasm-admin"></a>
+
+Gateway administrative operations
+
+## Synopsis
+
+```text
+Usage: aasm admin <COMMAND>
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| [`aasm admin run-retention`](aasm-admin-run-retention.md#cmd-aasm-admin-run-retention) | Trigger one manual retention pass against the running gateway |
+

--- a/docs/cli/aasm-agent-inspect.md
+++ b/docs/cli/aasm-agent-inspect.md
@@ -1,0 +1,18 @@
+# `aasm agent inspect`
+
+<a id="cmd-aasm-agent-inspect"></a>
+
+Show detailed information about a specific agent
+
+## Synopsis
+
+```text
+Usage: aasm agent inspect <AGENT_ID>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<AGENT_ID>` | `<AGENT_ID>` | Hex-encoded agent UUID to inspect *(required)* |
+

--- a/docs/cli/aasm-agent-kill.md
+++ b/docs/cli/aasm-agent-kill.md
@@ -1,0 +1,19 @@
+# `aasm agent kill`
+
+<a id="cmd-aasm-agent-kill"></a>
+
+Deregister and terminate an agent
+
+## Synopsis
+
+```text
+Usage: aasm agent kill [OPTIONS] <AGENT_ID>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<AGENT_ID>` | `<AGENT_ID>` | Hex-encoded agent UUID to kill *(required)* |
+| `--force` |  | Skip the confirmation prompt |
+

--- a/docs/cli/aasm-agent-list.md
+++ b/docs/cli/aasm-agent-list.md
@@ -1,0 +1,20 @@
+# `aasm agent list`
+
+<a id="cmd-aasm-agent-list"></a>
+
+List all registered agents
+
+## Synopsis
+
+```text
+Usage: aasm agent list [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--status` | `<STATUS>` | Filter by agent status (e.g. Active, Suspended, Deregistered) |
+| `--framework` | `<FRAMEWORK>` | Filter by agent framework (e.g. langgraph, crewai) |
+| `--watch` |  | Auto-refresh the table every 2 seconds |
+

--- a/docs/cli/aasm-agent-resume.md
+++ b/docs/cli/aasm-agent-resume.md
@@ -1,0 +1,18 @@
+# `aasm agent resume`
+
+<a id="cmd-aasm-agent-resume"></a>
+
+Resume a suspended agent
+
+## Synopsis
+
+```text
+Usage: aasm agent resume <AGENT_ID>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<AGENT_ID>` | `<AGENT_ID>` | Hex-encoded agent UUID to resume *(required)* |
+

--- a/docs/cli/aasm-agent-suspend.md
+++ b/docs/cli/aasm-agent-suspend.md
@@ -1,0 +1,20 @@
+# `aasm agent suspend`
+
+<a id="cmd-aasm-agent-suspend"></a>
+
+Suspend a running agent
+
+## Synopsis
+
+```text
+Usage: aasm agent suspend [OPTIONS] --reason <REASON> <AGENT_ID>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<AGENT_ID>` | `<AGENT_ID>` | Hex-encoded agent UUID to suspend *(required)* |
+| `--reason` | `<REASON>` | Reason for suspending the agent (logged for audit) *(required)* |
+| `--force` |  | Skip the confirmation prompt |
+

--- a/docs/cli/aasm-agent.md
+++ b/docs/cli/aasm-agent.md
@@ -1,0 +1,22 @@
+# `aasm agent`
+
+<a id="cmd-aasm-agent"></a>
+
+Manage monitored agent processes
+
+## Synopsis
+
+```text
+Usage: aasm agent <COMMAND>
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| [`aasm agent list`](aasm-agent-list.md#cmd-aasm-agent-list) | List all registered agents |
+| [`aasm agent inspect`](aasm-agent-inspect.md#cmd-aasm-agent-inspect) | Show detailed information about a specific agent |
+| [`aasm agent kill`](aasm-agent-kill.md#cmd-aasm-agent-kill) | Deregister and terminate an agent |
+| [`aasm agent suspend`](aasm-agent-suspend.md#cmd-aasm-agent-suspend) | Suspend a running agent |
+| [`aasm agent resume`](aasm-agent-resume.md#cmd-aasm-agent-resume) | Resume a suspended agent |
+

--- a/docs/cli/aasm-alerts-get.md
+++ b/docs/cli/aasm-alerts-get.md
@@ -1,0 +1,18 @@
+# `aasm alerts get`
+
+<a id="cmd-aasm-alerts-get"></a>
+
+Show full detail for a specific alert
+
+## Synopsis
+
+```text
+Usage: aasm alerts get <ALERT_ID>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<ALERT_ID>` | `<ALERT_ID>` | Alert ID to inspect *(required)* |
+

--- a/docs/cli/aasm-alerts-list.md
+++ b/docs/cli/aasm-alerts-list.md
@@ -1,0 +1,20 @@
+# `aasm alerts list`
+
+<a id="cmd-aasm-alerts-list"></a>
+
+List governance alerts
+
+## Synopsis
+
+```text
+Usage: aasm alerts list [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--agent` | `<AGENT>` | Filter by agent ID |
+| `--severity` | `<SEVERITY>` | Filter by severity (critical, warning, info) |
+| `--status` | `<STATUS>` | Filter by status (unresolved, acknowledged, resolved). Default: unresolved [default: unresolved] |
+

--- a/docs/cli/aasm-alerts-resolve.md
+++ b/docs/cli/aasm-alerts-resolve.md
@@ -1,0 +1,20 @@
+# `aasm alerts resolve`
+
+<a id="cmd-aasm-alerts-resolve"></a>
+
+Resolve an alert
+
+## Synopsis
+
+```text
+Usage: aasm alerts resolve [OPTIONS] <ALERT_ID>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<ALERT_ID>` | `<ALERT_ID>` | Alert ID to resolve *(required)* |
+| `--reason` | `<REASON>` | Optional resolution note |
+| `--force` |  | Skip the confirmation prompt |
+

--- a/docs/cli/aasm-alerts.md
+++ b/docs/cli/aasm-alerts.md
@@ -1,0 +1,20 @@
+# `aasm alerts`
+
+<a id="cmd-aasm-alerts"></a>
+
+Manage governance alerts
+
+## Synopsis
+
+```text
+Usage: aasm alerts <COMMAND>
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| [`aasm alerts list`](aasm-alerts-list.md#cmd-aasm-alerts-list) | List governance alerts |
+| [`aasm alerts get`](aasm-alerts-get.md#cmd-aasm-alerts-get) | Show full detail for a specific alert |
+| [`aasm alerts resolve`](aasm-alerts-resolve.md#cmd-aasm-alerts-resolve) | Resolve an alert |
+

--- a/docs/cli/aasm-approvals-approve.md
+++ b/docs/cli/aasm-approvals-approve.md
@@ -1,0 +1,19 @@
+# `aasm approvals approve`
+
+<a id="cmd-aasm-approvals-approve"></a>
+
+Approve a pending action
+
+## Synopsis
+
+```text
+Usage: aasm approvals approve [OPTIONS] <ID>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<ID>` | `<ID>` | Approval request ID to approve *(required)* |
+| `--reason` | `<REASON>` | Optional reason for the approval |
+

--- a/docs/cli/aasm-approvals-get.md
+++ b/docs/cli/aasm-approvals-get.md
@@ -1,0 +1,19 @@
+# `aasm approvals get`
+
+<a id="cmd-aasm-approvals-get"></a>
+
+Show details of a single pending approval request
+
+## Synopsis
+
+```text
+Usage: aasm approvals get [OPTIONS] <ID>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<ID>` | `<ID>` | Approval request ID to look up *(required)* |
+| `--output` | `<OUTPUT>` (`table`, `json`, `yaml`) | Output format override for this subcommand |
+

--- a/docs/cli/aasm-approvals-list.md
+++ b/docs/cli/aasm-approvals-list.md
@@ -1,0 +1,20 @@
+# `aasm approvals list`
+
+<a id="cmd-aasm-approvals-list"></a>
+
+List all pending approval requests
+
+## Synopsis
+
+```text
+Usage: aasm approvals list [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--output` | `<OUTPUT>` (`table`, `json`, `yaml`) | Output format override for this subcommand |
+| `--status` | `<STATUS>` (`pending`, `approved`, `rejected`) | Filter by approval status: `pending`, `approved`, or `rejected`. Omitted ⇒ pending only (matches pre-AAASM-1477 behavior) |
+| `--agent` | `<AGENT>` | Filter to approvals submitted by this agent id (exact match) |
+

--- a/docs/cli/aasm-approvals-reject.md
+++ b/docs/cli/aasm-approvals-reject.md
@@ -1,0 +1,19 @@
+# `aasm approvals reject`
+
+<a id="cmd-aasm-approvals-reject"></a>
+
+Reject a pending action (--reason required)
+
+## Synopsis
+
+```text
+Usage: aasm approvals reject [OPTIONS] <ID>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<ID>` | `<ID>` | Approval request ID to reject *(required)* |
+| `--reason` | `<REASON>` | Reason for rejection (required in non-interactive mode) |
+

--- a/docs/cli/aasm-approvals-watch.md
+++ b/docs/cli/aasm-approvals-watch.md
@@ -1,0 +1,18 @@
+# `aasm approvals watch`
+
+<a id="cmd-aasm-approvals-watch"></a>
+
+Watch for new approval requests in real time
+
+## Synopsis
+
+```text
+Usage: aasm approvals watch [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `-i`, `--interactive` |  | Enable interactive mode with keyboard shortcuts (a=approve, r=reject, q=quit) |
+

--- a/docs/cli/aasm-approvals.md
+++ b/docs/cli/aasm-approvals.md
@@ -1,0 +1,22 @@
+# `aasm approvals`
+
+<a id="cmd-aasm-approvals"></a>
+
+Manage human-in-the-loop approval requests
+
+## Synopsis
+
+```text
+Usage: aasm approvals <COMMAND>
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| [`aasm approvals list`](aasm-approvals-list.md#cmd-aasm-approvals-list) | List all pending approval requests |
+| [`aasm approvals get`](aasm-approvals-get.md#cmd-aasm-approvals-get) | Show details of a single pending approval request |
+| [`aasm approvals approve`](aasm-approvals-approve.md#cmd-aasm-approvals-approve) | Approve a pending action |
+| [`aasm approvals reject`](aasm-approvals-reject.md#cmd-aasm-approvals-reject) | Reject a pending action (--reason required) |
+| [`aasm approvals watch`](aasm-approvals-watch.md#cmd-aasm-approvals-watch) | Watch for new approval requests in real time |
+

--- a/docs/cli/aasm-audit-compliance-export.md
+++ b/docs/cli/aasm-audit-compliance-export.md
@@ -1,0 +1,27 @@
+# `aasm audit compliance-export`
+
+<a id="cmd-aasm-audit-compliance-export"></a>
+
+Full-fidelity compliance export of a local JSONL audit log file.
+
+Preserves the SHA-256 hash chain, credential findings, and delegation lineage for SIEM ingestion and regulatory review.
+
+## Synopsis
+
+```text
+Usage: aasm audit compliance-export [OPTIONS] --input <INPUT>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--input` | `<INPUT>` | Path to a per-session audit JSONL file produced by the gateway *(required)* |
+| `--format` | `<FORMAT>` (`csv`, `json`, `jsonl`) | Export file format. Defaults to JSONL for SIEM/regulator ingestion [default: jsonl] |
+| `--compliance` | `<COMPLIANCE>` (`eu-ai-act`, `soc2`) | Compliance framework header to prepend (EU AI Act or SOC 2) |
+| `--output-file` | `<OUTPUT_FILE>` | Write output to a file instead of stdout |
+| `--agent` | `<AGENT>` | Filter by hex-encoded agent identifier (32 hex chars) |
+| `--event-type` | `<EVENT_TYPE>` | Filter by audit event type label (e.g. `PolicyViolation`) |
+| `--since` | `<SINCE>` | Include entries after this duration shorthand (`30m`, `2h`, `1d`) or ISO 8601 timestamp |
+| `--until` | `<UNTIL>` | Include entries before this ISO 8601 timestamp |
+

--- a/docs/cli/aasm-audit-export.md
+++ b/docs/cli/aasm-audit-export.md
@@ -1,0 +1,26 @@
+# `aasm audit export`
+
+<a id="cmd-aasm-audit-export"></a>
+
+Export audit data in CSV or JSON format
+
+## Synopsis
+
+```text
+Usage: aasm audit export [OPTIONS] --format <FORMAT>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--format` | `<FORMAT>` (`csv`, `json`, `jsonl`) | Export file format *(required)* |
+| `--compliance` | `<COMPLIANCE>` (`eu-ai-act`, `soc2`) | Compliance report format (adds metadata headers) |
+| `--output-file` | `<OUTPUT_FILE>` | Write output to a file instead of stdout.  Renamed from `--output` to `--output-file` to avoid a clap matches-store id collision with the top-level `Cli::output: OutputFormat` global flag — the duplicate id used to panic on downcast at every `aasm audit export` invocation (AAASM-1479). |
+| `--agent` | `<AGENT>` | Filter by agent identifier |
+| `--action` | `<ACTION>` | Filter by action type |
+| `--result` | `<RESULT>` (`allow`, `deny`, `pending`) | Filter by policy decision result |
+| `--since` | `<SINCE>` | Show events after this duration or ISO 8601 timestamp |
+| `--until` | `<UNTIL>` | Show events before this ISO 8601 timestamp |
+| `--limit` | `<LIMIT>` | Maximum number of entries to fetch [default: 1000] |
+

--- a/docs/cli/aasm-audit-list.md
+++ b/docs/cli/aasm-audit-list.md
@@ -1,0 +1,24 @@
+# `aasm audit list`
+
+<a id="cmd-aasm-audit-list"></a>
+
+Query audit log entries with optional filters
+
+## Synopsis
+
+```text
+Usage: aasm audit list [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--agent` | `<AGENT>` | Filter by agent identifier |
+| `--action` | `<ACTION>` | Filter by action type (e.g. `ToolCallIntercepted`, `PolicyViolation`) |
+| `--result` | `<RESULT>` (`allow`, `deny`, `pending`) | Filter by policy decision result |
+| `--since` | `<SINCE>` | Show events after this duration or ISO 8601 timestamp (e.g. `30m`, `2h`, `2026-04-30T10:00:00Z`) |
+| `--until` | `<UNTIL>` | Show events before this ISO 8601 timestamp |
+| `--limit` | `<LIMIT>` | Maximum number of entries to return [default: 50] |
+| `--dry-run-only` |  | Show only sandbox / observe-mode shadow events — entries the gateway recorded with `dry_run: true` because policy was evaluated in observe mode (AAASM-1564). When this flag is OFF (the default), shadow events are hidden so operators see only live enforcement decisions |
+

--- a/docs/cli/aasm-audit-verify-chain.md
+++ b/docs/cli/aasm-audit-verify-chain.md
@@ -1,0 +1,18 @@
+# `aasm audit verify-chain`
+
+<a id="cmd-aasm-audit-verify-chain"></a>
+
+Verify the hash chain of a local JSONL audit log file
+
+## Synopsis
+
+```text
+Usage: aasm audit verify-chain <PATH>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<PATH>` | `<PATH>` | Path to the JSONL audit log file to verify *(required)* |
+

--- a/docs/cli/aasm-audit.md
+++ b/docs/cli/aasm-audit.md
@@ -1,0 +1,21 @@
+# `aasm audit`
+
+<a id="cmd-aasm-audit"></a>
+
+Query audit log entries and export compliance reports
+
+## Synopsis
+
+```text
+Usage: aasm audit <COMMAND>
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| [`aasm audit list`](aasm-audit-list.md#cmd-aasm-audit-list) | Query audit log entries with optional filters |
+| [`aasm audit export`](aasm-audit-export.md#cmd-aasm-audit-export) | Export audit data in CSV or JSON format |
+| [`aasm audit verify-chain`](aasm-audit-verify-chain.md#cmd-aasm-audit-verify-chain) | Verify the hash chain of a local JSONL audit log file |
+| [`aasm audit compliance-export`](aasm-audit-compliance-export.md#cmd-aasm-audit-compliance-export) | Full-fidelity compliance export of a local JSONL audit log file |
+

--- a/docs/cli/aasm-completion.md
+++ b/docs/cli/aasm-completion.md
@@ -1,0 +1,18 @@
+# `aasm completion`
+
+<a id="cmd-aasm-completion"></a>
+
+Generate shell completion scripts
+
+## Synopsis
+
+```text
+Usage: aasm completion <SHELL>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<SHELL>` | `<SHELL>` (`bash`, `elvish`, `fish`, `powershell`, `zsh`) | Shell to generate completions for *(required)* |
+

--- a/docs/cli/aasm-config-boot.md
+++ b/docs/cli/aasm-config-boot.md
@@ -1,0 +1,18 @@
+# `aasm config boot`
+
+<a id="cmd-aasm-config-boot"></a>
+
+Build the `[storage]` backends from an `agent-assembly.toml` and run a sample policy lookup
+
+## Synopsis
+
+```text
+Usage: aasm config boot <FILE>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<FILE>` | `<FILE>` | Path to the `agent-assembly.toml` file to boot from *(required)* |
+

--- a/docs/cli/aasm-config-validate.md
+++ b/docs/cli/aasm-config-validate.md
@@ -1,0 +1,18 @@
+# `aasm config validate`
+
+<a id="cmd-aasm-config-validate"></a>
+
+Validate an `agent-assembly.toml` file (currently the `[storage]` section)
+
+## Synopsis
+
+```text
+Usage: aasm config validate <FILE>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<FILE>` | `<FILE>` | Path to the `agent-assembly.toml` file to validate *(required)* |
+

--- a/docs/cli/aasm-config.md
+++ b/docs/cli/aasm-config.md
@@ -1,0 +1,19 @@
+# `aasm config`
+
+<a id="cmd-aasm-config"></a>
+
+Validate an `agent-assembly.toml` runtime configuration file
+
+## Synopsis
+
+```text
+Usage: aasm config <COMMAND>
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| [`aasm config validate`](aasm-config-validate.md#cmd-aasm-config-validate) | Validate an `agent-assembly.toml` file (currently the `[storage]` section) |
+| [`aasm config boot`](aasm-config-boot.md#cmd-aasm-config-boot) | Build the `[storage]` backends from an `agent-assembly.toml` and run a sample policy lookup |
+

--- a/docs/cli/aasm-context-list.md
+++ b/docs/cli/aasm-context-list.md
@@ -1,0 +1,12 @@
+# `aasm context list`
+
+<a id="cmd-aasm-context-list"></a>
+
+List all configured contexts
+
+## Synopsis
+
+```text
+Usage: aasm context list
+```
+

--- a/docs/cli/aasm-context-set.md
+++ b/docs/cli/aasm-context-set.md
@@ -1,0 +1,20 @@
+# `aasm context set`
+
+<a id="cmd-aasm-context-set"></a>
+
+Set or create a named context
+
+## Synopsis
+
+```text
+Usage: aasm context set [OPTIONS] --api-url <API_URL> <NAME>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<NAME>` | `<NAME>` | Name of the context to create or update *(required)* |
+| `--api-url` | `<API_URL>` | API URL for this context *(required)* |
+| `--api-key` | `<API_KEY>` | API key for this context (optional) |
+

--- a/docs/cli/aasm-context-use.md
+++ b/docs/cli/aasm-context-use.md
@@ -1,0 +1,18 @@
+# `aasm context use`
+
+<a id="cmd-aasm-context-use"></a>
+
+Switch the default context
+
+## Synopsis
+
+```text
+Usage: aasm context use <NAME>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<NAME>` | `<NAME>` | Name of the context to set as default *(required)* |
+

--- a/docs/cli/aasm-context.md
+++ b/docs/cli/aasm-context.md
@@ -1,0 +1,20 @@
+# `aasm context`
+
+<a id="cmd-aasm-context"></a>
+
+Manage named API contexts (connection profiles)
+
+## Synopsis
+
+```text
+Usage: aasm context <COMMAND>
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| [`aasm context list`](aasm-context-list.md#cmd-aasm-context-list) | List all configured contexts |
+| [`aasm context set`](aasm-context-set.md#cmd-aasm-context-set) | Set or create a named context |
+| [`aasm context use`](aasm-context-use.md#cmd-aasm-context-use) | Switch the default context |
+

--- a/docs/cli/aasm-cost-forecast.md
+++ b/docs/cli/aasm-cost-forecast.md
@@ -1,0 +1,12 @@
+# `aasm cost forecast`
+
+<a id="cmd-aasm-cost-forecast"></a>
+
+Forecast monthly spending based on current daily rate
+
+## Synopsis
+
+```text
+Usage: aasm cost forecast
+```
+

--- a/docs/cli/aasm-cost-summary.md
+++ b/docs/cli/aasm-cost-summary.md
@@ -1,0 +1,19 @@
+# `aasm cost summary`
+
+<a id="cmd-aasm-cost-summary"></a>
+
+Show cost summary for the current period
+
+## Synopsis
+
+```text
+Usage: aasm cost summary [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--period` | `<PERIOD>` (`today`, `month`) | Time period to report on [default: today] |
+| `--group-by` | `<GROUP_BY>` (`agent`) | Group spend by dimension |
+

--- a/docs/cli/aasm-cost.md
+++ b/docs/cli/aasm-cost.md
@@ -1,0 +1,19 @@
+# `aasm cost`
+
+<a id="cmd-aasm-cost"></a>
+
+Query cost summary and forecast spending
+
+## Synopsis
+
+```text
+Usage: aasm cost <COMMAND>
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| [`aasm cost summary`](aasm-cost-summary.md#cmd-aasm-cost-summary) | Show cost summary for the current period |
+| [`aasm cost forecast`](aasm-cost-forecast.md#cmd-aasm-cost-forecast) | Forecast monthly spending based on current daily rate |
+

--- a/docs/cli/aasm-dashboard-open.md
+++ b/docs/cli/aasm-dashboard-open.md
@@ -1,0 +1,18 @@
+# `aasm dashboard open`
+
+<a id="cmd-aasm-dashboard-open"></a>
+
+Open the browser to an already-running dashboard
+
+## Synopsis
+
+```text
+Usage: aasm dashboard open [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--port` | `<PORT>` | Port to connect to (overrides config and AASM_DASHBOARD_PORT env var) |
+

--- a/docs/cli/aasm-dashboard-start.md
+++ b/docs/cli/aasm-dashboard-start.md
@@ -1,0 +1,19 @@
+# `aasm dashboard start`
+
+<a id="cmd-aasm-dashboard-start"></a>
+
+Serve the embedded SPA at http://127.0.0.1:<port>. Blocks until Ctrl-C
+
+## Synopsis
+
+```text
+Usage: aasm dashboard start [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--port` | `<PORT>` | Port to listen on (overrides config and AASM_DASHBOARD_PORT env var) |
+| `--open` |  | Open the system browser after the server is ready |
+

--- a/docs/cli/aasm-dashboard-stop.md
+++ b/docs/cli/aasm-dashboard-stop.md
@@ -1,0 +1,12 @@
+# `aasm dashboard stop`
+
+<a id="cmd-aasm-dashboard-stop"></a>
+
+Stop a dashboard server started with `aasm dashboard start`
+
+## Synopsis
+
+```text
+Usage: aasm dashboard stop
+```
+

--- a/docs/cli/aasm-dashboard.md
+++ b/docs/cli/aasm-dashboard.md
@@ -1,0 +1,20 @@
+# `aasm dashboard`
+
+<a id="cmd-aasm-dashboard"></a>
+
+Open an interactive TUI dashboard for real-time governance monitoring
+
+## Synopsis
+
+```text
+Usage: aasm dashboard [COMMAND]
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| [`aasm dashboard start`](aasm-dashboard-start.md#cmd-aasm-dashboard-start) | Serve the embedded SPA at http://127.0.0.1:<port>. Blocks until Ctrl-C |
+| [`aasm dashboard open`](aasm-dashboard-open.md#cmd-aasm-dashboard-open) | Open the browser to an already-running dashboard |
+| [`aasm dashboard stop`](aasm-dashboard-stop.md#cmd-aasm-dashboard-stop) | Stop a dashboard server started with `aasm dashboard start` |
+

--- a/docs/cli/aasm-docs-export.md
+++ b/docs/cli/aasm-docs-export.md
@@ -1,0 +1,28 @@
+# `aasm docs export`
+
+<a id="cmd-aasm-docs-export"></a>
+
+Export the CLI reference, one Markdown file per command
+
+## Synopsis
+
+```text
+Usage: aasm docs export [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--format` | `<FORMAT>` (`markdown`) | Output format for the generated reference (only `markdown` today) [default: markdown] |
+| `--out` | `<OUT>` | Directory to write the generated reference into [default: docs/cli/] |
+| `--check` |  | Verify the on-disk reference is up to date instead of writing it.  Re-renders the CLI tree in memory and compares it against the files in `--out`. Exits non-zero (and lists the stale paths) when they differ, without modifying anything. Used by CI to block PRs that change a `clap` definition without regenerating `docs/cli/`. |
+
+## Examples
+
+```text
+  aasm docs export
+  aasm docs export --format markdown --out docs/cli/
+  aasm docs export --check
+```
+

--- a/docs/cli/aasm-docs.md
+++ b/docs/cli/aasm-docs.md
@@ -1,0 +1,18 @@
+# `aasm docs`
+
+<a id="cmd-aasm-docs"></a>
+
+Generate documentation from the live CLI definition
+
+## Synopsis
+
+```text
+Usage: aasm docs <COMMAND>
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| [`aasm docs export`](aasm-docs-export.md#cmd-aasm-docs-export) | Export the CLI reference, one Markdown file per command |
+

--- a/docs/cli/aasm-gateway-logs.md
+++ b/docs/cli/aasm-gateway-logs.md
@@ -1,0 +1,21 @@
+# `aasm gateway logs`
+
+<a id="cmd-aasm-gateway-logs"></a>
+
+Tail the gateway log file
+
+## Synopsis
+
+```text
+Usage: aasm gateway logs [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `-f`, `--follow` |  | Stream new log entries in real time (like `tail -f`) |
+| `--lines` | `<LINES>` | Number of lines to show from the end of the log (default 50) [default: 50] |
+| `--level` | `<LEVEL>` (`error`, `warn`, `info`, `debug`) | Filter log entries by minimum severity level |
+| `--log-file` | `<LOG_FILE>` | Path to the log file (default ~/.aasm/logs/gateway.log) |
+

--- a/docs/cli/aasm-gateway-start.md
+++ b/docs/cli/aasm-gateway-start.md
@@ -1,0 +1,22 @@
+# `aasm gateway start`
+
+<a id="cmd-aasm-gateway-start"></a>
+
+Spawn aa-gateway as a detached background process
+
+## Synopsis
+
+```text
+Usage: aasm gateway start [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--policy` | `<POLICY>` | Path to the policy YAML file (overrides $AA_POLICY and default locations) |
+| `--listen` | `<LISTEN>` | TCP listen address (e.g. "127.0.0.1:50051") [default: 127.0.0.1:50051] |
+| `--socket` | `<SOCKET>` | Unix domain socket path. When set, takes precedence over --listen |
+| `--no-detach` |  | Block the caller rather than detaching the gateway to the background |
+| `--log-file` | `<LOG_FILE>` | Log file path for aa-gateway stdout/stderr (default ~/.aasm/logs/gateway.log) |
+

--- a/docs/cli/aasm-gateway-status.md
+++ b/docs/cli/aasm-gateway-status.md
@@ -1,0 +1,18 @@
+# `aasm gateway status`
+
+<a id="cmd-aasm-gateway-status"></a>
+
+Report whether aa-gateway is running and serving gRPC
+
+## Synopsis
+
+```text
+Usage: aasm gateway status [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--json` |  | Emit machine-readable JSON instead of human-readable text |
+

--- a/docs/cli/aasm-gateway-stop.md
+++ b/docs/cli/aasm-gateway-stop.md
@@ -1,0 +1,12 @@
+# `aasm gateway stop`
+
+<a id="cmd-aasm-gateway-stop"></a>
+
+Terminate a running aa-gateway gracefully (SIGTERM → SIGKILL fallback)
+
+## Synopsis
+
+```text
+Usage: aasm gateway stop
+```
+

--- a/docs/cli/aasm-gateway.md
+++ b/docs/cli/aasm-gateway.md
@@ -1,0 +1,21 @@
+# `aasm gateway`
+
+<a id="cmd-aasm-gateway"></a>
+
+Manage the aa-gateway governance daemon — agent registry, policy engine, audit log
+
+## Synopsis
+
+```text
+Usage: aasm gateway <COMMAND>
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| [`aasm gateway start`](aasm-gateway-start.md#cmd-aasm-gateway-start) | Spawn aa-gateway as a detached background process |
+| [`aasm gateway stop`](aasm-gateway-stop.md#cmd-aasm-gateway-stop) | Terminate a running aa-gateway gracefully (SIGTERM → SIGKILL fallback) |
+| [`aasm gateway status`](aasm-gateway-status.md#cmd-aasm-gateway-status) | Report whether aa-gateway is running and serving gRPC |
+| [`aasm gateway logs`](aasm-gateway-logs.md#cmd-aasm-gateway-logs) | Tail the gateway log file |
+

--- a/docs/cli/aasm-logs.md
+++ b/docs/cli/aasm-logs.md
@@ -1,0 +1,25 @@
+# `aasm logs`
+
+<a id="cmd-aasm-logs"></a>
+
+Query and stream audit log events
+
+## Synopsis
+
+```text
+Usage: aasm logs [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `-f`, `--follow` |  | Stream events in real-time (like `tail -f`). Connects via WebSocket |
+| `--agent` | `<AGENT>` | Filter by agent identifier |
+| `--type` | `<TYPE>` (`violation`, `approval`, `budget`) | Filter by event type (comma-separated). Accepted: violation, approval, budget |
+| `--since` | `<SINCE>` | Show events after this duration or ISO 8601 timestamp (e.g. `30m`, `2h`, `2026-04-30T10:00:00Z`) |
+| `--until` | `<UNTIL>` | Show events before this ISO 8601 timestamp |
+| `--limit` | `<LIMIT>` | Maximum number of entries to return in non-follow mode [default: 50] |
+| `--no-color` |  | Disable colour output |
+| `--output` | `<OUTPUT>` (`table`, `json`, `yaml`) | Override the global output format for this command |
+

--- a/docs/cli/aasm-policy-apply.md
+++ b/docs/cli/aasm-policy-apply.md
@@ -1,0 +1,19 @@
+# `aasm policy apply`
+
+<a id="cmd-aasm-policy-apply"></a>
+
+Apply a policy YAML file and save it to version history
+
+## Synopsis
+
+```text
+Usage: aasm policy apply [OPTIONS] <FILE>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<FILE>` | `<FILE>` | Path to the policy YAML file *(required)* |
+| `--applied-by` | `<APPLIED_BY>` | Identity of the person or system applying the policy |
+

--- a/docs/cli/aasm-policy-diff.md
+++ b/docs/cli/aasm-policy-diff.md
@@ -1,0 +1,19 @@
+# `aasm policy diff`
+
+<a id="cmd-aasm-policy-diff"></a>
+
+Show the diff between two policy versions
+
+## Synopsis
+
+```text
+Usage: aasm policy diff <VERSION_A> <VERSION_B>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<VERSION_A>` | `<VERSION_A>` | First version identifier (SHA-256 prefix) *(required)* |
+| `<VERSION_B>` | `<VERSION_B>` | Second version identifier (SHA-256 prefix) *(required)* |
+

--- a/docs/cli/aasm-policy-get.md
+++ b/docs/cli/aasm-policy-get.md
@@ -1,0 +1,18 @@
+# `aasm policy get`
+
+<a id="cmd-aasm-policy-get"></a>
+
+Show the currently active policy YAML (or a specific version)
+
+## Synopsis
+
+```text
+Usage: aasm policy get
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--version` | `<VERSION>` | Version identifier (SHA-256 prefix) to retrieve. Shows the latest active policy when omitted |
+

--- a/docs/cli/aasm-policy-history.md
+++ b/docs/cli/aasm-policy-history.md
@@ -1,0 +1,18 @@
+# `aasm policy history`
+
+<a id="cmd-aasm-policy-history"></a>
+
+List recent policy versions
+
+## Synopsis
+
+```text
+Usage: aasm policy history [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `-n`, `--limit` | `<LIMIT>` | Maximum number of versions to show [default: 10] |
+

--- a/docs/cli/aasm-policy-list.md
+++ b/docs/cli/aasm-policy-list.md
@@ -1,0 +1,12 @@
+# `aasm policy list`
+
+<a id="cmd-aasm-policy-list"></a>
+
+List all policies deployed to the governance runtime
+
+## Synopsis
+
+```text
+Usage: aasm policy list
+```
+

--- a/docs/cli/aasm-policy-rollback.md
+++ b/docs/cli/aasm-policy-rollback.md
@@ -1,0 +1,18 @@
+# `aasm policy rollback`
+
+<a id="cmd-aasm-policy-rollback"></a>
+
+Roll back to a previous policy version
+
+## Synopsis
+
+```text
+Usage: aasm policy rollback <VERSION>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<VERSION>` | `<VERSION>` | Version identifier (SHA-256 prefix) to roll back to *(required)* |
+

--- a/docs/cli/aasm-policy-show.md
+++ b/docs/cli/aasm-policy-show.md
@@ -1,0 +1,29 @@
+# `aasm policy show`
+
+<a id="cmd-aasm-policy-show"></a>
+
+Show an agent's effective policy view (use `--show-permissions`)
+
+## Synopsis
+
+```text
+Usage: aasm policy show [OPTIONS] <AGENT_ID>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<AGENT_ID>` | `<AGENT_ID>` | Hex-encoded agent UUID (32 hex characters) *(required)* |
+| `--show-permissions` |  | Print the agent's effective capability set with cascade provenance |
+| `--show-budget` |  | Print the agent's budget rollup across agent / team / org / subtree |
+
+## Examples
+
+```text
+  aasm policy show aabbccdd00112233aabbccdd00112233 --show-permissions
+  aasm policy show aabbccdd00112233aabbccdd00112233 --show-budget
+  aasm policy show aabbccdd00112233aabbccdd00112233 --show-permissions --show-budget
+  aasm policy show aabbccdd00112233aabbccdd00112233 --show-budget --output json
+```
+

--- a/docs/cli/aasm-policy-simulate.md
+++ b/docs/cli/aasm-policy-simulate.md
@@ -1,0 +1,22 @@
+# `aasm policy simulate`
+
+<a id="cmd-aasm-policy-simulate"></a>
+
+Simulate a policy against historical events or live traffic (dry-run)
+
+## Synopsis
+
+```text
+Usage: aasm policy simulate [OPTIONS] --policy <POLICY>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--policy` | `<POLICY>` | Path to the policy YAML file to simulate *(required)* |
+| `--against` | `<AGAINST>` | Path to an audit log JSONL file to replay against the policy |
+| `--live` |  | Observe live agent traffic instead of replaying a file [default: false] |
+| `--duration` | `<DURATION>` | Duration for live simulation (e.g. "60s", "5m") |
+| `--output-file` | `<OUTPUT_FILE>` | Path to write the simulation report JSON.  Named `--output-file` (not `--output`) to avoid collision with the top-level global `--output <OutputFormat>` flag. |
+

--- a/docs/cli/aasm-policy-validate.md
+++ b/docs/cli/aasm-policy-validate.md
@@ -1,0 +1,18 @@
+# `aasm policy validate`
+
+<a id="cmd-aasm-policy-validate"></a>
+
+Validate a policy YAML file locally (no apply)
+
+## Synopsis
+
+```text
+Usage: aasm policy validate <FILE>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<FILE>` | `<FILE>` | Path to the policy YAML file to validate *(required)* |
+

--- a/docs/cli/aasm-policy.md
+++ b/docs/cli/aasm-policy.md
@@ -1,0 +1,26 @@
+# `aasm policy`
+
+<a id="cmd-aasm-policy"></a>
+
+Manage governance policies
+
+## Synopsis
+
+```text
+Usage: aasm policy <COMMAND>
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| [`aasm policy apply`](aasm-policy-apply.md#cmd-aasm-policy-apply) | Apply a policy YAML file and save it to version history |
+| [`aasm policy history`](aasm-policy-history.md#cmd-aasm-policy-history) | List recent policy versions |
+| [`aasm policy rollback`](aasm-policy-rollback.md#cmd-aasm-policy-rollback) | Roll back to a previous policy version |
+| [`aasm policy diff`](aasm-policy-diff.md#cmd-aasm-policy-diff) | Show the diff between two policy versions |
+| [`aasm policy simulate`](aasm-policy-simulate.md#cmd-aasm-policy-simulate) | Simulate a policy against historical events or live traffic (dry-run) |
+| [`aasm policy validate`](aasm-policy-validate.md#cmd-aasm-policy-validate) | Validate a policy YAML file locally (no apply) |
+| [`aasm policy get`](aasm-policy-get.md#cmd-aasm-policy-get) | Show the currently active policy YAML (or a specific version) |
+| [`aasm policy list`](aasm-policy-list.md#cmd-aasm-policy-list) | List all policies deployed to the governance runtime |
+| [`aasm policy show`](aasm-policy-show.md#cmd-aasm-policy-show) | Show an agent's effective policy view (use `--show-permissions`) |
+

--- a/docs/cli/aasm-proxy-install-ca.md
+++ b/docs/cli/aasm-proxy-install-ca.md
@@ -1,0 +1,19 @@
+# `aasm proxy install-ca`
+
+<a id="cmd-aasm-proxy-install-ca"></a>
+
+Install the proxy CA certificate into the OS trust store
+
+## Synopsis
+
+```text
+Usage: aasm proxy install-ca [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--ca-dir` | `<CA_DIR>` | Directory where the CA certificate and key are stored |
+| `--yes` |  | Skip the confirmation prompt |
+

--- a/docs/cli/aasm-proxy-logs.md
+++ b/docs/cli/aasm-proxy-logs.md
@@ -1,0 +1,21 @@
+# `aasm proxy logs`
+
+<a id="cmd-aasm-proxy-logs"></a>
+
+Tail the proxy log file
+
+## Synopsis
+
+```text
+Usage: aasm proxy logs [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `-f`, `--follow` |  | Stream new log entries continuously (like `tail -f`) |
+| `--lines` | `<LINES>` | Number of lines to show from the end of the log (default 50) [default: 50] |
+| `--level` | `<LEVEL>` | Filter to lines at or above this level: error, warn, info, debug |
+| `--since` | `<DURATION>` | Show only entries since a relative duration (e.g., `5m`, `1h`, `30s`) |
+

--- a/docs/cli/aasm-proxy-start.md
+++ b/docs/cli/aasm-proxy-start.md
@@ -1,0 +1,22 @@
+# `aasm proxy start`
+
+<a id="cmd-aasm-proxy-start"></a>
+
+Spawn the aa-proxy sidecar in the background (or foreground with --no-detach)
+
+## Synopsis
+
+```text
+Usage: aasm proxy start [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--listen` | `<LISTEN>` | Address the proxy should listen on [default: 127.0.0.1:8899] |
+| `--gateway` | `<GATEWAY>` | Gateway URL to forward policy decisions to |
+| `--ca-dir` | `<CA_DIR>` | Directory for CA certificate and key storage |
+| `--no-detach` |  | Run in the foreground instead of daemonizing |
+| `--log-file` | `<LOG_FILE>` | File to redirect proxy stdout/stderr to (background mode only) |
+

--- a/docs/cli/aasm-proxy-status.md
+++ b/docs/cli/aasm-proxy-status.md
@@ -1,0 +1,18 @@
+# `aasm proxy status`
+
+<a id="cmd-aasm-proxy-status"></a>
+
+Show whether the aa-proxy sidecar is running
+
+## Synopsis
+
+```text
+Usage: aasm proxy status [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--json` |  | Emit machine-readable JSON output |
+

--- a/docs/cli/aasm-proxy-stop.md
+++ b/docs/cli/aasm-proxy-stop.md
@@ -1,0 +1,12 @@
+# `aasm proxy stop`
+
+<a id="cmd-aasm-proxy-stop"></a>
+
+Stop the running aa-proxy sidecar
+
+## Synopsis
+
+```text
+Usage: aasm proxy stop
+```
+

--- a/docs/cli/aasm-proxy-uninstall-ca.md
+++ b/docs/cli/aasm-proxy-uninstall-ca.md
@@ -1,0 +1,19 @@
+# `aasm proxy uninstall-ca`
+
+<a id="cmd-aasm-proxy-uninstall-ca"></a>
+
+Remove the proxy CA certificate from the OS trust store
+
+## Synopsis
+
+```text
+Usage: aasm proxy uninstall-ca [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--ca-dir` | `<CA_DIR>` | Directory where the CA certificate and key are stored |
+| `--yes` |  | Skip the confirmation prompt |
+

--- a/docs/cli/aasm-proxy.md
+++ b/docs/cli/aasm-proxy.md
@@ -1,0 +1,23 @@
+# `aasm proxy`
+
+<a id="cmd-aasm-proxy"></a>
+
+Manage the aa-proxy sidecar — lifecycle, CA trust, and log tailing
+
+## Synopsis
+
+```text
+Usage: aasm proxy <COMMAND>
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| [`aasm proxy start`](aasm-proxy-start.md#cmd-aasm-proxy-start) | Spawn the aa-proxy sidecar in the background (or foreground with --no-detach) |
+| [`aasm proxy stop`](aasm-proxy-stop.md#cmd-aasm-proxy-stop) | Stop the running aa-proxy sidecar |
+| [`aasm proxy status`](aasm-proxy-status.md#cmd-aasm-proxy-status) | Show whether the aa-proxy sidecar is running |
+| [`aasm proxy install-ca`](aasm-proxy-install-ca.md#cmd-aasm-proxy-install-ca) | Install the proxy CA certificate into the OS trust store |
+| [`aasm proxy uninstall-ca`](aasm-proxy-uninstall-ca.md#cmd-aasm-proxy-uninstall-ca) | Remove the proxy CA certificate from the OS trust store |
+| [`aasm proxy logs`](aasm-proxy-logs.md#cmd-aasm-proxy-logs) | Tail the proxy log file |
+

--- a/docs/cli/aasm-run.md
+++ b/docs/cli/aasm-run.md
@@ -1,0 +1,27 @@
+# `aasm run`
+
+<a id="cmd-aasm-run"></a>
+
+Launch an AI dev tool (claude, codex, copilot, windsurf) with governance wiring
+
+## Synopsis
+
+```text
+Usage: aasm run [OPTIONS] <TOOL> [TOOL_ARGS]...
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<TOOL>` | `<TOOL>` | The AI development tool to launch (claude, codex, copilot, windsurf) *(required)* |
+| `<TOOL_ARGS>` | `<TOOL_ARGS>` | Arguments forwarded verbatim to the launched tool |
+| `--agent-id` | `<AGENT_ID>` | Override the agent identity for this session |
+| `--team-id` | `<TEAM_ID>` | Team identifier for this session |
+| `--root-agent` | `<ROOT_AGENT>` | Root agent identifier for lineage tracking |
+| `--governance-level` | `<GOVERNANCE_LEVEL>` | Override the governance level for this session |
+| `--no-proxy` |  | Skip proxy injection (not recommended for governed environments) |
+| `--dry-run` |  | Show the launch command and settings without executing |
+| `--enforcement-mode` | `<ENFORCEMENT_MODE>` (`enforce`, `observe`, `disabled`) | Enforcement posture for this session — overrides the policy default for this agent. Defaults to `enforce` (live enforcement). When set to `observe`, policy decisions are recorded but never applied; the launched tool sees Allow for every action and shadow events land in the audit log |
+| `--observe` |  | Shorthand for `--enforcement-mode observe`. Mutually exclusive with `--enforcement-mode` so the source of truth stays unambiguous |
+

--- a/docs/cli/aasm-sandbox-info.md
+++ b/docs/cli/aasm-sandbox-info.md
@@ -1,0 +1,12 @@
+# `aasm sandbox info`
+
+<a id="cmd-aasm-sandbox-info"></a>
+
+Show the default sandbox runtime limits
+
+## Synopsis
+
+```text
+Usage: aasm sandbox info
+```
+

--- a/docs/cli/aasm-sandbox-run.md
+++ b/docs/cli/aasm-sandbox-run.md
@@ -1,0 +1,21 @@
+# `aasm sandbox run`
+
+<a id="cmd-aasm-sandbox-run"></a>
+
+Run a WebAssembly module inside a fresh sandbox and report the outcome
+
+## Synopsis
+
+```text
+Usage: aasm sandbox run [OPTIONS] <WASM>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<WASM>` | `<WASM>` | Path to a `.wasm` module to execute under WASI preview 1 *(required)* |
+| `--fuel` | `<FUEL>` | Wasmtime instruction-fuel budget. Defaults to the safe-by-default 10M units; pass a larger value for long-running tools |
+| `--memory-pages` | `<MEMORY_PAGES>` | Maximum linear-memory pages (1 page = 64 KiB). Defaults to 16 (1 MiB) |
+| `--wall-clock-ms` | `<WALL_CLOCK_MS>` | Wall-clock deadline in milliseconds. Defaults to 5000 (5s) |
+

--- a/docs/cli/aasm-sandbox.md
+++ b/docs/cli/aasm-sandbox.md
@@ -1,0 +1,19 @@
+# `aasm sandbox`
+
+<a id="cmd-aasm-sandbox"></a>
+
+Run a WebAssembly tool inside the Agent Assembly sandbox (filesystem + CPU + memory + wall-clock isolation)
+
+## Synopsis
+
+```text
+Usage: aasm sandbox <COMMAND>
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| [`aasm sandbox run`](aasm-sandbox-run.md#cmd-aasm-sandbox-run) | Run a WebAssembly module inside a fresh sandbox and report the outcome |
+| [`aasm sandbox info`](aasm-sandbox-info.md#cmd-aasm-sandbox-info) | Show the default sandbox runtime limits |
+

--- a/docs/cli/aasm-start.md
+++ b/docs/cli/aasm-start.md
@@ -1,0 +1,22 @@
+# `aasm start`
+
+<a id="cmd-aasm-start"></a>
+
+Start the locally-managed Agent Assembly gateway process
+
+## Synopsis
+
+```text
+Usage: aasm start [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--mode` | `<MODE>` (`local`, `remote`) | Deployment mode to start [default: local] |
+| `--port` | `<PORT>` | TCP port the gateway should listen on [default: 7391] |
+| `--config` | `<CONFIG>` | Path to the YAML config file consumed by the gateway [default: ~/.aasm/config.yaml] |
+| `--foreground` |  | Stay in the foreground; do not daemonize |
+| `--no-dashboard` |  | Disable dashboard serving even in local mode |
+

--- a/docs/cli/aasm-status.md
+++ b/docs/cli/aasm-status.md
@@ -1,0 +1,19 @@
+# `aasm status`
+
+<a id="cmd-aasm-status"></a>
+
+Show fleet health, agents, approvals, and budget at a glance
+
+## Synopsis
+
+```text
+Usage: aasm status [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--watch` |  | Auto-refresh the status display every 5 seconds |
+| `--json` |  | Print only the deployment-overview header as machine-readable JSON.  Intended for scripting and CI integrations — the documented shape is the JSON contract published in the AAASM-1579 story description. Distinct from `--output json`, which serialises the full status snapshot. |
+

--- a/docs/cli/aasm-stop.md
+++ b/docs/cli/aasm-stop.md
@@ -1,0 +1,18 @@
+# `aasm stop`
+
+<a id="cmd-aasm-stop"></a>
+
+Stop the locally-managed Agent Assembly gateway process
+
+## Synopsis
+
+```text
+Usage: aasm stop [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--timeout` | `<TIMEOUT>` | Seconds to wait for graceful shutdown before SIGKILL [default: 30] |
+

--- a/docs/cli/aasm-tools-list.md
+++ b/docs/cli/aasm-tools-list.md
@@ -1,0 +1,12 @@
+# `aasm tools list`
+
+<a id="cmd-aasm-tools-list"></a>
+
+List all discovered AI dev tools on this system
+
+## Synopsis
+
+```text
+Usage: aasm tools list
+```
+

--- a/docs/cli/aasm-tools.md
+++ b/docs/cli/aasm-tools.md
@@ -1,0 +1,18 @@
+# `aasm tools`
+
+<a id="cmd-aasm-tools"></a>
+
+List and manage AI dev tools on this system
+
+## Synopsis
+
+```text
+Usage: aasm tools <COMMAND>
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| [`aasm tools list`](aasm-tools-list.md#cmd-aasm-tools-list) | List all discovered AI dev tools on this system |
+

--- a/docs/cli/aasm-topology-lineage.md
+++ b/docs/cli/aasm-topology-lineage.md
@@ -1,0 +1,27 @@
+# `aasm topology lineage`
+
+<a id="cmd-aasm-topology-lineage"></a>
+
+Show ancestry chain for a given agent
+
+## Synopsis
+
+```text
+Usage: aasm topology lineage [OPTIONS] <AGENT_ID>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<AGENT_ID>` | `<AGENT_ID>` | Agent ID (hex-encoded UUID) *(required)* |
+| `--show-permissions` |  | After the lineage, also print the agent's effective capability set with cascade provenance |
+
+## Examples
+
+```text
+  aasm topology lineage aabbccdd00112233aabbccdd00112233
+  aasm topology lineage aabbccdd00112233aabbccdd00112233 --output json
+  aasm topology lineage aabbccdd00112233aabbccdd00112233 --show-permissions
+```
+

--- a/docs/cli/aasm-topology-overview.md
+++ b/docs/cli/aasm-topology-overview.md
@@ -1,0 +1,27 @@
+# `aasm topology overview`
+
+<a id="cmd-aasm-topology-overview"></a>
+
+Show fleet-wide topology overview
+
+## Synopsis
+
+```text
+Usage: aasm topology overview [OPTIONS]
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--status` | `<STATUS>` | Filter agents by status (active, suspended, deregistered) |
+| `--show-budget` |  | Include governance level in agent nodes |
+
+## Examples
+
+```text
+  aasm topology overview
+  aasm topology overview --output json
+  aasm topology overview --status active
+```
+

--- a/docs/cli/aasm-topology-stats.md
+++ b/docs/cli/aasm-topology-stats.md
@@ -1,0 +1,19 @@
+# `aasm topology stats`
+
+<a id="cmd-aasm-topology-stats"></a>
+
+Show aggregate topology statistics
+
+## Synopsis
+
+```text
+Usage: aasm topology stats
+```
+
+## Examples
+
+```text
+  aasm topology stats
+  aasm topology stats --output json
+```
+

--- a/docs/cli/aasm-topology-team.md
+++ b/docs/cli/aasm-topology-team.md
@@ -1,0 +1,29 @@
+# `aasm topology team`
+
+<a id="cmd-aasm-topology-team"></a>
+
+Show all agents in a team
+
+## Synopsis
+
+```text
+Usage: aasm topology team [OPTIONS] <TEAM_ID>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<TEAM_ID>` | `<TEAM_ID>` | Team ID *(required)* |
+| `--status` | `<STATUS>` | Filter members by status |
+| `--show-budget` |  | Include governance level in agent nodes |
+
+## Examples
+
+```text
+  aasm topology team team-abc123
+  aasm topology team team-abc123 --output json
+  aasm topology team team-abc123 --status active
+  aasm topology team team-abc123 --show-budget
+```
+

--- a/docs/cli/aasm-topology-tree.md
+++ b/docs/cli/aasm-topology-tree.md
@@ -1,0 +1,21 @@
+# `aasm topology tree`
+
+<a id="cmd-aasm-topology-tree"></a>
+
+Render a subtree rooted at a given agent
+
+## Synopsis
+
+```text
+Usage: aasm topology tree [OPTIONS] <AGENT_ID>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<AGENT_ID>` | `<AGENT_ID>` | Root agent ID (hex-encoded UUID) *(required)* |
+| `--max-depth` | `<DEPTH>` | Maximum traversal depth from the root (default 10) |
+| `--status` | `<STATUS>` | Filter tree nodes by status |
+| `--show-budget` |  | Include governance level in tree nodes |
+

--- a/docs/cli/aasm-topology.md
+++ b/docs/cli/aasm-topology.md
@@ -1,0 +1,22 @@
+# `aasm topology`
+
+<a id="cmd-aasm-topology"></a>
+
+Visualize agent topology, trees, lineage, and statistics
+
+## Synopsis
+
+```text
+Usage: aasm topology <COMMAND>
+```
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| [`aasm topology overview`](aasm-topology-overview.md#cmd-aasm-topology-overview) | Show fleet-wide topology overview |
+| [`aasm topology tree`](aasm-topology-tree.md#cmd-aasm-topology-tree) | Render a subtree rooted at a given agent |
+| [`aasm topology team`](aasm-topology-team.md#cmd-aasm-topology-team) | Show all agents in a team |
+| [`aasm topology lineage`](aasm-topology-lineage.md#cmd-aasm-topology-lineage) | Show ancestry chain for a given agent |
+| [`aasm topology stats`](aasm-topology-stats.md#cmd-aasm-topology-stats) | Show aggregate topology statistics |
+

--- a/docs/cli/aasm-trace.md
+++ b/docs/cli/aasm-trace.md
@@ -1,0 +1,19 @@
+# `aasm trace`
+
+<a id="cmd-aasm-trace"></a>
+
+Visualize a session trace (tree or timeline)
+
+## Synopsis
+
+```text
+Usage: aasm trace [OPTIONS] <SESSION_ID>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `<SESSION_ID>` | `<SESSION_ID>` | Session ID to retrieve the trace for *(required)* |
+| `--format` | `<FORMAT>` (`tree`, `timeline`) | Visualization format [default: tree] |
+

--- a/docs/cli/aasm-version.md
+++ b/docs/cli/aasm-version.md
@@ -1,0 +1,12 @@
+# `aasm version`
+
+<a id="cmd-aasm-version"></a>
+
+Show CLI and gateway version information
+
+## Synopsis
+
+```text
+Usage: aasm version
+```
+

--- a/docs/cli/aasm.md
+++ b/docs/cli/aasm.md
@@ -1,0 +1,50 @@
+# `aasm`
+
+<a id="cmd-aasm"></a>
+
+aasm — command-line tool for Agent Assembly
+
+## Synopsis
+
+```text
+Usage: aasm [OPTIONS] <COMMAND>
+```
+
+## Options
+
+| Option | Value | Description |
+|--------|-------|-------------|
+| `--context` | `<CONTEXT>` | Named context from ~/.aa/config.yaml to use |
+| `--output` | `<OUTPUT>` (`table`, `json`, `yaml`) | Output format for list/get commands [default: table] |
+| `--api-url` | `<API_URL>` | Override the API URL (takes precedence over context config) |
+| `--api-key` | `<API_KEY>` | Override the API key (takes precedence over context config) |
+
+## Subcommands
+
+| Command | Description |
+|---------|-------------|
+| [`aasm admin`](aasm-admin.md#cmd-aasm-admin) | Gateway administrative operations |
+| [`aasm agent`](aasm-agent.md#cmd-aasm-agent) | Manage monitored agent processes |
+| [`aasm alerts`](aasm-alerts.md#cmd-aasm-alerts) | Manage governance alerts |
+| [`aasm audit`](aasm-audit.md#cmd-aasm-audit) | Query audit log entries and export compliance reports |
+| [`aasm logs`](aasm-logs.md#cmd-aasm-logs) | Query and stream audit log events |
+| [`aasm policy`](aasm-policy.md#cmd-aasm-policy) | Manage governance policies |
+| [`aasm context`](aasm-context.md#cmd-aasm-context) | Manage named API contexts (connection profiles) |
+| [`aasm config`](aasm-config.md#cmd-aasm-config) | Validate an `agent-assembly.toml` runtime configuration file |
+| [`aasm completion`](aasm-completion.md#cmd-aasm-completion) | Generate shell completion scripts |
+| [`aasm docs`](aasm-docs.md#cmd-aasm-docs) | Generate documentation from the live CLI definition |
+| [`aasm status`](aasm-status.md#cmd-aasm-status) | Show fleet health, agents, approvals, and budget at a glance |
+| [`aasm version`](aasm-version.md#cmd-aasm-version) | Show CLI and gateway version information |
+| [`aasm trace`](aasm-trace.md#cmd-aasm-trace) | Visualize a session trace (tree or timeline) |
+| [`aasm approvals`](aasm-approvals.md#cmd-aasm-approvals) | Manage human-in-the-loop approval requests |
+| [`aasm cost`](aasm-cost.md#cmd-aasm-cost) | Query cost summary and forecast spending |
+| [`aasm dashboard`](aasm-dashboard.md#cmd-aasm-dashboard) | Open an interactive TUI dashboard for real-time governance monitoring |
+| [`aasm gateway`](aasm-gateway.md#cmd-aasm-gateway) | Manage the aa-gateway governance daemon — agent registry, policy engine, audit log |
+| [`aasm run`](aasm-run.md#cmd-aasm-run) | Launch an AI dev tool (claude, codex, copilot, windsurf) with governance wiring |
+| [`aasm sandbox`](aasm-sandbox.md#cmd-aasm-sandbox) | Run a WebAssembly tool inside the Agent Assembly sandbox (filesystem + CPU + memory + wall-clock isolation) |
+| [`aasm tools`](aasm-tools.md#cmd-aasm-tools) | List and manage AI dev tools on this system |
+| [`aasm topology`](aasm-topology.md#cmd-aasm-topology) | Visualize agent topology, trees, lineage, and statistics |
+| [`aasm proxy`](aasm-proxy.md#cmd-aasm-proxy) | Manage the aa-proxy sidecar — lifecycle, CA trust, and log tailing |
+| [`aasm start`](aasm-start.md#cmd-aasm-start) | Start the locally-managed Agent Assembly gateway process |
+| [`aasm stop`](aasm-stop.md#cmd-aasm-stop) | Stop the locally-managed Agent Assembly gateway process |
+


### PR DESCRIPTION
## Description

Adds an **`aasm docs export`** subcommand that auto-generates the `aasm` CLI reference from the **live `clap` command tree** — never a hand-maintained list — so the docs cannot drift from the actual CLI surface.

- `aasm docs export --format markdown --out docs/cli/` walks `crate::Cli::command()` recursively (`get_subcommands()`), emitting **one Markdown file per command** with: synopsis (from `about`/`long_about`), usage (clap's own rendered usage, rewritten to the full command path), an **options table** (flags, value placeholders + enumerated possible values, defaults, required markers), a **subcommands** table linking children by stable anchor, and an **examples** block sourced from `#[command(after_help = …)]`.
- Each page carries a **stable anchor** `#cmd-aasm-<path>` (e.g. `#cmd-aasm-agent-list`) for durable cross-links.
- `aasm docs export --check` re-renders in memory and diffs against the on-disk `docs/cli/` tree, exiting **non-zero** (and listing stale / missing / orphaned files) when they differ. This is what CI runs.
- The generated reference (81 files) is committed under `docs/cli/` so `--check` has a baseline.

## Type of Change

- [x] ✨ New feature
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-421

### Deferred follow-up (depends on AAASM-303)

The stretch goal — firing `repository_dispatch` (`event_type: docs-release`, payload `{ tag, paths: ["docs/cli/"] }`) to `agent-assembly-docs` on release — is **deferred to AAASM-303**. The docs-sync infra it depends on is not present in this repo (the only existing `repository_dispatch` wiring in `release.yml` targets the SDK repos with `agent-assembly-release-published`, not a `docs-release` event to `agent-assembly-docs`). Per the ticket, rather than invent cross-repo wiring, the export + `--check` + PR CI job are implemented now and the release-dispatch is left as a dependent follow-up under AAASM-303.

## Testing

- [x] Unit tests added / updated

12 unit tests in `aa-cli/src/commands/docs/export.rs` cover: a page per root + nested command, the `help` pseudo-command being skipped, stable anchor derivation, synopsis/options/subcommands sections, examples surfaced from `after_help`, subcommand links using stable anchors, and `--check` passing on fresh output / failing on modified / missing / orphaned pages.

Validation (scoped to `-p aa-cli` and deps; some workspace crates e.g. eBPF don't build on macOS):

- `cargo build -p aa-cli` — pass
- `cargo clippy -p aa-cli --all-targets -- -D warnings` — clean
- `cargo fmt -p aa-cli --check` — clean
- `cargo nextest run -p aa-cli` — 597 passed (incl. 12 new docs tests)
- `aasm docs export` then `aasm docs export --check` → exit **0** on fresh output; verified exit **1** (listing the exact stale files) when a clap `about` is changed without regenerating.

## CI

New workflow `.github/workflows/cli-reference.yml` builds `aasm` and runs `aasm docs export --check --out docs/cli/` on every PR (and master push) touching `aa-cli/**` or `docs/cli/**`. Note: org GitHub Actions billing has been intermittently blocked, so CI may not execute on this PR — validated locally as above (`actionlint` clean on the workflow).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing — see CI billing caveat above
- [x] Commits are small and follow the Gitmoji convention

Held for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)