### PR TITLE
[AAASM-3091] 🔒 (dashboard): Make REDACTED_LINE_RE provably linear (S5852)

### DIFF
--- a/dashboard/src/components/trace/PayloadModal.tsx
+++ b/dashboard/src/components/trace/PayloadModal.tsx
@@ -3,10 +3,12 @@ import type { TraceEvent } from '../../features/trace/types'
 import { Tooltip } from '../Tooltip'
 import './PayloadModal.css'
 
-// Single greedy `.*` to end-of-line (no overlapping `.*?`/`,?`/`\s*` tail) keeps
-// this linear; the trailing comma is derived in code below. The previous form
-// could backtrack on whitespace-heavy payload lines. See typescript:S5852.
-const REDACTED_LINE_RE = /^(\s*)"([^"]+)":\s*(.*)$/
+// Provably linear: no `\s*`/`.*` overlap. The single greedy `(.*)` to end-of-line
+// absorbs any post-colon whitespace, so there is no overlapping-match region for
+// the engine to backtrack over. The render path reconstructs `"key": <sentinel>`
+// from scratch (it does not use the captured value's leading space) and the
+// trailing comma is derived in code below. See typescript:S5852.
+const REDACTED_LINE_RE = /^(\s*)"([^"]+)":(.*)$/
 
 function renderJsonLines(formatted: string, redactedSet: ReadonlySet<string>): ReactNode[] {
   return formatted.split('\n').map((line, i) => {


### PR DESCRIPTION
## What changed

Removed the overlapping `\s*` before the value capture in `REDACTED_LINE_RE` (`dashboard/src/components/trace/PayloadModal.tsx`):

```diff
-const REDACTED_LINE_RE = /^(\s*)"([^"]+)":\s*(.*)$/
+const REDACTED_LINE_RE = /^(\s*)"([^"]+)":(.*)$/
```

`\s*` and `.*` both match space characters, so SonarCloud `typescript:S5852` flagged the adjacency as a super-linear backtracking (ReDoS) region. The single greedy `(.*)$` now absorbs any post-colon whitespace, eliminating the overlapping-match region so the pattern is provably linear.

## Why

This is the one remaining open **security hotspot** on `agent-assembly` master (`typescript:S5852`, hotspot key `AZ7REEwHwvGMsgGnYwau`, at `PayloadModal.tsx:9`). It handles **payload-controlled trace JSON** rendered per-line in the trace viewer, so making it provably linear is preferred over a mark-safe acknowledgement. AAASM-3082 rewrote the regex once but the re-scan kept the hotspot open on the residual `\s*(.*)` adjacency.

## Behaviour is identical

- **Redacted line render** reconstructs `"key": <sentinel>` from scratch — it never renders the captured value's leading space (`sentinel` is built from `key` only).
- **Trailing-comma detection** is `rawValue.trimEnd().endsWith(',')` — `trimEnd()` strips trailing whitespace and a leading space does not affect `.endsWith(',')`.
- **Non-redacted passthrough** returns the original `line` untouched.

The explanatory comment was updated to describe the final, provably-linear form.

## Findings resolved

| Finding | Rule | File:Line | Status |
|---|---|---|---|
| Super-linear regex backtracking (ReDoS) | `typescript:S5852` | `dashboard/src/components/trace/PayloadModal.tsx:9` | Resolved |

## Test plan

Run from inside `dashboard/`:

- `pnpm install --frozen-lockfile` — clean
- `pnpm run type-check` (`tsc --noEmit`) — clean
- `pnpm run lint` (eslint, `--max-warnings 0`) — clean
- `pnpm run test` (vitest) — **1037/1037 passed** (121 files); PayloadModal suite **9/9** incl. the `redacted-field` testid path

## Deferrals

None. The 7 other hotspots are `safe_acknowledged` (AAASM-3082) and are out of scope (operator marks them Safe in the SonarCloud UI; no code change).

Closes AAASM-3091

🤖 Generated with [Claude Code](https://claude.com/claude-code)