### PR TITLE
[AAASM-3374] 🐛 (aa-cli): Probe configured api-url for version/status health

### DIFF
--- a/aa-cli/src/commands/status/fetch.rs
+++ b/aa-cli/src/commands/status/fetch.rs
@@ -23,7 +23,19 @@ use super::models::{
 /// exception of `database_url`, which is run through [`redact_database_url`]
 /// before being assigned to `database_url_redacted`. The raw wire value never
 /// reaches the display layer.
-pub fn build_deployment_overview(gateway_url: &str, healthz: Option<HealthzResponse>) -> DeploymentOverview {
+///
+/// When `healthz` is `None` but `api_health` is `Some`, the configured
+/// `--api-url` is a REST API that does not mount the gateway-only `/healthz`
+/// probe (`GET /api/v1/health` succeeded). The overview is still marked
+/// `health = "ok"` — populated from the REST health body — rather than
+/// contradictorily reporting `unreachable` next to a healthy runtime API.
+/// `mode` / `storage_backend` are `"unknown"` because the REST health body
+/// does not carry them.
+pub fn build_deployment_overview(
+    gateway_url: &str,
+    healthz: Option<HealthzResponse>,
+    api_health: Option<&HealthResponse>,
+) -> DeploymentOverview {
     match healthz {
         Some(h) => DeploymentOverview {
             mode: h.mode,
@@ -35,15 +47,27 @@ pub fn build_deployment_overview(gateway_url: &str, healthz: Option<HealthzRespo
             uptime_secs: h.uptime_secs,
             health: "ok".to_string(),
         },
-        None => DeploymentOverview {
-            mode: "unknown".to_string(),
-            gateway_url: gateway_url.to_string(),
-            storage_backend: "unknown".to_string(),
-            storage_path: None,
-            database_url_redacted: None,
-            version: String::new(),
-            uptime_secs: 0,
-            health: "unreachable".to_string(),
+        None => match api_health {
+            Some(h) => DeploymentOverview {
+                mode: "unknown".to_string(),
+                gateway_url: gateway_url.to_string(),
+                storage_backend: "unknown".to_string(),
+                storage_path: None,
+                database_url_redacted: None,
+                version: h.version.clone(),
+                uptime_secs: h.uptime_secs,
+                health: "ok".to_string(),
+            },
+            None => DeploymentOverview {
+                mode: "unknown".to_string(),
+                gateway_url: gateway_url.to_string(),
+                storage_backend: "unknown".to_string(),
+                storage_path: None,
+                database_url_redacted: None,
+                version: String::new(),
+                uptime_secs: 0,
+                health: "unreachable".to_string(),
+            },
         },
     }
 }
@@ -120,7 +144,8 @@ pub async fn fetch_all(client: &StatusClient) -> StatusSnapshot {
         client.get_costs(),
     );
 
-    let runtime = build_runtime_health(health_result.ok());
+    let api_health = health_result.ok();
+    let runtime = build_runtime_health(api_health.clone());
     let agents = build_agent_rows(agents_result.unwrap_or_default());
     let approvals = build_approvals_summary(&approvals_result.unwrap_or_default());
     let budget = match costs_result {
@@ -135,7 +160,7 @@ pub async fn fetch_all(client: &StatusClient) -> StatusSnapshot {
         },
     };
 
-    let deployment = build_deployment_overview(client.base_url(), healthz_result.ok());
+    let deployment = build_deployment_overview(client.base_url(), healthz_result.ok(), api_health.as_ref());
 
     // AAASM-1591: surface the admin/status storage block when the
     // gateway exposes it. A 404 / decode error from an older gateway
@@ -231,8 +256,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn build_deployment_overview_marks_health_unreachable_when_healthz_absent() {
-        let overview = build_deployment_overview("http://localhost:7391", None);
+    fn build_deployment_overview_marks_health_unreachable_when_both_probes_absent() {
+        let overview = build_deployment_overview("http://localhost:7391", None, None);
         assert_eq!(overview.gateway_url, "http://localhost:7391");
         assert_eq!(overview.health, "unreachable");
         assert_eq!(overview.mode, "unknown");
@@ -241,6 +266,27 @@ mod tests {
         assert!(overview.database_url_redacted.is_none());
         assert_eq!(overview.uptime_secs, 0);
         assert!(overview.version.is_empty());
+    }
+
+    #[test]
+    fn build_deployment_overview_is_ok_from_api_health_when_healthz_absent() {
+        // AAASM-3374: a reachable REST `--api-url` (no gateway `/healthz`)
+        // must report `health = "ok"`, not contradict the runtime API row.
+        let api_health = HealthResponse {
+            status: "ok".to_string(),
+            version: "0.0.1".to_string(),
+            uptime_secs: 42,
+            active_connections: 1,
+            pipeline_lag_ms: 0,
+        };
+        let overview = build_deployment_overview("http://127.0.0.1:8080", None, Some(&api_health));
+        assert_eq!(overview.health, "ok");
+        assert_eq!(overview.gateway_url, "http://127.0.0.1:8080");
+        assert_eq!(overview.version, "0.0.1");
+        assert_eq!(overview.uptime_secs, 42);
+        // Fields not carried by the REST health body stay unknown.
+        assert_eq!(overview.mode, "unknown");
+        assert_eq!(overview.storage_backend, "unknown");
     }
 
     #[test]
@@ -253,7 +299,7 @@ mod tests {
             storage_path: None,
             database_url: Some("postgresql://aasm:secret@aasm-db:5432/aasm".to_string()),
         };
-        let overview = build_deployment_overview("https://cp.company.internal:7391", Some(healthz));
+        let overview = build_deployment_overview("https://cp.company.internal:7391", Some(healthz), None);
         assert_eq!(overview.mode, "remote");
         assert_eq!(overview.storage_backend, "postgres");
         assert!(overview.storage_path.is_none());
@@ -274,7 +320,7 @@ mod tests {
             storage_path: Some("~/.aasm/local.db".to_string()),
             database_url: None,
         };
-        let overview = build_deployment_overview("http://localhost:7391", Some(healthz));
+        let overview = build_deployment_overview("http://localhost:7391", Some(healthz), None);
         assert_eq!(overview.mode, "local");
         assert_eq!(overview.gateway_url, "http://localhost:7391");
         assert_eq!(overview.storage_backend, "sqlite");
@@ -289,6 +335,7 @@ mod tests {
     fn build_runtime_health_reachable() {
         let resp = Some(HealthResponse {
             status: "ok".to_string(),
+            version: "0.0.1".to_string(),
             uptime_secs: 120,
             active_connections: 3,
             pipeline_lag_ms: 5,

--- a/aa-cli/src/commands/status/models.rs
+++ b/aa-cli/src/commands/status/models.rs
@@ -9,6 +9,11 @@ use serde::{Deserialize, Serialize};
 pub struct HealthResponse {
     /// Liveness status string, always `"ok"` when the service is running.
     pub status: String,
+    /// Service version (semver from Cargo.toml). Backs the deployment-overview
+    /// `Version` line when the configured `--api-url` is a REST API that does
+    /// not expose the gateway-only `/healthz` probe.
+    #[serde(default)]
+    pub version: String,
     /// Server uptime in seconds since startup.
     #[serde(default)]
     pub uptime_secs: u64,

--- a/aa-cli/src/commands/version.rs
+++ b/aa-cli/src/commands/version.rs
@@ -8,11 +8,13 @@ use serde::{Deserialize, Serialize};
 use crate::config::ResolvedContext;
 use crate::output::OutputFormat;
 
-/// Subset of the gateway `/healthz` response used for version extraction.
+/// Subset of the configured REST API `/api/v1/health` response used for
+/// version extraction.
 ///
-/// The gateway liveness endpoint reports `version` but does not carry a
-/// separate `api_version` field, so it is optional here and falls back to
-/// the served REST API major version.
+/// The REST API health endpoint reports both `version` and `api_version`.
+/// `api_version` stays optional so the same struct also parses a gateway
+/// `/healthz` body (which omits it), falling back to the served REST API
+/// major version.
 #[derive(Debug, Deserialize)]
 struct HealthInfo {
     version: String,
@@ -39,7 +41,11 @@ fn build_rows(ctx: &ResolvedContext) -> Vec<VersionRow> {
     let rt = tokio::runtime::Runtime::new().expect("failed to create tokio runtime");
     let (gateway_row, api_row) = rt.block_on(async {
         let client = reqwest::Client::new();
-        let url = format!("{}/healthz", ctx.api_url);
+        // Probe the configured `--api-url`'s own health endpoint. The REST
+        // API serves `GET /api/v1/health` (carrying `version`/`api_version`);
+        // the gateway-daemon-only `/healthz` is NOT mounted by the REST API,
+        // so probing it reported a reachable api-url as "unreachable".
+        let url = format!("{}/api/v1/health", ctx.api_url);
 
         let mut req = client.get(&url);
         if let Some(ref key) = ctx.api_key {
@@ -187,9 +193,19 @@ mod tests {
     }
 
     #[test]
+    fn health_info_parses_api_health_body_with_api_version() {
+        // The configured REST API `/api/v1/health` body carries both
+        // `version` and `api_version`; deserialization must capture both.
+        let body = r#"{"status":"ok","version":"0.0.1","api_version":"v1","uptime_secs":3,"active_connections":0,"pipeline_lag_ms":0,"checks":{}}"#;
+        let info: HealthInfo = serde_json::from_str(body).expect("api health body must parse");
+        assert_eq!(info.version, "0.0.1");
+        assert_eq!(info.api_version.as_deref(), Some("v1"));
+    }
+
+    #[test]
     fn health_info_parses_healthz_body_without_api_version() {
-        // The gateway `/healthz` body carries `version` but no
-        // `api_version`; deserialization must succeed and leave it absent.
+        // A gateway `/healthz` body still parses (api_version absent) so a
+        // gateway-targeted `--api-url` continues to work via fallback.
         let body = r#"{"mode":"local","version":"0.0.1","storage":"memory","uptime_secs":3}"#;
         let info: HealthInfo = serde_json::from_str(body).expect("healthz body must parse");
         assert_eq!(info.version, "0.0.1");


### PR DESCRIPTION
## Description

`aasm version` and `aasm status` reported contradictory health when `--api-url` points at a reachable HTTP REST API server. `version` showed the gateway/api rows as `unreachable`; `status` printed `Health: ✗ unreachable` and `Error: gateway is not running` (the exit-1 path) right next to a healthy `RUNTIME HEALTH > API: ✓ ok`.

Root cause: the deployment/health probe in both commands targeted the gateway-daemon-only `/healthz` endpoint, which the standalone REST API server (`aa-api`) does not mount — it serves `GET /api/v1/health`. So a reachable `--api-url` was probed at a 404 path and judged unreachable, while the data commands (which use `/api/v1/*`) worked fine.

Fix (minimal — only changes *which* endpoint is probed for the health verdict):
- `version`: probe the configured `{api_url}/api/v1/health` (carries both `version` and `api_version`); the same struct still parses a gateway `/healthz` body so gateway-targeted api-urls keep working via fallback.
- `status`: keep using `/healthz` for the rich deployment fields when present, but when `/healthz` is absent and the REST `/api/v1/health` probe succeeds, mark the overview `health = "ok"` and populate `version`/`uptime` from it — instead of contradicting the runtime-API row.

The graceful-degrade contract is intact: when both probes are unreachable, the overview is still `unreachable`, rows are still marked `unreachable`, and `version` still exits 0.

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

## Related Issues

- Related Jira ticket: AAASM-3374
- Closes AAASM-3374

## Testing

Describe the testing performed for this PR:

- [x] Unit tests added / updated
- [ ] Integration tests added / updated
- [x] Manual testing performed
- [ ] No tests required (explain why)

Verification:
- `cargo build -p aa-cli` — clean.
- `cargo nextest run -p aa-cli` — 594 passed, 0 failed (incl. existing `cli_version` tests).
- `cargo fmt -p aa-cli` + `cargo clippy -p aa-cli --all-targets` — clean.
- New regression tests: `health_info_parses_api_health_body_with_api_version` (version), `build_deployment_overview_is_ok_from_api_health_when_healthz_absent` (status). The previously-`/healthz`-only deployment test was renamed and asserts the both-probes-absent → `unreachable` graceful path.

Relates to the QA evidence under `agent-assembly-integration-tests/verification-reports/base-branch-2026-06/`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [ ] Documentation updated if behaviour changed
- [x] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)
