### PR TITLE
[AAASM-3351] 🐛 (aa-gateway): Fail closed on unsupported rule-list policy schema

### DIFF
--- a/aa-api/tests/common/mod.rs
+++ b/aa-api/tests/common/mod.rs
@@ -55,16 +55,22 @@ pub fn test_state_with_auth(mode: AuthMode, entries: &[ApiKeyEntry], rpm: u32) -
     let policy_dir = std::env::temp_dir().join(format!("aa-api-test-policy-{}-{policy_id}", std::process::id()));
     std::fs::create_dir_all(&policy_dir).unwrap();
     let policy_path = policy_dir.join("test-policy.yaml");
+    // AAASM-3351: the validator now fails closed on the legacy rule-list
+    // schema (top-level `spec.rules:` / `kind: GovernancePolicy`), so use a
+    // minimal valid section-based envelope. These tests only need a loadable
+    // PolicyEngine, not specific rules, so an empty section spec preserves
+    // intent (allow-by-default).
     std::fs::write(
         &policy_path,
         r#"
-apiVersion: agent-assembly.dev/v1alpha1
-kind: GovernancePolicy
+apiVersion: agent-assembly/v1
+kind: Policy
 metadata:
   name: test-policy
   version: "0.1.0"
 spec:
-  rules: []
+  budget:
+    daily_limit_usd: 100.0
 "#,
     )
     .unwrap();

--- a/aa-api/tests/policies.rs
+++ b/aa-api/tests/policies.rs
@@ -13,7 +13,8 @@ metadata:
   name: test-policy
   version: "1.0.0"
 spec:
-  rules: []
+  budget:
+    daily_limit_usd: 1000.0
 "#;
 
 const ENVELOPE_POLICY_WITH_TOOLS: &str = r#"

--- a/aa-api/tests/policy_rbac_integration.rs
+++ b/aa-api/tests/policy_rbac_integration.rs
@@ -19,7 +19,8 @@ metadata:
   name: rbac-test-policy
   version: "1.0.0"
 spec:
-  rules: []
+  budget:
+    daily_limit_usd: 1000.0
 "#;
 
 /// Build an authenticated POST /api/v1/policies request.

--- a/aa-cli/src/commands/policy/validate.rs
+++ b/aa-cli/src/commands/policy/validate.rs
@@ -58,14 +58,8 @@ kind: Policy
 metadata:
   name: test-policy
 spec:
-  tier: low
-  rules:
-    - id: allow-all
-      description: Allow all
-      match:
-        actions: ["*"]
-      effect: allow
-      audit: true"#
+  budget:
+    daily_limit_usd: 100.0"#
         )
         .unwrap();
 

--- a/aa-cli/tests/policy_apply.rs
+++ b/aa-cli/tests/policy_apply.rs
@@ -22,7 +22,7 @@ async fn apply_sends_post_to_api_and_prints_response() {
     Mock::given(method("POST"))
         .and(path("/api/v1/policies"))
         .and(body_partial_json(serde_json::json!({
-            "policy_yaml": "apiVersion: agent-assembly.dev/v1alpha1\nkind: GovernancePolicy\nmetadata:\n  name: test-policy\n  version: \"1.0.0\"\nspec:\n  rules: []\n"
+            "policy_yaml": "apiVersion: agent-assembly.dev/v1alpha1\nkind: GovernancePolicy\nmetadata:\n  name: test-policy\n  version: \"1.0.0\"\nspec:\n  budget:\n    daily_limit_usd: 1000.0\n"
         })))
         .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
             "name": "abc123def456",
@@ -35,7 +35,7 @@ async fn apply_sends_post_to_api_and_prints_response() {
         .await;
 
     let mut tmp = tempfile::NamedTempFile::new().unwrap();
-    tmp.write_all(b"apiVersion: agent-assembly.dev/v1alpha1\nkind: GovernancePolicy\nmetadata:\n  name: test-policy\n  version: \"1.0.0\"\nspec:\n  rules: []\n").unwrap();
+    tmp.write_all(b"apiVersion: agent-assembly.dev/v1alpha1\nkind: GovernancePolicy\nmetadata:\n  name: test-policy\n  version: \"1.0.0\"\nspec:\n  budget:\n    daily_limit_usd: 1000.0\n").unwrap();
 
     let file_path = tmp.path().to_path_buf();
     let uri = server.uri();

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -542,6 +542,23 @@ mod tests {
     }
 
     #[test]
+    fn rule_list_schema_is_a_validation_error_not_an_allow_all_warning() {
+        // AAASM-3351: a rule-list / GovernancePolicy-style document (top-level
+        // `rules:`) is not honored by the section-based engine. It must fail
+        // closed with a hard validation error, NOT validate into an empty
+        // allow-all policy with only a warning.
+        let yaml = "rules:\n  - id: deny-all\n    action: deny\n";
+        let result = PolicyValidator::from_yaml(yaml);
+        assert!(result.is_err(), "rule-list schema must be rejected, not allow-all");
+        let errs = result.unwrap_err();
+        assert!(
+            errs.iter().any(|e| e.field == "rules"),
+            "expected a hard error on the 'rules' field, got: {:?}",
+            errs,
+        );
+    }
+
+    #[test]
     fn network_unknown_key_produces_warning() {
         let yaml = "network:\n  allowlist:\n    - api.openai.com\n  blocklist:\n    - \"*\"\n";
         let out = PolicyValidator::from_yaml(yaml).unwrap();

--- a/aa-gateway/src/policy/validator.rs
+++ b/aa-gateway/src/policy/validator.rs
@@ -37,9 +37,26 @@ impl PolicyValidator {
         let mut errors: Vec<ValidationError> = Vec::new();
         let mut warnings: Vec<ValidationWarning> = Vec::new();
 
-        // Step 2 — collect top-level unknown keys
+        // Step 2 — collect top-level unknown keys.
+        //
+        // AAASM-3351: a top-level `rules:` key signals a rule-list /
+        // `GovernancePolicy`-style schema that the section-based engine does
+        // NOT honor. Previously this was treated as an unknown key (warning
+        // only), so the document validated into an empty allow-all policy —
+        // a fail-OPEN on a misformatted/legacy policy. Fail closed instead:
+        // refuse to load the document rather than silently allowing
+        // everything. (Full multi-schema support is a follow-up.)
         for key in raw.unknown.keys() {
-            warnings.push(ValidationWarning::unknown_key(key));
+            if key == "rules" {
+                errors.push(ValidationError::new(
+                    "rules",
+                    "unsupported rule-list policy schema (top-level 'rules:'); the gateway uses a \
+                     section-based schema (network/schedule/budget/data/tools/capabilities) and \
+                     refuses to load this document to avoid an allow-all fallback",
+                ));
+            } else {
+                warnings.push(ValidationWarning::unknown_key(key));
+            }
         }
 
         // Step 3 — validate each section

--- a/aa-gateway/src/simulation/engine.rs
+++ b/aa-gateway/src/simulation/engine.rs
@@ -164,16 +164,12 @@ mod tests {
         }
     }
 
-    const ALLOW_ALL_POLICY: &str = r#"
-        tier: low
-        rules:
-          - id: allow-all
-            description: Allow everything
-            match:
-              actions: ["*"]
-            effect: allow
-            audit: true
-    "#;
+    // AAASM-3351: the section-based engine allows by default when no section
+    // restricts an action, so a minimal valid document is an allow-all policy.
+    // (Previously this fixture used the unsupported top-level `rules:` schema,
+    // which the validator now rejects rather than silently loading as
+    // allow-all.)
+    const ALLOW_ALL_POLICY: &str = "version: \"1.0\"\n";
 
     #[test]
     fn simulate_event_allow() {

--- a/aa-gateway/src/simulation/live.rs
+++ b/aa-gateway/src/simulation/live.rs
@@ -65,16 +65,10 @@ mod tests {
     use crate::PolicyEngine;
 
     fn make_live_sim(duration: Duration) -> LiveSimulation {
-        let policy_yaml = r#"
-            tier: low
-            rules:
-              - id: allow-all
-                description: Allow everything
-                match:
-                  actions: ["*"]
-                effect: allow
-                audit: true
-        "#;
+        // AAASM-3351: a minimal valid section-based document allows by default
+        // (no section restricts any action). Previously this fixture used the
+        // unsupported top-level `rules:` schema, now rejected by the validator.
+        let policy_yaml = "version: \"1.0\"\n";
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         tmp.write_all(policy_yaml.as_bytes()).unwrap();
         tmp.flush().unwrap();

--- a/aa-gateway/tests/scope_index_fixtures_test.rs
+++ b/aa-gateway/tests/scope_index_fixtures_test.rs
@@ -94,17 +94,28 @@ fn tool_scoped_fixture_lands_in_matching_tool_bucket() {
 }
 
 /// Backward-compat: a YAML fixture from before F92 (no `scope:` field, in
-/// the envelope format used by `policy-examples/`) must validate cleanly
-/// and land under `PolicyScope::Global` when registered with the engine.
+/// the envelope format) must validate cleanly and land under
+/// `PolicyScope::Global` when registered with the engine.
+///
+/// AAASM-3351: this previously read `policy-examples/high-risk.yaml`, but that
+/// example uses the unsupported top-level `rules:` (rule-list) schema, which
+/// the validator now rejects (fail-closed) instead of silently loading as an
+/// empty allow-all policy. The test's intent — envelope format + missing
+/// `scope:` defaults to Global — is preserved here with an inline
+/// section-based envelope fixture.
 #[test]
 fn pre_f92_fixture_without_scope_field_lands_in_global() {
-    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("workspace root")
-        .join("policy-examples/high-risk.yaml");
-    let yaml = std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
-    let doc = PolicyValidator::from_yaml(&yaml)
-        .unwrap_or_else(|errs| panic!("validate {}: {errs:?}", path.display()))
+    let yaml = r#"
+apiVersion: agent-assembly/v1
+kind: Policy
+metadata:
+  name: pre-f92-no-scope
+spec:
+  budget:
+    daily_limit_usd: 10.0
+"#;
+    let doc = PolicyValidator::from_yaml(yaml)
+        .unwrap_or_else(|errs| panic!("validate inline pre-F92 fixture: {errs:?}"))
         .document;
     assert_eq!(doc.scope, PolicyScope::Global, "missing scope: must default to Global");
 

--- a/aa-integration-tests/tests/api_auth_matrix.rs
+++ b/aa-integration-tests/tests/api_auth_matrix.rs
@@ -308,7 +308,8 @@ metadata:
   name: rbac-test-policy
   version: "1.0.0"
 spec:
-  rules: []
+  budget:
+    daily_limit_usd: 1000.0
 "#;
 
     let resp = reqwest::Client::new()
@@ -681,7 +682,8 @@ metadata:
   name: rbac-test-policy
   version: "1.0.0"
 spec:
-  rules: []
+  budget:
+    daily_limit_usd: 1000.0
 "#;
 
 #[tokio::test]

--- a/aa-integration-tests/tests/api_policies.rs
+++ b/aa-integration-tests/tests/api_policies.rs
@@ -20,7 +20,8 @@ metadata:
   name: topology-it-policy
   version: "0.1.0"
 spec:
-  rules: []
+  budget:
+    daily_limit_usd: 1000.0
 "#;
 
 const ANOTHER_YAML: &str = r#"
@@ -30,7 +31,8 @@ metadata:
   name: another-policy
   version: "1.0.0"
 spec:
-  rules: []
+  budget:
+    daily_limit_usd: 1000.0
 "#;
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -153,7 +155,7 @@ async fn policies_list_pagination_param_respected() {
     // Seed 5 policy versions with distinct content so they get unique SHA256 entries.
     for i in 1..=5u32 {
         let yaml = format!(
-            "apiVersion: agent-assembly.dev/v1alpha1\nkind: GovernancePolicy\nmetadata:\n  name: pagination-policy\n  version: \"{i}.0.0\"\nspec:\n  rules: []\n"
+            "apiVersion: agent-assembly.dev/v1alpha1\nkind: GovernancePolicy\nmetadata:\n  name: pagination-policy\n  version: \"{i}.0.0\"\nspec:\n  budget:\n    daily_limit_usd: 1000.0\n"
         );
         post_policy(&client, &env.base_url(), &yaml).await;
     }

--- a/aa-integration-tests/tests/cli_gateway.rs
+++ b/aa-integration-tests/tests/cli_gateway.rs
@@ -33,9 +33,10 @@ use tempfile::TempDir;
 
 const MINIMAL_POLICY: &str = "\
 apiVersion: agent-assembly.dev/v1alpha1\n\
-kind: GovernancePolicy\n\
+kind: Policy\n\
 spec:\n\
-  rules: []\n";
+  budget:\n\
+    daily_limit_usd: 1000.0\n";
 
 fn free_port() -> u16 {
     TcpListener::bind("127.0.0.1:0")

--- a/aa-integration-tests/tests/common/fixtures/policies/allow_all.yaml
+++ b/aa-integration-tests/tests/common/fixtures/policies/allow_all.yaml
@@ -1,7 +1,11 @@
-apiVersion: agent-assembly.dev/v1alpha1
-kind: GovernancePolicy
+apiVersion: agent-assembly/v1
+kind: Policy
 metadata:
   name: cli-it-allow-all
   version: "0.1.0"
 spec:
-  rules: []
+  # AAASM-3351: migrated off the legacy rule-list (`spec.rules:`) schema, which
+  # the validator now rejects (fail-closed). A minimal section-based spec is the
+  # allow-by-default equivalent this fixture intends.
+  budget:
+    daily_limit_usd: 1000.0

--- a/aa-integration-tests/tests/common/fixtures/policies/budget_team_limit.yaml
+++ b/aa-integration-tests/tests/common/fixtures/policies/budget_team_limit.yaml
@@ -1,22 +1,13 @@
-apiVersion: agent-assembly.dev/v1alpha1
-kind: GovernancePolicy
+apiVersion: agent-assembly/v1
+kind: Policy
 metadata:
   name: f116-st-f-budget-team-limit
   version: "0.1.0"
 spec:
-  rules:
-    - id: allow-default
-      effect: allow
-      match: {}
-# Reference: the team daily limit is injected at BudgetTracker construction
-# time via BudgetTracker::with_team_daily_limit(). The YAML budget stanza is
-# the policy-plane representation; integration tests use the tracker API
-# directly (same pattern as api_costs.rs).
-#
-# Equivalent policy-plane stanza (not parsed by the test harness):
-#   budgets:
-#     - scope:
-#         team: "f116-budget-it"
-#       window: "1d"
-#       limit_usd: 2.00
-#       action_on_exhaust: deny
+  # AAASM-3351: migrated off the legacy rule-list (`spec.rules:`) schema, which
+  # the validator now rejects (fail-closed). A minimal section-based spec is the
+  # allow-by-default equivalent this fixture intends.
+  # The team daily limit is injected at BudgetTracker construction time via
+  # BudgetTracker::with_team_daily_limit(); tests use the tracker API directly.
+  budget:
+    daily_limit_usd: 1000.0

--- a/aa-integration-tests/tests/common/fixtures/policies/budget_two_teams.yaml
+++ b/aa-integration-tests/tests/common/fixtures/policies/budget_two_teams.yaml
@@ -1,26 +1,13 @@
-apiVersion: agent-assembly.dev/v1alpha1
-kind: GovernancePolicy
+apiVersion: agent-assembly/v1
+kind: Policy
 metadata:
   name: f116-st-f-budget-two-teams
   version: "0.1.0"
 spec:
-  rules:
-    - id: allow-default
-      effect: allow
-      match: {}
-# Reference: both teams (f116-budget-it-a and f116-budget-it-b) share the
-# same per-team cap set via BudgetTracker::with_team_daily_limit(). The
-# isolation test asserts that exhausting one team does not block the other.
-#
-# Equivalent policy-plane stanza (not parsed by the test harness):
-#   budgets:
-#     - scope:
-#         team: "f116-budget-it-a"
-#       window: "1d"
-#       limit_usd: 2.00
-#       action_on_exhaust: deny
-#     - scope:
-#         team: "f116-budget-it-b"
-#       window: "1d"
-#       limit_usd: 2.00
-#       action_on_exhaust: deny
+  # AAASM-3351: migrated off the legacy rule-list (`spec.rules:`) schema, which
+  # the validator now rejects (fail-closed). A minimal section-based spec is the
+  # allow-by-default equivalent this fixture intends.
+  # Per-team caps are injected via BudgetTracker::with_team_daily_limit();
+  # the isolation test asserts exhausting one team does not block the other.
+  budget:
+    daily_limit_usd: 1000.0

--- a/aa-integration-tests/tests/common/fixtures/policies/deny_websearch.yaml
+++ b/aa-integration-tests/tests/common/fixtures/policies/deny_websearch.yaml
@@ -1,11 +1,11 @@
-apiVersion: agent-assembly.dev/v1alpha1
-kind: GovernancePolicy
+apiVersion: agent-assembly/v1
+kind: Policy
 metadata:
   name: cli-it-deny-websearch
   version: "0.1.0"
 spec:
-  rules:
-    - id: deny-websearch
-      match:
-        tool: WebSearch
-      action: deny
+  # AAASM-3351: migrated off the legacy rule-list schema to the section-based
+  # tool-deny equivalent (WebSearch denied).
+  tools:
+    WebSearch:
+      allow: false

--- a/aa-integration-tests/tests/common/fixtures/policies/proxy_host_deny.yaml
+++ b/aa-integration-tests/tests/common/fixtures/policies/proxy_host_deny.yaml
@@ -1,10 +1,13 @@
-apiVersion: agent-assembly.dev/v1alpha1
-kind: GovernancePolicy
+apiVersion: agent-assembly/v1
+kind: Policy
 metadata:
   name: proxy-host-deny
   version: "0.1.0"
 spec:
-  # Host-level deny enforcement is configured via the AA_PROXY_DENIED_HOSTS
-  # environment variable, not from this policy YAML. This fixture documents the
-  # policy intent for Layer 2 MitM host blocking (AAASM-1517).
-  rules: []
+  # AAASM-3351: migrated off the legacy rule-list (`spec.rules:`) schema, which
+  # the validator now rejects (fail-closed). A minimal section-based spec is the
+  # allow-by-default equivalent this fixture intends.
+  # Host-level deny enforcement is configured via AA_PROXY_DENIED_HOSTS,
+  # not from this policy YAML (Layer 2 MitM host blocking, AAASM-1517).
+  budget:
+    daily_limit_usd: 1000.0

--- a/aa-integration-tests/tests/common/live_gateway.rs
+++ b/aa-integration-tests/tests/common/live_gateway.rs
@@ -46,7 +46,7 @@ impl LiveGateway {
         let policy_path = policy_tmp.path().join("policy.yaml");
         std::fs::write(
             &policy_path,
-            "apiVersion: agent-assembly.dev/v1alpha1\nkind: GovernancePolicy\nspec:\n  rules: []\n",
+            "apiVersion: agent-assembly.dev/v1alpha1\nkind: GovernancePolicy\nspec:\n  budget:\n    daily_limit_usd: 1000.0\n",
         )
         .context("writing minimal policy YAML")?;
 

--- a/aa-integration-tests/tests/common/mod.rs
+++ b/aa-integration-tests/tests/common/mod.rs
@@ -835,7 +835,8 @@ metadata:
   name: topology-it-policy
   version: "0.1.0"
 spec:
-  rules: []
+  budget:
+    daily_limit_usd: 1000.0
 "#,
     )?;
 
@@ -964,7 +965,8 @@ metadata:
   name: auth-it-policy
   version: "0.1.0"
 spec:
-  rules: []
+  budget:
+    daily_limit_usd: 1000.0
 "#,
     )?;
 
@@ -1103,7 +1105,8 @@ metadata:
   name: auth-it-policy
   version: "0.1.0"
 spec:
-  rules: []
+  budget:
+    daily_limit_usd: 1000.0
 "#,
     )?;
 
@@ -1243,7 +1246,8 @@ metadata:
   name: budget-it-policy
   version: "0.1.0"
 spec:
-  rules: []
+  budget:
+    daily_limit_usd: 1000.0
 "#,
     )?;
 

--- a/aa-integration-tests/tests/e2e_audit.rs
+++ b/aa-integration-tests/tests/e2e_audit.rs
@@ -289,7 +289,7 @@ async fn audit_chain_survives_gateway_restart() -> anyhow::Result<()> {
     let policy_path = policy_tmp.path().join("policy.yaml");
     std::fs::write(
         &policy_path,
-        "apiVersion: agent-assembly.dev/v1alpha1\nkind: GovernancePolicy\nspec:\n  rules: []\n",
+        "apiVersion: agent-assembly.dev/v1alpha1\nkind: GovernancePolicy\nspec:\n  budget:\n    daily_limit_usd: 1000.0\n",
     )?;
 
     // ── Seed: 3 valid chained audit entries on disk. ────────────────


### PR DESCRIPTION
## Description

The policy YAML validator (`aa-gateway/src/policy/validator.rs::from_yaml`) treated
a top-level `rules:` key — the rule-list / `GovernancePolicy`-style schema used by
some repo fixtures and `policy-examples/*.yaml` — as an *unknown key*: it emitted a
warning only and validated the document into an empty, allow-all section-based policy.

The result was a **fail-open**: a misformatted or legacy `rules:`-style policy that
was meant to be restrictive (e.g. `policy-examples/high-risk.yaml`, a
"block-all-by-default" policy) silently loaded as allow-all, permitting every action.

This PR makes the validator **fail closed**: when a document contains a top-level
`rules:` key, it now returns a hard `ValidationError` so the gateway refuses to load
the document rather than silently allowing everything.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] Yes (describe below)

Policy documents using the unsupported top-level `rules:` (rule-list) schema now
**fail validation** instead of loading as an allow-all policy. This is intentional and
safer (fail-closed), but it means any such document — including the bundled
`policy-examples/{high-risk,low-risk,medium-risk}.yaml` examples — will be rejected
until rewritten in the section-based schema (`network`/`schedule`/`budget`/`data`/
`tools`/`capabilities`). See "Follow-up" below.

## Related Issues

- Related Jira ticket: AAASM-3351
- Closes AAASM-3351

## Scope / Assumptions / Follow-up

Per the fix spec, this is the **minimal, surgical, fail-closed** change. It does NOT
attempt full multi-schema support (parsing and honoring the rule-list/`GovernancePolicy`
schema). That is a deliberate follow-up:

- **Follow-up:** add first-class support for the rule-list / `GovernancePolicy` schema
  in the gateway engine, OR rewrite the bundled `policy-examples/{high-risk,low-risk,
  medium-risk}.yaml` (and any external `rules:`-based fixtures) into the section-based
  schema. Until then those examples are correctly rejected.

No `proto/` files were changed.

## Testing

- [x] Unit tests added / updated

Commits (granular, GitEmoji):
1. `♻️ (aa-gateway): Migrate test fixtures off unsupported rule-list schema` — the
   `simulation::engine` / `simulation::live` allow-all fixtures and the
   `scope_index_fixtures_test::pre_f92_fixture_without_scope_field_lands_in_global`
   test previously relied on the now-removed allow-all fallback; repointed to minimal
   valid section-based documents preserving the same intent.
2. `🐛 (aa-gateway): Fail closed on unsupported rule-list policy schema` — the fix.
3. `✅ (aa-gateway): Add regression test for rule-list schema rejection` — new test
   `rule_list_schema_is_a_validation_error_not_an_allow_all_warning`.

How to verify:
```
cd agent-assembly
export RUSTUP_TOOLCHAIN=stable
cargo build -p aa-gateway
cargo nextest run -p aa-gateway
```
All `aa-gateway` tests pass, **except** the unrelated hardware-performance SLA test
`policy_latency_test::sustained_load_p99_under_5ms` (asserts p99 < 15 ms), which fails
on a loaded developer machine and is independent of this change — it does not exercise
the policy validator or any `rules:` schema. It is a known timing-sensitive test
(excluded from coverage passes per repo policy).

QA evidence: see
`agent-assembly-integration-tests/verification-reports/base-branch-2026-06/`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy --all-targets`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (inline rationale comments; follow-up noted)
- [ ] All CI checks passing (pending CI)
- [x] Commits are small and follow the Gitmoji convention
