### PR TITLE
[AAASM-3140] 🔒 (aa-proxy): Re-validate SSRF denylist on plain-HTTP forward path

### DIFF
--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -861,4 +861,32 @@ mod tests {
         assert_eq!(server.connect_deny_reason("api.openai.com"), None);
         assert_eq!(server.connect_deny_reason("1.1.1.1"), None);
     }
+
+    #[tokio::test]
+    async fn plain_http_forward_blocks_ssrf_resolved_ip() {
+        // AAASM-3140 regression: a plain-HTTP (non-CONNECT) request whose host
+        // resolves to a denied IP (here, loopback) must be refused by the same
+        // SSRF resolved-IP re-validation that guards the CONNECT/tunnel paths.
+        // Before the fix the plain-HTTP path dialed the upstream directly,
+        // bypassing the denylist.
+        let server = server_with(vec![], vec![]).await;
+
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let mut client = TcpStream::connect(addr).await.unwrap();
+        let (server_stream, _) = listener.accept().await.unwrap();
+
+        // Plain HTTP request targeting a loopback literal — a blocked range.
+        client
+            .write_all(b"GET http://127.0.0.1/secret HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n")
+            .await
+            .unwrap();
+
+        let result = server.handle_connection(server_stream).await;
+        let err = result.expect_err("plain-HTTP request to a blocked IP must be refused");
+        assert!(
+            matches!(&err, ProxyError::Config(msg) if msg.contains("ssrf")),
+            "expected SSRF denial, got: {err:?}"
+        );
+    }
 }

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -763,7 +763,15 @@ impl ProxyServer {
             } else {
                 format!("{host}:80")
             };
-            let mut upstream = TcpStream::connect(&upstream_addr).await?;
+            // SSRF re-validation (AAASM-3140): the plain-HTTP forward path must
+            // route through the same resolved-IP denylist as the CONNECT/tunnel
+            // paths. Without this, a steered agent making a plain `http://`
+            // request could reach loopback / RFC-1918 / `169.254.169.254` after
+            // DNS resolution, bypassing the AAASM-3130 hardening.
+            let mut upstream = match self.config.upstream_override {
+                Some(addr) => TcpStream::connect(addr).await?,
+                None => self.connect_revalidated(&upstream_addr).await?,
+            };
 
             // Re-serialise and forward the original request.
             upstream.write_all(request_line.as_bytes()).await?;

--- a/aa-proxy/tests/proxy_integration.rs
+++ b/aa-proxy/tests/proxy_integration.rs
@@ -24,9 +24,13 @@ fn test_config(ca_dir: &std::path::Path) -> ProxyConfig {
         credential_action: CredentialAction::default(),
         upstream_override: None,
         gateway_endpoint: None,
-        // CONNECT targets here are public names; the loopback case uses the
-        // plain-HTTP path, so the SSRF guard stays active.
-        allow_private_connect_targets: false,
+        // Integration tests dial loopback mock upstreams over both the CONNECT
+        // and the plain-HTTP forward paths. The plain-HTTP path now re-validates
+        // resolved IPs against the SSRF denylist (AAASM-3140), which blocks
+        // loopback — so the test-only escape hatch must be enabled here, exactly
+        // as the CONNECT/tunnel paths already require for their loopback mocks.
+        // Production `from_env` keeps this false.
+        allow_private_connect_targets: true,
     }
 }
 


### PR DESCRIPTION
## Description

The SSRF hardening in #1093 (AAASM-3130) added `connect_revalidated` — which
re-validates the DNS-resolved upstream IP against the egress denylist
immediately before dialing — to the HTTPS CONNECT and transparent-tunnel paths.
The **plain-HTTP (non-TLS, non-CONNECT) forward/dial path** was missed: it dialed
the resolved upstream directly via `TcpStream::connect`, bypassing the denylist.

A steered agent making a plain `http://` request through the sidecar could still
reach `169.254.169.254` (cloud metadata), RFC-1918, or loopback after DNS
resolution. This routes the plain-HTTP forward dial through the same
`connect_revalidated` guard, honouring `upstream_override` for test parity.

## Type of Change

- [x] 🐛 Bug fix (security: SSRF)

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3140
- Follow-up to #1093 (AAASM-3130)

## Testing

- [x] Unit tests added / updated — `plain_http_forward_blocks_ssrf_resolved_ip`
  asserts a plain-HTTP request to a blocked (loopback) IP is refused with an
  SSRF error.
- [x] Integration tests added / updated — `plain_http_request_is_forwarded_to_upstream`
  now enables the test-only `allow_private_connect_targets` escape hatch (the
  same hatch the CONNECT/tunnel loopback mocks already use); production
  `from_env` keeps it false.

Validated locally (org CI is billing-intermittent): `cargo build -p aa-proxy`,
`cargo nextest run -p aa-proxy` (105 passed), `cargo clippy -p aa-proxy
--all-targets -- -D warnings` (clean), `cargo fmt`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (inline why-comment added)
- [ ] All CI checks passing (org Actions billing-intermittent; validated locally)
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3140
