### PR TITLE
[AAASM-3373] 🐛 (aa-api): Register tools + topology/edges routes in OpenAPI spec

### DIFF
--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -57,6 +57,7 @@ use crate::routes::{
         (name = "audit", description = "Audit log aggregations — violation heatmaps and lineage analytics"),
         (name = "admin", description = "Admin operations — retention policy hot-reload and on-demand run (AAASM-1592 S-K)"),
         (name = "dispatch", description = "Secret Injection — tool dispatch with placeholder resolution (AAASM-1920)"),
+        (name = "tools", description = "Auto-discovered AI dev tools on the gateway host"),
     ),
     paths(
         crate::routes::health::health,

--- a/aa-api/src/openapi.rs
+++ b/aa-api/src/openapi.rs
@@ -20,7 +20,7 @@ use crate::models::trace::{TraceResponse, TraceSpan};
 use crate::models::ws_payloads::{ApprovalPayload, BudgetAlertPayload, EventPayload, ViolationPayload};
 use crate::routes::{
     admin, agents, alert_rules, alerts, approvals, audit, auth, capability, costs, destinations, dispatch, edges, iam,
-    logs, ops, policies, topology, traces,
+    logs, ops, policies, tools, topology, traces,
 };
 
 /// Root OpenAPI document collecting all annotated paths and schemas.
@@ -102,8 +102,10 @@ use crate::routes::{
         topology::get_lineage,
         topology::get_stats,
         edges::report_edge,
+        edges::list_topology_edges,
         edges::list_agent_edges,
         edges::get_agent_graph,
+        tools::list_tools,
         ops::list_ops,
         ops::register_op,
         ops::pause_op,
@@ -192,6 +194,8 @@ use crate::routes::{
         edges::EdgeListResponse,
         edges::GraphNode,
         edges::GraphResponse,
+        edges::TopologyEdgeListResponse,
+        tools::ToolInfoSchema,
         ops::OpActionAck,
         ops::RegisterOpRequest,
         crate::ops::OpRecord,

--- a/aa-api/src/routes/tools.rs
+++ b/aa-api/src/routes/tools.rs
@@ -18,7 +18,7 @@ type ToolsList = Vec<ToolInfoSchema>;
 /// entry without requiring [`DevToolInfo`] itself to implement `ToSchema`.
 #[allow(dead_code)] // fields are only used by utoipa's macro for OpenAPI schema generation
 #[derive(ToSchema)]
-struct ToolInfoSchema {
+pub struct ToolInfoSchema {
     kind: String,
     version: Option<String>,
     install_path: String,

--- a/aa-integration-tests/tests/api_openapi_contract.rs
+++ b/aa-integration-tests/tests/api_openapi_contract.rs
@@ -45,7 +45,7 @@ fn load_spec() -> Value {
     serde_yaml::from_str(&yaml).expect("openapi/v1.yaml must be valid YAML")
 }
 
-// ── TC-1: spec file loads and has 51 paths ───────────────────────────────────
+// ── TC-1: spec file loads and has 53 paths ───────────────────────────────────
 
 #[test]
 fn openapi_spec_loads_without_errors() {
@@ -60,8 +60,8 @@ fn openapi_spec_loads_without_errors() {
     let path_count = spec["paths"].as_object().expect("spec must have a paths object").len();
 
     assert_eq!(
-        path_count, 52,
-        "openapi/v1.yaml must declare exactly 52 paths, found {path_count}"
+        path_count, 53,
+        "openapi/v1.yaml must declare exactly 53 paths, found {path_count}"
     );
 
     for schema in ["HealthResponse", "ProblemDetail", "PolicyResponse", "AlertResponse"] {
@@ -142,6 +142,7 @@ fn openapi_spec_paths_match_implemented_routes() {
         "/api/v1/topology/stats",
         "/api/v1/topology/team/{team_id}",
         "/api/v1/topology/tree/{root_id}",
+        "/api/v1/tools",
         "/api/v1/traces/{session_id}",
         "/api/v1/ws/events",
     ];

--- a/dashboard/src/api/generated/schema.d.ts
+++ b/dashboard/src/api/generated/schema.d.ts
@@ -1080,6 +1080,28 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/tools": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List all auto-discovered AI dev tools on the gateway host.
+         * @description Runs all registered [`DevToolAdapter`][aa_core::DevToolAdapter]
+         *     implementations concurrently and returns the subset that are installed.
+         *     If no tools are detected, an empty array is returned (not an error).
+         */
+        get: operations["list_tools"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/topology/edges": {
         parameters: {
             query?: never;
@@ -1087,7 +1109,13 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /**
+         * List all topology edges, optionally filtered by team.
+         * @description Iterates every known edge type and collects up to `limit` edges total
+         *     (default 500, max 1 000). When `team_id` is provided, only edges where
+         *     the source **or** target agent belongs to that team are returned.
+         */
+        get: operations["list_topology_edges"];
         put?: never;
         /**
          * Record a new directed topology edge.
@@ -3091,6 +3119,28 @@ export interface components {
             scopes: components["schemas"]["Scope"][];
             /** @description The issued JWT token string. */
             token: string;
+        };
+        /**
+         * @description Schema wrapper so utoipa can derive the OpenAPI schema for [`DevToolInfo`].
+         *
+         *     The real handler returns `Vec<DevToolInfo>` directly; this wrapper is only
+         *     referenced by utoipa's `#[utoipa::path]` macro so it can generate a schema
+         *     entry without requiring [`DevToolInfo`] itself to implement `ToSchema`.
+         */
+        ToolInfoSchema: {
+            governance_level: string;
+            install_path: string;
+            kind: string;
+            supports_managed_settings: boolean;
+            supports_mcp: boolean;
+            version?: string | null;
+        };
+        /** @description All edges in the topology graph, optionally filtered by team membership. */
+        TopologyEdgeListResponse: {
+            /** @description Total number of edges returned. */
+            count: number;
+            /** @description Matching edges, sorted newest-first within each edge type. */
+            edges: components["schemas"]["EdgeResponse"][];
         };
         /**
          * @description Overview of the entire agent topology across all teams.
@@ -5421,6 +5471,66 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content?: never;
+            };
+        };
+    };
+    list_tools: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Discovered tools */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ToolInfoSchema"][];
+                };
+            };
+        };
+    };
+    list_topology_edges: {
+        parameters: {
+            query?: {
+                /**
+                 * @description Return only edges where at least one endpoint belongs to this team.
+                 * @example team-alpha
+                 */
+                team_id?: string | null;
+                /**
+                 * @description Maximum number of edges to return. Defaults to 500, capped at 1000.
+                 * @example 500
+                 */
+                limit?: number | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Edge list */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TopologyEdgeListResponse"];
+                };
+            };
+            /** @description Store error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ProblemDetail"];
+                };
             };
         };
     };

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -1916,7 +1916,69 @@ paths:
                 $ref: '#/components/schemas/PolicyResponse'
         '404':
           description: No active policy loaded
+  /api/v1/tools:
+    get:
+      tags:
+      - tools
+      summary: List all auto-discovered AI dev tools on the gateway host.
+      description: |-
+        Runs all registered [`DevToolAdapter`][aa_core::DevToolAdapter]
+        implementations concurrently and returns the subset that are installed.
+        If no tools are detected, an empty array is returned (not an error).
+      operationId: list_tools
+      responses:
+        '200':
+          description: Discovered tools
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ToolInfoSchema'
   /api/v1/topology/edges:
+    get:
+      tags:
+      - topology
+      summary: List all topology edges, optionally filtered by team.
+      description: |-
+        Iterates every known edge type and collects up to `limit` edges total
+        (default 500, max 1 000). When `team_id` is provided, only edges where
+        the source **or** target agent belongs to that team are returned.
+      operationId: list_topology_edges
+      parameters:
+      - name: team_id
+        in: query
+        description: Return only edges where at least one endpoint belongs to this team.
+        required: false
+        schema:
+          type:
+          - string
+          - 'null'
+        example: team-alpha
+      - name: limit
+        in: query
+        description: Maximum number of edges to return. Defaults to 500, capped at 1000.
+        required: false
+        schema:
+          type:
+          - integer
+          - 'null'
+          format: int32
+          minimum: 0
+        example: 500
+      responses:
+        '200':
+          description: Edge list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TopologyEdgeListResponse'
+        '500':
+          description: Store error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetail'
     post:
       tags:
       - topology
@@ -5264,6 +5326,51 @@ components:
         token:
           type: string
           description: The issued JWT token string.
+    ToolInfoSchema:
+      type: object
+      description: |-
+        Schema wrapper so utoipa can derive the OpenAPI schema for [`DevToolInfo`].
+
+        The real handler returns `Vec<DevToolInfo>` directly; this wrapper is only
+        referenced by utoipa's `#[utoipa::path]` macro so it can generate a schema
+        entry without requiring [`DevToolInfo`] itself to implement `ToSchema`.
+      required:
+      - kind
+      - install_path
+      - governance_level
+      - supports_mcp
+      - supports_managed_settings
+      properties:
+        governance_level:
+          type: string
+        install_path:
+          type: string
+        kind:
+          type: string
+        supports_managed_settings:
+          type: boolean
+        supports_mcp:
+          type: boolean
+        version:
+          type:
+          - string
+          - 'null'
+    TopologyEdgeListResponse:
+      type: object
+      description: All edges in the topology graph, optionally filtered by team membership.
+      required:
+      - edges
+      - count
+      properties:
+        count:
+          type: integer
+          description: Total number of edges returned.
+          minimum: 0
+        edges:
+          type: array
+          items:
+            $ref: '#/components/schemas/EdgeResponse'
+          description: Matching edges, sorted newest-first within each edge type.
     TopologyOverview:
       type: object
       description: |-

--- a/openapi/v1.yaml
+++ b/openapi/v1.yaml
@@ -5885,3 +5885,5 @@ tags:
   description: Admin operations — retention policy hot-reload and on-demand run (AAASM-1592 S-K)
 - name: dispatch
   description: Secret Injection — tool dispatch with placeholder resolution (AAASM-1920)
+- name: tools
+  description: Auto-discovered AI dev tools on the gateway host


### PR DESCRIPTION
## Description

The committed OpenAPI spec (`openapi/v1.yaml`) drifted from the implemented REST routes:

- `GET /api/v1/tools` (`tools::list_tools`) is `#[utoipa::path]`-annotated and mounted (route returns 200), but the handler was never listed in `aa-api/src/openapi.rs` `paths(...)`, so it was absent from the generated spec.
- `GET /api/v1/topology/edges` (`edges::list_topology_edges`) is also mounted (the path serves both `POST` and `GET`), but only the `POST` operation was documented.

This PR registers both handlers in the `ApiDoc` `paths(...)`/`components(...)` set, regenerates the committed spec, and keeps the spec↔implementation contract gate in sync.

Changes:
1. `aa-api/src/openapi.rs`: register `tools::list_tools` and `edges::list_topology_edges`; add `tools::ToolInfoSchema` and `edges::TopologyEdgeListResponse` component schemas. `ToolInfoSchema` made `pub` so the macro path resolves.
2. `openapi/v1.yaml`: regenerated via the spec generator — adds the `GET /api/v1/tools` operation, the `GET` method on `/api/v1/topology/edges`, and the two new schemas. Diff is purely additive (no removals/reordering).
3. `aa-integration-tests/tests/api_openapi_contract.rs`: bump expected path count 52 → 53 and add `/api/v1/tools` to the hardcoded expected-paths list (the bidirectional parity gate).

## Type of Change

- [ ] ✨ New feature
- [x] 🐛 Bug fix
- [ ] ♻️ Refactoring
- [ ] 🍀 Performance improvement
- [ ] 📝 Documentation update
- [ ] 🔧 Configuration / CI change
- [ ] ⬆️ Dependency upgrade
- [ ] 🚀 Release

## Breaking Changes

- [x] No
- [ ] Yes (describe below)

The spec change is purely additive (documents already-live routes). No API behaviour changes.

## Related Issues

- Related Jira ticket: AAASM-3373

## Testing

Describe the testing performed for this PR:

- [ ] Unit tests added / updated
- [x] Integration tests added / updated
- [ ] Manual testing performed
- [ ] No tests required (explain why)

How to verify:
- `cargo build -p aa-api` — green.
- `cargo nextest run -p aa-api` — 572 passed, 0 failed.
- `cargo nextest run -p aa-integration-tests --test api_openapi_contract` — 6 passed (including `openapi_spec_loads_without_errors` and `openapi_spec_paths_match_implemented_routes`).
- Spec regenerated with `cargo run -p aa-api --bin generate_openapi > openapi/v1.yaml`; the `openapi-drift` CI gate (`diff openapi/v1.yaml <generated>`) now matches.

QA evidence: `agent-assembly-integration-tests/verification-reports/base-branch-2026-06/`.

## Checklist

- [x] Code follows project style guidelines (`cargo fmt`, `cargo clippy`)
- [x] Self-review of the diff completed
- [x] Documentation updated if behaviour changed
- [ ] All CI checks passing
- [x] Commits are small and follow the Gitmoji convention

Closes AAASM-3373
