### PR TITLE
[AAASM-3136] 🔒 (aa-gateway): Case-insensitive sanitizer keys + alert_and_redact mode

### DIFF
--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -897,12 +897,25 @@ impl PolicyEngine {
                 finding_count = all_findings.len(),
                 "DataLeakEvent emission pending AAASM-31 EnrichedEvent::DataLeak variant"
             );
+            if credential_action == CredentialAction::AlertAndRedact {
+                // AAASM-3137: emit the alert AND redact — the operator is
+                // notified, but the raw secret is still removed before forward.
+                tracing::warn!(
+                    finding_count = all_findings.len(),
+                    "credential_action=alert_and_redact: alert emission pending AAASM-1545"
+                );
+            }
             if credential_action == CredentialAction::AlertOnly {
                 // Forward the unmodified payload upstream; alert side-effect emission
                 // is wired by sibling subtask AAASM-1545.
+                //
+                // SECURITY (AAASM-3137): this is the ONLY path that forwards the
+                // raw secret. It is a documented, deliberate audit-only downgrade;
+                // `alert_and_redact` is the safe alternative when an alert is
+                // wanted without leaking the credential.
                 tracing::warn!(
                     finding_count = all_findings.len(),
-                    "credential_action=alert_only: alert emission pending AAASM-1545"
+                    "credential_action=alert_only: forwarding UNREDACTED payload (alert emission pending AAASM-1545)"
                 );
                 (None, all_findings)
             } else {
@@ -1032,14 +1045,18 @@ impl PolicyEngine {
         let mut all_findings = scan.findings;
         collect_cascade_custom_findings(&cascade, text, &mut all_findings);
 
-        // Most-restrictive-wins across the cascade: Block > RedactOnly > AlertOnly.
-        // Docs without a `data` section don't vote — RedactOnly remains the default.
+        // Most-restrictive-wins across the cascade ranked by how well each mode
+        // protects the secret: Block > RedactOnly > AlertAndRedact > AlertOnly.
+        // AlertOnly ranks lowest because it is the only mode that forwards the
+        // raw secret (AAASM-3137). Docs without a `data` section don't vote —
+        // RedactOnly remains the default.
         let credential_action = cascade
             .iter()
             .filter_map(|d| d.data.as_ref().map(|dp| dp.credential_action))
             .max_by_key(|a| match a {
-                CredentialAction::Block => 2,
-                CredentialAction::RedactOnly => 1,
+                CredentialAction::Block => 3,
+                CredentialAction::RedactOnly => 2,
+                CredentialAction::AlertAndRedact => 1,
                 CredentialAction::AlertOnly => 0,
             })
             .unwrap_or_default();
@@ -1064,10 +1081,18 @@ impl PolicyEngine {
                 finding_count = all_findings.len(),
                 "DataLeakEvent emission pending AAASM-31 EnrichedEvent::DataLeak variant"
             );
-            if credential_action == CredentialAction::AlertOnly {
+            if credential_action == CredentialAction::AlertAndRedact {
+                // AAASM-3137: alert AND redact — notify but never leak the secret.
                 tracing::warn!(
                     finding_count = all_findings.len(),
-                    "credential_action=alert_only: alert emission pending AAASM-1545"
+                    "credential_action=alert_and_redact: alert emission pending AAASM-1545"
+                );
+            }
+            if credential_action == CredentialAction::AlertOnly {
+                // SECURITY (AAASM-3137): the only path that forwards the raw secret.
+                tracing::warn!(
+                    finding_count = all_findings.len(),
+                    "credential_action=alert_only: forwarding UNREDACTED payload (alert emission pending AAASM-1545)"
                 );
                 (None, all_findings)
             } else {

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1777,6 +1777,31 @@ mod tests {
     }
 
     #[test]
+    fn data_pattern_redacts_when_credential_action_is_alert_and_redact() {
+        // AAASM-3137: alert_and_redact must still redact the payload — the raw
+        // secret must NOT be forwarded even though an alert is raised.
+        let mut doc = empty_doc();
+        doc.data = Some(DataPolicy {
+            sensitive_patterns: vec![r"password=\w+".to_string()],
+            credential_action: CredentialAction::AlertAndRedact,
+        });
+        let engine = make_engine(doc);
+        let ctx = make_ctx();
+        let action = tool_call("any", "password=secret");
+        let result = engine.evaluate(&ctx, &action);
+        assert_eq!(result.decision, PolicyResult::Allow);
+        assert!(!result.credential_findings.is_empty());
+        // A redacted form IS set, and the raw secret is gone.
+        let redacted = result
+            .redacted_payload
+            .expect("alert_and_redact must produce a redacted payload");
+        assert!(
+            !redacted.contains("secret"),
+            "raw secret leaked in alert_and_redact mode"
+        );
+    }
+
+    #[test]
     fn budget_denies_when_exceeded() {
         let mut doc = empty_doc();
         doc.budget = Some(BudgetPolicy {

--- a/aa-gateway/src/policy/document.rs
+++ b/aa-gateway/src/policy/document.rs
@@ -74,7 +74,16 @@ pub enum CredentialAction {
     RedactOnly,
     /// Forward the unmodified payload and raise an alert side-effect.
     /// Documented as a deliberate downgrade for low-risk audit-only modes.
+    ///
+    /// SECURITY (AAASM-3137): this forwards the *raw* secret upstream. Prefer
+    /// [`CredentialAction::AlertAndRedact`] when an alert is wanted but the
+    /// secret must still not leave the boundary.
     AlertOnly,
+    /// Raise an alert side-effect **and** forward a redacted payload. This is
+    /// the safe alerting mode: the operator gets notified of the finding, but
+    /// the raw secret is redacted before it leaves the boundary regardless of
+    /// the alert (AAASM-3137).
+    AlertAndRedact,
 }
 
 /// Validated data / PII policy.

--- a/aa-gateway/src/policy/raw.rs
+++ b/aa-gateway/src/policy/raw.rs
@@ -70,7 +70,8 @@ pub struct RawDataPolicy {
     /// Regex patterns for PII / credential detection.
     pub sensitive_patterns: Option<Vec<String>>,
     /// Action taken on a finding: `"block"`, `"redact_only"` (default),
-    /// or `"alert_only"`. Validated into a [`crate::policy::document::CredentialAction`].
+    /// `"alert_only"`, or `"alert_and_redact"`. Validated into a
+    /// [`crate::policy::document::CredentialAction`].
     pub credential_action: Option<String>,
     /// Unknown keys captured for warning emission.
     #[serde(flatten)]

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -629,6 +629,14 @@ mod tests {
     }
 
     #[test]
+    fn data_credential_action_alert_and_redact_parses() {
+        let yaml = "data:\n  credential_action: alert_and_redact\n";
+        let out = PolicyValidator::from_yaml(yaml).unwrap();
+        let dp = out.document.data.unwrap();
+        assert_eq!(dp.credential_action, CredentialAction::AlertAndRedact);
+    }
+
+    #[test]
     fn data_credential_action_invalid_value_is_an_error() {
         let yaml = "data:\n  credential_action: not_a_real_mode\n";
         let result = PolicyValidator::from_yaml(yaml);

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -333,10 +333,15 @@ impl PolicyValidator {
             None | Some("redact_only") => CredentialAction::RedactOnly,
             Some("block") => CredentialAction::Block,
             Some("alert_only") => CredentialAction::AlertOnly,
+            // AAASM-3137: safe alerting mode — alert AND redact on forward.
+            Some("alert_and_redact") => CredentialAction::AlertAndRedact,
             Some(other) => {
                 errors.push(ValidationError::new(
                     "data.credential_action",
-                    format!("must be 'block', 'redact_only', or 'alert_only', got '{}'", other),
+                    format!(
+                        "must be 'block', 'redact_only', 'alert_only', or 'alert_and_redact', got '{}'",
+                        other
+                    ),
                 ));
                 CredentialAction::RedactOnly
             }

--- a/aa-gateway/src/sanitizer/rules.rs
+++ b/aa-gateway/src/sanitizer/rules.rs
@@ -51,11 +51,22 @@ pub(crate) const ALLOWED_TOP_LEVEL_KEYS: &[&str] = &[
 ];
 
 /// Returns `true` if `key` is on the recursive banned list.
+///
+/// AAASM-3136: the comparison is case-insensitive. A sender that emits
+/// `Prompt`, `TOOL_PAYLOAD`, or `Tool_Args` must not slip a secret past a
+/// case-sensitive `==` match — JSON keys are not case-normalized on the wire,
+/// so the banned list has to fold case to be a real control.
 pub(crate) fn is_banned(key: &str) -> bool {
-    BANNED_KEYS.contains(&key)
+    let lower = key.to_ascii_lowercase();
+    BANNED_KEYS.contains(&lower.as_str())
 }
 
 /// Returns `true` if `key` is an allowed top-level metadata key.
+///
+/// AAASM-3136: case-insensitive, for the same reason as [`is_banned`] — an
+/// unexpected field must not survive merely because its case differs from the
+/// allowlist entry.
 pub(crate) fn is_allowed_top_level(key: &str) -> bool {
-    ALLOWED_TOP_LEVEL_KEYS.contains(&key)
+    let lower = key.to_ascii_lowercase();
+    ALLOWED_TOP_LEVEL_KEYS.contains(&lower.as_str())
 }

--- a/aa-gateway/src/sanitizer/sanitize.rs
+++ b/aa-gateway/src/sanitizer/sanitize.rs
@@ -232,6 +232,27 @@ mod tests {
     }
 
     #[test]
+    fn drops_banned_keys_regardless_of_case() {
+        // AAASM-3136: a case-variant of a banned key must still be stripped,
+        // at the top level and nested inside the opaque payload container.
+        let raw = RawAuditEvent::new(json!({
+            "kind": "tool_call",
+            "agent_id": "acme/bot",
+            "Prompt": "top-level mixed case secret",
+            "payload": {
+                "TOOL_PAYLOAD": { "args": "nested upper-case secret" },
+                "steps": [{ "Completion": "deep mixed-case completion" }],
+            },
+        }));
+        let out = audit_value(raw);
+        assert!(!contains_key_recursive(&out, "Prompt"));
+        assert!(!contains_key_recursive(&out, "TOOL_PAYLOAD"));
+        assert!(!contains_key_recursive(&out, "Completion"));
+        // The vetted payload container itself survives.
+        assert!(contains_key_recursive(&out, "payload"));
+    }
+
+    #[test]
     fn drops_banned_keys_nested_in_payload() {
         let raw = RawAuditEvent::new(json!({
             "kind": "tool_call",


### PR DESCRIPTION
## Description

Wave-2 (Medium) secret-handling hardening.

**AAASM-3136 — sanitizer key matching is case-sensitive.** `is_banned` /
`is_allowed_top_level` used a case-sensitive `==`, so a sender emitting `Prompt`,
`TOOL_PAYLOAD`, or `Tool_Args` slipped a secret past the banned-key strip. JSON
keys are not case-normalized on the wire; both helpers now fold case, and the
recursive strip removes case-variants at every depth (including inside the opaque
`payload` container).

**AAASM-3137 — `credential_action: alert_only` forwards the raw secret.**
`AlertOnly` is the only mode that forwards the unredacted payload — fine as a
documented audit-only downgrade, but there was no way to alert *and* protect the
secret. Added `CredentialAction::AlertAndRedact`: it raises the alert side-effect
**and** redacts the payload before forward, ranked above `AlertOnly` in the
cascade most-restrictive-wins ordering.

Note: `aa-security/src/scanner.rs` credential patterns (`sk-ant-`, `AKIA`, PEM
headers) are intentionally case-significant value prefixes — lowercasing them
would corrupt detection — so the case-insensitivity fix is scoped to the
sanitizer key-name matching where it is genuinely a leak.

## Type of Change

- [x] 🐛 Bug fix (security)
- [x] ✨ New feature (the `alert_and_redact` mode)

## Breaking Changes

- [x] No (new enum variant + new accepted YAML value; existing modes unchanged)

## Related Issues

- Related Jira tickets: AAASM-3136, AAASM-3137

Closes AAASM-3136
Closes AAASM-3137

## Testing

- [x] Unit tests added / updated

Case-insensitive banned-key strip (mixed-case top-level + nested), `alert_and_redact`
parses, and the engine redacts (raw secret absent) under `alert_and_redact` unlike
`alert_only`. Validated locally: `cargo nextest run -p aa-gateway` 1109 passed,
`cargo clippy -p aa-gateway --all-targets -- -D warnings` clean, `cargo fmt`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
