### PR TITLE
[AAASM-3092] ♻️ (dashboard): Reduce 3 remaining ts:S3776 cognitive-complexity smells

### DIFF
--- a/dashboard/src/components/trace/TraceTimeline.tsx
+++ b/dashboard/src/components/trace/TraceTimeline.tsx
@@ -38,6 +38,24 @@ interface TraceEventRowProps {
 }
 
 /**
+ * Builds the keyboard handler that activates a row on Enter/Space. Kept as a
+ * top-level helper so the nested `if`/boolean branching does not count against
+ * `TraceEventRow`'s cognitive complexity (SonarCloud typescript:S3776).
+ */
+function makeRowKeyDownHandler(
+  event: TraceEvent,
+  onSelectEvent?: (event: TraceEvent) => void,
+): ((e: React.KeyboardEvent<HTMLLIElement>) => void) | undefined {
+  if (!onSelectEvent) return undefined
+  return (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      onSelectEvent(event)
+    }
+  }
+}
+
+/**
  * A single timeline step. Extracted from `TraceTimeline`'s map callback to
  * keep the parent's cognitive complexity low (SonarCloud typescript:S3776);
  * rendering and interaction wiring for one event live here.
@@ -51,14 +69,7 @@ function TraceEventRow({ event, isLast, onSelectEvent }: TraceEventRowProps) {
     <div className="trace-event__icon-circle" aria-hidden="true">{icon}</div>
   )
   const handleClick = onSelectEvent ? () => onSelectEvent(event) : undefined
-  const handleKeyDown = onSelectEvent
-    ? (e: React.KeyboardEvent<HTMLLIElement>) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          onSelectEvent(event)
-        }
-      }
-    : undefined
+  const handleKeyDown = makeRowKeyDownHandler(event, onSelectEvent)
 
   return (
     <li

--- a/dashboard/src/features/liveOps/PipelineCanvas.tsx
+++ b/dashboard/src/features/liveOps/PipelineCanvas.tsx
@@ -288,72 +288,102 @@ export function PipelineCanvas({
       counters.req += 1
     }
 
+    // The `advance` phase arms are split into one helper per phase so each
+    // stays trivially simple and the dispatcher's cognitive complexity stays
+    // low (SonarCloud typescript:S3776). The state mutations and their order
+    // are identical to the original single `switch` — these are pure
+    // structural extractions; jsdom cannot exercise the canvas so behaviour is
+    // preserved by inspection, not unit test. All helpers close over the same
+    // `counters` and lane geometry as the original arms.
+    function advanceToL1(p: Particle, ts: number): boolean {
+      p.x += p.speed
+      if (p.x >= laneX('l1')) {
+        p.x = laneX('l1')
+        if (p.fate === 'identity-fail') {
+          p.phase = 'blocked'
+          p.blockedAt = 'l1'
+          counters.deny += 1
+        } else {
+          p.phase = 'in-l1'
+          p.tEnter = ts
+        }
+      }
+      return true
+    }
+
+    function advanceToL2(p: Particle, ts: number): boolean {
+      p.x += p.speed
+      if (p.x >= laneX('l2')) {
+        p.x = laneX('l2')
+        if (p.fate === 'deny') {
+          p.phase = 'blocked'
+          p.blockedAt = 'l2'
+          counters.deny += 1
+        } else if (p.fate === 'approval') {
+          p.phase = 'stuck-l2'
+          p.stuckAt = ts
+          counters.approval += 1
+        } else {
+          p.phase = 'in-l2'
+          p.tEnter = ts
+          if (p.fate === 'narrow') counters.narrow += 1
+        }
+      }
+      return true
+    }
+
+    function advanceToL3(p: Particle, ts: number): boolean {
+      p.x += p.speed
+      if (p.x >= laneX('l3')) {
+        p.x = laneX('l3')
+        p.phase = 'in-l3'
+        p.tEnter = ts
+        if (p.fate === 'scrub') counters.scrub += 1
+      }
+      return true
+    }
+
+    function advanceToExt(p: Particle): boolean {
+      p.x += p.speed * 1.4
+      if (p.x >= laneRightX('ext')) {
+        counters.allow += 1
+        return false
+      }
+      return true
+    }
+
+    /** Dwell helper: advances a particle to `next` after a fixed 200 ms hold. */
+    function advanceInLane(p: Particle, ts: number, next: Phase): boolean {
+      if (ts - (p.tEnter ?? ts) > 200) p.phase = next
+      return true
+    }
+
+    function advanceBlocked(p: Particle): boolean {
+      p.fadeAge = (p.fadeAge ?? 0) + 1
+      return (p.fadeAge ?? 0) <= 50
+    }
+
     function advance(p: Particle, ts: number): boolean {
       p.age += 1
       switch (p.phase) {
         case 'to-l1':
-          p.x += p.speed
-          if (p.x >= laneX('l1')) {
-            p.x = laneX('l1')
-            if (p.fate === 'identity-fail') {
-              p.phase = 'blocked'
-              p.blockedAt = 'l1'
-              counters.deny += 1
-            } else {
-              p.phase = 'in-l1'
-              p.tEnter = ts
-            }
-          }
-          return true
+          return advanceToL1(p, ts)
         case 'in-l1':
-          if (ts - (p.tEnter ?? ts) > 200) p.phase = 'to-l2'
-          return true
+          return advanceInLane(p, ts, 'to-l2')
         case 'to-l2':
-          p.x += p.speed
-          if (p.x >= laneX('l2')) {
-            p.x = laneX('l2')
-            if (p.fate === 'deny') {
-              p.phase = 'blocked'
-              p.blockedAt = 'l2'
-              counters.deny += 1
-            } else if (p.fate === 'approval') {
-              p.phase = 'stuck-l2'
-              p.stuckAt = ts
-              counters.approval += 1
-            } else {
-              p.phase = 'in-l2'
-              p.tEnter = ts
-              if (p.fate === 'narrow') counters.narrow += 1
-            }
-          }
-          return true
+          return advanceToL2(p, ts)
         case 'in-l2':
-          if (ts - (p.tEnter ?? ts) > 200) p.phase = 'to-l3'
-          return true
+          return advanceInLane(p, ts, 'to-l3')
         case 'to-l3':
-          p.x += p.speed
-          if (p.x >= laneX('l3')) {
-            p.x = laneX('l3')
-            p.phase = 'in-l3'
-            p.tEnter = ts
-            if (p.fate === 'scrub') counters.scrub += 1
-          }
-          return true
+          return advanceToL3(p, ts)
         case 'in-l3':
-          if (ts - (p.tEnter ?? ts) > 200) p.phase = 'to-ext'
-          return true
+          return advanceInLane(p, ts, 'to-ext')
         case 'to-ext':
-          p.x += p.speed * 1.4
-          if (p.x >= laneRightX('ext')) {
-            counters.allow += 1
-            return false
-          }
-          return true
+          return advanceToExt(p)
         case 'stuck-l2':
           return ts - (p.stuckAt ?? ts) < 4500
         case 'blocked':
-          p.fadeAge = (p.fadeAge ?? 0) + 1
-          return (p.fadeAge ?? 0) <= 50
+          return advanceBlocked(p)
       }
     }
 

--- a/dashboard/src/pages/PoliciesPage.tsx
+++ b/dashboard/src/pages/PoliciesPage.tsx
@@ -147,6 +147,83 @@ function emptyStateDescription(filter: FilterTab): string {
     : 'Switch to All to see every policy.'
 }
 
+interface PoliciesTabsProps {
+  readonly filter: FilterTab
+  readonly counts: Record<FilterTab, number>
+  readonly onSelect: (tab: FilterTab) => void
+}
+
+/**
+ * The filter tab strip. Extracted from PoliciesPage so its per-tab
+ * active/count-class branching does not count against the page's
+ * cognitive complexity (SonarCloud typescript:S3776).
+ */
+function PoliciesTabs({ filter, counts, onSelect }: PoliciesTabsProps) {
+  return (
+    <nav className="policies-tabs" role="tablist" aria-label="Filter policies">
+      {FILTER_TABS.map((tab) => {
+        const active = filter === tab.id
+        const warnCount = tab.id === 'proposed' && counts.proposed > 0
+        return (
+          <button
+            type="button"
+            key={tab.id}
+            role="tab"
+            aria-selected={active}
+            data-testid={`policies-tab-${tab.id}`}
+            className={
+              active
+                ? 'policies-tabs__tab policies-tabs__tab--active'
+                : 'policies-tabs__tab'
+            }
+            onClick={() => onSelect(tab.id)}
+          >
+            {tab.label}
+            <span
+              className={
+                warnCount
+                  ? 'policies-tabs__count policies-tabs__count--warn'
+                  : 'policies-tabs__count'
+              }
+            >
+              {counts[tab.id]}
+            </span>
+          </button>
+        )
+      })}
+    </nav>
+  )
+}
+
+interface PoliciesSandboxBannerProps {
+  readonly summary: ReturnType<typeof useSandboxSummaryQuery>['data']
+  readonly onEnableLive: () => void
+}
+
+/**
+ * The observe-mode sandbox banner. Extracted from PoliciesPage so the
+ * nested optional-chaining for counts/top-rule does not count against the
+ * page's cognitive complexity (SonarCloud typescript:S3776).
+ */
+function PoliciesSandboxBanner({ summary, onEnableLive }: PoliciesSandboxBannerProps) {
+  const topRule = summary?.top_rule
+  return (
+    <div className="policies-page__sandbox" data-testid="policies-sandbox-banner">
+      <SandboxSummaryCard
+        policyName="All policies"
+        windowLabel="last 24h"
+        counts={{
+          wouldBeDenies: summary?.counts.would_be_denies ?? 0,
+          wouldBeRedactions: summary?.counts.would_be_redactions ?? 0,
+          wouldBePendingApprovals: summary?.counts.would_be_pending_approvals ?? 0,
+        }}
+        topRule={topRule ? { id: topRule.id, count: topRule.count } : undefined}
+        onEnableLiveEnforcement={onEnableLive}
+      />
+    </div>
+  )
+}
+
 interface PoliciesContentProps {
   readonly isError: boolean
   readonly isLoading: boolean
@@ -322,56 +399,13 @@ export function PoliciesPage() {
       </header>
 
       {showSandboxBanner ? (
-        <div className="policies-page__sandbox" data-testid="policies-sandbox-banner">
-          <SandboxSummaryCard
-            policyName="All policies"
-            windowLabel="last 24h"
-            counts={{
-              wouldBeDenies: sandboxSummary?.counts.would_be_denies ?? 0,
-              wouldBeRedactions: sandboxSummary?.counts.would_be_redactions ?? 0,
-              wouldBePendingApprovals: sandboxSummary?.counts.would_be_pending_approvals ?? 0,
-            }}
-            topRule={
-              sandboxSummary?.top_rule
-                ? { id: sandboxSummary.top_rule.id, count: sandboxSummary.top_rule.count }
-                : undefined
-            }
-            onEnableLiveEnforcement={openEnableLiveDialog}
-          />
-        </div>
+        <PoliciesSandboxBanner
+          summary={sandboxSummary}
+          onEnableLive={openEnableLiveDialog}
+        />
       ) : null}
 
-      <nav className="policies-tabs" role="tablist" aria-label="Filter policies">
-        {FILTER_TABS.map((tab) => {
-          const active = filter === tab.id
-          return (
-            <button
-              type="button"
-              key={tab.id}
-              role="tab"
-              aria-selected={active}
-              data-testid={`policies-tab-${tab.id}`}
-              className={
-                active
-                  ? 'policies-tabs__tab policies-tabs__tab--active'
-                  : 'policies-tabs__tab'
-              }
-              onClick={() => setFilter(tab.id)}
-            >
-              {tab.label}
-              <span
-                className={
-                  tab.id === 'proposed' && counts.proposed > 0
-                    ? 'policies-tabs__count policies-tabs__count--warn'
-                    : 'policies-tabs__count'
-                }
-              >
-                {counts[tab.id]}
-              </span>
-            </button>
-          )
-        })}
-      </nav>
+      <PoliciesTabs filter={filter} counts={counts} onSelect={setFilter} />
 
       <PoliciesContent
         isError={isError}


### PR DESCRIPTION
## Description

Clears the 3 remaining open `typescript:S3776` cognitive-complexity smells in the
dashboard (follow-up to AAASM-3084, whose extractions on two of these helped but
did not drop them below the Cx-15 threshold, plus the one it deferred). All three
are behaviour-preserving structural extractions.

### Findings resolved

| File:Line | Before | Fix | Validation |
| --- | --- | --- | --- |
| `dashboard/src/components/trace/TraceTimeline.tsx` | Cx 16 | Extracted `makeRowKeyDownHandler` from `TraceEventRow` (nested if + boolean ops) | type-check + lint + `TraceTimeline.test.tsx` |
| `dashboard/src/pages/PoliciesPage.tsx` | Cx 29 | Extracted `PoliciesTabs` (per-tab class branching) + `PoliciesSandboxBanner` (nested optional-chaining) | type-check + lint + `PoliciesPage.test.tsx` |
| `dashboard/src/features/liveOps/PipelineCanvas.tsx` `advance()` | Cx 31 | Split each switch arm into per-phase helpers; 3 in-lane dwell arms collapse into a shared `advanceInLane` | type-check + lint (see note) |

No deferrals — `advance()` reduced to a thin dispatcher via pure structural extraction.

## Type of Change

- [x] ♻️ Refactoring

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3092

## Testing

- [x] No tests required (behaviour-preserving structural refactor; existing suite covers it)

Test Plan (from inside `dashboard/`):
- `pnpm install --frozen-lockfile` — clean
- `pnpm run type-check` — clean
- `pnpm run lint` — clean (`--max-warnings 0`)
- `pnpm run test` — 121 files / 1037 tests passed

Note on `PipelineCanvas.advance()`: jsdom cannot exercise canvas `getContext`, so
this arm is validated by careful behaviour-preserving review (identical state
mutations in identical order) plus type-check + lint. The existing
`PipelineCanvas.test.tsx` still passes.

## Checklist

- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention (one per function)

Closes AAASM-3092

🤖 Generated with [Claude Code](https://claude.com/claude-code)
