### PR TITLE
[AAASM-3081] 🐛 (dashboard): Fix 12 CRITICAL S2871 sort-without-comparator bugs

### DIFF
--- a/dashboard/src/components/InheritedPermissionsPanel.tsx
+++ b/dashboard/src/components/InheritedPermissionsPanel.tsx
@@ -151,7 +151,7 @@ function buildRows(perms: EffectivePermissions): PermissionRow[] {
   // Union of allow + deny gives every capability touched by the cascade.
   const universe = new Set<string>([...perms.allow, ...perms.deny])
   return Array.from(universe)
-    .sort()
+    .sort((a, b) => a.localeCompare(b))
     .map((cap) => ({
       capability: cap,
       category: categoryFor(cap),

--- a/dashboard/src/features/agents/fleetFilters.ts
+++ b/dashboard/src/features/agents/fleetFilters.ts
@@ -40,7 +40,7 @@ export function applyFleetFilters(
 
 /** Distinct framework values present in the current agent list. */
 export function frameworkOptions(agents: readonly FleetAgent[]): string[] {
-  return Array.from(new Set(agents.map((a) => a.framework))).sort()
+  return Array.from(new Set(agents.map((a) => a.framework))).sort((a, b) => a.localeCompare(b))
 }
 
 /** Parse `FleetFilters` from a URL `URLSearchParams` instance. */

--- a/dashboard/src/features/analytics/policyEffectivenessUtils.ts
+++ b/dashboard/src/features/analytics/policyEffectivenessUtils.ts
@@ -95,5 +95,5 @@ export function collectDates(rules: PolicyRule[]): string[] {
       }
     }
   }
-  return result.sort()
+  return result.sort((a, b) => a.localeCompare(b))
 }

--- a/dashboard/src/features/approvals/filter.ts
+++ b/dashboard/src/features/approvals/filter.ts
@@ -26,9 +26,9 @@ export function deriveOptions(approvals: Approval[]): ApprovalsFilterOptions {
     if (a.action) actions.add(a.action)
   }
   return {
-    agents: [...agents].sort(),
-    teams: [...teams].sort(),
-    actions: [...actions].sort(),
+    agents: [...agents].sort((a, b) => a.localeCompare(b)),
+    teams: [...teams].sort((a, b) => a.localeCompare(b)),
+    actions: [...actions].sort((a, b) => a.localeCompare(b)),
   }
 }
 

--- a/dashboard/src/features/capability/CapabilityFilterBar.tsx
+++ b/dashboard/src/features/capability/CapabilityFilterBar.tsx
@@ -11,7 +11,7 @@ export interface CapabilityFilterBarProps {
 }
 
 function uniqueSorted(values: string[]): string[] {
-  return [...new Set(values)].sort()
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b))
 }
 
 export function CapabilityFilterBar({

--- a/dashboard/src/features/iam/AccessLogPanel.tsx
+++ b/dashboard/src/features/iam/AccessLogPanel.tsx
@@ -50,7 +50,7 @@ export function AccessLogPanel() {
     const memberEmails = membersPage?.items.map((m) => m.email) ?? []
     const keyLabels =
       apiKeys?.filter((k) => k.status === 'active').map((k) => k.label ?? k.prefix) ?? []
-    return Array.from(new Set([...memberEmails, ...keyLabels])).sort()
+    return Array.from(new Set([...memberEmails, ...keyLabels])).sort((a, b) => a.localeCompare(b))
   }, [membersPage, apiKeys])
 
   const rows = events ?? []

--- a/dashboard/src/routes.test.tsx
+++ b/dashboard/src/routes.test.tsx
@@ -21,7 +21,7 @@ describe('CANONICAL_ROUTES config', () => {
 
   it('covers all three groups (monitor, control, manage)', () => {
     const groups = new Set(CANONICAL_ROUTES.map((r) => r.group))
-    expect([...groups].sort()).toEqual(['control', 'manage', 'monitor'])
+    expect([...groups].sort((a, b) => a.localeCompare(b))).toEqual(['control', 'manage', 'monitor'])
     for (const group of ROUTE_GROUPS) {
       expect(CANONICAL_ROUTES.filter((r) => r.group === group).length).toBeGreaterThan(0)
     }
@@ -37,17 +37,17 @@ describe('CANONICAL_ROUTES config', () => {
   })
 
   it('includes the 12 canonical ids from design/v1/hi-fi/shell.jsx', () => {
-    const ids = CANONICAL_ROUTES.map((r) => r.id).sort()
+    const ids = CANONICAL_ROUTES.map((r) => r.id).sort((a, b) => a.localeCompare(b))
     expect(ids).toEqual(
       [
         'alerts', 'audit', 'capability', 'costs', 'fleet', 'identity',
         'live', 'overview', 'policy', 'scrub', 'teams', 'topology',
-      ].sort(),
+      ].sort((a, b) => a.localeCompare(b)),
     )
   })
 
   it('every num is a zero-padded two-digit sequence 01..12', () => {
-    const nums = CANONICAL_ROUTES.map((r) => r.num).sort()
+    const nums = CANONICAL_ROUTES.map((r) => r.num).sort((a, b) => a.localeCompare(b))
     expect(nums).toEqual([
       '01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12',
     ])


### PR DESCRIPTION
## Description

Fixes all 12 CRITICAL `typescript:S2871` bugs (`Array.prototype.sort()` / `.toSorted()` called without a compare function) on the `dashboard`. JavaScript's default sort coerces elements to strings and orders lexicographically; SonarCloud classifies these as bugs because the missing comparator is a wrong-behaviour risk. Every flagged call site sorts a list of **strings** (emails, capability keys, framework names, agent/team/action ids, ISO date strings, route group/id/num strings), so each gets an explicit `(a, b) => a.localeCompare(b)` comparator. No call site sorts a numeric array — the two SonarCloud "numeric" notes (`AccessLogPanel.tsx:53`, `routes.test.tsx:24`) are heuristic mislabels; the underlying data is strings, confirmed by reading each site. All sorts were ascending and remain ascending (no ordering semantics changed).

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: [AAASM-3081](https://lightning-dust-mite.atlassian.net/browse/AAASM-3081)

## Findings addressed

| File:Line | Element sorted | Type | Comparator | Verdict |
| --- | --- | --- | --- | --- |
| `dashboard/src/features/iam/AccessLogPanel.tsx:53` | identity candidates (emails + key labels) | string | `localeCompare` | real_finding → fixed |
| `dashboard/src/components/InheritedPermissionsPanel.tsx:154` | capability universe | string | `localeCompare` | real_finding → fixed |
| `dashboard/src/features/approvals/filter.ts:29` | agent ids | string | `localeCompare` | real_finding → fixed |
| `dashboard/src/features/approvals/filter.ts:30` | team ids | string | `localeCompare` | real_finding → fixed |
| `dashboard/src/features/approvals/filter.ts:31` | actions | string | `localeCompare` | real_finding → fixed |
| `dashboard/src/features/agents/fleetFilters.ts:43` | framework values | string | `localeCompare` | real_finding → fixed |
| `dashboard/src/features/capability/CapabilityFilterBar.tsx:14` | framework values | string | `localeCompare` | real_finding → fixed |
| `dashboard/src/routes.test.tsx:24` | route groups | string | `localeCompare` | real_finding → fixed |
| `dashboard/src/routes.test.tsx:40` | route ids (actual + expected) | string | `localeCompare` | real_finding → fixed |
| `dashboard/src/routes.test.tsx:45` | route ids (expected literal) | string | `localeCompare` | real_finding → fixed |
| `dashboard/src/routes.test.tsx:50` | route nums (`'01'..'12'`) | string | `localeCompare` | real_finding → fixed |
| `dashboard/src/features/analytics/policyEffectivenessUtils.ts:98` | distinct dates | string | `localeCompare` | real_finding → fixed |

Note: the ticket lists `routes.test.tsx:40` and `:45` as two findings on adjacent lines; both are covered by the single edit to that assertion block (the actual-ids `.sort()` and the expected-literal `.sort()`).

## Testing

- [x] Unit tests added / updated (test-file sort assertions updated in `routes.test.tsx`)
- [x] Manual testing performed

Test Plan (run in `dashboard/`):
- `pnpm type-check` → clean
- `pnpm lint` → clean (eslint, `--max-warnings 0`)
- `pnpm test` → 120 files / 1034 tests passed

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a — no behaviour change)
- [ ] All CI checks passing (org Actions is intermittently billing-blocked; validated locally — see Test Plan)
- [x] Commits are small and follow the Gitmoji convention

## Operator follow-ups

- After merge, SonarCloud re-analysis on `master` should drop these 12 `typescript:S2871` BUG findings to 0. No manual hotspot review is required for this rule.


[AAASM-3081]: https://lightning-dust-mite.atlassian.net/browse/AAASM-3081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ