### PR TITLE
[AAASM-3227] 🐛 (test): Make combined-pipeline throughput test robust under llvm-cov

### DIFF
--- a/aa-integration-tests/tests/e2e_combined_pipeline_throughput.rs
+++ b/aa-integration-tests/tests/e2e_combined_pipeline_throughput.rs
@@ -253,11 +253,17 @@ async fn combined_pipeline_sustains_target_throughput() {
     );
 
     // ---- Wait for every event to land, then measure the end-to-end rate ----
-    // The deadline scales with the volume so a larger run is not cut short: at
-    // worst the consumer drains at a fraction of the target, so allow ample
-    // headroom beyond the AC window.
+    // This is a *safety timeout* for the drain, not a correctness bound: the
+    // all-land assertion below still requires every event to persist. It only
+    // exists so a hung consumer fails fast instead of blocking forever, so it
+    // must be generous. This test runs only in the Coverage job under llvm-cov,
+    // whose 2-5x instrumentation overhead drops the end-to-end drain to ~7k/s
+    // (vs the uninstrumented target). So scale the deadline off a low ~4k/s
+    // floor (not the 10k/s the consumer hits uninstrumented) plus a fixed
+    // headroom buffer; at 3M events this yields ~870s, well above the observed
+    // ~407s instrumented drain. Widening this does NOT weaken correctness.
     let pool = sqlx::PgPool::connect(&pg_url).await.expect("assert pool");
-    let drain_deadline = Duration::from_secs((events / 10_000).max(TARGET_SECONDS) + 60);
+    let drain_deadline = Duration::from_secs((events / 4_000).max(TARGET_SECONDS) + 120);
     let landed = wait_for_count(&pool, events as i64, drain_deadline).await;
     let end_to_end_elapsed = run_start.elapsed();
 


### PR DESCRIPTION
## Description

`combined_pipeline_sustains_target_throughput` (AAASM-2607) in
`aa-integration-tests/tests/e2e_combined_pipeline_throughput.rs` was flaky in the
`Coverage` CI job. The "all events landed" wait used a fixed safety timeout:

```rust
let drain_deadline = Duration::from_secs((events / 10_000).max(TARGET_SECONDS) + 60);
```

With `events = TARGET_RATE(50_000) * TARGET_SECONDS(60) = 3_000_000`, this gives
`(300).max(60) + 60 = 360s`. The deadline implicitly assumes the consumer drains
at >=10k events/s. This test is `#![cfg(feature = "audit-consumer")]` and runs
**only** in the `Coverage` job (the sole `--all-features` job) under
`cargo llvm-cov`, whose 2-5x instrumentation overhead drops the end-to-end drain
to ~7,358/s. The full 3M drain therefore needs ~407s, so `wait_for_count` timed
out at 360s with ~2.8M landed and the no-loss assertion failed spuriously.

**No events were lost** — they simply had not persisted within a too-tight
deadline (verified: prior Coverage runs passed the same test, no channel
overflow, the change that surfaced this only touched the `sonar` job).

The fix widens the safety timeout to assume a low ~4k/s drain floor plus a 120s
buffer (`(events / 4_000).max(TARGET_SECONDS) + 120` => ~870s at 3M), comfortably
above the observed instrumented drain. The all-land assertion, the
bounded-channel-depth assertion, the drain-to-0 assertion, and the
`enforce_rate()`-gated throughput gate are all unchanged — only the timeout is
widened, so correctness is not weakened.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

Test-only change; no public API or runtime behaviour is affected.

## Related Issues

- Related Jira ticket: AAASM-3227 (Closes)
- Relates to: AAASM-2607 (test origin), AAASM-3197 (prior Coverage-job change)
- Related GitHub issues: n/a

## Testing

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

Local validation:
- `cargo check -p aa-integration-tests --all-features --tests` — compiles clean
- `cargo fmt -p aa-integration-tests -- --check` — clean
- `cargo clippy -p aa-integration-tests --all-features --tests -- -D warnings` — clean
- lefthook pre-commit (fmt + clippy) passed on commit

Deadline arithmetic review: old `(3_000_000 / 10_000).max(60) + 60 = 360s` < observed
~407s instrumented drain (flake); new `(3_000_000 / 4_000).max(60) + 120 = 870s` >> ~407s.

The instrumented flake cannot be reproduced locally (needs Docker + NATS + Postgres +
llvm-cov and ~7 min for 3M events on a CI runner). End-to-end no-flake confirmation
will only come from a real `master` Coverage run.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (added WHY comment explaining the deadline)
- [ ] All CI checks passing (Coverage job confirms post-merge; org Actions may be billing-throttled)
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)