### PR TITLE
[AAASM-3367] 🐛 (aa-gateway): Strip port in anomaly detector egress check

### DIFF
--- a/aa-gateway/src/anomaly/detector.rs
+++ b/aa-gateway/src/anomaly/detector.rs
@@ -95,13 +95,22 @@ impl AnomalyDetector {
         if allowlist.is_empty() {
             return None;
         }
-        let host = url
+        let host_port = url
             .split_once("://")
             .map(|x| x.1)
             .unwrap_or(url)
             .split('/')
             .next()
             .unwrap_or("");
+        // AAASM-3367: `convert.rs` builds the URL as `proto://host:port`, so the
+        // authority extracted above still carries the `:port` suffix. Allowlist
+        // entries are bare hosts, so comparing `host:port` against them always
+        // failed. Strip a trailing numeric `:port` before the allowlist compare,
+        // mirroring the engine network stage (AAASM-3350, `engine/decision.rs`).
+        let host = match host_port.rsplit_once(':') {
+            Some((h, port)) if !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) => h,
+            _ => host_port,
+        };
         if allowlist.iter().any(|entry| entry == host) {
             return None;
         }

--- a/aa-gateway/src/anomaly/detector.rs
+++ b/aa-gateway/src/anomaly/detector.rs
@@ -392,6 +392,24 @@ mod tests {
     }
 
     #[test]
+    fn unknown_connection_allowlisted_host_with_port_is_in_allowlist() {
+        // AAASM-3367: the gateway builds URLs as `proto://host:port`. A bare
+        // allowlist entry must still match when the URL carries a numeric port.
+        let detector = default_detector();
+        let id = agent(4);
+        let allowlist = vec!["api.openai.com".to_string()];
+
+        assert!(detector
+            .check_unknown_connection(id, "https://api.openai.com:443/v1", &allowlist)
+            .is_none());
+
+        // A non-allowlisted host (also with a port) is still flagged.
+        let result = detector.check_unknown_connection(id, "https://evil.com:8443/data", &allowlist);
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().anomaly_type, AnomalyType::UnknownExternalConnection);
+    }
+
+    #[test]
     fn unknown_connection_not_detected_when_allowlist_empty() {
         let detector = default_detector();
         let id = agent(5);


### PR DESCRIPTION
## Description

`aa-gateway/src/anomaly/detector.rs::check_unknown_connection` extracted the host from the URL but kept the `:port` suffix, then exact-compared it against bare allowlist entries. Because `service/convert.rs` builds URLs as `proto://host:port`, an allowlisted host carrying a port (e.g. `https://api.openai.com:443/v1`) never matched and would be flagged as an unknown external connection. This is the same bug class fixed in AAASM-3350 for `engine/decision.rs` / `engine/mod.rs::eval_network_stage`.

This path has no live callers today (latent), but is corrected for consistency with the engine network stage. The fix strips a trailing numeric `:port` from the extracted host before the allowlist compare, mirroring the `rsplit_once(':')` approach used in `engine/decision.rs`.

## Type of Change

- [x] 🐛 Bug fix

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3367

Closes AAASM-3367

## Testing

- [x] Unit tests added / updated

Added a regression test (`unknown_connection_allowlisted_host_with_port_is_in_allowlist`) asserting an allowlisted host with a port is recognized as in-allowlist, and a non-allowlisted host (also with a port) is still flagged.

Validation (crate-scoped, isolated worktree off `remote/master`):
- `cargo build -p aa-gateway` — OK
- `cargo clippy -p aa-gateway --all-targets` — clean
- `cargo nextest run -p aa-gateway anomaly::detector` — 18 passed, 0 failed (full-suite run skipped per spec to stay bounded on this host; targeted anomaly tests green)
- `cargo fmt -p aa-gateway` — applied

QA evidence: `agent-assembly-integration-tests/verification-reports/base-branch-2026-06/` (base = canonical `remote/master`, v0.0.1-beta.2).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention
