### PR TITLE
[AAASM-152] 🐛 (aa-gateway): Validate did:key format of agent_id in Register

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-server",
+ "bs58",
  "chrono",
  "chrono-tz",
  "clap",

--- a/aa-gateway/Cargo.toml
+++ b/aa-gateway/Cargo.toml
@@ -17,6 +17,7 @@ serde        = { workspace = true }
 serde_json   = { workspace = true }
 serde_yaml   = { workspace = true }
 arc-swap     = "1"
+bs58         = "0.5"
 dashmap      = { workspace = true }
 ed25519-dalek = { version = "2", features = ["std"] }
 hex          = { workspace = true }

--- a/aa-gateway/src/registry/convert.rs
+++ b/aa-gateway/src/registry/convert.rs
@@ -14,10 +14,47 @@ pub fn proto_agent_id_to_key(id: &ProtoAgentId) -> [u8; 16] {
     out
 }
 
-/// Validate that a proto [`AgentId`](ProtoAgentId) has all required fields populated.
+/// Validate that a proto [`AgentId`](ProtoAgentId) is populated and that its
+/// `agent_id` is a syntactically-valid `did:key` DID.
+///
+/// A `did:key` identifier has the shape `did:key:<multibase>` where the
+/// multibase value is `base58btc` (multibase prefix `z`). This check verifies:
+///
+/// 1. `agent_id` is non-empty.
+/// 2. It begins with the `did:key:` prefix.
+/// 3. The method-specific identifier starts with the `z` (base58btc)
+///    multibase prefix and the remainder decodes to a non-empty byte string.
+///
+/// It deliberately does not assert the multicodec key type or key length, so
+/// any well-formed base58btc `did:key` is accepted.
 pub fn validate_proto_agent_id(id: &ProtoAgentId) -> Result<(), &'static str> {
     if id.agent_id.is_empty() {
         return Err("agent_id is empty");
     }
+    validate_did_key(&id.agent_id)
+}
+
+/// Verify that `value` is a syntactically-valid `base58btc` `did:key` DID.
+fn validate_did_key(value: &str) -> Result<(), &'static str> {
+    let multibase = value
+        .strip_prefix("did:key:")
+        .ok_or("agent_id is not a did:key DID (missing \"did:key:\" prefix)")?;
+
+    let encoded = multibase
+        .strip_prefix('z')
+        .ok_or("agent_id is not a valid did:key DID (expected base58btc \"z\" multibase prefix)")?;
+
+    if encoded.is_empty() {
+        return Err("agent_id is not a valid did:key DID (empty multibase value)");
+    }
+
+    let decoded = bs58::decode(encoded)
+        .into_vec()
+        .map_err(|_| "agent_id is not a valid did:key DID (multibase value is not valid base58btc)")?;
+
+    if decoded.is_empty() {
+        return Err("agent_id is not a valid did:key DID (multibase value decodes to empty bytes)");
+    }
+
     Ok(())
 }

--- a/aa-gateway/src/registry/convert.rs
+++ b/aa-gateway/src/registry/convert.rs
@@ -58,3 +58,62 @@ fn validate_did_key(value: &str) -> Result<(), &'static str> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn proto_id(agent_id: &str) -> ProtoAgentId {
+        ProtoAgentId {
+            org_id: "acme-corp".into(),
+            team_id: "platform".into(),
+            agent_id: agent_id.into(),
+        }
+    }
+
+    #[test]
+    fn accepts_valid_did_key() {
+        // The DID used across the conformance vectors.
+        let id = proto_id("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T");
+        assert!(validate_proto_agent_id(&id).is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_agent_id() {
+        let id = proto_id("");
+        assert_eq!(validate_proto_agent_id(&id), Err("agent_id is empty"));
+    }
+
+    #[test]
+    fn rejects_non_did_string() {
+        let id = proto_id("agent-lifecycle-1");
+        assert!(validate_proto_agent_id(&id).is_err());
+    }
+
+    #[test]
+    fn rejects_wrong_did_method() {
+        // A real DID, but not the did:key method.
+        let id = proto_id("did:web:example.com");
+        assert!(validate_proto_agent_id(&id).is_err());
+    }
+
+    #[test]
+    fn rejects_did_key_without_multibase_prefix() {
+        // Missing the leading 'z' base58btc multibase marker.
+        let id = proto_id("did:key:6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T");
+        assert!(validate_proto_agent_id(&id).is_err());
+    }
+
+    #[test]
+    fn rejects_did_key_with_empty_multibase() {
+        let id = proto_id("did:key:z");
+        assert!(validate_proto_agent_id(&id).is_err());
+    }
+
+    #[test]
+    fn rejects_did_key_with_invalid_base58() {
+        // '0', 'O', 'I', 'l' are not in the base58btc alphabet.
+        let id = proto_id("did:key:z0OIl");
+        assert!(validate_proto_agent_id(&id).is_err());
+    }
+}

--- a/aa-gateway/tests/lifecycle_service_test.rs
+++ b/aa-gateway/tests/lifecycle_service_test.rs
@@ -28,7 +28,7 @@ fn test_agent_id() -> ProtoAgentId {
     ProtoAgentId {
         org_id: "org-test".into(),
         team_id: "team-test".into(),
-        agent_id: "agent-lifecycle-1".into(),
+        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
     }
 }
 
@@ -182,6 +182,43 @@ async fn register_with_invalid_public_key_returns_error() {
         .unwrap_err();
 
     assert_eq!(status.code(), tonic::Code::InvalidArgument);
+}
+
+/// AAASM-152 regression: Register must reject an `agent_id` that is not a
+/// syntactically-valid `did:key` DID.
+#[tokio::test]
+async fn register_with_non_did_agent_id_returns_invalid_argument() {
+    let (addr, _registry) = start_server().await;
+    let mut client = AgentLifecycleServiceClient::connect(format!("http://{addr}"))
+        .await
+        .unwrap();
+
+    let status = client
+        .register(RegisterRequest {
+            agent_id: Some(ProtoAgentId {
+                org_id: "org-test".into(),
+                team_id: "team-test".into(),
+                // Non-empty, but not a did:key — must be rejected.
+                agent_id: "agent-lifecycle-1".into(),
+            }),
+            name: "malformed-id-agent".into(),
+            framework: "custom".into(),
+            version: "1.0.0".into(),
+            risk_tier: 0,
+            tool_names: vec![],
+            public_key: test_ed25519_public_key_hex(),
+            metadata: Default::default(),
+            ..Default::default()
+        })
+        .await
+        .unwrap_err();
+
+    assert_eq!(status.code(), tonic::Code::InvalidArgument);
+    assert!(
+        status.message().contains("did:key"),
+        "error should mention did:key, got: {}",
+        status.message()
+    );
 }
 
 #[tokio::test]
@@ -485,7 +522,7 @@ async fn register_echoes_parent_agent_id_and_team_id() {
     let parent_id = ProtoAgentId {
         org_id: "org-echo".into(),
         team_id: "team-echo".into(),
-        agent_id: "parent-echo".into(),
+        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD2T".into(),
     };
     client
         .register(RegisterRequest {
@@ -505,7 +542,7 @@ async fn register_echoes_parent_agent_id_and_team_id() {
     let agent_id = ProtoAgentId {
         org_id: "org-echo".into(),
         team_id: "team-echo".into(),
-        agent_id: "agent-echo-1".into(),
+        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD3T".into(),
     };
 
     let reg_resp = client
@@ -518,14 +555,17 @@ async fn register_echoes_parent_agent_id_and_team_id() {
             tool_names: vec![],
             public_key: test_ed25519_public_key_hex(),
             metadata: Default::default(),
-            parent_agent_id: Some("parent-echo".into()),
+            parent_agent_id: Some("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD2T".into()),
             ..Default::default()
         })
         .await
         .unwrap()
         .into_inner();
 
-    assert_eq!(reg_resp.parent_agent_id, Some("parent-echo".into()));
+    assert_eq!(
+        reg_resp.parent_agent_id,
+        Some("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD2T".into())
+    );
     assert_eq!(reg_resp.team_id, Some("team-echo".into()));
     // root_agent_id must be echoed back — parent is root so root = parent's key
     assert!(reg_resp.root_agent_id.is_some());
@@ -542,7 +582,7 @@ async fn register_without_topology_returns_none_echo_fields() {
     let agent_id = ProtoAgentId {
         org_id: "org-no-topo".into(),
         team_id: String::new(),
-        agent_id: "agent-no-topo-1".into(),
+        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
     };
 
     let reg_resp = client
@@ -577,7 +617,7 @@ async fn root_agent_id_for_root_agent_is_set_to_self() {
     let agent_proto_id = ProtoAgentId {
         org_id: "root-org".into(),
         team_id: "root-team".into(),
-        agent_id: "root-agent-A".into(),
+        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
     };
     let expected_key = aa_gateway::registry::convert::proto_agent_id_to_key(&agent_proto_id);
 
@@ -619,7 +659,7 @@ async fn root_agent_id_chains_3_levels() {
     let proto_a = ProtoAgentId {
         org_id: org.into(),
         team_id: team.into(),
-        agent_id: "agent-A".into(),
+        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD2T".into(),
     };
     let key_a = aa_gateway::registry::convert::proto_agent_id_to_key(&proto_a);
     client
@@ -641,7 +681,7 @@ async fn root_agent_id_chains_3_levels() {
     let proto_b = ProtoAgentId {
         org_id: org.into(),
         team_id: team.into(),
-        agent_id: "agent-B".into(),
+        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD3T".into(),
     };
     client
         .register(RegisterRequest {
@@ -653,7 +693,7 @@ async fn root_agent_id_chains_3_levels() {
             tool_names: vec![],
             public_key: test_ed25519_public_key_hex(),
             metadata: Default::default(),
-            parent_agent_id: Some("agent-A".into()),
+            parent_agent_id: Some("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD2T".into()),
             ..Default::default()
         })
         .await
@@ -663,7 +703,7 @@ async fn root_agent_id_chains_3_levels() {
     let proto_c = ProtoAgentId {
         org_id: org.into(),
         team_id: team.into(),
-        agent_id: "agent-C".into(),
+        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD4T".into(),
     };
     let resp_c = client
         .register(RegisterRequest {
@@ -675,7 +715,7 @@ async fn root_agent_id_chains_3_levels() {
             tool_names: vec![],
             public_key: test_ed25519_public_key_hex(),
             metadata: Default::default(),
-            parent_agent_id: Some("agent-B".into()),
+            parent_agent_id: Some("did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD3T".into()),
             ..Default::default()
         })
         .await
@@ -864,7 +904,7 @@ async fn root_agent_id_when_parent_unknown_returns_invalid_argument() {
             agent_id: Some(ProtoAgentId {
                 org_id: "unknown-org".into(),
                 team_id: "unknown-team".into(),
-                agent_id: "orphan-B".into(),
+                agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
             }),
             name: "orphan".into(),
             framework: "custom".into(),
@@ -903,7 +943,7 @@ async fn register_persists_enforcement_mode_observe_override_on_agent_record() {
     let proto_id = ProtoAgentId {
         org_id: "org-obs".into(),
         team_id: "team-obs".into(),
-        agent_id: "experimental-agent-1".into(),
+        agent_id: "did:key:z6Mkm5rByiqq5UNbvPFPfXtGJwdg2kD1T".into(),
     };
 
     client


### PR DESCRIPTION
## Description

The `Register` RPC did not validate the format of the `agent_id` field. `validate_proto_agent_id` (in `aa-gateway/src/registry/convert.rs`) only rejected an *empty* `agent_id` — any non-empty string was accepted, so a malformed agent identifier passed registration.

This PR extends `validate_proto_agent_id` to require that `agent_id` is a syntactically-valid **`did:key`** DID. The value must:
1. be non-empty (existing check, kept),
2. start with the `did:key:` prefix,
3. carry the `z` (base58btc) multibase prefix, and
4. decode as valid base58btc to a non-empty byte string.

The `did:key` method matches the form used throughout the project's conformance vectors and serialization fixtures (`did:key:z6Mk…`). The check is deliberately syntactic — it does not assert the multicodec key type or key length — because the conformance fixtures use shortened test DIDs that are not full ed25519 keys. Validation is scoped to the `Register` path only; `proto_agent_id_to_key` (hashing) is unchanged, so policy/audit/topology RPCs are unaffected.

## Type of Change

- [x] 🐛 Bug fix
- [x] ⬆️ Dependency upgrade

## Breaking Changes

- [x] No

Behaviourally, malformed `agent_id`s that were previously accepted are now rejected with `InvalidArgument` — this is the intended fix, not a public-API break.

## Related Issues

- Related Jira ticket: AAASM-152

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

How to verify:
- `cargo nextest run -p aa-gateway` — 1100 tests pass.
- New unit tests in `convert.rs`: valid `did:key` accepted; empty / non-DID / wrong-method / missing-`z` / empty-multibase / invalid-base58 all rejected.
- New gateway integration test `register_with_non_did_agent_id_returns_invalid_argument` asserts the `Register` RPC rejects a non-DID `agent_id` with `InvalidArgument`.
- Existing lifecycle fixtures updated to valid `did:key` agent ids (parent references updated to match).

Dependency: promotes `bs58 0.5` (already in the lockfile via `serde_with`) to a direct `aa-gateway` dependency for base58btc decoding — no version change. `cargo deny check` passes (advisories / bans / licenses / sources all ok).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-152
