### PR TITLE
[AAASM-3130] 🔒 (aa-proxy): SSRF denylist + DNS-rebind revalidation + TLS-verify gate

### DIFF
--- a/aa-integration-tests/tests/e2e_mcp_interceptor.rs
+++ b/aa-integration-tests/tests/e2e_mcp_interceptor.rs
@@ -810,6 +810,9 @@ mod proxy_e2e {
             credential_action: CredentialAction::default(),
             upstream_override: Some(upstream_override),
             gateway_endpoint: Some(format!("http://{gateway_addr}")),
+            // CONNECT host is a public name redirected via `upstream_override`,
+            // so the SSRF guard stays fully active.
+            allow_private_connect_targets: false,
         };
         let bind_addr = config.bind_addr;
         let (tx, rx) = broadcast::channel(64);

--- a/aa-integration-tests/tests/e2e_policy_proxy.rs
+++ b/aa-integration-tests/tests/e2e_policy_proxy.rs
@@ -37,6 +37,9 @@ fn proxy_config(ca_dir: &std::path::Path, denied_hosts: Vec<String>) -> ProxyCon
         credential_action: CredentialAction::default(),
         upstream_override: None,
         gateway_endpoint: None,
+        // These tests use a loopback CONNECT target as the "allowed host"
+        // stand-in, which the AAASM-3130 SSRF guard blocks in production.
+        allow_private_connect_targets: true,
     }
 }
 

--- a/aa-integration-tests/tests/e2e_secret_interception.rs
+++ b/aa-integration-tests/tests/e2e_secret_interception.rs
@@ -570,6 +570,9 @@ mod proxy_data_path {
             credential_action,
             upstream_override: Some(upstream_override),
             gateway_endpoint: None,
+            // Dials are redirected via `upstream_override` to a loopback mock,
+            // so the SSRF guard stays fully active for the public CONNECT host.
+            allow_private_connect_targets: false,
         };
         let bind_addr = config.bind_addr;
         let (tx, rx) = broadcast::channel(64);

--- a/aa-integration-tests/tests/e2e_tool_sandbox.rs
+++ b/aa-integration-tests/tests/e2e_tool_sandbox.rs
@@ -49,6 +49,9 @@ fn proxy_config(ca_dir: &std::path::Path, network_allowlist: Vec<String>) -> Pro
         credential_action: CredentialAction::default(),
         upstream_override: None,
         gateway_endpoint: None,
+        // These tests allowlist `127.0.0.1` as a loopback stand-in upstream,
+        // which the AAASM-3130 SSRF guard blocks in production.
+        allow_private_connect_targets: true,
     }
 }
 

--- a/aa-proxy/src/config.rs
+++ b/aa-proxy/src/config.rs
@@ -105,6 +105,18 @@ pub struct ProxyConfig {
     ///
     /// Env: `AA_PROXY_GATEWAY_ENDPOINT` — e.g. `http://127.0.0.1:50051`.
     pub gateway_endpoint: Option<String>,
+
+    /// When `true`, the AAASM-3130 SSRF guard permits CONNECT targets that
+    /// resolve to private / loopback / link-local address ranges. Intended for
+    /// integration tests **only** — they stand up an in-process mock upstream
+    /// on `127.0.0.1`, which the SSRF guard would (correctly) refuse to dial in
+    /// production.
+    ///
+    /// There is **no env var** for this knob: [`ProxyConfig::from_env`] always
+    /// leaves it `false`, so a deployed binary can never be coaxed into
+    /// reaching internal address space. The guard's protection is unchanged in
+    /// every non-test build.
+    pub allow_private_connect_targets: bool,
 }
 
 impl ProxyConfig {
@@ -198,6 +210,8 @@ impl ProxyConfig {
             credential_action,
             upstream_override: None,
             gateway_endpoint,
+            // No env var: production binaries can never relax the SSRF guard.
+            allow_private_connect_targets: false,
         })
     }
 }

--- a/aa-proxy/src/config.rs
+++ b/aa-proxy/src/config.rs
@@ -69,8 +69,13 @@ pub struct ProxyConfig {
     pub network_allowlist: Vec<String>,
 
     /// When `true`, the proxy skips TLS certificate verification when
-    /// connecting to upstream servers. Intended for integration tests only —
-    /// never enable in production.
+    /// connecting to upstream servers. Intended for integration tests only.
+    ///
+    /// AAASM-3131: honoured **only in debug builds**. In a release build the
+    /// `AA_PROXY_SKIP_UPSTREAM_TLS_VERIFY` env var is ignored and this stays
+    /// `false`, so a deployed production binary can never disable upstream cert
+    /// verification. When it *is* active (debug), [`crate::run`] prints a loud
+    /// startup banner.
     /// Env: `AA_PROXY_SKIP_UPSTREAM_TLS_VERIFY` — default: `false`
     pub skip_upstream_tls_verify: bool,
 
@@ -151,9 +156,25 @@ impl ProxyConfig {
             _ => Vec::new(),
         };
 
-        let skip_upstream_tls_verify = match std::env::var("AA_PROXY_SKIP_UPSTREAM_TLS_VERIFY") {
+        let skip_upstream_tls_verify_requested = match std::env::var("AA_PROXY_SKIP_UPSTREAM_TLS_VERIFY") {
             Ok(val) => val == "1" || val.to_lowercase() == "true",
             Err(_) => false,
+        };
+        // AAASM-3131: this flag disables upstream certificate verification and
+        // is for integration tests only. In a release (production) build it must
+        // be unreachable — silently ignore the request and shout, so a stray env
+        // var in a deployed binary cannot quietly turn the proxy into a MitM that
+        // trusts any upstream certificate.
+        let skip_upstream_tls_verify = if cfg!(debug_assertions) {
+            skip_upstream_tls_verify_requested
+        } else {
+            if skip_upstream_tls_verify_requested {
+                tracing::error!(
+                    "AA_PROXY_SKIP_UPSTREAM_TLS_VERIFY is set but IGNORED in a release build — \
+                     upstream TLS verification stays ENABLED. This flag is debug-only."
+                );
+            }
+            false
         };
 
         let credential_action = match std::env::var("AA_PROXY_CREDENTIAL_ACTION") {
@@ -301,13 +322,17 @@ mod tests {
     }
 
     #[test]
-    fn from_env_skip_upstream_tls_verify_true() {
+    fn from_env_skip_upstream_tls_verify_honoured_in_debug_only() {
+        // AAASM-3131: the request is honoured only in debug builds. In a
+        // release build the env var is ignored and the flag stays `false`,
+        // so a deployed production binary cannot disable upstream TLS
+        // verification via a stray env var.
         let _lock = ENV_LOCK.lock().unwrap();
         clear_env_vars();
         std::env::set_var("AA_PROXY_SKIP_UPSTREAM_TLS_VERIFY", "1");
 
         let cfg = ProxyConfig::from_env().unwrap();
-        assert!(cfg.skip_upstream_tls_verify);
+        assert_eq!(cfg.skip_upstream_tls_verify, cfg!(debug_assertions));
     }
 
     #[test]

--- a/aa-proxy/src/lib.rs
+++ b/aa-proxy/src/lib.rs
@@ -38,6 +38,17 @@ pub async fn run(
     config: ProxyConfig,
     event_tx: tokio::sync::broadcast::Sender<aa_runtime::pipeline::PipelineEvent>,
 ) -> anyhow::Result<()> {
+    // AAASM-3131: shout if upstream TLS verification is disabled. This is a
+    // debug-only test affordance (the env var is ignored in release builds);
+    // the banner makes an accidentally-enabled run impossible to miss in logs.
+    if config.skip_upstream_tls_verify {
+        tracing::warn!(
+            "⚠️  AA_PROXY_SKIP_UPSTREAM_TLS_VERIFY is ACTIVE — upstream TLS certificate \
+             verification is DISABLED. This is for integration tests only and must NEVER \
+             be used against real upstreams."
+        );
+    }
+
     let ca = tls::CaStore::load_or_create(&config.ca_dir).await?;
 
     #[cfg(target_os = "macos")]

--- a/aa-proxy/src/lib.rs
+++ b/aa-proxy/src/lib.rs
@@ -23,6 +23,7 @@ pub mod error;
 pub mod intercept;
 pub mod mcp_enforce;
 pub mod proxy;
+pub mod ssrf;
 pub mod tls;
 
 pub use config::ProxyConfig;

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -237,6 +237,35 @@ impl ProxyServer {
         }
     }
 
+    /// Resolve `target` and open a TCP connection, re-validating every resolved
+    /// address against the SSRF denylist immediately before connecting.
+    ///
+    /// This is the DNS-rebinding defense (AAASM-3130): a hostname that passes
+    /// the allowlist at CONNECT time can resolve to — or be flipped to — an
+    /// internal address (loopback, RFC-1918, link-local, cloud metadata) by the
+    /// time the proxy actually dials. We refuse any such address here. Resolved
+    /// addresses are filtered, not just the first, so a poisoned A-record set
+    /// cannot slip an internal IP through behind a public one.
+    async fn connect_revalidated(&self, target: &str) -> Result<TcpStream, ProxyError> {
+        let addrs: Vec<_> = tokio::net::lookup_host(target)
+            .await
+            .map_err(|e| ProxyError::Config(format!("dns resolution failed for {target}: {e}")))?
+            .collect();
+        if addrs.is_empty() {
+            return Err(ProxyError::Config(format!("no addresses resolved for {target}")));
+        }
+        let safe: Vec<_> = addrs
+            .into_iter()
+            .filter(|addr| !crate::ssrf::is_blocked_ip(addr.ip()))
+            .collect();
+        if safe.is_empty() {
+            return Err(ProxyError::Config(format!(
+                "ssrf: {target} resolved only to blocked address range"
+            )));
+        }
+        Ok(TcpStream::connect(&safe[..]).await?)
+    }
+
     /// Dial the upstream TLS endpoint (TCP connect + ClientHello).
     ///
     /// Honours [`ProxyConfig::upstream_override`] when set — used by
@@ -248,8 +277,11 @@ impl ProxyServer {
         target: &str,
     ) -> Result<tokio_rustls::client::TlsStream<TcpStream>, ProxyError> {
         let upstream_tcp = match self.config.upstream_override {
+            // Integration-test path: the dial is redirected to a trusted local
+            // mock, so the SSRF re-validation below would (correctly) reject it.
+            // Skip it here; the override is never set in production.
             Some(addr) => TcpStream::connect(addr).await?,
-            None => TcpStream::connect(target).await?,
+            None => self.connect_revalidated(target).await?,
         };
         let client_config = if self.config.skip_upstream_tls_verify {
             // Integration-test-only path: skip certificate verification so tests
@@ -443,6 +475,14 @@ impl ProxyServer {
     /// pattern. Returns `None` when the connection is allowed. An empty
     /// allowlist preserves the pre-AAASM-1943 default-open behaviour.
     fn connect_deny_reason(&self, host: &str) -> Option<&'static str> {
+        // SSRF guard (AAASM-3130): an IP-literal CONNECT target pointed at
+        // loopback / RFC-1918 / link-local / cloud-metadata space must be
+        // refused regardless of the allowlist — a hostname allowlist cannot
+        // express "but not internal addresses". Names are re-validated after
+        // resolution in `dial_upstream_tls` (DNS-rebind defense).
+        if let Some(true) = crate::ssrf::blocked_ip_literal(host) {
+            return Some("ssrf: blocked address range");
+        }
         if self.config.denied_hosts.iter().any(|denied| denied == host) {
             return Some("host policy");
         }
@@ -607,7 +647,13 @@ impl ProxyServer {
             // just tunnel the raw TCP bytes transparently.
             if self.config.llm_only && detect_api(host) == LlmApiPattern::Unknown {
                 tracing::debug!(%host, "llm_only mode — transparent tunnel (no MitM)");
-                let upstream = TcpStream::connect(target).await?;
+                // SSRF re-validation also covers the transparent tunnel — this
+                // path forwards raw bytes without MitM, so it is the most likely
+                // SSRF vector if the host resolves to an internal address.
+                let upstream = match self.config.upstream_override {
+                    Some(addr) => TcpStream::connect(addr).await?,
+                    None => self.connect_revalidated(target).await?,
+                };
                 let (mut cr, mut cw) = tokio::io::split(stream);
                 let (mut ur, mut uw) = tokio::io::split(upstream);
                 tokio::select! {

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -784,3 +784,65 @@ impl ProxyServer {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn server_with(denied_hosts: Vec<String>, allowlist: Vec<String>) -> Arc<ProxyServer> {
+        let dir = tempfile::tempdir().unwrap();
+        let ca = CaStore::load_or_create(dir.path()).await.unwrap();
+        let mut config = ProxyConfig {
+            bind_addr: ([127, 0, 0, 1], 0).into(),
+            ca_dir: dir.path().to_path_buf(),
+            cert_cache_capacity: 8,
+            llm_only: true,
+            denied_hosts,
+            network_allowlist: allowlist,
+            skip_upstream_tls_verify: false,
+            credential_action: crate::config::CredentialAction::default(),
+            upstream_override: None,
+            gateway_endpoint: None,
+        };
+        config.bind_addr = ([127, 0, 0, 1], 0).into();
+        let (tx, _rx) = broadcast::channel(8);
+        ProxyServer::new(config, ca, tx)
+    }
+
+    #[tokio::test]
+    async fn connect_deny_reason_blocks_metadata_ip_literal() {
+        // SSRF: the cloud metadata endpoint as an IP literal must be denied
+        // even with an empty allowlist (which is otherwise allow-all).
+        let server = server_with(vec![], vec![]).await;
+        assert_eq!(
+            server.connect_deny_reason("169.254.169.254"),
+            Some("ssrf: blocked address range")
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_deny_reason_blocks_loopback_and_rfc1918_literals() {
+        let server = server_with(vec![], vec![]).await;
+        assert!(server.connect_deny_reason("127.0.0.1").is_some());
+        assert!(server.connect_deny_reason("10.0.0.5").is_some());
+        assert!(server.connect_deny_reason("192.168.1.1").is_some());
+    }
+
+    #[tokio::test]
+    async fn connect_deny_reason_ssrf_check_precedes_allowlist() {
+        // Even if an operator allowlists the literal, the SSRF guard wins —
+        // a hostname allowlist must never be a way to reach internal space.
+        let server = server_with(vec![], vec!["169.254.169.254".to_string()]).await;
+        assert_eq!(
+            server.connect_deny_reason("169.254.169.254"),
+            Some("ssrf: blocked address range")
+        );
+    }
+
+    #[tokio::test]
+    async fn connect_deny_reason_allows_public_host() {
+        let server = server_with(vec![], vec![]).await;
+        assert_eq!(server.connect_deny_reason("api.openai.com"), None);
+        assert_eq!(server.connect_deny_reason("1.1.1.1"), None);
+    }
+}

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -256,7 +256,11 @@ impl ProxyServer {
         }
         let safe: Vec<_> = addrs
             .into_iter()
-            .filter(|addr| !crate::ssrf::is_blocked_ip(addr.ip()))
+            .filter(|addr| {
+                // Test-only escape hatch: in-process tests dial a loopback mock.
+                // Never relaxed in production (see `allow_private_connect_targets`).
+                self.config.allow_private_connect_targets || !crate::ssrf::is_blocked_ip(addr.ip())
+            })
             .collect();
         if safe.is_empty() {
             return Err(ProxyError::Config(format!(
@@ -480,8 +484,10 @@ impl ProxyServer {
         // refused regardless of the allowlist — a hostname allowlist cannot
         // express "but not internal addresses". Names are re-validated after
         // resolution in `dial_upstream_tls` (DNS-rebind defense).
-        if let Some(true) = crate::ssrf::blocked_ip_literal(host) {
-            return Some("ssrf: blocked address range");
+        if !self.config.allow_private_connect_targets {
+            if let Some(true) = crate::ssrf::blocked_ip_literal(host) {
+                return Some("ssrf: blocked address range");
+            }
         }
         if self.config.denied_hosts.iter().any(|denied| denied == host) {
             return Some("host policy");
@@ -803,6 +809,8 @@ mod tests {
             credential_action: crate::config::CredentialAction::default(),
             upstream_override: None,
             gateway_endpoint: None,
+            // These unit tests assert the SSRF guard blocks loopback/RFC-1918.
+            allow_private_connect_targets: false,
         };
         config.bind_addr = ([127, 0, 0, 1], 0).into();
         let (tx, _rx) = broadcast::channel(8);

--- a/aa-proxy/src/ssrf.rs
+++ b/aa-proxy/src/ssrf.rs
@@ -1,0 +1,117 @@
+//! SSRF guard for the CONNECT path.
+//!
+//! The proxy dials arbitrary upstream hosts on behalf of an agent. Without a
+//! filter, an agent could coax the proxy into reaching the host's own loopback
+//! services, private RFC-1918 networks, link-local addresses, or — most
+//! dangerously — the cloud metadata endpoint (`169.254.169.254`), turning the
+//! proxy into a confused deputy for SSRF and credential exfiltration.
+//!
+//! Two checks are needed because a hostname-only allowlist cannot stop this:
+//!
+//! 1. **Literal check** — a CONNECT target may be an IP literal
+//!    (`CONNECT 169.254.169.254:80`); reject it before resolution.
+//! 2. **Resolved-IP re-validation** — a hostname that passes the allowlist can
+//!    still resolve to a blocked address, and a DNS-rebinding attacker can flip
+//!    the answer between the policy check and the dial. We therefore re-validate
+//!    every resolved address immediately before connecting.
+
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+/// Returns `true` when `ip` is in a range the proxy must never dial on an
+/// agent's behalf: loopback, private (RFC 1918 / unique-local), link-local
+/// (including the `169.254.169.254` cloud metadata endpoint), unspecified,
+/// broadcast, or other non-globally-routable space.
+///
+/// Fail-closed: any address whose reachability is not unambiguously public is
+/// treated as blocked.
+pub fn is_blocked_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => is_blocked_ipv4(v4),
+        // Map IPv4-mapped forms back to v4 so `::ffff:127.0.0.1` and
+        // `::ffff:169.254.169.254` cannot smuggle a blocked v4 past the filter.
+        // Only `to_ipv4_mapped` is used — the deprecated `to_ipv4` also maps
+        // `::1` to `0.0.0.1`, which would slip IPv6 loopback past the v4 path.
+        IpAddr::V6(v6) => match v6.to_ipv4_mapped() {
+            Some(v4) => is_blocked_ipv4(v4),
+            None => is_blocked_ipv6(v6),
+        },
+    }
+}
+
+fn is_blocked_ipv4(v4: Ipv4Addr) -> bool {
+    v4.is_loopback()
+        || v4.is_private()
+        || v4.is_link_local()
+        || v4.is_broadcast()
+        || v4.is_documentation()
+        || v4.is_unspecified()
+        // Carrier-grade NAT (100.64.0.0/10) — not globally routable.
+        || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xc0) == 0x40)
+}
+
+fn is_blocked_ipv6(v6: Ipv6Addr) -> bool {
+    v6.is_loopback()
+        || v6.is_unspecified()
+        // Unique-local (fc00::/7).
+        || (v6.segments()[0] & 0xfe00) == 0xfc00
+        // Link-local (fe80::/10).
+        || (v6.segments()[0] & 0xffc0) == 0xfe80
+}
+
+/// When `host` is an IP literal, returns whether it is blocked. Returns `None`
+/// when `host` is not an IP literal (i.e. a name that must be resolved and
+/// re-validated separately).
+pub fn blocked_ip_literal(host: &str) -> Option<bool> {
+    host.parse::<IpAddr>().ok().map(is_blocked_ip)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_endpoint_is_blocked() {
+        assert!(is_blocked_ip("169.254.169.254".parse().unwrap()));
+    }
+
+    #[test]
+    fn loopback_is_blocked() {
+        assert!(is_blocked_ip("127.0.0.1".parse().unwrap()));
+        assert!(is_blocked_ip("::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn rfc1918_is_blocked() {
+        assert!(is_blocked_ip("10.0.0.1".parse().unwrap()));
+        assert!(is_blocked_ip("172.16.5.4".parse().unwrap()));
+        assert!(is_blocked_ip("192.168.1.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn link_local_and_cgnat_are_blocked() {
+        assert!(is_blocked_ip("169.254.1.1".parse().unwrap()));
+        assert!(is_blocked_ip("100.64.0.1".parse().unwrap()));
+        assert!(is_blocked_ip("fe80::1".parse().unwrap()));
+        assert!(is_blocked_ip("fc00::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn ipv4_mapped_v6_cannot_smuggle_blocked_v4() {
+        assert!(is_blocked_ip("::ffff:127.0.0.1".parse().unwrap()));
+        assert!(is_blocked_ip("::ffff:169.254.169.254".parse().unwrap()));
+    }
+
+    #[test]
+    fn public_ips_are_allowed() {
+        assert!(!is_blocked_ip("1.1.1.1".parse().unwrap()));
+        assert!(!is_blocked_ip("8.8.8.8".parse().unwrap()));
+        assert!(!is_blocked_ip("2606:4700:4700::1111".parse().unwrap()));
+    }
+
+    #[test]
+    fn blocked_ip_literal_distinguishes_names() {
+        assert_eq!(blocked_ip_literal("169.254.169.254"), Some(true));
+        assert_eq!(blocked_ip_literal("8.8.8.8"), Some(false));
+        assert_eq!(blocked_ip_literal("api.openai.com"), None);
+    }
+}

--- a/aa-proxy/tests/proxy_integration.rs
+++ b/aa-proxy/tests/proxy_integration.rs
@@ -24,6 +24,9 @@ fn test_config(ca_dir: &std::path::Path) -> ProxyConfig {
         credential_action: CredentialAction::default(),
         upstream_override: None,
         gateway_endpoint: None,
+        // CONNECT targets here are public names; the loopback case uses the
+        // plain-HTTP path, so the SSRF guard stays active.
+        allow_private_connect_targets: false,
     }
 }
 


### PR DESCRIPTION
## Description

Wave-2 (Medium) security hardening of the `aa-proxy` sidecar.

**AAASM-3130 — SSRF / DNS-rebinding on the CONNECT path.** The proxy dialled
arbitrary upstream hosts with no IP-range filter, so an agent could coax it into
reaching loopback, RFC-1918, link-local, or the cloud metadata endpoint
(`169.254.169.254`). A new `ssrf` module rejects IP-literal CONNECT targets in
blocked ranges, and `connect_revalidated` re-validates **every** DNS-resolved
upstream address immediately before dialing — on both the TLS MitM and the
transparent-tunnel paths — closing the DNS-rebinding window. `upstream_override`
(integration-test only) bypasses re-validation by design.

**AAASM-3131 — `skip_upstream_tls_verify` reachable in production.** The flag is
now honoured **only in debug builds**; in a release build the
`AA_PROXY_SKIP_UPSTREAM_TLS_VERIFY` env var is ignored (forced `false` + loud
error log), and a startup banner shouts when it is active in debug.

## Type of Change

- [x] 🐛 Bug fix (security)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira tickets: AAASM-3130, AAASM-3131

Closes AAASM-3130
Closes AAASM-3131

## Testing

- [x] Unit tests added / updated

`ssrf` unit tests (metadata/loopback/RFC1918/CGNAT/unique-local + IPv4-mapped-v6
smuggling + public-IP allow), `connect_deny_reason` regression tests (SSRF check
precedes allowlist), and a debug-vs-release gate test for the TLS flag. Validated
locally: `cargo nextest run -p aa-proxy` (104 passed), `cargo clippy -p aa-proxy
--all-targets -- -D warnings` clean, `cargo fmt`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
