### PR TITLE
[AAASM-3125] 🔒 (aa-api): Deny-by-default API auth gate + IDOR fixes

### DIFF
--- a/aa-api/src/auth/gate.rs
+++ b/aa-api/src/auth/gate.rs
@@ -1,0 +1,42 @@
+//! Router-level authentication gate (AAASM-3125).
+//!
+//! Historically every protected handler had to opt in to authentication by
+//! declaring an `AuthenticatedCaller` / `RequireScope` extractor. Handlers
+//! that forgot to do so (e.g. the alert-rule CRUD endpoints, AAASM-3129)
+//! silently shipped unauthenticated. This module provides a single
+//! deny-by-default [`require_authentication`] middleware that is applied as a
+//! `route_layer` over the protected sub-router in [`crate::routes`], so a new
+//! route is authenticated unless it is explicitly mounted on the public
+//! router.
+//!
+//! The gate reuses the existing [`AuthenticatedCaller`] extractor, so it
+//! honours `AuthMode::Off` (bypass) and the API-key / JWT validation and
+//! per-key rate-limit logic exactly as the per-handler extractors do.
+
+use axum::extract::{FromRequestParts, Request};
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use http::request::Parts;
+
+use crate::auth::AuthenticatedCaller;
+
+/// Deny-by-default authentication middleware.
+///
+/// Resolves [`AuthenticatedCaller`] from the request parts. On success the
+/// request proceeds to the inner service; on failure the [`AuthError`] is
+/// rendered (401 / 403 / 429) and the inner handler is never reached.
+///
+/// [`AuthError`]: crate::auth::AuthError
+pub async fn require_authentication(request: Request, next: Next) -> Response {
+    let (mut parts, body): (Parts, _) = request.into_parts();
+
+    // `()` is a valid `S: Send + Sync` state for the extractor — all auth
+    // inputs come from request extensions, not router state.
+    match AuthenticatedCaller::from_request_parts(&mut parts, &()).await {
+        Ok(_caller) => {
+            let request = Request::from_parts(parts, body);
+            next.run(request).await
+        }
+        Err(rejection) => rejection.into_response(),
+    }
+}

--- a/aa-api/src/auth/mod.rs
+++ b/aa-api/src/auth/mod.rs
@@ -6,6 +6,7 @@
 
 pub mod api_key;
 pub mod config;
+pub mod gate;
 pub mod jwt;
 pub mod policy_auth;
 pub mod rate_limit;

--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -10,6 +10,7 @@ use utoipa::ToSchema;
 
 use aa_gateway::registry::{AgentStatus, OrphanMode};
 
+use crate::auth::scope::{RequireRead, Scope};
 use crate::error::ProblemDetail;
 use crate::pagination::{PaginatedResponse, PaginationParams};
 use crate::state::AppState;
@@ -508,9 +509,20 @@ fn budget_row_to_response(row: aa_gateway::budget::BudgetRow) -> BudgetRowRespon
     tag = "agents"
 )]
 pub async fn get_agent_budget(
+    RequireRead(caller): RequireRead,
     Extension(state): Extension<AppState>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> Result<(StatusCode, Json<BudgetRollupResponse>), ProblemDetail> {
+    // Cross-tenant IDOR guard (AAASM-3126): the authenticated principal does
+    // not yet carry an org/team scope (AAASM-3128), so an agent's budget
+    // rollup (which spans the agent's team / org / global totals) can only be
+    // safely served to admin callers. A non-admin caller cannot be confined to
+    // its own tenant, so reading an arbitrary agent's budget is denied.
+    if !caller.scopes.contains(&Scope::Admin) {
+        return Err(ProblemDetail::from_status(StatusCode::FORBIDDEN)
+            .with_detail("Reading an agent's budget rollup requires admin scope"));
+    }
+
     let agent_id_bytes = parse_agent_id(&id)?;
     let agent_id = aa_core::identity::AgentId::from_bytes(agent_id_bytes);
 

--- a/aa-api/src/routes/alert_rules.rs
+++ b/aa-api/src/routes/alert_rules.rs
@@ -24,6 +24,7 @@ use utoipa::ToSchema;
 
 use crate::alerts::rules::store::AlertRuleStoreError;
 use crate::alerts::rules::types::{AlertRule, AlertRuleValidationError, RuleMetric, RuleOperator, RuleSeverity};
+use crate::auth::scope::{RequireRead, RequireWrite};
 use crate::error::ProblemDetail;
 use crate::state::AppState;
 
@@ -171,6 +172,7 @@ fn parse_severity(s: &str) -> Result<RuleSeverity, ProblemDetail> {
     tag = "alert-rules"
 )]
 pub async fn list_rules(
+    _auth: RequireRead,
     Extension(state): Extension<AppState>,
     Query(params): Query<ListRulesParams>,
 ) -> impl IntoResponse {
@@ -200,6 +202,7 @@ pub async fn list_rules(
     tag = "alert-rules"
 )]
 pub async fn create_rule(
+    _auth: RequireWrite,
     Extension(state): Extension<AppState>,
     Json(body): Json<AlertRuleRequest>,
 ) -> Result<(StatusCode, Json<AlertRuleResponse>), ProblemDetail> {
@@ -234,6 +237,7 @@ fn not_found(id: &str) -> ProblemDetail {
     tag = "alert-rules"
 )]
 pub async fn get_rule(
+    _auth: RequireRead,
     Extension(state): Extension<AppState>,
     Path(id): Path<String>,
 ) -> Result<(StatusCode, Json<AlertRuleResponse>), ProblemDetail> {
@@ -260,6 +264,7 @@ pub async fn get_rule(
     tag = "alert-rules"
 )]
 pub async fn update_rule(
+    _auth: RequireWrite,
     Extension(state): Extension<AppState>,
     Path(id): Path<String>,
     Json(body): Json<AlertRuleRequest>,
@@ -290,6 +295,7 @@ pub async fn update_rule(
     tag = "alert-rules"
 )]
 pub async fn delete_rule(
+    _auth: RequireWrite,
     Extension(state): Extension<AppState>,
     Path(id): Path<String>,
 ) -> Result<StatusCode, ProblemDetail> {

--- a/aa-api/src/routes/costs.rs
+++ b/aa-api/src/routes/costs.rs
@@ -5,6 +5,7 @@ use axum::{Extension, Json};
 use serde::Serialize;
 use utoipa::ToSchema;
 
+use crate::auth::scope::{RequireRead, Scope};
 use crate::state::AppState;
 
 /// Per-agent cost entry within the budget summary.
@@ -60,39 +61,63 @@ pub struct CostSummary {
 ///
 /// Retrieve the current daily and monthly cost and budget summary,
 /// including per-agent breakdown and configured budget limits.
+///
+/// The per-agent and per-team breakdowns span every tenant, so they are
+/// only populated for callers holding `Scope::Admin` (AAASM-3126). Because
+/// the authenticated principal carries no org/team scope yet (AAASM-3128),
+/// a non-admin caller cannot be filtered down to its own tenant — so it
+/// receives only the aggregate totals with the cross-tenant breakdowns
+/// elided rather than leaking every tenant's spend (cross-tenant IDOR).
 #[utoipa::path(
     get,
     path = "/api/v1/costs",
     responses(
-        (status = 200, description = "Cost and budget summary", body = CostSummary)
+        (status = 200, description = "Cost and budget summary", body = CostSummary),
+        (status = 401, description = "Missing or invalid credentials"),
     ),
     tag = "costs"
 )]
-pub async fn get_cost_summary(Extension(state): Extension<AppState>) -> (StatusCode, Json<CostSummary>) {
+pub async fn get_cost_summary(
+    RequireRead(caller): RequireRead,
+    Extension(state): Extension<AppState>,
+) -> (StatusCode, Json<CostSummary>) {
     let snapshot = state.budget_tracker.snapshot();
 
-    let per_agent: Vec<AgentCostEntry> = snapshot
-        .per_agent
-        .iter()
-        .map(|entry| AgentCostEntry {
-            agent_id: entry.agent_id_hex.clone(),
-            daily_spend_usd: entry.state.spent_usd.to_string(),
-            monthly_spend_usd: entry.state.monthly_spent_usd.map(|d| d.to_string()),
-            date: entry.state.date.to_string(),
-        })
-        .collect();
+    // Cross-tenant breakdowns are admin-only until the principal carries a
+    // tenant scope to filter on (AAASM-3126 / AAASM-3128).
+    let include_breakdown = caller.scopes.contains(&Scope::Admin);
 
-    let mut per_team: Vec<TeamCostEntry> = snapshot
-        .team_budgets
-        .iter()
-        .map(|(team_id, state)| TeamCostEntry {
-            team_id: team_id.clone(),
-            daily_spend_usd: state.spent_usd.to_string(),
-            monthly_spend_usd: state.monthly_spent_usd.map(|d| d.to_string()),
-            date: state.date.to_string(),
-        })
-        .collect();
-    per_team.sort_by(|a, b| a.team_id.cmp(&b.team_id));
+    let per_agent: Vec<AgentCostEntry> = if !include_breakdown {
+        Vec::new()
+    } else {
+        snapshot
+            .per_agent
+            .iter()
+            .map(|entry| AgentCostEntry {
+                agent_id: entry.agent_id_hex.clone(),
+                daily_spend_usd: entry.state.spent_usd.to_string(),
+                monthly_spend_usd: entry.state.monthly_spent_usd.map(|d| d.to_string()),
+                date: entry.state.date.to_string(),
+            })
+            .collect()
+    };
+
+    let per_team: Vec<TeamCostEntry> = if !include_breakdown {
+        Vec::new()
+    } else {
+        let mut rows: Vec<TeamCostEntry> = snapshot
+            .team_budgets
+            .iter()
+            .map(|(team_id, state)| TeamCostEntry {
+                team_id: team_id.clone(),
+                daily_spend_usd: state.spent_usd.to_string(),
+                monthly_spend_usd: state.monthly_spent_usd.map(|d| d.to_string()),
+                date: state.date.to_string(),
+            })
+            .collect();
+        rows.sort_by(|a, b| a.team_id.cmp(&b.team_id));
+        rows
+    };
 
     let summary = CostSummary {
         daily_spend_usd: snapshot.global.spent_usd.to_string(),

--- a/aa-api/src/routes/mod.rs
+++ b/aa-api/src/routes/mod.rs
@@ -30,7 +30,29 @@ use axum::Router;
 use crate::error::ProblemDetail;
 
 /// Build the v1 API router with all registered routes.
+///
+/// The router is split into two layers (AAASM-3125):
+///
+/// * [`public_router`] — endpoints that are reachable without a bearer
+///   credential: liveness, the token-issue endpoint (it authenticates the
+///   caller itself), the WebSocket upgrade handlers, and the SaaS webhook
+///   (HMAC-authenticated in-handler).
+/// * [`protected_router`] — everything else, gated by the deny-by-default
+///   [`require_authentication`] middleware. A newly-added route is
+///   authenticated unless it is deliberately mounted on the public router.
+///
+/// [`require_authentication`]: crate::auth::gate::require_authentication
 pub fn v1_router() -> Router {
+    public_router().merge(protected_router())
+}
+
+/// Build the router of endpoints reachable without a bearer credential.
+///
+/// These either need to be reachable to obtain a credential (`/auth/token`),
+/// are unauthenticated liveness probes (`/health`), authenticate themselves
+/// out of band (`/devtools/saas/{provider}/events` via HMAC), or perform
+/// their auth handshake during the WebSocket upgrade.
+fn public_router() -> Router {
     Router::new()
         // Health
         .route("/health", get(health::health))
@@ -38,6 +60,22 @@ pub fn v1_router() -> Router {
         .route("/ws/events", get(crate::ws::handler::ws_events_handler))
         // Auth
         .route("/auth/token", post(auth::issue_token))
+        // AAASM-1389: real-time alert event stream.
+        .route("/alerts/ws", get(crate::ws::alerts_handler::ws_alerts_handler))
+        // Dev tool webhooks — HMAC-authenticated in-handler.
+        .route("/devtools/saas/{provider}/events", post(devtools::saas_webhook))
+}
+
+/// Build the router of endpoints that require an authenticated caller.
+///
+/// The whole router is wrapped in the [`require_authentication`] gate via
+/// `route_layer`, so every handler runs only after a valid API key / JWT has
+/// been verified (or `AuthMode::Off` bypasses it). Per-handler scope and
+/// tenant checks remain the handler's responsibility.
+///
+/// [`require_authentication`]: crate::auth::gate::require_authentication
+fn protected_router() -> Router {
+    Router::new()
         // Secret Injection — tool dispatch (AAASM-1920)
         .route("/dispatch_tool", post(dispatch::dispatch_tool))
         // Agents
@@ -72,10 +110,6 @@ pub fn v1_router() -> Router {
         .route("/iam/api-keys/{id}/rotate", post(iam::rotate_api_key))
         // Alerts
         .route("/alerts", get(alerts::list_alerts))
-        // AAASM-1389: real-time alert event stream (placed BEFORE the
-        // /alerts/{id} catch-all so the literal "ws" path segment is
-        // matched first).
-        .route("/alerts/ws", get(crate::ws::alerts_handler::ws_alerts_handler))
         // AAASM-1648: silence-an-alert endpoint. Literal "silence" path
         // segment must come BEFORE /alerts/{id} so it isn't captured
         // as an id.
@@ -106,11 +140,6 @@ pub fn v1_router() -> Router {
                 .delete(destinations::delete_destination),
         )
         .route("/alerts/destinations/{id}/test", post(destinations::test_destination))
-        // Dev tool webhooks
-        .route(
-            "/devtools/saas/{provider}/events",
-            post(devtools::saas_webhook),
-        )
         // Tools
         .route("/tools", get(tools::list_tools))
         // Topology
@@ -138,6 +167,8 @@ pub fn v1_router() -> Router {
             get(admin::get_retention_policy).put(admin::update_retention_policy),
         )
         .route("/admin/retention-policy/run", post(admin::run_retention_policy))
+        // Deny-by-default auth gate over every protected route (AAASM-3125).
+        .route_layer(axum::middleware::from_fn(crate::auth::gate::require_authentication))
 }
 
 /// Fallback handler returning a 404 RFC 7807 response.

--- a/aa-api/tests/auth_gate.rs
+++ b/aa-api/tests/auth_gate.rs
@@ -1,0 +1,191 @@
+//! Integration tests for the router-level authentication gate (AAASM-3125,
+//! AAASM-3129, AAASM-3126).
+//!
+//! These assert the deny-by-default behavior of the protected sub-router:
+//! protected routes reject unauthenticated callers with 401, public routes
+//! stay reachable, alert-rule CRUD is gated, and the cross-tenant spend
+//! surfaces are restricted.
+
+mod common;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use aa_api::auth::scope::Scope;
+
+fn bearer(uri: &str, method: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .header("content-type", "application/json")
+        .body(Body::empty())
+        .unwrap()
+}
+
+// ── F1 / AAASM-3125: deny-by-default over protected routes ──────────────────
+
+#[tokio::test]
+async fn protected_route_without_credentials_is_401() {
+    let app = common::test_app_with_auth(&[], 1000);
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/agents").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn protected_route_with_valid_key_is_not_401() {
+    let (plaintext, entry) = common::generate_test_api_key("k", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app.oneshot(bearer("/api/v1/agents", "GET", &plaintext)).await.unwrap();
+
+    assert_ne!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn health_endpoint_stays_public() {
+    let app = common::test_app_with_auth(&[], 1000);
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+// ── N1 / AAASM-3129: alert-rule CRUD requires auth ──────────────────────────
+
+#[tokio::test]
+async fn alert_rules_list_without_credentials_is_401() {
+    let app = common::test_app_with_auth(&[], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/alerts/rules")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn alert_rules_create_without_credentials_is_401() {
+    let app = common::test_app_with_auth(&[], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/alerts/rules")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn alert_rules_create_with_read_only_key_is_403() {
+    let (plaintext, entry) = common::generate_test_api_key("ro", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/alerts/rules")
+                .header("authorization", format!("Bearer {plaintext}"))
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Read-only caller is authenticated but lacks write scope.
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+// ── F1a / AAASM-3126: cross-tenant IDOR on /costs ───────────────────────────
+
+#[tokio::test]
+async fn costs_without_credentials_is_401() {
+    let app = common::test_app_with_auth(&[], 1000);
+
+    let response = app
+        .oneshot(Request::builder().uri("/api/v1/costs").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn costs_non_admin_does_not_leak_cross_tenant_breakdown() {
+    let (plaintext, entry) = common::generate_test_api_key("ro", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+
+    let response = app.oneshot(bearer("/api/v1/costs", "GET", &plaintext)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        json["per_agent"].as_array().unwrap().len(),
+        0,
+        "non-admin must not receive the cross-tenant per-agent breakdown"
+    );
+    assert_eq!(
+        json["per_team"].as_array().unwrap().len(),
+        0,
+        "non-admin must not receive the cross-tenant per-team breakdown"
+    );
+}
+
+// ── F1a / AAASM-3126: cross-tenant IDOR on /agents/{id}/budget ──────────────
+
+#[tokio::test]
+async fn agent_budget_without_credentials_is_401() {
+    let app = common::test_app_with_auth(&[], 1000);
+    let agent_id = "00000000000000000000000000000000";
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/v1/agents/{agent_id}/budget"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn agent_budget_non_admin_is_403() {
+    let (plaintext, entry) = common::generate_test_api_key("ro", vec![Scope::Read]);
+    let app = common::test_app_with_auth(&[entry], 1000);
+    let agent_id = "00000000000000000000000000000000";
+
+    let response = app
+        .oneshot(bearer(&format!("/api/v1/agents/{agent_id}/budget"), "GET", &plaintext))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}

--- a/aa-api/tests/policy_rbac_integration.rs
+++ b/aa-api/tests/policy_rbac_integration.rs
@@ -180,10 +180,13 @@ async fn invalid_scope_string_returns_400() {
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
-// ── GET endpoints remain accessible without auth ────────────────────────────
+// ── GET endpoints are gated by the deny-by-default auth layer ───────────────
 
+/// Regression for AAASM-3125: prior to the router-level auth gate, read
+/// endpoints such as `GET /policies` were reachable without any credential.
+/// They now reject unauthenticated callers with 401.
 #[tokio::test]
-async fn list_policies_requires_no_auth() {
+async fn list_policies_requires_auth() {
     let app = common::test_app_with_auth(&[], 1000);
 
     let response = app
@@ -191,5 +194,5 @@ async fn list_policies_requires_no_auth() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -785,6 +785,13 @@ export interface paths {
          * `GET /api/v1/costs` — cost and budget summary.
          * @description Retrieve the current daily and monthly cost and budget summary,
          *     including per-agent breakdown and configured budget limits.
+         *
+         *     The per-agent and per-team breakdowns span every tenant, so they are
+         *     only populated for callers holding `Scope::Admin` (AAASM-3126). Because
+         *     the authenticated principal carries no org/team scope yet (AAASM-3128),
+         *     a non-admin caller cannot be filtered down to its own tenant — so it
+         *     receives only the aggregate totals with the cross-tenant breakdowns
+         *     elided rather than leaking every tenant's spend (cross-tenant IDOR).
          */
         get: operations["get_cost_summary"];
         put?: never;
@@ -4855,6 +4862,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["CostSummary"];
                 };
+            };
+            /** @description Missing or invalid credentials */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1403,6 +1403,13 @@ paths:
       description: |-
         Retrieve the current daily and monthly cost and budget summary,
         including per-agent breakdown and configured budget limits.
+
+        The per-agent and per-team breakdowns span every tenant, so they are
+        only populated for callers holding `Scope::Admin` (AAASM-3126). Because
+        the authenticated principal carries no org/team scope yet (AAASM-3128),
+        a non-admin caller cannot be filtered down to its own tenant — so it
+        receives only the aggregate totals with the cross-tenant breakdowns
+        elided rather than leaking every tenant's spend (cross-tenant IDOR).
       operationId: get_cost_summary
       responses:
         '200':
@@ -1411,6 +1418,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CostSummary'
+        '401':
+          description: Missing or invalid credentials
   /api/v1/dispatch_tool:
     post:
       tags:


### PR DESCRIPTION
## Description

Closes a cluster of broken-access-control findings in the `aa-api` HTTP surface (security review F1 / F1a / N1). Adds a single deny-by-default router-level authentication gate so a protected route is authenticated unless it is deliberately mounted on the public router, plus per-handler scope/tenant hardening on the alert-rule, cost, and agent-budget endpoints.

- **AAASM-3125 (F1):** most endpoints relied on per-handler extractors and many had none. New `require_authentication` middleware is applied as a `route_layer` over a `protected_router`; the `public_router` keeps `/health`, `/auth/token`, the WS upgrades, and the HMAC-authed SaaS webhook. The gate reuses the existing `AuthenticatedCaller` extractor, so `AuthMode::Off` still bypasses.
- **AAASM-3129 (N1):** the five `/alerts/rules` CRUD handlers were unauthenticated. They are now both covered by the blanket gate and carry explicit `RequireRead` / `RequireWrite` extractors (defense-in-depth).
- **AAASM-3126 (F1a):** `/costs` and `/agents/{id}/budget` leaked every tenant's spend. Because the principal carries no org/team scope yet, the cross-tenant breakdowns are restricted to `Scope::Admin`: a non-admin `/costs` caller receives only aggregate totals (breakdowns elided), and a non-admin `/agents/{id}/budget` caller is denied (403).

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 🔧 Configuration / CI change

## Breaking Changes

- [ ] No
- [x] Yes (describe below)

When `AuthMode::On`, read endpoints that were previously reachable without credentials now return 401. This is the intended remediation. `AuthMode::Off` behavior is unchanged. The cross-tenant cost/budget breakdowns now require admin scope.

## Related Issues

- Related Jira tickets: AAASM-3125, AAASM-3129, AAASM-3126
- Closes AAASM-3125
- Closes AAASM-3129
- Closes AAASM-3126

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

New `aa-api/tests/auth_gate.rs` (10 tests): unauthenticated protected route -> 401, public route reachable, alert-rule CRUD 401/403, `/costs` cross-tenant elision for non-admin, agent-budget IDOR 401/403. Updated `policy_rbac_integration::list_policies_requires_auth` to assert the corrected deny-by-default behavior. Full `aa-api` suite: 550/551 pass; the single failure (`http_policy_invalidation`, a pre-existing 100ms-timing flake that runs under `AuthMode::Off` and passes in isolation) is unrelated to this change.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Validated locally (org CI is billing-blocked): `cargo build -p aa-api`, `cargo clippy -p aa-api --all-targets -- -D warnings`, `cargo nextest run -p aa-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
