### PR TITLE
[AAASM-3110] 🔒 (aa-runtime): Fail closed when gateway unreachable in enforce mode

### DIFF
--- a/aa-runtime/src/config.rs
+++ b/aa-runtime/src/config.rs
@@ -114,6 +114,19 @@ pub struct RuntimeConfig {
     /// Read from `AA_ENFORCEMENT_MAX_FIELD_BYTES`. Defaults to
     /// [`DEFAULT_MAX_FIELD_BYTES`] (64 KiB). Zero falls back to the default.
     pub enforcement_max_field_bytes: usize,
+
+    /// Whether a policy check **denies** when the gateway is configured but
+    /// unreachable (fail-closed), instead of falling back to permissive local
+    /// evaluation (fail-open).
+    ///
+    /// Read from `AA_GATEWAY_FAIL_CLOSED`. Defaults to `true` — the enforce
+    /// posture. The gateway is the authoritative policy decision point; when it
+    /// cannot be reached we must not silently default to Allow (AAASM-3110), so
+    /// the safe default is to deny. Set to `false` only for an observe /
+    /// disabled posture where the runtime should fall back to local rules and
+    /// allow on no match. Accepts `false`/`0`/`no`/`off` (case-insensitive) to
+    /// disable; any other value (or unset) keeps fail-closed.
+    pub gateway_fail_closed: bool,
 }
 
 impl RuntimeConfig {
@@ -143,6 +156,7 @@ impl RuntimeConfig {
     /// | `AA_NATS_CONFIG_PATH` | `Option<PathBuf>` | `None` (publisher disabled) |
     /// | `AA_AUDIT_BUFFER_PATH` | `PathBuf` | `<temp>/aa-audit-buffer-<agent_id>.db` |
     /// | `AA_ENFORCEMENT_MAX_FIELD_BYTES` | `usize` | `65536` (64 KiB) |
+    /// | `AA_GATEWAY_FAIL_CLOSED` | `bool` | `true` (deny on gateway unreachable) |
     pub fn from_env() -> Result<Self, String> {
         let agent_id = std::env::var("AA_AGENT_ID").map_err(|_| "AA_AGENT_ID is required but not set".to_string())?;
 
@@ -233,6 +247,12 @@ impl RuntimeConfig {
             .filter(|&n| n > 0)
             .unwrap_or(DEFAULT_MAX_FIELD_BYTES);
 
+        // Fail-closed by default; only an explicit falsey value opts out.
+        let gateway_fail_closed = std::env::var("AA_GATEWAY_FAIL_CLOSED")
+            .ok()
+            .map(|v| !matches!(v.trim().to_ascii_lowercase().as_str(), "false" | "0" | "no" | "off"))
+            .unwrap_or(true);
+
         Ok(Self {
             agent_id,
             worker_threads,
@@ -250,6 +270,7 @@ impl RuntimeConfig {
             nats_config_path,
             audit_buffer_path,
             enforcement_max_field_bytes,
+            gateway_fail_closed,
         })
     }
 }
@@ -772,5 +793,31 @@ mod tests {
         );
 
         std::env::remove_var("AA_AGENT_ID");
+    }
+
+    #[test]
+    fn gateway_fail_closed_defaults_true_and_honors_falsey_opt_out() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AA_AGENT_ID", "agent-fc");
+
+        // Unset → fail-closed (the safe enforce default, AAASM-3110).
+        std::env::remove_var("AA_GATEWAY_FAIL_CLOSED");
+        assert!(RuntimeConfig::from_env().unwrap().gateway_fail_closed);
+
+        // Explicit falsey values opt out (observe/disabled posture).
+        for falsey in ["false", "0", "no", "off", "OFF", "False"] {
+            std::env::set_var("AA_GATEWAY_FAIL_CLOSED", falsey);
+            assert!(
+                !RuntimeConfig::from_env().unwrap().gateway_fail_closed,
+                "{falsey} should disable fail-closed"
+            );
+        }
+
+        // Any other value keeps fail-closed.
+        std::env::set_var("AA_GATEWAY_FAIL_CLOSED", "true");
+        assert!(RuntimeConfig::from_env().unwrap().gateway_fail_closed);
+
+        std::env::remove_var("AA_AGENT_ID");
+        std::env::remove_var("AA_GATEWAY_FAIL_CLOSED");
     }
 }

--- a/aa-runtime/src/correlation/config.rs
+++ b/aa-runtime/src/correlation/config.rs
@@ -80,6 +80,7 @@ mod tests {
             nats_config_path: None,
             audit_buffer_path: std::path::PathBuf::from("/tmp/aa-audit-buffer-test.db"),
             enforcement_max_field_bytes: crate::pipeline::enforcement::DEFAULT_MAX_FIELD_BYTES,
+            gateway_fail_closed: true,
         };
 
         let config = CorrelationConfig::from_runtime_config(&rc);

--- a/aa-runtime/src/gateway_client.rs
+++ b/aa-runtime/src/gateway_client.rs
@@ -28,4 +28,17 @@ impl GatewayClient {
         let resp = self.client.check_action(req).await?;
         Ok(resp.into_inner())
     }
+
+    /// Build a client over a **lazy** channel to `endpoint` without connecting.
+    ///
+    /// Used by the AAASM-3110 fail-closed test to obtain a `GatewayClient`
+    /// whose `check_action` is guaranteed to fail (the endpoint never listens),
+    /// exercising the gateway-unreachable path without standing up a server.
+    #[cfg(test)]
+    pub(crate) fn connect_lazy(endpoint: &'static str) -> Self {
+        let channel = Channel::from_static(endpoint).connect_lazy();
+        Self {
+            client: PolicyServiceClient::new(channel),
+        }
+    }
 }

--- a/aa-runtime/src/ipc/server.rs
+++ b/aa-runtime/src/ipc/server.rs
@@ -641,6 +641,7 @@ mod tests {
             broadcast_capacity: 64,
             agent_id: "test-agent".to_string(),
             enforcement: crate::pipeline::enforcement::EnforcementConfig::default(),
+            gateway_fail_closed: true,
         };
         let pipeline_metrics = Arc::new(PipelineMetrics::default());
         let (broadcast_tx, _broadcast_rx) = tokio::sync::broadcast::channel::<crate::pipeline::PipelineEvent>(64);
@@ -734,6 +735,7 @@ mod tests {
             broadcast_capacity: 64,
             agent_id: "test-agent".to_string(),
             enforcement: crate::pipeline::enforcement::EnforcementConfig::default(),
+            gateway_fail_closed: true,
         };
         let pipeline_metrics = Arc::new(PipelineMetrics::default());
         let (broadcast_tx, _broadcast_rx) = tokio::sync::broadcast::channel::<crate::pipeline::PipelineEvent>(64);
@@ -834,6 +836,7 @@ mod tests {
             broadcast_capacity: 64,
             agent_id: "test-agent".to_string(),
             enforcement: crate::pipeline::enforcement::EnforcementConfig::default(),
+            gateway_fail_closed: true,
         };
         let pipeline_metrics = Arc::new(PipelineMetrics::default());
         let (broadcast_tx, _broadcast_rx) = tokio::sync::broadcast::channel::<crate::pipeline::PipelineEvent>(64);

--- a/aa-runtime/src/pipeline/enforcement.rs
+++ b/aa-runtime/src/pipeline/enforcement.rs
@@ -512,6 +512,7 @@ mod tests {
             nats_config_path: None,
             audit_buffer_path: std::path::PathBuf::from("/tmp/aa-audit-buffer-test.db"),
             enforcement_max_field_bytes: 4096,
+            gateway_fail_closed: true,
         };
 
         let config = EnforcementConfig::from_runtime_config(&rc);

--- a/aa-runtime/src/pipeline/mod.rs
+++ b/aa-runtime/src/pipeline/mod.rs
@@ -40,6 +40,10 @@ pub struct PipelineConfig {
     pub agent_id: String,
     /// Runtime scan/redact enforcement config — derived from `RuntimeConfig`.
     pub enforcement: enforcement::EnforcementConfig,
+    /// Deny a policy check when the gateway is configured but unreachable,
+    /// instead of falling back to permissive local evaluation (AAASM-3110).
+    /// Copied from [`RuntimeConfig::gateway_fail_closed`]; defaults to `true`.
+    pub gateway_fail_closed: bool,
 }
 
 impl PipelineConfig {
@@ -52,6 +56,7 @@ impl PipelineConfig {
             broadcast_capacity: c.pipeline_broadcast_capacity,
             agent_id: c.agent_id.clone(),
             enforcement: enforcement::EnforcementConfig::from_runtime_config(c),
+            gateway_fail_closed: c.gateway_fail_closed,
         }
     }
 }
@@ -129,6 +134,7 @@ pub async fn run(
                             &approval_queue,
                             &response_router,
                             &gateway_client,
+                            config.gateway_fail_closed,
                             &broadcast_tx,
                             &seq,
                         )
@@ -247,8 +253,14 @@ async fn send_ipc_response(connection_id: u64, response: IpcResponse, router: &R
 /// Evaluate a [`IpcFrame::PolicyQuery`] against the loaded policy and respond.
 ///
 /// When `gateway_client` is `Some`, the request is forwarded to the governance
-/// gateway over gRPC. If the gateway call fails, the function falls back to
-/// local [`PolicyRules`] evaluation with a warning log.
+/// gateway over gRPC. The gateway is the authoritative decision point.
+///
+/// **Fail-closed (AAASM-3110):** when the gateway is configured but the call
+/// fails (unreachable / timeout / transport error) and `fail_closed` is set,
+/// the check is **denied** rather than silently falling back to permissive
+/// local evaluation. Allow-on-fallback is only used when the gateway is not
+/// configured at all, or when `fail_closed` is `false` (observe / disabled
+/// posture).
 ///
 /// Local decision priority (first match wins):
 /// 1. `requires_approval_actions` → `PENDING` + submit to [`ApprovalQueue`]; spawn a task to
@@ -263,11 +275,12 @@ async fn handle_policy_query(
     approval_queue: &Arc<ApprovalQueue>,
     response_router: &ResponseRouter,
     gateway_client: &Option<Arc<Mutex<GatewayClient>>>,
+    fail_closed: bool,
     broadcast_tx: &broadcast::Sender<PipelineEvent>,
     sequence_counter: &AtomicU64,
 ) {
     // ── Gateway forwarding path ─────────────────────────────────────────
-    if try_gateway_forward(
+    match try_gateway_forward(
         connection_id,
         &req,
         gateway_client,
@@ -277,7 +290,30 @@ async fn handle_policy_query(
     )
     .await
     {
-        return;
+        // Gateway answered (allow/deny/approval) — response already sent.
+        GatewayOutcome::Handled => return,
+        // Gateway configured but unreachable: fail closed in enforce posture
+        // instead of leaking through to a permissive local default (AAASM-3110).
+        GatewayOutcome::Failed if fail_closed => {
+            tracing::warn!(
+                connection_id,
+                "gateway unreachable and fail-closed enabled — denying action"
+            );
+            send_ipc_response(
+                connection_id,
+                IpcResponse::PolicyResponse(CheckActionResponse {
+                    decision: Decision::Deny as i32,
+                    reason: "gateway unreachable; denied by fail-closed policy".to_string(),
+                    ..Default::default()
+                }),
+                response_router,
+            )
+            .await;
+            return;
+        }
+        // No gateway configured, or observe/disabled posture — fall through to
+        // local evaluation.
+        GatewayOutcome::NoClient | GatewayOutcome::Failed => {}
     }
 
     // ── Local evaluation path ───────────────────────────────────────────
@@ -335,10 +371,23 @@ async fn handle_policy_query(
     .await;
 }
 
+/// Outcome of attempting to forward a policy check to the gateway.
+///
+/// The caller ([`handle_policy_query`]) distinguishes these so it can fail
+/// **closed** when a configured gateway is unreachable, rather than treating
+/// every non-`Handled` outcome as "fall back and allow" (AAASM-3110).
+enum GatewayOutcome {
+    /// The gateway answered and a response was already sent to the SDK.
+    Handled,
+    /// No gateway client is configured — pure local-evaluation mode.
+    NoClient,
+    /// A gateway client is configured but the RPC failed (unreachable, timeout,
+    /// transport error). The caller decides allow-fallback vs fail-closed deny.
+    Failed,
+}
+
 /// Forward the request to the governance gateway over gRPC when a client is
-/// configured. Returns `true` when the request was fully handled (a response
-/// was sent); `false` when there is no client or the call failed, signalling
-/// the caller to fall back to local [`PolicyRules`] evaluation.
+/// configured. See [`GatewayOutcome`] for how the caller interprets the result.
 async fn try_gateway_forward(
     connection_id: u64,
     req: &aa_proto::assembly::policy::v1::CheckActionRequest,
@@ -346,9 +395,9 @@ async fn try_gateway_forward(
     response_router: &ResponseRouter,
     broadcast_tx: &broadcast::Sender<PipelineEvent>,
     sequence_counter: &AtomicU64,
-) -> bool {
+) -> GatewayOutcome {
     let Some(client) = gateway_client else {
-        return false;
+        return GatewayOutcome::NoClient;
     };
     let mut guard = client.lock().await;
     match guard.check_action(req.clone()).await {
@@ -362,15 +411,15 @@ async fn try_gateway_forward(
                 emit_gateway_violation(req, &resp, connection_id, broadcast_tx, sequence_counter);
             }
             send_ipc_response(connection_id, IpcResponse::PolicyResponse(resp), response_router).await;
-            true
+            GatewayOutcome::Handled
         }
         Err(e) => {
             tracing::warn!(
                 connection_id,
                 error = %e,
-                "gateway call failed — falling back to local policy evaluation"
+                "gateway call failed"
             );
-            false
+            GatewayOutcome::Failed
         }
     }
 }
@@ -719,6 +768,7 @@ mod tests {
             nats_config_path: None,
             audit_buffer_path: std::path::PathBuf::from("/tmp/aa-audit-buffer-test.db"),
             enforcement_max_field_bytes: enforcement::DEFAULT_MAX_FIELD_BYTES,
+            gateway_fail_closed: true,
         };
 
         let pipeline_config = PipelineConfig::from_runtime_config(&runtime_config);
@@ -745,6 +795,7 @@ mod tests {
             broadcast_capacity: 512,
             agent_id: "test-agent".to_string(),
             enforcement: enforcement::EnforcementConfig::default(),
+            gateway_fail_closed: true,
         };
 
         let cloned = pipeline_config.clone();
@@ -764,6 +815,7 @@ mod tests {
             broadcast_capacity: 1_024,
             agent_id: "test-agent".to_string(),
             enforcement: enforcement::EnforcementConfig::default(),
+            gateway_fail_closed: true,
         }
     }
 
@@ -1377,6 +1429,110 @@ mod tests {
 
         if let IpcResponse::PolicyResponse(r) = resp {
             assert_eq!(r.decision, Decision::Deny as i32);
+        } else {
+            panic!("expected PolicyResponse, got {resp:?}");
+        }
+        token.cancel();
+    }
+
+    /// AAASM-3110: when a gateway is configured but unreachable and the runtime
+    /// is in the fail-closed (enforce) posture, a policy check must be DENIED —
+    /// never silently allowed by the permissive local default.
+    #[tokio::test]
+    async fn gateway_unreachable_fail_closed_responds_deny() {
+        use aa_proto::assembly::common::v1::{ActionType, Decision};
+
+        let config = test_config(100, 10_000); // gateway_fail_closed = true
+        let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
+        let (broadcast_tx, _rx) = broadcast::channel::<PipelineEvent>(64);
+        let metrics = Arc::new(PipelineMetrics::default());
+        let token = CancellationToken::new();
+        let (router, mut resp_rx) = make_router_with_receiver();
+        let approval_queue = crate::approval::ApprovalQueue::new();
+
+        // Lazy client to a port that never listens → check_action fails.
+        let gateway = Arc::new(Mutex::new(crate::gateway_client::GatewayClient::connect_lazy(
+            "http://127.0.0.1:1",
+        )));
+
+        tokio::spawn(run(
+            rx,
+            broadcast_tx,
+            config,
+            metrics,
+            token.clone(),
+            Arc::new(PolicyRules::default()),
+            router,
+            approval_queue,
+            Some(gateway),
+            Arc::new(AtomicU64::new(0)),
+        ));
+
+        tx.send((0, policy_query_frame(ActionType::ToolCall))).await.unwrap();
+
+        let resp = tokio::time::timeout(Duration::from_secs(2), resp_rx.recv())
+            .await
+            .expect("response timed out")
+            .expect("channel closed");
+
+        if let IpcResponse::PolicyResponse(r) = resp {
+            assert_eq!(
+                r.decision,
+                Decision::Deny as i32,
+                "gateway unreachable in fail-closed posture must deny"
+            );
+        } else {
+            panic!("expected PolicyResponse, got {resp:?}");
+        }
+        token.cancel();
+    }
+
+    /// AAASM-3110: in the observe/disabled posture (`gateway_fail_closed = false`)
+    /// a gateway-unreachable check falls back to permissive local evaluation,
+    /// which allows when no local rule matches.
+    #[tokio::test]
+    async fn gateway_unreachable_fail_open_falls_back_to_local_allow() {
+        use aa_proto::assembly::common::v1::{ActionType, Decision};
+
+        let mut config = test_config(100, 10_000);
+        config.gateway_fail_closed = false;
+        let (tx, rx) = mpsc::channel::<(u64, IpcFrame)>(64);
+        let (broadcast_tx, _rx) = broadcast::channel::<PipelineEvent>(64);
+        let metrics = Arc::new(PipelineMetrics::default());
+        let token = CancellationToken::new();
+        let (router, mut resp_rx) = make_router_with_receiver();
+        let approval_queue = crate::approval::ApprovalQueue::new();
+
+        let gateway = Arc::new(Mutex::new(crate::gateway_client::GatewayClient::connect_lazy(
+            "http://127.0.0.1:1",
+        )));
+
+        tokio::spawn(run(
+            rx,
+            broadcast_tx,
+            config,
+            metrics,
+            token.clone(),
+            Arc::new(PolicyRules::default()),
+            router,
+            approval_queue,
+            Some(gateway),
+            Arc::new(AtomicU64::new(0)),
+        ));
+
+        tx.send((0, policy_query_frame(ActionType::ToolCall))).await.unwrap();
+
+        let resp = tokio::time::timeout(Duration::from_secs(2), resp_rx.recv())
+            .await
+            .expect("response timed out")
+            .expect("channel closed");
+
+        if let IpcResponse::PolicyResponse(r) = resp {
+            assert_eq!(
+                r.decision,
+                Decision::Allow as i32,
+                "fail-open posture should fall back to local allow"
+            );
         } else {
             panic!("expected PolicyResponse, got {resp:?}");
         }

--- a/aa-runtime/src/runtime.rs
+++ b/aa-runtime/src/runtime.rs
@@ -1201,6 +1201,7 @@ mod tests {
             nats_config_path,
             audit_buffer_path: std::env::temp_dir().join("aa-audit-buffer-audit-test.db"),
             enforcement_max_field_bytes: crate::pipeline::enforcement::DEFAULT_MAX_FIELD_BYTES,
+            gateway_fail_closed: true,
         }
     }
 

--- a/aa-runtime/tests/aaasm_2568_gate_verification.rs
+++ b/aa-runtime/tests/aaasm_2568_gate_verification.rs
@@ -32,6 +32,7 @@ fn verify_config(batch_size: usize) -> PipelineConfig {
         broadcast_capacity: 1_024,
         agent_id: "verify-agent".to_string(),
         enforcement: aa_runtime::pipeline::enforcement::EnforcementConfig::default(),
+        gateway_fail_closed: true,
     }
 }
 


### PR DESCRIPTION
## Description

Fixes the fail-open finding (security review F2 / AAASM-3110, part of the fail-open Epic AAASM-3095) in the runtime policy pipeline.

When `aa-runtime` is configured with a gateway endpoint, `handle_policy_query` forwards each check to the gateway (the authoritative decision point). Previously, if that gRPC call failed (gateway unreachable / timeout / transport error), the code fell through to permissive local `PolicyRules` evaluation, which defaults to **Allow** when no local rule matches — so a denied action could slip through whenever the gateway was down.

The fix introduces a `GatewayOutcome` enum (`Handled` / `NoClient` / `Failed`) so the handler can tell a *configured-but-unreachable* gateway apart from *no gateway at all*. On `Failed` in the fail-closed (enforce) posture, the check is now **denied**. Allow-on-fallback is preserved only for the no-gateway case and the observe/disabled posture.

Posture is controlled by a new `AA_GATEWAY_FAIL_CLOSED` env var (`RuntimeConfig::gateway_fail_closed`), defaulting to `true` (enforce). Operators in an observe/disabled deployment set it falsey to keep the old permissive fallback.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 🔧 Configuration / CI change

## Breaking Changes

- [ ] No
- [x] Yes (describe below)

By default, a configured gateway that is unreachable now causes policy checks to be **denied** instead of allowed. This is the intended fail-closed remediation. Set `AA_GATEWAY_FAIL_CLOSED=false` to restore the previous fail-open behavior (observe/disabled posture). Deployments with no gateway configured are unaffected.

## Related Issues

- Related Jira ticket: AAASM-3110 (Epic AAASM-3095)
- Closes AAASM-3110

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Three new tests: gateway-unreachable + fail-closed → Deny; gateway-unreachable + fail-open → local Allow fallback; and `AA_GATEWAY_FAIL_CLOSED` parsing (default-true + falsey opt-out). The unreachable path is driven by a test-only `GatewayClient::connect_lazy` over a non-listening endpoint. Full `aa-runtime` suite: 287 passed.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Validated locally (org CI is billing-blocked): `cargo clippy -p aa-runtime --all-targets -- -D warnings`, `cargo nextest run -p aa-runtime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
