### PR TITLE
[AAASM-3073] 🐛 (aa-gateway): Ack audit events individually so restart loses zero events

### DIFF
--- a/aa-gateway/src/audit_consumer.rs
+++ b/aa-gateway/src/audit_consumer.rs
@@ -10,18 +10,24 @@
 //! The design decisions:
 //!
 //! * **Throughput via batching (AAASM-2563).** The writer drains the channel
-//!   into batches of up to `batch_size`, writes each batch with a single
-//!   multi-row `INSERT … ON CONFLICT (event_id) DO NOTHING`, and acks the whole
-//!   batch with one JetStream ack — one DB round-trip and one ack per batch
-//!   instead of per event.
+//!   into batches of up to `batch_size` and writes each batch with a single
+//!   multi-row `INSERT … ON CONFLICT (event_id) DO NOTHING` — one DB round-trip
+//!   per batch instead of per event. Acks are then sent per message (see
+//!   *At-least-once* below) but without blocking on a server ack confirmation, so
+//!   the extra acks do not stall the writer.
 //! * **Idempotency.** A normal event becomes an [`AuditLogRecord`] keyed by the
 //!   event's own `event_id`; `ON CONFLICT (event_id) DO NOTHING` deduplicates
 //!   retries and intra-batch repeats. Each conflict bumps
 //!   `aa_audit_duplicates_total`.
-//! * **At-least-once.** The pull-consumer uses `AckPolicy::All`; the batch's
-//!   last message is acked only after the whole batch persists, which — in
-//!   stream order — acknowledges every message up to it. A failed batch is left
-//!   un-acked so NATS redelivers after `ack_wait`.
+//! * **At-least-once across restarts (AAASM-3073).** The pull-consumer uses
+//!   `AckPolicy::Explicit` and acks **each** message individually, only after its
+//!   row is persisted. An `AckPolicy::All` collapse (ack the batch's last message
+//!   to cover everything below it) is *unsafe across a restart*: redelivered +
+//!   still-pending messages arrive out of stream-sequence order, so acking the
+//!   highest sequence would acknowledge lower sequences that were never persisted
+//!   — silently dropping them. Per-message explicit acks never acknowledge an
+//!   unpersisted sequence. A message whose write failed is left un-acked so NATS
+//!   redelivers it after `ack_wait`; the `event_id` PK collapses the redelivery.
 //! * **Backpressure.** The channel is bounded; when it is full the producer
 //!   *awaits* room (`send().await`) rather than dropping, so large bursts queue
 //!   durably in JetStream instead of entering redelivery cycles. The in-flight
@@ -57,7 +63,7 @@ const STREAM_NAME: &str = "AUDIT";
 const DURABLE_NAME: &str = "aa-gateway-audit-consumer";
 /// Default bound on the producer→writer channel (spec/AC: 8192).
 const DEFAULT_CHANNEL_CAPACITY: usize = 8192;
-/// Default max events coalesced into one multi-row INSERT + one batch ack.
+/// Default max events coalesced into one multi-row INSERT (acked per message).
 const DEFAULT_BATCH_SIZE: usize = 1024;
 /// How long an un-acked message waits before JetStream redelivers it.
 const ACK_WAIT: Duration = Duration::from_secs(30);
@@ -95,7 +101,7 @@ pub struct AuditConsumerConfig {
     pub postgres: PostgresPoolConfig,
     /// Bound on the producer→writer channel.
     pub channel_capacity: usize,
-    /// Max events coalesced into one multi-row INSERT + one batch ack.
+    /// Max events coalesced into one multi-row INSERT (acked per message).
     pub batch_size: usize,
     /// JetStream stream name.
     pub stream_name: String,
@@ -218,10 +224,13 @@ pub async fn spawn(
             &config.durable_name,
             consumer::pull::Config {
                 durable_name: Some(config.durable_name.clone()),
-                // AckPolicy::All lets one ack cover a whole contiguous batch.
-                ack_policy: consumer::AckPolicy::All,
+                // Explicit per-message acks (AAASM-3073): each message is acked
+                // only after its own row is persisted. An AckPolicy::All collapse
+                // would acknowledge unpersisted lower sequences when, after a
+                // restart, redelivered messages arrive out of stream order.
+                ack_policy: consumer::AckPolicy::Explicit,
                 ack_wait: ACK_WAIT,
-                // Batched acking keeps up to channel_capacity + batch_size
+                // Per-message acking keeps up to channel_capacity + batch_size
                 // messages delivered-but-un-acked in flight. The server's
                 // default max_ack_pending (1000) would throttle below that and
                 // stall delivery; raise it to match — our real backpressure is
@@ -324,7 +333,7 @@ async fn run_producer(
 }
 
 /// DB-writer task: coalesce messages into batches, persist each batch with one
-/// multi-row INSERT, and ack the whole batch with one JetStream ack.
+/// multi-row INSERT, then ack each persisted message individually.
 ///
 /// Exits when the channel is closed (producer gone) after draining every
 /// buffered message.
@@ -382,56 +391,103 @@ fn classify(payload: &[u8]) -> Result<Classified, serde_json::Error> {
     })
 }
 
-/// Persist one batch, then ack it. On any DB error the batch is left un-acked so
-/// JetStream redelivers it — idempotent because the `event_id` PK collapses
-/// retries.
+/// How a message was handled, deciding whether it may be acked.
+enum Disposition {
+    /// A normal audit row, persisted only if the batch INSERT succeeds.
+    Audit,
+    /// A heartbeat, persisted only if its `touch_last_heartbeat` succeeds.
+    Heartbeat {
+        agent_id: String,
+        ts: Option<DateTime<Utc>>,
+    },
+    /// An undecodable payload: never retriable, so always safe to ack.
+    Undecodable,
+}
+
+/// Persist one batch, then ack each persisted message individually.
+///
+/// Under `AckPolicy::Explicit` a message must be acked **only after its own row
+/// is durable** — acking covers exactly that message, never neighbouring
+/// sequences. This is what makes the consumer safe across a restart, where
+/// redelivered + pending messages arrive out of stream-sequence order (AAASM-3073).
+///
+/// Audit rows go in one multi-row INSERT (all-or-nothing), so on success every
+/// audit message in the batch is durable and acked; on failure none are acked and
+/// JetStream redelivers them — idempotent because the `event_id` PK collapses
+/// retries. Heartbeats are acked per successful touch. Undecodable payloads can't
+/// be retried into validity, so they are acked to advance past them.
+///
+/// Acks use [`ack`](jetstream::Message::ack), which publishes the ack without
+/// awaiting a server confirmation (async ack), so per-message acking does not
+/// block the writer on a round-trip per message.
 async fn process_batch(batch: &[jetstream::Message], sink: &PgAuditSink, lifecycle: &PgLifecycleStore) {
     let mut records = Vec::with_capacity(batch.len());
-    let mut heartbeats = Vec::new();
+    let mut dispositions = Vec::with_capacity(batch.len());
     for message in batch {
         match classify(&message.payload) {
-            Ok(Classified::Audit(record)) => records.push(record),
-            Ok(Classified::Heartbeat { agent_id, ts }) => heartbeats.push((agent_id, ts)),
+            Ok(Classified::Audit(record)) => {
+                records.push(record);
+                dispositions.push(Disposition::Audit);
+            }
+            Ok(Classified::Heartbeat { agent_id, ts }) => {
+                dispositions.push(Disposition::Heartbeat { agent_id, ts });
+            }
             Err(err) => {
-                // Malformed payloads can't be retried into validity; drop them
-                // (the batch ack covers them) and surface the count.
+                // Malformed payloads can't be retried into validity; ack them to
+                // advance past them and surface the count.
                 metrics::counter!(METRIC_DECODE_ERRORS).increment(1);
                 tracing::warn!(%err, "audit consumer: dropping undecodable message");
+                dispositions.push(Disposition::Undecodable);
             }
         }
     }
 
+    // Persist the audit rows; on failure leave every audit message un-acked.
     let submitted = records.len() as u64;
-    if submitted > 0 {
+    let audit_persisted = if submitted > 0 {
         match sink.insert_audit_logs(&records).await {
             Ok(inserted) => {
                 metrics::counter!(METRIC_INSERTED).increment(inserted);
                 metrics::counter!(METRIC_DUPLICATES).increment(submitted - inserted);
+                true
             }
             Err(err) => {
                 metrics::counter!(METRIC_WRITE_ERRORS).increment(1);
-                tracing::warn!(%err, "audit consumer: batch insert failed, leaving batch un-acked");
-                return;
+                tracing::warn!(%err, "audit consumer: batch insert failed, leaving messages un-acked");
+                false
+            }
+        }
+    } else {
+        true
+    };
+
+    // Ack each message individually, only if its own write succeeded.
+    let mut heartbeats_touched = 0_u64;
+    for (message, disposition) in batch.iter().zip(&dispositions) {
+        let acked = match disposition {
+            Disposition::Audit => audit_persisted,
+            Disposition::Undecodable => true,
+            Disposition::Heartbeat { agent_id, ts } => match lifecycle.touch_last_heartbeat(agent_id, *ts).await {
+                Ok(()) => {
+                    heartbeats_touched += 1;
+                    true
+                }
+                Err(err) => {
+                    metrics::counter!(METRIC_WRITE_ERRORS).increment(1);
+                    tracing::warn!(%err, "audit consumer: heartbeat touch failed, leaving message un-acked");
+                    false
+                }
+            },
+        };
+        if acked {
+            if let Err(err) = message.ack().await {
+                tracing::warn!(%err, "audit consumer: ack failed after successful write");
             }
         }
     }
 
-    for (agent_id, ts) in &heartbeats {
-        if let Err(err) = lifecycle.touch_last_heartbeat(agent_id, *ts).await {
-            metrics::counter!(METRIC_WRITE_ERRORS).increment(1);
-            tracing::warn!(%err, "audit consumer: heartbeat touch failed, leaving batch un-acked");
-            return;
-        }
-    }
-    if !heartbeats.is_empty() {
-        metrics::counter!(METRIC_HEARTBEATS).increment(heartbeats.len() as u64);
-    }
-
-    // AckPolicy::All: acking the last message acks the whole contiguous batch.
-    if let Some(last) = batch.last() {
-        if let Err(err) = last.ack().await {
-            tracing::warn!(%err, "audit consumer: ack failed after successful batch write");
-        }
+    if heartbeats_touched > 0 {
+        metrics::counter!(METRIC_HEARTBEATS).increment(heartbeats_touched);
     }
 }
 

--- a/aa-integration-tests/tests/e2e_gateway_restart_durability.rs
+++ b/aa-integration-tests/tests/e2e_gateway_restart_durability.rs
@@ -23,29 +23,23 @@
 //!   `aa_audit_consumer_inserted_total` across both consumer lifetimes equals
 //!   `N` (no event inserted twice).
 //!
-//! ## Status — currently a known-failing regression guard (AAASM-3073)
+//! ## Status — durability regression guard (AAASM-3073 fixed)
 //!
-//! This test **fails today** because it surfaces a real product bug: the
-//! consumer uses `AckPolicy::All` and acks only the last message of each batch,
-//! which is safe only while processing order matches stream-sequence order. On
-//! restart the redelivered + still-pending messages no longer arrive in strict
-//! sequence order, so an `AckPolicy::All` ack on a high-sequence batch
-//! acknowledges lower sequences that were never persisted — they are dropped and
-//! never redelivered (`num_redelivered` stays 0 while `ack_floor` jumps to the
-//! head). Roughly 100–200 of 4000 events are lost per run, deterministically.
-//!
-//! Per AAASM-2609's directive *"do not weaken the assertion; file a Bug"*, the
-//! exactly-once assertions below are kept strict and the test is marked
-//! `#[ignore]`, pinned to **AAASM-3073**. Once the consumer's ack strategy is
-//! fixed (e.g. `AckPolicy::Explicit` per persisted message, or acking only the
-//! highest contiguously-persisted sequence), remove the `#[ignore]` and this
-//! becomes the durability regression guard the Epic AC always needed.
+//! This test previously failed because the consumer used `AckPolicy::All` and
+//! acked only the last message of each batch, which is safe only while processing
+//! order matches stream-sequence order. On restart the redelivered + still-pending
+//! messages no longer arrive in strict sequence order, so an `AckPolicy::All` ack
+//! on a high-sequence batch acknowledged lower sequences that were never persisted
+//! — they were dropped and never redelivered. AAASM-3073 fixed that by switching
+//! to `AckPolicy::Explicit` and acking each message only after its own row is
+//! persisted, so the assertions below now hold and this is the live durability
+//! regression guard the Epic AC always needed.
 //!
 //! Requires Docker. Gated behind the `audit-consumer` feature. Run explicitly:
 //!
 //! ```text
 //! cargo nextest run -p aa-integration-tests --features audit-consumer \
-//!     --test e2e_gateway_restart_durability --run-ignored all
+//!     --test e2e_gateway_restart_durability
 //! ```
 #![cfg(feature = "audit-consumer")]
 
@@ -121,10 +115,11 @@ async fn wait_for_first_rows(pool: &sqlx::PgPool, deadline: Duration) -> i64 {
     }
 }
 
-// Known-failing pending the AckPolicy::All restart-ack fix (AAASM-3073). The
-// assertions are intentionally strict: they encode the at-least-once contract
-// this Epic promises. Re-enable by deleting `#[ignore]` once AAASM-3073 lands.
-#[ignore = "AAASM-3073: consumer loses events across restart (AckPolicy::All ack collapse); re-enable when fixed"]
+// Durability regression guard (AAASM-3073 fixed). The assertions are
+// intentionally strict: they encode the at-least-once contract this Epic
+// promises. The consumer now acks each message individually under
+// AckPolicy::Explicit, so a restart redelivers and re-persists the un-acked tail
+// with zero loss and exactly-once.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn gateway_restart_loses_zero_acked_audit_events() {
     // A Prometheus recorder so the consumer's insert/duplicate counters can be


### PR DESCRIPTION
## Description

The gateway audit consumer violated at-least-once across a consumer restart. It bound the durable JetStream pull-consumer with `AckPolicy::All` and acked **only the last message of each batch** (`process_batch` → `batch.last().ack()`), relying on batch order matching stream-sequence order.

That holds in steady state but **breaks on restart**: redelivered + still-pending messages arrive out of stream-sequence order, so an `AckPolicy::All` ack on the batch's highest sequence acknowledges lower sequences **that were never persisted** — they get acked, are never redelivered, and are permanently lost (~100–200 of 4000 on restart; `num_redelivered=0`, `ack_floor` jumps straight to the head).

**The fix:** switch to `AckPolicy::Explicit` and ack **each message individually, only after its own row is persisted**:
- Audit rows go in one multi-row `INSERT … ON CONFLICT (event_id) DO NOTHING`; on success every audit message in the batch is durable and acked, on failure none are acked (JetStream redelivers; the PK collapses the retry).
- Heartbeats are acked per successful `touch_last_heartbeat`.
- Undecodable payloads (never retriable) are acked to advance past them.
- Acks use `message.ack()` (async — publishes the ack without awaiting a server round-trip), so per-message acking does **not** stall the writer.

The `ON CONFLICT (event_id) DO NOTHING` idempotency guard is unchanged. The per-batch multi-row INSERT is unchanged — only the ack granularity changed (batch-collapse → per-message).

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3073
- Unblocks / completes: AAASM-2609 (the restart-durability e2e is now un-`#[ignore]`d and passes as the live guard)

## Testing

Validated locally with Docker (`RUSTUP_TOOLCHAIN=stable`):

- **`e2e_gateway_restart_durability` (AAASM-2609) — now PASSES** (un-ignored):
  `published 4000; consumer #1 persisted 1400 before the crash; restart recovered to 4000/4000 rows (4000 distinct); cumulative inserts 4000, redelivery duplicates 104.`
  Zero loss, exactly-once.
- **`audit_consumer_throughput` (AAASM-2563)** — PASS, drain rate **85,746/s** (target ~65k/s — no regression).
- **`audit_consumer_verify` (AAASM-2394)** — PASS (dedupe + bounded channel depth intact).
- **`e2e_combined_pipeline_throughput` (AAASM-2607)** — PASS, **3,000,000 events end-to-end at 53,581/s**, all landed, channel depth bounded (peak 8193 = capacity 8192 + batch 1024).
- **`cargo nextest run -p aa-gateway`** — 1100/1100 pass.
- `cargo fmt --all`, `cargo clippy -p aa-gateway --all-targets -- -D warnings` — clean.

- [x] Integration tests added / updated (un-ignored the AAASM-2609 guard)
- [x] Manual testing performed (full Docker validation above)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (module doc-comment + the stale `AckPolicy::All` comments)
- [ ] All CI checks passing (org Actions billing-blocked; validated locally — see Testing)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
