### PR TITLE
[AAASM-3372] 📝 (docs): Update version references to v0.0.1-beta.2

### DIFF
--- a/agent-assembly.toml.example
+++ b/agent-assembly.toml.example
@@ -21,6 +21,15 @@ lifecycle_store    = "postgres"
 
 # Per-driver connection settings live under `[storage.<driver-name>]`. Provide a
 # subsection for every driver named above; each driver parses the keys it needs.
+#
+# NOTE: a subsection is required for EVERY named driver — including `memory`,
+# even though the in-memory driver takes no connection keys. An all-memory
+# config (every kind set to "memory") must still declare an (otherwise empty)
+# `[storage.memory]` table, or boot fails with a missing-subsection error.
+# For an all-memory setup, set the six kinds above to "memory" and add:
+#
+#     [storage.memory]
+#
 [storage.redis]
 url = "redis://localhost:6379"
 

--- a/docs/src/compatibility.md
+++ b/docs/src/compatibility.md
@@ -74,6 +74,8 @@ This document tracks which versions of `aa-runtime` are compatible with each SDK
 | v0.0.1-alpha.2 | v0.0.1-alpha.2 (PyPI `0.0.1a2`) ✓ | v0.0.1-alpha.2 ✓ | v0.0.1-alpha.2 ✓ | protocol/v1 |
 | v0.0.1-alpha.3 | v0.0.1-alpha.3 (PyPI `0.0.1a3`) ✓ | v0.0.1-alpha.3 ✓ | v0.0.1-alpha.3 ✓ | protocol/v1 |
 | v0.0.1 | v0.0.1 ✓ | v0.0.1 ✓ | v0.0.1 ✓ | protocol/v1 |
+| v0.0.1-beta.1 | v0.0.1-beta.1 (PyPI `0.0.1b1`) ✓ | v0.0.1-beta.1 ✓ | v0.0.1-beta.1 ✓ | protocol/v1 |
+| v0.0.1-beta.2 | v0.0.1-beta.2 (PyPI `0.0.1b2`) ✓ | v0.0.1-beta.2 ✓ | v0.0.1-beta.2 ✓ | protocol/v1 |
 
 **Legend:**
 - ✓ Compatible — fully supported
@@ -89,6 +91,9 @@ This document tracks which versions of `aa-runtime` are compatible with each SDK
 | Python SDK (`aa-ffi-python`) v0.0.1 | aa-runtime v0.0.1 |
 | Node.js SDK (`aa-ffi-node`) v0.0.1 | aa-runtime v0.0.1 |
 | Go SDK (`aa-ffi-go`) v0.0.1 | aa-runtime v0.0.1 |
+| Python SDK (`aa-ffi-python`) v0.0.1-beta.2 | aa-runtime v0.0.1-beta.1 |
+| Node.js SDK (`aa-ffi-node`) v0.0.1-beta.2 | aa-runtime v0.0.1-beta.1 |
+| Go SDK (`aa-ffi-go`) v0.0.1-beta.2 | aa-runtime v0.0.1-beta.1 |
 
 ---
 
@@ -102,6 +107,8 @@ A runtime version may support multiple protocol versions to allow SDK upgrades w
 | v0.0.1-alpha.2 | protocol/v1 |
 | v0.0.1-alpha.3 | protocol/v1 |
 | v0.0.1 | protocol/v1 |
+| v0.0.1-beta.1 | protocol/v1 |
+| v0.0.1-beta.2 | protocol/v1 |
 
 ---
 

--- a/docs/src/quick-start/installation.md
+++ b/docs/src/quick-start/installation.md
@@ -46,7 +46,7 @@ The installer honors these environment variables:
 
 ```sh
 # Install a specific release tag (default: latest)
-AASM_VERSION=v0.0.1-alpha.5 curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
+AASM_VERSION=v0.0.1-beta.2 curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
 
 # Install to a custom directory
 AASM_INSTALL_DIR=/usr/local/bin curl -sSf https://raw.githubusercontent.com/ai-agent-assembly/agent-assembly/master/scripts/install-cli.sh | sh
@@ -96,7 +96,7 @@ publishes per-platform tarballs plus a `SHA256SUMS` file and a
 To install and verify by hand:
 
 ```sh
-VERSION=v0.0.1-alpha.5
+VERSION=v0.0.1-beta.2
 ASSET=aasm-aarch64-apple-darwin.tar.gz   # adjust for your platform
 BASE="https://github.com/ai-agent-assembly/agent-assembly/releases/download/${VERSION}"
 
@@ -147,7 +147,7 @@ Confirm the binary is on your `PATH` and runs:
 
 ```console
 $ aasm --version
-aasm 0.0.1-alpha.5
+aasm 0.0.1-beta.2
 ```
 
 A fuller report — the CLI version plus whether a gateway and API are reachable —
@@ -159,7 +159,7 @@ $ aasm version
 +-----------+---------------+-------------+
 | COMPONENT | VERSION       | STATUS      |
 +=========================================+
-| cli       | 0.0.1-alpha.5 | -           |
+| cli       | 0.0.1-beta.2  | -           |
 |-----------+---------------+-------------|
 | gateway   | -             | unreachable |
 |-----------+---------------+-------------|


### PR DESCRIPTION
## Description

Documentation/config-only fix bringing stale version references in the monorepo docs up to the current product line, `v0.0.1-beta.2` (the canonical master `Cargo.toml` version).

Three independent corrections (one commit each):

- **`docs/src/compatibility.md`** — the Compatibility Matrix, Minimum Supported Runtime, and Supported Protocol tables only listed `alpha.1`–`alpha.3` + `v0.0.1` and omitted the entire beta channel, while the changelog table in the **same file** already reached `beta.2`. Added `beta.1` and `beta.2` rows to all three tables so the page is internally consistent.
- **`docs/src/quick-start/installation.md`** — replaced stale `v0.0.1-alpha.5` version examples (the `AASM_VERSION` install-script pin, the manual-binary `VERSION`, and the `aasm --version` / `aasm version` sample output) with `v0.0.1-beta.2`.
- **`agent-assembly.toml.example`** — documented that an all-memory storage config still requires an (otherwise empty) `[storage.memory]` subsection. Verified against `aa-storage`: `Registry::check` returns `ConfigError::MissingDriverSection` for any named driver — including `memory` — that has no `[storage.<name>]` table, so boot fails without it.

## Type of Change

- [x] 📝 Documentation update
- [x] 🔧 Configuration / CI change

## Breaking Changes

- [x] No

## Related Issues

- Related Jira ticket: AAASM-3372

This ticket spans two repos. This PR is the monorepo half. The hub mdBook (`agent-assembly-docs`) compatibility-table update is a separate PR.

## Testing

- [x] No tests required (explain why)

Docs/config-only change. The compatibility-table edits are content updates the `compat-matrix-check` gate expects; no version-carrying manifest files changed. The `[storage.memory]` claim was verified by reading `aa-storage/src/registry.rs` (`check`) and `aa-storage/src/error.rs` (`MissingDriverSection`).

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3372
