### PR TITLE
[AAASM-427] 📝 (docs): Contributing guide refinements + Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <security@agent-assembly.dev>. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,23 +57,49 @@ on; the faster linker is opt-in.
 
 ## Branch Naming
 
+Branch names have four parts:
+
 ```
-<version>/<ticket-number>/<short-summary>
+<release-or-phase>/<ticket-number>/<type>/<short-summary>
 ```
 
-Example: `v0.0.1/AAASM-42/add_agent_registry`
+- `<release-or-phase>` — milestone or sprint identifier (e.g. `v0.0.1`, `phase1`)
+- `<ticket-number>` — the Jira ticket reference (e.g. `AAASM-42`)
+- `<type>` — one of `feat`, `fix`, `refactor`, `test`, `docs`, `config`, `deps`, `remove`, `lint`
+- `<short-summary>` — 2–4 words from the ticket title in `snake_case`
+
+Example: `v0.0.1/AAASM-42/feat/add_agent_registry`
 
 ## Commit Style
 
-Use [Gitmoji](https://gitmoji.dev/) prefixed messages:
+Commit messages follow [Gitmoji](https://gitmoji.dev/)-prefixed
+[Conventional Commits](https://www.conventionalcommits.org/):
 
 ```
 <emoji> (<scope>): <imperative summary>
 ```
 
-**One commit per logical unit** — one new file, one property change, one function. Keep commits small and bisectable.
+- `<emoji>` — a [Gitmoji](https://gitmoji.dev/) marking the change category
+  (see the table below)
+- `<scope>` — the affected crate or area (e.g. `aa-core`, `ci`, `docs`)
+- `<imperative summary>` — imperative mood, under 72 characters
+
+| Emoji | Category | Conventional type |
+|---|---|---|
+| ✨ | New feature | `feat` |
+| 🐛 | Bug fix | `fix` |
+| ♻️ | Refactor (no behaviour change) | `refactor` |
+| ✅ | Tests | `test` |
+| 📝 | Documentation | `docs` |
+| 🔧 | Configuration / CI | `config` / `ci` |
+| ⬆️ | Dependency upgrade | `deps` |
+| 🗑️ | Deletion / removal | `remove` |
+| 🚨 | Lint / type-error fix | `style` |
+
+**One commit per logical unit** — one new file, one property change, one function. Keep commits small and bisectable so a reviewer can follow each step.
 
 Examples:
+
 - `✨ (aa-core): Add AgentId newtype wrapper`
 - `🐛 (aa-gateway): Fix policy evaluation order for overlapping rules`
 - `🔧 (ci): Add matrix build for MSRV check`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,14 @@
 
 Thank you for your interest in contributing! This guide explains how to set up your environment and submit changes.
 
+By participating in this project you agree to abide by our
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+For the fastest path from a fresh clone to a verified local environment, follow
+the [Quickstart in the README](README.md#quickstart) (`make dev-setup` +
+`make dev-verify`). The sections below cover the manual setup and the
+day-to-day contribution workflow in more detail.
+
 ## Prerequisites
 
 - **Rust stable** (≥ 1.75) — install via [rustup](https://rustup.rs/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,8 +220,13 @@ Mermaid diagrams use the `mdbook-mermaid` preprocessor, which is wired in `docs/
 
 ## Reporting Issues
 
-Use the GitHub issue templates:
-- **Bug report** — reproducible steps, expected vs actual behaviour, environment.
-- **Feature request** — motivation, proposed solution, alternatives considered.
+File issues through the GitHub issue templates so they capture the detail
+maintainers need to act:
 
-For security issues, see [SECURITY.md](SECURITY.md).
+- [**Bug report**](.github/ISSUE_TEMPLATE/bug_report.md) — reproducible steps, expected vs actual behaviour, environment.
+- [**Feature request**](.github/ISSUE_TEMPLATE/feature_request.md) — motivation, proposed solution, alternatives considered.
+
+Search [existing issues](https://github.com/ai-agent-assembly/agent-assembly/issues) before opening a new one to avoid duplicates.
+
+**Do not** open a public issue for a security vulnerability — see
+[SECURITY.md](SECURITY.md) for the private disclosure process.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,11 +128,27 @@ To add a new crate to the workspace:
 
 ## Pull Requests
 
-- Open a PR against `master`.
+- Open a PR against `master` — never against another feature branch (stacked
+  branches are fine for local development, but every PR targets `master`).
 - Title format: `[<ticket>] <emoji> (<scope>): <summary>`
-- Fill in the PR template — all checklist items must be addressed.
+- Fill in the [PR template](.github/PULL_REQUEST_TEMPLATE.md) — all checklist items must be addressed.
+- Keep PRs focused: one concern per PR, ideally under 500 lines of diff.
 - CI must be green before review is requested.
 - At least **1 approval** from the Pioneer team is required to merge.
+
+## Code Review
+
+What to expect during review, as both an author and a reviewer:
+
+- **Reviewers** look for correctness, test coverage, adherence to the
+  architecture, and the commit conventions above — not style nits that the
+  automated hooks already enforce.
+- **Authors** should respond to every comment (resolve it or explain why not),
+  re-request review after pushing changes, and avoid force-pushing while a
+  review is in progress so reviewers can see incremental diffs.
+- A PR merges only once all blocking comments are resolved, CI is green, and a
+  Pioneer-team approval is present. The merge strategy is squash for feature
+  PRs and rebase for dependency bumps.
 
 ## Developer Certificate of Origin (DCO)
 


### PR DESCRIPTION
## Description

Refines the root `CONTRIBUTING.md` and fills the previously-empty
`CODE_OF_CONDUCT.md` so the project has complete, accurate contributor
governance docs. Implements **AAASM-427**.

- **`CONTRIBUTING.md`** — kept all existing good content; added/expanded:
  issue reporting (with template links), four-part branch naming
  (`<release>/<ticket>/<type>/<summary>`), commit conventions aligned to
  **Conventional Commits + GitEmoji** (with a category table), the PR
  process (always base `master`, links the PR template), a new **Code
  Review** section (author/reviewer expectations, merge criteria, squash
  vs rebase), the **DCO sign-off** requirement (already present, kept),
  and a link to the README Quickstart for local-dev setup.
- **`CODE_OF_CONDUCT.md`** — the **unmodified Contributor Covenant 2.1**,
  with the enforcement contact substituted to `security@agent-assembly.dev`.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-427

## Testing

- [x] No tests required (documentation-only change)
- `markdownlint-cli2` against the repo `.markdownlint.json`: **0 errors** on both files.
- `lychee --offline`: **0 errors** (all internal links — Code of Conduct, README#quickstart, PR/issue templates, SECURITY.md, LICENSE — resolve).

## Checklist

- [x] Code follows project style guidelines (markdownlint clean)
- [x] Self-review of the diff completed
- [x] Documentation updated
- [x] All CI checks passing (mdBook build / commands — markdown-only)
- [x] Commits are small and follow the Gitmoji convention (5 atomic commits, DCO signed-off)

## Follow-up (dependent, not in scope)

Aggregation of these files to the docs site `/contributing/` page via
`repository_dispatch` depends on the **AAASM-302** docs-sync workflow,
which is **not yet present** in the repo. Noted here rather than invented.
