### PR TITLE
[AAASM-3082] 🔒 (dashboard): Triage + resolve 10 SonarCloud security hotspots

### DIFF
--- a/dashboard/src/components/trace/PayloadModal.tsx
+++ b/dashboard/src/components/trace/PayloadModal.tsx
@@ -3,13 +3,17 @@ import type { TraceEvent } from '../../features/trace/types'
 import { Tooltip } from '../Tooltip'
 import './PayloadModal.css'
 
-const REDACTED_LINE_RE = /^(\s*)"([^"]+)":\s*(.*?)(,?)\s*$/
+// Single greedy `.*` to end-of-line (no overlapping `.*?`/`,?`/`\s*` tail) keeps
+// this linear; the trailing comma is derived in code below. The previous form
+// could backtrack on whitespace-heavy payload lines. See typescript:S5852.
+const REDACTED_LINE_RE = /^(\s*)"([^"]+)":\s*(.*)$/
 
 function renderJsonLines(formatted: string, redactedSet: ReadonlySet<string>): ReactNode[] {
   return formatted.split('\n').map((line, i) => {
     const match = REDACTED_LINE_RE.exec(line)
     if (match && redactedSet.has(match[2])) {
-      const [, indent, key, , trailing] = match
+      const [, indent, key, rawValue] = match
+      const trailing = rawValue.trimEnd().endsWith(',') ? ',' : ''
       const sentinel = `"<redacted: ${key}>"`
       return (
         <span key={i} data-testid="redacted-field" className="payload-modal__redacted">

--- a/dashboard/src/features/iam/validation.ts
+++ b/dashboard/src/features/iam/validation.ts
@@ -1,4 +1,7 @@
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+// Bounded quantifiers (RFC-5321 length caps) keep this linear and avoid the
+// polynomial backtracking the unbounded `+` form triggers on inputs like
+// "a@" + many non-dot chars (the `.` overlaps `[^\s@]`). See typescript:S5852.
+const EMAIL_RE = /^[^\s@]{1,64}@[^\s@]{1,251}\.[^\s@]{1,63}$/
 
 export function isValidEmail(value: string): boolean {
   return EMAIL_RE.test(value.trim())

--- a/dashboard/src/features/onboarding/steps/Step3IssueIdentity.tsx
+++ b/dashboard/src/features/onboarding/steps/Step3IssueIdentity.tsx
@@ -11,10 +11,15 @@ type Phase = 'idle' | 'spinning' | 'done'
 
 const HEX = '0123456789abcdef'
 
+// These bytes back an agent's DID and key fingerprint — identity material, not
+// UI decoration — so they must come from a CSPRNG, never Math.random().
+// See typescript:S2245.
 function randHex(byteCount: number): string {
+  const bytes = new Uint8Array(byteCount)
+  crypto.getRandomValues(bytes)
   let out = ''
-  for (let i = 0; i < byteCount * 2; i++) {
-    out += HEX[Math.floor(Math.random() * 16)]
+  for (const byte of bytes) {
+    out += HEX[byte >> 4] + HEX[byte & 0x0f]
   }
   return out
 }


### PR DESCRIPTION
## What changed

Triages all 10 SonarCloud security hotspots (status `TO_REVIEW`) on `agent-assembly` master — all in `dashboard/`. Three are **real risk → fixed in code**; seven are **safe-in-context → documented below** for the operator to mark reviewed in the SonarCloud UI (status flips require an authenticated SonarCloud session, which is operator-side).

Resolves [AAASM-3082](https://lightning-dust-mite.atlassian.net/browse/AAASM-3082).

## Per-hotspot verdict + action

| File:Line | Rule | Hotspot key | Verdict | Action |
| --- | --- | --- | --- | --- |
| `dashboard/src/components/trace/PayloadModal.tsx:6` | S5852 | `AZ4htRvHKr1Tka8MoA8t` | fixed_in_code | Runs per-line on user/payload-controlled trace JSON; trailing `(.*?)(,?)\s*$` could backtrack super-linearly on whitespace-heavy lines. Rewrote to a single greedy `.*$` (linear); trailing comma derived in code. |
| `dashboard/src/features/iam/validation.ts:1` | S5852 | `AZ4iCQweSR9ZwIZSK1bT` | fixed_in_code | Runs on user-typed email input; unbounded `[^\s@]+...\.[^\s@]+` backtracks polynomially (the `.` overlaps `[^\s@]`). Bounded each quantifier with RFC-5321 length caps — linear, same acceptance set. |
| `dashboard/src/features/onboarding/steps/Step3IssueIdentity.tsx:17` | S2245 | `AZ4iDSmCTRI8FeNvz1ws` | fixed_in_code | `randHex()` backs an agent **DID + key fingerprint** (identity material, presented as a cryptographic identity). Replaced `Math.random()` with `crypto.getRandomValues()`. |
| `dashboard/src/features/policies/api.ts:40` | S5852 | `AZ4h04xJx8FArgvb1nd2` | safe_acknowledged | `^\s*name:\s*"?([^"\n]+)"?` on the editor YAML. `[^"\n]+` cannot overlap the trailing `"?` (`"` excluded) and is line-bounded — no super-linear backtracking exists. User-controlled but linear; no code change warranted. |
| `dashboard/src/features/liveOps/PipelineCanvas.tsx:147` | S2245 | `AZ4iWmx-7PLUpMHUdCkQ` | safe_acknowledged | `pickFate()` — picks a particle fate for the Live Ops backdrop **animation**. UI-only, no security meaning. |
| `dashboard/src/features/liveOps/PipelineCanvas.tsx:280` | S2245 | `AZ4iWmx-7PLUpMHUdCkS` | safe_acknowledged | Particle `id` for the animation loop (rendering key only). UI-only. |
| `dashboard/src/features/liveOps/PipelineCanvas.tsx:281` | S2245 | `AZ4iWmx-7PLUpMHUdCkT` | safe_acknowledged | Particle spawn `y` jitter. UI-only animation. |
| `dashboard/src/features/liveOps/PipelineCanvas.tsx:286` | S2245 | `AZ4iWmx-7PLUpMHUdCkU` | safe_acknowledged | Particle `speed` jitter. UI-only animation. |
| `dashboard/src/features/capability/fixtures.ts:9` | S5332 | `AZ4hQWUxwJ1e4rinoG5v` | safe_acknowledged | `http://*` inside a static **capability-matrix demo fixture** (a glob path label, not a live endpoint). Not a real connection. |
| `dashboard/src/features/capability/fixtures.ts:257` | S5332 | `AZ4hQWUxwJ1e4rinoG5w` | safe_acknowledged | `http://api.foo.io/log` inside static **sample-call demo data** rendered in the UI; not a real endpoint the app connects to. |

> Note: the ticket listed 5 of the 6 S2245 hotspots explicitly; the 6th is one of the four PipelineCanvas siblings (lines 147/280/281/286), all covered above. Operators: cross-check the live keys in the SonarCloud UI against this table.

## Why the three regexes / the random are split this way

- **S5852 is super-linear backtracking, not "any regex on user input."** PayloadModal and EMAIL both have overlapping quantifiers at the tail and run on attacker-influenceable text → fixed. `nameFromYaml` has no overlapping quantifier (negated class excludes its delimiter) → genuinely linear, documented safe rather than churned.
- **S2245 matters only when the value carries security meaning.** The DID/fingerprint generator does → CSPRNG. The particle animation does not → documented safe.
- **S5332 fixtures are inert demo data**, not default endpoints → documented safe.

## Test plan

Run from `dashboard/`:

- `pnpm run type-check` — clean (after `pnpm install --frozen-lockfile`)
- `pnpm run lint` — clean (eslint, `--max-warnings 0`)
- `pnpm run test` — **1034 passed / 120 files**

The PayloadModal and onboarding-identity suites both pass with the rewritten regex / CSPRNG path; the identity tests assert on fixed identity objects, not the generator, so output randomness is unaffected.

## Operator follow-ups (SonarCloud UI — requires authenticated session)

Mark the following 7 hotspots **Safe** (reviewed) with the reasoning in the table above; they require no code change:

- `AZ4h04xJx8FArgvb1nd2` — nameFromYaml regex (linear)
- `AZ4iWmx-7PLUpMHUdCkQ`, `AZ4iWmx-7PLUpMHUdCkS`, `AZ4iWmx-7PLUpMHUdCkT`, `AZ4iWmx-7PLUpMHUdCkU` — PipelineCanvas animation `Math.random()`
- `AZ4hQWUxwJ1e4rinoG5v`, `AZ4hQWUxwJ1e4rinoG5w` — capability demo fixtures `http://`

The 3 `fixed_in_code` hotspots should auto-resolve once SonarCloud re-scans the merged branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AAASM-3082]: https://lightning-dust-mite.atlassian.net/browse/AAASM-3082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ