### PR TITLE
[AAASM-3139] 🔒 (aa-api): Tenant claim + per-tenant cost/budget filtering

### DIFF
--- a/aa-api/src/auth/api_key.rs
+++ b/aa-api/src/auth/api_key.rs
@@ -92,6 +92,14 @@ pub struct ApiKeyEntry {
     /// Optional human-readable label.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
+    /// AAASM-3139 — the team this key is scoped to. When present, a non-admin
+    /// key is confined to its own team for per-tenant data. `None` leaves the
+    /// key unscoped (admin-gated for cross-tenant data), preserving legacy keys.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub team_id: Option<String>,
+    /// AAASM-3139 — the org this key is scoped to. See [`ApiKeyEntry::team_id`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub org_id: Option<String>,
 }
 
 /// In-memory store of API key entries loaded from a JSON file.
@@ -279,6 +287,8 @@ mod tests {
             scopes: vec![Scope::Read, Scope::Write],
             created_at: 1700000000,
             label: Some("test key".to_string()),
+            team_id: None,
+            org_id: None,
         };
         let store = ApiKeyStore {
             entries: vec![entry],
@@ -301,6 +311,8 @@ mod tests {
             scopes: vec![Scope::Read],
             created_at: 1700000000,
             label: None,
+            team_id: None,
+            org_id: None,
         };
         let store = ApiKeyStore {
             entries: vec![entry],

--- a/aa-api/src/auth/jwt.rs
+++ b/aa-api/src/auth/jwt.rs
@@ -182,6 +182,26 @@ mod tests {
     }
 
     #[test]
+    fn test_jwt_tenant_claim_roundtrip() {
+        // AAASM-3139: a tenant-scoped token must carry team_id back through
+        // verification; a plain token leaves the tenant claim None.
+        let signer = JwtSigner::new(TEST_SECRET);
+        let verifier = JwtVerifier::new(TEST_SECRET);
+
+        let scoped = signer
+            .sign_with_tenant("key-1", &[Scope::Read], Some("alpha".into()), Some("org-1".into()))
+            .unwrap();
+        let claims = verifier.verify(&scoped).unwrap();
+        assert_eq!(claims.team_id.as_deref(), Some("alpha"));
+        assert_eq!(claims.org_id.as_deref(), Some("org-1"));
+
+        let plain = signer.sign("key-2", &[Scope::Read]).unwrap();
+        let plain_claims = verifier.verify(&plain).unwrap();
+        assert_eq!(plain_claims.team_id, None);
+        assert_eq!(plain_claims.org_id, None);
+    }
+
+    #[test]
     fn test_jwt_scopes_preserved() {
         let signer = JwtSigner::new(TEST_SECRET);
         let verifier = JwtVerifier::new(TEST_SECRET);

--- a/aa-api/src/auth/jwt.rs
+++ b/aa-api/src/auth/jwt.rs
@@ -20,6 +20,16 @@ pub struct Claims {
     pub exp: u64,
     /// Scopes granted to this token.
     pub scope: Vec<Scope>,
+    /// AAASM-3139 — the team this token is scoped to. When present, a
+    /// non-admin caller is confined to its own team for per-tenant data
+    /// (e.g. `/costs`, `/agents/{id}/budget`). `None` on legacy tokens
+    /// issued before tenant claims existed, which therefore carry no team
+    /// scope (and remain admin-gated for cross-tenant data).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub team_id: Option<String>,
+    /// AAASM-3139 — the org this token is scoped to. See [`Claims::team_id`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub org_id: Option<String>,
 }
 
 /// Signs JWTs using HMAC-SHA256.
@@ -39,12 +49,29 @@ impl JwtSigner {
     ///
     /// The token expires after 24 hours.
     pub fn sign(&self, key_id: &str, scopes: &[Scope]) -> Result<String, JwtError> {
+        self.sign_with_tenant(key_id, scopes, None, None)
+    }
+
+    /// Sign a JWT that additionally carries a tenant scope (AAASM-3139).
+    ///
+    /// `team_id` / `org_id` confine a non-admin caller to its own tenant for
+    /// per-tenant data endpoints. Pass `None` for either to leave it unscoped.
+    /// The token expires after 24 hours.
+    pub fn sign_with_tenant(
+        &self,
+        key_id: &str,
+        scopes: &[Scope],
+        team_id: Option<String>,
+        org_id: Option<String>,
+    ) -> Result<String, JwtError> {
         let now = now_epoch_secs();
         let claims = Claims {
             sub: key_id.to_string(),
             iat: now,
             exp: now + TOKEN_EXPIRY_SECS,
             scope: scopes.to_vec(),
+            team_id,
+            org_id,
         };
         encode(&Header::default(), &claims, &self.encoding_key).map_err(JwtError::Encode)
     }
@@ -57,6 +84,8 @@ impl JwtSigner {
             iat: now_epoch_secs(),
             exp,
             scope: scopes.to_vec(),
+            team_id: None,
+            org_id: None,
         };
         encode(&Header::default(), &claims, &self.encoding_key).map_err(JwtError::Encode)
     }

--- a/aa-api/src/auth/mod.rs
+++ b/aa-api/src/auth/mod.rs
@@ -85,6 +85,21 @@ impl IntoResponse for AuthError {
 
 /// The authenticated identity of a request caller.
 ///
+/// The tenant a caller is scoped to (AAASM-3139).
+///
+/// A caller with a `team_id` (or `org_id`) is confined to that tenant for
+/// per-tenant data endpoints. An empty `Tenant` (both `None`) means "no tenant
+/// scope" — such a caller can only see cross-tenant data if it also holds
+/// `Scope::Admin`. The synthetic bypass-mode caller and admin callers are not
+/// confined by tenant.
+#[derive(Debug, Clone, Default)]
+pub struct Tenant {
+    /// The team this caller is scoped to, if any.
+    pub team_id: Option<String>,
+    /// The org this caller is scoped to, if any.
+    pub org_id: Option<String>,
+}
+
 /// Populated by the `FromRequestParts` implementation, which validates
 /// either an API key (`aa_…`) or a JWT bearer token.
 #[derive(Debug, Clone)]
@@ -93,6 +108,22 @@ pub struct AuthenticatedCaller {
     pub key_id: String,
     /// Scopes granted to this caller.
     pub scopes: Vec<Scope>,
+    /// The tenant this caller is confined to for per-tenant data (AAASM-3139).
+    pub tenant: Tenant,
+}
+
+impl AuthenticatedCaller {
+    /// Whether this caller may see data for `team` without a separate admin gate.
+    ///
+    /// AAASM-3139: an admin sees every tenant; a tenant-scoped caller sees only
+    /// its own team. A caller with no team scope (and no admin) sees no
+    /// per-tenant data.
+    pub fn can_access_team(&self, team: &str) -> bool {
+        if self.scopes.contains(&Scope::Admin) {
+            return true;
+        }
+        self.tenant.team_id.as_deref() == Some(team)
+    }
 }
 
 /// Prefix used by API keys (`aa_`).
@@ -116,6 +147,8 @@ where
             return Ok(AuthenticatedCaller {
                 key_id: "__bypass__".to_string(),
                 scopes: vec![Scope::Read, Scope::Write, Scope::Admin],
+                // Bypass mode is admin — not confined to any tenant.
+                tenant: Tenant::default(),
             });
         }
 
@@ -151,6 +184,10 @@ where
             AuthenticatedCaller {
                 key_id: entry.id.clone(),
                 scopes: entry.scopes.clone(),
+                tenant: Tenant {
+                    team_id: entry.team_id.clone(),
+                    org_id: entry.org_id.clone(),
+                },
             }
         } else {
             // JWT path.
@@ -171,6 +208,10 @@ where
             AuthenticatedCaller {
                 key_id: claims.sub,
                 scopes: claims.scope,
+                tenant: Tenant {
+                    team_id: claims.team_id,
+                    org_id: claims.org_id,
+                },
             }
         };
 

--- a/aa-api/src/auth/policy_auth.rs
+++ b/aa-api/src/auth/policy_auth.rs
@@ -148,6 +148,7 @@ mod tests {
         AuthenticatedCaller {
             key_id: "test".into(),
             scopes,
+            tenant: crate::auth::Tenant::default(),
         }
     }
 

--- a/aa-api/src/auth/scope.rs
+++ b/aa-api/src/auth/scope.rs
@@ -156,6 +156,7 @@ mod tests {
         let caller = AuthenticatedCaller {
             key_id: "test".to_string(),
             scopes: vec![Scope::Read, Scope::Write],
+            tenant: crate::auth::Tenant::default(),
         };
         assert!(RequireScope::check(&caller, Scope::Read).is_ok());
         assert!(RequireScope::check(&caller, Scope::Write).is_ok());

--- a/aa-api/src/routes/agents.rs
+++ b/aa-api/src/routes/agents.rs
@@ -513,14 +513,15 @@ pub async fn get_agent_budget(
     Extension(state): Extension<AppState>,
     axum::extract::Path(id): axum::extract::Path<String>,
 ) -> Result<(StatusCode, Json<BudgetRollupResponse>), ProblemDetail> {
-    // Cross-tenant IDOR guard (AAASM-3126): the authenticated principal does
-    // not yet carry an org/team scope (AAASM-3128), so an agent's budget
-    // rollup (which spans the agent's team / org / global totals) can only be
-    // safely served to admin callers. A non-admin caller cannot be confined to
-    // its own tenant, so reading an arbitrary agent's budget is denied.
-    if !caller.scopes.contains(&Scope::Admin) {
+    // Per-tenant authz (AAASM-3139, completing AAASM-3126's deferral): admin
+    // callers may read any agent's budget; a tenant-scoped caller may read only
+    // agents that belong to its own team. A caller with neither admin scope nor
+    // any team scope can never be authorized — deny it up front, before any
+    // existence check, so it cannot enumerate agents via 403-vs-404.
+    let is_admin = caller.scopes.contains(&Scope::Admin);
+    if !is_admin && caller.tenant.team_id.is_none() {
         return Err(ProblemDetail::from_status(StatusCode::FORBIDDEN)
-            .with_detail("Reading an agent's budget rollup requires admin scope"));
+            .with_detail("Reading an agent's budget rollup requires admin scope or a team scope"));
     }
 
     let agent_id_bytes = parse_agent_id(&id)?;
@@ -532,6 +533,19 @@ pub async fn get_agent_budget(
 
     let lineage = state.agent_registry.lineage(&agent_id_bytes);
     let team_id = lineage.as_ref().and_then(|l| l.team_id.as_deref());
+
+    // A tenant-scoped (non-admin) caller may only read agents in its own team;
+    // the rollup spans the agent's team / org / global totals, so a mismatch is
+    // a cross-tenant IDOR.
+    let authorized = match team_id {
+        Some(team) => caller.can_access_team(team),
+        // The agent has no team — only admin may read its (global-scoped) rollup.
+        None => is_admin,
+    };
+    if !authorized {
+        return Err(ProblemDetail::from_status(StatusCode::FORBIDDEN)
+            .with_detail("Reading this agent's budget rollup requires admin scope or membership in its team"));
+    }
     let descendants = state.agent_registry.descendants_of(&agent_id_bytes);
 
     let rollup = aa_gateway::budget::compute_budget_rollup(

--- a/aa-api/src/routes/costs.rs
+++ b/aa-api/src/routes/costs.rs
@@ -62,12 +62,11 @@ pub struct CostSummary {
 /// Retrieve the current daily and monthly cost and budget summary,
 /// including per-agent breakdown and configured budget limits.
 ///
-/// The per-agent and per-team breakdowns span every tenant, so they are
-/// only populated for callers holding `Scope::Admin` (AAASM-3126). Because
-/// the authenticated principal carries no org/team scope yet (AAASM-3128),
-/// a non-admin caller cannot be filtered down to its own tenant — so it
-/// receives only the aggregate totals with the cross-tenant breakdowns
-/// elided rather than leaking every tenant's spend (cross-tenant IDOR).
+/// Per-tenant filtering (AAASM-3139): an admin caller sees every tenant's
+/// per-agent and per-team breakdown; a tenant-scoped caller sees only its own
+/// team's row; a caller with neither admin scope nor a team scope receives the
+/// aggregate totals only, with the breakdowns elided rather than leaking every
+/// tenant's spend (the cross-tenant IDOR that AAASM-3126 admin-gated).
 #[utoipa::path(
     get,
     path = "/api/v1/costs",
@@ -83,13 +82,17 @@ pub async fn get_cost_summary(
 ) -> (StatusCode, Json<CostSummary>) {
     let snapshot = state.budget_tracker.snapshot();
 
-    // Cross-tenant breakdowns are admin-only until the principal carries a
-    // tenant scope to filter on (AAASM-3126 / AAASM-3128).
-    let include_breakdown = caller.scopes.contains(&Scope::Admin);
+    // Per-tenant filtering (AAASM-3139, completing AAASM-3126's deferral):
+    // * Admin callers see every tenant's breakdown.
+    // * A tenant-scoped caller sees ONLY its own team's row (and no per-agent
+    //   breakdown — the snapshot's per-agent list is not keyed by team, so
+    //   including it would leak other tenants' agents).
+    // * A caller with neither admin scope nor a team scope sees aggregate
+    //   totals only — the breakdowns stay empty rather than leaking spend.
+    let is_admin = caller.scopes.contains(&Scope::Admin);
+    let caller_team = caller.tenant.team_id.as_deref();
 
-    let per_agent: Vec<AgentCostEntry> = if !include_breakdown {
-        Vec::new()
-    } else {
+    let per_agent: Vec<AgentCostEntry> = if is_admin {
         snapshot
             .per_agent
             .iter()
@@ -100,14 +103,16 @@ pub async fn get_cost_summary(
                 date: entry.state.date.to_string(),
             })
             .collect()
+    } else {
+        Vec::new()
     };
 
-    let per_team: Vec<TeamCostEntry> = if !include_breakdown {
-        Vec::new()
-    } else {
+    let per_team: Vec<TeamCostEntry> = if is_admin || caller_team.is_some() {
         let mut rows: Vec<TeamCostEntry> = snapshot
             .team_budgets
             .iter()
+            // Non-admin tenant callers see only their own team's row.
+            .filter(|(team_id, _)| is_admin || caller_team == Some(team_id.as_str()))
             .map(|(team_id, state)| TeamCostEntry {
                 team_id: team_id.clone(),
                 daily_spend_usd: state.spent_usd.to_string(),
@@ -117,6 +122,8 @@ pub async fn get_cost_summary(
             .collect();
         rows.sort_by(|a, b| a.team_id.cmp(&b.team_id));
         rows
+    } else {
+        Vec::new()
     };
 
     let summary = CostSummary {

--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -238,6 +238,8 @@ pub fn generate_test_api_key(id: &str, scopes: Vec<Scope>) -> (String, ApiKeyEnt
         scopes,
         created_at: 1700000000,
         label: Some(format!("test key {id}")),
+        team_id: None,
+        org_id: None,
     };
     (key.as_str().to_string(), entry)
 }
@@ -247,4 +249,13 @@ pub fn generate_test_api_key(id: &str, scopes: Vec<Scope>) -> (String, ApiKeyEnt
 pub fn generate_test_jwt(key_id: &str, scopes: &[Scope]) -> String {
     let signer = JwtSigner::new(TEST_SECRET);
     signer.sign(key_id, scopes).expect("signing should succeed")
+}
+
+/// Generate a test JWT scoped to a team tenant (AAASM-3139).
+#[allow(dead_code)]
+pub fn generate_test_jwt_for_team(key_id: &str, scopes: &[Scope], team_id: &str) -> String {
+    let signer = JwtSigner::new(TEST_SECRET);
+    signer
+        .sign_with_tenant(key_id, scopes, Some(team_id.to_string()), None)
+        .expect("signing should succeed")
 }

--- a/aa-api/tests/tenant_scope.rs
+++ b/aa-api/tests/tenant_scope.rs
@@ -1,0 +1,156 @@
+//! Integration tests for per-tenant authorization of the cost / budget
+//! surfaces (AAASM-3139), which complete the per-tenant filtering that
+//! AAASM-3126 (#1089) deferred to an admin gate.
+
+mod common;
+
+use std::collections::{BTreeMap, VecDeque};
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use rust_decimal::Decimal;
+use tower::ServiceExt;
+
+use aa_api::auth::config::AuthMode;
+use aa_api::auth::scope::Scope;
+use aa_gateway::registry::{AgentRecord, AgentStatus};
+
+fn bearer(uri: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .method("GET")
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+fn agent_with_team(id_byte: u8, team: &str) -> AgentRecord {
+    AgentRecord {
+        agent_id: [id_byte; 16],
+        name: format!("agent-{id_byte}"),
+        framework: "test".to_string(),
+        version: "0".to_string(),
+        risk_tier: 1,
+        tool_names: Vec::new(),
+        public_key: String::new(),
+        credential_token: String::new(),
+        metadata: BTreeMap::new(),
+        registered_at: chrono::Utc::now(),
+        last_heartbeat: chrono::Utc::now(),
+        status: AgentStatus::Active,
+        pid: None,
+        session_count: 0,
+        last_event: None,
+        policy_violations_count: 0,
+        active_sessions: Vec::new(),
+        recent_events: VecDeque::new(),
+        recent_traces: Vec::new(),
+        layer: None,
+        governance_level: aa_core::GovernanceLevel::default(),
+        parent_agent_id: None,
+        team_id: Some(team.to_string()),
+        depth: 0,
+        delegation_reason: None,
+        spawned_by_tool: None,
+        root_agent_id: Some([id_byte; 16]),
+        children: Vec::new(),
+        parent_key: None,
+        enforcement_mode: None,
+        org_id: None,
+    }
+}
+
+fn hex_id(id_byte: u8) -> String {
+    format!("{id_byte:02x}").repeat(16)
+}
+
+#[tokio::test]
+async fn costs_tenant_caller_sees_only_its_own_team() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    // Seed spend for two distinct teams.
+    state.budget_tracker.record_raw_spend(
+        aa_core::identity::AgentId::from_bytes([1; 16]),
+        Some("alpha"),
+        None,
+        Decimal::new(5, 0),
+    );
+    state.budget_tracker.record_raw_spend(
+        aa_core::identity::AgentId::from_bytes([2; 16]),
+        Some("beta"),
+        None,
+        Decimal::new(7, 0),
+    );
+    let app = aa_api::build_app(state);
+
+    // A read-only caller scoped to team "alpha" must see only the alpha row.
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let response = app.oneshot(bearer("/api/v1/costs", &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let teams = json["per_team"].as_array().unwrap();
+    assert_eq!(teams.len(), 1, "tenant caller must see only its own team");
+    assert_eq!(teams[0]["team_id"], "alpha");
+    // No per-agent breakdown leaks to a non-admin tenant caller.
+    assert!(json["per_agent"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn costs_admin_sees_all_teams() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.budget_tracker.record_raw_spend(
+        aa_core::identity::AgentId::from_bytes([1; 16]),
+        Some("alpha"),
+        None,
+        Decimal::new(5, 0),
+    );
+    state.budget_tracker.record_raw_spend(
+        aa_core::identity::AgentId::from_bytes([2; 16]),
+        Some("beta"),
+        None,
+        Decimal::new(7, 0),
+    );
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt("admin", &[Scope::Admin]);
+    let response = app.oneshot(bearer("/api/v1/costs", &token)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["per_team"].as_array().unwrap().len(), 2, "admin sees every team");
+}
+
+#[tokio::test]
+async fn agent_budget_tenant_caller_can_read_own_team_agent() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0xAA, "alpha")).unwrap();
+    let app = aa_api::build_app(state);
+
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let uri = format!("/api/v1/agents/{}/budget", hex_id(0xAA));
+    let response = app.oneshot(bearer(&uri, &token)).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "a team-scoped caller may read its own team's agent budget"
+    );
+}
+
+#[tokio::test]
+async fn agent_budget_cross_tenant_read_is_403() {
+    let state = common::test_state_with_auth(AuthMode::On, &[], 1000);
+    state.agent_registry.register(agent_with_team(0xBB, "beta")).unwrap();
+    let app = aa_api::build_app(state);
+
+    // Caller scoped to "alpha" must not read a "beta" agent's budget.
+    let token = common::generate_test_jwt_for_team("u", &[Scope::Read], "alpha");
+    let uri = format!("/api/v1/agents/{}/budget", hex_id(0xBB));
+    let response = app.oneshot(bearer(&uri, &token)).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "cross-tenant budget read is denied"
+    );
+}

--- a/aa-integration-tests/tests/api_auth_matrix.rs
+++ b/aa-integration-tests/tests/api_auth_matrix.rs
@@ -36,6 +36,8 @@ fn build_expired_jwt() -> String {
         iat: 0,
         exp: 1, // epoch second 1 — always in the past
         scope: vec![],
+        team_id: None,
+        org_id: None,
     };
     encode(
         &Header::default(),
@@ -514,6 +516,8 @@ fn build_swapped_alg_jwt() -> String {
         iat: 0,
         exp: 9_999_999_999,
         scope: vec![],
+        team_id: None,
+        org_id: None,
     };
     let valid_jwt = encode(
         &Header::default(),

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -1361,6 +1361,8 @@ pub fn make_api_key(id: &str, scopes: Vec<aa_api::auth::scope::Scope>) -> (Strin
         scopes,
         created_at: 1_700_000_000,
         label: Some(format!("test key {id}")),
+        team_id: None,
+        org_id: None,
     };
     (key.as_str().to_string(), entry)
 }

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -786,12 +786,11 @@ export interface paths {
          * @description Retrieve the current daily and monthly cost and budget summary,
          *     including per-agent breakdown and configured budget limits.
          *
-         *     The per-agent and per-team breakdowns span every tenant, so they are
-         *     only populated for callers holding `Scope::Admin` (AAASM-3126). Because
-         *     the authenticated principal carries no org/team scope yet (AAASM-3128),
-         *     a non-admin caller cannot be filtered down to its own tenant — so it
-         *     receives only the aggregate totals with the cross-tenant breakdowns
-         *     elided rather than leaking every tenant's spend (cross-tenant IDOR).
+         *     Per-tenant filtering (AAASM-3139): an admin caller sees every tenant's
+         *     per-agent and per-team breakdown; a tenant-scoped caller sees only its own
+         *     team's row; a caller with neither admin scope nor a team scope receives the
+         *     aggregate totals only, with the breakdowns elided rather than leaking every
+         *     tenant's spend (the cross-tenant IDOR that AAASM-3126 admin-gated).
          */
         get: operations["get_cost_summary"];
         put?: never;

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1404,12 +1404,11 @@ paths:
         Retrieve the current daily and monthly cost and budget summary,
         including per-agent breakdown and configured budget limits.
 
-        The per-agent and per-team breakdowns span every tenant, so they are
-        only populated for callers holding `Scope::Admin` (AAASM-3126). Because
-        the authenticated principal carries no org/team scope yet (AAASM-3128),
-        a non-admin caller cannot be filtered down to its own tenant — so it
-        receives only the aggregate totals with the cross-tenant breakdowns
-        elided rather than leaking every tenant's spend (cross-tenant IDOR).
+        Per-tenant filtering (AAASM-3139): an admin caller sees every tenant's
+        per-agent and per-team breakdown; a tenant-scoped caller sees only its own
+        team's row; a caller with neither admin scope nor a team scope receives the
+        aggregate totals only, with the breakdowns elided rather than leaking every
+        tenant's spend (the cross-tenant IDOR that AAASM-3126 admin-gated).
       operationId: get_cost_summary
       responses:
         '200':


### PR DESCRIPTION
## Description

Wave-2 (Medium) — adds an org/team tenant claim to the API auth principal and
uses it to enforce true per-tenant filtering on the cost/budget surfaces. This
**completes** the per-tenant filtering that Wave-1 #1089 (AAASM-3126) deferred to
an admin-only gate.

- `Claims` (JWT) and `ApiKeyEntry` gain optional `team_id` / `org_id` (serde-default
  for legacy tokens/keys); `JwtSigner::sign_with_tenant` issues tenant-scoped tokens.
- `AuthenticatedCaller` carries a `Tenant` populated from the credential, plus a
  `can_access_team` helper. Bypass mode and admin callers are unscoped.
- `GET /costs`: a tenant-scoped caller now sees **only its own team's** `per_team`
  row (no per-agent breakdown); admin sees all; an unscoped non-admin sees aggregate
  totals only.
- `GET /agents/{id}/budget`: a tenant-scoped caller may read budgets for agents in
  **its own team** (no longer admin-only); a caller with neither admin nor a team
  scope is denied up front (before the existence check) to prevent 403-vs-404
  enumeration; a cross-tenant read is `403`.

## Type of Change

- [x] ✨ New feature (tenant claim)
- [x] 🐛 Bug fix (security — per-tenant authz)

## Breaking Changes

- [x] No (new optional claims; previously-admin-only data now also reachable by the
  owning tenant — a strict broadening for tenant callers, no regression for admins)

## Related Issues

- Related Jira ticket: AAASM-3139

Closes AAASM-3139

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

JWT tenant-claim round-trip; `/costs` per-tenant filtering (own-team-only vs
admin-all); `/agents/{id}/budget` own-team read vs cross-tenant 403. Validated
locally: `cargo nextest run -p aa-api` — all pass except a pre-existing,
load-sensitive 100ms-latency flake in `http_policy_invalidation` (passes in
isolation; untouched by this PR). `cargo clippy -p aa-api --all-targets -- -D
warnings` clean, `cargo fmt`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
