### PR TITLE
[AAASM-2975] 🔧 (release): Ship aa-gateway in the release tarball so aasm can launch a core

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,14 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm build
-      - name: Build aasm release binary
-        run: cargo build --release --target ${{ matrix.target }} -p aa-cli
+      - name: Build aasm + aa-gateway release binaries
+        # aasm is the operator CLI; aa-gateway is the core daemon that
+        # `aasm gateway start` spawns. Both must ship in the release tarball
+        # (AAASM-2975) so a release / Homebrew install can launch a core —
+        # without aa-gateway, `aasm gateway start` fails with
+        # "aa-gateway binary not found". aa-gateway is a normal host binary
+        # (no eBPF / cross-target quirks), so it builds for every matrix target.
+        run: cargo build --release --target ${{ matrix.target }} -p aa-cli -p aa-gateway
 
       - name: Install Rosetta 2 (x86_64-apple-darwin smoke test)
         if: matrix.target == 'x86_64-apple-darwin'
@@ -78,6 +84,17 @@ jobs:
           ls -lh "$BIN"
           file "$BIN"
           "$BIN" --version
+
+      - name: Verify aa-gateway binary built (size + type)
+        # aa-gateway is the daemon `aasm gateway start` spawns; it ships in the
+        # same tarball (AAASM-2975). We don't execute it here (it would bind a
+        # listener); a presence + Mach-O/ELF type check is enough — the archive
+        # step hard-fails anyway if the binary is missing.
+        shell: bash
+        run: |
+          BIN="target/${{ matrix.target }}/release/aa-gateway"
+          ls -lh "$BIN"
+          file "$BIN"
 
       - name: Codesign + notarize aasm (macOS — gated on Apple Developer creds)
         # Dormant until the operator sets the MACOS_SIGNING_ENABLED repo variable
@@ -118,11 +135,14 @@ jobs:
           rm -f "$RUNNER_TEMP/cert.p12" "$RUNNER_TEMP/notary_key.p8" "$RUNNER_TEMP/aasm.zip"
           security delete-keychain "$KEYCHAIN"
 
-      - name: Archive binary
+      - name: Archive binaries
         shell: bash
         run: |
+          # Package both binaries side-by-side so they unpack into the same
+          # directory; `aasm gateway start` resolves aa-gateway next to the
+          # running aasm executable (AAASM-2975).
           tar -czf "aasm-${{ matrix.target }}.tar.gz" \
-            -C "target/${{ matrix.target }}/release" aasm
+            -C "target/${{ matrix.target }}/release" aasm aa-gateway
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7

--- a/aa-cli/src/commands/gateway/start.rs
+++ b/aa-cli/src/commands/gateway/start.rs
@@ -358,4 +358,47 @@ mod tests {
         let addr = format!("127.0.0.1:{port}");
         assert!(wait_for_tcp(&addr, Duration::from_secs(1)));
     }
+
+    /// Create an executable file at `path` (sets the user-exec bit on Unix).
+    fn touch_executable(path: &std::path::Path) {
+        std::fs::write(path, b"#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(path).unwrap().permissions();
+            perms.set_mode(0o755);
+            std::fs::set_permissions(path, perms).unwrap();
+        }
+    }
+
+    #[test]
+    fn sibling_binary_resolves_aa_gateway_next_to_exe() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe = dir.path().join("aasm");
+        touch_executable(&exe);
+        let gateway = dir.path().join("aa-gateway");
+        touch_executable(&gateway);
+
+        assert_eq!(sibling_binary(&exe), Some(gateway));
+    }
+
+    #[test]
+    fn sibling_binary_returns_none_when_gateway_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe = dir.path().join("aasm");
+        touch_executable(&exe);
+        // No aa-gateway alongside it.
+        assert_eq!(sibling_binary(&exe), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sibling_binary_returns_none_when_gateway_not_executable() {
+        let dir = tempfile::tempdir().unwrap();
+        let exe = dir.path().join("aasm");
+        touch_executable(&exe);
+        // A non-executable file named aa-gateway must not be selected.
+        std::fs::write(dir.path().join("aa-gateway"), b"not a binary").unwrap();
+        assert_eq!(sibling_binary(&exe), None);
+    }
 }

--- a/aa-cli/src/commands/gateway/start.rs
+++ b/aa-cli/src/commands/gateway/start.rs
@@ -45,7 +45,7 @@ pub fn dispatch(args: StartArgs) -> ExitCode {
         None => {
             eprintln!(
                 "error: aa-gateway binary not found.\n\
-                 Tried: $PATH, ~/.cargo/bin/aa-gateway, ./target/release/aa-gateway, ./target/debug/aa-gateway"
+                 Tried: alongside aasm, $PATH, ~/.cargo/bin/aa-gateway, ./target/release/aa-gateway, ./target/debug/aa-gateway"
             );
             return ExitCode::FAILURE;
         }
@@ -146,9 +146,20 @@ pub fn dispatch(args: StartArgs) -> ExitCode {
 
 /// Resolve the `aa-gateway` binary path.
 ///
-/// Search order: directories in `$PATH` → `~/.cargo/bin/aa-gateway` →
+/// Search order: directory of the running `aasm` executable →
+/// directories in `$PATH` → `~/.cargo/bin/aa-gateway` →
 /// `./target/release/aa-gateway` → `./target/debug/aa-gateway`.
+///
+/// The exe-dir lookup is first so a release / Homebrew install — where
+/// `aa-gateway` ships alongside `aasm` in the same directory (AAASM-2975) —
+/// works even when that directory is not on `$PATH` (e.g. a tarball unpacked
+/// to an arbitrary location).
 pub fn resolve_binary() -> Option<PathBuf> {
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(candidate) = sibling_binary(&exe) {
+            return Some(candidate);
+        }
+    }
     if let Ok(path_var) = std::env::var("PATH") {
         for dir in path_var.split(':') {
             let candidate = PathBuf::from(dir).join("aa-gateway");
@@ -170,6 +181,13 @@ pub fn resolve_binary() -> Option<PathBuf> {
         }
     }
     None
+}
+
+/// Return the `aa-gateway` binary sitting next to the given `aasm` executable
+/// path, if it exists and is executable.
+fn sibling_binary(exe: &std::path::Path) -> Option<PathBuf> {
+    let candidate = exe.parent()?.join("aa-gateway");
+    is_executable(&candidate).then_some(candidate)
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Description

The GitHub Release shipped only the `aasm` binary (`aasm-<triple>.tar.gz`), but `aasm gateway start` spawns a **separate `aa-gateway` binary** via `Command::new(...)`. Because `aa-gateway` was never in the release artifact, a user installing from a Release or via Homebrew could not launch a core — `aasm gateway start` failed with `aa-gateway binary not found`.

Per the owner decision, this PR **packages `aa-gateway` in the release tarball** alongside `aasm` (no in-process serve mode). It also hardens `aasm`'s binary resolution so the packaged sibling is actually found.

### What changed

**`.github/workflows/release.yml`**
- Build step now compiles both binaries: `cargo build --release --target <triple> -p aa-cli -p aa-gateway` (was `-p aa-cli` only). `aa-gateway` is a normal host binary — no eBPF / cross-target quirks — so it builds for every matrix target.
- Added a lightweight `Verify aa-gateway binary built` step (size + `file` type; it is not executed to avoid binding a listener).
- Archive step now tars both binaries into the **same** `aasm-<triple>.tar.gz`: `tar -czf … -C target/<triple>/release aasm aa-gateway`. The tarball **name is unchanged**, so `SHA256SUMS`, cosign keyless signing, the Homebrew formula sha256 rewrite, and the GitHub Release upload all continue to work untouched.

**`aa-cli/src/commands/gateway/start.rs`**
- `resolve_binary()` now checks the directory of the running `aasm` executable (`std::env::current_exe()`) **first**, before `$PATH` → `~/.cargo/bin` → `./target/{release,debug}`. This is required because a tarball can be unpacked to an arbitrary directory that is not on `$PATH`; the new lookup finds the co-packaged `aa-gateway` regardless. New `sibling_binary()` helper + updated "not found" message.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-2975

## Testing

- [x] Unit tests added / updated
- [x] No tests required for the workflow change (explain why)

How verified:
- **release.yml** only runs on a tag push, so it was validated **statically**: `actionlint -shellcheck=` clean (avoids the known SC2016 false positive) and `python3 -c 'import yaml; yaml.safe_load(...)'` parses. Confirmed by reading the final archive + upload steps that **both** `aasm` and `aa-gateway` are built, verified, packaged, and uploaded for every matrix target, with the artifact name unchanged.
- **start.rs**: 3 new unit tests for `sibling_binary` (found alongside `aasm`, absent, present-but-not-executable). `cargo nextest run -p aa-cli` → 588 passed, 0 failed. `cargo fmt --all` clean, `cargo clippy -p aa-cli --all-targets -- -D warnings` exit 0.

How resolution now works: a Release/Homebrew install unpacks `aasm` and `aa-gateway` side-by-side; when the user runs `aasm gateway start`, `resolve_binary()` finds `aa-gateway` next to the running `aasm` executable (first lookup) and spawns it — no `$PATH` configuration required.

> Note (out of scope, follow-up): the dormant macOS codesign/notarize step signs only `aasm`. When Apple signing is enabled (`MACOS_SIGNING_ENABLED`), `aa-gateway` would also need signing. Left unchanged here to keep the fix scoped.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention
