### PR TITLE
[AAASM-3133] 🔒 (aa-gateway): Fail-closed schedule tz, tool.allow, and budget tenancy

### DIFF
--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -77,7 +77,17 @@ pub(crate) fn evaluate_single_doc(
 fn stage_schedule(doc: &PolicyDocument) -> Option<PolicyDecision> {
     let ah = doc.schedule.as_ref()?.active_hours.as_ref()?;
     use chrono::Timelike;
-    let tz: chrono_tz::Tz = ah.timezone.parse().unwrap_or(chrono_tz::UTC);
+    // AAASM-3133: an unparseable timezone must fail closed. Silently falling
+    // back to UTC let an operator's active-hours window be evaluated in the
+    // wrong zone — e.g. a window meant for business hours in `America/New_York`
+    // evaluated in UTC could be wide open when it should be shut, bypassing the
+    // schedule control. Deny when the configured tz does not parse.
+    let Ok(tz) = ah.timezone.parse::<chrono_tz::Tz>() else {
+        return Some(PolicyDecision::Deny {
+            reason: format!("invalid schedule timezone: {}", ah.timezone),
+            source_scope: doc.scope.clone(),
+        });
+    };
     let now = chrono::Utc::now().with_timezone(&tz);
     let current_hhmm = format!("{:02}:{:02}", now.hour(), now.minute());
     if current_hhmm < ah.start || current_hhmm >= ah.end {

--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -466,4 +466,39 @@ mod tests {
         let doc = minimal_doc(None);
         assert_eq!(stage_network(&doc, &net_action("https://anything.test/")), None);
     }
+
+    // ── Stage 1: schedule timezone fail-closed (AAASM-3133) ─────────────────
+
+    fn doc_with_schedule(tz: &str, start: &str, end: &str) -> PolicyDocument {
+        let mut doc = minimal_doc(None);
+        doc.schedule = Some(crate::policy::document::SchedulePolicy {
+            active_hours: Some(crate::policy::document::ActiveHours {
+                start: start.into(),
+                end: end.into(),
+                timezone: tz.into(),
+            }),
+        });
+        doc
+    }
+
+    #[test]
+    fn stage_schedule_invalid_timezone_fails_closed() {
+        // AAASM-3133: an unparseable tz must DENY, not silently fall back to UTC
+        // and risk evaluating the active-hours window in the wrong zone.
+        let doc = doc_with_schedule("Mars/Phobos", "00:00", "23:59");
+        let d = stage_schedule(&doc).expect("deny");
+        match d {
+            PolicyDecision::Deny { reason, .. } => {
+                assert!(reason.contains("invalid schedule timezone"), "got: {reason}");
+            }
+            other => panic!("expected Deny, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn stage_schedule_valid_timezone_full_day_window_allows() {
+        // A valid tz with an all-day window must not deny on the tz check.
+        let doc = doc_with_schedule("UTC", "00:00", "23:59");
+        assert_eq!(stage_schedule(&doc), None);
+    }
 }

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -2611,4 +2611,86 @@ mod tests {
         let resolved = resolve_enforcement_mode(None, aa_core::EnforcementMode::Enforce);
         assert_eq!(resolved, aa_core::EnforcementMode::Enforce);
     }
+
+    // ── AAASM-3138: budget tenancy keyed by registered owner ────────────────
+
+    /// Build a minimal registry record for `agent_id` owned by `team`.
+    fn registry_record(agent_id: [u8; 16], team: &str, org: Option<&str>) -> crate::registry::store::AgentRecord {
+        crate::registry::store::AgentRecord {
+            agent_id,
+            name: "demo".to_string(),
+            framework: "test".to_string(),
+            version: "0".to_string(),
+            risk_tier: 0,
+            tool_names: Vec::new(),
+            public_key: String::new(),
+            credential_token: String::new(),
+            metadata: BTreeMap::new(),
+            registered_at: chrono::Utc::now(),
+            last_heartbeat: chrono::Utc::now(),
+            status: crate::registry::AgentStatus::Active,
+            pid: None,
+            session_count: 0,
+            last_event: None,
+            policy_violations_count: 0,
+            active_sessions: Vec::new(),
+            recent_events: std::collections::VecDeque::new(),
+            recent_traces: Vec::new(),
+            layer: None,
+            governance_level: aa_core::GovernanceLevel::default(),
+            parent_agent_id: None,
+            team_id: Some(team.to_string()),
+            org_id: org.map(str::to_string),
+            depth: 0,
+            delegation_reason: None,
+            spawned_by_tool: None,
+            root_agent_id: Some(agent_id),
+            children: Vec::new(),
+            parent_key: None,
+            enforcement_mode: None,
+        }
+    }
+
+    #[test]
+    fn record_spend_keys_budget_by_registered_team_not_client_supplied() {
+        // AAASM-3138: a client must not be able to bill spend against a tenant
+        // it does not own by forging team_id in the request context. The budget
+        // must key on the agent's *registered* owner.
+        let registry = Arc::new(crate::registry::AgentRegistry::new());
+        registry
+            .register(registry_record([1u8; 16], "owner-team", Some("owner-org")))
+            .expect("register");
+
+        let engine = make_engine(empty_doc()).with_registry(registry);
+
+        // ctx carries a forged team_id / org_id that the agent does NOT own.
+        let mut ctx = make_ctx(); // agent_id = [1u8; 16]
+        ctx.team_id = Some("victim-team".to_string());
+        ctx.metadata.insert("org_id".to_string(), "victim-org".to_string());
+
+        engine.record_spend(&ctx, 7.0);
+
+        // Spend landed under the registered owner, not the forged tenant.
+        assert!(
+            engine.budget.team_state("owner-team").is_some(),
+            "spend must be attributed to the registered team"
+        );
+        assert!(
+            engine.budget.team_state("victim-team").is_none(),
+            "spend must NOT be attributed to the client-forged team"
+        );
+    }
+
+    #[test]
+    fn record_spend_falls_back_to_ctx_when_agent_unregistered() {
+        // With no registry attached, the legacy ctx-supplied tenancy is used —
+        // preserving behaviour for untenanted / pre-registry deployments.
+        let engine = make_engine(empty_doc());
+        let mut ctx = make_ctx();
+        ctx.team_id = Some("ctx-team".to_string());
+
+        engine.record_spend(&ctx, 3.0);
+
+        assert!(engine.budget.team_state("ctx-team").is_some());
+    }
 }

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1153,13 +1153,37 @@ impl PolicyEngine {
     /// tracker's `record_raw_spend`, which fires 80%/95% threshold alerts.
     pub fn record_spend(&self, ctx: &aa_core::AgentContext, amount_usd: f64) {
         if let Ok(amount) = rust_decimal::Decimal::try_from(amount_usd) {
-            // AAASM-2022 — thread `org_id` from ctx.metadata so the spend
-            // rolls up into the Org tier's budget envelope. Falls back to
-            // None when convert.rs didn't populate the metadata key.
-            let org_id = ctx.metadata.get("org_id").map(String::as_str);
+            // AAASM-3138 — the budget tenancy key (team_id / org_id) must be the
+            // agent's *registered* owner, not the values the client put in the
+            // request. Trusting the client-supplied tenancy lets one tenant
+            // charge spend against — or exhaust the budget of — another tenant
+            // they don't own. Resolve from the registry by agent_id; the
+            // client-supplied ctx values are used only as a fallback when no
+            // registry is attached or the agent is unregistered.
+            // AAASM-2022 — `org_id` still rolls the spend up into the Org tier.
+            let (team_id, org_id) = self.authoritative_tenancy(ctx);
             self.budget
-                .record_raw_spend(ctx.agent_id, ctx.team_id.as_deref(), org_id, amount);
+                .record_raw_spend(ctx.agent_id, team_id.as_deref(), org_id.as_deref(), amount);
         }
+    }
+
+    /// Resolve the budget tenancy (`team_id`, `org_id`) for `ctx` from the
+    /// authoritative agent registry, falling back to the client-supplied
+    /// `ctx` values only when no registry is attached or the agent is not
+    /// registered.
+    ///
+    /// AAASM-3138: the registered owner is the trust anchor for budget keying —
+    /// a client must not be able to bill spend against a tenant it does not own
+    /// by forging `team_id` / `org_id` in the request.
+    fn authoritative_tenancy(&self, ctx: &aa_core::AgentContext) -> (Option<String>, Option<String>) {
+        if let Some(registry) = self.registry.as_ref() {
+            if let Some(record) = registry.get(ctx.agent_id.as_bytes()) {
+                return (record.team_id, record.org_id);
+            }
+        }
+        let team_id = ctx.team_id.clone();
+        let org_id = ctx.metadata.get("org_id").cloned();
+        (team_id, org_id)
     }
 
     /// Check whether an agent is within both daily and monthly budget limits.

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -432,7 +432,13 @@ impl PolicyValidator {
             tools.insert(
                 name,
                 ToolPolicy {
-                    allow: rt.allow.unwrap_or(true),
+                    // AAASM-3134: a tool entry that omits `allow` defaults to
+                    // DENY, not allow. A policy typo (e.g. `alow: true`) or a
+                    // half-written rule previously failed permissive — the tool
+                    // was allowed by default — which is the opposite of what a
+                    // governance control should do. Fail closed: an explicit
+                    // `allow: true` is required to permit a listed tool.
+                    allow: rt.allow.unwrap_or(false),
                     limit_per_hour: rt.limit_per_hour,
                     requires_approval_if: rt.requires_approval_if,
                 },

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -817,6 +817,16 @@ mod tests {
         assert_eq!(ah.timezone, "Asia/Taipei");
     }
 
+    #[test]
+    fn schedule_invalid_timezone_is_an_error() {
+        // AAASM-3133: a bogus IANA timezone must be rejected at load time, not
+        // silently accepted (and later fall back to UTC at evaluation).
+        let yaml =
+            "schedule:\n  active_hours:\n    start: \"09:00\"\n    end: \"18:00\"\n    timezone: \"Mars/Phobos\"\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err(), "invalid timezone must be a validation error");
+    }
+
     // ── Capabilities validation ─────────────────────────────────────────────
 
     #[test]

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -229,6 +229,18 @@ impl PolicyValidator {
             }
         };
 
+        // AAASM-3133: reject an unparseable IANA timezone at load time. The
+        // engine fails closed on a bad tz at evaluation, but catching it here
+        // gives the operator an immediate, actionable error instead of a policy
+        // that silently denies every action once deployed.
+        if timezone.parse::<chrono_tz::Tz>().is_err() {
+            errors.push(ValidationError::new(
+                "schedule.active_hours.timezone",
+                "must be a valid IANA timezone (e.g. America/New_York)",
+            ));
+            return None;
+        }
+
         Some(ActiveHours { start, end, timezone })
     }
 

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -593,8 +593,17 @@ mod tests {
     }
 
     #[test]
-    fn tool_allow_defaults_to_true_when_absent() {
+    fn tool_allow_defaults_to_false_when_absent() {
+        // AAASM-3134: a tool entry without an explicit `allow` must fail closed
+        // (deny), so a policy typo cannot silently permit a tool.
         let yaml = "tools:\n  bash:\n    limit_per_hour: 5\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        assert!(!out.document.tools["bash"].allow);
+    }
+
+    #[test]
+    fn tool_allow_true_is_honoured_when_explicit() {
+        let yaml = "tools:\n  bash:\n    allow: true\n";
         let out = PolicyValidator::from_yaml(yaml).unwrap();
         assert!(out.document.tools["bash"].allow);
     }


### PR DESCRIPTION
## Description

Wave-2 (Medium) fail-closed hardening of the `aa-gateway` policy engine.

**AAASM-3133 — schedule timezone fail-open.** `stage_schedule` silently fell
back to UTC on an unparseable timezone, so an active-hours window meant for one
zone could be evaluated in UTC and left wide open. It now **denies** on a bad tz,
and the validator additionally rejects an invalid IANA timezone at load time.

**AAASM-3134 — `tool.allow` default permissive.** A tool entry that omitted
`allow` defaulted to `true`, so a policy typo failed open. It now defaults to
**deny**; an explicit `allow: true` is required.

**AAASM-3138 — budget keyed on client-supplied tenancy.** `record_spend` trusted
the request-supplied `team_id` / `org_id`, letting a caller bill spend against a
tenant it does not own. It now resolves the agent's **registered** tenancy from
the registry (`authoritative_tenancy`), falling back to ctx only when no registry
is attached.

## Type of Change

- [x] 🐛 Bug fix (security)

## Breaking Changes

- [x] Yes — a policy `tools:` entry without an explicit `allow: true` is now
  denied (previously allowed), and an invalid schedule timezone is now rejected
  at load time. Both are intentional fail-closed corrections.

## Related Issues

- Related Jira tickets: AAASM-3133, AAASM-3134, AAASM-3138

Closes AAASM-3133
Closes AAASM-3134
Closes AAASM-3138

## Testing

- [x] Unit tests added / updated

Schedule tz fail-closed (eval + validator), tool.allow default-deny, and budget
keyed-by-registered-owner (forged team_id not honoured; ctx fallback when
unregistered). Validated locally: `cargo nextest run -p aa-gateway` 1112 passed,
`cargo clippy -p aa-gateway --all-targets -- -D warnings` clean, `cargo fmt`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
