### PR TITLE
[AAASM-3128] 🔒 (aa-runtime): Stop logging decrypted TLS payload plaintext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,7 @@ version = "0.0.1-beta.2"
 dependencies = [
  "aa-core",
  "aa-ebpf",
+ "aa-ebpf-common",
  "aa-proto",
  "aa-security",
  "aa-storage-sqlite-buffer",

--- a/aa-runtime/Cargo.toml
+++ b/aa-runtime/Cargo.toml
@@ -44,6 +44,11 @@ which                       = { workspace = true }
 aa-ebpf = { path = "../aa-ebpf", version = "0.0.1-beta.2" }
 libc    = { workspace = true }
 
+# Linux-only dev dep: the AAASM-3128 regression test constructs a
+# `TlsCaptureEvent` to prove the DEBUG log never emits its plaintext payload.
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+aa-ebpf-common = { path = "../aa-ebpf-common", version = "0.0.1-beta.2", features = ["std"] }
+
 [dev-dependencies]
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -1736,4 +1736,75 @@ mod layer_integration {
         tracker.close();
         let _ = tokio::time::timeout(Duration::from_secs(1), tracker.wait()).await;
     }
+
+    /// Regression for AAASM-3128: the DEBUG-level TLS ring-buffer log must
+    /// never contain the decrypted-TLS `payload` bytes. Captures the tracing
+    /// output of [`super::log_ebpf_tls_event`] for an event whose payload holds
+    /// a known secret, and asserts the secret is absent while the scalar
+    /// metadata is present.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn tls_event_log_omits_payload_plaintext() {
+        use std::sync::{Arc, Mutex};
+
+        use aa_ebpf::ringbuf::EbpfEvent;
+        use aa_ebpf_common::tls::{TlsCaptureEvent, MAX_PAYLOAD_LEN};
+        use tracing::subscriber;
+        use tracing_subscriber::fmt::MakeWriter;
+
+        // Shared in-memory sink the fmt layer writes into.
+        #[derive(Clone, Default)]
+        struct BufWriter(Arc<Mutex<Vec<u8>>>);
+        impl std::io::Write for BufWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().unwrap().extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+        impl<'a> MakeWriter<'a> for BufWriter {
+            type Writer = BufWriter;
+            fn make_writer(&'a self) -> Self::Writer {
+                self.clone()
+            }
+        }
+
+        const SECRET: &[u8] = b"Authorization: Bearer sk-super-secret-token-value";
+        let mut payload = [0u8; MAX_PAYLOAD_LEN];
+        payload[..SECRET.len()].copy_from_slice(SECRET);
+        let event = EbpfEvent::Tls(Box::new(TlsCaptureEvent {
+            timestamp_ns: 42,
+            pid: 1234,
+            tid: 5678,
+            data_len: SECRET.len() as u32,
+            seq: 0,
+            direction: 0,
+            _pad: [0u8; 7],
+            payload,
+        }));
+
+        let sink = BufWriter::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .with_writer(sink.clone())
+            .finish();
+
+        subscriber::with_default(subscriber, || super::log_ebpf_tls_event(&event));
+
+        let out = String::from_utf8_lossy(&sink.0.lock().unwrap()).to_string();
+        assert!(
+            !out.contains("super-secret-token-value"),
+            "TLS log must not contain decrypted payload bytes; got: {out}"
+        );
+        assert!(
+            out.contains("1234"),
+            "scalar pid metadata should still be logged: {out}"
+        );
+        assert!(
+            out.contains("data_len"),
+            "scalar metadata should still be logged: {out}"
+        );
+    }
 }

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -152,7 +152,7 @@ fn spawn_ebpf_tls(
         loop {
             match reader.next().await {
                 Ok(Some(event)) => {
-                    tracing::debug!(?event, "TLS ring buffer event");
+                    log_ebpf_tls_event(&event);
                     let _ = &tls_broadcast_tx; // keep broadcast_tx alive for future forwarding
                 }
                 Ok(None) => {
@@ -168,6 +168,33 @@ fn spawn_ebpf_tls(
         }
     });
     tracing::info!("ebpf/tls sub-layer task spawned");
+}
+
+/// Log a ring-buffer event at DEBUG using **only scalar metadata**.
+///
+/// SECURITY (AAASM-3128): a `TlsCaptureEvent` carries up to
+/// [`aa_ebpf_common::tls::MAX_PAYLOAD_LEN`] bytes of decrypted-TLS plaintext —
+/// the credentials, tokens, and request bodies this layer exists to govern.
+/// Its derived `Debug` impl renders that payload, so logging the event with
+/// `?event` would dump raw secrets straight to the log sink, bypassing the
+/// credential scanner. This function deliberately emits only the scalar
+/// header fields (pid/tid/lengths/sequence/direction/timestamp) and never the
+/// `payload`.
+#[cfg(target_os = "linux")]
+fn log_ebpf_tls_event(event: &aa_ebpf::ringbuf::EbpfEvent) {
+    if let aa_ebpf::ringbuf::EbpfEvent::Tls(tls) = event {
+        tracing::debug!(
+            pid = tls.pid,
+            tid = tls.tid,
+            data_len = tls.data_len,
+            seq = tls.seq,
+            direction = tls.direction,
+            timestamp_ns = tls.timestamp_ns,
+            "TLS ring buffer event"
+        );
+    } else {
+        tracing::debug!("non-TLS ring buffer event on TLS reader");
+    }
 }
 
 #[cfg(not(target_os = "linux"))]


### PR DESCRIPTION
## Description

Fixes the decrypted-TLS plaintext logging finding (security review F15 / AAASM-3128) in the eBPF TLS sub-layer.

In `aa-runtime/src/runtime.rs`, the eBPF ring-buffer reader logged each captured event with `tracing::debug!(?event, ...)`. `TlsCaptureEvent` derives `Debug`, which renders its up-to-4 KiB `payload` field — the decrypted-TLS plaintext (credentials, bearer tokens, request bodies) this layer exists to govern. A `Debug`-format log dumps that raw secret straight into the log sink, bypassing the credential scanner.

The fix extracts the emit into `log_ebpf_tls_event`, which logs only the scalar header metadata (`pid`, `tid`, `data_len`, `seq`, `direction`, `timestamp_ns`) and never the `payload`.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 🔧 Configuration / CI change

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

The DEBUG TLS log line now carries only scalar metadata instead of the full event Debug; no API or behavior change beyond the removed plaintext.

## Related Issues

- Related Jira ticket: AAASM-3128
- Closes AAASM-3128

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Added a Linux-gated regression test (`tls_event_log_omits_payload_plaintext`) that captures the `tracing` output of `log_ebpf_tls_event` for an event whose payload holds a known secret, and asserts the secret bytes are absent while the scalar metadata is still present.

**Local validation note:** the production fix, host build, host clippy, and the full host `aa-runtime` test suite (284 passed) are green on macOS. The eBPF TLS path and its regression test are `#[cfg(target_os = "linux")]`, and this dev machine lacks the `x86_64-linux-gnu` C cross-toolchain (`aws-lc-sys`/`ring` fail to cross-compile), so the Linux-only test was self-reviewed but **could not be executed locally** — it needs the Linux CI runner to run.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
