### PR TITLE
[AAASM-3000] ♻️ (aa-sdk-client): Make IPC event reporting fire-and-forget

### DIFF
--- a/aa-sdk-client/src/ipc.rs
+++ b/aa-sdk-client/src/ipc.rs
@@ -53,8 +53,13 @@ pub fn spawn_ipc_thread(socket_path: PathBuf) -> Result<IpcHandle, std::io::Erro
 
 /// The async event loop running on the background thread.
 ///
-/// Connects to the runtime socket, sends an initial heartbeat, then
-/// processes commands from the mpsc channel until shutdown.
+/// Connects to the runtime socket, sends an initial heartbeat, then ships event
+/// reports **fire-and-forget** — it does not block waiting for a per-event
+/// acknowledgement. `aa-runtime` does not ack heartbeats or event reports; it
+/// only emits *unsolicited* responses (violation alerts, policy/approval
+/// decisions), which a dedicated reader task drains so the socket never backs
+/// up. Blocking on an ack the runtime never sends would deadlock this loop and
+/// hang `shutdown()` (AAASM-3000).
 async fn ipc_loop(socket_path: PathBuf, mut cmd_rx: mpsc::Receiver<IpcCommand>) {
     use tokio::net::UnixStream;
 
@@ -70,48 +75,51 @@ async fn ipc_loop(socket_path: PathBuf, mut cmd_rx: mpsc::Receiver<IpcCommand>) 
         }
     };
 
-    let (mut reader, mut writer) = tokio::io::split(stream);
+    // Owned halves let the reader run on its own task without racing the writer.
+    let (reader, mut writer) = stream.into_split();
 
-    // Send initial heartbeat to verify connection.
+    // Send the initial heartbeat (fire-and-forget — the runtime does not ack it).
     if let Err(e) = codec::write_heartbeat(&mut writer).await {
         tracing::error!(error = %e, "failed to send initial heartbeat");
         return;
     }
 
-    // Read the Ack response.
-    match codec::read_response(&mut reader).await {
-        Ok(codec::RuntimeResponse::Ack) => {
-            tracing::debug!("connected to aa-runtime, heartbeat acknowledged");
-        }
-        Ok(other) => {
-            tracing::warn!(?other, "unexpected response to heartbeat");
-        }
-        Err(e) => {
-            tracing::error!(error = %e, "failed to read heartbeat ack");
-            return;
-        }
-    }
+    // Drain unsolicited runtime responses on a dedicated task: reads never race
+    // writes (no cancellation hazard) and the connection cannot stall.
+    let reader_task = tokio::spawn(drain_responses(reader));
 
-    // Process commands from the calling thread.
+    // Process commands from the calling thread. Event reports are fire-and-forget.
     while let Some(cmd) = cmd_rx.recv().await {
         match cmd {
             IpcCommand::SendEvent(event) => {
                 if let Err(e) = codec::write_event_report(&mut writer, &event).await {
                     tracing::error!(error = %e, "failed to send event report");
                 }
-                // Read Ack.
-                match codec::read_response(&mut reader).await {
-                    Ok(codec::RuntimeResponse::Ack) => {}
-                    Ok(other) => {
-                        tracing::warn!(?other, "unexpected response to event report");
-                    }
-                    Err(e) => {
-                        tracing::error!(error = %e, "failed to read event report ack");
-                    }
-                }
             }
             IpcCommand::Shutdown => {
                 tracing::debug!("IPC shutdown requested");
+                break;
+            }
+        }
+    }
+
+    reader_task.abort();
+}
+
+/// Continuously read and discard unsolicited responses from the runtime.
+///
+/// `aa-runtime` sends violation alerts and policy/approval decisions
+/// asynchronously. The SDK does not yet act on them, but they must be drained
+/// so the connection does not stall. Exits on EOF or a read error (e.g. the
+/// runtime closing the connection), or when aborted on shutdown.
+async fn drain_responses(mut reader: tokio::net::unix::OwnedReadHalf) {
+    loop {
+        match codec::read_response(&mut reader).await {
+            Ok(response) => {
+                tracing::debug!(?response, "received unsolicited runtime response");
+            }
+            Err(e) => {
+                tracing::debug!(error = %e, "runtime response stream ended");
                 break;
             }
         }

--- a/aa-sdk-client/src/ipc.rs
+++ b/aa-sdk-client/src/ipc.rs
@@ -194,4 +194,68 @@ mod tests {
         // Clean up.
         let _ = std::fs::remove_file(&socket_path);
     }
+
+    /// Regression for AAASM-3000: a runtime that never acks (like the real
+    /// `aa-runtime`, which ignores heartbeats and only emits unsolicited
+    /// responses) must not deadlock the client — events ship fire-and-forget
+    /// and shutdown returns promptly. The pre-fix loop blocked forever reading
+    /// a heartbeat ack that never came, so `shutdown()` hung.
+    #[tokio::test]
+    async fn shutdown_is_clean_when_runtime_never_acks() {
+        use std::time::Duration;
+        use tokio::io::AsyncReadExt;
+        use tokio::net::UnixListener;
+
+        let socket_path = format!("/tmp/aa-test-noack-{}.sock", std::process::id());
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).unwrap();
+
+        // Mock runtime mimicking the real one: read whatever the client sends
+        // and never reply with an ack.
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 1024];
+            while let Ok(n) = stream.read(&mut buf).await {
+                if n == 0 {
+                    break; // client closed the connection
+                }
+            }
+        });
+
+        let mut handle = spawn_ipc_thread(PathBuf::from(&socket_path)).unwrap();
+
+        // Ship several events — fire-and-forget, must not block.
+        for i in 0..5 {
+            let event = aa_proto::assembly::audit::v1::AuditEvent {
+                event_id: format!("evt-{i}"),
+                ..Default::default()
+            };
+            handle
+                .cmd_tx
+                .send(IpcCommand::SendEvent(Box::new(event)))
+                .await
+                .unwrap();
+        }
+
+        // Shutdown must return promptly (pre-fix: hung forever on the ack read).
+        handle.cmd_tx.send(IpcCommand::Shutdown).await.unwrap();
+        let thread = handle.thread.take().unwrap();
+        let joined = tokio::time::timeout(
+            Duration::from_secs(5),
+            tokio::task::spawn_blocking(move || thread.join()),
+        )
+        .await;
+
+        assert!(
+            joined.is_ok(),
+            "IPC thread did not shut down within 5s — deadlock regression (AAASM-3000)"
+        );
+        joined
+            .unwrap()
+            .expect("join task panicked")
+            .expect("IPC thread panicked");
+
+        server.abort();
+        let _ = std::fs::remove_file(&socket_path);
+    }
 }

--- a/verification-reports/AAASM-3000.md
+++ b/verification-reports/AAASM-3000.md
@@ -1,0 +1,61 @@
+# Verification Report: AAASM-3000
+
+**Bug:** [AAASM-3000](https://lightning-dust-mite.atlassian.net/browse/AAASM-3000) — SDK⇄aa-runtime IPC deadlock: client blocks on a heartbeat/event Ack the runtime never sends
+**Verified by:** AAASM-3003
+**Date:** 2026-06-15
+**Status:** ✅ Fixed — `aa-sdk-client` IPC event reporting is now fire-and-forget
+
+---
+
+## Root cause (recap)
+
+`aa-sdk-client/src/ipc.rs` `ipc_loop` was synchronous request/response: it `write_heartbeat` →
+`read_response` (blocked for `TAG_ACK`), and after every `write_event_report` → `read_response`
+(blocked for `TAG_ACK`). But `aa-runtime` never sends those acks — `pipeline/mod.rs:137` ignores
+heartbeats and the server only emits *unsolicited* responses (violation/policy/approval). So the
+background IPC thread blocked at the first read (heartbeat ack), never drained the command channel,
+and `shutdown()`'s `thread.join()` hung forever. No events were delivered.
+
+## Fix (option A — fire-and-forget)
+
+`ipc_loop` now:
+- splits the stream with `into_split()` (owned halves),
+- sends the heartbeat fire-and-forget (no ack read),
+- ships event reports fire-and-forget (write only, no per-event ack read),
+- drains *unsolicited* runtime responses on a **dedicated reader task** (`drain_responses`) so reads
+  never race writes (no cancellation hazard) and the connection can't stall,
+- aborts the reader task on `Shutdown`.
+
+This matches `aa-runtime`'s design (hot-path events are async; only violations/decisions come back).
+Shared `aa-sdk-client` ⇒ fixes the deadlock for **all three SDKs** at once.
+
+## Acceptance criteria
+
+### AC 1 — The deadlock is gone (regression test)
+
+**Status:** ✅ PASS. New test `ipc::tests::shutdown_is_clean_when_runtime_never_acks` stands up a mock
+server that mimics the real runtime (reads frames, **never acks**), ships 5 events fire-and-forget, and
+asserts `shutdown()`/`thread.join()` returns within 5s. The **pre-fix** loop blocked forever here.
+
+```
+PASS [0.010s] aa-sdk-client ipc::tests::shutdown_is_clean_when_runtime_never_acks
+```
+
+### AC 2 — No existing behaviour regressed
+
+**Status:** ✅ PASS. `cargo nextest run -p aa-sdk-client` → **27 passed, 0 failed** (incl. the existing
+`ipc_loop_with_mock_server` and `lifecycle_e2e::client_ships_event_to_mock_runtime_and_shuts_down`).
+
+### AC 3 — Style/lint clean
+
+**Status:** ✅ PASS. `cargo fmt -p aa-sdk-client --check` clean; lefthook `fmt` + `clippy` (workspace,
+`-D warnings`) green on both commits.
+
+## End-to-end note
+
+The defect was originally reproduced end-to-end in `agent-assembly-integration-tests`
+(`tests/live/test_sdk_runtime.py`, AAASM-2989 PR #60), where the real `agent_assembly._core` against a
+real `aa-runtime` hung on `close()` — marked `xfail`. With this fix, once the SDKs' `aa-sdk-client`
+git-SHA pin is advanced to include this commit and `_core` is rebuilt, that test flips `XPASS` (the
+designed signal). The unit regression test above proves the fix at the contract level (a non-acking peer
+no longer deadlocks shutdown), which is the exact failure mode.


### PR DESCRIPTION
## Description

Fixes a **deadlock between every SDK and `aa-runtime`** (AAASM-3000), discovered by the re-oriented
with-core integration harness ([integration-tests #60](https://github.com/ai-agent-assembly/agent-assembly-integration-tests/pull/60), AAASM-2989).

`aa-sdk-client/src/ipc.rs` `ipc_loop` was synchronous request/response: it blocked on `read_response`
after the heartbeat **and after every event report**, waiting for a `TAG_ACK`. But `aa-runtime` never
sends those acks — `aa-runtime/src/pipeline/mod.rs:137` ignores heartbeats, and the server only emits
*unsolicited* responses (violation/policy/approval). So the background IPC thread blocked at the very
first read (the heartbeat ack), never drained the command channel, and `shutdown()`'s `thread.join()`
hung forever — **no audit events were delivered, and SDK shutdown hung**. Shared `aa-sdk-client` ⇒ this
affected python, node, and go.

Neither side's own tests caught it: the SDK/`_core` tests use a **mock server that acks** a protocol the
real runtime doesn't implement; the runtime's tests only assert frames arrive on the inbound channel.

### Fix (option A — fire-and-forget, matches the audit design)

`ipc_loop` now splits the stream with `into_split()`, sends the heartbeat and event reports
**fire-and-forget** (no per-write ack read), and drains *unsolicited* runtime responses on a **dedicated
reader task** so reads never race writes and the connection can't stall; the reader is aborted on
`Shutdown`. This matches the reference architecture (hot-path events are async; only violations/decisions
come back).

## Type of Change

- [x] 🐛 Bug fix
- [x] ♻️ Refactoring (IPC loop restructured)

## Breaking Changes

- [x] No — behaviour-only fix; the IPC wire protocol and public API are unchanged (event reporting was
  already async/fire-and-forget at the `AssemblyClient` API; this removes the internal blocking ack read
  that deadlocked against the real runtime).

## Related Issues

- Related Jira ticket: AAASM-3000 (subtasks AAASM-3001/3002/3003); surfaced by AAASM-2989

## Testing

- [x] Unit tests added — `ipc::tests::shutdown_is_clean_when_runtime_never_acks`: a mock server that
  mimics the real runtime (reads frames, **never acks**); ships 5 events and asserts `shutdown()` returns
  within 5s. Pre-fix this hung forever.
- [x] `cargo nextest run -p aa-sdk-client` → **27 passed, 0 failed** (incl. the existing
  `ipc_loop_with_mock_server` and `lifecycle_e2e` integration test)
- [x] lefthook `fmt` + `clippy` (`-D warnings`) green on every commit; pre-push `cargo doc` green

> The original end-to-end repro lives in integration-tests `tests/live/test_sdk_runtime.py` (xfail). Once
> the SDKs' `aa-sdk-client` SHA pin advances past this commit and `_core` is rebuilt, that test flips
> `XPASS` — the designed signal.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Verification report added (`verification-reports/AAASM-3000.md`)
- [x] Commits are small and follow the Gitmoji convention (3 commits: fix / test / report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)