### PR TITLE
[AAASM-3350] 🐛 (aa-gateway): Strip port from host before egress allowlist compare

### DIFF
--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -119,13 +119,22 @@ fn stage_network(doc: &PolicyDocument, action: &aa_core::GovernanceAction) -> Op
         return None;
     };
     let np = doc.network.as_ref()?;
-    let host = url
+    let host_port = url
         .split_once("://")
         .map(|x| x.1)
         .unwrap_or("")
         .split('/')
         .next()
         .unwrap_or("");
+    // AAASM-3350: `convert.rs` builds the URL as `proto://host:port`, so the
+    // authority extracted above still carries the `:port` suffix. Allowlist
+    // entries are bare hosts (`api.openai.com`, `*.openai.com`), so comparing
+    // `host:port` against them always failed and every allowlisted host was
+    // denied. Strip a trailing numeric `:port` before the allowlist compare.
+    let host = match host_port.rsplit_once(':') {
+        Some((h, port)) if !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) => h,
+        _ => host_port,
+    };
     // An empty allowlist denies all egress (fail-closed); `is_host_allowed_*`
     // treats an empty list as allow-all, so guard it explicitly here.
     let allowed = !np.allowlist.is_empty() && aa_core::policy::is_host_allowed_by_egress_allowlist(host, &np.allowlist);

--- a/aa-gateway/src/engine/decision.rs
+++ b/aa-gateway/src/engine/decision.rs
@@ -476,6 +476,29 @@ mod tests {
         assert_eq!(stage_network(&doc, &net_action("https://anything.test/")), None);
     }
 
+    #[test]
+    fn stage_network_allowlisted_host_with_port_allows() {
+        // AAASM-3350: the gateway builds URLs as `proto://host:port`. A bare
+        // allowlist entry must still match once the port is stripped.
+        let doc = doc_with_allowlist(vec!["api.openai.com".into()]);
+        assert_eq!(stage_network(&doc, &net_action("https://api.openai.com:443/v1")), None);
+    }
+
+    #[test]
+    fn stage_network_wildcard_host_with_port_allows() {
+        // AAASM-3350: port stripping must also let wildcard entries match.
+        let doc = doc_with_allowlist(vec!["*.openai.com".into()]);
+        assert_eq!(stage_network(&doc, &net_action("https://api.openai.com:443/v1")), None);
+    }
+
+    #[test]
+    fn stage_network_non_allowlisted_host_with_port_denies() {
+        // AAASM-3350: stripping the port must not let a non-allowlisted host through.
+        let doc = doc_with_allowlist(vec!["api.openai.com".into()]);
+        let d = stage_network(&doc, &net_action("https://evil.attacker.net:8443/x")).expect("deny");
+        assert!(matches!(d, PolicyDecision::Deny { .. }));
+    }
+
     // ── Stage 1: schedule timezone fail-closed (AAASM-3133) ─────────────────
 
     fn doc_with_schedule(tz: &str, start: &str, end: &str) -> PolicyDocument {


### PR DESCRIPTION
## Description

Fixes the network egress allowlist over-blocking every allowlisted host on the gRPC `CheckAction` path. `aa-gateway/src/service/convert.rs` builds the network URL as `"{proto}://{host}:{port}"`, and the allowlist stage in `engine/decision.rs` extracted the host but kept the port (e.g. `api.openai.com:443`), then exact-compared it against the bare allowlist entries (`api.openai.com`) — so no allowlisted host ever matched and all egress was denied. This strips the `:port` from the host before the allowlist comparison.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3350

## Testing

- [x] Unit tests added / updated
- [x] Manual testing performed

Found via QA black-box verification: with `schemas/examples/strict.yaml` (`network.allowlist: [api.openai.com, …]`), `NETWORK_CALL` to `api.openai.com:443` returned DENY ("host not in network allowlist") before the fix. Added regression tests asserting an allowlisted host **with a port** is allowed while a non-allowlisted host is denied. Evidence: `agent-assembly-integration-tests/verification-reports/base-branch-2026-06/enforcement-policy.md`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3350
