### PR TITLE
[AAASM-3185] 🔧 (ci): Add nightly SDK↔core git-SHA drift detector

### DIFF
--- a/.ci/check-sdk-sha-consistency.sh
+++ b/.ci/check-sdk-sha-consistency.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# check-sdk-sha-consistency.sh
+#
+# Audits that the three language-SDK repos pin the shared `agent-assembly` core
+# crates to ONE consistent git rev — both intra-repo (every `aa-*` git dep in a
+# repo's native binding shares one rev, the cargo single-checkout invariant) and
+# cross-repo (all three SDKs agree on one rev). See ADR 0003 (AAASM-3173).
+#
+# `agent-assembly-enterprise` is intentionally excluded — it moves on its own
+# cadence by design.
+#
+# Writes a Markdown report to $1 (default ./sdk-sha-report.md). Exit 1 on drift.
+# Reads the sibling public repos via the GitHub API (`gh`); no checkout needed.
+# POSIX-bash compatible (no associative arrays) so it runs anywhere.
+set -uo pipefail
+REPORT="${1:-./sdk-sha-report.md}"
+
+manifest_for() {
+  case "$1" in
+    python-sdk) echo "native/aa-ffi-python/Cargo.toml" ;;
+    node-sdk)   echo "native/aa-ffi-node/Cargo.toml" ;;
+    go-sdk)     echo "native/aa-ffi-go/Cargo.toml" ;;
+  esac
+}
+
+drift=0
+all_revs=""
+{
+  echo "## SDK ↔ core git-rev consistency ($(date -u +%Y-%m-%dT%H:%MZ))"
+  echo
+  echo "| Repo | aa-* deps | rev(s) | intra-consistent |"
+  echo "|---|---|---|---|"
+} > "$REPORT"
+
+for repo in python-sdk node-sdk go-sdk; do
+  manifest=$(manifest_for "$repo")
+  toml=$(gh api "repos/ai-agent-assembly/${repo}/contents/${manifest}" --jq '.content' 2>/dev/null | base64 -d)
+  lines=$(printf '%s\n' "$toml" | grep -E 'git *= *"https://github\.com/ai-agent-assembly/agent-assembly' || true)
+  revs=$(printf '%s\n' "$lines" | grep -oE 'rev *= *"[0-9a-f]{7,40}"' | grep -oE '[0-9a-f]{7,40}' | sort -u)
+  n=$(printf '%s\n' "$revs" | grep -c . || true)
+  crates=$(printf '%s\n' "$lines" | sed -E 's/^([a-z0-9_-]+).*/\1/' | paste -sd, - 2>/dev/null)
+  if [ "$n" -eq 1 ]; then
+    ok="✅"; repo_rev="$revs"
+  else
+    ok="❌ (${n} distinct)"; drift=1; repo_rev="MIXED:${n}"
+  fi
+  all_revs="${all_revs}${repo_rev}
+"
+  echo "| \`${repo}\` | ${crates:-—} | \`$(printf '%s' "$revs" | tr '\n' ' ')\` | ${ok} |" >> "$REPORT"
+done
+
+uniq=$(printf '%s' "$all_revs" | sort -u | grep -c . || true)
+{
+  echo
+  if [ "$drift" -eq 0 ] && [ "$uniq" -eq 1 ]; then
+    echo "**✅ Lockstep holds** — all three SDKs intra-consistent and on the same rev \`$(printf '%s' "$all_revs" | head -1)\`."
+  else
+    echo "**❌ Drift detected** — the SDKs are not all pinned to one consistent rev (see table). This breaks the ADR 0003 lockstep invariant; bump all three SDKs' native \`aa-*\` git deps to the same release rev."
+    drift=1
+  fi
+} >> "$REPORT"
+
+cat "$REPORT"
+exit "$drift"

--- a/.github/workflows/sdk-sha-drift.yml
+++ b/.github/workflows/sdk-sha-drift.yml
@@ -1,0 +1,45 @@
+name: SDK SHA drift detector
+
+# Nightly advisory check of the ADR 0003 cross-repo lockstep invariant: the three
+# language SDKs must pin the shared `agent-assembly` core crates to one consistent
+# git rev. On drift it opens (or updates) a tracking issue; it is non-blocking for
+# any product CI. Also runnable on demand via workflow_dispatch.
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  detect:
+    name: SDK ↔ core SHA consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check SDK ↔ core SHA consistency
+        id: check
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .ci/check-sdk-sha-consistency.sh "${GITHUB_WORKSPACE}/sdk-sha-report.md"
+      - name: Open or update the drift issue
+        if: steps.check.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --label sdk-sha-drift --state open --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body-file "${GITHUB_WORKSPACE}/sdk-sha-report.md"
+            echo "Updated existing drift issue #${existing}."
+          else
+            gh label create sdk-sha-drift --repo "$GITHUB_REPOSITORY" --color B60205 --description "SDK <-> core git-SHA pin drift (ADR 0003)" 2>/dev/null || true
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "SDK <-> core git-SHA drift detected" --label sdk-sha-drift --body-file "${GITHUB_WORKSPACE}/sdk-sha-report.md"
+          fi
+      - name: Surface drift as a failed run
+        if: steps.check.outcome == 'failure'
+        run: |
+          echo "SDK <-> core git-SHA drift detected — see the tracking issue."
+          exit 1


### PR DESCRIPTION
## What

Adds a nightly **cross-repo SDK↔core git-SHA drift detector** to this repo:

- `.ci/check-sdk-sha-consistency.sh` — fetches the three SDKs' `native/aa-ffi-*/Cargo.toml` via the GitHub API and asserts (a) each repo pins the `agent-assembly` `aa-*` git deps to **one** rev (intra-repo, the cargo single-checkout invariant) and (b) all three SDKs agree on **one** rev (cross-repo lockstep). Writes a Markdown report; exit 1 on drift.
- `.github/workflows/sdk-sha-drift.yml` — runs it nightly (`cron` + `workflow_dispatch`); on drift it opens/updates a labelled `sdk-sha-drift` tracking issue with the report, and surfaces the run as failed. Silent when consistent.

## Why

Per **ADR 0003** (AAASM-3173), the SDK bindings pin the core crates by git SHA, in lockstep. The per-SDK PR guards (AAASM-3182/3/4) catch *intra-repo* skew at PR time; this is the *cross-repo* safety net that notices when the three SDKs drift onto different revs (e.g. one released ahead). Advisory — it never blocks product CI.

## How to verify

```
bash .ci/check-sdk-sha-consistency.sh /tmp/r.md   # prints the report; exit 0 today
```
Baseline 2026-06-18: ✅ all three SDKs on `4f9eea19…` (intra- and cross-consistent). Validated locally (shellcheck clean, bash-3.2 portable, smoke-run green).

## Related

- Subtask: **AAASM-3185** · Story: **AAASM-3181** · Rationale: ADR 0003.
- Per-SDK PR guards: python-sdk #142, node-sdk #155, go-sdk #72. Verification: AAASM-3186.
