### PR TITLE
[AAASM-3197] 🐛 (ci): Stop master SonarCloud scan from wiping Rust/TS coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1196,6 +1196,26 @@ jobs:
         with:
           name: dashboard-coverage-lcov
           path: dashboard/coverage
+      # AAASM-3197: symmetric backfill for the TypeScript side. When
+      # `dashboard-test` was skipped or failed on a push (Rust-only change),
+      # pull `dashboard/coverage/lcov.info` from the last successful master run
+      # so the full-snapshot scan does not wipe dashboard coverage to 0.
+      - name: Backfill TypeScript coverage (LCOV) from last successful master run
+        if: ${{ github.event_name == 'push' && needs.dashboard-test.result != 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          run_id="$(gh run list --workflow ci.yml --branch master \
+            --status success --limit 1 --json databaseId \
+            --jq '.[0].databaseId')"
+          if [ -z "$run_id" ]; then
+            echo "::warning::No prior successful master CI run found; scanning without backfilled TypeScript LCOV."
+            exit 0
+          fi
+          echo "Backfilling dashboard-coverage-lcov from master run ${run_id}."
+          gh run download "$run_id" --name dashboard-coverage-lcov --dir dashboard/coverage \
+            || echo "::warning::dashboard-coverage-lcov artifact unavailable on run ${run_id} (expired/absent); scanning without it."
       # ---- Scan -------------------------------------------------------------
       - name: Cache SonarCloud analysis state
         uses: actions/cache@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1134,6 +1134,13 @@ jobs:
   # — either coverage producer may be skipped (path-gated), so the Rust steps run
   # only when `coverage` succeeded and the TS download only when `dashboard-test`
   # succeeded. Runs in the pull_request context so PR decoration works (AAASM-2542).
+  #
+  # AAASM-3197: SonarCloud treats every master-branch analysis as a FULL snapshot
+  # that REPLACES the project's coverage. A push that touches only one side (e.g.
+  # dashboard-only → `coverage` skipped) would otherwise publish a partial report
+  # that wipes the other side's coverage to 0. On pushes, whichever producer was
+  # skipped/failed is backfilled from the last successful master run so the
+  # snapshot is always complete. PR analysis (new-code-only) is left unchanged.
   sonar:
     name: SonarCloud analysis
     needs: [changes, coverage, dashboard-test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1168,6 +1168,27 @@ jobs:
         with:
           name: rust-coverage-lcov
           path: .
+      # AAASM-3197: master-branch analysis is a FULL snapshot — a partial report
+      # wipes the other side's coverage to 0. When the `coverage` job was skipped
+      # or failed on a push (non-Rust change), backfill `lcov.info` from the most
+      # recent successful master CI run so the snapshot stays complete. PR runs are
+      # new-code-decorated and intentionally left untouched.
+      - name: Backfill Rust coverage (LCOV) from last successful master run
+        if: ${{ github.event_name == 'push' && needs.coverage.result != 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          run_id="$(gh run list --workflow ci.yml --branch master \
+            --status success --limit 1 --json databaseId \
+            --jq '.[0].databaseId')"
+          if [ -z "$run_id" ]; then
+            echo "::warning::No prior successful master CI run found; scanning without backfilled Rust LCOV."
+            exit 0
+          fi
+          echo "Backfilling rust-coverage-lcov from master run ${run_id}."
+          gh run download "$run_id" --name rust-coverage-lcov --dir . \
+            || echo "::warning::rust-coverage-lcov artifact unavailable on run ${run_id} (expired/absent); scanning without it."
       # ---- TypeScript coverage (only when the dashboard side ran) ------------
       - name: Download TypeScript coverage (LCOV) from the Dashboard test job
         if: needs.dashboard-test.result == 'success'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1139,6 +1139,12 @@ jobs:
     needs: [changes, coverage, dashboard-test]
     if: ${{ !cancelled() && needs.changes.result == 'success' && github.actor != 'dependabot[bot]' && (github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-coverage')) }}
     runs-on: ubuntu-latest
+    # AAASM-3197: actions:read lets `gh run download` pull the last successful
+    # master LCOV when a coverage producer was skipped this run (see fallback
+    # steps below). contents:read mirrors the workflow default for checkout.
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Description

The `sonar` job feeds SonarCloud the Rust LCOV only when the `coverage` job
succeeded and the TypeScript LCOV only when `dashboard-test` succeeded. Both
producers are path-gated, so a push that touches only one side skips the other.
SonarCloud treats every **master-branch analysis as a FULL snapshot that
replaces the project's coverage**, so a one-sided push publishes a partial
report and wipes the untouched side to 0% (this is why the project currently
shows 0 Rust coverage — a non-Rust push last scanned master).

This PR adds a **push-only fallback**: when a coverage producer was skipped or
failed on a `push`, the missing LCOV is backfilled from the **last successful
master CI run** before the scan, so master snapshots are always complete.
PR analysis (new-code-only decoration) is intentionally left unchanged.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [x] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-3197
- Related GitHub issues: —

## Change Scope

`.github/workflows/ci.yml`, `sonar` job only:

1. **Job-level `permissions`** — `contents: read` + `actions: read` (the latter
   lets `gh run download` read prior runs' artifacts).
2. **Backfill Rust coverage step** — runs when
   `github.event_name == 'push' && needs.coverage.result != 'success'`; resolves
   the latest successful master `ci.yml` run via `gh run list` and downloads the
   `rust-coverage-lcov` artifact into `.` → `lcov.info`
   (matches `sonar.lcov.reportPaths=lcov.info`).
3. **Backfill TypeScript coverage step** — symmetric; runs when
   `dashboard-test.result != 'success'` on a push; downloads
   `dashboard-coverage-lcov` into `dashboard/coverage/` → `dashboard/coverage/lcov.info`
   (matches `sonar.javascript.lcov.reportPaths=dashboard/coverage/lcov.info`).

The existing "download from THIS run when the job succeeded" steps remain the
primary path; the fallback only fills the missing side. No PR-path behavior
changed. No new third-party action added — uses the runner's `gh` CLI with the
built-in `GITHUB_TOKEN`.

## Testing

- [ ] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed (static validation — see below)
- [x] No tests required (explain why)

Validation performed:
- `actionlint .github/workflows/ci.yml` → clean (exit 0).
- `python3 -c "yaml.safe_load(...)"` → YAML parses.
- Artifact name/path cross-check against the upload steps and
  `sonar-project.properties`: Rust producer uploads `lcov.info` → fallback
  `--dir .` yields `./lcov.info`; dashboard producer uploads
  `dashboard/coverage/lcov.info` → fallback `--dir dashboard/coverage` yields
  `dashboard/coverage/lcov.info`. Both mirror the primary download targets
  exactly.
- "No prior successful artifact yet" handled gracefully: empty run id →
  `::warning::` + `exit 0`; missing artifact on the resolved run →
  `|| echo ::warning::`, so the job never fails on the fallback.

> The real effect (master snapshot stops wiping coverage) can only be confirmed
> once this lands and a one-sided push scans master. Cannot run the real
> SonarCloud scan locally, and org Actions may be billing-blocked.

## Rollout Notes

No config/secret changes required — `GITHUB_TOKEN` and `gh` are already on the
runner; `actions: read` is granted at the job level. First post-merge run with no
prior successful master artifact logs a warning and scans without the backfill
(no regression vs. today). Coverage self-heals on the next full (Rust+dashboard)
master push.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`) — N/A, CI-only
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (job comment updated)
- [ ] All CI checks passing (pending CI run)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
