### PR TITLE
[AAASM-3061] 🔒 (agent-assembly): Triage + resolve 4 BLOCKER secrets findings

### DIFF
--- a/aa-gateway/src/secrets/resolver.rs
+++ b/aa-gateway/src/secrets/resolver.rs
@@ -159,9 +159,12 @@ mod tests {
 
     #[test]
     fn embedded_placeholder_substitutes_in_place() {
-        let store = store_with(&[("DB_PASSWORD", "real-secret-abc")]);
+        let store = store_with(&[("DB_PASSWORD", "TESTONLY_NOT_REAL_value")]);
         let result = resolve_placeholders(&json!("postgres://app:${DB_PASSWORD}@db:5432/prod"), &store).unwrap();
-        assert_eq!(result.resolved, json!("postgres://app:real-secret-abc@db:5432/prod"));
+        assert_eq!(
+            result.resolved,
+            json!("postgres://app:TESTONLY_NOT_REAL_value@db:5432/prod")
+        );
         assert_eq!(result.names_substituted, vec!["DB_PASSWORD"]);
     }
 

--- a/aa-gateway/src/secrets/resolver.rs
+++ b/aa-gateway/src/secrets/resolver.rs
@@ -185,12 +185,12 @@ mod tests {
 
     #[test]
     fn nested_array_recurses_into_leaves() {
-        let store = store_with(&[("API_TOKEN", "real-token-1")]);
+        let store = store_with(&[("API_TOKEN", "TESTONLY_NOT_REAL_token")]);
         let input = json!(["GET", "/v1/users", "Authorization: Bearer ${API_TOKEN}"]);
         let result = resolve_placeholders(&input, &store).unwrap();
         assert_eq!(
             result.resolved,
-            json!(["GET", "/v1/users", "Authorization: Bearer real-token-1"])
+            json!(["GET", "/v1/users", "Authorization: Bearer TESTONLY_NOT_REAL_token"])
         );
         assert_eq!(result.names_substituted, vec!["API_TOKEN"]);
     }

--- a/aa-proxy/src/intercept/mod.rs
+++ b/aa-proxy/src/intercept/mod.rs
@@ -628,7 +628,7 @@ mod tests {
         let mut event = make_event(LlmApiPattern::OpenAi);
         // Embed a well-known OpenAI API key pattern in a message content field.
         event.request_body = Some(Bytes::from(
-            r#"{"model":"gpt-4","messages":[{"role":"user","content":"my key is sk-proj-aBcDeFgHiJkLmNoPqRsT1234567890abcdef1234567890ab"}]}"#,
+            r#"{"model":"gpt-4","messages":[{"role":"user","content":"my key is sk-TESTONLY-NOT-REAL-1234567890abcdef1234567890ab"}]}"#,
         ));
         event.response_body = None;
 
@@ -645,7 +645,7 @@ mod tests {
         let mut event = make_event(LlmApiPattern::OpenAi);
         // Response body with a credential embedded in a field.
         event.response_body = Some(Bytes::from(
-            r#"{"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":8},"debug":"sk-proj-aBcDeFgHiJkLmNoPqRsT1234567890abcdef1234567890ab"}"#,
+            r#"{"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":8},"debug":"sk-TESTONLY-NOT-REAL-1234567890abcdef1234567890ab"}"#,
         ));
 
         let fields = interceptor.intercept(&event).await.unwrap().unwrap();
@@ -656,7 +656,7 @@ mod tests {
         let pipeline_event = rx.try_recv().expect("should receive pipeline event");
         let event_str = format!("{pipeline_event:?}");
         assert!(
-            !event_str.contains("sk-proj-"),
+            !event_str.contains("TESTONLY-NOT-REAL"),
             "pipeline event must not contain raw credential"
         );
     }
@@ -668,7 +668,7 @@ mod tests {
         let mut event = make_event(LlmApiPattern::OpenAi);
         // Body contains a credential — but scanner is disabled.
         event.response_body = Some(Bytes::from(
-            r#"{"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":8},"debug":"sk-proj-aBcDeFgHiJkLmNoPqRsT1234567890abcdef1234567890ab"}"#,
+            r#"{"model":"gpt-4","usage":{"prompt_tokens":5,"completion_tokens":8},"debug":"sk-TESTONLY-NOT-REAL-1234567890abcdef1234567890ab"}"#,
         ));
 
         let fields = interceptor.intercept(&event).await.unwrap().unwrap();

--- a/dashboard/src/features/scrub/fixtures.ts
+++ b/dashboard/src/features/scrub/fixtures.ts
@@ -35,7 +35,7 @@ export const PATTERNS: ScrubPattern[] = [
     id: 'GH_TOKEN',
     name: 'GitHub token',
     regex: 'gh[ps]_[A-Za-z0-9]{36}',
-    example: 'ghp_aB3dE5fG7hI9jK1lM3nO5pQ7rS9tU1vW3xY5z',
+    example: 'ghp_TESTONLYNOTREALxxxxxxxxxxxxxxxxxxxxx',
     replace: '[REDACTED:GH_TOKEN]',
     severity: 'critical',
     hits24h: 6,


### PR DESCRIPTION
## Summary

Triages and resolves 4 BLOCKER `secrets:*` findings flagged by SonarCloud
on the `agent-assembly` repository. All four were verified as false
positives (test fixtures / synthetic inputs / UI demo values) — no real
credential ever existed in the working tree. Each finding is fixed with
an obviously-fake value so SonarCloud no longer pattern-matches a
realistic-looking credential.

Tracks: [AAASM-3061](https://lightning-dust-mite.atlassian.net/browse/AAASM-3061).

## Findings addressed

| # | Rule | File:Line | Verdict | Action |
|---|---|---|---|---|
| 1 | `secrets:S6698` (PostgreSQL password) | `aa-gateway/src/secrets/resolver.rs:164` | **false_positive** — unit-test fixture inside a `#[test]` function, replacing `${DB_PASSWORD}` in a synthetic `postgres://app:...@db:5432/prod` URL. | Replaced literal `real-secret-abc` with `TESTONLY_NOT_REAL_value`. |
| 2 | `secrets:S8217` (Bearer token) | `aa-gateway/src/secrets/resolver.rs:190` | **false_positive** — unit-test fixture inside a `#[test]` function, asserting `Authorization: Bearer ${API_TOKEN}` substitution. | Replaced literal `real-token-1` with `TESTONLY_NOT_REAL_token`. |
| 3 | `secrets:S6689` (GitHub token) | `dashboard/src/features/scrub/fixtures.ts:38` | **test_pattern** — UI demo `example` field shown next to a `gh[ps]_[A-Za-z0-9]{36}` scrub-rule regex; demonstrates what a redacted token looks like. | Replaced realistic-looking literal with `ghp_TESTONLYNOTREALxxxxxxxxxxxxxxxxxxxxx` (still matches the rule's regex). |
| 4 | `secrets:S7013` (OpenAI API key) | `aa-proxy/src/intercept/mod.rs:631` | **test_pattern** — synthetic input embedded inside a `#[tokio::test]` body verifying the credential-redaction pipeline. Two sibling occurrences at lines 648 and 671 (same string) were replaced too to keep the scoping consistent. | Replaced realistic-looking literal with `sk-TESTONLY-NOT-REAL-1234567890abcdef1234567890ab`. The `sk-` prefix is preserved so the `aa-security` Aho-Corasick scanner still matches, and the post-redact assertion is updated to probe for `TESTONLY-NOT-REAL` instead of the old `sk-proj-` prefix. |

None of the findings required operator escalation — no real credentials
were present in the working tree.

## Test plan

- [x] `cargo check -p aa-proxy --tests` — builds clean after the
  intercept-test edit + the assertion update.
- [x] Lefthook `pre-commit` (`cargo fmt --all` + `cargo clippy --workspace`)
  passes on each of the four commits.
- [ ] CI: `Test` job runs all `aa-gateway::secrets::resolver::tests` and
  `aa-proxy::intercept::tests` — both should pass unchanged because the
  substitution logic is data-agnostic.
- [ ] CI: Dashboard `pnpm test` / `pnpm typecheck` should pass because
  the fixture is consumed as a plain string by the scrub-rule preview.
- [ ] SonarCloud: the 4 BLOCKER `secrets:*` findings should clear on the
  next analysis run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AAASM-3061]: https://lightning-dust-mite.atlassian.net/browse/AAASM-3061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ