### PR TITLE
[AAASM-3135] 🔒 (ci): Pin mutable-tag actions in release.yml to commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -429,7 +429,10 @@ jobs:
           git -C . diff -- Formula/aasm.rb || true
 
       - name: Open tap PR via peter-evans/create-pull-request
-        uses: peter-evans/create-pull-request@v8
+        # AAASM-3135: pinned to a full commit SHA (not the mutable v8 tag) so a
+        # compromised upstream tag cannot inject code into this privileged
+        # PR-opening job (it runs with elevated GITHUB_TOKEN). SHA = tag v8.1.1.
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           path: tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -501,7 +504,10 @@ jobs:
           git -C . diff -- native/aa-ffi-node/Cargo.lock || true
 
       - name: Open SDK pin-bump PR via peter-evans/create-pull-request
-        uses: peter-evans/create-pull-request@v8
+        # AAASM-3135: pinned to a full commit SHA (not the mutable v8 tag) so a
+        # compromised upstream tag cannot inject code into this privileged
+        # PR-opening job (it runs with elevated GITHUB_TOKEN). SHA = tag v8.1.1.
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           path: sdk
           token: ${{ secrets.NODE_SDK_BOT_TOKEN }}
@@ -583,7 +589,10 @@ jobs:
           git -C . diff -- native/aa-ffi-python/Cargo.lock || true
 
       - name: Open SDK pin-bump PR via peter-evans/create-pull-request
-        uses: peter-evans/create-pull-request@v8
+        # AAASM-3135: pinned to a full commit SHA (not the mutable v8 tag) so a
+        # compromised upstream tag cannot inject code into this privileged
+        # PR-opening job (it runs with elevated GITHUB_TOKEN). SHA = tag v8.1.1.
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           path: sdk
           token: ${{ secrets.PYTHON_SDK_BOT_TOKEN }}
@@ -670,7 +679,10 @@ jobs:
           git -C . diff -- native/aa-ffi-go/Cargo.lock || true
 
       - name: Open SDK pin-bump PR via peter-evans/create-pull-request
-        uses: peter-evans/create-pull-request@v8
+        # AAASM-3135: pinned to a full commit SHA (not the mutable v8 tag) so a
+        # compromised upstream tag cannot inject code into this privileged
+        # PR-opening job (it runs with elevated GITHUB_TOKEN). SHA = tag v8.1.1.
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           path: sdk
           token: ${{ secrets.GO_SDK_BOT_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,7 +214,10 @@ jobs:
 
       - name: Upload assets to GitHub Release
         if: github.event_name == 'push'
-        uses: softprops/action-gh-release@v3
+        # AAASM-3135: pin to a full commit SHA (not the mutable v3 tag) so a
+        # compromised upstream tag cannot inject code into this privileged
+        # release-publishing job. SHA = tag v3.0.0.
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: |
             artifacts/aasm-*.tar.gz


### PR DESCRIPTION
## Description

Wave-2 (Medium) supply-chain hardening of `release.yml`.

The privileged release jobs referenced third-party actions by **mutable tag**, so
a compromised or force-moved upstream tag could inject code into a job that runs
with an elevated `GITHUB_TOKEN` (publishing the GitHub Release and opening the
downstream homebrew/python/node/docs PRs). All five uses are now pinned to full
commit SHAs (with the resolved version in a trailing comment):

- `softprops/action-gh-release@v3` → `@b4309332…` (v3.0.0)
- 4× `peter-evans/create-pull-request@v8` → `@5f6978fa…` (v8.1.1)

SHAs were resolved from each tag via the GitHub API and verified against the
precise sub-version release (v3.0.0 / v8.1.1).

## Type of Change

- [x] 🔧 Configuration / CI change (security)

## Breaking Changes

- [x] No (same action versions, pinned immutably)

## Related Issues

- Related Jira ticket: AAASM-3135

Closes AAASM-3135

## Testing

- [x] No tests required (CI workflow change)

Validated locally: `actionlint -shellcheck=` clean on the file; YAML parses; the
only actionlint shellcheck finding (SC2046 at line 114) is pre-existing on master
and untouched by this PR. (Org Actions billing is intermittently blocked, so the
workflow itself was validated locally rather than by a live run.)

## Checklist

- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (inline why-comments added)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
