### PR TITLE
[AAASM-3006] 🤖 (release): Extend SDK pin-bumper fan-out to go-sdk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -713,11 +713,16 @@ jobs:
           event-type: agent-assembly-release-published
           client-payload: '{"release_tag": "${{ github.ref_name }}"}'
 
-      # go-sdk intentionally NOT dispatched: pure-Go module, no aasm
-      # binary consumption in its release pipeline (`goreleaser.yaml`
-      # is a check-only workflow; Go module proxy auto-indexes from
-      # git tags directly). Add a dispatch step here if that ever
-      # changes.
+      # go-sdk intentionally NOT dispatched from this job: pure-Go
+      # module, no `aasm-*` binary consumption in its release pipeline
+      # (`goreleaser.yaml` is a check-only workflow; Go module proxy
+      # auto-indexes from git tags directly). Add a dispatch step here
+      # if that ever changes.
+      #
+      # NOTE: this exclusion is scoped to BINARY-PUBLISH RACE
+      # COORDINATION only. go-sdk's `aa-sdk-client` Cargo git-SHA pin
+      # is still kept in lockstep with each release via the dedicated
+      # `update-go-sdk-ffi-pin` job above (AAASM-3006).
 
   release-status-aggregator:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -586,6 +586,90 @@ jobs:
             Upstream tag: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}
             Source workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
+  update-go-sdk-ffi-pin:
+    # AAASM-3006: after every tag push, open a PR on go-sdk that bumps
+    # native/aa-ffi-go/Cargo.toml's `aa-sdk-client` git-SHA pin to the
+    # exact commit this release was cut from. Extends AAASM-2883's
+    # node-sdk + python-sdk fan-out to go-sdk, which had been doing the
+    # bump manually (AAASM-3005 closed the v0.0.1-beta.2 lag) — go-sdk
+    # consumes `aa-sdk-client` through the same Cargo git-SHA pin
+    # mechanism as node-sdk's aa-ffi-node and drifts the same way
+    # without this automation.
+    #
+    # Mirrors `update-node-sdk-ffi-pin` (single-pin path) rather than
+    # `update-python-sdk-ffi-pin` (three-pin path) because aa-ffi-go's
+    # Cargo.toml carries only the single `aa-sdk-client` direct dep —
+    # aa-core / aa-proto arrive transitively, same shape as aa-ffi-node.
+    name: Update go-sdk aa-ffi-go pin
+    runs-on: ubuntu-latest
+    needs: publish
+    if: github.event_name == 'push'
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout go-sdk
+        uses: actions/checkout@v6
+        with:
+          repository: ai-agent-assembly/go-sdk
+          token: ${{ secrets.GO_SDK_BOT_TOKEN }}
+          path: sdk
+
+      - name: Rewrite native/aa-ffi-go/Cargo.toml aa-sdk-client rev
+        shell: bash
+        env:
+          NEW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          cd sdk
+          # Match the literal `aa-sdk-client = { git = "...", rev = "<40-hex>"`
+          # prefix and rewrite only the rev value. We don't need to know the
+          # old SHA ahead of time; the regex anchors on the surrounding tokens.
+          sed -i -E 's|(aa-sdk-client = \{ git = "[^"]*", rev = )"[0-9a-f]{40}"|\1"'"${NEW_SHA}"'"|' \
+            native/aa-ffi-go/Cargo.toml
+          grep -q "rev = \"${NEW_SHA}\"" native/aa-ffi-go/Cargo.toml \
+            || { echo "::error::aa-sdk-client rev rewrite produced unexpected result"; exit 1; }
+          git -C . diff -- native/aa-ffi-go/Cargo.toml || true
+
+      - name: Regenerate native/aa-ffi-go/Cargo.lock for the new pin
+        shell: bash
+        env:
+          NEW_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          cd sdk
+          # AAASM-2959: re-resolve the lock so it matches the just-rewritten
+          # Cargo.toml rev. go-sdk pins only aa-sdk-client; its transitive
+          # aa-core/aa-proto from the same git source update with it. This only
+          # re-resolves the lock (no compile), so cargo alone suffices.
+          cargo update --manifest-path native/aa-ffi-go/Cargo.toml \
+            -p aa-sdk-client --precise "${NEW_SHA}"
+          git -C . diff -- native/aa-ffi-go/Cargo.lock || true
+
+      - name: Open SDK pin-bump PR via peter-evans/create-pull-request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          path: sdk
+          token: ${{ secrets.GO_SDK_BOT_TOKEN }}
+          branch: bot/aa-ffi-pin-${{ github.ref_name }}
+          base: master
+          delete-branch: true
+          commit-message: "🤖 (aa-ffi-go): Bump aa-sdk-client pin to ${{ github.ref_name }}"
+          title: "🤖 (aa-ffi-go): Bump aa-sdk-client pin to ${{ github.ref_name }}"
+          body: |
+            Auto-bump `aa-sdk-client` git-SHA pin in `native/aa-ffi-go/Cargo.toml`
+            to track agent-assembly release `${{ github.ref_name }}` (commit
+            `${{ github.sha }}`).
+
+            Why: without this PR, the SDK source pin drifts behind the published
+            agent-assembly binaries (AAASM-2880 observed an 8-day drift behind
+            alpha-9; AAASM-3005 closed the equivalent lag on go-sdk for
+            v0.0.1-beta.2). Merging this PR on `go-sdk` realigns the native
+            shim with the matching upstream tag.
+
+            Upstream tag: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}
+            Source workflow: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
   notify-downstream:
     # Cross-repo trigger: after agent-assembly's Release object is
     # published (binaries available on the GH Release page), fire a


### PR DESCRIPTION
## Summary

Extends AAASM-2883's SDK pin-bumper fan-out to **go-sdk**. After this lands, every `agent-assembly` tag push opens **three** auto-PRs (node-sdk, python-sdk, go-sdk) bumping each SDK's `aa-sdk-client` Cargo git-SHA pin to the matching tag commit — closing the gap where go-sdk required a manual ticket every release (most recently [AAASM-3005](https://lightning-dust-mite.atlassian.net/browse/AAASM-3005), shipped for v0.0.1-beta.2 earlier today).

## Why this is the right shape

`release.yml` already has TWO logically-separate downstream concerns:

| Job | Purpose | go-sdk needs? |
|---|---|---|
| `notify-downstream` (l.589 pre-PR) | Binary-publish race coordinator — `repository_dispatch` so node/python's `release-*.yml` know `aasm-*.tar.gz` is downloadable | ❌ no — pure-Go module, no aasm binary consumption (Go proxy auto-indexes from git tags) |
| `update-node-sdk-ffi-pin` (l.426) + `update-python-sdk-ffi-pin` (l.503) | SHA-pin auto-bump | ✅ yes — `aa-ffi-go/Cargo.toml` carries the same pin shape and drifts the same way |

The exclusion comment in `notify-downstream` was correct for that job's scope but easy to misread as "go-sdk has no fan-out at all". This PR adds the missing pin-bumper AND clarifies the exclusion comment so the two scopes can't be conflated by future readers.

## Content delta

Two granular commits, one concern each:

1. **`61d3d19e` ✨ (release): Add update-go-sdk-ffi-pin pin-bumper job**
   New 84-line job, byte-for-byte mirror of `update-node-sdk-ffi-pin` with these swaps:
   - `repository: ai-agent-assembly/go-sdk`
   - `token: ${{ secrets.GO_SDK_BOT_TOKEN }}` (new secret — see operator step below)
   - `native/aa-ffi-go/Cargo.toml` instead of `native/aa-ffi-node/Cargo.toml`
   - `🤖 (aa-ffi-go): ...` in commit-message + PR title
   Mirrors the single-pin path (not python's three-pin path) because `aa-ffi-go` pins only `aa-sdk-client` directly.

2. **`0e9bb127` 📝 (release): Disambiguate notify-downstream go-sdk exclusion comment**
   Tightens the existing "go-sdk intentionally NOT dispatched" comment to make explicit that the exclusion is scoped to **binary-publish race coordination only**, with a pointer to the new `update-go-sdk-ffi-pin` job for the SHA-pin half.

Net: +94 / −5 lines, single file (`.github/workflows/release.yml`).

## Acceptance criteria

- [x] New `update-go-sdk-ffi-pin` job exists in `.github/workflows/release.yml`
- [x] Job mirrors `update-node-sdk-ffi-pin`: `needs: publish`, `if: github.event_name == 'push'`, checkout → sed rewrite → `cargo update -p aa-sdk-client --precise` → `peter-evans/create-pull-request@v8`
- [x] Branch name: `bot/aa-ffi-pin-${{ github.ref_name }}`, base `master`, `delete-branch: true`
- [x] Commit message + PR title: `🤖 (aa-ffi-go): Bump aa-sdk-client pin to ${{ github.ref_name }}`
- [x] Uses new secret `GO_SDK_BOT_TOKEN` (operator step — see below)
- [x] `notify-downstream` comment block updated to disambiguate the two go-sdk exclusion scopes
- [x] `actionlint -shellcheck= .github/workflows/release.yml` clean (pre-existing SC2046 on line 97 in the Apple notarization keychain code is unchanged, present on `master` too)
- [x] PR opened against `master`

## Out of scope

- `assembly/version.go` constant bump on go-sdk — same as how node-sdk's `package.json` and python-sdk's `pyproject.toml` are NOT bumped by their respective auto-PRs. Version cadence stays a per-SDK operator concern.
- go-sdk tag push (`v0.0.1-beta.X`) — same precedent.
- `notify-downstream` itself — unchanged behaviour (go-sdk's exclusion from binary-race coordination remains correct).

## Operator step (BEFORE the next tag push)

Provision a new repo secret `GO_SDK_BOT_TOKEN` on `ai-agent-assembly/agent-assembly`:
- Scopes: `contents: write` + `pull_requests: write` on `ai-agent-assembly/go-sdk`
- Mirrors how `NODE_SDK_BOT_TOKEN` / `PYTHON_SDK_BOT_TOKEN` are scoped to their respective target SDKs.

Without this secret, the new `update-go-sdk-ffi-pin` job will fail at the checkout step (token unset). The other two pin jobs and `notify-downstream` are unaffected (they use their own tokens).

## Test plan

- [x] `actionlint -shellcheck= .github/workflows/release.yml` clean
- [x] `python3 -c "import yaml; yaml.safe_load(open('...'))"` parses
- [ ] **Live verification**: after `GO_SDK_BOT_TOKEN` is provisioned + the next `v*` tag is pushed, a `bot/aa-ffi-pin-<tag>` branch + PR should appear on `ai-agent-assembly/go-sdk` matching the shape of the existing AAASM-2883 node/python PRs (#137 / #125 for v0.0.1-beta.2).
- [ ] CI on this PR green.

## Reference

- [AAASM-3006](https://lightning-dust-mite.atlassian.net/browse/AAASM-3006) — this ticket
- [AAASM-2880](https://lightning-dust-mite.atlassian.net/browse/AAASM-2880) — parent ticket "Auto-PR SDK source-pin bumps on core release to fix 8-day drift" (Done)
- [AAASM-2883](https://lightning-dust-mite.atlassian.net/browse/AAASM-2883) — original pin-bumper for node-sdk + python-sdk (Done)
- [AAASM-3005](https://lightning-dust-mite.atlassian.net/browse/AAASM-3005) — go-sdk v0.0.1-beta.3 manual bump that this ticket renders auto for future releases
- [ADR 0002 / AAASM-2559](https://lightning-dust-mite.atlassian.net/browse/AAASM-2559) — single-SHA invariant (already satisfied for go-sdk since it pins only one direct dep)

Closes #AAASM-3006

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-3005]: https://lightning-dust-mite.atlassian.net/browse/AAASM-3005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AAASM-3006]: https://lightning-dust-mite.atlassian.net/browse/AAASM-3006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ