### PR TITLE
[AAASM-3357] 🐛 (aa-proxy): Add CLI parser and fail-closed MCP enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,7 @@ dependencies = [
  "aa-security",
  "anyhow",
  "bytes",
+ "clap",
  "criterion",
  "dirs",
  "hyper",

--- a/aa-integration-tests/tests/e2e_mcp_interceptor.rs
+++ b/aa-integration-tests/tests/e2e_mcp_interceptor.rs
@@ -810,6 +810,7 @@ mod proxy_e2e {
             credential_action: CredentialAction::default(),
             upstream_override: Some(upstream_override),
             gateway_endpoint: Some(format!("http://{gateway_addr}")),
+            mcp_fail_open: false,
             // CONNECT host is a public name redirected via `upstream_override`,
             // so the SSRF guard stays fully active.
             allow_private_connect_targets: false,

--- a/aa-integration-tests/tests/e2e_policy_proxy.rs
+++ b/aa-integration-tests/tests/e2e_policy_proxy.rs
@@ -37,6 +37,7 @@ fn proxy_config(ca_dir: &std::path::Path, denied_hosts: Vec<String>) -> ProxyCon
         credential_action: CredentialAction::default(),
         upstream_override: None,
         gateway_endpoint: None,
+        mcp_fail_open: false,
         // These tests use a loopback CONNECT target as the "allowed host"
         // stand-in, which the AAASM-3130 SSRF guard blocks in production.
         allow_private_connect_targets: true,

--- a/aa-integration-tests/tests/e2e_secret_interception.rs
+++ b/aa-integration-tests/tests/e2e_secret_interception.rs
@@ -570,6 +570,7 @@ mod proxy_data_path {
             credential_action,
             upstream_override: Some(upstream_override),
             gateway_endpoint: None,
+            mcp_fail_open: false,
             // Dials are redirected via `upstream_override` to a loopback mock,
             // so the SSRF guard stays fully active for the public CONNECT host.
             allow_private_connect_targets: false,

--- a/aa-integration-tests/tests/e2e_tool_sandbox.rs
+++ b/aa-integration-tests/tests/e2e_tool_sandbox.rs
@@ -49,6 +49,7 @@ fn proxy_config(ca_dir: &std::path::Path, network_allowlist: Vec<String>) -> Pro
         credential_action: CredentialAction::default(),
         upstream_override: None,
         gateway_endpoint: None,
+        mcp_fail_open: false,
         // These tests allowlist `127.0.0.1` as a loopback stand-in upstream,
         // which the AAASM-3130 SSRF guard blocks in production.
         allow_private_connect_targets: true,

--- a/aa-proxy/Cargo.toml
+++ b/aa-proxy/Cargo.toml
@@ -18,6 +18,7 @@ aa-core    = { path = "../aa-core", version = "0.0.1-beta.2", features = ["serde
 aa-security = { path = "../aa-security", version = "0.0.1-beta.2", features = ["serde"] }
 aa-proto   = { path = "../aa-proto", version = "0.0.1-beta.2" }
 aa-runtime = { path = "../aa-runtime", version = "0.0.1-beta.2" }
+clap       = { workspace = true, features = ["derive"] }
 tokio      = { workspace = true, features = ["full"] }
 hyper      = { workspace = true, features = ["server", "http1"] }
 hyper-util   = { version = "0.1", features = ["tokio", "server"] }

--- a/aa-proxy/src/config.rs
+++ b/aa-proxy/src/config.rs
@@ -106,6 +106,25 @@ pub struct ProxyConfig {
     /// Env: `AA_PROXY_GATEWAY_ENDPOINT` — e.g. `http://127.0.0.1:50051`.
     pub gateway_endpoint: Option<String>,
 
+    /// AAASM-3357 — what to do when MCP enforcement is configured (a
+    /// [`Self::gateway_endpoint`] is set) but the gateway is unreachable,
+    /// either at startup or on a per-call `CheckAction` RPC.
+    ///
+    /// MCP enforcement is a governance path: silently forwarding when the
+    /// authority is down is a fail-open security hole. The default is
+    /// therefore **fail-closed** (`false`) — an MCP `tools/call` is denied
+    /// with a JSON-RPC error envelope when the gateway cannot be reached.
+    ///
+    /// Operators who explicitly prefer availability over enforcement can set
+    /// this to `true` to restore the historical soft-degradation behaviour
+    /// (forward without enforcement).
+    ///
+    /// This knob only affects MCP `tools/call` enforcement. Non-MCP traffic
+    /// is unaffected and continues to flow.
+    ///
+    /// Env: `AA_PROXY_MCP_FAIL_OPEN` — `1`/`true` to fail open; default `false`.
+    pub mcp_fail_open: bool,
+
     /// When `true`, the AAASM-3130 SSRF guard permits CONNECT targets that
     /// resolve to private / loopback / link-local address ranges. Intended for
     /// integration tests **only** — they stand up an in-process mock upstream
@@ -199,6 +218,13 @@ impl ProxyConfig {
             _ => None,
         };
 
+        // AAASM-3357: default fail-closed. Only an explicit truthy value
+        // opts into the historical fail-open soft-degradation behaviour.
+        let mcp_fail_open = match std::env::var("AA_PROXY_MCP_FAIL_OPEN") {
+            Ok(val) => val == "1" || val.to_lowercase() == "true",
+            Err(_) => false,
+        };
+
         Ok(Self {
             bind_addr,
             ca_dir,
@@ -210,6 +236,7 @@ impl ProxyConfig {
             credential_action,
             upstream_override: None,
             gateway_endpoint,
+            mcp_fail_open,
             // No env var: production binaries can never relax the SSRF guard.
             allow_private_connect_targets: false,
         })

--- a/aa-proxy/src/config.rs
+++ b/aa-proxy/src/config.rs
@@ -276,6 +276,7 @@ mod tests {
         std::env::remove_var("AA_PROXY_SKIP_UPSTREAM_TLS_VERIFY");
         std::env::remove_var("AA_PROXY_CREDENTIAL_ACTION");
         std::env::remove_var("AA_PROXY_GATEWAY_ENDPOINT");
+        std::env::remove_var("AA_PROXY_MCP_FAIL_OPEN");
     }
 
     #[test]
@@ -290,6 +291,8 @@ mod tests {
         assert!(cfg.llm_only);
         assert!(cfg.denied_hosts.is_empty());
         assert!(!cfg.skip_upstream_tls_verify);
+        // AAASM-3357: MCP enforcement defaults to fail-closed.
+        assert!(!cfg.mcp_fail_open);
     }
 
     #[test]
@@ -458,5 +461,46 @@ mod tests {
 
         let cfg = ProxyConfig::from_env().unwrap();
         assert_eq!(cfg.gateway_endpoint, None);
+    }
+
+    #[test]
+    fn from_env_mcp_fail_open_defaults_to_false() {
+        // AAASM-3357: an unreachable gateway must fail CLOSED unless the
+        // operator explicitly opts into fail-open.
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_env_vars();
+
+        let cfg = ProxyConfig::from_env().unwrap();
+        assert!(!cfg.mcp_fail_open);
+    }
+
+    #[test]
+    fn from_env_mcp_fail_open_reads_one() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_env_vars();
+        std::env::set_var("AA_PROXY_MCP_FAIL_OPEN", "1");
+
+        let cfg = ProxyConfig::from_env().unwrap();
+        assert!(cfg.mcp_fail_open);
+    }
+
+    #[test]
+    fn from_env_mcp_fail_open_reads_true_case_insensitive() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_env_vars();
+        std::env::set_var("AA_PROXY_MCP_FAIL_OPEN", "TRUE");
+
+        let cfg = ProxyConfig::from_env().unwrap();
+        assert!(cfg.mcp_fail_open);
+    }
+
+    #[test]
+    fn from_env_mcp_fail_open_other_value_is_false() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_env_vars();
+        std::env::set_var("AA_PROXY_MCP_FAIL_OPEN", "no");
+
+        let cfg = ProxyConfig::from_env().unwrap();
+        assert!(!cfg.mcp_fail_open);
     }
 }

--- a/aa-proxy/src/main.rs
+++ b/aa-proxy/src/main.rs
@@ -3,8 +3,43 @@
 //! This is intentionally minimal. All logic lives in the library crate.
 //! `aa-runtime` spawns this binary via `tokio::process::Command::new("aa-proxy")`.
 
+use clap::Parser;
+
+/// Agent Assembly sidecar traffic-interception proxy.
+///
+/// `aa-proxy` is a MitM HTTPS proxy that enforces Layer 2 governance policy
+/// (credential scanning, network egress allowlists, and MCP `tools/call`
+/// enforcement against `aa-gateway`). It is normally spawned by `aa-runtime`,
+/// but can be run standalone for testing and debugging.
+///
+/// All runtime configuration is read from environment variables. The most
+/// common knobs are listed below; see the project documentation for the full
+/// surface.
+///
+/// ENVIRONMENT VARIABLES:
+///
+///   AA_PROXY_ADDR                  TCP listen address (default 127.0.0.1:8899)
+///   AA_CA_DIR                      CA cert/key directory (default ~/.aa/ca)
+///   AA_PROXY_CERT_CACHE_CAPACITY   Max cached per-host certs (default 1000)
+///   AA_PROXY_LLM_ONLY              Intercept LLM traffic only (default true)
+///   AA_PROXY_DENIED_HOSTS          Comma-separated CONNECT block-list
+///   AA_PROXY_NETWORK_ALLOWLIST     Comma-separated egress allowlist patterns
+///   AA_PROXY_CREDENTIAL_ACTION     block | redact_only | alert_only
+///   AA_PROXY_GATEWAY_ENDPOINT      aa-gateway PolicyService URL for MCP enforcement
+///   AA_PROXY_MCP_FAIL_OPEN         1/true to fail OPEN when the gateway is
+///                                  unreachable (default: fail CLOSED — deny)
+///
+/// RUST_LOG controls log verbosity via the standard `EnvFilter` syntax.
+#[derive(Parser, Debug)]
+#[command(name = "aa-proxy", version, verbatim_doc_comment)]
+struct Cli {}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Parse CLI args. With no flags defined this still wires up `--help` and
+    // `--version`, making the binary's existence and version discoverable.
+    let _cli = Cli::parse();
+
     // rustls 0.23+ requires an explicit crypto provider at startup.
     // The `ring` feature is enabled in Cargo.toml; install it before any TLS operation.
     rustls::crypto::ring::default_provider().install_default().ok();

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -145,24 +145,39 @@ impl ProxyServer {
     /// This future runs until the process is killed or an unrecoverable error
     /// occurs. It is called from [`crate::run`].
     pub async fn run(self: &Arc<Self>) -> Result<(), ProxyError> {
-        // Best-effort connect to the gateway when an endpoint is configured.
-        // A connection failure here is logged but does not fail startup —
-        // MCP enforcement simply stays disabled and the proxy continues to
-        // serve the credential-scanner path. This matches `aa-runtime`'s
-        // policy that a missing gateway is a soft degradation, not a fatal
-        // error.
+        // Connect to the gateway when an endpoint is configured.
+        //
+        // AAASM-3357: MCP enforcement is a governance path. When an endpoint is
+        // configured the operator has asked the proxy to enforce — so a failed
+        // connection must NOT silently degrade to fail-open. The default is
+        // fail-closed: refuse to start so the operator notices the gateway is
+        // down rather than letting denied MCP `tools/call`s through unchecked.
+        // Operators who explicitly accept availability over enforcement can set
+        // `AA_PROXY_MCP_FAIL_OPEN=1` to restore the historical soft degradation.
         if let Some(endpoint) = &self.config.gateway_endpoint {
             match GatewayClient::connect(endpoint).await {
                 Ok(client) => {
                     let _ = self.gateway_client.set(Arc::new(Mutex::new(client)));
                     tracing::info!(%endpoint, "connected to aa-gateway PolicyService for MCP enforcement");
                 }
-                Err(e) => {
+                Err(e) if self.config.mcp_fail_open => {
                     tracing::warn!(
                         %endpoint,
                         error = %e,
-                        "failed to connect to aa-gateway; MCP enforcement disabled",
+                        "failed to connect to aa-gateway; MCP enforcement disabled (AA_PROXY_MCP_FAIL_OPEN is set, failing OPEN)",
                     );
+                }
+                Err(e) => {
+                    tracing::error!(
+                        %endpoint,
+                        error = %e,
+                        "failed to connect to aa-gateway; MCP enforcement is configured but the gateway is unreachable. \
+                         Refusing to start (fail-closed). Fix the gateway, or set AA_PROXY_MCP_FAIL_OPEN=1 to start anyway \
+                         and forward MCP traffic WITHOUT enforcement.",
+                    );
+                    return Err(ProxyError::Config(format!(
+                        "aa-gateway unreachable at {endpoint}: {e} (fail-closed; set AA_PROXY_MCP_FAIL_OPEN=1 to override)"
+                    )));
                 }
             }
         }
@@ -348,59 +363,87 @@ impl ProxyServer {
         // call AND its serialised args bytes forward so the response-side
         // path below can re-use both for audit emission (args go into
         // `ToolCallDetail.args_json`).
-        let mcp_call: Option<(crate::intercept::mcp::McpToolCall, Vec<u8>)> =
-            if let Some(call) = parse_mcp_request(&req.body) {
-                let target_url = format!("https://{host}{path}", path = req.target);
-                // Serialise args once and reuse across the audit emissions on
-                // both the request-side (Allow/Deny) and the response-side
-                // (post-redact) paths.
-                let args_bytes = serde_json::to_vec(&call.arguments).unwrap_or_default();
-                match evaluate_mcp_call(gateway, &call, &target_url, "", "").await {
-                    Ok(McpDecision::Allow) | Ok(McpDecision::Redact { .. }) => {
-                        tracing::info!(
-                            tool_name = %call.tool_name,
-                            %host,
-                            "MCP call allowed by gateway, forwarding to upstream with response-side scanning",
-                        );
-                        self.interceptor
-                            .emit_mcp_decision(&call.tool_name, &args_bytes, false, "")
-                            .await;
-                        Some((call, args_bytes))
-                    }
-                    Ok(McpDecision::Deny { reason }) => {
-                        tracing::info!(
-                            tool_name = %call.tool_name,
-                            %host,
-                            %reason,
-                            "MCP call denied by gateway, returning JSON-RPC error envelope",
-                        );
-                        self.interceptor
-                            .emit_mcp_decision(&call.tool_name, &args_bytes, true, &reason)
-                            .await;
-                        let body = build_jsonrpc_error_response(-32000, &reason);
-                        let resp = format!(
-                            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                            body.len(),
-                            body,
-                        );
-                        let mut client_tls = client_reader.into_inner();
-                        client_tls.write_all(resp.as_bytes()).await?;
-                        let _ = client_tls.shutdown().await;
-                        return Ok(());
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            tool_name = %call.tool_name,
-                            %host,
-                            error = %e,
-                            "gateway CheckAction failed, forwarding without enforcement",
-                        );
-                        None
-                    }
+        let mcp_call: Option<(crate::intercept::mcp::McpToolCall, Vec<u8>)> = if let Some(call) =
+            parse_mcp_request(&req.body)
+        {
+            let target_url = format!("https://{host}{path}", path = req.target);
+            // Serialise args once and reuse across the audit emissions on
+            // both the request-side (Allow/Deny) and the response-side
+            // (post-redact) paths.
+            let args_bytes = serde_json::to_vec(&call.arguments).unwrap_or_default();
+            match evaluate_mcp_call(gateway, &call, &target_url, "", "").await {
+                Ok(McpDecision::Allow) | Ok(McpDecision::Redact { .. }) => {
+                    tracing::info!(
+                        tool_name = %call.tool_name,
+                        %host,
+                        "MCP call allowed by gateway, forwarding to upstream with response-side scanning",
+                    );
+                    self.interceptor
+                        .emit_mcp_decision(&call.tool_name, &args_bytes, false, "")
+                        .await;
+                    Some((call, args_bytes))
                 }
-            } else {
-                None
-            };
+                Ok(McpDecision::Deny { reason }) => {
+                    tracing::info!(
+                        tool_name = %call.tool_name,
+                        %host,
+                        %reason,
+                        "MCP call denied by gateway, returning JSON-RPC error envelope",
+                    );
+                    self.interceptor
+                        .emit_mcp_decision(&call.tool_name, &args_bytes, true, &reason)
+                        .await;
+                    let body = build_jsonrpc_error_response(-32000, &reason);
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(),
+                        body,
+                    );
+                    let mut client_tls = client_reader.into_inner();
+                    client_tls.write_all(resp.as_bytes()).await?;
+                    let _ = client_tls.shutdown().await;
+                    return Ok(());
+                }
+                Err(e) if self.config.mcp_fail_open => {
+                    tracing::warn!(
+                        tool_name = %call.tool_name,
+                        %host,
+                        error = %e,
+                        "gateway CheckAction failed; forwarding without enforcement (AA_PROXY_MCP_FAIL_OPEN is set, failing OPEN)",
+                    );
+                    None
+                }
+                Err(e) => {
+                    // AAASM-3357: fail-closed — a governance check that
+                    // cannot reach its authority must not pass through. Deny
+                    // the MCP call with a JSON-RPC error envelope, mirroring
+                    // an explicit gateway Deny.
+                    let reason = "MCP enforcement unavailable: gateway CheckAction failed (fail-closed)";
+                    tracing::error!(
+                        tool_name = %call.tool_name,
+                        %host,
+                        error = %e,
+                        "gateway CheckAction failed; denying MCP call (fail-closed). \
+                         Set AA_PROXY_MCP_FAIL_OPEN=1 to forward without enforcement instead.",
+                    );
+                    self.interceptor
+                        .emit_mcp_decision(&call.tool_name, &args_bytes, true, reason)
+                        .await;
+                    let body = build_jsonrpc_error_response(-32000, reason);
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                        body.len(),
+                        body,
+                    );
+                    let mut client_tls = client_reader.into_inner();
+                    client_tls.write_all(resp.as_bytes()).await?;
+                    let _ = client_tls.shutdown().await;
+                    return Ok(());
+                }
+            }
+        } else {
+            None
+        };
 
         // Forward the (consumed) request body to upstream.
         let upstream_tls = self.dial_upstream_tls(host, target).await?;
@@ -817,6 +860,7 @@ mod tests {
             credential_action: crate::config::CredentialAction::default(),
             upstream_override: None,
             gateway_endpoint: None,
+            mcp_fail_open: false,
             // These unit tests assert the SSRF guard blocks loopback/RFC-1918.
             allow_private_connect_targets: false,
         };

--- a/aa-proxy/tests/proxy_integration.rs
+++ b/aa-proxy/tests/proxy_integration.rs
@@ -24,6 +24,7 @@ fn test_config(ca_dir: &std::path::Path) -> ProxyConfig {
         credential_action: CredentialAction::default(),
         upstream_override: None,
         gateway_endpoint: None,
+        mcp_fail_open: false,
         // Integration tests dial loopback mock upstreams over both the CONNECT
         // and the plain-HTTP forward paths. The plain-HTTP path now re-validates
         // resolved IPs against the SSRF denylist (AAASM-3140), which blocks


### PR DESCRIPTION
## Description

`aa-proxy` had two operator/governance gaps:

1. **No CLI surface.** `main.rs` called `ProxyConfig::from_env()` with no argument parser, so the binary had no `--help`/`--version` and its env-var configuration surface was undiscoverable.
2. **MCP enforcement failed open.** When a gateway endpoint was configured but the gateway was unreachable — either at startup (`connect` failure) or on a per-call `CheckAction` RPC — the proxy logged a warning ("MCP enforcement disabled") and forwarded MCP `tools/call` traffic **without enforcement**. A governance path silently failed open.

This PR:

- Adds a clap `Parser` to `aa-proxy/src/main.rs` providing `--help` and `--version`. The long help documents the env-var configuration knobs (config is still read from the environment). Commit: clap parser.
- Adds an `AA_PROXY_MCP_FAIL_OPEN` config flag (`ProxyConfig::mcp_fail_open`), **defaulting to fail-closed**. Commit: config flag.
- Makes the gateway-unreachable behaviour fail-closed by default. Commit: fail-closed logic:
  - **Startup:** if a gateway endpoint is configured but the connection fails, the proxy logs at ERROR with a clear operator message and **refuses to start** (returns an error from `ProxyServer::run`). Setting `AA_PROXY_MCP_FAIL_OPEN=1` restores the historical soft-degradation (start anyway, forward without enforcement, logged at WARN).
  - **Per-call:** if a `CheckAction` RPC fails, the MCP `tools/call` is **denied** with a JSON-RPC error envelope (mirroring an explicit gateway Deny) and logged at ERROR. `AA_PROXY_MCP_FAIL_OPEN=1` restores forward-without-enforcement (logged at WARN).
- Adds unit tests for the new env-var parsing. Commit: tests.

## Type of Change

- [x] ✨ New feature
- [x] 🐛 Bug fix
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [ ] No
- [x] Yes (describe below)

Two behavioural changes for operators who run the proxy with `AA_PROXY_GATEWAY_ENDPOINT` set:

- The proxy now **refuses to start** if the gateway is unreachable at startup (previously it started and disabled enforcement).
- An MCP `tools/call` is now **denied** if the per-call gateway RPC fails (previously it was forwarded unenforced).

Both are intentional security hardening (fail-closed) and are opt-out via `AA_PROXY_MCP_FAIL_OPEN=1`, which restores the previous behaviour exactly. No public API signatures changed; `ProxyConfig` gained one public field (`mcp_fail_open`).

## Related Issues

- Related Jira ticket: AAASM-3357

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

- Added `from_env_mcp_fail_open_*` unit tests (default false, reads `1`/`true` case-insensitively, other values false) and asserted the fail-closed default in the no-vars defaults test.
- Updated the four `aa-integration-tests` `ProxyConfig` literals + the `aa-proxy` integration-test literal for the new field.
- `cargo build -p aa-proxy`, `cargo clippy -p aa-proxy --all-targets`, and `cargo nextest run -p aa-proxy` all pass (116 tests, 3 skipped).
- Verified `aa-proxy --version` prints `aa-proxy 0.0.1-beta.2` and `aa-proxy --help` lists the documented env knobs.

QA evidence: see `agent-assembly-integration-tests/verification-reports/base-branch-2026-06/`.

## Notes / Assumptions

- The startup fail-closed behaviour is implemented as "refuse to start" rather than per-connection lazy-deny, because the gateway client is established once in `run()`; this is the smallest self-contained fix and gives the operator an immediate, unambiguous signal. A future iteration could add lazy reconnection / circuit-breaking so a transient gateway outage doesn't require a restart.
- No `proto/` files were changed.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (clap `--help` + doc comments)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3357
