### PR TITLE
[AAASM-3358] ♻️ (agent-assembly): Reduce rust:S3776 cognitive complexity

### DIFF
--- a/aa-api/src/ws/handler.rs
+++ b/aa-api/src/ws/handler.rs
@@ -74,17 +74,14 @@ async fn handle_socket(socket: WebSocket, params: WsQueryParams, state: AppState
     let allowed_types = params.event_types();
     let agent_filter = params.agent_id.clone();
 
-    // Replay buffered events if `since` was provided.
+    // Replay buffered events if `since` was provided. A send failure during
+    // replay means the client is gone — abandon the connection.
     if let Some(since_id) = params.since {
-        let events = state.replay_buffer.events_since(since_id);
-        let replay_sender = sender.clone();
-        for event in events {
-            if !matches_filter(&event, &allowed_types, agent_filter.as_deref()) {
-                continue;
-            }
-            if send_event(&replay_sender, &event).await.is_err() {
-                return;
-            }
+        if replay_buffered_events(&state, &sender, since_id, &allowed_types, agent_filter.as_deref())
+            .await
+            .is_err()
+        {
+            return;
         }
     }
 
@@ -453,6 +450,25 @@ fn detail_op_fields(
         Detail::Violation(d) => (Some(d.blocked_action.clone()), nonzero_latency(d.latency_ms)),
         Detail::Approval(_) => (None, None),
     }
+}
+
+/// Replay buffered events with id > `since_id`, applying the client's type and
+/// agent filters. Returns `Err(())` if a send fails (the client is gone) so the
+/// caller can abandon the connection; `Ok(())` when all matching events are sent.
+async fn replay_buffered_events(
+    state: &AppState,
+    sender: &std::sync::Arc<tokio::sync::Mutex<SplitSink<WebSocket, Message>>>,
+    since_id: u64,
+    allowed_types: &[EventType],
+    agent_filter: Option<&str>,
+) -> Result<(), ()> {
+    for event in state.replay_buffer.events_since(since_id) {
+        if !matches_filter(&event, allowed_types, agent_filter) {
+            continue;
+        }
+        send_event(sender, &event).await?;
+    }
+    Ok(())
 }
 
 /// Serialise a governance event and send it as a WebSocket text frame.

--- a/aa-cli/src/commands/approvals/watch.rs
+++ b/aa-cli/src/commands/approvals/watch.rs
@@ -241,15 +241,8 @@ pub async fn run_watch_interactive(mut ws: WsStream, ctx: &ResolvedContext) {
         }
 
         // Check for new WebSocket messages (non-blocking).
-        match ws.next().now_or_never() {
-            Some(Some(Ok(Message::Text(text)))) => {
-                if let Ok(approval) = serde_json::from_str::<ApprovalResponse>(&text) {
-                    state.items.push(approval);
-                    state.dirty = true;
-                }
-            }
-            Some(Some(Ok(Message::Close(_)))) | Some(None) => break,
-            _ => {}
+        if poll_ws_message(&mut ws, &mut state) {
+            break;
         }
 
         if state.dirty {
@@ -260,6 +253,23 @@ pub async fn run_watch_interactive(mut ws: WsStream, ctx: &ResolvedContext) {
 
     terminal::disable_raw_mode().ok();
     println!();
+}
+
+/// Non-blocking poll of the WebSocket: append a newly-received approval to the
+/// interactive list (marking it dirty) and report whether the loop should break
+/// (server-side close or stream end). `false` when nothing actionable arrived.
+fn poll_ws_message(ws: &mut WsStream, state: &mut InteractiveState) -> bool {
+    match ws.next().now_or_never() {
+        Some(Some(Ok(Message::Text(text)))) => {
+            if let Ok(approval) = serde_json::from_str::<ApprovalResponse>(&text) {
+                state.items.push(approval);
+                state.dirty = true;
+            }
+            false
+        }
+        Some(Some(Ok(Message::Close(_)))) | Some(None) => true,
+        _ => false,
+    }
 }
 
 /// Drop the resolved approval `id` from the interactive list and clamp the

--- a/aa-cli/src/commands/dashboard/mod.rs
+++ b/aa-cli/src/commands/dashboard/mod.rs
@@ -165,26 +165,7 @@ async fn handle_key_event(
     }
     // If a confirm dialog is showing, intercept y/n/Esc.
     if let Some(dialog_action) = state.confirm_dialog {
-        match key.code {
-            KeyCode::Char('y') => {
-                if let Some(approval) = dialog_approval {
-                    match dialog_action {
-                        DialogAction::Approve => {
-                            let _ = approvals_client::approve_action(ctx, &approval.id, Some("approved via dashboard"))
-                                .await;
-                        }
-                        DialogAction::Reject => {
-                            let _ = approvals_client::reject_action(ctx, &approval.id, "rejected via dashboard").await;
-                        }
-                    }
-                }
-                state.confirm_dialog = None;
-            }
-            KeyCode::Char('n') | KeyCode::Esc => {
-                state.confirm_dialog = None;
-            }
-            _ => {}
-        }
+        handle_confirm_dialog_key(state, ctx, key, dialog_action, dialog_approval).await;
         return;
     }
 
@@ -206,6 +187,38 @@ async fn handle_key_event(
             state.show_policy = true;
         }
         InputAction::None => {}
+    }
+}
+
+/// Handle a key while the approve/reject confirm dialog is open. `y` commits the
+/// pending `dialog_action` over the API (when an approval is selected); `n`/`Esc`
+/// cancels. Any handled key clears the dialog; other keys are ignored.
+async fn handle_confirm_dialog_key(
+    state: &mut DashboardState,
+    ctx: &ResolvedContext,
+    key: crossterm::event::KeyEvent,
+    dialog_action: DialogAction,
+    dialog_approval: Option<&crate::commands::status::models::ApprovalResponse>,
+) {
+    match key.code {
+        KeyCode::Char('y') => {
+            if let Some(approval) = dialog_approval {
+                match dialog_action {
+                    DialogAction::Approve => {
+                        let _ =
+                            approvals_client::approve_action(ctx, &approval.id, Some("approved via dashboard")).await;
+                    }
+                    DialogAction::Reject => {
+                        let _ = approvals_client::reject_action(ctx, &approval.id, "rejected via dashboard").await;
+                    }
+                }
+            }
+            state.confirm_dialog = None;
+        }
+        KeyCode::Char('n') | KeyCode::Esc => {
+            state.confirm_dialog = None;
+        }
+        _ => {}
     }
 }
 

--- a/aa-gateway/src/budget/tracker.rs
+++ b/aa-gateway/src/budget/tracker.rs
@@ -442,27 +442,30 @@ impl BudgetTracker {
         monthly_limit: Option<Decimal>,
         daily_limit: Option<Decimal>,
     ) -> bool {
-        if let Some(limit) = monthly_limit {
-            if let Some(state) = budgets.get(key) {
-                if let Some(monthly) = state.monthly_spent_usd {
-                    if self.check_limit_and_alert(agent_id, alert_team_id, monthly, limit)
-                        == BudgetStatus::LimitExceeded
-                    {
-                        return true;
-                    }
-                }
+        // Monthly takes precedence: only the recorded monthly spend (when set)
+        // participates, then today's spend against the daily limit.
+        let monthly_spent = monthly_limit
+            .zip(budgets.get(key).and_then(|s| s.monthly_spent_usd))
+            .map(|(limit, spent)| (spent, limit));
+        if let Some((spent, limit)) = monthly_spent {
+            if self.spend_exceeds(agent_id, alert_team_id, spent, limit) {
+                return true;
             }
         }
-        if let Some(limit) = daily_limit {
-            if let Some(state) = budgets.get(key) {
-                if self.check_limit_and_alert(agent_id, alert_team_id, state.spent_usd, limit)
-                    == BudgetStatus::LimitExceeded
-                {
-                    return true;
-                }
+        let daily = daily_limit.and_then(|limit| budgets.get(key).map(|s| (s.spent_usd, limit)));
+        if let Some((spent, limit)) = daily {
+            if self.spend_exceeds(agent_id, alert_team_id, spent, limit) {
+                return true;
             }
         }
         false
+    }
+
+    /// Run [`Self::check_limit_and_alert`] for one `(spent, limit)` pair and
+    /// report whether the limit is exceeded (emitting any threshold alert as a
+    /// side effect).
+    fn spend_exceeds(&self, agent_id: AgentId, alert_team_id: Option<&str>, spent: Decimal, limit: Decimal) -> bool {
+        self.check_limit_and_alert(agent_id, alert_team_id, spent, limit) == BudgetStatus::LimitExceeded
     }
 
     /// Shared cost-recording logic used by both [`record_usage`](Self::record_usage)

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -714,9 +714,7 @@ impl PolicyEngine {
     ) -> Option<EvaluationResult> {
         // Stages 3-5 apply to ToolCall; stage 5b applies to SendMessage.
         match action {
-            aa_core::GovernanceAction::ToolCall { name, .. } => {
-                self.eval_toolcall_stages(policy, ctx, name, action)
-            }
+            aa_core::GovernanceAction::ToolCall { name, .. } => self.eval_toolcall_stages(policy, ctx, name, action),
             // Stage 5b — Approval condition for SendMessage (channel policy).
             aa_core::GovernanceAction::SendMessage { .. } => {
                 self.eval_approval_condition(policy, policy.tools.get("message"), ctx, action)

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -233,6 +233,17 @@ pub enum PolicyLoadError {
     History(crate::policy::history::PolicyHistoryError),
 }
 
+/// Stage 6 outcome for [`PolicyEngine::apply_credential_scan`]: either a
+/// hard-block deny (the `credential_action: block` short-circuit) or the
+/// redacted payload + findings to carry into the remaining stages.
+enum CredentialScanOutcome {
+    /// `credential_action: block` with at least one finding — deny outright,
+    /// the payload never reaches the LLM in any form.
+    Block(EvaluationResult),
+    /// Continue evaluation with this (redacted_payload, findings) pair.
+    Continue(Option<String>, Vec<aa_security::CredentialFinding>),
+}
+
 impl PolicyEngine {
     /// Load a policy from a YAML file, parse it, validate it, and start the filesystem watcher.
     ///
@@ -823,6 +834,67 @@ impl PolicyEngine {
         bucket.try_consume()
     }
 
+    /// Apply the shared Stage 6 credential decision over already-collected
+    /// `all_findings` for `text` under the resolved `credential_action`.
+    ///
+    /// Identical for the single-policy and cascade paths: `block` + findings →
+    /// deny; `alert_only` forwards the unredacted payload (the only path that
+    /// leaks the raw secret, AAASM-3137); every other mode redacts in-memory.
+    /// Findings are sorted by offset for deterministic output.
+    fn apply_credential_scan(
+        text: &str,
+        mut all_findings: Vec<aa_security::CredentialFinding>,
+        credential_action: CredentialAction,
+    ) -> CredentialScanOutcome {
+        // Hard-block path: short-circuit every downstream stage.
+        if credential_action == CredentialAction::Block && !all_findings.is_empty() {
+            all_findings.sort_by_key(|f| f.offset);
+            return CredentialScanOutcome::Block(EvaluationResult {
+                decision: aa_core::PolicyResult::Deny {
+                    reason: "credential detected".into(),
+                },
+                redacted_payload: None,
+                credential_findings: all_findings,
+                deny_action: None,
+            });
+        }
+
+        if all_findings.is_empty() {
+            return CredentialScanOutcome::Continue(None, vec![]);
+        }
+
+        // Sort by offset for deterministic redaction order.
+        all_findings.sort_by_key(|f| f.offset);
+        // TODO(AAASM-31): wrap in EnrichedEvent::DataLeak(DataLeakEvent { ... }) and
+        // send on the broadcast_tx once AAASM-31 adds the DataLeak variant to EnrichedEvent.
+        tracing::warn!(
+            finding_count = all_findings.len(),
+            "DataLeakEvent emission pending AAASM-31 EnrichedEvent::DataLeak variant"
+        );
+        if credential_action == CredentialAction::AlertAndRedact {
+            // AAASM-3137: alert AND redact — notify but never leak the secret.
+            tracing::warn!(
+                finding_count = all_findings.len(),
+                "credential_action=alert_and_redact: alert emission pending AAASM-1545"
+            );
+        }
+        if credential_action == CredentialAction::AlertOnly {
+            // SECURITY (AAASM-3137): the ONLY path that forwards the raw secret.
+            // A documented, deliberate audit-only downgrade; alert side-effect
+            // emission is wired by sibling subtask AAASM-1545.
+            tracing::warn!(
+                finding_count = all_findings.len(),
+                "credential_action=alert_only: forwarding UNREDACTED payload (alert emission pending AAASM-1545)"
+            );
+            return CredentialScanOutcome::Continue(None, all_findings);
+        }
+        let merged = aa_security::ScanResult {
+            findings: all_findings.clone(),
+        };
+        let redacted = merged.redact(text);
+        CredentialScanOutcome::Continue(Some(redacted), all_findings)
+    }
+
     /// Single-policy evaluation path: used when no scoped policies are registered.
     ///
     /// This is the original 7-stage pipeline from before AAASM-220. When the
@@ -865,67 +937,11 @@ impl PolicyEngine {
 
         let credential_action = policy.data.as_ref().map(|d| d.credential_action).unwrap_or_default();
 
-        // Hard-block path: a finding with `credential_action: block` short-circuits
-        // every downstream stage so the payload never reaches the LLM in any form.
-        if credential_action == CredentialAction::Block && !all_findings.is_empty() {
-            all_findings.sort_by_key(|f| f.offset);
-            return EvaluationResult {
-                decision: aa_core::PolicyResult::Deny {
-                    reason: "credential detected".into(),
-                },
-                redacted_payload: None,
-                credential_findings: all_findings,
-                deny_action: None,
+        let (redacted_payload, credential_findings) =
+            match Self::apply_credential_scan(text, all_findings, credential_action) {
+                CredentialScanOutcome::Block(result) => return result,
+                CredentialScanOutcome::Continue(payload, findings) => (payload, findings),
             };
-        }
-
-        let (redacted_payload, credential_findings) = if all_findings.is_empty() {
-            (None, vec![])
-        } else {
-            // Sort by offset for deterministic redaction order.
-            all_findings.sort_by_key(|f| f.offset);
-            // TODO(AAASM-31): wrap in EnrichedEvent::DataLeak(DataLeakEvent { ... }) and
-            // send on the broadcast_tx once AAASM-31 adds the DataLeak variant to EnrichedEvent.
-            // DataLeakEvent fields are available here:
-            //   agent_id:         ctx.agent_id
-            //   session_id:       ctx.session_id
-            //   timestamp_ns:     <now>
-            //   finding_count:    all_findings.len()
-            //   credential_kinds: all_findings.iter().map(|f| f.kind.as_str())
-            //   policy_name:      policy.version.as_deref().unwrap_or("unknown")
-            tracing::warn!(
-                finding_count = all_findings.len(),
-                "DataLeakEvent emission pending AAASM-31 EnrichedEvent::DataLeak variant"
-            );
-            if credential_action == CredentialAction::AlertAndRedact {
-                // AAASM-3137: emit the alert AND redact — the operator is
-                // notified, but the raw secret is still removed before forward.
-                tracing::warn!(
-                    finding_count = all_findings.len(),
-                    "credential_action=alert_and_redact: alert emission pending AAASM-1545"
-                );
-            }
-            if credential_action == CredentialAction::AlertOnly {
-                // Forward the unmodified payload upstream; alert side-effect emission
-                // is wired by sibling subtask AAASM-1545.
-                //
-                // SECURITY (AAASM-3137): this is the ONLY path that forwards the
-                // raw secret. It is a documented, deliberate audit-only downgrade;
-                // `alert_and_redact` is the safe alternative when an alert is
-                // wanted without leaking the credential.
-                tracing::warn!(
-                    finding_count = all_findings.len(),
-                    "credential_action=alert_only: forwarding UNREDACTED payload (alert emission pending AAASM-1545)"
-                );
-                (None, all_findings)
-            } else {
-                let merged = aa_security::ScanResult {
-                    findings: all_findings.clone(),
-                };
-                let redacted = merged.redact(text);
-                (Some(redacted), all_findings)
-            }
-        };
 
         // Stage 7 — Budget check (monthly first, then daily).
         if let Some(bp) = &policy.budget {
@@ -1061,48 +1077,11 @@ impl PolicyEngine {
             })
             .unwrap_or_default();
 
-        if credential_action == CredentialAction::Block && !all_findings.is_empty() {
-            all_findings.sort_by_key(|f| f.offset);
-            return EvaluationResult {
-                decision: aa_core::PolicyResult::Deny {
-                    reason: "credential detected".into(),
-                },
-                redacted_payload: None,
-                credential_findings: all_findings,
-                deny_action: None,
+        let (redacted_payload, credential_findings) =
+            match Self::apply_credential_scan(text, all_findings, credential_action) {
+                CredentialScanOutcome::Block(result) => return result,
+                CredentialScanOutcome::Continue(payload, findings) => (payload, findings),
             };
-        }
-
-        let (redacted_payload, credential_findings) = if all_findings.is_empty() {
-            (None, vec![])
-        } else {
-            all_findings.sort_by_key(|f| f.offset);
-            tracing::warn!(
-                finding_count = all_findings.len(),
-                "DataLeakEvent emission pending AAASM-31 EnrichedEvent::DataLeak variant"
-            );
-            if credential_action == CredentialAction::AlertAndRedact {
-                // AAASM-3137: alert AND redact — notify but never leak the secret.
-                tracing::warn!(
-                    finding_count = all_findings.len(),
-                    "credential_action=alert_and_redact: alert emission pending AAASM-1545"
-                );
-            }
-            if credential_action == CredentialAction::AlertOnly {
-                // SECURITY (AAASM-3137): the only path that forwards the raw secret.
-                tracing::warn!(
-                    finding_count = all_findings.len(),
-                    "credential_action=alert_only: forwarding UNREDACTED payload (alert emission pending AAASM-1545)"
-                );
-                (None, all_findings)
-            } else {
-                let merged = aa_security::ScanResult {
-                    findings: all_findings.clone(),
-                };
-                let redacted = merged.redact(text);
-                (Some(redacted), all_findings)
-            }
-        };
 
         // Stage 7 — Budget: check against all cascade docs' budget configs.
         // Take the most restrictive (lowest) limit across all policies.

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -712,41 +712,47 @@ impl PolicyEngine {
         ctx: &aa_core::AgentContext,
         action: &aa_core::GovernanceAction,
     ) -> Option<EvaluationResult> {
+        // Stages 3-5 apply to ToolCall; stage 5b applies to SendMessage.
+        match action {
+            aa_core::GovernanceAction::ToolCall { name, .. } => {
+                self.eval_toolcall_stages(policy, ctx, name, action)
+            }
+            // Stage 5b — Approval condition for SendMessage (channel policy).
+            aa_core::GovernanceAction::SendMessage { .. } => {
+                self.eval_approval_condition(policy, policy.tools.get("message"), ctx, action)
+            }
+            _ => None,
+        }
+    }
+
+    /// Stages 3-5 for a `ToolCall`: per-tool allow/deny, rate limit, and the
+    /// `requires_approval_if` condition. Resolves the tool policy once for the
+    /// given `name`. Returns the first non-Allow decision, or `None`.
+    fn eval_toolcall_stages(
+        &self,
+        policy: &PolicyDocument,
+        ctx: &aa_core::AgentContext,
+        name: &str,
+        action: &aa_core::GovernanceAction,
+    ) -> Option<EvaluationResult> {
+        let tool_policy = policy.tools.get(name);
+
         // Stage 3 — Tool allow/deny.
-        if let aa_core::GovernanceAction::ToolCall { name, .. } = action {
-            if let Some(tp) = policy.tools.get(name) {
-                if !tp.allow {
-                    return Some(EvaluationResult::deny("tool denied by policy"));
-                }
+        if let Some(tp) = tool_policy {
+            if !tp.allow {
+                return Some(EvaluationResult::deny("tool denied by policy"));
             }
         }
 
         // Stage 4 — Tool rate limit.
-        if let aa_core::GovernanceAction::ToolCall { name, .. } = action {
-            if let Some(tp) = policy.tools.get(name) {
-                if let Some(limit) = tp.limit_per_hour {
-                    if !self.try_consume_rate(name, limit) {
-                        return Some(EvaluationResult::deny("rate limit exceeded"));
-                    }
-                }
+        if let Some(limit) = tool_policy.and_then(|tp| tp.limit_per_hour) {
+            if !self.try_consume_rate(name, limit) {
+                return Some(EvaluationResult::deny("rate limit exceeded"));
             }
         }
 
         // Stage 5 — Approval condition for ToolCall.
-        if let aa_core::GovernanceAction::ToolCall { name, .. } = action {
-            if let Some(result) = self.eval_approval_condition(policy, policy.tools.get(name), ctx, action) {
-                return Some(result);
-            }
-        }
-
-        // Stage 5b — Approval condition for SendMessage (channel policy).
-        if let aa_core::GovernanceAction::SendMessage { .. } = action {
-            if let Some(result) = self.eval_approval_condition(policy, policy.tools.get("message"), ctx, action) {
-                return Some(result);
-            }
-        }
-
-        None
+        self.eval_approval_condition(policy, tool_policy, ctx, action)
     }
 
     /// Evaluate a tool/channel policy's `requires_approval_if` expression for

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -559,12 +559,7 @@ fn eval_tool_result_field(
 
 /// `args.<key>` — JSON-pointer walk into the ToolCall's args payload.
 /// Null-safe at every step (see `eval_json_pointer`).
-fn eval_tool_arg_field(
-    field: &FieldRef,
-    op: &OpKind,
-    literal: &LiteralVal,
-    action: &GovernanceAction,
-) -> Option<bool> {
+fn eval_tool_arg_field(field: &FieldRef, op: &OpKind, literal: &LiteralVal, action: &GovernanceAction) -> Option<bool> {
     let FieldRef::ToolArg(pointer) = field else {
         return None;
     };
@@ -911,14 +906,10 @@ fn compare_json_value(resolved: &serde_json::Value, op: &OpKind, literal: &Liter
         }
         // Substring ops require a JSON string and a string literal.
         (OpKind::Contains, _, LiteralVal::Str(lit)) => resolved.as_str().is_some_and(|v| v.contains(lit.as_str())),
-        (OpKind::StartsWith, _, LiteralVal::Str(lit)) => {
-            resolved.as_str().is_some_and(|v| v.starts_with(lit.as_str()))
-        }
+        (OpKind::StartsWith, _, LiteralVal::Str(lit)) => resolved.as_str().is_some_and(|v| v.starts_with(lit.as_str())),
         // Membership ops require a JSON string and a list literal.
         (OpKind::In, _, LiteralVal::StrList(list)) => resolved.as_str().is_some_and(|v| list.iter().any(|i| i == v)),
-        (OpKind::NotIn, _, LiteralVal::StrList(list)) => {
-            resolved.as_str().is_some_and(|v| list.iter().all(|i| i != v))
-        }
+        (OpKind::NotIn, _, LiteralVal::StrList(list)) => resolved.as_str().is_some_and(|v| list.iter().all(|i| i != v)),
         // Ordered numeric comparisons require a JSON number and a numeric literal.
         (OpKind::Gt | OpKind::Gte | OpKind::Lt | OpKind::Lte, _, LiteralVal::Num(rhs)) => {
             resolved.as_f64().is_some_and(|lhs| compare_ord(lhs, *rhs, op))
@@ -1212,7 +1203,9 @@ fn validate_level_word(word: &str) -> Result<(), String> {
     }
     match word {
         "L0" | "L1" | "L2" | "L3" => Ok(()),
-        _ => Err(format!("unknown governance level: {word}; valid values: L0, L1, L2, L3")),
+        _ => Err(format!(
+            "unknown governance level: {word}; valid values: L0, L1, L2, L3"
+        )),
     }
 }
 

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -1043,42 +1043,19 @@ pub(crate) fn extract_field_names(expr: &str) -> Vec<String> {
 
         // Skip list literals: [...] — contents are string values, not field names
         if ch == '[' {
-            chars.next();
-            loop {
-                match chars.next() {
-                    Some(']') | None => break,
-                    _ => {}
-                }
-            }
+            skip_list_literal(&mut chars);
             continue;
         }
 
         // Skip quoted string literals
         if ch == '"' {
-            chars.next();
-            loop {
-                match chars.next() {
-                    Some('"') | None => break,
-                    Some('\\') => {
-                        chars.next();
-                    }
-                    _ => {}
-                }
-            }
+            skip_quoted_string(&mut chars);
             continue;
         }
 
         // Collect word token (letters, digits, underscore, hyphen, dot)
-        if ch.is_alphanumeric() || ch == '_' || ch == '-' || ch == '.' {
-            let mut word = String::new();
-            while let Some(&c) = chars.peek() {
-                if c.is_alphanumeric() || c == '_' || c == '-' || c == '.' {
-                    word.push(c);
-                    chars.next();
-                } else {
-                    break;
-                }
-            }
+        if is_word_char(ch) {
+            let word = take_word(&mut chars);
             // Skip combinators, boolean keywords, and numeric literals
             if SKIP_WORDS.contains(&word.as_str()) || word.parse::<f64>().is_ok() {
                 continue;
@@ -1091,6 +1068,53 @@ pub(crate) fn extract_field_names(expr: &str) -> Vec<String> {
     }
 
     names
+}
+
+/// Characters that may appear in a field-reference word: letters, digits,
+/// underscore, hyphen, and dot (for `args.<key>` / `tool_result.<key>`).
+fn is_word_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '-' || c == '.'
+}
+
+/// Consume the opening `[` and everything up to and including the closing `]`
+/// (or end of input). List contents are string values, not field names.
+fn skip_list_literal(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) {
+    chars.next(); // opening '['
+    while let Some(c) = chars.next() {
+        if c == ']' {
+            break;
+        }
+    }
+}
+
+/// Consume the opening `"` and everything up to and including the closing `"`
+/// (or end of input), honouring `\`-escaped characters.
+fn skip_quoted_string(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) {
+    chars.next(); // opening '"'
+    while let Some(c) = chars.next() {
+        match c {
+            '"' => break,
+            '\\' => {
+                chars.next();
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Collect a contiguous run of [`is_word_char`] characters into a `String`,
+/// leaving the iterator positioned on the first non-word character.
+fn take_word(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> String {
+    let mut word = String::new();
+    while let Some(&c) = chars.peek() {
+        if is_word_char(c) {
+            word.push(c);
+            chars.next();
+        } else {
+            break;
+        }
+    }
+    word
 }
 
 /// Return the closest entry in `KNOWN_VARIABLES` to `name` when the edit
@@ -1154,35 +1178,42 @@ pub(crate) fn validate_governance_levels(expr: &str) -> Result<(), String> {
     let mut chars = expr.chars().peekable();
     while let Some(&ch) = chars.peek() {
         if ch == 'L' {
-            // Collect the identifier-like word starting with 'L'.
-            let mut word = String::new();
-            while let Some(&c) = chars.peek() {
-                if c.is_alphanumeric() || c == '_' {
-                    word.push(c);
-                    chars.next();
-                } else {
-                    break;
-                }
-            }
-            // Only reject `L<digit>+` shapes — these are clearly intended as
-            // level literals. Anything else (`Logger`, `Limit`, …) is left
-            // for the runtime tokenizer to handle.
-            let rest = &word[1..];
-            if !rest.is_empty() && rest.chars().all(|c| c.is_ascii_digit()) {
-                match word.as_str() {
-                    "L0" | "L1" | "L2" | "L3" => {}
-                    _ => {
-                        return Err(format!(
-                            "unknown governance level: {word}; valid values: L0, L1, L2, L3"
-                        ));
-                    }
-                }
-            }
+            let word = take_identifier(&mut chars);
+            validate_level_word(&word)?;
             continue;
         }
         chars.next();
     }
     Ok(())
+}
+
+/// Collect a contiguous run of identifier characters (alphanumeric or `_`) into
+/// a `String`, leaving the iterator on the first non-identifier character.
+fn take_identifier(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) -> String {
+    let mut word = String::new();
+    while let Some(&c) = chars.peek() {
+        if c.is_alphanumeric() || c == '_' {
+            word.push(c);
+            chars.next();
+        } else {
+            break;
+        }
+    }
+    word
+}
+
+/// Reject an `L<digit>+` word that is not one of the four valid governance
+/// levels. Only `L`-prefixed all-digit suffixes are treated as level literals;
+/// anything else (`Logger`, `Limit`, …) is left for the runtime tokenizer.
+fn validate_level_word(word: &str) -> Result<(), String> {
+    let rest = &word[1..];
+    if rest.is_empty() || !rest.chars().all(|c| c.is_ascii_digit()) {
+        return Ok(());
+    }
+    match word {
+        "L0" | "L1" | "L2" | "L3" => Ok(()),
+        _ => Err(format!("unknown governance level: {word}; valid values: L0, L1, L2, L3")),
+    }
 }
 
 /// Evaluate a flat boolean expression against a [`GovernanceAction`] and the

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -439,9 +439,52 @@ fn eval_clause_safe(
     agent_level: Option<GovernanceLevel>,
     policy_ctx: Option<&dyn PolicyContext>,
 ) -> bool {
-    // Context-backed numeric fields share identical null-safe numeric semantics.
-    // `team.parallel_agents` delegates to the same registry query as
-    // `team.active_agents` by design.
+    // Each `eval_*` helper owns one field group and returns `Some(verdict)` when
+    // it recognises `field`, or `None` to fall through to the next group. The
+    // final string-field path is the catch-all. This dispatch chain preserves
+    // the original evaluation order and per-group null-safety contracts exactly.
+    if let Some(v) = eval_numeric_ctx_field(field, op, literal, policy_ctx) {
+        return v;
+    }
+    if let Some(v) = eval_child_tool_field(field, op, literal, policy_ctx) {
+        return v;
+    }
+    if let Some(v) = eval_tool_result_field(field, op, literal, action) {
+        return v;
+    }
+    if let Some(v) = eval_tool_arg_field(field, op, literal, action) {
+        return v;
+    }
+    if let Some(v) = eval_risk_tier_field(field, op, literal, policy_ctx) {
+        return v;
+    }
+    if let Some(v) = eval_agent_identity_field(field, op, literal, policy_ctx) {
+        return v;
+    }
+    if let Some(v) = eval_topology_flag_field(field, op, literal, policy_ctx) {
+        return v;
+    }
+    if let Some(v) = eval_send_message_field(field, op, literal, action) {
+        return v;
+    }
+    if let Some(v) = eval_governance_level_field(field, op, literal, agent_level) {
+        return v;
+    }
+
+    eval_string_field(field, op, literal, action)
+}
+
+/// Context-backed numeric fields (`agent.depth`, `team.active_agents`,
+/// `team.parallel_agents`, `team.budget_remaining`, `agent.age`,
+/// `agent.children_count`). All share identical null-safe numeric semantics.
+/// `team.parallel_agents` delegates to the same registry query as
+/// `team.active_agents` by design. Returns `None` for any other field.
+fn eval_numeric_ctx_field(
+    field: &FieldRef,
+    op: &OpKind,
+    literal: &LiteralVal,
+    policy_ctx: Option<&dyn PolicyContext>,
+) -> Option<bool> {
     let numeric_ctx_value: Option<f64> = match field {
         FieldRef::AgentDepth => policy_ctx.and_then(|c| c.agent_depth()).map(|d| d as f64),
         FieldRef::TeamActiveAgents | FieldRef::TeamParallelAgents => {
@@ -450,165 +493,211 @@ fn eval_clause_safe(
         FieldRef::TeamBudgetRemaining => policy_ctx.and_then(|c| c.team_budget_remaining()),
         FieldRef::AgentAge => policy_ctx.and_then(|c| c.agent_age_secs()).map(|a| a as f64),
         FieldRef::AgentChildrenCount => policy_ctx.and_then(|c| c.agent_children_count()).map(|n| n as f64),
-        _ => None,
+        _ => return None,
     };
-    if matches!(
-        field,
-        FieldRef::AgentDepth
-            | FieldRef::TeamActiveAgents
-            | FieldRef::TeamParallelAgents
-            | FieldRef::TeamBudgetRemaining
-            | FieldRef::AgentAge
-            | FieldRef::AgentChildrenCount
-    ) {
-        return match numeric_ctx_value {
-            Some(lhs) => compare_numeric(lhs, op, literal),
-            None => false,
-        };
-    }
+    Some(match numeric_ctx_value {
+        Some(lhs) => compare_numeric(lhs, op, literal),
+        None => false,
+    })
+}
 
-    // child.tool — string comparison against the union of tool_names across all
-    // direct children of the current agent. Returns false when context is absent.
-    if let FieldRef::ChildTool = field {
-        let tools = match policy_ctx {
-            Some(c) => c.child_tools(),
-            None => return false,
-        };
-        let rhs = match literal {
-            LiteralVal::Str(s) => s.as_str(),
-            _ => return false,
-        };
-        return match op {
-            OpKind::Eq => tools.iter().any(|t| t == rhs),
-            OpKind::Ne => tools.iter().all(|t| t != rhs),
-            OpKind::Contains => tools.iter().any(|t| t.contains(rhs)),
-            OpKind::StartsWith => tools.iter().any(|t| t.starts_with(rhs)),
-            _ => false,
-        };
-    }
-
-    // `tool_result.<key>` — JSON-pointer walk into the ToolResult's `result`
-    // payload, and the bare `tool_result` shorthand for matching the whole
-    // serialised body. Mirrors `args.<key>`'s null-safety contract: non-
-    // `ToolResult` actions, unparseable result JSON, and unresolved pointers
-    // all surface as no-match. The bare `tool_result` arm only accepts
-    // `contains` / `starts_with` against a string literal.
-    if matches!(field, FieldRef::ToolResult(_) | FieldRef::ToolResultWhole) {
-        let result_str = match action {
-            GovernanceAction::ToolResult { result, .. } => result.as_str(),
-            _ => return false,
-        };
-        if let FieldRef::ToolResultWhole = field {
-            return eval_whole_body(result_str, op, literal);
-        }
-        let FieldRef::ToolResult(pointer) = field else {
-            unreachable!()
-        };
-        return eval_json_pointer(result_str, pointer, op, literal);
-    }
-
-    // `args.<key>` — JSON-pointer walk into the ToolCall's args payload.
-    // Null-safe at every step (see `eval_json_pointer`).
-    if let FieldRef::ToolArg(pointer) = field {
-        let args_str = match action {
-            GovernanceAction::ToolCall { args, .. } => args.as_str(),
-            _ => return false,
-        };
-        return eval_json_pointer(args_str, pointer, op, literal);
-    }
-
-    // Risk-tier fields — ordinal comparison against a Tier literal. Null-safe
-    // when context/registry lookup is absent (or the agent has no parent/child).
-    let tier_ctx_value = match field {
-        FieldRef::AgentRiskTier => Some(policy_ctx.and_then(|c| c.agent_risk_tier())),
-        FieldRef::ParentRiskTier => Some(policy_ctx.and_then(|c| c.parent_risk_tier())),
-        FieldRef::ChildRiskTier => Some(policy_ctx.and_then(|c| c.child_risk_tier())),
-        _ => None,
+/// `child.tool` — string comparison against the union of tool names across all
+/// direct children of the current agent. `false` when context is absent.
+fn eval_child_tool_field(
+    field: &FieldRef,
+    op: &OpKind,
+    literal: &LiteralVal,
+    policy_ctx: Option<&dyn PolicyContext>,
+) -> Option<bool> {
+    let FieldRef::ChildTool = field else {
+        return None;
     };
-    if let Some(tier) = tier_ctx_value {
-        let (Some(lhs), LiteralVal::Tier(rhs)) = (tier, literal) else {
-            return false;
-        };
-        return compare_ord(lhs, *rhs, op);
-    }
-
-    // agent.parent_agent_id / agent.team_id — string comparison against an agent identity field.
-    // Returns false when the field resolves to None (null-safe no-match).
-    if matches!(field, FieldRef::AgentParentId | FieldRef::AgentTeamId) {
-        let val = match field {
-            FieldRef::AgentParentId => policy_ctx.and_then(|c| c.agent_parent_id()),
-            FieldRef::AgentTeamId => policy_ctx.and_then(|c| c.agent_team_id()),
-            _ => unreachable!(),
-        };
-        let id = match val {
-            Some(v) => v,
-            None => return false,
-        };
-        // In/NotIn don't apply to these identity fields (preserves prior `_ => false`).
-        return match op {
-            OpKind::In | OpKind::NotIn => false,
-            _ => compare_string(&id, op, literal),
-        };
-    }
-
-    // agent.is_root / agent.is_leaf — boolean (0/1) topology flags.
-    // is_root fires when depth == 0; is_leaf fires when children_count == 0.
-    // Only Eq/Ne against numeric 1 or 0 are meaningful; other ops return false.
-    if matches!(field, FieldRef::AgentIsRoot | FieldRef::AgentIsLeaf) {
-        let flag: Option<bool> = match field {
-            FieldRef::AgentIsRoot => policy_ctx.and_then(|c| c.agent_depth()).map(|d| d == 0),
-            FieldRef::AgentIsLeaf => policy_ctx.and_then(|c| c.agent_children_count()).map(|n| n == 0),
-            _ => unreachable!(),
-        };
-        let lhs = match flag {
-            Some(true) => 1.0_f64,
-            Some(false) => 0.0_f64,
-            None => return false,
-        };
-        let rhs = match numeric_literal(literal) {
-            Some(r) => r,
-            None => return false,
-        };
-        return match op {
-            OpKind::Eq => lhs == rhs,
-            OpKind::Ne => lhs != rhs,
-            _ => false,
-        };
-    }
-
-    // SendMessage routing fields — string comparison against a per-action id.
-    // Returns false when the action is not SendMessage or the field is None.
-    let message_field_value = match field {
-        FieldRef::SourceTeamId => Some(send_message_field(action, MsgField::SourceTeam)),
-        FieldRef::TargetTeamId => Some(send_message_field(action, MsgField::TargetTeam)),
-        FieldRef::TargetChannelId => Some(send_message_field(action, MsgField::Channel)),
-        _ => None,
+    let tools = match policy_ctx {
+        Some(c) => c.child_tools(),
+        None => return Some(false),
     };
-    if let Some(value) = message_field_value {
-        return match value {
-            Some(id) => compare_string(&id, op, literal),
-            None => false,
-        };
-    }
+    let rhs = match literal {
+        LiteralVal::Str(s) => s.as_str(),
+        _ => return Some(false),
+    };
+    Some(match op {
+        OpKind::Eq => tools.iter().any(|t| t == rhs),
+        OpKind::Ne => tools.iter().all(|t| t != rhs),
+        OpKind::Contains => tools.iter().any(|t| t.contains(rhs)),
+        OpKind::StartsWith => tools.iter().any(|t| t.starts_with(rhs)),
+        _ => false,
+    })
+}
 
-    // governance_level is the only field whose value type is not a string;
-    // route it through an Ord-based comparison and return early.
-    if let FieldRef::GovernanceLevel = field {
-        let rhs = match literal {
-            LiteralVal::Level(l) => *l,
-            // Mismatched literal kind (e.g. `governance_level == "L2"`) cannot
-            // match — treat as no-fire rather than fail-safe approval, since
-            // the validator should have rejected it before evaluation.
-            _ => return false,
-        };
-        let lhs = match agent_level {
-            Some(l) => l,
-            // No agent level supplied → cannot compare; treat as no-match.
-            None => return false,
-        };
-        return compare_ord(lhs, rhs, op);
+/// `tool_result.<key>` — JSON-pointer walk into the ToolResult's `result`
+/// payload, and the bare `tool_result` shorthand for matching the whole
+/// serialised body. Mirrors `args.<key>`'s null-safety contract: non-
+/// `ToolResult` actions, unparseable result JSON, and unresolved pointers
+/// all surface as no-match. The bare `tool_result` arm only accepts
+/// `contains` / `starts_with` against a string literal.
+fn eval_tool_result_field(
+    field: &FieldRef,
+    op: &OpKind,
+    literal: &LiteralVal,
+    action: &GovernanceAction,
+) -> Option<bool> {
+    if !matches!(field, FieldRef::ToolResult(_) | FieldRef::ToolResultWhole) {
+        return None;
     }
+    let result_str = match action {
+        GovernanceAction::ToolResult { result, .. } => result.as_str(),
+        _ => return Some(false),
+    };
+    if let FieldRef::ToolResultWhole = field {
+        return Some(eval_whole_body(result_str, op, literal));
+    }
+    let FieldRef::ToolResult(pointer) = field else {
+        unreachable!()
+    };
+    Some(eval_json_pointer(result_str, pointer, op, literal))
+}
 
+/// `args.<key>` — JSON-pointer walk into the ToolCall's args payload.
+/// Null-safe at every step (see `eval_json_pointer`).
+fn eval_tool_arg_field(
+    field: &FieldRef,
+    op: &OpKind,
+    literal: &LiteralVal,
+    action: &GovernanceAction,
+) -> Option<bool> {
+    let FieldRef::ToolArg(pointer) = field else {
+        return None;
+    };
+    let args_str = match action {
+        GovernanceAction::ToolCall { args, .. } => args.as_str(),
+        _ => return Some(false),
+    };
+    Some(eval_json_pointer(args_str, pointer, op, literal))
+}
+
+/// Risk-tier fields (`agent.risk_tier`, `parent.risk_tier`, `child.risk_tier`)
+/// — ordinal comparison against a Tier literal. Null-safe when context/registry
+/// lookup is absent (or the agent has no parent/child).
+fn eval_risk_tier_field(
+    field: &FieldRef,
+    op: &OpKind,
+    literal: &LiteralVal,
+    policy_ctx: Option<&dyn PolicyContext>,
+) -> Option<bool> {
+    let tier = match field {
+        FieldRef::AgentRiskTier => policy_ctx.and_then(|c| c.agent_risk_tier()),
+        FieldRef::ParentRiskTier => policy_ctx.and_then(|c| c.parent_risk_tier()),
+        FieldRef::ChildRiskTier => policy_ctx.and_then(|c| c.child_risk_tier()),
+        _ => return None,
+    };
+    let (Some(lhs), LiteralVal::Tier(rhs)) = (tier, literal) else {
+        return Some(false);
+    };
+    Some(compare_ord(lhs, *rhs, op))
+}
+
+/// `agent.parent_agent_id` / `agent.team_id` — string comparison against an
+/// agent identity field. `false` when the field resolves to `None`.
+fn eval_agent_identity_field(
+    field: &FieldRef,
+    op: &OpKind,
+    literal: &LiteralVal,
+    policy_ctx: Option<&dyn PolicyContext>,
+) -> Option<bool> {
+    let val = match field {
+        FieldRef::AgentParentId => policy_ctx.and_then(|c| c.agent_parent_id()),
+        FieldRef::AgentTeamId => policy_ctx.and_then(|c| c.agent_team_id()),
+        _ => return None,
+    };
+    let id = match val {
+        Some(v) => v,
+        None => return Some(false),
+    };
+    // In/NotIn don't apply to these identity fields (preserves prior `_ => false`).
+    Some(match op {
+        OpKind::In | OpKind::NotIn => false,
+        _ => compare_string(&id, op, literal),
+    })
+}
+
+/// `agent.is_root` / `agent.is_leaf` — boolean (0/1) topology flags. is_root
+/// fires when depth == 0; is_leaf fires when children_count == 0. Only Eq/Ne
+/// against numeric 1 or 0 are meaningful; other ops return false.
+fn eval_topology_flag_field(
+    field: &FieldRef,
+    op: &OpKind,
+    literal: &LiteralVal,
+    policy_ctx: Option<&dyn PolicyContext>,
+) -> Option<bool> {
+    let flag: Option<bool> = match field {
+        FieldRef::AgentIsRoot => policy_ctx.and_then(|c| c.agent_depth()).map(|d| d == 0),
+        FieldRef::AgentIsLeaf => policy_ctx.and_then(|c| c.agent_children_count()).map(|n| n == 0),
+        _ => return None,
+    };
+    let lhs = match flag {
+        Some(true) => 1.0_f64,
+        Some(false) => 0.0_f64,
+        None => return Some(false),
+    };
+    let rhs = match numeric_literal(literal) {
+        Some(r) => r,
+        None => return Some(false),
+    };
+    Some(match op {
+        OpKind::Eq => lhs == rhs,
+        OpKind::Ne => lhs != rhs,
+        _ => false,
+    })
+}
+
+/// SendMessage routing fields (`source_team_id`, `target_team_id`,
+/// `target_channel_id`) — string comparison against a per-action id. `false`
+/// when the action is not SendMessage or the field is `None`.
+fn eval_send_message_field(
+    field: &FieldRef,
+    op: &OpKind,
+    literal: &LiteralVal,
+    action: &GovernanceAction,
+) -> Option<bool> {
+    let value = match field {
+        FieldRef::SourceTeamId => send_message_field(action, MsgField::SourceTeam),
+        FieldRef::TargetTeamId => send_message_field(action, MsgField::TargetTeam),
+        FieldRef::TargetChannelId => send_message_field(action, MsgField::Channel),
+        _ => return None,
+    };
+    Some(match value {
+        Some(id) => compare_string(&id, op, literal),
+        None => false,
+    })
+}
+
+/// `governance_level` — the only field whose value type is not a string; routed
+/// through an Ord-based comparison. Mismatched literal kinds and an absent agent
+/// level both surface as no-match (the validator rejects malformed literals
+/// before evaluation, so a non-`Level` literal here is treated as no-fire).
+fn eval_governance_level_field(
+    field: &FieldRef,
+    op: &OpKind,
+    literal: &LiteralVal,
+    agent_level: Option<GovernanceLevel>,
+) -> Option<bool> {
+    let FieldRef::GovernanceLevel = field else {
+        return None;
+    };
+    let rhs = match literal {
+        LiteralVal::Level(l) => *l,
+        _ => return Some(false),
+    };
+    let lhs = match agent_level {
+        Some(l) => l,
+        None => return Some(false),
+    };
+    Some(compare_ord(lhs, rhs, op))
+}
+
+/// Catch-all for generic string-valued fields (`tool`, `path`, `url`, `method`,
+/// `command`). Resolves the field's value via [`field_value`] and applies `op`.
+fn eval_string_field(field: &FieldRef, op: &OpKind, literal: &LiteralVal, action: &GovernanceAction) -> bool {
     let lhs = field_value(field, action);
 
     match op {

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -899,51 +899,32 @@ fn send_message_field(action: &GovernanceAction, which: MsgField) -> Option<Stri
 /// numeric ops a JSON number, `in`/`not_in` a JSON string against a list.
 /// Mismatched types are no-match (`false`).
 fn compare_json_value(resolved: &serde_json::Value, op: &OpKind, literal: &LiteralVal) -> bool {
-    match op {
-        OpKind::Eq | OpKind::Ne => match (resolved, literal) {
-            (serde_json::Value::String(s), LiteralVal::Str(lit)) => {
-                if matches!(op, OpKind::Eq) {
-                    s == lit
-                } else {
-                    s != lit
-                }
-            }
-            (serde_json::Value::Number(n), LiteralVal::Num(lit)) => match n.as_f64() {
-                Some(v) => {
-                    if matches!(op, OpKind::Eq) {
-                        (v - *lit).abs() < f64::EPSILON
-                    } else {
-                        (v - *lit).abs() >= f64::EPSILON
-                    }
-                }
-                None => false,
-            },
-            _ => false,
-        },
-        OpKind::Contains | OpKind::StartsWith => match (resolved.as_str(), literal) {
-            (Some(value), LiteralVal::Str(lit)) => {
-                if matches!(op, OpKind::Contains) {
-                    value.contains(lit.as_str())
-                } else {
-                    value.starts_with(lit.as_str())
-                }
-            }
-            _ => false,
-        },
-        OpKind::In | OpKind::NotIn => match (resolved.as_str(), literal) {
-            (Some(value), LiteralVal::StrList(list)) => {
-                if matches!(op, OpKind::In) {
-                    list.iter().any(|item| item == value)
-                } else {
-                    list.iter().all(|item| item != value)
-                }
-            }
-            _ => false,
-        },
-        OpKind::Gt | OpKind::Gte | OpKind::Lt | OpKind::Lte => match (resolved.as_f64(), literal) {
-            (Some(lhs), LiteralVal::Num(rhs)) => compare_ord(lhs, *rhs, op),
-            _ => false,
-        },
+    match (op, resolved, literal) {
+        // Equality is type-strict: string-vs-string or number-vs-number only.
+        (OpKind::Eq, serde_json::Value::String(s), LiteralVal::Str(lit)) => s == lit,
+        (OpKind::Ne, serde_json::Value::String(s), LiteralVal::Str(lit)) => s != lit,
+        (OpKind::Eq, serde_json::Value::Number(n), LiteralVal::Num(lit)) => {
+            n.as_f64().is_some_and(|v| (v - *lit).abs() < f64::EPSILON)
+        }
+        (OpKind::Ne, serde_json::Value::Number(n), LiteralVal::Num(lit)) => {
+            n.as_f64().is_some_and(|v| (v - *lit).abs() >= f64::EPSILON)
+        }
+        // Substring ops require a JSON string and a string literal.
+        (OpKind::Contains, _, LiteralVal::Str(lit)) => resolved.as_str().is_some_and(|v| v.contains(lit.as_str())),
+        (OpKind::StartsWith, _, LiteralVal::Str(lit)) => {
+            resolved.as_str().is_some_and(|v| v.starts_with(lit.as_str()))
+        }
+        // Membership ops require a JSON string and a list literal.
+        (OpKind::In, _, LiteralVal::StrList(list)) => resolved.as_str().is_some_and(|v| list.iter().any(|i| i == v)),
+        (OpKind::NotIn, _, LiteralVal::StrList(list)) => {
+            resolved.as_str().is_some_and(|v| list.iter().all(|i| i != v))
+        }
+        // Ordered numeric comparisons require a JSON number and a numeric literal.
+        (OpKind::Gt | OpKind::Gte | OpKind::Lt | OpKind::Lte, _, LiteralVal::Num(rhs)) => {
+            resolved.as_f64().is_some_and(|lhs| compare_ord(lhs, *rhs, op))
+        }
+        // Mismatched value/literal types are no-match.
+        _ => false,
     }
 }
 

--- a/aa-gateway/src/policy/expr.rs
+++ b/aa-gateway/src/policy/expr.rs
@@ -1071,7 +1071,7 @@ fn is_word_char(c: char) -> bool {
 /// (or end of input). List contents are string values, not field names.
 fn skip_list_literal(chars: &mut std::iter::Peekable<std::str::Chars<'_>>) {
     chars.next(); // opening '['
-    while let Some(c) = chars.next() {
+    for c in chars.by_ref() {
         if c == ']' {
             break;
         }

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -426,53 +426,75 @@ impl PolicyServiceImpl {
         timeout_override: Option<u64>,
         role_override: Option<&String>,
     ) {
-        if let Some(decision) = routing_decision {
-            // Router-driven path: use the decision's escalation_role and escalate_at.
-            if let (Some(ref team_id_val), Some(ref scheduler)) = (&decision.team_id, &self.escalation_scheduler) {
-                let now_secs = SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs();
-                let esc_timeout = decision.escalate_at.saturating_sub(now_secs);
-                let approvers = vec![decision.escalation_role.clone()];
-                if let Err(e) = scheduler.register(approval_id, team_id_val.clone(), approvers, esc_timeout) {
-                    tracing::warn!(error = %e, "failed to register escalation for approval {}", approval_id);
-                }
-            }
-            if let Some(ref db_scheduler) = self.db_escalation_scheduler {
-                if let Some(ref team_id_val) = decision.team_id {
-                    if let Err(e) = db_scheduler
-                        .register(
-                            approval_id,
-                            team_id_val.clone(),
-                            decision.escalation_role.clone(),
-                            "TeamAdmin".to_string(),
-                            decision.escalate_at,
-                        )
-                        .await
-                    {
-                        tracing::warn!(error = %e, "failed to register DB escalation for approval {}", approval_id);
-                    }
-                }
-            }
-        } else if let (Some(ref tid), Some(ref scheduler)) = (team_id, &self.escalation_scheduler) {
-            // Legacy path: resolve escalation config from the RoutingConfigStore.
-            let effective_timeout = timeout_override.unwrap_or(u64::from(timeout_secs));
-            let escalation_approvers = self
-                .routing_store
-                .as_ref()
-                .and_then(|store| store.get(tid))
-                .map(|cfg| {
-                    if let Some(role) = role_override {
-                        vec![role.clone()]
-                    } else {
-                        cfg.escalation_approvers.clone()
-                    }
-                })
-                .unwrap_or_default();
-            if let Err(e) = scheduler.register(approval_id, tid.clone(), escalation_approvers, effective_timeout) {
+        match routing_decision {
+            Some(decision) => self.register_router_escalation(approval_id, decision).await,
+            None => self.register_legacy_escalation(approval_id, team_id, timeout_secs, timeout_override, role_override),
+        }
+    }
+
+    /// Router-driven escalation: register the in-memory scheduler (when a team
+    /// and scheduler are present) and the DB scheduler (when present) using the
+    /// decision's `escalation_role` and `escalate_at`. Failures are logged only.
+    async fn register_router_escalation(
+        &self,
+        approval_id: uuid::Uuid,
+        decision: &crate::approval::RoutingDecision,
+    ) {
+        if let (Some(ref team_id_val), Some(ref scheduler)) = (&decision.team_id, &self.escalation_scheduler) {
+            let now_secs = SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let esc_timeout = decision.escalate_at.saturating_sub(now_secs);
+            let approvers = vec![decision.escalation_role.clone()];
+            if let Err(e) = scheduler.register(approval_id, team_id_val.clone(), approvers, esc_timeout) {
                 tracing::warn!(error = %e, "failed to register escalation for approval {}", approval_id);
             }
+        }
+        if let (Some(ref db_scheduler), Some(ref team_id_val)) =
+            (&self.db_escalation_scheduler, &decision.team_id)
+        {
+            if let Err(e) = db_scheduler
+                .register(
+                    approval_id,
+                    team_id_val.clone(),
+                    decision.escalation_role.clone(),
+                    "TeamAdmin".to_string(),
+                    decision.escalate_at,
+                )
+                .await
+            {
+                tracing::warn!(error = %e, "failed to register DB escalation for approval {}", approval_id);
+            }
+        }
+    }
+
+    /// Legacy escalation: resolve escalation approvers and timeout from the
+    /// `RoutingConfigStore` (or `role_override`) and register the in-memory
+    /// scheduler. No-op without a team and scheduler. Failures are logged only.
+    fn register_legacy_escalation(
+        &self,
+        approval_id: uuid::Uuid,
+        team_id: &Option<String>,
+        timeout_secs: u32,
+        timeout_override: Option<u64>,
+        role_override: Option<&String>,
+    ) {
+        let (Some(tid), Some(scheduler)) = (team_id.as_ref(), self.escalation_scheduler.as_ref()) else {
+            return;
+        };
+        let effective_timeout = timeout_override.unwrap_or(u64::from(timeout_secs));
+        let escalation_approvers = self
+            .routing_store
+            .as_ref()
+            .and_then(|store| store.get(tid))
+            .map(|cfg| match role_override {
+                Some(role) => vec![role.clone()],
+                None => cfg.escalation_approvers.clone(),
+            })
+            .unwrap_or_default();
+        if let Err(e) = scheduler.register(approval_id, tid.clone(), escalation_approvers, effective_timeout) {
+            tracing::warn!(error = %e, "failed to register escalation for approval {}", approval_id);
         }
     }
 

--- a/aa-gateway/src/service/policy_service.rs
+++ b/aa-gateway/src/service/policy_service.rs
@@ -428,18 +428,16 @@ impl PolicyServiceImpl {
     ) {
         match routing_decision {
             Some(decision) => self.register_router_escalation(approval_id, decision).await,
-            None => self.register_legacy_escalation(approval_id, team_id, timeout_secs, timeout_override, role_override),
+            None => {
+                self.register_legacy_escalation(approval_id, team_id, timeout_secs, timeout_override, role_override)
+            }
         }
     }
 
     /// Router-driven escalation: register the in-memory scheduler (when a team
     /// and scheduler are present) and the DB scheduler (when present) using the
     /// decision's `escalation_role` and `escalate_at`. Failures are logged only.
-    async fn register_router_escalation(
-        &self,
-        approval_id: uuid::Uuid,
-        decision: &crate::approval::RoutingDecision,
-    ) {
+    async fn register_router_escalation(&self, approval_id: uuid::Uuid, decision: &crate::approval::RoutingDecision) {
         if let (Some(ref team_id_val), Some(ref scheduler)) = (&decision.team_id, &self.escalation_scheduler) {
             let now_secs = SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)
@@ -451,9 +449,7 @@ impl PolicyServiceImpl {
                 tracing::warn!(error = %e, "failed to register escalation for approval {}", approval_id);
             }
         }
-        if let (Some(ref db_scheduler), Some(ref team_id_val)) =
-            (&self.db_escalation_scheduler, &decision.team_id)
-        {
+        if let (Some(ref db_scheduler), Some(ref team_id_val)) = (&self.db_escalation_scheduler, &decision.team_id) {
             if let Err(e) = db_scheduler
                 .register(
                     approval_id,

--- a/aa-proxy/src/proxy/mod.rs
+++ b/aa-proxy/src/proxy/mod.rs
@@ -614,188 +614,216 @@ impl ProxyServer {
         let target = parts[1];
 
         if method.eq_ignore_ascii_case("CONNECT") {
-            // Consume remaining headers (we only need the request line for CONNECT).
-            let mut header_line = String::new();
-            loop {
-                header_line.clear();
-                reader.read_line(&mut header_line).await?;
-                if header_line.trim().is_empty() {
-                    break;
-                }
-            }
-
-            // Extract hostname (strip port) for deny check and certificate generation.
-            let host = target.split(':').next().unwrap_or(target);
-
-            // Egress policy: deny-list, then AAASM-1943 network allowlist.
-            // Both return 403 + emit a deny decision and end the connection.
-            if let Some(reason) = self.connect_deny_reason(host) {
-                tracing::info!(%host, "CONNECT denied: {reason}");
-                let mut stream = reader.into_inner();
-                stream
-                    .write_all(b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n")
-                    .await?;
-                self.interceptor.emit_policy_decision(host, true).await;
-                return Ok(());
-            }
-
-            // Send 200 Connection Established to tell the client the tunnel is open.
-            let inner = reader.into_inner();
-            let mut stream = inner;
-            stream.write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n").await?;
-
-            tracing::debug!(host = target, "CONNECT tunnel established");
-
-            // Emit allow audit event for the accepted connection.
-            self.interceptor.emit_policy_decision(host, false).await;
-
-            // When llm_only is enabled, skip TLS MitM for non-LLM hosts and
-            // just tunnel the raw TCP bytes transparently.
-            if self.config.llm_only && detect_api(host) == LlmApiPattern::Unknown {
-                tracing::debug!(%host, "llm_only mode — transparent tunnel (no MitM)");
-                // SSRF re-validation also covers the transparent tunnel — this
-                // path forwards raw bytes without MitM, so it is the most likely
-                // SSRF vector if the host resolves to an internal address.
-                let upstream = match self.config.upstream_override {
-                    Some(addr) => TcpStream::connect(addr).await?,
-                    None => self.connect_revalidated(target).await?,
-                };
-                let (mut cr, mut cw) = tokio::io::split(stream);
-                let (mut ur, mut uw) = tokio::io::split(upstream);
-                tokio::select! {
-                    r = tokio::io::copy(&mut cr, &mut uw) => { r?; }
-                    r = tokio::io::copy(&mut ur, &mut cw) => { r?; }
-                }
-                return Ok(());
-            }
-
-            // --- TLS MitM: act as TLS server to the client ---
-            let ck = self.certs.get_or_insert(host, &self.ca)?;
-            let cert = CertificateDer::from(ck.cert_der.clone());
-            let key = PrivateKeyDer::from(PrivatePkcs8KeyDer::from(ck.key_der.clone()));
-            let server_config = ServerConfig::builder()
-                .with_no_client_auth()
-                .with_single_cert(vec![cert], key)
-                .map_err(|e| ProxyError::Tls(e.to_string()))?;
-            let acceptor = TlsAcceptor::from(Arc::new(server_config));
-            let client_tls = acceptor
-                .accept(stream)
-                .await
-                .map_err(|e| ProxyError::Tls(e.to_string()))?;
-
-            tracing::debug!(%host, "TLS MitM (client side) handshake complete");
-
-            let pattern = detect_api(host);
-
-            // For LLM patterns, read the inbound HTTP request inside the
-            // tunnel so the credential scanner can run against the real
-            // body bytes before any byte reaches upstream. For non-LLM
-            // patterns we fall through to a raw bidirectional copy below.
-            if pattern != LlmApiPattern::Unknown {
-                return self.handle_llm_mitm(client_tls, host, target, pattern).await;
-            }
-
-            // Non-LLM pattern.
-            //
-            // When a gateway client is configured, attempt MCP detection
-            // on the inbound HTTPS request body: a JSON-RPC 2.0 `tools/call`
-            // envelope is dispatched to the gateway PolicyService and
-            // enforced on the wire (Deny → JSON-RPC error envelope, Allow →
-            // forward, Redact → forward unchanged until AAASM-1941 lands
-            // response-side rewriting). Non-MCP bodies fall through to a
-            // transparent forward of the bytes we've already read.
-            //
-            // When no gateway is configured, preserve the historical raw
-            // bidirectional copy (no body inspection at all).
-            if let Some(gateway) = self.gateway_client.get() {
-                self.handle_non_llm_with_gateway(client_tls, gateway, host, target)
-                    .await?;
-            } else {
-                let upstream_tls = self.dial_upstream_tls(host, target).await?;
-                let (mut client_read, mut client_write) = tokio::io::split(client_tls);
-                let (mut upstream_read, mut upstream_write) = tokio::io::split(upstream_tls);
-
-                let client_to_upstream = tokio::io::copy(&mut client_read, &mut upstream_write);
-                let upstream_to_client = tokio::io::copy(&mut upstream_read, &mut client_write);
-
-                tokio::select! {
-                    r = client_to_upstream => { r?; }
-                    r = upstream_to_client => { r?; }
-                }
-            }
-
-            Ok(())
+            self.handle_connect_tunnel(reader, target).await
         } else {
-            // Plain HTTP request forwarding.
-            tracing::debug!(method = method, target = target, "plain HTTP request");
+            self.handle_plain_http(reader, request_line, method, target).await
+        }
+    }
 
-            // Consume remaining request headers.
-            let mut headers = Vec::new();
-            let mut header_line = String::new();
-            loop {
-                header_line.clear();
-                reader.read_line(&mut header_line).await?;
-                if header_line.trim().is_empty() {
-                    break;
-                }
-                headers.push(header_line.clone());
+    /// Handle a `CONNECT` tunnel: enforce egress policy, open the tunnel, then
+    /// either raw-tunnel (llm_only non-LLM hosts) or perform TLS MitM and route
+    /// to the LLM / gateway / passthrough handler by detected API pattern.
+    async fn handle_connect_tunnel(
+        self: &Arc<Self>,
+        mut reader: BufReader<TcpStream>,
+        target: &str,
+    ) -> Result<(), ProxyError> {
+        // Consume remaining headers (we only need the request line for CONNECT).
+        let mut header_line = String::new();
+        loop {
+            header_line.clear();
+            reader.read_line(&mut header_line).await?;
+            if header_line.trim().is_empty() {
+                break;
             }
+        }
 
-            // Parse host from the target URL or Host header.
-            let host = if let Some(url_host) = target.strip_prefix("http://") {
-                url_host.split('/').next().unwrap_or(url_host)
-            } else {
-                headers
-                    .iter()
-                    .find_map(|h| {
-                        let lower = h.to_ascii_lowercase();
-                        lower
-                            .starts_with("host:")
-                            .then(|| h["host:".len()..].trim().to_string())
-                    })
-                    .unwrap_or_default()
-                    .leak()
-            };
+        // Extract hostname (strip port) for deny check and certificate generation.
+        let host = target.split(':').next().unwrap_or(target);
 
-            // Connect to upstream via plain TCP.
-            let upstream_addr = if host.contains(':') {
-                host.to_string()
-            } else {
-                format!("{host}:80")
-            };
-            // SSRF re-validation (AAASM-3140): the plain-HTTP forward path must
-            // route through the same resolved-IP denylist as the CONNECT/tunnel
-            // paths. Without this, a steered agent making a plain `http://`
-            // request could reach loopback / RFC-1918 / `169.254.169.254` after
-            // DNS resolution, bypassing the AAASM-3130 hardening.
-            let mut upstream = match self.config.upstream_override {
-                Some(addr) => TcpStream::connect(addr).await?,
-                None => self.connect_revalidated(&upstream_addr).await?,
-            };
+        // Egress policy: deny-list, then AAASM-1943 network allowlist.
+        // Both return 403 + emit a deny decision and end the connection.
+        if let Some(reason) = self.connect_deny_reason(host) {
+            tracing::info!(%host, "CONNECT denied: {reason}");
+            let mut stream = reader.into_inner();
+            stream
+                .write_all(b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n")
+                .await?;
+            self.interceptor.emit_policy_decision(host, true).await;
+            return Ok(());
+        }
 
-            // Re-serialise and forward the original request.
-            upstream.write_all(request_line.as_bytes()).await?;
-            upstream.write_all(b"\r\n").await?;
-            for h in &headers {
-                upstream.write_all(h.as_bytes()).await?;
-            }
-            upstream.write_all(b"\r\n").await?;
+        // Send 200 Connection Established to tell the client the tunnel is open.
+        let mut stream = reader.into_inner();
+        stream.write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n").await?;
 
-            // Bidirectional copy between client and upstream.
-            let stream = reader.into_inner();
-            let (mut client_read, mut client_write) = tokio::io::split(stream);
-            let (mut upstream_read, mut upstream_write) = tokio::io::split(upstream);
+        tracing::debug!(host = target, "CONNECT tunnel established");
 
-            let c2u = tokio::io::copy(&mut client_read, &mut upstream_write);
-            let u2c = tokio::io::copy(&mut upstream_read, &mut client_write);
+        // Emit allow audit event for the accepted connection.
+        self.interceptor.emit_policy_decision(host, false).await;
+
+        // When llm_only is enabled, skip TLS MitM for non-LLM hosts and
+        // just tunnel the raw TCP bytes transparently.
+        if self.config.llm_only && detect_api(host) == LlmApiPattern::Unknown {
+            tracing::debug!(%host, "llm_only mode — transparent tunnel (no MitM)");
+            return self.transparent_tunnel(stream, target).await;
+        }
+
+        // --- TLS MitM: act as TLS server to the client ---
+        let ck = self.certs.get_or_insert(host, &self.ca)?;
+        let cert = CertificateDer::from(ck.cert_der.clone());
+        let key = PrivateKeyDer::from(PrivatePkcs8KeyDer::from(ck.key_der.clone()));
+        let server_config = ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![cert], key)
+            .map_err(|e| ProxyError::Tls(e.to_string()))?;
+        let acceptor = TlsAcceptor::from(Arc::new(server_config));
+        let client_tls = acceptor
+            .accept(stream)
+            .await
+            .map_err(|e| ProxyError::Tls(e.to_string()))?;
+
+        tracing::debug!(%host, "TLS MitM (client side) handshake complete");
+
+        let pattern = detect_api(host);
+
+        // For LLM patterns, read the inbound HTTP request inside the
+        // tunnel so the credential scanner can run against the real
+        // body bytes before any byte reaches upstream. For non-LLM
+        // patterns we fall through to the gateway/passthrough handler.
+        if pattern != LlmApiPattern::Unknown {
+            return self.handle_llm_mitm(client_tls, host, target, pattern).await;
+        }
+
+        // Non-LLM pattern.
+        //
+        // When a gateway client is configured, attempt MCP detection
+        // on the inbound HTTPS request body: a JSON-RPC 2.0 `tools/call`
+        // envelope is dispatched to the gateway PolicyService and
+        // enforced on the wire (Deny → JSON-RPC error envelope, Allow →
+        // forward, Redact → forward unchanged until AAASM-1941 lands
+        // response-side rewriting). Non-MCP bodies fall through to a
+        // transparent forward of the bytes we've already read.
+        //
+        // When no gateway is configured, preserve the historical raw
+        // bidirectional copy (no body inspection at all).
+        if let Some(gateway) = self.gateway_client.get() {
+            self.handle_non_llm_with_gateway(client_tls, gateway, host, target)
+                .await?;
+        } else {
+            let upstream_tls = self.dial_upstream_tls(host, target).await?;
+            let (mut client_read, mut client_write) = tokio::io::split(client_tls);
+            let (mut upstream_read, mut upstream_write) = tokio::io::split(upstream_tls);
+
+            let client_to_upstream = tokio::io::copy(&mut client_read, &mut upstream_write);
+            let upstream_to_client = tokio::io::copy(&mut upstream_read, &mut client_write);
 
             tokio::select! {
-                r = c2u => { r?; }
-                r = u2c => { r?; }
+                r = client_to_upstream => { r?; }
+                r = upstream_to_client => { r?; }
             }
-
-            Ok(())
         }
+
+        Ok(())
+    }
+
+    /// Raw bidirectional copy between an established client `stream` and the
+    /// re-validated upstream for `target`. Used by the llm_only transparent-
+    /// tunnel path, which forwards bytes without MitM. SSRF re-validation covers
+    /// this path too — it is the most likely SSRF vector when the host resolves
+    /// to an internal address.
+    async fn transparent_tunnel(self: &Arc<Self>, stream: TcpStream, target: &str) -> Result<(), ProxyError> {
+        let upstream = match self.config.upstream_override {
+            Some(addr) => TcpStream::connect(addr).await?,
+            None => self.connect_revalidated(target).await?,
+        };
+        let (mut cr, mut cw) = tokio::io::split(stream);
+        let (mut ur, mut uw) = tokio::io::split(upstream);
+        tokio::select! {
+            r = tokio::io::copy(&mut cr, &mut uw) => { r?; }
+            r = tokio::io::copy(&mut ur, &mut cw) => { r?; }
+        }
+        Ok(())
+    }
+
+    /// Forward a plain (non-CONNECT) HTTP request: parse the host from the
+    /// target/Host header, SSRF-revalidate the upstream (AAASM-3140), re-serialise
+    /// the request line + headers, then bidirectionally copy the bodies.
+    async fn handle_plain_http(
+        self: &Arc<Self>,
+        mut reader: BufReader<TcpStream>,
+        request_line: &str,
+        method: &str,
+        target: &str,
+    ) -> Result<(), ProxyError> {
+        tracing::debug!(method = method, target = target, "plain HTTP request");
+
+        // Consume remaining request headers.
+        let mut headers = Vec::new();
+        let mut header_line = String::new();
+        loop {
+            header_line.clear();
+            reader.read_line(&mut header_line).await?;
+            if header_line.trim().is_empty() {
+                break;
+            }
+            headers.push(header_line.clone());
+        }
+
+        // Parse host from the target URL or Host header.
+        let host = if let Some(url_host) = target.strip_prefix("http://") {
+            url_host.split('/').next().unwrap_or(url_host)
+        } else {
+            headers
+                .iter()
+                .find_map(|h| {
+                    let lower = h.to_ascii_lowercase();
+                    lower
+                        .starts_with("host:")
+                        .then(|| h["host:".len()..].trim().to_string())
+                })
+                .unwrap_or_default()
+                .leak()
+        };
+
+        // Connect to upstream via plain TCP.
+        let upstream_addr = if host.contains(':') {
+            host.to_string()
+        } else {
+            format!("{host}:80")
+        };
+        // SSRF re-validation (AAASM-3140): the plain-HTTP forward path must
+        // route through the same resolved-IP denylist as the CONNECT/tunnel
+        // paths. Without this, a steered agent making a plain `http://`
+        // request could reach loopback / RFC-1918 / `169.254.169.254` after
+        // DNS resolution, bypassing the AAASM-3130 hardening.
+        let mut upstream = match self.config.upstream_override {
+            Some(addr) => TcpStream::connect(addr).await?,
+            None => self.connect_revalidated(&upstream_addr).await?,
+        };
+
+        // Re-serialise and forward the original request.
+        upstream.write_all(request_line.as_bytes()).await?;
+        upstream.write_all(b"\r\n").await?;
+        for h in &headers {
+            upstream.write_all(h.as_bytes()).await?;
+        }
+        upstream.write_all(b"\r\n").await?;
+
+        // Bidirectional copy between client and upstream.
+        let stream = reader.into_inner();
+        let (mut client_read, mut client_write) = tokio::io::split(stream);
+        let (mut upstream_read, mut upstream_write) = tokio::io::split(upstream);
+
+        let c2u = tokio::io::copy(&mut client_read, &mut upstream_write);
+        let u2c = tokio::io::copy(&mut upstream_read, &mut client_write);
+
+        tokio::select! {
+            r = c2u => { r?; }
+            r = u2c => { r?; }
+        }
+
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Description

Reduces `rust:S3776` cognitive-complexity smells across the Rust crates (no `dashboard/` changes — owned by a parallel wave). All 13 reported sites are addressed by behaviour-preserving extraction of named private helpers, early-returns, and flat match tables. The policy engine is the hotspot, so each refactor was validated against its own test suite.

Per-function work:

**aa-gateway / policy / expr.rs**
- `eval_clause_safe` (complexity 79) — split into per-field `eval_*_field` helpers returning `Option<bool>` (None = fall through); the dispatcher is a chain of early-returns. Evaluation order + null-safety contracts preserved.
- `compare_json_value` (29) — collapsed the per-op-group nested `matches!(op, …)` re-checks into one flat `(op, value, literal)` match.
- `extract_field_names` (38) — extracted `skip_list_literal` / `skip_quoted_string` / `take_word` / `is_word_char`.
- `validate_governance_levels` (20) — extracted `take_identifier` / `validate_level_word`.

**aa-gateway / engine / mod.rs**
- `evaluate_primary` (22) and `evaluate_with_cascade` (22) shared an identical ~70-line Stage-6 credential-scan block — hoisted into `PolicyEngine::apply_credential_scan` returning a `CredentialScanOutcome` (`Block | Continue`), cutting both and removing the duplication.
- `eval_tool_stages` (22) — replaced three independent `if let ToolCall` guards with an action-variant `match` delegating to a new `eval_toolcall_stages` (resolves the tool policy once).

**aa-gateway / budget / tracker.rs**
- `tier_limit_exceeded` (16) — flattened the monthly/daily if-let pyramids into option-zip lookups feeding a shared `spend_exceeds` helper.

**aa-gateway / service / policy_service.rs**
- `register_escalation` (22) — dispatched the router-driven and legacy paths to `register_router_escalation` / `register_legacy_escalation`.

**aa-proxy / proxy / mod.rs**
- `handle_connection` (36) — split into `handle_connect_tunnel`, `handle_plain_http`, and `transparent_tunnel`.

**aa-api / ws / handler.rs**
- `handle_socket` (22) — extracted the `since`-replay loop into `replay_buffered_events`.

**aa-cli**
- `handle_key_event` (19, dashboard TUI) — extracted `handle_confirm_dialog_key`.
- `run_watch_interactive` (18, approvals watch) — extracted `poll_ws_message`.

No site was left as too-risky; all 13 were reduced.

## Type of Change

- [x] ♻️ Refactoring

## Breaking Changes

- [x] No

Pure internal refactor — policy-evaluation, credential-scan, proxy-egress, and escalation behaviour are byte-for-byte identical. No public API or wire change.

## Related Issues

- Related Jira ticket: AAASM-3358 (child of AAASM-3346, Epic AAASM-3345)

## Testing

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed

No new tests — this is a behaviour-preserving refactor covered by the existing suites. Validated locally:
- `cargo nextest run -p aa-gateway` — expr (96), engine (99), credential (14), budget (101), escalation (23) all green.
- `cargo nextest run -p aa-proxy` — 112 green (incl. CONNECT / plain-HTTP / LLM-MitM integration).
- `cargo nextest run -p aa-api ws::` — 33 green.
- `cargo nextest run -p aa-cli` dashboard/approvals — 43 + 31 green.
- `cargo clippy -p aa-gateway -p aa-proxy -p aa-api -p aa-cli --all-targets -- -D warnings` — clean.
- `cargo fmt --all` — clean.

Full-workspace `cargo nextest run --workspace`: 3120 passed, 7 failed. **All 7 failures are pre-existing, environment-only `aa-integration-tests::cli_dashboard dashboard_start_*` cases** that spawn `aasm dashboard start` and require the HTTP server to bind + respond 200 on localhost (no real dashboard build present; the serve path in `aa-cli/src/commands/dashboard/start.rs` is untouched by this PR). The same set fails identically in isolation; every dashboard test not needing a live-bound server passes.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (n/a — no behaviour change; helper doc-comments added)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
