### PR TITLE
[AAASM-3362] ♻️ (aa-core): Move LLM provider/model inference into aa-core

### DIFF
--- a/aa-core/src/lib.rs
+++ b/aa-core/src/lib.rs
@@ -34,6 +34,8 @@ pub mod config;
 pub mod dev_tool;
 pub mod evaluators;
 pub mod identity;
+#[cfg(feature = "alloc")]
+pub mod llm;
 pub mod policy;
 pub mod risk_tier;
 #[cfg(feature = "std")]
@@ -58,6 +60,9 @@ pub use dev_tool::DevToolKind;
 pub use dev_tool::McpServerInfo;
 #[cfg(feature = "std")]
 pub use dev_tool::{AdapterError, DevToolAdapter, DevToolInfo};
+
+#[cfg(feature = "alloc")]
+pub use llm::{Model, Provider};
 
 #[cfg(feature = "alloc")]
 pub use policy::{ArgsJson, GovernanceAction, PolicyDocument, PolicyEvaluator, PolicyResult, PolicyRule};

--- a/aa-core/src/llm.rs
+++ b/aa-core/src/llm.rs
@@ -1,0 +1,159 @@
+//! LLM provider and model identifiers shared across the workspace.
+//!
+//! These types and the [`Model::infer_from_name`] helper were originally
+//! introduced inside `aa-gateway::budget::types` (AAASM-3353). They are
+//! relocated here (AAASM-3362) so that SDKs and other crates can reuse the
+//! provider/model taxonomy and the model-name → `(Provider, Model)` inference
+//! without taking a dependency on `aa-gateway`. Pricing tables remain in
+//! `aa-gateway` — only the enums and the inference logic are core-appropriate.
+
+/// LLM provider identifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+pub enum Provider {
+    /// OpenAI (GPT-* models).
+    OpenAi,
+    /// Anthropic (Claude models).
+    Anthropic,
+    /// Cohere (Command models).
+    Cohere,
+}
+
+/// LLM model identifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+pub enum Model {
+    /// OpenAI GPT-4o.
+    Gpt4o,
+    /// OpenAI GPT-4.
+    Gpt4,
+    /// OpenAI GPT-3.5 Turbo.
+    Gpt35Turbo,
+    /// Anthropic Claude 3 Opus.
+    Claude3Opus,
+    /// Anthropic Claude 3 Sonnet.
+    Claude3Sonnet,
+    /// Anthropic Claude 3 Haiku.
+    Claude3Haiku,
+    /// Cohere Command R+.
+    CommandRPlus,
+    /// Cohere Command R.
+    CommandR,
+}
+
+impl Model {
+    /// Infer the `(Provider, Model)` pair from a free-form model name string.
+    ///
+    /// AAASM-3353 — the live `CheckAction` proto (`LlmCallContext`) carries only
+    /// the model name string; it does NOT carry a provider field. Rather than
+    /// change `proto/` (out of scope), the provider is inferred here from the
+    /// model name. The match is a case-insensitive substring test against the
+    /// known model families, ordered most-specific-first so that e.g.
+    /// `gpt-4o-2024-08-06` maps to `Gpt4o` (not `Gpt4`) and
+    /// `command-r-plus` maps to `CommandRPlus` (not `CommandR`).
+    ///
+    /// Returns `None` for an unrecognised model name — the caller treats an
+    /// unknown model as zero cost (no spend accrued) rather than guessing.
+    pub fn infer_from_name(name: &str) -> Option<(Provider, Self)> {
+        let n = name.to_ascii_lowercase();
+        // Most-specific patterns first; substrings of others must come earlier.
+        if n.contains("gpt-4o") || n.contains("gpt4o") {
+            Some((Provider::OpenAi, Model::Gpt4o))
+        } else if n.contains("gpt-3.5") || n.contains("gpt35") || n.contains("gpt-35") {
+            Some((Provider::OpenAi, Model::Gpt35Turbo))
+        } else if n.contains("gpt-4") || n.contains("gpt4") {
+            Some((Provider::OpenAi, Model::Gpt4))
+        } else if n.contains("opus") {
+            Some((Provider::Anthropic, Model::Claude3Opus))
+        } else if n.contains("sonnet") {
+            Some((Provider::Anthropic, Model::Claude3Sonnet))
+        } else if n.contains("haiku") {
+            Some((Provider::Anthropic, Model::Claude3Haiku))
+        } else if n.contains("command-r-plus") || n.contains("command-r+") {
+            Some((Provider::Cohere, Model::CommandRPlus))
+        } else if n.contains("command-r") {
+            Some((Provider::Cohere, Model::CommandR))
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_variants_are_distinct() {
+        assert_eq!(Provider::OpenAi, Provider::OpenAi);
+        assert_ne!(Provider::OpenAi, Provider::Anthropic);
+        assert_ne!(Provider::OpenAi, Provider::Cohere);
+        assert_ne!(Provider::Anthropic, Provider::Cohere);
+    }
+
+    #[test]
+    fn model_variants_are_distinct() {
+        assert_eq!(Model::Gpt4o, Model::Gpt4o);
+        assert_ne!(Model::Gpt4o, Model::Gpt4);
+        assert_ne!(Model::Claude3Opus, Model::Claude3Haiku);
+        assert_ne!(Model::CommandRPlus, Model::CommandR);
+    }
+
+    #[test]
+    fn infer_openai_gpt4o_most_specific() {
+        assert_eq!(
+            Model::infer_from_name("gpt-4o-2024-08-06"),
+            Some((Provider::OpenAi, Model::Gpt4o))
+        );
+        assert_eq!(Model::infer_from_name("GPT4O"), Some((Provider::OpenAi, Model::Gpt4o)));
+    }
+
+    #[test]
+    fn infer_openai_gpt35_before_gpt4() {
+        assert_eq!(
+            Model::infer_from_name("gpt-3.5-turbo"),
+            Some((Provider::OpenAi, Model::Gpt35Turbo))
+        );
+    }
+
+    #[test]
+    fn infer_openai_gpt4() {
+        assert_eq!(Model::infer_from_name("gpt-4"), Some((Provider::OpenAi, Model::Gpt4)));
+    }
+
+    #[test]
+    fn infer_anthropic_family() {
+        assert_eq!(
+            Model::infer_from_name("claude-3-opus-20240229"),
+            Some((Provider::Anthropic, Model::Claude3Opus))
+        );
+        assert_eq!(
+            Model::infer_from_name("claude-3-5-sonnet"),
+            Some((Provider::Anthropic, Model::Claude3Sonnet))
+        );
+        assert_eq!(
+            Model::infer_from_name("claude-3-haiku"),
+            Some((Provider::Anthropic, Model::Claude3Haiku))
+        );
+    }
+
+    #[test]
+    fn infer_cohere_command_r_plus_before_command_r() {
+        assert_eq!(
+            Model::infer_from_name("command-r-plus"),
+            Some((Provider::Cohere, Model::CommandRPlus))
+        );
+        assert_eq!(
+            Model::infer_from_name("command-r"),
+            Some((Provider::Cohere, Model::CommandR))
+        );
+    }
+
+    #[test]
+    fn infer_unknown_returns_none() {
+        assert_eq!(Model::infer_from_name("mystery-model-v9"), None);
+        assert_eq!(Model::infer_from_name(""), None);
+    }
+}

--- a/aa-gateway/src/budget/types.rs
+++ b/aa-gateway/src/budget/types.rs
@@ -2,72 +2,13 @@
 
 use chrono::Datelike;
 
-/// LLM provider identifier.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum Provider {
-    /// OpenAI (GPT-* models).
-    OpenAi,
-    /// Anthropic (Claude models).
-    Anthropic,
-    /// Cohere (Command models).
-    Cohere,
-}
-
-/// LLM model identifier.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum Model {
-    // OpenAI
-    Gpt4o,
-    Gpt4,
-    Gpt35Turbo,
-    // Anthropic
-    Claude3Opus,
-    Claude3Sonnet,
-    Claude3Haiku,
-    // Cohere
-    CommandRPlus,
-    CommandR,
-}
-
-impl Model {
-    /// Infer the `(Provider, Model)` pair from a free-form model name string.
-    ///
-    /// AAASM-3353 — the live `CheckAction` proto (`LlmCallContext`) carries only
-    /// the model name string; it does NOT carry a provider field. Rather than
-    /// change `proto/` (out of scope), the provider is inferred here from the
-    /// model name. The match is a case-insensitive substring test against the
-    /// known model families, ordered most-specific-first so that e.g.
-    /// `gpt-4o-2024-08-06` maps to `Gpt4o` (not `Gpt4`) and
-    /// `command-r-plus` maps to `CommandRPlus` (not `CommandR`).
-    ///
-    /// Returns `None` for an unrecognised model name — the caller treats an
-    /// unknown model as zero cost (no spend accrued) rather than guessing.
-    pub fn infer_from_name(name: &str) -> Option<(Provider, Self)> {
-        let n = name.to_ascii_lowercase();
-        // Most-specific patterns first; substrings of others must come earlier.
-        if n.contains("gpt-4o") || n.contains("gpt4o") {
-            Some((Provider::OpenAi, Model::Gpt4o))
-        } else if n.contains("gpt-3.5") || n.contains("gpt35") || n.contains("gpt-35") {
-            Some((Provider::OpenAi, Model::Gpt35Turbo))
-        } else if n.contains("gpt-4") || n.contains("gpt4") {
-            Some((Provider::OpenAi, Model::Gpt4))
-        } else if n.contains("opus") {
-            Some((Provider::Anthropic, Model::Claude3Opus))
-        } else if n.contains("sonnet") {
-            Some((Provider::Anthropic, Model::Claude3Sonnet))
-        } else if n.contains("haiku") {
-            Some((Provider::Anthropic, Model::Claude3Haiku))
-        } else if n.contains("command-r-plus") || n.contains("command-r+") {
-            Some((Provider::Cohere, Model::CommandRPlus))
-        } else if n.contains("command-r") {
-            Some((Provider::Cohere, Model::CommandR))
-        } else {
-            None
-        }
-    }
-}
+// The LLM `Provider`/`Model` enums and the model-name → `(Provider, Model)`
+// inference (`Model::infer_from_name`) were relocated to `aa-core::llm`
+// (AAASM-3362) so SDKs and other crates can reuse them without depending on
+// `aa-gateway`. They are re-exported here so existing `budget::types::{Provider,
+// Model}` call sites (pricing table, engine accrual) keep working unchanged.
+// Pricing tables remain in `aa-gateway` (see `super::pricing`).
+pub use aa_core::llm::{Model, Provider};
 
 /// Discriminates which budget window a limit or check applies to.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -265,22 +206,6 @@ pub struct BudgetAlert {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn provider_variants_are_distinct() {
-        assert_eq!(Provider::OpenAi, Provider::OpenAi);
-        assert_ne!(Provider::OpenAi, Provider::Anthropic);
-        assert_ne!(Provider::OpenAi, Provider::Cohere);
-        assert_ne!(Provider::Anthropic, Provider::Cohere);
-    }
-
-    #[test]
-    fn model_variants_are_distinct() {
-        assert_eq!(Model::Gpt4o, Model::Gpt4o);
-        assert_ne!(Model::Gpt4o, Model::Gpt4);
-        assert_ne!(Model::Claude3Opus, Model::Claude3Haiku);
-        assert_ne!(Model::CommandRPlus, Model::CommandR);
-    }
 
     #[test]
     fn budget_status_within_budget_holds_values() {


### PR DESCRIPTION
## Description

Relocate the LLM `Provider`/`Model` enums and the model-name → `(Provider, Model)` inference (`Model::infer_from_name`) — originally added inside `aa-gateway::budget::types` by AAASM-3353 (PR #1120) — into a new `aa-core::llm` module. The enums and inference are now reusable by the language SDKs and any other crate without taking a dependency on `aa-gateway`.

`aa-gateway::budget::types` now re-exports `aa_core::llm::{Provider, Model}`, so every existing call site (`budget::pricing` pricing table, `engine` spend accrual) keeps working unchanged. Pricing tables remain in `aa-gateway` — the ticket is specifically about the enums + inference, not pricing.

## Type of Change

- [x] ♻️ Refactoring

## Breaking Changes

- [x] No

`aa-gateway::budget::types::{Provider, Model}` remain available at the same paths via re-export; the `Model::infer_from_name` signature is unchanged. No public API removed.

## Related Issues

- Related Jira ticket: AAASM-3362

Closes AAASM-3362

## Testing

- [x] Unit tests added / updated

The `infer_from_name` and enum-distinctness unit tests were moved into `aa-core::llm` (and expanded with explicit most-specific-ordering cases for `gpt-4o`/`gpt-3.5`, the Claude family, and `command-r-plus` vs `command-r`, plus an unknown-name → `None` case). The two now-duplicate enum tests were dropped from `aa-gateway`.

Validation (shared `CARGO_TARGET_DIR`, `RUSTUP_TOOLCHAIN=stable`):

- `cargo build -p aa-core -p aa-gateway` — clean
- `cargo clippy -p aa-core -p aa-gateway --all-targets` — clean
- `cargo nextest run -p aa-core -p aa-gateway` — **1349 passed, 0 skipped**

QA evidence base: `agent-assembly-integration-tests/verification-reports/base-branch-2026-06/`.

### Implementation notes

- In `aa-core` the enums gate their `serde` derives behind the crate's `serde` feature (`#[cfg_attr(feature = "serde", ...)]`), matching the existing `aa-core::types` pattern; `aa-gateway` already enables `aa-core`'s `serde` feature so serialization behaviour is preserved. The `llm` module is gated behind `alloc` (the inference allocates a `String`).
- aa-core's `missing_docs` lint required doc comments on every `Model` variant (the original aa-gateway version had none); added concise per-variant docs.
- No `proto/` files changed.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
