### PR TITLE
[AAASM-3346] 🐛 (agent-assembly): Reduce SonarCloud bugs + code smells (wave 1)

### DIFF
--- a/dashboard/src/components/AppShell.tsx
+++ b/dashboard/src/components/AppShell.tsx
@@ -63,6 +63,9 @@ export function AppShell() {
         className={`appshell__nav${navOpen ? ' appshell__nav--open' : ''}`}
         data-testid="appshell-nav"
         onClick={() => setNavOpen(false)}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') setNavOpen(false)
+        }}
       >
         <div className="appshell__nav-brand">Agent Assembly</div>
         {ROUTE_GROUPS.map((group) => (

--- a/dashboard/src/components/ConfirmDialog.tsx
+++ b/dashboard/src/components/ConfirmDialog.tsx
@@ -53,8 +53,15 @@ export function ConfirmDialog({
     <div
       className="confirm-dialog__backdrop"
       data-testid="confirm-dialog-backdrop"
+      role="presentation"
       onClick={(e) => {
         if (e.target === e.currentTarget) onCancel()
+      }}
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return
+        if (e.key !== 'Enter' && e.key !== ' ') return
+        e.preventDefault()
+        onCancel()
       }}
     >
       <div className="confirm-dialog" role="alertdialog" aria-modal="true" data-testid="confirm-dialog">

--- a/dashboard/src/components/OverlayHost.tsx
+++ b/dashboard/src/components/OverlayHost.tsx
@@ -53,11 +53,24 @@ export function OverlayHost({ name, onRequestClose, children }: OverlayHostProps
     dismiss()
   }
 
+  // Dismissal is driven by Escape via the document-level listener above; the
+  // backdrop key handler exists to satisfy the click/keyboard parity rule and
+  // mirrors the backdrop click for keyboard users who focus the backdrop.
+  const handleBackdropKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.target !== e.currentTarget) return
+    if (e.key !== 'Enter' && e.key !== ' ') return
+    e.preventDefault()
+    const dismiss = onRequestClose ?? closeOverlay
+    dismiss()
+  }
+
   return createPortal(
     <div
       className="overlay-backdrop"
       data-testid={`overlay-${name}`}
+      role="presentation"
       onClick={handleBackdropClick}
+      onKeyDown={handleBackdropKeyDown}
     >
       <div className="overlay-container" role="dialog" aria-modal="true">
         {children}

--- a/dashboard/src/components/ToastProvider.tsx
+++ b/dashboard/src/components/ToastProvider.tsx
@@ -10,6 +10,12 @@ function removeToast(list: ToastMessage[], id: number): ToastMessage[] {
   return list.filter((t) => t.id !== id)
 }
 
+const TOAST_BACKGROUND: Record<ToastVariant, string> = {
+  success: 'var(--status-success-solid)',
+  error: 'var(--status-danger-solid)',
+  info: 'var(--status-info-solid)',
+}
+
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<ToastMessage[]>([])
 
@@ -42,12 +48,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
             style={{
               padding: '0.75rem 1rem',
               borderRadius: '0.375rem',
-              background:
-                t.variant === 'success'
-                  ? 'var(--status-success-solid)'
-                  : t.variant === 'error'
-                    ? 'var(--status-danger-solid)'
-                    : 'var(--status-info-solid)',
+              background: TOAST_BACKGROUND[t.variant],
               color: 'var(--toast-text)',
               fontSize: '0.875rem',
               maxWidth: '24rem',

--- a/dashboard/src/components/fleet/StatusChip.stories.tsx
+++ b/dashboard/src/components/fleet/StatusChip.stories.tsx
@@ -11,4 +11,4 @@ type Story = StoryObj<typeof StatusChip>
 
 export const Active: Story = { args: { status: 'active' } }
 export const Suspended: Story = { args: { status: 'suspended' } }
-export const Error: Story = { args: { status: 'error' } }
+export const ErrorState: Story = { name: 'Error', args: { status: 'error' } }

--- a/dashboard/src/components/trace/PayloadModal.tsx
+++ b/dashboard/src/components/trace/PayloadModal.tsx
@@ -108,7 +108,14 @@ export function PayloadModal({ event, onClose }: PayloadModalProps) {
     <div
       className="payload-modal-scrim"
       data-testid="payload-modal-scrim"
+      role="presentation"
       onClick={onClose}
+      onKeyDown={e => {
+        if (e.target !== e.currentTarget) return
+        if (e.key !== 'Enter' && e.key !== ' ') return
+        e.preventDefault()
+        onClose()
+      }}
     >
       <div
         ref={dialogRef}

--- a/dashboard/src/components/trace/TraceDrawer.tsx
+++ b/dashboard/src/components/trace/TraceDrawer.tsx
@@ -61,7 +61,14 @@ export function TraceDrawer() {
     <div
       className="trace-drawer-scrim"
       data-testid="trace-drawer-scrim"
+      role="presentation"
       onClick={close}
+      onKeyDown={e => {
+        if (e.target !== e.currentTarget) return
+        if (e.key !== 'Enter' && e.key !== ' ') return
+        e.preventDefault()
+        close()
+      }}
     >
       <div
         ref={drawerRef}

--- a/dashboard/src/features/alerts/AlertDetailDrawer.tsx
+++ b/dashboard/src/features/alerts/AlertDetailDrawer.tsx
@@ -35,6 +35,12 @@ export function AlertDetailDrawer({ open, onClose, children }: AlertDetailDrawer
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose()
       }}
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return
+        if (e.key !== 'Enter' && e.key !== ' ') return
+        e.preventDefault()
+        onClose()
+      }}
     >
       <aside
         style={{

--- a/dashboard/src/features/alerts/AlertRuleForm.tsx
+++ b/dashboard/src/features/alerts/AlertRuleForm.tsx
@@ -130,6 +130,12 @@ export function AlertRuleForm({
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose()
       }}
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return
+        if (e.key !== 'Enter' && e.key !== ' ') return
+        e.preventDefault()
+        onClose()
+      }}
     >
       <div
         style={{

--- a/dashboard/src/features/alerts/DestinationManager.tsx
+++ b/dashboard/src/features/alerts/DestinationManager.tsx
@@ -127,6 +127,12 @@ export function DestinationManager({ open, onClose }: DestinationManagerProps) {
       onClick={(e) => {
         if (e.target === e.currentTarget) onClose()
       }}
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return
+        if (e.key !== 'Enter' && e.key !== ' ') return
+        e.preventDefault()
+        onClose()
+      }}
     >
       <div
         style={{

--- a/dashboard/src/features/analytics/ActionVolumePanel.tsx
+++ b/dashboard/src/features/analytics/ActionVolumePanel.tsx
@@ -40,31 +40,23 @@ export function ActionVolumePanel() {
   const chartData = useMemo(() => transformSeries(series), [series])
   const tickFormatter = useMemo(() => makeTickFormatter(filters.range), [filters.range])
 
-  return (
-    <div className="action-volume-panel" data-testid="action-volume-panel">
-      <h2 className="action-volume-panel__title">Action Volume</h2>
-
-      {/* Per-series test anchors — not visible in UI */}
-      {series.map(s => (
-        <span
-          key={s.key}
-          data-testid={`action-volume-line-${s.key}`}
-          aria-hidden
-          className="action-volume-panel__line-anchor"
-        />
-      ))}
-
-      {isPending ? (
-        <div className="action-volume-panel__skeleton" aria-hidden />
-      ) : isError ? (
-        <p className="action-volume-panel__error">Failed to load action volume data.</p>
-      ) : series.length === 0 ? (
+  function renderBody() {
+    if (isPending) {
+      return <div className="action-volume-panel__skeleton" aria-hidden />
+    }
+    if (isError) {
+      return <p className="action-volume-panel__error">Failed to load action volume data.</p>
+    }
+    if (series.length === 0) {
+      return (
         <div className="action-volume-panel__empty">
           <p>No data for the selected filters.</p>
           <a href="/docs/analytics#no-data">Why am I seeing nothing?</a>
         </div>
-      ) : (
-        <ResponsiveContainer width="100%" height={320}>
+      )
+    }
+    return (
+      <ResponsiveContainer width="100%" height={320}>
           <LineChart data={chartData} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="var(--surface-card-border)" />
             <XAxis
@@ -95,7 +87,24 @@ export function ActionVolumePanel() {
             ))}
           </LineChart>
         </ResponsiveContainer>
-      )}
+    )
+  }
+
+  return (
+    <div className="action-volume-panel" data-testid="action-volume-panel">
+      <h2 className="action-volume-panel__title">Action Volume</h2>
+
+      {/* Per-series test anchors — not visible in UI */}
+      {series.map(s => (
+        <span
+          key={s.key}
+          data-testid={`action-volume-line-${s.key}`}
+          aria-hidden
+          className="action-volume-panel__line-anchor"
+        />
+      ))}
+
+      {renderBody()}
     </div>
   )
 }

--- a/dashboard/src/features/analytics/ApprovalAnalyticsPanel.tsx
+++ b/dashboard/src/features/analytics/ApprovalAnalyticsPanel.tsx
@@ -39,18 +39,18 @@ export function ApprovalAnalyticsPanel() {
 
   const donutData = useMemo(() => (data ? buildDonutData(data) : []), [data])
 
-  return (
-    <div className="approval-analytics-panel" data-testid="approval-analytics-panel">
-      <div className="approval-analytics-panel__header">
-        <h2 className="approval-analytics-panel__title">Approval Analytics</h2>
-      </div>
-
-      {isPending ? (
-        <div className="approval-analytics-panel__skeleton" aria-hidden />
-      ) : isError ? (
-        <p className="approval-analytics-panel__error">Failed to load approval data.</p>
-      ) : !data ? null : (
-        <div className="approval-analytics-panel__body">
+  function renderBody() {
+    if (isPending) {
+      return <div className="approval-analytics-panel__skeleton" aria-hidden />
+    }
+    if (isError) {
+      return <p className="approval-analytics-panel__error">Failed to load approval data.</p>
+    }
+    if (!data) {
+      return null
+    }
+    return (
+      <div className="approval-analytics-panel__body">
           <div className="approval-analytics-panel__stats">
             <div className="approval-analytics-panel__stat">
               <span className="approval-analytics-panel__stat-value">
@@ -108,7 +108,16 @@ export function ApprovalAnalyticsPanel() {
             </ul>
           </div>
         </div>
-      )}
+    )
+  }
+
+  return (
+    <div className="approval-analytics-panel" data-testid="approval-analytics-panel">
+      <div className="approval-analytics-panel__header">
+        <h2 className="approval-analytics-panel__title">Approval Analytics</h2>
+      </div>
+
+      {renderBody()}
     </div>
   )
 }

--- a/dashboard/src/features/analytics/CostBreakdownPanel.tsx
+++ b/dashboard/src/features/analytics/CostBreakdownPanel.tsx
@@ -70,29 +70,23 @@ export function CostBreakdownPanel() {
     [segments, hidden],
   )
 
-  return (
-    <div className="cost-breakdown-panel" data-testid="cost-breakdown-panel">
-      <div className="cost-breakdown-panel__header">
-        <h2 className="cost-breakdown-panel__title">Cost Breakdown</h2>
-        <SegmentedControl
-          options={GROUP_BY_OPTIONS}
-          value={groupBy}
-          onChange={setGroupBy}
-          testIdPrefix="cost-breakdown-toggle"
-        />
-      </div>
-
-      {isPending ? (
-        <div className="cost-breakdown-panel__skeleton" aria-hidden />
-      ) : isError ? (
-        <p className="cost-breakdown-panel__error">Failed to load cost data.</p>
-      ) : buckets.length === 0 ? (
+  function renderBody() {
+    if (isPending) {
+      return <div className="cost-breakdown-panel__skeleton" aria-hidden />
+    }
+    if (isError) {
+      return <p className="cost-breakdown-panel__error">Failed to load cost data.</p>
+    }
+    if (buckets.length === 0) {
+      return (
         <div className="cost-breakdown-panel__empty">
           <p>No cost data for the selected filters.</p>
           <a href="/docs/analytics#no-data">Why am I seeing nothing?</a>
         </div>
-      ) : (
-        <>
+      )
+    }
+    return (
+      <>
           <ResponsiveContainer width="100%" height={320}>
             <BarChart data={chartData} margin={{ top: 8, right: 16, left: 8, bottom: 0 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="var(--surface-card-border)" vertical={false} />
@@ -151,7 +145,22 @@ export function CostBreakdownPanel() {
             })}
           </ul>
         </>
-      )}
+    )
+  }
+
+  return (
+    <div className="cost-breakdown-panel" data-testid="cost-breakdown-panel">
+      <div className="cost-breakdown-panel__header">
+        <h2 className="cost-breakdown-panel__title">Cost Breakdown</h2>
+        <SegmentedControl
+          options={GROUP_BY_OPTIONS}
+          value={groupBy}
+          onChange={setGroupBy}
+          testIdPrefix="cost-breakdown-toggle"
+        />
+      </div>
+
+      {renderBody()}
     </div>
   )
 }

--- a/dashboard/src/features/analytics/FleetHealthPanel.tsx
+++ b/dashboard/src/features/analytics/FleetHealthPanel.tsx
@@ -25,22 +25,22 @@ export function FleetHealthPanel() {
   const rawAgents = data?.agents
   const agents = useMemo(() => rawAgents ?? [], [rawAgents])
 
-  return (
-    <div className="fleet-health-panel" data-testid="fleet-health-panel">
-      <div className="fleet-health-panel__header">
-        <h2 className="fleet-health-panel__title">Fleet Health</h2>
-      </div>
-
-      {isPending ? (
-        <div className="fleet-health-panel__skeleton" aria-hidden />
-      ) : isError ? (
-        <p className="fleet-health-panel__error">Failed to load fleet health data.</p>
-      ) : agents.length === 0 ? (
+  function renderBody() {
+    if (isPending) {
+      return <div className="fleet-health-panel__skeleton" aria-hidden />
+    }
+    if (isError) {
+      return <p className="fleet-health-panel__error">Failed to load fleet health data.</p>
+    }
+    if (agents.length === 0) {
+      return (
         <div className="fleet-health-panel__empty">
           <p>No agents reporting in this window.</p>
         </div>
-      ) : (
-        <ul className="fleet-health-panel__list" aria-label="Agent health">
+      )
+    }
+    return (
+      <ul className="fleet-health-panel__list" aria-label="Agent health">
           {agents.map(agent => {
             const score = currentScore(agent)
             return (
@@ -73,7 +73,16 @@ export function FleetHealthPanel() {
             )
           })}
         </ul>
-      )}
+    )
+  }
+
+  return (
+    <div className="fleet-health-panel" data-testid="fleet-health-panel">
+      <div className="fleet-health-panel__header">
+        <h2 className="fleet-health-panel__title">Fleet Health</h2>
+      </div>
+
+      {renderBody()}
     </div>
   )
 }

--- a/dashboard/src/features/analytics/PolicyEffectivenessPanel.tsx
+++ b/dashboard/src/features/analytics/PolicyEffectivenessPanel.tsx
@@ -47,23 +47,23 @@ export function PolicyEffectivenessPanel() {
     return m
   }, [rules])
 
-  return (
-    <div className="policy-effectiveness-panel" data-testid="policy-effectiveness-panel">
-      <div className="policy-effectiveness-panel__header">
-        <h2 className="policy-effectiveness-panel__title">Policy Effectiveness</h2>
-      </div>
-
-      {isPending ? (
-        <div className="policy-effectiveness-panel__skeleton" aria-hidden />
-      ) : isError ? (
-        <p className="policy-effectiveness-panel__error">Failed to load policy data.</p>
-      ) : rules.length === 0 ? (
+  function renderBody() {
+    if (isPending) {
+      return <div className="policy-effectiveness-panel__skeleton" aria-hidden />
+    }
+    if (isError) {
+      return <p className="policy-effectiveness-panel__error">Failed to load policy data.</p>
+    }
+    if (rules.length === 0) {
+      return (
         <div className="policy-effectiveness-panel__empty">
           <p>No policies are enabled for the selected filters.</p>
           <a href="/policy/builder">Go to Policy Builder</a>
         </div>
-      ) : (
-        <div className="policy-effectiveness-panel__scroll">
+      )
+    }
+    return (
+      <div className="policy-effectiveness-panel__scroll">
           <div
             className="policy-effectiveness-panel__grid"
             style={{
@@ -148,7 +148,16 @@ export function PolicyEffectivenessPanel() {
             </div>
           )}
         </div>
-      )}
+    )
+  }
+
+  return (
+    <div className="policy-effectiveness-panel" data-testid="policy-effectiveness-panel">
+      <div className="policy-effectiveness-panel__header">
+        <h2 className="policy-effectiveness-panel__title">Policy Effectiveness</h2>
+      </div>
+
+      {renderBody()}
     </div>
   )
 }

--- a/dashboard/src/features/analytics/ToolUsagePanel.tsx
+++ b/dashboard/src/features/analytics/ToolUsagePanel.tsx
@@ -20,22 +20,22 @@ export function ToolUsagePanel() {
   const tools = useMemo(() => rawTools ?? [], [rawTools])
   const sortedTools = useMemo(() => sortToolsByCallsDesc(tools), [tools])
 
-  return (
-    <div className="tool-usage-panel" data-testid="tool-usage-panel">
-      <div className="tool-usage-panel__header">
-        <h2 className="tool-usage-panel__title">Tool Usage</h2>
-      </div>
-
-      {isPending ? (
-        <div className="tool-usage-panel__skeleton" aria-hidden />
-      ) : isError ? (
-        <p className="tool-usage-panel__error">Failed to load tool usage data.</p>
-      ) : tools.length === 0 ? (
+  function renderBody() {
+    if (isPending) {
+      return <div className="tool-usage-panel__skeleton" aria-hidden />
+    }
+    if (isError) {
+      return <p className="tool-usage-panel__error">Failed to load tool usage data.</p>
+    }
+    if (tools.length === 0) {
+      return (
         <div className="tool-usage-panel__empty">
           <p>No tool calls in the selected window.</p>
         </div>
-      ) : (
-        <>
+      )
+    }
+    return (
+      <>
           {/* Hidden anchors for testing — recharts SVG is invisible at 0-width in jsdom */}
           {sortedTools.map((tool, idx) => (
             <span
@@ -81,7 +81,16 @@ export function ToolUsagePanel() {
           </BarChart>
         </ResponsiveContainer>
         </>
-      )}
+    )
+  }
+
+  return (
+    <div className="tool-usage-panel" data-testid="tool-usage-panel">
+      <div className="tool-usage-panel__header">
+        <h2 className="tool-usage-panel__title">Tool Usage</h2>
+      </div>
+
+      {renderBody()}
     </div>
   )
 }

--- a/dashboard/src/features/approvals/useApprovalsStream.ts
+++ b/dashboard/src/features/approvals/useApprovalsStream.ts
@@ -26,7 +26,7 @@ function buildWsUrl(): string {
   const base = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? ''
   const wsBase = base
     ? base.replace(/^https/, 'wss').replace(/^http/, 'ws')
-    : `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}`
+    : `${globalThis.location.protocol === 'https:' ? 'wss' : 'ws'}://${globalThis.location.host}`
   const token = localStorage.getItem('aa_token')
   const query = ['types=approval', token ? `token=${encodeURIComponent(token)}` : '']
     .filter(Boolean)

--- a/dashboard/src/features/approvals/useApprovalsStream.ts
+++ b/dashboard/src/features/approvals/useApprovalsStream.ts
@@ -24,9 +24,10 @@ function mergeIncomingApproval(
 
 function buildWsUrl(): string {
   const base = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? ''
+  const scheme = globalThis.location.protocol === 'https:' ? 'wss' : 'ws'
   const wsBase = base
     ? base.replace(/^https/, 'wss').replace(/^http/, 'ws')
-    : `${globalThis.location.protocol === 'https:' ? 'wss' : 'ws'}://${globalThis.location.host}`
+    : `${scheme}://${globalThis.location.host}`
   const token = localStorage.getItem('aa_token')
   const query = ['types=approval', token ? `token=${encodeURIComponent(token)}` : '']
     .filter(Boolean)

--- a/dashboard/src/features/capability/CellInspectDrawer.tsx
+++ b/dashboard/src/features/capability/CellInspectDrawer.tsx
@@ -49,13 +49,25 @@ export function CellInspectDrawer({ cell, policies, sampleCalls, onClose }: Cell
   const recentCalls = callsFor(sampleCalls, agent, verb)
 
   return (
-    <div className="cap-drawer-scrim" onClick={onClose} data-testid="cell-inspect-scrim">
+    <div
+      className="cap-drawer-scrim"
+      role="presentation"
+      onClick={onClose}
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return
+        if (e.key !== 'Enter' && e.key !== ' ') return
+        e.preventDefault()
+        onClose()
+      }}
+      data-testid="cell-inspect-scrim"
+    >
       <aside
         className="cap-drawer"
         role="dialog"
         aria-modal
         aria-label="capability cell inspect"
         onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
       >
         <header className="cap-drawer-head">
           <div>
@@ -94,7 +106,7 @@ export function CellInspectDrawer({ cell, policies, sampleCalls, onClose }: Cell
             <div className="cap-drawer-claimed">
               <div>
                 <div className="cap-drawer-mini-label">agent claims</div>
-                <div className="mono">{verb}({resource.id}/*)</div>
+                <div className="mono">{`${verb}(${resource.id}/*)`}</div>
                 <div className="cap-drawer-mini-note">declared in agent manifest</div>
               </div>
               <div>

--- a/dashboard/src/features/iam/RevealOnceModal.tsx
+++ b/dashboard/src/features/iam/RevealOnceModal.tsx
@@ -58,8 +58,19 @@ export function RevealOnceModal({
       aria-modal="true"
       data-testid="reveal-once-modal"
       onClick={handleBackdropAttempt}
+      onKeyDown={(e) => {
+        if (e.target !== e.currentTarget) return
+        if (e.key !== 'Enter' && e.key !== ' ') return
+        e.preventDefault()
+        handleBackdropAttempt()
+      }}
     >
-      <div className="iam-dialog" onClick={(e) => e.stopPropagation()}>
+      <div
+        className="iam-dialog"
+        role="presentation"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
         <h2 className="iam-dialog__title">Your new API key</h2>
         <p style={{ fontSize: '0.85rem', margin: '0 0 0.75rem' }}>
           Copy this secret now — it will not be shown again.

--- a/dashboard/src/features/liveOps/PipelineCanvas.test.tsx
+++ b/dashboard/src/features/liveOps/PipelineCanvas.test.tsx
@@ -126,11 +126,11 @@ describe('PipelineCanvas — simulation loop', () => {
     getContextSpy = vi
       .spyOn(HTMLCanvasElement.prototype, 'getContext')
       .mockImplementation(() => makeCtxStub() as unknown as null)
-    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    vi.spyOn(globalThis, 'requestAnimationFrame').mockImplementation((cb) => {
       rafCallbacks.push(cb)
       return rafCallbacks.length
     })
-    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {})
+    vi.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => {})
   })
 
   afterEach(() => {

--- a/dashboard/src/features/liveOps/useLiveOpsStream.ts
+++ b/dashboard/src/features/liveOps/useLiveOpsStream.ts
@@ -96,9 +96,10 @@ export interface UseLiveOpsStreamResult {
 
 function buildWsUrl(): string {
   const base = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? ''
+  const scheme = globalThis.location.protocol === 'https:' ? 'wss' : 'ws'
   const wsBase = base
     ? base.replace(/^https/, 'wss').replace(/^http/, 'ws')
-    : `${globalThis.location.protocol === 'https:' ? 'wss' : 'ws'}://${globalThis.location.host}`
+    : `${scheme}://${globalThis.location.host}`
   const token =
     typeof localStorage !== 'undefined' ? localStorage.getItem('aa_token') : null
   const query = [

--- a/dashboard/src/features/liveOps/useLiveOpsStream.ts
+++ b/dashboard/src/features/liveOps/useLiveOpsStream.ts
@@ -98,7 +98,7 @@ function buildWsUrl(): string {
   const base = (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? ''
   const wsBase = base
     ? base.replace(/^https/, 'wss').replace(/^http/, 'ws')
-    : `${window.location.protocol === 'https:' ? 'wss' : 'ws'}://${window.location.host}`
+    : `${globalThis.location.protocol === 'https:' ? 'wss' : 'ws'}://${globalThis.location.host}`
   const token =
     typeof localStorage !== 'undefined' ? localStorage.getItem('aa_token') : null
   const query = [

--- a/dashboard/src/features/onboarding/__tests__/OnboardingPage.test.tsx
+++ b/dashboard/src/features/onboarding/__tests__/OnboardingPage.test.tsx
@@ -25,8 +25,8 @@ function renderAt(path: string) {
 
 describe('OnboardingPage', () => {
   beforeEach(() => {
-    window.localStorage.removeItem(ONBOARDING_COMPLETED_KEY)
-    window.localStorage.removeItem(ONBOARDING_SESSION_KEY)
+    globalThis.localStorage.removeItem(ONBOARDING_COMPLETED_KEY)
+    globalThis.localStorage.removeItem(ONBOARDING_SESSION_KEY)
   })
 
   it('renders the wizard when gateway is not yet configured', () => {
@@ -35,7 +35,7 @@ describe('OnboardingPage', () => {
   })
 
   it('redirects to / immediately when gateway is already configured', () => {
-    window.localStorage.setItem(ONBOARDING_COMPLETED_KEY, 'true')
+    globalThis.localStorage.setItem(ONBOARDING_COMPLETED_KEY, 'true')
     renderAt('/onboarding')
     expect(screen.queryByTestId('onboarding-wizard')).toBeNull()
     expect(screen.getByTestId('root-page')).toBeInTheDocument()
@@ -67,10 +67,10 @@ describe('OnboardingPage', () => {
     renderAt('/onboarding')
     // The wizard mounts and immediately persists its initial snapshot,
     // so the session key is present.
-    expect(window.localStorage.getItem(ONBOARDING_SESSION_KEY)).not.toBe(null)
+    expect(globalThis.localStorage.getItem(ONBOARDING_SESSION_KEY)).not.toBe(null)
     fireEvent.click(screen.getByTestId('onboarding-skip-all'))
-    expect(window.localStorage.getItem(ONBOARDING_COMPLETED_KEY)).toBe('true')
-    expect(window.localStorage.getItem(ONBOARDING_SESSION_KEY)).toBe(null)
+    expect(globalThis.localStorage.getItem(ONBOARDING_COMPLETED_KEY)).toBe('true')
+    expect(globalThis.localStorage.getItem(ONBOARDING_SESSION_KEY)).toBe(null)
     expect(screen.getByTestId('root-page')).toBeInTheDocument()
     expect(screen.getByTestId('toast-container')).toHaveTextContent(/Onboarding skipped/i)
   })
@@ -93,8 +93,8 @@ describe('OnboardingPage', () => {
     })
     renderAt('/onboarding')
     fireEvent.click(screen.getByTestId('onboarding-continue'))
-    expect(window.localStorage.getItem(ONBOARDING_COMPLETED_KEY)).toBe('true')
-    expect(window.localStorage.getItem(ONBOARDING_SESSION_KEY)).toBe(null)
+    expect(globalThis.localStorage.getItem(ONBOARDING_COMPLETED_KEY)).toBe('true')
+    expect(globalThis.localStorage.getItem(ONBOARDING_SESSION_KEY)).toBe(null)
     expect(screen.getByTestId('toast-container')).toHaveTextContent(/Setup complete/i)
   })
 })

--- a/dashboard/src/features/onboarding/steps/Step2InstallSdk.tsx
+++ b/dashboard/src/features/onboarding/steps/Step2InstallSdk.tsx
@@ -43,7 +43,7 @@ export function Step2InstallSdk({ state, onVerified }: Step2InstallSdkProps) {
       // ignore clipboard failure (older browsers / no permission)
     }
     setCopied(true)
-    window.setTimeout(() => setCopied(false), 1400)
+    globalThis.setTimeout(() => setCopied(false), 1400)
   }
 
   const handleRun = () => {
@@ -54,7 +54,7 @@ export function Step2InstallSdk({ state, onVerified }: Step2InstallSdkProps) {
       { kind: 'cmd', text: 'aa-cli verify' },
       { kind: 'out', text: 'connecting to runtime…' },
     ])
-    window.setTimeout(() => {
+    globalThis.setTimeout(() => {
       setLines(VERIFIED_LINES)
       setPhase('verified')
       onVerified()

--- a/dashboard/src/features/onboarding/steps/Step3IssueIdentity.tsx
+++ b/dashboard/src/features/onboarding/steps/Step3IssueIdentity.tsx
@@ -37,7 +37,7 @@ export function Step3IssueIdentity({ state, onIssued }: Step3IssueIdentityProps)
   const handleGenerate = () => {
     if (phase !== 'idle') return
     setPhase('spinning')
-    window.setTimeout(() => {
+    globalThis.setTimeout(() => {
       const identity: AgentIdentity = {
         did: `did:aa:${randHex(16)}`,
         alg: 'Ed25519',

--- a/dashboard/src/features/onboarding/steps/Step5EnrollAgent.tsx
+++ b/dashboard/src/features/onboarding/steps/Step5EnrollAgent.tsx
@@ -29,7 +29,7 @@ export function Step5EnrollAgent({ state, onEnrolled }: Step5EnrollAgentProps) {
   const handleStart = () => {
     if (phase !== 'idle') return
     setPhase('listening')
-    window.setTimeout(() => {
+    globalThis.setTimeout(() => {
       setPhase('live')
       setPings(COMPLETED_PINGS)
       onEnrolled()

--- a/dashboard/src/features/onboarding/steps/Step5EnrollAgent.tsx
+++ b/dashboard/src/features/onboarding/steps/Step5EnrollAgent.tsx
@@ -92,12 +92,12 @@ export function Step5EnrollAgent({ state, onEnrolled }: Step5EnrollAgentProps) {
       <div className="onb-enroll-pings" data-testid="onboarding-enroll-pings">
         {pings.length === 0 && phase === 'idle' && (
           <div className="onb-enroll-pings-empty">
-            // no calls yet — run your agent to phone home
+            {'// no calls yet — run your agent to phone home'}
           </div>
         )}
         {pings.length === 0 && phase === 'listening' && (
           <div className="onb-enroll-pings-empty">
-            // awaiting first authenticated call…
+            {'// awaiting first authenticated call…'}
           </div>
         )}
         {pings.map((p) => (

--- a/dashboard/src/features/onboarding/useGatewayConfiguredGuard.ts
+++ b/dashboard/src/features/onboarding/useGatewayConfiguredGuard.ts
@@ -6,7 +6,7 @@ export const ONBOARDING_COMPLETED_KEY = 'aa.onboarding.completed'
  * to render the wizard or redirect *before* the first paint — avoiding a
  * flash of the modal for already-set-up users.
  */
-export function isGatewayConfigured(storage: Storage = window.localStorage): boolean {
+export function isGatewayConfigured(storage: Storage = globalThis.localStorage): boolean {
   try {
     return storage.getItem(ONBOARDING_COMPLETED_KEY) === 'true'
   } catch {
@@ -14,7 +14,7 @@ export function isGatewayConfigured(storage: Storage = window.localStorage): boo
   }
 }
 
-export function markGatewayConfigured(storage: Storage = window.localStorage): void {
+export function markGatewayConfigured(storage: Storage = globalThis.localStorage): void {
   try {
     storage.setItem(ONBOARDING_COMPLETED_KEY, 'true')
   } catch {
@@ -22,7 +22,7 @@ export function markGatewayConfigured(storage: Storage = window.localStorage): v
   }
 }
 
-export function clearGatewayConfigured(storage: Storage = window.localStorage): void {
+export function clearGatewayConfigured(storage: Storage = globalThis.localStorage): void {
   try {
     storage.removeItem(ONBOARDING_COMPLETED_KEY)
   } catch {

--- a/dashboard/src/features/onboarding/useWizardSession.ts
+++ b/dashboard/src/features/onboarding/useWizardSession.ts
@@ -34,7 +34,7 @@ function isWizardState(value: unknown): value is WizardState {
  * shape change).
  */
 export function loadWizardSession(
-  storage: Storage = window.localStorage,
+  storage: Storage = globalThis.localStorage,
 ): WizardSession | null {
   try {
     const raw = storage.getItem(ONBOARDING_SESSION_KEY)
@@ -51,7 +51,7 @@ export function loadWizardSession(
 
 export function saveWizardSession(
   session: WizardSession,
-  storage: Storage = window.localStorage,
+  storage: Storage = globalThis.localStorage,
 ): void {
   try {
     storage.setItem(ONBOARDING_SESSION_KEY, JSON.stringify(session))
@@ -60,7 +60,7 @@ export function saveWizardSession(
   }
 }
 
-export function clearWizardSession(storage: Storage = window.localStorage): void {
+export function clearWizardSession(storage: Storage = globalThis.localStorage): void {
   try {
     storage.removeItem(ONBOARDING_SESSION_KEY)
   } catch {
@@ -73,7 +73,7 @@ export function clearWizardSession(storage: Storage = window.localStorage): void
  * step 1 with EMPTY_STATE when no session is persisted.
  */
 export function resolveInitialSession(
-  storage: Storage = window.localStorage,
+  storage: Storage = globalThis.localStorage,
 ): WizardSession {
   return (
     loadWizardSession(storage) ?? {

--- a/dashboard/src/features/policies/editor/serializeDraft.ts
+++ b/dashboard/src/features/policies/editor/serializeDraft.ts
@@ -146,7 +146,7 @@ export function serializeDraft(draft: PolicyDraft): string {
       version: draft.version,
     },
     spec: {
-      rules: draft.rules.map(serializeRule),
+      rules: draft.rules.map((rule, idx) => serializeRule(rule, idx)),
     },
   }
   return YAML.stringify(policy, { lineWidth: 0, indent: 2 })

--- a/dashboard/src/features/teams/permissions.ts
+++ b/dashboard/src/features/teams/permissions.ts
@@ -1,8 +1,8 @@
 const TEAM_ADMIN_FLAG_KEY = 'aa_team_admin'
 
 export function isTeamAdmin(): boolean {
-  if (typeof window === 'undefined') return false
-  return window.localStorage.getItem(TEAM_ADMIN_FLAG_KEY) === '1'
+  if (typeof globalThis === 'undefined') return false
+  return globalThis.localStorage.getItem(TEAM_ADMIN_FLAG_KEY) === '1'
 }
 
 export function useCanManageTeam(): boolean {

--- a/dashboard/src/pages/AgentDetailPage.tsx
+++ b/dashboard/src/pages/AgentDetailPage.tsx
@@ -19,6 +19,20 @@ const SubtreeBurnChart = lazy(() =>
 )
 import './AgentDetailDrawer.css'
 
+/** Trust score (0-100) to its gauge color token. */
+function trustTone(score: number): string {
+  if (score >= 80) return 'var(--ok)'
+  if (score >= 60) return 'var(--warn)'
+  return 'var(--danger)'
+}
+
+/** Trust score (0-100) to its human-readable standing summary. */
+function trustSummary(score: number): string {
+  if (score < 50) return 'low — needs review'
+  if (score < 75) return 'moderate'
+  return 'good standing'
+}
+
 function TrustGauge({ score }: { score: number | null }) {
   if (score === null) {
     return (
@@ -28,7 +42,7 @@ function TrustGauge({ score }: { score: number | null }) {
     )
   }
   const clamped = Math.max(0, Math.min(100, score))
-  const tone = clamped >= 80 ? 'var(--ok)' : clamped >= 60 ? 'var(--warn)' : 'var(--danger)'
+  const tone = trustTone(clamped)
   const dash = (clamped / 100) * 125.6
   return (
     <div className="ad-identity__trust">
@@ -47,7 +61,7 @@ function TrustGauge({ score }: { score: number | null }) {
       <div className="ad-identity__trust-meta">
         <p className="ad-identity__label">trust score</p>
         <span className="ad-identity__trust-summary">
-          {clamped < 50 ? 'low — needs review' : clamped < 75 ? 'moderate' : 'good standing'}
+          {trustSummary(clamped)}
         </span>
       </div>
     </div>

--- a/dashboard/src/pages/FleetPage.test.tsx
+++ b/dashboard/src/pages/FleetPage.test.tsx
@@ -253,7 +253,7 @@ describe('FleetPage table interactions', () => {
 
     const row = await screen.findByTestId('agent-row')
     fireEvent.click(row)
-    await waitFor(() => expect(window.location.pathname + lastPath).toBeDefined())
+    await waitFor(() => expect(globalThis.location.pathname + lastPath).toBeDefined())
 
     // Use findByTestId on a body cell to bypass the row's onClick? Just verify the navigation
     // by checking that the row click reached the navigate hook via a route effect:

--- a/dashboard/src/pages/TeamsPage.tsx
+++ b/dashboard/src/pages/TeamsPage.tsx
@@ -20,6 +20,20 @@ import {
 
 const PAGE_SIZE = 25
 
+/** Budget-burn percentage to its severity color token. */
+function burnColor(pct: number): string {
+  if (pct >= 90) return 'var(--status-danger-solid)'
+  if (pct >= 70) return 'var(--status-caution-solid)'
+  return 'var(--status-success-solid)'
+}
+
+/** Column sort state to its header indicator glyph. */
+function sortIndicator(sorted: false | 'asc' | 'desc'): string {
+  if (sorted === 'asc') return ' ↑'
+  if (sorted === 'desc') return ' ↓'
+  return ''
+}
+
 function SkeletonRows({ cols }: { cols: number }) {
   return (
     <>
@@ -45,12 +59,7 @@ function SkeletonRows({ cols }: { cols: number }) {
 
 function BurnCell({ pct }: { pct: number | null }) {
   if (pct == null) return <span style={{ color: 'var(--text-muted)' }}>—</span>
-  const color =
-    pct >= 90
-      ? 'var(--status-danger-solid)'
-      : pct >= 70
-        ? 'var(--status-caution-solid)'
-        : 'var(--status-success-solid)'
+  const color = burnColor(pct)
   return (
     <span style={{ color, fontFamily: 'JetBrains Mono, monospace' }}>
       {pct.toFixed(1)}%
@@ -172,11 +181,7 @@ export function TeamsPage() {
                   onClick={header.column.getToggleSortingHandler()}
                 >
                   {flexRender(header.column.columnDef.header, header.getContext())}
-                  {header.column.getIsSorted() === 'asc'
-                    ? ' ↑'
-                    : header.column.getIsSorted() === 'desc'
-                      ? ' ↓'
-                      : ''}
+                  {sortIndicator(header.column.getIsSorted())}
                 </th>
               ))}
             </tr>

--- a/dashboard/src/theme/useTheme.ts
+++ b/dashboard/src/theme/useTheme.ts
@@ -19,9 +19,9 @@ export const THEME_STORAGE_KEY = 'aa-dashboard-theme'
 
 function prefersDark(): boolean {
   return (
-    typeof window !== 'undefined' &&
-    typeof window.matchMedia === 'function' &&
-    window.matchMedia('(prefers-color-scheme: dark)').matches
+    typeof globalThis !== 'undefined' &&
+    typeof globalThis.matchMedia === 'function' &&
+    globalThis.matchMedia('(prefers-color-scheme: dark)').matches
   )
 }
 
@@ -62,8 +62,8 @@ export function useTheme(): UseThemeResult {
 
   // Follow OS changes only while the user has NOT made an explicit choice.
   useEffect(() => {
-    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
-    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    if (typeof globalThis === 'undefined' || typeof globalThis.matchMedia !== 'function') return
+    const mq = globalThis.matchMedia('(prefers-color-scheme: dark)')
     const onChange = (e: MediaQueryListEvent) => {
       if (readStored() === null) setThemeState(e.matches ? 'dark' : 'light')
     }


### PR DESCRIPTION
## Description

First wave of SonarCloud quality remediation for the **agent-assembly** monorepo (Epic AAASM-3345, ticket AAASM-3346). This wave is scoped to the dashboard (TypeScript), which is where **all 17 bugs** and the largest mechanical smell buckets live.

- **Bugs: fixed all 17 (→ 0)**
  - `S1082` (12) — added keyboard handlers / `role="presentation"` to clickable backdrop/scrim divs (Escape close already handled at document level; behaviour-preserving).
  - `S6438` (3) — wrapped comment-like JSX text children in braces.
  - `S7727` (1) — wrapped `serializeRule` in an arrow so `.map()` does not forward the array arg (index preserved).
  - `S2137` (1) — renamed the `Error` Storybook story export to `ErrorState`, kept display name via `name`.
- **Code smells: targeted the highest-count mechanical rules**
  - `S7764` (34) — replaced `window.*` with `globalThis.*` (all global-scoped APIs; browser + jsdom equivalent).
  - `S3358` (18 of 37) — replaced nested ternaries with `renderBody()` early-return helpers across the 6 analytics panels, hoisted ws-scheme out of URL ternaries, and extracted threshold→value lookup helpers (toast background, burn color, sort indicator, trust tone/summary).

All changes are behaviour-preserving; no test assertions changed. Remaining smells are deferred to follow-up waves (see ticket).

## Type of Change

- [x] 🐛 Bug fix
- [x] ♻️ Refactoring

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3346 (Epic AAASM-3345)

## Testing

- [x] Manual testing performed (full dashboard suite)
- [x] No tests required for the rest (mechanical, behaviour-preserving)

Validation (in `dashboard/`), all green:
- `pnpm type-check` — clean
- `pnpm lint` — clean (0 warnings)
- `pnpm test` — 143 files / 1262 tests passed
- `pnpm build` — succeeds (pre-existing chunk-size warning only)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of the diff completed
- [x] All local checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
