### PR TITLE
[AAASM-3007] 📝 (release-tag-cut): Add downstream SDK coordination SOP

### DIFF
--- a/.claude/skills/release-tag-cut/EXAMPLES.md
+++ b/.claude/skills/release-tag-cut/EXAMPLES.md
@@ -112,3 +112,45 @@ JOBS
 
 At this point the skill is done. The remainder of the release flow runs
 inside `release.yml` and is verified by `/release-validate-channels`.
+
+## Downstream SDK verification (after `git push remote v<X>`)
+
+> The tag-cut skill ends at the push above. Before dispatching any SDK
+> release workflow for the matching version, the operator MUST verify the
+> downstream fan-out completed per the SOP in `SKILL.md` § "Downstream SDK
+> coordination" (AAASM-3007).
+
+**1. Confirm `notify-downstream` and the three pin-bumper jobs ran green.**
+
+```bash
+$ RUN_ID=$(gh run list --repo ai-agent-assembly/agent-assembly --workflow release.yml \
+    --branch v0.0.1-alpha.10 --limit 1 --json databaseId --jq '.[0].databaseId')
+
+$ gh api "repos/ai-agent-assembly/agent-assembly/actions/runs/$RUN_ID/jobs" \
+    --jq '.jobs[] | {name, conclusion}'
+# Each of these jobs MUST be conclusion: success before proceeding:
+#   "Notify downstream SDK repos"             (AAASM-2336)
+#   "Update node-sdk aa-ffi-node pin"         (AAASM-2883)
+#   "Update python-sdk aa-ffi-python pin"     (AAASM-2883)
+#   "Update go-sdk aa-ffi-go pin"             (AAASM-3006)
+```
+
+**2. Confirm the `bot/aa-ffi-pin-v<X>` PR was opened on each SDK.**
+
+```bash
+$ for repo in node-sdk python-sdk go-sdk; do
+    echo "--- $repo ---"
+    gh pr list --repo ai-agent-assembly/$repo --head bot/aa-ffi-pin-v0.0.1-alpha.10 \
+      --json number,title,mergedAt
+  done
+# Each repo should show exactly one PR matching the branch. If any is
+# missing, investigate the corresponding pin-bumper job before proceeding.
+```
+
+**3. Wait until each auto-bump PR is reviewed + merged.**
+
+Only after all three (or two, if go-sdk is out of scope this cycle) have
+merged is the SDK side allowed to dispatch its release workflow for `v<X>`.
+Pre-dispatching against the previous agent-assembly content burns the
+npm / PyPI version slot and ships stale code to users — see AAASM-3007 for
+the 2026-06-15 incident that motivated this gate.

--- a/.claude/skills/release-tag-cut/SKILL.md
+++ b/.claude/skills/release-tag-cut/SKILL.md
@@ -48,6 +48,23 @@ Pick a different path in any of the following cases:
 - **Pre-conditions not met** — if `master` is dirty, behind `remote/master`,
   or has a red CI run, stop and surface the gap to the operator.
 
+## Downstream SDK coordination
+
+After this skill ends (`git push remote v<X>`), agent-assembly's `release.yml` will publish the GitHub Release and fire two automation jobs:
+
+- `notify-downstream` — `repository_dispatch` so node-sdk and python-sdk know `aasm-*` binaries are downloadable (AAASM-2336).
+- `update-{node|python|go}-sdk-ffi-pin` — opens an auto-bump PR on each SDK that aligns the `aa-sdk-client` git-SHA pin on master with this tag's commit (AAASM-2883 + AAASM-3006).
+
+### Operator rule for the SDK side (codified in each SDK's `sdk-only-release` skill — AAASM-3007)
+
+Until **all three** of the following are true for this tag, operators MUST NOT dispatch the SDK release workflows (`release-node.yml` or `release-python.yml`) for the matching version:
+
+1. agent-assembly's `Release` workflow has reached the `notify-downstream` step.
+2. The auto-bump PR (`bot/aa-ffi-pin-v<X>`) has been opened on each SDK repo.
+3. The auto-bump PR has been reviewed and merged.
+
+Pre-dispatching the SDK release with `npm_version=<X>` / `pypi_version=<X>` against the previous agent-assembly release content burns the version slot on npm + PyPI and ships stale content to users. See AAASM-3007 for the 2026-06-15 incident that motivated this SOP.
+
 ## How to use
 
 **Invocation**:


### PR DESCRIPTION
## Summary

Codifies the upstream-side ordering rule between an agent-assembly tag cut and the downstream SDK release dispatch. Adds a new `## Downstream SDK coordination` section to `.claude/skills/release-tag-cut/SKILL.md`, placed between `## When NOT to use` and `## How to use` so operators encounter the SDK-side gate before the procedural steps.

The new section explains:

- After `git push remote v<X>`, `release.yml` fires `notify-downstream` (AAASM-2336) and opens `update-{node|python|go}-sdk-ffi-pin` auto-bump PRs (AAASM-2883 + AAASM-3006) on each SDK.
- Operators MUST NOT dispatch `release-node.yml` / `release-python.yml` for the matching version until: (1) `Release` reaches `notify-downstream`, (2) the `bot/aa-ffi-pin-v<X>` PR is opened on the SDK repo, (3) that PR is reviewed and merged.
- Pre-dispatching against the previous tag's content burns the npm / PyPI version slot and ships stale code.

## Motivation — 2026-06-15 incident

- 02:21 UTC — `0.0.1-beta.2` pre-dispatched on `release-node.yml` and `release-python.yml` against the previous agent-assembly release content. npm + PyPI accepted and published the stale slot.
- 09:36 UTC — agent-assembly's actual `notify-downstream` for `0.0.1-beta.2` fired with the real new content. The SDK release workflow refused to re-publish under the burned version label; the new content was effectively unshipable under `0.0.1-beta.2`.
- AAASM-3007 was opened to track making this ordering rule discoverable to the operator at every entry point — both the agent-assembly tag-cut skill and each SDK's `sdk-only-release` skill.

## AAASM-3007 — three-PR coordination

This PR is one of three sibling PRs that share the same SOP wording. Reviewers should diff the inserted block across all three to confirm wording parity:

- `agent-assembly` (this PR) — adds `## Downstream SDK coordination` to `release-tag-cut`.
- `node-sdk` — adds `## Release-coordination SOP — when agent-assembly is ALSO releasing` to `sdk-only-release`.
- `python-sdk` — adds `## Release-coordination SOP — when agent-assembly is ALSO releasing` to `sdk-only-release`.

Reference: AAASM-3007 (https://lightning-dust-mite.atlassian.net/browse/AAASM-3007).

## Test Plan

- [x] `SKILL.md` still parses as valid Markdown (frontmatter intact, no duplicated section titles).
- [x] The new section sits between `## When NOT to use` and `## How to use`; existing skill flow (Pre-conditions → Executable plan → Post-conditions) is unchanged.
- [x] No procedural step in the existing executable plan was modified; the SOP is documentation-only and does not alter the skill's command sequence.
- [x] Worktree pushed with `LEFTHOOK=0` to bypass the macOS-incompatible `cargo doc` pre-push hook (documented project workaround); pre-commit hooks (fmt / clippy / deny) skipped because no Rust files staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)