### PR TITLE
[AAASM-3175] ✅ (agent-assembly): Raise core test coverage toward 90%

### DIFF
--- a/aa-api/tests/connectors.rs
+++ b/aa-api/tests/connectors.rs
@@ -1,0 +1,316 @@
+//! Integration tests for the notification connectors (AAASM-1388 / AAASM-3175).
+//!
+//! The webhook and Slack connectors POST to the destination-configured URL, so
+//! they can be exercised end-to-end against an `httpmock` server: success (2xx
+//! → `DispatchOutcome`), failure (non-2xx → `ConnectorError::Http`), header and
+//! payload shaping, and response-body truncation. The wrong-destination-type
+//! guard on every connector is a synchronous early-return that needs no server.
+//!
+//! PagerDuty and OpsGenie hardcode their vendor API URLs (`events.pagerduty.com`
+//! / `api.opsgenie.com`), so their dispatch happy-path cannot be redirected to a
+//! mock server; only their wrong-type guards are covered here.
+
+use aa_api::destinations::connectors::slack::SlackConnector;
+use aa_api::destinations::connectors::webhook::WebhookConnector;
+use aa_api::destinations::connectors::{ConnectorError, DispatchRequest, NotificationConnector};
+use aa_api::destinations::types::{Destination, DestinationConfig};
+use httpmock::prelude::*;
+use httpmock::Method::POST as MOCK_POST;
+
+/// Wrap a `DestinationConfig` in a `Destination` with throwaway metadata.
+fn destination(config: DestinationConfig) -> Destination {
+    Destination {
+        id: "dst_test".to_string(),
+        name: "test-destination".to_string(),
+        config,
+        enabled: true,
+        created_at: "2026-06-18T00:00:00Z".to_string(),
+        updated_at: "2026-06-18T00:00:00Z".to_string(),
+    }
+}
+
+fn request(severity: &str, message: &str) -> DispatchRequest {
+    DispatchRequest {
+        severity: severity.to_string(),
+        message: message.to_string(),
+    }
+}
+
+#[test]
+fn dispatch_request_default_has_low_severity_and_canned_message() {
+    let req = DispatchRequest::default();
+    assert_eq!(req.severity, "LOW");
+    assert_eq!(req.message, "AAASM test fire");
+}
+
+// ── Webhook connector ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn webhook_dispatch_posts_payload_and_returns_outcome_on_2xx() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(MOCK_POST)
+            .path("/hook")
+            .json_body_includes(r#"{ "severity": "HIGH", "message": "disk full" }"#);
+        then.status(202).body("queued");
+    });
+
+    let dst = destination(DestinationConfig::Webhook {
+        url: server.url("/hook"),
+        secret_header: None,
+    });
+
+    let outcome = WebhookConnector
+        .dispatch(&dst, &request("HIGH", "disk full"))
+        .await
+        .expect("2xx is a success");
+
+    mock.assert();
+    assert_eq!(outcome.connector_response_status, 202);
+    assert_eq!(outcome.connector_response_body, "queued");
+    assert!(!outcome.delivered_at.is_empty());
+}
+
+#[tokio::test]
+async fn webhook_dispatch_includes_secret_header_when_configured() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(MOCK_POST).path("/secure").header("X-AAASM-Token", "s3cr3t");
+        then.status(200);
+    });
+
+    let dst = destination(DestinationConfig::Webhook {
+        url: server.url("/secure"),
+        secret_header: Some("s3cr3t".to_string()),
+    });
+
+    WebhookConnector
+        .dispatch(&dst, &DispatchRequest::default())
+        .await
+        .expect("authenticated webhook succeeds");
+
+    // The mock only matches when the secret header is present.
+    mock.assert();
+}
+
+#[tokio::test]
+async fn webhook_dispatch_maps_non_2xx_to_http_error() {
+    let server = MockServer::start();
+    server.mock(|when, then| {
+        when.method(MOCK_POST).path("/hook");
+        then.status(500).body("upstream boom");
+    });
+
+    let dst = destination(DestinationConfig::Webhook {
+        url: server.url("/hook"),
+        secret_header: None,
+    });
+
+    let err = WebhookConnector
+        .dispatch(&dst, &DispatchRequest::default())
+        .await
+        .expect_err("500 must surface as an error");
+
+    match err {
+        ConnectorError::Http { status, body } => {
+            assert_eq!(status, 500);
+            assert_eq!(body, "upstream boom");
+        }
+        other => panic!("expected Http error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn webhook_dispatch_truncates_oversized_response_body() {
+    let server = MockServer::start();
+    // A 3000-byte body must be capped at the 2048-byte ceiling.
+    let big = "x".repeat(3000);
+    server.mock(|when, then| {
+        when.method(MOCK_POST).path("/hook");
+        then.status(200).body(&big);
+    });
+
+    let dst = destination(DestinationConfig::Webhook {
+        url: server.url("/hook"),
+        secret_header: None,
+    });
+
+    let outcome = WebhookConnector
+        .dispatch(&dst, &DispatchRequest::default())
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.connector_response_body.len(), 2048);
+}
+
+#[tokio::test]
+async fn webhook_dispatch_transport_error_on_unreachable_host() {
+    // Port 1 never listens; the connect attempt fails before any HTTP response.
+    let dst = destination(DestinationConfig::Webhook {
+        url: "http://127.0.0.1:1/hook".to_string(),
+        secret_header: None,
+    });
+
+    let err = WebhookConnector
+        .dispatch(&dst, &DispatchRequest::default())
+        .await
+        .expect_err("unreachable host must be a transport error");
+
+    assert!(matches!(err, ConnectorError::Transport(_)));
+}
+
+#[tokio::test]
+async fn webhook_connector_rejects_non_webhook_destination() {
+    let dst = destination(DestinationConfig::Slack {
+        webhook_url: "https://hooks.slack.test/x".to_string(),
+        channel_override: None,
+    });
+
+    let err = WebhookConnector
+        .dispatch(&dst, &DispatchRequest::default())
+        .await
+        .expect_err("wrong destination kind must be rejected");
+
+    match err {
+        ConnectorError::Transport(msg) => assert!(msg.contains("non-webhook")),
+        other => panic!("expected Transport guard error, got {other:?}"),
+    }
+}
+
+// ── Slack connector ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn slack_dispatch_posts_text_payload_and_returns_outcome() {
+    let server = MockServer::start();
+    // The mock only matches when the request body carries the formatted
+    // `"[SEVERITY] message"` text, so a passing `mock.assert()` verifies the
+    // payload shaping without needing to capture the raw body.
+    let mock = server.mock(|when, then| {
+        when.method(MOCK_POST)
+            .path("/slack")
+            .json_body_includes(r#"{ "text": "[CRITICAL] pipeline down" }"#);
+        then.status(200).body("ok");
+    });
+
+    let dst = destination(DestinationConfig::Slack {
+        webhook_url: server.url("/slack"),
+        channel_override: None,
+    });
+
+    let outcome = SlackConnector
+        .dispatch(&dst, &request("CRITICAL", "pipeline down"))
+        .await
+        .expect("slack 200 is a success");
+
+    mock.assert();
+    assert_eq!(outcome.connector_response_status, 200);
+    assert_eq!(outcome.connector_response_body, "ok");
+}
+
+#[tokio::test]
+async fn slack_dispatch_includes_channel_override_when_configured() {
+    let server = MockServer::start();
+    // The matcher requires the `channel` key, so a passing assert proves the
+    // override was injected into the payload.
+    let mock = server.mock(|when, then| {
+        when.method(MOCK_POST)
+            .path("/slack")
+            .json_body_includes(r##"{ "channel": "#alerts" }"##);
+        then.status(200);
+    });
+
+    let dst = destination(DestinationConfig::Slack {
+        webhook_url: server.url("/slack"),
+        channel_override: Some("#alerts".to_string()),
+    });
+
+    SlackConnector
+        .dispatch(&dst, &DispatchRequest::default())
+        .await
+        .unwrap();
+
+    mock.assert();
+}
+
+#[tokio::test]
+async fn slack_dispatch_maps_non_2xx_to_http_error() {
+    let server = MockServer::start();
+    server.mock(|when, then| {
+        when.method(MOCK_POST).path("/slack");
+        then.status(404).body("no_such_hook");
+    });
+
+    let dst = destination(DestinationConfig::Slack {
+        webhook_url: server.url("/slack"),
+        channel_override: None,
+    });
+
+    let err = SlackConnector
+        .dispatch(&dst, &DispatchRequest::default())
+        .await
+        .expect_err("404 must surface as an error");
+
+    match err {
+        ConnectorError::Http { status, .. } => assert_eq!(status, 404),
+        other => panic!("expected Http error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn slack_connector_rejects_non_slack_destination() {
+    let dst = destination(DestinationConfig::Webhook {
+        url: "https://example.test/hook".to_string(),
+        secret_header: None,
+    });
+
+    let err = SlackConnector
+        .dispatch(&dst, &DispatchRequest::default())
+        .await
+        .expect_err("wrong destination kind must be rejected");
+
+    match err {
+        ConnectorError::Transport(msg) => assert!(msg.contains("non-slack")),
+        other => panic!("expected Transport guard error, got {other:?}"),
+    }
+}
+
+// ── Feature-gated connectors: wrong-type guards only ────────────────────────
+//
+// PagerDuty / OpsGenie dispatch to hardcoded vendor URLs, so only the
+// synchronous wrong-destination-type guard is reachable without network.
+
+#[cfg(feature = "connector-pagerduty")]
+#[tokio::test]
+async fn pagerduty_connector_rejects_non_pagerduty_destination() {
+    use aa_api::destinations::connectors::pagerduty::PagerDutyConnector;
+
+    let dst = destination(DestinationConfig::Webhook {
+        url: "https://example.test/hook".to_string(),
+        secret_header: None,
+    });
+
+    let err = PagerDutyConnector
+        .dispatch(&dst, &DispatchRequest::default())
+        .await
+        .expect_err("wrong destination kind must be rejected");
+
+    assert!(matches!(err, ConnectorError::Transport(msg) if msg.contains("non-pagerduty")));
+}
+
+#[cfg(feature = "connector-opsgenie")]
+#[tokio::test]
+async fn opsgenie_connector_rejects_non_opsgenie_destination() {
+    use aa_api::destinations::connectors::opsgenie::OpsGenieConnector;
+
+    let dst = destination(DestinationConfig::Webhook {
+        url: "https://example.test/hook".to_string(),
+        secret_header: None,
+    });
+
+    let err = OpsGenieConnector
+        .dispatch(&dst, &DispatchRequest::default())
+        .await
+        .expect_err("wrong destination kind must be rejected");
+
+    assert!(matches!(err, ConnectorError::Transport(msg) if msg.contains("non-opsgenie")));
+}

--- a/aa-cli/src/commands/topology/render/table.rs
+++ b/aa-cli/src/commands/topology/render/table.rs
@@ -157,3 +157,29 @@ pub fn render_stats_table(stats: &TopologyStats) {
         println!("{htable}");
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_color_maps_known_statuses() {
+        assert_eq!(status_color("active"), Color::Green);
+        assert_eq!(status_color("deregistered"), Color::Red);
+        // Matching is case-insensitive.
+        assert_eq!(status_color("ACTIVE"), Color::Green);
+    }
+
+    #[test]
+    fn status_color_treats_any_suspended_prefix_as_yellow() {
+        assert_eq!(status_color("suspended"), Color::Yellow);
+        // The `suspended:<reason>` form still resolves to yellow.
+        assert_eq!(status_color("suspended:manual"), Color::Yellow);
+    }
+
+    #[test]
+    fn status_color_falls_back_to_reset_for_unknown() {
+        assert_eq!(status_color("pending"), Color::Reset);
+        assert_eq!(status_color(""), Color::Reset);
+    }
+}

--- a/aa-devtool-windsurf/src/lib.rs
+++ b/aa-devtool-windsurf/src/lib.rs
@@ -356,3 +356,363 @@ impl DevToolAdapter for WindsurfCascadeAdapter {
         GovernanceLevel::L2Enforce
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use aa_core::PolicyRule;
+    use serde_json::Value;
+    use std::sync::{Mutex, MutexGuard};
+    use tempfile::TempDir;
+
+    /// A `WINDSURF_BIN` value pointing at a binary that does not exist on disk.
+    /// `detect()` and `build_launch_command()` use the env var verbatim with no
+    /// existence check, so this is enough to drive the env-hook branch.
+    const FAKE_BIN: &str = "/opt/aa-test/windsurf-fake-binary";
+
+    /// Serializes tests that mutate process-global env vars so they cannot race
+    /// when the test binary runs them in parallel.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Run `f` with `key=value` set in the environment, restoring the previous
+    /// value (or absence) afterwards. Holds [`ENV_LOCK`] for the duration.
+    fn with_env<R>(key: &str, value: &str, f: impl FnOnce() -> R) -> R {
+        let _guard: MutexGuard<'_, ()> = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let prev = std::env::var_os(key);
+        // SAFETY: ENV_LOCK serializes all env mutation in this test binary.
+        unsafe { std::env::set_var(key, value) };
+        let out = f();
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var(key, v),
+                None => std::env::remove_var(key),
+            }
+        }
+        out
+    }
+
+    fn rule(pattern: &str, decision: PolicyDecision) -> PolicyRule {
+        PolicyRule {
+            action_pattern: pattern.to_string(),
+            decision,
+        }
+    }
+
+    fn policy(rules: Vec<PolicyRule>) -> PolicyDocument {
+        PolicyDocument {
+            version: 1,
+            name: "test-policy".to_string(),
+            rules,
+            enforcement_mode: Default::default(),
+        }
+    }
+
+    /// Build an adapter rooted in a fresh temp dir, returning the dir guard so
+    /// the caller controls its lifetime, plus the admin and mcp file paths.
+    fn adapter_in_tempdir() -> (TempDir, WindsurfCascadeAdapter) {
+        let dir = TempDir::new().expect("tempdir");
+        let admin = dir.path().join("admin_settings.json");
+        let mcp = dir.path().join("mcp_settings.json");
+        let adapter = WindsurfCascadeAdapter::with_paths(admin, mcp);
+        (dir, adapter)
+    }
+
+    #[test]
+    fn default_paths_live_under_codeium_windsurf() {
+        // The default paths are derived from $HOME; assert the stable suffix
+        // rather than the absolute prefix so the test is host-independent.
+        assert!(default_admin_settings_path().ends_with(".codeium/windsurf/admin_settings.json"));
+        assert!(default_mcp_config_path().ends_with(".codeium/windsurf/mcp_settings.json"));
+    }
+
+    #[test]
+    fn new_and_default_use_the_default_paths() {
+        let a = WindsurfCascadeAdapter::new();
+        assert_eq!(a.admin_settings_path(), default_admin_settings_path());
+        assert_eq!(a.mcp_config_path(), default_mcp_config_path());
+        let d = WindsurfCascadeAdapter::default();
+        assert_eq!(d.admin_settings_path(), default_admin_settings_path());
+    }
+
+    #[test]
+    fn governance_level_is_l2_enforce() {
+        assert_eq!(
+            WindsurfCascadeAdapter::new().governance_level(),
+            GovernanceLevel::L2Enforce
+        );
+    }
+
+    #[test]
+    fn detect_via_env_var_reports_l2_enforce_with_mcp_support() {
+        with_env(WINDSURF_BIN_ENV, FAKE_BIN, || {
+            let info = WindsurfCascadeAdapter::new()
+                .detect()
+                .expect("env hook should yield DevToolInfo");
+            assert_eq!(info.kind, DevToolKind::WindsurfCascade);
+            assert_eq!(info.install_path, PathBuf::from(FAKE_BIN));
+            assert_eq!(info.governance_level, GovernanceLevel::L2Enforce);
+            assert!(info.supports_mcp);
+            assert!(info.supports_managed_settings);
+            // The fake binary cannot be executed, so version probing yields None.
+            assert!(info.version.is_none());
+        });
+    }
+
+    #[tokio::test]
+    async fn generate_managed_settings_disables_denied_mcp_servers() {
+        let adapter = WindsurfCascadeAdapter::new();
+        let doc = policy(vec![
+            rule("mcp_tool:filesystem", PolicyDecision::Deny),
+            rule("mcp_tool:github:deny", PolicyDecision::Deny),
+            rule("mcp_tool:allowed-server", PolicyDecision::Allow),
+        ]);
+
+        let json = adapter.generate_managed_settings(&doc).await.unwrap();
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        let disabled = parsed["mcp"]["disabled_servers"].as_array().unwrap();
+
+        let names: Vec<&str> = disabled.iter().map(|v| v.as_str().unwrap()).collect();
+        assert!(names.contains(&"filesystem"));
+        // The defensive ":deny" suffix is stripped from the server name.
+        assert!(names.contains(&"github"));
+        // An Allow rule never disables a server.
+        assert!(!names.contains(&"allowed-server"));
+    }
+
+    #[tokio::test]
+    async fn generate_managed_settings_terminal_allowlist_built_from_allow_rules() {
+        let adapter = WindsurfCascadeAdapter::new();
+        let doc = policy(vec![
+            rule("terminal_exec:git", PolicyDecision::Allow),
+            rule("terminal_exec:ls", PolicyDecision::Allow),
+        ]);
+
+        let json = adapter.generate_managed_settings(&doc).await.unwrap();
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        let allow = parsed["terminal"]["command_allowlist"].as_array().unwrap();
+        let cmds: Vec<&str> = allow.iter().map(|v| v.as_str().unwrap()).collect();
+        assert_eq!(cmds, vec!["git", "ls"]);
+    }
+
+    #[tokio::test]
+    async fn generate_managed_settings_terminal_deny_all_clears_allowlist() {
+        let adapter = WindsurfCascadeAdapter::new();
+        // A blanket `terminal_exec` deny must override any per-command allows:
+        // the resulting allowlist is empty (deny-all wins).
+        let doc = policy(vec![
+            rule("terminal_exec:git", PolicyDecision::Allow),
+            rule("terminal_exec", PolicyDecision::Deny),
+        ]);
+
+        let json = adapter.generate_managed_settings(&doc).await.unwrap();
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        let allow = parsed["terminal"]["command_allowlist"].as_array().unwrap();
+        assert!(allow.is_empty(), "deny-all must clear the allowlist");
+    }
+
+    #[test]
+    fn generate_managed_settings_registry_url_from_env_when_team_sync_allowed() {
+        let adapter = WindsurfCascadeAdapter::new();
+        let doc = policy(vec![rule("team_policy_sync", PolicyDecision::Allow)]);
+
+        // The env var is read synchronously inside generate_managed_settings, so
+        // drive the future to completion on a current-thread runtime while the
+        // guard holds AA_GATEWAY_URL set.
+        let json = with_env("AA_GATEWAY_URL", "https://gw.example.com", || {
+            let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
+            rt.block_on(adapter.generate_managed_settings(&doc))
+        })
+        .unwrap();
+
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            parsed["policy"]["registry_url"].as_str(),
+            Some("https://gw.example.com")
+        );
+    }
+
+    #[tokio::test]
+    async fn generate_managed_settings_omits_policy_block_when_empty() {
+        let adapter = WindsurfCascadeAdapter::new();
+        let doc = policy(vec![]);
+
+        let json = adapter.generate_managed_settings(&doc).await.unwrap();
+        let parsed: Value = serde_json::from_str(&json).unwrap();
+        // `WindsurfPolicyAdmin::is_empty()` skips serialization entirely.
+        assert!(parsed.get("policy").is_none(), "empty policy block must be omitted");
+    }
+
+    #[tokio::test]
+    async fn apply_settings_creates_parent_dirs_and_writes_file() {
+        let dir = TempDir::new().unwrap();
+        // Nest the admin path two levels deep to exercise create_dir_all.
+        let admin = dir.path().join("nested/deeper/admin_settings.json");
+        let adapter = WindsurfCascadeAdapter::with_paths(&admin, dir.path().join("mcp_settings.json"));
+
+        adapter.apply_settings("{\"hello\":\"world\"}").await.unwrap();
+
+        let written = std::fs::read_to_string(&admin).unwrap();
+        assert_eq!(written, "{\"hello\":\"world\"}");
+    }
+
+    #[tokio::test]
+    async fn generate_then_apply_round_trips_through_disk() {
+        let (_dir, adapter) = adapter_in_tempdir();
+        let doc = policy(vec![rule("mcp_tool:filesystem", PolicyDecision::Deny)]);
+
+        let json = adapter.generate_managed_settings(&doc).await.unwrap();
+        adapter.apply_settings(&json).await.unwrap();
+
+        let back = std::fs::read_to_string(adapter.admin_settings_path()).unwrap();
+        let parsed: Value = serde_json::from_str(&back).unwrap();
+        assert_eq!(parsed["mcp"]["disabled_servers"][0].as_str(), Some("filesystem"));
+    }
+
+    #[tokio::test]
+    async fn list_mcp_servers_parses_configured_entries() {
+        let (_dir, adapter) = adapter_in_tempdir();
+        std::fs::write(
+            adapter.mcp_config_path(),
+            r#"{ "mcpServers": {
+                "filesystem": { "command": "mcp-fs", "args": ["--root", "/srv"] },
+                "github": { "command": "mcp-gh" }
+            } }"#,
+        )
+        .unwrap();
+
+        let mut servers = adapter.list_mcp_servers().await.unwrap();
+        // BTreeMap iteration is deterministic (sorted by name).
+        servers.sort_by(|a, b| a.name.cmp(&b.name));
+        assert_eq!(servers.len(), 2);
+        assert_eq!(servers[0].name, "filesystem");
+        assert_eq!(servers[0].command, "mcp-fs");
+        assert_eq!(servers[0].args, vec!["--root", "/srv"]);
+        assert_eq!(servers[1].name, "github");
+        assert!(servers[1].args.is_empty(), "missing args default to empty");
+    }
+
+    #[tokio::test]
+    async fn list_mcp_servers_errors_when_config_missing() {
+        let (_dir, adapter) = adapter_in_tempdir();
+        // No file written: read_to_string fails and surfaces as an error.
+        let err = adapter.list_mcp_servers().await.unwrap_err();
+        assert!(matches!(err, AdapterError::Io(_)));
+    }
+
+    #[tokio::test]
+    async fn list_mcp_servers_errors_on_malformed_json() {
+        let (_dir, adapter) = adapter_in_tempdir();
+        std::fs::write(adapter.mcp_config_path(), "{ not valid json").unwrap();
+
+        let err = adapter.list_mcp_servers().await.unwrap_err();
+        assert!(matches!(err, AdapterError::McpConfigFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn apply_mcp_governance_disables_denied_and_non_allowed_configured() {
+        let (_dir, adapter) = adapter_in_tempdir();
+        // Three configured servers; only `keep` is allowed.
+        std::fs::write(
+            adapter.mcp_config_path(),
+            r#"{ "mcpServers": {
+                "keep": { "command": "a" },
+                "drop": { "command": "b" },
+                "also-drop": { "command": "c" }
+            } }"#,
+        )
+        .unwrap();
+
+        adapter
+            .apply_mcp_governance(&["keep".to_string()], &["explicit-deny".to_string()])
+            .await
+            .unwrap();
+
+        let admin: Value =
+            serde_json::from_str(&std::fs::read_to_string(adapter.admin_settings_path()).unwrap()).unwrap();
+        let disabled: Vec<String> = admin["mcp"]["disabled_servers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+
+        // Explicit deny always present.
+        assert!(disabled.contains(&"explicit-deny".to_string()));
+        // Configured-but-not-allowed servers are disabled.
+        assert!(disabled.contains(&"drop".to_string()));
+        assert!(disabled.contains(&"also-drop".to_string()));
+        // The allowed server is never disabled.
+        assert!(!disabled.contains(&"keep".to_string()));
+    }
+
+    #[tokio::test]
+    async fn apply_mcp_governance_works_without_existing_admin_or_config() {
+        let (_dir, adapter) = adapter_in_tempdir();
+        // Neither admin nor mcp config exists: only the explicit denies land.
+        adapter
+            .apply_mcp_governance(&[], &["only-deny".to_string()])
+            .await
+            .unwrap();
+
+        let admin: Value =
+            serde_json::from_str(&std::fs::read_to_string(adapter.admin_settings_path()).unwrap()).unwrap();
+        let disabled: Vec<&str> = admin["mcp"]["disabled_servers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert_eq!(disabled, vec!["only-deny"]);
+    }
+
+    #[test]
+    fn build_launch_command_threads_governance_env() {
+        with_env(WINDSURF_BIN_ENV, FAKE_BIN, || {
+            let adapter = WindsurfCascadeAdapter::new();
+            let cmd = adapter
+                .build_launch_command(
+                    &["--flag".to_string()],
+                    "agent-7",
+                    Some("team-x"),
+                    Some("http://127.0.0.1:8888"),
+                )
+                .expect("env hook supplies the binary path");
+
+            assert_eq!(cmd.get_program(), std::ffi::OsStr::new(FAKE_BIN));
+            let args: Vec<_> = cmd.get_args().collect();
+            assert_eq!(args, vec![std::ffi::OsStr::new("--flag")]);
+
+            let envs: std::collections::HashMap<_, _> = cmd
+                .get_envs()
+                .filter_map(|(k, v)| v.map(|v| (k.to_owned(), v.to_owned())))
+                .collect();
+            assert_eq!(
+                envs.get(std::ffi::OsStr::new("AA_AGENT_ID")).unwrap(),
+                std::ffi::OsStr::new("agent-7")
+            );
+            assert_eq!(
+                envs.get(std::ffi::OsStr::new("AA_TEAM_ID")).unwrap(),
+                std::ffi::OsStr::new("team-x")
+            );
+            assert_eq!(
+                envs.get(std::ffi::OsStr::new("HTTPS_PROXY")).unwrap(),
+                std::ffi::OsStr::new("http://127.0.0.1:8888")
+            );
+        });
+    }
+
+    #[test]
+    fn build_launch_command_omits_optional_env_when_absent() {
+        with_env(WINDSURF_BIN_ENV, FAKE_BIN, || {
+            let adapter = WindsurfCascadeAdapter::new();
+            let cmd = adapter
+                .build_launch_command(&[], "solo-agent", None, None)
+                .expect("env hook supplies the binary path");
+
+            let env_keys: Vec<_> = cmd.get_envs().map(|(k, _)| k.to_owned()).collect();
+            assert!(env_keys.contains(&std::ffi::OsString::from("AA_AGENT_ID")));
+            assert!(!env_keys.contains(&std::ffi::OsString::from("AA_TEAM_ID")));
+            assert!(!env_keys.contains(&std::ffi::OsString::from("HTTPS_PROXY")));
+        });
+    }
+}

--- a/aa-proxy/src/audit_jsonl.rs
+++ b/aa-proxy/src/audit_jsonl.rs
@@ -178,4 +178,153 @@ mod tests {
             "single entry must produce exactly one trailing newline: {on_disk}",
         );
     }
+
+    /// Build a minimal clean entry (no findings, no redaction) for tests that
+    /// care about framing rather than redaction.
+    fn clean_entry(host: &str, decision: ProxyAuditDecision) -> ProxyAuditEntry {
+        ProxyAuditEntry {
+            ts_ms: 1_700_000_000_000,
+            agent_id: None,
+            host: host.into(),
+            method: "GET".into(),
+            path: "/".into(),
+            decision,
+            credential_findings: vec![],
+            redacted_body: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn writer_appends_one_jsonl_line_per_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("audit.jsonl");
+        let (tx, rx) = mpsc::channel(8);
+        let writer = JsonlWriter::new(&path, rx).await.unwrap();
+        let handle = tokio::spawn(writer.run());
+
+        for host in ["a.example", "b.example", "c.example"] {
+            tx.send(clean_entry(host, ProxyAuditDecision::Forwarded)).await.unwrap();
+        }
+        drop(tx);
+        handle.await.unwrap();
+
+        let on_disk = tokio::fs::read_to_string(&path).await.unwrap();
+        let lines: Vec<&str> = on_disk.lines().collect();
+        assert_eq!(lines.len(), 3, "three entries → three lines");
+        // Every line is independently valid JSON.
+        for line in &lines {
+            serde_json::from_str::<ProxyAuditEntry>(line).expect("each line is a valid entry");
+        }
+        assert!(on_disk.contains("a.example") && on_disk.contains("c.example"));
+    }
+
+    #[tokio::test]
+    async fn writer_appends_to_existing_file_across_two_runs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("audit.jsonl");
+
+        // First run writes one line, then the writer is dropped (file closed).
+        {
+            let (tx, rx) = mpsc::channel(4);
+            let writer = JsonlWriter::new(&path, rx).await.unwrap();
+            let handle = tokio::spawn(writer.run());
+            tx.send(clean_entry("first.example", ProxyAuditDecision::Blocked))
+                .await
+                .unwrap();
+            drop(tx);
+            handle.await.unwrap();
+        }
+
+        // Second run opens the same path in append mode; the first line survives.
+        {
+            let (tx, rx) = mpsc::channel(4);
+            let writer = JsonlWriter::new(&path, rx).await.unwrap();
+            let handle = tokio::spawn(writer.run());
+            tx.send(clean_entry("second.example", ProxyAuditDecision::Forwarded))
+                .await
+                .unwrap();
+            drop(tx);
+            handle.await.unwrap();
+        }
+
+        let on_disk = tokio::fs::read_to_string(&path).await.unwrap();
+        assert_eq!(on_disk.lines().count(), 2, "append mode preserves prior content");
+        assert!(on_disk.contains("first.example"));
+        assert!(on_disk.contains("second.example"));
+    }
+
+    #[tokio::test]
+    async fn writer_with_no_entries_produces_empty_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("audit.jsonl");
+        let (tx, rx) = mpsc::channel(1);
+        let writer = JsonlWriter::new(&path, rx).await.unwrap();
+        let handle = tokio::spawn(writer.run());
+        // Drop the sender immediately: the loop exits without writing anything.
+        drop(tx);
+        handle.await.unwrap();
+
+        let on_disk = tokio::fs::read_to_string(&path).await.unwrap();
+        assert!(on_disk.is_empty(), "no entries → empty file");
+    }
+
+    #[tokio::test]
+    async fn writer_exposes_its_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("audit.jsonl");
+        let (_tx, rx) = mpsc::channel(1);
+        let writer = JsonlWriter::new(&path, rx).await.unwrap();
+        assert_eq!(writer.path(), path.as_path());
+    }
+
+    #[tokio::test]
+    async fn writer_new_errors_when_parent_dir_missing() {
+        // `new` documents that parent dirs must already exist; opening under a
+        // non-existent directory therefore surfaces an I/O error.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("does/not/exist/audit.jsonl");
+        let (_tx, rx) = mpsc::channel(1);
+        // `JsonlWriter` is not `Debug`, so match the Result rather than using
+        // `expect_err`, which requires `T: Debug`.
+        match JsonlWriter::new(&path, rx).await {
+            Ok(_) => panic!("opening under a missing parent dir must fail"),
+            Err(e) => assert_eq!(e.kind(), io::ErrorKind::NotFound),
+        }
+    }
+
+    #[test]
+    fn decision_serializes_to_snake_case() {
+        let cases = [
+            (ProxyAuditDecision::Forwarded, "\"forwarded\""),
+            (ProxyAuditDecision::ForwardedRedacted, "\"forwarded_redacted\""),
+            (ProxyAuditDecision::Blocked, "\"blocked\""),
+        ];
+        for (decision, expected) in cases {
+            assert_eq!(serde_json::to_string(&decision).unwrap(), expected);
+            // Round-trips back to the same variant.
+            let back: ProxyAuditDecision = serde_json::from_str(expected).unwrap();
+            assert_eq!(back, decision);
+        }
+    }
+
+    #[test]
+    fn entry_round_trips_through_json_preserving_fields() {
+        let entry = ProxyAuditEntry {
+            ts_ms: 42,
+            agent_id: Some("agent-x".into()),
+            host: "api.example".into(),
+            method: "POST".into(),
+            path: "/v1/do".into(),
+            decision: ProxyAuditDecision::ForwardedRedacted,
+            credential_findings: vec![],
+            redacted_body: Some("clean body".into()),
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        let back: ProxyAuditEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.ts_ms, 42);
+        assert_eq!(back.agent_id.as_deref(), Some("agent-x"));
+        assert_eq!(back.host, "api.example");
+        assert_eq!(back.decision, ProxyAuditDecision::ForwardedRedacted);
+        assert_eq!(back.redacted_body.as_deref(), Some("clean body"));
+    }
 }


### PR DESCRIPTION
## Description

Test-only PR raising line/branch coverage in the core Rust monorepo (AAASM-3175). Targets the highest-value, lowest-covered production code that had **no or thin tests**: the notification connectors, the proxy audit JSONL writer, the Windsurf dev-tool adapter, and the topology table renderer's status mapping. No production code changed — these are pure additive tests.

## Type of Change

- [x] ✅ Tests

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3175

## Coverage (before → after)

Measured with `cargo llvm-cov nextest` on the four touched crates (`aa-api`, `aa-proxy`, `aa-cli`, `aa-devtool-windsurf`) on `remote/master` vs this branch — identical command, directly comparable.

| File | Line cov before | Line cov after |
|---|---|---|
| `aa-api/.../connectors/mod.rs` | 51.85% | **100.00%** |
| `aa-api/.../connectors/webhook.rs` | 66.67% | **100.00%** |
| `aa-api/.../connectors/slack.rs` | 0.00% | **66.67%** |
| `aa-proxy/src/audit_jsonl.rs` | 92.00% | **98.01%** |
| `aa-devtool-windsurf/src/lib.rs` | 80.83% | **94.85%** |
| `aa-cli/.../topology/render/table.rs` | 84.43% | **88.15%** |

Four-crate subset total line coverage: **77.13% → 77.63%** (production lines; the Sonar/codecov denominators exclude `**/tests/**`). SonarCloud overall baseline was 79.5% (line 81.7%); this PR adds ~115 net covered production lines concentrated in the previously-untested modules above. The full 90% workspace target is **not** reached by this PR alone — it is a meaningful step against the lowest-covered, highest-value paths, not a coverage-padding sweep.

## What is covered

- **aa-api notification connectors** (`tests/connectors.rs`, 11 + 2 feature-gated tests via `httpmock`): webhook/Slack 2xx → `DispatchOutcome`, non-2xx → `ConnectorError::Http`, secret-header injection, payload + channel-override shaping, oversized-body truncation, unreachable-host transport error, and the wrong-destination-type guards (including the feature-gated PagerDuty/OpsGenie guards).
- **aa-proxy `JsonlWriter`** (`audit_jsonl.rs`): multi-entry append, cross-run append persistence, empty-input, `path()` accessor, missing-parent-dir error, decision snake_case serde, and `ProxyAuditEntry` JSON round-trip.
- **aa-devtool-windsurf adapter** (`lib.rs`): env-hook `detect()`, managed-settings generation (MCP deny, terminal allow/deny-all, registry URL, empty-policy omission), `apply_settings` dir creation, MCP server listing + error paths, MCP governance disable logic, launch-command env wiring.
- **aa-cli topology `status_color`**: active/deregistered colour mapping, case-insensitivity, suspended-prefix branch, unknown→reset fallback.

## Deliberately left uncovered (with reason)

- The print-only topology renderers (`render_overview_table`, `render_*`, `json.rs`, `tree.rs`) — they only `println!` with no observable return; testing them would be coverage-padding with no real assertion.
- PagerDuty/OpsGenie happy-path dispatch — they hardcode vendor API URLs (`events.pagerduty.com`, `api.opsgenie.com`) that cannot be redirected to a mock server; only their deterministic wrong-type guards are tested.

## Testing

- [x] Unit tests added
- [x] Integration tests added (`aa-api/tests/connectors.rs`)

How to verify:

```
cargo nextest run -p aa-devtool-windsurf -p aa-proxy -p aa-cli -p aa-api
cargo nextest run -p aa-api --test connectors --features connector-pagerduty,connector-opsgenie
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --all -- --check
```

All new tests pass. `cargo fmt --all` clean; `cargo clippy --all-targets --all-features` clean (enforced by the pre-commit hook on every commit). The one pre-existing failure observed locally (`http_policy_mutation_invalidates_subscribed_l1_within_100ms`) is a timing-sensitive test unrelated to this PR — it is on the CI coverage exclusion list and only trips under CPU contention.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Commits are small and follow the Gitmoji convention

Refs AAASM-3175

🤖 Generated with [Claude Code](https://claude.com/claude-code)
