### PR TITLE
[AAASM-3353] 🐛 (aa-gateway): Accrue LLM spend + recover audit seq on restart

### DIFF
--- a/aa-gateway/src/audit.rs
+++ b/aa-gateway/src/audit.rs
@@ -216,6 +216,42 @@ impl AuditWriter {
         }
         Ok(last_hash)
     }
+
+    /// Read the `seq` of the last entry in a JSONL file.
+    ///
+    /// AAASM-3356 — on restart the service recovers the hash chain head via
+    /// [`read_last_hash`](Self::read_last_hash) but previously re-seeded the
+    /// `seq` counter at `0`, producing duplicate sequence numbers after a
+    /// restart. Pairing this with `read_last_hash` lets the service seed the
+    /// `seq` atomic from `last_seq + 1` so sequence numbers stay monotonic and
+    /// unique across process restarts.
+    ///
+    /// Returns `None` if the file does not exist or is empty.
+    /// Skips blank or incomplete trailing lines (standard JSONL recovery).
+    pub async fn read_last_seq(path: &Path) -> io::Result<Option<u64>> {
+        let file = match tokio::fs::File::open(path).await {
+            Ok(f) => f,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(e),
+        };
+        let reader = tokio::io::BufReader::new(file);
+        let mut lines = reader.lines();
+        let mut last_seq: Option<u64> = None;
+
+        while let Some(line) = lines.next_line().await? {
+            if line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<AuditEntry>(&line) {
+                Ok(entry) => last_seq = Some(entry.seq()),
+                Err(_) => {
+                    // Incomplete trailing line from a crash — skip it.
+                    continue;
+                }
+            }
+        }
+        Ok(last_seq)
+    }
 }
 
 /// Result of a hash-chain verification.

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -343,6 +343,15 @@ impl BudgetTracker {
         self.monthly_limit_usd
     }
 
+    /// Borrow the tracker's [`PricingTable`].
+    ///
+    /// AAASM-3353 — lets the service layer price an LLM call from the same
+    /// table the tracker uses for `record_usage`, so spend accrual and the
+    /// in-tracker cost lookup never diverge.
+    pub fn pricing(&self) -> &PricingTable {
+        &self.pricing
+    }
+
     /// Returns `true` if the agent has met or exceeded the given daily limit.
     ///
     /// Automatically resets spend to zero when the stored date is before today

--- a/aa-gateway/src/budget/types.rs
+++ b/aa-gateway/src/budget/types.rs
@@ -31,6 +31,44 @@ pub enum Model {
     CommandR,
 }
 
+impl Model {
+    /// Infer the `(Provider, Model)` pair from a free-form model name string.
+    ///
+    /// AAASM-3353 — the live `CheckAction` proto (`LlmCallContext`) carries only
+    /// the model name string; it does NOT carry a provider field. Rather than
+    /// change `proto/` (out of scope), the provider is inferred here from the
+    /// model name. The match is a case-insensitive substring test against the
+    /// known model families, ordered most-specific-first so that e.g.
+    /// `gpt-4o-2024-08-06` maps to `Gpt4o` (not `Gpt4`) and
+    /// `command-r-plus` maps to `CommandRPlus` (not `CommandR`).
+    ///
+    /// Returns `None` for an unrecognised model name — the caller treats an
+    /// unknown model as zero cost (no spend accrued) rather than guessing.
+    pub fn infer_from_name(name: &str) -> Option<(Provider, Self)> {
+        let n = name.to_ascii_lowercase();
+        // Most-specific patterns first; substrings of others must come earlier.
+        if n.contains("gpt-4o") || n.contains("gpt4o") {
+            Some((Provider::OpenAi, Model::Gpt4o))
+        } else if n.contains("gpt-3.5") || n.contains("gpt35") || n.contains("gpt-35") {
+            Some((Provider::OpenAi, Model::Gpt35Turbo))
+        } else if n.contains("gpt-4") || n.contains("gpt4") {
+            Some((Provider::OpenAi, Model::Gpt4))
+        } else if n.contains("opus") {
+            Some((Provider::Anthropic, Model::Claude3Opus))
+        } else if n.contains("sonnet") {
+            Some((Provider::Anthropic, Model::Claude3Sonnet))
+        } else if n.contains("haiku") {
+            Some((Provider::Anthropic, Model::Claude3Haiku))
+        } else if n.contains("command-r-plus") || n.contains("command-r+") {
+            Some((Provider::Cohere, Model::CommandRPlus))
+        } else if n.contains("command-r") {
+            Some((Provider::Cohere, Model::CommandR))
+        } else {
+            None
+        }
+    }
+}
+
 /// Discriminates which budget window a limit or check applies to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BudgetKind {

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1192,6 +1192,28 @@ impl PolicyEngine {
         }
     }
 
+    /// Price a completed LLM call in USD using the budget pricing table.
+    ///
+    /// AAASM-3353 — the live `CheckAction` proto carries only the model name
+    /// string and a prompt-token estimate (no provider, no output tokens).
+    /// The `(Provider, Model)` pair is inferred from the model name via
+    /// [`crate::budget::types::Model::infer_from_name`]; output tokens are
+    /// treated as `0` because the pre-execution check has no completion yet.
+    ///
+    /// Returns `0.0` for an unrecognised model (no spend accrued) so an
+    /// unknown name never silently charges against a wrong price.
+    pub fn llm_call_cost_usd(&self, model_name: &str, input_tokens: u64, output_tokens: u64) -> f64 {
+        let Some((provider, model)) = crate::budget::types::Model::infer_from_name(model_name) else {
+            return 0.0;
+        };
+        use rust_decimal::prelude::ToPrimitive;
+        self.budget
+            .pricing()
+            .cost_usd(provider, model, input_tokens, output_tokens)
+            .to_f64()
+            .unwrap_or(0.0)
+    }
+
     /// Resolve the budget tenancy (`team_id`, `org_id`) for `ctx` from the
     /// authoritative agent registry, falling back to the client-supplied
     /// `ctx` values only when no registry is attached or the agent is not

--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -76,13 +76,20 @@ async fn setup_audit(
     agent_id: &str,
     session_id: &str,
     storage: Option<Arc<dyn crate::storage::StorageBackend>>,
-) -> Result<(tokio::sync::mpsc::Sender<AuditEntry>, Arc<AtomicU64>, [u8; 32]), Box<dyn std::error::Error>> {
+) -> Result<(tokio::sync::mpsc::Sender<AuditEntry>, Arc<AtomicU64>, [u8; 32], u64), Box<dyn std::error::Error>> {
     let audit_dir = default_audit_dir();
 
-    // Read the last hash from the existing JSONL file (if any) so the hash
-    // chain is maintained across process restarts.
+    // Read the last hash AND seq from the existing JSONL file (if any) so both
+    // the hash chain and the monotonic sequence counter are maintained across
+    // process restarts. AAASM-3356: recovering only the hash (not the seq) made
+    // the seq counter restart at 0 and emit duplicate sequence numbers.
     let audit_path = audit_file_path(&audit_dir, agent_id, session_id);
     let initial_hash = AuditWriter::read_last_hash(&audit_path).await?.unwrap_or([0u8; 32]);
+    // `initial_seq` is the *next* seq to emit: last persisted seq + 1, or 0 for
+    // a fresh chain.
+    let initial_seq = AuditWriter::read_last_seq(&audit_path)
+        .await?
+        .map_or(0, |last| last + 1);
 
     let (audit_tx, audit_rx) = tokio::sync::mpsc::channel::<AuditEntry>(4096);
     let audit_drops = Arc::new(AtomicU64::new(0));
@@ -93,7 +100,7 @@ async fn setup_audit(
     }
     tokio::spawn(writer.run());
 
-    Ok((audit_tx, audit_drops, initial_hash))
+    Ok((audit_tx, audit_drops, initial_hash, initial_seq))
 }
 
 /// Load persisted budget state from `~/.aa/budget.json`, construct a
@@ -378,7 +385,7 @@ pub async fn serve_tcp(
     // an `ApprovalResolved` event so blocked agents need not poll. AAASM-2378.
     let approval_notifier: Arc<dyn ApprovalResolvedNotifier> = invalidation_hub.clone();
     approval_queue.set_resolved_notifier(approval_notifier);
-    let (audit_tx, audit_drops, initial_hash) = setup_audit("gateway", "default", storage).await?;
+    let (audit_tx, audit_drops, initial_hash, initial_seq) = setup_audit("gateway", "default", storage).await?;
     let escalation_scheduler = start_escalation_scheduler();
     let db_token = CancellationToken::new();
     let db_scheduler = start_db_escalation_scheduler(Arc::clone(&approval_queue), db_token.clone()).await;
@@ -394,6 +401,7 @@ pub async fn serve_tcp(
         Arc::clone(&audit_drops),
         initial_hash,
     )
+    .with_initial_seq(initial_seq)
     .with_db_scheduler(db_scheduler.clone());
     let audit_svc = AuditServiceImpl::new_with_registry(audit_tx, audit_drops, initial_hash, Arc::clone(&registry));
     let (edge_repo, _cross_team_rx) = InMemoryEdgeRepo::with_events(Arc::clone(&registry));
@@ -455,7 +463,7 @@ pub async fn serve_uds(
     // an `ApprovalResolved` event so blocked agents need not poll. AAASM-2378.
     let approval_notifier: Arc<dyn ApprovalResolvedNotifier> = invalidation_hub.clone();
     approval_queue.set_resolved_notifier(approval_notifier);
-    let (audit_tx, audit_drops, initial_hash) = setup_audit("gateway", "default", storage).await?;
+    let (audit_tx, audit_drops, initial_hash, initial_seq) = setup_audit("gateway", "default", storage).await?;
     let escalation_scheduler = start_escalation_scheduler();
     let db_token = CancellationToken::new();
     let db_scheduler = start_db_escalation_scheduler(Arc::clone(&approval_queue), db_token.clone()).await;
@@ -471,6 +479,7 @@ pub async fn serve_uds(
         Arc::clone(&audit_drops),
         initial_hash,
     )
+    .with_initial_seq(initial_seq)
     .with_db_scheduler(db_scheduler.clone());
     let audit_svc = AuditServiceImpl::new_with_registry(audit_tx, audit_drops, initial_hash, Arc::clone(&registry));
     let (edge_repo, _cross_team_rx) = InMemoryEdgeRepo::with_events(Arc::clone(&registry));

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -212,6 +212,20 @@ impl PolicyServiceImpl {
         self
     }
 
+    /// Seed the audit `seq` counter so sequence numbers continue monotonically
+    /// across process restarts (AAASM-3356).
+    ///
+    /// `initial_seq` should be the *next* sequence number to emit — i.e.
+    /// `last_persisted_seq + 1`, obtained from
+    /// [`AuditWriter::read_last_seq`](crate::audit::AuditWriter::read_last_seq).
+    /// Without this, the counter restarts at `0` and produces duplicate `seq`
+    /// values after a restart, breaking the WORM log's per-entry uniqueness.
+    /// Mirrors the `initial_hash` recovery already done for the hash chain.
+    pub fn with_initial_seq(self, initial_seq: u64) -> Self {
+        self.seq.store(initial_seq, Ordering::Relaxed);
+        self
+    }
+
     /// Attach a broadcast sender for secret-detection alerts (AAASM-1545).
     ///
     /// When present, the service publishes a [`SecretAlert`] each time a

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -1016,6 +1016,54 @@ impl PolicyServiceImpl {
         }
     }
 
+    /// AAASM-3353 — accrue the cost of a non-denied LLM call against the
+    /// agent's budget so daily / monthly limits actually fire.
+    ///
+    /// The live `CheckAction` handler previously only called `engine.evaluate`,
+    /// which *reads* accumulated spend (Stage 7) but never *records* it — so
+    /// `record_spend` had no caller outside tests and limits never triggered.
+    /// This closes the loop: after an Allow / Redact / Pending decision on an
+    /// `LLM_CALL`, the call is priced from the model name (provider inferred,
+    /// see [`crate::engine::PolicyEngine::llm_call_cost_usd`]) and accrued via
+    /// the existing `engine.record_spend` budget path. A subsequent call then
+    /// trips the Stage-7 budget check once the limit is exceeded.
+    ///
+    /// No-ops when:
+    /// * the action is not an `LLM_CALL`;
+    /// * the decision was a hard `Deny` (a denied call did not run, so it must
+    ///   not be charged);
+    /// * the model name is unrecognised (cost resolves to `0.0`).
+    fn maybe_accrue_llm_spend(&self, req: &CheckActionRequest, response: &CheckActionResponse) {
+        use aa_proto::assembly::policy::v1::action_context::Action;
+
+        // A hard Deny means the call was blocked — do not accrue spend.
+        if response.decision == aa_proto::assembly::common::v1::Decision::Deny as i32 {
+            return;
+        }
+
+        let Some(Action::LlmCall(lc)) = req.context.as_ref().and_then(|c| c.action.as_ref()) else {
+            return;
+        };
+
+        let input_tokens = lc.prompt_tokens.max(0) as u64;
+        // The pre-execution check has no completion yet, so output tokens are 0.
+        let cost = self.engine.llm_call_cost_usd(&lc.model, input_tokens, 0);
+        if cost <= 0.0 {
+            return;
+        }
+
+        // Rebuild the AgentContext for tenancy resolution. `record_spend` keys
+        // budget on the agent's *registered* owner (AAASM-3138) and only uses
+        // ctx tenancy as a fallback, so the governance_level override applied
+        // in `evaluate_one` is irrelevant here.
+        match convert::request_to_core(req) {
+            Ok((ctx, _action)) => self.engine.record_spend(&ctx, cost),
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to rebuild ctx for LLM spend accrual");
+            }
+        }
+    }
+
     /// Compose the live-ops registry id and ingest if a registry is attached.
     ///
     /// Returns `Some(op_id)` when ingestion happened so the caller can drive
@@ -1158,6 +1206,9 @@ impl PolicyService for PolicyServiceImpl {
         // Suspend the agent if the engine signaled SuspendAgent.
         self.maybe_suspend_agent(&req, deny_action).await;
 
+        // AAASM-3353: accrue LLM-call cost so daily / monthly budget limits fire.
+        self.maybe_accrue_llm_spend(&req, &response);
+
         // Fire-and-forget audit entry — never blocks the response.
         self.record_audit(&req, &response, &eval, shadow_event.as_ref()).await;
 
@@ -1188,6 +1239,8 @@ impl PolicyService for PolicyServiceImpl {
                 convert::eval_result_to_response(&eval, latency_us, &policy_rule)
             };
             self.maybe_suspend_agent(req, deny_action).await;
+            // AAASM-3353: accrue LLM-call cost so budget limits fire in batch mode too.
+            self.maybe_accrue_llm_spend(req, &resp);
             self.record_audit(req, &resp, &eval, shadow_event.as_ref()).await;
             responses.push(resp);
         }

--- a/aa-gateway/tests/audit_seq_recovery_test.rs
+++ b/aa-gateway/tests/audit_seq_recovery_test.rs
@@ -1,0 +1,126 @@
+//! AAASM-3356 — audit `seq` recovery across process restarts.
+//!
+//! Regression: the service seeded `seq: AtomicU64::new(0)` and, on restart,
+//! recovered the hash-chain head but NOT the seq, so sequence numbers restarted
+//! at 0 and produced duplicates in the WORM log. `with_initial_seq` (seeded from
+//! `AuditWriter::read_last_seq`) fixes this. This test drives `check_action`
+//! across a simulated restart and asserts the seq continues monotonically.
+
+use std::io::Write;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+
+use aa_core::AuditEntry;
+use aa_gateway::service::PolicyServiceImpl;
+use aa_gateway::PolicyEngine;
+use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId};
+use aa_proto::assembly::policy::v1::action_context::Action;
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyService;
+use aa_proto::assembly::policy::v1::{ActionContext, CheckActionRequest, ToolCallContext};
+use tokio::sync::mpsc;
+use tonic::Request;
+
+const POLICY_YAML: &str = r#"
+version: "1"
+tools:
+  web_search:
+    allow: true
+"#;
+
+fn make_engine() -> Arc<PolicyEngine> {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", POLICY_YAML).unwrap();
+    tmp.flush().unwrap();
+    let (alert_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    Arc::new(PolicyEngine::load_from_file(tmp.path(), alert_tx).unwrap())
+}
+
+fn tool_call_request() -> CheckActionRequest {
+    CheckActionRequest {
+        agent_id: Some(ProtoAgentId {
+            org_id: "org".into(),
+            team_id: "team".into(),
+            agent_id: "agent-1".into(),
+        }),
+        action_type: ActionType::ToolCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::ToolCall(ToolCallContext {
+                tool_name: "web_search".into(),
+                tool_source: "mcp".into(),
+                args_json: b"{}".to_vec(),
+                target_url: String::new(),
+            })),
+        }),
+        trace_id: "trace-seq".into(),
+        span_id: "span-seq".into(),
+        credential_token: String::new(),
+        caller_agent_id: None,
+    }
+}
+
+#[tokio::test]
+async fn seq_continues_monotonically_after_restart() {
+    let engine = make_engine();
+
+    // ── First "process": emit two entries (seq 0 and 1). ───────────────────
+    let (audit_tx, mut audit_rx) = mpsc::channel::<AuditEntry>(4096);
+    let drops = Arc::new(AtomicU64::new(0));
+    let svc = PolicyServiceImpl::new(Arc::clone(&engine), audit_tx, drops, [0u8; 32]);
+
+    svc.check_action(Request::new(tool_call_request())).await.unwrap();
+    svc.check_action(Request::new(tool_call_request())).await.unwrap();
+    drop(svc); // close the tx so the receiver drains to completion
+
+    let mut first_run_seqs = Vec::new();
+    while let Some(entry) = audit_rx.recv().await {
+        first_run_seqs.push(entry.seq());
+    }
+    assert_eq!(first_run_seqs, vec![0, 1], "first run must emit seqs 0 and 1");
+    let last_seq = *first_run_seqs.last().unwrap();
+
+    // ── Restart: seed the new service from last_seq + 1. ───────────────────
+    let (audit_tx2, mut audit_rx2) = mpsc::channel::<AuditEntry>(4096);
+    let drops2 = Arc::new(AtomicU64::new(0));
+    let svc2 = PolicyServiceImpl::new(Arc::clone(&engine), audit_tx2, drops2, [0u8; 32]).with_initial_seq(last_seq + 1);
+
+    svc2.check_action(Request::new(tool_call_request())).await.unwrap();
+    drop(svc2);
+
+    let mut second_run_seqs = Vec::new();
+    while let Some(entry) = audit_rx2.recv().await {
+        second_run_seqs.push(entry.seq());
+    }
+
+    assert_eq!(
+        second_run_seqs,
+        vec![2],
+        "post-restart seq must continue at {} (no duplicate of {:?})",
+        last_seq + 1,
+        first_run_seqs
+    );
+}
+
+#[tokio::test]
+async fn without_recovery_seq_would_duplicate() {
+    // Demonstrates the bug shape: a fresh service WITHOUT `with_initial_seq`
+    // restarts the counter at 0, duplicating the previous run's seqs.
+    let engine = make_engine();
+
+    let (audit_tx, mut audit_rx) = mpsc::channel::<AuditEntry>(4096);
+    let drops = Arc::new(AtomicU64::new(0));
+    let svc = PolicyServiceImpl::new(Arc::clone(&engine), audit_tx, drops, [0u8; 32]);
+    svc.check_action(Request::new(tool_call_request())).await.unwrap();
+    drop(svc);
+    let first = audit_rx.recv().await.unwrap().seq();
+    assert_eq!(first, 0);
+
+    let (audit_tx2, mut audit_rx2) = mpsc::channel::<AuditEntry>(4096);
+    let drops2 = Arc::new(AtomicU64::new(0));
+    let svc2 = PolicyServiceImpl::new(Arc::clone(&engine), audit_tx2, drops2, [0u8; 32]);
+    svc2.check_action(Request::new(tool_call_request())).await.unwrap();
+    drop(svc2);
+    let second = audit_rx2.recv().await.unwrap().seq();
+
+    // Without recovery the second run also starts at 0 — a duplicate.
+    assert_eq!(second, 0, "fresh service (no recovery) duplicates seq 0");
+}

--- a/aa-gateway/tests/audit_test.rs
+++ b/aa-gateway/tests/audit_test.rs
@@ -162,3 +162,37 @@ async fn read_last_hash_returns_none_for_missing_file() {
     let hash = AuditWriter::read_last_hash(&path).await.unwrap();
     assert_eq!(hash, None);
 }
+
+// AAASM-3356: the service must recover the last seq across restarts so the
+// monotonic sequence counter does not restart at 0 (which would emit duplicate
+// sequence numbers in the WORM log).
+#[tokio::test]
+async fn read_last_seq_returns_last_entry_seq() {
+    let dir = tempfile::tempdir().unwrap();
+    let (tx, rx) = mpsc::channel(64);
+    let writer = AuditWriter::new(dir.path().to_path_buf(), "agent-s", "sess-s", rx)
+        .await
+        .unwrap();
+
+    tokio::spawn(writer.run());
+
+    // Chain of 5 entries → seqs 0..=4, so the last seq is 4.
+    let entries = make_chain(5);
+    for entry in &entries {
+        tx.send(entry.clone()).await.unwrap();
+    }
+    drop(tx);
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let path = dir.path().join("agent-s-sess-s.jsonl");
+    let seq = AuditWriter::read_last_seq(&path).await.unwrap();
+    assert_eq!(seq, Some(4));
+}
+
+#[tokio::test]
+async fn read_last_seq_returns_none_for_missing_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("nonexistent.jsonl");
+    let seq = AuditWriter::read_last_seq(&path).await.unwrap();
+    assert_eq!(seq, None);
+}

--- a/aa-gateway/tests/budget_accrual_test.rs
+++ b/aa-gateway/tests/budget_accrual_test.rs
@@ -1,0 +1,120 @@
+//! AAASM-3353 — LLM-call budget accrual in the live `CheckAction` handler.
+//!
+//! Regression: the gRPC handler used to call only `engine.evaluate` (which
+//! *reads* accumulated spend at Stage 7) but never *recorded* spend, so daily /
+//! monthly budget limits never fired. These tests drive `check_action` directly
+//! and assert that spend accrues and a later call is denied once the limit is
+//! exceeded.
+
+use std::io::Write;
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+
+use aa_core::AuditEntry;
+use aa_gateway::service::PolicyServiceImpl;
+use aa_gateway::PolicyEngine;
+use aa_proto::assembly::common::v1::{ActionType, AgentId as ProtoAgentId, Decision};
+use aa_proto::assembly::policy::v1::action_context::Action;
+use aa_proto::assembly::policy::v1::policy_service_server::PolicyService;
+use aa_proto::assembly::policy::v1::{ActionContext, CheckActionRequest, LlmCallContext};
+use tokio::sync::mpsc;
+use tonic::Request;
+
+/// Daily limit of $0.50. A single gpt-4o call with 200k prompt tokens costs
+/// `0.005 * 200 = $1.00`, which exceeds the limit on the *next* check.
+const BUDGET_YAML: &str = r#"
+version: "1"
+budget:
+  daily_limit_usd: 0.5
+  action_on_exceed: deny
+"#;
+
+fn make_service(audit_tx: mpsc::Sender<AuditEntry>) -> PolicyServiceImpl {
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    write!(tmp, "{}", BUDGET_YAML).unwrap();
+    tmp.flush().unwrap();
+    let (alert_tx, _) = tokio::sync::broadcast::channel::<aa_gateway::budget::BudgetAlert>(64);
+    let engine = PolicyEngine::load_from_file(tmp.path(), alert_tx).unwrap();
+    let audit_drops = Arc::new(AtomicU64::new(0));
+    PolicyServiceImpl::new(Arc::new(engine), audit_tx, audit_drops, [0u8; 32])
+}
+
+fn llm_call_request(model: &str, prompt_tokens: i32) -> CheckActionRequest {
+    CheckActionRequest {
+        agent_id: Some(ProtoAgentId {
+            org_id: "org".into(),
+            team_id: "team".into(),
+            agent_id: "agent-1".into(),
+        }),
+        action_type: ActionType::LlmCall as i32,
+        context: Some(ActionContext {
+            action: Some(Action::LlmCall(LlmCallContext {
+                model: model.into(),
+                prompt_tokens,
+                contains_pii: false,
+            })),
+        }),
+        trace_id: "trace-budget".into(),
+        span_id: "span-budget".into(),
+        credential_token: String::new(),
+        caller_agent_id: None,
+    }
+}
+
+#[tokio::test]
+async fn llm_spend_accrues_and_later_call_is_denied_once_limit_exceeded() {
+    let (audit_tx, _audit_rx) = mpsc::channel::<AuditEntry>(4096);
+    let service = make_service(audit_tx);
+
+    // First call: spend is $0 at evaluation, so it is allowed. It then accrues
+    // $1.00 (gpt-4o, 200k prompt tokens) against the agent's daily budget.
+    let first = service
+        .check_action(Request::new(llm_call_request("gpt-4o", 200_000)))
+        .await
+        .expect("first check_action ok")
+        .into_inner();
+    assert_eq!(
+        first.decision,
+        Decision::Allow as i32,
+        "first call must be allowed (no spend recorded yet)"
+    );
+
+    // Second call: accumulated spend ($1.00) now exceeds the $0.50 daily limit,
+    // so Stage 7 denies it. Without accrual this would (incorrectly) be allowed.
+    let second = service
+        .check_action(Request::new(llm_call_request("gpt-4o", 200_000)))
+        .await
+        .expect("second check_action ok")
+        .into_inner();
+    assert_eq!(
+        second.decision,
+        Decision::Deny as i32,
+        "second call must be denied once accrued spend exceeds the daily limit"
+    );
+    assert!(
+        second.reason.contains("budget"),
+        "deny reason must reference the budget, got: {}",
+        second.reason
+    );
+}
+
+#[tokio::test]
+async fn unknown_model_accrues_no_spend() {
+    let (audit_tx, _audit_rx) = mpsc::channel::<AuditEntry>(4096);
+    let service = make_service(audit_tx);
+
+    // An unrecognised model name prices to $0.00, so no spend accrues and a
+    // large number of calls all stay allowed.
+    for _ in 0..5 {
+        let resp = service
+            .check_action(Request::new(llm_call_request("some-unknown-model", 1_000_000)))
+            .await
+            .expect("check_action ok")
+            .into_inner();
+        assert_eq!(
+            resp.decision,
+            Decision::Allow as i32,
+            "unknown model must accrue no spend and stay allowed"
+        );
+    }
+}


### PR DESCRIPTION
## Description

Two QA-round bug fixes that both live in `aa-gateway/src/service/policy_service.rs`, so they ship as one PR.

**D — AAASM-3353 (budget accrual):** The live `CheckAction` gRPC handler called only `engine.evaluate`, which *reads* accumulated spend at Stage 7 but never *records* it. `PolicyEngine::record_spend` / `BudgetTracker::check_and_decrement` had no caller outside tests, so daily/monthly budget limits never fired. This PR closes the loop: after a non-deny `LLM_CALL`, the call is priced from the model name and accrued via the existing `engine.record_spend` budget path (in both `check_action` and `batch_check`), so a later call is denied once the limit is exceeded.

**G — AAASM-3356 (audit seq recovery):** The service seeded `seq: AtomicU64::new(0)` and, on restart, recovered the hash-chain head (`read_last_hash`) but **not** the seq, so sequence numbers restarted at `0` and produced duplicate `seq` values in the WORM log. This PR adds `AuditWriter::read_last_seq`, a `PolicyServiceImpl::with_initial_seq` builder, and seeds the seq atomic from `last_persisted_seq + 1` at startup — mirroring the existing hash recovery.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

`setup_audit` (a private fn in `server.rs`) gained a fourth return value (`initial_seq`); no public API changed. `with_initial_seq` is an additive builder.

## Assumptions & scope notes

- **Provider is not in the proto.** Per spec, `proto/` was not changed. The `LlmCallContext` proto carries only the model name string (`model`), a `prompt_tokens` estimate, and `contains_pii` — no provider, no output tokens. The provider is therefore **inferred from the model name** via a new `Model::infer_from_name` helper (case-insensitive substring match, most-specific-first). NOTE: the spec said to put the helper "in aa-core", but the `Provider`/`Model` enums live in `aa-gateway::budget::types` (not aa-core), so the helper lives next to those enums. Moving the enums/helper into aa-core is a larger refactor and is left as a follow-up.
- **Output tokens are treated as 0** when pricing — the pre-execution check has no completion yet, so only input (prompt) tokens are charged. A post-execution true-up (e.g. via `ToolResult`) is a possible follow-up.
- **Unknown model → $0.00** (no spend accrued) rather than guessing a price.
- **Denied calls are not charged** (a hard `Deny` means the call did not run).
- **AuditService's independent seq.** This PR fixes only the `PolicyService` seq per the ticket scope. `AuditServiceImpl` keeps its own independent seq counter (also seeded from `initial_hash` only); that is a pre-existing, separate concern not regressed here and can be addressed in a follow-up if the two writers' sequence spaces need to be unified.

## Related Issues

- Closes AAASM-3353
- Closes AAASM-3356

## Testing

- [x] Unit tests added / updated
- [x] Integration tests added / updated

- `tests/budget_accrual_test.rs` — first `LLM_CALL` allowed and accrues spend; a second call is denied once accrued spend exceeds the daily limit; an unknown model accrues nothing.
- `tests/audit_seq_recovery_test.rs` — seq continues monotonically across a simulated restart (no duplicate of the prior run's seqs); a control case shows a fresh service without recovery duplicates `seq 0`.
- `tests/audit_test.rs` — `read_last_seq` returns the last entry's seq and `None` for a missing file.
- Full crate suite: `cargo nextest run -p aa-gateway` → **1121 passed, 0 failed**.
- `cargo fmt -p aa-gateway`, `cargo clippy -p aa-gateway --all-targets` clean.

QA evidence: see `agent-assembly-integration-tests/verification-reports/base-branch-2026-06/`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (doc comments on new APIs)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
