### PR TITLE
[AAASM-3354] 🐛 (aa-gateway): Serve /api/v1/health in local mode

### DIFF
--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -611,6 +611,45 @@ mod tests {
         );
     }
 
+    /// AAASM-3354: the local-mode router serves `/api/v1/health` with a
+    /// 200 + `application/json` body (wire-compatible with
+    /// `aa_api::routes::health::HealthResponse`) so the REST surface is
+    /// reachable in local mode instead of returning a blanket 404. The
+    /// route is mounted regardless of whether a storage backend is wired.
+    #[tokio::test]
+    async fn router_serves_api_v1_health_with_json() {
+        let cfg = healthz_only_config();
+        let app = router(&cfg, None);
+        let request = Request::builder()
+            .uri("/api/v1/health")
+            .body(Body::empty())
+            .expect("build request");
+
+        let response = app.oneshot(request).await.expect("router.oneshot");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let ctype = response
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default();
+        assert!(
+            ctype.starts_with("application/json"),
+            "expected application/json, got {ctype}"
+        );
+
+        let bytes = to_bytes(response.into_body(), 8 * 1024).await.expect("read body");
+        let body: serde_json::Value = serde_json::from_slice(&bytes).expect("parse json");
+
+        assert_eq!(body["status"], "ok", "status label");
+        assert_eq!(body["api_version"], "v1", "api version");
+        assert_eq!(body["version"], env!("CARGO_PKG_VERSION"), "crate version");
+        assert!(
+            body["uptime_secs"].is_u64(),
+            "uptime_secs must be present and a u64; got {body}",
+        );
+    }
+
     /// AAASM-1591 / Epic 18 S-J: when a storage backend is wired into
     /// the local-mode router, `GET /api/v1/admin/status` returns the
     /// documented storage block (backend=sqlite, health=ok, row counts,

--- a/aa-gateway/src/local_mode.rs
+++ b/aa-gateway/src/local_mode.rs
@@ -19,6 +19,7 @@ use tokio::sync::oneshot;
 
 use crate::dashboard_server::{dashboard_router, find_dashboard_dist};
 use crate::routes::admin_status::{admin_status, AdminStatusState};
+use crate::routes::api_health::{api_health, ApiHealthState};
 use crate::routes::healthz::{healthz, HealthzState};
 use crate::storage::{SqliteBackend, SqliteConfig, StorageBackend, StorageError};
 
@@ -264,6 +265,16 @@ pub(crate) fn router_with_resolved_dist(
 ) -> Router {
     let state = HealthzState::new("local", "sqlite");
     let mut app = Router::new().route("/healthz", get(healthz)).layer(Extension(state));
+    // AAASM-3354: serve the REST surface's liveness probe at /api/v1/health
+    // so `curl http://127.0.0.1:7391/api/v1/health` returns JSON, not a 404,
+    // in local mode. The full `aa-api` router cannot be nested here — `aa-api`
+    // depends on `aa-gateway` (circular) and requires the heavyweight
+    // `aa_api::AppState` local mode does not construct — so this is the
+    // smallest viable wiring; remaining `/api/v1/*` data routes are a
+    // documented follow-up (see the AAASM-3354 PR body).
+    app = app
+        .route("/api/v1/health", get(api_health))
+        .layer(Extension(ApiHealthState::new()));
     if let Some(backend) = storage {
         let admin_state = AdminStatusState::new(
             "local",

--- a/aa-gateway/src/routes/api_health.rs
+++ b/aa-gateway/src/routes/api_health.rs
@@ -1,0 +1,114 @@
+//! `GET /api/v1/health` — REST-surface liveness probe served by local mode.
+//!
+//! The full REST surface lives in the sibling `aa-api` crate, whose router
+//! is library-only: no shipped binary mounts it, and `aa-gateway` cannot
+//! depend on `aa-api` because `aa-api` already depends on `aa-gateway`
+//! (`pub use aa_gateway::ops`) — nesting the real router would be a
+//! circular crate dependency, and it additionally requires the heavyweight
+//! `aa_api::AppState` (≈30 wired subsystems) that local mode does not
+//! construct.
+//!
+//! To keep `/api/v1/*` from returning a blanket 404 in local mode
+//! (AAASM-3354), this module owns a minimal, self-contained
+//! `/api/v1/health` handler whose JSON body is wire-compatible with
+//! `aa_api::routes::health::HealthResponse`. It is the smallest viable
+//! version of "serve the REST API in local mode"; the remaining
+//! `/api/v1/*` data routes still require the `aa-api` router and are
+//! tracked as a follow-up (see the AAASM-3354 PR body).
+
+use std::time::Instant;
+
+use axum::{Extension, Json};
+use serde::Serialize;
+
+/// Process-wide state required by [`api_health`] to compute uptime.
+///
+/// Mirrors [`super::healthz::HealthzState`] but is its own type so the
+/// `/api/v1/health` surface can evolve independently of the bare
+/// `/healthz` liveness probe.
+#[derive(Clone, Debug)]
+pub struct ApiHealthState {
+    /// Gateway crate version (from `CARGO_PKG_VERSION`).
+    pub version: &'static str,
+    /// Wall-clock instant the gateway became ready to serve traffic.
+    pub started_at: Instant,
+}
+
+impl ApiHealthState {
+    /// Build state for a freshly-started gateway. `started_at` is captured
+    /// at construction time and drives the `uptime_secs` response field.
+    pub fn new() -> Self {
+        Self {
+            version: env!("CARGO_PKG_VERSION"),
+            started_at: Instant::now(),
+        }
+    }
+}
+
+impl Default for ApiHealthState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// JSON body returned by `GET /api/v1/health`.
+///
+/// Field names match the subset of `aa_api::routes::health::HealthResponse`
+/// that local mode can populate without the full `aa_api::AppState`: the
+/// per-subsystem `checks` map is reported empty because local mode does not
+/// wire the policy engine / registry / alert subsystems the `aa-api`
+/// handler probes.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+pub struct ApiHealthBody {
+    /// Liveness status string: always `"ok"` here — a 200 means the
+    /// process is responding to HTTP.
+    pub status: String,
+    /// Gateway version (semver from Cargo.toml).
+    pub version: String,
+    /// API version prefix.
+    pub api_version: String,
+    /// Server uptime in seconds since startup.
+    pub uptime_secs: u64,
+}
+
+/// `GET /api/v1/health` — REST-surface liveness probe.
+///
+/// Always returns `200 OK` with [`ApiHealthBody`] as long as the gateway
+/// process is responding to HTTP, so `curl http://127.0.0.1:7391/api/v1/health`
+/// returns JSON rather than a 404 in local mode (AAASM-3354).
+pub async fn api_health(Extension(state): Extension<ApiHealthState>) -> Json<ApiHealthBody> {
+    Json(ApiHealthBody {
+        status: "ok".to_string(),
+        version: state.version.to_string(),
+        api_version: "v1".to_string(),
+        uptime_secs: state.started_at.elapsed().as_secs(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn body_serialises_to_documented_shape() {
+        let body = ApiHealthBody {
+            status: "ok".into(),
+            version: "0.0.1".into(),
+            api_version: "v1".into(),
+            uptime_secs: 7,
+        };
+        let json = serde_json::to_value(&body).expect("ApiHealthBody must serialise");
+        assert_eq!(json["status"], "ok");
+        assert_eq!(json["version"], "0.0.1");
+        assert_eq!(json["api_version"], "v1");
+        assert_eq!(json["uptime_secs"], 7);
+    }
+
+    #[tokio::test]
+    async fn handler_returns_ok_body() {
+        let Json(body) = api_health(Extension(ApiHealthState::new())).await;
+        assert_eq!(body.status, "ok");
+        assert_eq!(body.api_version, "v1");
+        assert_eq!(body.version, env!("CARGO_PKG_VERSION"));
+    }
+}

--- a/aa-gateway/src/routes/mod.rs
+++ b/aa-gateway/src/routes/mod.rs
@@ -3,8 +3,9 @@
 //! In remote mode, the gateway exposes a small set of process-liveness
 //! and admin endpoints over Axum. The full agent-control surface lives
 //! in the sibling `aa-api` crate; this module only owns routes that
-//! must be reachable even when `aa-api` is not mounted (today: `/healthz`
-//! and `/api/v1/admin/status`).
+//! must be reachable even when `aa-api` is not mounted (today: `/healthz`,
+//! `/api/v1/health`, and `/api/v1/admin/status`).
 
 pub mod admin_status;
+pub mod api_health;
 pub mod healthz;


### PR DESCRIPTION
## Description

In local mode, `aa-gateway --mode local` binds HTTP `:7391` but its router
previously registered only `/healthz` + the optional `/api/v1/admin/status`
+ the dashboard SPA fallback. The entire `/api/v1/*` REST surface returned
`404`, so the documented CLI data commands and any REST client hitting
`/api/v1/health` were unreachable.

This PR mounts a minimal, self-contained `/api/v1/health` liveness probe into
the local-mode router so `curl http://127.0.0.1:7391/api/v1/health` returns
JSON (`200 application/json`) instead of a `404`.

### Why not nest the real `aa-api` router?

The QA report's literal remedy — "nest the existing `aa-api` router" — is **not
achievable as a minimal fix** for two structural reasons discovered during
investigation:

1. **Circular crate dependency.** `aa-api` already depends on `aa-gateway`
   (`pub use aa_gateway::ops;` in `aa-api/src/lib.rs`, plus ~15 `aa_gateway::*`
   imports in `aa-api/src/state.rs`). Adding `aa-gateway -> aa-api` would create
   a dependency cycle that Cargo rejects.
2. **Heavyweight required state.** `aa_api::server::build_app` requires a fully
   populated `aa_api::AppState` (~30 wired subsystems: policy engine, budget
   tracker, approval queue, auth config, JWT signer/verifier, alert stores,
   topology caches, etc.). `aa_api::AppState` has no constructor; it is assembled
   field-by-field by the remote-mode wiring. Local mode constructs none of this
   — it owns only an `Arc<dyn StorageBackend>` (`aa_gateway::app_state::AppState`,
   a different, minimal struct).

Per the spec's escalation clause ("If mounting requires shared state the local
mode can't provide, implement the smallest viable version and DOCUMENT remaining
gaps"), this PR implements the smallest viable wiring: a native
`/api/v1/health` handler in `aa-gateway` whose JSON body is wire-compatible with
the subset of `aa_api::routes::health::HealthResponse` local mode can populate
(`status`, `version`, `api_version`, `uptime_secs`). This mirrors the existing
pattern in `aa-gateway/src/routes/` (which already owns `/healthz` and
`/api/v1/admin/status` precisely "because the full agent-control surface lives
in the sibling `aa-api` crate").

### Remaining gap (follow-up)

The data-bearing `/api/v1/*` routes (`/agents`, `/policies`, `/costs`,
`/approvals`, `/topology/*`, etc.) still require the `aa-api` router and its
`AppState`. Serving them from local mode needs a larger design change — either
extracting the shared types into a leaf crate to break the `aa-api -> aa-gateway`
cycle, or building a local-mode `AppState` factory. That is out of scope for this
surgical fix and should be tracked as a separate ticket.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3354
- QA evidence: `agent-assembly-integration-tests/verification-reports/base-branch-2026-06/` (base-branch QA round, base = remote/master@5c7b1382, v0.0.1-beta.2)

Closes AAASM-3354

## Testing

- [x] Unit tests added / updated
- [x] Manual testing performed

Added:
- `routes::api_health::tests` — handler returns the `ok` body; body serialises
  to the documented shape.
- `local_mode::tests::router_serves_api_v1_health_with_json` — the local-mode
  router serves `GET /api/v1/health` with `200` + `application/json`.

Manual verification — ran the built `aa-gateway --mode local` on an ephemeral
port and confirmed:

```
$ curl -s -w '\nHTTP:%{http_code} CT:%{content_type}\n' http://127.0.0.1:7393/api/v1/health
{"status":"ok","version":"0.0.1-beta.2","api_version":"v1","uptime_secs":0}
HTTP:200 CT:application/json
```

Previously this returned `404`. `cargo build -p aa-gateway`,
`cargo clippy -p aa-gateway --all-targets` (clean), and
`cargo nextest run -p aa-gateway` (local_mode + api_health: 23 passed) all green.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
