### PR TITLE
[AAASM-3188] ♻️ (ci): Make the SDK SHA detector config-driven (+ enterprise)

### DIFF
--- a/.ci/check-sdk-sha-consistency.sh
+++ b/.ci/check-sdk-sha-consistency.sh
@@ -1,62 +1,106 @@
 #!/usr/bin/env bash
 # check-sdk-sha-consistency.sh
 #
-# Audits that the three language-SDK repos pin the shared `agent-assembly` core
-# crates to ONE consistent git rev — both intra-repo (every `aa-*` git dep in a
-# repo's native binding shares one rev, the cargo single-checkout invariant) and
-# cross-repo (all three SDKs agree on one rev). See ADR 0003 (AAASM-3173).
+# Audits that the repos consuming the shared `agent-assembly` core `aa-*` crates
+# pin them to a consistent git rev. The set of consumers is NOT hard-coded here —
+# it is read from `.ci/core-consumers.json` (the single source of truth) so no
+# consumer is silently missed. See ADR 0003 (AAASM-3173) and AAASM-3187/3188.
 #
-# `agent-assembly-enterprise` is intentionally excluded — it moves on its own
-# cadence by design.
+# Two invariants are checked:
+#   * intra-repo  — every `aa-*` git dep in a consumer's manifest shares one rev
+#                   (the cargo single-checkout invariant). Violation == drift.
+#   * lockstep    — all consumers with policy=="lockstep" (the SDKs, released in
+#                   lockstep) agree on one rev. Violation == drift.
+#
+# Consumers with policy=="independent" (e.g. agent-assembly-enterprise) move on
+# their own cadence: their rev is reported for visibility but a differing rev is
+# NOT drift. Consumers whose manifest cannot be fetched (e.g. a private repo the
+# token cannot read) are reported as `skipped (no access)` and never fail the run.
 #
 # Writes a Markdown report to $1 (default ./sdk-sha-report.md). Exit 1 on drift.
-# Reads the sibling public repos via the GitHub API (`gh`); no checkout needed.
-# POSIX-bash compatible (no associative arrays) so it runs anywhere.
+# Reads the consumer repos via the GitHub API (`gh`); no checkout needed.
+# bash-3.2 portable (no associative arrays) so it runs anywhere.
 set -uo pipefail
-REPORT="${1:-./sdk-sha-report.md}"
 
-manifest_for() {
-  case "$1" in
-    python-sdk) echo "native/aa-ffi-python/Cargo.toml" ;;
-    node-sdk)   echo "native/aa-ffi-node/Cargo.toml" ;;
-    go-sdk)     echo "native/aa-ffi-go/Cargo.toml" ;;
-  esac
-}
+REPORT="${1:-./sdk-sha-report.md}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+REGISTRY="${SCRIPT_DIR}/core-consumers.json"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required but not installed" >&2
+  exit 2
+fi
+if [ ! -f "$REGISTRY" ]; then
+  echo "error: consumer registry not found at ${REGISTRY}" >&2
+  exit 2
+fi
 
 drift=0
-all_revs=""
+lockstep_revs=""
+
 {
-  echo "## SDK ↔ core git-rev consistency ($(date -u +%Y-%m-%dT%H:%MZ))"
+  echo "## Core ↔ consumer git-rev consistency ($(date -u +%Y-%m-%dT%H:%MZ))"
   echo
-  echo "| Repo | aa-* deps | rev(s) | intra-consistent |"
-  echo "|---|---|---|---|"
+  echo "Source of truth: \`.ci/core-consumers.json\`. \`lockstep\` consumers must all"
+  echo "share one rev; \`independent\` consumers are reported for visibility only."
+  echo
+  echo "| Repo | policy | rev(s) | intra | status |"
+  echo "|---|---|---|---|---|"
 } > "$REPORT"
 
-for repo in python-sdk node-sdk go-sdk; do
-  manifest=$(manifest_for "$repo")
-  toml=$(gh api "repos/ai-agent-assembly/${repo}/contents/${manifest}" --jq '.content' 2>/dev/null | base64 -d)
+# Iterate the registry. Tab-separated so values with no spaces parse cleanly.
+while IFS=$'\t' read -r repo manifest policy; do
+  [ -n "$repo" ] || continue
+
+  toml=$(gh api "repos/ai-agent-assembly/${repo}/contents/${manifest}" --jq '.content' 2>/dev/null | base64 -d 2>/dev/null)
+  if [ -z "$toml" ]; then
+    echo "| \`${repo}\` | ${policy} | — | — | ⏭️ skipped (no access) |" >> "$REPORT"
+    continue
+  fi
+
   lines=$(printf '%s\n' "$toml" | grep -E 'git *= *"https://github\.com/ai-agent-assembly/agent-assembly' || true)
   revs=$(printf '%s\n' "$lines" | grep -oE 'rev *= *"[0-9a-f]{7,40}"' | grep -oE '[0-9a-f]{7,40}' | sort -u)
   n=$(printf '%s\n' "$revs" | grep -c . || true)
-  crates=$(printf '%s\n' "$lines" | sed -E 's/^([a-z0-9_-]+).*/\1/' | paste -sd, - 2>/dev/null)
-  if [ "$n" -eq 1 ]; then
-    ok="✅"; repo_rev="$revs"
-  else
-    ok="❌ (${n} distinct)"; drift=1; repo_rev="MIXED:${n}"
-  fi
-  all_revs="${all_revs}${repo_rev}
-"
-  echo "| \`${repo}\` | ${crates:-—} | \`$(printf '%s' "$revs" | tr '\n' ' ')\` | ${ok} |" >> "$REPORT"
-done
 
-uniq=$(printf '%s' "$all_revs" | sort -u | grep -c . || true)
+  if [ "$n" -eq 1 ]; then
+    intra="✅"
+    repo_rev="$revs"
+    rev_cell="\`${revs}\`"
+    status="ok"
+  else
+    intra="❌ (${n} distinct)"
+    repo_rev=""
+    rev_cell="\`$(printf '%s' "$revs" | tr '\n' ' ')\`"
+    status="❌ intra-drift"
+    drift=1
+  fi
+
+  if [ "$policy" = "lockstep" ]; then
+    if [ "$status" = "ok" ]; then
+      status="✅ lockstep"
+    fi
+    lockstep_revs="${lockstep_revs}${repo_rev}
+"
+  elif [ "$status" = "ok" ]; then
+    status="ℹ️ independent"
+  fi
+
+  echo "| \`${repo}\` | ${policy} | ${rev_cell} | ${intra} | ${status} |" >> "$REPORT"
+done < <(jq -r '.consumers[] | [.repo, .manifest, .policy] | @tsv' "$REGISTRY")
+
+# Lockstep group must agree on exactly one rev.
+lockstep_uniq=$(printf '%s' "$lockstep_revs" | sort -u | grep -c . || true)
+lockstep_head=$(printf '%s' "$lockstep_revs" | grep -v '^$' | head -1)
+
 {
   echo
-  if [ "$drift" -eq 0 ] && [ "$uniq" -eq 1 ]; then
-    echo "**✅ Lockstep holds** — all three SDKs intra-consistent and on the same rev \`$(printf '%s' "$all_revs" | head -1)\`."
+  if [ "$drift" -eq 0 ] && [ "$lockstep_uniq" -le 1 ]; then
+    echo "**✅ Lockstep holds** — all readable \`lockstep\` consumers are intra-consistent and on the same rev \`${lockstep_head:-n/a}\`. (Independent and skipped consumers do not affect this verdict.)"
   else
-    echo "**❌ Drift detected** — the SDKs are not all pinned to one consistent rev (see table). This breaks the ADR 0003 lockstep invariant; bump all three SDKs' native \`aa-*\` git deps to the same release rev."
-    drift=1
+    if [ "$lockstep_uniq" -gt 1 ]; then
+      drift=1
+    fi
+    echo "**❌ Drift detected** — the \`lockstep\` consumers are not all pinned to one consistent rev (see table). This breaks the ADR 0003 lockstep invariant; bump every lockstep consumer's native \`aa-*\` git deps to the same release rev."
   fi
 } >> "$REPORT"
 

--- a/.ci/core-consumers.json
+++ b/.ci/core-consumers.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Registry of repos that consume the agent-assembly core aa-* crates by git rev. policy=lockstep MUST all share one rev (the SDKs, released in lockstep). policy=independent moves on its own cadence (enterprise) - reported for visibility, a differing rev is NOT drift. Add new consumers here. See ADR 0003 / AAASM-3187.",
+  "consumers": [
+    { "repo": "python-sdk", "manifest": "native/aa-ffi-python/Cargo.toml", "visibility": "public", "policy": "lockstep" },
+    { "repo": "node-sdk",   "manifest": "native/aa-ffi-node/Cargo.toml",   "visibility": "public", "policy": "lockstep" },
+    { "repo": "go-sdk",     "manifest": "native/aa-ffi-go/Cargo.toml",     "visibility": "public", "policy": "lockstep" },
+    { "repo": "agent-assembly-enterprise", "manifest": "Cargo.toml", "visibility": "private", "policy": "independent" }
+  ]
+}

--- a/.github/workflows/sdk-sha-drift.yml
+++ b/.github/workflows/sdk-sha-drift.yml
@@ -23,7 +23,7 @@ jobs:
         id: check
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.CROSS_REPO_TOKEN || github.token }}
         run: bash .ci/check-sdk-sha-consistency.sh "${GITHUB_WORKSPACE}/sdk-sha-report.md"
       - name: Open or update the drift issue
         if: steps.check.outcome == 'failure'


### PR DESCRIPTION
## Description

Makes the SDK ↔ core SHA drift detector (added in AAASM-3185) **config-driven** so
no consumer of the `agent-assembly` core `aa-*` crates is silently missed.

- Adds `.ci/core-consumers.json` — the single source of truth listing every
  consumer repo, its manifest path, visibility, and a per-consumer `policy`:
  - `lockstep` — the SDKs, released in lockstep; they MUST all share one rev.
  - `independent` — `agent-assembly-enterprise`, which moves on its own cadence;
    reported for visibility, a differing rev is **not** drift.
- Refactors `.ci/check-sdk-sha-consistency.sh` to loop over that registry (via
  `jq`) instead of the hard-coded three-repo list. Behavior:
  - Each consumer's manifest is fetched via the GitHub API. A manifest that
    cannot be read (e.g. a private repo the token lacks access to) is marked
    `skipped (no access)` and never fails the run.
  - Intra-repo check: every `aa-*` git dep in a manifest must share one rev.
  - Lockstep check: all readable `lockstep` consumers must agree on one rev.
  - Drift (exit 1) iff a readable consumer is intra-inconsistent OR the lockstep
    group is not all-equal. Independent mismatch and skipped-private never fail.
- Adds `agent-assembly-enterprise` as a report-only (`independent`) entry.
- Tweaks the workflow's check-step env to
  `GH_TOKEN: ${{ secrets.CROSS_REPO_TOKEN || github.token }}` so that IF an org
  admin later adds a `CROSS_REPO_TOKEN` secret with enterprise read access, the
  detector reads enterprise too; otherwise it gracefully skips it.

The script stays bash-3.2 portable (no `declare -A`), `set -uo pipefail`, and
shellcheck `-S error` clean.

## Type of Change

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [x] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

The detector's filename, the workflow's reference to it, and its exit-code
contract are all unchanged.

## Related Issues

- Related Jira ticket: AAASM-3188
- Related GitHub issues: n/a

## Testing

Local validation against the LIVE repos (no checkout required):

- `jq . .ci/core-consumers.json` → valid JSON.
- `shellcheck -S error .ci/check-sdk-sha-consistency.sh` → clean (no info-level
  notes either).
- Full run against the live org repos → **exit 0**. The three SDKs show
  `4f9eea19…` / `lockstep ✅`; `agent-assembly-enterprise` is read (token has
  access) and shown as `6ba36f3d…` / `independent` — a differing rev that does
  **not** trip drift.
- Logic checks:
  - A manifest doctored to 2 distinct revs → intra-drift detected (`drift=1`).
  - A registry entry pointing at an unreadable repo → `skipped (no access)`,
    run still exit 0.
  - Two `lockstep` consumers on different revs (via a `gh` shim) → exit 1.
- `python3 -c "import yaml; yaml.safe_load(...)"` on the modified workflow →
  valid YAML; diff vs master is exactly the one `GH_TOKEN` env line.

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [x] No tests required (explain why)

This is a CI helper script + registry; it is exercised by its own
`workflow_dispatch`/nightly run. Validated manually against the live repos as
described above.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
