### PR TITLE
[AAASM-3350] 🐛 (aa-gateway): Strip port in eval_network_stage allowlist compare

### DIFF
--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -1650,6 +1650,38 @@ mod tests {
     }
 
     #[test]
+    fn network_allows_listed_host_with_port() {
+        // AAASM-3350: `convert.rs` emits `proto://host:port`, so the live
+        // `evaluate`/`eval_network_stage` path must strip the `:port` before the
+        // bare-host allowlist compare. An allowlisted host with a port must Allow.
+        let mut doc = empty_doc();
+        doc.network = Some(NetworkPolicy {
+            allowlist: vec!["api.openai.com".to_string()],
+        });
+        let engine = make_engine(doc);
+        let ctx = make_ctx();
+        let action = network_req("https://api.openai.com:443/v1");
+        assert_eq!(engine.evaluate(&ctx, &action).decision, PolicyResult::Allow);
+    }
+
+    #[test]
+    fn network_denies_unlisted_host_with_port() {
+        let mut doc = empty_doc();
+        doc.network = Some(NetworkPolicy {
+            allowlist: vec!["api.openai.com".to_string()],
+        });
+        let engine = make_engine(doc);
+        let ctx = make_ctx();
+        let action = network_req("https://evil.attacker.net:8443/x");
+        assert_eq!(
+            engine.evaluate(&ctx, &action).decision,
+            PolicyResult::Deny {
+                reason: "host not in network allowlist".into()
+            }
+        );
+    }
+
+    #[test]
     fn tool_deny_blocks_call() {
         let mut doc = empty_doc();
         doc.tools.insert(

--- a/aa-gateway/src/engine/mod.rs
+++ b/aa-gateway/src/engine/mod.rs
@@ -690,13 +690,23 @@ impl PolicyEngine {
         if np.allowlist.is_empty() {
             return None;
         }
-        let host = url
+        let host_port = url
             .split_once("://")
             .map(|x| x.1)
             .unwrap_or("")
             .split('/')
             .next()
             .unwrap_or("");
+        // AAASM-3350: `convert.rs` builds the URL as `proto://host:port`, so the
+        // authority extracted above still carries the `:port` suffix. Allowlist
+        // entries are bare hosts (`api.openai.com`), so comparing `host:port`
+        // against them always failed and every allowlisted host was denied on
+        // the live `evaluate`/`eval_network_stage` path. Strip a trailing
+        // numeric `:port` before the allowlist compare (mirrors `decision.rs`).
+        let host = match host_port.rsplit_once(':') {
+            Some((h, port)) if !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) => h,
+            _ => host_port,
+        };
         if !np.allowlist.iter().any(|entry| entry == host) {
             return Some(EvaluationResult::deny("host not in network allowlist"));
         }


### PR DESCRIPTION
## Description

The earlier AAASM-3350 fix (PR #1116) corrected the cascade decision path
(`aa-gateway/src/engine/decision.rs::stage_network`) but **missed the live
single-policy evaluation path**. QA re-verification on merged master showed an
allowlisted host with an explicit port is *still* denied.

Root cause: `aa-gateway/src/engine/mod.rs::eval_network_stage` (the stage used by
`evaluate_primary`, which `PolicyEngine::evaluate` calls whenever no scoped
policies are loaded) extracts the authority as `proto://host:port` and keeps the
`:port`, then exact-compares `entry == host` against the bare allowlist entries.
Since `service/convert.rs` builds the URL as `proto://host:port`, the compare
(`api.openai.com:443` vs `api.openai.com`) always failed and every allowlisted
host was denied on the live path.

Fix (minimal, surgical): strip a trailing numeric `:port` from the extracted
host before the allowlist compare, mirroring the `rsplit_once(':')` approach
already used in `decision.rs`. The existing `entry == host` exact-match semantics
of this stage are otherwise unchanged.

Scope note: I grepped all copies of this host-extraction pattern
(`split('/')` / "host not in network allowlist"). The only other live evaluation
copy is `decision.rs::stage_network`, which is **already patched** by #1116.
`anomaly/detector.rs::check_unknown_connection` carries the same pattern but has
**no callers** outside its own module (it is not wired into the live `CheckAction`
service path today), so it is out of this ticket's documented root-cause scope —
flagging it here as a candidate follow-up for whenever the anomaly detector is
wired live.

No `proto/` files were changed.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-3350
- Related GitHub issues: follow-up to #1116

Closes AAASM-3350

## Testing

Two regression tests added to `aa-gateway/src/engine/mod.rs`, both driving the
live `PolicyEngine::evaluate` path (not just the internal stage fn):

- `network_allows_listed_host_with_port` — allowlisted host **with** a port
  (`https://api.openai.com:443/v1`) → **Allow**.
- `network_denies_unlisted_host_with_port` — non-allowlisted host with a port
  (`https://evil.attacker.net:8443/x`) → **Deny**.

QA evidence: `agent-assembly-integration-tests/verification-reports/base-branch-2026-06/`.

Local validation (crate-scoped):
- `cargo build -p aa-gateway` — OK
- `cargo nextest run -p aa-gateway` — 1130 passed, 0 failed
- `cargo fmt -p aa-gateway` / `cargo clippy -p aa-gateway --all-targets` — clean

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
