### PR TITLE
[AAASM-3036] ♻️ (aa-sdk-client): Re-add synchronous query_policy over the runtime UDS

### DIFF
--- a/aa-sdk-client/src/client.rs
+++ b/aa-sdk-client/src/client.rs
@@ -8,11 +8,16 @@
 
 use std::collections::HashMap;
 use std::sync::Mutex;
+use std::time::Duration;
 
 use crate::error::SdkClientError;
 use crate::ipc::{IpcCommand, IpcHandle};
 #[cfg(feature = "preflight")]
 use crate::preflight::Preflight;
+
+/// How long [`AssemblyClient::query_policy`] blocks for a runtime decision
+/// before failing open with [`SdkClientError::QueryFailed`].
+const QUERY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Handle to an active Agent Assembly session.
 ///
@@ -155,6 +160,40 @@ impl AssemblyClient {
         };
 
         self.send(event)
+    }
+
+    /// Synchronously query the runtime for a policy decision on an action.
+    ///
+    /// Sends a `CheckActionRequest` to `aa-runtime` over the IPC connection and
+    /// blocks (up to [`QUERY_TIMEOUT`]) for the `CheckActionResponse`. Returns
+    /// [`SdkClientError::QueryFailed`] when the runtime does not answer in time
+    /// or the connection closes — callers must treat that as *fail-open* (the
+    /// SDK is advisory; the runtime/proxy/eBPF layers are authoritative).
+    ///
+    /// FFI shims that hold a language-runtime lock (e.g. Python's GIL) should
+    /// release it around this call, since it blocks the calling thread.
+    pub fn query_policy(
+        &self,
+        request: aa_proto::assembly::policy::v1::CheckActionRequest,
+    ) -> Result<aa_proto::assembly::policy::v1::CheckActionResponse, SdkClientError> {
+        let (resp_tx, resp_rx) = std::sync::mpsc::channel();
+
+        // Enqueue under the lock, then release it before blocking on the
+        // response so a slow runtime cannot stall shutdown or other calls.
+        {
+            let guard = self.inner.lock().map_err(|_| SdkClientError::LockPoisoned)?;
+            let ipc = guard.as_ref().ok_or(SdkClientError::Shutdown)?;
+            ipc.cmd_tx
+                .blocking_send(IpcCommand::QueryPolicy {
+                    request: Box::new(request),
+                    resp: resp_tx,
+                })
+                .map_err(|_| SdkClientError::ChannelClosed)?;
+        }
+
+        resp_rx
+            .recv_timeout(QUERY_TIMEOUT)
+            .map_err(|_| SdkClientError::QueryFailed)
     }
 
     /// Shut down the IPC connection and join the background thread.

--- a/aa-sdk-client/src/error.rs
+++ b/aa-sdk-client/src/error.rs
@@ -15,6 +15,10 @@ pub enum SdkClientError {
     /// The background IPC thread's command channel is closed, so the event
     /// could not be enqueued.
     ChannelClosed,
+    /// A synchronous policy query did not complete: the runtime did not answer
+    /// within the timeout, or the IPC connection closed before a response
+    /// arrived. Callers should treat this as *fail-open* (the SDK is advisory).
+    QueryFailed,
 }
 
 impl std::fmt::Display for SdkClientError {
@@ -26,6 +30,9 @@ impl std::fmt::Display for SdkClientError {
             SdkClientError::LockPoisoned => write!(f, "AssemblyClient lock was poisoned"),
             SdkClientError::ChannelClosed => {
                 write!(f, "failed to enqueue event: IPC channel is closed")
+            }
+            SdkClientError::QueryFailed => {
+                write!(f, "policy query failed: runtime did not respond in time")
             }
         }
     }

--- a/aa-sdk-client/src/ipc.rs
+++ b/aa-sdk-client/src/ipc.rs
@@ -307,4 +307,65 @@ mod tests {
         server.abort();
         let _ = std::fs::remove_file(&socket_path);
     }
+
+    /// A synchronous `query_policy` against a runtime that answers `PolicyQuery`
+    /// with a `PolicyResponse` returns that decision to the blocking caller.
+    #[tokio::test]
+    async fn query_policy_returns_runtime_decision() {
+        use std::time::Duration;
+
+        use prost::Message;
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::UnixListener;
+
+        use crate::client::AssemblyClient;
+
+        let socket_path = format!("/tmp/aa-test-query-{}.sock", std::process::id());
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).unwrap();
+
+        // Mock runtime: read the heartbeat + the PolicyQuery, then reply with a
+        // Deny CheckActionResponse. Bodies here are < 128 bytes, so the
+        // length-delimiter varint is a single byte.
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            assert_eq!(stream.read_u8().await.unwrap(), codec::TAG_HEARTBEAT);
+            assert_eq!(stream.read_u8().await.unwrap(), codec::TAG_POLICY_QUERY);
+            let len = stream.read_u8().await.unwrap() as usize;
+            if len > 0 {
+                let mut body = vec![0u8; len];
+                stream.read_exact(&mut body).await.unwrap();
+            }
+
+            let resp = aa_proto::assembly::policy::v1::CheckActionResponse {
+                decision: aa_proto::assembly::common::v1::Decision::Deny as i32,
+                ..Default::default()
+            };
+            let mut buf = Vec::new();
+            resp.encode(&mut buf).unwrap();
+            assert!(buf.len() < 128, "test assumes a single-byte length varint");
+            stream.write_u8(codec::TAG_POLICY_RESPONSE).await.unwrap();
+            stream.write_u8(buf.len() as u8).await.unwrap();
+            stream.write_all(&buf).await.unwrap();
+            stream.flush().await.unwrap();
+            // Keep the connection open so the client can read the reply.
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        });
+
+        let handle = spawn_ipc_thread(PathBuf::from(&socket_path)).unwrap();
+        let client = AssemblyClient::new(handle, Vec::new());
+
+        // query_policy blocks the calling thread, so run it off the async runtime.
+        let decision = tokio::task::spawn_blocking(move || {
+            client.query_policy(aa_proto::assembly::policy::v1::CheckActionRequest::default())
+        })
+        .await
+        .unwrap();
+
+        server.abort();
+        let _ = std::fs::remove_file(&socket_path);
+
+        let resp = decision.expect("query_policy should return the runtime decision");
+        assert_eq!(resp.decision, aa_proto::assembly::common::v1::Decision::Deny as i32);
+    }
 }

--- a/aa-sdk-client/src/ipc.rs
+++ b/aa-sdk-client/src/ipc.rs
@@ -4,10 +4,15 @@
 //! current-thread runtime. The calling thread communicates with the background
 //! thread via an mpsc command channel.
 
+use std::collections::VecDeque;
 use std::path::PathBuf;
+use std::sync::mpsc as blocking_mpsc;
+use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 
 use tokio::sync::mpsc;
+
+use aa_proto::assembly::policy::v1::{CheckActionRequest, CheckActionResponse};
 
 use crate::codec;
 
@@ -16,9 +21,23 @@ use crate::codec;
 pub enum IpcCommand {
     /// Send an audit event to the runtime.
     SendEvent(Box<aa_proto::assembly::audit::v1::AuditEvent>),
+    /// Synchronously query the runtime for a policy decision on an action. The
+    /// `CheckActionResponse` is delivered on `resp`; the calling thread blocks
+    /// on it (see [`crate::client::AssemblyClient::query_policy`]).
+    QueryPolicy {
+        request: Box<CheckActionRequest>,
+        resp: blocking_mpsc::Sender<CheckActionResponse>,
+    },
     /// Gracefully shut down the IPC connection.
     Shutdown,
 }
+
+/// Response senders awaiting a synchronous policy decision, in FIFO order.
+///
+/// The command loop pushes one when it writes a `PolicyQuery`; the reader pops
+/// the oldest when a `PolicyResponse` arrives. The wire carries no correlation
+/// id, so responses match queries by order over the single connection.
+type PendingQueries = Arc<Mutex<VecDeque<blocking_mpsc::Sender<CheckActionResponse>>>>;
 
 /// Handle to the background IPC thread.
 ///
@@ -84,16 +103,36 @@ async fn ipc_loop(socket_path: PathBuf, mut cmd_rx: mpsc::Receiver<IpcCommand>) 
         return;
     }
 
-    // Drain unsolicited runtime responses on a dedicated task: reads never race
-    // writes (no cancellation hazard) and the connection cannot stall.
-    let reader_task = tokio::spawn(drain_responses(reader));
+    // Pending synchronous policy queries, routed back by the reader task.
+    let pending: PendingQueries = Arc::new(Mutex::new(VecDeque::new()));
 
-    // Process commands from the calling thread. Event reports are fire-and-forget.
+    // Drain unsolicited runtime responses (and route policy responses to their
+    // waiting queries) on a dedicated task: reads never race writes (no
+    // cancellation hazard) and the connection cannot stall.
+    let reader_task = tokio::spawn(drain_responses(reader, Arc::clone(&pending)));
+
+    // Process commands from the calling thread. Event reports are fire-and-forget;
+    // policy queries register a waiter and write a `PolicyQuery`.
     while let Some(cmd) = cmd_rx.recv().await {
         match cmd {
             IpcCommand::SendEvent(event) => {
                 if let Err(e) = codec::write_event_report(&mut writer, &event).await {
                     tracing::error!(error = %e, "failed to send event report");
+                }
+            }
+            IpcCommand::QueryPolicy { request, resp } => {
+                // Queue the response sender BEFORE writing, so the reader can
+                // never observe the response before the sender is registered.
+                if let Ok(mut q) = pending.lock() {
+                    q.push_back(resp);
+                }
+                if let Err(e) = codec::write_policy_query(&mut writer, &request).await {
+                    tracing::error!(error = %e, "failed to send policy query");
+                    // The query never went out — drop the sender we just queued
+                    // so the caller unblocks with QueryFailed instead of hanging.
+                    if let Ok(mut q) = pending.lock() {
+                        q.pop_back();
+                    }
                 }
             }
             IpcCommand::Shutdown => {
@@ -106,17 +145,27 @@ async fn ipc_loop(socket_path: PathBuf, mut cmd_rx: mpsc::Receiver<IpcCommand>) 
     reader_task.abort();
 }
 
-/// Continuously read and discard unsolicited responses from the runtime.
+/// Read responses from the runtime: route each `PolicyResponse` to the oldest
+/// waiting synchronous query, and drain everything else (violation alerts,
+/// approval decisions) so the connection does not stall.
 ///
-/// `aa-runtime` sends violation alerts and policy/approval decisions
-/// asynchronously. The SDK does not yet act on them, but they must be drained
-/// so the connection does not stall. Exits on EOF or a read error (e.g. the
-/// runtime closing the connection), or when aborted on shutdown.
-async fn drain_responses(mut reader: tokio::net::unix::OwnedReadHalf) {
+/// Exits on EOF or a read error (e.g. the runtime closing the connection), or
+/// when aborted on shutdown.
+async fn drain_responses(mut reader: tokio::net::unix::OwnedReadHalf, pending: PendingQueries) {
     loop {
         match codec::read_response(&mut reader).await {
-            Ok(response) => {
-                tracing::debug!(?response, "received unsolicited runtime response");
+            Ok(codec::RuntimeResponse::PolicyResponse(resp)) => {
+                let waiting = pending.lock().ok().and_then(|mut q| q.pop_front());
+                match waiting {
+                    Some(tx) => {
+                        // Ignore send errors: the caller may have already timed out.
+                        let _ = tx.send(resp);
+                    }
+                    None => tracing::debug!("policy response with no pending query — dropping"),
+                }
+            }
+            Ok(other) => {
+                tracing::debug!(?other, "received unsolicited runtime response");
             }
             Err(e) => {
                 tracing::debug!(error = %e, "runtime response stream ended");


### PR DESCRIPTION
## Description

**Wave 1 of the AAASM-3021 fix** (SDK-layer enforcement is non-functional because the per-action policy `check()` is unwired across all 3 SDKs). This restores the **synchronous policy query** to `aa-sdk-client` over the existing local `SDK → aa-ffi → aa-runtime` UDS path — *not* the rejected HTTP-per-call route.

The wire codec already supported it (`write_policy_query(CheckActionRequest)` + `read_response → PolicyResponse(CheckActionResponse)`); the gap was that the post-AAASM-3000 `ipc_loop` is fire-and-forget and `drain_responses` discarded every response, and `AssemblyClient` exposed no query API. (`query_policy` was dropped in AAASM-2561; the runtime still answers `PolicyQuery`.)

### What changed (`aa-sdk-client`)
- `SdkClientError::QueryFailed` — timeout / closed-connection result (callers treat as **fail-open**).
- `IpcCommand::QueryPolicy { request, resp }` — carries the request + a blocking response sender.
- `ipc_loop` queues the sender then writes a `PolicyQuery`; the reader task routes each `PolicyResponse` to the **oldest waiting query** (FIFO over the single connection — the wire has no correlation id) and still drains unsolicited alerts.
- `AssemblyClient::query_policy(CheckActionRequest) -> Result<CheckActionResponse>` — blocks up to **5s**, releasing the inner lock before waiting so a slow runtime can't stall `shutdown()`.

### What's NOT in this PR (later waves)
- The 3 native shims (`aa-ffi-python`/`node`/`go`) expose `query_policy` — they pin `aa-sdk-client` by SHA, so that follows once this merges + the pin propagates.
- Each SDK's wrapper `check()` calls it (preserving fail-open) — the final wave that makes "with aasm, deny actually blocks" true and flips the integration-tests `xfail`s to `XPASS`.

## Type of Change
- [x] ✨ New feature (restores synchronous policy query)
- [x] ♻️ Refactoring (ipc_loop response routing)

## Breaking Changes
- [x] No — additive API; existing `report_*` fire-and-forget paths and the wire protocol are unchanged.

## Related Issues
- Parent bug: AAASM-3021 · this subtask: AAASM-3036

## Testing
- [x] `cargo nextest run -p aa-sdk-client` → **28 passed / 0 failed**, incl. new `ipc::tests::query_policy_returns_runtime_decision` (mock runtime answers `PolicyQuery` with a Deny `CheckActionResponse`; assert `query_policy` returns it). The existing AAASM-3000 deadlock regression + lifecycle e2e still pass.
- [x] lefthook `fmt` + `clippy` (`-D warnings`) green on every commit; pre-push `cargo doc` green.

## Checklist
- [x] `cargo fmt` / `cargo clippy` clean
- [x] Self-review done
- [x] Small, bisectable commits (error / ipc routing / client API / test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)