### PR TITLE
[AAASM-3033] 📝 (docs): AA_* canonical / AAASM_* deprecated env prefix

### DIFF
--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -141,6 +141,22 @@ Each field resolves as **explicit init argument > environment variable > unset**
 If `control_plane_url` is still unset after this chain, it falls back to
 `gateway_url` as described above.
 
+#### Canonical `AA_*` prefix and the deprecated `AAASM_*` alias
+
+`AA_*` is the **canonical** environment-variable prefix across all SDKs —
+`AA_GATEWAY_URL`, `AA_CONTROL_PLANE_URL`, and `AA_API_KEY`. New configuration
+should always use this prefix.
+
+The legacy **`AAASM_*`** prefix — used by the older zero-config gateway resolver
+in each SDK — is a **deprecated alias**. It is still honoured for
+backwards-compatibility, but reading a value from an `AAASM_*` variable emits a
+deprecation warning, and the alias will be removed in a future major version.
+Migrate to the `AA_*` names.
+
+This prefix reconciliation is tracked across the SDKs under
+[AAASM-3019](https://lightning-dust-mite.atlassian.net/browse/AAASM-3019);
+sibling subtasks update the Python, Node, and Go resolvers.
+
 ### Per-SDK notes
 
 - **Python** ([AAASM-2028](https://lightning-dust-mite.atlassian.net/browse/AAASM-2028)) —


### PR DESCRIPTION
## Description

Updates the **Dual-URL SDK configuration** section in `docs/src/compatibility.md` to document the env-var prefix convention. Adds a short, additive note under *Resolution order and environment variables* stating that `AA_*` (`AA_GATEWAY_URL`, `AA_CONTROL_PLANE_URL`, `AA_API_KEY`) is the **canonical** prefix across all SDKs, and that the legacy `AAASM_*` prefix (the older zero-config gateway resolver in each SDK) is a **deprecated alias** — still honoured for backwards-compat, emits a deprecation warning, and will be removed in a future major version. Cross-references the cross-SDK reconciliation tracked under AAASM-3019.

Docs-only, additive note; no other sections or files touched.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [x] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-3033 (cross-SDK reconciliation: AAASM-3019)
- Related GitHub issues: N/A

## Testing

Describe the testing performed for this PR:

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [x] No tests required (docs-only change)

Validation run locally:
- `markdownlint-cli2 docs/src/compatibility.md` — 0 new errors from this edit (the 3 pre-existing MD032 findings exist unchanged in `HEAD`).
- `lychee --offline docs/src/compatibility.md` — 0 errors (all links resolve).
- `mdbook build docs` — succeeds.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
