### PR TITLE
[AAASM-3359] ♻️ (dashboard): Mark React props readonly (typescript:S6759)

### DIFF
--- a/dashboard/src/App.test.tsx
+++ b/dashboard/src/App.test.tsx
@@ -11,7 +11,7 @@ function makeClient() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } })
 }
 
-function AppRoutes({ initialPath = '/' }: { initialPath?: string }) {
+function AppRoutes({ initialPath = '/' }: Readonly<{ initialPath?: string }>) {
   return (
     <QueryClientProvider client={makeClient()}>
       <MemoryRouter initialEntries={[initialPath]}>

--- a/dashboard/src/auth/AuthProvider.tsx
+++ b/dashboard/src/auth/AuthProvider.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { AuthContext } from './AuthContext'
 
-export function AuthProvider({ children }: { children: React.ReactNode }) {
+export function AuthProvider({ children }: Readonly<{ children: React.ReactNode }>) {
   const [token, setToken] = useState<string | null>(
     () => localStorage.getItem('aa_token'),
   )

--- a/dashboard/src/components/ApprovalRoutingBadge.tsx
+++ b/dashboard/src/components/ApprovalRoutingBadge.tsx
@@ -49,7 +49,7 @@ function formatHistoryTooltip(history: RoutingHistoryEntry[]): string {
     .join('\n')
 }
 
-export function ApprovalRoutingBadge({ routingStatus, tooltipOpen }: ApprovalRoutingBadgeProps) {
+export function ApprovalRoutingBadge({ routingStatus, tooltipOpen }: Readonly<ApprovalRoutingBadgeProps>) {
   const variant = resolveVariant(routingStatus.status)
   const label = formatLabel(routingStatus)
   const tooltipContent = formatHistoryTooltip(routingStatus.history)

--- a/dashboard/src/components/Badge.tsx
+++ b/dashboard/src/components/Badge.tsx
@@ -8,7 +8,7 @@ interface BadgeProps {
   children: ReactNode
 }
 
-export function Badge({ variant, children }: BadgeProps) {
+export function Badge({ variant, children }: Readonly<BadgeProps>) {
   return (
     <span className={`badge badge--${variant}`}>
       {children}

--- a/dashboard/src/components/Drawer.tsx
+++ b/dashboard/src/components/Drawer.tsx
@@ -33,7 +33,7 @@ interface DrawerProps {
  * scrim was rendered in-tree). On the server / pre-mount, falls back to
  * in-tree rendering to avoid SSR mismatches.
  */
-export function Drawer({ open, onClose, children, ariaLabel }: DrawerProps) {
+export function Drawer({ open, onClose, children, ariaLabel }: Readonly<DrawerProps>) {
   const onCloseRef = useRef(onClose)
   useEffect(() => {
     onCloseRef.current = onClose

--- a/dashboard/src/components/EmptyState.tsx
+++ b/dashboard/src/components/EmptyState.tsx
@@ -125,7 +125,7 @@ export interface EmptyStateProps {
   onSecondary?: () => void
 }
 
-export function EmptyState({ page = 'overview', onCta, onSecondary }: EmptyStateProps) {
+export function EmptyState({ page = 'overview', onCta, onSecondary }: Readonly<EmptyStateProps>) {
   const c = COPY[page] ?? COPY.overview
   return (
     <div className="state-page" role="status" data-testid={`empty-state-${page}`}>

--- a/dashboard/src/components/ErrorState.tsx
+++ b/dashboard/src/components/ErrorState.tsx
@@ -47,7 +47,7 @@ export interface ErrorStateProps {
   onSecondary?: () => void
 }
 
-export function ErrorState({ kind = 'generic', onRetry, onSecondary }: ErrorStateProps) {
+export function ErrorState({ kind = 'generic', onRetry, onSecondary }: Readonly<ErrorStateProps>) {
   const c = COPY[kind] ?? COPY.generic
   return (
     <div className="state-page" role="alert" data-testid={`error-state-${kind}`}>

--- a/dashboard/src/components/InheritedPermissionsPanel.tsx
+++ b/dashboard/src/components/InheritedPermissionsPanel.tsx
@@ -44,7 +44,7 @@ interface PermissionRow {
   readonly deniedByAncestor: PermissionSource | null
 }
 
-export function InheritedPermissionsPanel({ agentId }: { agentId: string }) {
+export function InheritedPermissionsPanel({ agentId }: Readonly<{ agentId: string }>) {
   const { data, isLoading, isError, refetch } = useAgentCapabilitiesQuery(agentId)
 
   const rows = useMemo<PermissionRow[]>(() => (data ? buildRows(data) : []), [data])

--- a/dashboard/src/components/LoadingState.tsx
+++ b/dashboard/src/components/LoadingState.tsx
@@ -35,7 +35,7 @@ function FleetSkeleton() {
   )
 }
 
-export function LoadingState({ page = 'generic' }: LoadingStateProps) {
+export function LoadingState({ page = 'generic' }: Readonly<LoadingStateProps>) {
   return (
     <div className="state-page sk-pulse" role="status" aria-busy data-testid={`loading-state-${page}`}>
       <div className="sk-page-head">

--- a/dashboard/src/components/OverlayHost.test.tsx
+++ b/dashboard/src/components/OverlayHost.test.tsx
@@ -20,7 +20,7 @@ interface HarnessProps {
   children?: ReactNode
 }
 
-function Harness({ withMount = true, onRequestClose, children }: HarnessProps) {
+function Harness({ withMount = true, onRequestClose, children }: Readonly<HarnessProps>) {
   return (
     <OverlayProvider>
       {withMount ? (

--- a/dashboard/src/components/OverlayProvider.tsx
+++ b/dashboard/src/components/OverlayProvider.tsx
@@ -5,7 +5,7 @@ const INITIAL_STATES: Record<OverlayName, OverlayState> = Object.fromEntries(
   OVERLAY_NAMES.map((n) => [n, { open: false, props: {} }]),
 ) as Record<OverlayName, OverlayState>
 
-export function OverlayProvider({ children }: { children: ReactNode }) {
+export function OverlayProvider({ children }: Readonly<{ children: ReactNode }>) {
   const [states, setStates] = useState<Record<OverlayName, OverlayState>>(INITIAL_STATES)
 
   const openOverlay = useCallback(

--- a/dashboard/src/components/SubtreeBurnChart.tsx
+++ b/dashboard/src/components/SubtreeBurnChart.tsx
@@ -37,7 +37,7 @@ type ChartRow = {
   [childId: string]: string | number
 }
 
-export function SubtreeBurnChart({ agentId }: { agentId: string }) {
+export function SubtreeBurnChart({ agentId }: Readonly<{ agentId: string }>) {
   const [period, setPeriod] = useState<BurnPeriod>('7d')
   const { data, isLoading, isError, refetch } = useAgentSubtreeBurnQuery(agentId, period)
 

--- a/dashboard/src/components/SuspendReasonDialog.tsx
+++ b/dashboard/src/components/SuspendReasonDialog.tsx
@@ -24,7 +24,7 @@ export function SuspendReasonDialog({
   pending = false,
   onConfirm,
   onCancel,
-}: SuspendReasonDialogProps) {
+}: Readonly<SuspendReasonDialogProps>) {
   const [reason, setReason] = useState('')
   const [touched, setTouched] = useState(false)
   const trimmed = reason.trim()

--- a/dashboard/src/components/ToastProvider.tsx
+++ b/dashboard/src/components/ToastProvider.tsx
@@ -16,7 +16,7 @@ const TOAST_BACKGROUND: Record<ToastVariant, string> = {
   info: 'var(--status-info-solid)',
 }
 
-export function ToastProvider({ children }: { children: ReactNode }) {
+export function ToastProvider({ children }: Readonly<{ children: ReactNode }>) {
   const [toasts, setToasts] = useState<ToastMessage[]>([])
 
   const toast = useCallback((message: string, variant: ToastVariant = 'info') => {

--- a/dashboard/src/components/Tooltip.tsx
+++ b/dashboard/src/components/Tooltip.tsx
@@ -8,7 +8,7 @@ interface TooltipProps {
   open?: boolean
 }
 
-export function Tooltip({ content, children, open = false }: TooltipProps) {
+export function Tooltip({ content, children, open = false }: Readonly<TooltipProps>) {
   const [hovered, setHovered] = useState(false)
   const visible = open || hovered
 

--- a/dashboard/src/components/ViolationHeatmap.tsx
+++ b/dashboard/src/components/ViolationHeatmap.tsx
@@ -52,7 +52,7 @@ const NODE_R = 18;
 const WIDTH = 900;
 const HEIGHT = 560;
 
-export function ViolationHeatmap({ nodes, maxNodes = 1000 }: Props) {
+export function ViolationHeatmap({ nodes, maxNodes = 1000 }: Readonly<Props>) {
   const [tooltip, setTooltip] = useState<{
     x: number;
     y: number;

--- a/dashboard/src/components/fleet/ModeChip.tsx
+++ b/dashboard/src/components/fleet/ModeChip.tsx
@@ -16,7 +16,7 @@ const GLYPH: Record<FleetMode, string> = {
  * `design/v1/fleet.jsx`. `enforce` uses the OK token, `shadow` uses
  * warn, `off` uses the neutral muted token.
  */
-export function ModeChip({ mode }: ModeChipProps) {
+export function ModeChip({ mode }: Readonly<ModeChipProps>) {
   return (
     <span className={`fleet-mode fleet-mode--${mode}`} data-testid="fleet-mode">
       <span aria-hidden="true">{GLYPH[mode]}</span>

--- a/dashboard/src/components/fleet/StatusChip.tsx
+++ b/dashboard/src/components/fleet/StatusChip.tsx
@@ -24,7 +24,7 @@ function classify(status: string): FleetStatusKind | 'unknown' {
  * Renders the hi-fi glyph + label using the design-system colour tokens
  * (palette literals; design tokens land project-wide in AAASM-1048).
  */
-export function StatusChip({ status }: StatusChipProps) {
+export function StatusChip({ status }: Readonly<StatusChipProps>) {
   const kind = classify(status)
   const glyph = kind === 'unknown' ? '○' : GLYPH[kind]
   return (

--- a/dashboard/src/components/fleet/TrustBar.tsx
+++ b/dashboard/src/components/fleet/TrustBar.tsx
@@ -17,7 +17,7 @@ function band(score: number): 'ok' | 'warn' | 'danger' {
  * A `null` score renders an em-dash so unwired analytics columns remain
  * visually inert.
  */
-export function TrustBar({ score }: TrustBarProps) {
+export function TrustBar({ score }: Readonly<TrustBarProps>) {
   if (score === null) {
     return (
       <span className="fleet-trust fleet-trust--empty" data-testid="fleet-trust">

--- a/dashboard/src/components/states/EmptyState.tsx
+++ b/dashboard/src/components/states/EmptyState.tsx
@@ -8,7 +8,7 @@ interface EmptyStateProps {
   icon?: ReactNode
 }
 
-export function EmptyState({ title, description, action, icon }: EmptyStateProps) {
+export function EmptyState({ title, description, action, icon }: Readonly<EmptyStateProps>) {
   return (
     <div className="state state--empty" role="status" data-testid="empty-state">
       {icon ? <div className="state__icon">{icon}</div> : null}

--- a/dashboard/src/components/states/ErrorState.tsx
+++ b/dashboard/src/components/states/ErrorState.tsx
@@ -13,7 +13,7 @@ export function ErrorState({
   description,
   onRetry,
   retryLabel = 'Retry',
-}: ErrorStateProps) {
+}: Readonly<ErrorStateProps>) {
   return (
     <div className="state state--error" role="alert" data-testid="error-state">
       <h2 className="state__title">{title}</h2>

--- a/dashboard/src/components/topology/NodeDetailPanel.tsx
+++ b/dashboard/src/components/topology/NodeDetailPanel.tsx
@@ -206,7 +206,7 @@ export function NodeDetailPanel({ node, onClose, onViewTrace }: NodeDetailPanelP
   )
 }
 
-function Field({ label, value }: { label: string; value: React.ReactNode }) {
+function Field({ label, value }: Readonly<{ label: string; value: React.ReactNode }>) {
   return (
     <div className="node-detail-panel__field">
       <span className="node-detail-panel__field-label">{label}</span>

--- a/dashboard/src/components/trace/TraceDrawer.test.tsx
+++ b/dashboard/src/components/trace/TraceDrawer.test.tsx
@@ -16,7 +16,7 @@ vi.mock('../../pages/TraceViewPage', () => ({
   ),
 }))
 
-function Opener({ agentId, sessionId, label }: { agentId: string; sessionId: string; label: string }) {
+function Opener({ agentId, sessionId, label }: Readonly<{ agentId: string; sessionId: string; label: string }>) {
   const { open } = useTraceDrawer()
   return (
     <button type="button" onClick={() => open(agentId, sessionId)}>
@@ -25,7 +25,7 @@ function Opener({ agentId, sessionId, label }: { agentId: string; sessionId: str
   )
 }
 
-function Harness({ openers }: { openers: Array<{ agentId: string; sessionId: string; label: string }> }) {
+function Harness({ openers }: Readonly<{ openers: Array<{ agentId: string; sessionId: string; label: string }> }>) {
   return (
     <TraceDrawerProvider>
       {openers.map(o => (

--- a/dashboard/src/components/trace/TraceDrawerProvider.tsx
+++ b/dashboard/src/components/trace/TraceDrawerProvider.tsx
@@ -13,7 +13,7 @@ import {
  * AAASM-1340 — paired with `<TraceDrawer />` which subscribes to the
  * same context and renders the drawer body.
  */
-export function TraceDrawerProvider({ children }: { children: ReactNode }) {
+export function TraceDrawerProvider({ children }: Readonly<{ children: ReactNode }>) {
   const [state, setState] = useState<TraceDrawerState>({ agentId: null, sessionId: null })
 
   const open = useCallback((agentId: string, sessionId: string) => {

--- a/dashboard/src/features/agents/api.test.tsx
+++ b/dashboard/src/features/agents/api.test.tsx
@@ -13,7 +13,7 @@ function makeClient() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } })
 }
 
-function Wrapper({ children, path = '/', initialPath = '/' }: { children: React.ReactNode; path?: string; initialPath?: string }) {
+function Wrapper({ children, path = '/', initialPath = '/' }: Readonly<{ children: React.ReactNode; path?: string; initialPath?: string }>) {
   return (
     <QueryClientProvider client={makeClient()}>
       <ToastProvider>

--- a/dashboard/src/features/alerts/AlertDetailContent.tsx
+++ b/dashboard/src/features/alerts/AlertDetailContent.tsx
@@ -40,7 +40,7 @@ interface AlertDetailContentProps {
   alertId: string
 }
 
-export function AlertDetailContent({ alertId }: AlertDetailContentProps) {
+export function AlertDetailContent({ alertId }: Readonly<AlertDetailContentProps>) {
   const { data, isLoading, isError, error } = useAlertQuery(alertId)
 
   if (isLoading) {

--- a/dashboard/src/features/alerts/AlertDetailDrawer.tsx
+++ b/dashboard/src/features/alerts/AlertDetailDrawer.tsx
@@ -6,7 +6,7 @@ interface AlertDetailDrawerProps {
   children?: React.ReactNode
 }
 
-export function AlertDetailDrawer({ open, onClose, children }: AlertDetailDrawerProps) {
+export function AlertDetailDrawer({ open, onClose, children }: Readonly<AlertDetailDrawerProps>) {
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => {

--- a/dashboard/src/features/alerts/AlertFilterBar.tsx
+++ b/dashboard/src/features/alerts/AlertFilterBar.tsx
@@ -13,7 +13,7 @@ function toggle<T>(list: readonly T[], item: T): readonly T[] {
   return list.includes(item) ? list.filter((v) => v !== item) : [...list, item]
 }
 
-export function AlertFilterBar({ value, onChange }: AlertFilterBarProps) {
+export function AlertFilterBar({ value, onChange }: Readonly<AlertFilterBarProps>) {
   return (
     <div
       data-testid="alerts-filter-bar"

--- a/dashboard/src/features/alerts/AlertList.tsx
+++ b/dashboard/src/features/alerts/AlertList.tsx
@@ -103,7 +103,7 @@ const columns = [
   }),
 ]
 
-function SkeletonRows({ columnCount }: { columnCount: number }) {
+function SkeletonRows({ columnCount }: Readonly<{ columnCount: number }>) {
   return (
     <>
       {Array.from({ length: 5 }).map((_, i) => (
@@ -127,7 +127,7 @@ function SkeletonRows({ columnCount }: { columnCount: number }) {
   )
 }
 
-export function AlertList({ rows, onSelect, loading = false }: AlertListProps) {
+export function AlertList({ rows, onSelect, loading = false }: Readonly<AlertListProps>) {
   const [sorting, setSorting] = useState<SortingState>([
     { id: 'severity', desc: true },
   ])

--- a/dashboard/src/features/alerts/AlertRuleForm.test.tsx
+++ b/dashboard/src/features/alerts/AlertRuleForm.test.tsx
@@ -77,7 +77,7 @@ const FIXTURE_RULE: AlertRule = {
   updatedAt: '2026-05-13T00:00:00Z',
 }
 
-function Wrapper({ children }: { children: React.ReactNode }) {
+function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return (
     <QueryClientProvider client={client}>

--- a/dashboard/src/features/alerts/AlertRuleForm.tsx
+++ b/dashboard/src/features/alerts/AlertRuleForm.tsx
@@ -76,7 +76,7 @@ export function AlertRuleForm({
   onClose,
   initialValue,
   onSaved,
-}: AlertRuleFormProps) {
+}: Readonly<AlertRuleFormProps>) {
   const methods = useForm<RuleFormValues>({
     resolver: zodResolver(ruleFormSchema),
     defaultValues: defaultValues(initialValue),

--- a/dashboard/src/features/alerts/AlertRulesTable.test.tsx
+++ b/dashboard/src/features/alerts/AlertRulesTable.test.tsx
@@ -76,7 +76,7 @@ const RULE_B: AlertRule = {
   enabled: false,
 }
 
-function Wrapper({ children }: { children: React.ReactNode }) {
+function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return (
     <QueryClientProvider client={client}>

--- a/dashboard/src/features/alerts/AlertRulesTable.tsx
+++ b/dashboard/src/features/alerts/AlertRulesTable.tsx
@@ -39,7 +39,7 @@ const headerStyle = {
  * Wired into AlertsPage in the same Story; rules state is fetched via
  * `useAlertRulesQuery` (same hook AlertsPage already uses).
  */
-export function AlertRulesTable({ onCreate, onEdit, onOpenDestinations }: AlertRulesTableProps) {
+export function AlertRulesTable({ onCreate, onEdit, onOpenDestinations }: Readonly<AlertRulesTableProps>) {
   const rulesQuery = useAlertRulesQuery()
   const deleteMutation = useDeleteAlertRuleMutation()
   const { toast } = useToast()

--- a/dashboard/src/features/alerts/AlertsErrorBanner.tsx
+++ b/dashboard/src/features/alerts/AlertsErrorBanner.tsx
@@ -3,7 +3,7 @@ interface AlertsErrorBannerProps {
   onRetry: () => void
 }
 
-export function AlertsErrorBanner({ message, onRetry }: AlertsErrorBannerProps) {
+export function AlertsErrorBanner({ message, onRetry }: Readonly<AlertsErrorBannerProps>) {
   return (
     <div
       role="alert"

--- a/dashboard/src/features/alerts/AlertsTabs.tsx
+++ b/dashboard/src/features/alerts/AlertsTabs.tsx
@@ -12,7 +12,7 @@ const TABS: ReadonlyArray<{ value: AlertsTab; label: string }> = [
   { value: 'rules', label: 'Rule Configuration' },
 ]
 
-export function AlertsTabs({ value, onChange }: AlertsTabsProps) {
+export function AlertsTabs({ value, onChange }: Readonly<AlertsTabsProps>) {
   return (
     <div
       data-testid="alerts-tabs"

--- a/dashboard/src/features/alerts/DestinationManager.tsx
+++ b/dashboard/src/features/alerts/DestinationManager.tsx
@@ -41,7 +41,7 @@ function draftFromDestination(d: Destination): DraftForm {
   }
 }
 
-export function DestinationManager({ open, onClose }: DestinationManagerProps) {
+export function DestinationManager({ open, onClose }: Readonly<DestinationManagerProps>) {
   const { data, isLoading, isError, error } = useDestinationsQuery()
   const createMut = useCreateDestinationMutation()
   const updateMut = useUpdateDestinationMutation()

--- a/dashboard/src/features/alerts/EmptyStateNoRules.tsx
+++ b/dashboard/src/features/alerts/EmptyStateNoRules.tsx
@@ -2,7 +2,7 @@ interface EmptyStateNoRulesProps {
   onCreateRule: () => void
 }
 
-export function EmptyStateNoRules({ onCreateRule }: EmptyStateNoRulesProps) {
+export function EmptyStateNoRules({ onCreateRule }: Readonly<EmptyStateNoRulesProps>) {
   return (
     <div
       data-testid="alerts-empty-no-rules"

--- a/dashboard/src/features/alerts/RuleYamlViewer.tsx
+++ b/dashboard/src/features/alerts/RuleYamlViewer.tsx
@@ -23,7 +23,7 @@ interface RuleYamlViewerProps {
  * `<div>` is the only thing rendered synchronously; Monaco itself is
  * lazy-loaded inside a `<Suspense>` boundary.
  */
-export function RuleYamlViewer({ yaml }: RuleYamlViewerProps) {
+export function RuleYamlViewer({ yaml }: Readonly<RuleYamlViewerProps>) {
   return (
     <div
       data-testid="alert-detail-rule-yaml"

--- a/dashboard/src/features/alerts/SeverityBadge.tsx
+++ b/dashboard/src/features/alerts/SeverityBadge.tsx
@@ -18,7 +18,7 @@ const SEVERITY_BG: Record<Severity, string> = {
   LOW: 'var(--severity-low)',
 }
 
-export function SeverityBadge({ severity }: { severity: Severity }) {
+export function SeverityBadge({ severity }: Readonly<{ severity: Severity }>) {
   return (
     <span
       data-testid={`severity-badge-${severity}`}

--- a/dashboard/src/features/alerts/SilenceAction.test.tsx
+++ b/dashboard/src/features/alerts/SilenceAction.test.tsx
@@ -39,7 +39,7 @@ afterEach(() => {
   localStorage.clear()
 })
 
-function Wrapper({ children }: { children: React.ReactNode }) {
+function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return (
     <QueryClientProvider client={client}>

--- a/dashboard/src/features/alerts/SilenceAction.tsx
+++ b/dashboard/src/features/alerts/SilenceAction.tsx
@@ -22,7 +22,7 @@ const DURATIONS: readonly DurationOption[] = [
   { label: 'custom', value: null },
 ]
 
-export function SilenceAction({ alertId, silenced = false }: SilenceActionProps) {
+export function SilenceAction({ alertId, silenced = false }: Readonly<SilenceActionProps>) {
   const [selected, setSelected] = useState<DurationOption>(DURATIONS[1])
   const [customMinutes, setCustomMinutes] = useState<string>('30')
   const [reason, setReason] = useState<string>('')

--- a/dashboard/src/features/alerts/StatusBadge.tsx
+++ b/dashboard/src/features/alerts/StatusBadge.tsx
@@ -6,7 +6,7 @@ const STATUS_STYLE: Record<AlertStatus, { bg: string; fg: string }> = {
   SUPPRESSED: { bg: 'var(--surface-card-border)', fg: 'var(--text-secondary)' },
 }
 
-export function StatusBadge({ status }: { status: AlertStatus }) {
+export function StatusBadge({ status }: Readonly<{ status: AlertStatus }>) {
   const { bg, fg } = STATUS_STYLE[status]
   return (
     <span

--- a/dashboard/src/features/analytics/ActionVolumePanel.test.tsx
+++ b/dashboard/src/features/analytics/ActionVolumePanel.test.tsx
@@ -26,7 +26,7 @@ function makeQC() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } })
 }
 
-function Wrapper({ children }: { children: ReactNode }) {
+function Wrapper({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <QueryClientProvider client={makeQC()}>
       <MemoryRouter initialEntries={['/analytics']}>{children}</MemoryRouter>

--- a/dashboard/src/features/analytics/ApprovalAnalyticsPanel.test.tsx
+++ b/dashboard/src/features/analytics/ApprovalAnalyticsPanel.test.tsx
@@ -22,7 +22,7 @@ function makeQC() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } })
 }
 
-function Wrapper({ children }: { children: ReactNode }) {
+function Wrapper({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <QueryClientProvider client={makeQC()}>
       <MemoryRouter initialEntries={['/analytics']}>{children}</MemoryRouter>

--- a/dashboard/src/features/analytics/CostBreakdownPanel.test.tsx
+++ b/dashboard/src/features/analytics/CostBreakdownPanel.test.tsx
@@ -31,7 +31,7 @@ function makeQC() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } })
 }
 
-function Wrapper({ children }: { children: ReactNode }) {
+function Wrapper({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <QueryClientProvider client={makeQC()}>
       <MemoryRouter initialEntries={['/analytics']}>{children}</MemoryRouter>

--- a/dashboard/src/features/analytics/FilterBar.tsx
+++ b/dashboard/src/features/analytics/FilterBar.tsx
@@ -31,7 +31,7 @@ export function FilterBar({
   teams = [],
   isLoadingAgents = false,
   isLoadingTeams = false,
-}: FilterBarProps) {
+}: Readonly<FilterBarProps>) {
   const isCurrentlyCustom = isCustomRange(filters.range)
   const [showCustom, setShowCustom] = useState(isCurrentlyCustom)
   const [customStart, setCustomStart] = useState(

--- a/dashboard/src/features/analytics/FleetHealthPanel.test.tsx
+++ b/dashboard/src/features/analytics/FleetHealthPanel.test.tsx
@@ -22,7 +22,7 @@ function makeQC() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } })
 }
 
-function Wrapper({ children }: { children: ReactNode }) {
+function Wrapper({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <QueryClientProvider client={makeQC()}>
       <MemoryRouter initialEntries={['/analytics']}>{children}</MemoryRouter>

--- a/dashboard/src/features/analytics/KpiCard.tsx
+++ b/dashboard/src/features/analytics/KpiCard.tsx
@@ -14,7 +14,7 @@ interface KpiCardProps {
 const DELTA_POSITIVE_COLOR = 'var(--trend-positive)'
 const DELTA_NEGATIVE_COLOR = 'var(--trend-negative)'
 
-export function KpiCard({ metric, label, value, delta, unit, isLoading, isError }: KpiCardProps) {
+export function KpiCard({ metric, label, value, delta, unit, isLoading, isError }: Readonly<KpiCardProps>) {
   return (
     <div className="kpi-card" data-testid={`kpi-${metric}`}>
       <span className="kpi-card__label">{label}</span>

--- a/dashboard/src/features/analytics/KpiStrip.test.tsx
+++ b/dashboard/src/features/analytics/KpiStrip.test.tsx
@@ -12,7 +12,7 @@ function makeQC() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } })
 }
 
-function Wrapper({ children }: { children: ReactNode }) {
+function Wrapper({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <QueryClientProvider client={makeQC()}>
       <MemoryRouter initialEntries={['/analytics']}>{children}</MemoryRouter>

--- a/dashboard/src/features/analytics/KpiStrip.tsx
+++ b/dashboard/src/features/analytics/KpiStrip.tsx
@@ -17,7 +17,7 @@ const KPI_CONFIGS: KpiConfig[] = [
   { metric: 'anomalies',   label: 'Anomaly Count' },
 ]
 
-function KpiCardConnected({ metric, label, unit }: KpiConfig) {
+function KpiCardConnected({ metric, label, unit }: Readonly<KpiConfig>) {
   const { filters } = useAnalyticsFilters()
   const { data, isPending, isError } = useKpiQuery(metric, filters)
   return (

--- a/dashboard/src/features/analytics/PolicyEffectivenessPanel.test.tsx
+++ b/dashboard/src/features/analytics/PolicyEffectivenessPanel.test.tsx
@@ -18,7 +18,7 @@ function makeQC() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } })
 }
 
-function Wrapper({ children }: { children: ReactNode }) {
+function Wrapper({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <QueryClientProvider client={makeQC()}>
       <MemoryRouter initialEntries={['/analytics']}>{children}</MemoryRouter>

--- a/dashboard/src/features/analytics/SegmentedControl.tsx
+++ b/dashboard/src/features/analytics/SegmentedControl.tsx
@@ -15,7 +15,7 @@ export function SegmentedControl<T extends string>({
   value,
   onChange,
   testIdPrefix,
-}: SegmentedControlProps<T>) {
+}: Readonly<SegmentedControlProps<T>>) {
   return (
     <div className="segmented-control" role="group">
       {options.map(opt => (

--- a/dashboard/src/features/analytics/ToolUsagePanel.test.tsx
+++ b/dashboard/src/features/analytics/ToolUsagePanel.test.tsx
@@ -23,7 +23,7 @@ function makeQC() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } })
 }
 
-function Wrapper({ children }: { children: ReactNode }) {
+function Wrapper({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <QueryClientProvider client={makeQC()}>
       <MemoryRouter initialEntries={['/analytics']}>{children}</MemoryRouter>

--- a/dashboard/src/features/approvals/ApprovalCountdown.tsx
+++ b/dashboard/src/features/approvals/ApprovalCountdown.tsx
@@ -16,7 +16,7 @@ interface ApprovalCountdownProps {
   onExpire?: () => void
 }
 
-export function ApprovalCountdown({ expiresAt, onExpire }: ApprovalCountdownProps) {
+export function ApprovalCountdown({ expiresAt, onExpire }: Readonly<ApprovalCountdownProps>) {
   const [now, setNow] = useState(() => Date.now())
   const firedRef = useRef(false)
   const remainingMs = getRemainingMs(expiresAt, now)

--- a/dashboard/src/features/approvals/ApprovalDetailRow.tsx
+++ b/dashboard/src/features/approvals/ApprovalDetailRow.tsx
@@ -19,7 +19,7 @@ const LABEL_STYLE = {
   fontWeight: 500,
 } as const
 
-export function ApprovalDetailRow({ approval, colSpan }: ApprovalDetailRowProps) {
+export function ApprovalDetailRow({ approval, colSpan }: Readonly<ApprovalDetailRowProps>) {
   return (
     <tr data-testid="approval-detail-row">
       <td

--- a/dashboard/src/features/approvals/ApprovalsBellButton.test.tsx
+++ b/dashboard/src/features/approvals/ApprovalsBellButton.test.tsx
@@ -11,7 +11,7 @@ function mockQuery<T>(p: Partial<UseQueryResult<T, Error>>): UseQueryResult<T, E
   return p as unknown as UseQueryResult<T, Error>
 }
 
-function Wrapper({ children }: { children: React.ReactNode }) {
+function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return (
     <QueryClientProvider client={client}>

--- a/dashboard/src/features/approvals/ApprovalsFilterBar.tsx
+++ b/dashboard/src/features/approvals/ApprovalsFilterBar.tsx
@@ -15,7 +15,7 @@ const SELECT_STYLE = {
   fontSize: '0.875rem',
 } as const
 
-export function ApprovalsFilterBar({ filter, onChange, options }: ApprovalsFilterBarProps) {
+export function ApprovalsFilterBar({ filter, onChange, options }: Readonly<ApprovalsFilterBarProps>) {
   function update<K extends keyof ApprovalsFilter>(key: K, value: ApprovalsFilter[K]) {
     onChange({ ...filter, [key]: value })
   }

--- a/dashboard/src/features/approvals/ExpiredApprovalsSection.tsx
+++ b/dashboard/src/features/approvals/ExpiredApprovalsSection.tsx
@@ -6,7 +6,7 @@ interface ExpiredApprovalsSectionProps {
   rows: Approval[]
 }
 
-export function ExpiredApprovalsSection({ rows }: ExpiredApprovalsSectionProps) {
+export function ExpiredApprovalsSection({ rows }: Readonly<ExpiredApprovalsSectionProps>) {
   const [expanded, setExpanded] = useState(false)
 
   if (rows.length === 0) return null

--- a/dashboard/src/features/approvals/api.test.tsx
+++ b/dashboard/src/features/approvals/api.test.tsx
@@ -53,7 +53,7 @@ function mockMutation<TData, TVariables>(
   return p as unknown as UseMutationResult<TData, Error, TVariables>
 }
 
-function Wrapper({ client, children }: { client: QueryClient; children: React.ReactNode }) {
+function Wrapper({ client, children }: Readonly<{ client: QueryClient; children: React.ReactNode }>) {
   return (
     <QueryClientProvider client={client}>
       <ToastProvider>

--- a/dashboard/src/features/capability/BulkActionBar.tsx
+++ b/dashboard/src/features/capability/BulkActionBar.tsx
@@ -12,7 +12,7 @@ export interface BulkActionBarProps {
 
 const DECISION_OPTIONS: Decision[] = ['allow', 'narrow', 'approval', 'deny']
 
-export function BulkActionBar({ count, resources, verb, onApply, onClear }: BulkActionBarProps) {
+export function BulkActionBar({ count, resources, verb, onApply, onClear }: Readonly<BulkActionBarProps>) {
   const [resourceId, setResourceId] = useState<string>(resources[0]?.id ?? '')
   const [decision, setDecision] = useState<Decision>('narrow')
 

--- a/dashboard/src/features/capability/CapabilityFilterBar.tsx
+++ b/dashboard/src/features/capability/CapabilityFilterBar.tsx
@@ -20,7 +20,7 @@ export function CapabilityFilterBar({
   totalAgents,
   visibleAgents,
   agents,
-}: CapabilityFilterBarProps) {
+}: Readonly<CapabilityFilterBarProps>) {
   const frameworks = uniqueSorted(agents.map((a) => a.framework))
   const owners = uniqueSorted(agents.map((a) => a.owner))
   const modes = uniqueSorted(agents.map((a) => a.mode))

--- a/dashboard/src/features/capability/CapabilityMatrixGrid.tsx
+++ b/dashboard/src/features/capability/CapabilityMatrixGrid.tsx
@@ -38,7 +38,7 @@ export function CapabilityMatrixGrid({
   selectedIds,
   onToggleSelect,
   onToggleSelectAll,
-}: CapabilityMatrixGridProps) {
+}: Readonly<CapabilityMatrixGridProps>) {
   const selectable = Boolean(selectedIds && onToggleSelect)
   const allSelected =
     selectable && agents.length > 0 && agents.every((a) => selectedIds?.has(a.id))
@@ -130,7 +130,7 @@ function RowGroup({
   onCellClick,
   selected,
   onToggleSelect,
-}: RowGroupProps) {
+}: Readonly<RowGroupProps>) {
   return (
     <>
       <div

--- a/dashboard/src/features/capability/CellInspectDrawer.tsx
+++ b/dashboard/src/features/capability/CellInspectDrawer.tsx
@@ -32,7 +32,7 @@ function callsFor(
   return sampleCalls.filter((c) => c.agent === agent.id && c.verb === verb).slice(0, 5)
 }
 
-export function CellInspectDrawer({ cell, policies, sampleCalls, onClose }: CellInspectDrawerProps) {
+export function CellInspectDrawer({ cell, policies, sampleCalls, onClose }: Readonly<CellInspectDrawerProps>) {
   useEffect(() => {
     if (!cell) return
     const onKey = (e: KeyboardEvent) => {

--- a/dashboard/src/features/capability/PerAgentTab.tsx
+++ b/dashboard/src/features/capability/PerAgentTab.tsx
@@ -18,7 +18,7 @@ export function PerAgentTab({
   selectedAgentId,
   onSelectAgent,
   onCellClick,
-}: PerAgentTabProps) {
+}: Readonly<PerAgentTabProps>) {
   const selected = useMemo(
     () => agents.find((a) => a.id === selectedAgentId) ?? agents[0],
     [agents, selectedAgentId],

--- a/dashboard/src/features/capability/PerResourceTab.tsx
+++ b/dashboard/src/features/capability/PerResourceTab.tsx
@@ -26,7 +26,7 @@ export function PerResourceTab({
   selectedResourceId,
   onSelectResource,
   onCellClick,
-}: PerResourceTabProps) {
+}: Readonly<PerResourceTabProps>) {
   const selected = useMemo(
     () => resources.find((r) => r.id === selectedResourceId) ?? resources[0],
     [resources, selectedResourceId],

--- a/dashboard/src/features/iam/AccessLogFilterBar.tsx
+++ b/dashboard/src/features/iam/AccessLogFilterBar.tsx
@@ -42,7 +42,7 @@ export function AccessLogFilterBar({
   identities,
   value,
   onChange,
-}: AccessLogFilterBarProps) {
+}: Readonly<AccessLogFilterBarProps>) {
   const currentTimeKind = readTimeRangeKind(value.timeRange)
   const isCustom = value.timeRange?.kind === 'custom'
 

--- a/dashboard/src/features/iam/AgentPermissionsPanel.tsx
+++ b/dashboard/src/features/iam/AgentPermissionsPanel.tsx
@@ -21,7 +21,7 @@ export interface AgentPermissionsPanelProps {
   onClose: () => void
 }
 
-export function AgentPermissionsPanel({ agent, onClose }: AgentPermissionsPanelProps) {
+export function AgentPermissionsPanel({ agent, onClose }: Readonly<AgentPermissionsPanelProps>) {
   const { data, isLoading, isError } = useAgentPermissionsQuery(agent?.id ?? null)
 
   const grouped = useMemo(

--- a/dashboard/src/features/iam/AgentRegistryList.tsx
+++ b/dashboard/src/features/iam/AgentRegistryList.tsx
@@ -9,7 +9,7 @@ const STATUS_CLASS: Record<AgentStatus, string> = {
   degraded: 'iam-agent-status--degraded',
 }
 
-function StatusChip({ status }: { status: AgentStatus }) {
+function StatusChip({ status }: Readonly<{ status: AgentStatus }>) {
   return <span className={`iam-agent-status ${STATUS_CLASS[status]}`}>{status}</span>
 }
 
@@ -25,7 +25,7 @@ export interface AgentRegistryListProps {
   onSelect: (agent: Agent) => void
 }
 
-export function AgentRegistryList({ selectedAgentId, onSelect }: AgentRegistryListProps) {
+export function AgentRegistryList({ selectedAgentId, onSelect }: Readonly<AgentRegistryListProps>) {
   const { data, isLoading, isError, refetch } = useAgentsQuery()
 
   if (isError) {

--- a/dashboard/src/features/iam/ApiKeyList.test.tsx
+++ b/dashboard/src/features/iam/ApiKeyList.test.tsx
@@ -12,7 +12,7 @@ import type { ApiKey } from './types'
 // the seeded 3-row fixture, so these tests render against the same shape
 // the gateway produces without needing to mock the openapi-fetch client.
 
-function Wrapper({ children }: { children: React.ReactNode }) {
+function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return (
     <QueryClientProvider client={client}>

--- a/dashboard/src/features/iam/ApiKeyList.tsx
+++ b/dashboard/src/features/iam/ApiKeyList.tsx
@@ -16,11 +16,11 @@ function formatDate(value: string | null): string {
   return d.toISOString().slice(0, 16).replace('T', ' ')
 }
 
-function ConfirmRevoke({ keyRecord, onCancel, onConfirm }: {
+function ConfirmRevoke({ keyRecord, onCancel, onConfirm }: Readonly<{
   keyRecord: ApiKey
   onCancel: () => void
   onConfirm: () => void
-}) {
+}>) {
   return (
     <div className="iam-dialog__backdrop" role="dialog" aria-modal="true" data-testid="confirm-revoke-key">
       <div className="iam-dialog">
@@ -46,12 +46,12 @@ function ConfirmRevoke({ keyRecord, onCancel, onConfirm }: {
   )
 }
 
-function ConfirmRotate({ keyRecord, onCancel, onConfirm, isPending }: {
+function ConfirmRotate({ keyRecord, onCancel, onConfirm, isPending }: Readonly<{
   keyRecord: ApiKey
   onCancel: () => void
   onConfirm: () => void
   isPending: boolean
-}) {
+}>) {
   return (
     <div className="iam-dialog__backdrop" role="dialog" aria-modal="true" data-testid="confirm-rotate-key">
       <div className="iam-dialog">

--- a/dashboard/src/features/iam/ConfirmDestroyUnseenKey.tsx
+++ b/dashboard/src/features/iam/ConfirmDestroyUnseenKey.tsx
@@ -9,7 +9,7 @@ export interface ConfirmDestroyUnseenKeyProps {
  * without the operator copying it. Shown when the operator attempts
  * to close the RevealOnceModal before pressing Copy.
  */
-export function ConfirmDestroyUnseenKey({ open, onKeepShowing, onDiscardSecret }: ConfirmDestroyUnseenKeyProps) {
+export function ConfirmDestroyUnseenKey({ open, onKeepShowing, onDiscardSecret }: Readonly<ConfirmDestroyUnseenKeyProps>) {
   if (!open) return null
   return (
     <div className="iam-dialog__backdrop" role="dialog" aria-modal="true" data-testid="confirm-destroy-unseen-key">

--- a/dashboard/src/features/iam/ConfirmRoleChangeModal.tsx
+++ b/dashboard/src/features/iam/ConfirmRoleChangeModal.tsx
@@ -18,7 +18,7 @@ export function ConfirmRoleChangeModal({
   danger,
   onCancel,
   onConfirm,
-}: ConfirmRoleChangeModalProps) {
+}: Readonly<ConfirmRoleChangeModalProps>) {
   // AAASM-1400 — `danger` may be null for safe changes; the modal still
   // renders, just with a neutral confirmation message instead of the
   // danger-tinted warning. Only `open`, `member`, and `nextRole` gate

--- a/dashboard/src/features/iam/GenerateKeyDialog.tsx
+++ b/dashboard/src/features/iam/GenerateKeyDialog.tsx
@@ -8,12 +8,12 @@ export interface GenerateKeyDialogProps {
   isSubmitting?: boolean
 }
 
-export function GenerateKeyDialog(props: GenerateKeyDialogProps) {
+export function GenerateKeyDialog(props: Readonly<GenerateKeyDialogProps>) {
   if (!props.open) return null
   return <GenerateKeyDialogBody {...props} />
 }
 
-function GenerateKeyDialogBody({ onClose, onSubmit, isSubmitting }: GenerateKeyDialogProps) {
+function GenerateKeyDialogBody({ onClose, onSubmit, isSubmitting }: Readonly<GenerateKeyDialogProps>) {
   const [label, setLabel] = useState('')
   const [scopes, setScopes] = useState<ApiKeyScope[]>([])
   const [touched, setTouched] = useState(false)

--- a/dashboard/src/features/iam/IdentityDetailCard.tsx
+++ b/dashboard/src/features/iam/IdentityDetailCard.tsx
@@ -28,7 +28,7 @@ function formatTimestamp(value: string): string {
  * Pairs with `<ServiceIdentitiesPanel>`'s 2-column layout — list on the
  * left, this card on the right — mirroring `<RolesPermissionsPanel>`.
  */
-export function IdentityDetailCard({ identity, onClose }: IdentityDetailCardProps) {
+export function IdentityDetailCard({ identity, onClose }: Readonly<IdentityDetailCardProps>) {
   return (
     <aside
       className="iam-identity-detail-card"

--- a/dashboard/src/features/iam/InviteMemberDialog.tsx
+++ b/dashboard/src/features/iam/InviteMemberDialog.tsx
@@ -10,7 +10,7 @@ export interface InviteMemberDialogProps {
   isSubmitting?: boolean
 }
 
-export function InviteMemberDialog({ open, onClose, onSubmit, isSubmitting }: InviteMemberDialogProps) {
+export function InviteMemberDialog({ open, onClose, onSubmit, isSubmitting }: Readonly<InviteMemberDialogProps>) {
   if (!open) return null
   return (
     <InviteMemberDialogBody
@@ -21,7 +21,7 @@ export function InviteMemberDialog({ open, onClose, onSubmit, isSubmitting }: In
   )
 }
 
-function InviteMemberDialogBody({ onClose, onSubmit, isSubmitting }: Omit<InviteMemberDialogProps, 'open'>) {
+function InviteMemberDialogBody({ onClose, onSubmit, isSubmitting }: Readonly<Omit<InviteMemberDialogProps, 'open'>>) {
   const [email, setEmail] = useState('')
   const [role, setRole] = useState<Role>('Member')
   const [touched, setTouched] = useState(false)

--- a/dashboard/src/features/iam/LockedFeatureCard.tsx
+++ b/dashboard/src/features/iam/LockedFeatureCard.tsx
@@ -9,7 +9,7 @@ export interface LockedFeatureCardProps {
   testId?: string
 }
 
-export function LockedFeatureCard({ title, body, cta, testId = 'locked-feature-card' }: LockedFeatureCardProps) {
+export function LockedFeatureCard({ title, body, cta, testId = 'locked-feature-card' }: Readonly<LockedFeatureCardProps>) {
   return (
     <div className="iam-locked-card" data-testid={testId} role="region" aria-label={title}>
       <div className="iam-locked-card__lock-badge" aria-hidden="true">🔒</div>

--- a/dashboard/src/features/iam/MemberList.tsx
+++ b/dashboard/src/features/iam/MemberList.tsx
@@ -11,16 +11,16 @@ const ROLE_BADGE_TONE: Record<Role, string> = {
   Viewer: 'iam-role-badge--viewer',
 }
 
-function Avatar({ name }: { name: string }) {
+function Avatar({ name }: Readonly<{ name: string }>) {
   const initial = name.trim().charAt(0).toUpperCase() || '?'
   return <div className="iam-avatar" aria-hidden="true">{initial}</div>
 }
 
-function RoleBadge({ role }: { role: Role }) {
+function RoleBadge({ role }: Readonly<{ role: Role }>) {
   return <span className={`iam-role-badge ${ROLE_BADGE_TONE[role]}`}>{role}</span>
 }
 
-function StatusCell({ status }: { status: Member['status'] }) {
+function StatusCell({ status }: Readonly<{ status: Member['status'] }>) {
   return <span className={`iam-status iam-status--${status}`}>{status}</span>
 }
 

--- a/dashboard/src/features/iam/RevealOnceModal.tsx
+++ b/dashboard/src/features/iam/RevealOnceModal.tsx
@@ -24,7 +24,7 @@ export function RevealOnceModal({
   onCopied,
   onClose,
   onAttemptCloseBeforeCopy,
-}: RevealOnceModalProps) {
+}: Readonly<RevealOnceModalProps>) {
   const { toast } = useToast()
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 

--- a/dashboard/src/features/iam/RoleSelect.tsx
+++ b/dashboard/src/features/iam/RoleSelect.tsx
@@ -7,7 +7,7 @@ export interface RoleSelectProps {
   onBeforeChange?: (member: Member, next: Role) => boolean | Promise<boolean>
 }
 
-export function RoleSelect({ member, onBeforeChange }: RoleSelectProps) {
+export function RoleSelect({ member, onBeforeChange }: Readonly<RoleSelectProps>) {
   const { mutate, isPending } = useUpdateMemberRoleMutation()
   const { toast } = useToast()
 

--- a/dashboard/src/features/liveOps/ApprovalPool.tsx
+++ b/dashboard/src/features/liveOps/ApprovalPool.tsx
@@ -15,7 +15,7 @@ interface ApprovalPoolProps {
  * Returns `null` when the pool is empty so the host zone stays
  * uncluttered (per ticket: no zero-state inside this component).
  */
-export function ApprovalPool({ ops }: ApprovalPoolProps) {
+export function ApprovalPool({ ops }: Readonly<ApprovalPoolProps>) {
   const pending = ops.filter((op) => op.status === 'pending')
   if (pending.length === 0) return null
 

--- a/dashboard/src/features/liveOps/AutoScrollToggle.stories.tsx
+++ b/dashboard/src/features/liveOps/AutoScrollToggle.stories.tsx
@@ -5,10 +5,10 @@ import { AutoScrollToggle } from './AutoScrollToggle'
 function Interactive({
   initialEnabled,
   initialPending,
-}: {
+}: Readonly<{
   initialEnabled: boolean
   initialPending: number
-}) {
+}>) {
   const [enabled, setEnabled] = useState(initialEnabled)
   const [pending, setPending] = useState(initialPending)
   return (

--- a/dashboard/src/features/liveOps/AutoScrollToggle.test.tsx
+++ b/dashboard/src/features/liveOps/AutoScrollToggle.test.tsx
@@ -4,12 +4,12 @@ import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import { AutoScrollToggle } from './AutoScrollToggle'
 
-function StaticHarness(props: {
+function StaticHarness(props: Readonly<{
   enabled: boolean
   pendingCount: number
   onEnabledChange?: (v: boolean) => void
   onFlushPending?: () => void
-}) {
+}>) {
   return (
     <AutoScrollToggle
       enabled={props.enabled}
@@ -23,10 +23,10 @@ function StaticHarness(props: {
 function ControlledHarness({
   initialEnabled,
   initialPending,
-}: {
+}: Readonly<{
   initialEnabled: boolean
   initialPending: number
-}) {
+}>) {
   const [enabled, setEnabled] = useState(initialEnabled)
   const [pending, setPending] = useState(initialPending)
   return (

--- a/dashboard/src/features/liveOps/AutoScrollToggle.tsx
+++ b/dashboard/src/features/liveOps/AutoScrollToggle.tsx
@@ -27,7 +27,7 @@ export function AutoScrollToggle({
   onEnabledChange,
   pendingCount,
   onFlushPending,
-}: AutoScrollToggleProps) {
+}: Readonly<AutoScrollToggleProps>) {
   const inputId = useId()
   const showPending = !enabled && pendingCount > 0
 

--- a/dashboard/src/features/liveOps/FilterBar.stories.tsx
+++ b/dashboard/src/features/liveOps/FilterBar.stories.tsx
@@ -15,7 +15,7 @@ const TEAMS: FilterOption[] = [
   { id: 'data', label: 'Data' },
 ]
 
-function Interactive({ initial }: { initial: LiveOpsFilters }) {
+function Interactive({ initial }: Readonly<{ initial: LiveOpsFilters }>) {
   const [filters, setFilters] = useState<LiveOpsFilters>(initial)
   return (
     <FilterBar

--- a/dashboard/src/features/liveOps/FilterBar.test.tsx
+++ b/dashboard/src/features/liveOps/FilterBar.test.tsx
@@ -14,10 +14,10 @@ const TEAMS: FilterOption[] = [{ id: 'support' }, { id: 'devops' }]
 function ControlledHarness({
   initial = EMPTY_FILTERS,
   onChange,
-}: {
+}: Readonly<{
   initial?: LiveOpsFilters
   onChange?: (next: LiveOpsFilters) => void
-}) {
+}>) {
   const [filters, setFilters] = useState<LiveOpsFilters>(initial)
   return (
     <FilterBar

--- a/dashboard/src/features/liveOps/FilterBar.tsx
+++ b/dashboard/src/features/liveOps/FilterBar.tsx
@@ -46,7 +46,7 @@ export function FilterBar({
   agentOptions,
   teamOptions,
   opTypeOptions = DEFAULT_OP_TYPES,
-}: FilterBarProps) {
+}: Readonly<FilterBarProps>) {
   const agentId = useId()
   const teamId = useId()
   const opTypeId = useId()

--- a/dashboard/src/features/liveOps/OperationRow.tsx
+++ b/dashboard/src/features/liveOps/OperationRow.tsx
@@ -62,7 +62,7 @@ export function OperationRow({
   onPause,
   onResume,
   onTerminate,
-}: OperationRowProps) {
+}: Readonly<OperationRowProps>) {
   const [expanded, setExpanded] = useState(defaultExpanded)
   const treeId = useId()
   const canExpand = (op.callStack?.length ?? 0) > 0
@@ -125,7 +125,7 @@ export function OperationRow({
   )
 }
 
-function CallStackTree({ id, nodes }: { id: string; nodes: CallStackNode[] }) {
+function CallStackTree({ id, nodes }: Readonly<{ id: string; nodes: CallStackNode[] }>) {
   return (
     <ul
       id={id}
@@ -140,7 +140,7 @@ function CallStackTree({ id, nodes }: { id: string; nodes: CallStackNode[] }) {
   )
 }
 
-function CallStackTreeNode({ node }: { node: CallStackNode }) {
+function CallStackTreeNode({ node }: Readonly<{ node: CallStackNode }>) {
   return (
     <li className="op-row__tree-node" role="treeitem">
       <div className="op-row__tree-row">

--- a/dashboard/src/features/liveOps/PipelineCanvas.tsx
+++ b/dashboard/src/features/liveOps/PipelineCanvas.tsx
@@ -167,7 +167,7 @@ export function PipelineCanvas({
   paused = false,
   intensity = 2,
   onCounters,
-}: PipelineCanvasProps) {
+}: Readonly<PipelineCanvasProps>) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const pausedRef = useRef(paused)
   const intensityRef = useRef(intensity)

--- a/dashboard/src/features/liveOps/RowActionMenu.tsx
+++ b/dashboard/src/features/liveOps/RowActionMenu.tsx
@@ -27,7 +27,7 @@ export function RowActionMenu({
   onPause,
   onResume,
   onTerminate,
-}: RowActionMenuProps) {
+}: Readonly<RowActionMenuProps>) {
   const [open, setOpen] = useState(false)
   const [confirmingTerminate, setConfirmingTerminate] = useState(false)
   const menuId = useId()

--- a/dashboard/src/features/onboarding/OnboardingWizard.tsx
+++ b/dashboard/src/features/onboarding/OnboardingWizard.tsx
@@ -30,7 +30,7 @@ export function OnboardingWizard({
   onFinish,
   onSkipAll,
   onPersist,
-}: OnboardingWizardProps) {
+}: Readonly<OnboardingWizardProps>) {
   const [current, setCurrent] = useState<StepId>(initialStep)
   const [state, setState] = useState<WizardState>(initialState)
 

--- a/dashboard/src/features/onboarding/Stepper.tsx
+++ b/dashboard/src/features/onboarding/Stepper.tsx
@@ -8,7 +8,7 @@ export interface StepperProps {
   onJump?: (step: StepId) => void
 }
 
-export function Stepper({ currentStep, onJump }: StepperProps) {
+export function Stepper({ currentStep, onJump }: Readonly<StepperProps>) {
   const ci = stepIndex(currentStep)
   return (
     <nav

--- a/dashboard/src/features/onboarding/steps/Step1Framework.tsx
+++ b/dashboard/src/features/onboarding/steps/Step1Framework.tsx
@@ -7,7 +7,7 @@ export interface Step1FrameworkProps {
   onChange: (framework: FrameworkId) => void
 }
 
-export function Step1Framework({ state, onChange }: Step1FrameworkProps) {
+export function Step1Framework({ state, onChange }: Readonly<Step1FrameworkProps>) {
   return (
     <section data-testid="onboarding-step-framework">
       <h2 className="onb-body-title">Pick the framework you&apos;re enrolling.</h2>

--- a/dashboard/src/features/onboarding/steps/Step2InstallSdk.tsx
+++ b/dashboard/src/features/onboarding/steps/Step2InstallSdk.tsx
@@ -30,7 +30,7 @@ const VERIFIED_LINES: Line[] = [
   { kind: 'ok', text: '✓ verified · ready to enroll' },
 ]
 
-export function Step2InstallSdk({ state, onVerified }: Step2InstallSdkProps) {
+export function Step2InstallSdk({ state, onVerified }: Readonly<Step2InstallSdkProps>) {
   const [pkg, setPkg] = useState<PackageManager>('pip')
   const [copied, setCopied] = useState(false)
   const [phase, setPhase] = useState<Phase>(state.installVerified ? 'verified' : 'idle')

--- a/dashboard/src/features/onboarding/steps/Step3IssueIdentity.tsx
+++ b/dashboard/src/features/onboarding/steps/Step3IssueIdentity.tsx
@@ -30,7 +30,7 @@ function formatFingerprint(): string {
   return groups.join(':').toUpperCase()
 }
 
-export function Step3IssueIdentity({ state, onIssued }: Step3IssueIdentityProps) {
+export function Step3IssueIdentity({ state, onIssued }: Readonly<Step3IssueIdentityProps>) {
   const [phase, setPhase] = useState<Phase>(state.identity ? 'done' : 'idle')
   const id = state.identity
 

--- a/dashboard/src/features/onboarding/steps/Step4BaselinePolicy.tsx
+++ b/dashboard/src/features/onboarding/steps/Step4BaselinePolicy.tsx
@@ -8,7 +8,7 @@ export interface Step4BaselinePolicyProps {
   onChange: (preset: PolicyPresetId) => void
 }
 
-export function Step4BaselinePolicy({ state, onChange }: Step4BaselinePolicyProps) {
+export function Step4BaselinePolicy({ state, onChange }: Readonly<Step4BaselinePolicyProps>) {
   // Sensible default — the recommended preset is "read-only" per the hi-fi.
   useEffect(() => {
     if (!state.policyPreset) onChange('read-only')

--- a/dashboard/src/features/onboarding/steps/Step5EnrollAgent.tsx
+++ b/dashboard/src/features/onboarding/steps/Step5EnrollAgent.tsx
@@ -22,7 +22,7 @@ const COMPLETED_PINGS: Ping[] = [
   { id: 1, time: '14:02:11', action: 'phone-home (heartbeat)', tag: 'identity-verified' },
 ]
 
-export function Step5EnrollAgent({ state, onEnrolled }: Step5EnrollAgentProps) {
+export function Step5EnrollAgent({ state, onEnrolled }: Readonly<Step5EnrollAgentProps>) {
   const [phase, setPhase] = useState<Phase>(state.enrolled ? 'live' : 'idle')
   const [pings, setPings] = useState<Ping[]>(state.enrolled ? COMPLETED_PINGS : [])
 

--- a/dashboard/src/features/policies/SandboxEnableLiveDialog.test.tsx
+++ b/dashboard/src/features/policies/SandboxEnableLiveDialog.test.tsx
@@ -23,7 +23,7 @@ const POLICY_B: Policy = {
 
 // Simple wrapper — the component portals into document.body so no router
 // or QueryClient is needed.
-function Wrapper({ children }: { children: ReactNode }) {
+function Wrapper({ children }: Readonly<{ children: ReactNode }>) {
   return <>{children}</>
 }
 

--- a/dashboard/src/features/policies/editor/ActionPicker.tsx
+++ b/dashboard/src/features/policies/editor/ActionPicker.tsx
@@ -18,7 +18,7 @@ function variantClass(id: ActionKind, active: boolean): string {
  * approval / scrub→allow / deny. The hint text is exposed as the button's
  * `title` so it appears as a native tooltip on hover.
  */
-export function ActionPicker({ value, onChange }: ActionPickerProps) {
+export function ActionPicker({ value, onChange }: Readonly<ActionPickerProps>) {
   return (
     <div
       className="editor__action-picker"

--- a/dashboard/src/features/policies/editor/ConditionList.tsx
+++ b/dashboard/src/features/policies/editor/ConditionList.tsx
@@ -11,7 +11,7 @@ interface ConditionListProps {
  * doesn't model them, see AAASM-1281 scope decision). Each row is a select
  * pointing at the next preset; rows are separated by an "AND" label.
  */
-export function ConditionList({ value, onChange }: ConditionListProps) {
+export function ConditionList({ value, onChange }: Readonly<ConditionListProps>) {
   const handleChangeAt = (idx: number, next: ConditionPreset) => {
     onChange(value.map((c, i) => (i === idx ? next : c)))
   }

--- a/dashboard/src/features/policies/editor/PolicyEditorOverlay.test.tsx
+++ b/dashboard/src/features/policies/editor/PolicyEditorOverlay.test.tsx
@@ -19,7 +19,7 @@ function makeDraft(patch: Partial<PolicyDraft> = {}): PolicyDraft {
   }
 }
 
-function Wrapper({ children }: { children: ReactNode }) {
+function Wrapper({ children }: Readonly<{ children: ReactNode }>) {
   return <ToastProvider>{children}</ToastProvider>
 }
 

--- a/dashboard/src/features/policies/editor/PolicyEditorOverlay.tsx
+++ b/dashboard/src/features/policies/editor/PolicyEditorOverlay.tsx
@@ -39,7 +39,7 @@ export function PolicyEditorOverlay({
   onClose,
   onDirtyChange,
   isSaving = false,
-}: PolicyEditorOverlayProps) {
+}: Readonly<PolicyEditorOverlayProps>) {
   const {
     draft,
     isDirty,

--- a/dashboard/src/features/policies/editor/RuleCard.tsx
+++ b/dashboard/src/features/policies/editor/RuleCard.tsx
@@ -18,7 +18,7 @@ function toggleVerb(current: VerbOption[], verb: VerbOption): VerbOption[] {
   return [...current, verb]
 }
 
-export function RuleCard({ index, rule, onChange, onDuplicate, onRemove }: RuleCardProps) {
+export function RuleCard({ index, rule, onChange, onDuplicate, onRemove }: Readonly<RuleCardProps>) {
   const isDeny = rule.action === 'deny'
 
   const handleActionChange = (next: ActionKind) => {

--- a/dashboard/src/features/policies/editor/ScopeRow.tsx
+++ b/dashboard/src/features/policies/editor/ScopeRow.tsx
@@ -11,7 +11,7 @@ interface ScopeRowProps {
  * decorative — the API has no env field. Wiring them lives behind a future
  * backend extension.
  */
-export function ScopeRow({ scope, onScopeChange }: ScopeRowProps) {
+export function ScopeRow({ scope, onScopeChange }: Readonly<ScopeRowProps>) {
   return (
     <section className="editor__section" data-testid="editor-scope">
       <header className="editor__section-head">

--- a/dashboard/src/features/policies/editor/SubClauses.tsx
+++ b/dashboard/src/features/policies/editor/SubClauses.tsx
@@ -31,12 +31,12 @@ function ChipList({
   onChange,
   placeholder,
   testid,
-}: {
+}: Readonly<{
   values: string[]
   onChange: (next: string[]) => void
   placeholder: string
   testid: string
-}) {
+}>) {
   const [draft, setDraft] = useState('')
 
   const handleAdd = (e: FormEvent<HTMLFormElement>) => {
@@ -92,11 +92,11 @@ function NarrowSubClause({
   resource,
   values,
   onChange,
-}: {
+}: Readonly<{
   resource: ResourceOption
   values: string[]
   onChange: (next: string[]) => void
-}) {
+}>) {
   return (
     <div className="editor__sub-clause" data-testid="editor-narrow">
       <div className="editor__sub-clause-row">
@@ -118,10 +118,10 @@ function NarrowSubClause({
 function ApprovalSubClause({
   value,
   onChange,
-}: {
+}: Readonly<{
   value: ApproverConfig
   onChange: (next: ApproverConfig) => void
-}) {
+}>) {
   return (
     <div className="editor__sub-clause" data-testid="editor-approver">
       <div className="editor__sub-clause-row">
@@ -174,10 +174,10 @@ function ApprovalSubClause({
 function ScrubSubClause({
   value,
   onChange,
-}: {
+}: Readonly<{
   value: string[]
   onChange: (next: string[]) => void
-}) {
+}>) {
   const toggle = (preset: string) => {
     if (value.includes(preset)) {
       onChange(value.filter((v) => v !== preset))
@@ -219,10 +219,10 @@ function ScrubSubClause({
 function ExceptionsSubClause({
   values,
   onChange,
-}: {
+}: Readonly<{
   values: string[]
   onChange: (next: string[]) => void
-}) {
+}>) {
   return (
     <div className="editor__sub-clause" data-testid="editor-except">
       <div className="editor__sub-clause-row">
@@ -252,7 +252,7 @@ function ExceptionsSubClause({
  *   - scrub-then-allow: scrub tags + except list
  *   - deny:             except list only
  */
-export function SubClauses({ rule, onChange }: SubClausesProps) {
+export function SubClauses({ rule, onChange }: Readonly<SubClausesProps>) {
   const action: ActionKind = rule.action
 
   return (

--- a/dashboard/src/features/policies/editor/ValidationPanel.tsx
+++ b/dashboard/src/features/policies/editor/ValidationPanel.tsx
@@ -16,7 +16,7 @@ const BADGE_GLYPH: Record<ValidationSeverity, string> = {
  * warnings) and per-issue rows. When no issues are present, shows a single
  * "policy is valid · ready to simulate" success row.
  */
-export function ValidationPanel({ issues }: ValidationPanelProps) {
+export function ValidationPanel({ issues }: Readonly<ValidationPanelProps>) {
   const { errors, warns } = countBySeverity(issues)
 
   return (

--- a/dashboard/src/features/policies/editor/WindowSeverityRow.tsx
+++ b/dashboard/src/features/policies/editor/WindowSeverityRow.tsx
@@ -16,7 +16,7 @@ export function WindowSeverityRow({
   severity,
   onWindowChange,
   onSeverityChange,
-}: WindowSeverityRowProps) {
+}: Readonly<WindowSeverityRowProps>) {
   return (
     <div className="editor__clause" data-testid="editor-window-severity">
       <span className="editor__clause-label">window</span>

--- a/dashboard/src/features/scrub/PatternDetail.tsx
+++ b/dashboard/src/features/scrub/PatternDetail.tsx
@@ -11,7 +11,7 @@ export function PatternDetail({
   pattern,
   collapsed,
   onToggleCollapsed,
-}: PatternDetailProps) {
+}: Readonly<PatternDetailProps>) {
   return (
     <section
       className="scrub-detail"

--- a/dashboard/src/features/scrub/PatternsLibrary.tsx
+++ b/dashboard/src/features/scrub/PatternsLibrary.tsx
@@ -16,7 +16,7 @@ export function PatternsLibrary({
   onSelect,
   onToggle,
   matchCounts,
-}: PatternsLibraryProps) {
+}: Readonly<PatternsLibraryProps>) {
   const [search, setSearch] = useState('')
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase()

--- a/dashboard/src/features/scrub/PayloadDiff.tsx
+++ b/dashboard/src/features/scrub/PayloadDiff.tsx
@@ -19,7 +19,7 @@ export function PayloadDiff({
   tokens,
   patterns,
   matchCounts,
-}: PayloadDiffProps) {
+}: Readonly<PayloadDiffProps>) {
   const matchCount = tokens.reduce(
     (n, t) => (t.kind === 'match' ? n + 1 : n),
     0,

--- a/dashboard/src/pages/AgentDetailPage.tsx
+++ b/dashboard/src/pages/AgentDetailPage.tsx
@@ -33,7 +33,7 @@ function trustSummary(score: number): string {
   return 'good standing'
 }
 
-function TrustGauge({ score }: { score: number | null }) {
+function TrustGauge({ score }: Readonly<{ score: number | null }>) {
   if (score === null) {
     return (
       <div className="ad-identity__trust">
@@ -68,7 +68,7 @@ function TrustGauge({ score }: { score: number | null }) {
   )
 }
 
-function IdentityStrip({ agent }: { agent: Agent }) {
+function IdentityStrip({ agent }: Readonly<{ agent: Agent }>) {
   const fleetAgent = useMemo(() => toFleetAgent(agent), [agent])
   const ownerSlug = fleetAgent.owner ?? 'agent-assembly'
 
@@ -133,7 +133,7 @@ const TABS: ReadonlyArray<{ id: AgentDetailTab; label: string }> = [
   { id: 'config',     label: 'Config' },
 ]
 
-function TabEmpty({ title, body }: { title: string; body: string }) {
+function TabEmpty({ title, body }: Readonly<{ title: string; body: string }>) {
   return (
     <div className="ad-tab-empty" data-testid={`ad-tab-empty-${title.toLowerCase()}`}>
       <p className="ad-tab-empty__title">{title}</p>
@@ -149,7 +149,7 @@ interface MiniBarProps {
   tone: 'ok' | 'warn' | 'deny' | 'info'
 }
 
-function MiniBar({ label, value, max, tone }: MiniBarProps) {
+function MiniBar({ label, value, max, tone }: Readonly<MiniBarProps>) {
   const pct = max === 0 ? 0 : Math.min(100, Math.max(0, (value / max) * 100))
   return (
     <div className="ad-minibar" data-testid={`ad-minibar-${tone}`}>
@@ -169,7 +169,7 @@ interface PostureSummaryProps {
   agent: Agent
 }
 
-function PostureSummary({ agent }: PostureSummaryProps) {
+function PostureSummary({ agent }: Readonly<PostureSummaryProps>) {
   // The dashboard has not yet wired a per-decision breakdown endpoint
   // (cf. AAASM-1280 capability matrix). Until that lands, the panel
   // derives an approximate decisions-this-session view from the two

--- a/dashboard/src/pages/ApprovalsPage.test.tsx
+++ b/dashboard/src/pages/ApprovalsPage.test.tsx
@@ -28,7 +28,7 @@ function mockMutation<D, V>(p: Partial<UseMutationResult<D, Error, V>>): UseMuta
   return p as unknown as UseMutationResult<D, Error, V>
 }
 
-function Wrapper({ children }: { children: React.ReactNode }) {
+function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return (
     <QueryClientProvider client={client}>

--- a/dashboard/src/pages/ApprovalsPage.tsx
+++ b/dashboard/src/pages/ApprovalsPage.tsx
@@ -35,7 +35,7 @@ interface RejectDialogProps {
   onCancel: () => void
 }
 
-function RejectDialog({ count, onConfirm, onCancel }: RejectDialogProps) {
+function RejectDialog({ count, onConfirm, onCancel }: Readonly<RejectDialogProps>) {
   const [reason, setReason] = useState('')
   return (
     <div
@@ -95,12 +95,12 @@ function TabBar({
   pendingCount,
   decidedCount,
   onChange,
-}: {
+}: Readonly<{
   active: 'pending' | 'decided'
   pendingCount: number
   decidedCount: number
   onChange: (t: 'pending' | 'decided') => void
-}) {
+}>) {
   function tabStyle(t: 'pending' | 'decided') {
     return {
       padding: '0.5rem 1rem',

--- a/dashboard/src/pages/ComingSoon.tsx
+++ b/dashboard/src/pages/ComingSoon.tsx
@@ -6,7 +6,7 @@ import { Link, useLocation } from 'react-router-dom'
  * Subtask. Keeps the nav and routing surface complete so users
  * never hit a 404 inside the shell (AAASM-94 AC #5, #6).
  */
-export function ComingSoon({ name }: { name?: string }) {
+export function ComingSoon({ name }: Readonly<{ name?: string }>) {
   const location = useLocation()
   const fromPath = location.pathname.replace(/^\//, '').replace(/-/g, ' ')
   const heading = name ?? (fromPath || 'this page')

--- a/dashboard/src/pages/FleetFilterBar.tsx
+++ b/dashboard/src/pages/FleetFilterBar.tsx
@@ -8,7 +8,7 @@ interface FleetFilterBarProps {
 
 const STATUS_OPTIONS = ['all', 'active', 'idle', 'suspended', 'error'] as const
 
-export function FleetFilterBar({ filters, frameworks, onChange }: FleetFilterBarProps) {
+export function FleetFilterBar({ filters, frameworks, onChange }: Readonly<FleetFilterBarProps>) {
   const frameworkOpts = ['all', ...frameworks]
 
   return (

--- a/dashboard/src/pages/FleetPage.tsx
+++ b/dashboard/src/pages/FleetPage.tsx
@@ -47,7 +47,7 @@ function SkeletonRows() {
   )
 }
 
-function NumericCell({ value }: { value: number | null }) {
+function NumericCell({ value }: Readonly<{ value: number | null }>) {
   return (
     <span className="fleet-table__numeric">
       {value === null ? '—' : value}

--- a/dashboard/src/pages/IdentityPage.tsx
+++ b/dashboard/src/pages/IdentityPage.tsx
@@ -6,7 +6,7 @@ import { AccessLogPanel } from '../features/iam/AccessLogPanel'
 import { IAM_DEFAULT_TAB, IAM_TAB_KEYS, IAM_TAB_LABELS, parseIamTab, type IamTabKey } from '../features/iam/tabs'
 import './IdentityPage.css'
 
-function TabPlaceholder({ tab }: { tab: IamTabKey }) {
+function TabPlaceholder({ tab }: Readonly<{ tab: IamTabKey }>) {
   return (
     <section className="iam-tab-panel" data-testid={`iam-panel-${tab}`}>
       <h2>{IAM_TAB_LABELS[tab]}</h2>
@@ -17,7 +17,7 @@ function TabPlaceholder({ tab }: { tab: IamTabKey }) {
   )
 }
 
-function ActiveTabContent({ tab }: { tab: IamTabKey }) {
+function ActiveTabContent({ tab }: Readonly<{ tab: IamTabKey }>) {
   if (tab === 'members') return <MembersPanel />
   if (tab === 'services') return <ServiceIdentitiesPanel />
   if (tab === 'roles') return <RolesPermissionsPanel />

--- a/dashboard/src/pages/PoliciesPage.test.tsx
+++ b/dashboard/src/pages/PoliciesPage.test.tsx
@@ -17,7 +17,7 @@ function makeClient() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } })
 }
 
-function Wrapper({ children }: { children: ReactNode }) {
+function Wrapper({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <QueryClientProvider client={makeClient()}>
       <ToastProvider>

--- a/dashboard/src/pages/PoliciesPage.tsx
+++ b/dashboard/src/pages/PoliciesPage.tsx
@@ -35,7 +35,7 @@ interface PolicyEditorOverlayContainerProps {
 function PolicyEditorOverlayContainer({
   dirtyRef,
   onRequestClose,
-}: PolicyEditorOverlayContainerProps) {
+}: Readonly<PolicyEditorOverlayContainerProps>) {
   const { props, closeOverlay } = useOverlay('policy-editor')
   const overlayProps = props as unknown as PolicyEditorOverlayProps
   const { toast } = useToast()
@@ -101,7 +101,7 @@ function PolicySkeletonRow() {
   )
 }
 
-function PolicyRow({ policy, onEdit }: { policy: Policy; onEdit: () => void }) {
+function PolicyRow({ policy, onEdit }: Readonly<{ policy: Policy; onEdit: () => void }>) {
   const proposed = !policy.active
   return (
     <li>

--- a/dashboard/src/pages/TeamDetailPage.actions.test.tsx
+++ b/dashboard/src/pages/TeamDetailPage.actions.test.tsx
@@ -21,7 +21,7 @@ function mockMutation<R>(p: { mutate: ReturnType<typeof vi.fn>; isPending: boole
   return p as unknown as R
 }
 
-function Wrapper({ children }: { children: React.ReactNode }) {
+function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return (
     <QueryClientProvider client={client}>

--- a/dashboard/src/pages/TeamDetailPage.stories.tsx
+++ b/dashboard/src/pages/TeamDetailPage.stories.tsx
@@ -33,7 +33,7 @@ interface MockArgs {
   team: TeamTopology
 }
 
-function MockedTeamDetailPage({ team }: MockArgs) {
+function MockedTeamDetailPage({ team }: Readonly<MockArgs>) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } })
   client.setQueryData(['topology', 'team', team.team_id], team)
   client.setQueryData(['costs', 'summary'], COSTS)

--- a/dashboard/src/pages/TeamDetailPage.test.tsx
+++ b/dashboard/src/pages/TeamDetailPage.test.tsx
@@ -17,7 +17,7 @@ function LocationProbe() {
   return <div data-testid="location">{loc.pathname + loc.search}</div>
 }
 
-function Wrapper({ initialEntries, children }: { initialEntries: string[]; children: React.ReactNode }) {
+function Wrapper({ initialEntries, children }: Readonly<{ initialEntries: string[]; children: React.ReactNode }>) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return (
     <QueryClientProvider client={client}>

--- a/dashboard/src/pages/TeamDetailPage.tsx
+++ b/dashboard/src/pages/TeamDetailPage.tsx
@@ -19,7 +19,7 @@ const STATUS_COLOR: Record<string, string> = {
   deregistered: 'var(--text-muted)',
 }
 
-function StatusBadge({ status }: { status: string }) {
+function StatusBadge({ status }: Readonly<{ status: string }>) {
   const color = STATUS_COLOR[status] ?? 'var(--text-muted)'
   return (
     <span
@@ -39,7 +39,7 @@ function StatusBadge({ status }: { status: string }) {
   )
 }
 
-function ShortId({ id }: { id: string }) {
+function ShortId({ id }: Readonly<{ id: string }>) {
   return (
     <code style={{ fontFamily: 'JetBrains Mono, monospace', fontSize: '0.8125rem' }}>
       {id.length > 12 ? `${id.slice(0, 8)}…${id.slice(-4)}` : id}
@@ -47,7 +47,7 @@ function ShortId({ id }: { id: string }) {
   )
 }
 
-function OpenInTopologyButton({ agentId }: { agentId: string }) {
+function OpenInTopologyButton({ agentId }: Readonly<{ agentId: string }>) {
   const lineage = useAgentLineageQuery(agentId)
   const navigate = useNavigate()
   const rootId = lineage.data?.ancestors?.[0]?.id ?? agentId
@@ -63,7 +63,7 @@ function OpenInTopologyButton({ agentId }: { agentId: string }) {
   )
 }
 
-function MemberRow({ member }: { member: AgentNode }) {
+function MemberRow({ member }: Readonly<{ member: AgentNode }>) {
   return (
     <tr data-testid="team-member-row" style={{ borderBottom: '1px solid var(--surface-hover-bg)' }}>
       <td style={{ padding: '0.5rem' }}>
@@ -92,7 +92,7 @@ interface ConfirmDialogProps {
   busy: boolean
 }
 
-function ConfirmDialog({ title, body, confirmLabel, onConfirm, onCancel, busy }: ConfirmDialogProps) {
+function ConfirmDialog({ title, body, confirmLabel, onConfirm, onCancel, busy }: Readonly<ConfirmDialogProps>) {
   return (
     <div
       data-testid="confirm-dialog"
@@ -122,7 +122,7 @@ interface ActionBarProps {
   onError: (msg: string) => void
 }
 
-function ActionBar({ team, onError }: ActionBarProps) {
+function ActionBar({ team, onError }: Readonly<ActionBarProps>) {
   const canManage = useCanManageTeam()
   const suspend = useSuspendTeam()
   const resume = useResumeTeam()

--- a/dashboard/src/pages/TeamsPage.stories.tsx
+++ b/dashboard/src/pages/TeamsPage.stories.tsx
@@ -36,7 +36,7 @@ interface MockArgs {
   teamCount: number
 }
 
-function MockedTeamsPage({ teamCount }: MockArgs) {
+function MockedTeamsPage({ teamCount }: Readonly<MockArgs>) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false, staleTime: Infinity } } })
   client.setQueryData(['topology', 'overview'], makeOverview(teamCount))
   client.setQueryData(['costs', 'summary'], makeCosts(teamCount))

--- a/dashboard/src/pages/TeamsPage.test.tsx
+++ b/dashboard/src/pages/TeamsPage.test.tsx
@@ -12,7 +12,7 @@ function mockQuery<T>(p: Partial<UseQueryResult<T, Error>>): UseQueryResult<T, E
   return p as unknown as UseQueryResult<T, Error>
 }
 
-function Wrapper({ children }: { children: React.ReactNode }) {
+function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return (
     <QueryClientProvider client={client}>

--- a/dashboard/src/pages/TeamsPage.tsx
+++ b/dashboard/src/pages/TeamsPage.tsx
@@ -34,7 +34,7 @@ function sortIndicator(sorted: false | 'asc' | 'desc'): string {
   return ''
 }
 
-function SkeletonRows({ cols }: { cols: number }) {
+function SkeletonRows({ cols }: Readonly<{ cols: number }>) {
   return (
     <>
       {Array.from({ length: 5 }).map((_, i) => (
@@ -57,7 +57,7 @@ function SkeletonRows({ cols }: { cols: number }) {
   )
 }
 
-function BurnCell({ pct }: { pct: number | null }) {
+function BurnCell({ pct }: Readonly<{ pct: number | null }>) {
   if (pct == null) return <span style={{ color: 'var(--text-muted)' }}>—</span>
   const color = burnColor(pct)
   return (


### PR DESCRIPTION
## Description

Clears the `typescript:S6759` ("Mark the props of the React component as read-only") SonarCloud smell across the dashboard. This is the largest smell bucket for `AI-agent-assembly_agent-assembly` (155 occurrences). Each flagged React component's props type annotation is wrapped in `Readonly<...>` at the parameter site — a pure type-level annotation with zero runtime behaviour change. No component logic was modified.

Scope is **dashboard only** (`dashboard/`); no Rust crates were touched (a parallel wave owns the Rust smells).

## Type of Change

- [x] ♻️ Refactoring

## Breaking Changes

- [x] No

Type-only change. `Readonly<T>` is a compile-time wrapper; emitted JS is identical.

## Related Issues

- Related Jira ticket: AAASM-3359 (child of AAASM-3346, Epic AAASM-3345)

## Testing

- [x] No tests required (explain why)

This is a pure type annotation change with no runtime or visual/UX impact, so no design-spec review or screenshot is needed (per the FE type-only-change rule). Full dashboard validation suite was run and is green:

- `pnpm type-check` — pass (`tsc --noEmit`, no errors)
- `pnpm lint` — pass (eslint, `--max-warnings 0`)
- `pnpm test` — pass (143 files, 1262 tests)
- `pnpm build` — pass

`typescript:S6759` occurrences: **155 → 0** (in `dashboard/`).

## Checklist

- [x] Self-review of the diff completed (167 insertions / 167 deletions, all `Readonly<...>` wraps)
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention (grouped by feature area)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
