### PR TITLE
[AAASM-3363] 🐛 (aa-gateway): Recover AuditService audit seq on restart

### DIFF
--- a/aa-gateway/src/server.rs
+++ b/aa-gateway/src/server.rs
@@ -403,7 +403,8 @@ pub async fn serve_tcp(
     )
     .with_initial_seq(initial_seq)
     .with_db_scheduler(db_scheduler.clone());
-    let audit_svc = AuditServiceImpl::new_with_registry(audit_tx, audit_drops, initial_hash, Arc::clone(&registry));
+    let audit_svc = AuditServiceImpl::new_with_registry(audit_tx, audit_drops, initial_hash, Arc::clone(&registry))
+        .with_initial_seq(initial_seq);
     let (edge_repo, _cross_team_rx) = InMemoryEdgeRepo::with_events(Arc::clone(&registry));
     let topology_svc = TopologyServiceImpl::new(Arc::clone(&registry), edge_repo);
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);
@@ -481,7 +482,8 @@ pub async fn serve_uds(
     )
     .with_initial_seq(initial_seq)
     .with_db_scheduler(db_scheduler.clone());
-    let audit_svc = AuditServiceImpl::new_with_registry(audit_tx, audit_drops, initial_hash, Arc::clone(&registry));
+    let audit_svc = AuditServiceImpl::new_with_registry(audit_tx, audit_drops, initial_hash, Arc::clone(&registry))
+        .with_initial_seq(initial_seq);
     let (edge_repo, _cross_team_rx) = InMemoryEdgeRepo::with_events(Arc::clone(&registry));
     let topology_svc = TopologyServiceImpl::new(Arc::clone(&registry), edge_repo);
     let lifecycle_svc = AgentLifecycleServiceImpl::new(registry);

--- a/aa-gateway/src/service/audit_service.rs
+++ b/aa-gateway/src/service/audit_service.rs
@@ -59,6 +59,22 @@ impl AuditServiceImpl {
         }
     }
 
+    /// Seed the audit `seq` counter so sequence numbers continue monotonically
+    /// across process restarts (AAASM-3363).
+    ///
+    /// `initial_seq` should be the *next* sequence number to emit — i.e.
+    /// `last_persisted_seq + 1`, obtained from
+    /// [`AuditWriter::read_last_seq`](crate::audit::AuditWriter::read_last_seq).
+    /// Without this, the counter restarts at `0` and produces duplicate `seq`
+    /// values after a restart, breaking the WORM log's per-entry uniqueness.
+    /// Mirrors the seq recovery already done for `PolicyServiceImpl` and the
+    /// `initial_hash` recovery for the hash chain.
+    #[must_use]
+    pub fn with_initial_seq(self, initial_seq: u64) -> Self {
+        self.seq.store(initial_seq, Ordering::Relaxed);
+        self
+    }
+
     /// Convert a proto `AuditEvent` into a core `AuditEntry` and send via try_send.
     ///
     /// Maintains the hash chain by reading and updating `last_hash`.

--- a/aa-gateway/tests/audit_service_seq_recovery_test.rs
+++ b/aa-gateway/tests/audit_service_seq_recovery_test.rs
@@ -1,0 +1,100 @@
+//! AAASM-3363 — `AuditService` `seq` recovery across process restarts.
+//!
+//! Sibling bug to AAASM-3356: `AuditServiceImpl` keeps its OWN `seq` atomic,
+//! independent of `PolicyServiceImpl`. It also seeded `seq: AtomicU64::new(0)`
+//! and recovered the hash-chain head but NOT the seq on restart, so
+//! `AuditService`-emitted events restarted at seq 0 and produced duplicates in
+//! the WORM log. `with_initial_seq` (seeded from `AuditWriter::read_last_seq`)
+//! fixes this. This test drives `report_events` across a simulated restart and
+//! asserts the seq continues monotonically.
+
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+
+use aa_core::AuditEntry;
+use aa_gateway::service::AuditServiceImpl;
+use aa_proto::assembly::audit::v1::audit_service_server::AuditService;
+use aa_proto::assembly::audit::v1::{AuditEvent, ReportEventsRequest};
+use aa_proto::assembly::common::v1::{AgentId as ProtoAgentId, Decision};
+use tokio::sync::mpsc;
+use tonic::Request;
+
+fn report_request() -> ReportEventsRequest {
+    ReportEventsRequest {
+        events: vec![AuditEvent {
+            event_id: "evt-seq".into(),
+            agent_id: Some(ProtoAgentId {
+                org_id: "org".into(),
+                team_id: "team".into(),
+                agent_id: "agent-1".into(),
+            }),
+            decision: Decision::Allow as i32,
+            trace_id: "trace-seq".into(),
+            span_id: "span-seq".into(),
+            ..Default::default()
+        }],
+    }
+}
+
+#[tokio::test]
+async fn audit_service_seq_continues_monotonically_after_restart() {
+    // ── First "process": emit two entries (seq 0 and 1). ───────────────────
+    let (audit_tx, mut audit_rx) = mpsc::channel::<AuditEntry>(4096);
+    let drops = Arc::new(AtomicU64::new(0));
+    let svc = AuditServiceImpl::new(audit_tx, drops, [0u8; 32]);
+
+    svc.report_events(Request::new(report_request())).await.unwrap();
+    svc.report_events(Request::new(report_request())).await.unwrap();
+    drop(svc); // close the tx so the receiver drains to completion
+
+    let mut first_run_seqs = Vec::new();
+    while let Some(entry) = audit_rx.recv().await {
+        first_run_seqs.push(entry.seq());
+    }
+    assert_eq!(first_run_seqs, vec![0, 1], "first run must emit seqs 0 and 1");
+    let last_seq = *first_run_seqs.last().unwrap();
+
+    // ── Restart: seed the new service from last_seq + 1. ───────────────────
+    let (audit_tx2, mut audit_rx2) = mpsc::channel::<AuditEntry>(4096);
+    let drops2 = Arc::new(AtomicU64::new(0));
+    let svc2 = AuditServiceImpl::new(audit_tx2, drops2, [0u8; 32]).with_initial_seq(last_seq + 1);
+
+    svc2.report_events(Request::new(report_request())).await.unwrap();
+    drop(svc2);
+
+    let mut second_run_seqs = Vec::new();
+    while let Some(entry) = audit_rx2.recv().await {
+        second_run_seqs.push(entry.seq());
+    }
+
+    assert_eq!(
+        second_run_seqs,
+        vec![2],
+        "post-restart seq must continue at {} (no duplicate of {:?})",
+        last_seq + 1,
+        first_run_seqs
+    );
+}
+
+#[tokio::test]
+async fn audit_service_without_recovery_seq_would_duplicate() {
+    // Demonstrates the bug shape: a fresh service WITHOUT `with_initial_seq`
+    // restarts the counter at 0, duplicating the previous run's seqs.
+    let (audit_tx, mut audit_rx) = mpsc::channel::<AuditEntry>(4096);
+    let drops = Arc::new(AtomicU64::new(0));
+    let svc = AuditServiceImpl::new(audit_tx, drops, [0u8; 32]);
+    svc.report_events(Request::new(report_request())).await.unwrap();
+    drop(svc);
+    let first = audit_rx.recv().await.unwrap().seq();
+    assert_eq!(first, 0);
+
+    let (audit_tx2, mut audit_rx2) = mpsc::channel::<AuditEntry>(4096);
+    let drops2 = Arc::new(AtomicU64::new(0));
+    let svc2 = AuditServiceImpl::new(audit_tx2, drops2, [0u8; 32]);
+    svc2.report_events(Request::new(report_request())).await.unwrap();
+    drop(svc2);
+    let second = audit_rx2.recv().await.unwrap().seq();
+
+    // Without recovery the second run also starts at 0 — a duplicate.
+    assert_eq!(second, 0, "fresh service (no recovery) duplicates seq 0");
+}


### PR DESCRIPTION
## Description

`aa-gateway`'s `AuditService` (`aa-gateway/src/service/audit_service.rs`) keeps its **own** `seq` atomic, independent of `PolicyService`. AAASM-3356 (PR #1120) added `AuditWriter::read_last_seq` and seeded the **PolicyService** seq from it on restart, but `AuditServiceImpl` was still constructed with `seq: AtomicU64::new(0)` and recovered only the hash chain (`initial_hash`), not the seq. On restart, `AuditService`-emitted events therefore restarted at seq 0 and produced **duplicate sequence numbers** across reboots — the same bug class as AAASM-3356 on a separate code path.

This PR applies the identical recovery to `AuditServiceImpl`:
- Adds a `with_initial_seq(initial_seq)` builder mirroring `PolicyServiceImpl::with_initial_seq`.
- Seeds it from the already-computed `initial_seq` (from `AuditWriter::read_last_seq(...) + 1`) at both `aa-gateway/src/server.rs` construction sites (TCP `serve` and UDS `serve_uds`).

No proto changes. `read_last_seq` already exists from #1120.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3363

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [ ] Manual testing performed

New regression test `aa-gateway/tests/audit_service_seq_recovery_test.rs` (mirrors the PolicyService restart-seq test from #1120):
- `audit_service_seq_continues_monotonically_after_restart` — drives `report_events` across a simulated restart and asserts post-restart seq continues at `last_seq + 1` (no duplicate).
- `audit_service_without_recovery_seq_would_duplicate` — documents the bug shape (fresh service without recovery duplicates seq 0).

Validation (in worktree, `cargo build`/`nextest -p aa-gateway`):
- `cargo build -p aa-gateway` — clean.
- `cargo nextest run -p aa-gateway` for the seq tests — 4 passed (2 new + 2 existing from #1120).
- `cargo fmt -p aa-gateway` + `cargo clippy -p aa-gateway --all-targets` — clean, zero warnings.

Note: a full `cargo nextest run -p aa-gateway` list errors locally with SIGKILL on the unrelated `remote_mode_tls` test binary (a pre-existing macOS sandbox issue, not introduced by this change). The targeted seq tests pass.

QA evidence: see `agent-assembly-integration-tests/verification-reports/base-branch-2026-06/`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed (doc comment on `with_initial_seq`)
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3363
