### PR TITLE
[AAASM-3360] ✨ (aa-api): Serve the full /api/v1/* REST surface from a shipped entrypoint

### DIFF
--- a/aa-api/Cargo.toml
+++ b/aa-api/Cargo.toml
@@ -43,6 +43,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 utoipa = { workspace = true }
 utoipa-swagger-ui = { version = "9", features = ["axum"] }
 chrono = { workspace = true, features = ["serde"] }
+chrono-tz = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
 moka = { workspace = true, features = ["future"] }
@@ -54,7 +55,6 @@ uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
 axum-test = "20"
-chrono-tz = { workspace = true }
 futures = { workspace = true }
 hmac = { workspace = true }
 httpmock = "0.8"

--- a/aa-api/src/bin/aa-api-server.rs
+++ b/aa-api/src/bin/aa-api-server.rs
@@ -1,0 +1,36 @@
+//! Shipped entrypoint that serves the full `/api/v1/*` REST surface from a
+//! single in-memory process (AAASM-3360).
+//!
+//! Usage:
+//! ```text
+//! cargo run -p aa-api --bin aa-api-server          # binds 127.0.0.1:7700
+//! AA_API_ADDR=127.0.0.1:8080 \
+//!   cargo run -p aa-api --bin aa-api-server         # custom bind address
+//! ```
+//!
+//! Every route registered by `aa_api::routes::v1_router()` is served. Auth is
+//! disabled in this mode, so protected routes (e.g. `/api/v1/agents`,
+//! `/api/v1/policies`) are reachable without a bearer credential. See
+//! `aa_api::AppState::local_in_memory` for the documented limitations of the
+//! in-memory wiring.
+
+use std::net::SocketAddr;
+
+/// Default bind address when `AA_API_ADDR` is unset.
+const DEFAULT_ADDR: &str = "127.0.0.1:7700";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .init();
+
+    let raw = std::env::var("AA_API_ADDR").unwrap_or_else(|_| DEFAULT_ADDR.to_string());
+    let addr: SocketAddr = raw.parse().unwrap_or_else(|e| {
+        eprintln!("invalid AA_API_ADDR={raw:?} ({e}); falling back to {DEFAULT_ADDR}");
+        DEFAULT_ADDR.parse().expect("default address is valid")
+    });
+
+    eprintln!("aa-api serving full /api/v1/* REST surface (in-memory, auth disabled) on http://{addr}");
+    aa_api::serve_local(addr).await
+}

--- a/aa-api/src/lib.rs
+++ b/aa-api/src/lib.rs
@@ -33,6 +33,6 @@ pub use events::EventBroadcast;
 pub use models::{EventType, GovernanceEvent};
 pub use openapi::ApiDoc;
 pub use replay::ReplayBuffer;
-pub use server::{build_app, run_server};
-pub use state::AppState;
+pub use server::{build_app, run_server, serve_local};
+pub use state::{AppState, LocalStateError};
 pub use trace_store::{InMemoryTraceStore, TraceStore};

--- a/aa-api/src/server.rs
+++ b/aa-api/src/server.rs
@@ -33,6 +33,29 @@ pub fn build_app(state: AppState) -> Router {
     apply_middleware(app)
 }
 
+/// Serve the full `/api/v1/*` REST surface from an in-memory, single-process
+/// `AppState` (AAASM-3360).
+///
+/// This is the shipped entrypoint that makes the entire REST surface reachable
+/// without the operator hand-wiring ~30 subsystems: it builds an
+/// [`AppState::local_in_memory`], constructs an [`ApiConfig`] bound to `addr`
+/// with auth disabled, and delegates to [`run_server`]. The process blocks
+/// until a shutdown signal (SIGTERM/SIGINT) arrives.
+///
+/// All routes registered by [`routes::v1_router`] are served. Because auth is
+/// off, protected routes (e.g. `/api/v1/agents`, `/api/v1/policies`) respond
+/// without a bearer credential. See [`AppState::local_in_memory`] for the
+/// documented limitations of the in-memory wiring (audit pipeline + retention
+/// engine respond 503; alert rules never fire).
+pub async fn serve_local(addr: std::net::SocketAddr) -> Result<(), Box<dyn std::error::Error>> {
+    let state = AppState::local_in_memory()?;
+    let config = ApiConfig {
+        bind_addr: addr,
+        auth: (*state.auth_config).clone(),
+    };
+    run_server(config, state).await
+}
+
 /// Start the HTTP server and block until shutdown.
 ///
 /// After receiving a shutdown signal the server drains in-flight requests.

--- a/aa-api/src/state.rs
+++ b/aa-api/src/state.rs
@@ -25,7 +25,7 @@ use crate::alerts::rules::store::AlertRuleStore;
 use crate::alerts::silence_store::SilenceStore;
 use crate::alerts::AlertStore;
 use crate::auth::api_key::ApiKeyStore;
-use crate::auth::config::AuthConfig;
+use crate::auth::config::{AuthConfig, AuthMode};
 use crate::auth::jwt::{JwtSigner, JwtVerifier};
 use crate::auth::rate_limit::RateLimiter;
 use crate::destinations::store::DestinationStore;
@@ -132,4 +132,185 @@ pub struct AppState {
     /// secret-injection / forward-upstream path. (AAASM-2033 /
     /// F116 ST-W data-path follow-up.)
     pub tool_registry: ToolRegistry,
+}
+
+/// Error returned by [`AppState::local_in_memory`] when the in-memory wiring
+/// cannot be constructed — currently only when the bundled minimal policy
+/// fails to materialise on disk or the policy engine refuses to load it.
+#[derive(Debug, thiserror::Error)]
+pub enum LocalStateError {
+    /// Writing the bundled minimal policy to a temp file failed.
+    #[error("failed to write bootstrap policy at {path}: {source}", path = path.display())]
+    PolicyWrite {
+        /// The temp policy path we tried to write.
+        path: std::path::PathBuf,
+        /// Underlying I/O error.
+        #[source]
+        source: std::io::Error,
+    },
+    /// Loading the bundled minimal policy into a [`PolicyEngine`] failed.
+    #[error("failed to load bootstrap policy: {0}")]
+    PolicyLoad(String),
+}
+
+impl AppState {
+    /// Build a fully-wired `AppState` backed entirely by in-memory / default
+    /// implementations (AAASM-3360).
+    ///
+    /// This is the production seam that lets a single shipped entrypoint serve
+    /// the full `/api/v1/*` REST surface in local / single-process mode without
+    /// the operator wiring ~30 subsystems by hand. Every store is the same
+    /// in-memory implementation the gateway already uses for ephemeral state;
+    /// nothing here touches a remote database, NATS, or the network.
+    ///
+    /// Authentication is disabled ([`AuthMode::Off`]) so the protected
+    /// `/api/v1/*` routes are reachable without a bearer credential — this is a
+    /// local single-process developer surface, not a hardened deployment.
+    ///
+    /// Documented limitations of the in-memory wiring (callers / the PR body
+    /// should surface these):
+    /// * `audit_sender` is `None` — audit-emitting handlers (e.g. the SaaS
+    ///   webhook) respond 503; audit *reads* return an empty list.
+    /// * `retention_engine` is `None` — `/api/v1/admin/retention-policy`
+    ///   handlers respond 503 (no `storage` section in this mode).
+    /// * The alert-rule evaluator runs against a `NullMetricSource`, so rules
+    ///   never fire (same as the existing `run_server` wiring).
+    ///
+    /// The bootstrap policy is an empty section-based envelope (allow-by-default
+    /// with a daily budget limit) written to a per-process temp file because
+    /// [`PolicyEngine::load_from_file`] is the only public loader.
+    pub fn local_in_memory() -> Result<Self, LocalStateError> {
+        use std::sync::atomic::AtomicUsize;
+
+        // Unique temp paths per call so concurrent processes / tests do not
+        // collide on the bootstrap policy / history / audit directories.
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let uniq = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let pid = std::process::id();
+
+        let policy_dir = std::env::temp_dir().join(format!("aa-api-local-policy-{pid}-{uniq}"));
+        std::fs::create_dir_all(&policy_dir).map_err(|source| LocalStateError::PolicyWrite {
+            path: policy_dir.clone(),
+            source,
+        })?;
+        let policy_path = policy_dir.join("local-policy.yaml");
+        std::fs::write(
+            &policy_path,
+            // Minimal valid section-based envelope. AAASM-3351 made the
+            // validator fail closed on the legacy rule-list schema, so this
+            // must use the `spec:` section form.
+            "apiVersion: agent-assembly/v1\n\
+             kind: Policy\n\
+             metadata:\n  \
+             name: local-policy\n  \
+             version: \"0.1.0\"\n\
+             spec:\n  \
+             budget:\n    \
+             daily_limit_usd: 100.0\n",
+        )
+        .map_err(|source| LocalStateError::PolicyWrite {
+            path: policy_path.clone(),
+            source,
+        })?;
+
+        let events = Arc::new(EventBroadcast::default());
+        let budget_alert_tx = events.budget_sender();
+        let policy_engine = Arc::new(
+            aa_gateway::engine::PolicyEngine::load_from_file(&policy_path, budget_alert_tx)
+                .map_err(|e| LocalStateError::PolicyLoad(format!("{e:?}")))?
+                .with_invalidation_hub(aa_gateway::invalidation::InvalidationHub::new()),
+        );
+
+        let budget_tracker = Arc::new(BudgetTracker::new(
+            aa_gateway::budget::pricing::PricingTable::default_table(),
+            None,
+            None,
+            chrono_tz::UTC,
+        ));
+
+        let history_dir = std::env::temp_dir().join(format!("aa-api-local-history-{pid}-{uniq}"));
+        let policy_history = Arc::new(aa_gateway::policy::history::FsHistoryStore::new(
+            aa_gateway::policy::history::HistoryConfig {
+                history_dir,
+                max_versions: 50,
+            },
+        ));
+
+        let auth_config = Arc::new(AuthConfig {
+            mode: AuthMode::Off,
+            jwt_secret: None,
+            api_keys_path: std::path::PathBuf::from("/dev/null"),
+            rate_limit_rpm: 1000,
+        });
+        // AuthMode::Off bypasses the gate, so any JWT secret works for the
+        // signer/verifier (the token-issue route still needs them to exist).
+        const LOCAL_JWT_SECRET: &[u8] = b"aa-local-mode-jwt-secret-not-for-production-use!!";
+        let jwt_signer = Arc::new(JwtSigner::new(LOCAL_JWT_SECRET));
+        let jwt_verifier = Arc::new(JwtVerifier::new(LOCAL_JWT_SECRET));
+        // `load` on a non-existent path returns an empty store (infallible).
+        let key_store = Arc::new(
+            ApiKeyStore::load(std::path::Path::new("/nonexistent-aa-local-keys"))
+                .expect("loading a non-existent key file yields an empty store"),
+        );
+        let rate_limiter = Arc::new(RateLimiter::new(1000));
+
+        let audit_dir = std::env::temp_dir().join(format!("aa-api-local-audit-{pid}-{uniq}"));
+        std::fs::create_dir_all(&audit_dir).map_err(|source| LocalStateError::PolicyWrite {
+            path: audit_dir.clone(),
+            source,
+        })?;
+        let audit_reader = Arc::new(AuditReader::new(audit_dir));
+
+        Ok(AppState {
+            agent_registry: Arc::new(AgentRegistry::new()),
+            policy_engine,
+            budget_tracker,
+            approval_queue: ApprovalQueue::new(),
+            policy_history,
+            alert_store: Arc::new(crate::alerts::store::InMemoryAlertStore::new()),
+            silence_store: Arc::new(crate::alerts::silence_store::InMemorySilenceStore::new()),
+            events,
+            replay_buffer: ReplayBuffer::new(),
+            next_event_id: Arc::new(AtomicU64::new(0)),
+            auth_config,
+            key_store,
+            rate_limiter,
+            jwt_signer,
+            jwt_verifier,
+            trace_store: Arc::new(crate::trace_store::InMemoryTraceStore::new()),
+            audit_reader,
+            startup_time: Instant::now(),
+            active_connections: Arc::new(AtomicI64::new(0)),
+            discovery: Arc::new(DiscoveryService::with_adapters(vec![])),
+            edge_repo: Arc::new(aa_gateway::edges::InMemoryEdgeRepo::new()),
+            topology_overview_cache: moka::future::Cache::builder()
+                .time_to_live(std::time::Duration::from_secs(1))
+                .build(),
+            topology_tree_cache: moka::future::Cache::builder()
+                .time_to_live(std::time::Duration::from_secs(5))
+                .build(),
+            topology_team_cache: moka::future::Cache::builder()
+                .time_to_live(std::time::Duration::from_secs(5))
+                .build(),
+            topology_lineage_cache: moka::future::Cache::builder()
+                .time_to_live(std::time::Duration::from_secs(5))
+                .build(),
+            topology_stats_cache: moka::future::Cache::builder()
+                .time_to_live(std::time::Duration::from_secs(10))
+                .build(),
+            capability_store: crate::routes::capability::CapabilityStore::new_seeded(),
+            iam_api_key_store: crate::routes::iam::seeded_iam_store(),
+            ops_registry: Arc::new(OpsRegistry::new()),
+            destination_store: Arc::new(crate::destinations::store::InMemoryDestinationStore::new(Arc::new(
+                crate::destinations::store::NoopRuleReferenceChecker,
+            ))),
+            audit_sender: None,
+            saas_secret_cache: Arc::new(crate::routes::devtools::secret_cache::SecretCache::new()),
+            alert_rule_store: Arc::new(crate::alerts::rules::store::InMemoryAlertRuleStore::new()),
+            destination_registry: Arc::new(DestinationRegistry::seeded()),
+            retention_engine: None,
+            secrets_store: Arc::new(aa_gateway::secrets::InMemorySecretsStore::new()),
+            tool_registry: ToolRegistry::new(),
+        })
+    }
 }

--- a/aa-api/tests/serve_local_smoke.rs
+++ b/aa-api/tests/serve_local_smoke.rs
@@ -1,0 +1,70 @@
+//! Smoke test for the AAASM-3360 in-memory serving entrypoint.
+//!
+//! Verifies that an app built from `AppState::local_in_memory()` serves the
+//! full `/api/v1/*` REST surface — both the public liveness probe and the
+//! protected data routes (reachable because local mode disables auth) — with
+//! real JSON bodies instead of 404s.
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+/// Build the production local-mode app the shipped `aa-api-server` binary
+/// serves: an in-memory `AppState` wired through `build_app`.
+fn local_app() -> axum::Router {
+    let state = aa_api::AppState::local_in_memory().expect("local_in_memory must construct");
+    aa_api::build_app(state)
+}
+
+async fn get_json(app: axum::Router, uri: &str) -> (StatusCode, serde_json::Value) {
+    let response = app
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).expect("build request"))
+        .await
+        .expect("router.oneshot");
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), 64 * 1024).await.expect("read body");
+    let body: serde_json::Value = serde_json::from_slice(&bytes).expect("parse json");
+    (status, body)
+}
+
+#[tokio::test]
+async fn local_in_memory_serves_health() {
+    let (status, body) = get_json(local_app(), "/api/v1/health").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["status"], "ok");
+    assert_eq!(body["api_version"], "v1");
+}
+
+#[tokio::test]
+async fn local_in_memory_serves_agents_list() {
+    // Protected route — reachable because local mode disables auth.
+    let (status, body) = get_json(local_app(), "/api/v1/agents").await;
+    assert_eq!(status, StatusCode::OK, "agents list must be reachable (auth off)");
+    assert!(body.get("items").is_some(), "agents list must return a paginated body");
+}
+
+#[tokio::test]
+async fn local_in_memory_serves_policies_list() {
+    let (status, body) = get_json(local_app(), "/api/v1/policies").await;
+    assert_eq!(status, StatusCode::OK, "policies list must be reachable (auth off)");
+    assert!(
+        body.get("items").is_some(),
+        "policies list must return a paginated body"
+    );
+}
+
+#[tokio::test]
+async fn local_in_memory_serves_active_policy() {
+    let (status, body) = get_json(local_app(), "/api/v1/policies/active").await;
+    assert_eq!(status, StatusCode::OK);
+    // The bootstrap policy carries the documented local-policy name.
+    assert_eq!(body["name"], "local-policy");
+}
+
+#[tokio::test]
+async fn local_in_memory_unknown_route_is_json_404_not_html() {
+    let (status, body) = get_json(local_app(), "/api/v1/does-not-exist").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    // ProblemDetail JSON, not an SPA/HTML fallback.
+    assert_eq!(body["status"], 404);
+}


### PR DESCRIPTION
## Description

`AAASM-3354` / #1118 only added `/api/v1/health` to local mode. The full `/api/v1/*` REST surface (~60 routes in `aa-api`) was still unserved by any shipped binary, because (a) `aa-api` already depends on `aa-gateway` (so `aa-gateway` cannot mount the `aa-api` router — circular) and (b) `aa_api::build_app` needs a heavyweight `AppState` (~30 wired subsystems) with no constructor.

This PR puts the serving entrypoint on the `aa-api` side (which *can* depend on `aa-gateway`):

1. **`AppState::local_in_memory()`** — a production factory that wires every subsystem with the same in-memory/default implementations the gateway already uses for ephemeral state. Mirrors the existing `aa-api` test-state builder. Auth is `AuthMode::Off` so protected routes are reachable in this single-process local surface.
2. **`aa_api::serve_local(addr)`** — builds the in-memory app and serves the complete `routes::v1_router()` via `run_server`.
3. **`aa-api-server` binary** — a runnable entrypoint (`AA_API_ADDR`, default `127.0.0.1:7700`) that serves the full surface.
4. **Smoke test** — asserts the live routes return real JSON and unknown routes return a JSON `ProblemDetail` 404.

No `proto/` changes.

## Type of Change

- [x] ✨ New feature

## Breaking Changes

- [x] No

The factory/serve fn/binary are purely additive; existing `build_app`/`run_server`/`AppState` are unchanged.

## Related Issues

- Related Jira ticket: AAASM-3360

Closes AAASM-3360

## Testing

- [x] Integration tests added (`aa-api/tests/serve_local_smoke.rs`, 5 tests)
- [x] Manual testing performed

**Manual curl** against `cargo run -p aa-api --bin aa-api-server` (port 7799) — all real JSON, no 404/HTML:

| Route | HTTP | Body |
|---|---|---|
| `GET /api/v1/health` | 200 | `{"status":"ok","api_version":"v1",...}` |
| `GET /api/v1/agents` | 200 | `{"items":[],"page":1,"per_page":50,"total":0}` |
| `GET /api/v1/policies` | 200 | `{"items":[],...}` |
| `GET /api/v1/policies/active` | 200 | `{"name":"local-policy","version":"0.1.0","active":true,...}` |
| `GET /api/v1/costs` | 200 | `{"daily_spend_usd":"0",...}` |
| `GET /api/v1/nonexistent` | 404 | `{"type":"about:blank","title":"Not Found","status":404,...}` (JSON ProblemDetail, not HTML) |

`cargo build -p aa-api -p aa-gateway` clean; `cargo nextest run -p aa-api` = 572 passed, 0 skipped; `cargo fmt`/`cargo clippy -p aa-api --all-targets` clean.

### Live routes
**All** routes registered by `routes::v1_router()` are now served and reachable (auth off): `agents*`, `policies*`, `approvals*`, `costs`, `alerts*`, `alert rules`, `capability*`, `iam*`, `logs`, `traces`, `topology*`, `edges`, `tools`, `dispatch_tool`, `auth/token`, `ws/events`, `ws/alerts`, `health`. Smoke-verified subset live: `health`, `agents`, `policies`, `policies/active`, plus the 404 contract.

### Documented stubbed / limited subsystems (in-memory wiring)
These are inherent to single-process in-memory mode and are documented on `AppState::local_in_memory`:

- **`audit_sender: None`** — audit-*emitting* handlers (e.g. the SaaS webhook `POST /devtools/saas/{provider}/events`) respond `503`. Audit *reads* (`/logs`) return an empty list. Follow-up: wire an in-process audit channel.
- **`retention_engine: None`** — `/api/v1/admin/retention-policy` handlers respond `503` (no `storage` section in this mode).
- **Alert-rule evaluator** runs against `NullMetricSource` (same as the existing `run_server` wiring) — rules never fire.
- **Auth is disabled** — this is a local single-process developer surface, not a hardened deployment.

### Remaining follow-up
- Optionally wire local mode (`aasm`/`aa-gateway --mode local`) to spawn this entrypoint so a single command serves both the SPA and the full REST surface. Today the operator runs `aa-api-server` directly (or `cargo run -p aa-api --bin aa-api-server`); the existing local-mode `/api/v1/health` from AAASM-3354 is unchanged.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing (pending CI)
- [x] Commits are small and follow the Gitmoji convention
