### PR TITLE
[AAASM-2610] ✨ (aa-runtime): Convert & publish pipeline audit events to NATS

### DIFF
--- a/aa-runtime/src/audit_publisher/conversion.rs
+++ b/aa-runtime/src/audit_publisher/conversion.rs
@@ -1,0 +1,461 @@
+//! Conversion from a pipeline [`EnrichedEvent`] (wrapping a proto
+//! [`AuditEvent`](aa_proto::assembly::audit::v1::AuditEvent)) into a governance
+//! [`AuditEntry`](aa_core::storage::AuditEntry) ready for NATS publishing.
+//!
+//! The pipeline broadcast channel carries SDK/eBPF/proxy interception events as
+//! proto [`AuditEvent`]s. The [`AuditPublisher`](super::AuditPublisher) speaks
+//! governance [`AuditEntry`]s, so this module bridges the two: it maps the
+//! proto action discriminant to an [`AuditEventType`], derives the agent /
+//! session identity and tenant lineage that the NATS subject is keyed on, and
+//! serialises a non-secret JSON payload summarising the action.
+//!
+//! ## Independence from the approval audit stream
+//!
+//! These entries originate from `PipelineEvent::Audit` interception events and
+//! are a *disjoint* set from the approval-decision entries emitted by
+//! [`ApprovalQueue`](crate::approval::ApprovalQueue). Each logical audit event
+//! is therefore published exactly once — see [`runtime`](crate::runtime) for
+//! the wiring and the no-double-publish test.
+//!
+//! ## Hash chain
+//!
+//! Pipeline-audit entries are *not* part of the approval queue's per-decision
+//! hash chain — they are an independent stream produced concurrently from
+//! kernel/SDK/proxy sources with no shared ordering authority. Each entry is
+//! constructed with a genesis (`[0u8; 32]`) previous-hash; downstream storage
+//! keys on `(agent, session, seq)` and the monotonic `sequence_number` carried
+//! from the pipeline, not on chain linkage.
+
+use aa_core::audit::Lineage;
+use aa_core::storage::AuditEntry;
+use aa_core::{AgentId, AuditEventType, SessionId};
+use aa_proto::assembly::audit::v1::audit_event::Detail;
+use aa_proto::assembly::audit::v1::AuditEvent;
+use aa_proto::assembly::common::v1::ActionType;
+use sha2::{Digest, Sha256};
+
+use crate::pipeline::event::{EnrichedEvent, EventSource};
+
+/// Genesis previous-hash sentinel used for every pipeline-audit entry (see the
+/// module-level "Hash chain" note for why these are not chained).
+const GENESIS_HASH: [u8; 32] = [0u8; 32];
+
+/// Convert an [`EnrichedEvent`] from the pipeline broadcast channel into a
+/// governance [`AuditEntry`] suitable for the [`AuditPublisher`](super::AuditPublisher).
+///
+/// The mapping is total: every event yields an entry (the audit trail must not
+/// silently drop interception events). The proto action discriminant selects
+/// the [`AuditEventType`] via [`event_type_for`]; identity and lineage are
+/// derived from the proto agent id and lineage fields.
+pub fn enriched_to_audit_entry(event: &EnrichedEvent) -> AuditEntry {
+    let proto = &event.inner;
+    let event_type = event_type_for(proto);
+    let agent_id = derive_agent_id(event);
+    let session_id = derive_session_id(event);
+    let lineage = derive_lineage(proto);
+    let payload = build_payload(event);
+    let timestamp_ns = timestamp_ns_for(event);
+
+    AuditEntry::new_with_lineage(
+        event.sequence_number,
+        timestamp_ns,
+        event_type,
+        agent_id,
+        session_id,
+        payload,
+        GENESIS_HASH,
+        lineage,
+    )
+}
+
+/// Map a proto [`AuditEvent`] to the governance [`AuditEventType`].
+///
+/// The `action_type` discriminant drives the mapping. A populated
+/// `Detail::Violation` overrides it to [`AuditEventType::PolicyViolation`] so a
+/// blocked action is categorised by its outcome rather than its action class.
+fn event_type_for(proto: &AuditEvent) -> AuditEventType {
+    // A structured policy violation is recorded as a violation regardless of
+    // which action class triggered it.
+    if matches!(proto.detail, Some(Detail::Violation(_))) {
+        return AuditEventType::PolicyViolation;
+    }
+    match ActionType::try_from(proto.action_type).unwrap_or(ActionType::ActionUnspecified) {
+        // Tool / MCP invocations and file/network/process syscalls are all
+        // governance "tool call intercepted" events at the audit tier — the
+        // action class is preserved in the payload's `action_type` field.
+        ActionType::ToolCall
+        | ActionType::FileOperation
+        | ActionType::NetworkCall
+        | ActionType::ProcessExec
+        | ActionType::LlmCall
+        | ActionType::ToolResult => AuditEventType::ToolCallIntercepted,
+        // A spawned child agent is recorded as an A2A interception.
+        ActionType::AgentSpawn => AuditEventType::A2ACallIntercepted,
+        // Unspecified / unknown discriminants fall back to the generic
+        // interception type rather than being dropped.
+        ActionType::ActionUnspecified => AuditEventType::ToolCallIntercepted,
+    }
+}
+
+/// Derive a 16-byte [`AgentId`] from the event.
+///
+/// Prefers parsing the proto composite agent id's inner `agent_id` string as a
+/// UUID (the canonical on-wire form). When that field is empty or not a UUID it
+/// falls back to a SHA-256 truncation of the enriched event's `agent_id`
+/// string — the same stable derivation the approval path uses (`hash_to_16`).
+fn derive_agent_id(event: &EnrichedEvent) -> AgentId {
+    if let Some(proto_agent) = &event.inner.agent_id {
+        if let Ok(uuid) = proto_agent.agent_id.parse::<uuid::Uuid>() {
+            return AgentId::from_bytes(*uuid.as_bytes());
+        }
+        if !proto_agent.agent_id.is_empty() {
+            return AgentId::from_bytes(hash_to_16(&proto_agent.agent_id));
+        }
+    }
+    AgentId::from_bytes(hash_to_16(&event.agent_id))
+}
+
+/// Derive a 16-byte [`SessionId`] from the proto `session_id` string (UUID when
+/// parseable, otherwise a SHA-256 truncation). Falls back to the proto
+/// `event_id` so each event is still attributable to a session bucket.
+fn derive_session_id(event: &EnrichedEvent) -> SessionId {
+    let raw = if !event.inner.session_id.is_empty() {
+        &event.inner.session_id
+    } else {
+        &event.inner.event_id
+    };
+    if let Ok(uuid) = raw.parse::<uuid::Uuid>() {
+        return SessionId::from_bytes(*uuid.as_bytes());
+    }
+    SessionId::from_bytes(hash_to_16(raw))
+}
+
+/// Derive the audit [`Lineage`] (org/team for the NATS subject tenant, plus the
+/// delegation context) from the proto event's lineage fields.
+fn derive_lineage(proto: &AuditEvent) -> Lineage {
+    let org_id = proto
+        .agent_id
+        .as_ref()
+        .map(|a| a.org_id.clone())
+        .filter(|s| !s.is_empty());
+    // Prefer the composite agent id's team, falling back to the top-level
+    // lineage `team_id` carried for legacy events.
+    let team_id = proto
+        .agent_id
+        .as_ref()
+        .map(|a| a.team_id.clone())
+        .filter(|s| !s.is_empty())
+        .or_else(|| Some(proto.team_id.clone()).filter(|s| !s.is_empty()));
+
+    Lineage {
+        org_id,
+        team_id,
+        delegation_reason: Some(proto.delegation_reason.clone()).filter(|s| !s.is_empty()),
+        spawned_by_tool: Some(proto.spawned_by_tool.clone()).filter(|s| !s.is_empty()),
+        depth: (proto.depth != 0).then_some(proto.depth),
+        // Root/parent agent ids are UUID-encoded strings on the wire; only
+        // attach them when they parse, to keep the entry's identity bytes well-formed.
+        root_agent_id: parse_optional_agent_id(&proto.root_agent_id),
+        parent_agent_id: parse_optional_agent_id(&proto.parent_agent_id),
+    }
+}
+
+/// Parse an optional UUID-encoded agent id string into an [`AgentId`].
+fn parse_optional_agent_id(raw: &str) -> Option<AgentId> {
+    raw.parse::<uuid::Uuid>()
+        .ok()
+        .map(|u| AgentId::from_bytes(*u.as_bytes()))
+}
+
+/// Build the non-secret JSON payload for the entry.
+///
+/// Carries the event id, the action class, the interception source, the
+/// proto decision, and a per-detail summary. Detail summaries deliberately copy
+/// only metadata fields (tool names, paths, hosts) — never raw `args_json`
+/// bytes, which the producer is contractually required to scan/redact and which
+/// this audit tier must not re-expand.
+fn build_payload(event: &EnrichedEvent) -> String {
+    let proto = &event.inner;
+    let action = ActionType::try_from(proto.action_type)
+        .unwrap_or(ActionType::ActionUnspecified)
+        .as_str_name();
+    let detail = detail_summary(&proto.detail);
+    serde_json::json!({
+        "event_id": proto.event_id,
+        "action_type": action,
+        "source": source_label(&event.source),
+        "decision": proto.decision,
+        "detail": detail,
+    })
+    .to_string()
+}
+
+/// Summarise the proto detail oneof as a small JSON object, copying only
+/// non-secret metadata fields.
+fn detail_summary(detail: &Option<Detail>) -> serde_json::Value {
+    match detail {
+        Some(Detail::LlmCall(d)) => serde_json::json!({
+            "kind": "llm_call", "model": d.model, "provider": d.provider,
+        }),
+        Some(Detail::ToolCall(d)) => serde_json::json!({
+            "kind": "tool_call", "tool_name": d.tool_name, "tool_source": d.tool_source,
+            "succeeded": d.succeeded,
+        }),
+        Some(Detail::FileOp(d)) => serde_json::json!({
+            "kind": "file_op", "operation": d.operation, "path": d.path, "source": d.source,
+        }),
+        Some(Detail::Network(d)) => serde_json::json!({
+            "kind": "network_call", "host": d.host, "port": d.port, "protocol": d.protocol,
+        }),
+        Some(Detail::Process(d)) => serde_json::json!({
+            "kind": "process_exec", "command": d.command, "exit_code": d.exit_code,
+        }),
+        Some(Detail::Violation(d)) => serde_json::json!({
+            "kind": "policy_violation", "policy_rule": d.policy_rule,
+            "blocked_action": d.blocked_action, "reason": d.reason,
+        }),
+        Some(Detail::Approval(d)) => serde_json::json!({
+            "kind": "approval", "approval_id": d.approval_id, "approved": d.approved,
+        }),
+        None => serde_json::Value::Null,
+    }
+}
+
+/// Stable string label for the interception source.
+fn source_label(source: &EventSource) -> &'static str {
+    match source {
+        EventSource::Sdk => "sdk",
+        EventSource::EBpf => "ebpf",
+        EventSource::Proxy => "proxy",
+    }
+}
+
+/// Convert the enriched event's wall-clock receive time (Unix milliseconds) to
+/// the nanosecond timestamp the [`AuditEntry`] records. Negative values (clock
+/// skew) clamp to `0`.
+fn timestamp_ns_for(event: &EnrichedEvent) -> u64 {
+    let ms = event.received_at_ms.max(0) as u64;
+    ms.saturating_mul(1_000_000)
+}
+
+/// Hash a string into a 16-byte identifier via SHA-256 truncation.
+///
+/// Mirrors the approval queue's `hash_to_16` so a given agent-id string maps to
+/// the same [`AgentId`] bytes across both the approval and pipeline audit paths.
+fn hash_to_16(s: &str) -> [u8; 16] {
+    let digest = Sha256::digest(s.as_bytes());
+    let mut out = [0u8; 16];
+    out.copy_from_slice(&digest[..16]);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aa_proto::assembly::audit::v1::{
+        ApprovalEvent, FileOpDetail, LlmCallDetail, NetworkCallDetail, PolicyViolation, ProcessExecDetail,
+        ToolCallDetail,
+    };
+    use aa_proto::assembly::common::v1::AgentId as ProtoAgentId;
+
+    /// Build an enriched event wrapping a proto `AuditEvent` with the given
+    /// action type, detail, and source.
+    fn enriched(action: ActionType, detail: Option<Detail>, source: EventSource) -> EnrichedEvent {
+        EnrichedEvent {
+            inner: AuditEvent {
+                event_id: "550e8400-e29b-41d4-a716-446655440000".to_string(),
+                action_type: action as i32,
+                detail,
+                ..AuditEvent::default()
+            },
+            received_at_ms: 1_700,
+            source,
+            agent_id: "test-agent".to_string(),
+            connection_id: 1,
+            sequence_number: 7,
+        }
+    }
+
+    fn payload_json(entry: &AuditEntry) -> serde_json::Value {
+        serde_json::from_str(entry.payload()).expect("payload is valid JSON")
+    }
+
+    #[test]
+    fn tool_call_maps_to_tool_call_intercepted() {
+        let detail = Some(Detail::ToolCall(ToolCallDetail {
+            tool_name: "web_search".to_string(),
+            tool_source: "mcp".to_string(),
+            succeeded: true,
+            ..ToolCallDetail::default()
+        }));
+        let entry = enriched_to_audit_entry(&enriched(ActionType::ToolCall, detail, EventSource::Sdk));
+        assert_eq!(entry.event_type(), AuditEventType::ToolCallIntercepted);
+        let p = payload_json(&entry);
+        assert_eq!(p["action_type"], "TOOL_CALL");
+        assert_eq!(p["source"], "sdk");
+        assert_eq!(p["detail"]["kind"], "tool_call");
+        assert_eq!(p["detail"]["tool_name"], "web_search");
+    }
+
+    #[test]
+    fn llm_call_maps_to_tool_call_intercepted_with_model() {
+        let detail = Some(Detail::LlmCall(LlmCallDetail {
+            model: "gpt-4o".to_string(),
+            provider: "openai".to_string(),
+            ..LlmCallDetail::default()
+        }));
+        let entry = enriched_to_audit_entry(&enriched(ActionType::LlmCall, detail, EventSource::Sdk));
+        assert_eq!(entry.event_type(), AuditEventType::ToolCallIntercepted);
+        let p = payload_json(&entry);
+        assert_eq!(p["action_type"], "LLM_CALL");
+        assert_eq!(p["detail"]["model"], "gpt-4o");
+    }
+
+    #[test]
+    fn file_operation_maps_to_tool_call_intercepted_with_path() {
+        let detail = Some(Detail::FileOp(FileOpDetail {
+            operation: "read".to_string(),
+            path: "/etc/passwd".to_string(),
+            source: "ebpf".to_string(),
+            ..FileOpDetail::default()
+        }));
+        let entry = enriched_to_audit_entry(&enriched(ActionType::FileOperation, detail, EventSource::EBpf));
+        assert_eq!(entry.event_type(), AuditEventType::ToolCallIntercepted);
+        let p = payload_json(&entry);
+        assert_eq!(p["action_type"], "FILE_OPERATION");
+        assert_eq!(p["source"], "ebpf");
+        assert_eq!(p["detail"]["path"], "/etc/passwd");
+    }
+
+    #[test]
+    fn network_call_maps_with_host_and_port() {
+        let detail = Some(Detail::Network(NetworkCallDetail {
+            host: "api.example.com".to_string(),
+            port: 443,
+            protocol: "https".to_string(),
+            ..NetworkCallDetail::default()
+        }));
+        let entry = enriched_to_audit_entry(&enriched(ActionType::NetworkCall, detail, EventSource::Proxy));
+        assert_eq!(entry.event_type(), AuditEventType::ToolCallIntercepted);
+        let p = payload_json(&entry);
+        assert_eq!(p["action_type"], "NETWORK_CALL");
+        assert_eq!(p["source"], "proxy");
+        assert_eq!(p["detail"]["host"], "api.example.com");
+        assert_eq!(p["detail"]["port"], 443);
+    }
+
+    #[test]
+    fn process_exec_maps_with_command() {
+        let detail = Some(Detail::Process(ProcessExecDetail {
+            command: "/bin/sh".to_string(),
+            exit_code: 0,
+            ..ProcessExecDetail::default()
+        }));
+        let entry = enriched_to_audit_entry(&enriched(ActionType::ProcessExec, detail, EventSource::EBpf));
+        assert_eq!(entry.event_type(), AuditEventType::ToolCallIntercepted);
+        let p = payload_json(&entry);
+        assert_eq!(p["action_type"], "PROCESS_EXEC");
+        assert_eq!(p["detail"]["command"], "/bin/sh");
+    }
+
+    #[test]
+    fn agent_spawn_maps_to_a2a_call_intercepted() {
+        let entry = enriched_to_audit_entry(&enriched(ActionType::AgentSpawn, None, EventSource::Sdk));
+        assert_eq!(entry.event_type(), AuditEventType::A2ACallIntercepted);
+        assert_eq!(payload_json(&entry)["action_type"], "AGENT_SPAWN");
+    }
+
+    #[test]
+    fn policy_violation_detail_overrides_action_type() {
+        // Even on a TOOL_CALL action, a populated violation detail records a
+        // PolicyViolation governance event.
+        let detail = Some(Detail::Violation(PolicyViolation {
+            policy_rule: "no-egress".to_string(),
+            blocked_action: "network".to_string(),
+            reason: "blocked host".to_string(),
+            ..PolicyViolation::default()
+        }));
+        let entry = enriched_to_audit_entry(&enriched(ActionType::ToolCall, detail, EventSource::Proxy));
+        assert_eq!(entry.event_type(), AuditEventType::PolicyViolation);
+        let p = payload_json(&entry);
+        assert_eq!(p["detail"]["kind"], "policy_violation");
+        assert_eq!(p["detail"]["policy_rule"], "no-egress");
+    }
+
+    #[test]
+    fn approval_detail_summarised() {
+        let detail = Some(Detail::Approval(ApprovalEvent {
+            approval_id: "a-1".to_string(),
+            approved: true,
+            ..ApprovalEvent::default()
+        }));
+        let entry = enriched_to_audit_entry(&enriched(ActionType::ToolCall, detail, EventSource::Sdk));
+        let p = payload_json(&entry);
+        assert_eq!(p["detail"]["kind"], "approval");
+        assert_eq!(p["detail"]["approved"], true);
+    }
+
+    #[test]
+    fn unspecified_action_falls_back_to_intercepted_not_dropped() {
+        let entry = enriched_to_audit_entry(&enriched(ActionType::ActionUnspecified, None, EventSource::Sdk));
+        assert_eq!(entry.event_type(), AuditEventType::ToolCallIntercepted);
+    }
+
+    #[test]
+    fn sequence_number_and_timestamp_are_carried() {
+        let entry = enriched_to_audit_entry(&enriched(ActionType::ToolCall, None, EventSource::Sdk));
+        assert_eq!(entry.seq(), 7);
+        // received_at_ms 1_700 → 1_700 * 1_000_000 ns.
+        assert_eq!(entry.timestamp_ns(), 1_700_000_000);
+    }
+
+    #[test]
+    fn negative_timestamp_clamps_to_zero() {
+        let mut event = enriched(ActionType::ToolCall, None, EventSource::Sdk);
+        event.received_at_ms = -5;
+        let entry = enriched_to_audit_entry(&event);
+        assert_eq!(entry.timestamp_ns(), 0);
+    }
+
+    #[test]
+    fn agent_id_uuid_parsed_from_proto_when_present() {
+        let uuid = uuid::Uuid::new_v4();
+        let mut event = enriched(ActionType::ToolCall, None, EventSource::Sdk);
+        event.inner.agent_id = Some(ProtoAgentId {
+            agent_id: uuid.to_string(),
+            ..ProtoAgentId::default()
+        });
+        let entry = enriched_to_audit_entry(&event);
+        assert_eq!(entry.agent_id().as_bytes(), uuid.as_bytes());
+    }
+
+    #[test]
+    fn agent_id_falls_back_to_hash_of_enriched_agent_string() {
+        // No proto agent id → SHA-256 truncation of the enriched agent_id,
+        // matching the approval path's hash_to_16 derivation.
+        let event = enriched(ActionType::ToolCall, None, EventSource::Sdk);
+        let entry = enriched_to_audit_entry(&event);
+        assert_eq!(entry.agent_id().as_bytes(), &hash_to_16("test-agent"));
+    }
+
+    #[test]
+    fn lineage_org_and_team_drive_tenant() {
+        let mut event = enriched(ActionType::ToolCall, None, EventSource::Sdk);
+        event.inner.agent_id = Some(ProtoAgentId {
+            org_id: "acme".to_string(),
+            team_id: "payments".to_string(),
+            agent_id: uuid::Uuid::new_v4().to_string(),
+        });
+        let entry = enriched_to_audit_entry(&event);
+        assert_eq!(entry.org_id(), Some("acme"));
+        assert_eq!(entry.team_id(), Some("payments"));
+        // The NATS subject derived from this entry must carry the org tenant.
+        assert!(super::super::subject_for(&entry).starts_with("assembly.audit.acme."));
+    }
+
+    #[test]
+    fn entry_integrity_holds() {
+        let entry = enriched_to_audit_entry(&enriched(ActionType::ToolCall, None, EventSource::Sdk));
+        assert!(entry.verify_integrity());
+    }
+}

--- a/aa-runtime/src/audit_publisher/mod.rs
+++ b/aa-runtime/src/audit_publisher/mod.rs
@@ -13,11 +13,13 @@
 //! not touch the agent-facing API.
 
 mod config;
+mod conversion;
 mod publisher;
 mod sink;
 mod subject;
 
 pub use config::{NatsConfig, NatsTlsConfig, DEFAULT_MAX_INFLIGHT, DEFAULT_URL};
+pub use conversion::enriched_to_audit_entry;
 pub use publisher::AuditPublisher;
 pub use sink::NatsAuditSink;
 pub use subject::subject_for;

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -1215,6 +1215,202 @@ mod tests {
             .await
             .is_none());
     }
+
+    // ── spawn_pipeline_audit_publisher tests (AAASM-2610) ────────────────────
+
+    use aa_core::storage::{AuditEntry, AuditSink, Result as StorageResult};
+
+    /// An [`AuditSink`] that records every published entry's payload so tests
+    /// can assert what reached NATS.
+    struct RecordingSink {
+        published: std::sync::Mutex<Vec<AuditEntry>>,
+    }
+
+    impl RecordingSink {
+        fn new() -> std::sync::Arc<Self> {
+            std::sync::Arc::new(Self {
+                published: std::sync::Mutex::new(Vec::new()),
+            })
+        }
+
+        fn payloads(&self) -> Vec<String> {
+            self.published
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|e| e.payload().to_string())
+                .collect()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AuditSink for RecordingSink {
+        async fn emit(&self, event: AuditEntry) -> StorageResult<()> {
+            self.published.lock().unwrap().push(event);
+            Ok(())
+        }
+    }
+
+    /// Build an [`AuditPublisher`] over the given recording sink with a fresh
+    /// on-disk fallback buffer (returned `TempDir` keeps it alive).
+    fn publisher_over(
+        sink: std::sync::Arc<RecordingSink>,
+    ) -> (
+        std::sync::Arc<crate::audit_publisher::AuditPublisher>,
+        tempfile::TempDir,
+    ) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let buffer = std::sync::Arc::new(
+            aa_storage_sqlite_buffer::EventBuffer::new(tmp.path().join("buffer.db"), 1_024).expect("buffer"),
+        );
+        let sink: std::sync::Arc<dyn AuditSink> = sink;
+        let publisher = std::sync::Arc::new(crate::audit_publisher::AuditPublisher::new(sink, buffer));
+        (publisher, tmp)
+    }
+
+    /// Build a `PipelineEvent::Audit` carrying a TOOL_CALL interception event.
+    fn pipeline_tool_call(event_id: &str, seq: u64) -> crate::pipeline::PipelineEvent {
+        use crate::pipeline::event::{EnrichedEvent, EventSource};
+        use aa_proto::assembly::audit::v1::AuditEvent;
+        use aa_proto::assembly::common::v1::ActionType;
+
+        crate::pipeline::PipelineEvent::Audit(Box::new(EnrichedEvent {
+            inner: AuditEvent {
+                event_id: event_id.to_string(),
+                action_type: ActionType::ToolCall as i32,
+                ..AuditEvent::default()
+            },
+            received_at_ms: 1_000,
+            source: EventSource::Sdk,
+            agent_id: "pipe-agent".to_string(),
+            connection_id: 1,
+            sequence_number: seq,
+        }))
+    }
+
+    /// The subscriber converts and publishes each pipeline `Audit` event, and
+    /// ignores `LayerDegradation` operational events.
+    #[tokio::test]
+    async fn pipeline_audit_publisher_publishes_converted_events() {
+        let sink = RecordingSink::new();
+        let (publisher, _tmp) = publisher_over(std::sync::Arc::clone(&sink));
+        let token = CancellationToken::new();
+        let tracker = TaskTracker::new();
+
+        let (tx, rx) = tokio::sync::broadcast::channel::<crate::pipeline::PipelineEvent>(16);
+        super::spawn_pipeline_audit_publisher(&tracker, rx, std::sync::Arc::clone(&publisher), token.clone());
+
+        // Two audit events plus one degradation event that must be ignored.
+        tx.send(pipeline_tool_call("550e8400-e29b-41d4-a716-446655440010", 0))
+            .unwrap();
+        tx.send(crate::pipeline::PipelineEvent::LayerDegradation(
+            crate::pipeline::LayerDegradationInfo {
+                layer: "proxy".to_string(),
+                reason: "test".to_string(),
+                remaining_layers: vec![],
+            },
+        ))
+        .unwrap();
+        tx.send(pipeline_tool_call("550e8400-e29b-41d4-a716-446655440011", 1))
+            .unwrap();
+
+        // Wait until both audit events have been published (poll briefly).
+        for _ in 0..50 {
+            if sink.payloads().len() == 2 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let payloads = sink.payloads();
+        assert_eq!(payloads.len(), 2, "exactly the two Audit events should be published");
+        assert!(payloads.iter().all(|p| p.contains("\"action_type\":\"TOOL_CALL\"")));
+        assert!(payloads.iter().any(|p| p.contains("446655440010")));
+        assert!(payloads.iter().any(|p| p.contains("446655440011")));
+
+        token.cancel();
+        tracker.close();
+        let _ = tokio::time::timeout(Duration::from_secs(2), tracker.wait()).await;
+    }
+
+    /// The pipeline-audit publisher and the approval audit drain are disjoint:
+    /// approval-decision entries flow only through the approval queue's mpsc
+    /// drain, and pipeline interception entries flow only through the broadcast
+    /// subscriber. Driving both with a shared publisher must publish each
+    /// logical event exactly once — never the same event twice.
+    #[tokio::test]
+    async fn pipeline_and_approval_paths_do_not_double_publish() {
+        let sink = RecordingSink::new();
+        let (publisher, _tmp) = publisher_over(std::sync::Arc::clone(&sink));
+        let token = CancellationToken::new();
+        let tracker = TaskTracker::new();
+
+        // Approval path: an mpsc drain feeding the same publisher.
+        let (audit_tx, audit_rx) = tokio::sync::mpsc::channel::<AuditEntry>(16);
+        super::spawn_audit_drain(&tracker, audit_rx, std::sync::Arc::clone(&publisher), token.clone());
+        let approval_queue = crate::approval::ApprovalQueue::with_audit(audit_tx, [0u8; 32]);
+
+        // Pipeline path: the broadcast subscriber feeding the same publisher.
+        let (tx, rx) = tokio::sync::broadcast::channel::<crate::pipeline::PipelineEvent>(16);
+        super::spawn_pipeline_audit_publisher(&tracker, rx, std::sync::Arc::clone(&publisher), token.clone());
+
+        // Drive one approval lifecycle (submit + approve ⇒ 2 approval entries:
+        // ApprovalRequested + ApprovalGranted).
+        let req = crate::approval::ApprovalRequest {
+            request_id: uuid::Uuid::new_v4(),
+            agent_id: "approval-agent".to_string(),
+            action: "read_file".to_string(),
+            condition_triggered: "sensitive".to_string(),
+            submitted_at: 1_700_000_000,
+            timeout_secs: 60,
+            fallback: aa_core::PolicyResult::Deny {
+                reason: "x".to_string(),
+            },
+            team_id: None,
+            timeout_override_secs: None,
+            escalation_role_override: None,
+        };
+        let id = req.request_id;
+        let (_rid, _fut) = approval_queue.submit(req);
+        approval_queue
+            .decide(
+                id,
+                crate::approval::ApprovalDecision::Approved {
+                    by: "alice".to_string(),
+                    reason: None,
+                },
+            )
+            .expect("decide");
+
+        // Drive one pipeline interception event.
+        tx.send(pipeline_tool_call("550e8400-e29b-41d4-a716-446655440020", 0))
+            .unwrap();
+
+        // Expect exactly 3 published entries total: 2 approval + 1 pipeline.
+        for _ in 0..50 {
+            if sink.published.lock().unwrap().len() == 3 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        let payloads = sink.payloads();
+        assert_eq!(
+            payloads.len(),
+            3,
+            "exactly 2 approval + 1 pipeline entries; no double-publish. got: {payloads:?}"
+        );
+        // The single pipeline interception event appears exactly once.
+        let pipeline_hits = payloads.iter().filter(|p| p.contains("446655440020")).count();
+        assert_eq!(pipeline_hits, 1, "pipeline event must be published exactly once");
+        // Approval entries carry the request/agent context, not the pipeline action_type.
+        let approval_hits = payloads.iter().filter(|p| p.contains("approval-agent")).count();
+        assert_eq!(approval_hits, 2, "both approval lifecycle entries present exactly once");
+
+        token.cancel();
+        tracker.close();
+        let _ = tokio::time::timeout(Duration::from_secs(2), tracker.wait()).await;
+    }
 }
 
 // ── Layer integration tests ─────────────────────────────────────────────

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -420,6 +420,63 @@ fn spawn_audit_drain(
     });
 }
 
+/// Spawn (into `tracker`) the task that converts pipeline `PipelineEvent::Audit`
+/// interception events to governance `AuditEntry`s and publishes them to NATS via
+/// the same fire-and-forget [`AuditPublisher`](crate::audit_publisher::AuditPublisher)
+/// (AAASM-2610).
+///
+/// This subscriber runs *alongside* the correlation-engine subscriber — both
+/// read the same broadcast channel, but only this task converts and publishes.
+/// `LayerDegradation` events are not audit events and are ignored here.
+///
+/// ## No double-publish vs the approval stream
+///
+/// The approval audit stream (`spawn_audit_drain`) publishes `AuditEntry`s
+/// produced by the `ApprovalQueue` for approval *decisions* (requested /
+/// granted / denied / timed-out). This task publishes `AuditEntry`s converted
+/// from `PipelineEvent::Audit` *interception* events (SDK / eBPF / proxy tool,
+/// file, network, process calls). The two are disjoint sources carried on
+/// different channels — an approval decision never travels on the pipeline
+/// broadcast as a `PipelineEvent::Audit`, so each logical audit event reaches
+/// NATS exactly once.
+///
+/// Publish failures are absorbed by the publisher (buffered to SQLite), so a
+/// NATS outage never crashes or blocks the pipeline.
+fn spawn_pipeline_audit_publisher(
+    tracker: &TaskTracker,
+    mut rx: tokio::sync::broadcast::Receiver<crate::pipeline::PipelineEvent>,
+    publisher: std::sync::Arc<crate::audit_publisher::AuditPublisher>,
+    token: CancellationToken,
+) {
+    tracker.spawn(async move {
+        loop {
+            tokio::select! {
+                _ = token.cancelled() => {
+                    tracing::info!("pipeline audit publisher shutting down");
+                    break;
+                }
+                result = rx.recv() => match result {
+                    Ok(crate::pipeline::PipelineEvent::Audit(enriched)) => {
+                        let entry = crate::audit_publisher::enriched_to_audit_entry(&enriched);
+                        publisher.publish(entry).await;
+                    }
+                    Ok(crate::pipeline::PipelineEvent::LayerDegradation(_)) => {
+                        // Layer degradation is an operational event, not an audit event.
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!(dropped = n, "pipeline audit publisher lagged — audit events lost");
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        tracing::info!("broadcast channel closed — pipeline audit publisher exiting");
+                        break;
+                    }
+                },
+            }
+        }
+        tracing::info!("pipeline audit publisher task exiting");
+    });
+}
+
 /// Start the runtime and block until graceful shutdown completes.
 ///
 /// This is the main async entry point called from `main()`. It creates the
@@ -512,6 +569,21 @@ pub async fn run(config: RuntimeConfig) {
         }
         None => crate::approval::ApprovalQueue::new(),
     };
+
+    // AAASM-2610: when audit publishing is enabled, convert pipeline
+    // interception events (PipelineEvent::Audit from SDK/eBPF/proxy) to
+    // governance AuditEntry and publish them to NATS. Subscribe before
+    // `broadcast_tx` is moved into the pipeline task. This runs alongside the
+    // correlation subscriber and is disjoint from the approval audit drain, so
+    // each logical audit event is published exactly once.
+    if let Some(publisher) = &audit_publisher {
+        spawn_pipeline_audit_publisher(
+            &tracker,
+            broadcast_tx.subscribe(),
+            std::sync::Arc::clone(publisher),
+            token.clone(),
+        );
+    }
 
     // Clone inbound_tx for the health/metrics handler before IpcServer consumes it.
     let inbound_tx_health = inbound_tx.clone();


### PR DESCRIPTION
## Description

The only NATS audit publish path in `aa-runtime` was the **approval** stream:
`spawn_audit_drain` drains `ApprovalQueue`'s governance `AuditEntry`s (approval
requested / granted / denied / timed-out) into the `AuditPublisher`. The
`PipelineEvent::Audit(EnrichedEvent)` broadcast — carrying SDK / eBPF / proxy
**interception** events (tool / llm / file / network / process calls) — was
consumed *only* by the correlation engine and never converted to an
`AuditEntry` nor published. So interception events never reached NATS → Postgres.

This PR closes that gap:

1. **Conversion** (`audit_publisher/conversion.rs`): `enriched_to_audit_entry()`
   maps a proto `AuditEvent` (wrapped in `EnrichedEvent`) to a governance
   `AuditEntry`. It maps every `ActionType` variant to an `AuditEventType`
   (tool/llm/file/network/process → `ToolCallIntercepted`, agent-spawn →
   `A2ACallIntercepted`, populated violation detail → `PolicyViolation`),
   derives agent/session identity (UUID-parse the proto agent id, else SHA-256
   truncation matching the approval path's `hash_to_16`), derives org/team
   tenant lineage (which drives the NATS subject `assembly.audit.<tenant>.<agent>`),
   and serialises a non-secret per-detail JSON payload (no raw `args_json`).
2. **Subscriber** (`runtime.rs::spawn_pipeline_audit_publisher`): a task in
   `run()` consumes the `PipelineEvent::Audit` broadcast, converts each event,
   and publishes via the existing fire-and-forget `AuditPublisher`. Spawned only
   when NATS audit publishing is configured, alongside the correlation
   subscriber. Fail-soft: publish errors are buffered to SQLite by the publisher
   and never crash or block the pipeline.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2610

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

`cargo nextest run -p aa-runtime` → **284 passed, 2 skipped** (Linux/eBPF-gated).
`cargo fmt --all --check` clean; `cargo clippy -p aa-runtime --all-targets -D warnings` clean.

Added:
- Per-event-type conversion unit tests (tool/llm/file/network/process/agent-spawn,
  violation-override, approval, unspecified-fallback, identity/lineage, integrity).
- `pipeline_audit_publisher_publishes_converted_events` — pipeline `Audit` events
  are converted + published; `LayerDegradation` ignored.
- `pipeline_and_approval_paths_do_not_double_publish` — driving the pipeline
  subscriber and the approval drain over a shared publisher yields exactly
  2 approval + 1 pipeline entries, no duplication.

## De-dup / ordering decision

The two publish paths are **disjoint sources on different channels**, so no
gating is needed:

- **Approval path** (`spawn_audit_drain`, `mpsc<AuditEntry>`): approval-queue
  lifecycle *decisions*.
- **Pipeline path** (this PR, `broadcast<PipelineEvent>`): SDK/eBPF/proxy
  *interception* events.

An approval decision never travels on the pipeline broadcast as a
`PipelineEvent::Audit`, so each logical audit event reaches NATS exactly once.
The no-double-publish test asserts this contract. Pipeline-audit entries use a
genesis previous-hash (they are an independent concurrent stream with no shared
ordering authority); downstream storage keys on `(agent, session, seq)` and the
pipeline's monotonic `sequence_number`, not chain linkage — documented in the
conversion module.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (rustdoc on new items)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-2610