### PR TITLE
[AAASM-3352] 🐛 (aa-core): Default retention schedule to valid 6-field cron

### DIFF
--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -1054,6 +1054,21 @@ agent:
     }
 
     #[test]
+    fn default_retention_schedule_is_a_valid_six_field_cron() {
+        // The gateway validates `schedule` with the `cron` crate, which
+        // requires the 6-field (seconds-leading) form. A 5-field default
+        // is rejected at startup and silently disables retention, so the
+        // default must always parse as 6 whitespace-separated fields.
+        let schedule = RetentionConfig::default().schedule;
+        assert_eq!(
+            schedule.split_whitespace().count(),
+            6,
+            "default retention schedule {schedule:?} must be a 6-field cron",
+        );
+        assert_eq!(schedule, "0 0 3 * * *");
+    }
+
+    #[test]
     fn apply_env_overrides_storage_matrix() {
         let mut cfg = GatewayConfig::default();
         cfg.apply_env_overrides_with(env(&[

--- a/aa-core/src/config.rs
+++ b/aa-core/src/config.rs
@@ -216,8 +216,8 @@ pub enum ColdAction {
 /// Defaults align with the SOC 2 / ISO 27001 reference window from the
 /// Epic 18 spec: 30 days fully indexed (hot), 90 days
 /// compressed-but-queryable (warm), then `cold_action` decides. The
-/// `schedule` is a UTC cron expression — default `0 3 * * *` runs the
-/// retention sweep at 03:00 UTC daily.
+/// `schedule` is a 6-field UTC cron expression — default `0 0 3 * * *`
+/// runs the retention sweep at 03:00 UTC daily.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[cfg_attr(feature = "serde", serde(default))]
@@ -245,7 +245,7 @@ impl Default for RetentionConfig {
             warm_days: 90,
             cold_action: ColdAction::Drop,
             archive_url: None,
-            schedule: String::from("0 3 * * *"),
+            schedule: String::from("0 0 3 * * *"),
             dry_run: false,
         }
     }
@@ -1049,7 +1049,7 @@ agent:
         assert_eq!(s.retention.warm_days, 90);
         assert_eq!(s.retention.cold_action, ColdAction::Drop);
         assert!(s.retention.archive_url.is_none());
-        assert_eq!(s.retention.schedule, "0 3 * * *");
+        assert_eq!(s.retention.schedule, "0 0 3 * * *");
         assert!(!s.retention.dry_run);
     }
 


### PR DESCRIPTION
## Description

The default audit/storage retention `schedule` in `aa-core` was the 5-field
cron `"0 3 * * *"`. The gateway's retention validator
(`aa-gateway/src/storage/retention_config.rs`) parses the schedule with the
`cron` crate, which requires the **6-field** (seconds-leading) form. As a
result the default schedule failed validation at startup and retention was
silently disabled on every boot.

This PR changes the `aa-core` default to the equivalent 6-field cron
`"0 0 3 * * *"` (03:00 UTC daily), so the out-of-the-box default validates
and retention runs as documented.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

The default cron is functionally equivalent (daily 03:00 UTC); only the
field-count form changes so it parses correctly.

## Related Issues

- Related Jira ticket: AAASM-3352
- QA evidence: `agent-assembly-integration-tests/verification-reports/base-branch-2026-06/`

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

How to verify:

```
cd agent-assembly
export RUSTUP_TOOLCHAIN=stable
cargo build -p aa-core
cargo nextest run -p aa-core
```

- Updated the existing `GatewayConfig::default` storage assertion to the new
  `"0 0 3 * * *"` value.
- Added `default_retention_schedule_is_a_valid_six_field_cron`, asserting the
  default has 6 whitespace-separated fields (mirroring the gateway validator's
  requirement without pulling the `cron` crate into `aa-core`) and equals the
  expected value.
- All 215 `aa-core` tests pass; `cargo fmt` + `cargo clippy --all-targets`
  clean.

## Notes / Assumptions

- The fix is scoped to `aa-core` (the crate that owns the default). The
  gateway's `RetentionConfig` already uses the correct 6-field default; this
  PR aligns the `aa-core` default with it.
- The regression test asserts the 6-field shape rather than calling the `cron`
  parser directly, to avoid adding a new dependency to `aa-core`. The
  authoritative parse-time validation continues to live in `aa-gateway`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3352
