### PR TITLE
[AAASM-3141] 🐛 (aa-integration-tests): Fix node init e2e test for AA_AUTO_START gating

### DIFF
--- a/aa-integration-tests/tests/e2e_sdk_runtime_lifecycle.rs
+++ b/aa-integration-tests/tests/e2e_sdk_runtime_lifecycle.rs
@@ -361,6 +361,11 @@ fn node_init_assembly_throws_when_missing() {
         .env("NODE_SDK_PATH", node_sdk_path())
         .env("PATH", EMPTY_PATH_DIR)
         .env("HOME", fake_home.path())
+        // AAASM-3124 (node #153) gated sidecar auto-start behind AA_AUTO_START.
+        // Opt in so init exercises the resolve-and-throw path (binary lookup
+        // followed by the INSTALL_HINT error) rather than the auto-start-disabled
+        // early return, which is what this test asserts.
+        .env("AA_AUTO_START", "1")
         .output()
         .expect("spawn node");
     let stderr = String::from_utf8_lossy(&out.stderr);


### PR DESCRIPTION
## Description

`node_init_assembly_throws_when_missing` in `aa-integration-tests/tests/e2e_sdk_runtime_lifecycle.rs` asserted the OLD node `init` behavior (always auto-start, throw INSTALL_HINT when the binary is missing). node-sdk #153 (AAASM-3124) gated sidecar auto-start behind the `AA_AUTO_START` opt-in: `runtime.ts::initAssembly` now early-returns with an "auto-start is disabled" error **before** reaching the binary lookup unless `AA_AUTO_START` is truthy. Once node-sdk master picked up #153, the cross-repo `Test` gate (which resolves the SDK from the sibling `node-sdk` checkout) went red, blocking PR #1099 and all agent-assembly PRs.

This opts the spawned probe into `AA_AUTO_START=1` so `init` exercises the resolve-and-throw path (binary lookup → `INSTALL_HINT`) the test asserts. The `INSTALL_HINT` string is unchanged (still starts with `agent-assembly runtime not found.`), so the asserted stderr substring stays the same. Python/Go sibling tests are unaffected and left untouched. Minimal 5-line diff.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3141
- Cause: node-sdk #153 (AAASM-3124)

## Testing

- [x] Integration tests added / updated
- [x] Manual testing performed

Built node-sdk from `remote/master` (the #153 merge) and ran:

```
NODE_SDK_PATH=<node-sdk built from remote/master> \
  cargo nextest run -p aa-integration-tests node_init_assembly_throws_when_missing
# => 1 passed
```

The current node contract (read from `node-sdk` `remote/master` `src/runtime.ts`, the module the fixture imports as `dist/esm/runtime.js`): with `AA_AUTO_START=1` and `aasm` absent, `initAssembly` passes the auto-start gate, `findAasmBinary()` returns `null`, and it throws `Error(INSTALL_HINT)` → Node exits non-zero with `agent-assembly runtime not found.` on stderr.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3141

🤖 Generated with [Claude Code](https://claude.com/claude-code)