### PR TITLE
[AAASM-2031] 📝 (docs): Document dual-URL SDK convention

### DIFF
--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -105,6 +105,68 @@ A runtime version may support multiple protocol versions to allow SDK upgrades w
 
 ---
 
+## Dual-URL SDK configuration
+
+Starting with the v0.0.1 SDK line, every SDK accepts **two** endpoint fields so
+a single install can target either a single-host OSS deployment or a split
+enterprise deployment (gRPC gateway and HTTP control plane on different hosts).
+
+| Field (Python / Node / Go) | What it addresses | Scheme |
+|---|---|---|
+| `gateway_url` / `gatewayUrl` / `WithGatewayURL` | gRPC endpoint of the gateway | `host:port`, no scheme |
+| `control_plane_url` / `controlPlaneUrl` / `WithControlPlaneURL` | HTTP base URL for the control plane — `aa-api` (OSS) or the FastAPI cloud (enterprise) | full URL with scheme |
+
+The HTTP control plane serves agent registration, policy checks, and topology
+edges (`POST /agents/{id}/register`, `POST /agents/{id}/policy/check`,
+`POST /topology/edges`). The gRPC transport carries the streaming op-control,
+lifecycle, audit, and approval flows and always reads `gateway_url`.
+
+### Backwards-compatible default
+
+`control_plane_url` is **optional**. When it is not set, each SDK defaults it to
+the resolved `gateway_url`, so a single-host OSS dev install keeps working with
+only one endpoint configured — the pre-feature behaviour is preserved exactly.
+It only needs a distinct value when the HTTP control plane and the gRPC gateway
+live on separate hosts (the production enterprise topology).
+
+### Resolution order and environment variables
+
+Each field resolves as **explicit init argument > environment variable > unset**:
+
+| Field | Environment variable |
+|---|---|
+| `gateway_url` / `gatewayUrl` / `WithGatewayURL` | `AA_GATEWAY_URL` |
+| `control_plane_url` / `controlPlaneUrl` / `WithControlPlaneURL` | `AA_CONTROL_PLANE_URL` |
+
+If `control_plane_url` is still unset after this chain, it falls back to
+`gateway_url` as described above.
+
+### Per-SDK notes
+
+- **Python** ([AAASM-2028](https://lightning-dust-mite.atlassian.net/browse/AAASM-2028)) —
+  `control_plane_url` is a keyword argument on `init_assembly`, threaded into
+  `GatewayClient` (httpx). The gRPC path (`op_control`) continues to read
+  `gateway_url`.
+- **Node** ([AAASM-2029](https://lightning-dust-mite.atlassian.net/browse/AAASM-2029)) —
+  `controlPlaneUrl` is an optional field on `AssemblyConfig`. When set, the
+  gateway client routes its HTTP traffic at it; the gRPC transport
+  (`op-control`) keeps using `gatewayUrl`.
+- **Go** ([AAASM-2030](https://lightning-dust-mite.atlassian.net/browse/AAASM-2030)) —
+  `assembly.WithControlPlaneURL` stores the value on the runtime options for
+  parity with the other SDKs. The Go SDK has no HTTP control-plane caller today
+  (lifecycle is delegated to the `aasm` runtime), so the field is in place ready
+  for the first HTTP caller; gRPC dial behaviour is unchanged.
+
+### Authoritative strategy source
+
+The enterprise-vs-OSS connectivity strategy — why the second field exists, the
+transport split, and the per-SDK survey — is owned by
+`agent-assembly-enterprise/docs/sdk-compatibility.md` (filed under AAASM-1953).
+This section documents the OSS-visible surface of that convention; the
+enterprise doc is the authoritative source for the strategy.
+
+---
+
 ## CI Enforcement
 
 A CI check (`compat-matrix-check`) enforces that this file is updated whenever version-carrying files change in a pull request.


### PR DESCRIPTION
## Description

Adds a **"Dual-URL SDK configuration"** section to `docs/src/compatibility.md` documenting the OSS-visible surface of the dual-URL SDK config convention introduced for enterprise deployments. The section covers:

- `gateway_url` / `gatewayUrl` / `WithGatewayURL` — gRPC endpoint of the gateway (`host:port`, no scheme).
- `control_plane_url` / `controlPlaneUrl` / `WithControlPlaneURL` — HTTP base URL for the control plane (`aa-api` on OSS, FastAPI cloud on enterprise).
- The **backwards-compatible default**: when `control_plane_url` is unset, each SDK defaults it to the resolved `gateway_url`, preserving single-host OSS dev behaviour exactly.
- The `AA_GATEWAY_URL` / `AA_CONTROL_PLANE_URL` env-var fallbacks and the consistent **explicit arg > env-var > unset** resolution order.
- Per-SDK notes grounded in the merged SDK code.
- A cross-link to the authoritative strategy source: `agent-assembly-enterprise/docs/sdk-compatibility.md` (AAASM-1953).

The field names and semantics are grounded in the merged SDK implementations: Python `control_plane_url` kwarg on `init_assembly` threaded into `GatewayClient`; Node `controlPlaneUrl` on `AssemblyConfig` routing the gateway client's HTTP traffic; Go `assembly.WithControlPlaneURL` stored on runtime options for config-shape parity (no Go HTTP caller yet). All three read `AA_CONTROL_PLANE_URL` as the env fallback; the gRPC transport in every SDK keeps reading `gateway_url`.

## Type of Change

- [x] 📝 Documentation update

## Breaking Changes

- [x] No

Docs-only, additive section. No code, API, protocol, or version change.

## Related Issues

- Related Jira ticket: AAASM-2031
- SDK follow-ups documented (all merged/Done): AAASM-2028 (python-sdk), AAASM-2029 (node-sdk), AAASM-2030 (go-sdk)
- Source strategy: AAASM-1953 (`agent-assembly-enterprise/docs/sdk-compatibility.md`)

## Testing

- [x] No tests required (explain why)

Documentation-only change. Validation performed:
- `markdownlint-cli2 docs/src/compatibility.md` — 0 new errors (the 3 pre-existing MD032 errors on the Legend / CI-Enforcement lists are unchanged and out of scope; the new section is clean).
- `lychee --offline docs/src/compatibility.md` — 0 errors (3 external Jira URLs excluded under `--offline`).
- `mdbook build docs` — succeeds.
- `compat-matrix-check` gate satisfied: the PR edits `docs/src/compatibility.md` itself, and the change is additive (no workspace member / version change).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`) — N/A, docs only
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)