### PR TITLE
[AAASM-3365] ♻️ (dashboard): Clear pages/components/rest SonarCloud smells (recovered)

### DIFF
--- a/dashboard/src/api/__tests__/capability.test.ts
+++ b/dashboard/src/api/__tests__/capability.test.ts
@@ -35,13 +35,7 @@ describe('createApiCapabilityClient', () => {
     const stub = stubMatrix()
     const getSpy = vi
       .spyOn(api, 'GET')
-      // openapi-fetch's GET signature is complex; the runtime contract is `{ data, error }`,
-      // and the test only depends on that runtime shape — so we narrow the cast at the
-      // call site rather than reconstructing the full overload type here.
-      // openapi-fetch's per-path generic return types are awkward to satisfy
-      // from a Vitest spy; the runtime contract is `{ data, error }` and that
-      // is what the factory consumes, so the mock-side narrow uses `unknown`.
-      .mockResolvedValue({ data: stub, error: undefined } as unknown as never)
+      .mockResolvedValue({ data: stub, error: undefined })
 
     const client = createApiCapabilityClient()
     const matrix = await client.getMatrix()
@@ -55,7 +49,7 @@ describe('createApiCapabilityClient', () => {
     const stubUpdated: OverrideResponse = { updated: stubMatrix().agents }
     const postSpy = vi
       .spyOn(api, 'POST')
-      .mockResolvedValue({ data: stubUpdated, error: undefined } as unknown as never)
+      .mockResolvedValue({ data: stubUpdated, error: undefined })
 
     const client = createApiCapabilityClient()
     const res = await client.applyOverride({
@@ -81,7 +75,7 @@ describe('createApiCapabilityClient', () => {
     vi.spyOn(api, 'POST').mockResolvedValue({
       data: undefined,
       error: { status: 403, detail: 'policy mutation denied' },
-    } as unknown as never)
+    })
 
     const client = createApiCapabilityClient()
     await expect(
@@ -98,7 +92,7 @@ describe('createApiCapabilityClient', () => {
     vi.spyOn(api, 'GET').mockResolvedValue({
       data: undefined,
       error: { status: 500, detail: 'internal error' },
-    } as unknown as never)
+    })
 
     const client = createApiCapabilityClient()
     await expect(client.getMatrix()).rejects.toThrow(/capability matrix fetch failed/)

--- a/dashboard/src/api/capability.ts
+++ b/dashboard/src/api/capability.ts
@@ -10,7 +10,7 @@ import { api } from './client'
 const MOCK_LATENCY_MS = 120
 
 function clone<T>(value: T): T {
-  return JSON.parse(JSON.stringify(value)) as T
+  return structuredClone(value)
 }
 
 function delay(ms: number): Promise<void> {

--- a/dashboard/src/auth/AuthProvider.tsx
+++ b/dashboard/src/auth/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { AuthContext } from './AuthContext'
 
 export function AuthProvider({ children }: Readonly<{ children: React.ReactNode }>) {
@@ -6,7 +6,7 @@ export function AuthProvider({ children }: Readonly<{ children: React.ReactNode 
     () => localStorage.getItem('aa_token'),
   )
 
-  async function login(apiKey: string): Promise<void> {
+  const login = useCallback(async (apiKey: string): Promise<void> => {
     const base = import.meta.env.VITE_API_BASE_URL ?? ''
     const res = await fetch(`${base}/api/v1/auth/token`, {
       method: 'POST',
@@ -22,15 +22,17 @@ export function AuthProvider({ children }: Readonly<{ children: React.ReactNode 
     const data = (await res.json()) as { token: string }
     localStorage.setItem('aa_token', data.token)
     setToken(data.token)
-  }
+  }, [])
 
-  function logout() {
+  const logout = useCallback(() => {
     localStorage.removeItem('aa_token')
     setToken(null)
-  }
+  }, [])
+
+  const value = useMemo(() => ({ token, login, logout }), [token, login, logout])
 
   return (
-    <AuthContext.Provider value={{ token, login, logout }}>
+    <AuthContext.Provider value={value}>
       {children}
     </AuthContext.Provider>
   )

--- a/dashboard/src/components/ApprovalRoutingBadge.tsx
+++ b/dashboard/src/components/ApprovalRoutingBadge.tsx
@@ -28,14 +28,14 @@ function formatLabel(routingStatus: RoutingStatusInfo): string {
     return 'Routed to Org Admin'
   }
   if (status.startsWith('escalated_to_')) {
-    const role = status.slice('escalated_to_'.length).replace(/_/g, ' ')
+    const role = status.slice('escalated_to_'.length).replaceAll('_', ' ')
     return `Escalated to ${role} (timed out)`
   }
   if (status.startsWith('escalated:')) {
-    const role = status.slice('escalated:'.length).replace(/_/g, ' ')
+    const role = status.slice('escalated:'.length).replaceAll('_', ' ')
     return `Escalated to ${role} (timed out)`
   }
-  return status.replace(/_/g, ' ')
+  return status.replaceAll('_', ' ')
 }
 
 function formatHistoryTooltip(history: RoutingHistoryEntry[]): string {

--- a/dashboard/src/components/EmptyState.tsx
+++ b/dashboard/src/components/EmptyState.tsx
@@ -128,7 +128,7 @@ export interface EmptyStateProps {
 export function EmptyState({ page = 'overview', onCta, onSecondary }: Readonly<EmptyStateProps>) {
   const c = COPY[page] ?? COPY.overview
   return (
-    <div className="state-page" role="status" data-testid={`empty-state-${page}`}>
+    <output className="state-page" data-testid={`empty-state-${page}`}>
       <div className="state-block">
         <div className="state-icon" aria-hidden>
           {c.icon}
@@ -151,6 +151,6 @@ export function EmptyState({ page = 'overview', onCta, onSecondary }: Readonly<E
           </div>
         )}
       </div>
-    </div>
+    </output>
   )
 }

--- a/dashboard/src/components/LoadingState.tsx
+++ b/dashboard/src/components/LoadingState.tsx
@@ -6,12 +6,14 @@ export interface LoadingStateProps {
   page?: LoadingStatePage
 }
 
+const MATRIX_CELL_KEYS = Array.from({ length: 9 * 7 }, (_, i) => `sk-matrix-cell-${i}`)
+const FLEET_ROW_KEYS = Array.from({ length: 8 }, (_, i) => `sk-fleet-row-${i}`)
+
 function MatrixSkeleton() {
-  const cells = Array.from({ length: 9 * 7 })
   return (
     <div className="sk-matrix">
-      {cells.map((_, i) => (
-        <div key={i} className="sk-matrix-cell">
+      {MATRIX_CELL_KEYS.map((key) => (
+        <div key={key} className="sk-matrix-cell">
           <span className="sk sk-line" style={{ width: '60%' }} />
         </div>
       ))}
@@ -22,8 +24,8 @@ function MatrixSkeleton() {
 function FleetSkeleton() {
   return (
     <div className="sk-table">
-      {Array.from({ length: 8 }).map((_, i) => (
-        <div key={i} className="sk-table-row">
+      {FLEET_ROW_KEYS.map((key) => (
+        <div key={key} className="sk-table-row">
           <span className="sk sk-line" style={{ width: '80%' }} />
           <span className="sk sk-line" style={{ width: 60 }} />
           <span className="sk sk-line" style={{ width: 80 }} />
@@ -37,7 +39,7 @@ function FleetSkeleton() {
 
 export function LoadingState({ page = 'generic' }: Readonly<LoadingStateProps>) {
   return (
-    <div className="state-page sk-pulse" role="status" aria-busy data-testid={`loading-state-${page}`}>
+    <output className="state-page sk-pulse" aria-busy data-testid={`loading-state-${page}`}>
       <div className="sk-page-head">
         <div>
           <span className="sk sk-line" />
@@ -59,6 +61,6 @@ export function LoadingState({ page = 'generic' }: Readonly<LoadingStateProps>) 
           <span className="sk sk-block" style={{ width: '100%' }} />
         </div>
       )}
-    </div>
+    </output>
   )
 }

--- a/dashboard/src/components/Overlay.test.tsx
+++ b/dashboard/src/components/Overlay.test.tsx
@@ -87,7 +87,7 @@ describe('AppShell overlay mount points', () => {
     for (const name of OVERLAY_NAMES) {
       const mount = screen.getByTestId(`overlay-mount-${name}`)
       expect(mount).toBeInTheDocument()
-      expect(mount.getAttribute('data-overlay')).toBe(name)
+      expect(mount.dataset.overlay).toBe(name)
     }
     localStorage.clear()
   })

--- a/dashboard/src/components/OverlayProvider.tsx
+++ b/dashboard/src/components/OverlayProvider.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, type ReactNode } from 'react'
+import { useCallback, useMemo, useState, type ReactNode } from 'react'
 import { OverlayContext, OVERLAY_NAMES, type OverlayName, type OverlayState } from './OverlayContext'
 
 const INITIAL_STATES: Record<OverlayName, OverlayState> = Object.fromEntries(
@@ -19,8 +19,13 @@ export function OverlayProvider({ children }: Readonly<{ children: ReactNode }>)
     setStates((prev) => ({ ...prev, [name]: { open: false, props: {} } }))
   }, [])
 
+  const value = useMemo(
+    () => ({ states, openOverlay, closeOverlay }),
+    [states, openOverlay, closeOverlay],
+  )
+
   return (
-    <OverlayContext.Provider value={{ states, openOverlay, closeOverlay }}>
+    <OverlayContext.Provider value={value}>
       {children}
     </OverlayContext.Provider>
   )

--- a/dashboard/src/components/SubtreeBurnChart.tsx
+++ b/dashboard/src/components/SubtreeBurnChart.tsx
@@ -151,10 +151,10 @@ function transform(data: SubtreeBurn | undefined): {
   const sortedChildIds = Array.from(childIds).sort((a, b) => a.localeCompare(b))
 
   const rows: ChartRow[] = (data?.points ?? []).map((point) => {
-    const row: ChartRow = { date: point.date, total: parseFloat(point.total_usd) || 0 }
+    const row: ChartRow = { date: point.date, total: Number.parseFloat(point.total_usd) || 0 }
     for (const cid of sortedChildIds) {
       const match = point.per_child.find((c) => c.child_agent_id === cid)
-      row[cid] = match ? parseFloat(match.spent_usd) || 0 : 0
+      row[cid] = match ? Number.parseFloat(match.spent_usd) || 0 : 0
     }
     return row
   })

--- a/dashboard/src/components/Toast.tsx
+++ b/dashboard/src/components/Toast.tsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
-import { ToastContext, type ToastVariant } from './ToastContext'
+import { ToastContext } from './ToastContext'
 
-export type { ToastVariant }
+export type { ToastVariant } from './ToastContext'
 
 export function useToast() {
   const ctx = useContext(ToastContext)

--- a/dashboard/src/components/ToastProvider.tsx
+++ b/dashboard/src/components/ToastProvider.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, type ReactNode } from 'react'
+import { useState, useCallback, useMemo, type ReactNode } from 'react'
 import { ToastContext, type ToastVariant, type ToastMessage } from './ToastContext'
 
 let _nextId = 0
@@ -25,8 +25,10 @@ export function ToastProvider({ children }: Readonly<{ children: ReactNode }>) {
     setTimeout(() => setToasts((prev) => removeToast(prev, id)), TOAST_TTL_MS)
   }, [])
 
+  const value = useMemo(() => ({ toast }), [toast])
+
   return (
-    <ToastContext.Provider value={{ toast }}>
+    <ToastContext.Provider value={value}>
       {children}
       <div
         style={{

--- a/dashboard/src/components/Tooltip.tsx
+++ b/dashboard/src/components/Tooltip.tsx
@@ -17,6 +17,8 @@ export function Tooltip({ content, children, open = false }: Readonly<TooltipPro
       className="tooltip-wrapper"
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
+      onFocus={() => setHovered(true)}
+      onBlur={() => setHovered(false)}
     >
       {children}
       {visible && (

--- a/dashboard/src/components/ViolationHeatmap.tsx
+++ b/dashboard/src/components/ViolationHeatmap.tsx
@@ -142,11 +142,11 @@ export function ViolationHeatmap({ nodes, maxNodes = 1000 }: Readonly<Props>) {
       >
         {/* Links */}
         <g transform="translate(40,40)">
-          {links.map((link, i) => {
+          {links.map((link) => {
             if (link.source.data.agent_id === "__root__") return null;
             return (
               <line
-                key={i}
+                key={`${link.source.data.agent_id}->${link.target.data.agent_id}`}
                 x1={link.source.x}
                 y1={link.source.y}
                 x2={link.target.x}

--- a/dashboard/src/components/states/EmptyState.test.tsx
+++ b/dashboard/src/components/states/EmptyState.test.tsx
@@ -27,8 +27,8 @@ describe('EmptyState', () => {
     expect(screen.queryByTestId('empty-icon')).not.toBeInTheDocument()
   })
 
-  it('marks the surface with role="status" for assistive tech', () => {
+  it('exposes the surface with the status role for assistive tech', () => {
     render(<EmptyState title="No results" />)
-    expect(screen.getByTestId('empty-state')).toHaveAttribute('role', 'status')
+    expect(screen.getByRole('status')).toBe(screen.getByTestId('empty-state'))
   })
 })

--- a/dashboard/src/components/states/EmptyState.tsx
+++ b/dashboard/src/components/states/EmptyState.tsx
@@ -10,11 +10,11 @@ interface EmptyStateProps {
 
 export function EmptyState({ title, description, action, icon }: Readonly<EmptyStateProps>) {
   return (
-    <div className="state state--empty" role="status" data-testid="empty-state">
+    <output className="state state--empty" data-testid="empty-state">
       {icon ? <div className="state__icon">{icon}</div> : null}
       <h2 className="state__title">{title}</h2>
       {description ? <div className="state__description">{description}</div> : null}
       {action ? <div className="state__action">{action}</div> : null}
-    </div>
+    </output>
   )
 }

--- a/dashboard/src/components/topology/NodeDetailPanel.tsx
+++ b/dashboard/src/components/topology/NodeDetailPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { useTopologyNodeRecentEvents } from '../../features/topology/api'
 import type { TopologyNode } from '../../features/topology/types'
+import { bucketForRatio } from './budgetThreshold'
 import './NodeDetailPanel.css'
 
 const RECENT_EVENT_LIMIT = 5
@@ -125,9 +126,7 @@ export function NodeDetailPanel({ node, onClose, onViewTrace }: NodeDetailPanelP
           <div
             className="node-detail-panel__progress-fill"
             style={{ width: `${Math.round(ratio * 100)}%` }}
-            data-ratio-bucket={
-              ratio < 0.8 ? 'ok' : ratio < 0.95 ? 'warn' : 'danger'
-            }
+            data-ratio-bucket={bucketForRatio(ratio)}
           />
         </div>
       </section>

--- a/dashboard/src/components/topology/TopologyGraph.test.tsx
+++ b/dashboard/src/components/topology/TopologyGraph.test.tsx
@@ -113,7 +113,7 @@ describe('TopologyGraph', () => {
       render(<TopologyGraph nodes={TWO_TEAMS} edges={[]} />)
       const clusters = screen.getAllByTestId('team-cluster')
       expect(clusters).toHaveLength(2)
-      const teams = clusters.map(c => c.getAttribute('data-team')).sort()
+      const teams = clusters.map(c => c.dataset.team).sort()
       expect(teams).toEqual(['analytics', 'support'])
     })
 
@@ -122,8 +122,8 @@ describe('TopologyGraph', () => {
       const bars = screen.getAllByTestId('team-budget-bar')
       expect(bars).toHaveLength(2)
 
-      const support = bars.find(b => b.getAttribute('data-team') === 'support')!
-      const analytics = bars.find(b => b.getAttribute('data-team') === 'analytics')!
+      const support = bars.find(b => b.dataset.team === 'support')!
+      const analytics = bars.find(b => b.dataset.team === 'analytics')!
 
       // support: spent 1+2+4=7, limit 10+10+10=30 → 23% → ok
       expect(support).toHaveAttribute('data-threshold-bucket', 'ok')

--- a/dashboard/src/components/topology/TopologyGraph.tsx
+++ b/dashboard/src/components/topology/TopologyGraph.tsx
@@ -70,10 +70,11 @@ export function TopologyGraph({
 }: TopologyGraphProps) {
   // Stable identity key — restart the sim only when the *set* of node/edge
   // ids changes, not on every parent re-render.
-  const identityKey = useMemo(
-    () => `${nodes.map(n => n.id).join(',')}|${edges.map(e => `${e.source}->${e.target}`).join(',')}`,
-    [nodes, edges],
-  )
+  const identityKey = useMemo(() => {
+    const nodeIds = nodes.map(n => n.id).join(',')
+    const edgeIds = edges.map(e => `${e.source}->${e.target}`).join(',')
+    return `${nodeIds}|${edgeIds}`
+  }, [nodes, edges])
 
   // Per-team layout: centers laid out left-to-right, top-to-bottom in a
   // grid based on team count, plus aggregated spend/limit/member count.
@@ -87,7 +88,9 @@ export function TopologyGraph({
       byTeam.set(n.team, entry)
     }
     const teams = [...byTeam.keys()]
-    const cols = teams.length <= 2 ? teams.length : teams.length <= 6 ? 3 : 4
+    let cols = 4
+    if (teams.length <= 2) cols = teams.length
+    else if (teams.length <= 6) cols = 3
     const rows = Math.max(1, Math.ceil(teams.length / cols))
     const cellW = width / Math.max(1, cols)
     const cellH = height / rows

--- a/dashboard/src/components/topology/budgetThreshold.ts
+++ b/dashboard/src/components/topology/budgetThreshold.ts
@@ -13,10 +13,14 @@
 
 export type BudgetThresholdBucket = 'ok' | 'warn' | 'danger'
 
-export function bucketForBudget(spent: number, limit: number): BudgetThresholdBucket {
-  if (limit <= 0) return 'ok'
-  const ratio = spent / limit
+/** Map a precomputed burn ratio (spent/limit) to its threshold bucket. */
+export function bucketForRatio(ratio: number): BudgetThresholdBucket {
   if (ratio < 0.8) return 'ok'
   if (ratio < 0.95) return 'warn'
   return 'danger'
+}
+
+export function bucketForBudget(spent: number, limit: number): BudgetThresholdBucket {
+  if (limit <= 0) return 'ok'
+  return bucketForRatio(spent / limit)
 }

--- a/dashboard/src/lib/ignorePromise.ts
+++ b/dashboard/src/lib/ignorePromise.ts
@@ -14,7 +14,7 @@
  * that returns `undefined` in tests): the `.catch` handler is only attached
  * when the value is actually a promise, otherwise the value is discarded.
  */
-export function ignorePromise(promise: Promise<unknown> | unknown): void {
+export function ignorePromise(promise: unknown): void {
   if (promise instanceof Promise) {
     // Attach a no-op handler so an unexpected rejection cannot surface as an
     // unhandled-rejection warning. Intentionally swallows — callers use this

--- a/dashboard/src/pages/AgentDetailPage.test.tsx
+++ b/dashboard/src/pages/AgentDetailPage.test.tsx
@@ -90,6 +90,28 @@ function mockHappyPath() {
   )
 }
 
+function mockSuspendedAgent() {
+  vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
+    mockQuery<Agent[]>({ data: [MOCK_AGENT], isLoading: false, isError: false, refetch: vi.fn() }),
+  )
+  vi.spyOn(agentsApi, 'useAgentQuery').mockReturnValue(
+    mockQuery<Agent | undefined>({
+      data: { ...MOCK_AGENT, status: 'suspended' },
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    }),
+  )
+  vi.spyOn(agentsApi, 'useAgentEventsQuery').mockReturnValue(
+    mockQuery<LogEntry[]>({ data: [MOCK_LOG], isLoading: false, isError: false }),
+  )
+  vi.spyOn(agentsApi, 'useAgentCapabilitiesQuery').mockReturnValue(
+    mockQuery<agentsApi.EffectivePermissions>({
+      data: { allow: [], deny: [], sources: [] }, isLoading: false, isError: false,
+    }),
+  )
+}
+
 afterEach(() => { vi.restoreAllMocks() })
 
 describe('AgentDetailPage deep link', () => {
@@ -389,28 +411,6 @@ describe('AgentDetailPage — suspend / resume actions', () => {
       { mutate, isPending: false } as unknown as ReturnType<typeof agentsMutations.useResumeAgent>,
     )
     return mutate
-  }
-
-  function mockSuspendedAgent() {
-    vi.spyOn(agentsApi, 'useAgentsQuery').mockReturnValue(
-      mockQuery<Agent[]>({ data: [MOCK_AGENT], isLoading: false, isError: false, refetch: vi.fn() }),
-    )
-    vi.spyOn(agentsApi, 'useAgentQuery').mockReturnValue(
-      mockQuery<Agent | undefined>({
-        data: { ...MOCK_AGENT, status: 'suspended' },
-        isLoading: false,
-        isError: false,
-        refetch: vi.fn(),
-      }),
-    )
-    vi.spyOn(agentsApi, 'useAgentEventsQuery').mockReturnValue(
-      mockQuery<LogEntry[]>({ data: [MOCK_LOG], isLoading: false, isError: false }),
-    )
-    vi.spyOn(agentsApi, 'useAgentCapabilitiesQuery').mockReturnValue(
-      mockQuery<agentsApi.EffectivePermissions>({
-        data: { allow: [], deny: [], sources: [] }, isLoading: false, isError: false,
-      }),
-    )
   }
 
   it('opens the suspend dialog and toasts on a successful suspend', async () => {

--- a/dashboard/src/pages/AgentDetailPage.tsx
+++ b/dashboard/src/pages/AgentDetailPage.tsx
@@ -343,7 +343,7 @@ export function AgentDetailPage() {
 
             <IdentityStrip agent={agent} />
 
-            <nav className="ad-tabs" data-testid="agent-detail-tabs" role="tablist" aria-label="Agent detail sections">
+            <div className="ad-tabs" data-testid="agent-detail-tabs" role="tablist" aria-label="Agent detail sections">
               {TABS.map((t) => (
                 <button
                   key={t.id}
@@ -357,7 +357,7 @@ export function AgentDetailPage() {
                   {t.label}
                 </button>
               ))}
-            </nav>
+            </div>
 
             <div className="ad-body" data-testid="agent-detail-body">
               {tab === 'overview' && (
@@ -394,7 +394,7 @@ export function AgentDetailPage() {
                             checked={sandboxOnly}
                             onChange={(e) => setSandboxOnly(e.target.checked)}
                             data-testid="agent-events-sandbox-toggle"
-                          />
+                          />{' '}
                           Sandbox events only
                         </label>
                       </div>

--- a/dashboard/src/pages/AlertsPage.tsx
+++ b/dashboard/src/pages/AlertsPage.tsx
@@ -14,14 +14,13 @@ import { EmptyStateNoRules } from '../features/alerts/EmptyStateNoRules'
 import { EmptyStateNoAlerts } from '../features/alerts/EmptyStateNoAlerts'
 import { AlertsErrorBanner } from '../features/alerts/AlertsErrorBanner'
 import { useAlertRulesQuery, useAlertsQuery } from '../features/alerts/api'
-import type { AlertRule } from '../features/alerts/types'
 import { useAlertsStream } from '../features/alerts/useAlertsStream'
 import { applyFire, applyResolve, applySilence } from '../features/alerts/alertsStreamSync'
 import {
   filtersFromSearchParams,
   filtersToSearchParams,
 } from '../features/alerts/urlFilters'
-import type { Alert, AlertFilters } from '../features/alerts/types'
+import type { Alert, AlertFilters, AlertRule } from '../features/alerts/types'
 
 function partitionByTab(rows: readonly Alert[], tab: AlertsTab): readonly Alert[] {
   if (tab === 'incidents') return rows.filter((r) => r.status === 'RESOLVED')
@@ -86,6 +85,21 @@ export function AlertsPage() {
   const noAlertsInWindow =
     !alertsQuery.isLoading && !alertsQuery.isError && rows.length === 0 && !noRulesConfigured
 
+  let alertsBody
+  if (noRulesConfigured) {
+    alertsBody = <EmptyStateNoRules onCreateRule={() => setRuleFormOpen(true)} />
+  } else if (noAlertsInWindow) {
+    alertsBody = <EmptyStateNoAlerts />
+  } else {
+    alertsBody = (
+      <AlertList
+        rows={rows}
+        onSelect={setSelectedAlertId}
+        loading={alertsQuery.isLoading && rows.length === 0}
+      />
+    )
+  }
+
   return (
     <main style={{ padding: '1.5rem' }}>
       <header
@@ -131,10 +145,10 @@ export function AlertsPage() {
       </header>
 
       {streamStatus !== 'open' && (
-        <div
+        <output
           data-testid="alerts-stream-banner"
-          role="status"
           style={{
+            display: 'block',
             marginBottom: '0.75rem',
             padding: '6px 10px',
             background: 'var(--badge-amber-bg)',
@@ -146,7 +160,7 @@ export function AlertsPage() {
           {streamStatus === 'connecting'
             ? 'Connecting to live alerts stream…'
             : 'Live alerts stream disconnected — reconnecting.'}
-        </div>
+        </output>
       )}
 
       <AlertsTabs value={tab} onChange={setTab} />
@@ -183,17 +197,7 @@ export function AlertsPage() {
               : `${rows.length} alert${rows.length === 1 ? '' : 's'}`}
           </div>
 
-          {noRulesConfigured ? (
-            <EmptyStateNoRules onCreateRule={() => setRuleFormOpen(true)} />
-          ) : noAlertsInWindow ? (
-            <EmptyStateNoAlerts />
-          ) : (
-            <AlertList
-              rows={rows}
-              onSelect={setSelectedAlertId}
-              loading={alertsQuery.isLoading && rows.length === 0}
-            />
-          )}
+          {alertsBody}
         </>
       )}
 

--- a/dashboard/src/pages/ApprovalsPage.test.tsx
+++ b/dashboard/src/pages/ApprovalsPage.test.tsx
@@ -66,19 +66,19 @@ const MOCK_APPROVAL: Approval = {
 
 afterEach(() => { vi.restoreAllMocks() })
 
-describe('ApprovalsPage', () => {
-  function setupMocks(approvals: Approval[]) {
-    vi.spyOn(approvalsApi, 'useApprovalsQuery').mockReturnValue(
-      mockQuery<Approval[]>({ data: approvals, isLoading: false, isError: false, refetch: vi.fn() }),
-    )
-    vi.spyOn(approvalsApi, 'useApproveAction').mockReturnValue(
-      mockMutation({ mutateAsync: vi.fn().mockResolvedValue(MOCK_APPROVAL), isPending: false }),
-    )
-    vi.spyOn(approvalsApi, 'useRejectAction').mockReturnValue(
-      mockMutation({ mutateAsync: vi.fn().mockResolvedValue(MOCK_APPROVAL), isPending: false }),
-    )
-  }
+function setupMocks(approvals: Approval[]) {
+  vi.spyOn(approvalsApi, 'useApprovalsQuery').mockReturnValue(
+    mockQuery<Approval[]>({ data: approvals, isLoading: false, isError: false, refetch: vi.fn() }),
+  )
+  vi.spyOn(approvalsApi, 'useApproveAction').mockReturnValue(
+    mockMutation({ mutateAsync: vi.fn().mockResolvedValue(MOCK_APPROVAL), isPending: false }),
+  )
+  vi.spyOn(approvalsApi, 'useRejectAction').mockReturnValue(
+    mockMutation({ mutateAsync: vi.fn().mockResolvedValue(MOCK_APPROVAL), isPending: false }),
+  )
+}
 
+describe('ApprovalsPage', () => {
   it('renders the page heading', async () => {
     setupMocks([])
     render(<ApprovalsPage />, { wrapper: Wrapper })

--- a/dashboard/src/pages/ApprovalsPage.tsx
+++ b/dashboard/src/pages/ApprovalsPage.tsx
@@ -27,6 +27,12 @@ import './ApprovalsPage.css'
 
 const APPROVAL_ROW_COL_COUNT = 8
 
+const SKELETON_ROW_KEYS = Array.from({ length: 3 }, (_, i) => `approval-skeleton-row-${i}`)
+const SKELETON_CELL_KEYS = Array.from(
+  { length: APPROVAL_ROW_COL_COUNT },
+  (_, j) => `approval-skeleton-cell-${j}`,
+)
+
 // ── Reject dialog ─────────────────────────────────────────────────────────────
 
 interface RejectDialogProps {
@@ -53,8 +59,7 @@ function RejectDialog({ count, onConfirm, onCancel }: Readonly<RejectDialogProps
           Reject {count > 1 ? `${count} requests` : 'request'}
         </h2>
         <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.875rem' }}>
-          Reason (required)
-          <textarea
+          Reason (required)<textarea
             data-testid="reject-reason-input"
             rows={3}
             value={reason}
@@ -75,8 +80,8 @@ function RejectDialog({ count, onConfirm, onCancel }: Readonly<RejectDialogProps
             onClick={() => onConfirm(reason.trim())}
             style={{
               padding: '0.4rem 0.75rem', borderRadius: '0.25rem', border: 'none',
-              background: !reason.trim() ? 'var(--ink-4)' : 'var(--danger)',
-              color: 'var(--paper-2)', cursor: !reason.trim() ? 'not-allowed' : 'pointer',
+              background: reason.trim() ? 'var(--danger)' : 'var(--ink-4)',
+              color: 'var(--paper-2)', cursor: reason.trim() ? 'pointer' : 'not-allowed',
               fontWeight: 600,
             }}
           >
@@ -181,7 +186,7 @@ export function ApprovalsPage() {
       queryClient.setQueryData<Approval[]>(['approvals'], (prev) => [...failedRows, ...(prev ?? [])])
       toast(`Approved ${succeededIds.length}, failed ${failedIds.length}.`, 'error')
     } else {
-      toast(`Approved ${succeededIds.length} request${succeededIds.length !== 1 ? 's' : ''}.`, 'success')
+      toast(`Approved ${succeededIds.length} request${succeededIds.length === 1 ? '' : 's'}.`, 'success')
     }
 
     const succeededRows = targets.filter((a) => succeededIds.includes(a.id))
@@ -205,7 +210,7 @@ export function ApprovalsPage() {
       queryClient.setQueryData<Approval[]>(['approvals'], (prev) => [...failedRows, ...(prev ?? [])])
       toast(`Rejected ${succeededIds.length}, failed ${failedIds.length}.`, 'error')
     } else {
-      toast(`Rejected ${succeededIds.length} request${succeededIds.length !== 1 ? 's' : ''}.`, 'success')
+      toast(`Rejected ${succeededIds.length} request${succeededIds.length === 1 ? '' : 's'}.`, 'success')
     }
 
     const succeededRows = targets.filter((a) => succeededIds.includes(a.id))
@@ -314,10 +319,10 @@ export function ApprovalsPage() {
               </thead>
               <tbody>
                 {isLoading
-                  ? Array.from({ length: 3 }).map((_, i) => (
-                    <tr key={i} data-testid="approval-row-skeleton">
-                      {Array.from({ length: 8 }).map((_, j) => (
-                        <td key={j} style={{ padding: '8px 12px' }}>
+                  ? SKELETON_ROW_KEYS.map((rowKey) => (
+                    <tr key={rowKey} data-testid="approval-row-skeleton">
+                      {SKELETON_CELL_KEYS.map((cellKey) => (
+                        <td key={cellKey} style={{ padding: '8px 12px' }}>
                           <span style={{ display: 'block', height: '0.875rem', background: 'var(--line)', borderRadius: '4px' }} />
                         </td>
                       ))}

--- a/dashboard/src/pages/CapabilityPage.test.tsx
+++ b/dashboard/src/pages/CapabilityPage.test.tsx
@@ -83,7 +83,7 @@ describe('CapabilityPage', () => {
     await screen.findByText('Capability')
     const interactiveCell = screen
       .getAllByRole('gridcell')
-      .find((c) => c.getAttribute('data-decision') !== 'na')
+      .find((c) => c.dataset.decision !== 'na')
     expect(interactiveCell).toBeDefined()
     fireEvent.click(interactiveCell!)
     expect(
@@ -148,7 +148,7 @@ describe('CapabilityPage', () => {
     await screen.findByText('Capability')
     const cell = screen
       .getAllByRole('gridcell')
-      .find((c) => c.getAttribute('data-decision') !== 'na')!
+      .find((c) => c.dataset.decision !== 'na')!
     fireEvent.click(cell)
     await screen.findByRole('dialog', { name: 'capability cell inspect' })
     fireEvent.click(screen.getByLabelText('close drawer'))

--- a/dashboard/src/pages/ComingSoon.tsx
+++ b/dashboard/src/pages/ComingSoon.tsx
@@ -8,7 +8,7 @@ import { Link, useLocation } from 'react-router-dom'
  */
 export function ComingSoon({ name }: Readonly<{ name?: string }>) {
   const location = useLocation()
-  const fromPath = location.pathname.replace(/^\//, '').replace(/-/g, ' ')
+  const fromPath = location.pathname.replace(/^\//, '').replaceAll('-', ' ')
   const heading = name ?? (fromPath || 'this page')
 
   return (

--- a/dashboard/src/pages/FleetPage.tsx
+++ b/dashboard/src/pages/FleetPage.tsx
@@ -1,4 +1,4 @@
-import { Link, Outlet, useNavigate } from 'react-router-dom'
+import { Link, Outlet, useNavigate, useSearchParams } from 'react-router-dom'
 import { ignorePromise } from '../lib/ignorePromise'
 import {
   useReactTable,
@@ -10,7 +10,6 @@ import {
   type SortingState,
 } from '@tanstack/react-table'
 import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent } from 'react'
-import { useSearchParams } from 'react-router-dom'
 import { useAgentsQuery } from '../features/agents/api'
 import { toFleetAgent, type FleetAgent } from '../features/agents/fleetTypes'
 import {
@@ -31,13 +30,16 @@ import './FleetPage.css'
 
 const COLUMN_COUNT = 11
 
+const SKELETON_ROW_KEYS = Array.from({ length: 5 }, (_, i) => `skeleton-row-${i}`)
+const SKELETON_CELL_KEYS = Array.from({ length: COLUMN_COUNT }, (_, j) => `skeleton-cell-${j}`)
+
 function SkeletonRows() {
   return (
     <>
-      {Array.from({ length: 5 }).map((_, i) => (
-        <tr key={i} data-testid="agent-row-skeleton">
-          {Array.from({ length: COLUMN_COUNT }).map((_, j) => (
-            <td key={j} className="fleet-table__cell fleet-table__cell--skeleton">
+      {SKELETON_ROW_KEYS.map((rowKey) => (
+        <tr key={rowKey} data-testid="agent-row-skeleton">
+          {SKELETON_CELL_KEYS.map((cellKey) => (
+            <td key={cellKey} className="fleet-table__cell fleet-table__cell--skeleton">
               <span className="fleet-table__skeleton" />
             </td>
           ))}
@@ -50,9 +52,15 @@ function SkeletonRows() {
 function NumericCell({ value }: Readonly<{ value: number | null }>) {
   return (
     <span className="fleet-table__numeric">
-      {value === null ? '—' : value}
+      {value ?? '—'}
     </span>
   )
+}
+
+function sortIndicator(sorted: false | 'asc' | 'desc'): { glyph: string; label: string } {
+  if (sorted === 'asc') return { glyph: '▲', label: 'sorted ascending' }
+  if (sorted === 'desc') return { glyph: '▼', label: 'sorted descending' }
+  return { glyph: '↕', label: 'not sorted' }
 }
 
 const columnHelper = createColumnHelper<FleetAgent>()
@@ -338,8 +346,7 @@ export function FleetPage() {
       <header className="fleet-page__head" data-testid="fleet-page-head">
         <div className="fleet-page__heading">
           <h1 className="fleet-page__title">
-            Fleet
-            <span className="fleet-page__count" data-testid="fleet-page-count">
+            Fleet<span className="fleet-page__count" data-testid="fleet-page-count">
               · {filteredCount} of {totalAgents} agents
             </span>
           </h1>
@@ -357,7 +364,7 @@ export function FleetPage() {
         </div>
       </header>
 
-      <nav className="fleet-tabs" data-testid="fleet-tabs" role="tablist" aria-label="Fleet views">
+      <div className="fleet-tabs" data-testid="fleet-tabs" role="tablist" aria-label="Fleet views">
         <button
           type="button"
           role="tab"
@@ -366,8 +373,7 @@ export function FleetPage() {
           onClick={() => setView('agents')}
           data-testid="fleet-tab-agents"
         >
-          Agents
-          <span className="fleet-tabs__count">{filteredCount}</span>
+          Agents<span className="fleet-tabs__count">{filteredCount}</span>
         </button>
         <button
           type="button"
@@ -379,7 +385,7 @@ export function FleetPage() {
         >
           Active Sessions
         </button>
-      </nav>
+      </div>
 
       {view === 'sessions' && (
         <div className="fleet-empty" data-testid="fleet-sessions-empty">
@@ -472,18 +478,12 @@ export function FleetPage() {
                       {flexRender(header.column.columnDef.header, header.getContext())}
                       {header.column.getCanSort() && (() => {
                         const sorted = header.column.getIsSorted()
-                        const glyph = sorted === 'asc' ? '▲' : sorted === 'desc' ? '▼' : '↕'
+                        const { glyph, label } = sortIndicator(sorted)
                         return (
                           <span
                             className={`fleet-table__sort${sorted ? '' : ' fleet-table__sort--inactive'}`}
                             data-testid={`fleet-sort-${header.column.id}`}
-                            aria-label={
-                              sorted === 'asc'
-                                ? 'sorted ascending'
-                                : sorted === 'desc'
-                                  ? 'sorted descending'
-                                  : 'not sorted'
-                            }
+                            aria-label={label}
                           >
                             {glyph}
                           </span>

--- a/dashboard/src/pages/LiveOpsPage.tsx
+++ b/dashboard/src/pages/LiveOpsPage.tsx
@@ -68,7 +68,7 @@ export function LiveOpsPage() {
     for (const op of ops) {
       const intent = overrides.get(op.id)
       if (intent && matchesIntent(op.status, intent)) {
-        if (!pruned) pruned = new Map(overrides)
+        pruned ??= new Map(overrides)
         pruned.delete(op.id)
       }
     }
@@ -109,10 +109,10 @@ export function LiveOpsPage() {
   )
 
   function handleAutoScrollChange(next: boolean) {
-    if (!next) {
-      setFrozenIds(new Set(ops.map((o) => o.id)))
-    } else {
+    if (next) {
       setFrozenIds(null)
+    } else {
+      setFrozenIds(new Set(ops.map((o) => o.id)))
     }
     setAutoScroll(next)
   }
@@ -144,6 +144,31 @@ export function LiveOpsPage() {
     () => Math.max(0.5, Math.min(5, ops.length / 15)),
     [ops.length],
   )
+
+  let streamBody
+  if (status === 'error') {
+    streamBody = (
+      <ErrorState
+        title="Connection lost"
+        description="Lost the connection to the gateway event stream after several attempts."
+        onRetry={reconnect}
+        retryLabel="Reconnect"
+      />
+    )
+  } else if (status === 'connected' && ops.length === 0) {
+    streamBody = <EmptyState page="live" />
+  } else {
+    streamBody = filteredOps.map((op) => (
+      <OperationRow
+        key={op.id}
+        op={op}
+        override={liveOverrides.get(op.id)}
+        onPause={() => runAction(op.id, 'pausing', pauseOp)}
+        onResume={() => runAction(op.id, 'resuming', resumeOp)}
+        onTerminate={() => runAction(op.id, 'terminating', terminateOp)}
+      />
+    ))
+  }
 
   return (
     <main className="live-page" data-testid="live-ops-page">
@@ -189,36 +214,16 @@ export function LiveOpsPage() {
             teamOptions={teamOptions}
           />
           {status === 'reconnecting' && (
-            <div
+            <output
               className="live-page__reconnecting"
               data-testid="live-ops-reconnecting"
-              role="status"
+              style={{ display: 'block' }}
             >
               Reconnecting…
-            </div>
+            </output>
           )}
           <div className="live-page__pane-body live-page__pane-body--stream">
-            {status === 'error' ? (
-              <ErrorState
-                title="Connection lost"
-                description="Lost the connection to the gateway event stream after several attempts."
-                onRetry={reconnect}
-                retryLabel="Reconnect"
-              />
-            ) : status === 'connected' && ops.length === 0 ? (
-              <EmptyState page="live" />
-            ) : (
-              filteredOps.map((op) => (
-                <OperationRow
-                  key={op.id}
-                  op={op}
-                  override={liveOverrides.get(op.id)}
-                  onPause={() => runAction(op.id, 'pausing', pauseOp)}
-                  onResume={() => runAction(op.id, 'resuming', resumeOp)}
-                  onTerminate={() => runAction(op.id, 'terminating', terminateOp)}
-                />
-              ))
-            )}
+            {streamBody}
           </div>
         </section>
 

--- a/dashboard/src/pages/PoliciesPage.test.tsx
+++ b/dashboard/src/pages/PoliciesPage.test.tsx
@@ -80,7 +80,7 @@ function mockSandboxSummary(
 ) {
   const base = { data: EMPTY_SUMMARY, isLoading: false, isError: false }
   return vi.spyOn(auditApi, 'useSandboxSummaryQuery').mockReturnValue(
-    mockQuery<SandboxSummaryResponse>(Object.assign({}, base, partial) as Partial<
+    mockQuery<SandboxSummaryResponse>({ ...base, ...partial } as Partial<
       UseQueryResult<SandboxSummaryResponse, Error>
     >),
   )

--- a/dashboard/src/pages/PoliciesPage.tsx
+++ b/dashboard/src/pages/PoliciesPage.tsx
@@ -160,7 +160,7 @@ interface PoliciesTabsProps {
  */
 function PoliciesTabs({ filter, counts, onSelect }: PoliciesTabsProps) {
   return (
-    <nav className="policies-tabs" role="tablist" aria-label="Filter policies">
+    <div className="policies-tabs" role="tablist" aria-label="Filter policies">
       {FILTER_TABS.map((tab) => {
         const active = filter === tab.id
         const warnCount = tab.id === 'proposed' && counts.proposed > 0
@@ -191,7 +191,7 @@ function PoliciesTabs({ filter, counts, onSelect }: PoliciesTabsProps) {
           </button>
         )
       })}
-    </nav>
+    </div>
   )
 }
 
@@ -366,8 +366,9 @@ export function PoliciesPage() {
   const activePolicies = useMemo(() => all.filter((p) => p.active), [all])
   const proposedPolicies = useMemo(() => all.filter((p) => !p.active), [all])
 
-  const filtered =
-    filter === 'active' ? activePolicies : filter === 'proposed' ? proposedPolicies : all
+  let filtered = all
+  if (filter === 'active') filtered = activePolicies
+  else if (filter === 'proposed') filtered = proposedPolicies
 
   const counts: Record<FilterTab, number> = {
     all: all.length,

--- a/dashboard/src/pages/ScrubPage.tsx
+++ b/dashboard/src/pages/ScrubPage.tsx
@@ -32,8 +32,7 @@ export function ScrubPage() {
       <header className="scrub-page-head">
         <div>
           <h1 className="scrub-page-title">
-            Secret Scrubbing
-            <span className="scrub-page-subtitle">
+            Secret Scrubbing<span className="scrub-page-subtitle">
               · L3 · network-layer sanitization
             </span>
           </h1>

--- a/dashboard/src/pages/Settings/RetentionPolicy.tsx
+++ b/dashboard/src/pages/Settings/RetentionPolicy.tsx
@@ -38,7 +38,7 @@ function validate(req: UpdateRetentionPolicyRequest): FormErrors {
     const url = (req.archive_url ?? '').trim()
     if (!url) {
       errors.archive_url = 'archive_url is required when cold_action is "archive"'
-    } else if (!/^s3:\/\//.test(url) && !/^gs:\/\//.test(url)) {
+    } else if (!url.startsWith('s3://') && !url.startsWith('gs://')) {
       errors.archive_url = 'archive_url must start with s3:// or gs://'
     }
   }

--- a/dashboard/src/pages/TeamDetailPage.actions.test.tsx
+++ b/dashboard/src/pages/TeamDetailPage.actions.test.tsx
@@ -44,9 +44,9 @@ const TEAM: TeamTopology = {
   ],
 }
 
-function mockTeam(result: Partial<TeamTopologyResult> = { data: TEAM }) {
+function mockTeam(result?: Partial<TeamTopologyResult>) {
   vi.spyOn(teamsApi, 'useTeamTopologyQuery').mockReturnValue({
-    data: undefined, notFound: false, isLoading: false, isError: false, ...result,
+    data: undefined, notFound: false, isLoading: false, isError: false, ...(result ?? { data: TEAM }),
   })
 }
 

--- a/dashboard/src/pages/TeamDetailPage.tsx
+++ b/dashboard/src/pages/TeamDetailPage.tsx
@@ -231,9 +231,8 @@ export function TeamDetailPage() {
         </div>
       )}
 
-      {teamQuery.isLoading ? (
-        <p data-testid="team-detail-loading">Loading…</p>
-      ) : teamQuery.data ? (
+      {teamQuery.isLoading && <p data-testid="team-detail-loading">Loading…</p>}
+      {!teamQuery.isLoading && teamQuery.data && (
         <>
           <header data-testid="team-detail-header" style={{ marginBottom: '1rem' }}>
             <h1 style={{ marginBottom: '0.25rem' }}>{teamQuery.data.team_id}</h1>
@@ -273,7 +272,7 @@ export function TeamDetailPage() {
             </table>
           )}
         </>
-      ) : null}
+      )}
     </main>
   )
 }

--- a/dashboard/src/pages/TeamsPage.tsx
+++ b/dashboard/src/pages/TeamsPage.tsx
@@ -34,13 +34,16 @@ function sortIndicator(sorted: false | 'asc' | 'desc'): string {
   return ''
 }
 
+const TEAM_SKELETON_ROW_KEYS = Array.from({ length: 5 }, (_, i) => `team-skeleton-row-${i}`)
+
 function SkeletonRows({ cols }: Readonly<{ cols: number }>) {
+  const cellKeys = Array.from({ length: cols }, (_, j) => `team-skeleton-cell-${j}`)
   return (
     <>
-      {Array.from({ length: 5 }).map((_, i) => (
-        <tr key={i} data-testid="team-row-skeleton">
-          {Array.from({ length: cols }).map((_, j) => (
-            <td key={j} style={{ padding: '0.5rem' }}>
+      {TEAM_SKELETON_ROW_KEYS.map((rowKey) => (
+        <tr key={rowKey} data-testid="team-row-skeleton">
+          {cellKeys.map((cellKey) => (
+            <td key={cellKey} style={{ padding: '0.5rem' }}>
               <span
                 style={{
                   display: 'block',

--- a/dashboard/src/pages/TopologyPage.tsx
+++ b/dashboard/src/pages/TopologyPage.tsx
@@ -7,6 +7,8 @@ import { useTraceDrawer } from '../components/trace/useTraceDrawer'
 import type { TopologyNode } from '../features/topology/types'
 import './TopologyPage.css'
 
+const TOPOLOGY_SKELETON_KEYS = Array.from({ length: 4 }, (_, i) => `topology-skeleton-${i}`)
+
 /**
  * Topology page shell — header, D3 force graph (AAASM-1335), and
  * node-detail panel (AAASM-1337) docked on the right when a node is
@@ -34,8 +36,7 @@ export function TopologyPage() {
     <main className="topology-page" data-testid="topology-view">
       <header className="topology-page__head" data-testid="topology-header">
         <h1 className="topology-page__title">
-          Topology
-          <span className="topology-page__meta" data-testid="topology-meta">
+          Topology<span className="topology-page__meta" data-testid="topology-meta">
             · {agentCount} agent{agentCount === 1 ? '' : 's'} · {teamCount} team{teamCount === 1 ? '' : 's'}
           </span>
         </h1>
@@ -43,8 +44,8 @@ export function TopologyPage() {
 
       {isLoading && (
         <div data-testid="topology-loading" className="topology-page__loading">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} data-testid="topology-row-skeleton" className="topology-page__skeleton" />
+          {TOPOLOGY_SKELETON_KEYS.map((key) => (
+            <div key={key} data-testid="topology-row-skeleton" className="topology-page__skeleton" />
           ))}
         </div>
       )}

--- a/dashboard/src/pages/TraceViewPage.test.tsx
+++ b/dashboard/src/pages/TraceViewPage.test.tsx
@@ -248,8 +248,8 @@ describe('TraceViewPage', () => {
     URL.createObjectURL = vi.fn((blob: Blob) => {
       blob.text().then(text => { capturedBlobText = text })
       return 'blob:fake'
-    }) as unknown as typeof URL.createObjectURL
-    URL.revokeObjectURL = vi.fn() as unknown as typeof URL.revokeObjectURL
+    })
+    URL.revokeObjectURL = vi.fn()
 
     const originalCreateElement = document.createElement.bind(document)
     vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {

--- a/dashboard/src/pages/TraceViewPage.tsx
+++ b/dashboard/src/pages/TraceViewPage.tsx
@@ -12,6 +12,8 @@ import { downloadTraceJson } from '../features/trace/export'
 import type { TraceEvent } from '../features/trace/types'
 import './TraceViewPage.css'
 
+const TRACE_SKELETON_KEYS = Array.from({ length: 4 }, (_, i) => `trace-skeleton-${i}`)
+
 function applyFilter(events: readonly TraceEvent[], filter: SeverityFilter): TraceEvent[] {
   return events.filter(event => {
     const key = event.severity ?? 'neutral'
@@ -53,9 +55,9 @@ export function TraceViewPage({ agentId, sessionId: sessionIdProp }: TraceViewPa
 
       {isLoading && (
         <div data-testid="trace-loading" style={{ marginTop: '1rem' }}>
-          {Array.from({ length: 4 }).map((_, i) => (
+          {TRACE_SKELETON_KEYS.map((key) => (
             <div
-              key={i}
+              key={key}
               data-testid="trace-row-skeleton"
               style={{
                 background: 'var(--paper-3)',
@@ -75,7 +77,7 @@ export function TraceViewPage({ agentId, sessionId: sessionIdProp }: TraceViewPa
         </div>
       )}
 
-      {!isLoading && !isError && data && data.length === 0 && (
+      {!isLoading && !isError && data?.length === 0 && (
         <EmptyState
           title="No events recorded for this session"
           description="The agent ran but produced no governed actions in this session."

--- a/dashboard/src/pages/ViolationHeatmapPage.tsx
+++ b/dashboard/src/pages/ViolationHeatmapPage.tsx
@@ -90,7 +90,7 @@ export function ViolationHeatmapPage() {
       {status === "success" && (
         <>
           <p style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 8 }}>
-            {data.nodes.length} agent{data.nodes.length !== 1 ? "s" : ""} with violations ·
+            {data.nodes.length} agent{data.nodes.length === 1 ? "" : "s"} with violations ·
             window {data.window_secs}s · generated {data.generated_at}
           </p>
           {data.nodes.length === 0 ? (

--- a/dashboard/src/test/mockWebSocket.ts
+++ b/dashboard/src/test/mockWebSocket.ts
@@ -26,8 +26,8 @@
  */
 export class MockWebSocket {
   static instances: MockWebSocket[] = []
-  static OPEN = 1
-  static CLOSED = 3
+  static readonly OPEN = 1
+  static readonly CLOSED = 3
 
   readyState = 0
   url: string

--- a/dashboard/src/theme/useTheme.test.tsx
+++ b/dashboard/src/theme/useTheme.test.tsx
@@ -18,7 +18,7 @@ function mockMatchMedia(matchesDark: boolean) {
 beforeEach(() => {
   vi.unstubAllGlobals()
   localStorage.clear()
-  document.documentElement.removeAttribute('data-theme')
+  delete document.documentElement.dataset.theme
 })
 
 describe('theme resolution', () => {
@@ -37,7 +37,7 @@ describe('theme resolution', () => {
 
   it('applyTheme sets data-theme on the document root', () => {
     applyTheme('dark')
-    expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+    expect(document.documentElement.dataset.theme).toBe('dark')
   })
 })
 
@@ -47,12 +47,12 @@ describe('useTheme', () => {
     const { result } = renderHook(() => useTheme())
 
     expect(result.current.theme).toBe('light')
-    expect(document.documentElement.getAttribute('data-theme')).toBe('light')
+    expect(document.documentElement.dataset.theme).toBe('light')
 
     act(() => result.current.toggleTheme())
 
     expect(result.current.theme).toBe('dark')
     expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe('dark')
-    expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+    expect(document.documentElement.dataset.theme).toBe('dark')
   })
 })


### PR DESCRIPTION
## Ticket
[AAASM-3365] — wave 3b of AAASM-3346 (Epic AAASM-3345, public-repo SonarCloud quality).

## Summary
Clears SonarCloud `typescript:*` code smells under the **non-features** dashboard paths (`dashboard/src/{pages,components,topology,api,test,lib,auth,theme}`). Behaviour-preserving cleanups: `structuredClone`/redundant-cast removal in api + tests, logic/JSX smells across pages & providers, a11y/logic smells in shared & topology components.

> **Note:** the original sub-agent stalled mid-run (watchdog timeout). This PR is the **recovered set of 5 clean, validated commits** it had already produced; 4 half-edited files were discarded and the **remaining non-features smells are deferred to a follow-up wave** (tracked on AAASM-3365 / a wave-3c subtask). No partial/broken edits are included.

## Change scope
41 files, all under `dashboard/src/` non-features paths. **Zero** Rust files, **zero** `dashboard/src/features/**` files (verified via merge-base) — disjoint from wave 3a (#1126) and the parallel Rust bug-fix PRs.

## Testing
In `dashboard/`: `pnpm type-check` ✓ · `pnpm lint` (`--max-warnings 0`) ✓ · `pnpm test` ✓ **143 files / 1262 tests** · `pnpm build` ✓.

## Rollout notes
Type/logic-level cleanup, no intended visual/behaviour change; no migration. Branched off the latest `remote/master`.


[AAASM-3365]: https://lightning-dust-mite.atlassian.net/browse/AAASM-3365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ